### PR TITLE
fix(web): reduce release alert arbitrary drift

### DIFF
--- a/apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx
+++ b/apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx
@@ -164,7 +164,7 @@ export function SoundsLandingPage({
       returnLabel={`Back to ${artist.name}`}
       heroOverlay={
         <div className='absolute inset-x-0 bottom-5 z-10 px-5'>
-          <h1 className='text-3xl font-semibold leading-[1.06] tracking-[-0.02em] text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
+          <h1 className='text-3xl font-semibold leading-[1.06] tracking-tighter text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
             {release.title}
           </h1>
           {artist.handle ? (

--- a/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
+++ b/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
@@ -390,7 +390,7 @@ export function ReleaseLandingPage({
       heroOverlay={
         <div className='absolute inset-x-0 bottom-5 z-10 flex items-end justify-between px-5'>
           <div className='min-w-0 flex-1'>
-            <h1 className='text-[28px] font-semibold leading-[1.06] tracking-[-0.02em] text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
+            <h1 className='text-[28px] font-semibold leading-[1.06] tracking-tighter text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
               {release.title}
             </h1>
             <SmartLinkArtistLine

--- a/apps/web/components/features/alerts/AlertGrowthLanding.tsx
+++ b/apps/web/components/features/alerts/AlertGrowthLanding.tsx
@@ -285,7 +285,7 @@ export function AlertGrowthLanding({
                     value={phoneInput}
                     onChange={e => setPhoneInput(e.target.value)}
                     disabled={isPending}
-                    className='border-subtle bg-surface-0 text-primary-token focus-visible:ring-accent h-12 w-full rounded-[var(--profile-action-radius)] border px-3.5 text-base focus:outline-none focus-visible:ring-2'
+                    className='border-subtle bg-surface-0 text-primary-token focus-visible:ring-accent h-12 w-full rounded-(--profile-action-radius) border px-3.5 text-base focus:outline-none focus-visible:ring-2'
                   />
                 </>
               ) : (
@@ -305,7 +305,7 @@ export function AlertGrowthLanding({
                     value={emailInput}
                     onChange={e => setEmailInput(e.target.value)}
                     disabled={isPending}
-                    className='border-subtle bg-surface-0 text-primary-token focus-visible:ring-accent h-12 w-full rounded-[var(--profile-action-radius)] border px-3.5 text-base focus:outline-none focus-visible:ring-2'
+                    className='border-subtle bg-surface-0 text-primary-token focus-visible:ring-accent h-12 w-full rounded-(--profile-action-radius) border px-3.5 text-base focus:outline-none focus-visible:ring-2'
                   />
                 </>
               )}
@@ -314,7 +314,7 @@ export function AlertGrowthLanding({
             <button
               type='submit'
               disabled={isPending}
-              className='h-12 w-full rounded-[var(--profile-action-radius)] border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-sm font-semibold text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover disabled:opacity-60'
+              className='h-12 w-full rounded-(--profile-action-radius) border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-sm font-semibold text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover disabled:opacity-60'
             >
               {isPending ? 'Sending…' : 'Get alerts'}
             </button>
@@ -352,7 +352,7 @@ export function AlertGrowthLanding({
           {PROOF_POINTS.map(point => (
             <li
               key={point}
-              className='border-subtle text-secondary-token rounded-[var(--profile-action-radius)] border bg-surface-1 px-3.5 py-3 text-app'
+              className='border-subtle text-secondary-token rounded-(--profile-action-radius) border bg-surface-1 px-3.5 py-3 text-app'
             >
               {point}
             </li>
@@ -390,8 +390,8 @@ function ChannelToggle({
       onClick={onSelect}
       className={
         pressed
-          ? 'border-default bg-surface-1 text-primary-token flex-1 rounded-[var(--profile-action-radius)] border px-4 py-3 text-app font-semibold disabled:opacity-60'
-          : 'border-subtle bg-surface-0 text-secondary-token flex-1 rounded-[var(--profile-action-radius)] border px-4 py-3 text-app font-semibold disabled:opacity-60'
+          ? 'border-default bg-surface-1 text-primary-token flex-1 rounded-(--profile-action-radius) border px-4 py-3 text-app font-semibold disabled:opacity-60'
+          : 'border-subtle bg-surface-0 text-secondary-token flex-1 rounded-(--profile-action-radius) border px-4 py-3 text-app font-semibold disabled:opacity-60'
       }
     >
       {label}
@@ -410,7 +410,7 @@ function SubscribedState({
     return (
       <div
         role='status'
-        className='bg-surface-1 border-subtle rounded-[var(--profile-card-radius)] border p-5'
+        className='bg-surface-1 border-subtle rounded-(--profile-card-radius) border p-5'
         data-testid='alerts-landing-pending'
       >
         <h2 className='text-primary-token text-base font-semibold tracking-normal'>
@@ -428,7 +428,7 @@ function SubscribedState({
   return (
     <div
       role='status'
-      className='bg-surface-1 border-subtle rounded-[var(--profile-card-radius)] border p-5'
+      className='bg-surface-1 border-subtle rounded-(--profile-card-radius) border p-5'
       data-testid='alerts-landing-success'
     >
       <h2 className='text-primary-token text-base font-semibold tracking-normal'>

--- a/apps/web/components/features/dashboard/tasks/TaskDescriptionHelper.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskDescriptionHelper.tsx
@@ -22,7 +22,7 @@ export function TaskDescriptionHelper({
         aria-label={`Open ${helper.title} description helper`}
         data-testid='task-description-helper'
         onClick={onBeginEditing}
-        className='absolute inset-0 rounded-2xl bg-[color-mix(in_oklab,var(--linear-app-content-surface)_82%,var(--linear-app-shell-border)_18%)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--linear-border-focus)]'
+        className='absolute inset-0 rounded-2xl bg-[color-mix(in_oklab,var(--linear-app-content-surface)_82%,var(--linear-app-shell-border)_18%)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
       />
       <div className='pointer-events-none relative z-10 max-w-[40rem] space-y-3 px-5 py-5 text-left'>
         <div className='space-y-1'>

--- a/apps/web/components/features/demo/DemoReleaseDetail.tsx
+++ b/apps/web/components/features/demo/DemoReleaseDetail.tsx
@@ -34,7 +34,7 @@ export function DemoReleaseDetail({
     <div className='flex h-full flex-col'>
       {/* Header */}
       <div className='flex min-h-10 items-center justify-between border-b border-(--linear-app-frame-seam) px-4 py-2'>
-        <div className='min-w-0 flex-1 text-app font-medium tracking-[-0.01em] text-secondary-token'>
+        <div className='min-w-0 flex-1 text-app font-medium tracking-tight text-secondary-token'>
           REL-{release.id.slice(0, 4).toUpperCase()}
         </div>
         <DrawerInlineIconButton

--- a/apps/web/components/features/demo/DemoReleaseTrackedLinksSurface.tsx
+++ b/apps/web/components/features/demo/DemoReleaseTrackedLinksSurface.tsx
@@ -29,7 +29,7 @@ export function DemoReleaseTrackedLinksSurface() {
             data-testid='demo-release-tracked-links-capture'
           >
             <div className='rounded-2xl border border-subtle bg-surface-1 px-4 py-3'>
-              <p className='text-2xs font-medium tracking-[-0.01em] text-tertiary-token'>
+              <p className='text-2xs font-medium tracking-tight text-tertiary-token'>
                 Release row
               </p>
               <div className='mt-2 flex items-center justify-between gap-4'>

--- a/apps/web/components/features/demo/DemoSettingsPanel.tsx
+++ b/apps/web/components/features/demo/DemoSettingsPanel.tsx
@@ -348,7 +348,7 @@ function SyncSurfacePill({
 }>) {
   return (
     <div className='rounded-2xl border border-subtle bg-surface-1 px-3 py-3'>
-      <p className='text-2xs font-semibold tracking-[-0.01em] text-secondary-token'>
+      <p className='text-2xs font-semibold tracking-tight text-secondary-token'>
         {label}
       </p>
       <p className='mt-1 text-sm font-semibold text-primary-token'>{value}</p>

--- a/apps/web/components/features/release/UnreleasedReleaseHero.tsx
+++ b/apps/web/components/features/release/UnreleasedReleaseHero.tsx
@@ -83,7 +83,7 @@ export function UnreleasedReleaseHero({
         returnLabel={`Back to ${artist.name}`}
         heroOverlay={
           <div className='absolute inset-x-0 bottom-5 z-10 px-5'>
-            <h1 className='text-3xl font-semibold leading-[1.06] tracking-[-0.02em] text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
+            <h1 className='text-3xl font-semibold leading-[1.06] tracking-tighter text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
               {release.title}
             </h1>
             <Link

--- a/apps/web/components/features/release/VideoReleasePage.tsx
+++ b/apps/web/components/features/release/VideoReleasePage.tsx
@@ -85,7 +85,7 @@ export function VideoReleasePage({
       returnLabel={`Back to ${artist.name}`}
       heroOverlay={
         <div className='absolute inset-x-0 bottom-5 z-10 px-5'>
-          <h1 className='text-mid font-medium leading-[1.2] tracking-[-0.01em] text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
+          <h1 className='text-mid font-medium leading-[1.2] tracking-tight text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
             {release.title}
           </h1>
           <Link

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -591,7 +591,7 @@ export function JovieChat({
           {isDragOver && (
             <motion.div
               data-testid='chat-attachment-dropzone'
-              className='absolute inset-0 z-50 flex items-center justify-center rounded-[var(--linear-app-shell-radius)] border border-dashed border-(--linear-app-frame-seam) bg-[linear-gradient(180deg,color-mix(in_oklab,var(--linear-app-content-surface)_82%,black),color-mix(in_oklab,var(--linear-app-content-surface)_70%,black))] p-6 backdrop-blur-md'
+              className='absolute inset-0 z-50 flex items-center justify-center rounded-(--linear-app-shell-radius) border border-dashed border-(--linear-app-frame-seam) bg-[linear-gradient(180deg,color-mix(in_oklab,var(--linear-app-content-surface)_82%,black),color-mix(in_oklab,var(--linear-app-content-surface)_70%,black))] p-6 backdrop-blur-md'
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}

--- a/apps/web/components/marketing/artist-profile/ShellCtaButton.tsx
+++ b/apps/web/components/marketing/artist-profile/ShellCtaButton.tsx
@@ -29,7 +29,7 @@ const TONE: Record<`${Tone}-${Context}`, string> = {
   'secondary-on-dark':
     'bg-white/[0.04] text-white border border-white/12 hover:bg-white/[0.08]',
   'secondary-auto':
-    'bg-transparent text-primary-token border border-[var(--linear-app-shell-border)] hover:bg-surface-2/80',
+    'bg-transparent text-primary-token border border-(--linear-app-shell-border) hover:bg-surface-2/80',
 };
 
 const RING_OFFSET: Record<Context, string> = {
@@ -49,7 +49,7 @@ export function shellCtaClassName({
   return cn(
     'inline-flex shrink-0 items-center justify-center rounded-full font-semibold tracking-[-0.011em]',
     'transition-[background-color,border-color,box-shadow,opacity] duration-150 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--linear-border-focus)] focus-visible:ring-offset-2',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus) focus-visible:ring-offset-2',
     RING_OFFSET[context],
     SHAPE[size],
     TONE[`${tone}-${context}`]

--- a/apps/web/components/tokens/linear-surface.ts
+++ b/apps/web/components/tokens/linear-surface.ts
@@ -29,7 +29,7 @@ export const LINEAR_SURFACE = {
 
   // Tier 3 — floating UI (popovers, dropdowns)
   popover:
-    'rounded-xl border border-subtle bg-surface-1 p-0 shadow-[var(--shadow-popover)]',
+    'rounded-xl border border-subtle bg-surface-1 p-0 shadow-(--shadow-popover)',
 } as const;
 
 export const LINEAR_SURFACE_TIER = {

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3165,
+  "count": 3145,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- convert exact release/demo/alert CSS variable arbitrary utilities to Tailwind variable shorthand
- replace exact release/demo tracking arbitrary values with existing tracking tokens
- lower the arbitrary-value ratchet baseline from 3165 to 3145

## Verification
- `node -e "...count arbitrary values..."` → `3145`
- `pnpm biome check --write <changed files>`
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content <changed tsx files>`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`
