### PR TITLE
fix(web): reduce notification shared arbitrary drift

### DIFF
--- a/apps/web/components/features/profile/artist-notifications-cta/shared.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/shared.tsx
@@ -37,40 +37,40 @@ export const subscriptionHeadingClassName =
   'text-balance text-center text-[1.55rem] font-[640] tracking-[-0.045em] text-primary-token sm:text-[1.8rem]';
 
 export const subscriptionDisclaimerClassName =
-  'text-center text-xs leading-5 font-normal tracking-[-0.01em] text-muted-foreground/80';
+  'text-center text-xs leading-5 font-normal tracking-tight text-muted-foreground/80';
 
 export const profilePrimaryPillClassName =
-  'inline-flex h-12 items-center justify-center rounded-full border border-transparent bg-[var(--profile-pearl-primary-bg)] px-5 text-mid font-semibold tracking-[-0.018em] text-[var(--profile-pearl-primary-fg)] shadow-[0_10px_24px_rgba(0,0,0,0.16)] transition-[background-color,color,opacity,box-shadow,border-color] duration-200 ease-out hover:opacity-[0.96] hover:shadow-[0_12px_28px_rgba(0,0,0,0.18)] active:opacity-[0.9] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
+  'inline-flex h-12 items-center justify-center rounded-full border border-transparent bg-(--profile-pearl-primary-bg) px-5 text-mid font-semibold tracking-[-0.018em] text-(--profile-pearl-primary-fg) shadow-[0_10px_24px_rgba(0,0,0,0.16)] transition-[background-color,color,opacity,box-shadow,border-color] duration-200 ease-out hover:opacity-[0.96] hover:shadow-[0_12px_28px_rgba(0,0,0,0.18)] active:opacity-[0.9] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
 
 /** Pearl-Notify hero morph-bar CTA pill — glassy dark, sits over the hero image. */
 export const profileHeroMorphPillClassName =
-  'inline-flex h-11 items-center justify-center rounded-full border border-white/14 bg-white/10 px-5 text-app font-semibold tracking-[-0.01em] text-white shadow-[inset_0_0_0_1px_rgba(255,255,255,0.14),0_6px_16px_rgba(0,0,0,0.22)] backdrop-blur-xl transition-[background-color,color,opacity,box-shadow] duration-200 ease-out hover:bg-white/14 active:opacity-[0.9] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
+  'inline-flex h-11 items-center justify-center rounded-full border border-white/14 bg-white/10 px-5 text-app font-semibold tracking-tight text-white shadow-[inset_0_0_0_1px_rgba(255,255,255,0.14),0_6px_16px_rgba(0,0,0,0.22)] backdrop-blur-xl transition-[background-color,color,opacity,box-shadow] duration-200 ease-out hover:bg-white/14 active:opacity-[0.9] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
 
 export const profileSecondaryPillClassName =
-  'inline-flex h-12 items-center justify-center rounded-full border border-[color:var(--profile-pearl-border)] bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_92%,transparent)] px-5 text-mid font-semibold tracking-[-0.018em] text-primary-token shadow-[0_10px_24px_rgba(10,12,18,0.08)] backdrop-blur-xl transition-[background-color,border-color,color,box-shadow,opacity] duration-200 ease-out hover:bg-[var(--profile-pearl-bg-hover)] hover:border-[color:var(--profile-pearl-border)] hover:shadow-[0_14px_28px_rgba(10,12,18,0.1)] active:opacity-[0.9] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
+  'inline-flex h-12 items-center justify-center rounded-full border border-(--profile-pearl-border) bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_92%,transparent)] px-5 text-mid font-semibold tracking-[-0.018em] text-primary-token shadow-[0_10px_24px_rgba(10,12,18,0.08)] backdrop-blur-xl transition-[background-color,border-color,color,box-shadow,opacity] duration-200 ease-out hover:bg-(--profile-pearl-bg-hover) hover:border-(--profile-pearl-border) hover:shadow-[0_14px_28px_rgba(10,12,18,0.1)] active:opacity-[0.9] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
 
 export const profileQuietIconButtonClassName =
-  'border-transparent bg-transparent text-white/72 shadow-none hover:border-[color:var(--profile-pearl-border)] hover:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_86%,transparent)] hover:text-white focus-visible:border-[color:var(--profile-pearl-border)] focus-visible:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_90%,transparent)] focus-visible:text-white active:bg-[var(--profile-pearl-bg-active)] active:text-white';
+  'border-transparent bg-transparent text-white/72 shadow-none hover:border-(--profile-pearl-border) hover:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_86%,transparent)] hover:text-white focus-visible:border-(--profile-pearl-border) focus-visible:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_90%,transparent)] focus-visible:text-white active:bg-(--profile-pearl-bg-active) active:text-white';
 
 export const subscriptionComposerSurfaceClassName =
-  'rounded-full border border-[color:var(--profile-pearl-border)] bg-[var(--profile-pearl-bg)] shadow-[0_10px_22px_rgba(15,17,24,0.08)] backdrop-blur-2xl transition-[background-color,border-color,box-shadow] duration-slow ease-out dark:shadow-[0_10px_24px_rgba(0,0,0,0.18)]';
+  'rounded-full border border-(--profile-pearl-border) bg-(--profile-pearl-bg) shadow-[0_10px_22px_rgba(15,17,24,0.08)] backdrop-blur-2xl transition-[background-color,border-color,box-shadow] duration-slow ease-out dark:shadow-[0_10px_24px_rgba(0,0,0,0.18)]';
 
 export const subscriptionComposerFocusClassName =
-  'border-[color:var(--profile-pearl-border)] bg-[var(--profile-pearl-bg-hover)] shadow-[0_14px_30px_rgba(15,17,24,0.12)] dark:bg-[var(--profile-pearl-bg-hover)] dark:shadow-[0_12px_28px_rgba(0,0,0,0.22)]';
+  'border-(--profile-pearl-border) bg-(--profile-pearl-bg-hover) shadow-[0_14px_30px_rgba(15,17,24,0.12)] dark:bg-(--profile-pearl-bg-hover) dark:shadow-[0_12px_28px_rgba(0,0,0,0.22)]';
 
 /** Hero morph-bar surface — matches the glassy-dark collapsed pill so every
  * step (email/OTP/name/birthday/done) shares the exact same shell. */
 export const subscriptionHeroComposerSurfaceClassName =
-  'rounded-full border border-white/14 bg-white/10 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.14),0_6px_16px_rgba(0,0,0,0.22)] backdrop-blur-xl transition-[background-color,border-color,box-shadow] duration-200 ease-out';
+  'rounded-full border border-white/14 bg-white/10 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.14),0_6px_16px_rgba(0,0,0,0.22)] backdrop-blur-xl transition-[background-color,border-color,box-shadow] duration-subtle ease-out';
 
 export const subscriptionHeroComposerFocusClassName =
   'border-white/22 bg-white/14 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.22),0_8px_22px_rgba(0,0,0,0.28)]';
 
 export const subscriptionInputClassName =
-  'h-12 w-full bg-transparent px-2 text-mid font-semibold tracking-[-0.02em] text-primary-token placeholder:text-tertiary-token placeholder:opacity-80 transition-[color,opacity] duration-slow focus-visible:outline-none focus-visible:ring-0';
+  'h-12 w-full bg-transparent px-2 text-mid font-semibold tracking-tighter text-primary-token placeholder:text-tertiary-token placeholder:opacity-80 transition-[color,opacity] duration-slow focus-visible:outline-none focus-visible:ring-0';
 
 export const subscriptionHeroInputClassName =
-  'h-11 w-full bg-transparent px-2 text-app font-semibold tracking-[-0.01em] text-white placeholder:text-white/45 focus-visible:outline-none focus-visible:ring-0';
+  'h-11 w-full bg-transparent px-2 text-app font-semibold tracking-tight text-white placeholder:text-white/45 focus-visible:outline-none focus-visible:ring-0';
 
 /** Hero morph-bar circular submit button — 36×36 inverted-white to match the
  * white Play button beside the pill, while staying inside the 44px shell. */
@@ -90,7 +90,7 @@ export const subscriptionFeedbackRailClassName =
   'flex min-h-5 items-center justify-between gap-2 px-1';
 
 export const subscriptionFeedbackCopyClassName =
-  'text-2xs leading-4 tracking-[-0.01em] text-secondary-token/68';
+  'text-2xs leading-4 tracking-tight text-secondary-token/68';
 
 export const subscriptionErrorTextClassName =
   'text-xs leading-4 tracking-[-0.012em] text-red-400';
@@ -473,7 +473,7 @@ export function SubscriptionSuccess({
   if (canCaptureName && (phase === 'ask' || phase === 'saving')) {
     return (
       <div
-        className={`space-y-3 transition-all duration-slower ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}`}
+        className={`space-y-3 transition duration-slower ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}`}
       >
         <p className='flex items-center justify-center gap-1.5 text-sm text-secondary-token'>
           <CheckCircle2

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3099,
+  "count": 3081,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Reduce profile notification shared arbitrary Tailwind drift with exact token aliases only for the measured drift replacements.
- Convert CSS-var color utilities to Tailwind v4 variable shorthand and exact tracking values to canonical tracking tokens.
- Clear the touched file's existing motion lint warnings with DS motion utilities so the staged-file gate stays green.
- Lower the arbitrary-value ratchet baseline from 3099 to 3081.

## Verification
- `pnpm biome check --write apps/web/components/features/profile/artist-notifications-cta/shared.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/features/profile/artist-notifications-cta/shared.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter=@jovie/web run pre-push`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`
