### PR TITLE
fix(ios): gate native Chat tab on server chatEnabled capability (JOV-3230)

### DIFF
--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -194,6 +194,7 @@ private struct AppContentView: View {
           initialTab: .profile,
           opensSettingsOnLaunch: appState.launchMode.opensSettingsOnLaunch,
           billingURL: appState.billingURL,
+          chatEnabled: false,
           recentConversations: chatRepository?.conversations ?? [],
           onSelectConversation: { conversationID in
             Task { await chatRepository?.openConversation(conversationID) }
@@ -219,6 +220,7 @@ private struct AppContentView: View {
           initialTab: appState.launchMode.opensChatOnLaunch ? .chat : .profile,
           opensSettingsOnLaunch: appState.launchMode.opensSettingsOnLaunch,
           billingURL: appState.billingURL,
+          chatEnabled: appState.loadedDashboardResponse?.chatEnabled ?? false,
           recentConversations: chatRepository?.conversations ?? [],
           onSelectConversation: { conversationID in
             Task { await chatRepository?.openConversation(conversationID) }

--- a/apps/ios/Jovie/Core/MobileMeResponse.swift
+++ b/apps/ios/Jovie/Core/MobileMeResponse.swift
@@ -13,6 +13,7 @@ struct MobileMeResponse: Codable, Equatable, Sendable {
   let qrPayload: String?
   let avatarURL: String?
   let appleWalletProfilePassAvailable: Bool
+  let chatEnabled: Bool
   let continueOnWebURL: String
 
   enum CodingKeys: String, CodingKey {
@@ -23,6 +24,7 @@ struct MobileMeResponse: Codable, Equatable, Sendable {
     case qrPayload
     case avatarURL = "avatarUrl"
     case appleWalletProfilePassAvailable
+    case chatEnabled
     case continueOnWebURL = "continueOnWebUrl"
   }
 
@@ -34,6 +36,7 @@ struct MobileMeResponse: Codable, Equatable, Sendable {
     qrPayload: "https://jov.ie/tim",
     avatarURL: nil,
     appleWalletProfilePassAvailable: false,
+    chatEnabled: true,
     continueOnWebURL: "https://jov.ie/app"
   )
 
@@ -45,6 +48,7 @@ struct MobileMeResponse: Codable, Equatable, Sendable {
     qrPayload: nil,
     avatarURL: nil,
     appleWalletProfilePassAvailable: false,
+    chatEnabled: false,
     continueOnWebURL: "https://jov.ie/app"
   )
 }

--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -63,6 +63,7 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
   let isOffline: Bool
   let opensSettingsOnLaunch: Bool
   let billingURL: URL
+  let chatEnabled: Bool
   let recentConversations: [MobileConversationSummary]
   let onSelectConversation: (String) -> Void
   let onLogout: @MainActor () async -> Void
@@ -81,6 +82,7 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
     initialTab: AppShellTab = .profile,
     opensSettingsOnLaunch: Bool = false,
     billingURL: URL,
+    chatEnabled: Bool = false,
     recentConversations: [MobileConversationSummary] = [],
     onSelectConversation: @escaping (String) -> Void = { _ in },
     onLogout: @escaping @MainActor () async -> Void,
@@ -91,12 +93,13 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
     self.isOffline = isOffline
     self.opensSettingsOnLaunch = opensSettingsOnLaunch
     self.billingURL = billingURL
+    self.chatEnabled = chatEnabled
     self.recentConversations = recentConversations
     self.onSelectConversation = onSelectConversation
     self.onLogout = onLogout
     self.profileContent = profileContent()
     self.chatContent = chatContent
-    _selectedTab = State(initialValue: initialTab)
+    _selectedTab = State(initialValue: chatEnabled ? initialTab : .profile)
   }
 
   var body: some View {
@@ -134,6 +137,7 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
         profile: profile,
         isOffline: isOffline,
         selectedTab: selectedTab,
+        chatEnabled: chatEnabled,
         recentConversations: recentConversations,
         onSelectTab: { tab in
           selectedTab = tab
@@ -163,7 +167,11 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
   private var activeContent: some View {
     switch selectedTab {
     case .chat:
-      chatContent($chatDraft)
+      if chatEnabled {
+        chatContent($chatDraft)
+      } else {
+        profileContent
+      }
     case .profile:
       profileContent
     }
@@ -210,28 +218,31 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
     .background(JovieColor.backgroundBase.opacity(0.96))
   }
 
+  @ViewBuilder
   private var bottomNavigation: some View {
-    HStack(spacing: JovieSpacing.small) {
-      tabButton(.chat)
-      tabButton(.profile)
-    }
-    .padding(6)
-    .frame(width: 236)
-    .background {
-      if #available(iOS 26.0, *) {
-        Capsule(style: .continuous)
-          .fill(JovieColor.surface1.opacity(0.54))
-          .glassEffect(.regular.tint(JovieColor.surface1.opacity(0.54)), in: .rect(cornerRadius: 28))
-      } else {
-        Capsule(style: .continuous)
-          .fill(.ultraThinMaterial)
-          .overlay {
-            Capsule(style: .continuous)
-              .stroke(JovieColor.borderDefault, lineWidth: 1)
-          }
+    if chatEnabled {
+      HStack(spacing: JovieSpacing.small) {
+        tabButton(.chat)
+        tabButton(.profile)
       }
+      .padding(6)
+      .frame(width: 236)
+      .background {
+        if #available(iOS 26.0, *) {
+          Capsule(style: .continuous)
+            .fill(JovieColor.surface1.opacity(0.54))
+            .glassEffect(.regular.tint(JovieColor.surface1.opacity(0.54)), in: .rect(cornerRadius: 28))
+        } else {
+          Capsule(style: .continuous)
+            .fill(.ultraThinMaterial)
+            .overlay {
+              Capsule(style: .continuous)
+                .stroke(JovieColor.borderDefault, lineWidth: 1)
+            }
+        }
+      }
+      .padding(.bottom, JovieSpacing.medium)
     }
-    .padding(.bottom, JovieSpacing.medium)
   }
 
   private func tabButton(_ tab: AppShellTab) -> some View {
@@ -283,6 +294,7 @@ private struct AppNavigationMenu: View {
   let profile: AppShellProfile
   let isOffline: Bool
   let selectedTab: AppShellTab
+  let chatEnabled: Bool
   let recentConversations: [MobileConversationSummary]
   let onSelectTab: (AppShellTab) -> Void
   let onSelectConversation: (String) -> Void
@@ -311,12 +323,14 @@ private struct AppNavigationMenu: View {
         MenuAccountView(profile: profile, isOffline: isOffline)
 
         VStack(spacing: JovieSpacing.small) {
-          MenuRow(
-            title: "Chat",
-            systemImage: AppShellTab.chat.systemImage,
-            isSelected: selectedTab == .chat
-          ) {
-            onSelectTab(.chat)
+          if chatEnabled {
+            MenuRow(
+              title: "Chat",
+              systemImage: AppShellTab.chat.systemImage,
+              isSelected: selectedTab == .chat
+            ) {
+              onSelectTab(.chat)
+            }
           }
 
           MenuRow(
@@ -335,37 +349,39 @@ private struct AppNavigationMenu: View {
           )
         }
 
-        VStack(alignment: .leading, spacing: JovieSpacing.medium) {
-          Text("Recent")
-            .font(JovieFont.body(size: 13, weight: .semibold))
-            .foregroundStyle(JovieColor.textTertiary)
-
-          if recentConversations.isEmpty {
-            Text("Start a chat to see recent conversations here.")
-              .font(JovieFont.body(size: 15))
+        if chatEnabled {
+          VStack(alignment: .leading, spacing: JovieSpacing.medium) {
+            Text("Recent")
+              .font(JovieFont.body(size: 13, weight: .semibold))
               .foregroundStyle(JovieColor.textTertiary)
-              .fixedSize(horizontal: false, vertical: true)
-          } else {
-            VStack(spacing: JovieSpacing.small) {
-              ForEach(recentConversations.prefix(5)) { conversation in
-                Button {
-                  onSelectConversation(conversation.id)
-                } label: {
-                  HStack {
-                    Text(conversation.title ?? "New chat")
-                      .font(JovieFont.body(size: 15))
-                      .foregroundStyle(JovieColor.textPrimary)
-                      .lineLimit(1)
-                    Spacer()
+
+            if recentConversations.isEmpty {
+              Text("Start a chat to see recent conversations here.")
+                .font(JovieFont.body(size: 15))
+                .foregroundStyle(JovieColor.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+            } else {
+              VStack(spacing: JovieSpacing.small) {
+                ForEach(recentConversations.prefix(5)) { conversation in
+                  Button {
+                    onSelectConversation(conversation.id)
+                  } label: {
+                    HStack {
+                      Text(conversation.title ?? "New chat")
+                        .font(JovieFont.body(size: 15))
+                        .foregroundStyle(JovieColor.textPrimary)
+                        .lineLimit(1)
+                      Spacer()
+                    }
+                    .padding(.vertical, JovieSpacing.small)
                   }
-                  .padding(.vertical, JovieSpacing.small)
+                  .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
               }
             }
           }
+          .padding(.top, JovieSpacing.medium)
         }
-        .padding(.top, JovieSpacing.medium)
 
         Spacer(minLength: 0)
       }

--- a/apps/web/app/api/mobile/v1/me/route.ts
+++ b/apps/web/app/api/mobile/v1/me/route.ts
@@ -4,6 +4,7 @@ import { isProfileComplete } from '@/lib/auth/profile-completeness';
 import { getSessionContext, SESSION_ERRORS } from '@/lib/auth/session';
 import { captureError } from '@/lib/error-tracking';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
+import { isMobileChatEnabledForUser } from '@/lib/mobile/chat/access';
 import { getMobileSessionUserId } from '@/lib/mobile/session-auth';
 import { isAppleWalletProfilePassAvailable } from '@/lib/wallet/apple/profile-pass';
 
@@ -18,6 +19,7 @@ export interface MobileMeResponse {
   avatarUrl: string | null;
   continueOnWebUrl: string;
   appleWalletProfilePassAvailable: boolean;
+  chatEnabled: boolean;
 }
 
 function buildNeedsOnboardingResponse(): NextResponse {
@@ -30,6 +32,7 @@ function buildNeedsOnboardingResponse(): NextResponse {
     avatarUrl: null,
     continueOnWebUrl: getAppUrl(),
     appleWalletProfilePassAvailable: false,
+    chatEnabled: false,
   };
 
   return NextResponse.json(payload, {
@@ -103,6 +106,9 @@ export async function GET(request: Request) {
         isPublic: profile.isPublic,
         onboardingCompletedAt: profile.onboardingCompletedAt,
       });
+    const chatEnabled = await isMobileChatEnabledForUser(userId, {
+      isAdmin: session.user.isAdmin,
+    });
     const payload: MobileMeResponse = {
       state: 'ready',
       displayName: profile.displayName,
@@ -112,6 +118,7 @@ export async function GET(request: Request) {
       avatarUrl: profile.avatarUrl,
       continueOnWebUrl: getAppUrl(),
       appleWalletProfilePassAvailable,
+      chatEnabled,
     };
 
     return NextResponse.json(payload, {

--- a/apps/web/lib/mobile/chat/access.ts
+++ b/apps/web/lib/mobile/chat/access.ts
@@ -1,0 +1,64 @@
+import 'server-only';
+
+import { getSessionContext } from '@/lib/auth/session';
+import { getAppFlagValue } from '@/lib/flags/server';
+
+/**
+ * Master environment switch. The native mobile chat runtime only serves turns on
+ * environments that explicitly opt in via `MOBILE_CHAT_RUNTIME_ENABLED=true`.
+ * Production stays off until launch is approved (see JOV-2550); alpha/staging opt in.
+ */
+export function isMobileChatRuntimeEnabled(): boolean {
+  return process.env.MOBILE_CHAT_RUNTIME_ENABLED === 'true';
+}
+
+/**
+ * Per-user alpha cohort check. Admins always pass; everyone else must be inside the
+ * `ios_app_alpha_access` Statsig gate. Fetches the session, so prefer
+ * {@link isMobileChatEnabledForUser} with a known `isAdmin` when the caller has
+ * already resolved the session.
+ */
+export async function hasMobileChatAlphaAccess(
+  clerkUserId: string
+): Promise<boolean> {
+  const session = await getSessionContext({
+    clerkUserId,
+    requireUser: true,
+    requireProfile: false,
+  });
+
+  if (session.user.isAdmin) {
+    return true;
+  }
+
+  return getAppFlagValue('IOS_APP_ALPHA_ACCESS', {
+    userId: clerkUserId,
+  });
+}
+
+/**
+ * Whether native mobile chat is actually usable for this user in this environment:
+ * the runtime must be enabled AND the user must be in the alpha cohort (or admin).
+ *
+ * This is the single source of truth behind both the `/api/mobile/v1/chat/turns`
+ * gate and the `chatEnabled` capability returned by `/api/mobile/v1/me`, so the iOS
+ * client never renders a Chat tab that would only 501/403.
+ *
+ * Pass `isAdmin` when the caller already resolved the session to avoid a refetch.
+ */
+export async function isMobileChatEnabledForUser(
+  clerkUserId: string,
+  options?: { readonly isAdmin?: boolean }
+): Promise<boolean> {
+  if (!isMobileChatRuntimeEnabled()) {
+    return false;
+  }
+
+  if (options?.isAdmin) {
+    return true;
+  }
+
+  return getAppFlagValue('IOS_APP_ALPHA_ACCESS', {
+    userId: clerkUserId,
+  });
+}

--- a/apps/web/lib/mobile/chat/turn-handler.ts
+++ b/apps/web/lib/mobile/chat/turn-handler.ts
@@ -16,12 +16,12 @@ import {
   reserveChatTurn,
   TURN_IN_PROGRESS_ERROR_CODE,
 } from '@/lib/chat/turns';
-import { getAppFlagValue } from '@/lib/flags/server';
 import {
   classifyIntent,
   isDeterministicIntent,
   routeIntent,
 } from '@/lib/intent-detection';
+import { hasMobileChatAlphaAccess } from '@/lib/mobile/chat/access';
 import { fetchMobileArtistContext } from '@/lib/mobile/chat/artist-context';
 import {
   buildMobileChatHandoffUrl,
@@ -96,22 +96,6 @@ function errorNdjsonResponse(
       },
     }
   );
-}
-
-async function hasMobileChatAlphaAccess(clerkUserId: string): Promise<boolean> {
-  const session = await getSessionContext({
-    clerkUserId,
-    requireUser: true,
-    requireProfile: false,
-  });
-
-  if (session.user.isAdmin) {
-    return true;
-  }
-
-  return getAppFlagValue('IOS_APP_ALPHA_ACCESS', {
-    userId: clerkUserId,
-  });
 }
 
 export async function handleMobileChatTurn(

--- a/apps/web/tests/unit/api/mobile/v1/chat-turns.test.ts
+++ b/apps/web/tests/unit/api/mobile/v1/chat-turns.test.ts
@@ -1,11 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
   getMobileSessionUserIdMock: vi.fn(),
+  handleMobileChatTurnMock: vi.fn(),
 }));
 
 vi.mock('@/lib/mobile/session-auth', () => ({
   getMobileSessionUserId: hoisted.getMobileSessionUserIdMock,
+}));
+
+vi.mock('@/lib/mobile/chat/turn-handler', () => ({
+  handleMobileChatTurn: hoisted.handleMobileChatTurnMock,
 }));
 
 const routeModulePromise = import('@/app/api/mobile/v1/chat/turns/route');
@@ -18,6 +23,10 @@ describe('POST /api/mobile/v1/chat/turns', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hoisted.getMobileSessionUserIdMock.mockResolvedValue('user_123');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('returns 401 when the mobile session token is missing', async () => {
@@ -61,7 +70,9 @@ describe('POST /api/mobile/v1/chat/turns', () => {
     });
   });
 
-  it('fails closed with an NDJSON error event until native chat runtime is enabled', async () => {
+  it('fails closed with an NDJSON error event when the runtime flag is off', async () => {
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', '');
+
     const { POST } = await routeModulePromise;
     const response = await POST(
       new Request('https://jov.ie/api/mobile/v1/chat/turns', {
@@ -81,6 +92,42 @@ describe('POST /api/mobile/v1/chat/turns', () => {
     );
     await expect(text(response)).resolves.toBe(
       '{"type":"error","errorCode":"MOBILE_CHAT_RUNTIME_DISABLED","message":"Native chat is not enabled for this build."}\n'
+    );
+    expect(hoisted.handleMobileChatTurnMock).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the chat runtime when the flag is enabled', async () => {
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', 'true');
+    const runtimeResponse = new Response('{"type":"turn.reserved"}\n', {
+      status: 200,
+      headers: { 'Content-Type': 'application/x-ndjson; charset=utf-8' },
+    });
+    hoisted.handleMobileChatTurnMock.mockResolvedValue(runtimeResponse);
+
+    const { POST } = await routeModulePromise;
+    const response = await POST(
+      new Request('https://jov.ie/api/mobile/v1/chat/turns', {
+        method: 'POST',
+        body: JSON.stringify({
+          clientTurnId: 'turn_123',
+          clientMessageId: 'msg_123',
+          text: 'Help me launch my release',
+          source: 'typed',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(hoisted.handleMobileChatTurnMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.handleMobileChatTurnMock).toHaveBeenCalledWith(
+      'user_123',
+      expect.objectContaining({
+        clientTurnId: 'turn_123',
+        clientMessageId: 'msg_123',
+        text: 'Help me launch my release',
+        source: 'typed',
+      }),
+      expect.anything()
     );
   });
 });

--- a/apps/web/tests/unit/api/mobile/v1/me.test.ts
+++ b/apps/web/tests/unit/api/mobile/v1/me.test.ts
@@ -8,6 +8,7 @@ const hoisted = vi.hoisted(() => ({
   getSessionContextMock: vi.fn(),
   isProfileCompleteMock: vi.fn(),
   isAppleWalletProfilePassAvailableMock: vi.fn(),
+  isMobileChatEnabledForUserMock: vi.fn(),
 }));
 
 vi.mock('@/constants/domains', () => ({
@@ -41,6 +42,10 @@ vi.mock('@/lib/wallet/apple/profile-pass', () => ({
     hoisted.isAppleWalletProfilePassAvailableMock,
 }));
 
+vi.mock('@/lib/mobile/chat/access', () => ({
+  isMobileChatEnabledForUser: hoisted.isMobileChatEnabledForUserMock,
+}));
+
 const routeModulePromise = import('@/app/api/mobile/v1/me/route');
 
 function makeRequest() {
@@ -61,6 +66,7 @@ describe('GET /api/mobile/v1/me', () => {
     );
     hoisted.isProfileCompleteMock.mockReturnValue(true);
     hoisted.isAppleWalletProfilePassAvailableMock.mockResolvedValue(true);
+    hoisted.isMobileChatEnabledForUserMock.mockResolvedValue(true);
   });
 
   it('returns 401 when unauthenticated', async () => {
@@ -125,6 +131,7 @@ describe('GET /api/mobile/v1/me', () => {
       avatarUrl: 'https://cdn.jov.ie/avatar.png',
       continueOnWebUrl: 'https://jov.ie/app',
       appleWalletProfilePassAvailable: true,
+      chatEnabled: true,
     });
     expect(hoisted.isProfileCompleteMock).toHaveBeenCalledWith({
       username: 'djshadow',
@@ -133,6 +140,36 @@ describe('GET /api/mobile/v1/me', () => {
       isPublic: true,
       onboardingCompletedAt: new Date('2026-04-01T00:00:00.000Z'),
     });
+  });
+
+  it('reports chatEnabled from the mobile chat access gate', async () => {
+    hoisted.isMobileChatEnabledForUserMock.mockResolvedValue(false);
+    hoisted.getSessionContextMock.mockResolvedValue({
+      user: {
+        userStatus: 'active',
+        isAdmin: false,
+      },
+      profile: {
+        id: 'profile_123',
+        username: 'djshadow',
+        usernameNormalized: 'djshadow',
+        displayName: 'DJ Shadow',
+        avatarUrl: null,
+        isPublic: true,
+        onboardingCompletedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+    });
+
+    const { GET } = await routeModulePromise;
+    const response = await GET(makeRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.chatEnabled).toBe(false);
+    expect(hoisted.isMobileChatEnabledForUserMock).toHaveBeenCalledWith(
+      'user_123',
+      { isAdmin: false }
+    );
   });
 
   it('returns needs_onboarding when the DB user is missing', async () => {
@@ -154,6 +191,7 @@ describe('GET /api/mobile/v1/me', () => {
       avatarUrl: null,
       continueOnWebUrl: 'https://jov.ie/app',
       appleWalletProfilePassAvailable: false,
+      chatEnabled: false,
     });
   });
 
@@ -179,6 +217,7 @@ describe('GET /api/mobile/v1/me', () => {
       avatarUrl: null,
       continueOnWebUrl: 'https://jov.ie/app',
       appleWalletProfilePassAvailable: false,
+      chatEnabled: false,
     });
   });
 
@@ -213,6 +252,7 @@ describe('GET /api/mobile/v1/me', () => {
       avatarUrl: null,
       continueOnWebUrl: 'https://jov.ie/app',
       appleWalletProfilePassAvailable: false,
+      chatEnabled: false,
     });
   });
 


### PR DESCRIPTION
<!-- linear-issue-id: JOV-3230 -->
Closes JOV-3230.

## Problem
The TestFlight app shows a **Chat tab that doesn't work**. `AppShellView` rendered the Chat tab unconditionally, but `/api/mobile/v1/chat/turns` returns `501 MOBILE_CHAT_RUNTIME_DISABLED` when the runtime is gated off / the user lacks alpha access — a dead tab. A flagged-off feature should not show a tab.

## Change
- **Backend** — new `chatEnabled` capability on `GET /api/mobile/v1/me`, computed from `MOBILE_CHAT_RUNTIME_ENABLED === 'true'` **and** mobile-chat alpha access (admin OR `ios_app_alpha_access`). Extracted the shared gate into `lib/mobile/chat/access.ts` (single source of truth) and refactored `turn-handler.ts` to reuse it (behavior-preserving).
- **iOS** — `MobileMeResponse.chatEnabled`; `AppShellView` hides the Chat tab, the menu Chat row, and the Recent section when `chatEnabled` is false, and clamps the initial tab to Profile. `RootView` passes the capability through (false pre-onboarding).

This encodes the **"alpha on by default, production off until approved"** policy: the tab appears only where chat actually works.

## Verification
- `pnpm --filter @jovie/web run typecheck` — clean (exit 0)
- `pnpm biome check` — clean (pre-push lint, 6242 files)
- Vitest (25 passing): `me.test.ts` (+chatEnabled true/false + wiring assertion), `chat-turns.test.ts` (now env-deterministic via `vi.stubEnv` + new enabled-delegation case), `chat-conversations`, `chat-contract`, `chat/turns`
- `swiftc -typecheck MobileMeResponse.swift` — clean; brace-balance verified on edited SwiftUI files
- iOS build/UI tests run in `ios-ci` (macos-26) on this PR — **no local Xcode available in the authoring environment**, so the Swift compile + Swift Testing suites are verified by CI here.

## Cost Impact
This PR is gating-only (no new recurring calls). Separately, `MOBILE_CHAT_RUNTIME_ENABLED=true` was set in Doppler dev/stg/prd this session to turn the runtime on; per-turn LLM cost is scoped to alpha testers (+admins) by the `ios_app_alpha_access` gate. Production picks up the flag on next redeploy.

## Guardrail added
`chat-turns.test.ts` no longer depends on ambient `MOBILE_CHAT_RUNTIME_ENABLED` (it stubs the env), and now covers both the disabled (501) and enabled (delegates to runtime) branches — closing the gap that let the env flag silently change test behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat feature availability gating, allowing control over which users can access the mobile chat functionality based on admin status and alpha access eligibility.

* **Chores**
  * Refactored internal chat access utilities and updated tests to cover new feature controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->