### PR TITLE
feat(shell): cinematic reveal for the persistent audio bar (JOV-3482)

### DIFF
--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -17,6 +17,7 @@ import {
   resolveLyricsReturnRoute,
 } from '@/constants/routes';
 import { useAppFlag } from '@/lib/flags/client';
+import { useReducedMotion } from '@/lib/hooks/useReducedMotion';
 import { cn } from '@/lib/utils';
 import { formatDuration } from '@/lib/utils/formatDuration';
 import { isFormElement } from '@/lib/utils/keyboard';
@@ -63,9 +64,16 @@ export function PersistentAudioBar({
     stop,
     onError,
   } = useTrackAudioPlayer();
+  const prefersReducedMotion = useReducedMotion();
   const [imgError, setImgError] = useState(false);
   const [barCollapsed, setBarCollapsed] = useState(false);
   const [waveformOn, setWaveformOn] = useState(true);
+  // Cinematic reveal (JOV-3487): the shell bar lands into place from the
+  // bottom on first play. Starts un-revealed so the CSS transition has an
+  // off-screen "from" frame to interpolate from; flips to revealed on the
+  // next frame after a track becomes active. Resets per track so a fresh
+  // track replays the reveal even without an unmount.
+  const [revealed, setRevealed] = useState(false);
   const lastNonLyricsPathRef = useRef<string>(APP_ROUTES.LIBRARY);
   const currentPathWithSearch = useMemo(() => {
     if (!pathname) return APP_ROUTES.LIBRARY;
@@ -87,6 +95,31 @@ export function PersistentAudioBar({
   useEffect(() => {
     setBarCollapsed(false);
   }, [playbackState.activeTrackId]);
+
+  // Drive the cinematic reveal. No active track → no reveal (un-revealed so
+  // the next first-play animates in). Reduced motion → snap revealed (no
+  // translate frame ever paints). Otherwise paint one un-revealed frame, then
+  // flip to revealed on the next animation frame so the bar decelerates into
+  // place from below.
+  useEffect(() => {
+    if (!playbackState.activeTrackId) {
+      setRevealed(false);
+      return;
+    }
+    if (prefersReducedMotion) {
+      setRevealed(true);
+      return;
+    }
+    setRevealed(false);
+    let secondFrame = 0;
+    const firstFrame = requestAnimationFrame(() => {
+      secondFrame = requestAnimationFrame(() => setRevealed(true));
+    });
+    return () => {
+      cancelAnimationFrame(firstFrame);
+      if (secondFrame) cancelAnimationFrame(secondFrame);
+    };
+  }, [playbackState.activeTrackId, prefersReducedMotion]);
 
   useEffect(() => {
     if (!isLyricsRoutePath(pathname) && pathname) {
@@ -376,8 +409,15 @@ export function PersistentAudioBar({
           maxHeight: barCollapsed
             ? 0
             : 'var(--linear-app-audio-bar-max-height)',
-          opacity: barCollapsed ? 0 : 1,
-          transform: barCollapsed ? 'translateY(10px)' : 'translateY(0)',
+          opacity: revealed && !barCollapsed ? 1 : 0,
+          transform: !revealed
+            ? 'translateY(100%)'
+            : barCollapsed
+              ? 'translateY(10px)'
+              : 'translateY(0)',
+          // Keyed on collapse only — the reveal is purely visual (transform +
+          // opacity), so the bar stays interactive the instant it mounts
+          // rather than waiting out the slide-in.
           pointerEvents: barCollapsed ? 'none' : 'auto',
           transition: SHELL_AUDIO_BAR_TRANSITION,
         }}

--- a/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
+++ b/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -73,6 +74,11 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push }),
 }));
 
+let mockPrefersReducedMotion = false;
+vi.mock('@/lib/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockPrefersReducedMotion,
+}));
+
 vi.mock('@/components/atoms/TruncatedText', () => ({
   TruncatedText: ({ children }: { children: ReactNode }) => (
     <span>{children}</span>
@@ -142,8 +148,17 @@ describe('PersistentAudioBar', () => {
     pathname = '/app';
     searchParams = new URLSearchParams();
     mockPlaybackState = { ...basePlaybackState };
+    mockPrefersReducedMotion = false;
     resetAudioChromeSnapshot();
   });
+
+  /** Flush the two requestAnimationFrame ticks the cinematic reveal waits on. */
+  async function flushReveal() {
+    await act(async () => {
+      await new Promise(resolve => requestAnimationFrame(() => resolve(null)));
+      await new Promise(resolve => requestAnimationFrame(() => resolve(null)));
+    });
+  }
 
   it('renders nothing when no track is active', () => {
     const { container } = render(<PersistentAudioBar />);
@@ -579,5 +594,55 @@ describe('PersistentAudioBar', () => {
     expect(push).toHaveBeenCalledWith(
       resolveLyricsReturnRoute(searchParams.get('from'), APP_ROUTES.CHAT)
     );
+  });
+
+  it('cinematically reveals the shell V1 bar into place on first play', async () => {
+    setPlaying({ artistName: 'DJ Cool' });
+
+    render(<PersistentAudioBar variant='shellChatV1' />);
+
+    const expandedSurface = screen.getByTestId('audio-surface-expanded-shell');
+
+    // First frame: off the bottom + transparent so the transition has a
+    // "from" state to decelerate out of.
+    expect(expandedSurface.style.transform).toBe('translateY(100%)');
+    expect(expandedSurface.style.opacity).toBe('0');
+
+    await flushReveal();
+
+    // Lands into place: no translate offset, fully opaque, interactive.
+    expect(expandedSurface.style.transform).toBe('translateY(0)');
+    expect(expandedSurface.style.opacity).toBe('1');
+    expect(expandedSurface.style.pointerEvents).toBe('auto');
+  });
+
+  it('keeps the reserved bar height across the reveal so nothing shifts', async () => {
+    setPlaying({ artistName: 'DJ Cool' });
+
+    render(<PersistentAudioBar variant='shellChatV1' />);
+
+    const expandedSurface = screen.getByTestId('audio-surface-expanded-shell');
+    const reservedHeight = 'var(--linear-app-audio-bar-max-height)';
+
+    // Height is reserved from the very first frame (only transform/opacity
+    // animate), so surrounding content never reflows.
+    expect(expandedSurface.style.maxHeight).toBe(reservedHeight);
+
+    await flushReveal();
+
+    expect(expandedSurface.style.maxHeight).toBe(reservedHeight);
+  });
+
+  it('snaps the shell V1 bar revealed without a translate frame under reduced motion', () => {
+    mockPrefersReducedMotion = true;
+    setPlaying({ artistName: 'DJ Cool' });
+
+    render(<PersistentAudioBar variant='shellChatV1' />);
+
+    const expandedSurface = screen.getByTestId('audio-surface-expanded-shell');
+
+    // No translateY(100%) frame ever paints — it's already in place.
+    expect(expandedSurface.style.transform).toBe('translateY(0)');
+    expect(expandedSurface.style.opacity).toBe('1');
   });
 });


### PR DESCRIPTION
## What
The persistent audio bar — already mounted globally in the `(shell)` layout, so it persists across releases/library/tasks/lyrics/chats/dashboard — now **lands into place** on first play with the canonical **cinematic** motion intent: slides up from `translateY(100%)` + fades in, decelerating via `var(--ds-motion-cinematic-easing)` / `-duration` so you "feel" the movement land. Resets per track. Respects `prefers-reduced-motion`.

## Why
JOV-3482 (global audio bar — satisfied by the existing shell mount) + **JOV-3487** (cinematic reveal easing). DESIGN.md prescribes the `cinematic` intent for "audio player open/close."

## Risk
Low — transform/opacity only; `max-height` stays reserved so **no layout shift**; bar interactive immediately.

## Screenshots
Eyeball the preview deploy — start playback from any shell surface and watch the bar slide up.

## Verification
typecheck clean · biome clean · 27 PersistentAudioBar tests (incl. new reveal test) + arbitrary-values & raw-button ratchets green.

<!-- linear-issue-id:JOV-3482 -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)