### PR TITLE
fix: exclude profile-owner self-traffic from audience analytics (#11040)

### DIFF
--- a/apps/web/app/api/audience/click/route.ts
+++ b/apps/web/app/api/audience/click/route.ts
@@ -235,7 +235,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Pro feature: exclude the artist's own clicks from analytics
+    // Exclude authenticated owner self-clicks from audience analytics
     if (await shouldExcludeSelfByProfileId(profileId)) {
       return NextResponse.json(
         { success: true, fingerprint: 'self-filtered' },

--- a/apps/web/app/api/audience/visit/route.ts
+++ b/apps/web/app/api/audience/visit/route.ts
@@ -1,5 +1,6 @@
 import { and, sql as drizzleSql, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { shouldExcludeSelfByProfileId } from '@/lib/analytics/self-exclusion';
 import {
   checkVisitRateLimit,
   getRateLimitHeaders,
@@ -550,6 +551,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: 'Profile is not public' },
         { status: 403, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    if (await shouldExcludeSelfByProfileId(profileId)) {
+      return NextResponse.json(
+        { success: true, fingerprint: 'self-filtered' },
+        { headers: NO_STORE_HEADERS }
       );
     }
 

--- a/apps/web/app/api/profile/view/route.ts
+++ b/apps/web/app/api/profile/view/route.ts
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Pro feature: exclude the artist's own visits from analytics
+    // Exclude authenticated owner self-views from profile view counts
     if (await shouldExcludeSelfByHandle(handle)) {
       return NextResponse.json(
         { success: true, filtered: true },

--- a/apps/web/lib/analytics/self-exclusion.ts
+++ b/apps/web/lib/analytics/self-exclusion.ts
@@ -7,13 +7,12 @@ import { users } from '@/lib/db/schema/auth';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 
 /**
- * Fetch the authenticated user's profile for self-exclusion checks.
+ * Fetch the authenticated user's active creator profile for self-exclusion checks.
  * Returns null if unauthenticated or profile not found.
  */
 async function getAuthenticatedUserProfile(): Promise<{
   profileId: string;
   usernameNormalized: string;
-  excludeSelf: boolean;
 } | null> {
   const { userId: clerkUserId } = await getOptionalAuth();
   if (!clerkUserId) return null;
@@ -22,7 +21,6 @@ async function getAuthenticatedUserProfile(): Promise<{
     .select({
       profileId: creatorProfiles.id,
       usernameNormalized: creatorProfiles.usernameNormalized,
-      settings: creatorProfiles.settings,
     })
     .from(creatorProfiles)
     .innerJoin(users, eq(users.activeProfileId, creatorProfiles.id))
@@ -31,11 +29,9 @@ async function getAuthenticatedUserProfile(): Promise<{
 
   if (!row) return null;
 
-  const settings = row.settings as Record<string, unknown> | null;
   return {
     profileId: row.profileId,
     usernameNormalized: row.usernameNormalized,
-    excludeSelf: Boolean(settings?.exclude_self_from_analytics),
   };
 }
 
@@ -43,12 +39,9 @@ async function getAuthenticatedUserProfile(): Promise<{
  * Check if the current authenticated user should be excluded from analytics
  * for a given profile (identified by handle/username).
  *
- * Returns true if:
- * 1. The visitor is authenticated
- * 2. They own the profile being visited
- * 3. They have `exclude_self_from_analytics` enabled in their settings
+ * Returns true when the visitor is authenticated and owns the profile.
+ * Anonymous traffic is never excluded.
  *
- * Returns false (don't exclude) if any condition is not met, or on error.
  * Designed to be non-blocking — failures are swallowed so tracking always works.
  */
 export async function shouldExcludeSelfByHandle(
@@ -56,7 +49,7 @@ export async function shouldExcludeSelfByHandle(
 ): Promise<boolean> {
   try {
     const profile = await getAuthenticatedUserProfile();
-    if (!profile?.excludeSelf) return false;
+    if (!profile) return false;
     return profile.usernameNormalized === handle.toLowerCase();
   } catch {
     // Never block tracking on auth/DB errors
@@ -68,15 +61,14 @@ export async function shouldExcludeSelfByHandle(
  * Check if the current authenticated user should be excluded from analytics
  * for a given profile (identified by creator profile ID).
  *
- * Same logic as shouldExcludeSelfByHandle but for click tracking which
- * uses profileId instead of handle.
+ * Same logic as shouldExcludeSelfByHandle but for audience visit/click tracking.
  */
 export async function shouldExcludeSelfByProfileId(
   profileId: string
 ): Promise<boolean> {
   try {
     const profile = await getAuthenticatedUserProfile();
-    if (!profile?.excludeSelf) return false;
+    if (!profile) return false;
     return profile.profileId === profileId;
   } catch {
     // Never block tracking on auth/DB errors

--- a/apps/web/tests/unit/api/audience/click.test.ts
+++ b/apps/web/tests/unit/api/audience/click.test.ts
@@ -5,6 +5,7 @@ const mockPublicClickLimiterGetStatus = vi.hoisted(() => vi.fn());
 const mockPublicClickLimiterLimit = vi.hoisted(() => vi.fn());
 const capturedInsertValues = vi.hoisted(() => [] as unknown[]);
 const mockDetectBot = vi.hoisted(() => vi.fn());
+const mockShouldExcludeSelfByProfileId = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/rate-limit', () => ({
   publicClickLimiter: {
@@ -132,6 +133,10 @@ vi.mock('@/lib/utils/bot-detection', () => ({
   detectBot: mockDetectBot,
 }));
 
+vi.mock('@/lib/analytics/self-exclusion', () => ({
+  shouldExcludeSelfByProfileId: mockShouldExcludeSelfByProfileId,
+}));
+
 const { POST } = await import('@/app/api/audience/click/route');
 
 describe('POST /api/audience/click', () => {
@@ -146,6 +151,7 @@ describe('POST /api/audience/click', () => {
     });
     mockPublicClickLimiterLimit.mockResolvedValue({ success: true });
     mockDetectBot.mockReturnValue({ isBot: false, shouldBlock: false });
+    mockShouldExcludeSelfByProfileId.mockResolvedValue(false);
   });
 
   it('returns 429 when rate limited', async () => {
@@ -198,6 +204,30 @@ describe('POST /api/audience/click', () => {
 
     expect(response.status).toBe(400);
     expect(data.error).toBe('Invalid click payload');
+  });
+
+  it('skips recording when the authenticated owner clicks their own profile', async () => {
+    mockShouldExcludeSelfByProfileId.mockResolvedValueOnce(true);
+
+    const request = new NextRequest('http://localhost/api/audience/click', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        profileId: '123e4567-e89b-12d3-a456-426614174000',
+        linkId: '123e4567-e89b-12d3-a456-426614174001',
+        linkType: 'social',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      fingerprint: 'self-filtered',
+    });
+    expect(capturedInsertValues).toHaveLength(0);
   });
 
   it('records click for valid payload', async () => {

--- a/apps/web/tests/unit/api/audience/visit.test.ts
+++ b/apps/web/tests/unit/api/audience/visit.test.ts
@@ -17,6 +17,7 @@ const mockCaptureError = vi.hoisted(() => vi.fn());
 const mockRecordAudienceEvent = vi.hoisted(() =>
   vi.fn().mockResolvedValue(undefined)
 );
+const mockShouldExcludeSelfByProfileId = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/rate-limit', () => ({
   publicVisitLimiter: {
@@ -75,6 +76,10 @@ vi.mock('@/lib/audience/record-audience-event', () => ({
   recordAudienceEvent: mockRecordAudienceEvent,
 }));
 
+vi.mock('@/lib/analytics/self-exclusion', () => ({
+  shouldExcludeSelfByProfileId: mockShouldExcludeSelfByProfileId,
+}));
+
 const { POST } = await import('@/app/api/audience/visit/route');
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -97,6 +102,7 @@ describe('POST /api/audience/visit', () => {
     mockDoesTableExist.mockResolvedValue(true);
     mockCaptureWarning.mockReset();
     mockCaptureError.mockReset();
+    mockShouldExcludeSelfByProfileId.mockResolvedValue(false);
   });
 
   it('returns 429 when rate limited', async () => {
@@ -484,6 +490,38 @@ describe('POST /api/audience/visit', () => {
 
     expect(response.status).toBe(200);
     expect(data.success).toBe(true);
+  });
+
+  it('skips recording when the authenticated owner views their own profile', async () => {
+    mockShouldExcludeSelfByProfileId.mockResolvedValueOnce(true);
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi
+            .fn()
+            .mockResolvedValue([{ id: 'profile_123', isPublic: true }]),
+        }),
+      }),
+    });
+
+    const request = new NextRequest('http://localhost/api/audience/visit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        profileId: '123e4567-e89b-12d3-a456-426614174000',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      fingerprint: 'self-filtered',
+    });
+    expect(mockWithSystemIngestionSession).not.toHaveBeenCalled();
+    expect(mockRecordAudienceEvent).not.toHaveBeenCalled();
   });
 
   it('records visit for valid public profile', async () => {

--- a/apps/web/tests/unit/lib/analytics/self-exclusion.test.ts
+++ b/apps/web/tests/unit/lib/analytics/self-exclusion.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetOptionalAuth = vi.hoisted(() => vi.fn());
+const mockDbSelect = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/cached', () => ({
+  getOptionalAuth: mockGetOptionalAuth,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mockDbSelect,
+  },
+}));
+
+const { shouldExcludeSelfByHandle, shouldExcludeSelfByProfileId } =
+  await import('@/lib/analytics/self-exclusion');
+
+const OWNER_PROFILE_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+function mockAuthenticatedProfile(
+  profileId = OWNER_PROFILE_ID,
+  usernameNormalized = 'tim'
+) {
+  mockGetOptionalAuth.mockResolvedValue({ userId: 'user_owner' });
+  mockDbSelect.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ profileId, usernameNormalized }]),
+        }),
+      }),
+    }),
+  });
+}
+
+describe('analytics self-exclusion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOptionalAuth.mockResolvedValue({ userId: null });
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    });
+  });
+
+  it('excludes authenticated owners viewing their own profile by id', async () => {
+    mockAuthenticatedProfile();
+
+    await expect(shouldExcludeSelfByProfileId(OWNER_PROFILE_ID)).resolves.toBe(
+      true
+    );
+  });
+
+  it('excludes authenticated owners viewing their own profile by handle', async () => {
+    mockAuthenticatedProfile(OWNER_PROFILE_ID, 'tim');
+
+    await expect(shouldExcludeSelfByHandle('tim')).resolves.toBe(true);
+    await expect(shouldExcludeSelfByHandle('TIM')).resolves.toBe(true);
+  });
+
+  it('does not exclude anonymous visitors', async () => {
+    mockGetOptionalAuth.mockResolvedValue({ userId: null });
+
+    await expect(shouldExcludeSelfByProfileId(OWNER_PROFILE_ID)).resolves.toBe(
+      false
+    );
+    await expect(shouldExcludeSelfByHandle('tim')).resolves.toBe(false);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not exclude authenticated visitors on another profile', async () => {
+    mockAuthenticatedProfile(OWNER_PROFILE_ID, 'tim');
+
+    await expect(
+      shouldExcludeSelfByProfileId('223e4567-e89b-12d3-a456-426614174001')
+    ).resolves.toBe(false);
+    await expect(shouldExcludeSelfByHandle('dualipa')).resolves.toBe(false);
+  });
+
+  it('fails open when auth lookup throws', async () => {
+    mockGetOptionalAuth.mockRejectedValue(new Error('auth unavailable'));
+
+    await expect(shouldExcludeSelfByProfileId(OWNER_PROFILE_ID)).resolves.toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (grok-composer-2.5-fast). Closes #11040.

Card: t_d2bb8205
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- API/route 5xx rate + p95 latency on touched endpoints
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Self-visits and self-clicks are now consistently excluded from analytics tracking across all endpoints.

* **Tests**
  * Added test coverage for self-exclusion behavior to ensure accurate analytics reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->