### PR TITLE
fix(design-system): tokenize font weight drift

### DIFF
--- a/apps/web/app/(dynamic)/playlists/_components/PlaylistGrid.tsx
+++ b/apps/web/app/(dynamic)/playlists/_components/PlaylistGrid.tsx
@@ -51,7 +51,7 @@ export function PlaylistGrid({
               </div>
             )}
           </div>
-          <h2 className='mt-2 text-[13px] font-[450] leading-[1.3] text-white/80 group-hover:text-white'>
+          <h2 className='mt-2 text-[13px] font-book leading-[1.3] text-white/80 group-hover:text-white'>
             {playlist.title}
           </h2>
           <p className='text-[11px] text-white/40'>

--- a/apps/web/app/app/(shell)/admin/ops/HudStatusPill.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudStatusPill.tsx
@@ -12,7 +12,7 @@ export function HudStatusPill({ label, tone }: Readonly<HudStatusPillProps>) {
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full border px-3 py-1 text-2xs font-[510] leading-none'
+        'inline-flex items-center rounded-full border px-3 py-1 text-2xs font-medium leading-none'
       )}
       style={{
         borderColor: `color-mix(in oklab, ${accent.solid} 26%, var(--linear-app-frame-seam))`,

--- a/apps/web/app/ui/selects/page.tsx
+++ b/apps/web/app/ui/selects/page.tsx
@@ -145,7 +145,7 @@ export default function SelectsPage() {
         <Stack title='Assignee'>
           <p
             id='label-assignee'
-            className='text-[13px] font-[450] text-primary-token'
+            className='text-[13px] font-book text-primary-token'
           >
             Assignee
           </p>
@@ -163,7 +163,7 @@ export default function SelectsPage() {
         <Stack title='Priority'>
           <p
             id='label-priority'
-            className='text-[13px] font-[450] text-primary-token'
+            className='text-[13px] font-book text-primary-token'
           >
             Priority
           </p>
@@ -182,7 +182,7 @@ export default function SelectsPage() {
         <Stack title='Status'>
           <p
             id='label-status'
-            className='text-[13px] font-[450] text-primary-token'
+            className='text-[13px] font-book text-primary-token'
           >
             Status
           </p>

--- a/apps/web/components/features/share/PublicShareMenu.tsx
+++ b/apps/web/components/features/share/PublicShareMenu.tsx
@@ -217,7 +217,7 @@ export function PublicShareMenu({
     ) : (
       <button
         type='button'
-        className='inline-flex items-center gap-2 rounded-full border border-subtle bg-surface-0 px-3 py-1.5 text-app font-[510] text-secondary-token transition-colors duration-subtle hover:text-primary-token'
+        className='inline-flex items-center gap-2 rounded-full border border-subtle bg-surface-0 px-3 py-1.5 text-app font-medium text-secondary-token transition-colors duration-subtle hover:text-primary-token'
       >
         {title}
       </button>

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -1101,7 +1101,7 @@ function InputRow({
             className={cn(
               'min-w-[min(13rem,100%)] flex-[1_1_13rem] resize-none bg-transparent placeholder:text-quaternary-token',
               isHero
-                ? 'min-h-7 px-2 py-0.5 text-[15px] font-[450] leading-6 text-primary-token sm:text-[16px]'
+                ? 'min-h-7 px-2 py-0.5 text-[15px] font-book leading-6 text-primary-token sm:text-[16px]'
                 : 'min-h-6 px-1.5 py-[1px] text-[15px] leading-6 text-primary-token',
               // Remove the browser's default focus outline. The surrounding
               // surface provides the focus affordance (border glow via

--- a/apps/web/components/marketing/artist-profile/ArtistProfileSectionHeader.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileSectionHeader.tsx
@@ -12,7 +12,7 @@ interface ArtistProfileSectionHeaderProps {
 }
 
 export const SHELL_H2_CLASS =
-  'text-[clamp(2.25rem,4.8vw,3.5rem)] font-[680] leading-[1.02] tracking-[-0.04em] text-primary-token text-balance';
+  'text-[clamp(2.25rem,4.8vw,3.5rem)] font-bold leading-[1.02] tracking-[-0.04em] text-primary-token text-balance';
 
 export const SHELL_EYEBROW_CLASS =
   'text-xs font-medium uppercase tracking-[0.06em] text-secondary-token';

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -167,7 +167,7 @@ export function EntityCard({
             <span className='text-2xs font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
               {model.datePill.month}
             </span>
-            <span className='text-[34px] font-[680] leading-none tracking-[-0.02em] tabular-nums'>
+            <span className='text-[34px] font-bold leading-none tracking-[-0.02em] tabular-nums'>
               {model.datePill.day}
             </span>
           </div>
@@ -222,7 +222,7 @@ export function EntityCard({
         >
           {model.price ? (
             <div className='min-w-0'>
-              <span className='text-sm font-[680] text-primary-token'>
+              <span className='text-sm font-bold text-primary-token'>
                 {model.price.original ? (
                   <>
                     {model.price.display}

--- a/apps/web/tests/unit/app/admin-ops-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-ops-shell-normalization.test.ts
@@ -105,7 +105,7 @@ describe('admin ops shell normalization', () => {
 
     expect(source).not.toContain('uppercase');
     expect(source).not.toMatch(/\btracking-\[/);
-    expect(source).toContain('font-[510]');
+    expect(source).toContain('font-medium');
     expect(source).toContain('getAccentCssVars');
     expect(source).toContain('HUD_TONE_ACCENT');
   });

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3525,
+  "count": 3515,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replaced exact arbitrary font-weight values with configured Tailwind token utilities:
  - `font-[450]` -> `font-book`
  - `font-[510]` -> `font-medium`
  - `font-[680]` -> `font-bold`
- Lowered the design-system arbitrary-value ratchet baseline from `3525` to `3515`.

## Bug-to-Test
bug-to-test: waived — mechanical design-token alias replacement; regression coverage is the design-system arbitrary-value ratchet.

## Verification
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `pnpm biome check --write` on the 8 touched files
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored` on the 7 touched TSX files
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook passed: secret scan, proxy guard, staged Biome, ESLint, a11y staged check, and staged typecheck
- Graphite submit pre-push passed: repo Biome check, web proxy guard, Tailwind guard, web typecheck, web lint

## Linear Follow-Ups
None.
