### PR TITLE
fix(chat): fail soft on tool errors with recoverable states (JOV-3338)

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -933,6 +933,7 @@ function createGenerateAlbumArtTool(params: {
         return {
           success: false as const,
           retryable: false,
+          errorCode: 'PROFILE_REQUIRED' as const,
           error: 'Profile ID required',
         };
       }
@@ -940,6 +941,7 @@ function createGenerateAlbumArtTool(params: {
         return {
           success: false as const,
           retryable: false,
+          errorCode: 'PLAN_UNAVAILABLE' as const,
           error: 'Album art generation requires a Pro plan.',
         };
       }
@@ -948,6 +950,7 @@ function createGenerateAlbumArtTool(params: {
         return {
           success: false as const,
           retryable: false,
+          errorCode: 'PROVIDER_UNAVAILABLE' as const,
           error: 'Album art generation is temporarily unavailable.',
         };
       }
@@ -985,6 +988,7 @@ function createGenerateAlbumArtTool(params: {
         return {
           success: false as const,
           retryable: true,
+          errorCode: 'RATE_LIMITED' as const,
           error:
             burstLimit.reason ??
             'Album art generation limit reached. Please try again later.',
@@ -998,6 +1002,7 @@ function createGenerateAlbumArtTool(params: {
         return {
           success: false as const,
           retryable: true,
+          errorCode: 'RATE_LIMITED' as const,
           error:
             dailyLimit.reason ??
             'Album art generation limit reached. Please try again later.',
@@ -1097,6 +1102,7 @@ function createGenerateAlbumArtTool(params: {
           return {
             success: false as const,
             retryable: false,
+            errorCode: 'PROVIDER_UNAVAILABLE' as const,
             error: 'Album art generation is temporarily unavailable.',
           };
         }
@@ -1107,6 +1113,7 @@ function createGenerateAlbumArtTool(params: {
         return {
           success: false as const,
           retryable: true,
+          errorCode: 'TOOL_EXECUTION_FAILED' as const,
           error: 'Unable to generate album art. Please try again.',
         };
       }

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -97,6 +97,7 @@ import {
   type ChatTelemetry,
   type ReleaseContext,
 } from '@/lib/chat/types';
+import { wrapToolSetFailSoft } from '@/lib/chat/wrap-tool-execute';
 import { db } from '@/lib/db';
 import { clickEvents, tips } from '@/lib/db/schema/analytics';
 import { users } from '@/lib/db/schema/auth';
@@ -2722,7 +2723,7 @@ export async function POST(req: Request) {
       insightsEnabled,
       forceLightModel,
       lastUserText: userText,
-      tools,
+      tools: wrapToolSetFailSoft(tools),
       signal: req.signal,
       requestId,
       telemetry,

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -510,14 +510,15 @@ export function JovieChat({
     />
   );
 
-  const inlineChatError = chatError ? (
-    <ChatInlineError
-      chatError={chatError}
-      onRetry={handleRetry}
-      isLoading={isLoading}
-      isSubmitting={isSubmitting}
-    />
-  ) : null;
+  const inlineChatError =
+    chatError && !chatError.suppressComposerPause ? (
+      <ChatInlineError
+        chatError={chatError}
+        onRetry={handleRetry}
+        isLoading={isLoading}
+        isSubmitting={isSubmitting}
+      />
+    ) : null;
 
   return (
     <EntityResolutionProvider profileId={profileId}>

--- a/apps/web/components/jovie/components/ErrorDisplay.test.tsx
+++ b/apps/web/components/jovie/components/ErrorDisplay.test.tsx
@@ -28,7 +28,7 @@ describe('ErrorDisplay', () => {
     expect(screen.getByText('Message paused')).toBeInTheDocument();
     expect(screen.getByText('CHAT_TIMEOUT · req_123')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Retry message' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Retry Message' }));
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/components/jovie/components/ErrorDisplay.tsx
+++ b/apps/web/components/jovie/components/ErrorDisplay.tsx
@@ -49,6 +49,12 @@ export function ErrorDisplay({
     }
   };
 
+  const isToolScopedFailure =
+    chatError.type === 'tool' || chatError.suppressComposerPause === true;
+  const headline = isToolScopedFailure
+    ? 'Action could not finish'
+    : 'Message paused';
+
   return (
     <div
       role='alert'
@@ -63,13 +69,13 @@ export function ErrorDisplay({
         <div className='min-w-0 flex-1'>
           <div>
             <p className='text-app font-medium leading-5 text-primary-token'>
-              Message paused
+              {headline}
             </p>
             <p className='text-xs leading-5 text-secondary-token'>
               {chatError.message}
             </p>
             <p className='text-xs leading-5 text-tertiary-token'>
-              {getNextStepMessage(chatError.type)}
+              {getNextStepMessage(chatError.type, chatError.errorCode)}
             </p>
           </div>
 
@@ -87,7 +93,7 @@ export function ErrorDisplay({
                 size='sm'
                 onClick={handleCopySupportCode}
                 className='h-7 gap-1 rounded-lg px-2 text-2xs font-medium tracking-[-0.01em]'
-                aria-label='Copy support reference'
+                aria-label='Copy Support Reference'
               >
                 <Copy className='size-3' />
                 {copied ? 'Copied' : 'Copy'}
@@ -95,19 +101,21 @@ export function ErrorDisplay({
             </div>
           )}
 
-          {chatError.failedMessage && !chatError.retryAfter && (
-            <Button
-              type='button'
-              variant='ghost'
-              size='sm'
-              onClick={onRetry}
-              disabled={isLoading || isSubmitting}
-              className='mt-2 h-7 gap-1.5 rounded-lg px-2 text-2xs font-medium tracking-[-0.01em] text-error hover:bg-error/10 hover:text-error'
-            >
-              <RefreshCw className='size-3.5' />
-              Retry message
-            </Button>
-          )}
+          {!isToolScopedFailure &&
+            chatError.failedMessage &&
+            !chatError.retryAfter && (
+              <Button
+                type='button'
+                variant='ghost'
+                size='sm'
+                onClick={onRetry}
+                disabled={isLoading || isSubmitting}
+                className='mt-2 h-7 gap-1.5 rounded-lg px-2 text-2xs font-medium tracking-[-0.01em] text-error hover:bg-error/10 hover:text-error'
+              >
+                <RefreshCw className='size-3.5' />
+                Retry Message
+              </Button>
+            )}
         </div>
       </div>
     </div>

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { track } from '@/lib/analytics';
 import { matchCommand } from '@/lib/chat/command-registry';
 import { consumePendingChatPrompt } from '@/lib/chat/open-chat-with-prompt';
+import { isRecoverableToolErrorCode } from '@/lib/chat/tool-errors';
 import { PACER_TIMING } from '@/lib/pacer/hooks/timing';
 import { queryKeys, useChatConversationQuery } from '@/lib/queries';
 import { captureException } from '@/lib/sentry/client-lite';
@@ -35,6 +36,7 @@ import {
   getErrorType,
   getPartsChangeFingerprint,
   getPreferredErrorMessage,
+  shouldSuppressChatPauseForToolFailure,
 } from '../utils';
 import { composeMessage, useChipTray } from './useChipTray';
 
@@ -226,6 +228,7 @@ export function useJovieChat({
   const activeClientTurnIdRef = useRef<string | null>(null);
   const streamRevisionRef = useRef(0);
   const lastAssistantPartsSignatureRef = useRef<string | null>(null);
+  const sdkMessagesRef = useRef<UIMessage[]>([]);
   const loadedConversationIdsRef = useRef<Set<string>>(new Set());
   const [input, setInput] = useState('');
   const chipTray = useChipTray();
@@ -425,13 +428,20 @@ export function useJovieChat({
       const chatErrorType = getErrorType(error);
       const metadata = extractErrorMetadata(error);
 
+      const suppressComposerPause =
+        chatErrorType === 'tool' ||
+        isRecoverableToolErrorCode(metadata.errorCode);
+
       setChatError({
         type: chatErrorType,
         message: getPreferredErrorMessage(error, chatErrorType, metadata),
         retryAfter: metadata.retryAfter,
         errorCode: metadata.errorCode,
         requestId: metadata.requestId,
-        failedMessage: lastAttemptedMessageRef.current,
+        failedMessage: suppressComposerPause
+          ? undefined
+          : lastAttemptedMessageRef.current,
+        suppressComposerPause,
       });
 
       if (lastAttemptedMessageRef.current) {
@@ -499,7 +509,28 @@ export function useJovieChat({
       setIsSubmitting(false);
     },
     onError: error => {
-      handleChatFailure(error, 'stream', activeClientTurnIdRef.current);
+      const clientTurnId = activeClientTurnIdRef.current;
+      const assistantMessage = getLastAssistantMessage(sdkMessagesRef.current);
+      const assistantParts = getMessageParts(assistantMessage);
+
+      if (
+        clientTurnId &&
+        shouldSuppressChatPauseForToolFailure(error, assistantParts)
+      ) {
+        dispatchTimelineEvent({
+          type: 'assistant.stream.completed',
+          conversationId: activeConversationId,
+          clientTurnId,
+          requestId: clientTurnId,
+          parts: assistantParts,
+          now: Date.now(),
+        });
+        activeClientTurnIdRef.current = null;
+        setIsSubmitting(false);
+        return;
+      }
+
+      handleChatFailure(error, 'stream', clientTurnId);
 
       queryClient.invalidateQueries({
         queryKey: queryKeys.chat.usage(),
@@ -571,6 +602,10 @@ export function useJovieChat({
     existingConversation?.conversation?.id,
     persistedTimelineMessages,
   ]);
+
+  useEffect(() => {
+    sdkMessagesRef.current = sdkMessages;
+  }, [sdkMessages]);
 
   useEffect(() => {
     const clientTurnId = activeClientTurnIdRef.current;

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -7,6 +7,7 @@ import {
   type ProfileEditPreview,
   ProfileEditPreviewCard,
 } from '@/components/features/dashboard/organisms/ProfileEditPreviewCard';
+import { resolveToolFailurePresentation } from '@/lib/chat/tool-errors';
 import {
   encodeToolEvents,
   type PersistedToolEvent,
@@ -92,7 +93,15 @@ function getToolStatusBody(event: PersistedToolEvent): string | undefined {
   switch (event.state) {
     case 'running':
       return event.summary;
-    case 'failed':
+    case 'failed': {
+      const presentation = resolveToolFailurePresentation({
+        toolName: event.toolName,
+        errorCode: event.errorCode,
+        errorMessage: event.errorMessage ?? event.summary,
+        retryable: event.retryable,
+      });
+      return presentation.body;
+    }
     case 'denied':
       return event.errorMessage ?? event.summary;
     case 'needs-approval':
@@ -100,6 +109,19 @@ function getToolStatusBody(event: PersistedToolEvent): string | undefined {
     case 'succeeded':
       return event.summary ?? 'Completed';
   }
+}
+
+function getToolStatusNextStep(event: PersistedToolEvent): string | undefined {
+  if (event.state !== 'failed') {
+    return undefined;
+  }
+
+  return resolveToolFailurePresentation({
+    toolName: event.toolName,
+    errorCode: event.errorCode,
+    errorMessage: event.errorMessage ?? event.summary,
+    retryable: event.retryable,
+  }).nextStep;
 }
 
 const TOOL_STATUS_ICONS: Record<PersistedToolEvent['state'], typeof Loader2> = {
@@ -143,6 +165,7 @@ function ToolActivityRow({
   count: number;
 }>) {
   const body = getToolStatusBody(event);
+  const nextStep = getToolStatusNextStep(event);
   const isInline = variant === 'inline';
   const isError = event.state === 'failed' || event.state === 'denied';
   const isRunning = event.state === 'running';
@@ -206,6 +229,16 @@ function ToolActivityRow({
             )}
           >
             {body}
+          </div>
+        ) : null}
+        {nextStep ? (
+          <div
+            className={cn(
+              'mt-0.5 text-tertiary-token',
+              isInline ? 'line-clamp-2 text-3xs' : 'line-clamp-2 text-2xs'
+            )}
+          >
+            {nextStep}
           </div>
         ) : null}
         {showVerboseDetails ? (

--- a/apps/web/components/jovie/types.ts
+++ b/apps/web/components/jovie/types.ts
@@ -69,7 +69,12 @@ export interface ChatActionCard {
 
 export type ChatConversationCreatePhase = 'reserved' | 'completed';
 
-export type ChatErrorType = 'network' | 'rate_limit' | 'server' | 'unknown';
+export type ChatErrorType =
+  | 'network'
+  | 'rate_limit'
+  | 'server'
+  | 'tool'
+  | 'unknown';
 
 export interface ChatError {
   readonly type: ChatErrorType;
@@ -78,6 +83,8 @@ export interface ChatError {
   readonly errorCode?: string;
   readonly requestId?: string;
   readonly failedMessage?: string;
+  /** Tool-only failures stay inline in the thread and should not pause the composer. */
+  readonly suppressComposerPause?: boolean;
 }
 
 /** Maximum allowed message length */

--- a/apps/web/components/jovie/utils.ts
+++ b/apps/web/components/jovie/utils.ts
@@ -1,5 +1,10 @@
 import type { UIMessage } from 'ai';
 
+import {
+  isRecoverableToolErrorCode,
+  isRecoverableToolStreamError,
+  resolveToolFailurePresentation,
+} from '@/lib/chat/tool-errors';
 import type { ChatErrorType, MessagePart } from './types';
 
 /**
@@ -67,6 +72,10 @@ export function getErrorType(error: Error): ChatErrorType {
     return 'network';
   }
 
+  if (isRecoverableToolStreamError(error) || isRecoverableToolErrorCode(code)) {
+    return 'tool';
+  }
+
   if (status === 429 || code === 'RATE_LIMITED') {
     return 'rate_limit';
   }
@@ -94,7 +103,8 @@ export function getErrorType(error: Error): ChatErrorType {
  */
 export function getUserFriendlyMessage(
   type: ChatErrorType,
-  retryAfter?: number
+  retryAfter?: number,
+  errorCode?: string
 ): string {
   switch (type) {
     case 'network':
@@ -105,6 +115,14 @@ export function getUserFriendlyMessage(
         : 'Too many requests. Please wait a moment.';
     case 'server':
       return 'We encountered a temporary issue. Please try again.';
+    case 'tool':
+      return (
+        resolveToolFailurePresentation({
+          toolName: 'action',
+          errorCode,
+          errorMessage: null,
+        }).body ?? 'This action could not finish. You can keep chatting.'
+      );
     default:
       return 'Something went wrong. Please try again.';
   }
@@ -113,7 +131,10 @@ export function getUserFriendlyMessage(
 /**
  * Get next step message based on error type
  */
-export function getNextStepMessage(type: ChatErrorType): string {
+export function getNextStepMessage(
+  type: ChatErrorType,
+  errorCode?: string
+): string {
   switch (type) {
     case 'network':
       return 'Check your connection and try again';
@@ -121,9 +142,63 @@ export function getNextStepMessage(type: ChatErrorType): string {
       return 'Wait a moment, then try again';
     case 'server':
       return 'Try again or contact support if this persists';
+    case 'tool':
+      return resolveToolFailurePresentation({
+        toolName: 'action',
+        errorCode,
+        errorMessage: null,
+      }).nextStep;
     default:
       return 'Try again or contact support';
   }
+}
+
+export function messagePartsIncludeFailedTool(
+  parts: readonly MessagePart[]
+): boolean {
+  for (const part of parts) {
+    if (
+      typeof part !== 'object' ||
+      part === null ||
+      !('type' in part) ||
+      typeof part.type !== 'string'
+    ) {
+      continue;
+    }
+
+    if (
+      part.type === 'dynamic-tool' ||
+      (part.type.startsWith('tool-') && part.type !== 'tool-invocation')
+    ) {
+      const state =
+        'state' in part && typeof part.state === 'string' ? part.state : null;
+      if (state === 'output-error') {
+        return true;
+      }
+
+      if (state === 'output-available' && 'output' in part) {
+        const output = part.output;
+        if (
+          typeof output === 'object' &&
+          output !== null &&
+          (output as { success?: unknown }).success === false
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+export function shouldSuppressChatPauseForToolFailure(
+  error: Error,
+  parts: readonly MessagePart[]
+): boolean {
+  return (
+    messagePartsIncludeFailedTool(parts) || isRecoverableToolStreamError(error)
+  );
 }
 
 interface ErrorMetadata {
@@ -229,11 +304,19 @@ export function getPreferredErrorMessage(
 
   const rawMessage = error.message?.trim();
   if (!rawMessage) {
-    return getUserFriendlyMessage(type, metadata.retryAfter);
+    return getUserFriendlyMessage(
+      type,
+      metadata.retryAfter,
+      metadata.errorCode
+    );
   }
 
   if (isJsonLikeErrorMessage(rawMessage)) {
-    return getUserFriendlyMessage(type, metadata.retryAfter);
+    return getUserFriendlyMessage(
+      type,
+      metadata.retryAfter,
+      metadata.errorCode
+    );
   }
 
   return rawMessage;

--- a/apps/web/lib/chat/run.ts
+++ b/apps/web/lib/chat/run.ts
@@ -24,7 +24,7 @@ import type {
   ChatTelemetry,
   ReleaseContext,
 } from '@/lib/chat/types';
-import { wrapToolSetFailSoft } from '@/lib/chat/wrap-tool-execute';
+
 import { CHAT_MODEL, CHAT_MODEL_LIGHT } from '@/lib/constants/ai-models';
 import type { getEntitlements as GetEntitlements } from '@/lib/entitlements/registry';
 
@@ -270,10 +270,7 @@ export async function executeChatTurn(
     );
   }
 
-  const failSoftTools = wrapToolSetFailSoft(tools);
-  const toolNames = Object.keys(failSoftTools).sort((a, b) =>
-    a.localeCompare(b)
-  );
+  const toolNames = Object.keys(tools).sort((a, b) => a.localeCompare(b));
   const toolStepLimit = resolveChatToolStepLimit(
     planLimits.booleans.aiCanUseTools
   );
@@ -282,7 +279,7 @@ export async function executeChatTurn(
     model: gateway(selectedModel),
     system: systemPrompt,
     messages: modelMessages,
-    tools: failSoftTools,
+    tools,
     stopWhen: stepCountIs(toolStepLimit),
     prepareStep: ({ steps, stepNumber }) => {
       const restrictedTools = resolveImportBioRestrictedTools(

--- a/apps/web/lib/chat/run.ts
+++ b/apps/web/lib/chat/run.ts
@@ -24,6 +24,7 @@ import type {
   ChatTelemetry,
   ReleaseContext,
 } from '@/lib/chat/types';
+import { wrapToolSetFailSoft } from '@/lib/chat/wrap-tool-execute';
 import { CHAT_MODEL, CHAT_MODEL_LIGHT } from '@/lib/constants/ai-models';
 import type { getEntitlements as GetEntitlements } from '@/lib/entitlements/registry';
 
@@ -269,7 +270,10 @@ export async function executeChatTurn(
     );
   }
 
-  const toolNames = Object.keys(tools).sort((a, b) => a.localeCompare(b));
+  const failSoftTools = wrapToolSetFailSoft(tools);
+  const toolNames = Object.keys(failSoftTools).sort((a, b) =>
+    a.localeCompare(b)
+  );
   const toolStepLimit = resolveChatToolStepLimit(
     planLimits.booleans.aiCanUseTools
   );
@@ -278,7 +282,7 @@ export async function executeChatTurn(
     model: gateway(selectedModel),
     system: systemPrompt,
     messages: modelMessages,
-    tools,
+    tools: failSoftTools,
     stopWhen: stepCountIs(toolStepLimit),
     prepareStep: ({ steps, stepNumber }) => {
       const restrictedTools = resolveImportBioRestrictedTools(

--- a/apps/web/lib/chat/tool-errors.ts
+++ b/apps/web/lib/chat/tool-errors.ts
@@ -1,0 +1,308 @@
+/** Stable codes persisted on tool failure payloads and shown in chat UI. */
+export const TOOL_ERROR_CODES = {
+  FEATURE_DISABLED: 'FEATURE_DISABLED',
+  PLAN_UNAVAILABLE: 'PLAN_UNAVAILABLE',
+  PROVIDER_UNAVAILABLE: 'PROVIDER_UNAVAILABLE',
+  TOOL_UNAVAILABLE: 'TOOL_UNAVAILABLE',
+  TOOL_UNPROVISIONED: 'TOOL_UNPROVISIONED',
+  RATE_LIMITED: 'RATE_LIMITED',
+  PROFILE_REQUIRED: 'PROFILE_REQUIRED',
+  TOOL_EXECUTION_FAILED: 'TOOL_EXECUTION_FAILED',
+} as const;
+
+export type ToolErrorCode =
+  (typeof TOOL_ERROR_CODES)[keyof typeof TOOL_ERROR_CODES];
+
+export interface ToolFailurePayload {
+  readonly success: false;
+  readonly error: string;
+  readonly errorCode: ToolErrorCode;
+  readonly retryable: boolean;
+  readonly hint?: string;
+}
+
+export interface ToolFailurePresentation {
+  readonly title: string;
+  readonly body: string;
+  readonly nextStep: string;
+  readonly errorCode: ToolErrorCode;
+  readonly recoverable: boolean;
+}
+
+const USER_COPY: Record<
+  ToolErrorCode,
+  {
+    readonly body: string;
+    readonly nextStep: string;
+    readonly recoverable: boolean;
+  }
+> = {
+  FEATURE_DISABLED: {
+    body: 'This feature is not enabled for your workspace yet.',
+    nextStep:
+      'Try a different request or check back after your workspace is updated.',
+    recoverable: true,
+  },
+  PLAN_UNAVAILABLE: {
+    body: 'This action needs a paid Jovie plan.',
+    nextStep:
+      'Upgrade your plan or ask Jovie for a workaround you can do manually.',
+    recoverable: true,
+  },
+  PROVIDER_UNAVAILABLE: {
+    body: 'The service behind this action is temporarily unavailable.',
+    nextStep: 'Retry in a few minutes or ask Jovie for an alternate approach.',
+    recoverable: true,
+  },
+  TOOL_UNAVAILABLE: {
+    body: 'This action is temporarily unavailable.',
+    nextStep: 'Retry shortly or rephrase what you need help with.',
+    recoverable: true,
+  },
+  TOOL_UNPROVISIONED: {
+    body: 'This capability has not been provisioned for your account yet.',
+    nextStep:
+      'Ask Jovie for a manual workaround while provisioning catches up.',
+    recoverable: true,
+  },
+  RATE_LIMITED: {
+    body: 'You have hit the limit for this action.',
+    nextStep: 'Wait a moment, then try again.',
+    recoverable: true,
+  },
+  PROFILE_REQUIRED: {
+    body: 'Jovie needs an artist profile before it can run this action.',
+    nextStep: 'Refresh the page and try again once your profile has loaded.',
+    recoverable: true,
+  },
+  TOOL_EXECUTION_FAILED: {
+    body: 'Jovie could not finish this action.',
+    nextStep: 'Retry or ask for a simpler next step.',
+    recoverable: true,
+  },
+};
+
+const RECOVERABLE_STREAM_ERROR_CODES = new Set<ToolErrorCode>([
+  TOOL_ERROR_CODES.FEATURE_DISABLED,
+  TOOL_ERROR_CODES.PLAN_UNAVAILABLE,
+  TOOL_ERROR_CODES.PROVIDER_UNAVAILABLE,
+  TOOL_ERROR_CODES.TOOL_UNAVAILABLE,
+  TOOL_ERROR_CODES.TOOL_UNPROVISIONED,
+  TOOL_ERROR_CODES.RATE_LIMITED,
+  TOOL_ERROR_CODES.PROFILE_REQUIRED,
+  TOOL_ERROR_CODES.TOOL_EXECUTION_FAILED,
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asToolErrorCode(value: unknown): ToolErrorCode | undefined {
+  if (typeof value !== 'string') return undefined;
+  return Object.values(TOOL_ERROR_CODES).includes(value as ToolErrorCode)
+    ? (value as ToolErrorCode)
+    : undefined;
+}
+
+function inferErrorCodeFromMessage(message: string): ToolErrorCode {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes('not provisioned') ||
+    normalized.includes('unprovisioned')
+  ) {
+    return TOOL_ERROR_CODES.TOOL_UNPROVISIONED;
+  }
+  if (
+    normalized.includes('requires a pro plan') ||
+    normalized.includes('paid plan') ||
+    normalized.includes('upgrade')
+  ) {
+    return TOOL_ERROR_CODES.PLAN_UNAVAILABLE;
+  }
+  if (
+    normalized.includes('temporarily unavailable') ||
+    normalized.includes('provider') ||
+    normalized.includes('not configured')
+  ) {
+    return TOOL_ERROR_CODES.PROVIDER_UNAVAILABLE;
+  }
+  if (
+    normalized.includes('rate limit') ||
+    normalized.includes('too many') ||
+    normalized.includes('limit reached')
+  ) {
+    return TOOL_ERROR_CODES.RATE_LIMITED;
+  }
+  if (normalized.includes('profile id required')) {
+    return TOOL_ERROR_CODES.PROFILE_REQUIRED;
+  }
+  if (
+    normalized.includes('not enabled') ||
+    normalized.includes('feature disabled')
+  ) {
+    return TOOL_ERROR_CODES.FEATURE_DISABLED;
+  }
+
+  return TOOL_ERROR_CODES.TOOL_EXECUTION_FAILED;
+}
+
+export function classifyThrownToolError(
+  toolName: string,
+  error: unknown
+): ToolFailurePayload {
+  const thrownCode =
+    error instanceof Error ? (error as { code?: unknown }).code : undefined;
+  const errorCodeFromThrown = asToolErrorCode(thrownCode);
+
+  if (
+    errorCodeFromThrown === TOOL_ERROR_CODES.PROVIDER_UNAVAILABLE ||
+    thrownCode === 'XAI_API_KEY_MISSING'
+  ) {
+    return buildToolFailure({
+      errorCode: TOOL_ERROR_CODES.PROVIDER_UNAVAILABLE,
+      error: 'Album art generation is temporarily unavailable.',
+      retryable: false,
+      toolName,
+    });
+  }
+
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : 'Tool execution failed.';
+  const code =
+    error instanceof Error
+      ? asToolErrorCode((error as { code?: unknown }).code)
+      : undefined;
+
+  return buildToolFailure({
+    errorCode: code ?? inferErrorCodeFromMessage(message),
+    error: message,
+    retryable: code !== TOOL_ERROR_CODES.PLAN_UNAVAILABLE,
+    toolName,
+  });
+}
+
+export function buildToolFailure(input: {
+  readonly toolName?: string;
+  readonly errorCode: ToolErrorCode;
+  readonly error?: string;
+  readonly retryable?: boolean;
+  readonly hint?: string;
+}): ToolFailurePayload {
+  const presentation = resolveToolFailurePresentation({
+    toolName: input.toolName ?? 'tool',
+    errorCode: input.errorCode,
+    errorMessage: input.error,
+    retryable: input.retryable,
+  });
+
+  return {
+    success: false,
+    errorCode: input.errorCode,
+    error: presentation.body,
+    retryable: input.retryable ?? presentation.recoverable,
+    ...(input.hint ? { hint: input.hint } : {}),
+  };
+}
+
+export function normalizeToolFailureOutput(
+  toolName: string,
+  output: unknown
+): ToolFailurePayload | null {
+  if (!isRecord(output) || output.success !== false) {
+    return null;
+  }
+
+  const rawError =
+    typeof output.error === 'string' && output.error.trim().length > 0
+      ? output.error.trim()
+      : typeof output.message === 'string' && output.message.trim().length > 0
+        ? output.message.trim()
+        : 'Tool execution failed.';
+
+  const errorCode =
+    asToolErrorCode(output.errorCode) ??
+    asToolErrorCode(output.code) ??
+    asToolErrorCode(output.reason) ??
+    inferErrorCodeFromMessage(rawError);
+
+  const retryable =
+    typeof output.retryable === 'boolean'
+      ? output.retryable
+      : errorCode !== TOOL_ERROR_CODES.PLAN_UNAVAILABLE;
+
+  return buildToolFailure({
+    toolName,
+    errorCode,
+    error: rawError,
+    retryable,
+    hint: typeof output.hint === 'string' ? output.hint : undefined,
+  });
+}
+
+export function resolveToolFailurePresentation(input: {
+  readonly toolName: string;
+  readonly errorCode?: string | null;
+  readonly errorMessage?: string | null;
+  readonly retryable?: boolean | null;
+}): ToolFailurePresentation {
+  const errorCode =
+    asToolErrorCode(input.errorCode) ??
+    inferErrorCodeFromMessage(input.errorMessage ?? '');
+  const defaults = USER_COPY[errorCode];
+  const body =
+    input.errorMessage && input.errorMessage.trim().length > 0
+      ? input.errorMessage.trim()
+      : defaults.body;
+
+  return {
+    title: `Couldn't finish ${humanizeToolName(input.toolName)}`,
+    body,
+    nextStep: defaults.nextStep,
+    errorCode,
+    recoverable: input.retryable ?? defaults.recoverable,
+  };
+}
+
+export function isRecoverableToolErrorCode(
+  errorCode: string | undefined | null
+): boolean {
+  if (!errorCode) return false;
+  return RECOVERABLE_STREAM_ERROR_CODES.has(errorCode as ToolErrorCode);
+}
+
+export function isRecoverableToolStreamError(error: Error): boolean {
+  const code =
+    typeof (error as { code?: unknown }).code === 'string'
+      ? ((error as { code?: string }).code ?? undefined)
+      : undefined;
+
+  if (isRecoverableToolErrorCode(code)) {
+    return true;
+  }
+
+  const message = error.message.toLowerCase();
+  if (message.includes('tool') && message.includes('unavailable')) {
+    return true;
+  }
+  if (
+    message.includes('not provisioned') ||
+    message.includes('unprovisioned')
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function humanizeToolName(toolName: string): string {
+  return toolName
+    .replaceAll(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replaceAll(/[-_]/g, ' ')
+    .trim()
+    .toLowerCase();
+}

--- a/apps/web/lib/chat/tool-events.ts
+++ b/apps/web/lib/chat/tool-events.ts
@@ -5,6 +5,7 @@ import {
   type UIMessage,
 } from 'ai';
 import { z } from 'zod';
+import { normalizeToolFailureOutput } from './tool-errors';
 import { getToolUiConfig } from './tool-ui-registry';
 
 export type PersistedToolState =
@@ -30,6 +31,8 @@ export interface PersistedToolEvent {
   readonly input?: Record<string, unknown>;
   readonly output?: Record<string, unknown>;
   readonly errorMessage?: string;
+  readonly errorCode?: string;
+  readonly retryable?: boolean;
   readonly summary?: string;
   readonly uiHint: PersistedToolUiHint;
   readonly approval?: PersistedToolApproval;
@@ -56,6 +59,8 @@ export const persistedToolEventSchema = z.object({
   input: recordSchema.optional(),
   output: recordSchema.optional(),
   errorMessage: z.string().optional(),
+  errorCode: z.string().optional(),
+  retryable: z.boolean().optional(),
   summary: z.string().optional(),
   uiHint: z.enum(['artifact', 'status']),
   approval: approvalSchema.optional(),
@@ -267,6 +272,10 @@ function normalizeToolPart(part: ToolPart): PersistedToolEvent | null {
 
   const persistedOutput =
     state === 'succeeded' ? capPersistedToolOutput(output) : output;
+  const normalizedFailure =
+    state === 'failed'
+      ? normalizeToolFailureOutput(toolName, output ?? { error: errorMessage })
+      : null;
 
   return {
     schemaVersion: 2,
@@ -274,14 +283,15 @@ function normalizeToolPart(part: ToolPart): PersistedToolEvent | null {
     toolName,
     state,
     input,
-    output: persistedOutput,
-    errorMessage,
-    summary: getSummaryForState(
-      state,
+    output:
+      (normalizedFailure as unknown as Record<string, unknown> | undefined) ??
       persistedOutput,
-      outputError,
-      approvalReason
-    ),
+    errorMessage: normalizedFailure?.error ?? errorMessage,
+    errorCode: normalizedFailure?.errorCode,
+    retryable: normalizedFailure?.retryable,
+    summary:
+      normalizedFailure?.error ??
+      getSummaryForState(state, persistedOutput, outputError, approvalReason),
     uiHint: config.uiHint,
     approval,
   };

--- a/apps/web/lib/chat/wrap-tool-execute.ts
+++ b/apps/web/lib/chat/wrap-tool-execute.ts
@@ -1,0 +1,65 @@
+import 'server-only';
+
+import type { Tool, ToolSet } from 'ai';
+import { captureError } from '@/lib/error-tracking';
+import {
+  classifyThrownToolError,
+  normalizeToolFailureOutput,
+} from './tool-errors';
+
+type ToolExecute = Tool['execute'];
+
+/**
+ * Mirrors the track-route audience upsert fail-soft pattern: tool failures must
+ * never take down the chat stream. Throws are captured, logged, and returned as
+ * structured `{ success: false, errorCode, ... }` payloads.
+ */
+export function withFailSoftToolExecute(
+  toolName: string,
+  execute: ToolExecute | undefined
+): ToolExecute | undefined {
+  if (!execute) {
+    return execute;
+  }
+
+  return async (input, options) => {
+    try {
+      const result = await execute(input, options);
+      const normalizedFailure = normalizeToolFailureOutput(toolName, result);
+      return normalizedFailure ?? result;
+    } catch (error) {
+      const failure = classifyThrownToolError(toolName, error);
+      await captureError('Chat tool execute failed', error, {
+        feature: 'ai-chat',
+        source: 'chat-tool-execute',
+        toolName,
+        errorCode: failure.errorCode,
+        retryable: failure.retryable,
+      });
+      return failure;
+    }
+  };
+}
+
+export function wrapToolSetFailSoft(tools: ToolSet): ToolSet {
+  const wrappedEntries = Object.entries(tools).map(([toolName, toolConfig]) => {
+    if (!toolConfig || typeof toolConfig !== 'object') {
+      return [toolName, toolConfig] as const;
+    }
+
+    const execute = 'execute' in toolConfig ? toolConfig.execute : undefined;
+    if (typeof execute !== 'function') {
+      return [toolName, toolConfig] as const;
+    }
+
+    return [
+      toolName,
+      {
+        ...toolConfig,
+        execute: withFailSoftToolExecute(toolName, execute),
+      },
+    ] as const;
+  });
+
+  return Object.fromEntries(wrappedEntries);
+}

--- a/apps/web/tests/unit/chat/jovie-error-utils.test.ts
+++ b/apps/web/tests/unit/chat/jovie-error-utils.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from 'vitest';
 import {
   extractErrorMetadata,
   getErrorType,
+  getNextStepMessage,
   getPreferredErrorMessage,
   getUserFriendlyMessage,
+  messagePartsIncludeFailedTool,
+  shouldSuppressChatPauseForToolFailure,
 } from '@/components/jovie/utils';
 
 describe('extractErrorMetadata', () => {
@@ -96,6 +99,37 @@ describe('getPreferredErrorMessage', () => {
 
     expect(getPreferredErrorMessage(error, 'server', {})).toBe(
       'Service is temporarily unavailable.'
+    );
+  });
+});
+
+describe('tool failure chat pause suppression', () => {
+  it('detects failed tool parts in assistant messages', () => {
+    expect(
+      messagePartsIncludeFailedTool([
+        {
+          type: 'dynamic-tool',
+          toolName: 'retouchImage',
+          toolCallId: 'tool-1',
+          state: 'output-error',
+          errorText: 'Retouch is not provisioned for this account.',
+        },
+      ])
+    ).toBe(true);
+  });
+
+  it('suppresses composer pause for recoverable tool stream errors', () => {
+    const error = Object.assign(new Error('Retouch provider unavailable'), {
+      code: 'TOOL_UNPROVISIONED',
+    });
+
+    expect(getErrorType(error)).toBe('tool');
+    expect(shouldSuppressChatPauseForToolFailure(error, [])).toBe(true);
+    expect(
+      getUserFriendlyMessage('tool', undefined, 'TOOL_UNPROVISIONED')
+    ).toContain('provisioned');
+    expect(getNextStepMessage('tool', 'TOOL_UNPROVISIONED')).toContain(
+      'workaround'
     );
   });
 });

--- a/apps/web/tests/unit/chat/tool-errors.test.ts
+++ b/apps/web/tests/unit/chat/tool-errors.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildToolFailure,
+  classifyThrownToolError,
+  isRecoverableToolStreamError,
+  normalizeToolFailureOutput,
+  resolveToolFailurePresentation,
+  TOOL_ERROR_CODES,
+} from '@/lib/chat/tool-errors';
+
+describe('tool-errors', () => {
+  it('maps unprovisioned failures to TOOL_UNPROVISIONED copy', () => {
+    const presentation = resolveToolFailurePresentation({
+      toolName: 'retouchImage',
+      errorCode: TOOL_ERROR_CODES.TOOL_UNPROVISIONED,
+      errorMessage: 'Retouch is not provisioned for this account.',
+    });
+
+    expect(presentation.errorCode).toBe('TOOL_UNPROVISIONED');
+    expect(presentation.body).toContain('not provisioned');
+    expect(presentation.nextStep).toContain('workaround');
+  });
+
+  it('normalizes legacy tool failure payloads with inferred codes', () => {
+    const normalized = normalizeToolFailureOutput('generateAlbumArt', {
+      success: false,
+      error: 'Album art generation requires a Pro plan.',
+      retryable: false,
+    });
+
+    expect(normalized).toMatchObject({
+      success: false,
+      errorCode: 'PLAN_UNAVAILABLE',
+      retryable: false,
+    });
+  });
+
+  it('classifies thrown provider errors without rethrowing semantics', () => {
+    const failure = classifyThrownToolError(
+      'generateAlbumArt',
+      Object.assign(new Error('XAI_API_KEY is not configured'), {
+        code: 'XAI_API_KEY_MISSING',
+      })
+    );
+
+    expect(failure.errorCode).toBe('PROVIDER_UNAVAILABLE');
+    expect(failure.retryable).toBe(false);
+  });
+
+  it('treats recoverable tool stream errors as soft failures', () => {
+    const error = Object.assign(new Error('Retouch provider unavailable'), {
+      code: TOOL_ERROR_CODES.TOOL_UNPROVISIONED,
+    });
+
+    expect(isRecoverableToolStreamError(error)).toBe(true);
+    expect(
+      buildToolFailure({
+        toolName: 'retouchImage',
+        errorCode: TOOL_ERROR_CODES.TOOL_UNPROVISIONED,
+      }).errorCode
+    ).toBe('TOOL_UNPROVISIONED');
+  });
+});

--- a/apps/web/tests/unit/chat/tool-ui-errors.test.tsx
+++ b/apps/web/tests/unit/chat/tool-ui-errors.test.tsx
@@ -1,0 +1,37 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ToolPartsRenderer } from '@/components/jovie/tool-ui';
+import { fastRender } from '@/tests/utils/fast-render';
+
+describe('ToolPartsRenderer tool failure presentation', () => {
+  it('renders mapped recoverable copy for unprovisioned retouch failures', () => {
+    fastRender(
+      <ToolPartsRenderer
+        variant='chat'
+        parts={[
+          {
+            type: 'dynamic-tool',
+            toolName: 'retouchImage',
+            toolCallId: 'tool-retouch-1',
+            state: 'output-available',
+            output: {
+              success: false,
+              errorCode: 'TOOL_UNPROVISIONED',
+              error: 'Retouch is not provisioned for this account.',
+              retryable: true,
+            },
+          },
+        ]}
+      />
+    );
+
+    const row = screen.getByTestId('tool-status-row');
+    expect(row.getAttribute('data-tool-state')).toBe('failed');
+    expect(
+      screen.getByText('Retouch is not provisioned for this account.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Ask Jovie for a manual workaround/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/unit/chat/useJovieChat.rate-limit.test.tsx
+++ b/apps/web/tests/unit/chat/useJovieChat.rate-limit.test.tsx
@@ -505,6 +505,49 @@ describe('useJovieChat', () => {
     expect(result.current.chatError?.message).toBe('Server failed');
   });
 
+  it('does not pause the composer for recoverable tool stream failures', async () => {
+    mockMessages = [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        createdAt: new Date(),
+        parts: [
+          {
+            type: 'dynamic-tool',
+            toolName: 'retouchImage',
+            toolCallId: 'tool-1',
+            state: 'output-error',
+            errorText: 'Retouch is not provisioned for this account.',
+          },
+        ],
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useJovieChat({ profileId: 'profile_1' })
+    );
+
+    act(() => {
+      result.current.setInput('Retouch my press photo');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    act(() => {
+      onErrorHandler?.(
+        Object.assign(new Error('Retouch provider unavailable'), {
+          code: 'TOOL_UNPROVISIONED',
+        })
+      );
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.chatError).toBeNull();
+    expect(result.current.input).toBe('');
+  });
+
   it('marks album art generation prompts with a tool intent', async () => {
     const { result, rerender } = renderHook(() =>
       useJovieChat({ profileId: 'profile_1', conversationId: 'conv_123' })

--- a/apps/web/tests/unit/chat/wrap-tool-execute.test.ts
+++ b/apps/web/tests/unit/chat/wrap-tool-execute.test.ts
@@ -1,0 +1,61 @@
+import { tool } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  withFailSoftToolExecute,
+  wrapToolSetFailSoft,
+} from '@/lib/chat/wrap-tool-execute';
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('wrap-tool-execute', () => {
+  it('returns structured failure instead of throwing', async () => {
+    const execute = withFailSoftToolExecute('retouchImage', async () => {
+      throw new Error('Retouch is not provisioned for this account.');
+    });
+
+    const result = await execute?.({}, {} as never);
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: 'TOOL_UNPROVISIONED',
+      retryable: true,
+    });
+  });
+
+  it('normalizes success:false payloads from execute', async () => {
+    const execute = withFailSoftToolExecute('generateAlbumArt', async () => ({
+      success: false as const,
+      error: 'Album art generation is temporarily unavailable.',
+      retryable: false,
+    }));
+
+    const result = await execute?.({}, {} as never);
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: 'PROVIDER_UNAVAILABLE',
+    });
+  });
+
+  it('wraps every tool in a tool set', async () => {
+    const tools = wrapToolSetFailSoft({
+      demoTool: tool({
+        description: 'demo',
+        inputSchema: z.object({}),
+        execute: async () => {
+          throw new Error('demo failed');
+        },
+      }),
+    });
+
+    const result = await tools.demoTool.execute?.({}, {} as never);
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: 'TOOL_EXECUTION_FAILED',
+    });
+  });
+});


### PR DESCRIPTION
## Goal
When a chat tool fails (e.g. retouch unprovisioned, album art provider down), users should see specific recoverable inline errors instead of a generic "Something went wrong" stream failure that pauses the composer.

## Changes
- Add `tool-errors.ts` to map stable tool error codes (`TOOL_UNPROVISIONED`, `PROVIDER_UNAVAILABLE`, etc.) to user-facing copy and recovery hints
- Add `wrap-tool-execute.ts` fail-soft wrapper (mirrors `/api/track` audience upsert pattern): tool throws are captured, logged, and returned as structured `{ success: false, errorCode }` payloads
- Wrap all chat tools in `executeChatTurn` via `wrapToolSetFailSoft`
- Persist `errorCode` / `retryable` on tool events; render mapped copy + next-step hints in `tool-ui.tsx`
- Suppress global "Message paused" composer errors for recoverable tool-only failures in `useJovieChat`
- Tag album art tool failures with explicit error codes

## Testing
```bash
cd apps/web && pnpm exec vitest run \
  tests/unit/chat/tool-errors.test.ts \
  tests/unit/chat/wrap-tool-execute.test.ts \
  tests/unit/chat/tool-ui-errors.test.tsx \
  tests/unit/chat/jovie-error-utils.test.ts \
  tests/unit/chat/useJovieChat.rate-limit.test.tsx
```

<!-- linear-issue-id:JOV-3338 -->