### PR TITLE
perf(ci): shard unit tests 6→10 to cut merge-queue critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2631,7 +2631,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
+        shard: ['1/10', '2/10', '3/10', '4/10', '5/10', '6/10', '7/10', '8/10', '9/10', '10/10']
     outputs:
       run_full_ci: ${{ steps.check_changes.outputs.run_full_ci }}
     steps:
@@ -2672,7 +2672,7 @@ jobs:
           VITEST_CI_FLAGS="--pool=forks --maxWorkers=2"
           # Retry budget comes from apps/web/tests/quarantine.json
           RETRY_FLAG="--retry=${{ steps.quarantine.outputs.unit_default_retries }}"
-          # Use shard-specific output file so Codecov Test Analytics receives all 6 shards
+          # Use shard-specific output file so Codecov Test Analytics receives all 10 shards
           # (a shared filename causes only the last upload to be recorded)
           # Note: vitest runs from apps/web/, so path is relative to that directory
           SHARD_SLUG="${{ matrix.shard }}"


### PR DESCRIPTION
## What
Bump the unit-test matrix from **6 → 10 shards** (`.github/workflows/ci.yml`).

## Why
Measured the merge path: **Unit Tests is 100% of the Graphite merge batch wall-clock (~7 min)**. Build (4m07) and Typecheck (4m05) run in parallel and finish ~3 min earlier — the batch just waits on unit tests.

| Job (merge batch) | Time | On critical path |
|---|---|---|
| Unit Tests ×6 | ~7 min | **yes — sole long pole** |
| Build (public routes) | 4m07 | hidden (parallel) |
| Typecheck | 4m05 | hidden (parallel) |
| everything else | <2 min | hidden |

Shards are balanced (7m12 vs 6m39 = 33s spread), so more shards scale near-linearly. 6→10 → batch **~4.6 min** (just above the ~4 min build/typecheck floor). Going past 10 only wastes runner-minutes since that floor takes over.

## Cost: $0
- Public-repo GitHub Actions minutes are free.
- Unit-test shards create **no Neon branches** (`test:fast`, no DB), so no Neon-limit pressure from the extra runners.

## Safety (merge gate)
- Only `PR Ready`, `Migration Guard`, `Fork PR Gate`, `PR Size Guard` are required (ruleset *Main Branch Protection*).
- `PR Ready` gates unit tests via `needs: [... ci-unit-tests ...]` — the **job ID**. GitHub rolls all matrix shards into one job result (success iff all shards pass), so shard count is invisible to the gate. No per-`(x/6)` context is pinned.
- Flakiness normalizer already strips `(x/N) → Unit Tests` for any N.

## Verification
- `actionlint` clean on changed lines (only pre-existing info/style findings remain), YAML parses, `pnpm ci:harness:check` passes.
- This PR's own CI run will execute with 10 shards — compare the `Unit Tests` job times to confirm ~4.6 min.

## Follow-up
After this lands and p95 settles, lock the win by updating the CI duration ratchet baseline (`node scripts/ci-duration-ratchet.mjs update --p95 <seconds>`). Lower p95 passes the ratchet either way, so non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)