### PR TITLE
fix(web): reduce support surface arbitrary drift

### DIFF
--- a/apps/web/components/atoms/CalendarInner.tsx
+++ b/apps/web/components/atoms/CalendarInner.tsx
@@ -29,7 +29,7 @@ export default function CalendarInner({
         months: 'flex flex-col gap-4',
         month: 'flex flex-col gap-3',
         month_caption:
-          'flex items-center justify-center h-8 text-app font-medium tracking-[-0.01em] text-primary-token',
+          'flex items-center justify-center h-8 text-app font-medium tracking-tight text-primary-token',
         caption_label: 'text-app font-medium',
         nav: 'flex items-center gap-1 absolute right-3 top-3',
         button_previous: cn(

--- a/apps/web/components/features/dashboard/atoms/PlatformPill.utils.ts
+++ b/apps/web/components/features/dashboard/atoms/PlatformPill.utils.ts
@@ -26,7 +26,7 @@ export interface PillClassNameParams {
  * Base classes applied to all pills
  */
 const BASE_CLASSES = [
-  'group/pill relative min-w-0 border text-xs font-caption tracking-[-0.01em]',
+  'group/pill relative min-w-0 border text-xs font-caption tracking-tight',
   'border-(--pill-border) hover:border-(--pill-border-hover)',
   'bg-(--linear-app-content-surface) hover:bg-(--pill-bg-hover)',
   'text-secondary-token hover:text-primary-token',

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -244,7 +244,7 @@ export function DashboardNav(_: DashboardNavProps) {
               if (canAccessTasksWorkspace)
                 return formatTaskBadge(taskStats, tasksSeenAt);
               return (
-                <span className='rounded-full border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_76%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_90%,transparent)] px-1.5 py-0.5 text-3xs font-semibold tracking-[0.02em] text-secondary-token'>
+                <span className='rounded-full border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_76%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_90%,transparent)] px-1.5 py-0.5 text-3xs font-semibold tracking-wider text-secondary-token'>
                   Pro
                 </span>
               );
@@ -629,7 +629,7 @@ export function DashboardNav(_: DashboardNavProps) {
                   className='space-y-2'
                   data-admin-section={section.label}
                 >
-                  <p className='px-2.5 pb-0.5 text-2xs font-semibold tracking-[-0.01em] text-sidebar-muted/80 group-data-[collapsible=icon]:hidden'>
+                  <p className='px-2.5 pb-0.5 text-2xs font-semibold tracking-tight text-sidebar-muted/80 group-data-[collapsible=icon]:hidden'>
                     {section.label}
                   </p>
                   {renderSection(section.items)}

--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
@@ -114,7 +114,7 @@ function FunnelStage({
           {label}
         </span>
         <span className='flex items-baseline gap-1.5'>
-          <span className='tabular-nums text-mid font-semibold leading-none tracking-[-0.02em] text-primary-token'>
+          <span className='tabular-nums text-mid font-semibold leading-none tracking-tighter text-primary-token'>
             {numberFormatter.format(value)}
           </span>
           {rate && (

--- a/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
@@ -271,7 +271,7 @@ export function SettingsUsageStatsSection() {
             </p>
             <span
               className={cn(
-                'inline-flex items-center rounded-md border px-1.5 py-0.5 text-3xs font-medium tracking-[0.01em]',
+                'inline-flex items-center rounded-md border px-1.5 py-0.5 text-3xs font-medium tracking-wide',
                 getStatusToneClasses(copy.state)
               )}
             >

--- a/apps/web/components/features/home/HeroTaskCard.tsx
+++ b/apps/web/components/features/home/HeroTaskCard.tsx
@@ -54,7 +54,7 @@ export function HeroTaskCard({
           </p>
           <h3
             className={[
-              'mt-1 font-[580] tracking-[-0.02em] text-white',
+              'mt-1 font-[580] tracking-tighter text-white',
               compact ? 'text-app leading-5' : 'text-sm leading-5',
             ].join(' ')}
           >

--- a/apps/web/components/features/home/HomeTrustSection.tsx
+++ b/apps/web/components/features/home/HomeTrustSection.tsx
@@ -90,7 +90,7 @@ export function HomeTrustSection({
           className={cn(
             isInlineStrip
               ? 'system-b-mounted-home-trust-strip-label'
-              : 'text-center font-medium tracking-[0.01em] text-xs text-white/56',
+              : 'text-center font-medium tracking-wide text-xs text-white/56',
             !isInlineStrip && labelMarginClass
           )}
         >

--- a/apps/web/components/features/home/ReleasePhoneContent.tsx
+++ b/apps/web/components/features/home/ReleasePhoneContent.tsx
@@ -61,7 +61,7 @@ export function ReleasePhoneContent({
               key={key}
               label={DSP_LABELS[key] ?? 'Spotify'}
               iconPath={config.iconPath}
-              className='bg-surface-1 ring-[color:var(--linear-border-subtle)] hover:bg-hover'
+              className='bg-surface-1 ring-(--linear-border-subtle) hover:bg-hover'
             />
           );
         })}

--- a/apps/web/components/features/home/SeeItInActionCarousel.tsx
+++ b/apps/web/components/features/home/SeeItInActionCarousel.tsx
@@ -156,7 +156,7 @@ function ReleasePopoverContent({
               label={DSP_LABELS[provider]}
               iconPath={config.iconPath}
               href={`${releaseHref}?dsp=${provider}`}
-              className='bg-surface-1 ring-[color:var(--linear-border-subtle)] hover:bg-hover'
+              className='bg-surface-1 ring-(--linear-border-subtle) hover:bg-hover'
             />
           );
         })}
@@ -207,7 +207,7 @@ function ReleaseCard({
                 onHoverEnd(release.id);
               }
             }}
-            className='group flex w-full flex-col rounded-xl p-6 text-left no-underline transition-colors duration-[var(--linear-duration-normal)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--linear-text-secondary)]'
+            className='group flex w-full flex-col rounded-xl p-6 text-left no-underline transition-colors duration-[var(--linear-duration-normal)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-text-secondary)'
             style={{
               backgroundColor: 'var(--linear-bg-surface-0)',
               border: '1px solid var(--linear-border-subtle)',

--- a/apps/web/components/site/MarketingFooter.tsx
+++ b/apps/web/components/site/MarketingFooter.tsx
@@ -73,7 +73,7 @@ const markLinkClassName =
 const footerLinkClassName =
   'mf-link inline-flex w-fit rounded-md text-mid leading-[1.45] tracking-[-0.005em] text-white/[0.72] transition-colors duration-subtle hover:text-white focus-visible:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/25 focus-visible:ring-offset-2 focus-visible:ring-offset-black';
 const footerLegalLinkClassName =
-  'mf-legal-link inline-flex w-fit rounded-md text-xs leading-5 tracking-[-0.01em] text-white/[0.5] transition-colors duration-subtle hover:text-white/70 focus-visible:text-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/25 focus-visible:ring-offset-2 focus-visible:ring-offset-black';
+  'mf-legal-link inline-flex w-fit rounded-md text-xs leading-5 tracking-tight text-white/[0.5] transition-colors duration-subtle hover:text-white/70 focus-visible:text-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/25 focus-visible:ring-offset-2 focus-visible:ring-offset-black';
 
 function FooterLink({ link }: Readonly<{ link: MarketingFooterLink }>) {
   return (

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3111,
+  "count": 3099,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Reduce arbitrary Tailwind drift on lint-clean support surfaces with exact token aliases only.
- Replace exact tracking values with canonical Tailwind tracking tokens and exact CSS-var ring shorthand.
- Lower the arbitrary-value ratchet baseline from 3111 to 3099.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx apps/web/components/features/home/SeeItInActionCarousel.tsx apps/web/components/atoms/CalendarInner.tsx apps/web/components/features/dashboard/atoms/PlatformPill.utils.ts apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx apps/web/components/features/home/HeroTaskCard.tsx apps/web/components/features/home/HomeTrustSection.tsx apps/web/components/features/home/ReleasePhoneContent.tsx apps/web/components/site/MarketingFooter.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx apps/web/components/features/home/SeeItInActionCarousel.tsx apps/web/components/atoms/CalendarInner.tsx apps/web/components/features/dashboard/atoms/PlatformPill.utils.ts apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx apps/web/components/features/home/HeroTaskCard.tsx apps/web/components/features/home/HomeTrustSection.tsx apps/web/components/features/home/ReleasePhoneContent.tsx apps/web/components/site/MarketingFooter.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter=@jovie/web run pre-push`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`
