### PR TITLE
fix(ci): retry public Lighthouse on Chrome protocol-timeout flakes

### DIFF
--- a/apps/web/scripts/run-public-lighthouse.ts
+++ b/apps/web/scripts/run-public-lighthouse.ts
@@ -91,7 +91,27 @@ async function main() {
     ...selectedUrls.map(url => `--collect.url=${url}`),
   ];
 
-  await runCommand('pnpm', args, process.env);
+  // Retry once on failure to absorb transient Chrome DevTools flakes
+  // (PROTOCOL_TIMEOUT / "Waiting for DevTools protocol response has exceeded
+  // the allotted time"), which fail lhci collection and were jamming the
+  // Graphite merge queue. Real assertion/perf failures are deterministic, so
+  // they still fail the retry — this clears flakes without masking regressions.
+  // ponytail: blanket retry-once; per-error classification only if a real
+  // perf regression ever slips through a borderline retry.
+  const MAX_ATTEMPTS = 2;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      await runCommand('pnpm', args, process.env);
+      return;
+    } catch (error) {
+      if (attempt === MAX_ATTEMPTS) throw error;
+      console.error(
+        `Public Lighthouse attempt ${attempt}/${MAX_ATTEMPTS} failed; retrying once. Cause: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
 }
 
 void main().catch(error => {


### PR DESCRIPTION
## Root cause (queue stall, nothing shipping)
The Graphite merge queue jammed for hours. `Lighthouse (public routes PR)` intermittently fails `lhci` **collection** with a Chrome DevTools `PROTOCOL_TIMEOUT` / `Waiting for DevTools protocol response has exceeded the allotted time (DOMSnapshot.disable)` — an infra flake, **not** a perf-threshold failure (scores were fine).

Failure loop:
1. A public-route PR passes Lighthouse on its own branch → looks CLEAN.
2. Its Graphite batch re-runs Lighthouse, re-rolls the flake → `PR Ready` fails → can't fast-forward.
3. `merge-queue-autoenroll` (every 20 min) sees the PR still CLEAN → re-enrolls it.
4. The same PR perpetually jams the queue head. Only Lighthouse-skipping PRs (docs/screenshots) trickled through.

Evidence: #11786 own PR Lighthouse `[success,success]`; its batch #11823 `[failure,success]` with `PROTOCOL_TIMEOUT` in the log; `PR Ready` failed as a result. main last advanced 05:05 UTC after a multi-hour gap.

## Fix
Retry the `lhci` run once in `run-public-lighthouse.ts`. Collection flakes clear on retry; real assertion/perf failures are deterministic and fail both attempts, so this absorbs the flake **without masking regressions**.

## Cost / safety
- Extra Lighthouse run only when the first fails (rare) — negligible.
- No threshold/assertion changes; `.lighthouserc.public-launch.json` untouched.

## Verification
- Typecheck passes (pre-commit). This PR touches `run-public-lighthouse.ts` so its own CI + batch exercise the retried path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)