### PR TITLE
fix(web): reduce admin action arbitrary drift

### DIFF
--- a/apps/web/components/features/admin/CreatorVerificationToggleButton.tsx
+++ b/apps/web/components/features/admin/CreatorVerificationToggleButton.tsx
@@ -24,11 +24,11 @@ export function CreatorVerificationToggleButton({
   const label = profile.isVerified ? 'Unverify' : 'Verify';
 
   const stateClass = cn(
-    'transition duration-200 ease-out transform',
+    'transition duration-subtle ease-out transform',
     status === 'success' &&
-      'animate-pulse motion-reduce:animate-none scale-[1.02] ring-1 ring-[color:var(--color-accent)]',
+      'animate-pulse motion-reduce:animate-none scale-[1.02] ring-1 ring-(--color-accent)',
     status === 'error' &&
-      'animate-bounce motion-reduce:animate-none scale-[0.97] ring-1 ring-[color:var(--color-destructive)]'
+      'animate-bounce motion-reduce:animate-none scale-[0.97] ring-1 ring-(--color-destructive)'
   );
 
   const getIcon = () => {

--- a/apps/web/components/features/admin/creator-actions-menu/CreatorActionsMenu.tsx
+++ b/apps/web/components/features/admin/creator-actions-menu/CreatorActionsMenu.tsx
@@ -156,11 +156,11 @@ export function CreatorActionsMenu({
   const isError = status === 'error';
 
   const stateClass = cn(
-    'transition duration-200 ease-out transform',
+    'transition duration-subtle ease-out transform',
     isSuccess &&
-      'animate-pulse motion-reduce:animate-none scale-[1.02] ring-1 ring-[color:var(--color-accent)]',
+      'animate-pulse motion-reduce:animate-none scale-[1.02] ring-1 ring-(--color-accent)',
     isError &&
-      'animate-bounce motion-reduce:animate-none scale-[0.97] ring-1 ring-[color:var(--color-destructive)]'
+      'animate-bounce motion-reduce:animate-none scale-[0.97] ring-1 ring-(--color-destructive)'
   );
 
   if (!isMobile) {

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3077,
+  "count": 3073,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Reduce admin action state arbitrary Tailwind drift with exact ring token aliases.
- Replace raw duration classes in touched admin state animations with DS duration tokens.
- Lower the arbitrary-value ratchet baseline from 3077 to 3073.

## Verification
- `pnpm biome check --write apps/web/components/features/admin/CreatorVerificationToggleButton.tsx apps/web/components/features/admin/creator-actions-menu/CreatorActionsMenu.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/features/admin/CreatorVerificationToggleButton.tsx apps/web/components/features/admin/creator-actions-menu/CreatorActionsMenu.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter=@jovie/web run pre-push`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`
