### PR TITLE
perf(auth): dedupe redundant per-request work in proxy hot path (JOV-3232)

### DIFF
--- a/apps/web/lib/auth/staging-clerk-keys.ts
+++ b/apps/web/lib/auth/staging-clerk-keys.ts
@@ -34,11 +34,28 @@ function runtimePublicEnv(key: string): string | undefined {
 }
 
 /**
+ * Module-scope memoization cache for resolveClerkKeys.
+ *
+ * Env vars are fixed at container start — caching avoids repeated env reads
+ * on every middleware invocation (3-4× per request).
+ *
+ * SAFETY: only entries with BOTH keys present (status === 'ok') are stored.
+ * Incomplete / degraded statuses ('staging_missing', 'staging_inherits_prod',
+ * 'no_publishable_key', 'missing') are returned directly and never stored, so
+ * a transient env-miss on a cold start cannot be pinned for the worker lifetime.
+ *
+ * Exported for test teardown only. Do not call from production code.
+ */
+export const _resolveClerkKeysCache = new Map<string, ClerkKeys>();
+
+/**
  * Resolve Clerk keys for a given hostname.
  * Returns staging keys when on a staging host and staging keys are configured.
  * Staging must never silently fall back to production keys.
  */
 export function resolveClerkKeys(hostname: string): ClerkKeys {
+  const cached = _resolveClerkKeysCache.get(hostname);
+  if (cached) return cached;
   if (isStagingHost(hostname)) {
     const explicitPk = process.env.CLERK_PUBLISHABLE_KEY_STAGING;
     const explicitSk = process.env.CLERK_SECRET_KEY_STAGING;
@@ -52,11 +69,13 @@ export function resolveClerkKeys(hostname: string): ClerkKeys {
           status: 'staging_missing',
         };
       }
-      return {
+      const result: ClerkKeys = {
         publishableKey: explicitPk,
         secretKey: explicitSk,
         status: 'ok',
       };
+      _resolveClerkKeysCache.set(hostname, result);
+      return result;
     }
 
     // No _STAGING vars at all: fall back to the standard env vars read at
@@ -85,19 +104,26 @@ export function resolveClerkKeys(hostname: string): ClerkKeys {
         status: 'staging_inherits_prod',
       };
     }
-    return {
+    const stagingResult: ClerkKeys = {
       publishableKey: runtimePk,
       secretKey: runtimeSk,
       status: 'ok',
     };
+    _resolveClerkKeysCache.set(hostname, stagingResult);
+    return stagingResult;
   }
 
   const publishableKey = publicEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
   const secretKey = process.env.CLERK_SECRET_KEY || undefined;
+  if (publishableKey && secretKey) {
+    const prodResult: ClerkKeys = { publishableKey, secretKey, status: 'ok' };
+    _resolveClerkKeysCache.set(hostname, prodResult);
+    return prodResult;
+  }
   return {
     publishableKey,
     secretKey,
-    status: publishableKey && secretKey ? 'ok' : 'no_publishable_key',
+    status: 'no_publishable_key',
   };
 }
 

--- a/apps/web/lib/auth/staging-clerk-keys.ts
+++ b/apps/web/lib/auth/staging-clerk-keys.ts
@@ -44,9 +44,28 @@ function runtimePublicEnv(key: string): string | undefined {
  * 'no_publishable_key', 'missing') are returned directly and never stored, so
  * a transient env-miss on a cold start cannot be pinned for the worker lifetime.
  *
+ * BOUNDED: capped at 50 entries with FIFO eviction. Real hostnames are few
+ * (jov.ie, staging.jov.ie, localhost, preview URLs), but `hostname` derives
+ * from the attacker-controllable Host header — the cap defends against a
+ * scanner spraying unique Host values that would otherwise grow the Map until
+ * the worker OOMs.
+ *
  * Exported for test teardown only. Do not call from production code.
  */
+const RESOLVE_CLERK_KEYS_CACHE_MAX = 50;
 export const _resolveClerkKeysCache = new Map<string, ClerkKeys>();
+
+/**
+ * Store a resolved key set with FIFO eviction so the cache stays bounded.
+ * Only called for status:'ok' results (both keys present).
+ */
+function cacheClerkKeys(hostname: string, result: ClerkKeys): void {
+  if (_resolveClerkKeysCache.size >= RESOLVE_CLERK_KEYS_CACHE_MAX) {
+    const firstKey = _resolveClerkKeysCache.keys().next().value;
+    if (firstKey !== undefined) _resolveClerkKeysCache.delete(firstKey);
+  }
+  _resolveClerkKeysCache.set(hostname, result);
+}
 
 /**
  * Resolve Clerk keys for a given hostname.
@@ -74,7 +93,7 @@ export function resolveClerkKeys(hostname: string): ClerkKeys {
         secretKey: explicitSk,
         status: 'ok',
       };
-      _resolveClerkKeysCache.set(hostname, result);
+      cacheClerkKeys(hostname, result);
       return result;
     }
 
@@ -109,7 +128,7 @@ export function resolveClerkKeys(hostname: string): ClerkKeys {
       secretKey: runtimeSk,
       status: 'ok',
     };
-    _resolveClerkKeysCache.set(hostname, stagingResult);
+    cacheClerkKeys(hostname, stagingResult);
     return stagingResult;
   }
 
@@ -117,7 +136,7 @@ export function resolveClerkKeys(hostname: string): ClerkKeys {
   const secretKey = process.env.CLERK_SECRET_KEY || undefined;
   if (publishableKey && secretKey) {
     const prodResult: ClerkKeys = { publishableKey, secretKey, status: 'ok' };
-    _resolveClerkKeysCache.set(hostname, prodResult);
+    cacheClerkKeys(hostname, prodResult);
     return prodResult;
   }
   return {

--- a/apps/web/lib/routing/proxy-routing.ts
+++ b/apps/web/lib/routing/proxy-routing.ts
@@ -139,11 +139,25 @@ export function isProxyRewriteExempt(pathname: string): boolean {
 }
 
 /**
+ * Module-scope cache for categorizePath results.
+ *
+ * Bounded to 1000 entries with FIFO eviction (usernames are unbounded so an
+ * unguarded Map would grow without limit).  The returned PathCategory object
+ * is treated as immutable by all callers — the only spread site
+ * (clerk-middleware-bypass.ts) produces a new object from the spread, so
+ * sharing the cached reference is safe.
+ */
+const CATEGORIZE_PATH_CACHE_MAX = 1000;
+const categorizePathCache = new Map<string, PathCategory>();
+
+/**
  * Categorize a pathname once for all routing decisions.
  * Eliminates redundant path matching throughout the middleware.
  * Now also owns public-profile candidate detection (derived from APP_ROUTES).
  */
 export function categorizePath(pathname: string): PathCategory {
+  const cached = categorizePathCache.get(pathname);
+  if (cached) return cached;
   const isAuthPath =
     pathname === APP_ROUTES.SIGNIN ||
     pathname === APP_ROUTES.SIGNIN_HYPHEN ||
@@ -186,7 +200,7 @@ export function categorizePath(pathname: string): PathCategory {
 
   const publicProfileCandidate = getPublicProfileCandidate(pathname);
 
-  return {
+  const result: PathCategory = {
     needsNonce,
     isProtectedPath,
     isAuthPath,
@@ -194,7 +208,25 @@ export function categorizePath(pathname: string): PathCategory {
     isSensitiveAPI: pathname.startsWith('/api/link/'),
     publicProfileCandidate,
   };
+
+  if (categorizePathCache.size >= CATEGORIZE_PATH_CACHE_MAX) {
+    // FIFO eviction: remove the oldest entry
+    const firstKey = categorizePathCache.keys().next().value;
+    if (firstKey !== undefined) categorizePathCache.delete(firstKey);
+  }
+  categorizePathCache.set(pathname, result);
+  return result;
 }
+
+/**
+ * Module-scope cache for analyzeHost results.
+ *
+ * Capped at 50 entries: the set of real hostnames (jov.ie, staging.jov.ie,
+ * localhost, Vercel preview URLs) is small and bounded in practice.
+ * FIFO eviction prevents unbounded growth from fuzz/scan traffic.
+ */
+const ANALYZE_HOST_CACHE_MAX = 50;
+const analyzeHostCache = new Map<string, HostInfo>();
 
 /**
  * Analyze hostname once for all routing decisions.
@@ -202,13 +234,15 @@ export function categorizePath(pathname: string): PathCategory {
  * Investor portal: /investor-portal (path-based, bypasses Clerk auth)
  */
 export function analyzeHost(hostname: string): HostInfo {
+  const cached = analyzeHostCache.get(hostname);
+  if (cached) return cached;
   const isDevOrPreview =
     hostname === 'localhost' ||
     hostname === '127.0.0.1' ||
     hostname.includes('vercel.app') ||
     STAGING_HOSTNAMES.has(hostname);
 
-  return {
+  const result: HostInfo = {
     isDevOrPreview,
     isMainHost:
       hostname === HOSTNAME ||
@@ -220,6 +254,14 @@ export function analyzeHost(hostname: string): HostInfo {
     isSupportHost: hostname === `support.${HOSTNAME}`,
     isInvestorPortal: INVESTOR_HOSTNAMES.has(hostname),
   };
+
+  if (analyzeHostCache.size >= ANALYZE_HOST_CACHE_MAX) {
+    // FIFO eviction: remove the oldest entry
+    const firstKey = analyzeHostCache.keys().next().value;
+    if (firstKey !== undefined) analyzeHostCache.delete(firstKey);
+  }
+  analyzeHostCache.set(hostname, result);
+  return result;
 }
 
 /** Dashboard is always at /app in single-domain architecture */

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -584,31 +584,6 @@ async function handleRequest(req: NextRequest, userId: string | null) {
   }
 }
 
-/**
- * Build the final response with CSP headers and cookies.
- * The nonce is pre-generated and set on request headers for Server Components.
- * Here we set it on response headers for the CSP policy.
- */
-
-function _getGeoFromRequest(req: NextRequest): {
-  city: string | null;
-  region: string | null;
-} {
-  const geoRequest = req as NextRequest & {
-    geo?: { city?: string | null; region?: string | null };
-  };
-
-  const rawCity = req.headers.get('x-vercel-ip-city')?.trim() ?? null;
-  const cityFromHeader = rawCity ? decodeURIComponent(rawCity) : null;
-  const regionFromHeader =
-    req.headers.get('x-vercel-ip-country-region')?.trim() ?? null;
-
-  return {
-    city: cityFromHeader || geoRequest.geo?.city?.trim() || null,
-    region: regionFromHeader || geoRequest.geo?.region?.trim() || null,
-  };
-}
-
 // Production Clerk middleware (default keys from env)
 const clerkProductionMiddleware = clerkMiddleware(async (auth, req) => {
   const { userId } = await auth();

--- a/apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts
+++ b/apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts
@@ -7,6 +7,7 @@ vi.mock('next/headers', () => ({
 }));
 
 import {
+  _resolveClerkKeysCache,
   resolveClerkKeys,
   resolvePublishableKeyFromHeaders,
   resolvePublishableKeyStaticFirst,
@@ -22,6 +23,7 @@ const ORIGINAL_ENV = {
 describe('staging Clerk key resolution', () => {
   beforeEach(() => {
     headersMock.mockReset();
+    _resolveClerkKeysCache.clear();
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
       'pk_live_production_example';
     process.env.CLERK_SECRET_KEY = 'sk_live_production_example';
@@ -215,6 +217,7 @@ describe('resolvePublishableKeyStaticFirst', () => {
 
   beforeEach(() => {
     headersMock.mockReset();
+    _resolveClerkKeysCache.clear();
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
       'pk_live_production_example';
     process.env.CLERK_SECRET_KEY = 'sk_live_production_example';


### PR DESCRIPTION
<!-- linear-issue-id: JOV-3232 -->

## Summary
Behavior-preserving cleanup of the proxy middleware hot path: removes dead code and memoizes pure helpers that were recomputed multiple times per request.

## Changes
- **Removed dead `_getGeoFromRequest`** from `proxy.ts` (L593-610). Zero callers confirmed via `grep -rn`. The live version `getGeoFromRequest` remains in `final-response.ts`.
- **Memoized `resolveClerkKeys(hostname)`** in `staging-clerk-keys.ts` with a module-scope `Map<string, ClerkKeys>`. Cold-start safe: only entries with `status: 'ok'` (both keys present) are stored — degraded/partial results (`staging_missing`, `staging_inherits_prod`, `no_publishable_key`) are returned directly, so a transient env-miss at cold start cannot be pinned for the worker lifetime. Cache exported as `_resolveClerkKeysCache` for test teardown. Staging-clerk-keys test updated to call `_resolveClerkKeysCache.clear()` in `beforeEach` of both describe blocks to preserve full test isolation.
- **Memoized `analyzeHost(hostname)`** with a bounded Map (cap 50, FIFO eviction) — hostname set is small and bounded in practice.
- **Memoized `categorizePath(pathname)`** with a bounded Map (cap 1000, FIFO eviction) — usernames are unbounded, so FIFO prevents growth from scan traffic. Callers treat the returned `PathCategory` as immutable; the one spread site in `clerk-middleware-bypass.ts` produces a new object, making shared references safe.
- **Item 4 deferred**: `getCspReportUri()` deduplication at the `final-response.ts` call site. The `proxy-composition.critical.test.ts` and `proxy-behavioral.test.ts` files mock `getCspReportUri` via `vi.fn().mockReturnValue(null)` — a module-level const would evaluate to `null` at module init and work correctly for those tests, but the interaction with `vi.resetModules()` in `csp-reporting.test.ts` warrants a careful dedicated pass. Filed as JOV-3234.

## Cost Impact
None. No new external calls — reduces redundant per-request CPU only (env reads, string comparisons, regex matching).

## Test evidence
```
pnpm --filter web exec vitest run tests/unit/middleware/ tests/integration/middleware-proxy.test.ts tests/unit/lib/csp-reporting.test.ts tests/unit/lib/content-security-policy.test.ts tests/unit/lib/auth/proxy-state.test.ts lib/security/probe-detection.test.ts

Test Files  9 passed (9)
     Tests  240 passed (240)
  Duration  1.92s

staging-clerk-keys.test.ts: 18 passed (18)
```

TypeScript: `tsc -p apps/web/tsconfig.typecheck.json --noEmit --pretty false` — exit 0, zero errors.
Biome: `pnpm biome check --write <edited files>` — "Checked 5 files in 25ms. No fixes applied."
Pre-push hooks (biome, eslint, typecheck, proxy-guard): all passed.

No behavior change; middleware + CSP suites green.