### PR TITLE
fix(design-system): tokenize ui reference drift

### DIFF
--- a/apps/web/app/ui/dialogs/page.tsx
+++ b/apps/web/app/ui/dialogs/page.tsx
@@ -90,7 +90,7 @@ export default function DialogsPage() {
               </DialogHeader>
               <DialogFooter>
                 <Button variant='ghost'>Cancel</Button>
-                <Button variant='primary'>Got it</Button>
+                <Button variant='primary'>Got It</Button>
               </DialogFooter>
             </DialogContent>
           </Dialog>
@@ -159,7 +159,7 @@ export default function DialogsPage() {
                 <div className='flex flex-col gap-1.5'>
                   <label
                     htmlFor='issue-title'
-                    className='text-[13px] font-[450] text-primary-token'
+                    className='text-[13px] font-book text-primary-token'
                   >
                     Title
                   </label>
@@ -173,7 +173,7 @@ export default function DialogsPage() {
                 <div className='flex flex-col gap-1.5'>
                   <label
                     htmlFor='issue-description'
-                    className='text-[13px] font-[450] text-primary-token'
+                    className='text-[13px] font-book text-primary-token'
                   >
                     Description
                   </label>
@@ -208,7 +208,7 @@ export default function DialogsPage() {
                 <input
                   type='text'
                   defaultValue='My Project'
-                  aria-label='Project name'
+                  aria-label='Project Name'
                   className='h-8 w-full rounded-(--linear-radius-md) border border-subtle bg-surface-1 px-3 text-[13px] text-primary-token outline-none transition-colors focus:border-(--linear-border-focus)'
                 />
               </div>

--- a/apps/web/app/ui/switches/page.tsx
+++ b/apps/web/app/ui/switches/page.tsx
@@ -44,19 +44,19 @@ export default function SwitchesPage() {
       {/* Default states */}
       <Section title='Default States'>
         <Stack title='unchecked'>
-          <Switch aria-label='Toggle unchecked' />
+          <Switch aria-label='Toggle Unchecked' />
         </Stack>
         <Stack title='checked'>
-          <Switch defaultChecked aria-label='Toggle checked' />
+          <Switch defaultChecked aria-label='Toggle Checked' />
         </Stack>
         <Stack title='disabled unchecked'>
-          <Switch disabled aria-label='Toggle disabled unchecked' />
+          <Switch disabled aria-label='Toggle Disabled Unchecked' />
         </Stack>
         <Stack title='disabled checked'>
           <Switch
             disabled
             defaultChecked
-            aria-label='Toggle disabled checked'
+            aria-label='Toggle Disabled Checked'
           />
         </Stack>
       </Section>
@@ -65,10 +65,10 @@ export default function SwitchesPage() {
       <Section title='With Labels'>
         <Stack title='Enable notifications'>
           <div className='flex items-center gap-3'>
-            <Switch id='notifications' aria-label='Enable notifications' />
+            <Switch id='notifications' aria-label='Enable Notifications' />
             <label
               htmlFor='notifications'
-              className='text-[13px] font-[510] text-primary-token'
+              className='text-[13px] font-medium text-primary-token'
             >
               Enable notifications
             </label>
@@ -79,11 +79,11 @@ export default function SwitchesPage() {
             <Switch
               id='auto-assign'
               defaultChecked
-              aria-label='Auto-assign issues'
+              aria-label='Auto Assign Issues'
             />
             <label
               htmlFor='auto-assign'
-              className='text-[13px] font-[510] text-primary-token'
+              className='text-[13px] font-medium text-primary-token'
             >
               Auto-assign issues
             </label>
@@ -94,11 +94,11 @@ export default function SwitchesPage() {
             <Switch
               id='disabled-setting'
               disabled
-              aria-label='Disabled setting'
+              aria-label='Disabled Setting'
             />
             <label
               htmlFor='disabled-setting'
-              className='text-[13px] font-[510] text-primary-token opacity-50'
+              className='text-[13px] font-medium text-primary-token opacity-50'
             >
               Disabled setting
             </label>
@@ -111,9 +111,9 @@ export default function SwitchesPage() {
         <Stack title='settings row'>
           <div className='flex w-64 flex-col divide-y rounded-lg border border-subtle'>
             {[
-              { label: 'Slack notifications', checked: true },
-              { label: 'Email digest', checked: false },
-              { label: 'Desktop alerts', checked: true },
+              { label: 'Slack Notifications', checked: true },
+              { label: 'Email Digest', checked: false },
+              { label: 'Desktop Alerts', checked: true },
             ].map(item => (
               <div
                 key={item.label}
@@ -121,7 +121,7 @@ export default function SwitchesPage() {
               >
                 <label
                   htmlFor={`setting-${item.label}`}
-                  className='text-[13px] font-[450] text-primary-token'
+                  className='text-[13px] font-book text-primary-token'
                 >
                   {item.label}
                 </label>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3462,
+  "count": 3456,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Tokenizes exact UI reference font-weight utilities: `font-[510]` to `font-medium`, `font-[450]` to `font-book`.
- Normalizes touched UI reference labels to the project title-case lint convention.
- Lowers the arbitrary Tailwind ratchet baseline from `3462` to `3456`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/ui/switches/page.tsx apps/web/app/ui/dialogs/page.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/app/ui/switches/page.tsx apps/web/app/ui/dialogs/page.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied — `arbitrary-values-ratchet.test.ts` covers this drift reduction.