### PR TITLE
fix(design-system): tokenize investor portal drift

### DIFF
--- a/apps/web/app/investor-portal/[slug]/loading.tsx
+++ b/apps/web/app/investor-portal/[slug]/loading.tsx
@@ -15,13 +15,13 @@ export default function MemoLoading() {
   return (
     <div className='px-4 pt-8 sm:px-6 lg:pt-12'>
       <div className='mx-auto max-w-5xl animate-pulse space-y-4'>
-        <div className='h-8 w-64 rounded bg-[var(--color-bg-surface-1)]' />
-        <div className='h-4 w-32 rounded bg-[var(--color-bg-surface-1)]' />
+        <div className='h-8 w-64 rounded bg-surface-1' />
+        <div className='h-4 w-32 rounded bg-surface-1' />
         <div className='mt-8 space-y-3'>
           {SKELETON_LINES.map((key, i) => (
             <div
               key={key}
-              className='h-4 rounded bg-[var(--color-bg-surface-1)]'
+              className='h-4 rounded bg-surface-1'
               style={{ width: LINE_WIDTHS[i] }}
             />
           ))}

--- a/apps/web/app/investor-portal/_components/FundraiseProgress.tsx
+++ b/apps/web/app/investor-portal/_components/FundraiseProgress.tsx
@@ -23,7 +23,7 @@ export function FundraiseProgress({
     <div className='flex flex-1 flex-col gap-1.5'>
       {/* Progress bar — 4px thin, accent fill */}
       <progress
-        className='h-1 w-full appearance-none overflow-hidden rounded-full [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-[var(--color-accent)] [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-[var(--color-bg-surface-2)] [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-[var(--color-accent)] [&::-webkit-progress-value]:transition-colors'
+        className='h-1 w-full appearance-none overflow-hidden rounded-full [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-accent [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-surface-2 [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-accent [&::-webkit-progress-value]:transition-colors'
         style={{ background: 'var(--color-bg-surface-2)' }}
         value={percentage}
         max={100}
@@ -31,7 +31,7 @@ export function FundraiseProgress({
       />
 
       {/* Text */}
-      <p className='text-[length:var(--text-xs)] font-medium text-[var(--color-text-tertiary-token)]'>
+      <p className='text-[length:var(--text-xs)] font-medium text-tertiary-token'>
         {formatCompactUsd(committedAmount)} / {formatCompactUsd(raiseTarget)}{' '}
         committed
         {investorCount > 0 &&

--- a/apps/web/app/investor-portal/_components/MemoContent.tsx
+++ b/apps/web/app/investor-portal/_components/MemoContent.tsx
@@ -40,7 +40,7 @@ export function MemoContent({
         <div className='mb-8 flex items-start justify-between'>
           <div>
             <h1
-              className='text-[length:var(--text-3xl)] font-bold text-[var(--color-text-primary-token)]'
+              className='text-[length:var(--text-3xl)] font-bold text-primary-token'
               style={{
                 letterSpacing: 'var(--tracking-tight)',
                 fontFeatureSettings: 'var(--font-features)',
@@ -48,7 +48,7 @@ export function MemoContent({
             >
               {title}
             </h1>
-            <p className='mt-1 text-[length:var(--text-sm)] text-[var(--color-text-quaternary-token)]'>
+            <p className='mt-1 text-[length:var(--text-sm)] text-quaternary-token'>
               {readingTime} min read
             </p>
           </div>
@@ -80,7 +80,7 @@ export function MemoContent({
               aria-label='Table Of Contents'
             >
               <div className='sticky top-8'>
-                <p className='mb-3 text-[length:var(--text-xs)] font-semibold uppercase tracking-widest text-[var(--color-text-quaternary-token)]'>
+                <p className='mb-3 text-[length:var(--text-xs)] font-semibold uppercase tracking-widest text-quaternary-token'>
                   On this page
                 </p>
                 <ul className='flex flex-col gap-1.5'>
@@ -88,7 +88,7 @@ export function MemoContent({
                     <li key={entry.id}>
                       <a
                         href={`#${entry.id}`}
-                        className='block text-[length:var(--text-xs)] leading-snug text-[var(--color-text-tertiary-token)] transition-colors hover:text-[var(--color-text-secondary-token)]'
+                        className='block text-[length:var(--text-xs)] leading-snug text-tertiary-token transition-colors hover:text-secondary-token'
                       >
                         {entry.title}
                       </a>

--- a/apps/web/app/investor-portal/layout.tsx
+++ b/apps/web/app/investor-portal/layout.tsx
@@ -51,7 +51,7 @@ export default async function InvestorLayout({
     .map(p => ({ slug: p.slug, title: p.title }));
 
   return (
-    <div className='dark min-h-screen bg-[var(--color-bg-base)] text-[var(--color-text-primary-token)]'>
+    <div className='dark min-h-screen bg-base text-primary-token'>
       <div className='flex min-h-screen'>
         {/* Left sidebar nav — 200px fixed on desktop */}
         <InvestorNav investorName={investorName} pages={navPages} />

--- a/apps/web/app/investor-portal/page.tsx
+++ b/apps/web/app/investor-portal/page.tsx
@@ -39,7 +39,7 @@ export default async function InvestorLandingPage() {
     <div className='flex flex-col'>
       {investorName && (
         <p
-          className='px-4 pt-12 pb-2 text-center text-[length:var(--text-2xl)] font-[var(--font-weight-medium)] text-[var(--color-text-secondary-token)] sm:px-6 sm:pt-16 lg:pt-20'
+          className='px-4 pt-12 pb-2 text-center text-[length:var(--text-2xl)] font-[var(--font-weight-medium)] text-secondary-token sm:px-6 sm:pt-16 lg:pt-20'
           style={{ letterSpacing: 'var(--tracking-normal)' }}
         >
           Hi {investorName}

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3559,
+  "count": 3544,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replaces investor portal CSS-variable color utilities with existing named Tailwind token utilities.
- Lowers the arbitrary Tailwind ratchet baseline from 3559 to 3544.
- Keeps the slice exact-token-only: text-size, radius, and calc arbitraries are untouched.

## Layout Shift Audit
- Audited investor portal loading skeleton, layout wrapper, landing greeting, memo content headings/TOC, and fundraise progress states.
- This PR only swaps equivalent color utility aliases, so dimensions, wrappers, text sizing, radius, and progress values are unchanged.

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/investor-portal/[slug]/loading.tsx apps/web/app/investor-portal/_components/FundraiseProgress.tsx apps/web/app/investor-portal/_components/MemoContent.tsx apps/web/app/investor-portal/layout.tsx apps/web/app/investor-portal/page.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- gt submit pre-push: biome check . && pnpm --filter=@jovie/web run pre-push