### PR TITLE
feat(web): ui-feel quick wins in global css (JOV-3368)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -519,6 +519,10 @@ body {
     --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
     --safe-area-inset-left: env(safe-area-inset-left, 0px);
   }
+  html {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
   /* Linear Typography Features - apply font features globally */
   body {
     font-feature-settings:
@@ -530,6 +534,7 @@ body {
        Nav items, buttons, and labels should have normal tracking.
        Body text classes (.text-linear, .marketing-lead-linear) apply their own. */
     text-rendering: optimizelegibility;
+    text-wrap: pretty;
   }
 }
 
@@ -717,10 +722,15 @@ body {
   .focus-ring-transparent-offset {
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-transparent;
   }
+  /* Tactile press — transform only; never transition:all (DESIGN.md / JOV-3368) */
+  .interactive-press {
+    @apply transition-transform duration-subtle ease-subtle active:scale-[0.96];
+  }
   /* Button component styles */
   .btn {
-    @apply inline-flex items-center justify-center rounded-full text-[13px] font-medium transition-colors duration-normal disabled:opacity-50 disabled:pointer-events-none;
+    @apply inline-flex items-center justify-center rounded-full text-[13px] font-medium transition-[background-color,transform] duration-normal ease-interactive disabled:opacity-50 disabled:pointer-events-none;
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-(--linear-bg-page);
+    @apply active:scale-[0.96];
   }
   .btn-primary {
     background-color: var(--color-btn-primary-bg);
@@ -2015,6 +2025,17 @@ body {
   h5,
   h6 {
     @apply font-semibold tracking-tight;
+    text-wrap: balance;
+  }
+  /* Dynamic numerals — tabular figures for counters, timestamps, badges */
+  :where(.tabular-nums, time, [data-tabular-nums], kbd) {
+    font-variant-numeric: tabular-nums;
+  }
+  /* Subtle 1px image edge — prevents floating assets on dark surfaces */
+  :where(img:not([role="presentation"]):not([aria-hidden="true"])) {
+    outline: 1px solid
+      color-mix(in oklab, var(--color-border-subtle) 55%, transparent);
+    outline-offset: -1px;
   }
   h1 {
     @apply text-4xl lg:text-5xl;
@@ -2033,6 +2054,23 @@ body {
   }
   h6 {
     @apply text-base lg:text-lg;
+  }
+  /* Interactive controls — tactile press via transform only (no transition:all) */
+  :where(
+      button:not(:disabled):not([data-static="true"]),
+      [role="button"]:not([aria-disabled="true"]):not([data-static="true"]),
+      summary
+    ) {
+    transition: transform var(--duration-subtle) var(--ease-subtle);
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    :where(
+        button:not(:disabled):not([data-static="true"]),
+        [role="button"]:not([aria-disabled="true"]):not([data-static="true"]),
+        summary
+      ):active {
+      transform: scale(0.96);
+    }
   }
 }
 
@@ -2155,7 +2193,7 @@ body {
     );
   }
   .btn-press {
-    @apply transition-opacity duration-subtle ease-subtle active:opacity-80;
+    @apply interactive-press;
   }
   /* Chat empty state — refined depth & motion */
   .chat-logo-mark {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -728,7 +728,7 @@ body {
   }
   /* Button component styles */
   .btn {
-    @apply inline-flex items-center justify-center rounded-full text-[13px] font-medium transition-[background-color,transform] duration-normal ease-interactive disabled:opacity-50 disabled:pointer-events-none;
+    @apply inline-flex items-center justify-center rounded-full text-[13px] font-medium transition-[background-color,transform] duration-normal ease-subtle disabled:opacity-50 disabled:pointer-events-none;
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-(--linear-bg-page);
     @apply active:scale-[0.96];
   }
@@ -2193,7 +2193,7 @@ body {
     );
   }
   .btn-press {
-    @apply interactive-press;
+    @apply transition-transform duration-subtle ease-subtle active:scale-[0.96];
   }
   /* Chat empty state — refined depth & motion */
   .chat-logo-mark {

--- a/apps/web/tests/unit/app/globals-ui-feel-style-guard.test.ts
+++ b/apps/web/tests/unit/app/globals-ui-feel-style-guard.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const globalsPath = 'app/globals.css';
+
+function readGlobals() {
+  return readFileSync(resolve(process.cwd(), globalsPath), 'utf8');
+}
+
+describe('globals.css ui-feel quick wins (JOV-3368)', () => {
+  const source = readGlobals();
+
+  it('applies root font antialiasing', () => {
+    expect(source).toContain('-webkit-font-smoothing: antialiased');
+    expect(source).toContain('-moz-osx-font-smoothing: grayscale');
+  });
+
+  it('applies text-wrap balance on headings and pretty on body', () => {
+    expect(source).toMatch(/h1,\s*\n\s*h2[\s\S]*text-wrap:\s*balance/);
+    expect(source).toMatch(/body\s*\{[\s\S]*text-wrap:\s*pretty/);
+  });
+
+  it('applies tabular-nums on dynamic numerals', () => {
+    expect(source).toMatch(
+      /:where\(\.tabular-nums,\s*time,\s*\[data-tabular-nums\],\s*kbd\)[\s\S]*font-variant-numeric:\s*tabular-nums/
+    );
+  });
+
+  it('applies subtle 1px image outlines', () => {
+    expect(source).toMatch(
+      /:where\(img:not\(\[role="presentation"\]\)[\s\S]*outline:\s*1px solid/
+    );
+  });
+
+  it('uses named transition-transform and active scale on interactive controls', () => {
+    expect(source).toContain('.interactive-press');
+    expect(source).toMatch(
+      /\.interactive-press\s*\{[\s\S]*transition-transform[\s\S]*active:scale-\[0\.96\]/
+    );
+    expect(source).toMatch(
+      /button:not\(:disabled\)[\s\S]*transition:\s*transform var\(--duration-subtle\)/
+    );
+    expect(source).toMatch(/transform:\s*scale\(0\.96\)/);
+    expect(source).not.toMatch(
+      /\.interactive-press\s*\{[^}]*transition:\s*all/
+    );
+  });
+
+  it('migrates btn-press from opacity to interactive-press', () => {
+    expect(source).toMatch(/\.btn-press\s*\{[^}]*interactive-press/);
+    expect(source).not.toMatch(/\.btn-press\s*\{[^}]*active:opacity-80/);
+  });
+});

--- a/apps/web/tests/unit/app/globals-ui-feel-style-guard.test.ts
+++ b/apps/web/tests/unit/app/globals-ui-feel-style-guard.test.ts
@@ -47,8 +47,10 @@ describe('globals.css ui-feel quick wins (JOV-3368)', () => {
     );
   });
 
-  it('migrates btn-press from opacity to interactive-press', () => {
-    expect(source).toMatch(/\.btn-press\s*\{[^}]*interactive-press/);
+  it('migrates btn-press from opacity to scale press feedback', () => {
+    expect(source).toMatch(
+      /\.btn-press\s*\{[\s\S]*transition-transform[\s\S]*active:scale-\[0\.96\]/
+    );
     expect(source).not.toMatch(/\.btn-press\s*\{[^}]*active:opacity-80/);
   });
 });


### PR DESCRIPTION
## Goal

Ship mechanical UI-feel polish globally via `globals.css` — tabular numerals, text-wrap, antialiased rendering, subtle image outlines, and tactile press feedback.

Linear: https://linear.app/jovie/issue/JOV-3368

## Changes

- **Root antialiasing**: `-webkit-font-smoothing: antialiased` + `-moz-osx-font-smoothing: grayscale` on `html`
- **Text-wrap**: `balance` on `h1–h6`, `pretty` on `body`
- **Tabular numerals**: `font-variant-numeric: tabular-nums` on `.tabular-nums`, `time`, `[data-tabular-nums]`, `kbd`
- **Image outlines**: subtle 1px inset outline on content images
- **Press feedback**: `.interactive-press` utility + base-layer `transition-transform` / `scale(0.96)` on interactive controls; `.btn-press` migrated from opacity to scale; `.btn` uses named transform transition (no `transition:all`)
- **Style guard**: `globals-ui-feel-style-guard.test.ts` locks the contracts

## Testing

- `pnpm exec vitest run tests/unit/app/globals-ui-feel-style-guard.test.ts`
- Pre-push: typecheck, lint, tailwind-guard all pass

---
Generated with Jovie Agent