### PR TITLE
feat(web): mount GA4 gtag.js loader with Consent Mode v2

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,9 +11,15 @@ import './globals.css';
 import '@/components/organisms/HeaderNav.css';
 import '@/components/site/MarketingFooter.css';
 import { CookieBannerMount } from '@/components/organisms/CookieBannerMount';
+import { GoogleAnalytics } from '@/components/providers/GoogleAnalytics';
 import { InstantlyPixel } from '@/components/providers/InstantlyPixel';
 import { getRootLayoutChromeState } from '@/lib/demo-recording';
 import { publicEnv } from '@/lib/env-public';
+import {
+  buildGoogleConsentInitScript,
+  isValidGaMeasurementId,
+  shouldMountGoogleAnalytics,
+} from '@/lib/tracking/google-consent-mode';
 
 const inter = localFont({
   src: '../public/fonts/Inter-Latin.woff2',
@@ -177,6 +183,13 @@ export default async function RootLayout({
       devEnv,
       isE2EClientRuntime,
     });
+  const gaMeasurementId = publicEnv.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  const shouldMountGa = shouldMountGoogleAnalytics({
+    measurementId: gaMeasurementId,
+    isTest: process.env.NODE_ENV === 'test',
+    isE2E: isE2EClientRuntime,
+    isDemoRecording,
+  });
 
   let devToolbar: React.ReactNode = null;
   let FlagBadgeProvider: React.ComponentType<{
@@ -210,6 +223,7 @@ export default async function RootLayout({
       {auth}
       {devToolbar}
       {shouldRenderCookieBanner ? <CookieBannerMount /> : null}
+      <GoogleAnalytics />
       <InstantlyPixel />
     </>
   );
@@ -237,6 +251,14 @@ export default async function RootLayout({
         <script src='/electron-runtime-init.js' />
         {/* eslint-disable-next-line @next/next/no-sync-scripts -- Must run before React hydration; next/script nonce drift causes local E2E console errors. */}
         <script src='/theme-init.js' />
+        {shouldMountGa && isValidGaMeasurementId(gaMeasurementId) ? (
+          <script
+            id='ga-consent-init'
+            dangerouslySetInnerHTML={{
+              __html: buildGoogleConsentInitScript(gaMeasurementId),
+            }}
+          />
+        ) : null}
       </head>
       <body className={bodyClassName}>
         {FlagBadgeProvider ? (

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -254,6 +254,7 @@ export default async function RootLayout({
         {shouldMountGa && isValidGaMeasurementId(gaMeasurementId) ? (
           <script
             id='ga-consent-init'
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: script body is generated from a validated GA measurement ID.
             dangerouslySetInnerHTML={{
               __html: buildGoogleConsentInitScript(gaMeasurementId),
             }}

--- a/apps/web/components/providers/GoogleAnalytics.tsx
+++ b/apps/web/components/providers/GoogleAnalytics.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import Script from 'next/script';
+import { useEffect } from 'react';
+import type { Consent } from '@/lib/cookies/consent';
+import { isDemoRecordingClient } from '@/lib/demo-recording';
+import { env } from '@/lib/env-client';
+import { publicEnv } from '@/lib/env-public';
+import {
+  applyGoogleConsentMode,
+  buildGoogleAnalyticsConfigScript,
+  consentToGoogleConsentMode,
+  isCookieBannerRequiredFromClient,
+  isValidGaMeasurementId,
+} from '@/lib/tracking/google-consent-mode';
+
+function isConsentPayload(value: unknown): value is Consent {
+  if (!value || typeof value !== 'object') return false;
+  const consent = value as Partial<Consent>;
+  return (
+    typeof consent.essential === 'boolean' &&
+    typeof consent.analytics === 'boolean' &&
+    typeof consent.marketing === 'boolean'
+  );
+}
+
+export function GoogleAnalytics() {
+  const measurementId = publicEnv.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  const isPassive = env.IS_TEST || env.IS_E2E;
+  const isDemo = isDemoRecordingClient();
+  const skip = !isValidGaMeasurementId(measurementId) || isPassive || isDemo;
+
+  useEffect(() => {
+    if (skip) return;
+    if (globalThis.window === undefined) return;
+
+    const syncConsent = (value: unknown) => {
+      if (!isConsentPayload(value)) return;
+      applyGoogleConsentMode(
+        consentToGoogleConsentMode(value, isCookieBannerRequiredFromClient())
+      );
+    };
+
+    let unsubConsent: (() => void) | undefined;
+
+    const attach = () => {
+      if (!globalThis.JVConsent) return;
+      unsubConsent = globalThis.JVConsent.onChange(syncConsent);
+    };
+
+    if (globalThis.JVConsent) {
+      attach();
+      return () => {
+        unsubConsent?.();
+      };
+    }
+
+    const onReady = () => attach();
+    globalThis.addEventListener('jvconsent:ready', onReady, { once: true });
+    return () => {
+      globalThis.removeEventListener('jvconsent:ready', onReady);
+      unsubConsent?.();
+    };
+  }, [skip]);
+
+  if (skip) return null;
+
+  return (
+    <>
+      <Script
+        id='ga-gtag-loader'
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+        strategy='afterInteractive'
+      />
+      <Script id='ga-config' strategy='afterInteractive'>
+        {buildGoogleAnalyticsConfigScript(measurementId)}
+      </Script>
+    </>
+  );
+}

--- a/apps/web/lib/env-public.ts
+++ b/apps/web/lib/env-public.ts
@@ -116,4 +116,8 @@ export const publicEnv = {
   get NEXT_PUBLIC_INSTANTLY_PIXEL_ID() {
     return process.env.NEXT_PUBLIC_INSTANTLY_PIXEL_ID || undefined;
   },
+  // Google Analytics 4 measurement ID (gtag.js)
+  get NEXT_PUBLIC_GA_MEASUREMENT_ID() {
+    return process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || undefined;
+  },
 } as const;

--- a/apps/web/lib/tracking/consent.ts
+++ b/apps/web/lib/tracking/consent.ts
@@ -127,6 +127,37 @@ export function isMarketingAllowed(): boolean {
 }
 
 /**
+ * Check if analytics tracking is allowed.
+ *
+ * Reads the granular consent object from localStorage (jv_cc).
+ * Returns true if analytics consent has NOT been explicitly rejected.
+ * In consent-required regions without a stored choice, analytics stays blocked.
+ */
+export function isAnalyticsAllowed(): boolean {
+  if (globalThis.window === undefined) return false;
+
+  if (isGPCEnabled() || isDNTEnabled()) return false;
+
+  const legacyState = getConsentState();
+  if (legacyState === 'rejected') return false;
+
+  try {
+    const raw = globalThis.localStorage?.getItem('jv_cc');
+    if (!raw) {
+      const bannerRequired = globalThis.document.cookie
+        .split(';')
+        .some(cookie => cookie.trim().startsWith('jv_cc_required=1'));
+      return !bannerRequired;
+    }
+
+    const parsed = JSON.parse(raw);
+    return parsed?.analytics !== false;
+  } catch {
+    return true;
+  }
+}
+
+/**
  * Generate a session ID for anonymous tracking
  * This is NOT PII - it's a random identifier that doesn't persist long-term
  */

--- a/apps/web/lib/tracking/google-consent-mode.ts
+++ b/apps/web/lib/tracking/google-consent-mode.ts
@@ -1,0 +1,210 @@
+import type { Consent } from '@/lib/cookies/consent';
+import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
+import { isDNTEnabled, isGPCEnabled } from '@/lib/tracking/consent';
+
+export type GoogleConsentModeValue = 'granted' | 'denied';
+
+export type GoogleConsentModeState = {
+  readonly analytics_storage: GoogleConsentModeValue;
+  readonly ad_storage: GoogleConsentModeValue;
+  readonly ad_user_data: GoogleConsentModeValue;
+  readonly ad_personalization: GoogleConsentModeValue;
+};
+
+const DENIED_CONSENT: GoogleConsentModeState = {
+  analytics_storage: 'denied',
+  ad_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied',
+};
+
+const GRANTED_CONSENT: GoogleConsentModeState = {
+  analytics_storage: 'granted',
+  ad_storage: 'granted',
+  ad_user_data: 'granted',
+  ad_personalization: 'granted',
+};
+
+const GA_MEASUREMENT_ID_PATTERN = /^G-[A-Z0-9]+$/;
+
+type AnalyticsWindow = Window & {
+  gtag?: (...args: unknown[]) => void;
+};
+
+function getAnalyticsWindow(): AnalyticsWindow | null {
+  if (globalThis.window === undefined) return null;
+  return globalThis.window as AnalyticsWindow;
+}
+
+export function isValidGaMeasurementId(
+  measurementId: string | undefined
+): measurementId is string {
+  return (
+    typeof measurementId === 'string' &&
+    GA_MEASUREMENT_ID_PATTERN.test(measurementId)
+  );
+}
+
+export function shouldMountGoogleAnalytics(params: {
+  readonly measurementId: string | undefined;
+  readonly isTest: boolean;
+  readonly isE2E: boolean;
+  readonly isDemoRecording: boolean;
+}): boolean {
+  return (
+    isValidGaMeasurementId(params.measurementId) &&
+    !params.isTest &&
+    !params.isE2E &&
+    !params.isDemoRecording
+  );
+}
+
+export function isCookieBannerRequiredFromClient(): boolean {
+  if (globalThis.document === undefined) return false;
+
+  const bannerCookie = globalThis.document.cookie
+    .split(';')
+    .find(cookie =>
+      cookie.trim().startsWith(`${COOKIE_BANNER_REQUIRED_COOKIE}=`)
+    );
+
+  return bannerCookie?.split('=')[1]?.trim() === '1';
+}
+
+export function readStoredConsentFromClient(): Consent | null {
+  if (globalThis.window === undefined) return null;
+
+  try {
+    const raw = globalThis.localStorage?.getItem('jv_cc');
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<Consent>;
+    if (
+      typeof parsed.essential !== 'boolean' ||
+      typeof parsed.analytics !== 'boolean' ||
+      typeof parsed.marketing !== 'boolean'
+    ) {
+      return null;
+    }
+
+    return parsed as Consent;
+  } catch {
+    return null;
+  }
+}
+
+export function consentToGoogleConsentMode(
+  consent: Consent | null,
+  bannerRequired: boolean
+): GoogleConsentModeState {
+  if (consent) {
+    return {
+      analytics_storage: consent.analytics ? 'granted' : 'denied',
+      ad_storage: consent.marketing ? 'granted' : 'denied',
+      ad_user_data: consent.marketing ? 'granted' : 'denied',
+      ad_personalization: consent.marketing ? 'granted' : 'denied',
+    };
+  }
+
+  if (bannerRequired) {
+    return DENIED_CONSENT;
+  }
+
+  return GRANTED_CONSENT;
+}
+
+export function getGoogleConsentModeFromClient(): GoogleConsentModeState {
+  if (isGPCEnabled() || isDNTEnabled()) {
+    return DENIED_CONSENT;
+  }
+
+  return consentToGoogleConsentMode(
+    readStoredConsentFromClient(),
+    isCookieBannerRequiredFromClient()
+  );
+}
+
+export function applyGoogleConsentMode(state: GoogleConsentModeState): void {
+  const analyticsWindow = getAnalyticsWindow();
+  analyticsWindow?.gtag?.('consent', 'update', state);
+}
+
+export function buildGoogleConsentInitScript(measurementId: string): string {
+  if (!isValidGaMeasurementId(measurementId)) {
+    throw new Error('Invalid GA measurement ID');
+  }
+
+  return `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('consent', 'default', {
+  analytics_storage: 'denied',
+  ad_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied',
+  wait_for_update: 500
+});
+(function () {
+  var denied = {
+    analytics_storage: 'denied',
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied'
+  };
+  var granted = {
+    analytics_storage: 'granted',
+    ad_storage: 'granted',
+    ad_user_data: 'granted',
+    ad_personalization: 'granted'
+  };
+  var gpcEnabled = navigator.globalPrivacyControl === true;
+  var dntEnabled = navigator.doNotTrack === '1' || navigator.doNotTrack === 'yes';
+  if (gpcEnabled || dntEnabled) {
+    gtag('consent', 'update', denied);
+    return;
+  }
+  var bannerRequired = document.cookie.split(';').some(function (cookie) {
+    return cookie.trim().indexOf('${COOKIE_BANNER_REQUIRED_COOKIE}=1') === 0;
+  });
+  var storedConsent = null;
+  try {
+    var raw = localStorage.getItem('jv_cc');
+    if (raw) {
+      storedConsent = JSON.parse(raw);
+    }
+  } catch (e) {}
+  if (
+    storedConsent &&
+    typeof storedConsent.essential === 'boolean' &&
+    typeof storedConsent.analytics === 'boolean' &&
+    typeof storedConsent.marketing === 'boolean'
+  ) {
+    gtag('consent', 'update', {
+      analytics_storage: storedConsent.analytics ? 'granted' : 'denied',
+      ad_storage: storedConsent.marketing ? 'granted' : 'denied',
+      ad_user_data: storedConsent.marketing ? 'granted' : 'denied',
+      ad_personalization: storedConsent.marketing ? 'granted' : 'denied'
+    });
+    return;
+  }
+  if (bannerRequired) {
+    gtag('consent', 'update', denied);
+    return;
+  }
+  gtag('consent', 'update', granted);
+})();
+`.trim();
+}
+
+export function buildGoogleAnalyticsConfigScript(
+  measurementId: string
+): string {
+  if (!isValidGaMeasurementId(measurementId)) {
+    throw new Error('Invalid GA measurement ID');
+  }
+
+  return `
+gtag('js', new Date());
+gtag('config', '${measurementId}');
+`.trim();
+}

--- a/apps/web/tests/unit/tracking/google-analytics.test.tsx
+++ b/apps/web/tests/unit/tracking/google-analytics.test.tsx
@@ -1,0 +1,183 @@
+import { cleanup, render } from '@testing-library/react';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+let _measurementId: string | undefined = 'G-TMY7Z8HK47';
+let _isTest = false;
+let _isE2E = false;
+let _isDemo = false;
+
+vi.mock('next/script', () => ({
+  default: (props: Record<string, unknown>) => {
+    const { children, ...rest } = props;
+    return (
+      <script data-testid='next-script' {...rest}>
+        {children}
+      </script>
+    );
+  },
+}));
+
+vi.mock('@/lib/env-client', () => ({
+  env: {
+    get IS_TEST() {
+      return _isTest;
+    },
+    get IS_E2E() {
+      return _isE2E;
+    },
+  },
+}));
+
+vi.mock('@/lib/env-public', () => ({
+  publicEnv: {
+    get NEXT_PUBLIC_GA_MEASUREMENT_ID() {
+      return _measurementId;
+    },
+  },
+}));
+
+vi.mock('@/lib/demo-recording', () => ({
+  isDemoRecordingClient: () => _isDemo,
+}));
+
+let GoogleAnalytics: typeof import('@/components/providers/GoogleAnalytics').GoogleAnalytics;
+
+beforeAll(async () => {
+  const mod = await import('@/components/providers/GoogleAnalytics');
+  GoogleAnalytics = mod.GoogleAnalytics;
+});
+
+function getScripts(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll('[data-testid="next-script"]'));
+}
+
+describe('GoogleAnalytics', () => {
+  beforeEach(() => {
+    _measurementId = 'G-TMY7Z8HK47';
+    _isTest = false;
+    _isE2E = false;
+    _isDemo = false;
+    globalThis.JVConsent = undefined;
+    globalThis.gtag = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders gtag loader and config scripts', () => {
+    const { container } = render(<GoogleAnalytics />);
+    const scripts = getScripts(container);
+
+    expect(scripts).toHaveLength(2);
+    expect(scripts[0]?.id).toBe('ga-gtag-loader');
+    expect(scripts[0]?.getAttribute('src')).toBe(
+      'https://www.googletagmanager.com/gtag/js?id=G-TMY7Z8HK47'
+    );
+    expect(scripts[1]?.id).toBe('ga-config');
+    expect(scripts[1]?.textContent).toContain("gtag('config', 'G-TMY7Z8HK47')");
+  });
+
+  it('returns null when measurement ID is missing', () => {
+    _measurementId = undefined;
+    const { container } = render(<GoogleAnalytics />);
+    expect(getScripts(container)).toHaveLength(0);
+  });
+
+  it('returns null when measurement ID is invalid', () => {
+    _measurementId = 'UA-123456-1';
+    const { container } = render(<GoogleAnalytics />);
+    expect(getScripts(container)).toHaveLength(0);
+  });
+
+  it('returns null in test runtime', () => {
+    _isTest = true;
+    const { container } = render(<GoogleAnalytics />);
+    expect(getScripts(container)).toHaveLength(0);
+  });
+
+  it('returns null in demo recording mode', () => {
+    _isDemo = true;
+    const { container } = render(<GoogleAnalytics />);
+    expect(getScripts(container)).toHaveLength(0);
+  });
+
+  it('updates Google consent mode when CookieBanner emits consent', async () => {
+    const listeners = new Set<(value: unknown) => void>();
+    globalThis.JVConsent = {
+      onChange(cb) {
+        listeners.add(cb);
+        return () => listeners.delete(cb);
+      },
+      _emit(value) {
+        listeners.forEach(listener => listener(value));
+      },
+      openModal: vi.fn(),
+    };
+
+    render(<GoogleAnalytics />);
+
+    globalThis.JVConsent._emit({
+      essential: true,
+      analytics: true,
+      marketing: false,
+    });
+
+    expect(globalThis.gtag).toHaveBeenCalledWith('consent', 'update', {
+      analytics_storage: 'granted',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+    });
+  });
+});
+
+describe('isAnalyticsAllowed', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.cookie =
+      'jv_cc_required=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  });
+
+  it('returns true when analytics consent is granted', async () => {
+    vi.doUnmock('@/lib/tracking/consent');
+    const { isAnalyticsAllowed } = await import('@/lib/tracking/consent');
+    localStorage.setItem(
+      'jv_cc',
+      JSON.stringify({ essential: true, analytics: true, marketing: false })
+    );
+    expect(isAnalyticsAllowed()).toBe(true);
+  });
+
+  it('returns false when analytics consent is rejected', async () => {
+    vi.doUnmock('@/lib/tracking/consent');
+    const { isAnalyticsAllowed } = await import('@/lib/tracking/consent');
+    localStorage.setItem(
+      'jv_cc',
+      JSON.stringify({ essential: true, analytics: false, marketing: true })
+    );
+    expect(isAnalyticsAllowed()).toBe(false);
+  });
+
+  it('returns false in consent-required regions before a choice is stored', async () => {
+    vi.doUnmock('@/lib/tracking/consent');
+    const { isAnalyticsAllowed } = await import('@/lib/tracking/consent');
+    document.cookie = 'jv_cc_required=1; path=/';
+    expect(isAnalyticsAllowed()).toBe(false);
+  });
+
+  it('returns true outside consent-required regions before a choice is stored', async () => {
+    vi.doUnmock('@/lib/tracking/consent');
+    const { isAnalyticsAllowed } = await import('@/lib/tracking/consent');
+    document.cookie = 'jv_cc_required=0; path=/';
+    expect(isAnalyticsAllowed()).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/tracking/google-consent-mode.test.ts
+++ b/apps/web/tests/unit/tracking/google-consent-mode.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Consent } from '@/lib/cookies/consent';
+import {
+  buildGoogleAnalyticsConfigScript,
+  buildGoogleConsentInitScript,
+  consentToGoogleConsentMode,
+  getGoogleConsentModeFromClient,
+  isCookieBannerRequiredFromClient,
+  isValidGaMeasurementId,
+  readStoredConsentFromClient,
+  shouldMountGoogleAnalytics,
+} from '@/lib/tracking/google-consent-mode';
+
+describe('google-consent-mode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.cookie =
+      'jv_cc_required=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.cookie =
+      'jv_cc_required=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  });
+
+  it('validates GA measurement IDs', () => {
+    expect(isValidGaMeasurementId('G-TMY7Z8HK47')).toBe(true);
+    expect(isValidGaMeasurementId('G-ABC12345')).toBe(true);
+    expect(isValidGaMeasurementId('UA-123456-1')).toBe(false);
+    expect(isValidGaMeasurementId(undefined)).toBe(false);
+  });
+
+  it('maps stored consent to Google Consent Mode v2 fields', () => {
+    const consent: Consent = {
+      essential: true,
+      analytics: true,
+      marketing: false,
+    };
+
+    expect(consentToGoogleConsentMode(consent, true)).toEqual({
+      analytics_storage: 'granted',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+    });
+  });
+
+  it('defaults to denied in consent-required regions without a stored choice', () => {
+    document.cookie = 'jv_cc_required=1; path=/';
+
+    expect(consentToGoogleConsentMode(null, true)).toEqual({
+      analytics_storage: 'denied',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+    });
+  });
+
+  it('defaults to granted outside consent-required regions', () => {
+    expect(consentToGoogleConsentMode(null, false)).toEqual({
+      analytics_storage: 'granted',
+      ad_storage: 'granted',
+      ad_user_data: 'granted',
+      ad_personalization: 'granted',
+    });
+  });
+
+  it('reads stored consent from localStorage', () => {
+    localStorage.setItem(
+      'jv_cc',
+      JSON.stringify({ essential: true, analytics: false, marketing: true })
+    );
+
+    expect(readStoredConsentFromClient()).toEqual({
+      essential: true,
+      analytics: false,
+      marketing: true,
+    });
+  });
+
+  it('detects consent-required cookie from the client', () => {
+    document.cookie = 'jv_cc_required=1; path=/';
+    expect(isCookieBannerRequiredFromClient()).toBe(true);
+
+    document.cookie = 'jv_cc_required=0; path=/';
+    expect(isCookieBannerRequiredFromClient()).toBe(false);
+  });
+
+  it('resolves client consent mode from stored preferences', () => {
+    localStorage.setItem(
+      'jv_cc',
+      JSON.stringify({ essential: true, analytics: true, marketing: true })
+    );
+
+    expect(getGoogleConsentModeFromClient()).toEqual({
+      analytics_storage: 'granted',
+      ad_storage: 'granted',
+      ad_user_data: 'granted',
+      ad_personalization: 'granted',
+    });
+  });
+
+  it('decides when GA should mount in the root layout', () => {
+    expect(
+      shouldMountGoogleAnalytics({
+        measurementId: 'G-TMY7Z8HK47',
+        isTest: false,
+        isE2E: false,
+        isDemoRecording: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldMountGoogleAnalytics({
+        measurementId: undefined,
+        isTest: false,
+        isE2E: false,
+        isDemoRecording: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldMountGoogleAnalytics({
+        measurementId: 'G-TMY7Z8HK47',
+        isTest: false,
+        isE2E: true,
+        isDemoRecording: false,
+      })
+    ).toBe(false);
+  });
+
+  it('builds consent init and config scripts for gtag', () => {
+    const measurementId = 'G-TMY7Z8HK47';
+
+    expect(buildGoogleConsentInitScript(measurementId)).toContain(
+      "gtag('consent', 'default'"
+    );
+    expect(buildGoogleConsentInitScript(measurementId)).toContain(
+      'jv_cc_required=1'
+    );
+    expect(buildGoogleAnalyticsConfigScript(measurementId)).toContain(
+      "gtag('config', 'G-TMY7Z8HK47')"
+    );
+  });
+});


### PR DESCRIPTION
## Goal
Mount GA4 gtag.js (G-TMY7Z8HK47) in the root layout so existing `track()` calls reach Google Analytics, with Google Consent Mode v2 wired to the CookieBanner.

Closes JOV-3629

## Changes
- Add `NEXT_PUBLIC_GA_MEASUREMENT_ID` to `env-public.ts`
- Add `GoogleAnalytics` provider that loads gtag.js + config via `next/script`
- Bootstrap Consent Mode v2 defaults in root layout `<head>` before gtag loads
- Sync consent updates from `JVConsent` / CookieBanner (`analytics` + `marketing` buckets)
- Add `isAnalyticsAllowed()` helper and unit tests

## Testing
- `pnpm exec vitest run tests/unit/tracking/google-consent-mode.test.ts tests/unit/tracking/google-analytics.test.tsx`
- `pnpm run typecheck`
- `pnpm run lint`

## Deploy note
Set `NEXT_PUBLIC_GA_MEASUREMENT_ID=G-TMY7Z8HK47` in Doppler (`jovie-web` dev/stg/prd) before deploy.

---
Generated with [Claude Code](https://claude.com/claude-code)