### PR TITLE
fix(design-system): replace text-[13px] with text-app token in artists page

### DIFF
--- a/apps/web/app/artists/page.tsx
+++ b/apps/web/app/artists/page.tsx
@@ -63,7 +63,7 @@ export default async function ArtistsPage() {
               <p className='text-[12px] font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
                 Public profiles
               </p>
-              <p className='text-[13px] leading-5 text-secondary-token'>
+              <p className='text-app leading-5 text-secondary-token'>
                 Creator pages currently available to browse.
               </p>
             </ContentSurfaceCard>
@@ -71,7 +71,7 @@ export default async function ArtistsPage() {
               <p className='text-[13px] font-semibold text-primary-token'>
                 Discover artists
               </p>
-              <p className='text-[13px] leading-5 text-secondary-token'>
+              <p className='text-app leading-5 text-secondary-token'>
                 Browse creator pages, profile themes, and public fan
                 experiences.
               </p>
@@ -80,7 +80,7 @@ export default async function ArtistsPage() {
               <p className='text-[13px] font-semibold text-primary-token'>
                 Jump straight in
               </p>
-              <p className='text-[13px] leading-5 text-secondary-token'>
+              <p className='text-app leading-5 text-secondary-token'>
                 Every card opens the artist&apos;s public profile in one click.
               </p>
             </ContentSurfaceCard>
@@ -115,11 +115,11 @@ export default async function ArtistsPage() {
                       {profile.displayName || profile.username}
                     </h2>
                     {profile.bio ? (
-                      <p className='line-clamp-3 text-[13px] leading-5 text-secondary-token'>
+                      <p className='line-clamp-3 text-app leading-5 text-secondary-token'>
                         {profile.bio}
                       </p>
                     ) : (
-                      <p className='text-[13px] leading-5 text-tertiary-token'>
+                      <p className='text-app leading-5 text-tertiary-token'>
                         Public creator profile on Jovie.
                       </p>
                     )}
@@ -139,7 +139,7 @@ export default async function ArtistsPage() {
               <p className='text-[15px] font-semibold text-primary-token'>
                 No profiles found
               </p>
-              <p className='mt-2 text-[13px] leading-5 text-secondary-token'>
+              <p className='mt-2 text-app leading-5 text-secondary-token'>
                 Check back later for new creator profiles.
               </p>
             </div>
@@ -160,7 +160,7 @@ function renderFallback() {
           subtitle='Please check back shortly once the connection is available.'
         />
         <div className='px-5 py-8 text-center sm:px-6'>
-          <p className='text-[13px] leading-5 text-secondary-token'>
+          <p className='text-app leading-5 text-secondary-token'>
             Public creator data is temporarily unavailable.
           </p>
         </div>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 6417,
+  "count": 6410,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replace 7 occurrences of `text-[13px]` with `text-app` (13 px token) in `app/artists/page.tsx`
- All 7 lines carry an explicit `leading-5` class → rendered output is byte-for-byte identical
- Skipped 6 remaining instances on the same file that lack an explicit `leading-*` class (safe-replacement rule)
- Lower ratchet baseline 6417 → 6410 to lock in the 7-value reduction (rebased onto integration/loop-ui tip which had already moved the baseline from 6431 → 6417)

## Changes

| File | Change |
|------|--------|
| `app/artists/page.tsx` | 7× `text-[13px]` → `text-app` (lines with explicit `leading-5`) |
| `tests/unit/design-system/arbitrary-values.baseline.json` | 6417 → 6410 |

## Verification

- Pre-commit hooks: typecheck ✅, biome ✅, gitleaks ✅
- Pre-push hooks: biome check ✅, tailwind guard ✅, typecheck ✅, lint ✅
- SonarQube Quality Gate: passed (0 new issues) ✅
- Arbitrary values count: 6417 → 6410 (−7, ratchet passes)

## Test plan

- [ ] Confirm `apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts` passes in CI Unit Tests
- [ ] Visual diff on `/artists` page: all body copy renders identically at 13 px / leading-5

<!-- linear-issue-id:JOV-DS-ARTISTS -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGHrimxSbxKJn7CvFs7NXd)_