### PR TITLE
fix(web): stabilize start verification layout

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -646,6 +646,7 @@ function ChatErrorStatusBanner({
 }
 
 interface ComposerStatusBannerProps extends ChatErrorStatusBannerProps {
+  readonly reserveTurnstileSpace?: boolean;
   readonly shouldShowTurnstileBanner: boolean;
   readonly turnstilePanel: ReactNode;
 }
@@ -655,6 +656,7 @@ function ComposerStatusBanner({
   handleRetry,
   isBusy,
   isSubmitted,
+  reserveTurnstileSpace = false,
   shouldShowTurnstileBanner,
   turnstilePanel,
 }: ComposerStatusBannerProps) {
@@ -663,7 +665,12 @@ function ComposerStatusBanner({
   return (
     <div className='divide-y divide-white/[0.065]'>
       {shouldShowTurnstileBanner ? (
-        <div data-testid='onboarding-turnstile-slot'>{turnstilePanel}</div>
+        <div
+          className={reserveTurnstileSpace ? 'min-h-[10rem]' : undefined}
+          data-testid='onboarding-turnstile-slot'
+        >
+          {turnstilePanel}
+        </div>
       ) : null}
       <ChatErrorStatusBanner
         chatError={chatError}
@@ -779,8 +786,12 @@ export function OnboardingChat({
   turnstileStatus,
   turnstileToken,
 }: OnboardingChatProps) {
-  const [input, setInput] = useState('');
-  const latestInputRef = useRef('');
+  const initialStarterPrompt = starterPrompt
+    ? sanitizeHomepagePrompt(starterPrompt)
+    : '';
+  const hasInitialStarterPrompt = initialStarterPrompt.length > 0;
+  const [input, setInput] = useState(initialStarterPrompt);
+  const latestInputRef = useRef(initialStarterPrompt);
   const [hasSentFirst, setHasSentFirst] = useState(false);
   const [chatError, setChatError] = useState<ChatError | null>(null);
   const [composerPickerOpen, setComposerPickerOpen] = useState(false);
@@ -792,10 +803,12 @@ export function OnboardingChat({
   const hasTrackedChatStartedRef = useRef(false);
   const hasTrackedChatCompletedRef = useRef(false);
   const lastAttemptedMessageRef = useRef<string | null>(null);
-  const hasInjectedStarterPromptRef = useRef(false);
+  const hasInjectedStarterPromptRef = useRef(hasInitialStarterPrompt);
   const hasAutoSubmittedStarterPromptRef = useRef(false);
   const hasRequestedStarterVerificationRef = useRef(false);
-  const pendingStarterPromptRef = useRef<string | null>(null);
+  const pendingStarterPromptRef = useRef<string | null>(
+    hasInitialStarterPrompt ? initialStarterPrompt : null
+  );
   const wasAwaitingTurnstileRetryRef = useRef(false);
   const [localAutomationBypass, setLocalAutomationBypass] = useState<
     boolean | null
@@ -1066,8 +1079,17 @@ export function OnboardingChat({
     onConversationActivity?.();
   }, [messages, onConversationActivity, status]);
 
+  const shouldReserveStarterVerification =
+    hasInitialStarterPrompt &&
+    messages.length === 0 &&
+    !hasSentFirst &&
+    chatError === null &&
+    !isTurnstileTokenUsable(turnstileToken, turnstileStatus) &&
+    localAutomationBypass !== true;
   const shouldShowTurnstileBanner =
-    Boolean(turnstilePanel) && turnstilePanelVisible && isAwaitingFirstToken;
+    Boolean(turnstilePanel) &&
+    (turnstilePanelVisible || shouldReserveStarterVerification) &&
+    (isAwaitingFirstToken || shouldReserveStarterVerification);
   const hasComposerStatusBanner =
     shouldShowTurnstileBanner || chatError !== null;
   const composerStatusBanner = hasComposerStatusBanner ? (
@@ -1076,6 +1098,7 @@ export function OnboardingChat({
       handleRetry={handleRetry}
       isBusy={isBusy}
       isSubmitted={isSubmitted}
+      reserveTurnstileSpace={shouldReserveStarterVerification}
       shouldShowTurnstileBanner={shouldShowTurnstileBanner}
       turnstilePanel={turnstilePanel}
     />

--- a/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
@@ -275,6 +275,27 @@ describe('OnboardingChat Turnstile gating', () => {
     expect(screen.getByTestId('onboarding-composer-dock')).toBeVisible();
   });
 
+  it('renders a starter prompt and reserves verification space before effects run', () => {
+    render(
+      <OnboardingChat
+        starterPrompt='  Hey, I want to get access to Jovie.  '
+        turnstilePanel={<div data-testid='test-turnstile-panel' />}
+        turnstilePanelVisible={false}
+        turnstileStatus='interactive'
+        turnstileToken={null}
+      />
+    );
+
+    expect(screen.getByLabelText('Chat message input')).toHaveValue(
+      'Hey, I want to get access to Jovie.'
+    );
+    expect(screen.getByTestId('onboarding-turnstile-slot')).toHaveClass(
+      'min-h-[10rem]'
+    );
+    expect(screen.getByTestId('test-turnstile-panel')).toBeInTheDocument();
+    expect(chatMocks.sendMessage).not.toHaveBeenCalled();
+  });
+
   it('keeps the first message local and shows verification guidance until a token exists', () => {
     const onTurnstileRequired = vi.fn();
     render(<TurnstileHarness onTurnstileRequired={onTurnstileRequired} />);


### PR DESCRIPTION
## Summary
- seed `/start?starter_prompt=` into the onboarding composer on first render instead of after hydration
- reserve the Turnstile verification slot for starter-prompt first-message gating so the security panel does not grow the centered composer
- add a regression test for first-render starter prompt and reserved verification space

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/onboarding/OnboardingChat.turnstile.test.tsx tests/unit/onboarding/OnboardingTurnstile.test.tsx`
- `pnpm biome check apps/web/components/features/onboarding/OnboardingChat.tsx apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web run build`
- `git push` pre-push: repo Biome, web proxy guard, Tailwind guard, typecheck, Biome lint

Manual staging audit on the previous deploy showed the starter prompt was preserved and the failed-verification dead end was gone, but CLS remained from client-side starter/security insertion. This PR targets that residual layout shift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Starter prompts now pre-populate the chat input field during onboarding initialization.
  * Enhanced verification interface layout to better reserve and display space during the onboarding process.

* **Tests**
  * Added test coverage for starter prompt initialization and verification UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->