### PR TITLE
test(album-art): verify computeAlbumArtWinner control fix (#11117)

### DIFF
--- a/apps/web/tests/unit/lib/services/album-art/ab-test.test.ts
+++ b/apps/web/tests/unit/lib/services/album-art/ab-test.test.ts
@@ -98,6 +98,18 @@ describe('computeAlbumArtWinner', () => {
     expect(result).toBeNull();
   });
 
+  it('does not promote a challenger to control when true control misses a custom threshold', () => {
+    const result = computeAlbumArtWinner(
+      [
+        { variantId: 'control', impressions: 49, clicks: 4 },
+        { variantId: 'c1', impressions: 50, clicks: 5 },
+        { variantId: 'c2', impressions: 50, clicks: 10 },
+      ],
+      { minImpressions: 50 }
+    );
+    expect(result).toBeNull();
+  });
+
   it('throws when impressions are negative', () => {
     expect(() =>
       computeAlbumArtWinner([

--- a/apps/web/tests/unit/lib/services/album-art/ab-test.test.ts
+++ b/apps/web/tests/unit/lib/services/album-art/ab-test.test.ts
@@ -87,6 +87,17 @@ describe('computeAlbumArtWinner', () => {
     expect(result).toBeNull();
   });
 
+  it('does not promote a challenger to control when true control is unqualified', () => {
+    // Regression: pre-fix code used qualified[0] as control. With two qualified
+    // challengers it would return a winner with controlId='c1' instead of null.
+    const result = computeAlbumArtWinner([
+      { variantId: 'control', impressions: minI - 1, clicks: 5 },
+      { variantId: 'c1', impressions: minI, clicks: 10 },
+      { variantId: 'c2', impressions: minI, clicks: 20 },
+    ]);
+    expect(result).toBeNull();
+  });
+
   it('throws when impressions are negative', () => {
     expect(() =>
       computeAlbumArtWinner([


### PR DESCRIPTION
## Summary

Verifies the `computeAlbumArtWinner` control-variant fix from PR #11109 (commit ebaef77), already merged to `main`.

**Root cause (trigger → symptom):** Pre-fix code filtered variants by `minImpressions` and used `qualified[0]` as control. When `variants[0]` (canonical cover art) had insufficient impressions but two challengers qualified, the first challenger was silently promoted to control — producing incorrect lift calculations and potentially declaring the wrong winner.

**Fix (already on main):** Pin `variants[0]` as control unconditionally; return `null` when control lacks sufficient impressions; filter challengers from `variants.slice(1)` only.

This PR adds a regression test that **fails on the buggy implementation** (two qualified challengers + unqualified true control previously returned a non-null result with `controlId='c1'`).

## Verification

```bash
pnpm --filter web exec vitest run tests/unit/lib/services/album-art/ab-test.test.ts
# 23 passed (23)
pnpm --filter @jovie/web run typecheck -- --pretty false
# pass
pnpm biome check --write apps/web/tests/unit/lib/services/album-art/ab-test.test.ts
# pass
```

## Files changed

- `apps/web/tests/unit/lib/services/album-art/ab-test.test.ts` — new regression test

## Risk

Low — test-only; no production logic changes.

Closes #11117

<!-- linear-issue-id:11117 -->