### PR TITLE
fix(web): suppress cookie banner on start

### DIFF
--- a/apps/web/lib/cookies/banner-visibility.ts
+++ b/apps/web/lib/cookies/banner-visibility.ts
@@ -2,6 +2,7 @@ const COOKIE_BANNER_SUPPRESSED_PATH_PREFIXES = [
   '/app',
   '/demo',
   '/desktop-auth',
+  '/start',
   // Native/browser auth handoff routes should stay free of visible banner chrome.
   '/auth',
   '/signin',

--- a/apps/web/tests/unit/cookie-banner.test.tsx
+++ b/apps/web/tests/unit/cookie-banner.test.tsx
@@ -43,6 +43,8 @@ describe('CookieBannerSection', () => {
 
   it.each([
     '/desktop-auth',
+    '/start',
+    '/start/access',
     '/auth/native-complete',
     '/signin',
     '/signin/sso-callback',


### PR DESCRIPTION
## Summary
- Suppress the global cookie banner on /start using the existing cookie-banner route suppression helper.
- Cover /start and nested /start paths in the cookie-banner unit test.

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/cookie-banner.test.tsx
- pnpm biome check apps/web/lib/cookies/banner-visibility.ts apps/web/tests/unit/cookie-banner.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- git push pre-push hook: biome check ., web proxy guard, Tailwind guard, typecheck, biome lint

## Staging context
Manual staging audit for dba713fa showed /start was clean for prompt retention, overflow, first-party console/page errors, verification-failed copy, and DevToolbar copy. It still failed CLS because the cookie banner appeared on /start. This PR removes that route-specific banner source.