### PR TITLE
fix(design-system): tokenize tracking drift

### DIFF
--- a/apps/web/app/exp/onboarding-v1/page.tsx
+++ b/apps/web/app/exp/onboarding-v1/page.tsx
@@ -756,7 +756,7 @@ function SidebarShim({
     >
       <div className='flex items-center gap-2.5 h-7 pl-3 pr-2'>
         <JovieMark className='h-4 w-4 shrink-0 text-primary-token' />
-        <span className='text-app font-semibold tracking-[-0.02em] text-primary-token'>
+        <span className='text-app font-semibold tracking-tighter text-primary-token'>
           Jovie
         </span>
       </div>
@@ -834,7 +834,7 @@ function ReadyCard({ handle }: { handle: string }) {
         <Sparkles className='h-3 w-3' strokeWidth={2.5} />
         Welcome home
       </div>
-      <h3 className='mt-2 text-lg font-display tracking-[-0.02em] text-primary-token'>
+      <h3 className='mt-2 text-lg font-display tracking-tighter text-primary-token'>
         jov.ie/{name} is live.
       </h3>
       <p className='mt-2 text-app text-secondary-token leading-[1.55]'>
@@ -862,7 +862,7 @@ function WaitlistCard() {
       <div className='flex items-center gap-2 text-3xs uppercase tracking-[0.12em] text-amber-300/90 font-medium'>
         Saved for later
       </div>
-      <h3 className='mt-2 text-lg font-display tracking-[-0.02em] text-primary-token'>
+      <h3 className='mt-2 text-lg font-display tracking-tighter text-primary-token'>
         On the early-access list.
       </h3>
       <p className='mt-2 text-app text-secondary-token leading-[1.55]'>

--- a/apps/web/app/exp/shell-v1/page.tsx
+++ b/apps/web/app/exp/shell-v1/page.tsx
@@ -3179,7 +3179,7 @@ function Sidebar({
                   className='shrink-0 text-primary-token'
                   aria-hidden
                 />
-                <span className='text-app font-semibold tracking-[-0.02em] text-primary-token flex-1 truncate'>
+                <span className='text-app font-semibold tracking-tighter text-primary-token flex-1 truncate'>
                   Jovie
                 </span>
                 <ChevronDown
@@ -5085,7 +5085,7 @@ function ReleaseRow({
       {/* Title (with type badge) / artist */}
       <div className='min-w-0'>
         <div className='flex items-center gap-1.5 min-w-0'>
-          <span className='truncate text-app font-caption leading-tight tracking-[-0.01em] text-primary-token'>
+          <span className='truncate text-app font-caption leading-tight tracking-tight text-primary-token'>
             {release.title}
           </span>
           <TypeBadge label={release.type} />
@@ -6281,7 +6281,7 @@ function TrackRow({
       </div>
 
       {/* BPM — heavier weight, monochrome, right-aligned */}
-      <span className='w-11 shrink-0 text-right text-xs tabular-nums font-semibold text-secondary-token tracking-[-0.01em]'>
+      <span className='w-11 shrink-0 text-right text-xs tabular-nums font-semibold text-secondary-token tracking-tight'>
         {track.bpm}
       </span>
 
@@ -6727,7 +6727,7 @@ function TaskDetail({
     : null;
   return (
     <article className='max-w-3xl mx-auto px-8 pt-8 pb-12'>
-      <h1 className='text-2xl font-display tracking-[-0.02em] text-primary-token leading-tight'>
+      <h1 className='text-2xl font-display tracking-tighter text-primary-token leading-tight'>
         {onOpenRelease
           ? renderWithEntities(task.title, RELEASES, onOpenRelease)
           : task.title}

--- a/apps/web/components/features/admin/KpiCards.tsx
+++ b/apps/web/components/features/admin/KpiCards.tsx
@@ -27,7 +27,7 @@ interface KpiCardsProps {
 function UnavailableBadge({ message }: Readonly<{ message?: string }>) {
   return (
     <span
-      className='inline-flex min-h-6 items-center gap-1 rounded bg-warning/10 px-1.5 py-0.5 text-2xs font-medium tracking-[-0.01em] text-warning'
+      className='inline-flex min-h-6 items-center gap-1 rounded bg-warning/10 px-1.5 py-0.5 text-2xs font-medium tracking-tight text-warning'
       title={message ?? 'Data source unavailable'}
     >
       <AlertTriangle className='size-3' aria-hidden='true' />
@@ -42,7 +42,7 @@ function UnavailableBadge({ message }: Readonly<{ message?: string }>) {
 function NotConfiguredBadge({ message }: Readonly<{ message?: string }>) {
   return (
     <span
-      className='inline-flex min-h-6 items-center gap-1 rounded bg-surface-0 px-1.5 py-0.5 text-2xs font-medium tracking-[-0.01em] text-tertiary-token'
+      className='inline-flex min-h-6 items-center gap-1 rounded bg-surface-0 px-1.5 py-0.5 text-2xs font-medium tracking-tight text-tertiary-token'
       title={message ?? 'Data source not configured'}
     >
       <span className='max-sm:hidden truncate max-w-[10rem] sm:inline'>

--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -94,21 +94,21 @@ function BreadcrumbTrail({
   return (
     <>
       {usesSectionTitleLayout ? (
-        <span className='truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'>
+        <span className='truncate text-xs font-semibold tracking-tight text-primary-token'>
           {currentLabel}
         </span>
       ) : (
         <>
-          <span className='shrink-0 text-2xs font-caption tracking-[-0.01em] text-tertiary-token'>
+          <span className='shrink-0 text-2xs font-caption tracking-tight text-tertiary-token'>
             {rootLabel}
           </span>
           <ChevronRight className='size-3 shrink-0 text-quaternary-token/85' />
           {breadcrumbSuffix ? (
-            <div className='min-w-0 truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'>
+            <div className='min-w-0 truncate text-xs font-semibold tracking-tight text-primary-token'>
               {breadcrumbSuffix}
             </div>
           ) : (
-            <span className='truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'>
+            <span className='truncate text-xs font-semibold tracking-tight text-primary-token'>
               {currentLabel}
             </span>
           )}

--- a/apps/web/components/features/dashboard/organisms/ProfileEditPreviewCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/ProfileEditPreviewCard.tsx
@@ -118,12 +118,12 @@ export function ProfileEditPreviewCard({
       <ContentSurfaceCard className='p-3'>
         <div className='flex items-center justify-between gap-2'>
           <div className='min-w-0 space-y-0.5'>
-            <p className='truncate text-app font-semibold tracking-[-0.01em] text-primary-token'>
+            <p className='truncate text-app font-semibold tracking-tight text-primary-token'>
               {preview.fieldLabel}
             </p>
             <p className='text-xs text-secondary-token'>Updated</p>
           </div>
-          <span className='inline-flex shrink-0 items-center gap-1 rounded-md border border-subtle bg-surface-1 px-1.5 py-0.5 text-2xs font-caption tracking-[-0.01em] text-success'>
+          <span className='inline-flex shrink-0 items-center gap-1 rounded-md border border-subtle bg-surface-1 px-1.5 py-0.5 text-2xs font-caption tracking-tight text-success'>
             <Check className='h-3.5 w-3.5' />
             Applied
           </span>
@@ -138,12 +138,12 @@ export function ProfileEditPreviewCard({
       <ContentSurfaceCard className='p-3 opacity-70'>
         <div className='flex items-center justify-between gap-2'>
           <div className='min-w-0 space-y-0.5'>
-            <p className='truncate text-app font-semibold tracking-[-0.01em] text-primary-token'>
+            <p className='truncate text-app font-semibold tracking-tight text-primary-token'>
               {preview.fieldLabel}
             </p>
             <p className='text-xs text-secondary-token'>Edit cancelled</p>
           </div>
-          <span className='inline-flex shrink-0 items-center gap-1 rounded-md bg-surface-0 px-1.5 py-0.5 text-2xs font-caption tracking-[-0.01em] text-secondary-token'>
+          <span className='inline-flex shrink-0 items-center gap-1 rounded-md bg-surface-0 px-1.5 py-0.5 text-2xs font-caption tracking-tight text-secondary-token'>
             <X className='h-3.5 w-3.5' />
             Cancelled
           </span>
@@ -156,7 +156,7 @@ export function ProfileEditPreviewCard({
     <ContentSurfaceCard className='overflow-hidden'>
       <div className='px-3 py-2'>
         <div className='space-y-0.5'>
-          <h4 className='text-app font-semibold tracking-[-0.01em] text-primary-token'>
+          <h4 className='text-app font-semibold tracking-tight text-primary-token'>
             Update {preview.fieldLabel}
           </h4>
           {preview.reason && (
@@ -194,7 +194,7 @@ export function ProfileEditPreviewCard({
           </div>
           <div
             className={cn(
-              'text-app tracking-[-0.01em] text-primary-token',
+              'text-app tracking-tight text-primary-token',
               !preview.currentValue && 'italic text-tertiary-token'
             )}
           >
@@ -205,7 +205,7 @@ export function ProfileEditPreviewCard({
           <div className='mb-0.5 text-app font-caption tracking-normal text-(--linear-accent)'>
             New
           </div>
-          <div className='text-app tracking-[-0.01em] text-primary-token'>
+          <div className='text-app tracking-tight text-primary-token'>
             {formatValue(resolvedNewValue)}
           </div>
         </div>

--- a/apps/web/components/features/dashboard/organisms/dashboard-activity-feed/DashboardActivityFeed.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-activity-feed/DashboardActivityFeed.tsx
@@ -83,7 +83,7 @@ const ActivityItem = memo(function ActivityItem({
         <ActivityGlyph icon={activity.icon} />
       </span>
       <div className='min-w-0 flex-1'>
-        <p className='text-app leading-5 tracking-[-0.01em] text-secondary-token'>
+        <p className='text-app leading-5 tracking-tight text-secondary-token'>
           <span className='tabular-nums text-tertiary-token'>
             {formatTimeAgo(activity.timestamp)}
           </span>
@@ -147,7 +147,7 @@ export function DashboardActivityFeed({
           <div className='flex h-6 w-6 items-center justify-center rounded-full bg-surface-0'>
             <Zap className='h-4 w-4 text-tertiary-token' aria-hidden='true' />
           </div>
-          <h3 className='text-app font-caption tracking-[-0.01em] text-secondary-token'>
+          <h3 className='text-app font-caption tracking-tight text-secondary-token'>
             Activity
           </h3>
         </div>

--- a/apps/web/components/organisms/footer-module/Footer.tsx
+++ b/apps/web/components/organisms/footer-module/Footer.tsx
@@ -180,7 +180,7 @@ export function Footer({
                 <Link
                   href={APP_ROUTES.LEGAL_PRIVACY}
                   prefetch={false}
-                  className='text-app tracking-[-0.01em] transition-colors duration-subtle hover:[color:var(--linear-text-primary)]'
+                  className='text-app tracking-tight transition-colors duration-subtle hover:[color:var(--linear-text-primary)]'
                   style={{ color: 'var(--linear-text-tertiary)' }}
                 >
                   Privacy
@@ -188,7 +188,7 @@ export function Footer({
                 <Link
                   href={APP_ROUTES.LEGAL_TERMS}
                   prefetch={false}
-                  className='text-app tracking-[-0.01em] transition-colors duration-subtle hover:[color:var(--linear-text-primary)]'
+                  className='text-app tracking-tight transition-colors duration-subtle hover:[color:var(--linear-text-primary)]'
                   style={{ color: 'var(--linear-text-tertiary)' }}
                 >
                   Terms
@@ -196,7 +196,7 @@ export function Footer({
               </div>
               <Copyright
                 variant='light'
-                className='text-2xs leading-[16px] font-normal tracking-[-0.01em] opacity-100'
+                className='text-2xs leading-[16px] font-normal tracking-tight opacity-100'
                 style={{
                   color: 'var(--linear-text-tertiary)',
                 }}
@@ -243,7 +243,7 @@ export function Footer({
                       key={link.href}
                       href={link.href}
                       prefetch={false}
-                      className='text-app leading-[19.5px] font-normal tracking-[-0.01em] transition-colors duration-subtle hover:[color:var(--linear-text-secondary)]'
+                      className='text-app leading-[19.5px] font-normal tracking-tight transition-colors duration-subtle hover:[color:var(--linear-text-secondary)]'
                       style={{ color: 'var(--linear-text-tertiary)' }}
                     >
                       {link.label}
@@ -254,7 +254,7 @@ export function Footer({
             </div>
             <Copyright
               variant={config.colorVariant}
-              className='text-2xs leading-[16px] font-normal tracking-[-0.01em] opacity-100'
+              className='text-2xs leading-[16px] font-normal tracking-tight opacity-100'
               style={{
                 color: 'var(--linear-text-tertiary)',
               }}

--- a/apps/web/components/organisms/footer-module/config.ts
+++ b/apps/web/components/organisms/footer-module/config.ts
@@ -67,7 +67,7 @@ export function getVariantConfigs(
 
 export const FOOTER_LINK_CLASS_NAME = cn(
   'inline-flex h-7 items-center',
-  'text-app leading-[19.5px] font-normal tracking-[-0.01em]',
+  'text-app leading-[19.5px] font-normal tracking-tight',
   'transition-colors duration-100',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interactive focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
 );
@@ -82,7 +82,7 @@ export const FOOTER_LINK_HOVER_CLASS =
 
 // Linear: 13px, weight 510, normal case, line-height 19.5px, tracking -0.01em, mb 24px
 export const SECTION_HEADING_CLASS_NAME =
-  'mb-5 text-app font-semibold leading-[19.5px] tracking-[-0.01em]';
+  'mb-5 text-app font-semibold leading-[19.5px] tracking-tight';
 
 // Linear-aligned: headings are PRIMARY (white), links are muted
 export const SECTION_HEADING_STYLE = {

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3385,
+  "count": 3356,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaces exact `tracking-[-0.01em]` aliases with `tracking-tight` and exact `tracking-[-0.02em]` aliases with `tracking-tighter` in lint-clean dashboard, footer, admin KPI, and experiment surfaces.
- Keeps the slice to mechanical tracking-token aliases only.
- Lowers the arbitrary Tailwind ratchet baseline from `3385` to `3356`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/dashboard/organisms/ProfileEditPreviewCard.tsx apps/web/components/organisms/footer-module/Footer.tsx apps/web/components/organisms/footer-module/config.ts apps/web/components/features/dashboard/organisms/DashboardHeader.tsx apps/web/components/features/dashboard/organisms/dashboard-activity-feed/DashboardActivityFeed.tsx apps/web/components/features/admin/KpiCards.tsx apps/web/app/exp/shell-v1/page.tsx apps/web/app/exp/onboarding-v1/page.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/features/dashboard/organisms/ProfileEditPreviewCard.tsx apps/web/components/organisms/footer-module/Footer.tsx apps/web/components/organisms/footer-module/config.ts apps/web/components/features/dashboard/organisms/DashboardHeader.tsx apps/web/components/features/dashboard/organisms/dashboard-activity-feed/DashboardActivityFeed.tsx apps/web/components/features/admin/KpiCards.tsx apps/web/app/exp/shell-v1/page.tsx apps/web/app/exp/onboarding-v1/page.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied - `arbitrary-values-ratchet.test.ts` covers this drift reduction.