### PR TITLE
fix(growth-access): rate-limit the early-access request endpoint

### DIFF
--- a/apps/web/app/api/growth-access-request/route.ts
+++ b/apps/web/app/api/growth-access-request/route.ts
@@ -14,6 +14,11 @@ import { users } from '@/lib/db/schema/auth';
 import { captureError } from '@/lib/error-tracking';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
 import { notifySlackGrowthRequest } from '@/lib/notifications/providers/slack';
+import {
+  createRateLimitHeaders,
+  generalLimiter,
+  getClientIP,
+} from '@/lib/rate-limit';
 import { logger } from '@/lib/utils/logger';
 
 const growthAccessSchema = z.object({
@@ -27,6 +32,20 @@ const growthAccessSchema = z.object({
 export async function POST(request: Request) {
   const { userId, error } = await requireAuth();
   if (error) return error;
+
+  // Defense in depth: even though this is auth-gated and one-shot per user,
+  // rate-limit by user (falling back to IP) so a scripted client can't hammer
+  // the DB write + Slack notification path.
+  const rateLimit = await generalLimiter.limit(userId ?? getClientIP(request));
+  if (!rateLimit.success) {
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again in a moment.' },
+      {
+        status: 429,
+        headers: { ...NO_STORE_HEADERS, ...createRateLimitHeaders(rateLimit) },
+      }
+    );
+  }
 
   try {
     const body = await request.json();

--- a/apps/web/tests/unit/api/growth-access-request/route.test.ts
+++ b/apps/web/tests/unit/api/growth-access-request/route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireAuth = vi.hoisted(() => vi.fn());
+const mockLimit = vi.hoisted(() => vi.fn());
+const mockGetClientIP = vi.hoisted(() => vi.fn());
+const mockSelectLimit = vi.hoisted(() => vi.fn());
+const mockUpdateWhere = vi.hoisted(() => vi.fn());
+const mockNotifySlackGrowthRequest = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/require-auth', () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  generalLimiter: { limit: mockLimit },
+  getClientIP: mockGetClientIP,
+  createRateLimitHeaders: () => ({ 'X-RateLimit-Limit': '60' }),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: mockSelectLimit }) }),
+    }),
+    update: () => ({ set: () => ({ where: mockUpdateWhere }) }),
+  },
+}));
+
+vi.mock('@/lib/notifications/providers/slack', () => ({
+  notifySlackGrowthRequest: mockNotifySlackGrowthRequest,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+function requestWith(body: unknown): Request {
+  return new Request('http://localhost/api/growth-access-request', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/growth-access-request', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockRequireAuth.mockResolvedValue({ userId: 'clerk_1', error: null });
+    mockGetClientIP.mockReturnValue('127.0.0.1');
+    mockLimit.mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: new Date(Date.now() + 60_000),
+    });
+    // Already requested -> route returns 409 before any write, keeping the
+    // happy-path test focused on the limiter wiring.
+    mockSelectLimit.mockResolvedValue([
+      {
+        id: 'user_1',
+        name: 'Test User',
+        email: 'test@example.com',
+        plan: 'free',
+        growthAccessRequestedAt: new Date(),
+      },
+    ]);
+    mockUpdateWhere.mockResolvedValue(undefined);
+    mockNotifySlackGrowthRequest.mockResolvedValue(undefined);
+  });
+
+  it('rate-limits by authenticated user id', async () => {
+    const { POST } = await import('@/app/api/growth-access-request/route');
+
+    await POST(requestWith({ reason: 'Smart links sound great' }));
+
+    expect(mockLimit).toHaveBeenCalledWith('clerk_1');
+  });
+
+  it('returns 429 before touching the database when the limiter rejects', async () => {
+    mockLimit.mockResolvedValueOnce({
+      success: false,
+      limit: 60,
+      remaining: 0,
+      reset: new Date(Date.now() + 60_000),
+    });
+
+    const { POST } = await import('@/app/api/growth-access-request/route');
+
+    const response = await POST(
+      requestWith({ reason: 'Smart links sound great' })
+    );
+
+    expect(response.status).toBe(429);
+    expect(mockSelectLimit).not.toHaveBeenCalled();
+    expect(mockNotifySlackGrowthRequest).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

`/api/growth-access-request` was the one public-ish POST route with **no rate limiting**. Adds the canonical `generalLimiter` keyed by the authenticated user (IP fallback) as defense-in-depth.

## Changes
- `app/api/growth-access-request/route.ts` — rate-limit before any DB/Slack work; return 429 with rate-limit headers when exceeded.
- `tests/unit/api/growth-access-request/route.test.ts` — asserts the limiter is keyed by user id and that a rejected limit returns 429 **before** touching the database or Slack.

## Audit
This closes the last unprotected POST found in the earlier audit. For reference, the other public/anonymous POSTs already have limiters: changelog subscribe, feedback, onboarding chat (triple), tip checkout, waitlist.

## Why
"Rate limiting in addition to Turnstile" — every endpoint that triggers a DB write + outbound notification should have a flood guard, even auth-gated one-shot ones.

## Tests
- 2 passed · Typecheck ✓ · Biome ✓.

## Risk-based testing
New branch (the 429 path) is covered. No schema/auth/billing change; reuses existing limiter infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)