### PR TITLE
feat(ios): App Intents foundation — Siri/Shortcuts/Spotlight (JOV-2916)

### DIFF
--- a/apps/ios/Jovie.xcodeproj/project.pbxproj
+++ b/apps/ios/Jovie.xcodeproj/project.pbxproj
@@ -13,16 +13,18 @@
 		2C6C36E98540C94E3F1EF74A /* Configuration.local.plist in Resources */ = {isa = PBXBuildFile; fileRef = D24EEA621BFC0D5C4F57065C /* Configuration.local.plist */; };
 		3397C6D45B48BBDAF736A405 /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71290AE6A5F14D6941193B70 /* AppRouter.swift */; };
 		33F1DF8D4B8D292316335711 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FDEFEB6D7C1D0251FDA1E61 /* Foundation.framework */; };
-		D7BCD277F96E47648D68C062 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B53DAA4BCC9D40A3A2C1552B /* PrivacyInfo.xcprivacy */; };
-		5F4F3551CC9F4C09A2520AEB /* AppShellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2C97BF3A0B42C58A62529F /* AppShellView.swift */; };
 		4C46B1496145C062FB2FE978 /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0199C257CC5EA4F6FD36397D /* ClerkKit */; };
 		4CA1C477ECC6B7B40EA17787 /* LaunchMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD30F57584F71E958D8C0514 /* LaunchMode.swift */; };
 		52C5CBF9C24E4C502FA64955 /* MobileMeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2367922F1F00AB0AF1164 /* MobileMeResponse.swift */; };
+		5E40E80F8AFF20CF3CE9A09B /* IntentNavigationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F157EB66EC5E06F7EE8974 /* IntentNavigationStore.swift */; };
+		5F4F3551CC9F4C09A2520AEB /* AppShellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2C97BF3A0B42C58A62529F /* AppShellView.swift */; };
 		61A81E78D0B448B6A68F45AD /* MobileAuthReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EBA07D5CBE04B0BBF053706 /* MobileAuthReturn.swift */; };
 		6853DA69F7459FE14462F48F /* Jovie-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 969C5D08D3E71A2D9824375A /* Jovie-logo.png */; };
 		6E62396A29D88F275920CA48 /* JovieTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E6B0F83EC74031D75DCFB /* JovieTheme.swift */; };
 		70003B11B0FA1692B2017553 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FDEFEB6D7C1D0251FDA1E61 /* Foundation.framework */; };
+		71B98E46403E1759256C61A5 /* IntentNavigationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5615484B29C6B6E26EE5E92B /* IntentNavigationStoreTests.swift */; };
 		74E75D0A3C816805F65FA48A /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E33DCDBD6A55190F563B419C /* DashboardView.swift */; };
+		7F479BE5BDDDDCF9BFFF256B /* JovieAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A40F1B3BFCC6AD8FF8EAF93 /* JovieAppIntents.swift */; };
 		8747690FEEF7BD069EBF7430 /* MeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FBA9F0D12E0BD1CB8B0B09 /* MeRepository.swift */; };
 		89B2D98342D65781B5E80A72 /* JovieApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BCF42EFB99B5DAB4E0F400 /* JovieApp.swift */; };
 		964DEFE0F4D4206832B6888E /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969DB5F8041C9A004CDB5234 /* RootView.swift */; };
@@ -35,6 +37,15 @@
 		A0B10F00000000000000000F /* ObservabilityRedactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B10F00000000000000000D /* ObservabilityRedactionTests.swift */; };
 		A0B10F000000000000000012 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A0B10F000000000000000011 /* Sentry */; };
 		A0B10F000000000000000020 /* AuthScreenStyleGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B10F000000000000000021 /* AuthScreenStyleGuardTests.swift */; };
+		A0J0V25490000000000000002 /* ChatCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000001 /* ChatCache.swift */; };
+		A0J0V25490000000000000004 /* ChatRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000003 /* ChatRepository.swift */; };
+		A0J0V25490000000000000006 /* MobileChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000005 /* MobileChatClient.swift */; };
+		A0J0V25490000000000000008 /* MobileChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000007 /* MobileChatModels.swift */; };
+		A0J0V2549000000000000000A /* MobileChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000009 /* MobileChatView.swift */; };
+		A0J0V2549000000000000000C /* ChatRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V2549000000000000000B /* ChatRepositoryTests.swift */; };
+		A0J0V2549000000000000000E /* MobileChatClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V2549000000000000000D /* MobileChatClientTests.swift */; };
+		A0J0V26350000000000000002 /* MobileAuthFinalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V26350000000000000001 /* MobileAuthFinalization.swift */; };
+		A0J0V26350000000000000004 /* MobileAuthFinalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V26350000000000000003 /* MobileAuthFinalizationTests.swift */; };
 		A13F86A7D4F0C7F83D2BB000 /* ScreenBrightnessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA81B967152B211E5988375 /* ScreenBrightnessManager.swift */; };
 		ADC14533827EFD888D1ED50F /* QRCodeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000F426E1AB94DD5401C3341 /* QRCodeRenderer.swift */; };
 		B0B0995CD42EDBEAFBAABE04 /* JovieUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611EE527D20DC6F6872CBF33 /* JovieUITests.swift */; };
@@ -43,28 +54,21 @@
 		C2C8C16A08954501FB61E562 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8753F36E077F69D925EE26 /* APIClientTests.swift */; };
 		CE7C4C47EFA23AFA2B205BE4 /* MobileMeResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B83A77F0A36DF3E6D5C77C2F /* MobileMeResponseTests.swift */; };
 		D179CCF9F0BD00565174ACF6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FDEFEB6D7C1D0251FDA1E61 /* Foundation.framework */; };
+		D7BCD277F96E47648D68C062 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B53DAA4BCC9D40A3A2C1552B /* PrivacyInfo.xcprivacy */; };
 		D9CF5232BCCF1F895975D7B7 /* ClerkTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CC57081FA315DA3E260B77 /* ClerkTokenProvider.swift */; };
 		DA0F3A9E1C4B4B149B7D4C21 /* NativeSessionTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B3D151E21A49C2876932A8 /* NativeSessionTokenStore.swift */; };
-		A0J0V26350000000000000002 /* MobileAuthFinalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V26350000000000000001 /* MobileAuthFinalization.swift */; };
-		A0J0V26350000000000000004 /* MobileAuthFinalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V26350000000000000003 /* MobileAuthFinalizationTests.swift */; };
 		DA762182661489283A851F6B /* ScreenBrightnessManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178C37B20F46EAF919EB2031 /* ScreenBrightnessManagerTests.swift */; };
 		E26FB0F0CBAA2DE24B6BC572 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9924B177AFB753A4C23A4098 /* APIClient.swift */; };
 		E6EA9EC85A52208BEFC20DF0 /* ClerkKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = 37321F1DC431FDA58D969E72 /* ClerkKitUI */; };
 		EBDA8137B767F16402C41C24 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4EAFC467F76300BCFC2659F /* Configuration.swift */; };
 		EE4CBA88057592FAFCD7F926 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93DB506915B418D06E897A4 /* AppStateTests.swift */; };
 		F178AB3E908746C78645E4EE /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E151E782B5462F89618579 /* SettingsView.swift */; };
+		F232904F618A4671B805D0BC /* JovieAppIntentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4562819B40056163650929C /* JovieAppIntentsTests.swift */; };
 		F3E8220C7612A63FF54DB345 /* NeedsOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88FB8A38A81A1249F313D416 /* NeedsOnboardingView.swift */; };
 		F8BC948A5A68297B746E217F /* MeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918FBCBCF600AA8C10191F60 /* MeCache.swift */; };
 		F95545618F95E792DCBCA7DF /* AuthScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFB0D6D1DA6A287207AC1A6 /* AuthScreen.swift */; };
 		FA8D45F4123178BDD33F82C5 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D156B3220339CAB0DBE1DD /* SplashView.swift */; };
 		FDD930D67ACF374B16E87FDE /* MeRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191669F70597A1039C74C0B1 /* MeRepositoryTests.swift */; };
-		A0J0V25490000000000000002 /* ChatCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000001 /* ChatCache.swift */; };
-		A0J0V25490000000000000004 /* ChatRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000003 /* ChatRepository.swift */; };
-		A0J0V25490000000000000006 /* MobileChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000005 /* MobileChatClient.swift */; };
-		A0J0V25490000000000000008 /* MobileChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000007 /* MobileChatModels.swift */; };
-		A0J0V2549000000000000000A /* MobileChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000009 /* MobileChatView.swift */; };
-		A0J0V2549000000000000000C /* ChatRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V2549000000000000000B /* ChatRepositoryTests.swift */; };
-		A0J0V2549000000000000000E /* MobileChatClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V2549000000000000000D /* MobileChatClientTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,27 +91,24 @@
 /* Begin PBXFileReference section */
 		000F426E1AB94DD5401C3341 /* QRCodeRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeRenderer.swift; sourceTree = "<group>"; };
 		00BCF42EFB99B5DAB4E0F400 /* JovieApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JovieApp.swift; sourceTree = "<group>"; };
+		0A40F1B3BFCC6AD8FF8EAF93 /* JovieAppIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JovieAppIntents.swift; sourceTree = "<group>"; };
 		178C37B20F46EAF919EB2031 /* ScreenBrightnessManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScreenBrightnessManagerTests.swift; sourceTree = "<group>"; };
 		191669F70597A1039C74C0B1 /* MeRepositoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeRepositoryTests.swift; sourceTree = "<group>"; };
-		A0J0V25490000000000000001 /* ChatCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatCache.swift; sourceTree = "<group>"; };
-		A0J0V25490000000000000003 /* ChatRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatRepository.swift; sourceTree = "<group>"; };
-		A0J0V25490000000000000005 /* MobileChatClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatClient.swift; sourceTree = "<group>"; };
-		A0J0V25490000000000000007 /* MobileChatModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatModels.swift; sourceTree = "<group>"; };
-		A0J0V25490000000000000009 /* MobileChatView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatView.swift; sourceTree = "<group>"; };
-		A0J0V2549000000000000000B /* ChatRepositoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatRepositoryTests.swift; sourceTree = "<group>"; };
-		A0J0V2549000000000000000D /* MobileChatClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatClientTests.swift; sourceTree = "<group>"; };
+		26F157EB66EC5E06F7EE8974 /* IntentNavigationStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntentNavigationStore.swift; sourceTree = "<group>"; };
 		28FBA9F0D12E0BD1CB8B0B09 /* MeRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeRepository.swift; sourceTree = "<group>"; };
 		2E13A897DB2C3D06E845EC58 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2EBA07D5CBE04B0BBF053706 /* MobileAuthReturn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileAuthReturn.swift; sourceTree = "<group>"; };
+		35E151E782B5462F89618579 /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		3EC2367922F1F00AB0AF1164 /* MobileMeResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileMeResponse.swift; sourceTree = "<group>"; };
 		3FA81B967152B211E5988375 /* ScreenBrightnessManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScreenBrightnessManager.swift; sourceTree = "<group>"; };
-		44B3D151E21A49C2876932A8 /* NativeSessionTokenStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NativeSessionTokenStore.swift; sourceTree = "<group>"; };
 		448ADF9C21BB11784C6AD119 /* QRCodeRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeRendererTests.swift; sourceTree = "<group>"; };
+		44B3D151E21A49C2876932A8 /* NativeSessionTokenStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NativeSessionTokenStore.swift; sourceTree = "<group>"; };
 		47976CA8BC5B309FDB2B6215 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		4C8753F36E077F69D925EE26 /* APIClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		4C2C97BF3A0B42C58A62529F /* AppShellView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellView.swift; sourceTree = "<group>"; };
+		4C8753F36E077F69D925EE26 /* APIClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		535ED5D3D849F7B0F9DBB0E9 /* Jovie.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = Jovie.entitlements; sourceTree = "<group>"; };
 		549B9163EF50F377CA1A4C5B /* JovieTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JovieTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5615484B29C6B6E26EE5E92B /* IntentNavigationStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntentNavigationStoreTests.swift; sourceTree = "<group>"; };
 		611EE527D20DC6F6872CBF33 /* JovieUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JovieUITests.swift; sourceTree = "<group>"; };
 		6FDEFEB6D7C1D0251FDA1E61 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		71290AE6A5F14D6941193B70 /* AppRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
@@ -121,7 +122,6 @@
 		989D4251AFCEB0A633337F2C /* JovieUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JovieUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		98CC57081FA315DA3E260B77 /* ClerkTokenProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClerkTokenProvider.swift; sourceTree = "<group>"; };
 		9924B177AFB753A4C23A4098 /* APIClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
-		A108B03BA602F4C24B54E590 /* Inter-Variable.ttf */ = {isa = PBXFileReference; includeInIndex = 1; path = "Inter-Variable.ttf"; sourceTree = "<group>"; };
 		A0B10F000000000000000001 /* ObservabilityTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ObservabilityTypes.swift; sourceTree = "<group>"; };
 		A0B10F000000000000000002 /* NoopObservabilityProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NoopObservabilityProvider.swift; sourceTree = "<group>"; };
 		A0B10F000000000000000003 /* ObservabilityRedactor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ObservabilityRedactor.swift; sourceTree = "<group>"; };
@@ -130,19 +130,27 @@
 		A0B10F00000000000000000C /* ObservabilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ObservabilityTests.swift; sourceTree = "<group>"; };
 		A0B10F00000000000000000D /* ObservabilityRedactionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ObservabilityRedactionTests.swift; sourceTree = "<group>"; };
 		A0B10F000000000000000021 /* AuthScreenStyleGuardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthScreenStyleGuardTests.swift; sourceTree = "<group>"; };
+		A0J0V25490000000000000001 /* ChatCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatCache.swift; sourceTree = "<group>"; };
+		A0J0V25490000000000000003 /* ChatRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatRepository.swift; sourceTree = "<group>"; };
+		A0J0V25490000000000000005 /* MobileChatClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatClient.swift; sourceTree = "<group>"; };
+		A0J0V25490000000000000007 /* MobileChatModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatModels.swift; sourceTree = "<group>"; };
+		A0J0V25490000000000000009 /* MobileChatView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatView.swift; sourceTree = "<group>"; };
+		A0J0V2549000000000000000B /* ChatRepositoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatRepositoryTests.swift; sourceTree = "<group>"; };
+		A0J0V2549000000000000000D /* MobileChatClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatClientTests.swift; sourceTree = "<group>"; };
 		A0J0V26350000000000000001 /* MobileAuthFinalization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileAuthFinalization.swift; sourceTree = "<group>"; };
 		A0J0V26350000000000000003 /* MobileAuthFinalizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileAuthFinalizationTests.swift; sourceTree = "<group>"; };
+		A108B03BA602F4C24B54E590 /* Inter-Variable.ttf */ = {isa = PBXFileReference; includeInIndex = 1; path = "Inter-Variable.ttf"; sourceTree = "<group>"; };
 		A93DB506915B418D06E897A4 /* AppStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		B4D156B3220339CAB0DBE1DD /* SplashView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
-		B83A77F0A36DF3E6D5C77C2F /* MobileMeResponseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileMeResponseTests.swift; sourceTree = "<group>"; };
-		35E151E782B5462F89618579 /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B53DAA4BCC9D40A3A2C1552B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		B83A77F0A36DF3E6D5C77C2F /* MobileMeResponseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileMeResponseTests.swift; sourceTree = "<group>"; };
 		D03E6B0F83EC74031D75DCFB /* JovieTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JovieTheme.swift; sourceTree = "<group>"; };
-		DD30F57584F71E958D8C0514 /* LaunchMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LaunchMode.swift; sourceTree = "<group>"; };
 		D24EEA621BFC0D5C4F57065C /* Configuration.local.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Configuration.local.plist; sourceTree = "<group>"; };
+		DD30F57584F71E958D8C0514 /* LaunchMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LaunchMode.swift; sourceTree = "<group>"; };
 		E33DCDBD6A55190F563B419C /* DashboardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		E4EAFC467F76300BCFC2659F /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		EDFB0D6D1DA6A287207AC1A6 /* AuthScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthScreen.swift; sourceTree = "<group>"; };
+		F4562819B40056163650929C /* JovieAppIntentsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JovieAppIntentsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -207,15 +215,6 @@
 			path = JovieUITests;
 			sourceTree = "<group>";
 		};
-		A0J0V25490000000000000010 /* Chat */ = {
-			isa = PBXGroup;
-			children = (
-				A0J0V25490000000000000009 /* MobileChatView.swift */,
-			);
-			name = Chat;
-			path = Chat;
-			sourceTree = "<group>";
-		};
 		38A521B77CFB8C49A552F2BF /* Features */ = {
 			isa = PBXGroup;
 			children = (
@@ -226,6 +225,7 @@
 				3BE73A70044C889546FD4A64 /* NeedsOnboarding */,
 				876FD84B7A3B40CAA0DDDBC8 /* Settings */,
 				D8C70D614390928784D627FC /* Splash */,
+				4F75D6D1A88984CBC96C6702 /* Intents */,
 			);
 			name = Features;
 			path = Features;
@@ -246,6 +246,8 @@
 				448ADF9C21BB11784C6AD119 /* QRCodeRendererTests.swift */,
 				178C37B20F46EAF919EB2031 /* ScreenBrightnessManagerTests.swift */,
 				A0J0V26350000000000000003 /* MobileAuthFinalizationTests.swift */,
+				5615484B29C6B6E26EE5E92B /* IntentNavigationStoreTests.swift */,
+				F4562819B40056163650929C /* JovieAppIntentsTests.swift */,
 			);
 			name = JovieTests;
 			path = JovieTests;
@@ -260,6 +262,14 @@
 			path = NeedsOnboarding;
 			sourceTree = "<group>";
 		};
+		447FB872611F29AB452FBAFB /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				6FDEFEB6D7C1D0251FDA1E61 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
 		44CFD0078FC64A56A527EB88 /* AppShell */ = {
 			isa = PBXGroup;
 			children = (
@@ -267,14 +277,6 @@
 			);
 			name = AppShell;
 			path = AppShell;
-			sourceTree = "<group>";
-		};
-		447FB872611F29AB452FBAFB /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				6FDEFEB6D7C1D0251FDA1E61 /* Foundation.framework */,
-			);
-			name = iOS;
 			sourceTree = "<group>";
 		};
 		4A21A051CA70F90309561576 /* DesignSystem */ = {
@@ -293,6 +295,16 @@
 			);
 			name = Fonts;
 			path = Fonts;
+			sourceTree = "<group>";
+		};
+		4F75D6D1A88984CBC96C6702 /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				26F157EB66EC5E06F7EE8974 /* IntentNavigationStore.swift */,
+				0A40F1B3BFCC6AD8FF8EAF93 /* JovieAppIntents.swift */,
+			);
+			name = Intents;
+			path = Intents;
 			sourceTree = "<group>";
 		};
 		55D872945D057DBB23C014CF /* Products */ = {
@@ -353,16 +365,6 @@
 			path = Jovie;
 			sourceTree = "<group>";
 		};
-		A5A8CD9F74C3AE8AD7332D93 /* Dashboard */ = {
-			isa = PBXGroup;
-			children = (
-				E33DCDBD6A55190F563B419C /* DashboardView.swift */,
-				7DEB4AD6A6B0BBDE4A347E2D /* VenueModeView.swift */,
-			);
-			name = Dashboard;
-			path = Dashboard;
-			sourceTree = "<group>";
-		};
 		A0B10F00000000000000000B /* Observability */ = {
 			isa = PBXGroup;
 			children = (
@@ -374,6 +376,25 @@
 			);
 			name = Observability;
 			path = Observability;
+			sourceTree = "<group>";
+		};
+		A0J0V25490000000000000010 /* Chat */ = {
+			isa = PBXGroup;
+			children = (
+				A0J0V25490000000000000009 /* MobileChatView.swift */,
+			);
+			name = Chat;
+			path = Chat;
+			sourceTree = "<group>";
+		};
+		A5A8CD9F74C3AE8AD7332D93 /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				E33DCDBD6A55190F563B419C /* DashboardView.swift */,
+				7DEB4AD6A6B0BBDE4A347E2D /* VenueModeView.swift */,
+			);
+			name = Dashboard;
+			path = Dashboard;
 			sourceTree = "<group>";
 		};
 		CD1E4E5554DA1BC0E409C363 /* App */ = {
@@ -561,6 +582,8 @@
 				DA762182661489283A851F6B /* ScreenBrightnessManagerTests.swift in Sources */,
 				A0J0V26350000000000000004 /* MobileAuthFinalizationTests.swift in Sources */,
 				A0B10F000000000000000020 /* AuthScreenStyleGuardTests.swift in Sources */,
+				71B98E46403E1759256C61A5 /* IntentNavigationStoreTests.swift in Sources */,
+				F232904F618A4671B805D0BC /* JovieAppIntentsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -602,6 +625,8 @@
 				F178AB3E908746C78645E4EE /* SettingsView.swift in Sources */,
 				A0J0V2549000000000000000A /* MobileChatView.swift in Sources */,
 				FA8D45F4123178BDD33F82C5 /* SplashView.swift in Sources */,
+				5E40E80F8AFF20CF3CE9A09B /* IntentNavigationStore.swift in Sources */,
+				7F479BE5BDDDDCF9BFFF256B /* JovieAppIntents.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -636,9 +661,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CLERK_ASSOCIATED_DOMAIN = "distinct-giraffe-5.clerk.accounts.dev";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
+				CLERK_ASSOCIATED_DOMAIN = "distinct-giraffe-5.clerk.accounts.dev";
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_ENTITLEMENTS = Jovie/Jovie.entitlements;
@@ -668,9 +693,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CLERK_ASSOCIATED_DOMAIN = "distinct-giraffe-5.clerk.accounts.dev";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
+				CLERK_ASSOCIATED_DOMAIN = "distinct-giraffe-5.clerk.accounts.dev";
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_ENTITLEMENTS = Jovie/Jovie.entitlements;

--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -75,6 +75,7 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
   @State private var isShowingMenu = false
   @State private var didOpenLaunchSettings = false
   @State private var chatDraft = ""
+  @State private var intentStore = IntentNavigationStore.shared
 
   init(
     profile: AppShellProfile,
@@ -158,6 +159,31 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
       didOpenLaunchSettings = true
       await Task.yield()
       navigationPath.append(.settings)
+    }
+    .task {
+      applyPendingIntentNavigation()
+    }
+    .onChange(of: intentStore.pending) {
+      applyPendingIntentNavigation()
+    }
+  }
+
+  // Consume a navigation request raised by an App Intent (Siri / Shortcuts /
+  // Spotlight). Chat-bound requests land on Profile when chat is unavailable.
+  private func applyPendingIntentNavigation() {
+    guard let request = intentStore.consume() else { return }
+    guard chatEnabled else { return }
+
+    switch request {
+    case .openChat, .continueLastConversation:
+      withAnimation(.easeInOut(duration: 0.25)) {
+        selectedTab = .chat
+      }
+    case let .sendMessage(text):
+      chatDraft = text
+      withAnimation(.easeInOut(duration: 0.25)) {
+        selectedTab = .chat
+      }
     }
   }
 

--- a/apps/ios/Jovie/Features/Intents/IntentNavigationStore.swift
+++ b/apps/ios/Jovie/Features/Intents/IntentNavigationStore.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Observation
+
+/// A navigation request raised by an App Intent (Siri / Shortcuts / Spotlight).
+///
+/// Intents run in a separate execution context from the SwiftUI scene, so they
+/// cannot mutate the shell directly. They enqueue a request here; the running
+/// shell observes ``IntentNavigationStore/shared`` and consumes it when it can.
+enum IntentNavigationRequest: Equatable, Sendable {
+  /// Open the chat surface.
+  case openChat
+  /// Open chat and pre-fill the composer with the given text ("Ask Jovie …").
+  case sendMessage(String)
+  /// Open chat and resume the most recent conversation.
+  case continueLastConversation
+}
+
+@MainActor
+@Observable
+final class IntentNavigationStore {
+  static let shared = IntentNavigationStore()
+
+  /// The pending request, if any. Set by intents, cleared by ``consume()``.
+  private(set) var pending: IntentNavigationRequest?
+
+  init() {}
+
+  func submit(_ request: IntentNavigationRequest) {
+    pending = request
+  }
+
+  /// Returns and clears the pending request so it is applied exactly once.
+  @discardableResult
+  func consume() -> IntentNavigationRequest? {
+    let value = pending
+    pending = nil
+    return value
+  }
+}

--- a/apps/ios/Jovie/Features/Intents/JovieAppIntents.swift
+++ b/apps/ios/Jovie/Features/Intents/JovieAppIntents.swift
@@ -1,0 +1,84 @@
+import AppIntents
+
+// Modern App Intents (Shortcuts / Spotlight / Siri). These do NOT require the
+// legacy `com.apple.developer.siri` SiriKit entitlement — they are discovered by
+// the App Intents metadata processor at build time. Each intent opens the app and
+// enqueues a navigation request that the shell consumes.
+
+struct OpenChatIntent: AppIntent {
+  static let title: LocalizedStringResource = "Open Jovie Chat"
+  static let description = IntentDescription("Opens the Jovie chat.")
+  static let openAppWhenRun = true
+
+  @MainActor
+  func perform() async throws -> some IntentResult {
+    IntentNavigationStore.shared.submit(.openChat)
+    return .result()
+  }
+}
+
+struct SendMessageIntent: AppIntent {
+  static let title: LocalizedStringResource = "Ask Jovie"
+  static let description = IntentDescription(
+    "Opens Jovie chat with your message ready to send."
+  )
+  static let openAppWhenRun = true
+
+  @Parameter(
+    title: "Message",
+    requestValueDialog: "What do you want to ask Jovie?"
+  )
+  var message: String
+
+  @MainActor
+  func perform() async throws -> some IntentResult {
+    IntentNavigationStore.shared.submit(.sendMessage(message))
+    return .result()
+  }
+}
+
+struct ContinueLastConversationIntent: AppIntent {
+  static let title: LocalizedStringResource = "Continue Jovie Chat"
+  static let description = IntentDescription(
+    "Reopens your most recent Jovie conversation."
+  )
+  static let openAppWhenRun = true
+
+  @MainActor
+  func perform() async throws -> some IntentResult {
+    IntentNavigationStore.shared.submit(.continueLastConversation)
+    return .result()
+  }
+}
+
+struct JovieAppShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: OpenChatIntent(),
+      phrases: [
+        "Open \(.applicationName) chat",
+        "Open chat in \(.applicationName)",
+      ],
+      shortTitle: "Open Chat",
+      systemImageName: "bubble.left.and.bubble.right"
+    )
+    AppShortcut(
+      intent: SendMessageIntent(),
+      phrases: [
+        "Ask \(.applicationName)",
+        "Start a \(.applicationName) chat",
+      ],
+      shortTitle: "Ask Jovie",
+      systemImageName: "sparkles"
+    )
+    AppShortcut(
+      intent: ContinueLastConversationIntent(),
+      phrases: [
+        "Continue my \(.applicationName) chat",
+        "Resume \(.applicationName)",
+      ],
+      shortTitle: "Continue Chat",
+      systemImageName: "arrow.uturn.backward"
+    )
+  }
+}

--- a/apps/ios/JovieTests/IntentNavigationStoreTests.swift
+++ b/apps/ios/JovieTests/IntentNavigationStoreTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import Jovie
+
+@MainActor
+@Suite(.serialized)
+struct IntentNavigationStoreTests {
+  @Test func submitThenConsumeReturnsRequestOnce() {
+    let store = IntentNavigationStore()
+
+    #expect(store.consume() == nil)
+
+    store.submit(.openChat)
+    #expect(store.pending == .openChat)
+    #expect(store.consume() == .openChat)
+    #expect(store.consume() == nil)
+  }
+
+  @Test func latestSubmissionWins() {
+    let store = IntentNavigationStore()
+
+    store.submit(.openChat)
+    store.submit(.sendMessage("hi"))
+
+    #expect(store.consume() == .sendMessage("hi"))
+  }
+}

--- a/apps/ios/JovieTests/JovieAppIntentsTests.swift
+++ b/apps/ios/JovieTests/JovieAppIntentsTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import Jovie
+
+@MainActor
+@Suite(.serialized)
+struct JovieAppIntentsTests {
+  @Test func openChatIntentRequestsChat() async throws {
+    IntentNavigationStore.shared.consume()
+
+    _ = try await OpenChatIntent().perform()
+
+    #expect(IntentNavigationStore.shared.consume() == .openChat)
+  }
+
+  @Test func sendMessageIntentRequestsMessageText() async throws {
+    IntentNavigationStore.shared.consume()
+
+    let intent = SendMessageIntent()
+    intent.message = "launch my single"
+    _ = try await intent.perform()
+
+    #expect(
+      IntentNavigationStore.shared.consume() == .sendMessage("launch my single")
+    )
+  }
+
+  @Test func continueLastConversationIntentRequestsResume() async throws {
+    IntentNavigationStore.shared.consume()
+
+    _ = try await ContinueLastConversationIntent().perform()
+
+    #expect(
+      IntentNavigationStore.shared.consume() == .continueLastConversation
+    )
+  }
+}


### PR DESCRIPTION
<!-- linear-issue-id: JOV-2916 -->
Closes JOV-2916. **Stacked on #11002** (nav) → base retargets to main when that lands.

## What
Makes Jovie iOS invocable by **Siri, Shortcuts, and Spotlight** via the modern App Intents framework:
- `JovieAppShortcuts` (`AppShortcutsProvider`) exposing **OpenChatIntent**, **SendMessageIntent** ("Ask Jovie …"), **ContinueLastConversationIntent** with spoken phrases.
- `IntentNavigationStore` (`@Observable` singleton) — intents enqueue a request; the shell consumes it on appear/change, opening Chat and pre-filling the composer for sent messages. Respects the `chatEnabled` gate.

## Key decision: no entitlement/Info.plist/provisioning changes
Modern App Intents (Shortcuts/Spotlight/Siri-via-AppShortcuts) do **not** require the legacy `com.apple.developer.siri` SiriKit entitlement — so I deliberately skipped the entitlement + `NSSiriUsageDescription` the ticket mentioned, keeping TestFlight signing (match) untouched. Intents live in the app target; build-time `--validate-assistant-intents` passes.

## Verification (local, Xcode 26.3)
- `xcodebuild build` — BUILD SUCCEEDED; App Intents metadata extraction + validation pass.
- `JovieTests` — TEST SUCCEEDED on iPhone 16 Pro + iPhone 17, incl. new `IntentNavigationStoreTests` + `JovieAppIntentsTests` (intent.perform → correct navigation request).
- Full `ios-ci` runs on this PR.

## Follow-ups (filed separately)
- `NSUserActivity` donation on conversation-open for richer Spotlight/Siri suggestions, and the optional WidgetKit quick-compose widget (listed as optional in JOV-2916).
- `SendMessageIntent` currently pre-fills the composer; auto-send is a candidate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)