### PR TITLE
fix(design-system): converge h-[32px]/min-h-[32px] → h-8/min-h-8 in AddReleaseSidebar

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/AddReleaseSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/AddReleaseSidebar.tsx
@@ -328,7 +328,7 @@ export function AddReleaseSidebar({
               onChange={event => setTitle(event.target.value)}
               placeholder='My New Release'
               autoFocus
-              className='h-[32px] rounded-lg border-subtle bg-surface-0 text-xs'
+              className='h-8 rounded-lg border-subtle bg-surface-0 text-xs'
             />
           </DrawerFormField>
 
@@ -339,7 +339,7 @@ export function AddReleaseSidebar({
             >
               <SelectTrigger
                 id='release-type'
-                className='h-[32px] rounded-lg border-subtle bg-surface-0 text-xs'
+                className='h-8 rounded-lg border-subtle bg-surface-0 text-xs'
               >
                 <SelectValue>{releaseTypeLabel}</SelectValue>
               </SelectTrigger>
@@ -361,7 +361,7 @@ export function AddReleaseSidebar({
                   type='button'
                   variant='outline'
                   className={cn(
-                    'h-[32px] w-full justify-start gap-2 rounded-lg border-subtle bg-surface-0 px-3 text-xs font-normal',
+                    'h-8 w-full justify-start gap-2 rounded-lg border-subtle bg-surface-0 px-3 text-xs font-normal',
                     !releaseDate && 'text-tertiary-token'
                   )}
                 >
@@ -392,7 +392,7 @@ export function AddReleaseSidebar({
                     type='button'
                     variant='outline'
                     className={cn(
-                      'h-[32px] w-full justify-start gap-2 rounded-lg border-subtle bg-surface-0 px-3 text-xs font-normal',
+                      'h-8 w-full justify-start gap-2 rounded-lg border-subtle bg-surface-0 px-3 text-xs font-normal',
                       !revealDate && 'text-tertiary-token'
                     )}
                   >
@@ -426,7 +426,7 @@ export function AddReleaseSidebar({
               trigger={
                 <button
                   type='button'
-                  className='flex min-h-[32px] w-full items-center justify-between gap-2 rounded-lg border border-subtle bg-surface-0 px-3 py-1.5 text-left text-xs text-primary-token transition-[border-color,background-color,color] duration-subtle hover:border-default hover:bg-surface-1'
+                  className='flex min-h-8 w-full items-center justify-between gap-2 rounded-lg border border-subtle bg-surface-0 px-3 py-1.5 text-left text-xs text-primary-token transition-[border-color,background-color,color] duration-subtle hover:border-default hover:bg-surface-1'
                 >
                   <span className='flex min-w-0 flex-1 flex-wrap gap-1.5'>
                     {genres.length > 0 ? (

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 6380,
+  "count": 6375,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

Scheduled DS convergence run — replaces arbitrary Tailwind height values with standard spacing tokens in `AddReleaseSidebar.tsx`.

**Changes:** 1 file, 5 arbitrary values replaced, ratchet baseline 6380 → 6375

| Before | After | Reason |
|--------|-------|--------|
| `h-[32px]` | `h-8` | 32px = 2rem = Tailwind `h-8` (exact) |
| `min-h-[32px]` | `min-h-8` | same mapping |

Affected controls: Title `<Input>`, Release Type `<SelectTrigger>`, Release Date `<Button>`, Reveal Date `<Button>`, Genres `<button>`. All are 32px-tall form controls — semantically correct as `--linear-button-height-sm` = 32px = `h-8`.

**Rendered output:** unchanged. 32px = 8 × 4px = `h-8` on the standard Tailwind spacing scale.

## Verification

- [ ] Ratchet: `arbitrary-values.baseline.json` lowered 6380 → 6375 (-5)
- [ ] No new arbitrary values introduced
- [ ] No logic changes — className-only edits
- [ ] Typecheck: structural change only (className strings), no type-level impact

## Cost Impact

None — static CSS change only.

<!-- linear-issue-id:none -->
<!-- ds-convergence-run:2026-06-20 -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdKdwyg2L4M5N3TEApUqWZ)_