### PR TITLE
fix(design-system): tokenize ui demo text drift

### DIFF
--- a/apps/web/app/ui/dialogs/page.tsx
+++ b/apps/web/app/ui/dialogs/page.tsx
@@ -48,7 +48,7 @@ export default function DialogsPage() {
   return (
     <div>
       <h1 className='mb-1 text-lg font-semibold text-primary-token'>Dialog</h1>
-      <p className='mb-8 text-[13px] text-tertiary-token'>
+      <p className='mb-8 text-app text-tertiary-token'>
         Matches Linear.app — semi-transparent overlay, elevated surface, 8px
         radius, Linear typography
       </p>
@@ -159,7 +159,7 @@ export default function DialogsPage() {
                 <div className='flex flex-col gap-1.5'>
                   <label
                     htmlFor='issue-title'
-                    className='text-[13px] font-book text-primary-token'
+                    className='text-app font-book text-primary-token'
                   >
                     Title
                   </label>
@@ -167,13 +167,13 @@ export default function DialogsPage() {
                     id='issue-title'
                     type='text'
                     placeholder='Issue title'
-                    className='h-8 w-full rounded-(--linear-radius-md) border border-subtle bg-surface-1 px-3 text-[13px] text-primary-token outline-none transition-colors focus:border-(--linear-border-focus)'
+                    className='h-8 w-full rounded-(--linear-radius-md) border border-subtle bg-surface-1 px-3 text-app text-primary-token outline-none transition-colors focus:border-(--linear-border-focus)'
                   />
                 </div>
                 <div className='flex flex-col gap-1.5'>
                   <label
                     htmlFor='issue-description'
-                    className='text-[13px] font-book text-primary-token'
+                    className='text-app font-book text-primary-token'
                   >
                     Description
                   </label>
@@ -181,7 +181,7 @@ export default function DialogsPage() {
                     id='issue-description'
                     placeholder='Add a description...'
                     rows={3}
-                    className='w-full resize-none rounded-(--linear-radius-md) border border-subtle bg-surface-1 px-3 py-2 text-[13px] text-primary-token outline-none transition-colors focus:border-(--linear-border-focus)'
+                    className='w-full resize-none rounded-(--linear-radius-md) border border-subtle bg-surface-1 px-3 py-2 text-app text-primary-token outline-none transition-colors focus:border-(--linear-border-focus)'
                   />
                 </div>
               </div>
@@ -209,7 +209,7 @@ export default function DialogsPage() {
                   type='text'
                   defaultValue='My Project'
                   aria-label='Project Name'
-                  className='h-8 w-full rounded-(--linear-radius-md) border border-subtle bg-surface-1 px-3 text-[13px] text-primary-token outline-none transition-colors focus:border-(--linear-border-focus)'
+                  className='h-8 w-full rounded-(--linear-radius-md) border border-subtle bg-surface-1 px-3 text-app text-primary-token outline-none transition-colors focus:border-(--linear-border-focus)'
                 />
               </div>
               <DialogFooter>

--- a/apps/web/app/ui/selects/page.tsx
+++ b/apps/web/app/ui/selects/page.tsx
@@ -44,7 +44,7 @@ export default function SelectsPage() {
   return (
     <div>
       <h1 className='mb-1 text-lg font-semibold text-primary-token'>Select</h1>
-      <p className='mb-8 text-[13px] text-tertiary-token'>
+      <p className='mb-8 text-app text-tertiary-token'>
         Matches Linear.app — 32px trigger height, 6px radius, shared dropdown
         content styles
       </p>
@@ -145,7 +145,7 @@ export default function SelectsPage() {
         <Stack title='Assignee'>
           <p
             id='label-assignee'
-            className='text-[13px] font-book text-primary-token'
+            className='text-app font-book text-primary-token'
           >
             Assignee
           </p>
@@ -163,7 +163,7 @@ export default function SelectsPage() {
         <Stack title='Priority'>
           <p
             id='label-priority'
-            className='text-[13px] font-book text-primary-token'
+            className='text-app font-book text-primary-token'
           >
             Priority
           </p>
@@ -182,7 +182,7 @@ export default function SelectsPage() {
         <Stack title='Status'>
           <p
             id='label-status'
-            className='text-[13px] font-book text-primary-token'
+            className='text-app font-book text-primary-token'
           >
             Status
           </p>

--- a/apps/web/app/ui/switches/page.tsx
+++ b/apps/web/app/ui/switches/page.tsx
@@ -36,7 +36,7 @@ export default function SwitchesPage() {
   return (
     <div>
       <h1 className='mb-1 text-lg font-semibold text-primary-token'>Switch</h1>
-      <p className='mb-8 text-[13px] text-tertiary-token'>
+      <p className='mb-8 text-app text-tertiary-token'>
         Matches Linear.app toggle — compact 28×16px track, smooth thumb
         transition
       </p>
@@ -68,7 +68,7 @@ export default function SwitchesPage() {
             <Switch id='notifications' aria-label='Enable Notifications' />
             <label
               htmlFor='notifications'
-              className='text-[13px] font-medium text-primary-token'
+              className='text-app font-medium text-primary-token'
             >
               Enable notifications
             </label>
@@ -83,7 +83,7 @@ export default function SwitchesPage() {
             />
             <label
               htmlFor='auto-assign'
-              className='text-[13px] font-medium text-primary-token'
+              className='text-app font-medium text-primary-token'
             >
               Auto-assign issues
             </label>
@@ -98,7 +98,7 @@ export default function SwitchesPage() {
             />
             <label
               htmlFor='disabled-setting'
-              className='text-[13px] font-medium text-primary-token opacity-50'
+              className='text-app font-medium text-primary-token opacity-50'
             >
               Disabled setting
             </label>
@@ -121,7 +121,7 @@ export default function SwitchesPage() {
               >
                 <label
                   htmlFor={`setting-${item.label}`}
-                  className='text-[13px] font-book text-primary-token'
+                  className='text-app font-book text-primary-token'
                 >
                   {item.label}
                 </label>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3413,
+  "count": 3398,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Tokenizes UI demo typography drift with exact `text-[13px]` to `text-app` aliases in dialogs, selects, and switches examples.
- Keeps the change to lint-clean UI demo surfaces only.
- Lowers the arbitrary Tailwind ratchet baseline from `3413` to `3398`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/ui/dialogs/page.tsx apps/web/app/ui/selects/page.tsx apps/web/app/ui/switches/page.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/app/ui/dialogs/page.tsx apps/web/app/ui/selects/page.tsx apps/web/app/ui/switches/page.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied — `arbitrary-values-ratchet.test.ts` covers this drift reduction.
