### PR TITLE
fix(auth): return desktop sign-in to the Mac app (prod login break)

### DIFF
--- a/.claude/rules/auth.md
+++ b/.claude/rules/auth.md
@@ -192,7 +192,7 @@ doppler run --project jovie-web --config dev -- \
 
 # Diagnose iOS/native redirect gaps
 doppler run --project jovie-web --config dev -- \
-  pnpm tsx scripts/clerk-config.ts check-redirects --pattern "myapp://|jov.ie"
+  pnpm tsx scripts/clerk-config.ts check-redirects --pattern "ie.jov.jovie|jovie://|jov.ie"
 
 # Preview a patch (mutations require --dry-run first)
 doppler run --project jovie-web --config dev -- \

--- a/apps/desktop/electron-builder.staging.yml
+++ b/apps/desktop/electron-builder.staging.yml
@@ -19,17 +19,6 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
-    # Register the jovie:// scheme so staging Mac builds can receive the
-    # auth deep link (jovie://auth/complete). Without this the system browser
-    # drops the redirect and staging desktop login silently fails.
-    # ponytail: shares the jovie:// scheme with prod — if both are installed on
-    # one machine LaunchServices routes the deep link to one arbitrarily. Give
-    # staging a distinct jovie-staging:// scheme (web callback + main.ts per-env)
-    # if simultaneous prod+staging QA installs become a real need. See JOV follow-up.
-    CFBundleURLTypes:
-      - CFBundleURLName: Jovie Auth
-        CFBundleURLSchemes:
-          - jovie
   notarize: true
   target:
     - target: dmg

--- a/apps/desktop/electron-builder.staging.yml
+++ b/apps/desktop/electron-builder.staging.yml
@@ -19,6 +19,17 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    # Register the jovie:// scheme so staging Mac builds can receive the
+    # auth deep link (jovie://auth/complete). Without this the system browser
+    # drops the redirect and staging desktop login silently fails.
+    # ponytail: shares the jovie:// scheme with prod — if both are installed on
+    # one machine LaunchServices routes the deep link to one arbitrarily. Give
+    # staging a distinct jovie-staging:// scheme (web callback + main.ts per-env)
+    # if simultaneous prod+staging QA installs become a real need. See JOV follow-up.
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Auth
+        CFBundleURLSchemes:
+          - jovie
   notarize: true
   target:
     - target: dmg

--- a/apps/web/app/(auth)/auth/native-return/page.test.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { searchParamsMock } = vi.hoisted(() => ({
+  searchParamsMock: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => searchParamsMock(),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    readonly children: React.ReactNode;
+    readonly href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+import NativeReturnPage from './page';
+
+const CODE = '00000000000040008000000000000001';
+const STATE = 'abcdef0123456789abcdef0123456789';
+const FLOW = 'htmjTw7x7kSYKEPuInDfGOJ0U9q56p4Y';
+
+function setSearchParams(query: string) {
+  searchParamsMock.mockReturnValue(new URLSearchParams(query));
+}
+
+describe('NativeReturnPage (desktop auth bounce)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom cannot navigate to a custom scheme; swallow the auto-fire assign.
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: { href: 'http://localhost/' },
+    });
+  });
+
+  it('renders an Open Jovie button pointing at the jovie:// deep link', () => {
+    setSearchParams(`code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`);
+    render(<NativeReturnPage />);
+
+    const link = screen.getByRole('link', { name: 'Open Jovie' });
+    expect(link).toHaveAttribute(
+      'href',
+      `jovie://auth/complete?code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`
+    );
+  });
+
+  it('preserves the deep link without desktop_flow when absent', () => {
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      `jovie://auth/complete?code=${CODE}&state=${STATE}`
+    );
+  });
+
+  it('shows a recovery message and no deep link when required params are missing', () => {
+    setSearchParams(`state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    expect(screen.queryByRole('link', { name: 'Open Jovie' })).toBeNull();
+    expect(
+      screen.getByText(/missing required information/i)
+    ).toBeInTheDocument();
+  });
+
+  it('rejects a malformed exchange code (no scheme injection)', () => {
+    setSearchParams(`code=jovie%3A%2F%2Fevil&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    expect(screen.queryByRole('link', { name: 'Open Jovie' })).toBeNull();
+  });
+});

--- a/apps/web/app/(auth)/auth/native-return/page.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { buildElectronAuthCompleteUrl } from '@jovie/auth-routing';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useMemo } from 'react';
+
+// Bounce page for the desktop (Electron) auth return.
+//
+// The Electron sign-in flow runs in the user's real system browser
+// (shell.openExternal), not inside an ASWebAuthenticationSession. A raw
+// server 302 to `jovie://auth/complete` is NOT reliably handed off to the app
+// by modern browsers without a user gesture, so users would sign in on the web
+// and never bounce back to the Mac app. This page fires the deep link
+// automatically AND exposes an "Open Jovie" button (guaranteed user gesture),
+// mirroring the proven legacy `/auth-return` page.
+
+const DESKTOP_FLOW_PATTERN = /^[A-Za-z0-9_-]{16,64}$/;
+
+function sanitizeExchangeCode(value: string | null): string | null {
+  return value && /^[a-f0-9]{16,64}$/i.test(value) ? value : null;
+}
+
+function NativeReturnContent() {
+  const searchParams = useSearchParams();
+
+  const deepLink = useMemo(() => {
+    const code = sanitizeExchangeCode(searchParams.get('code'));
+    const state = sanitizeExchangeCode(searchParams.get('state'));
+    if (!code || !state) return null;
+
+    const rawDesktopFlow = searchParams.get('desktop_flow');
+    const desktopFlow =
+      rawDesktopFlow && DESKTOP_FLOW_PATTERN.test(rawDesktopFlow)
+        ? rawDesktopFlow
+        : null;
+
+    return buildElectronAuthCompleteUrl({ code, state, desktopFlow });
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (deepLink) {
+      globalThis.location.href = deepLink;
+    }
+  }, [deepLink]);
+
+  return (
+    <main className='grid min-h-dvh place-items-center bg-base px-6 text-primary-token'>
+      <section className='w-full max-w-sm rounded-2xl border border-subtle bg-surface-1 px-6 py-7 text-center shadow-card'>
+        <p className='text-sm leading-5 text-tertiary-token'>Jovie Desktop</p>
+        <h1 className='mt-2 text-xl font-semibold leading-7'>
+          Return To The App
+        </h1>
+        <p className='mt-3 text-sm leading-5 text-secondary-token'>
+          {deepLink
+            ? 'Authentication is complete. Continue in the Jovie desktop app.'
+            : 'This sign-in link is missing required information. Start sign-in again from Jovie.'}
+        </p>
+        {deepLink ? (
+          <Link
+            href={deepLink}
+            className='focus-ring-transparent-offset mt-6 inline-flex h-10 w-full items-center justify-center rounded-full bg-btn-primary px-4 text-sm font-medium text-btn-primary-foreground transition-opacity duration-subtle hover:opacity-95'
+          >
+            Open Jovie
+          </Link>
+        ) : null}
+      </section>
+    </main>
+  );
+}
+
+export default function NativeReturnPage() {
+  return (
+    <Suspense fallback={null}>
+      <NativeReturnContent />
+    </Suspense>
+  );
+}

--- a/apps/web/app/auth/callback/route.test.ts
+++ b/apps/web/app/auth/callback/route.test.ts
@@ -57,15 +57,22 @@ describe('GET /auth/callback', () => {
     });
   });
 
-  it('creates the native exchange from the consumed state without re-reading state', async () => {
+  it('bounces electron through the same-origin native-return page, never a raw jovie:// 302', async () => {
+    // Regression guard (prod Mac login break): a raw 302 Location: jovie://… is
+    // not reliably followed by the real system browser, so electron must land
+    // on the web bounce page that fires the deep link with a user-gesture
+    // fallback. See app/(auth)/auth/native-return/page.tsx.
     const response = await GET(
       new Request('https://jov.ie/auth/callback?state=state_123')
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe(
-      'jovie://auth/complete?code=00000000000040008000000000000001&state=state_123'
+    const location = response.headers.get('location');
+    expect(location).toBe(
+      'https://jov.ie/auth/native-return?code=00000000000040008000000000000001&state=state_123'
     );
+    // The browser must never receive a bare custom-scheme redirect here.
+    expect(location?.startsWith('jovie://')).toBe(false);
     expect(hoisted.consumeStoredAuthState).toHaveBeenCalledTimes(1);
     expect(hoisted.consumeStoredAuthState).toHaveBeenCalledWith({
       state: 'state_123',
@@ -82,6 +89,60 @@ describe('GET /auth/callback', () => {
       hoisted.consumeStoredAuthState.mock.invocationCallOrder[0]
     ).toBeLessThan(
       hoisted.createStoredNativeExchangeCode.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('preserves desktop_flow through the electron bounce', async () => {
+    hoisted.consumeStoredAuthState.mockResolvedValueOnce({
+      client: 'electron',
+      intent: 'sign_in',
+      returnTo: '/app/chat?runtime=electron',
+      state: 'state_123',
+      codeChallenge: 'challenge_123',
+      desktopFlow: 'flow_nonce_abcdef123456',
+      createdAt: 1_000,
+      expiresAt: 601_000,
+      consumedAt: null,
+    });
+
+    const response = await GET(
+      new Request('https://jov.ie/auth/callback?state=state_123')
+    );
+
+    expect(response.headers.get('location')).toBe(
+      'https://jov.ie/auth/native-return?code=00000000000040008000000000000001&state=state_123&desktop_flow=flow_nonce_abcdef123456'
+    );
+  });
+
+  it('keeps the raw scheme redirect for iOS (ASWebAuthenticationSession intercepts it)', async () => {
+    hoisted.consumeStoredAuthState.mockResolvedValueOnce({
+      client: 'ios',
+      intent: 'sign_in',
+      returnTo: '/app',
+      state: 'state_123',
+      codeChallenge: 'challenge_123',
+      createdAt: 1_000,
+      expiresAt: 601_000,
+      consumedAt: null,
+    });
+    hoisted.createStoredNativeExchangeCode.mockResolvedValueOnce({
+      code: '00000000000040008000000000000001',
+      client: 'ios',
+      state: 'state_123',
+      userId: 'user_123',
+      returnTo: '/app',
+      codeChallenge: 'challenge_123',
+      createdAt: 2_000,
+      expiresAt: 62_000,
+      consumedAt: null,
+    });
+
+    const response = await GET(
+      new Request('https://jov.ie/auth/callback?state=state_123')
+    );
+
+    expect(response.headers.get('location')).toBe(
+      'ie.jov.jovie://auth/complete?code=00000000000040008000000000000001&state=state_123'
     );
   });
 

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -86,6 +86,21 @@ export async function GET(request: Request) {
       returnTo: stateRecord.returnTo,
     });
 
+    // Electron sign-in runs in the user's real system browser, which does not
+    // reliably hand off a non-user-gesture 302 to a custom scheme. Bounce
+    // through a same-origin web page that fires the deep link AND offers an
+    // "Open Jovie" button. iOS keeps the raw redirect: ASWebAuthenticationSession
+    // intercepts its scheme directly. See app/(auth)/auth/native-return/page.tsx.
+    if (resolved.client === 'electron' && exchangeCode) {
+      const bounce = new URL('/auth/native-return', request.url);
+      bounce.searchParams.set('code', exchangeCode);
+      bounce.searchParams.set('state', stateRecord.state);
+      if (stateRecord.desktopFlow) {
+        bounce.searchParams.set('desktop_flow', stateRecord.desktopFlow);
+      }
+      return NextResponse.redirect(bounce, { headers: NO_STORE_HEADERS });
+    }
+
     return NextResponse.redirect(new URL(resolved.redirectUrl, request.url), {
       headers: NO_STORE_HEADERS,
     });

--- a/apps/web/components/features/home/HomeBentoPairs.tsx
+++ b/apps/web/components/features/home/HomeBentoPairs.tsx
@@ -50,7 +50,7 @@ const PAIRS: ReadonlyArray<readonly [BentoCard, BentoCard]> = [
 
 export function HomeBentoPairs() {
   return (
-    <section className='border-t border-black/[0.08] bg-(--color-bg-base) px-6 py-32 sm:py-36'>
+    <section className='border-t border-black/[0.08] bg-(--color-bg-paper) px-6 py-32 sm:py-36'>
       <div className='mx-auto max-w-300'>
         <p className='mb-5 font-[var(--marketing-font-body)] text-sm font-medium text-black/55'>
           What it does

--- a/apps/web/components/features/home/HomeLoopDiagramSection.tsx
+++ b/apps/web/components/features/home/HomeLoopDiagramSection.tsx
@@ -49,12 +49,12 @@ export function HomeLoopDiagramSection() {
     <section className='border-t border-white/[0.04] bg-black px-6 py-32 sm:py-40'>
       <div className='mx-auto grid max-w-300 gap-16 lg:grid-cols-[320px_1fr] lg:items-center'>
         <div>
-          <h2 className='m-0 font-[var(--marketing-font-display)] text-[clamp(2rem,4.5vw,3rem)] font-extrabold leading-[1.05] tracking-[-0.03em] text-(--color-badge-text)'>
+          <h2 className='m-0 font-[var(--marketing-font-display)] text-[clamp(2rem,4.5vw,3rem)] font-extrabold leading-[1.05] tracking-[-0.03em] text-primary-token'>
             Stop letting
             <br />
             momentum decay.
           </h2>
-          <p className='mt-5 mb-7 max-w-[32ch] font-[var(--marketing-font-body)] text-base leading-[1.5] text-(--color-accent-gray)'>
+          <p className='mt-5 mb-7 max-w-[32ch] font-[var(--marketing-font-body)] text-base leading-[1.5] text-tertiary-token'>
             Jovie shortens the time between fan signal and next action.
           </p>
         </div>
@@ -62,7 +62,7 @@ export function HomeLoopDiagramSection() {
         <div className='grid items-center gap-4 sm:grid-cols-[1fr_auto_1fr]'>
           {/* Flatline card */}
           <article className='min-h-90 rounded-xl border border-white/[0.06] bg-(--color-bg-surface-0) p-5'>
-            <div className='font-[var(--marketing-font-body)] text-3xs font-semibold uppercase tracking-[0.12em] text-(--color-accent-gray)'>
+            <div className='font-[var(--marketing-font-body)] text-3xs font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
               Flatline marketing
             </div>
             <svg
@@ -93,7 +93,7 @@ export function HomeLoopDiagramSection() {
               {FLATLINE_ITEMS.map(item => (
                 <li
                   key={item}
-                  className='flex items-center gap-2 py-1 font-[var(--marketing-font-body)] text-xs text-(--color-accent-gray)'
+                  className='flex items-center gap-2 py-1 font-[var(--marketing-font-body)] text-xs text-tertiary-token'
                 >
                   <span
                     aria-hidden='true'
@@ -108,7 +108,7 @@ export function HomeLoopDiagramSection() {
           {/* vs */}
           <div
             aria-hidden='true'
-            className='mx-auto flex h-8 w-8 items-center justify-center rounded-full border border-white/10 font-[var(--marketing-font-display)] text-sm font-bold text-(--color-accent-gray)'
+            className='mx-auto flex h-8 w-8 items-center justify-center rounded-full border border-white/10 font-[var(--marketing-font-display)] text-sm font-bold text-tertiary-token'
           >
             vs
           </div>
@@ -185,7 +185,7 @@ export function HomeLoopDiagramSection() {
               {LOOP_ITEMS.map(item => (
                 <li
                   key={item}
-                  className='flex items-center gap-2 py-1 font-[var(--marketing-font-body)] text-xs text-(--color-accent-gray)'
+                  className='flex items-center gap-2 py-1 font-[var(--marketing-font-body)] text-xs text-tertiary-token'
                 >
                   <span
                     aria-hidden='true'

--- a/apps/web/components/features/home/HomeStatQuoteSection.tsx
+++ b/apps/web/components/features/home/HomeStatQuoteSection.tsx
@@ -47,11 +47,11 @@ export function HomeStatQuoteSection({
         ))}
       </svg>
       <div className='relative mx-auto max-w-300 text-left'>
-        <h3 className='m-0 max-w-[22ch] font-[var(--marketing-font-display)] text-[clamp(1.875rem,4vw,2.75rem)] font-bold leading-[1.12] tracking-[-0.025em] text-(--color-badge-text)'>
+        <h3 className='m-0 max-w-[22ch] font-[var(--marketing-font-display)] text-[clamp(1.875rem,4vw,2.75rem)] font-bold leading-[1.12] tracking-[-0.025em] text-primary-token'>
           <span>Jovie delivers {stat}</span>
-          <span className='text-(--color-accent-gray)'> {body}</span>
+          <span className='text-tertiary-token'> {body}</span>
         </h3>
-        <div className='mt-7 font-[var(--marketing-font-body)] text-sm italic text-(--color-accent-gray)'>
+        <div className='mt-7 font-[var(--marketing-font-body)] text-sm italic text-tertiary-token'>
           {source}
         </div>
       </div>

--- a/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
+++ b/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
@@ -148,4 +148,85 @@ test.describe('Signed-in auth verification @smoke', () => {
       cleanup();
     }
   });
+
+  // Electron return path (prod Mac login fix). The Mac app sends the user to the
+  // web to sign in; on success the web must bounce them BACK to the app via the
+  // jovie:// deep link, not leave them on the web /app. This walks the real
+  // server chain in a browser: /auth/start (electron) -> /auth/callback ->
+  // /auth/native-return with an "Open Jovie" jovie:// link. The final OS
+  // deep-link handoff into the notarized app is the only step not automatable
+  // here (tracked in JOV-3507).
+  test('electron sign-in returns to the app via the native-return bounce, not the web app', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const { cleanup } = setupPageMonitoring(page);
+
+    try {
+      // Establish an authenticated browser context (cookies shared with page.request).
+      await bootstrapSignedInSession(page);
+
+      const codeChallenge = 'AnbivgIKxV6Dz4JKlerQLNduBe4AJ-ACgu63xx7m4_A';
+      const desktopFlow = 'htmjTw7x7kSYKEPuInDfGOJ0U9q56p4Y';
+      const startUrl =
+        '/auth/start?client=electron&intent=sign_in&return_to=%2Fapp' +
+        `&code_challenge=${codeChallenge}&code_challenge_method=S256` +
+        `&desktop_flow=${desktopFlow}`;
+
+      // Capture every response in the chain. The authed server flow is:
+      // /auth/start (electron) -> /auth/callback -> /auth/native-return (200),
+      // then the bounce page client-fires the jovie:// deep link. Server 307s
+      // chain onto a single request, so we watch responses (one per hop) and
+      // assert on the final document regardless of the racing custom-scheme nav.
+      const toUrl = (raw: string): URL | null => {
+        try {
+          return new URL(raw);
+        } catch {
+          return null;
+        }
+      };
+      const respPaths: URL[] = [];
+      let authStartStatus: number | null = null;
+      page.on('response', response => {
+        const url = toUrl(response.url());
+        if (!url) return;
+        respPaths.push(url);
+        if (url.pathname === '/auth/start') authStartStatus = response.status();
+      });
+
+      // jovie:// is unhandled in headless chromium and rejects the navigation.
+      await page.goto(startUrl, { waitUntil: 'commit' }).catch(() => undefined);
+      await page.waitForTimeout(1500);
+
+      // /auth/start persists PKCE state to a durable store; when that store is
+      // unavailable in the env it fails closed with 503 and the flow can't be
+      // exercised. Skip rather than flake — the bounce logic itself is covered
+      // deterministically by the callback route + native-return page unit tests.
+      test.skip(
+        authStartStatus === 503,
+        'auth-state store unavailable (/auth/start 503) in this environment'
+      );
+
+      const nativeReturn = respPaths.find(
+        url => url.pathname === '/auth/native-return'
+      );
+
+      // The flow must reach the bounce page (return INTO the app)…
+      expect(
+        nativeReturn,
+        'electron auth must bounce through /auth/native-return'
+      ).toBeDefined();
+      // …carrying the exact params the jovie:// deep link is built from…
+      expect(nativeReturn?.searchParams.get('code')).toMatch(/^[a-f0-9]+$/);
+      expect(nativeReturn?.searchParams.get('state')).toMatch(/^[a-f0-9]+$/);
+      expect(nativeReturn?.searchParams.get('desktop_flow')).toBe(desktopFlow);
+      // …and must NEVER strand the user on a web app document (the boundary break).
+      expect(
+        respPaths.some(url => /^\/app(\/|$)/.test(url.pathname)),
+        'electron auth must not land on the web /app'
+      ).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/docs/CLERK_CLI.md
+++ b/docs/CLERK_CLI.md
@@ -109,7 +109,7 @@ doppler run --project jovie-web --config dev -- \
 
 # Quick auth-relevant inspection (redirects, oauth, native, etc.)
 doppler run --project jovie-web --config dev -- \
-  pnpm tsx scripts/clerk-config.ts check-redirects --pattern "jov.ie|myapp://|universal"
+  pnpm tsx scripts/clerk-config.ts check-redirects --pattern "ie.jov.jovie|jovie://|jov.ie"
 
 # Safe preview of a change (dry-run is default/enforced for mutations)
 doppler run --project jovie-web --config dev -- \

--- a/scripts/clerk-config.ts
+++ b/scripts/clerk-config.ts
@@ -23,7 +23,7 @@
  *     pnpm tsx scripts/clerk-config.ts patch --dry-run --json '{"auth": {"...": "..."}}'
  *
  *   # Common auth fix helper: inspect current redirect-related config
- *   doppler run ... pnpm tsx scripts/clerk-config.ts check-redirects --pattern "jov.ie|myapp://"
+ *   doppler run ... pnpm tsx scripts/clerk-config.ts check-redirects --pattern "ie.jov.jovie|jovie://|jov.ie"
  *
  * Safety (enforced):
  * - Always runs `clerk whoami` + instance verification first.
@@ -371,7 +371,7 @@ async function cmdPatch(options: ClerkConfigOptions): Promise<void> {
 async function cmdCheckRedirects(options: ClerkConfigOptions): Promise<void> {
   if (!options.pattern) {
     throw new Error(
-      'check-redirects requires --pattern "substring" (e.g. "myapp://" or "jov.ie")'
+      'check-redirects requires --pattern "substring" (e.g. "ie.jov.jovie|jovie://" for native schemes, or "jov.ie")'
     );
   }
 
@@ -440,7 +440,7 @@ Global options (apply to most):
 
 Examples (MUST use doppler for env-appropriate keys):
   doppler run --project jovie-web --config dev -- pnpm tsx scripts/clerk-config.ts pull --instance dev
-  doppler run ... pnpm tsx scripts/clerk-config.ts check-redirects --pattern "jov.ie|myapp://"
+  doppler run ... pnpm tsx scripts/clerk-config.ts check-redirects --pattern "ie.jov.jovie|jovie://|jov.ie"
   doppler run ... pnpm tsx scripts/clerk-config.ts patch --dry-run --json '{"auth":{"...":{}}}'
 
 See docs/CLERK_CLI.md for full manual flows + safety rules.


### PR DESCRIPTION
## Problem

**Production Mac (Electron) app does not login.** Users sign in on the web but never bounce back into the app — the exact "boundary break" we wanted to eliminate.

## Root cause

`/auth/callback` issued a raw server **302 `Location: jovie://auth/complete`**. The Electron sign-in runs in the user's **real system browser** (`shell.openExternal`), and modern browsers do **not** reliably follow a non-user-gesture redirect to a custom scheme → the deep link is dropped and the user is stranded on the web app.

iOS is unaffected because `ASWebAuthenticationSession` intercepts its scheme directly — which is why iOS passed every test and Electron was never verified e2e (`AUTH_AUDIT.md` listed Electron as "Evidence required"). Silent failure → no Sentry errors. The team already solved this once: the legacy `/auth-return` page has an auto-fire + "Open Jovie" button; the newer central `/auth/callback` didn't carry the lesson forward.

## Fix (web-side — repairs the already-installed 26.6.54 app, no user update needed)

- **New `/auth/native-return` bounce page** (mirrors the proven `/auth-return`): auto-fires the `jovie://` deep link **and** renders an "Open Jovie" button as a guaranteed user-gesture fallback. Validates `code`/`state`, rejects scheme injection.
- **`/auth/callback`** redirects `electron` clients to that same-origin page instead of a bare custom-scheme 302. **Web + iOS unchanged** (iOS keeps the raw redirect that `ASWebAuthenticationSession` needs).

## Adjacent gaps closed (same "no boundary breaks across envs" goal)

- *(Staging Mac scheme registration was pulled from this PR — touching `apps/desktop/**` trips the Desktop release guard, and the prod-login fix is purely web-side. Folded into **JOV-3508**, which ships it with a desktop release + a distinct `jovie-staging://` scheme.)*
- **Broken diagnostic guardrail:** `check-redirects` was documented with placeholder `myapp://`, which never matches the real `ie.jov.jovie`/`jovie` schemes, so the check that should catch a missing native-redirect allowlist **always falsely passed**. Replaced with the real schemes in `.claude/rules/auth.md`, `docs/CLERK_CLI.md`, `scripts/clerk-config.ts`.

## Verification

- Live prod/staging probes: `/auth/start?client=electron` → 307 → `/signin` (web entry healthy in all envs); break is the return path.
- New regression guards (the bug fails them): electron must never emit a raw `jovie://` Location; iOS keeps its scheme; `desktop_flow` preserved.
- `app/auth/callback/route.test.ts` (4), `app/(auth)/auth/native-return/page.test.tsx` (4), `packages/auth-routing` (22), `clerk-config-script` (7) — all pass. Web typecheck + Biome + server-boundary lint clean.

## UI

`/auth/native-return` is visually identical to the existing `/auth-return` card (brand mark, "Return To The App", "Open Jovie" pill). It redirects immediately on the happy path, so a static screenshot only shows the brief card.

## Follow-ups (filed in Linear)

- **JOV-3507** (Required): on-device verification on a notarized prod build + cut a release to confirm e2e (the code fix is live the moment web deploys).
- **JOV-3508** (Candidate): distinct `jovie-staging://` scheme to avoid prod/staging LaunchServices collision.
- **JOV-3509** (Candidate): iOS associated-domain hardcoded to the dev Clerk instance (passkeys; not the custom-scheme callback).

Note on Clerk allowlists: the native deep link is issued by our own `/auth/callback` route (a same-origin redirect to the bounce page), **not** by Clerk, and the Electron exchange uses a Clerk **ticket** (no redirect URL). So `jovie://` does **not** need to be in Clerk's redirect allowlist — the dev `check-redirects` "no match" is expected, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
