### PR TITLE
fix(design-system): tokenize auth brand drift

### DIFF
--- a/apps/web/components/features/auth/AuthBrandPanel.tsx
+++ b/apps/web/components/features/auth/AuthBrandPanel.tsx
@@ -33,7 +33,7 @@ export function AuthBrandPanel({ className }: Readonly<AuthBrandPanelProps>) {
 function AuthBrandFrame() {
   return (
     <section
-      aria-label='Product preview'
+      aria-label='Product Preview'
       className='absolute inset-0 flex flex-col'
     >
       {/* Spacer above the floating screenshot. */}
@@ -53,8 +53,8 @@ function AuthBrandFrame() {
       <div className='min-h-0 flex-1' />
 
       <div className='relative z-10 px-8 pb-4 sm:px-10'>
-        <h2 className='text-balance text-[clamp(1.5rem,2.6vw,2rem)] font-[680] leading-[1.05] tracking-[-0.025em] text-(--color-text-tooltip)'>
-          Built for Artists.
+        <h2 className='text-balance text-[clamp(1.5rem,2.6vw,2rem)] font-bold leading-[1.05] tracking-[-0.025em] text-(--color-text-tooltip)'>
+          Built For Artists.
         </h2>
       </div>
     </section>

--- a/apps/web/tests/unit/auth/AuthBrandPanel.test.tsx
+++ b/apps/web/tests/unit/auth/AuthBrandPanel.test.tsx
@@ -16,7 +16,7 @@ describe('AuthBrandPanel', () => {
   it('renders a single static first product frame instead of a carousel', () => {
     render(<AuthBrandPanel />);
 
-    const preview = screen.getByRole('region', { name: 'Product preview' });
+    const preview = screen.getByRole('region', { name: 'Product Preview' });
 
     expect(preview).not.toHaveAttribute('aria-roledescription', 'carousel');
     expect(

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3456,
+  "count": 3455,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Tokenizes the auth brand panel exact `font-[680]` utility to `font-bold`.
- Normalizes touched auth brand labels to the project title-case lint convention.
- Lowers the arbitrary Tailwind ratchet baseline from `3456` to `3455`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/auth/AuthBrandPanel.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/auth/AuthBrandPanel.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied — `arbitrary-values-ratchet.test.ts` covers this drift reduction.