### PR TITLE
fix(auth): redirect signed-in users away from /signin before Clerk flows mount

### DIFF
--- a/apps/web/app/(auth)/signin/SignInPageClient.tsx
+++ b/apps/web/app/(auth)/signin/SignInPageClient.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
 import { toast } from 'sonner';
+import { AuthenticatedAuthEntryGuard } from '@/components/features/auth/AuthenticatedAuthEntryGuard';
 import { SignInTimeoutEscape } from '@/components/molecules/SignInTimeoutEscape';
 import { APP_ROUTES } from '@/constants/routes';
 import { AuthLayout, AuthRoutePrefetch, AuthShell } from '@/features/auth';
@@ -183,24 +184,26 @@ export function SignInPageClient() {
   }
 
   return (
-    <AuthLayout
-      formTitle='Sign in'
-      showFormTitle={false}
-      showFooterPrompt={false}
-      layoutVariant='split'
-    >
-      <AuthRoutePrefetch href={signUpUrl} />
-      <SignInOauthErrorBanner />
-      <AuthShell
-        mode='sign-in'
-        forceOppositeModeHardNavigation
-        oppositeModeUrl={
-          desktopReturnRoute || mobileReturnRoute ? signUpUrl : undefined
-        }
-        fallbackRedirectUrl={fallbackRedirectUrl}
-        initialValues={initialValues}
-      />
-      <SignInTimeoutEscape />
-    </AuthLayout>
+    <AuthenticatedAuthEntryGuard>
+      <AuthLayout
+        formTitle='Sign in'
+        showFormTitle={false}
+        showFooterPrompt={false}
+        layoutVariant='split'
+      >
+        <AuthRoutePrefetch href={signUpUrl} />
+        <SignInOauthErrorBanner />
+        <AuthShell
+          mode='sign-in'
+          forceOppositeModeHardNavigation
+          oppositeModeUrl={
+            desktopReturnRoute || mobileReturnRoute ? signUpUrl : undefined
+          }
+          fallbackRedirectUrl={fallbackRedirectUrl}
+          initialValues={initialValues}
+        />
+        <SignInTimeoutEscape />
+      </AuthLayout>
+    </AuthenticatedAuthEntryGuard>
   );
 }

--- a/apps/web/app/(auth)/signin/page.tsx
+++ b/apps/web/app/(auth)/signin/page.tsx
@@ -5,6 +5,8 @@ import { getAuthenticatedAuthRouteRedirect } from '@/lib/auth/access-route-redir
 import { CanonicalUserState, resolveUserState } from '@/lib/auth/gate';
 import { SignInPageClient } from './SignInPageClient';
 
+export const dynamic = 'force-dynamic';
+
 export default async function SignInPage({
   searchParams,
 }: Readonly<{

--- a/apps/web/app/@auth/(.)signin/SigninModalClient.tsx
+++ b/apps/web/app/@auth/(.)signin/SigninModalClient.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams } from 'next/navigation';
 import { AuthModalShell } from '@/components/auth/AuthModalShell';
+import { AuthenticatedAuthEntryGuard } from '@/components/features/auth/AuthenticatedAuthEntryGuard';
 import { AuthShell } from '@/components/features/auth/AuthShell';
 import { APP_ROUTES } from '@/constants/routes';
 import { buildAuthRouteUrl } from '@/lib/auth/build-auth-route-url';
@@ -21,13 +22,15 @@ export function SigninModalClient() {
     APP_ROUTES.DASHBOARD;
 
   return (
-    <AuthModalShell ariaLabel='Sign in to Jovie'>
-      <AuthShell
-        mode='sign-in'
-        compact
-        oppositeModeUrl={signUpUrl}
-        fallbackRedirectUrl={redirectUrl}
-      />
-    </AuthModalShell>
+    <AuthenticatedAuthEntryGuard>
+      <AuthModalShell ariaLabel='Sign in to Jovie'>
+        <AuthShell
+          mode='sign-in'
+          compact
+          oppositeModeUrl={signUpUrl}
+          fallbackRedirectUrl={redirectUrl}
+        />
+      </AuthModalShell>
+    </AuthenticatedAuthEntryGuard>
   );
 }

--- a/apps/web/app/@auth/(.)signin/page.tsx
+++ b/apps/web/app/@auth/(.)signin/page.tsx
@@ -1,9 +1,27 @@
+import { redirect } from 'next/navigation';
 import { connection } from 'next/server';
 import { Suspense } from 'react';
+import { getAuthenticatedAuthRouteRedirect } from '@/lib/auth/access-route-redirect';
+import { CanonicalUserState, resolveUserState } from '@/lib/auth/gate';
 import { SigninModalClient } from './SigninModalClient';
 
-export default async function SigninModalPage() {
+export default async function SigninModalPage({
+  searchParams,
+}: Readonly<{
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}>) {
   await connection();
+  const params = await searchParams;
+  const redirectUrl =
+    typeof params.redirect_url === 'string' ? params.redirect_url : null;
+  const authResult = await resolveUserState({ createDbUserIfMissing: false });
+
+  if (authResult.state !== CanonicalUserState.UNAUTHENTICATED) {
+    redirect(
+      getAuthenticatedAuthRouteRedirect(authResult.state, { redirectUrl })
+    );
+  }
+
   return (
     <Suspense fallback={null}>
       <SigninModalClient />

--- a/apps/web/components/features/auth/AuthShell.tsx
+++ b/apps/web/components/features/auth/AuthShell.tsx
@@ -9,11 +9,13 @@ import {
   AuthProviderButtonSlot,
   AuthProviderButtonSlots,
 } from '@/features/auth/AuthProviderButtons';
+import { useAuthSafe } from '@/hooks/useClerkSafe';
+import { getClientAuthenticatedAuthEntryRedirect } from '@/lib/auth/access-route-redirect';
 import {
   buildAuthRouteUrl,
   getDefaultSignUpFallbackRedirectUrl,
 } from '@/lib/auth/build-auth-route-url';
-import { parseClerkError } from '@/lib/auth/clerk-errors';
+import { isSessionExists, parseClerkError } from '@/lib/auth/clerk-errors';
 import { CLERK_COMPONENT_OPTIONS } from '@/lib/auth/clerk-options';
 import {
   getEnabledAuthOAuthProviders,
@@ -113,6 +115,7 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
     compact = false,
   } = props;
   const searchParams = useSearchParams();
+  const { isLoaded: isAuthLoaded, isSignedIn } = useAuthSafe();
   const clerk = useClerk();
   const signInState = useSignIn();
   const signUpState = useSignUp();
@@ -142,7 +145,15 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
   );
   const activeAuthResource = isSignUp ? signUpState.signUp : signInState.signIn;
   const isAuthStartReady =
-    isMounted && clerk.loaded && Boolean(activeAuthResource);
+    isMounted &&
+    clerk.loaded &&
+    Boolean(activeAuthResource) &&
+    !(isAuthLoaded && isSignedIn);
+
+  const redirectSignedInVisitor = useCallback(() => {
+    const destination = getClientAuthenticatedAuthEntryRedirect(searchParams);
+    globalThis.location?.assign(destination);
+  }, [searchParams]);
 
   const handleProviderSelect = useCallback(
     async (provider: PrimaryAuthOAuthProvider) => {
@@ -168,9 +179,19 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
           : await signInState.signIn?.sso(redirectParams);
 
         if (!result || result.error) {
+          if (isSessionExists(result?.error)) {
+            redirectSignedInVisitor();
+            return;
+          }
+
           throw result?.error ?? new Error('Missing Clerk auth resource');
         }
       } catch (error) {
+        if (isSessionExists(error)) {
+          redirectSignedInVisitor();
+          return;
+        }
+
         setOauthError(
           error && typeof error === 'object' && 'errors' in error
             ? parseClerkError(error)
@@ -185,10 +206,15 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
       mode,
       pendingProvider,
       resolvedRedirect,
+      redirectSignedInVisitor,
       signInState.signIn,
       signUpState.signUp,
     ]
   );
+
+  if (isAuthLoaded && isSignedIn) {
+    return null;
+  }
 
   const hasNoEnabledProviders = enabledOAuthProviders.length === 0;
   const showStablePlaceholder = !isAuthStartReady;

--- a/apps/web/components/features/auth/AuthenticatedAuthEntryGuard.tsx
+++ b/apps/web/components/features/auth/AuthenticatedAuthEntryGuard.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { type ReactNode, useEffect, useState } from 'react';
+import { useAuthSafe } from '@/hooks/useClerkSafe';
+import { getClientAuthenticatedAuthEntryRedirect } from '@/lib/auth/access-route-redirect';
+import { hasClientAuthSession } from '@/lib/auth/auth-session-cookies';
+
+interface AuthenticatedAuthEntryGuardProps {
+  readonly children: ReactNode;
+}
+
+/**
+ * Redirects signed-in visitors away from auth entry surfaces before Clerk
+ * sign-in/sign-up flows can mount and fail with duplicate error banners.
+ *
+ * Uses the Clerk activity cookie for an immediate pre-hydration redirect, then
+ * confirms with `useAuthSafe()` once Clerk loads.
+ */
+export function AuthenticatedAuthEntryGuard({
+  children,
+}: AuthenticatedAuthEntryGuardProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isLoaded, isSignedIn } = useAuthSafe();
+  const [isRedirecting, setIsRedirecting] = useState(
+    () =>
+      typeof document !== 'undefined' && hasClientAuthSession(document.cookie)
+  );
+
+  useEffect(() => {
+    const cookieSignedIn =
+      typeof document !== 'undefined' && hasClientAuthSession(document.cookie);
+    const clerkSignedIn = isLoaded && isSignedIn;
+
+    if (!cookieSignedIn && !clerkSignedIn) {
+      setIsRedirecting(false);
+      return;
+    }
+
+    if (cookieSignedIn && !isLoaded) {
+      setIsRedirecting(true);
+      return;
+    }
+
+    setIsRedirecting(true);
+    router.replace(getClientAuthenticatedAuthEntryRedirect(searchParams));
+  }, [isLoaded, isSignedIn, router, searchParams]);
+
+  if (isRedirecting) {
+    return null;
+  }
+
+  return children;
+}

--- a/apps/web/components/features/auth/AuthenticatedAuthEntryGuard.tsx
+++ b/apps/web/components/features/auth/AuthenticatedAuthEntryGuard.tsx
@@ -43,8 +43,13 @@ export function AuthenticatedAuthEntryGuard({
       return;
     }
 
-    setIsRedirecting(true);
-    router.replace(getClientAuthenticatedAuthEntryRedirect(searchParams));
+    if (clerkSignedIn) {
+      setIsRedirecting(true);
+      router.replace(getClientAuthenticatedAuthEntryRedirect(searchParams));
+      return;
+    }
+
+    setIsRedirecting(false);
   }, [isLoaded, isSignedIn, router, searchParams]);
 
   if (isRedirecting) {

--- a/apps/web/components/features/auth/EmailCodeAuthForm.tsx
+++ b/apps/web/components/features/auth/EmailCodeAuthForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useSignIn, useSignUp } from '@clerk/nextjs';
+import { useSearchParams } from 'next/navigation';
 import type { FormEvent } from 'react';
 import { useCallback, useState } from 'react';
 import {
@@ -9,7 +10,13 @@ import {
   FormError,
   OtpInput,
 } from '@/features/auth/atoms';
-import { isBotProtectionError, parseClerkError } from '@/lib/auth/clerk-errors';
+import { useAuthSafe } from '@/hooks/useClerkSafe';
+import { getClientAuthenticatedAuthEntryRedirect } from '@/lib/auth/access-route-redirect';
+import {
+  isBotProtectionError,
+  isSessionExists,
+  parseClerkError,
+} from '@/lib/auth/clerk-errors';
 import type { AuthShellMode } from './AuthShell';
 
 /**
@@ -105,6 +112,8 @@ export function EmailCodeAuthForm({
   redirectUrl,
   initialEmailAddress,
 }: EmailCodeAuthFormProps) {
+  const searchParams = useSearchParams();
+  const { isLoaded: isAuthLoaded, isSignedIn } = useAuthSafe();
   const signInState = useSignIn();
   const signUpState = useSignUp();
   const [step, setStep] = useState<EmailCodeStep>('email');
@@ -116,11 +125,25 @@ export function EmailCodeAuthForm({
   const isSignUp = mode === 'sign-up';
   const signIn = signInState.signIn;
   const signUp = signUpState.signUp;
-  const isReady = isSignUp ? Boolean(signUp) : Boolean(signIn);
+  const isReady =
+    (isSignUp ? Boolean(signUp) : Boolean(signIn)) &&
+    !(isAuthLoaded && isSignedIn);
+
+  const redirectSignedInVisitor = useCallback(() => {
+    const destination = getClientAuthenticatedAuthEntryRedirect(searchParams);
+    globalThis.location?.assign(destination);
+  }, [searchParams]);
 
   const sendCode = useCallback(async () => {
     const trimmedEmail = emailAddress.trim();
-    if (!trimmedEmail || isPending || !isReady) return;
+    if (
+      !trimmedEmail ||
+      isPending ||
+      !isReady ||
+      (isAuthLoaded && isSignedIn)
+    ) {
+      return;
+    }
 
     setIsPending(true);
     setErrorMessage(null);
@@ -146,11 +169,27 @@ export function EmailCodeAuthForm({
       setCode('');
       setStep('code');
     } catch (error) {
+      if (isSessionExists(error)) {
+        redirectSignedInVisitor();
+        return;
+      }
+
       setErrorMessage(getSendErrorMessage(mode, error));
     } finally {
       setIsPending(false);
     }
-  }, [emailAddress, isPending, isReady, isSignUp, mode, signIn, signUp]);
+  }, [
+    emailAddress,
+    isAuthLoaded,
+    isPending,
+    isReady,
+    isSignedIn,
+    isSignUp,
+    mode,
+    redirectSignedInVisitor,
+    signIn,
+    signUp,
+  ]);
 
   const verifyCode = useCallback(
     async (submittedCode: string) => {
@@ -208,6 +247,10 @@ export function EmailCodeAuthForm({
     setCode('');
     setErrorMessage(null);
   }, []);
+
+  if (isAuthLoaded && isSignedIn) {
+    return null;
+  }
 
   if (step === 'code') {
     return (

--- a/apps/web/components/features/home/AuthRedirectHandler.tsx
+++ b/apps/web/components/features/home/AuthRedirectHandler.tsx
@@ -3,22 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
-
-const CLERK_ACTIVITY_COOKIE = '__client_uat';
-
-const hasActiveClerkSession = (cookieValue: string) => {
-  const cookies = cookieValue.split(';');
-  const clientUat = cookies.find(cookie =>
-    cookie.trim().startsWith(`${CLERK_ACTIVITY_COOKIE}=`)
-  );
-
-  if (!clientUat) {
-    return false;
-  }
-
-  const value = clientUat.split('=')[1]?.trim();
-  return Boolean(value && value !== '0');
-};
+import { hasActiveClerkSession } from '@/lib/auth/auth-session-cookies';
 
 /**
  * Non-blocking redirect handler for authenticated users on the homepage.
@@ -66,4 +51,4 @@ export function AuthRedirectHandler() {
   );
 }
 
-export { hasActiveClerkSession };
+export { hasActiveClerkSession } from '@/lib/auth/auth-session-cookies';

--- a/apps/web/lib/auth/access-route-redirect.ts
+++ b/apps/web/lib/auth/access-route-redirect.ts
@@ -70,6 +70,34 @@ export function getAuthenticatedAuthRouteRedirect(
   return APP_ROUTES.DASHBOARD;
 }
 
+type AuthEntrySearchParams = {
+  get(name: string): string | null;
+};
+
+/**
+ * Client-side redirect for signed-in visitors on auth entry routes when the
+ * server render could not resolve canonical state (stale RSC payload, modal
+ * interception, or cookie/session timing). Mirrors the ACTIVE-user branch of
+ * `getAuthenticatedAuthRouteRedirect` without a canonical state lookup.
+ */
+export function getClientAuthenticatedAuthEntryRedirect(
+  searchParams: AuthEntrySearchParams
+): string {
+  const sanitizedRedirect = sanitizeRedirectUrl(
+    searchParams.get('redirect_url')
+  );
+
+  if (sanitizedRedirect && isWaitlistInviteRedirect(sanitizedRedirect)) {
+    return sanitizedRedirect;
+  }
+
+  if (sanitizedRedirect && !isAuthEntryRedirect(sanitizedRedirect)) {
+    return sanitizedRedirect;
+  }
+
+  return APP_ROUTES.DASHBOARD;
+}
+
 /**
  * Redirect destination for /start based on canonical access state.
  * Anonymous visitors and onboarding-eligible users may remain on /start.

--- a/apps/web/lib/auth/auth-session-cookies.ts
+++ b/apps/web/lib/auth/auth-session-cookies.ts
@@ -1,0 +1,32 @@
+import { TEST_USER_ID_COOKIE } from '@/lib/auth/test-mode-constants';
+
+const CLERK_ACTIVITY_COOKIE = '__client_uat';
+
+export function hasActiveClerkSession(cookieValue: string): boolean {
+  const cookies = cookieValue.split(';');
+  const clientUat = cookies.find(cookie =>
+    cookie.trim().startsWith(`${CLERK_ACTIVITY_COOKIE}=`)
+  );
+
+  if (!clientUat) {
+    return false;
+  }
+
+  const value = clientUat.split('=')[1]?.trim();
+  return Boolean(value && value !== '0');
+}
+
+export function hasTestAuthSession(cookieValue: string): boolean {
+  const cookies = cookieValue.split(';');
+  return cookies.some(cookie =>
+    cookie.trim().startsWith(`${TEST_USER_ID_COOKIE}=`)
+  );
+}
+
+/**
+ * Best-effort client-side session probe used before Clerk hydrates.
+ * Covers Clerk's activity cookie and the dev/E2E test-auth bypass cookie.
+ */
+export function hasClientAuthSession(cookieValue: string): boolean {
+  return hasActiveClerkSession(cookieValue) || hasTestAuthSession(cookieValue);
+}

--- a/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
+++ b/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
@@ -118,7 +118,7 @@ test.describe('Signed-in auth verification @smoke', () => {
 
       if (TEST_AUTH_BYPASS_ENABLED) {
         await smokeNavigateWithRetry(page, APP_ROUTES.SIGNIN);
-        await expect(page).toHaveURL(/\/signin/, {
+        await expect(page).toHaveURL(/\/app/, {
           timeout: SMOKE_TIMEOUTS.NAVIGATION,
         });
       } else {

--- a/apps/web/tests/unit/app/signin-page-server.test.tsx
+++ b/apps/web/tests/unit/app/signin-page-server.test.tsx
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { resolveUserStateMock, redirectMock } = vi.hoisted(() => ({
+  resolveUserStateMock: vi.fn(),
+  redirectMock: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+vi.mock('@/lib/auth/gate', () => ({
+  CanonicalUserState: {
+    UNAUTHENTICATED: 'UNAUTHENTICATED',
+    ACTIVE: 'ACTIVE',
+  },
+  resolveUserState: resolveUserStateMock,
+}));
+
+vi.mock('@/app/(auth)/signin/SignInPageClient', () => ({
+  SignInPageClient: () => null,
+}));
+
+describe('/signin page server redirect', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resolveUserStateMock.mockReset();
+    redirectMock.mockClear();
+  });
+
+  it('redirects authenticated visitors away from the sign-in surface', async () => {
+    resolveUserStateMock.mockResolvedValueOnce({
+      state: 'ACTIVE',
+    });
+
+    const { default: SignInPage } = await import('@/app/(auth)/signin/page');
+
+    await expect(
+      SignInPage({ searchParams: Promise.resolve({}) })
+    ).rejects.toThrow('NEXT_REDIRECT:/app');
+    expect(resolveUserStateMock).toHaveBeenCalledWith({
+      createDbUserIfMissing: false,
+    });
+  });
+
+  it('renders the client shell for signed-out visitors', async () => {
+    resolveUserStateMock.mockResolvedValueOnce({
+      state: 'UNAUTHENTICATED',
+    });
+
+    const { default: SignInPage } = await import('@/app/(auth)/signin/page');
+
+    const result = await SignInPage({ searchParams: Promise.resolve({}) });
+    expect(result).toBeTruthy();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/app/signin-page.test.tsx
+++ b/apps/web/tests/unit/app/signin-page.test.tsx
@@ -10,8 +10,20 @@ const { authShellMock, authLayoutMock, routerPrefetchMock, searchParamsState } =
     searchParamsState: { value: '' },
   }));
 
+const replaceMock = vi.fn();
+
 vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(searchParamsState.value),
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+}));
+
+vi.mock('@/hooks/useClerkSafe', () => ({
+  useAuthSafe: () => ({
+    isLoaded: true,
+    isSignedIn: false,
+  }),
 }));
 
 vi.mock('@/lib/auth/gate', () => ({
@@ -53,7 +65,10 @@ describe('signin page', () => {
     authShellMock.mockReset();
     authLayoutMock.mockReset();
     routerPrefetchMock.mockReset();
+    replaceMock.mockReset();
     searchParamsState.value = '';
+    document.cookie =
+      '__client_uat=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
   });
 
   it('renders AuthShell with the expected auth props', () => {

--- a/apps/web/tests/unit/auth/AuthenticatedAuthEntryGuard.test.tsx
+++ b/apps/web/tests/unit/auth/AuthenticatedAuthEntryGuard.test.tsx
@@ -1,0 +1,98 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { replaceMock, searchParamsState, authState } = vi.hoisted(() => ({
+  replaceMock: vi.fn(),
+  searchParamsState: { value: '' },
+  authState: {
+    isLoaded: true,
+    isSignedIn: false,
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+  useSearchParams: () => new URLSearchParams(searchParamsState.value),
+}));
+
+vi.mock('@/hooks/useClerkSafe', () => ({
+  useAuthSafe: () => authState,
+}));
+
+import { AuthenticatedAuthEntryGuard } from '@/components/features/auth/AuthenticatedAuthEntryGuard';
+import { APP_ROUTES } from '@/constants/routes';
+
+describe('AuthenticatedAuthEntryGuard', () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+    searchParamsState.value = '';
+    authState.isLoaded = true;
+    authState.isSignedIn = false;
+    document.cookie =
+      '__client_uat=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    document.cookie =
+      '__e2e_test_user_id=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+  });
+
+  it('renders children for signed-out visitors', async () => {
+    const { getByText } = render(
+      <AuthenticatedAuthEntryGuard>
+        <div>Sign-in form</div>
+      </AuthenticatedAuthEntryGuard>
+    );
+
+    expect(getByText('Sign-in form')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('redirects authenticated Clerk users before rendering auth flows', async () => {
+    authState.isSignedIn = true;
+
+    const { queryByText } = render(
+      <AuthenticatedAuthEntryGuard>
+        <div>Sign-in form</div>
+      </AuthenticatedAuthEntryGuard>
+    );
+
+    expect(queryByText('Sign-in form')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith(APP_ROUTES.DASHBOARD);
+    });
+  });
+
+  it('preserves a safe redirect_url for authenticated users', async () => {
+    authState.isSignedIn = true;
+    searchParamsState.value = 'redirect_url=%2Fapp%2Fsettings';
+
+    render(
+      <AuthenticatedAuthEntryGuard>
+        <div>Sign-in form</div>
+      </AuthenticatedAuthEntryGuard>
+    );
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith('/app/settings');
+    });
+  });
+
+  it('redirects when only the Clerk activity cookie is present', async () => {
+    document.cookie = '__client_uat=1700000000';
+
+    const { queryByText } = render(
+      <AuthenticatedAuthEntryGuard>
+        <div>Sign-in form</div>
+      </AuthenticatedAuthEntryGuard>
+    );
+
+    expect(queryByText('Sign-in form')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith(APP_ROUTES.DASHBOARD);
+    });
+  });
+});

--- a/apps/web/tests/unit/auth/AuthenticatedAuthEntryGuard.test.tsx
+++ b/apps/web/tests/unit/auth/AuthenticatedAuthEntryGuard.test.tsx
@@ -80,8 +80,10 @@ describe('AuthenticatedAuthEntryGuard', () => {
     });
   });
 
-  it('redirects when only the Clerk activity cookie is present', async () => {
+  it('waits for Clerk when only the activity cookie is present', async () => {
     document.cookie = '__client_uat=1700000000';
+    authState.isLoaded = false;
+    authState.isSignedIn = false;
 
     const { queryByText } = render(
       <AuthenticatedAuthEntryGuard>
@@ -92,7 +94,24 @@ describe('AuthenticatedAuthEntryGuard', () => {
     expect(queryByText('Sign-in form')).not.toBeInTheDocument();
 
     await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith(APP_ROUTES.DASHBOARD);
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('renders the sign-in form when a stale cookie outlives the session', async () => {
+    document.cookie = '__client_uat=1700000000';
+    authState.isLoaded = true;
+    authState.isSignedIn = false;
+
+    const { getByText } = render(
+      <AuthenticatedAuthEntryGuard>
+        <div>Sign-in form</div>
+      </AuthenticatedAuthEntryGuard>
+    );
+
+    await waitFor(() => {
+      expect(getByText('Sign-in form')).toBeInTheDocument();
+      expect(replaceMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/tests/unit/lib/auth/access-route-matrix.test.ts
+++ b/apps/web/tests/unit/lib/auth/access-route-matrix.test.ts
@@ -3,6 +3,7 @@ import { APP_ROUTES } from '@/constants/routes';
 import {
   canAccessAppShell,
   getAuthenticatedAuthRouteRedirect,
+  getClientAuthenticatedAuthEntryRedirect,
   getStartRouteRedirect,
 } from '@/lib/auth/access-route-redirect';
 import { CanonicalUserState } from '@/lib/auth/canonical-user-state';
@@ -58,6 +59,30 @@ describe('access route matrix (JOV-3087)', () => {
           redirectUrl: '/waitlist/invite?token=secure-token',
         })
       ).toBe(APP_ROUTES.UNAVAILABLE);
+    });
+
+    it('maps client auth-entry redirects to dashboard by default', () => {
+      expect(
+        getClientAuthenticatedAuthEntryRedirect(new URLSearchParams())
+      ).toBe(APP_ROUTES.DASHBOARD);
+    });
+
+    it('preserves safe redirect_url values for client auth-entry redirects', () => {
+      expect(
+        getClientAuthenticatedAuthEntryRedirect(
+          new URLSearchParams('redirect_url=%2Fapp%2Fsettings')
+        )
+      ).toBe('/app/settings');
+    });
+
+    it('does not loop client auth-entry redirects back to /signin', () => {
+      expect(
+        getClientAuthenticatedAuthEntryRedirect(
+          new URLSearchParams(
+            `redirect_url=${encodeURIComponent(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.SIGNIN}`)}`
+          )
+        )
+      ).toBe(APP_ROUTES.DASHBOARD);
     });
   });
 });


### PR DESCRIPTION
## Goal
Fix JOV-3332: authenticated users visiting `/signin` should be redirected immediately instead of seeing the sign-in form plus duplicate Clerk error banners ("Could not send the code" + "Could not start sign-in") on load.

## Root cause
The full-page `/signin` route had a server redirect, but the intercepted modal route and client hydration could still mount `AuthShell` when a Clerk/dev session was already active. Starting sign-in flows against an existing session fails with `session_exists`, surfacing both OAuth and email-code error banners without user interaction.

## Changes
- Add `AuthenticatedAuthEntryGuard` to redirect signed-in visitors before auth flows mount (cookie + Clerk hook detection)
- Add server-side redirect to intercepted `@auth/(.)signin` route
- Mark `/signin` page `force-dynamic` for reliable auth resolution
- Prevent `AuthShell` / `EmailCodeAuthForm` from mounting or calling Clerk when already signed in
- Handle `session_exists` by redirecting instead of showing inline errors
- Add unit tests for server redirect, client guard, and redirect matrix

## Testing
- `pnpm exec vitest run tests/unit/auth/AuthenticatedAuthEntryGuard.test.tsx tests/unit/app/signin-page-server.test.tsx tests/unit/lib/auth/access-route-matrix.test.ts tests/unit/app/signin-page.test.tsx tests/unit/auth/AuthShell.test.tsx`
- Updated `signed-in-auth-verify.spec.ts` to expect redirect away from `/signin` for authenticated test-auth sessions

JOV-3332

Co-authored-by: Cursor <cursoragent@cursor.com>