### PR TITLE
fix(design-system): tokenize radius drift

### DIFF
--- a/apps/web/app/investor-portal/_components/MemoContent.tsx
+++ b/apps/web/app/investor-portal/_components/MemoContent.tsx
@@ -60,7 +60,7 @@ export function MemoContent({
         <div className='flex gap-10'>
           {/* Main prose — light mode applies white bg + dark text */}
           <article
-            className={`investor-prose min-w-0 flex-1 rounded-[var(--radius-xl)] transition-colors duration-subtle ${
+            className={`investor-prose min-w-0 flex-1 rounded-xl transition-colors duration-subtle ${
               isLight ? 'bg-paper p-6' : ''
             }`}
             style={{

--- a/apps/web/components/features/auth/AuthFormContainer.stories.tsx
+++ b/apps/web/components/features/auth/AuthFormContainer.stories.tsx
@@ -22,7 +22,7 @@ const SampleForm = () => (
       <input
         type='email'
         placeholder='you@example.com'
-        className='w-full px-3 py-2 border border-subtle rounded-[--radius-xl] bg-surface-0 text-primary-token placeholder:text-tertiary-token'
+        className='w-full px-3 py-2 border border-subtle rounded-xl bg-surface-0 text-primary-token placeholder:text-tertiary-token'
       />
     </div>
     <div className='space-y-2'>
@@ -35,12 +35,12 @@ const SampleForm = () => (
       <input
         type='password'
         placeholder='••••••••'
-        className='w-full px-3 py-2 border border-subtle rounded-[--radius-xl] bg-surface-0 text-primary-token placeholder:text-tertiary-token'
+        className='w-full px-3 py-2 border border-subtle rounded-xl bg-surface-0 text-primary-token placeholder:text-tertiary-token'
       />
     </div>
     <button
       type='button'
-      className='w-full py-2 bg-btn-primary text-btn-primary-foreground rounded-[--radius-xl] font-medium'
+      className='w-full py-2 bg-btn-primary text-btn-primary-foreground rounded-xl font-medium'
     >
       Sign In
     </button>

--- a/apps/web/components/features/auth/AuthLayout.stories.tsx
+++ b/apps/web/components/features/auth/AuthLayout.stories.tsx
@@ -22,12 +22,12 @@ const SampleForm = () => (
       <input
         type='email'
         placeholder='you@example.com'
-        className='w-full px-3 py-2 border border-subtle rounded-[--radius-xl] bg-surface-0 text-primary-token placeholder:text-tertiary-token'
+        className='w-full px-3 py-2 border border-subtle rounded-xl bg-surface-0 text-primary-token placeholder:text-tertiary-token'
       />
     </div>
     <button
       type='button'
-      className='w-full py-2 bg-btn-primary text-btn-primary-foreground rounded-[--radius-xl] font-medium'
+      className='w-full py-2 bg-btn-primary text-btn-primary-foreground rounded-xl font-medium'
     >
       Continue
     </button>
@@ -72,7 +72,7 @@ export const Waitlist: Story = {
           <input
             type='email'
             placeholder='you@example.com'
-            className='w-full px-3 py-2 border border-subtle rounded-[--radius-xl] bg-surface-0 text-primary-token placeholder:text-tertiary-token'
+            className='w-full px-3 py-2 border border-subtle rounded-xl bg-surface-0 text-primary-token placeholder:text-tertiary-token'
           />
         </div>
         <div className='space-y-2'>
@@ -85,12 +85,12 @@ export const Waitlist: Story = {
           <input
             type='text'
             placeholder='@yourhandle'
-            className='w-full px-3 py-2 border border-subtle rounded-[--radius-xl] bg-surface-0 text-primary-token placeholder:text-tertiary-token'
+            className='w-full px-3 py-2 border border-subtle rounded-xl bg-surface-0 text-primary-token placeholder:text-tertiary-token'
           />
         </div>
         <button
           type='button'
-          className='w-full py-2 bg-btn-primary text-btn-primary-foreground rounded-[--radius-xl] font-medium'
+          className='w-full py-2 bg-btn-primary text-btn-primary-foreground rounded-xl font-medium'
         >
           Join Waitlist
         </button>

--- a/apps/web/components/features/auth/atoms/AuthLinkPreviewCard.tsx
+++ b/apps/web/components/features/auth/atoms/AuthLinkPreviewCard.tsx
@@ -19,7 +19,7 @@ export function AuthLinkPreviewCard({
   return (
     <div
       className={cn(
-        'w-full rounded-[--radius-lg] border border-subtle bg-surface-0 px-4 py-3',
+        'w-full rounded-lg border border-subtle bg-surface-0 px-4 py-3',
         className
       )}
     >

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3494,
+  "count": 3484,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced exact `rounded-[--radius-xl]` utilities with `rounded-xl`.
- Replaced exact `rounded-[--radius-lg]` utility with `rounded-lg`.
- Replaced exact `rounded-[var(--radius-xl)]` in investor memo content with `rounded-xl`.
- Updated the arbitrary-values ratchet baseline from 3494 to 3484.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/auth/AuthLayout.stories.tsx apps/web/components/features/auth/AuthFormContainer.stories.tsx apps/web/components/features/auth/atoms/AuthLinkPreviewCard.tsx apps/web/app/investor-portal/_components/MemoContent.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/auth/AuthLayout.stories.tsx apps/web/components/features/auth/AuthFormContainer.stories.tsx apps/web/components/features/auth/atoms/AuthLinkPreviewCard.tsx apps/web/app/investor-portal/_components/MemoContent.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing arbitrary-values ratchet test was updated and run for this exact-token drift slice.

## Notes

No visual behavior change intended. Tailwind `rounded-xl` and `rounded-lg` resolve to the same `--radius-xl` and `--radius-lg` theme variables used by the removed arbitrary utilities.