### PR TITLE
feat(ci): screenshot-gated taste-approve action for lights-out shipping

### DIFF
--- a/.github/workflows/taste-approve.yml
+++ b/.github/workflows/taste-approve.yml
@@ -1,0 +1,100 @@
+name: Taste Approve
+
+# Lights-out taste gate. The ONLY human-in-the-loop step in autonomous shipping
+# is a taste call (approving an LLM-created design/copy). This workflow lets a
+# maintainer clear that gate from the PR alone — an approving review, or a
+# `/approve` | `lgtm` | 👍 comment — with no checkout.
+#
+# Contract:
+#   - Acts only on PRs labelled `needs-human-taste`.
+#   - Approver must have write+ permission (a real maintainer, not a bot/outsider).
+#   - The PR body MUST contain a screenshot, so the change is judgeable from the
+#     body alone. No screenshot -> the gate is NOT cleared and we ask for one.
+#   - On approval: remove `needs-human-taste`, add `merge-queue`, and hand off to
+#     Graphite. We do NOT bypass-merge; Graphite owns the actual merge.
+
+on:
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: taste-approve-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Cheap pre-filter so this only spins up on plausible approval signals.
+    if: >-
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
+    steps:
+      - name: Evaluate approval signal
+        id: signal
+        env:
+          # Untrusted input — passed via env, never interpolated into the script.
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            # Job-level `if` already gated on review.state == approved.
+            PR_NUM="${{ github.event.pull_request.number }}"
+            ACTOR_LOGIN="${{ github.event.review.user.login }}"
+            APPROVED=true
+          else
+            PR_NUM="${{ github.event.issue.number }}"
+            ACTOR_LOGIN="${{ github.event.comment.user.login }}"
+            # Match an explicit approval token (untrusted body read from env).
+            if printf '%s' "$COMMENT_BODY" | grep -qiE '(^|[[:space:]])(/approve|lgtm|ship it|👍|:\+1:)([[:space:]]|$)'; then
+              APPROVED=true
+            else
+              APPROVED=false
+            fi
+          fi
+          {
+            echo "pr=$PR_NUM"
+            echo "actor=$ACTOR_LOGIN"
+            echo "approved=$APPROVED"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Clear taste gate and enroll in Graphite
+        if: steps.signal.outputs.approved == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.signal.outputs.pr }}
+          ACTOR: ${{ steps.signal.outputs.actor }}
+        run: |
+          set -euo pipefail
+
+          # 1. Only act on taste-gated PRs.
+          if ! gh pr view "$PR" --repo "$REPO" --json labels --jq '[.labels[].name]' \
+              | jq -e 'index("needs-human-taste")' >/dev/null; then
+            echo "PR #$PR is not labelled needs-human-taste; nothing to do."
+            exit 0
+          fi
+
+          # 2. Approver must be a real maintainer (write+).
+          PERM=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null || echo none)
+          case "$PERM" in
+            admin|write|maintain) ;;
+            *) echo "::notice::@$ACTOR lacks write access (perm=$PERM); ignoring approval."; exit 0 ;;
+          esac
+
+          # 3. The PR body must contain a screenshot (image markdown/html or image URL/attachment).
+          BODY=$(gh pr view "$PR" --repo "$REPO" --json body --jq '.body')
+          if ! printf '%s' "$BODY" | grep -qiE '!\[[^]]*\]\(|<img |https?://[^ )]+\.(png|jpe?g|gif|webp)|user-images\.githubusercontent\.com|github\.com/user-attachments'; then
+            gh pr comment "$PR" --repo "$REPO" --body "@$ACTOR approved on taste, but this PR has **no screenshot in the body** — the design can't be judged from the PR alone. Add a screenshot and re-approve. Taste gate **not** cleared."
+            exit 0
+          fi
+
+          # 4. Clear the gate and hand to Graphite (do NOT bypass-merge).
+          gh pr edit "$PR" --repo "$REPO" --remove-label needs-human-taste --add-label merge-queue
+          gh pr comment "$PR" --repo "$REPO" --body "Taste approved by @$ACTOR ✅ — cleared \`needs-human-taste\` and enrolled in the Graphite merge queue. Graphite will land it once checks pass."


### PR DESCRIPTION
## What
The one human-in-the-loop step in autonomous shipping is a **taste call**. This adds a workflow so a maintainer clears the `needs-human-taste` gate from the PR alone — an approving review or a `/approve` | `lgtm` | 👍 comment — no checkout.

## Contract
- Acts only on `needs-human-taste` PRs
- Approver must have write+ access (real maintainer, not a bot/outsider)
- PR body **must contain a screenshot** — else the gate stays and it asks for one
- On approval: removes `needs-human-taste`, adds `merge-queue`, **hands off to Graphite** (does not bypass-merge)

## Security
Untrusted comment bodies are passed via `env`, never interpolated into the run script. actionlint clean.

Part of the lights-out shipping push (companion to the clerk-bump false-positive fix). Risk-tiered CI tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)