### PR TITLE
fix(web): restore paid usage/plan counts in settings and header (JOV-3339)

### DIFF
--- a/apps/web/app/api/chat/usage/route.ts
+++ b/apps/web/app/api/chat/usage/route.ts
@@ -4,11 +4,11 @@ import {
   getEntitlements,
   resolveChatUsagePlan,
 } from '@/lib/entitlements/registry';
-import { RETRY_AFTER_SERVICE } from '@/lib/http/headers';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import { aiChatDailyPlanAwareLimiter } from '@/lib/rate-limit/limiters';
 import { getRedis } from '@/lib/redis';
-import { getUserBillingInfo } from '@/lib/stripe/customer-sync';
 import { logger } from '@/lib/utils/logger';
+import type { UserPlan } from '@/types';
 
 export const runtime = 'nodejs';
 
@@ -89,6 +89,40 @@ function formatResetAt(resetTime: number): string | null {
   return new Date(resetTime).toISOString();
 }
 
+export function buildChatUsageSnapshot(params: {
+  readonly userId: string;
+  readonly entitlementPlan: UserPlan;
+}): ChatUsageSnapshot {
+  const plan = resolveChatUsagePlan(params.entitlementPlan);
+  const entitlements = getEntitlements(params.entitlementPlan);
+  const dailyLimit = entitlements.limits.aiDailyMessageLimit;
+  const status = aiChatDailyPlanAwareLimiter.getStatus(
+    params.userId,
+    params.entitlementPlan
+  );
+  const remaining = Math.max(0, Math.min(dailyLimit, status.remaining));
+  const used = Math.max(0, dailyLimit - remaining);
+  const warningThreshold = plan === 'free' ? 2 : 5;
+  const monthlyWindow = resolveMonthlyUsageWindow();
+  const monthlyLimit = dailyLimit * monthlyWindow.daysInMonth;
+  const monthlyUsed = Math.min(used, monthlyLimit);
+
+  return {
+    plan,
+    dailyLimit,
+    used,
+    remaining,
+    resetAt: formatResetAt(status.resetTime),
+    monthlyLimit,
+    monthlyUsed,
+    monthlyRemaining: Math.max(0, monthlyLimit - monthlyUsed),
+    monthlyResetAt: monthlyWindow.resetAt,
+    isExhausted: remaining <= 0,
+    warningThreshold,
+    isNearLimit: remaining > 0 && remaining <= warningThreshold,
+  };
+}
+
 export async function GET() {
   let userId: string | null;
   try {
@@ -106,55 +140,35 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const billing = await getUserBillingInfo();
-  if (!billing.success) {
-    // Billing unavailable — serve stale cached data if we have it
+  const entitlements = await getCurrentUserEntitlements();
+  if (!entitlements.isAuthenticated || !entitlements.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const billingUnavailable = entitlements.billingVerification === 'unavailable';
+
+  if (billingUnavailable) {
     const cached = await readCachedChatUsage(userId);
     if (cached) {
       const stale: StaleChatUsageSnapshot = { ...cached, _stale: true };
       return NextResponse.json(stale, { headers: CACHE_HEADERS });
     }
 
-    logger.warn('Chat usage billing lookup failed with no cache fallback', {
+    logger.warn('Chat usage billing unavailable; serving degraded snapshot', {
       userId,
     });
-    return NextResponse.json(
-      { error: 'Billing service temporarily unavailable' },
-      {
-        status: 503,
-        headers: {
-          'Cache-Control': 'no-store',
-          'Retry-After': RETRY_AFTER_SERVICE,
-        },
-      }
-    );
+    const degraded = buildChatUsageSnapshot({
+      userId,
+      entitlementPlan: entitlements.plan,
+    });
+    const stale: StaleChatUsageSnapshot = { ...degraded, _stale: true };
+    return NextResponse.json(stale, { headers: CACHE_HEADERS });
   }
 
-  const plan = resolveChatUsagePlan(billing.data?.plan);
-  const entitlements = getEntitlements(plan);
-  const dailyLimit = entitlements.limits.aiDailyMessageLimit;
-  const status = aiChatDailyPlanAwareLimiter.getStatus(userId, plan);
-  const remaining = Math.max(0, Math.min(dailyLimit, status.remaining));
-  const used = Math.max(0, dailyLimit - remaining);
-  const warningThreshold = plan === 'free' ? 2 : 5;
-  const monthlyWindow = resolveMonthlyUsageWindow();
-  const monthlyLimit = dailyLimit * monthlyWindow.daysInMonth;
-  const monthlyUsed = Math.min(used, monthlyLimit);
-
-  const response: ChatUsageSnapshot = {
-    plan,
-    dailyLimit,
-    used,
-    remaining,
-    resetAt: formatResetAt(status.resetTime),
-    monthlyLimit,
-    monthlyUsed,
-    monthlyRemaining: Math.max(0, monthlyLimit - monthlyUsed),
-    monthlyResetAt: monthlyWindow.resetAt,
-    isExhausted: remaining <= 0,
-    warningThreshold,
-    isNearLimit: remaining > 0 && remaining <= warningThreshold,
-  };
+  const response = buildChatUsageSnapshot({
+    userId,
+    entitlementPlan: entitlements.plan,
+  });
 
   writeChatUsageCache(userId, response);
 

--- a/apps/web/components/features/dashboard/atoms/HeaderChatUsageIndicator.tsx
+++ b/apps/web/components/features/dashboard/atoms/HeaderChatUsageIndicator.tsx
@@ -18,16 +18,36 @@ export const HeaderChatUsageIndicator = memo(
       enabled: !isPassiveRuntime && !isDemoRoute,
     });
 
-    if (
-      isPassiveRuntime ||
-      isDemoRoute ||
-      !data ||
-      (!data.isNearLimit && !data.isExhausted)
-    ) {
+    if (isPassiveRuntime || isDemoRoute || !data) {
       return null;
     }
 
     const copy = getChatUsageCopy(data);
+    const isPaidPlan = data.plan === 'pro' || data.plan === 'max';
+    const showHealthyPaidUsage =
+      isPaidPlan && !data.isNearLimit && !data.isExhausted;
+
+    if (!isPaidPlan && !data.isNearLimit && !data.isExhausted) {
+      return null;
+    }
+
+    if (showHealthyPaidUsage) {
+      return (
+        <Link
+          href={APP_ROUTES.PRICING}
+          className='group inline-flex items-center gap-1.5 rounded-lg border border-subtle bg-surface-1 px-2.5 py-1.5 text-app font-caption text-secondary-token transition-colors hover:bg-surface-2 hover:text-primary-token'
+          aria-label={copy.headerAriaLabel}
+        >
+          <span className='font-medium text-primary-token'>
+            {copy.planLabel}
+          </span>
+          <span className='text-tertiary-token' aria-hidden>
+            ·
+          </span>
+          <span className='tabular-nums'>{copy.headerLabel}</span>
+        </Link>
+      );
+    }
 
     return (
       <Link

--- a/apps/web/lib/queries/useChatUsageQuery.ts
+++ b/apps/web/lib/queries/useChatUsageQuery.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { STABLE_CACHE } from './cache-strategies';
+import { FREQUENT_BACKGROUND_CACHE } from './cache-strategies';
 import { createQueryFn, FetchError } from './fetch';
 import { queryKeys } from './keys';
 
@@ -25,7 +25,7 @@ const fetchChatUsage = createQueryFn<ChatUsageData>('/api/chat/usage');
 export const chatUsageQueryOptions = {
   queryKey: queryKeys.chat.usage(),
   queryFn: fetchChatUsage,
-  ...STABLE_CACHE,
+  ...FREQUENT_BACKGROUND_CACHE,
   retry: (failureCount: number, error: Error) => {
     if (error instanceof FetchError && !error.isRetryable()) {
       return false;

--- a/apps/web/tests/unit/api/chat/usage.test.ts
+++ b/apps/web/tests/unit/api/chat/usage.test.ts
@@ -1,32 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ENTITLEMENT_REGISTRY } from '@/lib/entitlements/registry';
 
 const hoisted = vi.hoisted(() => ({
-  authMock: vi.fn(),
-  getUserBillingInfoMock: vi.fn(),
-  getEntitlementsMock: vi.fn(),
+  getCachedAuthMock: vi.fn(),
+  getCurrentUserEntitlementsMock: vi.fn(),
   getRedisMock: vi.fn(),
   getStatusMock: vi.fn(),
 }));
 
-vi.mock('@clerk/nextjs/server', () => ({
-  auth: hoisted.authMock,
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: hoisted.getCachedAuthMock,
 }));
 
-vi.mock('@/lib/stripe/customer-sync', () => ({
-  getUserBillingInfo: hoisted.getUserBillingInfoMock,
+vi.mock('@/lib/entitlements/server', () => ({
+  getCurrentUserEntitlements: hoisted.getCurrentUserEntitlementsMock,
 }));
-
-vi.mock('@/lib/entitlements/registry', async () => {
-  // Preserve real exports (including `resolveChatUsagePlan`, extracted from
-  // the route in 45ef3d68) while only substituting `getEntitlements`.
-  const actual = await vi.importActual<
-    typeof import('@/lib/entitlements/registry')
-  >('@/lib/entitlements/registry');
-  return {
-    ...actual,
-    getEntitlements: hoisted.getEntitlementsMock,
-  };
-});
 
 vi.mock('@/lib/redis', () => ({
   getRedis: hoisted.getRedisMock,
@@ -38,22 +26,56 @@ vi.mock('@/lib/rate-limit/limiters', () => ({
   },
 }));
 
-vi.mock('@/lib/http/headers', () => ({
-  RETRY_AFTER_SERVICE: '30',
-}));
-
 vi.mock('@/lib/utils/logger', () => ({
   logger: { warn: vi.fn(), error: vi.fn() },
 }));
 
+function makeEntitlements(
+  overrides: Partial<{
+    plan: 'free' | 'trial' | 'pro' | 'max' | 'founding' | 'growth';
+    billingVerification: 'verified' | 'unavailable' | 'missing_user';
+    isAuthenticated: boolean;
+    userId: string | null;
+  }> = {}
+) {
+  const plan = overrides.plan ?? 'free';
+  const ent =
+    ENTITLEMENT_REGISTRY[
+      plan === 'founding'
+        ? 'pro'
+        : plan === 'growth'
+          ? 'max'
+          : plan === 'trial'
+            ? 'trial'
+            : plan
+    ];
+  return {
+    userId: overrides.userId ?? 'user_123',
+    email: 'artist@example.com',
+    isAuthenticated: overrides.isAuthenticated ?? true,
+    isAdmin: false,
+    plan,
+    isPro: plan !== 'free',
+    hasAdvancedFeatures: plan === 'max' || plan === 'growth',
+    billingVerification: overrides.billingVerification ?? 'verified',
+    ...ent.booleans,
+    ...ent.limits,
+  };
+}
+
 describe('GET /api/chat/usage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.getCachedAuthMock.mockResolvedValue({ userId: 'user_123' });
     hoisted.getRedisMock.mockReturnValue(null);
+    hoisted.getStatusMock.mockReturnValue({
+      remaining: 7,
+      resetTime: Date.UTC(2026, 4, 23, 7, 0, 0),
+    });
   });
 
   it('returns 401 when unauthenticated', async () => {
-    hoisted.authMock.mockResolvedValue({ userId: null });
+    hoisted.getCachedAuthMock.mockResolvedValue({ userId: null });
 
     const { GET } = await import('@/app/api/chat/usage/route');
     const response = await GET();
@@ -64,18 +86,9 @@ describe('GET /api/chat/usage', () => {
   });
 
   it('returns usage snapshot for authenticated user on free plan', async () => {
-    hoisted.authMock.mockResolvedValue({ userId: 'user_123' });
-    hoisted.getUserBillingInfoMock.mockResolvedValue({
-      success: true,
-      data: { plan: 'free' },
-    });
-    hoisted.getEntitlementsMock.mockReturnValue({
-      limits: { aiDailyMessageLimit: 10 },
-    });
-    hoisted.getStatusMock.mockReturnValue({
-      remaining: 7,
-      resetTime: Date.UTC(2026, 4, 23, 7, 0, 0),
-    });
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue(
+      makeEntitlements({ plan: 'free' })
+    );
 
     const { GET } = await import('@/app/api/chat/usage/route');
     const response = await GET();
@@ -95,50 +108,75 @@ describe('GET /api/chat/usage', () => {
   });
 
   it('returns usage for pro plan with correct warning threshold', async () => {
-    hoisted.authMock.mockResolvedValue({ userId: 'user_123' });
-    hoisted.getUserBillingInfoMock.mockResolvedValue({
-      success: true,
-      data: { plan: 'pro' },
-    });
-    hoisted.getEntitlementsMock.mockReturnValue({
-      limits: { aiDailyMessageLimit: 50 },
-    });
-    hoisted.getStatusMock.mockReturnValue({ remaining: 4 });
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue(
+      makeEntitlements({ plan: 'pro' })
+    );
+    hoisted.getStatusMock.mockReturnValue({ remaining: 4, resetTime: 0 });
 
     const { GET } = await import('@/app/api/chat/usage/route');
     const response = await GET();
 
     const body = await response.json();
     expect(body.plan).toBe('pro');
+    expect(body.dailyLimit).toBe(100);
     expect(body.warningThreshold).toBe(5);
     expect(body.isNearLimit).toBe(true);
+    expect(hoisted.getStatusMock).toHaveBeenCalledWith('user_123', 'pro');
   });
 
-  it('returns 503 when billing unavailable and no cache', async () => {
-    hoisted.authMock.mockResolvedValue({ userId: 'user_123' });
-    hoisted.getUserBillingInfoMock.mockResolvedValue({ success: false });
-    hoisted.getRedisMock.mockReturnValue({
-      get: vi.fn().mockResolvedValue(null),
-    });
+  it('normalizes isPro-backed pro entitlements to pro usage limits', async () => {
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue(
+      makeEntitlements({ plan: 'pro' })
+    );
+    hoisted.getStatusMock.mockReturnValue({ remaining: 88, resetTime: 0 });
 
     const { GET } = await import('@/app/api/chat/usage/route');
     const response = await GET();
 
-    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.plan).toBe('pro');
+    expect(body.dailyLimit).toBe(100);
+    expect(body.remaining).toBe(88);
   });
 
-  it('returns stale cached data when billing unavailable', async () => {
-    hoisted.authMock.mockResolvedValue({ userId: 'user_123' });
-    hoisted.getUserBillingInfoMock.mockResolvedValue({ success: false });
+  it('returns degraded usage when billing is unavailable and no cache', async () => {
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue(
+      makeEntitlements({
+        plan: 'free',
+        billingVerification: 'unavailable',
+      })
+    );
+
+    const { GET } = await import('@/app/api/chat/usage/route');
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body._stale).toBe(true);
+    expect(body.plan).toBe('free');
+    expect(body.dailyLimit).toBe(10);
+  });
+
+  it('returns stale cached data when billing is unavailable', async () => {
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue(
+      makeEntitlements({
+        plan: 'pro',
+        billingVerification: 'unavailable',
+      })
+    );
 
     const cachedSnapshot = {
-      plan: 'free',
-      dailyLimit: 10,
+      plan: 'pro',
+      dailyLimit: 100,
       used: 5,
-      remaining: 5,
+      remaining: 95,
       isExhausted: false,
-      warningThreshold: 2,
+      warningThreshold: 5,
       isNearLimit: false,
+      monthlyLimit: 3100,
+      monthlyUsed: 5,
+      monthlyRemaining: 3095,
+      monthlyResetAt: '2026-07-01T00:00:00.000Z',
     };
     hoisted.getRedisMock.mockReturnValue({
       get: vi.fn().mockResolvedValue(cachedSnapshot),
@@ -150,19 +188,15 @@ describe('GET /api/chat/usage', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body._stale).toBe(true);
-    expect(body.plan).toBe('free');
+    expect(body.plan).toBe('pro');
+    expect(body.remaining).toBe(95);
   });
 
   it('marks isExhausted when remaining is 0', async () => {
-    hoisted.authMock.mockResolvedValue({ userId: 'user_123' });
-    hoisted.getUserBillingInfoMock.mockResolvedValue({
-      success: true,
-      data: { plan: 'free' },
-    });
-    hoisted.getEntitlementsMock.mockReturnValue({
-      limits: { aiDailyMessageLimit: 10 },
-    });
-    hoisted.getStatusMock.mockReturnValue({ remaining: 0 });
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue(
+      makeEntitlements({ plan: 'free' })
+    );
+    hoisted.getStatusMock.mockReturnValue({ remaining: 0, resetTime: 0 });
 
     const { GET } = await import('@/app/api/chat/usage/route');
     const response = await GET();

--- a/apps/web/tests/unit/dashboard/HeaderChatUsageIndicator.test.tsx
+++ b/apps/web/tests/unit/dashboard/HeaderChatUsageIndicator.test.tsx
@@ -31,6 +31,7 @@ describe('HeaderChatUsageIndicator', () => {
   it('renders near-limit copy in header', () => {
     mockUseChatUsageQuery.mockReturnValue({
       data: {
+        plan: 'free',
         remaining: 2,
         isNearLimit: true,
         isExhausted: false,
@@ -41,6 +42,23 @@ describe('HeaderChatUsageIndicator', () => {
 
     expect(getByRole('link')).toBeDefined();
     expect(getByText('2 messages left')).toBeDefined();
+  });
+
+  it('renders healthy paid plan usage in header', () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: {
+        plan: 'pro',
+        remaining: 42,
+        isNearLimit: false,
+        isExhausted: false,
+      },
+    });
+
+    const { getByRole, getByText } = fastRender(<HeaderChatUsageIndicator />);
+
+    expect(getByRole('link')).toBeDefined();
+    expect(getByText('Pro')).toBeDefined();
+    expect(getByText('42 messages left')).toBeDefined();
   });
 
   it('suppresses the banner on nested demo routes', () => {


### PR DESCRIPTION
## Goal
Fix JOV-3339: paid users not seeing usage/plan counts in settings and header.

## Root cause
- `/api/chat/usage` resolved plans from raw `billing.data.plan` without the `isPro`-aware normalization used elsewhere (`getCurrentUserEntitlements`), so paid rows with drifted plan values resolved to free limits.
- Billing outages returned HTTP 503 with no fallback unless Redis had a prior snapshot, leaving the client query in a permanent error state.
- `useChatUsageQuery` used `STABLE_CACHE` (`refetchOnMount: false`), so transient failures and post-upgrade plan changes could stick.
- `HeaderChatUsageIndicator` only rendered near-limit/exhausted states, hiding healthy paid usage entirely.

## Changes
- Route now builds snapshots from `getCurrentUserEntitlements()` via exported `buildChatUsageSnapshot`.
- Billing-unavailable path serves stale Redis cache or a degraded 200 snapshot (never 503).
- Client query uses `FREQUENT_BACKGROUND_CACHE` like billing status.
- Header shows plan + remaining for healthy Pro/Max users.
- Unit tests updated/added for plan normalization, billing degrade, and paid header rendering.

## Testing
- `pnpm --filter @jovie/web exec vitest run tests/unit/api/chat/usage.test.ts tests/unit/dashboard/HeaderChatUsageIndicator.test.tsx tests/unit/dashboard/SettingsUsageStatsSection.test.tsx`
- `pnpm run typecheck --filter=@jovie/web`

Closes JOV-3339