### PR TITLE
fix(design-system): tokenize home viewport drift

### DIFF
--- a/apps/web/app/(home)/layout.tsx
+++ b/apps/web/app/(home)/layout.tsx
@@ -12,12 +12,12 @@ export default function HomeLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Dual min-h-[100svh] is intentional (Lovable-style hero shell): the outer
+  // Dual min-h-svh is intentional (Lovable-style hero shell): the outer
   // container is at least viewport height, AND main holds the hero at full
   // viewport height on its own. Header sits in flow above, footer below the
   // fold. Scrolling reveals the footer; the hero is the first paint.
   return (
-    <div className='home-viewport dark flex min-h-[100svh] flex-col overflow-x-clip bg-base text-primary-token'>
+    <div className='home-viewport dark flex min-h-svh flex-col overflow-x-clip bg-base text-primary-token'>
       <SkipToContent />
       <HomeScrollWatcher />
       <MarketingHeader
@@ -26,7 +26,7 @@ export default function HomeLayout({
         showHomepageCenterNav={FEATURE_FLAGS.SHOW_HOMEPAGE_CENTER_NAV}
         variant='homepage'
       />
-      <main id='main-content' className='flex min-h-[100svh] flex-1 flex-col'>
+      <main id='main-content' className='flex min-h-svh flex-1 flex-col'>
         {children}
       </main>
       <HomeLegalFooter className='system-b-mounted-home-footer' />

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3497,
+  "count": 3494,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced the home layout's exact `min-h-[100svh]` utilities with `min-h-svh`.
- Updated the nearby comment so the ratchet scanner no longer counts the old arbitrary utility text.
- Updated the arbitrary-values ratchet baseline from 3497 to 3494.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/(home)/layout.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/app/(home)/layout.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing arbitrary-values ratchet test was updated and run for this exact-token drift slice.

## Notes

No visual behavior change intended. This PR only swaps `100svh` arbitrary utilities to the exact built-in Tailwind alias.