### PR TITLE
fix(web): reduce dashboard control arbitrary drift

### DIFF
--- a/apps/web/components/features/dashboard/atoms/DspConnectionPill.tsx
+++ b/apps/web/components/features/dashboard/atoms/DspConnectionPill.tsx
@@ -24,7 +24,7 @@ import {
 } from './DspProviderIcon';
 
 const BASE_PILL_CLASSNAME =
-  'inline-flex min-h-7 items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-caption tracking-[-0.01em] transition-[background-color,border-color,color] duration-150';
+  'inline-flex min-h-7 items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-caption tracking-tight transition-[background-color,border-color,color] duration-subtle';
 
 const INTERACTIVE_PILL_CLASSNAME =
   'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20 disabled:opacity-50 disabled:cursor-not-allowed';

--- a/apps/web/components/features/dashboard/dashboard-analytics/RangeToggle.tsx
+++ b/apps/web/components/features/dashboard/dashboard-analytics/RangeToggle.tsx
@@ -67,7 +67,7 @@ export function RangeToggle({
   return (
     <div
       role='tablist'
-      aria-label='Select analytics range'
+      aria-label='Select Analytics Range'
       className='inline-flex items-center rounded-full border border-subtle bg-surface-1 p-0.5'
     >
       {RANGE_OPTIONS.map((opt, index) => {
@@ -104,7 +104,7 @@ export function RangeToggle({
             title={
               disabled ? 'Upgrade to Pro for extended analytics' : undefined
             }
-            className={`relative h-7 rounded-full border border-transparent px-2.5 text-xs font-caption tracking-[-0.01em] shadow-none transition-[background-color,color,border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-app-content-surface) ${stateClass}`}
+            className={`relative h-7 rounded-full border border-transparent px-2.5 text-xs font-caption tracking-tight shadow-none transition-[background-color,color,border-color,box-shadow] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-app-content-surface) ${stateClass}`}
           >
             {opt.label}
           </button>

--- a/apps/web/components/features/dashboard/organisms/InlineChatArea.tsx
+++ b/apps/web/components/features/dashboard/organisms/InlineChatArea.tsx
@@ -300,10 +300,10 @@ export const InlineChatArea = forwardRef<
                       size='sm'
                       onClick={handleRetry}
                       disabled={isLoading || isSubmitting}
-                      className='mt-2 h-7 gap-1.5 rounded-lg text-2xs font-caption tracking-[-0.01em]'
+                      className='mt-2 h-7 gap-1.5 rounded-lg text-2xs font-caption tracking-tight'
                     >
                       <RefreshCw className='h-3 w-3' />
-                      Try again
+                      Try Again
                     </Button>
                   )}
                 </div>

--- a/apps/web/components/features/dashboard/organisms/releases/cells/SmartLinkCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/SmartLinkCell.tsx
@@ -35,7 +35,7 @@ export const SmartLinkCell = memo(function SmartLinkCell({
       <div
         className={cn(
           'flex h-7 items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-2.5',
-          'text-2xs font-[430] tracking-[-0.01em] text-tertiary-token select-none transition-[background-color,border-color,color] duration-150'
+          'text-2xs font-[430] tracking-tight text-tertiary-token select-none transition-[background-color,border-color,color] duration-subtle'
         )}
         title={
           isScheduled

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3063,
+  "count": 3059,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replace four exact `tracking-[-0.01em]` utilities with `tracking-tight` across dashboard controls.
- Convert adjacent `duration-150` classes to `duration-subtle` and fix local Title Case labels so focused ESLint stays clean.
- Drop the arbitrary-values ratchet baseline from 3063 to 3059.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/atoms/DspConnectionPill.tsx apps/web/components/features/dashboard/dashboard-analytics/RangeToggle.tsx apps/web/components/features/dashboard/organisms/releases/cells/SmartLinkCell.tsx apps/web/components/features/dashboard/organisms/InlineChatArea.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm --filter @jovie/web exec eslint --max-warnings=0 --no-warn-ignored components/features/dashboard/atoms/DspConnectionPill.tsx components/features/dashboard/dashboard-analytics/RangeToggle.tsx components/features/dashboard/organisms/releases/cells/SmartLinkCell.tsx components/features/dashboard/organisms/InlineChatArea.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter=@jovie/web run pre-push`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Test notes
- Bug-to-test: not a bug fix; ratchet coverage is the behavior guard for this token-only cleanup.
- Layout shift: no sizing, spacing, conditional rendering, or state transition changed; only exact tracking aliases, equivalent duration token names, and local label casing changed.