### PR TITLE
feat(profile): bento empty states with full-color gradients (JOV-3651)

### DIFF
--- a/apps/web/components/features/profile/ProfileEmptyBentoCard.tsx
+++ b/apps/web/components/features/profile/ProfileEmptyBentoCard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import type { LucideIcon } from 'lucide-react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, MouseEvent, ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
 export type ProfileEmptyBentoAccent = 'alerts' | 'music' | 'events';
@@ -52,7 +53,7 @@ function CardShell({
   children,
 }: Readonly<{
   href?: string;
-  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
   ariaLabel?: string;
   className: string;
   style: CSSProperties;
@@ -76,16 +77,17 @@ function CardShell({
 
   if (onClick) {
     return (
-      <button
+      <Button
         type='button'
+        variant='ghost'
         onClick={onClick}
         aria-label={ariaLabel}
-        className={className}
+        className={cn('h-auto rounded-(--profile-inner-radius) p-0', className)}
         style={style}
         data-testid={dataTestId}
       >
         {children}
-      </button>
+      </Button>
     );
   }
 

--- a/apps/web/components/features/profile/ProfileEmptyBentoCard.tsx
+++ b/apps/web/components/features/profile/ProfileEmptyBentoCard.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import type { LucideIcon } from 'lucide-react';
+import type { CSSProperties, ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type ProfileEmptyBentoAccent = 'alerts' | 'music' | 'events';
+
+export type ProfileEmptyBentoLayout = 'prominent' | 'compact' | 'inline';
+
+/**
+ * Full-color accent gradients for profile empty/low-content bento cards.
+ * Inline styles (not arbitrary Tailwind) to avoid the arbitrary-value ratchet.
+ */
+const ACCENT_GRADIENTS: Record<ProfileEmptyBentoAccent, CSSProperties> = {
+  alerts: {
+    background:
+      'radial-gradient(120% 100% at 50% -8%, color-mix(in oklab, var(--color-accent-purple) 82%, white) 0%, color-mix(in oklab, var(--color-accent-purple) 48%, #1a1030) 44%, color-mix(in oklab, var(--color-accent-purple) 22%, #0a0814) 100%)',
+  },
+  music: {
+    background:
+      'radial-gradient(120% 100% at 50% -8%, color-mix(in oklab, var(--color-accent-pink) 78%, white) 0%, color-mix(in oklab, var(--color-accent-pink) 44%, #2a1028) 44%, color-mix(in oklab, var(--color-accent-pink) 20%, #0a0814) 100%)',
+  },
+  events: {
+    background:
+      'radial-gradient(120% 100% at 50% -8%, color-mix(in oklab, var(--color-accent-blue) 78%, white) 0%, color-mix(in oklab, var(--color-accent-blue) 44%, #102040) 44%, color-mix(in oklab, var(--color-accent-blue) 20%, #0a0814) 100%)',
+  },
+};
+
+export interface ProfileEmptyBentoCardProps {
+  readonly accent: ProfileEmptyBentoAccent;
+  readonly icon: LucideIcon;
+  readonly title: string;
+  readonly body: string;
+  readonly layout?: ProfileEmptyBentoLayout;
+  readonly trailing?: ReactNode;
+  readonly action?: ReactNode;
+  readonly href?: string;
+  readonly onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  readonly ariaLabel?: string;
+  readonly className?: string;
+  readonly dataTestId?: string;
+}
+
+function CardShell({
+  href,
+  onClick,
+  ariaLabel,
+  className,
+  style,
+  dataTestId,
+  children,
+}: Readonly<{
+  href?: string;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  ariaLabel?: string;
+  className: string;
+  style: CSSProperties;
+  dataTestId?: string;
+  children: ReactNode;
+}>) {
+  if (href) {
+    return (
+      <a
+        href={href}
+        onClick={onClick}
+        aria-label={ariaLabel}
+        className={className}
+        style={style}
+        data-testid={dataTestId}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  if (onClick) {
+    return (
+      <button
+        type='button'
+        onClick={onClick}
+        aria-label={ariaLabel}
+        className={className}
+        style={style}
+        data-testid={dataTestId}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return (
+    <div className={className} style={style} data-testid={dataTestId}>
+      {children}
+    </div>
+  );
+}
+
+export function ProfileEmptyBentoCard({
+  accent,
+  icon: Icon,
+  title,
+  body,
+  layout = 'compact',
+  trailing,
+  action,
+  href,
+  onClick,
+  ariaLabel,
+  className,
+  dataTestId,
+}: ProfileEmptyBentoCardProps) {
+  const gradientStyle = ACCENT_GRADIENTS[accent];
+  const isInline = layout === 'inline';
+  const isProminent = layout === 'prominent';
+
+  const shellClassName = cn(
+    'group relative w-full min-w-0 overflow-hidden rounded-(--profile-inner-radius) border border-white/14 text-left text-white shadow-[0_18px_46px_rgba(0,0,0,0.34)] transition-[transform,opacity] duration-subtle dark:text-white',
+    (href || onClick) &&
+      'cursor-pointer hover:brightness-[1.04] active:opacity-90',
+    isInline && 'flex min-h-16 items-center gap-3 px-3.5 py-3',
+    isProminent && 'flex min-h-44 flex-col justify-between p-4',
+    layout === 'compact' && 'flex min-h-36 flex-col justify-between p-4',
+    className
+  );
+
+  const iconClassName = cn(
+    'shrink-0 text-white/92',
+    isInline ? 'h-5 w-5' : isProminent ? 'h-6 w-6' : 'h-5 w-5'
+  );
+
+  const titleClassName = cn(
+    'font-semibold leading-tight text-white [overflow-wrap:anywhere] dark:text-white',
+    isInline
+      ? 'text-app'
+      : isProminent
+        ? 'text-lg tracking-[-0.018em]'
+        : 'text-base tracking-[-0.016em]'
+  );
+
+  const bodyClassName = cn(
+    'text-white/72 [overflow-wrap:anywhere]',
+    isInline
+      ? 'mt-0.5 block max-w-64 text-2xs leading-4 text-white/68'
+      : isProminent
+        ? 'mt-1.5 max-w-[30ch] text-sm leading-5'
+        : 'mt-1 max-w-[32ch] text-xs leading-5'
+  );
+
+  const content = isInline ? (
+    <>
+      <Icon className={iconClassName} aria-hidden='true' />
+      <span className='min-w-0 flex-1'>
+        <span className={cn(titleClassName, 'block')}>{title}</span>
+        <span className={bodyClassName}>{body}</span>
+      </span>
+      {trailing}
+    </>
+  ) : (
+    <>
+      <div className='relative z-10 flex items-start gap-3'>
+        <span className='inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/18 bg-white/12 backdrop-blur-md'>
+          <Icon className={iconClassName} aria-hidden='true' />
+        </span>
+        <div className='min-w-0 flex-1'>
+          <p className={titleClassName}>{title}</p>
+          <p className={bodyClassName}>{body}</p>
+        </div>
+        {trailing ? <div className='shrink-0'>{trailing}</div> : null}
+      </div>
+      {action ? <div className='relative z-10 mt-4'>{action}</div> : null}
+    </>
+  );
+
+  return (
+    <CardShell
+      href={href}
+      onClick={onClick}
+      ariaLabel={ariaLabel}
+      className={shellClassName}
+      style={gradientStyle}
+      dataTestId={dataTestId}
+    >
+      <span
+        aria-hidden='true'
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_82%_88%,rgba(255,255,255,0.14),transparent_42%)]'
+      />
+      <span
+        aria-hidden='true'
+        className='pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-[linear-gradient(to_top,rgba(0,0,0,0.22),transparent)]'
+      />
+      <div className='relative z-10 flex h-full w-full flex-col'>{content}</div>
+    </CardShell>
+  );
+}

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Bell } from 'lucide-react';
-import { useMemo } from 'react';
+import { type MouseEvent, useMemo } from 'react';
 import {
   type EntityCardModel,
   merchToEntityCard,
@@ -10,6 +10,7 @@ import {
 } from '@/components/organisms/entity-card';
 import type { NotificationSourceContext } from '@/features/profile/artist-notifications-cta/types';
 import type { ProfileRenderMode } from '@/features/profile/contracts';
+import { ProfileEmptyBentoCard } from '@/features/profile/ProfileEmptyBentoCard';
 import type { ProfilePrimaryActionCardRelease } from '@/features/profile/ProfilePrimaryActionCard';
 import {
   startOfProfileSurfaceLocalDay as startOfLocalDay,
@@ -23,7 +24,6 @@ import type { PublicMerchCard } from '@/lib/merch/types';
 import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import { getProfileReleaseVisibility } from '@/lib/profile/release-visibility';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
-import { cn } from '@/lib/utils';
 import type { Artist } from '@/types/db';
 import { ReleaseCatalogCarousel } from './ReleaseCatalogCarousel';
 import type { PublicRelease } from './releases/types';
@@ -68,93 +68,60 @@ function getUpcomingTourDates(
     );
 }
 
+function HomeAlertsSwitch() {
+  return (
+    <span
+      className='relative inline-flex h-7 w-12 shrink-0 items-center rounded-full border border-white/18 bg-white/18 p-1 shadow-sm transition-colors duration-subtle group-hover:bg-white/24'
+      aria-hidden='true'
+      data-testid='profile-home-alerts-switch'
+    >
+      <span className='block h-6 w-6 rounded-full bg-white shadow-[0_3px_10px_rgba(0,0,0,0.32)] dark:bg-white' />
+    </span>
+  );
+}
+
 function HomeAlertsCard({
   artist,
   onAlertsClick,
   renderMode,
-  variant,
+  prominent,
   sourceContext,
 }: Readonly<{
   artist: Artist;
   onAlertsClick?: (context: NotificationSourceContext) => void;
   renderMode: ProfileRenderMode;
-  variant: 'row' | 'bento';
+  prominent: boolean;
   sourceContext: NotificationSourceContext;
 }>) {
   const title = 'Alerts';
   const description = `${artist.name}: music, shows, merch.`;
   const isInteractive = renderMode === 'interactive';
   const subscribeHref = `/${artist.handle}?mode=subscribe`;
-  const sharedProps = {
-    className:
-      variant === 'bento'
-        ? 'group flex min-h-16 w-full min-w-0 items-center gap-3 rounded-(--profile-inner-radius) border border-white/10 bg-white/5 px-3.5 py-3 text-left text-white dark:text-white shadow-card backdrop-blur-2xl transition-colors duration-subtle hover:bg-white/10 active:opacity-90'
-        : 'group flex min-h-12 w-full min-w-0 items-center gap-2.5 rounded-2xl border border-white/10 bg-white/5 px-3 text-left text-white dark:text-white shadow-card backdrop-blur-2xl transition-colors duration-subtle hover:bg-white/10 active:opacity-90',
-    'data-testid':
-      variant === 'bento'
-        ? 'profile-home-alerts-fallback-card'
-        : 'profile-home-alerts-row',
-  } as const;
   const ariaLabel = `Turn on alerts for ${artist.name}`;
-  const content = (
-    <>
-      <Bell
-        className={cn(
-          'shrink-0 text-white/84',
-          variant === 'bento' ? 'h-5 w-5' : 'h-4 w-4'
-        )}
-        aria-hidden='true'
-      />
-      <span className='min-w-0 flex-1'>
-        <span
-          className={
-            variant === 'bento'
-              ? 'block text-app font-semibold leading-tight [overflow-wrap:anywhere]'
-              : 'block text-xs font-semibold leading-4 [overflow-wrap:anywhere]'
-          }
-        >
-          {title}
-        </span>
-        <span
-          className={
-            variant === 'bento'
-              ? 'mt-0.5 block max-w-64 text-2xs leading-4 text-white/55 [overflow-wrap:anywhere]'
-              : 'mt-0.5 block text-2xs leading-3.5 text-white/50 [overflow-wrap:anywhere]'
-          }
-        >
-          {description}
-        </span>
-      </span>
-      <span
-        className='relative inline-flex h-7 w-12 shrink-0 items-center rounded-full border border-white/12 bg-white/15 p-1 shadow-sm transition-colors duration-subtle group-hover:bg-white/20'
-        aria-hidden='true'
-        data-testid='profile-home-alerts-switch'
-      >
-        <span className='block h-6 w-6 rounded-full bg-white dark:bg-white shadow-[0_3px_10px_rgba(0,0,0,0.32)]' />
-      </span>
-    </>
+  const handleClick = isInteractive
+    ? (event: MouseEvent<HTMLElement>) => {
+        if (!onAlertsClick) {
+          return;
+        }
+        event.preventDefault();
+        onAlertsClick(sourceContext);
+      }
+    : undefined;
+
+  return (
+    <ProfileEmptyBentoCard
+      accent='alerts'
+      icon={Bell}
+      title={title}
+      body={description}
+      layout={prominent ? 'prominent' : 'inline'}
+      trailing={<HomeAlertsSwitch />}
+      href={isInteractive ? subscribeHref : undefined}
+      onClick={handleClick}
+      ariaLabel={ariaLabel}
+      dataTestId='profile-home-alerts-fallback-card'
+    />
   );
-
-  if (isInteractive) {
-    return (
-      <a
-        href={subscribeHref}
-        onClick={event => {
-          if (!onAlertsClick) {
-            return;
-          }
-          event.preventDefault();
-          onAlertsClick(sourceContext);
-        }}
-        aria-label={ariaLabel}
-        {...sharedProps}
-      >
-        {content}
-      </a>
-    );
-  }
-
-  return <div {...sharedProps}>{content}</div>;
 }
 
 export function ProfileHomeRail({
@@ -290,12 +257,14 @@ export function ProfileHomeRail({
     upcomingTourDates,
   ]);
 
+  const isLowContentHome = carouselItems.length === 0;
+
   const alertsCard = isSubscribed ? null : (
     <HomeAlertsCard
       artist={artist}
       onAlertsClick={onAlertsClick}
       renderMode={renderMode}
-      variant='bento'
+      prominent={isLowContentHome}
       sourceContext={{
         artistId: artist.id,
         profileId: artist.id,

--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Bell, CheckCircle2 } from 'lucide-react';
+import { Bell, CheckCircle2, Music2 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { AboutSection } from '@/features/profile/AboutSection';
 import { ArtistNotificationsCTA } from '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA';
@@ -11,6 +11,7 @@ import type {
   ProfilePrimaryTab,
   ProfileRenderMode,
 } from '@/features/profile/contracts';
+import { ProfileEmptyBentoCard } from '@/features/profile/ProfileEmptyBentoCard';
 import type { PublicRelease } from '@/features/profile/releases/types';
 import { TourDrawerContent } from '@/features/profile/TourModePanel';
 import { ReleasesView } from '@/features/profile/views/ReleasesView';
@@ -254,38 +255,46 @@ function SubscribePanel({
   );
 }
 
-function ProfileEmptyState({
+function ProfileMusicEmptyState({
   artist,
-  title,
-  body,
-  triggerLabel,
   sourceContext,
+  renderMode,
 }: Readonly<{
   artist: Artist;
-  title: string;
-  body: string;
-  triggerLabel: string;
   sourceContext: NotificationSourceContext;
+  renderMode: ProfileRenderMode;
 }>) {
+  const action =
+    renderMode === 'preview' ? (
+      <button
+        type='button'
+        className='inline-flex h-11 w-full items-center justify-center rounded-full bg-white px-5 text-app font-semibold tracking-tight text-black dark:bg-white dark:text-black'
+        disabled
+      >
+        Turn on alerts
+      </button>
+    ) : (
+      <ArtistNotificationsCTA
+        artist={artist}
+        variant='button'
+        presentation='overlay'
+        hideListenFallback
+        source={sourceContext.ctaLocation}
+        sourceContext={sourceContext}
+        triggerLabel='Turn on alerts'
+      />
+    );
+
   return (
-    <div className='flex min-h-[36vh] flex-col items-center justify-center px-6 py-12 text-center'>
-      <p className='text-base font-semibold tracking-[-0.018em] text-white dark:text-white'>
-        {title}
-      </p>
-      <p className='mt-2 max-w-[25ch] text-xs leading-5 text-white/52'>
-        {body}
-      </p>
-      <div className='mt-5'>
-        <ArtistNotificationsCTA
-          artist={artist}
-          variant='button'
-          presentation='overlay'
-          hideListenFallback
-          source={sourceContext.ctaLocation}
-          sourceContext={sourceContext}
-          triggerLabel={triggerLabel}
-        />
-      </div>
+    <div className='px-4 pb-4' data-testid='profile-primary-tab-music-empty'>
+      <ProfileEmptyBentoCard
+        accent='music'
+        icon={Music2}
+        title='No Music'
+        body='Get a note when the first release lands.'
+        layout='compact'
+        action={action}
+      />
     </div>
   );
 }
@@ -535,11 +544,9 @@ export function ProfilePrimaryTabPanel({
             Music
           </h2>
         </div>
-        <ProfileEmptyState
+        <ProfileMusicEmptyState
           artist={artist}
-          title='No Music'
-          body='Get a note when the first release lands.'
-          triggerLabel='Turn on alerts'
+          renderMode={renderMode}
           sourceContext={musicEmptySourceContext}
         />
       </div>

--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { Bell, CheckCircle2, Music2 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { AboutSection } from '@/features/profile/AboutSection';
@@ -266,13 +267,14 @@ function ProfileMusicEmptyState({
 }>) {
   const action =
     renderMode === 'preview' ? (
-      <button
+      <Button
         type='button'
-        className='inline-flex h-11 w-full items-center justify-center rounded-full bg-white px-5 text-app font-semibold tracking-tight text-black dark:bg-white dark:text-black'
+        variant='primary'
+        className='h-11 w-full rounded-full'
         disabled
       >
-        Turn on alerts
-      </button>
+        Turn On Alerts
+      </Button>
     ) : (
       <ArtistNotificationsCTA
         artist={artist}

--- a/apps/web/components/features/profile/TourModePanel.tsx
+++ b/apps/web/components/features/profile/TourModePanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { Ticket } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
@@ -188,13 +189,14 @@ function TourDatesContent({
   if (allDates.length === 0) {
     const action =
       renderMode === 'preview' ? (
-        <button
+        <Button
           type='button'
-          className='inline-flex h-11 w-full items-center justify-center rounded-full bg-white px-5 text-app font-semibold tracking-tight text-black dark:bg-white dark:text-black'
+          variant='primary'
+          className='h-11 w-full rounded-full'
           disabled
         >
           Event Alerts
-        </button>
+        </Button>
       ) : (
         <ArtistNotificationsCTA
           artist={artist}

--- a/apps/web/components/features/profile/TourModePanel.tsx
+++ b/apps/web/components/features/profile/TourModePanel.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { Ticket } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 import type { ProfileRenderMode } from '@/features/profile/contracts';
+import { ProfileEmptyBentoCard } from '@/features/profile/ProfileEmptyBentoCard';
 import { useBreakpointDown } from '@/hooks/useBreakpoint';
 import {
   type TourDateWithProximity,
@@ -188,7 +190,7 @@ function TourDatesContent({
       renderMode === 'preview' ? (
         <button
           type='button'
-          className='inline-flex h-11 items-center rounded-full bg-white px-5 text-app font-semibold tracking-tight text-black dark:bg-white dark:text-black'
+          className='inline-flex h-11 w-full items-center justify-center rounded-full bg-white px-5 text-app font-semibold tracking-tight text-black dark:bg-white dark:text-black'
           disabled
         >
           Event Alerts
@@ -206,14 +208,15 @@ function TourDatesContent({
       );
 
     return (
-      <div className='flex min-h-[36vh] flex-col items-center justify-center px-6 py-12 text-center'>
-        <p className='text-base font-semibold tracking-[-0.018em] dark:text-white'>
-          No Events
-        </p>
-        <p className='mt-2 max-w-[25ch] text-xs leading-5 text-white/52'>
-          Get alerted when shows are announced.
-        </p>
-        <div className='mt-5'>{action}</div>
+      <div className='px-4 pb-4' data-testid='profile-primary-tab-events-empty'>
+        <ProfileEmptyBentoCard
+          accent='events'
+          icon={Ticket}
+          title='No Events'
+          body='Get alerted when shows are announced.'
+          layout='compact'
+          action={action}
+        />
       </div>
     );
   }

--- a/apps/web/tests/unit/profile/ProfileEmptyBentoCard.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileEmptyBentoCard.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { Bell, Music2 } from 'lucide-react';
+import { describe, expect, it } from 'vitest';
+import { ProfileEmptyBentoCard } from '@/features/profile/ProfileEmptyBentoCard';
+
+describe('ProfileEmptyBentoCard', () => {
+  it('renders a prominent alerts bento with full-color gradient background', () => {
+    render(
+      <ProfileEmptyBentoCard
+        accent='alerts'
+        icon={Bell}
+        title='Alerts'
+        body='Tim White: music, shows, merch.'
+        layout='prominent'
+        dataTestId='profile-home-alerts-fallback-card'
+        trailing={<span data-testid='profile-home-alerts-switch'>switch</span>}
+      />
+    );
+
+    const card = screen.getByTestId('profile-home-alerts-fallback-card');
+    expect(card.style.background).toContain('var(--color-accent-purple)');
+    expect(screen.getByText('Alerts')).toBeVisible();
+    expect(screen.getByText('Tim White: music, shows, merch.')).toBeVisible();
+    expect(screen.getByTestId('profile-home-alerts-switch')).toBeVisible();
+  });
+
+  it('renders a compact music empty bento with CTA action', () => {
+    render(
+      <ProfileEmptyBentoCard
+        accent='music'
+        icon={Music2}
+        title='No Music'
+        body='Get a note when the first release lands.'
+        layout='compact'
+        action={<button type='button'>Turn on alerts</button>}
+      />
+    );
+
+    const card =
+      screen.getByText('No Music').parentElement?.parentElement?.parentElement
+        ?.parentElement;
+    expect(card).toBeTruthy();
+    expect(card?.style.background).toContain('var(--color-accent-pink)');
+    expect(screen.getByText('No Music')).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Turn on alerts' })
+    ).toBeVisible();
+  });
+});

--- a/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
@@ -79,6 +79,25 @@ describe('ProfileHomeRail', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders a prominent gradient alerts bento when the home rail is empty', () => {
+    render(
+      <ProfileHomeRail
+        artist={makeArtist()}
+        latestRelease={null}
+        profileSettings={{ showOldReleases: true }}
+        featuredPlaylistFallback={null}
+        tourDates={[]}
+        hasPlayableDestinations
+        renderMode='preview'
+        isSubscribed={false}
+      />
+    );
+
+    const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
+    expect(alertsCard.style.background).toContain('var(--color-accent-purple)');
+    expect(alertsCard.className).toContain('min-h-44');
+  });
+
   it('pins the alerts bento above the carousel and renders no carousel when empty', () => {
     render(
       <ProfileHomeRail

--- a/apps/web/tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx
+++ b/apps/web/tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx
@@ -138,6 +138,7 @@ describe('ProfilePrimaryTabPanel listen mode', () => {
       />
     );
 
+    expect(screen.getByTestId('profile-primary-tab-music-empty')).toBeVisible();
     expect(screen.getByText('No Music')).toBeVisible();
     expect(
       screen.getByRole('button', { name: 'Turn on alerts' })

--- a/apps/web/tests/unit/profile/TourModePanel.test.tsx
+++ b/apps/web/tests/unit/profile/TourModePanel.test.tsx
@@ -145,15 +145,18 @@ describe('TourModePanel', () => {
     );
   });
 
-  // JOV-3555: the "No Events" heading must be the primary readable line, not a
-  // low-contrast token. The profile drawer is an always-dark surface, so the
-  // high-contrast white is applied via the lint-compliant `dark:text-white`
-  // pairing. Regression guard against the near-invisible heading.
-  it('renders the No Events heading with primary (dark:text-white) contrast', () => {
+  it('renders the events empty state as a full-color gradient bento card', () => {
     render(<TourModePanel artist={artist} tourDates={[]} />);
+
+    expect(
+      screen.getByTestId('profile-primary-tab-events-empty')
+    ).toBeInTheDocument();
     const heading = screen.getByText('No Events');
     expect(heading).toHaveClass('dark:text-white');
     expect(heading.className).not.toMatch(/text-\(--color-text-tooltip\)/);
+    const bentoCard = screen.getByTestId('profile-primary-tab-events-empty')
+      .firstChild as HTMLElement;
+    expect(bentoCard.style.background).toContain('var(--color-accent-blue)');
   });
 
   it('renders the styled all-shows list when no geolocation is available', () => {


### PR DESCRIPTION
## Goal

Give profile empty/low-content surfaces a shared bento treatment with full-color accent gradients instead of frosted glass or centered sparse copy.

## Changes

- Add `ProfileEmptyBentoCard` with alerts/music/events accent gradients and prominent/compact/inline layouts
- Home rail: alerts card uses gradient bento; switches to prominent layout when carousel is empty
- Music tab: replace centered empty state with compact music bento + alerts CTA
- Events tab: replace centered empty state with compact events bento + alerts CTA
- Unit tests for the new component and updated empty-state surfaces

## Testing

- `pnpm --filter @jovie/web exec vitest run tests/unit/profile/ProfileEmptyBentoCard.test.tsx tests/unit/profile/ProfileHomeRail.test.tsx tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx tests/unit/profile/TourModePanel.test.tsx`
- Visual: `/demo/showcase/tim-white-profile?state=alerts-fallback` and `?state=events-empty`

<!-- linear-issue-id:JOV-3651 -->