### PR TITLE
chore: standalone internal ops console + admin-tooling extraction out of Jovie (#11207)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 scripts/node_modules
 apps/web/node_modules
+apps/console/node_modules
 /.bundle/
 /vendor/bundle/
 /.pnp

--- a/apps/console/app/api/health/route.ts
+++ b/apps/console/app/api/health/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok', app: 'console' });
+}

--- a/apps/console/app/globals.css
+++ b/apps/console/app/globals.css
@@ -1,0 +1,47 @@
+/* System B palette — dark-first, operational, Inter */
+:root {
+  --bg-page: #06070a;
+  --bg-surface: #0a0b0e;
+  --bg-card: #101216;
+  --border: #1a1e26;
+  --text-primary: #e8e9ec;
+  --text-secondary: #8d8d93;
+  --text-muted: #52535a;
+  --accent-blue: #4d7dff;
+  --accent-purple: #9b4dff;
+  --accent-green: #43b85c;
+  --accent-red: #ff4d5f;
+  --accent-orange: #ffab2e;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+  background: var(--bg-page);
+  color: var(--text-primary);
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent-blue);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}

--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -1,0 +1,72 @@
+import type { Metadata, Viewport } from 'next';
+import type { ReactNode } from 'react';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: { template: '%s | Jovie Console', default: 'Jovie Console' },
+  description: 'Internal ops console — not for public use.',
+  robots: { index: false, follow: false },
+};
+
+export const viewport: Viewport = {
+  themeColor: '#06070a',
+};
+
+const navItems = [{ href: '/taste-inbox', label: 'Taste Inbox' }];
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang='en' suppressHydrationWarning>
+      <body>
+        <div
+          style={{
+            display: 'flex',
+            minHeight: '100vh',
+            flexDirection: 'column',
+          }}
+        >
+          <header
+            style={{
+              borderBottom: '1px solid var(--border)',
+              background: 'var(--bg-surface)',
+              padding: '0 20px',
+              height: 44,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 24,
+              flexShrink: 0,
+            }}
+          >
+            <span
+              style={{
+                fontWeight: 600,
+                fontSize: 13,
+                color: 'var(--text-primary)',
+                letterSpacing: '-0.01em',
+              }}
+            >
+              Jovie Console
+            </span>
+            <nav style={{ display: 'flex', gap: 4 }}>
+              {navItems.map(item => (
+                <a
+                  key={item.href}
+                  href={item.href}
+                  style={{
+                    fontSize: 12,
+                    color: 'var(--text-secondary)',
+                    padding: '4px 8px',
+                    borderRadius: 'var(--radius-sm)',
+                  }}
+                >
+                  {item.label}
+                </a>
+              ))}
+            </nav>
+          </header>
+          <main style={{ flex: 1, padding: '24px 20px' }}>{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/console/app/page.tsx
+++ b/apps/console/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function HomePage() {
+  redirect('/taste-inbox');
+}

--- a/apps/console/app/taste-inbox/page.tsx
+++ b/apps/console/app/taste-inbox/page.tsx
@@ -1,0 +1,246 @@
+import type { Metadata } from 'next';
+import { fetchTasteInbox, type TasteIssue } from '@/lib/linear';
+
+export const metadata: Metadata = {
+  title: 'Taste Inbox',
+};
+
+export const dynamic = 'force-dynamic';
+
+const LABEL_STYLES: Record<
+  string,
+  { bg: string; text: string; label: string }
+> = {
+  'needs:taste': { bg: '#9b4dff22', text: '#9b4dff', label: 'Taste call' },
+  'needs:human': { bg: '#ffab2e22', text: '#ffab2e', label: 'Human action' },
+};
+
+const PRIORITY_COLORS: Record<number, string> = {
+  1: '#ff4d5f',
+  2: '#ffab2e',
+  3: '#4d7dff',
+  4: '#8d8d93',
+  0: '#52535a',
+};
+
+function IssueCard({ issue }: { issue: TasteIssue }) {
+  const style = LABEL_STYLES[issue.label] ?? LABEL_STYLES['needs:human'];
+  const priorityColor = PRIORITY_COLORS[issue.priority] ?? PRIORITY_COLORS[0];
+
+  return (
+    <div
+      style={{
+        background: 'var(--bg-card)',
+        border: '1px solid var(--border)',
+        borderRadius: 'var(--radius-md)',
+        padding: '14px 16px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            background: priorityColor,
+            flexShrink: 0,
+          }}
+        />
+        <span
+          style={{
+            fontSize: 11,
+            color: 'var(--text-muted)',
+            fontVariantNumeric: 'tabular-nums',
+          }}
+        >
+          {issue.identifier}
+        </span>
+        <span
+          style={{
+            marginLeft: 'auto',
+            fontSize: 11,
+            padding: '2px 6px',
+            borderRadius: 4,
+            background: style.bg,
+            color: style.text,
+          }}
+        >
+          {style.label}
+        </span>
+      </div>
+
+      <a
+        href={issue.url}
+        target='_blank'
+        rel='noopener noreferrer'
+        style={{
+          fontSize: 13,
+          fontWeight: 500,
+          color: 'var(--text-primary)',
+          lineHeight: 1.4,
+        }}
+      >
+        {issue.title}
+      </a>
+
+      {issue.blockingReason && (
+        <p
+          style={{
+            fontSize: 12,
+            color: 'var(--text-secondary)',
+            lineHeight: 1.5,
+          }}
+        >
+          {issue.blockingReason}
+        </p>
+      )}
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          marginTop: 4,
+        }}
+      >
+        <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>
+          {issue.priorityLabel}
+        </span>
+        <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>
+          {new Date(issue.createdAt).toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+          })}
+        </span>
+        <a
+          href={issue.url}
+          target='_blank'
+          rel='noopener noreferrer'
+          style={{
+            marginLeft: 'auto',
+            fontSize: 11,
+            color: 'var(--accent-blue)',
+          }}
+        >
+          Open in Linear →
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        padding: '32px 16px',
+        textAlign: 'center',
+        color: 'var(--text-muted)',
+        fontSize: 12,
+        border: '1px dashed var(--border)',
+        borderRadius: 'var(--radius-md)',
+      }}
+    >
+      No open {label} issues
+    </div>
+  );
+}
+
+export default async function TasteInboxPage() {
+  const result = await fetchTasteInbox(process.env.LINEAR_API_KEY);
+
+  const tasteIssues = result.issues.filter(i => i.label === 'needs:taste');
+  const humanIssues = result.issues.filter(i => i.label === 'needs:human');
+
+  return (
+    <div style={{ maxWidth: 760 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 12,
+          marginBottom: 24,
+        }}
+      >
+        <h1
+          style={{
+            fontSize: 16,
+            fontWeight: 600,
+            color: 'var(--text-primary)',
+            letterSpacing: '-0.01em',
+          }}
+        >
+          Taste Inbox
+        </h1>
+        <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+          {result.available
+            ? `${result.issues.length} open · fetched ${new Date(result.fetchedAt).toLocaleTimeString()}`
+            : (result.error ?? 'Unavailable')}
+        </span>
+      </div>
+
+      {!result.available && (
+        <div
+          style={{
+            padding: '12px 16px',
+            background: '#ff4d5f11',
+            border: '1px solid #ff4d5f44',
+            borderRadius: 'var(--radius-md)',
+            fontSize: 12,
+            color: '#ff4d5f',
+            marginBottom: 24,
+          }}
+        >
+          {result.error ?? 'Could not reach Linear. Set LINEAR_API_KEY.'}
+        </div>
+      )}
+
+      <section style={{ marginBottom: 32 }}>
+        <h2
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            color: 'var(--text-muted)',
+            marginBottom: 12,
+          }}
+        >
+          Taste calls — {tasteIssues.length}
+        </h2>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {tasteIssues.length === 0 ? (
+            <EmptyState label='taste call' />
+          ) : (
+            tasteIssues.map(issue => <IssueCard key={issue.id} issue={issue} />)
+          )}
+        </div>
+      </section>
+
+      <section>
+        <h2
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            color: 'var(--text-muted)',
+            marginBottom: 12,
+          }}
+        >
+          Human actions — {humanIssues.length}
+        </h2>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {humanIssues.length === 0 ? (
+            <EmptyState label='human action' />
+          ) : (
+            humanIssues.map(issue => <IssueCard key={issue.id} issue={issue} />)
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/console/lib/linear.test.ts
+++ b/apps/console/lib/linear.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchTasteInbox } from './linear';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('fetchTasteInbox', () => {
+  it('returns unavailable when no API key is provided', async () => {
+    const result = await fetchTasteInbox(undefined);
+    expect(result.available).toBe(false);
+    expect(result.issues).toHaveLength(0);
+    expect(result.error).toMatch(/LINEAR_API_KEY/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns issues split by label when API responds successfully', async () => {
+    mockFetch.mockResolvedValue(
+      makeResponse({
+        data: {
+          issues: {
+            nodes: [
+              {
+                id: 'issue-1',
+                identifier: 'JOV-100',
+                title: 'Pick a color for the hero',
+                url: 'https://linear.app/jovie/issue/JOV-100',
+                priority: 2,
+                priorityLabel: 'High',
+                createdAt: '2026-06-10T12:00:00Z',
+                description: 'Design judgment needed — is the purple right?',
+                labels: { nodes: [{ id: 'lbl-1', name: 'needs:taste' }] },
+              },
+              {
+                id: 'issue-2',
+                identifier: 'JOV-101',
+                title: 'Sign the ASC agreement',
+                url: 'https://linear.app/jovie/issue/JOV-101',
+                priority: 1,
+                priorityLabel: 'Urgent',
+                createdAt: '2026-06-11T09:00:00Z',
+                description: 'Requires a physical action from Tim.',
+                labels: { nodes: [{ id: 'lbl-2', name: 'needs:human' }] },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const result = await fetchTasteInbox('test-key');
+
+    expect(result.available).toBe(true);
+    expect(result.issues).toHaveLength(2);
+
+    const tasteIssue = result.issues.find(i => i.label === 'needs:taste');
+    expect(tasteIssue?.identifier).toBe('JOV-100');
+    expect(tasteIssue?.blockingReason).toContain('purple');
+
+    const humanIssue = result.issues.find(i => i.label === 'needs:human');
+    expect(humanIssue?.identifier).toBe('JOV-101');
+    expect(humanIssue?.label).toBe('needs:human');
+  });
+
+  it('filters out issues that carry no recognised label', async () => {
+    mockFetch.mockResolvedValue(
+      makeResponse({
+        data: {
+          issues: {
+            nodes: [
+              {
+                id: 'issue-3',
+                identifier: 'JOV-200',
+                title: 'Some unrelated issue',
+                url: 'https://linear.app/jovie/issue/JOV-200',
+                priority: 4,
+                priorityLabel: 'Low',
+                createdAt: '2026-06-01T00:00:00Z',
+                description: null,
+                labels: { nodes: [{ id: 'lbl-x', name: 'bug' }] },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const result = await fetchTasteInbox('test-key');
+    expect(result.available).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('returns unavailable on a non-ok HTTP response', async () => {
+    mockFetch.mockResolvedValue(makeResponse({}, false, 401));
+    const result = await fetchTasteInbox('bad-key');
+    expect(result.available).toBe(false);
+    expect(result.error).toContain('401');
+  });
+
+  it('returns unavailable when Linear returns GraphQL errors', async () => {
+    mockFetch.mockResolvedValue(
+      makeResponse({ errors: [{ message: 'Unauthenticated' }] })
+    );
+    const result = await fetchTasteInbox('test-key');
+    expect(result.available).toBe(false);
+    expect(result.error).toContain('Unauthenticated');
+  });
+
+  it('returns unavailable on network failure', async () => {
+    mockFetch.mockRejectedValue(new Error('connection refused'));
+    const result = await fetchTasteInbox('test-key');
+    expect(result.available).toBe(false);
+    expect(result.error).toContain('connection refused');
+  });
+});

--- a/apps/console/lib/linear.ts
+++ b/apps/console/lib/linear.ts
@@ -1,0 +1,174 @@
+const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql';
+
+// Labels that surface items in the Taste Inbox (created manually in Linear).
+// See JOV-3297 / issue #11205 for the label-creation step.
+export const TASTE_INBOX_LABELS = ['needs:taste', 'needs:human'] as const;
+export type TasteInboxLabel = (typeof TASTE_INBOX_LABELS)[number];
+
+export interface TasteIssue {
+  readonly id: string;
+  readonly identifier: string;
+  readonly title: string;
+  readonly url: string;
+  readonly label: TasteInboxLabel;
+  readonly priority: number;
+  readonly priorityLabel: string;
+  readonly createdAt: string;
+  /** One-line description of why this is blocked, pulled from the first line of the description. */
+  readonly blockingReason: string;
+}
+
+export interface TasteInboxResult {
+  readonly issues: TasteIssue[];
+  readonly fetchedAt: string;
+  readonly available: boolean;
+  readonly error?: string;
+}
+
+interface LinearLabelNode {
+  id: string;
+  name: string;
+}
+
+interface LinearIssueNode {
+  id: string;
+  identifier: string;
+  title: string;
+  url: string;
+  priority: number;
+  priorityLabel: string;
+  createdAt: string;
+  description: string | null;
+  labels: { nodes: LinearLabelNode[] };
+}
+
+interface LinearGraphQLResponse {
+  data?: {
+    issues?: { nodes: LinearIssueNode[] };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+function extractBlockingReason(description: string | null): string {
+  if (!description) return '';
+  const firstLine =
+    description.split('\n').find(l => l.trim().length > 0) ?? '';
+  return firstLine.slice(0, 140);
+}
+
+function detectLabel(nodes: LinearLabelNode[]): TasteInboxLabel | null {
+  for (const n of nodes) {
+    if (n.name === 'needs:taste' || n.name === 'needs:human') {
+      return n.name as TasteInboxLabel;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch all open issues labeled `needs:taste` or `needs:human` from Linear.
+ * Returns an empty list if LINEAR_API_KEY is not set.
+ */
+export async function fetchTasteInbox(
+  apiKey: string | undefined
+): Promise<TasteInboxResult> {
+  const fetchedAt = new Date().toISOString();
+
+  if (!apiKey) {
+    return {
+      issues: [],
+      fetchedAt,
+      available: false,
+      error: 'LINEAR_API_KEY not configured',
+    };
+  }
+
+  // Filter by label names directly — avoids hardcoding label IDs that don't exist yet.
+  const query = `
+    query TasteInbox {
+      issues(
+        filter: {
+          state: { type: { in: ["triage", "unstarted", "started"] } }
+          labels: { name: { in: ["needs:taste", "needs:human"] } }
+        }
+        orderBy: priority
+        first: 100
+      ) {
+        nodes {
+          id
+          identifier
+          title
+          url
+          priority
+          priorityLabel
+          createdAt
+          description
+          labels { nodes { id name } }
+        }
+      }
+    }
+  `;
+
+  let res: Response;
+  try {
+    res = await fetch(LINEAR_GRAPHQL_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: apiKey,
+        'Content-Type': 'application/json',
+        'User-Agent': 'Jovie-Console/1.0',
+      },
+      body: JSON.stringify({ query }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err) {
+    return {
+      issues: [],
+      fetchedAt,
+      available: false,
+      error: err instanceof Error ? err.message : 'Network error',
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      issues: [],
+      fetchedAt,
+      available: false,
+      error: `Linear API responded ${res.status}`,
+    };
+  }
+
+  const payload = (await res.json()) as LinearGraphQLResponse;
+
+  if (payload.errors && payload.errors.length > 0) {
+    return {
+      issues: [],
+      fetchedAt,
+      available: false,
+      error: payload.errors[0]?.message ?? 'GraphQL error',
+    };
+  }
+
+  const nodes = payload.data?.issues?.nodes ?? [];
+
+  const issues: TasteIssue[] = nodes
+    .map((n): TasteIssue | null => {
+      const label = detectLabel(n.labels.nodes);
+      if (!label) return null;
+      return {
+        id: n.id,
+        identifier: n.identifier,
+        title: n.title,
+        url: n.url,
+        label,
+        priority: n.priority,
+        priorityLabel: n.priorityLabel,
+        createdAt: n.createdAt,
+        blockingReason: extractBlockingReason(n.description),
+      };
+    })
+    .filter((i): i is TasteIssue => i !== null);
+
+  return { issues, fetchedAt, available: true };
+}

--- a/apps/console/middleware.ts
+++ b/apps/console/middleware.ts
@@ -1,0 +1,60 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const REALM = 'Jovie Internal Console';
+
+function unauthorized(): NextResponse {
+  return new NextResponse('Unauthorized', {
+    status: 401,
+    headers: { 'WWW-Authenticate': `Basic realm="${REALM}"` },
+  });
+}
+
+/**
+ * HTTP Basic Auth gate. Set CONSOLE_USER + CONSOLE_PASSWORD env vars.
+ * Behind a VPN this is sufficient; credentials never hit the consumer app.
+ *
+ * Skip auth for the /api/health probe so load balancers can reach it.
+ */
+export function middleware(request: NextRequest): NextResponse {
+  if (request.nextUrl.pathname === '/api/health') {
+    return NextResponse.next();
+  }
+
+  const user = process.env.CONSOLE_USER;
+  const password = process.env.CONSOLE_PASSWORD;
+
+  // No credentials configured → open access (dev / local).
+  if (!user || !password) {
+    return NextResponse.next();
+  }
+
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader?.startsWith('Basic ')) {
+    return unauthorized();
+  }
+
+  const encoded = authHeader.slice('Basic '.length);
+  let decoded: string;
+  try {
+    decoded = Buffer.from(encoded, 'base64').toString('utf-8');
+  } catch {
+    return unauthorized();
+  }
+
+  const colon = decoded.indexOf(':');
+  if (colon === -1) return unauthorized();
+
+  const inUser = decoded.slice(0, colon);
+  const inPass = decoded.slice(colon + 1);
+
+  if (inUser !== user || inPass !== password) {
+    return unauthorized();
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};

--- a/apps/console/next.config.mjs
+++ b/apps/console/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // ponytail: standalone deploy boundary — no shared Vercel project
+};
+
+export default nextConfig;

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jovie/console",
-  "version": "26.6.53",
+  "version": "26.6.54",
   "private": true,
   "sideEffects": false,
   "engines": {

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@jovie/console",
+  "version": "26.6.53",
+  "private": true,
+  "sideEffects": false,
+  "engines": {
+    "node": ">=22.13.0 <23"
+  },
+  "scripts": {
+    "dev": "next dev --port 3003",
+    "build": "next build",
+    "start": "next start",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "next": "16.2.6",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "4.1.8",
+    "typescript": "^6.0.3",
+    "vitest": "4.1.8"
+  }
+}

--- a/apps/console/tsconfig.json
+++ b/apps/console/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/apps/console/vitest.config.mts
+++ b/apps/console/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+    exclude: ['node_modules', '.next'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,37 @@ importers:
         specifier: 4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  apps/console:
+    dependencies:
+      next:
+        specifier: 16.2.6
+        version: 16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+
   apps/desktop:
     dependencies:
       electron-updater:
@@ -7044,12 +7075,6 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
-  '@types/node@22.19.18':
-    resolution: {integrity: sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==}
-
-  '@types/node@22.19.19':
-    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
-
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
 
@@ -8431,11 +8456,6 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
-  baseline-browser-mapping@2.10.29:
-    resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.10.38:
     resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
     engines: {node: '>=6.0.0'}
@@ -8698,9 +8718,6 @@ packages:
 
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
-
-  caniuse-lite@1.0.30001792:
-    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
@@ -18378,7 +18395,7 @@ snapshots:
       node-gyp: 9.4.1
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
-      semver: 7.8.1
+      semver: 7.8.5
       tar: 7.5.13
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -18945,6 +18962,14 @@ snapshots:
       '@types/node': 22.19.15
     optional: true
 
+  '@inquirer/confirm@5.1.21(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+    optional: true
+
   '@inquirer/confirm@5.1.21(@types/node@25.5.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.5.0)
@@ -18972,6 +18997,20 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 22.19.15
+    optional: true
+
+  '@inquirer/core@10.3.2(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.20.0
     optional: true
 
   '@inquirer/core@10.3.2(@types/node@25.5.0)':
@@ -19104,6 +19143,11 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@22.19.15)':
     optionalDependencies:
       '@types/node': 22.19.15
+    optional: true
+
+  '@inquirer/type@3.0.10(@types/node@22.20.0)':
+    optionalDependencies:
+      '@types/node': 22.20.0
     optional: true
 
   '@inquirer/type@3.0.10(@types/node@25.5.0)':
@@ -21346,7 +21390,7 @@ snapshots:
       '@react-aria/interactions': 3.27.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@react-aria/utils': 3.33.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@react-types/shared': 3.33.1(react@19.2.4)
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -21357,13 +21401,13 @@ snapshots:
       '@react-aria/utils': 3.33.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@react-stately/flags': 3.1.2
       '@react-types/shared': 3.33.1(react@19.2.4)
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
   '@react-aria/ssr@3.9.10(react@19.2.4)':
     dependencies:
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
       react: 19.2.4
 
   '@react-aria/utils@3.33.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
@@ -21372,7 +21416,7 @@ snapshots:
       '@react-stately/flags': 3.1.2
       '@react-stately/utils': 3.11.0(react@19.2.4)
       '@react-types/shared': 3.33.1(react@19.2.4)
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
       clsx: 2.1.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -21461,11 +21505,11 @@ snapshots:
 
   '@react-stately/flags@3.1.2':
     dependencies:
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
 
   '@react-stately/utils@3.11.0(react@19.2.4)':
     dependencies:
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
       react: 19.2.4
 
   '@react-types/shared@3.33.1(react@19.2.4)':
@@ -22177,7 +22221,7 @@ snapshots:
 
   '@slack/logger@4.0.1':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
     optional: true
 
   '@slack/types@2.21.1':
@@ -22187,7 +22231,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.21.1
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
       '@types/retry': 0.12.0
       axios: 1.16.1(debug@4.3.4)
       eventemitter3: 5.0.4
@@ -23379,7 +23423,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
 
   '@types/cors@2.8.19':
     dependencies:
@@ -23539,7 +23583,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
 
   '@types/geojson@7946.0.16': {}
 
@@ -23581,7 +23625,7 @@ snapshots:
   '@types/liftoff@4.0.3':
     dependencies:
       '@types/fined': 1.1.5
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
 
   '@types/md5@2.3.6': {}
 
@@ -23595,7 +23639,7 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
 
   '@types/nlcst@2.0.3':
     dependencies:
@@ -23622,14 +23666,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@22.19.18':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@22.19.19':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.20.0':
     dependencies:
       undici-types: 6.21.0
@@ -23653,7 +23689,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -23667,13 +23703,13 @@ snapshots:
 
   '@types/plist@3.0.5':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.20.0
       xmlbuilder: 15.1.1
     optional: true
 
   '@types/qrcode@1.5.6':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.20.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -23699,7 +23735,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
 
   '@types/through@0.0.33':
     dependencies:
@@ -23738,7 +23774,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 22.20.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -24196,7 +24232,7 @@ snapshots:
       md5: 2.3.0
       nanoid: 3.3.12
       path-to-regexp: 8.4.2
-      semver: 7.8.1
+      semver: 7.8.5
     optionalDependencies:
       '@vercel/analytics': 2.0.1(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/speed-insights': 1.3.1(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -24425,6 +24461,20 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser-playwright@4.1.8(bufferutil@4.1.0)(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(playwright@1.60.0)(utf-8-validate@6.0.6)(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@vitest/browser': 4.1.8(bufferutil@4.1.0)(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(utf-8-validate@6.0.6)(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      playwright: 1.60.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser-playwright@4.1.8(bufferutil@4.1.0)(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.3))(playwright@1.60.0)(utf-8-validate@6.0.6)(vite@6.4.3(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@vitest/browser': 4.1.8(bufferutil@4.1.0)(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.3))(utf-8-validate@6.0.6)(vite@6.4.3(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
@@ -24469,6 +24519,24 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser@4.1.8(bufferutil@4.1.0)(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(utf-8-validate@6.0.6)(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.8(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/browser@4.1.8(bufferutil@4.1.0)(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.3))(utf-8-validate@6.0.6)(vite@6.4.3(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
@@ -24518,9 +24586,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.4(@types/node@22.19.15)(typescript@6.0.3))(vite@6.4.3(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(bufferutil@4.1.0)(msw@2.12.4(@types/node@22.19.15)(typescript@6.0.3))(utf-8-validate@6.0.6)(vite@6.4.3(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser': 4.1.8(bufferutil@4.1.0)(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(utf-8-validate@6.0.6)(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -24547,6 +24615,15 @@ snapshots:
     optionalDependencies:
       msw: 2.12.4(@types/node@22.19.15)(typescript@6.0.3)
       vite: 6.4.3(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.8(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.4(@types/node@22.20.0)(typescript@6.0.3)
+      vite: 8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.8(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.3))(vite@6.4.3(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -25632,8 +25709,6 @@ snapshots:
 
   base64id@2.0.0: {}
 
-  baseline-browser-mapping@2.10.29: {}
-
   baseline-browser-mapping@2.10.38: {}
 
   basic-ftp@5.3.0: {}
@@ -25802,8 +25877,8 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.29
-      caniuse-lite: 1.0.30001792
+      baseline-browser-mapping: 2.10.38
+      caniuse-lite: 1.0.30001799
       electron-to-chromium: 1.5.321
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -26009,8 +26084,6 @@ snapshots:
 
   caniuse-lite@1.0.30001781: {}
 
-  caniuse-lite@1.0.30001792: {}
-
   caniuse-lite@1.0.30001799: {}
 
   cbor-extract@2.2.2:
@@ -26114,7 +26187,7 @@ snapshots:
 
   chrome-launcher@0.13.4:
     dependencies:
-      '@types/node': 22.19.18
+      '@types/node': 22.20.0
       escape-string-regexp: 1.0.5
       is-wsl: 2.2.0
       lighthouse-logger: 1.2.0
@@ -26134,7 +26207,7 @@ snapshots:
 
   chrome-launcher@1.2.1:
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -27261,7 +27334,7 @@ snapshots:
   engine.io@6.6.8(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
       '@types/ws': 8.18.1
       accepts: 1.3.8
       base64id: 2.0.0
@@ -31271,6 +31344,32 @@ snapshots:
       - '@types/node'
     optional: true
 
+  msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@22.20.0)
+      '@mswjs/interceptors': 0.40.0
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.2
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 8.4.2
+      picocolors: 1.1.1
+      rettime: 0.7.0
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.7.0
+      until-async: 3.0.2
+      yargs: 17.7.3
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   msw@2.12.4(@types/node@25.5.0)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@25.5.0)
@@ -31392,8 +31491,8 @@ snapshots:
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.29
-      caniuse-lite: 1.0.30001792
+      baseline-browser-mapping: 2.10.38
+      caniuse-lite: 1.0.30001799
       postcss: 8.5.15
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -32829,7 +32928,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
       '@types/doctrine': 0.0.9
@@ -34031,7 +34130,7 @@ snapshots:
 
   speedline-core@1.4.3:
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 22.20.0
       image-ssim: 0.2.0
       jpeg-js: 0.4.4
 
@@ -35280,6 +35379,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
+  vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.0
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.48.0
+      tsx: 4.21.0
+      yaml: 2.9.0
+
   vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -35323,6 +35438,38 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.15
       '@vitest/browser-playwright': 4.1.8(bufferutil@4.1.0)(msw@2.12.4(@types/node@22.19.15)(typescript@6.0.3))(playwright@1.60.0)(utf-8-validate@6.0.6)(vite@6.4.3(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      jsdom: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.8(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 3.2.0
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.20.0
+      '@vitest/browser-playwright': 4.1.8(bufferutil@4.1.0)(msw@2.12.4(@types/node@22.20.0)(typescript@6.0.3))(playwright@1.60.0)(utf-8-validate@6.0.6)(vite@8.0.16(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       jsdom: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (claude-sonnet-4-6). Closes #11207.

Card: t_181cd5e5
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- API/route 5xx rate + p95 latency on touched endpoints
- client console errors + render of affected pages
- sign-in / session success rate (auth-sensitive)
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a protected console experience with HTTP Basic Authentication
  * Introduced a lightweight `/api/health` endpoint for monitoring
  * Built the “Taste Inbox” page with live Linear issue lists split into **Taste calls** and **Human actions**
* **UI/Styling**
  * Updated the console app shell and added dark-first global styling
  * Redirects the console home page to **/taste-inbox**
* **Tests**
  * Added automated coverage for the Linear inbox fetching logic (including failures and filtering)
  * Improved Axe audit and onboarding smoke-test reliability
* **Chores**
  * Updated console configuration, tooling setup, and CI/audit runtime settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->