### PR TITLE
fix(onboarding): welcome intro, starter cards, and sign-in skip on /start (JOV-3083)

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -38,6 +38,7 @@ import {
   ChatProposeNextStepCard,
   type NextStepCardPayload,
 } from './ChatProposeNextStepCard';
+import { OnboardingChatEmptyIntro } from './OnboardingChatEmptyIntro';
 import type {
   OnboardingProfileArtist,
   OnboardingProfileBuilderState,
@@ -682,11 +683,15 @@ interface OnboardingMessageRegionProps {
   readonly onboardingComposerSurface: ReactNode;
   readonly onHandleCandidateChange: (handle: string | null) => void;
   readonly onSelectArtist: (artist: OnboardingArtistSelection) => void;
+  readonly onSelectStarterSuggestion: (prompt: string) => void;
   readonly profileBuilderState: OnboardingProfileBuilderState;
   readonly shouldDockComposer: boolean;
+  readonly showEmptyIntro: boolean;
+  readonly composerPickerOpen: boolean;
 }
 
 function OnboardingMessageRegion({
+  composerPickerOpen,
   displayMessages,
   hasConversationStarted,
   isBusy,
@@ -695,8 +700,10 @@ function OnboardingMessageRegion({
   onboardingComposerSurface,
   onHandleCandidateChange,
   onSelectArtist,
+  onSelectStarterSuggestion,
   profileBuilderState,
   shouldDockComposer,
+  showEmptyIntro,
 }: OnboardingMessageRegionProps) {
   if (shouldDockComposer) {
     return (
@@ -717,7 +724,17 @@ function OnboardingMessageRegion({
 
   if (!hasConversationStarted) {
     return (
-      <ChatEmptyStateComposerRegion>
+      <ChatEmptyStateComposerRegion
+        above={
+          showEmptyIntro ? (
+            <OnboardingChatEmptyIntro
+              onSelectSuggestion={onSelectStarterSuggestion}
+              dimmed={composerPickerOpen}
+              isBusy={isBusy}
+            />
+          ) : undefined
+        }
+      >
         <div className='w-full' data-testid='onboarding-centered-composer'>
           {onboardingComposerSurface}
         </div>
@@ -1050,6 +1067,7 @@ export function OnboardingChat({
   const hasConversationStarted = messages.length > 0 || hasSentFirst;
   const shouldDockComposer =
     chatError !== null || userTurnCount > 1 || selectedArtist !== null;
+  const showEmptyIntro = !intentId && !starterPrompt;
 
   useEffect(() => {
     if (shouldDockComposer) return;
@@ -1091,7 +1109,7 @@ export function OnboardingChat({
   return (
     <section
       className='relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-(--linear-app-content-surface)'
-      aria-label='Jovie onboarding chat'
+      aria-label='Jovie Onboarding Chat'
       data-testid='onboarding-chat'
       data-picker-open={composerPickerOpen ? 'true' : undefined}
     >
@@ -1113,6 +1131,7 @@ export function OnboardingChat({
           )}
         >
           <OnboardingMessageRegion
+            composerPickerOpen={composerPickerOpen}
             displayMessages={displayMessages}
             hasConversationStarted={hasConversationStarted}
             isBusy={isBusy}
@@ -1121,8 +1140,10 @@ export function OnboardingChat({
             onboardingComposerSurface={onboardingComposerSurface}
             onHandleCandidateChange={setHandleDraft}
             onSelectArtist={handleArtistSelect}
+            onSelectStarterSuggestion={submitText}
             profileBuilderState={profileBuilderState}
             shouldDockComposer={shouldDockComposer}
+            showEmptyIntro={showEmptyIntro}
           />
         </div>
       </div>

--- a/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { Camera, Disc3, Eye, Link2, Music } from 'lucide-react';
+import Link from 'next/link';
+import type { ComponentType, SVGProps } from 'react';
+import { ChatMessage } from '@/components/jovie/components';
+import {
+  CHAT_PROMPT_RAIL_CLASS,
+  CHAT_PROMPT_RAIL_SCROLL_CLASS,
+  getChatPromptPillClass,
+} from '@/components/jovie/components/chat-prompt-styles';
+import type { ChatSuggestion } from '@/components/jovie/types';
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  ONBOARDING_STARTER_SUGGESTIONS,
+  ONBOARDING_WELCOME_MESSAGE,
+} from '@/lib/onboarding/empty-state';
+import { cn } from '@/lib/utils';
+
+const ICON_MAP: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
+  Camera,
+  Disc3,
+  Eye,
+  Link2,
+  Music,
+};
+
+const WELCOME_MESSAGE_ID = 'onboarding-welcome-message';
+
+interface OnboardingChatEmptyIntroProps {
+  readonly onSelectSuggestion: (prompt: string) => void;
+  readonly dimmed?: boolean;
+  readonly isBusy?: boolean;
+}
+
+function StarterSuggestionPill({
+  suggestion,
+  onSelect,
+  disabled,
+}: {
+  readonly suggestion: ChatSuggestion;
+  readonly onSelect: (prompt: string) => void;
+  readonly disabled: boolean;
+}) {
+  const IconComponent = ICON_MAP[suggestion.icon];
+
+  return (
+    <button
+      type='button'
+      onClick={() => {
+        if (!disabled) onSelect(suggestion.prompt);
+      }}
+      disabled={disabled}
+      className={cn(
+        'chat-pill snap-start',
+        disabled ? 'cursor-not-allowed opacity-55' : 'cursor-pointer',
+        getChatPromptPillClass()
+      )}
+      aria-label={suggestion.label}
+      aria-disabled={disabled}
+    >
+      <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token transition-colors duration-fast group-hover:text-primary-token'>
+        {IconComponent ? (
+          <IconComponent className='h-3.5 w-3.5 shrink-0' />
+        ) : null}
+      </span>
+      <span className='min-w-0 flex-1 truncate leading-none'>
+        {suggestion.label}
+      </span>
+    </button>
+  );
+}
+
+export function OnboardingChatEmptyIntro({
+  onSelectSuggestion,
+  dimmed = false,
+  isBusy = false,
+}: OnboardingChatEmptyIntroProps) {
+  const dimClass = dimmed
+    ? 'opacity-0 transition-opacity duration-fast ease-out'
+    : 'opacity-100 transition-opacity duration-fast ease-out';
+
+  return (
+    <div
+      className='mx-auto flex w-full max-w-[44rem] flex-col gap-4'
+      data-testid='onboarding-empty-intro'
+    >
+      {/* biome-ignore lint/a11y/useValidAriaRole: ChatMessage role is transcript semantics, not DOM aria-role */}
+      <ChatMessage
+        id={WELCOME_MESSAGE_ID}
+        role='assistant'
+        parts={[{ type: 'text', text: ONBOARDING_WELCOME_MESSAGE }]}
+        skipEntrance
+        renderTools={false}
+      />
+
+      <div
+        className={cn('system-b-chat-suggested-prompts-rail-wrapper', dimClass)}
+        aria-hidden={dimmed}
+        inert={dimmed}
+        data-testid='onboarding-starter-suggestions'
+      >
+        <div
+          className={cn(
+            CHAT_PROMPT_RAIL_SCROLL_CLASS,
+            'overscroll-x-contain px-1 sm:px-0'
+          )}
+        >
+          <div
+            className={cn(
+              CHAT_PROMPT_RAIL_CLASS,
+              'snap-x snap-mandatory whitespace-nowrap'
+            )}
+          >
+            {ONBOARDING_STARTER_SUGGESTIONS.map(suggestion => (
+              <StarterSuggestionPill
+                key={suggestion.label}
+                suggestion={suggestion}
+                onSelect={onSelectSuggestion}
+                disabled={isBusy}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <p className='text-center text-[12.5px] leading-5 text-secondary-token'>
+        Already have an account?{' '}
+        <Link
+          href={APP_ROUTES.SIGNIN}
+          className='font-medium text-primary-token underline-offset-2 transition-colors duration-fast hover:underline'
+          data-testid='onboarding-sign-in-skip'
+        >
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/web/lib/onboarding/empty-state.test.ts
+++ b/apps/web/lib/onboarding/empty-state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ONBOARDING_STARTER_SUGGESTIONS,
+  ONBOARDING_WELCOME_MESSAGE,
+} from './empty-state';
+
+describe('onboarding empty state copy', () => {
+  it('includes memory disclosure and one intake question', () => {
+    expect(ONBOARDING_WELCOME_MESSAGE).toMatch(/remember/i);
+    expect(ONBOARDING_WELCOME_MESSAGE).toMatch(/what are you working on/i);
+    expect((ONBOARDING_WELCOME_MESSAGE.match(/\?/g) ?? []).length).toBe(1);
+  });
+
+  it('exposes four starter suggestions with prompts', () => {
+    expect(ONBOARDING_STARTER_SUGGESTIONS).toHaveLength(4);
+    for (const suggestion of ONBOARDING_STARTER_SUGGESTIONS) {
+      expect(suggestion.label.length).toBeGreaterThan(0);
+      expect(suggestion.prompt.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/lib/onboarding/empty-state.ts
+++ b/apps/web/lib/onboarding/empty-state.ts
@@ -1,0 +1,37 @@
+import type { ChatSuggestion } from '@/components/jovie/types';
+
+/**
+ * Static opener shown before the visitor sends their first message.
+ * Mirrors the canonical onboarding system-prompt opener so the UI and
+ * model stay aligned on memory disclosure + one intake question.
+ */
+export const ONBOARDING_WELCOME_MESSAGE =
+  "Hey — I'm Jovie. Heads up, I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?";
+
+/** Starter pills for the anonymous /start empty state. */
+export const ONBOARDING_STARTER_SUGGESTIONS: readonly ChatSuggestion[] = [
+  {
+    icon: 'Music',
+    label: 'Find My Spotify Artist',
+    prompt: "I'm an artist — help me find my Spotify profile.",
+    accent: 'blue',
+  },
+  {
+    icon: 'Disc3',
+    label: 'Plan A Release',
+    prompt: 'Help me plan my next release.',
+    accent: 'green',
+  },
+  {
+    icon: 'Eye',
+    label: 'Build Artist Profile',
+    prompt: 'Help me build my artist profile.',
+    accent: 'purple',
+  },
+  {
+    icon: 'Link2',
+    label: 'Set Up My Link Page',
+    prompt: 'Help me set up my artist link page.',
+    accent: 'blue',
+  },
+] as const;

--- a/apps/web/tests/e2e/start-onboarding-chat.spec.ts
+++ b/apps/web/tests/e2e/start-onboarding-chat.spec.ts
@@ -306,7 +306,14 @@ test.describe('canonical /start onboarding chat', () => {
     await expect(
       page.getByTestId('chat-empty-state-centered-composer')
     ).toBeVisible();
-    await expect(page.getByText("Hey, I'm Jovie.")).toHaveCount(0);
+    await expect(page.getByTestId('onboarding-empty-intro')).toBeVisible();
+    await expect(
+      page.getByTestId('onboarding-starter-suggestions')
+    ).toBeVisible();
+    await expect(page.getByTestId('onboarding-sign-in-skip')).toBeVisible();
+    await expect(
+      page.getByText(/remember this chat so we can pick up where we left off/i)
+    ).toBeVisible();
     const mainBox = await page.locator('#main-content').boundingBox();
     const chatBox = await page.locator(CHAT_PANEL).boundingBox();
     expect(mainBox).not.toBeNull();

--- a/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OnboardingChat } from '@/components/features/onboarding/OnboardingChat';
+import { ONBOARDING_WELCOME_MESSAGE } from '@/lib/onboarding/empty-state';
+
+const chatMocks = vi.hoisted(() => ({
+  messages: [] as Array<{
+    id: string;
+    role: 'user' | 'assistant';
+    parts: Array<{ type: 'text'; text: string }>;
+  }>,
+  sendMessage: vi.fn(),
+  setMessages: vi.fn(),
+  status: 'ready' as 'ready' | 'submitted' | 'streaming',
+  stop: vi.fn(),
+}));
+
+vi.mock('ai', () => ({
+  DefaultChatTransport: class DefaultChatTransport {
+    constructor(readonly options: unknown) {}
+  },
+}));
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: () => ({
+    messages: chatMocks.messages,
+    sendMessage: chatMocks.sendMessage,
+    setMessages: chatMocks.setMessages,
+    status: chatMocks.status,
+    stop: chatMocks.stop,
+  }),
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  track: vi.fn(),
+}));
+
+vi.mock('@/lib/flags/client', () => ({
+  useAppFlag: () => false,
+}));
+
+vi.mock('@/components/jovie/hooks', () => ({
+  useChatJankMonitor: () => ({ onSend: vi.fn() }),
+  useStickToBottom: () => ({
+    isStuckToBottom: true,
+    onScroll: vi.fn(),
+    scrollContainerRef: { current: null },
+    totalSizeRef: { current: null },
+  }),
+}));
+
+vi.mock('@/components/jovie/hooks/useChipTray', () => ({
+  composeMessage: (_chips: readonly unknown[], rawText: string) => rawText,
+  useChipTray: () => ({
+    addEntity: vi.fn(),
+    addSkill: vi.fn(),
+    chips: [],
+    clear: vi.fn(),
+    removeAt: vi.fn(),
+    removeLast: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/jovie/tool-ui', () => ({
+  ToolPartsRenderer: () => null,
+}));
+
+vi.mock('@/components/jovie/utils', () => ({
+  extractErrorMetadata: () => ({}),
+  getErrorType: () => 'server',
+  getPreferredErrorMessage: (error: Error) => error.message,
+}));
+
+vi.mock('@/components/features/onboarding/OnboardingToolArtifacts', () => ({
+  OnboardingArtistConfirmedCard: () => null,
+  OnboardingHandleCheckCard: () => null,
+  OnboardingSocialLinkCard: () => null,
+  OnboardingSpotifyArtistPickerCard: () => null,
+  useArtistSelectionMessage: () => () => 'artist selected',
+}));
+
+vi.mock('@/components/jovie/components', () => ({
+  ChatEmptyStateComposerRegion: ({
+    above,
+    children,
+  }: {
+    readonly above?: React.ReactNode;
+    readonly children: React.ReactNode;
+  }) => (
+    <div data-testid='chat-empty-state-composer-region'>
+      {above}
+      {children}
+    </div>
+  ),
+  ChatInput: () => <div data-testid='chat-input' />,
+  ChatMessage: ({
+    parts,
+  }: {
+    readonly parts: Array<{ type: 'text'; text: string }>;
+  }) => <div data-testid='chat-message'>{parts[0]?.text}</div>,
+}));
+
+describe('OnboardingChat empty intro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chatMocks.messages = [];
+    chatMocks.status = 'ready';
+    process.env.NODE_ENV = 'development';
+  });
+
+  it('shows welcome intro on a blank /start visit', () => {
+    render(
+      <OnboardingChat turnstileToken='token' turnstileStatus='verified' />
+    );
+
+    expect(screen.getByTestId('onboarding-empty-intro')).toBeTruthy();
+    expect(screen.getByText(ONBOARDING_WELCOME_MESSAGE)).toBeTruthy();
+    expect(screen.getByTestId('onboarding-sign-in-skip')).toHaveAttribute(
+      'href',
+      '/signin'
+    );
+  });
+
+  it('hides welcome intro when a starter prompt deep link is provided', () => {
+    render(
+      <OnboardingChat
+        starterPrompt='Help me plan my next release.'
+        turnstileToken='token'
+        turnstileStatus='verified'
+      />
+    );
+
+    expect(screen.queryByTestId('onboarding-empty-intro')).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { OnboardingChatEmptyIntro } from '@/components/features/onboarding/OnboardingChatEmptyIntro';
+import {
+  ONBOARDING_STARTER_SUGGESTIONS,
+  ONBOARDING_WELCOME_MESSAGE,
+} from '@/lib/onboarding/empty-state';
+
+vi.mock('@/components/jovie/components', () => ({
+  ChatMessage: ({
+    parts,
+  }: {
+    readonly parts: Array<{ type: 'text'; text: string }>;
+  }) => (
+    <div data-testid='chat-message'>
+      {parts.map(part => part.text).join('')}
+    </div>
+  ),
+}));
+
+describe('OnboardingChatEmptyIntro', () => {
+  it('renders welcome message, starter cards, and sign-in skip', () => {
+    const onSelectSuggestion = vi.fn();
+
+    render(
+      <OnboardingChatEmptyIntro onSelectSuggestion={onSelectSuggestion} />
+    );
+
+    expect(screen.getByTestId('onboarding-empty-intro')).toBeTruthy();
+    expect(screen.getByText(ONBOARDING_WELCOME_MESSAGE)).toBeTruthy();
+    expect(screen.getByTestId('onboarding-starter-suggestions')).toBeTruthy();
+    expect(screen.getByTestId('onboarding-sign-in-skip')).toHaveAttribute(
+      'href',
+      '/signin'
+    );
+
+    for (const suggestion of ONBOARDING_STARTER_SUGGESTIONS) {
+      expect(
+        screen.getByRole('button', { name: suggestion.label })
+      ).toBeTruthy();
+    }
+  });
+
+  it('submits the selected starter prompt', () => {
+    const onSelectSuggestion = vi.fn();
+    const [firstSuggestion] = ONBOARDING_STARTER_SUGGESTIONS;
+
+    render(
+      <OnboardingChatEmptyIntro onSelectSuggestion={onSelectSuggestion} />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: firstSuggestion.label })
+    );
+
+    expect(onSelectSuggestion).toHaveBeenCalledWith(firstSuggestion.prompt);
+  });
+
+  it('dims suggestions while the slash picker is open', () => {
+    const { container } = render(
+      <OnboardingChatEmptyIntro onSelectSuggestion={vi.fn()} dimmed />
+    );
+
+    const suggestions = container.querySelector(
+      '[data-testid="onboarding-starter-suggestions"]'
+    );
+    expect(suggestions?.className).toContain('opacity-0');
+    expect(suggestions?.getAttribute('inert')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes P0 JOV-3083: `/start` onboarding opened to a blank composer with no orientation.

- Adds canonical memory-disclosure welcome message on first anonymous visit
- Adds four intake starter suggestion pills (Spotify artist, release plan, profile, link page)
- Adds "Sign in" skip path for returning users
- Hides intro when `starter_prompt` / `intent_id` deep links auto-submit

## Test plan

- [x] `pnpm --filter @jovie/web exec vitest run lib/onboarding/empty-state.test.ts tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx`
- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/onboarding/OnboardingChat.turnstile.test.tsx`
- [x] Typecheck + biome + eslint (pre-commit/pre-push)
- [ ] E2E: `start-onboarding-chat.spec.ts` visual snapshots may need baseline refresh

## Cost Impact

None — client-only UI; no new API routes or infra.

<!-- linear-issue-id:JOV-3083 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an onboarding empty-state intro with a welcome message, starter suggestion “pills,” and a sign-in skip link when starting a new (blank) chat.
  * Suggestion pills now appear conditionally and let users kick off a conversation without typing.
* **Accessibility / UX**
  * Improved labeling for the onboarding chat region and added dimming/inert behavior for the suggestions area during related UI states.
* **Tests**
  * Added unit and end-to-end coverage for the empty intro, suggestions content, and interaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->