### PR TITLE
fix(design-system): tokenize playlist listing drift

### DIFF
--- a/apps/web/app/(dynamic)/playlists/genre/[genre]/page.tsx
+++ b/apps/web/app/(dynamic)/playlists/genre/[genre]/page.tsx
@@ -61,7 +61,7 @@ export default async function GenreHubPage({
 
   return (
     <div className='mx-auto max-w-6xl px-4 py-16'>
-      <nav className='mb-6 text-[13px] text-white/40'>
+      <nav className='mb-6 text-app text-white/40'>
         <Link href='/playlists' className='hover:text-white/60'>
           Playlists
         </Link>
@@ -71,7 +71,7 @@ export default async function GenreHubPage({
         </span>
       </nav>
 
-      <h1 className='text-[48px] font-[510] leading-[1.0] tracking-[-1.056px] text-white'>
+      <h1 className='text-5xl font-medium leading-none tracking-[-1.056px] text-(--color-text-tooltip)'>
         {decoded.charAt(0).toUpperCase() + decoded.slice(1)} Playlists
       </h1>
 

--- a/apps/web/app/(dynamic)/playlists/mood/[mood]/page.tsx
+++ b/apps/web/app/(dynamic)/playlists/mood/[mood]/page.tsx
@@ -55,7 +55,7 @@ export default async function MoodHubPage({
 
   return (
     <div className='mx-auto max-w-6xl px-4 py-16'>
-      <nav className='mb-6 text-[13px] text-white/40'>
+      <nav className='mb-6 text-app text-white/40'>
         <Link href='/playlists' className='hover:text-white/60'>
           Playlists
         </Link>
@@ -65,7 +65,7 @@ export default async function MoodHubPage({
         </span>
       </nav>
 
-      <h1 className='text-[48px] font-[510] leading-[1.0] tracking-[-1.056px] text-white'>
+      <h1 className='text-5xl font-medium leading-none tracking-[-1.056px] text-(--color-text-tooltip)'>
         {decoded.charAt(0).toUpperCase() + decoded.slice(1)} Playlists
       </h1>
 

--- a/apps/web/app/(dynamic)/playlists/page.tsx
+++ b/apps/web/app/(dynamic)/playlists/page.tsx
@@ -46,10 +46,10 @@ export default async function PlaylistsIndexPage() {
 
   return (
     <div className='mx-auto max-w-6xl px-4 py-16'>
-      <h1 className='text-[48px] font-[510] leading-[1.0] tracking-[-1.056px] text-white'>
+      <h1 className='text-5xl font-medium leading-none tracking-[-1.056px] text-(--color-text-tooltip)'>
         Playlists
       </h1>
-      <p className='mt-4 text-[15px] font-[400] leading-[1.6] tracking-[-0.165px] text-white/60'>
+      <p className='mt-4 text-mid font-normal leading-[1.6] tracking-[-0.165px] text-white/60'>
         Hyper-specific. Expertly curated. Featuring independent artists.
       </p>
 

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3426,
+  "count": 3413,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Tokenizes playlist listing typography drift with exact text/font/line-height aliases: 48px to `text-5xl`, 15px to `text-mid`, 13px to `text-app`, 510 to `font-medium`, 400 to `font-normal`, and 1.0 to `leading-none`.
- Replaces full-white playlist listing headings with exact `--color-text-tooltip`.
- Leaves the playlist detail Spotify green untouched because no exact `#1DB954` token exists.
- Lowers the arbitrary Tailwind ratchet baseline from `3426` to `3413`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write 'apps/web/app/(dynamic)/playlists/page.tsx' 'apps/web/app/(dynamic)/playlists/genre/[genre]/page.tsx' 'apps/web/app/(dynamic)/playlists/mood/[mood]/page.tsx' apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored 'apps/web/app/(dynamic)/playlists/page.tsx' 'apps/web/app/(dynamic)/playlists/genre/[genre]/page.tsx' 'apps/web/app/(dynamic)/playlists/mood/[mood]/page.tsx'`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied — `arbitrary-values-ratchet.test.ts` covers this drift reduction.
