### PR TITLE
feat(a11y): contrast inventory sweep + baseline schema guard (JOV-#11028)

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -7,6 +7,7 @@
 test-results/
 playwright-report/
 .auth/
+tests/e2e/contrast-screenshots/
 
 # Lighthouse CI output
 .lighthouseci/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -115,6 +115,7 @@
     "e2e:chaos:extended": "CHAOS_EXTENDED=1 playwright test --config=playwright.config.nightly.ts -g 'extended'",
     "a11y:ci": "playwright test -g @a11y",
     "a11y:axe": "playwright test tests/e2e/axe-audit.spec.ts",
+    "contrast:inventory": "playwright test tests/e2e/contrast-inventory.spec.ts --workers=1 --reporter=list",
     "a11y:check:staged": "biome lint .",
     "a11y:fix": "biome check --write .",
     "a11y:fix:unsafe": "biome check --write --unsafe .",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jovie/web",
-  "version": "26.6.53",
+  "version": "26.6.54",
   "private": true,
   "sideEffects": false,
   "engines": {
@@ -110,12 +110,12 @@
     "visual-qa:breakpoint-summary": "tsx scripts/visual-qa-breakpoint-check.ts",
     "visual-qa:theme-check": "tsx scripts/visual-qa-theme-check.ts",
     "visual-qa": "pnpm run visual-qa:capture",
+    "design-taste-jury": "tsx scripts/design-taste-jury.ts",
     "e2e:full:noauth": "playwright test --config=playwright.config.noauth.ts",
     "e2e:chaos": "playwright test --config=playwright.config.nightly.ts tests/e2e/nightly/chaos-click-testing.spec.ts",
     "e2e:chaos:extended": "CHAOS_EXTENDED=1 playwright test --config=playwright.config.nightly.ts -g 'extended'",
     "a11y:ci": "playwright test -g @a11y",
     "a11y:axe": "playwright test tests/e2e/axe-audit.spec.ts",
-    "contrast:inventory": "playwright test tests/e2e/contrast-inventory.spec.ts --workers=1 --reporter=list",
     "a11y:check:staged": "biome lint .",
     "a11y:fix": "biome check --write .",
     "a11y:fix:unsafe": "biome check --write --unsafe .",

--- a/apps/web/tests/e2e/contrast-inventory.spec.ts
+++ b/apps/web/tests/e2e/contrast-inventory.spec.ts
@@ -9,76 +9,38 @@
  * collected and written to contrast-baseline.json for downstream use.
  *
  * Run:
- *   pnpm run contrast:inventory
+ *   E2E_USE_TEST_AUTH_BYPASS=1 pnpm run contrast:inventory
  *
- * Authenticated routes require:
- *   E2E_USE_TEST_AUTH_BYPASS=1  (local)
- *   or Clerk credentials
- *
- * Output: apps/web/tests/e2e/contrast-baseline.json
+ * Output:
+ *   apps/web/tests/e2e/contrast-baseline.json
+ *   apps/web/tests/e2e/contrast-baseline.md
+ *   apps/web/tests/e2e/contrast-screenshots/*.png
  *
  * @see JovieInc/Jovie#11028 (this task)
  * @see JovieInc/Jovie#11025 (gate that consumes the baseline)
  */
 
-import { writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import AxeBuilder from '@axe-core/playwright';
 import type { Page } from '@playwright/test';
-import { test } from '@playwright/test';
+import { APP_ROUTES } from '@/constants/routes';
+import { test } from './setup';
+import {
+  buildComponentIndex,
+  buildFixClusters,
+  buildSelectorIndex,
+  type ContrastInventory,
+  type ContrastViolationRecord,
+  ensureScreenshotDirectory,
+  extractContrastData,
+  getScreenshotAbsolutePath,
+  getScreenshotRelativePath,
+  writeContrastInventoryArtifacts,
+} from './utils/contrast-inventory';
+import { installPublicRouteMocks } from './utils/public-surface-helpers';
 import { resolvePublicSurfaceManifestSync } from './utils/public-surface-manifest';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const BASELINE_PATH = join(__dirname, 'contrast-baseline.json');
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface ContrastNode {
-  /** CSS selector identifying the violating element */
-  readonly selector: string;
-  /** axe failure summary */
-  readonly failureSummary: string;
-  /** fg/bg color data from axe */
-  readonly data: {
-    readonly fgColor?: string;
-    readonly bgColor?: string;
-    readonly contrastRatio?: number;
-    readonly expectedContrastRatio?: number;
-  } | null;
-}
-
-export interface ContrastViolationRecord {
-  readonly route: string;
-  readonly theme: 'light' | 'dark';
-  /** axe rule id — always 'color-contrast' in this sweep */
-  readonly ruleId: string;
-  readonly impact: string | null;
-  readonly nodes: readonly ContrastNode[];
-}
-
-export interface ContrastInventory {
-  readonly schemaVersion: 1;
-  /** ISO timestamp of when this inventory was generated */
-  readonly generatedAt: string;
-  readonly issueRef: '#11028';
-  readonly totalViolations: number;
-  readonly violations: readonly ContrastViolationRecord[];
-  /** Violations grouped by CSS selector for component-level deduplication */
-  readonly bySelector: Record<
-    string,
-    {
-      readonly count: number;
-      readonly routes: readonly string[];
-      readonly worstRatio: number | null;
-      readonly themes: readonly ('light' | 'dark')[];
-    }
-  >;
-}
+const OUTPUT_DIR = join(process.cwd(), 'tests/e2e');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -94,69 +56,90 @@ async function setTheme(page: Page, theme: 'light' | 'dark'): Promise<void> {
       document.documentElement.setAttribute('data-theme', 'light');
     }
   }, theme);
-  // Give CSS transitions a moment to settle
   await page.waitForTimeout(200);
 }
 
-function extractContrastData(node: {
-  any: Array<{ data?: unknown }>;
-  all: Array<{ data?: unknown }>;
-}): ContrastNode['data'] {
-  const sources = [...node.any, ...node.all];
-  for (const check of sources) {
-    const d = check.data as
-      | {
-          fgColor?: string;
-          bgColor?: string;
-          contrastRatio?: number;
-          expectedContrastRatio?: number;
-        }
-      | null
-      | undefined;
-    if (d?.fgColor) return d;
+async function collectContrastViolations(
+  page: Page,
+  route: string,
+  theme: 'light' | 'dark'
+): Promise<ContrastViolationRecord | null> {
+  const results = await new AxeBuilder({ page })
+    .withRules(['color-contrast'])
+    .disableRules(['frame-tested'])
+    .analyze();
+
+  if (results.violations.length === 0) {
+    return null;
   }
-  return null;
+
+  const screenshotPath = getScreenshotAbsolutePath(OUTPUT_DIR, route, theme);
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  const screenshot = getScreenshotRelativePath(route, theme);
+
+  return {
+    route,
+    theme,
+    ruleId: 'color-contrast',
+    impact: results.violations[0]?.impact ?? null,
+    screenshot,
+    nodes: results.violations.flatMap(violation =>
+      violation.nodes.map(node => ({
+        selector: node.target.join(', '),
+        failureSummary: node.failureSummary ?? '',
+        data: extractContrastData(node),
+      }))
+    ),
+  };
 }
 
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
-// Public routes (unauthenticated) — filter to expectedState: 'ok' only
 const publicSurfaces = resolvePublicSurfaceManifestSync().filter(
-  s => s.expectedState === 'ok'
+  surface => surface.expectedState === 'ok'
 );
 
-// Key authenticated routes for onboarding / dashboard / paywall / settings
-// These are the highest-priority surfaces per #11028 acceptance criteria
 const AUTH_ROUTES: ReadonlyArray<{
   readonly id: string;
   readonly path: string;
   readonly label: string;
 }> = [
-  { id: 'app-dashboard', path: '/app/dashboard', label: 'App Dashboard' },
-  { id: 'app-chat', path: '/app/chat', label: 'Chat' },
-  { id: 'app-releases', path: '/app/releases', label: 'Releases' },
+  {
+    id: 'app-dashboard',
+    path: APP_ROUTES.LEGACY_DASHBOARD,
+    label: 'App Dashboard',
+  },
+  { id: 'app-chat', path: APP_ROUTES.CHAT, label: 'Chat' },
+  { id: 'app-releases', path: APP_ROUTES.RELEASES, label: 'Releases' },
   {
     id: 'settings-artist-profile',
-    path: '/app/settings/artist-profile',
+    path: APP_ROUTES.SETTINGS_ARTIST_PROFILE,
     label: 'Settings — Artist Profile',
   },
   {
     id: 'settings-billing',
-    path: '/app/settings/billing',
+    path: APP_ROUTES.SETTINGS_BILLING,
     label: 'Settings — Billing',
   },
   {
     id: 'settings-account',
-    path: '/app/settings/account',
+    path: APP_ROUTES.SETTINGS_ACCOUNT,
     label: 'Settings — Account',
   },
-  { id: 'onboarding-start', path: '/onboarding', label: 'Onboarding' },
-  { id: 'paywall', path: '/app/upgrade', label: 'Paywall / Upgrade' },
+  {
+    id: 'onboarding-start',
+    path: APP_ROUTES.ONBOARDING,
+    label: 'Onboarding',
+  },
+  {
+    id: 'paywall',
+    path: APP_ROUTES.BILLING,
+    label: 'Paywall / Upgrade',
+  },
 ] as const;
 
-// Shared violation accumulator (module-level, safe for serial test execution)
 const allViolations: ContrastViolationRecord[] = [];
 
 // ---------------------------------------------------------------------------
@@ -164,14 +147,12 @@ const allViolations: ContrastViolationRecord[] = [];
 // ---------------------------------------------------------------------------
 
 test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
-  // Serial execution to keep accumulator consistent and reduce server load
   test.describe.configure({ mode: 'serial' });
+  test.setTimeout(300_000);
 
-  test.setTimeout(300_000); // 5 min for the full sweep
-
-  // -------------------------------------------------------------------------
-  // Public routes — unauthenticated
-  // -------------------------------------------------------------------------
+  test.beforeAll(() => {
+    ensureScreenshotDirectory(OUTPUT_DIR);
+  });
 
   test.describe('Public routes (unauthenticated)', () => {
     test.use({ storageState: { cookies: [], origins: [] } });
@@ -181,15 +162,7 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
         const testId = `${surface.id}/${theme}`;
 
         test(`contrast:inventory — ${testId}`, async ({ page }) => {
-          await page.route('**/api/profile/view', r =>
-            r.fulfill({ status: 200, body: '{}' })
-          );
-          await page.route('**/api/audience/visit', r =>
-            r.fulfill({ status: 200, body: '{}' })
-          );
-          await page.route('**/api/track', r =>
-            r.fulfill({ status: 200, body: '{}' })
-          );
+          await installPublicRouteMocks(page);
 
           try {
             await page.goto(surface.resolvedPath, {
@@ -198,43 +171,25 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
             });
             await setTheme(page, theme);
 
-            const results = await new AxeBuilder({ page })
-              .withRules(['color-contrast'])
-              .analyze();
-
-            for (const violation of results.violations) {
-              allViolations.push({
-                route: surface.resolvedPath,
-                theme,
-                ruleId: violation.id,
-                impact: violation.impact ?? null,
-                nodes: violation.nodes.map(n => ({
-                  selector: n.target.join(', '),
-                  failureSummary: n.failureSummary ?? '',
-                  data: extractContrastData(n),
-                })),
-              });
+            const record = await collectContrastViolations(
+              page,
+              surface.resolvedPath,
+              theme
+            );
+            if (record) {
+              allViolations.push(record);
             }
           } catch (err) {
-            // Log but never fail — inventory mode
             console.warn(`[contrast-inventory] ${testId} error:`, err);
           }
-
-          // Always pass
         });
       }
     }
   });
 
-  // -------------------------------------------------------------------------
-  // Authenticated routes — dev auth bypass (creator-ready persona)
-  // -------------------------------------------------------------------------
-
   test.describe('Authenticated routes', () => {
     const hasBypass = process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
 
-    // Skip the entire block when auth isn't available — inventory still
-    // captures the public surfaces above
     test.skip(
       !hasBypass,
       'Auth routes skipped: set E2E_USE_TEST_AUTH_BYPASS=1'
@@ -244,10 +199,8 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
       if (!hasBypass) return;
 
       const baseUrl = process.env.BASE_URL ?? 'http://localhost:3100';
-      // Use the canonical dev auth bypass: creator-ready gives Pro entitlements
-      // so onboarding is bypassed and paywall renders correctly
       await page.goto(
-        `${baseUrl}/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/dashboard`,
+        `${baseUrl}/api/dev/test-auth/enter?persona=creator-ready&redirect=${APP_ROUTES.CHAT}`,
         { waitUntil: 'domcontentloaded', timeout: 30_000 }
       );
     });
@@ -265,26 +218,15 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
               timeout: 60_000,
             });
             await setTheme(page, theme);
-            // Wait for authenticated shell to settle
             await page.waitForTimeout(1_000);
 
-            const results = await new AxeBuilder({ page })
-              .withRules(['color-contrast'])
-              .disableRules(['frame-tested'])
-              .analyze();
-
-            for (const violation of results.violations) {
-              allViolations.push({
-                route: route.path,
-                theme,
-                ruleId: violation.id,
-                impact: violation.impact ?? null,
-                nodes: violation.nodes.map(n => ({
-                  selector: n.target.join(', '),
-                  failureSummary: n.failureSummary ?? '',
-                  data: extractContrastData(n),
-                })),
-              });
+            const record = await collectContrastViolations(
+              page,
+              route.path,
+              theme
+            );
+            if (record) {
+              allViolations.push(record);
             }
           } catch (err) {
             console.warn(`[contrast-inventory] ${testId} error:`, err);
@@ -294,51 +236,13 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
     }
   });
 
-  // -------------------------------------------------------------------------
-  // Aggregation — write inventory after all routes are crawled
-  // -------------------------------------------------------------------------
+  test('write contrast inventory artifacts', async () => {
+    const bySelector = buildSelectorIndex(allViolations);
+    const byComponent = buildComponentIndex(allViolations);
+    const fixClusters = buildFixClusters(byComponent);
 
-  test('write contrast-baseline.json', async () => {
-    // Build bySelector index
-    const bySelector: ContrastInventory['bySelector'] = {};
-
-    for (const v of allViolations) {
-      for (const node of v.nodes) {
-        const sel = node.selector;
-        const existing = bySelector[sel];
-        const ratio = node.data?.contrastRatio ?? null;
-
-        if (!existing) {
-          bySelector[sel] = {
-            count: 1,
-            routes: [v.route],
-            worstRatio: ratio,
-            themes: [v.theme],
-          };
-        } else {
-          const updatedRoutes = existing.routes.includes(v.route)
-            ? existing.routes
-            : ([...existing.routes, v.route] as const);
-          const updatedThemes = existing.themes.includes(v.theme)
-            ? existing.themes
-            : ([...existing.themes, v.theme] as const);
-          const worstRatio =
-            ratio !== null && existing.worstRatio !== null
-              ? Math.min(existing.worstRatio, ratio)
-              : (existing.worstRatio ?? ratio);
-
-          bySelector[sel] = {
-            count: existing.count + 1,
-            routes: updatedRoutes,
-            worstRatio,
-            themes: updatedThemes,
-          };
-        }
-      }
-    }
-
-    const totalViolationNodes = Object.values(bySelector).reduce(
-      (sum, s) => sum + s.count,
+    const totalViolationNodes = allViolations.reduce(
+      (sum, violation) => sum + violation.nodes.length,
       0
     );
 
@@ -349,34 +253,35 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
       totalViolations: totalViolationNodes,
       violations: allViolations,
       bySelector,
+      byComponent,
+      fixClusters,
     };
 
-    writeFileSync(BASELINE_PATH, JSON.stringify(inventory, null, 2));
+    const { jsonPath, markdownPath } = writeContrastInventoryArtifacts(
+      inventory,
+      OUTPUT_DIR
+    );
 
-    // Summary to console
-    const topOffenders = Object.entries(bySelector)
-      .sort((a, b) => b[1].count - a[1].count)
-      .slice(0, 20);
-
+    const topClusters = fixClusters.slice(0, 20);
     console.log(
-      `\n[contrast-inventory] ✓ Wrote ${BASELINE_PATH}\n` +
+      `\n[contrast-inventory] ✓ Wrote ${jsonPath}\n` +
+        `[contrast-inventory] ✓ Wrote ${markdownPath}\n` +
         `  Total violation nodes: ${totalViolationNodes}\n` +
         `  Unique selectors: ${Object.keys(bySelector).length}\n` +
+        `  Shared component keys: ${Object.keys(byComponent).length}\n` +
         `  Routes scanned: ${
           [...new Set(allViolations.map(v => v.route))].length
         }\n\n` +
-        `  Top 20 worst offenders (by occurrence count):\n` +
-        topOffenders
+        `  Top 20 fix clusters:\n` +
+        topClusters
           .map(
-            ([sel, data]) =>
-              `    [×${data.count}] ${data.themes.join('+')} ` +
-              `ratio:${data.worstRatio ?? 'n/a'} — ${sel.slice(0, 80)}`
+            cluster =>
+              `    [${cluster.priority} ×${cluster.count}] ` +
+              `ratio:${cluster.worstRatio ?? 'n/a'} — ${cluster.componentKey}`
           )
           .join('\n')
     );
 
-    // Non-blocking: the test passes regardless of violation count
-    // The JSON file is the deliverable, not a pass/fail assertion
     console.log(
       '[contrast-inventory] Inventory complete — gate-baseline seeded'
     );

--- a/apps/web/tests/e2e/contrast-inventory.spec.ts
+++ b/apps/web/tests/e2e/contrast-inventory.spec.ts
@@ -1,0 +1,384 @@
+/**
+ * Contrast Inventory Sweep — JOV-#11028
+ *
+ * One-time (but re-runnable) crawl of all public routes × light/dark themes
+ * with axe color-contrast rule only. Emits a structured JSON inventory used
+ * to seed the JOV-#11025 gate baseline.
+ *
+ * This spec NEVER fails — it is an inventory, not a gate. Violations are
+ * collected and written to contrast-baseline.json for downstream use.
+ *
+ * Run:
+ *   pnpm run contrast:inventory
+ *
+ * Authenticated routes require:
+ *   E2E_USE_TEST_AUTH_BYPASS=1  (local)
+ *   or Clerk credentials
+ *
+ * Output: apps/web/tests/e2e/contrast-baseline.json
+ *
+ * @see JovieInc/Jovie#11028 (this task)
+ * @see JovieInc/Jovie#11025 (gate that consumes the baseline)
+ */
+
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import AxeBuilder from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+import { test } from '@playwright/test';
+import { resolvePublicSurfaceManifestSync } from './utils/public-surface-manifest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const BASELINE_PATH = join(__dirname, 'contrast-baseline.json');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ContrastNode {
+  /** CSS selector identifying the violating element */
+  readonly selector: string;
+  /** axe failure summary */
+  readonly failureSummary: string;
+  /** fg/bg color data from axe */
+  readonly data: {
+    readonly fgColor?: string;
+    readonly bgColor?: string;
+    readonly contrastRatio?: number;
+    readonly expectedContrastRatio?: number;
+  } | null;
+}
+
+export interface ContrastViolationRecord {
+  readonly route: string;
+  readonly theme: 'light' | 'dark';
+  /** axe rule id — always 'color-contrast' in this sweep */
+  readonly ruleId: string;
+  readonly impact: string | null;
+  readonly nodes: readonly ContrastNode[];
+}
+
+export interface ContrastInventory {
+  readonly schemaVersion: 1;
+  /** ISO timestamp of when this inventory was generated */
+  readonly generatedAt: string;
+  readonly issueRef: '#11028';
+  readonly totalViolations: number;
+  readonly violations: readonly ContrastViolationRecord[];
+  /** Violations grouped by CSS selector for component-level deduplication */
+  readonly bySelector: Record<
+    string,
+    {
+      readonly count: number;
+      readonly routes: readonly string[];
+      readonly worstRatio: number | null;
+      readonly themes: readonly ('light' | 'dark')[];
+    }
+  >;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function setTheme(page: Page, theme: 'light' | 'dark'): Promise<void> {
+  await page.evaluate(t => {
+    if (t === 'dark') {
+      document.documentElement.classList.add('dark');
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  }, theme);
+  // Give CSS transitions a moment to settle
+  await page.waitForTimeout(200);
+}
+
+function extractContrastData(node: {
+  any: Array<{ data?: unknown }>;
+  all: Array<{ data?: unknown }>;
+}): ContrastNode['data'] {
+  const sources = [...node.any, ...node.all];
+  for (const check of sources) {
+    const d = check.data as
+      | {
+          fgColor?: string;
+          bgColor?: string;
+          contrastRatio?: number;
+          expectedContrastRatio?: number;
+        }
+      | null
+      | undefined;
+    if (d?.fgColor) return d;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+// Public routes (unauthenticated) — filter to expectedState: 'ok' only
+const publicSurfaces = resolvePublicSurfaceManifestSync().filter(
+  s => s.expectedState === 'ok'
+);
+
+// Key authenticated routes for onboarding / dashboard / paywall / settings
+// These are the highest-priority surfaces per #11028 acceptance criteria
+const AUTH_ROUTES: ReadonlyArray<{
+  readonly id: string;
+  readonly path: string;
+  readonly label: string;
+}> = [
+  { id: 'app-dashboard', path: '/app/dashboard', label: 'App Dashboard' },
+  { id: 'app-chat', path: '/app/chat', label: 'Chat' },
+  { id: 'app-releases', path: '/app/releases', label: 'Releases' },
+  {
+    id: 'settings-artist-profile',
+    path: '/app/settings/artist-profile',
+    label: 'Settings — Artist Profile',
+  },
+  {
+    id: 'settings-billing',
+    path: '/app/settings/billing',
+    label: 'Settings — Billing',
+  },
+  {
+    id: 'settings-account',
+    path: '/app/settings/account',
+    label: 'Settings — Account',
+  },
+  { id: 'onboarding-start', path: '/onboarding', label: 'Onboarding' },
+  { id: 'paywall', path: '/app/upgrade', label: 'Paywall / Upgrade' },
+] as const;
+
+// Shared violation accumulator (module-level, safe for serial test execution)
+const allViolations: ContrastViolationRecord[] = [];
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
+  // Serial execution to keep accumulator consistent and reduce server load
+  test.describe.configure({ mode: 'serial' });
+
+  test.setTimeout(300_000); // 5 min for the full sweep
+
+  // -------------------------------------------------------------------------
+  // Public routes — unauthenticated
+  // -------------------------------------------------------------------------
+
+  test.describe('Public routes (unauthenticated)', () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    for (const surface of publicSurfaces) {
+      for (const theme of ['light', 'dark'] as const) {
+        const testId = `${surface.id}/${theme}`;
+
+        test(`contrast:inventory — ${testId}`, async ({ page }) => {
+          await page.route('**/api/profile/view', r =>
+            r.fulfill({ status: 200, body: '{}' })
+          );
+          await page.route('**/api/audience/visit', r =>
+            r.fulfill({ status: 200, body: '{}' })
+          );
+          await page.route('**/api/track', r =>
+            r.fulfill({ status: 200, body: '{}' })
+          );
+
+          try {
+            await page.goto(surface.resolvedPath, {
+              waitUntil: 'domcontentloaded',
+              timeout: 60_000,
+            });
+            await setTheme(page, theme);
+
+            const results = await new AxeBuilder({ page })
+              .withRules(['color-contrast'])
+              .analyze();
+
+            for (const violation of results.violations) {
+              allViolations.push({
+                route: surface.resolvedPath,
+                theme,
+                ruleId: violation.id,
+                impact: violation.impact ?? null,
+                nodes: violation.nodes.map(n => ({
+                  selector: n.target.join(', '),
+                  failureSummary: n.failureSummary ?? '',
+                  data: extractContrastData(n),
+                })),
+              });
+            }
+          } catch (err) {
+            // Log but never fail — inventory mode
+            console.warn(`[contrast-inventory] ${testId} error:`, err);
+          }
+
+          // Always pass
+        });
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Authenticated routes — dev auth bypass (creator-ready persona)
+  // -------------------------------------------------------------------------
+
+  test.describe('Authenticated routes', () => {
+    const hasBypass = process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
+
+    // Skip the entire block when auth isn't available — inventory still
+    // captures the public surfaces above
+    test.skip(
+      !hasBypass,
+      'Auth routes skipped: set E2E_USE_TEST_AUTH_BYPASS=1'
+    );
+
+    test.beforeEach(async ({ page }) => {
+      if (!hasBypass) return;
+
+      const baseUrl = process.env.BASE_URL ?? 'http://localhost:3100';
+      // Use the canonical dev auth bypass: creator-ready gives Pro entitlements
+      // so onboarding is bypassed and paywall renders correctly
+      await page.goto(
+        `${baseUrl}/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/dashboard`,
+        { waitUntil: 'domcontentloaded', timeout: 30_000 }
+      );
+    });
+
+    for (const route of AUTH_ROUTES) {
+      for (const theme of ['light', 'dark'] as const) {
+        const testId = `${route.id}/${theme}`;
+
+        test(`contrast:inventory — ${testId}`, async ({ page }) => {
+          const baseUrl = process.env.BASE_URL ?? 'http://localhost:3100';
+
+          try {
+            await page.goto(`${baseUrl}${route.path}`, {
+              waitUntil: 'domcontentloaded',
+              timeout: 60_000,
+            });
+            await setTheme(page, theme);
+            // Wait for authenticated shell to settle
+            await page.waitForTimeout(1_000);
+
+            const results = await new AxeBuilder({ page })
+              .withRules(['color-contrast'])
+              .disableRules(['frame-tested'])
+              .analyze();
+
+            for (const violation of results.violations) {
+              allViolations.push({
+                route: route.path,
+                theme,
+                ruleId: violation.id,
+                impact: violation.impact ?? null,
+                nodes: violation.nodes.map(n => ({
+                  selector: n.target.join(', '),
+                  failureSummary: n.failureSummary ?? '',
+                  data: extractContrastData(n),
+                })),
+              });
+            }
+          } catch (err) {
+            console.warn(`[contrast-inventory] ${testId} error:`, err);
+          }
+        });
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Aggregation — write inventory after all routes are crawled
+  // -------------------------------------------------------------------------
+
+  test('write contrast-baseline.json', async () => {
+    // Build bySelector index
+    const bySelector: ContrastInventory['bySelector'] = {};
+
+    for (const v of allViolations) {
+      for (const node of v.nodes) {
+        const sel = node.selector;
+        const existing = bySelector[sel];
+        const ratio = node.data?.contrastRatio ?? null;
+
+        if (!existing) {
+          bySelector[sel] = {
+            count: 1,
+            routes: [v.route],
+            worstRatio: ratio,
+            themes: [v.theme],
+          };
+        } else {
+          const updatedRoutes = existing.routes.includes(v.route)
+            ? existing.routes
+            : ([...existing.routes, v.route] as const);
+          const updatedThemes = existing.themes.includes(v.theme)
+            ? existing.themes
+            : ([...existing.themes, v.theme] as const);
+          const worstRatio =
+            ratio !== null && existing.worstRatio !== null
+              ? Math.min(existing.worstRatio, ratio)
+              : (existing.worstRatio ?? ratio);
+
+          bySelector[sel] = {
+            count: existing.count + 1,
+            routes: updatedRoutes,
+            worstRatio,
+            themes: updatedThemes,
+          };
+        }
+      }
+    }
+
+    const totalViolationNodes = Object.values(bySelector).reduce(
+      (sum, s) => sum + s.count,
+      0
+    );
+
+    const inventory: ContrastInventory = {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      issueRef: '#11028',
+      totalViolations: totalViolationNodes,
+      violations: allViolations,
+      bySelector,
+    };
+
+    writeFileSync(BASELINE_PATH, JSON.stringify(inventory, null, 2));
+
+    // Summary to console
+    const topOffenders = Object.entries(bySelector)
+      .sort((a, b) => b[1].count - a[1].count)
+      .slice(0, 20);
+
+    console.log(
+      `\n[contrast-inventory] ✓ Wrote ${BASELINE_PATH}\n` +
+        `  Total violation nodes: ${totalViolationNodes}\n` +
+        `  Unique selectors: ${Object.keys(bySelector).length}\n` +
+        `  Routes scanned: ${
+          [...new Set(allViolations.map(v => v.route))].length
+        }\n\n` +
+        `  Top 20 worst offenders (by occurrence count):\n` +
+        topOffenders
+          .map(
+            ([sel, data]) =>
+              `    [×${data.count}] ${data.themes.join('+')} ` +
+              `ratio:${data.worstRatio ?? 'n/a'} — ${sel.slice(0, 80)}`
+          )
+          .join('\n')
+    );
+
+    // Non-blocking: the test passes regardless of violation count
+    // The JSON file is the deliverable, not a pass/fail assertion
+    console.log(
+      '[contrast-inventory] Inventory complete — gate-baseline seeded'
+    );
+  });
+});

--- a/apps/web/tests/e2e/contrast-inventory.spec.ts
+++ b/apps/web/tests/e2e/contrast-inventory.spec.ts
@@ -1,23 +1,6 @@
 /**
- * Contrast Inventory Sweep — JOV-#11028
- *
- * One-time (but re-runnable) crawl of all public routes × light/dark themes
- * with axe color-contrast rule only. Emits a structured JSON inventory used
- * to seed the JOV-#11025 gate baseline.
- *
- * This spec NEVER fails — it is an inventory, not a gate. Violations are
- * collected and written to contrast-baseline.json for downstream use.
- *
- * Run:
- *   E2E_USE_TEST_AUTH_BYPASS=1 pnpm run contrast:inventory
- *
- * Output:
- *   apps/web/tests/e2e/contrast-baseline.json
- *   apps/web/tests/e2e/contrast-baseline.md
- *   apps/web/tests/e2e/contrast-screenshots/*.png
- *
- * @see JovieInc/Jovie#11028 (this task)
- * @see JovieInc/Jovie#11025 (gate that consumes the baseline)
+ * Contrast inventory sweep (JOV-#11028). Never fails — writes contrast-baseline.json.
+ * Run: E2E_USE_TEST_AUTH_BYPASS=1 pnpm --filter web exec playwright test tests/e2e/contrast-inventory.spec.ts --workers=1
  */
 
 import { join } from 'node:path';
@@ -42,10 +25,6 @@ import { resolvePublicSurfaceManifestSync } from './utils/public-surface-manifes
 
 const OUTPUT_DIR = join(process.cwd(), 'tests/e2e');
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 async function setTheme(page: Page, theme: 'light' | 'dark'): Promise<void> {
   await page.evaluate(t => {
     if (t === 'dark') {
@@ -69,20 +48,17 @@ async function collectContrastViolations(
     .disableRules(['frame-tested'])
     .analyze();
 
-  if (results.violations.length === 0) {
-    return null;
-  }
+  if (results.violations.length === 0) return null;
 
   const screenshotPath = getScreenshotAbsolutePath(OUTPUT_DIR, route, theme);
   await page.screenshot({ path: screenshotPath, fullPage: true });
-  const screenshot = getScreenshotRelativePath(route, theme);
 
   return {
     route,
     theme,
     ruleId: 'color-contrast',
     impact: results.violations[0]?.impact ?? null,
-    screenshot,
+    screenshot: getScreenshotRelativePath(route, theme),
     nodes: results.violations.flatMap(violation =>
       violation.nodes.map(node => ({
         selector: node.target.join(', '),
@@ -93,58 +69,22 @@ async function collectContrastViolations(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Route definitions
-// ---------------------------------------------------------------------------
-
 const publicSurfaces = resolvePublicSurfaceManifestSync().filter(
   surface => surface.expectedState === 'ok'
 );
 
-const AUTH_ROUTES: ReadonlyArray<{
-  readonly id: string;
-  readonly path: string;
-  readonly label: string;
-}> = [
-  {
-    id: 'app-dashboard',
-    path: APP_ROUTES.LEGACY_DASHBOARD,
-    label: 'App Dashboard',
-  },
-  { id: 'app-chat', path: APP_ROUTES.CHAT, label: 'Chat' },
-  { id: 'app-releases', path: APP_ROUTES.RELEASES, label: 'Releases' },
-  {
-    id: 'settings-artist-profile',
-    path: APP_ROUTES.SETTINGS_ARTIST_PROFILE,
-    label: 'Settings — Artist Profile',
-  },
-  {
-    id: 'settings-billing',
-    path: APP_ROUTES.SETTINGS_BILLING,
-    label: 'Settings — Billing',
-  },
-  {
-    id: 'settings-account',
-    path: APP_ROUTES.SETTINGS_ACCOUNT,
-    label: 'Settings — Account',
-  },
-  {
-    id: 'onboarding-start',
-    path: APP_ROUTES.ONBOARDING,
-    label: 'Onboarding',
-  },
-  {
-    id: 'paywall',
-    path: APP_ROUTES.BILLING,
-    label: 'Paywall / Upgrade',
-  },
+const AUTH_ROUTES = [
+  [APP_ROUTES.LEGACY_DASHBOARD, 'app-dashboard'],
+  [APP_ROUTES.CHAT, 'app-chat'],
+  [APP_ROUTES.RELEASES, 'app-releases'],
+  [APP_ROUTES.SETTINGS_ARTIST_PROFILE, 'settings-artist-profile'],
+  [APP_ROUTES.SETTINGS_BILLING, 'settings-billing'],
+  [APP_ROUTES.SETTINGS_ACCOUNT, 'settings-account'],
+  [APP_ROUTES.ONBOARDING, 'onboarding-start'],
+  [APP_ROUTES.BILLING, 'paywall'],
 ] as const;
 
 const allViolations: ContrastViolationRecord[] = [];
-
-// ---------------------------------------------------------------------------
-// Suite
-// ---------------------------------------------------------------------------
 
 test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
   test.describe.configure({ mode: 'serial' });
@@ -159,28 +99,24 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
 
     for (const surface of publicSurfaces) {
       for (const theme of ['light', 'dark'] as const) {
-        const testId = `${surface.id}/${theme}`;
-
-        test(`contrast:inventory — ${testId}`, async ({ page }) => {
+        test(`contrast:inventory — ${surface.id}/${theme}`, async ({
+          page,
+        }) => {
           await installPublicRouteMocks(page);
-
           try {
             await page.goto(surface.resolvedPath, {
               waitUntil: 'domcontentloaded',
               timeout: 60_000,
             });
             await setTheme(page, theme);
-
             const record = await collectContrastViolations(
               page,
               surface.resolvedPath,
               theme
             );
-            if (record) {
-              allViolations.push(record);
-            }
+            if (record) allViolations.push(record);
           } catch (err) {
-            console.warn(`[contrast-inventory] ${testId} error:`, err);
+            console.warn(`[contrast-inventory] ${surface.id}/${theme}:`, err);
           }
         });
       }
@@ -189,7 +125,6 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
 
   test.describe('Authenticated routes', () => {
     const hasBypass = process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
-
     test.skip(
       !hasBypass,
       'Auth routes skipped: set E2E_USE_TEST_AUTH_BYPASS=1'
@@ -197,7 +132,6 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
 
     test.beforeEach(async ({ page }) => {
       if (!hasBypass) return;
-
       const baseUrl = process.env.BASE_URL ?? 'http://localhost:3100';
       await page.goto(
         `${baseUrl}/api/dev/test-auth/enter?persona=creator-ready&redirect=${APP_ROUTES.CHAT}`,
@@ -205,31 +139,21 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
       );
     });
 
-    for (const route of AUTH_ROUTES) {
+    for (const [path, id] of AUTH_ROUTES) {
       for (const theme of ['light', 'dark'] as const) {
-        const testId = `${route.id}/${theme}`;
-
-        test(`contrast:inventory — ${testId}`, async ({ page }) => {
+        test(`contrast:inventory — ${id}/${theme}`, async ({ page }) => {
           const baseUrl = process.env.BASE_URL ?? 'http://localhost:3100';
-
           try {
-            await page.goto(`${baseUrl}${route.path}`, {
+            await page.goto(`${baseUrl}${path}`, {
               waitUntil: 'domcontentloaded',
               timeout: 60_000,
             });
             await setTheme(page, theme);
             await page.waitForTimeout(1_000);
-
-            const record = await collectContrastViolations(
-              page,
-              route.path,
-              theme
-            );
-            if (record) {
-              allViolations.push(record);
-            }
+            const record = await collectContrastViolations(page, path, theme);
+            if (record) allViolations.push(record);
           } catch (err) {
-            console.warn(`[contrast-inventory] ${testId} error:`, err);
+            console.warn(`[contrast-inventory] ${id}/${theme}:`, err);
           }
         });
       }
@@ -240,7 +164,6 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
     const bySelector = buildSelectorIndex(allViolations);
     const byComponent = buildComponentIndex(allViolations);
     const fixClusters = buildFixClusters(byComponent);
-
     const totalViolationNodes = allViolations.reduce(
       (sum, violation) => sum + violation.nodes.length,
       0
@@ -262,28 +185,9 @@ test.describe('Contrast Inventory Sweep — JOV-#11028', () => {
       OUTPUT_DIR
     );
 
-    const topClusters = fixClusters.slice(0, 20);
     console.log(
-      `\n[contrast-inventory] ✓ Wrote ${jsonPath}\n` +
-        `[contrast-inventory] ✓ Wrote ${markdownPath}\n` +
-        `  Total violation nodes: ${totalViolationNodes}\n` +
-        `  Unique selectors: ${Object.keys(bySelector).length}\n` +
-        `  Shared component keys: ${Object.keys(byComponent).length}\n` +
-        `  Routes scanned: ${
-          [...new Set(allViolations.map(v => v.route))].length
-        }\n\n` +
-        `  Top 20 fix clusters:\n` +
-        topClusters
-          .map(
-            cluster =>
-              `    [${cluster.priority} ×${cluster.count}] ` +
-              `ratio:${cluster.worstRatio ?? 'n/a'} — ${cluster.componentKey}`
-          )
-          .join('\n')
-    );
-
-    console.log(
-      '[contrast-inventory] Inventory complete — gate-baseline seeded'
+      `[contrast-inventory] wrote ${jsonPath} and ${markdownPath} ` +
+        `(${totalViolationNodes} nodes, ${Object.keys(bySelector).length} selectors)`
     );
   });
 });

--- a/apps/web/tests/e2e/utils/contrast-inventory.ts
+++ b/apps/web/tests/e2e/utils/contrast-inventory.ts
@@ -2,11 +2,8 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 export interface ContrastNode {
-  /** CSS selector identifying the violating element */
   readonly selector: string;
-  /** axe failure summary */
   readonly failureSummary: string;
-  /** fg/bg color data from axe */
   readonly data: {
     readonly fgColor?: string;
     readonly bgColor?: string;
@@ -18,11 +15,9 @@ export interface ContrastNode {
 export interface ContrastViolationRecord {
   readonly route: string;
   readonly theme: 'light' | 'dark';
-  /** axe rule id — always 'color-contrast' in this sweep */
   readonly ruleId: string;
   readonly impact: string | null;
   readonly nodes: readonly ContrastNode[];
-  /** Route-level screenshot when violations were found */
   readonly screenshot?: string;
 }
 
@@ -44,22 +39,17 @@ export interface ContrastFixCluster {
   readonly worstRatio: number | null;
   readonly priority: ContrastFixPriority;
   readonly sampleSelector: string;
-  /** Canonical fix issue title for Linear triage */
   readonly suggestedIssueTitle: string;
 }
 
 export interface ContrastInventory {
   readonly schemaVersion: 1;
-  /** ISO timestamp of when this inventory was generated */
   readonly generatedAt: string;
   readonly issueRef: '#11028';
   readonly totalViolations: number;
   readonly violations: readonly ContrastViolationRecord[];
-  /** Violations grouped by CSS selector for deduplication */
   readonly bySelector: Record<string, ContrastComponentIndexEntry>;
-  /** Violations grouped by inferred shared component/token for fix triage */
   readonly byComponent: Record<string, ContrastComponentIndexEntry>;
-  /** Worst offenders clustered for one-fix-closes-many triage */
   readonly fixClusters: readonly ContrastFixCluster[];
 }
 
@@ -74,21 +64,89 @@ const CRITICAL_ROUTE_PATTERNS = [
 
 const PROFILE_ROUTE_PATTERN = /^\/[^/]+$/;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isIndexEntry(value: unknown): value is ContrastComponentIndexEntry {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.count === 'number' &&
+    Array.isArray(value.routes) &&
+    Array.isArray(value.themes) &&
+    typeof value.sampleSelector === 'string'
+  );
+}
+
+export function isContrastInventory(data: unknown): data is ContrastInventory {
+  if (!isRecord(data)) return false;
+  if (
+    data.schemaVersion !== 1 ||
+    data.issueRef !== '#11028' ||
+    typeof data.generatedAt !== 'string' ||
+    typeof data.totalViolations !== 'number' ||
+    !Array.isArray(data.violations) ||
+    !isRecord(data.bySelector) ||
+    !isRecord(data.byComponent) ||
+    !Array.isArray(data.fixClusters)
+  ) {
+    return false;
+  }
+
+  for (const violation of data.violations) {
+    if (!isRecord(violation)) return false;
+    if (
+      typeof violation.route !== 'string' ||
+      (violation.theme !== 'light' && violation.theme !== 'dark') ||
+      typeof violation.ruleId !== 'string' ||
+      !Array.isArray(violation.nodes)
+    ) {
+      return false;
+    }
+    for (const node of violation.nodes) {
+      if (
+        !isRecord(node) ||
+        typeof node.selector !== 'string' ||
+        typeof node.failureSummary !== 'string'
+      ) {
+        return false;
+      }
+    }
+  }
+
+  if (
+    !Object.values(data.bySelector).every(isIndexEntry) ||
+    !Object.values(data.byComponent).every(isIndexEntry)
+  ) {
+    return false;
+  }
+
+  for (const cluster of data.fixClusters) {
+    if (!isRecord(cluster)) return false;
+    if (
+      typeof cluster.componentKey !== 'string' ||
+      typeof cluster.count !== 'number' ||
+      !Array.isArray(cluster.routes) ||
+      !Array.isArray(cluster.themes) ||
+      (cluster.priority !== 'critical' &&
+        cluster.priority !== 'high' &&
+        cluster.priority !== 'normal') ||
+      typeof cluster.suggestedIssueTitle !== 'string' ||
+      typeof cluster.sampleSelector !== 'string'
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export function extractContrastData(node: {
   any: Array<{ data?: unknown }>;
   all: Array<{ data?: unknown }>;
 }): ContrastNode['data'] {
-  const sources = [...node.any, ...node.all];
-  for (const check of sources) {
-    const d = check.data as
-      | {
-          fgColor?: string;
-          bgColor?: string;
-          contrastRatio?: number;
-          expectedContrastRatio?: number;
-        }
-      | null
-      | undefined;
+  for (const check of [...node.any, ...node.all]) {
+    const d = check.data as ContrastNode['data'];
     if (d?.fgColor) return d;
   }
   return null;
@@ -112,8 +170,7 @@ export function inferComponentKey(selector: string): string {
     return [...new Set(opacityMatch)].sort().join(' ');
   }
 
-  const tagMatch = selector.match(/^([a-z][\w-]*)/i);
-  return tagMatch?.[1] ?? 'unknown-element';
+  return selector.match(/^([a-z][\w-]*)/i)?.[1] ?? 'unknown-element';
 }
 
 function mergeIndexEntry(
@@ -133,65 +190,52 @@ function mergeIndexEntry(
     };
   }
 
-  const updatedRoutes = existing.routes.includes(route)
-    ? existing.routes
-    : ([...existing.routes, route] as const);
-  const updatedThemes = existing.themes.includes(theme)
-    ? existing.themes
-    : ([...existing.themes, theme] as const);
-  const worstRatio =
-    ratio !== null && existing.worstRatio !== null
-      ? Math.min(existing.worstRatio, ratio)
-      : (existing.worstRatio ?? ratio);
-
   return {
     count: existing.count + 1,
-    routes: updatedRoutes,
-    worstRatio,
-    themes: updatedThemes,
+    routes: existing.routes.includes(route)
+      ? existing.routes
+      : ([...existing.routes, route] as const),
+    worstRatio:
+      ratio !== null && existing.worstRatio !== null
+        ? Math.min(existing.worstRatio, ratio)
+        : (existing.worstRatio ?? ratio),
+    themes: existing.themes.includes(theme)
+      ? existing.themes
+      : ([...existing.themes, theme] as const),
     sampleSelector: existing.sampleSelector,
   };
+}
+
+function buildIndex(
+  violations: readonly ContrastViolationRecord[],
+  keyFn: (selector: string) => string
+): Record<string, ContrastComponentIndexEntry> {
+  const index: Record<string, ContrastComponentIndexEntry> = {};
+  for (const violation of violations) {
+    for (const node of violation.nodes) {
+      const key = keyFn(node.selector);
+      index[key] = mergeIndexEntry(
+        index[key],
+        violation.route,
+        violation.theme,
+        node.data?.contrastRatio ?? null,
+        node.selector
+      );
+    }
+  }
+  return index;
 }
 
 export function buildSelectorIndex(
   violations: readonly ContrastViolationRecord[]
 ): ContrastInventory['bySelector'] {
-  const bySelector: ContrastInventory['bySelector'] = {};
-
-  for (const violation of violations) {
-    for (const node of violation.nodes) {
-      bySelector[node.selector] = mergeIndexEntry(
-        bySelector[node.selector],
-        violation.route,
-        violation.theme,
-        node.data?.contrastRatio ?? null,
-        node.selector
-      );
-    }
-  }
-
-  return bySelector;
+  return buildIndex(violations, selector => selector);
 }
 
 export function buildComponentIndex(
   violations: readonly ContrastViolationRecord[]
 ): ContrastInventory['byComponent'] {
-  const byComponent: ContrastInventory['byComponent'] = {};
-
-  for (const violation of violations) {
-    for (const node of violation.nodes) {
-      const componentKey = inferComponentKey(node.selector);
-      byComponent[componentKey] = mergeIndexEntry(
-        byComponent[componentKey],
-        violation.route,
-        violation.theme,
-        node.data?.contrastRatio ?? null,
-        node.selector
-      );
-    }
-  }
-
-  return byComponent;
+  return buildIndex(violations, inferComponentKey);
 }
 
 export function classifyFixPriority(
@@ -204,7 +248,6 @@ export function classifyFixPriority(
     /\bbutton\b/.test(selectorLower) ||
     componentKey.includes('data-testid:') ||
     /cta|upgrade|pay|checkout|subscribe/.test(selectorLower);
-
   const isCriticalRoute = routes.some(route =>
     CRITICAL_ROUTE_PATTERNS.some(pattern => pattern.test(route))
   );
@@ -216,10 +259,7 @@ export function classifyFixPriority(
       route !== '/'
   );
 
-  if (isCriticalRoute || isProfileRoute || isCta) {
-    return 'critical';
-  }
-
+  if (isCriticalRoute || isProfileRoute || isCta) return 'critical';
   if (
     routes.some(route => route.startsWith('/app')) ||
     componentKey.includes('text-primary-token') ||
@@ -227,13 +267,18 @@ export function classifyFixPriority(
   ) {
     return 'high';
   }
-
   return 'normal';
 }
 
 export function buildFixClusters(
   byComponent: ContrastInventory['byComponent']
 ): ContrastFixCluster[] {
+  const priorityRank: Record<ContrastFixPriority, number> = {
+    critical: 0,
+    high: 1,
+    normal: 2,
+  };
+
   return Object.entries(byComponent)
     .map(([componentKey, entry]) => ({
       componentKey,
@@ -250,86 +295,27 @@ export function buildFixClusters(
       suggestedIssueTitle: `Fix contrast: ${componentKey}`,
     }))
     .sort((a, b) => {
-      const priorityRank: Record<ContrastFixPriority, number> = {
-        critical: 0,
-        high: 1,
-        normal: 2,
-      };
       const priorityDelta = priorityRank[a.priority] - priorityRank[b.priority];
-      if (priorityDelta !== 0) return priorityDelta;
-      return b.count - a.count;
+      return priorityDelta !== 0 ? priorityDelta : b.count - a.count;
     });
 }
 
 export function renderMarkdownReport(inventory: ContrastInventory): string {
   const routesScanned = new Set(inventory.violations.map(v => v.route)).size;
-  const criticalClusters = inventory.fixClusters.filter(
-    cluster => cluster.priority === 'critical'
-  );
-
-  const topComponents = inventory.fixClusters.slice(0, 40);
-  const componentRows = topComponents
-    .map(cluster => {
-      const ratio =
-        cluster.worstRatio === null ? 'n/a' : cluster.worstRatio.toFixed(2);
-      return `| ${cluster.priority} | ${cluster.count} | ${cluster.themes.join(', ')} | ${ratio} | \`${cluster.componentKey}\` | ${cluster.routes.length} |`;
-    })
-    .join('\n');
-
-  const violationRows = inventory.violations
-    .flatMap(violation =>
-      violation.nodes.map(node => {
-        const ratio =
-          node.data?.contrastRatio === undefined
-            ? 'n/a'
-            : String(node.data.contrastRatio);
-        const fg = node.data?.fgColor ?? 'n/a';
-        const bg = node.data?.bgColor ?? 'n/a';
-        const screenshot = violation.screenshot ?? 'n/a';
-        const component = inferComponentKey(node.selector);
-        return `| ${violation.route} | ${violation.theme} | ${component} | ${ratio} | ${fg} | ${bg} | ${screenshot} | \`${node.selector.slice(0, 120)}\` |`;
-      })
-    )
-    .slice(0, 200)
-    .join('\n');
-
+  const topClusters = inventory.fixClusters.slice(0, 20);
   return [
     '# Contrast Inventory Baseline',
     '',
-    `Generated: ${inventory.generatedAt}`,
-    `Issue: ${inventory.issueRef}`,
-    '',
-    '## Summary',
-    '',
-    `- Total violation nodes: ${inventory.totalViolations}`,
+    `Generated: ${inventory.generatedAt} | Issue: ${inventory.issueRef}`,
+    `- Violation nodes: ${inventory.totalViolations}`,
     `- Unique selectors: ${Object.keys(inventory.bySelector).length}`,
-    `- Shared component keys: ${Object.keys(inventory.byComponent).length}`,
     `- Routes scanned: ${routesScanned}`,
-    `- Critical fix clusters: ${criticalClusters.length}`,
     '',
-    '## Worst Offenders (component clusters)',
-    '',
-    '| Priority | Count | Themes | Worst ratio | Component key | Routes |',
-    '| --- | ---: | --- | ---: | --- | ---: |',
-    componentRows,
-    '',
-    '## Sample Violations (first 200 nodes)',
-    '',
-    '| Route | Theme | Component | Ratio | FG | BG | Screenshot | Selector |',
-    '| --- | --- | --- | ---: | --- | --- | --- | --- |',
-    violationRows,
-    '',
-    '## Critical clusters (canonical fix issues)',
-    '',
-    ...criticalClusters
-      .slice(0, 25)
-      .map(
-        (cluster, index) =>
-          `${index + 1}. **${cluster.suggestedIssueTitle}** — ` +
-          `${cluster.count} nodes across ${cluster.routes.length} routes ` +
-          `(${cluster.themes.join('+')}); sample: \`${cluster.sampleSelector.slice(0, 100)}\``
-      ),
-    '',
+    '## Top fix clusters',
+    ...topClusters.map(
+      cluster =>
+        `- [${cluster.priority} ×${cluster.count}] ${cluster.componentKey}`
+    ),
   ].join('\n');
 }
 
@@ -338,13 +324,10 @@ export function writeContrastInventoryArtifacts(
   outputDir: string
 ): { readonly jsonPath: string; readonly markdownPath: string } {
   mkdirSync(outputDir, { recursive: true });
-
   const jsonPath = join(outputDir, 'contrast-baseline.json');
   const markdownPath = join(outputDir, 'contrast-baseline.md');
-
   writeFileSync(jsonPath, JSON.stringify(inventory, null, 2));
   writeFileSync(markdownPath, renderMarkdownReport(inventory));
-
   return { jsonPath, markdownPath };
 }
 

--- a/apps/web/tests/e2e/utils/contrast-inventory.ts
+++ b/apps/web/tests/e2e/utils/contrast-inventory.ts
@@ -1,0 +1,374 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface ContrastNode {
+  /** CSS selector identifying the violating element */
+  readonly selector: string;
+  /** axe failure summary */
+  readonly failureSummary: string;
+  /** fg/bg color data from axe */
+  readonly data: {
+    readonly fgColor?: string;
+    readonly bgColor?: string;
+    readonly contrastRatio?: number;
+    readonly expectedContrastRatio?: number;
+  } | null;
+}
+
+export interface ContrastViolationRecord {
+  readonly route: string;
+  readonly theme: 'light' | 'dark';
+  /** axe rule id — always 'color-contrast' in this sweep */
+  readonly ruleId: string;
+  readonly impact: string | null;
+  readonly nodes: readonly ContrastNode[];
+  /** Route-level screenshot when violations were found */
+  readonly screenshot?: string;
+}
+
+export interface ContrastComponentIndexEntry {
+  readonly count: number;
+  readonly routes: readonly string[];
+  readonly worstRatio: number | null;
+  readonly themes: readonly ('light' | 'dark')[];
+  readonly sampleSelector: string;
+}
+
+export type ContrastFixPriority = 'critical' | 'high' | 'normal';
+
+export interface ContrastFixCluster {
+  readonly componentKey: string;
+  readonly count: number;
+  readonly routes: readonly string[];
+  readonly themes: readonly ('light' | 'dark')[];
+  readonly worstRatio: number | null;
+  readonly priority: ContrastFixPriority;
+  readonly sampleSelector: string;
+  /** Canonical fix issue title for Linear triage */
+  readonly suggestedIssueTitle: string;
+}
+
+export interface ContrastInventory {
+  readonly schemaVersion: 1;
+  /** ISO timestamp of when this inventory was generated */
+  readonly generatedAt: string;
+  readonly issueRef: '#11028';
+  readonly totalViolations: number;
+  readonly violations: readonly ContrastViolationRecord[];
+  /** Violations grouped by CSS selector for deduplication */
+  readonly bySelector: Record<string, ContrastComponentIndexEntry>;
+  /** Violations grouped by inferred shared component/token for fix triage */
+  readonly byComponent: Record<string, ContrastComponentIndexEntry>;
+  /** Worst offenders clustered for one-fix-closes-many triage */
+  readonly fixClusters: readonly ContrastFixCluster[];
+}
+
+const CRITICAL_ROUTE_PATTERNS = [
+  /^\/onboarding/,
+  /^\/billing/,
+  /^\/app\/settings\/billing/,
+  /\/tip$/,
+  /\/pay$/,
+  /\/subscribe$/,
+] as const;
+
+const PROFILE_ROUTE_PATTERN = /^\/[^/]+$/;
+
+export function extractContrastData(node: {
+  any: Array<{ data?: unknown }>;
+  all: Array<{ data?: unknown }>;
+}): ContrastNode['data'] {
+  const sources = [...node.any, ...node.all];
+  for (const check of sources) {
+    const d = check.data as
+      | {
+          fgColor?: string;
+          bgColor?: string;
+          contrastRatio?: number;
+          expectedContrastRatio?: number;
+        }
+      | null
+      | undefined;
+    if (d?.fgColor) return d;
+  }
+  return null;
+}
+
+export function inferComponentKey(selector: string): string {
+  const tokenClasses = selector.match(
+    /\.(?:text|bg|border)-[\w-]+(?:-token)?/g
+  );
+  if (tokenClasses?.length) {
+    return [...new Set(tokenClasses)].sort().join(' ');
+  }
+
+  const testIdMatch = selector.match(/\[data-testid="([^"]+)"\]/);
+  if (testIdMatch?.[1]) {
+    return `data-testid:${testIdMatch[1]}`;
+  }
+
+  const opacityMatch = selector.match(/\.opacity-[\w/]+/g);
+  if (opacityMatch?.length) {
+    return [...new Set(opacityMatch)].sort().join(' ');
+  }
+
+  const tagMatch = selector.match(/^([a-z][\w-]*)/i);
+  return tagMatch?.[1] ?? 'unknown-element';
+}
+
+function mergeIndexEntry(
+  existing: ContrastComponentIndexEntry | undefined,
+  route: string,
+  theme: 'light' | 'dark',
+  ratio: number | null,
+  selector: string
+): ContrastComponentIndexEntry {
+  if (!existing) {
+    return {
+      count: 1,
+      routes: [route],
+      worstRatio: ratio,
+      themes: [theme],
+      sampleSelector: selector,
+    };
+  }
+
+  const updatedRoutes = existing.routes.includes(route)
+    ? existing.routes
+    : ([...existing.routes, route] as const);
+  const updatedThemes = existing.themes.includes(theme)
+    ? existing.themes
+    : ([...existing.themes, theme] as const);
+  const worstRatio =
+    ratio !== null && existing.worstRatio !== null
+      ? Math.min(existing.worstRatio, ratio)
+      : (existing.worstRatio ?? ratio);
+
+  return {
+    count: existing.count + 1,
+    routes: updatedRoutes,
+    worstRatio,
+    themes: updatedThemes,
+    sampleSelector: existing.sampleSelector,
+  };
+}
+
+export function buildSelectorIndex(
+  violations: readonly ContrastViolationRecord[]
+): ContrastInventory['bySelector'] {
+  const bySelector: ContrastInventory['bySelector'] = {};
+
+  for (const violation of violations) {
+    for (const node of violation.nodes) {
+      bySelector[node.selector] = mergeIndexEntry(
+        bySelector[node.selector],
+        violation.route,
+        violation.theme,
+        node.data?.contrastRatio ?? null,
+        node.selector
+      );
+    }
+  }
+
+  return bySelector;
+}
+
+export function buildComponentIndex(
+  violations: readonly ContrastViolationRecord[]
+): ContrastInventory['byComponent'] {
+  const byComponent: ContrastInventory['byComponent'] = {};
+
+  for (const violation of violations) {
+    for (const node of violation.nodes) {
+      const componentKey = inferComponentKey(node.selector);
+      byComponent[componentKey] = mergeIndexEntry(
+        byComponent[componentKey],
+        violation.route,
+        violation.theme,
+        node.data?.contrastRatio ?? null,
+        node.selector
+      );
+    }
+  }
+
+  return byComponent;
+}
+
+export function classifyFixPriority(
+  componentKey: string,
+  routes: readonly string[],
+  selector: string
+): ContrastFixPriority {
+  const selectorLower = selector.toLowerCase();
+  const isCta =
+    /\bbutton\b/.test(selectorLower) ||
+    componentKey.includes('data-testid:') ||
+    /cta|upgrade|pay|checkout|subscribe/.test(selectorLower);
+
+  const isCriticalRoute = routes.some(route =>
+    CRITICAL_ROUTE_PATTERNS.some(pattern => pattern.test(route))
+  );
+  const isProfileRoute = routes.some(
+    route =>
+      PROFILE_ROUTE_PATTERN.test(route) &&
+      !route.startsWith('/app') &&
+      !route.startsWith('/onboarding') &&
+      route !== '/'
+  );
+
+  if (isCriticalRoute || isProfileRoute || isCta) {
+    return 'critical';
+  }
+
+  if (
+    routes.some(route => route.startsWith('/app')) ||
+    componentKey.includes('text-primary-token') ||
+    componentKey.includes('text-secondary-token')
+  ) {
+    return 'high';
+  }
+
+  return 'normal';
+}
+
+export function buildFixClusters(
+  byComponent: ContrastInventory['byComponent']
+): ContrastFixCluster[] {
+  return Object.entries(byComponent)
+    .map(([componentKey, entry]) => ({
+      componentKey,
+      count: entry.count,
+      routes: entry.routes,
+      themes: entry.themes,
+      worstRatio: entry.worstRatio,
+      priority: classifyFixPriority(
+        componentKey,
+        entry.routes,
+        entry.sampleSelector
+      ),
+      sampleSelector: entry.sampleSelector,
+      suggestedIssueTitle: `Fix contrast: ${componentKey}`,
+    }))
+    .sort((a, b) => {
+      const priorityRank: Record<ContrastFixPriority, number> = {
+        critical: 0,
+        high: 1,
+        normal: 2,
+      };
+      const priorityDelta = priorityRank[a.priority] - priorityRank[b.priority];
+      if (priorityDelta !== 0) return priorityDelta;
+      return b.count - a.count;
+    });
+}
+
+export function renderMarkdownReport(inventory: ContrastInventory): string {
+  const routesScanned = new Set(inventory.violations.map(v => v.route)).size;
+  const criticalClusters = inventory.fixClusters.filter(
+    cluster => cluster.priority === 'critical'
+  );
+
+  const topComponents = inventory.fixClusters.slice(0, 40);
+  const componentRows = topComponents
+    .map(cluster => {
+      const ratio =
+        cluster.worstRatio === null ? 'n/a' : cluster.worstRatio.toFixed(2);
+      return `| ${cluster.priority} | ${cluster.count} | ${cluster.themes.join(', ')} | ${ratio} | \`${cluster.componentKey}\` | ${cluster.routes.length} |`;
+    })
+    .join('\n');
+
+  const violationRows = inventory.violations
+    .flatMap(violation =>
+      violation.nodes.map(node => {
+        const ratio =
+          node.data?.contrastRatio === undefined
+            ? 'n/a'
+            : String(node.data.contrastRatio);
+        const fg = node.data?.fgColor ?? 'n/a';
+        const bg = node.data?.bgColor ?? 'n/a';
+        const screenshot = violation.screenshot ?? 'n/a';
+        const component = inferComponentKey(node.selector);
+        return `| ${violation.route} | ${violation.theme} | ${component} | ${ratio} | ${fg} | ${bg} | ${screenshot} | \`${node.selector.slice(0, 120)}\` |`;
+      })
+    )
+    .slice(0, 200)
+    .join('\n');
+
+  return [
+    '# Contrast Inventory Baseline',
+    '',
+    `Generated: ${inventory.generatedAt}`,
+    `Issue: ${inventory.issueRef}`,
+    '',
+    '## Summary',
+    '',
+    `- Total violation nodes: ${inventory.totalViolations}`,
+    `- Unique selectors: ${Object.keys(inventory.bySelector).length}`,
+    `- Shared component keys: ${Object.keys(inventory.byComponent).length}`,
+    `- Routes scanned: ${routesScanned}`,
+    `- Critical fix clusters: ${criticalClusters.length}`,
+    '',
+    '## Worst Offenders (component clusters)',
+    '',
+    '| Priority | Count | Themes | Worst ratio | Component key | Routes |',
+    '| --- | ---: | --- | ---: | --- | ---: |',
+    componentRows,
+    '',
+    '## Sample Violations (first 200 nodes)',
+    '',
+    '| Route | Theme | Component | Ratio | FG | BG | Screenshot | Selector |',
+    '| --- | --- | --- | ---: | --- | --- | --- | --- |',
+    violationRows,
+    '',
+    '## Critical clusters (canonical fix issues)',
+    '',
+    ...criticalClusters
+      .slice(0, 25)
+      .map(
+        (cluster, index) =>
+          `${index + 1}. **${cluster.suggestedIssueTitle}** — ` +
+          `${cluster.count} nodes across ${cluster.routes.length} routes ` +
+          `(${cluster.themes.join('+')}); sample: \`${cluster.sampleSelector.slice(0, 100)}\``
+      ),
+    '',
+  ].join('\n');
+}
+
+export function writeContrastInventoryArtifacts(
+  inventory: ContrastInventory,
+  outputDir: string
+): { readonly jsonPath: string; readonly markdownPath: string } {
+  mkdirSync(outputDir, { recursive: true });
+
+  const jsonPath = join(outputDir, 'contrast-baseline.json');
+  const markdownPath = join(outputDir, 'contrast-baseline.md');
+
+  writeFileSync(jsonPath, JSON.stringify(inventory, null, 2));
+  writeFileSync(markdownPath, renderMarkdownReport(inventory));
+
+  return { jsonPath, markdownPath };
+}
+
+export function slugifyRouteForScreenshot(route: string): string {
+  return route.replace(/^\/+/, '').replaceAll('/', '__') || 'root';
+}
+
+export function getScreenshotRelativePath(
+  route: string,
+  theme: 'light' | 'dark'
+): string {
+  return `contrast-screenshots/${slugifyRouteForScreenshot(route)}--${theme}.png`;
+}
+
+export function ensureScreenshotDirectory(outputDir: string): string {
+  const screenshotDir = join(outputDir, 'contrast-screenshots');
+  mkdirSync(screenshotDir, { recursive: true });
+  return screenshotDir;
+}
+
+export function getScreenshotAbsolutePath(
+  outputDir: string,
+  route: string,
+  theme: 'light' | 'dark'
+): string {
+  return join(outputDir, getScreenshotRelativePath(route, theme));
+}

--- a/apps/web/tests/unit/design-system/contrast-baseline-schema.test.ts
+++ b/apps/web/tests/unit/design-system/contrast-baseline-schema.test.ts
@@ -6,13 +6,7 @@
  *     ContrastInventory schema — the gate (#11025) can read it safely.
  *  2. The critical high-priority surfaces are represented in the inventory
  *     route list (public profile, onboarding, paywall, dashboard).
- *  3. The bySelector index is consistent with the violations array.
- *
- * This test:
- *  - PASSES when the baseline file doesn't exist yet (first run before sweep).
- *  - FAILS if the baseline file is malformed after a sweep.
- *  - FAILS if required critical routes are missing from the sweep route list
- *    defined in contrast-inventory.spec.ts.
+ *  3. The bySelector/byComponent indexes are consistent with violations.
  *
  * Run: pnpm --filter web exec vitest run tests/unit/design-system/contrast-baseline-schema.test.ts
  *
@@ -23,22 +17,25 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import type { ContrastInventory } from '../../e2e/contrast-inventory.spec';
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  buildComponentIndex,
+  buildFixClusters,
+  buildSelectorIndex,
+  type ContrastInventory,
+  inferComponentKey,
+} from '../../e2e/utils/contrast-inventory';
 
 const WEB_ROOT = process.cwd();
 const BASELINE_PATH = join(WEB_ROOT, 'tests/e2e/contrast-baseline.json');
+const SPEC_PATH = join(WEB_ROOT, 'tests/e2e/contrast-inventory.spec.ts');
 
-// Routes that MUST be present in the sweep — highest-priority per #11028
-const CRITICAL_ROUTE_PREFIXES = [
-  '/app/dashboard',
-  '/app/settings/billing',
-  '/onboarding',
-  '/app/upgrade',
+const CRITICAL_ROUTE_CONSTANTS = [
+  'APP_ROUTES.LEGACY_DASHBOARD',
+  'APP_ROUTES.SETTINGS_BILLING',
+  'APP_ROUTES.ONBOARDING',
+  'APP_ROUTES.BILLING',
 ] as const;
-
-// ---------------------------------------------------------------------------
-// Schema validators
-// ---------------------------------------------------------------------------
 
 function isContrastNode(
   n: unknown
@@ -64,6 +61,37 @@ function isContrastViolationRecord(
   );
 }
 
+function isIndexEntry(
+  entry: unknown
+): entry is ContrastInventory['bySelector'][string] {
+  if (typeof entry !== 'object' || entry === null) return false;
+  const o = entry as Record<string, unknown>;
+  return (
+    typeof o['count'] === 'number' &&
+    Array.isArray(o['routes']) &&
+    Array.isArray(o['themes']) &&
+    typeof o['sampleSelector'] === 'string'
+  );
+}
+
+function isFixCluster(
+  cluster: unknown
+): cluster is ContrastInventory['fixClusters'][number] {
+  if (typeof cluster !== 'object' || cluster === null) return false;
+  const o = cluster as Record<string, unknown>;
+  return (
+    typeof o['componentKey'] === 'string' &&
+    typeof o['count'] === 'number' &&
+    Array.isArray(o['routes']) &&
+    Array.isArray(o['themes']) &&
+    (o['priority'] === 'critical' ||
+      o['priority'] === 'high' ||
+      o['priority'] === 'normal') &&
+    typeof o['suggestedIssueTitle'] === 'string' &&
+    typeof o['sampleSelector'] === 'string'
+  );
+}
+
 function isContrastInventory(data: unknown): data is ContrastInventory {
   if (typeof data !== 'object' || data === null) return false;
   const o = data as Record<string, unknown>;
@@ -75,51 +103,120 @@ function isContrastInventory(data: unknown): data is ContrastInventory {
     Array.isArray(o['violations']) &&
     (o['violations'] as unknown[]).every(isContrastViolationRecord) &&
     typeof o['bySelector'] === 'object' &&
-    o['bySelector'] !== null
+    o['bySelector'] !== null &&
+    typeof o['byComponent'] === 'object' &&
+    o['byComponent'] !== null &&
+    Array.isArray(o['fixClusters']) &&
+    (o['fixClusters'] as unknown[]).every(isFixCluster) &&
+    Object.values(o['bySelector'] as Record<string, unknown>).every(
+      isIndexEntry
+    ) &&
+    Object.values(o['byComponent'] as Record<string, unknown>).every(
+      isIndexEntry
+    )
   );
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe('Contrast baseline schema (JOV-#11028)', () => {
   it('contrast-inventory.spec.ts must include all critical authenticated routes', () => {
-    // This test validates the source file, not the generated baseline —
-    // it fails even before a sweep runs, ensuring the spec is complete.
-    const specPath = join(WEB_ROOT, 'tests/e2e/contrast-inventory.spec.ts');
-    expect(existsSync(specPath), 'contrast-inventory.spec.ts must exist').toBe(
+    expect(existsSync(SPEC_PATH), 'contrast-inventory.spec.ts must exist').toBe(
       true
     );
 
-    const specSource = readFileSync(specPath, 'utf8');
+    const specSource = readFileSync(SPEC_PATH, 'utf8');
 
-    for (const prefix of CRITICAL_ROUTE_PREFIXES) {
+    for (const routeConstant of CRITICAL_ROUTE_CONSTANTS) {
       expect(
         specSource,
-        `contrast-inventory.spec.ts must include critical route "${prefix}"`
-      ).toContain(`'${prefix}'`);
+        `contrast-inventory.spec.ts must include critical route constant "${routeConstant}"`
+      ).toContain(routeConstant);
     }
+
+    expect(APP_ROUTES.LEGACY_DASHBOARD).toBe('/app/dashboard');
+    expect(APP_ROUTES.BILLING).toBe('/billing');
   });
 
   it('contrast-inventory.spec.ts must cover both light and dark themes', () => {
-    const specPath = join(WEB_ROOT, 'tests/e2e/contrast-inventory.spec.ts');
-    const src = readFileSync(specPath, 'utf8');
+    const src = readFileSync(SPEC_PATH, 'utf8');
     expect(src, 'spec must cover light theme').toContain("'light'");
     expect(src, 'spec must cover dark theme').toContain("'dark'");
   });
 
   it('contrast-inventory.spec.ts must use axe color-contrast rule exclusively', () => {
-    const specPath = join(WEB_ROOT, 'tests/e2e/contrast-inventory.spec.ts');
-    const src = readFileSync(specPath, 'utf8');
+    const src = readFileSync(SPEC_PATH, 'utf8');
     expect(src, 'spec must use color-contrast axe rule').toContain(
       "withRules(['color-contrast'])"
     );
   });
 
+  it('contrast-inventory.spec.ts must not use import.meta.url (breaks Playwright loader)', () => {
+    const src = readFileSync(SPEC_PATH, 'utf8');
+    expect(src, 'import.meta.url breaks Playwright ESM loading').not.toContain(
+      'import.meta.url'
+    );
+  });
+
+  it('component inference groups token classes for shared fixes', () => {
+    const key = inferComponentKey(
+      'button.text-tertiary-token.bg-surface-1.rounded-full'
+    );
+    expect(key).toBe('.bg-surface-1 .text-tertiary-token');
+  });
+
+  it('inventory indexes stay consistent for synthetic violations', () => {
+    const violations: ContrastInventory['violations'] = [
+      {
+        route: '/billing',
+        theme: 'dark',
+        ruleId: 'color-contrast',
+        impact: 'serious',
+        nodes: [
+          {
+            selector: 'button.text-tertiary-token',
+            failureSummary: 'Fix contrast',
+            data: {
+              fgColor: '#666',
+              bgColor: '#000',
+              contrastRatio: 2.1,
+              expectedContrastRatio: 4.5,
+            },
+          },
+        ],
+      },
+      {
+        route: '/onboarding',
+        theme: 'light',
+        ruleId: 'color-contrast',
+        impact: 'serious',
+        nodes: [
+          {
+            selector: 'button.text-tertiary-token',
+            failureSummary: 'Fix contrast',
+            data: {
+              fgColor: '#777',
+              bgColor: '#fff',
+              contrastRatio: 2.4,
+              expectedContrastRatio: 4.5,
+            },
+          },
+        ],
+      },
+    ];
+
+    const bySelector = buildSelectorIndex(violations);
+    const byComponent = buildComponentIndex(violations);
+    const fixClusters = buildFixClusters(byComponent);
+
+    expect(bySelector['button.text-tertiary-token']?.count).toBe(2);
+    expect(byComponent['.text-tertiary-token']?.count).toBe(2);
+    expect(fixClusters[0]?.priority).toBe('critical');
+    expect(fixClusters[0]?.routes).toEqual(
+      expect.arrayContaining(['/billing', '/onboarding'])
+    );
+  });
+
   it('baseline schema is valid when the file exists', () => {
     if (!existsSync(BASELINE_PATH)) {
-      // Not yet generated — skip gracefully (first run before sweep)
       return;
     }
 
@@ -140,23 +237,30 @@ describe('Contrast baseline schema (JOV-#11028)', () => {
 
     const inventory = parsed as ContrastInventory;
 
-    // bySelector count consistency: sum of node counts across all violations
-    // must match totalViolations
     const computedTotal = inventory.violations.reduce(
       (sum, v) => sum + v.nodes.length,
       0
     );
-    const indexedTotal = Object.values(inventory.bySelector).reduce(
+    const indexedSelectorTotal = Object.values(inventory.bySelector).reduce(
       (sum, s) => sum + s.count,
       0
     );
+    const indexedComponentTotal = Object.values(inventory.byComponent).reduce(
+      (sum, s) => sum + s.count,
+      0
+    );
+
     expect(
       inventory.totalViolations,
       'totalViolations must equal sum of violation nodes'
     ).toBe(computedTotal);
     expect(
-      indexedTotal,
+      indexedSelectorTotal,
       'bySelector count sum must equal totalViolations'
+    ).toBe(computedTotal);
+    expect(
+      indexedComponentTotal,
+      'byComponent count sum must equal totalViolations'
     ).toBe(computedTotal);
   });
 
@@ -174,6 +278,8 @@ describe('Contrast baseline schema (JOV-#11028)', () => {
       'totalViolations',
       'violations',
       'bySelector',
+      'byComponent',
+      'fixClusters',
     ] as const;
 
     for (const field of requiredFields) {

--- a/apps/web/tests/unit/design-system/contrast-baseline-schema.test.ts
+++ b/apps/web/tests/unit/design-system/contrast-baseline-schema.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Contrast baseline schema guard — JOV-#11028
+ *
+ * Validates that:
+ *  1. The contrast-baseline.json file (if it exists) conforms to the expected
+ *     ContrastInventory schema — the gate (#11025) can read it safely.
+ *  2. The critical high-priority surfaces are represented in the inventory
+ *     route list (public profile, onboarding, paywall, dashboard).
+ *  3. The bySelector index is consistent with the violations array.
+ *
+ * This test:
+ *  - PASSES when the baseline file doesn't exist yet (first run before sweep).
+ *  - FAILS if the baseline file is malformed after a sweep.
+ *  - FAILS if required critical routes are missing from the sweep route list
+ *    defined in contrast-inventory.spec.ts.
+ *
+ * Run: pnpm --filter web exec vitest run tests/unit/design-system/contrast-baseline-schema.test.ts
+ *
+ * @see JovieInc/Jovie#11028 (inventory sweep)
+ * @see JovieInc/Jovie#11025 (gate that consumes this baseline)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { ContrastInventory } from '../../e2e/contrast-inventory.spec';
+
+const WEB_ROOT = process.cwd();
+const BASELINE_PATH = join(WEB_ROOT, 'tests/e2e/contrast-baseline.json');
+
+// Routes that MUST be present in the sweep — highest-priority per #11028
+const CRITICAL_ROUTE_PREFIXES = [
+  '/app/dashboard',
+  '/app/settings/billing',
+  '/onboarding',
+  '/app/upgrade',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Schema validators
+// ---------------------------------------------------------------------------
+
+function isContrastNode(
+  n: unknown
+): n is ContrastInventory['violations'][number]['nodes'][number] {
+  if (typeof n !== 'object' || n === null) return false;
+  const o = n as Record<string, unknown>;
+  return (
+    typeof o['selector'] === 'string' && typeof o['failureSummary'] === 'string'
+  );
+}
+
+function isContrastViolationRecord(
+  v: unknown
+): v is ContrastInventory['violations'][number] {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o['route'] === 'string' &&
+    (o['theme'] === 'light' || o['theme'] === 'dark') &&
+    typeof o['ruleId'] === 'string' &&
+    Array.isArray(o['nodes']) &&
+    (o['nodes'] as unknown[]).every(isContrastNode)
+  );
+}
+
+function isContrastInventory(data: unknown): data is ContrastInventory {
+  if (typeof data !== 'object' || data === null) return false;
+  const o = data as Record<string, unknown>;
+  return (
+    o['schemaVersion'] === 1 &&
+    o['issueRef'] === '#11028' &&
+    typeof o['generatedAt'] === 'string' &&
+    typeof o['totalViolations'] === 'number' &&
+    Array.isArray(o['violations']) &&
+    (o['violations'] as unknown[]).every(isContrastViolationRecord) &&
+    typeof o['bySelector'] === 'object' &&
+    o['bySelector'] !== null
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Contrast baseline schema (JOV-#11028)', () => {
+  it('contrast-inventory.spec.ts must include all critical authenticated routes', () => {
+    // This test validates the source file, not the generated baseline —
+    // it fails even before a sweep runs, ensuring the spec is complete.
+    const specPath = join(WEB_ROOT, 'tests/e2e/contrast-inventory.spec.ts');
+    expect(existsSync(specPath), 'contrast-inventory.spec.ts must exist').toBe(
+      true
+    );
+
+    const specSource = readFileSync(specPath, 'utf8');
+
+    for (const prefix of CRITICAL_ROUTE_PREFIXES) {
+      expect(
+        specSource,
+        `contrast-inventory.spec.ts must include critical route "${prefix}"`
+      ).toContain(`'${prefix}'`);
+    }
+  });
+
+  it('contrast-inventory.spec.ts must cover both light and dark themes', () => {
+    const specPath = join(WEB_ROOT, 'tests/e2e/contrast-inventory.spec.ts');
+    const src = readFileSync(specPath, 'utf8');
+    expect(src, 'spec must cover light theme').toContain("'light'");
+    expect(src, 'spec must cover dark theme').toContain("'dark'");
+  });
+
+  it('contrast-inventory.spec.ts must use axe color-contrast rule exclusively', () => {
+    const specPath = join(WEB_ROOT, 'tests/e2e/contrast-inventory.spec.ts');
+    const src = readFileSync(specPath, 'utf8');
+    expect(src, 'spec must use color-contrast axe rule').toContain(
+      "withRules(['color-contrast'])"
+    );
+  });
+
+  it('baseline schema is valid when the file exists', () => {
+    if (!existsSync(BASELINE_PATH)) {
+      // Not yet generated — skip gracefully (first run before sweep)
+      return;
+    }
+
+    const raw = readFileSync(BASELINE_PATH, 'utf8');
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error(
+        `contrast-baseline.json is not valid JSON: ${BASELINE_PATH}`
+      );
+    }
+
+    expect(
+      isContrastInventory(parsed),
+      'contrast-baseline.json must conform to ContrastInventory schema'
+    ).toBe(true);
+
+    const inventory = parsed as ContrastInventory;
+
+    // bySelector count consistency: sum of node counts across all violations
+    // must match totalViolations
+    const computedTotal = inventory.violations.reduce(
+      (sum, v) => sum + v.nodes.length,
+      0
+    );
+    const indexedTotal = Object.values(inventory.bySelector).reduce(
+      (sum, s) => sum + s.count,
+      0
+    );
+    expect(
+      inventory.totalViolations,
+      'totalViolations must equal sum of violation nodes'
+    ).toBe(computedTotal);
+    expect(
+      indexedTotal,
+      'bySelector count sum must equal totalViolations'
+    ).toBe(computedTotal);
+  });
+
+  it('baseline covers all schemaVersion=1 required fields', () => {
+    if (!existsSync(BASELINE_PATH)) return;
+
+    const inventory = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    const requiredFields = [
+      'schemaVersion',
+      'generatedAt',
+      'issueRef',
+      'totalViolations',
+      'violations',
+      'bySelector',
+    ] as const;
+
+    for (const field of requiredFields) {
+      expect(
+        field in inventory,
+        `contrast-baseline.json must have field "${field}"`
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/web/tests/unit/design-system/contrast-baseline-schema.test.ts
+++ b/apps/web/tests/unit/design-system/contrast-baseline-schema.test.ts
@@ -1,17 +1,5 @@
 /**
  * Contrast baseline schema guard — JOV-#11028
- *
- * Validates that:
- *  1. The contrast-baseline.json file (if it exists) conforms to the expected
- *     ContrastInventory schema — the gate (#11025) can read it safely.
- *  2. The critical high-priority surfaces are represented in the inventory
- *     route list (public profile, onboarding, paywall, dashboard).
- *  3. The bySelector/byComponent indexes are consistent with violations.
- *
- * Run: pnpm --filter web exec vitest run tests/unit/design-system/contrast-baseline-schema.test.ts
- *
- * @see JovieInc/Jovie#11028 (inventory sweep)
- * @see JovieInc/Jovie#11025 (gate that consumes this baseline)
  */
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -24,6 +12,7 @@ import {
   buildSelectorIndex,
   type ContrastInventory,
   inferComponentKey,
+  isContrastInventory,
 } from '../../e2e/utils/contrast-inventory';
 
 const WEB_ROOT = process.cwd();
@@ -37,130 +26,27 @@ const CRITICAL_ROUTE_CONSTANTS = [
   'APP_ROUTES.BILLING',
 ] as const;
 
-function isContrastNode(
-  n: unknown
-): n is ContrastInventory['violations'][number]['nodes'][number] {
-  if (typeof n !== 'object' || n === null) return false;
-  const o = n as Record<string, unknown>;
-  return (
-    typeof o['selector'] === 'string' && typeof o['failureSummary'] === 'string'
-  );
-}
-
-function isContrastViolationRecord(
-  v: unknown
-): v is ContrastInventory['violations'][number] {
-  if (typeof v !== 'object' || v === null) return false;
-  const o = v as Record<string, unknown>;
-  return (
-    typeof o['route'] === 'string' &&
-    (o['theme'] === 'light' || o['theme'] === 'dark') &&
-    typeof o['ruleId'] === 'string' &&
-    Array.isArray(o['nodes']) &&
-    (o['nodes'] as unknown[]).every(isContrastNode)
-  );
-}
-
-function isIndexEntry(
-  entry: unknown
-): entry is ContrastInventory['bySelector'][string] {
-  if (typeof entry !== 'object' || entry === null) return false;
-  const o = entry as Record<string, unknown>;
-  return (
-    typeof o['count'] === 'number' &&
-    Array.isArray(o['routes']) &&
-    Array.isArray(o['themes']) &&
-    typeof o['sampleSelector'] === 'string'
-  );
-}
-
-function isFixCluster(
-  cluster: unknown
-): cluster is ContrastInventory['fixClusters'][number] {
-  if (typeof cluster !== 'object' || cluster === null) return false;
-  const o = cluster as Record<string, unknown>;
-  return (
-    typeof o['componentKey'] === 'string' &&
-    typeof o['count'] === 'number' &&
-    Array.isArray(o['routes']) &&
-    Array.isArray(o['themes']) &&
-    (o['priority'] === 'critical' ||
-      o['priority'] === 'high' ||
-      o['priority'] === 'normal') &&
-    typeof o['suggestedIssueTitle'] === 'string' &&
-    typeof o['sampleSelector'] === 'string'
-  );
-}
-
-function isContrastInventory(data: unknown): data is ContrastInventory {
-  if (typeof data !== 'object' || data === null) return false;
-  const o = data as Record<string, unknown>;
-  return (
-    o['schemaVersion'] === 1 &&
-    o['issueRef'] === '#11028' &&
-    typeof o['generatedAt'] === 'string' &&
-    typeof o['totalViolations'] === 'number' &&
-    Array.isArray(o['violations']) &&
-    (o['violations'] as unknown[]).every(isContrastViolationRecord) &&
-    typeof o['bySelector'] === 'object' &&
-    o['bySelector'] !== null &&
-    typeof o['byComponent'] === 'object' &&
-    o['byComponent'] !== null &&
-    Array.isArray(o['fixClusters']) &&
-    (o['fixClusters'] as unknown[]).every(isFixCluster) &&
-    Object.values(o['bySelector'] as Record<string, unknown>).every(
-      isIndexEntry
-    ) &&
-    Object.values(o['byComponent'] as Record<string, unknown>).every(
-      isIndexEntry
-    )
-  );
-}
-
 describe('Contrast baseline schema (JOV-#11028)', () => {
-  it('contrast-inventory.spec.ts must include all critical authenticated routes', () => {
-    expect(existsSync(SPEC_PATH), 'contrast-inventory.spec.ts must exist').toBe(
-      true
-    );
-
+  it('contrast-inventory.spec.ts covers critical routes, themes, and axe rule', () => {
+    expect(existsSync(SPEC_PATH)).toBe(true);
     const specSource = readFileSync(SPEC_PATH, 'utf8');
 
     for (const routeConstant of CRITICAL_ROUTE_CONSTANTS) {
-      expect(
-        specSource,
-        `contrast-inventory.spec.ts must include critical route constant "${routeConstant}"`
-      ).toContain(routeConstant);
+      expect(specSource).toContain(routeConstant);
     }
 
+    expect(specSource).toContain("'light'");
+    expect(specSource).toContain("'dark'");
+    expect(specSource).toContain("withRules(['color-contrast'])");
+    expect(specSource).not.toContain('import.meta.url');
     expect(APP_ROUTES.LEGACY_DASHBOARD).toBe('/app/dashboard');
     expect(APP_ROUTES.BILLING).toBe('/billing');
   });
 
-  it('contrast-inventory.spec.ts must cover both light and dark themes', () => {
-    const src = readFileSync(SPEC_PATH, 'utf8');
-    expect(src, 'spec must cover light theme').toContain("'light'");
-    expect(src, 'spec must cover dark theme').toContain("'dark'");
-  });
-
-  it('contrast-inventory.spec.ts must use axe color-contrast rule exclusively', () => {
-    const src = readFileSync(SPEC_PATH, 'utf8');
-    expect(src, 'spec must use color-contrast axe rule').toContain(
-      "withRules(['color-contrast'])"
-    );
-  });
-
-  it('contrast-inventory.spec.ts must not use import.meta.url (breaks Playwright loader)', () => {
-    const src = readFileSync(SPEC_PATH, 'utf8');
-    expect(src, 'import.meta.url breaks Playwright ESM loading').not.toContain(
-      'import.meta.url'
-    );
-  });
-
   it('component inference groups token classes for shared fixes', () => {
-    const key = inferComponentKey(
-      'button.text-tertiary-token.bg-surface-1.rounded-full'
-    );
-    expect(key).toBe('.bg-surface-1 .text-tertiary-token');
+    expect(
+      inferComponentKey('button.text-tertiary-token.bg-surface-1.rounded-full')
+    ).toBe('.bg-surface-1 .text-tertiary-token');
   });
 
   it('inventory indexes stay consistent for synthetic violations', () => {
@@ -216,27 +102,12 @@ describe('Contrast baseline schema (JOV-#11028)', () => {
   });
 
   it('baseline schema is valid when the file exists', () => {
-    if (!existsSync(BASELINE_PATH)) {
-      return;
-    }
+    if (!existsSync(BASELINE_PATH)) return;
 
-    const raw = readFileSync(BASELINE_PATH, 'utf8');
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      throw new Error(
-        `contrast-baseline.json is not valid JSON: ${BASELINE_PATH}`
-      );
-    }
-
-    expect(
-      isContrastInventory(parsed),
-      'contrast-baseline.json must conform to ContrastInventory schema'
-    ).toBe(true);
+    const parsed: unknown = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+    expect(isContrastInventory(parsed)).toBe(true);
 
     const inventory = parsed as ContrastInventory;
-
     const computedTotal = inventory.violations.reduce(
       (sum, v) => sum + v.nodes.length,
       0
@@ -250,43 +121,8 @@ describe('Contrast baseline schema (JOV-#11028)', () => {
       0
     );
 
-    expect(
-      inventory.totalViolations,
-      'totalViolations must equal sum of violation nodes'
-    ).toBe(computedTotal);
-    expect(
-      indexedSelectorTotal,
-      'bySelector count sum must equal totalViolations'
-    ).toBe(computedTotal);
-    expect(
-      indexedComponentTotal,
-      'byComponent count sum must equal totalViolations'
-    ).toBe(computedTotal);
-  });
-
-  it('baseline covers all schemaVersion=1 required fields', () => {
-    if (!existsSync(BASELINE_PATH)) return;
-
-    const inventory = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as Record<
-      string,
-      unknown
-    >;
-    const requiredFields = [
-      'schemaVersion',
-      'generatedAt',
-      'issueRef',
-      'totalViolations',
-      'violations',
-      'bySelector',
-      'byComponent',
-      'fixClusters',
-    ] as const;
-
-    for (const field of requiredFields) {
-      expect(
-        field in inventory,
-        `contrast-baseline.json must have field "${field}"`
-      ).toBe(true);
-    }
+    expect(inventory.totalViolations).toBe(computedTotal);
+    expect(indexedSelectorTotal).toBe(computedTotal);
+    expect(indexedComponentTotal).toBe(computedTotal);
   });
 });


### PR DESCRIPTION
## Goal

Implements JOV-#11028: crawls all public routes × light/dark themes with axe color-contrast rule, emits `contrast-baseline.json` to seed the JOV-#11025 contrast gate, and adds a schema guard to ensure the baseline never silently rots.

## Changes

- **`apps/web/tests/e2e/contrast-inventory.spec.ts`** — Playwright spec that crawls public routes (from `PUBLIC_SURFACE_MANIFEST`, `expectedState: 'ok'`) + 8 key authenticated surfaces (dashboard, chat, releases, settings/billing, settings/account, settings/artist-profile, onboarding, paywall) in both light and dark themes using `AxeBuilder.withRules(['color-contrast'])`. Never fails — always green inventory mode. Writes `contrast-baseline.json` with full violation inventory + `bySelector` dedup index for component-level triage.

- **`apps/web/tests/unit/design-system/contrast-baseline-schema.test.ts`** — Vitest unit test that (a) validates the spec covers all critical routes and both themes even before the sweep runs, (b) validates the generated baseline JSON conforms to the `ContrastInventory` schema, and (c) checks internal consistency of `totalViolations` vs `bySelector` counts.

- **`apps/web/package.json`** — Adds `contrast:inventory` script: `playwright test tests/e2e/contrast-inventory.spec.ts --workers=1 --reporter=list`

## Testing

```bash
# Unit test (always passes, even before sweep is run):
pnpm --filter web exec vitest run tests/unit/design-system/contrast-baseline-schema.test.ts

# Run the full sweep (needs dev server + auth bypass for auth routes):
E2E_USE_TEST_AUTH_BYPASS=1 pnpm run contrast:inventory
# Output: apps/web/tests/e2e/contrast-baseline.json
```

## Notes

- The sweep spec is non-blocking by design (inventory, not gate). The JOV-#11025 gate PR will consume `contrast-baseline.json` as its known-baseline.
- Auth routes are skipped gracefully when `E2E_USE_TEST_AUTH_BYPASS=1` is not set, so CI passes without secrets.
- `bySelector` groups violations by CSS selector across all routes × themes, enabling a single component fix to close many instances.

Closes #11028

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test suite detecting color contrast accessibility violations across public and authenticated routes with light and dark theme variations, capturing screenshots and generating violation reports.
  * Added unit tests validating contrast baseline schema consistency and accuracy.

* **Chores**
  * Version bumped from 26.6.53 to 26.6.54.
  * Added new test runner script for design testing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->