### PR TITLE
fix: reconcile visits vs daily_profile_views and add a unique-views metric (#11041)

### DIFF
--- a/apps/web/app/api/audience/visit/route.ts
+++ b/apps/web/app/api/audience/visit/route.ts
@@ -665,24 +665,6 @@ export async function POST(request: NextRequest) {
           const instagramReferrerHost =
             getInstagramReferrerHost(resolvedReferrer);
 
-          if (compatibility.hasDailyProfileViewsTable && !isBotAudienceMember) {
-            await writeDailyProfileViews(tx, profileId, viewDate, now);
-          }
-
-          if (
-            compatibility.hasCreatorDistributionEventsTable &&
-            shouldTrackInstagramActivation &&
-            !isBotAudienceMember
-          ) {
-            await writeInstagramActivation(
-              tx,
-              profileId,
-              instagramReferrerHost,
-              utmParams,
-              now
-            );
-          }
-
           // Summary column value for fast list views
           const latestReferrerUrl = resolvedReferrer?.trim() ?? null;
           const recordProfileVisitEvent = async (audienceMemberId: string) => {
@@ -720,6 +702,9 @@ export async function POST(request: NextRequest) {
             );
           };
 
+          let audienceMemberId: string | null = null;
+          let visitRecorded = false;
+
           if (existing) {
             await tx
               .update(audienceMembers)
@@ -740,55 +725,152 @@ export async function POST(request: NextRequest) {
               })
               .where(eq(audienceMembers.id, existing.id));
 
-            if (compatibility.hasAudienceReferrersTable && latestReferrerUrl) {
-              await writeReferrer(tx, existing.id, latestReferrerUrl, now);
+            audienceMemberId = existing.id;
+            visitRecorded = !isBotAudienceMember;
+          } else {
+            const [inserted] = await tx
+              .insert(audienceMembers)
+              .values({
+                creatorProfileId: profileId,
+                fingerprint,
+                type: 'anonymous',
+                displayName: 'Visitor',
+                firstSeenAt: now,
+                lastSeenAt: now,
+                visits: updatedVisits,
+                engagementScore: updatedScore,
+                intentLevel: updatedIntent,
+                geoCity: geoCityValue,
+                geoCountry: geoCountryValue,
+                deviceType: normalizedDevice,
+                referrerHistory,
+                utmParams: resolvedUtmParams,
+                tags: mergedTags,
+                latestActions: [],
+                ...(compatibility.hasAudienceMemberLatestReferrerUrlColumn &&
+                  latestReferrerUrl && { latestReferrerUrl }),
+                updatedAt: now,
+                createdAt: now,
+              })
+              .onConflictDoNothing({
+                target: [
+                  audienceMembers.creatorProfileId,
+                  audienceMembers.fingerprint,
+                ],
+              })
+              .returning({ id: audienceMembers.id });
+
+            if (inserted) {
+              audienceMemberId = inserted.id;
+              visitRecorded = !isBotAudienceMember;
+            } else {
+              const [racedMember] = await tx
+                .select({
+                  id: audienceMembers.id,
+                  visits: audienceMembers.visits,
+                  latestActions: audienceMembers.latestActions,
+                  referrerHistory: audienceMembers.referrerHistory,
+                  engagementScore: audienceMembers.engagementScore,
+                  geoCity: audienceMembers.geoCity,
+                  geoCountry: audienceMembers.geoCountry,
+                  deviceType: audienceMembers.deviceType,
+                  utmParams: audienceMembers.utmParams,
+                  tags: audienceMembers.tags,
+                })
+                .from(audienceMembers)
+                .where(
+                  and(
+                    eq(audienceMembers.creatorProfileId, profileId),
+                    eq(audienceMembers.fingerprint, fingerprint)
+                  )
+                )
+                .limit(1);
+
+              if (racedMember) {
+                const racedTags = mergeAudienceTags(
+                  racedMember.tags,
+                  audienceTags
+                );
+                const racedIsBot = racedTags.includes('bot');
+                const racedActionCount = Array.isArray(
+                  racedMember.latestActions
+                )
+                  ? racedMember.latestActions.length
+                  : 0;
+                const racedVisits = racedIsBot
+                  ? racedMember.visits
+                  : racedMember.visits + 1;
+                const racedScore = racedIsBot
+                  ? racedMember.engagementScore
+                  : racedMember.engagementScore + 1;
+                const racedIntent = racedIsBot
+                  ? 'low'
+                  : deriveIntentLevel(racedVisits, racedActionCount);
+                const racedReferrers = Array.isArray(
+                  racedMember.referrerHistory
+                )
+                  ? racedMember.referrerHistory
+                  : [];
+                const racedReferrerHistory = trimHistory(
+                  [...referrerEntry, ...racedReferrers],
+                  3
+                );
+                const racedUtmParams = hasUtmParams
+                  ? utmParams
+                  : (racedMember.utmParams ?? {});
+
+                await tx
+                  .update(audienceMembers)
+                  .set({
+                    visits: racedVisits,
+                    lastSeenAt: now,
+                    updatedAt: now,
+                    engagementScore: racedScore,
+                    intentLevel: racedIntent,
+                    geoCity: resolvedGeoCity ?? racedMember.geoCity ?? null,
+                    geoCountry:
+                      resolvedGeoCountry ?? racedMember.geoCountry ?? null,
+                    deviceType: normalizedDevice,
+                    referrerHistory: racedReferrerHistory,
+                    tags: racedTags,
+                    ...(compatibility.hasAudienceMemberLatestReferrerUrlColumn &&
+                      latestReferrerUrl && { latestReferrerUrl }),
+                    ...(utmParams && { utmParams: racedUtmParams }),
+                  })
+                  .where(eq(audienceMembers.id, racedMember.id));
+
+                audienceMemberId = racedMember.id;
+                visitRecorded = !racedIsBot;
+              }
             }
-            await recordProfileVisitEvent(existing.id);
+          }
+
+          if (visitRecorded && compatibility.hasDailyProfileViewsTable) {
+            await writeDailyProfileViews(tx, profileId, viewDate, now);
+          }
+
+          if (
+            visitRecorded &&
+            compatibility.hasCreatorDistributionEventsTable &&
+            shouldTrackInstagramActivation
+          ) {
+            await writeInstagramActivation(
+              tx,
+              profileId,
+              instagramReferrerHost,
+              utmParams,
+              now
+            );
+          }
+
+          if (!audienceMemberId) {
             return;
           }
 
-          const [inserted] = await tx
-            .insert(audienceMembers)
-            .values({
-              creatorProfileId: profileId,
-              fingerprint,
-              type: 'anonymous',
-              displayName: 'Visitor',
-              firstSeenAt: now,
-              lastSeenAt: now,
-              visits: updatedVisits,
-              engagementScore: updatedScore,
-              intentLevel: updatedIntent,
-              geoCity: geoCityValue,
-              geoCountry: geoCountryValue,
-              deviceType: normalizedDevice,
-              referrerHistory,
-              utmParams: resolvedUtmParams,
-              tags: mergedTags,
-              latestActions: [],
-              ...(compatibility.hasAudienceMemberLatestReferrerUrlColumn &&
-                latestReferrerUrl && { latestReferrerUrl }),
-              updatedAt: now,
-              createdAt: now,
-            })
-            .onConflictDoNothing({
-              target: [
-                audienceMembers.creatorProfileId,
-                audienceMembers.fingerprint,
-              ],
-            })
-            .returning({ id: audienceMembers.id });
-
-          if (
-            inserted &&
-            compatibility.hasAudienceReferrersTable &&
-            latestReferrerUrl
-          ) {
-            await writeReferrer(tx, inserted.id, latestReferrerUrl, now);
+          if (compatibility.hasAudienceReferrersTable && latestReferrerUrl) {
+            await writeReferrer(tx, audienceMemberId, latestReferrerUrl, now);
           }
-          if (inserted) {
-            await recordProfileVisitEvent(inserted.id);
-          }
+          await recordProfileVisitEvent(audienceMemberId);
         });
       }
     );

--- a/apps/web/app/api/audience/visit/route.ts
+++ b/apps/web/app/api/audience/visit/route.ts
@@ -789,7 +789,7 @@ export async function POST(request: NextRequest) {
               if (racedMember) {
                 const racedTags = mergeAudienceTags(
                   racedMember.tags,
-                  audienceTags
+                  effectiveAudienceTags
                 );
                 const racedIsBot = racedTags.includes('bot');
                 const racedActionCount = Array.isArray(

--- a/apps/web/app/api/dashboard/analytics/route.ts
+++ b/apps/web/app/api/dashboard/analytics/route.ts
@@ -128,6 +128,7 @@ export async function GET(request: Request) {
       return NextResponse.json(
         {
           profile_views: 0,
+          unique_views: 0,
           unique_users: 0,
           tip_link_visits: 0,
           top_cities: [],

--- a/apps/web/lib/db/queries/analytics.ts
+++ b/apps/web/lib/db/queries/analytics.ts
@@ -84,6 +84,11 @@ export async function getUserDashboardAnalytics(
     const hasDailyProfileViews = await doesTableExist(
       TABLE_NAMES.dailyProfileViews
     );
+    // Canonical total views: daily_profile_views (written atomically with member
+    // visits on /api/audience/visit). SUM(audience_members.visits) diverges because
+    // (1) member visits predate the daily aggregate table, (2) seed scripts write
+    // independent random values, and (3) other write paths (e.g. short-link scans)
+    // increment member visits without daily_profile_views.
     const totalViewsSelect = hasDailyProfileViews
       ? drizzleSql`(
           select coalesce(sum(${dailyProfileViews.viewCount}), 0)
@@ -112,6 +117,7 @@ export async function getUserDashboardAnalytics(
               count: number;
             }>;
             total_views: AggregateValue;
+            unique_views: AggregateValue;
             unique_users: AggregateValue;
             total_clicks: AggregateValue;
             spotify_clicks: AggregateValue;
@@ -203,6 +209,15 @@ export async function getUserDashboardAnalytics(
               where ${audienceMembers.creatorProfileId} = ${creatorProfile.id}
                 and ${audienceMembers.lastSeenAt} >= ${sqlTimestamp(startDate)}
             ),
+            audience_unique_views as (
+              select 1
+              from ${audienceMembers}
+              where ${audienceMembers.creatorProfileId} = ${creatorProfile.id}
+                and ${audienceMembers.lastSeenAt} >= ${sqlTimestamp(startDate)}
+                and not (
+                  coalesce(${audienceMembers.tags}, '[]'::jsonb) @> '["bot"]'::jsonb
+                )
+            ),
             audience_identified as (
               select 1
               from ${audienceMembers}
@@ -212,6 +227,7 @@ export async function getUserDashboardAnalytics(
             )
             select
               ${totalViewsSelect} as total_views,
+              (select count(*) from audience_unique_views) as unique_views,
               (select count(*) from audience_recent) as unique_users,
               (select count(*) from ranged_events) as total_clicks,
               (select count(*) from ranged_events where link_type = 'listen') as spotify_clicks,
@@ -234,11 +250,13 @@ export async function getUserDashboardAnalytics(
     );
 
     const totalViews = Number(aggregates?.total_views ?? 0);
+    const uniqueViews = Number(aggregates?.unique_views ?? 0);
     const subscribers = Number(aggregates?.subscribers ?? 0);
 
     const base: DashboardAnalyticsResponse = {
       view,
       profile_views: totalViews,
+      unique_views: uniqueViews,
       unique_users: Number(aggregates?.unique_users ?? 0),
       subscribers,
       top_cities: parseJsonArray<{ city: string | null; count: number }>(

--- a/apps/web/tests/unit/api/audience/visit.test.ts
+++ b/apps/web/tests/unit/api/audience/visit.test.ts
@@ -366,14 +366,14 @@ describe('POST /api/audience/visit', () => {
         .fn()
         .mockReturnValueOnce({
           values: vi.fn().mockReturnValue({
-            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+            onConflictDoNothing: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'inserted_member' }]),
+            }),
           }),
         })
         .mockReturnValueOnce({
           values: vi.fn().mockReturnValue({
-            onConflictDoNothing: vi.fn().mockReturnValue({
-              returning: vi.fn().mockResolvedValue([{ id: 'inserted_member' }]),
-            }),
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
           }),
         });
 
@@ -416,29 +416,26 @@ describe('POST /api/audience/visit', () => {
     });
 
     mockWithSystemIngestionSession.mockImplementation(async callback => {
-      const mockInsert = vi
-        .fn()
-        .mockReturnValueOnce({
-          values: vi.fn().mockReturnValue({
-            onConflictDoUpdate: vi
-              .fn()
-              .mockRejectedValue(
-                new Error(
-                  '42P10: there is no unique or exclusion constraint matching the ON CONFLICT specification'
-                )
-              ),
-          }),
-        })
-        .mockReturnValueOnce({
-          values: vi.fn().mockReturnValue({
-            onConflictDoNothing: vi.fn().mockReturnValue({
-              returning: vi.fn().mockResolvedValue([{ id: 'inserted_member' }]),
-            }),
-          }),
-        });
+      const mockInsert = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoUpdate: vi
+            .fn()
+            .mockRejectedValue(
+              new Error(
+                '42P10: there is no unique or exclusion constraint matching the ON CONFLICT specification'
+              )
+            ),
+          onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
 
       const mockUpdate = vi
         .fn()
+        .mockReturnValueOnce({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+        })
         .mockReturnValueOnce({
           set: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
@@ -524,6 +521,115 @@ describe('POST /api/audience/visit', () => {
     expect(mockRecordAudienceEvent).not.toHaveBeenCalled();
   });
 
+  it('increments daily_profile_views only after a non-bot member visit is recorded', async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi
+            .fn()
+            .mockResolvedValue([{ id: 'profile_123', isPublic: true }]),
+        }),
+      }),
+    });
+
+    const writeOrder: string[] = [];
+    mockWithSystemIngestionSession.mockImplementation(async callback => {
+      const mockInsert = vi.fn().mockImplementation(() => ({
+        values: vi.fn().mockImplementation((value: Record<string, unknown>) => {
+          if (value.type === 'anonymous') {
+            writeOrder.push('audience_member');
+          }
+          if (typeof value.viewCount === 'number') {
+            writeOrder.push('daily_profile_views');
+          }
+          return {
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+            onConflictDoNothing: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'inserted_member' }]),
+            }),
+          };
+        }),
+      }));
+
+      await callback({
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+        insert: mockInsert,
+      });
+    });
+
+    const request = new NextRequest('http://localhost/api/audience/visit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        profileId: '123e4567-e89b-12d3-a456-426614174000',
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(writeOrder).toEqual(['audience_member', 'daily_profile_views']);
+  });
+
+  it('does not increment daily_profile_views for bot traffic', async () => {
+    mockDetectBot.mockReturnValue({ isBot: true, reason: 'User-Agent match' });
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi
+            .fn()
+            .mockResolvedValue([{ id: 'profile_123', isPublic: true }]),
+        }),
+      }),
+    });
+
+    const dailyViewWrites: unknown[] = [];
+    mockWithSystemIngestionSession.mockImplementation(async callback => {
+      const mockInsert = vi.fn().mockImplementation(() => ({
+        values: vi.fn().mockImplementation((value: Record<string, unknown>) => {
+          if (typeof value.viewCount === 'number') {
+            dailyViewWrites.push(value);
+          }
+          return {
+            onConflictDoNothing: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'inserted_member' }]),
+            }),
+          };
+        }),
+      }));
+
+      await callback({
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+        insert: mockInsert,
+      });
+    });
+
+    const request = new NextRequest('http://localhost/api/audience/visit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        profileId: '123e4567-e89b-12d3-a456-426614174000',
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(dailyViewWrites).toHaveLength(0);
+  });
+
   it('records visit for valid public profile', async () => {
     mockDbSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({
@@ -539,12 +645,12 @@ describe('POST /api/audience/visit', () => {
         values: vi
           .fn()
           .mockReturnValueOnce({
-            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-          })
-          .mockReturnValueOnce({
             onConflictDoNothing: vi.fn().mockReturnValue({
               returning: vi.fn().mockResolvedValue([{ id: 'inserted_member' }]),
             }),
+          })
+          .mockReturnValueOnce({
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
           }),
       });
 
@@ -694,10 +800,7 @@ describe('POST /api/audience/visit', () => {
       const mockInsert = vi.fn().mockReturnValue({
         values: vi
           .fn()
-          .mockReturnValueOnce({
-            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-          })
-          .mockImplementation((value: Record<string, unknown>) => {
+          .mockImplementationOnce((value: Record<string, unknown>) => {
             insertedValues.push(value);
             return {
               onConflictDoNothing: vi.fn().mockReturnValue({
@@ -706,6 +809,9 @@ describe('POST /api/audience/visit', () => {
                   .mockResolvedValue([{ id: 'inserted_member' }]),
               }),
             };
+          })
+          .mockReturnValueOnce({
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
           }),
       });
 
@@ -815,46 +921,41 @@ describe('POST /api/audience/visit', () => {
 
     const insertedValues: unknown[] = [];
     mockWithSystemIngestionSession.mockImplementation(async callback => {
-      const mockInsert = vi
-        .fn()
-        .mockReturnValueOnce({
-          // 1. daily profile view insert
-          values: vi.fn().mockImplementation(value => {
-            insertedValues.push(value);
-            return {
-              onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-            };
-          }),
-        })
-        .mockReturnValueOnce({
-          // 2. distribution event insert (before audience member)
-          values: vi.fn().mockImplementation(value => {
-            insertedValues.push(value);
+      const mockInsert = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation(value => {
+          insertedValues.push(value);
+          if (
+            typeof value === 'object' &&
+            value !== null &&
+            (value as { eventType?: unknown }).eventType === 'activated'
+          ) {
             return {
               onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
             };
-          }),
-        })
-        .mockReturnValueOnce({
-          // 3. audience member insert (new member path)
-          values: vi.fn().mockImplementation(value => {
-            insertedValues.push(value);
+          }
+          if (
+            typeof value === 'object' &&
+            value !== null &&
+            typeof (value as { viewCount?: unknown }).viewCount === 'number'
+          ) {
             return {
-              onConflictDoNothing: vi.fn().mockReturnValue({
-                returning: vi
-                  .fn()
-                  .mockResolvedValue([{ id: 'inserted_member' }]),
-              }),
+              onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
             };
-          }),
-        })
-        .mockReturnValueOnce({
-          // 4. audienceReferrers dual-write
-          values: vi.fn().mockImplementation(value => {
-            insertedValues.push(value);
+          }
+          if (
+            typeof value === 'object' &&
+            value !== null &&
+            (value as { audienceMemberId?: unknown }).audienceMemberId
+          ) {
             return Promise.resolve(undefined);
-          }),
-        });
+          }
+          return {
+            onConflictDoNothing: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'inserted_member' }]),
+            }),
+          };
+        }),
+      });
 
       await callback({
         select: vi.fn().mockReturnValue({
@@ -933,7 +1034,11 @@ describe('POST /api/audience/visit', () => {
           values: vi.fn().mockImplementation(value => {
             insertedValues.push(value);
             return {
-              onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+              onConflictDoNothing: vi.fn().mockReturnValue({
+                returning: vi
+                  .fn()
+                  .mockResolvedValue([{ id: 'inserted_member' }]),
+              }),
             };
           }),
         })
@@ -941,11 +1046,7 @@ describe('POST /api/audience/visit', () => {
           values: vi.fn().mockImplementation(value => {
             insertedValues.push(value);
             return {
-              onConflictDoNothing: vi.fn().mockReturnValue({
-                returning: vi
-                  .fn()
-                  .mockResolvedValue([{ id: 'inserted_member' }]),
-              }),
+              onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
             };
           }),
         });
@@ -1075,6 +1176,94 @@ describe('POST /api/audience/visit', () => {
       expect.any(Error),
       { profileId: '123e4567-e89b-12d3-a456-426614174000' }
     );
+  });
+
+  it('preserves raced member geo when insert conflicts and visit has no geo', async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi
+            .fn()
+            .mockResolvedValue([{ id: 'profile_123', isPublic: true }]),
+        }),
+      }),
+    });
+
+    const updateSets: Record<string, unknown>[] = [];
+    let audienceMemberSelectCount = 0;
+
+    mockWithSystemIngestionSession.mockImplementation(async callback => {
+      const mockInsert = vi.fn().mockReturnValue({
+        values: vi
+          .fn()
+          .mockReturnValueOnce({
+            onConflictDoNothing: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([]),
+            }),
+          })
+          .mockReturnValueOnce({
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          }),
+      });
+
+      await callback({
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockImplementation(async () => {
+                audienceMemberSelectCount += 1;
+                if (audienceMemberSelectCount === 1) {
+                  return [];
+                }
+                return [
+                  {
+                    id: 'aud_raced',
+                    visits: 1,
+                    latestActions: [],
+                    referrerHistory: [],
+                    engagementScore: 1,
+                    geoCity: 'Austin',
+                    geoCountry: 'US',
+                    deviceType: 'mobile',
+                    utmParams: {},
+                    tags: [],
+                  },
+                ];
+              }),
+            }),
+          }),
+        }),
+        insert: mockInsert,
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockImplementation((value: Record<string, unknown>) => {
+            updateSets.push(value);
+            return {
+              where: vi.fn().mockResolvedValue(undefined),
+            };
+          }),
+        }),
+      });
+    });
+
+    const request = new NextRequest('http://localhost/api/audience/visit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        profileId: '123e4567-e89b-12d3-a456-426614174000',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(audienceMemberSelectCount).toBe(2);
+    expect(updateSets).toHaveLength(1);
+    expect(updateSets[0]).toMatchObject({
+      geoCity: 'Austin',
+      geoCountry: 'US',
+    });
   });
 
   it('skips the aggregate write when daily_profile_views is missing', async () => {

--- a/apps/web/tests/unit/lib/db/queries/analytics-views.test.ts
+++ b/apps/web/tests/unit/lib/db/queries/analytics-views.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  getSessionContextMock: vi.fn(),
+  setupDbSessionMock: vi.fn(),
+  doesTableExistMock: vi.fn(),
+  cacheQueryMock: vi.fn(),
+  dashboardQueryMock: vi.fn(),
+  dbExecuteMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionContext: hoisted.getSessionContextMock,
+  setupDbSession: hoisted.setupDbSessionMock,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: { execute: hoisted.dbExecuteMock },
+  doesTableExist: hoisted.doesTableExistMock,
+  TABLE_NAMES: { dailyProfileViews: 'daily_profile_views' },
+}));
+
+vi.mock('@/lib/db/cache', () => ({
+  cacheQuery: hoisted.cacheQueryMock,
+}));
+
+vi.mock('@/lib/db/query-timeout', () => ({
+  dashboardQuery: hoisted.dashboardQueryMock,
+}));
+
+vi.mock('@/lib/db/schema/analytics', () => ({
+  audienceMembers: {
+    creatorProfileId: 'creator_profile_id',
+    lastSeenAt: 'last_seen_at',
+    tags: 'tags',
+    geoCity: 'geo_city',
+    geoCountry: 'geo_country',
+    referrerHistory: 'referrer_history',
+    updatedAt: 'updated_at',
+    email: 'email',
+  },
+  clickEvents: {
+    creatorProfileId: 'creator_profile_id',
+    isBot: 'is_bot',
+  },
+  dailyProfileViews: {
+    creatorProfileId: 'creator_profile_id',
+    viewDate: 'view_date',
+    viewCount: 'view_count',
+  },
+  notificationSubscriptions: {
+    creatorProfileId: 'creator_profile_id',
+    createdAt: 'created_at',
+  },
+}));
+
+vi.mock('@/lib/db/sql-helpers', () => ({
+  sqlTimestamp: (value: Date) => value,
+}));
+
+describe('getUserDashboardAnalytics view metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getSessionContextMock.mockResolvedValue({
+      profile: { id: 'profile-123' },
+    });
+    hoisted.setupDbSessionMock.mockResolvedValue(undefined);
+    hoisted.doesTableExistMock.mockResolvedValue(true);
+    hoisted.cacheQueryMock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    hoisted.dashboardQueryMock.mockImplementation(
+      async (fn: () => Promise<unknown>) => fn()
+    );
+  });
+
+  it('returns unique_views from daily_profile_views-backed total views', async () => {
+    hoisted.dbExecuteMock.mockResolvedValue({
+      rows: [
+        {
+          total_views: 150,
+          unique_views: 62,
+          unique_users: 70,
+          total_clicks: 20,
+          spotify_clicks: 10,
+          social_clicks: 5,
+          tip_link_visits: 1,
+          recent_clicks: 3,
+          listen_clicks: 10,
+          subscribers: 4,
+          identified_users: 2,
+          top_cities: [],
+          top_countries: [],
+          top_referrers: [],
+          top_links: [],
+        },
+      ],
+    });
+
+    const { getUserDashboardAnalytics } = await import(
+      '@/lib/db/queries/analytics'
+    );
+    const result = await getUserDashboardAnalytics(
+      'user_123',
+      '30d',
+      'traffic'
+    );
+
+    expect(result.profile_views).toBe(150);
+    expect(result.unique_views).toBe(62);
+    expect(result.unique_views).toBeLessThanOrEqual(result.profile_views);
+  });
+
+  it('keeps unique_views at or below profile_views for repeat-visitor totals', async () => {
+    hoisted.dbExecuteMock.mockResolvedValue({
+      rows: [
+        {
+          total_views: 500,
+          unique_views: 120,
+          unique_users: 130,
+          total_clicks: 0,
+          spotify_clicks: 0,
+          social_clicks: 0,
+          tip_link_visits: 0,
+          recent_clicks: 0,
+          listen_clicks: 0,
+          subscribers: 0,
+          identified_users: 0,
+          top_cities: [],
+          top_countries: [],
+          top_referrers: [],
+          top_links: [],
+        },
+      ],
+    });
+
+    const { getUserDashboardAnalytics } = await import(
+      '@/lib/db/queries/analytics'
+    );
+    const result = await getUserDashboardAnalytics('user_123', '7d', 'full');
+
+    expect(result.unique_views).toBeLessThanOrEqual(result.profile_views);
+  });
+});

--- a/apps/web/types/analytics.ts
+++ b/apps/web/types/analytics.ts
@@ -35,6 +35,8 @@ export interface TourDateAnalyticsData {
 
 export type DashboardAnalyticsResponse = {
   profile_views: number;
+  /** Distinct non-bot audience members/fingerprints active in the selected range. */
+  unique_views?: number;
   unique_users?: number;
   listen_clicks?: number;
   subscribers?: number;


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (grok-composer-2.5-fast). Closes #11041.

Card: t_941be40b
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- API/route 5xx rate + p95 latency on touched endpoints
- DB error rate + query latency (data-layer change)
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.