### PR TITLE
fix(design-system): tokenize release font drift

### DIFF
--- a/apps/web/components/features/release/ReleaseCountdown.tsx
+++ b/apps/web/components/features/release/ReleaseCountdown.tsx
@@ -143,7 +143,7 @@ export function ReleaseCountdown({
       <div className='flex items-baseline gap-2.5 tabular-nums'>
         {segments.map(segment => (
           <span key={segment.label}>
-            <span className='text-xl font-[680] tracking-[-0.03em] text-white'>
+            <span className='text-xl font-bold tracking-[-0.03em] text-(--color-text-tooltip)'>
               {segment.value}
             </span>
             <span className='ml-0.5 text-3xs font-semibold uppercase tracking-[0.08em] text-white/35'>
@@ -161,7 +161,7 @@ export function ReleaseCountdown({
       <div className='mt-2 flex items-center justify-center gap-3'>
         {timeLeft.days > 0 && (
           <div className='flex flex-col items-center'>
-            <span className='text-2xl font-bold tabular-nums text-white'>
+            <span className='text-2xl font-bold tabular-nums text-(--color-text-tooltip)'>
               {timeLeft.days}
             </span>
             <span className='text-3xs uppercase tracking-wider text-white/40'>
@@ -170,7 +170,7 @@ export function ReleaseCountdown({
           </div>
         )}
         <div className='flex flex-col items-center'>
-          <span className='text-2xl font-bold tabular-nums text-white'>
+          <span className='text-2xl font-bold tabular-nums text-(--color-text-tooltip)'>
             {timeLeft.hours}
           </span>
           <span className='text-3xs uppercase tracking-wider text-white/40'>
@@ -178,7 +178,7 @@ export function ReleaseCountdown({
           </span>
         </div>
         <div className='flex flex-col items-center'>
-          <span className='text-2xl font-bold tabular-nums text-white'>
+          <span className='text-2xl font-bold tabular-nums text-(--color-text-tooltip)'>
             {timeLeft.minutes}
           </span>
           <span className='text-3xs uppercase tracking-wider text-white/40'>

--- a/apps/web/components/features/release/UnreleasedReleaseHero.tsx
+++ b/apps/web/components/features/release/UnreleasedReleaseHero.tsx
@@ -83,12 +83,12 @@ export function UnreleasedReleaseHero({
         returnLabel={`Back to ${artist.name}`}
         heroOverlay={
           <div className='absolute inset-x-0 bottom-5 z-10 px-5'>
-            <h1 className='text-3xl font-semibold leading-[1.06] tracking-[-0.02em] text-white [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
+            <h1 className='text-3xl font-semibold leading-[1.06] tracking-[-0.02em] text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
               {release.title}
             </h1>
             <Link
               href={`/${artist.handle}`}
-              className='mt-1 block text-sm font-[450] text-white/70 transition-colors hover:text-white/90 [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'
+              className='mt-1 block text-sm font-book text-white/70 transition-colors hover:text-white/90 [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'
             >
               {artist.name}
             </Link>

--- a/apps/web/components/features/release/VideoReleasePage.tsx
+++ b/apps/web/components/features/release/VideoReleasePage.tsx
@@ -85,12 +85,12 @@ export function VideoReleasePage({
       returnLabel={`Back to ${artist.name}`}
       heroOverlay={
         <div className='absolute inset-x-0 bottom-5 z-10 px-5'>
-          <h1 className='text-mid font-[510] leading-[1.2] tracking-[-0.01em] text-white [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
+          <h1 className='text-mid font-medium leading-[1.2] tracking-[-0.01em] text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
             {release.title}
           </h1>
           <Link
             href={`/${artist.handle}`}
-            className='mt-1 block text-app font-[450] text-white/70 transition-colors hover:text-white/90 [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'
+            className='mt-1 block text-app font-book text-white/70 transition-colors hover:text-white/90 [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'
           >
             {artist.name}
           </Link>
@@ -130,8 +130,8 @@ export function VideoReleasePage({
             href={youtubeUrl}
             target='_blank'
             rel='noopener noreferrer'
-            aria-label='Watch on YouTube (opens in new tab)'
-            className='inline-flex items-center gap-1.5 text-app font-[450] text-white/40 transition-colors hover:text-white/60'
+            aria-label='Watch On YouTube (Opens In New Tab)'
+            className='inline-flex items-center gap-1.5 text-app font-book text-white/40 transition-colors hover:text-white/60'
           >
             <ExternalLink className='size-3.5' />
             Watch on YouTube

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3448,
+  "count": 3443,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Tokenizes release smart-link font drift with exact aliases: `font-[680]` to `font-bold`, `font-[510]` to `font-medium`, and `font-[450]` to `font-book`.
- Replaces bare full-white release hero/countdown text with the exact `--color-text-tooltip` token used for white tooltip text.
- Fixes the non-visual video outbound aria-label casing required by focused lint.
- Lowers the arbitrary Tailwind ratchet baseline from `3448` to `3443`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/release/ReleaseCountdown.tsx apps/web/components/features/release/UnreleasedReleaseHero.tsx apps/web/components/features/release/VideoReleasePage.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/release/ReleaseCountdown.tsx apps/web/components/features/release/UnreleasedReleaseHero.tsx apps/web/components/features/release/VideoReleasePage.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied — `arbitrary-values-ratchet.test.ts` covers this drift reduction.
