### PR TITLE
feat(web): reconcile design tokens to canonical Jovie DS + drift ratchet (foundation)

### DIFF
--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -330,8 +330,9 @@
   --color-accent-teal: #0f9b8e;
   --color-accent-teal-subtle: #e8f7f5;
 
-  /* Default product accent uses the palette purple */
-  --color-accent: var(--color-accent-purple);
+  /* Interactive accent (focus, links, active) — canonical Jovie DS #7170ff,
+     decoupled from the purple feature accent (carbon palette, title text only) */
+  --color-accent: #7170ff;
   --color-accent-hover: #9a46ff;
   --color-accent-active: #7612df;
   --color-accent-subtle: var(--color-accent-purple-subtle);
@@ -572,8 +573,9 @@
   --color-accent-teal: #22b8a7;
   --color-accent-teal-subtle: rgb(15 155 142 / 0.18);
 
-  /* Default product accent uses the palette purple */
-  --color-accent: var(--color-accent-purple);
+  /* Interactive accent (focus, links, active) — canonical Jovie DS #7170ff,
+     decoupled from the purple feature accent (carbon palette, title text only) */
+  --color-accent: #7170ff;
   --color-accent-hover: #b06bff;
   --color-accent-active: #8a37f4;
   --color-accent-subtle: var(--color-accent-purple-subtle);
@@ -1232,8 +1234,8 @@
   /* Modals, sheets — extracted: 16px on elevated panels */
   --radius-3xl: 22px;
   /* Large modals — extracted: 22px on hero sections */
-  --radius-pill: 48px;
-  /* Pill buttons (observed in Linear) */
+  --radius-pill: 9999px;
+  /* All app buttons / inputs / tabs — canonical Jovie DS true pill */
   --radius-full: 9999px;
   /* Circles, tags */
 }

--- a/apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts
+++ b/apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts
@@ -1,0 +1,83 @@
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Design-system drift ratchet.
+ *
+ * Counts arbitrary Tailwind values (`w-[327px]`, `text-[#fff]`,
+ * `data-[state=open]:…`) across the web surfaces. The count may only go
+ * DOWN: every wave that converges screens onto the canonical Jovie Design
+ * System tokens removes arbitrary values, never adds them.
+ *
+ * Why a ratchet and not zero-tolerance: there are ~6.6k existing arbitrary
+ * values; banning them outright would block all work. The ratchet locks in
+ * progress — regressions fail CI, improvements pass. When you reduce the
+ * count, lower `count` in arbitrary-values.baseline.json in the same PR so
+ * the floor follows the work down.
+ *
+ * Pattern mirrors apps/web/scripts/seo-ratchet-guard.mjs (baseline JSON +
+ * source-text guard).
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// tests/unit/design-system → apps/web
+const WEB_ROOT = join(__dirname, '..', '..', '..');
+const SCAN_DIRS = ['components', 'app'].map(d => join(WEB_ROOT, d));
+const BASELINE_PATH = join(__dirname, 'arbitrary-values.baseline.json');
+
+// Tailwind arbitrary value: a utility/variant chain ending in `-[…]`.
+// The `-[` signature avoids array-index false positives (`items[i]`).
+const ARBITRARY = /\b[a-z][a-z0-9]*(?:-[a-z0-9]+)*-\[[^\]]+\]/gi;
+const SOURCE_EXT = /\.(tsx|ts)$/;
+
+function walk(dir: string, out: string[]): void {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) {
+      if (entry === 'node_modules' || entry === '.next') continue;
+      walk(full, out);
+    } else if (SOURCE_EXT.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+function countArbitraryValues(): number {
+  const files: string[] = [];
+  for (const dir of SCAN_DIRS) walk(dir, files);
+  let total = 0;
+  for (const file of files) {
+    const matches = readFileSync(file, 'utf8').match(ARBITRARY);
+    if (matches) total += matches.length;
+  }
+  return total;
+}
+
+describe('design-system arbitrary-value ratchet', () => {
+  it('arbitrary Tailwind values do not increase above the baseline', () => {
+    const current = countArbitraryValues();
+
+    // Self-seed on first run so the baseline and the count logic can never
+    // diverge. Commit the seeded file; CI compares against it.
+    if (!existsSync(BASELINE_PATH)) {
+      writeFileSync(
+        BASELINE_PATH,
+        `${JSON.stringify({ count: current, note: 'Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count.' }, null, 2)}\n`
+      );
+    }
+
+    const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as {
+      count: number;
+    };
+
+    expect(
+      current,
+      `Arbitrary Tailwind values rose to ${current} (baseline ${baseline.count}). ` +
+        'Use design-system tokens instead of arbitrary values, or — if this is intentional — justify it in review.'
+    ).toBeLessThanOrEqual(baseline.count);
+  });
+});

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,0 +1,4 @@
+{
+  "count": 6431,
+  "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
+}


### PR DESCRIPTION
## What

Phase 0 of converging the web app onto the canonical **Jovie Design System** (`claude.ai/design`, reverse-engineered from this repo + cleaned). Aligns the drifted token *values* to canonical and adds a drift guardrail. No screen/markup changes yet — pure foundation that later atom/screen waves build on.

## Changes
- `--color-accent`: `var(--color-accent-purple)` (#8b1eff dark / #9b4dff light) → **#7170ff** — the canonical interactive accent (focus/links/active), decoupled from the purple carbon *feature* accent (title-text only). The focus ring (`--color-border-focus`) was already #7170ff; this makes links/active match.
- `--radius-pill`: `48px` → **9999px** — true pill on all buttons/inputs/tabs (renders identically for normal control heights; only differs on tall elements).
- **Drift ratchet** (new): `tests/unit/design-system/arbitrary-values-ratchet.test.ts` + baseline (**6431**). Arbitrary Tailwind values may only decrease — every later wave ratchets it down; regressions fail `ci-unit-tests`. Mirrors the `seo-ratchet` pattern.

## 🎨 Taste decision (needs-human)
The accent hue shift (purple → blue-purple #7170ff) is a real, global, visible change to links/active states. It matches the canonical DS, but it's a brand-color call — **please eyeball before merging.**

## Verify
- CI: `ci-typecheck / ci-lint / ci-build / ci-unit-tests / pr-policy` + graphite-ai-reviews.
- Ratchet green at 6431; `rg -o '\b[a-z-]+\[[^]]+\]' apps/web/components apps/web/app | wc -l` trends down each wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated design system interactive accent color to align with canonical Jovie DS specifications
  * Enhanced pill-shaped component border radius for improved visual consistency

* **Tests**
  * Added new unit test to enforce and monitor Tailwind CSS arbitrary values baseline constraint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->