### PR TITLE
refactor(ui): isolate server-only /actions import out of CreateProfileDialog (JOV-3568)

### DIFF
--- a/apps/web/app/api/dashboard/profile/create/route.ts
+++ b/apps/web/app/api/dashboard/profile/create/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { createAdditionalProfile } from '@/app/app/(shell)/dashboard/actions/switch-profile';
+import { captureError } from '@/lib/error-tracking';
+import { parseJsonBody } from '@/lib/http/parse-json';
+
+// Use Node.js runtime for compatibility with DB libs used by the server action.
+export const runtime = 'nodejs';
+
+interface CreateProfileBody {
+  displayName?: unknown;
+  username?: unknown;
+}
+
+export async function POST(request: Request) {
+  const parsed = await parseJsonBody<CreateProfileBody | null>(request, {
+    route: 'POST /api/dashboard/profile/create',
+  });
+  if (!parsed.ok) {
+    return parsed.response;
+  }
+
+  const displayName = parsed.data?.displayName;
+  const username = parsed.data?.username;
+  if (typeof displayName !== 'string' || typeof username !== 'string') {
+    return NextResponse.json(
+      { success: false, error: 'Display name and username are required' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await createAdditionalProfile({ displayName, username });
+    if (!result.success) {
+      return NextResponse.json(result, { status: 400 });
+    }
+    return NextResponse.json(result);
+  } catch (error) {
+    await captureError('POST /api/dashboard/profile/create failed', error, {
+      route: '/api/dashboard/profile/create',
+      method: 'POST',
+    });
+    return NextResponse.json(
+      { success: false, error: 'Something went wrong' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/components/organisms/CreateProfileDialog.tsx
+++ b/apps/web/components/organisms/CreateProfileDialog.tsx
@@ -15,7 +15,12 @@ import { Loader2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { type FormEvent, useState, useTransition } from 'react';
 import { toast } from 'sonner';
-import { createAdditionalProfile } from '@/app/app/(shell)/dashboard/actions/switch-profile';
+
+interface CreateProfileResult {
+  success: boolean;
+  error?: string;
+  profileId?: string;
+}
 
 interface CreateProfileDialogProps {
   readonly open: boolean;
@@ -53,10 +58,21 @@ export function CreateProfileDialog({
     }
 
     startTransition(async () => {
-      const result = await createAdditionalProfile({
-        displayName: displayName.trim(),
-        username: username.trim(),
-      });
+      let result: CreateProfileResult;
+      try {
+        const response = await fetch('/api/dashboard/profile/create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            displayName: displayName.trim(),
+            username: username.trim(),
+          }),
+        });
+        result = (await response.json()) as CreateProfileResult;
+      } catch {
+        setError("Couldn't create profile. Try again.");
+        return;
+      }
 
       if (!result.success) {
         setError(result.error ?? "Couldn't create profile. Try again.");

--- a/apps/web/tests/unit/design-system/server-imports.baseline.json
+++ b/apps/web/tests/unit/design-system/server-imports.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3,
-  "note": "Files in apps/web/components/{atoms,molecules,organisms} that import a server-only specifier (server-only, @clerk/nextjs/server, drizzle-orm, @/lib/db/*, /actions modules, next/headers, next/cache, etc.) or contain 'use server'. Baseline of 3 reflects organism offenders: CreateProfileDialog.tsx, ProfileSwitcher.tsx, release-sidebar/ReleaseSidebar.tsx (all import from /actions). Exclusions: *.stories.tsx, *.test.ts(x), *-action.ts, *.server.ts. Ratchet only goes down — lower this when a PR moves the /actions import to a feature wrapper."
+  "count": 2,
+  "note": "Files in apps/web/components/{atoms,molecules,organisms} that import a server-only specifier (server-only, @clerk/nextjs/server, drizzle-orm, @/lib/db/*, /actions modules, next/headers, next/cache, etc.) or contain 'use server'. Baseline of 2 reflects remaining organism offenders: ProfileSwitcher.tsx, release-sidebar/ReleaseSidebar.tsx (both import from /actions). CreateProfileDialog.tsx was isolated (JOV-3568) — it now calls POST /api/dashboard/profile/create via fetch instead of importing the server action. Exclusions: *.stories.tsx, *.test.ts(x), *-action.ts, *.server.ts. Ratchet only goes down — lower this when a PR moves the /actions import to a feature wrapper or API route."
 }


### PR DESCRIPTION
<!-- linear-issue-id: JOV-3568 -->

## What moved

`apps/web/components/organisms/CreateProfileDialog.tsx` (a shared organism that must bundle for the browser) imported `createAdditionalProfile` from the dashboard `/actions` module. The **server-imports drift ratchet** flags `/actions` imports in `components/{atoms,molecules,organisms}`.

Fix: move the server dependency behind a thin API route and call it via `fetch`.

- **New:** `POST /api/dashboard/profile/create` — a thin wrapper over the existing `createAdditionalProfile` server action. All validation, auth (`getCachedAuth`), the soft profile cap, the atomic transaction, and the `{ success, error?, profileId? }` contract are unchanged.
- **Changed:** `CreateProfileDialog.handleSubmit` now `fetch`es the route instead of importing the action. Dialog **markup, props, state, and every render output are byte-for-byte identical** (diff is only the import line + the data-fetch block inside `handleSubmit`).

## Ratchet

`apps/web/tests/unit/design-system/server-imports.baseline.json`: **3 → 2**. Remaining offenders (separate PRs): `ProfileSwitcher.tsx`, `release-sidebar/ReleaseSidebar.tsx`.

**Regression guard:** `apps/web/tests/unit/design-system/server-imports-ratchet.test.ts` (passes at count 2; would fail if the `/actions` import returned).

## Verification

- `pnpm --filter web exec vitest run tests/unit/design-system/server-imports-ratchet.test.ts` — PASS (count 2 ≤ baseline 2)
- `pnpm --filter @jovie/web run typecheck` — PASS
- `pnpm biome check` (edited files) — clean
- `pnpm --filter web lint:server-boundaries` — PASS
- `ProfileSwitcher.test.tsx` (mocks CreateProfileDialog) — PASS
- **Live end-to-end** against the running app (`creator-ready` persona): the dialog's new `fetch` path hit `POST /api/dashboard/profile/create` and returned the action's real contract — validation error path returned `{ success: false, error: "Username must be 3-30 characters" }` (400), unique-constraint path returned `{ success: false, error: "Username already taken" }` (400). Wiring fetch → route → server action confirmed.

## Layout-shift audit

States enumerated: closed (not rendered), open (form), submitting (`isPending` disables inputs/buttons, spinner renders inline in the existing Create button — no reflow), error (renders into the pre-existing conditional `<p role="alert">` slot). The JSX is unchanged, so no state transition can introduce a new shift. Screenshot evidence: dashboard renders cleanly post-change (the dialog only opens for users with 2+ profiles; markup verified unchanged via diff).

## Cost impact

None — the new route is a 1:1 wrapper over an existing server action invoked only on explicit profile creation (user-initiated, not scheduled/looped).