### PR TITLE
fix(chat): vertically center new-conversation empty state (JOV-3650)

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -562,12 +562,16 @@ export function JovieChat({
             ref={scrollContainerRef}
             className={cn(
               'absolute inset-0 overflow-y-auto px-4 py-5 sm:px-5',
+              !showThreadView && 'flex flex-col',
               showBottomComposer &&
                 CHAT_COMPOSER_THREAD_SCROLL_PADDING_CLASSNAME
             )}
           >
             {!showThreadView ? (
-              <div className='relative min-h-full'>
+              <div
+                className='flex flex-1 flex-col items-center justify-center'
+                data-testid='chat-empty-state-viewport'
+              >
                 <ChatEmptyStateComposerRegion>
                   {composerSurface}
                   {inlineChatError ? (

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -178,6 +178,9 @@ describe('JovieChat empty state', () => {
     expect(queryByText("Hey, I'm Jovie.")).toBeNull();
     expect(queryByText('Jovie Assistant')).toBeNull();
     expect(queryByText('Ask anything or tell Jovie what you need')).toBeNull();
+    const emptyViewport = getByTestId('chat-empty-state-viewport');
+    expect(emptyViewport.className).toContain('flex-1');
+    expect(emptyViewport.className).toContain('justify-center');
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
     expect(getByTestId('chat-empty-state-logo')).toBeTruthy();
     expect(getByTestId('chat-empty-state-centered-composer')).toBeTruthy();


### PR DESCRIPTION
## Goal

Fix the web chat new-conversation empty state so the background logo and composer are vertically centered in the viewport instead of pinned to the top.

<!-- linear-issue-id:JOV-3650 -->

## Changes

- Restore flex centering on the empty-state viewport in `JovieChat.tsx` after JOV-3594 moved the scroll container to `absolute inset-0`, which broke `min-h-full` height propagation
- Add `flex flex-col` to the scroll container when showing the empty state so `flex-1` can fill available height
- Add `chat-empty-state-viewport` test id and unit test assertions for centering classes

## Testing

- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/JovieChat.empty-state.test.tsx`
- `pnpm --filter @jovie/web exec vitest run components/jovie/components/ChatEmptyStateComposerRegion.test.tsx`
- Manual: open `/app/chat` with no messages — logo and composer should be vertically centered

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>