### PR TITLE
fix(tasks): enrich rows + fix excessive inter-row spacing

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { UserAvatar } from '@jovie/ui';
-import { Disc3 } from 'lucide-react';
+import { Disc3, Sparkles, Tag } from 'lucide-react';
 import { memo, type ReactNode } from 'react';
 import { ShellListRowFrame } from '@/components/organisms/table';
 import { DueChip } from '@/components/shell/DueChip';
@@ -10,8 +10,10 @@ import { getAccentCssVars } from '@/lib/ui/accent-palette';
 import { cn } from '@/lib/utils';
 import {
   getTaskAssigneeVisual,
+  getTaskCategoryLabel,
   getTaskPriorityVisual,
   getTaskStageVisual,
+  isTaskAgentWorking,
 } from './task-presentation';
 
 interface TaskListRowProps {
@@ -107,6 +109,36 @@ function TaskAssigneeInline({
   );
 }
 
+function TaskCategoryInline({ label }: Readonly<{ label: string }>) {
+  return (
+    <span
+      className='inline-flex min-w-0 max-w-full items-center gap-1 text-tertiary-token'
+      title={`Category ${label}`}
+    >
+      <Tag className='h-3 w-3 shrink-0' aria-hidden='true' />
+      <span className='truncate'>{label}</span>
+    </span>
+  );
+}
+
+function TaskAgentWorkingGlyph() {
+  return (
+    <span
+      className='inline-flex h-4 w-4 shrink-0 items-center justify-center text-accent-blue'
+      title='Jovie is working on this'
+    >
+      <span className='relative inline-grid h-3 w-3 place-items-center'>
+        <span
+          aria-hidden='true'
+          className='absolute inset-0 rounded-full bg-accent-blue-subtle anim-calm-halo'
+        />
+        <Sparkles className='relative h-3 w-3' strokeWidth={2.25} />
+      </span>
+      <span className='sr-only'>Jovie working</span>
+    </span>
+  );
+}
+
 export const TaskListRow = memo(function TaskListRow({
   task,
   artistName,
@@ -117,6 +149,13 @@ export const TaskListRow = memo(function TaskListRow({
   const stage = getTaskStageVisual(task.status, task.agentStatus);
   const isDone = task.status === 'done';
   const isCancelled = task.status === 'cancelled';
+  const isMuted = isDone || isCancelled;
+  const categoryLabel = getTaskCategoryLabel(task.category);
+  const agentWorking = isTaskAgentWorking(
+    task.assigneeKind,
+    task.status,
+    task.agentStatus
+  );
 
   return (
     <ShellListRowFrame
@@ -124,34 +163,47 @@ export const TaskListRow = memo(function TaskListRow({
       isSelected={isSelected}
       interaction='task-row-group'
       className={cn(
-        'group/row grid h-full grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-3 px-3 py-1 transition-[opacity] duration-subtle ease-subtle',
+        'group/row flex h-full items-center gap-3 px-3 py-1.5 transition-[opacity] duration-subtle ease-subtle',
         isDone && !isSelected && 'opacity-75',
         isCancelled && !isSelected && 'opacity-60'
       )}
     >
-      <TaskStageGlyph task={task} />
+      <span className='flex shrink-0 items-center'>
+        <TaskStageGlyph task={task} />
+      </span>
 
       <div className='min-w-0 flex-1'>
-        <p
-          className={cn(
-            'truncate text-app font-semibold leading-[17px] text-primary-token',
-            isDone && 'text-secondary-token',
-            isCancelled && 'text-tertiary-token'
-          )}
-        >
-          {task.title}
-        </p>
+        <div className='flex min-w-0 items-center gap-1.5'>
+          <p
+            className={cn(
+              'min-w-0 truncate text-app font-semibold leading-tight text-primary-token',
+              isDone && 'text-secondary-token',
+              isCancelled && 'text-tertiary-token'
+            )}
+          >
+            {task.title}
+          </p>
+          {agentWorking ? <TaskAgentWorkingGlyph /> : null}
+        </div>
 
         <div
           data-testid={`task-list-row-meta-${task.id}`}
           className='mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1 overflow-hidden text-3xs leading-none text-secondary-token'
         >
+          {task.dueAt ? (
+            <DueChip dueIso={task.dueAt.toISOString()} muted={isMuted} />
+          ) : null}
           <span className='shrink-0 truncate text-tertiary-token'>
             {stage.label}
           </span>
           <span className='shrink-0 truncate font-semibold text-tertiary-token'>
             J-{task.taskNumber}
           </span>
+          {categoryLabel ? (
+            <div className='min-w-0 max-w-full overflow-hidden text-left'>
+              <TaskCategoryInline label={categoryLabel} />
+            </div>
+          ) : null}
           <div className='min-w-0 max-w-full overflow-hidden text-left'>
             <TaskPriorityInline task={task} />
           </div>
@@ -175,17 +227,7 @@ export const TaskListRow = memo(function TaskListRow({
         </div>
       </div>
 
-      <div className='flex shrink-0 items-center justify-end gap-1.5'>
-        <div className='flex shrink-0 items-center justify-end'>
-          {task.dueAt ? (
-            <DueChip
-              dueIso={task.dueAt.toISOString()}
-              muted={isDone || isCancelled}
-            />
-          ) : null}
-        </div>
-        <div className='shrink-0'>{actionSlot}</div>
-      </div>
+      <div className='flex shrink-0 items-center justify-end'>{actionSlot}</div>
     </ShellListRowFrame>
   );
 });

--- a/apps/web/components/features/dashboard/tasks/task-presentation.test.ts
+++ b/apps/web/components/features/dashboard/tasks/task-presentation.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   getTaskAssigneeVisual,
+  getTaskCategoryLabel,
   getTaskPriorityVisual,
   getTaskStageVisual,
   getTaskStatusVisual,
+  isTaskAgentWorking,
 } from './task-presentation';
 
 describe('task-presentation', () => {
@@ -75,5 +77,30 @@ describe('task-presentation', () => {
       avatarName: 'Tim White',
       accent: 'blue',
     });
+  });
+
+  it('Title-Cases category labels and degrades on blank input', () => {
+    expect(getTaskCategoryLabel('distribution')).toBe('Distribution');
+    expect(getTaskCategoryLabel('  design ')).toBe('Design');
+    expect(getTaskCategoryLabel('')).toBeNull();
+    expect(getTaskCategoryLabel('   ')).toBeNull();
+    expect(getTaskCategoryLabel(null)).toBeNull();
+    expect(getTaskCategoryLabel(undefined)).toBeNull();
+  });
+
+  it('flags the agent-working glyph only for live Jovie in-progress work', () => {
+    expect(isTaskAgentWorking('jovie', 'in_progress', 'drafting')).toBe(true);
+    expect(isTaskAgentWorking('jovie', 'in_progress', 'queued')).toBe(true);
+    expect(isTaskAgentWorking('jovie', 'in_progress', 'awaiting_review')).toBe(
+      true
+    );
+    // Terminal / idle agent states are not "in-flight".
+    expect(isTaskAgentWorking('jovie', 'in_progress', 'idle')).toBe(false);
+    expect(isTaskAgentWorking('jovie', 'in_progress', 'approved')).toBe(false);
+    expect(isTaskAgentWorking('jovie', 'in_progress', 'failed')).toBe(false);
+    // Human-owned or non-active statuses never show the glyph.
+    expect(isTaskAgentWorking('human', 'in_progress', 'drafting')).toBe(false);
+    expect(isTaskAgentWorking('jovie', 'todo', 'drafting')).toBe(false);
+    expect(isTaskAgentWorking('jovie', 'done', 'approved')).toBe(false);
   });
 });

--- a/apps/web/components/features/dashboard/tasks/task-presentation.ts
+++ b/apps/web/components/features/dashboard/tasks/task-presentation.ts
@@ -6,6 +6,7 @@ import type {
   TaskStatus,
 } from '@/lib/tasks/types';
 import type { AccentPaletteName } from '@/lib/ui/accent-palette';
+import { capitalizeFirst } from '@/lib/utils/string-utils';
 
 export interface TaskVisualStage {
   readonly label: string;
@@ -183,3 +184,43 @@ export function getTaskPriorityMeta(
 
 // DEPRECATION: use getTaskAssigneeVisual instead.
 export const getTaskAssigneeMeta = getTaskAssigneeVisual;
+
+/**
+ * Agent statuses where Jovie is actively working the task. These drive
+ * the inline "agent working" glyph on the row so a returning user can
+ * see at a glance which queue items have a live thread. Terminal states
+ * (idle/approved/failed) are excluded — the glyph signals *in-flight*
+ * work, not history.
+ */
+const ACTIVE_AGENT_STATUSES = new Set<TaskAgentStatus>([
+  'queued',
+  'drafting',
+  'awaiting_review',
+]);
+
+export function isTaskAgentWorking(
+  assigneeKind: TaskAssigneeKind,
+  status: TaskStatus,
+  agentStatus: TaskAgentStatus
+): boolean {
+  return (
+    assigneeKind === 'jovie' &&
+    status === 'in_progress' &&
+    ACTIVE_AGENT_STATUSES.has(agentStatus)
+  );
+}
+
+/**
+ * Presentational label for a task category (design / lyric / video /
+ * distribution …). Categories are free-form strings on the task record;
+ * this normalizes whitespace and Title-Cases the first word for display
+ * per the UI casing rules. Returns null when the category is absent or
+ * blank so callers can render nothing without a layout placeholder.
+ */
+export function getTaskCategoryLabel(
+  category: string | null | undefined
+): string | null {
+  const trimmed = category?.trim();
+  if (!trimmed) return null;
+  return capitalizeFirst(trimmed);
+}

--- a/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TaskListRow } from '@/components/features/dashboard/tasks/TaskListRow';
 import { fastRender } from '@/tests/utils/fast-render';
@@ -78,11 +78,11 @@ describe('TaskListRow', () => {
     );
   });
 
-  it('renders shell due metadata through the compact chip contract', () => {
+  it('renders shell due metadata inline inside the wrapping meta row', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-04-25T12:00:00.000Z'));
 
-    const { getByText } = fastRender(
+    const { getByText, getByTestId } = fastRender(
       <TaskListRow
         task={{
           ...mockTask,
@@ -96,5 +96,60 @@ describe('TaskListRow', () => {
     const dueChip = getByText('Due tomorrow').closest('span');
     expect(dueChip).toHaveClass('uppercase');
     expect(dueChip?.parentElement?.className).toContain('h-5');
+    // The due chip now lives in the inline meta row, not a separate right rail.
+    expect(getByTestId('task-list-row-meta-task-1')).toContainElement(
+      dueChip as HTMLElement
+    );
+  });
+
+  it('renders a Title-Cased category label when present and nothing when absent', () => {
+    const withCategory = fastRender(
+      <TaskListRow
+        task={{ ...mockTask, category: 'distribution' }}
+        artistName='Tim White'
+        onOpenRelease={vi.fn()}
+      />
+    );
+    expect(
+      within(withCategory.container).getByText('Distribution')
+    ).toBeInTheDocument();
+
+    const withoutCategory = fastRender(
+      <TaskListRow
+        task={{ ...mockTask, category: null }}
+        artistName='Tim White'
+        onOpenRelease={vi.fn()}
+      />
+    );
+    expect(
+      within(withoutCategory.container).queryByText('Distribution')
+    ).toBeNull();
+  });
+
+  it('shows the agent-working glyph only for live Jovie in-progress work', () => {
+    const working = fastRender(
+      <TaskListRow
+        task={{
+          ...mockTask,
+          assigneeKind: 'jovie',
+          status: 'in_progress',
+          agentStatus: 'drafting',
+        }}
+        artistName='Tim White'
+        onOpenRelease={vi.fn()}
+      />
+    );
+    expect(
+      within(working.container).getByText('Jovie working')
+    ).toBeInTheDocument();
+
+    const human = fastRender(
+      <TaskListRow
+        task={{ ...mockTask, assigneeKind: 'human', agentStatus: 'idle' }}
+        artistName='Tim White'
+        onOpenRelease={vi.fn()}
+      />
+    );
+    expect(within(human.container).queryByText('Jovie working')).toBeNull();
   });
 });

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3061,
-  "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count. Corrected 3057→3061 on 2026-06-23: #11689 set the baseline 4 below the true post-sweep count and was admin-merged past its own red ratchet, leaving main RED and failing every PR's Unit Tests. Drive back down via JOV-3466 (tokenize the 4 stragglers)."
+  "count": 3059,
+  "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count. Corrected 3057→3061 on 2026-06-23: #11689 set the baseline 4 below the true post-sweep count and was admin-merged past its own red ratchet, leaving main RED and failing every PR's Unit Tests. Drive back down via JOV-3466 (tokenize the 4 stragglers). 3061→3059 on 2026-06-23 (JOV-3484): TaskListRow dropped grid-cols-[…] + leading-[17px] arbitrary values when converging to a flex layout."
 }


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3484 -->

## What
Tighten + enrich the shipped Tasks list rows to `/exp/shell-v1` density and fix the excessive vertical gap between rows.

- **Fixed the inter-row spacing bug.** Rows are now compact and uniform (verified in-browser: **125px -> 56px** per row).
- **Inline due-chip** moved into the wrapping meta row (from real `task.dueAt`).
- **Category label** added (`task.category`), Title-Cased, with a tag glyph.
- **Agent-working glyph** (animated `Sparkles` + `anim-calm-halo`) shown next to the title when Jovie is actively running the task (`agentStatus` in `queued` / `drafting` / `awaiting_review`).
- All new fields **degrade cleanly when absent** — no placeholder, no layout shift.

## Why
The list row used `grid grid-cols-[1.25rem_minmax(0,1fr)_auto]`. The `minmax(0,1fr)` arbitrary value never reached the generated Tailwind CSS, so the computed `grid-template-columns` collapsed to a single column and the three children **stacked vertically into implicit grid rows** with a 12px (`gap-3`) row gap. Each row ballooned to ~125px against ~35px of real content — the "excessive vertical gap" reported in JOV-3484.

Converting to a named-token `flex items-center gap-3` layout fixes the root cause and removes the broken arbitrary value at the same time.

## Screenshots
Before (125px gap bug):

![before](https://raw.githubusercontent.com/JovieInc/Jovie/screenshots-jov-3484/shots/before.png)

After (compact, uniform 56px rows):

![after](https://raw.githubusercontent.com/JovieInc/Jovie/screenshots-jov-3484/shots/after.png)

Split-pane detail still opens on row select (selection highlight + nav arrows top-right), keyboard nav unchanged:

![detail](https://raw.githubusercontent.com/JovieInc/Jovie/screenshots-jov-3484/shots/detail-open.png)

> Eyeball the preview deploy for taste approval. The two seed fixtures have no category/due/agent fields, so the enrichment isn't visible in the screenshots — it renders for tasks that have those fields and is covered by unit tests.

## Scope / what is NOT in this PR
- The matching **mobile loading skeleton** in `TasksPageClient.tsx` still uses the same broken `grid-cols-[…]` (mobile-only `TaskLoadingState`, separate from the desktop `UnifiedTable` skeleton). Reverted out of this PR to keep it within lint-clean files and avoid touching pre-existing copy-casing lint debt in that file. Tracked as **JOV-3490**.
- `TaskBoard.tsx` retains a pre-existing `leading-[17px]` on its kanban card title (different surface, not the list row).

## Risk
Low. Pure presentational change to one list-row component + a presentation helper; no data model, server, or keyboard-nav changes (J/K/arrow/Enter/Esc and split-pane detail are owned by `UnifiedTable` and untouched). Layout-shift audited: the agent glyph is `h-4` and fits inside the title line box (measured 0px shift); category/due chips live in the existing `flex-wrap` meta line.

## Verification
- `pnpm --filter @jovie/web run typecheck -- --pretty false` -> **0 errors**
- `pnpm biome check` on edited files -> **clean**
- `vitest run` (TaskListRow.test, task-presentation.test, TaskRowActionMenu.test, arbitrary-values-ratchet, raw-button-ratchet) -> **18 passed**
- Arbitrary-values ratchet baseline lowered **3061 -> 3059** (dropped `grid-cols-[…]` + `leading-[17px]`). Raw-button count unchanged (712).
- In-browser: rows measured **56px** uniform (was 125px); split-pane detail opens on select; no console errors (only stale HMR socket warnings from a dev-server restart).
