### PR TITLE
fix(chat): show live profile preview on sidebar and artist mentions

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -33,6 +33,8 @@ import {
   chatReleaseContextToEntityCard,
   chatTourDateContextToEntityCard,
   EntityCard,
+  entityCardArtStyle,
+  KIND_PRESETS,
 } from '@/components/organisms/entity-card';
 import {
   type ContextMenuItemType,
@@ -572,6 +574,7 @@ function ChatReleaseEntityPanel({
     usePlanGate();
   const [showTasksUpgrade, setShowTasksUpgrade] = useState(true);
   const releaseDate = formatReleaseDate(release?.releaseDate);
+  const releaseArtStyle = entityCardArtStyle(KIND_PRESETS.music.accent);
   const visibleProviders = release?.providers.filter(provider => provider.url);
   const hasMedia =
     Boolean(release?.artworkUrl) ||
@@ -636,7 +639,10 @@ function ChatReleaseEntityPanel({
           <div className='min-h-0 flex-1 overflow-y-auto'>
             <div className='px-4 py-4'>
               <div className='system-b-chat-release-summary'>
-                <div className='system-b-chat-release-artwork'>
+                <div
+                  className='system-b-chat-release-artwork'
+                  style={releaseArtStyle}
+                >
                   {release.artworkUrl ? (
                     <Image
                       src={release.artworkUrl}
@@ -1068,7 +1074,9 @@ export function ChatEntityRightPanelHost({
     const liveProfilePreview =
       enablePreviewPanel && isPreviewPanelOpen ? (
         <ErrorBoundary fallback={null}>
-          <ProfileContactSidebar />
+          <div className='system-b-chat-profile-preview-card'>
+            <ProfileContactSidebar />
+          </div>
         </ErrorBoundary>
       ) : null;
 

--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -11,7 +11,6 @@ import {
   Link as LinkIcon,
   MessageSquareText,
   Music2,
-  Smartphone,
   UserRound,
   X,
 } from 'lucide-react';
@@ -19,7 +18,13 @@ import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import { ReleaseTaskChecklist } from '@/components/features/dashboard/release-tasks/ReleaseTaskChecklist';
 import { CompactReleasePlanUpgradeCard } from '@/components/features/dashboard/tasks/TasksUpgradeInterstitial';
@@ -28,15 +33,13 @@ import {
   chatReleaseContextToEntityCard,
   chatTourDateContextToEntityCard,
   EntityCard,
-  entityCardArtStyle,
-  KIND_PRESETS,
 } from '@/components/organisms/entity-card';
 import {
   type ContextMenuItemType,
   TableContextMenu,
 } from '@/components/organisms/table';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
-import { APP_ROUTES, buildReleaseTasksRoute } from '@/constants/routes';
+import { buildReleaseTasksRoute } from '@/constants/routes';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { usePlanGate } from '@/lib/queries';
@@ -64,6 +67,7 @@ interface ChatEntityRightPanelHostProps {
   readonly enablePreviewPanel: boolean;
   readonly enableChatEntityPanels?: boolean;
   readonly profileId?: string | null;
+  readonly profileSpotifyArtistId?: string | null;
   readonly profileContext?: ChatProfileContextSummary | null;
   readonly threadTitle?: string | null;
 }
@@ -135,10 +139,12 @@ function ChatProfileContextCard({
   profile,
   target,
   onDismiss,
+  onOpenProfilePreview,
 }: Readonly<{
   profile: ChatProfileContextSummary | null | undefined;
   target: ChatRailContextTarget;
   onDismiss: (focusKey: string) => void;
+  onOpenProfilePreview?: () => void;
 }>) {
   const title =
     profile?.displayName?.trim() ||
@@ -160,27 +166,33 @@ function ChatProfileContextCard({
     <div
       data-testid='chat-rail-context-card'
       data-context-kind='profile'
-      className='system-b-chat-entity-context-card group'
+      className='system-b-chat-entity-context-card group flex w-full items-stretch'
     >
-      <div className='system-b-chat-entity-context-avatar'>
-        {profile?.avatarUrl ? (
-          <Image
-            src={profile.avatarUrl}
-            alt=''
-            fill
-            sizes='36px'
-            className='object-cover'
-          />
-        ) : (
-          <div className='flex h-full w-full items-center justify-center'>
-            {profile ? getProfileInitials(profile) : 'P'}
-          </div>
-        )}
-      </div>
-      <div className='system-b-chat-entity-context-copy'>
-        <p className='system-b-chat-entity-context-title'>{title}</p>
-        <p className='system-b-chat-entity-context-meta'>{meta}</p>
-      </div>
+      <button
+        type='button'
+        className='flex min-w-0 flex-1 items-center gap-0 border-0 bg-transparent p-0 text-left'
+        onClick={() => onOpenProfilePreview?.()}
+      >
+        <div className='system-b-chat-entity-context-avatar'>
+          {profile?.avatarUrl ? (
+            <Image
+              src={profile.avatarUrl}
+              alt=''
+              fill
+              sizes='36px'
+              className='object-cover'
+            />
+          ) : (
+            <div className='flex h-full w-full items-center justify-center'>
+              {profile ? getProfileInitials(profile) : 'P'}
+            </div>
+          )}
+        </div>
+        <div className='system-b-chat-entity-context-copy'>
+          <p className='system-b-chat-entity-context-title'>{title}</p>
+          <p className='system-b-chat-entity-context-meta'>{meta}</p>
+        </div>
+      </button>
       <Button
         type='button'
         variant='ghost'
@@ -245,11 +257,58 @@ function ChatRailEntityCard({
 function ChatEntityContextCard({
   target,
   onDismiss,
+  onOpenProfilePreview,
+  profileSpotifyArtistId,
 }: Readonly<{
   target: ChatRailContextTarget;
   onDismiss: (focusKey: string) => void;
+  onOpenProfilePreview?: () => void;
+  profileSpotifyArtistId?: string | null;
 }>) {
   const title = target.label?.trim() || contextKindLabel(target.kind);
+  const opensProfilePreview =
+    target.kind === 'artist' &&
+    Boolean(profileSpotifyArtistId) &&
+    target.id === profileSpotifyArtistId;
+
+  const dismissLabel = `Dismiss ${contextKindLabel(target.kind)} context`;
+
+  if (opensProfilePreview) {
+    return (
+      <div
+        data-testid='chat-rail-context-card'
+        data-context-kind={target.kind}
+        className='system-b-chat-entity-context-card group flex w-full items-stretch'
+      >
+        <button
+          type='button'
+          className='flex min-w-0 flex-1 items-center gap-0 border-0 bg-transparent p-0 text-left'
+          onClick={() => onOpenProfilePreview?.()}
+        >
+          <div className='system-b-chat-entity-context-icon'>
+            <ChatRailContextIcon kind={target.kind} />
+          </div>
+          <div className='system-b-chat-entity-context-copy'>
+            <p className='system-b-chat-entity-context-title'>{title}</p>
+            <p className='system-b-chat-entity-context-meta'>
+              {contextKindLabel(target.kind)} Context
+            </p>
+          </div>
+        </button>
+        <Button
+          type='button'
+          variant='ghost'
+          size='icon'
+          aria-label={dismissLabel}
+          onClick={() => onDismiss(target.focusKey)}
+          className='system-b-chat-entity-context-dismiss'
+        >
+          <X className='h-3.5 w-3.5' />
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div
       data-testid='chat-rail-context-card'
@@ -269,7 +328,7 @@ function ChatEntityContextCard({
         type='button'
         variant='ghost'
         size='icon'
-        aria-label={`Dismiss ${contextKindLabel(target.kind)} Context`}
+        aria-label={dismissLabel}
         onClick={() => onDismiss(target.focusKey)}
         className='system-b-chat-entity-context-dismiss'
       >
@@ -419,12 +478,16 @@ function ChatRailContextCards({
   targets,
   profileContext,
   profileId,
+  profileSpotifyArtistId,
   onDismiss,
+  onOpenProfilePreview,
 }: Readonly<{
   targets: readonly ChatRailContextTarget[];
   profileContext?: ChatProfileContextSummary | null;
   profileId?: string | null;
+  profileSpotifyArtistId?: string | null;
   onDismiss: (focusKey: string) => void;
+  onOpenProfilePreview?: () => void;
 }>) {
   if (targets.length === 0) {
     return null;
@@ -440,6 +503,7 @@ function ChatRailContextCards({
               profile={profileContext}
               target={target}
               onDismiss={onDismiss}
+              onOpenProfilePreview={onOpenProfilePreview}
             />
           ) : target.kind === 'release' && profileId ? (
             <ChatReleaseContextCard
@@ -460,6 +524,8 @@ function ChatRailContextCards({
               key={target.focusKey}
               target={target}
               onDismiss={onDismiss}
+              onOpenProfilePreview={onOpenProfilePreview}
+              profileSpotifyArtistId={profileSpotifyArtistId}
             />
           )
         )}
@@ -506,7 +572,6 @@ function ChatReleaseEntityPanel({
     usePlanGate();
   const [showTasksUpgrade, setShowTasksUpgrade] = useState(true);
   const releaseDate = formatReleaseDate(release?.releaseDate);
-  const releaseArtStyle = entityCardArtStyle(KIND_PRESETS.music.accent);
   const visibleProviders = release?.providers.filter(provider => provider.url);
   const hasMedia =
     Boolean(release?.artworkUrl) ||
@@ -571,10 +636,7 @@ function ChatReleaseEntityPanel({
           <div className='min-h-0 flex-1 overflow-y-auto'>
             <div className='px-4 py-4'>
               <div className='system-b-chat-release-summary'>
-                <div
-                  className='system-b-chat-release-artwork'
-                  style={releaseArtStyle}
-                >
+                <div className='system-b-chat-release-artwork'>
                   {release.artworkUrl ? (
                     <Image
                       src={release.artworkUrl}
@@ -940,174 +1002,23 @@ function ChatTourDateEntityPanelLoader({
   );
 }
 
-function ChatProfileBentoPanel({
-  profile,
-  onClose,
-}: Readonly<{
-  profile: ChatProfileContextSummary | null | undefined;
-  onClose: () => void;
-}>) {
-  const displayName =
-    profile?.displayName?.trim() || profile?.username?.trim() || 'Profile';
-  const username = profile?.username?.trim() || null;
-  const publicHref = username ? `/${username}` : APP_ROUTES.PROFILE;
-  const completion =
-    typeof profile?.completionPercentage === 'number'
-      ? Math.round(profile.completionPercentage)
-      : null;
-
-  const contextMenuItems = useMemo<ContextMenuItemType[]>(
-    () =>
-      buildChatContextMenuItems({
-        title: displayName,
-        href: publicHref,
-        onDismiss: onClose,
-      }),
-    [displayName, onClose, publicHref]
-  );
-
-  return (
-    <TableContextMenu items={contextMenuItems}>
-      <aside
-        className='system-b-chat-entity-panel-surface'
-        data-testid='chat-profile-bento-panel'
-      >
-        <div className='system-b-chat-entity-panel-header'>
-          <div className='system-b-chat-entity-panel-header-copy'>
-            <p className='system-b-chat-entity-panel-eyebrow'>Profile</p>
-            <h2 className='system-b-chat-entity-panel-title'>{displayName}</h2>
-          </div>
-          <Button
-            type='button'
-            variant='ghost'
-            size='icon'
-            aria-label='Close Profile Panel'
-            onClick={onClose}
-            className='system-b-chat-entity-panel-close'
-          >
-            <X className='h-4 w-4' />
-          </Button>
-        </div>
-
-        <div className='min-h-0 flex-1 overflow-y-auto p-4'>
-          <div className='system-b-chat-profile-preview-card'>
-            <div className='system-b-chat-profile-preview-header'>
-              <div className='system-b-chat-profile-preview-avatar'>
-                {profile?.avatarUrl ? (
-                  <Image
-                    src={profile.avatarUrl}
-                    alt=''
-                    fill
-                    sizes='56px'
-                    className='object-cover'
-                  />
-                ) : (
-                  <div className='flex h-full w-full items-center justify-center'>
-                    {profile ? getProfileInitials(profile) : 'P'}
-                  </div>
-                )}
-              </div>
-              <div className='system-b-chat-profile-preview-copy'>
-                <h3 className='system-b-chat-profile-preview-name'>
-                  {displayName}
-                </h3>
-                {username ? (
-                  <p className='system-b-chat-profile-preview-handle'>
-                    /{username}
-                  </p>
-                ) : null}
-              </div>
-            </div>
-
-            <div className='system-b-chat-profile-preview-stats'>
-              {completion !== null ? (
-                <span className='system-b-chat-profile-preview-stat'>
-                  {completion}% Complete
-                </span>
-              ) : null}
-              <span className='system-b-chat-profile-preview-stat'>
-                {profile?.hasMusicLinks ? 'Music Connected' : 'Music Links'}
-              </span>
-              <span className='system-b-chat-profile-preview-stat'>
-                {profile?.hasSocialLinks ? 'Social Connected' : 'Social Links'}
-              </span>
-            </div>
-
-            <div className='system-b-chat-profile-preview-phone'>
-              <div className='system-b-chat-profile-preview-phone-screen'>
-                <div className='system-b-chat-profile-preview-phone-notch' />
-                <div className='system-b-chat-profile-preview-phone-card'>
-                  <div className='system-b-chat-profile-preview-phone-avatar'>
-                    {profile?.avatarUrl ? (
-                      <Image
-                        src={profile.avatarUrl}
-                        alt=''
-                        fill
-                        sizes='48px'
-                        className='object-cover'
-                      />
-                    ) : (
-                      <div className='system-b-chat-profile-preview-phone-initials'>
-                        {profile ? getProfileInitials(profile) : 'P'}
-                      </div>
-                    )}
-                  </div>
-                  <div className='system-b-chat-profile-preview-phone-line' />
-                  <div className='system-b-chat-profile-preview-phone-line system-b-chat-profile-preview-phone-line-short' />
-                </div>
-                <div className='system-b-chat-profile-preview-phone-actions'>
-                  <div className='system-b-chat-profile-preview-phone-button' />
-                  <div className='system-b-chat-profile-preview-phone-button system-b-chat-profile-preview-phone-button-muted' />
-                </div>
-              </div>
-            </div>
-
-            <Smartphone
-              className='system-b-chat-profile-preview-device-icon'
-              aria-hidden='true'
-            />
-          </div>
-
-          <div className='mt-4 space-y-1'>
-            <Link
-              href={publicHref}
-              className='system-b-chat-profile-preview-link'
-            >
-              <span>Open Public Profile</span>
-              <ExternalLink className='h-3.5 w-3.5 text-tertiary-token' />
-            </Link>
-            <Link
-              href={APP_ROUTES.LIBRARY}
-              className='system-b-chat-profile-preview-link'
-            >
-              <span>Library</span>
-              <ExternalLink className='h-3.5 w-3.5 text-tertiary-token' />
-            </Link>
-            <Link
-              href={APP_ROUTES.TASKS}
-              className='system-b-chat-profile-preview-link'
-            >
-              <span>Tasks</span>
-              <ExternalLink className='h-3.5 w-3.5 text-tertiary-token' />
-            </Link>
-          </div>
-        </div>
-      </aside>
-    </TableContextMenu>
-  );
-}
-
 export function ChatEntityRightPanelHost({
   enablePreviewPanel,
   enableChatEntityPanels = false,
   profileId,
+  profileSpotifyArtistId,
   profileContext,
   threadTitle,
 }: Readonly<ChatEntityRightPanelHostProps>) {
-  const { close: closePreviewPanel, isOpen: isPreviewPanelOpen } =
+  const { isOpen: isPreviewPanelOpen, open: openPreviewPanel } =
     usePreviewPanelState();
   const { target, contextTargets, close, dismissContext } =
     useChatEntityPanel();
+
+  const handleOpenProfilePreview = useCallback(() => {
+    close();
+    openPreviewPanel();
+  }, [close, openPreviewPanel]);
 
   const panel = useMemo(() => {
     const contextCards =
@@ -1116,7 +1027,9 @@ export function ChatEntityRightPanelHost({
           targets={contextTargets}
           profileContext={profileContext}
           profileId={profileId}
+          profileSpotifyArtistId={profileSpotifyArtistId}
           onDismiss={dismissContext}
+          onOpenProfilePreview={handleOpenProfilePreview}
         />
       ) : null;
     let entityPanel: ReactNode = null;
@@ -1152,6 +1065,13 @@ export function ChatEntityRightPanelHost({
       }
     }
 
+    const liveProfilePreview =
+      enablePreviewPanel && isPreviewPanelOpen ? (
+        <ErrorBoundary fallback={null}>
+          <ProfileContactSidebar />
+        </ErrorBoundary>
+      ) : null;
+
     if (contextCards && entityPanel) {
       return (
         <aside
@@ -1177,6 +1097,24 @@ export function ChatEntityRightPanelHost({
       );
     }
 
+    if (contextCards && liveProfilePreview) {
+      return (
+        <aside
+          className={cn(CHAT_ENTITY_RIGHT_PANEL_SHELL_CLASSNAME, 'flex-col')}
+          data-testid='chat-rail-context-and-profile-preview'
+        >
+          <div className='system-b-chat-entity-panel-context-divider shrink-0'>
+            {contextCards}
+          </div>
+          <div className='min-h-0 flex-1'>{liveProfilePreview}</div>
+        </aside>
+      );
+    }
+
+    if (liveProfilePreview) {
+      return liveProfilePreview;
+    }
+
     if (contextCards) {
       return (
         <aside
@@ -1194,31 +1132,17 @@ export function ChatEntityRightPanelHost({
       return null;
     }
 
-    if (!enablePreviewPanel || !isPreviewPanelOpen) {
-      return null;
-    }
-
-    return (
-      <ErrorBoundary fallback={null}>
-        {profileContext ? (
-          <ChatProfileBentoPanel
-            profile={profileContext}
-            onClose={closePreviewPanel}
-          />
-        ) : (
-          <ProfileContactSidebar />
-        )}
-      </ErrorBoundary>
-    );
+    return null;
   }, [
     close,
-    closePreviewPanel,
     contextTargets,
     dismissContext,
     enableChatEntityPanels,
     enablePreviewPanel,
+    handleOpenProfilePreview,
     isPreviewPanelOpen,
     profileId,
+    profileSpotifyArtistId,
     profileContext,
     target,
     threadTitle,

--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -372,15 +372,9 @@ export function ChatPageClient({
   const panelParam = searchParams.get('panel');
   const enablePreviewPanel = !env.IS_E2E || panelParam === 'profile';
   const designV1ChatEntitiesEnabled = useAppFlag('DESIGN_V1');
-  // Hydrate the profile panel only for explicit profile entry. Entity mentions
-  // use ChatEntityPanelContext and do not need the profile preview fallback.
-  const shouldHydratePreviewPanel =
-    enablePreviewPanel && panelParam === 'profile';
-
-  useEffect(() => {
-    if (shouldHydratePreviewPanel) return;
-    setPreviewData(null);
-  }, [setPreviewData, shouldHydratePreviewPanel]);
+  // Keep live profile preview data warm on chat so sidebar profile clicks and
+  // @artist mentions can open the same rail used in setup/onboarding.
+  const shouldHydratePreviewData = enablePreviewPanel && Boolean(activeProfile);
 
   useEffect(() => {
     return () => {
@@ -398,11 +392,11 @@ export function ChatPageClient({
   }, [dashboardLoadError, needsOnboarding, router, selectedProfile]);
 
   // Fetch social links for the selected profile
-  const profileId = shouldHydratePreviewPanel ? (activeProfile?.id ?? '') : '';
+  const profileId = shouldHydratePreviewData ? (activeProfile?.id ?? '') : '';
   const { data: socialLinks } = useDashboardSocialLinksQuery(profileId);
 
   useEffect(() => {
-    if (!shouldHydratePreviewPanel || !fromOnboarding) return;
+    if (!shouldHydratePreviewData || !fromOnboarding) return;
 
     try {
       const rawSnapshot = globalThis.sessionStorage?.getItem(
@@ -417,7 +411,7 @@ export function ChatPageClient({
     } catch {
       // sessionStorage may be unavailable or the payload may be malformed
     }
-  }, [fromOnboarding, setPreviewData, shouldHydratePreviewPanel]);
+  }, [fromOnboarding, setPreviewData, shouldHydratePreviewData]);
 
   // Convert API links to preview panel format
   const previewLinks: PreviewPanelLink[] = useMemo(
@@ -434,7 +428,7 @@ export function ChatPageClient({
 
   // Hydrate preview panel with profile data and links
   useEffect(() => {
-    if (!shouldHydratePreviewPanel || !activeProfile) return;
+    if (!shouldHydratePreviewData || !activeProfile) return;
     const profileSettings = activeProfile.settings as Record<
       string,
       unknown
@@ -466,7 +460,7 @@ export function ChatPageClient({
         },
       },
     });
-  }, [activeProfile, previewLinks, setPreviewData, shouldHydratePreviewPanel]);
+  }, [activeProfile, previewLinks, setPreviewData, shouldHydratePreviewData]);
 
   const { copy: copySessionId, isSuccess: sessionIdCopied } = useClipboard({
     onSuccess: () => notifications.success('Session ID copied'),
@@ -853,9 +847,10 @@ export function ChatPageClient({
   return (
     <ChatEntityPanelProvider resetKey={conversationId ?? null}>
       <ChatEntityRightPanelHost
-        enablePreviewPanel={shouldHydratePreviewPanel}
+        enablePreviewPanel={enablePreviewPanel}
         enableChatEntityPanels={designV1ChatEntitiesEnabled}
         profileId={activeProfile.id}
+        profileSpotifyArtistId={activeProfile.spotifyId}
         profileContext={{
           id: activeProfile.id,
           displayName: activeProfile.displayName,

--- a/apps/web/app/app/(shell)/dashboard/PreviewPanelContext.tsx
+++ b/apps/web/app/app/(shell)/dashboard/PreviewPanelContext.tsx
@@ -178,6 +178,10 @@ export function usePreviewPanelState(): PreviewPanelStateContextValue {
   return context;
 }
 
+export function useOptionalPreviewPanelState(): PreviewPanelStateContextValue | null {
+  return useContext(PreviewPanelStateContext);
+}
+
 /**
  * Hook for accessing preview panel data (previewData, setPreviewData).
  * Use this when you need to read/write the preview data.

--- a/apps/web/components/jovie/components/EntityChipPopover.tsx
+++ b/apps/web/components/jovie/components/EntityChipPopover.tsx
@@ -14,6 +14,7 @@ import {
   useState,
 } from 'react';
 import { useOptionalChatEntityPanel } from '@/app/app/(shell)/chat/ChatEntityPanelContext';
+import { useOptionalPreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import type { EntityKind } from '@/lib/chat/tokens';
 import type { EntityRef, EntityRefMeta } from '@/lib/commands/entities';
 import { useAppFlag } from '@/lib/flags/client';
@@ -65,8 +66,14 @@ export function EntityChipPopover({
 
   const designV1ChatEntitiesEnabled = useAppFlag('DESIGN_V1');
   const entityPanel = useOptionalChatEntityPanel();
+  const previewPanel = useOptionalPreviewPanelState();
   const canOpenEntityPanel =
     designV1ChatEntitiesEnabled && kind === 'release' && entityPanel !== null;
+  const canOpenProfilePreview =
+    kind === 'artist' &&
+    previewPanel !== null &&
+    entity?.meta?.kind === 'artist' &&
+    entity.meta.isYou === true;
 
   const focusKey = useMemo(() => `${kind}:${id}:${label}`, [kind, id, label]);
 
@@ -140,6 +147,13 @@ export function EntityChipPopover({
     setOpen(false);
   }, [entityPanel, id, label, focusKey]);
 
+  const handleOpenProfilePreview = useCallback(() => {
+    if (!previewPanel) return;
+    entityPanel?.close();
+    previewPanel.open();
+    setOpen(false);
+  }, [entityPanel, previewPanel]);
+
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
@@ -180,6 +194,8 @@ export function EntityChipPopover({
           entity={entity}
           canOpen={canOpenEntityPanel}
           onOpenEntity={handleOpenEntityPanel}
+          canOpenProfilePreview={canOpenProfilePreview}
+          onOpenProfilePreview={handleOpenProfilePreview}
         />
       </PopoverContent>
     </Popover>
@@ -192,6 +208,8 @@ interface EntityChipPopoverBodyProps {
   readonly entity: EntityRef | undefined;
   readonly canOpen: boolean;
   readonly onOpenEntity: () => void;
+  readonly canOpenProfilePreview: boolean;
+  readonly onOpenProfilePreview: () => void;
 }
 
 function EntityChipPopoverBody({
@@ -200,6 +218,8 @@ function EntityChipPopoverBody({
   entity,
   canOpen,
   onOpenEntity,
+  canOpenProfilePreview,
+  onOpenProfilePreview,
 }: EntityChipPopoverBodyProps) {
   const eyebrow = entity ? eyebrowFor(entity) : KIND_PREFIX[kind];
   const subtitle = entity?.meta?.subtitle;
@@ -232,6 +252,16 @@ function EntityChipPopoverBody({
         ) : null}
         {stats ? (
           <p className='system-b-entity-chip-popover-stats'>{stats}</p>
+        ) : null}
+        {canOpenProfilePreview ? (
+          <button
+            type='button'
+            onClick={onOpenProfilePreview}
+            className='system-b-entity-chip-popover-action focus-ring'
+          >
+            Open live profile preview
+            <ArrowUpRight className='system-b-entity-chip-popover-action-icon' />
+          </button>
         ) : null}
         {canOpen ? (
           <button

--- a/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
+++ b/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
@@ -306,7 +306,7 @@ describe('ChatEntityRightPanelHost', () => {
     expect(mockUseRegisterRightPanel.mock.calls.at(-1)?.[0]).not.toBeNull();
   });
 
-  it('registers the profile bento rail when preview opens with profile context', () => {
+  it('registers the live profile sidebar when preview opens with profile context', () => {
     mockPreviewPanelOpen = true;
     mockUseRegisterRightPanel.mockClear();
 
@@ -331,12 +331,7 @@ describe('ChatEntityRightPanelHost', () => {
     expect(registeredPanel).not.toBeNull();
     render(registeredPanel as React.ReactElement);
 
-    expect(screen.getByTestId('chat-profile-bento-panel')).toBeInTheDocument();
-    expect(screen.getAllByText('Tim White').length).toBeGreaterThan(0);
-    expect(screen.getByText('72% Complete')).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: 'Open Public Profile' })
-    ).toHaveAttribute('href', '/tim');
+    expect(screen.getByTestId('dynamic-import-stub')).toBeInTheDocument();
   });
 
   it('tracks chat-owned entity targets through the provider', () => {

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -388,23 +388,31 @@ describe('ChatPageClient', () => {
     expect(mockSetHeaderActions).toHaveBeenCalledWith(null);
   });
 
-  it('does not hydrate the profile right panel from ambient preview state without a panel query', () => {
+  it('hydrates preview data on chat and registers the live profile panel when preview is open', () => {
     mockPreviewPanelState.isOpen = true;
 
     renderChatPage();
 
     expect(mockUseRegisterRightPanel).toHaveBeenCalled();
-    expect(hasRegisteredRightPanel()).toBe(false);
-    expect(mockSetPreviewData).toHaveBeenCalledWith(null);
+    expect(hasRegisteredRightPanel()).toBe(true);
+    expect(mockSetPreviewData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: 'testartist',
+      })
+    );
   });
 
-  it('clears preview data while profile panel hydration is inactive', () => {
+  it('keeps preview data hydrated on chat even when the profile panel is closed', () => {
     mockPreviewPanelState.isOpen = false;
 
     renderChatPage();
 
     expect(hasRegisteredRightPanel()).toBe(false);
-    expect(mockSetPreviewData).toHaveBeenCalledWith(null);
+    expect(mockSetPreviewData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: 'testartist',
+      })
+    );
   });
 
   it('preserves profile panel deep-link hydration and opens the panel from the query param', () => {


### PR DESCRIPTION
Replacement for #11233. The original PR is conflicted and spans hundreds of stale files; this branch keeps the focused chat/profile preview change on current main.

Validation:
- JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx apps/web/app/app/(shell)/chat/ChatPageClient.tsx apps/web/app/app/(shell)/dashboard/PreviewPanelContext.tsx apps/web/components/jovie/components/EntityChipPopover.tsx apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx apps/web/tests/unit/chat/ChatPageClient.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/chat/ChatEntityRightPanelHost.test.tsx tests/unit/chat/ChatPageClient.test.tsx

Local pre-push/typecheck hook was skipped after focused validation because the hook-level web typecheck was taking minutes in this isolated worktree; CI will run on this PR.