### PR TITLE
fix(ios): open native chat to all TestFlight testers (JOV-3238)

### DIFF
--- a/apps/web/app/api/mobile/v1/me/route.ts
+++ b/apps/web/app/api/mobile/v1/me/route.ts
@@ -4,7 +4,7 @@ import { isProfileComplete } from '@/lib/auth/profile-completeness';
 import { getSessionContext, SESSION_ERRORS } from '@/lib/auth/session';
 import { captureError } from '@/lib/error-tracking';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
-import { isMobileChatEnabledForUser } from '@/lib/mobile/chat/access';
+import { isMobileChatRuntimeEnabled } from '@/lib/mobile/chat/access';
 import { getMobileSessionUserId } from '@/lib/mobile/session-auth';
 import { isAppleWalletProfilePassAvailable } from '@/lib/wallet/apple/profile-pass';
 
@@ -106,9 +106,7 @@ export async function GET(request: Request) {
         isPublic: profile.isPublic,
         onboardingCompletedAt: profile.onboardingCompletedAt,
       });
-    const chatEnabled = await isMobileChatEnabledForUser(userId, {
-      isAdmin: session.user.isAdmin,
-    });
+    const chatEnabled = isMobileChatRuntimeEnabled();
     const payload: MobileMeResponse = {
       state: 'ready',
       displayName: profile.displayName,

--- a/apps/web/lib/mobile/chat/access.ts
+++ b/apps/web/lib/mobile/chat/access.ts
@@ -1,64 +1,15 @@
 import 'server-only';
 
-import { getSessionContext } from '@/lib/auth/session';
-import { getAppFlagValue } from '@/lib/flags/server';
-
 /**
- * Master environment switch. The native mobile chat runtime only serves turns on
- * environments that explicitly opt in via `MOBILE_CHAT_RUNTIME_ENABLED=true`.
- * Production stays off until launch is approved (see JOV-2550); alpha/staging opt in.
+ * Single control for native mobile chat. Chat is available to any authenticated
+ * iOS user when the runtime is enabled for the environment
+ * (`MOBILE_CHAT_RUNTIME_ENABLED=true`, set per-environment in Doppler).
+ *
+ * The iOS app is internal-TestFlight only today, so this scopes chat to alpha
+ * testers. To disable chat in an environment, flip the env switch off. Before a
+ * public App Store launch, re-introduce a per-user gate here (see JOV-3239) so
+ * production users don't get chat by default.
  */
 export function isMobileChatRuntimeEnabled(): boolean {
   return process.env.MOBILE_CHAT_RUNTIME_ENABLED === 'true';
-}
-
-/**
- * Per-user alpha cohort check. Admins always pass; everyone else must be inside the
- * `ios_app_alpha_access` Statsig gate. Fetches the session, so prefer
- * {@link isMobileChatEnabledForUser} with a known `isAdmin` when the caller has
- * already resolved the session.
- */
-export async function hasMobileChatAlphaAccess(
-  clerkUserId: string
-): Promise<boolean> {
-  const session = await getSessionContext({
-    clerkUserId,
-    requireUser: true,
-    requireProfile: false,
-  });
-
-  if (session.user.isAdmin) {
-    return true;
-  }
-
-  return getAppFlagValue('IOS_APP_ALPHA_ACCESS', {
-    userId: clerkUserId,
-  });
-}
-
-/**
- * Whether native mobile chat is actually usable for this user in this environment:
- * the runtime must be enabled AND the user must be in the alpha cohort (or admin).
- *
- * This is the single source of truth behind both the `/api/mobile/v1/chat/turns`
- * gate and the `chatEnabled` capability returned by `/api/mobile/v1/me`, so the iOS
- * client never renders a Chat tab that would only 501/403.
- *
- * Pass `isAdmin` when the caller already resolved the session to avoid a refetch.
- */
-export async function isMobileChatEnabledForUser(
-  clerkUserId: string,
-  options?: { readonly isAdmin?: boolean }
-): Promise<boolean> {
-  if (!isMobileChatRuntimeEnabled()) {
-    return false;
-  }
-
-  if (options?.isAdmin) {
-    return true;
-  }
-
-  return getAppFlagValue('IOS_APP_ALPHA_ACCESS', {
-    userId: clerkUserId,
-  });
 }

--- a/apps/web/lib/mobile/chat/turn-handler.ts
+++ b/apps/web/lib/mobile/chat/turn-handler.ts
@@ -21,12 +21,10 @@ import {
   isDeterministicIntent,
   routeIntent,
 } from '@/lib/intent-detection';
-import { hasMobileChatAlphaAccess } from '@/lib/mobile/chat/access';
 import { fetchMobileArtistContext } from '@/lib/mobile/chat/artist-context';
 import {
   buildMobileChatHandoffUrl,
   encodeMobileChatNdjsonEvent,
-  MOBILE_CHAT_ALPHA_REQUIRED_CODE,
   MOBILE_CHAT_PROFILE_REQUIRED_CODE,
   type MobileChatNdjsonEvent,
   type ParsedMobileChatTurnRequest,
@@ -103,14 +101,6 @@ export async function handleMobileChatTurn(
   parsed: ParsedMobileChatTurnRequest,
   signal: AbortSignal
 ): Promise<Response> {
-  if (!(await hasMobileChatAlphaAccess(userId))) {
-    return errorNdjsonResponse(
-      403,
-      MOBILE_CHAT_ALPHA_REQUIRED_CODE,
-      'Native chat is limited to internal alpha testers.'
-    );
-  }
-
   const session = await getSessionContext({
     clerkUserId: userId,
     requireUser: true,

--- a/apps/web/tests/unit/api/mobile/v1/me.test.ts
+++ b/apps/web/tests/unit/api/mobile/v1/me.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
   captureErrorMock: vi.fn(),
@@ -8,7 +8,6 @@ const hoisted = vi.hoisted(() => ({
   getSessionContextMock: vi.fn(),
   isProfileCompleteMock: vi.fn(),
   isAppleWalletProfilePassAvailableMock: vi.fn(),
-  isMobileChatEnabledForUserMock: vi.fn(),
 }));
 
 vi.mock('@/constants/domains', () => ({
@@ -42,10 +41,6 @@ vi.mock('@/lib/wallet/apple/profile-pass', () => ({
     hoisted.isAppleWalletProfilePassAvailableMock,
 }));
 
-vi.mock('@/lib/mobile/chat/access', () => ({
-  isMobileChatEnabledForUser: hoisted.isMobileChatEnabledForUserMock,
-}));
-
 const routeModulePromise = import('@/app/api/mobile/v1/me/route');
 
 function makeRequest() {
@@ -66,7 +61,11 @@ describe('GET /api/mobile/v1/me', () => {
     );
     hoisted.isProfileCompleteMock.mockReturnValue(true);
     hoisted.isAppleWalletProfilePassAvailableMock.mockResolvedValue(true);
-    hoisted.isMobileChatEnabledForUserMock.mockResolvedValue(true);
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', 'true');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('returns 401 when unauthenticated', async () => {
@@ -142,8 +141,8 @@ describe('GET /api/mobile/v1/me', () => {
     });
   });
 
-  it('reports chatEnabled from the mobile chat access gate', async () => {
-    hoisted.isMobileChatEnabledForUserMock.mockResolvedValue(false);
+  it('reports chatEnabled from the mobile chat runtime switch', async () => {
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', '');
     hoisted.getSessionContextMock.mockResolvedValue({
       user: {
         userStatus: 'active',
@@ -166,10 +165,6 @@ describe('GET /api/mobile/v1/me', () => {
 
     expect(response.status).toBe(200);
     expect(data.chatEnabled).toBe(false);
-    expect(hoisted.isMobileChatEnabledForUserMock).toHaveBeenCalledWith(
-      'user_123',
-      { isAdmin: false }
-    );
   });
 
   it('returns needs_onboarding when the DB user is missing', async () => {


### PR DESCRIPTION
<!-- linear-issue-id: JOV-3238 -->
Closes JOV-3238. Founder request ("flip it") — open native chat from admin-only to all TestFlight alpha testers, in code (Statsig isn't reachable from the code workspace).

## What
Collapse mobile chat gating to the **`MOBILE_CHAT_RUNTIME_ENABLED`** env switch (already true in dev/stg/prd) and drop the `ios_app_alpha_access` Statsig sub-gate from the chat path:
- `lib/mobile/chat/access.ts` → single `isMobileChatRuntimeEnabled()` control.
- `/api/mobile/v1/me`: `chatEnabled` reflects the runtime switch (so the Chat tab shows for all testers).
- `lib/mobile/chat/turn-handler.ts`: removed the `MOBILE_CHAT_ALPHA_REQUIRED` 403 — the route already gates on the env switch.

The iOS app is **internal-TestFlight only** today, so "all authenticated users" == "all alpha testers". Admins already passed. The `ios_app_alpha_access` flag is untouched for the separate iOS **install**-gating surfaces.

## Safety / reversibility
- Off-switch unchanged: set `MOBILE_CHAT_RUNTIME_ENABLED` to anything but `true` in an environment → chat returns 501 (unavailable). 
- **Before a public App Store launch**, re-gate per-user — tracked in **JOV-3239** (and the code comment points there).

## Verification (local)
- `pnpm --filter @jovie/web run typecheck` — clean (exit 0)
- `pnpm biome check` — clean
- Vitest (25 passing): `me.test` (now env-stubbed + deterministic; chatEnabled true/false via the runtime switch), `chat-turns`, `chat-conversations`, `chat-contract`, `chat/turns`.

## Cost note
No new recurring calls. Broadens who can send chat turns (one LLM call per turn) from admins to all current TestFlight testers — bounded by the small alpha tester set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)