### PR TITLE
feat(observability): langfuse SDK tracing for chat turns (JOV-3660)

### DIFF
--- a/apps/web/lib/chat/prompts/registry.ts
+++ b/apps/web/lib/chat/prompts/registry.ts
@@ -1,0 +1,35 @@
+/**
+ * Chat system-prompt registry — source of truth for Langfuse prompt linkage.
+ *
+ * Week 1: local version constants mirrored in Langfuse Cloud prompt registry.
+ * Bump `version` when the prompt body changes; keep `versionId` stable for
+ * cross-release trace filters.
+ */
+
+export type ChatPromptRegistryEntry = {
+  readonly name: string;
+  readonly version: number;
+  /** Stable identifier wired into Langfuse generation metadata. */
+  readonly versionId: string;
+};
+
+export const CHAT_PROMPT_REGISTRY = {
+  app: {
+    name: 'jovie-chat-app-system',
+    version: 1,
+    versionId: 'jovie-chat-app-system:v1',
+  },
+  onboarding: {
+    name: 'jovie-chat-onboarding-system',
+    version: 1,
+    versionId: 'jovie-chat-onboarding-system:v1',
+  },
+} as const satisfies Record<'app' | 'onboarding', ChatPromptRegistryEntry>;
+
+export function resolveChatPromptRegistryEntry(
+  mode: 'app' | 'onboarding'
+): ChatPromptRegistryEntry {
+  return mode === 'onboarding'
+    ? CHAT_PROMPT_REGISTRY.onboarding
+    : CHAT_PROMPT_REGISTRY.app;
+}

--- a/apps/web/lib/chat/run.ts
+++ b/apps/web/lib/chat/run.ts
@@ -21,6 +21,7 @@ import {
   sanitizeAssistantResponse,
 } from '@/lib/chat/prompt-disclosure-guard';
 import { ONBOARDING_SYSTEM_PROMPT } from '@/lib/chat/prompts/onboarding';
+import { resolveChatPromptRegistryEntry } from '@/lib/chat/prompts/registry';
 import { buildSystemPrompt } from '@/lib/chat/system-prompt';
 import {
   isChatToolStepCapExhausted,
@@ -31,9 +32,9 @@ import type {
   ChatTelemetry,
   ReleaseContext,
 } from '@/lib/chat/types';
-
 import { CHAT_MODEL, CHAT_MODEL_LIGHT } from '@/lib/constants/ai-models';
 import type { getEntitlements as GetEntitlements } from '@/lib/entitlements/registry';
+import { startChatTurnLangfuseTrace } from '@/lib/observability/langfuse';
 
 type EntitlementsForPlan = ReturnType<typeof GetEntitlements>;
 
@@ -288,6 +289,20 @@ export async function executeChatTurn(
     disclosureProbeText.length > 0 &&
     isPromptDisclosureRequest(disclosureProbeText);
 
+  const promptRegistry = resolveChatPromptRegistryEntry(mode);
+  const langfuseTrace = await startChatTurnLangfuseTrace({
+    requestId,
+    conversationId: resolvedConversationId,
+    userId,
+    userPlan,
+    mode,
+    selectedModel,
+    toolNames,
+    promptRegistry,
+    messageCount: uiMessages.length,
+    blockedForDisclosure,
+  });
+
   const rawStreamResult = streamText({
     model: blockedForDisclosure
       ? (createStaticTextLanguageModel(
@@ -324,9 +339,11 @@ export async function executeChatTurn(
       },
     }),
     onFinish: async ({ steps, text }) => {
+      let promptLeakBlocked = false;
       if (!blockedForDisclosure && typeof text === 'string') {
         const sanitized = sanitizeAssistantResponse(text);
         if (sanitized.leaked) {
+          promptLeakBlocked = true;
           telemetry?.setTags?.({
             chat_prompt_leak_blocked: 'true',
           });
@@ -361,6 +378,12 @@ export async function executeChatTurn(
         }
       }
 
+      langfuseTrace.endSuccess({
+        text: typeof text === 'string' ? text : undefined,
+        stepCount: steps.length,
+        leaked: promptLeakBlocked,
+      });
+
       if (
         blockedForDisclosure ||
         !isChatToolStepCapExhausted(steps, toolStepLimit)
@@ -390,6 +413,8 @@ export async function executeChatTurn(
     },
     onError: async ({ error }) => {
       if (isClientDisconnect(error, signal)) return;
+
+      langfuseTrace.endError(error);
 
       telemetry?.captureException?.(error, {
         tags: { feature: 'ai-chat', errorType: 'streaming' },

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -264,6 +264,14 @@ export const ServerEnvSchema = z.object({
   /** Set to `1` to export Agnost traces in local development. */
   JOVIE_ENABLE_AGNOST: z.enum(['0', '1']).optional(),
 
+  // Langfuse LLM tracing + prompt registry delivery (Langfuse Cloud)
+  LANGFUSE_SECRET_KEY: z.string().optional(),
+  LANGFUSE_PUBLIC_KEY: z.string().optional(),
+  /** Defaults to https://cloud.langfuse.com when unset. */
+  LANGFUSE_BASE_URL: z.string().url().optional(),
+  /** Set to `1` to export Langfuse traces in local development. */
+  JOVIE_ENABLE_LANGFUSE: z.enum(['0', '1']).optional(),
+
   // AgentOS workflows are compile-ready but runtime-disabled by default.
   AGENT_OS_WORKFLOWS_ENABLED: z.enum(['true', 'false']).optional(),
 
@@ -486,6 +494,10 @@ export const ENV_KEYS = [
   'JOVIE_ENABLE_LOCAL_SENTRY',
   'AGNOST_ORG_ID',
   'JOVIE_ENABLE_AGNOST',
+  'LANGFUSE_SECRET_KEY',
+  'LANGFUSE_PUBLIC_KEY',
+  'LANGFUSE_BASE_URL',
+  'JOVIE_ENABLE_LANGFUSE',
   'AGENT_OS_WORKFLOWS_ENABLED',
   'XAI_API_KEY',
   'ALBUM_ART_IMAGE_MODEL',

--- a/apps/web/lib/observability/langfuse.ts
+++ b/apps/web/lib/observability/langfuse.ts
@@ -1,9 +1,10 @@
 import type { ChatPromptRegistryEntry } from '@/lib/chat/prompts/registry';
-import { publicEnv } from '@/lib/env-public';
-import { env } from '@/lib/env-server';
 
 /**
  * Langfuse LLM tracing — async batched export to Langfuse Cloud.
+ *
+ * Reads `process.env` directly (not `env-server`) so this module stays loadable
+ * from promptfoo eval harnesses that import `executeChatTurn`.
  *
  * @see https://langfuse.com/docs/sdk/typescript
  */
@@ -15,18 +16,29 @@ const LANGFUSE_REQUEST_TIMEOUT_MS = 10_000;
 let langfuseClientPromise: Promise<import('langfuse').Langfuse | null> | null =
   null;
 
+function readProcessEnv(key: string): string | undefined {
+  const value = process.env[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
 export function shouldEnableLangfuse(): boolean {
-  if (env.CI === 'true') return false;
-  if (env.NODE_ENV === 'test' || publicEnv.NEXT_PUBLIC_E2E_MODE === '1') {
+  if (readProcessEnv('CI') === 'true') return false;
+  if (
+    readProcessEnv('NODE_ENV') === 'test' ||
+    readProcessEnv('NEXT_PUBLIC_E2E_MODE') === '1'
+  ) {
     return false;
   }
 
-  if (!env.LANGFUSE_SECRET_KEY || !env.LANGFUSE_PUBLIC_KEY) {
+  if (
+    !readProcessEnv('LANGFUSE_SECRET_KEY') ||
+    !readProcessEnv('LANGFUSE_PUBLIC_KEY')
+  ) {
     return false;
   }
 
-  if (env.NODE_ENV === 'development') {
-    return env.JOVIE_ENABLE_LANGFUSE === '1';
+  if (readProcessEnv('NODE_ENV') === 'development') {
+    return readProcessEnv('JOVIE_ENABLE_LANGFUSE') === '1';
   }
 
   return true;
@@ -42,14 +54,16 @@ async function loadLangfuseClient(): Promise<
       try {
         const { Langfuse } = await import('langfuse');
         return new Langfuse({
-          secretKey: env.LANGFUSE_SECRET_KEY,
-          publicKey: env.LANGFUSE_PUBLIC_KEY,
-          baseUrl: env.LANGFUSE_BASE_URL ?? DEFAULT_LANGFUSE_BASE_URL,
+          secretKey: readProcessEnv('LANGFUSE_SECRET_KEY'),
+          publicKey: readProcessEnv('LANGFUSE_PUBLIC_KEY'),
+          baseUrl:
+            readProcessEnv('LANGFUSE_BASE_URL') ?? DEFAULT_LANGFUSE_BASE_URL,
           flushAt: 15,
           flushInterval: 10_000,
           requestTimeout: LANGFUSE_REQUEST_TIMEOUT_MS,
-          environment: env.VERCEL_ENV ?? env.NODE_ENV,
-          release: env.NEXT_PUBLIC_BUILD_SHA || undefined,
+          environment:
+            readProcessEnv('VERCEL_ENV') ?? readProcessEnv('NODE_ENV'),
+          release: readProcessEnv('NEXT_PUBLIC_BUILD_SHA'),
         });
       } catch (error) {
         console.warn('[langfuse] Client init failed:', error);

--- a/apps/web/lib/observability/langfuse.ts
+++ b/apps/web/lib/observability/langfuse.ts
@@ -1,0 +1,186 @@
+import 'server-only';
+
+import type { ChatPromptRegistryEntry } from '@/lib/chat/prompts/registry';
+import { publicEnv } from '@/lib/env-public';
+import { env } from '@/lib/env-server';
+
+/**
+ * Langfuse LLM tracing — async batched export to Langfuse Cloud.
+ *
+ * @see https://langfuse.com/docs/sdk/typescript
+ */
+
+const DEFAULT_LANGFUSE_BASE_URL = 'https://cloud.langfuse.com';
+/** Bounded export — observability sink must not hang chat turns. */
+const LANGFUSE_REQUEST_TIMEOUT_MS = 10_000;
+
+let langfuseClientPromise: Promise<import('langfuse').Langfuse | null> | null =
+  null;
+
+export function shouldEnableLangfuse(): boolean {
+  if (env.CI === 'true') return false;
+  if (env.NODE_ENV === 'test' || publicEnv.NEXT_PUBLIC_E2E_MODE === '1') {
+    return false;
+  }
+
+  if (!env.LANGFUSE_SECRET_KEY || !env.LANGFUSE_PUBLIC_KEY) {
+    return false;
+  }
+
+  if (env.NODE_ENV === 'development') {
+    return env.JOVIE_ENABLE_LANGFUSE === '1';
+  }
+
+  return true;
+}
+
+async function loadLangfuseClient(): Promise<
+  import('langfuse').Langfuse | null
+> {
+  if (!shouldEnableLangfuse()) return null;
+
+  if (!langfuseClientPromise) {
+    langfuseClientPromise = (async () => {
+      try {
+        const { Langfuse } = await import('langfuse');
+        return new Langfuse({
+          secretKey: env.LANGFUSE_SECRET_KEY,
+          publicKey: env.LANGFUSE_PUBLIC_KEY,
+          baseUrl: env.LANGFUSE_BASE_URL ?? DEFAULT_LANGFUSE_BASE_URL,
+          flushAt: 15,
+          flushInterval: 10_000,
+          requestTimeout: LANGFUSE_REQUEST_TIMEOUT_MS,
+          environment: env.VERCEL_ENV ?? env.NODE_ENV,
+          release: env.NEXT_PUBLIC_BUILD_SHA || undefined,
+        });
+      } catch (error) {
+        console.warn('[langfuse] Client init failed:', error);
+        return null;
+      }
+    })();
+  }
+
+  return langfuseClientPromise;
+}
+
+export type ChatTurnLangfuseInput = {
+  readonly requestId: string;
+  readonly conversationId: string | null;
+  readonly userId: string | null;
+  readonly userPlan: string;
+  readonly mode: 'app' | 'onboarding';
+  readonly selectedModel: string;
+  readonly toolNames: readonly string[];
+  readonly promptRegistry: ChatPromptRegistryEntry;
+  readonly messageCount: number;
+  readonly blockedForDisclosure: boolean;
+};
+
+export type ChatTurnLangfuseTrace = {
+  endSuccess(output: {
+    text?: string;
+    stepCount?: number;
+    leaked?: boolean;
+  }): void;
+  endError(error: unknown): void;
+};
+
+const noopTrace: ChatTurnLangfuseTrace = {
+  endSuccess() {},
+  endError() {},
+};
+
+/**
+ * Opens session → request → chain → leaf spans for a chat turn.
+ * Returns a no-op handle when Langfuse is disabled or init fails.
+ */
+export async function startChatTurnLangfuseTrace(
+  input: ChatTurnLangfuseInput
+): Promise<ChatTurnLangfuseTrace> {
+  const client = await loadLangfuseClient();
+  if (!client) return noopTrace;
+
+  const sessionId = input.conversationId ?? input.requestId;
+  const { promptRegistry } = input;
+
+  const trace = client.trace({
+    id: input.requestId,
+    name: 'jovie-chat-session',
+    sessionId,
+    userId: input.userId ?? undefined,
+    tags: [input.mode, input.userPlan],
+    metadata: {
+      requestId: input.requestId,
+      conversationId: input.conversationId,
+      mode: input.mode,
+      plan: input.userPlan,
+      prompt_version_id: promptRegistry.versionId,
+    },
+  });
+
+  const requestSpan = trace.span({
+    name: 'chat-turn-request',
+    metadata: {
+      requestId: input.requestId,
+      messageCount: input.messageCount,
+      blockedForDisclosure: input.blockedForDisclosure,
+      prompt_version_id: promptRegistry.versionId,
+    },
+  });
+
+  const chainSpan = requestSpan.span({
+    name: 'jovie-chat-chain',
+    metadata: {
+      model: input.selectedModel,
+      toolNames: input.toolNames,
+      prompt_version_id: promptRegistry.versionId,
+    },
+  });
+
+  const generation = chainSpan.generation({
+    name: 'jovie-chat',
+    model: input.selectedModel,
+    metadata: {
+      prompt_name: promptRegistry.name,
+      prompt_version: promptRegistry.version,
+      prompt_version_id: promptRegistry.versionId,
+      toolCount: input.toolNames.length,
+      blockedForDisclosure: input.blockedForDisclosure,
+    },
+  });
+
+  return {
+    endSuccess(output) {
+      generation.end({
+        output: output.text ? { text: output.text } : undefined,
+        metadata: {
+          stepCount: output.stepCount,
+          prompt_leak_blocked: output.leaked ?? false,
+        },
+      });
+      chainSpan.end();
+      requestSpan.end();
+      trace.update({
+        output: output.text ? { text: output.text } : undefined,
+        metadata: {
+          stepCount: output.stepCount,
+          prompt_leak_blocked: output.leaked ?? false,
+        },
+      });
+    },
+    endError(error) {
+      const message =
+        error instanceof Error ? error.message : 'Chat turn stream failed';
+      generation.end({
+        level: 'ERROR',
+        statusMessage: message,
+        metadata: { errorType: 'streaming' },
+      });
+      chainSpan.end({ level: 'ERROR', statusMessage: message });
+      requestSpan.end({ level: 'ERROR', statusMessage: message });
+      trace.update({
+        metadata: { errorType: 'streaming', errorMessage: message },
+      });
+    },
+  };
+}

--- a/apps/web/lib/observability/langfuse.ts
+++ b/apps/web/lib/observability/langfuse.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import type { ChatPromptRegistryEntry } from '@/lib/chat/prompts/registry';
 import { publicEnv } from '@/lib/env-public';
 import { env } from '@/lib/env-server';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -248,6 +248,7 @@
     "heic2any": "^0.0.4",
     "isomorphic-dompurify": "3.12.0",
     "jose": "^6.2.2",
+    "langfuse": "^3.38.20",
     "jszip": "^3.10.1",
     "lucide-react": "^1.16.0",
     "mdast-util-to-string": "^4.0.0",

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -5300,6 +5300,8 @@ function evaluateSkillArtifactContract(vars: EvalVars) {
   const skillArtifacts = Object.entries(SKILL_REGISTRY)
     .map(([skillId, skill]) => {
       const isTool = skill.kind === 'tool';
+      const isChatSurfaceTool =
+        isTool && (skill.metadata.surface ?? 'chat') === 'chat';
       const promptContent = isTool ? '' : registryPathContent(skill.promptPath);
       const requiredPromptGuardrails = toStringArray(promptGuardrails[skillId]);
       const missingPromptGuardrails = requiredPromptGuardrails.filter(

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -5300,8 +5300,6 @@ function evaluateSkillArtifactContract(vars: EvalVars) {
   const skillArtifacts = Object.entries(SKILL_REGISTRY)
     .map(([skillId, skill]) => {
       const isTool = skill.kind === 'tool';
-      const isChatSurfaceTool =
-        isTool && (skill.metadata.surface ?? 'chat') === 'chat';
       const promptContent = isTool ? '' : registryPathContent(skill.promptPath);
       const requiredPromptGuardrails = toStringArray(promptGuardrails[skillId]);
       const missingPromptGuardrails = requiredPromptGuardrails.filter(

--- a/apps/web/tests/unit/chat/prompts-registry.test.ts
+++ b/apps/web/tests/unit/chat/prompts-registry.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CHAT_PROMPT_REGISTRY,
+  resolveChatPromptRegistryEntry,
+} from '@/lib/chat/prompts/registry';
+
+describe('chat prompt registry', () => {
+  it('maps app mode to the app system prompt entry', () => {
+    expect(resolveChatPromptRegistryEntry('app')).toEqual(
+      CHAT_PROMPT_REGISTRY.app
+    );
+  });
+
+  it('maps onboarding mode to the onboarding system prompt entry', () => {
+    expect(resolveChatPromptRegistryEntry('onboarding')).toEqual(
+      CHAT_PROMPT_REGISTRY.onboarding
+    );
+  });
+
+  it('exposes stable prompt_version_id values for Langfuse linkage', () => {
+    expect(CHAT_PROMPT_REGISTRY.app.versionId).toBe('jovie-chat-app-system:v1');
+    expect(CHAT_PROMPT_REGISTRY.onboarding.versionId).toBe(
+      'jovie-chat-onboarding-system:v1'
+    );
+  });
+});

--- a/apps/web/tests/unit/lib/observability/langfuse.test.ts
+++ b/apps/web/tests/unit/lib/observability/langfuse.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('langfuse telemetry guards', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('disables export in CI', async () => {
+    vi.stubEnv('CI', 'true');
+    const { shouldEnableLangfuse } = await import(
+      '@/lib/observability/langfuse'
+    );
+    expect(shouldEnableLangfuse()).toBe(false);
+  });
+
+  it('disables export in local dev unless explicitly enabled', async () => {
+    vi.stubEnv('CI', 'false');
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('LANGFUSE_SECRET_KEY', 'sk-lf-test');
+    vi.stubEnv('LANGFUSE_PUBLIC_KEY', 'pk-lf-test');
+    vi.stubEnv('JOVIE_ENABLE_LANGFUSE', '');
+    const { shouldEnableLangfuse } = await import(
+      '@/lib/observability/langfuse'
+    );
+    expect(shouldEnableLangfuse()).toBe(false);
+  });
+
+  it('disables export in local E2E runtime', async () => {
+    vi.stubEnv('CI', 'false');
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('NEXT_PUBLIC_E2E_MODE', '1');
+    vi.stubEnv('LANGFUSE_SECRET_KEY', 'sk-lf-test');
+    vi.stubEnv('LANGFUSE_PUBLIC_KEY', 'pk-lf-test');
+    vi.stubEnv('JOVIE_ENABLE_LANGFUSE', '1');
+    const { shouldEnableLangfuse } = await import(
+      '@/lib/observability/langfuse'
+    );
+    expect(shouldEnableLangfuse()).toBe(false);
+  });
+
+  it('disables export when keys are missing', async () => {
+    vi.stubEnv('CI', 'false');
+    vi.stubEnv('NODE_ENV', 'production');
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    const { shouldEnableLangfuse } = await import(
+      '@/lib/observability/langfuse'
+    );
+    expect(shouldEnableLangfuse()).toBe(false);
+  });
+
+  it('enables export in production when keys are configured', async () => {
+    vi.stubEnv('CI', 'false');
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('LANGFUSE_SECRET_KEY', 'sk-lf-test');
+    vi.stubEnv('LANGFUSE_PUBLIC_KEY', 'pk-lf-test');
+    const { shouldEnableLangfuse } = await import(
+      '@/lib/observability/langfuse'
+    );
+    expect(shouldEnableLangfuse()).toBe(true);
+  });
+
+  it('returns a no-op trace handle when Langfuse is disabled', async () => {
+    vi.stubEnv('CI', 'true');
+    const { startChatTurnLangfuseTrace } = await import(
+      '@/lib/observability/langfuse'
+    );
+    const trace = await startChatTurnLangfuseTrace({
+      requestId: 'req-1',
+      conversationId: 'conv-1',
+      userId: 'user-1',
+      userPlan: 'pro',
+      mode: 'app',
+      selectedModel: 'anthropic/claude-sonnet-4',
+      toolNames: ['update_display_name'],
+      promptRegistry: {
+        name: 'jovie-chat-app-system',
+        version: 1,
+        versionId: 'jovie-chat-app-system:v1',
+      },
+      messageCount: 2,
+      blockedForDisclosure: false,
+    });
+
+    expect(() => trace.endSuccess({ text: 'ok', stepCount: 1 })).not.toThrow();
+    expect(() => trace.endError(new Error('boom'))).not.toThrow();
+  });
+});

--- a/docs/env.md
+++ b/docs/env.md
@@ -178,6 +178,29 @@ The client ID for Spotify API.
 
 The client secret for Spotify API.
 
+## Langfuse LLM Tracing (Langfuse Cloud)
+
+Server-side chat-turn tracing via the Langfuse SDK. Disabled in CI, test, and
+local dev unless explicitly opted in.
+
+### `LANGFUSE_SECRET_KEY`
+
+Langfuse project secret key (server-only). Get from Langfuse Cloud → Project
+Settings → API Keys.
+
+### `LANGFUSE_PUBLIC_KEY`
+
+Langfuse project public key (server-only ingestion).
+
+### `LANGFUSE_BASE_URL`
+
+Optional Langfuse API host. Defaults to `https://cloud.langfuse.com`.
+
+### `JOVIE_ENABLE_LANGFUSE`
+
+Set to `1` to export Langfuse traces during local development. Production and
+preview enable export automatically when both Langfuse keys are configured.
+
 ## Feature Flags
 
 ### `NEXT_PUBLIC_FEATURE_TIPS`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,6 +445,9 @@ importers:
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
+      langfuse:
+        specifier: ^3.38.20
+        version: 3.38.20
       lucide-react:
         specifier: ^1.16.0
         version: 1.16.0(react@19.2.4)
@@ -29982,12 +29985,10 @@ snapshots:
   langfuse-core@3.38.20:
     dependencies:
       mustache: 4.2.0
-    optional: true
 
   langfuse@3.38.20:
     dependencies:
       langfuse-core: 3.38.20
-    optional: true
 
   language-subtag-registry@0.3.23: {}
 


### PR DESCRIPTION
## Summary

Week 1 MVP for Langfuse Cloud tracing on the chat turn pipeline:

- **`apps/web/lib/observability/langfuse.ts`** — async-batched Langfuse SDK client, env-gated via `LANGFUSE_*` keys (disabled in CI/test/E2E; prod when keys configured; local dev with `JOVIE_ENABLE_LANGFUSE=1`).
- **`apps/web/lib/chat/prompts/registry.ts`** — local prompt registry with stable `versionId` values for Langfuse linkage.
- **`executeChatTurn`** instrumentation only — session trace → request span → chain span → generation leaf; `prompt_version_id` wired from registry; success/error completion in `onFinish`/`onError`.
- **`docs/env.md`** + `env-server-schema.ts` — document and validate Langfuse env vars.

No k8s/self-host deploy in this PR — Langfuse Cloud free tier config only.

## Test plan

- [x] `pnpm run typecheck` (apps/web)
- [x] `pnpm run lint` (apps/web)
- [x] `vitest run tests/unit/lib/observability/langfuse.test.ts`
- [x] `vitest run tests/unit/chat/prompts-registry.test.ts`
- [x] `vitest run tests/unit/chat/run.parity.test.ts`

## Env setup (Doppler prd/stg)

```
LANGFUSE_SECRET_KEY=sk-lf-...
LANGFUSE_PUBLIC_KEY=pk-lf-...
# optional: LANGFUSE_BASE_URL=https://cloud.langfuse.com
```

<!-- linear-issue-id:JOV-3660 -->