### PR TITLE
fix(design-system): tokenize demo tracked links drift

### DIFF
--- a/apps/web/components/features/demo/DemoReleaseTrackedLinksSurface.tsx
+++ b/apps/web/components/features/demo/DemoReleaseTrackedLinksSurface.tsx
@@ -5,10 +5,10 @@ import { DemoAuthShell } from './DemoAuthShell';
 import { DEMO_RELEASE_VIEW_MODELS } from './mock-release-data';
 
 const UTM_PRESETS = [
-  { label: 'Instagram story', detail: 'utm_source=instagram' },
-  { label: 'TikTok post', detail: 'utm_source=tiktok' },
-  { label: 'Press outreach', detail: 'utm_source=press' },
-  { label: 'Paid campaign', detail: 'utm_medium=paid' },
+  { label: 'Instagram Story', detail: 'utm_source=instagram' },
+  { label: 'TikTok Post', detail: 'utm_source=tiktok' },
+  { label: 'Press Outreach', detail: 'utm_source=press' },
+  { label: 'Paid Campaign', detail: 'utm_medium=paid' },
 ] as const;
 
 export function DemoReleaseTrackedLinksSurface() {
@@ -29,7 +29,7 @@ export function DemoReleaseTrackedLinksSurface() {
             data-testid='demo-release-tracked-links-capture'
           >
             <div className='rounded-2xl border border-subtle bg-surface-1 px-4 py-3'>
-              <p className='text-2xs font-[510] tracking-[-0.01em] text-tertiary-token'>
+              <p className='text-2xs font-medium tracking-[-0.01em] text-tertiary-token'>
                 Release row
               </p>
               <div className='mt-2 flex items-center justify-between gap-4'>
@@ -41,7 +41,7 @@ export function DemoReleaseTrackedLinksSurface() {
                     {release.artistNames?.join(', ') ?? 'Unknown artist'}
                   </p>
                 </div>
-                <div className='rounded-full border border-subtle bg-surface-0 px-3 py-1.5 text-xs font-[510] text-secondary-token'>
+                <div className='rounded-full border border-subtle bg-surface-0 px-3 py-1.5 text-xs font-medium text-secondary-token'>
                   Share
                 </div>
               </div>
@@ -75,7 +75,7 @@ export function DemoReleaseTrackedLinksSurface() {
                           {preset.detail}
                         </p>
                       </div>
-                      <span className='rounded-full border border-subtle px-2.5 py-1 text-2xs font-[510] text-secondary-token'>
+                      <span className='rounded-full border border-subtle px-2.5 py-1 text-2xs font-medium text-secondary-token'>
                         Copy
                       </span>
                     </div>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3469,
+  "count": 3466,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaced exact `font-[510]` utilities with `font-medium` in the demo tracked-links surface.
- Normalized touched UTM preset labels to Title Case for the focused lint gate.
- Updated the arbitrary-values ratchet baseline from 3469 to 3466.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/demo/DemoReleaseTrackedLinksSurface.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/demo/DemoReleaseTrackedLinksSurface.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: passed
- Graphite submit pre-push checks: passed

bug-to-test: satisfied — existing arbitrary-values ratchet test was updated and run for this exact-token drift slice.

## Notes

No visual behavior change intended. Tailwind `font-medium` resolves to `--font-weight-medium`, the same 510 weight used by the removed arbitrary utilities.