### PR TITLE
fix(tasks): align mobile loading skeleton with TaskListRow flex layout

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -301,7 +301,7 @@ function TaskReleasePanelStatus({
     <EntitySidebarShell
       isOpen
       width={344}
-      ariaLabel='Release details'
+      ariaLabel='Release Details'
       title='Release'
       onClose={onClose}
       scrollStrategy='shell'
@@ -505,7 +505,7 @@ function TaskMetaMenuNumber({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <TaskMetaTrigger ariaLabel='Open task controls'>
+        <TaskMetaTrigger ariaLabel='Open Task Controls'>
           <span className='inline-flex items-center gap-1 text-2xs font-semibold text-tertiary-token'>
             <span className='shrink-0'>J-{task.taskNumber}</span>
             <ChevronDown className='h-3 w-3 shrink-0 text-tertiary-token' />
@@ -708,7 +708,7 @@ function TaskDocumentPanel({
               />
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <TaskMetaTrigger ariaLabel='Change task status'>
+                  <TaskMetaTrigger ariaLabel='Change Task Status'>
                     <TaskStageInline task={task} withChevron />
                   </TaskMetaTrigger>
                 </DropdownMenuTrigger>
@@ -736,7 +736,7 @@ function TaskDocumentPanel({
               </DropdownMenu>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <TaskMetaTrigger ariaLabel='Change task priority'>
+                  <TaskMetaTrigger ariaLabel='Change Task Priority'>
                     <TaskPriorityInline priority={task.priority} withChevron />
                   </TaskMetaTrigger>
                 </DropdownMenuTrigger>
@@ -764,7 +764,7 @@ function TaskDocumentPanel({
               </DropdownMenu>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <TaskMetaTrigger ariaLabel='Change task assignee'>
+                  <TaskMetaTrigger ariaLabel='Change Task Assignee'>
                     <TaskAssigneeInline
                       assigneeKind={task.assigneeKind}
                       artistName={artistName}
@@ -970,20 +970,34 @@ function TaskLoadingState() {
         <ShellListRowFrame
           key={row.key}
           interaction='none'
-          className='group/row grid min-h-16 grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-3 px-3 py-1.5'
+          data-testid='task-loading-row'
+          className='group/row flex min-h-16 items-center gap-3 px-3 py-1.5'
         >
-          <div className='skeleton h-4 w-4 rounded-full' />
-          <div className='min-w-0 space-y-2'>
+          <span className='flex shrink-0 items-center'>
+            <div className='skeleton h-5 w-5 rounded-full' aria-hidden='true' />
+          </span>
+
+          <div className='min-w-0 flex-1'>
             <div
-              className='skeleton h-3.5 rounded'
+              className='skeleton h-3.5 max-w-full rounded'
               style={{ width: row.titleWidth }}
+              aria-hidden='true'
             />
+            <div className='mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1'>
+              <div
+                className='skeleton h-3 rounded'
+                style={{ width: row.metaWidth }}
+                aria-hidden='true'
+              />
+            </div>
+          </div>
+
+          <div className='flex shrink-0 items-center justify-end'>
             <div
-              className='skeleton h-3 rounded'
-              style={{ width: row.metaWidth }}
+              className='skeleton h-5 w-14 rounded-full'
+              aria-hidden='true'
             />
           </div>
-          <div className='skeleton h-5 w-14 rounded-full' />
         </ShellListRowFrame>
       ))}
     </div>
@@ -1960,7 +1974,7 @@ export function TasksPageClient() {
               pills.length > 0
                 ? `Filter Tasks (${pills.length})`
                 : 'Filter Tasks',
-            ariaLabel: 'Filter tasks',
+            ariaLabel: 'Filter Tasks',
             placeholder: 'Search tasks',
             allowedFields: ['title'] as const,
           },
@@ -1973,7 +1987,7 @@ export function TasksPageClient() {
     () => (
       <DashboardHeaderActionGroup>
         <DashboardHeaderActionButton
-          ariaLabel='Create task'
+          ariaLabel='Create Task'
           icon={<Plus className='h-3.5 w-3.5' />}
           label='New Task'
           onClick={() => setHeaderMode('create')}

--- a/apps/web/tests/e2e/tasks-layout.spec.ts
+++ b/apps/web/tests/e2e/tasks-layout.spec.ts
@@ -606,9 +606,9 @@ test.describe('Tasks layout', () => {
     await expect(titleEditor).toHaveValue(taskTitle, { timeout: 15_000 });
     await titleEditor.fill(editedTitle);
 
-    await selectTaskMetaOption(page, 'Change task priority', 'Urgent');
-    await selectTaskMetaOption(page, 'Change task assignee', 'Jovie');
-    await selectTaskMetaOption(page, 'Change task status', 'In Progress');
+    await selectTaskMetaOption(page, 'Change Task Priority', 'Urgent');
+    await selectTaskMetaOption(page, 'Change Task Assignee', 'Jovie');
+    await selectTaskMetaOption(page, 'Change Task Status', 'In Progress');
 
     await expect
       .poll(() => getSeededTaskState(taskId), {

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -626,7 +626,7 @@ function getLatestTableProps() {
 
 function openDesktopTaskSearch() {
   fireEvent.click(screen.getByRole('button', { name: /filter tasks/i }));
-  return screen.getByRole('combobox', { name: 'Filter tasks' });
+  return screen.getByRole('combobox', { name: 'Filter Tasks' });
 }
 
 function enableDesignV1Tasks() {
@@ -965,6 +965,13 @@ describe('TasksPageClient', () => {
     expect(
       screen.queryByText('Your Task List Is Empty')
     ).not.toBeInTheDocument();
+
+    const loadingRows = screen.getAllByTestId('task-loading-row');
+    expect(loadingRows.length).toBeGreaterThan(0);
+    for (const row of loadingRows) {
+      expect(row.className).toContain('flex');
+      expect(row.className).not.toContain('grid-cols-');
+    }
   });
 
   it('renders the shared retry state when the task query fails', () => {
@@ -1264,7 +1271,7 @@ describe('TasksPageClient', () => {
     ).not.toBeInTheDocument();
     expect(
       within(screen.getByTestId('header-actions-host')).getByRole('button', {
-        name: 'Create task',
+        name: 'Create Task',
       })
     ).toBeInTheDocument();
   }, 10000);
@@ -1273,13 +1280,13 @@ describe('TasksPageClient', () => {
     renderPage();
 
     expect(
-      screen.queryByRole('combobox', { name: 'Filter tasks' })
+      screen.queryByRole('combobox', { name: 'Filter Tasks' })
     ).not.toBeInTheDocument();
 
     openDesktopTaskSearch();
 
     expect(
-      screen.getByRole('combobox', { name: 'Filter tasks' })
+      screen.getByRole('combobox', { name: 'Filter Tasks' })
     ).toBeInTheDocument();
   });
 
@@ -1336,7 +1343,7 @@ describe('TasksPageClient', () => {
 
     fireEvent.click(
       within(screen.getByTestId('header-actions-host')).getByRole('button', {
-        name: 'Create task',
+        name: 'Create Task',
       })
     );
 
@@ -1519,7 +1526,7 @@ describe('TasksPageClient', () => {
 
     expect(
       within(screen.getByTestId('header-actions-host')).getByRole('button', {
-        name: 'Create task',
+        name: 'Create Task',
       })
     ).toBeInTheDocument();
   });
@@ -1531,7 +1538,7 @@ describe('TasksPageClient', () => {
 
     expect(screen.getByText('2 total tasks')).toBeInTheDocument();
     expect(
-      screen.queryByRole('combobox', { name: 'Filter tasks' })
+      screen.queryByRole('combobox', { name: 'Filter Tasks' })
     ).not.toBeInTheDocument();
 
     const firstMobileRow = screen.getAllByTestId('mobile-task-row')[0]!;

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3059,
-  "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count. Corrected 3057→3061 on 2026-06-23: #11689 set the baseline 4 below the true post-sweep count and was admin-merged past its own red ratchet, leaving main RED and failing every PR's Unit Tests. Drive back down via JOV-3466 (tokenize the 4 stragglers). 3061→3059 on 2026-06-23 (JOV-3484): TaskListRow dropped grid-cols-[…] + leading-[17px] arbitrary values when converging to a flex layout."
+  "count": 3058,
+  "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count. Corrected 3057→3061 on 2026-06-23: #11689 set the baseline 4 below the true post-sweep count and was admin-merged past its own red ratchet, leaving main RED and failing every PR's Unit Tests. Drive back down via JOV-3466 (tokenize the 4 stragglers). 3061→3059 on 2026-06-23 (JOV-3484): TaskListRow dropped grid-cols-[…] + leading-[17px] arbitrary values when converging to a flex layout. 3059→3058 on 2026-06-27 (JOV-3490): TaskLoadingState dropped grid-cols-[…] when matching TaskListRow flex layout."
 }


### PR DESCRIPTION
## Goal

Fix mobile Tasks loading skeleton layout shift by replacing broken `grid-cols-[…]` with flex layout matching `TaskListRow`. Also fix pre-existing `ariaLabel` Title Case violations so lint-staged passes.

## Linear

- Issue: JOV-3490
- URL: https://linear.app/jovie/issue/JOV-3490

<!-- linear-issue-id:JOV-3490 -->
<!-- linear-issue-identifier:JOV-3490 -->

## Changes

- Replace `TaskLoadingState` grid layout with flex row structure aligned to `TaskListRow` (stage glyph, flex-1 content, trailing badge slot)
- Add `data-testid="task-loading-row"` and unit test asserting no `grid-cols-` in loading skeleton
- Fix six `ariaLabel` strings to canonical Title Case (`Open Task Controls`, `Change Task Status`, etc.)
- Lower `arbitrary-values.baseline.json` 3059 → 3058 after removing `grid-cols-[1.25rem_minmax(0,1fr)_auto]`

## Testing

- `pnpm exec vitest run tests/unit/dashboard/TasksPageClient.test.tsx tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- Pre-commit lint-staged (eslint + typecheck + a11y) passed
- Pre-push biome + typecheck + lint passed

---
*PR created for JOV-3490*