### PR TITLE
fix(ui): kill decorative hover/press motion + guard regressions

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2087,7 +2087,7 @@ body {
   }
   /* Micro-animations */
   .card-hover {
-    @apply transform transition-all duration-slow ease-out hover:-translate-y-1 hover:shadow-lg hover:shadow-gray-200/25 dark:hover:shadow-gray-900/25;
+    @apply transition-shadow duration-subtle ease-subtle hover:shadow-lg hover:shadow-gray-200/25 dark:hover:shadow-gray-900/25;
   }
   .input-focus-glow {
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:shadow-lg transition-all duration-slow;
@@ -2098,7 +2098,7 @@ body {
     );
   }
   .btn-press {
-    @apply transform transition-transform duration-100 ease-out active:scale-95;
+    @apply transition-opacity duration-subtle ease-subtle active:opacity-80;
   }
   /* Chat empty state — refined depth & motion */
   .chat-logo-mark {

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -272,7 +272,7 @@ export function ProfileCompactSurface({
   previewNotificationsState = {
     kind: 'button',
     tone: 'quiet',
-    label: 'Get alerts',
+    label: 'Get Alerts',
   },
   dataTestId,
   hideBackButton = false,
@@ -395,7 +395,7 @@ export function ProfileCompactSurface({
   const isMenuActive =
     drawerOpen && drawerView === 'menu' && activeVisiblePrimaryTab !== 'tour';
   const topChromeButtonClassName =
-    'h-9! w-9! border-white/14 bg-black/24 text-white shadow-[0_10px_24px_rgba(0,0,0,0.22)] backdrop-blur-md hover:bg-black/36 active:scale-100';
+    'h-9! w-9! border-white/14 bg-black/24 text-white shadow-[0_10px_24px_rgba(0,0,0,0.22)] backdrop-blur-md hover:bg-black/36';
   const socialIconClassName =
     'inline-flex h-7 w-7 items-center justify-center text-white/68 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
   const heroHeightClassName = isHomeMode

--- a/apps/web/eslint-rules/no-raw-motion-values.js
+++ b/apps/web/eslint-rules/no-raw-motion-values.js
@@ -22,10 +22,18 @@ const CUBIC_BEZIER_REGEX = /cubic-bezier\s*\(/;
 const TRANSITION_ALL_REGEX = /\btransition-all\b/;
 const NUMERIC_DURATION_CLASS_REGEX = /\bduration-\d+\b/;
 const NUMERIC_EASE_CLASS_REGEX = /\bease-\[/;
+// Decorative hover/press motion is banned (.claude/rules/ui.md → "No Decorative
+// Hover Motion"). Flag lift (translate-y) and scale on interaction states.
+// `scale-100` is a no-op reset and is intentionally exempt.
+const DECORATIVE_LIFT_REGEX =
+  /\b(?:hover|active|focus|focus-visible|group-hover):-?translate-y-/;
+const DECORATIVE_SCALE_REGEX =
+  /\b(?:hover|active|focus|focus-visible|group-hover):scale-(?!100\b)(?:\[|\d)/;
 
 const ALLOWED_PATH_FRAGMENTS = [
   '/apps/web/styles/',
   '/apps/web/eslint-rules/',
+  '/app/exp/',
   '.stories.',
   '.test.',
   '.spec.',
@@ -56,6 +64,12 @@ function checkClassNameLiteral(node, value, context) {
     context.report({
       node,
       messageId: 'arbitraryEaseClass',
+    });
+  }
+  if (DECORATIVE_LIFT_REGEX.test(value) || DECORATIVE_SCALE_REGEX.test(value)) {
+    context.report({
+      node,
+      messageId: 'decorativeHoverMotion',
     });
   }
 }
@@ -183,6 +197,8 @@ module.exports = {
         'Numeric duration class `{{value}}` bypasses the DS motion taxonomy. Use `duration-subtle` (150ms) or `duration-cinematic` (420ms) instead.',
       arbitraryEaseClass:
         'Arbitrary ease class bypasses the DS motion taxonomy. Use `ease-subtle` or `ease-cinematic` instead.',
+      decorativeHoverMotion:
+        'Decorative hover/press motion (translate/scale) is banned. Use color, border, shadow, or opacity feedback instead (see .claude/rules/ui.md → "No Decorative Hover Motion").',
       rawMsDuration:
         'Raw `{{value}}` duration in inline style bypasses the DS motion tokens. Use `var(--ds-motion-subtle-duration)` or `var(--ds-motion-cinematic-duration)`.',
       rawCubicBezier:


### PR DESCRIPTION
## What
Kill decorative hover/press motion (the repo's "No Decorative Hover Motion" invariant) and add a lint guard so it can't regress.

- `globals.css` `.card-hover`: drop `hover:-translate-y-1` + `transition-all` → shadow-only hover feedback
- `globals.css` `.btn-press`: drop `active:scale-95` → opacity press feedback
- `ProfileCompactSurface.tsx`: drop no-op `active:scale-100`; Title Case "Get Alerts"
- `no-raw-motion-values` ESLint rule: new `decorativeHoverMotion` check flagging `hover/active/focus` `translate-y` + `scale` (exempts `scale-100` and `/app/exp/`)

## Why
`.claude/rules/ui.md` → "No Decorative Hover Motion" bans lift/scale/translate on hover/press. A full sweep confirmed these were the only product-code violations (all other matches are in `app/exp/` experimental pages, now exempted). Related: JOV-2256.

## Verification
- ESLint guard **fires** on a seeded `active:scale-95 hover:-translate-y-1` (warning) and is **clean** on the fixed files.
- biome + eslint `--max-warnings=0` + typecheck + a11y all pass (pre-commit hook).
- Layout-shift: removing hover translate/scale only removes motion; no reserved-space change, no layout shift.

## Cost Impact
None (no new external calls or scheduled work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)