### PR TITLE
fix(design-system): tokenize dashboard chat tracking

### DIFF
--- a/apps/web/components/features/dashboard/atoms/AnalyticsCard.tsx
+++ b/apps/web/components/features/dashboard/atoms/AnalyticsCard.tsx
@@ -71,7 +71,7 @@ export function AnalyticsCard({
       iconClassName={cn('text-accent-token', iconClassName)}
       headerRight={headerRight}
       headerClassName='gap-2'
-      labelClassName='text-app text-secondary-token tracking-[-0.01em]'
+      labelClassName='text-app text-secondary-token tracking-tight'
       valueClassName='text-3xl font-semibold tracking-[-0.022em]'
       subtitleClassName='text-app text-tertiary-token'
       aria-label={ariaLabel ?? `${title} metric`}

--- a/apps/web/components/features/dashboard/molecules/SettingsGroupHeading.tsx
+++ b/apps/web/components/features/dashboard/molecules/SettingsGroupHeading.tsx
@@ -15,7 +15,7 @@ export function SettingsGroupHeading({
   return (
     <h3
       className={cn(
-        'text-app font-caption tracking-[-0.01em] text-secondary-token',
+        'text-app font-caption tracking-tight text-secondary-token',
         className
       )}
     >

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -191,7 +191,7 @@ function ToolActivityRow({
         <div
           title={getToolStatusTitle(event)}
           className={cn(
-            'truncate font-semibold tracking-[-0.01em]',
+            'truncate font-semibold tracking-tight',
             isError && 'text-red-500',
             isInline ? 'text-xs' : 'text-app'
           )}

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3235,
+  "count": 3232,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- replace three exact tracking arbitrary values in dashboard/chat components with existing tracking tokens
- lower the arbitrary Tailwind ratchet baseline from 3235 to 3232

## Verification
- `node - <<'NODE' ...` arbitrary Tailwind count: 3232
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/dashboard/atoms/AnalyticsCard.tsx apps/web/components/features/dashboard/molecules/SettingsGroupHeading.tsx apps/web/components/jovie/tool-ui.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/features/dashboard/atoms/AnalyticsCard.tsx apps/web/components/features/dashboard/molecules/SettingsGroupHeading.tsx apps/web/components/jovie/tool-ui.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- precommit hook: passed
- pre-push hook: passed

bug-to-test: satisfied - arbitrary-values-ratchet.test.ts covers this drift reduction.
