### PR TITLE
fix(routing): context-aware 404 pages (JOV-3091)

### DIFF
--- a/apps/web/app/[username]/[...slug]/page.tsx
+++ b/apps/web/app/[username]/[...slug]/page.tsx
@@ -1,22 +1,13 @@
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { REDIRECT_SINK_METADATA } from '@/lib/profile/metadata';
 
-interface Props {
-  readonly params: Promise<{
-    readonly username: string;
-    readonly slug: string[];
-  }>;
-}
-
-// Catch-all for unknown sub-paths — redirects to the profile root.
+// Catch-all for unknown sub-paths — returns a context-aware 404.
 // Marked noindex to avoid indexing transient or unknown paths.
 export function generateMetadata(): Metadata {
   return REDIRECT_SINK_METADATA;
 }
 
-export default async function CatchAllPage({ params }: Props) {
-  const { username } = await params;
-  // Redirect unknown paths to the main profile
-  redirect(`/${username}`);
+export default async function CatchAllPage() {
+  notFound();
 }

--- a/apps/web/app/[username]/not-found.tsx
+++ b/apps/web/app/[username]/not-found.tsx
@@ -1,7 +1,14 @@
-import Link from 'next/link';
+import { NotFoundPageContent } from '@/components/site/NotFoundPageContent';
 import { PublicPageShell } from '@/components/site/PublicPageShell';
+import {
+  resolveNotFoundPathname,
+  resolveNotFoundVariant,
+} from '@/lib/routing/not-found-context';
 
-export default function NotFound() {
+export default async function NotFound() {
+  const pathname = await resolveNotFoundPathname();
+  const variant = resolveNotFoundVariant(pathname);
+
   return (
     <PublicPageShell
       headerVariant='minimal'
@@ -12,17 +19,7 @@ export default function NotFound() {
         className='profile-viewport system-b-public-profile-not-found-container'
       >
         <div className='system-b-public-profile-not-found-content'>
-          <p className='system-b-public-profile-not-found-code'>404</p>
-          <h1 className='system-b-public-profile-not-found-title'>
-            Profile not found
-          </h1>
-          <p className='system-b-public-profile-not-found-description'>
-            This profile may have moved or the link may be incorrect.
-          </p>
-
-          <Link href='/' className='system-b-public-profile-not-found-action'>
-            Return home
-          </Link>
+          <NotFoundPageContent variant={variant} surface='profile' />
         </div>
       </div>
     </PublicPageShell>

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,7 +1,7 @@
-import Link from 'next/link';
 import { Container } from '@/components/site/Container';
 import { MarketingFooter } from '@/components/site/MarketingFooter';
 import { MarketingHeader } from '@/components/site/MarketingHeader';
+import { NotFoundPageContent } from '@/components/site/NotFoundPageContent';
 
 export default function NotFound() {
   return (
@@ -15,26 +15,7 @@ export default function NotFound() {
       >
         <Container className='system-b-root-not-found-container'>
           <div className='system-b-root-not-found-content'>
-            <div className='system-b-root-not-found-code-wrap'>
-              <span className='system-b-root-not-found-code' aria-hidden='true'>
-                404
-              </span>
-            </div>
-
-            <div className='system-b-root-not-found-copy'>
-              <h1 className='system-b-root-not-found-title'>Page not found</h1>
-              <p className='system-b-root-not-found-description'>
-                The link you followed may be broken, or the page may have been
-                removed.
-              </p>
-
-              <Link
-                href='/'
-                className='system-b-root-not-found-action focus-ring-transparent-offset'
-              >
-                Return home
-              </Link>
-            </div>
+            <NotFoundPageContent variant='generic' surface='root' />
           </div>
         </Container>
       </main>

--- a/apps/web/components/site/NotFoundPageContent.tsx
+++ b/apps/web/components/site/NotFoundPageContent.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  getNotFoundCopy,
+  type NotFoundVariant,
+} from '@/lib/routing/not-found-context';
+
+type NotFoundSurface = 'root' | 'profile';
+
+interface NotFoundPageContentProps {
+  readonly variant: NotFoundVariant;
+  readonly surface: NotFoundSurface;
+}
+
+const SURFACE_CLASS_PREFIX = {
+  root: 'system-b-root-not-found',
+  profile: 'system-b-public-profile-not-found',
+} as const satisfies Record<NotFoundSurface, string>;
+
+export function NotFoundPageContent({
+  variant,
+  surface,
+}: Readonly<NotFoundPageContentProps>) {
+  const copy = getNotFoundCopy(variant);
+  const prefix = SURFACE_CLASS_PREFIX[surface];
+
+  return (
+    <>
+      {surface === 'root' ? (
+        <div className={`${prefix}-code-wrap`}>
+          <span className={`${prefix}-code`} aria-hidden='true'>
+            404
+          </span>
+        </div>
+      ) : (
+        <p className={`${prefix}-code`}>404</p>
+      )}
+
+      <div className={`${prefix}-copy`}>
+        <h1 className={`${prefix}-title`}>{copy.title}</h1>
+        <p className={`${prefix}-description`}>{copy.description}</p>
+
+        <div className={`${prefix}-actions`}>
+          <Link href={APP_ROUTES.HOME} className={`${prefix}-action`}>
+            Go home
+          </Link>
+          <Link
+            href={APP_ROUTES.ARTIST_PROFILES}
+            className={`${prefix}-action-secondary`}
+          >
+            Search artists
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/lib/routing/not-found-context.ts
+++ b/apps/web/lib/routing/not-found-context.ts
@@ -1,0 +1,100 @@
+import { headers } from 'next/headers';
+import { getPublicProfileCandidate } from '@/lib/routing/proxy-routing';
+
+export type NotFoundVariant = 'profile-miss' | 'generic';
+
+export interface NotFoundCopy {
+  readonly title: string;
+  readonly description: string;
+}
+
+export const NOT_FOUND_COPY: Readonly<Record<NotFoundVariant, NotFoundCopy>> = {
+  'profile-miss': {
+    title: 'Profile not found',
+    description: "This profile doesn't exist.",
+  },
+  generic: {
+    title: "We can't find that page.",
+    description: 'The link may be broken or the page may have been removed.',
+  },
+};
+
+/**
+ * Profile-specific copy only applies to single-segment handle lookups that
+ * passed the public-profile candidate gate. Everything else is generic.
+ */
+export function resolveNotFoundVariant(pathname: string): NotFoundVariant {
+  const normalizedPath = normalizePathname(pathname);
+  const segments = normalizedPath.split('/').filter(Boolean);
+
+  if (segments.length !== 1) {
+    return 'generic';
+  }
+
+  return getPublicProfileCandidate(normalizedPath) ? 'profile-miss' : 'generic';
+}
+
+export function getNotFoundCopy(variant: NotFoundVariant): NotFoundCopy {
+  return NOT_FOUND_COPY[variant];
+}
+
+function normalizePathname(pathname: string): string {
+  const trimmed = pathname.trim();
+  if (!trimmed) return '/';
+
+  try {
+    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+      return new URL(trimmed).pathname;
+    }
+  } catch {
+    // Fall through to the relative-path normalization below.
+  }
+
+  const withoutQuery = trimmed.split('?')[0]?.split('#')[0] ?? trimmed;
+  const withLeadingSlash = withoutQuery.startsWith('/')
+    ? withoutQuery
+    : `/${withoutQuery}`;
+
+  if (withLeadingSlash.length > 1 && withLeadingSlash.endsWith('/')) {
+    return withLeadingSlash.slice(0, -1);
+  }
+
+  return withLeadingSlash;
+}
+
+function resolvePathnameFromHeaderValue(value: string | null): string | null {
+  if (!value) return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    try {
+      return new URL(trimmed).pathname;
+    } catch {
+      return null;
+    }
+  }
+
+  if (trimmed.startsWith('/')) {
+    return normalizePathname(trimmed);
+  }
+
+  return null;
+}
+
+/**
+ * Best-effort pathname resolution for not-found boundaries, which do not
+ * receive route params directly.
+ */
+export async function resolveNotFoundPathname(): Promise<string> {
+  const headerStore = await headers();
+
+  return (
+    resolvePathnameFromHeaderValue(headerStore.get('next-url')) ??
+    resolvePathnameFromHeaderValue(headerStore.get('x-url')) ??
+    resolvePathnameFromHeaderValue(headerStore.get('x-invoke-path')) ??
+    resolvePathnameFromHeaderValue(headerStore.get('x-matched-path')) ??
+    '/'
+  );
+}

--- a/apps/web/scripts/route-qa.ts
+++ b/apps/web/scripts/route-qa.ts
@@ -132,6 +132,7 @@ export function isNotFoundLike({
     loweredTitle.includes('not found') ||
     bodyText.includes('page not found') ||
     bodyText.includes('content not found') ||
+    bodyText.includes("can't find that page") ||
     bodyText.includes("doesn't exist") ||
     bodyText.includes("couldn't find")
   );

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2300,23 +2300,50 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   line-height: var(--leading-relaxed);
 }
 
-:where(.system-b-root-not-found-action) {
+:where(.system-b-root-not-found-actions) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+}
+
+:where(.system-b-root-not-found-action),
+:where(.system-b-root-not-found-action-secondary) {
   display: inline-flex;
-  height: var(--space-8);
+  min-height: var(--space-8);
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-md);
-  background: var(--system-b-primary-bg);
-  color: var(--system-b-primary-fg);
   font-size: var(--text-sm);
   font-weight: var(--font-weight-medium);
   padding-inline: var(--space-4);
   text-decoration: none;
-  transition: background var(--system-b-duration-fast) var(--system-b-ease);
+  transition:
+    background var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease),
+    color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-root-not-found-action) {
+  background: var(--system-b-primary-bg);
+  color: var(--system-b-primary-fg);
 }
 
 :where(.system-b-root-not-found-action:hover) {
   background: var(--color-btn-primary-hover);
+}
+
+:where(.system-b-root-not-found-action-secondary) {
+  border: var(--space-px) solid var(--color-border-subtle);
+  background: transparent;
+  color: var(--color-text-tertiary-token);
+}
+
+:where(.system-b-root-not-found-action-secondary:hover) {
+  border-color: var(--color-border-default);
+  background: var(--color-bg-surface-0);
+  color: var(--system-b-text-primary);
 }
 
 /* ============================================
@@ -2497,28 +2524,54 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   line-height: var(--leading-relaxed);
 }
 
-:where(.system-b-public-profile-not-found-action) {
+:where(.system-b-public-profile-not-found-actions) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}
+
+:where(.system-b-public-profile-not-found-action),
+:where(.system-b-public-profile-not-found-action-secondary) {
   display: inline-flex;
   min-height: var(--space-10);
   align-items: center;
   justify-content: center;
   border-radius: var(--profile-action-radius);
-  background: var(--profile-pearl-primary-bg);
-  color: var(--profile-pearl-primary-fg);
   font-size: var(--text-sm);
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-normal);
-  margin-top: var(--space-6);
   padding-inline: var(--space-4);
   text-decoration: none;
   transition:
     background var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease),
+    color var(--system-b-duration-fast) var(--system-b-ease),
     opacity var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-public-profile-not-found-action) {
+  background: var(--profile-pearl-primary-bg);
+  color: var(--profile-pearl-primary-fg);
 }
 
 :where(.system-b-public-profile-not-found-action:hover) {
   background: var(--profile-pearl-bg-active);
   opacity: 0.96;
+}
+
+:where(.system-b-public-profile-not-found-action-secondary) {
+  border: var(--space-px) solid var(--color-border-subtle);
+  background: transparent;
+  color: var(--color-text-tertiary-token);
+}
+
+:where(.system-b-public-profile-not-found-action-secondary:hover) {
+  border-color: var(--color-border-default);
+  background: var(--profile-pearl-bg-hover);
+  color: var(--system-b-text-primary);
 }
 
 /* ============================================

--- a/apps/web/tests/unit/app/[username]/not-found-system-b-source.test.ts
+++ b/apps/web/tests/unit/app/[username]/not-found-system-b-source.test.ts
@@ -32,10 +32,9 @@ describe('public profile not-found System B source tokens', () => {
     expect(source).not.toContain('style={{');
     expect(source).toContain("headerVariant='minimal'");
     expect(source).toContain('system-b-public-profile-not-found-main');
-    expect(source).toContain('system-b-public-profile-not-found-action');
-    expect(
-      source.match(/system-b-public-profile-not-found-action/g)
-    ).toHaveLength(1);
+    expect(source).toContain('NotFoundPageContent');
+    expect(source).toContain('resolveNotFoundVariant');
+    expect(source).toContain('resolveNotFoundPathname');
   });
 
   it('backs the public profile not-found primitives with System B profile tokens', async () => {
@@ -51,6 +50,10 @@ describe('public profile not-found System B source tokens', () => {
     expect(block).toContain('var(--system-b-text-primary)');
     expect(block).toContain('var(--profile-pearl-primary-bg)');
     expect(block).toContain('var(--profile-pearl-primary-fg)');
+    expect(block).toContain('system-b-public-profile-not-found-actions');
+    expect(block).toContain(
+      'system-b-public-profile-not-found-action-secondary'
+    );
     expect(block).toContain('var(--space-16)');
     expect(block).not.toMatch(hardcodedHashColorPattern);
     expect(block).not.toMatch(rawAlphaColorPattern);

--- a/apps/web/tests/unit/app/not-found-system-b-source.test.ts
+++ b/apps/web/tests/unit/app/not-found-system-b-source.test.ts
@@ -32,8 +32,8 @@ describe('root not-found System B source tokens', () => {
     expect(source).not.toContain('style={{');
     expect(source).toContain("variant='minimal'");
     expect(source).toContain('system-b-root-not-found-main');
-    expect(source).toContain('system-b-root-not-found-action');
-    expect(source.match(/system-b-root-not-found-action/g)).toHaveLength(1);
+    expect(source).toContain('NotFoundPageContent');
+    expect(source).toContain("variant='generic'");
   });
 
   it('backs the root not-found primitives with System B tokens', async () => {
@@ -47,6 +47,8 @@ describe('root not-found System B source tokens', () => {
     expect(block).toContain('var(--system-b-text-primary)');
     expect(block).toContain('var(--system-b-primary-bg)');
     expect(block).toContain('var(--system-b-primary-fg)');
+    expect(block).toContain('system-b-root-not-found-actions');
+    expect(block).toContain('system-b-root-not-found-action-secondary');
     expect(block).toContain('var(--space-16)');
     expect(block).not.toMatch(hardcodedHashColorPattern);
     expect(block).not.toMatch(rawAlphaColorPattern);

--- a/apps/web/tests/unit/components/site/NotFoundPageContent.test.tsx
+++ b/apps/web/tests/unit/components/site/NotFoundPageContent.test.tsx
@@ -1,0 +1,70 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { NotFoundPageContent } from '@/components/site/NotFoundPageContent';
+import { APP_ROUTES } from '@/constants/routes';
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const componentPath = join(appRoot, 'components/site/NotFoundPageContent.tsx');
+
+const hashMark = String.fromCharCode(35);
+const hardcodedHashColorPattern = new RegExp(`${hashMark}[\\da-fA-F]{3,8}\\b`);
+const rawVisualUtilityPattern =
+  /\b(?:bg|border|text|ring|shadow|outline|rounded|h|w|max-w|min-h|min-w|tracking|leading|px|py|pt|pb)-\[/;
+
+describe('NotFoundPageContent', () => {
+  it('renders profile miss copy with both CTAs', () => {
+    render(<NotFoundPageContent variant='profile-miss' surface='profile' />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Profile not found' })
+    ).toBeInTheDocument();
+    expect(screen.getByText("This profile doesn't exist.")).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.HOME
+    );
+    expect(
+      screen.getByRole('link', { name: 'Search artists' })
+    ).toHaveAttribute('href', APP_ROUTES.ARTIST_PROFILES);
+  });
+
+  it('renders generic copy with both CTAs', () => {
+    render(<NotFoundPageContent variant='generic' surface='root' />);
+
+    expect(
+      screen.getByRole('heading', { name: "We can't find that page." })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The link may be broken or the page may have been removed.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go home' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Search artists' })
+    ).toBeInTheDocument();
+  });
+
+  it('does not render numeric link IDs or debug dumps', () => {
+    const { container } = render(
+      <NotFoundPageContent variant='profile-miss' surface='profile' />
+    );
+
+    expect(container.textContent).not.toMatch(/\b\d{6,}\b/);
+  });
+
+  it('keeps shared not-found CTA primitives free of route-local token drift', async () => {
+    const source = await readFile(componentPath, 'utf8');
+
+    expect(source).not.toMatch(hardcodedHashColorPattern);
+    expect(source).not.toMatch(rawVisualUtilityPattern);
+    expect(source).toContain('`${prefix}-actions`');
+    expect(source).toContain('`${prefix}-action-secondary`');
+    expect(source).not.toContain('style={{');
+  });
+});

--- a/apps/web/tests/unit/lib/routing/not-found-context.test.ts
+++ b/apps/web/tests/unit/lib/routing/not-found-context.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getNotFoundCopy,
+  NOT_FOUND_COPY,
+  resolveNotFoundVariant,
+} from '@/lib/routing/not-found-context';
+
+describe('resolveNotFoundVariant', () => {
+  it('treats valid single-segment handle misses as profile misses', () => {
+    expect(resolveNotFoundVariant('/nonexistent-artist')).toBe('profile-miss');
+    expect(resolveNotFoundVariant('/missing-qa-user')).toBe('profile-miss');
+  });
+
+  it('treats invalid or reserved single-segment paths as generic misses', () => {
+    expect(resolveNotFoundVariant('/ab')).toBe('generic');
+    expect(resolveNotFoundVariant('/register')).toBe('generic');
+    expect(resolveNotFoundVariant('/artist-profiles')).toBe('generic');
+    expect(resolveNotFoundVariant('/pricing')).toBe('generic');
+  });
+
+  it('treats multi-segment paths as generic misses', () => {
+    expect(resolveNotFoundVariant('/timwhite/missing-release')).toBe('generic');
+    expect(resolveNotFoundVariant('/timwhite/extra/deep/path')).toBe('generic');
+  });
+});
+
+describe('getNotFoundCopy', () => {
+  it('returns profile-specific copy for profile misses', () => {
+    expect(getNotFoundCopy('profile-miss')).toEqual(
+      NOT_FOUND_COPY['profile-miss']
+    );
+    expect(getNotFoundCopy('profile-miss').title).toBe('Profile not found');
+    expect(getNotFoundCopy('profile-miss').description).toContain(
+      "doesn't exist"
+    );
+  });
+
+  it('returns generic copy for non-profile misses', () => {
+    expect(getNotFoundCopy('generic')).toEqual(NOT_FOUND_COPY.generic);
+    expect(getNotFoundCopy('generic').title).toBe("We can't find that page.");
+  });
+});


### PR DESCRIPTION
## Summary
Fix 404 dead ends: profile-specific copy only for username misses; generic not-found elsewhere with home/search CTAs.

## Linear
- JOV-3091
<!-- linear-issue-id:JOV-3091 -->

## Changes
- Context-aware not-found routing
- Remove raw link ID rendering
- Add Go home + Search artists CTAs

## Verification
- typecheck passed
- biome passed
- vitest passed (if tests added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added context-aware 404 pages with distinct messaging for missing profiles versus other pages.
  * Added "Search artists" navigation link on 404 pages.

* **Bug Fixes**
  * Fixed improper redirects on unknown profile paths; now displays proper 404 pages.

* **Style**
  * Enhanced 404 page design with improved button layouts and hover states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->