### PR TITLE
fix(design-system): tokenize molecule tracking

### DIFF
--- a/apps/web/components/molecules/CompactLinkRail.tsx
+++ b/apps/web/components/molecules/CompactLinkRail.tsx
@@ -50,7 +50,7 @@ export function CompactLinkRail({
     >
       {showSummaryPill ? (
         <div
-          className='inline-flex h-6 shrink-0 items-center gap-1 rounded-full border border-(--linear-app-frame-seam) bg-surface-1 px-1.5 text-2xs font-caption tracking-[-0.01em] text-secondary-token'
+          className='inline-flex h-6 shrink-0 items-center gap-1 rounded-full border border-(--linear-app-frame-seam) bg-surface-1 px-1.5 text-2xs font-caption tracking-tight text-secondary-token'
           title={summaryAriaLabel ?? `${displayCount} ${countLabel}`}
         >
           <div className='flex -space-x-1 overflow-hidden pr-0.5'>

--- a/apps/web/components/molecules/ContentTable.tsx
+++ b/apps/web/components/molecules/ContentTable.tsx
@@ -6,7 +6,7 @@ export const CONTENT_TABLE_WRAPPER_CLASS = 'overflow-x-auto px-4 py-4 sm:px-6';
 export const CONTENT_TABLE_CLASS = 'w-full text-xs text-secondary-token';
 export const CONTENT_TABLE_HEAD_ROW_CLASS = 'border-b border-subtle text-left';
 export const CONTENT_TABLE_HEAD_CELL_CLASS =
-  'pb-2 pr-3 text-2xs font-semibold tracking-[0.01em] text-tertiary-token';
+  'pb-2 pr-3 text-2xs font-semibold tracking-wide text-tertiary-token';
 export const CONTENT_TABLE_ROW_CLASS =
   'border-b border-subtle transition-colors hover:bg-surface-0';
 export const CONTENT_TABLE_CELL_CLASS = 'py-2.5 pr-3 align-middle';

--- a/apps/web/components/molecules/drawer/DrawerButton.tsx
+++ b/apps/web/components/molecules/drawer/DrawerButton.tsx
@@ -28,7 +28,7 @@ export interface DrawerButtonProps
 }
 
 export const DRAWER_BUTTON_CLASSNAME =
-  'border font-caption tracking-[-0.01em] shadow-none transition-[background-color,border-color,color] duration-subtle focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20';
+  'border font-caption tracking-tight shadow-none transition-[background-color,border-color,color] duration-subtle focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20';
 
 export const DrawerButton = React.forwardRef<
   HTMLButtonElement,

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3243,
+  "count": 3240,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- replace three exact tracking arbitrary values in molecule components with existing tracking tokens
- lower the arbitrary Tailwind ratchet baseline from 3243 to 3240

## Verification
- `node - <<'NODE' ...` arbitrary Tailwind count: 3240
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/molecules/CompactLinkRail.tsx apps/web/components/molecules/drawer/DrawerButton.tsx apps/web/components/molecules/ContentTable.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/molecules/CompactLinkRail.tsx apps/web/components/molecules/drawer/DrawerButton.tsx apps/web/components/molecules/ContentTable.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- precommit hook: passed
- pre-push hook: passed

bug-to-test: satisfied - arbitrary-values-ratchet.test.ts covers this drift reduction.
