### PR TITLE
feat(hud): live Hermes events on Agent OS runs panel

### DIFF
--- a/apps/web/app/api/hud/hermes-events/route.ts
+++ b/apps/web/app/api/hud/hermes-events/route.ts
@@ -1,0 +1,97 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { authorizeHud } from '@/lib/auth/hud';
+import { env } from '@/lib/env-server';
+import { setHermesEventsPayload } from '@/lib/hud/hermes-events-store';
+import { logger } from '@/lib/utils/logger';
+
+export const runtime = 'nodejs';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+function authorizePost(request: NextRequest): boolean {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return false;
+  }
+  const token = authHeader.slice('Bearer '.length).trim();
+  const expected = env.HERMES_HUD_API_KEY?.trim();
+  return Boolean(expected && token === expected);
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const kioskToken = request.nextUrl.searchParams.get('kiosk');
+    const auth = await authorizeHud(kioskToken);
+    if (!auth.ok) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const { getHermesEventsPayload } = await import(
+      '@/lib/hud/hermes-events-store'
+    );
+    const payload = getHermesEventsPayload();
+    return NextResponse.json(payload, { headers: NO_STORE_HEADERS });
+  } catch (error) {
+    logger.error('HUD Hermes events GET failed', error);
+    return NextResponse.json(
+      { error: 'Failed to retrieve Hermes events' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    if (!authorizePost(request)) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const body: unknown = await request.json();
+    if (!body || typeof body !== 'object' || !('events' in body)) {
+      return NextResponse.json(
+        { error: 'Expected JSON body { events: [...] }' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const record = body as {
+      events?: unknown;
+      generatedAt?: unknown;
+    };
+    if (!Array.isArray(record.events)) {
+      return NextResponse.json(
+        { error: 'events must be an array' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const events = record.events.filter(
+      (item): item is Record<string, unknown> =>
+        Boolean(item) && typeof item === 'object' && !Array.isArray(item)
+    );
+
+    setHermesEventsPayload({
+      events,
+      generatedAt:
+        typeof record.generatedAt === 'string' ? record.generatedAt : null,
+    });
+
+    return NextResponse.json(
+      { stored: events.length },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    logger.error('HUD Hermes events POST failed', error);
+    return NextResponse.json(
+      { error: 'Failed to ingest Hermes events' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -30,6 +30,7 @@ import { ContentMetricRow } from '@/components/molecules/ContentMetricRow';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { QRCode } from '@/components/molecules/QRCode';
 import { ShellListRowFrame } from '@/components/organisms/table';
+import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
 import { AGENT_OS_ADMIN_FIXTURE_ARTIFACTS } from '@/lib/agent-os/fixtures';
 import { isHudMetricValueAvailable } from '@/lib/hud/source-trust';
 import {
@@ -662,6 +663,21 @@ export interface HudDashboardClientProps {
   readonly initialShippingData?: DailyBucket[];
   /** ISO timestamp of when shipping data was last cached. */
   readonly initialShippingCachedAt?: string;
+  /** When true and agentRuns empty, show dev fixtures on Agent OS panel. */
+  readonly useFixtureAgentRuns?: boolean;
+}
+
+function resolveAgentOsArtifacts(
+  metrics: HudMetrics,
+  useFixtureAgentRuns: boolean
+): AgentRunArtifact[] {
+  if (metrics.agentRuns.length > 0) {
+    return [...metrics.agentRuns];
+  }
+  if (useFixtureAgentRuns) {
+    return [...AGENT_OS_ADMIN_FIXTURE_ARTIFACTS];
+  }
+  return [];
 }
 
 function makeItemKey(item: HudMetrics['aiOps']['blockers'][number]): string {
@@ -689,10 +705,15 @@ export function HudDashboardClient({
   kioskToken = null,
   initialShippingData,
   initialShippingCachedAt,
+  useFixtureAgentRuns = false,
 }: HudDashboardClientProps) {
   const { data: metrics, refetch } = useHudMetricsQuery(
     initialMetrics,
     kioskToken
+  );
+  const agentOsArtifacts = resolveAgentOsArtifacts(
+    metrics,
+    useFixtureAgentRuns
   );
 
   const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(new Set());
@@ -828,7 +849,7 @@ export function HudDashboardClient({
 
         {metrics.accessMode === 'admin' ? (
           <AgentOsRunsPanel
-            artifacts={AGENT_OS_ADMIN_FIXTURE_ARTIFACTS}
+            artifacts={agentOsArtifacts}
             summary={aiOpsSummary}
             status={<HudStatusPill label={aiOpsLabel} tone={aiOpsTone} />}
             deploymentsPanel={
@@ -1203,7 +1224,7 @@ export function HudDashboardClient({
       </ContentSurfaceCard>
 
       {isShell && metrics.accessMode === 'admin' ? (
-        <AgentOsRunsPanel artifacts={AGENT_OS_ADMIN_FIXTURE_ARTIFACTS} />
+        <AgentOsRunsPanel artifacts={agentOsArtifacts} />
       ) : null}
 
       <ContentSurfaceCard

--- a/apps/web/app/app/(shell)/admin/ops/page.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/page.tsx
@@ -182,6 +182,7 @@ export default async function AdminOpsPage({
           presentationMode='admin-kiosk'
           initialShippingData={shippingPrefetch?.data}
           initialShippingCachedAt={shippingPrefetch?.cachedAt}
+          useFixtureAgentRuns={env.HUD_AGENT_RUNS_FIXTURES === '1'}
         />
       </div>
     );
@@ -295,6 +296,7 @@ export default async function AdminOpsPage({
         presentationMode='shell'
         initialShippingData={shippingPrefetch?.data}
         initialShippingCachedAt={shippingPrefetch?.cachedAt}
+        useFixtureAgentRuns={env.HUD_AGENT_RUNS_FIXTURES === '1'}
       />
     </AdminPage>
   );

--- a/apps/web/app/app/(shell)/chat/loading.tsx
+++ b/apps/web/app/app/(shell)/chat/loading.tsx
@@ -40,7 +40,7 @@ export default function ChatLoading() {
                   <textarea
                     disabled
                     rows={1}
-                    aria-label='Chat message input'
+                    aria-label='Chat Message Input'
                     placeholder='What are you working on?'
                     className='min-w-0 flex-1 resize-none bg-transparent py-1.5 text-sm leading-6 text-primary-token placeholder:text-tertiary-token focus:outline-none'
                   />

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -189,8 +189,6 @@ export const ServerEnvSchema = z.object({
   // Upstash Redis
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),
   UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
-  // Redis URL for optional caching
-  REDIS_URL: z.string().url().optional(),
 
   // Onboarding chat (anonymous session signing + bot challenge — JOV-2132)
   SESSION_SECRET: z.string().min(32).optional(),
@@ -473,6 +471,8 @@ export const ENV_KEYS = [
   'VERCEL_PRODUCTION_DEPLOY_HOOK',
   'STATSIG_SERVER_SECRET',
   'AI_GATEWAY_API_KEY',
+  'HERMES_HUD_API_KEY',
+  'HUD_AGENT_RUNS_FIXTURES',
   'OPENAI_API_KEY',
   'ELEVENLABS_API_KEY',
   'ELEVENLABS_WEBHOOK_SECRET',

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -189,6 +189,8 @@ export const ServerEnvSchema = z.object({
   // Upstash Redis
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),
   UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
+  // Redis URL for optional caching
+  REDIS_URL: z.string().url().optional(),
 
   // Onboarding chat (anonymous session signing + bot challenge — JOV-2132)
   SESSION_SECRET: z.string().min(32).optional(),
@@ -234,6 +236,14 @@ export const ServerEnvSchema = z.object({
 
   // AI Gateway auth (required for chat completions)
   AI_GATEWAY_API_KEY: z.string().optional(),
+  // Hermes HUD events ingest authentication
+  HERMES_HUD_API_KEY: z.string().optional(),
+  HUD_AGENT_RUNS_FIXTURES: z
+    .string()
+    .optional()
+    .describe(
+      'Set to 1 to show fixture Agent OS runs when live ingest is empty'
+    ),
 
   // OpenAI (for vision model fallback in asset extraction)
   OPENAI_API_KEY: z.string().optional(),

--- a/apps/web/lib/hud/hermes-events-store.ts
+++ b/apps/web/lib/hud/hermes-events-store.ts
@@ -1,0 +1,25 @@
+import 'server-only';
+
+export type HermesEventsPayload = {
+  events: Array<Record<string, unknown>>;
+  generatedAt?: string | null;
+};
+
+let latestPayload: HermesEventsPayload = { events: [], generatedAt: null };
+
+const MAX_EVENTS = 200;
+
+export function setHermesEventsPayload(payload: HermesEventsPayload): void {
+  const events = payload.events.slice(-MAX_EVENTS);
+  latestPayload = {
+    events,
+    generatedAt: payload.generatedAt ?? null,
+  };
+}
+
+export function getHermesEventsPayload(): HermesEventsPayload {
+  return {
+    events: [...latestPayload.events],
+    generatedAt: latestPayload.generatedAt,
+  };
+}

--- a/apps/web/lib/hud/hermes-events.ts
+++ b/apps/web/lib/hud/hermes-events.ts
@@ -1,0 +1,146 @@
+import type { AgentRunArtifact, AgentRunStatus } from '@/lib/agent-os/artifact';
+import { safeParseAgentRunArtifact } from '@/lib/agent-os/artifact';
+
+const GITHUB_PULL = 'https://github.com/JovieInc/Jovie/pull/';
+
+function parseTimestamp(raw: unknown): string {
+  if (typeof raw === 'string') {
+    const parsed = Date.parse(raw);
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed).toISOString();
+    }
+  }
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return new Date(raw).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function mapOutcome(outcome: unknown, detail: string): AgentRunStatus {
+  const value = String(outcome ?? '').toLowerCase();
+  if (
+    value === 'ok' ||
+    value === 'success' ||
+    value === 'done' ||
+    value === 'completed'
+  ) {
+    return 'done';
+  }
+  if (value === 'failed' || value === 'error' || value === 'fail') {
+    return 'failed';
+  }
+  if (value === 'blocked' || value === 'block') {
+    return 'blocked';
+  }
+  if (value === 'running' || value === 'start' || value === 'started') {
+    return 'running';
+  }
+  if (value === 'review') {
+    return 'review';
+  }
+  if (detail.toLowerCase().includes('blocked')) {
+    return 'blocked';
+  }
+  return 'done';
+}
+
+function stableId(event: Record<string, unknown>): string {
+  const parts = [
+    event.ts,
+    event.action,
+    event.source,
+    event.job,
+    event.pr,
+    event.run_id,
+    event.detail,
+  ]
+    .filter(Boolean)
+    .join('|');
+  let hash = 0;
+  for (let i = 0; i < parts.length; i++) {
+    hash = (hash << 5) - hash + parts.charCodeAt(i);
+    hash |= 0;
+  }
+  return `hermes-${Math.abs(hash).toString(36)}`;
+}
+
+/**
+ * Map Hermes events.jsonl records (watchdog, ship, merge queue, etc.) to Agent OS artifacts.
+ */
+export function mapHermesEventsToAgentRunArtifacts(
+  events: ReadonlyArray<Record<string, unknown>>
+): AgentRunArtifact[] {
+  const sorted = [...events].reverse();
+  const seen = new Set<string>();
+  const artifacts: AgentRunArtifact[] = [];
+
+  for (const event of sorted) {
+    const action = String(event.action ?? 'event');
+    const source = String(event.source ?? event.job ?? 'hermes');
+    const actor = String(event.actor ?? 'hermes');
+    const detail = String(event.detail ?? event.message ?? '').trim();
+    const title = `${source} · ${action}`.slice(0, 180);
+    const summary = (detail || title).slice(0, 1200);
+    const status = mapOutcome(event.outcome, detail);
+    const id = stableId(event);
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    const pr =
+      typeof event.pr === 'number'
+        ? event.pr
+        : typeof event.pr === 'string'
+          ? Number.parseInt(event.pr, 10)
+          : NaN;
+    const pullRequestUrl =
+      Number.isFinite(pr) && pr > 0 ? `${GITHUB_PULL}${pr}` : null;
+
+    const blockedReason = status === 'blocked' ? summary.slice(0, 500) : null;
+    const updatedAt = parseTimestamp(event.ts ?? event.timestamp);
+
+    const candidate = {
+      id,
+      source: 'hermes' as const,
+      sourceRunId:
+        typeof event.run_id === 'string' || typeof event.run_id === 'number'
+          ? String(event.run_id)
+          : null,
+      kind: 'workflow' as const,
+      status,
+      title,
+      summary,
+      modelRoute: 'deterministic' as const,
+      allowedActions: [] as const,
+      forbiddenActions: ['deploy', 'merge', 'mutate_production_data'] as const,
+      humanApprovalRequired: false,
+      humanGate: {
+        required: false,
+        status: 'not_required' as const,
+        reason: null,
+        reviewer: null,
+        reviewedAt: null,
+      },
+      linearIssueId: null,
+      linearIssueUrl: null,
+      pullRequestUrl,
+      adminSurface: null,
+      verificationGates: [],
+      costEstimate: null,
+      blockedReason,
+      createdAt: updatedAt,
+      updatedAt,
+      metadata: {
+        actor,
+        rawAction: action,
+        rawSource: source,
+      },
+    };
+
+    const parsed = safeParseAgentRunArtifact(candidate);
+    if (parsed.success) {
+      artifacts.push(parsed.data);
+    }
+  }
+
+  return artifacts.slice(0, 50);
+}

--- a/apps/web/lib/hud/metrics.ts
+++ b/apps/web/lib/hud/metrics.ts
@@ -10,10 +10,17 @@ import { env } from '@/lib/env-server';
 import { getHermesDispatchAvailability } from '@/lib/hermes/dispatch';
 import { ServerFetchTimeoutError } from '@/lib/http/server-fetch';
 import { getHudAiOpsSummary } from '@/lib/hud/ai-ops';
+import { mapHermesEventsToAgentRunArtifacts } from '@/lib/hud/hermes-events';
+import { getHermesEventsPayload } from '@/lib/hud/hermes-events-store';
 import { buildHudMetricSources } from '@/lib/hud/source-trust';
 import { getHudQuarantineMetrics } from '@/lib/testing/quarantine-ledger.server';
 import { logger } from '@/lib/utils/logger';
 import type { HudAccessMode, HudMetrics } from '@/types/hud';
+
+function buildHudAgentRuns(): HudMetrics['agentRuns'] {
+  const { events } = getHermesEventsPayload();
+  return mapHermesEventsToAgentRunArtifacts(events);
+}
 
 function buildHudTestingMetrics(): HudMetrics['testing'] {
   const quarantine = getHudQuarantineMetrics();
@@ -317,6 +324,7 @@ export function buildDegradedHudMetrics(
       githubOwner: env.HUD_GITHUB_OWNER,
       githubRepo: env.HUD_GITHUB_REPO,
     }),
+    agentRuns: buildHudAgentRuns(),
     generatedAtIso: fetchedAtIso,
   };
 }
@@ -419,6 +427,7 @@ async function fetchHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
     deployments,
     aiOps,
     sources,
+    agentRuns: buildHudAgentRuns(),
     generatedAtIso: fetchedAtIso,
   };
 }

--- a/apps/web/tests/e2e/onboarding-robot.smoke.spec.ts
+++ b/apps/web/tests/e2e/onboarding-robot.smoke.spec.ts
@@ -28,7 +28,9 @@ test.describe('Onboarding Robot PR Smoke', () => {
       ONBOARDING_FUNNEL_EVENTS.ONBOARDING_STARTED,
     ]);
 
-    await chatComposerInputLocator(page).fill('I am launching a test artist');
+    const composerInput = chatComposerInputLocator(page);
+    await expect(composerInput).toBeVisible({ timeout: 30_000 });
+    await composerInput.fill('I am launching a test artist');
     await page.getByRole('button', { name: 'Send message' }).click();
 
     await expect(

--- a/apps/web/tests/lib/hud/hermes-events.test.ts
+++ b/apps/web/tests/lib/hud/hermes-events.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { mapHermesEventsToAgentRunArtifacts } from '@/lib/hud/hermes-events';
+
+describe('mapHermesEventsToAgentRunArtifacts', () => {
+  it('maps merge-eval blocked events to hermes workflow artifacts', () => {
+    const artifacts = mapHermesEventsToAgentRunArtifacts([
+      {
+        ts: '2026-06-20T12:00:00.000Z',
+        source: 'pr-merge-queue',
+        action: 'merge-eval',
+        actor: 'hermes',
+        detail: '#11313 blocked: CI red: failing: E2E',
+        outcome: 'blocked',
+        pr: 11313,
+      },
+    ]);
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.source).toBe('hermes');
+    expect(artifacts[0]?.status).toBe('blocked');
+    expect(artifacts[0]?.title).toContain('pr-merge-queue');
+    expect(artifacts[0]?.pullRequestUrl).toBe(
+      'https://github.com/JovieInc/Jovie/pull/11313'
+    );
+    expect(artifacts[0]?.blockedReason).toContain('CI red');
+  });
+
+  it('dedupes identical events and caps volume', () => {
+    const row = {
+      ts: '2026-06-20T12:00:00.000Z',
+      source: 'ship',
+      action: 'ship-done',
+      outcome: 'ok',
+      detail: 'merged',
+    };
+    const artifacts = mapHermesEventsToAgentRunArtifacts([row, row]);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.status).toBe('done');
+  });
+});

--- a/apps/web/tests/lib/hud/metrics.test.ts
+++ b/apps/web/tests/lib/hud/metrics.test.ts
@@ -204,6 +204,18 @@ describe('getHudMetrics', () => {
     expect(metrics.aiOps.counts.blocked).toBe(1);
   });
 
+  it('includes live Hermes agent runs in the HUD payload', async () => {
+    mockGetHudDeployments.mockResolvedValueOnce({
+      availability: 'not_configured',
+      current: null,
+      recent: [],
+    });
+
+    const metrics = await getHudMetrics('admin');
+
+    expect(metrics.agentRuns).toEqual([]);
+  });
+
   it('includes per-source trust metadata in the HUD payload', async () => {
     mockGetHudDeployments.mockResolvedValueOnce({
       availability: 'not_configured',

--- a/apps/web/types/hud.ts
+++ b/apps/web/types/hud.ts
@@ -1,3 +1,4 @@
+import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
 import type { HermesAiOpsSummary } from '@/types/ai-ops';
 
 export type HudAccessMode = 'admin' | 'kiosk';
@@ -108,6 +109,8 @@ export interface HudMetrics {
   };
   deployments: HudDeployments;
   aiOps: HermesAiOpsSummary;
+  /** Live Hermes events mapped for Agent OS runs panel (laptop ingest). */
+  agentRuns: AgentRunArtifact[];
   /** Per-source fetch metadata for ops metric cards (freshness + failure states). */
   sources: Record<HudMetricSourceKey, HudMetricSourceTrust>;
   generatedAtIso: string;


### PR DESCRIPTION
Closes #8319

## Summary
- `POST /api/hud/hermes-events` — Bearer `HERMES_HUD_API_KEY` (pairs with `~/.hermes/scripts/publish-hud-events.py` + cron `b9fc7e745520`)
- `GET` — same auth as other HUD routes (admin session / kiosk token)
- Maps `events.jsonl` rows → `AgentRunArtifact` for `/app/admin/ops`
- Agent OS panel uses `metrics.agentRuns` when non-empty; fixtures only when `HUD_AGENT_RUNS_FIXTURES=1`

## After merge (Tim)
1. Doppler/Vercel: `HERMES_HUD_API_KEY` (shared secret with laptop publisher)
2. Optional: `HUD_AGENT_RUNS_FIXTURES=1` locally only

No deploy from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Hermes events API endpoints to ingest and retrieve HUD event data with secure authorization.
  * HUD metrics now include live Hermes-derived “agent runs” for the Agent OS runs panel.
  * Added fixture-based fallback for agent runs when live Hermes data isn’t available.
  * Introduced new environment settings for Hermes HUD authentication and fixture mode.
* **Tests**
  * Added unit tests covering Hermes event-to-artifact mapping, deduplication, and result limiting.
  * Added a HUD metrics test to verify `agentRuns` is present.
* **Chores / QA**
  * Improved onboarding and chat e2e selectors to reduce brittleness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->