### PR TITLE
docs(pitch): market funnel slide reconciling creator-count axes

### DIFF
--- a/apps/web/public/pitch/market-funnel-slide.html
+++ b/apps/web/public/pitch/market-funnel-slide.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="robots" content="noindex, nofollow">
+<title>Jovie — Market slide</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Manrope:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  /* ── Tokens lifted verbatim from /pitch/index.html ── */
+  :root{
+    --bg:#000000; --ink:#F5F4F0; --ink-2:#A2A7AF; --ink-3:#8A8F98; --ink-4:#4A4E57;
+    --hair:rgba(255,255,255,0.08); --hair-2:rgba(255,255,255,0.14);
+    --blue:#4D7DFF; --red:#FF4D5F; --green:#43B85C;
+    --display:"Manrope",-apple-system,BlinkMacSystemFont,"Helvetica Neue",Arial,sans-serif;
+    --body:"DM Sans",-apple-system,BlinkMacSystemFont,"Helvetica Neue",Arial,sans-serif;
+    --mono:"JetBrains Mono",ui-monospace,"SF Mono",Menlo,monospace;
+  }
+  html,body{margin:0;background:#000;}
+  /* render the authored 1920×1080 frame, centered */
+  .stage{width:1920px;height:1080px;margin:0 auto;position:relative;}
+
+  section{
+    width:1920px;height:1080px;box-sizing:border-box;
+    background:
+      radial-gradient(ellipse 70% 55% at 90% 5%, rgba(77,125,255,0.07) 0%, rgba(0,0,0,0) 55%),
+      radial-gradient(ellipse 55% 35% at 10% 100%, rgba(77,125,255,0.035) 0%, rgba(0,0,0,0) 60%),
+      var(--bg);
+    color:var(--ink);font-family:var(--body);
+    padding:120px 140px;display:flex;flex-direction:column;justify-content:center;
+    position:relative;overflow:hidden;-webkit-font-smoothing:antialiased;
+  }
+  /* film grain — identical to deck */
+  section::before{content:"";position:absolute;inset:0;pointer-events:none;opacity:0.35;
+    mix-blend-mode:overlay;z-index:0;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 0.05 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");}
+  section > *{position:relative;z-index:1;}
+
+  .chrome-logo{position:absolute;top:56px;right:56px;height:24px;width:24px;opacity:0.42;z-index:5;}
+  .num{position:absolute;left:56px;bottom:48px;font-family:var(--mono);font-size:12px;color:var(--ink-4);letter-spacing:0.06em;z-index:5;}
+  .tag{position:absolute;top:56px;left:56px;font-family:var(--mono);font-size:13px;color:var(--ink-3);letter-spacing:-0.005em;font-weight:500;z-index:5;}
+
+  .eyebrow{font-family:var(--body);text-transform:uppercase;letter-spacing:0.18em;font-size:13px;font-weight:500;color:var(--ink-3);display:inline-flex;align-items:center;gap:12px;margin:0 0 56px 0;}
+  .eyebrow::before{content:"";display:inline-block;width:24px;height:1px;background:var(--ink-4);}
+
+  /* ── Funnel ── */
+  .funnel{display:flex;flex-direction:column;gap:22px;}
+  .row{display:flex;align-items:center;gap:36px;}
+  .bar{
+    border:1px solid var(--hair);border-radius:20px;
+    background:linear-gradient(180deg,rgba(255,255,255,0.022) 0%, rgba(255,255,255,0.003) 100%);
+    padding:34px 48px;display:flex;align-items:baseline;gap:40px;position:relative;overflow:hidden;
+  }
+  .bar::before{content:"";position:absolute;top:0;left:0;right:0;height:1px;
+    background:linear-gradient(90deg,rgba(255,255,255,0) 0%, rgba(255,255,255,0.10) 50%, rgba(255,255,255,0) 100%);}
+  .r1 .bar{width:100%;}
+  .r2 .bar{width:64%;}
+  .r3 .bar{width:38%;border-color:rgba(77,125,255,0.30);
+    background:linear-gradient(180deg,rgba(77,125,255,0.08) 0%, rgba(77,125,255,0.012) 100%);}
+
+  .nbig{font-family:var(--display);font-weight:700;font-size:118px;line-height:0.9;letter-spacing:-0.05em;
+    background:linear-gradient(180deg,#ffffff 0%, #c4c4c4 100%);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;white-space:nowrap;}
+  .r3 .nbig{background:linear-gradient(180deg,#6f9aff 0%, #4d7dff 100%);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;}
+  .meta{display:flex;flex-direction:column;gap:8px;padding-bottom:8px;}
+  .label{font-family:var(--display);font-weight:600;font-size:34px;letter-spacing:-0.018em;color:var(--ink);line-height:1.1;}
+  .label .arr{color:var(--blue);}
+  .cap{font-family:var(--body);font-size:21px;color:var(--ink-3);letter-spacing:-0.01em;line-height:1.3;}
+
+  .src{font-family:var(--mono);font-size:15px;color:var(--ink-4);letter-spacing:0.02em;line-height:1.5;white-space:nowrap;}
+  .src b{color:var(--ink-2);font-weight:500;}
+
+  .foot{margin-top:52px;padding-top:26px;border-top:1px solid var(--hair);
+    font-family:var(--mono);font-size:15px;color:var(--ink-4);letter-spacing:0.02em;line-height:1.65;max-width:1500px;}
+  .foot b{color:var(--ink-2);font-weight:500;}
+</style>
+</head>
+<body>
+<div class="stage">
+  <section class="market-funnel">
+    <img class="chrome-logo" src="assets/logo-icon-white.svg" alt="Jovie" onerror="this.style.display='none'">
+    <p class="tag">Market</p>
+
+    <p class="eyebrow">One creator class. One wedge.</p>
+
+    <div class="funnel">
+      <!-- TOP: the new creator class (Suno) -->
+      <div class="row r1">
+        <div class="bar">
+          <span class="nbig">100M</span>
+          <span class="meta">
+            <span class="label">made music on Suno</span>
+            <span class="cap">The new creator class — most for the first time in their lives.</span>
+          </span>
+        </div>
+        <span class="src"><b>Suno</b> · Nov 2025<br>cumulative, trailing 2 yrs</span>
+      </div>
+
+      <!-- MIDDLE: the monetizing core -->
+      <div class="row r2">
+        <div class="bar">
+          <span class="nbig">8.2M</span>
+          <span class="meta">
+            <span class="label">self-releasing artists</span>
+            <span class="cap">Already paying to distribute &amp; monetize. +17%/yr.</span>
+          </span>
+        </div>
+        <span class="src"><b>MIDiA</b> · 2024<br>active "Artists Direct"</span>
+      </div>
+
+      <!-- BOTTOM: Jovie's wedge -->
+      <div class="row r3">
+        <div class="bar">
+          <span class="nbig">208K</span>
+          <span class="meta">
+            <span class="label">Jovie creators <span class="arr">→ $97M ARR</span></span>
+            <span class="cap">0.2% of Suno's base · Pro plan only.</span>
+          </span>
+        </div>
+        <span class="src"><b>Jovie</b> · target<br>208K × $39 × 12</span>
+      </div>
+    </div>
+
+    <p class="foot">
+      Different axes, one funnel. <b>Suno's 100M</b> is cumulative people who made a track on one tool;
+      <b>MIDiA's 8.2M</b> is active self-releasing artists; <b>208K</b> is Jovie's wedge. The numbers don't
+      compete — they nest.
+    </p>
+
+    <div class="num">06 / 10</div>
+  </section>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds a standalone Market slide (`apps/web/public/pitch/market-funnel-slide.html`) built in the live `/pitch` deck's design system (pure black, cream `#F5F4F0`, Manrope display, `mm-hero` gradient numerals, mono tags, chrome logo, slide number), authored at the deck's native 1920×1080.

## Why

A reviewer flagged that "76M music creators" (in a draft TAM memo) appeared to contradict "100M Suno creators." They aren't comparable:

- **Suno ~100M** = trailing-2-year *cumulative* people who made ≥1 track on one product (Suno Series C blog, Nov 2025).
- **MIDiA ~76M** = survey-derived *active* music creators, point-in-time year-end 2022 — a different cohort, pre-AI-wave.

Putting both on one "creators" axis reads as a contradiction. This slide resolves it by **dropping the stale 76M figure** (the live deck never used it) and nesting the market on labeled, non-contradictory axes:

| Tier | Figure | Axis / source |
|---|---|---|
| New creator class | **100M** | made music on Suno — cumulative, 2 yr (Suno, 2025) |
| Monetizing core | **8.2M** | active self-releasing artists (MIDiA, 2024, +17%/yr) |
| Jovie wedge | **208K → $97M ARR** | 0.2% of Suno's base, Pro only — same math as the existing Market slide |

The funnel narrows 100% → 64% → 38%; footer: *"the numbers don't compete — they nest."*

## Notes

- Standalone preview file; the `<section>` is drop-in for `index.html` (renumber `.num`). Not yet wired into the deck — happy to replace the existing `market-math` section in a follow-up if preferred.
- Bar widths are a designed taper, not a literal log scale (standard for funnel slides).
- All figures first-party / top-analyst (Suno blog; MIDiA). No product/runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmcrHhH9HGkZAW31CeGXAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmcrHhH9HGkZAW31CeGXAC)_