### PR TITLE
fix(design-system): tokenize footer width drift

### DIFF
--- a/apps/web/components/site/MarketingFooter.tsx
+++ b/apps/web/components/site/MarketingFooter.tsx
@@ -112,7 +112,7 @@ export function MarketingFooter({
     >
       <div
         className={cn(
-          'mx-auto w-full max-w-[var(--linear-content-max)] px-[clamp(1.25rem,2.2vw,2rem)]',
+          'mx-auto w-full max-w-linear-content px-[clamp(1.25rem,2.2vw,2rem)]',
           isMinimal
             ? 'pt-[clamp(3rem,5vw,4.5rem)] pb-[clamp(2.5rem,4vw,3.5rem)]'
             : shouldShowCta
@@ -130,7 +130,7 @@ export function MarketingFooter({
           <Link
             href={APP_ROUTES.HOME}
             prefetch={false}
-            aria-label='Jovie home'
+            aria-label='Jovie Home'
             className={markLinkClassName}
           >
             <BrandLogo size={22} tone='white' rounded={false} aria-hidden />
@@ -141,7 +141,7 @@ export function MarketingFooter({
               <Link
                 href={APP_ROUTES.HOME}
                 prefetch={false}
-                aria-label='Jovie home'
+                aria-label='Jovie Home'
                 className={markLinkClassName}
               >
                 <BrandLogo size={22} tone='white' rounded={false} aria-hidden />

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3470,
+  "count": 3469,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced exact `max-w-[var(--linear-content-max)]` in the marketing footer with `max-w-linear-content`.
- Normalized the touched footer home-link aria labels required by the focused lint gate.
- Updated the arbitrary-values ratchet baseline from 3470 to 3469.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/site/MarketingFooter.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/site/MarketingFooter.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing arbitrary-values ratchet test was updated and run for this exact-token drift slice.

## Notes

No visual behavior change intended. Tailwind `max-w-linear-content` resolves to the same `--linear-content-max` token used by the removed arbitrary utility.