### PR TITLE
fix(settings): align billing page copy with Stripe-only action (JOV-3092)

### DIFF
--- a/apps/web/app/app/(shell)/settings/billing/loading.tsx
+++ b/apps/web/app/app/(shell)/settings/billing/loading.tsx
@@ -10,10 +10,10 @@ export default function SettingsBillingLoading() {
           {/* Static heading — visible immediately */}
           <div className='mb-6 space-y-2'>
             <h2 className='text-lg font-semibold tracking-tight text-primary-token'>
-              Billing &amp; Subscription
+              Billing
             </h2>
             <p className='text-sm text-secondary-token'>
-              Plan, payment methods, and invoices.
+              Current plan status only; billing details open outside this page.
             </p>
           </div>
 

--- a/apps/web/app/app/(shell)/settings/billing/page.tsx
+++ b/apps/web/app/app/(shell)/settings/billing/page.tsx
@@ -8,7 +8,7 @@ export default function SettingsBillingPage() {
     <SettingsSection
       id='billing'
       title='Billing'
-      description='Plan, payment methods, and invoices.'
+      description='Current plan status only; billing details open outside this page.'
     >
       <SettingsBillingSection />
     </SettingsSection>

--- a/apps/web/components/features/dashboard/organisms/SettingsBillingSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsBillingSection.tsx
@@ -52,7 +52,7 @@ function resolveSummaryDescription(ctx: {
   if (ctx.billingLoading)
     return 'Checking your subscription and billing access.';
   if (ctx.isPro)
-    return 'Manage invoices, payment methods, and subscription details without leaving the app.';
+    return 'Open Stripe to manage invoices, payment methods, and subscription details.';
   if (ctx.canOpenPortal)
     return 'Open Stripe to review invoices, payment details, or reactivate your plan.';
   return 'Compare plans and upgrade when you are ready.';

--- a/apps/web/tests/unit/settings/SettingsBillingSection.test.tsx
+++ b/apps/web/tests/unit/settings/SettingsBillingSection.test.tsx
@@ -72,7 +72,7 @@ describe('SettingsBillingSection', () => {
     expect(screen.getByText('Active')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Manage invoices, payment methods, and subscription details without leaving the app.'
+        'Open Stripe to manage invoices, payment methods, and subscription details.'
       )
     ).toBeInTheDocument();
     expect(


### PR DESCRIPTION
## Summary

Aligns billing settings page copy with the page's actual behavior: a stub that shows plan status and routes to Stripe or plan comparison — not inline invoices or payment methods.

## Changes

- **Page header**: Replaces "Plan, payment methods, and invoices." with honest stub copy about what's shown vs. external billing
- **Loading state**: Aligns title ("Billing") and description with the page
- **Pro plan summary**: Replaces "without leaving the app" with "Open Stripe to manage…" to match the "Manage in Stripe" action

## Linear

<!-- linear-issue-id:JOV-3092 -->

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `biome check` on changed files
- [x] `vitest run tests/unit/settings/SettingsBillingSection.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refined billing settings page messaging to clarify current plan status display only
  * Updated copy to direct users to Stripe portal for managing invoices, payment methods, and subscription details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->