### PR TITLE
fix(infra): clamp gbrain Supabase pool budget in Jovie wrappers (JOV-3123)

### DIFF
--- a/.claude/skills/setup-gbrain/SKILL.md
+++ b/.claude/skills/setup-gbrain/SKILL.md
@@ -960,6 +960,25 @@ Walk the user through the supabase.com steps:
 
 Then follow the same secret-read + verify + init flow as Path 1.
 
+### Supabase pool budget (Paths 1, 2a, 2b)
+
+After any Supabase `gbrain init`, clamp per-process pool multiplication so
+overlapping CLI processes (serve, autopilot, sync) do not exhaust the
+Supavisor session pool. Jovie-owned wrappers source
+`scripts/lib/gbrain-pool-env.sh`; for interactive shells add the same exports
+to `~/.zshrc` or your launchd/cron env:
+
+```bash
+export GBRAIN_DISABLE_DIRECT_POOL=1
+export GBRAIN_POOL_SIZE=2
+export GBRAIN_DIRECT_POOL_SIZE=1
+export GBRAIN_MAX_CONNECTIONS=15   # tune to your Supabase tier / pool_size
+```
+
+`GBRAIN_MAX_CONNECTIONS` turns on gbrain's opt-in budget clamp (v0.42+).
+Verify with `gbrain doctor --json | jq '.checks[] | select(.name=="pool_budget")'`.
+See `docs/GBRAIN_POOL_BUDGET.md` for tier guidance and troubleshooting.
+
 ### Path 3 (PGLite local)
 
 ```bash

--- a/docs/GBRAIN_POOL_BUDGET.md
+++ b/docs/GBRAIN_POOL_BUDGET.md
@@ -1,0 +1,86 @@
+# gbrain Supabase pool budget
+
+Jovie agents and Hermes cron wrappers call the external `gbrain` CLI. On
+Supabase-backed brains, each process opens its own Postgres pools (defaults:
+read pool 10 + direct pool 3). Overlapping processes — `gbrain serve`, autopilot
+ticks, `gbrain sync`, Codex hooks — multiply connections and can trigger
+`EMAXCONNSESSION` / "connections exhausted" on low-cap Supavisor tiers.
+
+PGLite engines (Hermes-Air default) do not use Postgres pooling; this doc does
+not apply there.
+
+## Env vars
+
+| Variable | Default (when clamp applies) | Purpose |
+|---|---:|---|
+| `GBRAIN_DISABLE_DIRECT_POOL` | `1` | Single-pool mode; avoids doubling connections per process |
+| `GBRAIN_POOL_SIZE` | `2` | Read/pooler pool size per process (gbrain default is 10) |
+| `GBRAIN_DIRECT_POOL_SIZE` | `1` | Direct `:5432` pool size when direct pool is enabled |
+| `GBRAIN_MAX_CONNECTIONS` | `15` | Opt-in per-process budget clamp for parallel sync workers (gbrain v0.42+) |
+| `GBRAIN_POOL_BUDGET_DISABLED` | unset | Set to `1` to skip Jovie's auto-clamp helper |
+
+Set `GBRAIN_MAX_CONNECTIONS` to your Supabase **session pooler** `pool_size`
+(not raw Postgres `max_connections`). Supavisor free tiers are often 15–20.
+
+## Where Jovie applies the clamp
+
+- `scripts/codex-gbrain-sync.sh` — sources `scripts/lib/gbrain-pool-env.sh` before
+  `gbrain doctor` / sync during Codex session hooks.
+- `scripts/lib/gbrain-pool-env.mjs` — shared detection (Supabase vs PGLite) and
+  defaults; unit-tested.
+
+Operator-owned surfaces (not rendered by this repo) still need the same exports:
+
+- `~/.zshrc` / shell profile for ad-hoc `gbrain` CLI
+- launchd plists / cron wrappers on the always-on MacBook Pro
+- `gbrain serve` / autopilot long-lived processes
+
+## Recommended operator setup (MacBook Pro, Supabase brain)
+
+Add to shell profile or a dedicated `~/.gbrain/env` sourced by cron:
+
+```bash
+export GBRAIN_DISABLE_DIRECT_POOL=1
+export GBRAIN_POOL_SIZE=2
+export GBRAIN_DIRECT_POOL_SIZE=1
+export GBRAIN_MAX_CONNECTIONS=15
+```
+
+Upgrade gbrain to v0.42+ (see JovieInc/Jovie#10458) so `pool_budget` doctor check
+and the `GBRAIN_MAX_CONNECTIONS` clamp are available.
+
+## Verification
+
+```bash
+gbrain doctor --json | jq '.checks[] | select(.name=="pool_budget")'
+```
+
+Expect `status: "ok"` with a message showing room for parallel sync workers.
+In Supabase SQL editor:
+
+```sql
+select state, wait_event_type, count(*)
+from pg_stat_activity
+where datname = current_database()
+group by 1, 2
+order by 3 desc;
+```
+
+Steady-state connections should stay well under tier cap; no long-lived
+`ClientRead` orphans after SIGKILL'd autopilot runs.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `EMAXCONNSESSION` / pool_size exceeded | Too many overlapping gbrain processes × default pool sizes | Lower `GBRAIN_POOL_SIZE`; ensure clamp env is set in **every** wrapper |
+| `pool_budget` warns "no room for parallel sync worker" | `GBRAIN_MAX_CONNECTIONS` too low for parent pool | Lower `GBRAIN_POOL_SIZE` or raise `GBRAIN_MAX_CONNECTIONS` |
+| Errors only on Codex sessions | Shell wrappers clamped but serve/autopilot are not | Add env to launchd/cron for long-lived processes |
+| PGLite brain on Air | N/A — pool env is intentionally skipped | No action |
+
+## Related
+
+- GitHub issue: [JovieInc/Jovie#10815](https://github.com/JovieInc/Jovie/issues/10815)
+- Linear: [JOV-3123](https://linear.app/jovie/issue/JOV-3123)
+- gbrain upstream env docs: `GBRAIN_POOL_SIZE` in garrytan/gbrain `src/core/db.ts`
+- Hermes-Air (PGLite): [`docs/HERMES_AIR.md`](./HERMES_AIR.md)

--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -257,6 +257,15 @@ Once you understand the cause, fix it (likely in `free-model-router.ts` rankings
 2. On Air: `lsof -i :<gbrain-port>` — confirm `gbrain serve --http --bind <tailscale-ip>` is listening.
 3. On Pro: update MCP config to point at `http://<air-tailscale-ip>:<port>`.
 
+### Supabase connection exhaustion (Pro-hosted company brain)
+
+Hermes-Air runs gbrain on **PGLite** — no Postgres pool budget needed on the Air.
+The shared Supabase company brain on the MacBook Pro is different: each gbrain
+process multiplies pools unless clamped. See [`docs/GBRAIN_POOL_BUDGET.md`](./GBRAIN_POOL_BUDGET.md)
+for `GBRAIN_POOL_SIZE`, `GBRAIN_MAX_CONNECTIONS`, and verification steps.
+Codex hooks already source `scripts/lib/gbrain-pool-env.sh`; long-lived Pro
+cron/launchd wrappers must export the same env.
+
 ### Air rebooted
 
 launchd handles this. All services come back automatically because `RunAtLoad: true` is set on every plist. Confirm with status checks above.

--- a/scripts/codex-gbrain-sync.sh
+++ b/scripts/codex-gbrain-sync.sh
@@ -10,6 +10,11 @@ set -u
 PHASE="${1:-manual}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Supabase-backed brains: clamp per-process pool multiplication before any gbrain CLI.
+# shellcheck source=lib/gbrain-pool-env.sh
+. "${SCRIPT_DIR}/lib/gbrain-pool-env.sh"
+apply_gbrain_pool_budget
 GBRAIN_DOCTOR_TIMEOUT_SECONDS="${CODEX_GBRAIN_DOCTOR_TIMEOUT_SECONDS:-10}"
 GBRAIN_SYNC_TIMEOUT_SECONDS="${CODEX_GBRAIN_SYNC_TIMEOUT_SECONDS:-60}"
 

--- a/scripts/hermes/launchd/README.md
+++ b/scripts/hermes/launchd/README.md
@@ -6,6 +6,8 @@ Each `.plist.template` uses `{{HOME}}`, `{{JOVIE_REPO}}`, `{{HERMES_BIN}}`, `{{G
 
 The Hermes gateway itself is managed by the installed Hermes CLI as `ai.hermes.gateway`; these templates manage the Air-specific watchdog, gbrain server, and cron jobs around it.
 
+**Supabase pool budget:** Hermes-Air's `gbrain serve` uses PGLite and does not need Postgres pool env vars. If you run a Supabase-backed gbrain on the MacBook Pro (serve/autopilot/cron), export the clamp documented in `docs/GBRAIN_POOL_BUDGET.md` in every long-lived wrapper — Codex hooks already source `scripts/lib/gbrain-pool-env.sh`.
+
 ## Units
 
 | File | Schedule | Purpose |

--- a/scripts/lib/__tests__/gbrain-pool-env.test.mjs
+++ b/scripts/lib/__tests__/gbrain-pool-env.test.mjs
@@ -1,0 +1,111 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  engineNeedsPoolBudget,
+  formatShellExports,
+  planPoolBudget,
+  resolvePoolBudgetEnv,
+  SUPABASE_POOL_BUDGET_DEFAULTS,
+  shellQuote,
+} from '../gbrain-pool-env.mjs';
+
+describe('engineNeedsPoolBudget', () => {
+  it('skips PGLite engines', () => {
+    expect(engineNeedsPoolBudget({ engine: 'pglite' })).toBe(false);
+  });
+
+  it('applies to postgres/supabase engines', () => {
+    expect(engineNeedsPoolBudget({ engine: 'postgres' })).toBe(true);
+    expect(engineNeedsPoolBudget({ engine: 'supabase' })).toBe(true);
+  });
+
+  it('detects Supabase hosts even when engine is unset', () => {
+    expect(
+      engineNeedsPoolBudget({
+        database_url: 'host=pooler.supabase.com:6543',
+      })
+    ).toBe(true);
+  });
+});
+
+describe('resolvePoolBudgetEnv', () => {
+  it('fills missing keys from defaults', () => {
+    expect(resolvePoolBudgetEnv({})).toEqual(SUPABASE_POOL_BUDGET_DEFAULTS);
+  });
+
+  it('preserves operator overrides', () => {
+    expect(
+      resolvePoolBudgetEnv({
+        GBRAIN_POOL_SIZE: '3',
+        GBRAIN_MAX_CONNECTIONS: '20',
+      })
+    ).toEqual({
+      ...SUPABASE_POOL_BUDGET_DEFAULTS,
+      GBRAIN_POOL_SIZE: '3',
+      GBRAIN_MAX_CONNECTIONS: '20',
+    });
+  });
+});
+
+describe('planPoolBudget', () => {
+  it('returns no-op for PGLite config files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-pool-'));
+    const configPath = join(dir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ engine: 'pglite' }));
+
+    expect(planPoolBudget(configPath, {})).toEqual({
+      apply: false,
+      env: {},
+      reason: 'engine-skip',
+    });
+  });
+
+  it('returns clamp env for Supabase configs', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-pool-'));
+    const configPath = join(dir, 'config.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        engine: 'postgres',
+        database_url: 'host=pooler.supabase.com:6543',
+      })
+    );
+
+    expect(planPoolBudget(configPath, {})).toEqual({
+      apply: true,
+      env: SUPABASE_POOL_BUDGET_DEFAULTS,
+      reason: 'supabase-pool-budget',
+    });
+  });
+
+  it('honors GBRAIN_POOL_BUDGET_DISABLED', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-pool-'));
+    const configPath = join(dir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ engine: 'postgres' }));
+
+    expect(
+      planPoolBudget(configPath, { GBRAIN_POOL_BUDGET_DISABLED: '1' })
+    ).toEqual({
+      apply: false,
+      env: {},
+      reason: 'disabled',
+    });
+  });
+});
+
+describe('formatShellExports', () => {
+  it('emits safe export statements', () => {
+    const output = formatShellExports({
+      GBRAIN_POOL_SIZE: '2',
+      GBRAIN_NOTE: 'has space',
+    });
+    expect(output).toContain('export GBRAIN_POOL_SIZE=2');
+    expect(output).toContain("export GBRAIN_NOTE='has space'");
+  });
+
+  it('quotes values with shell metacharacters', () => {
+    expect(shellQuote('a;b')).toBe(`'a;b'`);
+  });
+});

--- a/scripts/lib/gbrain-pool-env.mjs
+++ b/scripts/lib/gbrain-pool-env.mjs
@@ -1,0 +1,169 @@
+/**
+ * Shared gbrain Supabase pool-budget defaults for Jovie-owned wrappers.
+ *
+ * gbrain opens per-process read + direct pools (defaults 10 + 3). Multiple
+ * overlapping CLI processes (serve, autopilot, sync) multiply connections and
+ * can exhaust low-cap Supabase / Supavisor tiers. Upstream gbrain honors:
+ *   - GBRAIN_POOL_SIZE
+ *   - GBRAIN_DIRECT_POOL_SIZE
+ *   - GBRAIN_DISABLE_DIRECT_POOL
+ *   - GBRAIN_MAX_CONNECTIONS (opt-in budget clamp for parallel sync workers)
+ *
+ * PGLite engines do not use Postgres pooling — this helper is a no-op there.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** Conservative defaults for Supabase session pooler (pool_size often 15). */
+export const SUPABASE_POOL_BUDGET_DEFAULTS = Object.freeze({
+  GBRAIN_DISABLE_DIRECT_POOL: '1',
+  GBRAIN_POOL_SIZE: '2',
+  GBRAIN_DIRECT_POOL_SIZE: '1',
+  GBRAIN_MAX_CONNECTIONS: '15',
+});
+
+const SUPABASE_HOST_MARKERS = [
+  'pooler.supabase.com',
+  'supabase.co',
+  'supabase.in',
+];
+
+/**
+ * @param {unknown} config
+ * @returns {boolean}
+ */
+export function engineNeedsPoolBudget(config) {
+  if (!config || typeof config !== 'object') return false;
+
+  const record = /** @type {Record<string, unknown>} */ (config);
+  const engine =
+    typeof record.engine === 'string' ? record.engine.toLowerCase() : '';
+
+  if (engine === 'pglite') return false;
+  if (engine === 'postgres' || engine === 'supabase') return true;
+
+  const urlCandidates = [
+    record.database_url,
+    record.pooler_url,
+    record.direct_database_url,
+  ].filter(value => typeof value === 'string');
+
+  return urlCandidates.some(url =>
+    SUPABASE_HOST_MARKERS.some(marker => url.includes(marker))
+  );
+}
+
+/**
+ * @param {Record<string, string | undefined>} env
+ * @param {Record<string, string>} defaults
+ * @returns {Record<string, string>}
+ */
+export function resolvePoolBudgetEnv(
+  env,
+  defaults = SUPABASE_POOL_BUDGET_DEFAULTS
+) {
+  /** @type {Record<string, string>} */
+  const resolved = {};
+
+  for (const [key, fallback] of Object.entries(defaults)) {
+    const current = env[key];
+    resolved[key] = current && current.length > 0 ? current : fallback;
+  }
+
+  return resolved;
+}
+
+/**
+ * @param {string | undefined} configPath
+ * @param {Record<string, string | undefined>} env
+ * @returns {{ apply: boolean, env: Record<string, string>, reason: string }}
+ */
+export function planPoolBudget(configPath, env = process.env) {
+  if (
+    env.GBRAIN_POOL_BUDGET_DISABLED === '1' ||
+    env.GBRAIN_POOL_BUDGET_DISABLED === 'true'
+  ) {
+    return { apply: false, env: {}, reason: 'disabled' };
+  }
+
+  if (!configPath) {
+    return { apply: false, env: {}, reason: 'no-config-path' };
+  }
+
+  let config;
+  try {
+    config = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch {
+    return { apply: false, env: {}, reason: 'config-unreadable' };
+  }
+
+  if (!engineNeedsPoolBudget(config)) {
+    return { apply: false, env: {}, reason: 'engine-skip' };
+  }
+
+  return {
+    apply: true,
+    env: resolvePoolBudgetEnv(env),
+    reason: 'supabase-pool-budget',
+  };
+}
+
+/**
+ * @param {Record<string, string>} values
+ * @returns {string}
+ */
+export function formatShellExports(values) {
+  return Object.entries(values)
+    .map(([key, value]) => `export ${key}=${shellQuote(value)}`)
+    .join('\n');
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+export function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:@%+-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function parseArgs(argv) {
+  const args = {
+    mode: 'shell',
+    configPath: `${process.env.HOME ?? ''}/.gbrain/config.json`,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      args.mode = 'json';
+    } else if (arg === '--shell') {
+      args.mode = 'shell';
+    } else if (arg === '--config' && argv[i + 1]) {
+      args.configPath = argv[++i];
+    } else if (!arg.startsWith('-')) {
+      args.configPath = arg;
+    }
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const plan = planPoolBudget(args.configPath, process.env);
+
+  if (args.mode === 'json') {
+    process.stdout.write(`${JSON.stringify(plan)}\n`);
+    return;
+  }
+
+  if (plan.apply) {
+    process.stdout.write(`${formatShellExports(plan.env)}\n`);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/lib/gbrain-pool-env.sh
+++ b/scripts/lib/gbrain-pool-env.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Apply conservative gbrain pool-budget env vars before Supabase-backed CLI runs.
+# No-op for PGLite engines and when GBRAIN_POOL_BUDGET_DISABLED=1.
+#
+# Usage (source, do not execute):
+#   . "$(dirname "${BASH_SOURCE[0]}")/gbrain-pool-env.sh"
+#   apply_gbrain_pool_budget
+#
+set -u
+
+_gbrain_pool_env_lib_dir() {
+  if [[ -n "${BASH_SOURCE[1]:-}" ]]; then
+    cd "$(dirname "${BASH_SOURCE[1]}")" && pwd
+  else
+    cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+  fi
+}
+
+apply_gbrain_pool_budget() {
+  local lib_dir config_path exports
+  lib_dir="$(_gbrain_pool_env_lib_dir)"
+  config_path="${GBRAIN_CONFIG_FILE:-${HOME}/.gbrain/config.json}"
+
+  if [[ ! -f "${lib_dir}/gbrain-pool-env.mjs" ]]; then
+    return 0
+  fi
+
+  exports="$(node "${lib_dir}/gbrain-pool-env.mjs" --shell "$config_path" 2>/dev/null || true)"
+  if [[ -n "$exports" ]]; then
+    # shellcheck disable=SC1090
+    eval "$exports"
+  fi
+}


### PR DESCRIPTION
## Summary

Stops Supabase connection exhaustion from gbrain per-process pool multiplication by
clamping pool budget env vars in Jovie-owned wrappers and documenting operator setup.

- Add `scripts/lib/gbrain-pool-env.{mjs,sh}` — detects Supabase vs PGLite and exports
  conservative defaults (`GBRAIN_POOL_SIZE=2`, `GBRAIN_DIRECT_POOL_SIZE=1`,
  `GBRAIN_DISABLE_DIRECT_POOL=1`, `GBRAIN_MAX_CONNECTIONS=15`).
- Wire helper into `scripts/codex-gbrain-sync.sh` before `gbrain doctor` / sync.
- Document operator env + verification in `docs/GBRAIN_POOL_BUDGET.md`; cross-link from
  `docs/HERMES_AIR.md`, `setup-gbrain` skill, and launchd README.
- Unit tests for detection/defaults (`scripts/lib/__tests__/gbrain-pool-env.test.mjs`).

## Problem

GitHub #10815 / JOV-3123: overlapping gbrain processes each open default 10+3 pools on
Supabase, exhausting Supavisor session pool (`EMAXCONNSESSION`). gbrain v0.42+ has an
opt-in `GBRAIN_MAX_CONNECTIONS` clamp but it is off unless env is set in every wrapper.

## Operator follow-up (MacBook Pro, not in this PR)

Long-lived Pro cron/launchd wrappers still need the same exports in shell profile or
`~/.gbrain/env`. See `docs/GBRAIN_POOL_BUDGET.md`.

## Verification

```bash
pnpm exec vitest run --project workspace-scripts scripts/lib/__tests__/gbrain-pool-env.test.mjs
bash -n scripts/codex-gbrain-sync.sh scripts/lib/gbrain-pool-env.sh
node scripts/lib/gbrain-pool-env.mjs --json ~/.gbrain/config.json  # PGLite → engine-skip
```

## Linear

<!-- linear-issue-id:JOV-3123 -->
<!-- linear-issue-identifier:JOV-3123 -->

Closes #10815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pool budget configuration helpers and utilities to prevent Supabase connection exhaustion in multi-process environments.

* **Documentation**
  * Added comprehensive Supabase pool budget setup, verification, and troubleshooting guide.
  * Updated setup documentation with pool configuration requirements and environment variable guidance.
  * Updated runbook with connection exhaustion recovery procedures and configuration verification steps for different deployment types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->