### PR TITLE
refactor(design-system): unify on System B — retire DM Sans, add singular-system-B ratchet

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,7 +9,20 @@
 
 ## Surface Classification
 
-Jovie uses two related but distinct design systems based on surface purpose:
+> **Direction (2026-06-18, founder-locked): one design system, two languages.**
+> Jovie is converging on a single token foundation, one color palette, and one core
+> typeface (Inter), expressed as a compact **product language** (operational, Linear-like)
+> and a more editorial **marketing language** (more spacing, larger type scale, more
+> cinematic motion — same tokens underneath). **System B is canonical.** The historical
+> "System A vs System B" split documented below is being **actively retired**: System A
+> surfaces are reskinned onto System B tokens with their editorial layouts preserved.
+> DM Sans was retired 2026-06-18 — Inter is the sole body/UI face; **Satoshi is the one
+> approved display exception** (hero / large display). This supersedes the earlier
+> "full retirement deferred 3 months" note. The table below reflects migration *state*,
+> not the target.
+
+Jovie historically used two related but distinct design systems based on surface purpose
+(now converging — see the banner above):
 
 | Surface | System | Mood | Routes |
 |---------|--------|------|--------|
@@ -22,7 +35,7 @@ Jovie uses two related but distinct design systems based on surface purpose:
 
 **Decision tree:** Selling/explaining (blog, pricing, legal) → System A. Everything else (homepage, auth, app, profiles) → System B.
 
-Note: the homepage migrated from System A to System B on 2026-04-22. The chat-intake surface is product, not marketing. The restraint is the brand. Full System A retirement is TBD after 3 months of shipping.
+Migration status: homepage migrated 2026-04-22; pricing, download, launch, artist-notifications, and pay since. **Full System A retirement is now in progress (founder-directed 2026-06-18), superseding the earlier 3-month deferral.** Remaining holdouts being reskinned onto System B tokens: `(marketing)/{about, ai, artist-profile, artist-profiles, blog, changelog, compare/[slug], alternatives/[slug], support, investors, voice, new}` and `(dynamic)/legal/*`. Each surface ships with its own `*-system-b-style-guard` test, and a global ratchet keeps the holdout list shrink-only.
 
 See the [Surface Classification](#canonical-surface-split) section below for full route mapping.
 
@@ -30,20 +43,28 @@ See the [Surface Classification](#canonical-surface-split) section below for ful
 
 ## Typography
 
-### System A — Marketing (Satoshi + DM Sans)
+### Marketing language — display type (Satoshi) — formerly "System A"
 
-Marketing pages use a two-font system loaded via `next/font/local` in the marketing layout:
+> **DM Sans retired 2026-06-18.** Marketing body + UI is now **Inter** (the single body/UI
+> face). **Satoshi** is retained only as the approved **display** exception for headings /
+> hero on the editorial marketing language. `--marketing-font-body` now resolves to Inter
+> (`var(--font-sans)`); `--marketing-font-display` stays Satoshi.
+
+The editorial marketing language uses Satoshi at display sizes only:
 
 - **Display/Hero:** Satoshi Variable (weight 800, letter-spacing -0.025em)
 - **Section headlines:** Satoshi Variable (weight 700, letter-spacing -0.02em)
 - **Subsection:** Satoshi Variable (weight 600, letter-spacing -0.015em)
-- **Buttons:** Satoshi Variable (weight 600, letter-spacing -0.01em) — buttons are controls, not copy
-- **Body:** DM Sans Variable (weight 400, letter-spacing -0.005em)
-- **Captions/meta:** DM Sans Variable (weight 500)
+- **Buttons:** Inter (weight 600) — buttons are product controls, on the product UI face
+- **Body:** Inter Variable — unified body face (was DM Sans, retired 2026-06-18)
+- **Captions/meta:** Inter Variable
 
-Font files: `apps/web/public/fonts/Satoshi-Variable.woff2` (~42KB), `apps/web/public/fonts/DMSans-Variable.woff2` (~48KB).
+Font files: `apps/web/public/fonts/Satoshi-Latin.woff2`. The DM Sans web font is no longer
+loaded in `app/layout.tsx`. (`DMSans-Regular.ttf` remains only for server-side OG-image
+Satori rendering, which is a build-time asset, not live page type — tracked for cleanup.)
 
-CSS variables: `--font-satoshi`, `--font-dm-sans` (set by `next/font/local`). Scoped to `.linear-marketing` wrapper via `--marketing-font-display` and `--marketing-font-body`.
+CSS variables: `--font-satoshi` (set by `next/font/local`); `--marketing-font-display`
+(Satoshi) and `--marketing-font-body` (Inter) scoped to the `.linear-marketing` wrapper.
 
 ### System B — App (Inter)
 
@@ -775,3 +796,5 @@ The `/start` onboarding composer fix (JOV-2496 follow-up) is the canonical examp
 | 2026-04-11 | Canonical 1200px width for all marketing | Fixed inconsistent widths (header 1200px, hero 1120px). Everything boxed at 1200px now. |
 | 2026-04-11 | Ban emoji-on-colored-square icons | Replaced with accent color on card title text. Icon-on-square reads as AI slop and cheapens the brand. |
 | 2026-04-11 | Ban gold colors | Gold signals prestige-seeking. Not appropriate for Jovie's DJ audience. |
+| 2026-06-18 | **Unify on one design system, two languages.** Retire System A; conform whole app to System B tokens. | Founder-directed (supersedes the 2026-04-22 "defer 3 months" note). Target = one token foundation, one palette, one core typeface (Inter), expressed as a compact product language + an editorial marketing language. Aligns with gbrain "design system review" canon ("not two design systems — one system, two languages"). Editorial layouts are preserved; surfaces are reskinned onto System B tokens, each with a `*-system-b-style-guard` test + a global shrink-only ratchet. |
+| 2026-06-18 | Retire DM Sans; Inter is the sole body/UI face; Satoshi kept for display only | One core typeface for the unified system. Satoshi remains the single approved display exception (hero / large editorial headings), generalizing the 2026-04-28 homepage-hero exception. DM Sans `next/font` load removed from `app/layout.tsx`; `--font-body` and `--marketing-font-body` repoint to Inter. |

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -542,11 +542,11 @@ body {
   /* Font stack: var(--font-inter) for Next.js localFont, then Linear's exact fallbacks */
   --font-sans:
     var(--font-inter), "Inter Variable", "SF Pro Display", -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  /* Marketing display + body fonts (scoped via CSS variables set by next/font/local in marketing layout) */
+  /* Unified type (one system, two languages): body + UI = Inter; display = Satoshi
+     (the single approved display exception). DM Sans retired 2026-06-18. */
   --font-display:
     var(--font-satoshi), "Satoshi", -apple-system, "system-ui", sans-serif;
-  --font-body:
-    var(--font-dm-sans), "DM Sans", -apple-system, "system-ui", sans-serif;
+  --font-body: var(--font-sans);
   --color-gray-50: #f9fafb;
   --color-gray-100: #f3f4f6;
   --color-gray-200: #e5e7eb;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -30,17 +30,9 @@ const satoshi = localFont({
   weight: '300 900',
 });
 
-// JOV-2267: DM Sans is only used in below-fold marketing sections
-// (HomeLoopDiagramSection, HomeStatQuoteSection, HomeBentoPairs) via
-// --marketing-font-body. Setting preload:false prevents a 68KB preload hint
-// on every page; display:'optional' already suppresses FOUT.
-const dmSans = localFont({
-  src: '../public/fonts/DMSans-Latin.woff2',
-  variable: '--font-dm-sans',
-  display: 'optional',
-  preload: false,
-  weight: '100 1000',
-});
+// DM Sans retired 2026-06-18 (JOV design-system unification — "one system, two
+// languages"). Body + UI type is now Inter everywhere; Satoshi is the single
+// approved display exception (hero / large display). See DESIGN.md decision log.
 
 export const metadata: Metadata = {
   title: {
@@ -206,7 +198,7 @@ export default async function RootLayout({
     );
   }
 
-  const bodyClassName = `${inter.variable} ${satoshi.variable} ${dmSans.variable} font-sans antialiased bg-base text-primary-token`;
+  const bodyClassName = `${inter.variable} ${satoshi.variable} font-sans antialiased bg-base text-primary-token`;
 
   const content = (
     <>

--- a/apps/web/eslint-rules/canonical-ui-label-casing-utils.js
+++ b/apps/web/eslint-rules/canonical-ui-label-casing-utils.js
@@ -254,10 +254,28 @@ function isSentenceCase(value) {
   }
   if (isAllCapsPhrase(trimmed)) return false;
 
-  for (let index = 1; index < words.length; index += 1) {
-    const word = words[index];
-    if (isAbbreviation(word) || isBrandWord(word)) continue;
-    if (/^[A-Z][a-z]/.test(word)) return false;
+  // Walk raw (un-stripped) tokens so sentence boundaries are respected: a
+  // capitalized word is legitimate when it starts a new sentence (the previous
+  // token ended with sentence-terminating punctuation). Without this, valid
+  // multi-sentence copy ("...your career. Smart links...") false-positives.
+  const rawWords = trimmed.split(' ');
+  let prevEndsSentence = true;
+  for (const raw of rawWords) {
+    const word = stripEdgePunctuation(raw);
+    const endsSentence = /[.!?:][)"'\]]*$/.test(raw);
+    if (!word) {
+      if (endsSentence) prevEndsSentence = true;
+      continue;
+    }
+    if (
+      !prevEndsSentence &&
+      !isAbbreviation(word) &&
+      !isBrandWord(word) &&
+      /^[A-Z][a-z]/.test(word)
+    ) {
+      return false;
+    }
+    prevEndsSentence = endsSentence;
   }
 
   return true;

--- a/apps/web/eslint-rules/canonical-ui-label-casing.test.ts
+++ b/apps/web/eslint-rules/canonical-ui-label-casing.test.ts
@@ -39,6 +39,13 @@ ruleTester.run('canonical-ui-label-casing', rule, {
       code: `<CardDescription>Share your profile link on social media.</CardDescription>`,
     },
     {
+      // Multi-sentence sentence-case copy: words after a sentence boundary may
+      // legitimately be capitalized (regression for the layout.tsx metadata
+      // false-positive). "AI" is an approved abbreviation.
+      filename,
+      code: `<CardDescription>Share your profile link. Fans can subscribe and AI keeps it current.</CardDescription>`,
+    },
+    {
       filename,
       code: `<span aria-label="Copy Profile Link" />`,
     },

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1484,13 +1484,12 @@
 
 [data-theme="linear"],
 .linear-marketing {
-  /* Marketing typography: Satoshi (display/buttons) + DM Sans (body) */
-  font-family:
-    var(--font-dm-sans), "DM Sans", -apple-system, "system-ui", sans-serif;
+  /* Unified type (one system, two languages): Inter body + UI; Satoshi reserved
+     for display/headings (approved exception). DM Sans retired 2026-06-18. */
+  font-family: var(--font-sans);
   --marketing-font-display:
     var(--font-satoshi), "Satoshi", -apple-system, "system-ui", sans-serif;
-  --marketing-font-body:
-    var(--font-dm-sans), "DM Sans", -apple-system, "system-ui", sans-serif;
+  --marketing-font-body: var(--font-sans);
 
   /* Map Linear text colors to design system */
   --color-text-primary-token: var(--linear-text-primary);

--- a/apps/web/tests/unit/design-system/singular-system-b-ratchet.test.ts
+++ b/apps/web/tests/unit/design-system/singular-system-b-ratchet.test.ts
@@ -1,0 +1,132 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Singular design system ("one system, two languages") ratchet.
+ *
+ * Founder-directed 2026-06-18 (see DESIGN.md decision log + gbrain "design
+ * system review" canon): Jovie is converging the whole app onto System B — one
+ * token foundation, one palette, one core typeface (Inter). System A (the
+ * cinematic marketing language) is being RETIRED, not maintained.
+ *
+ * This is the global, machine-checked guardrail for that convergence. Per-surface
+ * forbidden-pattern checks live in the individual `*-system-b-style-guard` tests;
+ * this file enforces the two app-wide invariants that must only get tighter:
+ *
+ *   1. DM Sans is retired — no live source loads it or reads its font var.
+ *      (Inter is the sole body/UI face; Satoshi is the one approved display face.)
+ *   2. `.linear-marketing` (the System A wrapper) is shrink-only — no NEW surface
+ *      may adopt it, and migrated surfaces must drop out of the allowlist. When the
+ *      allowlist reaches empty, System A is fully retired and the goal is met.
+ *
+ * Tests run with cwd = apps/web (Vitest project root).
+ */
+
+const WEB_ROOT = process.cwd();
+
+const SKIP: RegExp[] = [
+  /\/tests\//,
+  /\/node_modules\//,
+  /\/\.next\//,
+  /\/\.turbo\//,
+  // Self-contained pitch reference stylesheet: defines its own --font-dm-sans and
+  // imports the Google webfont. Tracked for cleanup in the System A teardown phase.
+  /\/public\/pitch\//,
+  // Server-side OG-image Satori rendering is a build-time asset, not live page type.
+  /opengraph-image\.tsx$/,
+  /\/lib\/share\/image-utils\.ts$/,
+  /\.test\.[tj]sx?$/,
+];
+
+function walk(dir: string, exts: readonly string[]): string[] {
+  const out: string[] = [];
+  let entries: ReturnType<typeof readdirSync>;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (SKIP.some(rx => rx.test(full))) continue;
+    if (entry.isDirectory()) {
+      out.push(...walk(full, exts));
+    } else if (exts.some(ext => entry.name.endsWith(ext))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function rel(file: string): string {
+  return relative(WEB_ROOT, file);
+}
+
+describe('singular System B — design-system unification ratchet', () => {
+  it('DM Sans is retired: no live source loads it or reads --font-dm-sans', () => {
+    const layout = readFileSync(resolve(WEB_ROOT, 'app/layout.tsx'), 'utf8');
+    expect(
+      layout,
+      'app/layout.tsx must not load DM Sans via next/font/local (retired 2026-06-18)'
+    ).not.toMatch(/DMSans|--font-dm-sans|\bdmSans\b/);
+
+    const files = [
+      ...walk(resolve(WEB_ROOT, 'app'), ['.tsx', '.ts', '.css']),
+      ...walk(resolve(WEB_ROOT, 'components'), ['.tsx', '.ts', '.css']),
+      ...walk(resolve(WEB_ROOT, 'styles'), ['.css']),
+    ];
+
+    const offenders = files
+      .filter(file => {
+        const src = readFileSync(file, 'utf8');
+        return (
+          /var\(--font-dm-sans\)/.test(src) || /--font-dm-sans\s*:/.test(src)
+        );
+      })
+      .map(rel);
+
+    expect(
+      offenders,
+      `DM Sans was retired 2026-06-18. Repoint these to Inter (var(--font-sans)):\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('.linear-marketing wrapper is shrink-only (System A is being retired)', () => {
+    // Baseline 2026-06-18. This set may only SHRINK. Removing the wrapper from a
+    // surface (reskinning it onto System B tokens) must also remove it here.
+    const APPLIERS_ALLOWLIST = new Set<string>([
+      'app/(dynamic)/playlists/layout.tsx',
+      'app/(marketing)/layout.tsx',
+      'app/brand/layout.tsx',
+      'app/not-found.tsx',
+      'app/pitch/layout.tsx',
+      'components/features/home/MarketingScrollUnlock.tsx',
+    ]);
+
+    const files = [
+      ...walk(resolve(WEB_ROOT, 'app'), ['.tsx', '.ts']),
+      ...walk(resolve(WEB_ROOT, 'components'), ['.tsx', '.ts']),
+    ];
+
+    const actual = new Set(
+      files
+        .filter(file => /linear-marketing/.test(readFileSync(file, 'utf8')))
+        .map(rel)
+    );
+
+    const added = [...actual].filter(file => !APPLIERS_ALLOWLIST.has(file));
+    expect(
+      added,
+      `New .linear-marketing usage — System A is being retired (DESIGN.md 2026-06-18).\n` +
+        `Build this surface on System B tokens instead of the System A wrapper:\n${added.join('\n')}`
+    ).toEqual([]);
+
+    const stale = [...APPLIERS_ALLOWLIST].filter(file => !actual.has(file));
+    expect(
+      stale,
+      `These no longer use .linear-marketing — delete them from APPLIERS_ALLOWLIST so the ` +
+        `ratchet tightens toward full System A retirement:\n${stale.join('\n')}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Converge the app onto **one design system, two languages** (product + editorial) per founder direction (2026-06-18), superseding the earlier "defer System A retirement 3 months" note.

- **Retire DM Sans.** Remove its `next/font/local` load in `app/layout.tsx`; repoint `--font-body` and `--marketing-font-body` to Inter (`var(--font-sans)`). Inter is now the sole body/UI face; **Satoshi remains the single approved display exception.**
- **Add a machine-checked ratchet** (`tests/unit/design-system/singular-system-b-ratchet.test.ts`): hard-locks DM Sans retirement and keeps the `.linear-marketing` (System A) wrapper **shrink-only** — no new System A surfaces; the allowlist must empty as surfaces migrate.
- **DESIGN.md:** record the direction + DM Sans retirement in the decision log; mark the surface split as converging; enumerate remaining holdouts.
- **Lint fix (`canonical-ui-label-casing`):** sentence-case check now resets at sentence-terminating punctuation, so a legitimately-capitalized word starting a *second* sentence no longer false-positives. Safe-direction (only removes false-positives) + a multi-sentence regression case.

## Verification
- `pnpm --filter @jovie/web typecheck` — **PASS** (exit 0)
- `biome check` (touched files) — **PASS**
- `singular-system-b-ratchet.test.ts` — **PASS** (2/2)
- `canonical-ui-label-casing.test.ts` — **PASS** (19/19)
- Grep: no **live** source wires DM Sans into the body/UI/marketing-body chain. Remaining matches are dated retirement comments, brand-page/OG type-history copy, the CSP comment, standalone-HTML fallback stacks, and the self-contained `public/pitch/*` deck — none are the app's font system.

## Visual evidence
Token-level font-stack swap (DM Sans → Inter for body + marketing-body copy). The affected view is "all body text" — the **Preview Deploy + Lighthouse** lanes on this PR render the live result, which is stronger evidence than a static shot for a font change. Happy to attach a specific before/after if a reviewer wants one.

## Cost Impact
None — no new external calls, crons, or runtime cost. Removes one `next/font/local` load (marginally fewer font assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design system documentation to record migration to unified system with Inter as standard body font and Satoshi restricted to display typography.

* **Style**
  * Updated default body and UI font from DM Sans to Inter across the platform.
  * Satoshi now used exclusively for display typography.

* **Tests**
  * Added test coverage for design system font configuration verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->