### PR TITLE
test(profile): guard alerts-above-content card order on public profile

### DIFF
--- a/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
@@ -54,6 +54,31 @@ function makePublicRelease(
 }
 
 describe('ProfileHomeRail', () => {
+  it('renders alerts above content cards in the home rail DOM order (JOV-11084)', () => {
+    render(
+      <ProfileHomeRail
+        artist={makeArtist()}
+        latestRelease={makeRelease({ title: 'Never Say A Word' })}
+        profileSettings={{ showOldReleases: true }}
+        featuredPlaylistFallback={null}
+        tourDates={[]}
+        hasPlayableDestinations
+        renderMode='preview'
+        isSubscribed={false}
+      />
+    );
+
+    const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
+    const carousel = screen.getByTestId('profile-home-carousel');
+
+    expect(alertsCard.compareDocumentPosition(carousel)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Never Say A Word' })
+    ).toBeInTheDocument();
+  });
+
   it('pins the alerts bento above the carousel and renders no carousel when empty', () => {
     render(
       <ProfileHomeRail
@@ -94,10 +119,14 @@ describe('ProfileHomeRail', () => {
       />
     );
 
-    expect(
-      screen.getByTestId('profile-home-alerts-fallback-card')
-    ).toBeInTheDocument();
-    expect(screen.getByTestId('profile-home-carousel')).toBeInTheDocument();
+    const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
+    const carousel = screen.getByTestId('profile-home-carousel');
+
+    expect(alertsCard).toBeInTheDocument();
+    expect(carousel).toBeInTheDocument();
+    expect(alertsCard.compareDocumentPosition(carousel)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
     expect(
       screen.getByRole('heading', { name: 'The Deep End' })
     ).toBeInTheDocument();

--- a/apps/web/tests/unit/profile/profile-compact-template.test.tsx
+++ b/apps/web/tests/unit/profile/profile-compact-template.test.tsx
@@ -637,11 +637,13 @@ describe('ProfileCompactTemplate', () => {
       />
     );
 
-    expect(
-      screen.getByTestId('profile-home-alerts-fallback-card')
-    ).toHaveTextContent('Alerts');
-    expect(screen.getByTestId('profile-home-carousel')).toHaveTextContent(
-      'Listen'
+    const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
+    const carousel = screen.getByTestId('profile-home-carousel');
+
+    expect(alertsCard).toHaveTextContent('Alerts');
+    expect(carousel).toHaveTextContent('Listen');
+    expect(alertsCard.compareDocumentPosition(carousel)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
     );
     expect(
       screen.queryByTestId('profile-hero-status-pill')


### PR DESCRIPTION
## Summary

- Add DOM-order regression tests for `ProfileHomeRail` and `ProfileCompactTemplate` so the alerts opt-in card cannot slip back below music/content cards.
- New test uses `compareDocumentPosition(Node.DOCUMENT_POSITION_FOLLOWING)` to assert alerts card precedes the carousel in DOM order.
- Enhanced existing `pins the alerts bento above the carousel` test with the same DOM-order assertion.

Supersedes #11383, which had accumulated ~1050 files of merge noise (design-system drift sweeps + screenshot catalog + unrelated merges). This PR is the clean extraction: 2 test files, 40 insertions, 9 deletions.

Closes JOV-11084

## Test plan

- [x] `pnpm --filter web exec vitest run tests/unit/profile/ProfileHomeRail.test.tsx tests/unit/profile/profile-compact-template.test.tsx` — 39 tests pass
- [x] Biome lint: clean
- [x] Typecheck: clean (passed pre-commit + pre-push hooks)
- [x] Pre-push hook (biome + proxy-guard + tailwind-guard + typecheck + lint): all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)