### PR TITLE
perf(ios): rock-solid, blazing-fast native app (cache-first, off-main rendering, 0 jank) + guardrails

### DIFF
--- a/.claude/rules/ios.md
+++ b/.claude/rules/ios.md
@@ -1,0 +1,68 @@
+# iOS (Native SwiftUI App)
+
+Operating rules for the native iOS app at `apps/ios` (SwiftUI, dark-only, Clerk-auth, TestFlight via Fastlane). Read this before touching any Swift under `apps/ios/`.
+
+The north star: **rock solid and blazing fast — 0 jank.** Every change should make the existing surface faster or more robust, never add main-thread work, flicker, or layout shift.
+
+## Hard Invariants (Enforced by `scripts/ios-best-practices-lint.sh`)
+
+The guardrail lint runs in `ios-ci.yml` and via `pnpm run ios:lint`. It scans production Swift (`apps/ios/Jovie/**`, tests excluded) and **fails the build** on any of these:
+
+| Rule | Blocks | Why | Fix |
+|------|--------|-----|-----|
+| `no-raw-asyncimage` | `AsyncImage(` | Re-fetches and flashes its placeholder on every appearance; no cross-instance cache → avatar flicker | Use a cached, off-main loader (`AvatarImageCache` + `AvatarImageLoader` in `DashboardView.swift`) |
+| `no-coreimage-in-views` | `CIContext(` / `createCGImage(` outside `*Renderer.swift` | CoreImage/CGImage generation is CPU-bound; in a `body` it hitches the first paint | Put it in a dedicated cache-backed `*Renderer.swift` and render via `Task.detached` (see `QRCodeRenderer.imageAsync`) |
+| `no-main-thread-blocking` | `DispatchQueue.main.sync`, `Thread.sleep`, `usleep`, `DispatchSemaphore`, `Data(contentsOf:)` | Blocks the render loop → dropped frames | `async`/`await`: `Task`, `URLSession.data`, `Task.sleep` |
+| `no-userdefaults-synchronize` | `.synchronize()` | Deprecated; forces a blocking disk flush | Delete it — `UserDefaults` persists automatically |
+| `no-print` | `print(` | Invisible in production, ships noise | Use the `Observability` layer |
+| `no-force-try` | `try!` | Crashes the whole app on any thrown error | `try?` or `do`/`catch` |
+
+Do **not** add an inline-ignore escape hatch to this lint (same spirit as the web `no biome-ignore` rule). If a rule is genuinely wrong for a case, fix the rule with review — don't suppress it.
+
+## Performance Canon
+
+### Cache-first, stale-while-revalidate
+
+Network-bound screens must paint cached data **instantly**, then revalidate in the background and swap. Never make a returning user wait on a round-trip to see content they already have.
+
+- `MeRepository.cachedSnapshot(for:)` returns the last persisted profile with no network.
+- `AppState.handleSignedInUserChange` paints the cache first, then `loadMe` revalidates and swaps.
+- `isOffline` is only set when revalidation fails and stale data is retained — a cache paint that is being revalidated is **not** "offline".
+- Preserve the dedupe (`loadingUserID`), cancellation (`activeUserID == userID` guards), 401, and sign-out guards on any change to this path. They are covered by `AppStateTests`.
+
+### Image loading
+
+- Decode and downsample **off the main actor** (non-isolated `async` function or `Task.detached`).
+- Cache decoded bitmaps process-wide (`NSCache`) keyed by URL, and **seed view `@State` from the cache synchronously in `init`** so a previously-loaded image shows on the first frame (no placeholder flash).
+- Downsample to display size (`byPreparingThumbnail`) to keep memory and compositing cheap.
+
+### Heavy rendering
+
+- CoreImage / Core Graphics / PDF / large-bitmap work lives in a dedicated `*Renderer.swift`, is `NSCache`-backed, exposes a `cachedImage(...)` peek and an `imageAsync(...) async` (via `Task.detached`), and is **never** called from a `body`.
+
+## Layout Shift Prevention (Mandatory)
+
+Same contract as the web app (`.claude/rules/ui.md` → "Layout Shift Prevention"), applied to SwiftUI. Before editing any view, enumerate every visual state it can render (loading, empty, error, partial, success, offline, signed-out, etc.) and verify **no state transition shifts layout**:
+
+- Reserve space for conditional content up front. For async media, use a fixed `aspectRatio` + `frame(maxWidth:)` container that exists in every state (see `QRCodeCardView` — square footprint reserved while the QR renders).
+- Skeletons must mirror the loaded layout's dimensions and alignment so skeleton → loaded does not jump (see `DashboardView.skeleton`).
+- Prefer `opacity`/`transition(.opacity)` for content swaps; never animate `height`/`margin` in a way that reflows siblings.
+- No decorative spatial motion (translate/scale/lift) for hover/press polish — match the web taste rule.
+
+## Verification (Before Claiming Done)
+
+- `pnpm run ios:lint` — guardrail lint (fast, no simulator).
+- `pnpm run ios:test` — builds + runs unit/UI tests on a simulator (`apps/ios/scripts/run-xcodebuild.sh`).
+- New behavior gets a unit test; new view state gets a layout-shift check. Tests live in existing files under `apps/ios/JovieTests/` unless a new file is added to `project.pbxproj` (the project does **not** use synchronized file groups — new files require explicit pbxproj entries, so prefer extending existing files).
+- The local `Configuration.local.plist` is generated and gitignored (`apps/ios/scripts/ensure-configuration.sh`); never commit it.
+
+## Company-Wide Portability (Apply These Guardrails to Every iOS-Touching Repo)
+
+`scripts/ios-best-practices-lint.sh` is intentionally self-contained and portable — it takes a target directory and has no repo-specific dependencies. Any company repo that ships iOS/SwiftUI code must run it:
+
+1. Vendor `scripts/ios-best-practices-lint.sh` into the repo (copy as-is).
+2. Add a CI step before the Swift build: `bash scripts/ios-best-practices-lint.sh <swift-source-dir>` (mirror the `iOS best-practices lint` step in `.github/workflows/ios-ci.yml`).
+3. Add a `pnpm run ios:lint` (or equivalent) pointing at the repo's Swift source dir.
+4. Adopt the performance canon and layout-shift rules above in that repo's agent rules.
+
+Rollout to other repos is tracked in Linear (this repo cannot edit other repos). When standing up iOS code in a new repo, copy the lint and wire the CI step in the same PR — do not ship SwiftUI without the guardrail.

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: iOS best-practices lint
+        run: bash scripts/ios-best-practices-lint.sh apps/ios/Jovie
+
       - name: Ensure iOS local configuration exists
         run: bash apps/ios/scripts/ensure-configuration.sh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ These rules will block your changes if violated.
 - **Outbound email personalization must fail safe (generic fallback)** → [`.claude/rules/security.md`](.claude/rules/security.md)
 - **Entitlements: single source of truth (`getCurrentUserEntitlements()`)** → [`.claude/rules/security.md`](.claude/rules/security.md)
 - **Performance must not replace route UIs (same design, faster)** → [`.claude/rules/ui.md`](.claude/rules/ui.md)
+- **iOS: no raw `AsyncImage`, no CoreImage in views, no main-thread blocking, cache-first loads** → [`.claude/rules/ios.md`](.claude/rules/ios.md)
 - **Founder/featured-creator identity must be canonical (Tim White Spotify ID `4u`)** → [`.claude/rules/ui.md`](.claude/rules/ui.md)
 - **Bot review comments (CodeRabbit, Greptile) block merge** → [`.claude/rules/release.md`](.claude/rules/release.md)
 - **Conventional commits required** → [`.claude/rules/release.md`](.claude/rules/release.md)
@@ -135,6 +136,7 @@ Read the file for the topic you're touching. More-local instructions override th
 | [`.claude/rules/ci-branching.md`](.claude/rules/ci-branching.md) | Agent integration branches, train PRs, CI throughput for parallel work |
 | [`.claude/rules/testing.md`](.claude/rules/testing.md) | E2E patterns, test perf, coverage, verify-before-done |
 | [`.claude/rules/infra.md`](.claude/rules/infra.md) | Cron, API budgets, forbidden infra, cost disclosure, API runtime |
+| [`.claude/rules/ios.md`](.claude/rules/ios.md) | Native SwiftUI app: cache-first loads, off-main rendering, image caching, layout shift, guardrail lint, company-wide portability |
 | [`.claude/rules/code-style.md`](.claude/rules/code-style.md) | TypeScript, React, server/client boundaries, canonical imports, ESLint, hooks |
 | [`.claude/rules/linear.md`](.claude/rules/linear.md) | Issue gating, ownership contract |
 | [`.claude/rules/gstack.md`](.claude/rules/gstack.md) | Vendored toolkit, skill routing |

--- a/apps/ios/Jovie/App/AppState.swift
+++ b/apps/ios/Jovie/App/AppState.swift
@@ -11,6 +11,13 @@ enum DashboardLoadState: Equatable {
 protocol AppStateRepository: Sendable {
   func loadMe(for clerkUserID: String) async throws -> MeRepositoryResult
   func clearCachedUser(_ clerkUserID: String) async
+  func cachedSnapshot(for clerkUserID: String) async -> MobileMeResponse?
+}
+
+extension AppStateRepository {
+  /// Default: no cached snapshot. Concrete repositories that persist profiles
+  /// (e.g. ``MeRepository``) override this to enable instant cache-first paint.
+  func cachedSnapshot(for _: String) async -> MobileMeResponse? { nil }
 }
 
 extension MeRepository: AppStateRepository {}
@@ -108,10 +115,25 @@ final class AppState {
       }
     }
 
-    route = .launching
-    dashboardState = .loading
-    isOffline = false
-    MobileAuthDiagnostics.record("mobile_me_loading")
+    // Cache-first: paint the last persisted profile instantly so returning
+    // users never wait on the network to see their dashboard. The network
+    // revalidation below silently swaps in fresh data when it lands.
+    let cachedSnapshot = await repository.cachedSnapshot(for: userID)
+    guard activeUserID == userID, loadingUserID == userID else { return }
+
+    if let cachedSnapshot {
+      apply(response: cachedSnapshot)
+      isOffline = false
+      MobileAuthDiagnostics.record(
+        "mobile_me_cache_hit",
+        detail: "state=\(cachedSnapshot.state.rawValue)"
+      )
+    } else {
+      route = .launching
+      dashboardState = .loading
+      isOffline = false
+      MobileAuthDiagnostics.record("mobile_me_loading")
+    }
 
     do {
       let result = try await repository.loadMe(for: userID)
@@ -120,16 +142,14 @@ final class AppState {
 
       switch result.response.state {
       case .ready:
-        route = .ready
-        dashboardState = .loaded(result.response)
+        apply(response: result.response)
         Observability.addBreadcrumb(
           .appRouteAfterLogin,
           context: ["route": "ready"]
         )
         MobileAuthDiagnostics.record("route_ready", detail: "state=ready")
       case .needsOnboarding:
-        route = .needsOnboarding
-        dashboardState = .idle
+        apply(response: result.response)
         Observability.addBreadcrumb(
           .appRouteAfterLogin,
           context: ["route": "needs_onboarding"]
@@ -164,6 +184,20 @@ final class AppState {
       dashboardState = .error("Couldn't load your profile.")
       isOffline = didTransportFail
       MobileAuthDiagnostics.record("mobile_me_error", detail: error.localizedDescription)
+    }
+  }
+
+  /// Maps a resolved profile response onto the navigation route and dashboard
+  /// state. Shared by the instant cache paint and the network revalidation so
+  /// both paths transition identically (and never disagree on the route).
+  private func apply(response: MobileMeResponse) {
+    switch response.state {
+    case .ready:
+      route = .ready
+      dashboardState = .loaded(response)
+    case .needsOnboarding:
+      route = .needsOnboarding
+      dashboardState = .idle
     }
   }
 

--- a/apps/ios/Jovie/App/JovieApp.swift
+++ b/apps/ios/Jovie/App/JovieApp.swift
@@ -247,7 +247,6 @@ enum NativeTicketSignInDiagnostics {
 
   private static func setSummary(_ summary: String) {
     UserDefaults.standard.set(summary, forKey: summaryKey)
-    UserDefaults.standard.synchronize()
   }
 }
 #endif

--- a/apps/ios/Jovie/App/MobileAuthReturn.swift
+++ b/apps/ios/Jovie/App/MobileAuthReturn.swift
@@ -20,7 +20,6 @@ enum MobileAuthDiagnostics {
     }
 
     defaults.set(Date().timeIntervalSince1970, forKey: timestampKey)
-    defaults.synchronize()
   }
 }
 

--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -178,6 +178,7 @@ private struct AppContentView: View {
       switch appState.route {
       case .launching:
         SplashView()
+          .transition(.opacity)
       case .signedOut:
         AuthScreen(
           isMock: !isAuthAvailable,
@@ -187,6 +188,7 @@ private struct AppContentView: View {
           onAuthReturn: onAuthReturn,
           onAuthError: onAuthError
         )
+        .transition(.opacity)
       case .needsOnboarding:
         AppShellView(
           profile: AppShellProfile(response: nil),
@@ -213,6 +215,7 @@ private struct AppContentView: View {
             MobileChatPlaceholderView(isOffline: false, draft: draft)
           }
         }
+        .transition(.opacity)
       case .ready:
         AppShellView(
           profile: AppShellProfile(response: appState.loadedDashboardResponse),
@@ -251,8 +254,13 @@ private struct AppContentView: View {
             MobileChatPlaceholderView(isOffline: appState.isOffline, draft: draft)
           }
         }
+        .transition(.opacity)
       }
     }
+    // Cross-fade between top-level routes (notably splash → app) so the first
+    // content paint feels intentional rather than a hard cut. Opacity-only, so
+    // no layout shift and no decorative spatial motion.
+    .animation(.easeInOut(duration: 0.28), value: appState.route)
     .task(id: appState.activeUserID) {
       guard let activeUserID = appState.activeUserID else {
         chatRepository = nil
@@ -422,8 +430,6 @@ private enum LiveAuthUITestStatus {
     } else if status == "starting" {
       defaults.removeObject(forKey: userIDKey)
     }
-
-    defaults.synchronize()
   }
 
   @MainActor

--- a/apps/ios/Jovie/Core/MeRepository.swift
+++ b/apps/ios/Jovie/Core/MeRepository.swift
@@ -7,6 +7,7 @@ struct MeRepositoryResult: Equatable, Sendable {
 
 protocol MeRepositoryProtocol: Sendable {
   func loadMe(for clerkUserID: String) async throws -> MeRepositoryResult
+  func cachedSnapshot(for clerkUserID: String) async -> MobileMeResponse?
 }
 
 struct MeRepository: MeRepositoryProtocol, Sendable {
@@ -16,6 +17,13 @@ struct MeRepository: MeRepositoryProtocol, Sendable {
   init(apiClient: APIClientProtocol, cache: MeCache) {
     self.apiClient = apiClient
     self.cache = cache
+  }
+
+  /// Returns the last persisted profile for this user without touching the
+  /// network. Used to paint the dashboard instantly on launch while a fresh
+  /// copy is revalidated in the background (stale-while-revalidate).
+  func cachedSnapshot(for clerkUserID: String) async -> MobileMeResponse? {
+    await cache.load(for: clerkUserID)?.response
   }
 
   func loadMe(for clerkUserID: String) async throws -> MeRepositoryResult {

--- a/apps/ios/Jovie/Core/QRCodeRenderer.swift
+++ b/apps/ios/Jovie/Core/QRCodeRenderer.swift
@@ -5,6 +5,26 @@ enum QRCodeRenderer {
   private static let cache = NSCache<NSString, UIImage>()
   private static let context = CIContext(options: [.cacheIntermediates: false])
 
+  /// Returns an already-rendered QR image without doing any CoreImage work.
+  /// Lets views paint instantly on a cache hit and only defer to async
+  /// rendering on a miss.
+  static func cachedImage(for payload: String, scale: CGFloat = 12) -> UIImage? {
+    guard !payload.isEmpty else {
+      return nil
+    }
+
+    return cache.object(forKey: "\(scale):\(payload)" as NSString)
+  }
+
+  /// Renders the QR off the main actor. CoreImage generation + `createCGImage`
+  /// are CPU-bound and must never run inside a SwiftUI `body` on the main
+  /// thread (that hitches the first dashboard/venue paint).
+  static func imageAsync(for payload: String, scale: CGFloat = 12) async -> UIImage? {
+    await Task.detached(priority: .userInitiated) {
+      image(for: payload, scale: scale)
+    }.value
+  }
+
   static func image(for payload: String, scale: CGFloat = 12) -> UIImage? {
     guard !payload.isEmpty else {
       return nil

--- a/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
+++ b/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
@@ -2,23 +2,75 @@ import PassKit
 import SwiftUI
 import UIKit
 
+/// Process-wide cache of decoded, downsampled avatar bitmaps. Keyed by URL so
+/// the same avatar rendered in the dashboard header, the menu, and settings
+/// never re-fetches or re-decodes — eliminating the flicker raw `AsyncImage`
+/// produces by dropping back to its placeholder on every appearance.
+enum AvatarImageCache {
+  private static let cache: NSCache<NSURL, UIImage> = {
+    let cache = NSCache<NSURL, UIImage>()
+    cache.countLimit = 64
+    return cache
+  }()
+
+  static func image(for url: URL) -> UIImage? {
+    cache.object(forKey: url as NSURL)
+  }
+
+  static func store(_ image: UIImage, for url: URL) {
+    cache.setObject(image, forKey: url as NSURL)
+  }
+}
+
+/// Non-isolated loader so the network fetch *and* the decode/downsample run off
+/// the main actor. Avatars are tiny on screen, so we downsample to a small
+/// thumbnail to keep memory and compositing cheap.
+enum AvatarImageLoader {
+  static func load(_ url: URL) async -> UIImage? {
+    guard let (data, response) = try? await URLSession.shared.data(from: url) else {
+      return nil
+    }
+
+    if let http = response as? HTTPURLResponse,
+       !(200 ... 299).contains(http.statusCode)
+    {
+      return nil
+    }
+
+    guard let image = UIImage(data: data) else {
+      return nil
+    }
+
+    // The async overload prepares the thumbnail off the main thread.
+    let thumbnail = await image.byPreparingThumbnail(
+      ofSize: CGSize(width: 96, height: 96)
+    ) ?? image
+    AvatarImageCache.store(thumbnail, for: url)
+    return thumbnail
+  }
+}
+
 struct DashboardAvatarView: View {
   let name: String
   let avatarURL: URL?
 
+  @State private var image: UIImage?
+
+  init(name: String, avatarURL: URL?) {
+    self.name = name
+    self.avatarURL = avatarURL
+    // Seed from cache synchronously so a previously-loaded avatar shows on the
+    // very first frame — no placeholder flash on re-appearance.
+    _image = State(initialValue: avatarURL.flatMap(AvatarImageCache.image(for:)))
+  }
+
   var body: some View {
     Group {
-      if let avatarURL {
-        AsyncImage(url: avatarURL) { phase in
-          switch phase {
-          case let .success(image):
-            image.resizable().scaledToFill()
-          case .empty, .failure:
-            fallback
-          @unknown default:
-            fallback
-          }
-        }
+      if let image {
+        Image(uiImage: image)
+          .resizable()
+          .scaledToFill()
+          .transition(.opacity)
       } else {
         fallback
       }
@@ -26,6 +78,29 @@ struct DashboardAvatarView: View {
     .frame(width: 28, height: 28)
     .clipShape(Circle())
     .overlay(Circle().stroke(JovieColor.borderDefault, lineWidth: 1))
+    .animation(.easeOut(duration: 0.2), value: image == nil)
+    .task(id: avatarURL) { await load() }
+  }
+
+  @MainActor
+  private func load() async {
+    guard let avatarURL else {
+      image = nil
+      return
+    }
+
+    if let cached = AvatarImageCache.image(for: avatarURL) {
+      if image == nil {
+        image = cached
+      }
+      return
+    }
+
+    guard let loaded = await AvatarImageLoader.load(avatarURL) else {
+      return
+    }
+
+    image = loaded
   }
 
   private var fallback: some View {
@@ -183,24 +258,28 @@ struct DashboardView: View {
     }
   }
 
+  // Mirrors the loaded layout exactly (full-width square QR, single URL line,
+  // two full-width pills, top-aligned) so the skeleton → loaded transition
+  // causes zero layout shift on a cold (uncached) first load.
   private var skeleton: some View {
     VStack(spacing: JovieSpacing.large) {
       RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
         .fill(JovieColor.surface1)
-        .frame(width: 280, height: 280)
+        .aspectRatio(1, contentMode: .fit)
+        .frame(maxWidth: .infinity)
       RoundedRectangle(cornerRadius: JovieRadius.small, style: .continuous)
         .fill(JovieColor.surface1)
-        .frame(width: 180, height: 18)
+        .frame(width: 180, height: 16)
       HStack(spacing: JovieSpacing.medium) {
         RoundedRectangle(cornerRadius: JovieRadius.pill, style: .continuous)
           .fill(JovieColor.surface1)
-          .frame(height: 48)
+          .frame(height: 46)
         RoundedRectangle(cornerRadius: JovieRadius.pill, style: .continuous)
           .fill(JovieColor.surface1)
-          .frame(height: 48)
+          .frame(height: 46)
       }
     }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     .redacted(reason: .placeholder)
   }
 
@@ -209,26 +288,11 @@ struct DashboardView: View {
       Button {
         isShowingVenueMode = true
       } label: {
-        if let payload = response.qrPayload, let image = QRCodeRenderer.image(for: payload) {
-          Image(uiImage: image)
-            .interpolation(.none)
-            .resizable()
-            .scaledToFit()
-            .jovieQRCodePlate()
-            .accessibilityLabel("Profile QR Code")
-        } else {
-          Text("QR unavailable")
-            .font(JovieFont.body(size: 15, weight: .medium))
-            .foregroundStyle(JovieColor.textTertiary)
-            .frame(width: 280, height: 280)
-            .background(
-              JovieColor.surface1,
-              in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
-            )
-        }
+        QRCodeCardView(payload: response.qrPayload)
       }
       .buttonStyle(.plain)
       .frame(maxWidth: .infinity)
+      .disabled(response.qrPayload == nil)
       .accessibilityLabel("Profile QR Code")
       .accessibilityIdentifier("profile-qr-button")
 
@@ -360,5 +424,69 @@ private struct AppleWalletAddPassView: UIViewControllerRepresentable {
     func addPassesViewControllerDidFinish(_ controller: PKAddPassesViewController) {
       controller.dismiss(animated: true)
     }
+  }
+}
+
+/// A fixed-aspect QR card that reserves its square footprint up front and
+/// renders the QR off the main thread. The reserved space guarantees zero
+/// layout shift between the loading, loaded, and unavailable states. Shared by
+/// the dashboard and Venue Mode so both render identically. Uses the shared
+/// ``JovieQRCodePlate`` tokens so the plate matches the rest of the system.
+struct QRCodeCardView: View {
+  let payload: String?
+  var accessibilityLabelText: String = "Profile QR Code"
+
+  @State private var image: UIImage?
+
+  init(payload: String?, accessibilityLabelText: String = "Profile QR Code") {
+    self.payload = payload
+    self.accessibilityLabelText = accessibilityLabelText
+    // Seed from the renderer cache so a QR rendered once (e.g. on the
+    // dashboard) appears instantly when Venue Mode opens — no flash.
+    _image = State(
+      initialValue: payload.flatMap { QRCodeRenderer.cachedImage(for: $0) }
+    )
+  }
+
+  var body: some View {
+    ZStack {
+      RoundedRectangle(cornerRadius: JovieQRCodePlate.radius, style: .continuous)
+        .fill(payload == nil ? JovieColor.surface1 : JovieQRCodePlate.background)
+
+      if let image {
+        Image(uiImage: image)
+          .interpolation(.none)
+          .resizable()
+          .scaledToFit()
+          .padding(JovieQRCodePlate.padding)
+          .transition(.opacity)
+          .accessibilityLabel(accessibilityLabelText)
+      } else if payload == nil {
+        Text("QR unavailable")
+          .font(JovieFont.body(size: 15, weight: .medium))
+          .foregroundStyle(JovieColor.textTertiary)
+      }
+    }
+    .aspectRatio(1, contentMode: .fit)
+    .frame(maxWidth: .infinity)
+    .animation(.easeOut(duration: 0.2), value: image == nil)
+    .task(id: payload) { await render() }
+  }
+
+  @MainActor
+  private func render() async {
+    guard let payload, !payload.isEmpty else {
+      image = nil
+      return
+    }
+
+    if let cached = QRCodeRenderer.cachedImage(for: payload) {
+      if image == nil {
+        image = cached
+      }
+      return
+    }
+
+    image = await QRCodeRenderer.imageAsync(for: payload)
   }
 }

--- a/apps/ios/Jovie/Features/Dashboard/VenueModeView.swift
+++ b/apps/ios/Jovie/Features/Dashboard/VenueModeView.swift
@@ -11,14 +11,10 @@ struct VenueModeView: View {
       JovieColor.backgroundBase.ignoresSafeArea()
 
       VStack(spacing: JovieSpacing.large) {
-        if let image = QRCodeRenderer.image(for: qrPayload) {
-          Image(uiImage: image)
-            .interpolation(.none)
-            .resizable()
-            .scaledToFit()
-            .jovieQRCodePlate()
-            .accessibilityLabel("Fullscreen Profile QR Code")
-        }
+        QRCodeCardView(
+          payload: qrPayload,
+          accessibilityLabelText: "Fullscreen Profile QR Code"
+        )
 
         Button("Done") {
           onDismiss()

--- a/apps/ios/JovieTests/AppStateTests.swift
+++ b/apps/ios/JovieTests/AppStateTests.swift
@@ -7,10 +7,16 @@ private actor MockRepository: AppStateRepository {
   private var clearedUserIDs: [String] = []
   private var loadCallCount = 0
   private let loadDelay: Duration?
+  private let cached: MobileMeResponse?
 
-  init(nextResult: Result<MeRepositoryResult, Error>, loadDelay: Duration? = nil) {
+  init(
+    nextResult: Result<MeRepositoryResult, Error>,
+    loadDelay: Duration? = nil,
+    cached: MobileMeResponse? = nil
+  ) {
     self.nextResult = nextResult
     self.loadDelay = loadDelay
+    self.cached = cached
   }
 
   func loadMe(for clerkUserID: String) async throws -> MeRepositoryResult {
@@ -19,6 +25,10 @@ private actor MockRepository: AppStateRepository {
       try await Task.sleep(for: loadDelay)
     }
     return try nextResult.get()
+  }
+
+  func cachedSnapshot(for clerkUserID: String) -> MobileMeResponse? {
+    cached
   }
 
   func clearCachedUser(_ clerkUserID: String) {
@@ -74,6 +84,70 @@ struct AppStateTests {
 
     #expect(appState.route == .ready)
     #expect(appState.dashboardState == .loaded(.previewReady))
+  }
+
+  @Test func paintsCachedSnapshotInstantlyThenRevalidates() async throws {
+    let fresh = MobileMeResponse(
+      state: .ready,
+      displayName: "Fresh Name",
+      username: "fresh",
+      publicProfileURL: "https://jov.ie/fresh",
+      qrPayload: "https://jov.ie/fresh",
+      avatarURL: nil,
+      appleWalletProfilePassAvailable: false,
+      chatEnabled: true,
+      continueOnWebURL: "https://jov.ie/app"
+    )
+    let repository = MockRepository(
+      nextResult: .success(MeRepositoryResult(response: fresh, isStale: false)),
+      loadDelay: .milliseconds(300),
+      cached: .previewReady
+    )
+    let appState = AppState(
+      configuration: configuration,
+      launchMode: .live,
+      repository: repository,
+      brightnessManager: MockBrightnessController()
+    )
+    appState.didLoadClerk = true
+
+    async let change: Void = appState.handleSignedInUserChange("user_123")
+
+    // Well before the 300ms network delay resolves, the cached profile must
+    // already be on screen — this is the "blazing fast" guarantee.
+    try await Task.sleep(for: .milliseconds(40))
+    #expect(appState.route == .ready)
+    #expect(appState.dashboardState == .loaded(.previewReady))
+
+    await change
+
+    // Once revalidation lands, the fresh profile silently replaces the cache.
+    #expect(appState.dashboardState == .loaded(fresh))
+    #expect(appState.isOffline == false)
+  }
+
+  @Test func cachedSnapshotPaintDoesNotDuplicateNetworkLoad() async throws {
+    let repository = MockRepository(
+      nextResult: .success(
+        MeRepositoryResult(response: .previewReady, isStale: false)
+      ),
+      loadDelay: .milliseconds(50),
+      cached: .previewReady
+    )
+    let appState = AppState(
+      configuration: configuration,
+      launchMode: .live,
+      repository: repository,
+      brightnessManager: MockBrightnessController()
+    )
+    appState.didLoadClerk = true
+
+    async let first: Void = appState.handleSignedInUserChange("user_123")
+    async let second: Void = appState.handleSignedInUserChange("user_123")
+    _ = await (first, second)
+
+    #expect(await repository.loadCount() == 1)
+    #expect(appState.route == .ready)
   }
 
   @Test func mapsNeedsOnboardingResponseToNeedsOnboardingRoute() async throws {

--- a/apps/ios/JovieTests/MeRepositoryTests.swift
+++ b/apps/ios/JovieTests/MeRepositoryTests.swift
@@ -64,6 +64,30 @@ struct MeRepositoryTests {
     #expect(staleResult.response == .previewReady)
   }
 
+  @Test func cachedSnapshotReturnsNilBeforeFirstLoad() async throws {
+    let defaults = UserDefaults(suiteName: "MeRepositoryTests-D")!
+    defaults.removePersistentDomain(forName: "MeRepositoryTests-D")
+    let cache = MeCache(defaults: defaults)
+    let apiClient = MutableAPIClient(mode: .success(.previewReady))
+    let repository = MeRepository(apiClient: apiClient, cache: cache)
+
+    #expect(await repository.cachedSnapshot(for: "user_d") == nil)
+  }
+
+  @Test func cachedSnapshotReturnsPersistedResponseWithoutNetwork() async throws {
+    let defaults = UserDefaults(suiteName: "MeRepositoryTests-E")!
+    defaults.removePersistentDomain(forName: "MeRepositoryTests-E")
+    let cache = MeCache(defaults: defaults)
+    let apiClient = MutableAPIClient(mode: .success(.previewReady))
+    let repository = MeRepository(apiClient: apiClient, cache: cache)
+
+    _ = try await repository.loadMe(for: "user_e")
+    // Network now fails — cachedSnapshot must still return the persisted copy.
+    await apiClient.updateMode(.failure(APIClientError.requestFailed(statusCode: 500)))
+
+    #expect(await repository.cachedSnapshot(for: "user_e") == .previewReady)
+  }
+
   @Test func clearCachedUserRemovesSnapshot() async throws {
     let defaults = UserDefaults(suiteName: "MeRepositoryTests-C")!
     defaults.removePersistentDomain(forName: "MeRepositoryTests-C")

--- a/apps/ios/JovieTests/QRCodeRendererTests.swift
+++ b/apps/ios/JovieTests/QRCodeRendererTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import UIKit
 @testable import Jovie
 
 struct QRCodeRendererTests {
@@ -23,5 +24,45 @@ struct QRCodeRendererTests {
   @Test func qrPlateStyleUsesSystemBTokens() {
     #expect(JovieQRCodePlate.padding == JovieSpacing.xLarge)
     #expect(JovieQRCodePlate.radius == JovieRadius.large)
+  }
+
+  @Test func cachedImageMissesBeforeRenderAndHitsAfterAsyncRender() async throws {
+    QRCodeRenderer.clearCache()
+    let payload = "https://jov.ie/async-\(UUID().uuidString)"
+
+    #expect(QRCodeRenderer.cachedImage(for: payload) == nil)
+
+    let rendered = try #require(await QRCodeRenderer.imageAsync(for: payload))
+    let cached = try #require(QRCodeRenderer.cachedImage(for: payload))
+
+    // Async render populates the same cache the synchronous path uses.
+    #expect(rendered === cached)
+  }
+
+  @Test func cachedImageSkipsEmptyPayloads() {
+    #expect(QRCodeRenderer.cachedImage(for: "") == nil)
+  }
+}
+
+struct AvatarImageCacheTests {
+  @Test func storesAndReturnsDecodedImageForURL() throws {
+    let url = URL(string: "https://example.com/avatar-\(UUID().uuidString).png")!
+    #expect(AvatarImageCache.image(for: url) == nil)
+
+    let image = try #require(UIImage(systemName: "person.crop.circle"))
+    AvatarImageCache.store(image, for: url)
+
+    #expect(AvatarImageCache.image(for: url) === image)
+  }
+
+  @Test func distinctURLsDoNotCollide() throws {
+    let first = URL(string: "https://example.com/a-\(UUID().uuidString).png")!
+    let second = URL(string: "https://example.com/b-\(UUID().uuidString).png")!
+    let image = try #require(UIImage(systemName: "person.crop.circle"))
+
+    AvatarImageCache.store(image, for: first)
+
+    #expect(AvatarImageCache.image(for: first) === image)
+    #expect(AvatarImageCache.image(for: second) == nil)
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "ios:open": "open apps/ios/Jovie.xcodeproj",
     "ios:setup-env": "bash apps/ios/scripts/setup-env.sh",
     "ios:build": "bash apps/ios/scripts/run-xcodebuild.sh build",
+    "ios:lint": "bash scripts/ios-best-practices-lint.sh apps/ios/Jovie",
     "ios:test": "bash apps/ios/scripts/run-xcodebuild.sh test",
     "ios:performance": "bash apps/ios/scripts/measure-launch-performance.sh",
     "ios:runtime-performance": "bash apps/ios/scripts/measure-runtime-performance.sh",

--- a/scripts/ios-best-practices-lint.sh
+++ b/scripts/ios-best-practices-lint.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# iOS best-practices guardrail lint.
+#
+# Flags performance / robustness anti-patterns in production SwiftUI code that
+# cause jank, main-thread stalls, or crashes. Each rule maps to a fix that the
+# Jovie iOS app already follows — see `.claude/rules/ios.md` for rationale.
+#
+# Portable by design: pass a target directory so this same script can be
+# vendored into any company repo that ships iOS/SwiftUI code.
+#
+#   scripts/ios-best-practices-lint.sh [TARGET_DIR]
+#
+# Default TARGET_DIR is apps/ios/Jovie (this repo's app sources). Test targets
+# are skipped automatically — tests legitimately exercise some of these APIs.
+
+TARGET_DIR="${1:-apps/ios/Jovie}"
+
+if [[ ! -d "$TARGET_DIR" ]]; then
+  echo "ios-best-practices-lint: target directory not found: $TARGET_DIR" >&2
+  exit 2
+fi
+
+violations=0
+
+report() {
+  local file="$1" line="$2" rule="$3" message="$4"
+  violations=$((violations + 1))
+  echo "  ✖ ${file}:${line} [${rule}]"
+  echo "      ${message}"
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::error file=${file},line=${line}::[${rule}] ${message}"
+  fi
+}
+
+# scan PATTERN RULE MESSAGE [ALLOW_PATH_REGEX]
+#
+# Greps production Swift for PATTERN (extended regex), skipping test files,
+# comment-only lines, and any file matching ALLOW_PATH_REGEX.
+scan() {
+  local pattern="$1" rule="$2" message="$3" allow="${4:-}"
+  local file line content
+  while IFS=: read -r file line content; do
+    [[ -z "${file:-}" ]] && continue
+    case "$file" in
+      *Tests.swift | *UITests* | */Tests/* | */*Tests/*) continue ;;
+    esac
+    if [[ -n "$allow" && "$file" =~ $allow ]]; then
+      continue
+    fi
+    # Skip comment-only lines (first non-whitespace characters are `//`).
+    # A line with trailing code before the `//` is still scanned.
+    if [[ "$content" =~ ^[[:space:]]*// ]]; then
+      continue
+    fi
+    report "$file" "$line" "$rule" "$message"
+  done < <(grep -rnHE "$pattern" --include='*.swift' "$TARGET_DIR" 2>/dev/null || true)
+}
+
+echo "iOS best-practices lint → ${TARGET_DIR}"
+
+# 1. Raw AsyncImage drops to its placeholder on every appearance (flicker) and
+#    shares no decoded-image cache across instances.
+scan 'AsyncImage\(' 'no-raw-asyncimage' \
+  'Raw AsyncImage re-fetches and flashes its placeholder on every appearance. Use a cached image loader (e.g. AvatarImageCache + AvatarImageLoader).'
+
+# 2. CoreImage / CGImage generation is CPU-bound and must live in a dedicated,
+#    cache-backed renderer that runs off the main actor — never in a view body.
+scan '(CIContext\(|createCGImage\()' 'no-coreimage-in-views' \
+  'CoreImage/CGImage rendering must live in a dedicated cache-backed *Renderer.swift and run off the main actor (Task.detached) — never inside a SwiftUI body.' \
+  'Renderer\.swift$'
+
+# 3. Anything that blocks the main thread janks the UI.
+scan '(DispatchQueue\.main\.sync|Thread\.sleep|usleep\(|DispatchSemaphore|Data\(contentsOf:)' 'no-main-thread-blocking' \
+  'Synchronous blocking on the main thread janks the UI. Use async/await (Task, URLSession.data, Task.sleep) instead.'
+
+# 4. UserDefaults.synchronize() is deprecated and forces a blocking disk flush.
+scan '\.synchronize\(\)' 'no-userdefaults-synchronize' \
+  'UserDefaults.synchronize() is deprecated and forces a blocking disk flush. Remove it — values persist automatically.'
+
+# 5. print() ships noise and is invisible in production telemetry.
+scan '(^|[^A-Za-z0-9_.])print\(' 'no-print' \
+  'print() ships noise and is invisible in production. Use the Observability layer.'
+
+# 6. try! crashes the app on any thrown error.
+scan '(^|[^A-Za-z0-9_])try!' 'no-force-try' \
+  'try! crashes the whole app on any thrown error. Use try? or do/catch.'
+
+echo ""
+if [[ "$violations" -gt 0 ]]; then
+  echo "iOS best-practices lint: ${violations} violation(s) found."
+  exit 1
+fi
+
+echo "iOS best-practices lint: clean ✓"


### PR DESCRIPTION
## Goal

Make the native iOS app (`apps/ios`) **rock solid and blazing fast — 0 jank. No new features**, the existing surface faster and fully polished. Plus durable guardrails so it stays that way, made portable for company-wide rollout.

## What changed (and why it's faster)

### Speed
- **Cache-first, stale-while-revalidate load.** `AppState.handleSignedInUserChange` now paints the last persisted profile **instantly** (`MeRepository.cachedSnapshot`), then revalidates over the network and silently swaps in fresh data. Returning users no longer wait on a round-trip to see their dashboard/QR — the previous flow was network-first (splash → skeleton → network → content). Dedupe, cancellation, 401, and sign-out guards are all preserved.
- **QR rendering off the main thread.** `QRCodeRenderer.imageAsync` (`Task.detached`) + a synchronous `cachedImage` peek. CoreImage generation no longer runs inside a `body` on the main thread, so the first dashboard/Venue-Mode paint doesn't hitch.
- **Cached, downsampled avatars.** Raw `AsyncImage` (re-fetches + flashes its placeholder on every appearance) replaced with a process-wide decoded-image `NSCache` loader, seeded synchronously from cache and decoded/downsampled off-main. Kills avatar flicker across dashboard, menu, and settings.

### Robustness / 0 jank
- Image/QR view loaders marked `@MainActor` so SwiftUI `@State` mutates on main while the heavy work stays off-main.
- Removed three deprecated `UserDefaults.synchronize()` calls (one on the live auth path) that force a blocking disk flush.
- **Layout-shift audit (mandatory):** `QRCodeCardView` reserves a fixed square footprint across loading/loaded/unavailable; the dashboard skeleton now mirrors the loaded layout exactly (top-aligned, full-width square QR, full-width pills) so cold load doesn't jump; splash → app is an opacity cross-fade. No state transition shifts layout.

### Guardrails (so it stays fast)
- **`scripts/ios-best-practices-lint.sh`** — portable (takes a target dir), blocks: raw `AsyncImage`, CoreImage/CGImage outside `*Renderer.swift`, main-thread blocking (`DispatchQueue.main.sync`/`Thread.sleep`/`DispatchSemaphore`/`Data(contentsOf:)`), `UserDefaults.synchronize()`, `print()`, `try!`. Wired into `ios-ci.yml` and `pnpm run ios:lint`. Verified it **fires** on a bad file (5 violations, exit 1) and is **clean** on the fixed app.
- **`.claude/rules/ios.md`** — codifies the performance canon, the SwiftUI layout-shift rule, and the **company-wide portability contract**. Referenced from `CLAUDE.md` (scoped rules + hard invariants).

## Company-wide rollout
The guardrail is portable by design. Vendoring it into every other iOS-touching company repo (this repo can't edit others) is tracked in **JOV-3264** (Required), with the vendor + CI-wire steps spelled out.

## Tests / verification (local)
- `pnpm run ios:test` (Xcode 26.3, iPhone simulator): **`** TEST SUCCEEDED **` — 57 passed, 0 failed, 4 skipped (pre-existing live-auth).** Confirmed via the `.xcresult` bundle.
- 8 new unit tests: cache-first instant paint + dedupe (`AppStateTests`), `cachedSnapshot` (`MeRepositoryTests`), async QR cache + avatar cache (`QRCodeRendererTests`).
- `pnpm run ios:lint`: clean ✓ (and proven to catch violations).
- Pre-push gate (web typecheck + Biome lint, 5,812 files): passed.

## Cost Impact
None. No new external API calls, crons, or services. The cache-first change **reduces** redundant `mobile/v1/me` fetches' perceived cost (same call count, instant render).

## Risk / notes
- Touches the iOS profile-load path; all existing guards (dedupe/cancellation/401/sign-out) preserved and covered by tests.
- 16 files (slightly over the 10-file guideline) but one cohesive concern: iOS perf hardening + its guardrail; splitting would separate the fix from the test/guardrail that protects it.
- New Swift files were intentionally avoided (the Xcode project doesn't use synchronized file groups); changes extend existing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache-first profile loading: User profiles now load instantly from cache while network revalidation occurs in the background.
  * Improved QR code display with consistent sizing to prevent layout shifts.

* **Performance**
  * Avatar images now load optimized with off-main-thread processing.
  * Enhanced caching strategy for frequently accessed data.

* **UI/UX**
  * Smoother cross-fade transitions when navigating between app states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->