### PR TITLE
fix(auth): proxy hot-path bug-fix + perf dedupe (JOV-3231, JOV-3232)

### DIFF
--- a/apps/web/lib/audience/public-profile-block.ts
+++ b/apps/web/lib/audience/public-profile-block.ts
@@ -2,9 +2,15 @@ import 'server-only';
 
 import * as Sentry from '@sentry/nextjs';
 import { createFingerprintEdge } from '@/lib/audience/fingerprint';
+import { withTimeout } from '@/lib/db/query-timeout';
 import { env } from '@/lib/env-server';
 import { captureWarning } from '@/lib/error-tracking';
 import { getRedis } from '@/lib/redis';
+
+// Timeout for audience-block DB queries. Matches proxy-state.ts budget — kept
+// below the Neon p99 cold-start budget (~3 s) so a cache-miss does not stall
+// every visitor navigation for more than ~3 s. Fails open on timeout.
+const AUDIENCE_BLOCK_DB_QUERY_TIMEOUT_MS = 3000;
 
 /**
  * Mirror extractClientIP() priority for the middleware audience-block check.
@@ -219,7 +225,7 @@ async function profileHasActiveBlocks(username: string): Promise<boolean> {
   const { audienceBlocks } = await import('@/lib/db/schema/analytics');
   const { creatorProfiles } = await import('@/lib/db/schema/profiles');
 
-  const [result] = await db
+  const queryPromise = db
     .select({ profileId: creatorProfiles.id })
     .from(creatorProfiles)
     .where(
@@ -240,6 +246,12 @@ async function profileHasActiveBlocks(username: string): Promise<boolean> {
     )
     .limit(1);
 
+  const [result] = await withTimeout(
+    queryPromise,
+    AUDIENCE_BLOCK_DB_QUERY_TIMEOUT_MS,
+    '[audience-block] profileHasActiveBlocks'
+  );
+
   return !!result;
 }
 
@@ -252,7 +264,7 @@ async function isVisitorBlockedByFingerprint(
   const { audienceBlocks } = await import('@/lib/db/schema/analytics');
   const { creatorProfiles } = await import('@/lib/db/schema/profiles');
 
-  const [result] = await db
+  const queryPromise = db
     .select({ blockId: audienceBlocks.id })
     .from(creatorProfiles)
     .innerJoin(
@@ -267,6 +279,12 @@ async function isVisitorBlockedByFingerprint(
       )
     )
     .limit(1);
+
+  const [result] = await withTimeout(
+    queryPromise,
+    AUDIENCE_BLOCK_DB_QUERY_TIMEOUT_MS,
+    '[audience-block] isVisitorBlockedByFingerprint'
+  );
 
   return !!result;
 }
@@ -306,7 +324,7 @@ export async function checkProfileVisitorBlocked(
     }
 
     const fingerprint = await createFingerprintEdge(ip, ua);
-    return isVisitorBlockedByFingerprint(normalizedUsername, fingerprint);
+    return await isVisitorBlockedByFingerprint(normalizedUsername, fingerprint);
   } catch {
     return false;
   }

--- a/apps/web/lib/auth/staging-clerk-keys.ts
+++ b/apps/web/lib/auth/staging-clerk-keys.ts
@@ -34,11 +34,47 @@ function runtimePublicEnv(key: string): string | undefined {
 }
 
 /**
+ * Module-scope memoization cache for resolveClerkKeys.
+ *
+ * Env vars are fixed at container start — caching avoids repeated env reads
+ * on every middleware invocation (3-4× per request).
+ *
+ * SAFETY: only entries with BOTH keys present (status === 'ok') are stored.
+ * Incomplete / degraded statuses ('staging_missing', 'staging_inherits_prod',
+ * 'no_publishable_key', 'missing') are returned directly and never stored, so
+ * a transient env-miss on a cold start cannot be pinned for the worker lifetime.
+ *
+ * BOUNDED: capped at 50 entries with FIFO eviction. Real hostnames are few
+ * (jov.ie, staging.jov.ie, localhost, preview URLs), but `hostname` derives
+ * from the attacker-controllable Host header — the cap defends against a
+ * scanner spraying unique Host values that would otherwise grow the Map until
+ * the worker OOMs.
+ *
+ * Exported for test teardown only. Do not call from production code.
+ */
+const RESOLVE_CLERK_KEYS_CACHE_MAX = 50;
+export const _resolveClerkKeysCache = new Map<string, ClerkKeys>();
+
+/**
+ * Store a resolved key set with FIFO eviction so the cache stays bounded.
+ * Only called for status:'ok' results (both keys present).
+ */
+function cacheClerkKeys(hostname: string, result: ClerkKeys): void {
+  if (_resolveClerkKeysCache.size >= RESOLVE_CLERK_KEYS_CACHE_MAX) {
+    const firstKey = _resolveClerkKeysCache.keys().next().value;
+    if (firstKey !== undefined) _resolveClerkKeysCache.delete(firstKey);
+  }
+  _resolveClerkKeysCache.set(hostname, result);
+}
+
+/**
  * Resolve Clerk keys for a given hostname.
  * Returns staging keys when on a staging host and staging keys are configured.
  * Staging must never silently fall back to production keys.
  */
 export function resolveClerkKeys(hostname: string): ClerkKeys {
+  const cached = _resolveClerkKeysCache.get(hostname);
+  if (cached) return cached;
   if (isStagingHost(hostname)) {
     const explicitPk = process.env.CLERK_PUBLISHABLE_KEY_STAGING;
     const explicitSk = process.env.CLERK_SECRET_KEY_STAGING;
@@ -52,11 +88,13 @@ export function resolveClerkKeys(hostname: string): ClerkKeys {
           status: 'staging_missing',
         };
       }
-      return {
+      const result: ClerkKeys = {
         publishableKey: explicitPk,
         secretKey: explicitSk,
         status: 'ok',
       };
+      cacheClerkKeys(hostname, result);
+      return result;
     }
 
     // No _STAGING vars at all: fall back to the standard env vars read at
@@ -85,19 +123,26 @@ export function resolveClerkKeys(hostname: string): ClerkKeys {
         status: 'staging_inherits_prod',
       };
     }
-    return {
+    const stagingResult: ClerkKeys = {
       publishableKey: runtimePk,
       secretKey: runtimeSk,
       status: 'ok',
     };
+    cacheClerkKeys(hostname, stagingResult);
+    return stagingResult;
   }
 
   const publishableKey = publicEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
   const secretKey = process.env.CLERK_SECRET_KEY || undefined;
+  if (publishableKey && secretKey) {
+    const prodResult: ClerkKeys = { publishableKey, secretKey, status: 'ok' };
+    cacheClerkKeys(hostname, prodResult);
+    return prodResult;
+  }
   return {
     publishableKey,
     secretKey,
-    status: publishableKey && secretKey ? 'ok' : 'no_publishable_key',
+    status: 'no_publishable_key',
   };
 }
 

--- a/apps/web/lib/routing/proxy-routing.ts
+++ b/apps/web/lib/routing/proxy-routing.ts
@@ -146,11 +146,25 @@ export function isProxyRewriteExempt(pathname: string): boolean {
 }
 
 /**
+ * Module-scope cache for categorizePath results.
+ *
+ * Bounded to 1000 entries with FIFO eviction (usernames are unbounded so an
+ * unguarded Map would grow without limit).  The returned PathCategory object
+ * is treated as immutable by all callers — the only spread site
+ * (clerk-middleware-bypass.ts) produces a new object from the spread, so
+ * sharing the cached reference is safe.
+ */
+const CATEGORIZE_PATH_CACHE_MAX = 1000;
+const categorizePathCache = new Map<string, PathCategory>();
+
+/**
  * Categorize a pathname once for all routing decisions.
  * Eliminates redundant path matching throughout the middleware.
  * Now also owns public-profile candidate detection (derived from APP_ROUTES).
  */
 export function categorizePath(pathname: string): PathCategory {
+  const cached = categorizePathCache.get(pathname);
+  if (cached) return cached;
   const isAuthPath =
     pathname === APP_ROUTES.SIGNIN ||
     pathname === APP_ROUTES.SIGNIN_HYPHEN ||
@@ -201,7 +215,7 @@ export function categorizePath(pathname: string): PathCategory {
 
   const publicProfileCandidate = getPublicProfileCandidate(pathname);
 
-  return {
+  const result: PathCategory = {
     needsNonce,
     isProtectedPath,
     isAuthPath,
@@ -209,7 +223,25 @@ export function categorizePath(pathname: string): PathCategory {
     isSensitiveAPI: pathname.startsWith('/api/link/'),
     publicProfileCandidate,
   };
+
+  if (categorizePathCache.size >= CATEGORIZE_PATH_CACHE_MAX) {
+    // FIFO eviction: remove the oldest entry
+    const firstKey = categorizePathCache.keys().next().value;
+    if (firstKey !== undefined) categorizePathCache.delete(firstKey);
+  }
+  categorizePathCache.set(pathname, result);
+  return result;
 }
+
+/**
+ * Module-scope cache for analyzeHost results.
+ *
+ * Capped at 50 entries: the set of real hostnames (jov.ie, staging.jov.ie,
+ * localhost, Vercel preview URLs) is small and bounded in practice.
+ * FIFO eviction prevents unbounded growth from fuzz/scan traffic.
+ */
+const ANALYZE_HOST_CACHE_MAX = 50;
+const analyzeHostCache = new Map<string, HostInfo>();
 
 /**
  * Analyze hostname once for all routing decisions.
@@ -217,13 +249,15 @@ export function categorizePath(pathname: string): PathCategory {
  * Investor portal: /investor-portal (path-based, bypasses Clerk auth)
  */
 export function analyzeHost(hostname: string): HostInfo {
+  const cached = analyzeHostCache.get(hostname);
+  if (cached) return cached;
   const isDevOrPreview =
     hostname === 'localhost' ||
     hostname === '127.0.0.1' ||
     hostname.includes('vercel.app') ||
     STAGING_HOSTNAMES.has(hostname);
 
-  return {
+  const result: HostInfo = {
     isDevOrPreview,
     isMainHost:
       hostname === HOSTNAME ||
@@ -235,6 +269,14 @@ export function analyzeHost(hostname: string): HostInfo {
     isSupportHost: hostname === `support.${HOSTNAME}`,
     isInvestorPortal: INVESTOR_HOSTNAMES.has(hostname),
   };
+
+  if (analyzeHostCache.size >= ANALYZE_HOST_CACHE_MAX) {
+    // FIFO eviction: remove the oldest entry
+    const firstKey = analyzeHostCache.keys().next().value;
+    if (firstKey !== undefined) analyzeHostCache.delete(firstKey);
+  }
+  analyzeHostCache.set(hostname, result);
+  return result;
 }
 
 /** Dashboard is always at /app in single-domain architecture */

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -634,31 +634,6 @@ async function handleRequest(req: NextRequest, userId: string | null) {
   }
 }
 
-/**
- * Build the final response with CSP headers and cookies.
- * The nonce is pre-generated and set on request headers for Server Components.
- * Here we set it on response headers for the CSP policy.
- */
-
-function _getGeoFromRequest(req: NextRequest): {
-  city: string | null;
-  region: string | null;
-} {
-  const geoRequest = req as NextRequest & {
-    geo?: { city?: string | null; region?: string | null };
-  };
-
-  const rawCity = req.headers.get('x-vercel-ip-city')?.trim() ?? null;
-  const cityFromHeader = rawCity ? decodeURIComponent(rawCity) : null;
-  const regionFromHeader =
-    req.headers.get('x-vercel-ip-country-region')?.trim() ?? null;
-
-  return {
-    city: cityFromHeader || geoRequest.geo?.city?.trim() || null,
-    region: regionFromHeader || geoRequest.geo?.region?.trim() || null,
-  };
-}
-
 // Production Clerk middleware (default keys from env)
 const clerkProductionMiddleware = clerkMiddleware(async (auth, req) => {
   const { userId } = await auth();

--- a/apps/web/tests/unit/lib/audience/public-profile-block.test.ts
+++ b/apps/web/tests/unit/lib/audience/public-profile-block.test.ts
@@ -9,9 +9,20 @@ const mocks = vi.hoisted(() => ({
   isNull: vi.fn(() => 'is-null-clause'),
   getRedis: vi.fn(),
   addBreadcrumb: vi.fn(),
+  withTimeout: vi.fn(),
 }));
 
 vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/db/query-timeout', () => ({
+  withTimeout: mocks.withTimeout,
+  QueryTimeoutError: class QueryTimeoutError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'QueryTimeoutError';
+    }
+  },
+}));
 
 vi.mock('@sentry/nextjs', () => ({
   addBreadcrumb: mocks.addBreadcrumb,
@@ -88,6 +99,15 @@ describe('public profile audience block helper', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mocks.getRedis.mockReturnValue(null);
+    // Default: withTimeout passes the promise through unchanged so existing
+    // tests continue to work without being aware of the timeout wrapper.
+    mocks.withTimeout.mockImplementation(
+      (promise: Promise<unknown>) => promise
+    );
+    // Reset select to a clean no-op so persistent mockImplementation from a
+    // prior test (e.g. "fails open when the DB query throws") does not bleed
+    // into subsequent tests.
+    mocks.select.mockReset();
     process.env.NODE_ENV = originalNodeEnv;
     if (originalSmoke === undefined) {
       delete process.env.PUBLIC_NOAUTH_SMOKE;
@@ -250,5 +270,40 @@ describe('public profile audience block helper', () => {
     await expect(
       checkProfileVisitorBlocked('tim', '1.2.3.4', 'Mozilla')
     ).resolves.toBe(false);
+  });
+
+  it('fails open after DB query timeout', async () => {
+    process.env.NODE_ENV = 'production';
+    // profileHasActiveBlocks builds the query promise first (db.select chain),
+    // then passes it to withTimeout. We need select to return a valid chain for
+    // BOTH the outer select and the inner exists-subquery select so the
+    // queryPromise is fully constructed. Only then does withTimeout get called.
+    // withTimeout rejecting with QueryTimeoutError simulates a Neon cold-start
+    // timeout. This also validates the `return await` fix: without it, the
+    // rejected promise escapes the local try/catch in checkProfileVisitorBlocked
+    // and the caller would see an unhandled rejection instead of `false`.
+    const { QueryTimeoutError } = await import('@/lib/db/query-timeout');
+    // Outer select chain (profileId row)
+    mockProfileHasBlocksRows([]);
+    // Inner exists-subquery select chain (audienceBlocks.id row) — needs to
+    // produce a chainable object even though we never await its result.
+    const innerLimit = vi.fn().mockResolvedValue([]);
+    const innerWhere = vi.fn(() => ({ limit: innerLimit }));
+    const innerFrom = vi.fn(() => ({ where: innerWhere }));
+    mocks.select.mockReturnValueOnce({ from: innerFrom });
+
+    mocks.withTimeout.mockRejectedValueOnce(
+      new QueryTimeoutError(
+        '[audience-block] profileHasActiveBlocks timed out after 3000ms'
+      )
+    );
+
+    await expect(
+      checkProfileVisitorBlocked('tim', '1.2.3.4', 'Mozilla')
+    ).resolves.toBe(false);
+
+    // withTimeout must have been reached — both select chains were constructed
+    // and the timeout wrapper was invoked before the rejection.
+    expect(mocks.withTimeout).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts
+++ b/apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts
@@ -7,6 +7,7 @@ vi.mock('next/headers', () => ({
 }));
 
 import {
+  _resolveClerkKeysCache,
   resolveClerkKeys,
   resolvePublishableKeyFromHeaders,
   resolvePublishableKeyStaticFirst,
@@ -22,6 +23,7 @@ const ORIGINAL_ENV = {
 describe('staging Clerk key resolution', () => {
   beforeEach(() => {
     headersMock.mockReset();
+    _resolveClerkKeysCache.clear();
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
       'pk_live_production_example';
     process.env.CLERK_SECRET_KEY = 'sk_live_production_example';
@@ -215,6 +217,7 @@ describe('resolvePublishableKeyStaticFirst', () => {
 
   beforeEach(() => {
     headersMock.mockReset();
+    _resolveClerkKeysCache.clear();
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
       'pk_live_production_example';
     process.env.CLERK_SECRET_KEY = 'sk_live_production_example';


### PR DESCRIPTION
<!-- linear-issue-id: JOV-3231 -->
<!-- linear-issue-id: JOV-3232 -->

## Summary
Ships the two reviewed proxy-middleware fixes directly to main (the integration/loop-auth train is stale/conflicted; these are cleanly cherry-picked off main). Both were already reviewed and CI-green as #11000 and #10999 against integration/loop-auth.

## JOV-3231 — bug fix (high impact)
`apps/web/lib/audience/public-profile-block.ts`: the two audience-block Drizzle queries were uncapped; `checkProfileVisitorBlocked` runs in proxy.ts on every single-segment public-profile navigation. On a Neon cold start with a cold cache this stalled the entire middleware ~3-10s for every visitor. Now bounded at 3s via the existing `withTimeout` util (fail-open, contract-consistent), plus a latent missing-`await` fix so timeout errors hit the local `catch`. Regression test added.

## JOV-3232 — perf hygiene (behavior-preserving)
- Removed dead `_getGeoFromRequest` from proxy.ts.
- Bounded memoization of pure helpers recomputed 2-4×/request: `resolveClerkKeys` (cached only when both keys present — cold-start safe; FIFO cap 50), `analyzeHost` (cap 50), `categorizePath` (cap 1000, FIFO).

## Cost Impact
None. No new external calls — strictly reduces worst-case middleware latency + redundant per-request CPU.

## Verification (local, off main)
- typecheck: exit 0
- biome: 6 files clean
- vitest: 156 passed (both new test files + full tests/unit/middleware/ suite)

## Risk / merge
Auth/proxy surface → `testing`, full CI. Attended merge after CI green + bot reviews clear; no auto-merge.