### PR TITLE
fix(design-system): tokenize home width drift

### DIFF
--- a/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
+++ b/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
@@ -44,9 +44,9 @@ export function AutomaticReleaseSmartlinksSection() {
           {/* Two-column header */}
           <div className='grid md:grid-cols-2 md:items-start section-gap-linear'>
             <h2 className='max-w-md marketing-h2-linear text-primary-token'>
-              New release?
+              New Release?
               <br />
-              Already live.
+              Already Live.
             </h2>
             <div className='max-w-lg'>
               <p className='marketing-lead-linear text-secondary-token'>

--- a/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
+++ b/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
@@ -44,9 +44,9 @@ export function AutomaticReleaseSmartlinksSection() {
           {/* Two-column header */}
           <div className='grid md:grid-cols-2 md:items-start section-gap-linear'>
             <h2 className='max-w-md marketing-h2-linear text-primary-token'>
-              New Release?
+              New release?
               <br />
-              Already Live.
+              Already live.
             </h2>
             <div className='max-w-lg'>
               <p className='marketing-lead-linear text-secondary-token'>

--- a/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
+++ b/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
@@ -40,13 +40,13 @@ export function AutomaticReleaseSmartlinksSection() {
       />
 
       <Container size='homepage'>
-        <div className='relative mx-auto max-w-[var(--linear-content-max)]'>
+        <div className='relative mx-auto max-w-linear-content'>
           {/* Two-column header */}
           <div className='grid md:grid-cols-2 md:items-start section-gap-linear'>
             <h2 className='max-w-md marketing-h2-linear text-primary-token'>
-              New release?
+              New Release?
               <br />
-              Already live.
+              Already Live.
             </h2>
             <div className='max-w-lg'>
               <p className='marketing-lead-linear text-secondary-token'>

--- a/apps/web/components/features/home/BentoFeatureGrid.tsx
+++ b/apps/web/components/features/home/BentoFeatureGrid.tsx
@@ -141,7 +141,7 @@ export function BentoFeatureGrid() {
             id='bento-heading'
             className='marketing-h2-linear text-primary-token'
           >
-            A command center for your career.
+            A Command Center For Your Career.
           </h2>
 
           <div className='mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2'>

--- a/apps/web/components/features/home/BentoFeatureGrid.tsx
+++ b/apps/web/components/features/home/BentoFeatureGrid.tsx
@@ -141,7 +141,7 @@ export function BentoFeatureGrid() {
             id='bento-heading'
             className='marketing-h2-linear text-primary-token'
           >
-            A Command Center For Your Career.
+            A command center for your career.
           </h2>
 
           <div className='mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2'>

--- a/apps/web/components/features/home/BentoFeatureGrid.tsx
+++ b/apps/web/components/features/home/BentoFeatureGrid.tsx
@@ -136,12 +136,12 @@ export function BentoFeatureGrid() {
       aria-labelledby='bento-heading'
     >
       <Container size='homepage'>
-        <div className='mx-auto max-w-[var(--linear-content-max)]'>
+        <div className='mx-auto max-w-linear-content'>
           <h2
             id='bento-heading'
             className='marketing-h2-linear text-primary-token'
           >
-            A command center for your career.
+            A Command Center For Your Career.
           </h2>
 
           <div className='mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2'>

--- a/apps/web/components/features/home/FeatureShowcase.tsx
+++ b/apps/web/components/features/home/FeatureShowcase.tsx
@@ -119,12 +119,12 @@ export function FeatureShowcase() {
   return (
     <section className='section-glow section-spacing-linear'>
       <Container size='homepage'>
-        <div className='mx-auto max-w-[var(--linear-content-max)]'>
+        <div className='mx-auto max-w-linear-content'>
           {/* Section header */}
           <div className='reveal-on-scroll mb-12 max-w-150 lg:mb-16'>
             <p className='homepage-section-eyebrow'>The platform</p>
             <h2 className='marketing-h2-linear mt-5 text-primary-token'>
-              Everything your music needs.
+              Everything Your Music Needs.
             </h2>
             <p className='marketing-lead-linear mt-4 text-secondary-token'>
               From smart links to fan intelligence, every release gets the full

--- a/apps/web/components/features/home/FeatureShowcase.tsx
+++ b/apps/web/components/features/home/FeatureShowcase.tsx
@@ -124,7 +124,7 @@ export function FeatureShowcase() {
           <div className='reveal-on-scroll mb-12 max-w-150 lg:mb-16'>
             <p className='homepage-section-eyebrow'>The platform</p>
             <h2 className='marketing-h2-linear mt-5 text-primary-token'>
-              Everything Your Music Needs.
+              Everything your music needs.
             </h2>
             <p className='marketing-lead-linear mt-4 text-secondary-token'>
               From smart links to fan intelligence, every release gets the full

--- a/apps/web/components/features/home/FeatureShowcase.tsx
+++ b/apps/web/components/features/home/FeatureShowcase.tsx
@@ -124,7 +124,7 @@ export function FeatureShowcase() {
           <div className='reveal-on-scroll mb-12 max-w-150 lg:mb-16'>
             <p className='homepage-section-eyebrow'>The platform</p>
             <h2 className='marketing-h2-linear mt-5 text-primary-token'>
-              Everything your music needs.
+              Everything Your Music Needs.
             </h2>
             <p className='marketing-lead-linear mt-4 text-secondary-token'>
               From smart links to fan intelligence, every release gets the full

--- a/apps/web/components/features/home/RedesignedHero.tsx
+++ b/apps/web/components/features/home/RedesignedHero.tsx
@@ -9,9 +9,9 @@ export async function RedesignedHero() {
         style={{ background: 'var(--linear-hero-backdrop)' }}
       />
 
-      <div className='hero-stagger relative z-10 mx-auto flex w-full max-w-[var(--linear-content-max)] flex-col items-center text-center'>
+      <div className='hero-stagger relative z-10 mx-auto flex w-full max-w-linear-content flex-col items-center text-center'>
         <h1 className='marketing-h1-linear text-balance text-primary-token'>
-          One link to launch your music career.
+          One Link To Launch Your Music Career.
         </h1>
 
         <p className='marketing-lead-linear mt-8 max-w-[40rem] text-balance text-tertiary-token'>

--- a/apps/web/components/features/home/RedesignedHero.tsx
+++ b/apps/web/components/features/home/RedesignedHero.tsx
@@ -11,7 +11,7 @@ export async function RedesignedHero() {
 
       <div className='hero-stagger relative z-10 mx-auto flex w-full max-w-linear-content flex-col items-center text-center'>
         <h1 className='marketing-h1-linear text-balance text-primary-token'>
-          One Link To Launch Your Music Career.
+          One link to launch your music career.
         </h1>
 
         <p className='marketing-lead-linear mt-8 max-w-[40rem] text-balance text-tertiary-token'>

--- a/apps/web/components/features/home/RedesignedHero.tsx
+++ b/apps/web/components/features/home/RedesignedHero.tsx
@@ -11,7 +11,7 @@ export async function RedesignedHero() {
 
       <div className='hero-stagger relative z-10 mx-auto flex w-full max-w-linear-content flex-col items-center text-center'>
         <h1 className='marketing-h1-linear text-balance text-primary-token'>
-          One link to launch your music career.
+          One Link To Launch Your Music Career.
         </h1>
 
         <p className='marketing-lead-linear mt-8 max-w-[40rem] text-balance text-tertiary-token'>

--- a/apps/web/components/features/home/ReplacesSection.tsx
+++ b/apps/web/components/features/home/ReplacesSection.tsx
@@ -35,7 +35,7 @@ export function ReplacesSection() {
               Why switch
             </span>
             <h2 className='marketing-h2-linear text-primary-token'>
-              One Tool Instead Of Three.
+              One tool instead of three.
             </h2>
             <p className='max-w-lg marketing-lead-linear text-secondary-token'>
               Most artists juggle a link page, a smart link service, and an

--- a/apps/web/components/features/home/ReplacesSection.tsx
+++ b/apps/web/components/features/home/ReplacesSection.tsx
@@ -28,14 +28,14 @@ export function ReplacesSection() {
   return (
     <section className='section-spacing-linear relative overflow-hidden bg-page'>
       <Container size='homepage'>
-        <div className='relative mx-auto max-w-[var(--linear-content-max)]'>
+        <div className='relative mx-auto max-w-linear-content'>
           {/* Header */}
           <div className='reveal-on-scroll flex flex-col items-center text-center gap-5 mb-16'>
             <span className='inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium tracking-[-0.01em] text-tertiary-token border border-subtle'>
               Why switch
             </span>
             <h2 className='marketing-h2-linear text-primary-token'>
-              One tool instead of three.
+              One Tool Instead Of Three.
             </h2>
             <p className='max-w-lg marketing-lead-linear text-secondary-token'>
               Most artists juggle a link page, a smart link service, and an

--- a/apps/web/components/features/home/ReplacesSection.tsx
+++ b/apps/web/components/features/home/ReplacesSection.tsx
@@ -35,7 +35,7 @@ export function ReplacesSection() {
               Why switch
             </span>
             <h2 className='marketing-h2-linear text-primary-token'>
-              One tool instead of three.
+              One Tool Instead Of Three.
             </h2>
             <p className='max-w-lg marketing-lead-linear text-secondary-token'>
               Most artists juggle a link page, a smart link service, and an

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3455,
+  "count": 3450,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }

--- a/apps/web/tests/unit/home/BentoFeatureGrid.test.tsx
+++ b/apps/web/tests/unit/home/BentoFeatureGrid.test.tsx
@@ -8,7 +8,7 @@ describe('BentoFeatureGrid', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: 'A command center for your career.',
+        name: 'A Command Center For Your Career.',
       })
     ).toBeInTheDocument();
 
@@ -19,7 +19,7 @@ describe('BentoFeatureGrid', () => {
 
     const section = screen
       .getByRole('heading', {
-        name: 'A command center for your career.',
+        name: 'A Command Center For Your Career.',
       })
       .closest('section');
     expect(section).toHaveAttribute('aria-labelledby', 'bento-heading');

--- a/apps/web/tests/unit/home/bento-feature-grid-system-b-style-guard.test.tsx
+++ b/apps/web/tests/unit/home/bento-feature-grid-system-b-style-guard.test.tsx
@@ -89,7 +89,7 @@ describe('BentoFeatureGrid System B source contract', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: 'A command center for your career.',
+        name: 'A Command Center For Your Career.',
       })
     ).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary

- Tokenizes five exact home layout width utilities from `max-w-[var(--linear-content-max)]` to `max-w-linear-content`.
- Normalizes touched home headings to the project title-case lint convention.
- Lowers the arbitrary Tailwind ratchet baseline from `3455` to `3450`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx apps/web/components/features/home/BentoFeatureGrid.tsx apps/web/components/features/home/FeatureShowcase.tsx apps/web/components/features/home/ReplacesSection.tsx apps/web/components/features/home/RedesignedHero.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx apps/web/components/features/home/BentoFeatureGrid.tsx apps/web/components/features/home/FeatureShowcase.tsx apps/web/components/features/home/ReplacesSection.tsx apps/web/components/features/home/RedesignedHero.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied — `arbitrary-values-ratchet.test.ts` covers this drift reduction.