### PR TITLE
fix(web): reduce marketing story arbitrary drift

### DIFF
--- a/apps/web/components/features/home/ArtistProfileModesShowcase.tsx
+++ b/apps/web/components/features/home/ArtistProfileModesShowcase.tsx
@@ -23,7 +23,7 @@ export function ArtistProfileModesShowcase() {
                 aria-pressed={isActive}
                 onClick={() => setActiveIndex(index)}
                 className={cn(
-                  'rounded-full border px-3 py-1.5 text-left text-2xs font-semibold tracking-[-0.01em] transition-colors',
+                  'rounded-full border px-3 py-1.5 text-left text-2xs font-semibold tracking-tight transition-colors',
                   isActive
                     ? 'border-white/12 bg-white/[0.045] text-primary-token'
                     : 'border-transparent bg-transparent text-secondary-token hover:border-white/8 hover:bg-white/[0.02] hover:text-primary-token'

--- a/apps/web/components/marketing/MarketingStoryPrimitives.tsx
+++ b/apps/web/components/marketing/MarketingStoryPrimitives.tsx
@@ -93,7 +93,7 @@ export function ArtistNotificationFloatingCardView({
           <Icon className='h-4 w-4' strokeWidth={1.9} />
         </span>
         <div className='min-w-0 flex-1'>
-          <p className='text-sm font-semibold leading-[1.35] tracking-[-0.02em] text-primary-token'>
+          <p className='text-sm font-semibold leading-[1.35] tracking-tighter text-primary-token'>
             {card.title}
           </p>
           {card.detail ? (
@@ -243,7 +243,7 @@ export function ArtistProfileReactivationVisual({
             </span>
             <div className='min-w-0'>
               <div className='flex items-center gap-2 text-2xs text-white/60'>
-                <p className='font-medium tracking-[-0.01em]'>
+                <p className='font-medium tracking-tight'>
                   {notification.appName}
                 </p>
                 <span>{notification.timeLabel}</span>
@@ -312,7 +312,7 @@ export function ArtistProfileReactivationVisual({
                     <p className='text-app leading-normal text-secondary-token'>
                       {output.detail}
                     </p>
-                    <p className='text-xs font-medium tracking-[-0.01em] text-tertiary-token'>
+                    <p className='text-xs font-medium tracking-tight text-tertiary-token'>
                       {output.destination}
                     </p>
                   </div>
@@ -352,9 +352,9 @@ function WorkflowCell({
 
   let textClass: string;
   if (tone === 'audience') {
-    textClass = 'text-sm font-medium tracking-[-0.02em] text-secondary-token';
+    textClass = 'text-sm font-medium tracking-tighter text-secondary-token';
   } else if (tone === 'message') {
-    textClass = 'text-sm font-medium tracking-[-0.02em] text-white/88';
+    textClass = 'text-sm font-medium tracking-tighter text-white/88';
   } else {
     textClass = 'text-mid font-semibold tracking-[-0.03em] text-primary-token';
   }

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3126,
+  "count": 3120,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- replace exact marketing story tracking arbitrary values with existing tracking tokens
- lower the arbitrary-value ratchet baseline from 3126 to 3120

## Verification
- `node -e "...count arbitrary values..."` → `3120`
- `pnpm biome check --write apps/web/components/features/home/ArtistProfileModesShowcase.tsx apps/web/components/marketing/MarketingStoryPrimitives.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/features/home/ArtistProfileModesShowcase.tsx apps/web/components/marketing/MarketingStoryPrimitives.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`
