### PR TITLE
fix(design-system): tokenize dev toolbar divider drift

### DIFF
--- a/apps/web/components/features/dev/DevToolbar.tsx
+++ b/apps/web/components/features/dev/DevToolbar.tsx
@@ -934,7 +934,7 @@ export function DevToolbar({
             <Flag size={12} />
           </button>
 
-          <div className='w-px h-4 mx-1 bg-[var(--color-border-subtle)]' />
+          <div className='w-px h-4 mx-1 bg-subtle' />
 
           {/* Theme picker */}
           {[
@@ -958,7 +958,7 @@ export function DevToolbar({
             </button>
           ))}
 
-          <div className='w-px h-4 mx-1 bg-[var(--color-border-subtle)]' />
+          <div className='w-px h-4 mx-1 bg-subtle' />
 
           {sha && (
             <button
@@ -1234,7 +1234,7 @@ export function DevToolbar({
             promoteState !== 'idle' &&
             promoteState !== 'checking' && (
               <>
-                <div className='w-px h-4 mx-1 bg-[var(--color-border-subtle)]' />
+                <div className='w-px h-4 mx-1 bg-subtle' />
                 <button
                   type='button'
                   onClick={handlePromote}
@@ -1258,7 +1258,7 @@ export function DevToolbar({
               </>
             )}
 
-          <div className='w-px h-4 mx-1 bg-[var(--color-border-subtle)]' />
+          <div className='w-px h-4 mx-1 bg-subtle' />
 
           {/* Expand/collapse + hide */}
           <button
@@ -1302,7 +1302,7 @@ function PlanToggleInner({
 
   return (
     <>
-      <div className='w-px h-4 mx-1 bg-[var(--color-border-subtle)]' />
+      <div className='w-px h-4 mx-1 bg-subtle' />
       <div className='flex items-center gap-0.5'>
         <span className='text-3xs text-quaternary-token mr-0.5'>Plan</span>
         {(['free', 'pro', 'max'] as const).map(plan => (

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3507,
+  "count": 3502,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced five exact `bg-[var(--color-border-subtle)]` divider utilities in `DevToolbar` with `bg-subtle`.
- `bg-subtle` is generated from `--color-subtle: var(--color-border-subtle)`, so this preserves the same color value.
- Updated the arbitrary-values ratchet baseline from 3507 to 3502.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts tests/unit/dev/DevToolbar.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/dev/DevToolbar.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/dev/DevToolbar.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing DevToolbar unit coverage and arbitrary-values ratchet test were run for this exact-token drift slice.

## Notes

No visual behavior change intended. This PR only swaps divider backgrounds to the existing exact token alias.