### PR TITLE
fix(web): reduce keyboard shortcuts arbitrary drift

### DIFF
--- a/apps/web/components/organisms/keyboard-shortcuts-sheet/KeyboardShortcutsSheet.tsx
+++ b/apps/web/components/organisms/keyboard-shortcuts-sheet/KeyboardShortcutsSheet.tsx
@@ -179,11 +179,11 @@ export function KeyboardShortcutsSheet() {
               size='icon'
               className='h-8 w-8 shrink-0'
               onClick={close}
-              aria-label='Close keyboard shortcuts'
+              aria-label='Close Keyboard Shortcuts'
             >
               <ChevronLeft className='h-4 w-4' />
             </Button>
-            <SheetTitle className='text-app font-medium tracking-[-0.01em]'>
+            <SheetTitle className='text-app font-medium tracking-tight'>
               Keyboard Shortcuts
             </SheetTitle>
             <Button
@@ -215,7 +215,7 @@ export function KeyboardShortcutsSheet() {
                   size='icon'
                   className='absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2'
                   onClick={() => setSearchQuery('')}
-                  aria-label='Clear search'
+                  aria-label='Clear Search'
                 >
                   <X className='h-3 w-3' />
                 </Button>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3059,
+  "count": 3058,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replace one exact `tracking-[-0.01em]` utility with `tracking-tight` in the keyboard shortcuts sheet title.
- Fix local aria-label casing so focused ESLint stays clean.
- Drop the arbitrary-values ratchet baseline from 3059 to 3058.

## Verification
- `pnpm biome check --write apps/web/components/organisms/keyboard-shortcuts-sheet/KeyboardShortcutsSheet.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm --filter @jovie/web exec eslint --max-warnings=0 --no-warn-ignored components/organisms/keyboard-shortcuts-sheet/KeyboardShortcutsSheet.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter=@jovie/web run pre-push`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Test notes
- Bug-to-test: not a bug fix; ratchet coverage is the behavior guard for this token-only cleanup.
- Layout shift: no sizing, spacing, conditional rendering, or state transition changed; only exact tracking alias and local aria-label casing changed.