### PR TITLE
fix(web): reduce shell entity arbitrary drift

### DIFF
--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -73,7 +73,7 @@ export const AppShellFrame = memo(function AppShellFrame({
           className={cn(
             'relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-surface-0',
             isShellChatV1
-              ? 'lg:rounded-[var(--linear-app-shell-radius)] lg:border lg:border-(--linear-app-shell-border) lg:bg-(--linear-app-content-surface) lg:shadow-[var(--linear-app-shell-shadow)]'
+              ? 'lg:rounded-(--linear-app-shell-radius) lg:border lg:border-(--linear-app-shell-border) lg:bg-(--linear-app-content-surface) lg:shadow-(--linear-app-shell-shadow)'
               : 'lg:border-l lg:border-subtle'
           )}
         >

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -226,7 +226,7 @@ function AuthShellWrapperInner({
         <div className='w-full max-w-3xl rounded-2xl border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_96%,var(--linear-bg-surface-0))] px-4 py-4 shadow-[0_16px_40px_rgba(0,0,0,0.16)] sm:px-5'>
           <div className='flex items-center justify-between gap-4'>
             <div>
-              <p className='text-sm font-semibold tracking-[-0.02em] text-primary-token'>
+              <p className='text-sm font-semibold tracking-tighter text-primary-token'>
                 Opening Releases
               </p>
               <p className='mt-1 text-sm text-secondary-token'>

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -138,7 +138,7 @@ export function EntityCard({
         'group flex min-w-0 flex-col text-left transition-[background-color,border-color] duration-subtle focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]',
         treatment === 'big' ? 'gap-0 overflow-hidden p-0' : 'gap-3 p-3',
         isPearl
-          ? 'rounded-[var(--profile-inner-radius)] border border-[color:var(--profile-pearl-border)] bg-[color:var(--profile-pearl-bg)] shadow-[var(--profile-pearl-shadow)] backdrop-blur-2xl hover:bg-[color:var(--profile-pearl-bg-hover)]'
+          ? 'rounded-(--profile-inner-radius) border border-(--profile-pearl-border) bg-(--profile-pearl-bg) shadow-(--profile-pearl-shadow) backdrop-blur-2xl hover:bg-(--profile-pearl-bg-hover)'
           : 'rounded-2xl border border-subtle bg-surface-1 shadow-card hover:border-default',
         className
       )}
@@ -167,7 +167,7 @@ export function EntityCard({
             <span className='text-2xs font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
               {model.datePill.month}
             </span>
-            <span className='text-[34px] font-bold leading-none tracking-[-0.02em] tabular-nums'>
+            <span className='text-[34px] font-bold leading-none tracking-tighter tabular-nums'>
               {model.datePill.day}
             </span>
           </div>
@@ -201,7 +201,7 @@ export function EntityCard({
 
         <h3
           className={cn(
-            'min-w-0 font-semibold leading-tight tracking-[-0.02em] text-primary-token line-clamp-2',
+            'min-w-0 font-semibold leading-tight tracking-tighter text-primary-token line-clamp-2',
             size.titleClass
           )}
         >

--- a/apps/web/components/organisms/release-sidebar/ReleaseCreditsSection.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseCreditsSection.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils';
 import { fetchReleaseCreditsAction } from './release-credits-action';
 
 const LABEL_CLASSNAME =
-  'text-3xs font-[500] leading-[13px] tracking-[0.01em] text-quaternary-token';
+  'text-3xs font-[500] leading-[13px] tracking-wide text-quaternary-token';
 const VALUE_CLASSNAME =
   'text-xs font-[460] leading-[16px] text-secondary-token';
 const ROW_CLASSNAME = 'rounded-none px-0 py-1 first:pt-0 last:pb-0';

--- a/apps/web/components/organisms/release-sidebar/TrackMetaSummary.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackMetaSummary.tsx
@@ -38,7 +38,7 @@ const VARIANT_STYLES: Record<
   drawer: {
     container: 'space-y-1.5',
     number: 'text-3xs',
-    title: 'text-sm tracking-[-0.01em]',
+    title: 'text-sm tracking-tight',
     meta: 'text-3xs',
   },
 };
@@ -102,7 +102,7 @@ export function TrackMetaSummary({
               <span className='tabular-nums'>{formatDuration(durationMs)}</span>
             )}
             {isrc && showIsrc ? (
-              <span className='font-mono text-3xs tracking-[0.02em] text-tertiary-token'>
+              <span className='font-mono text-3xs tracking-wider text-tertiary-token'>
                 {isrc}
               </span>
             ) : null}

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -363,7 +363,7 @@ export function TrackSidebar({
                       </span>
                     )}
                     {track.isrc ? (
-                      <span className='font-mono text-3xs tracking-[0.02em]'>
+                      <span className='font-mono text-3xs tracking-wider'>
                         {track.isrc}
                       </span>
                     ) : null}

--- a/apps/web/components/organisms/sidebar/sidebar.tsx
+++ b/apps/web/components/organisms/sidebar/sidebar.tsx
@@ -104,7 +104,7 @@ export const Sidebar = React.forwardRef<
           >
             <div
               data-sidebar='sidebar'
-              className='pointer-events-auto flex h-full w-full flex-col overflow-clip bg-sidebar transition-[background-color] duration-normal ease-interactive lg:rounded-[var(--linear-app-shell-radius)] lg:shadow-[var(--linear-app-sidebar-shadow)] group-data-[variant=floating]:rounded-sidebar-floating group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow group-data-[variant=inset]:border-r group-data-[variant=inset]:border-sidebar-border'
+              className='pointer-events-auto flex h-full w-full flex-col overflow-clip bg-sidebar transition-[background-color] duration-normal ease-interactive lg:rounded-(--linear-app-shell-radius) lg:shadow-(--linear-app-sidebar-shadow) group-data-[variant=floating]:rounded-sidebar-floating group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow group-data-[variant=inset]:border-r group-data-[variant=inset]:border-sidebar-border'
             >
               {children}
             </div>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3216,
+  "count": 3200,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- convert exact app-shell and sidebar CSS variable arbitrary classes to Tailwind variable shorthand
- convert entity-card pearl surface CSS variable arbitrary classes to shorthand
- replace exact tracking arbitrary values with existing tracking tokens
- lower the arbitrary-value ratchet baseline from 3216 to 3200

## Verification
- `node -e "...count arbitrary values..."` → `3200`
- `pnpm biome check --write apps/web/components/organisms/AppShellFrame.tsx apps/web/components/organisms/sidebar/sidebar.tsx apps/web/components/organisms/entity-card/EntityCard.tsx apps/web/components/organisms/AuthShellWrapper.tsx apps/web/components/organisms/release-sidebar/TrackSidebar.tsx apps/web/components/organisms/release-sidebar/TrackMetaSummary.tsx apps/web/components/organisms/release-sidebar/ReleaseCreditsSection.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/organisms/AppShellFrame.tsx apps/web/components/organisms/sidebar/sidebar.tsx apps/web/components/organisms/entity-card/EntityCard.tsx apps/web/components/organisms/AuthShellWrapper.tsx apps/web/components/organisms/release-sidebar/TrackSidebar.tsx apps/web/components/organisms/release-sidebar/TrackMetaSummary.tsx apps/web/components/organisms/release-sidebar/ReleaseCreditsSection.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`
