### PR TITLE
fix(ci): avoid merge queue drain graphql timeouts

### DIFF
--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Graphite-native PR queue drain.
 # Classifies every open PR and ENROLLS the clean ones into the Graphite merge
-# queue by applying the `merge-queue` label. That label is the only mutation.
+# queue by applying the `merge-queue` label. It also removes that label from
+# hard-gated PRs so they stop occupying queue slots.
 #
 # It deliberately does NOT:
 #   - run `gh pr merge` (branch protection lets only the Graphite app push to
@@ -17,7 +18,7 @@
 #   DRY_RUN=1   classify and print only; apply no labels
 set -euo pipefail
 
-# shellcheck source=lib/gh-retry.sh
+# shellcheck source=./scripts/lib/gh-retry.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/gh-retry.sh"
 
 REPO="${REPO:-JovieInc/Jovie}"
@@ -31,8 +32,69 @@ label() {  # label <num> <label>
     && echo "    +$2 on #$1" || echo "    !! failed to add $2 on #$1"
 }
 
+unlabel() {  # unlabel <num> <label>
+  [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would -$2 on #$1"; return 0; }
+  gh_retry pr edit "$1" -R "$REPO" --remove-label "$2" >/dev/null 2>&1 \
+    && echo "    -$2 on #$1" || echo "    !! failed to remove $2 on #$1"
+}
+
+check_failures_for_pr() {  # check_failures_for_pr <num>
+  local n="$1"
+  local attempts="${GH_RETRY_ATTEMPTS:-5}"
+  local base_delay="${GH_RETRY_BASE_DELAY:-2}"
+  local max_delay="${GH_RETRY_MAX_DELAY:-30}"
+  local attempt=1
+  local out_file err_file err delay
+  out_file="$(mktemp)"
+  err_file="$(mktemp)"
+
+  local jq_filter='[
+    .[]
+    | select(
+        ((.bucket // "") | test("fail|pending|cancel"; "i"))
+        or ((.state // "") | test("FAIL|ERROR|CANCEL|TIMED_OUT|ACTION_REQUIRED|PENDING|QUEUED|IN_PROGRESS|WAITING"; "i"))
+      )
+    | select(((.name // "") | test("advisory|Preview Deploy|Slop Gate"; "i")) | not)
+    | (.name // .workflow // .description // "unnamed check")
+  ]'
+
+  while [[ "$attempt" -le "$attempts" ]]; do
+    : >"$out_file"
+    : >"$err_file"
+    if gh pr checks "$n" -R "$REPO" --required --json name,bucket,state,workflow,description --jq "$jq_filter" >"$out_file" 2>"$err_file"; then
+      if jq -e 'type == "array"' "$out_file" >/dev/null 2>&1; then
+        cat "$out_file"
+        rm -f "$out_file" "$err_file"
+        return 0
+      fi
+    elif jq -e 'type == "array"' "$out_file" >/dev/null 2>&1; then
+      # `gh pr checks` exits 8 when checks are pending, even with valid JSON.
+      cat "$out_file"
+      rm -f "$out_file" "$err_file"
+      return 0
+    fi
+
+    err="$(<"$err_file")"
+    if [[ "$attempt" -eq "$attempts" ]] || ! gh_retry_is_transient_error "$err"; then
+      [[ -n "$err" ]] && echo "  !! could not read required checks for #$n: $err" >&2
+      jq -cn --arg reason "required check status unavailable" '[$reason]'
+      rm -f "$out_file" "$err_file"
+      return 0
+    fi
+
+    delay=$((base_delay * (2 ** (attempt - 1))))
+    [[ "$delay" -gt "$max_delay" ]] && delay="$max_delay"
+    echo "  [gh-retry] pr checks #$n attempt $attempt/$attempts failed (transient); retrying in ${delay}s…" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+
+  rm -f "$out_file" "$err_file"
+  jq -cn --arg reason "required check status unavailable" '[$reason]'
+}
+
 SNAP="$(gh_retry pr list -R "$REPO" --state open --limit 200 \
-  --json number,title,isDraft,mergeable,labels,headRefName,author,statusCheckRollup --jq '
+  --json number,title,isDraft,mergeable,labels,headRefName --jq '
   [ .[] | {
     n: .number,
     t: (.title[0:48]),
@@ -40,11 +102,35 @@ SNAP="$(gh_retry pr list -R "$REPO" --state open --limit 200 \
     m: .mergeable,
     head: .headRefName,
     L: [.labels[].name],
-    fail: [ .statusCheckRollup[]?
-            | select((.conclusion//"")|test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED"))
-            | (.name // .context)
-            | select((. | test("advisory|Preview Deploy|Slop Gate"; "i")) | not) ]
+    fail: []
   } ]')"
+
+ENRICHED="[]"
+while IFS= read -r pr; do
+  n="$(jq -r '.n' <<<"$pr")"
+  fail="[]"
+  if jq -e '
+    (.draft | not)
+    and (.m == "MERGEABLE")
+    and ((.head | startswith("gtmq_")) | not)
+    and (([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated" or . == "merge-queue" or . == "fast")) | not)
+  ' <<<"$pr" >/dev/null; then
+    fail="$(check_failures_for_pr "$n")"
+  fi
+  ENRICHED="$(jq -c --argjson pr "$pr" --argjson fail "$fail" '. + [$pr + {fail: $fail}]' <<<"$ENRICHED")"
+done < <(jq -c '.[]' <<<"$SNAP")
+SNAP="$ENRICHED"
+
+# --- DEQUEUE: hard-gated PRs must not occupy Graphite queue slots ---
+echo "=== DEQUEUE (hard gates → -merge-queue) ==="
+echo "$SNAP" | jq -c '.[]
+  | select([.L[]] | index("merge-queue"))
+  | select([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated"))' \
+| while read -r pr; do
+    n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
+    echo "  #$n  $t"
+    unlabel "$n" merge-queue
+  done
 
 # --- ENROLL: non-draft, mergeable, green, not opted-out, not already queued ---
 echo "=== ENROLL (clean → +merge-queue) ==="
@@ -53,8 +139,7 @@ echo "$SNAP" | jq -c '.[]
   | select(.m=="MERGEABLE")
   | select(.fail|length==0)
   | select((.head|startswith("gtmq_"))|not)
-  | select([.L[]] | any(.=="hold" or .=="gated" or .=="merge-queue" or .=="fast") | not)
-  | select( (([.L[]]|index("needs-human"))|not) or ([.L[]]|any(.=="tim-approved" or .=="approved:taste")))' \
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="merge-queue" or .=="fast") | not)' \
 | while read -r pr; do
     n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
     echo "  #$n  $t"
@@ -66,24 +151,24 @@ echo "=== CONFLICT (needs rebase → fix agent) ==="
 echo "$SNAP" | jq -r --arg re "$AGENT_RE" '.[]
   | select(.m=="CONFLICTING")
   | select(.head|test($re))
-  | select([.L[]]|index("needs-human")|not)
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated") | not)
   | "  #\(.n)  \(.t)  [\(.head)]"'
 echo "$SNAP" | jq -r --arg re "$AGENT_RE" '.[]
   | select(.m=="CONFLICTING") | select(.head|test($re))
-  | select([.L[]]|index("needs-human")|not) | .n' \
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated") | not) | .n' \
 | while read -r n; do [[ -n "$n" ]] && label "$n" needs-conflict-resolution; done
 
 # --- BLOCKED: mergeable but red checks → hand to fix agent ---
 echo "=== BLOCKED (red checks → fix agent) ==="
 echo "$SNAP" | jq -r '.[]
   | select(.draft|not) | select(.m=="MERGEABLE") | select(.fail|length>0)
-  | select([.L[]]|index("needs-human")|not)
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated") | not)
   | "  #\(.n)  \(.t)  ✗ \(.fail|join(", "))"'
 
 # --- SURFACE: human-gated / superseded → report only, never auto-close ---
 echo "=== SURFACE (human decision; not touched) ==="
 echo "$SNAP" | jq -r '.[]
-  | select([.L[]]|index("needs-human"))
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated"))
   | "  #\(.n)  \(.t)  {\(.L|join(","))}"'
 
 # --- Graphite MQ working drafts (the queue itself; leave alone) ---

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -163,17 +163,19 @@ class TestGhRetryHelper:
 
 
 class TestDrainPrQueueWiring:
-    def test_drain_script_uses_bulk_status_check_rollup_and_taste_approval(self) -> None:
+    def test_drain_script_avoids_bulk_status_rollup_and_uses_per_pr_checks(self) -> None:
         content = _DRAIN_SCRIPT.read_text(encoding="utf-8")
         assert 'source "$(dirname "${BASH_SOURCE[0]}")/lib/gh-retry.sh"' in content
         assert 'gh_retry pr list' in content
         assert "--limit 200" in content
-        assert "statusCheckRollup" in content
-        assert 'tim-approved' in content
-        assert 'approved:taste' in content
-        assert "gh_retry pr checks" not in content
+        assert "statusCheckRollup" not in content
+        assert "gh pr checks" in content
+        assert "--required" in content
+        assert "--remove-label" in content
+        assert "tim-approved" not in content
+        assert "approved:taste" not in content
 
-    def test_red_status_check_rollup_blocks_enqueue(self, tmp_path: Path) -> None:
+    def test_red_required_checks_block_enqueue(self, tmp_path: Path) -> None:
         fake_gh = tmp_path / "gh"
         fake_gh.write_text(
             textwrap.dedent(
@@ -182,9 +184,13 @@ class TestDrainPrQueueWiring:
                 set -euo pipefail
                 if [[ "$1 $2" == "pr list" ]]; then
                   cat <<'JSON'
-                [{"n":123,"t":"Red CI PR","draft":false,"m":"MERGEABLE","head":"codex/jov-123-red","L":[],"fail":["Typecheck"]}]
-                JSON
+                [{"n":123,"t":"Red CI PR","draft":false,"m":"MERGEABLE","head":"codex/jov-123-red","L":[],"fail":[]}]
+JSON
                   exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  echo '["Typecheck"]'
+                  exit 1
                 fi
                 echo "unexpected gh args: $*" >&2
                 exit 2
@@ -204,7 +210,7 @@ class TestDrainPrQueueWiring:
         assert "#123" in result.stdout
         assert "Typecheck" in result.stdout
 
-    def test_taste_approved_needs_human_pr_can_enqueue(self, tmp_path: Path) -> None:
+    def test_hard_gated_prs_dequeue_and_do_not_enqueue(self, tmp_path: Path) -> None:
         fake_gh = tmp_path / "gh"
         fake_gh.write_text(
             textwrap.dedent(
@@ -213,8 +219,13 @@ class TestDrainPrQueueWiring:
                 set -euo pipefail
                 if [[ "$1 $2" == "pr list" ]]; then
                   cat <<'JSON'
-                [{"n":456,"t":"Taste approved PR","draft":false,"m":"MERGEABLE","head":"codex/jov-456-taste","L":["needs-human","approved:taste"],"fail":[]},{"n":789,"t":"Human gated PR","draft":false,"m":"MERGEABLE","head":"codex/jov-789-human","L":["needs-human","merge-queue"],"fail":[]}]
-                JSON
+                [{"n":456,"t":"Taste approved PR","draft":false,"m":"MERGEABLE","head":"codex/jov-456-taste","L":["needs-human","approved:taste"],"fail":[]},{"n":789,"t":"Human gated PR","draft":false,"m":"MERGEABLE","head":"codex/jov-789-human","L":["needs-human","merge-queue"],"fail":[]},{"n":101,"t":"Clean PR","draft":false,"m":"MERGEABLE","head":"codex/jov-101-clean","L":[],"fail":[]}]
+JSON
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  [[ "$3" == "101" ]]
+                  echo '[]'
                   exit 0
                 fi
                 echo "unexpected gh args: $*" >&2
@@ -230,7 +241,87 @@ class TestDrainPrQueueWiring:
         )
 
         assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
-        assert "[dry-run] would +merge-queue on #456" in result.stdout
+        assert "=== DEQUEUE (hard gates" in result.stdout
+        assert "[dry-run] would -merge-queue on #789" in result.stdout
+        assert "[dry-run] would +merge-queue on #101" in result.stdout
+        assert "[dry-run] would +merge-queue on #456" not in result.stdout
         assert "[dry-run] would +merge-queue on #789" not in result.stdout
         assert "=== SURFACE (human decision; not touched) ===" in result.stdout
+        assert "#456" in result.stdout
         assert "#789" in result.stdout
+
+    def test_nonzero_checks_with_valid_json_do_not_abort_drain(self, tmp_path: Path) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{"n":321,"t":"Clean nonzero checks","draft":false,"m":"MERGEABLE","head":"codex/jov-321-clean","L":[],"fail":[]}]
+JSON
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  echo '[]'
+                  exit 8
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=1 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "[dry-run] would +merge-queue on #321" in result.stdout
+
+    def test_required_check_lookup_retries_transient_failures(self, tmp_path: Path) -> None:
+        counter = tmp_path / "checks"
+        counter.write_text("0", encoding="utf-8")
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{"n":654,"t":"Retry checks PR","draft":false,"m":"MERGEABLE","head":"codex/jov-654-retry","L":[],"fail":[]}]
+JSON
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  count_file="${GH_RETRY_TEST_COUNTER:?}"
+                  count=$(<"$count_file")
+                  count=$((count + 1))
+                  echo "$count" >"$count_file"
+                  if [[ "$count" -lt 2 ]]; then
+                    echo "HTTP 504: We couldn't respond to your request in time." >&2
+                    exit 1
+                  fi
+                  echo '[]'
+                  exit 0
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" GH_RETRY_BASE_DELAY=0 GH_RETRY_TEST_COUNTER="{counter}" DRY_RUN=1 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "[dry-run] would +merge-queue on #654" in result.stdout
+        assert "gh-retry" in result.stderr
+        assert counter.read_text(encoding="utf-8").strip() == "2"


### PR DESCRIPTION
## Summary
- replaced the timeout-prone bulk `statusCheckRollup` PR list query in `scripts/drain-pr-queue.sh` with lightweight PR metadata plus required-check lookup only for enqueue candidates
- fail closed when required check status is unavailable, pending, red, cancelled, or transiently unreadable after retries
- remove `merge-queue` from hard-gated PRs (`needs-human`, `hold`, `gated`) so Graphite slots are not occupied by PRs automation cannot land
- updated drain regression tests to prevent the bulk status rollup and taste-approved hard-gate behavior from returning

## Root cause
The scheduled Merge Queue Auto-Enroll workflow was failing before it could classify PRs because `gh pr list --json ... statusCheckRollup` requested status rollups for up to 200 open PRs in one GraphQL call. Recent runs failed with GitHub GraphQL HTTP 504s, leaving clean/hard-gated PR labels stale and Graphite without fresh queue movement.

## Verification
- `bash -n scripts/lib/gh-retry.sh scripts/drain-pr-queue.sh`
- `python3 -m pytest scripts/tests/test_gh_retry.py -v` (9 passed)
- `shellcheck -x scripts/lib/gh-retry.sh scripts/drain-pr-queue.sh`
- `DRY_RUN=1 GH_RETRY_BASE_DELAY=0 bash scripts/drain-pr-queue.sh`
- `GH_RETRY_BASE_DELAY=0 bash scripts/drain-pr-queue.sh`
- pre-push hook: `biome check .`, web proxy guard, Tailwind guard, web typecheck, web lint

## Live queue action
- Removed `merge-queue` from hard-gated `#11634`.
- Verified no open PR currently has `merge-queue` plus `needs-human`, `hold`, or `gated`.
- Labeled conflict PRs with `needs-conflict-resolution`; did not touch Graphite `gtmq_*` PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PR merge queue classification with more robust on-demand status checking per PR instead of bulk data lookups.
  * Improved resilience to transient failures with retry and backoff handling.
  * Better management of PRs on hold or gated for review before merging.

* **Tests**
  * Updated merge-queue tests to reflect new per-PR status verification approach and label-based gating logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->