### PR TITLE
fix(design-system): tokenize profile skeleton viewport drift

### DIFF
--- a/apps/web/components/features/profile/ProfileSkeleton.tsx
+++ b/apps/web/components/features/profile/ProfileSkeleton.tsx
@@ -9,9 +9,9 @@ export function ProfileSkeleton() {
 
   return (
     <output
-      className='relative min-h-[100dvh] overflow-hidden bg-[color:var(--profile-stage-bg)] text-white/90'
+      className='relative min-h-dvh overflow-hidden bg-[color:var(--profile-stage-bg)] text-white/90'
       aria-busy='true'
-      aria-label='Loading Jovie profile'
+      aria-label='Loading Jovie Profile'
     >
       {/* Ambient background blur placeholder */}
       <div className='absolute inset-0' aria-hidden='true'>
@@ -19,7 +19,7 @@ export function ProfileSkeleton() {
       </div>
 
       {/* Viewport shell */}
-      <div className='relative mx-auto flex min-h-[100dvh] w-full max-w-170 items-stretch justify-center md:items-center md:px-6 md:py-8'>
+      <div className='relative mx-auto flex min-h-dvh w-full max-w-170 items-stretch justify-center md:items-center md:px-6 md:py-8'>
         <div className='relative flex w-full flex-col overflow-hidden bg-white/[0.02] md:min-h-0 md:rounded-[var(--profile-shell-card-radius)] md:border md:border-white/[0.06]'>
           {/* Hero placeholder — matches ArtistHero height */}
           <div

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3472,
+  "count": 3470,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced exact `min-h-[100dvh]` utilities with `min-h-dvh` in the profile skeleton.
- Normalized the touched skeleton aria label casing required by the focused lint gate.
- Updated the arbitrary-values ratchet baseline from 3472 to 3470.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/profile/ProfileSkeleton.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/profile/ProfileSkeleton.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing arbitrary-values ratchet test was updated and run for this exact-token drift slice.

## Notes

No visual behavior change intended. Tailwind `min-h-dvh` resolves to the same dynamic viewport height as the removed arbitrary utility.