### PR TITLE
fix(design-system): tokenize profile contact vars

### DIFF
--- a/apps/web/app/[username]/notifications/NotificationsPageClient.tsx
+++ b/apps/web/app/[username]/notifications/NotificationsPageClient.tsx
@@ -52,25 +52,25 @@ export function NotificationsPageClient({ artist }: Props) {
   return (
     <ProfileNotificationsContext.Provider value={notificationsContextValue}>
       <div
-        className='relative flex h-dvh items-center justify-center overflow-hidden bg-[color:var(--profile-stage-bg)] p-4 sm:p-6'
+        className='relative flex h-dvh items-center justify-center overflow-hidden bg-(--profile-stage-bg) p-4 sm:p-6'
         data-testid='notifications-page'
         style={accentStyle}
       >
         <div
-          className='pointer-events-none absolute inset-0 bg-[var(--profile-stage-overlay)]'
+          className='pointer-events-none absolute inset-0 bg-(--profile-stage-overlay)'
           aria-hidden='true'
         />
         <div
-          className='pointer-events-none absolute left-[12%] top-[10%] h-56 w-56 rounded-full bg-[color:var(--profile-stage-glow-a)] blur-3xl sm:h-72 sm:w-72'
+          className='pointer-events-none absolute left-[12%] top-[10%] h-56 w-56 rounded-full bg-(--profile-stage-glow-a) blur-3xl sm:h-72 sm:w-72'
           aria-hidden='true'
         />
         <div
-          className='pointer-events-none absolute bottom-[12%] right-[10%] h-52 w-52 rounded-full bg-[color:var(--profile-stage-glow-b)] blur-3xl sm:h-64 sm:w-64'
+          className='pointer-events-none absolute bottom-[12%] right-[10%] h-52 w-52 rounded-full bg-(--profile-stage-glow-b) blur-3xl sm:h-64 sm:w-64'
           aria-hidden='true'
         />
         <div
           ref={setNotificationsPortalContainer}
-          className='relative z-10 flex h-[calc(100dvh-2rem)] w-full max-w-sm flex-col overflow-hidden rounded-[var(--profile-card-radius)] border border-[color:var(--profile-panel-border)] bg-[var(--profile-content-bg)] p-5 shadow-[var(--profile-panel-shadow)] backdrop-blur-2xl sm:h-[min(844px,calc(100dvh-48px))] sm:p-6 min-[1180px]:h-[min(940px,calc(100dvh-48px))] min-[1180px]:max-w-profile-notifications-wide min-[1180px]:p-8'
+          className='relative z-10 flex h-[calc(100dvh-2rem)] w-full max-w-sm flex-col overflow-hidden rounded-(--profile-card-radius) border border-(--profile-panel-border) bg-(--profile-content-bg) p-5 shadow-(--profile-panel-shadow) backdrop-blur-2xl sm:h-[min(844px,calc(100dvh-48px))] sm:p-6 min-[1180px]:h-[min(940px,calc(100dvh-48px))] min-[1180px]:max-w-profile-notifications-wide min-[1180px]:p-8'
         >
           <div className='mb-5 flex items-center justify-between'>
             <Link

--- a/apps/web/components/features/profile/ContactSection.tsx
+++ b/apps/web/components/features/profile/ContactSection.tsx
@@ -27,7 +27,7 @@ export function ContactSection({
   if (available.length === 0) {
     return (
       <div className='text-center'>
-        <div className='rounded-[var(--profile-card-radius)] border border-[color:var(--profile-panel-border)] bg-[var(--profile-content-bg)] p-6 shadow-[var(--profile-panel-shadow)] backdrop-blur-2xl'>
+        <div className='rounded-(--profile-card-radius) border border-(--profile-panel-border) bg-(--profile-content-bg) p-6 shadow-(--profile-panel-shadow) backdrop-blur-2xl'>
           <p className='text-sm text-secondary-token' role='alert'>
             No contact information is available for this artist yet.
           </p>
@@ -41,7 +41,7 @@ export function ContactSection({
       <h2 id='contact-title' className='sr-only'>
         Contact {artistName}
       </h2>
-      <div className='rounded-[var(--profile-inner-radius)] border border-[color:var(--profile-pearl-border)] bg-[var(--profile-pearl-bg)] p-2 shadow-[var(--profile-pearl-shadow)] backdrop-blur-xl'>
+      <div className='rounded-(--profile-inner-radius) border border-(--profile-pearl-border) bg-(--profile-pearl-bg) p-2 shadow-(--profile-pearl-shadow) backdrop-blur-xl'>
         <ProfileContactDrawerContent
           artistHandle={artistHandle}
           contacts={available}

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3282,
+  "count": 3266,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary

- Replaces profile notifications/contact arbitrary CSS-variable utilities with Tailwind v4 shorthand.
- Keeps the change syntax-only across profile `bg`, `border`, `rounded`, and `shadow` variables.
- Lowers the arbitrary Tailwind ratchet baseline from `3282` to `3266`.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/[username]/notifications/NotificationsPageClient.tsx apps/web/components/features/profile/ContactSection.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/app/[username]/notifications/NotificationsPageClient.tsx apps/web/components/features/profile/ContactSection.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook passed during `gt create`.
- Graphite submit pre-push passed: Biome repo check, Next proxy guard, Tailwind guard, web typecheck, and web lint.

bug-to-test: satisfied - `arbitrary-values-ratchet.test.ts` covers this drift reduction.