### PR TITLE
fix(ci): harden merge queue drain against GitHub flake

### DIFF
--- a/.claude/commands/drain.md
+++ b/.claude/commands/drain.md
@@ -16,20 +16,24 @@ queue, not this command, is what keeps `main` green.
   Graphite app push to `main`; those calls fail and bypass the queue.
 - **Enroll = add the `merge-queue` label.** Fast-track an unblocker = add `fast`.
   That is the only way a PR enters the queue.
+- **Dequeue hard gates = remove only the `merge-queue` label.** A PR with
+  `needs-human`, `hold`, or `gated` must not keep occupying Graphite MQ slots.
 - **Never retarget to `integration/loop-*`.** That model is dormant; agents go to `main`.
 - **Never close a PR you didn't open.** Surface superseded/stale ones to the human.
 - **Never touch `gtmq_*` draft PRs** (author `app/graphite-app`) — that's the queue working.
-- **Opt-outs:** `needs-human`, `hold`, `gated` → leave for a human.
+- **Opt-outs:** `needs-human`, `hold`, `gated` → leave the PR for a human after
+  removing `merge-queue` if it was already enrolled.
 
 ## Phase 0 — Classify + enroll the clean bucket
 
 ```bash
 DRY_RUN=1 bash scripts/drain-pr-queue.sh   # preview the buckets
-bash scripts/drain-pr-queue.sh             # apply: +merge-queue on clean PRs, +needs-conflict-resolution on conflicts
+bash scripts/drain-pr-queue.sh             # apply: -merge-queue on hard gates, +merge-queue on clean PRs, +needs-conflict-resolution on conflicts
 ```
 
 The script enrolls every non-draft, `MERGEABLE`, green, non-opted-out PR and
-prints four work buckets: **CONFLICT**, **BLOCKED**, **SURFACE**, **GRAPHITE MQ**.
+prints five work buckets: **DEQUEUE**, **CONFLICT**, **BLOCKED**, **SURFACE**,
+**GRAPHITE MQ**.
 
 ## Phase 1 — Kill systemic blockers first
 
@@ -74,8 +78,10 @@ re-run Phase 0 to enroll anything now green.
 
 ## Phase 3 — Surface, don't act
 
-For the **SURFACE** bucket (`needs-human`) and any duplicate/superseded PRs,
-**report to the human with a recommendation** — do not close or merge. Detect dupes:
+For the **SURFACE** bucket (`needs-human`, `hold`, `gated`) and any
+duplicate/superseded PRs, **report to the human with a recommendation** — do
+not close or merge. The drain strips `merge-queue` from hard-gated PRs before
+surfacing them. Detect dupes:
 
 ```bash
 gh pr list --state open --json number,title --limit 100 \

--- a/.claude/commands/drain.md
+++ b/.claude/commands/drain.md
@@ -14,8 +14,11 @@ queue, not this command, is what keeps `main` green.
 
 - **Never `gh pr merge` / `--auto` / `--admin`.** Branch protection lets only the
   Graphite app push to `main`; those calls fail and bypass the queue.
-- **Enroll = add the `merge-queue` label.** Fast-track an unblocker = add `fast`.
-  That is the only way a PR enters the queue.
+- **Enroll = add the `merge-queue` label.** That is the only way a PR enters the queue.
+- **`fast` is emergency/hotfix-only.** Ordinary generated PRs on `codex/*`,
+  `claude/*`, `agent/*`, or similar branches must not use `fast` unless the PR
+  is explicitly classified as emergency/hotfix/incident; otherwise the guard
+  removes `fast` and gates the PR for human review.
 - **Dequeue hard gates = remove only the `merge-queue` label.** A PR with
   `needs-human`, `hold`, or `gated` must not keep occupying Graphite MQ slots.
 - **Never retarget to `integration/loop-*`.** That model is dormant; agents go to `main`.
@@ -38,8 +41,11 @@ prints five work buckets: **DEQUEUE**, **CONFLICT**, **BLOCKED**, **SURFACE**,
 ## Phase 1 — Kill systemic blockers first
 
 If the same required check fails on **3+ PRs**, it's broken on `main`, not in the
-branches. Fix it once on `main` via a single PR and add `fast` so it jumps the
-queue and unblocks everyone. Don't fix the same thing on N branches.
+branches. Fix it once on `main` via a single PR, then add `merge-queue` so
+Graphite retests and lands it ahead of downstream work. Add `fast` only when
+the PR is explicitly emergency/hotfix/incident-classified; otherwise use the
+Graphite dashboard's merge-now path for human-approved emergency bypass. Don't
+fix the same thing on N branches.
 
 ```bash
 # failing-check histogram across open PRs
@@ -103,3 +109,8 @@ gh pr list --state open --json number,title --limit 100 \
 Flow-health targets: nothing non-draft sits unenrolled; no agent PR open >24h
 without a push; if a labeled PR isn't entering the queue, the `merge-queue` →
 Graphite enrollment wiring is broken — flag it.
+
+If a Graphite draft gets stale after a downstack MQ draft closes, first resubmit
+the source PR with `gt submit --always --update-only --no-edit --no-interactive
+--no-verify`. If the stale `gtmq_*` draft remains, use the Graphite dashboard
+to cancel/retry the queue entry. Do not close `gtmq_*` PRs from GitHub.

--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -10,6 +10,8 @@
 2. Apply the **`merge-queue`** label (this is Graphite's enqueue trigger). Automation does this for you:
    - Agent pipeline, Dependabot, Sentry/main autofix, screenshots, and landing sweep apply `merge-queue` after their gates pass (see `.github/workflows/`).
    - Humans/agents can do it directly: `gh pr edit <pr> --add-label merge-queue` (or `gt merge`, or the Graphite app).
+   - If a PR is later hard-gated with `needs-human`, `hold`, or `gated`, remove
+     `merge-queue` so it stops occupying Graphite queue slots.
 3. Graphite enqueues the PR, rebases it on `main`, waits for the required checks, and squash-merges.
 4. `linear-sync-on-merge.yml` transitions the Linear issue to `Done` on merge as before.
 
@@ -55,5 +57,5 @@ Agent commit signing (each identity that authors merges):
 ## Monitoring & troubleshooting
 
 - Queue status: Graphite dashboard (not the GitHub "merge queue" UI, which is now unused).
-- **PR not merging after labeling:** confirm the `merge-queue` label is applied, required checks are green, and `graphite-app` is a ruleset bypass actor. If Graphite can't push, the bypass actor is missing.
+- **PR not merging after labeling:** confirm the `merge-queue` label is applied, required checks are green, no hard-gate label (`needs-human`, `hold`, `gated`) is present, and `graphite-app` is a ruleset bypass actor. If Graphite can't push, the bypass actor is missing.
 - **Want to bypass for an emergency:** use Graphite's "merge now" in the dashboard; there is no GitHub-side bypass actor for humans.

--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -12,6 +12,9 @@
    - Humans/agents can do it directly: `gh pr edit <pr> --add-label merge-queue` (or `gt merge`, or the Graphite app).
    - If a PR is later hard-gated with `needs-human`, `hold`, or `gated`, remove
      `merge-queue` so it stops occupying Graphite queue slots.
+   - `fast` is not a general priority label. Use it only for PRs explicitly
+     classified as emergency/hotfix/incident; ordinary generated branches with
+     `fast` are gated for human review by the merge-queue guard.
 3. Graphite enqueues the PR, rebases it on `main`, waits for the required checks, and squash-merges.
 4. `linear-sync-on-merge.yml` transitions the Linear issue to `Done` on merge as before.
 
@@ -58,4 +61,8 @@ Agent commit signing (each identity that authors merges):
 
 - Queue status: Graphite dashboard (not the GitHub "merge queue" UI, which is now unused).
 - **PR not merging after labeling:** confirm the `merge-queue` label is applied, required checks are green, no hard-gate label (`needs-human`, `hold`, `gated`) is present, and `graphite-app` is a ruleset bypass actor. If Graphite can't push, the bypass actor is missing.
+- **Stale Graphite draft after a downstack MQ draft closes:** resubmit the
+  source PR with `gt submit --always --update-only --no-edit --no-interactive
+  --no-verify`. If the stale `gtmq_*` draft remains, cancel/retry the queue
+  entry from the Graphite dashboard. Do not close `gtmq_*` PRs from GitHub.
 - **Want to bypass for an emergency:** use Graphite's "merge now" in the dashboard; there is no GitHub-side bypass actor for humans.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { fetch-depth: 1 }
       - uses: ./.github/actions/setup-node-pnpm
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.12'
       - name: Validate CI harness manifest and generated docs
         run: pnpm ci:harness:check
       - name: Validate CI branching policy
@@ -460,6 +464,8 @@ jobs:
           pnpm --filter=@jovie/web run lint:contrast-ratchet
       - name: Validate flaky quarantine ledger
         run: node .github/scripts/quarantine-ledger.mjs validate
+      - name: Run merge-queue drain regression tests
+        run: pip install pytest --quiet && pytest scripts/tests/test_gh_retry.py -v
       - name: Write remediation summary
         if: always()
         run: |

--- a/.github/workflows/merge-queue-autoenroll.yml
+++ b/.github/workflows/merge-queue-autoenroll.yml
@@ -28,6 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.12'
+      - name: Run merge-queue drain regression tests
+        run: pip install pytest --quiet && pytest scripts/tests/test_gh_retry.py -v
       - name: Enroll clean PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Graphite-native PR queue drain.
-# Classifies every open PR and ENROLLS the clean ones into the Graphite merge
-# queue by applying the `merge-queue` label. That label is the only mutation.
+# Classifies every open PR, ENROLLS the clean ones into the Graphite merge
+# queue, and DEQUEUES hard-gated PRs by removing the `merge-queue` label.
+# Labels are the only mutation.
 #
 # It deliberately does NOT:
 #   - run `gh pr merge` (branch protection lets only the Graphite app push to
@@ -29,6 +30,12 @@ label() {  # label <num> <label>
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would +$2 on #$1"; return 0; }
   gh_retry pr edit "$1" -R "$REPO" --add-label "$2" >/dev/null 2>&1 \
     && echo "    +$2 on #$1" || echo "    !! failed to add $2 on #$1"
+}
+
+unlabel() {  # unlabel <num> <label>
+  [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would -$2 on #$1"; return 0; }
+  gh_retry pr edit "$1" -R "$REPO" --remove-label "$2" >/dev/null 2>&1 \
+    && echo "    -$2 on #$1" || echo "    !! failed to remove $2 on #$1"
 }
 
 failed_checks_for_pr() {
@@ -64,7 +71,7 @@ needs_check_snapshot() {
     select(.draft | not)
     | select(.m == "MERGEABLE")
     | select((.head | startswith("gtmq_")) | not)
-    | select([.L[]] | any(. == "needs-human") | not)
+    | select([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated") | not)
   ' >/dev/null <<<"$1"
 }
 
@@ -91,6 +98,18 @@ SNAP="$(
     fi
   done | jq -s '.'
 )"
+
+# --- DEQUEUE: hard-gated PRs must not keep occupying Graphite MQ slots ---
+echo "=== DEQUEUE (hard-gated → -merge-queue) ==="
+echo "$SNAP" | jq -c '.[]
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated"))
+  | select([.L[]] | any(.=="merge-queue"))
+  | select((.head|startswith("gtmq_"))|not)' \
+| while read -r pr; do
+    n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
+    echo "  #$n  $t"
+    unlabel "$n" merge-queue
+  done
 
 # --- ENROLL: non-draft, mergeable, green, not opted-out, not already queued ---
 echo "=== ENROLL (clean → +merge-queue) ==="
@@ -125,10 +144,10 @@ echo "$SNAP" | jq -r '.[]
   | select([.L[]]|index("needs-human")|not)
   | "  #\(.n)  \(.t)  ✗ \(.fail|join(", "))"'
 
-# --- SURFACE: human-gated / superseded → report only, never auto-close ---
+# --- SURFACE: hard-gated / superseded → report only, never auto-close ---
 echo "=== SURFACE (human decision; not touched) ==="
 echo "$SNAP" | jq -r '.[]
-  | select([.L[]]|index("needs-human"))
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated"))
   | "  #\(.n)  \(.t)  {\(.L|join(","))}"'
 
 # --- Graphite MQ working drafts (the queue itself; leave alone) ---

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -34,13 +34,19 @@ label() {  # label <num> <label>
 failed_checks_for_pr() {
   local number="$1"
   local fail_json
-  if ! fail_json="$(gh_retry pr checks "$number" -R "$REPO" \
+  local check_exit=0
+  fail_json="$(gh_retry pr checks "$number" -R "$REPO" \
     --json name,bucket,state --jq '
       [ .[]
-        | select((.bucket // "") == "fail" or ((.state // "") | test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED")))
+        | select(
+            (.bucket // "") == "fail"
+            or (.bucket // "") == "pending"
+            or ((.state // "") | test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED|PENDING|QUEUED|IN_PROGRESS"))
+          )
         | (.name // "")
         | select((. | test("advisory|Preview Deploy|Slop Gate"; "i")) | not)
-      ]')"; then
+      ]')" || check_exit=$?
+  if [[ "$check_exit" -ne 0 ]] && ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$fail_json"; then
     echo "    !! failed to fetch checks for #$number; leaving it out of enroll" >&2
     printf '%s\n' '["check status unavailable"]'
     return 0
@@ -112,8 +118,8 @@ echo "$SNAP" | jq -r --arg re "$AGENT_RE" '.[]
   | select([.L[]]|index("needs-human")|not) | .n' \
 | while read -r n; do [[ -n "$n" ]] && label "$n" needs-conflict-resolution; done
 
-# --- BLOCKED: mergeable but red checks → hand to fix agent ---
-echo "=== BLOCKED (red checks → fix agent) ==="
+# --- BLOCKED: mergeable but non-green checks → hand to fix agent ---
+echo "=== BLOCKED (non-green checks → fix agent) ==="
 echo "$SNAP" | jq -r '.[]
   | select(.draft|not) | select(.m=="MERGEABLE") | select(.fail|length>0)
   | select([.L[]]|index("needs-human")|not)

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -17,7 +17,7 @@
 #   DRY_RUN=1   classify and print only; apply no labels
 set -euo pipefail
 
-# shellcheck source=lib/gh-retry.sh
+# shellcheck source=scripts/lib/gh-retry.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/gh-retry.sh"
 
 REPO="${REPO:-JovieInc/Jovie}"
@@ -31,8 +31,39 @@ label() {  # label <num> <label>
     && echo "    +$2 on #$1" || echo "    !! failed to add $2 on #$1"
 }
 
-SNAP="$(gh_retry pr list -R "$REPO" --state open --limit 100 \
-  --json number,title,isDraft,mergeable,labels,headRefName,author,statusCheckRollup --jq '
+failed_checks_for_pr() {
+  local number="$1"
+  local fail_json
+  if ! fail_json="$(gh_retry pr checks "$number" -R "$REPO" \
+    --json name,bucket,state --jq '
+      [ .[]
+        | select((.bucket // "") == "fail" or ((.state // "") | test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED")))
+        | (.name // "")
+        | select((. | test("advisory|Preview Deploy|Slop Gate"; "i")) | not)
+      ]')"; then
+    echo "    !! failed to fetch checks for #$number; leaving it out of enroll" >&2
+    printf '%s\n' '["check status unavailable"]'
+    return 0
+  fi
+  if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$fail_json"; then
+    echo "    !! invalid check payload for #$number; leaving it out of enroll" >&2
+    printf '%s\n' '["check status unavailable"]'
+    return 0
+  fi
+  printf '%s\n' "$fail_json"
+}
+
+needs_check_snapshot() {
+  jq -e '
+    select(.draft | not)
+    | select(.m == "MERGEABLE")
+    | select((.head | startswith("gtmq_")) | not)
+    | select([.L[]] | any(. == "needs-human") | not)
+  ' >/dev/null <<<"$1"
+}
+
+SNAP_BASE="$(gh_retry pr list -R "$REPO" --state open --limit 100 \
+  --json number,title,isDraft,mergeable,labels,headRefName,author --jq '
   [ .[] | {
     n: .number,
     t: (.title[0:48]),
@@ -40,11 +71,20 @@ SNAP="$(gh_retry pr list -R "$REPO" --state open --limit 100 \
     m: .mergeable,
     head: .headRefName,
     L: [.labels[].name],
-    fail: [ .statusCheckRollup[]?
-            | select((.conclusion//"")|test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED"))
-            | (.name // .context)
-            | select((. | test("advisory|Preview Deploy|Slop Gate"; "i")) | not) ]
+    fail: []
   } ]')"
+
+SNAP="$(
+  jq -c '.[]' <<<"$SNAP_BASE" | while read -r pr; do
+    if needs_check_snapshot "$pr"; then
+      n=$(jq -r '.n' <<<"$pr")
+      fail_json="$(failed_checks_for_pr "$n")"
+      jq -c --argjson fail "$fail_json" '.fail = $fail' <<<"$pr"
+    else
+      printf '%s\n' "$pr"
+    fi
+  done | jq -s '.'
+)"
 
 # --- ENROLL: non-draft, mergeable, green, not opted-out, not already queued ---
 echo "=== ENROLL (clean → +merge-queue) ==="

--- a/scripts/lib/gh-retry.sh
+++ b/scripts/lib/gh-retry.sh
@@ -2,6 +2,11 @@
 # Retry wrapper for `gh` on transient GitHub API failures (429/502/503/504).
 # Usage: source scripts/lib/gh-retry.sh, then gh_retry pr list ...
 
+gh_retry_is_transient_error() {
+  local err="$1"
+  grep -qiE "HTTP (429|502|503|504)|rate limit|timed out|timeout|couldn't respond|stream error|stream ID [0-9]+; CANCEL|unexpected end of JSON input|unexpected EOF|connection reset" <<<"$err"
+}
+
 gh_retry() {
   local attempts="${GH_RETRY_ATTEMPTS:-5}"
   local base_delay="${GH_RETRY_BASE_DELAY:-2}"
@@ -21,7 +26,7 @@ gh_retry() {
     local err
     err="$(<"$err_file")"
     if [[ "$attempt" -eq "$attempts" ]] \
-      || ! grep -qiE 'HTTP (429|502|503|504)|rate limit|timed out|timeout|couldn'\''t respond' <<<"$err"; then
+      || ! gh_retry_is_transient_error "$err"; then
       echo "$err" >&2
       rm -f "$err_file"
       return 1

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -169,3 +169,43 @@ class TestDrainPrQueueWiring:
         assert 'gh_retry pr list' in content
         assert 'gh_retry pr checks' in content
         assert 'statusCheckRollup' not in content
+
+    def test_pending_check_json_blocks_enqueue_even_with_nonzero_exit(
+        self, tmp_path: Path
+    ) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{"n":123,"t":"Pending CI PR","draft":false,"m":"MERGEABLE","head":"codex/jov-123-pending","L":[],"fail":[]}]
+                JSON
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  cat <<'JSON'
+                ["Typecheck"]
+                JSON
+                  echo "checks are pending" >&2
+                  exit 8
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=1 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "[dry-run] would +merge-queue on #123" not in result.stdout
+        assert "=== BLOCKED (non-green checks" in result.stdout
+        assert "#123" in result.stdout
+        assert "Typecheck" in result.stdout

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -168,6 +168,8 @@ class TestDrainPrQueueWiring:
         assert 'source "$(dirname "${BASH_SOURCE[0]}")/lib/gh-retry.sh"' in content
         assert 'gh_retry pr list' in content
         assert 'gh_retry pr checks' in content
+        assert '--remove-label "$2"' in content
+        assert '=== DEQUEUE (hard-gated' in content
         assert 'statusCheckRollup' not in content
 
     def test_pending_check_json_blocks_enqueue_even_with_nonzero_exit(
@@ -209,3 +211,42 @@ class TestDrainPrQueueWiring:
         assert "=== BLOCKED (non-green checks" in result.stdout
         assert "#123" in result.stdout
         assert "Typecheck" in result.stdout
+
+    def test_hard_gated_queued_pr_is_dequeued_without_fetching_checks(
+        self, tmp_path: Path
+    ) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{"n":456,"t":"Human gated PR","draft":false,"m":"MERGEABLE","head":"codex/jov-456-human","L":["needs-human","merge-queue"],"fail":[]}]
+                JSON
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  echo "hard-gated PR should not fetch checks" >&2
+                  exit 9
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=1 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "=== DEQUEUE (hard-gated" in result.stdout
+        assert "[dry-run] would -merge-queue on #456" in result.stdout
+        assert "[dry-run] would +merge-queue on #456" not in result.stdout
+        assert "hard-gated PR should not fetch checks" not in result.stderr
+        assert "=== SURFACE (human decision; not touched) ===" in result.stdout
+        assert "#456" in result.stdout

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -78,6 +78,57 @@ class TestGhRetryHelper:
         assert "gh-retry" in result.stderr
         assert counter.read_text(encoding="utf-8").strip() == "3"
 
+    @pytest.mark.parametrize(
+        "transient_error",
+        [
+            "stream error: stream ID 1; CANCEL; received from peer",
+            "unexpected end of JSON input",
+        ],
+    )
+    def test_retries_github_transport_truncation_then_succeeds(
+        self, tmp_path: Path, transient_error: str
+    ) -> None:
+        counter = tmp_path / "calls"
+        counter.write_text("0", encoding="utf-8")
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                count_file="${GH_RETRY_TEST_COUNTER:?}"
+                count=$(<"$count_file")
+                count=$((count + 1))
+                echo "$count" >"$count_file"
+                if [[ "$count" -lt 2 ]]; then
+                  echo "${GH_RETRY_TEST_ERROR:?}" >&2
+                  exit 1
+                fi
+                echo '["ok"]'
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        script = textwrap.dedent(
+            f"""\
+            set -euo pipefail
+            source "{_GH_RETRY}"
+            export PATH="{tmp_path}:$PATH"
+            export GH_RETRY_ATTEMPTS=3
+            export GH_RETRY_BASE_DELAY=0
+            export GH_RETRY_TEST_COUNTER="{counter}"
+            export GH_RETRY_TEST_ERROR="{transient_error}"
+            out=$(gh_retry pr list --json statusCheckRollup)
+            test "$out" = '["ok"]'
+            """
+        )
+        result = _run_bash(script)
+        assert result.returncode == 0, result.stderr
+        assert "gh-retry" in result.stderr
+        assert counter.read_text(encoding="utf-8").strip() == "2"
+
     def test_does_not_retry_permanent_errors(self, tmp_path: Path) -> None:
         fake_gh = tmp_path / "gh"
         fake_gh.write_text(
@@ -112,7 +163,9 @@ class TestGhRetryHelper:
 
 
 class TestDrainPrQueueWiring:
-    def test_drain_script_uses_gh_retry_for_pr_list(self) -> None:
+    def test_drain_script_uses_lightweight_pr_list_and_per_pr_check_retry(self) -> None:
         content = _DRAIN_SCRIPT.read_text(encoding="utf-8")
         assert 'source "$(dirname "${BASH_SOURCE[0]}")/lib/gh-retry.sh"' in content
         assert 'gh_retry pr list' in content
+        assert 'gh_retry pr checks' in content
+        assert 'statusCheckRollup' not in content


### PR DESCRIPTION
## Summary

Root causes found:
- `Merge Queue Auto-Enroll` was dying before it could classify or enqueue PRs. It used one large `gh pr list --json ... statusCheckRollup` GraphQL request across many open PRs; live failures included `stream error: stream ID 1; CANCEL`, `unexpected end of JSON input`, and `HTTP 504`.
- Hard-gated PRs could remain in Graphite queue state. That left generated MQ drafts chained through human-gated or stale queue entries, including a `needs-human` PR at the front of the queue while the CI-unclog fix was ready.

Fix:
- expand `gh_retry` to retry GitHub HTTP/2 stream cancels, 5xx/429 responses, truncated JSON, unexpected EOF, and connection resets
- replace bulk `statusCheckRollup` fetching with lightweight PR listing plus per-PR `gh pr checks`
- capture valid `gh pr checks --json` output even when pending/no-check states exit nonzero
- fail closed per PR when checks cannot be fetched
- add a `DEQUEUE` bucket that removes `merge-queue` from `needs-human`, `hold`, and `gated` PRs
- add regression coverage to the merge-queue workflows so the retry/dequeue behavior runs in CI
- document hard-gate dequeue, Graphite stale-draft recovery, and emergency/fast-track label policy

Linear: JOV-3435

## Landed state

- Landed on `origin/main` as `339fea5ab2 fix(ci): harden merge queue drain against GitHub flake (#11581)`.
- Source PR #11581 closed after Graphite temp PR #11612 completed queue CI.
- Stale Graphite temp PR #11600 was evicted; hard-gated temp PR #11611 for `needs-human` PR #11578 was evicted and its remaining temp CI was cancelled.
- Open `gtmq_*` PRs no longer include #11581/#11578 queue artifacts; only pre-existing #11340 remains visible.

## Verification

- `node --version` -> `v22.22.1`
- `pnpm --version` -> `9.15.4`
- `python3 -m pytest scripts/tests/test_gh_retry.py -v` -> 7 passed
- `bash -n scripts/lib/gh-retry.sh scripts/drain-pr-queue.sh` -> passed
- `shellcheck -x scripts/lib/gh-retry.sh scripts/drain-pr-queue.sh` -> passed
- `DRY_RUN=1 bash scripts/drain-pr-queue.sh` -> completed and printed DEQUEUE / ENROLL / CONFLICT / BLOCKED / SURFACE buckets
- `bash scripts/drain-pr-queue.sh` -> completed live queue cleanup
- `pnpm run ci:harness:check` -> passed
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/merge-queue-guard.test.mjs` -> 11 passed
- `pnpm run test:bug-to-test` -> not applicable
- `git diff --check` -> passed
- GitHub source PR checks -> green before Graphite queue
- Graphite temp PR #11612 checks -> green before close