### PR TITLE
ci(perf): move CodeQL + security scans off the PR path (post-merge + nightly)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,12 +12,14 @@
 name: CodeQL Security Analysis
 
 on:
+  # Risk-tiered CI: CodeQL runs on the merged code (post-merge on main) + nightly
+  # deep scan — NOT on every PR/merge-queue batch. Running 5-language CodeQL on
+  # each PR saturated the runner pool and stalled the Graphite queue (2026-06-22).
   push:
     branches: ['main']
-  pull_request:
-    branches: ['main']
   schedule:
-    - cron: '36 13 * * 1' # Weekly on Monday at 13:36 UTC
+    - cron: '36 5 * * *' # Nightly at 05:36 UTC
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,12 +9,14 @@
 name: Security Scanning
 
 on:
+  # Risk-tiered CI: Gitleaks/Trivy/TruffleHog/Scorecard run on merged code
+  # (post-merge on main) + nightly — NOT on every PR/merge-queue batch. Running
+  # the full security suite per-PR saturated runners and stalled the queue
+  # (2026-06-22). Secrets are still caught pre-commit by the local gitleaks hook.
   push:
     branches: ['main']
-  pull_request:
-    branches: ['main']
   schedule:
-    - cron: '0 6 * * 1' # Weekly on Monday at 6:00 AM UTC
+    - cron: '0 6 * * *' # Nightly at 06:00 UTC
   workflow_dispatch:
 
 # Default permissions - each job specifies its own required permissions


### PR DESCRIPTION
Risk-tiered CI — the durable fix for the runner-saturation runaway that stalled the queue for 6h. CodeQL ×5 + Trivy/Gitleaks/TruffleHog/Scorecard moved from per-PR to **push:main + nightly**. ~9 heavy jobs removed from every PR and every gtmq batch. Secrets still caught by the pre-commit gitleaks hook. JOV-3461. 🤖 Generated with [Claude Code](https://claude.com/claude-code)