### PR TITLE
feat(seo): post-deploy live robots/sitemap ratchet (JOV-11044)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2059,6 +2059,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-node-pnpm
+
       - name: Wait for CDN propagation
         run: |
           echo "Waiting 30s for Vercel CDN propagation after deploy..."
@@ -2140,7 +2146,7 @@ jobs:
             return 0
           }
 
-          echo "=== 1/4 Health API ==="
+          echo "=== 1/5 Health API ==="
           if ! retry "Health API" check_health; then
             FAILURES=$((FAILURES + 1))
           fi
@@ -2171,7 +2177,7 @@ jobs:
             return 0
           }
 
-          echo "=== 2/4 Homepage ==="
+          echo "=== 2/5 Homepage ==="
           if ! retry "Homepage" check_homepage; then
             FAILURES=$((FAILURES + 1))
           fi
@@ -2214,7 +2220,7 @@ jobs:
             return 0
           }
 
-          echo "=== 3/4 Public Profile ==="
+          echo "=== 3/5 Public Profile ==="
           if ! retry "Public Profile" check_profile; then
             FAILURES=$((FAILURES + 1))
           fi
@@ -2240,18 +2246,24 @@ jobs:
             return 0
           }
 
-          echo "=== 4/4 Critical Pages ==="
+          echo "=== 4/5 Critical Pages ==="
           if ! retry "Critical Pages" check_critical_pages; then
+            FAILURES=$((FAILURES + 1))
+          fi
+
+          # -- 5. Production SEO surfaces: robots.txt + sitemap.xml --
+          echo "=== 5/5 Production SEO Surfaces ==="
+          if ! retry "Production SEO Surfaces" bash -c 'BASE_URL=https://jov.ie pnpm --filter=@jovie/web exec tsx scripts/seo-ratchet-live.ts'; then
             FAILURES=$((FAILURES + 1))
           fi
 
           # -- Summary --
           echo ""
           if [ $FAILURES -gt 0 ]; then
-            echo "::error::Post-deploy smoke failed: $FAILURES/4 checks failed"
+            echo "::error::Post-deploy smoke failed: $FAILURES/5 checks failed"
             exit 1
           fi
-          echo "Post-deploy smoke passed: 4/4 checks OK"
+          echo "Post-deploy smoke passed: 5/5 checks OK"
 
   # Post-deploy authenticated smoke test — lightweight Playwright test against production.
   # Verifies sign-in + dashboard load with real credentials after deploy.

--- a/apps/web/lib/seo/surface-ratchet.ts
+++ b/apps/web/lib/seo/surface-ratchet.ts
@@ -1,0 +1,181 @@
+export interface SeoRobotsBaseline {
+  readonly requiredAiCrawlers: readonly string[];
+}
+
+export interface SeoSitemapBaseline {
+  readonly requireLastModified: boolean;
+  readonly minEntryCount: number;
+}
+
+export interface SeoSurfaceViolation {
+  readonly check: string;
+  readonly message: string;
+  readonly remediation: string;
+}
+
+function isGlobalDisallow(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim();
+  return normalized === '/' || normalized === '/*';
+}
+
+function parseRobotsRules(
+  body: string
+): Map<string, { allow: string[]; disallow: string[] }> {
+  const rules = new Map<string, { allow: string[]; disallow: string[] }>();
+  let currentAgent = '*';
+
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const [directive, ...rest] = line.split(':');
+    if (!directive || rest.length === 0) continue;
+
+    const value = rest.join(':').trim();
+    const key = directive.trim().toLowerCase();
+
+    if (key === 'user-agent') {
+      currentAgent = value;
+      if (!rules.has(currentAgent)) {
+        rules.set(currentAgent, { allow: [], disallow: [] });
+      }
+      continue;
+    }
+
+    if (!rules.has(currentAgent)) {
+      rules.set(currentAgent, { allow: [], disallow: [] });
+    }
+
+    const rule = rules.get(currentAgent);
+    if (!rule) continue;
+
+    if (key === 'allow') {
+      rule.allow.push(value);
+    }
+    if (key === 'disallow') {
+      rule.disallow.push(value);
+    }
+  }
+
+  return rules;
+}
+
+export function validateRobotsTxtSurface(
+  body: string,
+  baseline: SeoRobotsBaseline
+): SeoSurfaceViolation[] {
+  const violations: SeoSurfaceViolation[] = [];
+  const rules = parseRobotsRules(body);
+  const wildcard = rules.get('*');
+
+  if (!wildcard) {
+    violations.push({
+      check: 'robots-wildcard',
+      message: 'robots.txt is missing a User-agent: * rule block.',
+      remediation:
+        'Restore the default crawler rule with Allow: / and scoped disallow paths.',
+    });
+  } else {
+    const hasGlobalBlock = wildcard.disallow.some(isGlobalDisallow);
+    if (hasGlobalBlock) {
+      violations.push({
+        check: 'robots-global-disallow',
+        message:
+          'robots.txt globally blocks all crawlers (User-agent: * + Disallow: /).',
+        remediation:
+          'Fix VERCEL_ENV fail-safe logic in app/robots.ts — undefined must not map to preview-block.',
+      });
+    }
+
+    const allowsRoot =
+      wildcard.allow.includes('/') || wildcard.allow.includes('/*');
+    if (!allowsRoot) {
+      violations.push({
+        check: 'robots-allow-root',
+        message: 'robots.txt does not allow crawling the site root.',
+        remediation: 'Add Allow: / to the User-agent: * production rule block.',
+      });
+    }
+  }
+
+  if (!/sitemap:\s*https?:\/\//i.test(body)) {
+    violations.push({
+      check: 'robots-sitemap-reference',
+      message: 'robots.txt does not reference an absolute sitemap URL.',
+      remediation:
+        'Add Sitemap: `${BASE_URL}/sitemap.xml` to the production robots config.',
+    });
+  }
+
+  for (const crawler of baseline.requiredAiCrawlers) {
+    if (!rules.has(crawler)) {
+      violations.push({
+        check: `robots-ai-crawler-${crawler}`,
+        message: `robots.txt is missing explicit rules for ${crawler}.`,
+        remediation: `Add ${crawler} to AI_CRAWLERS in app/robots.ts or update seo-ratchet.baseline.json intentionally.`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function validateSitemapXmlSurface(
+  xml: string,
+  baseline: SeoSitemapBaseline
+): SeoSurfaceViolation[] {
+  const violations: SeoSurfaceViolation[] = [];
+  const trimmed = xml.trim();
+
+  if (!trimmed.startsWith('<?xml') && !trimmed.includes('<urlset')) {
+    violations.push({
+      check: 'sitemap-xml-shape',
+      message:
+        'sitemap.xml is not valid XML (missing declaration or <urlset>).',
+      remediation:
+        'Ensure app/sitemap.ts returns MetadataRoute.Sitemap entries and Next.js emits XML.',
+    });
+    return violations;
+  }
+
+  const locMatches = trimmed.match(/<loc>[^<]+<\/loc>/gi) ?? [];
+  if (locMatches.length < baseline.minEntryCount) {
+    violations.push({
+      check: 'sitemap-non-empty',
+      message: `sitemap.xml has ${locMatches.length} URLs; expected at least ${baseline.minEntryCount}.`,
+      remediation:
+        'Restore marketing/profile URLs in app/sitemap.ts or fix the production data source.',
+    });
+  }
+
+  if (baseline.requireLastModified) {
+    const urlBlocks = trimmed.match(/<url>[\s\S]*?<\/url>/gi) ?? [];
+    const blocks = urlBlocks.length > 0 ? urlBlocks : [trimmed];
+    const missingLastmod = blocks.filter(
+      block => !/<lastmod>[^<]+<\/lastmod>/i.test(block)
+    );
+
+    if (missingLastmod.length > 0) {
+      violations.push({
+        check: 'sitemap-lastmod',
+        message: `sitemap.xml is missing <lastmod> on ${missingLastmod.length} URL block(s).`,
+        remediation:
+          'Set lastModified on every sitemap entry in app/sitemap.ts.',
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function formatSurfaceViolations(
+  violations: readonly SeoSurfaceViolation[]
+): string {
+  return violations
+    .map(
+      violation =>
+        `  ✗ [${violation.check}] ${violation.message}\n    Fix: ${violation.remediation}`
+    )
+    .join('\n');
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,7 @@
     "lint:server-boundaries": "node scripts/run-server-boundary-eslint.mjs",
     "lint:no-native-dialogs": "node scripts/lint-no-native-dialogs.mjs",
     "lint:seo": "node scripts/seo-ratchet-guard.mjs && vitest run --config=vitest.config.fast.mts tests/app/seo-ratchet.test.ts tests/app/robots.test.ts tests/app/sitemap.test.ts",
+    "lint:seo:live": "tsx scripts/seo-ratchet-live.ts",
     "typecheck": "node ../../scripts/typecheck-singleflight.mjs -- tsc -p tsconfig.typecheck.json --noEmit --incremental --tsBuildInfoFile .cache/tsbuildinfo",
     "typecheck:tests": "node ../../scripts/typecheck-singleflight.mjs -- tsc -p tsconfig.test.json --noEmit --incremental",
     "next:proxy-guard": "node scripts/next-proxy-guard.mjs",

--- a/apps/web/scripts/seo-ratchet-live.ts
+++ b/apps/web/scripts/seo-ratchet-live.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env tsx
+/**
+ * Live SEO/AEO ratchet — fetches production robots.txt + sitemap.xml and fails loud.
+ *
+ * Used by post-deploy smoke against https://jov.ie. PR-level source checks live in
+ * scripts/seo-ratchet-guard.mjs + tests/app/seo-ratchet.test.ts.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  formatSurfaceViolations,
+  validateRobotsTxtSurface,
+  validateSitemapXmlSurface,
+} from '../lib/seo/surface-ratchet';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(scriptDir, '..');
+const baselinePath = join(projectRoot, 'seo-ratchet.baseline.json');
+
+const baseUrl = (
+  process.env.BASE_URL ??
+  process.argv[2] ??
+  'https://jov.ie'
+).replace(/\/$/, '');
+
+const baseline = JSON.parse(readFileSync(baselinePath, 'utf8')) as {
+  robots: { requiredAiCrawlers: string[] };
+  sitemap: { requireLastModified: boolean; minEntryCount: number };
+};
+
+const USER_AGENT =
+  'Mozilla/5.0 (compatible; JovieSeoRatchet/1.0; +https://jov.ie)';
+const TIMEOUT_MS = 15_000;
+
+async function fetchText(
+  path: string
+): Promise<{ status: number; body: string }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const response = await fetch(`${baseUrl}${path}`, {
+      headers: {
+        Accept: '*/*',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        Pragma: 'no-cache',
+        'User-Agent': USER_AGENT,
+      },
+      signal: controller.signal,
+    });
+
+    const body = await response.text();
+    return { status: response.status, body };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function main(): Promise<void> {
+  const violations = [];
+
+  console.log(`[seo-ratchet:live] Checking ${baseUrl}`);
+
+  const robots = await fetchText('/robots.txt');
+  if (robots.status !== 200) {
+    violations.push({
+      check: 'robots-http',
+      message: `robots.txt returned HTTP ${robots.status}.`,
+      remediation: 'Verify production deploy and app/robots.ts route health.',
+    });
+  } else {
+    violations.push(
+      ...validateRobotsTxtSurface(robots.body, {
+        requiredAiCrawlers: baseline.robots.requiredAiCrawlers,
+      })
+    );
+    console.log('[seo-ratchet:live] ✓ robots.txt fetched');
+  }
+
+  const sitemap = await fetchText('/sitemap.xml');
+  if (sitemap.status !== 200) {
+    violations.push({
+      check: 'sitemap-http',
+      message: `sitemap.xml returned HTTP ${sitemap.status}.`,
+      remediation: 'Verify production deploy and app/sitemap.ts route health.',
+    });
+  } else {
+    violations.push(
+      ...validateSitemapXmlSurface(sitemap.body, {
+        requireLastModified: baseline.sitemap.requireLastModified,
+        minEntryCount: baseline.sitemap.minEntryCount,
+      })
+    );
+    console.log('[seo-ratchet:live] ✓ sitemap.xml fetched');
+  }
+
+  if (violations.length > 0) {
+    console.error('');
+    console.error('[seo-ratchet:live] FAILED — live SEO surface violations:');
+    console.error(formatSurfaceViolations(violations));
+    console.error('');
+    console.error(
+      '  Incident context: JovieInc/Jovie#11043 — silent Disallow: / on production.'
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    '[seo-ratchet:live] ✓ Production robots.txt and sitemap.xml are healthy'
+  );
+}
+
+main().catch(error => {
+  console.error('[seo-ratchet:live] Unexpected failure:', error);
+  process.exit(1);
+});

--- a/apps/web/tests/app/seo-ratchet.test.ts
+++ b/apps/web/tests/app/seo-ratchet.test.ts
@@ -10,6 +10,10 @@ import {
   type SeoRequiredTag,
   validateMetadataTags,
 } from '../../lib/seo/metadata-ratchet';
+import {
+  validateRobotsTxtSurface,
+  validateSitemapXmlSurface,
+} from '../../lib/seo/surface-ratchet';
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(testDir, '../..');
@@ -20,6 +24,9 @@ const baseline = JSON.parse(
     id: string;
     requiredTags: SeoRequiredTag[];
   }>;
+  robots: {
+    requiredAiCrawlers: string[];
+  };
 };
 
 function formatRobotsTxt(robots: MetadataRoute.Robots): string {
@@ -149,6 +156,74 @@ describe('seo-ratchet robots.txt serialization', () => {
     expect(body).not.toMatch(/User-agent: \*\nDisallow: \/\n/);
     expect(body).toContain('Sitemap: https://jov.ie/sitemap.xml');
     expect(body).toContain('Allow: /');
+  });
+});
+
+describe('seo-ratchet live surface validators', () => {
+  const productionRobots = [
+    'User-agent: *',
+    'Allow: /',
+    'Disallow: /app/',
+    'Disallow: /api/',
+    'Sitemap: https://jov.ie/sitemap.xml',
+    'Host: https://jov.ie',
+    '',
+    ...baseline.robots.requiredAiCrawlers.flatMap(crawler => [
+      `User-agent: ${crawler}`,
+      'Allow: /',
+      'Allow: /llms.txt',
+      'Disallow: /app/',
+      '',
+    ]),
+  ].join('\n');
+
+  it('flags global Disallow: / on wildcard user-agent', () => {
+    const violations = validateRobotsTxtSurface(
+      `User-agent: *\nDisallow: /\n`,
+      { requiredAiCrawlers: ['GPTBot'] }
+    );
+
+    expect(
+      violations.some(violation => violation.check === 'robots-global-disallow')
+    ).toBe(true);
+  });
+
+  it('accepts production-shaped robots.txt bodies', () => {
+    const violations = validateRobotsTxtSurface(productionRobots, {
+      requiredAiCrawlers: baseline.robots.requiredAiCrawlers,
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('requires lastmod on every sitemap URL block', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://jov.ie</loc></url>
+</urlset>`;
+
+    const violations = validateSitemapXmlSurface(xml, {
+      requireLastModified: true,
+      minEntryCount: 1,
+    });
+
+    expect(
+      violations.some(violation => violation.check === 'sitemap-lastmod')
+    ).toBe(true);
+  });
+
+  it('accepts non-empty sitemap XML with lastmod entries', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://jov.ie</loc><lastmod>2026-06-18</lastmod></url>
+</urlset>`;
+
+    const violations = validateSitemapXmlSurface(xml, {
+      requireLastModified: true,
+      minEntryCount: 1,
+    });
+
+    expect(violations).toEqual([]);
   });
 });
 


### PR DESCRIPTION
<!-- linear-issue-id:JOV-11044 -->

## Summary

Completes GitHub issue #11044 by adding **post-deploy** live verification of production `robots.txt` and `sitemap.xml`. The PR-level static ratchet (guard script + metadata baseline + Structural Contract gate) landed in #11065; this PR closes the remaining scope item: fail loud if production SEO surfaces regress after promote.

## Changes

1. **`apps/web/lib/seo/surface-ratchet.ts`** — shared validators for live robots.txt and sitemap.xml bodies (global `Disallow: /`, sitemap reference, AI crawlers, `<lastmod>`, non-empty URL set).
2. **`apps/web/scripts/seo-ratchet-live.ts`** — fetches `https://jov.ie/robots.txt` + `/sitemap.xml` with bounded timeout; prints remediation on failure.
3. **`lint:seo:live`** — local/CI entrypoint for the live probe.
4. **Post-Deploy Smoke (Production)** — new step 5/5 runs the live ratchet after every successful production promote.
5. **Tests** — 4 new unit tests in `seo-ratchet.test.ts` for surface validators (would fail on #11043-style `Disallow: /`).

## Verification

```bash
pnpm --filter=@jovie/web run lint:seo          # exit 0, 22 tests passed
pnpm --filter=@jovie/web run typecheck          # exit 0
pnpm --filter=@jovie/web run lint:seo:live      # exit 0 against https://jov.ie
```

## Bug-to-Test

Regression tests added in `tests/app/seo-ratchet.test.ts` — `validateRobotsTxtSurface` hard-fails on `User-agent: *` + `Disallow: /`.

## Risks / follow-ups

- Live probe depends on production CDN propagation (inherits post-deploy smoke retry/backoff).
- Per-route HTML metadata ratchet for release/track pages remains source-marker + E2E (`metadata-regression.spec.ts`); expanding `seo-ratchet.baseline.json` routes is a candidate follow-up if we want builder-level locks on asset pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated SEO verification to post-deployment production checks, validating robots.txt and sitemap.xml compliance against baseline standards.
  * New script to validate production SEO surfaces and report violations with remediation guidance.

* **Tests**
  * Added comprehensive test coverage for SEO surface validators to ensure robots.txt and sitemap.xml compliance checks work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->