### PR TITLE
train(ui): land stranded JOV-3043 dashboard lazy-load (integration/loop-ui → main)

### DIFF
--- a/apps/web/app/app/(shell)/audience/page.tsx
+++ b/apps/web/app/app/(shell)/audience/page.tsx
@@ -2,9 +2,9 @@ import type { SearchParams } from 'nuqs/server';
 import { Suspense } from 'react';
 import { BASE_URL } from '@/constants/app';
 import { APP_ROUTES } from '@/constants/routes';
-import { DashboardAudienceClient } from '@/features/dashboard/organisms/DashboardAudienceClient';
 import { AudienceTableLoadingShell } from '@/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell';
 import type { AudienceSegment } from '@/features/dashboard/organisms/dashboard-audience-table/types';
+import { LazyDashboardAudienceClient } from '@/features/dashboard/organisms/LazyDashboardAudienceClient';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
 import { captureError } from '@/lib/error-tracking';
 import { audienceFilters, audienceSearchParams } from '@/lib/nuqs';
@@ -114,7 +114,7 @@ async function AudienceContent({
     );
 
     return (
-      <DashboardAudienceClient
+      <LazyDashboardAudienceClient
         mode={audienceData.mode}
         view={audienceData.view}
         initialRows={audienceData.rows}

--- a/apps/web/app/app/(shell)/calendar/LazyCalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/LazyCalendarPageClient.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { PageContent, PageShell } from '@/components/organisms/PageShell';
+import { PageToolbar } from '@/components/organisms/table';
+
+const CALENDAR_WEEKDAY_KEYS = [
+  'weekday-sun',
+  'weekday-mon',
+  'weekday-tue',
+  'weekday-wed',
+  'weekday-thu',
+  'weekday-fri',
+  'weekday-sat',
+] as const;
+
+const CALENDAR_GRID_CELL_KEYS = [
+  'calendar-cell-01',
+  'calendar-cell-02',
+  'calendar-cell-03',
+  'calendar-cell-04',
+  'calendar-cell-05',
+  'calendar-cell-06',
+  'calendar-cell-07',
+  'calendar-cell-08',
+  'calendar-cell-09',
+  'calendar-cell-10',
+  'calendar-cell-11',
+  'calendar-cell-12',
+  'calendar-cell-13',
+  'calendar-cell-14',
+  'calendar-cell-15',
+  'calendar-cell-16',
+  'calendar-cell-17',
+  'calendar-cell-18',
+  'calendar-cell-19',
+  'calendar-cell-20',
+  'calendar-cell-21',
+  'calendar-cell-22',
+  'calendar-cell-23',
+  'calendar-cell-24',
+  'calendar-cell-25',
+  'calendar-cell-26',
+  'calendar-cell-27',
+  'calendar-cell-28',
+  'calendar-cell-29',
+  'calendar-cell-30',
+  'calendar-cell-31',
+  'calendar-cell-32',
+  'calendar-cell-33',
+  'calendar-cell-34',
+  'calendar-cell-35',
+] as const;
+
+function CalendarRouteSkeleton() {
+  return (
+    <PageShell
+      aria-busy='true'
+      aria-label='Loading Calendar'
+      aria-live='polite'
+      toolbar={
+        <PageToolbar
+          start={<div className='skeleton h-4 w-56 rounded-md' />}
+          end={
+            <div className='flex flex-wrap items-center justify-end gap-1'>
+              <div className='skeleton h-7 w-12 rounded-full' />
+              <div className='skeleton h-7 w-20 rounded-full' />
+              <div className='skeleton h-7 w-16 rounded-full' />
+              <div className='skeleton h-7 w-28 rounded-full' />
+            </div>
+          }
+        />
+      }
+    >
+      <PageContent>
+        <div className='flex h-full min-h-0 flex-col gap-4'>
+          <div className='flex flex-wrap items-center justify-between gap-2'>
+            <div className='skeleton h-7 w-40 rounded-md' />
+            <div className='skeleton h-7 w-16 rounded-md' />
+          </div>
+          <div className='overflow-hidden rounded-xl border border-subtle'>
+            <div className='grid grid-cols-7 border-b border-subtle'>
+              {CALENDAR_WEEKDAY_KEYS.map(key => (
+                <div key={key} className='px-2 py-2'>
+                  <div className='skeleton mx-auto h-3 w-8 rounded-sm' />
+                </div>
+              ))}
+            </div>
+            <div className='grid grid-cols-7'>
+              {CALENDAR_GRID_CELL_KEYS.map(key => (
+                <div
+                  key={key}
+                  className='min-h-24 border-b border-r border-subtle p-2 last:border-r-0'
+                >
+                  <div className='skeleton mb-2 h-3 w-5 rounded-sm' />
+                  <div className='skeleton h-4 w-full rounded-sm' />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </PageContent>
+    </PageShell>
+  );
+}
+
+const CalendarPageClient = dynamic(
+  () =>
+    import('./CalendarPageClient').then(mod => ({
+      default: mod.CalendarPageClient,
+    })),
+  {
+    loading: () => <CalendarRouteSkeleton />,
+  }
+);
+
+export function LazyCalendarPageClient() {
+  return <CalendarPageClient />;
+}

--- a/apps/web/app/app/(shell)/calendar/page.tsx
+++ b/apps/web/app/app/(shell)/calendar/page.tsx
@@ -13,7 +13,7 @@ import type {
 } from '@/lib/tour-dates/types';
 import { loadAppShellRouteContext } from '../app-shell-route-context';
 import { loadTourDates } from '../dashboard/tour-dates/actions';
-import { CalendarPageClient } from './CalendarPageClient';
+import { LazyCalendarPageClient } from './LazyCalendarPageClient';
 
 export const runtime = 'nodejs';
 
@@ -120,7 +120,7 @@ export default async function CalendarPage() {
 
   return (
     <HydrateClient state={getDehydratedState()}>
-      <CalendarPageClient />
+      <LazyCalendarPageClient />
     </HydrateClient>
   );
 }

--- a/apps/web/app/app/(shell)/tasks/TasksRoute.tsx
+++ b/apps/web/app/app/(shell)/tasks/TasksRoute.tsx
@@ -1,4 +1,4 @@
-import { TasksPageClient } from '@/components/features/dashboard/tasks/TasksPageClient';
+import { LazyTasksPageClient } from '@/components/features/dashboard/tasks/LazyTasksPageClient';
 import { TasksWorkspaceUpgradeInterstitial } from '@/components/features/dashboard/tasks/TasksUpgradeInterstitial';
 import { APP_ROUTES } from '@/constants/routes';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
@@ -55,7 +55,7 @@ export async function TasksRoute() {
 
   return (
     <HydrateClient state={getDehydratedState()}>
-      <TasksPageClient />
+      <LazyTasksPageClient />
     </HydrateClient>
   );
 }

--- a/apps/web/components/features/dashboard/organisms/LazyDashboardAudienceClient.tsx
+++ b/apps/web/components/features/dashboard/organisms/LazyDashboardAudienceClient.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { AudienceTableLoadingShell } from '@/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell';
+import type { DashboardAudienceClientProps } from './DashboardAudienceClient';
+
+const DashboardAudienceClient = dynamic(
+  () =>
+    import('./DashboardAudienceClient').then(mod => ({
+      default: mod.DashboardAudienceClient,
+    })),
+  {
+    loading: () => <AudienceTableLoadingShell />,
+  }
+);
+
+export function LazyDashboardAudienceClient(
+  props: Readonly<DashboardAudienceClientProps>
+) {
+  return <DashboardAudienceClient {...props} />;
+}

--- a/apps/web/components/features/dashboard/tasks/LazyTasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/LazyTasksPageClient.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { TasksRouteSkeleton } from '@/components/shell/TasksRouteSkeleton';
+
+const TasksPageClient = dynamic(
+  () =>
+    import('./TasksPageClient').then(mod => ({
+      default: mod.TasksPageClient,
+    })),
+  {
+    loading: () => <TasksRouteSkeleton />,
+  }
+);
+
+export function LazyTasksPageClient() {
+  return <TasksPageClient />;
+}

--- a/apps/web/tests/e2e/mobile-overflow.spec.ts
+++ b/apps/web/tests/e2e/mobile-overflow.spec.ts
@@ -21,6 +21,7 @@ import {
 const DEFAULT_MOBILE_WIDTHS = [
   320, 360, 375, 390, 393, 402, 414, 428, 430,
 ] as const;
+const DEFAULT_PUBLIC_BOUNDARY_WIDTHS = [320, 430] as const;
 const MOBILE_HEIGHT = 844;
 const FOCUS_TRAVERSAL_LIMIT = getPositiveIntegerEnv(
   'MOBILE_OVERFLOW_FOCUS_LIMIT',
@@ -31,6 +32,27 @@ const USE_TEST_AUTH_BYPASS = process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
 const MOBILE_WIDTHS =
   getMobileWidthsFromEnv(process.env.MOBILE_OVERFLOW_WIDTHS) ??
   DEFAULT_MOBILE_WIDTHS;
+const PUBLIC_BOUNDARY_WIDTHS =
+  getMobileWidthsFromEnv(process.env.MOBILE_OVERFLOW_PUBLIC_WIDTHS) ??
+  DEFAULT_PUBLIC_BOUNDARY_WIDTHS;
+const HAS_DATABASE = Boolean(
+  process.env.DATABASE_URL && !process.env.DATABASE_URL.includes('dummy')
+);
+const ONE_PIXEL_GIF = Buffer.from(
+  'R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==',
+  'base64'
+);
+const SEEDED_SURFACE_FAMILIES = new Set<ResolvedPublicSurfaceSpec['family']>([
+  'profile-core',
+  'profile-mode',
+  'release',
+  'track',
+  'countdown',
+  'playlist-or-sounds',
+  'download',
+]);
+const UNAVAILABLE_SURFACE_TEXT =
+  /profile not found|temporarily unavailable|loading jovie profile/i;
 
 const PUBLIC_SURFACE_IDS = [
   'home',
@@ -76,14 +98,37 @@ function getMobileWidthsFromEnv(value: string | undefined) {
   return widths && widths.length > 0 ? widths : null;
 }
 
+const RESOLVED_PUBLIC_SURFACES = resolvePublicSurfaceManifestSync();
+
 const PUBLIC_SURFACES_BY_ID = new Map(
-  resolvePublicSurfaceManifestSync().map(surface => [surface.id, surface])
+  RESOLVED_PUBLIC_SURFACES.map(surface => [surface.id, surface])
 );
 
 const PUBLIC_SURFACES = PUBLIC_SURFACE_IDS.map(surfaceId => {
   const surface = PUBLIC_SURFACES_BY_ID.get(surfaceId);
   if (!surface) {
     throw new Error(`Missing public mobile overflow surface: ${surfaceId}`);
+  }
+  return surface;
+});
+
+function getPublicSurfaceFilterFromEnv(value: string | undefined) {
+  const surfaceIds = value
+    ?.split(',')
+    .map(surfaceId => surfaceId.trim())
+    .filter(Boolean);
+
+  return surfaceIds && surfaceIds.length > 0
+    ? surfaceIds
+    : RESOLVED_PUBLIC_SURFACES.map(surface => surface.id);
+}
+
+const ALL_PUBLIC_SURFACES = getPublicSurfaceFilterFromEnv(
+  process.env.MOBILE_OVERFLOW_PUBLIC_SURFACES
+).map(surfaceId => {
+  const surface = PUBLIC_SURFACES_BY_ID.get(surfaceId);
+  if (!surface) {
+    throw new Error(`Unknown public mobile overflow surface: ${surfaceId}`);
   }
   return surface;
 });
@@ -167,7 +212,7 @@ async function gotoRouteWithRetry(
   page: Page,
   route: MobileOverflowRoute
 ): Promise<Response | null> {
-  const maxAttempts = 2;
+  const maxAttempts = 4;
   let lastError: unknown = null;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -185,7 +230,14 @@ async function gotoRouteWithRetry(
       lastError = error;
       const message = error instanceof Error ? error.message : String(error);
       const shouldRetry =
-        attempt < maxAttempts && /ERR_EMPTY_RESPONSE|ECONNRESET/i.test(message);
+        attempt < maxAttempts &&
+        /ERR_EMPTY_RESPONSE|ERR_CONNECTION_REFUSED|ERR_CONNECTION_RESET|ECONNREFUSED|ECONNRESET/i.test(
+          message
+        );
+      if (shouldRetry) {
+        await page.waitForTimeout(1_000 * attempt);
+        continue;
+      }
       if (!shouldRetry) break;
     }
   }
@@ -211,10 +263,45 @@ async function navigateToPublicSurface(
   await waitForHydration(page, {
     timeout: surface.readyVisibleTimeoutMs ?? SMOKE_TIMEOUTS.VISIBILITY,
   });
-  await waitForAnySelector(
-    page,
-    surface.readySelectors,
-    surface.readyVisibleTimeoutMs ?? SMOKE_TIMEOUTS.VISIBILITY
+  try {
+    await waitForAnySelector(
+      page,
+      surface.readySelectors,
+      surface.readyVisibleTimeoutMs ?? SMOKE_TIMEOUTS.VISIBILITY
+    );
+  } catch (error) {
+    await skipUnavailableSeededSurface(page, surface);
+    throw error;
+  }
+  await skipUnavailableSeededSurface(page, surface);
+}
+
+async function skipUnavailableSeededSurface(
+  page: Page,
+  surface: ResolvedPublicSurfaceSpec
+): Promise<void> {
+  if (HAS_DATABASE || !SEEDED_SURFACE_FAMILIES.has(surface.family)) {
+    return;
+  }
+
+  const bodyText =
+    (await page
+      .locator('body')
+      .textContent()
+      .catch(() => '')) ?? '';
+  test.skip(
+    UNAVAILABLE_SURFACE_TEXT.test(bodyText),
+    `${surface.id} unavailable without DATABASE_URL`
+  );
+}
+
+async function stabilizeImageOptimizerRequests(page: Page): Promise<void> {
+  await page.route('**/_next/image?**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'image/gif',
+      body: ONE_PIXEL_GIF,
+    })
   );
 }
 
@@ -324,6 +411,31 @@ test.describe('Mobile Overflow', () => {
               page,
               testInfo,
               `${route.id} ${width}px`
+            );
+          });
+        }
+      });
+    }
+  });
+
+  test.describe('All Public Surface Boundary Guard', () => {
+    test.describe.configure({ mode: 'parallel' });
+    test.setTimeout(180_000);
+
+    for (const width of PUBLIC_BOUNDARY_WIDTHS) {
+      test.describe(`${width}px`, () => {
+        test.use({ viewport: { width, height: MOBILE_HEIGHT } });
+
+        for (const surface of ALL_PUBLIC_SURFACES) {
+          test(`public boundary ${surface.id} has no horizontal overflow @ ${width}px`, async ({
+            page,
+          }, testInfo) => {
+            await stabilizeImageOptimizerRequests(page);
+            await navigateToPublicSurface(page, surface);
+            await assertSurfaceDoesNotOverflow(
+              page,
+              testInfo,
+              `${surface.id} ${width}px`
             );
           });
         }

--- a/apps/web/tests/unit/app/audience-page.test.tsx
+++ b/apps/web/tests/unit/app/audience-page.test.tsx
@@ -9,6 +9,7 @@ describe('audience app shell route', () => {
       'utf8'
     );
 
+    expect(source).toContain('LazyDashboardAudienceClient');
     expect(source).toContain('loadAppShellRouteContext');
     expect(source).toContain('loadAuthenticatedAppShellUserId');
     expect(source).toContain('requireAppShellDashboardUserId');

--- a/apps/web/tests/unit/app/dashboard-tasks-page.test.tsx
+++ b/apps/web/tests/unit/app/dashboard-tasks-page.test.tsx
@@ -68,8 +68,8 @@ vi.mock('@/lib/queries/HydrateClient', () => ({
   }) => <div data-testid='hydrate-client'>{children}</div>,
 }));
 
-vi.mock('@/components/features/dashboard/tasks/TasksPageClient', () => ({
-  TasksPageClient: () => (
+vi.mock('@/components/features/dashboard/tasks/LazyTasksPageClient', () => ({
+  LazyTasksPageClient: () => (
     <div data-testid='tasks-page-client'>Tasks Client</div>
   ),
 }));

--- a/apps/web/tests/unit/calendar/calendar-page.test.tsx
+++ b/apps/web/tests/unit/calendar/calendar-page.test.tsx
@@ -70,8 +70,10 @@ vi.mock('@/app/app/(shell)/dashboard/tour-dates/actions', () => ({
   loadTourDates: mocks.loadTourDates,
 }));
 
-vi.mock('@/app/app/(shell)/calendar/CalendarPageClient', () => ({
-  CalendarPageClient: () => <div data-testid='calendar-client'>Calendar</div>,
+vi.mock('@/app/app/(shell)/calendar/LazyCalendarPageClient', () => ({
+  LazyCalendarPageClient: () => (
+    <div data-testid='calendar-client'>Calendar</div>
+  ),
 }));
 
 const { default: CalendarPage } = await import(


### PR DESCRIPTION
Train PR draining **integration/loop-ui** → main. These 3 commits were ready + tested but stranded 90 commits behind main from a prior UI wave; rebased current (clean, no conflicts) and landed now so the integration branch is a clean base for the design-system waves.

- feat(web): lazy-load heaviest dashboard client bundles (JOV-3043)
- fix(web): stable keys in calendar lazy-load skeleton (JOV-3043)
- test(e2e): cover public mobile boundary routes

Full CI runs here (integration → main train). No new changes — pure rebase of existing reviewed work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audience, calendar, and tasks pages now lazy-load their route clients and display skeleton placeholders while loading.

* **Bug Fixes**
  * Improved navigation reliability in mobile overflow tests with broader retry detection and incremental backoff.

* **Tests**
  * Updated unit tests to mock the new lazy-loaded clients.
  * Expanded mobile overflow E2E coverage with a dedicated public boundary guard and “all public surface” overflow checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->