### PR TITLE
fix(design-system): converge LiquidGlassMenu arbitrary values to scale tokens

### DIFF
--- a/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
@@ -115,7 +115,7 @@ function GlassHighlight({
     <div
       className={cn(
         'absolute inset-0 pointer-events-none',
-        rounded && 'rounded-[10px]'
+        rounded && 'rounded-xl'
       )}
       style={
         subtle
@@ -136,7 +136,7 @@ function GlassBlur({
 }) {
   return (
     <div
-      className={cn('absolute inset-0', rounded && 'rounded-[10px]')}
+      className={cn('absolute inset-0', rounded && 'rounded-xl')}
       style={intense ? GLASS_LAYER_STYLES.blur : GLASS_LAYER_STYLES.blurLight}
       aria-hidden='true'
     />
@@ -153,9 +153,7 @@ function Badge({
   if (count <= 0) return null;
 
   const sizeClasses =
-    size === 'sm'
-      ? 'min-w-[16px] h-[16px] px-1 text-[9px]'
-      : 'min-w-[24px] h-[20px] px-2 text-xs';
+    size === 'sm' ? 'min-w-4 h-4 px-1 text-[9px]' : 'min-w-6 h-5 px-2 text-xs';
 
   return (
     <span
@@ -274,7 +272,7 @@ export function LiquidGlassMenu({
 
           <nav
             className='relative z-10 py-2 max-h-[70svh] overflow-y-auto overscroll-contain'
-            aria-label='Expanded navigation menu'
+            aria-label='Expanded Navigation Menu'
           >
             {/* Menu items */}
             <div className='px-2'>
@@ -327,7 +325,7 @@ export function LiquidGlassMenu({
 
       {/* Bottom tab bar */}
       <nav
-        aria-label='Dashboard tabs'
+        aria-label='Dashboard Tabs'
         className='relative z-50'
         style={{
           background: 'var(--liquid-glass-bg-solid)',
@@ -350,7 +348,7 @@ export function LiquidGlassMenu({
                 href={item.href}
                 aria-current={active ? 'page' : undefined}
                 className={cn(
-                  'relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors duration-subtle ease-subtle active:text-primary-token',
+                  'relative flex min-w-16 flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors duration-subtle ease-subtle active:text-primary-token',
                   active
                     ? 'text-primary-token'
                     : 'text-tertiary-token hover:text-secondary-token'
@@ -387,7 +385,7 @@ export function LiquidGlassMenu({
             aria-label={isExpanded ? 'Close menu' : 'More options'}
             aria-expanded={isExpanded}
             className={cn(
-              'relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors duration-subtle ease-subtle active:text-primary-token',
+              'relative flex min-w-16 flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors duration-subtle ease-subtle active:text-primary-token',
               isExpanded
                 ? 'text-primary-token'
                 : 'text-tertiary-token hover:text-secondary-token'
@@ -410,7 +408,7 @@ export function LiquidGlassMenu({
               type='button'
               onClick={onSearchClick}
               aria-label='Search'
-              className='relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 text-tertiary-token transition-colors duration-subtle ease-subtle hover:text-secondary-token active:text-primary-token'
+              className='relative flex min-w-16 flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 text-tertiary-token transition-colors duration-subtle ease-subtle hover:text-secondary-token active:text-primary-token'
             >
               <Search className='h-5 w-5' aria-hidden='true' />
               <span className='sr-only'>Search</span>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 6399,
+  "count": 6390,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

Replaces 9 arbitrary Tailwind values in `LiquidGlassMenu.tsx` with canonical design-system token utilities. Zero visual change — every substitution maps to the exact same computed value.

| Before | After | Token source |
|--------|-------|--------------|
| `rounded-[10px]` ×2 | `rounded-xl` | `var(--radius-xl)` = 10px |
| `min-w-[64px]` ×3 | `min-w-16` | Tailwind spacing scale (4rem = 64px) |
| `min-w-[24px]` | `min-w-6` | spacing scale (1.5rem = 24px) |
| `h-[20px]` | `h-5` | spacing scale (1.25rem = 20px) |
| `min-w-[16px]` | `min-w-4` | spacing scale (1rem = 16px) |
| `h-[16px]` | `h-4` | spacing scale (1rem = 16px) |

Also fixes two pre-existing `aria-label` Title Case violations caught by the ESLint `canonical-ui-label-casing` rule (`"Expanded navigation menu"` → `"Expanded Navigation Menu"`, `"Dashboard tabs"` → `"Dashboard Tabs"`).

**Ratchet:** 6399 → 6390 (−9 arbitrary values, rebased onto `integration/loop-ui` baseline of 6399)

## Verification

- [x] `typecheck` — passed (zero errors)
- [x] `biome check` — passed (0 issues)
- [x] `eslint` — passed (0 warnings)
- [x] `tailwind:check` — passed
- [x] Pre-push hook — all checks passed
- [x] Rebase onto `integration/loop-ui` — one conflict in baseline JSON, resolved to 6390 (6399 − 9)
- [x] Rendered output: visually identical (pure class name substitution, no computed-value change)

## Remaining arbitrary values in this file (not convertible)
`text-[9px]`, `transition-[opacity]`, `transition-[background-color,color]` ×2, `pb-[calc(env(safe-area-inset-bottom)+4px)]`, `max-h-[70svh]` — these have no equivalent token and were left untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UD8m8jhGCjL2AoZHwrSkso)_