### PR TITLE
fix(design-system): tokenize viewport height drift

### DIFF
--- a/apps/web/app/[username]/notifications/NotificationsPageClient.tsx
+++ b/apps/web/app/[username]/notifications/NotificationsPageClient.tsx
@@ -52,7 +52,7 @@ export function NotificationsPageClient({ artist }: Props) {
   return (
     <ProfileNotificationsContext.Provider value={notificationsContextValue}>
       <div
-        className='relative flex h-[100dvh] items-center justify-center overflow-hidden bg-[color:var(--profile-stage-bg)] p-4 sm:p-6'
+        className='relative flex h-dvh items-center justify-center overflow-hidden bg-[color:var(--profile-stage-bg)] p-4 sm:p-6'
         data-testid='notifications-page'
         style={accentStyle}
       >

--- a/apps/web/components/organisms/public-surface/PublicSurfaceShell.tsx
+++ b/apps/web/components/organisms/public-surface/PublicSurfaceShell.tsx
@@ -22,7 +22,7 @@ export function PublicSurfaceShell({
   return (
     <div
       className={cn(
-        'profile-viewport relative h-[100dvh] overflow-clip bg-base text-primary-token md:h-auto md:min-h-[100dvh] md:overflow-x-hidden',
+        'profile-viewport relative h-dvh overflow-clip bg-base text-primary-token md:h-auto md:min-h-dvh md:overflow-x-hidden',
         className
       )}
     >

--- a/apps/web/components/organisms/public-surface/PublicSurfaceStage.tsx
+++ b/apps/web/components/organisms/public-surface/PublicSurfaceStage.tsx
@@ -16,7 +16,7 @@ export function PublicSurfaceStage({
   return (
     <div
       className={cn(
-        'relative mx-auto flex h-[100dvh] w-full max-w-170 items-stretch justify-center md:h-auto md:min-h-[100dvh] md:items-center md:px-6 md:py-8',
+        'relative mx-auto flex h-dvh w-full max-w-170 items-stretch justify-center md:h-auto md:min-h-dvh md:items-center md:px-6 md:py-8',
         className
       )}
     >

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3502,
+  "count": 3497,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced exact `h-[100dvh]` utilities with `h-dvh`.
- Replaced exact responsive `min-h-[100dvh]` utilities with `min-h-dvh`.
- Updated the arbitrary-values ratchet baseline from 3502 to 3497.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/organisms/public-surface/PublicSurfaceStage.tsx apps/web/components/organisms/public-surface/PublicSurfaceShell.tsx apps/web/app/[username]/notifications/NotificationsPageClient.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/organisms/public-surface/PublicSurfaceStage.tsx apps/web/components/organisms/public-surface/PublicSurfaceShell.tsx apps/web/app/[username]/notifications/NotificationsPageClient.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing arbitrary-values ratchet test was updated and run for this exact-token drift slice.

## Notes

No visual behavior change intended. This PR only swaps Tailwind arbitrary viewport-height utilities to their exact built-in aliases.