### PR TITLE
fix(web): harden native auth release redirects

### DIFF
--- a/apps/web/app/(auth)/auth/native-complete/page.tsx
+++ b/apps/web/app/(auth)/auth/native-complete/page.tsx
@@ -3,6 +3,7 @@
 import { useClerk, useSignIn } from '@clerk/nextjs';
 import { useRouter } from 'next/navigation';
 import { Suspense, useEffect, useRef, useState } from 'react';
+import { APP_ROUTES } from '@/constants/routes';
 import { consumeDesktopAuthCompletion } from '@/lib/desktop/electron-bridge';
 import {
   completeDesktopNativeAuth,
@@ -19,6 +20,7 @@ type ClerkBrowserGlobal = {
 let completionKey: string | null = null;
 let completionPromise: ReturnType<typeof completeDesktopNativeAuth> | null =
   null;
+const DESKTOP_DEFAULT_RETURN_ROUTE = `${APP_ROUTES.RELEASES}?runtime=electron`;
 
 function getCompletionPromise(
   key: string,
@@ -49,7 +51,7 @@ function getStoredDesktopAuthReturnTo(): string {
     // Missing storage should fall back to the app shell.
   }
 
-  return '/app/chat?runtime=electron';
+  return DESKTOP_DEFAULT_RETURN_ROUTE;
 }
 
 function isRecoverableCompletionReplayError(error: unknown): boolean {
@@ -148,14 +150,14 @@ function NativeCompleteContent() {
   }, [clerk, router, signIn]);
 
   return (
-    <main className='grid min-h-dvh place-items-center bg-[#06070a] px-6 text-white [color-scheme:dark]'>
+    <main className='grid min-h-dvh place-items-center bg-base px-6 text-primary-token [color-scheme:dark]'>
       <section className='w-full max-w-sm px-6 py-7 text-center'>
         <h1 className='text-[22px] font-semibold leading-7'>
           {state === 'error'
             ? 'Sign-in did not complete'
             : 'Completing sign-in'}
         </h1>
-        <p className='mt-3 text-[14px] leading-5 text-white/64'>
+        <p className='mt-3 text-[14px] leading-5 text-secondary-token'>
           {state === 'error'
             ? 'Close this window and start sign-in again from Jovie.'
             : 'Jovie will open your workspace in a moment.'}

--- a/apps/web/app/auth/callback/route.test.ts
+++ b/apps/web/app/auth/callback/route.test.ts
@@ -37,7 +37,7 @@ describe('GET /auth/callback', () => {
     hoisted.consumeStoredAuthState.mockResolvedValue({
       client: 'electron',
       intent: 'sign_in',
-      returnTo: '/app/chat?runtime=electron',
+      returnTo: '/app/releases?runtime=electron',
       state: 'state_123',
       codeChallenge: 'challenge_123',
       createdAt: 1_000,
@@ -49,7 +49,7 @@ describe('GET /auth/callback', () => {
       client: 'electron',
       state: 'state_123',
       userId: 'user_123',
-      returnTo: '/app/chat?runtime=electron',
+      returnTo: '/app/releases?runtime=electron',
       codeChallenge: 'challenge_123',
       createdAt: 2_000,
       expiresAt: 62_000,
@@ -75,7 +75,7 @@ describe('GET /auth/callback', () => {
       client: 'electron',
       state: 'state_123',
       userId: 'user_123',
-      returnTo: '/app/chat?runtime=electron',
+      returnTo: '/app/releases?runtime=electron',
       codeChallenge: 'challenge_123',
     });
     expect(

--- a/apps/web/app/auth/start/route.test.ts
+++ b/apps/web/app/auth/start/route.test.ts
@@ -58,7 +58,7 @@ describe('GET /auth/start', () => {
     hoisted.createStoredAuthState.mockResolvedValue({
       client: 'electron',
       intent: 'sign_in',
-      returnTo: '/app/chat?runtime=electron',
+      returnTo: '/app/releases?runtime=electron',
       state: 'state_123',
       codeChallenge: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ',
       createdAt: 1_000,
@@ -70,7 +70,7 @@ describe('GET /auth/start', () => {
   it('redirects signed-in native auth starts to the same-origin callback', async () => {
     const response = await GET(
       new Request(
-        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Fchat%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
+        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Freleases%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
       )
     );
 
@@ -82,9 +82,46 @@ describe('GET /auth/start', () => {
       expect.objectContaining({
         client: 'electron',
         intent: 'sign_in',
-        returnTo: '/app/chat?runtime=electron',
+        returnTo: '/app/releases?runtime=electron',
         state: '00000000000040008000000000000123',
       })
+    );
+  });
+
+  it('falls back to browser sign-in when Clerk context is unavailable in local native auth', async () => {
+    hoisted.auth.mockRejectedValueOnce(new Error('missing middleware context'));
+
+    const response = await GET(
+      new Request(
+        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Freleases%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
+      )
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3112/signin?auth_state=state_123'
+    );
+    expect(hoisted.createStoredAuthState).toHaveBeenCalled();
+  });
+
+  it('preserves the forwarded local app origin in native auth redirects', async () => {
+    hoisted.auth.mockRejectedValueOnce(new Error('missing middleware context'));
+
+    const response = await GET(
+      new Request(
+        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Freleases%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256',
+        {
+          headers: {
+            host: '127.0.0.1:3112',
+            'x-forwarded-proto': 'http',
+          },
+        }
+      )
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://127.0.0.1:3112/signin?auth_state=state_123'
     );
   });
 
@@ -103,7 +140,7 @@ describe('GET /auth/start', () => {
 
     const response = await GET(
       new Request(
-        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Fchat%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
+        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Freleases%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
       )
     );
 
@@ -124,7 +161,7 @@ describe('GET /auth/start', () => {
 
     const response = await GET(
       new Request(
-        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Fchat%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
+        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Freleases%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
       )
     );
 
@@ -145,7 +182,7 @@ describe('GET /auth/start', () => {
 
     const response = await GET(
       new Request(
-        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Fchat%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
+        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Freleases%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
       )
     );
 

--- a/apps/web/app/auth/start/route.ts
+++ b/apps/web/app/auth/start/route.ts
@@ -62,6 +62,32 @@ function getStringParam(url: URL, key: string): string | null {
   return trimmed || null;
 }
 
+function getRedirectOrigin(request: Request): string {
+  const requestUrl = new URL(request.url);
+  const host =
+    request.headers.get('x-forwarded-host')?.split(',')[0]?.trim() ||
+    request.headers.get('host')?.trim();
+  if (!host) return requestUrl.origin;
+
+  const protocol =
+    request.headers
+      .get('x-forwarded-proto')
+      ?.split(',')[0]
+      ?.trim()
+      ?.replace(/:$/, '') || requestUrl.protocol.replace(/:$/, '');
+
+  return `${protocol}://${host}`;
+}
+
+async function getOptionalAuthUserId(): Promise<string | null> {
+  try {
+    const { userId } = await auth();
+    return userId ?? null;
+  } catch {
+    return null;
+  }
+}
+
 async function trackAuthEvent(
   event: Parameters<typeof createAuthAnalyticsEvent>[0],
   input: {
@@ -156,6 +182,7 @@ export async function GET(request: Request) {
 
   try {
     const state = createState();
+    const redirectOrigin = getRedirectOrigin(request);
     const record = await createStoredAuthState({
       client: rawClient,
       intent: rawIntent,
@@ -172,15 +199,15 @@ export async function GET(request: Request) {
       returnTo,
     });
 
-    const { userId } = await auth();
+    const userId = await getOptionalAuthUserId();
     if (userId) {
       return NextResponse.redirect(
-        new URL(buildAuthCallbackPath(record.state), request.url),
+        new URL(buildAuthCallbackPath(record.state), redirectOrigin),
         { headers: NO_STORE_HEADERS }
       );
     }
 
-    const authPage = new URL(getAuthPageForIntent(rawIntent), request.url);
+    const authPage = new URL(getAuthPageForIntent(rawIntent), redirectOrigin);
     authPage.searchParams.set('auth_state', record.state);
     void trackAuthEvent('auth_provider_opened', {
       client: rawClient,

--- a/apps/web/lib/auth/clerk-middleware-bypass.ts
+++ b/apps/web/lib/auth/clerk-middleware-bypass.ts
@@ -26,6 +26,8 @@ const CLERK_REQUIRED_PREFIXES = [
   '/monitoring/',
 ] as const;
 
+const AUTH_ROUTE_BYPASS_EXACT_PATHS = [APP_ROUTES.AUTH_START] as const;
+
 const AUTHENTICATED_API_PREFIXES = [
   '/api/account',
   '/api/admin',
@@ -117,6 +119,18 @@ export function shouldBypassClerkForRequest(options: {
   }
 
   const allowAuthRouteBypass = options.allowAuthRouteBypass === true;
+  const cookies = Array.from(options.cookies);
+  const hasActiveSessionCookie = cookies.some(hasActiveClerkCookie);
+
+  if (
+    allowAuthRouteBypass &&
+    !hasActiveSessionCookie &&
+    AUTH_ROUTE_BYPASS_EXACT_PATHS.includes(
+      options.pathname as (typeof AUTH_ROUTE_BYPASS_EXACT_PATHS)[number]
+    )
+  ) {
+    return true;
+  }
 
   // Public API routes must be able to answer as signed-out requests without
   // entering Clerk's handshake/rewrite flow. Route handlers own auth for
@@ -133,10 +147,8 @@ export function shouldBypassClerkForRequest(options: {
     return false;
   }
 
-  for (const cookie of options.cookies) {
-    if (hasActiveClerkCookie(cookie)) {
-      return false;
-    }
+  if (hasActiveSessionCookie) {
+    return false;
   }
 
   return true;

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -48,7 +48,10 @@ import {
   isDedicatedRootSegment,
   isProxyRewriteExempt,
 } from '@/lib/routing/proxy-routing';
-import { SCRIPT_NONCE_HEADER } from '@/lib/security/content-security-policy';
+import {
+  buildContentSecurityPolicy,
+  SCRIPT_NONCE_HEADER,
+} from '@/lib/security/content-security-policy';
 import {
   isExplicitDevelopmentEnvironment,
   isLocalDevelopmentAutomationHostname,
@@ -135,6 +138,21 @@ function redirectSignedOutElectronAppShell(req: NextRequest): NextResponse {
   );
   const response = NextResponse.redirect(targetUrl);
   response.headers.set('Location', targetUrl.toString());
+  return withElectronRedirectCsp(response);
+}
+
+function withElectronRedirectCsp(response: NextResponse): NextResponse {
+  const nonce = generateNonce();
+  const allowTestRuntimeRelaxations =
+    process.env.E2E_ALLOW_DEV_CSP === '1' ||
+    process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
+
+  response.headers.set(SCRIPT_NONCE_HEADER, nonce);
+  response.headers.set(
+    'Content-Security-Policy',
+    buildContentSecurityPolicy({ nonce, allowTestRuntimeRelaxations })
+  );
+
   return response;
 }
 

--- a/apps/web/scripts/grant-desktop-smoke-access.ts
+++ b/apps/web/scripts/grant-desktop-smoke-access.ts
@@ -1,0 +1,276 @@
+import { neon } from '@neondatabase/serverless';
+import { Redis } from '@upstash/redis';
+import { and, eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/neon-http';
+import { users } from '../lib/db/schema/auth';
+import { discogReleases } from '../lib/db/schema/content';
+import { creatorProfiles, userProfileClaims } from '../lib/db/schema/profiles';
+import { waitlistEntries } from '../lib/db/schema/waitlist';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+if (!DATABASE_URL) {
+  throw new Error('DATABASE_URL is not configured');
+}
+
+const sql = neon(DATABASE_URL);
+const db = drizzle(sql);
+const SMOKE_PROFILE_USERNAME = 'native-auth-smoke-localhost';
+const SMOKE_PROFILE_DISPLAY_NAME = 'Native Auth Smoke';
+const SMOKE_RELEASE_SLUG = 'native-auth-smoke-release';
+const SMOKE_RELEASE_TITLE = 'Native Auth Smoke Release';
+
+function getRequiredArg(name: string): string {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1]?.trim() : '';
+  if (!value) {
+    throw new Error(`Missing required argument: ${name}`);
+  }
+  return value;
+}
+
+function getOptionalArg(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1]?.trim() : '';
+  return value || null;
+}
+
+async function invalidateProxyUserState(clerkUserId: string): Promise<boolean> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return false;
+
+  const redis = new Redis({ url, token });
+  await Promise.all([
+    redis.del(`proxy:user-state:${clerkUserId}`),
+    redis.del(`proxy:user-state:stale:${clerkUserId}`),
+  ]);
+  return true;
+}
+
+async function ensureSmokeProfile(userId: string): Promise<string> {
+  const now = new Date();
+  const values = {
+    userId,
+    creatorType: 'artist' as const,
+    username: SMOKE_PROFILE_USERNAME,
+    usernameNormalized: SMOKE_PROFILE_USERNAME,
+    displayName: SMOKE_PROFILE_DISPLAY_NAME,
+    isPublic: true,
+    isClaimed: true,
+    claimedAt: now,
+    onboardingCompletedAt: now,
+    updatedAt: now,
+  };
+
+  const [existingProfile] = await db
+    .select({ id: creatorProfiles.id })
+    .from(creatorProfiles)
+    .where(eq(creatorProfiles.usernameNormalized, SMOKE_PROFILE_USERNAME))
+    .limit(1);
+
+  if (existingProfile) {
+    await db
+      .update(creatorProfiles)
+      .set(values)
+      .where(eq(creatorProfiles.id, existingProfile.id));
+    return existingProfile.id;
+  }
+
+  const [createdProfile] = await db
+    .insert(creatorProfiles)
+    .values(values)
+    .returning({ id: creatorProfiles.id });
+
+  if (!createdProfile?.id) {
+    throw new Error('Failed to create desktop smoke profile');
+  }
+
+  return createdProfile.id;
+}
+
+async function ensureSmokeProfileClaim(
+  userId: string,
+  creatorProfileId: string
+): Promise<void> {
+  const now = new Date();
+  const [existingClaim] = await db
+    .select({ id: userProfileClaims.id })
+    .from(userProfileClaims)
+    .where(
+      and(
+        eq(userProfileClaims.creatorProfileId, creatorProfileId),
+        eq(userProfileClaims.role, 'owner')
+      )
+    )
+    .limit(1);
+
+  if (existingClaim) {
+    await db
+      .update(userProfileClaims)
+      .set({ userId, claimedAt: now })
+      .where(eq(userProfileClaims.id, existingClaim.id));
+    return;
+  }
+
+  await db.insert(userProfileClaims).values({
+    userId,
+    creatorProfileId,
+    role: 'owner',
+    claimedAt: now,
+  });
+}
+
+async function ensureSmokeRelease(creatorProfileId: string): Promise<string> {
+  const now = new Date();
+  const releaseDate = new Date('2026-06-01T00:00:00.000Z');
+  const [release] = await db
+    .insert(discogReleases)
+    .values({
+      creatorProfileId,
+      title: SMOKE_RELEASE_TITLE,
+      slug: SMOKE_RELEASE_SLUG,
+      releaseType: 'single',
+      releaseDate,
+      status: 'released',
+      totalTracks: 1,
+      label: 'Jovie Smoke',
+      distributor: 'Jovie',
+      sourceType: 'manual',
+      metadata: {
+        desktopSmoke: true,
+      },
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [discogReleases.creatorProfileId, discogReleases.slug],
+      set: {
+        title: SMOKE_RELEASE_TITLE,
+        releaseType: 'single',
+        releaseDate,
+        status: 'released',
+        deletedAt: null,
+        totalTracks: 1,
+        label: 'Jovie Smoke',
+        distributor: 'Jovie',
+        sourceType: 'manual',
+        metadata: {
+          desktopSmoke: true,
+        },
+        updatedAt: now,
+      },
+    })
+    .returning({ id: discogReleases.id });
+
+  if (!release?.id) {
+    throw new Error('Failed to create desktop smoke release');
+  }
+
+  return release.id;
+}
+
+async function main() {
+  const clerkUserId = getRequiredArg('--clerk-user-id');
+  const email = getRequiredArg('--email');
+  const entryId = getOptionalArg('--entry-id');
+  const now = new Date();
+
+  if (entryId) {
+    const [entry] = await db
+      .select({ id: waitlistEntries.id })
+      .from(waitlistEntries)
+      .where(eq(waitlistEntries.id, entryId))
+      .limit(1);
+
+    if (!entry) {
+      throw new Error(`Waitlist entry not found: ${entryId}`);
+    }
+
+    await db
+      .update(waitlistEntries)
+      .set({
+        status: 'approved',
+        statusReason: 'desktop_smoke_local',
+        approvedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(waitlistEntries.id, entryId));
+  }
+
+  const userUpdate = {
+    userStatus: 'waitlist_approved' as const,
+    ...(entryId ? { waitlistEntryId: entryId } : {}),
+    updatedAt: now,
+  };
+
+  let updatedUsers = await db
+    .update(users)
+    .set(userUpdate)
+    .where(eq(users.clerkId, clerkUserId))
+    .returning({ id: users.id });
+
+  if (updatedUsers.length === 0) {
+    updatedUsers = await db
+      .update(users)
+      .set({
+        ...userUpdate,
+        clerkId: clerkUserId,
+      })
+      .where(eq(users.email, email))
+      .returning({ id: users.id });
+  }
+
+  if (updatedUsers.length === 0) {
+    updatedUsers = await db
+      .insert(users)
+      .values({
+        clerkId: clerkUserId,
+        email,
+        userStatus: 'waitlist_approved',
+        ...(entryId ? { waitlistEntryId: entryId } : {}),
+      })
+      .returning({ id: users.id });
+  }
+
+  if (updatedUsers.length === 0) {
+    throw new Error(`User not found or created for Clerk id: ${clerkUserId}`);
+  }
+
+  const userId = updatedUsers[0]?.id;
+  if (!userId) {
+    throw new Error(`User id missing for Clerk id: ${clerkUserId}`);
+  }
+
+  const profileId = await ensureSmokeProfile(userId);
+  await ensureSmokeProfileClaim(userId, profileId);
+  const releaseId = await ensureSmokeRelease(profileId);
+
+  await db
+    .update(users)
+    .set({
+      userStatus: 'active',
+      activeProfileId: profileId,
+      updatedAt: now,
+    })
+    .where(eq(users.id, userId));
+
+  const redisInvalidated = await invalidateProxyUserState(clerkUserId);
+
+  console.log(
+    JSON.stringify({
+      ok: true,
+      clerkUserId,
+      email,
+      entryId,
+      userId,
+      profileId,
+      releaseId,
+      redisInvalidated,
+    })
+  );
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.stack : String(error));
+  process.exit(1);
+});

--- a/apps/web/tests/unit/app/native-complete-page.test.tsx
+++ b/apps/web/tests/unit/app/native-complete-page.test.tsx
@@ -79,11 +79,31 @@ describe('NativeCompletePage', () => {
       expect(completeDesktopNativeAuthMock).toHaveBeenCalledTimes(1);
     });
 
-    resolveCompletion({ returnTo: '/app/chat?runtime=electron' });
+    resolveCompletion({ returnTo: '/app/releases?runtime=electron' });
 
     await waitFor(() => {
       expect(routerReplaceMock).toHaveBeenCalledWith(
-        '/app/chat?runtime=electron'
+        '/app/releases?runtime=electron'
+      );
+    });
+  });
+
+  it('falls back to the desktop releases route when replay recovery has no stored return route', async () => {
+    clerkSession = { id: 'sess_123' };
+    clerkUser = { id: 'user_123' };
+    completeDesktopNativeAuthMock.mockRejectedValue(
+      new Error('missing-auth-completion')
+    );
+
+    const { default: NativeCompletePage } = await import(
+      '../../../app/(auth)/auth/native-complete/page'
+    );
+
+    render(<NativeCompletePage />);
+
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith(
+        '/app/releases?runtime=electron'
       );
     });
   });

--- a/apps/web/tests/unit/desktop/native-complete.test.ts
+++ b/apps/web/tests/unit/desktop/native-complete.test.ts
@@ -16,7 +16,7 @@ describe('completeDesktopNativeAuth', () => {
       ok: true,
       json: async () => ({
         ticket: 'ticket_123',
-        returnTo: '/app/chat',
+        returnTo: '/app/releases',
       }),
     }));
     const signIn = {
@@ -35,7 +35,7 @@ describe('completeDesktopNativeAuth', () => {
         signIn,
         setActive,
       })
-    ).resolves.toEqual({ returnTo: '/app/chat' });
+    ).resolves.toEqual({ returnTo: '/app/releases' });
 
     expect(consumeCompletion).toHaveBeenCalledTimes(1);
     expect(fetchNativeExchange).toHaveBeenCalledWith(
@@ -57,7 +57,7 @@ describe('completeDesktopNativeAuth', () => {
     });
     expect(setActive).toHaveBeenCalledWith({
       session: 'sess_123',
-      redirectUrl: '/app/chat',
+      redirectUrl: '/app/releases',
     });
   });
 
@@ -149,7 +149,7 @@ describe('completeDesktopNativeAuth', () => {
       ok: true,
       json: async () => ({
         ticket: 'ticket_123',
-        returnTo: '/app/chat',
+        returnTo: '/app/releases',
         userId: 'user_123',
       }),
     }));
@@ -171,7 +171,7 @@ describe('completeDesktopNativeAuth', () => {
         getActiveSessionId: () => 'sess_123',
         getActiveUserId: () => 'user_123',
       })
-    ).resolves.toEqual({ returnTo: '/app/chat' });
+    ).resolves.toEqual({ returnTo: '/app/releases' });
 
     expect(reloadClerk).toHaveBeenCalledTimes(1);
     expect(setActive).not.toHaveBeenCalled();
@@ -192,7 +192,7 @@ describe('completeDesktopNativeAuth', () => {
         ok: true,
         json: async () => ({
           ticket: 'ticket_123',
-          returnTo: '/app/chat',
+          returnTo: '/app/releases',
           userId: 'user_123',
         }),
       }));
@@ -223,14 +223,14 @@ describe('completeDesktopNativeAuth', () => {
       });
 
       await vi.advanceTimersByTimeAsync(1);
-      await expect(result).resolves.toEqual({ returnTo: '/app/chat' });
+      await expect(result).resolves.toEqual({ returnTo: '/app/releases' });
 
       expect(setActive).toHaveBeenCalledWith({
         session: 'sess_123',
-        redirectUrl: '/app/chat',
+        redirectUrl: '/app/releases',
       });
       expect(reloadClerk).toHaveBeenCalledTimes(1);
-      expect(verifyReturnRoute).toHaveBeenCalledWith('/app/chat');
+      expect(verifyReturnRoute).toHaveBeenCalledWith('/app/releases');
     } finally {
       vi.useRealTimers();
     }
@@ -251,7 +251,7 @@ describe('completeDesktopNativeAuth', () => {
         ok: true,
         json: async () => ({
           ticket: 'ticket_123',
-          returnTo: '/app/chat',
+          returnTo: '/app/releases',
           userId: 'user_123',
         }),
       }));
@@ -282,7 +282,7 @@ describe('completeDesktopNativeAuth', () => {
       );
       await vi.advanceTimersByTimeAsync(501);
       await expectation;
-      expect(verifyReturnRoute).toHaveBeenCalledWith('/app/chat');
+      expect(verifyReturnRoute).toHaveBeenCalledWith('/app/releases');
     } finally {
       vi.useRealTimers();
     }
@@ -301,7 +301,7 @@ describe('completeDesktopNativeAuth', () => {
       ok: true,
       json: async () => ({
         ticket: 'ticket_123',
-        returnTo: '/app/chat',
+        returnTo: '/app/releases',
         userId: 'user_123',
       }),
     }));

--- a/apps/web/tests/unit/lib/auth/clerk-middleware-bypass.test.ts
+++ b/apps/web/tests/unit/lib/auth/clerk-middleware-bypass.test.ts
@@ -156,6 +156,28 @@ describe('shouldBypassClerkForRequest', () => {
     ).toBe(false);
   });
 
+  it('bypasses native auth start in mock lanes even when dev-browser cookies are missing', () => {
+    expect(
+      shouldBypassClerkForRequest({
+        allowAuthRouteBypass: true,
+        cookies: [],
+        pathInfo: PUBLIC_PATH_INFO,
+        pathname: '/auth/start',
+      })
+    ).toBe(true);
+  });
+
+  it('keeps Clerk enabled for native auth start in mock lanes when a session exists', () => {
+    expect(
+      shouldBypassClerkForRequest({
+        allowAuthRouteBypass: true,
+        cookies: [{ name: '__session', value: 'sess_123' }],
+        pathInfo: PUBLIC_PATH_INFO,
+        pathname: '/auth/start',
+      })
+    ).toBe(false);
+  });
+
   it('bypasses auth routes in mock lanes without an active Clerk session', () => {
     expect(
       shouldBypassClerkForRequest({

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -502,6 +502,10 @@ describe('proxy.ts middleware', () => {
       expect(res.headers.get('location')).toBe(
         'https://localhost:3112/signin?redirect_url=%2Fapp%2Fchat%3Fruntime%3Delectron'
       );
+      expect(res.headers.get('Content-Security-Policy')).toBe(
+        "default-src 'self'"
+      );
+      expect(res.headers.get('x-nonce')).toBeTruthy();
       expect(mocks.clerkMiddleware).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- Sends native auth completion back to the Electron releases route by default.
- Keeps `/auth/start` usable when local Electron auth lacks Clerk middleware context, while preserving active-session Clerk handling.
- Adds CSP headers to signed-out Electron app-shell redirects.
- Adds a deterministic smoke-access provisioning script that seeds an approved smoke user, claimed profile, and visible release for local/staging validation.

## Bug-to-Test
bug-to-test: satisfied

## Test Coverage
Native auth start/callback, Clerk bypass, proxy redirect CSP, and native completion route behavior have focused regression coverage.

## Pre-Landing Review
No new pre-landing findings in this slice.

## Design Review
Frontend changes are limited to tokenized native auth completion copy and layout-preserving text states.

## Eval Results
No prompt-related files changed, evals skipped.

## Plan Completion
No plan file detected.

## Linear follow-ups
Linear follow-ups: none.

## Test plan
- [x] `pnpm --filter @jovie/web exec vitest run app/auth/start/route.test.ts app/auth/callback/route.test.ts tests/unit/app/native-complete-page.test.tsx tests/unit/desktop/native-complete.test.ts tests/unit/lib/auth/clerk-middleware-bypass.test.ts tests/unit/middleware/proxy-behavioral.test.ts` (113 tests)
- [x] `pnpm biome check --write 'apps/web/app/(auth)/auth/native-complete/page.tsx' apps/web/app/auth/start/route.ts apps/web/app/auth/start/route.test.ts apps/web/app/auth/callback/route.test.ts apps/web/lib/auth/clerk-middleware-bypass.ts apps/web/proxy.ts apps/web/scripts/grant-desktop-smoke-access.ts apps/web/tests/unit/app/native-complete-page.test.tsx apps/web/tests/unit/desktop/native-complete.test.ts apps/web/tests/unit/lib/auth/clerk-middleware-bypass.test.ts apps/web/tests/unit/middleware/proxy-behavioral.test.ts`
- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

Stack branch based on `codex/electron-auth-web`.
