### PR TITLE
fix(auth): make onboarding Turnstile fully invisible (JOV-3305)

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
+++ b/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
@@ -12,12 +12,17 @@ import { isOnboardingLocalAutomationBypassRuntime } from './onboardingAutomation
 /**
  * Cloudflare Turnstile widget for the onboarding chat (JOV-2132 PR 3).
  *
- * Loads the Turnstile script and mounts a Managed widget inside the onboarding
- * composer security panel. The resulting token is passed back via `onToken`,
- * then consumed by the chat client on the first /api/chat POST in
+ * Loads the Turnstile script and mounts a fully invisible (executed) Turnstile
+ * widget inside the onboarding composer. The resulting token is passed back via
+ * `onToken`, then consumed by the chat client on the first /api/chat POST in
  * `mode='onboarding'`. Subsequent messages within the same session rely on the
  * signed session cookie + the session-lifetime rate limiter and do NOT
  * re-verify.
+ *
+ * The widget uses `appearance: 'execute'` (fully invisible/managed mode) —
+ * no visible UI, no "Security Check" panel, no bordered widget frame. If
+ * Cloudflare requires interaction or the challenge fails, the error surfaces
+ * as a compact toast in OnboardingShell, never as inline Turnstile UI (JOV-3305).
  *
  * In local development, the widget short-circuits and the chat handler's
  * dev-mode skip kicks in.
@@ -163,6 +168,10 @@ export function isOnboardingTurnstilePanelVisible(
 ): boolean {
   if (instruction) return true;
   if (!siteKey) return true;
+  // In execute (invisible) mode, 'interactive' status should never fire.
+  // We keep the check for defensive completeness but it will be unreachable
+  // in normal operation. Only error/timeout/expired/unsupported surface
+  // the compact error panel — never the bordered widget frame (JOV-3305).
   return (
     state.status === 'interactive' ||
     state.status === 'error' ||
@@ -246,7 +255,7 @@ export function OnboardingTurnstile({
       commitState(DEFAULT_STATE);
       widgetIdRef.current = turnstile.render(containerRef.current, {
         sitekey: siteKey,
-        appearance: 'interaction-only',
+        appearance: 'execute',
         size: 'flexible',
         theme: 'dark',
         callback: token => {

--- a/apps/web/tests/e2e/synthetic-golden-path.spec.ts
+++ b/apps/web/tests/e2e/synthetic-golden-path.spec.ts
@@ -88,6 +88,55 @@ test.describe('Synthetic Monitoring - Golden Path', () => {
     }
   });
 
+  test('Onboarding start page shows no visible Turnstile UI (JOV-3305)', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    await page.route('**/api/profile/view', route =>
+      route.fulfill({ status: 200, body: '{}' })
+    );
+    await page.route('**/api/audience/visit', route =>
+      route.fulfill({ status: 200, body: '{}' })
+    );
+    await page.route('**/api/track', route =>
+      route.fulfill({ status: 200, body: '{}' })
+    );
+
+    await page.goto(START_PATH, {
+      waitUntil: 'commit',
+      timeout: SMOKE_TIMEOUTS.NAVIGATION,
+    });
+    await waitForHydration(page);
+
+    // The Turnstile widget must be fully invisible (appearance: 'execute').
+    // No "Security Check" heading, no visible bordered widget frame, no
+    // "Required before your first message" copy should appear on the
+    // golden-path start page. If Cloudflare's Turnstile re-pings or falls
+    // back to interactive mode, this assertion goes red (JOV-3305).
+    await expect(
+      page.getByText('Security Check'),
+      'No visible "Security Check" panel should appear on the start page'
+    ).not.toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByText('Required before your first message.'),
+      'No visible Turnstile interaction prompt should appear on the start page'
+    ).not.toBeVisible();
+    await expect(
+      page.getByTestId('onboarding-turnstile-panel'),
+      'Turnstile panel should not be visible on the golden-path start page'
+    ).not.toBeVisible();
+
+    // The widget frame should exist but be screen-reader-only (invisible).
+    const widgetFrame = page.getByTestId('onboarding-turnstile-widget-frame');
+    if ((await widgetFrame.count()) > 0) {
+      // If the frame exists, it must be hidden (sr-only or not visible)
+      await expect(widgetFrame).not.toBeVisible();
+    }
+
+    console.log('[Synthetic] ✅ No visible Turnstile UI on start page');
+  });
+
   test('Performance baseline check', async ({ page }) => {
     test.setTimeout(60_000);
 

--- a/apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
@@ -71,7 +71,7 @@ describe('OnboardingTurnstile', () => {
         expect.any(HTMLElement),
         expect.objectContaining({
           sitekey: 'site-key',
-          appearance: 'interaction-only',
+          appearance: 'execute',
           size: 'flexible',
         })
       );


### PR DESCRIPTION
## Summary

Change Cloudflare Turnstile from `appearance: 'interaction-only'` to `appearance: 'execute'` (fully invisible/managed mode) on the onboarding chat composer. This eliminates the visible "Security Check" panel, bordered widget frame, and interaction prompts that were causing real-world signup failures when Turnstile re-pinged and fell back to interactive mode.

**Owner directive (Tim White, Slack #product 2026-06-20 to 21):** "the whole turnstile interface is jank, it needs to go away and be invisible entirely."

## Changes

- **`OnboardingTurnstile.tsx`**: Change `appearance: 'interaction-only'` to `appearance: 'execute'`. In execute mode, Turnstile runs fully invisibly. If Cloudflare demands interaction or the challenge fails, the error surfaces as a compact toast in `OnboardingShell`, never as inline Turnstile UI.
- **`OnboardingTurnstile.test.tsx`**: Update the appearance assertion. All 12 tests pass.
- **`synthetic-golden-path.spec.ts`**: Add a deterministic golden-path e2e assertion that verifies no visible Turnstile UI appears on the `/start` page. This would have caught the Turnstile re-ping issue that was blocking real-world signups.

## Validation

- 12/12 unit tests pass (`OnboardingTurnstile.test.tsx`)
- Biome lint/format clean
- ESLint clean (0 warnings)
- a11y check clean
- Typecheck passes
- Pre-commit hooks all green (gitleaks, trufflehog, biome, eslint, a11y, typecheck)

## Risk

Auth-sensitive change. Server-side verification (`verifyTurnstileToken`) is unchanged. The change only affects client-side widget rendering mode. Rollback: revert the single commit.

## What this does NOT cover (follow-up within JOV-3305 scope)

The full deterministic golden-path e2e test (land to sign up to onboarding to chat to profile published) against prod/staging is a separate test infrastructure piece. This PR adds the Turnstile visibility assertion to the existing synthetic golden-path test. The full end-to-end golden-path test is tracked within JOV-3305 scope item 2.

Linear: https://linear.app/jovie/issue/JOV-3305/p0-real-world-signup-golden-path-fully-invisible-turnstile

<!-- linear-issue-id:JOV-3305 -->

[Continue this on Linzumi](https://serve.linzumi.com/w/itstimwhite-workspace/thread/itstimwhite-office/ae8a84f7-90e8-47a4-8742-b00a0d096b40)