### PR TITLE
Migrate conductor.json to .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,11 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+archive = "bash scripts/archive.sh"
+setup = "bash scripts/setup.sh"
+
+[tasks.Run]
+available_in = "local"
+command = "doppler run -- pnpm --filter web dev:local"
+default = true
+icon = "play"

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,0 @@
-{
-  "scripts": {
-    "setup": "bash scripts/setup.sh",
-    "run": "doppler run -- pnpm --filter web dev:local",
-    "archive": "bash scripts/archive.sh"
-  }
-}


### PR DESCRIPTION
This PR migrates the legacy `conductor.json` configuration to the new `.conductor/settings.toml` format.

Generated by Conductor.