### PR TITLE
chore(design-sync): pin homepage projectId for Claude Design sync (JOV-3579)

### DIFF
--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,4 +1,5 @@
 {
+  "projectId": "98f908a5-93eb-4219-a591-fdd3e5b7eaab",
   "pkg": "apps/web/components",
   "globalName": "JovieHome",
   "shape": "package",


### PR DESCRIPTION
## What
Pins the Claude Design `projectId` for the **homepage** kit (`.design-sync/config.json`) so Phase 0 of JOV-3579 (`/design-sync` wiring) can sync.

- `.design-sync/config.json` → `projectId: 98f908a5-93eb-4219-a591-fdd3e5b7eaab` (project **"Jovie — Product (System B)"**, confirmed by Tim).
- Only key added; no other config changes (13/13 section maps untouched).

## Why
The homepage kit is built + validated (13/13 render clean per `.design-sync/NOTES.md`) but `projectId` was never pinned because Claude Design auth wasn't available in the web session. Tim created the project and handed back the id.

## Not in this PR
- **Marketing kit** (`.design-sync-marketing/config.json`) — already pinned to a *different* id (`9d09246a…`). Whether to overwrite it with the new `235bb730…` is pending Tim's confirm; will follow up separately.
- **Kit upload into Claude Design** — needs an authed Claude Code/Claude Design session; can't run from the agent runtime.

Refs: JOV-3579