### PR TITLE
fix(web): reduce home landing arbitrary drift

### DIFF
--- a/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
+++ b/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
@@ -53,7 +53,7 @@ export function AutomaticReleaseSmartlinksSection() {
                 Connect Spotify once. Every new release gets a smart link across
                 every platform — automatically.
               </p>
-              <span className='mt-6 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium tracking-[-0.01em] text-tertiary-token border border-subtle'>
+              <span className='mt-6 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium tracking-tight text-tertiary-token border border-subtle'>
                 Zero manual work
               </span>
             </div>
@@ -203,7 +203,7 @@ export function AutomaticReleaseSmartlinksSection() {
                             DSP_LOGO_CONFIG[key as keyof typeof DSP_LOGO_CONFIG]
                               ?.iconPath
                           }
-                          className='bg-surface-1 ring-[color:var(--linear-border-subtle)] hover:bg-hover'
+                          className='bg-surface-1 ring-(--linear-border-subtle) hover:bg-hover'
                         />
                       );
                     })}

--- a/apps/web/components/features/home/HeroLinear.tsx
+++ b/apps/web/components/features/home/HeroLinear.tsx
@@ -57,7 +57,7 @@ export function HeroLinear({ fullScreen = false }: Readonly<HeroLinearProps>) {
                 Request Access
               </Link>
             </div>
-            <p className='mt-3 text-2xs tracking-[0.01em] text-quaternary-token'>
+            <p className='mt-3 text-2xs tracking-wide text-quaternary-token'>
               Private launch access. No credit card required.
             </p>
           </div>

--- a/apps/web/components/features/home/HomePhoneFrame.tsx
+++ b/apps/web/components/features/home/HomePhoneFrame.tsx
@@ -39,24 +39,24 @@ export function HomePhoneFrame({
         />
         <div
           aria-hidden='true'
-          className='pointer-events-none absolute left-[11%] right-[11%] top-3 h-6 rounded-full bg-[color:var(--system-b-cinematic-black)]'
+          className='pointer-events-none absolute left-[11%] right-[11%] top-3 h-6 rounded-full bg-(--system-b-cinematic-black)'
         />
         <div
           aria-hidden='true'
           className='pointer-events-none absolute inset-2 rounded-[2.3rem] bg-[linear-gradient(165deg,rgba(255,255,255,0.14),rgba(255,255,255,0)_22%)] opacity-90'
         />
 
-        <div className='homepage-phone-screen relative aspect-[430/950] overflow-hidden rounded-[2.2rem] bg-[color:var(--system-b-cinematic-black)]'>
+        <div className='homepage-phone-screen relative aspect-[430/950] overflow-hidden rounded-[2.2rem] bg-(--system-b-cinematic-black)'>
           <div
             aria-hidden='true'
-            className='pointer-events-none absolute left-1/2 top-3 z-[18] h-10 w-32 -translate-x-1/2 rounded-full bg-[color:var(--system-b-cinematic-black)] shadow-[0_8px_24px_rgba(0,0,0,0.32)]'
+            className='pointer-events-none absolute left-1/2 top-3 z-[18] h-10 w-32 -translate-x-1/2 rounded-full bg-(--system-b-cinematic-black) shadow-[0_8px_24px_rgba(0,0,0,0.32)]'
           />
           <div
             aria-hidden='true'
             data-testid='home-phone-status-bar'
-            className='pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center justify-between px-7 pt-4 text-[color:var(--system-b-text-primary)]'
+            className='pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center justify-between px-7 pt-4 text-(--system-b-text-primary)'
           >
-            <span className='text-mid font-semibold tracking-[-0.02em]'>
+            <span className='text-mid font-semibold tracking-tighter'>
               9:41
             </span>
             <div className='flex items-center gap-2.5'>
@@ -64,17 +64,17 @@ export function HomePhoneFrame({
                 {[8, 12, 16, 20].map(height => (
                   <span
                     key={height}
-                    className='block w-1 rounded-full bg-[color:var(--system-b-text-primary)]'
+                    className='block w-1 rounded-full bg-(--system-b-text-primary)'
                     style={{ height }}
                   />
                 ))}
               </div>
               <div className='relative h-3 w-5'>
                 <span className='absolute inset-0 rounded-full border-[1.8px] border-white/96' />
-                <span className='absolute left-1 right-1 top-1 h-1 rounded-full bg-[color:var(--system-b-text-primary)]' />
+                <span className='absolute left-1 right-1 top-1 h-1 rounded-full bg-(--system-b-text-primary)' />
               </div>
               <div className='relative h-3 w-6 rounded-xs border-[1.8px] border-white/92'>
-                <span className='absolute inset-1 rounded-xs bg-[color:var(--system-b-text-primary)]' />
+                <span className='absolute inset-1 rounded-xs bg-(--system-b-text-primary)' />
                 <span className='absolute -right-[3px] top-1 h-1 w-1 rounded-r-full bg-white/92' />
               </div>
             </div>

--- a/apps/web/components/features/home/RedesignedHero.tsx
+++ b/apps/web/components/features/home/RedesignedHero.tsx
@@ -22,10 +22,10 @@ export async function RedesignedHero() {
           <ClaimHandleForm size='hero' />
         </div>
 
-        <p className='mt-5 text-[length:var(--linear-label-size)] font-[number:var(--linear-font-weight-normal)] tracking-[0.01em] text-tertiary-token'>
+        <p className='mt-5 text-[length:var(--linear-label-size)] font-[number:var(--linear-font-weight-normal)] tracking-wide text-tertiary-token'>
           <span
             aria-hidden='true'
-            className='mr-2 inline-block h-1.5 w-1.5 rounded-full bg-[var(--linear-success)]'
+            className='mr-2 inline-block h-1.5 w-1.5 rounded-full bg-(--linear-success)'
           />{' '}
           Private launch access. No credit card required.
         </p>

--- a/apps/web/components/features/home/ReplacesSection.tsx
+++ b/apps/web/components/features/home/ReplacesSection.tsx
@@ -31,7 +31,7 @@ export function ReplacesSection() {
         <div className='relative mx-auto max-w-linear-content'>
           {/* Header */}
           <div className='reveal-on-scroll flex flex-col items-center text-center gap-5 mb-16'>
-            <span className='inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium tracking-[-0.01em] text-tertiary-token border border-subtle'>
+            <span className='inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium tracking-tight text-tertiary-token border border-subtle'>
               Why switch
             </span>
             <h2 className='marketing-h2-linear text-primary-token'>

--- a/apps/web/components/features/home/StickyPhoneTour.tsx
+++ b/apps/web/components/features/home/StickyPhoneTour.tsx
@@ -43,7 +43,7 @@ function StickyPhoneTourFallback({
             <div className='relative'>
               <div className='grid items-center grid-cols-[1fr_auto_1fr] gap-8 xl:gap-16'>
                 <div className='relative min-h-80'>
-                  <span className='inline-flex items-center gap-1.5 self-start rounded-full border border-subtle px-3 py-1 text-xs font-medium tracking-[-0.01em] text-tertiary-token'>
+                  <span className='inline-flex items-center gap-1.5 self-start rounded-full border border-subtle px-3 py-1 text-xs font-medium tracking-tight text-tertiary-token'>
                     {introBadge}
                   </span>
 
@@ -77,7 +77,7 @@ function StickyPhoneTourFallback({
                     return (
                       <div key={mode.id} className='text-right'>
                         <p
-                          className='font-mono tracking-[-0.02em]'
+                          className='font-mono tracking-tighter'
                           style={{
                             fontSize: isActive ? '20px' : '15px',
                             fontWeight: isActive ? 590 : 400,

--- a/apps/web/components/features/landing/SharedMarketingHero.tsx
+++ b/apps/web/components/features/landing/SharedMarketingHero.tsx
@@ -115,7 +115,7 @@ export function SharedMarketingHero({
                   {proofPoints.map(label => (
                     <span
                       key={label}
-                      className='inline-flex items-center rounded-full border border-subtle bg-surface-1 px-3.5 py-1.5 text-xs font-medium tracking-[-0.01em] text-secondary-token'
+                      className='inline-flex items-center rounded-full border border-subtle bg-surface-1 px-3.5 py-1.5 text-xs font-medium tracking-tight text-secondary-token'
                     >
                       {label}
                     </span>

--- a/apps/web/components/features/landing/VoiceDemoVisual.tsx
+++ b/apps/web/components/features/landing/VoiceDemoVisual.tsx
@@ -52,7 +52,7 @@ export function VoiceDemoVisual({ className }: Readonly<VoiceDemoVisualProps>) {
           <div
             key={i}
             className={cn(
-              'w-1.5 rounded-full bg-[var(--color-primary)]',
+              'w-1.5 rounded-full bg-(--color-primary)',
               isPlaying ? 'voice-bar-animate' : 'h-3'
             )}
             style={{
@@ -65,13 +65,13 @@ export function VoiceDemoVisual({ className }: Readonly<VoiceDemoVisualProps>) {
       <button
         type='button'
         onClick={toggleDemo}
-        className='mt-5 inline-flex items-center gap-2 rounded-full border border-subtle bg-panel px-5 py-2 text-sm font-medium text-primary-token transition hover:bg-surface-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]'
+        className='mt-5 inline-flex items-center gap-2 rounded-full border border-subtle bg-panel px-5 py-2 text-sm font-medium text-primary-token transition hover:bg-surface-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-(--color-primary)'
         data-testid='voice-demo-play-btn'
         aria-label={isPlaying ? 'Stop voice sample' : 'Play voice sample demo'}
       >
         {isPlaying ? (
           <>
-            <span className='inline-block h-2 w-2 animate-pulse rounded-full bg-[var(--color-primary)]' />
+            <span className='inline-block h-2 w-2 animate-pulse rounded-full bg-(--color-primary)' />
             Playing sample…
           </>
         ) : (

--- a/apps/web/components/marketing/MarketingContentShell.tsx
+++ b/apps/web/components/marketing/MarketingContentShell.tsx
@@ -22,7 +22,7 @@ export function MarketingContentShell({
         <div
           className={cn(
             'marketing-body',
-            'text-[var(--linear-text-secondary)]',
+            'text-(--linear-text-secondary)',
             className
           )}
         >

--- a/apps/web/components/marketing/MarketingSectionIntro.tsx
+++ b/apps/web/components/marketing/MarketingSectionIntro.tsx
@@ -60,7 +60,7 @@ export function MarketingSectionIntro({
               <span
                 key={badge.label}
                 data-testid={badge.testId}
-                className='inline-flex items-center rounded-full border border-subtle bg-surface-1 px-3 py-1.5 text-xs font-medium tracking-[-0.01em] text-secondary-token'
+                className='inline-flex items-center rounded-full border border-subtle bg-surface-1 px-3 py-1.5 text-xs font-medium tracking-tight text-secondary-token'
               >
                 {badge.label}
               </span>

--- a/apps/web/components/site/MarketingFinalCTA.tsx
+++ b/apps/web/components/site/MarketingFinalCTA.tsx
@@ -53,7 +53,7 @@ export function MarketingFinalCTA({
           <Link
             href={ctaHref}
             prefetch={false}
-            className='inline-flex h-10 items-center rounded-full bg-(--color-text-tooltip) px-6 text-sm font-semibold tracking-[0.01em] text-black transition-opacity duration-subtle ease-subtle hover:opacity-92 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black dark:text-black'
+            className='inline-flex h-10 items-center rounded-full bg-(--color-text-tooltip) px-6 text-sm font-semibold tracking-wide text-black transition-opacity duration-subtle ease-subtle hover:opacity-92 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black dark:text-black'
           >
             {ctaLabel}
           </Link>
@@ -61,7 +61,7 @@ export function MarketingFinalCTA({
             <Link
               href={secondaryHref}
               prefetch={false}
-              className='inline-flex h-10 items-center gap-1 rounded-full px-6 text-sm font-semibold tracking-[0.01em] text-white/92 transition-colors duration-subtle ease-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
+              className='inline-flex h-10 items-center gap-1 rounded-full px-6 text-sm font-semibold tracking-wide text-white/92 transition-colors duration-subtle ease-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
             >
               {secondaryLabel}
               <span aria-hidden='true'>→</span>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3189,
+  "count": 3165,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- convert exact home/landing CSS variable arbitrary classes to Tailwind variable shorthand
- replace exact home/landing tracking arbitrary values with existing tracking tokens
- lower the arbitrary-value ratchet baseline from 3189 to 3165

## Verification
- `node -e "...count arbitrary values..."` → `3165`
- `pnpm biome check --write <changed files>`
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content <changed tsx files>`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`
