### PR TITLE
fix: unblock observability ingest typecheck

### DIFF
--- a/workers/observability-ingest/src/report.ts
+++ b/workers/observability-ingest/src/report.ts
@@ -57,13 +57,17 @@ export function parseObservabilityReport(
   const occurred_at =
     typeof record.occurred_at === 'string' ? record.occurred_at : undefined;
 
-  const metadata =
+  const metadata: Record<string, string> | undefined =
     record.metadata && typeof record.metadata === 'object'
-      ? Object.fromEntries(
-          Object.entries(record.metadata as Record<string, unknown>).filter(
-            ([, entry]) => typeof entry === 'string'
-          )
-        )
+      ? Object.entries(record.metadata as Record<string, unknown>).reduce<
+          Record<string, string>
+        >((entries, [key, entry]) => {
+          if (typeof entry === 'string') {
+            entries[key] = entry;
+          }
+
+          return entries;
+        }, {})
       : undefined;
 
   return {

--- a/workers/observability-ingest/tsconfig.json
+++ b/workers/observability-ingest/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ES2022", "WebWorker"],
     "types": ["@cloudflare/workers-types"],
     "strict": true,
+    "allowImportingTsExtensions": true,
     "noEmit": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary
- allow `.ts` imports in the no-emit observability worker typecheck so Node's direct `.ts` test path remains valid
- narrow parsed observability metadata to `Record<string, string>` before returning the typed report

## Verification
- `pnpm --filter @jovie/observability-ingest run typecheck`
- `pnpm --filter @jovie/observability-ingest test`
- `TURBO_SCM_BASE=origin/main pnpm turbo typecheck --affected`
- pre-push: `biome check .`, web proxy guard, Tailwind guard, web typecheck, web lint

## Scope
- CI unblocker for the existing `@jovie/observability-ingest` typecheck failure on `main`; intentionally separate from iOS ledger PR #11734.
