### PR TITLE
fix(design-system): replace arbitrary color tokens with named utilities in InvestorNav

### DIFF
--- a/apps/web/app/investor-portal/_components/InvestorNav.tsx
+++ b/apps/web/app/investor-portal/_components/InvestorNav.tsx
@@ -100,7 +100,7 @@ export function InvestorNav({ investorName, pages }: InvestorNavProps) {
             onClick={toggleSheet}
             aria-expanded={isOpen}
             aria-controls='mobile-nav'
-            aria-label={isOpen ? 'Close navigation' : 'Open navigation'}
+            aria-label={isOpen ? 'Close Navigation' : 'Open Navigation'}
             className={cn(
               'flex h-8 w-8 items-center justify-center rounded',
               'text-secondary-token hover:bg-interactive-hover',

--- a/apps/web/app/investor-portal/_components/InvestorNav.tsx
+++ b/apps/web/app/investor-portal/_components/InvestorNav.tsx
@@ -66,16 +66,16 @@ export function InvestorNav({ investorName, pages }: InvestorNavProps) {
     <>
       {/* Desktop sidebar */}
       <nav
-        className='max-lg:hidden w-[200px] flex-shrink-0 flex-col border-r border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-0)] px-3 py-6 lg:flex'
-        aria-label='Investor portal navigation'
+        className='max-lg:hidden w-[200px] flex-shrink-0 flex-col border-r border-subtle bg-surface-0 px-3 py-6 lg:flex'
+        aria-label='Investor Portal Navigation'
       >
         {/* Branding */}
         <div className='mb-8 px-2'>
-          <span className='text-[length:var(--text-lg)] font-bold tracking-tight text-[var(--color-text-primary-token)]'>
+          <span className='text-[length:var(--text-lg)] font-bold tracking-tight text-primary-token'>
             Jovie
           </span>
           {investorName && (
-            <p className='mt-1 text-[length:var(--text-xs)] text-[var(--color-text-tertiary-token)]'>
+            <p className='mt-1 text-[length:var(--text-xs)] text-tertiary-token'>
               For {investorName}
             </p>
           )}
@@ -85,13 +85,13 @@ export function InvestorNav({ investorName, pages }: InvestorNavProps) {
       </nav>
 
       {/* Mobile header bar */}
-      <header className='fixed left-0 right-0 top-0 z-40 flex items-center justify-between border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-base)] px-4 py-3 lg:hidden'>
-        <span className='text-[length:var(--text-base)] font-bold text-[var(--color-text-primary-token)]'>
+      <header className='fixed left-0 right-0 top-0 z-40 flex items-center justify-between border-b border-subtle bg-base px-4 py-3 lg:hidden'>
+        <span className='text-[length:var(--text-base)] font-bold text-primary-token'>
           Jovie
         </span>
         <div className='flex items-center gap-3'>
           {investorName && (
-            <span className='text-[length:var(--text-xs)] text-[var(--color-text-tertiary-token)]'>
+            <span className='text-[length:var(--text-xs)] text-tertiary-token'>
               For {investorName}
             </span>
           )}
@@ -102,8 +102,8 @@ export function InvestorNav({ investorName, pages }: InvestorNavProps) {
             aria-controls='mobile-nav'
             aria-label={isOpen ? 'Close navigation' : 'Open navigation'}
             className={cn(
-              'flex h-8 w-8 items-center justify-center rounded-[var(--radius-default)]',
-              'text-[var(--color-text-secondary-token)] hover:bg-[var(--color-interactive-hover)]',
+              'flex h-8 w-8 items-center justify-center rounded',
+              'text-secondary-token hover:bg-interactive-hover',
               'focus-ring-themed transition-colors'
             )}
           >
@@ -124,7 +124,7 @@ export function InvestorNav({ investorName, pages }: InvestorNavProps) {
             type='button'
             className='absolute inset-0 bg-black/50 transition-opacity'
             onClick={() => setIsOpen(false)}
-            aria-label='Close navigation'
+            aria-label='Close Navigation'
             tabIndex={-1}
           />
 
@@ -133,16 +133,16 @@ export function InvestorNav({ investorName, pages }: InvestorNavProps) {
             id='mobile-nav'
             open
             aria-label='Navigation'
-            className='absolute bottom-0 left-0 top-0 m-0 w-64 border-r border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-0)] px-3 py-6'
+            className='absolute bottom-0 left-0 top-0 m-0 w-64 border-r border-subtle bg-surface-0 px-3 py-6'
           >
             {/* Branding */}
             <div className='mb-8 flex items-center justify-between px-2'>
               <div>
-                <span className='text-[length:var(--text-lg)] font-bold tracking-tight text-[var(--color-text-primary-token)]'>
+                <span className='text-[length:var(--text-lg)] font-bold tracking-tight text-primary-token'>
                   Jovie
                 </span>
                 {investorName && (
-                  <p className='mt-1 text-[length:var(--text-xs)] text-[var(--color-text-tertiary-token)]'>
+                  <p className='mt-1 text-[length:var(--text-xs)] text-tertiary-token'>
                     For {investorName}
                   </p>
                 )}
@@ -150,10 +150,10 @@ export function InvestorNav({ investorName, pages }: InvestorNavProps) {
               <button
                 type='button'
                 onClick={() => setIsOpen(false)}
-                aria-label='Close navigation'
+                aria-label='Close Navigation'
                 className={cn(
-                  'flex h-8 w-8 items-center justify-center rounded-[var(--radius-default)]',
-                  'text-[var(--color-text-secondary-token)] hover:bg-[var(--color-interactive-hover)]',
+                  'flex h-8 w-8 items-center justify-center rounded',
+                  'text-secondary-token hover:bg-interactive-hover',
                   'focus-ring-themed transition-colors'
                 )}
               >
@@ -185,8 +185,8 @@ function NavItem({
         aria-current={isActive ? 'page' : undefined}
         className={`block rounded-[var(--radius-sm)] px-2 py-1.5 text-[length:var(--text-app)] font-medium transition-colors ${
           isActive
-            ? 'bg-[var(--color-interactive-hover)] text-[var(--color-text-primary-token)]'
-            : 'text-[var(--color-text-tertiary-token)] hover:bg-[var(--color-interactive-hover)] hover:text-[var(--color-text-secondary-token)]'
+            ? 'bg-interactive-hover text-primary-token'
+            : 'text-tertiary-token hover:bg-interactive-hover hover:text-secondary-token'
         }`}
       >
         {label}

--- a/apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts
+++ b/apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 6431,
+  "count": 6408,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaces 23 CSS-variable arbitrary values in `InvestorNav.tsx` with their named design-system token utilities
- Exact equivalents replaced: `border-[var(--color-border-subtle)]` → `border-subtle`, `bg-[var(--color-bg-surface-0)]` → `bg-surface-0`, `bg-[var(--color-bg-base)]` → `bg-base`, `text-[var(--color-text-primary-token)]` → `text-primary-token`, `text-[var(--color-text-secondary-token)]` → `text-secondary-token`, `text-[var(--color-text-tertiary-token)]` → `text-tertiary-token`, `bg-[var(--color-interactive-hover)]` → `bg-interactive-hover`, `rounded-[var(--radius-default)]` → `rounded`
- Layout-specific arbitraries left untouched: `w-[200px]`, `w-64` (no named equivalent)
- Text-size and radius-sm arbitraries left untouched: `text-[length:var(--text-*)]`, `rounded-[var(--radius-sm)]` (named equivalents change rendered output)
- Also fixes pre-existing `@jovie/canonical-ui-label-casing` violations: aria-labels now use Title Case per rules
- Also formats `arbitrary-values-ratchet.test.ts` (pre-existing biome issue caught by pre-push hook)
- **Ratchet: 6431 → 6408 (−23)**

## Verification

- `pnpm --filter @jovie/web run typecheck` ✓ (FULL TURBO cache hit)
- `pnpm --filter @jovie/web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts` ✓ (1 passed, count 6408 ≤ baseline 6408)
- `pnpm biome check --write apps/web/app/investor-portal/_components/InvestorNav.tsx` ✓ (no fixes needed)
- ESLint clean ✓
- Rendered output unchanged: only class name form changed, not semantic value

## Files Changed

- `apps/web/app/investor-portal/_components/InvestorNav.tsx` — token replacements + aria-label casing
- `apps/web/tests/unit/design-system/arbitrary-values.baseline.json` — ratchet lowered 6431 → 6408
- `apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts` — biome import formatting fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwBkQCo7mHQyz2AgWRQh7a)_

<!-- agent-run-artifact
{
  "id": "ds-drift-investor-nav-20260619",
  "source": "ci",
  "sourceRunId": "7368b45a7ada3ae03836142b2c111e9ab3499dbb",
  "kind": "workflow",
  "status": "done",
  "title": "Design-system drift: InvestorNav token migration",
  "summary": "Scheduled agent run (2026-06-19) replacing 23 CSS-variable arbitraries with named token utilities in InvestorNav.tsx. Typecheck, biome, vitest ratchet, and ESLint all passed. Rendered output unchanged.",
  "modelRoute": "claude-code",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": [],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": null,
  "linearIssueUrl": null,
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/11121",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Token-for-token substitution verified by diff inspection. Only class name form changed, not semantic value. Layout arbitraries (w-[200px]) and text-size bundles (text-[length:var(--text-*)]) left untouched. No rendered output change.",
      "checkedAt": "2026-06-19T09:30:00.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed token equivalence in tailwind.config.ts: border-subtle=var(--color-border-subtle), bg-surface-0=var(--color-bg-surface-0), bg-base=var(--color-bg-base), text-primary-token, text-secondary-token, text-tertiary-token, bg-interactive-hover, rounded=var(--radius-default). ESLint aria-label casing violations fixed. rounded-[var(--radius-sm)] excluded (no exact named equivalent).",
      "checkedAt": "2026-06-19T09:30:00.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "pnpm typecheck passed (Turbo: 8 successful, cache hit). pnpm biome check clean (6295 files). vitest ratchet passed (6408 <= 6408 baseline). Baseline JSON lowered 6431->6408. Branch rebased on origin/main (HEAD: 6d1f761). Empty trigger commit SHA: 7368b45a7ada3ae03836142b2c111e9ab3499dbb.",
      "checkedAt": "2026-06-19T09:53:00.000Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-06-19T09:30:00.000Z",
  "updatedAt": "2026-06-19T09:53:00.000Z",
  "metadata": {}
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated navigation component styling to align with design system theme tokens for improved consistency.

* **Tests**
  * Updated test baseline and import formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->