### PR TITLE
chore: candidate follow-up: re-gate native mobile chat before public iOS App St (#11014)

### DIFF
--- a/apps/web/app/api/mobile/v1/chat/turns/route.ts
+++ b/apps/web/app/api/mobile/v1/chat/turns/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
+import { isMobileChatEnabled } from '@/lib/mobile/chat/access';
 import {
   encodeMobileChatNdjsonEvent,
   MOBILE_CHAT_RUNTIME_DISABLED_CODE,
@@ -35,7 +36,7 @@ export async function POST(request: Request) {
     );
   }
 
-  if (process.env.MOBILE_CHAT_RUNTIME_ENABLED !== 'true') {
+  if (!(await isMobileChatEnabled(userId))) {
     return new Response(
       encodeMobileChatNdjsonEvent({
         type: 'error',

--- a/apps/web/app/api/mobile/v1/me/route.ts
+++ b/apps/web/app/api/mobile/v1/me/route.ts
@@ -4,7 +4,7 @@ import { isProfileComplete } from '@/lib/auth/profile-completeness';
 import { getSessionContext, SESSION_ERRORS } from '@/lib/auth/session';
 import { captureError } from '@/lib/error-tracking';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
-import { isMobileChatRuntimeEnabled } from '@/lib/mobile/chat/access';
+import { isMobileChatEnabled } from '@/lib/mobile/chat/access';
 import { getMobileSessionUserId } from '@/lib/mobile/session-auth';
 import { isAppleWalletProfilePassAvailable } from '@/lib/wallet/apple/profile-pass';
 
@@ -106,7 +106,7 @@ export async function GET(request: Request) {
         isPublic: profile.isPublic,
         onboardingCompletedAt: profile.onboardingCompletedAt,
       });
-    const chatEnabled = isMobileChatRuntimeEnabled();
+    const chatEnabled = await isMobileChatEnabled(userId);
     const payload: MobileMeResponse = {
       state: 'ready',
       displayName: profile.displayName,

--- a/apps/web/lib/mobile/chat/access.ts
+++ b/apps/web/lib/mobile/chat/access.ts
@@ -1,15 +1,37 @@
 import 'server-only';
 
+import { getAppFlagValue } from '@/lib/flags/server';
+
 /**
- * Single control for native mobile chat. Chat is available to any authenticated
- * iOS user when the runtime is enabled for the environment
- * (`MOBILE_CHAT_RUNTIME_ENABLED=true`, set per-environment in Doppler).
- *
- * The iOS app is internal-TestFlight only today, so this scopes chat to alpha
- * testers. To disable chat in an environment, flip the env switch off. Before a
- * public App Store launch, re-introduce a per-user gate here (see JOV-3239) so
- * production users don't get chat by default.
+ * Global runtime kill-switch for native mobile chat.
+ * Returns true when MOBILE_CHAT_RUNTIME_ENABLED=true in the environment.
  */
 export function isMobileChatRuntimeEnabled(): boolean {
   return process.env.MOBILE_CHAT_RUNTIME_ENABLED === 'true';
+}
+
+/**
+ * Full per-request chat gate combining the env kill-switch with an optional
+ * per-user Statsig gate (ios_app_alpha_access).
+ *
+ * Set MOBILE_CHAT_ALPHA_GATE_ENABLED=true in Doppler before the public App Store
+ * launch so only users with the ios_app_alpha_access flag enabled can access
+ * chat. Without it, any authenticated user gets chat when the runtime switch is
+ * on — which is safe while the iOS app is internal-TestFlight only.
+ *
+ * To launch chat publicly, flip MOBILE_CHAT_ALPHA_GATE_ENABLED back to false
+ * (or remove it) after the App Store launch decision (see JOV-3239, JOV-9550).
+ */
+export async function isMobileChatEnabled(
+  userId: string | null
+): Promise<boolean> {
+  if (!isMobileChatRuntimeEnabled()) {
+    return false;
+  }
+
+  if (process.env.MOBILE_CHAT_ALPHA_GATE_ENABLED === 'true') {
+    return getAppFlagValue('IOS_APP_ALPHA_ACCESS', { userId });
+  }
+
+  return true;
 }

--- a/apps/web/tests/unit/lib/mobile/chat-access.test.ts
+++ b/apps/web/tests/unit/lib/mobile/chat-access.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  getAppFlagValueMock: vi.fn<() => Promise<boolean>>(),
+}));
+
+vi.mock('@/lib/flags/server', () => ({
+  getAppFlagValue: hoisted.getAppFlagValueMock,
+}));
+
+const { isMobileChatEnabled, isMobileChatRuntimeEnabled } = await import(
+  '@/lib/mobile/chat/access'
+);
+
+describe('isMobileChatRuntimeEnabled', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns true when MOBILE_CHAT_RUNTIME_ENABLED=true', () => {
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', 'true');
+    expect(isMobileChatRuntimeEnabled()).toBe(true);
+  });
+
+  it('returns false when MOBILE_CHAT_RUNTIME_ENABLED is not set', () => {
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', '');
+    expect(isMobileChatRuntimeEnabled()).toBe(false);
+  });
+});
+
+describe('isMobileChatEnabled', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('returns false when runtime switch is off, skipping the per-user gate', async () => {
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', '');
+    await expect(isMobileChatEnabled('user_123')).resolves.toBe(false);
+    expect(hoisted.getAppFlagValueMock).not.toHaveBeenCalled();
+  });
+
+  it('returns true when runtime switch is on and alpha gate is not enabled', async () => {
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', 'true');
+    await expect(isMobileChatEnabled('user_123')).resolves.toBe(true);
+    expect(hoisted.getAppFlagValueMock).not.toHaveBeenCalled();
+  });
+
+  it('checks IOS_APP_ALPHA_ACCESS flag when MOBILE_CHAT_ALPHA_GATE_ENABLED=true and user has access', async () => {
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', 'true');
+    vi.stubEnv('MOBILE_CHAT_ALPHA_GATE_ENABLED', 'true');
+    hoisted.getAppFlagValueMock.mockResolvedValue(true);
+
+    await expect(isMobileChatEnabled('user_123')).resolves.toBe(true);
+    expect(hoisted.getAppFlagValueMock).toHaveBeenCalledWith(
+      'IOS_APP_ALPHA_ACCESS',
+      { userId: 'user_123' }
+    );
+  });
+
+  it('returns false when alpha gate is enabled and user lacks the flag', async () => {
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', 'true');
+    vi.stubEnv('MOBILE_CHAT_ALPHA_GATE_ENABLED', 'true');
+    hoisted.getAppFlagValueMock.mockResolvedValue(false);
+
+    await expect(isMobileChatEnabled('user_123')).resolves.toBe(false);
+  });
+
+  it('returns false when alpha gate is enabled and userId is null', async () => {
+    vi.stubEnv('MOBILE_CHAT_RUNTIME_ENABLED', 'true');
+    vi.stubEnv('MOBILE_CHAT_ALPHA_GATE_ENABLED', 'true');
+    hoisted.getAppFlagValueMock.mockResolvedValue(false);
+
+    await expect(isMobileChatEnabled(null)).resolves.toBe(false);
+    expect(hoisted.getAppFlagValueMock).toHaveBeenCalledWith(
+      'IOS_APP_ALPHA_ACCESS',
+      { userId: null }
+    );
+  });
+});


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (claude-sonnet-4-6). Closes #11014.

Card: t_30aabe70
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- API/route 5xx rate + p95 latency on touched endpoints
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.