### PR TITLE
fix(design-system): tokenize ui reference text drift

### DIFF
--- a/apps/web/app/ui/avatars/page.tsx
+++ b/apps/web/app/ui/avatars/page.tsx
@@ -16,7 +16,7 @@ function Section({
 }) {
   return (
     <div className='mb-10'>
-      <h2 className='mb-4 text-[11px] font-semibold uppercase tracking-wider text-tertiary-token'>
+      <h2 className='mb-4 text-2xs font-semibold uppercase tracking-wider text-tertiary-token'>
         {title}
       </h2>
       <div className='flex flex-wrap items-end gap-6'>{children}</div>
@@ -34,7 +34,7 @@ function Stack({
   return (
     <div className='flex flex-col items-center gap-2'>
       <div>{children}</div>
-      <span className='text-[11px] text-tertiary-token'>{title}</span>
+      <span className='text-2xs text-tertiary-token'>{title}</span>
     </div>
   );
 }
@@ -43,7 +43,7 @@ export default function AvatarsPage() {
   return (
     <div>
       <h1 className='mb-1 text-lg font-semibold text-primary-token'>Avatar</h1>
-      <p className='mb-8 text-[13px] text-tertiary-token'>
+      <p className='mb-8 text-app text-tertiary-token'>
         Matches Linear.app — circular, 5 sizes, image+fallback, status dot
       </p>
 

--- a/apps/web/app/ui/dialogs/page.tsx
+++ b/apps/web/app/ui/dialogs/page.tsx
@@ -21,7 +21,7 @@ function Section({
 }) {
   return (
     <div className='mb-10'>
-      <h2 className='mb-4 text-[11px] font-semibold uppercase tracking-wider text-tertiary-token'>
+      <h2 className='mb-4 text-2xs font-semibold uppercase tracking-wider text-tertiary-token'>
         {title}
       </h2>
       <div className='flex flex-wrap items-start gap-6'>{children}</div>
@@ -38,7 +38,7 @@ function Stack({
 }) {
   return (
     <div className='flex flex-col gap-2'>
-      <span className='text-[11px] text-tertiary-token'>{title}</span>
+      <span className='text-2xs text-tertiary-token'>{title}</span>
       {children}
     </div>
   );

--- a/apps/web/app/ui/layout.tsx
+++ b/apps/web/app/ui/layout.tsx
@@ -40,24 +40,24 @@ export default function UILayout({
       <div className='flex h-screen bg-page text-primary-token'>
         <aside className='sticky top-0 flex h-screen w-52 shrink-0 flex-col overflow-y-auto border-r border-subtle py-6'>
           <div className='px-4 pb-4'>
-            <span className='text-[11px] font-semibold uppercase tracking-wider text-tertiary-token'>
+            <span className='text-2xs font-semibold uppercase tracking-wider text-tertiary-token'>
               UI Demo
             </span>
-            <p className='mt-0.5 text-[11px] text-tertiary-token'>
+            <p className='mt-0.5 text-2xs text-tertiary-token'>
               Linear parity review
             </p>
           </div>
 
           {NAV_ITEMS.map(group => (
             <div key={group.label} className='px-2'>
-              <p className='px-2 pb-1 pt-3 text-[10px] font-semibold uppercase tracking-wider text-tertiary-token'>
+              <p className='px-2 pb-1 pt-3 text-3xs font-semibold uppercase tracking-wider text-tertiary-token'>
                 {group.label}
               </p>
               {group.items.map(item => (
                 <Link
                   key={item.href}
                   href={item.href}
-                  className='flex items-center justify-between rounded px-2 py-1.5 text-[13px] transition-colors hover:bg-surface-1 text-tertiary-token data-[status=done]:text-primary-token'
+                  className='flex items-center justify-between rounded px-2 py-1.5 text-app transition-colors hover:bg-surface-1 text-tertiary-token data-[status=done]:text-primary-token'
                   data-status={item.status}
                 >
                   {item.label}

--- a/apps/web/app/ui/parallax/page.tsx
+++ b/apps/web/app/ui/parallax/page.tsx
@@ -37,7 +37,7 @@ export default function ParallaxPage() {
       <h1 className='mb-1 text-lg font-semibold text-primary-token'>
         Zoom Parallax
       </h1>
-      <p className='mb-8 text-[13px] text-tertiary-token'>
+      <p className='mb-8 text-app text-tertiary-token'>
         Scroll-driven image collage powered by a lightweight DOM animation loop
         and Next.js image optimization.
       </p>

--- a/apps/web/app/ui/selects/page.tsx
+++ b/apps/web/app/ui/selects/page.tsx
@@ -17,7 +17,7 @@ function Section({
 }) {
   return (
     <div className='mb-10'>
-      <h2 className='mb-4 text-[11px] font-semibold uppercase tracking-wider text-tertiary-token'>
+      <h2 className='mb-4 text-2xs font-semibold uppercase tracking-wider text-tertiary-token'>
         {title}
       </h2>
       <div className='flex flex-wrap items-start gap-6'>{children}</div>
@@ -34,7 +34,7 @@ function Stack({
 }) {
   return (
     <div className='flex flex-col gap-2'>
-      <span className='text-[11px] text-tertiary-token'>{title}</span>
+      <span className='text-2xs text-tertiary-token'>{title}</span>
       {children}
     </div>
   );

--- a/apps/web/app/ui/switches/page.tsx
+++ b/apps/web/app/ui/switches/page.tsx
@@ -9,7 +9,7 @@ function Section({
 }) {
   return (
     <div className='mb-10'>
-      <h2 className='mb-4 text-[11px] font-semibold uppercase tracking-wider text-tertiary-token'>
+      <h2 className='mb-4 text-2xs font-semibold uppercase tracking-wider text-tertiary-token'>
         {title}
       </h2>
       <div className='flex flex-wrap items-start gap-6'>{children}</div>
@@ -26,7 +26,7 @@ function Stack({
 }) {
   return (
     <div className='flex flex-col gap-2'>
-      <span className='text-[11px] text-tertiary-token'>{title}</span>
+      <span className='text-2xs text-tertiary-token'>{title}</span>
       {children}
     </div>
   );

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3356,
+  "count": 3342,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaces exact UI reference text scale aliases with `text-3xs`, `text-2xs`, and `text-app` in lint-clean UI catalog pages.
- Leaves UI catalog pages with existing title-case lint debt untouched.
- Lowers the arbitrary Tailwind ratchet baseline from `3356` to `3342`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/ui/avatars/page.tsx apps/web/app/ui/layout.tsx apps/web/app/ui/dialogs/page.tsx apps/web/app/ui/selects/page.tsx apps/web/app/ui/switches/page.tsx apps/web/app/ui/parallax/page.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/app/ui/avatars/page.tsx apps/web/app/ui/layout.tsx apps/web/app/ui/dialogs/page.tsx apps/web/app/ui/selects/page.tsx apps/web/app/ui/switches/page.tsx apps/web/app/ui/parallax/page.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied - `arbitrary-values-ratchet.test.ts` covers this drift reduction.