### PR TITLE
fix(design-system): converge artists page text-size arbitraries to tokens (−13)

### DIFF
--- a/apps/web/app/artists/page.tsx
+++ b/apps/web/app/artists/page.tsx
@@ -60,27 +60,27 @@ export default async function ArtistsPage() {
               <p className='text-2xl font-semibold tracking-[-0.03em] text-primary-token'>
                 {profiles.length}
               </p>
-              <p className='text-[12px] font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
+              <p className='text-xs font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
                 Public profiles
               </p>
-              <p className='text-[13px] leading-5 text-secondary-token'>
+              <p className='text-app leading-5 text-secondary-token'>
                 Creator pages currently available to browse.
               </p>
             </ContentSurfaceCard>
             <ContentSurfaceCard surface='nested' className='space-y-1 p-4'>
-              <p className='text-[13px] font-semibold text-primary-token'>
+              <p className='text-app font-semibold text-primary-token'>
                 Discover artists
               </p>
-              <p className='text-[13px] leading-5 text-secondary-token'>
+              <p className='text-app leading-5 text-secondary-token'>
                 Browse creator pages, profile themes, and public fan
                 experiences.
               </p>
             </ContentSurfaceCard>
             <ContentSurfaceCard surface='nested' className='space-y-1 p-4'>
-              <p className='text-[13px] font-semibold text-primary-token'>
+              <p className='text-app font-semibold text-primary-token'>
                 Jump straight in
               </p>
-              <p className='text-[13px] leading-5 text-secondary-token'>
+              <p className='text-app leading-5 text-secondary-token'>
                 Every card opens the artist&apos;s public profile in one click.
               </p>
             </ContentSurfaceCard>
@@ -111,21 +111,21 @@ export default async function ArtistsPage() {
                   </div>
 
                   <div className='space-y-1'>
-                    <h2 className='text-[15px] font-semibold text-primary-token transition-colors group-hover:text-secondary-token'>
+                    <h2 className='text-mid font-semibold text-primary-token transition-colors group-hover:text-secondary-token'>
                       {profile.displayName || profile.username}
                     </h2>
                     {profile.bio ? (
-                      <p className='line-clamp-3 text-[13px] leading-5 text-secondary-token'>
+                      <p className='line-clamp-3 text-app leading-5 text-secondary-token'>
                         {profile.bio}
                       </p>
                     ) : (
-                      <p className='text-[13px] leading-5 text-tertiary-token'>
+                      <p className='text-app leading-5 text-tertiary-token'>
                         Public creator profile on Jovie.
                       </p>
                     )}
                   </div>
 
-                  <span className='inline-flex items-center gap-1 text-[12px] font-semibold text-tertiary-token transition-colors group-hover:text-primary-token'>
+                  <span className='inline-flex items-center gap-1 text-xs font-semibold text-tertiary-token transition-colors group-hover:text-primary-token'>
                     View profile
                     <Icon name='ChevronRight' className='h-4 w-4' />
                   </span>
@@ -136,10 +136,10 @@ export default async function ArtistsPage() {
         ) : (
           <ContentSurfaceCard surface='details'>
             <div className='px-5 py-8 text-center sm:px-6'>
-              <p className='text-[15px] font-semibold text-primary-token'>
+              <p className='text-mid font-semibold text-primary-token'>
                 No profiles found
               </p>
-              <p className='mt-2 text-[13px] leading-5 text-secondary-token'>
+              <p className='mt-2 text-app leading-5 text-secondary-token'>
                 Check back later for new creator profiles.
               </p>
             </div>
@@ -160,7 +160,7 @@ function renderFallback() {
           subtitle='Please check back shortly once the connection is available.'
         />
         <div className='px-5 py-8 text-center sm:px-6'>
-          <p className='text-[13px] leading-5 text-secondary-token'>
+          <p className='text-app leading-5 text-secondary-token'>
             Public creator data is temporarily unavailable.
           </p>
         </div>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 5394,
+  "count": 5066,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

Converges `app/artists/page.tsx` from arbitrary Tailwind text-size values to canonical design-system token utilities. One file, 13 replacements, no visual change.

**Replacements made:**

| Before | After | Count | px |
|--------|-------|-------|-----|
| `text-[12px]` | `text-xs` | ×2 | 12px |
| `text-[13px]` | `text-app` | ×9 | 13px |
| `text-[15px]` | `text-mid` | ×2 | 15px |

**Left unchanged (no exact token equivalent):**
- `tracking-[-0.03em]` — custom negative tracking on stat count headline
- `tracking-[0.14em]` — positive tracking on uppercase label (no canonical token)

## Ratchet

| Metric | Value |
|--------|-------|
| Baseline before (main after multiple convergence PRs) | 5394 |
| Actual count after this PR (rebased on current main) | 5066 |
| Baseline after | 5066 |
| This PR's direct removals | −13 |

Note: The baseline drops from 5394 → 5066 because several PRs merged to main since the previous rebase reduced the actual count without updating the baseline. This PR sets it to the tightest correct value (verified by grep count on the rebased working tree).

File: `apps/web/tests/unit/design-system/arbitrary-values.baseline.json` updated in same commit.

## Verification

- [x] TypeScript: `pnpm --filter @jovie/web run typecheck` — 0 errors
- [x] Ratchet: actual count 5066 ≤ baseline 5066 — PASS
- [x] Token validity: `text-xs` (0.75rem/12px), `text-app` (0.8125rem/13px), `text-mid` (0.9375rem/15px) confirmed in `design-system.css` `@theme`
- [x] Rebased onto current main (`6706bbe`); baseline conflict resolved to exact grep count

🤖 Scheduled design-system convergence run · 2026-06-20