### PR TITLE
fix(web): suppress dev toolbar on start

### DIFF
--- a/apps/web/components/features/dev/DevToolbarGate.tsx
+++ b/apps/web/components/features/dev/DevToolbarGate.tsx
@@ -25,6 +25,7 @@ const DEV_TOOLBAR_SUPPRESSED_PATHS = new Set([
   '/demovideo',
   '/demo',
   '/demo/video',
+  '/start',
 ]);
 const DEV_TOOLBAR_SUPPRESSED_PREFIXES = ['/demo/'];
 

--- a/apps/web/tests/unit/dev/DevToolbar.test.tsx
+++ b/apps/web/tests/unit/dev/DevToolbar.test.tsx
@@ -100,8 +100,8 @@ describe('DevToolbar', () => {
       expect(isDevToolbarSuppressedPath('/demo')).toBe(true);
       expect(isDevToolbarSuppressedPath('/demo/video')).toBe(true);
       expect(isDevToolbarSuppressedPath('/demo/founder-video')).toBe(true);
+      expect(isDevToolbarSuppressedPath('/start')).toBe(true);
       expect(isDevToolbarSuppressedPath('/app/dashboard/releases')).toBe(false);
-      expect(isDevToolbarSuppressedPath('/start')).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- suppress `DevToolbar` on `/start` so the public onboarding golden path does not render preview-only flag chrome
- removes the toolbar's preview `/api/deploy/status` poll from `/start`, which caused a first-party 401 console error in staging
- updates the dev-toolbar path suppression unit test

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/dev/DevToolbar.test.tsx`
- `pnpm biome check apps/web/components/features/dev/DevToolbarGate.tsx apps/web/tests/unit/dev/DevToolbar.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git push` pre-push: repo Biome, web proxy guard, Tailwind guard, typecheck, Biome lint

Manual staging audit on the previous deploy showed `/start` was otherwise on the expected SHA with the prompt preserved and no failed-verification dead end, but the preview toolbar still added visible flag text and a first-party `/api/deploy/status` 401. This PR removes that toolbar from the public start surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Development toolbar is no longer displayed on the start page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->