### PR TITLE
feat(releases): enrich shell list row with type badge + inline agent status

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
@@ -21,6 +21,7 @@ import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActio
 import type { TableActionMenuItem } from '@/components/atoms/table-action-menu/types';
 import { useTrackAudioPlayer } from '@/components/organisms/release-sidebar/useTrackAudioPlayer';
 import { ShellListRowFrame } from '@/components/organisms/table';
+import { AgentPulse } from '@/components/shell/AgentPulse';
 import { ArtworkThumb } from '@/components/shell/ArtworkThumb';
 import { DropDateChip } from '@/components/shell/DropDateChip';
 import { DspAvatarStack } from '@/components/shell/DspAvatarStack';
@@ -29,15 +30,47 @@ import {
   type EntityPopoverData,
 } from '@/components/shell/EntityPopover';
 import { StatusBadge } from '@/components/shell/StatusBadge';
-import type { ReleaseViewModel } from '@/lib/discography/types';
+import { TypeBadge } from '@/components/shell/TypeBadge';
+import type { ReleaseType, ReleaseViewModel } from '@/lib/discography/types';
 import { dropDateMeta } from '@/lib/format-drop-date';
 import { cn } from '@/lib/utils';
 import { releaseStatusToShell, releaseToDspItems } from './release-adapters';
 
 export type ShellRowLockReason = 'scheduled' | 'cap' | null;
+
+/**
+ * In-flight agent state for a release row, mirroring the experiment's
+ * inline "Syncing artwork…" affordance. Driven by real production signals
+ * (the parent's `refreshingReleaseId` / ISRC rescan), not mock data.
+ */
+export type ShellReleaseSyncStatus = 'refreshing' | 'rescanning-isrc' | null;
+
+const SHELL_RELEASE_SYNC_LABEL: Record<
+  NonNullable<ShellReleaseSyncStatus>,
+  string
+> = {
+  refreshing: 'Syncing…',
+  'rescanning-isrc': 'Rescanning ISRC…',
+};
+
+/**
+ * Short, capitalized release-type label for the inline `TypeBadge`. Mirrors
+ * the canonical labels used in the release filter/add surfaces so the row
+ * agrees with the rest of the releases experience.
+ */
+const RELEASE_TYPE_BADGE_LABEL: Record<ReleaseType, string> = {
+  single: 'Single',
+  ep: 'EP',
+  album: 'Album',
+  compilation: 'Comp',
+  live: 'Live',
+  mixtape: 'Mixtape',
+  music_video: 'Video',
+  other: 'Other',
+};
 export const shellReleaseRowTypography = {
   title: 'truncate text-app font-caption text-primary-token leading-[1.2]',
-  subtitle: 'truncate text-2xs text-tertiary-token leading-[1.3] mt-0.5',
+  subtitle: 'truncate text-2xs text-tertiary-token leading-[1.3]',
 } as const;
 
 // ── Subcomponents ─────────────────────────────────────────────────────────────
@@ -93,8 +126,10 @@ function useArtworkPlayback(release: ReleaseViewModel) {
 
 const ArtworkCell = memo(function ArtworkCell({
   release,
+  isSyncing,
 }: {
   readonly release: ReleaseViewModel;
+  readonly isSyncing: boolean;
 }) {
   const { previewUrl, isTrackPlaying, handleTogglePlayback } =
     useArtworkPlayback(release);
@@ -107,6 +142,7 @@ const ArtworkCell = memo(function ArtworkCell({
         title={release.title}
         size={40}
       />
+      {isSyncing ? <AgentPulse className='rounded-sm' /> : null}
       {hasPreview ? (
         <button
           type='button'
@@ -118,7 +154,10 @@ const ArtworkCell = memo(function ArtworkCell({
           aria-pressed={isTrackPlaying}
           data-testid={`shell-release-play-${release.id}`}
           className={cn(
-            'absolute inset-0 grid place-items-center rounded-sm bg-black/50 text-white transition-opacity duration-subtle ease-subtle focus-visible:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
+            // Always renders white-on-black scrim in both themes — pair the
+            // light/dark utilities so the play glyph stays legible on the
+            // `bg-black/50` overlay (satisfies no-hardcoded-theme-colors).
+            'absolute inset-0 grid place-items-center rounded-sm bg-black/50 text-white dark:text-white transition-opacity duration-subtle ease-subtle focus-visible:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
             isTrackPlaying
               ? 'opacity-100'
               : 'opacity-0 group-hover/row:opacity-100'
@@ -203,8 +242,9 @@ const SmartLinkCell = memo(function SmartLinkCell({
 
 /**
  * Linear-style release row for the DESIGN_V1 path. Replaces the legacy
- * provider-matrix cells with: artwork + title + artists + status + drop date
- * + DSP avatar stack + smart link + more menu.
+ * provider-matrix cells with: artwork (+ agent pulse when syncing) + title
+ * + type badge + artists (+ inline sync status) + status + drop date +
+ * DSP avatar stack + smart link + more menu.
  *
  * The outer `<div>` is the click + keyboard target (parent `<div role="listbox">`)
  * Inner interactive elements (smart link, more-menu) stop propagation so
@@ -216,12 +256,19 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
   onSelect,
   actionMenuItems,
   smartLinkLockReason = null,
+  syncStatus = null,
 }: {
   readonly release: ReleaseViewModel;
   readonly isSelected: boolean;
   readonly onSelect: () => void;
   readonly actionMenuItems?: TableActionMenuItem[];
   readonly smartLinkLockReason?: ShellRowLockReason;
+  /**
+   * In-flight agent state for this release (refresh / ISRC rescan). When set,
+   * the artwork shows an `AgentPulse` and the artist line appends a status
+   * label. Degrades to nothing when `null` (the common idle case).
+   */
+  readonly syncStatus?: ShellReleaseSyncStatus;
 }) {
   const dspItems = useMemo(() => releaseToDspItems(release), [release]);
   const dropMeta = useMemo(
@@ -230,6 +277,8 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
   );
   const status = releaseStatusToShell(release.status);
   const artistLabel = release.artistNames?.join(', ') ?? '';
+  const typeLabel = RELEASE_TYPE_BADGE_LABEL[release.releaseType] ?? 'Single';
+  const syncLabel = syncStatus ? SHELL_RELEASE_SYNC_LABEL[syncStatus] : null;
   const smartLinkPath = release.smartLinkPath || `/${release.slug}`;
   const { playbackState } = useTrackAudioPlayer();
   const isActiveTrack = playbackState.activeTrackId === release.id;
@@ -270,19 +319,34 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
       interactive
       className='group/row flex h-14 items-center gap-3 px-3'
     >
-      <ArtworkCell release={release} />
+      <ArtworkCell release={release} isSyncing={syncLabel !== null} />
 
       <div className='min-w-0 flex-1'>
-        <EntityHoverLink
-          entity={releaseEntity}
-          className={cn(
-            shellReleaseRowTypography.title,
-            'inline-flex w-full max-w-full hover:no-underline'
-          )}
-        >
-          {release.title}
-        </EntityHoverLink>
-        <div className={shellReleaseRowTypography.subtitle}>{artistLabel}</div>
+        <div className='flex min-w-0 items-center gap-1.5'>
+          <EntityHoverLink
+            entity={releaseEntity}
+            className={cn(
+              shellReleaseRowTypography.title,
+              'inline-flex min-w-0 hover:no-underline'
+            )}
+          >
+            {release.title}
+          </EntityHoverLink>
+          <TypeBadge label={typeLabel} />
+        </div>
+        <div className='mt-0.5 flex min-w-0 items-center'>
+          <span className={shellReleaseRowTypography.subtitle}>
+            {artistLabel}
+          </span>
+          {syncLabel ? (
+            <span className='ml-1 inline-flex shrink-0 items-center text-2xs text-accent-blue'>
+              <span aria-hidden='true' className='mr-1 text-quaternary-token'>
+                ·
+              </span>
+              <span className='whitespace-nowrap'>{syncLabel}</span>
+            </span>
+          ) : null}
+        </div>
       </div>
 
       <div className='hidden w-24 shrink-0 justify-start md:inline-flex'>

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
@@ -69,7 +69,10 @@ import {
   useReleaseRightPanelTableMeta,
 } from '../useReleaseRightPanelTableMeta';
 import { releaseStatusToShell } from './release-adapters';
-import { ShellReleaseRow } from './ShellReleaseRow';
+import {
+  ShellReleaseRow,
+  type ShellReleaseSyncStatus,
+} from './ShellReleaseRow';
 
 /**
  * Match a release against a single filter value. Field-level operator
@@ -158,6 +161,7 @@ interface ReleasesListContentProps {
   >;
   readonly isSmartLinkLocked: (id: string) => boolean;
   readonly getSmartLinkLockReason: (id: string) => SmartLinkLockReason | null;
+  readonly getSyncStatus: (id: string) => ShellReleaseSyncStatus;
   readonly onConnectSpotify: () => void;
   readonly onNewRelease: () => void;
   readonly onSync: () => void;
@@ -178,6 +182,7 @@ function ReleasesListContent({
   actionMenusByReleaseId,
   isSmartLinkLocked,
   getSmartLinkLockReason,
+  getSyncStatus,
   onConnectSpotify,
   onNewRelease,
   onSync,
@@ -309,6 +314,7 @@ function ReleasesListContent({
           smartLinkLockReason={
             isSmartLinkLocked(r.id) ? getSmartLinkLockReason(r.id) : null
           }
+          syncStatus={getSyncStatus(r.id)}
         />
       ))}
     </div>
@@ -449,6 +455,20 @@ export function ShellReleasesView({
       return lockReasons.get(releaseId) ?? null;
     },
     [lockReasons]
+  );
+
+  // Per-row in-flight agent state, derived from real mutation signals:
+  // a refresh is tracked per-release; an ISRC rescan applies to the
+  // currently-edited release. Idle rows resolve to `null` (no chrome).
+  const getSyncStatus = useCallback(
+    (releaseId: string): ShellReleaseSyncStatus => {
+      if (refreshingReleaseId === releaseId) return 'refreshing';
+      if (isRescanningIsrc && editingRelease?.id === releaseId) {
+        return 'rescanning-isrc';
+      }
+      return null;
+    },
+    [refreshingReleaseId, isRescanningIsrc, editingRelease?.id]
   );
 
   const visibleReleases = useMemo(() => applyPills(rows, pills), [rows, pills]);
@@ -942,6 +962,7 @@ export function ShellReleasesView({
             actionMenusByReleaseId={actionMenusByReleaseId}
             isSmartLinkLocked={isSmartLinkLocked}
             getSmartLinkLockReason={getSmartLinkLockReason}
+            getSyncStatus={getSyncStatus}
             onConnectSpotify={() => setSpotifySearchOpen(true)}
             onNewRelease={handleNewRelease}
             onSync={handleSync}

--- a/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.test.tsx
+++ b/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.test.tsx
@@ -273,3 +273,122 @@ describe('ShellReleaseRow audio affordance', () => {
     );
   });
 });
+
+describe('ShellReleaseRow enrichment', () => {
+  it('renders a release-type badge derived from real release data', () => {
+    render(
+      <ShellReleaseRow
+        release={fakeRelease({
+          id: 'r1',
+          title: 'Materia',
+          releaseType: 'album',
+          previewUrl: null,
+        })}
+        isSelected={false}
+        onSelect={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('Album')).toBeInTheDocument();
+  });
+
+  it('falls back to a Single badge for unmapped release types', () => {
+    render(
+      <ShellReleaseRow
+        release={fakeRelease({
+          id: 'r1',
+          title: 'Mystery',
+          // Force an out-of-map value to exercise the fallback.
+          releaseType: 'unknown' as never,
+          previewUrl: null,
+        })}
+        isSelected={false}
+        onSelect={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('Single')).toBeInTheDocument();
+  });
+
+  it('omits the inline sync status and agent pulse when idle', () => {
+    const { container } = render(
+      <ShellReleaseRow
+        release={fakeRelease({ id: 'r1', title: 'Idle', previewUrl: null })}
+        isSelected={false}
+        onSelect={() => undefined}
+        syncStatus={null}
+      />
+    );
+
+    expect(screen.queryByText('Syncing…')).not.toBeInTheDocument();
+    expect(screen.queryByText('Rescanning ISRC…')).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[title="Agent working"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the inline sync status and agent pulse while refreshing', () => {
+    const { container } = render(
+      <ShellReleaseRow
+        release={fakeRelease({ id: 'r1', title: 'Syncing', previewUrl: null })}
+        isSelected={false}
+        onSelect={() => undefined}
+        syncStatus='refreshing'
+      />
+    );
+
+    expect(screen.getByText('Syncing…')).toBeInTheDocument();
+    expect(
+      container.querySelector('[title="Agent working"]')
+    ).toBeInTheDocument();
+  });
+
+  it('labels an in-flight ISRC rescan distinctly', () => {
+    render(
+      <ShellReleaseRow
+        release={fakeRelease({ id: 'r1', title: 'Rescan', previewUrl: null })}
+        isSelected={false}
+        onSelect={() => undefined}
+        syncStatus='rescanning-isrc'
+      />
+    );
+
+    expect(screen.getByText('Rescanning ISRC…')).toBeInTheDocument();
+  });
+
+  it('keeps a stable row height across idle and syncing states (no layout shift)', () => {
+    const release = fakeRelease({
+      id: 'r1',
+      title: 'Stable Row',
+      previewUrl: null,
+    });
+
+    const idle = render(
+      <ShellReleaseRow
+        release={release}
+        isSelected={false}
+        onSelect={() => undefined}
+        syncStatus={null}
+      />
+    );
+    const idleRow = idle.container.querySelector('[data-shell-release-row]');
+    expect(idleRow?.className).toContain('h-14');
+    idle.unmount();
+
+    const syncing = render(
+      <ShellReleaseRow
+        release={release}
+        isSelected={false}
+        onSelect={() => undefined}
+        syncStatus='refreshing'
+      />
+    );
+    const syncingRow = syncing.container.querySelector(
+      '[data-shell-release-row]'
+    );
+    // Same fixed row height token in both states — the sync chrome lives
+    // inside the existing single-line subtitle and an absolutely-positioned
+    // pulse, so adding it cannot reflow the row.
+    expect(syncingRow?.className).toContain('h-14');
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3483 -->

## What
Enriches the DESIGN_V1 Releases **list row** (`ShellReleaseRow`) up toward `/exp/shell-v1` fidelity using **real production data only**:

- **Release-type badge** — inline `TypeBadge` next to the title, driven by real `release.releaseType` (Single / EP / Album / Comp / Live / Mixtape / Video / Other). Falls back to `Single` for unmapped types.
- **Inline agent status + AgentPulse** — when a release is actively syncing, the artwork shows an `AgentPulse` ring and the artist line appends `· Syncing…` / `· Rescanning ISRC…` in the info-blue accent. Driven by the **real** mutation signals already in `ShellReleasesView` (`refreshingReleaseId`, `isRescanningIsrc` + `editingRelease`), plumbed through a new `getSyncStatus(id)` → `syncStatus` prop. Degrades to nothing when idle.

All shipped affordances are preserved: play overlay, smart-link lock (scheduled/cap), status badge, drop-date chip, DSP avatar stack with per-provider status, more-menu, J/K keyboard nav, right-rail drawer (JOV-1822/1823 untouched).

## Why
The shipped row already carried artwork/title/artist/status/drop-date/DSP-stack/smart-link; the genuine gaps vs. the experiment were the **type badge** and the **inline "agent is working" affordance**. These are the two highest-fidelity experiment elements that map to real data, so they were the right slice to port.

**Weekly stream count was intentionally omitted** — production `ReleaseViewModel` has no weekly-streams field (only `spotifyPopularity`), and fabricating a number violates the "no invented metrics / use real data" canon. Tracked as **JOV-3489** (Candidate follow-up: real per-release weekly-streams metric), blocked by this PR.

## Risk
Low. Additive, real-data, behind the existing DESIGN_V1 path. No new feature flag. No schema/API/auth/billing surface touched. The only non-row edit pairs `text-white dark:text-white` on the pre-existing play overlay to satisfy `no-hardcoded-theme-colors` for the now-staged file (no visual change — it always sits on a `bg-black/50` scrim).

## Layout-shift audit (mandatory)
States enumerated: idle, syncing (refresh), rescanning-ISRC, selected, playing, no-preview, no-actions, locked smart link, upcoming (drop chip) vs released. The type badge renders for **every** release (consistent across rows). The sync chrome lives inside the existing single-line subtitle (`shrink-0`, artist truncates) and an **absolutely-positioned** `AgentPulse` — neither can reflow the fixed `h-14` row. A dedicated test asserts the row keeps `h-14` across idle ↔ syncing.

## Guardrails
- **arbitrary-values ratchet**: PASS (no new arbitrary Tailwind values — only named tokens / standard spacing).
- **raw-button ratchet**: PASS (no new raw `<button>`).
- No emoji, no native dialogs, no decorative hover motion.

## Screenshots
Eyeball the preview deploy once it builds (DESIGN_V1 Releases list) — `testing` label requested for the preview/QA lane.

## Verification
```
pnpm --filter @jovie/web run typecheck -- --pretty false   # clean (0 errors)
pnpm biome check apps/web/.../shell-releases/*               # clean
pnpm --filter @jovie/web exec eslint --max-warnings=0 ...    # 0 errors, 0 warnings
vitest run ShellReleaseRow.test.tsx ShellReleasesView.test.tsx
       arbitrary-values-ratchet raw-button-ratchet           # 40 passed (4 files)
```
`ShellReleaseRow.test.tsx` gains 6 tests (type badge + fallback, idle vs syncing sync-status/pulse, ISRC label, h-14 layout-shift guard). Pre-commit hooks (lint-staged, a11y, eslint --max-warnings=0, turbo typecheck) all passed.

## Follow-up
- **JOV-3489** — Candidate: real per-release weekly-streams metric for the row (blocked by this PR).
