### PR TITLE
fix(sentry): align client/server config with @sentry/nextjs v10 types

### DIFF
--- a/apps/web/app/sentry-example-page/SentryExamplePageClient.tsx
+++ b/apps/web/app/sentry-example-page/SentryExamplePageClient.tsx
@@ -2,8 +2,8 @@
 
 import { Button } from '@jovie/ui';
 import * as Sentry from '@sentry/nextjs';
-import { CheckCircle2, TriangleAlert } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { CheckCircle2 } from 'lucide-react';
+import { useState } from 'react';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { StandaloneProductPage } from '@/components/organisms/StandaloneProductPage';
@@ -17,21 +17,6 @@ class SentryExampleFrontendError extends Error {
 
 export function SentryExamplePageClient() {
   const [hasSentError, setHasSentError] = useState(false);
-  const [isConnected, setIsConnected] = useState(true);
-
-  useEffect(() => {
-    async function checkConnectivity() {
-      try {
-        const result = await Sentry.diagnoseSdkConnectivity();
-        setIsConnected(result !== 'sentry-unreachable');
-      } catch (error) {
-        console.error('Failed to check Sentry connectivity:', error);
-        setIsConnected(false);
-      }
-    }
-
-    checkConnectivity();
-  }, []);
 
   return (
     <StandaloneProductPage width='md' centered>
@@ -88,7 +73,6 @@ export function SentryExamplePageClient() {
                   'This error is raised on the frontend of the example page.'
                 );
               }}
-              disabled={!isConnected}
             >
               Throw Sample Error
             </Button>
@@ -105,24 +89,6 @@ export function SentryExamplePageClient() {
               </div>
             </ContentSurfaceCard>
           ) : null}
-
-          {isConnected ? null : (
-            <ContentSurfaceCard
-              surface='nested'
-              className='border-[color-mix(in_oklab,var(--linear-warning)_30%,var(--linear-app-frame-seam))] bg-[color-mix(in_oklab,var(--linear-warning)_10%,var(--linear-app-content-surface))] p-4'
-            >
-              <div className='space-y-2 text-center'>
-                <div className='flex items-center justify-center gap-2 text-app font-semibold text-primary-token'>
-                  <TriangleAlert className='h-4 w-4 text-(--linear-warning)' />
-                  Sentry connectivity looks blocked.
-                </div>
-                <p className='text-app leading-5 text-secondary-token'>
-                  Network requests to Sentry may be blocked by an ad blocker or
-                  local filtering rule.
-                </p>
-              </div>
-            </ContentSurfaceCard>
-          )}
         </div>
       </ContentSurfaceCard>
     </StandaloneProductPage>

--- a/apps/web/lib/sentry/client-full.ts
+++ b/apps/web/lib/sentry/client-full.ts
@@ -36,9 +36,24 @@ let isInitialized = false;
 let isReplayLoaded = false;
 
 /**
- * Integration type - inferred from Sentry's breadcrumbsIntegration return type
+ * Integration type. SDK v10 no longer exports `Integration` from @sentry/nextjs's
+ * isomorphic surface, so derive it from the init() options' integrations array.
  */
-type SentryIntegration = ReturnType<typeof Sentry.breadcrumbsIntegration>;
+type SentryIntegration = Extract<
+  NonNullable<NonNullable<Parameters<typeof Sentry.init>[0]>['integrations']>,
+  readonly unknown[]
+>[number];
+
+/**
+ * breadcrumbsIntegration / replayIntegration are client-only exports that exist
+ * on @sentry/nextjs at runtime in the browser build but are absent from its
+ * isomorphic type surface in SDK v10. Cast to a typed view of just the
+ * client-only factories this module calls.
+ */
+const clientSentry = Sentry as typeof Sentry & {
+  breadcrumbsIntegration: () => SentryIntegration;
+  replayIntegration: () => SentryIntegration;
+};
 
 /**
  * Full Sentry configuration options.
@@ -92,7 +107,7 @@ export interface FullSentryConfig {
  */
 export function getFullClientConfig(
   options: FullSentryConfig = {}
-): Sentry.BrowserOptions {
+): NonNullable<Parameters<typeof Sentry.init>[0]> {
   const baseConfig = getBaseClientConfig();
   const {
     tracesSampleRate = TRACES_SAMPLE_RATE,
@@ -108,12 +123,12 @@ export function getFullClientConfig(
 
   // Add breadcrumb integration if enabled (default behavior)
   if (enableBreadcrumbs) {
-    integrations.push(Sentry.breadcrumbsIntegration());
+    integrations.push(clientSentry.breadcrumbsIntegration());
   }
 
   // Add Replay integration if enabled
   if (enableReplay) {
-    integrations.push(Sentry.replayIntegration());
+    integrations.push(clientSentry.replayIntegration());
     isReplayLoaded = true;
   }
 
@@ -222,11 +237,14 @@ export async function addReplayIntegration(): Promise<boolean> {
     return false;
   }
 
-  // Dynamically import Replay integration to enable code splitting
-  const { replayIntegration } = await import('@sentry/nextjs');
+  // Dynamically import Replay integration to enable code splitting.
+  // replayIntegration is a client-only runtime export (see clientSentry note).
+  const mod = (await import('@sentry/nextjs')) as unknown as {
+    replayIntegration: () => SentryIntegration;
+  };
 
   // Add the Replay integration to the existing client
-  client.addIntegration(replayIntegration());
+  client.addIntegration(mod.replayIntegration());
   isReplayLoaded = true;
 
   return true;

--- a/apps/web/lib/sentry/client-lite.ts
+++ b/apps/web/lib/sentry/client-lite.ts
@@ -29,9 +29,22 @@ import {
 let isInitialized = false;
 
 /**
- * Integration type - inferred from Sentry's breadcrumbsIntegration return type
+ * Integration type. SDK v10 no longer exports `Integration` from @sentry/nextjs's
+ * isomorphic surface, so derive it from the init() options' integrations array.
  */
-type SentryIntegration = ReturnType<typeof Sentry.breadcrumbsIntegration>;
+type SentryIntegration = Extract<
+  NonNullable<NonNullable<Parameters<typeof Sentry.init>[0]>['integrations']>,
+  readonly unknown[]
+>[number];
+
+/**
+ * breadcrumbsIntegration is a client-only export that exists on @sentry/nextjs
+ * at runtime in the browser build but is absent from its isomorphic type surface
+ * in SDK v10. Cast to a typed view of the client-only factory this module calls.
+ */
+const clientSentry = Sentry as typeof Sentry & {
+  breadcrumbsIntegration: () => SentryIntegration;
+};
 
 /**
  * Lite Sentry configuration options.
@@ -66,7 +79,7 @@ export interface LiteSentryConfig {
  */
 export function getLiteClientConfig(
   options: LiteSentryConfig = {}
-): Sentry.BrowserOptions {
+): NonNullable<Parameters<typeof Sentry.init>[0]> {
   const baseConfig = getBaseClientConfig();
   const {
     tracesSampleRate = TRACES_SAMPLE_RATE,
@@ -79,7 +92,7 @@ export function getLiteClientConfig(
 
   // Add breadcrumb integration if enabled (default behavior)
   if (enableBreadcrumbs) {
-    integrations.push(Sentry.breadcrumbsIntegration());
+    integrations.push(clientSentry.breadcrumbsIntegration());
   }
 
   // Add any custom lightweight integrations

--- a/apps/web/lib/sentry/config.ts
+++ b/apps/web/lib/sentry/config.ts
@@ -57,12 +57,11 @@ import type * as Sentry from '@sentry/nextjs';
 /**
  * Sentry Event type alias for cleaner code
  */
-type SentryEvent = Parameters<
-  NonNullable<Sentry.BrowserOptions['beforeSend']>
->[0];
-type SentryEventHint = Parameters<
-  NonNullable<Sentry.BrowserOptions['beforeSend']>
->[1];
+// SDK v10: BrowserOptions is no longer exported from @sentry/nextjs's isomorphic
+// type surface. Use the core event types directly — they are the exact params of
+// beforeSend (event, hint).
+type SentryEvent = Sentry.ErrorEvent;
+type SentryEventHint = Sentry.EventHint;
 
 /**
  * Environment detection utilities.

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -17,12 +17,18 @@ const baseConfig = getBaseServerConfig();
 //   URL: https://app.jovie.com/api/health  |  Interval: 1 min
 const HEALTH_ENDPOINT_PATTERN = /^\/api\/health/;
 
+// SDK v10 no longer exports SamplingContext from @sentry/nextjs's isomorphic
+// surface — derive it from the init() options' tracesSampler parameter.
+type SamplingContext = Parameters<
+  NonNullable<NonNullable<Parameters<typeof Sentry.init>[0]>['tracesSampler']>
+>[0];
+
 Sentry.init({
   ...baseConfig,
 
   // Drop performance traces for the health endpoint — Sentry's uptime monitor
   // pings it every minute, which would otherwise skew p50/p99 latency data.
-  tracesSampler: samplingContext => {
+  tracesSampler: (samplingContext: SamplingContext) => {
     const name = samplingContext.name ?? '';
     if (HEALTH_ENDPOINT_PATTERN.test(name)) {
       return 0;


### PR DESCRIPTION
## What

`@sentry/nextjs@10.59` dropped several symbols from its **isomorphic** type surface and removed `diagnoseSdkConnectivity`, leaving `pnpm --filter @jovie/web typecheck` red. CI was green only because the turbo `typecheck` task was a **cache hit** — a fresh `tsc` (and the local pre-push hook) surfaces the errors.

Removed/relocated symbols this fixes:
- `breadcrumbsIntegration`, `replayIntegration` — client-only runtime exports, no longer in the isomorphic types
- `BrowserOptions`, `Integration`, `SamplingContext` — no longer exported from `@sentry/nextjs`
- `diagnoseSdkConnectivity` — removed in v10

## How

- Derive option / integration / event / sampling types from the still-exported `init` signature and core event types (`ErrorEvent`, `EventHint`) instead of the dropped named exports.
- Access the client-only integration factories (`breadcrumbsIntegration` / `replayIntegration`) through a typed view of the runtime module — they ship in the browser build but aren't on the isomorphic type surface.
- Drop the now-unsupported `diagnoseSdkConnectivity` connectivity pre-check from the Sentry **example/debug** page (`/sentry-example-page`), plus its now-unused state, imports, and warning UI.

## Risk / behavior

No runtime behavior change except the example page's connectivity indicator (a debug-only feature backed by a removed API). Error capture, breadcrumbs, replay, tracing, and `beforeSend` filtering are unchanged.

## Verification

- `pnpm --filter @jovie/web run typecheck` → **0 errors** (was failing on these files)
- `pnpm biome check` on the 5 changed files → clean
- Pre-push gate (typecheck + biome + proxy/tailwind guards) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)