### PR TITLE
fix(analytics): increment profile views when clicks are recorded (JOV-3589)

### DIFF
--- a/apps/web/app/api/audience/visit/route.ts
+++ b/apps/web/app/api/audience/visit/route.ts
@@ -1,5 +1,6 @@
-import { and, sql as drizzleSql, eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { writeDailyProfileViews } from '@/lib/analytics/daily-profile-views';
 import { shouldExcludeSelfByProfileId } from '@/lib/analytics/self-exclusion';
 import {
   checkVisitRateLimit,
@@ -19,11 +20,7 @@ import {
   invalidateColumnExistenceCache,
 } from '@/lib/db';
 import { isMissingColumnError, unwrapPgError } from '@/lib/db/errors';
-import {
-  audienceMembers,
-  audienceReferrers,
-  dailyProfileViews,
-} from '@/lib/db/schema/analytics';
+import { audienceMembers, audienceReferrers } from '@/lib/db/schema/analytics';
 import {
   creatorDistributionEvents,
   creatorProfiles,
@@ -262,26 +259,6 @@ async function writeReferrer(
   }
 }
 
-async function writeDailyProfileViews(
-  tx: DbOrTransaction,
-  profileId: string,
-  viewDate: string,
-  now: Date
-): Promise<void> {
-  try {
-    await incrementDailyProfileViews(tx, profileId, viewDate, now);
-  } catch (error) {
-    if (!isMissingDailyProfileViewsTableError(error)) {
-      throw error;
-    }
-    await captureWarning(
-      '[audience/visit] daily_profile_views table missing; skipping aggregate write',
-      error,
-      { profileId, viewDate }
-    );
-  }
-}
-
 async function writeInstagramActivation(
   tx: DbOrTransaction,
   profileId: string,
@@ -323,90 +300,6 @@ async function writeInstagramActivation(
       { profileId }
     );
   }
-}
-
-async function incrementDailyProfileViews(
-  tx: DbOrTransaction,
-  profileId: string,
-  viewDate: string,
-  now: Date
-): Promise<void> {
-  const values = {
-    creatorProfileId: profileId,
-    viewDate,
-    viewCount: 1,
-    createdAt: now,
-    updatedAt: now,
-  };
-
-  try {
-    await tx
-      .insert(dailyProfileViews)
-      .values(values)
-      .onConflictDoUpdate({
-        target: [
-          dailyProfileViews.creatorProfileId,
-          dailyProfileViews.viewDate,
-        ],
-        set: {
-          viewCount: drizzleSql`${dailyProfileViews.viewCount} + 1`,
-          updatedAt: now,
-        },
-      });
-    return;
-  } catch (error) {
-    const isMissingConflictTarget =
-      error instanceof Error &&
-      (error.message.includes('42P10') ||
-        error.message.includes(
-          'there is no unique or exclusion constraint matching the ON CONFLICT specification'
-        ));
-
-    if (!isMissingConflictTarget) {
-      throw error;
-    }
-
-    logger.warn(
-      '[Audience Visit] Missing conflict target for daily_profile_views upsert, using safe fallback update path'
-    );
-  }
-
-  const [updatedExisting] = await tx
-    .update(dailyProfileViews)
-    .set({
-      viewCount: drizzleSql`${dailyProfileViews.viewCount} + 1`,
-      updatedAt: now,
-    })
-    .where(
-      and(
-        eq(dailyProfileViews.creatorProfileId, profileId),
-        eq(dailyProfileViews.viewDate, viewDate)
-      )
-    )
-    .returning({ id: dailyProfileViews.id });
-
-  if (updatedExisting) {
-    return;
-  }
-
-  await tx.insert(dailyProfileViews).values(values).onConflictDoNothing();
-
-  await tx
-    .update(dailyProfileViews)
-    .set({
-      viewCount: drizzleSql`${dailyProfileViews.viewCount} + 1`,
-      updatedAt: now,
-    })
-    .where(
-      and(
-        eq(dailyProfileViews.creatorProfileId, profileId),
-        eq(dailyProfileViews.viewDate, viewDate)
-      )
-    );
-}
-
-function isMissingDailyProfileViewsTableError(error: unknown): boolean {
-  return unwrapPgError(error).code === '42P01';
 }
 
 function isMissingAudienceReferrersTableError(error: unknown): boolean {
@@ -846,7 +739,9 @@ export async function POST(request: NextRequest) {
           }
 
           if (visitRecorded && compatibility.hasDailyProfileViewsTable) {
-            await writeDailyProfileViews(tx, profileId, viewDate, now);
+            await writeDailyProfileViews(tx, profileId, viewDate, now, {
+              route: 'audience/visit',
+            });
           }
 
           if (

--- a/apps/web/app/api/track/route.ts
+++ b/apps/web/app/api/track/route.ts
@@ -1,5 +1,6 @@
 import { and, sql as drizzleSql, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { writeDailyProfileViews } from '@/lib/analytics/daily-profile-views';
 import type { AudienceSourceType } from '@/lib/audience/activity-types';
 import {
   resolveAudienceClickEventType,
@@ -15,7 +16,7 @@ import {
   CONSENT_COOKIE_NAME,
   parseConsentCookieValue,
 } from '@/lib/cookies/consent-state';
-import { db } from '@/lib/db';
+import { db, doesTableExist } from '@/lib/db';
 import { audienceMembers, clickEvents } from '@/lib/db/schema/analytics';
 import { socialLinks } from '@/lib/db/schema/links';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
@@ -450,6 +451,10 @@ export async function POST(request: NextRequest) {
         })
       : null;
 
+    const hasDailyProfileViewsTable = await doesTableExist(
+      'daily_profile_views'
+    );
+
     const trackingResult = await withSystemIngestionSession(async tx => {
       const metadata = buildClickMetadata(
         target,
@@ -478,6 +483,23 @@ export async function POST(request: NextRequest) {
           audienceMemberId,
         })
         .returning({ id: clickEvents.id });
+
+      // Click implies profile view: keep daily_profile_views in sync when
+      // /api/audience/visit did not fire (e.g. blocked scripts, token failures).
+      if (
+        insertedClickEvent &&
+        !botDetection.isBot &&
+        hasDailyProfileViewsTable
+      ) {
+        const now = new Date();
+        await writeDailyProfileViews(
+          tx,
+          profile.id,
+          now.toISOString().slice(0, 10),
+          now,
+          { route: 'api/track' }
+        );
+      }
 
       if (insertedClickEvent && audienceMemberId) {
         await recordAudienceEvent(tx, {

--- a/apps/web/lib/analytics/daily-profile-views.ts
+++ b/apps/web/lib/analytics/daily-profile-views.ts
@@ -1,0 +1,111 @@
+import { and, sql as drizzleSql, eq } from 'drizzle-orm';
+import type { DbOrTransaction } from '@/lib/db';
+import { unwrapPgError } from '@/lib/db/errors';
+import { dailyProfileViews } from '@/lib/db/schema/analytics';
+import { captureWarning } from '@/lib/error-tracking';
+import { logger } from '@/lib/utils/logger';
+
+export function isMissingDailyProfileViewsTableError(error: unknown): boolean {
+  return unwrapPgError(error).code === '42P01';
+}
+
+export async function incrementDailyProfileViews(
+  tx: DbOrTransaction,
+  profileId: string,
+  viewDate: string,
+  now: Date
+): Promise<void> {
+  const values = {
+    creatorProfileId: profileId,
+    viewDate,
+    viewCount: 1,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  try {
+    await tx
+      .insert(dailyProfileViews)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [
+          dailyProfileViews.creatorProfileId,
+          dailyProfileViews.viewDate,
+        ],
+        set: {
+          viewCount: drizzleSql`${dailyProfileViews.viewCount} + 1`,
+          updatedAt: now,
+        },
+      });
+    return;
+  } catch (error) {
+    const isMissingConflictTarget =
+      error instanceof Error &&
+      (error.message.includes('42P10') ||
+        error.message.includes(
+          'there is no unique or exclusion constraint matching the ON CONFLICT specification'
+        ));
+
+    if (!isMissingConflictTarget) {
+      throw error;
+    }
+
+    logger.warn(
+      '[analytics/daily-profile-views] Missing conflict target for daily_profile_views upsert, using safe fallback update path'
+    );
+  }
+
+  const [updatedExisting] = await tx
+    .update(dailyProfileViews)
+    .set({
+      viewCount: drizzleSql`${dailyProfileViews.viewCount} + 1`,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(dailyProfileViews.creatorProfileId, profileId),
+        eq(dailyProfileViews.viewDate, viewDate)
+      )
+    )
+    .returning({ id: dailyProfileViews.id });
+
+  if (updatedExisting) {
+    return;
+  }
+
+  await tx.insert(dailyProfileViews).values(values).onConflictDoNothing();
+
+  await tx
+    .update(dailyProfileViews)
+    .set({
+      viewCount: drizzleSql`${dailyProfileViews.viewCount} + 1`,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(dailyProfileViews.creatorProfileId, profileId),
+        eq(dailyProfileViews.viewDate, viewDate)
+      )
+    );
+}
+
+export async function writeDailyProfileViews(
+  tx: DbOrTransaction,
+  profileId: string,
+  viewDate: string,
+  now: Date,
+  context: { route: string }
+): Promise<void> {
+  try {
+    await incrementDailyProfileViews(tx, profileId, viewDate, now);
+  } catch (error) {
+    if (!isMissingDailyProfileViewsTableError(error)) {
+      throw error;
+    }
+    await captureWarning(
+      `[${context.route}] daily_profile_views table missing; skipping aggregate write`,
+      error,
+      { profileId, viewDate }
+    );
+  }
+}

--- a/apps/web/lib/db/queries/analytics.ts
+++ b/apps/web/lib/db/queries/analytics.ts
@@ -84,11 +84,11 @@ export async function getUserDashboardAnalytics(
     const hasDailyProfileViews = await doesTableExist(
       TABLE_NAMES.dailyProfileViews
     );
-    // Canonical total views: daily_profile_views (written atomically with member
-    // visits on /api/audience/visit). SUM(audience_members.visits) diverges because
-    // (1) member visits predate the daily aggregate table, (2) seed scripts write
-    // independent random values, and (3) other write paths (e.g. short-link scans)
-    // increment member visits without daily_profile_views.
+    // Canonical total views: daily_profile_views (written on /api/audience/visit
+    // and /api/track click-implies-view). SUM(audience_members.visits) diverges
+    // because (1) member visits predate the daily aggregate table, (2) seed scripts
+    // write independent random values, and (3) other write paths (e.g. short-link
+    // scans) increment member visits without daily_profile_views.
     const totalViewsSelect = hasDailyProfileViews
       ? drizzleSql`(
           select coalesce(sum(${dailyProfileViews.viewCount}), 0)

--- a/apps/web/tests/bench/track-route.bench.test.ts
+++ b/apps/web/tests/bench/track-route.bench.test.ts
@@ -77,20 +77,21 @@ function buildDb(state: BenchmarkState) {
 }
 
 function buildTx(state: BenchmarkState) {
-  const buildReturning = async (isConflictPath: boolean) => {
-    const isClickEvent = !isConflictPath;
-    const isAudience = isConflictPath;
-
+  const buildReturning = async (
+    insertKind: 'click' | 'audience' | 'daily_views'
+  ) => {
     await sleep(
-      isClickEvent ? state.delays.clickInsert : state.delays.audienceInsert
+      insertKind === 'click'
+        ? state.delays.clickInsert
+        : state.delays.audienceInsert
     );
 
-    if (isClickEvent) {
+    if (insertKind === 'click') {
       const eventId = `click-${state.clickEvents.length + 1}`;
       state.clickEvents.push({ id: eventId, linkType: 'social' });
       return [{ id: eventId }];
     }
-    if (isAudience) {
+    if (insertKind === 'audience') {
       if (state.audienceMember) return [];
       state.audienceMember = { ...DEFAULT_MEMBER };
       return [state.audienceMember];
@@ -111,15 +112,26 @@ function buildTx(state: BenchmarkState) {
       }),
     }),
     insert: () => {
-      let conflictPath = false;
+      let insertKind: 'click' | 'audience' | 'daily_views' = 'click';
       return {
-        values: () => ({
-          onConflictDoNothing: () => {
-            conflictPath = true;
-            return { returning: () => buildReturning(conflictPath) };
-          },
-          returning: () => buildReturning(conflictPath),
-        }),
+        values: (payload: Record<string, unknown>) => {
+          if (typeof payload.viewCount === 'number') {
+            insertKind = 'daily_views';
+          } else if (payload.type === 'anonymous') {
+            insertKind = 'audience';
+          } else {
+            insertKind = 'click';
+          }
+
+          return {
+            onConflictDoUpdate: async () => undefined,
+            onConflictDoNothing: () => {
+              insertKind = 'audience';
+              return { returning: () => buildReturning(insertKind) };
+            },
+            returning: () => buildReturning(insertKind),
+          };
+        },
       };
     },
     update: () => ({
@@ -158,6 +170,7 @@ async function runBenchmark(sampleSize: number) {
 
   vi.doMock('@/lib/db', () => ({
     db: buildDb(state),
+    doesTableExist: async () => true,
   }));
 
   vi.doMock('@/lib/rate-limit', () => ({

--- a/apps/web/tests/unit/api/track/route.test.ts
+++ b/apps/web/tests/unit/api/track/route.test.ts
@@ -5,6 +5,9 @@ import { recordAudienceEvent } from '@/lib/audience/record-audience-event';
 import { captureError } from '@/lib/error-tracking';
 
 const hoisted = vi.hoisted(() => {
+  const writeDailyProfileViewsMock = vi.fn().mockResolvedValue(undefined);
+  const doesTableExistMock = vi.fn().mockResolvedValue(true);
+  const detectBotMock = vi.fn().mockReturnValue({ isBot: false, reason: null });
   const selectLimitMock = vi.fn().mockResolvedValue([{ id: 'profile_123' }]);
   const selectWhereMock = vi.fn().mockReturnValue({
     limit: selectLimitMock,
@@ -38,6 +41,9 @@ const hoisted = vi.hoisted(() => {
     );
 
   return {
+    writeDailyProfileViewsMock,
+    doesTableExistMock,
+    detectBotMock,
     selectMock,
     selectWhereMock,
     selectFromMock,
@@ -56,6 +62,15 @@ vi.mock('@/lib/db', () => ({
     select: hoisted.selectMock,
     update: hoisted.updateMock,
   },
+  doesTableExist: hoisted.doesTableExistMock,
+}));
+
+vi.mock('@/lib/analytics/daily-profile-views', () => ({
+  writeDailyProfileViews: hoisted.writeDailyProfileViewsMock,
+}));
+
+vi.mock('@/lib/utils/bot-detection', () => ({
+  detectBot: hoisted.detectBotMock,
 }));
 
 vi.mock('@/lib/db/schema', () => ({
@@ -381,6 +396,83 @@ describe('POST /api/track', () => {
       })
     );
     expect(recordAudienceEvent).not.toHaveBeenCalled();
+  });
+
+  it('increments daily_profile_views when a non-bot click is recorded (click-implies-view)', async () => {
+    const clickValuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'click_event_123' }]),
+    });
+
+    hoisted.withSystemIngestionSession.mockImplementationOnce(async callback =>
+      callback({
+        insert: vi.fn().mockReturnValue({
+          values: clickValuesMock,
+        }),
+      })
+    );
+
+    const request = new NextRequest('http://localhost/api/track', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'jv_cc={"essential":true,"analytics":false,"marketing":false}',
+      },
+      body: JSON.stringify({
+        handle: 'artist123',
+        linkType: 'listen',
+        target: 'https://open.spotify.com/artist/example',
+      }),
+    });
+
+    const response = await POST(request as unknown as NextRequest);
+
+    expect(response.status).toBe(200);
+    expect(hoisted.doesTableExistMock).toHaveBeenCalledWith(
+      'daily_profile_views'
+    );
+    expect(hoisted.writeDailyProfileViewsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'profile_123',
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      expect.any(Date),
+      { route: 'api/track' }
+    );
+  });
+
+  it('does not increment daily_profile_views for bot clicks', async () => {
+    hoisted.detectBotMock.mockReturnValueOnce({
+      isBot: true,
+      reason: 'User-Agent match',
+    });
+
+    const clickValuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'click_event_123' }]),
+    });
+
+    hoisted.withSystemIngestionSession.mockImplementationOnce(async callback =>
+      callback({
+        insert: vi.fn().mockReturnValue({
+          values: clickValuesMock,
+        }),
+      })
+    );
+
+    const request = new NextRequest('http://localhost/api/track', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        handle: 'artist123',
+        linkType: 'other',
+        target: 'https://example.com',
+      }),
+    });
+
+    const response = await POST(request as unknown as NextRequest);
+
+    expect(response.status).toBe(200);
+    expect(hoisted.writeDailyProfileViewsMock).not.toHaveBeenCalled();
   });
 
   it('decodes percent-encoded x-vercel-ip-city before storing click events', async () => {

--- a/apps/web/tests/unit/lib/analytics/daily-profile-views.test.ts
+++ b/apps/web/tests/unit/lib/analytics/daily-profile-views.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  incrementDailyProfileViews,
+  isMissingDailyProfileViewsTableError,
+} from '@/lib/analytics/daily-profile-views';
+
+vi.mock('@/lib/db/schema/analytics', () => ({
+  dailyProfileViews: {
+    creatorProfileId: 'creator_profile_id',
+    viewDate: 'view_date',
+    viewCount: 'view_count',
+    id: 'id',
+  },
+}));
+
+describe('daily-profile-views analytics helper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('detects missing daily_profile_views table errors', () => {
+    expect(
+      isMissingDailyProfileViewsTableError({
+        code: '42P01',
+        message: 'missing',
+      })
+    ).toBe(true);
+    expect(
+      isMissingDailyProfileViewsTableError({ cause: { code: '42P01' } })
+    ).toBe(true);
+    expect(
+      isMissingDailyProfileViewsTableError(new Error('other failure'))
+    ).toBe(false);
+  });
+
+  it('upserts daily_profile_views with onConflictDoUpdate', async () => {
+    const onConflictDoUpdateMock = vi.fn().mockResolvedValue(undefined);
+    const valuesMock = vi.fn().mockReturnValue({
+      onConflictDoUpdate: onConflictDoUpdateMock,
+    });
+    const insertMock = vi.fn().mockReturnValue({
+      values: valuesMock,
+    });
+
+    await incrementDailyProfileViews(
+      { insert: insertMock } as never,
+      'profile_123',
+      '2026-06-26',
+      new Date('2026-06-26T12:00:00.000Z')
+    );
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creatorProfileId: 'profile_123',
+        viewDate: '2026-06-26',
+        viewCount: 1,
+      })
+    );
+    expect(onConflictDoUpdateMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Goal

Fix live analytics contradiction where `total_clicks` could exceed counted profile views because clicks land via `/api/track` while `daily_profile_views` only incremented on `/api/audience/visit`.

## Changes

- Extract shared `writeDailyProfileViews` / `incrementDailyProfileViews` helper to `lib/analytics/daily-profile-views.ts`
- Call click-implies-view from `/api/track` for non-bot clicks inside the click insert transaction
- Refactor `/api/audience/visit` to use the shared helper
- Add unit tests asserting non-bot clicks increment `daily_profile_views` and bot clicks do not

## Testing

```bash
pnpm exec vitest run apps/web/tests/unit/api/track/route.test.ts apps/web/tests/unit/lib/analytics/daily-profile-views.test.ts apps/web/tests/unit/api/audience/visit.test.ts
```

<!-- linear-issue-identifier:JOV-3589 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)