### PR TITLE
fix(design-system): tokenize marketing cta drift

### DIFF
--- a/apps/web/components/site/MarketingFinalCTA.tsx
+++ b/apps/web/components/site/MarketingFinalCTA.tsx
@@ -36,12 +36,12 @@ export function MarketingFinalCTA({
     <section
       data-testid={testId}
       className={cn(
-        'relative isolate overflow-hidden bg-black px-[clamp(1.25rem,2.2vw,2rem)] py-[clamp(5rem,9vw,8rem)] text-white',
+        'relative isolate overflow-hidden bg-black px-[clamp(1.25rem,2.2vw,2rem)] py-[clamp(5rem,9vw,8rem)] text-(--color-text-tooltip) dark:bg-black',
         className
       )}
     >
       <div className='relative z-[2] mx-auto flex w-full max-w-[var(--homepage-section-max,80rem)] flex-col items-center text-center'>
-        <h2 className='font-display max-w-[20ch] text-balance text-[clamp(2rem,3.4vw,3rem)] font-[680] leading-[1.05] tracking-[-0.025em] text-white'>
+        <h2 className='font-display max-w-[20ch] text-balance text-[clamp(2rem,3.4vw,3rem)] font-bold leading-[1.05] tracking-[-0.025em] text-(--color-text-tooltip)'>
           {title}
         </h2>
         {body ? (
@@ -53,7 +53,7 @@ export function MarketingFinalCTA({
           <Link
             href={ctaHref}
             prefetch={false}
-            className='inline-flex h-10 items-center rounded-full bg-(--color-text-tooltip) px-6 text-sm font-semibold tracking-[0.01em] text-black transition-opacity duration-subtle ease-subtle hover:opacity-92 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
+            className='inline-flex h-10 items-center rounded-full bg-(--color-text-tooltip) px-6 text-sm font-semibold tracking-[0.01em] text-black transition-opacity duration-subtle ease-subtle hover:opacity-92 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black dark:text-black'
           >
             {ctaLabel}
           </Link>

--- a/apps/web/components/site/MarketingFooterCta.tsx
+++ b/apps/web/components/site/MarketingFooterCta.tsx
@@ -45,7 +45,7 @@ export function MarketingFooterCta({
     <section
       data-testid='marketing-footer-cta'
       className={cn(
-        'homepage-story-final-cta relative isolate overflow-hidden bg-black',
+        'homepage-story-final-cta relative isolate overflow-hidden bg-black dark:bg-black',
         className
       )}
     >
@@ -101,7 +101,7 @@ export function MarketingFooterCta({
       </svg>
       <MarketingContainer width='page' className='relative z-10'>
         <div className='homepage-final-cta-copy mx-auto'>
-          <h2 className='text-balance text-[clamp(2rem,3.4vw,3rem)] font-[680] leading-[1.05] tracking-[-0.025em] text-white'>
+          <h2 className='text-balance text-[clamp(2rem,3.4vw,3rem)] font-bold leading-[1.05] tracking-[-0.025em] text-(--color-text-tooltip)'>
             {title}
           </h2>
           {body ? (

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3439,
+  "count": 3437,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Tokenizes marketing CTA headline weight drift with exact `font-[680]` to `font-bold` aliases.
- Replaces full-white CTA text with exact `--color-text-tooltip` and adds same-value dark black variants required by the color guard.
- Lowers the arbitrary Tailwind ratchet baseline from `3439` to `3437`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/site/MarketingFinalCTA.tsx apps/web/components/site/MarketingFooterCta.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/site/MarketingFinalCTA.tsx apps/web/components/site/MarketingFooterCta.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied — `arbitrary-values-ratchet.test.ts` covers this drift reduction.
