### PR TITLE
feat(ui): interaction-polish core — touch targets, scoped transitions, press scale

### DIFF
--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -196,6 +196,8 @@ This is the subtraction principle applied specifically to container boundaries. 
 
 - Hover states must not move layout or shift components without a product reason.
 - Do **NOT** use `translate`, `scale`, lift-on-hover, or floating-card motion on buttons, cards, screenshots, auth surfaces, or marketing panels as a default polish move.
+- Press/click feedback may use a subtle `scale(0.96)` when it is tactile and interruptible; provide a static opt-out when the motion would distract.
+- Menus, panels, drawers, and sidebars may use intentional `translate`/`scale` motion for open/close because the movement communicates spatial state.
 - Prefer background-color, border-color, text-color, opacity, or shadow changes for hover feedback.
 - If motion is necessary because the UI is directly manipulating something spatial, it must be intentional and clearly tied to that interaction.
 

--- a/apps/web/app/billing/success/page.tsx
+++ b/apps/web/app/billing/success/page.tsx
@@ -325,10 +325,10 @@ export default function CheckoutSuccessPage() {
     contentClassName = 'space-y-6 px-5 py-5 text-center sm:px-6';
   } else if (isVisible) {
     contentClassName =
-      'space-y-6 px-5 py-5 text-center opacity-100 translate-y-0 scale-100 transition-all duration-700 ease-out sm:px-6';
+      'space-y-6 px-5 py-5 text-center opacity-100 translate-y-0 scale-100 transition-[opacity,transform] duration-700 ease-out sm:px-6';
   } else {
     contentClassName =
-      'space-y-6 px-5 py-5 text-center opacity-0 translate-y-6 scale-[0.98] transition-all duration-700 ease-out sm:px-6';
+      'space-y-6 px-5 py-5 text-center opacity-0 translate-y-6 scale-[0.98] transition-[opacity,transform] duration-700 ease-out sm:px-6';
   }
 
   const successSubtitle = isOnboardingUpgrade

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -899,6 +899,7 @@ body {
     letter-spacing: -0.011em;
     /* -0.165px at 15px = -0.011em */
     line-height: 1.65;
+    text-wrap: pretty;
   }
   .marketing-kicker {
     display: inline-flex;
@@ -1304,7 +1305,10 @@ body {
     border: 1px solid var(--linear-border-subtle);
     border-radius: var(--linear-radius-sm, 8px);
     cursor: pointer;
-    transition: all var(--linear-duration-fast) var(--linear-ease);
+    transition:
+      background-color var(--linear-duration-fast) var(--linear-ease),
+      border-color var(--linear-duration-fast) var(--linear-ease),
+      color var(--linear-duration-fast) var(--linear-ease);
     letter-spacing: -0.011em;
   }
   .accordion-trigger:hover {
@@ -1584,7 +1588,13 @@ body {
     box-shadow:
       var(--shadow-button-inset),
       0 1px 1px rgba(0, 0, 0, 0.14);
-    transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    transition:
+      background-color var(--ds-motion-subtle-duration)
+      var(--ds-motion-subtle-easing),
+      border-color var(--ds-motion-subtle-duration)
+      var(--ds-motion-subtle-easing),
+      box-shadow var(--ds-motion-subtle-duration) var(--ds-motion-subtle-easing),
+      color var(--ds-motion-subtle-duration) var(--ds-motion-subtle-easing);
     &:hover {
       background-color: var(--color-btn-primary-hover);
     }
@@ -2136,7 +2146,7 @@ body {
     @apply transition-shadow duration-subtle ease-subtle hover:shadow-lg hover:shadow-gray-200/25 dark:hover:shadow-gray-900/25;
   }
   .input-focus-glow {
-    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:shadow-lg transition-all duration-slow;
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:shadow-lg transition-[box-shadow,border-color] duration-slow;
     --tw-ring-color: color-mix(
       in oklab,
       var(--color-focus-ring) 40%,
@@ -2725,28 +2735,28 @@ body {
 @keyframes pb-eq-a {
   0%,
   100% {
-    height: 50%;
+    transform: scaleY(0.5);
   }
   50% {
-    height: 80%;
+    transform: scaleY(0.8);
   }
 }
 @keyframes pb-eq-b {
   0%,
   100% {
-    height: 70%;
+    transform: scaleY(0.7);
   }
   50% {
-    height: 42%;
+    transform: scaleY(0.42);
   }
 }
 @keyframes pb-eq-c {
   0%,
   100% {
-    height: 55%;
+    transform: scaleY(0.55);
   }
   50% {
-    height: 78%;
+    transform: scaleY(0.78);
   }
 }
 

--- a/apps/web/components/atoms/CircleIconButton.tsx
+++ b/apps/web/components/atoms/CircleIconButton.tsx
@@ -49,7 +49,7 @@ export interface CircleIconButtonProps
   readonly children: React.ReactNode;
   /** Accessible label for screen readers */
   readonly ariaLabel: string;
-  /** Button size - xs: 32px, sm: 36px, md: 40px, lg: 44px */
+  /** Button size - xs/sm/md: 40px, lg: 44px */
   readonly size?: CircleIconButtonSize;
   /** Visual variant */
   readonly variant?: CircleIconButtonVariant;
@@ -60,10 +60,10 @@ export interface CircleIconButtonProps
 }
 
 const sizeStyles: Record<CircleIconButtonSize, string> = {
-  xs: 'h-8 w-8', // 32px - compact, good for dense UIs
-  sm: 'h-9 w-9', // 36px - default for most use cases
-  md: 'h-10 w-10', // 40px - standard touch target
-  lg: 'h-11 w-11', // 44px - large touch target (mobile-first)
+  xs: 'h-10 w-10',
+  sm: 'h-10 w-10',
+  md: 'h-10 w-10',
+  lg: 'h-11 w-11',
 };
 
 const iconSizeStyles: Record<CircleIconButtonSize, string> = {

--- a/apps/web/components/atoms/ImageWithFallback.tsx
+++ b/apps/web/components/atoms/ImageWithFallback.tsx
@@ -146,7 +146,7 @@ export function ImageWithFallback({
     return (
       <div
         className={cn(
-          'flex items-center justify-center',
+          'flex items-center justify-center outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10',
           isFill ? 'absolute inset-0' : 'h-full w-full',
           fallbackClassName
         )}
@@ -162,7 +162,10 @@ export function ImageWithFallback({
     <Image
       src={src}
       alt={alt}
-      className={className}
+      className={cn(
+        'outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10',
+        className
+      )}
       onError={() => {
         setHasError(true);
         onLoadError?.();

--- a/apps/web/components/atoms/InlineIconButton.tsx
+++ b/apps/web/components/atoms/InlineIconButton.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/lib/utils';
 // icon buttons (used by DrawerEditableTextField triggers + actions) to
 // canonical focus rings + DS subtle motion. Predecessor: rot 21 InlineEditRow.
 export const INLINE_ICON_BUTTON_BASE_CLASSNAME =
-  'h-auto w-auto shrink-0 rounded-full border border-transparent bg-transparent p-0.5 text-secondary-token leading-none shadow-none transition-[opacity,background-color,color,box-shadow] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) [&_svg]:block';
+  'relative h-auto min-h-10 w-auto min-w-10 shrink-0 rounded-full border border-transparent bg-transparent p-0.5 text-secondary-token leading-none shadow-none transition-[opacity,background-color,color,box-shadow,transform] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) [&_svg]:block';
 
 export const INLINE_ICON_BUTTON_VISIBLE_CLASSNAME =
   'p-0.5 opacity-60 hover:opacity-100 focus-visible:opacity-100';

--- a/apps/web/components/atoms/ProgressIndicator.tsx
+++ b/apps/web/components/atoms/ProgressIndicator.tsx
@@ -89,7 +89,7 @@ export function ProgressIndicator({
               key={step.id}
               className={(() => {
                 const baseClasses =
-                  'flex flex-col items-center space-y-1 transition-[color,opacity] duration-200 flex-1';
+                  'flex flex-col items-center space-y-1 transition-colors duration-subtle flex-1';
                 if (isCompleted) return `${baseClasses} text-success`;
                 if (isCurrent) return `${baseClasses} text-info`;
                 return `${baseClasses} text-quaternary-token`;
@@ -99,7 +99,7 @@ export function ProgressIndicator({
               <div
                 className={(() => {
                   const baseClasses =
-                    'w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center text-xs font-semibold border-2 transition-[background-color,border-color,color] duration-200';
+                    'w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center text-xs font-semibold border-2 transition-colors duration-subtle';
                   if (isCompleted) {
                     return `${baseClasses} bg-surface-1 border-success/20 text-success`;
                   }

--- a/apps/web/components/atoms/ProgressIndicator.tsx
+++ b/apps/web/components/atoms/ProgressIndicator.tsx
@@ -89,7 +89,7 @@ export function ProgressIndicator({
               key={step.id}
               className={(() => {
                 const baseClasses =
-                  'flex flex-col items-center space-y-1 transition-all duration-200 flex-1';
+                  'flex flex-col items-center space-y-1 transition-[color,opacity] duration-200 flex-1';
                 if (isCompleted) return `${baseClasses} text-success`;
                 if (isCurrent) return `${baseClasses} text-info`;
                 return `${baseClasses} text-quaternary-token`;
@@ -99,7 +99,7 @@ export function ProgressIndicator({
               <div
                 className={(() => {
                   const baseClasses =
-                    'w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center text-xs font-semibold border-2 transition-all duration-200';
+                    'w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center text-xs font-semibold border-2 transition-[background-color,border-color,color] duration-200';
                   if (isCompleted) {
                     return `${baseClasses} bg-surface-1 border-success/20 text-success`;
                   }

--- a/apps/web/components/atoms/ReleaseArtworkThumb.tsx
+++ b/apps/web/components/atoms/ReleaseArtworkThumb.tsx
@@ -38,7 +38,7 @@ export function ReleaseArtworkThumb({
   return (
     <div
       className={cn(
-        'relative shrink-0 overflow-hidden rounded bg-surface-2 shadow-sm',
+        'relative shrink-0 overflow-hidden rounded bg-surface-2 shadow-sm outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10',
         className
       )}
       style={{ width: size, height: size }}

--- a/apps/web/components/features/admin/VerificationStatusToggle.tsx
+++ b/apps/web/components/features/admin/VerificationStatusToggle.tsx
@@ -22,7 +22,7 @@ function getButtonStyles(
     // Base badge-like styles
     'inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium',
     // Transition effects
-    'transition-[background-color,border-color,color,opacity] duration-200 ease-out',
+    'transition-colors duration-subtle ease-subtle',
     // Focus ring
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent',
     // Cursor

--- a/apps/web/components/features/admin/VerificationStatusToggle.tsx
+++ b/apps/web/components/features/admin/VerificationStatusToggle.tsx
@@ -22,7 +22,7 @@ function getButtonStyles(
     // Base badge-like styles
     'inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium',
     // Transition effects
-    'transition-all duration-200 ease-out',
+    'transition-[background-color,border-color,color,opacity] duration-200 ease-out',
     // Focus ring
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent',
     // Cursor

--- a/apps/web/components/features/dashboard/molecules/MatchConfidenceBreakdown.tsx
+++ b/apps/web/components/features/dashboard/molecules/MatchConfidenceBreakdown.tsx
@@ -114,7 +114,7 @@ function ScoreRow({ label, score, weight, description }: ScoreRowProps) {
       <div className='mt-1 h-1.5 w-full overflow-hidden rounded-full bg-surface-2'>
         <div
           className={cn(
-            'h-full rounded-full transition-all',
+            'h-full rounded-full transition-[width,background-color]',
             getPercentageColorClass(percentage)
           )}
           style={{ width: `${percentage}%` }}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ImportProgressBanner.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ImportProgressBanner.tsx
@@ -46,7 +46,7 @@ export const ImportProgressBanner = memo(function ImportProgressBanner({
         <span className='max-w-45 truncate text-secondary-token'>
           {artistName ? `Importing ${artistName}` : 'Importing from Spotify'}
         </span>
-        <span className='shrink-0 text-tertiary-token'>
+        <span className='shrink-0 text-tertiary-token tabular-nums'>
           · {totalCount > 0 ? `${importedCount}/${totalCount}` : importedCount}
         </span>
       </div>
@@ -76,7 +76,7 @@ export const ImportProgressBanner = memo(function ImportProgressBanner({
                 ? `Importing releases from ${artistName}...`
                 : 'Importing releases from Spotify...'}
             </span>
-            <span className='shrink-0 text-2xs text-secondary-token'>
+            <span className='shrink-0 text-2xs text-secondary-token tabular-nums'>
               {totalCount > 0
                 ? `${importedCount} of ${totalCount} imported`
                 : `${importedCount} imported`}

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskProgressBar.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskProgressBar.tsx
@@ -29,7 +29,7 @@ export function ReleaseTaskProgressBar({
 
   return (
     <div className={className}>
-      <p className='text-2xs text-tertiary-token mb-1'>
+      <p className='text-2xs text-tertiary-token mb-1 tabular-nums'>
         {isComplete ? (
           <span className='text-accent'>
             Campaign complete! All {total} tasks done.

--- a/apps/web/components/features/dashboard/tokens/card-tokens.ts
+++ b/apps/web/components/features/dashboard/tokens/card-tokens.ts
@@ -81,7 +81,7 @@ export const cardTokens = {
     hover: tw`
       hover:bg-surface-2
       hover:border-default
-      transition-all ${timing.normal} ${timing.easing}
+      transition-[background-color,border-color,box-shadow] ${timing.normal} ${timing.easing}
     `,
 
     active: tw`

--- a/apps/web/components/features/dashboard/tokens/card-tokens.ts
+++ b/apps/web/components/features/dashboard/tokens/card-tokens.ts
@@ -81,7 +81,7 @@ export const cardTokens = {
     hover: tw`
       hover:bg-surface-2
       hover:border-default
-      transition-[background-color,border-color,box-shadow] ${timing.normal} ${timing.easing}
+      transition ${timing.normal} ${timing.easing}
     `,
 
     active: tw`

--- a/apps/web/components/features/home/DashboardMockup.tsx
+++ b/apps/web/components/features/home/DashboardMockup.tsx
@@ -126,7 +126,7 @@ export function DashboardMockup({
               </div>
 
               <div
-                className='flex items-center gap-1.5 rounded-lg px-3 py-1.5 transition-[background-color,border-color] duration-slower'
+                className='flex items-center gap-1.5 rounded-lg px-3 py-1.5 transition-colors duration-slower'
                 style={{
                   backgroundColor: isActive
                     ? 'rgba(255,255,255,0.07)'

--- a/apps/web/components/features/home/DashboardMockup.tsx
+++ b/apps/web/components/features/home/DashboardMockup.tsx
@@ -126,7 +126,7 @@ export function DashboardMockup({
               </div>
 
               <div
-                className='flex items-center gap-1.5 rounded-lg px-3 py-1.5 transition-all duration-slower'
+                className='flex items-center gap-1.5 rounded-lg px-3 py-1.5 transition-[background-color,border-color] duration-slower'
                 style={{
                   backgroundColor: isActive
                     ? 'rgba(255,255,255,0.07)'

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -724,7 +724,7 @@ export function ProfileCompactSurface({
 
           <div
             className={cn(
-              'overflow-y-auto overscroll-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [touch-action:pan-y] [will-change:scroll-position]',
+              'overflow-y-auto overscroll-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [touch-action:pan-y]',
               homeContentScrollClassName,
               showBottomNav ? CONTENT_SAFE_AREA_BOTTOM_PADDING : 'pb-0',
               !isHomeMode &&

--- a/apps/web/components/features/release/SmartLinkPagePrimitives.tsx
+++ b/apps/web/components/features/release/SmartLinkPagePrimitives.tsx
@@ -50,7 +50,7 @@ export function SmartLinkArtworkCard({
   return (
     <div
       className={cn(
-        'relative aspect-square w-full overflow-hidden rounded-2xl bg-white/5 shadow-2xl ring-1 ring-white/[0.08]',
+        'relative aspect-square w-full overflow-hidden rounded-2xl bg-white/5 shadow-2xl outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10',
         className
       )}
     >

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -587,7 +587,7 @@ export function JovieChat({
         />
 
         {/* Drag-and-drop overlay */}
-        <AnimatePresence>
+        <AnimatePresence initial={false}>
           {isDragOver && (
             <motion.div
               data-testid='chat-attachment-dropzone'

--- a/apps/web/components/marketing/ProductScreenshotFrame.tsx
+++ b/apps/web/components/marketing/ProductScreenshotFrame.tsx
@@ -75,7 +75,7 @@ export function ProductScreenshotFrame({
         aria-hidden={ariaHidden}
         className={cn(
           'block h-full w-full bg-(--color-bg-base) object-contain',
-          isPhone ? 'rounded-3xl' : 'rounded-lg'
+          isPhone ? 'rounded-[calc(var(--radius-3xl)-0.375rem)]' : 'rounded-lg'
         )}
       />
     </div>

--- a/apps/web/components/marketing/artist-profile/ArtistProfileSectionHeader.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileSectionHeader.tsx
@@ -18,7 +18,7 @@ export const SHELL_EYEBROW_CLASS =
   'text-xs font-medium uppercase tracking-[0.06em] text-secondary-token';
 
 export const SHELL_LEAD_CLASS =
-  'text-[clamp(1.0625rem,1.4vw,1.25rem)] leading-[1.45] text-secondary-token';
+  'text-[clamp(1.0625rem,1.4vw,1.25rem)] leading-[1.45] text-secondary-token text-pretty';
 
 export function ArtistProfileSectionHeader({
   headline,

--- a/apps/web/components/molecules/Avatar/Avatar.tsx
+++ b/apps/web/components/molecules/Avatar/Avatar.tsx
@@ -132,7 +132,8 @@ function generateInitials(name?: string): string {
  * - Accessibility support with proper ARIA attributes
  * - Dark mode support
  */
-const BORDER_RING = '';
+const BORDER_RING =
+  'outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10';
 
 const AvatarComponent = forwardRef<HTMLDivElement, AvatarProps>(function Avatar(
   {

--- a/apps/web/components/molecules/FooterBranding.tsx
+++ b/apps/web/components/molecules/FooterBranding.tsx
@@ -61,7 +61,7 @@ function getLogoLinkClass(mark: string, isLinear: boolean): string {
   if (isLinear) {
     return 'rounded-md p-1 -m-1 focus-ring-themed transition-opacity duration-150 ease-out hover:opacity-80';
   }
-  return 'rounded-md p-1 -m-1 focus-ring-themed transition-all duration-150 ease-out hover:bg-surface-1';
+  return 'rounded-md p-1 -m-1 focus-ring-themed transition-colors duration-150 ease-out hover:bg-surface-1';
 }
 
 export function FooterBranding({

--- a/apps/web/components/molecules/OptimizedImage.tsx
+++ b/apps/web/components/molecules/OptimizedImage.tsx
@@ -256,7 +256,7 @@ export const OptimizedImage = React.memo(function OptimizedImage({
   const { defaultSizes, containerClasses } = useMemo(() => {
     const defaultSizes = getDefaultSizes({ sizes, fill, size });
     const containerClasses = cn(
-      'relative overflow-hidden',
+      'relative overflow-hidden outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10',
       !fill && sizeClasses[size],
       shapeClasses[shape],
       className

--- a/apps/web/components/molecules/UsageLimitUpgradePrompt.tsx
+++ b/apps/web/components/molecules/UsageLimitUpgradePrompt.tsx
@@ -75,7 +75,7 @@ export function UsageLimitUpgradePrompt({
       {/* Progress bar */}
       <div className='mb-2 h-1.5 w-full overflow-hidden rounded-full bg-surface-2'>
         <div
-          className={`h-full rounded-full transition-all ${
+          className={`h-full rounded-full transition-[background-color,width] ${
             isAtLimit ? 'bg-destructive' : 'bg-amber-500'
           }`}
           style={{ width: `${Math.min(percentage, 100)}%` }}

--- a/apps/web/components/molecules/drawer/DrawerMediaThumb.tsx
+++ b/apps/web/components/molecules/drawer/DrawerMediaThumb.tsx
@@ -26,7 +26,7 @@ export function DrawerMediaThumb({
   return (
     <div
       className={cn(
-        'relative shrink-0 overflow-hidden rounded-lg bg-surface-1',
+        'relative shrink-0 overflow-hidden rounded-lg bg-surface-1 outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10',
         sizeClassName,
         className
       )}

--- a/apps/web/components/organisms/CinematicAppBoot.tsx
+++ b/apps/web/components/organisms/CinematicAppBoot.tsx
@@ -209,7 +209,7 @@ export function CinematicAppBoot({
           animationDuration: `${TIMELINE_MS}ms`,
           animationTimingFunction: 'var(--ds-motion-subtle-easing)',
           animationFillMode: 'forwards',
-          willChange: hasSidebar ? 'opacity, left' : 'opacity',
+          willChange: 'opacity',
         }}
       >
         <div

--- a/apps/web/components/organisms/table/atoms/TableIconButton.tsx
+++ b/apps/web/components/organisms/table/atoms/TableIconButton.tsx
@@ -26,7 +26,7 @@ export function TableIconButton({
       size='icon'
       onClick={onClick}
       aria-label={ariaLabel}
-      className={cn('h-8 w-8', className)}
+      className={cn('h-10 w-10', className)}
     >
       {icon}
     </Button>

--- a/apps/web/eslint-rules/no-raw-motion-values.js
+++ b/apps/web/eslint-rules/no-raw-motion-values.js
@@ -22,13 +22,13 @@ const CUBIC_BEZIER_REGEX = /cubic-bezier\s*\(/;
 const TRANSITION_ALL_REGEX = /\btransition-all\b/;
 const NUMERIC_DURATION_CLASS_REGEX = /\bduration-\d+\b/;
 const NUMERIC_EASE_CLASS_REGEX = /\bease-\[/;
-// Decorative hover/press motion is banned (.claude/rules/ui.md → "No Decorative
-// Hover Motion"). Flag lift (translate-y) and scale on interaction states.
+// Decorative hover motion is banned (.claude/rules/ui.md → "No Decorative
+// Hover Motion"). Press/click and menu/panel/sidebar open/close motion are allowed
+// when intentional, so only hover-triggered translate/scale is flagged here.
 // `scale-100` is a no-op reset and is intentionally exempt.
-const DECORATIVE_LIFT_REGEX =
-  /\b(?:hover|active|focus|focus-visible|group-hover):-?translate-y-/;
+const DECORATIVE_LIFT_REGEX = /\b(?:hover|group-hover):-?translate(?:-[xy])?-/;
 const DECORATIVE_SCALE_REGEX =
-  /\b(?:hover|active|focus|focus-visible|group-hover):scale-(?!100\b)(?:\[|\d)/;
+  /\b(?:hover|group-hover):scale-(?!100\b)(?:\[|\d)/;
 
 const ALLOWED_PATH_FRAGMENTS = [
   '/apps/web/styles/',
@@ -198,7 +198,7 @@ module.exports = {
       arbitraryEaseClass:
         'Arbitrary ease class bypasses the DS motion taxonomy. Use `ease-subtle` or `ease-cinematic` instead.',
       decorativeHoverMotion:
-        'Decorative hover/press motion (translate/scale) is banned. Use color, border, shadow, or opacity feedback instead (see .claude/rules/ui.md → "No Decorative Hover Motion").',
+        'Decorative hover motion (translate/scale) is banned. Use color, border, shadow, or opacity feedback instead (see .claude/rules/ui.md → "No Decorative Hover Motion").',
       rawMsDuration:
         'Raw `{{value}}` duration in inline style bypasses the DS motion tokens. Use `var(--ds-motion-subtle-duration)` or `var(--ds-motion-cinematic-duration)`.',
       rawCubicBezier:

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1328,19 +1328,19 @@ html[data-profile-initial-mode]
   --radius-xs: 2px;
   /* Tags/badges — extracted: 2px on issue labels */
   --radius-sm: 8px;
-  /* Sidebar items, buttons */
-  --radius-md: 6px;
-  /* Input fields — extracted: 6px on inputs & sidebar buttons */
-  --radius-default: 8px;
-  /* Buttons */
-  --radius-lg: 8px;
-  /* Cards, menus — extracted: 8px on marketing cards */
-  --radius-xl: 12px;
-  /* Large cards, panels — extracted: 12px on feature sections */
-  --radius-2xl: 16px;
-  /* Modals, sheets — extracted: 16px on elevated panels */
-  --radius-3xl: 22px;
-  /* Large modals — extracted: 22px on hero sections */
+  /* Badges, issue rows, small cards */
+  --radius-md: 10px;
+  /* Inner cards, drawer cards, properties panels */
+  --radius-default: 4px;
+  /* Marketing buttons */
+  --radius-lg: 12px;
+  /* App shell frame, content surface cards */
+  --radius-xl: 16px;
+  /* Large decorative elements */
+  --radius-2xl: 20px;
+  /* Modals, sheets, large nested surfaces */
+  --radius-3xl: 24px;
+  /* Large modals and phone shells */
   --radius-pill: 9999px;
   /* All app buttons / inputs / tabs — canonical Jovie DS true pill */
   --radius-full: 9999px;

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -79,12 +79,16 @@ module.exports = {
         'investor-table': '47.5rem',
       },
 
-      // Border radius - Linear-extracted values
+      // Border radius - System B canonical values
       borderRadius: {
-        xs: 'var(--radius-xs)', // 2px — tags, tiny elements
-        DEFAULT: 'var(--radius-default)', // 4px — buttons (Linear exact)
-        xl: 'var(--radius-xl)', // 10px — large cards
-        '3xl': 'var(--radius-3xl)', // 14px — large modals
+        xs: 'var(--radius-xs)',
+        sm: 'var(--radius-sm)',
+        DEFAULT: 'var(--radius-default)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+        xl: 'var(--radius-xl)',
+        '2xl': 'var(--radius-2xl)',
+        '3xl': 'var(--radius-3xl)',
         dialog: 'var(--app-dialog-radius)',
         'sidebar-floating': 'var(--app-shell-sidebar-floating-radius)',
         pill: 'var(--radius-pill)', // 48px — pill buttons

--- a/apps/web/tests/components/dashboard/link-action-system-b-style-guard.test.ts
+++ b/apps/web/tests/components/dashboard/link-action-system-b-style-guard.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const forbiddenMotionClasses =
-  /\b(?:transition-all|transition-transform|duration-\d+|active:scale|active:translate|hover:-translate|group-hover:scale)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
+  /\b(?:transition-all|transition-transform|duration-\d+|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
 
 const linkRowSources = [
   [

--- a/apps/web/tests/unit/app/exp-auth-v1-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/app/exp-auth-v1-system-b-style-guard.test.ts
@@ -6,8 +6,8 @@ const webRoot = path.resolve(__dirname, '../../..');
 const sourcePath = 'app/exp/auth-v1/page.tsx';
 
 const forbiddenButtonMotionPatterns = [
-  /\bactive:scale(?:-\[[^\]]+\]|-\d+)?\b/,
-  /\bactive:translate(?:-\[[^\]]+\]|-[a-z0-9/[\].-]+)?\b/,
+  /\bhover:scale(?:-\[[^\]]+\]|-\d+)?\b/,
+  /\bhover:translate(?:-\[[^\]]+\]|-[a-z0-9/[\].-]+)?\b/,
   /\bhover:-translate(?:-\[[^\]]+\]|-[a-z0-9/[\].-]+)?\b/,
   /\bgroup-hover:scale(?:-\[[^\]]+\]|-\d+)?\b/,
   /\btransition-all\b/,

--- a/apps/web/tests/unit/app/exp-home-v1-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/app/exp-home-v1-system-b-style-guard.test.ts
@@ -6,8 +6,8 @@ const webRoot = path.resolve(__dirname, '../../..');
 const sourcePath = 'app/exp/home-v1/page.tsx';
 
 const forbiddenControlPatterns = [
-  /\bactive:scale(?:-\[[^\]]+\]|-\d+)?\b/,
-  /\bactive:translate(?:-\[[^\]]+\]|-[a-z0-9/[\].-]+)?\b/,
+  /\bhover:scale(?:-\[[^\]]+\]|-\d+)?\b/,
+  /\bhover:translate(?:-\[[^\]]+\]|-[a-z0-9/[\].-]+)?\b/,
   /\bhover:-translate(?:-\[[^\]]+\]|-[a-z0-9/[\].-]+)?\b/,
   /\bgroup-hover:scale(?:-\[[^\]]+\]|-\d+)?\b/,
   /\btransition-all\b/,

--- a/apps/web/tests/unit/atoms/CircleIconButton.test.tsx
+++ b/apps/web/tests/unit/atoms/CircleIconButton.test.tsx
@@ -33,7 +33,7 @@ describe('CircleIconButton', () => {
       </CircleIconButton>
     );
     const button = screen.getByRole('button', { name: 'Action' });
-    expect(button).toHaveClass('h-8', 'w-8');
+    expect(button).toHaveClass('h-10', 'w-10');
   });
 
   it('applies sm size classes by default', () => {
@@ -43,7 +43,7 @@ describe('CircleIconButton', () => {
       </CircleIconButton>
     );
     const button = screen.getByRole('button', { name: 'Action' });
-    expect(button).toHaveClass('h-9', 'w-9');
+    expect(button).toHaveClass('h-10', 'w-10');
   });
 
   it('applies md size classes', () => {
@@ -119,7 +119,7 @@ describe('CircleIconButton', () => {
     expect(button).toHaveClass('my-custom-class');
   });
 
-  it('keeps shared press feedback free of decorative transforms', () => {
+  it('keeps shared hover feedback free of decorative transforms', () => {
     const variants = [
       'surface',
       'frosted',
@@ -140,7 +140,7 @@ describe('CircleIconButton', () => {
         name: `${variant} action`,
       });
       expect(button.className).not.toMatch(
-        /\b(?:transition-all|duration-\d+|active:scale|active:translate|transform|motion-reduce:transform-none)\b/
+        /\b(?:transition-all|duration-\d+|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/
       );
       unmount();
     }

--- a/apps/web/tests/unit/atoms/FrostedButton.test.tsx
+++ b/apps/web/tests/unit/atoms/FrostedButton.test.tsx
@@ -72,11 +72,11 @@ describe('FrostedButton', () => {
     expect(button).toBeDisabled();
   });
 
-  it('keeps shared press feedback free of decorative transforms', () => {
+  it('keeps shared hover feedback free of decorative transforms', () => {
     render(<FrostedButton>Motion safe</FrostedButton>);
     const button = screen.getByRole('button', { name: 'Motion safe' });
     expect(button.className).not.toMatch(
-      /\b(?:transition-all|duration-\d+|active:scale|active:translate|transform|motion-reduce:transform-none)\b/
+      /\b(?:transition-all|duration-\d+|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/
     );
   });
 

--- a/apps/web/tests/unit/atoms/amount-selector-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/atoms/amount-selector-system-b-style-guard.test.ts
@@ -7,7 +7,7 @@ const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
 const sourcePath = join(appRoot, 'components/atoms/AmountSelector.tsx');
 
 const forbiddenMotionClasses =
-  /\b(?:transition-all|transition-transform|duration-\d+|active:scale|active:translate|hover:-translate|group-hover:scale)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
+  /\b(?:transition-all|transition-transform|duration-\d+|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
 
 describe('AmountSelector System B style guard', () => {
   it('keeps amount state changes visually stable', async () => {

--- a/apps/web/tests/unit/dashboard/liquid-glass-menu-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/liquid-glass-menu-system-b-style-guard.test.ts
@@ -7,16 +7,14 @@ const sourcePath =
   'components/features/dashboard/organisms/LiquidGlassMenu.tsx';
 
 const transformMotionPatterns = [
-  /\bactive:scale(?:-\[[^\]]+\]|-\d+)?\b/,
+  /\bhover:scale(?:-\[[^\]]+\]|-\d+)?\b/,
+  /\bhover:translate(?:-\[[^\]]+\]|-[a-z0-9/[\].-]+)?\b/,
+  /\bhover:-translate(?:-\[[^\]]+\]|-[a-z0-9/[\].-]+)?\b/,
   /\btransition-all\b/,
-  /\btransition-transform\b/,
-  /\btransition-\[[^\]]*transform[^\]]*\]/,
-  /\btranslate-y-/,
-  /\bscale(?:-\[[^\]]+\]|-\d{1,3})/,
 ];
 
 describe('dashboard LiquidGlassMenu System B guard', () => {
-  it('keeps mobile menu feedback color or opacity only', () => {
+  it('keeps mobile menu hover feedback non-positional', () => {
     const source = readFileSync(path.join(webRoot, sourcePath), 'utf8');
     const offenders = transformMotionPatterns
       .filter(pattern => pattern.test(source))

--- a/apps/web/tests/unit/dashboard/popularity-cell-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/popularity-cell-system-b-style-guard.test.ts
@@ -10,7 +10,7 @@ const sourcePath = join(
 );
 
 const forbiddenMotionClasses =
-  /\b(?:transition-all|transition-transform|duration-\d+|active:scale|active:translate|hover:-translate|group-hover:scale)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
+  /\b(?:transition-all|transition-transform|duration-\d+|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
 
 describe('PopularityCell System B style guard', () => {
   it('keeps popularity bar changes bounded to color and width', async () => {

--- a/apps/web/tests/unit/dashboard/universal-link-suggestions-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/universal-link-suggestions-system-b-style-guard.test.ts
@@ -10,7 +10,9 @@ const suggestionSources = [
 ];
 
 const transformPressPatterns = [
-  /\bactive:scale(?:-\[[^\]]+\]|-\d+)?\b/,
+  /\bhover:scale(?:-\[[^\]]+\]|-\d+)?\b/,
+  /\bhover:translate(?:-\[[^\]]+\]|-[a-z0-9/[\].-]+)?\b/,
+  /\bhover:-translate(?:-\[[^\]]+\]|-[a-z0-9/[\].-]+)?\b/,
   /\btransition-all\b/,
   /\btransition-transform\b/,
   /\btransition-\[[^\]]*transform[^\]]*\]/,

--- a/apps/web/tests/unit/home/bento-feature-grid-system-b-style-guard.test.tsx
+++ b/apps/web/tests/unit/home/bento-feature-grid-system-b-style-guard.test.tsx
@@ -17,7 +17,7 @@ const forbiddenSourcePatterns = [
   /\b(?:bg|border|text|ring|shadow|rounded|h|w|max-w|min-h|tracking|leading|px|py|pt|pb)-\[(?!var\()[^\]]+\]/,
   /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white|blue)-(?:[0-9]|\[|\/)/,
   /\bshadow-(?:sm|md|lg|xl|2xl|inner|none|\[)/,
-  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+  /\b(?:transition-all|transition-transform|hover:brightness|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/,
 ] as const;
 
 const forbiddenCssPatterns = [

--- a/apps/web/tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts
@@ -15,7 +15,7 @@ const forbiddenCommandCenterSourcePatterns = [
   /\btext-white(?:\/|\b)/,
   /\b(?:white|black|blue|violet|sky|cyan|pink|fuchsia|emerald|amber|orange|rose|red)-(?:[0-9]|\[|\/)/,
   /\bshadow-(?:sm|md|lg|xl|2xl|inner|\[)/,
-  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+  /\b(?:transition-all|transition-transform|hover:brightness|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/,
 ] as const;
 
 const forbiddenCommandCenterCssPatterns = [

--- a/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
@@ -15,7 +15,7 @@ const forbiddenPageChromePatterns = [
   /\btext-white(?:\/|\b)/,
   /\b(?:white|black|blue|violet|sky|cyan|pink|fuchsia|emerald|amber|orange|rose|red)-(?:[0-9]|\[|\/)/,
   /\bshadow-(?:sm|md|lg|xl|2xl|inner|\[)/,
-  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+  /\b(?:transition-all|transition-transform|hover:brightness|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/,
 ] as const;
 
 const forbiddenHeroCssPatterns = [

--- a/apps/web/tests/unit/home/mounted-home-product-statement-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-product-statement-system-b-style-guard.test.ts
@@ -15,7 +15,7 @@ const forbiddenProductStatementSourcePatterns = [
   /\btext-white(?:\/|\b)/,
   /\b(?:white|black|blue|violet|sky|cyan|pink|fuchsia|emerald|amber|orange|rose|red)-(?:[0-9]|\[|\/)/,
   /\bshadow-(?:sm|md|lg|xl|2xl|inner|\[)/,
-  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+  /\b(?:transition-all|transition-transform|hover:brightness|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/,
 ] as const;
 
 const forbiddenProductStatementCssPatterns = [

--- a/apps/web/tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts
@@ -17,7 +17,7 @@ const forbiddenWorkspaceSourcePatterns = [
   /\btext-white(?:\/|\b)/,
   /\b(?:white|black|blue|violet|sky|cyan|pink|fuchsia|emerald|amber|orange|rose|red)-(?:[0-9]|\[|\/)/,
   /\bshadow-(?:sm|md|lg|xl|2xl|inner|\[)/,
-  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+  /\b(?:transition-all|transition-transform|hover:brightness|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/,
 ] as const;
 
 const forbiddenWorkspaceCssPatterns = [

--- a/apps/web/tests/unit/home/release-mode-mock-card-system-b-style-guard.test.tsx
+++ b/apps/web/tests/unit/home/release-mode-mock-card-system-b-style-guard.test.tsx
@@ -34,7 +34,7 @@ const forbiddenSourceVisualPatterns = [
   /\b(?:bg|border|text|ring|shadow|rounded|h|w|max-w|min-h|tracking|leading|px|py|pt|pb)-\[/,
   /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white|blue)-(?:[0-9]|\[|\/)/,
   /\bshadow-(?:sm|md|lg|xl|2xl|inner|none|\[)/,
-  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+  /\b(?:transition-all|transition-transform|hover:brightness|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/,
 ] as const;
 
 const forbiddenReleaseModeCssPatterns = [

--- a/apps/web/tests/unit/home/release-operating-system-showcase-system-b-style-guard.test.tsx
+++ b/apps/web/tests/unit/home/release-operating-system-showcase-system-b-style-guard.test.tsx
@@ -33,7 +33,7 @@ const forbiddenSourceVisualPatterns = [
   /\b(?:bg|border|text|ring|shadow|rounded|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
   /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white|blue)-(?:[0-9]|\[|\/)/,
   /\bshadow-(?:sm|md|lg|xl|2xl|inner|none|\[)/,
-  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+  /\b(?:transition-all|transition-transform|hover:brightness|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/,
   /\b(?:space-y|lg:hidden|lg:block|absolute|relative|pointer-events-none)\b/,
 ] as const;
 

--- a/apps/web/tests/unit/lib/auth/constants.test.ts
+++ b/apps/web/tests/unit/lib/auth/constants.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { AUTH_CLASSES, sanitizeRedirectUrl } from '@/lib/auth/constants';
 
 describe('AUTH_CLASSES', () => {
-  it('keeps OAuth mobile feedback free of transform motion', () => {
+  it('keeps OAuth mobile hover feedback free of transform motion', () => {
     expect(AUTH_CLASSES.oauthButtonMobile).toContain('touch-manipulation');
     expect(AUTH_CLASSES.oauthButtonMobile).toContain('transition-[opacity]');
     expect(AUTH_CLASSES.oauthButtonMobile).toContain('active:opacity-[0.92]');
     expect(AUTH_CLASSES.oauthButtonMobile).not.toMatch(
-      /\b(?:transition-all|transition-transform|active:scale|active:translate|hover:-translate)\b/
+      /\b(?:transition-all|transition-transform|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/
     );
   });
 });

--- a/apps/web/tests/unit/molecules/pay-selector-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/molecules/pay-selector-system-b-style-guard.test.ts
@@ -7,7 +7,7 @@ const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
 const sourcePath = join(appRoot, 'components/molecules/PaySelector.tsx');
 
 const forbiddenPresetMotionClasses =
-  /\b(?:transition-all|transition-transform|duration-\d+|active:scale|active:translate|hover:-translate|group-hover:scale)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
+  /\b(?:transition-all|transition-transform|duration-\d+|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
 
 describe('PaySelector System B style guard', () => {
   it('keeps amount preset state changes visually stable', async () => {

--- a/packages/ui/atoms/avatar.tsx
+++ b/packages/ui/atoms/avatar.tsx
@@ -108,7 +108,7 @@ const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>(
       <span
         ref={ref}
         className={cn(
-          'relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full',
+          'relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10',
           ring && 'ring-2 ring-surface-page',
           className
         )}

--- a/packages/ui/atoms/button.test.tsx
+++ b/packages/ui/atoms/button.test.tsx
@@ -71,6 +71,22 @@ describe('Button', () => {
     expect(btn.className).not.toContain('text-accent-foreground');
   });
 
+  it('uses tactile press feedback with a static opt-out', () => {
+    render(
+      <>
+        <Button>Press</Button>
+        <Button static>Static</Button>
+      </>
+    );
+
+    expect(screen.getByRole('button', { name: 'Press' }).className).toContain(
+      'active:scale-[0.96]'
+    );
+    expect(
+      screen.getByRole('button', { name: 'Static' }).className
+    ).not.toContain('active:scale-[0.96]');
+  });
+
   it('uses the Jovie focus token', () => {
     render(<Button>Press</Button>);
     const btn = screen.getByRole('button');

--- a/packages/ui/atoms/button.tsx
+++ b/packages/ui/atoms/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 const buttonVariants = cva(
-  'relative inline-flex items-center justify-center rounded-full text-[13px] font-[510] tracking-normal transition-colors duration-normal ease-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) disabled:opacity-50 disabled:pointer-events-none',
+  'relative inline-flex items-center justify-center rounded-full text-[13px] font-[510] tracking-normal transition-[background-color,border-color,color,box-shadow,opacity,transform] duration-normal ease-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) disabled:opacity-50 disabled:pointer-events-none',
   {
     variants: {
       variant: {
@@ -36,18 +36,18 @@ const buttonVariants = cva(
         'frosted-outline':
           'backdrop-blur-sm bg-transparent border border-subtle hover:bg-surface-1/20 dark:hover:bg-surface-2/10',
         // Canonical white pill CTA — high-contrast hero/auth pill used across
-        // marketing headers and homepage sign-in. Calm color/opacity feedback
-        // only — no decorative scale/translate. See .claude/rules/ui.md.
+        // marketing headers and homepage sign-in.
         whitePill:
           'border border-white/88 bg-white text-black shadow-[0_8px_20px_rgba(0,0,0,0.14),inset_0_1px_0_rgba(255,255,255,0.72)] hover:bg-white/95 font-medium tracking-normal sm:shadow-[0_10px_24px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.72)]',
       },
       size: {
-        default: 'h-8 px-3 py-1.5',
-        sm: 'h-7 px-2.5 text-xs',
+        default:
+          'h-8 px-3 py-1.5 before:absolute before:left-1/2 before:top-1/2 before:h-10 before:min-w-10 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
+        sm: 'h-7 px-2.5 text-xs before:absolute before:left-1/2 before:top-1/2 before:h-10 before:min-w-10 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
         lg: 'h-10 px-4 py-2 text-sm',
         xl: 'h-12 px-6 py-3 text-sm',
         hero: 'h-14 px-10 py-4 text-base font-semibold',
-        icon: 'h-8 w-8',
+        icon: 'h-10 w-10',
       },
     },
     defaultVariants: {
@@ -62,6 +62,7 @@ export interface ButtonProps
     VariantProps<typeof buttonVariants> {
   readonly asChild?: boolean;
   readonly loading?: boolean;
+  readonly static?: boolean;
 }
 
 // Helper to compute data-state attribute
@@ -111,6 +112,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       size,
       asChild = false,
       loading = false,
+      static: isStatic = false,
       disabled,
       children,
       ...props
@@ -125,6 +127,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       ref,
       className: cn(
         buttonVariants({ variant, size, className }),
+        !isStatic && !isDisabled && 'active:scale-[0.96]',
         isDisabled && 'pointer-events-none'
       ),
       'aria-disabled': isDisabled || undefined,

--- a/packages/ui/atoms/checkbox.test.tsx
+++ b/packages/ui/atoms/checkbox.test.tsx
@@ -216,11 +216,11 @@ describe('Checkbox', () => {
       );
     });
 
-    it('keeps press feedback free of transform motion', () => {
+    it('keeps hover feedback free of transform motion', () => {
       render(<Checkbox aria-label='Test' data-testid='checkbox' />);
       const checkbox = screen.getByTestId('checkbox');
       expect(checkbox.className).not.toMatch(
-        /\b(?:transition-all|transition-transform|active:scale|active:translate|hover:-translate)\b/
+        /\b(?:transition-all|transition-transform|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/
       );
     });
 

--- a/packages/ui/atoms/close-button.tsx
+++ b/packages/ui/atoms/close-button.tsx
@@ -9,7 +9,7 @@ import { cn } from '../lib/utils';
  * Provides consistent close button styling across Dialog, AlertDialog, and Sheet.
  */
 export const closeButtonStyles = {
-  base: 'absolute right-4 top-4 rounded-full text-secondary-token opacity-70 transition-colors duration-normal ease-interactive p-1',
+  base: 'absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full text-secondary-token opacity-70 transition-colors duration-normal ease-interactive',
   hover:
     'hover:bg-interactive-hover hover:text-primary-token hover:opacity-100',
   focus:

--- a/packages/ui/atoms/radio-group.test.tsx
+++ b/packages/ui/atoms/radio-group.test.tsx
@@ -231,7 +231,7 @@ describe('RadioGroup', () => {
       expect(radio.className).toContain('disabled:opacity-50');
     });
 
-    it('keeps press feedback free of transform motion', () => {
+    it('keeps hover feedback free of transform motion', () => {
       render(
         <RadioGroup>
           <RadioGroupItem value='test' data-testid='radio' />
@@ -239,7 +239,7 @@ describe('RadioGroup', () => {
       );
       const radio = screen.getByTestId('radio');
       expect(radio.className).not.toMatch(
-        /\b(?:transition-all|transition-transform|active:scale|active:translate|hover:-translate)\b/
+        /\b(?:transition-all|transition-transform|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/
       );
     });
 

--- a/packages/ui/atoms/switch.tsx
+++ b/packages/ui/atoms/switch.tsx
@@ -16,7 +16,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-4 w-7 shrink-0 cursor-pointer items-center rounded-full px-0.5',
+      'peer relative inline-flex h-4 w-7 shrink-0 cursor-pointer items-center rounded-full px-0.5 before:absolute before:left-1/2 before:top-1/2 before:h-10 before:w-10 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
       'transition-colors duration-fast ease-interactive',
       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-page',
       'disabled:cursor-not-allowed disabled:opacity-50',

--- a/packages/ui/atoms/textarea.test.tsx
+++ b/packages/ui/atoms/textarea.test.tsx
@@ -17,7 +17,7 @@ describe('Textarea', () => {
       );
 
       expect(source).not.toMatch(
-        /\b(?:transition-all|transition-transform|active:scale|active:translate|hover:-translate)\b/
+        /\b(?:transition-all|transition-transform|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b/
       );
       expect(source).not.toMatch(/\bduration-\d+\b/);
       expect(source).toContain(


### PR DESCRIPTION
## What

Design-system interaction-polish core, extracted clean from a larger uncommitted sweep in this worktree.

- **Button**: 40px tap-area pseudo-element on small sizes; subtle `active:scale-[0.96]` press feedback with a `static` opt-out; explicit transition property list (no more `transition-all`).
- **Icon atoms** (CircleIconButton, InlineIconButton, AppIconButton subset): 40px minimum touch target.
- **Tokens**: retuned radius scale; `PlayingBars` height keyframes → `transform: scaleY()` (compositor-only, no layout thrash).
- **Transitions**: blanket `transition-all` / `transition: all` replaced with explicit property lists in the clean component + CSS surfaces.
- **Rule**: `ui.md` now documents the press/menu-motion allowance; `no-raw-motion-values` eslint rule loosened to hover-only (intentional press/panel motion is permitted).

## Scope note

~34 additional files from the original sweep carry **pre-existing** lint debt (Title-Case copy, `text-white` without dark counterpart, numeric `duration-*` classes) that the whole-file `--max-warnings=0` pre-commit surfaces on any edit. Those per-component motion tweaks were dropped from this PR rather than expanding it into copy/taste fixes. Tracked as a follow-up.

## Verification

- `pnpm --filter @jovie/web typecheck` — green (pre-rebase)
- 18 affected web style-guard/atom tests + 4 `@jovie/ui` atom tests — all pass
- `biome check` — clean
- pre-commit eslint (`--max-warnings=0`) — clean on the narrowed set

## Taste gate

This is an app-wide visual/interaction change **and** loosens a hard UI invariant (decorative-motion rule). Labeled `needs-human-taste` — awaiting 👍 before merge, not auto-merging.