### PR TITLE
test(profile): harden mobile-viewport flake stalling the merge queue

### DIFF
--- a/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
+++ b/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
@@ -630,9 +630,14 @@ test.describe('Public Profile Mock Home Release Card Layout @smoke @critical', (
         { timeout: 120_000 }
       );
       await waitForHydration(page);
-      await waitForAnyVisible(page, [
-        '[data-testid="profile-home-carousel"] a',
-      ]);
+      // Cold Turbopack route compile in the merge-queue lane can exceed the
+      // default VISIBILITY (20s) wait; give first-paint readiness the same
+      // budget as navigation so a slow cold compile reads as slow, not failed.
+      await waitForAnyVisible(
+        page,
+        ['[data-testid="profile-home-carousel"] a'],
+        SMOKE_TIMEOUTS.NAVIGATION
+      );
       await settleLayout(page);
       await expectNoDocumentOverflow(
         page,
@@ -696,7 +701,11 @@ test.describe('Public Profile Home Carousel @smoke @critical', () => {
       { timeout: 120_000 }
     );
     await waitForHydration(page);
-    await waitForAnyVisible(page, ['[data-testid="profile-home-carousel"] a']);
+    await waitForAnyVisible(
+      page,
+      ['[data-testid="profile-home-carousel"] a'],
+      SMOKE_TIMEOUTS.NAVIGATION
+    );
 
     const carousel = page.getByTestId('profile-home-carousel');
     await expect(carousel).toBeVisible();
@@ -748,7 +757,11 @@ test.describe('Public Profile Mobile Viewport Stability @smoke @critical', () =>
           expect(response?.status() ?? 0).toBeLessThan(500);
 
           await waitForHydration(screenPage);
-          await waitForAnyVisible(screenPage, screen.readySelectors);
+          await waitForAnyVisible(
+            screenPage,
+            screen.readySelectors,
+            SMOKE_TIMEOUTS.NAVIGATION
+          );
           await settleLayout(screenPage);
 
           const snapshot = await collectViewportSnapshot(
@@ -799,9 +812,11 @@ test.describe('Public Profile Mobile Viewport Stability @smoke @critical', () =>
         );
         expect(response?.status() ?? 0).toBeLessThan(500);
         await waitForHydration(flowPage);
-        await waitForAnyVisible(flowPage, [
-          '[data-testid="profile-mobile-notifications-step-email"]',
-        ]);
+        await waitForAnyVisible(
+          flowPage,
+          ['[data-testid="profile-mobile-notifications-step-email"]'],
+          SMOKE_TIMEOUTS.NAVIGATION
+        );
 
         const rootSelector = '[data-testid="notifications-page"]';
         const activeFlow = flowPage.locator(


### PR DESCRIPTION
## What

The Graphite merge queue was stuck in a ~2h fail→requeue loop. Every queue group failed the `Lighthouse (public routes PR)` lane on:

```
Error: None of these selectors became visible: [data-testid="profile-header"]
```

(`apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts`)

## Root cause

Cold Turbopack route compile under merge-queue-lane load exceeds the 20s `SMOKE_TIMEOUTS.VISIBILITY` wait used for the post-hydration readiness check. The navigation itself already gets 120s, but the selector-visibility gate was starved — so a slow cold compile read as a hard failure, not slow. The queued PRs (#11990, #12048) passed this exact lane on their own branches; only the combined queue groups flaked, consistent with a timing/cold-start flake rather than a regression.

## Fix

Give the four post-hydration `waitForAnyVisible` readiness waits in this spec the 60s `SMOKE_TIMEOUTS.NAVIGATION` budget instead of the default 20s. Test-only change.

## Verification

- `pnpm --filter @jovie/web run typecheck` — 0 errors
- `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)