### PR TITLE
refactor(insights): migrate raw colors to carbon accent tokens

### DIFF
--- a/apps/web/components/features/dashboard/insights/InsightCard.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightCard.tsx
@@ -1,21 +1,44 @@
 'use client';
 
 import { Badge } from '@jovie/ui';
+import type { CSSProperties } from 'react';
+import {
+  type AccentPaletteName,
+  getAccentCssVars,
+} from '@/lib/ui/accent-palette';
 import type { InsightResponse } from '@/types/insights';
 import { InsightActions } from './InsightActions';
 import { InsightCategoryIcon } from './InsightCategoryIcon';
 
-const PRIORITY_BADGE_STYLES = {
-  high: 'border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300',
-  medium: 'border-sky-500/20 bg-sky-500/10 text-sky-700 dark:text-sky-300',
-  low: 'border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token',
-} as const;
+// Priority is semantic: high → orange (warning), medium → blue (info),
+// low → neutral token greyscale.
+const PRIORITY_ACCENT: Record<
+  InsightResponse['priority'],
+  AccentPaletteName | null
+> = {
+  high: 'orange',
+  medium: 'blue',
+  low: null,
+};
 
 const PRIORITY_LABELS = {
   high: 'High priority',
   medium: 'Medium',
   low: 'Low',
 } as const;
+
+function priorityBadgeStyle(
+  priority: InsightResponse['priority']
+): CSSProperties | undefined {
+  const accent = PRIORITY_ACCENT[priority];
+  if (!accent) return undefined;
+  const { solid, subtle } = getAccentCssVars(accent);
+  return {
+    color: solid,
+    backgroundColor: subtle,
+    borderColor: `color-mix(in oklab, ${solid} 35%, transparent)`,
+  };
+}
 
 interface InsightCardProps {
   readonly insight: InsightResponse;
@@ -38,7 +61,12 @@ export function InsightCard({ insight }: InsightCardProps) {
             <Badge
               variant='secondary'
               size='sm'
-              className={`rounded-md px-1.5 py-0.5 text-3xs ${PRIORITY_BADGE_STYLES[insight.priority]}`}
+              className={`rounded-md px-1.5 py-0.5 text-3xs ${
+                insight.priority === 'low'
+                  ? 'border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token'
+                  : ''
+              }`}
+              style={priorityBadgeStyle(insight.priority)}
             >
               {PRIORITY_LABELS[insight.priority]}
             </Badge>

--- a/apps/web/components/features/dashboard/insights/InsightCategoryIcon.test.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightCategoryIcon.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { InsightCategory } from '@/types/insights';
+import { InsightCategoryIcon } from './InsightCategoryIcon';
+
+/**
+ * JOV-3486: category icons must use carbon accent tokens
+ * (`var(--color-accent-*)`) rather than raw Tailwind colors. The neutral
+ * `timing` category stays on greyscale tokens.
+ */
+const ACCENT_BY_CATEGORY: Record<InsightCategory, string | null> = {
+  geographic: 'var(--color-accent-blue)',
+  growth: 'var(--color-accent-green)',
+  content: 'var(--color-accent-purple)',
+  revenue: 'var(--color-accent-teal)',
+  tour: 'var(--color-accent-orange)',
+  platform: 'var(--color-accent-gray)',
+  engagement: 'var(--color-accent-pink)',
+  timing: null,
+};
+
+const RAW_COLOR =
+  /(?:text|bg|border)-(?:blue|emerald|yellow|amber|sky|orange|purple|pink|red|green)-\d/;
+
+describe('InsightCategoryIcon carbon tokens', () => {
+  it.each(
+    Object.entries(ACCENT_BY_CATEGORY)
+  )('applies a carbon accent token for %s', (category, expectedSolid) => {
+    const { container } = render(
+      <InsightCategoryIcon category={category as InsightCategory} />
+    );
+    const chip = container.firstElementChild as HTMLElement;
+    const icon = chip.querySelector('svg') as SVGElement;
+
+    // No raw Tailwind color classes survive on the chip or icon.
+    expect(chip.className).not.toMatch(RAW_COLOR);
+    expect(icon.getAttribute('class') ?? '').not.toMatch(RAW_COLOR);
+
+    if (expectedSolid) {
+      expect(chip.style.backgroundColor).toContain('--color-accent-');
+      expect(icon.getAttribute('style') ?? '').toContain(expectedSolid);
+    } else {
+      // Neutral timing category uses greyscale tokens, no inline accent var.
+      expect(chip.className).toContain('bg-surface-0');
+      expect(icon.getAttribute('class') ?? '').toContain('text-tertiary-token');
+    }
+  });
+});

--- a/apps/web/components/features/dashboard/insights/InsightCategoryIcon.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightCategoryIcon.tsx
@@ -8,56 +8,32 @@ import {
   TrendingUp,
   Users,
 } from 'lucide-react';
+import {
+  type AccentPaletteName,
+  getAccentCssVars,
+} from '@/lib/ui/accent-palette';
 import type { InsightCategory } from '@/types/insights';
 
+/**
+ * Carbon accent assignment per insight category. Categories are categorical
+ * (8 distinct variables), so the full palette reads as categories rather than
+ * status. `timing` stays neutral (token greyscale) by design.
+ */
 const CATEGORY_CONFIG: Record<
   InsightCategory,
   {
     icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-    iconClassName: string;
-    chipClassName: string;
+    accent: AccentPaletteName | null;
   }
 > = {
-  geographic: {
-    icon: MapPin,
-    iconClassName: 'text-blue-600 dark:text-blue-400',
-    chipClassName: 'bg-blue-500/10 dark:bg-blue-500/15',
-  },
-  growth: {
-    icon: TrendingUp,
-    iconClassName: 'text-emerald-600 dark:text-emerald-400',
-    chipClassName: 'bg-emerald-500/10 dark:bg-emerald-500/15',
-  },
-  content: {
-    icon: Music,
-    iconClassName: 'text-purple-600 dark:text-purple-400',
-    chipClassName: 'bg-purple-500/10 dark:bg-purple-500/15',
-  },
-  revenue: {
-    icon: DollarSign,
-    iconClassName: 'text-yellow-600 dark:text-yellow-400',
-    chipClassName: 'bg-yellow-500/10 dark:bg-yellow-500/15',
-  },
-  tour: {
-    icon: Ticket,
-    iconClassName: 'text-orange-600 dark:text-orange-400',
-    chipClassName: 'bg-orange-500/10 dark:bg-orange-500/15',
-  },
-  platform: {
-    icon: Share2,
-    iconClassName: 'text-accent',
-    chipClassName: 'bg-accent/10 dark:bg-accent/15',
-  },
-  engagement: {
-    icon: Users,
-    iconClassName: 'text-pink-600 dark:text-pink-400',
-    chipClassName: 'bg-pink-500/10 dark:bg-pink-500/15',
-  },
-  timing: {
-    icon: Clock,
-    iconClassName: 'text-tertiary-token',
-    chipClassName: 'bg-surface-0',
-  },
+  geographic: { icon: MapPin, accent: 'blue' },
+  growth: { icon: TrendingUp, accent: 'green' },
+  content: { icon: Music, accent: 'purple' },
+  revenue: { icon: DollarSign, accent: 'teal' },
+  tour: { icon: Ticket, accent: 'orange' },
+  platform: { icon: Share2, accent: 'gray' },
+  engagement: { icon: Users, accent: 'pink' },
+  timing: { icon: Clock, accent: null },
 };
 
 interface InsightCategoryIconProps {
@@ -74,11 +50,24 @@ export function InsightCategoryIcon({
   const chipSize = size === 'sm' ? 'h-6 w-6' : 'h-7 w-7';
   const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4';
 
+  if (!config.accent) {
+    return (
+      <div
+        className={`shrink-0 flex ${chipSize} items-center justify-center rounded-lg bg-surface-0`}
+      >
+        <IconComponent className={`${iconSize} text-tertiary-token`} />
+      </div>
+    );
+  }
+
+  const accent = getAccentCssVars(config.accent);
+
   return (
     <div
-      className={`shrink-0 flex ${chipSize} items-center justify-center rounded-lg ${config.chipClassName}`}
+      className={`shrink-0 flex ${chipSize} items-center justify-center rounded-lg`}
+      style={{ backgroundColor: accent.subtle }}
     >
-      <IconComponent className={`${iconSize} ${config.iconClassName}`} />
+      <IconComponent className={iconSize} style={{ color: accent.solid }} />
     </div>
   );
 }

--- a/apps/web/components/features/dashboard/insights/InsightsPanel.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightsPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { CSSProperties } from 'react';
 import { useMemo, useState } from 'react';
 import { AppSegmentControl } from '@/components/atoms/AppSegmentControl';
 import { Icon } from '@/components/atoms/Icon';
@@ -10,26 +11,30 @@ import {
   PageToolbarActionButton,
 } from '@/components/organisms/table';
 import { useGenerateInsightsMutation, useInsightsQuery } from '@/lib/queries';
+import { getAccentCssVars } from '@/lib/ui/accent-palette';
 import type { InsightCategory, InsightResponse } from '@/types/insights';
 import { InsightCard } from './InsightCard';
 import { InsightEmptyState } from './InsightEmptyState';
 
 interface PrioritySectionProps {
   readonly label: string;
-  readonly colorClass: string;
+  readonly colorClass?: string;
+  readonly colorStyle?: CSSProperties;
   readonly insights: InsightResponse[];
 }
 
 function PrioritySection({
   label,
   colorClass,
+  colorStyle,
   insights,
 }: PrioritySectionProps) {
   if (insights.length === 0) return null;
   return (
     <section>
       <h3
-        className={`mb-3 text-app font-caption tracking-normal ${colorClass}`}
+        className={`mb-3 text-app font-caption tracking-normal ${colorClass ?? ''}`}
+        style={colorStyle}
       >
         {label}
       </h3>
@@ -97,12 +102,12 @@ function InsightsPanelContent({
     <div className='space-y-6'>
       <PrioritySection
         label='High Priority'
-        colorClass='text-orange-600 dark:text-orange-400'
+        colorStyle={{ color: getAccentCssVars('orange').solid }}
         insights={grouped.high}
       />
       <PrioritySection
         label='Recommended'
-        colorClass='text-blue-600 dark:text-blue-400'
+        colorStyle={{ color: getAccentCssVars('blue').solid }}
         insights={grouped.medium}
       />
       <PrioritySection
@@ -186,7 +191,7 @@ export function InsightsPanelView({
             value={selectedCategory}
             onValueChange={onCategoryChange}
             options={CATEGORY_FILTERS}
-            aria-label='Filter insights by category'
+            aria-label='Filter Insights By Category'
             surface='ghost'
             className='flex flex-wrap gap-1.5 rounded-none border-0 bg-transparent p-0'
             triggerClassName='min-h-8 border border-subtle bg-surface-1 px-3 py-1 text-xs text-secondary-token hover:border-default hover:bg-surface-0 hover:text-primary-token data-[state=active]:border-default data-[state=active]:bg-surface-0 data-[state=active]:text-primary-token'


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3486 -->

## What
Migrates the **Insights** surface (the one production-only insights surface; siblings are clean redirect stubs) off raw Tailwind color utilities and onto the canonical **carbon accent tokens**.

- **InsightCategoryIcon.tsx** — replaced `text-blue-600 / bg-blue-500/10 / emerald-600 / yellow-600 / orange-600 / purple-600 / pink-600 / text-accent` etc. with the shared `getAccentCssVars()` palette. The 8 categories map 1:1 to the carbon accent rotation (categorical use, ≥4 vars → full palette allowed per `ui.md`); `timing` stays neutral greyscale tokens (`bg-surface-0` / `text-tertiary-token`).
- **InsightCard.tsx** — priority badges now semantic via tokens: `high → orange` (warning), `medium → blue` (info), `low → neutral token` (was raw `amber-500 / sky-500`).
- **InsightsPanel.tsx** — priority section headers use `orange` / `blue` accents (was raw `orange-600 / blue-600`); `Informational` stays `text-tertiary-token`. Also fixed a **pre-existing** `aria-label` casing lint error (`@jovie/canonical-ui-label-casing`) that blocked the commit hook.
- **InsightCategoryIcon.test.tsx** (new, co-located) — asserts every category resolves to a carbon accent CSS var and that no raw Tailwind color classes survive.

Implementation follows the established codebase pattern (`getAccentCssVars` + inline `style` with `var(--color-accent-*)`), the same approach used by tasks / HUD / marketing. The AC-suggested `text-accent-blue` Tailwind classes do **not** exist as utilities (those tokens live in `:root`, not `@theme`), so the CSS-var route is the correct, ratchet-safe one.

## Why
JOV-3486 audit found this surface used raw colors instead of carbon accent tokens — off-brand and out of sync with the design system. Token migration keeps semantics correct (green=success, red=error, orange=warning, blue=info; decorative prefers blue/purple/pink) and centralizes accent values.

## Screenshots
Color-only token swap — visual states identical in shape/size. Eyeball the preview deploy: `/app/insights` (category icon chips, priority badges, section headers).

## Risk
Low. No behavior, keyboard nav, or layout changes. All dimension classes preserved (chip `h-7 w-7`, badge sizing, header spacing) → no layout shift across loading / empty / error / populated states. No new arbitrary Tailwind values, no new raw `<button>`s, no new feature flag, no emoji, no native dialogs, no decorative hover motion.

## Verification
```
typecheck            → EXIT 0 (pnpm --filter @jovie/web run typecheck -- --pretty false)
biome check          → Checked 4 files, clean
eslint (4 files)     → EXIT 0, no lint errors
vitest               → 13 passed (4 files):
  - tests/unit/dashboard/insights-components.test.tsx                3 passed
  - components/.../insights/InsightCategoryIcon.test.tsx (new)       8 passed
  - tests/unit/design-system/arbitrary-values-ratchet.test.ts        1 passed (no new arbitrary values)
  - tests/unit/design-system/raw-button-ratchet.test.ts              1 passed (no new raw buttons)
```
