### PR TITLE
ci(guards): stop required deterministic guards from re-running on label events (JOV-3580)

### DIFF
--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -6,9 +6,17 @@ name: PR Size Guard
 # approved mechanical codemods (token sweeps, renames, generated output) with
 # the `big-pr` label. Thresholds tunable via repo vars PR_MAX_LINES / PR_MAX_FILES.
 
+# PR size can only change on a push (opened/synchronize/reopened), never on a
+# label event. This guard is a REQUIRED check, so re-running it on
+# labeled/unlabeled is not just wasteful: rapid label churn (the autonomous
+# merge loop does this constantly) cancels the in-flight run via
+# cancel-in-progress, leaving a CANCELLED/QUEUED run as the latest for a
+# required context → GitHub pins the PR BLOCKED even though it's green
+# (JOV-3580). The big-pr/codemod opt-out is still honored: it's read via
+# `gh pr view` at run time, which works on push events too.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- linear-issue-id: JOV-3580 -->

## Root cause

`PR Size Guard` is a **required** check in the `Main Branch Protection` ruleset, yet `.github/workflows/pr-size-guard.yml` triggered on `pull_request: types: [opened, synchronize, reopened, labeled, unlabeled]` with `concurrency.cancel-in-progress: true`.

A PR's size can only change on a push — never on a label event. So re-running the guard on `labeled`/`unlabeled` was not just wasteful, it was actively harmful: the autonomous merge loop churns labels constantly (`merge-queue` enroll, `needs-human-taste` ↔ `merge-queue` dance). Each label op re-triggered the guard; a rapid second label op cancelled the in-flight run via `cancel-in-progress`, leaving a `CANCELLED`/`QUEUED` run as the **latest** for a required context. GitHub's ruleset then evaluated that required context as not-passing and pinned the PR `BLOCKED` even though every real check was green. Instance: PR #12001. Same zombie-check class as the 2026-06-22 6h queue stall (#11689), but at the ruleset level where downstream guards (`drain-pr-queue.sh`, `pr_gates.py`) can't override it.

## Change

`.github/workflows/pr-size-guard.yml` — removed `labeled, unlabeled` from `pull_request.types`:

```diff
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
```

The `big-pr` / `codemod` opt-out is **not** affected: the guard reads labels via `gh pr view` at run time (job body lines 51–55), which still fires on push events. Dropping the label *trigger* does not break the bypass.

## Audit of other required deterministic guards

| Required check | Workflow | Label-event trigger? | Action |
|---|---|---|---|
| PR Size Guard | `pr-size-guard.yml` | **yes** (`labeled`, `unlabeled`) | **Removed** — primary fix |
| PR Ready | `ci.yml` | no (`pull_request` has no `types:` → defaults to `opened/synchronize/reopened`) | Left alone — already clean |
| Migration Guard | `ci.yml` (job) | no (same as PR Ready) | Left alone — already clean |
| Fork PR Gate | `fork-pr-gate.yml` | no (`types: [opened, synchronize, reopened]` + `pull_request_review`) | Left alone — already clean |

Workflows that legitimately act on labels and were **deliberately left untouched** (not result-producing required guards):

- `linear-ai-dispatcher.yml` — orchestrator; triggers on `schedule`/`workflow_dispatch`, reads label scope at runtime. No label *event* trigger.
- `agent-pipeline.yml` — triggers on `workflow_run`; the `needs-human` reference is comment text, not an event trigger.

A repo-wide sweep (`types:.*labeled|unlabeled` across `.github/workflows/*.yml`) confirms `pr-size-guard.yml` was the **only** workflow with a label-event trigger, and after this change none remain.

## Verification

- `pnpm ci:harness:check` → manifest valid; README / TESTING_STRATEGY / release.md docs current.
- `actionlint .github/workflows/pr-size-guard.yml` → clean.
- No app code changed → typecheck / Biome N/A.

Verifies JOV-3580 acceptance: a label-only change can no longer move a green PR to BLOCKED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
