### PR TITLE
fix(ci): correct arbitrary-values ratchet baseline (unblock main)

### DIFF
--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3057,
-  "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count."
+  "count": 3061,
+  "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count. Corrected 3057→3061 on 2026-06-23: #11689 set the baseline 4 below the true post-sweep count and was admin-merged past its own red ratchet, leaving main RED and failing every PR's Unit Tests. Drive back down via JOV-3466 (tokenize the 4 stragglers)."
 }


### PR DESCRIPTION
## What
`apps/web/tests/unit/design-system/arbitrary-values.baseline.json` said **3057** but the real count on `main` is **3061** — so the ratchet test fails on pristine `main`, failing **Unit Tests (5/6) on every open PR**.

## Root cause
#11689 (DS token-sweep collapse) set the baseline 4 below the true post-sweep count and was admin-merged past its own red ratchet during yesterday's queue drain. No single later commit added arbitrary values (verified: all 5 apps/web commits since #11689 are net-0). The baseline was simply set too low.

## Fix
Correct baseline to the true current count (3061). This is **not** loosening the guard — it aligns it with reality so the ratchet functions again and can be driven back down. Follow-up **JOV-3466** tracks tokenizing the 4 stragglers to ratchet 3061→3057.

## Verify
`pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts` → green with baseline 3061.

CI-repair PR → targets `main` directly (exempt per ci-branching rules).