### PR TITLE
feat(merch): AI design-carousel merch generation (engine + chat wiring)

### DIFF
--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.guard.test.ts
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.guard.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { isChatMerchDesignCarouselResult } from './ChatMerchDesignCarousel';
+
+describe('isChatMerchDesignCarouselResult', () => {
+  it('accepts a valid carousel result', () => {
+    expect(
+      isChatMerchDesignCarouselResult({
+        success: true,
+        generationId: 'gen_1',
+        designs: [],
+      })
+    ).toBe(true);
+  });
+
+  it('rejects non-carousel shapes', () => {
+    expect(isChatMerchDesignCarouselResult(null)).toBe(false);
+    expect(isChatMerchDesignCarouselResult({ success: false })).toBe(false);
+    expect(
+      isChatMerchDesignCarouselResult({ success: true, generationId: 'g' })
+    ).toBe(false);
+    expect(
+      isChatMerchDesignCarouselResult({ success: true, designs: [] })
+    ).toBe(false);
+  });
+});

--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
@@ -111,17 +111,19 @@ export function ChatMerchDesignCarousel({
         {count > 1 ? (
           <div className='flex items-center justify-center gap-1.5'>
             {designs.map((design, index) => (
-              <button
+              <Button
                 key={design.id}
                 type='button'
+                variant='ghost'
                 aria-label={`Go to design ${index + 1}`}
                 aria-current={index === active}
                 onClick={() => setActive(index)}
                 className={cn(
-                  'h-1.5 rounded-full transition-[width,background-color] duration-subtle',
+                  'h-1.5 min-w-0 p-0 before:content-none',
+                  'rounded-full transition-[width,background-color] duration-subtle',
                   index === active
-                    ? 'w-5 bg-primary-token'
-                    : 'w-1.5 bg-surface-2'
+                    ? 'w-5 bg-primary-token hover:bg-primary-token'
+                    : 'w-1.5 bg-surface-2 hover:bg-surface-2'
                 )}
               />
             ))}
@@ -141,18 +143,18 @@ function CarouselArrow({
 }) {
   const Icon = side === 'left' ? ChevronLeft : ChevronRight;
   return (
-    <button
+    <Button
       type='button'
+      variant='frosted'
+      size='icon'
       aria-label={side === 'left' ? 'Previous design' : 'Next design'}
       onClick={onClick}
       className={cn(
-        'absolute top-1/2 grid h-8 w-8 -translate-y-1/2 place-items-center rounded-full border border-subtle bg-surface-1/90 text-primary-token backdrop-blur',
-        'transition-colors duration-subtle hover:bg-surface-2',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
+        'absolute top-1/2 h-8 w-8 -translate-y-1/2',
         side === 'left' ? 'left-2' : 'right-2'
       )}
     >
       <Icon className='h-4 w-4' strokeWidth={2.25} />
-    </button>
+    </Button>
   );
 }

--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { Button } from '@jovie/ui';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { ThreadImageCard } from '@/components/shell/ThreadImageCard';
+import type {
+  MerchDesignCarouselResult,
+  MerchDesignPreview,
+} from '@/lib/merch/types';
+import { cn } from '@/lib/utils';
+import { ChatGenerationArtifactSurface } from './ChatGenerationArtifactSurface';
+
+export function isChatMerchDesignCarouselResult(
+  value: unknown
+): value is MerchDesignCarouselResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { success?: unknown }).success === true &&
+    typeof (value as { generationId?: unknown }).generationId === 'string' &&
+    Array.isArray((value as { designs?: unknown }).designs)
+  );
+}
+
+function submitMerchPrompt(prompt: string): void {
+  globalThis.dispatchEvent(
+    new CustomEvent('jovie-chat-submit-prompt', { detail: { prompt } })
+  );
+}
+
+function usePrompt(generationId: string, design: MerchDesignPreview): string {
+  return `Use design ${design.option_number} from generation ${generationId}.`;
+}
+
+export function ChatMerchDesignCarousel({
+  result,
+}: {
+  readonly result: MerchDesignCarouselResult;
+}) {
+  const designs = result.designs;
+  const [active, setActive] = useState(0);
+  const count = designs.length;
+  const current = designs[Math.min(active, Math.max(0, count - 1))];
+
+  const go = useCallback(
+    (dir: -1 | 1) => {
+      setActive(prev => (prev + dir + count) % count);
+    },
+    [count]
+  );
+
+  if (count === 0 || !current) return null;
+
+  const useThis = () =>
+    submitMerchPrompt(usePrompt(result.generationId, current));
+
+  return (
+    <ChatGenerationArtifactSurface
+      title='Merch Designs'
+      subtitle={result.nextStep ?? 'Pick one and I’ll put it on products'}
+      className='max-w-2xl'
+    >
+      <div className='flex flex-col gap-3'>
+        <div className='relative'>
+          {/* Fixed-aspect media so generating -> ready never shifts layout. */}
+          <div className='overflow-hidden rounded-[16px]'>
+            {current.status === 'ready' && current.preview_url ? (
+              <ThreadImageCard
+                status='ready'
+                prompt={current.design_name}
+                previewUrl={current.preview_url}
+              />
+            ) : (
+              <ThreadImageCard
+                status='generating'
+                prompt={current.design_name}
+              />
+            )}
+          </div>
+
+          {count > 1 ? (
+            <>
+              <CarouselArrow side='left' onClick={() => go(-1)} />
+              <CarouselArrow side='right' onClick={() => go(1)} />
+            </>
+          ) : null}
+        </div>
+
+        <div className='flex min-h-9 items-start justify-between gap-3'>
+          <div className='min-w-0'>
+            <h3 className='truncate text-app font-semibold text-primary-token'>
+              {current.design_name}
+            </h3>
+            {current.concept ? (
+              <p className='mt-0.5 line-clamp-1 text-2xs text-tertiary-token'>
+                {current.concept}
+              </p>
+            ) : null}
+          </div>
+          <Button
+            type='button'
+            size='sm'
+            onClick={useThis}
+            disabled={current.status !== 'ready'}
+          >
+            Use This One
+          </Button>
+        </div>
+
+        {count > 1 ? (
+          <div className='flex items-center justify-center gap-1.5'>
+            {designs.map((design, index) => (
+              <button
+                key={design.id}
+                type='button'
+                aria-label={`Go to design ${index + 1}`}
+                aria-current={index === active}
+                onClick={() => setActive(index)}
+                className={cn(
+                  'h-1.5 rounded-full transition-[width,background-color] duration-subtle',
+                  index === active
+                    ? 'w-5 bg-primary-token'
+                    : 'w-1.5 bg-surface-2'
+                )}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </ChatGenerationArtifactSurface>
+  );
+}
+
+function CarouselArrow({
+  side,
+  onClick,
+}: {
+  readonly side: 'left' | 'right';
+  readonly onClick: () => void;
+}) {
+  const Icon = side === 'left' ? ChevronLeft : ChevronRight;
+  return (
+    <button
+      type='button'
+      aria-label={side === 'left' ? 'Previous design' : 'Next design'}
+      onClick={onClick}
+      className={cn(
+        'absolute top-1/2 grid h-8 w-8 -translate-y-1/2 place-items-center rounded-full border border-subtle bg-surface-1/90 text-primary-token backdrop-blur',
+        'transition-colors duration-subtle hover:bg-surface-2',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
+        side === 'left' ? 'left-2' : 'right-2'
+      )}
+    >
+      <Icon className='h-4 w-4' strokeWidth={2.25} />
+    </button>
+  );
+}

--- a/apps/web/lib/merch/graphic-engine.test.ts
+++ b/apps/web/lib/merch/graphic-engine.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const generateImage = vi.fn();
+vi.mock('ai', () => ({
+  generateImage: (args: unknown) => generateImage(args),
+}));
+vi.mock('@ai-sdk/gateway', () => ({
+  gateway: { image: (id: string) => ({ __model: id }) },
+}));
+
+import {
+  generatePrintGraphic,
+  MERCH_IMAGE_MODELS,
+  selectMerchImageModel,
+  weightedPick,
+} from './graphic-engine';
+
+describe('weightedPick', () => {
+  const models = [{ key: 'a' }, { key: 'b' }, { key: 'c' }] as const;
+
+  it('picks the bucket the roll lands in (equal weights)', () => {
+    // total = 3; rand 0 → first, ~0.5 → middle, ~0.99 → last
+    expect(weightedPick(models, undefined, () => 0).key).toBe('a');
+    expect(weightedPick(models, undefined, () => 0.5).key).toBe('b');
+    expect(weightedPick(models, undefined, () => 0.99).key).toBe('c');
+  });
+
+  it('biases toward the higher-weighted model', () => {
+    const weights = { a: 0.1, b: 0.1, c: 10 };
+    // total ≈ 10.2; almost the entire range belongs to c
+    expect(weightedPick(models, weights, () => 0.5).key).toBe('c');
+  });
+
+  it('keeps a zero-feedback model in rotation via the floor', () => {
+    const weights = { a: 0, b: 0, c: 0 };
+    // floor makes all equal again → roll 0 returns the first, never throws
+    expect(weightedPick(models, weights, () => 0).key).toBe('a');
+  });
+
+  it('throws on an empty pool', () => {
+    expect(() => weightedPick([], undefined, () => 0)).toThrow();
+  });
+});
+
+describe('selectMerchImageModel', () => {
+  it('only ever returns enabled roster models', () => {
+    const enabledKeys = new Set(
+      MERCH_IMAGE_MODELS.filter(m => m.enabled).map(m => m.key)
+    );
+    for (const r of [0, 0.25, 0.5, 0.75, 0.999]) {
+      expect(
+        enabledKeys.has(selectMerchImageModel({ rand: () => r }).key)
+      ).toBe(true);
+    }
+  });
+});
+
+describe('generatePrintGraphic', () => {
+  it('requests a transparent background for native-alpha models and returns the bytes', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    generateImage.mockResolvedValueOnce({ images: [{ uint8Array: bytes }] });
+
+    const native = MERCH_IMAGE_MODELS.find(m => m.alpha === 'native');
+    if (!native) throw new Error('expected a native-alpha model in the roster');
+
+    const out = await generatePrintGraphic({
+      prompt: 'panda surf',
+      model: native,
+    });
+
+    const callArg = generateImage.mock.calls[0][0] as {
+      model: { __model: string };
+      prompt: string;
+      providerOptions?: { openai?: { background?: string } };
+    };
+    expect(callArg.model.__model).toBe(native.id);
+    expect(callArg.providerOptions?.openai?.background).toBe('transparent');
+    expect(callArg.prompt).toContain('transparent');
+    expect(out.modelKey).toBe(native.key);
+    expect(out.mediaType).toBe('image/png');
+    expect(out.image.equals(Buffer.from(bytes))).toBe(true);
+  });
+
+  it('throws rather than emit a non-alpha graphic for knockout models', async () => {
+    generateImage.mockResolvedValueOnce({
+      images: [{ uint8Array: new Uint8Array([9]) }],
+    });
+    const knockout = MERCH_IMAGE_MODELS.find(m => m.alpha === 'knockout');
+    if (!knockout) throw new Error('expected a knockout model in the roster');
+
+    await expect(
+      generatePrintGraphic({ prompt: 'x', model: knockout })
+    ).rejects.toThrow(/knockoutBackground/);
+  });
+});

--- a/apps/web/lib/merch/graphic-engine.ts
+++ b/apps/web/lib/merch/graphic-engine.ts
@@ -1,0 +1,214 @@
+import 'server-only';
+
+/**
+ * Merch graphic engine.
+ *
+ * Generates the print graphic for a merch design via the Vercel AI Gateway,
+ * across a roster of image models that are A/B'd in production and biased toward
+ * the winner by thumbs up/down feedback (see selectMerchImageModel). Output is a
+ * transparent / alpha-knockout PNG so it drops cleanly onto any garment color
+ * for the mockup comp AND is the real print file.
+ *
+ * Proven in spikes (apps/web/scripts/merch-{image,alpha}-spike.ts): all roster
+ * models clear the quality bar; gpt-image transparent output composites cleanly
+ * onto a garment color.
+ *
+ * @see @/lib/constants/ai-models — gateway model id format (`provider/model`)
+ * @see @/lib/merch/mockup-engine — composites this graphic onto Printful blanks
+ */
+
+import { gateway } from '@ai-sdk/gateway';
+import { generateImage } from 'ai';
+import { logger } from '@/lib/utils/logger';
+
+// ---------------------------------------------------------------------------
+// Model roster
+// ---------------------------------------------------------------------------
+
+/**
+ * Alpha strategy per model:
+ * - `native`: the provider returns a real transparent background (gpt-image).
+ * - `knockout`: opaque output; needs a background-removal pass before it is
+ *   alpha-clean. Gated off until that pass lands (see knockoutBackground).
+ */
+type AlphaStrategy = 'native' | 'knockout';
+
+export interface MerchImageModelConfig {
+  /** Gateway model id, `provider/model`. */
+  readonly id: string;
+  /** Short stable key used for feedback scoring + analytics. */
+  readonly key: string;
+  readonly alpha: AlphaStrategy;
+  /** In the live A/B roster. `knockout` models stay false until bg-removal ships. */
+  readonly enabled: boolean;
+}
+
+export const MERCH_IMAGE_MODELS: readonly MerchImageModelConfig[] = [
+  {
+    id: 'openai/gpt-image-1.5',
+    key: 'gpt-image-1.5',
+    alpha: 'native',
+    enabled: true,
+  },
+  {
+    id: 'openai/gpt-image-1',
+    key: 'gpt-image-1',
+    alpha: 'native',
+    enabled: false,
+  },
+  {
+    id: 'bfl/flux-2-pro',
+    key: 'flux-2-pro',
+    alpha: 'knockout',
+    enabled: false,
+  },
+  {
+    id: 'xai/grok-imagine-image',
+    key: 'grok-imagine',
+    alpha: 'knockout',
+    enabled: false,
+  },
+  {
+    id: 'google/imagen-4.0-ultra-generate-001',
+    key: 'imagen-4-ultra',
+    alpha: 'knockout',
+    enabled: false,
+  },
+] as const;
+
+export type MerchImageModelKey = (typeof MERCH_IMAGE_MODELS)[number]['key'];
+
+function activeModels(): readonly MerchImageModelConfig[] {
+  return MERCH_IMAGE_MODELS.filter(m => m.enabled);
+}
+
+// ---------------------------------------------------------------------------
+// Feedback-weighted model selection (epsilon-greedy-ish)
+// ---------------------------------------------------------------------------
+
+export interface ModelSelectionOptions {
+  /** Per-model weight, e.g. derived from thumbs up/down. Missing → 1 (equal). */
+  readonly weights?: Partial<Record<MerchImageModelKey, number>>;
+  /** Injectable RNG for deterministic tests. */
+  readonly rand?: () => number;
+}
+
+/** Floor weight so a temporarily-unlucky model stays in rotation and can recover. */
+const MODEL_WEIGHT_FLOOR = 0.05;
+
+/**
+ * Pure weighted random pick. Each model gets `max(FLOOR, weight ?? 1)`; a model
+ * with no recorded weight is treated as average (1). Exported for testing the
+ * bandit math independent of which roster entries are enabled.
+ */
+export function weightedPick<T extends { readonly key: string }>(
+  models: readonly T[],
+  weights: Partial<Record<string, number>> | undefined,
+  rand: () => number
+): T {
+  if (models.length === 0) {
+    throw new Error('No models to pick from');
+  }
+  const weighted = models.map(
+    m => [m, Math.max(MODEL_WEIGHT_FLOOR, weights?.[m.key] ?? 1)] as const
+  );
+  const total = weighted.reduce((sum, [, w]) => sum + w, 0);
+  let roll = rand() * total;
+  for (const [model, weight] of weighted) {
+    roll -= weight;
+    if (roll <= 0) return model;
+  }
+  return weighted[weighted.length - 1][0];
+}
+
+/**
+ * Pick an active model weighted by feedback score. Starts equal across the
+ * active roster; biases toward higher-scoring models as feedback accrues.
+ */
+export function selectMerchImageModel(
+  options: ModelSelectionOptions = {}
+): MerchImageModelConfig {
+  const models = activeModels();
+  if (models.length === 0) {
+    throw new Error('No active merch image models configured');
+  }
+  return weightedPick(models, options.weights, options.rand ?? Math.random);
+}
+
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+export interface PrintGraphic {
+  /** Transparent (alpha) PNG bytes — drops onto any garment + is the print file. */
+  readonly image: Buffer;
+  /** Which roster model produced it (stamp on the design for feedback scoring). */
+  readonly modelKey: MerchImageModelKey;
+  readonly modelId: string;
+  readonly mediaType: 'image/png';
+}
+
+const ALPHA_DIRECTIVE =
+  'Isolate the artwork with a fully transparent background — no garment, no mockup, no backdrop. Clean cut-out edges, print-ready.';
+
+interface RawImage {
+  readonly uint8Array?: Uint8Array;
+  readonly base64?: string;
+}
+
+function toBuffer(image: RawImage): Buffer {
+  if (image.uint8Array) return Buffer.from(image.uint8Array);
+  if (image.base64) return Buffer.from(image.base64, 'base64');
+  throw new TypeError('Gateway image result did not include image bytes');
+}
+
+/**
+ * Opaque output → alpha. Not yet implemented; `knockout` models stay disabled
+ * until this lands so the roster never emits a white-boxed (non-alpha) graphic.
+ */
+// ponytail: native-transparent (gpt-image) is the only alpha path today; add a
+// background-removal step here (local @imgly/background-removal or a Bria model)
+// to enable flux/grok/imagen in the A/B. Tracked as the next merch task.
+function knockoutBackground(_opaquePng: Buffer): never {
+  throw new Error(
+    'knockoutBackground not implemented — keep knockout models disabled'
+  );
+}
+
+/**
+ * Generate one transparent print graphic. The model is feedback-weighted unless
+ * one is pinned (e.g. to regenerate with the same model on "make another like this").
+ */
+export async function generatePrintGraphic(params: {
+  readonly prompt: string;
+  readonly model?: MerchImageModelConfig;
+  readonly selection?: ModelSelectionOptions;
+}): Promise<PrintGraphic> {
+  const model = params.model ?? selectMerchImageModel(params.selection);
+  const started = Date.now();
+
+  const result = await generateImage({
+    model: gateway.image(model.id),
+    prompt: `${params.prompt}\n${ALPHA_DIRECTIVE}`,
+    size: '1024x1024',
+    ...(model.alpha === 'native'
+      ? { providerOptions: { openai: { background: 'transparent' } } }
+      : {}),
+  });
+
+  const raw = toBuffer(result.images[0] as RawImage);
+  const image = model.alpha === 'native' ? raw : knockoutBackground(raw);
+
+  logger.info('[merch] print graphic generated', {
+    model: model.key,
+    ms: Date.now() - started,
+    bytes: image.length,
+  });
+
+  return {
+    image,
+    modelKey: model.key,
+    modelId: model.id,
+    mediaType: 'image/png',
+  };
+}

--- a/apps/web/lib/merch/types.ts
+++ b/apps/web/lib/merch/types.ts
@@ -83,6 +83,80 @@ export interface MerchSelectionResult {
   readonly publishBlockedReasons?: readonly string[];
 }
 
+// ---------------------------------------------------------------------------
+// Two-phase guided merch flow contracts
+//
+// Phase A (design): the chat shows a carousel of product-agnostic design
+// concepts rendered from the parametric archetype library. Phase B (product):
+// the chosen design is composited onto a curated product+color set by the
+// own-generator mockup engine. Chat-facing fields stay snake_case to match
+// MerchGenerationOptionView and the ChatMerch* components.
+// ---------------------------------------------------------------------------
+
+/** Slot values filled into a design archetype. Lyric is sourced from the
+ * artist's own catalog (discog_recordings/tracks.lyrics) or typed manually. */
+export interface MerchDesignSlots {
+  readonly artist_name: string;
+  readonly short_text?: string;
+  readonly lyric?: string;
+  readonly year?: string;
+  readonly location?: string;
+  readonly tracklist?: readonly string[];
+}
+
+/** One design concept in the Phase-A carousel (product-agnostic).
+ * Mirrors ThreadImageCard's discriminated union: while the image model runs the
+ * design is `generating` with no preview; `preview_url` is present once `ready`. */
+export interface MerchDesignPreview {
+  readonly id: string;
+  readonly option_number: number;
+  readonly design_name: string;
+  /** Which roster model produced it — stamped for feedback scoring. */
+  readonly model_key?: string;
+  readonly concept: string;
+  readonly status: 'generating' | 'ready';
+  /** Transparent (alpha) print-art preview. Present only when status is `ready`. */
+  readonly preview_url?: string;
+  readonly slots: MerchDesignSlots;
+}
+
+export interface MerchDesignCarouselResult {
+  readonly success: true;
+  readonly generationId: string;
+  readonly prompt?: string;
+  readonly nextStep?: string;
+  readonly designs: readonly MerchDesignPreview[];
+}
+
+/** One product in the Phase-B set: the chosen design composited onto a
+ * curated product in a pop color, with the instant own-generator mockup. */
+export interface MerchProductApplication {
+  readonly id: string;
+  readonly product_type: string;
+  readonly product_name: string;
+  readonly color_name: string;
+  readonly color_hex: string;
+  /** Printful variant id for the shown color, so the order matches the mockup. */
+  readonly color_variant_id: number;
+  /** Plain-language reason this color/product makes the print pop. */
+  readonly pop_reason: string;
+  /** Instant own-generator mockup (always present — synchronous render). */
+  readonly mockup_url: string;
+  readonly price_recommendation: MerchGenerationOptionView['price_recommendation'];
+  readonly sellability?: {
+    readonly sellable: boolean;
+    readonly reasons: readonly string[];
+  };
+}
+
+export interface MerchProductSetResult {
+  readonly success: true;
+  readonly designId: string;
+  readonly design_name: string;
+  readonly nextStep?: string;
+  readonly products: readonly MerchProductApplication[];
+}
+
 export interface PublicMerchCard {
   readonly id: string;
   readonly artistId: string;

--- a/apps/web/scripts/merch-alpha-spike.ts
+++ b/apps/web/scripts/merch-alpha-spike.ts
@@ -1,0 +1,66 @@
+/**
+ * Alpha-knockout spike (throwaway). Proves gpt-image transparent output drops
+ * cleanly onto a garment color (Tim: "alpha'd clean so it can be dropped onto
+ * objects for the comp and product printing").
+ *
+ *   doppler run --project jovie-web --config dev -- \
+ *     pnpm --filter @jovie/web exec tsx scripts/merch-alpha-spike.ts
+ *
+ * Outputs: <repo>/.context/spike-merch/alpha.png  (raw transparent art)
+ *          <repo>/.context/spike-merch/alpha-on-pink.png  (composited on hot pink)
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { gateway } from '@ai-sdk/gateway';
+import { generateImage } from 'ai';
+import sharp from 'sharp';
+
+const OUT_DIR = resolve(process.cwd(), '../../.context/spike-merch');
+const PROMPT = [
+  'Vintage distressed band-merch graphic, screen-print texture, heavy wash and grain.',
+  'A cool panda in sunglasses surfing a big ocean wave, red rising sun, palm trees.',
+  'Bold gnarly metal display lettering "PANADA" on top, rough script "RIDE THE WAVES" below.',
+  'Retro cream/teal/red/black palette, high detail, centered, no background.',
+].join(' ');
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true });
+  const result = await generateImage({
+    model: gateway.image('openai/gpt-image-1.5'),
+    prompt: PROMPT,
+    size: '1024x1024',
+    providerOptions: { openai: { background: 'transparent' } },
+  });
+  const img = result.images[0] as { uint8Array?: Uint8Array; base64?: string };
+  const raw = img.uint8Array
+    ? Buffer.from(img.uint8Array)
+    : Buffer.from(img.base64 ?? '', 'base64');
+  writeFileSync(resolve(OUT_DIR, 'alpha.png'), raw);
+
+  // Composite onto a hot-pink garment swatch — the real "drop onto product" test.
+  const pink = await sharp({
+    create: {
+      width: 1024,
+      height: 1024,
+      channels: 4,
+      background: { r: 233, g: 74, b: 156, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  const onPink = await sharp(pink)
+    .composite([{ input: raw, gravity: 'center' }])
+    .png()
+    .toBuffer();
+  writeFileSync(resolve(OUT_DIR, 'alpha-on-pink.png'), onPink);
+
+  // Report alpha channel stats so we know it's truly transparent, not white-boxed.
+  const stats = await sharp(raw).stats();
+  const hasAlpha = (await sharp(raw).metadata()).hasAlpha;
+  console.log(
+    `alpha.png ${(raw.length / 1024) | 0}KB hasAlpha=${hasAlpha} channels=${stats.channels.length}`
+  );
+  console.log(`Outputs in ${OUT_DIR}`);
+}
+
+void main();

--- a/apps/web/scripts/merch-image-spike.ts
+++ b/apps/web/scripts/merch-image-spike.ts
@@ -1,0 +1,79 @@
+/**
+ * Merch image-gen quality spike (throwaway).
+ *
+ * Proves whether we can hit Tim's quality bar (the GPT-image "PANADA / RIDE THE
+ * WAVES" vintage band tee) by generating the same kind of print graphic across
+ * all three gateway image models. Run, then eyeball the outputs vs the reference.
+ *
+ *   doppler run --project jovie-web --config dev -- \
+ *     pnpm --filter @jovie/web exec tsx scripts/merch-image-spike.ts
+ *
+ * Outputs: <repo>/.context/spike-merch/<model>.png
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { gateway } from '@ai-sdk/gateway';
+import { generateImage } from 'ai';
+
+const OUT_DIR = resolve(process.cwd(), '../../.context/spike-merch');
+
+// Mirrors the reference aesthetic so it's an apples-to-apples quality read.
+const PROMPT = [
+  'Vintage distressed band-merch t-shirt graphic, screen-print texture with heavy wash and grain.',
+  'Subject: a cool panda wearing sunglasses surfing a big ocean wave, a red rising sun behind,',
+  'palm trees and a small tropical island in the background.',
+  'Bold gnarly hand-drawn metal/punk display lettering reading "PANADA" across the top,',
+  'and a rough script tagline "RIDE THE WAVES" along the bottom.',
+  'Limited retro color palette (cream, teal, red, black), high detail, centered composition,',
+  'isolated as cleanly cut artwork on a flat dark charcoal background. Print-ready, no garment, no mockup.',
+].join(' ');
+
+const ALL_MODELS = [
+  { id: 'openai/gpt-image-1.5', label: 'gpt-image-1.5' },
+  { id: 'openai/gpt-image-1', label: 'gpt-image-1' },
+  { id: 'bfl/flux-2-pro', label: 'flux-2-pro' },
+  { id: 'bfl/flux-pro-1.1-ultra', label: 'flux-1.1-ultra' },
+  { id: 'xai/grok-imagine-image', label: 'grok-imagine' },
+  { id: 'google/imagen-4.0-ultra-generate-001', label: 'imagen-4-ultra' },
+] as const;
+
+// Optional argv filter by label substring, e.g. `tsx ... grok imagen`
+const filters = process.argv.slice(2);
+const MODELS = filters.length
+  ? ALL_MODELS.filter(m => filters.some(f => m.label.includes(f)))
+  : ALL_MODELS;
+
+function toBuffer(image: { uint8Array?: Uint8Array; base64?: string }): Buffer {
+  if (image.uint8Array) return Buffer.from(image.uint8Array);
+  if (image.base64) return Buffer.from(image.base64, 'base64');
+  throw new Error('image result had no bytes');
+}
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true });
+  for (const m of MODELS) {
+    const started = Date.now();
+    try {
+      const result = await generateImage({
+        model: gateway.image(m.id),
+        prompt: PROMPT,
+        size: '1024x1024',
+      });
+      const buf = toBuffer(
+        result.images[0] as { uint8Array?: Uint8Array; base64?: string }
+      );
+      const out = resolve(OUT_DIR, `${m.label}.png`);
+      writeFileSync(out, buf);
+      console.log(
+        `OK   ${m.label} (${m.id}) ${Date.now() - started}ms -> ${out} (${(buf.length / 1024) | 0}KB)`
+      );
+    } catch (err) {
+      console.log(
+        `FAIL ${m.label} (${m.id}): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+  console.log(`\nDone. Outputs in ${OUT_DIR}`);
+}
+
+void main();


### PR DESCRIPTION
## What
The new merch experience: ask Jovie to make merch → it generates **illustrated, transparent (alpha) graphics** with a top image model and shows them in a premium **design carousel**. Replaces the old crude black-tee SVG + 30-48s 'preview pending' spinner.

## How it works now
1. `createMerch`/`previewMerchOptions` → `generateMerchDesigns` generates 3 alpha graphics in parallel (Vintage / Bold / Mono directions) via the multi-model graphic engine.
2. Each is uploaded and persisted as a `merchDesignOption` on the default product, so the existing `selectMerchDesign` turns a pick into a card.
3. `tool-ui` routes the result to **ChatMerchDesignCarousel**, which reuses the `/exp/shell-v1` `ThreadImageCard` loading state.

## Engine
- Generation via **Vercel AI Gateway** (`gateway.image()`) — no new keys, `AI_GATEWAY_API_KEY` already set.
- **Feedback-weighted bandit** across a model roster; **native-transparent (alpha)** output so art drops onto any garment color and is the print file.
- Proven in spikes: gpt-image-1.5 ≈ the reference quality bar; flux-2-pro / grok-imagine / imagen-4 all clear it. Alpha composites cleanly onto a garment color.

## Verification
- 9 unit tests (engine bandit/alpha + carousel guard). Biome, ESLint, a11y, full `@jovie/web` typecheck all green (pre-commit).
- **No live in-chat screenshot captured** in-session (driving the LLM chat + ~30s 3-image generation headlessly was out of scope); the graphics the carousel renders are the same alpha graphics validated in the spikes.

## Follow-ups (tracked)
- Printful-truthful mockup on 'Use This One' (Phase B); per-card streaming shimmer; feedback→weights loop; background-removal to add flux/grok/imagen to the live A/B.

## Cost
Image generation is user-initiated (explicit 'make merch'), routed through the existing gateway. No background/recurring cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)