### PR TITLE
fix(design-system): tokenize status color drift

### DIFF
--- a/apps/web/components/features/dashboard/organisms/releases/components/ProviderStatusDot.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/components/ProviderStatusDot.tsx
@@ -74,7 +74,7 @@ function getProviderStatusConfig(
         label: PROVIDER_STATUS_LABELS.manual,
         icon: <TriangleAlert className='h-2.5 w-2.5' aria-hidden='true' />,
         className:
-          'border-[color:color-mix(in_oklab,var(--color-warning)_28%,var(--linear-app-frame-seam))] bg-[color:color-mix(in_oklab,var(--color-warning)_12%,transparent)] text-[var(--color-warning)] shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
+          'border-[color:color-mix(in_oklab,var(--color-warning)_28%,var(--linear-app-frame-seam))] bg-[color:color-mix(in_oklab,var(--color-warning)_12%,transparent)] text-warning shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
       };
     default:
       return {

--- a/apps/web/components/features/demo/DemoSettingsPanel.tsx
+++ b/apps/web/components/features/demo/DemoSettingsPanel.tsx
@@ -282,7 +282,7 @@ function AlwaysInSyncToggle() {
       <span className='text-xs font-semibold text-primary-token'>
         Always In Sync
       </span>
-      <span className='flex h-7 w-12 items-center rounded-full bg-[color:var(--color-accent)] px-1 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]'>
+      <span className='flex h-7 w-12 items-center rounded-full bg-accent px-1 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]'>
         <span className='ml-auto h-5 w-5 rounded-full bg-white shadow-[0_2px_8px_rgba(0,0,0,0.22)] dark:bg-white' />
       </span>
     </div>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3527,
+  "count": 3525,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replaces two remaining exact CSS-variable color utilities with existing named Tailwind token utilities.
- Covers the demo sync accent pill and manual-provider warning text token.
- Lowers the arbitrary Tailwind ratchet baseline from 3527 to 3525.

## Layout Shift Audit
- Audited demo sync toggle and provider status dot states.
- This PR only swaps equivalent color utility aliases, so dimensions, wrappers, text sizing, radius, animation, and state logic are unchanged.

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/dashboard/organisms/releases/components/ProviderStatusDot.tsx apps/web/components/features/demo/DemoSettingsPanel.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- gt submit pre-push: biome check . && pnpm --filter=@jovie/web run pre-push