### PR TITLE
test(design-system): drift ratchets for UI convergence (raw-button + component-family)

### DIFF
--- a/apps/web/tests/unit/design-system/component-family-ratchet.test.ts
+++ b/apps/web/tests/unit/design-system/component-family-ratchet.test.ts
@@ -1,0 +1,120 @@
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Duplicate-component-family guard (count ratchet).
+ *
+ * Counts component files per drift-prone family (`*Button`, `*Palette`,
+ * `*EmptyState`, `*Shell`) under apps/web/components. The count may only go
+ * DOWN. Convergence collapses duplicate implementations onto one canonical
+ * per family; this ratchet stops NEW one-off variants from landing while that
+ * work is in flight.
+ *
+ * Seeded at the current count, so it never reds-out main and never blocks an
+ * unrelated PR — it only triggers on a PR that ADDS a new family file. To add
+ * a genuinely-distinct component, raise the family's baseline in the SAME PR
+ * with a Linear ID in the description (the inverse of "lower it when you dedup").
+ *
+ * WARN_ONLY: ships warn-mode first (per the convergence plan, D3) so the
+ * mechanism + baseline land without risk. Flip WARN_ONLY to false once the
+ * wave-1 dedup PRs (button/CTA, command palettes) have landed and the
+ * canonical set is settled — then growth fails CI instead of just warning.
+ *
+ * Sibling of arbitrary-values-ratchet.test.ts / raw-button-ratchet.test.ts.
+ */
+
+const WARN_ONLY = true;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// tests/unit/design-system → apps/web
+const WEB_ROOT = join(__dirname, '..', '..', '..');
+const SCAN_DIR = join(WEB_ROOT, 'components');
+const BASELINE_PATH = join(__dirname, 'component-family.baseline.json');
+
+const FAMILIES = {
+  button: /Button\.tsx$/,
+  palette: /Palette\.tsx$/,
+  emptyState: /EmptyState\.tsx$/,
+  shell: /Shell\.tsx$/,
+} as const;
+type Family = keyof typeof FAMILIES;
+
+// Exclude tests, stories, and type/util siblings — count only component files.
+const EXCLUDED = /\.(test|stories)\.tsx$/;
+
+function walk(dir: string, out: string[]): void {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) {
+      if (entry === 'node_modules' || entry === '.next') continue;
+      walk(full, out);
+    } else if (entry.endsWith('.tsx') && !EXCLUDED.test(entry)) {
+      out.push(entry);
+    }
+  }
+}
+
+function countFamilies(): Record<Family, number> {
+  const files: string[] = [];
+  walk(SCAN_DIR, files);
+  const counts = { button: 0, palette: 0, emptyState: 0, shell: 0 };
+  for (const name of files) {
+    for (const family of Object.keys(FAMILIES) as Family[]) {
+      if (FAMILIES[family].test(name)) counts[family] += 1;
+    }
+  }
+  return counts;
+}
+
+describe('design-system component-family ratchet', () => {
+  it('duplicate component families do not grow above the baseline', () => {
+    const current = countFamilies();
+
+    if (!existsSync(BASELINE_PATH)) {
+      writeFileSync(
+        BASELINE_PATH,
+        `${JSON.stringify({ counts: current, note: 'Component files per drift-prone family in apps/web/components. Ratchet only goes down — lower when you dedup, raise with a Linear ID for a genuinely-distinct new component. Flip WARN_ONLY=false in the test after wave-1 dedup lands.' }, null, 2)}\n`
+      );
+    }
+
+    const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as {
+      counts: Record<Family, number>;
+    };
+
+    const grown = (Object.keys(FAMILIES) as Family[]).filter(
+      family => current[family] > baseline.counts[family]
+    );
+
+    if (grown.length > 0) {
+      const detail = grown
+        .map(f => `${f}: ${current[f]} (baseline ${baseline.counts[f]})`)
+        .join(', ');
+      const message =
+        `New duplicate-family component file(s) detected — ${detail}. ` +
+        'Reuse/extend the canonical component for that family instead of adding a variant. ' +
+        'If genuinely distinct, raise the baseline in component-family.baseline.json in this PR with a Linear ID.';
+      if (WARN_ONLY) {
+        // Warn-mode: surface drift without blocking. Flip WARN_ONLY=false
+        // after wave-1 dedup lands to make this a hard gate.
+        console.warn(`[component-family ratchet — WARN] ${message}`);
+      } else {
+        expect.fail(message);
+      }
+    }
+
+    // Sanity: baseline keys stay in sync with the family list.
+    expect(Object.keys(baseline.counts).sort()).toEqual(
+      Object.keys(FAMILIES).sort()
+    );
+  });
+});

--- a/apps/web/tests/unit/design-system/component-family.baseline.json
+++ b/apps/web/tests/unit/design-system/component-family.baseline.json
@@ -1,0 +1,9 @@
+{
+  "counts": {
+    "button": 41,
+    "palette": 4,
+    "emptyState": 12,
+    "shell": 21
+  },
+  "note": "Component files per drift-prone family in apps/web/components. Ratchet only goes down — lower when you dedup, raise with a Linear ID for a genuinely-distinct new component. Flip WARN_ONLY=false in the test after wave-1 dedup lands."
+}

--- a/apps/web/tests/unit/design-system/raw-button-ratchet.test.ts
+++ b/apps/web/tests/unit/design-system/raw-button-ratchet.test.ts
@@ -1,0 +1,88 @@
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Raw `<button>` drift ratchet.
+ *
+ * Counts raw `<button>` JSX tags across the web surfaces. The count may only
+ * go DOWN: convergence onto the canonical `Button` (`@jovie/ui` /
+ * `components/atoms/Button`) removes raw `<button>` usage, never adds it.
+ *
+ * Why a ratchet and not zero-tolerance: there are ~700 existing raw buttons;
+ * banning them outright would block all work. The ratchet locks in progress —
+ * regressions fail, conversions pass. When you reduce the count, lower `count`
+ * in raw-button.baseline.json in the SAME PR so the floor follows the work down.
+ *
+ * Sibling of arbitrary-values-ratchet.test.ts — same committed-baseline shape.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// tests/unit/design-system → apps/web
+const WEB_ROOT = join(__dirname, '..', '..', '..');
+const SCAN_DIRS = ['components', 'app'].map(d => join(WEB_ROOT, d));
+const BASELINE_PATH = join(__dirname, 'raw-button.baseline.json');
+
+// A raw lowercase `<button` opening tag: `<button` followed by whitespace,
+// `>`, or `/` (self-closing). The lookahead avoids matching the canonical
+// `<Button` component (capital B) and any hypothetical `<buttonish` element.
+const RAW_BUTTON = /<button(?=[\s/>])/g;
+const SOURCE_EXT = /\.(tsx|ts)$/;
+
+function walk(dir: string, out: string[]): void {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) {
+      if (entry === 'node_modules' || entry === '.next') continue;
+      walk(full, out);
+    } else if (SOURCE_EXT.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+function countRawButtons(): number {
+  const files: string[] = [];
+  for (const dir of SCAN_DIRS) walk(dir, files);
+  let total = 0;
+  for (const file of files) {
+    const matches = readFileSync(file, 'utf8').match(RAW_BUTTON);
+    if (matches) total += matches.length;
+  }
+  return total;
+}
+
+describe('design-system raw-button ratchet', () => {
+  it('raw <button> usage does not increase above the baseline', () => {
+    const current = countRawButtons();
+
+    // Self-seed on first run so the baseline and the count logic can never
+    // diverge. Commit the seeded file; CI compares against it.
+    if (!existsSync(BASELINE_PATH)) {
+      writeFileSync(
+        BASELINE_PATH,
+        `${JSON.stringify({ count: current, note: 'Raw <button> tags in apps/web/{components,app}. Ratchet only goes down — lower this when a PR converts raw buttons to the canonical Button.' }, null, 2)}\n`
+      );
+    }
+
+    const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as {
+      count: number;
+    };
+
+    expect(
+      current,
+      `Raw <button> usage rose to ${current} (baseline ${baseline.count}). ` +
+        'Use the canonical Button from @jovie/ui (or components/atoms/Button) instead of a raw <button>, ' +
+        'or — if a raw <button> is genuinely required — justify it in review and raise the baseline with a Linear ID.'
+    ).toBeLessThanOrEqual(baseline.count);
+  });
+});

--- a/apps/web/tests/unit/design-system/raw-button.baseline.json
+++ b/apps/web/tests/unit/design-system/raw-button.baseline.json
@@ -1,0 +1,4 @@
+{
+  "count": 712,
+  "note": "Raw <button> tags in apps/web/{components,app}. Ratchet only goes down — lower this when a PR converts raw buttons to the canonical Button."
+}


### PR DESCRIPTION
## What

Phase 1 of the UI convergence pass: two down-only **drift guards** so consolidation work is enforced and measured, not vibes. Mirrors the existing \`arbitrary-values-ratchet\`.

- **raw-button ratchet** (\`raw-button-ratchet.test.ts\`, baseline **712**) — raw \`<button>\` count in \`apps/web/{components,app}\` may only go DOWN. Converge onto the canonical \`Button\`.
- **component-family ratchet** (\`component-family-ratchet.test.ts\`) — per-family component-file counts (Button 41, Palette 4, EmptyState 12, Shell 21) may only grow with a Linear-ID baseline bump. **Warn-mode first**; flip \`WARN_ONLY=false\` after the wave-1 dedup PRs (button/CTA, command palettes) land.

## Why

We're converging the repo onto its existing, already-enforced design system (DESIGN.md, packages/ui, eslint boundaries) and ratcheting drift to zero. These guards stop NEW drift while the dedup PRs collapse the existing duplication. Seeded at current counts, so they **cannot red-out main** — only a PR that adds drift is affected (the #11689 failure mode is avoided by design + verified green on main first).

## Risk

Low — test-only, no product code. Both tests are fast (<0.5s), deterministic, self-seeding.

## Verification

- \`vitest run\` — both new ratchets pass; existing arbitrary-values ratchet still green on main.
- \`pnpm --filter @jovie/web run typecheck\` — clean.
- \`pnpm biome check\` — clean.

## Follow-ups (same wave, sequential)

- PR2: button/CTA dedup → canonical \`Button\` (drops the raw-button baseline).
- PR3: command palettes → one \`cmdk\` primitive + domain wrappers, then flip the family guard to error-mode.

bug-to-test: n/a — this PR *is* the test/guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)