### PR TITLE
fix(design-system): tokenize signin timeout text vars

### DIFF
--- a/apps/web/components/molecules/SignInTimeoutEscape.tsx
+++ b/apps/web/components/molecules/SignInTimeoutEscape.tsx
@@ -55,7 +55,7 @@ export function SignInTimeoutEscape() {
       {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
       <a
         href='/api/auth/reset'
-        className='underline font-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+        className='underline font-medium text-(--color-text-secondary) hover:text-(--color-text-primary)'
       >
         Reset session and retry &rarr;
       </a>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3255,
+  "count": 3253,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replaces exact sign-in timeout `text-[var(--color-text-*)]` arbitrary classes with Tailwind CSS-variable shorthand.
- Drops the arbitrary-value ratchet baseline from `3255` to `3253`.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/molecules/SignInTimeoutEscape.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/molecules/SignInTimeoutEscape.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `JOVIE_AGENT_PROFILE=coder git push -u origin codex/jov-ds-signin-timeout-token-aliases` pre-push gate passed Biome, proxy guard, Tailwind guard, typecheck, and lint.

bug-to-test: satisfied - `arbitrary-values-ratchet.test.ts` covers this drift reduction.