### PR TITLE
fix(analytics): decode x-vercel-ip-city in /api/track before storing

### DIFF
--- a/apps/web/app/api/track/route.ts
+++ b/apps/web/app/api/track/route.ts
@@ -376,7 +376,8 @@ export async function POST(request: NextRequest) {
       httpReferer && isSameOriginReferrer(httpReferer, request.url)
         ? undefined
         : httpReferer;
-    const geoCity = request.headers.get('x-vercel-ip-city') ?? undefined;
+    const rawGeoCity = request.headers.get('x-vercel-ip-city') ?? undefined;
+    const geoCity = rawGeoCity ? decodeURIComponent(rawGeoCity) : undefined;
     const geoCountry =
       request.headers.get('x-vercel-ip-country') ??
       request.headers.get('cf-ipcountry') ??

--- a/apps/web/scripts/cleanup-synthetic-audience.ts
+++ b/apps/web/scripts/cleanup-synthetic-audience.ts
@@ -1,0 +1,230 @@
+#!/usr/bin/env -S tsx
+/* eslint-disable no-restricted-imports -- Script requires full schema access */
+
+/**
+ * Audit and optionally delete synthetic/seed audience analytics rows.
+ *
+ * Default is dry-run. Use --execute to delete matched rows.
+ *
+ * Usage:
+ *   doppler run --project jovie-web --config dev -- \
+ *     pnpm tsx apps/web/scripts/cleanup-synthetic-audience.ts
+ *
+ *   doppler run --project jovie-web --config prd -- \
+ *     pnpm tsx apps/web/scripts/cleanup-synthetic-audience.ts --username tim --execute
+ */
+
+import { neon } from '@neondatabase/serverless';
+import { sql as drizzleSql, eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/neon-http';
+import * as schema from '@/lib/db/schema';
+import {
+  audienceMembers,
+  clickEvents,
+  dailyProfileViews,
+} from '@/lib/db/schema/analytics';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { assertSeedDatabaseTarget } from './seed-database-guard';
+import {
+  syntheticAudienceMemberWhere,
+  syntheticClickEventWhere,
+} from './synthetic-audience-markers';
+
+interface CliOptions {
+  readonly username?: string;
+  readonly profileId?: string;
+  readonly execute: boolean;
+  readonly includeViews: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  let username: string | undefined;
+  let profileId: string | undefined;
+  let execute = false;
+  let includeViews = false;
+
+  for (const arg of argv) {
+    if (arg === '--execute') {
+      execute = true;
+      continue;
+    }
+    if (arg === '--include-views') {
+      includeViews = true;
+      continue;
+    }
+    if (arg.startsWith('--username=')) {
+      username = arg.slice('--username='.length).trim().toLowerCase();
+      continue;
+    }
+    if (arg.startsWith('--profile-id=')) {
+      profileId = arg.slice('--profile-id='.length).trim();
+    }
+  }
+
+  return { username, profileId, execute, includeViews };
+}
+
+async function resolveProfileId(
+  db: ReturnType<typeof drizzle>,
+  options: CliOptions
+): Promise<string | undefined> {
+  if (options.profileId) {
+    return options.profileId;
+  }
+
+  if (!options.username) {
+    return undefined;
+  }
+
+  const [profile] = await db
+    .select({ id: creatorProfiles.id, username: creatorProfiles.username })
+    .from(creatorProfiles)
+    .where(eq(creatorProfiles.usernameNormalized, options.username))
+    .limit(1);
+
+  if (!profile) {
+    console.error(`❌ No profile found for username "${options.username}"`);
+    process.exit(1);
+  }
+
+  console.log(`🎯 Scoped to @${profile.username} (${profile.id})`);
+  return profile.id;
+}
+
+async function countRows(
+  db: ReturnType<typeof drizzle>,
+  table: 'audience_members' | 'click_events' | 'daily_profile_views',
+  profileId?: string
+): Promise<number> {
+  if (table === 'audience_members') {
+    const [row] = await db
+      .select({ count: drizzleSql<number>`count(*)::int` })
+      .from(audienceMembers)
+      .where(syntheticAudienceMemberWhere(profileId));
+    return row?.count ?? 0;
+  }
+
+  if (table === 'click_events') {
+    const [row] = await db
+      .select({ count: drizzleSql<number>`count(*)::int` })
+      .from(clickEvents)
+      .where(syntheticClickEventWhere(profileId));
+    return row?.count ?? 0;
+  }
+
+  if (!profileId) {
+    const [row] = await db
+      .select({ count: drizzleSql<number>`count(*)::int` })
+      .from(dailyProfileViews);
+    return row?.count ?? 0;
+  }
+
+  const [row] = await db
+    .select({ count: drizzleSql<number>`count(*)::int` })
+    .from(dailyProfileViews)
+    .where(eq(dailyProfileViews.creatorProfileId, profileId));
+  return row?.count ?? 0;
+}
+
+async function sampleEncodedCities(
+  db: ReturnType<typeof drizzle>,
+  profileId?: string
+): Promise<Array<{ geoCity: string | null; count: number }>> {
+  const profileFilter = profileId
+    ? drizzleSql`${audienceMembers.creatorProfileId} = ${profileId}`
+    : drizzleSql`true`;
+
+  return db
+    .select({
+      geoCity: audienceMembers.geoCity,
+      count: drizzleSql<number>`count(*)::int`,
+    })
+    .from(audienceMembers)
+    .where(
+      drizzleSql`${profileFilter} AND ${audienceMembers.geoCity} LIKE ${'%\\%%'}`
+    )
+    .groupBy(audienceMembers.geoCity)
+    .orderBy(drizzleSql`count(*) desc`)
+    .limit(10);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    console.error('❌ DATABASE_URL not configured');
+    process.exit(1);
+  }
+
+  if (options.execute) {
+    assertSeedDatabaseTarget({
+      scriptName: 'cleanup-synthetic-audience.ts',
+    });
+  } else {
+    console.log('ℹ️  Dry-run mode (pass --execute to delete matched rows)');
+  }
+
+  const sqlClient = neon(databaseUrl);
+  const db = drizzle(sqlClient, { schema });
+  const profileId = await resolveProfileId(db, options);
+
+  const audienceCount = await countRows(db, 'audience_members', profileId);
+  const clickCount = await countRows(db, 'click_events', profileId);
+  const viewCount = options.includeViews
+    ? await countRows(db, 'daily_profile_views', profileId)
+    : 0;
+
+  console.log('\nSynthetic audience blast radius');
+  console.log(`  audience_members: ${audienceCount}`);
+  console.log(`  click_events:     ${clickCount}`);
+  if (options.includeViews) {
+    console.log(
+      `  daily_profile_views (profile-scoped, optional): ${viewCount}`
+    );
+  }
+
+  const encodedCitySamples = await sampleEncodedCities(db, profileId);
+  if (encodedCitySamples.length > 0) {
+    console.log('\nTop URL-encoded geo_city values:');
+    for (const sample of encodedCitySamples) {
+      console.log(`  ${sample.geoCity ?? '(null)'}: ${sample.count}`);
+    }
+  }
+
+  if (!options.execute) {
+    console.log('\nNo rows deleted (dry-run).');
+    return;
+  }
+
+  await db.delete(clickEvents).where(syntheticClickEventWhere(profileId));
+  await db
+    .delete(audienceMembers)
+    .where(syntheticAudienceMemberWhere(profileId));
+
+  if (options.includeViews && profileId) {
+    await db
+      .delete(dailyProfileViews)
+      .where(eq(dailyProfileViews.creatorProfileId, profileId));
+  }
+
+  const audienceAfter = await countRows(db, 'audience_members', profileId);
+  const clicksAfter = await countRows(db, 'click_events', profileId);
+
+  console.log('\nDelete complete');
+  console.log(`  audience_members removed: ${audienceCount - audienceAfter}`);
+  console.log(`  click_events removed: ${clickCount - clicksAfter}`);
+  if (options.includeViews && profileId) {
+    const viewsAfter = await countRows(db, 'daily_profile_views', profileId);
+    console.log(`  daily_profile_views removed: ${viewCount - viewsAfter}`);
+  }
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch(error => {
+      console.error('❌ cleanup-synthetic-audience failed:', error);
+      process.exit(1);
+    });
+}

--- a/apps/web/scripts/drizzle-seed.ts
+++ b/apps/web/scripts/drizzle-seed.ts
@@ -33,6 +33,7 @@ import {
 import { scraperConfigs } from '@/lib/db/schema/ingestion';
 import { socialAccounts, socialLinks } from '@/lib/db/schema/links';
 import { creatorContacts, creatorProfiles } from '@/lib/db/schema/profiles';
+import { assertSeedDatabaseTarget } from './seed-database-guard';
 import {
   chunk,
   FAN_NAMES,
@@ -45,9 +46,10 @@ import {
   pickWeightedLinkType,
   pickWeightedReferrer,
 } from './seed-helpers';
-
-const SEED_FINGERPRINT_PREFIX = 'seed_fp_';
-const SEED_TESTNET_IP_PREFIX = '203.0.113.';
+import {
+  SEED_FINGERPRINT_PREFIX,
+  SEED_TESTNET_IP_PREFIX,
+} from './synthetic-audience-markers';
 
 // Load .env.local first to override defaults, then fallback to .env
 dotenvConfig({ path: '.env.local', override: true });
@@ -1827,14 +1829,7 @@ async function seedDatabase() {
 }
 
 async function main() {
-  const branch =
-    process.env.VERCEL_GIT_COMMIT_REF || process.env.GIT_BRANCH || 'local';
-  console.log(`🔀 Detected branch: ${branch}`);
-
-  if (branch === 'production') {
-    console.log('⚠️  Skipping: will not seed production database');
-    return;
-  }
+  assertSeedDatabaseTarget({ scriptName: 'drizzle-seed.ts' });
 
   try {
     await initDb();

--- a/apps/web/scripts/seed-database-guard.test.ts
+++ b/apps/web/scripts/seed-database-guard.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assessDatabaseTarget,
+  isProductionDatabaseTarget,
+} from './seed-database-guard';
+
+describe('seed-database-guard', () => {
+  it('treats Doppler prd config as production', () => {
+    const assessment = assessDatabaseTarget({
+      DATABASE_URL: 'neon-dev-url',
+      DOPPLER_CONFIG: 'prd',
+    });
+
+    expect(assessment.target).toBe('production');
+    expect(assessment.reasons).toContain('DOPPLER_CONFIG=prd');
+  });
+
+  it('treats matching DATABASE_URL_MAIN as production', () => {
+    const url = 'neon-main-branch-url';
+
+    const assessment = assessDatabaseTarget({
+      DATABASE_URL: url,
+      DATABASE_URL_MAIN: url,
+    });
+
+    expect(assessment.target).toBe('production');
+    expect(assessment.reasons).toContain(
+      'DATABASE_URL matches DATABASE_URL_MAIN'
+    );
+  });
+
+  it('allows dev databases without production signals', () => {
+    const assessment = assessDatabaseTarget({
+      DATABASE_URL: 'neon-dev-branch-url',
+      DOPPLER_CONFIG: 'dev',
+      VERCEL_ENV: 'development',
+    });
+
+    expect(assessment.target).toBe('non-production');
+    expect(
+      isProductionDatabaseTarget({
+        DATABASE_URL: 'neon-dev-branch-url',
+        DOPPLER_CONFIG: 'dev',
+      })
+    ).toBe(false);
+  });
+
+  it('flags production DATABASE_URL substrings', () => {
+    const assessment = assessDatabaseTarget({
+      DATABASE_URL: 'neon-endpoint-production-branch',
+    });
+
+    expect(assessment.target).toBe('production');
+    expect(assessment.reasons).toContain('DATABASE_URL contains "production"');
+  });
+});

--- a/apps/web/scripts/seed-database-guard.ts
+++ b/apps/web/scripts/seed-database-guard.ts
@@ -1,0 +1,127 @@
+/**
+ * Refuse seed/demo scripts against production databases.
+ *
+ * drizzle-seed.ts previously only skipped when VERCEL_GIT_COMMIT_REF ===
+ * 'production', which does not protect `doppler run --config prd -- tsx ...`.
+ */
+
+export type DatabaseTarget = 'production' | 'non-production';
+
+export interface DatabaseTargetAssessment {
+  readonly target: DatabaseTarget;
+  readonly reasons: readonly string[];
+}
+
+const PRODUCTION_DOPPLER_CONFIGS = new Set(['prd', 'prod', 'production']);
+
+function readEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function redactDatabaseUrl(databaseUrl: string): string {
+  try {
+    const parsed = new URL(databaseUrl);
+    return `${parsed.protocol}//${parsed.hostname}${parsed.port ? `:${parsed.port}` : ''}${parsed.pathname}`;
+  } catch {
+    return '(unparseable DATABASE_URL)';
+  }
+}
+
+export function assessDatabaseTarget(
+  env: NodeJS.ProcessEnv = process.env
+): DatabaseTargetAssessment {
+  const reasons: string[] = [];
+  const databaseUrl = readEnv(env, 'DATABASE_URL')?.toLowerCase() ?? '';
+  const databaseUrlMain =
+    readEnv(env, 'DATABASE_URL_MAIN')?.toLowerCase() ?? '';
+
+  const dopplerConfig = readEnv(env, 'DOPPLER_CONFIG')?.toLowerCase();
+  if (dopplerConfig && PRODUCTION_DOPPLER_CONFIGS.has(dopplerConfig)) {
+    reasons.push(`DOPPLER_CONFIG=${dopplerConfig}`);
+  }
+
+  const dopplerEnvironment = readEnv(env, 'DOPPLER_ENVIRONMENT')?.toLowerCase();
+  if (dopplerEnvironment === 'production' || dopplerEnvironment === 'prd') {
+    reasons.push(`DOPPLER_ENVIRONMENT=${dopplerEnvironment}`);
+  }
+
+  if (readEnv(env, 'VERCEL_ENV') === 'production') {
+    reasons.push('VERCEL_ENV=production');
+  }
+
+  const gitBranch =
+    readEnv(env, 'VERCEL_GIT_COMMIT_REF') ??
+    readEnv(env, 'GIT_BRANCH') ??
+    undefined;
+  if (gitBranch === 'main' || gitBranch === 'production') {
+    reasons.push(`git branch=${gitBranch}`);
+  }
+
+  if (databaseUrl.includes('production')) {
+    reasons.push('DATABASE_URL contains "production"');
+  }
+
+  if (databaseUrlMain && databaseUrl && databaseUrl === databaseUrlMain) {
+    reasons.push('DATABASE_URL matches DATABASE_URL_MAIN');
+  }
+
+  return {
+    target: reasons.length > 0 ? 'production' : 'non-production',
+    reasons,
+  };
+}
+
+export function isProductionDatabaseTarget(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return assessDatabaseTarget(env).target === 'production';
+}
+
+export interface AssertSeedDatabaseTargetOptions {
+  readonly scriptName: string;
+  readonly allowProductionOverride?: boolean;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Exit the process when the active database target looks like production.
+ * Set ALLOW_PRODUCTION_SEED=1 to override (same pattern as ALLOW_PROD_MIGRATIONS).
+ */
+export function assertSeedDatabaseTarget(
+  options: AssertSeedDatabaseTargetOptions
+): void {
+  const env = options.env ?? process.env;
+  const assessment = assessDatabaseTarget(env);
+
+  if (assessment.target !== 'production') {
+    return;
+  }
+
+  const allowOverride =
+    options.allowProductionOverride === true ||
+    readEnv(env, 'ALLOW_PRODUCTION_SEED') === '1';
+
+  if (allowOverride) {
+    console.warn(
+      `⚠️  ${options.scriptName}: ALLOW_PRODUCTION_SEED=1 override — proceeding against production signals: ${assessment.reasons.join(', ')}`
+    );
+    return;
+  }
+
+  const databaseUrl = readEnv(env, 'DATABASE_URL');
+  console.error(
+    `❌ ${options.scriptName} refused: production database target detected.`
+  );
+  console.error(`   Signals: ${assessment.reasons.join(', ')}`);
+  if (databaseUrl) {
+    console.error(`   DATABASE_URL host: ${redactDatabaseUrl(databaseUrl)}`);
+  }
+  console.error(
+    '   Seed/demo scripts must run against dev or preview databases only.'
+  );
+  console.error(
+    '   If you truly intend production, set ALLOW_PRODUCTION_SEED=1 explicitly.'
+  );
+  process.exit(1);
+}

--- a/apps/web/scripts/seed-demo-account.ts
+++ b/apps/web/scripts/seed-demo-account.ts
@@ -26,6 +26,7 @@ import {
   INTERNAL_DJ_DEMO_PERSONA,
 } from '@/lib/demo-personas';
 import { DEFAULT_RELEASE_TASK_TEMPLATE } from '@/lib/release-tasks/default-template';
+import { assertSeedDatabaseTarget } from './seed-database-guard';
 
 const {
   users,
@@ -204,6 +205,8 @@ if (!DATABASE_URL) {
   console.error('DATABASE_URL not configured');
   process.exit(1);
 }
+
+assertSeedDatabaseTarget({ scriptName: 'seed-demo-account.ts' });
 
 const DEMO_CLERK_USER_ID = process.env.DEMO_CLERK_USER_ID;
 if (!DEMO_CLERK_USER_ID) {

--- a/apps/web/scripts/seed-video-release.ts
+++ b/apps/web/scripts/seed-video-release.ts
@@ -8,10 +8,12 @@
 import { eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import * as schema from '@/lib/db/schema';
+import { assertSeedDatabaseTarget } from './seed-database-guard';
 
 const { creatorProfiles, discogReleases, providerLinks } = schema;
 
 async function main() {
+  assertSeedDatabaseTarget({ scriptName: 'seed-video-release.ts' });
   // Find any claimed demo profile to attach the video release to
   const profiles = await db
     .select({

--- a/apps/web/scripts/synthetic-audience-markers.test.ts
+++ b/apps/web/scripts/synthetic-audience-markers.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifySyntheticAudienceMember,
+  isUrlEncodedGeoCity,
+  SEED_FINGERPRINT_PREFIX,
+} from './synthetic-audience-markers';
+
+describe('synthetic-audience-markers', () => {
+  it('detects seed script fingerprints and emails', () => {
+    expect(
+      classifySyntheticAudienceMember({
+        fingerprint: `${SEED_FINGERPRINT_PREFIX}8473a72f_12`,
+        email: 'seed.aud.8473a7.12@example.com',
+        geoCity: 'Los Angeles',
+      })
+    ).toEqual(['seed-fingerprint', 'seed-email']);
+  });
+
+  it('detects demo seed fingerprints and emails', () => {
+    expect(
+      classifySyntheticAudienceMember({
+        fingerprint: 'fp_demo_3',
+        email: 'demo.aud.3@example.com',
+        geoCity: 'Nashville',
+      })
+    ).toEqual(['demo-fingerprint', 'demo-email']);
+  });
+
+  it('detects URL-encoded geo cities from undecoded Vercel headers', () => {
+    expect(isUrlEncodedGeoCity('Los%20Angeles')).toBe(true);
+    expect(isUrlEncodedGeoCity('Forest%20City')).toBe(true);
+    expect(isUrlEncodedGeoCity('Los Angeles')).toBe(false);
+
+    expect(
+      classifySyntheticAudienceMember({
+        fingerprint: 'fp_realhash',
+        email: null,
+        geoCity: 'San%20Jose',
+      })
+    ).toEqual(['encoded-geo-city']);
+  });
+
+  it('returns no reasons for organic-looking members', () => {
+    expect(
+      classifySyntheticAudienceMember({
+        fingerprint: 'fp_8f3c2a1b9d0e',
+        email: 'fan@gmail.com',
+        geoCity: 'Austin',
+      })
+    ).toEqual([]);
+  });
+});

--- a/apps/web/scripts/synthetic-audience-markers.ts
+++ b/apps/web/scripts/synthetic-audience-markers.ts
@@ -1,0 +1,110 @@
+/**
+ * Heuristics for identifying seed/demo or undecoded-geo synthetic audience rows.
+ *
+ * Investigation notes (issue #11042):
+ * - drizzle-seed.ts writes plain city names and `seed_fp_*` fingerprints.
+ * - seed-demo-account.ts writes `fp_demo_*` fingerprints and `demo.aud.*@example.com`.
+ * - URL-encoded geo_city values (e.g. Los%20Angeles) come from routes that store
+ *   raw x-vercel-ip-city without decodeURIComponent (/api/track), not seed scripts.
+ */
+
+import { sql as drizzleSql, type SQL } from 'drizzle-orm';
+import {
+  audienceMembers,
+  clickEvents,
+  dailyProfileViews,
+} from '@/lib/db/schema/analytics';
+
+export const SEED_FINGERPRINT_PREFIX = 'seed_fp_';
+export const DEMO_FINGERPRINT_PREFIX = 'fp_demo_';
+export const SEED_TESTNET_IP_PREFIX = '203.0.113.';
+
+export type SyntheticAudienceReason =
+  | 'seed-fingerprint'
+  | 'demo-fingerprint'
+  | 'seed-email'
+  | 'demo-email'
+  | 'encoded-geo-city'
+  | 'seed-testnet-ip';
+
+export function isUrlEncodedGeoCity(
+  geoCity: string | null | undefined
+): boolean {
+  if (!geoCity) return false;
+  return geoCity.includes('%');
+}
+
+export function classifySyntheticAudienceMember(input: {
+  readonly fingerprint: string | null;
+  readonly email: string | null;
+  readonly geoCity: string | null;
+}): SyntheticAudienceReason[] {
+  const reasons: SyntheticAudienceReason[] = [];
+
+  if (input.fingerprint?.startsWith(SEED_FINGERPRINT_PREFIX)) {
+    reasons.push('seed-fingerprint');
+  }
+  if (input.fingerprint?.startsWith(DEMO_FINGERPRINT_PREFIX)) {
+    reasons.push('demo-fingerprint');
+  }
+  if (
+    input.email?.startsWith('seed.aud.') &&
+    input.email.endsWith('@example.com')
+  ) {
+    reasons.push('seed-email');
+  }
+  if (
+    input.email?.startsWith('demo.aud.') &&
+    input.email.endsWith('@example.com')
+  ) {
+    reasons.push('demo-email');
+  }
+  if (isUrlEncodedGeoCity(input.geoCity)) {
+    reasons.push('encoded-geo-city');
+  }
+
+  return reasons;
+}
+
+export function syntheticAudienceMemberWhere(profileId?: string): SQL<unknown> {
+  const profileFilter = profileId
+    ? drizzleSql`${audienceMembers.creatorProfileId} = ${profileId}`
+    : drizzleSql`true`;
+
+  return drizzleSql`
+    ${profileFilter}
+    AND (
+      ${audienceMembers.fingerprint} LIKE ${`${SEED_FINGERPRINT_PREFIX}%`}
+      OR ${audienceMembers.fingerprint} LIKE ${`${DEMO_FINGERPRINT_PREFIX}%`}
+      OR ${audienceMembers.email} LIKE ${'seed.aud.%@example.com'}
+      OR ${audienceMembers.email} LIKE ${'demo.aud.%@example.com'}
+      OR ${audienceMembers.geoCity} LIKE ${'%\\%%'}
+    )
+  `;
+}
+
+export function syntheticClickEventWhere(profileId?: string): SQL<unknown> {
+  const profileFilter = profileId
+    ? drizzleSql`${clickEvents.creatorProfileId} = ${profileId}`
+    : drizzleSql`true`;
+
+  return drizzleSql`
+    ${profileFilter}
+    AND (
+      ${clickEvents.ipAddress} LIKE ${`${SEED_TESTNET_IP_PREFIX}%`}
+      OR ${clickEvents.city} LIKE ${'%\\%%'}
+    )
+  `;
+}
+
+export function syntheticDailyProfileViewsWhere(
+  profileId?: string
+): SQL<unknown> {
+  const profileFilter = profileId
+    ? drizzleSql`${dailyProfileViews.creatorProfileId} = ${profileId}`
+    : drizzleSql`true`;
+
+  // Seed scripts generate 90 contiguous days; only offer this path when the
+  // caller passes --include-views alongside a scoped profile cleanup.
+  return profileFilter;
+}

--- a/apps/web/tests/unit/api/track/route.test.ts
+++ b/apps/web/tests/unit/api/track/route.test.ts
@@ -382,4 +382,42 @@ describe('POST /api/track', () => {
     );
     expect(recordAudienceEvent).not.toHaveBeenCalled();
   });
+
+  it('decodes percent-encoded x-vercel-ip-city before storing click events', async () => {
+    const clickValuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'click_event_123' }]),
+    });
+
+    hoisted.withSystemIngestionSession.mockImplementationOnce(async callback =>
+      callback({
+        insert: vi.fn().mockReturnValue({
+          values: clickValuesMock,
+        }),
+      })
+    );
+
+    const request = new NextRequest('http://localhost/api/track', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'jv_cc={"essential":true,"analytics":false,"marketing":false}',
+        'x-vercel-ip-city': 'Los%20Angeles',
+        'x-vercel-ip-country': 'US',
+      },
+      body: JSON.stringify({
+        handle: 'artist123',
+        linkType: 'listen',
+        target: 'https://open.spotify.com/artist/example',
+      }),
+    });
+
+    const response = await POST(request as unknown as NextRequest);
+    expect(response.status).toBe(200);
+
+    expect(clickValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        city: 'Los Angeles',
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- **Root cause (issue #11042):** `/api/track` read the `x-vercel-ip-city` Vercel header and stored it raw — percent-encoded — into `audience_members.geo_city` and `click_events.city` (e.g. `Los%20Angeles`, `San%20Jose`). The sibling route `/api/audience/visit` already called `decodeURIComponent` correctly; `/api/track` was the missing decode site.
- Added `decodeURIComponent` to `rawGeoCity` before it flows into `upsertAudienceMember` and the click-event insert, matching the pattern already used in the visit route (line 504).
- Added a regression test that sends `x-vercel-ip-city: Los%20Angeles` and asserts the stored `city` value is `Los Angeles` (would have failed before this fix).

## Context

The prior commit in this branch (`8b9c4a337`) added the production guard (`seed-database-guard.ts`), synthetic-row markers (`synthetic-audience-markers.ts`), and the cleanup script (`cleanup-synthetic-audience.ts`) to address the seeding side of #11042. This PR closes the remaining production bug that created those encoded rows in the first place.

## Test plan

- [x] `pnpm --filter web exec vitest run tests/unit/api/track/route.test.ts` — 8 tests, all pass
- [x] `pnpm --filter web exec vitest run scripts/seed-database-guard.test.ts scripts/synthetic-audience-markers.test.ts` — 8 tests, all pass
- [x] `pnpm --filter @jovie/web run typecheck` — no errors
- [x] `pnpm biome check` — no issues
- [ ] Cleanup of already-encoded rows: run `doppler run --project jovie-web --config prd -- pnpm tsx apps/web/scripts/cleanup-synthetic-audience.ts --username tim --execute` after this lands (dry-run first to confirm counts)

Closes #11042

🤖 Generated with [Claude Code](https://claude.com/claude-code)