### PR TITLE
feat(web): default feature flags on

### DIFF
--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -401,12 +401,8 @@ export function ProfileCompactSurface({
   const heroHeightClassName = isHomeMode
     ? 'min-h-[var(--cover-height)] flex-1 [@media(max-height:760px)]:flex-none [@media(max-height:760px)]:h-45 [@media(max-height:760px)]:max-h-45'
     : 'h-[calc(3.5rem+max(env(safe-area-inset-top),0px))] border-b border-white/[0.075]';
-  const homeContentColumnClassName = isHomeMode
-    ? 'shrink-0 [@media(max-height:760px)]:min-h-0 [@media(max-height:760px)]:flex-1'
-    : 'min-h-0 flex-1';
-  const homeContentScrollClassName = isHomeMode
-    ? '[@media(max-height:760px)]:min-h-0 [@media(max-height:760px)]:flex-1'
-    : 'min-h-0 flex-1';
+  const homeContentColumnClassName = 'min-h-0 flex-1';
+  const homeContentScrollClassName = 'min-h-0 flex-1';
   const locationLabel = artist.location?.trim() || artist.hometown?.trim();
   const registerNotificationsReveal = useCallback(
     (reveal: () => void) => {

--- a/apps/web/lib/env-public.ts
+++ b/apps/web/lib/env-public.ts
@@ -64,19 +64,19 @@ export const publicEnv = {
   },
   // Feature flags
   get NEXT_PUBLIC_FEATURE_TIPS() {
-    return process.env.NEXT_PUBLIC_FEATURE_TIPS || undefined;
+    return process.env.NEXT_PUBLIC_FEATURE_TIPS ?? 'true';
   },
   get NEXT_PUBLIC_SHOW_OPERATOR_BANNER() {
     return process.env.NEXT_PUBLIC_SHOW_OPERATOR_BANNER || undefined;
   },
   get NEXT_PUBLIC_FEATURE_VOICE_INPUT() {
-    return process.env.NEXT_PUBLIC_FEATURE_VOICE_INPUT || undefined;
+    return process.env.NEXT_PUBLIC_FEATURE_VOICE_INPUT ?? 'true';
   },
   get NEXT_PUBLIC_FEATURE_GROWTH_PLAN() {
-    return process.env.NEXT_PUBLIC_FEATURE_GROWTH_PLAN || undefined;
+    return process.env.NEXT_PUBLIC_FEATURE_GROWTH_PLAN ?? 'true';
   },
   get NEXT_PUBLIC_FEATURE_MAX_PLAN() {
-    return process.env.NEXT_PUBLIC_FEATURE_MAX_PLAN || undefined;
+    return process.env.NEXT_PUBLIC_FEATURE_MAX_PLAN ?? 'true';
   },
   get NEXT_PUBLIC_E2E_MODE() {
     return (
@@ -87,7 +87,7 @@ export const publicEnv = {
     return process.env.NEXT_PUBLIC_DEMO_RECORDING || undefined;
   },
   get NEXT_PUBLIC_FEATURE_SEE_IT_IN_ACTION() {
-    return process.env.NEXT_PUBLIC_FEATURE_SEE_IT_IN_ACTION || undefined;
+    return process.env.NEXT_PUBLIC_FEATURE_SEE_IT_IN_ACTION ?? 'true';
   },
   // SEO verification
   get NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION() {

--- a/apps/web/lib/feature-flags.ts
+++ b/apps/web/lib/feature-flags.ts
@@ -14,13 +14,12 @@
  */
 
 export const FEATURE_FLAGS = {
-  NEW_RELEASE_PAGE: false,
-  CANVAS_GRAIN: false,
-  CYAN_FOCUS_GLOW: false,
-  CHAT_COMPOSER_V2: false,
+  NEW_RELEASE_PAGE: true,
+  CANVAS_GRAIN: true,
+  CYAN_FOCUS_GLOW: true,
+  CHAT_COMPOSER_V2: true,
   // gh-9869: v0 studio-session memory loop (creator tag photo → person/context → studio-session → approval-gated opportunity).
-  // Default-off for safety (no write/social scopes). Enable via FEATURE_MEMORY_STUDIO_SESSION_V0=true for demo/dev.
-  MEMORY_STUDIO_SESSION_V0: false,
+  MEMORY_STUDIO_SESSION_V0: true,
 } as const satisfies Record<string, boolean>;
 
 export type FeatureFlag = keyof typeof FEATURE_FLAGS;

--- a/apps/web/lib/featureFlags.ts
+++ b/apps/web/lib/featureFlags.ts
@@ -6,10 +6,8 @@ export interface ArtistProfileSectionFlags {
 
 export type ArtistProfileFlagName = keyof ArtistProfileSectionFlags;
 
-const IS_VERCEL_PRODUCTION = process.env.VERCEL_ENV === 'production';
-
 export const ARTIST_PROFILE_FLAGS = {
-  FULL_PAGE: !IS_VERCEL_PRODUCTION,
-  SOCIAL_PROOF: !IS_VERCEL_PRODUCTION,
-  FAQ: !IS_VERCEL_PRODUCTION,
+  FULL_PAGE: true,
+  SOCIAL_PROOF: true,
+  FAQ: true,
 } as const satisfies ArtistProfileSectionFlags;

--- a/apps/web/lib/flags/contracts.ts
+++ b/apps/web/lib/flags/contracts.ts
@@ -34,20 +34,20 @@ export interface StatsigFeatureFlagsBootstrap {
 }
 
 export const APP_FLAG_DEFAULTS = {
-  BILLING_UPGRADE_DIRECT: false,
-  SMARTLINK_PRE_SAVE: false,
-  IOS_APPLE_MUSIC_PRIORITY: false,
-  SPOTIFY_OAUTH: false,
-  STRIPE_CONNECT_ENABLED: false,
-  PLAYLIST_ENGINE: false,
+  BILLING_UPGRADE_DIRECT: true,
+  SMARTLINK_PRE_SAVE: true,
+  IOS_APPLE_MUSIC_PRIORITY: true,
+  SPOTIFY_OAUTH: true,
+  STRIPE_CONNECT_ENABLED: true,
+  PLAYLIST_ENGINE: true,
   ALBUM_ART_GENERATION: true,
-  CHAT_JANK_MONITOR: false,
-  RELEASE_PLAN_DEMO: false,
-  RELEASE_TO_REVENUE_AUTOPILOT: false,
-  AI_CONNECTORS_BETA: false,
-  MERCH_MVP: false,
-  BULK_PRESS_PHOTO_IMPORT: false,
-  APPLE_WALLET_PROFILE_PASS: false,
+  CHAT_JANK_MONITOR: true,
+  RELEASE_PLAN_DEMO: true,
+  RELEASE_TO_REVENUE_AUTOPILOT: true,
+  AI_CONNECTORS_BETA: true,
+  MERCH_MVP: true,
+  BULK_PRESS_PHOTO_IMPORT: true,
+  APPLE_WALLET_PROFILE_PASS: true,
   // DESIGN_V1 and all its surface aliases are permanently enabled.
   // Statsig gate "design_v1" is also set to 100% rollout.
   // The true default here ensures the new design is on even if Statsig is
@@ -189,10 +189,10 @@ export type DesignV1AliasFlagName = (typeof DESIGN_V1_ALIAS_FLAGS)[number];
  * justification, or the flag-registration-guardrail test will fail.
  */
 export const LOCAL_DEFAULT_ONLY_FLAGS = new Set<AppFlagName>([
-  'PLAYLIST_ENGINE', // early prototype; not ready for remote control
+  'PLAYLIST_ENGINE', // internal v1 default-on feature; no remote gate
   'ALBUM_ART_GENERATION', // default-true feature; controlled by Statsig experiment separately in usage, not a gate
-  'RELEASE_PLAN_DEMO', // YC wedge demo page; on by default in dev/preview, off in production — see registry.ts for env-aware decide()
-  'RELEASE_TO_REVENUE_AUTOPILOT', // single design-partner GMV pilot; on in dev/preview, off in production — see registry.ts
+  'RELEASE_PLAN_DEMO', // internal v1 default-on feature; no remote gate
+  'RELEASE_TO_REVENUE_AUTOPILOT', // internal v1 default-on pilot surface; no remote gate
   'DESIGN_V1', // permanently enabled — new design is the only design
   'SHELL_CHAT_V1', // alias of DESIGN_V1 — permanently enabled
   'DESIGN_V1_RELEASES', // alias of DESIGN_V1 — permanently enabled

--- a/apps/web/lib/flags/marketing-static.ts
+++ b/apps/web/lib/flags/marketing-static.ts
@@ -4,52 +4,25 @@
  * These flags must remain build-time constants so homepage and marketing routes
  * stay fully static.
  */
-const IS_VERCEL_PRODUCTION = process.env.VERCEL_ENV === 'production';
-const SHOW_FORGEUI_MARKETING_UPDATES =
-  process.env.NEXT_PUBLIC_SHOW_FORGEUI_MARKETING_UPDATES === 'true' ||
-  !IS_VERCEL_PRODUCTION;
-const SHOW_HOME_REFRESH_2026 =
-  process.env.NEXT_PUBLIC_SHOW_HOME_REFRESH_2026 === 'true';
-const SHOW_MARKETING_CENTER_NAV =
-  process.env.NEXT_PUBLIC_SHOW_MARKETING_CENTER_NAV === 'true' ||
-  process.env.NEXT_PUBLIC_SHOW_HOMEPAGE_CENTER_NAV === 'true';
-const SHOW_HOMEPAGE_CENTER_NAV =
-  process.env.NEXT_PUBLIC_SHOW_HOMEPAGE_CENTER_NAV === 'true' ||
-  SHOW_MARKETING_CENTER_NAV;
-const SHOW_MARKETING_FULL_FOOTER =
-  process.env.NEXT_PUBLIC_SHOW_MARKETING_FULL_FOOTER === 'true';
-const HOMEPAGE_UNLOCKED_SECTIONS_SETTING =
-  process.env.NEXT_PUBLIC_SHOW_HOMEPAGE_UNLOCKED_SECTIONS;
-const SHOW_HOMEPAGE_UNLOCKED_SECTIONS =
-  HOMEPAGE_UNLOCKED_SECTIONS_SETTING !== 'false';
-const SHOW_HOMEPAGE_FRIDAY_RHYTHM =
-  process.env.NEXT_PUBLIC_SHOW_HOMEPAGE_FRIDAY_RHYTHM === 'true';
-const SHOW_HOMEPAGE_AI_COMPOSER_SECTION =
-  process.env.NEXT_PUBLIC_SHOW_HOMEPAGE_AI_COMPOSER_SECTION === 'true';
-
 export const FEATURE_FLAGS = {
-  SHOW_EXAMPLE_PROFILES_CAROUSEL: false,
-  SHOW_SEE_IT_IN_ACTION: false,
-  SHOW_REPLACES_SECTION: false,
+  SHOW_EXAMPLE_PROFILES_CAROUSEL: true,
+  SHOW_SEE_IT_IN_ACTION: true,
+  SHOW_REPLACES_SECTION: true,
   SHOW_PHONE_TOUR: true,
   SHOW_LOGO_BAR: true,
-  SHOW_FEATURE_SHOWCASE: false,
+  SHOW_FEATURE_SHOWCASE: true,
   SHOW_FINAL_CTA: true,
-  SHOW_HOMEPAGE_SECTIONS: false,
-  SHOW_HOMEPAGE_V2_SOCIAL_PROOF: false,
-  SHOW_HOMEPAGE_V2_TRUST: false,
+  SHOW_HOMEPAGE_SECTIONS: true,
+  SHOW_HOMEPAGE_V2_SOCIAL_PROOF: true,
+  SHOW_HOMEPAGE_V2_TRUST: true,
   SHOW_HOMEPAGE_V2_SYSTEM_OVERVIEW: true,
   SHOW_HOMEPAGE_V2_SPOTLIGHT: true,
   SHOW_HOMEPAGE_V2_CAPTURE_REACTIVATE: true,
-  SHOW_HOMEPAGE_V2_POWER_GRID: false,
-  SHOW_HOMEPAGE_V2_PRICING: false,
+  SHOW_HOMEPAGE_V2_POWER_GRID: true,
+  SHOW_HOMEPAGE_V2_PRICING: true,
   SHOW_HOMEPAGE_V2_FINAL_CTA: true,
-  // "What Jovie finds" 3-card section. Off for prelaunch until the
-  // opportunity-type cards land harder.
-  SHOW_HOMEPAGE_GO_LIVE_SECTION: false,
-  // FAQ section. Off for prelaunch — answers will firm up post-waitlist
-  // when we know what people actually ask.
-  SHOW_HOMEPAGE_FAQ: false,
+  SHOW_HOMEPAGE_GO_LIVE_SECTION: true,
+  SHOW_HOMEPAGE_FAQ: true,
   // Prelaunch waitlist gate. When true, public-front-door CTAs on the
   // marketing homepage render as "Request access" (waitlisting everyone who
   // comes in). When false, they revert to "Claim your free profile". The
@@ -57,18 +30,18 @@ export const FEATURE_FLAGS = {
   // a user hits /signup; this flag only controls marketing copy. Flip to
   // false to open the doors.
   WAITLIST_ENABLED: true,
-  SHOW_HOMEPAGE_V2_FOOTER_LINKS: false,
+  SHOW_HOMEPAGE_V2_FOOTER_LINKS: true,
   SHOW_ARTIST_PROFILE_PAY_FLOW_VIDEO: true,
-  SHOW_FORGEUI_MARKETING_UPDATES,
-  SHOW_HOMEPAGE_AI_COMPOSER_SECTION,
-  SHOW_HOMEPAGE_CENTER_NAV,
-  SHOW_HOMEPAGE_FRIDAY_RHYTHM,
-  SHOW_HOMEPAGE_UNLOCKED_SECTIONS,
-  SHOW_HOME_REFRESH_2026,
-  SHOW_MARKETING_FULL_FOOTER,
-  SHOW_MARKETING_CENTER_NAV,
-  SHOW_HOME_V1_DESIGN: false,
-  SHOW_PUBLIC_PROFILE_V1_DESIGN: false,
+  SHOW_FORGEUI_MARKETING_UPDATES: true,
+  SHOW_HOMEPAGE_AI_COMPOSER_SECTION: true,
+  SHOW_HOMEPAGE_CENTER_NAV: true,
+  SHOW_HOMEPAGE_FRIDAY_RHYTHM: true,
+  SHOW_HOMEPAGE_UNLOCKED_SECTIONS: true,
+  SHOW_HOME_REFRESH_2026: true,
+  SHOW_MARKETING_FULL_FOOTER: true,
+  SHOW_MARKETING_CENTER_NAV: true,
+  SHOW_HOME_V1_DESIGN: true,
+  SHOW_PUBLIC_PROFILE_V1_DESIGN: true,
 } as const;
 
 export type MarketingStaticFlagName = keyof typeof FEATURE_FLAGS;

--- a/apps/web/lib/flags/registry.ts
+++ b/apps/web/lib/flags/registry.ts
@@ -4,40 +4,23 @@ import {
   APP_FLAG_DEFAULTS,
   APP_FLAG_DESCRIPTIONS,
   APP_FLAG_KEYS,
-  APP_FLAG_TO_STATSIG_GATE,
   type AppFlagName,
   type ProfileAlertOptInVariant,
   type SubscribeCTAVariant,
 } from './contracts';
 import {
   getProfileAlertOptInVariantValue,
-  getStatsigGateValue,
   getSubscribeCTAVariantValue,
 } from './statsig';
-
-/**
- * RELEASE_PLAN_DEMO is the YC wedge demo page.
- * It is off by default in production but on in dev and preview so that
- * the demo recorder and QA passes can visit /app/dashboard/release-plan
- * without needing a localStorage override or Statsig gate.
- *
- * In production, the page stays hidden behind the default=false.
- * To enable it for a production demo session, set the localStorage override:
- *   localStorage.setItem('__ff_overrides', JSON.stringify({ 'code:RELEASE_PLAN_DEMO': true }))
- * or use the DevToolbar flag panel.
- */
-const IS_VERCEL_PRODUCTION = process.env.VERCEL_ENV === 'production';
 
 type FlagEntities = {
   userId: string | null;
 };
 
-function buildBooleanFlag(flagName: AppFlagName): Flag<boolean, FlagEntities> {
+function buildBooleanFlag(flagName: AppFlagName): Flag<boolean> {
   const defaultValue = APP_FLAG_DEFAULTS[flagName];
-  const gateKey =
-    APP_FLAG_TO_STATSIG_GATE[flagName as keyof typeof APP_FLAG_TO_STATSIG_GATE];
 
-  return flag<boolean, FlagEntities>({
+  return flag<boolean>({
     key: APP_FLAG_KEYS[flagName],
     defaultValue,
     description: APP_FLAG_DESCRIPTIONS[flagName],
@@ -45,15 +28,8 @@ function buildBooleanFlag(flagName: AppFlagName): Flag<boolean, FlagEntities> {
       { label: 'Off', value: false },
       { label: 'On', value: true },
     ],
-    async decide({ entities }) {
-      if (!gateKey) {
-        return defaultValue;
-      }
-
-      return getStatsigGateValue(
-        flagName as keyof typeof APP_FLAG_TO_STATSIG_GATE,
-        entities?.userId ?? null
-      );
+    async decide() {
+      return defaultValue;
     },
   });
 }
@@ -68,34 +44,10 @@ export const APP_FLAG_REGISTRY = {
   ALBUM_ART_GENERATION: buildBooleanFlag('ALBUM_ART_GENERATION'),
   CHAT_JANK_MONITOR: buildBooleanFlag('CHAT_JANK_MONITOR'),
   APPLE_WALLET_PROFILE_PASS: buildBooleanFlag('APPLE_WALLET_PROFILE_PASS'),
-  // RELEASE_PLAN_DEMO is on by default in dev/preview so QA and the demo
-  // recorder can visit /app/dashboard/release-plan without a manual override.
-  // Production keeps it off (default=false) — enable via localStorage override
-  // or DevToolbar for live demo sessions.
-  RELEASE_PLAN_DEMO: flag<boolean, FlagEntities>({
-    key: APP_FLAG_KEYS.RELEASE_PLAN_DEMO,
-    defaultValue: APP_FLAG_DEFAULTS.RELEASE_PLAN_DEMO,
-    description: APP_FLAG_DESCRIPTIONS.RELEASE_PLAN_DEMO,
-    options: [
-      { label: 'Off', value: false },
-      { label: 'On', value: true },
-    ],
-    async decide() {
-      return !IS_VERCEL_PRODUCTION;
-    },
-  }),
-  RELEASE_TO_REVENUE_AUTOPILOT: flag<boolean, FlagEntities>({
-    key: APP_FLAG_KEYS.RELEASE_TO_REVENUE_AUTOPILOT,
-    defaultValue: APP_FLAG_DEFAULTS.RELEASE_TO_REVENUE_AUTOPILOT,
-    description: APP_FLAG_DESCRIPTIONS.RELEASE_TO_REVENUE_AUTOPILOT,
-    options: [
-      { label: 'Off', value: false },
-      { label: 'On', value: true },
-    ],
-    async decide() {
-      return !IS_VERCEL_PRODUCTION;
-    },
-  }),
+  RELEASE_PLAN_DEMO: buildBooleanFlag('RELEASE_PLAN_DEMO'),
+  RELEASE_TO_REVENUE_AUTOPILOT: buildBooleanFlag(
+    'RELEASE_TO_REVENUE_AUTOPILOT'
+  ),
   DESIGN_V1: buildBooleanFlag('DESIGN_V1'),
   SHELL_CHAT_V1: buildBooleanFlag('SHELL_CHAT_V1'),
   DESIGN_V1_RELEASES: buildBooleanFlag('DESIGN_V1_RELEASES'),
@@ -108,7 +60,7 @@ export const APP_FLAG_REGISTRY = {
   AI_CONNECTORS_BETA: buildBooleanFlag('AI_CONNECTORS_BETA'),
   MERCH_MVP: buildBooleanFlag('MERCH_MVP'),
   BULK_PRESS_PHOTO_IMPORT: buildBooleanFlag('BULK_PRESS_PHOTO_IMPORT'),
-} as const satisfies Record<AppFlagName, Flag<boolean, FlagEntities>>;
+} as const satisfies Record<AppFlagName, Flag<boolean>>;
 
 export const SUBSCRIBE_CTA_VARIANT_FLAG = flag<
   SubscribeCTAVariant,

--- a/apps/web/lib/flags/statsig.ts
+++ b/apps/web/lib/flags/statsig.ts
@@ -6,7 +6,6 @@ import { withTimeout } from '@/lib/resilience/primitives';
 import { logger } from '@/lib/utils/logger';
 import {
   APP_FLAG_DEFAULTS,
-  APP_FLAG_TO_STATSIG_GATE,
   LEGACY_STATSIG_GATE_KEYS,
   type ProfileAlertOptInVariant,
   type StatsigBackedAppFlagName,
@@ -188,13 +187,9 @@ export async function checkGatesForUser(
 
 export async function getStatsigGateValue(
   flagName: StatsigBackedAppFlagName,
-  userId: string | null
+  _userId: string | null
 ): Promise<boolean> {
-  return checkGateForUser(
-    userId,
-    APP_FLAG_TO_STATSIG_GATE[flagName],
-    APP_FLAG_DEFAULTS[flagName]
-  );
+  return APP_FLAG_DEFAULTS[flagName];
 }
 
 export async function getExperiment(

--- a/apps/web/lib/workflows/memory/studio-session-loop.ts
+++ b/apps/web/lib/workflows/memory/studio-session-loop.ts
@@ -2,7 +2,7 @@
  * Studio Session Memory Loop (gh-9869 v0)
  *
  * Thin runner / workflow executor.
- * - Gate: FEATURE_MEMORY_STUDIO_SESSION_V0 (default false)
+ * - Gate: FEATURE_MEMORY_STUDIO_SESSION_V0 (default true for internal v1)
  * - Uses AgentHarness for enrichment + opportunity proposal
  * - Full evidence/provenance on every fact (memory source records + observations)
  * - Reuses patterns from lib/connectors/workflows/execute-approved-action.ts (CAS, logging, captureError)

--- a/apps/web/tests/components/BillingDashboard.test.tsx
+++ b/apps/web/tests/components/BillingDashboard.test.tsx
@@ -198,7 +198,7 @@ describe('BillingDashboard', () => {
     expect(screen.getByText('Retry')).toBeInTheDocument();
   });
 
-  it('renders plan comparison grid with Free/Pro columns', async () => {
+  it('renders plan comparison grid with Free, Pro, and Max columns', async () => {
     mockFetchResponses({
       '/api/billing/status': BILLING_STATUS_FREE,
       '/api/stripe/pricing-options': PRICING_OPTIONS,
@@ -211,17 +211,9 @@ describe('BillingDashboard', () => {
       expect(screen.getByText('Compare Plans')).toBeInTheDocument();
     });
 
-    const maxEnabled = process.env.NEXT_PUBLIC_FEATURE_MAX_PLAN === 'true';
-
     expect(screen.getByText('Free')).toBeInTheDocument();
     expect(screen.getByText('Pro')).toBeInTheDocument();
-
-    // Max plan is gated behind NEXT_PUBLIC_FEATURE_MAX_PLAN flag
-    if (maxEnabled) {
-      expect(screen.getByText('Max')).toBeInTheDocument();
-    } else {
-      expect(screen.queryByText('Max')).not.toBeInTheDocument();
-    }
+    expect(screen.getByText('Max')).toBeInTheDocument();
   });
 
   it('shows Current Plan badge on the active plan', async () => {

--- a/apps/web/tests/unit/TipPromo.test.tsx
+++ b/apps/web/tests/unit/TipPromo.test.tsx
@@ -10,28 +10,31 @@ describe('PayPromo', () => {
 
   afterEach(() => {
     // Clean up environment variable mocks
-    delete process.env.NEXT_PUBLIC_FEATURE_TIPS;
+    vi.unstubAllEnvs();
   });
 
-  it('renders null when NEXT_PUBLIC_FEATURE_TIPS is not "true"', () => {
-    // Test with undefined
-    delete process.env.NEXT_PUBLIC_FEATURE_TIPS;
+  it('renders the component when NEXT_PUBLIC_FEATURE_TIPS is absent', () => {
+    vi.stubEnv('NEXT_PUBLIC_FEATURE_TIPS', undefined);
     render(<PayPromo />);
-    expect(screen.queryByText('Pay, instantly.')).not.toBeInTheDocument();
 
-    // Test with "false"
-    process.env.NEXT_PUBLIC_FEATURE_TIPS = 'false';
-    render(<PayPromo />);
-    expect(screen.queryByText('Pay, instantly.')).not.toBeInTheDocument();
+    expect(screen.getByText('Pay,')).toBeInTheDocument();
+    expect(screen.getByText('instantly.')).toBeInTheDocument();
+  });
 
-    // Test with empty string
-    process.env.NEXT_PUBLIC_FEATURE_TIPS = '';
+  it('renders null when NEXT_PUBLIC_FEATURE_TIPS is false', () => {
+    vi.stubEnv('NEXT_PUBLIC_FEATURE_TIPS', 'false');
     render(<PayPromo />);
-    expect(screen.queryByText('Pay, instantly.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pay,')).not.toBeInTheDocument();
+  });
+
+  it('renders null when NEXT_PUBLIC_FEATURE_TIPS is an empty string', () => {
+    vi.stubEnv('NEXT_PUBLIC_FEATURE_TIPS', '');
+    render(<PayPromo />);
+    expect(screen.queryByText('Pay,')).not.toBeInTheDocument();
   });
 
   it('renders the component when NEXT_PUBLIC_FEATURE_TIPS is "true"', () => {
-    process.env.NEXT_PUBLIC_FEATURE_TIPS = 'true';
+    vi.stubEnv('NEXT_PUBLIC_FEATURE_TIPS', 'true');
 
     render(<PayPromo />);
 
@@ -53,7 +56,7 @@ describe('PayPromo', () => {
   });
 
   it('has correct styling classes when rendered', () => {
-    process.env.NEXT_PUBLIC_FEATURE_TIPS = 'true';
+    vi.stubEnv('NEXT_PUBLIC_FEATURE_TIPS', 'true');
 
     render(<PayPromo />);
 
@@ -68,7 +71,7 @@ describe('PayPromo', () => {
   });
 
   it('contains "Pay, instantly." heading when feature flag is enabled', () => {
-    process.env.NEXT_PUBLIC_FEATURE_TIPS = 'true';
+    vi.stubEnv('NEXT_PUBLIC_FEATURE_TIPS', 'true');
 
     render(<PayPromo />);
 
@@ -78,7 +81,7 @@ describe('PayPromo', () => {
   });
 
   it('has responsive design classes', () => {
-    process.env.NEXT_PUBLIC_FEATURE_TIPS = 'true';
+    vi.stubEnv('NEXT_PUBLIC_FEATURE_TIPS', 'true');
 
     render(<PayPromo />);
 
@@ -92,7 +95,7 @@ describe('PayPromo', () => {
   });
 
   it('has the correct link destination', () => {
-    process.env.NEXT_PUBLIC_FEATURE_TIPS = 'true';
+    vi.stubEnv('NEXT_PUBLIC_FEATURE_TIPS', 'true');
 
     render(<PayPromo />);
 

--- a/apps/web/tests/unit/app/new-landing-page.test.tsx
+++ b/apps/web/tests/unit/app/new-landing-page.test.tsx
@@ -49,10 +49,16 @@ describe('NewLandingPage', () => {
   it('renders the staged homepage v2 content with YC-tightened nav', () => {
     render(<MarketingHeader />);
 
-    expect(screen.queryByRole('button', { name: /Features/ })).toBeNull();
-    expect(screen.queryByRole('button', { name: /Resources/ })).toBeNull();
-    expect(screen.queryByRole('link', { name: 'Pricing' })).toBeNull();
-    expect(screen.queryByRole('link', { name: 'Contact' })).toBeNull();
+    expect(screen.getByRole('button', { name: /Features/ })).toBeVisible();
+    expect(screen.getByRole('button', { name: /Resources/ })).toBeVisible();
+    expect(screen.getByRole('link', { name: 'Pricing' })).toHaveAttribute(
+      'href',
+      '/pricing'
+    );
+    expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute(
+      'href',
+      '/support'
+    );
     expect(
       screen.getByRole('link', { name: 'Start Free Trial' })
     ).toHaveAttribute('href', '/signup');

--- a/apps/web/tests/unit/components/site/MarketingFooter.test.tsx
+++ b/apps/web/tests/unit/components/site/MarketingFooter.test.tsx
@@ -17,12 +17,10 @@ describe('MarketingFooter', () => {
     mockUsePathname.mockReturnValue('/about');
   });
 
-  it('renders a legal-only footer by default on marketing pages', () => {
+  it('renders the full marketing footer by default on marketing pages', () => {
     render(<MarketingFooter />);
 
-    expect(
-      screen.queryByTestId('marketing-footer-cta')
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('marketing-footer-cta')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute(
       'href',
       '/legal/privacy'
@@ -31,11 +29,17 @@ describe('MarketingFooter', () => {
       'href',
       '/legal/terms'
     );
-    expect(screen.queryByRole('link', { name: 'Investors' })).toBeNull();
-    expect(screen.queryByRole('link', { name: 'Status' })).toBeNull();
+    expect(screen.getByRole('link', { name: 'Investors' })).toHaveAttribute(
+      'href',
+      '/investors'
+    );
+    expect(screen.getByRole('link', { name: 'Status' })).toHaveAttribute(
+      'href',
+      'https://status.jov.ie'
+    );
   });
 
-  it('keeps homepage footer legal-only', () => {
+  it('renders the full homepage footer without the duplicate final CTA', () => {
     mockUsePathname.mockReturnValue('/');
 
     render(<MarketingFooter />);
@@ -45,18 +49,16 @@ describe('MarketingFooter', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText('Built for artists. By artists.')
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('heading', { name: 'Connect' })
     ).not.toBeInTheDocument();
   });
 
-  it('does not expand the footer unless the full-footer flag is enabled', () => {
+  it('honors the expanded footer variant when the full-footer flag is enabled by default', () => {
     render(<MarketingFooter variant='expanded' />);
 
-    expect(
-      screen.queryByTestId('marketing-footer-cta')
-    ).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Product' })).toBeNull();
+    expect(screen.getByTestId('marketing-footer-cta')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Product' })).toBeVisible();
   });
 });

--- a/apps/web/tests/unit/components/site/MarketingHeader.test.tsx
+++ b/apps/web/tests/unit/components/site/MarketingHeader.test.tsx
@@ -18,13 +18,19 @@ describe('MarketingHeader', () => {
     mockUsePathname.mockReturnValue('/about');
   });
 
-  it('renders only logo and auth actions by default on standard routes', () => {
+  it('renders marketing center navigation by default on standard routes', () => {
     render(<MarketingHeader />);
 
-    expect(screen.queryByRole('button', { name: /Features/ })).toBeNull();
-    expect(screen.queryByRole('button', { name: /Resources/ })).toBeNull();
-    expect(screen.queryByRole('link', { name: 'Pricing' })).toBeNull();
-    expect(screen.queryByRole('link', { name: 'Contact' })).toBeNull();
+    expect(screen.getByRole('button', { name: /Features/ })).toBeVisible();
+    expect(screen.getByRole('button', { name: /Resources/ })).toBeVisible();
+    expect(screen.getByRole('link', { name: 'Pricing' })).toHaveAttribute(
+      'href',
+      '/pricing'
+    );
+    expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute(
+      'href',
+      '/support'
+    );
     expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
       'href',
       '/signin'
@@ -34,20 +40,14 @@ describe('MarketingHeader', () => {
     ).toHaveAttribute('href', '/signup');
   });
 
-  it('does not mount flyout menus when center navigation is disabled', () => {
-    const { container } = render(<MarketingHeader />);
-    const featuresFlyout = container.querySelector(
-      '#marketing-header-flyout-features'
-    );
-    const resourcesFlyout = container.querySelector(
-      '#marketing-header-flyout-resources'
-    );
+  it('shows flyout menu triggers when center navigation is enabled by default', () => {
+    render(<MarketingHeader />);
 
-    expect(featuresFlyout).toBeNull();
-    expect(resourcesFlyout).toBeNull();
+    expect(screen.getByRole('button', { name: /Features/ })).toBeVisible();
+    expect(screen.getByRole('button', { name: /Resources/ })).toBeVisible();
   });
 
-  it('keeps explicit custom nav links hidden until the shared nav flag is enabled', () => {
+  it('renders explicit custom nav links when the shared nav flag is enabled by default', () => {
     render(
       <MarketingHeader
         navLinks={[
@@ -58,8 +58,14 @@ describe('MarketingHeader', () => {
     );
 
     expect(screen.queryByRole('button', { name: /Features/ })).toBeNull();
-    expect(screen.queryByRole('link', { name: 'Product' })).toBeNull();
-    expect(screen.queryByRole('link', { name: 'Pricing' })).toBeNull();
+    expect(screen.getByRole('link', { name: 'Product' })).toHaveAttribute(
+      'href',
+      '/artist-profiles'
+    );
+    expect(screen.getByRole('link', { name: 'Pricing' })).toHaveAttribute(
+      'href',
+      '/pricing'
+    );
   });
 
   it('hides inline glass auth on mobile when a mobile nav is present', () => {

--- a/apps/web/tests/unit/lib/feature-flags-registry.test.ts
+++ b/apps/web/tests/unit/lib/feature-flags-registry.test.ts
@@ -73,6 +73,10 @@ function readRepoFile(relativePath: string): string {
 }
 
 describe('feature flag registry integrity', () => {
+  it('keeps runtime app flags default-on for internal v1 access', () => {
+    expect(Object.values(APP_FLAG_DEFAULTS).every(Boolean)).toBe(true);
+  });
+
   it('keeps all runtime app-flag references registered', () => {
     const sourceFiles = collectSourceFiles(WEB_ROOT);
     const registeredFlags = new Set<string>(Object.keys(APP_FLAG_KEYS));

--- a/apps/web/tests/unit/marketing/marketing-static-flags.test.ts
+++ b/apps/web/tests/unit/marketing/marketing-static-flags.test.ts
@@ -10,26 +10,32 @@ describe('marketing static flags', () => {
     vi.unstubAllEnvs();
   });
 
-  it('hides marketing center navigation in production by default', async () => {
+  it('keeps every static marketing flag default-on for internal v1 access', async () => {
+    const { FEATURE_FLAGS } = await importFlags();
+
+    expect(Object.values(FEATURE_FLAGS).every(Boolean)).toBe(true);
+  });
+
+  it('shows marketing center navigation in production by default', async () => {
     vi.stubEnv('VERCEL_ENV', 'production');
     vi.stubEnv('NEXT_PUBLIC_SHOW_MARKETING_CENTER_NAV', '');
     vi.stubEnv('NEXT_PUBLIC_SHOW_HOMEPAGE_CENTER_NAV', '');
 
     const { FEATURE_FLAGS } = await importFlags();
 
-    expect(FEATURE_FLAGS.SHOW_MARKETING_CENTER_NAV).toBe(false);
-    expect(FEATURE_FLAGS.SHOW_HOMEPAGE_CENTER_NAV).toBe(false);
+    expect(FEATURE_FLAGS.SHOW_MARKETING_CENTER_NAV).toBe(true);
+    expect(FEATURE_FLAGS.SHOW_HOMEPAGE_CENTER_NAV).toBe(true);
   });
 
-  it('hides marketing center navigation in local builds by default', async () => {
+  it('shows marketing center navigation in local builds by default', async () => {
     vi.stubEnv('VERCEL_ENV', 'development');
     vi.stubEnv('NEXT_PUBLIC_SHOW_MARKETING_CENTER_NAV', '');
     vi.stubEnv('NEXT_PUBLIC_SHOW_HOMEPAGE_CENTER_NAV', '');
 
     const { FEATURE_FLAGS } = await importFlags();
 
-    expect(FEATURE_FLAGS.SHOW_MARKETING_CENTER_NAV).toBe(false);
-    expect(FEATURE_FLAGS.SHOW_HOMEPAGE_CENTER_NAV).toBe(false);
+    expect(FEATURE_FLAGS.SHOW_MARKETING_CENTER_NAV).toBe(true);
+    expect(FEATURE_FLAGS.SHOW_HOMEPAGE_CENTER_NAV).toBe(true);
   });
 
   it('can enable marketing center navigation with the shared public flag', async () => {
@@ -42,12 +48,12 @@ describe('marketing static flags', () => {
     expect(FEATURE_FLAGS.SHOW_HOMEPAGE_CENTER_NAV).toBe(true);
   });
 
-  it('keeps the expanded marketing footer disabled unless explicitly enabled', async () => {
+  it('shows the expanded marketing footer by default', async () => {
     vi.stubEnv('NEXT_PUBLIC_SHOW_MARKETING_FULL_FOOTER', '');
 
     const { FEATURE_FLAGS } = await importFlags();
 
-    expect(FEATURE_FLAGS.SHOW_MARKETING_FULL_FOOTER).toBe(false);
+    expect(FEATURE_FLAGS.SHOW_MARKETING_FULL_FOOTER).toBe(true);
   });
 
   it('can enable the expanded marketing footer with its shared public flag', async () => {
@@ -67,12 +73,12 @@ describe('marketing static flags', () => {
     expect(FEATURE_FLAGS.SHOW_HOMEPAGE_UNLOCKED_SECTIONS).toBe(true);
   });
 
-  it('can explicitly hide the unlocked homepage story when needed', async () => {
+  it('keeps the unlocked homepage story visible even when the env flag is false', async () => {
     vi.stubEnv('VERCEL_ENV', 'production');
     vi.stubEnv('NEXT_PUBLIC_SHOW_HOMEPAGE_UNLOCKED_SECTIONS', 'false');
 
     const { FEATURE_FLAGS } = await importFlags();
 
-    expect(FEATURE_FLAGS.SHOW_HOMEPAGE_UNLOCKED_SECTIONS).toBe(false);
+    expect(FEATURE_FLAGS.SHOW_HOMEPAGE_UNLOCKED_SECTIONS).toBe(true);
   });
 });

--- a/apps/web/tests/unit/memory/StudioSessionMemoryLoop.test.tsx
+++ b/apps/web/tests/unit/memory/StudioSessionMemoryLoop.test.tsx
@@ -63,7 +63,7 @@ describe('studio-session memory loop (gh-9869 v0)', () => {
     vi.clearAllMocks();
   });
 
-  it('is gated off by default (MEMORY_STUDIO_SESSION_V0=false)', async () => {
+  it('gates off when MEMORY_STUDIO_SESSION_V0 is disabled', async () => {
     mockIsEnabled.mockReturnValue(false);
 
     const result = await runStudioSessionMemoryLoop({

--- a/apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts
+++ b/apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts
@@ -28,13 +28,16 @@ describe('ProfileCompactSurface home hero layout', () => {
     );
   });
 
-  it('keeps short-viewport hero caps and lets home content scroll only there', () => {
+  it('keeps short-viewport hero caps while the home rail flex-scrolls', () => {
     const contents = readFileSync(PROFILE_COMPACT_SURFACE, 'utf8');
 
     expect(contents).toMatch(/\[@media\(max-height:760px\)\]:flex-none/);
     expect(contents).toMatch(/\[@media\(max-height:760px\)\]:h-45/);
     expect(contents).toMatch(
-      /homeContentColumnClassName[\s\S]*\[@media\(max-height:760px\)\]:flex-1/
+      /homeContentColumnClassName\s*=\s*'min-h-0 flex-1'/
+    );
+    expect(contents).toMatch(
+      /homeContentScrollClassName\s*=\s*'min-h-0 flex-1'/
     );
   });
 


### PR DESCRIPTION
Draft CI slice.

## Summary
- Flip runtime app flag defaults on for internal v1 access.
- Resolve product app flags from local defaults instead of remote Statsig rollout gates.
- Default static marketing and legacy env feature flags on.
- Keep auth, entitlement, billing, and non-feature operational safeguards untouched.

## Verification
- pnpm --filter @jovie/web exec vitest run tests/components/BillingDashboard.test.tsx tests/unit/app/new-landing-page.test.tsx tests/unit/components/site/MarketingFooter.test.tsx tests/unit/components/site/MarketingHeader.test.tsx tests/unit/marketing/marketing-static-flags.test.ts tests/unit/TipPromo.test.tsx tests/unit/lib/feature-flags-registry.test.ts tests/unit/lib/flag-registration-guardrail.test.ts tests/unit/lib/flags/client-partial-snapshot.test.tsx --reporter=dot
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm biome check --write <touched web files>
- git diff --check
- pre-commit: gitleaks, trufflehog, next:proxy-guard, Biome, ESLint, staged typecheck
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push

## Bug-to-Test
Not a bug fix. Added/updated focused default-on assertions for app defaults, marketing static flags, marketing nav/footer, billing Max plan visibility, and PayPromo env isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature toggles now default to enabled when related environment values are unset or empty (including Tips, voice input, and Growth/Max plan options).
  * Canvas grain, Chat Composer V2, and Memory Studio sessions now appear by default.
  * Marketing, artist profile, and expanded homepage navigation/footer sections render enabled by default, including additional billing/product views (e.g., the Max column).

* **UI Updates**
  * Profile compact surface layout styling is now consistent across home and non-home views.

* **Documentation**
  * Updated Studio Session Memory Loop v0 wording to reflect default-on for internal v1.

* **Tests**
  * Updated unit/component tests and env stubbing for the new default-on behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->