### PR TITLE
fix(web): reduce dashboard settings arbitrary drift

### DIFF
--- a/apps/web/components/features/admin/table/organisms/KanbanBoard.tsx
+++ b/apps/web/components/features/admin/table/organisms/KanbanBoard.tsx
@@ -191,7 +191,7 @@ function KanbanColumn<TData>({
               aria-hidden='true'
             />
           )}
-          <h3 className='text-app font-semibold tracking-[-0.01em] text-primary-token'>
+          <h3 className='text-app font-semibold tracking-tight text-primary-token'>
             {column.title}
           </h3>
         </div>

--- a/apps/web/components/features/dashboard/molecules/ContactItem.tsx
+++ b/apps/web/components/features/dashboard/molecules/ContactItem.tsx
@@ -67,7 +67,7 @@ export const ContactItem = memo(function ContactItem({
             size='sm'
             variant='ghost'
             onClick={() => onUpdate({ isExpanded: !contact.isExpanded })}
-            className='rounded-lg px-3 text-2xs font-caption tracking-[-0.01em]'
+            className='rounded-lg px-3 text-2xs font-caption tracking-tight'
           >
             {contact.isExpanded ? 'Collapse' : 'Edit'}
           </Button>

--- a/apps/web/components/features/dashboard/organisms/MusicImportHero.tsx
+++ b/apps/web/components/features/dashboard/organisms/MusicImportHero.tsx
@@ -133,7 +133,7 @@ export const MusicImportHero = memo(function MusicImportHero({
           variant='secondary'
           size='sm'
           asChild
-          className='rounded-lg text-2xs font-caption tracking-[-0.01em]'
+          className='rounded-lg text-2xs font-caption tracking-tight'
         >
           <Link href={APP_ROUTES.RELEASES}>
             {isImporting ? 'View All Releases' : 'Explore Your Releases'}

--- a/apps/web/components/features/dashboard/organisms/settings-artist-profile-section/ConnectedDspList.tsx
+++ b/apps/web/components/features/dashboard/organisms/settings-artist-profile-section/ConnectedDspList.tsx
@@ -417,7 +417,7 @@ function ConnectedDspListContent({
       <div className='space-y-3 px-4 py-3'>
         <ContentSurfaceCard className='space-y-3 bg-surface-0 p-4'>
           <div className='space-y-1'>
-            <p className='text-app font-caption tracking-[-0.01em] text-primary-token'>
+            <p className='text-app font-caption tracking-tight text-primary-token'>
               Primary platforms
             </p>
             <p className='text-app leading-[18px] text-secondary-token'>
@@ -442,7 +442,7 @@ function ConnectedDspListContent({
         {nonPrimaryMatches.length > 0 ? (
           <ContentSurfaceCard className='space-y-3 bg-surface-0 p-4'>
             <div className='space-y-1'>
-              <p className='text-app font-caption tracking-[-0.01em] text-primary-token'>
+              <p className='text-app font-caption tracking-tight text-primary-token'>
                 Other platforms
               </p>
               <p className='text-app leading-[18px] text-secondary-token'>

--- a/apps/web/components/features/onboarding/OnboardingExperienceShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingExperienceShell.tsx
@@ -81,7 +81,7 @@ export function OnboardingExperienceShell({
             <div className='sticky top-8'>
               {sidebarTitle ? (
                 <div className='border-b border-[color-mix(in_oklab,var(--linear-app-frame-seam)_68%,transparent)] pb-4'>
-                  <p className='text-sm font-semibold tracking-[-0.02em] text-primary-token'>
+                  <p className='text-sm font-semibold tracking-tighter text-primary-token'>
                     {sidebarTitle}
                   </p>
                 </div>

--- a/apps/web/components/molecules/drawer/RightDrawer.tsx
+++ b/apps/web/components/molecules/drawer/RightDrawer.tsx
@@ -128,7 +128,7 @@ export function RightDrawer({
           'overflow-hidden',
           'outline-none focus:outline-none focus:ring-0',
           'border-l border-(--linear-app-frame-seam) bg-(--linear-app-content-surface)',
-          'shadow-[var(--linear-app-drawer-shadow)]',
+          'shadow-(--linear-app-drawer-shadow)',
           'pb-[env(safe-area-inset-bottom)]',
           'transition-transform duration-cinematic ease-cinematic',
           isOpen ? 'translate-x-0' : 'translate-x-full pointer-events-none',

--- a/apps/web/components/molecules/settings/SettingsActionRow.tsx
+++ b/apps/web/components/molecules/settings/SettingsActionRow.tsx
@@ -38,7 +38,7 @@ export function SettingsActionRow({
         <div className='min-w-0'>
           <p
             className={cn(
-              'text-app font-[540] tracking-[-0.02em] text-primary-token',
+              'text-app font-[540] tracking-tighter text-primary-token',
               titleClassName
             )}
           >

--- a/apps/web/components/molecules/settings/SettingsPanel.tsx
+++ b/apps/web/components/molecules/settings/SettingsPanel.tsx
@@ -42,7 +42,7 @@ export function SettingsPanel({
             {title ? (
               <h3
                 className={cn(
-                  'text-app font-[540] tracking-[-0.02em] text-primary-token',
+                  'text-app font-[540] tracking-tighter text-primary-token',
                   titleClassName
                 )}
               >

--- a/apps/web/components/molecules/settings/SettingsToggleRow.tsx
+++ b/apps/web/components/molecules/settings/SettingsToggleRow.tsx
@@ -62,7 +62,7 @@ export function SettingsToggleRow(props: Readonly<SettingsToggleRowProps>) {
           <h3
             id={titleId}
             className={cn(
-              'text-app font-[540] tracking-[-0.02em]',
+              'text-app font-[540] tracking-tighter',
               props.gated ? 'text-tertiary-token' : 'text-primary-token'
             )}
           >

--- a/apps/web/components/organisms/ProfileNotificationsButton.tsx
+++ b/apps/web/components/organisms/ProfileNotificationsButton.tsx
@@ -44,7 +44,7 @@ export function ProfileNotificationsButton({
       variant='pearlQuiet'
       className={
         isActive
-          ? 'relative bg-[var(--profile-pearl-bg-active)] text-primary-token'
+          ? 'relative bg-(--profile-pearl-bg-active) text-primary-token'
           : 'relative text-primary-token/76'
       }
       aria-expanded={ariaExpanded}

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3200,
+  "count": 3189,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- convert exact dashboard/settings tracking arbitrary values to existing tracking tokens
- convert drawer/profile notification CSS variable arbitrary classes to Tailwind variable shorthand
- lower the arbitrary-value ratchet baseline from 3200 to 3189

## Verification
- `node -e "...count arbitrary values..."` → `3189`
- `pnpm biome check --write apps/web/components/features/onboarding/OnboardingExperienceShell.tsx apps/web/components/features/dashboard/organisms/MusicImportHero.tsx apps/web/components/features/dashboard/organisms/settings-artist-profile-section/ConnectedDspList.tsx apps/web/components/features/dashboard/molecules/ContactItem.tsx apps/web/components/molecules/settings/SettingsActionRow.tsx apps/web/components/molecules/settings/SettingsPanel.tsx apps/web/components/molecules/settings/SettingsToggleRow.tsx apps/web/components/molecules/drawer/RightDrawer.tsx apps/web/components/organisms/ProfileNotificationsButton.tsx apps/web/components/features/admin/table/organisms/KanbanBoard.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content <changed tsx files>`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`
