### PR TITLE
fix(design-system): tokenize line-height drift

### DIFF
--- a/apps/web/app/app/(shell)/admin/share-studio/page.tsx
+++ b/apps/web/app/app/(shell)/admin/share-studio/page.tsx
@@ -217,7 +217,7 @@ function PayloadBlock(props: Readonly<{ label: string; value: string }>) {
   return (
     <div className='space-y-1.5'>
       <p className='text-xs font-semibold text-primary-token'>{props.label}</p>
-      <pre className='overflow-x-auto rounded-xl border border-subtle bg-surface-0 px-3 py-2 text-2xs leading-[1.5] text-secondary-token whitespace-pre-wrap'>
+      <pre className='overflow-x-auto rounded-xl border border-subtle bg-surface-0 px-3 py-2 text-2xs leading-normal text-secondary-token whitespace-pre-wrap'>
         {props.value}
       </pre>
     </div>

--- a/apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx
@@ -47,7 +47,7 @@ function TasksUpgradeContent({
       <h2 className='text-lg font-semibold tracking-[-0.025em] text-primary-token'>
         {heading}
       </h2>
-      <p className='mt-2 max-w-md text-app leading-[1.5] text-secondary-token'>
+      <p className='mt-2 max-w-md text-app leading-normal text-secondary-token'>
         {description}
       </p>
       <div className='mt-6 flex flex-wrap items-center justify-center gap-3'>

--- a/apps/web/components/organisms/CookieBannerSection.tsx
+++ b/apps/web/components/organisms/CookieBannerSection.tsx
@@ -190,7 +190,7 @@ export function CookieBannerSection() {
                 <Shield className='h-3.5 w-3.5' aria-hidden='true' />
               </div>
               <div className='min-w-0 flex-1'>
-                <p className='text-xs leading-[1.5] text-secondary-token'>
+                <p className='text-xs leading-normal text-secondary-token'>
                   We use cookies for essential functionality and to improve your
                   experience.{' '}
                   <Link

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3480,
+  "count": 3477,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced exact `leading-[1.5]` utilities with `leading-normal` in three clean surfaces.
- Updated the arbitrary-values ratchet baseline from 3480 to 3477.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/app/(shell)/admin/share-studio/page.tsx apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx apps/web/components/organisms/CookieBannerSection.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/app/app/(shell)/admin/share-studio/page.tsx apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx apps/web/components/organisms/CookieBannerSection.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing arbitrary-values ratchet test was updated and run for this exact-token drift slice.

## Notes

No visual behavior change intended. Tailwind `leading-normal` resolves to `--leading-normal`, which is the same 1.5 line-height used by the removed arbitrary utilities.