### PR TITLE
fix(ios): render tool_call as card not raw XML (JOV-3607)

### DIFF
--- a/apps/ios/Jovie.xcodeproj/project.pbxproj
+++ b/apps/ios/Jovie.xcodeproj/project.pbxproj
@@ -50,6 +50,9 @@
 		A0J0V2549000000000000000A /* MobileChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000009 /* MobileChatView.swift */; };
 		A0J0V2549000000000000000C /* ChatRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V2549000000000000000B /* ChatRepositoryTests.swift */; };
 		A0J0V2549000000000000000E /* MobileChatClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V2549000000000000000D /* MobileChatClientTests.swift */; };
+		A0J0V36070000000000000002 /* MobileChatContentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V36070000000000000001 /* MobileChatContentParser.swift */; };
+		A0J0V36070000000000000004 /* MobileChatToolCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V36070000000000000003 /* MobileChatToolCardView.swift */; };
+		A0J0V36070000000000000006 /* MobileChatContentParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V36070000000000000005 /* MobileChatContentParserTests.swift */; };
 		A0J0V26350000000000000002 /* MobileAuthFinalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V26350000000000000001 /* MobileAuthFinalization.swift */; };
 		A0J0V26350000000000000004 /* MobileAuthFinalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V26350000000000000003 /* MobileAuthFinalizationTests.swift */; };
 		A13F86A7D4F0C7F83D2BB000 /* ScreenBrightnessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA81B967152B211E5988375 /* ScreenBrightnessManager.swift */; };
@@ -149,6 +152,9 @@
 		A0J0V25490000000000000009 /* MobileChatView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatView.swift; sourceTree = "<group>"; };
 		A0J0V2549000000000000000B /* ChatRepositoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatRepositoryTests.swift; sourceTree = "<group>"; };
 		A0J0V2549000000000000000D /* MobileChatClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatClientTests.swift; sourceTree = "<group>"; };
+		A0J0V36070000000000000001 /* MobileChatContentParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatContentParser.swift; sourceTree = "<group>"; };
+		A0J0V36070000000000000003 /* MobileChatToolCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatToolCardView.swift; sourceTree = "<group>"; };
+		A0J0V36070000000000000005 /* MobileChatContentParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatContentParserTests.swift; sourceTree = "<group>"; };
 		A0J0V26350000000000000001 /* MobileAuthFinalization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileAuthFinalization.swift; sourceTree = "<group>"; };
 		A0J0V26350000000000000003 /* MobileAuthFinalizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileAuthFinalizationTests.swift; sourceTree = "<group>"; };
 		A108B03BA602F4C24B54E590 /* Inter-Variable.ttf */ = {isa = PBXFileReference; includeInIndex = 1; path = "Inter-Variable.ttf"; sourceTree = "<group>"; };
@@ -252,6 +258,7 @@
 				F1E2D3C4B5A697886756453E /* SettingsEscapeTrapGuardTests.swift */,
 				A0J0V2549000000000000000B /* ChatRepositoryTests.swift */,
 				A0J0V2549000000000000000D /* MobileChatClientTests.swift */,
+				A0J0V36070000000000000005 /* MobileChatContentParserTests.swift */,
 				191669F70597A1039C74C0B1 /* MeRepositoryTests.swift */,
 				B83A77F0A36DF3E6D5C77C2F /* MobileMeResponseTests.swift */,
 				A0B10F00000000000000000D /* ObservabilityRedactionTests.swift */,
@@ -343,6 +350,7 @@
 				918FBCBCF600AA8C10191F60 /* MeCache.swift */,
 				28FBA9F0D12E0BD1CB8B0B09 /* MeRepository.swift */,
 				A0J0V25490000000000000005 /* MobileChatClient.swift */,
+				A0J0V36070000000000000001 /* MobileChatContentParser.swift */,
 				A0J0V25490000000000000007 /* MobileChatModels.swift */,
 				3EC2367922F1F00AB0AF1164 /* MobileMeResponse.swift */,
 				A0B10F00000000000000000B /* Observability */,
@@ -400,6 +408,7 @@
 			isa = PBXGroup;
 			children = (
 				A0J0V25490000000000000009 /* MobileChatView.swift */,
+				A0J0V36070000000000000003 /* MobileChatToolCardView.swift */,
 			);
 			name = Chat;
 			path = Chat;
@@ -592,6 +601,7 @@
 				EE4CBA88057592FAFCD7F926 /* AppStateTests.swift in Sources */,
 				A0J0V2549000000000000000C /* ChatRepositoryTests.swift in Sources */,
 				A0J0V2549000000000000000E /* MobileChatClientTests.swift in Sources */,
+				A0J0V36070000000000000006 /* MobileChatContentParserTests.swift in Sources */,
 				FDD930D67ACF374B16E87FDE /* MeRepositoryTests.swift in Sources */,
 				CE7C4C47EFA23AFA2B205BE4 /* MobileMeResponseTests.swift in Sources */,
 				A0B10F00000000000000000F /* ObservabilityRedactionTests.swift in Sources */,
@@ -634,6 +644,7 @@
 				8747690FEEF7BD069EBF7430 /* MeRepository.swift in Sources */,
 				A0J0V25490000000000000006 /* MobileChatClient.swift in Sources */,
 				A0J0V25490000000000000008 /* MobileChatModels.swift in Sources */,
+				A0J0V36070000000000000002 /* MobileChatContentParser.swift in Sources */,
 				52C5CBF9C24E4C502FA64955 /* MobileMeResponse.swift in Sources */,
 				DA0F3A9E1C4B4B149B7D4C21 /* NativeSessionTokenStore.swift in Sources */,
 				A0J0V26350000000000000002 /* MobileAuthFinalization.swift in Sources */,
@@ -648,6 +659,7 @@
 				F3E8220C7612A63FF54DB345 /* NeedsOnboardingView.swift in Sources */,
 				F178AB3E908746C78645E4EE /* SettingsView.swift in Sources */,
 				A0J0V2549000000000000000A /* MobileChatView.swift in Sources */,
+				A0J0V36070000000000000004 /* MobileChatToolCardView.swift in Sources */,
 				FA8D45F4123178BDD33F82C5 /* SplashView.swift in Sources */,
 				5E40E80F8AFF20CF3CE9A09B /* IntentNavigationStore.swift in Sources */,
 				7F479BE5BDDDDCF9BFFF256B /* JovieAppIntents.swift in Sources */,

--- a/apps/ios/Jovie/Core/MobileChatContentParser.swift
+++ b/apps/ios/Jovie/Core/MobileChatContentParser.swift
@@ -1,0 +1,362 @@
+import Foundation
+
+enum MobileChatToolCallState: Equatable, Sendable {
+  case running
+  case succeeded
+  case failed
+}
+
+struct MobileChatToolCallCardModel: Equatable, Identifiable, Sendable {
+  let id: String
+  let toolName: String
+  let title: String
+  let body: String?
+  let state: MobileChatToolCallState
+}
+
+enum MobileChatRenderableSegment: Equatable, Identifiable, Sendable {
+  case text(String)
+  case toolCall(MobileChatToolCallCardModel)
+
+  var id: String {
+    switch self {
+    case let .text(text):
+      return "text:\(text.hashValue)"
+    case let .toolCall(model):
+      return model.id
+    }
+  }
+}
+
+enum MobileChatContentParser {
+  static func segments(
+    from content: String,
+    isStreaming: Bool
+  ) -> [MobileChatRenderableSegment] {
+    guard !content.isEmpty else { return [] }
+
+    let resultStates = parseToolResultStates(from: content)
+    let sanitized = suppressIncompleteToolMarkup(
+      stripToolResultMarkup(from: content),
+      isStreaming: isStreaming
+    )
+
+    var segments: [MobileChatRenderableSegment] = []
+    var cursor = sanitized.startIndex
+
+    while cursor < sanitized.endIndex {
+      guard
+        let openRange = sanitized.range(
+          of: "<tool_call>",
+          range: cursor ..< sanitized.endIndex
+        )
+      else {
+        appendTextSegment(
+          String(sanitized[cursor...]).trimmingCharacters(in: .whitespacesAndNewlines),
+          to: &segments
+        )
+        break
+      }
+
+      appendTextSegment(
+        String(sanitized[cursor ..< openRange.lowerBound])
+          .trimmingCharacters(in: .whitespacesAndNewlines),
+        to: &segments
+      )
+
+      let afterOpen = openRange.upperBound
+      guard
+        let closeRange = sanitized.range(
+          of: "</tool_call>",
+          range: afterOpen ..< sanitized.endIndex
+        )
+      else {
+        if let partial = parseToolCallBlock(
+          String(sanitized[afterOpen...]),
+          isComplete: false,
+          resultState: nil
+        ) {
+          segments.append(.toolCall(partial))
+        }
+        break
+      }
+
+      let block = String(sanitized[afterOpen ..< closeRange.lowerBound])
+      if let model = parseToolCallBlock(
+        block,
+        isComplete: true,
+        resultState: resultStates[firstCapture(in: block, pattern: "<name>\\s*([^<]+?)\\s*</name>") ?? ""]
+      ) {
+        segments.append(.toolCall(model))
+      }
+
+      cursor = closeRange.upperBound
+    }
+
+    return segments
+  }
+
+  static func displayText(from content: String, isStreaming: Bool) -> String {
+    segments(from: content, isStreaming: isStreaming)
+      .compactMap { segment -> String? in
+        guard case let .text(text) = segment else { return nil }
+        return text
+      }
+      .filter { !$0.isEmpty }
+      .joined(separator: "\n\n")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private static func suppressIncompleteToolMarkup(_ content: String, isStreaming: Bool) -> String {
+    guard isStreaming else { return content }
+
+    var sanitized = content
+
+    if let openRange = sanitized.range(
+      of: "<tool_result",
+      options: [.backwards, .caseInsensitive]
+    ) {
+      let tail = sanitized[openRange.lowerBound...]
+      if !tail.contains("</tool_result>") {
+        sanitized = String(sanitized[..<openRange.lowerBound])
+      }
+    }
+
+    return sanitized
+  }
+
+  private static func stripToolResultMarkup(from content: String) -> String {
+    var sanitized = content
+    while let range = sanitized.range(
+      of: "<tool_result>[\\s\\S]*?</tool_result>",
+      options: .regularExpression
+    ) {
+      sanitized.removeSubrange(range)
+    }
+    return sanitized
+  }
+
+  private static func parseToolResultStates(from content: String) -> [String: MobileChatToolCallState] {
+    var states: [String: MobileChatToolCallState] = [:]
+    let pattern = "<tool_result>([\\s\\S]*?)</tool_result>"
+    guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+      return states
+    }
+
+    let range = NSRange(content.startIndex..., in: content)
+    regex.enumerateMatches(in: content, range: range) { match, _, _ in
+      guard
+        let match,
+        let blockRange = Range(match.range(at: 1), in: content)
+      else {
+        return
+      }
+
+      let block = String(content[blockRange])
+      guard let toolName = firstCapture(in: block, pattern: "<name>\\s*([^<]+?)\\s*</name>") else {
+        return
+      }
+
+      let trimmedName = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmedName.isEmpty else { return }
+
+      states[trimmedName] = resolveResultState(from: block)
+    }
+
+    return states
+  }
+
+  private static func resolveResultState(from block: String) -> MobileChatToolCallState {
+    if let explicitState = firstCapture(in: block, pattern: "<state>\\s*([^<]+?)\\s*</state>") {
+      let normalized = explicitState.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+      if normalized.contains("fail") || normalized.contains("denied") || normalized.contains("error") {
+        return .failed
+      }
+      if normalized.contains("pending") || normalized.contains("approval") || normalized.contains("running") {
+        return .running
+      }
+      if normalized.contains("success") || normalized.contains("complete") {
+        return .succeeded
+      }
+    }
+
+    let lower = block.lowercased()
+    if lower.contains("denied") || lower.contains("failed") || lower.contains("error") {
+      return .failed
+    }
+    if lower.contains("pending") || lower.contains("needs-approval") || lower.contains("approval") {
+      return .running
+    }
+    return .succeeded
+  }
+
+  private static func parseToolCallBlock(
+    _ block: String,
+    isComplete: Bool,
+    resultState: MobileChatToolCallState?
+  ) -> MobileChatToolCallCardModel? {
+    guard let toolName = firstCapture(in: block, pattern: "<name>\\s*([^<]+?)\\s*</name>") else {
+      return nil
+    }
+
+    let trimmedName = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedName.isEmpty else { return nil }
+
+    let parameters = parseParameters(from: block)
+    let state = resultState ?? (isComplete ? .running : .running)
+
+    return MobileChatToolCallCardModel(
+      id: "tool:\(trimmedName):\(block.hashValue)",
+      toolName: trimmedName,
+      title: resolvedTitle(for: trimmedName, state: state),
+      body: summarizeParameters(parameters),
+      state: state
+    )
+  }
+
+  private static func parseParameters(from block: String) -> [String: String] {
+    guard
+      let parametersBlock = firstCapture(
+        in: block,
+        pattern: "<parameters>([\\s\\S]*?)</parameters>"
+      )
+    else {
+      return [:]
+    }
+
+    var values: [String: String] = [:]
+    let elementPattern = "<([A-Za-z0-9_]+)>\\s*([\\s\\S]*?)\\s*</\\1>"
+    guard let regex = try? NSRegularExpression(pattern: elementPattern) else {
+      return values
+    }
+
+    let range = NSRange(parametersBlock.startIndex..., in: parametersBlock)
+    regex.enumerateMatches(in: parametersBlock, range: range) { match, _, _ in
+      guard
+        let match,
+        let keyRange = Range(match.range(at: 1), in: parametersBlock),
+        let valueRange = Range(match.range(at: 2), in: parametersBlock)
+      else {
+        return
+      }
+
+      let key = String(parametersBlock[keyRange])
+      let value = String(parametersBlock[valueRange])
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !value.isEmpty else { return }
+      values[key] = value
+    }
+
+    return values
+  }
+
+  private static func summarizeParameters(_ parameters: [String: String]) -> String? {
+    guard !parameters.isEmpty else { return nil }
+
+    let prioritizedKeys = [
+      "artistName",
+      "title",
+      "name",
+      "query",
+      "platform",
+      "field",
+      "artistGenres",
+      "releaseContext",
+    ]
+
+    var parts: [String] = []
+    for key in prioritizedKeys {
+      if let value = parameters[key], !value.isEmpty {
+        parts.append(value)
+      }
+      if parts.count == 2 { break }
+    }
+
+    if parts.isEmpty {
+      parts = parameters.values.prefix(2).map { $0 }
+    }
+
+    let summary = parts.joined(separator: " · ")
+    return summary.isEmpty ? nil : summary
+  }
+
+  private static func resolvedTitle(
+    for toolName: String,
+    state: MobileChatToolCallState
+  ) -> String {
+    let labels = MobileChatToolLabels.registry[toolName]
+    switch state {
+    case .running:
+      return labels?.loadingTitle ?? "\(MobileChatToolLabels.displayName(for: toolName))…"
+    case .succeeded:
+      return labels?.successTitle ?? MobileChatToolLabels.displayName(for: toolName)
+    case .failed:
+      return labels?.errorTitle ?? "Couldn't complete \(MobileChatToolLabels.displayName(for: toolName).lowercased())"
+    }
+  }
+
+  private static func firstCapture(in text: String, pattern: String) -> String? {
+    guard
+      let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+      let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+      let range = Range(match.range(at: 1), in: text)
+    else {
+      return nil
+    }
+
+    return String(text[range])
+  }
+
+  private static func appendTextSegment(_ text: String, to segments: inout [MobileChatRenderableSegment]) {
+    guard !text.isEmpty else { return }
+    segments.append(.text(text))
+  }
+}
+
+enum MobileChatToolLabels {
+  struct ToolLabel: Sendable {
+    let loadingTitle: String
+    let successTitle: String
+    let errorTitle: String
+  }
+
+  static let registry: [String: ToolLabel] = [
+    "createMerch": ToolLabel(
+      loadingTitle: "Creating merch options…",
+      successTitle: "Merch options ready",
+      errorTitle: "Couldn't create merch"
+    ),
+    "previewMerchOptions": ToolLabel(
+      loadingTitle: "Preparing merch options…",
+      successTitle: "Merch options ready",
+      errorTitle: "Couldn't prepare merch"
+    ),
+    "proposeProfileEdit": ToolLabel(
+      loadingTitle: "Updating your profile…",
+      successTitle: "Profile updated",
+      errorTitle: "Couldn't update your profile"
+    ),
+    "proposeSocialLink": ToolLabel(
+      loadingTitle: "Adding your link…",
+      successTitle: "Link added",
+      errorTitle: "Couldn't add that link"
+    ),
+    "importBioFromUrl": ToolLabel(
+      loadingTitle: "Importing your bio…",
+      successTitle: "Bio imported",
+      errorTitle: "Couldn't import that bio"
+    ),
+    "generateAlbumArt": ToolLabel(
+      loadingTitle: "Creating your album art…",
+      successTitle: "Album art ready",
+      errorTitle: "Couldn't create your album art"
+    ),
+  ]
+
+  static func displayName(for toolName: String) -> String {
+    registry[toolName]?.successTitle
+      ?? toolName
+        .replacingOccurrences(of: "([a-z])([A-Z])", with: "$1 $2", options: .regularExpression)
+        .capitalized
+  }
+}

--- a/apps/ios/Jovie/Features/Chat/MobileChatToolCardView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatToolCardView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct MobileChatToolCardView: View {
+  let model: MobileChatToolCallCardModel
+
+  var body: some View {
+    HStack(alignment: .top, spacing: JovieSpacing.medium) {
+      Image(systemName: iconName)
+        .font(.system(size: 15, weight: .semibold))
+        .foregroundStyle(iconColor)
+        .frame(width: 20, height: 20)
+        .padding(.top, 1)
+
+      VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
+        Text(model.title)
+          .font(JovieFont.body(size: 15, weight: .semibold))
+          .foregroundStyle(titleColor)
+          .fixedSize(horizontal: false, vertical: true)
+
+        if let body = model.body {
+          Text(body)
+            .font(JovieFont.body(size: 13))
+            .foregroundStyle(JovieColor.textTertiary)
+            .lineLimit(2)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(.horizontal, JovieSpacing.large)
+    .padding(.vertical, JovieSpacing.medium)
+    .background(JovieColor.surface2, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 16, style: .continuous)
+        .stroke(JovieColor.borderDefault, lineWidth: 1)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(accessibilityLabel)
+    .accessibilityIdentifier("mobile-chat-tool-card")
+  }
+
+  private var iconName: String {
+    switch model.state {
+    case .running:
+      return "ellipsis.circle"
+    case .succeeded:
+      return "checkmark.circle.fill"
+    case .failed:
+      return "exclamationmark.circle.fill"
+    }
+  }
+
+  private var iconColor: Color {
+    switch model.state {
+    case .running:
+      return JovieColor.textTertiary
+    case .succeeded:
+      return JovieColor.accentBlue
+    case .failed:
+      return JovieColor.errorText
+    }
+  }
+
+  private var titleColor: Color {
+    switch model.state {
+    case .failed:
+      return JovieColor.errorText
+    default:
+      return JovieColor.textPrimary
+    }
+  }
+
+  private var accessibilityLabel: String {
+    if let body = model.body {
+      return "\(model.title). \(body)"
+    }
+    return model.title
+  }
+}

--- a/apps/ios/Jovie/Features/Chat/MobileChatView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatView.swift
@@ -93,18 +93,25 @@ private struct MobileChatMessageRow: View {
   let webBaseURL: URL
   let onRetry: () -> Void
 
+  private var isStreamingAssistant: Bool {
+    item.role == .assistant && item.status == .streaming
+  }
+
+  private var assistantSegments: [MobileChatRenderableSegment] {
+    MobileChatContentParser.segments(from: item.content, isStreaming: isStreamingAssistant)
+  }
+
+  private var assistantDisplayText: String {
+    MobileChatContentParser.displayText(from: item.content, isStreaming: isStreamingAssistant)
+  }
+
   var body: some View {
     VStack(alignment: item.role == .user ? .trailing : .leading, spacing: JovieSpacing.small) {
-      Text(item.content.isEmpty && item.status == .streaming ? "Thinking…" : item.content)
-        .font(JovieFont.body(size: 16))
-        .foregroundStyle(item.role == .user ? JovieColor.backgroundBase : JovieColor.textPrimary)
-        .padding(.horizontal, JovieSpacing.large)
-        .padding(.vertical, JovieSpacing.medium)
-        .background(
-          item.role == .user ? Color.white : JovieColor.surface1,
-          in: RoundedRectangle(cornerRadius: 22, style: .continuous)
-        )
-        .frame(maxWidth: 320, alignment: item.role == .user ? .trailing : .leading)
+      if item.role == .user {
+        userMessageBubble
+      } else {
+        assistantMessageContent
+      }
 
       if item.requiresWebHandoff, let handoffURL = item.handoffURL {
         Link("Continue on web", destination: handoffURL)
@@ -119,6 +126,52 @@ private struct MobileChatMessageRow: View {
       }
     }
     .frame(maxWidth: .infinity, alignment: item.role == .user ? .trailing : .leading)
+  }
+
+  private var userMessageBubble: some View {
+    Text(item.content)
+      .font(JovieFont.body(size: 16))
+      .foregroundStyle(JovieColor.backgroundBase)
+      .padding(.horizontal, JovieSpacing.large)
+      .padding(.vertical, JovieSpacing.medium)
+      .background(Color.white, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+      .frame(maxWidth: 320, alignment: .trailing)
+  }
+
+  @ViewBuilder
+  private var assistantMessageContent: some View {
+    let segments = assistantSegments
+    let displayText = assistantDisplayText
+    let showsThinking = displayText.isEmpty && segments.isEmpty && isStreamingAssistant
+
+    if showsThinking {
+      Text("Thinking…")
+        .font(JovieFont.body(size: 16))
+        .foregroundStyle(JovieColor.textPrimary)
+        .padding(.horizontal, JovieSpacing.large)
+        .padding(.vertical, JovieSpacing.medium)
+        .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .frame(maxWidth: 320, alignment: .leading)
+    } else {
+      VStack(alignment: .leading, spacing: JovieSpacing.small) {
+        if !displayText.isEmpty {
+          Text(displayText)
+            .font(JovieFont.body(size: 16))
+            .foregroundStyle(JovieColor.textPrimary)
+            .padding(.horizontal, JovieSpacing.large)
+            .padding(.vertical, JovieSpacing.medium)
+            .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+            .frame(maxWidth: 320, alignment: .leading)
+        }
+
+        ForEach(segments) { segment in
+          if case let .toolCall(model) = segment {
+            MobileChatToolCardView(model: model)
+              .frame(maxWidth: 320, alignment: .leading)
+          }
+        }
+      }
+    }
   }
 }
 

--- a/apps/ios/JovieTests/MobileChatContentParserTests.swift
+++ b/apps/ios/JovieTests/MobileChatContentParserTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import Jovie
+
+struct MobileChatContentParserTests {
+  @Test func parsesToolCallIntoCardAndSuppressesRawMarkup() {
+    let content = """
+    Here are some ideas.
+    <tool_call><name>createMerch</name><parameters><artistName>Tim White</artistName><artistGenres>pop, electronic</artistGenres><releaseContext>All This Noise EP and remixes</releaseContext></parameters></tool_call>
+    """
+
+    let segments = MobileChatContentParser.segments(from: content, isStreaming: false)
+
+    #expect(segments.count == 2)
+    #expect(segments[0] == .text("Here are some ideas."))
+
+    guard case let .toolCall(model) = segments[1] else {
+      Issue.record("Expected tool call segment")
+      return
+    }
+
+    #expect(model.toolName == "createMerch")
+    #expect(model.title == "Creating merch options…")
+    #expect(model.body == "Tim White · pop, electronic")
+    #expect(model.state == .running)
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: false) == "Here are some ideas.")
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: false).contains("<tool_call>") == false)
+  }
+
+  @Test func suppressesIncompleteToolCallWhileStreaming() {
+    let content = "Working on it <tool_call><name>createMerch</name><parameters><artistName>Tim"
+
+    let segments = MobileChatContentParser.segments(from: content, isStreaming: true)
+
+    #expect(segments.count == 2)
+    #expect(segments[0] == .text("Working on it"))
+    guard case let .toolCall(model) = segments[1] else {
+      Issue.record("Expected partial tool call segment")
+      return
+    }
+    #expect(model.toolName == "createMerch")
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: true) == "Working on it")
+  }
+
+  @Test func marksFailedToolResultState() {
+    let content = """
+    <tool_call><name>createMerch</name><parameters><artistName>Tim White</artistName></parameters></tool_call>
+    <tool_result><name>createMerch</name><state>failed</state><message>Denied by user</message></tool_result>
+    """
+
+    let segments = MobileChatContentParser.segments(from: content, isStreaming: false)
+    guard case let .toolCall(model) = segments.first else {
+      Issue.record("Expected tool call segment")
+      return
+    }
+
+    #expect(model.state == .failed)
+    #expect(model.title == "Couldn't create merch")
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: false).isEmpty)
+  }
+
+  @Test func leavesPlainTextUntouched() {
+    let content = "Just a normal assistant reply."
+
+    #expect(
+      MobileChatContentParser.segments(from: content, isStreaming: false) == [.text(content)]
+    )
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: false) == content)
+  }
+}


### PR DESCRIPTION
## Summary
- Parse assistant `<tool_call>` / `<tool_result>` markup in native iOS chat instead of rendering raw XML in message bubbles
- Render compact tool status cards with human-readable titles and parameter summaries
- Suppress incomplete tool markup during streaming while still showing a running tool card

## Test plan
- [x] `MobileChatContentParserTests` (4 cases) — tool call parsing, streaming suppression, failed results, plain text
- [x] iOS `xcodebuild test` for parser suite

<!-- linear-issue-id:JOV-3607 -->