### PR TITLE
fix(chat): open profile rail from sidebar artist name click (JOV-3557)

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
+import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import { openCommandPalette } from '@/components/organisms/command-palette-events';
 import { usePendingShell } from '@/components/organisms/PendingShellContext';
 import {
@@ -170,6 +171,8 @@ export function DashboardNav(_: DashboardNavProps) {
   const { isMobile, openMobile, state: sidebarState } = useSidebar();
   const pathname = usePathname();
   const router = useRouter();
+  const { isOpen: isPreviewPanelOpen, open: openPreviewPanel } =
+    usePreviewPanelState();
   const queryClient = useQueryClient();
   const shellChatV1Enabled = useAppFlag('DESIGN_V1');
   const [threadReadAtById, setThreadReadAtById] =
@@ -226,8 +229,11 @@ export function DashboardNav(_: DashboardNavProps) {
     setTasksSeenAt(nextSeenAt);
   }, [pathname]);
 
-  // Settings nav: "General" (user) and artist name (or "Artist") groups
-  const artistSettingsLabel = artistName || 'Artist';
+  // Settings nav: "General" (user) and artist name (or "Artist") groups.
+  // In the chat shell the artist row itself shows the display name, so keep the
+  // section label generic to avoid duplicate "Tim White" buttons in the sidebar.
+  const artistSettingsLabel =
+    shellChatV1Enabled && !isInSettings ? 'Artist' : artistName || 'Artist';
   const moreLabel = 'More';
 
   // Memoize nav sections for dashboard (non-settings) mode
@@ -235,22 +241,33 @@ export function DashboardNav(_: DashboardNavProps) {
     readonly moreSection: MoreNavSection | null;
     readonly navSections: DashboardNavSection[];
   }>(() => {
-    const decorateItem = (item: NavItem): NavItem =>
-      item.id === 'tasks'
-        ? {
-            ...item,
-            badge: (() => {
-              if (isPlanGateLoading) return undefined;
-              if (canAccessTasksWorkspace)
-                return formatTaskBadge(taskStats, tasksSeenAt);
-              return (
-                <span className='rounded-full border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_76%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_90%,transparent)] px-1.5 py-0.5 text-3xs font-semibold tracking-wider text-secondary-token'>
-                  Pro
-                </span>
-              );
-            })(),
-          }
-        : item;
+    const decorateItem = (item: NavItem): NavItem => {
+      if (item.id === 'tasks') {
+        return {
+          ...item,
+          badge: (() => {
+            if (isPlanGateLoading) return undefined;
+            if (canAccessTasksWorkspace)
+              return formatTaskBadge(taskStats, tasksSeenAt);
+            return (
+              <span className='rounded-full border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_76%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_90%,transparent)] px-1.5 py-0.5 text-3xs font-semibold tracking-wider text-secondary-token'>
+                Pro
+              </span>
+            );
+          })(),
+        };
+      }
+
+      if (shellChatV1Enabled && !isInSettings && item.id === 'artist-profile') {
+        return {
+          ...item,
+          name: artistName || item.name,
+          href: APP_ROUTES.CHAT_PROFILE_PANEL,
+        };
+      }
+
+      return item;
+    };
 
     const audienceItem = primaryNavigation.find(item => item.id === 'audience');
     const tasksItem = primaryNavigation.find(item => item.id === 'tasks');
@@ -297,7 +314,9 @@ export function DashboardNav(_: DashboardNavProps) {
   }, [
     canAccessTasksWorkspace,
     isPlanGateLoading,
+    artistName,
     artistSettingsLabel,
+    isInSettings,
     moreLabel,
     shellChatV1Enabled,
     taskStats,
@@ -421,6 +440,20 @@ export function DashboardNav(_: DashboardNavProps) {
     openCommandPalette();
   }, []);
 
+  const handleOpenArtistProfilePanel = useCallback(() => {
+    const isOnChat = pathname.startsWith(APP_ROUTES.CHAT);
+
+    if (isOnChat) {
+      openPreviewPanel();
+      return;
+    }
+
+    router.push(APP_ROUTES.CHAT);
+    queueMicrotask(() => {
+      openPreviewPanel();
+    });
+  }, [openPreviewPanel, pathname, router]);
+
   const activeThreadId = useMemo(() => {
     const chatPrefix = `${APP_ROUTES.CHAT}/`;
     if (!pathname.startsWith(chatPrefix)) return null;
@@ -474,11 +507,15 @@ export function DashboardNav(_: DashboardNavProps) {
     (item: NavItem, _index: number) => {
       const isReleasesItem = item.id === 'releases';
       const isSearchItem = item.id === 'search';
+      const opensArtistProfilePanel =
+        shellChatV1Enabled && !isInSettings && item.id === 'artist-profile';
       const isNewThreadItem =
         item.id === 'chat' && item.href === APP_ROUTES.CHAT;
       let isActive = false;
       if (isNewThreadItem) {
         isActive = normalizeTrailingSlash(pathname) === APP_ROUTES.CHAT;
+      } else if (opensArtistProfilePanel) {
+        isActive = isPreviewPanelOpen;
       } else if (!isSearchItem) {
         isActive = isItemActive(pathname, item);
       }
@@ -486,10 +523,11 @@ export function DashboardNav(_: DashboardNavProps) {
 
       // In demo mode, only Releases has real content — intercept all other nav clicks
       const demoUnavailable = isDemo && !isReleasesItem && !isSearchItem;
-      const renderAsButton = isSearchItem;
+      const renderAsButton = isSearchItem || opensArtistProfilePanel;
       let onClick: (() => void) | undefined;
       if (demoUnavailable) onClick = () => handleDemoNavClick(item);
       else if (isSearchItem) onClick = handleSearchClick;
+      else if (opensArtistProfilePanel) onClick = handleOpenArtistProfilePanel;
 
       return (
         <NavMenuItem
@@ -517,9 +555,12 @@ export function DashboardNav(_: DashboardNavProps) {
       handleDemoNavClick,
       handlePrefetch,
       handleSearchClick,
+      handleOpenArtistProfilePanel,
       clearPendingReleasesShell,
       showPendingReleasesShell,
       isDemo,
+      isInSettings,
+      isPreviewPanelOpen,
       shellChatV1Enabled,
     ]
   );

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -7,6 +7,7 @@ import { OPEN_COMMAND_PALETTE_EVENT } from '@/components/organisms/command-palet
 import { APP_ROUTES, buildLibraryViewRoute } from '@/constants/routes';
 import {
   mockClearPendingShell,
+  mockOpenPreviewPanel,
   mockRouterPush,
   mockShowPendingShell,
   mockToastInfo,
@@ -59,8 +60,9 @@ describe('DashboardNav interactions', () => {
       buildLibraryViewRoute('releases')
     );
     expect(
-      screen.getByRole('link', { name: 'Artist Profile' })
-    ).toHaveAttribute('href', APP_ROUTES.SETTINGS_ARTIST_PROFILE);
+      screen.getByRole('button', { name: 'Artist Profile' })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Artist Profile' })).toBeNull();
     expect(screen.getByRole('link', { name: 'Touring' })).toHaveAttribute(
       'href',
       APP_ROUTES.SETTINGS_TOURING
@@ -145,7 +147,8 @@ describe('DashboardNav interactions', () => {
     expect(labelNode).toHaveClass('group-data-[collapsible=icon]:hidden');
   });
 
-  it('renders Artist Profile in the primary artist group on chat routes', () => {
+  it('opens the in-chat profile rail from the artist name on chat routes', async () => {
+    const user = userEvent.setup();
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.CHAT);
     renderDashboardNav({
       renderFn: render,
@@ -160,9 +163,9 @@ describe('DashboardNav interactions', () => {
       },
     });
 
-    expect(
-      screen.getByRole('link', { name: 'Artist Profile' })
-    ).toHaveAttribute('href', APP_ROUTES.SETTINGS_ARTIST_PROFILE);
+    await user.click(screen.getByRole('button', { name: 'Tim White' }));
+
+    expect(mockOpenPreviewPanel).toHaveBeenCalledTimes(1);
     expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
@@ -218,7 +221,7 @@ describe('DashboardNav interactions', () => {
     expect(screen.getByRole('button', { name: 'More' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Releases' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Tim White' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: 'Artist' })).toHaveAttribute(
       'aria-expanded',
       'true'
     );
@@ -227,8 +230,9 @@ describe('DashboardNav interactions', () => {
       buildLibraryViewRoute('releases')
     );
     expect(
-      screen.getByRole('link', { name: 'Artist Profile' })
-    ).toHaveAttribute('href', APP_ROUTES.SETTINGS_ARTIST_PROFILE);
+      screen.getByRole('button', { name: 'Tim White' })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Tim White' })).toBeNull();
     expect(screen.getByRole('link', { name: 'Touring' })).toHaveAttribute(
       'href',
       APP_ROUTES.SETTINGS_TOURING
@@ -316,7 +320,8 @@ describe('DashboardNav interactions', () => {
     ).toBeInTheDocument();
   });
 
-  it('keeps Artist Profile in the artist group off chat routes', () => {
+  it('navigates to chat and opens the profile rail from artist name off chat routes', async () => {
+    const user = userEvent.setup();
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.AUDIENCE);
     renderDashboardNav({
       renderFn: render,
@@ -331,10 +336,10 @@ describe('DashboardNav interactions', () => {
       },
     });
 
-    expect(
-      screen.getByRole('link', { name: 'Artist Profile' })
-    ).toHaveAttribute('href', APP_ROUTES.SETTINGS_ARTIST_PROFILE);
-    expect(mockRouterPush).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Tim White' }));
+
+    expect(mockRouterPush).toHaveBeenCalledWith(APP_ROUTES.CHAT);
+    expect(mockOpenPreviewPanel).toHaveBeenCalledTimes(1);
   });
 
   it('shows the releases pending shell once for a pointer click', async () => {

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -31,9 +31,7 @@ describe('DashboardNav', () => {
     expect(getByRole('link', { name: 'Releases' }).getAttribute('href')).toBe(
       buildLibraryViewRoute('releases')
     );
-    expect(
-      getByRole('link', { name: 'Artist Profile' }).getAttribute('href')
-    ).toBe(APP_ROUTES.SETTINGS_ARTIST_PROFILE);
+    expect(getByRole('button', { name: 'Artist Profile' })).toBeDefined();
     expect(getByRole('link', { name: 'Touring' }).getAttribute('href')).toBe(
       APP_ROUTES.SETTINGS_TOURING
     );
@@ -71,10 +69,11 @@ describe('DashboardNav', () => {
       },
     });
 
-    expect(getByRole('button', { name: 'Tim White' })).toHaveAttribute(
+    expect(getByRole('button', { name: 'Artist' })).toHaveAttribute(
       'aria-expanded',
       'true'
     );
+    expect(getByRole('button', { name: 'Tim White' })).toBeDefined();
     const releasesLink = getByRole('link', { name: 'Releases' });
     expect(releasesLink.getAttribute('href')).toBe(
       buildLibraryViewRoute('releases')
@@ -82,9 +81,6 @@ describe('DashboardNav', () => {
     expect(releasesLink.className).toContain(
       'grid-cols-[22px_minmax(0,1fr)_34px]'
     );
-    expect(
-      getByRole('link', { name: 'Artist Profile' }).getAttribute('href')
-    ).toBe(APP_ROUTES.SETTINGS_ARTIST_PROFILE);
     expect(getByRole('link', { name: 'Touring' }).getAttribute('href')).toBe(
       APP_ROUTES.SETTINGS_TOURING
     );
@@ -249,10 +245,7 @@ describe('DashboardNav', () => {
       'href',
       buildLibraryViewRoute('releases')
     );
-    expect(getByRole('link', { name: 'Artist Profile' })).toHaveAttribute(
-      'href',
-      APP_ROUTES.SETTINGS_ARTIST_PROFILE
-    );
+    expect(getByRole('button', { name: 'Artist Profile' })).toBeDefined();
     expect(getByRole('link', { name: 'Touring' })).toHaveAttribute(
       'href',
       APP_ROUTES.SETTINGS_TOURING


### PR DESCRIPTION
## Goal
Fix JOV-3557: clicking the artist name in the chat sidebar should open the in-chat right-rail profile bento card, not navigate to Settings.

## Changes
- Wire Design V1 sidebar artist row to `usePreviewPanelState().open()` instead of `SETTINGS_ARTIST_PROFILE`
- Show the artist display name on the nav row; keep the section label as "Artist" to avoid duplicate labels
- Navigate to `/app/chat` first when opening the rail from non-chat routes
- Update DashboardNav unit/interaction tests for the new button behavior

## Testing
- `pnpm exec vitest run apps/web/tests/unit/dashboard/DashboardNav.test.tsx apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx`
- Manual: on `/app/chat`, click artist name in sidebar → right-rail profile bento opens (no Settings navigation)

Closes JOV-3557