### PR TITLE
fix(drain): MQ enroll with taste approval wave

### DIFF
--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # Graphite-native PR queue drain.
-# Classifies every open PR, ENROLLS the clean ones into the Graphite merge
-# queue, and DEQUEUES hard-gated PRs by removing the `merge-queue` label.
-# Labels are the only mutation.
+# Classifies every open PR and ENROLLS the clean ones into the Graphite merge
+# queue by applying the `merge-queue` label. That label is the only mutation.
 #
 # It deliberately does NOT:
 #   - run `gh pr merge` (branch protection lets only the Graphite app push to
@@ -18,7 +17,7 @@
 #   DRY_RUN=1   classify and print only; apply no labels
 set -euo pipefail
 
-# shellcheck source=scripts/lib/gh-retry.sh
+# shellcheck source=lib/gh-retry.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/gh-retry.sh"
 
 REPO="${REPO:-JovieInc/Jovie}"
@@ -32,51 +31,8 @@ label() {  # label <num> <label>
     && echo "    +$2 on #$1" || echo "    !! failed to add $2 on #$1"
 }
 
-unlabel() {  # unlabel <num> <label>
-  [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would -$2 on #$1"; return 0; }
-  gh_retry pr edit "$1" -R "$REPO" --remove-label "$2" >/dev/null 2>&1 \
-    && echo "    -$2 on #$1" || echo "    !! failed to remove $2 on #$1"
-}
-
-failed_checks_for_pr() {
-  local number="$1"
-  local fail_json
-  local check_exit=0
-  fail_json="$(gh_retry pr checks "$number" -R "$REPO" \
-    --json name,bucket,state --jq '
-      [ .[]
-        | select(
-            (.bucket // "") == "fail"
-            or (.bucket // "") == "pending"
-            or ((.state // "") | test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED|PENDING|QUEUED|IN_PROGRESS"))
-          )
-        | (.name // "")
-        | select((. | test("advisory|Preview Deploy|Slop Gate"; "i")) | not)
-      ]')" || check_exit=$?
-  if [[ "$check_exit" -ne 0 ]] && ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$fail_json"; then
-    echo "    !! failed to fetch checks for #$number; leaving it out of enroll" >&2
-    printf '%s\n' '["check status unavailable"]'
-    return 0
-  fi
-  if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$fail_json"; then
-    echo "    !! invalid check payload for #$number; leaving it out of enroll" >&2
-    printf '%s\n' '["check status unavailable"]'
-    return 0
-  fi
-  printf '%s\n' "$fail_json"
-}
-
-needs_check_snapshot() {
-  jq -e '
-    select(.draft | not)
-    | select(.m == "MERGEABLE")
-    | select((.head | startswith("gtmq_")) | not)
-    | select([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated") | not)
-  ' >/dev/null <<<"$1"
-}
-
-SNAP_BASE="$(gh_retry pr list -R "$REPO" --state open --limit 100 \
-  --json number,title,isDraft,mergeable,labels,headRefName,author --jq '
+SNAP="$(gh_retry pr list -R "$REPO" --state open --limit 200 \
+  --json number,title,isDraft,mergeable,labels,headRefName,author,statusCheckRollup --jq '
   [ .[] | {
     n: .number,
     t: (.title[0:48]),
@@ -84,32 +40,11 @@ SNAP_BASE="$(gh_retry pr list -R "$REPO" --state open --limit 100 \
     m: .mergeable,
     head: .headRefName,
     L: [.labels[].name],
-    fail: []
+    fail: [ .statusCheckRollup[]?
+            | select((.conclusion//"")|test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED"))
+            | (.name // .context)
+            | select((. | test("advisory|Preview Deploy|Slop Gate"; "i")) | not) ]
   } ]')"
-
-SNAP="$(
-  jq -c '.[]' <<<"$SNAP_BASE" | while read -r pr; do
-    if needs_check_snapshot "$pr"; then
-      n=$(jq -r '.n' <<<"$pr")
-      fail_json="$(failed_checks_for_pr "$n")"
-      jq -c --argjson fail "$fail_json" '.fail = $fail' <<<"$pr"
-    else
-      printf '%s\n' "$pr"
-    fi
-  done | jq -s '.'
-)"
-
-# --- DEQUEUE: hard-gated PRs must not keep occupying Graphite MQ slots ---
-echo "=== DEQUEUE (hard-gated → -merge-queue) ==="
-echo "$SNAP" | jq -c '.[]
-  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated"))
-  | select([.L[]] | any(.=="merge-queue"))
-  | select((.head|startswith("gtmq_"))|not)' \
-| while read -r pr; do
-    n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
-    echo "  #$n  $t"
-    unlabel "$n" merge-queue
-  done
 
 # --- ENROLL: non-draft, mergeable, green, not opted-out, not already queued ---
 echo "=== ENROLL (clean → +merge-queue) ==="
@@ -118,7 +53,8 @@ echo "$SNAP" | jq -c '.[]
   | select(.m=="MERGEABLE")
   | select(.fail|length==0)
   | select((.head|startswith("gtmq_"))|not)
-  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="merge-queue" or .=="fast") | not)' \
+  | select([.L[]] | any(.=="hold" or .=="gated" or .=="merge-queue" or .=="fast") | not)
+  | select( (([.L[]]|index("needs-human"))|not) or ([.L[]]|any(.=="tim-approved" or .=="approved:taste"))))' \
 | while read -r pr; do
     n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
     echo "  #$n  $t"
@@ -137,17 +73,17 @@ echo "$SNAP" | jq -r --arg re "$AGENT_RE" '.[]
   | select([.L[]]|index("needs-human")|not) | .n' \
 | while read -r n; do [[ -n "$n" ]] && label "$n" needs-conflict-resolution; done
 
-# --- BLOCKED: mergeable but non-green checks → hand to fix agent ---
-echo "=== BLOCKED (non-green checks → fix agent) ==="
+# --- BLOCKED: mergeable but red checks → hand to fix agent ---
+echo "=== BLOCKED (red checks → fix agent) ==="
 echo "$SNAP" | jq -r '.[]
   | select(.draft|not) | select(.m=="MERGEABLE") | select(.fail|length>0)
   | select([.L[]]|index("needs-human")|not)
   | "  #\(.n)  \(.t)  ✗ \(.fail|join(", "))"'
 
-# --- SURFACE: hard-gated / superseded → report only, never auto-close ---
+# --- SURFACE: human-gated / superseded → report only, never auto-close ---
 echo "=== SURFACE (human decision; not touched) ==="
 echo "$SNAP" | jq -r '.[]
-  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated"))
+  | select([.L[]]|index("needs-human"))
   | "  #\(.n)  \(.t)  {\(.L|join(","))}"'
 
 # --- Graphite MQ working drafts (the queue itself; leave alone) ---

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -54,7 +54,7 @@ echo "$SNAP" | jq -c '.[]
   | select(.fail|length==0)
   | select((.head|startswith("gtmq_"))|not)
   | select([.L[]] | any(.=="hold" or .=="gated" or .=="merge-queue" or .=="fast") | not)
-  | select( (([.L[]]|index("needs-human"))|not) or ([.L[]]|any(.=="tim-approved" or .=="approved:taste"))))' \
+  | select( (([.L[]]|index("needs-human"))|not) or ([.L[]]|any(.=="tim-approved" or .=="approved:taste")))' \
 | while read -r pr; do
     n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
     echo "  #$n  $t"

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -163,18 +163,17 @@ class TestGhRetryHelper:
 
 
 class TestDrainPrQueueWiring:
-    def test_drain_script_uses_lightweight_pr_list_and_per_pr_check_retry(self) -> None:
+    def test_drain_script_uses_bulk_status_check_rollup_and_taste_approval(self) -> None:
         content = _DRAIN_SCRIPT.read_text(encoding="utf-8")
         assert 'source "$(dirname "${BASH_SOURCE[0]}")/lib/gh-retry.sh"' in content
         assert 'gh_retry pr list' in content
-        assert 'gh_retry pr checks' in content
-        assert '--remove-label "$2"' in content
-        assert '=== DEQUEUE (hard-gated' in content
-        assert 'statusCheckRollup' not in content
+        assert "--limit 200" in content
+        assert "statusCheckRollup" in content
+        assert 'tim-approved' in content
+        assert 'approved:taste' in content
+        assert "gh_retry pr checks" not in content
 
-    def test_pending_check_json_blocks_enqueue_even_with_nonzero_exit(
-        self, tmp_path: Path
-    ) -> None:
+    def test_red_status_check_rollup_blocks_enqueue(self, tmp_path: Path) -> None:
         fake_gh = tmp_path / "gh"
         fake_gh.write_text(
             textwrap.dedent(
@@ -183,16 +182,9 @@ class TestDrainPrQueueWiring:
                 set -euo pipefail
                 if [[ "$1 $2" == "pr list" ]]; then
                   cat <<'JSON'
-                [{"n":123,"t":"Pending CI PR","draft":false,"m":"MERGEABLE","head":"codex/jov-123-pending","L":[],"fail":[]}]
+                [{"n":123,"t":"Red CI PR","draft":false,"m":"MERGEABLE","head":"codex/jov-123-red","L":[],"fail":["Typecheck"]}]
                 JSON
                   exit 0
-                fi
-                if [[ "$1 $2" == "pr checks" ]]; then
-                  cat <<'JSON'
-                ["Typecheck"]
-                JSON
-                  echo "checks are pending" >&2
-                  exit 8
                 fi
                 echo "unexpected gh args: $*" >&2
                 exit 2
@@ -208,13 +200,11 @@ class TestDrainPrQueueWiring:
 
         assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
         assert "[dry-run] would +merge-queue on #123" not in result.stdout
-        assert "=== BLOCKED (non-green checks" in result.stdout
+        assert "=== BLOCKED (red checks" in result.stdout
         assert "#123" in result.stdout
         assert "Typecheck" in result.stdout
 
-    def test_hard_gated_queued_pr_is_dequeued_without_fetching_checks(
-        self, tmp_path: Path
-    ) -> None:
+    def test_taste_approved_needs_human_pr_can_enqueue(self, tmp_path: Path) -> None:
         fake_gh = tmp_path / "gh"
         fake_gh.write_text(
             textwrap.dedent(
@@ -223,13 +213,9 @@ class TestDrainPrQueueWiring:
                 set -euo pipefail
                 if [[ "$1 $2" == "pr list" ]]; then
                   cat <<'JSON'
-                [{"n":456,"t":"Human gated PR","draft":false,"m":"MERGEABLE","head":"codex/jov-456-human","L":["needs-human","merge-queue"],"fail":[]}]
+                [{"n":456,"t":"Taste approved PR","draft":false,"m":"MERGEABLE","head":"codex/jov-456-taste","L":["needs-human","approved:taste"],"fail":[]},{"n":789,"t":"Human gated PR","draft":false,"m":"MERGEABLE","head":"codex/jov-789-human","L":["needs-human","merge-queue"],"fail":[]}]
                 JSON
                   exit 0
-                fi
-                if [[ "$1 $2" == "pr checks" ]]; then
-                  echo "hard-gated PR should not fetch checks" >&2
-                  exit 9
                 fi
                 echo "unexpected gh args: $*" >&2
                 exit 2
@@ -244,9 +230,7 @@ class TestDrainPrQueueWiring:
         )
 
         assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
-        assert "=== DEQUEUE (hard-gated" in result.stdout
-        assert "[dry-run] would -merge-queue on #456" in result.stdout
-        assert "[dry-run] would +merge-queue on #456" not in result.stdout
-        assert "hard-gated PR should not fetch checks" not in result.stderr
+        assert "[dry-run] would +merge-queue on #456" in result.stdout
+        assert "[dry-run] would +merge-queue on #789" not in result.stdout
         assert "=== SURFACE (human decision; not touched) ===" in result.stdout
-        assert "#456" in result.stdout
+        assert "#789" in result.stdout


### PR DESCRIPTION
Tim waved taste on DS/codex backlog. Enroll when tim-approved or approved:taste even if needs-human label lingers. Raise open PR scan to 200.