### PR TITLE
feat(onboarding): world-class invisible-first Turnstile security check

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
+++ b/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { Skeleton } from '@jovie/ui';
+import { RotateCcw, ShieldAlert, ShieldCheck, ShieldOff } from 'lucide-react';
+import { useReducedMotion } from 'motion/react';
 import Script from 'next/script';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { publicEnv } from '@/lib/env-public';
@@ -114,6 +117,44 @@ function getHeading(status: OnboardingTurnstileStatus) {
   return 'Security Check';
 }
 
+type TurnstileTone = 'neutral' | 'success' | 'warning' | 'muted';
+
+const TONE_BADGE_CLASSES: Record<TurnstileTone, string> = {
+  neutral: 'border-subtle bg-surface-0 text-secondary-token',
+  success: 'border-success/30 bg-success/10 text-success',
+  warning: 'border-warning/30 bg-warning/10 text-warning',
+  muted: 'border-subtle bg-surface-0 text-tertiary-token',
+};
+
+function getStatusTone(status: OnboardingTurnstileStatus): TurnstileTone {
+  if (status === 'verified' || status === 'bypassed') return 'success';
+  if (status === 'error' || status === 'timeout' || status === 'expired') {
+    return 'warning';
+  }
+  if (status === 'unsupported' || status === 'unconfigured') return 'muted';
+  return 'neutral';
+}
+
+function TurnstileStatusIcon({
+  status,
+  className,
+}: {
+  readonly status: OnboardingTurnstileStatus;
+  readonly className?: string;
+}) {
+  switch (getStatusTone(status)) {
+    case 'warning':
+      return <ShieldAlert className={className} strokeWidth={2} />;
+    case 'muted':
+      return <ShieldOff className={className} strokeWidth={2} />;
+    default:
+      return <ShieldCheck className={className} strokeWidth={2} />;
+  }
+}
+
+/** Hold the "Verified" confirmation briefly before the panel collapses. */
+const VERIFIED_MOMENT_MS = 600;
+
 export function isOnboardingTurnstilePanelVisible(
   state: OnboardingTurnstileState,
   instruction?: string | null,
@@ -143,7 +184,13 @@ export function OnboardingTurnstile({
   const lastResetSignalRef = useRef(resetSignal);
   const widgetDomId = useId();
   const headingId = useId();
+  const reducedMotion = useReducedMotion();
   const [state, setState] = useState<OnboardingTurnstileState>(DEFAULT_STATE);
+  // True only while the brief "Verified" confirmation is held open after a
+  // *visible* challenge. Silent (invisible-first) verifications never set it,
+  // so the panel stays collapsed when the user never saw a challenge.
+  const [verifiedMoment, setVerifiedMoment] = useState(false);
+  const panelVisibleRef = useRef(false);
   const siteKey = publicEnv.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
   const shouldBypassTurnstile =
     process.env.NODE_ENV === 'development' ||
@@ -188,6 +235,11 @@ export function OnboardingTurnstile({
         theme: 'dark',
         callback: token => {
           onToken(token);
+          // Only celebrate when the user actually saw a challenge. Silent
+          // invisible-first verifications collapse straight away (no UI churn).
+          if (panelVisibleRef.current && !reducedMotion) {
+            setVerifiedMoment(true);
+          }
           commitState({ status: 'verified' });
         },
         'error-callback': code =>
@@ -230,11 +282,21 @@ export function OnboardingTurnstile({
       });
       console.error('[onboarding] turnstile render error', err);
     }
-  }, [commitState, onToken, shouldBypassTurnstile, siteKey]);
+  }, [commitState, onToken, reducedMotion, shouldBypassTurnstile, siteKey]);
+
+  useEffect(() => {
+    if (!verifiedMoment) return;
+    const timer = setTimeout(
+      () => setVerifiedMoment(false),
+      VERIFIED_MOMENT_MS
+    );
+    return () => clearTimeout(timer);
+  }, [verifiedMoment]);
 
   const resetWidget = useCallback(
     (message = 'Verification reset. Complete the check to retry.') => {
       clearWidget();
+      setVerifiedMoment(false);
       commitState({ status: 'loading', message });
       render();
     },
@@ -282,6 +344,17 @@ export function OnboardingTurnstile({
     panelRef.current?.focus({ preventScroll: true });
   }, [focusSignal]);
 
+  const shouldShowPanel =
+    isOnboardingTurnstilePanelVisible(state, instruction, siteKey) ||
+    verifiedMoment;
+  // Track the panel's visibility so the success callback can tell a *visible*
+  // challenge (worth a "Verified" beat) from a silent invisible verification.
+  // Synced in an effect (never written during render) so the value reflects the
+  // last committed render when Cloudflare's async callback fires.
+  useEffect(() => {
+    panelVisibleRef.current = shouldShowPanel;
+  }, [shouldShowPanel]);
+
   if (shouldBypassTurnstile) {
     // No Turnstile UI in dev. The server-side dev-mode skip still owns trust.
     return null;
@@ -292,11 +365,6 @@ export function OnboardingTurnstile({
     state.status === 'error' ||
     state.status === 'expired' ||
     state.status === 'timeout';
-  const shouldShowPanel = isOnboardingTurnstilePanelVisible(
-    state,
-    instruction,
-    siteKey
-  );
   const shouldShowWidgetFrame =
     shouldShowPanel &&
     siteKey &&
@@ -304,7 +372,11 @@ export function OnboardingTurnstile({
       state.status === 'error' ||
       state.status === 'expired' ||
       state.status === 'timeout' ||
+      // Keep the frame reserved through the "Verified" beat so the panel
+      // collapses in one clean step instead of shrinking twice.
+      verifiedMoment ||
       Boolean(instruction));
+  const tone = getStatusTone(state.status);
 
   return (
     <>
@@ -327,27 +399,41 @@ export function OnboardingTurnstile({
             'focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
           )}
         >
-          <div className='flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between'>
-            <div className='min-w-0'>
-              <p
-                id={headingId}
-                className='text-app font-medium leading-5 text-primary-token'
-              >
-                {getHeading(state.status)}
-              </p>
-              <p className='mt-0.5 max-w-[34rem] text-2xs leading-5 text-secondary-token sm:text-[12px]'>
-                {panelCopy}
-              </p>
+          <div className='flex items-start gap-2.5'>
+            <span
+              aria-hidden='true'
+              data-testid='onboarding-turnstile-icon'
+              data-turnstile-icon={state.status}
+              className={cn(
+                'mt-px flex size-7 shrink-0 items-center justify-center rounded-[8px] border transition-colors duration-subtle',
+                TONE_BADGE_CLASSES[tone]
+              )}
+            >
+              <TurnstileStatusIcon status={state.status} className='size-4' />
+            </span>
+            <div className='flex min-w-0 flex-1 flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between'>
+              <div className='min-w-0'>
+                <p
+                  id={headingId}
+                  className='text-app font-medium leading-5 text-primary-token'
+                >
+                  {getHeading(state.status)}
+                </p>
+                <p className='mt-0.5 max-w-[34rem] text-2xs leading-5 text-secondary-token sm:text-[12px]'>
+                  {panelCopy}
+                </p>
+              </div>
+              {isActionable ? (
+                <button
+                  type='button'
+                  onClick={() => resetWidget()}
+                  className='inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full border border-subtle px-2.5 text-2xs font-medium text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
+                >
+                  <RotateCcw className='size-3.5' aria-hidden='true' />
+                  Retry Verification
+                </button>
+              ) : null}
             </div>
-            {isActionable ? (
-              <button
-                type='button'
-                onClick={() => resetWidget()}
-                className='h-7 shrink-0 rounded-full border border-subtle px-2.5 text-2xs font-medium text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
-              >
-                Retry Verification
-              </button>
-            ) : null}
           </div>
         </section>
       ) : null}
@@ -355,17 +441,25 @@ export function OnboardingTurnstile({
         <div
           className={cn(
             shouldShowWidgetFrame
-              ? 'mt-2.5 overflow-hidden rounded-[10px] border border-subtle bg-surface-0'
+              ? 'relative mt-2 overflow-hidden rounded-[8px] border border-subtle bg-surface-0 p-1.5'
               : 'sr-only h-0 overflow-hidden',
             !shouldShowPanel && 'sr-only h-0 overflow-hidden'
           )}
           data-testid='onboarding-turnstile-widget-frame'
           aria-hidden={!shouldShowWidgetFrame ? 'true' : undefined}
         >
+          {shouldShowWidgetFrame && state.status !== 'verified' ? (
+            <Skeleton
+              aria-hidden='true'
+              data-testid='onboarding-turnstile-widget-skeleton'
+              rounded='md'
+              className='pointer-events-none absolute inset-1.5'
+            />
+          ) : null}
           <div
             ref={containerRef}
             id={`cf-turnstile-${widgetDomId}`}
-            className='min-h-[64px]'
+            className='relative min-h-[64px]'
           />
         </div>
       ) : null}

--- a/apps/web/tests/setup-optimized.ts
+++ b/apps/web/tests/setup-optimized.ts
@@ -165,6 +165,7 @@ vi.mock('motion/react', () => ({
           children ?? null,
     }
   ),
+  useReducedMotion: () => false,
 }));
 
 vi.mock('@headlessui/react', async () => {

--- a/apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
@@ -298,4 +298,128 @@ describe('OnboardingTurnstile', () => {
     expect(removeMock).toHaveBeenCalledWith('widget-1');
     expect(renderMock).toHaveBeenCalledTimes(2);
   });
+
+  it('renders a state-aware security icon badge', async () => {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY', 'site-key');
+    const renderMock = vi.fn(
+      (_target: HTMLElement, _options: TurnstileOptions) => 'widget-1'
+    );
+    window.turnstile = {
+      render: renderMock,
+      reset: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    render(<OnboardingTurnstile onToken={vi.fn()} onStateChange={vi.fn()} />);
+
+    await waitFor(() => expect(renderMock).toHaveBeenCalled());
+    const options = renderMock.mock.calls[0]?.[1];
+
+    act(() => options?.['before-interactive-callback']?.());
+    expect(screen.getByTestId('onboarding-turnstile-icon')).toHaveAttribute(
+      'data-turnstile-icon',
+      'interactive'
+    );
+
+    act(() => options?.['error-callback']?.('bad-token'));
+    expect(screen.getByTestId('onboarding-turnstile-icon')).toHaveAttribute(
+      'data-turnstile-icon',
+      'error'
+    );
+  });
+
+  it('shows a shimmer placeholder in the widget frame during a challenge', async () => {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY', 'site-key');
+    const renderMock = vi.fn(
+      (_target: HTMLElement, _options: TurnstileOptions) => 'widget-1'
+    );
+    window.turnstile = {
+      render: renderMock,
+      reset: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    render(<OnboardingTurnstile onToken={vi.fn()} onStateChange={vi.fn()} />);
+
+    await waitFor(() => expect(renderMock).toHaveBeenCalled());
+    const options = renderMock.mock.calls[0]?.[1];
+
+    // Silent loading: no challenge UI, so no shimmer.
+    expect(
+      screen.queryByTestId('onboarding-turnstile-widget-skeleton')
+    ).not.toBeInTheDocument();
+
+    act(() => options?.['before-interactive-callback']?.());
+    expect(
+      screen.getByTestId('onboarding-turnstile-widget-skeleton')
+    ).toBeInTheDocument();
+  });
+
+  it('holds a brief Verified confirmation after a visible challenge, then collapses', async () => {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY', 'site-key');
+    const onToken = vi.fn();
+    const onStateChange = vi.fn();
+    const renderMock = vi.fn(
+      (_target: HTMLElement, _options: TurnstileOptions) => 'widget-1'
+    );
+    window.turnstile = {
+      render: renderMock,
+      reset: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    render(
+      <OnboardingTurnstile onToken={onToken} onStateChange={onStateChange} />
+    );
+
+    await waitFor(() => expect(renderMock).toHaveBeenCalled());
+    const options = renderMock.mock.calls[0]?.[1];
+
+    // The user actually sees a challenge first.
+    act(() => options?.['before-interactive-callback']?.());
+    expect(screen.getByTestId('onboarding-turnstile-panel')).toBeVisible();
+
+    // Success while visible holds a brief "Verified" beat.
+    act(() => options?.callback('turnstile-token'));
+    expect(screen.getByTestId('onboarding-turnstile-panel')).toHaveAttribute(
+      'data-turnstile-status',
+      'verified'
+    );
+    expect(screen.getByText('Verified')).toBeVisible();
+
+    // The panel collapses once the confirmation hold elapses.
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('onboarding-turnstile-panel')
+      ).not.toBeInTheDocument()
+    );
+    expect(onToken).toHaveBeenCalledWith('turnstile-token');
+  });
+
+  it('collapses immediately on a silent verification (no challenge shown)', async () => {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY', 'site-key');
+    const renderMock = vi.fn(
+      (_target: HTMLElement, _options: TurnstileOptions) => 'widget-1'
+    );
+    window.turnstile = {
+      render: renderMock,
+      reset: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    render(<OnboardingTurnstile onToken={vi.fn()} onStateChange={vi.fn()} />);
+
+    await waitFor(() => expect(renderMock).toHaveBeenCalled());
+    const options = renderMock.mock.calls[0]?.[1];
+
+    // No before-interactive callback: token arrives silently.
+    act(() => options?.callback('turnstile-token'));
+    expect(
+      screen.queryByTestId('onboarding-turnstile-panel')
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## What

Makes the onboarding chat's Cloudflare Turnstile gate (`/start` first-message check) **world-class and invisible-first**. The widget already mounts on load and silently obtains a token; this polishes the *rare* visible fallback so it reads as a designed surface, not a stock CAPTCHA embed.

Screenshot context: the "Security Check" panel that appears above the composer when Cloudflare actually challenges.

## Changes (presentation only)

`apps/web/components/features/onboarding/OnboardingTurnstile.tsx`:
- **State-aware security badge** — Lucide `ShieldCheck`/`ShieldAlert`/`ShieldOff` in a quiet rounded badge, tinted with semantic `success`/`warning`/`muted` tokens by status.
- **Integrated widget frame** — `rounded-[8px]` + inner padding so the Cloudflare iframe reads as one block.
- **Loading shimmer** — reduced-motion-aware `Skeleton` behind the iframe; `min-h-[64px]` reserves space → **no layout shift** when the iframe paints.
- **Refined retry** — `RotateCcw` icon + premium pill, color/border transitions only (no hover motion).
- **"Verified" moment** — after a *visible* challenge, holds a ~600ms success beat then collapses in one clean step; silent verifications collapse instantly. Respects `prefers-reduced-motion`.

The Turnstile state machine, callbacks, env handling, `isOnboardingTurnstilePanelVisible`, and the `OnboardingChat`/`ChatInput` integration are unchanged.

Also adds `useReducedMotion` to the shared `motion/react` test mock (the real module exports it).

## Why

First step of an invisible-first Turnstile initiative: keep bot protection invisible whenever possible, and when Cloudflare does challenge, present a minimal premium panel rather than a giant CAPTCHA card.

## Tests
- `OnboardingTurnstile.test.tsx` — 12 passed (8 existing kept green + 4 new: icon badge by status, loading shimmer, verified-hold→collapse, silent-collapse).
- `OnboardingChat.turnstile.test.tsx` — 9 passed.
- Typecheck ✓ · Biome ✓ · ESLint ✓ · Tailwind guard ✓.

## Risk-based testing
New branch behavior (verified-moment timing, icon-by-status) is covered by unit tests; this is the bugfix/feature path. No auth/billing/DB surface touched.

## Layout shift
Mandatory audit done: the `min-h-[64px]` reserved frame + shimmer means the iframe paint causes no shift; the verified beat collapses the panel in a single step (no double shrink). Reduced-motion collapses instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)