### PR TITLE
fix(ci): clerk-bump guard only flags declared @clerk bumps, not lockfile churn

### DIFF
--- a/.github/workflows/clerk-bump-needs-human.yml
+++ b/.github/workflows/clerk-bump-needs-human.yml
@@ -41,9 +41,14 @@ jobs:
           set -euo pipefail
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          # Only flag a DECLARED @clerk/* dependency change in package.json.
+          # Do NOT scan pnpm-lock.yaml: an unrelated bump (e.g. @radix-ui)
+          # reshuffles the lockfile and re-adds @clerk/* transitive entries as
+          # "+" lines, which false-triggered needs-human on non-Clerk PRs.
+          # A real @clerk bump always edits the package.json version spec.
           if git diff --unified=0 "$BASE_SHA" "$HEAD_SHA" -- \
-              apps/web/package.json package.json pnpm-lock.yaml \
-              | grep -E '^\+.*@clerk/' >/dev/null; then
+              apps/web/package.json package.json \
+              | grep -E '^\+\s*"@clerk/' >/dev/null; then
             echo "clerk_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "clerk_changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
A @radix-ui bump (#11640) false-triggered needs-human + area:auth because the detect step grepped pnpm-lock.yaml for any @clerk/ line (incidental transitive churn). Now only flags declared @clerk changes in package.json. 🤖 Generated with [Claude Code](https://claude.com/claude-code)