### PR TITLE
fix(design-system): tokenize app text drift

### DIFF
--- a/apps/web/app/hud-tv/page.tsx
+++ b/apps/web/app/hud-tv/page.tsx
@@ -93,9 +93,7 @@ export default async function HudTvPage({
           />
 
           <div className='space-y-4 px-5 py-5 sm:px-6'>
-            <p className='text-[13px] leading-6 text-secondary-token'>
-              {message}
-            </p>
+            <p className='text-app leading-6 text-secondary-token'>{message}</p>
             <div className='rounded-[12px] border border-subtle bg-surface-0 px-4 py-3 text-[12px] leading-5 text-tertiary-token'>
               Tip: open{' '}
               <span className='font-mono text-[11px] text-primary-token'>

--- a/apps/web/app/out/[id]/InterstitialClient.tsx
+++ b/apps/web/app/out/[id]/InterstitialClient.tsx
@@ -68,7 +68,7 @@ export function InterstitialClient({
         <div className='mx-auto flex h-16 w-16 items-center justify-center rounded-full border border-success/20 bg-success-subtle'>
           <CheckCircle2 className='h-6 w-6 text-success' aria-hidden='true' />
         </div>
-        <p className='text-[13px] font-semibold text-primary-token'>
+        <p className='text-app font-semibold text-primary-token'>
           Verified. Redirecting...
         </p>
       </div>
@@ -78,7 +78,7 @@ export function InterstitialClient({
   return (
     <div className='space-y-4'>
       <noscript>
-        <p className='mb-4 text-[13px] text-error'>
+        <p className='mb-4 text-app text-error'>
           JavaScript is required to continue to this link.
         </p>
       </noscript>
@@ -87,7 +87,7 @@ export function InterstitialClient({
         <p className='text-[11px] uppercase tracking-[0.14em] text-tertiary-token'>
           Destination
         </p>
-        <p className='text-[13px] font-semibold text-primary-token'>
+        <p className='text-app font-semibold text-primary-token'>
           {titleAlias}
         </p>
         {domain === 'External Site' ? null : (
@@ -102,7 +102,7 @@ export function InterstitialClient({
           aria-live='assertive'
           className='border-error/20 bg-error-subtle p-4'
         >
-          <p className='text-[13px] text-primary-token'>{error}</p>
+          <p className='text-app text-primary-token'>{error}</p>
         </ContentSurfaceCard>
       ) : null}
 

--- a/apps/web/app/out/[id]/page.tsx
+++ b/apps/web/app/out/[id]/page.tsx
@@ -54,13 +54,13 @@ function MissingLinkState() {
             />
           </div>
 
-          <p className='text-[13px] leading-5 text-tertiary-token'>
+          <p className='text-app leading-5 text-tertiary-token'>
             Check the URL or ask the sender for a fresh link.
           </p>
 
           <Link
             href='/'
-            className='inline-flex h-9 items-center justify-center rounded-lg bg-btn-primary px-4 text-[13px] font-medium text-btn-primary-foreground transition-colors duration-100 hover:bg-btn-primary-hover'
+            className='inline-flex h-9 items-center justify-center rounded-lg bg-btn-primary px-4 text-app font-medium text-btn-primary-foreground transition-colors duration-100 hover:bg-btn-primary-hover'
           >
             Return Home
           </Link>

--- a/apps/web/app/sandbox/page.tsx
+++ b/apps/web/app/sandbox/page.tsx
@@ -26,7 +26,7 @@ export default function SandboxPage() {
           <div className='grid grid-cols-1 gap-3 p-3 pt-0 sm:grid-cols-2 sm:p-4 sm:pt-0'>
             <ContentSurfaceCard surface='nested' className='space-y-4 p-4'>
               <div className='space-y-1'>
-                <h2 className='text-[13px] font-semibold text-primary-token'>
+                <h2 className='text-app font-semibold text-primary-token'>
                   Buttons
                 </h2>
                 <p className='text-[12px] text-secondary-token'>
@@ -42,7 +42,7 @@ export default function SandboxPage() {
 
             <ContentSurfaceCard surface='nested' className='space-y-4 p-4'>
               <div className='space-y-1'>
-                <h2 className='text-[13px] font-semibold text-primary-token'>
+                <h2 className='text-app font-semibold text-primary-token'>
                   Inputs
                 </h2>
                 <p className='text-[12px] text-secondary-token'>

--- a/apps/web/app/sentry-example-page/SentryExamplePageClient.tsx
+++ b/apps/web/app/sentry-example-page/SentryExamplePageClient.tsx
@@ -44,7 +44,7 @@ export function SentryExamplePageClient() {
 
         <div className='space-y-5 px-5 py-5 text-center sm:px-6'>
           <div className='space-y-3'>
-            <p className='text-[13px] leading-6 text-secondary-token'>
+            <p className='text-app leading-6 text-secondary-token'>
               Click the button below, then confirm the sample error on the{' '}
               <a
                 target='_blank'
@@ -99,7 +99,7 @@ export function SentryExamplePageClient() {
               surface='nested'
               className='border-[color-mix(in_oklab,var(--linear-success)_30%,var(--linear-app-frame-seam))] bg-[color-mix(in_oklab,var(--linear-success)_10%,var(--linear-app-content-surface))] p-4'
             >
-              <div className='flex items-center justify-center gap-2 text-[13px] font-semibold text-primary-token'>
+              <div className='flex items-center justify-center gap-2 text-app font-semibold text-primary-token'>
                 <CheckCircle2 className='h-4 w-4 text-[var(--linear-success)]' />
                 Error sent to Sentry.
               </div>
@@ -112,11 +112,11 @@ export function SentryExamplePageClient() {
               className='border-[color-mix(in_oklab,var(--linear-warning)_30%,var(--linear-app-frame-seam))] bg-[color-mix(in_oklab,var(--linear-warning)_10%,var(--linear-app-content-surface))] p-4'
             >
               <div className='space-y-2 text-center'>
-                <div className='flex items-center justify-center gap-2 text-[13px] font-semibold text-primary-token'>
+                <div className='flex items-center justify-center gap-2 text-app font-semibold text-primary-token'>
                   <TriangleAlert className='h-4 w-4 text-[var(--linear-warning)]' />
                   Sentry connectivity looks blocked.
                 </div>
-                <p className='text-[13px] leading-5 text-secondary-token'>
+                <p className='text-app leading-5 text-secondary-token'>
                   Network requests to Sentry may be blocked by an ad blocker or
                   local filtering rule.
                 </p>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3398,
+  "count": 3385,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Tokenizes app utility/demo text drift with exact `text-[13px]` to `text-app` aliases.
- Keeps the change to lint-clean app surfaces only.
- Lowers the arbitrary Tailwind ratchet baseline from `3398` to `3385`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/sandbox/page.tsx apps/web/app/hud-tv/page.tsx apps/web/app/sentry-example-page/SentryExamplePageClient.tsx apps/web/app/out/[id]/page.tsx apps/web/app/out/[id]/InterstitialClient.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/app/sandbox/page.tsx apps/web/app/hud-tv/page.tsx apps/web/app/sentry-example-page/SentryExamplePageClient.tsx apps/web/app/out/[id]/page.tsx apps/web/app/out/[id]/InterstitialClient.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied - `arbitrary-values-ratchet.test.ts` covers this drift reduction.