### PR TITLE
fix(ci): serialize overlapping agent dispatch

### DIFF
--- a/.github/workflows/linear-ai-dispatcher.yml
+++ b/.github/workflows/linear-ai-dispatcher.yml
@@ -53,9 +53,17 @@ jobs:
           app-id: ${{ vars.JOVIE_BOT_APP_ID }}
           private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
 
+      - name: Checkout dispatch policy code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
       - name: Find capacity and dispatch candidates
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         run: |
           set -euo pipefail
@@ -123,6 +131,76 @@ jobs:
               echo "Open PR already exists for $ISSUE_IDENTIFIER; skipping"
               continue
             fi
+
+            CANDIDATE_JSON=$(mktemp)
+            jq -cn \
+              --arg id "$ISSUE_ID" \
+              --arg identifier "$ISSUE_IDENTIFIER" \
+              --arg title "$ISSUE_TITLE" \
+              --arg description "$ISSUE_DESCRIPTION" \
+              '{id: $id, identifier: $identifier, title: $title, description: $description}' \
+              > "$CANDIDATE_JSON"
+
+            CONFLICT_JSON=$(mktemp)
+            set +e
+            node scripts/merge-queue-guard.mjs dispatch-conflicts \
+              --candidate-json "$CANDIDATE_JSON" \
+              --json > "$CONFLICT_JSON"
+            CONFLICT_STATUS=$?
+            set -e
+            rm -f "$CANDIDATE_JSON"
+
+            if [[ "$CONFLICT_STATUS" -ne 0 && "$CONFLICT_STATUS" -ne 2 ]]; then
+              echo "::warning::${ISSUE_IDENTIFIER} dispatch overlap check failed closed (exit=${CONFLICT_STATUS}); not dispatching this candidate"
+              cat "$CONFLICT_JSON" || true
+              rm -f "$CONFLICT_JSON"
+              continue
+            fi
+
+            if [[ "$CONFLICT_STATUS" -eq 2 ]]; then
+              BLOCK_REASON=$(jq -r '.blockers[] | "blocked by PR #\(.number) (\(.headRefName)): \(.reason)"' "$CONFLICT_JSON" | head -5)
+              echo "${ISSUE_IDENTIFIER} blocked by in-flight autonomous PR overlap:"
+              echo "$BLOCK_REASON"
+
+              EXISTING_BLOCKED_COMMENT=$(curl -sS --connect-timeout 10 --max-time 30 \
+                https://api.linear.app/graphql \
+                -H "Authorization: ${LINEAR_API_KEY}" \
+                -H 'Content-Type: application/json' \
+                -d "$(jq -cn \
+                  --arg issueId "$ISSUE_ID" \
+                  '{
+                    query: "query BlockedByPrComments($issueId: String!) { issue(id: $issueId) { comments(first: 20) { nodes { body } } } }",
+                    variables: { issueId: $issueId }
+                  }')" \
+                | jq -r --arg reason "$BLOCK_REASON" '[.data.issue.comments.nodes[]?.body // "" | contains($reason)] | any' 2>/dev/null || echo "false")
+
+              if [[ "$EXISTING_BLOCKED_COMMENT" == "true" ]]; then
+                rm -f "$CONFLICT_JSON"
+                continue
+              fi
+
+              COMMENT_RESPONSE_FILE=$(mktemp)
+              COMMENT_HTTP=$(curl -sS --connect-timeout 10 --max-time 30 -o "$COMMENT_RESPONSE_FILE" -w '%{http_code}' \
+                https://api.linear.app/graphql \
+                -H "Authorization: ${LINEAR_API_KEY}" \
+                -H 'Content-Type: application/json' \
+                -d "$(jq -cn \
+                  --arg issueId "$ISSUE_ID" \
+                  --arg body "Linear AI Dispatcher did not dispatch ${ISSUE_IDENTIFIER}: ${BLOCK_REASON}. The dispatcher will retry after the blocking PR lands or closes." \
+                  '{
+                    query: "mutation AddBlockedByPrComment($issueId: String!, $body: String!) { commentCreate(input: { issueId: $issueId, body: $body }) { success } }",
+                    variables: { issueId: $issueId, body: $body }
+                  }')" 2>/dev/null) || true
+              COMMENT_SUCCESS=$(jq -r '.data.commentCreate.success // false' < "$COMMENT_RESPONSE_FILE" 2>/dev/null || echo "false")
+              if [[ "$COMMENT_HTTP" != "200" || "$COMMENT_SUCCESS" != "true" ]]; then
+                echo "::warning::Linear blocked-by-PR comment failed for ${ISSUE_IDENTIFIER} (http=${COMMENT_HTTP}, success=${COMMENT_SUCCESS})"
+                cat "$COMMENT_RESPONSE_FILE" || true
+                echo
+              fi
+              rm -f "$COMMENT_RESPONSE_FILE" "$CONFLICT_JSON"
+              continue
+            fi
+            rm -f "$CONFLICT_JSON"
 
             if [[ "${DRY_RUN,,}" == "true" ]]; then
               continue

--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -11,7 +11,7 @@
  * issue is eligible and claimed.
  */
 
-import { execFileSync, spawn } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import {
   appendFileSync,
   closeSync,
@@ -379,6 +379,95 @@ function commentIssue(
     ],
     config
   );
+}
+
+function issueHasCommentContaining(
+  config: ShipperConfig,
+  issueNumber: number,
+  needle: string
+): boolean {
+  try {
+    const raw = run(
+      [
+        'gh',
+        'api',
+        `repos/${config.repo}/issues/${issueNumber}/comments`,
+        '--paginate',
+        '--slurp',
+      ],
+      config
+    );
+    const pages = JSON.parse(raw) as ReadonlyArray<
+      ReadonlyArray<{ body?: string }>
+    >;
+    const comments = pages.flat();
+    return comments.some(comment => comment.body?.includes(needle));
+  } catch {
+    return false;
+  }
+}
+
+function dispatchOverlapReason(
+  config: ShipperConfig,
+  plan: DispatchPlan
+): string | null {
+  const candidatePath = join(
+    tmpdir(),
+    `jovie-dispatch-candidate-${plan.issue.number}-${Date.now()}.json`
+  );
+  writeFileSync(
+    candidatePath,
+    `${JSON.stringify({
+      id: String(plan.issue.number),
+      title: plan.issue.title,
+      description: plan.issue.body ?? '',
+    })}\n`
+  );
+
+  try {
+    const result = spawnSync(
+      'node',
+      [
+        'scripts/merge-queue-guard.mjs',
+        'dispatch-conflicts',
+        '--candidate-json',
+        candidatePath,
+        '--json',
+      ],
+      {
+        cwd: config.repoRoot,
+        encoding: 'utf8',
+        timeout: 60_000,
+        env: {
+          ...process.env,
+          GH_REPO: config.repo,
+        },
+      }
+    );
+
+    if (result.status === 0) return null;
+    if (result.status !== 2) {
+      throw new Error((result.stderr || result.stdout).trim());
+    }
+
+    const parsed = JSON.parse(result.stdout) as {
+      blockers?: ReadonlyArray<{
+        number: number;
+        headRefName: string;
+        reason: string;
+      }>;
+    };
+    const blockers = parsed.blockers ?? [];
+    return blockers
+      .slice(0, 5)
+      .map(
+        blocker =>
+          `blocked by PR #${blocker.number} (${blocker.headRefName}): ${blocker.reason}`
+      )
+      .join('\n');
+  } finally {
+    rmSync(candidatePath, { force: true });
+  }
 }
 
 function claimIssue(config: ShipperConfig, plan: DispatchPlan): void {
@@ -865,6 +954,60 @@ async function dispatchBatch(
   );
 }
 
+function filterPlansBlockedByOpenPrs(
+  config: ShipperConfig,
+  plans: ReadonlyArray<DispatchPlan>
+): ReadonlyArray<DispatchPlan> {
+  const unblocked: DispatchPlan[] = [];
+
+  for (const plan of plans) {
+    let reason: string | null;
+    try {
+      reason = dispatchOverlapReason(config, plan);
+    } catch (err) {
+      reason = `dispatch overlap check failed closed: ${shortError(err)}`;
+    }
+
+    if (!reason) {
+      unblocked.push(plan);
+      continue;
+    }
+
+    logJobEvent({
+      job: JOB,
+      event: 'dispatch_blocked_by_pr',
+      issue: plan.issue.number,
+      reason,
+    });
+
+    const marker = `codex issue shipper blocked-by-pr ${plan.issue.number}`;
+    if (!issueHasCommentContaining(config, plan.issue.number, marker)) {
+      try {
+        commentIssue(
+          config,
+          plan.issue.number,
+          [
+            `Jovie agent (codex issue shipper) did not dispatch this issue because it overlaps in-flight autonomous work.`,
+            '',
+            reason,
+            '',
+            `Marker: ${marker}`,
+          ].join('\n')
+        );
+      } catch (err) {
+        logJobEvent({
+          job: JOB,
+          event: 'dispatch_blocked_comment_failed',
+          issue: plan.issue.number,
+          error: shortError(err),
+        });
+      }
+    }
+  }
+
+  return unblocked;
+}
+
 async function main(): Promise<void> {
   loadHermesEnv();
   const repoRoot = detectRepoRoot();
@@ -884,7 +1027,10 @@ async function main(): Promise<void> {
             labelNames(issue).includes(HUMAN_REVIEW_LABEL)
           ).length;
           const capacity = systemCapacity(config);
-          const batch = plans.slice(0, capacity.allowedAgents);
+          const batch = filterPlansBlockedByOpenPrs(
+            config,
+            plans.slice(0, capacity.allowedAgents)
+          );
 
           logJobEvent({
             job: JOB,


### PR DESCRIPTION
## Summary
- Add dispatch overlap checks to the Linear AI dispatcher before starting new autonomous work.
- Add the same fail-closed overlap check to Hermes `codex-issue-shipper` before claiming and dispatching issues.
- Emit explicit blocked-by-PR reasons when candidate issue text overlaps open autonomous PR hot files or subsystems.

## Stack
- Depends on #11320 for guarded queue enrollment.
- Top PR adds ratchet comparison and telemetry reporting.

## Verification
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/merge-queue-guard.test.mjs lib/__tests__/codex-issue-shipper.test.mjs`
- `pnpm biome check --write scripts/hermes/jobs/codex-issue-shipper.ts`
- `pnpm exec actionlint .github/workflows/linear-ai-dispatcher.yml`
