### PR TITLE
fix(design-system): converge EntityCard arbitrary values to tokens (−14)

### DIFF
--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -30,22 +30,22 @@ type SizeConfig = {
 // divergent layouts. "Adapt to real estate" = scale + reveal, single design.
 const SIZE: Record<EntityTreatment, SizeConfig> = {
   compact: {
-    artClass: 'aspect-square rounded-[12px]',
-    titleClass: 'text-[14px]',
+    artClass: 'aspect-square rounded-xl',
+    titleClass: 'text-sm',
     showStatus: false,
     showMeta: true,
     ctaBlock: false,
   },
   detailed: {
-    artClass: 'aspect-square rounded-[12px]',
-    titleClass: 'text-[15px]',
+    artClass: 'aspect-square rounded-xl',
+    titleClass: 'text-mid',
     showStatus: true,
     showMeta: true,
     ctaBlock: false,
   },
   big: {
-    artClass: 'aspect-[4/5] rounded-[16px]',
-    titleClass: 'text-[20px]',
+    artClass: 'aspect-[4/5] rounded-2xl',
+    titleClass: 'text-xl',
     showStatus: true,
     showMeta: true,
     ctaBlock: true,
@@ -131,7 +131,7 @@ export function EntityCard({
         'group flex min-w-0 flex-col gap-3 p-3 text-left transition-[background-color,border-color] duration-subtle focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]',
         isPearl
           ? 'rounded-[var(--profile-inner-radius)] border border-[color:var(--profile-pearl-border)] bg-[color:var(--profile-pearl-bg)] shadow-[var(--profile-pearl-shadow)] backdrop-blur-2xl hover:bg-[color:var(--profile-pearl-bg-hover)]'
-          : 'rounded-[16px] border border-subtle bg-surface-1 shadow-card hover:border-default',
+          : 'rounded-2xl border border-subtle bg-surface-1 shadow-card hover:border-default',
         className
       )}
     >
@@ -155,7 +155,7 @@ export function EntityCard({
           />
         ) : model.datePill ? (
           <div className='flex flex-col items-center justify-center text-primary-token'>
-            <span className='text-[11px] font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
+            <span className='text-2xs font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
               {model.datePill.month}
             </span>
             <span className='text-[34px] font-[680] leading-none tracking-[-0.02em] tabular-nums'>
@@ -169,12 +169,12 @@ export function EntityCard({
 
       <div className='flex min-w-0 flex-1 flex-col gap-1.5'>
         <div className='flex min-w-0 items-center justify-between gap-2'>
-          <span className='inline-flex min-w-0 items-center gap-1.5 text-[10px] font-semibold uppercase leading-none tracking-[0.08em] text-tertiary-token'>
+          <span className='inline-flex min-w-0 items-center gap-1.5 text-3xs font-semibold uppercase leading-none tracking-[0.08em] text-tertiary-token'>
             <Icon className='h-3 w-3 shrink-0' aria-hidden='true' />
             <span className='truncate'>{model.eyebrow ?? preset.eyebrow}</span>
           </span>
           {size.showStatus && model.status ? (
-            <span className='inline-flex shrink-0 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.06em] text-secondary-token'>
+            <span className='inline-flex shrink-0 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.06em] text-secondary-token'>
               <span
                 className='h-1.5 w-1.5 shrink-0 rounded-full'
                 style={{ background: statusDotVar(model.status.tone) }}
@@ -208,11 +208,11 @@ export function EntityCard({
         >
           {model.price ? (
             <div className='min-w-0'>
-              <span className='text-[14px] font-[680] text-primary-token'>
+              <span className='text-sm font-[680] text-primary-token'>
                 {model.price.original ? (
                   <>
                     {model.price.display}
-                    <span className='ml-1 text-[11px] font-medium text-tertiary-token line-through'>
+                    <span className='ml-1 text-2xs font-medium text-tertiary-token line-through'>
                       {model.price.original}
                     </span>
                   </>
@@ -221,7 +221,7 @@ export function EntityCard({
                 )}
               </span>
               {model.price.profit ? (
-                <p className='text-[11px] text-tertiary-token'>
+                <p className='text-2xs text-tertiary-token'>
                   Profit {model.price.profit}
                 </p>
               ) : null}
@@ -233,7 +233,7 @@ export function EntityCard({
           {model.cta ? (
             <span
               className={cn(
-                'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-[12px] font-[560] text-btn-primary-foreground transition-colors duration-subtle group-hover:border-(--linear-btn-primary-hover) group-hover:bg-btn-primary-hover',
+                'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle group-hover:border-(--linear-btn-primary-hover) group-hover:bg-btn-primary-hover',
                 size.ctaBlock ? 'h-11 w-full' : 'h-8'
               )}
             >

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 6375,
+  "count": 6361,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

Converges `EntityCard.tsx` (organisms/entity-card) from arbitrary Tailwind values to canonical design-system token utilities. One file, 14 replacements, no visual change.

**Replacements made:**

| Before | After | Count |
|--------|-------|-------|
| `rounded-[12px]` | `rounded-xl` | ×2 |
| `rounded-[16px]` | `rounded-2xl` | ×2 |
| `text-[14px]` | `text-sm` | ×2 |
| `text-[15px]` | `text-mid` | ×1 |
| `text-[20px]` | `text-xl` | ×1 |
| `text-[11px]` | `text-2xs` | ×3 |
| `text-[10px]` | `text-3xs` | ×2 |
| `text-[12px]` | `text-xs` | ×1 |

**Left unchanged (no exact token equivalent):** CSS-variable pearl-surface values (`rounded-[var(...)]`, `bg-[color:var(...)]`, `shadow-[var(...)]`), custom font weights (`font-[680/590/560]`), non-standard tracking values, `text-[34px]`, `text-[11.5px]`, `aspect-[4/5]`, `transition-[background-color,border-color]`.

## Ratchet

| Metric | Value |
|--------|-------|
| Baseline before | 6375 |
| Baseline after | 6361 |
| Delta | −14 |

File: `apps/web/tests/unit/design-system/arbitrary-values.baseline.json` updated in same commit.

## Verification

- [ ] TypeScript: no new types touched (pure className string changes)
- [ ] Token validity: `text-2xs`/`text-3xs`/`text-mid` confirmed in `@theme` block at `apps/web/app/globals.css:535`; used in existing production components
- [ ] `rounded-xl` = 0.75rem (12 px) and `rounded-2xl` = 1rem (16 px) per Tailwind v4 defaults
- [ ] `EntityCard.tsx` not touched by any of the 10 other big-PR design-system sweeps in the queue (#11218–#11228) — no merge conflict expected

🤖 Scheduled design-system convergence run · 2026-06-20

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSKTW2fosN9b3JVVgb9Hzs)_