### PR TITLE
fix(design-system): tokenize misc color drift

### DIFF
--- a/apps/web/app/(home)/layout.tsx
+++ b/apps/web/app/(home)/layout.tsx
@@ -17,7 +17,7 @@ export default function HomeLayout({
   // viewport height on its own. Header sits in flow above, footer below the
   // fold. Scrolling reveals the footer; the hero is the first paint.
   return (
-    <div className='home-viewport dark flex min-h-[100svh] flex-col overflow-x-clip bg-[var(--color-bg-base)] text-primary-token'>
+    <div className='home-viewport dark flex min-h-[100svh] flex-col overflow-x-clip bg-base text-primary-token'>
       <SkipToContent />
       <HomeScrollWatcher />
       <MarketingHeader

--- a/apps/web/app/app/(shell)/settings/referral/ReferralCodeCopyClient.tsx
+++ b/apps/web/app/app/(shell)/settings/referral/ReferralCodeCopyClient.tsx
@@ -29,7 +29,7 @@ export function ReferralCodeCopyClient({
       </code>
       <Button variant='ghost' size='sm' onClick={handleCopy}>
         {copied ? (
-          <Check className='h-4 w-4 text-[var(--color-success)]' />
+          <Check className='h-4 w-4 text-success' />
         ) : (
           <Copy className='h-4 w-4' />
         )}

--- a/apps/web/app/out/[id]/page.tsx
+++ b/apps/web/app/out/[id]/page.tsx
@@ -60,7 +60,7 @@ function MissingLinkState() {
 
           <Link
             href='/'
-            className='inline-flex h-9 items-center justify-center rounded-lg bg-[var(--color-btn-primary-bg)] px-4 text-[13px] font-medium text-[var(--color-btn-primary-fg)] transition-colors duration-100 hover:bg-[var(--color-btn-primary-hover)]'
+            className='inline-flex h-9 items-center justify-center rounded-lg bg-btn-primary px-4 text-[13px] font-medium text-btn-primary-foreground transition-colors duration-100 hover:bg-btn-primary-hover'
           >
             Return Home
           </Link>

--- a/apps/web/components/marketing/artist-profile/ShellCtaButton.tsx
+++ b/apps/web/components/marketing/artist-profile/ShellCtaButton.tsx
@@ -25,17 +25,16 @@ const SHAPE: Record<Size, string> = {
 const TONE: Record<`${Tone}-${Context}`, string> = {
   'primary-on-dark':
     'bg-white text-black hover:bg-white/90 shadow-[0_1px_0_rgba(255,255,255,0.06)_inset]',
-  'primary-auto':
-    'bg-[var(--color-text-primary-token)] text-[var(--color-bg-surface-1)] hover:bg-[var(--color-text-primary-token)]/90',
+  'primary-auto': 'bg-primary-token text-surface-1 hover:bg-primary-token/90',
   'secondary-on-dark':
     'bg-white/[0.04] text-white border border-white/12 hover:bg-white/[0.08]',
   'secondary-auto':
-    'bg-transparent text-primary-token border border-[var(--linear-app-shell-border)] hover:bg-[var(--color-bg-surface-2)]/80',
+    'bg-transparent text-primary-token border border-[var(--linear-app-shell-border)] hover:bg-surface-2/80',
 };
 
 const RING_OFFSET: Record<Context, string> = {
   'on-dark': 'focus-visible:ring-offset-black',
-  auto: 'focus-visible:ring-offset-[var(--color-bg-surface-1)]',
+  auto: 'focus-visible:ring-offset-surface-1',
 };
 
 export function shellCtaClassName({

--- a/apps/web/components/molecules/DataCard.tsx
+++ b/apps/web/components/molecules/DataCard.tsx
@@ -24,9 +24,9 @@ export function DataCard({
 }: DataCardProps) {
   const badgeClasses = {
     default: 'bg-surface-hover text-secondary',
-    success: 'bg-[var(--color-success-subtle)] text-[var(--color-success)]',
-    warning: 'bg-[var(--color-warning-subtle)] text-[var(--color-warning)]',
-    error: 'bg-[var(--color-error-subtle)] text-[var(--color-error)]',
+    success: 'bg-success-subtle text-success',
+    warning: 'bg-warning-subtle text-warning',
+    error: 'bg-error-subtle text-error',
   };
 
   return (

--- a/apps/web/components/molecules/SignInTimeoutEscape.tsx
+++ b/apps/web/components/molecules/SignInTimeoutEscape.tsx
@@ -48,7 +48,7 @@ export function SignInTimeoutEscape() {
   if (!timedOut) return null;
 
   return (
-    <div className='mt-6 text-center text-sm text-[var(--color-text-tertiary-token)]'>
+    <div className='mt-6 text-center text-sm text-tertiary-token'>
       Having trouble?{' '}
       {/* API route, not a page — intentional full-document navigation so the
           server can clear cookies and 303 to /signin?reset=1. */}

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3544,
+  "count": 3527,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replaces scattered CSS-variable color utilities with existing named Tailwind token utilities.
- Covers status badges, CTA helper tones, outbound fallback button tones, signin timeout text, home wrapper background, and referral success icon.
- Lowers the arbitrary Tailwind ratchet baseline from 3544 to 3527.

## Layout Shift Audit
- Audited touched surfaces by state: status badges, CTA tone/context variants, missing-link fallback, signin timeout escape, home wrapper, and copied referral state.
- This PR only swaps equivalent color utility aliases, so dimensions, wrappers, text sizing, radius, and interaction flow are unchanged.

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/molecules/DataCard.tsx apps/web/components/marketing/artist-profile/ShellCtaButton.tsx apps/web/app/out/[id]/page.tsx apps/web/components/molecules/SignInTimeoutEscape.tsx apps/web/app/(home)/layout.tsx apps/web/app/app/(shell)/settings/referral/ReferralCodeCopyClient.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- gt submit pre-push: biome check . && pnpm --filter=@jovie/web run pre-push