### PR TITLE
fix(copy): standardize conversation terminology (JOV-3095)

### DIFF
--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -391,7 +391,7 @@ private struct AppNavigationMenu: View {
               .foregroundStyle(JovieColor.textTertiary)
 
             if recentConversations.isEmpty {
-              Text("Start a chat to see recent conversations here.")
+              Text("Start a conversation to see recent conversations here.")
                 .font(JovieFont.body(size: 15))
                 .foregroundStyle(JovieColor.textTertiary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -402,7 +402,7 @@ private struct AppNavigationMenu: View {
                     onSelectConversation(conversation.id)
                   } label: {
                     HStack {
-                      Text(conversation.title ?? "New chat")
+                      Text(conversation.title ?? "New Conversation")
                         .font(JovieFont.body(size: 15))
                         .foregroundStyle(JovieColor.textPrimary)
                         .lineLimit(1)

--- a/apps/web/app/app/(shell)/chat/[id]/chat-thread-metadata-data.ts
+++ b/apps/web/app/app/(shell)/chat/[id]/chat-thread-metadata-data.ts
@@ -6,7 +6,7 @@ import { sanitizeConversationTitle } from '@/lib/chat/title';
 import { db } from '@/lib/db';
 import { chatConversations } from '@/lib/db/schema/chat';
 
-export const CHAT_THREAD_TITLE_FALLBACK = 'Thread';
+export const CHAT_THREAD_TITLE_FALLBACK = 'Conversation';
 
 export async function loadChatThreadTitle(
   conversationId: string

--- a/apps/web/app/app/(shell)/chat/[id]/page.tsx
+++ b/apps/web/app/app/(shell)/chat/[id]/page.tsx
@@ -11,7 +11,7 @@ interface Props {
   }>;
 }
 
-const CONVERSATION_DESCRIPTION = 'Thread with Jovie AI';
+const CONVERSATION_DESCRIPTION = 'Conversation with Jovie AI';
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;

--- a/apps/web/app/app/(shell)/chat/error.tsx
+++ b/apps/web/app/app/(shell)/chat/error.tsx
@@ -17,7 +17,7 @@ export default function ChatError({ error, reset }: ErrorProps) {
           <AlertCircle className='h-8 w-8 text-tertiary-token' />
           <div className='space-y-1'>
             <p className='text-sm font-medium text-primary-token'>
-              Chat couldn&apos;t load
+              Conversation couldn&apos;t load
             </p>
             <p className='text-sm text-secondary-token'>
               Something went wrong. Please try again.

--- a/apps/web/app/app/(shell)/chat/page.tsx
+++ b/apps/web/app/app/(shell)/chat/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { DeferredChatPageClient } from './DeferredChatPageClient';
 
-const CHAT_DESCRIPTION = 'Start a new chat with Jovie AI';
+const CHAT_DESCRIPTION = 'Start a new conversation with Jovie AI';
 const CHAT_TITLE = 'Home';
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/apps/web/app/app/(shell)/chats/page.tsx
+++ b/apps/web/app/app/(shell)/chats/page.tsx
@@ -11,7 +11,7 @@ export default async function ChatsPage() {
     route: APP_ROUTES.CHATS,
     dashboardErrorLogMessage: 'Dashboard data load failed on chats page',
     dashboardErrorMessage:
-      'Failed to load chats data. Please refresh the page.',
+      'Failed to load conversations data. Please refresh the page.',
   });
   if (!routeContext.ok) {
     return routeContext.error;

--- a/apps/web/app/app/(shell)/dashboard/profile/ProfilePageChat.tsx
+++ b/apps/web/app/app/(shell)/dashboard/profile/ProfilePageChat.tsx
@@ -21,10 +21,10 @@ function ProfilePageChatFallback() {
             <AlertCircle className='h-5 w-5 text-tertiary-token' />
           </div>
           <p className='text-sm text-secondary-token'>
-            Something went wrong loading chat. Please try again.
+            Something went wrong loading the conversation. Please try again.
           </p>
           <DashboardHeaderActionButton
-            ariaLabel='Reload chat'
+            ariaLabel='Reload Conversation'
             onClick={() => router.refresh()}
             icon={<RefreshCw className='h-4 w-4' />}
             label='Reload'
@@ -54,7 +54,7 @@ function ProfilePageChatInner() {
                 We hit a problem loading your profile. Please retry in a moment.
               </p>
               <DashboardHeaderActionButton
-                ariaLabel='Retry loading profile chat'
+                ariaLabel='Retry Loading Profile Conversation'
                 onClick={() => router.refresh()}
                 icon={<RefreshCw className='h-4 w-4' />}
                 label='Retry'

--- a/apps/web/app/app/(shell)/page.tsx
+++ b/apps/web/app/app/(shell)/page.tsx
@@ -5,7 +5,7 @@ import { HydrateClient } from '@/lib/queries/HydrateClient';
 import { getDehydratedState } from '@/lib/queries/server';
 import { DeferredChatPageClient } from './chat/DeferredChatPageClient';
 
-const DASHBOARD_DESCRIPTION = 'Start a new chat with Jovie AI';
+const DASHBOARD_DESCRIPTION = 'Start a new conversation with Jovie AI';
 const DASHBOARD_TITLE = 'Home';
 
 export function generateMetadata(): Metadata {

--- a/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
+++ b/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
@@ -114,9 +114,9 @@ export function ChatsPageClient() {
           deleteConversation.mutateAsync({ conversationId: thread.id })
         )
       );
-      notifications.success('All chats archived');
+      notifications.success('All conversations archived');
     } catch {
-      notifications.error('Could not archive all chats');
+      notifications.error('Could not archive all conversations');
     }
   }, [deleteConversation, notifications, sidebarThreads]);
 
@@ -134,8 +134,8 @@ export function ChatsPageClient() {
             <AppSearchField
               value={query}
               onChange={setQuery}
-              placeholder='Search chats'
-              ariaLabel='Search chats'
+              placeholder='Search conversations'
+              ariaLabel='Search Conversations'
               className='max-w-2xl flex-1'
               inputClassName='text-[13px]'
             />
@@ -147,19 +147,19 @@ export function ChatsPageClient() {
                   size='sm'
                   onClick={() => setArchiveAllOpen(true)}
                 >
-                  Archive All Chats
+                  Archive All Conversations
                 </Button>
               ) : null}
               <Button asChild variant='secondary' size='sm'>
-                <Link href={APP_ROUTES.CHAT}>New Chat</Link>
+                <Link href={APP_ROUTES.CHAT}>New Conversation</Link>
               </Button>
             </div>
           </div>
           <div className='mt-2 flex items-center gap-3 text-[11px] text-tertiary-token'>
-            <span>{sidebarThreads.length} chats</span>
+            <span>{sidebarThreads.length} conversations</span>
             <span className='inline-flex items-center gap-1'>
               <Search className='h-3 w-3' />
-              Search is local to chat titles and statuses
+              Search is local to conversation titles and statuses
             </span>
             {unreadCount > 0 ? <span>{unreadCount} unread</span> : null}
           </div>
@@ -170,15 +170,15 @@ export function ChatsPageClient() {
             <ChatListSkeleton />
           ) : isError ? (
             <PageErrorState
-              title='Unable to load chats'
-              message='We could not load your recent chats. Retry the request or refresh the page.'
+              title='Unable to load conversations'
+              message='We could not load your recent conversations. Retry the request or refresh the page.'
               error={error instanceof Error ? error : undefined}
               actionLabel='Retry load'
               onRetry={() => {
                 refetch();
               }}
               secondaryAction={{
-                label: 'Refresh page',
+                label: 'Refresh Page',
                 onClick: () => globalThis.location.reload(),
               }}
             />
@@ -187,16 +187,16 @@ export function ChatsPageClient() {
               <div className='max-w-sm space-y-3'>
                 <p className='text-[14px] font-semibold text-primary-token'>
                   {normalizedQuery
-                    ? `No chats match "${trimmedQuery}".`
-                    : 'No chats yet'}
+                    ? `No conversations match "${trimmedQuery}".`
+                    : 'No conversations yet'}
                 </p>
                 <p className='text-[13px] leading-6 text-secondary-token'>
                   {normalizedQuery
                     ? 'Clear the search or try a different phrase.'
-                    : 'Start a new chat to see conversations appear here.'}
+                    : 'Start a new conversation and it will appear here.'}
                 </p>
                 <Button asChild variant='secondary' size='sm'>
-                  <Link href={APP_ROUTES.CHAT}>New Chat</Link>
+                  <Link href={APP_ROUTES.CHAT}>New Conversation</Link>
                 </Button>
               </div>
             </div>
@@ -219,8 +219,8 @@ export function ChatsPageClient() {
       <ConfirmDialog
         open={archiveAllOpen}
         onOpenChange={setArchiveAllOpen}
-        title='Archive all chats?'
-        description={`This will archive ${sidebarThreads.length} chat${sidebarThreads.length === 1 ? '' : 's'}. You cannot undo this action.`}
+        title='Archive all conversations?'
+        description={`This will archive ${sidebarThreads.length} conversation${sidebarThreads.length === 1 ? '' : 's'}. You cannot undo this action.`}
         confirmLabel='Archive All'
         variant='destructive'
         onConfirm={handleArchiveAll}

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -53,7 +53,7 @@ const searchNavItem: NavItem = {
   id: 'search',
   icon: Search,
   description:
-    'Search app content across chats, releases, artists, tasks, and more',
+    'Search app content across conversations, releases, artists, tasks, and more',
 };
 
 type DashboardNavSection = {

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -44,15 +44,15 @@ export const dashboardHome: NavItem = {
   href: APP_ROUTES.CHAT,
   id: 'overview',
   icon: Home,
-  description: 'Start a new chat',
+  description: 'Start a new conversation',
 };
 
 export const newThreadNavItem: NavItem = {
-  name: 'New Chat',
+  name: 'New Conversation',
   href: APP_ROUTES.CHAT,
   id: 'chat',
   icon: SquarePen,
-  description: 'Start a new chat',
+  description: 'Start a new conversation',
 };
 
 export const profileNavItem: NavItem = {
@@ -287,7 +287,7 @@ export const mobileHome: NavItem = {
   href: APP_ROUTES.CHAT,
   id: 'home',
   icon: SquarePen,
-  description: 'Start a new chat',
+  description: 'Start a new conversation',
 };
 
 /** Items shown as icons in the bottom tab bar (max 3). */

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -258,7 +258,7 @@ export function CmdKPalette({
           Command palette
         </DialogPrimitive.Title>
         <DialogPrimitive.Description className='sr-only'>
-          Search routes, skills, releases, artists, and recent chats.
+          Search routes, skills, releases, artists, and recent conversations.
         </DialogPrimitive.Description>
         <div
           className='flex flex-col'
@@ -278,9 +278,9 @@ export function CmdKPalette({
                 setQuery(e.target.value);
                 setSelectedIndex(0);
               }}
-              placeholder='Jump to a page, skill, release, or chat...'
+              placeholder='Jump to a page, skill, release, or conversation...'
               className='flex-1 appearance-none bg-transparent text-sm text-primary-token outline-none placeholder:text-tertiary-token focus:outline-none focus-visible:outline-none focus-visible:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_45%,transparent)]'
-              aria-label='Command palette search'
+              aria-label='Command Palette Search'
             />
             <span className='hidden shrink-0 px-1 text-[11px] font-medium text-quaternary-token sm:inline'>
               Esc
@@ -289,7 +289,7 @@ export function CmdKPalette({
           <div
             className='max-h-[420px] overflow-y-auto px-2 pb-2 pt-1.5'
             role='listbox'
-            aria-label='Command palette results'
+            aria-label='Command Palette Results'
           >
             <PaletteList
               sections={allSections}

--- a/apps/web/components/organisms/CommandPalette.tsx
+++ b/apps/web/components/organisms/CommandPalette.tsx
@@ -87,15 +87,15 @@ function CommandPaletteInner({ profileId }: CommandPaletteInnerProps) {
     if (conversations && conversations.length > 0) {
       sections.push({
         id: 'recent-chats',
-        label: 'Recent chats',
+        label: 'Recent Conversations',
         items: conversations.map(convo => {
           const entity: EntityRef = {
             kind: 'track', // Reuses the generic Music2 fallback art.
             id: `thread:${convo.id}`,
-            label: convo.title || 'Untitled chat',
+            label: convo.title || 'Untitled conversation',
             meta: {
               kind: 'track',
-              subtitle: 'Chat',
+              subtitle: 'Conversation',
             },
           };
           return { kind: 'entity', entity };

--- a/apps/web/components/shell/EntityThreadGlyph.test.tsx
+++ b/apps/web/components/shell/EntityThreadGlyph.test.tsx
@@ -24,7 +24,7 @@ describe('EntityThreadGlyph', () => {
       </div>
     );
     fireEvent.click(
-      screen.getByRole('button', { name: 'Open running thread' })
+      screen.getByRole('button', { name: 'Open Running Conversation' })
     );
     expect(onOpen).toHaveBeenCalledOnce();
     expect(onParentClick).not.toHaveBeenCalled();

--- a/apps/web/components/shell/EntityThreadGlyph.tsx
+++ b/apps/web/components/shell/EntityThreadGlyph.tsx
@@ -34,7 +34,7 @@ export interface EntityThreadGlyphProps {
 export function EntityThreadGlyph({
   threadTitle,
   onOpen,
-  tooltipLabel = 'Jovie working — open thread',
+  tooltipLabel = 'Jovie working — open conversation',
 }: EntityThreadGlyphProps) {
   return (
     <Tooltip label={tooltipLabel}>
@@ -44,7 +44,7 @@ export function EntityThreadGlyph({
           e.stopPropagation();
           onOpen();
         }}
-        aria-label='Open running thread'
+        aria-label='Open Running Conversation'
         className='shrink-0 inline-flex items-center justify-center h-5 w-5 rounded text-cyan-300/85 hover:text-cyan-200 hover:bg-surface-1/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token transition-colors duration-subtle ease-subtle'
       >
         <span className='relative inline-grid place-items-center h-3 w-3'>

--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -64,7 +64,7 @@ describe('SidebarThreadsSection', () => {
 
     const threadLink = screen.getByRole('link', { name: 'Pitch tasks' });
     const actionsButton = screen.getByRole('button', {
-      name: 'Chat actions for Pitch tasks',
+      name: 'Conversation Actions for Pitch tasks',
     });
 
     fireEvent.contextMenu(threadLink);
@@ -90,7 +90,9 @@ describe('SidebarThreadsSection', () => {
       />
     );
 
-    const allThreadsLink = screen.getByRole('link', { name: 'All Chats' });
+    const allThreadsLink = screen.getByRole('link', {
+      name: 'All Conversations',
+    });
 
     expect(allThreadsLink).toHaveAttribute('href', APP_ROUTES.CHATS);
     expect(allThreadsLink).toHaveAttribute('aria-current', 'page');
@@ -136,7 +138,9 @@ describe('SidebarThreadsSection', () => {
       />
     );
 
-    const newThreadButton = screen.getByRole('button', { name: 'New Chat' });
+    const newThreadButton = screen.getByRole('button', {
+      name: 'New Conversation',
+    });
 
     fireEvent.click(newThreadButton);
     expect(onNewThread).toHaveBeenCalledTimes(1);

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -146,7 +146,7 @@ export function toSidebarThread(
   return {
     id: conversation.id,
     href: `${APP_ROUTES.CHAT}/${encodeURIComponent(conversation.id)}`,
-    title: conversation.title?.trim() || 'Untitled chat',
+    title: conversation.title?.trim() || 'Untitled conversation',
     status: getSidebarThreadStatus(latestTurnStatus),
     updatedAt: conversation.updatedAt,
     unread,
@@ -268,11 +268,11 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
         )}
       </Tooltip>
       {onThreadContextMenu ? (
-        <Tooltip label='Chat actions' side='right'>
+        <Tooltip label='Conversation Actions' side='right'>
           <button
             type='button'
             onClick={e => onThreadContextMenu(e, thread)}
-            aria-label={`Chat actions for ${thread.title}`}
+            aria-label={`Conversation Actions for ${thread.title}`}
             className={cn(
               'absolute right-1 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-full text-quaternary-token transition-[background-color,color,opacity] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
               'opacity-0 group-hover/thread:opacity-100 focus-visible:opacity-100'
@@ -325,7 +325,7 @@ export function SidebarThreadsSection({
     <div className='space-y-1.5'>
       <div className='flex items-center justify-between border-t border-[color-mix(in_oklab,var(--linear-app-frame-seam)_44%,transparent)] px-2.5 pb-0.5 pt-2'>
         <span className='text-[10.5px] font-semibold uppercase tracking-[0.08em] text-quaternary-token'>
-          Chats
+          Conversations
         </span>
         {unreadCount > 0 && (
           <span className='inline-flex items-center gap-1 text-[11px] font-medium text-quaternary-token'>
@@ -359,12 +359,14 @@ export function SidebarThreadsSection({
               tight ? 'h-6 text-[12px]' : 'h-6.5 text-[12.5px]'
             )}
           >
-            <span className='min-w-0 flex-1 truncate'>Chats unavailable</span>
+            <span className='min-w-0 flex-1 truncate'>
+              Conversations unavailable
+            </span>
             {onRetry ? (
               <button
                 type='button'
                 onClick={onRetry}
-                aria-label='Retry chats'
+                aria-label='Retry Conversations'
                 className='grid h-5 w-5 shrink-0 place-items-center rounded text-quaternary-token transition-[background-color] duration-subtle ease-subtle hover:bg-sidebar-accent/55 hover:text-primary-token'
               >
                 <RefreshCw
@@ -394,7 +396,7 @@ export function SidebarThreadsSection({
               strokeWidth={2.25}
             />
             <span className='min-w-0 truncate justify-self-start'>
-              New Chat
+              New Conversation
             </span>
           </button>
         ) : null}
@@ -433,7 +435,7 @@ export function SidebarThreadsSection({
               strokeWidth={2.25}
             />
             <span className='min-w-0 truncate justify-self-start'>
-              All Chats
+              All Conversations
             </span>
           </Link>
         ) : null}

--- a/apps/web/components/shell/ThreadView.tsx
+++ b/apps/web/components/shell/ThreadView.tsx
@@ -17,7 +17,7 @@ export interface ThreadViewProps {
   readonly thread: ThreadViewData;
   /** Rendered turns / cards (typically `<ThreadTurn>`s and `<Thread*Card>`s). */
   readonly children: ReactNode;
-  /** Composer slot — defaults to `<ThreadComposer placeholder="Reply to this chat..." />`. */
+  /** Composer slot — defaults to `<ThreadComposer placeholder="Reply to this conversation..." />`. */
   readonly composer?: ReactNode;
   /** Submit handler forwarded to the default ThreadComposer. */
   readonly onComposerSubmit?: (text: string) => void;
@@ -60,7 +60,7 @@ export function ThreadView({
   children,
   composer,
   onComposerSubmit,
-  composerPlaceholder = 'Reply to this chat...',
+  composerPlaceholder = 'Reply to this conversation...',
 }: ThreadViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [atBottom, setAtBottom] = useState(true);
@@ -124,7 +124,7 @@ export function ThreadView({
             <button
               type='button'
               onClick={scrollToBottom}
-              aria-label='Scroll to bottom'
+              aria-label='Scroll To Bottom'
               className={cn(
                 'absolute left-1/2 -top-10 z-10 grid h-8 w-8 -translate-x-1/2 place-items-center rounded-full border border-(--linear-app-shell-border) bg-(--linear-app-content-surface) text-secondary-token shadow-popover transition-colors duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55'
               )}

--- a/apps/web/components/shell/useChatThreadContextMenu.tsx
+++ b/apps/web/components/shell/useChatThreadContextMenu.tsx
@@ -42,12 +42,12 @@ export function useChatThreadContextMenu(
     async (threadId: string) => {
       try {
         await deleteConversation.mutateAsync({ conversationId: threadId });
-        notifications.success('Chat archived');
+        notifications.success('Conversation archived');
         if (options.activeThreadId === threadId) {
           router.push(APP_ROUTES.CHAT);
         }
       } catch {
-        notifications.error('Could not archive chat');
+        notifications.error('Could not archive conversation');
       }
     },
     [deleteConversation, notifications, options.activeThreadId, router]

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -222,8 +222,8 @@ export const COMMANDS: readonly Command[] = [
   ),
   nav(
     'go-chats',
-    'Chats',
-    'Open the all-chats workspace.',
+    'Conversations',
+    'Open the all-conversations workspace.',
     'MessageSquare',
     APP_ROUTES.CHATS
   ),

--- a/apps/web/lib/constants/breadcrumb-labels.ts
+++ b/apps/web/lib/constants/breadcrumb-labels.ts
@@ -14,9 +14,9 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   audience: 'Audience',
   earnings: 'Earnings',
   analytics: 'Analytics',
-  chat: 'New chat',
-  chats: 'Chats',
-  threads: 'Chats',
+  chat: 'New Conversation',
+  chats: 'Conversations',
+  threads: 'Conversations',
   'tour-dates': 'Tour dates',
 
   // Settings routes
@@ -41,7 +41,7 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   feedback: 'Feedback',
 
   // Root routes
-  app: 'New chat',
+  app: 'New Conversation',
 } as const;
 
 /**

--- a/apps/web/lib/keyboard-shortcuts.ts
+++ b/apps/web/lib/keyboard-shortcuts.ts
@@ -239,7 +239,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
   },
   {
     id: 'nav-chat',
-    label: 'Go to chat',
+    label: 'Go to conversation',
     keys: 'G then T',
     category: 'navigation',
     icon: MessageCircle,

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -51,10 +51,9 @@ describe('DashboardNav interactions', () => {
   it('renders the full primary navigation config', () => {
     renderDashboardNav({ renderFn: render });
 
-    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
-      'href',
-      APP_ROUTES.CHAT
-    );
+    expect(
+      screen.getByRole('link', { name: 'New Conversation' })
+    ).toHaveAttribute('href', APP_ROUTES.CHAT);
     expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
       'href',
       buildLibraryViewRoute('releases')
@@ -84,10 +83,9 @@ describe('DashboardNav interactions', () => {
       'href',
       buildLibraryViewRoute('releases')
     );
-    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
-      'href',
-      APP_ROUTES.CHAT
-    );
+    expect(
+      screen.getByRole('link', { name: 'New Conversation' })
+    ).toHaveAttribute('href', APP_ROUTES.CHAT);
   });
 
   it('shows grouped admin navigation with growth links for admin users', () => {
@@ -267,7 +265,7 @@ describe('DashboardNav interactions', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(screen.getByText('Chats')).toBeInTheDocument();
+    expect(screen.getByText('Conversations')).toBeInTheDocument();
     expect(mockUseChatConversationsQuery).toHaveBeenCalledWith({
       limit: 10,
       enabled: true,
@@ -278,7 +276,9 @@ describe('DashboardNav interactions', () => {
       '/app/chat/thread-newer'
     );
     expect(
-      screen.getByRole('button', { name: 'Chat actions for Pitch tasks' })
+      screen.getByRole('button', {
+        name: 'Conversation Actions for Pitch tasks',
+      })
     ).toBeInTheDocument();
   });
 
@@ -308,9 +308,11 @@ describe('DashboardNav interactions', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(screen.getAllByRole('link', { name: 'New Chat' })).toHaveLength(1);
     expect(
-      screen.getByRole('button', { name: 'New Chat' })
+      screen.getAllByRole('link', { name: 'New Conversation' })
+    ).toHaveLength(1);
+    expect(
+      screen.getByRole('button', { name: 'New Conversation' })
     ).toBeInTheDocument();
   });
 

--- a/apps/web/tests/e2e/electron-titlebar-geometry.spec.ts
+++ b/apps/web/tests/e2e/electron-titlebar-geometry.spec.ts
@@ -102,9 +102,11 @@ async function assertElectronShellControls(
     page.locator('[data-testid="electron-sidebar-toggle"]')
   ).toHaveCount(1);
   await expect(page.locator('[data-sidebar="trigger"]')).toHaveCount(0);
-  await expect(page.locator('header a[aria-label="New Chat"]')).toHaveCount(0);
+  await expect(
+    page.locator('header a[aria-label="New Conversation"]')
+  ).toHaveCount(0);
   const newChatRowCount = await page
-    .getByRole('link', { name: 'New Chat' })
+    .getByRole('link', { name: 'New Conversation' })
     .count();
   expect(newChatRowCount).toBeLessThanOrEqual(1);
   if (expectedNewChatRows === 1) {
@@ -191,11 +193,15 @@ test('no duplicate sidebar dock button and titlebar toggle on the same page', as
   });
 
   await expect(page.locator('[data-sidebar="trigger"]')).toHaveCount(0);
-  await expect(page.locator('header a[aria-label="New Chat"]')).toHaveCount(0);
+  await expect(
+    page.locator('header a[aria-label="New Conversation"]')
+  ).toHaveCount(0);
   await expect(
     page.locator('[data-testid="electron-sidebar-toggle"]')
   ).toHaveCount(1);
-  await expect(page.getByRole('link', { name: 'New Chat' })).toHaveCount(1);
+  await expect(
+    page.getByRole('link', { name: 'New Conversation' })
+  ).toHaveCount(1);
 
   // The titlebar sidebar toggle must be present (it is the canonical one in Electron).
   const titlebarToggle = page.locator(

--- a/apps/web/tests/unit/app/dashboard-metadata.test.ts
+++ b/apps/web/tests/unit/app/dashboard-metadata.test.ts
@@ -118,7 +118,7 @@ describe('dashboard metadata generation', () => {
       params: Promise.resolve({ id: 'conversation-123' }),
     });
 
-    expect(metadata.title).toBe('Thread');
+    expect(metadata.title).toBe('Conversation');
   });
 
   it('keeps chat thread metadata queries outside the page module', () => {

--- a/apps/web/tests/unit/chat/ProfilePageChat.test.tsx
+++ b/apps/web/tests/unit/chat/ProfilePageChat.test.tsx
@@ -152,7 +152,7 @@ describe('ProfilePageChat', () => {
 
     const { getByRole } = renderProfilePageChat();
 
-    fireEvent.click(getByRole('button', { name: 'Reload chat' }));
+    fireEvent.click(getByRole('button', { name: 'Reload Conversation' }));
 
     expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/tests/unit/chat/breadcrumb-uuid.test.ts
+++ b/apps/web/tests/unit/chat/breadcrumb-uuid.test.ts
@@ -3,16 +3,16 @@ import { getDemoBreadcrumbSegment } from '@/hooks/useAuthRouteConfig';
 import { getBreadcrumbLabel } from '@/lib/constants/breadcrumb-labels';
 
 describe('getBreadcrumbLabel', () => {
-  it('returns "New chat" for the chat segment', () => {
-    expect(getBreadcrumbLabel('chat')).toBe('New chat');
+  it('returns "New Conversation" for the chat segment', () => {
+    expect(getBreadcrumbLabel('chat')).toBe('New Conversation');
   });
 
   it('returns "Dashboard" for the dashboard segment', () => {
     expect(getBreadcrumbLabel('dashboard')).toBe('Dashboard');
   });
 
-  it('returns "New chat" for the app root segment', () => {
-    expect(getBreadcrumbLabel('app')).toBe('New chat');
+  it('returns "New Conversation" for the app root segment', () => {
+    expect(getBreadcrumbLabel('app')).toBe('New Conversation');
   });
 
   it('converts unknown kebab-case to sentence case', () => {

--- a/apps/web/tests/unit/chat/useAuthRouteConfig.test.tsx
+++ b/apps/web/tests/unit/chat/useAuthRouteConfig.test.tsx
@@ -24,7 +24,7 @@ describe('useAuthRouteConfig', () => {
 
     expect(result.current.breadcrumbs).toEqual([
       {
-        label: 'New chat',
+        label: 'New Conversation',
         href: '/app/chat/conv-123',
       },
     ]);

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -151,7 +151,7 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
         expect.objectContaining({
           kind: 'nav',
           id: 'go-chats',
-          label: 'Chats',
+          label: 'Conversations',
           href: APP_ROUTES.CHATS,
         }),
       ])

--- a/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
+++ b/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
@@ -86,7 +86,7 @@ describe('DesktopTitlebar', () => {
       screen.getByTestId('electron-sidebar-toggle').querySelector('svg')
     ).toBeTruthy();
     expect(
-      screen.queryByRole('link', { name: 'New Chat' })
+      screen.queryByRole('link', { name: 'New Conversation' })
     ).not.toBeInTheDocument();
   });
 

--- a/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
+++ b/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
@@ -177,7 +177,7 @@ describe('UnifiedSidebar library route', () => {
     );
   });
 
-  it('omits header New Chat and the web collapse control in Electron dashboard mode', () => {
+  it('omits header New Conversation and the web collapse control in Electron dashboard mode', () => {
     renderUnifiedSidebar({
       designV1: false,
       pathname: APP_ROUTES.DASHBOARD,
@@ -186,7 +186,7 @@ describe('UnifiedSidebar library route', () => {
 
     expect(screen.getByText('Jovie', { selector: 'span' })).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: 'New Chat' })
+      screen.queryByRole('link', { name: 'New Conversation' })
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Collapse sidebar' })
@@ -205,7 +205,7 @@ describe('UnifiedSidebar library route', () => {
       screen.getByRole('button', { name: 'Collapse sidebar' })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: 'New Chat' })
+      screen.queryByRole('link', { name: 'New Conversation' })
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
@@ -70,7 +70,9 @@ describe('DashboardHeader', () => {
   it('prefers the breadcrumb suffix for the mobile title when present', () => {
     const { container } = render(
       <DashboardHeader
-        breadcrumbs={[{ label: 'New chat', href: '/app/chat/conv-123' }]}
+        breadcrumbs={[
+          { label: 'New Conversation', href: '/app/chat/conv-123' },
+        ]}
         breadcrumbSuffix={<span>Release planning thread</span>}
       />
     );
@@ -81,7 +83,7 @@ describe('DashboardHeader', () => {
     expect(
       within(mobileHeader!).getByText('Release planning thread')
     ).toBeInTheDocument();
-    expect(within(mobileHeader!).queryByText('New chat')).toBeNull();
+    expect(within(mobileHeader!).queryByText('New Conversation')).toBeNull();
   });
 
   it('collapses the breadcrumb when the search surface takes over', () => {

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -24,9 +24,9 @@ describe('DashboardNav', () => {
       renderFn: fastRender,
     });
 
-    expect(getByRole('link', { name: 'New Chat' }).getAttribute('href')).toBe(
-      APP_ROUTES.CHAT
-    );
+    expect(
+      getByRole('link', { name: 'New Conversation' }).getAttribute('href')
+    ).toBe(APP_ROUTES.CHAT);
     expect(getByRole('button', { name: 'Search' })).toBeDefined();
     expect(getByRole('link', { name: 'Releases' }).getAttribute('href')).toBe(
       buildLibraryViewRoute('releases')
@@ -110,7 +110,7 @@ describe('DashboardNav', () => {
     expect(releasesLink.getAttribute('aria-current')).toBe('page');
   });
 
-  it('only marks New Chat active on the chat root', () => {
+  it('only marks New Conversation active on the chat root', () => {
     mockUsePathname.mockReturnValueOnce(`${APP_ROUTES.CHAT}/thread-123`);
 
     const { getByRole } = renderDashboardNav({
@@ -119,11 +119,13 @@ describe('DashboardNav', () => {
     });
 
     expect(
-      getByRole('link', { name: 'New Chat' }).getAttribute('aria-current')
+      getByRole('link', { name: 'New Conversation' }).getAttribute(
+        'aria-current'
+      )
     ).toBeNull();
   });
 
-  it('keeps New Chat on the default shell tone when it is inactive', () => {
+  it('keeps New Conversation on the default shell tone when it is inactive', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.RELEASES);
 
     const { getByRole } = renderDashboardNav({
@@ -131,20 +133,20 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    const newThreadLink = getByRole('link', { name: 'New Chat' });
+    const newThreadLink = getByRole('link', { name: 'New Conversation' });
     expect(newThreadLink.className).toContain('text-sidebar-muted/80');
     expect(newThreadLink.className).not.toContain(
       'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)]'
     );
   });
 
-  it('renders one canonical New Chat nav row in Design V1', () => {
+  it('renders one canonical New Conversation nav row in Design V1', () => {
     const { getAllByRole } = renderDashboardNav({
       renderFn: fastRender,
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(getAllByRole('link', { name: 'New Chat' })).toHaveLength(1);
+    expect(getAllByRole('link', { name: 'New Conversation' })).toHaveLength(1);
   });
 
   it('opens the global command palette from Search instead of navigating', () => {
@@ -223,7 +225,7 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    const newThreadLink = getByRole('link', { name: 'New Chat' });
+    const newThreadLink = getByRole('link', { name: 'New Conversation' });
     expect(newThreadLink.className).toContain(
       'group-data-[collapsible=icon]:justify-center'
     );
@@ -239,7 +241,7 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(getByRole('link', { name: 'New Chat' })).toHaveAttribute(
+    expect(getByRole('link', { name: 'New Conversation' })).toHaveAttribute(
       'href',
       APP_ROUTES.CHAT
     );

--- a/apps/web/tests/unit/organisms/CommandPalette.test.tsx
+++ b/apps/web/tests/unit/organisms/CommandPalette.test.tsx
@@ -137,7 +137,7 @@ describe('CommandPalette', () => {
     fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
     expect(screen.getByText('Recent chats')).toBeInTheDocument();
     expect(screen.getByText('Q1 release plan')).toBeInTheDocument();
-    expect(screen.getByText('Untitled chat')).toBeInTheDocument();
+    expect(screen.getByText('Untitled conversation')).toBeInTheDocument();
   });
 
   it('routes a recent-chat commit to the chat route', () => {

--- a/apps/web/tests/unit/organisms/CommandPalette.test.tsx
+++ b/apps/web/tests/unit/organisms/CommandPalette.test.tsx
@@ -125,7 +125,7 @@ describe('CommandPalette', () => {
   it('opens on Cmd+K and shows the autofocused search input', () => {
     render(withDashboard(<CommandPalette />));
     fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
-    const input = screen.getByLabelText('Command palette search');
+    const input = screen.getByLabelText('Command Palette Search');
     expect(input).toBeInTheDocument();
     // React applies autofocus by calling .focus() on mount, not by emitting
     // the deprecated HTML attribute — assert focus state instead.
@@ -135,7 +135,7 @@ describe('CommandPalette', () => {
   it('lists recent chats with safe fallback titles', () => {
     render(withDashboard(<CommandPalette />));
     fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
-    expect(screen.getByText('Recent chats')).toBeInTheDocument();
+    expect(screen.getByText('Recent Conversations')).toBeInTheDocument();
     expect(screen.getByText('Q1 release plan')).toBeInTheDocument();
     expect(screen.getByText('Untitled conversation')).toBeInTheDocument();
   });
@@ -156,11 +156,11 @@ describe('CommandPalette', () => {
     render(withDashboard(<CommandPalette />));
     fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
     expect(
-      screen.queryByLabelText('Command palette search')
+      screen.queryByLabelText('Command Palette Search')
     ).toBeInTheDocument();
     fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
     expect(
-      screen.queryByLabelText('Command palette search')
+      screen.queryByLabelText('Command Palette Search')
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/threads/ThreadsPageClient.test.tsx
+++ b/apps/web/tests/unit/threads/ThreadsPageClient.test.tsx
@@ -92,10 +92,9 @@ describe('ChatsPageClient', () => {
       limit: 50,
     });
     expect(screen.queryByRole('heading', { name: 'Threads' })).toBeNull();
-    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
-      'href',
-      APP_ROUTES.CHAT
-    );
+    expect(
+      screen.getByRole('link', { name: 'New Conversation' })
+    ).toHaveAttribute('href', APP_ROUTES.CHAT);
 
     const threadLinks = screen
       .getAllByRole('link')
@@ -144,9 +143,12 @@ describe('ChatsPageClient', () => {
     );
     expect(document.querySelector('.anim-calm-breath')).toBeInTheDocument();
 
-    fireEvent.change(screen.getByRole('searchbox', { name: 'Search chats' }), {
-      target: { value: 'Pitch' },
-    });
+    fireEvent.change(
+      screen.getByRole('searchbox', { name: 'Search Conversations' }),
+      {
+        target: { value: 'Pitch' },
+      }
+    );
 
     expect(screen.queryByRole('link', { name: 'Unread answer' })).toBeNull();
     expect(
@@ -173,12 +175,19 @@ describe('ChatsPageClient', () => {
 
     render(<ThreadsPageClient />);
 
-    fireEvent.change(screen.getByRole('searchbox', { name: 'Search chats' }), {
-      target: { value: 'Missing' },
-    });
+    fireEvent.change(
+      screen.getByRole('searchbox', { name: 'Search Conversations' }),
+      {
+        target: { value: 'Missing' },
+      }
+    );
 
-    expect(screen.getByText('No chats match "Missing".')).toBeInTheDocument();
-    expect(screen.getAllByRole('link', { name: 'New Chat' })).toHaveLength(2);
+    expect(
+      screen.getByText('No conversations match "Missing".')
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('link', { name: 'New Conversation' })
+    ).toHaveLength(2);
   });
 
   it('opens per-chat actions from the hover menu and right-click', async () => {
@@ -207,7 +216,9 @@ describe('ChatsPageClient', () => {
     expect(copySessionId).toHaveBeenCalledWith('thread-newer');
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Chat actions for Pitch tasks' })
+      screen.getByRole('button', {
+        name: 'Conversation Actions for Pitch tasks',
+      })
     );
     fireEvent.click(screen.getByRole('menuitem', { name: 'Archive' }));
 
@@ -245,7 +256,9 @@ describe('ChatsPageClient', () => {
 
     render(<ThreadsPageClient />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Archive All Chats' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Archive All Conversations' })
+    );
     fireEvent.click(screen.getByRole('button', { name: 'Archive All' }));
 
     await waitFor(() => {
@@ -257,7 +270,7 @@ describe('ChatsPageClient', () => {
         conversationId: 'thread-newer',
       });
       expect(mockNotificationsSuccess).toHaveBeenCalledWith(
-        'All chats archived'
+        'All conversations archived'
       );
     });
   });


### PR DESCRIPTION
## Summary
- Standardize user-facing copy on **conversation** for the chat object (sidebar, conversations index, cmd+k, breadcrumbs, toasts, metadata fallbacks)
- Keep **Contacts** label unchanged
- Apply Title Case for nav/button labels per DESIGN.md

## Changes
- Sidebar: Chats → Conversations, New Chat → New Conversation, All Chats → All Conversations
- Conversations page: search, empty states, archive flows, and error copy
- Cmd+K / command palette: recent conversations section and placeholders
- Breadcrumbs, keyboard shortcuts, iOS recent list fallback copy
- Metadata fallback: Thread → Conversation

## Test plan
- [x] `pnpm run typecheck`
- [x] `biome check`
- [x] Pre-commit / pre-push hooks

linear-issue-id:JOV-3095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Terminology Updates**
- Updated user-facing copy and accessibility labels across the chat experience to consistently use “conversation(s)” terminology.
- Refreshed navigation, breadcrumbs, command palette, sidebar, and empty/error-state messaging to match the new wording.
- Updated metadata text and the default title fallback from “Thread” to “Conversation,” including related descriptions and error headlines.

**Tests**
- Updated unit, interaction, and E2E checks to align with the revised labels and accessible names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->