### PR TITLE
fix(design-system): tokenize demo line-height drift

### DIFF
--- a/apps/web/app/exp/home-v1/page.tsx
+++ b/apps/web/app/exp/home-v1/page.tsx
@@ -474,7 +474,7 @@ function HeroBrutalist({ draft, onDraft, onSubmit, onScrollNext }: HeroProps) {
               {EYEBROW}
             </span>
           </div>
-          <p className='text-xs uppercase tracking-[0.06em] text-(--color-bg-surface-0)/55 leading-[1.5] max-w-[26ch]'>
+          <p className='text-xs uppercase tracking-[0.06em] text-(--color-bg-surface-0)/55 leading-normal max-w-[26ch]'>
             ED. 01 / 2026 — A studio for artists who&apos;d rather make than
             manage.
           </p>
@@ -592,7 +592,7 @@ function HeroCinematic({ onScrollNext }: HeroProps) {
         >
           {HEADLINE}
         </h1>
-        <p className='mt-7 text-base lg:text-lg leading-[1.5] text-white/60 max-w-[52ch]'>
+        <p className='mt-7 text-base lg:text-lg leading-normal text-white/60 max-w-[52ch]'>
           {SUBHEAD}
         </p>
         <Link

--- a/apps/web/components/features/demo/DemoSettingsPanel.tsx
+++ b/apps/web/components/features/demo/DemoSettingsPanel.tsx
@@ -180,7 +180,7 @@ function AudienceQualityCaptureCard() {
                   <p className='text-app font-semibold text-primary-token'>
                     Advanced Quality Filtering
                   </p>
-                  <p className='mt-1 text-xs leading-[1.5] text-secondary-token'>
+                  <p className='mt-1 text-xs leading-normal text-secondary-token'>
                     Apply the same quality logic across audience views, exports,
                     and downstream automations.
                   </p>
@@ -231,7 +231,7 @@ function SyncSettingsCaptureCard() {
                 <p className='text-app font-semibold text-primary-token'>
                   Always in sync
                 </p>
-                <p className='mt-1 text-xs leading-[1.5] text-secondary-token'>
+                <p className='mt-1 text-xs leading-normal text-secondary-token'>
                   New releases, top tracks, and linked surfaces stay aligned.
                 </p>
               </div>
@@ -305,7 +305,7 @@ function QualitySignalRow({
       <div className='flex items-start justify-between gap-3'>
         <div>
           <p className='text-app font-semibold text-primary-token'>{label}</p>
-          <p className='mt-1 text-xs leading-[1.5] text-secondary-token'>
+          <p className='mt-1 text-xs leading-normal text-secondary-token'>
             {detail}
           </p>
         </div>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3477,
+  "count": 3472,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced exact `leading-[1.5]` utilities with `leading-normal` in the demo settings panel and experimental home variant.
- Updated the arbitrary-values ratchet baseline from 3477 to 3472.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/exp/home-v1/page.tsx apps/web/components/features/demo/DemoSettingsPanel.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/app/exp/home-v1/page.tsx apps/web/components/features/demo/DemoSettingsPanel.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing arbitrary-values ratchet test was updated and run for this exact-token drift slice.

## Notes

No visual behavior change intended. Tailwind `leading-normal` resolves to `--leading-normal`, which is the same 1.5 line-height used by the removed arbitrary utilities.