### PR TITLE
fix(chat): hydrate referenced entities into system prompt (JOV-3537)

### DIFF
--- a/apps/web/lib/chat/entity-hydration.ts
+++ b/apps/web/lib/chat/entity-hydration.ts
@@ -1,0 +1,132 @@
+/**
+ * Server-side entity hydration for chat turns (JOV-3537).
+ *
+ * Entity mentions ride the wire as opaque `@kind:id[label]` tokens
+ * (see `tokens.ts`). Without server-side resolution the model only ever sees
+ * the bare `[label]` and routinely mis-attributes the artist's own release to
+ * "another artist". This module parses those tokens from the recent user turns
+ * and resolves each id against the data already loaded for the turn — the
+ * artist's own catalog (`releases`, the same `discogReleases` rows that feed the
+ * right-rail `ChatReleaseEntityPanel` via `loadReleaseEntity`) and the artist's
+ * own identity — then renders a compact "Referenced entities" block for the
+ * system prompt so the model treats owned assets as owned.
+ *
+ * Pure functions — no React, no fetching. Resolution reuses the catalog the
+ * route already fetched (`fetchReleasesForChat`), so there is no extra DB call
+ * and owned-catalog matches are inherently preferred.
+ */
+
+import { extractEntities } from '@/lib/chat/tokens';
+import type { ReleaseContext } from '@/lib/chat/types';
+
+/** Minimal artist identity needed to recognise self-references. */
+export interface HydrationArtistIdentity {
+  readonly displayName: string;
+  readonly username: string;
+}
+
+export interface HydrateReferencedEntitiesInput {
+  /**
+   * Recent user message texts (most-recent first is fine — order is preserved
+   * for de-duplication but does not affect output). Each is the raw wire string
+   * that may carry `@kind:id[label]` tokens.
+   */
+  readonly userTexts: readonly string[];
+  /** The artist's own catalog already loaded for this turn. */
+  readonly ownedReleases: readonly ReleaseContext[];
+  /** The artist's own identity, used to recognise `@artist` self-references. */
+  readonly artist: HydrationArtistIdentity;
+}
+
+const RELEASE_TYPE_NOUN: Record<string, string> = {
+  single: 'single',
+  album: 'album',
+  ep: 'EP',
+  compilation: 'compilation',
+  mixtape: 'mixtape',
+  music_video: 'music video',
+};
+
+function releaseTypeNoun(releaseType: string): string {
+  return RELEASE_TYPE_NOUN[releaseType] ?? releaseType.replaceAll('_', ' ');
+}
+
+function formatReleaseDate(value: string | null): string | null {
+  if (!value) return null;
+  return value.slice(0, 10);
+}
+
+function describeOwnedRelease(release: ReleaseContext): string {
+  const noun = releaseTypeNoun(release.releaseType);
+  const date = formatReleaseDate(release.releaseDate);
+  const facts: string[] = [];
+  if (date) facts.push(`released ${date}`);
+  if (release.totalTracks > 0) {
+    const trackLabel = release.totalTracks === 1 ? 'track' : 'tracks';
+    facts.push(`${release.totalTracks} ${trackLabel}`);
+  }
+  const factSuffix = facts.length > 0 ? ` (${facts.join(', ')})` : '';
+  return `- "${release.title}" — a ${noun} in THIS artist's own catalog${factSuffix}. Treat any reference to it as the user's own release, never another artist's work.`;
+}
+
+/**
+ * Build the "Referenced entities" system-prompt block from tokens in the recent
+ * user turns. Returns `undefined` when no entity tokens are present (so the
+ * caller can omit the section entirely and keep the prompt stable).
+ *
+ * Resolution rules:
+ *  - `@release` / `@track` whose id matches an owned release → hydrated as the
+ *    artist's own asset with catalog facts.
+ *  - `@artist` whose label matches the artist's own display name/username → the
+ *    user themselves.
+ *  - Anything else → described as "referenced by the user" with a neutral note
+ *    so the model does not invent attribution.
+ */
+export function buildReferencedEntitiesBlock(
+  input: HydrateReferencedEntitiesInput
+): string | undefined {
+  const mentions = input.userTexts.flatMap(text => extractEntities(text ?? ''));
+  if (mentions.length === 0) return undefined;
+
+  const releaseById = new Map(input.ownedReleases.map(r => [r.id, r]));
+  const ownNames = new Set(
+    [input.artist.displayName, input.artist.username]
+      .map(name => name?.trim().toLowerCase())
+      .filter((name): name is string => Boolean(name))
+  );
+
+  const seen = new Set<string>();
+  const lines: string[] = [];
+
+  for (const mention of mentions) {
+    const dedupeKey = `${mention.kind}:${mention.id}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    if (mention.kind === 'release' || mention.kind === 'track') {
+      const owned = releaseById.get(mention.id);
+      if (owned) {
+        lines.push(describeOwnedRelease(owned));
+        continue;
+      }
+    }
+
+    if (
+      mention.kind === 'artist' &&
+      ownNames.has(mention.label.trim().toLowerCase())
+    ) {
+      lines.push(
+        `- "${mention.label}" — this is the user (the artist you are assisting), not a different artist.`
+      );
+      continue;
+    }
+
+    lines.push(
+      `- "${mention.label}" (${mention.kind}) — referenced by the user. Do not assert who it belongs to unless it appears in this artist's own catalog above.`
+    );
+  }
+
+  return `## Referenced Entities
+The user's latest message references the following entities. Use these resolved facts; do not contradict them or re-attribute owned assets to another artist.
+${lines.join('\n')}`;
+}

--- a/apps/web/lib/chat/run.ts
+++ b/apps/web/lib/chat/run.ts
@@ -9,6 +9,7 @@ import {
 import { streamText } from '@/lib/ai/sdk';
 import { buildAiTelemetry } from '@/lib/ai/telemetry';
 import type { ChatAccountContext } from '@/lib/chat/account-context';
+import { buildReferencedEntitiesBlock } from '@/lib/chat/entity-hydration';
 import { resolveImportBioRestrictedTools } from '@/lib/chat/import-bio-turn-guard';
 import { selectKnowledgeContext } from '@/lib/chat/knowledge/router';
 import { extractLastUserText } from '@/lib/chat/message-text';
@@ -77,25 +78,33 @@ export function isClientDisconnect(
 }
 
 /**
- * Selects the music-industry knowledge context relevant to the recent
- * conversation. Uses the last 3 user turns so follow-up questions retain
- * context from earlier turns.
+ * Collects the raw text of the most recent user turns (most-recent first),
+ * preserving any `@kind:id[label]` entity tokens verbatim so the server can
+ * resolve them. Used both for knowledge-context selection and entity hydration.
  */
-export function selectKnowledgeContextForTurn(uiMessages: UIMessage[]): string {
-  const recentUserText = [...uiMessages]
+export function recentUserTexts(uiMessages: UIMessage[], limit = 3): string[] {
+  return [...uiMessages]
     .reverse()
     .filter(m => m.role === 'user')
-    .slice(0, 3)
-    .flatMap(m =>
+    .slice(0, limit)
+    .map(m =>
       (m.parts ?? [])
         .filter(
           (p): p is { type: 'text'; text: string } =>
             p.type === 'text' && typeof p.text === 'string'
         )
         .map(p => p.text)
-    )
-    .join(' ');
-  return selectKnowledgeContext(recentUserText);
+        .join(' ')
+    );
+}
+
+/**
+ * Selects the music-industry knowledge context relevant to the recent
+ * conversation. Uses the last 3 user turns so follow-up questions retain
+ * context from earlier turns.
+ */
+export function selectKnowledgeContextForTurn(uiMessages: UIMessage[]): string {
+  return selectKnowledgeContext(recentUserTexts(uiMessages).join(' '));
 }
 
 export interface ExecuteChatTurnInput {
@@ -206,12 +215,25 @@ export async function executeChatTurn(
     if (!artistContext) {
       throw new Error('artistContext is required when mode is "app"');
     }
+    // Resolve `@kind:id[label]` entity tokens from the recent user turns against
+    // the artist's own catalog (the same `releases` rows that feed the
+    // right-rail entity panel) so the model recognises owned assets instead of
+    // mis-attributing them to another artist (JOV-3537).
+    const referencedEntities = buildReferencedEntitiesBlock({
+      userTexts: recentUserTexts(uiMessages),
+      ownedReleases: releases,
+      artist: {
+        displayName: artistContext.displayName,
+        username: artistContext.username,
+      },
+    });
     systemPrompt = buildSystemPrompt(artistContext, releases, {
       aiCanUseTools: planLimits.booleans.aiCanUseTools,
       aiDailyMessageLimit: planLimits.limits.aiDailyMessageLimit,
       insightsEnabled,
       knowledgeContext: selectKnowledgeContextForTurn(uiMessages) || undefined,
       accountContext,
+      referencedEntities,
     });
   }
 

--- a/apps/web/lib/chat/system-prompt.ts
+++ b/apps/web/lib/chat/system-prompt.ts
@@ -94,6 +94,14 @@ export function buildSystemPrompt(
     insightsEnabled?: boolean;
     knowledgeContext?: string;
     accountContext?: AccountPromptContext;
+    /**
+     * Resolved facts for entities the user referenced via `@kind:id[label]`
+     * tokens in their latest turn(s). Built server-side by
+     * `buildReferencedEntitiesBlock` (JOV-3537) so the model recognises the
+     * artist's own catalog instead of mis-attributing it. Omitted when no
+     * entity tokens are present.
+     */
+    referencedEntities?: string;
   }
 ): string {
   return `You are Jovie, an AI music career assistant. You help independent artists understand their data and make smart career decisions.
@@ -129,7 +137,7 @@ Messages may contain structured tokens the UI attached before sending:
 - \`@artist:<id>[<name>]\` and \`@track:<id>[<title>]\` — same pattern for artists/tracks.
 - \`/skill:<toolId>\` — the user picked this skill explicitly. Call the matching tool immediately **only if that tool is available to this artist on their current plan** (anything not in the tools list you were given is gated). If the tool is gated, do not attempt to call it or describe its output; say briefly that the skill is a Pro-plan feature. If the tool is available but required entity slots aren't filled (no matching @entity token), ask for the missing entity before calling.
 Do not echo tokens in your responses. When referring to the entity in your reply, use its display name ("Midnight Drive"), not the token.
-
+${buildReferencedEntitiesSection(options?.referencedEntities)}
 ## Voice (CRITICAL)
 - Direct, concise: 1-3 sentences, max 150 words unless detail requested or generating a bio.
 - No emoji, no exclamation marks, no cheerleading, no filler, no repeating the user.
@@ -198,6 +206,11 @@ Merch quality standard:
 
 ## Feedback
 When the artist wants to share feedback, report a bug, or request a feature, ask them to describe it. Once they provide their feedback, call the submitFeedback tool with their message. Thank them briefly after submission.${buildPlanLimitationsSection(options)}`;
+}
+
+function buildReferencedEntitiesSection(referencedEntities?: string): string {
+  if (!referencedEntities) return '';
+  return `\n${referencedEntities}\n`;
 }
 
 function buildKnowledgeSection(knowledgeContext?: string): string {

--- a/apps/web/tests/eval/golden/golden-eval-set.ci.test.ts
+++ b/apps/web/tests/eval/golden/golden-eval-set.ci.test.ts
@@ -10,9 +10,12 @@
 
 import { tool as aiTool, generateText } from 'ai';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { buildReferencedEntitiesBlock } from '@/lib/chat/entity-hydration';
 import { selectKnowledgeContext } from '@/lib/chat/knowledge/router';
 import { buildSystemPrompt } from '@/lib/chat/system-prompt';
+import { serializeEntity } from '@/lib/chat/tokens';
 import { TOOL_SCHEMAS } from '@/lib/chat/tool-schemas';
+import type { ReleaseContext } from '@/lib/chat/types';
 import { CHAT_MODEL } from '@/lib/constants/ai-models';
 import {
   buildTestArtistContext,
@@ -106,5 +109,100 @@ describe('Golden eval-set CI gate', () => {
       'Release on Monday. Any day works equally well for streams.';
 
     expect(() => assertGoldenCaseQuality(degraded, GOLDEN_CASES[0])).toThrow();
+  });
+});
+
+/**
+ * Entity hydration golden case (JOV-3537).
+ *
+ * Regression guard: when a user message carries an `@release` token for an
+ * asset in the artist's own catalog, the server must hydrate that token into
+ * the system prompt as the user's OWN release. Before the fix the model only
+ * saw the bare `[label]` and mis-attributed the song to "another artist".
+ */
+describe('Golden eval-set CI gate: referenced-entity hydration', () => {
+  const evalTools = buildEvalTools();
+
+  const OWNED_RELEASE: ReleaseContext = {
+    id: 'rel_revival_001',
+    title: 'Revival',
+    releaseType: 'single',
+    releaseDate: '2025-08-22T00:00:00Z',
+    artworkUrl: null,
+    spotifyPopularity: 38,
+    totalTracks: 1,
+    canvasStatus: 'not_set',
+    metadata: null,
+  };
+
+  const artistContext = buildTestArtistContext();
+  const releases = buildTestReleases();
+
+  // The wire string the composer sends: bare label + opaque entity token.
+  const releaseToken = serializeEntity({
+    kind: 'release',
+    id: OWNED_RELEASE.id,
+    label: OWNED_RELEASE.title,
+  });
+  const userPrompt = `How is ${releaseToken} doing? Should I pitch it again?`;
+
+  function buildPromptWithReferencedEntities(): string {
+    const referencedEntities = buildReferencedEntitiesBlock({
+      userTexts: [userPrompt],
+      ownedReleases: [OWNED_RELEASE],
+      artist: {
+        displayName: artistContext.displayName,
+        username: artistContext.username,
+      },
+    });
+
+    return buildSystemPrompt(artistContext, releases, {
+      aiCanUseTools: true,
+      aiDailyMessageLimit: 50,
+      knowledgeContext: selectKnowledgeContext(userPrompt) || undefined,
+      referencedEntities,
+    });
+  }
+
+  it('injects the owned release into the system prompt as the user own catalog', () => {
+    const systemPrompt = buildPromptWithReferencedEntities();
+
+    expect(systemPrompt).toContain('Referenced Entities');
+    // Hydrated facts the model can rely on: title, role (single), and the
+    // explicit "own catalog" framing.
+    expect(systemPrompt).toContain('"Revival"');
+    expect(systemPrompt).toContain('single');
+    expect(systemPrompt.toLowerCase()).toContain("this artist's own catalog");
+    expect(systemPrompt.toLowerCase()).toContain('never another artist');
+  });
+
+  it('produces a reply that treats the owned release as the user own work', async () => {
+    const systemPrompt = buildPromptWithReferencedEntities();
+
+    // The mock reply represents the quality bar given the hydrated prompt:
+    // it uses the resolved title/role and never disclaims it as someone else's.
+    const reply =
+      'Revival, your single, is at moderate popularity. Pitching it again to editorial is worth a shot now that it has some traction.';
+
+    mockGenerateText.mockResolvedValueOnce({ text: reply });
+
+    const result = await generateText({
+      model: { __model: CHAT_MODEL },
+      system: systemPrompt,
+      prompt: userPrompt,
+      tools: evalTools,
+      maxOutputTokens: 500,
+      temperature: 0,
+    });
+
+    const lower = result.text.toLowerCase();
+    // Reflects correct catalog facts.
+    expect(lower).toContain('revival');
+    expect(lower).toContain('single');
+    // Never mis-attributes the owned release to another artist.
+    expect(lower).not.toContain('another artist');
+    expect(lower).not.toContain("another artist's");
+    expect(lower).not.toContain("someone else's");
+    expect(lower).not.toContain('not your');
   });
 });

--- a/apps/web/tests/unit/lib/chat/entity-hydration.test.ts
+++ b/apps/web/tests/unit/lib/chat/entity-hydration.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for server-side chat entity hydration (JOV-3537).
+ *
+ * Regression guard for the bug where `@kind:id[label]` tokens were passed to
+ * the model as bare labels with no catalog resolution, causing the assistant
+ * to treat the artist's own release as "another artist's work".
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildReferencedEntitiesBlock } from '@/lib/chat/entity-hydration';
+import { serializeEntity } from '@/lib/chat/tokens';
+import type { ReleaseContext } from '@/lib/chat/types';
+
+const ARTIST = { displayName: 'Luna Waves', username: 'lunawaves' } as const;
+
+function ownedRelease(overrides?: Partial<ReleaseContext>): ReleaseContext {
+  return {
+    id: 'rel_revival_001',
+    title: 'Revival',
+    releaseType: 'single',
+    releaseDate: '2025-08-22T00:00:00Z',
+    artworkUrl: null,
+    spotifyPopularity: 38,
+    totalTracks: 1,
+    canvasStatus: 'not_set',
+    metadata: null,
+    ...overrides,
+  };
+}
+
+function tokenText(
+  kind: 'release' | 'track' | 'artist' | 'event',
+  id: string,
+  label: string
+): string {
+  return `Tell me about ${serializeEntity({ kind, id, label })}`;
+}
+
+describe('buildReferencedEntitiesBlock', () => {
+  it('returns undefined when there are no entity tokens', () => {
+    expect(
+      buildReferencedEntitiesBlock({
+        userTexts: ['How is my latest single doing?'],
+        ownedReleases: [ownedRelease()],
+        artist: ARTIST,
+      })
+    ).toBeUndefined();
+  });
+
+  it('hydrates an owned @release token as the artist own catalog', () => {
+    const block = buildReferencedEntitiesBlock({
+      userTexts: [tokenText('release', 'rel_revival_001', 'Revival')],
+      ownedReleases: [ownedRelease()],
+      artist: ARTIST,
+    });
+
+    expect(block).toBeDefined();
+    expect(block).toContain('Referenced Entities');
+    expect(block).toContain('"Revival"');
+    expect(block).toContain('single');
+    expect(block?.toLowerCase()).toContain("this artist's own catalog");
+    expect(block?.toLowerCase()).toContain('never another artist');
+  });
+
+  it('resolves @track tokens against the owned release catalog too', () => {
+    const block = buildReferencedEntitiesBlock({
+      userTexts: [tokenText('track', 'rel_revival_001', 'Revival')],
+      ownedReleases: [ownedRelease()],
+      artist: ARTIST,
+    });
+
+    expect(block?.toLowerCase()).toContain("this artist's own catalog");
+  });
+
+  it('does not claim ownership for a release id not in the catalog', () => {
+    const block = buildReferencedEntitiesBlock({
+      userTexts: [tokenText('release', 'rel_unknown_999', 'Someone Else Song')],
+      ownedReleases: [ownedRelease()],
+      artist: ARTIST,
+    });
+
+    expect(block).toBeDefined();
+    expect(block).toContain('"Someone Else Song"');
+    // Not described with the owned-release framing — only the neutral
+    // "do not assert who it belongs to" guidance.
+    expect(block?.toLowerCase()).not.toContain('treat any reference to it');
+    expect(block?.toLowerCase()).toContain('do not assert who it belongs to');
+  });
+
+  it('recognises an @artist token that matches the user own identity', () => {
+    const block = buildReferencedEntitiesBlock({
+      userTexts: [tokenText('artist', 'art_self', 'Luna Waves')],
+      ownedReleases: [ownedRelease()],
+      artist: ARTIST,
+    });
+
+    expect(block?.toLowerCase()).toContain('this is the user');
+  });
+
+  it('de-duplicates repeated references to the same entity', () => {
+    const text = `${tokenText('release', 'rel_revival_001', 'Revival')} and again ${serializeEntity(
+      { kind: 'release', id: 'rel_revival_001', label: 'Revival' }
+    )}`;
+    const block = buildReferencedEntitiesBlock({
+      userTexts: [text],
+      ownedReleases: [ownedRelease()],
+      artist: ARTIST,
+    });
+
+    const occurrences = block?.match(/"Revival"/g)?.length ?? 0;
+    expect(occurrences).toBe(1);
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id: JOV-3537 -->

Closes JOV-3537. Server-side entity hydration into the system prompt so the model recognizes the user's own catalog (no longer disclaims an owned song as another artist's work). New pure helper `apps/web/lib/chat/entity-hydration.ts` reusing the right-rail catalog resolver; golden-eval + unit cases added. No UI change.

Note: recreated after graphite-app auto-closed the prior PR (#11987) unmerged despite green checks.