### PR TITLE
fix(design-system): tokenize circle icon vars

### DIFF
--- a/apps/web/components/atoms/CircleIconButton.tsx
+++ b/apps/web/components/atoms/CircleIconButton.tsx
@@ -127,10 +127,10 @@ const variantStyles: Record<
   pearl: {
     buttonVariant: 'ghost',
     className: cn(
-      'border border-[color:var(--profile-pearl-border)] bg-[var(--profile-pearl-bg)] text-primary-token backdrop-blur-xl',
-      'shadow-[var(--profile-pearl-shadow)]',
-      'hover:bg-[var(--profile-pearl-bg-hover)] hover:text-primary-token',
-      'active:bg-[var(--profile-pearl-bg-active)]'
+      'border border-(--profile-pearl-border) bg-(--profile-pearl-bg) text-primary-token backdrop-blur-xl',
+      'shadow-(--profile-pearl-shadow)',
+      'hover:bg-(--profile-pearl-bg-hover) hover:text-primary-token',
+      'active:bg-(--profile-pearl-bg-active)'
     ),
   },
   pearlQuiet: {
@@ -138,9 +138,9 @@ const variantStyles: Record<
     className: cn(
       'border border-transparent bg-transparent text-primary-token/78 backdrop-blur-xl',
       'shadow-none',
-      'hover:border-[color:var(--profile-pearl-border)] hover:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_88%,transparent)] hover:text-primary-token hover:shadow-[0_10px_24px_rgba(10,12,18,0.1)]',
-      'focus-visible:border-[color:var(--profile-pearl-border)] focus-visible:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_92%,transparent)] focus-visible:text-primary-token focus-visible:shadow-[0_10px_24px_rgba(10,12,18,0.12)]',
-      'active:bg-[var(--profile-pearl-bg-active)] active:text-primary-token'
+      'hover:border-(--profile-pearl-border) hover:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_88%,transparent)] hover:text-primary-token hover:shadow-[0_10px_24px_rgba(10,12,18,0.1)]',
+      'focus-visible:border-(--profile-pearl-border) focus-visible:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_92%,transparent)] focus-visible:text-primary-token focus-visible:shadow-[0_10px_24px_rgba(10,12,18,0.12)]',
+      'active:bg-(--profile-pearl-bg-active) active:text-primary-token'
     ),
   },
 };

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3290,
+  "count": 3282,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaces CircleIconButton profile pearl arbitrary CSS-variable utilities with Tailwind v4 shorthand.
- Keeps color-mix and raw shadow literals untouched because they are not exact token aliases.
- Lowers the arbitrary Tailwind ratchet baseline from `3290` to `3282`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/atoms/CircleIconButton.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/atoms/CircleIconButton.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied - `arbitrary-values-ratchet.test.ts` covers this drift reduction.