### PR TITLE
fix(tests): stabilize proxy-state parallel gate/DB assertion (JOV-3298)

### DIFF
--- a/apps/web/tests/unit/lib/auth/proxy-state.test.ts
+++ b/apps/web/tests/unit/lib/auth/proxy-state.test.ts
@@ -112,30 +112,47 @@ describe('proxy-state.ts', () => {
 
   describe('getUserState', () => {
     it('fetches waitlist gate in parallel with the DB query on cache miss', async () => {
-      let gateLookupStarted = false;
-      let dbLookupStarted = false;
+      let releaseGate!: () => void;
+      let releaseDb!: () => void;
 
-      mockIsWaitlistGateEnabled.mockImplementation(async () => {
-        gateLookupStarted = true;
-        expect(dbLookupStarted).toBe(true);
-        return true;
+      const gateBlocker = new Promise<boolean>(resolve => {
+        releaseGate = () => resolve(true);
+      });
+      const dbBlocker = new Promise<never[]>(resolve => {
+        releaseDb = () => resolve([]);
+      });
+
+      let gateInFlight = false;
+      let dbInFlight = false;
+
+      mockIsWaitlistGateEnabled.mockImplementation(() => {
+        gateInFlight = true;
+        return gateBlocker;
       });
 
       mockDbSelect.mockReturnValue({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockImplementation(async () => {
-                dbLookupStarted = true;
-                expect(gateLookupStarted).toBe(true);
-                return [];
+              limit: vi.fn().mockImplementation(() => {
+                dbInFlight = true;
+                return dbBlocker;
               }),
             }),
           }),
         }),
       });
 
-      await getUserState('clerk_parallel_gate');
+      const pending = getUserState('clerk_parallel_gate');
+
+      // Promise.all starts both operations; neither should complete before both are in flight.
+      await Promise.resolve();
+      expect(gateInFlight).toBe(true);
+      expect(dbInFlight).toBe(true);
+
+      releaseGate();
+      releaseDb();
+      await pending;
 
       expect(mockIsWaitlistGateEnabled).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
## Summary

- Replaces ordering assertions inside `Promise.all` mocks with an in-flight overlap check
- The old test asserted that operation B had already started inside operation A's mock — this races under CI scheduling because JS microtask ordering between async calls is not guaranteed
- Root cause: `expect(dbLookupStarted).toBe(true)` inside the gate mock assumed the DB branch always started first, which is false when both run via `Promise.all`

**Causal chain:** `Promise.all([executeUserStateQuery(), isWaitlistGateEnabled()])` → each branch starts as a microtask → CI scheduler interleaves them → gate mock fires before DB `limit()` call → `expected false to be true` at ~9.2% rate (10/109 runs)

## Fix

New approach:
1. Both mocks set an `inFlight` flag and return a blocker promise (never resolves until explicitly released)
2. After one microtask tick (`await Promise.resolve()`), both flags must be `true` — this is deterministic because `Promise.all` evaluates both arguments synchronously
3. `releaseGate()` / `releaseDb()` are called to let the test complete normally

## Test plan
- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/lib/auth/proxy-state.test.ts` — 18/18 pass
- [x] Biome lint on changed file — no issues
- Closes GH-11216 / JOV-3298

<!-- linear-issue-id:JOV-3298 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)