### PR TITLE
chore: ignore workers/*/node_modules in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ apps/should-i-make/node_modules
 apps/should-i-make/.next
 packages/ui/node_modules
 packages/*/node_modules
+workers/*/node_modules
 
 # Turborepo
 .turbo


### PR DESCRIPTION
## Summary
- `workers/observability-ingest/node_modules/` was showing as untracked because `.gitignore` listed specific workspace paths (`apps/*/`, `packages/*/`) but had no entry for `workers/*/`.
- Added `workers/*/node_modules` to the existing "App-specific node_modules" block.

## Test plan
- [ ] Confirm `git status` no longer shows `workers/observability-ingest/node_modules/` as untracked after pulling this branch.

## Note
This was filed automatically by the `pr-size-guard` maintenance routine (2026-06-23). The routine's primary goal (adding "PR Size Guard" as a required status check on ruleset 10512119) is blocked until `gh` CLI + `GH_TOKEN` are available in the cloud container — see the draft email queued to T@timwhite.co for the two manual commands needed to complete that step.

---
_Generated by [Claude Code](https://claude.ai/code/session_019icW5YFvY2n7wb7ogSpbpi)_