### PR TITLE
fix(design-system): tokenize drawer editable tracking

### DIFF
--- a/apps/web/components/molecules/drawer/DrawerEditableTextField.tsx
+++ b/apps/web/components/molecules/drawer/DrawerEditableTextField.tsx
@@ -205,7 +205,7 @@ export const DrawerEditableTextField = React.memo(
               aria-label={`Edit ${label}`}
               className={cn(
                 'h-8 w-full rounded-lg border-(--linear-app-frame-seam) bg-surface-0 px-2.5 text-app text-primary-token',
-                monospace && 'font-mono tracking-[0.02em]',
+                monospace && 'font-mono tracking-wider',
                 inputClassName
               )}
             />
@@ -233,7 +233,7 @@ export const DrawerEditableTextField = React.memo(
               <span
                 className={cn(
                   'block truncate text-app text-primary-token',
-                  monospace && 'font-mono tracking-[0.02em]',
+                  monospace && 'font-mono tracking-wider',
                   !hasValue && 'italic text-tertiary-token',
                   displayClassName,
                   !hasValue && emptyClassName
@@ -248,7 +248,7 @@ export const DrawerEditableTextField = React.memo(
             <span
               className={cn(
                 'block min-w-0 w-full truncate text-app text-primary-token',
-                monospace && 'font-mono tracking-[0.02em]',
+                monospace && 'font-mono tracking-wider',
                 !hasValue && 'italic text-tertiary-token',
                 displayClassName,
                 !hasValue && emptyClassName

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3253,
+  "count": 3250,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replaces exact drawer editable `tracking-[0.02em]` monospace classes with `tracking-wider`.
- Drops the arbitrary-value ratchet baseline from `3253` to `3250`.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/molecules/drawer/DrawerEditableTextField.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/molecules/drawer/DrawerEditableTextField.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `JOVIE_AGENT_PROFILE=coder git push -u origin codex/jov-ds-drawer-editable-tracking` pre-push gate passed Biome, proxy guard, Tailwind guard, typecheck, and lint.

bug-to-test: satisfied - `arbitrary-values-ratchet.test.ts` covers this drift reduction.