### PR TITLE
fix(seo): fail-safe robots.txt — serve allow-rules unless affirmative preview signal

### DIFF
--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -11,8 +11,13 @@ import { env } from '@/lib/env-server';
 //
 // Uses VERCEL_ENV to distinguish production from preview/staging at build time,
 // making this route statically renderable (no runtime headers() dependency).
-
-const isProduction = env.VERCEL_ENV === 'production';
+//
+// Fail-safe default: serve allow-rules UNLESS an affirmative non-prod signal is
+// present. A missing or empty VERCEL_ENV must never block production crawlers —
+// the original `=== 'production'` check was fail-dangerous (undefined → Disallow: /).
+const isPreview =
+  env.VERCEL_ENV === 'preview' || env.VERCEL_ENV === 'development';
+const isProduction = !isPreview;
 
 /**
  * Paths blocked from indexing.

--- a/apps/web/tests/unit/app/public-surface-guardrails.test.ts
+++ b/apps/web/tests/unit/app/public-surface-guardrails.test.ts
@@ -33,6 +33,56 @@ describe('public surface guardrails', () => {
     );
   });
 
+  describe('robots() VERCEL_ENV branch matrix — fail-safe default', () => {
+    async function getRobotsMeta(vercelEnv: string | undefined) {
+      vi.resetModules();
+      vi.doMock('@/constants/app', () => ({ BASE_URL: 'https://jov.ie' }));
+      vi.doMock('@/lib/env-server', () => ({
+        env: { VERCEL_ENV: vercelEnv },
+      }));
+      const { default: robots } = await import('../../../app/robots');
+      return robots();
+    }
+
+    it('VERCEL_ENV=production → allow-rules (sitemap present)', async () => {
+      const meta = await getRobotsMeta('production');
+      const rules = Array.isArray(meta.rules) ? meta.rules : [];
+      const wildcard = rules.find(r => r.userAgent === '*');
+      expect(wildcard?.allow).toBe('/');
+      expect(meta.sitemap).toBeTruthy();
+    });
+
+    it('VERCEL_ENV=preview → Disallow: / (block all)', async () => {
+      const meta = await getRobotsMeta('preview');
+      const rules = Array.isArray(meta.rules) ? meta.rules : [];
+      const wildcard = rules.find(r => r.userAgent === '*');
+      expect(wildcard?.disallow).toBe('/');
+      expect(wildcard?.allow).toBeUndefined();
+    });
+
+    it('VERCEL_ENV=development → Disallow: / (block all)', async () => {
+      const meta = await getRobotsMeta('development');
+      const rules = Array.isArray(meta.rules) ? meta.rules : [];
+      const wildcard = rules.find(r => r.userAgent === '*');
+      expect(wildcard?.disallow).toBe('/');
+      expect(wildcard?.allow).toBeUndefined();
+    });
+
+    it('VERCEL_ENV="" (empty) → allow-rules (fail-safe: empty ≠ preview)', async () => {
+      const meta = await getRobotsMeta('');
+      const rules = Array.isArray(meta.rules) ? meta.rules : [];
+      const wildcard = rules.find(r => r.userAgent === '*');
+      expect(wildcard?.allow).toBe('/');
+    });
+
+    it('VERCEL_ENV=undefined → allow-rules (fail-safe: missing ≠ preview)', async () => {
+      const meta = await getRobotsMeta(undefined);
+      const rules = Array.isArray(meta.rules) ? meta.rules : [];
+      const wildcard = rules.find(r => r.userAgent === '*');
+      expect(wildcard?.allow).toBe('/');
+    });
+  });
+
   it('marks sensitive utility and investor routes as noindex', async () => {
     const modules = await Promise.all([
       import('../../../app/demo/layout'),


### PR DESCRIPTION
## Summary

Fixes **JOV-3260** (P0/Urgent): Production `robots.txt` was serving `Disallow: /` for all crawlers, blocking 100% of organic and AI-assistant discovery.

**Root cause:** `const isProduction = env.VERCEL_ENV === 'production'` was evaluated at build time (made static in JOV-660 / PR #3638). When `VERCEL_ENV` is not exactly `"production"` during the production build, the code fell through to the preview branch and baked `Disallow: /` into the static artifact — a fail-dangerous default.

**Fix:** Inverts the check to fail-safe — block only when `VERCEL_ENV` is explicitly `'preview'` or `'development'`. All other values (including `undefined` / `''`) serve allow-rules.

```ts
// BEFORE (fail-dangerous)
const isProduction = env.VERCEL_ENV === 'production';

// AFTER (fail-safe)
const isPreview = env.VERCEL_ENV === 'preview' || env.VERCEL_ENV === 'development';
const isProduction = !isPreview;
```

## Files changed

| File | Change |
|------|--------|
| `apps/web/app/robots.ts` | Invert `isProduction` → fail-safe logic (~5 LOC) |
| `apps/web/tests/unit/app/public-surface-guardrails.test.ts` | Branch matrix tests (5 new cases) |

## Test plan

- [x] 7 unit tests pass: 5 new `VERCEL_ENV` branch matrix cases + 2 existing guardrails
- [x] TypeScript typecheck: clean
- [x] Biome lint: clean
- [x] Pre-push hooks: all green

**Acceptance criteria (from JOV-3260):**
- [x] `VERCEL_ENV=production` → allow-rules with sitemap
- [x] `VERCEL_ENV=preview` → `Disallow: /`
- [x] `VERCEL_ENV=development` → `Disallow: /`
- [x] `VERCEL_ENV=''` → allow-rules (fail-safe)
- [x] `VERCEL_ENV=undefined` → allow-rules (fail-safe)

## Cost Impact

None — static route, no external API calls, no cron.

<!-- linear-issue-id:b02d13a7-e19c-4832-8e27-42ec01a0fbbb -->