### PR TITLE
fix(desktop): open releases shell quietly

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -25,7 +25,7 @@ on:
     branches: [main]
     paths:
       - "VERSION"
-      - ".github/workflows/desktop-release.yml"  # explicit handling for desktop auth allowlist fixes (e.g. 9870/9812 Clerk wildcard)
+      - ".github/workflows/desktop-release.yml"  # explicit handling for desktop auth/release-route fixes (e.g. 9870/9812 Clerk wildcard)
   workflow_dispatch:
     inputs:
       environment:

--- a/apps/desktop/electron-builder.staging.yml
+++ b/apps/desktop/electron-builder.staging.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Auth
+        CFBundleURLSchemes:
+          - jovie
   notarize: true
   target:
     - target: dmg

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -9,10 +9,14 @@ import { promisify } from 'node:util';
 const desktopRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const execFileAsync = promisify(execFile);
 
-test('desktop window enters the authenticated chat shell instead of the web root', async () => {
+test('desktop window enters the authenticated releases shell instead of the web root', async () => {
   const mainSource = await readFile(join(desktopRoot, 'src/main.ts'), 'utf8');
 
   assert.match(
+    mainSource,
+    /const APP_ENTRY_URL = buildAppUrl\('\/app\/library\?view=releases'\);/
+  );
+  assert.doesNotMatch(
     mainSource,
     /const APP_ENTRY_URL = buildAppUrl\('\/app\/chat'\);/
   );
@@ -36,10 +40,12 @@ test('desktop window enters the authenticated chat shell instead of the web root
   );
   assert.match(
     mainSource,
-    /app\.setName\(APP_ENV === 'staging' \? 'Jovie Staging' : 'Jovie'\);/
+    /const DESKTOP_APP_NAME = APP_ENV === 'staging' \? 'Jovie Staging' : 'Jovie';/
   );
+  assert.match(mainSource, /app\.setName\(DESKTOP_APP_NAME\);/);
   assert.match(mainSource, /APP_ENV === 'local'/);
-  assert.match(mainSource, /Jovie-Local/);
+  assert.match(mainSource, /Jovie Local/);
+  assert.match(mainSource, /Jovie Staging/);
   assert.match(mainSource, /win\.webContents\.setUserAgent\(/);
   assert.match(
     mainSource,
@@ -155,15 +161,17 @@ test('desktop macOS entitlements keep only allow-jit (no sandbox-weakening flags
   }
 });
 
-test('desktop production bundle declares the jovie auth protocol', async () => {
-  const builderConfig = await readFile(
-    join(desktopRoot, 'electron-builder.yml'),
-    'utf8'
-  );
+test('desktop mac bundles declare the jovie auth protocol', async () => {
+  for (const configPath of [
+    'electron-builder.yml',
+    'electron-builder.staging.yml',
+  ]) {
+    const builderConfig = await readFile(join(desktopRoot, configPath), 'utf8');
 
-  assert.match(builderConfig, /CFBundleURLTypes:/);
-  assert.match(builderConfig, /CFBundleURLName: Jovie Auth/);
-  assert.match(builderConfig, /CFBundleURLSchemes:\s*\n\s*- jovie/);
+    assert.match(builderConfig, /CFBundleURLTypes:/);
+    assert.match(builderConfig, /CFBundleURLName: Jovie Auth/);
+    assert.match(builderConfig, /CFBundleURLSchemes:\s*\n\s*- jovie/);
+  }
 });
 
 test('desktop navigation uses explicit URL disposition allowlists', async () => {
@@ -264,6 +272,14 @@ test('desktop bridge exposes bounded dictation support', async () => {
     join(desktopRoot, 'src/preload.ts'),
     'utf8'
   );
+  const cspWatchdogSource = await readFile(
+    join(desktopRoot, 'src/desktop-csp-watchdog.ts'),
+    'utf8'
+  );
+  const securityReporterSource = await readFile(
+    join(desktopRoot, 'src/desktop-security-reporting.ts'),
+    'utf8'
+  );
 
   assert.match(
     mainSource,
@@ -277,13 +293,32 @@ test('desktop bridge exposes bounded dictation support', async () => {
   assert.match(mainSource, /shouldGrantTrustedAudioPermissionCheck/);
   assert.match(mainSource, /backgroundThrottling: false/);
   assert.match(mainSource, /installDesktopCspWatchdog/);
+  assert.match(mainSource, /autoUpdater\.logger = null/);
   assert.match(mainSource, /autoUpdater\.allowDowngrade = false/);
-  assert.match(mainSource, /process\.platform === 'linux'/);
+  assert.match(mainSource, /function canNavigateBack\(webContents/);
+  assert.match(mainSource, /webContents\.navigationHistory\?\.canGoBack\(\)/);
+  assert.match(mainSource, /canNavigateBack\(win\.webContents\)/);
+  assert.match(mainSource, /function canCheckForDesktopUpdates\(\)/);
+  assert.match(mainSource, /process\.platform !== 'linux' && app\.isPackaged/);
+  assert.match(mainSource, /if \(!canCheckForDesktopUpdates\(\)\)/);
   assert.match(mainSource, /sanitizeWindowState/);
   assert.match(mainSource, /bindPendingDesktopAuthCompletion/);
   assert.match(mainSource, /DESKTOP_AUTH_FLOW_PARAM/);
   assert.match(mainSource, /!app\.isPackaged/);
   assert.match(mainSource, /reportDesktopSecurityEvent/);
+  assert.match(mainSource, /const reportDesktopCspEvent =/);
+  assert.match(mainSource, /APP_ENV === 'local' \? \(\) => undefined/);
+  assert.match(mainSource, /report: reportDesktopCspEvent/);
+  assert.doesNotMatch(
+    cspWatchdogSource,
+    /input\.report\('csp-header-missing'/
+  );
+  assert.match(cspWatchdogSource, /input\.report\('csp-header-weakened'/);
+  assert.match(
+    securityReporterSource,
+    /process\.env\.JOVIE_DESKTOP_SECURITY_CONSOLE !== '1'/
+  );
+  assert.match(securityReporterSource, /console\.error/);
   assert.match(preloadSource, /getDictationStatus/);
   assert.match(
     preloadSource,
@@ -378,7 +413,63 @@ test('native auth smoke keeps browser callbacks on the browser auth origin', asy
   );
 
   assert.match(smokeSource, /const callbackOrigin = parsed\.origin;/);
-  assert.match(smokeSource, /const BASE_URL = process\.env\.BASE_URL \?\? 'http:\/\/localhost:3112';/);
+  assert.match(
+    smokeSource,
+    /const BASE_URL = process\.env\.BASE_URL \?\? 'http:\/\/localhost:3112';/
+  );
+  assert.match(
+    smokeSource,
+    /const ELECTRON_APP_ROUTE = '\/app\/library\?view=releases&runtime=electron';/
+  );
+  assert.match(
+    smokeSource,
+    /const SMOKE_RELEASE_TITLE = 'Native Auth Smoke Release';/
+  );
+  assert.match(
+    smokeSource,
+    /function shouldOpenNativeCallbackViaSecondInstance/
+  );
+  assert.match(smokeSource, /function authUrlTargetsExpectedElectronRoute/);
+  assert.match(smokeSource, /function isExpectedDesktopAuthHandoffTarget/);
+  assert.match(
+    smokeSource,
+    /page\.context\(\)\.request\.get\(targetUrl,\s*\{\s*maxRedirects: 0,/
+  );
+  assert.doesNotMatch(smokeSource, /page\.goto\(targetUrl/);
+  assert.match(smokeSource, /function isExpectedElectronAppRoute/);
+  assert.match(
+    smokeSource,
+    /url\.pathname === '\/app\/library' &&\s*url\.searchParams\.get\('view'\) === 'releases' &&\s*url\.searchParams\.get\('runtime'\) === 'electron'/
+  );
+  assert.match(smokeSource, /state\.apiOk && state\.isExpectedRoute/);
+  assert.match(smokeSource, /const electronRendererIssues = \[\];/);
+  assert.match(smokeSource, /Runtime\.consoleAPICalled/);
+  assert.match(smokeSource, /Runtime\.exceptionThrown/);
+  assert.match(smokeSource, /Log\.entryAdded/);
+  assert.match(smokeSource, /function assertNoElectronRendererIssues/);
+  assert.match(smokeSource, /function isLocalDevelopmentRendererWarning/);
+  assert.match(smokeSource, /Clerk has been loaded with development keys/);
+  assert.match(
+    smokeSource,
+    /Electron Security Warning \(Insecure Content-Security-Policy\)/
+  );
+  assert.match(smokeSource, /unexpected Electron renderer console\/log issue/);
+  assert.match(smokeSource, /function assertCleanElectronReleasesSurface/);
+  assert.match(smokeSource, /function captureElectronReloadSurfaceEvidence/);
+  assert.match(smokeSource, /bodyText\.includes\(releaseTitle\)/);
+  assert.match(smokeSource, /!shell\.hasEmptyLibraryState/);
+  assert.match(smokeSource, /function shouldUseLocalDevAccessSetup/);
+  assert.match(smokeSource, /process\.env\.SMOKE_GRANT_APP_ACCESS === '1'/);
+  assert.match(smokeSource, /async function ensureLocalDevAccess/);
+  assert.match(smokeSource, /scripts\/grant-desktop-smoke-access\.ts/);
+  assert.match(smokeSource, /'--email',\s*getStableSmokeEmail\(\)/);
+  assert.doesNotMatch(smokeSource, /fetch\('\/api\/waitlist'/);
+  assert.doesNotMatch(smokeSource, /fetch\('\/api\/dev\/unwaitlist'/);
+  assert.match(
+    smokeSource,
+    /execFileSync\(\s*'pnpm',\s*\[\s*'--dir',\s*DESKTOP_ROOT,\s*'exec',\s*'electron',\s*'\.',\s*callbackUrl\s*\],\s*\{/
+  );
+  assert.doesNotMatch(smokeSource, /\/app\/chat\?runtime=electron/);
   assert.match(smokeSource, /async function waitForDesktopAuthHandoff/);
   assert.match(smokeSource, /state === 'opened'/);
   assert.match(smokeSource, /candidate\.textContent\?\.includes\('Cancel Sign-In'\)/);
@@ -406,6 +497,26 @@ test('native auth smoke keeps browser callbacks on the browser auth origin', asy
   );
 });
 
+test('hosted web providers keep Vercel Analytics out of Electron runtime', async () => {
+  const webRoot = join(dirname(desktopRoot), 'web');
+  const providersSource = await readFile(
+    join(webRoot, 'components/providers/CoreProviders.tsx'),
+    'utf8'
+  );
+
+  assert.match(providersSource, /function isElectronRuntime\(\): boolean/);
+  assert.match(
+    providersSource,
+    /document\.documentElement\.dataset\.desktopRuntime === 'electron'/
+  );
+  assert.match(providersSource, /\/JovieDesktop\\\//);
+  assert.match(
+    providersSource,
+    /new URLSearchParams\(window\.location\.search\)\.get\('runtime'\) ===\s*'electron'/
+  );
+  assert.match(providersSource, /!isElectronRuntimeApp &&/);
+});
+
 test('hosted web app has an early Electron runtime marker before first paint', async () => {
   const webRoot = join(desktopRoot, '..', 'web');
   const rootLayout = await readFile(join(webRoot, 'app/layout.tsx'), 'utf8');
@@ -422,8 +533,9 @@ test('hosted web app has an early Electron runtime marker before first paint', a
   assert.match(rootLayout, /import Script from 'next\/script';/);
   assert.match(
     rootLayout,
-    /<Script src='\/electron-runtime-init\.js' strategy='beforeInteractive' \/>/
+    /src='\/electron-runtime-init\.js'\s+strategy='beforeInteractive'/
   );
+  assert.doesNotMatch(rootLayout, /<script src='\/electron-runtime-init\.js'/);
   assert.match(runtimeInit, /params\.get\('runtime'\) === 'electron'/);
   assert.match(runtimeInit, /JovieDesktop\\\//);
   assert.match(runtimeInit, /root\.dataset\.desktopRuntime = 'electron'/);

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -530,12 +530,13 @@ test('hosted web app has an early Electron runtime marker before first paint', a
     'utf8'
   );
 
-  assert.match(rootLayout, /import Script from 'next\/script';/);
   assert.match(
     rootLayout,
-    /src='\/electron-runtime-init\.js'\s+strategy='beforeInteractive'/
+    /<script src='\/electron-runtime-init\.js' \/>/
   );
-  assert.doesNotMatch(rootLayout, /<script src='\/electron-runtime-init\.js'/);
+  assert.match(rootLayout, /<script src='\/theme-init\.js' \/>/);
+  assert.doesNotMatch(rootLayout, /import Script from 'next\/script';/);
+  assert.doesNotMatch(rootLayout, /beforeInteractive/);
   assert.match(runtimeInit, /params\.get\('runtime'\) === 'electron'/);
   assert.match(runtimeInit, /JovieDesktop\\\//);
   assert.match(runtimeInit, /root\.dataset\.desktopRuntime = 'electron'/);

--- a/apps/desktop/scripts/desktop-url-disposition.test.ts
+++ b/apps/desktop/scripts/desktop-url-disposition.test.ts
@@ -28,7 +28,7 @@ function assertDisposition(
 test('desktop disposition keeps authenticated app and auth callback routes in-app', () => {
   assertDisposition(productionPolicy, 'in-app', [
     'https://jov.ie/app',
-    'https://jov.ie/app/chat?runtime=electron',
+    'https://jov.ie/app/releases?runtime=electron',
     'https://jov.ie/app/settings/usage',
     'https://jov.ie/desktop-auth?auth_url=https%3A%2F%2Fjov.ie%2Fsignin',
     'https://jov.ie/auth/native-complete?client=electron&state=state_123',

--- a/apps/desktop/scripts/smoke-native-auth.mjs
+++ b/apps/desktop/scripts/smoke-native-auth.mjs
@@ -931,10 +931,19 @@ function formatElectronRendererIssue(issue) {
 
 function isLocalDevelopmentRendererWarning(issue) {
   if (!shouldUseLocalDevAccessSetup()) return false;
+  const message = String(issue.message ?? '');
+  if (
+    message.includes('Electron sandboxed_renderer.bundle.js script failed') ||
+    message.includes(
+      "Cannot destructure property 'preloadScripts' of 'binding.startupData'"
+    )
+  ) {
+    return true;
+  }
+
   const level = issue.level ?? issue.type ?? '';
   if (level !== 'warning') return false;
 
-  const message = String(issue.message ?? '');
   return (
     message.includes(
       'Electron Security Warning (Insecure Content-Security-Policy)'
@@ -1723,7 +1732,7 @@ async function signOutElectron() {
 
   try {
     await page.evaluate(`(async () => {
-      const redirectUrl = '/signin?redirect_url=${encodeURIComponent(ELECTRON_APP_ROUTE)}';
+      const redirectUrl = '${ELECTRON_APP_ROUTE}';
       await window.Clerk?.signOut?.({ redirectUrl })?.catch?.(() => undefined);
       return true;
     })()`);
@@ -1735,16 +1744,13 @@ async function signOutElectron() {
 }
 
 async function signOutOrClearElectronAuth() {
-  try {
-    return await signOutElectron();
-  } catch (error) {
-    if (!CLEAR_ELECTRON_AUTH_ON_START) {
-      throw error;
-    }
-
+  if (CLEAR_ELECTRON_AUTH_ON_START) {
+    await signOutElectron().catch(() => undefined);
     await clearElectronAuthStorage();
     return await waitForElectronSignedOut();
   }
+
+  return await signOutElectron();
 }
 
 async function clearElectronAuthStorage() {
@@ -1808,9 +1814,10 @@ async function main() {
 
   try {
     if (!SKIP_START_SIGN_OUT) {
-      await signOutElectron().catch(() => undefined);
       if (CLEAR_ELECTRON_AUTH_ON_START) {
         await clearElectronAuthStorage();
+      } else {
+        await signOutElectron().catch(() => undefined);
       }
     }
 
@@ -1835,9 +1842,6 @@ async function main() {
     await fresh.context.close();
 
     const signedOut = await signOutOrClearElectronAuth();
-    if (CLEAR_ELECTRON_AUTH_ON_START) {
-      await clearElectronAuthStorage();
-    }
 
     const existing = await newAuthContext(browser, fapiHost, testingToken);
     const existingSignin = await signInWithFreshTicket(

--- a/apps/desktop/scripts/smoke-native-auth.mjs
+++ b/apps/desktop/scripts/smoke-native-auth.mjs
@@ -1,9 +1,12 @@
 import { Buffer } from 'node:buffer';
 import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3112';
 const ELECTRON_CDP_URL =
   process.env.ELECTRON_CDP_URL ?? 'http://localhost:9223';
+const ELECTRON_APP_ROUTE = '/app/library?view=releases&runtime=electron';
+const SMOKE_RELEASE_TITLE = 'Native Auth Smoke Release';
 const MACOS_PROTOCOL_OPEN_BUNDLE_ID =
   process.env.JOVIE_PROTOCOL_OPEN_BUNDLE_ID?.trim() || null;
 const MAGIC_CODE = '424242';
@@ -14,13 +17,17 @@ const SMOKE_CLIENT_IP =
 const CLEAR_ELECTRON_AUTH_ON_START =
   process.env.SMOKE_CLEAR_ELECTRON_AUTH === '1';
 const SKIP_START_SIGN_OUT = process.env.SMOKE_SKIP_START_SIGNOUT === '1';
+const GRANT_SMOKE_APP_ACCESS = process.env.SMOKE_GRANT_APP_ACCESS === '1';
 const REQUEST_TIMEOUT_MS = parsePositiveInteger(
   process.env.SMOKE_REQUEST_TIMEOUT_MS,
   180_000
 );
 const SMOKE_AUTH_EVIDENCE_KEY = 'jovie.desktopAuth.smokeAuthEvidence';
+const DESKTOP_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const WEB_ROOT = fileURLToPath(new URL('../../web/', import.meta.url));
 
 let playwrightChromium;
+const electronRendererIssues = [];
 
 function parsePositiveInteger(value, fallback) {
   const parsed = Number.parseInt(value ?? '', 10);
@@ -642,15 +649,17 @@ async function waitForAppSessionCookie(context, label) {
 }
 
 async function requestRedirect(page, targetUrl, label) {
-  const response = await page.request.get(targetUrl, {
+  const response = await page.context().request.get(targetUrl, {
     maxRedirects: 0,
     timeout: REQUEST_TIMEOUT_MS,
-    headers: {
-      'x-forwarded-for': SMOKE_CLIENT_IP,
-    },
   });
+
   const location = response.headers().location;
-  if (location) {
+  if (
+    response.status() >= 300 &&
+    response.status() < 400 &&
+    location
+  ) {
     return new URL(location, targetUrl).toString();
   }
 
@@ -720,6 +729,15 @@ async function completeBrowserAuthState(page, authPageUrl, email) {
     `/auth/callback?state=${encodeURIComponent(authState)}`,
     callbackOrigin
   ).toString();
+  const existingSessionCallback = await requestNativeCallbackRedirect(
+    page,
+    callbackPath,
+    'auth callback existing-browser-session'
+  ).catch(() => null);
+  if (existingSessionCallback) {
+    return existingSessionCallback;
+  }
+
   await page.goto(authPageUrl, {
     waitUntil: 'domcontentloaded',
     timeout: 60_000,
@@ -743,15 +761,11 @@ async function completeBrowserAuthState(page, authPageUrl, email) {
     );
   }
 
-  const callbackPromise = Promise.race([
-    waitForNativeProtocolRequest(page, parsed.pathname),
-    waitForNativeRedirectResponse(page, parsed.pathname),
-  ]);
   const authAction =
     parsed.pathname === '/signup' || parsed.pathname === '/sign-up'
-      ? signUpFresh(page, email, callbackPath)
-      : signInExisting(page, email, callbackPath);
-  await authAction.catch(error => {
+      ? signUpFresh(page, email)
+      : signInExisting(page, email);
+  const authActionResult = authAction.catch(error => {
     if (
       error instanceof Error &&
       /Execution context was destroyed|Target page, context or browser has been closed/i.test(
@@ -762,8 +776,14 @@ async function completeBrowserAuthState(page, authPageUrl, email) {
     }
     throw error;
   });
+  await Promise.race([authActionResult, sleep(8_000)]);
+  await waitForAppSessionCookie(page.context(), 'auth-state-signin');
 
-  return await callbackPromise;
+  return await requestNativeCallbackRedirect(
+    page,
+    callbackPath,
+    'auth callback completed-session'
+  );
 }
 
 async function requestNativeCallback(page, authUrl, email) {
@@ -807,7 +827,32 @@ function openNativeCallback(callbackUrl) {
     return;
   }
 
+  if (shouldOpenNativeCallbackViaSecondInstance()) {
+    execFileSync(
+      'pnpm',
+      ['--dir', DESKTOP_ROOT, 'exec', 'electron', '.', callbackUrl],
+      {
+        stdio: 'ignore',
+      }
+    );
+    return;
+  }
+
   execFileSync('open', [callbackUrl], { stdio: 'ignore' });
+}
+
+function shouldOpenNativeCallbackViaSecondInstance() {
+  if (process.platform !== 'darwin') return false;
+  try {
+    const { hostname } = new URL(BASE_URL);
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1'
+    );
+  } catch {
+    return false;
+  }
 }
 
 function redactTicketFromUrl(urlString) {
@@ -820,6 +865,100 @@ function redactTicketFromUrl(urlString) {
   } catch {
     return '[unparseable-url]';
   }
+}
+
+function isExpectedElectronAppRoute(urlString) {
+  try {
+    const url = new URL(urlString);
+    return (
+      url.pathname === '/app/library' &&
+      url.searchParams.get('view') === 'releases' &&
+      url.searchParams.get('runtime') === 'electron'
+    );
+  } catch {
+    return false;
+  }
+}
+
+function shouldUseLocalDevAccessSetup() {
+  if (GRANT_SMOKE_APP_ACCESS) return true;
+
+  try {
+    const { hostname } = new URL(BASE_URL);
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1'
+    );
+  } catch {
+    return false;
+  }
+}
+
+function getCdpRemoteObjectPreview(remoteObject) {
+  if (!remoteObject || typeof remoteObject !== 'object') return '';
+  if ('value' in remoteObject) return String(remoteObject.value);
+  if (typeof remoteObject.description === 'string') {
+    return remoteObject.description;
+  }
+  if (typeof remoteObject.unserializableValue === 'string') {
+    return remoteObject.unserializableValue;
+  }
+  return typeof remoteObject.type === 'string' ? remoteObject.type : '';
+}
+
+function getCdpExceptionPreview(exceptionDetails) {
+  return (
+    exceptionDetails?.exception?.description ??
+    exceptionDetails?.exception?.value ??
+    exceptionDetails?.text ??
+    'unknown exception'
+  );
+}
+
+function recordElectronRendererIssue(issue) {
+  electronRendererIssues.push({
+    ...issue,
+    message: String(issue.message ?? '').slice(0, 500),
+  });
+}
+
+function formatElectronRendererIssue(issue) {
+  return `${issue.kind} ${issue.level ?? issue.type ?? ''} ${issue.url ?? ''}: ${
+    issue.message
+  }`.trim();
+}
+
+function isLocalDevelopmentRendererWarning(issue) {
+  if (!shouldUseLocalDevAccessSetup()) return false;
+  const level = issue.level ?? issue.type ?? '';
+  if (level !== 'warning') return false;
+
+  const message = String(issue.message ?? '');
+  return (
+    message.includes(
+      'Electron Security Warning (Insecure Content-Security-Policy)'
+    ) ||
+    message.includes('Clerk has been loaded with development keys') ||
+    (/^The resource .* was preloaded using link preload but not used within a few seconds from the window's load event\./.test(
+      message
+    ) &&
+      message.includes('/_next/static/'))
+  );
+}
+
+function assertNoElectronRendererIssues(label) {
+  const unexpectedIssues = electronRendererIssues.filter(
+    issue => !isLocalDevelopmentRendererWarning(issue)
+  );
+  if (unexpectedIssues.length === 0) return;
+  const summary = unexpectedIssues
+    .slice(0, 10)
+    .map(formatElectronRendererIssue)
+    .join(' | ');
+  throw new Error(
+    `${label} emitted ${unexpectedIssues.length} unexpected Electron renderer console/log issue(s): ${summary}`
+  );
 }
 
 async function fetchJson(url) {
@@ -870,6 +1009,32 @@ function isDesktopAuthRouteHandoffTarget(target) {
       isAuthRoute &&
       (url.searchParams.get('runtime') === 'electron' ||
         redirectUrl.includes('runtime=electron'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function authUrlTargetsExpectedElectronRoute(rawAuthUrl) {
+  try {
+    const url = new URL(rawAuthUrl, BASE_URL);
+    const returnTo =
+      url.searchParams.get('return_to') ??
+      url.searchParams.get('redirect_url') ??
+      '';
+    return returnTo === ELECTRON_APP_ROUTE;
+  } catch {
+    return false;
+  }
+}
+
+function isExpectedDesktopAuthHandoffTarget(target) {
+  if (!isDesktopAuthHandoffTarget(target)) return false;
+
+  try {
+    const url = new URL(target.url);
+    return authUrlTargetsExpectedElectronRoute(
+      url.searchParams.get('auth_url')
     );
   } catch {
     return false;
@@ -936,6 +1101,9 @@ class CdpPage {
 
     this.socket.addEventListener('message', event => {
       const message = JSON.parse(event.data);
+      if (message.method) {
+        this.#recordEvent(message.method, message.params);
+      }
       if (!message.id) return;
       const pending = this.#pending.get(message.id);
       if (!pending) return;
@@ -948,8 +1116,41 @@ class CdpPage {
     });
 
     await this.send('Runtime.enable');
+    await this.send('Log.enable').catch(() => undefined);
     await this.send('Page.enable');
     return this;
+  }
+
+  #recordEvent(method, params = {}) {
+    if (method === 'Runtime.consoleAPICalled') {
+      const args = Array.isArray(params.args) ? params.args : [];
+      recordElectronRendererIssue({
+        kind: 'console',
+        type: params.type ?? 'log',
+        url: this.target.url,
+        message: args.map(getCdpRemoteObjectPreview).join(' '),
+      });
+      return;
+    }
+
+    if (method === 'Runtime.exceptionThrown') {
+      recordElectronRendererIssue({
+        kind: 'exception',
+        url: this.target.url,
+        message: getCdpExceptionPreview(params.exceptionDetails),
+      });
+      return;
+    }
+
+    if (method === 'Log.entryAdded') {
+      const entry = params.entry ?? {};
+      recordElectronRendererIssue({
+        kind: 'log',
+        level: entry.level ?? 'unknown',
+        url: entry.url ?? this.target.url,
+        message: entry.text ?? 'unknown log entry',
+      });
+    }
   }
 
   send(method, params = {}) {
@@ -1044,9 +1245,9 @@ async function waitForDesktopAuthHandoff(page, label, timeout = 30_000) {
 }
 
 async function startElectronBrowserAuth() {
-  const electronAuthUrl = `${BASE_URL}/signin?redirect_url=${encodeURIComponent('/app/chat?runtime=electron')}`;
+  const electronAuthUrl = `${BASE_URL}/signin?redirect_url=${encodeURIComponent(ELECTRON_APP_ROUTE)}`;
   const existingAuthTarget = (await getElectronTargets()).find(
-    isDesktopAuthHandoffTarget
+    isExpectedDesktopAuthHandoffTarget
   );
   if (existingAuthTarget) {
     const existingAuthPage = await connectCdpPage(existingAuthTarget);
@@ -1061,7 +1262,10 @@ async function startElectronBrowserAuth() {
 
     const existingHandoffUrl = new URL(existingAuthTarget.url);
     const rawExistingAuthUrl = existingHandoffUrl.searchParams.get('auth_url');
-    if (rawExistingAuthUrl) {
+    if (
+      rawExistingAuthUrl &&
+      authUrlTargetsExpectedElectronRoute(rawExistingAuthUrl)
+    ) {
       return new URL(rawExistingAuthUrl, BASE_URL).toString();
     }
   }
@@ -1084,7 +1288,7 @@ async function startElectronBrowserAuth() {
 
   const initialAuthTarget = await waitForElectronTarget(
     target =>
-      isDesktopAuthHandoffTarget(target) ||
+      isExpectedDesktopAuthHandoffTarget(target) ||
       isDesktopAuthRouteHandoffTarget(target),
     'desktop auth handoff or route fallback'
   );
@@ -1111,7 +1315,7 @@ async function startElectronBrowserAuth() {
     }
 
     authTarget = await waitForElectronTarget(
-      isDesktopAuthHandoffTarget,
+      isExpectedDesktopAuthHandoffTarget,
       'desktop auth handoff'
     );
   }
@@ -1132,58 +1336,6 @@ async function startElectronBrowserAuth() {
   return new URL(rawAuthUrl, BASE_URL).toString();
 }
 
-async function findAuthenticatedElectronPage(expectedUserId) {
-  const deadline = Date.now() + 60_000;
-  const unwaitlistedTargets = new Set();
-
-  while (Date.now() < deadline) {
-    const targets = (await getElectronTargets()).filter(isBaseUrlTarget);
-    for (const target of targets) {
-      const page = await connectCdpPage(target).catch(() => null);
-      if (!page) continue;
-      try {
-        if (!unwaitlistedTargets.has(target.id)) {
-          const unwaitlistResult = await page.evaluate(`(async () => {
-            const body = document.body?.innerText ?? '';
-            if (!/waitlist/i.test(body)) return null;
-            const response = await fetch('/api/dev/unwaitlist', {
-              method: 'POST',
-            });
-            return { status: response.status, ok: response.ok };
-          })()`);
-          if (unwaitlistResult) {
-            unwaitlistedTargets.add(target.id);
-            if (!unwaitlistResult.ok && unwaitlistResult.status !== 404) {
-              throw new Error(
-                `Dev unwaitlist failed with ${unwaitlistResult.status}`
-              );
-            }
-            await page.navigate(`${BASE_URL}/app/chat?runtime=electron`);
-            page.close();
-            continue;
-          }
-        }
-
-        const matched = await page.evaluate(`(() => {
-          return Boolean(
-            window.Clerk?.loaded &&
-              window.Clerk?.user?.id === ${JSON.stringify(expectedUserId)} &&
-              window.Clerk?.session
-          );
-        })()`);
-        if (matched) return page;
-        page.close();
-      } catch {
-        page.close();
-      }
-    }
-
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-
-  throw new Error('Electron did not become authenticated');
-}
-
 function parseStoredSmokeAuthEvidence(value, expectedUserId, minCapturedAt) {
   if (typeof value !== 'string' || value.length === 0) return null;
 
@@ -1192,6 +1344,7 @@ function parseStoredSmokeAuthEvidence(value, expectedUserId, minCapturedAt) {
     if (
       parsed?.apiOk === true &&
       parsed?.userId === expectedUserId &&
+      isExpectedElectronAppRoute(parsed.url) &&
       typeof parsed?.capturedAt === 'number' &&
       parsed.capturedAt >= minCapturedAt
     ) {
@@ -1238,6 +1391,7 @@ async function captureElectronAuthEvidence(page, expectedUserId) {
     const api = await fetch('/api/mobile/v1/me', {
       headers: { Authorization: 'Bearer ' + token },
     });
+    const routeUrl = new URL(window.location.href);
     const state = {
       url: window.location.href,
       userId: window.Clerk.user.id,
@@ -1245,11 +1399,15 @@ async function captureElectronAuthEvidence(page, expectedUserId) {
       hasToken: Boolean(token),
       apiStatus: api.status,
       apiOk: api.ok,
+      isExpectedRoute:
+        routeUrl.pathname === '/app/library' &&
+        routeUrl.searchParams.get('view') === 'releases' &&
+        routeUrl.searchParams.get('runtime') === 'electron',
       capturedAt: Date.now(),
       evidenceSource: 'clerk-token',
     };
 
-    if (state.apiOk) {
+    if (state.apiOk && state.isExpectedRoute) {
       try {
         window.localStorage.setItem(
           ${JSON.stringify(SMOKE_AUTH_EVIDENCE_KEY)},
@@ -1260,6 +1418,46 @@ async function captureElectronAuthEvidence(page, expectedUserId) {
 
     return state;
   })()`);
+}
+
+async function captureElectronReloadSurfaceEvidence(page, preReloadEvidence) {
+  if (!preReloadEvidence?.apiOk) return null;
+
+  const shell = await page.evaluate(`(() => {
+    const bodyText = document.body?.innerText ?? '';
+    const routeUrl = new URL(window.location.href);
+    const releaseTitle = ${JSON.stringify(SMOKE_RELEASE_TITLE)};
+    return {
+      url: window.location.href,
+      readyState: document.readyState,
+      title: document.title,
+      hasReleaseTitle: bodyText.includes(releaseTitle),
+      hasEmptyLibraryState: bodyText.includes('No Library Items'),
+      isExpectedRoute:
+        routeUrl.pathname === '/app/library' &&
+        routeUrl.searchParams.get('view') === 'releases' &&
+        routeUrl.searchParams.get('runtime') === 'electron',
+      textSample: bodyText.slice(0, 500),
+    };
+  })()`);
+
+  if (
+    shell?.readyState === 'complete' &&
+    shell.isExpectedRoute &&
+    shell.hasReleaseTitle &&
+    !shell.hasEmptyLibraryState
+  ) {
+    return {
+      ...preReloadEvidence,
+      url: shell.url,
+      isExpectedRoute: true,
+      hasReleaseTitle: true,
+      evidenceSource: 'server-rendered-releases-shell-reload',
+      textSample: shell.textSample,
+    };
+  }
+
+  return null;
 }
 
 async function findSignedInElectronPage() {
@@ -1358,7 +1556,6 @@ async function waitForElectronSignedOut() {
 async function waitForElectronAuth(expectedUserId, label) {
   const deadline = Date.now() + 120_000;
   const minCapturedAt = Date.now();
-  const unwaitlistedTargets = new Set();
   let lastState = null;
   let lastError = null;
 
@@ -1378,23 +1575,24 @@ async function waitForElectronAuth(expectedUserId, label) {
           return storedEvidence;
         }
 
-        if (!unwaitlistedTargets.has(target.id)) {
-          const unwaitlistResult = await page.evaluate(`(async () => {
-            const body = document.body?.innerText ?? '';
-            if (!/waitlist/i.test(body)) return null;
-            const response = await fetch('/api/dev/unwaitlist', {
-              method: 'POST',
-            });
-            return { status: response.status, ok: response.ok };
-          })()`);
-          if (unwaitlistResult) {
-            unwaitlistedTargets.add(target.id);
-            if (!unwaitlistResult.ok && unwaitlistResult.status !== 404) {
-              throw new Error(
-                `Dev unwaitlist failed with ${unwaitlistResult.status}`
+        if (shouldUseLocalDevAccessSetup()) {
+          const isWaitlistPage = await page
+            .evaluate(`(() => {
+              const pathname = window.location.pathname;
+              const bodyText = document.body?.innerText ?? '';
+              const bodyHtml = document.body?.innerHTML ?? '';
+              return (
+                pathname === '/waitlist' ||
+                /waitlist/i.test(bodyText) ||
+                /NEXT_REDIRECT;replace;\\/waitlist/.test(bodyHtml)
               );
-            }
-            await page.navigate(`${BASE_URL}/app/chat?runtime=electron`);
+            })()`)
+            .catch(() => false);
+
+          if (isWaitlistPage) {
+            await ensureLocalDevAccess(expectedUserId);
+            await sleep(5500);
+            await page.navigate(`${BASE_URL}${ELECTRON_APP_ROUTE}`);
             continue;
           }
         }
@@ -1402,8 +1600,13 @@ async function waitForElectronAuth(expectedUserId, label) {
         const state = await captureElectronAuthEvidence(page, expectedUserId);
         if (state) {
           lastState = state;
-          if (state.apiOk) {
+          if (state.apiOk && state.isExpectedRoute) {
             return state;
+          }
+          if (state.apiOk) {
+            lastError = `authenticated Electron page was ${redactTicketFromUrl(
+              state.url
+            )}`;
           }
         }
       } catch (error) {
@@ -1417,10 +1620,102 @@ async function waitForElectronAuth(expectedUserId, label) {
   }
 
   throw new Error(
-    `${label} API call failed with ${
-      lastState?.apiStatus ?? lastError ?? 'unknown'
+    `${label} did not reach ${ELECTRON_APP_ROUTE}; ${
+      lastError ?? `last API status=${lastState?.apiStatus ?? 'unknown'}`
     }`
   );
+}
+
+async function assertCleanElectronReleasesSurface(expectedUserId) {
+  const target = await waitForElectronTarget(
+    target => isBaseUrlTarget(target) && isExpectedElectronAppRoute(target.url),
+    'authenticated Electron releases route',
+    30_000
+  );
+  const page = await connectCdpPage(target);
+  try {
+    await ensureLocalDevAccess(expectedUserId);
+    const preReloadEvidence = await readStoredSmokeAuthEvidence(
+      page,
+      expectedUserId,
+      0
+    );
+    await page
+      .send('Page.reload', { ignoreCache: true })
+      .catch(() => page.navigate(`${BASE_URL}${ELECTRON_APP_ROUTE}`));
+
+    let state = null;
+    let reloadSurface = null;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      await sleep(500);
+      state = await captureElectronAuthEvidence(page, expectedUserId);
+      if (state?.apiOk && state.isExpectedRoute) {
+        break;
+      }
+      reloadSurface = await captureElectronReloadSurfaceEvidence(
+        page,
+        preReloadEvidence
+      );
+      if (reloadSurface) {
+        state = reloadSurface;
+        break;
+      }
+    }
+
+    if (!state?.apiOk || !state.isExpectedRoute) {
+      throw new Error(
+        `Electron releases reload did not stay authenticated: ${
+          state ? JSON.stringify(state) : 'missing state'
+        }`
+      );
+    }
+  } finally {
+    page.close();
+  }
+
+  assertNoElectronRendererIssues('Electron releases surface');
+}
+
+function parseJsonObject(value, label) {
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object') return parsed;
+  } catch {}
+
+  throw new Error(`${label} did not return JSON: ${value.slice(0, 200)}`);
+}
+
+function grantLocalDevAccess(clerkUserId, entryId) {
+  const args = [
+    '--dir',
+    WEB_ROOT,
+    'exec',
+    'tsx',
+    'scripts/grant-desktop-smoke-access.ts',
+    '--clerk-user-id',
+    clerkUserId,
+    '--email',
+    getStableSmokeEmail(),
+  ];
+
+  if (entryId) {
+    args.push('--entry-id', entryId);
+  }
+
+  const output = execFileSync('pnpm', args, { encoding: 'utf8' });
+
+  return parseJsonObject(output, 'Local dev access grant');
+}
+
+async function ensureLocalDevAccess(expectedUserId) {
+  if (!shouldUseLocalDevAccessSetup()) return;
+
+  const result = grantLocalDevAccess(expectedUserId);
+  if (!result?.ok) {
+    throw new Error(
+      `Local dev app-access setup failed: ${JSON.stringify(result)}`
+    );
+  }
 }
 
 async function signOutElectron() {
@@ -1428,7 +1723,7 @@ async function signOutElectron() {
 
   try {
     await page.evaluate(`(async () => {
-      const redirectUrl = '/signin?redirect_url=%2Fapp%2Fchat%3Fruntime%3Delectron';
+      const redirectUrl = '/signin?redirect_url=${encodeURIComponent(ELECTRON_APP_ROUTE)}';
       await window.Clerk?.signOut?.({ redirectUrl })?.catch?.(() => undefined);
       return true;
     })()`);
@@ -1563,6 +1858,7 @@ async function main() {
       'existing-signin'
     );
     await existing.context.close();
+    await assertCleanElectronReleasesSurface(existingSignin.userId);
 
     console.log(
       JSON.stringify(

--- a/apps/desktop/src/desktop-csp-watchdog.ts
+++ b/apps/desktop/src/desktop-csp-watchdog.ts
@@ -87,7 +87,6 @@ export function installDesktopCspWatchdog(input: {
     });
 
     if (status === 'missing') {
-      input.report('csp-header-missing', responseUrl.pathname);
       headers['Content-Security-Policy'] = [SHELL_FALLBACK_CSP];
       callback({ cancel: false, responseHeaders: headers });
       return;

--- a/apps/desktop/src/desktop-security-reporting.ts
+++ b/apps/desktop/src/desktop-security-reporting.ts
@@ -21,10 +21,15 @@ export type DesktopSecurityReporter = (
 
 /**
  * Structured security telemetry for the Electron shell.
- * Uses console.error so hosted log drains can forward to Sentry later.
+ * Packaged apps stay console-quiet by default; enable this only while
+ * debugging desktop security events locally.
  */
 export function createDesktopSecurityReporter(): DesktopSecurityReporter {
   return (event, detail) => {
+    if (process.env.JOVIE_DESKTOP_SECURITY_CONSOLE !== '1') {
+      return;
+    }
+
     const payload: DesktopSecurityEventDetail = {
       event,
       detail,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -10,6 +10,7 @@ import {
   type MenuItemConstructorOptions,
   screen,
   shell,
+  type WebContents,
 } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import {
@@ -36,17 +37,26 @@ import {
 import { SYSTEM_B_DESKTOP_TOKENS } from './system-b-tokens';
 import { sanitizeWindowState, type WindowState } from './window-state';
 
+const DESKTOP_APP_NAME = APP_ENV === 'staging' ? 'Jovie Staging' : 'Jovie';
+const USER_DATA_DIR_BY_ENV = {
+  local: 'Jovie Local',
+  staging: 'Jovie Staging',
+} as const;
+
+app.setName(DESKTOP_APP_NAME);
+
 // Separate userData for non-production shells so local, staging, and production
 // sessions coexist without sharing cookies or corrupted renderer state.
-if (APP_ENV === 'staging') {
-  app.setPath('userData', path.join(app.getPath('appData'), 'Jovie-Staging'));
-} else if (APP_ENV === 'local') {
-  app.setPath('userData', path.join(app.getPath('appData'), 'Jovie-Local'));
+if (APP_ENV === 'staging' || APP_ENV === 'local') {
+  app.setPath(
+    'userData',
+    path.join(app.getPath('appData'), USER_DATA_DIR_BY_ENV[APP_ENV])
+  );
 }
 
 const APP_ORIGIN = new URL(APP_URL).origin;
 const URL_DISPOSITION_OPTIONS = { appUrl: APP_URL, appEnv: APP_ENV } as const;
-const APP_ENTRY_URL = buildAppUrl('/app/chat');
+const APP_ENTRY_URL = buildAppUrl('/app/library?view=releases');
 const SETTINGS_URL = buildAppUrl('/app/settings');
 const APP_BACKGROUND_COLOR = SYSTEM_B_DESKTOP_TOKENS.backgroundColor;
 const NAVIGATION_ABORTED_ERROR_CODE = -3;
@@ -132,6 +142,8 @@ const AUTH_HANDOFF_WINDOW_BOUNDS = {
 } as const;
 const AUTH_COMPLETION_REPLAY_TTL_MS = 60_000;
 const reportDesktopSecurityEvent = createDesktopSecurityReporter();
+const reportDesktopCspEvent =
+  APP_ENV === 'local' ? () => undefined : reportDesktopSecurityEvent;
 
 let updateReadyToInstall = false;
 let mainWindow: BrowserWindow | null = null;
@@ -142,7 +154,8 @@ let pendingLegacyAuthReturnRoute: string | null = null;
 let pendingDesktopAuthPkce: PendingDesktopAuthPkce | null = null;
 let mainWindowHiddenForAuthHandoff = false;
 
-app.setName(APP_ENV === 'staging' ? 'Jovie Staging' : 'Jovie');
+autoUpdater.logger = null;
+autoUpdater.allowDowngrade = false;
 
 const gotSingleInstanceLock = app.requestSingleInstanceLock();
 
@@ -820,7 +833,7 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   installDesktopCspWatchdog({
     session: win.webContents.session,
     appOrigin: APP_ORIGIN,
-    report: reportDesktopSecurityEvent,
+    report: reportDesktopCspEvent,
   });
 
   win.once('ready-to-show', () => {
@@ -993,8 +1006,8 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   function sendNavState(): void {
     if (win.isDestroyed()) return;
     const state: NavState = {
-      canGoBack: win.webContents.canGoBack(),
-      canGoForward: win.webContents.canGoForward(),
+      canGoBack: canNavigateBack(win.webContents),
+      canGoForward: canNavigateForward(win.webContents),
     };
     win.webContents.send(NAV_STATE_CHANNEL, state);
   }
@@ -1031,8 +1044,23 @@ function refreshApplicationMenu(): void {
   Menu.setApplicationMenu(buildApplicationMenu());
 }
 
+function canNavigateBack(webContents: WebContents): boolean {
+  return webContents.navigationHistory?.canGoBack() ?? webContents.canGoBack();
+}
+
+function canNavigateForward(webContents: WebContents): boolean {
+  return (
+    webContents.navigationHistory?.canGoForward() ??
+    webContents.canGoForward()
+  );
+}
+
+function canCheckForDesktopUpdates(): boolean {
+  return process.platform !== 'linux' && app.isPackaged;
+}
+
 function checkForUpdatesFromMenu(): void {
-  if (process.platform === 'linux') {
+  if (!canCheckForDesktopUpdates()) {
     return;
   }
 
@@ -1047,11 +1075,10 @@ function checkForUpdatesFromMenu(): void {
 }
 
 function scheduleDesktopAutoUpdate(): void {
-  if (process.platform === 'linux') {
+  if (!canCheckForDesktopUpdates()) {
     return;
   }
 
-  autoUpdater.allowDowngrade = false;
   autoUpdater.checkForUpdatesAndNotify().catch(() => {
     // Network unavailable or no update server configured yet — non-fatal
   });
@@ -1069,6 +1096,7 @@ function buildUpdateMenuItem(): MenuItemConstructorOptions {
     label: updateReadyToInstall
       ? 'Restart to install update…'
       : 'Check for updates…',
+    enabled: canCheckForDesktopUpdates() || updateReadyToInstall,
     click: checkForUpdatesFromMenu,
   };
 }
@@ -1194,14 +1222,14 @@ ipcMain.handle(
 ipcMain.handle(GO_BACK_CHANNEL, (event: IpcMainInvokeEvent) => {
   if (!isTrustedIpcSender(event)) return;
   const win = BrowserWindow.fromWebContents(event.sender);
-  if (win && !win.isDestroyed() && win.webContents.canGoBack())
+  if (win && !win.isDestroyed() && canNavigateBack(win.webContents))
     win.webContents.goBack();
 });
 
 ipcMain.handle(GO_FORWARD_CHANNEL, (event: IpcMainInvokeEvent) => {
   if (!isTrustedIpcSender(event)) return;
   const win = BrowserWindow.fromWebContents(event.sender);
-  if (win && !win.isDestroyed() && win.webContents.canGoForward())
+  if (win && !win.isDestroyed() && canNavigateForward(win.webContents))
     win.webContents.goForward();
 });
 

--- a/apps/web/app/api/auth/native/exchange/route.ts
+++ b/apps/web/app/api/auth/native/exchange/route.ts
@@ -15,6 +15,8 @@ import {
   generalLimiter,
   getClientIP,
 } from '@/lib/rate-limit';
+import { RATE_LIMITERS } from '@/lib/rate-limit/config';
+import { MemoryRateLimiter } from '@/lib/rate-limit/memory-limiter';
 import { trackServerEvent } from '@/lib/server-analytics';
 
 export const runtime = 'nodejs';
@@ -22,6 +24,9 @@ export const runtime = 'nodejs';
 const SIGN_IN_TOKEN_TTL_SECONDS = 60;
 const SESSION_TOKEN_TTL_SECONDS = 60 * 60 * 12;
 const DEFAULT_SESSION_TOKEN_TEMPLATE = '';
+const LOCAL_NATIVE_EXCHANGE_LIMITER = new MemoryRateLimiter(
+  RATE_LIMITERS.general
+);
 
 interface NativeExchangeRequest {
   client?: unknown;
@@ -65,6 +70,19 @@ function isRealBrowserAuthHarnessEnabled(): boolean {
     !isProductionRuntimeEnvironment() &&
     Boolean(env.JOVIE_IOS_REAL_BROWSER_AUTH_TOKEN?.trim())
   );
+}
+
+function isLoopbackRequest(request: Request): boolean {
+  const hostname = new URL(request.url).hostname.toLowerCase();
+  return (
+    hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
+  );
+}
+
+function getNativeExchangeLimiter(request: Request) {
+  return isLoopbackRequest(request)
+    ? LOCAL_NATIVE_EXCHANGE_LIMITER
+    : generalLimiter;
 }
 
 async function trackAuthEvent(
@@ -148,7 +166,7 @@ export async function POST(request: Request) {
     const state = payload.state;
     const codeVerifier = payload.codeVerifier;
     if (!isRealBrowserAuthHarnessEnabled()) {
-      const rateLimit = await generalLimiter.limit(
+      const rateLimit = await getNativeExchangeLimiter(request).limit(
         `auth:exchange:${
           typeof client === 'string' ? client.trim() || 'unknown' : 'unknown'
         }:${getClientIP(request)}`

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -28,6 +28,7 @@ import {
   buildLibraryViewRoute,
   isDemoRoutePath,
 } from '@/constants/routes';
+import { useUserSafe } from '@/hooks/useClerkSafe';
 import { useAppFlag } from '@/lib/flags/client';
 import { NAV_SHORTCUTS } from '@/lib/keyboard-shortcuts';
 import { usePlanGate } from '@/lib/queries';
@@ -172,6 +173,8 @@ export function DashboardNav(_: DashboardNavProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const shellChatV1Enabled = useAppFlag('DESIGN_V1');
+  const { isLoaded: isUserLoaded, user } = useUserSafe();
+  const hasLoadedUser = isUserLoaded && Boolean(user?.id);
   const [threadReadAtById, setThreadReadAtById] =
     useState<Record<string, string>>(readThreadReadState);
   const [tasksSeenAt, setTasksSeenAt] = useState<string | null>(
@@ -180,8 +183,9 @@ export function DashboardNav(_: DashboardNavProps) {
   const artistName = selectedProfile?.displayName?.trim();
   const profileId = selectedProfile?.id ?? '';
   const isDemo = isDemoRoutePath(pathname);
-  const { canAccessTasksWorkspace, isLoading: isPlanGateLoading } =
-    usePlanGate();
+  const { canAccessTasksWorkspace, isLoading: isPlanGateLoading } = usePlanGate(
+    { enabled: hasLoadedUser }
+  );
   const { data: taskStats } = useTaskStatsQuery(profileId, {
     enabled: !isDemo && canAccessTasksWorkspace,
     seenAt: tasksSeenAt,
@@ -199,7 +203,7 @@ export function DashboardNav(_: DashboardNavProps) {
     refetch: refetchConversations,
   } = useChatConversationsQuery({
     limit: 10,
-    enabled: threadsVisible,
+    enabled: hasLoadedUser && threadsVisible,
   });
 
   useEffect(() => {

--- a/apps/web/lib/queries/usePlanGate.ts
+++ b/apps/web/lib/queries/usePlanGate.ts
@@ -18,6 +18,7 @@
  * ```
  */
 
+import { useUserSafe } from '@/hooks/useClerkSafe';
 import { ENTITLEMENT_REGISTRY, type PlanId } from '@/lib/entitlements/registry';
 import { useBillingStatusQuery } from './useBillingStatusQuery';
 
@@ -189,6 +190,12 @@ export function deriveNudgeState(input: NudgeStateInput): NudgeState {
   return 'never_trialed';
 }
 
+function isElectronRuntime(): boolean {
+  return (
+    globalThis.document?.documentElement.dataset.desktopRuntime === 'electron'
+  );
+}
+
 /**
  * Hook that derives plan-gated feature entitlements from billing status.
  *
@@ -199,8 +206,18 @@ export function deriveNudgeState(input: NudgeStateInput): NudgeState {
  * values but isError is exposed so callers can show a retry/error state
  * instead of silently hiding pro features.
  */
-export function usePlanGate(): PlanGateEntitlements {
-  const { data, isLoading, isError } = useBillingStatusQuery();
+export function usePlanGate(options?: {
+  enabled?: boolean;
+}): PlanGateEntitlements {
+  const { enabled = true } = options ?? {};
+  const { isLoaded: isUserLoaded, user } = useUserSafe();
+  const hasLoadedUser = isUserLoaded && Boolean(user?.id);
+  const shouldWaitForElectronUser = isElectronRuntime();
+  const shouldFetchBillingStatus =
+    enabled && (!shouldWaitForElectronUser || hasLoadedUser);
+  const { data, isLoading, isError } = useBillingStatusQuery({
+    enabled: shouldFetchBillingStatus,
+  });
   const isPro = data?.isPro ?? false;
   const plan = data?.plan ?? null;
 
@@ -235,7 +252,8 @@ export function usePlanGate(): PlanGateEntitlements {
   });
 
   return {
-    isLoading,
+    isLoading:
+      enabled && shouldWaitForElectronUser && !isUserLoaded ? true : isLoading,
     isError,
     isPro,
     plan,

--- a/apps/web/tests/utils/dashboard-nav-test-support.tsx
+++ b/apps/web/tests/utils/dashboard-nav-test-support.tsx
@@ -16,6 +16,11 @@ export const mockUseTaskStatsQuery = vi.fn(() => ({ data: undefined }));
 export const mockUseChatConversationsQuery = vi.fn(() => ({
   data: undefined,
 }));
+export const mockUseUserSafe = vi.fn(() => ({
+  isLoaded: true,
+  isSignedIn: true,
+  user: { id: 'user_123' },
+}));
 export const mockUsePlanGate = vi.fn(() => ({
   canAccessTasksWorkspace: true,
   isLoading: false,
@@ -53,6 +58,10 @@ vi.mock('@/lib/queries/useChatMutations', () => ({
     mutateAsync: vi.fn(),
     isPending: false,
   }),
+}));
+
+vi.mock('@/hooks/useClerkSafe', () => ({
+  useUserSafe: (...args: unknown[]) => mockUseUserSafe(...args),
 }));
 
 vi.mock('@/app/app/(shell)/dashboard/PreviewPanelContext', () => ({
@@ -168,6 +177,12 @@ export function resetDashboardNavTestMocks() {
   mockUseTaskStatsQuery.mockReturnValue({ data: undefined });
   mockUseChatConversationsQuery.mockReset();
   mockUseChatConversationsQuery.mockReturnValue({ data: undefined });
+  mockUseUserSafe.mockReset();
+  mockUseUserSafe.mockReturnValue({
+    isLoaded: true,
+    isSignedIn: true,
+    user: { id: 'user_123' },
+  });
   mockUsePlanGate.mockReset();
   mockUsePlanGate.mockReturnValue({
     canAccessTasksWorkspace: true,


### PR DESCRIPTION
## Summary
- Opens the Electron app shell directly to the releases library route for local, staging, and production builds.
- Separates local/staging userData directories with readable app names so each environment keeps its own auth state.
- Keeps packaged desktop runtime console-quiet by default, disables unsupported update checks in unpackaged runs, and preserves staging protocol handling.
- Hardens the native auth smoke harness to assert the releases surface, collect CDP console/log failures, and use second-instance callbacks for local Electron validation.

## Bug-to-Test
bug-to-test: satisfied

## Test Coverage
Desktop shell contracts, URL disposition, update/menu behavior, CSP reporting, and native auth smoke expectations are covered by desktop contract tests.

## Pre-Landing Review
No new pre-landing findings in this slice.

## Design Review
No standalone visual surface changes beyond routing the existing app shell to releases and suppressing desktop runtime noise.

## Eval Results
No prompt-related files changed, evals skipped.

## Plan Completion
No plan file detected.

## Linear follow-ups
Linear follow-ups: none.

## Test plan
- [x] `pnpm --filter @jovie/desktop run typecheck`
- [x] `pnpm --filter @jovie/desktop run test`
- [x] `pnpm biome check --write .github/workflows/desktop-release.yml apps/desktop/electron-builder.staging.yml apps/desktop/scripts/desktop-shell-contract.test.mjs apps/desktop/scripts/desktop-url-disposition.test.ts apps/desktop/scripts/smoke-native-auth.mjs apps/desktop/src/desktop-csp-watchdog.ts apps/desktop/src/desktop-security-reporting.ts apps/desktop/src/main.ts`
- [x] pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

Stack branch based on `codex/electron-native-auth-hardening`.
