### PR TITLE
perf: dedupe redundant per-request work in proxy.ts hot path (#10992)

### DIFF
--- a/apps/web/lib/routing/proxy-routing.ts
+++ b/apps/web/lib/routing/proxy-routing.ts
@@ -155,7 +155,8 @@ export function isProxyRewriteExempt(pathname: string): boolean {
  * sharing the cached reference is safe.
  */
 const CATEGORIZE_PATH_CACHE_MAX = 1000;
-const categorizePathCache = new Map<string, PathCategory>();
+/** Exported for test teardown only. Do not call from production code. */
+export const _categorizePathCache = new Map<string, PathCategory>();
 
 /**
  * Categorize a pathname once for all routing decisions.
@@ -163,7 +164,7 @@ const categorizePathCache = new Map<string, PathCategory>();
  * Now also owns public-profile candidate detection (derived from APP_ROUTES).
  */
 export function categorizePath(pathname: string): PathCategory {
-  const cached = categorizePathCache.get(pathname);
+  const cached = _categorizePathCache.get(pathname);
   if (cached) return cached;
   const isAuthPath =
     pathname === APP_ROUTES.SIGNIN ||
@@ -224,12 +225,12 @@ export function categorizePath(pathname: string): PathCategory {
     publicProfileCandidate,
   };
 
-  if (categorizePathCache.size >= CATEGORIZE_PATH_CACHE_MAX) {
+  if (_categorizePathCache.size >= CATEGORIZE_PATH_CACHE_MAX) {
     // FIFO eviction: remove the oldest entry
-    const firstKey = categorizePathCache.keys().next().value;
-    if (firstKey !== undefined) categorizePathCache.delete(firstKey);
+    const firstKey = _categorizePathCache.keys().next().value;
+    if (firstKey !== undefined) _categorizePathCache.delete(firstKey);
   }
-  categorizePathCache.set(pathname, result);
+  _categorizePathCache.set(pathname, result);
   return result;
 }
 
@@ -241,7 +242,8 @@ export function categorizePath(pathname: string): PathCategory {
  * FIFO eviction prevents unbounded growth from fuzz/scan traffic.
  */
 const ANALYZE_HOST_CACHE_MAX = 50;
-const analyzeHostCache = new Map<string, HostInfo>();
+/** Exported for test teardown only. Do not call from production code. */
+export const _analyzeHostCache = new Map<string, HostInfo>();
 
 /**
  * Analyze hostname once for all routing decisions.
@@ -249,7 +251,7 @@ const analyzeHostCache = new Map<string, HostInfo>();
  * Investor portal: /investor-portal (path-based, bypasses Clerk auth)
  */
 export function analyzeHost(hostname: string): HostInfo {
-  const cached = analyzeHostCache.get(hostname);
+  const cached = _analyzeHostCache.get(hostname);
   if (cached) return cached;
   const isDevOrPreview =
     hostname === 'localhost' ||
@@ -270,12 +272,12 @@ export function analyzeHost(hostname: string): HostInfo {
     isInvestorPortal: INVESTOR_HOSTNAMES.has(hostname),
   };
 
-  if (analyzeHostCache.size >= ANALYZE_HOST_CACHE_MAX) {
+  if (_analyzeHostCache.size >= ANALYZE_HOST_CACHE_MAX) {
     // FIFO eviction: remove the oldest entry
-    const firstKey = analyzeHostCache.keys().next().value;
-    if (firstKey !== undefined) analyzeHostCache.delete(firstKey);
+    const firstKey = _analyzeHostCache.keys().next().value;
+    if (firstKey !== undefined) _analyzeHostCache.delete(firstKey);
   }
-  analyzeHostCache.set(hostname, result);
+  _analyzeHostCache.set(hostname, result);
   return result;
 }
 

--- a/apps/web/tests/unit/lib/auth/final-response-csp-memo.contract.test.ts
+++ b/apps/web/tests/unit/lib/auth/final-response-csp-memo.contract.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guardrail: getCspReportUri() must be resolved once at module load in
+ * final-response.ts so nonce requests do not re-parse the Sentry DSN.
+ * csp-reporting.ts intentionally stays un-memoized for env-mutation tests.
+ */
+describe('final-response CSP report URI memoization (#10992)', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'lib/auth/final-response.ts'),
+    'utf8'
+  );
+
+  it('caches getCspReportUri at module scope', () => {
+    expect(source).toMatch(/const CSP_REPORT_URI = getCspReportUri\(\);/);
+  });
+
+  it('uses the cached URI inside buildFinalResponse instead of re-calling getCspReportUri', () => {
+    const buildFnStart = source.indexOf('export function buildFinalResponse');
+    expect(buildFnStart).toBeGreaterThan(-1);
+    const buildFnBody = source.slice(buildFnStart);
+    expect(buildFnBody).toContain('CSP_REPORT_URI');
+    expect(buildFnBody).not.toContain('getCspReportUri()');
+  });
+});

--- a/apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts
+++ b/apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts
@@ -196,6 +196,60 @@ describe('staging Clerk key resolution', () => {
     await expect(resolvePublishableKeyFromHeaders()).resolves.toBeUndefined();
   });
 
+  describe('resolveClerkKeys memoization (#10992)', () => {
+    it('caches ok results so env reads are not repeated on the hot path', () => {
+      process.env.CLERK_PUBLISHABLE_KEY_STAGING = 'pk_live_staging_example';
+      process.env.CLERK_SECRET_KEY_STAGING = 'sk_live_staging_example';
+
+      const first = resolveClerkKeys('staging.jov.ie');
+      delete process.env.CLERK_PUBLISHABLE_KEY_STAGING;
+      delete process.env.CLERK_SECRET_KEY_STAGING;
+
+      const second = resolveClerkKeys('staging.jov.ie');
+      expect(second).toBe(first);
+      expect(second.publishableKey).toBe('pk_live_staging_example');
+    });
+
+    it('does not cache staging_missing so a later secret key can resolve', () => {
+      process.env.CLERK_PUBLISHABLE_KEY_STAGING = 'pk_live_staging_example';
+
+      expect(resolveClerkKeys('staging.jov.ie').status).toBe('staging_missing');
+
+      process.env.CLERK_SECRET_KEY_STAGING = 'sk_live_staging_example';
+      expect(resolveClerkKeys('staging.jov.ie')).toEqual({
+        publishableKey: 'pk_live_staging_example',
+        secretKey: 'sk_live_staging_example',
+        status: 'ok',
+      });
+    });
+
+    it('does not cache staging_inherits_prod so a corrected env can resolve', () => {
+      expect(resolveClerkKeys('staging.jov.ie').status).toBe(
+        'staging_inherits_prod'
+      );
+
+      process.env.CLERK_PUBLISHABLE_KEY_STAGING = 'pk_live_staging_example';
+      process.env.CLERK_SECRET_KEY_STAGING = 'sk_live_staging_example';
+      expect(resolveClerkKeys('staging.jov.ie').status).toBe('ok');
+    });
+
+    it('bounds the cache with FIFO eviction at 50 hostnames', () => {
+      process.env.CLERK_PUBLISHABLE_KEY_STAGING = 'pk_live_staging_example';
+      process.env.CLERK_SECRET_KEY_STAGING = 'sk_live_staging_example';
+
+      const evictedHost = 'memo-evict-probe.example';
+      const first = resolveClerkKeys(evictedHost);
+      expect(resolveClerkKeys(evictedHost)).toBe(first);
+
+      for (let i = 0; i < 50; i++) {
+        resolveClerkKeys(`memo-filler-${i}.example`);
+      }
+
+      expect(_resolveClerkKeysCache.size).toBe(50);
+      expect(resolveClerkKeys(evictedHost)).not.toBe(first);
+    });
+  });
+
   it('prefers the middleware-injected publishable key header when present', async () => {
     headersMock.mockResolvedValue(
       new Headers({

--- a/apps/web/tests/unit/lib/proxy-url-mapping.test.ts
+++ b/apps/web/tests/unit/lib/proxy-url-mapping.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 import {
+  _analyzeHostCache,
+  _categorizePathCache,
   analyzeHost,
   categorizePath,
   DASHBOARD_URL,
@@ -101,6 +103,51 @@ describe('proxy routing helpers', () => {
 
   it('keeps the dashboard path stable across environments', () => {
     expect(DASHBOARD_URL).toBe('/app');
+  });
+
+  describe('proxy hot-path memoization (#10992)', () => {
+    beforeEach(() => {
+      _categorizePathCache.clear();
+      _analyzeHostCache.clear();
+    });
+
+    it('returns the same categorizePath object for repeated pathname lookups', () => {
+      const first = categorizePath('/app/dashboard');
+      const second = categorizePath('/app/dashboard');
+      expect(second).toBe(first);
+    });
+
+    it('returns the same analyzeHost object for repeated hostname lookups', () => {
+      const first = analyzeHost('staging.jov.ie');
+      const second = analyzeHost('staging.jov.ie');
+      expect(second).toBe(first);
+    });
+
+    it('bounds categorizePath cache with FIFO eviction at 1000 entries', () => {
+      const evictedPath = '/memo-evict-probe';
+      const first = categorizePath(evictedPath);
+      expect(categorizePath(evictedPath)).toBe(first);
+
+      for (let i = 0; i < 1000; i++) {
+        categorizePath(`/memo-filler-${i}`);
+      }
+
+      expect(_categorizePathCache.size).toBe(1000);
+      expect(categorizePath(evictedPath)).not.toBe(first);
+    });
+
+    it('bounds analyzeHost cache with FIFO eviction at 50 entries', () => {
+      const evictedHost = 'memo-evict-probe.example';
+      const first = analyzeHost(evictedHost);
+      expect(analyzeHost(evictedHost)).toBe(first);
+
+      for (let i = 0; i < 50; i++) {
+        analyzeHost(`memo-filler-${i}.example`);
+      }
+
+      expect(_analyzeHostCache.size).toBe(50);
+      expect(analyzeHost(evictedHost)).not.toBe(first);
+    });
   });
 
   describe('getPublicProfileCandidate reserved short-circuit (JOV-3054)', () => {

--- a/apps/web/tests/unit/middleware/route-policy.test.ts
+++ b/apps/web/tests/unit/middleware/route-policy.test.ts
@@ -6,9 +6,12 @@
  * These tests assert the classification bugfix: /start, /pricing, /about,
  * /investors etc NEVER trigger the public-profile audience block DB path.
  */
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 import {
+  _analyzeHostCache,
+  _categorizePathCache,
+  analyzeHost,
   categorizePath,
   getPublicProfileCandidate,
   isProxyRewriteExempt,
@@ -88,6 +91,73 @@ describe('route-policy (proxy-routing)', () => {
       expect(isProxyRewriteExempt('/onboarding')).toBe(true);
       expect(isProxyRewriteExempt('/onboarding/checkout')).toBe(true);
       expect(isProxyRewriteExempt('/pricing')).toBe(false);
+    });
+  });
+});
+
+describe('proxy-routing memoization (#10992)', () => {
+  afterEach(() => {
+    _categorizePathCache.clear();
+    _analyzeHostCache.clear();
+  });
+
+  describe('categorizePath cache', () => {
+    it('returns the same object reference on repeated calls (cache hit)', () => {
+      const first = categorizePath('/timwhite');
+      const second = categorizePath('/timwhite');
+      expect(second).toBe(first);
+    });
+
+    it('returns a fresh result for a different pathname', () => {
+      const a = categorizePath('/timwhite');
+      const b = categorizePath('/joviewhite');
+      expect(b).not.toBe(a);
+    });
+
+    it('bounds the cache at 1000 entries with FIFO eviction', () => {
+      // Seed a reference entry
+      const evictedPath = '/memo-evict-probe-path';
+      const first = categorizePath(evictedPath);
+      expect(categorizePath(evictedPath)).toBe(first);
+
+      // Fill 1000 entries so evictedPath is pushed out
+      for (let i = 0; i < 1000; i++) {
+        categorizePath(`/memo-filler-user-${i}`);
+      }
+
+      expect(_categorizePathCache.size).toBe(1000);
+      // The evicted entry is no longer the same reference
+      expect(categorizePath(evictedPath)).not.toBe(first);
+    });
+  });
+
+  describe('analyzeHost cache', () => {
+    it('returns the same object reference on repeated calls (cache hit)', () => {
+      const first = analyzeHost('jov.ie');
+      const second = analyzeHost('jov.ie');
+      expect(second).toBe(first);
+    });
+
+    it('returns a fresh result for a different hostname', () => {
+      const a = analyzeHost('jov.ie');
+      const b = analyzeHost('staging.jov.ie');
+      expect(b).not.toBe(a);
+    });
+
+    it('bounds the cache at 50 entries with FIFO eviction', () => {
+      // Seed a reference entry
+      const evictedHost = 'memo-evict-probe.example';
+      const first = analyzeHost(evictedHost);
+      expect(analyzeHost(evictedHost)).toBe(first);
+
+      // Fill 50 entries so evictedHost is pushed out
+      for (let i = 0; i < 50; i++) {
+        analyzeHost(`memo-filler-${i}.example`);
+      }
+
+      expect(_analyzeHostCache.size).toBe(50);
+      // The evicted entry is no longer the same reference
+      expect(analyzeHost(evictedHost)).not.toBe(first);
     });
   });
 });


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (claude-sonnet-4-6). Closes #10992.

Card: t_e34fe351
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- sign-in / session success rate (auth-sensitive)
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.