### PR TITLE
fix(design-system): tokenize public profile vars

### DIFF
--- a/apps/web/components/features/profile/ProfileSkeleton.tsx
+++ b/apps/web/components/features/profile/ProfileSkeleton.tsx
@@ -5,11 +5,11 @@
 export function ProfileSkeleton() {
   const pulse = 'animate-pulse motion-reduce:animate-none';
   const panelClass =
-    'rounded-[var(--profile-card-radius)] bg-white/[0.04] backdrop-blur-sm';
+    'rounded-(--profile-card-radius) bg-white/[0.04] backdrop-blur-sm';
 
   return (
     <output
-      className='relative min-h-dvh overflow-hidden bg-[color:var(--profile-stage-bg)] text-white/90'
+      className='relative min-h-dvh overflow-hidden bg-(--profile-stage-bg) text-white/90'
       aria-busy='true'
       aria-label='Loading Jovie Profile'
     >
@@ -20,7 +20,7 @@ export function ProfileSkeleton() {
 
       {/* Viewport shell */}
       <div className='relative mx-auto flex min-h-dvh w-full max-w-170 items-stretch justify-center md:items-center md:px-6 md:py-8'>
-        <div className='relative flex w-full flex-col overflow-hidden bg-white/[0.02] md:min-h-0 md:rounded-[var(--profile-shell-card-radius)] md:border md:border-white/[0.06]'>
+        <div className='relative flex w-full flex-col overflow-hidden bg-white/[0.02] md:min-h-0 md:rounded-(--profile-shell-card-radius) md:border md:border-white/[0.06]'>
           {/* Hero placeholder — matches ArtistHero height */}
           <div
             className={`relative h-[48dvh] max-h-155 min-h-105 w-full overflow-hidden md:h-[56dvh] md:min-h-130 md:rounded-t-[var(--profile-shell-card-radius)] xl:max-h-160 2xl:max-h-170 ${pulse}`}

--- a/apps/web/components/organisms/public-surface/PublicSurfaceStage.tsx
+++ b/apps/web/components/organisms/public-surface/PublicSurfaceStage.tsx
@@ -23,11 +23,11 @@ export function PublicSurfaceStage({
       <main className='relative flex w-full items-stretch md:items-center'>
         <div
           className={cn(
-            'relative flex h-full w-full max-w-(--profile-shell-max-width) flex-col overflow-clip bg-[color:var(--profile-content-bg)] md:mx-auto md:min-h-[min(920px,calc(100dvh-64px))] md:overflow-hidden md:rounded-[var(--profile-card-radius)] md:border md:border-[color:var(--profile-panel-border)] md:shadow-[var(--profile-panel-shadow)]',
+            'relative flex h-full w-full max-w-(--profile-shell-max-width) flex-col overflow-clip bg-(--profile-content-bg) md:mx-auto md:min-h-[min(920px,calc(100dvh-64px))] md:overflow-hidden md:rounded-(--profile-card-radius) md:border md:border-(--profile-panel-border) md:shadow-(--profile-panel-shadow)',
             panelClassName
           )}
         >
-          <div className='pointer-events-none absolute inset-0 bg-[var(--profile-panel-gradient)]' />
+          <div className='pointer-events-none absolute inset-0 bg-(--profile-panel-gradient)' />
           {children}
         </div>
       </main>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3232,
+  "count": 3224,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- replace eight exact CSS variable arbitrary utilities in public profile shell components with Tailwind token shorthand
- lower the arbitrary Tailwind ratchet baseline from 3232 to 3224

## Verification
- `node - <<'NODE' ...` arbitrary Tailwind count: 3224
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/organisms/public-surface/PublicSurfaceStage.tsx apps/web/components/features/profile/ProfileSkeleton.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/organisms/public-surface/PublicSurfaceStage.tsx apps/web/components/features/profile/ProfileSkeleton.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- precommit hook: passed
- pre-push hook: passed

bug-to-test: satisfied - arbitrary-values-ratchet.test.ts covers this drift reduction.
