### PR TITLE
fix(web): reduce shared tracking arbitrary drift

### DIFF
--- a/apps/web/components/atoms/FooterLink.tsx
+++ b/apps/web/components/atoms/FooterLink.tsx
@@ -47,8 +47,8 @@ export const FooterLink = React.forwardRef<HTMLAnchorElement, FooterLinkProps>(
 
     const linkClassName = cn(
       'inline-flex items-center rounded-md px-2 py-1 -mx-2 -my-1',
-      'text-app leading-5 font-medium tracking-[-0.01em]',
-      'transition-all duration-150 ease-out',
+      'text-app leading-5 font-medium tracking-tight',
+      'transition-colors duration-subtle ease-out',
       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interactive focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
       palette,
       className

--- a/apps/web/components/molecules/ActivityFeed.tsx
+++ b/apps/web/components/molecules/ActivityFeed.tsx
@@ -86,14 +86,14 @@ export function ActivityFeedSkeleton({ rows = 4 }: { readonly rows?: number }) {
 function ActivityEventRow({ event }: { readonly event: ActivityEvent }) {
   const isSystem = event.actor?.type === 'system';
   return (
-    <div className='group relative flex items-start gap-3 rounded-md px-1.5 py-1 transition-[background-color] duration-150 hover:bg-surface-1 focus-within:bg-surface-1'>
+    <div className='group relative flex items-start gap-3 rounded-md px-1.5 py-1 transition-[background-color] duration-subtle hover:bg-surface-1 focus-within:bg-surface-1'>
       <div
         aria-hidden='true'
         className='absolute left-3 top-0 bottom-0 w-px bg-(--linear-border-subtle) group-last:hidden'
       />
       <ActivityIcon action={event.action} />
       <div className='min-w-0 flex-1'>
-        <p className='text-app leading-[18px] tracking-[-0.01em] text-secondary-token'>
+        <p className='text-app leading-[18px] tracking-tight text-secondary-token'>
           {event.description}
         </p>
         <div className='mt-0.5 flex items-center gap-1.5 text-2xs text-tertiary-token'>
@@ -129,7 +129,7 @@ export function ActivityFeed({
       <div
         className='space-y-0.5'
         role='feed'
-        aria-label='Activity feed'
+        aria-label='Activity Feed'
         aria-busy='true'
       >
         <ActivityFeedSkeleton rows={4} />
@@ -152,7 +152,7 @@ export function ActivityFeed({
   );
 
   return (
-    <div className='space-y-0.5' role='feed' aria-label='Activity feed'>
+    <div className='space-y-0.5' role='feed' aria-label='Activity Feed'>
       {sorted.map(event => (
         <ActivityEventRow key={event.id} event={event} />
       ))}

--- a/apps/web/components/molecules/AppSearchField.tsx
+++ b/apps/web/components/molecules/AppSearchField.tsx
@@ -36,7 +36,7 @@ export function AppSearchField({
   return (
     <div
       className={cn(
-        'flex h-(--linear-app-control-height-sm) items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-2.5 text-primary-token transition-[border-color,box-shadow,background-color] duration-150 hover:bg-surface-1 focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-(--linear-border-focus)/14',
+        'flex h-(--linear-app-control-height-sm) items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-2.5 text-primary-token transition-[border-color,box-shadow,background-color] duration-subtle hover:bg-surface-1 focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-(--linear-border-focus)/14',
         className
       )}
     >
@@ -54,7 +54,7 @@ export function AppSearchField({
         placeholder={placeholder}
         aria-label={ariaLabel}
         className={cn(
-          'h-full border-0 bg-transparent px-0 text-app tracking-[-0.01em] text-secondary-token shadow-none ring-0 placeholder:text-tertiary-token focus-visible:border-0 focus-visible:ring-0',
+          'h-full border-0 bg-transparent px-0 text-app tracking-tight text-secondary-token shadow-none ring-0 placeholder:text-tertiary-token focus-visible:border-0 focus-visible:ring-0',
           inputClassName
         )}
       />

--- a/apps/web/components/molecules/CopyableUrlRow.tsx
+++ b/apps/web/components/molecules/CopyableUrlRow.tsx
@@ -99,7 +99,7 @@ export function CopyableUrlRow({
     <div
       data-testid={testId}
       className={cn(
-        'flex items-center transition-[background-color,border-color] duration-150',
+        'flex items-center transition-[background-color,border-color] duration-subtle',
         surface === 'boxed'
           ? 'border border-(--linear-app-frame-seam) bg-surface-0 hover:bg-surface-1'
           : 'border border-transparent bg-transparent hover:bg-surface-1/80',
@@ -115,7 +115,7 @@ export function CopyableUrlRow({
       )}
       <span
         className={cn(
-          'min-w-0 flex-1 truncate font-mono tracking-[-0.01em] text-secondary-token',
+          'min-w-0 flex-1 truncate font-mono tracking-tight text-secondary-token',
           styles.value,
           'leading-none',
           valueClassName
@@ -129,7 +129,7 @@ export function CopyableUrlRow({
       </span>
       <span
         className={cn(
-          'inline-flex shrink-0 items-center gap-1 transition-opacity duration-150',
+          'inline-flex shrink-0 items-center gap-1 transition-opacity duration-subtle',
           actionsVisibility === 'hover' &&
             'opacity-0 focus-within:opacity-100 group-hover:opacity-100'
         )}

--- a/apps/web/components/molecules/drawer/DrawerSplitButton.tsx
+++ b/apps/web/components/molecules/drawer/DrawerSplitButton.tsx
@@ -25,7 +25,7 @@ const DRAWER_SPLIT_BUTTON_BASE_CLASSNAME =
   'inline-flex h-7 shrink-0 items-stretch overflow-hidden rounded-full border border-subtle bg-surface-1 text-secondary-token shadow-none';
 
 const DRAWER_SPLIT_BUTTON_SEGMENT_CLASSNAME =
-  'inline-flex items-center justify-center gap-1.5 whitespace-nowrap border-0 bg-transparent px-2.5 text-2xs font-caption tracking-[-0.01em] text-secondary-token transition-[background-color,color] duration-150 hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-0 focus-visible:text-primary-token disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:h-3.5 [&_svg]:w-3.5';
+  'inline-flex items-center justify-center gap-1.5 whitespace-nowrap border-0 bg-transparent px-2.5 text-2xs font-caption tracking-tight text-secondary-token transition-[background-color,color] duration-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-0 focus-visible:text-primary-token disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:h-3.5 [&_svg]:w-3.5';
 
 export function DrawerSplitButton({
   primaryAction,

--- a/apps/web/tests/unit/DotBadge.test.tsx
+++ b/apps/web/tests/unit/DotBadge.test.tsx
@@ -171,7 +171,7 @@ describe('DotBadge', () => {
       expect(badge).toHaveClass('rounded-full');
       expect(badge).toHaveClass('border');
       expect(badge).toHaveClass('font-[510]');
-      expect(badge).toHaveClass('tracking-[-0.01em]');
+      expect(badge).toHaveClass('tracking-tight');
     });
 
     it('applies dot base classes', () => {

--- a/apps/web/tests/unit/atoms/HeaderText.test.tsx
+++ b/apps/web/tests/unit/atoms/HeaderText.test.tsx
@@ -7,7 +7,7 @@ describe('headerTextClass', () => {
     expect(result).toContain('text-sm');
     expect(result).toContain('font-medium');
     expect(result).toContain('leading-5');
-    expect(result).toContain('tracking-[-0.01em]');
+    expect(result).toContain('tracking-tight');
   });
 
   it('returns primary tone classes by default', () => {

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3073,
+  "count": 3068,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replace five exact `tracking-[-0.01em]` utilities with `tracking-tight` in shared app primitives.
- Update stale `HeaderText` and `DotBadge` assertions to the token alias already emitted by source.
- Drop the arbitrary-values ratchet baseline from 3073 to 3068.

## Verification
- `pnpm biome check --write apps/web/components/atoms/FooterLink.tsx apps/web/components/molecules/ActivityFeed.tsx apps/web/components/molecules/AppSearchField.tsx apps/web/components/molecules/CopyableUrlRow.tsx apps/web/components/molecules/drawer/DrawerSplitButton.tsx apps/web/tests/unit/atoms/HeaderText.test.tsx apps/web/tests/unit/DotBadge.test.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm --filter @jovie/web exec eslint --max-warnings=0 --no-warn-ignored components/atoms/FooterLink.tsx components/molecules/ActivityFeed.tsx components/molecules/AppSearchField.tsx components/molecules/CopyableUrlRow.tsx components/molecules/drawer/DrawerSplitButton.tsx tests/unit/atoms/HeaderText.test.tsx tests/unit/DotBadge.test.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts tests/unit/atoms/HeaderText.test.tsx tests/unit/DotBadge.test.tsx --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter=@jovie/web run pre-push`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Test notes
- Bug-to-test: not a bug fix; updated existing class assertion tests because the source already emitted `tracking-tight`.
- Layout shift: no element dimensions, conditional rendering, or layout state changed; only exact class aliases, DS motion token names, and aria-label casing changed.