### PR TITLE
fix(design-system): tokenize artist info drift

### DIFF
--- a/apps/web/components/molecules/ArtistInfo.tsx
+++ b/apps/web/components/molecules/ArtistInfo.tsx
@@ -43,8 +43,8 @@ export function ArtistInfo({
     subtitle ?? artist.tagline ?? DEFAULT_PROFILE_TAGLINE;
   const subtitleClassName =
     resolvedSubtitle === DEFAULT_PROFILE_TAGLINE
-      ? 'text-xs font-semibold leading-none tracking-[-0.01em] text-tertiary-token'
-      : 'text-app sm:text-mid font-[520] leading-[1.32] tracking-[-0.02em] text-secondary-token line-clamp-2';
+      ? 'text-xs font-semibold leading-none tracking-tight text-tertiary-token'
+      : 'text-app sm:text-mid font-[520] leading-[1.32] tracking-tighter text-secondary-token line-clamp-2';
 
   const avatarSizeMap = {
     sm: { mobile: 'lg', desktop: 'display-sm' },
@@ -66,7 +66,7 @@ export function ArtistInfo({
   }[resolvedAvatarSize];
 
   const avatarContent = (
-    <div className='rounded-full border border-[color:var(--profile-pearl-border)] bg-[var(--profile-pearl-bg)] p-1 shadow-[var(--profile-pearl-shadow)] backdrop-blur-xl'>
+    <div className='rounded-full border border-(--profile-pearl-border) bg-(--profile-pearl-bg) p-1 shadow-(--profile-pearl-shadow) backdrop-blur-xl'>
       <Avatar
         src={artist.image_url || ''}
         alt={artist.name}

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3260,
+  "count": 3255,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replaces exact `tracking-[-0.01em]` and `tracking-[-0.02em]` subtitle classes with `tracking-tight` and `tracking-tighter`.
- Replaces exact profile avatar `var(--profile-pearl-*)` arbitrary classes with Tailwind CSS-variable shorthand.
- Drops the arbitrary-value ratchet baseline from `3260` to `3255`.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/molecules/ArtistInfo.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/molecules/ArtistInfo.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `JOVIE_AGENT_PROFILE=coder git push -u origin codex/jov-ds-artist-info-token-aliases` pre-push gate passed Biome, proxy guard, Tailwind guard, typecheck, and lint.

bug-to-test: satisfied - `arbitrary-values-ratchet.test.ts` covers this drift reduction.