### PR TITLE
chore: candidate follow-up: Per-card impression + CTR analytics for catalog car (#11118)

### DIFF
--- a/apps/web/components/features/home/HomeProfileShowcase.tsx
+++ b/apps/web/components/features/home/HomeProfileShowcase.tsx
@@ -18,6 +18,7 @@ import { HomePhoneFrame } from './HomePhoneFrame';
 import {
   HOMEPAGE_PROFILE_PREVIEW_ARTIST,
   HOMEPAGE_PROFILE_PREVIEW_CONTACTS,
+  HOMEPAGE_PROFILE_PREVIEW_DRAWER_RELEASES,
   HOMEPAGE_PROFILE_PREVIEW_MOCK_HOME_ARTIST,
   HOMEPAGE_PROFILE_PREVIEW_MOCK_HOME_RELEASE,
   HOMEPAGE_PROFILE_PREVIEW_MOCK_HOME_SOCIAL_LINKS,
@@ -173,6 +174,14 @@ function getLatestRelease(stateId: ProfileShowcaseStateId) {
   }
 }
 
+function getPreviewReleases(stateId: ProfileShowcaseStateId) {
+  if (stateId === 'mock-home' || getLatestRelease(stateId) !== null) {
+    return [...HOMEPAGE_PROFILE_PREVIEW_DRAWER_RELEASES];
+  }
+
+  return [];
+}
+
 function getTourDates(stateId: ProfileShowcaseStateId) {
   switch (stateId) {
     case 'mock-home':
@@ -269,6 +278,7 @@ function ShowcaseSurface({
         pressPhotos={[]}
         allowPhotoDownloads={false}
         tourDates={getTourDates(state.id)}
+        releases={getPreviewReleases(state.id)}
         viewerLocation={getViewerLocation(state.id)}
         resolveNearbyTour={shouldResolveNearbyTour(state.id)}
         showSubscriptionConfirmedBanner={state.showSubscriptionConfirmedBanner}

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -4,7 +4,6 @@ import { Bell } from 'lucide-react';
 import { useMemo } from 'react';
 import {
   type EntityCardModel,
-  EntityCarousel,
   merchToEntityCard,
   releaseToEntityCard,
   showToEntityCard,
@@ -26,6 +25,8 @@ import { getProfileReleaseVisibility } from '@/lib/profile/release-visibility';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import { cn } from '@/lib/utils';
 import type { Artist } from '@/types/db';
+import { ReleaseCatalogCarousel } from './ReleaseCatalogCarousel';
+import type { PublicRelease } from './releases/types';
 
 interface ProfileHomeRailProps {
   readonly artist: Artist;
@@ -44,6 +45,7 @@ interface ProfileHomeRailProps {
   readonly viewerLocation?: UserLocation | null;
   readonly resolveNearbyTour?: boolean;
   readonly merchCards?: readonly PublicMerchCard[];
+  readonly releases?: readonly PublicRelease[];
 }
 
 function getUpcomingTourDates(
@@ -128,7 +130,7 @@ function HomeAlertsCard({
         aria-hidden='true'
         data-testid='profile-home-alerts-switch'
       >
-        <span className='block h-6 w-6 rounded-full bg-white shadow-[0_3px_10px_rgba(0,0,0,0.32)]' />
+        <span className='block h-6 w-6 rounded-full bg-white dark:bg-white shadow-[0_3px_10px_rgba(0,0,0,0.32)]' />
       </span>
     </>
   );
@@ -167,6 +169,7 @@ export function ProfileHomeRail({
   viewerLocation,
   resolveNearbyTour = true,
   merchCards = [],
+  releases = [],
 }: Readonly<ProfileHomeRailProps>) {
   // Re-evaluate visibility at the release boundary so the rail's "Drops in"
   // chrome transitions to "Out Now" when the release drops, even if the
@@ -202,10 +205,19 @@ export function ProfileHomeRail({
     const hasFeaturedRelease = Boolean(
       releaseVisibility?.show && latestRelease
     );
+    const featuredReleaseSlug =
+      hasFeaturedRelease && latestRelease ? latestRelease.slug : null;
+    const featuredReleaseId =
+      featuredReleaseSlug === null
+        ? null
+        : (releases.find(release => release.slug === featuredReleaseSlug)?.id ??
+          null);
+
     if (hasFeaturedRelease && latestRelease) {
       items.push(
         releaseToEntityCard(
           {
+            id: featuredReleaseId ?? undefined,
             title: latestRelease.title,
             slug: latestRelease.slug,
             artworkUrl: latestRelease.artworkUrl,
@@ -233,6 +245,14 @@ export function ProfileHomeRail({
           external: true,
         },
       });
+    }
+
+    // Back catalog: include non-featured releases in the same carousel.
+    for (const release of releases) {
+      if (release.slug === '' || release.slug === featuredReleaseSlug) {
+        continue;
+      }
+      items.push(releaseToEntityCard(release, { handle: artist.handle, now }));
     }
 
     // Shoppable merch (revenue) next.
@@ -265,6 +285,7 @@ export function ProfileHomeRail({
     merchCards,
     nearbyTourDateId,
     now,
+    releases,
     releaseVisibility?.show,
     upcomingTourDates,
   ]);
@@ -292,10 +313,11 @@ export function ProfileHomeRail({
       data-testid='profile-home-rail'
     >
       {alertsCard}
-      <EntityCarousel
+      <ReleaseCatalogCarousel
         items={carouselItems}
-        surface='pearl'
-        dataTestId='profile-home-carousel'
+        artistHandle={artist.handle}
+        artistId={artist.id}
+        analyticsEnabled={renderMode !== 'preview'}
       />
     </div>
   );

--- a/apps/web/components/features/profile/ReleaseCatalogCarousel.tsx
+++ b/apps/web/components/features/profile/ReleaseCatalogCarousel.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useCallback } from 'react';
+import { EntityCarousel } from '@/components/organisms/entity-card';
+import type { EntityCardModel } from '@/components/organisms/entity-card/types';
+import { track } from '@/lib/analytics';
+
+interface ReleaseCatalogCarouselProps {
+  readonly items: readonly EntityCardModel[];
+  readonly artistHandle: string;
+  readonly artistId: string;
+  readonly analyticsEnabled?: boolean;
+  readonly dataTestId?: string;
+}
+
+function isCatalogMusicCard(model: EntityCardModel): boolean {
+  return model.kind === 'music' || model.kind === 'video';
+}
+
+function resolveReleaseId(model: EntityCardModel): string {
+  return model.releaseId ?? model.id;
+}
+
+export function ReleaseCatalogCarousel({
+  items,
+  artistHandle,
+  artistId,
+  analyticsEnabled = true,
+  dataTestId = 'profile-home-carousel',
+}: Readonly<ReleaseCatalogCarouselProps>) {
+  const handleCardImpression = useCallback(
+    (index: number, model: EntityCardModel) => {
+      if (!analyticsEnabled || !isCatalogMusicCard(model)) {
+        return;
+      }
+
+      track('catalog_carousel_card_impression', {
+        release_id: resolveReleaseId(model),
+        index,
+        artist_handle: artistHandle,
+        artist_id: artistId,
+        profile_id: artistId,
+        profile_slug: artistHandle,
+        release_slug: model.id,
+        is_featured: index === 0,
+        current_route_tab: 'home',
+      });
+    },
+    [analyticsEnabled, artistHandle, artistId]
+  );
+
+  const handleCardClick = useCallback(
+    (index: number, model: EntityCardModel) => {
+      if (!analyticsEnabled || !isCatalogMusicCard(model)) {
+        return;
+      }
+
+      track('catalog_carousel_listen_click', {
+        release_id: resolveReleaseId(model),
+        index,
+        artist_handle: artistHandle,
+        artist_id: artistId,
+        profile_id: artistId,
+        profile_slug: artistHandle,
+        release_slug: model.id,
+        is_featured: index === 0,
+        current_route_tab: 'home',
+        cta_location: 'catalog_carousel',
+      });
+    },
+    [analyticsEnabled, artistHandle, artistId]
+  );
+
+  return (
+    <EntityCarousel
+      items={items}
+      surface='pearl'
+      dataTestId={dataTestId}
+      onCardImpression={handleCardImpression}
+      onCardClick={handleCardClick}
+    />
+  );
+}

--- a/apps/web/components/features/profile/ReleaseCatalogCarousel.tsx
+++ b/apps/web/components/features/profile/ReleaseCatalogCarousel.tsx
@@ -13,12 +13,14 @@ interface ReleaseCatalogCarouselProps {
   readonly dataTestId?: string;
 }
 
-function isCatalogMusicCard(model: EntityCardModel): boolean {
-  return model.kind === 'music' || model.kind === 'video';
-}
-
-function resolveReleaseId(model: EntityCardModel): string {
-  return model.releaseId ?? model.id;
+function isCatalogReleaseCard(
+  model: EntityCardModel
+): model is EntityCardModel & { readonly releaseId: string } {
+  return (
+    (model.kind === 'music' || model.kind === 'video') &&
+    typeof model.releaseId === 'string' &&
+    model.releaseId.length > 0
+  );
 }
 
 export function ReleaseCatalogCarousel({
@@ -30,12 +32,12 @@ export function ReleaseCatalogCarousel({
 }: Readonly<ReleaseCatalogCarouselProps>) {
   const handleCardImpression = useCallback(
     (index: number, model: EntityCardModel) => {
-      if (!analyticsEnabled || !isCatalogMusicCard(model)) {
+      if (!analyticsEnabled || !isCatalogReleaseCard(model)) {
         return;
       }
 
       track('catalog_carousel_card_impression', {
-        release_id: resolveReleaseId(model),
+        release_id: model.releaseId,
         index,
         artist_handle: artistHandle,
         artist_id: artistId,
@@ -51,12 +53,12 @@ export function ReleaseCatalogCarousel({
 
   const handleCardClick = useCallback(
     (index: number, model: EntityCardModel) => {
-      if (!analyticsEnabled || !isCatalogMusicCard(model)) {
+      if (!analyticsEnabled || !isCatalogReleaseCard(model)) {
         return;
       }
 
       track('catalog_carousel_listen_click', {
-        release_id: resolveReleaseId(model),
+        release_id: model.releaseId,
         index,
         artist_handle: artistHandle,
         artist_id: artistId,

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -575,7 +575,7 @@ export function ProfileCompactSurface({
 
               {!isHomeMode ? (
                 <p
-                  className='absolute left-14 right-14 top-[max(env(safe-area-inset-top),14px)] truncate text-center text-sm font-semibold tracking-[-0.012em] text-white'
+                  className='absolute left-14 right-14 top-[max(env(safe-area-inset-top),14px)] truncate text-center text-sm font-semibold tracking-[-0.012em] text-white dark:text-white'
                   data-testid={
                     renderMode === 'preview' ? undefined : 'profile-header'
                   }
@@ -620,7 +620,7 @@ export function ProfileCompactSurface({
                     data-testid='profile-identity-link'
                     href={profileHref}
                     aria-label={`Go to ${artist.name}'s profile`}
-                    className='inline-flex max-w-full min-w-0 flex-wrap items-start gap-1 rounded-md text-3xl font-semibold leading-none tracking-normal text-white drop-shadow-[0_2px_14px_rgba(0,0,0,0.42)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent [@media(max-height:820px)]:text-2xl [@media(max-height:760px)]:text-2xl'
+                    className='inline-flex max-w-full min-w-0 flex-wrap items-start gap-1 rounded-md text-3xl font-semibold leading-none tracking-normal text-white dark:text-white drop-shadow-[0_2px_14px_rgba(0,0,0,0.42)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent [@media(max-height:820px)]:text-2xl [@media(max-height:760px)]:text-2xl'
                   >
                     <span className='min-w-0 max-w-full [overflow-wrap:anywhere]'>
                       {artist.name}
@@ -738,6 +738,7 @@ export function ProfileCompactSurface({
                 viewerLocation={viewerLocation}
                 resolveNearbyTour={resolveNearbyTour}
                 merchCards={merchCards}
+                releases={releases}
               />
             ) : (
               <ProfilePrimaryTabPanel

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -16,6 +16,7 @@ interface EntityCardProps {
   readonly className?: string;
   readonly priority?: boolean;
   readonly dataTestId?: string;
+  readonly onClick?: () => void;
 }
 
 type SizeConfig = {
@@ -58,6 +59,7 @@ function CardShell({
   testId,
   className,
   style,
+  onClick,
   children,
 }: Readonly<{
   href?: string | null;
@@ -65,6 +67,7 @@ function CardShell({
   testId?: string;
   className: string;
   style?: CSSProperties;
+  onClick?: () => void;
   children: ReactNode;
 }>) {
   if (href?.startsWith('/')) {
@@ -75,6 +78,7 @@ function CardShell({
         className={className}
         style={style}
         data-testid={testId}
+        onClick={onClick}
       >
         {children}
       </Link>
@@ -89,6 +93,7 @@ function CardShell({
         className={className}
         style={style}
         data-testid={testId}
+        onClick={onClick}
       >
         {children}
       </a>
@@ -108,6 +113,7 @@ export function EntityCard({
   className,
   priority = false,
   dataTestId,
+  onClick,
 }: EntityCardProps) {
   const size = SIZE[treatment];
   const preset = KIND_PRESETS[model.kind];
@@ -127,6 +133,7 @@ export function EntityCard({
       href={cardHref}
       external={cardExternal}
       testId={dataTestId ?? `entity-card-${model.kind}`}
+      onClick={onClick}
       className={cn(
         'group flex min-w-0 flex-col gap-3 p-3 text-left transition-[background-color,border-color] duration-subtle focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]',
         isPearl

--- a/apps/web/components/organisms/entity-card/EntityCarousel.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
 import { EntityCard } from './EntityCard';
 import type { EntityCardModel, EntitySurface } from './types';
@@ -7,6 +10,8 @@ interface EntityCarouselProps {
   readonly surface?: EntitySurface;
   readonly className?: string;
   readonly dataTestId?: string;
+  readonly onCardImpression?: (index: number, model: EntityCardModel) => void;
+  readonly onCardClick?: (index: number, model: EntityCardModel) => void;
 }
 
 /**
@@ -24,7 +29,65 @@ export function EntityCarousel({
   surface = 'pearl',
   className,
   dataTestId,
+  onCardImpression,
+  onCardClick,
 }: EntityCarouselProps) {
+  const itemRefs = useRef<Array<HTMLLIElement | null>>([]);
+  const trackedImpressionKeys = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!onCardImpression || items.length === 0) {
+      return;
+    }
+
+    if (typeof IntersectionObserver === 'undefined') {
+      for (const [index, model] of items.entries()) {
+        const key = `${model.kind}-${model.id}-${index}`;
+        if (trackedImpressionKeys.current.has(key)) {
+          continue;
+        }
+        trackedImpressionKeys.current.add(key);
+        onCardImpression(index, model);
+      }
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) {
+            continue;
+          }
+
+          const index = Number(
+            entry.target.getAttribute('data-carousel-index')
+          );
+          const model = items[index];
+          if (!model) {
+            continue;
+          }
+
+          const key = `${model.kind}-${model.id}-${index}`;
+          if (trackedImpressionKeys.current.has(key)) {
+            continue;
+          }
+
+          trackedImpressionKeys.current.add(key);
+          onCardImpression(index, model);
+        }
+      },
+      { threshold: 0.5 }
+    );
+
+    for (const node of itemRefs.current) {
+      if (node) {
+        observer.observe(node);
+      }
+    }
+
+    return () => observer.disconnect();
+  }, [items, onCardImpression]);
+
   if (items.length === 0) {
     return null;
   }
@@ -42,6 +105,10 @@ export function EntityCarousel({
         return (
           <li
             key={`${model.kind}-${model.id}`}
+            ref={node => {
+              itemRefs.current[index] = node;
+            }}
+            data-carousel-index={index}
             className={cn(
               'flex shrink-0 snap-start',
               isFeatured ? 'w-[260px]' : 'w-[180px]'
@@ -53,6 +120,9 @@ export function EntityCarousel({
               surface={surface}
               priority={isFeatured}
               className='w-full'
+              onClick={
+                onCardClick ? () => onCardClick(index, model) : undefined
+              }
             />
           </li>
         );

--- a/apps/web/components/organisms/entity-card/adapters.test.ts
+++ b/apps/web/components/organisms/entity-card/adapters.test.ts
@@ -98,6 +98,21 @@ describe('releaseToEntityCard', () => {
     expect(model.kind).toBe('video');
     expect(model.cta?.label).toBe('Watch');
   });
+
+  it('preserves the database release id for carousel analytics', () => {
+    const model = releaseToEntityCard(
+      {
+        id: 'release-42',
+        title: 'Catalog Cut',
+        slug: 'catalog-cut',
+        releaseType: 'single',
+      },
+      { handle: 'tim', now }
+    );
+
+    expect(model.releaseId).toBe('release-42');
+    expect(model.id).toBe('catalog-cut');
+  });
 });
 
 describe('showToEntityCard', () => {

--- a/apps/web/components/organisms/entity-card/adapters.ts
+++ b/apps/web/components/organisms/entity-card/adapters.ts
@@ -79,6 +79,7 @@ export function merchToEntityCard(
 }
 
 export interface ReleaseEntityInput {
+  readonly id?: string;
   readonly title: string;
   readonly slug: string;
   readonly artworkUrl?: string | null;
@@ -116,6 +117,7 @@ export function releaseToEntityCard(
 
   return {
     id: release.slug,
+    releaseId: release.id,
     kind,
     href,
     imageUrl: release.artworkUrl ?? null,

--- a/apps/web/components/organisms/entity-card/types.ts
+++ b/apps/web/components/organisms/entity-card/types.ts
@@ -51,6 +51,8 @@ export interface EntityCardCta {
  */
 export interface EntityCardModel {
   readonly id: string;
+  /** Database release id when the card represents catalog music. */
+  readonly releaseId?: string;
   readonly kind: EntityKind;
   /** Whole-card link target. Falls back to `cta.href` for hit area. */
   readonly href?: string | null;

--- a/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { ProfileHomeRail } from '@/features/profile/ProfileHomeRail';
 import type { ProfilePrimaryActionCardRelease } from '@/features/profile/ProfilePrimaryActionCard';
+import type { PublicRelease } from '@/features/profile/releases/types';
 import type { Artist } from '@/types/db';
 
 function makeArtist(overrides: Partial<Artist> = {}): Artist {
@@ -32,6 +33,22 @@ function makeRelease(
     revealDate: null,
     releaseType: 'single',
     metadata: null,
+    ...overrides,
+  };
+}
+
+function makePublicRelease(
+  overrides: Partial<PublicRelease> = {}
+): PublicRelease {
+  return {
+    id: 'catalog-release',
+    title: 'Back Catalog',
+    slug: 'back-catalog',
+    releaseType: 'single',
+    releaseDate: '2025-01-10T07:00:00.000Z',
+    revealDate: null,
+    artworkUrl: '/img/releases/back-catalog.jpg',
+    artistNames: ['Tim White'],
     ...overrides,
   };
 }
@@ -83,6 +100,41 @@ describe('ProfileHomeRail', () => {
     expect(screen.getByTestId('profile-home-carousel')).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'The Deep End' })
+    ).toBeInTheDocument();
+  });
+
+  it('adds back-catalog releases without duplicating the featured release', () => {
+    render(
+      <ProfileHomeRail
+        artist={makeArtist()}
+        latestRelease={makeRelease()}
+        profileSettings={{ showOldReleases: true }}
+        featuredPlaylistFallback={null}
+        tourDates={[]}
+        hasPlayableDestinations
+        renderMode='preview'
+        isSubscribed={false}
+        releases={[
+          makePublicRelease({
+            id: 'release-featured',
+            title: 'The Deep End',
+            slug: 'the-deep-end',
+          }),
+          makePublicRelease({
+            id: 'release-catalog',
+            title: 'Under Lights',
+            slug: 'under-lights',
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId('profile-home-carousel')).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('heading', { name: 'The Deep End' })
+    ).toHaveLength(1);
+    expect(
+      screen.getByRole('heading', { name: 'Under Lights' })
     ).toBeInTheDocument();
   });
 

--- a/apps/web/tests/unit/profile/ReleaseCatalogCarousel.test.tsx
+++ b/apps/web/tests/unit/profile/ReleaseCatalogCarousel.test.tsx
@@ -39,17 +39,22 @@ vi.mock('next/link', () => ({
     children,
     href,
     onClick,
+    prefetch,
     ...props
   }: {
     readonly children: React.ReactNode;
     readonly href: string;
     readonly onClick?: () => void;
+    readonly prefetch?: boolean;
     readonly [key: string]: unknown;
-  }) => (
-    <a href={href} onClick={onClick} {...props}>
-      {children}
-    </a>
-  ),
+  }) => {
+    void prefetch;
+    return (
+      <a href={href} onClick={onClick} {...props}>
+        {children}
+      </a>
+    );
+  },
 }));
 
 vi.mock('@/components/atoms/ImageWithFallback', () => ({
@@ -82,6 +87,20 @@ const catalogRelease: EntityCardModel = {
   imageAlt: 'Under Lights artwork',
   title: 'Under Lights',
   cta: { label: 'Listen', href: '/tim/under-lights' },
+};
+
+const playlistFallback: EntityCardModel = {
+  id: 'playlist-this-is-tim',
+  kind: 'music',
+  href: 'https://open.spotify.com/playlist/this-is-tim',
+  imageUrl: '/img/playlists/this-is-tim.jpg',
+  imageAlt: 'This Is Tim playlist cover',
+  title: 'This Is Tim',
+  cta: {
+    label: 'Open Playlist',
+    href: 'https://open.spotify.com/playlist/this-is-tim',
+    external: true,
+  },
 };
 
 describe('ReleaseCatalogCarousel', () => {
@@ -162,6 +181,24 @@ describe('ReleaseCatalogCarousel', () => {
     trackMock.mockClear();
 
     const link = screen.getByRole('link', { name: /The Deep End/i });
+    link.addEventListener('click', event => event.preventDefault());
+    fireEvent.click(link);
+
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it('does not track music-like cards without a release id', () => {
+    render(
+      <ReleaseCatalogCarousel
+        items={[playlistFallback]}
+        artistHandle='tim'
+        artistId='artist-1'
+      />
+    );
+
+    expect(trackMock).not.toHaveBeenCalled();
+
+    const link = screen.getByRole('link', { name: /This Is Tim/i });
     link.addEventListener('click', event => event.preventDefault());
     fireEvent.click(link);
 

--- a/apps/web/tests/unit/profile/ReleaseCatalogCarousel.test.tsx
+++ b/apps/web/tests/unit/profile/ReleaseCatalogCarousel.test.tsx
@@ -1,0 +1,170 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EntityCardModel } from '@/components/organisms/entity-card/types';
+import { ReleaseCatalogCarousel } from '@/features/profile/ReleaseCatalogCarousel';
+
+const { trackMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+}));
+
+class MockIntersectionObserver {
+  private readonly callback: IntersectionObserverCallback;
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(target: Element) {
+    this.callback(
+      [
+        {
+          isIntersecting: true,
+          target,
+        } as IntersectionObserverEntry,
+      ],
+      this as unknown as IntersectionObserver
+    );
+  }
+
+  disconnect() {}
+  unobserve() {}
+}
+
+vi.mock('@/lib/analytics', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    onClick,
+    ...props
+  }: {
+    readonly children: React.ReactNode;
+    readonly href: string;
+    readonly onClick?: () => void;
+    readonly [key: string]: unknown;
+  }) => (
+    <a href={href} onClick={onClick} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/atoms/ImageWithFallback', () => ({
+  ImageWithFallback: ({
+    alt,
+    src,
+  }: {
+    readonly alt: string;
+    readonly src?: string | null;
+  }) => <img alt={alt} src={src ?? undefined} />,
+}));
+
+const featuredRelease: EntityCardModel = {
+  id: 'the-deep-end',
+  releaseId: 'release-featured',
+  kind: 'music',
+  href: '/tim/the-deep-end',
+  imageUrl: '/img/releases/the-deep-end.jpg',
+  imageAlt: 'The Deep End artwork',
+  title: 'The Deep End',
+  cta: { label: 'Listen', href: '/tim/the-deep-end' },
+};
+
+const catalogRelease: EntityCardModel = {
+  id: 'under-lights',
+  releaseId: 'release-catalog',
+  kind: 'music',
+  href: '/tim/under-lights',
+  imageUrl: '/img/releases/under-lights.jpg',
+  imageAlt: 'Under Lights artwork',
+  title: 'Under Lights',
+  cta: { label: 'Listen', href: '/tim/under-lights' },
+};
+
+describe('ReleaseCatalogCarousel', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    trackMock.mockClear();
+  });
+
+  it('tracks per-card impressions when cards become visible', () => {
+    render(
+      <ReleaseCatalogCarousel
+        items={[featuredRelease, catalogRelease]}
+        artistHandle='tim'
+        artistId='artist-1'
+      />
+    );
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'catalog_carousel_card_impression',
+      expect.objectContaining({
+        release_id: 'release-featured',
+        index: 0,
+        artist_handle: 'tim',
+        is_featured: true,
+      })
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      'catalog_carousel_card_impression',
+      expect.objectContaining({
+        release_id: 'release-catalog',
+        index: 1,
+        artist_handle: 'tim',
+        is_featured: false,
+      })
+    );
+  });
+
+  it('tracks listen CTA clicks with release context', () => {
+    render(
+      <ReleaseCatalogCarousel
+        items={[featuredRelease, catalogRelease]}
+        artistHandle='tim'
+        artistId='artist-1'
+      />
+    );
+
+    trackMock.mockClear();
+
+    const link = screen.getByRole('link', { name: /Under Lights/i });
+    link.addEventListener('click', event => event.preventDefault());
+    fireEvent.click(link);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'catalog_carousel_listen_click',
+      expect.objectContaining({
+        release_id: 'release-catalog',
+        index: 1,
+        artist_handle: 'tim',
+        cta_location: 'catalog_carousel',
+      })
+    );
+  });
+
+  it('does not emit analytics when analytics are disabled', () => {
+    render(
+      <ReleaseCatalogCarousel
+        items={[featuredRelease]}
+        artistHandle='tim'
+        artistId='artist-1'
+        analyticsEnabled={false}
+      />
+    );
+
+    trackMock.mockClear();
+
+    const link = screen.getByRole('link', { name: /The Deep End/i });
+    link.addEventListener('click', event => event.preventDefault());
+    fireEvent.click(link);
+
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/profile/profile-compact-template.test.tsx
+++ b/apps/web/tests/unit/profile/profile-compact-template.test.tsx
@@ -648,7 +648,7 @@ describe('ProfileCompactTemplate', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows the newest catalog release on Home when latestRelease is not provided', async () => {
+  it('shows catalog releases in the home carousel when latestRelease is not provided', async () => {
     render(
       <ProfileCompactTemplate
         mode='profile'
@@ -661,7 +661,7 @@ describe('ProfileCompactTemplate', () => {
 
     const homeCard = screen.getByTestId('profile-home-carousel');
     expect(homeCard).toHaveTextContent("Don't Look Down");
-    expect(homeCard).not.toHaveTextContent('Holding On');
+    expect(homeCard).toHaveTextContent('Holding On');
   });
 
   it('opens the alerts tab from the compact hero alerts row', async () => {


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (codex). Closes #11118.

Card: t_1ed51a49
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- client console errors + render of affected pages
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a release catalog carousel to artist profile home pages, displaying a curated collection of releases.
  * Implemented analytics tracking for carousel interactions (impressions and clicks).

* **Improvements**
  * Enhanced carousel card interactivity with click handlers.
  * Improved dark mode styling for profile sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->