### PR TITLE
fix(design-system): tokenize content width drift

### DIFF
--- a/apps/web/components/features/home/FeatureRow.tsx
+++ b/apps/web/components/features/home/FeatureRow.tsx
@@ -23,7 +23,7 @@ export function FeatureRow({
   return (
     <section className='section-spacing-linear'>
       <Container size='homepage'>
-        <div className='mx-auto max-w-[var(--linear-content-max)]'>
+        <div className='mx-auto max-w-linear-content'>
           <div className='reveal-on-scroll grid items-center gap-10 lg:grid-cols-2 lg:gap-16'>
             {/* Left: text */}
             <div className='max-w-120'>

--- a/apps/web/components/features/home/HeroLinear.tsx
+++ b/apps/web/components/features/home/HeroLinear.tsx
@@ -31,7 +31,7 @@ export function HeroLinear({ fullScreen = false }: Readonly<HeroLinearProps>) {
 
       {/* Hero text — left aligned, same max-width + padding as header nav */}
       <div className='relative z-10 flex flex-1 flex-col justify-center pb-6 pt-10 md:pb-8 md:pt-12'>
-        <div className='mx-auto w-full max-w-[var(--linear-content-max)] px-5 sm:px-6 lg:px-0'>
+        <div className='mx-auto w-full max-w-linear-content px-5 sm:px-6 lg:px-0'>
           <div className='hero-stagger'>
             <p className='homepage-section-eyebrow'>
               Built for independent artists
@@ -65,7 +65,7 @@ export function HeroLinear({ fullScreen = false }: Readonly<HeroLinearProps>) {
       </div>
 
       {/* Product screenshot — same max-width as header, top-cropped */}
-      <div className='relative z-10 mx-auto w-full max-w-[var(--linear-content-max)] px-5 sm:px-6 lg:px-0'>
+      <div className='relative z-10 mx-auto w-full max-w-linear-content px-5 sm:px-6 lg:px-0'>
         <div
           className='relative overflow-hidden'
           style={{ borderRadius: '6px', aspectRatio: '16 / 6' }}

--- a/apps/web/components/features/home/HomeTrustSection.tsx
+++ b/apps/web/components/features/home/HomeTrustSection.tsx
@@ -82,7 +82,7 @@ export function HomeTrustSection({
         className={cn(
           isInlineStrip
             ? 'homepage-trust-strip-inner'
-            : 'mx-auto max-w-[var(--linear-content-max)]',
+            : 'mx-auto max-w-linear-content',
           innerBoxClass
         )}
       >

--- a/apps/web/components/features/home/SocialProofSection.tsx
+++ b/apps/web/components/features/home/SocialProofSection.tsx
@@ -1,7 +1,7 @@
 export function SocialProofSection() {
   return (
     <section className='py-[var(--linear-section-pt-sm)] px-5 sm:px-6'>
-      <div className='mx-auto flex max-w-[var(--linear-content-max)] flex-col items-center gap-8 text-center'>
+      <div className='mx-auto flex max-w-linear-content flex-col items-center gap-8 text-center'>
         {/* Founder credibility */}
         <div className='flex flex-col items-center gap-3'>
           <p className='text-[var(--linear-label-size)] font-medium uppercase tracking-[0.1em] text-tertiary-token'>

--- a/apps/web/components/marketing/artist-profile/ArtistProfileSectionShell.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileSectionShell.tsx
@@ -3,7 +3,7 @@ import { MarketingContainer } from '@/components/marketing';
 import { cn } from '@/lib/utils';
 
 const PAGE_CHROME_ALIGNED_CONTAINER_CLASS =
-  '!max-w-[var(--linear-content-max)] !px-5 sm:!px-6 lg:!px-0';
+  '!max-w-linear-content !px-5 sm:!px-6 lg:!px-0';
 
 interface ArtistProfileSectionShellProps {
   readonly id?: string;

--- a/apps/web/components/organisms/HeaderNav.tsx
+++ b/apps/web/components/organisms/HeaderNav.tsx
@@ -270,7 +270,7 @@ function getNavContainerVariantClass({
   }
 
   if (containerSize === 'homepage') {
-    return 'max-w-[var(--linear-content-max)] lg:px-0';
+    return 'max-w-linear-content lg:px-0';
   }
 
   return 'max-w-[calc(var(--linear-content-max)+3rem)]';

--- a/apps/web/components/organisms/footer-module/config.ts
+++ b/apps/web/components/organisms/footer-module/config.ts
@@ -7,7 +7,7 @@ export const CONTAINER_SIZES: Record<ContainerSize, string> = {
   lg: 'max-w-6xl',
   xl: 'max-w-7xl',
   full: 'max-w-none',
-  homepage: 'max-w-[var(--linear-content-max)]',
+  homepage: 'max-w-linear-content',
 };
 
 export function getVariantConfigs(

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3515,
+  "count": 3507,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced exact `max-w-[var(--linear-content-max)]` usages with `max-w-linear-content`.
- Replaced exact important width usage with `!max-w-linear-content`.
- Updated the arbitrary-values ratchet baseline from 3515 to 3507.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/organisms/footer-module/config.ts apps/web/components/marketing/artist-profile/ArtistProfileSectionShell.tsx apps/web/components/organisms/HeaderNav.tsx apps/web/components/features/home/HomeTrustSection.tsx apps/web/components/features/home/FeatureRow.tsx apps/web/components/features/home/HeroLinear.tsx apps/web/components/features/home/SocialProofSection.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/organisms/footer-module/config.ts apps/web/components/marketing/artist-profile/ArtistProfileSectionShell.tsx apps/web/components/organisms/HeaderNav.tsx apps/web/components/features/home/HomeTrustSection.tsx apps/web/components/features/home/FeatureRow.tsx apps/web/components/features/home/HeroLinear.tsx apps/web/components/features/home/SocialProofSection.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing arbitrary-values ratchet test was updated and run for this exact-token drift slice.

## Notes

No visual behavior change intended. This PR only swaps exact design-token aliases for the same `--linear-content-max` CSS variable.