### PR TITLE
feat(hermes): wire high-value cron jobs to gbrain compounding memory

### DIFF
--- a/scripts/hermes/jobs/ci-failure-monitor.ts
+++ b/scripts/hermes/jobs/ci-failure-monitor.ts
@@ -13,7 +13,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
+import { gbrainLearn, gbrainSlug } from '../lib/gbrain';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
 import { buildFollowUpBody, fileIssue } from '../lib/linear-client';
 
@@ -142,6 +142,17 @@ async function processFailure(
     runId: run.databaseId,
     identifier: filed.identifier,
     error: filed.error,
+  });
+
+  // Compound the failure signature to gbrain, keyed by workflow (idempotent → a
+  // recurring failure on the same workflow updates one page). Makes "has this
+  // workflow failed before, and how was it resolved" recallable.
+  gbrainLearn({
+    slug: `ci-failures/${gbrainSlug(run.workflowName)}`,
+    title: `CI failure: ${run.workflowName} on main`,
+    body: `Workflow "${run.workflowName}" failed on main.\n\n- Latest run: ${run.databaseId} (${run.createdAt})\n- Title: ${run.displayTitle}\n- URL: ${run.url}\n- Linear: ${filed.identifier ?? 'not filed'}`,
+    tags: ['type:ci-failure', `workflow:${gbrainSlug(run.workflowName)}`],
+    type: 'ci-failure',
   });
 }
 

--- a/scripts/hermes/jobs/daily-briefing.ts
+++ b/scripts/hermes/jobs/daily-briefing.ts
@@ -16,6 +16,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 
 import { chat } from '../lib/free-model-router';
+import { gbrainRecall } from '../lib/gbrain';
 import { HERMES_PATHS } from '../lib/hermes-paths';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
 import { sendTelegram } from '../lib/telegram-client';
@@ -149,16 +150,29 @@ async function main(): Promise<void> {
       2
     );
 
+    // Recall durable founder context (priorities, decisions, open threads) so the
+    // brief is memory-aware, not just yesterday's mechanical counts. Soft-degrades to ''.
+    const memory = gbrainRecall(
+      `founder priorities decisions blockers ${merged
+        .map(p => p.title)
+        .join(' ')
+        .slice(0, 200)}`,
+      5
+    );
+    const memoryBlock = memory
+      ? `\n\nRelevant long-term context (from gbrain):\n${memory}`
+      : '';
+
     const result = await chat(
       [
         {
           role: 'system',
           content:
-            'You are Hermes, an always-on chief-of-staff for a pre-PMF founder. Write a terse morning briefing (≤200 words, Markdown). Lead with what shipped, then what to focus on today. No emoji except where signaling. Plain language. No filler.',
+            'You are Hermes, an always-on chief-of-staff for a pre-PMF founder. Write a terse morning briefing (≤200 words, Markdown). Lead with what shipped, then what to focus on today. Use the long-term context to connect yesterday to ongoing priorities. No emoji except where signaling. Plain language. No filler.',
         },
         {
           role: 'user',
-          content: `Yesterday's data (UTC):\n\`\`\`json\n${context}\n\`\`\``,
+          content: `Yesterday's data (UTC):\n\`\`\`json\n${context}\n\`\`\`${memoryBlock}`,
         },
       ],
       { caller: JOB, need: 'reasoning', maxTokens: 600, temperature: 0.4 }

--- a/scripts/hermes/jobs/deterministic-tracker.ts
+++ b/scripts/hermes/jobs/deterministic-tracker.ts
@@ -12,7 +12,7 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-
+import { gbrainLearn, gbrainSlug } from '../lib/gbrain';
 import { HERMES_PATHS } from '../lib/hermes-paths';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
 import { buildFollowUpBody, fileIssue } from '../lib/linear-client';
@@ -115,6 +115,16 @@ async function main(): Promise<void> {
         count: c.count,
         identifier: filed.identifier,
         error: filed.error,
+      });
+
+      // Compound the pattern to gbrain (idempotent slug → recurring shapes update one
+      // page, not spam). Future runs / agents can recall "what intent shapes recur".
+      gbrainLearn({
+        slug: `deterministic/${gbrainSlug(c.key)}`,
+        title: `Deterministic candidate: ${c.key} (${c.count}x/${WINDOW_DAYS}d)`,
+        body: `Intent shape "${c.key}" dispatched ${c.count}x in the last ${WINDOW_DAYS} days.\n\nSamples:\n${c.samples.map((s, i) => `${i + 1}. ${s}`).join('\n')}\n\nLinear: ${filed.identifier ?? 'not filed'}`,
+        tags: ['type:deterministic-candidate', `count:${c.count}`],
+        type: 'deterministic-candidate',
       });
     }
   });

--- a/scripts/hermes/jobs/pr-stuck-monitor.ts
+++ b/scripts/hermes/jobs/pr-stuck-monitor.ts
@@ -15,7 +15,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-
+import { gbrainLearn } from '../lib/gbrain';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
 import { buildFollowUpBody, fileIssue } from '../lib/linear-client';
 
@@ -161,6 +161,16 @@ async function processPr(pr: Pr): Promise<void> {
       identifier: filed.identifier,
       labelApplied: labelOk,
       reasons: verdict.reasons,
+    });
+
+    // Compound the stuck pattern to gbrain (idempotent per PR → updates as the PR's
+    // situation changes). Makes recurring stuck-reasons recallable across PRs.
+    gbrainLearn({
+      slug: `pr-stuck/pr-${pr.number}`,
+      title: `Stuck PR #${pr.number}: ${pr.title.slice(0, 60)}`,
+      body: `PR #${pr.number} flagged stuck.\n\nReasons:\n${verdict.reasons.map(r => `- ${r}`).join('\n')}\n\nLinear: ${filed.identifier ?? 'not filed'}`,
+      tags: ['type:pr-stuck', `pr:${pr.number}`],
+      type: 'pr-stuck',
     });
   } else {
     logJobEvent({

--- a/scripts/hermes/lib/gbrain.ts
+++ b/scripts/hermes/lib/gbrain.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared gbrain client for Hermes cron jobs — the TS mirror of
+ * `~/.hermes/scripts/lib/gbrain_mem.py`. Lets the always-on jobs both READ prior
+ * knowledge (recall) and WRITE durable learnings (learn) so findings compound
+ * across runs instead of being re-derived (or re-filed) every cron tick.
+ *
+ * Every call soft-degrades: gbrain being down returns '' / false, never throws —
+ * a cron job must never block on the memory layer.
+ */
+import { execFileSync } from 'node:child_process';
+import { basename } from 'node:path';
+
+const GBRAIN = process.env.HERMES_GBRAIN_BIN ?? 'gbrain';
+
+/** Stable slug from arbitrary text (mirrors gbrain_mem.slugify). */
+export function gbrainSlug(s: string, maxLen = 60): string {
+  return (
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, maxLen) || 'untitled'
+  );
+}
+
+/**
+ * Return relevant prior knowledge for `query`, or '' if gbrain is down. One
+ * `gbrain search` call (semantic relevance). Generous timeout — fine for crons,
+ * never interactive. Never throws.
+ */
+export function gbrainRecall(
+  query: string,
+  limit = 5,
+  maxChars = 3000
+): string {
+  if (!query.trim()) return '';
+  try {
+    const out = execFileSync(
+      GBRAIN,
+      ['search', query, '--limit', String(limit)],
+      {
+        encoding: 'utf8',
+        timeout: 30_000,
+      }
+    ).trim();
+    if (!out || out.slice(0, 60).toLowerCase().includes('failed')) return '';
+    return out.length > maxChars
+      ? `${out.slice(0, maxChars)}\n[truncated]`
+      : out;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Idempotent upsert of a gbrain page (mirrors gbrain_mem.learn — `gbrain put <slug>`
+ * with frontmatter). A deterministic slug means a recurring finding overwrites its
+ * page instead of duplicating. Returns true on success, false if gbrain is down.
+ * Never throws.
+ */
+export function gbrainLearn(args: {
+  readonly slug: string;
+  readonly title: string;
+  readonly body: string;
+  readonly tags?: readonly string[];
+  readonly type?: string;
+}): boolean {
+  if (!args.slug || !args.title) return false;
+  const tags = [...new Set(args.tags ?? [])].sort().join(', ');
+  const page =
+    `---\ntitle: ${args.title}\ntype: ${args.type ?? 'learning'}\n` +
+    `tags: [${tags}]\ncreated: ${new Date().toISOString()}\n---\n\n${args.body.trim()}\n`;
+  try {
+    execFileSync(GBRAIN, ['put', args.slug], {
+      input: page,
+      encoding: 'utf8',
+      timeout: 25_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Append free-form content to the brain inbox (auto-slugged) and return its id.
+ * Used by ingestion jobs (e.g. voice memos) where the content is a stream, not a
+ * keyed page. Throws on failure (the caller decides whether that's fatal).
+ */
+export function gbrainIngest(args: {
+  readonly text: string;
+  readonly tags: readonly string[];
+}): string {
+  const out = execFileSync(
+    GBRAIN,
+    ['ingest', '--tags', args.tags.join(','), '--stdin-text', '--print-id'],
+    { encoding: 'utf8', input: args.text, timeout: 30_000 }
+  );
+  const id = out.trim();
+  if (!id) throw new Error('gbrain ingest returned empty id');
+  return id;
+}
+
+export { basename as gbrainBasename };


### PR DESCRIPTION
Adds a shared `scripts/hermes/lib/gbrain.ts` (TS mirror of `~/.hermes/scripts/lib/gbrain_mem.py`) and wires four Hermes cron jobs to compound their findings into gbrain, so learnings accumulate across runs instead of being re-derived every tick.

## What
- **`lib/gbrain.ts`** — `gbrainRecall` (→`gbrain search`), `gbrainLearn` (idempotent `gbrain put` with frontmatter), `gbrainIngest`, `gbrainSlug`. Every call soft-degrades to `''`/`false` — a cron is never blocked by the memory layer.
- **deterministic-tracker** — writes each recurring intent-shape cluster to `deterministic/{slug}` (the self-improvement loop now compounds).
- **ci-failure-monitor** — writes failure signatures to `ci-failures/{workflow}` (idempotent → recurring failures update one page).
- **pr-stuck-monitor** — writes stuck-PR patterns to `pr-stuck/pr-{n}`.
- **daily-briefing** — recalls long-term founder context so the brief connects yesterday to ongoing priorities.

## Verification
- Lib load-tested: all exports are functions; recall→`''`, learn→`false` when gbrain absent (soft-degrade).
- Live write→read round-trip through the lib: `gbrain put` succeeded, `gbrain get` returned the page.
- biome clean on all 5 files. `scripts/` is not in any tsconfig (jobs run via tsx) — no project typecheck gate; runtime correctness verified instead.

## Notes
- Left `voice-memo-ingest.ts` inline helper as-is (works, critical path; shared lib is canonical for new code).
- Pre-existing gbrain `resolver_health` warnings (35) are separate corpus-health, handled by gbrain's own weekly-doctor/reconcile-links tooling.

<!-- linear-issue-id: JOV-3476 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)