### PR TITLE
fix(home): restore V2 homepage — undo accidental V1 flag flip (#11484)

### DIFF
--- a/apps/web/lib/flags/marketing-static.test.ts
+++ b/apps/web/lib/flags/marketing-static.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { FEATURE_FLAGS } from './marketing-static';
+
+/**
+ * Guardrail for the 2026-06-22 homepage regression (#11484, fixed in the PR that
+ * adds this test). The `*_V1_DESIGN` flags have INVERTED semantics: `true` renders
+ * the OLD design. A blanket "default all flags on" change flipped them to `true`,
+ * silently reverting the homepage to `HomeV1Design` and bypassing the V2 hero +
+ * sections — caught only by the post-deploy synthetic monitor, ~36h late.
+ *
+ * These assertions run in the gated unit suite, so any accidental re-flip fails on
+ * the PR instead of in production. If V1 is ever intended again, that's a
+ * deliberate product decision — update these assertions in the same PR.
+ */
+describe('marketing-static homepage design flags', () => {
+  it('renders the V2 homepage (SHOW_HOME_V1_DESIGN must stay false)', () => {
+    expect(FEATURE_FLAGS.SHOW_HOME_V1_DESIGN).toBe(false);
+  });
+
+  it('renders the V2 public profile (SHOW_PUBLIC_PROFILE_V1_DESIGN must stay false)', () => {
+    expect(FEATURE_FLAGS.SHOW_PUBLIC_PROFILE_V1_DESIGN).toBe(false);
+  });
+});

--- a/apps/web/lib/flags/marketing-static.ts
+++ b/apps/web/lib/flags/marketing-static.ts
@@ -40,8 +40,12 @@ export const FEATURE_FLAGS = {
   SHOW_HOME_REFRESH_2026: true,
   SHOW_MARKETING_FULL_FOOTER: true,
   SHOW_MARKETING_CENTER_NAV: true,
-  SHOW_HOME_V1_DESIGN: true,
-  SHOW_PUBLIC_PROFILE_V1_DESIGN: true,
+  // V1_DESIGN flags have INVERTED semantics: true = render the OLD design.
+  // #11484 ("default feature flags on") blanket-flipped every flag false→true,
+  // which silently reverted the homepage to HomeV1Design and bypassed the V2
+  // hero + sections that same PR enabled. Restore the pre-#11484 known-good state.
+  SHOW_HOME_V1_DESIGN: false,
+  SHOW_PUBLIC_PROFILE_V1_DESIGN: false,
 } as const;
 
 export type MarketingStaticFlagName = keyof typeof FEATURE_FLAGS;

--- a/apps/web/tests/unit/marketing/marketing-static-flags.test.ts
+++ b/apps/web/tests/unit/marketing/marketing-static-flags.test.ts
@@ -10,10 +10,22 @@ describe('marketing static flags', () => {
     vi.unstubAllEnvs();
   });
 
-  it('keeps every static marketing flag default-on for internal v1 access', async () => {
+  it('keeps every static marketing flag default-on except inverted V1 design toggles', async () => {
     const { FEATURE_FLAGS } = await importFlags();
 
-    expect(Object.values(FEATURE_FLAGS).every(Boolean)).toBe(true);
+    // *_V1_DESIGN flags use inverted semantics: true = OLD design. Production ships V2.
+    const invertedV1DesignFlags = new Set([
+      'SHOW_HOME_V1_DESIGN',
+      'SHOW_PUBLIC_PROFILE_V1_DESIGN',
+    ]);
+
+    const defaultOnFlags = Object.entries(FEATURE_FLAGS)
+      .filter(([key]) => !invertedV1DesignFlags.has(key))
+      .map(([, value]) => value);
+
+    expect(defaultOnFlags.every(Boolean)).toBe(true);
+    expect(FEATURE_FLAGS.SHOW_HOME_V1_DESIGN).toBe(false);
+    expect(FEATURE_FLAGS.SHOW_PUBLIC_PROFILE_V1_DESIGN).toBe(false);
   });
 
   it('shows marketing center navigation in production by default', async () => {


### PR DESCRIPTION
## Regression
The production homepage has served the **old `HomeV1Design`** since **2026-06-22 ~08:23 UTC**, when #11484 "default feature flags on" blanket-flipped every flag `false→true`. But `SHOW_HOME_V1_DESIGN` / `SHOW_PUBLIC_PROFILE_V1_DESIGN` have **inverted semantics** — `true` = render the OLD design. So that PR silently:
- reverted the homepage to V1 (`page.tsx:403` `if (SHOW_HOME_V1_DESIGN) return <HomeV1Design/>`), and
- bypassed the V2 hero + all the V2 sections (`SHOW_HOMEPAGE_V2_*`, FAQ, social-proof…) that the **same PR** enabled but that the early V1 return never reaches.

The **Production Synthetic Monitor caught it and has been red ~36h** (last green 06-22 06:51) — `synthetic-golden-path.spec.ts` asserts `homepage-hero-shell` / `homepage-primary-cta`, which V1 doesn't render. Tracked in JOV-3488.

## Fix
Restore both `V1_DESIGN` flags to `false` — the exact pre-#11484 known-good state. (`SHOW_PUBLIC_PROFILE_V1_DESIGN` is currently a dead/unused flag, but reset for consistency so it can't bite later.)

## Verified locally
Rendered `/` on a local dev server with the fix: `homepage-hero-shell` ×2, `homepage-primary-cta` ×2, `system-b-mounted-*` ×3, **0 V1 markers**, HTTP 200. Typecheck clean. The synthetic monitor + `homepage.spec.ts` go green post-deploy = the confirmation.

## Screenshot
Local render confirms the V2 hero shell + primary CTA are back (testids present). Post-deploy synthetic is the gate.