### PR TITLE
fix(tests): harden agnost org-id guard against env drift (JOV-3600)

### DIFF
--- a/apps/web/lib/observability/agnost.ts
+++ b/apps/web/lib/observability/agnost.ts
@@ -11,7 +11,7 @@ const AGNOST_OTEL_ENDPOINT = 'https://otel.agnost.ai/v1/traces';
 /** Bounded OTLP export — observability sink must not hang cold starts. */
 const AGNOST_OTEL_TIMEOUT_MS = 10_000;
 
-const DEFAULT_AGNOST_ORG_ID = '3e2d4388-5d86-41f5-8f67-4a3bac08d72f';
+export const DEFAULT_AGNOST_ORG_ID = '3e2d4388-5d86-41f5-8f67-4a3bac08d72f';
 
 let agnostStarted = false;
 

--- a/apps/web/tests/unit/lib/observability/agnost.test.ts
+++ b/apps/web/tests/unit/lib/observability/agnost.test.ts
@@ -1,44 +1,50 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 describe('agnost telemetry guards', () => {
-  const originalEnv = { ...process.env };
-
   afterEach(() => {
-    process.env = { ...originalEnv };
+    vi.unstubAllEnvs();
     vi.resetModules();
   });
 
   it('disables export in CI', async () => {
-    process.env.CI = 'true';
+    vi.stubEnv('CI', 'true');
     const { shouldEnableAgnost } = await import('@/lib/observability/agnost');
     expect(shouldEnableAgnost()).toBe(false);
   });
 
   it('disables export in local dev unless explicitly enabled', async () => {
-    process.env.CI = 'false';
-    process.env.NODE_ENV = 'development';
-    delete process.env.JOVIE_ENABLE_AGNOST;
+    vi.stubEnv('CI', 'false');
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('JOVIE_ENABLE_AGNOST', '');
     const { shouldEnableAgnost } = await import('@/lib/observability/agnost');
     expect(shouldEnableAgnost()).toBe(false);
   });
 
   it('disables export in local E2E runtime', async () => {
-    process.env.CI = 'false';
-    process.env.NODE_ENV = 'test';
-    process.env.NEXT_PUBLIC_E2E_MODE = '1';
-    process.env.JOVIE_ENABLE_AGNOST = '1';
+    vi.stubEnv('CI', 'false');
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('NEXT_PUBLIC_E2E_MODE', '1');
+    vi.stubEnv('JOVIE_ENABLE_AGNOST', '1');
     const { shouldEnableAgnost } = await import('@/lib/observability/agnost');
     expect(shouldEnableAgnost()).toBe(false);
   });
 
   it('enables export in production with default org id', async () => {
-    process.env.CI = 'false';
-    process.env.NODE_ENV = 'production';
+    vi.stubEnv('CI', 'false');
+    vi.stubEnv('NODE_ENV', 'production');
     delete process.env.AGNOST_ORG_ID;
-    const { shouldEnableAgnost, getAgnostOrgId } = await import(
-      '@/lib/observability/agnost'
-    );
+    const { shouldEnableAgnost, getAgnostOrgId, DEFAULT_AGNOST_ORG_ID } =
+      await import('@/lib/observability/agnost');
     expect(shouldEnableAgnost()).toBe(true);
-    expect(getAgnostOrgId()).toBe('3e2d4388-5d86-41f5-8f67-4a3bac08d72f');
+    expect(getAgnostOrgId()).toBe(DEFAULT_AGNOST_ORG_ID);
+  });
+
+  it('prefers AGNOST_ORG_ID when explicitly configured', async () => {
+    const configuredOrgId = '384ebd06-d9a5-48dd-ba22-7a51e430c173';
+    vi.stubEnv('CI', 'false');
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('AGNOST_ORG_ID', configuredOrgId);
+    const { getAgnostOrgId } = await import('@/lib/observability/agnost');
+    expect(getAgnostOrgId()).toBe(configuredOrgId);
   });
 });


### PR DESCRIPTION
Linear: https://linear.app/jovie/issue/JOV-3600

<!-- linear-issue-id:JOV-3600 -->

## Goal

Deflake the unit-test guard for Agnost telemetry org ID resolution so CI secrets and default-constant drift cannot cause intermittent shard failures.

## Root cause

CI logs showed `tests/unit/lib/observability/agnost.test.ts > enables export in production with default org id` failing when the test's hardcoded UUID drifted from `DEFAULT_AGNOST_ORG_ID` (post #12036) or when `AGNOST_ORG_ID` leaked from CI env.

## Changes

- Export `DEFAULT_AGNOST_ORG_ID` from `agnost.ts` and assert against it in tests (no duplicated UUID)
- Switch env setup to `vi.stubEnv` + explicit `delete process.env.AGNOST_ORG_ID` for default-path isolation
- Add regression coverage for explicit `AGNOST_ORG_ID` override behavior

## Testing

- `pnpm --filter @jovie/web exec vitest run tests/unit/lib/observability/agnost.test.ts` (5/5 pass)
- Re-run 5x with leaked `AGNOST_ORG_ID=384ebd06-...` in env (5/5 pass)
- `pnpm --filter @jovie/web run typecheck`
- `pnpm biome check --write` on touched files

## Rollback

Revert this PR; no runtime behavior change beyond exporting an existing constant.

bug-to-test: not applicable — deflake hardening for existing telemetry guard