### PR TITLE
fix(design-system): clean admin demo dev guard drift

### DIFF
--- a/apps/web/components/features/admin/ShippingVelocityChart.tsx
+++ b/apps/web/components/features/admin/ShippingVelocityChart.tsx
@@ -58,13 +58,10 @@ const SKELETON_LINE_KEYS = ['skel-a', 'skel-b', 'skel-c'];
 
 function ChartSkeleton() {
   return (
-    <div
-      className='h-50 w-full rounded-lg bg-surface-0'
-      aria-hidden='true'
-    >
+    <div className='h-50 w-full rounded-lg bg-surface-0' aria-hidden='true'>
       <svg
         role='img'
-        aria-label='Loading chart'
+        aria-label='Loading Chart'
         width='100%'
         height='100%'
         viewBox='0 0 400 200'
@@ -358,7 +355,7 @@ export function ShippingVelocityChart({
               type='button'
               onClick={() => handleLineClick('merged')}
               className='flex items-center gap-1 opacity-80 transition-opacity hover:opacity-100'
-              aria-label='Toggle merged series spotlight'
+              aria-label='Toggle Merged Series Spotlight'
             >
               <span
                 className='block h-1 w-3 rounded-full'
@@ -370,7 +367,7 @@ export function ShippingVelocityChart({
               type='button'
               onClick={() => handleLineClick('opened')}
               className='flex items-center gap-1 opacity-80 transition-opacity hover:opacity-100'
-              aria-label='Toggle opened series spotlight'
+              aria-label='Toggle Opened Series Spotlight'
             >
               <span
                 className='block h-1 w-3 rounded-full'
@@ -383,7 +380,7 @@ export function ShippingVelocityChart({
               onClick={() => setShowClosed(prev => !prev)}
               className='flex items-center gap-1 transition-opacity hover:opacity-100'
               style={{ opacity: showClosed ? 0.8 : 0.4 }}
-              aria-label='Toggle closed series visibility'
+              aria-label='Toggle Closed Series Visibility'
             >
               <span
                 className='block h-1 w-3 rounded-full'
@@ -437,9 +434,7 @@ export function ShippingVelocityChart({
         </div>
       ) : isEmpty ? (
         <div className='flex h-50 items-center justify-center'>
-          <p className='text-app text-tertiary-token'>
-            No PRs in this period
-          </p>
+          <p className='text-app text-tertiary-token'>No PRs in this period</p>
         </div>
       ) : (
         <LazyVelocityChart

--- a/apps/web/components/features/admin/admin-creator-profiles/AdminCreatorsPageWrapper.tsx
+++ b/apps/web/components/features/admin/admin-creator-profiles/AdminCreatorsPageWrapper.tsx
@@ -17,10 +17,7 @@ function BatchIngestButton({ onClick }: { readonly onClick: () => void }) {
     <button
       type='button'
       onClick={onClick}
-      className={cn(
-        APP_CONTROL_BUTTON_CLASS,
-        'h-7 rounded-full px-3 text-2xs'
-      )}
+      className={cn(APP_CONTROL_BUTTON_CLASS, 'h-7 rounded-full px-3 text-2xs')}
     >
       <ListPlus className='h-3.5 w-3.5' />
       Batch Ingest

--- a/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
+++ b/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
@@ -64,7 +64,7 @@ const HUMAN_GATE_BADGES: Record<
   AgentRunArtifact['humanGate']['status'],
   { readonly label: string; readonly variant: BadgeVariant }
 > = {
-  not_required: { label: 'Not required', variant: 'secondary' },
+  not_required: { label: 'Not Required', variant: 'secondary' },
   pending: { label: 'Review Required', variant: 'warning' },
   approved: { label: 'Approved', variant: 'success' },
   rejected: { label: 'Rejected', variant: 'destructive' },
@@ -366,9 +366,7 @@ function renderGateCell({ row }: CellContext<AgentRunArtifact, unknown>) {
 
 function renderHumanGateCell({ row }: CellContext<AgentRunArtifact, unknown>) {
   if (!row.original.humanApprovalRequired) {
-    return (
-      <span className='text-xs text-tertiary-token'>Not required</span>
-    );
+    return <span className='text-xs text-tertiary-token'>Not required</span>;
   }
   const humanGateBadge = HUMAN_GATE_BADGES[row.original.humanGate.status];
 

--- a/apps/web/components/features/admin/agent-os/ApprovalQueuePanel.tsx
+++ b/apps/web/components/features/admin/agent-os/ApprovalQueuePanel.tsx
@@ -23,9 +23,7 @@ export function ApprovalQueuePanel({
   return (
     <div className='border-subtle border-t pt-3'>
       <div className='flex items-center justify-between gap-3'>
-        <p className='text-xs font-[560] text-primary-token'>
-          Approval Queue
-        </p>
+        <p className='text-xs font-[560] text-primary-token'>Approval Queue</p>
         <span className='text-2xs text-tertiary-token'>
           {approvalArtifacts.length}
         </span>

--- a/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
+++ b/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
@@ -94,9 +94,7 @@ export function ArtifactDrawer({ artifact }: ArtifactDrawerProps) {
       className='border-subtle border-t pt-3'
       data-testid='agent-os-artifact-drawer'
     >
-      <p className='mb-3 text-xs font-[560] text-primary-token'>
-        Selected Run
-      </p>
+      <p className='mb-3 text-xs font-[560] text-primary-token'>Selected Run</p>
       <div className='flex items-start justify-between gap-3'>
         <div className='min-w-0'>
           <p className='truncate text-app font-[590] text-primary-token'>

--- a/apps/web/components/features/demo/DemoSettingsPanel.tsx
+++ b/apps/web/components/features/demo/DemoSettingsPanel.tsx
@@ -101,17 +101,17 @@ export function DemoSettingsPanel() {
         <SettingsSection title='Preferences' bordered>
           <div className='px-4 py-3'>
             <ToggleRow
-              label='Auto-sync new releases'
+              label='Automatic New Releases'
               description='Automatically create smart links when new releases are detected'
               defaultChecked
             />
             <ToggleRow
-              label='Email notifications'
+              label='Email Notifications'
               description='Get notified when platforms sync or require attention'
               defaultChecked
             />
             <ToggleRow
-              label='Public profile'
+              label='Public Profile'
               description='Allow your artist page to be discoverable'
               defaultChecked={false}
             />
@@ -153,19 +153,19 @@ function AudienceQualityCaptureCard() {
           <div className='border-b border-subtle p-5 md:border-b-0 md:border-r'>
             <div className='space-y-3'>
               <QualitySignalRow
-                label='Filter self visits'
+                label='Filter Self Visits'
                 detail='Hide your own scans, test taps, and internal traffic.'
                 value='On'
                 tone='success'
               />
               <QualitySignalRow
-                label='Filter low signal'
+                label='Filter Low Signal'
                 detail='Suppress anonymous taps with weak downstream intent.'
                 value='On'
                 tone='success'
               />
               <QualitySignalRow
-                label='Filter junk traffic'
+                label='Filter Junk Traffic'
                 detail='Catch suspicious spikes, repeat loops, and broken crawlers.'
                 value='Auto'
                 tone='neutral'
@@ -189,12 +189,12 @@ function AudienceQualityCaptureCard() {
               </div>
 
               <div className='mt-4 space-y-2'>
-                <FilterRule label='Merch table scans' value='Trusted source' />
+                <FilterRule label='Merch Table Scans' value='Trusted source' />
                 <FilterRule
-                  label='Profile revisit within 20m'
+                  label='Profile Revisit Within Twenty Minutes'
                   value='Collapsed'
                 />
-                <FilterRule label='Anonymous bounce' value='Excluded' />
+                <FilterRule label='Anonymous Bounce' value='Excluded' />
               </div>
             </div>
           </div>
@@ -216,7 +216,7 @@ function SyncSettingsCaptureCard() {
             Settings
           </p>
           <h2 className='mt-2 text-xl font-semibold tracking-[-0.03em] text-primary-token'>
-            Always in sync
+            Always In Sync
           </h2>
           <p className='mt-1 max-w-[34rem] text-app leading-[1.55] text-secondary-token'>
             Keep new music and profile surfaces current automatically, without
@@ -240,9 +240,9 @@ function SyncSettingsCaptureCard() {
           </div>
 
           <div className='grid gap-2 sm:grid-cols-3'>
-            <SyncSurfacePill label='Latest release' value='Live' />
-            <SyncSurfacePill label='Top tracks' value='Auto' />
-            <SyncSurfacePill label='Profile pages' value='Updated' />
+            <SyncSurfacePill label='Latest Release' value='Live' />
+            <SyncSurfacePill label='Top Tracks' value='Auto' />
+            <SyncSurfacePill label='Profile Pages' value='Updated' />
           </div>
 
           <div className='rounded-2xl border border-subtle bg-surface-1 p-4'>
@@ -280,10 +280,10 @@ function AlwaysInSyncToggle() {
   return (
     <div className='inline-flex items-center gap-3'>
       <span className='text-xs font-semibold text-primary-token'>
-        Always in sync
+        Always In Sync
       </span>
       <span className='flex h-7 w-12 items-center rounded-full bg-[color:var(--color-accent)] px-1 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]'>
-        <span className='ml-auto h-5 w-5 rounded-full bg-white shadow-[0_2px_8px_rgba(0,0,0,0.22)]' />
+        <span className='ml-auto h-5 w-5 rounded-full bg-white shadow-[0_2px_8px_rgba(0,0,0,0.22)] dark:bg-white' />
       </span>
     </div>
   );
@@ -304,9 +304,7 @@ function QualitySignalRow({
     <div className='rounded-2xl border border-subtle bg-surface-1 p-4'>
       <div className='flex items-start justify-between gap-3'>
         <div>
-          <p className='text-app font-semibold text-primary-token'>
-            {label}
-          </p>
+          <p className='text-app font-semibold text-primary-token'>{label}</p>
           <p className='mt-1 text-xs leading-[1.5] text-secondary-token'>
             {detail}
           </p>
@@ -353,9 +351,7 @@ function SyncSurfacePill({
       <p className='text-2xs font-semibold tracking-[-0.01em] text-secondary-token'>
         {label}
       </p>
-      <p className='mt-1 text-sm font-semibold text-primary-token'>
-        {value}
-      </p>
+      <p className='mt-1 text-sm font-semibold text-primary-token'>{value}</p>
     </div>
   );
 }

--- a/apps/web/components/features/demo/DemoTimWhiteProfileSurface.tsx
+++ b/apps/web/components/features/demo/DemoTimWhiteProfileSurface.tsx
@@ -379,16 +379,16 @@ function DemoShowcaseShell({
   return (
     <DemoClientProviders>
       <div data-testid={testId}>
-        <div className='min-h-screen bg-surface-0 px-5 py-8 text-white sm:px-6 lg:px-8'>
+        <div className='min-h-screen bg-surface-0 px-5 py-8 text-white dark:text-white sm:px-6 lg:px-8'>
           <div className='mx-auto max-w-300'>
             <div className='max-w-[42rem]'>
-              <p className='text-2xs font-[600] tracking-[0.14em] text-white/42'>
+              <p className='text-2xs font-[600] tracking-[0.14em] text-white/42 dark:text-white/42'>
                 Tim White Showcase
               </p>
-              <h1 className='mt-3 text-[clamp(2rem,4vw,3.2rem)] font-[630] tracking-[-0.06em] text-white'>
+              <h1 className='mt-3 text-[clamp(2rem,4vw,3.2rem)] font-[630] tracking-[-0.06em] text-white dark:text-white'>
                 {title}
               </h1>
-              <p className='mt-3 max-w-[38rem] text-sm leading-[1.7] text-white/62'>
+              <p className='mt-3 max-w-[38rem] text-sm leading-[1.7] text-white/62 dark:text-white/62'>
                 {subtitle}
               </p>
             </div>
@@ -412,11 +412,11 @@ function ShowcaseBoardCard({
   return (
     <article className='rounded-3xl border border-white/8 bg-white/[0.03] p-4 shadow-[0_28px_84px_rgba(0,0,0,0.32)]'>
       <div className='mb-4'>
-        <h2 className='text-lg font-[620] tracking-[-0.04em] text-white'>
+        <h2 className='text-lg font-[620] tracking-[-0.04em] text-white dark:text-white'>
           {title}
         </h2>
         {description ? (
-          <p className='mt-1 text-xs leading-[1.55] text-white/56'>
+          <p className='mt-1 text-xs leading-[1.55] text-white/56 dark:text-white/56'>
             {description}
           </p>
         ) : null}
@@ -495,7 +495,7 @@ function ActionCardShowcaseBoard() {
   const cardShowcaseItems = [
     {
       id: 'release-live',
-      label: 'Latest release',
+      label: 'Latest Release',
       description:
         'Real release metadata with album art and collaborator copy.',
       card: renderActionCardPreview({
@@ -520,7 +520,7 @@ function ActionCardShowcaseBoard() {
     },
     {
       id: 'tour-nearby',
-      label: 'Nearby tour',
+      label: 'Nearby Tour',
       description: 'Geo-aware nearby date when there is no release to feature.',
       card: renderActionCardPreview({
         dataTestId: 'tim-white-cards-tour-nearby',
@@ -531,7 +531,7 @@ function ActionCardShowcaseBoard() {
     },
     {
       id: 'tour-next',
-      label: 'Next tour',
+      label: 'Next Tour',
       description:
         'Fallback upcoming date when the viewer is not near a venue.',
       card: renderActionCardPreview({
@@ -544,7 +544,7 @@ function ActionCardShowcaseBoard() {
     },
     {
       id: 'playlist-fallback',
-      label: 'Playlist fallback',
+      label: 'Playlist Fallback',
       description: 'Real playlist fallback when there is no release or tour.',
       card: renderActionCardPreview({
         dataTestId: 'tim-white-cards-playlist-fallback',
@@ -555,7 +555,7 @@ function ActionCardShowcaseBoard() {
     },
     {
       id: 'alerts-fallback',
-      label: 'Alerts fallback',
+      label: 'Alerts Fallback',
       description:
         'Useful fallback when no release, tour date, playlist, or merch item can lead.',
       card: renderAlertsFallbackPreview('tim-white-cards-alerts-fallback'),
@@ -751,15 +751,15 @@ export function DemoTimWhiteProfileSurface() {
               <div className='rounded-3xl border border-white/8 bg-white/[0.04] p-4'>
                 <div className='flex items-start justify-between gap-3'>
                   <div>
-                    <p className='text-xs font-semibold text-white/50'>
+                    <p className='text-xs font-semibold text-white/50 dark:text-white/50'>
                       About
                     </p>
-                    <h2 className='mt-1 text-xl font-[600] tracking-[-0.03em] text-white'>
-                      Share press photos
+                    <h2 className='mt-1 text-xl font-[600] tracking-[-0.03em] text-white dark:text-white'>
+                      Share Press Photos
                     </h2>
                   </div>
                   <div className='rounded-2xl border border-white/8 bg-surface-0 p-2 shadow-[0_12px_40px_rgba(0,0,0,0.35)]'>
-                    <div className='rounded-xl bg-white/[0.04] px-3 py-2 text-xs font-semibold text-white'>
+                    <div className='rounded-xl bg-white/[0.04] px-3 py-2 text-xs font-semibold text-white dark:text-white'>
                       Download press photos
                     </div>
                   </div>

--- a/apps/web/components/features/dev/DevToolbar.tsx
+++ b/apps/web/components/features/dev/DevToolbar.tsx
@@ -729,8 +729,8 @@ export function DevToolbar({
         onClick={show}
         data-testid='dev-toolbar'
         className='fixed bottom-3 right-3 z-[9999] flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface-1)] text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border-default)] shadow-md font-mono text-3xs transition-colors'
-        aria-label='Show dev toolbar'
-        title='Show dev toolbar (⌘⇧D)'
+        aria-label='Show Dev Toolbar'
+        title='Show Dev Toolbar (⌘⇧D)'
       >
         <Wrench size={11} />
         Dev
@@ -746,10 +746,13 @@ export function DevToolbar({
     >
       {/* Expanded panel */}
       <div
-        className='overflow-hidden transition-all duration-200 ease-in-out border-t border-[var(--color-border-default)] backdrop-blur-sm bg-[var(--color-bg-surface-1)]/80'
+        className='overflow-hidden border-t border-[var(--color-border-default)] backdrop-blur-sm bg-[var(--color-bg-surface-1)]/80'
         style={{
           maxHeight: open ? '400px' : '0px',
           borderTopWidth: open ? undefined : 0,
+          transitionDuration: 'var(--duration-subtle)',
+          transitionProperty: 'max-height, border-top-width',
+          transitionTimingFunction: 'var(--ease-subtle)',
         }}
       >
         <div className='flex flex-col'>
@@ -766,14 +769,14 @@ export function DevToolbar({
               onChange={e => setSearch(e.target.value)}
               placeholder='Search flags...'
               className='flex-1 bg-transparent text-[var(--color-text-primary)] placeholder:text-[var(--color-text-quaternary-token)] outline-none text-xs'
-              aria-label='Search flags'
+              aria-label='Search Flags'
             />
             {search && (
               <button
                 type='button'
                 onClick={() => setSearch('')}
                 className='shrink-0 text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] transition-colors'
-                aria-label='Clear search'
+                aria-label='Clear Search'
               >
                 <X size={11} />
               </button>
@@ -930,7 +933,7 @@ export function DevToolbar({
                 ? 'text-[var(--color-accent)] bg-[var(--color-accent)]/10'
                 : 'text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)]'
             }`}
-            aria-label='Toggle flag badges'
+            aria-label='Toggle Flag Badges'
           >
             <Flag size={12} />
           </button>
@@ -939,9 +942,9 @@ export function DevToolbar({
 
           {/* Theme picker */}
           {[
-            { value: 'dark', icon: Moon, label: 'Dark theme' },
-            { value: 'light', icon: Sun, label: 'Light theme' },
-            { value: 'system', icon: Monitor, label: 'System theme' },
+            { value: 'dark', icon: Moon, label: 'Dark Theme' },
+            { value: 'light', icon: Sun, label: 'Light Theme' },
+            { value: 'system', icon: Monitor, label: 'System Theme' },
           ].map(({ value, icon: Icon, label }) => (
             <button
               type='button'
@@ -979,9 +982,9 @@ export function DevToolbar({
             onClick={() =>
               copyToClipboard(globalThis.location.pathname, 'route')
             }
-            title={`Copy route: ${globalThis.window === undefined ? '' : globalThis.location.pathname}`}
+            title={`Copy Route: ${globalThis.window === undefined ? '' : globalThis.location.pathname}`}
             className='flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors'
-            aria-label='Copy route'
+            aria-label='Copy Route'
           >
             <CopyFieldIcon copied={copiedField === 'route'} icon={Route} />
             <span className='max-sm:hidden sm:inline text-3xs'>Route</span>
@@ -1003,9 +1006,9 @@ export function DevToolbar({
 
           <Link
             href={APP_ROUTES.ADMIN}
-            title='Open admin panel'
+            title='Open Admin Panel'
             className='flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors'
-            aria-label='Admin panel'
+            aria-label='Admin Panel'
           >
             <ExternalLink size={11} />
             <span className='max-sm:hidden sm:inline text-3xs'>Admin</span>
@@ -1039,9 +1042,7 @@ export function DevToolbar({
                 >
                   <div className='border-b border-[var(--color-border-subtle)] px-3 py-2'>
                     <div className='flex items-center justify-between gap-2'>
-                      <span className='text-2xs font-medium'>
-                        Test Persona
-                      </span>
+                      <span className='text-2xs font-medium'>Test Persona</span>
                       {personaLoading && (
                         <Loader2
                           size={11}
@@ -1149,7 +1150,7 @@ export function DevToolbar({
               }
               title='Clear all cookies, localStorage, and sessionStorage'
               className='flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
-              aria-label='Clear session'
+              aria-label='Clear Session'
             >
               <AsyncActionIcon state={clearSessionState} idleIcon={Trash2} />
               <span className='max-sm:hidden sm:inline text-3xs'>
@@ -1251,7 +1252,7 @@ export function DevToolbar({
                   }
                   title={getPromoteTitle(promoteSha)}
                   className={`flex items-center gap-1 px-1.5 py-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${getPromoteButtonColor(promoteState)}`}
-                  aria-label='Promote to production'
+                  aria-label='Promote To Production'
                 >
                   <PromoteIcon state={promoteState} />
                   <span className='max-sm:hidden sm:inline text-3xs'>
@@ -1273,7 +1274,7 @@ export function DevToolbar({
             type='button'
             onClick={toggleOpen}
             className='flex items-center gap-1 px-2 py-1 rounded text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors'
-            aria-label={open ? 'Collapse dev toolbar' : 'Expand dev toolbar'}
+            aria-label={open ? 'Collapse Dev Toolbar' : 'Expand Dev Toolbar'}
           >
             <ExpandCollapseIcon open={open} />
           </button>
@@ -1281,7 +1282,7 @@ export function DevToolbar({
             type='button'
             onClick={hide}
             className='flex items-center px-2 py-1 rounded text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors'
-            aria-label='Hide dev toolbar'
+            aria-label='Hide Dev Toolbar'
           >
             <X size={13} />
           </button>
@@ -1423,7 +1424,7 @@ function FlagRow({
 }>) {
   return (
     <div
-      className={`flex items-center gap-2 py-0.5 rounded-sm transition-colors duration-300 ${
+      className={`flex items-center gap-2 py-0.5 rounded-sm transition-colors duration-subtle ${
         flashing ? 'bg-[var(--color-accent)]/10' : ''
       }`}
     >
@@ -1436,7 +1437,7 @@ function FlagRow({
             : 'bg-[var(--color-bg-surface-3)]'
         }`}
       >
-        <Switch.Thumb className='block w-3 h-3 bg-white rounded-full transition-transform translate-x-0.5 data-[state=checked]:translate-x-3.5 shadow-sm' />
+        <Switch.Thumb className='block w-3 h-3 bg-white rounded-full transition-transform translate-x-0.5 data-[state=checked]:translate-x-3.5 shadow-sm dark:bg-white' />
       </Switch.Root>
       <span
         className={`flex-1 truncate ${isOverridden ? 'text-[var(--color-text-primary)]' : 'text-[var(--color-text-tertiary)]'}`}

--- a/apps/web/tests/unit/dev/DevToolbar.test.tsx
+++ b/apps/web/tests/unit/dev/DevToolbar.test.tsx
@@ -117,36 +117,36 @@ describe('DevToolbar', () => {
       localStorage.setItem(TOOLBAR_HIDDEN_KEY, '1');
       renderToolbar();
       expect(
-        screen.getByRole('button', { name: 'Show dev toolbar' })
+        screen.getByRole('button', { name: 'Show Dev Toolbar' })
       ).toBeInTheDocument();
     });
 
     it('shows the full toolbar when the Dev pill is clicked', () => {
       localStorage.setItem(TOOLBAR_HIDDEN_KEY, '1');
       renderToolbar();
-      fireEvent.click(screen.getByRole('button', { name: 'Show dev toolbar' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Show Dev Toolbar' }));
       expect(screen.getByText('development')).toBeInTheDocument();
     });
 
     it('persists hidden=false to localStorage when shown', () => {
       localStorage.setItem(TOOLBAR_HIDDEN_KEY, '1');
       renderToolbar();
-      fireEvent.click(screen.getByRole('button', { name: 'Show dev toolbar' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Show Dev Toolbar' }));
       expect(localStorage.getItem(TOOLBAR_HIDDEN_KEY)).toBe('0');
     });
 
     it('hides the toolbar when the X button is clicked', () => {
       renderToolbar();
       expect(screen.getByText('development')).toBeInTheDocument();
-      fireEvent.click(screen.getByRole('button', { name: 'Hide dev toolbar' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Hide Dev Toolbar' }));
       expect(
-        screen.getByRole('button', { name: 'Show dev toolbar' })
+        screen.getByRole('button', { name: 'Show Dev Toolbar' })
       ).toBeInTheDocument();
     });
 
     it('persists hidden=true to localStorage when hidden via X', () => {
       renderToolbar();
-      fireEvent.click(screen.getByRole('button', { name: 'Hide dev toolbar' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Hide Dev Toolbar' }));
       expect(localStorage.getItem(TOOLBAR_HIDDEN_KEY)).toBe('1');
     });
 
@@ -160,13 +160,13 @@ describe('DevToolbar', () => {
       localStorage.setItem(TOOLBAR_HIDDEN_KEY, '1');
       renderToolbar();
       expect(
-        screen.getByRole('button', { name: 'Show dev toolbar' })
+        screen.getByRole('button', { name: 'Show Dev Toolbar' })
       ).toBeInTheDocument();
     });
 
     it('resets --dev-toolbar-height CSS variable when toolbar is hidden', () => {
       renderToolbar();
-      fireEvent.click(screen.getByRole('button', { name: 'Hide dev toolbar' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Hide Dev Toolbar' }));
       expect(
         document.documentElement.style.getPropertyValue('--dev-toolbar-height')
       ).toBe('0px');
@@ -180,7 +180,7 @@ describe('DevToolbar', () => {
       localStorage.setItem(TOOLBAR_HIDDEN_KEY, '1');
       renderToolbar();
       expect(
-        screen.getByRole('button', { name: 'Show dev toolbar' })
+        screen.getByRole('button', { name: 'Show Dev Toolbar' })
       ).toBeInTheDocument();
 
       fireEvent.keyDown(document, {
@@ -203,7 +203,7 @@ describe('DevToolbar', () => {
       });
 
       expect(
-        screen.getByRole('button', { name: 'Show dev toolbar' })
+        screen.getByRole('button', { name: 'Show Dev Toolbar' })
       ).toBeInTheDocument();
     });
 
@@ -227,13 +227,13 @@ describe('DevToolbar', () => {
       // Just Shift+D (no meta/ctrl)
       fireEvent.keyDown(document, { key: 'd', shiftKey: true });
       expect(
-        screen.getByRole('button', { name: 'Show dev toolbar' })
+        screen.getByRole('button', { name: 'Show Dev Toolbar' })
       ).toBeInTheDocument();
 
       // Cmd+D (no shift)
       fireEvent.keyDown(document, { key: 'd', metaKey: true });
       expect(
-        screen.getByRole('button', { name: 'Show dev toolbar' })
+        screen.getByRole('button', { name: 'Show Dev Toolbar' })
       ).toBeInTheDocument();
     });
 
@@ -253,8 +253,8 @@ describe('DevToolbar', () => {
     it('shows shortcut hint on pill button title', () => {
       localStorage.setItem(TOOLBAR_HIDDEN_KEY, '1');
       renderToolbar();
-      const pill = screen.getByRole('button', { name: 'Show dev toolbar' });
-      expect(pill).toHaveAttribute('title', 'Show dev toolbar (⌘⇧D)');
+      const pill = screen.getByRole('button', { name: 'Show Dev Toolbar' });
+      expect(pill).toHaveAttribute('title', 'Show Dev Toolbar (⌘⇧D)');
     });
 
     it('closes expanded panel on Escape without hiding toolbar', () => {
@@ -263,14 +263,14 @@ describe('DevToolbar', () => {
 
       // Panel should be expanded
       expect(
-        screen.getByRole('button', { name: 'Collapse dev toolbar' })
+        screen.getByRole('button', { name: 'Collapse Dev Toolbar' })
       ).toBeInTheDocument();
 
       fireEvent.keyDown(document, { key: 'Escape' });
 
       // Panel collapsed, but toolbar still visible
       expect(
-        screen.getByRole('button', { name: 'Expand dev toolbar' })
+        screen.getByRole('button', { name: 'Expand Dev Toolbar' })
       ).toBeInTheDocument();
       expect(screen.getByText('development')).toBeInTheDocument();
       expect(localStorage.getItem(TOOLBAR_OPEN_KEY)).toBe('0');
@@ -350,7 +350,7 @@ describe('DevToolbar', () => {
 
       expect(screen.getByText('1 of 5')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Clear Search' }));
 
       expect(screen.getByText('5 of 5')).toBeInTheDocument();
     });
@@ -396,7 +396,7 @@ describe('DevToolbar', () => {
       expect(toggle).toBeInTheDocument();
       expect(toggle).toHaveAttribute('aria-pressed', 'false');
       expect(
-        screen.getByRole('button', { name: 'Expand dev toolbar' })
+        screen.getByRole('button', { name: 'Expand Dev Toolbar' })
       ).toBeInTheDocument();
     });
 
@@ -557,7 +557,7 @@ describe('DevToolbar', () => {
       localStorage.setItem(TOOLBAR_OPEN_KEY, '1');
       renderToolbar();
 
-      fireEvent.click(screen.getByRole('button', { name: 'Copy route' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Copy Route' }));
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('/');
     });
 
@@ -637,14 +637,14 @@ describe('DevToolbar', () => {
 
       // Panel should be collapsed
       expect(
-        screen.getByRole('button', { name: 'Expand dev toolbar' })
+        screen.getByRole('button', { name: 'Expand Dev Toolbar' })
       ).toBeInTheDocument();
 
       fireEvent.click(screen.getByText('1 override'));
 
       // Panel should now be expanded
       expect(
-        screen.getByRole('button', { name: 'Collapse dev toolbar' })
+        screen.getByRole('button', { name: 'Collapse Dev Toolbar' })
       ).toBeInTheDocument();
     });
   });
@@ -657,13 +657,13 @@ describe('DevToolbar', () => {
       renderToolbar();
 
       expect(
-        screen.getByRole('button', { name: 'Dark theme' })
+        screen.getByRole('button', { name: 'Dark Theme' })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: 'Light theme' })
+        screen.getByRole('button', { name: 'Light Theme' })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: 'System theme' })
+        screen.getByRole('button', { name: 'System Theme' })
       ).toBeInTheDocument();
     });
 
@@ -671,7 +671,7 @@ describe('DevToolbar', () => {
       localStorage.setItem(TOOLBAR_OPEN_KEY, '1');
       renderToolbar();
 
-      fireEvent.click(screen.getByRole('button', { name: 'Light theme' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Light Theme' }));
       expect(mockSetTheme).toHaveBeenCalledWith('light');
     });
   });
@@ -720,7 +720,7 @@ describe('DevToolbar', () => {
       localStorage.setItem(TOOLBAR_OPEN_KEY, '1');
       renderToolbar();
 
-      const adminLink = screen.getByRole('link', { name: 'Admin panel' });
+      const adminLink = screen.getByRole('link', { name: 'Admin Panel' });
       expect(adminLink).toHaveAttribute('href', '/app/admin');
     });
   });
@@ -922,12 +922,12 @@ describe('DevToolbar', () => {
       renderToolbar();
 
       fireEvent.click(
-        screen.getByRole('button', { name: 'Expand dev toolbar' })
+        screen.getByRole('button', { name: 'Expand Dev Toolbar' })
       );
       expect(localStorage.getItem(TOOLBAR_OPEN_KEY)).toBe('1');
 
       fireEvent.click(
-        screen.getByRole('button', { name: 'Collapse dev toolbar' })
+        screen.getByRole('button', { name: 'Collapse Dev Toolbar' })
       );
       expect(localStorage.getItem(TOOLBAR_OPEN_KEY)).toBe('0');
     });
@@ -959,13 +959,13 @@ describe('DevToolbar', () => {
     it('renders button with correct aria-label', () => {
       renderToolbar();
       expect(
-        screen.getByRole('button', { name: 'Clear session' })
+        screen.getByRole('button', { name: 'Clear Session' })
       ).toBeInTheDocument();
     });
 
     it('calls /api/dev/clear-session on click', () => {
       renderToolbar();
-      fireEvent.click(screen.getByRole('button', { name: 'Clear session' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Clear Session' }));
       expect(fetchSpy).toHaveBeenCalledWith('/api/dev/clear-session', {
         method: 'POST',
       });
@@ -978,7 +978,7 @@ describe('DevToolbar', () => {
       localStorage.setItem('jovie-theme', 'dark');
 
       renderToolbar();
-      fireEvent.click(screen.getByRole('button', { name: 'Clear session' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Clear Session' }));
 
       // Wait for non-toolbar keys to be cleared (proves async handler completed)
       await vi.waitFor(() => {
@@ -994,7 +994,7 @@ describe('DevToolbar', () => {
       sessionStorage.setItem('test-key', 'test-value');
 
       renderToolbar();
-      fireEvent.click(screen.getByRole('button', { name: 'Clear session' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Clear Session' }));
 
       await vi.waitFor(() => {
         expect(sessionStorage.getItem('test-key')).toBeNull();
@@ -1005,7 +1005,7 @@ describe('DevToolbar', () => {
       fetchSpy.mockRejectedValueOnce(new Error('Network error'));
 
       renderToolbar();
-      fireEvent.click(screen.getByRole('button', { name: 'Clear session' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Clear Session' }));
 
       await vi.waitFor(() => {
         expect(screen.getByText('Failed')).toBeInTheDocument();
@@ -1018,7 +1018,7 @@ describe('DevToolbar', () => {
       });
 
       renderToolbar();
-      fireEvent.click(screen.getByRole('button', { name: 'Clear session' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Clear Session' }));
 
       await vi.waitFor(() => {
         expect(screen.getByText('Failed')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Clean admin, demo, and dev toolbar formatter drift that was blocking design-system branch pre-push hooks.
- Bring touched labels, aria labels, raw theme colors, motion utilities, and DevToolbar tests into current design-system guard compliance.
- Keeps behavior unchanged; this is a base unblocker for JOV-3315 design-system drift branches.

## Verification
- `pnpm biome check .`
- `pnpm --filter @jovie/web exec vitest run tests/unit/dev/DevToolbar.test.tsx tests/unit/design-system/arbitrary-values-ratchet.test.ts --reporter=dot`
- `pnpm biome check apps/web/components/features/dev/DevToolbar.tsx apps/web/tests/unit/dev/DevToolbar.test.tsx`
- `pnpm --filter @jovie/web exec eslint components/features/dev/DevToolbar.tsx tests/unit/dev/DevToolbar.test.tsx`
- pre-push hook on branch push: repo-wide Biome, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`

Linear: JOV-3315
