### PR TITLE
fix(ci): repair Storybook A11y vitest prebundle (infra)

### DIFF
--- a/apps/web/.storybook/dashboard-actions-mock.ts
+++ b/apps/web/.storybook/dashboard-actions-mock.ts
@@ -1,12 +1,19 @@
 // Mock for dashboard actions that provides types but no server-side functionality
 
 export type DashboardData = {
-  user: any;
-  creatorProfile: any;
-  socialLinks: any[];
-  totalClicks: number;
-  recentClicks: any[];
-  analytics: any;
+  user: { id: string } | null;
+  creatorProfiles: unknown[];
+  selectedProfile: unknown | null;
+  needsOnboarding: boolean;
+  sidebarCollapsed: boolean;
+  hasSocialLinks: boolean;
+  hasMusicLinks: boolean;
+  isAdmin: boolean;
+  tippingStats: Record<string, unknown>;
+  profileCompletion: {
+    percentage: number;
+    steps: unknown[];
+  };
 };
 
 export type ProfileSocialLink = {
@@ -17,17 +24,43 @@ export type ProfileSocialLink = {
   order: number;
 };
 
-// Mock functions that don't do anything in Storybook
-export const updateCreatorProfile = async (...args: any[]) => {
-  return Promise.resolve();
-};
+const emptyDashboardData = (): DashboardData => ({
+  user: { id: 'storybook-user' },
+  creatorProfiles: [],
+  selectedProfile: null,
+  needsOnboarding: false,
+  sidebarCollapsed: false,
+  hasSocialLinks: false,
+  hasMusicLinks: false,
+  isAdmin: false,
+  tippingStats: {},
+  profileCompletion: { percentage: 0, steps: [] },
+});
 
-export const updateSocialLinks = async (...args: any[]) => {
-  return Promise.resolve();
-};
+export const getDashboardDataEssential = async (): Promise<DashboardData> =>
+  emptyDashboardData();
 
-// Add any other exports that might be needed
+export const getDashboardData = async (): Promise<DashboardData> =>
+  emptyDashboardData();
+
+export const getDashboardShellData = async (): Promise<DashboardData> =>
+  emptyDashboardData();
+
+export const updateCreatorProfile = async (..._args: unknown[]) =>
+  Promise.resolve();
+
+export const updateSocialLinks = async (..._args: unknown[]) =>
+  Promise.resolve();
+
+export const updateAllowProfilePhotoDownloads = async (..._args: unknown[]) =>
+  Promise.resolve();
+
+export const updateShowOldReleases = async (..._args: unknown[]) =>
+  Promise.resolve();
+
 export default {
+  getDashboardDataEssential,
+  getDashboardData,
   updateCreatorProfile,
   updateSocialLinks,
 };

--- a/apps/web/.storybook/enrich-profile-mock.ts
+++ b/apps/web/.storybook/enrich-profile-mock.ts
@@ -1,0 +1,11 @@
+export interface EnrichedProfileData {
+  name: string | null;
+  imageUrl: string | null;
+  bio: string | null;
+  genres: string[];
+  followers: number | null;
+}
+
+export async function enrichProfileFromDsp(): Promise<EnrichedProfileData | null> {
+  return null;
+}

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -71,6 +71,27 @@ const config: StorybookConfig = {
           replacement: require.resolve('./dashboard-layout-client-mock.tsx'),
         },
         {
+          find: '@/app/app/(shell)/dashboard/actions/dashboard-data',
+          replacement: require.resolve('./dashboard-actions-mock.ts'),
+        },
+        {
+          find: '@/app/app/(shell)/dashboard/actions/creator-profile',
+          replacement: require.resolve('./dashboard-actions-mock.ts'),
+        },
+        {
+          find: '@/app/onboarding/actions/connect-spotify',
+          replacement: require.resolve('./onboarding-actions-mock.ts'),
+        },
+        {
+          find: '@/app/onboarding/actions/update-profile',
+          replacement: require.resolve('./onboarding-actions-mock.ts'),
+        },
+        {
+          find: '@/app/onboarding/actions/enrich-profile',
+          replacement: require.resolve('./enrich-profile-mock.ts'),
+        },
+
+        {
           find: '@/app/app/(shell)/dashboard/actions',
           replacement: require.resolve('./dashboard-actions-mock.ts'),
         },
@@ -166,11 +187,15 @@ const config: StorybookConfig = {
           replacement: path.resolve(__dirname, 'clerk-elements-mock.jsx'),
         },
         // Project aliases
-        { find: '@', replacement: path.resolve(__dirname, '..') },
+        {
+          find: '@/features',
+          replacement: path.resolve(__dirname, '../components/features'),
+        },
         {
           find: '@jovie/ui',
-          replacement: path.resolve(__dirname, '../packages/ui'),
+          replacement: path.resolve(__dirname, '../../../packages/ui'),
         },
+        { find: '@', replacement: path.resolve(__dirname, '..') },
         ...normalizedAlias,
       ],
     };

--- a/apps/web/components/atoms/DropdownMenu.stories.tsx
+++ b/apps/web/components/atoms/DropdownMenu.stories.tsx
@@ -1,13 +1,13 @@
-import { Button } from '@jovie/ui';
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import {
+  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from './DropdownMenu';
+} from '@jovie/ui';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta: Meta<typeof DropdownMenu> = {
   title: 'Atoms/DropdownMenu',

--- a/apps/web/components/atoms/Popover.stories.tsx
+++ b/apps/web/components/atoms/Popover.stories.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@jovie/ui';
+import { Button, Popover, PopoverContent, PopoverTrigger } from '@jovie/ui';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { Popover, PopoverContent, PopoverTrigger } from './Popover';
 
 const meta: Meta<typeof Popover> = {
   title: 'Atoms/Popover',

--- a/apps/web/components/atoms/Sheet.stories.tsx
+++ b/apps/web/components/atoms/Sheet.stories.tsx
@@ -1,13 +1,13 @@
-import { Button } from '@jovie/ui';
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import {
+  Button,
   Sheet,
   SheetContent,
   SheetFooter,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
-} from './Sheet';
+} from '@jovie/ui';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta: Meta<typeof Sheet> = {
   title: 'Atoms/Sheet',

--- a/apps/web/components/atoms/Tooltip.stories.tsx
+++ b/apps/web/components/atoms/Tooltip.stories.tsx
@@ -1,11 +1,11 @@
-import { Button } from '@jovie/ui';
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import {
+  Button,
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from './Tooltip';
+} from '@jovie/ui';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta: Meta<typeof Tooltip> = {
   title: 'Atoms/Tooltip',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -294,7 +294,7 @@
     "@sentry/node": "^10.49.0",
     "@storybook/addon-a11y": "^10.3.6",
     "@storybook/addon-docs": "^10.3.3",
-    "@storybook/addon-vitest": "^10.4.1",
+    "@storybook/addon-vitest": "10.3.3",
     "@storybook/nextjs-vite": "^10.3.5",
     "@stryker-mutator/core": "9.6.1",
     "@stryker-mutator/vitest-runner": "9.6.1",

--- a/apps/web/vitest.config.storybook.mts
+++ b/apps/web/vitest.config.storybook.mts
@@ -36,7 +36,15 @@ export default defineConfig({
       'react/jsx-dev-runtime',
     ],
   },
+  // Browser mode prebundles with a legacy default target; use esnext so modern
+  // syntax in client deps does not fail esbuild transforms.
+  esbuild: {
+    target: 'esnext',
+  },
   optimizeDeps: {
+    esbuildOptions: {
+      target: 'esnext',
+    },
     include: [
       // React core
       'react',
@@ -56,7 +64,6 @@ export default defineConfig({
       'motion/react',
       'vaul',
       'react-error-boundary',
-      'react-hook-form',
       // Radix UI primitives
       '@radix-ui/react-slot',
       '@radix-ui/react-alert-dialog',
@@ -71,7 +78,6 @@ export default defineConfig({
       '@radix-ui/react-switch',
       '@radix-ui/react-tabs',
       '@radix-ui/react-tooltip',
-      '@radix-ui/react-context-menu',
       // Data / state
       '@tanstack/react-query',
       '@tanstack/react-pacer',
@@ -95,27 +101,10 @@ export default defineConfig({
       'nuqs',
       'nuqs/adapters/next/app',
       'recharts',
-      // Auth / analytics
-      '@clerk/nextjs',
+      // Analytics
       '@vercel/analytics/react',
       // AI SDK (used by chat components)
       '@ai-sdk/react',
-      // Form + context menu (pulled in via @jovie/ui barrel exports)
-      'react-hook-form',
-      '@radix-ui/react-context-menu',
-      // Server-side deps (referenced by stories indirectly)
-      '@sentry/nextjs',
-      'isomorphic-dompurify',
-      'drizzle-orm',
-      'drizzle-orm/pg-core',
-      'drizzle-orm/neon-http',
-      'drizzle-zod',
-      'zod',
-      '@upstash/ratelimit',
-      '@upstash/redis',
-      '@neondatabase/serverless',
-      'jose',
-      'stripe',
     ],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,8 +576,8 @@ importers:
         specifier: ^10.3.3
         version: 10.3.3(@types/react@19.2.14)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.3.3(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@6.0.6))(vite@6.4.3(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.0(@swc/core@1.15.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/addon-vitest':
-        specifier: ^10.4.1
-        version: 10.4.1(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@6.0.6))(vitest@4.1.8)
+        specifier: 10.3.3
+        version: 10.3.3(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@6.0.6))(vitest@4.1.8)
       '@storybook/nextjs-vite':
         specifier: ^10.3.5
         version: 10.3.5(@babel/core@7.29.6)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(next@16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.62.2)(storybook@10.3.3(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@6.4.3(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.0(@swc/core@1.15.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
@@ -6227,13 +6227,13 @@ packages:
     peerDependencies:
       storybook: ^10.3.3
 
-  '@storybook/addon-vitest@10.4.1':
-    resolution: {integrity: sha512-ymrX9EOou1x3d21iDhjP3j3XfhOAiflhlPZWKcipULBoJCq/aZPbV68EghzovkJNuGRl9ezMYxbbKxwrMmCmGg==}
+  '@storybook/addon-vitest@10.3.3':
+    resolution: {integrity: sha512-9bbUAgraZhHh35WuWJn/83B0KvkcsP8dNpzbhssMeWQTfu92TR3DqRNeGTNSlyZvhbGfwiwT3TfBzzM4dX1feg==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^10.4.1
+      storybook: ^10.3.3
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -22780,7 +22780,7 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-vitest@10.4.1(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@6.0.6))(vitest@4.1.8)':
+  '@storybook/addon-vitest@10.3.3(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@6.0.6))(vitest@4.1.8)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Goal

Repair Storybook A11y CI infrastructure blocked by vitest browser-mode esbuild prebundle failures (6811 chrome87 transform errors) and `@storybook/addon-vitest` version skew.

## Changes

- **vitest.config.storybook.mts**: Remove server-side deps from `optimizeDeps.include` (drizzle, stripe, sentry, neon, upstash, jose, etc.); set `esbuild`/`optimizeDeps.esbuildOptions` target to `esnext`; drop unresolvable prebundle entries (`react-hook-form`, `@radix-ui/react-context-menu`, `@clerk/nextjs`).
- **package.json / lockfile**: Pin `@storybook/addon-vitest` to `10.3.3` to match `storybook@10.3.x` (fixes `analyzeTestResults` export mismatch with 10.4.x).
- **.storybook/main.ts**: Fix `@jovie/ui` monorepo alias path; add `@/features` alias; extend dashboard/onboarding action mocks for subpath imports.
- **Story fixes**: Point atom DropdownMenu/Popover/Sheet/Tooltip stories at `@jovie/ui` exports (local wrapper files removed).

## Testing

```bash
CI=true pnpm --filter web test:a11y
```

**Before (main):** config load fails — `@storybook/addon-vitest@10.4.1` vs `storybook@10.3.3`, plus esbuild chrome87 errors prebundling server deps.

**After:** 107/120 story files load; **533/533 a11y tests pass**. Remaining 13 files fail on unrelated server-module leakage (`node:net` in auth test-mode) — follow-up outside this infra PR.

## Unblocks

PRs #12155 and #12156 should re-run CI after merge.

---
*Generated by Claude Code*