### PR TITLE
fix(web): reduce insight action arbitrary drift

### DIFF
--- a/apps/web/components/features/dashboard/insights/InsightActions.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightActions.tsx
@@ -18,7 +18,7 @@ export function InsightActions({ insightId }: InsightActionsProps) {
         size='sm'
         disabled={isPending}
         onClick={() => mutate({ insightId, status: 'dismissed' })}
-        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-[-0.01em] text-tertiary-token transition-[background-color,color,border-color,box-shadow] duration-150 hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-secondary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/20'
+        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-tight text-tertiary-token transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-secondary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/20'
       >
         <X className='h-3 w-3' />
         Dismiss
@@ -28,7 +28,7 @@ export function InsightActions({ insightId }: InsightActionsProps) {
         size='sm'
         disabled={isPending}
         onClick={() => mutate({ insightId, status: 'acted_on' })}
-        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-[-0.01em] text-secondary-token transition-[background-color,color,border-color,box-shadow] duration-150 hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-primary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/20'
+        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-tight text-secondary-token transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-primary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/20'
       >
         <Check className='h-3 w-3' />
         Done

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3065,
+  "count": 3063,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replace two exact `tracking-[-0.01em]` utilities with `tracking-tight` in insight action buttons.
- Convert the adjacent `duration-150` classes to the equivalent DS motion token so focused ESLint stays clean.
- Drop the arbitrary-values ratchet baseline from 3065 to 3063.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/insights/InsightActions.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm --filter @jovie/web exec eslint --max-warnings=0 --no-warn-ignored components/features/dashboard/insights/InsightActions.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter=@jovie/web run pre-push`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Test notes
- Bug-to-test: not a bug fix; ratchet coverage is the behavior guard for this token-only cleanup.
- Layout shift: no sizing, spacing, conditional rendering, or state transition changed; only exact tracking aliases and equivalent duration token names changed.