### PR TITLE
fix(design-system): tokenize release route drift

### DIFF
--- a/apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx
+++ b/apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx
@@ -164,18 +164,18 @@ export function SoundsLandingPage({
       returnLabel={`Back to ${artist.name}`}
       heroOverlay={
         <div className='absolute inset-x-0 bottom-5 z-10 px-5'>
-          <h1 className='text-3xl font-semibold leading-[1.06] tracking-[-0.02em] text-white [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
+          <h1 className='text-3xl font-semibold leading-[1.06] tracking-[-0.02em] text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
             {release.title}
           </h1>
           {artist.handle ? (
             <Link
               href={`/${artist.handle}`}
-              className='mt-1 block text-sm font-[450] text-white/70 transition-colors hover:text-white/90 [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'
+              className='mt-1 block text-sm font-book text-white/70 transition-colors hover:text-white/90 [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'
             >
               {artist.name}
             </Link>
           ) : (
-            <p className='mt-1 text-sm font-[450] text-white/70 [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'>
+            <p className='mt-1 text-sm font-book text-white/70 [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'>
               {artist.name}
             </p>
           )}

--- a/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
+++ b/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
@@ -248,14 +248,14 @@ function SmartLinkArtistLine({
 
   if (!hasFeatured) {
     return (
-      <p className='mt-1 text-[14px] font-[450] [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'>
+      <p className='mt-1 text-[14px] font-book [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'>
         {primaryName}
       </p>
     );
   }
 
   return (
-    <p className='mt-1 text-[14px] font-[450] [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'>
+    <p className='mt-1 text-[14px] font-book [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'>
       {primaryName}
       <span className='text-white/40'> feat. </span>
       {featuredArtists.map((fa, i) => (
@@ -390,7 +390,7 @@ export function ReleaseLandingPage({
       heroOverlay={
         <div className='absolute inset-x-0 bottom-5 z-10 flex items-end justify-between px-5'>
           <div className='min-w-0 flex-1'>
-            <h1 className='text-[28px] font-semibold leading-[1.06] tracking-[-0.02em] text-white [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
+            <h1 className='text-[28px] font-semibold leading-[1.06] tracking-[-0.02em] text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
               {release.title}
             </h1>
             <SmartLinkArtistLine
@@ -459,7 +459,7 @@ export function ReleaseLandingPage({
                 {downloadUrl ? (
                   <Link
                     href={appendUTMParamsToUrl(downloadUrl, resolvedUtmParams)}
-                    className='inline-flex h-8 items-center justify-center rounded-full border border-white/10 bg-white/10 px-3 text-xs font-medium text-white transition-colors hover:bg-white/15'
+                    className='inline-flex h-8 items-center justify-center rounded-full border border-white/10 bg-white/10 px-3 text-xs font-medium text-(--color-text-tooltip) transition-colors hover:bg-white/15'
                   >
                     Download files
                   </Link>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3443,
+  "count": 3439,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Tokenizes release route artist-line font drift with the exact `font-[450]` to `font-book` alias.
- Replaces full-white release/sounds route text with exact `--color-text-tooltip` where focused lint requires tokenized white.
- Lowers the arbitrary Tailwind ratchet baseline from `3443` to `3439`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write 'apps/web/app/r/[slug]/ReleaseLandingPage.tsx' 'apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx' apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored 'apps/web/app/r/[slug]/ReleaseLandingPage.tsx' 'apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx'`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied — `arbitrary-values-ratchet.test.ts` covers this drift reduction.
