### PR TITLE
fix(profile): polish live profile preview card UI

### DIFF
--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
@@ -249,7 +249,7 @@ function ProfileBentoView({
         genres={previewData.genres}
         profileHref={previewData.profilePath}
         showLiveBadge
-        caption='Your live profile'
+        caption='Your Live Profile'
         phoneAlign='top'
         showBottomFade
         className='shrink-0'
@@ -265,15 +265,15 @@ function ProfileBentoView({
                 variant='ghost'
                 size='icon'
                 aria-label='Profile Actions'
-                className='rounded-full border border-white/14 bg-black/40 text-white backdrop-blur-md hover:bg-black/60 dark:text-white'
+                className='h-6 w-6 rounded-full border border-white/12 bg-black/50 text-white backdrop-blur-md hover:bg-black/65 dark:text-white'
               >
-                <MoreVertical className='h-4 w-4' />
+                <MoreVertical className='h-3.5 w-3.5' />
               </Button>
             }
           />
         }
         footer={
-          <div className='space-y-2.5 pt-2.5'>
+          <div className='space-y-2 pt-1.5'>
             <ProfileSmartLinkAnalytics profileUrl={profileUrl} variant='flat' />
             <Button
               type='button'

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileSmartLinkAnalytics.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileSmartLinkAnalytics.tsx
@@ -17,8 +17,8 @@ import type { AnalyticsRange } from '@/types/analytics';
 const numberFormatter = new Intl.NumberFormat();
 
 const RANGE_OPTIONS: { value: AnalyticsRange; label: string }[] = [
-  { value: '7d', label: '7 days' },
-  { value: '30d', label: '30 days' },
+  { value: '7d', label: '7D' }, // ui-casing-allow: compact range pill
+  { value: '30d', label: '30D' }, // ui-casing-allow: compact range pill
 ];
 
 interface ProfileSmartLinkAnalyticsProps {
@@ -35,11 +35,11 @@ function ProfileSmartLinkControl({
 
   return (
     <div
-      className='flex h-8 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2.5'
+      className='flex h-9 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-3'
       data-testid='profile-smart-link-control'
     >
       <Link2
-        className='h-3 w-3 shrink-0 text-tertiary-token'
+        className='h-3.5 w-3.5 shrink-0 text-tertiary-token'
         aria-hidden='true'
       />
       <span
@@ -59,9 +59,9 @@ function ProfileSmartLinkControl({
           toast.error('Failed to copy link');
         }}
         title='Copy profile link'
-        className='h-5 w-5 rounded-full text-tertiary-token'
+        className='h-6 w-6 rounded-full text-tertiary-token'
       >
-        <Copy className='h-3 w-3' />
+        <Copy className='h-3.5 w-3.5' />
       </DrawerInlineIconButton>
       <DrawerInlineIconButton
         onClick={event => {
@@ -69,9 +69,9 @@ function ProfileSmartLinkControl({
           globalThis.open(profileUrl, '_blank', 'noopener,noreferrer');
         }}
         title='Open profile link'
-        className='h-5 w-5 rounded-full text-tertiary-token'
+        className='h-6 w-6 rounded-full text-tertiary-token'
       >
-        <ExternalLink className='h-3 w-3' />
+        <ExternalLink className='h-3.5 w-3.5' />
       </DrawerInlineIconButton>
     </div>
   );
@@ -93,7 +93,7 @@ export function ProfileSmartLinkAnalytics({
   const showSkeleton = isLoading && !data;
 
   const currentRangeLabel =
-    RANGE_OPTIONS.find(o => o.value === range)?.label ?? '30 days';
+    RANGE_OPTIONS.find(o => o.value === range)?.label ?? '30D';
 
   const content = (
     <>
@@ -124,22 +124,23 @@ export function ProfileSmartLinkAnalytics({
         {!showSkeleton && !isError && (
           <div
             className={cn(
-              'space-y-3 transition-opacity duration-subtle',
+              'space-y-1.5 transition-opacity duration-subtle',
               isFetching && 'opacity-50'
             )}
           >
             <div className='grid grid-cols-2 gap-3'>
               <AnalyticsMetric
-                label='Profile views'
+                label='Profile Views'
                 value={numberFormatter.format(profileViews)}
-                hint={`Last ${currentRangeLabel}`}
               />
               <AnalyticsMetric
-                label='Link clicks'
+                label='Link Clicks'
                 value={numberFormatter.format(totalClicks)}
-                hint={`Last ${currentRangeLabel}`}
               />
             </div>
+            <p className='text-3xs leading-[13px] text-tertiary-token'>
+              Last {currentRangeLabel}
+            </p>
           </div>
         )}
       </div>
@@ -173,7 +174,7 @@ function AnalyticsMetric({
 }: {
   readonly label: string;
   readonly value: string;
-  readonly hint: string;
+  readonly hint?: string;
   readonly className?: string;
 }) {
   return (
@@ -184,7 +185,9 @@ function AnalyticsMetric({
       <p className='tabular-nums text-lg font-semibold leading-none tracking-[-0.02em] text-primary-token'>
         {value}
       </p>
-      <p className='text-3xs leading-[13px] text-tertiary-token'>{hint}</p>
+      {hint ? (
+        <p className='text-3xs leading-[13px] text-tertiary-token'>{hint}</p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/features/profile/ProfilePreviewBento.tsx
+++ b/apps/web/components/features/profile/ProfilePreviewBento.tsx
@@ -67,7 +67,7 @@ const BOTTOM_FADE_STYLE: CSSProperties = {
 
 /** Cover/page-pad CSS vars the compact surface reads (inline to avoid arbitrary classes). */
 const DEFAULT_COVER_VARS = {
-  '--cover-height': '45%',
+  '--cover-height': '64%',
   '--page-pad': '18px',
 } as CSSProperties;
 


### PR DESCRIPTION
## What

Polishes the live profile preview card shown in the dashboard sidebar:

- **Cover height**: Increased from 45% to 64% (`--cover-height`) to reduce empty space and give the cover photo more breathing room
- **Stats dedup**: Moved redundant per-column "Last 30 Days" hints into a single shared line below both stats columns, tightened spacing
- **3-dot menu**: Made the More menu button smaller (`h-6 w-6`) with refined backdrop and icon sizing
- **URL pill**: Increased height (`h-8` → `h-9`), wider padding, and larger copy/open button hit targets (`h-5` → `h-6`)
- **Edit Profile button**: Tightened footer spacing to feel more connected to the analytics section above

## Files

- `apps/web/components/features/profile/ProfilePreviewBento.tsx` — cover height CSS var
- `apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx` — menu button sizing, footer spacing
- `apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileSmartLinkAnalytics.tsx` — stats layout, URL pill sizing

## Verified

- Typecheck (pre-commit + pre-push)
- Biome lint (pre-commit + pre-push)
- ESLint (pre-commit)
- Tailwind guard (pre-push)
- Next proxy guard (pre-commit + pre-push)
- a11y check (pre-commit)
- Secret scan (pre-commit)