### PR TITLE
fix(onboarding): bypass Clerk on local /start E2E runs (#11309)

### DIFF
--- a/apps/web/app/(dynamic)/start/layout.test.tsx
+++ b/apps/web/app/(dynamic)/start/layout.test.tsx
@@ -78,4 +78,16 @@ describe('start route layout', () => {
       { forceBypassClerk: false, skipCoreProviders: true },
     ]);
   });
+
+  it('bypasses Clerk for local Playwright E2E runs', async () => {
+    vi.stubEnv('NEXT_PUBLIC_E2E_MODE', '1');
+    vi.stubEnv('VERCEL_ENV', '');
+    const { default: StartLayout } = await import('./layout');
+
+    render(await StartLayout({ children: <div data-testid='child' /> }));
+
+    expect(mocks.providerProps).toEqual([
+      { forceBypassClerk: true, skipCoreProviders: true },
+    ]);
+  });
 });

--- a/apps/web/app/(dynamic)/start/layout.tsx
+++ b/apps/web/app/(dynamic)/start/layout.tsx
@@ -16,7 +16,12 @@ export default async function StartLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const forceBypassClerk = env.PUBLIC_NOAUTH_SMOKE === '1' && !isSecureEnv();
+  // Anonymous onboarding never needs a live Clerk bootstrap on loopback E2E/dev
+  // hosts — loading FAPI JS from localhost causes CORS console errors and jank.
+  const forceBypassClerk =
+    !isSecureEnv() &&
+    (env.PUBLIC_NOAUTH_SMOKE === '1' ||
+      process.env.NEXT_PUBLIC_E2E_MODE === '1');
   const initialFlags = await getAppFlagsSnapshot({
     flagNames: resolveStartRouteFlagNames(),
   });


### PR DESCRIPTION
## Goal

Clean the `/start` goal golden path: zero console errors, layout shift, UI jank, and Turnstile issues (GitHub #11309 / JOV-3314).

<!-- linear-issue-id:JOV-3314 -->

## Root cause

Local Playwright E2E hit `/start` with `NEXT_PUBLIC_E2E_MODE=1` but without `PUBLIC_NOAUTH_SMOKE` or `NEXT_PUBLIC_CLERK_MOCK`. `shouldBypassClerk` permitted real Clerk on loopback, so the page loaded FAPI `clerk.browser.js` and the browser logged CORS preflight failures — failing the zero-console golden-path gate.

## Fix

Extend `/start` layout `forceBypassClerk` to include local E2E mode (`NEXT_PUBLIC_E2E_MODE=1` on non-secure hosts). Anonymous onboarding does not need a live Clerk bootstrap on loopback.

## Verification

| Check | Result |
|-------|--------|
| `app/(dynamic)/start/layout.test.tsx` | 3 passed |
| `start-onboarding-chat.spec.ts` (chromium) | 8 passed, 1 flaky (pre-existing starter-prompt strict-mode duplicate) |
| `pnpm --filter @jovie/web run typecheck` | pass |
| `pnpm biome check` (changed files) | pass |
| Staging canary `https://staging.jov.ie/start` | no Turnstile/500 error strings |
| Production canary `https://jov.ie/start` | no Turnstile/500 error strings |

## bug-to-test

Regression test added: `bypasses Clerk for local Playwright E2E runs` in `layout.test.tsx`.

## Risk

Low — only affects local/non-secure E2E and smoke hosts; staging/production `/start` still loads Clerk for inline sign-up.