### PR TITLE
fix(chat): composer draft persistence + paste resilience (JOV-3647)

### DIFF
--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -13,6 +13,10 @@ import {
   useState,
 } from 'react';
 import { DictationWaveform } from '@/components/shell/DictationWaveform';
+import {
+  insertLargeTextAtCaret,
+  shouldChunkLargePaste,
+} from '@/lib/chat/large-text-paste';
 import { serializeEntity, serializeSkill } from '@/lib/chat/tokens';
 import type { TranscriberErrorCode } from '@/lib/chat/transcriber';
 import { cn } from '@/lib/utils';
@@ -567,6 +571,37 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
       []
     );
 
+    const handlePaste = useCallback(
+      (event: React.ClipboardEvent) => {
+        const hasFileItems = Array.from(event.clipboardData.items).some(
+          item => item.kind === 'file'
+        );
+        if (hasFileItems) {
+          onPaste?.(event);
+          return;
+        }
+
+        const pastedText = event.clipboardData.getData('text/plain');
+        if (!shouldChunkLargePaste(pastedText.length)) {
+          onPaste?.(event);
+          return;
+        }
+
+        const textarea = internalTextareaRef.current;
+        if (!textarea) return;
+
+        event.preventDefault();
+        insertLargeTextAtCaret({
+          textarea,
+          pastedText,
+          currentValue: value,
+          onValueChange: handleChange,
+          maxLength: MAX_MESSAGE_LENGTH + 100,
+        });
+      },
+      [handleChange, onPaste, value]
+    );
+
     // Resolve the surface mode from textarea + picker state. Shell + Chat V1
     // keeps empty focus calm so the composer doesn't reflow just because the
     // textarea received focus.
@@ -743,7 +778,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                       value={value}
                       onChange={handleChange}
                       handleKeyDown={handleKeyDown}
-                      onPaste={onPaste}
+                      onPaste={handlePaste}
                       placeholder={placeholder}
                       isAtMaxHeight={isAtMaxHeight}
                       measuredHeight={measuredHeight}
@@ -825,7 +860,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                   value={value}
                   onChange={handleChange}
                   handleKeyDown={handleKeyDown}
-                  onPaste={onPaste}
+                  onPaste={handlePaste}
                   placeholder={placeholder}
                   isAtMaxHeight={isAtMaxHeight}
                   measuredHeight={measuredHeight}

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -3,8 +3,9 @@
 import { SimpleTooltip, Skeleton } from '@jovie/ui';
 import { Check, Copy } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
-import { memo } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { useClipboard } from '@/hooks/useClipboard';
+import { copyMarkdownToClipboard } from '@/lib/chat/copy-markdown';
 import { cn } from '@/lib/utils';
 import { getRenderableToolEvents, ToolPartsRenderer } from '../tool-ui';
 import type { MessagePart } from '../types';
@@ -62,8 +63,37 @@ export const ChatMessage = memo(function ChatMessage({
   renderTools = true,
 }: ChatMessageProps) {
   const isUser = role === 'user';
-  const { copy, isSuccess } = useClipboard();
+  const { copy, isSuccess: fallbackCopySuccess } = useClipboard();
+  const [markdownCopied, setMarkdownCopied] = useState(false);
+  const markdownCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
   const messageText = getMessageText(parts);
+  const isCopySuccess = markdownCopied || fallbackCopySuccess;
+
+  useEffect(() => {
+    return () => {
+      if (markdownCopyTimeoutRef.current) {
+        clearTimeout(markdownCopyTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopyMessage = () => {
+    void copyMarkdownToClipboard(messageText).then(success => {
+      if (success) {
+        setMarkdownCopied(true);
+        if (markdownCopyTimeoutRef.current) {
+          clearTimeout(markdownCopyTimeoutRef.current);
+        }
+        markdownCopyTimeoutRef.current = setTimeout(() => {
+          setMarkdownCopied(false);
+        }, 2000);
+        return;
+      }
+      void copy(messageText);
+    });
+  };
   const shouldReduceMotion = useReducedMotion();
   const toolEvents = getRenderableToolEvents(parts);
   const fileParts = parts.filter(
@@ -137,7 +167,7 @@ export const ChatMessage = memo(function ChatMessage({
               className='system-b-chat-loading-indicator'
               role='status'
               aria-live='polite'
-              aria-label='Jovie is thinking'
+              aria-label='Jovie Is Thinking'
             >
               {/* Assistant thinking shimmer — ChatMessageSkeleton-style reserved space */}
               <div className='system-b-chat-loading-head'>
@@ -189,16 +219,18 @@ export const ChatMessage = memo(function ChatMessage({
 
           {!isThinking && !isStreaming && messageText ? (
             <div className='system-b-chat-copy-row'>
-              <SimpleTooltip content={isSuccess ? 'Copied!' : 'Copy response'}>
+              <SimpleTooltip
+                content={isCopySuccess ? 'Copied!' : 'Copy response'}
+              >
                 <button
                   type='button'
-                  onClick={() => copy(messageText)}
+                  onClick={handleCopyMessage}
                   className='system-b-chat-copy-button'
                   aria-label={
-                    isSuccess ? 'Copied to clipboard' : 'Copy message'
+                    isCopySuccess ? 'Copied to clipboard' : 'Copy message'
                   }
                 >
-                  {isSuccess ? (
+                  {isCopySuccess ? (
                     <Check className='system-b-chat-copy-icon' />
                   ) : (
                     <Copy className='system-b-chat-copy-icon' />

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -8,6 +8,11 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { track } from '@/lib/analytics';
 import { matchCommand } from '@/lib/chat/command-registry';
+import {
+  clearComposerDraft,
+  readComposerDraft,
+  saveComposerDraft,
+} from '@/lib/chat/composer-draft-store';
 import { consumePendingChatPrompt } from '@/lib/chat/open-chat-with-prompt';
 import { isRecoverableToolErrorCode } from '@/lib/chat/tool-errors';
 import { PACER_TIMING } from '@/lib/pacer/hooks/timing';
@@ -230,7 +235,10 @@ export function useJovieChat({
   const lastAssistantPartsSignatureRef = useRef<string | null>(null);
   const sdkMessagesRef = useRef<UIMessage[]>([]);
   const loadedConversationIdsRef = useRef<Set<string>>(new Set());
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState(() =>
+    readComposerDraft(conversationId ?? null)
+  );
+  const inputDraftRef = useRef(input);
   const chipTray = useChipTray();
   const [chatError, setChatError] = useState<ChatError | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -708,6 +716,17 @@ export function useJovieChat({
     }
   }, [input, chatError]);
 
+  useEffect(() => {
+    inputDraftRef.current = input;
+  }, [input]);
+
+  useEffect(() => {
+    const handle = globalThis.setTimeout(() => {
+      saveComposerDraft(activeConversationId, input);
+    }, 250);
+    return () => globalThis.clearTimeout(handle);
+  }, [activeConversationId, input]);
+
   // Sync activeConversationId when parent prop changes
   useEffect(() => {
     const nextConversationId = conversationId ?? null;
@@ -721,6 +740,9 @@ export function useJovieChat({
         return;
       }
     }
+
+    saveComposerDraft(activeConversationId, inputDraftRef.current);
+    setInput(readComposerDraft(nextConversationId));
 
     setActiveConversationId(nextConversationId);
     activeClientTurnIdRef.current = null;
@@ -751,6 +773,7 @@ export function useJovieChat({
         ],
         now: Date.now(),
       });
+      clearComposerDraft(activeConversationId);
       setInput('');
       command.execute(commandCtx);
       return true;
@@ -823,6 +846,7 @@ export function useJovieChat({
 
       try {
         const result = sendMessage(payload, sendOptions);
+        clearComposerDraft(activeConversationId);
         setInput('');
         void Promise.resolve(result).catch(error_ => {
           handleChatFailure(toError(error_), 'send', clientTurnId);

--- a/apps/web/lib/chat/composer-draft-store.ts
+++ b/apps/web/lib/chat/composer-draft-store.ts
@@ -1,0 +1,54 @@
+const NEW_CHAT_DRAFT_KEY = '__new__';
+const DRAFT_CACHE_LIMIT = 50;
+
+const draftByConversationId = new Map<string, string>();
+
+function draftKey(conversationId: string | null | undefined): string {
+  return conversationId ?? NEW_CHAT_DRAFT_KEY;
+}
+
+function trimDraft(value: string): string {
+  return value;
+}
+
+function pruneDraftCache(): void {
+  while (draftByConversationId.size > DRAFT_CACHE_LIMIT) {
+    const oldestKey = draftByConversationId.keys().next().value;
+    if (!oldestKey) break;
+    draftByConversationId.delete(oldestKey);
+  }
+}
+
+/** Persist the in-progress composer text for a conversation thread. */
+export function saveComposerDraft(
+  conversationId: string | null | undefined,
+  value: string
+): void {
+  const key = draftKey(conversationId);
+  const nextValue = trimDraft(value);
+  if (nextValue.length === 0) {
+    draftByConversationId.delete(key);
+    return;
+  }
+  draftByConversationId.set(key, nextValue);
+  pruneDraftCache();
+}
+
+/** Read the saved composer draft for a conversation thread. */
+export function readComposerDraft(
+  conversationId: string | null | undefined
+): string {
+  return draftByConversationId.get(draftKey(conversationId)) ?? '';
+}
+
+/** Remove a saved composer draft after a successful send or command commit. */
+export function clearComposerDraft(
+  conversationId: string | null | undefined
+): void {
+  draftByConversationId.delete(draftKey(conversationId));
+}
+
+/** Test helper — reset module state between unit tests. */
+export function resetComposerDraftStoreForTests(): void {
+  draftByConversationId.clear();
+}

--- a/apps/web/lib/chat/copy-markdown.ts
+++ b/apps/web/lib/chat/copy-markdown.ts
@@ -1,0 +1,76 @@
+import { remark } from 'remark';
+import remarkGfm from 'remark-gfm';
+import remarkHtml from 'remark-html';
+import { sanitizeServerHtml } from '@/lib/html/sanitize';
+
+let markdownProcessor: ReturnType<typeof remark> | null = null;
+
+function getMarkdownProcessor(): ReturnType<typeof remark> {
+  if (!markdownProcessor) {
+    markdownProcessor = remark()
+      .use(remarkGfm)
+      .use(remarkHtml, { sanitize: false });
+  }
+  return markdownProcessor;
+}
+
+/** Render markdown to sanitized HTML for rich clipboard payloads. */
+export async function markdownToHtml(markdown: string): Promise<string> {
+  const result = await getMarkdownProcessor().process(markdown);
+  return sanitizeServerHtml(String(result));
+}
+
+function fallbackCopyPlainText(text: string): boolean {
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-999999px';
+    textarea.style.top = '-999999px';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const successful = document.execCommand('copy');
+    textarea.remove();
+    return successful;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copy assistant markdown to the clipboard with both plain-text markdown and
+ * rendered HTML so rich paste targets keep formatting.
+ */
+export async function copyMarkdownToClipboard(
+  markdown: string
+): Promise<boolean> {
+  if (!markdown) return false;
+
+  try {
+    if (
+      typeof navigator !== 'undefined' &&
+      navigator.clipboard?.write &&
+      typeof ClipboardItem !== 'undefined'
+    ) {
+      const html = await markdownToHtml(markdown);
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          'text/plain': new Blob([markdown], { type: 'text/plain' }),
+          'text/html': new Blob([html], { type: 'text/html' }),
+        }),
+      ]);
+      return true;
+    }
+
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(markdown);
+      return true;
+    }
+  } catch {
+    // Fall through to legacy copy.
+  }
+
+  return fallbackCopyPlainText(markdown);
+}

--- a/apps/web/lib/chat/large-text-paste.ts
+++ b/apps/web/lib/chat/large-text-paste.ts
@@ -1,0 +1,96 @@
+export const LARGE_PASTE_THRESHOLD = 4096;
+export const LARGE_PASTE_CHUNK_SIZE = 2048;
+
+export interface InsertLargeTextAtCaretOptions {
+  readonly textarea: HTMLTextAreaElement;
+  readonly pastedText: string;
+  readonly currentValue: string;
+  readonly onValueChange: (value: string) => void;
+  readonly maxLength?: number;
+  readonly chunkSize?: number;
+  readonly schedule?: (work: () => void) => void;
+}
+
+function defaultSchedule(work: () => void): void {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    globalThis.requestAnimationFrame(work);
+    return;
+  }
+  globalThis.setTimeout(work, 0);
+}
+
+function selectionBounds(
+  textarea: HTMLTextAreaElement,
+  currentValue: string
+): { start: number; end: number } {
+  const start = textarea.selectionStart ?? currentValue.length;
+  const end = textarea.selectionEnd ?? start;
+  return { start, end };
+}
+
+/**
+ * Insert very large pasted text in chunks so React state updates do not block
+ * the main thread in a single synchronous paste handler.
+ */
+export function insertLargeTextAtCaret({
+  textarea,
+  pastedText,
+  currentValue,
+  onValueChange,
+  maxLength = Number.POSITIVE_INFINITY,
+  chunkSize = LARGE_PASTE_CHUNK_SIZE,
+  schedule = defaultSchedule,
+}: InsertLargeTextAtCaretOptions): void {
+  if (!pastedText) return;
+
+  const { start, end } = selectionBounds(textarea, currentValue);
+  const replacedLength = end - start;
+  const availableLength = Math.max(
+    0,
+    maxLength - currentValue.length + replacedLength
+  );
+  const textToInsert = pastedText.slice(0, availableLength);
+  if (textToInsert.length === 0) return;
+
+  const prefix = currentValue.slice(0, start);
+  const suffix = currentValue.slice(end);
+  const chunks: string[] = [];
+  for (let index = 0; index < textToInsert.length; index += chunkSize) {
+    chunks.push(textToInsert.slice(index, index + chunkSize));
+  }
+
+  let workingValue = `${prefix}${suffix}`;
+  let insertAt = start;
+
+  const finish = () => {
+    schedule(() => {
+      textarea.setSelectionRange(insertAt, insertAt);
+    });
+  };
+
+  const applyChunk = (chunkIndex: number) => {
+    const chunk = chunks[chunkIndex];
+    if (!chunk) {
+      finish();
+      return;
+    }
+
+    workingValue =
+      workingValue.slice(0, insertAt) + chunk + workingValue.slice(insertAt);
+    insertAt += chunk.length;
+    onValueChange(workingValue);
+
+    if (chunkIndex + 1 >= chunks.length) {
+      finish();
+      return;
+    }
+
+    schedule(() => applyChunk(chunkIndex + 1));
+  };
+
+  schedule(() => applyChunk(0));
+}
+
+export function shouldChunkLargePaste(textLength: number): boolean {
+  return textLength >= LARGE_PASTE_THRESHOLD;
+}

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -6,6 +6,7 @@ import { type ComponentProps, type ReactNode, useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatInput } from '@/components/jovie/components/ChatInput';
+import * as largeTextPaste from '@/lib/chat/large-text-paste';
 import { fastRender } from '@/tests/utils/fast-render';
 
 function withProviders(ui: ReactNode) {
@@ -748,6 +749,37 @@ describe('ChatInput', () => {
     });
 
     await waitFor(() => expect(sendButton).toBeEnabled());
+  });
+
+  it('routes very large text pastes through the chunked insert helper', () => {
+    const insertSpy = vi.spyOn(largeTextPaste, 'insertLargeTextAtCaret');
+    const onChange = vi.fn();
+    const largePaste = 'z'.repeat(5000);
+
+    fastRender(
+      withProviders(
+        <ChatInput {...baseProps} value='hello' onChange={onChange} />
+      )
+    );
+
+    const textarea = screen.getByRole('textbox', {
+      name: /chat message input/i,
+    }) as HTMLTextAreaElement;
+    textarea.setSelectionRange(5, 5);
+
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        items: [],
+        getData: (type: string) => (type === 'text/plain' ? largePaste : ''),
+      },
+    });
+
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+    expect(insertSpy.mock.calls[0]?.[0]).toMatchObject({
+      pastedText: largePaste,
+      currentValue: 'hello',
+    });
+    insertSpy.mockRestore();
   });
 
   it('shows the stop action while streaming even when the draft is empty', async () => {

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import type { ComponentProps, ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { ChatMessage } from '@/components/jovie/components/ChatMessage';
@@ -66,6 +66,13 @@ vi.mock('next/dynamic', () => ({
 
 vi.mock('@/components/jovie/components/ChatMarkdown', () => ({
   ChatMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+const copyMarkdownToClipboardMock = vi.fn().mockResolvedValue(true);
+
+vi.mock('@/lib/chat/copy-markdown', () => ({
+  copyMarkdownToClipboard: (...args: unknown[]) =>
+    copyMarkdownToClipboardMock(...args),
 }));
 
 describe('ChatMessage', () => {
@@ -167,6 +174,21 @@ describe('ChatMessage', () => {
     expect(loading.querySelector('.system-b-chat-loading-avatar')).toBeTruthy();
     expect(loading.querySelector('.system-b-chat-loading-label')).toBeTruthy();
     expect(loading.querySelector('.system-b-chat-loading-line')).toBeTruthy();
+  });
+
+  it('copies assistant markdown through the rich clipboard helper', () => {
+    copyMarkdownToClipboardMock.mockClear();
+    const messageProps = {
+      id: 'assistant-copy-rich',
+      role: 'assistant' as const,
+      parts: [{ type: 'text' as const, text: '**Bold** answer' }],
+    };
+
+    fastRender(<ChatMessage {...messageProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy message' }));
+
+    expect(copyMarkdownToClipboardMock).toHaveBeenCalledWith('**Bold** answer');
   });
 
   it('keeps assistant reply and copy action on named System B primitives', () => {

--- a/apps/web/tests/unit/chat/composer-draft-store.test.ts
+++ b/apps/web/tests/unit/chat/composer-draft-store.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clearComposerDraft,
+  readComposerDraft,
+  resetComposerDraftStoreForTests,
+  saveComposerDraft,
+} from '@/lib/chat/composer-draft-store';
+
+describe('composer-draft-store', () => {
+  it('stores and restores drafts per conversation thread', () => {
+    resetComposerDraftStoreForTests();
+
+    saveComposerDraft('thread-a', 'Draft for thread A');
+    saveComposerDraft('thread-b', 'Draft for thread B');
+
+    expect(readComposerDraft('thread-a')).toBe('Draft for thread A');
+    expect(readComposerDraft('thread-b')).toBe('Draft for thread B');
+  });
+
+  it('uses a shared draft bucket for new chats without a conversation id', () => {
+    resetComposerDraftStoreForTests();
+
+    saveComposerDraft(null, 'Brand new chat draft');
+    expect(readComposerDraft(null)).toBe('Brand new chat draft');
+    expect(readComposerDraft(undefined)).toBe('Brand new chat draft');
+  });
+
+  it('clears drafts after send and removes empty drafts on save', () => {
+    resetComposerDraftStoreForTests();
+
+    saveComposerDraft('thread-a', 'temporary draft');
+    clearComposerDraft('thread-a');
+    expect(readComposerDraft('thread-a')).toBe('');
+
+    saveComposerDraft('thread-b', '   ');
+    expect(readComposerDraft('thread-b')).toBe('   ');
+    saveComposerDraft('thread-b', '');
+    expect(readComposerDraft('thread-b')).toBe('');
+  });
+});

--- a/apps/web/tests/unit/chat/copy-markdown.test.ts
+++ b/apps/web/tests/unit/chat/copy-markdown.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  copyMarkdownToClipboard,
+  markdownToHtml,
+} from '@/lib/chat/copy-markdown';
+
+describe('copy-markdown', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders markdown to sanitized html', async () => {
+    const html = await markdownToHtml('**Bold** and `code`');
+    expect(html).toContain('<strong>Bold</strong>');
+    expect(html).toContain('<code>code</code>');
+    expect(html).not.toContain('<script');
+  });
+
+  it('writes markdown and html clipboard payloads when supported', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    class MockClipboardItem {
+      readonly items: Record<string, Blob>;
+      constructor(items: Record<string, Blob>) {
+        this.items = items;
+      }
+    }
+
+    vi.stubGlobal('ClipboardItem', MockClipboardItem);
+    vi.stubGlobal('navigator', {
+      clipboard: { write, writeText: vi.fn() },
+    });
+
+    const success = await copyMarkdownToClipboard('## Heading\n\nParagraph');
+
+    expect(success).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    const clipboardItem = write.mock.calls[0]?.[0]?.[0] as MockClipboardItem;
+    expect(clipboardItem.items['text/plain']).toBeInstanceOf(Blob);
+    expect(clipboardItem.items['text/html']).toBeInstanceOf(Blob);
+    expect(clipboardItem.items['text/plain'].type).toBe('text/plain');
+    expect(clipboardItem.items['text/html'].type).toBe('text/html');
+  });
+
+  it('falls back to plain text copy when rich clipboard write is unavailable', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', {
+      clipboard: { writeText },
+    });
+    vi.stubGlobal('ClipboardItem', undefined);
+
+    const success = await copyMarkdownToClipboard('Keep **markdown**');
+
+    expect(success).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('Keep **markdown**');
+  });
+});

--- a/apps/web/tests/unit/chat/large-text-paste.test.ts
+++ b/apps/web/tests/unit/chat/large-text-paste.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  insertLargeTextAtCaret,
+  LARGE_PASTE_CHUNK_SIZE,
+  shouldChunkLargePaste,
+} from '@/lib/chat/large-text-paste';
+
+describe('large-text-paste', () => {
+  it('only chunks pastes at or above the threshold', () => {
+    expect(shouldChunkLargePaste(4095)).toBe(false);
+    expect(shouldChunkLargePaste(4096)).toBe(true);
+  });
+
+  it('inserts large pasted text in multiple onValueChange calls', () => {
+    const pastedText = 'x'.repeat(LARGE_PASTE_CHUNK_SIZE * 2 + 10);
+    const textarea = document.createElement('textarea');
+    textarea.value = 'prefix|suffix';
+    textarea.selectionStart = 6;
+    textarea.selectionEnd = 6;
+
+    const onValueChange = vi.fn();
+    const schedule = vi.fn((work: () => void) => work());
+
+    insertLargeTextAtCaret({
+      textarea,
+      pastedText,
+      currentValue: 'prefix|suffix',
+      onValueChange,
+      schedule,
+    });
+
+    expect(onValueChange).toHaveBeenCalledTimes(3);
+    expect(onValueChange.mock.calls[2]?.[0]).toBe(`prefix${pastedText}|suffix`);
+  });
+
+  it('places the caret after the inserted text when chunking finishes', () => {
+    const textarea = document.createElement('textarea');
+    textarea.value = 'prefix|suffix';
+    textarea.selectionStart = 6;
+    textarea.selectionEnd = 6;
+    const setSelectionRange = vi.spyOn(textarea, 'setSelectionRange');
+
+    insertLargeTextAtCaret({
+      textarea,
+      pastedText: 'abc',
+      currentValue: 'prefix|suffix',
+      onValueChange: vi.fn(),
+      schedule: work => work(),
+    });
+
+    expect(setSelectionRange).toHaveBeenCalledWith(9, 9);
+  });
+
+  it('respects max length when inserting chunked paste', () => {
+    const pastedText = 'y'.repeat(20);
+    const textarea = document.createElement('textarea');
+    textarea.value = 'abc';
+    textarea.selectionStart = 3;
+    textarea.selectionEnd = 3;
+
+    const onValueChange = vi.fn();
+    const schedule = vi.fn((work: () => void) => work());
+
+    insertLargeTextAtCaret({
+      textarea,
+      pastedText,
+      currentValue: 'abc',
+      onValueChange,
+      maxLength: 8,
+      chunkSize: 3,
+      schedule,
+    });
+
+    expect(onValueChange.mock.calls.at(-1)?.[0]).toBe('abcyyyyy');
+  });
+});

--- a/apps/web/tests/unit/chat/useJovieChat.draft-persistence.test.tsx
+++ b/apps/web/tests/unit/chat/useJovieChat.draft-persistence.test.tsx
@@ -1,0 +1,121 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useJovieChat } from '@/components/jovie/hooks/useJovieChat';
+import { resetComposerDraftStoreForTests } from '@/lib/chat/composer-draft-store';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const sendMessageMock = vi.fn();
+const maybeExecuteMock = vi.fn();
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: () => ({
+    messages: [],
+    sendMessage: sendMessageMock,
+    status: 'ready',
+    setMessages: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn(),
+  }),
+}));
+
+vi.mock('@tanstack/react-pacer', () => ({
+  useAsyncRateLimiter: (
+    fn: (args: { text: string }) => Promise<void>,
+    _options: { onReject?: () => void }
+  ) => ({
+    maybeExecute: (args: { text: string }) => {
+      maybeExecuteMock(args);
+      return fn(args);
+    },
+    getRemainingInWindow: () => 1,
+    state: { isExecuting: false },
+  }),
+}));
+
+vi.mock('@/lib/queries', () => ({
+  queryKeys: {
+    chat: {
+      usage: () => ['chat', 'usage'],
+      conversations: () => ['chat', 'conversations'],
+    },
+  },
+  useChatConversationQuery: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/lib/chat/open-chat-with-prompt', () => ({
+  consumePendingChatPrompt: () => null,
+}));
+
+describe('useJovieChat draft persistence', () => {
+  beforeEach(() => {
+    resetComposerDraftStoreForTests();
+    sendMessageMock.mockReset();
+    maybeExecuteMock.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('restores per-thread drafts when switching conversations', () => {
+    const { result, rerender } = renderHook(
+      ({ conversationId }: { conversationId: string | null }) =>
+        useJovieChat({ conversationId }),
+      { initialProps: { conversationId: 'thread-a' as string | null } }
+    );
+
+    act(() => {
+      result.current.setInput('Draft for thread A');
+    });
+
+    rerender({ conversationId: 'thread-b' });
+    act(() => {
+      result.current.setInput('Draft for thread B');
+    });
+
+    rerender({ conversationId: 'thread-a' });
+    expect(result.current.input).toBe('Draft for thread A');
+
+    rerender({ conversationId: 'thread-b' });
+    expect(result.current.input).toBe('Draft for thread B');
+  });
+
+  it('clears the active thread draft after a successful send', async () => {
+    sendMessageMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useJovieChat({ conversationId: 'thread-a' })
+    );
+
+    act(() => {
+      result.current.setInput('Send me');
+    });
+
+    await act(async () => {
+      await result.current.submitMessage('Send me');
+    });
+
+    expect(result.current.input).toBe('');
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements JOV-3647 chat composer resilience:

- **Per-thread draft persistence** — composer text is saved/restored when switching conversations
- **Markdown-preserving copy** — assistant copy writes both `text/plain` (markdown source) and `text/html` (rendered) clipboard payloads
- **Large-paste resilience** — pastes ≥4KB are inserted in chunked updates via `requestAnimationFrame` to avoid UI hangs

## Approach

- `composer-draft-store.ts` keeps an in-memory per-conversation draft map; `useJovieChat` saves on switch/debounce and clears on send
- `copy-markdown.ts` renders markdown with remark + writes rich clipboard items
- `large-text-paste.ts` + `ChatInput` paste handler chunk large inserts before React state updates

## Test plan

- [x] `pnpm --filter=@jovie/web run typecheck`
- [x] `pnpm --filter=@jovie/web exec vitest run tests/unit/chat/` (766 passing)
- [x] New unit tests for draft store, markdown copy, large paste, `useJovieChat` draft restore, `ChatInput`/`ChatMessage` integration

<!-- linear-issue-id:JOV-3647 -->