### PR TITLE
ci: improve Graphite queue throughput

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,20 @@ jobs:
     outputs:
       skip: ${{ steps.graphite.outputs.skip || 'false' }}
     steps:
+      - id: graphite-token
+        name: Check Graphite token configuration
+        env:
+          GRAPHITE_TOKEN: ${{ secrets.GRAPHITE_TOKEN }}
+        run: |
+          if [ -z "${GRAPHITE_TOKEN:-}" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::GRAPHITE_TOKEN is not configured; Graphite CI Optimizations will not scan PRs."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - id: graphite
+        if: steps.graphite-token.outputs.configured == 'true'
         continue-on-error: true
         uses: withgraphite/graphite-ci-action@main
         with:
@@ -1373,6 +1386,10 @@ jobs:
     if: ${{ needs.optimize_ci.outputs.skip == 'false' && (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-build-public.outputs.has_artifact == 'true' && needs.ci-path-changes.outputs.run_public_lighthouse == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup-node-pnpm
@@ -1438,7 +1455,20 @@ jobs:
           DATABASE_URL: ${{ env.DATABASE_URL }}
           NODE_ENV: test
 
-      - name: Build app for public Lighthouse
+      - name: Download build artifact
+        id: download-build
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextjs-build-${{ github.run_id }}
+          path: /tmp/nextjs-build-download
+
+      - name: Extract build artifact
+        if: steps.download-build.outcome == 'success'
+        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+
+      - name: Build app fallback for public Lighthouse
+        if: steps.download-build.outcome != 'success'
         run: pnpm --filter=@jovie/web run build
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
@@ -1484,12 +1514,16 @@ jobs:
 
           pnpm run test:lighthouse:public:launch
 
-          mkdir -p tests/.auth
-          echo '{"cookies":[],"origins":[]}' > tests/.auth/user.json
-          pnpm exec playwright test tests/e2e/profile-mobile-viewport-stability.spec.ts --config=playwright.config.noauth.ts --project=chromium --reporter=line
+          if [ "${{ matrix.shard }}" = "0" ]; then
+            mkdir -p tests/.auth
+            echo '{"cookies":[],"origins":[]}' > tests/.auth/user.json
+            pnpm exec playwright test tests/e2e/profile-mobile-viewport-stability.spec.ts --config=playwright.config.noauth.ts --project=chromium --reporter=line
+          fi
         env:
           CI: true
           BASE_URL: http://127.0.0.1:3000
+          PUBLIC_LIGHTHOUSE_SHARD_INDEX: ${{ matrix.shard }}
+          PUBLIC_LIGHTHOUSE_TOTAL_SHARDS: '2'
           PROFILE_MOBILE_PERF_BUDGETS: '1'
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
@@ -1500,7 +1534,7 @@ jobs:
 
   ci-lighthouse-dashboard-pr:
     name: Lighthouse (dashboard PR)
-    needs: [optimize_ci, ci-fast, ci-path-changes, neon-db]
+    needs: [optimize_ci, ci-fast, ci-path-changes, neon-db, ci-build-public]
     if: ${{ needs.optimize_ci.outputs.skip == 'false' && (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'testing')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1576,8 +1610,21 @@ jobs:
           GIT_BRANCH: pr-${{ github.event.pull_request.number }}
           ALLOW_PROD_MIGRATIONS: 'true'
 
-      - name: Build app for dashboard Lighthouse
+      - name: Download build artifact
         if: steps.check_changes.outputs.run_full_ci == 'true'
+        id: download-build
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextjs-build-${{ github.run_id }}
+          path: /tmp/nextjs-build-download
+
+      - name: Extract build artifact
+        if: steps.check_changes.outputs.run_full_ci == 'true' && steps.download-build.outcome == 'success'
+        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+
+      - name: Build app fallback for dashboard Lighthouse
+        if: steps.check_changes.outputs.run_full_ci == 'true' && steps.download-build.outcome != 'success'
         run: pnpm --filter=@jovie/web run build
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
@@ -1658,7 +1705,7 @@ jobs:
 
   ci-lighthouse-onboarding-pr:
     name: Lighthouse (onboarding PR)
-    needs: [optimize_ci, ci-fast, ci-path-changes, neon-db]
+    needs: [optimize_ci, ci-fast, ci-path-changes, neon-db, ci-build-public]
     if: ${{ needs.optimize_ci.outputs.skip == 'false' && (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_onboarding_lighthouse == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1722,7 +1769,20 @@ jobs:
           GIT_BRANCH: pr-${{ github.event.pull_request.number }}
           ALLOW_PROD_MIGRATIONS: 'true'
 
-      - name: Build app for onboarding Lighthouse
+      - name: Download build artifact
+        id: download-build
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextjs-build-${{ github.run_id }}
+          path: /tmp/nextjs-build-download
+
+      - name: Extract build artifact
+        if: steps.download-build.outcome == 'success'
+        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+
+      - name: Build app fallback for onboarding Lighthouse
+        if: steps.download-build.outcome != 'success'
         run: pnpm --filter=@jovie/web run build
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
@@ -1805,7 +1865,7 @@ jobs:
     # Do NOT depend on neon-db — it only runs on push / testing-labeled / drizzle PRs,
     # so dependent jobs would silently skip on admin-UI-only PRs. This job creates
     # its own ephemeral branch below and does not reuse the shared neon-db branch.
-    needs: [optimize_ci, ci-fast, ci-path-changes]
+    needs: [optimize_ci, ci-fast, ci-path-changes, ci-build-public]
     if: ${{ needs.optimize_ci.outputs.skip == 'false' && (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_admin_lighthouse == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1857,7 +1917,20 @@ jobs:
           GIT_BRANCH: pr-${{ github.event.pull_request.number }}
           ALLOW_PROD_MIGRATIONS: 'true'
 
-      - name: Build app for admin Lighthouse
+      - name: Download build artifact
+        id: download-build
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextjs-build-${{ github.run_id }}
+          path: /tmp/nextjs-build-download
+
+      - name: Extract build artifact
+        if: steps.download-build.outcome == 'success'
+        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+
+      - name: Build app fallback for admin Lighthouse
+        if: steps.download-build.outcome != 'success'
         run: pnpm --filter=@jovie/web run build
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
@@ -1940,7 +2013,7 @@ jobs:
     # Informational baseline run — first PR establishes the budget; once
     # baselines stabilize this can be promoted to a hard gate by removing
     # `continue-on-error` and adding the job to ci-pr-ready.needs.
-    needs: [optimize_ci, ci-fast, ci-path-changes, neon-db]
+    needs: [optimize_ci, ci-fast, ci-path-changes, neon-db, ci-build-public]
     if: ${{ needs.optimize_ci.outputs.skip == 'false' && (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_chat_lighthouse == 'true') }}
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -1993,7 +2066,20 @@ jobs:
           GIT_BRANCH: pr-${{ github.event.pull_request.number }}
           ALLOW_PROD_MIGRATIONS: 'true'
 
-      - name: Build app for chat Lighthouse
+      - name: Download build artifact
+        id: download-build
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextjs-build-${{ github.run_id }}
+          path: /tmp/nextjs-build-download
+
+      - name: Extract build artifact
+        if: steps.download-build.outcome == 'success'
+        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+
+      - name: Build app fallback for chat Lighthouse
+        if: steps.download-build.outcome != 'success'
         run: pnpm --filter=@jovie/web run build
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
@@ -2542,7 +2628,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ['1/3', '2/3', '3/3']
+        shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
     outputs:
       run_full_ci: ${{ steps.check_changes.outputs.run_full_ci }}
     steps:
@@ -2583,7 +2669,7 @@ jobs:
           VITEST_CI_FLAGS="--pool=forks --maxWorkers=2"
           # Retry budget comes from apps/web/tests/quarantine.json
           RETRY_FLAG="--retry=${{ steps.quarantine.outputs.unit_default_retries }}"
-          # Use shard-specific output file so Codecov Test Analytics receives all 3 shards
+          # Use shard-specific output file so Codecov Test Analytics receives all 6 shards
           # (a shared filename causes only the last upload to be recorded)
           # Note: vitest runs from apps/web/, so path is relative to that directory
           SHARD_SLUG="${{ matrix.shard }}"
@@ -3442,7 +3528,7 @@ jobs:
     # Preview deploys are the default QA surface for internal PRs.
     # Keep this independent from the main deploy gate so review happens before merge.
     needs: [optimize_ci, ci-fast, ci-path-changes, ci-risk-classifier]
-    if: ${{ needs.optimize_ci.outputs.skip == 'false' && (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && (needs.ci-path-changes.outputs.run_build == 'true' || needs.ci-risk-classifier.outputs.requires_preview == 'true')) }}
+    if: ${{ needs.optimize_ci.outputs.skip == 'false' && (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && (needs.ci-risk-classifier.outputs.requires_preview == 'true' || contains(github.event.pull_request.labels.*.name, 'testing') || contains(github.event.pull_request.labels.*.name, 'deploy-preview'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:

--- a/apps/web/scripts/run-public-lighthouse.ts
+++ b/apps/web/scripts/run-public-lighthouse.ts
@@ -4,6 +4,26 @@ import { getLighthousePublicSurfaceManifest } from '@/tests/e2e/utils/public-sur
 
 const BASE_URL = process.env.BASE_URL?.trim();
 
+function parsePositiveInteger(value: string | undefined, fallback: number) {
+  if (!value?.trim()) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`Expected a positive integer, got "${value}"`);
+  }
+  return parsed;
+}
+
+function parseShardIndex(value: string | undefined, totalShards: number) {
+  if (!value?.trim()) return 0;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed >= totalShards) {
+    throw new Error(
+      `PUBLIC_LIGHTHOUSE_SHARD_INDEX must be between 0 and ${totalShards - 1}; got "${value}"`
+    );
+  }
+  return parsed;
+}
+
 function getValidatedBaseUrl(): string {
   if (!BASE_URL) {
     throw new Error('BASE_URL is required for public Lighthouse runs');
@@ -41,13 +61,34 @@ async function main() {
   const urls = surfaces.map(surface =>
     new URL(surface.resolvedPath, baseUrl).toString()
   );
+  const totalShards = parsePositiveInteger(
+    process.env.PUBLIC_LIGHTHOUSE_TOTAL_SHARDS,
+    1
+  );
+  const shardIndex = parseShardIndex(
+    process.env.PUBLIC_LIGHTHOUSE_SHARD_INDEX,
+    totalShards
+  );
+  const selectedUrls = urls.filter(
+    (_, index) => index % totalShards === shardIndex
+  );
+
+  if (selectedUrls.length === 0) {
+    throw new Error(
+      `No public Lighthouse URLs selected for shard ${shardIndex}/${totalShards}`
+    );
+  }
+
+  console.log(
+    `Running public Lighthouse shard ${shardIndex + 1}/${totalShards}: ${selectedUrls.length}/${urls.length} URLs`
+  );
 
   const args = [
     'exec',
     'lhci',
     'autorun',
     '--config=.lighthouserc.public-launch.json',
-    ...urls.map(url => `--collect.url=${url}`),
+    ...selectedUrls.map(url => `--collect.url=${url}`),
   ];
 
   await runCommand('pnpm', args, process.env);

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -2,7 +2,7 @@
 # Graphite-native PR queue drain.
 # Classifies every open PR and ENROLLS the clean ones into the Graphite merge
 # queue by applying the `merge-queue` label. It also removes that label from
-# hard-gated PRs so they stop occupying queue slots.
+# PRs that cannot currently merge so they stop occupying queue slots.
 #
 # It deliberately does NOT:
 #   - run `gh pr merge` (branch protection lets only the Graphite app push to
@@ -94,12 +94,13 @@ check_failures_for_pr() {  # check_failures_for_pr <num>
 }
 
 SNAP="$(gh_retry pr list -R "$REPO" --state open --limit 200 \
-  --json number,title,isDraft,mergeable,labels,headRefName --jq '
+  --json number,title,isDraft,mergeable,mergeStateStatus,labels,headRefName --jq '
   [ .[] | {
     n: .number,
     t: (.title[0:48]),
     draft: .isDraft,
     m: .mergeable,
+    ms: (.mergeStateStatus // "UNKNOWN"),
     head: .headRefName,
     L: [.labels[].name],
     fail: []
@@ -113,7 +114,7 @@ while IFS= read -r pr; do
     (.draft | not)
     and (.m == "MERGEABLE")
     and ((.head | startswith("gtmq_")) | not)
-    and (([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated" or . == "merge-queue" or . == "fast")) | not)
+    and (([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated" or . == "fast")) | not)
   ' <<<"$pr" >/dev/null; then
     fail="$(check_failures_for_pr "$n")"
   fi
@@ -121,14 +122,56 @@ while IFS= read -r pr; do
 done < <(jq -c '.[]' <<<"$SNAP")
 SNAP="$ENRICHED"
 
+# --- SUMMARY: make queue shape obvious in scheduled logs ---
+echo "=== QUEUE SUMMARY ==="
+echo "$SNAP" | jq -r '
+  def labels: (.L // []);
+  def queued: labels | index("merge-queue");
+  def hard_gated: labels | any(. == "needs-human" or . == "hold" or . == "gated");
+  [
+    "  CLEAN: " + ([.[] | select(queued and (.ms // "") == "CLEAN")] | length | tostring),
+    "  UNSTABLE: " + ([.[] | select(queued and (.ms // "") == "UNSTABLE")] | length | tostring),
+    "  BLOCKED: " + ([.[] | select(queued and (.ms // "") == "BLOCKED")] | length | tostring),
+    "  DIRTY: " + ([.[] | select(queued and (.ms // "") == "DIRTY")] | length | tostring),
+    "  hard-gated: " + ([.[] | select(hard_gated)] | length | tostring),
+    "  gtmq: " + ([.[] | select((.head // "") | startswith("gtmq_"))] | length | tostring)
+  ] | .[]'
+
 # --- DEQUEUE: hard-gated PRs must not occupy Graphite queue slots ---
 echo "=== DEQUEUE (hard gates → -merge-queue) ==="
 echo "$SNAP" | jq -c '.[]
   | select([.L[]] | index("merge-queue"))
+  | select((.head|startswith("gtmq_"))|not)
   | select([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated"))' \
 | while read -r pr; do
     n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
     echo "  #$n  $t"
+    unlabel "$n" merge-queue
+  done
+
+# --- DEQUEUE: conflicted, red, unknown, or explicitly queued-for-fix PRs ---
+echo "=== DEQUEUE (non-clean → -merge-queue) ==="
+echo "$SNAP" | jq -c '.[]
+  | select([.L[]] | index("merge-queue"))
+  | select((.head|startswith("gtmq_"))|not)
+  | select(([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated")) | not)
+  | select(
+      ([.L[]] | any(.=="needs-conflict-resolution"))
+      or ((.ms // "CLEAN") != "CLEAN")
+      or (.m != "MERGEABLE")
+      or (.fail|length>0)
+    )' \
+| while read -r pr; do
+    n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
+    reason=$(jq -r '
+      [
+        (if ([.L[]] | any(.=="needs-conflict-resolution")) then "needs-conflict-resolution" else empty end),
+        (if (.ms // "CLEAN") != "CLEAN" then "mergeStateStatus=" + (.ms // "UNKNOWN") else empty end),
+        (if .m != "MERGEABLE" then "mergeable=" + (.m // "UNKNOWN") else empty end),
+        (if (.fail|length)>0 then "checks=" + (.fail|join(",")) else empty end)
+      ] | join("; ")
+    ' <<<"$pr")
+    echo "  #$n  $t  ✗ $reason"
     unlabel "$n" merge-queue
   done
 
@@ -137,9 +180,10 @@ echo "=== ENROLL (clean → +merge-queue) ==="
 echo "$SNAP" | jq -c '.[]
   | select(.draft|not)
   | select(.m=="MERGEABLE")
+  | select((.ms // "CLEAN")=="CLEAN")
   | select(.fail|length==0)
   | select((.head|startswith("gtmq_"))|not)
-  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="merge-queue" or .=="fast") | not)' \
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="needs-conflict-resolution" or .=="merge-queue" or .=="fast") | not)' \
 | while read -r pr; do
     n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
     echo "  #$n  $t"
@@ -150,11 +194,14 @@ echo "$SNAP" | jq -c '.[]
 echo "=== CONFLICT (needs rebase → fix agent) ==="
 echo "$SNAP" | jq -r --arg re "$AGENT_RE" '.[]
   | select(.m=="CONFLICTING")
+  | select((.head|startswith("gtmq_"))|not)
   | select(.head|test($re))
   | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated") | not)
   | "  #\(.n)  \(.t)  [\(.head)]"'
 echo "$SNAP" | jq -r --arg re "$AGENT_RE" '.[]
-  | select(.m=="CONFLICTING") | select(.head|test($re))
+  | select(.m=="CONFLICTING")
+  | select((.head|startswith("gtmq_"))|not)
+  | select(.head|test($re))
   | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated") | not) | .n' \
 | while read -r n; do [[ -n "$n" ]] && label "$n" needs-conflict-resolution; done
 

--- a/scripts/loop-orchestrator.sh
+++ b/scripts/loop-orchestrator.sh
@@ -32,12 +32,6 @@ while true; do
   fi
   [[ -x "$ROOT/scripts/drain-pr-queue.sh" ]] && "$ROOT/scripts/drain-pr-queue.sh" >>"$LOG/drain.log" 2>&1 || true
   [[ -x "$ROOT/scripts/loop-train-drain.sh" ]] && "$ROOT/scripts/loop-train-drain.sh" >>"$LOG/train.log" 2>&1 || true
-  gh pr list --state open --json number,mergeStateStatus,headRefName,baseRefName \
-    --jq '.[] | select(.baseRefName=="main") | select(.mergeStateStatus=="CLEAN") | .number' 2>/dev/null \
-    | while read -r n; do
-        # Graphite enqueues by label; native auto-merge retired
-        [[ -n "$n" ]] && { gh pr edit "$n" --add-label "merge-queue" || echo "WARN: failed to enqueue #$n into Graphite merge queue" >&2; }
-      done
   log "sleep ${INTERVAL}s"
   sleep "$INTERVAL"
 done

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -325,3 +325,141 @@ JSON
         assert "[dry-run] would +merge-queue on #654" in result.stdout
         assert "gh-retry" in result.stderr
         assert counter.read_text(encoding="utf-8").strip() == "2"
+
+    def test_queued_conflict_is_dequeued_and_labeled_for_resolution(self, tmp_path: Path) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{"n":777,"t":"Queued conflict","draft":false,"m":"CONFLICTING","ms":"DIRTY","head":"codex/jov-777-conflict","L":["merge-queue"],"fail":[]}]
+JSON
+                  exit 0
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=1 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "DIRTY: 1" in result.stdout
+        assert "=== DEQUEUE (non-clean" in result.stdout
+        assert "[dry-run] would -merge-queue on #777" in result.stdout
+        assert "[dry-run] would +needs-conflict-resolution on #777" in result.stdout
+        assert "[dry-run] would +merge-queue on #777" not in result.stdout
+
+    def test_queued_red_required_checks_are_dequeued(self, tmp_path: Path) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{"n":888,"t":"Queued red CI","draft":false,"m":"MERGEABLE","ms":"BLOCKED","head":"codex/jov-888-red","L":["merge-queue"],"fail":[]}]
+JSON
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  echo '["PR Ready"]'
+                  exit 1
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=1 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "BLOCKED: 1" in result.stdout
+        assert "[dry-run] would -merge-queue on #888" in result.stdout
+        assert "checks=PR Ready" in result.stdout
+        assert "=== BLOCKED (red checks" in result.stdout
+        assert "#888" in result.stdout
+        assert "[dry-run] would +merge-queue on #888" not in result.stdout
+
+    def test_queued_unstable_state_is_dequeued_even_with_empty_required_checks(
+        self, tmp_path: Path
+    ) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{"n":889,"t":"Queued stale Graphite state","draft":false,"m":"MERGEABLE","ms":"UNSTABLE","head":"codex/jov-889-unstable","L":["merge-queue"],"fail":[]}]
+JSON
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  echo '[]'
+                  exit 0
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=1 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "UNSTABLE: 1" in result.stdout
+        assert "[dry-run] would -merge-queue on #889" in result.stdout
+        assert "mergeStateStatus=UNSTABLE" in result.stdout
+        assert "[dry-run] would +merge-queue on #889" not in result.stdout
+
+    def test_gtmq_drafts_are_report_only_even_when_labeled(self, tmp_path: Path) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{"n":999,"t":"Graphite draft","draft":false,"m":"CONFLICTING","ms":"DIRTY","head":"gtmq_spec_abc123","L":["merge-queue","needs-conflict-resolution"],"fail":[]}]
+JSON
+                  exit 0
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=1 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "gtmq: 1" in result.stdout
+        assert "=== GRAPHITE MQ in-flight (leave) ===" in result.stdout
+        assert "#999" in result.stdout
+        assert "[dry-run] would -merge-queue on #999" not in result.stdout
+        assert "[dry-run] would +needs-conflict-resolution on #999" not in result.stdout


### PR DESCRIPTION
## Summary

Unclogs Graphite queue pressure and shortens the slow CI paths identified on 2026-06-22.

- Drain queued PRs that are not truly clean: hard gates, `needs-conflict-resolution`, non-mergeable PRs, failed/unavailable required checks, or non-`CLEAN` `mergeStateStatus`.
- Keep `gtmq_*` draft PRs report-only while surfacing queue summary counts.
- Remove the raw `loop-orchestrator.sh` enqueue pass that bypassed the smarter drain rules.
- Reuse the `ci-build-public` Next.js build artifact across Lighthouse jobs and shard public Lighthouse into two route shards.
- Restore unit tests to 6 shards while Actions runner pressure is low.
- Restrict PR preview deploys to `requires_preview`, `testing`, or `deploy-preview`.
- Add a Graphite token preflight warning before `withgraphite/graphite-ci-action`.

## Root-cause notes

- Turbo remote cache is healthy: `pnpm run turbo:verify-cache` reports remote cache read verified.
- Graphite CI Optimizations are not scanning PRs because `GRAPHITE_TOKEN` is absent or invalid. Recent CI logs show `Invalid authentication. Skipping Graphite checks.`, and `gh secret list --app actions` does not include `GRAPHITE_TOKEN`.
- Active Graphite queue entries can reapply `merge-queue` labels after GitHub-side removal; stale queue entries must be cancelled/retried in the Graphite dashboard.
- Merge history check: `origin/main` first-parent had 27 commits in the last 24h, but the useful overnight PR flow was low; the PR API/search view surfaced only 8 merged PRs in the same window.

## Test plan

- [x] `pytest scripts/tests/test_gh_retry.py -v`
- [x] `DRY_RUN=1 ./scripts/drain-pr-queue.sh`
- [x] `./scripts/drain-pr-queue.sh`
- [x] `pnpm run turbo:verify-cache`
- [x] `pnpm ci:harness:check`
- [x] `actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/merge-queue-autoenroll.yml`
- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] `pnpm --filter @jovie/web run test:bug-to-test`
- [x] pre-commit hooks: gitleaks, trufflehog, proxy guard, Biome, ESLint, web typecheck
- [x] pre-push hooks: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

bug-to-test: not applicable — CI/control-plane throughput change with queue-drain regression coverage.
