### PR TITLE
fix(design-system): converge AlertGrowthLanding text-size arbitraries to tokens

### DIFF
--- a/apps/web/components/features/alerts/AlertGrowthLanding.tsx
+++ b/apps/web/components/features/alerts/AlertGrowthLanding.tsx
@@ -299,7 +299,8 @@ export function AlertGrowthLanding({
                     type='email'
                     inputMode='email'
                     autoComplete='email'
-                    placeholder='You@example.com'
+                    // eslint-disable-next-line @jovie/canonical-ui-label-casing
+                    placeholder='you@example.com'
                     aria-describedby={consentId}
                     value={emailInput}
                     onChange={e => setEmailInput(e.target.value)}

--- a/apps/web/components/features/alerts/AlertGrowthLanding.tsx
+++ b/apps/web/components/features/alerts/AlertGrowthLanding.tsx
@@ -231,10 +231,10 @@ export function AlertGrowthLanding({
       <div className='mx-auto flex min-h-dvh max-w-[430px] flex-col px-5 py-10 sm:py-12'>
         <header className='mb-6'>
           <p className='text-secondary-token text-[13px]'>{APP_LABEL}</p>
-          <h1 className='mt-2 text-[24px] font-semibold leading-[1.08] tracking-normal'>
-            Get alerts first.
+          <h1 className='mt-2 text-2xl font-semibold leading-[1.08] tracking-normal'>
+            Get Alerts First.
           </h1>
-          <p className='text-secondary-token mt-3 max-w-[28rem] text-[14px] leading-5'>
+          <p className='text-secondary-token mt-3 max-w-[28rem] text-sm leading-5'>
             Text or email alerts for new music, shows, and major updates from{' '}
             <span className='text-primary-token'>{artistName}</span>.
           </p>
@@ -257,13 +257,13 @@ export function AlertGrowthLanding({
               <ChannelToggle
                 pressed={channel === 'sms'}
                 disabled={isPending}
-                label='Text me'
+                label='Text Me'
                 onSelect={() => handleChannelChange('sms')}
               />
               <ChannelToggle
                 pressed={channel === 'email'}
                 disabled={isPending}
-                label='Email me'
+                label='Email Me'
                 onSelect={() => handleChannelChange('email')}
               />
             </fieldset>
@@ -285,7 +285,7 @@ export function AlertGrowthLanding({
                     value={phoneInput}
                     onChange={e => setPhoneInput(e.target.value)}
                     disabled={isPending}
-                    className='border-subtle bg-surface-0 text-primary-token focus-visible:ring-accent h-12 w-full rounded-[var(--profile-action-radius)] border px-3.5 text-[16px] focus:outline-none focus-visible:ring-2'
+                    className='border-subtle bg-surface-0 text-primary-token focus-visible:ring-accent h-12 w-full rounded-[var(--profile-action-radius)] border px-3.5 text-base focus:outline-none focus-visible:ring-2'
                   />
                 </>
               ) : (
@@ -299,12 +299,12 @@ export function AlertGrowthLanding({
                     type='email'
                     inputMode='email'
                     autoComplete='email'
-                    placeholder='you@example.com'
+                    placeholder='You@example.com'
                     aria-describedby={consentId}
                     value={emailInput}
                     onChange={e => setEmailInput(e.target.value)}
                     disabled={isPending}
-                    className='border-subtle bg-surface-0 text-primary-token focus-visible:ring-accent h-12 w-full rounded-[var(--profile-action-radius)] border px-3.5 text-[16px] focus:outline-none focus-visible:ring-2'
+                    className='border-subtle bg-surface-0 text-primary-token focus-visible:ring-accent h-12 w-full rounded-[var(--profile-action-radius)] border px-3.5 text-base focus:outline-none focus-visible:ring-2'
                   />
                 </>
               )}
@@ -313,7 +313,7 @@ export function AlertGrowthLanding({
             <button
               type='submit'
               disabled={isPending}
-              className='h-12 w-full rounded-[var(--profile-action-radius)] border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-[14px] font-semibold text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover disabled:opacity-60'
+              className='h-12 w-full rounded-[var(--profile-action-radius)] border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-sm font-semibold text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover disabled:opacity-60'
             >
               {isPending ? 'Sending…' : 'Get alerts'}
             </button>
@@ -413,7 +413,7 @@ function SubscribedState({
         data-testid='alerts-landing-pending'
       >
         <h2 className='text-primary-token text-[17px] font-semibold tracking-normal'>
-          Check your {channel === 'sms' ? 'phone' : 'inbox'}.
+          Check Your {channel === 'sms' ? 'phone' : 'inbox'}.
         </h2>
         <p className='text-secondary-token mt-2 text-sm'>
           {channel === 'sms'
@@ -431,7 +431,7 @@ function SubscribedState({
       data-testid='alerts-landing-success'
     >
       <h2 className='text-primary-token text-[17px] font-semibold tracking-normal'>
-        You&apos;re on the list.
+        You&apos;re On The List.
       </h2>
       <p className='text-secondary-token mt-2 text-sm'>
         {channel === 'sms'

--- a/apps/web/tests/unit/components/alerts/AlertGrowthLanding.test.tsx
+++ b/apps/web/tests/unit/components/alerts/AlertGrowthLanding.test.tsx
@@ -111,7 +111,7 @@ describe('<AlertGrowthLanding>', () => {
     render(<AlertGrowthLanding artist={ARTIST} />);
 
     fireEvent.click(screen.getByRole('button', { name: /Email me/i }));
-    fireEvent.change(screen.getByPlaceholderText(/you@example/i), {
+    fireEvent.change(screen.getByPlaceholderText(/you@example/), {
       target: { value: '  Fan@Example.com  ' },
     });
     fireEvent.submit(screen.getByRole('button', { name: /Get alerts/i }));
@@ -184,7 +184,7 @@ describe('<AlertGrowthLanding>', () => {
 
     render(<AlertGrowthLanding artist={ARTIST} />);
     fireEvent.click(screen.getByRole('button', { name: /Email me/i }));
-    fireEvent.change(screen.getByPlaceholderText(/you@example/i), {
+    fireEvent.change(screen.getByPlaceholderText(/you@example/), {
       target: { value: 'fan@example.com' },
     });
     fireEvent.submit(screen.getByRole('button', { name: /Get alerts/i }));

--- a/apps/web/tests/unit/components/alerts/AlertGrowthLanding.test.tsx
+++ b/apps/web/tests/unit/components/alerts/AlertGrowthLanding.test.tsx
@@ -111,7 +111,7 @@ describe('<AlertGrowthLanding>', () => {
     render(<AlertGrowthLanding artist={ARTIST} />);
 
     fireEvent.click(screen.getByRole('button', { name: /Email me/i }));
-    fireEvent.change(screen.getByPlaceholderText(/you@example/), {
+    fireEvent.change(screen.getByPlaceholderText(/you@example/i), {
       target: { value: '  Fan@Example.com  ' },
     });
     fireEvent.submit(screen.getByRole('button', { name: /Get alerts/i }));
@@ -184,7 +184,7 @@ describe('<AlertGrowthLanding>', () => {
 
     render(<AlertGrowthLanding artist={ARTIST} />);
     fireEvent.click(screen.getByRole('button', { name: /Email me/i }));
-    fireEvent.change(screen.getByPlaceholderText(/you@example/), {
+    fireEvent.change(screen.getByPlaceholderText(/you@example/i), {
       target: { value: 'fan@example.com' },
     });
     fireEvent.submit(screen.getByRole('button', { name: /Get alerts/i }));

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 5066,
+  "count": 5061,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

Convergence pass on `apps/web/components/features/alerts/AlertGrowthLanding.tsx` — replaces arbitrary text-size values with canonical design-system token equivalents.

### Token replacements (5 substitutions, no visual change)

| Before | After | Why safe |
|--------|-------|----------|
| `text-[24px]` on `<h1>` | `text-2xl` | `--text-2xl: 1.5rem = 24px`; line-height overridden by explicit `leading-[1.08]` |
| `text-[14px]` on description `<p>` | `text-sm` | `--text-sm: 0.875rem = 14px`; line-height pinned by explicit `leading-5` |
| `text-[16px]` on phone `<input>` | `text-base` | `--text-base: 1rem = 16px`; ≥16px preserves iOS no-zoom; fixed `h-12` container |
| `text-[16px]` on email `<input>` | `text-base` | Same as above |
| `text-[14px]` on submit `<button>` | `text-sm` | `--text-sm: 14px`; fixed `h-12` container prevents reflow |

### Left unchanged (no exact token or semantic reason)

- `rounded-[var(--profile-action-radius)]` × 6 — CSS custom property, semantic coupling
- `rounded-[var(--profile-card-radius)]` × 2 — CSS custom property, semantic coupling
- `text-[13px]` × 4 — between `text-xs` (12px) and `text-sm` (14px), no exact match
- `text-[17px]` × 2 — between `text-base` (16px) and `text-lg` (18px), no exact match
- `leading-[1.08]` × 1 — no standard Tailwind equivalent
- `max-w-[430px]`, `max-w-[28rem]` × 1 each — layout-specific

### ESLint casing fixes (mandatory — pre-existing violations surfaced by lint-staged)

`@jovie/canonical-ui-label-casing` requires Title Case on headings and button labels. Five pre-existing violations fixed; one suppressed:

- `h1`: "Get alerts first." → "Get Alerts First."
- `label='Text me'` → `label='Text Me'`
- `label='Email me'` → `label='Email Me'`
- `h2`: "Check your phone/inbox." → "Check Your phone/inbox."
- `h2`: "You're on the list." → "You're On The List."
- `placeholder='you@example.com'` — left as-is (lowercase); `// eslint-disable-next-line @jovie/canonical-ui-label-casing` added because placeholder text is example data, not a UI label — Title-casing an email address placeholder degrades usability.

### Ratchet

| | Count |
|---|---|
| Baseline before (main after artists page #11263) | 5066 |
| Baseline after | **5061** |
| Reduction from this PR | −5 |

Baseline 5061 = 5066 (main after artists page #11263 merged) − 5 (AlertGrowthLanding replacements in this PR).

## Verification

- [x] `pnpm --filter @jovie/web run typecheck` — pass
- [x] `pnpm biome check --write apps/web/components/features/alerts/AlertGrowthLanding.tsx` — pass
- [x] `pnpm --filter web exec vitest run tests/unit/components/alerts/AlertGrowthLanding.test.tsx` — pass (16/16)
- [x] Pre-commit hooks — pass (gitleaks, trufflehog, proxy-guard, typecheck, biome, eslint)
- [x] Rebased on main (c9fa9de on top of cbd4517); baseline conflict resolved to 5061
