### PR TITLE
feat(library): add Grid/Table/List view-mode toggle (JOV-3481 slice 1)

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -536,6 +536,25 @@ const CatalogArtworkCell = memo(function CatalogArtworkCell({
 
 const libraryColumnHelper = createColumnHelper<LibraryReleaseAsset>();
 
+function createLibraryTypeColumn(
+  metaClassName: string,
+  size: number,
+  minSize: number
+) {
+  return libraryColumnHelper.display({
+    id: 'type',
+    header: 'Type',
+    cell: ({ row }) => (
+      <span className='system-b-library-meta-text truncate text-tertiary-token'>
+        {formatLibraryItemType(row.original)}
+      </span>
+    ),
+    size,
+    minSize,
+    meta: { className: metaClassName },
+  });
+}
+
 // Slice 1 minimal catalog column set: status · artwork · title · artist · type.
 // Slice 2/3 adds BPM/key/energy/rating/waveform/DSP columns + the Tracks fold-in.
 const LIBRARY_CATALOG_COLUMNS = [
@@ -582,18 +601,7 @@ const LIBRARY_CATALOG_COLUMNS = [
     enableSorting: false,
     meta: { className: 'hidden md:table-cell px-2' },
   }),
-  libraryColumnHelper.display({
-    id: 'type',
-    header: 'Type',
-    cell: ({ row }) => (
-      <span className='system-b-library-meta-text truncate text-tertiary-token'>
-        {formatLibraryItemType(row.original)}
-      </span>
-    ),
-    size: 120,
-    minSize: 96,
-    meta: { className: 'hidden sm:table-cell pl-2 pr-3' },
-  }),
+  createLibraryTypeColumn('hidden sm:table-cell pl-2 pr-3', 120, 96),
 ] as ColumnDef<LibraryReleaseAsset, unknown>[];
 
 const LIBRARY_TABLE_COLUMNS = [
@@ -622,18 +630,7 @@ const LIBRARY_TABLE_COLUMNS = [
     minSize: 108,
     meta: { className: 'hidden md:table-cell px-2' },
   }),
-  libraryColumnHelper.display({
-    id: 'type',
-    header: 'Type',
-    cell: ({ row }) => (
-      <span className='system-b-library-meta-text truncate text-tertiary-token'>
-        {formatLibraryItemType(row.original)}
-      </span>
-    ),
-    size: 104,
-    minSize: 88,
-    meta: { className: 'hidden lg:table-cell px-2' },
-  }),
+  createLibraryTypeColumn('hidden lg:table-cell px-2', 104, 88),
   libraryColumnHelper.display({
     id: 'providers',
     header: 'Providers',
@@ -1427,9 +1424,27 @@ function AssetGrid({
   );
 }
 
-function LibraryDataTable({
+function useLibraryTableRowState(selectedId: string | null) {
+  const getRowId = useMemo(() => (asset: LibraryReleaseAsset) => asset.id, []);
+  const rowSelection = useMemo<RowSelectionState>(
+    () => (selectedId ? { [selectedId]: true } : {}),
+    [selectedId]
+  );
+  const getRowClassName = useCallback(
+    (asset: LibraryReleaseAsset) =>
+      asset.id === selectedId ? 'system-b-library-table-row-selected' : '',
+    [selectedId]
+  );
+
+  return { getRowId, rowSelection, getRowClassName };
+}
+
+function LibraryReleaseTable({
   assets,
   selectedId,
+  columns,
+  hideHeader,
+  rowTestIdPrefix,
   playingPreviewId,
   onSelect,
   onTogglePreview,
@@ -1437,89 +1452,33 @@ function LibraryDataTable({
 }: {
   readonly assets: readonly LibraryReleaseAsset[];
   readonly selectedId: string | null;
-  readonly playingPreviewId: string | null;
+  readonly columns: ColumnDef<LibraryReleaseAsset, unknown>[];
+  readonly hideHeader?: boolean;
+  readonly rowTestIdPrefix: 'library-release-row' | 'library-catalog-row';
+  readonly playingPreviewId?: string | null;
   readonly onSelect: (id: string) => void;
-  readonly onTogglePreview: LibraryPreviewToggle;
+  readonly onTogglePreview?: LibraryPreviewToggle;
   readonly getContextMenuItems: LibraryContextMenuBuilder;
 }) {
   const tableData = useMemo(() => [...assets], [assets]);
   const previewContext = useMemo(
-    () => ({ playingPreviewId, onTogglePreview }),
+    () => ({
+      playingPreviewId: playingPreviewId ?? null,
+      onTogglePreview: onTogglePreview ?? noopPreviewToggle,
+    }),
     [onTogglePreview, playingPreviewId]
   );
-  const getRowId = useMemo(() => (asset: LibraryReleaseAsset) => asset.id, []);
-  const getRowTestId = useMemo(
-    () => (asset: LibraryReleaseAsset) => `library-release-row-${asset.id}`,
-    []
-  );
-  const rowSelection = useMemo<RowSelectionState>(
-    () => (selectedId ? { [selectedId]: true } : {}),
-    [selectedId]
-  );
-  const getRowClassName = useCallback(
-    (asset: LibraryReleaseAsset) =>
-      asset.id === selectedId ? 'system-b-library-table-row-selected' : '',
-    [selectedId]
+  const { getRowId, rowSelection, getRowClassName } =
+    useLibraryTableRowState(selectedId);
+  const getRowTestId = useCallback(
+    (asset: LibraryReleaseAsset) => `${rowTestIdPrefix}-${asset.id}`,
+    [rowTestIdPrefix]
   );
 
-  return (
-    <LibraryPreviewContext.Provider value={previewContext}>
-      <UnifiedTable<LibraryReleaseAsset>
-        data={tableData}
-        columns={LIBRARY_TABLE_COLUMNS}
-        onRowClick={asset => onSelect(asset.id)}
-        getRowId={getRowId}
-        getRowTestId={getRowTestId}
-        rowSelection={rowSelection}
-        getRowClassName={getRowClassName}
-        getContextMenuItems={getContextMenuItems}
-        enableVirtualization={assets.length >= 20}
-        rowHeight={LIBRARY_TABLE_ROW_HEIGHT}
-        minWidth={LIBRARY_TABLE_MIN_WIDTH}
-        hideHeader
-        className='system-b-library-table'
-        containerClassName={cn('h-full', LIBRARY_CONTENT_INSET_CLASS)}
-        skeletonRows={SKELETON_ROW_COUNT.TABLE}
-        skeletonColumnConfig={LIBRARY_TABLE_SKELETON_CONFIG}
-      />
-    </LibraryPreviewContext.Provider>
-  );
-}
-
-// Table mode: dense catalog grid with a visible column header (status · artwork
-// · title · artist · type). Distinct from List mode, which hides the header and
-// folds artwork/title/artist into a single release cell.
-function LibraryCatalogTable({
-  assets,
-  selectedId,
-  onSelect,
-  getContextMenuItems,
-}: {
-  readonly assets: readonly LibraryReleaseAsset[];
-  readonly selectedId: string | null;
-  readonly onSelect: (id: string) => void;
-  readonly getContextMenuItems: LibraryContextMenuBuilder;
-}) {
-  const tableData = useMemo(() => [...assets], [assets]);
-  const getRowId = useMemo(() => (asset: LibraryReleaseAsset) => asset.id, []);
-  const getRowTestId = useMemo(
-    () => (asset: LibraryReleaseAsset) => `library-catalog-row-${asset.id}`,
-    []
-  );
-  const rowSelection = useMemo<RowSelectionState>(
-    () => (selectedId ? { [selectedId]: true } : {}),
-    [selectedId]
-  );
-  const getRowClassName = useCallback(
-    (asset: LibraryReleaseAsset) =>
-      asset.id === selectedId ? 'system-b-library-table-row-selected' : '',
-    [selectedId]
-  );
-
-  return (
+  const table = (
     <UnifiedTable<LibraryReleaseAsset>
       data={tableData}
-      columns={LIBRARY_CATALOG_COLUMNS}
+      columns={columns}
       onRowClick={asset => onSelect(asset.id)}
       getRowId={getRowId}
       getRowTestId={getRowTestId}
@@ -1529,11 +1488,22 @@ function LibraryCatalogTable({
       enableVirtualization={assets.length >= 20}
       rowHeight={LIBRARY_TABLE_ROW_HEIGHT}
       minWidth={LIBRARY_TABLE_MIN_WIDTH}
+      hideHeader={hideHeader}
       className='system-b-library-table'
       containerClassName={cn('h-full', LIBRARY_CONTENT_INSET_CLASS)}
       skeletonRows={SKELETON_ROW_COUNT.TABLE}
       skeletonColumnConfig={LIBRARY_TABLE_SKELETON_CONFIG}
     />
+  );
+
+  if (!onTogglePreview) {
+    return table;
+  }
+
+  return (
+    <LibraryPreviewContext.Provider value={previewContext}>
+      {table}
+    </LibraryPreviewContext.Provider>
   );
 }
 
@@ -2577,16 +2547,21 @@ export function LibrarySurface({
                 getContextMenuItems={getContextMenuItems}
               />
             ) : view === 'table' ? (
-              <LibraryCatalogTable
+              <LibraryReleaseTable
                 assets={visibleAssets}
                 selectedId={selectedId}
+                columns={LIBRARY_CATALOG_COLUMNS}
+                rowTestIdPrefix='library-catalog-row'
                 onSelect={openAsset}
                 getContextMenuItems={getContextMenuItems}
               />
             ) : (
-              <LibraryDataTable
+              <LibraryReleaseTable
                 assets={visibleAssets}
                 selectedId={selectedId}
+                columns={LIBRARY_TABLE_COLUMNS}
+                hideHeader
+                rowTestIdPrefix='library-release-row'
                 playingPreviewId={playingPreviewId}
                 onSelect={openAsset}
                 onTogglePreview={handleTogglePreview}

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -23,6 +23,7 @@ import {
   Pause,
   PlayCircle,
   Shirt,
+  Table2,
   Video,
   X,
 } from 'lucide-react';
@@ -97,11 +98,13 @@ import {
   type LibraryGridDensity,
   type LibraryReleaseAsset,
   type LibraryView,
+  type LibraryViewMode,
   libraryAssetMatchesView,
 } from './library-data';
 import {
   LIBRARY_GRID_DENSITY_OPTIONS,
   useLibraryGridDensity,
+  useLibraryViewMode,
 } from './library-grid-preferences';
 import {
   countLibrarySavedViewMatches,
@@ -140,7 +143,6 @@ const LIBRARY_TABLE_SKELETON_CONFIG: Array<{
   { variant: 'text', width: '96px' },
 ];
 
-type LibraryViewMode = 'grid' | 'list';
 type LibrarySortKey = 'releaseDate' | 'title' | 'status' | 'providers';
 type LibraryPresetId = LibraryView;
 type LibraryPreviewToggle = (
@@ -520,7 +522,79 @@ const ProvidersCell = memo(function ProvidersCell({
   );
 });
 
+const CatalogArtworkCell = memo(function CatalogArtworkCell({
+  asset,
+}: {
+  readonly asset: LibraryReleaseAsset;
+}) {
+  return (
+    <span className='system-b-library-artwork-shell relative block h-9 w-9 overflow-hidden'>
+      <LibraryMediaThumbnail asset={asset} size='row' />
+    </span>
+  );
+});
+
 const libraryColumnHelper = createColumnHelper<LibraryReleaseAsset>();
+
+// Slice 1 minimal catalog column set: status · artwork · title · artist · type.
+// Slice 2/3 adds BPM/key/energy/rating/waveform/DSP columns + the Tracks fold-in.
+const LIBRARY_CATALOG_COLUMNS = [
+  libraryColumnHelper.display({
+    id: 'status',
+    header: 'Status',
+    cell: ({ row }) => <StatusCell asset={row.original} />,
+    size: 112,
+    minSize: 96,
+    meta: { className: 'pl-2.5 pr-2' },
+  }),
+  libraryColumnHelper.display({
+    id: 'artwork',
+    header: 'Artwork',
+    cell: ({ row }) => <CatalogArtworkCell asset={row.original} />,
+    size: 56,
+    minSize: 56,
+    enableSorting: false,
+    meta: { className: 'px-2' },
+  }),
+  libraryColumnHelper.accessor('title', {
+    id: 'title',
+    header: 'Title',
+    cell: ({ row }) => (
+      <span className='system-b-library-release-title block truncate'>
+        {row.original.title}
+      </span>
+    ),
+    minSize: 180,
+    size: 9999,
+    enableSorting: false,
+    meta: { className: 'px-2' },
+  }),
+  libraryColumnHelper.accessor('artist', {
+    id: 'artist',
+    header: 'Artist',
+    cell: ({ row }) => (
+      <span className='system-b-library-meta-text block truncate text-tertiary-token'>
+        {row.original.artist}
+      </span>
+    ),
+    size: 160,
+    minSize: 120,
+    enableSorting: false,
+    meta: { className: 'hidden md:table-cell px-2' },
+  }),
+  libraryColumnHelper.display({
+    id: 'type',
+    header: 'Type',
+    cell: ({ row }) => (
+      <span className='system-b-library-meta-text truncate text-tertiary-token'>
+        {formatLibraryItemType(row.original)}
+      </span>
+    ),
+    size: 120,
+    minSize: 96,
+    meta: { className: 'hidden sm:table-cell pl-2 pr-3' },
+  }),
+] as ColumnDef<LibraryReleaseAsset, unknown>[];
 
 const LIBRARY_TABLE_COLUMNS = [
   libraryColumnHelper.accessor('title', {
@@ -765,7 +839,7 @@ function LibraryRail({
 
   return (
     <nav
-      aria-label='Library filters'
+      aria-label='Library Filters'
       className={cn(
         'system-b-library-rail flex min-h-0 flex-col p-2.5',
         className
@@ -1034,20 +1108,28 @@ function ViewToggle({
   return (
     <div className={cn(PAGE_TOOLBAR_END_GROUP_CLASS, 'ml-0 gap-0.5')}>
       <PageToolbarActionButton
-        label='Grid view'
+        label='Grid View'
         icon={<Grid3x3 className={PAGE_TOOLBAR_ICON_CLASS} />}
         active={view === 'grid'}
         onClick={() => onView('grid')}
         iconOnly
-        tooltipLabel='Grid view'
+        tooltipLabel='Grid View'
       />
       <PageToolbarActionButton
-        label='List view'
+        label='List View'
         icon={<LayoutList className={PAGE_TOOLBAR_ICON_CLASS} />}
         active={view === 'list'}
         onClick={() => onView('list')}
         iconOnly
-        tooltipLabel='List view'
+        tooltipLabel='List View'
+      />
+      <PageToolbarActionButton
+        label='Table View'
+        icon={<Table2 className={PAGE_TOOLBAR_ICON_CLASS} />}
+        active={view === 'table'}
+        onClick={() => onView('table')}
+        iconOnly
+        tooltipLabel='Table View'
       />
     </div>
   );
@@ -1064,7 +1146,7 @@ function GridDensityToggle({
     <fieldset
       className={cn(PAGE_TOOLBAR_END_GROUP_CLASS, 'ml-0 gap-0.5 border-0 p-0')}
       data-testid='library-grid-density-toggle'
-      aria-label='Card size'
+      aria-label='Card Size'
     >
       {LIBRARY_GRID_DENSITY_OPTIONS.map(option => (
         <PageToolbarActionButton
@@ -1404,6 +1486,57 @@ function LibraryDataTable({
   );
 }
 
+// Table mode: dense catalog grid with a visible column header (status · artwork
+// · title · artist · type). Distinct from List mode, which hides the header and
+// folds artwork/title/artist into a single release cell.
+function LibraryCatalogTable({
+  assets,
+  selectedId,
+  onSelect,
+  getContextMenuItems,
+}: {
+  readonly assets: readonly LibraryReleaseAsset[];
+  readonly selectedId: string | null;
+  readonly onSelect: (id: string) => void;
+  readonly getContextMenuItems: LibraryContextMenuBuilder;
+}) {
+  const tableData = useMemo(() => [...assets], [assets]);
+  const getRowId = useMemo(() => (asset: LibraryReleaseAsset) => asset.id, []);
+  const getRowTestId = useMemo(
+    () => (asset: LibraryReleaseAsset) => `library-catalog-row-${asset.id}`,
+    []
+  );
+  const rowSelection = useMemo<RowSelectionState>(
+    () => (selectedId ? { [selectedId]: true } : {}),
+    [selectedId]
+  );
+  const getRowClassName = useCallback(
+    (asset: LibraryReleaseAsset) =>
+      asset.id === selectedId ? 'system-b-library-table-row-selected' : '',
+    [selectedId]
+  );
+
+  return (
+    <UnifiedTable<LibraryReleaseAsset>
+      data={tableData}
+      columns={LIBRARY_CATALOG_COLUMNS}
+      onRowClick={asset => onSelect(asset.id)}
+      getRowId={getRowId}
+      getRowTestId={getRowTestId}
+      rowSelection={rowSelection}
+      getRowClassName={getRowClassName}
+      getContextMenuItems={getContextMenuItems}
+      enableVirtualization={assets.length >= 20}
+      rowHeight={LIBRARY_TABLE_ROW_HEIGHT}
+      minWidth={LIBRARY_TABLE_MIN_WIDTH}
+      className='system-b-library-table'
+      containerClassName={cn('h-full', LIBRARY_CONTENT_INSET_CLASS)}
+      skeletonRows={SKELETON_ROW_COUNT.TABLE}
+      skeletonColumnConfig={LIBRARY_TABLE_SKELETON_CONFIG}
+    />
+  );
+}
+
 function EmptyCatalog() {
   return (
     <PageShell
@@ -1732,7 +1865,7 @@ function AssetDrawer({
       <button
         type='button'
         onClick={onClose}
-        aria-label='Close asset details'
+        aria-label='Close Asset Details'
         {...closedInteractiveProps}
         className={cn(
           'system-b-library-icon-button grid h-7 w-7 place-items-center',
@@ -2008,7 +2141,8 @@ function LibraryStatusBar({
   readonly view: LibraryViewMode;
   readonly activePreviewTitle: string | null;
 }) {
-  const viewLabel = view === 'grid' ? 'Grid' : 'List';
+  const viewLabel =
+    view === 'grid' ? 'Grid' : view === 'table' ? 'Table' : 'List';
   const idleSummary = `${SORT_LABELS[sort]} - ${viewLabel}`;
   const playbackSummary = activePreviewTitle
     ? `Playing ${activePreviewTitle}`
@@ -2048,7 +2182,7 @@ export function LibrarySurface({
   );
   const [filters, setFilters] = useState<LibraryFilters>(() => emptyFilters());
   const [sort, setSort] = useState<LibrarySortKey>('releaseDate');
-  const [view, setView] = useState<LibraryViewMode>('list');
+  const { view, setView } = useLibraryViewMode();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
@@ -2440,6 +2574,13 @@ export function LibrarySurface({
                 gridDensity={gridDensity}
                 onSelect={openAsset}
                 onTogglePreview={handleTogglePreview}
+                getContextMenuItems={getContextMenuItems}
+              />
+            ) : view === 'table' ? (
+              <LibraryCatalogTable
+                assets={visibleAssets}
+                selectedId={selectedId}
+                onSelect={openAsset}
                 getContextMenuItems={getContextMenuItems}
               />
             ) : (

--- a/apps/web/app/app/(shell)/library/library-data.ts
+++ b/apps/web/app/app/(shell)/library/library-data.ts
@@ -33,6 +33,8 @@ export type LibraryAspectRatio = '1:1' | '16:9' | '9:16';
 
 export type LibraryGridDensity = 'compact' | 'comfortable' | 'spacious';
 
+export type LibraryViewMode = 'grid' | 'list' | 'table';
+
 export type LibraryMediaOrientation = 'landscape' | 'portrait';
 
 export interface LibraryReleaseAsset {

--- a/apps/web/app/app/(shell)/library/library-grid-preferences.ts
+++ b/apps/web/app/app/(shell)/library/library-grid-preferences.ts
@@ -19,6 +19,53 @@ export const LIBRARY_GRID_DENSITY_OPTIONS: readonly {
   { value: 'spacious', label: 'L', tooltip: 'Large cards' },
 ] as const;
 
+function readStoredPreference<T extends string>(
+  storageKey: string,
+  parse: (value: string | null) => T,
+  defaultValue: T
+): T {
+  if (typeof window === 'undefined') return defaultValue;
+
+  try {
+    return parse(window.localStorage.getItem(storageKey));
+  } catch {
+    return defaultValue;
+  }
+}
+
+function writeStoredPreference(storageKey: string, value: string): void {
+  try {
+    window.localStorage.setItem(storageKey, value);
+  } catch {
+    // Ignore storage access errors.
+  }
+}
+
+function useStoredPreference<T extends string>(
+  defaultValue: T,
+  read: () => T,
+  write: (value: T) => void
+): {
+  readonly value: T;
+  readonly setValue: (value: T) => void;
+} {
+  const [value, setValueState] = useState<T>(defaultValue);
+
+  useEffect(() => {
+    setValueState(read());
+  }, [read]);
+
+  const setValue = useCallback(
+    (next: T) => {
+      setValueState(next);
+      write(next);
+    },
+    [write]
+  );
+
+  return { value, setValue };
+}
+
 function parseLibraryGridDensity(value: string | null): LibraryGridDensity {
   if (value === 'compact' || value === 'comfortable' || value === 'spacious') {
     return value;
@@ -27,43 +74,28 @@ function parseLibraryGridDensity(value: string | null): LibraryGridDensity {
 }
 
 export function readLibraryGridDensity(): LibraryGridDensity {
-  if (typeof window === 'undefined') return DEFAULT_LIBRARY_GRID_DENSITY;
-
-  try {
-    return parseLibraryGridDensity(
-      window.localStorage.getItem(LIBRARY_GRID_DENSITY_STORAGE_KEY)
-    );
-  } catch {
-    return DEFAULT_LIBRARY_GRID_DENSITY;
-  }
+  return readStoredPreference(
+    LIBRARY_GRID_DENSITY_STORAGE_KEY,
+    parseLibraryGridDensity,
+    DEFAULT_LIBRARY_GRID_DENSITY
+  );
 }
 
 export function writeLibraryGridDensity(density: LibraryGridDensity): void {
-  try {
-    window.localStorage.setItem(LIBRARY_GRID_DENSITY_STORAGE_KEY, density);
-  } catch {
-    // Ignore storage access errors.
-  }
+  writeStoredPreference(LIBRARY_GRID_DENSITY_STORAGE_KEY, density);
 }
 
 export function useLibraryGridDensity(): {
   readonly density: LibraryGridDensity;
   readonly setDensity: (density: LibraryGridDensity) => void;
 } {
-  const [density, setDensityState] = useState<LibraryGridDensity>(
-    DEFAULT_LIBRARY_GRID_DENSITY
+  const { value, setValue } = useStoredPreference(
+    DEFAULT_LIBRARY_GRID_DENSITY,
+    readLibraryGridDensity,
+    writeLibraryGridDensity
   );
 
-  useEffect(() => {
-    setDensityState(readLibraryGridDensity());
-  }, []);
-
-  const setDensity = useCallback((next: LibraryGridDensity) => {
-    setDensityState(next);
-    writeLibraryGridDensity(next);
-  }, []);
-
-  return { density, setDensity };
+  return { density: value, setDensity: setValue };
 }
 
 function parseLibraryViewMode(value: string | null): LibraryViewMode {
@@ -74,41 +106,26 @@ function parseLibraryViewMode(value: string | null): LibraryViewMode {
 }
 
 export function readLibraryViewMode(): LibraryViewMode {
-  if (typeof window === 'undefined') return DEFAULT_LIBRARY_VIEW_MODE;
-
-  try {
-    return parseLibraryViewMode(
-      window.localStorage.getItem(LIBRARY_VIEW_MODE_STORAGE_KEY)
-    );
-  } catch {
-    return DEFAULT_LIBRARY_VIEW_MODE;
-  }
+  return readStoredPreference(
+    LIBRARY_VIEW_MODE_STORAGE_KEY,
+    parseLibraryViewMode,
+    DEFAULT_LIBRARY_VIEW_MODE
+  );
 }
 
 export function writeLibraryViewMode(view: LibraryViewMode): void {
-  try {
-    window.localStorage.setItem(LIBRARY_VIEW_MODE_STORAGE_KEY, view);
-  } catch {
-    // Ignore storage access errors.
-  }
+  writeStoredPreference(LIBRARY_VIEW_MODE_STORAGE_KEY, view);
 }
 
 export function useLibraryViewMode(): {
   readonly view: LibraryViewMode;
   readonly setView: (view: LibraryViewMode) => void;
 } {
-  const [view, setViewState] = useState<LibraryViewMode>(
-    DEFAULT_LIBRARY_VIEW_MODE
+  const { value, setValue } = useStoredPreference(
+    DEFAULT_LIBRARY_VIEW_MODE,
+    readLibraryViewMode,
+    writeLibraryViewMode
   );
 
-  useEffect(() => {
-    setViewState(readLibraryViewMode());
-  }, []);
-
-  const setView = useCallback((next: LibraryViewMode) => {
-    setViewState(next);
-    writeLibraryViewMode(next);
-  }, []);
-
-  return { view, setView };
+  return { view: value, setView: setValue };
 }

--- a/apps/web/app/app/(shell)/library/library-grid-preferences.ts
+++ b/apps/web/app/app/(shell)/library/library-grid-preferences.ts
@@ -1,11 +1,13 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import type { LibraryGridDensity } from './library-data';
+import type { LibraryGridDensity, LibraryViewMode } from './library-data';
 
 export const LIBRARY_GRID_DENSITY_STORAGE_KEY = 'jovie:library-grid-density';
+export const LIBRARY_VIEW_MODE_STORAGE_KEY = 'jovie:library-view-mode';
 
 export const DEFAULT_LIBRARY_GRID_DENSITY: LibraryGridDensity = 'comfortable';
+export const DEFAULT_LIBRARY_VIEW_MODE: LibraryViewMode = 'list';
 
 export const LIBRARY_GRID_DENSITY_OPTIONS: readonly {
   readonly value: LibraryGridDensity;
@@ -62,4 +64,51 @@ export function useLibraryGridDensity(): {
   }, []);
 
   return { density, setDensity };
+}
+
+function parseLibraryViewMode(value: string | null): LibraryViewMode {
+  if (value === 'grid' || value === 'list' || value === 'table') {
+    return value;
+  }
+  return DEFAULT_LIBRARY_VIEW_MODE;
+}
+
+export function readLibraryViewMode(): LibraryViewMode {
+  if (typeof window === 'undefined') return DEFAULT_LIBRARY_VIEW_MODE;
+
+  try {
+    return parseLibraryViewMode(
+      window.localStorage.getItem(LIBRARY_VIEW_MODE_STORAGE_KEY)
+    );
+  } catch {
+    return DEFAULT_LIBRARY_VIEW_MODE;
+  }
+}
+
+export function writeLibraryViewMode(view: LibraryViewMode): void {
+  try {
+    window.localStorage.setItem(LIBRARY_VIEW_MODE_STORAGE_KEY, view);
+  } catch {
+    // Ignore storage access errors.
+  }
+}
+
+export function useLibraryViewMode(): {
+  readonly view: LibraryViewMode;
+  readonly setView: (view: LibraryViewMode) => void;
+} {
+  const [view, setViewState] = useState<LibraryViewMode>(
+    DEFAULT_LIBRARY_VIEW_MODE
+  );
+
+  useEffect(() => {
+    setViewState(readLibraryViewMode());
+  }, []);
+
+  const setView = useCallback((next: LibraryViewMode) => {
+    setViewState(next);
+    writeLibraryViewMode(next);
+  }, []);
+
+  return { view, setView };
 }

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -202,13 +202,14 @@ function renderLibraryWithSidebarOverride(
 }
 
 function clickGridView() {
-  fireEvent.click(screen.getByRole('button', { name: 'Grid view' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Grid View' }));
 }
 
 describe('LibrarySurface', () => {
   const baseMatchMedia = window.matchMedia;
 
   beforeEach(() => {
+    window.localStorage.clear();
     audioMock.playbackState = { ...audioMock.basePlaybackState };
     audioMock.toggleTrack.mockClear();
     audioMock.seek.mockClear();
@@ -486,7 +487,7 @@ describe('LibrarySurface', () => {
 
     expect(stickyCard).toBeInTheDocument();
     expect(stickyCard).toContainElement(
-      screen.getByRole('button', { name: 'Close asset details' })
+      screen.getByRole('button', { name: 'Close Asset Details' })
     );
     expect(
       within(stickyRail).getByRole('heading', { name: 'Take Me Over' })
@@ -517,7 +518,7 @@ describe('LibrarySurface', () => {
     fireEvent.click(assetCardButton);
 
     const closeButton = screen.getByRole('button', {
-      name: 'Close asset details',
+      name: 'Close Asset Details',
     });
     const openReleaseLink = screen.getByRole('link', {
       name: /Open Release/u,
@@ -566,7 +567,7 @@ describe('LibrarySurface', () => {
     expect(screen.getByRole('table')).toBeInTheDocument();
     clickGridView();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'List view' }));
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }));
 
     expect(screen.getByRole('table')).toBeInTheDocument();
     expect(
@@ -574,6 +575,59 @@ describe('LibrarySurface', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Never Say A Word')).toBeInTheDocument();
     expect(screen.getByText('Take Me Over')).toBeInTheDocument();
+  });
+
+  it('switches to the catalog table view with explicit columns and persists the choice', () => {
+    renderLibrary([
+      buildAsset(),
+      buildAsset({
+        id: 'release-2',
+        title: 'Never Say A Word',
+        artist: 'Other Artist',
+      }),
+    ]);
+
+    // Defaults to list (header hidden, release rows present).
+    expect(
+      screen.getByTestId('library-release-row-release-1')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table View' }));
+
+    // Catalog rows render with the minimal column header.
+    expect(
+      screen.getByTestId('library-catalog-row-release-1')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('library-catalog-row-release-2')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Status' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Title' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Artist' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Type' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Take Me Over')).toBeInTheDocument();
+    expect(screen.getByText('Never Say A Word')).toBeInTheDocument();
+    expect(window.localStorage.getItem('jovie:library-view-mode')).toBe(
+      'table'
+    );
+
+    // No regression: switching back to list restores release rows.
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }));
+    expect(
+      screen.getByTestId('library-release-row-release-1')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('library-catalog-row-release-1')
+    ).not.toBeInTheDocument();
+    expect(window.localStorage.getItem('jovie:library-view-mode')).toBe('list');
   });
 
   it('starts the persistent player from real production preview data', () => {
@@ -802,7 +856,7 @@ describe('LibrarySurface', () => {
     expect(screen.getByRole('button', { name: /Audio/u })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Show filters' }));
     expect(
-      screen.getByRole('navigation', { name: 'Library filters' })
+      screen.getByRole('navigation', { name: 'Library Filters' })
     ).toBeInTheDocument();
     expect(
       screen.getByTestId('library-saved-filter-views')

--- a/apps/web/tests/unit/library/library-grid-preferences.test.ts
+++ b/apps/web/tests/unit/library/library-grid-preferences.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_LIBRARY_GRID_DENSITY,
+  DEFAULT_LIBRARY_VIEW_MODE,
   LIBRARY_GRID_DENSITY_STORAGE_KEY,
+  LIBRARY_VIEW_MODE_STORAGE_KEY,
   readLibraryGridDensity,
+  readLibraryViewMode,
   writeLibraryGridDensity,
+  writeLibraryViewMode,
 } from '@/app/app/(shell)/library/library-grid-preferences';
 
 describe('library grid preferences', () => {
@@ -45,5 +49,51 @@ describe('library grid preferences', () => {
   it('falls back to the default for invalid stored values', () => {
     storage.set(LIBRARY_GRID_DENSITY_STORAGE_KEY, 'xl');
     expect(readLibraryGridDensity()).toBe(DEFAULT_LIBRARY_GRID_DENSITY);
+  });
+});
+
+describe('library view mode preferences', () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    storage.clear();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      clear: () => {
+        storage.clear();
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to list view when no preference is stored', () => {
+    expect(readLibraryViewMode()).toBe(DEFAULT_LIBRARY_VIEW_MODE);
+    expect(readLibraryViewMode()).toBe('list');
+  });
+
+  it('persists and reads grid, list, and table view modes', () => {
+    writeLibraryViewMode('grid');
+    expect(storage.get(LIBRARY_VIEW_MODE_STORAGE_KEY)).toBe('grid');
+    expect(readLibraryViewMode()).toBe('grid');
+
+    writeLibraryViewMode('table');
+    expect(readLibraryViewMode()).toBe('table');
+
+    writeLibraryViewMode('list');
+    expect(readLibraryViewMode()).toBe('list');
+  });
+
+  it('falls back to the default for invalid stored view modes', () => {
+    storage.set(LIBRARY_VIEW_MODE_STORAGE_KEY, 'gallery');
+    expect(readLibraryViewMode()).toBe(DEFAULT_LIBRARY_VIEW_MODE);
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3481 -->

## What
Adds a **Grid / Table / List** view-mode toggle to the Library asset hub (`/app/library`). This is **slice 1 of 3** of JOV-3481 (the issue explicitly splits into 2-3 PRs under the size cap).

- **3-way view toggle** in the `PageToolbar` end group (`ViewToggle`), styled exactly like the existing Grid/List `PageToolbarActionButton` control — adds a `Table View` button (`Table2` lucide icon). `LibraryViewMode` is now `'grid' | 'list' | 'table'`.
- **Grid** = existing artwork-forward `AssetCard` tiles. **List** = existing `UnifiedTable` (header hidden, artwork/title/artist folded into one release cell). **Table** = new `LibraryCatalogTable`: the same canonical `UnifiedTable` primitive with a **visible column header** and a **minimal catalog column set** on real production data — `status · artwork · title · artist · type`.
- **Persists the choice across reloads** via the existing `library-grid-preferences` localStorage pattern (new `useLibraryViewMode` hook + `jovie:library-view-mode` key), mirroring how grid density and saved views already persist.
- Smart Filters, asset-type chips, and counts keep operating in **every** mode (they live on the surface state, not the renderer). No regression to the read-only inventory; the Tracks route is untouched.

## Why
Slice 1 scaffolds the Table mode container + the 3-way toggle so the richer catalog (slice 2/3) has a home. Reusing the canonical `UnifiedTable` keeps zero new arbitrary Tailwind values and zero new raw `<button>`s (both drift ratchets pass), and avoids divergence from the experiment in `app/exp/library-v1` (read for reference only; not imported).

## Deferred to slices 2/3 (tracked under JOV-3481)
- Table-catalog rich columns: BPM / key / energy / rating / waveform / DSP — **slice 2**.
- Tracks-route fold-in into the Library table — **slice 3** (Tracks route intentionally **not** removed here).

## Risk
Low, scoped entirely to `app/app/(shell)/library/**`. Behavior-preserving: List remains the default view; Grid + List rendering paths are unchanged. Switching modes reuses the same `h-full` `UnifiedTable` container (no layout shift). Also Title-cased five pre-existing library aria-labels/toolbar labels (`Library Filters`, `Card Size`, `Close Asset Details`, `Grid View`, `List View`) that the `@jovie/canonical-ui-label-casing` lint flagged on the touched file (Shame-on-Me cleanup), and updated the matching test selectors.

## Layout-shift audit
States enumerated for the content region: grid / list / table / no-results / empty-catalog, drawer open/closed, mobile filters open/closed, ≥20 rows (virtualized) vs <20. All three populated modes mount a `UnifiedTable`/grid inside the same `min-h-0 flex-1 overflow-y-auto` column with a fixed `h-full` container, so mode switches do not reflow siblings. The grid-density toggle visibility (grid-only) is unchanged from the prior grid↔list behavior and covered by an existing test.

## Screenshots
Eyeball on the `testing`-label preview deploy (Grid / List / Table toggle on `/app/library`).

## Verification
```
pnpm --filter @jovie/web run typecheck -- --pretty false        # EXIT 0
pnpm biome check --write <edited files>                          # Checked 5 files. No fixes applied.
pnpm --filter @jovie/web exec vitest run \
  tests/unit/library/LibrarySurface.test.tsx \
  tests/unit/library/library-grid-preferences.test.ts \
  tests/unit/design-system/arbitrary-values-ratchet.test.ts \
  tests/unit/design-system/raw-button-ratchet.test.ts \
  tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
  # Test Files 5 passed (5) · Tests 34 passed (34)
```
New tests: catalog-table view switch + persistence + no-regression-back-to-list (`LibrarySurface.test.tsx`); view-mode read/write/default/invalid-fallback (`library-grid-preferences.test.ts`). Both design-system ratchets pass (no new arbitrary values, no new raw buttons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
