### PR TITLE
fix: extend bot detection to catch datacenter/cloud traffic (#11039)

### DIFF
--- a/apps/web/app/api/audience/click/route.ts
+++ b/apps/web/app/api/audience/click/route.ts
@@ -137,16 +137,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Bot detection - detect but continue to record with isBot flag
-    const botDetection = detectBot(request, '/api/audience/click');
-    if (botDetection.isBot && botDetection.shouldBlock) {
-      // Return success but don't record for blocked bots
-      return NextResponse.json(
-        { success: true, fingerprint: 'bot-filtered' },
-        { headers: NO_STORE_HEADERS }
-      );
-    }
-
     let body: unknown;
     try {
       body = await request.json();
@@ -246,7 +236,12 @@ export async function POST(request: NextRequest) {
     const fingerprint = createFingerprint(resolvedIP, userAgent);
     const normalizedDevice = deviceType ?? 'unknown';
     const now = new Date();
-    const audienceTags = botDetection.isBot ? ['bot'] : [];
+    const preliminaryBotDetection = detectBot(request, '/api/audience/click', {
+      userAgent,
+    });
+    const preliminaryAudienceTags = preliminaryBotDetection.isBot
+      ? ['bot']
+      : [];
 
     // Encrypt IP address for storage (GDPR/CCPA compliance)
     const encryptedIP = encryptIP(resolvedIP);
@@ -275,7 +270,7 @@ export async function POST(request: NextRequest) {
             deviceType: normalizedDevice,
             referrerHistory: [],
             latestActions: [],
-            tags: audienceTags,
+            tags: preliminaryAudienceTags,
             createdAt: now,
             updatedAt: now,
           })
@@ -312,6 +307,12 @@ export async function POST(request: NextRequest) {
       const existingActionCount = Array.isArray(member.latestActions)
         ? member.latestActions.length
         : 0;
+      const botDetection = detectBot(request, '/api/audience/click', {
+        userAgent,
+        memberVisits: member.visits ?? 0,
+        memberConversions: existingActionCount,
+      });
+      const audienceTags = botDetection.isBot ? ['bot'] : [];
       const actionCount = Math.min(existingActionCount + 1, 5);
       const weight = getActionWeight(linkType);
       const tags = mergeAudienceTags(member.tags, audienceTags);

--- a/apps/web/app/api/audience/visit/route.ts
+++ b/apps/web/app/api/audience/visit/route.ts
@@ -484,7 +484,6 @@ export async function POST(request: NextRequest) {
     const botResult = detectBot(request, '/api/audience/visit', {
       userAgent: resolvedUserAgent,
     });
-    const audienceTags = botResult.isBot ? ['bot'] : [];
     // Use the client-provided referrer (document.referrer) if available.
     // The HTTP Referer header on same-origin fetch() is the current page URL,
     // NOT the external referrer, so we filter out self-referrals from the fallback.
@@ -611,14 +610,24 @@ export async function POST(request: NextRequest) {
             )
             .limit(1);
 
-          const mergedTags = mergeAudienceTags(existing?.tags, audienceTags);
+          const actionCount = Array.isArray(existing?.latestActions)
+            ? existing.latestActions.length
+            : 0;
+          const velocityBotResult = detectBot(request, '/api/audience/visit', {
+            userAgent: resolvedUserAgent,
+            memberVisits: existing?.visits ?? 0,
+            memberConversions: actionCount,
+          });
+          const effectiveAudienceTags =
+            botResult.isBot || velocityBotResult.isBot ? ['bot'] : [];
+          const mergedTags = mergeAudienceTags(
+            existing?.tags,
+            effectiveAudienceTags
+          );
           const isBotAudienceMember = mergedTags.includes('bot');
           const updatedVisits = isBotAudienceMember
             ? (existing?.visits ?? 0)
             : (existing?.visits ?? 0) + 1;
-          const actionCount = Array.isArray(existing?.latestActions)
-            ? existing.latestActions.length
-            : 0;
           const updatedIntent = isBotAudienceMember
             ? 'low'
             : deriveIntentLevel(updatedVisits, actionCount);

--- a/apps/web/lib/utils/bot-detection.ts
+++ b/apps/web/lib/utils/bot-detection.ts
@@ -15,9 +15,51 @@ export interface BotDetectionResult {
   asn?: number;
 }
 
-interface DetectBotOptions {
+export interface DetectBotOptions {
   readonly userAgent?: string | null;
+  readonly asn?: number;
+  readonly memberVisits?: number;
+  readonly memberConversions?: number;
 }
+
+/** Minimum visits before the high-velocity zero-click heuristic applies. */
+export const VELOCITY_BOT_MIN_VISITS = 40;
+
+/** Maximum conversions allowed for the high-velocity zero-click heuristic. */
+export const VELOCITY_BOT_MAX_CONVERSIONS = 0;
+
+/**
+ * Known cloud/hosting provider ASNs observed in datacenter-city traffic
+ * (AWS, Azure, GCP, OCI, DigitalOcean, etc.).
+ */
+export const DATACENTER_ASNS = new Set([
+  // Amazon AWS
+  16509, 14618, 8987, 7224, 39111, 393406,
+  // Microsoft Azure
+  8075, 8068, 8069, 12076, 35106, 35908,
+  // Google Cloud
+  15169, 396982, 19527, 36040, 36039,
+  // Oracle Cloud
+  31898, 14340,
+  // DigitalOcean
+  14061,
+  // Linode / Akamai
+  63949,
+  // Vultr
+  20473,
+  // Hetzner
+  24940,
+  // OVH
+  16276,
+  // Scaleway
+  12876,
+  // Alibaba Cloud
+  45102, 37963,
+  // Tencent Cloud
+  132203, 45090,
+  // IBM Cloud
+  36351, 14148,
+]);
 
 // Conservative bot detection - only block obvious crawlers on sensitive endpoints
 const META_USER_AGENTS = [
@@ -46,6 +88,39 @@ const KNOWN_CRAWLERS = [
 ];
 
 /**
+ * Extract ASN from CDN/proxy headers (Vercel, Cloudflare).
+ */
+export function extractAsnFromRequest(request: {
+  headers: Headers;
+}): number | undefined {
+  const raw =
+    request.headers.get('x-vercel-ip-asn')?.trim() ||
+    request.headers.get('cf-ip-asn')?.trim() ||
+    null;
+
+  if (!raw) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function isDatacenterAsn(asn: number): boolean {
+  return DATACENTER_ASNS.has(asn);
+}
+
+export function isHighVelocityZeroClickBot(
+  visits: number,
+  conversions: number
+): boolean {
+  return (
+    visits >= VELOCITY_BOT_MIN_VISITS &&
+    conversions <= VELOCITY_BOT_MAX_CONVERSIONS
+  );
+}
+
+/**
  * Detects if request is from a bot with anti-cloaking considerations
  */
 export function detectBot(
@@ -66,7 +141,14 @@ export function detectBot(
     userAgent.toLowerCase().includes(bot.toLowerCase())
   );
 
-  const isBot = isMeta || isKnownCrawler;
+  const asn = options.asn ?? extractAsnFromRequest(request);
+  const isDatacenter = asn !== undefined && isDatacenterAsn(asn);
+  const isVelocityBot =
+    options.memberVisits !== undefined &&
+    options.memberConversions !== undefined &&
+    isHighVelocityZeroClickBot(options.memberVisits, options.memberConversions);
+
+  const isBot = isMeta || isKnownCrawler || isDatacenter || isVelocityBot;
 
   // Determine blocking strategy based on endpoint
   let shouldBlock = false;
@@ -81,6 +163,10 @@ export function detectBot(
   } else if (isKnownCrawler) {
     reason = 'Known crawler detected';
     // Don't block other crawlers to avoid anti-cloaking issues
+  } else if (isDatacenter) {
+    reason = 'datacenter_asn';
+  } else if (isVelocityBot) {
+    reason = 'high_velocity_zero_click';
   }
 
   return {
@@ -89,6 +175,7 @@ export function detectBot(
     reason,
     shouldBlock,
     userAgent,
+    asn,
   };
 }
 

--- a/apps/web/tests/lib/utils/bot-detection.test.ts
+++ b/apps/web/tests/lib/utils/bot-detection.test.ts
@@ -228,6 +228,86 @@ describe('Bot Detection', () => {
       expect(result.isBot).toBe(false);
       expect(result.userAgent).toBe('');
     });
+
+    describe('datacenter ASN detection', () => {
+      const chromeUserAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+      it('should flag Azure datacenter ASN with a normal browser UA', () => {
+        const request = createMockRequest(chromeUserAgent, {
+          headers: { 'x-vercel-ip-asn': '8075' },
+        });
+
+        const result = detectBot(request);
+
+        expect(result.isBot).toBe(true);
+        expect(result.reason).toBe('datacenter_asn');
+        expect(result.asn).toBe(8075);
+        expect(result.shouldBlock).toBe(false);
+      });
+
+      it('should flag AWS datacenter ASN from Cloudflare header', () => {
+        const request = createMockRequest(chromeUserAgent, {
+          headers: { 'cf-ip-asn': '16509' },
+        });
+
+        const result = detectBot(request);
+
+        expect(result.isBot).toBe(true);
+        expect(result.reason).toBe('datacenter_asn');
+        expect(result.asn).toBe(16509);
+      });
+
+      it('should not flag residential ASN', () => {
+        const request = createMockRequest(chromeUserAgent, {
+          headers: { 'x-vercel-ip-asn': '7018' },
+        });
+
+        const result = detectBot(request);
+
+        expect(result.isBot).toBe(false);
+        expect(result.asn).toBe(7018);
+      });
+    });
+
+    describe('high-velocity zero-click heuristic', () => {
+      const chromeUserAgent =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+      it('should flag members with high visits and zero conversions', () => {
+        const request = createMockRequest(chromeUserAgent);
+
+        const result = detectBot(request, '/api/audience/visit', {
+          memberVisits: 40,
+          memberConversions: 0,
+        });
+
+        expect(result.isBot).toBe(true);
+        expect(result.reason).toBe('high_velocity_zero_click');
+      });
+
+      it('should not flag members below the visit threshold', () => {
+        const request = createMockRequest(chromeUserAgent);
+
+        const result = detectBot(request, '/api/audience/visit', {
+          memberVisits: 39,
+          memberConversions: 0,
+        });
+
+        expect(result.isBot).toBe(false);
+      });
+
+      it('should not flag members with conversions', () => {
+        const request = createMockRequest(chromeUserAgent);
+
+        const result = detectBot(request, '/api/audience/visit', {
+          memberVisits: 40,
+          memberConversions: 1,
+        });
+
+        expect(result.isBot).toBe(false);
+      });
+    });
   });
 
   describe('createBotResponse', () => {


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (grok-composer-2.5-fast). Closes #11039.

Card: t_df3f9315
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- API/route 5xx rate + p95 latency on touched endpoints
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.