### PR TITLE
fix(design-system): tokenize semibold drift

### DIFF
--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -353,7 +353,7 @@ function CompactDeploymentRow({
             className={`h-1.5 w-1.5 shrink-0 rounded-full ${DEPLOYMENT_STATE_DOT_CLASSNAMES[run.status]}`}
             aria-hidden='true'
           />
-          <p className='truncate text-app font-[590] text-primary-token'>
+          <p className='truncate text-app font-semibold text-primary-token'>
             {DEPLOYMENT_STATE_LABELS[run.status]}
           </p>
         </div>

--- a/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
+++ b/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
@@ -130,7 +130,7 @@ function AgentRunDetailPopover({
       >
         <div className='space-y-3'>
           <div className='min-w-0'>
-            <p className='text-xs font-[590] text-primary-token'>
+            <p className='text-xs font-semibold text-primary-token'>
               {artifact.title}
             </p>
             <p className='mt-1 text-xs leading-5 text-secondary-token'>

--- a/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
+++ b/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
@@ -97,7 +97,7 @@ export function ArtifactDrawer({ artifact }: ArtifactDrawerProps) {
       <p className='mb-3 text-xs font-[560] text-primary-token'>Selected Run</p>
       <div className='flex items-start justify-between gap-3'>
         <div className='min-w-0'>
-          <p className='truncate text-app font-[590] text-primary-token'>
+          <p className='truncate text-app font-semibold text-primary-token'>
             {artifact.title}
           </p>
           <p className='mt-1 text-xs leading-5 text-secondary-token'>

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -201,7 +201,7 @@ export function EntityCard({
 
         <h3
           className={cn(
-            'min-w-0 font-[590] leading-tight tracking-[-0.02em] text-primary-token line-clamp-2',
+            'min-w-0 font-semibold leading-tight tracking-[-0.02em] text-primary-token line-clamp-2',
             size.titleClass
           )}
         >

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3484,
+  "count": 3480,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced exact `font-[590]` utilities with `font-semibold` in admin run rows and entity cards.
- Updated the arbitrary-values ratchet baseline from 3484 to 3480.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx apps/web/components/organisms/entity-card/EntityCard.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx apps/web/components/organisms/entity-card/EntityCard.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing arbitrary-values ratchet test was updated and run for this exact-token drift slice.

## Notes

No visual behavior change intended. Tailwind `font-semibold` resolves to the same `--font-weight-semibold` value (590) used by the removed arbitrary utilities.