### PR TITLE
fix(ci): gate generated PR queue labels

### DIFF
--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -7,9 +7,10 @@
 ## How a PR gets merged
 
 1. Open a PR against `main`. CI runs the normal PR lane (`CI / PR Ready`, `CI / Migration Guard`, `Fork PR Gate`).
-2. Apply the **`merge-queue`** label (this is Graphite's enqueue trigger). Automation does this for you:
-   - Agent pipeline, Dependabot, Sentry/main autofix, screenshots, and landing sweep apply `merge-queue` after their gates pass (see `.github/workflows/`).
-   - Humans/agents can do it directly: `gh pr edit <pr> --add-label merge-queue` (or `gt merge`, or the Graphite app).
+2. Apply the **`merge-queue`** label (this is Graphite's enqueue trigger). Automation does this through `node scripts/merge-queue-guard.mjs enqueue <pr>`:
+   - Agent pipeline, Sentry/main autofix, screenshots, and landing sweep run the guard after their gates pass (see `.github/workflows/`).
+   - The guard fetches current `main`, rebases generated same-repo branches when stale, refuses conflicts, refuses overlapping autonomous PRs on hot files/subsystems, and only applies `merge-queue` when required statuses are green on the current head.
+   - Humans can still apply the label directly for manual work, but generated PRs should use the guard.
 3. Graphite enqueues the PR, rebases it on `main`, waits for the required checks, and squash-merges.
 4. `linear-sync-on-merge.yml` transitions the Linear issue to `Done` on merge as before.
 
@@ -49,8 +50,20 @@ Agent commit signing (each identity that authors merges):
 - **Merge queue label:** `merge-queue`.
 - **Auto-enqueue rule:** enqueue PRs labeled `merge-queue`.
 - **Timeout:** cap queue duration so a regression can't hang the queue.
-- **CI optimization / fast-track:** enable if available on the plan (skips redundant CI on already-validated commits / fast-forwards trivially-clean PRs).
+- **CI optimization / fast-track:** ordinary generated PRs must not use the `fast` label. `scripts/merge-queue-guard.mjs` removes `fast` from generated branches unless the PR is explicitly classified with an emergency/hotfix label or `hotfix/*` branch.
 - **Push access:** make `graphite-app` the push actor for `main`.
+
+## Telemetry
+
+`merge-queue-telemetry.yml` runs daily and records:
+
+- queued-to-merged duration
+- conflict and CI evictions
+- requeue count
+- branch staleness at enqueue from guard telemetry markers
+- speculative reruns when detected
+
+Use the daily artifact or workflow summary to confirm the observed wait is trending toward the under-30-minute target.
 
 ## Monitoring & troubleshooting
 

--- a/.github/workflows/agent-landing-sweep.yml
+++ b/.github/workflows/agent-landing-sweep.yml
@@ -247,12 +247,18 @@ jobs:
               continue
             fi
 
-            # Graphite enqueues by label; native auto-merge retired
-            if gh pr edit "$PR_NUMBER" --add-label "merge-queue"; then
-              echo "Added PR #$PR_NUMBER to the Graphite merge queue."
-              LANDED=$((LANDED + 1))
+            # Graphite enqueues by label; native auto-merge retired.
+            # The guard rebases stale generated heads and refuses conflicts or
+            # overlapping autonomous PRs before the label can be applied.
+            if node scripts/merge-queue-guard.mjs enqueue "$PR_NUMBER" --skip-local-gates; then
+              if gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json labels \
+                --jq '[.labels[].name] | any(. == "merge-queue")' | grep -q true; then
+                LANDED=$((LANDED + 1))
+              else
+                SKIPPED=$((SKIPPED + 1))
+              fi
             else
-              echo "::warning::Failed to add merge-queue label to PR #$PR_NUMBER — not enqueued."
+              echo "::warning::Pre-queue guard failed for PR #$PR_NUMBER — not enqueued."
               SKIPPED=$((SKIPPED + 1))
             fi
           done < <(echo "$AGENT_PRS" | jq -c '.[]')

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -774,18 +774,21 @@ jobs:
           steps.queue-pressure.outputs.defer_auto_merge != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           PR_NUMBER="${{ needs.guard.outputs.pr_number }}"
 
-          # Graphite enqueues by label; native auto-merge retired
-          gh pr edit $PR_NUMBER --add-label "merge-queue" || { echo "::error::Failed to add merge-queue label to #$PR_NUMBER"; exit 1; }
+          # Graphite enqueues by label; native auto-merge retired.
+          # The guard refuses stale/conflicting heads and waits for required
+          # checks to rerun on any rebased head before applying the label.
+          node scripts/merge-queue-guard.mjs enqueue "$PR_NUMBER" --skip-local-gates
 
           # Add label for tracking
           gh api repos/${{ github.repository }}/issues/$PR_NUMBER/labels \
             --method POST \
             --field "labels[]=auto-approved" || true
 
-          echo "Added PR #$PR_NUMBER to the Graphite merge queue"
+          echo "Pre-queue guard completed for PR #$PR_NUMBER"
 
       - name: Defer auto-merge under queue pressure
         if: >-
@@ -815,9 +818,9 @@ jobs:
 
           This keeps quick human-driven PRs moving when the queue is saturated with agent traffic.
 
-          Re-enable auto-merge later with:
+          Re-run guarded enqueue later with:
 
-          \`gh pr edit $PR_NUMBER --add-label merge-queue\`"
+          \`node scripts/merge-queue-guard.mjs enqueue $PR_NUMBER --skip-local-gates\`"
 
           echo "Auto-merge deferred for PR #$PR_NUMBER due to queue pressure"
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,6 +20,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Checkout merge-queue policy
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
@@ -34,8 +39,8 @@ jobs:
         run: |
           echo "Dependency: ${{ steps.meta.outputs.dependency-names }}"
           echo "Update type: ${{ steps.meta.outputs.update-type }}"
-          # Graphite enqueues by label; native auto-merge retired
-          gh pr edit --add-label "merge-queue" "$PR_URL"
+          # Graphite enqueues by label; guard verifies freshness/conflicts first.
+          node scripts/merge-queue-guard.mjs enqueue "$PR_URL" --skip-local-gates
 
       - name: Note major bump requires manual review
         if: steps.meta.outputs.update-type == 'version-update:semver-major'

--- a/.github/workflows/main-autofix.yml
+++ b/.github/workflows/main-autofix.yml
@@ -608,10 +608,11 @@ jobs:
         if: steps.create-pr.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
         run: |
           # Graphite enqueues by label; native auto-merge retired
-          gh pr edit "$PR_URL" --add-label "merge-queue" || { echo "::error::Failed to add merge-queue label to $PR_URL"; exit 1; }
+          node scripts/merge-queue-guard.mjs enqueue "$PR_URL" --skip-local-gates
 
       - name: Slack — PR opened
         if: steps.create-pr.outputs.has_changes == 'true' && env.SLACK_WEBHOOK_URL != ''

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -176,11 +176,11 @@ jobs:
             echo "Updated existing PR #$EXISTING_PR via force-push"
             # Re-apply merge-queue label (idempotent; Graphite enqueues by label)
             # Graphite enqueues by label; native auto-merge retired
-            gh pr edit --add-label "merge-queue" "$EXISTING_PR" || { echo "::error::Failed to add merge-queue label to $EXISTING_PR"; exit 1; }
+            node scripts/merge-queue-guard.mjs enqueue "$EXISTING_PR" --skip-local-gates
           else
             PR_URL=$(gh pr create \
               --title "chore: update product screenshots" \
               --body "Auto-generated screenshot update triggered by ${GITHUB_SHA::8}.")
             # Graphite enqueues by label; native auto-merge retired
-            gh pr edit --add-label "merge-queue" "$PR_URL" || { echo "::error::Failed to add merge-queue label to $PR_URL"; exit 1; }
+            node scripts/merge-queue-guard.mjs enqueue "$PR_URL" --skip-local-gates
           fi

--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -201,10 +201,11 @@ jobs:
         if: steps.create-pr.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
         run: |
           # Graphite enqueues by label; native auto-merge retired
-          gh pr edit "$PR_URL" --add-label "merge-queue" || { echo "::error::Failed to add merge-queue label to $PR_URL"; exit 1; }
+          node scripts/merge-queue-guard.mjs enqueue "$PR_URL" --skip-local-gates
 
       - name: Fallback — convert to draft if validation failed
         if: failure() && steps.dedup.outputs.skip != 'true'

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -24,6 +24,11 @@ AGENT_RE='^(tim/|codex/|agent/|claude/|linear/|feat/|dependabot/)'
 
 label() {  # label <num> <label>
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would +$2 on #$1"; return 0; }
+  if [[ "$2" == "merge-queue" ]]; then
+    GH_REPO="$REPO" node scripts/merge-queue-guard.mjs enqueue "$1" --skip-local-gates \
+      && echo "    pre-queue guard completed for #$1" || echo "    !! pre-queue guard failed for #$1"
+    return 0
+  fi
   gh pr edit "$1" -R "$REPO" --add-label "$2" >/dev/null 2>&1 \
     && echo "    +$2 on #$1" || echo "    !! failed to add $2 on #$1"
 }

--- a/scripts/loop-orchestrator.sh
+++ b/scripts/loop-orchestrator.sh
@@ -36,7 +36,7 @@ while true; do
     --jq '.[] | select(.baseRefName=="main") | select(.mergeStateStatus=="CLEAN") | .number' 2>/dev/null \
     | while read -r n; do
         # Graphite enqueues by label; native auto-merge retired
-        [[ -n "$n" ]] && { gh pr edit "$n" --add-label "merge-queue" || echo "WARN: failed to enqueue #$n into Graphite merge queue" >&2; }
+        [[ -n "$n" ]] && { node scripts/merge-queue-guard.mjs enqueue "$n" --skip-local-gates || echo "WARN: pre-queue guard failed for #$n; not enqueued" >&2; }
       done
   log "sleep ${INTERVAL}s"
   sleep "$INTERVAL"

--- a/scripts/loop-train-drain.sh
+++ b/scripts/loop-train-drain.sh
@@ -20,7 +20,8 @@ for num in "${TRAIN_PRS[@]}"; do
   fi
   if [[ "$state" == "CLEAN" ]]; then
     # Graphite enqueues by label; native auto-merge retired
-    gh pr edit "$num" --add-label "merge-queue" || echo "WARN: failed to enqueue #$num into Graphite merge queue" >&2
+    node scripts/merge-queue-guard.mjs enqueue "$num" --skip-local-gates || \
+      echo "WARN: pre-queue guard failed for #$num; not enqueued" >&2
   fi
 done
 

--- a/scripts/merge-queue-guard.mjs
+++ b/scripts/merge-queue-guard.mjs
@@ -1,0 +1,524 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  detectChangedFileOverlap,
+  detectIssueOverlap,
+  fastTrackPolicy,
+  formatBlockedByPrReason,
+  isAutonomousBranch,
+  MERGE_QUEUE_LABEL,
+  NEEDS_CONFLICT_RESOLUTION_LABEL,
+  parseMergeQueueTimeline,
+  preQueueFreshnessDecision,
+  requiredStatusDecision,
+} from './lib/merge-queue-guard.mjs';
+
+const repo = process.env.GH_REPO || process.env.REPO || 'JovieInc/Jovie';
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: options.cwd ?? process.cwd(),
+    encoding: 'utf8',
+    timeout: options.timeout ?? 120_000,
+    maxBuffer: options.maxBuffer ?? 20 * 1024 * 1024,
+    stdio: options.stdio ?? ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function runStatus(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? process.cwd(),
+    encoding: 'utf8',
+    timeout: options.timeout ?? 120_000,
+    maxBuffer: options.maxBuffer ?? 20 * 1024 * 1024,
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function hasArg(args, flag) {
+  return args.includes(flag);
+}
+
+function argValue(args, flag, fallback = undefined) {
+  const index = args.indexOf(flag);
+  return index === -1 ? fallback : args[index + 1];
+}
+
+function ghJson(args) {
+  return JSON.parse(run('gh', args));
+}
+
+function labelNames(labels = []) {
+  return labels.map(label => (typeof label === 'string' ? label : label.name));
+}
+
+function loadPr(prRef) {
+  return ghJson([
+    'pr',
+    'view',
+    prRef,
+    '--repo',
+    repo,
+    '--json',
+    'number,title,body,headRefName,headRefOid,headRepositoryOwner,baseRefName,isDraft,labels,statusCheckRollup,mergeStateStatus,url',
+  ]);
+}
+
+function changedFilesForPr(prRef) {
+  const output = run('gh', [
+    'pr',
+    'diff',
+    String(prRef),
+    '--repo',
+    repo,
+    '--name-only',
+  ]);
+  return output.split(/\r?\n/).filter(Boolean);
+}
+
+function listOpenAutonomousPrs(excludeNumber = null) {
+  const prs = ghJson([
+    'pr',
+    'list',
+    '--repo',
+    repo,
+    '--state',
+    'open',
+    '--base',
+    'main',
+    '--limit',
+    '100',
+    '--json',
+    'number,title,headRefName,isDraft,labels',
+  ]);
+  return prs
+    .filter(pr => pr.number !== excludeNumber)
+    .filter(pr => isAutonomousBranch(pr.headRefName ?? ''))
+    .map(pr => ({
+      ...pr,
+      changedFiles: changedFilesForPr(pr.number),
+    }));
+}
+
+function comment(prNumber, body) {
+  run(
+    'gh',
+    ['pr', 'comment', String(prNumber), '--repo', repo, '--body', body],
+    {
+      timeout: 60_000,
+    }
+  );
+}
+
+function editLabels(prNumber, args) {
+  run('gh', ['pr', 'edit', String(prNumber), '--repo', repo, ...args], {
+    timeout: 60_000,
+  });
+}
+
+function telemetryMarker(payload) {
+  return `<!-- merge-queue-telemetry ${JSON.stringify(payload)} -->`;
+}
+
+function ensureFreshHead(pr, { skipLocalGates }) {
+  if (pr.baseRefName !== 'main') {
+    return {
+      behindBy: 0,
+      pushedRebasedHead: false,
+      rebaseAttempted: false,
+      rebaseOk: true,
+      note: `base branch ${pr.baseRefName} is not main; freshness rebase skipped`,
+    };
+  }
+
+  const headRef = pr.headRefName;
+  if (!headRef || headRef.startsWith('gtmq_')) {
+    return {
+      behindBy: 0,
+      pushedRebasedHead: false,
+      rebaseAttempted: false,
+      rebaseOk: true,
+      note: 'Graphite working branch; freshness rebase skipped',
+    };
+  }
+
+  run(
+    'git',
+    [
+      'fetch',
+      'origin',
+      '+refs/heads/main:refs/remotes/origin/main',
+      `+refs/heads/${headRef}:refs/remotes/origin/${headRef}`,
+    ],
+    {
+      timeout: 120_000,
+    }
+  );
+
+  const tempRoot = mkdtempSync(join(tmpdir(), 'jovie-mq-'));
+  const worktree = join(tempRoot, 'worktree');
+  try {
+    run('git', ['worktree', 'add', '--detach', worktree, `origin/${headRef}`], {
+      timeout: 120_000,
+    });
+    const behindRaw = run('git', ['rev-list', '--count', 'HEAD..origin/main'], {
+      cwd: worktree,
+    });
+    const behindBy = Number(behindRaw);
+    if (!Number.isFinite(behindBy)) {
+      return {
+        behindBy: Number.NaN,
+        pushedRebasedHead: false,
+        rebaseAttempted: false,
+        rebaseOk: false,
+        note: `could not parse branch staleness: ${behindRaw}`,
+      };
+    }
+
+    if (behindBy === 0) {
+      return {
+        behindBy,
+        pushedRebasedHead: false,
+        rebaseAttempted: false,
+        rebaseOk: true,
+        note: 'branch already contains current main',
+      };
+    }
+
+    const rebase = runStatus('git', ['rebase', 'origin/main'], {
+      cwd: worktree,
+      timeout: 120_000,
+    });
+    if (rebase.status !== 0) {
+      runStatus('git', ['rebase', '--abort'], {
+        cwd: worktree,
+        timeout: 30_000,
+      });
+      return {
+        behindBy,
+        pushedRebasedHead: false,
+        rebaseAttempted: true,
+        rebaseOk: false,
+        note: `${rebase.stdout}\n${rebase.stderr}`.trim(),
+      };
+    }
+
+    if (!skipLocalGates) {
+      run('bash', ['scripts/automation-verify.sh', 'affected'], {
+        cwd: worktree,
+        timeout: 30 * 60 * 1000,
+        stdio: 'inherit',
+      });
+    }
+
+    run('git', ['push', '--force-with-lease', 'origin', `HEAD:${headRef}`], {
+      cwd: worktree,
+      timeout: 120_000,
+    });
+
+    return {
+      behindBy,
+      pushedRebasedHead: true,
+      rebaseAttempted: true,
+      rebaseOk: true,
+      note: 'rebased on origin/main and pushed with force-with-lease',
+    };
+  } finally {
+    runStatus('git', ['worktree', 'remove', '--force', worktree], {
+      timeout: 60_000,
+    });
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function runEnqueue(args) {
+  const prRef = args[0];
+  if (!prRef) {
+    throw new Error('Usage: merge-queue-guard.mjs enqueue <pr-number-or-url>');
+  }
+  const dryRun =
+    hasArg(args, '--dry-run') ||
+    process.env.DRY_RUN === '1' ||
+    process.env.DRY_RUN?.toLowerCase() === 'true';
+  const skipLocalGates = hasArg(args, '--skip-local-gates');
+  const pr = loadPr(prRef);
+  const labels = new Set(labelNames(pr.labels));
+
+  if (pr.isDraft) {
+    console.log(`PR #${pr.number} is draft; not enqueuing.`);
+    return;
+  }
+  if (['needs-human', 'hold', 'gated'].some(label => labels.has(label))) {
+    console.log(`PR #${pr.number} has a blocking label; not enqueuing.`);
+    return;
+  }
+
+  const fastPolicy = fastTrackPolicy(pr);
+  if (fastPolicy.removeFast && !dryRun) {
+    editLabels(pr.number, ['--remove-label', 'fast']);
+    console.log(
+      `Removed fast label from PR #${pr.number}: ${fastPolicy.reason}`
+    );
+  }
+
+  const changedFiles = changedFilesForPr(pr.number);
+  const overlap = detectChangedFileOverlap(
+    changedFiles,
+    listOpenAutonomousPrs(pr.number)
+  );
+  if (overlap.blocked && !fastPolicy.emergency) {
+    const reason = formatBlockedByPrReason(overlap);
+    console.log(reason);
+    if (!dryRun) {
+      comment(
+        pr.number,
+        [
+          '## Merge Queue Deferred',
+          '',
+          'This PR was not added to Graphite because it overlaps an open autonomous PR.',
+          '',
+          '```text',
+          reason,
+          '```',
+          '',
+          telemetryMarker({
+            event: 'blocked_by_pr',
+            branchStalenessCommits: null,
+            blockers: overlap.blockers.map(blocker => blocker.number),
+          }),
+        ].join('\n')
+      );
+    }
+    return;
+  }
+
+  const freshness = ensureFreshHead(pr, { skipLocalGates });
+  const decision = preQueueFreshnessDecision({
+    behindBy: freshness.behindBy,
+    rebaseAttempted: freshness.rebaseAttempted,
+    rebaseOk: freshness.rebaseOk,
+    pushedRebasedHead: freshness.pushedRebasedHead,
+    requiredStatuses: pr.statusCheckRollup,
+  });
+
+  if (decision.action === 'block_conflict') {
+    console.log(`PR #${pr.number} conflicts with current main; not enqueuing.`);
+    if (!dryRun) {
+      editLabels(pr.number, ['--add-label', NEEDS_CONFLICT_RESOLUTION_LABEL]);
+      comment(
+        pr.number,
+        [
+          '## Merge Queue Deferred',
+          '',
+          'Pre-queue freshness detected a merge conflict against current `main`.',
+          '',
+          'The `merge-queue` label was not applied. Rebase this branch on current `main`, resolve conflicts, and let CI rerun before enqueueing.',
+          '',
+          '```text',
+          freshness.note || '(no conflict output captured)',
+          '```',
+          '',
+          telemetryMarker({
+            event: 'conflict_eviction',
+            branchStalenessCommits: freshness.behindBy,
+          }),
+        ].join('\n')
+      );
+    }
+    return;
+  }
+
+  if (decision.action !== 'enqueue') {
+    console.log(`PR #${pr.number} not enqueued: ${decision.reason}`);
+    if (freshness.pushedRebasedHead && !dryRun) {
+      comment(
+        pr.number,
+        [
+          '## Merge Queue Deferred',
+          '',
+          'Pre-queue freshness rebased this branch onto current `main` and pushed it back to the PR branch.',
+          '',
+          'The `merge-queue` label was not applied because required checks must rerun on the new head first.',
+          '',
+          telemetryMarker({
+            event: 'rebased_before_enqueue',
+            branchStalenessCommits: freshness.behindBy,
+          }),
+        ].join('\n')
+      );
+    }
+    return;
+  }
+
+  const statuses = requiredStatusDecision(pr.statusCheckRollup);
+  if (!statuses.ok) {
+    console.log(
+      `PR #${pr.number} required statuses are not green; not enqueuing.`
+    );
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`[dry-run] would add ${MERGE_QUEUE_LABEL} to PR #${pr.number}`);
+    return;
+  }
+
+  editLabels(pr.number, ['--add-label', MERGE_QUEUE_LABEL]);
+  comment(
+    pr.number,
+    telemetryMarker({
+      event: 'enqueue',
+      branchStalenessCommits: freshness.behindBy,
+      speculativeRerun: false,
+    })
+  );
+  console.log(`Added PR #${pr.number} to Graphite merge queue.`);
+}
+
+function runDispatchConflictCheck(args) {
+  const candidatePath = argValue(args, '--candidate-json');
+  if (!candidatePath) {
+    throw new Error(
+      'Usage: merge-queue-guard.mjs dispatch-conflicts --candidate-json <path>'
+    );
+  }
+  const candidate = JSON.parse(readFileSync(candidatePath, 'utf8'));
+  const result = detectIssueOverlap(candidate, listOpenAutonomousPrs(null));
+  if (hasArg(args, '--json')) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.blocked) {
+    console.log(formatBlockedByPrReason(result));
+  } else {
+    console.log('No autonomous PR overlap detected.');
+  }
+  if (result.blocked) process.exitCode = 2;
+}
+
+function timelineForPr(number) {
+  const pages = ghJson([
+    'api',
+    `repos/${repo}/issues/${number}/timeline?per_page=100`,
+    '--paginate',
+    '--slurp',
+  ]);
+  return pages.flat();
+}
+
+function runTelemetryReport(args) {
+  const days = Number(argValue(args, '--days', '1'));
+  const sinceMs = Date.now() - days * 24 * 60 * 60 * 1000;
+  const prs = ghJson([
+    'pr',
+    'list',
+    '--repo',
+    repo,
+    '--state',
+    'all',
+    '--limit',
+    '100',
+    '--json',
+    'number,title,url,state,createdAt,mergedAt,closedAt,labels',
+  ]);
+
+  const rows = prs
+    .filter(pr => {
+      const timestamp = pr.mergedAt || pr.closedAt || pr.createdAt;
+      return timestamp && new Date(timestamp).getTime() >= sinceMs;
+    })
+    .map(pr => ({
+      pr,
+      metrics: parseMergeQueueTimeline(timelineForPr(pr.number)),
+    }))
+    .filter(
+      row => row.metrics.queuedAt.length > 0 || row.metrics.dequeueCount > 0
+    );
+
+  const mergedDurations = rows
+    .map(row => row.metrics.queuedToMergedSeconds)
+    .filter(value => Number.isFinite(value));
+  const averageSeconds =
+    mergedDurations.length > 0
+      ? Math.round(
+          mergedDurations.reduce((sum, value) => sum + value, 0) /
+            mergedDurations.length
+        )
+      : null;
+  const totalConflictEvictions = rows.reduce(
+    (sum, row) => sum + row.metrics.conflictEvictions,
+    0
+  );
+  const totalCiEvictions = rows.reduce(
+    (sum, row) => sum + row.metrics.ciEvictions,
+    0
+  );
+  const totalRequeues = rows.reduce(
+    (sum, row) => sum + row.metrics.requeueCount,
+    0
+  );
+
+  const lines = [
+    '# Merge Queue Daily Telemetry',
+    '',
+    `Window: last ${days} day(s)`,
+    '',
+    `- PRs with queue activity: ${rows.length}`,
+    `- Average queued-to-merged: ${averageSeconds === null ? 'n/a' : `${Math.round(averageSeconds / 60)}m`}`,
+    `- Conflict evictions: ${totalConflictEvictions}`,
+    `- CI evictions: ${totalCiEvictions}`,
+    `- Requeues: ${totalRequeues}`,
+    '',
+    '| PR | Requeues | Conflict Evictions | CI Evictions | Staleness At Enqueue | Queued To Merged |',
+    '| --- | ---: | ---: | ---: | ---: | ---: |',
+  ];
+
+  for (const row of rows) {
+    const minutes =
+      row.metrics.queuedToMergedSeconds === null
+        ? 'n/a'
+        : `${Math.round(row.metrics.queuedToMergedSeconds / 60)}m`;
+    lines.push(
+      `| [#${row.pr.number}](${row.pr.url}) ${row.pr.title.replaceAll('|', '\\|')} | ${row.metrics.requeueCount} | ${row.metrics.conflictEvictions} | ${row.metrics.ciEvictions} | ${row.metrics.branchStalenessAtEnqueue ?? 'n/a'} | ${minutes} |`
+    );
+  }
+
+  const report = `${lines.join('\n')}\n`;
+  const output = argValue(args, '--output');
+  if (output) {
+    writeFileSync(output, report);
+  }
+  console.log(report);
+}
+
+function main() {
+  const [, , command, ...args] = process.argv;
+  switch (command) {
+    case 'enqueue':
+      runEnqueue(args);
+      break;
+    case 'dispatch-conflicts':
+      runDispatchConflictCheck(args);
+      break;
+    case 'telemetry-report':
+      runTelemetryReport(args);
+      break;
+    default:
+      throw new Error(
+        'Usage: merge-queue-guard.mjs <enqueue|dispatch-conflicts|telemetry-report>'
+      );
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- Add `scripts/merge-queue-guard.mjs enqueue` as the single generated/bot enrollment path for Graphite labels.
- Rewire agent pipeline, landing sweep, train/orchestrator loops, autofix, screenshots, and Dependabot to call the guard instead of applying `merge-queue` directly.
- Document the guarded enqueue flow and remove ordinary generated `fast` treatment unless a PR is explicitly emergency/hotfix classified.

## Stack
- Depends on #11319 for pure guard helpers and tests.
- Next PR adds dispatch-side overlap serialization.

## Verification
- `node --check scripts/merge-queue-guard.mjs`
- `pnpm exec actionlint .github/workflows/agent-pipeline.yml .github/workflows/agent-landing-sweep.yml .github/workflows/dependabot-auto-merge.yml .github/workflows/screenshots.yml`
- `pnpm exec actionlint -shellcheck= .github/workflows/main-autofix.yml .github/workflows/sentry-autofix.yml`
