### PR TITLE
chore(otel): update default Agnost org ID

### DIFF
--- a/apps/web/lib/observability/agnost.ts
+++ b/apps/web/lib/observability/agnost.ts
@@ -11,7 +11,7 @@ const AGNOST_OTEL_ENDPOINT = 'https://otel.agnost.ai/v1/traces';
 /** Bounded OTLP export — observability sink must not hang cold starts. */
 const AGNOST_OTEL_TIMEOUT_MS = 10_000;
 
-const DEFAULT_AGNOST_ORG_ID = '384ebd06-d9a5-48dd-ba22-7a51e430c173';
+const DEFAULT_AGNOST_ORG_ID = '3e2d4388-5d86-41f5-8f67-4a3bac08d72f';
 
 let agnostStarted = false;
 

--- a/apps/web/tests/unit/lib/observability/agnost.test.ts
+++ b/apps/web/tests/unit/lib/observability/agnost.test.ts
@@ -39,6 +39,6 @@ describe('agnost telemetry guards', () => {
       '@/lib/observability/agnost'
     );
     expect(shouldEnableAgnost()).toBe(true);
-    expect(getAgnostOrgId()).toBe('384ebd06-d9a5-48dd-ba22-7a51e430c173');
+    expect(getAgnostOrgId()).toBe('3e2d4388-5d86-41f5-8f67-4a3bac08d72f');
   });
 });


### PR DESCRIPTION
## Description

Updates `DEFAULT_AGNOST_ORG_ID` in the OTEL observability configuration to point to the new Agnost organization.

## Type of Change

- [ ] Chore (maintenance, dependencies, etc.)

## Testing

- [x] Typecheck passes
- [x] Lint passes
- [x] Biome check passes

## Code Quality

- [x] Code follows project style guidelines
- [x] Self-review completed

### Bug-to-Test

bug-to-test: not applicable — chore/config change