### PR TITLE
ci(perf): reduce unit-test shards 6→3 to cut runner contention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2448,7 +2448,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
+        shard: ['1/3', '2/3', '3/3']
     outputs:
       run_full_ci: ${{ steps.check_changes.outputs.run_full_ci }}
     steps:
@@ -2489,7 +2489,7 @@ jobs:
           VITEST_CI_FLAGS="--pool=forks --maxWorkers=2"
           # Retry budget comes from apps/web/tests/quarantine.json
           RETRY_FLAG="--retry=${{ steps.quarantine.outputs.unit_default_retries }}"
-          # Use shard-specific output file so Codecov Test Analytics receives all 6 shards
+          # Use shard-specific output file so Codecov Test Analytics receives all 3 shards
           # (a shared filename causes only the last upload to be recorded)
           # Note: vitest runs from apps/web/, so path is relative to that directory
           SHARD_SLUG="${{ matrix.shard }}"


### PR DESCRIPTION
**Why:** free-tier GitHub runners are saturated — **78 jobs queued, 0 running**. 6 unit-test shards × ~35 open PRs = ~210 queued jobs for unit tests alone, with no throughput gain when there's no spare runner.

**What:** unit-test matrix 6 shards → 3. Halves per-PR unit-test runner demand so merge-group validation (the thing that actually lands PRs) gets a runner sooner.

Part of the CI throughput fix. See also the strict-policy + optimizer changes.