### PR TITLE
docs(claude): add Build-before-you-build prior-art gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,17 @@ Skill hygiene rules:
 - If a skill workflow requires repeated shell logic, add or reuse a script instead of embedding long command prose in every skill.
 - When changing skill templates or generators, run the focused gstack checks from `.agents/skills/gstack/CLAUDE.md`.
 
+## Build before you build (prior-art gate)
+
+Before scoping or implementing anything that builds infrastructure, tooling, or re-implements a known software category (visual regression/diffing, scheduling, queues, auth, parsing, charts, date handling, state management, etc.), run the prior-art gate. This enforces gstack ETHOS §2 "Search Before Building" as a hard step, not advice:
+
+1. **Name the category** ("this is a visual-regression differ").
+2. **Scan prior art (~5 min):** does the existing stack already do it (framework feature / native / installed dep)? a standard OSS lib? a SaaS/API? Note licenses.
+3. **Decide adopt > wrap > build.** Only build for core product differentiation, or when every candidate fails a *stated* hard requirement.
+4. **Record it** on the issue/plan: category · candidates + links + license · adopt/wrap/build + one-line why. Infra/tooling work without this section is not ready to start.
+
+**Precedence:** §2 (Search Before Building) runs BEFORE §1 (Boil the Lake). "Completeness is cheap / prefer the fuller approach" governs how thoroughly you finish something you've *decided* to build — it never justifies rebuilding what already exists off the shelf.
+
 ## gstack
 
 Use /browse from gstack for all web browsing. Never use mcp__claude-in-chrome__* tools.


### PR DESCRIPTION
## Why
A custom Playwright pixel-diff engine was scoped (JOV-1944) when Vitest `toMatchScreenshot` + Playwright's built-in `toHaveScreenshot` already solve it for free. Root cause isn't a missing principle — gstack ETHOS **§2 "Search Before Building"** already says "has someone already solved this? … anti-pattern: rolling a custom solution when the runtime has a built-in." It failed because (1) it's **advisory, not gated**, and (2) it's **outranked in practice by §1 "Boil the Lake"** ("completeness is cheap; prefer the +70 LOC approach, every time").

## What
Adds a concise **"Build before you build (prior-art gate)"** section to `CLAUDE.md` that:
- makes §2 a **hard scoping step** (name category → scan prior art → adopt > wrap > build → record the decision), and
- fixes **precedence**: §2 runs before §1; Boil-the-Lake governs how thoroughly you finish something you've *decided* to build, never justifies rebuilding what already exists.

Local + upgrade-safe (lives in our `CLAUDE.md`, not vendored gstack). Companion upstream PRs to `garrytan/gstack` (enforce §2 in plan-eng-review; reconcile §1/§2 in ETHOS.md) to follow.

## Risk
Docs-only, one file, additive. No code paths touched.

🤖 Drafted by Eve (PM agent) for review — do not merge without a human pass.