### PR TITLE
fix(mcp): echo JSON-RPC request id in responses instead of hardcoding 1

### DIFF
--- a/apps/web/app/api/mcp/[username]/route.test.ts
+++ b/apps/web/app/api/mcp/[username]/route.test.ts
@@ -1,0 +1,183 @@
+/**
+ * JSON-RPC id echo regression tests for /api/mcp/[username].
+ *
+ * JSON-RPC 2.0 §5 requires the response `id` to match the request `id` exactly.
+ * Previously mcpOk/mcpError hardcoded `id: 1`, breaking clients that send any
+ * other id or multiple concurrent requests.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoist mocks
+// ---------------------------------------------------------------------------
+const hoisted = vi.hoisted(() => ({
+  getProfileByUsername: vi.fn(),
+  getReleasesForProfileLite: vi.fn(),
+  getLiveMerchCardsForProfile: vi.fn(),
+  getUpcomingTourDatesForProfile: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/services/profile', () => ({
+  getProfileByUsername: hoisted.getProfileByUsername,
+}));
+
+vi.mock('@/lib/discography/queries', () => ({
+  getReleasesForProfileLite: hoisted.getReleasesForProfileLite,
+}));
+
+vi.mock('@/lib/merch/service', () => ({
+  getLiveMerchCardsForProfile: hoisted.getLiveMerchCardsForProfile,
+}));
+
+vi.mock('@/lib/tour-dates/queries', () => ({
+  getUpcomingTourDatesForProfile: hoisted.getUpcomingTourDatesForProfile,
+}));
+
+vi.mock('@/constants/app', () => ({ BASE_URL: 'https://jov.ie' }));
+
+vi.mock('@/lib/http/headers', () => ({ NO_STORE_HEADERS: {} }));
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+const FAKE_PROFILE = {
+  id: 'p1',
+  username: 'artist1',
+  displayName: 'Artist One',
+  isPublic: true,
+  bio: null,
+  location: null,
+  genres: [],
+  avatarUrl: null,
+  spotifyUrl: null,
+  appleMusicUrl: null,
+  youtubeUrl: null,
+};
+
+function makeRequest(body: unknown) {
+  return new Request('https://jov.ie/api/mcp/artist1', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('POST /api/mcp/[username] — JSON-RPC id echo', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    hoisted.getProfileByUsername.mockResolvedValue(FAKE_PROFILE);
+    hoisted.getReleasesForProfileLite.mockResolvedValue([]);
+    hoisted.getLiveMerchCardsForProfile.mockResolvedValue([]);
+    hoisted.getUpcomingTourDatesForProfile.mockResolvedValue([]);
+  });
+
+  it('echoes a numeric request id in the success response', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({ jsonrpc: '2.0', id: 42, method: 'initialize' }),
+      {
+        params: Promise.resolve({ username: 'artist1' }),
+      }
+    );
+
+    const body = await res.json();
+    expect(body.id).toBe(42);
+    expect(body.result).toBeDefined();
+  });
+
+  it('echoes a string request id in the success response', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({ jsonrpc: '2.0', id: 'req-abc', method: 'resources/list' }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+
+    const body = await res.json();
+    expect(body.id).toBe('req-abc');
+    expect(body.result).toBeDefined();
+  });
+
+  it('echoes null id when request id is explicitly null', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({ jsonrpc: '2.0', id: null, method: 'tools/list' }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+
+    const body = await res.json();
+    expect(body).toHaveProperty('id', null);
+  });
+
+  it('omits id when request has no id (notification)', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({ jsonrpc: '2.0', method: 'initialize' }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+
+    const body = await res.json();
+    expect(Object.prototype.hasOwnProperty.call(body, 'id')).toBe(false);
+  });
+
+  it('echoes id in error responses (invalid method)', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({ jsonrpc: '2.0', id: 7, method: 'unknown/method' }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+
+    const body = await res.json();
+    expect(body.id).toBe(7);
+    expect(body.error).toBeDefined();
+  });
+
+  it('does not hardcode id: 1 (regression guard)', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({ jsonrpc: '2.0', id: 99, method: 'initialize' }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+
+    const body = await res.json();
+    expect(body.id).not.toBe(1);
+    expect(body.id).toBe(99);
+  });
+
+  it('uses null id for parse error (body is not valid JSON / unreadable)', async () => {
+    const { POST } = await import('./route');
+    // Send non-JSON body to trigger the parse error path
+    const req = new Request('https://jov.ie/api/mcp/artist1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json{{{',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ username: 'artist1' }),
+    });
+    const body = await res.json();
+    expect(body.id).toBeNull();
+    expect(body.error).toBeDefined();
+  });
+
+  it('returns 404 with null id when artist is not found (pre-body-parse)', async () => {
+    hoisted.getProfileByUsername.mockResolvedValue(null);
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({ jsonrpc: '2.0', id: 5, method: 'initialize' }),
+      { params: Promise.resolve({ username: 'nobody' }) }
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    // Before body is parsed we cannot echo the client id; spec says use null
+    expect(body.id).toBeNull();
+    expect(body.error).toBeDefined();
+  });
+});

--- a/apps/web/app/api/mcp/[username]/route.ts
+++ b/apps/web/app/api/mcp/[username]/route.ts
@@ -99,12 +99,28 @@ export async function POST(
   try {
     body = await req.json();
   } catch {
-    return mcpError(-32700, 'Parse error');
+    return mcpError(-32700, 'Parse error', 200, null);
   }
+
+  // Extract JSON-RPC id before method dispatch so all responses can echo it.
+  // Per JSON-RPC 2.0 §5, the response id MUST match the request id exactly.
+  // If id is absent (notification) we pass undefined so mcpOk/mcpError omit it.
+  const idParse = z
+    .union([z.string(), z.number(), z.null()])
+    .optional()
+    .safeParse((body as Record<string, unknown>)?.id);
+  const requestId: JsonRpcId | undefined = idParse.success
+    ? idParse.data
+    : undefined;
 
   const parsed = mcpRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return mcpError(-32601, 'Method not found or invalid params');
+    return mcpError(
+      -32601,
+      'Method not found or invalid params',
+      200,
+      requestId
+    );
   }
   const msg = parsed.data;
 
@@ -112,21 +128,27 @@ export async function POST(
   // initialize
   // -------------------------------------------------------------------------
   if (msg.method === 'initialize') {
-    return mcpOk({
-      protocolVersion: '2025-11-05',
-      capabilities: { resources: {}, tools: {} },
-      serverInfo: {
-        name: `jovie-artist-${profile.username}`,
-        version: '1.0.0',
+    return mcpOk(
+      {
+        protocolVersion: '2025-11-05',
+        capabilities: { resources: {}, tools: {} },
+        serverInfo: {
+          name: `jovie-artist-${profile.username}`,
+          version: '1.0.0',
+        },
       },
-    });
+      requestId
+    );
   }
 
   // -------------------------------------------------------------------------
   // resources/list
   // -------------------------------------------------------------------------
   if (msg.method === 'resources/list') {
-    return mcpOk({ resources: buildResourceDescriptors(profile.username) });
+    return mcpOk(
+      { resources: buildResourceDescriptors(profile.username) },
+      requestId
+    );
   }
 
   // -------------------------------------------------------------------------
@@ -136,20 +158,23 @@ export async function POST(
     const uri = msg.params.uri;
     const content = await readResource(uri, profile);
     if (!content) {
-      return mcpError(-32602, `Unknown resource: ${uri}`);
+      return mcpError(-32602, `Unknown resource: ${uri}`, 200, requestId);
     }
-    return mcpOk({
-      contents: [
-        { uri, mimeType: 'application/json', text: JSON.stringify(content) },
-      ],
-    });
+    return mcpOk(
+      {
+        contents: [
+          { uri, mimeType: 'application/json', text: JSON.stringify(content) },
+        ],
+      },
+      requestId
+    );
   }
 
   // -------------------------------------------------------------------------
   // tools/list
   // -------------------------------------------------------------------------
   if (msg.method === 'tools/list') {
-    return mcpOk({ tools: buildToolDescriptors() });
+    return mcpOk({ tools: buildToolDescriptors() }, requestId);
   }
 
   // -------------------------------------------------------------------------
@@ -162,27 +187,41 @@ export async function POST(
       profile
     );
     if (result.error) {
-      return mcpError(-32602, result.error);
+      return mcpError(-32602, result.error, 200, requestId);
     }
-    return mcpOk({
-      content: [{ type: 'text', text: JSON.stringify(result.data) }],
-    });
+    return mcpOk(
+      { content: [{ type: 'text', text: JSON.stringify(result.data) }] },
+      requestId
+    );
   }
 
-  return mcpError(-32601, 'Method not found');
+  return mcpError(-32601, 'Method not found', 200, requestId);
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function mcpOk(result: unknown) {
-  return NextResponse.json({ jsonrpc: '2.0', id: 1, result });
+type JsonRpcId = string | number | null;
+
+function mcpOk(result: unknown, requestId: JsonRpcId | undefined) {
+  return NextResponse.json(
+    requestId !== undefined
+      ? { jsonrpc: '2.0', id: requestId, result }
+      : { jsonrpc: '2.0', result }
+  );
 }
 
-function mcpError(code: number, message: string, status = 200) {
+function mcpError(
+  code: number,
+  message: string,
+  status = 200,
+  requestId: JsonRpcId | undefined = null
+) {
   return NextResponse.json(
-    { jsonrpc: '2.0', id: 1, error: { code, message } },
+    requestId !== undefined
+      ? { jsonrpc: '2.0', id: requestId, error: { code, message } }
+      : { jsonrpc: '2.0', error: { code, message } },
     { status }
   );
 }

--- a/apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts
+++ b/apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';


### PR DESCRIPTION
## Goal
Fix JSON-RPC 2.0 §5 compliance in the MCP route: response `id` must echo the request `id` exactly. Previously `mcpOk` and `mcpError` hardcoded `id: 1`, breaking any client that sends a different id or multiple concurrent requests.

Closes #11131.

## Changes
- `mcpOk(result, requestId)` — accepts `JsonRpcId | undefined`; echoes the request id or omits it for notifications
- `mcpError(code, message, status, requestId)` — same; defaults to `null` for pre-body-parse errors (parse error, artist not found) per JSON-RPC spec
- POST handler: extracts `id` via Zod union parse before method dispatch, passes `requestId` to every call-site
- New test file `route.test.ts` — 8 tests covering numeric id, string id, null id, absent id (notification), error responses, regression guard (`id ≠ 1`), parse-error null id, and 404 null id
- Fixes pre-existing Biome import format violation in `arbitrary-values-ratchet.test.ts` (blocked push)

## Testing
```bash
cd apps/web && pnpm exec vitest run "app/api/mcp"
# → 8 passed
```

## Risk
Low. Pure additive: new parameter with backward-compatible default for `mcpError`, no schema or DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)