### PR TITLE
fix(design-system): tokenize surface status vars

### DIFF
--- a/apps/web/app/billing/cancel/page.tsx
+++ b/apps/web/app/billing/cancel/page.tsx
@@ -36,7 +36,7 @@ export default function CheckoutCancelPage() {
 
         <div className='space-y-5 px-5 py-5 text-center sm:px-6'>
           <div className='mx-auto flex h-14 w-14 items-center justify-center rounded-full border border-[color-mix(in_oklab,var(--linear-warning)_32%,var(--linear-app-frame-seam))] bg-[color-mix(in_oklab,var(--linear-warning)_10%,var(--linear-app-content-surface))]'>
-            <XCircle className='h-7 w-7 text-[var(--linear-warning)]' />
+            <XCircle className='h-7 w-7 text-(--linear-warning)' />
           </div>
 
           <p className='text-app leading-5 text-secondary-token'>

--- a/apps/web/app/sentry-example-page/SentryExamplePageClient.tsx
+++ b/apps/web/app/sentry-example-page/SentryExamplePageClient.tsx
@@ -100,7 +100,7 @@ export function SentryExamplePageClient() {
               className='border-[color-mix(in_oklab,var(--linear-success)_30%,var(--linear-app-frame-seam))] bg-[color-mix(in_oklab,var(--linear-success)_10%,var(--linear-app-content-surface))] p-4'
             >
               <div className='flex items-center justify-center gap-2 text-app font-semibold text-primary-token'>
-                <CheckCircle2 className='h-4 w-4 text-[var(--linear-success)]' />
+                <CheckCircle2 className='h-4 w-4 text-(--linear-success)' />
                 Error sent to Sentry.
               </div>
             </ContentSurfaceCard>
@@ -113,7 +113,7 @@ export function SentryExamplePageClient() {
             >
               <div className='space-y-2 text-center'>
                 <div className='flex items-center justify-center gap-2 text-app font-semibold text-primary-token'>
-                  <TriangleAlert className='h-4 w-4 text-[var(--linear-warning)]' />
+                  <TriangleAlert className='h-4 w-4 text-(--linear-warning)' />
                   Sentry connectivity looks blocked.
                 </div>
                 <p className='text-app leading-5 text-secondary-token'>

--- a/apps/web/components/organisms/AccountDashboard.tsx
+++ b/apps/web/components/organisms/AccountDashboard.tsx
@@ -27,7 +27,7 @@ export function AccountDashboard() {
         <ContentSurfaceCard className='p-5'>
           <div className='flex items-center'>
             <div className='shrink-0'>
-              <CreditCard className='h-7 w-7 text-[var(--accent-analytics)]' />
+              <CreditCard className='h-7 w-7 text-(--accent-analytics)' />
             </div>
             <div className='ml-4'>
               <h3 className='text-mid font-semibold text-primary-token'>
@@ -49,7 +49,7 @@ export function AccountDashboard() {
         <ContentSurfaceCard className='p-5'>
           <div className='flex items-center'>
             <div className='shrink-0'>
-              <User className='h-7 w-7 text-[var(--accent-speed)]' />
+              <User className='h-7 w-7 text-(--accent-speed)' />
             </div>
             <div className='ml-4'>
               <h3 className='text-mid font-semibold text-primary-token'>
@@ -73,7 +73,7 @@ export function AccountDashboard() {
         <ContentSurfaceCard className='p-5'>
           <div className='flex items-center'>
             <div className='shrink-0'>
-              <Settings className='h-7 w-7 text-[var(--accent-conv)]' />
+              <Settings className='h-7 w-7 text-(--accent-conv)' />
             </div>
             <div className='ml-4'>
               <h3 className='text-mid font-semibold text-primary-token'>

--- a/apps/web/components/organisms/public-surface/PublicSurfaceShell.tsx
+++ b/apps/web/components/organisms/public-surface/PublicSurfaceShell.tsx
@@ -47,8 +47,8 @@ export function PublicSurfaceShell({
 
       {!ambientMediaUrl && showGradientBlurs ? (
         <>
-          <div className='pointer-events-none absolute left-[12%] top-[14%] h-56 w-56 rounded-full bg-[color:var(--profile-stage-glow-a)] blur-3xl sm:h-72 sm:w-72 md:h-[26rem] md:w-[26rem]' />
-          <div className='pointer-events-none absolute bottom-[10%] right-[10%] h-56 w-56 rounded-full bg-[color:var(--profile-stage-glow-b)] blur-3xl sm:h-72 sm:w-72 md:h-[24rem] md:w-[24rem]' />
+          <div className='pointer-events-none absolute left-[12%] top-[14%] h-56 w-56 rounded-full bg-(--profile-stage-glow-a) blur-3xl sm:h-72 sm:w-72 md:h-[26rem] md:w-[26rem]' />
+          <div className='pointer-events-none absolute bottom-[10%] right-[10%] h-56 w-56 rounded-full bg-(--profile-stage-glow-b) blur-3xl sm:h-72 sm:w-72 md:h-[24rem] md:w-[24rem]' />
         </>
       ) : null}
 

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3224,
+  "count": 3216,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- replace eight exact CSS variable arbitrary utilities in status/surface files with Tailwind token shorthand
- lower the arbitrary Tailwind ratchet baseline from 3224 to 3216

## Verification
- `node - <<'NODE' ...` arbitrary Tailwind count: 3216
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/organisms/public-surface/PublicSurfaceShell.tsx apps/web/components/organisms/AccountDashboard.tsx apps/web/app/billing/cancel/page.tsx apps/web/app/sentry-example-page/SentryExamplePageClient.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/organisms/public-surface/PublicSurfaceShell.tsx apps/web/components/organisms/AccountDashboard.tsx apps/web/app/billing/cancel/page.tsx apps/web/app/sentry-example-page/SentryExamplePageClient.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- precommit hook: passed
- pre-push hook: passed

bug-to-test: satisfied - arbitrary-values-ratchet.test.ts covers this drift reduction.
