### PR TITLE
fix(web): reduce billing warning arbitrary drift

### DIFF
--- a/apps/web/components/organisms/BillingDashboard.tsx
+++ b/apps/web/components/organisms/BillingDashboard.tsx
@@ -57,7 +57,7 @@ const BillingDashboardContent = memo(function BillingDashboardContent() {
   const errorActions = useMemo(
     () => [
       { label: 'Retry', onClick: handleRefresh },
-      { label: 'Contact support', href: '/support' },
+      { label: 'Contact Support', href: '/support' },
     ],
     [handleRefresh]
   );
@@ -121,7 +121,7 @@ const BillingDashboardContent = memo(function BillingDashboardContent() {
           surface='nested'
         >
           <AlertCircle
-            className='mt-0.5 h-4 w-4 shrink-0 text-[color:var(--linear-warning)]'
+            className='mt-0.5 h-4 w-4 shrink-0 text-(--linear-warning)'
             aria-hidden='true'
           />
           <p>

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3058,
+  "count": 3057,
   "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
 }


### PR DESCRIPTION
## Summary
- Replace one exact `text-[color:var(--linear-warning)]` utility with Tailwind v4 CSS-variable shorthand.
- Fix local `Contact Support` label casing so focused ESLint stays clean.
- Drop the arbitrary-values ratchet baseline from 3058 to 3057.

## Verification
- `pnpm biome check --write apps/web/components/organisms/BillingDashboard.tsx apps/web/tests/unit/design-system/arbitrary-values.baseline.json`
- `pnpm --filter @jovie/web exec eslint --max-warnings=0 --no-warn-ignored components/organisms/BillingDashboard.tsx`
- `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts --testTimeout 20000`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter=@jovie/web run pre-push`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Test notes
- Bug-to-test: not a bug fix; ratchet coverage is the behavior guard for this token-only cleanup.
- Layout shift: no sizing, spacing, conditional rendering, or state transition changed; only exact color utility alias and local label casing changed.