### PR TITLE
fix(design-system): tokenize amount selector vars

### DIFF
--- a/apps/web/components/atoms/AmountSelector.tsx
+++ b/apps/web/components/atoms/AmountSelector.tsx
@@ -36,8 +36,8 @@ export const AmountSelector = memo(function AmountSelector({
         'group relative flex aspect-square w-full flex-col items-center justify-center gap-0.5 rounded-2xl border text-center transition-[background-color,border-color,box-shadow,color,opacity] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-base',
         disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
         isSelected
-          ? 'border-[color:var(--profile-pearl-primary-bg)] bg-[var(--profile-pearl-primary-bg)] text-[var(--profile-pearl-primary-fg)] ring-1 ring-white/10'
-          : 'border-black/6 bg-white text-primary-token ring-1 ring-black/[0.03] hover:border-black/10 hover:bg-[var(--profile-pearl-bg-hover)] hover:ring-black/[0.05] dark:border-white/10 dark:bg-(--color-text-tooltip) dark:ring-white/[0.04] dark:hover:border-white/14 dark:hover:bg-[var(--profile-pearl-bg-hover)] dark:hover:ring-white/[0.06]',
+          ? 'border-(--profile-pearl-primary-bg) bg-(--profile-pearl-primary-bg) text-(--profile-pearl-primary-fg) ring-1 ring-white/10'
+          : 'border-black/6 bg-white text-primary-token ring-1 ring-black/[0.03] hover:border-black/10 hover:bg-(--profile-pearl-bg-hover) hover:ring-black/[0.05] dark:border-white/10 dark:bg-(--color-text-tooltip) dark:ring-white/[0.04] dark:hover:border-white/14 dark:hover:bg-(--profile-pearl-bg-hover) dark:hover:ring-white/[0.06]',
         className
       )}
     >
@@ -45,7 +45,7 @@ export const AmountSelector = memo(function AmountSelector({
         className={cn(
           'text-3xs font-medium tracking-[0.08em]',
           isSelected
-            ? 'text-[var(--profile-pearl-primary-fg)]/72'
+            ? 'text-(--profile-pearl-primary-fg)/72'
             : 'text-secondary-token'
         )}
         aria-hidden

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3266,
+  "count": 3260,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replaces exact `var(--profile-*)` arbitrary classes in `AmountSelector` with Tailwind CSS-variable shorthand.
- Drops the arbitrary-value ratchet baseline from `3266` to `3260`.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/atoms/AmountSelector.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/atoms/AmountSelector.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `JOVIE_AGENT_PROFILE=coder git push -u origin codex/jov-ds-amount-selector-var-token-aliases` pre-push gate passed Biome, proxy guard, Tailwind guard, typecheck, and lint.

bug-to-test: satisfied - `arbitrary-values-ratchet.test.ts` covers this drift reduction.