### PR TITLE
fix(design-system): tokenize demo shell drift

### DIFF
--- a/apps/web/components/features/demo/DemoShell.tsx
+++ b/apps/web/components/features/demo/DemoShell.tsx
@@ -113,7 +113,7 @@ export function DemoShell({
                   <SidebarMenuButton
                     size='sm'
                     className='h-7 font-medium'
-                    aria-label='Open workspace selector'
+                    aria-label='Open Workspace Selector'
                   >
                     <div className='flex items-center gap-1.5 w-full'>
                       <BrandLogo size={14} className='rounded-sm' tone='auto' />
@@ -336,7 +336,7 @@ export function DemoShell({
                   {DEMO_ARTIST_NAME}
                 </span>
                 <ChevronRight className='size-3.5 shrink-0 text-quaternary-token' />
-                <span className='truncate font-[510] text-primary-token'>
+                <span className='truncate font-medium text-primary-token'>
                   {TAB_LABEL[activeTab]}
                 </span>
               </div>
@@ -392,11 +392,11 @@ export function DemoShell({
                         />
                       ))}
                       <PageToolbarActionButton
-                        label='Add view'
+                        label='Add View'
                         icon={<Plus className='size-3.5' aria-hidden='true' />}
                         iconOnly
                         tooltipLabel='Add View'
-                        ariaLabel='Add view'
+                        ariaLabel='Add View'
                       />
                     </>
                   ) : null

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3464,
+  "count": 3463,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Tokenizes the demo shell exact `font-[510]` utility to `font-medium`.
- Normalizes touched demo shell labels to the project title-case lint convention.
- Lowers the arbitrary Tailwind ratchet baseline from `3464` to `3463`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/demo/DemoShell.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/demo/DemoShell.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied — `arbitrary-values-ratchet.test.ts` covers this drift reduction.