### PR TITLE
refactor(design-system): relocate orphaned CTAButton stories+README to molecules

### DIFF
--- a/apps/web/components/molecules/CTAButton.README.md
+++ b/apps/web/components/molecules/CTAButton.README.md
@@ -1,9 +1,9 @@
-# CTAButton (components/atoms/CTAButton)
+# CTAButton (components/molecules/CTAButton)
 
 A token-driven call-to-action built on `@jovie/ui`'s `Button` primitive. It preserves shadcn focus and hover affordances, adds micro-interactions for pressed states, and keeps analytics-friendly link handling consistent across internal and external destinations.
 
 ```tsx
-import { CTAButton } from '@/components/atoms/CTAButton';
+import { CTAButton } from '@/components/molecules/CTAButton';
 
 <CTAButton href='/pricing' icon={<SparklesIcon />}>
   Join the waitlist

--- a/apps/web/components/molecules/CTAButton.stories.tsx
+++ b/apps/web/components/molecules/CTAButton.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { Sparkles } from 'lucide-react';
 import {
   CTAButton,
   type CTAButtonProps,
@@ -26,11 +27,7 @@ export const Primary: Story = {
 export const WithIcon: Story = {
   args: {
     children: 'Upgrade to Pro',
-    icon: (
-      <span aria-hidden className='h-4 w-4'>
-        ✨
-      </span>
-    ),
+    icon: <Sparkles aria-hidden className='h-4 w-4' />,
   },
 };
 


### PR DESCRIPTION
## What

`CTAButton` lives at `components/molecules/CTAButton.tsx`, but its stories + README were stranded in `components/atoms/` with a **stale `components/atoms/CTAButton` path and a broken import example**. This co-locates them with the component, fixes the doc path, and replaces an emoji (`✨`) in the `WithIcon` story with the Lucide `Sparkles` icon (no-emoji rule).

## Why

Found during the UI convergence audit. The orphaned files were the only real "CTA/button" drift — the planned literal `atoms/CTAButton` vs `molecules/CTAButton` duplicate **does not exist** (one canonical CTAButton; `UpgradeButton`/`PrimaryCTA` are distinct/thin wrappers). Pure hygiene.

## Risk

None — no component or behavior change. Storybook discovers stories by glob, so the move is cosmetic; the stale doc + emoji were the real (tiny) drift.

## Verification

- `git mv` (rename preserved), biome + eslint + typecheck + a11y staged checks all pass.
- No ratchet impact (stories/README excluded from component-family count; no `<button>`).

bug-to-test: waived — docs/stories relocation, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)