### PR TITLE
fix(web): stabilize start turnstile widget

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
+++ b/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
@@ -194,6 +194,8 @@ export function OnboardingTurnstile({
   // *visible* challenge. Silent (invisible-first) verifications never set it,
   // so the panel stays collapsed when the user never saw a challenge.
   const [verifiedMoment, setVerifiedMoment] = useState(false);
+  const [interactiveChallengeVisible, setInteractiveChallengeVisible] =
+    useState(false);
   const panelVisibleRef = useRef(false);
   const siteKey = publicEnv.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
   const hasStaticBypass =
@@ -247,6 +249,7 @@ export function OnboardingTurnstile({
         theme: 'dark',
         callback: token => {
           onToken(token);
+          setInteractiveChallengeVisible(false);
           // Only celebrate when the user actually saw a challenge. Silent
           // invisible-first verifications collapse straight away (no UI churn).
           if (panelVisibleRef.current && !reducedMotion) {
@@ -254,33 +257,42 @@ export function OnboardingTurnstile({
           }
           commitState({ status: 'verified' });
         },
-        'error-callback': code =>
+        'error-callback': code => {
+          setInteractiveChallengeVisible(false);
           commitState({
             status: 'error',
             message: `Verification failed (${code}). Retry the check or refresh the page.`,
-          }),
+          });
+        },
         'expired-callback': () => {
+          setInteractiveChallengeVisible(false);
           commitState({
             status: 'expired',
             message: 'Verification expired. Complete the check again to send.',
           });
         },
-        'timeout-callback': () =>
+        'timeout-callback': () => {
+          setInteractiveChallengeVisible(false);
           commitState({
             status: 'timeout',
             message: 'Verification timed out. Retry the check to send.',
-          }),
-        'unsupported-callback': () =>
+          });
+        },
+        'unsupported-callback': () => {
+          setInteractiveChallengeVisible(false);
           commitState({
             status: 'unsupported',
             message:
               'This browser cannot complete the security check. Try another browser or disable restrictive extensions.',
-          }),
-        'before-interactive-callback': () =>
+          });
+        },
+        'before-interactive-callback': () => {
+          setInteractiveChallengeVisible(true);
           commitState({
             status: 'interactive',
             message: 'Required before your first message.',
-          }),
+          });
+        },
         'after-interactive-callback': () =>
           commitState({
             status: 'loading',
@@ -316,6 +328,7 @@ export function OnboardingTurnstile({
     (message = 'Verification reset. Complete the check to retry.') => {
       clearWidget();
       setVerifiedMoment(false);
+      setInteractiveChallengeVisible(false);
       commitState({ status: 'loading', message });
       render();
     },
@@ -403,6 +416,13 @@ export function OnboardingTurnstile({
       // collapses in one clean step instead of shrinking twice.
       verifiedMoment ||
       Boolean(instruction));
+  const shouldExposeWidgetContent =
+    state.status === 'interactive' ||
+    (state.status === 'loading' && interactiveChallengeVisible);
+  const shouldShowWidgetSkeleton =
+    shouldShowWidgetFrame &&
+    !shouldExposeWidgetContent &&
+    state.status !== 'verified';
   const tone = getStatusTone(state.status);
 
   return (
@@ -475,7 +495,7 @@ export function OnboardingTurnstile({
           data-testid='onboarding-turnstile-widget-frame'
           aria-hidden={!shouldShowWidgetFrame ? 'true' : undefined}
         >
-          {shouldShowWidgetFrame && state.status !== 'verified' ? (
+          {shouldShowWidgetSkeleton ? (
             <Skeleton
               aria-hidden='true'
               data-testid='onboarding-turnstile-widget-skeleton'
@@ -486,7 +506,12 @@ export function OnboardingTurnstile({
           <div
             ref={containerRef}
             id={`cf-turnstile-${widgetDomId}`}
-            className='relative min-h-16'
+            className={cn(
+              'relative min-h-16',
+              shouldExposeWidgetContent
+                ? '[&>div]:visible'
+                : '[&>div]:invisible'
+            )}
           />
         </div>
       ) : null}

--- a/apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
@@ -339,11 +339,14 @@ describe('OnboardingTurnstile', () => {
     );
   });
 
-  it('shows a shimmer placeholder in the widget frame during a challenge', async () => {
+  it('masks Cloudflare content until a challenge becomes interactive', async () => {
     vi.stubEnv('NODE_ENV', 'test');
     vi.stubEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY', 'site-key');
     const renderMock = vi.fn(
-      (_target: HTMLElement, _options: TurnstileOptions) => 'widget-1'
+      (target: HTMLElement, _options: TurnstileOptions) => {
+        target.append(document.createElement('div'));
+        return 'widget-1';
+      }
     );
     window.turnstile = {
       render: renderMock,
@@ -351,20 +354,34 @@ describe('OnboardingTurnstile', () => {
       remove: vi.fn(),
     };
 
-    render(<OnboardingTurnstile onToken={vi.fn()} onStateChange={vi.fn()} />);
+    render(
+      <OnboardingTurnstile
+        instruction='Verify you are human to send'
+        onToken={vi.fn()}
+        onStateChange={vi.fn()}
+      />
+    );
 
     await waitFor(() => expect(renderMock).toHaveBeenCalled());
     const options = renderMock.mock.calls[0]?.[1];
+    const widgetTarget = document.querySelector('[id^="cf-turnstile-"]');
 
-    // Silent loading: no challenge UI, so no shimmer.
-    expect(
-      screen.queryByTestId('onboarding-turnstile-widget-skeleton')
-    ).not.toBeInTheDocument();
-
-    act(() => options?.['before-interactive-callback']?.());
     expect(
       screen.getByTestId('onboarding-turnstile-widget-skeleton')
     ).toBeInTheDocument();
+    expect(widgetTarget?.className).toContain('[&>div]:invisible');
+
+    act(() => options?.['before-interactive-callback']?.());
+    expect(
+      screen.queryByTestId('onboarding-turnstile-widget-skeleton')
+    ).not.toBeInTheDocument();
+    expect(widgetTarget?.className).toContain('[&>div]:visible');
+
+    act(() => options?.['after-interactive-callback']?.());
+    expect(widgetTarget?.className).toContain('[&>div]:visible');
+    expect(
+      screen.queryByTestId('onboarding-turnstile-widget-skeleton')
+    ).not.toBeInTheDocument();
   });
 
   it('holds a brief Verified confirmation after a visible challenge, then collapses', async () => {


### PR DESCRIPTION
## Summary
- Keep Cloudflare Turnstile's direct inserted child hidden while the onboarding security widget is still non-interactive.
- Reveal the widget child only when Turnstile reports an interactive challenge.
- Remove the skeleton overlay during an interactive challenge so the challenge remains usable.

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/onboarding/OnboardingTurnstile.test.tsx tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
- pnpm biome check apps/web/components/features/onboarding/OnboardingTurnstile.tsx apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- git push pre-push hook: biome check ., web proxy guard, Tailwind guard, typecheck, biome lint

## Staging context
Strict staging audit for 89d19fb had the cookie banner and DevToolbar removed, no first-party console/page errors, no overflow, prompt preserved, and no verification-failed copy. Remaining CLS came from Cloudflare inserting a Turnstile child from 0x0 to the reserved widget box. HTML-injected CSS hiding that child reduced the measured mobile CLS to 0 in the staging probe.