### PR TITLE
fix(design-system): tokenize dev toolbar drift

### DIFF
--- a/apps/web/components/features/dev/DevToolbar.tsx
+++ b/apps/web/components/features/dev/DevToolbar.tsx
@@ -201,7 +201,7 @@ const PROMOTE_LABELS: Record<PromoteState, string> = {
 };
 
 function getPromoteButtonColor(state: PromoteState): string {
-  if (state === 'done') return 'text-[var(--color-accent)]';
+  if (state === 'done') return 'text-accent';
   if (state === 'error') return 'text-red-400';
   return 'text-emerald-400 hover:text-emerald-300 hover:bg-emerald-500/10';
 }
@@ -215,8 +215,7 @@ function AsyncActionIcon({
 }>) {
   if (state === 'loading')
     return <Loader2 size={11} className='animate-spin' />;
-  if (state === 'done')
-    return <Check size={11} className='text-[var(--color-accent)]' />;
+  if (state === 'done') return <Check size={11} className='text-accent' />;
   return <IdleIcon size={11} />;
 }
 
@@ -231,7 +230,7 @@ function CopyFieldIcon({
   copied,
   icon: Icon,
 }: Readonly<{ copied: boolean; icon: typeof Copy }>) {
-  if (copied) return <Check size={11} className='text-[var(--color-accent)]' />;
+  if (copied) return <Check size={11} className='text-accent' />;
   return <Icon size={11} />;
 }
 
@@ -247,8 +246,8 @@ function getSwButtonProps(enabled: boolean) {
       : 'Service worker disabled — click to enable',
     className: `flex items-center gap-1 px-1.5 py-1 rounded transition-colors ${
       enabled
-        ? 'text-[var(--color-accent)] bg-[var(--color-accent)]/10'
-        : 'text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)]'
+        ? 'text-accent bg-accent/10'
+        : 'text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2'
     }`,
     'aria-label': enabled ? 'Disable service worker' : 'Enable service worker',
   };
@@ -728,7 +727,7 @@ export function DevToolbar({
         type='button'
         onClick={show}
         data-testid='dev-toolbar'
-        className='fixed bottom-3 right-3 z-[9999] flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface-1)] text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border-default)] shadow-md font-mono text-3xs transition-colors'
+        className='fixed bottom-3 right-3 z-[9999] flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-default bg-surface-1 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:border-default shadow-md font-mono text-3xs transition-colors'
         aria-label='Show Dev Toolbar'
         title='Show Dev Toolbar (⌘⇧D)'
       >
@@ -746,7 +745,7 @@ export function DevToolbar({
     >
       {/* Expanded panel */}
       <div
-        className='overflow-hidden border-t border-[var(--color-border-default)] backdrop-blur-sm bg-[var(--color-bg-surface-1)]/80'
+        className='overflow-hidden border-t border-default backdrop-blur-sm bg-surface-1/80'
         style={{
           maxHeight: open ? '400px' : '0px',
           borderTopWidth: open ? undefined : 0,
@@ -757,31 +756,28 @@ export function DevToolbar({
       >
         <div className='flex flex-col'>
           {/* Search bar */}
-          <div className='flex items-center gap-2 px-4 py-2 border-b border-[var(--color-border-subtle)]'>
-            <Search
-              size={12}
-              className='shrink-0 text-[var(--color-text-quaternary-token)]'
-            />
+          <div className='flex items-center gap-2 px-4 py-2 border-b border-subtle'>
+            <Search size={12} className='shrink-0 text-quaternary-token' />
             <input
               ref={searchRef}
               type='text'
               value={search}
               onChange={e => setSearch(e.target.value)}
               placeholder='Search flags...'
-              className='flex-1 bg-transparent text-[var(--color-text-primary)] placeholder:text-[var(--color-text-quaternary-token)] outline-none text-xs'
+              className='flex-1 bg-transparent text-[var(--color-text-primary)] placeholder:text-quaternary-token outline-none text-xs'
               aria-label='Search Flags'
             />
             {search && (
               <button
                 type='button'
                 onClick={() => setSearch('')}
-                className='shrink-0 text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] transition-colors'
+                className='shrink-0 text-quaternary-token hover:text-[var(--color-text-primary)] transition-colors'
                 aria-label='Clear Search'
               >
                 <X size={11} />
               </button>
             )}
-            <span className='shrink-0 text-3xs text-[var(--color-text-quaternary-token)]'>
+            <span className='shrink-0 text-3xs text-quaternary-token'>
               {matchCount} of {filteredFlags.total}
             </span>
           </div>
@@ -790,9 +786,9 @@ export function DevToolbar({
           <div className='px-4 py-2 max-h-48 overflow-y-auto'>
             {/* Overridden flags group */}
             {filteredFlags.overridden.length > 0 && (
-              <div className='mb-2 border-l-2 border-[var(--color-accent)] pl-3'>
+              <div className='mb-2 border-l-2 border-accent pl-3'>
                 <div className='flex items-center justify-between mb-1'>
-                  <span className='text-3xs font-semibold uppercase tracking-wide text-[var(--color-accent)]'>
+                  <span className='text-3xs font-semibold uppercase tracking-wide text-accent'>
                     Overrides ({filteredFlags.overridden.length})
                   </span>
                   <button
@@ -853,7 +849,7 @@ export function DevToolbar({
 
             {/* Empty search state */}
             {matchCount === 0 && search && (
-              <div className='py-3 text-center text-[var(--color-text-quaternary-token)]'>
+              <div className='py-3 text-center text-quaternary-token'>
                 No flags match &lsquo;{search}&rsquo;
               </div>
             )}
@@ -862,7 +858,7 @@ export function DevToolbar({
       </div>
 
       {/* Bottom bar (always visible) */}
-      <div className='relative flex items-center h-9 px-4 gap-2 border-t border-[var(--color-border-default)] backdrop-blur-sm bg-[var(--color-bg-surface-1)]/80 shadow-[0_-2px_8px_rgba(0,0,0,0.1)]'>
+      <div className='relative flex items-center h-9 px-4 gap-2 border-t border-default backdrop-blur-sm bg-surface-1/80 shadow-[0_-2px_8px_rgba(0,0,0,0.1)]'>
         {/* Center: brand logo */}
         <div className='absolute left-1/2 -translate-x-1/2 pointer-events-none'>
           <BrandLogo size={16} tone='auto' aria-hidden rounded={false} />
@@ -874,12 +870,12 @@ export function DevToolbar({
           {env}
         </span>
         {sha && (
-          <span className='max-sm:hidden sm:inline text-[var(--color-text-quaternary-token)] truncate'>
+          <span className='max-sm:hidden sm:inline text-quaternary-token truncate'>
             {sha}
           </span>
         )}
         {version && (
-          <span className='max-sm:hidden sm:inline text-[var(--color-text-quaternary-token)] shrink-0'>
+          <span className='max-sm:hidden sm:inline text-quaternary-token shrink-0'>
             v{version}
           </span>
         )}
@@ -891,14 +887,14 @@ export function DevToolbar({
             onClick={() => {
               if (!open) toggleOpen();
             }}
-            className='px-2 py-0.5 rounded-full text-3xs font-medium bg-[var(--color-accent)]/10 text-[var(--color-accent)] border border-[var(--color-accent)]/30 shrink-0 hover:bg-[var(--color-accent)]/20 transition-colors cursor-pointer'
+            className='px-2 py-0.5 rounded-full text-3xs font-medium bg-accent/10 text-accent border border-accent/30 shrink-0 hover:bg-accent/20 transition-colors cursor-pointer'
             title='View overrides'
           >
             {overrideCount} {overrideCount === 1 ? 'override' : 'overrides'}
           </button>
         )}
 
-        <span className='max-md:hidden md:inline px-1.5 py-0.5 rounded text-3xs text-[var(--color-text-quaternary-token)] bg-[var(--color-bg-surface-2)] shrink-0'>
+        <span className='max-md:hidden md:inline px-1.5 py-0.5 rounded text-3xs text-quaternary-token bg-surface-2 shrink-0'>
           {breakpoint}
         </span>
 
@@ -909,8 +905,8 @@ export function DevToolbar({
           onClick={toggleDesignV1}
           className={`inline-flex shrink-0 items-center gap-1 px-1.5 py-1 rounded text-3xs transition-colors ${
             designV1Enabled
-              ? 'text-[var(--color-accent)] bg-[var(--color-accent)]/10 hover:bg-[var(--color-accent)]/15'
-              : 'text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)]'
+              ? 'text-accent bg-accent/10 hover:bg-accent/15'
+              : 'text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2'
           }`}
         >
           <span>New Design</span>
@@ -930,8 +926,8 @@ export function DevToolbar({
             title={`${flagBadgeCtx?.showBadges ? 'Hide' : 'Show'} flag badges (⌘⇧F)`}
             className={`p-1.5 rounded transition-colors ${
               flagBadgeCtx?.showBadges
-                ? 'text-[var(--color-accent)] bg-[var(--color-accent)]/10'
-                : 'text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)]'
+                ? 'text-accent bg-accent/10'
+                : 'text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2'
             }`}
             aria-label='Toggle Flag Badges'
           >
@@ -953,8 +949,8 @@ export function DevToolbar({
               title={label}
               className={`p-1.5 rounded transition-colors ${
                 mounted && theme === value
-                  ? 'text-[var(--color-accent)] bg-[var(--color-accent)]/10'
-                  : 'text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)]'
+                  ? 'text-accent bg-accent/10'
+                  : 'text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2'
               }`}
               aria-label={label}
             >
@@ -969,7 +965,7 @@ export function DevToolbar({
               type='button'
               onClick={() => copyToClipboard(sha, 'sha')}
               title={`Copy SHA: ${sha}`}
-              className='flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors'
+              className='flex items-center gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors'
               aria-label='Copy SHA'
             >
               <CopyFieldIcon copied={copiedField === 'sha'} icon={Copy} />
@@ -983,7 +979,7 @@ export function DevToolbar({
               copyToClipboard(globalThis.location.pathname, 'route')
             }
             title={`Copy Route: ${globalThis.window === undefined ? '' : globalThis.location.pathname}`}
-            className='flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors'
+            className='flex items-center gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors'
             aria-label='Copy Route'
           >
             <CopyFieldIcon copied={copiedField === 'route'} icon={Route} />
@@ -994,7 +990,7 @@ export function DevToolbar({
             <Link
               href={APP_ROUTES.DESIGN_STUDIO}
               title='Open Design Studio'
-              className='flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors'
+              className='flex items-center gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors'
               aria-label='Design Studio'
             >
               <PanelsTopLeft size={11} />
@@ -1007,7 +1003,7 @@ export function DevToolbar({
           <Link
             href={APP_ROUTES.ADMIN}
             title='Open Admin Panel'
-            className='flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors'
+            className='flex items-center gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors'
             aria-label='Admin Panel'
           >
             <ExternalLink size={11} />
@@ -1023,10 +1019,8 @@ export function DevToolbar({
                 aria-label='Test Persona'
                 aria-expanded={personaPanelOpen}
                 aria-haspopup='menu'
-                className={`flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors ${
-                  personaSession?.active
-                    ? 'text-[var(--color-accent)] bg-[var(--color-accent)]/10'
-                    : ''
+                className={`flex items-center gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors ${
+                  personaSession?.active ? 'text-accent bg-accent/10' : ''
                 }`}
               >
                 <UserRound size={11} />
@@ -1038,25 +1032,25 @@ export function DevToolbar({
               {personaPanelOpen && (
                 <div
                   role='menu'
-                  className='absolute bottom-full right-0 mb-2 w-72 overflow-hidden rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface-1)] text-[var(--color-text-primary)] shadow-lg'
+                  className='absolute bottom-full right-0 mb-2 w-72 overflow-hidden rounded-md border border-default bg-surface-1 text-[var(--color-text-primary)] shadow-lg'
                 >
-                  <div className='border-b border-[var(--color-border-subtle)] px-3 py-2'>
+                  <div className='border-b border-subtle px-3 py-2'>
                     <div className='flex items-center justify-between gap-2'>
                       <span className='text-2xs font-medium'>Test Persona</span>
                       {personaLoading && (
                         <Loader2
                           size={11}
-                          className='animate-spin text-[var(--color-text-quaternary-token)]'
+                          className='animate-spin text-quaternary-token'
                         />
                       )}
                     </div>
-                    <p className='mt-1 truncate text-3xs text-[var(--color-text-quaternary-token)]'>
+                    <p className='mt-1 truncate text-3xs text-quaternary-token'>
                       {personaSession?.active
                         ? `Active: ${personaSession.email ?? personaSession.userId ?? 'test user'}`
                         : 'No test persona active'}
                     </p>
                     {personaSession?.active && personaSession.profilePath && (
-                      <p className='mt-0.5 truncate text-3xs text-[var(--color-text-quaternary-token)]'>
+                      <p className='mt-0.5 truncate text-3xs text-quaternary-token'>
                         {personaSession.profilePath}
                       </p>
                     )}
@@ -1081,9 +1075,9 @@ export function DevToolbar({
                             role='menuitem'
                             disabled={Boolean(personaAction) || isActive}
                             onClick={() => handleSelectPersona(option.persona)}
-                            className='flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[var(--color-bg-surface-2)] disabled:cursor-default disabled:opacity-75'
+                            className='flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-surface-2 disabled:cursor-default disabled:opacity-75'
                           >
-                            <span className='flex size-4 shrink-0 items-center justify-center text-[var(--color-accent)]'>
+                            <span className='flex size-4 shrink-0 items-center justify-center text-accent'>
                               {isSwitching ? (
                                 <Loader2 size={12} className='animate-spin' />
                               ) : isActive ? (
@@ -1095,7 +1089,7 @@ export function DevToolbar({
                                 <span className='truncate text-2xs font-medium'>
                                   {option.label}
                                 </span>
-                                <span className='shrink-0 text-3xs text-[var(--color-text-quaternary-token)]'>
+                                <span className='shrink-0 text-3xs text-quaternary-token'>
                                   {option.meta}
                                 </span>
                               </span>
@@ -1113,7 +1107,7 @@ export function DevToolbar({
                           role='menuitem'
                           disabled={Boolean(personaAction)}
                           onClick={handleExitPersona}
-                          className='mt-1 flex w-full items-center gap-2 border-t border-[var(--color-border-subtle)] px-3 py-2 text-left text-2xs text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-surface-2)] hover:text-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-50'
+                          className='mt-1 flex w-full items-center gap-2 border-t border-subtle px-3 py-2 text-left text-2xs text-[var(--color-text-tertiary)] transition-colors hover:bg-surface-2 hover:text-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-50'
                         >
                           <span className='flex size-4 shrink-0 items-center justify-center'>
                             {personaAction === 'exit' ? (
@@ -1129,7 +1123,7 @@ export function DevToolbar({
                   )}
 
                   {personaError && (
-                    <div className='border-t border-[var(--color-border-subtle)] px-3 py-2 text-3xs text-red-400'>
+                    <div className='border-t border-subtle px-3 py-2 text-3xs text-red-400'>
                       {personaError}
                     </div>
                   )}
@@ -1149,7 +1143,7 @@ export function DevToolbar({
                 clearSessionState === 'loading' || clearSessionState === 'done'
               }
               title='Clear all cookies, localStorage, and sessionStorage'
-              className='flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+              className='flex items-center gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
               aria-label='Clear Session'
             >
               <AsyncActionIcon state={clearSessionState} idleIcon={Trash2} />
@@ -1167,7 +1161,7 @@ export function DevToolbar({
                 unwaitlistState === 'loading' || unwaitlistState === 'done'
               }
               title='Approve your own waitlist entry (dev only)'
-              className='flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+              className='flex items-center gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
               aria-label='Unwaitlist'
             >
               <AsyncActionIcon state={unwaitlistState} idleIcon={UserCheck} />
@@ -1185,20 +1179,17 @@ export function DevToolbar({
                 syncClerkState === 'loading' || syncClerkState === 'done'
               }
               title='Sync Clerk user ID to DB (fixes clerk_id mismatch between dev/prod)'
-              className='flex items-center gap-1 px-1.5 py-1 rounded text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+              className='flex items-center gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
               aria-label='Sync Clerk ID'
             >
               {syncClerkState === 'loading' && (
                 <Loader2 size={11} className='animate-spin' />
               )}
               {syncClerkState === 'done' && (
-                <Check size={11} className='text-[var(--color-accent)]' />
+                <Check size={11} className='text-accent' />
               )}
               {syncClerkState === 'noop' && (
-                <Check
-                  size={11}
-                  className='text-[var(--color-text-quaternary-token)]'
-                />
+                <Check size={11} className='text-quaternary-token' />
               )}
               {syncClerkState !== 'loading' &&
                 syncClerkState !== 'done' &&
@@ -1273,7 +1264,7 @@ export function DevToolbar({
           <button
             type='button'
             onClick={toggleOpen}
-            className='flex items-center gap-1 px-2 py-1 rounded text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors'
+            className='flex items-center gap-1 px-2 py-1 rounded text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors'
             aria-label={open ? 'Collapse Dev Toolbar' : 'Expand Dev Toolbar'}
           >
             <ExpandCollapseIcon open={open} />
@@ -1281,7 +1272,7 @@ export function DevToolbar({
           <button
             type='button'
             onClick={hide}
-            className='flex items-center px-2 py-1 rounded text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)] transition-colors'
+            className='flex items-center px-2 py-1 rounded text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors'
             aria-label='Hide Dev Toolbar'
           >
             <X size={13} />
@@ -1313,9 +1304,7 @@ function PlanToggleInner({
     <>
       <div className='w-px h-4 mx-1 bg-[var(--color-border-subtle)]' />
       <div className='flex items-center gap-0.5'>
-        <span className='text-3xs text-[var(--color-text-quaternary-token)] mr-0.5'>
-          Plan
-        </span>
+        <span className='text-3xs text-quaternary-token mr-0.5'>Plan</span>
         {(['free', 'pro', 'max'] as const).map(plan => (
           <button
             key={plan}
@@ -1341,8 +1330,8 @@ function PlanToggleInner({
             }}
             className={`px-1.5 py-0.5 rounded text-3xs transition-colors ${
               plan === currentPlan
-                ? 'font-semibold text-[var(--color-accent)] bg-[var(--color-accent)]/10'
-                : 'text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-2)]'
+                ? 'font-semibold text-accent bg-accent/10'
+                : 'text-quaternary-token hover:text-[var(--color-text-primary)] hover:bg-surface-2'
             } ${switching ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
             title={`Switch to ${plan} plan`}
             aria-label={`Switch to ${plan} plan`}
@@ -1391,7 +1380,7 @@ function OrphanOverrides({
           {keys.map(k => (
             <span
               key={k}
-              className='truncate text-3xs text-[var(--color-text-quaternary-token)] font-mono'
+              className='truncate text-3xs text-quaternary-token font-mono'
             >
               {k}
             </span>
@@ -1425,16 +1414,14 @@ function FlagRow({
   return (
     <div
       className={`flex items-center gap-2 py-0.5 rounded-sm transition-colors duration-subtle ${
-        flashing ? 'bg-[var(--color-accent)]/10' : ''
+        flashing ? 'bg-accent/10' : ''
       }`}
     >
       <Switch.Root
         checked={checked}
         onCheckedChange={onCheckedChange}
         className={`relative w-7 h-4 rounded-full transition-colors outline-none cursor-pointer shrink-0 ${
-          checked
-            ? 'bg-[var(--color-accent)]'
-            : 'bg-[var(--color-bg-surface-3)]'
+          checked ? 'bg-accent' : 'bg-surface-3'
         }`}
       >
         <Switch.Thumb className='block w-3 h-3 bg-white rounded-full transition-transform translate-x-0.5 data-[state=checked]:translate-x-3.5 shadow-sm dark:bg-white' />
@@ -1445,7 +1432,7 @@ function FlagRow({
         {label}
       </span>
       {isOverridden && serverDefault !== undefined && (
-        <span className='shrink-0 text-3xs text-[var(--color-text-quaternary-token)]'>
+        <span className='shrink-0 text-3xs text-quaternary-token'>
           server: {serverDefault ? 'on' : 'off'}
         </span>
       )}
@@ -1454,13 +1441,13 @@ function FlagRow({
           type='button'
           onClick={onClear}
           title='Remove override'
-          className='shrink-0 text-[var(--color-text-quaternary-token)] hover:text-[var(--color-text-secondary)] transition-colors'
+          className='shrink-0 text-quaternary-token hover:text-[var(--color-text-secondary)] transition-colors'
         >
           <X size={10} />
         </button>
       )}
       {!isOverridden && (
-        <span className='shrink-0 text-3xs text-[var(--color-text-quaternary-token)]'>
+        <span className='shrink-0 text-3xs text-quaternary-token'>
           {source}
         </span>
       )}

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 5050,
+  "count": 3579,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }

--- a/apps/web/tests/unit/dev/DevToolbar.test.tsx
+++ b/apps/web/tests/unit/dev/DevToolbar.test.tsx
@@ -601,7 +601,7 @@ describe('DevToolbar', () => {
       // The flag now lives in the Overrides section — find its new row.
       const newLabel = screen.getByText('claim handle');
       const newRow = newLabel.closest('[class*="rounded-sm"]');
-      expect(newRow?.className).toContain('bg-[var(--color-accent)]/10');
+      expect(newRow?.className).toContain('bg-accent/10');
     });
   });
 


### PR DESCRIPTION
## Summary
- Replaces DevToolbar arbitrary CSS-variable color utilities with existing named Tailwind token utilities.
- Lowers the arbitrary Tailwind ratchet baseline from 5050 to the exact current measured floor, 3579.
- Keeps the slice exact-token-only: semantic aliases map to the same CSS variables and no layout geometry changes.

## Layout Shift Audit
- Audited DevToolbar hidden/open, flag list, persona panel, async loading/done/error/no-op, theme controls, and service-worker controls.
- This PR only swaps equivalent color utility aliases, so dimensions and conditional wrapper structure are unchanged.

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/dev/DevToolbar.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- JOVIE_AGENT_PROFILE=coder pnpm turbo typecheck
- gt submit pre-push: biome check . && pnpm --filter=@jovie/web run pre-push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dev toolbar styling to implement the latest design token system for improved visual consistency across all UI elements.
  * Refined styling treatments for buttons, icons, panels, badges, and status indicators throughout the toolbar interface.
  * Enhanced visual alignment with updated design system standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->