### PR TITLE
refactor(chat): unify conversation surface naming on "Chats" (JOV-3485)

### DIFF
--- a/apps/web/app/app/(shell)/chat/[id]/chat-thread-metadata-data.ts
+++ b/apps/web/app/app/(shell)/chat/[id]/chat-thread-metadata-data.ts
@@ -6,7 +6,7 @@ import { sanitizeConversationTitle } from '@/lib/chat/title';
 import { db } from '@/lib/db';
 import { chatConversations } from '@/lib/db/schema/chat';
 
-export const CHAT_THREAD_TITLE_FALLBACK = 'Conversation';
+export const CHAT_THREAD_TITLE_FALLBACK = 'Chat';
 
 export async function loadChatThreadTitle(
   conversationId: string

--- a/apps/web/app/app/(shell)/chat/[id]/page.tsx
+++ b/apps/web/app/app/(shell)/chat/[id]/page.tsx
@@ -11,7 +11,7 @@ interface Props {
   }>;
 }
 
-const CONVERSATION_DESCRIPTION = 'Conversation with Jovie AI';
+const CONVERSATION_DESCRIPTION = 'Chat with Jovie AI';
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;

--- a/apps/web/app/app/(shell)/chats/page.tsx
+++ b/apps/web/app/app/(shell)/chats/page.tsx
@@ -11,7 +11,7 @@ export default async function ChatsPage() {
     route: APP_ROUTES.CHATS,
     dashboardErrorLogMessage: 'Dashboard data load failed on chats page',
     dashboardErrorMessage:
-      'Failed to load conversations data. Please refresh the page.',
+      'Failed to load chats data. Please refresh the page.',
   });
   if (!routeContext.ok) {
     return routeContext.error;

--- a/apps/web/app/app/(shell)/dashboard/profile/ProfilePageChat.tsx
+++ b/apps/web/app/app/(shell)/dashboard/profile/ProfilePageChat.tsx
@@ -24,7 +24,7 @@ function ProfilePageChatFallback() {
             Something went wrong loading the conversation. Please try again.
           </p>
           <DashboardHeaderActionButton
-            ariaLabel='Reload Conversation'
+            ariaLabel='Reload Chat'
             onClick={() => router.refresh()}
             icon={<RefreshCw className='h-4 w-4' />}
             label='Reload'
@@ -54,7 +54,7 @@ function ProfilePageChatInner() {
                 We hit a problem loading your profile. Please retry in a moment.
               </p>
               <DashboardHeaderActionButton
-                ariaLabel='Retry Loading Profile Conversation'
+                ariaLabel='Retry Loading Profile Chat'
                 onClick={() => router.refresh()}
                 icon={<RefreshCw className='h-4 w-4' />}
                 label='Retry'

--- a/apps/web/app/app/(shell)/page.tsx
+++ b/apps/web/app/app/(shell)/page.tsx
@@ -5,7 +5,7 @@ import { HydrateClient } from '@/lib/queries/HydrateClient';
 import { getDehydratedState } from '@/lib/queries/server';
 import { DeferredChatPageClient } from './chat/DeferredChatPageClient';
 
-const DASHBOARD_DESCRIPTION = 'Start a new conversation with Jovie AI';
+const DASHBOARD_DESCRIPTION = 'Start a new chat with Jovie AI';
 const DASHBOARD_TITLE = 'Home';
 
 export function generateMetadata(): Metadata {

--- a/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
+++ b/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
@@ -114,9 +114,9 @@ export function ChatsPageClient() {
           deleteConversation.mutateAsync({ conversationId: thread.id })
         )
       );
-      notifications.success('All conversations archived');
+      notifications.success('All chats archived');
     } catch {
-      notifications.error('Could not archive all conversations');
+      notifications.error('Could not archive all chats');
     }
   }, [deleteConversation, notifications, sidebarThreads]);
 
@@ -134,8 +134,8 @@ export function ChatsPageClient() {
             <AppSearchField
               value={query}
               onChange={setQuery}
-              placeholder='Search conversations'
-              ariaLabel='Search Conversations'
+              placeholder='Search chats'
+              ariaLabel='Search Chats'
               className='max-w-2xl flex-1'
               inputClassName='text-app'
             />
@@ -147,19 +147,19 @@ export function ChatsPageClient() {
                   size='sm'
                   onClick={() => setArchiveAllOpen(true)}
                 >
-                  Archive All Conversations
+                  Archive All Chats
                 </Button>
               ) : null}
               <Button asChild variant='secondary' size='sm'>
-                <Link href={APP_ROUTES.CHAT}>New Conversation</Link>
+                <Link href={APP_ROUTES.CHAT}>New Chat</Link>
               </Button>
             </div>
           </div>
           <div className='mt-2 flex items-center gap-3 text-2xs text-tertiary-token'>
-            <span>{sidebarThreads.length} conversations</span>
+            <span>{sidebarThreads.length} chats</span>
             <span className='inline-flex items-center gap-1'>
               <Search className='h-3 w-3' />
-              Search is local to conversation titles and statuses
+              Search is local to chat titles and statuses
             </span>
             {unreadCount > 0 ? <span>{unreadCount} unread</span> : null}
           </div>
@@ -170,8 +170,8 @@ export function ChatsPageClient() {
             <ChatListSkeleton />
           ) : isError ? (
             <PageErrorState
-              title='Unable to load conversations'
-              message='We could not load your recent conversations. Retry the request or refresh the page.'
+              title='Unable to load chats'
+              message='We could not load your recent chats. Retry the request or refresh the page.'
               error={error instanceof Error ? error : undefined}
               actionLabel='Retry load'
               onRetry={() => {
@@ -187,16 +187,16 @@ export function ChatsPageClient() {
               <div className='max-w-sm space-y-3'>
                 <p className='text-sm font-semibold text-primary-token'>
                   {normalizedQuery
-                    ? `No conversations match "${trimmedQuery}".`
-                    : 'No conversations yet'}
+                    ? `No chats match "${trimmedQuery}".`
+                    : 'No chats yet'}
                 </p>
                 <p className='text-app leading-6 text-secondary-token'>
                   {normalizedQuery
                     ? 'Clear the search or try a different phrase.'
-                    : 'Start a new conversation and it will appear here.'}
+                    : 'Start a new chat and it will appear here.'}
                 </p>
                 <Button asChild variant='secondary' size='sm'>
-                  <Link href={APP_ROUTES.CHAT}>New Conversation</Link>
+                  <Link href={APP_ROUTES.CHAT}>New Chat</Link>
                 </Button>
               </div>
             </div>
@@ -219,8 +219,8 @@ export function ChatsPageClient() {
       <ConfirmDialog
         open={archiveAllOpen}
         onOpenChange={setArchiveAllOpen}
-        title='Archive all conversations?'
-        description={`This will archive ${sidebarThreads.length} conversation${sidebarThreads.length === 1 ? '' : 's'}. You cannot undo this action.`}
+        title='Archive all chats?'
+        description={`This will archive ${sidebarThreads.length} chat${sidebarThreads.length === 1 ? '' : 's'}. You cannot undo this action.`}
         confirmLabel='Archive All'
         variant='destructive'
         onConfirm={handleArchiveAll}

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -46,11 +46,11 @@ export const dashboardHome: NavItem = {
   href: APP_ROUTES.CHAT,
   id: 'overview',
   icon: Home,
-  description: 'Start a new conversation',
+  description: 'Start a new chat',
 };
 
 export const newThreadNavItem: NavItem = {
-  name: 'New Conversation',
+  name: 'New Chat',
   href: APP_ROUTES.CHAT,
   id: 'chat',
   icon: SquarePen,

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -560,7 +560,7 @@ export function useJovieChat({
     const errorMessage =
       existingConversationError instanceof Error
         ? existingConversationError.message
-        : 'Conversation failed to load';
+        : 'Chat failed to load';
     const failureKey = `${activeConversationId}:${errorMessage}`;
     if (lastConversationLoadFailureRef.current === failureKey) return;
     lastConversationLoadFailureRef.current = failureKey;

--- a/apps/web/components/organisms/CommandPalette.tsx
+++ b/apps/web/components/organisms/CommandPalette.tsx
@@ -87,15 +87,15 @@ function CommandPaletteInner({ profileId }: CommandPaletteInnerProps) {
     if (conversations && conversations.length > 0) {
       sections.push({
         id: 'recent-chats',
-        label: 'Recent Conversations',
+        label: 'Recent Chats',
         items: conversations.map(convo => {
           const entity: EntityRef = {
             kind: 'track', // Reuses the generic Music2 fallback art.
             id: `thread:${convo.id}`,
-            label: convo.title || 'Untitled conversation',
+            label: convo.title || 'Untitled chat',
             meta: {
               kind: 'track',
-              subtitle: 'Conversation',
+              subtitle: 'Chat',
             },
           };
           return { kind: 'entity', entity };

--- a/apps/web/components/shell/EntityThreadGlyph.test.tsx
+++ b/apps/web/components/shell/EntityThreadGlyph.test.tsx
@@ -23,9 +23,7 @@ describe('EntityThreadGlyph', () => {
         <EntityThreadGlyph threadTitle='t' onOpen={onOpen} />
       </div>
     );
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Open Running Conversation' })
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Open Running Chat' }));
     expect(onOpen).toHaveBeenCalledOnce();
     expect(onParentClick).not.toHaveBeenCalled();
   });

--- a/apps/web/components/shell/EntityThreadGlyph.tsx
+++ b/apps/web/components/shell/EntityThreadGlyph.tsx
@@ -34,7 +34,7 @@ export interface EntityThreadGlyphProps {
 export function EntityThreadGlyph({
   threadTitle,
   onOpen,
-  tooltipLabel = 'Jovie working — open conversation',
+  tooltipLabel = 'Jovie working — open chat',
 }: EntityThreadGlyphProps) {
   return (
     <Tooltip label={tooltipLabel}>
@@ -44,7 +44,7 @@ export function EntityThreadGlyph({
           e.stopPropagation();
           onOpen();
         }}
-        aria-label='Open Running Conversation'
+        aria-label='Open Running Chat'
         className='shrink-0 inline-flex items-center justify-center h-5 w-5 rounded text-cyan-300/85 hover:text-cyan-200 hover:bg-surface-1/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token transition-colors duration-subtle ease-subtle'
       >
         <span className='relative inline-grid place-items-center h-3 w-3'>

--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -64,7 +64,7 @@ describe('SidebarThreadsSection', () => {
 
     const threadLink = screen.getByRole('link', { name: 'Pitch tasks' });
     const actionsButton = screen.getByRole('button', {
-      name: 'Conversation Actions for Pitch tasks',
+      name: 'Chat Actions for Pitch tasks',
     });
 
     fireEvent.contextMenu(threadLink);
@@ -91,7 +91,7 @@ describe('SidebarThreadsSection', () => {
     );
 
     const allThreadsLink = screen.getByRole('link', {
-      name: 'All Conversations',
+      name: 'All Chats',
     });
 
     expect(allThreadsLink).toHaveAttribute('href', APP_ROUTES.CHATS);
@@ -139,7 +139,7 @@ describe('SidebarThreadsSection', () => {
     );
 
     const newThreadButton = screen.getByRole('button', {
-      name: 'New Conversation',
+      name: 'New Chat',
     });
 
     fireEvent.click(newThreadButton);

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -146,7 +146,7 @@ export function toSidebarThread(
   return {
     id: conversation.id,
     href: `${APP_ROUTES.CHAT}/${encodeURIComponent(conversation.id)}`,
-    title: conversation.title?.trim() || 'Untitled conversation',
+    title: conversation.title?.trim() || 'Untitled chat',
     status: getSidebarThreadStatus(latestTurnStatus),
     updatedAt: conversation.updatedAt,
     unread,
@@ -268,11 +268,11 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
         )}
       </Tooltip>
       {onThreadContextMenu ? (
-        <Tooltip label='Conversation Actions' side='right'>
+        <Tooltip label='Chat Actions' side='right'>
           <button
             type='button'
             onClick={e => onThreadContextMenu(e, thread)}
-            aria-label={`Conversation Actions for ${thread.title}`}
+            aria-label={`Chat Actions for ${thread.title}`}
             className={cn(
               'absolute right-1 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-full text-quaternary-token transition-[background-color,color,opacity] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
               'opacity-0 group-hover/thread:opacity-100 focus-visible:opacity-100'
@@ -325,7 +325,7 @@ export function SidebarThreadsSection({
     <div className='space-y-1.5'>
       <div className='flex items-center justify-between border-t border-[color-mix(in_oklab,var(--linear-app-frame-seam)_44%,transparent)] px-2.5 pb-0.5 pt-2'>
         <span className='text-3xs font-semibold uppercase tracking-[0.08em] text-quaternary-token'>
-          Conversations
+          Chats
         </span>
         {unreadCount > 0 && (
           <span className='inline-flex items-center gap-1 text-2xs font-medium text-quaternary-token'>
@@ -366,7 +366,7 @@ export function SidebarThreadsSection({
               <button
                 type='button'
                 onClick={onRetry}
-                aria-label='Retry Conversations'
+                aria-label='Retry Chats'
                 className='grid h-5 w-5 shrink-0 place-items-center rounded text-quaternary-token transition-[background-color] duration-subtle ease-subtle hover:bg-sidebar-accent/55 hover:text-primary-token'
               >
                 <RefreshCw
@@ -396,7 +396,7 @@ export function SidebarThreadsSection({
               strokeWidth={2.25}
             />
             <span className='min-w-0 truncate justify-self-start'>
-              New Conversation
+              New Chat
             </span>
           </button>
         ) : null}
@@ -435,7 +435,7 @@ export function SidebarThreadsSection({
               strokeWidth={2.25}
             />
             <span className='min-w-0 truncate justify-self-start'>
-              All Conversations
+              All Chats
             </span>
           </Link>
         ) : null}

--- a/apps/web/components/shell/ThreadView.tsx
+++ b/apps/web/components/shell/ThreadView.tsx
@@ -17,7 +17,7 @@ export interface ThreadViewProps {
   readonly thread: ThreadViewData;
   /** Rendered turns / cards (typically `<ThreadTurn>`s and `<Thread*Card>`s). */
   readonly children: ReactNode;
-  /** Composer slot — defaults to `<ThreadComposer placeholder="Reply to this conversation..." />`. */
+  /** Composer slot — defaults to `<ThreadComposer placeholder="Reply to this chat..." />`. */
   readonly composer?: ReactNode;
   /** Submit handler forwarded to the default ThreadComposer. */
   readonly onComposerSubmit?: (text: string) => void;
@@ -60,7 +60,7 @@ export function ThreadView({
   children,
   composer,
   onComposerSubmit,
-  composerPlaceholder = 'Reply to this conversation...',
+  composerPlaceholder = 'Reply to this chat...',
 }: ThreadViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [atBottom, setAtBottom] = useState(true);

--- a/apps/web/components/shell/useChatThreadContextMenu.tsx
+++ b/apps/web/components/shell/useChatThreadContextMenu.tsx
@@ -42,7 +42,7 @@ export function useChatThreadContextMenu(
     async (threadId: string) => {
       try {
         await deleteConversation.mutateAsync({ conversationId: threadId });
-        notifications.success('Conversation archived');
+        notifications.success('Chat archived');
         if (options.activeThreadId === threadId) {
           router.push(APP_ROUTES.CHAT);
         }

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -222,8 +222,8 @@ export const COMMANDS: readonly Command[] = [
   ),
   nav(
     'go-chats',
-    'Conversations',
-    'Open the all-conversations workspace.',
+    'Chats',
+    'Open the chats workspace.',
     'MessageSquare',
     APP_ROUTES.CHATS
   ),

--- a/apps/web/lib/constants/breadcrumb-labels.ts
+++ b/apps/web/lib/constants/breadcrumb-labels.ts
@@ -14,9 +14,9 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   audience: 'Audience',
   earnings: 'Earnings',
   analytics: 'Analytics',
-  chat: 'New Conversation',
-  chats: 'Conversations',
-  threads: 'Conversations',
+  chat: 'New Chat',
+  chats: 'Chats',
+  threads: 'Chats',
   'tour-dates': 'Tour dates',
 
   // Settings routes
@@ -41,7 +41,7 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   feedback: 'Feedback',
 
   // Root routes
-  app: 'New Conversation',
+  app: 'New Chat',
 } as const;
 
 /**

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -52,9 +52,10 @@ describe('DashboardNav interactions', () => {
   it('renders the full primary navigation config', () => {
     renderDashboardNav({ renderFn: render });
 
-    expect(
-      screen.getByRole('link', { name: 'New Conversation' })
-    ).toHaveAttribute('href', APP_ROUTES.CHAT);
+    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.CHAT
+    );
     expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
       'href',
       buildLibraryViewRoute('releases')
@@ -85,9 +86,10 @@ describe('DashboardNav interactions', () => {
       'href',
       buildLibraryViewRoute('releases')
     );
-    expect(
-      screen.getByRole('link', { name: 'New Conversation' })
-    ).toHaveAttribute('href', APP_ROUTES.CHAT);
+    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.CHAT
+    );
   });
 
   it('shows grouped admin navigation with growth links for admin users', () => {
@@ -269,7 +271,7 @@ describe('DashboardNav interactions', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(screen.getByText('Conversations')).toBeInTheDocument();
+    expect(screen.getByText('Chats')).toBeInTheDocument();
     expect(mockUseChatConversationsQuery).toHaveBeenCalledWith({
       limit: 10,
       enabled: true,
@@ -281,7 +283,7 @@ describe('DashboardNav interactions', () => {
     );
     expect(
       screen.getByRole('button', {
-        name: 'Conversation Actions for Pitch tasks',
+        name: 'Chat Actions for Pitch tasks',
       })
     ).toBeInTheDocument();
   });
@@ -312,11 +314,9 @@ describe('DashboardNav interactions', () => {
       appFlags: { DESIGN_V1: true },
     });
 
+    expect(screen.getAllByRole('link', { name: 'New Chat' })).toHaveLength(1);
     expect(
-      screen.getAllByRole('link', { name: 'New Conversation' })
-    ).toHaveLength(1);
-    expect(
-      screen.getByRole('button', { name: 'New Conversation' })
+      screen.getByRole('button', { name: 'New Chat' })
     ).toBeInTheDocument();
   });
 

--- a/apps/web/tests/unit/app/dashboard-metadata.test.ts
+++ b/apps/web/tests/unit/app/dashboard-metadata.test.ts
@@ -118,7 +118,7 @@ describe('dashboard metadata generation', () => {
       params: Promise.resolve({ id: 'conversation-123' }),
     });
 
-    expect(metadata.title).toBe('Conversation');
+    expect(metadata.title).toBe('Chat');
   });
 
   it('keeps chat thread metadata queries outside the page module', () => {

--- a/apps/web/tests/unit/chat/ProfilePageChat.test.tsx
+++ b/apps/web/tests/unit/chat/ProfilePageChat.test.tsx
@@ -152,7 +152,7 @@ describe('ProfilePageChat', () => {
 
     const { getByRole } = renderProfilePageChat();
 
-    fireEvent.click(getByRole('button', { name: 'Reload Conversation' }));
+    fireEvent.click(getByRole('button', { name: 'Reload Chat' }));
 
     expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/tests/unit/chat/breadcrumb-uuid.test.ts
+++ b/apps/web/tests/unit/chat/breadcrumb-uuid.test.ts
@@ -3,16 +3,16 @@ import { getDemoBreadcrumbSegment } from '@/hooks/useAuthRouteConfig';
 import { getBreadcrumbLabel } from '@/lib/constants/breadcrumb-labels';
 
 describe('getBreadcrumbLabel', () => {
-  it('returns "New Conversation" for the chat segment', () => {
-    expect(getBreadcrumbLabel('chat')).toBe('New Conversation');
+  it('returns "New Chat" for the chat segment', () => {
+    expect(getBreadcrumbLabel('chat')).toBe('New Chat');
   });
 
   it('returns "Dashboard" for the dashboard segment', () => {
     expect(getBreadcrumbLabel('dashboard')).toBe('Dashboard');
   });
 
-  it('returns "New Conversation" for the app root segment', () => {
-    expect(getBreadcrumbLabel('app')).toBe('New Conversation');
+  it('returns "New Chat" for the app root segment', () => {
+    expect(getBreadcrumbLabel('app')).toBe('New Chat');
   });
 
   it('converts unknown kebab-case to sentence case', () => {

--- a/apps/web/tests/unit/chat/useAuthRouteConfig.test.tsx
+++ b/apps/web/tests/unit/chat/useAuthRouteConfig.test.tsx
@@ -24,7 +24,7 @@ describe('useAuthRouteConfig', () => {
 
     expect(result.current.breadcrumbs).toEqual([
       {
-        label: 'New Conversation',
+        label: 'New Chat',
         href: '/app/chat/conv-123',
       },
     ]);

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -151,7 +151,7 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
         expect.objectContaining({
           kind: 'nav',
           id: 'go-chats',
-          label: 'Conversations',
+          label: 'Chats',
           href: APP_ROUTES.CHATS,
         }),
       ])

--- a/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
+++ b/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
@@ -86,7 +86,7 @@ describe('DesktopTitlebar', () => {
       screen.getByTestId('electron-sidebar-toggle').querySelector('svg')
     ).toBeTruthy();
     expect(
-      screen.queryByRole('link', { name: 'New Conversation' })
+      screen.queryByRole('link', { name: 'New Chat' })
     ).not.toBeInTheDocument();
   });
 

--- a/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
+++ b/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
@@ -186,7 +186,7 @@ describe('UnifiedSidebar library route', () => {
 
     expect(screen.getByText('Jovie', { selector: 'span' })).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: 'New Conversation' })
+      screen.queryByRole('link', { name: 'New Chat' })
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Collapse sidebar' })
@@ -205,7 +205,7 @@ describe('UnifiedSidebar library route', () => {
       screen.getByRole('button', { name: 'Collapse sidebar' })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: 'New Conversation' })
+      screen.queryByRole('link', { name: 'New Chat' })
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
@@ -70,9 +70,7 @@ describe('DashboardHeader', () => {
   it('prefers the breadcrumb suffix for the mobile title when present', () => {
     const { container } = render(
       <DashboardHeader
-        breadcrumbs={[
-          { label: 'New Conversation', href: '/app/chat/conv-123' },
-        ]}
+        breadcrumbs={[{ label: 'New Chat', href: '/app/chat/conv-123' }]}
         breadcrumbSuffix={<span>Release planning thread</span>}
       />
     );
@@ -83,7 +81,7 @@ describe('DashboardHeader', () => {
     expect(
       within(mobileHeader!).getByText('Release planning thread')
     ).toBeInTheDocument();
-    expect(within(mobileHeader!).queryByText('New Conversation')).toBeNull();
+    expect(within(mobileHeader!).queryByText('New Chat')).toBeNull();
   });
 
   it('collapses the breadcrumb when the search surface takes over', () => {

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -24,9 +24,9 @@ describe('DashboardNav', () => {
       renderFn: fastRender,
     });
 
-    expect(
-      getByRole('link', { name: 'New Conversation' }).getAttribute('href')
-    ).toBe(APP_ROUTES.CHAT);
+    expect(getByRole('link', { name: 'New Chat' }).getAttribute('href')).toBe(
+      APP_ROUTES.CHAT
+    );
     expect(getByRole('button', { name: 'Search' })).toBeDefined();
     expect(getByRole('link', { name: 'Releases' }).getAttribute('href')).toBe(
       buildLibraryViewRoute('releases')
@@ -115,9 +115,7 @@ describe('DashboardNav', () => {
     });
 
     expect(
-      getByRole('link', { name: 'New Conversation' }).getAttribute(
-        'aria-current'
-      )
+      getByRole('link', { name: 'New Chat' }).getAttribute('aria-current')
     ).toBeNull();
   });
 
@@ -129,7 +127,7 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    const newThreadLink = getByRole('link', { name: 'New Conversation' });
+    const newThreadLink = getByRole('link', { name: 'New Chat' });
     expect(newThreadLink.className).toContain('text-sidebar-muted/80');
     expect(newThreadLink.className).not.toContain(
       'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)]'
@@ -142,7 +140,7 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(getAllByRole('link', { name: 'New Conversation' })).toHaveLength(1);
+    expect(getAllByRole('link', { name: 'New Chat' })).toHaveLength(1);
   });
 
   it('opens the global command palette from Search instead of navigating', () => {
@@ -221,7 +219,7 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    const newThreadLink = getByRole('link', { name: 'New Conversation' });
+    const newThreadLink = getByRole('link', { name: 'New Chat' });
     expect(newThreadLink.className).toContain(
       'group-data-[collapsible=icon]:justify-center'
     );
@@ -237,7 +235,7 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(getByRole('link', { name: 'New Conversation' })).toHaveAttribute(
+    expect(getByRole('link', { name: 'New Chat' })).toHaveAttribute(
       'href',
       APP_ROUTES.CHAT
     );

--- a/apps/web/tests/unit/organisms/CommandPalette.test.tsx
+++ b/apps/web/tests/unit/organisms/CommandPalette.test.tsx
@@ -135,9 +135,9 @@ describe('CommandPalette', () => {
   it('lists recent chats with safe fallback titles', () => {
     render(withDashboard(<CommandPalette />));
     fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
-    expect(screen.getByText('Recent Conversations')).toBeInTheDocument();
+    expect(screen.getByText('Recent Chats')).toBeInTheDocument();
     expect(screen.getByText('Q1 release plan')).toBeInTheDocument();
-    expect(screen.getByText('Untitled conversation')).toBeInTheDocument();
+    expect(screen.getByText('Untitled chat')).toBeInTheDocument();
   });
 
   it('routes a recent-chat commit to the chat route', () => {

--- a/apps/web/tests/unit/threads/ThreadsPageClient.test.tsx
+++ b/apps/web/tests/unit/threads/ThreadsPageClient.test.tsx
@@ -92,9 +92,10 @@ describe('ChatsPageClient', () => {
       limit: 50,
     });
     expect(screen.queryByRole('heading', { name: 'Threads' })).toBeNull();
-    expect(
-      screen.getByRole('link', { name: 'New Conversation' })
-    ).toHaveAttribute('href', APP_ROUTES.CHAT);
+    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.CHAT
+    );
 
     const threadLinks = screen
       .getAllByRole('link')
@@ -143,12 +144,9 @@ describe('ChatsPageClient', () => {
     );
     expect(document.querySelector('.anim-calm-breath')).toBeInTheDocument();
 
-    fireEvent.change(
-      screen.getByRole('searchbox', { name: 'Search Conversations' }),
-      {
-        target: { value: 'Pitch' },
-      }
-    );
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search Chats' }), {
+      target: { value: 'Pitch' },
+    });
 
     expect(screen.queryByRole('link', { name: 'Unread answer' })).toBeNull();
     expect(
@@ -175,19 +173,12 @@ describe('ChatsPageClient', () => {
 
     render(<ThreadsPageClient />);
 
-    fireEvent.change(
-      screen.getByRole('searchbox', { name: 'Search Conversations' }),
-      {
-        target: { value: 'Missing' },
-      }
-    );
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search Chats' }), {
+      target: { value: 'Missing' },
+    });
 
-    expect(
-      screen.getByText('No conversations match "Missing".')
-    ).toBeInTheDocument();
-    expect(
-      screen.getAllByRole('link', { name: 'New Conversation' })
-    ).toHaveLength(2);
+    expect(screen.getByText('No chats match "Missing".')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'New Chat' })).toHaveLength(2);
   });
 
   it('opens per-chat actions from the hover menu and right-click', async () => {
@@ -217,7 +208,7 @@ describe('ChatsPageClient', () => {
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'Conversation Actions for Pitch tasks',
+        name: 'Chat Actions for Pitch tasks',
       })
     );
     fireEvent.click(screen.getByRole('menuitem', { name: 'Archive' }));
@@ -256,9 +247,7 @@ describe('ChatsPageClient', () => {
 
     render(<ThreadsPageClient />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Archive All Conversations' })
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Archive All Chats' }));
     fireEvent.click(screen.getByRole('button', { name: 'Archive All' }));
 
     await waitFor(() => {
@@ -270,7 +259,7 @@ describe('ChatsPageClient', () => {
         conversationId: 'thread-newer',
       });
       expect(mockNotificationsSuccess).toHaveBeenCalledWith(
-        'All conversations archived'
+        'All chats archived'
       );
     });
   });


### PR DESCRIPTION
## What
Standardize all user-facing copy for the conversation surface on a single name — **"Chats"** — replacing mixed "Conversations" (production) and "Threads" (experiment) wording across: breadcrumbs, the command palette nav + recent-chats section, the sidebar section header / actions / "All Chats" / "New Chat", the Chats page (search, archive-all, counts, empty/error states), chat page metadata + title fallback, dashboard nav, and related toasts/aria-labels.

## Scope
Copy/label only — **no** route, data-contract, or DB-schema (`chatConversations`) changes. Meta "Threads" (social platform) and `conversation.*` event types left intact. Title/sentence casing per DESIGN.md.

## Risk
Low — visible-string changes + matching test-assertion updates. No behavior change.

## Verification
typecheck clean · biome clean · **87 tests green** across 11 affected files · design-system ratchets unchanged.

<!-- linear-issue-id:JOV-3485 -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)