### PR TITLE
chore: candidate follow-up: tour-page TourDateCard visual pass to match EntityC (#11103)

### DIFF
--- a/apps/web/app/[username]/tour/TourDateCard.test.tsx
+++ b/apps/web/app/[username]/tour/TourDateCard.test.tsx
@@ -91,6 +91,7 @@ describe('TourDateCard', () => {
     expect(
       screen.getByRole('button', { name: /add to calendar/i })
     ).toBeInTheDocument();
+    expect(screen.getByText('Sold Out')).toBeInTheDocument();
   });
 
   it('renders Get Tickets as the primary CTA when tickets are available', () => {

--- a/apps/web/app/[username]/tour/TourDateCard.test.tsx
+++ b/apps/web/app/[username]/tour/TourDateCard.test.tsx
@@ -40,7 +40,19 @@ function makeTourDate(
   };
 }
 
-describe('TourDateCard — cancelled state', () => {
+describe('TourDateCard', () => {
+  it('renders via EntityCard with the shared show test id', () => {
+    const { container } = renderWithQueryClient(
+      <TourDateCard tourDate={makeTourDate()} handle='testartist' />
+    );
+
+    expect(
+      container.querySelector('[data-testid="entity-card-show"]')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Jun')).toBeInTheDocument();
+    expect(screen.getByText('15')).toBeInTheDocument();
+  });
+
   it('hides the Add to Calendar button when the date is cancelled', () => {
     renderWithQueryClient(
       <TourDateCard
@@ -79,5 +91,16 @@ describe('TourDateCard — cancelled state', () => {
     expect(
       screen.getByRole('button', { name: /add to calendar/i })
     ).toBeInTheDocument();
+  });
+
+  it('renders Get Tickets as the primary CTA when tickets are available', () => {
+    renderWithQueryClient(
+      <TourDateCard tourDate={makeTourDate()} handle='testartist' />
+    );
+
+    expect(screen.getByRole('link', { name: /get tickets/i })).toHaveAttribute(
+      'href',
+      'https://example.com/tickets'
+    );
   });
 });

--- a/apps/web/app/[username]/tour/TourDateCard.tsx
+++ b/apps/web/app/[username]/tour/TourDateCard.tsx
@@ -1,14 +1,12 @@
 'use client';
 
-import { ProfileMediaCard } from '@/features/profile/ProfileMediaCard';
+import {
+  EntityCard,
+  tourDateToEntityCard,
+} from '@/components/organisms/entity-card';
 import { useTourDateTicketClick } from '@/hooks/useTourDateTicketClick';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
-import { formatLocationString } from '@/lib/utils/string-utils';
-
-// Pre-configured formatters for date display
-const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' });
-const dayFormatter = new Intl.DateTimeFormat('en-US', { day: 'numeric' });
-const weekdayFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
+import { cn } from '@/lib/utils';
 
 interface TourDateCardProps {
   readonly tourDate: TourDateViewModel;
@@ -17,68 +15,13 @@ interface TourDateCardProps {
   readonly distanceKm?: number | null;
 }
 
-function getActionLabel({
-  canBuyTickets,
-  isCancelled,
-}: {
-  readonly canBuyTickets: boolean;
-  readonly isCancelled: boolean;
-}) {
-  if (isCancelled) {
-    return 'Cancelled';
-  }
-
-  if (canBuyTickets) {
-    return 'Get tickets';
-  }
-
-  return 'Add to calendar';
-}
-
-function getEyebrow(isNearYou: boolean, distanceKm: number | null | undefined) {
-  if (!isNearYou) {
-    return 'Next Show';
-  }
-
-  return distanceKm === null || distanceKm === undefined
-    ? 'Near You'
-    : `${Math.round(distanceKm)} km away`;
-}
-
 export function TourDateCard({
   tourDate,
   handle,
   isNearYou = false,
   distanceKm,
 }: Readonly<TourDateCardProps>) {
-  const date = new Date(tourDate.startDate);
-  // Decode URL-encoded location parts (e.g., %20 -> space)
-  const location = formatLocationString([
-    tourDate.city,
-    tourDate.region,
-    tourDate.country,
-  ]);
-
-  const isSoldOut = tourDate.ticketStatus === 'sold_out';
   const isCancelled = tourDate.ticketStatus === 'cancelled';
-
-  // Derive timezone abbreviation (e.g., "EST") from IANA timezone
-  // Wrapped in try/catch: timezone is a free-text field that may contain invalid IANA values
-  let timezoneAbbr: string | null = null;
-  if (tourDate.timezone) {
-    try {
-      timezoneAbbr =
-        new Intl.DateTimeFormat('en-US', {
-          timeZone: tourDate.timezone,
-          timeZoneName: 'short',
-        })
-          .formatToParts(date)
-          .find(part => part.type === 'timeZoneName')?.value ?? null;
-    } catch {
-      // Invalid timezone — silently ignore
-    }
-  }
-
   const handleTicketClick = useTourDateTicketClick(
     handle,
     tourDate.id,
@@ -89,57 +32,35 @@ export function TourDateCard({
     globalThis.location.href = `/api/calendar/${tourDate.id}`;
   };
 
+  const baseModel = tourDateToEntityCard(tourDate, { isNearYou, distanceKm });
   const canBuyTickets =
-    Boolean(tourDate.ticketUrl) && !isCancelled && !isSoldOut;
-  const canAddToCalendar = !isCancelled;
-  const actionLabel = getActionLabel({
-    canBuyTickets,
-    isCancelled,
-  });
-  const eyebrow = getEyebrow(isNearYou, distanceKm);
-  const calendarAction = canAddToCalendar
-    ? {
-        label: 'Add to calendar',
-        onClick: handleAddToCalendar,
-        icon: 'CalendarPlus' as const,
-      }
-    : null;
+    Boolean(tourDate.ticketUrl) &&
+    !isCancelled &&
+    tourDate.ticketStatus !== 'sold_out';
+
+  const model = {
+    ...baseModel,
+    cta: baseModel.cta
+      ? {
+          ...baseModel.cta,
+          onClick: canBuyTickets ? handleTicketClick : handleAddToCalendar,
+        }
+      : null,
+    secondaryCta: baseModel.secondaryCta
+      ? {
+          ...baseModel.secondaryCta,
+          onClick: handleAddToCalendar,
+        }
+      : null,
+  };
 
   return (
-    <ProfileMediaCard
-      eyebrow={eyebrow}
-      title={tourDate.title ?? 'Live'}
-      subtitle={tourDate.venueName}
-      locationLabel={location}
-      secondaryLocationLabel={
-        tourDate.startTime
-          ? 'Doors: ' +
-            tourDate.startTime +
-            (timezoneAbbr ? ' ' + timezoneAbbr : '')
-          : null
-      }
-      imageAlt={tourDate.venueName}
-      fallbackVariant='generic'
-      accent={isNearYou ? 'blue' : 'orange'}
-      ratio='portrait'
-      datePill={{
-        month: monthFormatter.format(date),
-        day: dayFormatter.format(date),
-        meta:
-          weekdayFormatter.format(date) +
-          (tourDate.startTime ? ' · ' + tourDate.startTime : ''),
-      }}
-      action={{
-        label: actionLabel,
-        href: canBuyTickets ? tourDate.ticketUrl : null,
-        onClick: canBuyTickets ? handleTicketClick : handleAddToCalendar,
-        icon: canBuyTickets ? 'Ticket' : 'CalendarPlus',
-        showChevron: canBuyTickets,
-        disabled: isCancelled,
-      }}
-      secondaryAction={canBuyTickets ? calendarAction : null}
-      status={isSoldOut ? { label: 'Sold out', tone: 'orange' } : null}
-      className={isCancelled ? 'opacity-60' : undefined}
+    <EntityCard
+      model={model}
+      treatment='big'
+      surface='pearl'
+      className={cn('w-full', isCancelled && 'opacity-60')}
+      dataTestId='entity-card-show'
     />
   );
 }

--- a/apps/web/components/organisms/entity-card/EntityCard.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { EntityCard } from './EntityCard';
@@ -85,5 +85,35 @@ describe('EntityCard', () => {
     render(<EntityCard model={noLink} />);
     const el = screen.getByTestId('entity-card-music');
     expect(el.tagName).toBe('DIV');
+  });
+
+  it('renders interactive CTAs as real controls instead of a whole-card link', () => {
+    const onCalendar = vi.fn();
+    const interactive: EntityCardModel = {
+      id: 't1',
+      kind: 'show',
+      title: 'Live',
+      imageAlt: 'The Venue',
+      interactive: true,
+      cta: {
+        label: 'Get Tickets',
+        href: 'https://tickets.test/show',
+        external: true,
+      },
+      secondaryCta: {
+        label: 'Add To Calendar',
+        onClick: onCalendar,
+      },
+    };
+
+    render(<EntityCard model={interactive} treatment='big' />);
+    const card = screen.getByTestId('entity-card-show');
+    expect(card.tagName).toBe('DIV');
+    expect(screen.getByRole('link', { name: 'Get Tickets' })).toHaveAttribute(
+      'href',
+      'https://tickets.test/show'
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add To Calendar' }));
+    expect(onCalendar).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -5,7 +5,12 @@ import type { CSSProperties, ReactNode } from 'react';
 import { ImageWithFallback } from '@/components/atoms/ImageWithFallback';
 import { cn } from '@/lib/utils';
 import { accentVar, KIND_PRESETS, statusDotVar } from './kind-presets';
-import type { EntityCardModel, EntitySurface, EntityTreatment } from './types';
+import type {
+  EntityCardCta,
+  EntityCardModel,
+  EntitySurface,
+  EntityTreatment,
+} from './types';
 
 interface EntityCardProps {
   readonly model: EntityCardModel;
@@ -52,6 +57,62 @@ const SIZE: Record<EntityTreatment, SizeConfig> = {
     ctaBlock: true,
   },
 };
+
+function EntityCtaControl({
+  cta,
+  block,
+}: Readonly<{
+  cta: EntityCardCta;
+  block: boolean;
+}>) {
+  const className = cn(
+    'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover',
+    block ? 'h-11 w-full' : 'h-8 min-w-0 flex-1',
+    cta.disabled &&
+      'cursor-not-allowed border-subtle bg-surface-0 text-tertiary-token hover:border-subtle hover:bg-surface-0'
+  );
+
+  if (cta.disabled || (!cta.href && !cta.onClick)) {
+    return (
+      <span className={className} aria-disabled={cta.disabled || undefined}>
+        {cta.label}
+      </span>
+    );
+  }
+
+  if (cta.href?.startsWith('/')) {
+    return (
+      <Link
+        href={cta.href}
+        prefetch={false}
+        onClick={cta.onClick}
+        className={className}
+      >
+        {cta.label}
+      </Link>
+    );
+  }
+
+  if (cta.href) {
+    return (
+      <a
+        href={cta.href}
+        target={cta.external ? '_blank' : undefined}
+        rel={cta.external ? 'noopener noreferrer' : undefined}
+        onClick={cta.onClick}
+        className={className}
+      >
+        {cta.label}
+      </a>
+    );
+  }
+
+  return (
+    <button type='button' onClick={cta.onClick} className={className}>
+      {cta.label}
+    </button>
+  );
+}
 
 function CardShell({
   href,
@@ -121,7 +182,12 @@ export function EntityCard({
   const Icon = preset.icon;
   const isPearl = surface === 'pearl';
 
-  const cardHref = model.href ?? model.cta?.href ?? null;
+  const isInteractive =
+    model.interactive === true ||
+    Boolean(model.cta?.onClick || model.secondaryCta);
+  const cardHref = isInteractive
+    ? null
+    : (model.href ?? model.cta?.href ?? null);
   const cardExternal = model.cta?.external;
 
   const artStyle: CSSProperties = {
@@ -201,7 +267,7 @@ export function EntityCard({
 
         <h3
           className={cn(
-            'min-w-0 font-semibold leading-tight tracking-tighter text-primary-token line-clamp-2',
+            'min-w-0 font-[590] leading-tight tracking-[-0.02em] text-primary-token line-clamp-2',
             size.titleClass
           )}
         >
@@ -214,46 +280,75 @@ export function EntityCard({
           </p>
         ) : null}
 
+        {size.showMeta && model.secondaryMeta ? (
+          <p className='min-w-0 truncate text-[11.5px] text-tertiary-token'>
+            {model.secondaryMeta}
+          </p>
+        ) : null}
+
         <div
           className={cn(
-            'mt-auto flex items-center gap-2 pt-1',
-            size.ctaBlock ? 'flex-col items-stretch' : 'justify-between'
+            'mt-auto flex gap-2 pt-1',
+            isInteractive
+              ? size.ctaBlock
+                ? 'flex-col items-stretch'
+                : 'flex-row items-stretch'
+              : cn(
+                  'items-center',
+                  size.ctaBlock ? 'flex-col items-stretch' : 'justify-between'
+                )
           )}
         >
-          {model.price ? (
-            <div className='min-w-0'>
-              <span className='text-sm font-bold text-primary-token'>
-                {model.price.original ? (
-                  <>
-                    {model.price.display}
-                    <span className='ml-1 text-2xs font-medium text-tertiary-token line-through'>
-                      {model.price.original}
-                    </span>
-                  </>
-                ) : (
-                  model.price.display
-                )}
-              </span>
-              {model.price.profit ? (
-                <p className='text-2xs text-tertiary-token'>
-                  Profit {model.price.profit}
-                </p>
+          {isInteractive ? (
+            <>
+              {model.cta ? (
+                <EntityCtaControl cta={model.cta} block={size.ctaBlock} />
               ) : null}
-            </div>
+              {model.secondaryCta ? (
+                <EntityCtaControl
+                  cta={model.secondaryCta}
+                  block={size.ctaBlock}
+                />
+              ) : null}
+            </>
           ) : (
-            <span aria-hidden='true' />
-          )}
-
-          {model.cta ? (
-            <span
-              className={cn(
-                'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle group-hover:border-(--linear-btn-primary-hover) group-hover:bg-btn-primary-hover',
-                size.ctaBlock ? 'h-11 w-full' : 'h-8'
+            <>
+              {model.price ? (
+                <div className='min-w-0'>
+                  <span className='text-sm font-[680] text-primary-token'>
+                    {model.price.original ? (
+                      <>
+                        {model.price.display}
+                        <span className='ml-1 text-2xs font-medium text-tertiary-token line-through'>
+                          {model.price.original}
+                        </span>
+                      </>
+                    ) : (
+                      model.price.display
+                    )}
+                  </span>
+                  {model.price.profit ? (
+                    <p className='text-2xs text-tertiary-token'>
+                      Profit {model.price.profit}
+                    </p>
+                  ) : null}
+                </div>
+              ) : (
+                <span aria-hidden='true' />
               )}
-            >
-              {model.cta.label}
-            </span>
-          ) : null}
+
+              {model.cta ? (
+                <span
+                  className={cn(
+                    'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle group-hover:border-(--linear-btn-primary-hover) group-hover:bg-btn-primary-hover',
+                    size.ctaBlock ? 'h-11 w-full' : 'h-8'
+                  )}
+                >
+                  {model.cta.label}
+                </span>
+              ) : null}
+            </>
+          )}
         </div>
       </div>
     </CardShell>

--- a/apps/web/components/organisms/entity-card/adapters.test.ts
+++ b/apps/web/components/organisms/entity-card/adapters.test.ts
@@ -241,6 +241,19 @@ describe('tourDateToEntityCard', () => {
     expect(model.secondaryCta).toBeNull();
   });
 
+  it('marks sold-out dates with a status pill and Add To Calendar as primary (no secondary)', () => {
+    const model = tourDateToEntityCard({
+      ...tourDate,
+      ticketStatus: 'sold_out',
+    });
+    expect(model.status).toEqual({ label: 'Sold Out', tone: 'scheduled' });
+    // Primary CTA becomes Add To Calendar (no ticket purchase possible)
+    expect(model.cta?.label).toBe('Add To Calendar');
+    expect(model.cta?.disabled).toBe(false);
+    // No secondary CTA — there is only one action for sold-out shows
+    expect(model.secondaryCta).toBeNull();
+  });
+
   it('uses a near-you eyebrow and blue accent when requested', () => {
     const model = tourDateToEntityCard(tourDate, {
       isNearYou: true,

--- a/apps/web/components/organisms/entity-card/adapters.test.ts
+++ b/apps/web/components/organisms/entity-card/adapters.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { PublicMerchCard } from '@/lib/merch/types';
+import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import {
   chatReleaseContextToEntityCard,
   chatTourDateContextToEntityCard,
   merchToEntityCard,
   releaseToEntityCard,
   showToEntityCard,
+  tourDateToEntityCard,
 } from './adapters';
 
 const merch: PublicMerchCard = {
@@ -177,6 +179,75 @@ describe('chatTourDateContextToEntityCard', () => {
 
     expect(model.title).toBe('Brooklyn Steel');
     expect(model.meta).toBe('Loading Tour Date');
+  });
+});
+
+const tourDate: TourDateViewModel = {
+  id: 'td-1',
+  profileId: 'profile-1',
+  externalId: null,
+  provider: 'manual',
+  eventType: 'tour',
+  confirmationStatus: 'confirmed',
+  reviewedAt: '2026-01-01T00:00:00.000Z',
+  title: null,
+  startDate: '2030-06-15T20:00:00.000Z',
+  startTime: '20:00',
+  timezone: 'America/New_York',
+  venueName: 'The Venue',
+  city: 'Brooklyn',
+  region: 'NY',
+  country: 'USA',
+  latitude: null,
+  longitude: null,
+  ticketUrl: 'https://example.com/tickets',
+  ticketStatus: 'available',
+  lastSyncedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('tourDateToEntityCard', () => {
+  it('maps venue, date pill, ticket CTA, and calendar secondary action', () => {
+    const model = tourDateToEntityCard(tourDate);
+    expect(model.kind).toBe('show');
+    expect(model.interactive).toBe(true);
+    expect(model.title).toBe('Live');
+    expect(model.meta).toBe('The Venue · Brooklyn, NY, USA');
+    expect(model.datePill).toEqual({ month: 'Jun', day: '15' });
+    expect(model.cta).toEqual({
+      label: 'Get Tickets',
+      href: 'https://example.com/tickets',
+      external: true,
+      disabled: false,
+    });
+    expect(model.secondaryCta).toEqual({
+      label: 'Add To Calendar',
+      href: null,
+    });
+  });
+
+  it('marks cancelled dates disabled without a secondary action', () => {
+    const model = tourDateToEntityCard({
+      ...tourDate,
+      ticketStatus: 'cancelled',
+    });
+    expect(model.cta).toEqual({
+      label: 'Cancelled',
+      href: null,
+      external: false,
+      disabled: true,
+    });
+    expect(model.secondaryCta).toBeNull();
+  });
+
+  it('uses a near-you eyebrow and blue accent when requested', () => {
+    const model = tourDateToEntityCard(tourDate, {
+      isNearYou: true,
+      distanceKm: 12.4,
+    });
+    expect(model.eyebrow).toBe('12 km away');
+    expect(model.accent).toBe('blue');
   });
 });
 

--- a/apps/web/components/organisms/entity-card/adapters.ts
+++ b/apps/web/components/organisms/entity-card/adapters.ts
@@ -1,7 +1,10 @@
 import { getMerchPriceDisplay } from '@/lib/merch/pricing';
 import type { PublicMerchCard } from '@/lib/merch/types';
+import type { TourDateViewModel } from '@/lib/tour-dates/types';
+import { formatLocationString } from '@/lib/utils/string-utils';
 import { KIND_PRESETS } from './kind-presets';
 import type {
+  EntityAccent,
   EntityCardModel,
   EntityCardStatus,
   EntityStatusTone,
@@ -225,6 +228,111 @@ export function chatTourDateContextToEntityCard(
     href: null,
     cta: null,
     meta: 'Tour Date Context',
+  };
+}
+
+const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' });
+const dayFormatter = new Intl.DateTimeFormat('en-US', { day: 'numeric' });
+
+function getTourEyebrow(
+  isNearYou: boolean,
+  distanceKm: number | null | undefined
+): string {
+  if (!isNearYou) {
+    return 'Next Show';
+  }
+
+  return distanceKm === null || distanceKm === undefined
+    ? 'Near You'
+    : `${Math.round(distanceKm)} km away`;
+}
+
+function getTimezoneAbbrev(
+  date: Date,
+  timezone: string | null | undefined
+): string | null {
+  if (!timezone) {
+    return null;
+  }
+
+  try {
+    return (
+      new Intl.DateTimeFormat('en-US', {
+        timeZone: timezone,
+        timeZoneName: 'short',
+      })
+        .formatToParts(date)
+        .find(part => part.type === 'timeZoneName')?.value ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+export interface TourDateEntityOptions {
+  readonly isNearYou?: boolean;
+  readonly distanceKm?: number | null;
+}
+
+/**
+ * Tour page card → unified model. Call-site wires `cta` / `secondaryCta`
+ * onClick handlers for analytics and calendar fallback.
+ */
+export function tourDateToEntityCard(
+  tourDate: TourDateViewModel,
+  options: TourDateEntityOptions = {}
+): EntityCardModel {
+  const date = toDate(tourDate.startDate);
+  const location = formatLocationString([
+    tourDate.city,
+    tourDate.region,
+    tourDate.country,
+  ]);
+  const isSoldOut = tourDate.ticketStatus === 'sold_out';
+  const isCancelled = tourDate.ticketStatus === 'cancelled';
+  const canBuyTickets =
+    Boolean(tourDate.ticketUrl) && !isCancelled && !isSoldOut;
+  const timezoneAbbr = date ? getTimezoneAbbrev(date, tourDate.timezone) : null;
+  const doorsMeta = tourDate.startTime
+    ? `Doors: ${tourDate.startTime}${timezoneAbbr ? ` ${timezoneAbbr}` : ''}`
+    : null;
+  const accent: EntityAccent = options.isNearYou ? 'blue' : 'orange';
+
+  let primaryLabel = 'Add To Calendar';
+  if (isCancelled) {
+    primaryLabel = 'Cancelled';
+  } else if (canBuyTickets) {
+    primaryLabel = 'Get Tickets';
+  }
+
+  return {
+    id: tourDate.id,
+    kind: 'show',
+    imageUrl: null,
+    imageAlt: tourDate.venueName,
+    accent,
+    eyebrow: getTourEyebrow(options.isNearYou ?? false, options.distanceKm),
+    title: tourDate.title ?? 'Live',
+    meta: [tourDate.venueName, location].filter(Boolean).join(' · ') || null,
+    secondaryMeta: doorsMeta,
+    datePill: date
+      ? {
+          month: monthFormatter.format(date),
+          day: dayFormatter.format(date),
+        }
+      : null,
+    status: isSoldOut ? { label: 'Sold Out', tone: 'scheduled' } : null,
+    interactive: true,
+    cta: {
+      label: primaryLabel,
+      href: canBuyTickets ? tourDate.ticketUrl : null,
+      external: canBuyTickets,
+      disabled: isCancelled,
+    },
+    secondaryCta:
+      canBuyTickets && !isCancelled
+        ? { label: 'Add To Calendar', href: null }
+        : null,
   };
 }
 

--- a/apps/web/components/organisms/entity-card/index.ts
+++ b/apps/web/components/organisms/entity-card/index.ts
@@ -3,6 +3,7 @@ export type {
   ChatTourDateContextInput,
   ReleaseEntityInput,
   ShowEntityInput,
+  TourDateEntityOptions,
 } from './adapters';
 export {
   chatReleaseContextToEntityCard,
@@ -10,6 +11,7 @@ export {
   merchToEntityCard,
   releaseToEntityCard,
   showToEntityCard,
+  tourDateToEntityCard,
 } from './adapters';
 export { EntityCard } from './EntityCard';
 export { EntityCarousel } from './EntityCarousel';

--- a/apps/web/components/organisms/entity-card/types.ts
+++ b/apps/web/components/organisms/entity-card/types.ts
@@ -1,3 +1,5 @@
+import type { MouseEvent } from 'react';
+
 /** The four entity kinds a card can represent across profile + chat. */
 export type EntityKind = 'merch' | 'music' | 'video' | 'show';
 
@@ -43,6 +45,8 @@ export interface EntityCardCta {
   readonly label: string;
   readonly href?: string | null;
   readonly external?: boolean;
+  readonly onClick?: (event: MouseEvent<HTMLElement>) => void;
+  readonly disabled?: boolean;
 }
 
 /**
@@ -65,8 +69,16 @@ export interface EntityCardModel {
   readonly title: string;
   /** Secondary meta line (product type, release type · year, venue · city). */
   readonly meta?: string | null;
+  /** Tertiary meta line (doors time, timezone). */
+  readonly secondaryMeta?: string | null;
   readonly status?: EntityCardStatus | null;
   readonly price?: EntityCardPrice | null;
   readonly datePill?: EntityCardDatePill | null;
   readonly cta?: EntityCardCta | null;
+  readonly secondaryCta?: EntityCardCta | null;
+  /**
+   * When true, the card is not a whole-card link and CTAs render as real
+   * controls (for analytics, calendar fallback, sold-out/cancelled states).
+   */
+  readonly interactive?: boolean;
 }


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (claude-sonnet-4-6). Closes #11103.

Card: t_6d4f83dc
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- client console errors + render of affected pages
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.