### PR TITLE
ci(security): diff-scoped secret scan back on the PR path

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,11 +9,16 @@
 name: Security Scanning
 
 on:
-  # Risk-tiered CI: Gitleaks/Trivy/TruffleHog/Scorecard run on merged code
-  # (post-merge on main) + nightly — NOT on every PR/merge-queue batch. Running
-  # the full security suite per-PR saturated runners and stalled the queue
-  # (2026-06-22). Secrets are still caught pre-commit by the local gitleaks hook.
+  # Risk-tiered CI (JOV-3461). The FAST secret scans (gitleaks + trufflehog,
+  # diff-scoped via `scan-secrets.sh ci-pr`) run on PRs — a leaked key on a
+  # PUBLIC repo is scraped within seconds of hitting main, so secret detection
+  # must gate pre-merge (EVENT-class). The HEAVY scans (Trivy full-tree, CodeQL,
+  # Scorecard) stay post-merge on main + nightly — they saturated runners and
+  # stalled the queue when run per-PR (2026-06-22). Per-job `if:` guards below
+  # keep the heavy ones off the PR path.
   push:
+    branches: ['main']
+  pull_request:
     branches: ['main']
   schedule:
     - cron: '0 6 * * *' # Nightly at 06:00 UTC
@@ -77,6 +82,9 @@ jobs:
   trivy:
     name: Trivy Vulnerability Scanning
     runs-on: ubuntu-latest
+    # Heavy full-tree scan stays off the PR path (post-merge on main + nightly).
+    # Only the fast diff-scoped secret scans (gitleaks/trufflehog) gate PRs.
+    if: github.event_name != 'pull_request'
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
#11735 correctly moved heavy scans (Trivy/CodeQL/Scorecard) off the PR path, but it also dropped **secret scanning** — and a leaked key on a **public** repo is scraped within seconds of hitting main (EVENT-class, unrecoverable). gitleaks+trufflehog already have a diff-scoped `ci-pr` mode; this re-adds the `pull_request` trigger and guards the heavy Trivy job off PR. On a PR only the two ~10s diff-scoped secret scans run. Tier-1 #2 of JOV-3461. 🤖 Generated with [Claude Code](https://claude.com/claude-code)