### PR TITLE
fix(ci): typecheck gate can't pass on a stale turbo cache (JOV-3499)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,8 @@ jobs:
         run: pnpm ci:branching-guard:validate
       - name: Validate Graphite merge queue config
         run: pnpm ci:merge-queue:check
+      - name: Verify typecheck gate uses --force (JOV-3499)
+        run: pnpm ci:typecheck-gate-guard
       - name: Run actionlint
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
       - name: Run structural repo guardrails
@@ -650,19 +652,16 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - name: Cache TypeScript artifacts
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            .cache/tsbuildinfo
-            apps/web/.cache/tsbuildinfo
-          key: ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig*.json', '**/pnpm-lock.yaml', '**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-tsc-
+      # NOTE: tsbuildinfo restore intentionally removed (JOV-3499).
+      # A stale tsbuildinfo from GH Actions cache can convince tsc --incremental that no
+      # types changed, producing a false green even after --force bypasses the Turbo cache.
+      # The merge gate must be a fresh tsc run; the cost is ~1–2 extra minutes per PR.
       - name: Run typecheck
         env:
           TURBO_SCM_BASE: ${{ (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
-        run: pnpm turbo typecheck --affected
+        # --force bypasses Turbo's remote cache so a stale SUCCESS from a prior commit
+        # cannot be replayed as the merge gate result. See JOV-3499.
+        run: pnpm turbo typecheck --affected --force
 
   neon-db:
     name: Neon DB

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "ci:branching-guard:validate": "node scripts/ci-branching-guard.mjs validate",
     "ci:merge-queue:check": "node scripts/ci-merge-queue-check.mjs validate",
     "ci:merge-queue:verify": "node scripts/ci-merge-queue-check.mjs verify",
+    "ci:typecheck-gate-guard": "node scripts/ci-typecheck-gate-guard.mjs",
     "ci:harness:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__",
     "qa:swarm:list": "node scripts/qa-swarm/cli.mjs list",
     "qa:swarm:propose": "node scripts/qa-swarm/cli.mjs propose",

--- a/scripts/ci-typecheck-gate-guard.mjs
+++ b/scripts/ci-typecheck-gate-guard.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+/**
+ * Guard: ci-typecheck gate must run with --force (JOV-3499).
+ *
+ * A turbo remote cache or stale tsbuildinfo can replay a SUCCESS from a prior commit,
+ * producing a false-green merge gate. The gate MUST use --force so every PR runs a
+ * fresh tsc, never a cached replay.
+ *
+ * This script is invoked by the Structural Contract lane:
+ *   pnpm ci:typecheck-gate-guard
+ *
+ * Exit 0 = pass. Exit 1 = fail (prints the offending line and remediation).
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const WORKFLOW_PATH = resolve('.github/workflows/ci.yml');
+const JOB_MARKER = 'ci-typecheck:';
+const REQUIRED_FLAG = '--force';
+const TURBO_CMD_PATTERN = /pnpm\s+turbo\s+typecheck/;
+
+function main() {
+  let workflow;
+  try {
+    workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+  } catch {
+    console.error(`[ci-typecheck-gate-guard] Cannot read ${WORKFLOW_PATH}`);
+    process.exit(1);
+  }
+
+  const lines = workflow.split('\n');
+
+  // Locate the ci-typecheck job block and find the turbo typecheck run line.
+  let inJob = false;
+  let inNextJob = false;
+  const findings = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Detect job boundaries (top-level job keys end with a colon at column 2 in GH Actions YAML).
+    if (/^\s{2}\w[\w-]+:\s*$/.test(line)) {
+      if (line.trim() === JOB_MARKER) {
+        inJob = true;
+        inNextJob = false;
+      } else if (inJob) {
+        // Entered the next job — stop scanning.
+        inNextJob = true;
+      }
+    }
+
+    if (!inJob || inNextJob) continue;
+
+    // Found a turbo typecheck invocation inside the ci-typecheck job.
+    if (TURBO_CMD_PATTERN.test(line)) {
+      if (!line.includes(REQUIRED_FLAG)) {
+        findings.push({ lineNumber: i + 1, content: line.trim() });
+      }
+    }
+  }
+
+  if (findings.length === 0) {
+    console.log(
+      `[ci-typecheck-gate-guard] PASS — ci-typecheck gate invokes turbo with ${REQUIRED_FLAG}.`
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    '[ci-typecheck-gate-guard] FAIL — ci-typecheck gate is missing --force.'
+  );
+  console.error('');
+  console.error(
+    'A stale Turbo remote cache can replay a SUCCESS from a prior commit,'
+  );
+  console.error(
+    'producing a false-green merge gate (JOV-3499). The gate MUST use --force.'
+  );
+  console.error('');
+  for (const { lineNumber, content } of findings) {
+    console.error(`  Line ${lineNumber}: ${content}`);
+  }
+  console.error('');
+  console.error(
+    `Remediation: add ${REQUIRED_FLAG} to the turbo typecheck command in ${WORKFLOW_PATH}`
+  );
+  process.exit(1);
+}
+
+main();

--- a/turbo.json
+++ b/turbo.json
@@ -90,7 +90,12 @@
     "typecheck": {
       "description": "Runs TypeScript compiler in noEmit mode to verify type correctness across the workspace",
       "dependsOn": ["^typecheck"],
-      "inputs": ["$TURBO_DEFAULT$", "tsconfig.json", "tsconfig.*.json"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "package.json"
+      ],
       "outputs": [".cache/tsbuildinfo"]
     },
     "dev": {


### PR DESCRIPTION
## Summary

- **Root cause:** `ci-typecheck` ran `pnpm turbo typecheck --affected` without `--force`, so Turbo's remote cache could replay a stale SUCCESS from a prior commit. During the @sentry/nextjs v10 incident, main was type-red but the merge gate stayed green via a cached replay.
- **Secondary vector:** CI also restored `.cache/tsbuildinfo` from GH Actions cache. A stale tsbuildinfo tells `tsc --incremental` that nothing changed, producing a false green even if the Turbo cache were bypassed.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add `--force` to the `ci-typecheck` turbo command; remove the GH Actions tsbuildinfo cache restore |
| `turbo.json` | Add `package.json` to `typecheck` task inputs (busts local cache on dep version changes) |
| `scripts/ci-typecheck-gate-guard.mjs` | New Structural Contract check — fails CI if `--force` is ever dropped from the gate |
| `package.json` | Wire `ci:typecheck-gate-guard` script |

## Fail-then-pass evidence

**Buggy state** (`--affected`, no `--force`, stale tsbuildinfo simulated):
```
@jovie/web:typecheck: cache hit, replaying logs fe22611f98acf98f
Tasks:    3 successful, 3 total / Cached: 3 cached → exit 0 (FALSE GREEN)
```

**Fixed state** (`--affected --force`, no tsbuildinfo restore, deliberate type error introduced):
```
@jovie/web:typecheck: cache bypass, force executing 7b8de50e78c9ba39
lib/analytics.ts(7,7): error TS2322: Type 'string' is not assignable to type 'number'.
@jovie/web#typecheck: command exited (2) → exit 1 (CORRECTLY RED)
```

**Guard** — fails when `--force` missing, passes when present:
```
FAIL: [ci-typecheck-gate-guard] FAIL — ci-typecheck gate is missing --force. (exit 1)
PASS: [ci-typecheck-gate-guard] PASS — ci-typecheck gate invokes turbo with --force. (exit 0)
```

## Cost Impact

- **Extra CI time:** ~1–2 minutes per PR (one fresh tsc run instead of a cache replay)
- **Monthly cost:** $0 — no external services, just runner minutes already in the CI budget
- **Scaling factor:** O(1) per PR, no user-count dependency

Closes JOV-3499.

<!-- linear-issue-id: JOV-3499 -->