### PR TITLE
feat(shell): cinematic right-rail toggle + artist profile header control (JOV-3599)

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -1016,8 +1016,7 @@ export function ChatEntityRightPanelHost({
   profileContext,
   threadTitle,
 }: Readonly<ChatEntityRightPanelHostProps>) {
-  const { isOpen: isPreviewPanelOpen, open: openPreviewPanel } =
-    usePreviewPanelState();
+  const { open: openPreviewPanel } = usePreviewPanelState();
   const { target, contextTargets, close, dismissContext } =
     useChatEntityPanel();
 
@@ -1071,14 +1070,13 @@ export function ChatEntityRightPanelHost({
       }
     }
 
-    const liveProfilePreview =
-      enablePreviewPanel && isPreviewPanelOpen ? (
-        <ErrorBoundary fallback={null}>
-          <div className='system-b-chat-profile-preview-card'>
-            <ProfileContactSidebar />
-          </div>
-        </ErrorBoundary>
-      ) : null;
+    const liveProfilePreview = enablePreviewPanel ? (
+      <ErrorBoundary fallback={null}>
+        <div className='system-b-chat-profile-preview-card'>
+          <ProfileContactSidebar />
+        </div>
+      </ErrorBoundary>
+    ) : null;
 
     if (contextCards && entityPanel) {
       return (
@@ -1148,7 +1146,6 @@ export function ChatEntityRightPanelHost({
     enableChatEntityPanels,
     enablePreviewPanel,
     handleOpenProfilePreview,
-    isPreviewPanelOpen,
     profileId,
     profileSpotifyArtistId,
     profileContext,

--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -32,6 +32,7 @@ import { JovieChat } from '@/components/jovie/JovieChat';
 import type { ChatActionCard } from '@/components/jovie/types';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
+import { ArtistProfileRailToggle } from '@/components/shell/ArtistProfileRailToggle';
 import { APP_ROUTES } from '@/constants/routes';
 import { useSetHeaderActions } from '@/contexts/HeaderActionsContext';
 import { DASHBOARD_HEADER_ACTION_ICON_BUTTON_CLASS } from '@/features/dashboard/atoms/DashboardHeaderActionButton';
@@ -487,38 +488,46 @@ export function ChatPageClient({
   }, [conversationId, deleteConversation, router, notifications]);
 
   const headerActions = useMemo(() => {
+    const artistProfileToggle = designV1ChatEntitiesEnabled ? (
+      <ArtistProfileRailToggle />
+    ) : null;
+
     if (!conversationId) {
-      return null;
+      return artistProfileToggle;
     }
 
     return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <AppIconButton
-            ariaLabel='Thread options'
-            className={DASHBOARD_HEADER_ACTION_ICON_BUTTON_CLASS}
-          >
-            <Ellipsis aria-hidden='true' className='size-4' />
-          </AppIconButton>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align='end'>
-          <DropdownMenuItem onClick={handleCopyConversationId}>
-            {sessionIdCopied ? (
-              <Check aria-hidden='true' className='size-3.5' />
-            ) : (
-              <Copy aria-hidden='true' className='size-3.5' />
-            )}
-            {sessionIdCopied ? 'Copied!' : 'Copy Session ID'}
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleArchive}>
-            <Archive aria-hidden='true' className='size-3.5' />
-            Archive
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <div className='flex items-center gap-1'>
+        {artistProfileToggle}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <AppIconButton
+              ariaLabel='Thread options'
+              className={DASHBOARD_HEADER_ACTION_ICON_BUTTON_CLASS}
+            >
+              <Ellipsis aria-hidden='true' className='size-4' />
+            </AppIconButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='end'>
+            <DropdownMenuItem onClick={handleCopyConversationId}>
+              {sessionIdCopied ? (
+                <Check aria-hidden='true' className='size-3.5' />
+              ) : (
+                <Copy aria-hidden='true' className='size-3.5' />
+              )}
+              {sessionIdCopied ? 'Copied!' : 'Copy Session ID'}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleArchive}>
+              <Archive aria-hidden='true' className='size-3.5' />
+              Archive
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
     );
   }, [
     conversationId,
+    designV1ChatEntitiesEnabled,
     sessionIdCopied,
     handleCopyConversationId,
     handleArchive,

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { TooltipProvider } from '@jovie/ui';
+import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
 import {
   useCallback,
@@ -13,6 +14,8 @@ import {
 import { PreviewPanelProvider } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import { UpdateAvailablePill } from '@/components/atoms/UpdateAvailablePill';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
+import { ArtistProfileRailToggle } from '@/components/shell/ArtistProfileRailToggle';
+import { APP_ROUTES } from '@/constants/routes';
 import {
   HeaderActionsProvider,
   useHeaderActions,
@@ -35,6 +38,7 @@ import { useAuthRouteConfig } from '@/hooks/useAuthRouteConfig';
 import { useDashboardShortcuts } from '@/hooks/useDashboardShortcuts';
 import { useGlobalShortcutActions } from '@/hooks/useGlobalShortcutActions';
 import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
+import { useAppFlag } from '@/lib/flags/client';
 import { AuthShell } from './AuthShell';
 import { CommandPalette } from './CommandPalette';
 import { KeyboardShortcutsSheet } from './keyboard-shortcuts-sheet';
@@ -78,8 +82,10 @@ function AuthShellWrapperInner({
   children: ReactNode;
 }>) {
   const config = useAuthRouteConfig();
+  const pathname = usePathname();
   const headerActions = useHeaderActions();
   const isElectron = useIsElectronRuntime();
+  const shellChatV1Enabled = useAppFlag('DESIGN_V1');
   const [, startTransition] = useTransition();
   const [pendingShellRoute, setPendingShellRoute] =
     useState<PendingShellRoute>(null);
@@ -105,18 +111,30 @@ function AuthShellWrapperInner({
     ? 'artist-profile-settings'
     : 'app-shell';
 
+  const showArtistProfileRailToggle =
+    shellChatV1Enabled &&
+    previewEnabled &&
+    !config.isDemoRoute &&
+    (config.isChatRoute || pathname === APP_ROUTES.DASHBOARD);
+
   // Determine header action: use custom actions from context if available,
   // otherwise fall back to default based on route type
   const defaultHeaderAction = useMemo(
     () => (
       <>
+        {showArtistProfileRailToggle ? <ArtistProfileRailToggle /> : null}
         {config.showChatUsageIndicator && !config.isDemoRoute ? (
           <HeaderChatUsageIndicator />
         ) : null}
         {isElectron ? null : <UpdateAvailablePill />}
       </>
     ),
-    [config.isDemoRoute, config.showChatUsageIndicator, isElectron]
+    [
+      config.isDemoRoute,
+      config.showChatUsageIndicator,
+      isElectron,
+      showArtistProfileRailToggle,
+    ]
   );
   // Wrap page-injected header elements in ErrorBoundary so a throwing badge/action
   // degrades gracefully (renders nothing + toast) instead of crashing the shell.

--- a/apps/web/components/shell/AppShellRightRail.tsx
+++ b/apps/web/components/shell/AppShellRightRail.tsx
@@ -36,9 +36,12 @@ export function AppShellRightRail({
     <aside
       data-testid='app-shell-right-rail'
       data-shell-design={variant}
-      aria-label='Context panel'
+      aria-label='Context Panel'
       className={cn(
         'sticky top-0 z-10 flex h-full min-h-0 shrink-0 flex-col self-start overflow-hidden',
+        // Mirror the left sidebar mount language so inner drawer width changes
+        // reclaim canvas space with the same cinematic timing.
+        'transition-[width,opacity,transform] duration-cinematic ease-cinematic motion-reduce:transition-none',
         isShellChatV1 && 'lg:rounded-[var(--linear-app-shell-radius)]',
         className
       )}

--- a/apps/web/components/shell/ArtistProfileRailToggle.tsx
+++ b/apps/web/components/shell/ArtistProfileRailToggle.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { TooltipShortcut } from '@jovie/ui';
+import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
+import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
+import { Avatar } from '@/components/molecules/Avatar';
+import { RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE } from '@/hooks/useRightRailKeyboardShortcut';
+import { cn } from '@/lib/utils';
+
+/**
+ * Shell header control for opening/closing the artist profile right rail on
+ * home + chat routes. Uses preview-panel state so the rail stays mounted and
+ * RightDrawer can run the cinematic width transition.
+ */
+export function ArtistProfileRailToggle() {
+  const { selectedProfile } = useDashboardData();
+  const { isOpen, toggle } = usePreviewPanelState();
+
+  const displayName = selectedProfile?.displayName?.trim() || 'Artist profile';
+  const label = isOpen
+    ? `Hide ${displayName} profile`
+    : `Show ${displayName} profile`;
+
+  return (
+    <TooltipShortcut
+      label={label}
+      shortcut={RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE}
+      side='bottom'
+    >
+      <button
+        type='button'
+        data-testid='artist-profile-rail-toggle'
+        aria-label={label}
+        aria-pressed={isOpen}
+        onClick={toggle}
+        className={cn(
+          'inline-flex h-7 max-w-44 items-center gap-1.5 rounded-full px-1.5',
+          'text-xs font-semibold text-secondary-token',
+          'transition-[background,color,opacity] duration-subtle ease-subtle',
+          'hover:bg-surface-0 hover:text-primary-token',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+          isOpen && 'bg-surface-0 text-primary-token'
+        )}
+      >
+        <Avatar
+          src={selectedProfile?.avatarUrl}
+          alt={displayName}
+          size='xs'
+          className='size-5 shrink-0 rounded-full'
+        />
+        <span className='hidden truncate sm:inline'>{displayName}</span>
+      </button>
+    </TooltipShortcut>
+  );
+}

--- a/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
+++ b/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
@@ -12,8 +12,14 @@ describe('AppShellRightRail', () => {
 
     const rail = screen.getByTestId('app-shell-right-rail');
 
-    expect(rail).toHaveAttribute('aria-label', 'Context panel');
-    expect(rail).toHaveClass('sticky', 'top-0', 'overflow-hidden');
+    expect(rail).toHaveAttribute('aria-label', 'Context Panel');
+    expect(rail).toHaveClass(
+      'sticky',
+      'top-0',
+      'overflow-hidden',
+      'duration-cinematic',
+      'ease-cinematic'
+    );
     expect(rail).toContainElement(screen.getByTestId('fixture-panel'));
   });
 

--- a/apps/web/components/shell/__tests__/ArtistProfileRailToggle.test.tsx
+++ b/apps/web/components/shell/__tests__/ArtistProfileRailToggle.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArtistProfileRailToggle } from '../ArtistProfileRailToggle';
+
+const toggleMock = vi.fn();
+let mockIsOpen = false;
+
+vi.mock('@/app/app/(shell)/dashboard/PreviewPanelContext', () => ({
+  usePreviewPanelState: () => ({
+    isOpen: mockIsOpen,
+    toggle: toggleMock,
+  }),
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
+  useDashboardData: () => ({
+    selectedProfile: {
+      displayName: 'Tim White',
+      avatarUrl: 'https://example.com/avatar.jpg',
+    },
+  }),
+}));
+
+vi.mock('@jovie/ui', () => ({
+  TooltipShortcut: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe('ArtistProfileRailToggle', () => {
+  beforeEach(() => {
+    mockIsOpen = false;
+    toggleMock.mockReset();
+  });
+
+  it('renders the artist name and toggles the preview panel', async () => {
+    const user = userEvent.setup();
+
+    render(<ArtistProfileRailToggle />);
+
+    const button = screen.getByTestId('artist-profile-rail-toggle');
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+    expect(button).toHaveAttribute('aria-label', 'Show Tim White profile');
+    expect(screen.getByText('Tim White')).toBeInTheDocument();
+
+    await user.click(button);
+    expect(toggleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects the open pressed state', () => {
+    mockIsOpen = true;
+
+    render(<ArtistProfileRailToggle />);
+
+    expect(screen.getByTestId('artist-profile-rail-toggle')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByTestId('artist-profile-rail-toggle')).toHaveAttribute(
+      'aria-label',
+      'Hide Tim White profile'
+    );
+  });
+});

--- a/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
+++ b/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
@@ -279,7 +279,7 @@ describe('ChatEntityRightPanelHost', () => {
     });
   });
 
-  it('registers no right panel when preview is closed', () => {
+  it('keeps the profile sidebar mounted when preview is closed for cinematic close', () => {
     mockPreviewPanelOpen = false;
     mockUseRegisterRightPanel.mockClear();
 
@@ -289,7 +289,8 @@ describe('ChatEntityRightPanelHost', () => {
       </ChatEntityPanelProvider>
     );
 
-    expect(mockUseRegisterRightPanel).toHaveBeenLastCalledWith(null);
+    expect(mockUseRegisterRightPanel).toHaveBeenCalled();
+    expect(mockUseRegisterRightPanel.mock.calls.at(-1)?.[0]).not.toBeNull();
   });
 
   it('registers the profile sidebar when preview is open', () => {

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -382,10 +382,16 @@ describe('ChatPageClient', () => {
     );
   });
 
-  it('does not register chat header actions on the new-chat route', () => {
+  it('registers the artist profile rail toggle on the new-chat route', () => {
     renderChatPage();
 
-    expect(mockSetHeaderActions).toHaveBeenCalledWith(null);
+    const headerActions = mockSetHeaderActions.mock.calls.at(-1)?.[0];
+    expect(headerActions).not.toBeNull();
+    expect(headerActions).toEqual(
+      expect.objectContaining({
+        type: expect.anything(),
+      })
+    );
   });
 
   it('hydrates preview data on chat and registers the live profile panel when preview is open', () => {
@@ -402,12 +408,12 @@ describe('ChatPageClient', () => {
     );
   });
 
-  it('keeps preview data hydrated on chat even when the profile panel is closed', () => {
+  it('keeps the profile panel mounted on chat when closed so the rail can animate shut', () => {
     mockPreviewPanelState.isOpen = false;
 
     renderChatPage();
 
-    expect(hasRegisteredRightPanel()).toBe(false);
+    expect(hasRegisteredRightPanel()).toBe(true);
     expect(mockSetPreviewData).toHaveBeenCalledWith(
       expect.objectContaining({
         username: 'testartist',


### PR DESCRIPTION
## Goal
Add a slick cinematic open/close for the artist profile right rail on home + chat, and expose a top-right artist-profile toggle in the app shell header.

## Changes
- Keep `ProfileContactSidebar` mounted on `/app` + `/app/chat` even when the preview panel is closed so `RightDrawer` can run the cinematic width transition instead of unmounting the rail
- Add `ArtistProfileRailToggle` (avatar + name) in the shell header for home/chat routes, wired to `usePreviewPanelState`
- Include the toggle alongside thread options in `ChatPageClient` header actions
- Mirror left-sidebar cinematic timing on `AppShellRightRail` container transitions

## Testing
- `pnpm exec vitest run apps/web/components/shell/__tests__/ArtistProfileRailToggle.test.tsx`
- `pnpm exec vitest run apps/web/components/shell/__tests__/AppShellRightRail.test.tsx`
- `pnpm exec vitest run apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx`
- `pnpm exec vitest run apps/web/tests/unit/chat/ChatPageClient.test.tsx`

Linear: JOV-3599

Co-authored-by: Cursor <cursoragent@cursor.com>