### PR TITLE
fix(web): reduce avatar overlay arbitrary drift

### DIFF
--- a/apps/web/components/atoms/AvatarUploadOverlay.tsx
+++ b/apps/web/components/atoms/AvatarUploadOverlay.tsx
@@ -33,8 +33,8 @@ export function AvatarUploadOverlay({
         className={cn(
           'absolute inset-0 flex items-center justify-center',
           roundedClass,
-          'bg-[color:var(--color-accent)]/90 text-[color:var(--color-accent-foreground)]',
-          'border-2 border-[color:var(--color-accent)] shadow-md transition-transform duration-200'
+          'bg-(--color-accent)/90 text-(--color-accent-foreground)',
+          'border-2 border-(--color-accent) shadow-md transition-transform duration-subtle'
         )}
         aria-hidden='true'
         data-testid='avatar-uploadable-drag-overlay'
@@ -49,8 +49,8 @@ export function AvatarUploadOverlay({
       className={cn(
         'absolute inset-0 flex items-center justify-center',
         roundedClass,
-        'bg-surface-3/80 text-primary-token ring-1 ring-[color:var(--color-border-subtle)] backdrop-blur',
-        'opacity-0 transition-opacity duration-200 group-hover/avatar:opacity-100'
+        'bg-surface-3/80 text-primary-token ring-1 ring-(--color-border-subtle) backdrop-blur',
+        'opacity-0 transition-opacity duration-subtle group-hover/avatar:opacity-100'
       )}
       aria-hidden='true'
       data-testid='avatar-uploadable-hover-overlay'

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3081,
+  "count": 3077,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Reduce avatar upload overlay arbitrary Tailwind drift with exact CSS-var token shorthand.
- Replace raw duration classes in the touched overlay with DS duration tokens so the staged-file lint gate stays green.
- Lower the arbitrary-value ratchet baseline from 3081 to 3077.

## Verification
- `pnpm biome check --write apps/web/components/atoms/AvatarUploadOverlay.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/atoms/AvatarUploadOverlay.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter=@jovie/web run pre-push`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`
