### PR TITLE
fix(design-system): tokenize demo detail drift

### DIFF
--- a/apps/web/components/features/demo/DemoReleaseDetail.tsx
+++ b/apps/web/components/features/demo/DemoReleaseDetail.tsx
@@ -34,13 +34,13 @@ export function DemoReleaseDetail({
     <div className='flex h-full flex-col'>
       {/* Header */}
       <div className='flex min-h-10 items-center justify-between border-b border-(--linear-app-frame-seam) px-4 py-2'>
-        <div className='min-w-0 flex-1 text-app font-[510] tracking-[-0.01em] text-secondary-token'>
+        <div className='min-w-0 flex-1 text-app font-medium tracking-[-0.01em] text-secondary-token'>
           REL-{release.id.slice(0, 4).toUpperCase()}
         </div>
         <DrawerInlineIconButton
           onClick={onClose}
           className='size-7 rounded-full'
-          aria-label='Close detail panel'
+          aria-label='Close Detail Panel'
         >
           <X className='size-4' />
         </DrawerInlineIconButton>
@@ -86,7 +86,7 @@ export function DemoReleaseDetail({
               <span>{release.trackCount}</span>
             </div>
           </DemoPropertyRow>
-          <DemoPropertyRow label='Release date'>
+          <DemoPropertyRow label='Release Date'>
             <div className='-ml-2 rounded px-2 py-1'>
               <span>{release.releaseDate}</span>
             </div>
@@ -129,7 +129,7 @@ export function DemoReleaseDetail({
               {release.labels.map(label => (
                 <span
                   key={label.id}
-                  className='flex items-center gap-1.5 rounded bg-surface-1 px-1.5 py-0.5 text-3xs font-[510] text-secondary-token'
+                  className='flex items-center gap-1.5 rounded bg-surface-1 px-1.5 py-0.5 text-3xs font-medium text-secondary-token'
                 >
                   <span
                     className='size-1.5 rounded-full'
@@ -203,7 +203,7 @@ export function DemoReleaseDetail({
                 <div className='flex items-center gap-1.5'>
                   <DrawerInlineIconButton
                     className='size-7 rounded-full text-tertiary-token'
-                    aria-label='Attach file'
+                    aria-label='Attach File'
                   >
                     <Paperclip className='size-3.5' />
                   </DrawerInlineIconButton>
@@ -211,7 +211,7 @@ export function DemoReleaseDetail({
                     size='icon'
                     tone='secondary'
                     className='h-7 w-7 rounded-full'
-                    aria-label='Send comment'
+                    aria-label='Send Comment'
                     onClick={() =>
                       runDemoAction({
                         loadingMessage: 'Posting comment',

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3466,
+  "count": 3464,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Tokenizes the demo release detail drawer exact `font-[510]` utilities to `font-medium`.
- Normalizes touched drawer labels to the project title-case lint convention.
- Lowers the arbitrary Tailwind ratchet baseline from `3466` to `3464`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/demo/DemoReleaseDetail.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/demo/DemoReleaseDetail.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied — `arbitrary-values-ratchet.test.ts` covers this drift reduction.