### PR TITLE
feat(chat): chatgpt-style unified composer width + scroll-behind fade (JOV-3594)

### DIFF
--- a/apps/web/app/app/(shell)/chat/loading.tsx
+++ b/apps/web/app/app/(shell)/chat/loading.tsx
@@ -1,6 +1,7 @@
 import { Skeleton } from '@jovie/ui';
 import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
 import { ChatWorkspaceSurface } from '@/components/jovie/ChatWorkspaceSurface';
+import { CHAT_CONTENT_SHELL_CLASSNAME } from '@/components/jovie/chat-layout';
 import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
 
 /**
@@ -17,7 +18,9 @@ export default function ChatLoading() {
         data-testid='chat-loading'
       >
         <div className='flex flex-1 flex-col items-center justify-center px-4 py-6 sm:px-6 sm:py-8'>
-          <div className='relative mx-auto flex min-h-full w-full max-w-[52rem] flex-1 flex-col items-center justify-center px-1 py-8'>
+          <div
+            className={`${CHAT_CONTENT_SHELL_CLASSNAME} relative flex min-h-full flex-1 flex-col items-center justify-center px-1 py-8`}
+          >
             <div
               className='pointer-events-none absolute left-1/2 top-1/2 h-[min(46vw,28rem)] w-[min(46vw,28rem)] -translate-x-1/2 -translate-y-[60%] opacity-45 max-sm:h-[min(72vw,18rem)] max-sm:w-[min(72vw,18rem)]'
               aria-hidden='true'
@@ -26,13 +29,15 @@ export default function ChatLoading() {
             </div>
 
             {/* Input area skeleton */}
-            <div className='relative z-10 w-full max-w-[45rem] space-y-2'>
+            <div
+              className={`${CHAT_CONTENT_SHELL_CLASSNAME} relative z-10 space-y-2`}
+            >
               <div className='system-b-shell-loading-composer'>
                 <div className='relative flex items-end gap-2 px-3 py-2.5'>
                   <button
                     type='button'
                     disabled
-                    aria-label='Attachment options'
+                    aria-label='Attachment Options'
                     className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-0 text-secondary-token opacity-80'
                   >
                     <LoadingSkeleton height='h-4' width='w-4' rounded='full' />
@@ -47,7 +52,7 @@ export default function ChatLoading() {
                   <button
                     type='button'
                     disabled
-                    aria-label='Send message'
+                    aria-label='Send Message'
                     className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-0 text-tertiary-token'
                   >
                     <LoadingSkeleton height='h-4' width='w-4' rounded='full' />

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -12,6 +12,7 @@ import {
 import { useOptionalChatEntityPanel } from '@/app/app/(shell)/chat/ChatEntityPanelContext';
 import { useAppFlag } from '@/lib/flags/client';
 import { usePlanGate } from '@/lib/queries';
+import { cn } from '@/lib/utils';
 
 import { deriveChatRailContextTargets } from './chat-context-rail';
 import { ChatDropZoneOverlay } from './components/ChatDropZoneOverlay';
@@ -25,6 +26,8 @@ import {
 } from './hooks';
 import {
   CHAT_COMPOSER_DOCK_CLASSNAME,
+  CHAT_COMPOSER_SCROLL_FADE_CLASSNAME,
+  CHAT_COMPOSER_THREAD_SCROLL_PADDING_CLASSNAME,
   ChatComposerSurface,
   ChatEmptyStateComposerRegion,
   ChatInlineError,
@@ -554,10 +557,14 @@ export function JovieChat({
         {/* Persistent scroll viewport (flex-1) + morphing upper content.
             Empty chat intentionally renders only the composer. Thread state
             owns the message viewport and the persistent bottom dock. */}
-        <div className='flex flex-1 flex-col overflow-hidden'>
+        <div className='relative flex flex-1 flex-col overflow-hidden'>
           <div
             ref={scrollContainerRef}
-            className='relative flex flex-1 flex-col overflow-y-auto px-4 py-5 sm:px-5'
+            className={cn(
+              'absolute inset-0 overflow-y-auto px-4 py-5 sm:px-5',
+              showBottomComposer &&
+                CHAT_COMPOSER_THREAD_SCROLL_PADDING_CLASSNAME
+            )}
           >
             {!showThreadView ? (
               <div className='relative min-h-full'>
@@ -594,15 +601,22 @@ export function JovieChat({
 
           {/*
             Thread composer dock. Empty chat keeps the same composer surface centered
-            above, while active threads pin it below the message viewport.
+            in the scroll viewport; active threads float it over the transcript with
+            a scroll-behind fade so the last message never hard-stops at the input.
           */}
           {showBottomComposer ? (
-            <div
-              className={CHAT_COMPOSER_DOCK_CLASSNAME}
-              data-testid='chat-composer-dock'
-            >
-              {composerSurface}
-            </div>
+            <>
+              <div
+                aria-hidden='true'
+                className={CHAT_COMPOSER_SCROLL_FADE_CLASSNAME}
+              />
+              <div
+                className={CHAT_COMPOSER_DOCK_CLASSNAME}
+                data-testid='chat-composer-dock'
+              >
+                {composerSurface}
+              </div>
+            </>
           ) : null}
         </div>
       </div>

--- a/apps/web/components/jovie/JovieChatSections.tsx
+++ b/apps/web/components/jovie/JovieChatSections.tsx
@@ -2,7 +2,12 @@
 
 import type { Virtualizer } from '@tanstack/react-virtual';
 import type { ReactNode, RefCallback } from 'react';
-import { CHAT_COMPOSER_DOCK_CLASSNAME } from './chat-layout';
+import {
+  CHAT_COMPOSER_DOCK_CLASSNAME,
+  CHAT_COMPOSER_SCROLL_FADE_CLASSNAME,
+  CHAT_COMPOSER_THREAD_SCROLL_PADDING_CLASSNAME,
+  CHAT_CONTENT_SHELL_CLASSNAME,
+} from './chat-layout';
 import {
   ChatConversationComposerSkeleton,
   ChatEmptyStateComposerRegion,
@@ -58,7 +63,7 @@ export function ChatComposerSurface({
   onExpandManifest,
 }: ChatComposerSurfaceProps) {
   return (
-    <div className='mx-auto w-full max-w-[45rem]'>
+    <div className={CHAT_CONTENT_SHELL_CLASSNAME}>
       <ChatUsageAlert />
 
       {isRateLimited ? (
@@ -126,7 +131,7 @@ export function ChatInlineError({
 }: ChatInlineErrorProps) {
   return (
     <div
-      className='mx-auto w-full max-w-[44rem] pb-4'
+      className={`${CHAT_CONTENT_SHELL_CLASSNAME} pb-4`}
       data-testid='chat-inline-error-slot'
     >
       <ErrorDisplay
@@ -188,7 +193,7 @@ export function ChatThreadMessages({
       {shouldVirtualizeMessages ? (
         <div
           ref={totalSizeRef}
-          className='mx-auto flex min-h-full w-full max-w-[44rem] flex-col'
+          className={`${CHAT_CONTENT_SHELL_CLASSNAME} flex min-h-full flex-col`}
           style={{
             position: 'relative',
             height: virtualizedMessageViewportHeight,
@@ -232,7 +237,7 @@ export function ChatThreadMessages({
       ) : (
         <div
           ref={totalSizeRef}
-          className='mx-auto flex min-h-full w-full max-w-[44rem] flex-col'
+          className={`${CHAT_CONTENT_SHELL_CLASSNAME} flex min-h-full flex-col`}
           style={{
             paddingBottom: messageViewportPaddingBottom,
           }}
@@ -290,4 +295,9 @@ export function ChatLoadingConversationSkeleton() {
   );
 }
 
-export { CHAT_COMPOSER_DOCK_CLASSNAME, ChatEmptyStateComposerRegion };
+export {
+  CHAT_COMPOSER_DOCK_CLASSNAME,
+  CHAT_COMPOSER_SCROLL_FADE_CLASSNAME,
+  CHAT_COMPOSER_THREAD_SCROLL_PADDING_CLASSNAME,
+  ChatEmptyStateComposerRegion,
+};

--- a/apps/web/components/jovie/chat-layout.ts
+++ b/apps/web/components/jovie/chat-layout.ts
@@ -1,2 +1,16 @@
-export const CHAT_COMPOSER_DOCK_CLASSNAME =
-  'shrink-0 bg-(--linear-app-content-surface) px-4 pt-2 pb-4 max-lg:pb-[calc(1.5rem+env(safe-area-inset-bottom))] sm:px-5 sm:pt-2.5 lg:pb-5';
+/** Shared chat content width — composer and transcript share one column. */
+export const CHAT_CONTENT_SHELL_CLASSNAME = 'system-b-chat-content-shell';
+
+/** Thread composer dock — overlays the scroll viewport at the bottom. */
+export const CHAT_COMPOSER_DOCK_CLASSNAME = 'system-b-chat-composer-dock';
+
+/** Gradient veil so transcript copy fades behind the floating composer. */
+export const CHAT_COMPOSER_SCROLL_FADE_CLASSNAME =
+  'system-b-chat-composer-scroll-fade';
+
+/** Bottom inset so the last message can scroll behind the composer. */
+export const CHAT_COMPOSER_THREAD_SCROLL_PADDING_CLASSNAME =
+  'system-b-chat-composer-thread-scroll-padding';
+
+/** Inline max-width token for motion surfaces that cannot use the shell class. */
+export const CHAT_COMPOSER_MAX_WIDTH = '45rem';

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
@@ -3,6 +3,8 @@
 import type { ReactNode } from 'react';
 import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
 
+import { CHAT_CONTENT_SHELL_CLASSNAME } from '../chat-layout';
+
 export function ChatEmptyStateComposerRegion({
   above,
   children,
@@ -12,7 +14,7 @@ export function ChatEmptyStateComposerRegion({
 }) {
   return (
     <div
-      className='relative mx-auto flex min-h-full w-full max-w-[52rem] flex-col items-center justify-center px-1 py-8'
+      className={`${CHAT_CONTENT_SHELL_CLASSNAME} relative flex min-h-full flex-col items-center justify-center px-1 py-8`}
       data-testid='chat-empty-state-composer-region'
     >
       <div

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -17,6 +17,7 @@ import { serializeEntity, serializeSkill } from '@/lib/chat/tokens';
 import type { TranscriberErrorCode } from '@/lib/chat/transcriber';
 import { cn } from '@/lib/utils';
 
+import { CHAT_COMPOSER_MAX_WIDTH } from '../chat-layout';
 import { useSpeechRecognition } from '../hooks/useSpeechRecognition';
 import {
   HIDDEN_DIV_STYLES,
@@ -97,16 +98,17 @@ interface SurfaceGeometry {
 function geometryFor(
   mode: SurfaceMode,
   stacked: boolean,
-  variant: NonNullable<ChatInputProps['variant']>
+  variant: NonNullable<ChatInputProps['variant']>,
+  usePillLayout: boolean
 ): SurfaceGeometry {
   const width = '100%';
-  const isHero = variant === 'hero';
-  const maxWidth = isHero
-    ? 'min(calc(100vw - 32px), 840px)'
-    : 'min(calc(100vw - 32px), 720px)';
+  const maxWidth = `min(calc(100vw - 32px), ${CHAT_COMPOSER_MAX_WIDTH})`;
   if (stacked) return { width, maxWidth, borderRadius: 28 };
-  if (isHero && mode !== 'entity') return { width, maxWidth, borderRadius: 36 };
   if (mode === 'entity') return { width, maxWidth, borderRadius: 24 };
+  if (variant === 'hero' && usePillLayout) {
+    return { width, maxWidth, borderRadius: 999 };
+  }
+  if (variant === 'hero') return { width, maxWidth, borderRadius: 24 };
   return { width, maxWidth, borderRadius: 28 };
 }
 
@@ -575,7 +577,16 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
     else if (picker.state.status === 'root') surfaceMode = 'root';
     else if (hasText || plusMenuOpen || isListening) surfaceMode = 'typing';
 
-    const geometry = geometryFor(surfaceMode, isStacked, variant);
+    const hasInlineContent = Boolean(value.trim()) || hasChips;
+    const hasOnlyRootSlashQuery =
+      picker.state.status === 'root' &&
+      value.trim().startsWith('/') &&
+      !hasChips;
+    const useHeroPill =
+      isHero &&
+      !hasPendingFiles &&
+      (!hasInlineContent || hasOnlyRootSlashQuery);
+    const geometry = geometryFor(surfaceMode, isStacked, variant, useHeroPill);
     const showInlinePicker = picker.state.status === 'root';
     const showEntitySurface = picker.state.status === 'entity';
     const reserveInlinePickerSpace =
@@ -985,8 +996,10 @@ function InputRow({
 
   return (
     <div className={cn(hasBorderTop && 'system-b-chat-composer-seam border-t')}>
-      <div
+      <motion.div
+        layout={!reducedMotion}
         ref={containerRef}
+        transition={reducedMotion ? undefined : TRANSITION_SURFACE}
         className={cn(
           'relative',
           useHeroPill
@@ -1123,7 +1136,7 @@ function InputRow({
             />
           </div>
         </div>
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -113,8 +113,10 @@
   --system-b-chat-action-card-min-height-compact: 132px;
   --system-b-chat-action-card-icon-size: 28px;
   --system-b-chat-action-card-primary-height: 32px;
-  --system-b-chat-message-content-max: 44rem;
+  --system-b-chat-message-content-max: 45rem;
   --system-b-chat-composer-max-width: 45rem;
+  --system-b-chat-composer-thread-scroll-padding: 9rem;
+  --system-b-chat-composer-scroll-fade-height: 7rem;
   --system-b-chat-loading-composer-height: 88px;
   --system-b-duration-fast: var(--ds-motion-subtle-duration);
   --system-b-ease: var(--ds-motion-subtle-easing);
@@ -7929,6 +7931,51 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 
 .system-b-copy-link-icon[data-visible="true"] {
   opacity: 1;
+}
+
+:where(.system-b-chat-content-shell) {
+  width: 100%;
+  max-width: var(--system-b-chat-composer-max-width);
+  margin-inline: auto;
+}
+
+:where(.system-b-chat-composer-dock) {
+  position: absolute;
+  z-index: 10;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: var(--space-2) var(--space-4)
+    calc(var(--space-4) + env(safe-area-inset-bottom));
+  background: var(--system-b-app-content-surface);
+}
+
+@media (min-width: 640px) {
+  :where(.system-b-chat-composer-dock) {
+    padding: calc(var(--space-2) + var(--space-0-5)) var(--space-5)
+      var(--space-5);
+  }
+}
+
+:where(.system-b-chat-composer-scroll-fade) {
+  pointer-events: none;
+  position: absolute;
+  z-index: 5;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: var(--system-b-chat-composer-scroll-fade-height);
+  background: linear-gradient(
+    to top,
+    var(--system-b-app-content-surface) 0%,
+    color-mix(in oklab, var(--system-b-app-content-surface) 80%, transparent)
+      45%,
+    transparent 100%
+  );
+}
+
+:where(.system-b-chat-composer-thread-scroll-padding) {
+  padding-bottom: var(--system-b-chat-composer-thread-scroll-padding);
 }
 
 :where(.system-b-chat-composer-surface) {

--- a/apps/web/tests/e2e/shell-chat-v1.spec.ts
+++ b/apps/web/tests/e2e/shell-chat-v1.spec.ts
@@ -348,7 +348,7 @@ test('chat route renders the Shell V1 app frame when forced on', async ({
   await expect(chatContent).toBeVisible({ timeout: 30_000 });
   await expect(composer).toHaveCSS(
     'border-radius',
-    /^(?:999px|18px|20px|24px|28px|36px)$/
+    /^(?:999px|18px|20px|24px|28px|36px|45rem)$/
   );
   await expect(page.locator('.animate-shell-in')).toHaveCount(0);
 });

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -348,8 +348,8 @@ describe('ChatInput', () => {
 
     const surface = screen.getByTestId('chat-composer-surface');
     expect(surface.getAttribute('data-variant')).toBe('hero');
-    expect(surface.style.maxWidth).toBe('min(calc(100vw - 32px), 840px)');
-    expect(surface.style.borderRadius).toBe('36px');
+    expect(surface.style.maxWidth).toBe('min(calc(100vw - 32px), 45rem)');
+    expect(surface.style.borderRadius).toBe('999px');
 
     expect(surface.firstElementChild?.firstElementChild?.className).toContain(
       'min-h-13'
@@ -378,7 +378,7 @@ describe('ChatInput', () => {
     );
 
     const surface = screen.getByTestId('chat-composer-surface');
-    expect(surface.style.borderRadius).toBe('36px');
+    expect(surface.style.borderRadius).toBe('24px');
 
     expect(surface.firstElementChild?.firstElementChild?.className).toContain(
       'min-h-22'
@@ -418,7 +418,7 @@ describe('ChatInput', () => {
     );
 
     const surface = screen.getByTestId('chat-composer-surface');
-    expect(surface.style.borderRadius).toBe('36px'); // geometry still 36 for hero non-entity
+    expect(surface.style.borderRadius).toBe('24px'); // expanded hero geometry with attachments
 
     const inlineField = screen.getByTestId('chat-input-inline-field');
     const container = inlineField.parentElement;

--- a/apps/web/tests/unit/chat/JovieChat.styling.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.styling.test.tsx
@@ -192,9 +192,7 @@ describe('JovieChat styling regressions', () => {
       ?.parentElement?.parentElement;
 
     expect(composerDock?.className).toContain(CHAT_COMPOSER_DOCK_CLASSNAME);
-    expect(composerDock?.className).toContain(
-      'max-lg:pb-[calc(1.5rem+env(safe-area-inset-bottom))]'
-    );
+    expect(composerDock?.className).toContain('system-b-chat-composer-dock');
   });
 
   it('marks runtime conversation loading shell as busy for assistive technology', () => {

--- a/apps/web/tests/unit/chat/chat-composer-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-composer-system-b-style-guard.test.ts
@@ -41,6 +41,10 @@ describe('chat composer System B source contract', () => {
     );
 
     for (const className of [
+      'system-b-chat-content-shell',
+      'system-b-chat-composer-dock',
+      'system-b-chat-composer-scroll-fade',
+      'system-b-chat-composer-thread-scroll-padding',
       'system-b-chat-composer-surface',
       'system-b-chat-composer-picker-shell',
       'system-b-chat-composer-icon-button',

--- a/apps/web/tests/unit/chat/chat-loading-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-loading-system-b-style-guard.test.ts
@@ -39,7 +39,7 @@ function extractConversationLoadingBranch(source: string) {
   const start = source.indexOf(
     'export function ChatLoadingConversationSkeleton'
   );
-  const end = source.indexOf('export { CHAT_COMPOSER_DOCK_CLASSNAME', start);
+  const end = source.indexOf('CHAT_COMPOSER_DOCK_CLASSNAME,', start);
 
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);


### PR DESCRIPTION
## Goal
Align the chat composer with ChatGPT-style layout: one unified content width, transcript scroll-behind fade, smooth hero pill→multiline morph, and corrected expanded border radius.

Closes JOV-3594

## Changes
- Add System B primitives: `system-b-chat-content-shell`, `system-b-chat-composer-dock`, `system-b-chat-composer-scroll-fade`, `system-b-chat-composer-thread-scroll-padding`
- Unify composer + transcript width to `45rem` via shared shell class
- Float thread composer dock over scroll viewport with gradient fade veil
- Hero empty state uses pill radius (`999px`); expanded hero uses `24px` (was over-rounded `36px`)
- Animate InputRow pill→multiline transition with motion layout
- Update unit tests and style-guard contracts

## Testing
- `pnpm exec vitest run tests/unit/chat/ChatInput.test.tsx tests/unit/chat/chat-composer-system-b-style-guard.test.ts tests/unit/chat/JovieChat.styling.test.tsx tests/unit/chat/JovieChat.empty-state.test.tsx`
- Typecheck + lint pass via pre-push hooks

Generated with Claude Code