### PR TITLE
fix(chat): stop transcript flash on send by preserving timeline identity

### DIFF
--- a/apps/web/components/jovie/timeline/chat-timeline.ts
+++ b/apps/web/components/jovie/timeline/chat-timeline.ts
@@ -557,8 +557,16 @@ function mergeServerMessages(
 
     const existing = messages[index];
     if (shouldKeepLocalContent(existing, serverMessage, options.receivedAt)) {
+      // Never downgrade an already-settled (`complete`) row. A prior refetch can
+      // promote the optimistic user row to `complete`; forcing it back to `sent`
+      // here oscillates its status across subsequent refetches, churning the
+      // memoized transcript and re-flashing it on send (JOV-3528).
+      const nextStatus =
+        serverMessage.role === 'user' && existing.status !== 'complete'
+          ? 'sent'
+          : existing.status;
       messages[index] = mergeServerMetadata(existing, serverMessage, {
-        status: serverMessage.role === 'user' ? 'sent' : existing.status,
+        status: nextStatus,
         receivedAt: options.receivedAt,
       });
       continue;
@@ -578,7 +586,14 @@ function mergeServerMessages(
     }
   }
 
-  const sortedMessages = sortTimeline(messages);
+  // Reuse the prior array reference when the merge changed nothing the renderer
+  // reads. Without this, every refetch hands the transcript a fresh array, which
+  // re-runs `messages.map` and the scroll/jank effects even though the content is
+  // identical — a contributor to the on-send flash (JOV-3528).
+  const sortedMessages = preserveTimelineIdentity(
+    state.messages,
+    sortTimeline(messages)
+  );
 
   return {
     ...state,
@@ -605,6 +620,23 @@ function mergeServerMessages(
       }
     ),
   };
+}
+
+/**
+ * Returns the previous messages array when `next` is element-wise reference
+ * identical (same order, same objects). Lets a no-op refetch leave the rendered
+ * list untouched so React skips re-running `messages.map` and dependent effects.
+ */
+function preserveTimelineIdentity(
+  previous: readonly ChatTimelineMessage[],
+  next: readonly ChatTimelineMessage[]
+): readonly ChatTimelineMessage[] {
+  if (previous === next) return previous;
+  if (previous.length !== next.length) return next;
+  for (let index = 0; index < previous.length; index++) {
+    if (previous[index] !== next[index]) return next;
+  }
+  return previous;
 }
 
 function normalizeServerMessage(
@@ -637,7 +669,7 @@ function mergeServerMetadata(
     readonly receivedAt: number;
   }
 ): ChatTimelineMessage {
-  return {
+  const merged: ChatTimelineMessage = {
     ...existing,
     status: options.status ?? existing.status,
     clientMessageId: serverMessage.clientMessageId ?? existing.clientMessageId,
@@ -646,6 +678,11 @@ function mergeServerMetadata(
     serverMessageId: serverMessage.id,
     updatedAt: Math.max(existing.updatedAt, options.receivedAt),
   };
+
+  // Metadata-only merges (server acknowledging an optimistic row) must not
+  // change the rendered identity. Preserve the original object when only
+  // non-rendered bookkeeping fields would change (JOV-3528).
+  return rowRenderEqual(existing, merged) ? existing : merged;
 }
 
 function mergeServerContent(
@@ -653,9 +690,19 @@ function mergeServerContent(
   serverMessage: ChatTimelineMessage,
   receivedAt: number
 ): ChatTimelineMessage {
-  return {
+  // Preserve the existing `parts` reference when the server payload is
+  // content-identical. A refetch (title polling, post-stream invalidation)
+  // otherwise hands every matched row a fresh `parts` array, which breaks the
+  // memoized `ChatMessage` reference check and replays its entrance animation —
+  // the whole transcript flashes blank then re-renders on each send
+  // (JOV-3528, regression of the JOV-2559 merge contract).
+  const nextParts = messagePartsEqual(existing.parts, serverMessage.parts)
+    ? existing.parts
+    : serverMessage.parts;
+
+  const merged: ChatTimelineMessage = {
     ...existing,
-    parts: serverMessage.parts,
+    parts: nextParts,
     status: 'complete',
     clientMessageId: serverMessage.clientMessageId ?? existing.clientMessageId,
     turnId: serverMessage.turnId ?? existing.turnId,
@@ -664,6 +711,74 @@ function mergeServerContent(
     updatedAt: Math.max(existing.updatedAt, receivedAt),
     completedAt: existing.completedAt ?? receivedAt,
   };
+
+  // If nothing the renderer reads changed, return the original object so React
+  // reconciliation treats the row as untouched (no remount, no entrance flash).
+  return rowRenderEqual(existing, merged) ? existing : merged;
+}
+
+/**
+ * Structural equality for the fields a rendered row depends on. Used to keep
+ * message object identity stable across no-op server merges so the memoized
+ * transcript does not re-render or replay entrance animations.
+ */
+function rowRenderEqual(
+  left: ChatTimelineMessage,
+  right: ChatTimelineMessage
+): boolean {
+  return (
+    left.id === right.id &&
+    left.role === right.role &&
+    left.status === right.status &&
+    left.parts === right.parts
+  );
+}
+
+/**
+ * Shallow-ish structural comparison of message parts. Avoids JSON.stringify on
+ * a path that runs on every conversation refetch. Returns true when both arrays
+ * describe the same renderable content.
+ */
+function messagePartsEqual(
+  left: readonly MessagePart[],
+  right: readonly MessagePart[]
+): boolean {
+  if (left === right) return true;
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index++) {
+    if (!messagePartEqual(left[index], right[index])) return false;
+  }
+  return true;
+}
+
+function messagePartEqual(left: MessagePart, right: MessagePart): boolean {
+  if (left === right) return true;
+  if (left.type !== right.type) return false;
+
+  const leftText =
+    'text' in left && typeof left.text === 'string' ? left.text : undefined;
+  const rightText =
+    'text' in right && typeof right.text === 'string' ? right.text : undefined;
+  if (leftText !== rightText) return false;
+
+  const leftUrl =
+    'url' in left && typeof left.url === 'string' ? left.url : undefined;
+  const rightUrl =
+    'url' in right && typeof right.url === 'string' ? right.url : undefined;
+  if (leftUrl !== rightUrl) return false;
+
+  // Tool/dynamic parts carry richer payloads; fall back to a structural compare
+  // only for these (rare on the refetch path) so we never wrongly treat a
+  // changed tool result as identical.
+  const type = left.type;
+  if (
+    typeof type === 'string' &&
+    (type.startsWith('tool-') || type === 'dynamic-tool')
+  ) {
+    return JSON.stringify(left) === JSON.stringify(right);
+  }
+
+  return true;
 }
 
 function shouldKeepLocalContent(

--- a/apps/web/tests/unit/chat/chat-timeline-reducer.test.ts
+++ b/apps/web/tests/unit/chat/chat-timeline-reducer.test.ts
@@ -377,4 +377,128 @@ describe('chat timeline reducer', () => {
       textPart('Please answer'),
     ]);
   });
+
+  // Regression guard for JOV-3528: an on-send refetch (title polling, post-stream
+  // query invalidation) returns the same completed messages and must NOT hand the
+  // transcript fresh message objects / a fresh array. New references break the
+  // memoized `ChatMessage` reference check and replay its entrance animation,
+  // which reads as the whole transcript flashing blank then re-rendering.
+  describe('on-send refetch does not destructively replace settled content', () => {
+    const serverEcho = [
+      {
+        id: 'msg_user_server',
+        role: 'user' as const,
+        parts: [textPart('Hello')],
+        createdAt: new Date(100),
+        clientMessageId: 'turn_client_1:user',
+        turnId: 'turn_server',
+      },
+      {
+        id: 'msg_assistant_server',
+        role: 'assistant' as const,
+        parts: [textPart('Hi there, here is your answer.')],
+        createdAt: new Date(101),
+        clientMessageId: 'assistant:turn_client_1',
+        turnId: 'turn_server',
+      },
+    ];
+
+    // Fresh objects every call, mirroring a real React Query JSON response.
+    function freshServerEcho() {
+      return serverEcho.map(message => ({
+        ...message,
+        parts: message.parts.map(part => ({ ...part })),
+      }));
+    }
+
+    function settledConversation() {
+      // send → server acknowledges (user row goes `sent`) → stream completes.
+      const sent = reduceChatTimeline(
+        createInitialChatTimelineState('conv_1'),
+        {
+          type: 'message.send.started',
+          conversationId: 'conv_1',
+          clientTurnId: 'turn_client_1',
+          clientMessageId: 'turn_client_1:user',
+          requestId: 'req_1',
+          parts: [textPart('Hello')],
+          now: 100,
+        }
+      );
+      const acknowledged = reduceChatTimeline(sent, {
+        type: 'message.send.acknowledged',
+        conversationId: 'conv_1',
+        clientTurnId: 'turn_client_1',
+        turnId: 'turn_server',
+        serverUserMessageId: 'msg_user_server',
+        now: 150,
+      });
+      const completed = reduceChatTimeline(acknowledged, {
+        type: 'assistant.stream.completed',
+        conversationId: 'conv_1',
+        clientTurnId: 'turn_client_1',
+        turnId: 'turn_server',
+        requestId: 'req_1',
+        parts: [textPart('Hi there, here is your answer.')],
+        now: 500,
+      });
+      // First refetch settles server metadata onto the rows.
+      return reduceChatTimeline(completed, {
+        type: 'conversation.refetch.succeeded',
+        conversationId: 'conv_1',
+        requestId: 'refetch_0',
+        receivedAt: 550,
+        messages: freshServerEcho(),
+      });
+    }
+
+    it('preserves message + array identity across a steady-state refetch', () => {
+      const settled = settledConversation();
+      const before = selectRenderableMessages(settled);
+
+      // A subsequent refetch (e.g. title-poll tick) with identical content must
+      // leave the rendered list untouched — no new array, no new row objects, no
+      // new `parts` references. New references would replay the memoized
+      // ChatMessage entrance animation = the transcript flash on send (JOV-3528).
+      const refetched = reduceChatTimeline(settled, {
+        type: 'conversation.refetch.succeeded',
+        conversationId: 'conv_1',
+        requestId: 'refetch_1',
+        receivedAt: 600,
+        messages: freshServerEcho(),
+      });
+
+      const after = selectRenderableMessages(refetched);
+
+      expect(after.map(m => m.id)).toEqual(before.map(m => m.id));
+      expect(after).toBe(before);
+      for (let index = 0; index < before.length; index++) {
+        expect(after[index]).toBe(before[index]);
+        expect(after[index]?.parts).toBe(before[index]?.parts);
+      }
+    });
+
+    it('keeps streamed assistant content stable across repeated refetches', () => {
+      const settled = settledConversation();
+      let state = settled;
+      // Hammer the refetch path the way title polling + invalidation does.
+      for (let tick = 0; tick < 4; tick++) {
+        state = reduceChatTimeline(state, {
+          type: 'conversation.refetch.succeeded',
+          conversationId: 'conv_1',
+          requestId: `refetch_loop_${tick}`,
+          receivedAt: 700 + tick,
+          messages: freshServerEcho(),
+        });
+      }
+
+      const messages = selectRenderableMessages(state);
+      expect(messages).toBe(selectRenderableMessages(settled));
+      expect(messages[messages.length - 1]).toMatchObject({
+        id: 'assistant:turn_client_1',
+        status: 'complete',
+        parts: [textPart('Hi there, here is your answer.')],
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3528 -->

Fixes **JOV-3528** — Web chat: reply flashes blank then re-renders repeatedly on send (destructive state-replacement regression).

## Problem
On submit, the chat transcript flashed blank → re-showed prior content → blanked → re-showed, then began streaming. Multiple full-transcript flashes per send.

## Root cause
A regression of the JOV-2559 canonical-timeline merge contract, in the **send → hydrate → stream** handoff rather than the reducer's destructive-removal guards (which were intact).

On every send the conversation query refetches twice — once via `onFinish` query invalidation and again via title polling (`refetchInterval`). Each refetch fed the reducer a fresh server payload, and `mergeServerMessages` rebuilt **new row objects and a new `parts` array even when the content was byte-identical**. Because `ChatMessage` is `memo`-ized on `parts` reference + `status`, new references made it re-render, and since refetched rows aren't in `knownMessageIdsRef`, the `initial: { opacity: 0 } → 1` entrance animation replayed — reading as the whole transcript flashing blank then fading back in. A secondary contributor: the optimistic user row oscillated `complete → sent → complete` across refetches because the keep-local metadata branch always forced `sent`.

## Fix (`apps/web/components/jovie/timeline/chat-timeline.ts`)
- `mergeServerContent` reuses the existing `parts` reference and returns the **original row object** when nothing the renderer reads changed (new `messagePartsEqual` / `rowRenderEqual` helpers; tool/dynamic parts still deep-compared so real changes aren't masked).
- `mergeServerMetadata` preserves row identity for metadata-only merges.
- Stop downgrading an already-`complete` user row back to `sent`, which oscillated status across refetches.
- `mergeServerMessages` reuses the prior `messages` array when the merge is a no-op (`preserveTimelineIdentity`), so a steady-state refetch leaves the rendered list — and its scroll/jank effects — untouched.

No component/markup changes; the same design renders, just without the spurious remount. Layout-shift safe (no new conditional states, no key changes — render keys remain `user:${clientTurnId}` / `assistant:${clientTurnId}`).

## Visual states enumerated (no layout shift / no flash on any transition)
optimistic send → acknowledged → streaming → complete → first refetch → steady-state refetch (×N title polls) → completed. Existing rows never unmount/remount on submit.

## Tests
Extended `apps/web/tests/unit/chat/chat-timeline-reducer.test.ts` with a regression block asserting message **and** array object identity is preserved across steady-state and repeated (×4) refetches, and that streamed content stays stable. These tests fail against the pre-fix reducer (verified: 2 failures before fix → 11 passing after).

## Checks run (all green)
- `pnpm --filter @jovie/web run typecheck -- --pretty false` ✅
- `pnpm biome check apps/web/...` ✅ (no fixes)
- `pnpm --filter web exec vitest run tests/unit/chat/chat-timeline-reducer.test.ts` → 11 passed ✅
- `pnpm --filter web exec vitest run tests/unit/chat/` → 738 passed ✅
- pre-push hook (full biome + next:proxy-guard + tailwind:check + typecheck + lint) ✅

## Files changed
- `apps/web/components/jovie/timeline/chat-timeline.ts`
- `apps/web/tests/unit/chat/chat-timeline-reducer.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vtMWhawFMU7Gbn642y2Ls

---
_Generated by [Claude Code](https://claude.ai/code/session_012vtMWhawFMU7Gbn642y2Ls)_