### PR TITLE
chore: release-to-Revenue: GMV-per-release attribution + dashboard line (#10965)

### DIFF
--- a/apps/web/app/app/(shell)/admin/ops/ReleaseToRevenueGmvPanel.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/ReleaseToRevenueGmvPanel.tsx
@@ -1,0 +1,72 @@
+import { ContentMetricRow } from '@/components/molecules/ContentMetricRow';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+import { formatUsd } from '@/lib/admin/format';
+import { getDesignPartnerReleaseGmvSnapshot } from '@/lib/release-to-revenue/gmv-attribution';
+
+function formatGmvFromCents(gmvCents: number): string {
+  return formatUsd(gmvCents / 100);
+}
+
+export async function ReleaseToRevenueGmvPanel() {
+  const snapshot = await getDesignPartnerReleaseGmvSnapshot();
+
+  if (!snapshot) {
+    return (
+      <ContentSurfaceCard
+        surface='details'
+        className='space-y-2 p-3'
+        data-testid='release-to-revenue-gmv-panel'
+      >
+        <p className='text-app font-medium text-primary-token'>
+          Release-to-Revenue GMV
+        </p>
+        <p className='text-app text-secondary-token'>
+          Design partner is not configured in this environment.
+        </p>
+      </ContentSurfaceCard>
+    );
+  }
+
+  return (
+    <ContentSurfaceCard
+      surface='details'
+      className='space-y-3 p-3'
+      data-testid='release-to-revenue-gmv-panel'
+    >
+      <div className='space-y-1'>
+        <p className='text-app font-medium text-primary-token'>
+          Release-to-Revenue GMV
+        </p>
+        <p className='text-app text-secondary-token'>
+          Store GMV per autopilot release for @{snapshot.creatorUsername}
+        </p>
+      </div>
+
+      {snapshot.releases.length === 0 ? (
+        <p className='text-app text-secondary-token'>
+          No release autopilot runs yet.
+        </p>
+      ) : (
+        <div className='space-y-2'>
+          {snapshot.releases.map(release => (
+            <div
+              key={release.workflowRunId}
+              data-testid={`release-gmv-row-${release.workflowRunId}`}
+            >
+              <ContentMetricRow
+                label={`${release.releaseTitle} (${release.orderCount.toLocaleString('en-US')} orders)`}
+                value={formatGmvFromCents(release.gmvCents)}
+              />
+            </div>
+          ))}
+          <div data-testid='release-gmv-total'>
+            <ContentMetricRow
+              label={`Total GMV (${snapshot.releases.length.toLocaleString('en-US')} releases)`}
+              value={formatGmvFromCents(snapshot.totalGmvCents)}
+            />
+          </div>
+        </div>
+      )}
+    </ContentSurfaceCard>
+  );
+}

--- a/apps/web/app/app/(shell)/admin/ops/page.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/page.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/testing/nightly-agent-report';
 import { logger } from '@/lib/utils/logger';
 import { HudDashboardClient } from './HudDashboardClient';
+import { ReleaseToRevenueGmvPanel } from './ReleaseToRevenueGmvPanel';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -285,6 +286,8 @@ export default async function AdminOpsPage({
       </div>
 
       <OperationalControlPanel />
+
+      <ReleaseToRevenueGmvPanel />
 
       <HudDashboardClient
         initialMetrics={metrics}

--- a/apps/web/lib/merch/orders.ts
+++ b/apps/web/lib/merch/orders.ts
@@ -21,6 +21,10 @@ import {
   isPrintfulConfigured,
   type PrintfulCreateOrderInput,
 } from '@/lib/printful/client';
+import {
+  RELEASE_GMV_ATTRIBUTION_METADATA_KEY,
+  resolveReleaseWorkflowRunIdForMerchCard,
+} from '@/lib/release-to-revenue/gmv-attribution';
 import { stripe } from '@/lib/stripe/client';
 import { logger } from '@/lib/utils/logger';
 import {
@@ -243,6 +247,9 @@ export async function createMerchCheckoutSession(
     jovieShareEstimateCents,
   });
   const printfulExternalId = `jovie_merch_${crypto.randomUUID()}`;
+  const releaseWorkflowRunId = await resolveReleaseWorkflowRunIdForMerchCard(
+    row.card.id
+  );
 
   const [order] = await db
     .insert(merchOrders)
@@ -268,6 +275,9 @@ export async function createMerchCheckoutSession(
       metadata: {
         source: 'merch_checkout',
         handle: input.handle,
+        ...(releaseWorkflowRunId
+          ? { [RELEASE_GMV_ATTRIBUTION_METADATA_KEY]: releaseWorkflowRunId }
+          : {}),
       },
     })
     .returning();

--- a/apps/web/lib/release-to-revenue/gmv-attribution.test.ts
+++ b/apps/web/lib/release-to-revenue/gmv-attribution.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockResolveMerchCardIdsForRun = vi.hoisted(() => vi.fn());
+const mockDbSelect = vi.hoisted(() => vi.fn());
+
+vi.mock('./store-listing', () => ({
+  resolveMerchCardIdsForRun: mockResolveMerchCardIdsForRun,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mockDbSelect,
+  },
+}));
+
+import {
+  buildReleaseGmvRowForRun,
+  computeStoreGmvCents,
+  isReleaseGmvCountableStatus,
+} from './gmv-attribution';
+
+describe('release-to-revenue GMV attribution', () => {
+  it('counts only paid Printful-backed order subtotals toward GMV', () => {
+    const result = computeStoreGmvCents([
+      { subtotalCents: 2500, status: 'paid' },
+      { subtotalCents: 3000, status: 'shipped' },
+      { subtotalCents: 9999, status: 'checkout_created' },
+      { subtotalCents: 1200, status: 'refunded' },
+    ]);
+
+    expect(result).toEqual({ gmvCents: 5500, orderCount: 2 });
+  });
+
+  it('treats fulfillment pipeline statuses as countable GMV', () => {
+    expect(isReleaseGmvCountableStatus('submitted_to_printful')).toBe(true);
+    expect(isReleaseGmvCountableStatus('fulfilling')).toBe(true);
+    expect(isReleaseGmvCountableStatus('checkout_created')).toBe(false);
+    expect(isReleaseGmvCountableStatus('cancelled')).toBe(false);
+  });
+
+  it('returns zero GMV when no orders qualify', () => {
+    expect(
+      computeStoreGmvCents([
+        { subtotalCents: 4000, status: 'checkout_created' },
+        { subtotalCents: 1500, status: 'failed' },
+      ])
+    ).toEqual({ gmvCents: 0, orderCount: 0 });
+  });
+});
+
+describe('buildReleaseGmvRowForRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rolls up paid orders from a release store listing to the autopilot run', async () => {
+    mockResolveMerchCardIdsForRun.mockResolvedValue(['card-1', 'card-2']);
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            id: 'order-1',
+            merchCardId: 'card-1',
+            subtotalCents: 3200,
+            status: 'paid',
+          },
+          {
+            id: 'order-2',
+            merchCardId: 'card-2',
+            subtotalCents: 1800,
+            status: 'shipped',
+          },
+          {
+            id: 'order-3',
+            merchCardId: 'card-2',
+            subtotalCents: 5000,
+            status: 'checkout_created',
+          },
+        ]),
+      }),
+    });
+
+    const row = await buildReleaseGmvRowForRun({
+      workflowRunId: 'run-1',
+      stepOutputs: {
+        releaseId: 'release-1',
+        triggerSource: 'catalog',
+        triggeredAt: '2026-06-19T00:00:00.000Z',
+        designPartner: {
+          creatorUsername: 'tim',
+          creatorProfileId: 'profile-1',
+          userId: 'user-1',
+          store: { provider: 'printful', scope: 'default' },
+          socialAccount: { platform: 'instagram', handle: 'tim' },
+          smsListId: 'sms-1',
+        },
+        release: {
+          title: 'Night Drive',
+          artworkUrl: null,
+          links: [],
+        },
+        storeListing: { merchCardIds: ['card-1', 'card-2'] },
+      },
+    });
+
+    expect(row).toMatchObject({
+      workflowRunId: 'run-1',
+      releaseId: 'release-1',
+      releaseTitle: 'Night Drive',
+      merchCardIds: ['card-1', 'card-2'],
+      orderCount: 2,
+      gmvCents: 5000,
+    });
+  });
+});

--- a/apps/web/lib/release-to-revenue/gmv-attribution.ts
+++ b/apps/web/lib/release-to-revenue/gmv-attribution.ts
@@ -1,0 +1,180 @@
+import 'server-only';
+
+import { and, sql as drizzleSql, eq, inArray } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { workflowRuns } from '@/lib/db/schema/connectors';
+import { type MerchOrder, merchOrders } from '@/lib/db/schema/merch';
+import { resolveDesignPartnerConfig } from './design-partner-config';
+import { resolveMerchCardIdsForRun } from './store-listing';
+import type {
+  DesignPartnerReleaseGmvSnapshot,
+  ReleaseGmvPerRunRow,
+  ReleaseToRevenueRunStepOutputs,
+} from './types';
+import { RELEASE_TO_REVENUE_WORKFLOW_KIND } from './types';
+
+export const RELEASE_GMV_COUNTABLE_ORDER_STATUSES = [
+  'paid',
+  'paid_fulfillment_hold',
+  'paid_fulfillment_failed',
+  'printful_draft_created',
+  'submitted_to_printful',
+  'fulfilling',
+  'shipped',
+  'delivered',
+] as const satisfies readonly MerchOrder['status'][];
+
+export const RELEASE_GMV_ATTRIBUTION_METADATA_KEY = 'releaseWorkflowRunId';
+
+export function isReleaseGmvCountableStatus(
+  status: MerchOrder['status']
+): boolean {
+  return (RELEASE_GMV_COUNTABLE_ORDER_STATUSES as readonly string[]).includes(
+    status
+  );
+}
+
+/** Store GMV uses paid order subtotals (Printful-backed storefront product revenue). */
+export function computeStoreGmvCents(
+  orders: readonly Pick<MerchOrder, 'subtotalCents' | 'status'>[]
+): { readonly gmvCents: number; readonly orderCount: number } {
+  let gmvCents = 0;
+  let orderCount = 0;
+
+  for (const order of orders) {
+    if (!isReleaseGmvCountableStatus(order.status)) {
+      continue;
+    }
+    gmvCents += order.subtotalCents;
+    orderCount += 1;
+  }
+
+  return { gmvCents, orderCount };
+}
+
+export async function getPaidOrdersForMerchCards(
+  merchCardIds: readonly string[]
+): Promise<
+  Pick<MerchOrder, 'id' | 'merchCardId' | 'subtotalCents' | 'status'>[]
+> {
+  if (merchCardIds.length === 0) {
+    return [];
+  }
+
+  return db
+    .select({
+      id: merchOrders.id,
+      merchCardId: merchOrders.merchCardId,
+      subtotalCents: merchOrders.subtotalCents,
+      status: merchOrders.status,
+    })
+    .from(merchOrders)
+    .where(inArray(merchOrders.merchCardId, [...merchCardIds]));
+}
+
+export async function buildReleaseGmvRowForRun(input: {
+  readonly workflowRunId: string;
+  readonly stepOutputs: ReleaseToRevenueRunStepOutputs;
+}): Promise<ReleaseGmvPerRunRow> {
+  const merchCardIds = await resolveMerchCardIdsForRun(input.stepOutputs);
+  const orders = await getPaidOrdersForMerchCards(merchCardIds);
+  const { gmvCents, orderCount } = computeStoreGmvCents(orders);
+
+  return {
+    workflowRunId: input.workflowRunId,
+    releaseId: input.stepOutputs.releaseId,
+    releaseTitle: input.stepOutputs.release.title,
+    triggeredAt: input.stepOutputs.triggeredAt,
+    merchCardIds,
+    orderCount,
+    gmvCents,
+  };
+}
+
+export async function getDesignPartnerReleaseGmvSnapshot(): Promise<DesignPartnerReleaseGmvSnapshot | null> {
+  const designPartner = await resolveDesignPartnerConfig();
+  if (!designPartner) {
+    return null;
+  }
+
+  const runs = await db
+    .select({
+      id: workflowRuns.id,
+      stepOutputs: workflowRuns.stepOutputs,
+      createdAt: workflowRuns.createdAt,
+    })
+    .from(workflowRuns)
+    .where(
+      and(
+        eq(workflowRuns.userId, designPartner.userId),
+        eq(workflowRuns.kind, RELEASE_TO_REVENUE_WORKFLOW_KIND)
+      )
+    )
+    .orderBy(drizzleSql`${workflowRuns.createdAt} DESC`);
+
+  const releases: ReleaseGmvPerRunRow[] = [];
+  for (const run of runs) {
+    const stepOutputs = run.stepOutputs as ReleaseToRevenueRunStepOutputs;
+    if (!stepOutputs?.release?.title) {
+      continue;
+    }
+    releases.push(
+      await buildReleaseGmvRowForRun({
+        workflowRunId: run.id,
+        stepOutputs,
+      })
+    );
+  }
+
+  const totalGmvCents = releases.reduce(
+    (sum, release) => sum + release.gmvCents,
+    0
+  );
+
+  return {
+    creatorUsername: designPartner.creatorUsername,
+    generatedAtIso: new Date().toISOString(),
+    releases,
+    totalGmvCents,
+  };
+}
+
+export async function resolveReleaseWorkflowRunIdForMerchCard(
+  merchCardId: string
+): Promise<string | null> {
+  const [explicit] = await db
+    .select({ id: workflowRuns.id })
+    .from(workflowRuns)
+    .where(
+      and(
+        eq(workflowRuns.kind, RELEASE_TO_REVENUE_WORKFLOW_KIND),
+        drizzleSql`${workflowRuns.stepOutputs}->'storeListing'->'merchCardIds' @> ${JSON.stringify([merchCardId])}::jsonb`
+      )
+    )
+    .orderBy(drizzleSql`${workflowRuns.createdAt} DESC`)
+    .limit(1);
+
+  if (explicit?.id) {
+    return explicit.id;
+  }
+
+  const runs = await db
+    .select({
+      id: workflowRuns.id,
+      stepOutputs: workflowRuns.stepOutputs,
+      createdAt: workflowRuns.createdAt,
+    })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.kind, RELEASE_TO_REVENUE_WORKFLOW_KIND))
+    .orderBy(drizzleSql`${workflowRuns.createdAt} DESC`);
+
+  for (const run of runs) {
+    const stepOutputs = run.stepOutputs as ReleaseToRevenueRunStepOutputs;
+    const merchCardIds = await resolveMerchCardIdsForRun(stepOutputs);
+    if (merchCardIds.includes(merchCardId)) {
+      return run.id;
+    }
+  }
+
+  return null;
+}

--- a/apps/web/lib/release-to-revenue/store-listing.test.ts
+++ b/apps/web/lib/release-to-revenue/store-listing.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeStoreListingMerchCardIds,
+  normalizeStoreListing,
+} from './store-listing';
+
+describe('release-to-revenue store listing helpers', () => {
+  it('deduplicates linked merch card ids', () => {
+    expect(
+      normalizeStoreListing({
+        merchCardIds: ['card-a', 'card-a', 'card-b', ''],
+      })
+    ).toEqual({ merchCardIds: ['card-a', 'card-b'] });
+  });
+
+  it('merges explicit and discovered merch card ids without duplicates', () => {
+    expect(
+      mergeStoreListingMerchCardIds({ merchCardIds: ['card-a'] }, [
+        'card-a',
+        'card-b',
+      ])
+    ).toEqual({ merchCardIds: ['card-a', 'card-b'] });
+  });
+});

--- a/apps/web/lib/release-to-revenue/store-listing.ts
+++ b/apps/web/lib/release-to-revenue/store-listing.ts
@@ -1,0 +1,146 @@
+import 'server-only';
+
+import { and, eq, isNotNull, like } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { workflowRuns } from '@/lib/db/schema/connectors';
+import { merchGenerationBatches } from '@/lib/db/schema/merch';
+import { RELEASE_AUTOPILOT_MERCH_COMMAND } from '@/lib/services/release-autopilot/types';
+import type {
+  ReleaseToRevenueRunStepOutputs,
+  ReleaseToRevenueStoreListing,
+} from './types';
+import { RELEASE_TO_REVENUE_WORKFLOW_KIND } from './types';
+
+const RELEASE_ID_PROMPT_PREFIX = 'release_id:';
+
+function releasePromptPrefix(releaseId: string): string {
+  return `${RELEASE_ID_PROMPT_PREFIX}${releaseId}`;
+}
+
+export function normalizeStoreListing(
+  storeListing: ReleaseToRevenueStoreListing | undefined
+): ReleaseToRevenueStoreListing {
+  const merchCardIds = storeListing?.merchCardIds ?? [];
+  const uniqueIds = [
+    ...new Set(merchCardIds.filter(id => id.trim().length > 0)),
+  ];
+  return { merchCardIds: uniqueIds };
+}
+
+export function mergeStoreListingMerchCardIds(
+  storeListing: ReleaseToRevenueStoreListing | undefined,
+  merchCardIds: readonly string[]
+): ReleaseToRevenueStoreListing {
+  const current = normalizeStoreListing(storeListing);
+  return normalizeStoreListing({
+    merchCardIds: [...current.merchCardIds, ...merchCardIds],
+  });
+}
+
+export async function findMerchCardIdsForRelease(
+  releaseId: string
+): Promise<string[]> {
+  const batches = await db
+    .select({
+      merchCardId: merchGenerationBatches.selectedMerchCardId,
+    })
+    .from(merchGenerationBatches)
+    .where(
+      and(
+        eq(merchGenerationBatches.command, RELEASE_AUTOPILOT_MERCH_COMMAND),
+        like(
+          merchGenerationBatches.prompt,
+          `${releasePromptPrefix(releaseId)}%`
+        ),
+        isNotNull(merchGenerationBatches.selectedMerchCardId)
+      )
+    );
+
+  return [
+    ...new Set(
+      batches
+        .map(batch => batch.merchCardId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    ),
+  ];
+}
+
+export async function resolveMerchCardIdsForRun(
+  stepOutputs: ReleaseToRevenueRunStepOutputs
+): Promise<string[]> {
+  const linked = normalizeStoreListing(stepOutputs.storeListing).merchCardIds;
+  if (linked.length > 0) {
+    return [...linked];
+  }
+
+  if (!stepOutputs.releaseId) {
+    return [];
+  }
+
+  return findMerchCardIdsForRelease(stepOutputs.releaseId);
+}
+
+export async function linkMerchCardToReleaseRun(input: {
+  readonly workflowRunId: string;
+  readonly merchCardId: string;
+}): Promise<ReleaseToRevenueStoreListing> {
+  const [run] = await db
+    .select({
+      id: workflowRuns.id,
+      kind: workflowRuns.kind,
+      stepOutputs: workflowRuns.stepOutputs,
+    })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.id, input.workflowRunId))
+    .limit(1);
+
+  if (!run || run.kind !== RELEASE_TO_REVENUE_WORKFLOW_KIND) {
+    throw new Error('Release-to-revenue workflow run not found');
+  }
+
+  const stepOutputs = run.stepOutputs as ReleaseToRevenueRunStepOutputs;
+  const storeListing = mergeStoreListingMerchCardIds(stepOutputs.storeListing, [
+    input.merchCardId,
+  ]);
+
+  await db
+    .update(workflowRuns)
+    .set({
+      stepOutputs: {
+        ...stepOutputs,
+        storeListing,
+      },
+      updatedAt: new Date(),
+    })
+    .where(eq(workflowRuns.id, input.workflowRunId));
+
+  return storeListing;
+}
+
+export async function syncStoreListingForRun(input: {
+  readonly workflowRunId: string;
+  readonly stepOutputs: ReleaseToRevenueRunStepOutputs;
+}): Promise<ReleaseToRevenueStoreListing> {
+  const discovered = await resolveMerchCardIdsForRun(input.stepOutputs);
+  if (discovered.length === 0) {
+    return normalizeStoreListing(input.stepOutputs.storeListing);
+  }
+
+  const storeListing = mergeStoreListingMerchCardIds(
+    input.stepOutputs.storeListing,
+    discovered
+  );
+
+  await db
+    .update(workflowRuns)
+    .set({
+      stepOutputs: {
+        ...input.stepOutputs,
+        storeListing,
+      },
+      updatedAt: new Date(),
+    })
+    .where(eq(workflowRuns.id, input.workflowRunId));
+
+  return storeListing;
+}

--- a/apps/web/lib/release-to-revenue/types.ts
+++ b/apps/web/lib/release-to-revenue/types.ts
@@ -40,12 +40,36 @@ export interface ResolvedDesignPartnerConfig
   readonly userId: string;
 }
 
+export interface ReleaseToRevenueStoreListing {
+  /** Merch cards published as the release store listing for this autopilot run. */
+  readonly merchCardIds: readonly string[];
+}
+
 export interface ReleaseToRevenueRunStepOutputs {
   readonly releaseId: string | null;
   readonly triggerSource: ReleaseToRevenueTriggerSource;
   readonly triggeredAt: string;
   readonly designPartner: ResolvedDesignPartnerConfig;
   readonly release: ReleaseToRevenueReleaseMetadata;
+  readonly storeListing?: ReleaseToRevenueStoreListing;
+}
+
+export interface ReleaseGmvPerRunRow {
+  readonly workflowRunId: string;
+  readonly releaseId: string | null;
+  readonly releaseTitle: string;
+  readonly triggeredAt: string;
+  readonly merchCardIds: readonly string[];
+  readonly orderCount: number;
+  /** Store GMV in cents (paid Printful-backed order subtotals). */
+  readonly gmvCents: number;
+}
+
+export interface DesignPartnerReleaseGmvSnapshot {
+  readonly creatorUsername: string;
+  readonly generatedAtIso: string;
+  readonly releases: readonly ReleaseGmvPerRunRow[];
+  readonly totalGmvCents: number;
 }
 
 export interface ManualReleaseTriggerInput {

--- a/apps/web/lib/release-to-revenue/workflows/initialize-run.test.ts
+++ b/apps/web/lib/release-to-revenue/workflows/initialize-run.test.ts
@@ -30,6 +30,14 @@ vi.mock('@/lib/utils/logger', () => ({
   },
 }));
 
+const mockSyncStoreListingForRun = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ merchCardIds: ['card-1'] })
+);
+
+vi.mock('../store-listing', () => ({
+  syncStoreListingForRun: mockSyncStoreListingForRun,
+}));
+
 import { RELEASE_TO_REVENUE_WORKFLOW_KIND } from '../types';
 import { initializeReleaseToRevenueRun } from './initialize-run';
 
@@ -59,6 +67,13 @@ describe('initializeReleaseToRevenueRun', () => {
 
     await initializeReleaseToRevenueRun({ workflowRunId: 'run-1' });
 
+    expect(mockSyncStoreListingForRun).toHaveBeenCalledWith({
+      workflowRunId: 'run-1',
+      stepOutputs: {
+        releaseId: 'release-1',
+        release: { title: 'Launch Track' },
+      },
+    });
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'waiting_for_approval',

--- a/apps/web/lib/release-to-revenue/workflows/initialize-run.ts
+++ b/apps/web/lib/release-to-revenue/workflows/initialize-run.ts
@@ -10,6 +10,7 @@ import { markWorkflowFailed } from '@/lib/connectors/workflows/execute-approved-
 import { db } from '@/lib/db';
 import { workflowRuns } from '@/lib/db/schema/connectors';
 import { logger } from '@/lib/utils/logger';
+import { syncStoreListingForRun } from '../store-listing';
 import type { ReleaseToRevenueRunStepOutputs } from '../types';
 import { RELEASE_TO_REVENUE_WORKFLOW_KIND } from '../types';
 
@@ -47,6 +48,11 @@ export async function initializeReleaseToRevenueRun(
     return;
   }
 
+  const storeListing = await syncStoreListingForRun({
+    workflowRunId: input.workflowRunId,
+    stepOutputs,
+  });
+
   await db
     .update(workflowRuns)
     .set({
@@ -65,5 +71,6 @@ export async function initializeReleaseToRevenueRun(
     workflowRunId: input.workflowRunId,
     releaseId: stepOutputs.releaseId,
     title: stepOutputs.release.title,
+    merchCardIds: storeListing.merchCardIds,
   });
 }


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (grok-composer-2.5-fast). Closes #10965.

Card: t_7f418e41
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- API/route 5xx rate + p95 latency on touched endpoints
- client console errors + render of affected pages
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.