### PR TITLE
chore: ignore workers/*/node_modules in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ apps/should-i-make/node_modules
 apps/should-i-make/.next
 packages/ui/node_modules
 packages/*/node_modules
+workers/*/node_modules
 
 # Turborepo
 .turbo


### PR DESCRIPTION
## Summary

- `workers/observability-ingest/node_modules/` was appearing as an untracked file because `.gitignore` covered `packages/*/node_modules` and specific `apps/*/node_modules` paths but had no entry for `workers/*/node_modules`
- Adds `workers/*/node_modules` to the existing block of workspace-scoped node_modules ignores

## Test plan
- [ ] Confirm `git status` is clean after this merges (no untracked `workers/*/node_modules`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzeAefaoJSu2i9d6ivrEwU

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzeAefaoJSu2i9d6ivrEwU)_