### PR TITLE
docs(memory): ADR — split product memory workflows from internal AgentOS WDK (JOV-2705)

### DIFF
--- a/apps/web/tests/unit/memory/memory-adr-contract.test.ts
+++ b/apps/web/tests/unit/memory/memory-adr-contract.test.ts
@@ -1,0 +1,158 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(process.cwd(), '../..');
+const MEMORY_ADR_PATH = join(REPO_ROOT, 'docs/MEMORY_ADR.md');
+const WEB_ROOT = join(REPO_ROOT, 'apps/web');
+
+const REQUIRED_ADR_SECTIONS = [
+  '## Decision',
+  '## Scope',
+  '## Context',
+  '## Current file map',
+  '## Forbidden couplings',
+] as const;
+
+const PRODUCT_MEMORY_PATHS = [
+  'lib/memory',
+  'lib/workflows/memory',
+  'lib/agents/agent-harness.ts',
+  'app/api/memory',
+] as const;
+
+const INTERNAL_AGENTOS_WDK_PATHS = [
+  'workflows/agent-os-dry-run.ts',
+  'lib/agent-os/workflows.ts',
+] as const;
+
+const FORBIDDEN_PRODUCT_IMPORT_MARKERS = [
+  '@/workflows/agent-os-dry-run',
+  '@/lib/agent-os/workflows',
+  "from 'workflow'",
+  'from "workflow"',
+] as const;
+
+const FORBIDDEN_AGENTOS_IMPORT_MARKERS = [
+  '@/lib/memory',
+  '@/lib/workflows/memory',
+  '@/lib/agents/agent-harness',
+] as const;
+
+function collectSourceFiles(
+  absoluteDir: string,
+  relativePrefix: string
+): string[] {
+  const entries = readdirSync(absoluteDir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const absolutePath = join(absoluteDir, entry.name);
+    const relativePath = join(relativePrefix, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(absolutePath, relativePath));
+      continue;
+    }
+
+    if (
+      /\.(ts|tsx)$/.test(entry.name) &&
+      !/\.test\.(ts|tsx)$/.test(entry.name)
+    ) {
+      files.push(relativePath);
+    }
+  }
+
+  return files;
+}
+
+function readBoundedSource(relativePath: string): string {
+  const absolutePath = join(WEB_ROOT, relativePath);
+  expect(existsSync(absolutePath), `${relativePath} missing`).toBe(true);
+  return readFileSync(absolutePath, 'utf8');
+}
+
+function findForbiddenImports(
+  source: string,
+  markers: readonly string[]
+): string[] {
+  return markers.filter(marker => source.includes(marker));
+}
+
+describe('MEMORY ADR contract (JOV-2705)', () => {
+  it('keeps docs/MEMORY_ADR.md present with required decision sections', () => {
+    expect(existsSync(MEMORY_ADR_PATH)).toBe(true);
+
+    const adr = readFileSync(MEMORY_ADR_PATH, 'utf8');
+    expect(adr).toContain('Issue: JOV-2705');
+    expect(adr).toContain('Internal AgentOS');
+    expect(adr).toContain('Product memory workflows');
+    expect(adr).toContain('WorkflowRunner');
+
+    for (const section of REQUIRED_ADR_SECTIONS) {
+      expect(adr, `missing ${section}`).toContain(section);
+    }
+  });
+
+  it('links AgentOS architecture without collapsing the runtime split', () => {
+    const agentOsAdrPath = join(REPO_ROOT, 'docs/AGENT_OS_ARCHITECTURE.md');
+    expect(existsSync(agentOsAdrPath)).toBe(true);
+
+    const agentOsAdr = readFileSync(agentOsAdrPath, 'utf8');
+    expect(agentOsAdr).toContain('MEMORY_ADR.md');
+    expect(agentOsAdr).toContain('JOV-2705');
+  });
+
+  it('blocks product memory modules from importing AgentOS WDK workflow code', () => {
+    const violations: string[] = [];
+
+    for (const root of PRODUCT_MEMORY_PATHS) {
+      const absoluteRoot = join(WEB_ROOT, root);
+      expect(existsSync(absoluteRoot), `${root} missing`).toBe(true);
+
+      const files = statSync(absoluteRoot).isDirectory()
+        ? collectSourceFiles(absoluteRoot, root)
+        : [root];
+
+      for (const file of files) {
+        const forbidden = findForbiddenImports(
+          readBoundedSource(file),
+          FORBIDDEN_PRODUCT_IMPORT_MARKERS
+        );
+        if (forbidden.length > 0) {
+          violations.push(
+            `${file} imports forbidden AgentOS marker(s): ${forbidden.join(', ')}`
+          );
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('blocks internal AgentOS WDK modules from importing product memory code', () => {
+    const violations: string[] = [];
+
+    for (const file of INTERNAL_AGENTOS_WDK_PATHS) {
+      const forbidden = findForbiddenImports(
+        readBoundedSource(file),
+        FORBIDDEN_AGENTOS_IMPORT_MARKERS
+      );
+      if (forbidden.length > 0) {
+        violations.push(
+          `${file} imports forbidden product-memory marker(s): ${forbidden.join(', ')}`
+        );
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('documents the guardrail beside the ADR for future editors', () => {
+    const adr = readFileSync(MEMORY_ADR_PATH, 'utf8');
+    const testPath = 'apps/web/tests/unit/memory/memory-adr-contract.test.ts';
+
+    expect(adr).toContain(testPath);
+    expect(relative(REPO_ROOT, MEMORY_ADR_PATH)).toBe('docs/MEMORY_ADR.md');
+  });
+});

--- a/docs/AGENT_OS_ARCHITECTURE.md
+++ b/docs/AGENT_OS_ARCHITECTURE.md
@@ -98,6 +98,10 @@ Do not install Trigger in this wave. Revisit it only if WDK fails one of these p
 - Retry/resume/step behavior cannot be tested reliably in CI.
 - Jovie needs a self-hosted durable worker outside Vercel's execution model.
 
+## Related ADRs
+
+- [`docs/MEMORY_ADR.md`](./MEMORY_ADR.md) (JOV-2705) — product memory workflows use a separate durable runtime from internal AgentOS WDK. Customer memory loops must not import `workflows/agent-os-dry-run.ts`; WDK remains internal operator orchestration only.
+
 ## Linear Dedupe
 
 Duplicates linked during this ADR:

--- a/docs/MEMORY_ADR.md
+++ b/docs/MEMORY_ADR.md
@@ -1,0 +1,112 @@
+# MEMORY ADR — Split Product Memory Workflows from Internal AgentOS WDK
+
+> Issue: JOV-2705
+> Status: Accepted
+> Date: 2026-06-27
+> Parent: JOV-2704 (memory-ship-v0-studio-session-memory-loop)
+> Schema: JOV-2706 (Memory Core v0 evidence-backed entity graph)
+
+## Decision
+
+Product memory workflows and internal AgentOS orchestration use **separate durable runtimes**:
+
+1. **Internal AgentOS / Hermes / Ruflo experiments** — Vercel Workflow/WDK only. This path proves operator coordination (`AgentRunArtifact` emission, dry-run gates, admin visibility) and must never write customer memory rows or call product harness code.
+
+2. **Customer-facing product memory workflows** — Trigger.dev behind a `WorkflowRunner` interface once production durability is required. Until that interface ships, product memory loops run inline from API routes, cron hooks, or demo scripts — **not** through AgentOS WDK workflows.
+
+3. **Product cognition harness** — OpenAI Agents SDK (or equivalent) behind `AgentHarness`, writing only to `memory_*` tables via `lib/memory/*`. WDK coordinates internal ops; it does not orchestrate creator memory ingestion.
+
+**Ship now:** keep the runtimes split at the module boundary; product memory never imports AgentOS WDK workflow code.
+**Re-evaluate when:** first production memory workflow needs cross-step resume, retry, or customer-visible run status outside a request handler.
+**Then:** implement `WorkflowRunner` with `TriggerWorkflowRunner` for product paths; keep `WDKWorkflowRunner` internal-only.
+
+## Scope
+
+### In scope (this ADR)
+
+- Durable runtime selection for memory ingestion/enrichment/opportunity loops
+- Import boundaries between `lib/memory/*`, `lib/workflows/memory/*`, and AgentOS WDK
+- Where `AgentHarness` and `WorkflowRunner` live relative to `workflows/agent-os-dry-run.ts`
+
+### Out of scope
+
+- Agent session memory (`MEMORY.md`, gbrain founder recall) — see `docs/company/operating-principles.md`
+- AgentOS design-lab taste memory (`lib/agent-os/design-lab/taste-memory.ts`) — internal operator artifact, not product memory
+- Memory Core schema design — canonical in `apps/web/lib/db/schema/memory.ts` (JOV-2706)
+
+## Context
+
+AgentOS v1 selected Vercel Workflow/WDK as the internal durable coordinator ([`docs/AGENT_OS_ARCHITECTURE.md`](./AGENT_OS_ARCHITECTURE.md), JOV-1922). That decision covers **operator control plane** work: dry-run proof, gate evidence, Hermes/Ruflo dispatch visibility.
+
+Product memory has different constraints:
+
+| Aspect | Internal AgentOS WDK | Product memory workflows |
+| --- | --- | --- |
+| Runtime | `workflows/agent-os-dry-run.ts` + admin API | `lib/workflows/memory/*` → future `TriggerWorkflowRunner` |
+| Data writes | `AgentRunArtifact` only; no `memory_*` tables | `memory_*` tables via `lib/memory/*` |
+| Audience | Operators (`/app/admin/ops`) | Creators (scoped by `userId` + `creatorProfileId`) |
+| Durability bar | Dry-run / proof sufficient | Production retry, resume, audit trail |
+| SDK / harness | Deterministic artifact builders | `AgentHarness` + evidence-backed `MemoryStore` |
+
+Mixing these paths would let internal experiment tooling mutate creator memory or couple customer workflows to admin-only WDK compile gates.
+
+## Current file map
+
+```
+apps/web/lib/db/schema/memory.ts          # product memory SoT (12 tables)
+apps/web/lib/memory/*                     # ingest, graph, enrichment, review
+apps/web/lib/agents/agent-harness.ts      # studio-session harness (v0)
+apps/web/lib/workflows/memory/*           # product workflow entrypoints
+apps/web/app/api/memory/*                 # creator-scoped read APIs
+
+apps/web/workflows/agent-os-dry-run.ts    # internal WDK proof only
+apps/web/lib/agent-os/*                   # artifacts, gates, admin fixtures
+apps/web/app/api/admin/agent-os/*         # operator workflow APIs
+```
+
+v0 studio-session loop (`lib/workflows/memory/studio-session-loop.ts`) executes inline via `AgentHarness` when `MEMORY_STUDIO_SESSION_V0` is enabled. It does not enqueue AgentOS WDK runs.
+
+## Interface definitions (target)
+
+```typescript
+// apps/web/lib/workflows/workflow-runner.ts (not yet implemented)
+interface WorkflowRunner {
+  run(workflowId: string, input: unknown): Promise<WorkflowResult>;
+  getRun(runId: string): Promise<RunStatus>;
+}
+```
+
+Planned implementations:
+
+- `WDKWorkflowRunner` — internal AgentOS experiments only
+- `TriggerWorkflowRunner` — production product memory workflows
+
+`AgentHarness` selects the runner from configuration; product call sites must not import `@/workflows/agent-os-dry-run` or `workflow` directives directly.
+
+## Forbidden couplings
+
+| From | Must not import |
+| --- | --- |
+| `lib/memory/*`, `lib/workflows/memory/*`, `lib/agents/agent-harness.ts`, `app/api/memory/*` | `@/workflows/agent-os-dry-run`, `@/lib/agent-os/workflows`, `workflow` package |
+| `workflows/agent-os-dry-run.ts`, `lib/agent-os/workflows.ts` | `@/lib/memory/*`, `@/lib/workflows/memory/*`, `@/lib/agents/agent-harness` |
+
+## Configuration
+
+- Internal WDK: existing Vercel Workflow / `AGENT_OS_WORKFLOWS_ENABLED` gate
+- Product Trigger.dev (future): `TRIGGER_API_KEY` + task-scoped secrets; isolated from AgentOS admin routes
+
+## Related issues
+
+| Issue | Role |
+| --- | --- |
+| JOV-2704 | Parent memory-ship epic |
+| JOV-2706 | Memory Core schema |
+| JOV-1922 | AgentOS architecture ADR (internal WDK) |
+| JOV-1945 | Trigger.dev local worker POC |
+| JOV-3081 | Headroom context compression (inference cost) |
+
+## References
+
+- [`docs/AGENT_OS_ARCHITECTURE.md`](./AGENT_OS_ARCHITECTURE.md) — internal control plane
+- [`apps/web/lib/db/schema/memory.ts`](../apps/web/lib/db/schema/memory.ts) — product memory schema
+- [`apps/web/tests/unit/memory/memory-adr-contract.test.ts`](../apps/web/tests/unit/memory/memory-adr-contract.test.ts) — import-boundary guardrail


### PR DESCRIPTION
## Summary

Documents the runtime boundary between creator-facing product memory workflows and internal AgentOS WDK orchestration.

- Adds `docs/MEMORY_ADR.md` (JOV-2705) with decision, scope, file map, and forbidden import couplings
- Cross-links from `docs/AGENT_OS_ARCHITECTURE.md`
- Adds `memory-adr-contract.test.ts` guardrail that blocks forbidden cross-imports between product memory and AgentOS WDK modules

## Linear

<!-- linear-issue-id:JOV-2705 -->

Closes JOV-2705

## Verification

```bash
pnpm exec vitest run tests/unit/memory/memory-adr-contract.test.ts  # 5 passed
pnpm biome check apps/web/tests/unit/memory/memory-adr-contract.test.ts
```

## Bug-to-Test

Regression guardrail: `apps/web/tests/unit/memory/memory-adr-contract.test.ts` — would fail if product memory imports AgentOS WDK or vice versa.

## Risks

None — docs + contract test only; no runtime behavior change.