### PR TITLE
feat(eval): LLM judge calibration with Cohen's kappa gate

### DIFF
--- a/apps/web/lib/eval/calibration.test.ts
+++ b/apps/web/lib/eval/calibration.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertJudgeCalibrationGate,
+  CalibrationGateError,
+  computeCohensKappa,
+  computeHoldoutKappa,
+  DEFAULT_KAPPA_THRESHOLD,
+  type HumanHoldoutSet,
+  loadHumanHoldoutSet,
+  pairHoldoutLabels,
+  parseHumanHoldoutSet,
+  runJudgeCalibrationGate,
+} from './calibration';
+
+function makeHoldout(items: HumanHoldoutSet['items']): HumanHoldoutSet {
+  return {
+    schemaVersion: 1,
+    labeledAt: '2026-06-27T12:00:00.000Z',
+    items,
+  };
+}
+
+describe('parseHumanHoldoutSet', () => {
+  it('parses a valid holdout payload', () => {
+    const holdout = parseHumanHoldoutSet({
+      schemaVersion: 1,
+      labeledAt: '2026-06-27T12:00:00.000Z',
+      items: [
+        {
+          id: 'a',
+          caseId: 'case-a',
+          humanLabel: 'pass',
+        },
+      ],
+    });
+
+    expect(holdout.items).toHaveLength(1);
+    expect(holdout.items[0]?.humanLabel).toBe('pass');
+  });
+
+  it('rejects duplicate ids and invalid labels', () => {
+    expect(() =>
+      parseHumanHoldoutSet({
+        schemaVersion: 1,
+        labeledAt: '2026-06-27T12:00:00.000Z',
+        items: [
+          { id: 'dup', caseId: 'one', humanLabel: 'pass' },
+          { id: 'dup', caseId: 'two', humanLabel: 'fail' },
+        ],
+      })
+    ).toThrow(/Duplicate holdout id/);
+
+    expect(() =>
+      parseHumanHoldoutSet({
+        schemaVersion: 1,
+        labeledAt: '2026-06-27T12:00:00.000Z',
+        items: [{ id: 'a', caseId: 'case-a', humanLabel: 'maybe' }],
+      })
+    ).toThrow(/invalid humanLabel/);
+  });
+});
+
+describe('loadHumanHoldoutSet', () => {
+  it('loads the bundled human-labeled holdout fixture', () => {
+    const holdout = loadHumanHoldoutSet();
+
+    expect(holdout.schemaVersion).toBe(1);
+    expect(holdout.items.length).toBeGreaterThanOrEqual(4);
+    expect(
+      holdout.items.every(
+        item => item.humanLabel === 'pass' || item.humanLabel === 'fail'
+      )
+    ).toBe(true);
+  });
+});
+
+describe('computeCohensKappa', () => {
+  it('returns 1 for perfect agreement', () => {
+    const result = computeCohensKappa(
+      ['pass', 'pass', 'fail', 'fail'],
+      ['pass', 'pass', 'fail', 'fail']
+    );
+
+    expect(result.kappa).toBe(1);
+    expect(result.observedAgreement).toBe(1);
+  });
+
+  it('returns 0 for chance-level disagreement on balanced labels', () => {
+    const result = computeCohensKappa(
+      ['pass', 'pass', 'fail', 'fail'],
+      ['pass', 'fail', 'pass', 'fail']
+    );
+
+    expect(result.kappa).toBeCloseTo(0, 5);
+  });
+
+  it('returns negative kappa for worse-than-chance disagreement', () => {
+    const result = computeCohensKappa(
+      ['pass', 'pass', 'fail', 'fail'],
+      ['fail', 'fail', 'pass', 'pass']
+    );
+
+    expect(result.kappa).toBeLessThan(0);
+    expect(result.observedAgreement).toBe(0);
+  });
+});
+
+describe('pairHoldoutLabels', () => {
+  it('pairs by holdout id and falls back to caseId', () => {
+    const holdout = makeHoldout([
+      { id: 'by-id', caseId: 'case-a', humanLabel: 'pass' },
+      { id: 'by-case', caseId: 'case-b', humanLabel: 'fail' },
+    ]);
+
+    const { paired, missingJudgeLabels } = pairHoldoutLabels(holdout, {
+      'by-id': 'pass',
+      'case-b': 'fail',
+    });
+
+    expect(missingJudgeLabels).toEqual([]);
+    expect(paired).toHaveLength(2);
+    expect(computeHoldoutKappa(paired).kappa).toBe(1);
+  });
+});
+
+describe('runJudgeCalibrationGate', () => {
+  it('passes when judge labels align with human holdout labels', () => {
+    const holdout = loadHumanHoldoutSet();
+    const judgeLabels = Object.fromEntries(
+      holdout.items.map(item => [item.id, item.humanLabel])
+    );
+
+    const result = runJudgeCalibrationGate({ holdout, judgeLabels });
+
+    expect(result.passed).toBe(true);
+    expect(result.kappa).toBe(1);
+    expect(result.threshold).toBe(DEFAULT_KAPPA_THRESHOLD);
+    expect(result.disagreements).toEqual([]);
+  });
+
+  it('fails when kappa falls below the default threshold', () => {
+    const holdout = makeHoldout([
+      { id: 'a', caseId: 'case-a', humanLabel: 'pass' },
+      { id: 'b', caseId: 'case-b', humanLabel: 'pass' },
+      { id: 'c', caseId: 'case-c', humanLabel: 'fail' },
+      { id: 'd', caseId: 'case-d', humanLabel: 'fail' },
+    ]);
+
+    const result = runJudgeCalibrationGate({
+      holdout,
+      judgeLabels: {
+        a: 'pass',
+        b: 'fail',
+        c: 'pass',
+        d: 'fail',
+      },
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.kappa).toBeCloseTo(0, 5);
+    expect(result.disagreements).toHaveLength(2);
+  });
+
+  it('throws when judge labels are missing for holdout rows', () => {
+    const holdout = makeHoldout([
+      { id: 'a', caseId: 'case-a', humanLabel: 'pass' },
+    ]);
+
+    expect(() =>
+      runJudgeCalibrationGate({
+        holdout,
+        judgeLabels: {},
+      })
+    ).toThrow(/Missing judge labels/);
+  });
+});
+
+describe('assertJudgeCalibrationGate', () => {
+  it('returns the gate result when calibration passes', () => {
+    const holdout = makeHoldout([
+      { id: 'a', caseId: 'case-a', humanLabel: 'pass' },
+      { id: 'b', caseId: 'case-b', humanLabel: 'fail' },
+    ]);
+
+    const result = assertJudgeCalibrationGate({
+      holdout,
+      judgeLabels: { a: 'pass', b: 'fail' },
+    });
+
+    expect(result.passed).toBe(true);
+  });
+
+  it('throws CalibrationGateError when kappa is below threshold', () => {
+    const holdout = makeHoldout([
+      { id: 'a', caseId: 'case-a', humanLabel: 'pass' },
+      { id: 'b', caseId: 'case-b', humanLabel: 'pass' },
+      { id: 'c', caseId: 'case-c', humanLabel: 'fail' },
+      { id: 'd', caseId: 'case-d', humanLabel: 'fail' },
+    ]);
+
+    expect(() =>
+      assertJudgeCalibrationGate({
+        holdout,
+        judgeLabels: {
+          a: 'pass',
+          b: 'fail',
+          c: 'pass',
+          d: 'fail',
+        },
+        threshold: 0.6,
+      })
+    ).toThrow(CalibrationGateError);
+  });
+});

--- a/apps/web/lib/eval/calibration.ts
+++ b/apps/web/lib/eval/calibration.ts
@@ -1,0 +1,320 @@
+/**
+ * LLM-as-judge calibration: human holdout loader + Cohen's kappa gate (JOV-3663).
+ *
+ * Compares human reviewer labels on a fixed holdout set against LLM judge
+ * labels and blocks promotion when inter-rater agreement falls below threshold.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const HUMAN_HOLDOUT_SCHEMA_VERSION = 1 as const;
+
+export const DEFAULT_KAPPA_THRESHOLD = 0.6;
+
+export type JudgeBinaryLabel = 'pass' | 'fail';
+
+export interface HumanHoldoutItem {
+  /** Stable holdout row identifier. */
+  readonly id: string;
+  /** Golden-case name or trace id the label refers to. */
+  readonly caseId: string;
+  readonly humanLabel: JudgeBinaryLabel;
+  readonly notes?: string;
+}
+
+export interface HumanHoldoutSet {
+  readonly schemaVersion: typeof HUMAN_HOLDOUT_SCHEMA_VERSION;
+  /** ISO-8601 timestamp when the holdout was last curated. */
+  readonly labeledAt: string;
+  readonly items: readonly HumanHoldoutItem[];
+}
+
+export type JudgeLabelMap = Readonly<Record<string, JudgeBinaryLabel>>;
+
+export interface PairedJudgeLabel {
+  readonly id: string;
+  readonly caseId: string;
+  readonly humanLabel: JudgeBinaryLabel;
+  readonly judgeLabel: JudgeBinaryLabel;
+}
+
+export interface CohensKappaResult {
+  readonly kappa: number;
+  readonly observedAgreement: number;
+  readonly expectedAgreement: number;
+  readonly pairedCount: number;
+}
+
+export interface CalibrationGateResult {
+  readonly passed: boolean;
+  readonly kappa: number;
+  readonly threshold: number;
+  readonly pairedCount: number;
+  readonly observedAgreement: number;
+  readonly expectedAgreement: number;
+  readonly disagreements: readonly PairedJudgeLabel[];
+}
+
+export class CalibrationGateError extends Error {
+  readonly result: CalibrationGateResult;
+
+  constructor(message: string, result: CalibrationGateResult) {
+    super(message);
+    this.name = 'CalibrationGateError';
+    this.result = result;
+  }
+}
+
+const JUDGE_LABELS: ReadonlySet<string> = new Set(['pass', 'fail']);
+
+const DEFAULT_HOLDOUT_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'holdout.json'
+);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function assertJudgeLabel(
+  value: unknown,
+  field: string,
+  itemId: string
+): JudgeBinaryLabel {
+  if (typeof value !== 'string' || !JUDGE_LABELS.has(value)) {
+    throw new Error(
+      `Holdout item "${itemId}" has invalid ${field}: expected "pass" or "fail"`
+    );
+  }
+
+  return value as JudgeBinaryLabel;
+}
+
+export function parseHumanHoldoutSet(raw: unknown): HumanHoldoutSet {
+  if (!isRecord(raw)) {
+    throw new Error('Holdout set must be a JSON object');
+  }
+
+  if (raw.schemaVersion !== HUMAN_HOLDOUT_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported holdout schemaVersion: expected ${HUMAN_HOLDOUT_SCHEMA_VERSION}`
+    );
+  }
+
+  if (typeof raw.labeledAt !== 'string' || raw.labeledAt.trim().length === 0) {
+    throw new Error('Holdout set requires a non-empty labeledAt timestamp');
+  }
+
+  if (!Array.isArray(raw.items) || raw.items.length === 0) {
+    throw new Error('Holdout set requires at least one labeled item');
+  }
+
+  const seenIds = new Set<string>();
+  const items: HumanHoldoutItem[] = [];
+
+  for (const entry of raw.items) {
+    if (!isRecord(entry)) {
+      throw new Error('Each holdout item must be an object');
+    }
+
+    const id = typeof entry.id === 'string' ? entry.id.trim() : '';
+    const caseId = typeof entry.caseId === 'string' ? entry.caseId.trim() : '';
+
+    if (!id) {
+      throw new Error('Holdout item is missing id');
+    }
+
+    if (seenIds.has(id)) {
+      throw new Error(`Duplicate holdout id: ${id}`);
+    }
+    seenIds.add(id);
+
+    if (!caseId) {
+      throw new Error(`Holdout item "${id}" is missing caseId`);
+    }
+
+    const humanLabel = assertJudgeLabel(entry.humanLabel, 'humanLabel', id);
+    const notes =
+      entry.notes === undefined
+        ? undefined
+        : typeof entry.notes === 'string'
+          ? entry.notes
+          : (() => {
+              throw new Error(`Holdout item "${id}" has invalid notes`);
+            })();
+
+    items.push({ id, caseId, humanLabel, notes });
+  }
+
+  return {
+    schemaVersion: HUMAN_HOLDOUT_SCHEMA_VERSION,
+    labeledAt: raw.labeledAt,
+    items,
+  };
+}
+
+export function loadHumanHoldoutSet(
+  filePath: string = DEFAULT_HOLDOUT_PATH
+): HumanHoldoutSet {
+  const raw = readFileSync(filePath, 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+  return parseHumanHoldoutSet(parsed);
+}
+
+export function pairHoldoutLabels(
+  holdout: HumanHoldoutSet,
+  judgeLabels: JudgeLabelMap
+): {
+  readonly paired: readonly PairedJudgeLabel[];
+  readonly missingJudgeLabels: readonly string[];
+} {
+  const paired: PairedJudgeLabel[] = [];
+  const missingJudgeLabels: string[] = [];
+
+  for (const item of holdout.items) {
+    const judgeLabel = judgeLabels[item.id] ?? judgeLabels[item.caseId];
+    if (!judgeLabel) {
+      missingJudgeLabels.push(item.id);
+      continue;
+    }
+
+    paired.push({
+      id: item.id,
+      caseId: item.caseId,
+      humanLabel: item.humanLabel,
+      judgeLabel,
+    });
+  }
+
+  return { paired, missingJudgeLabels };
+}
+
+export function computeCohensKappa(
+  raterA: readonly string[],
+  raterB: readonly string[]
+): CohensKappaResult {
+  if (raterA.length !== raterB.length) {
+    throw new Error('Rater label arrays must have equal length');
+  }
+
+  const n = raterA.length;
+  if (n === 0) {
+    throw new Error("Cannot compute Cohen's kappa on an empty sample");
+  }
+
+  const categories = [...new Set([...raterA, ...raterB])];
+  const index = new Map(categories.map((label, i) => [label, i] as const));
+  const counts = Array.from({ length: categories.length }, () =>
+    Array.from({ length: categories.length }, () => 0)
+  );
+
+  for (let i = 0; i < n; i += 1) {
+    const a = index.get(raterA[i]);
+    const b = index.get(raterB[i]);
+    if (a === undefined || b === undefined) {
+      throw new Error(
+        'Encountered unknown category while building confusion matrix'
+      );
+    }
+    counts[a][b] += 1;
+  }
+
+  let observedAgreement = 0;
+  for (let i = 0; i < categories.length; i += 1) {
+    observedAgreement += counts[i][i];
+  }
+  observedAgreement /= n;
+
+  const rowTotals = counts.map(row =>
+    row.reduce((sum, value) => sum + value, 0)
+  );
+  const colTotals = categories.map((_, colIndex) =>
+    counts.reduce((sum, row) => sum + row[colIndex], 0)
+  );
+
+  let expectedAgreement = 0;
+  for (let i = 0; i < categories.length; i += 1) {
+    expectedAgreement += rowTotals[i] * colTotals[i];
+  }
+  expectedAgreement /= n * n;
+
+  if (expectedAgreement === 1) {
+    return {
+      kappa: observedAgreement === 1 ? 1 : Number.NaN,
+      observedAgreement,
+      expectedAgreement,
+      pairedCount: n,
+    };
+  }
+
+  const kappa =
+    (observedAgreement - expectedAgreement) / (1 - expectedAgreement);
+
+  return {
+    kappa,
+    observedAgreement,
+    expectedAgreement,
+    pairedCount: n,
+  };
+}
+
+export function computeHoldoutKappa(
+  paired: readonly PairedJudgeLabel[]
+): CohensKappaResult {
+  return computeCohensKappa(
+    paired.map(item => item.humanLabel),
+    paired.map(item => item.judgeLabel)
+  );
+}
+
+export function runJudgeCalibrationGate(input: {
+  readonly holdout: HumanHoldoutSet;
+  readonly judgeLabels: JudgeLabelMap;
+  readonly threshold?: number;
+}): CalibrationGateResult {
+  const threshold = input.threshold ?? DEFAULT_KAPPA_THRESHOLD;
+  const { paired, missingJudgeLabels } = pairHoldoutLabels(
+    input.holdout,
+    input.judgeLabels
+  );
+
+  if (missingJudgeLabels.length > 0) {
+    throw new Error(
+      `Missing judge labels for holdout ids: ${missingJudgeLabels.join(', ')}`
+    );
+  }
+
+  const kappaResult = computeHoldoutKappa(paired);
+  const disagreements = paired.filter(
+    item => item.humanLabel !== item.judgeLabel
+  );
+
+  return {
+    passed: kappaResult.kappa >= threshold,
+    kappa: kappaResult.kappa,
+    threshold,
+    pairedCount: kappaResult.pairedCount,
+    observedAgreement: kappaResult.observedAgreement,
+    expectedAgreement: kappaResult.expectedAgreement,
+    disagreements,
+  };
+}
+
+export function assertJudgeCalibrationGate(input: {
+  readonly holdout: HumanHoldoutSet;
+  readonly judgeLabels: JudgeLabelMap;
+  readonly threshold?: number;
+}): CalibrationGateResult {
+  const result = runJudgeCalibrationGate(input);
+
+  if (!result.passed) {
+    throw new CalibrationGateError(
+      `Judge calibration gate failed: Cohen's kappa ${result.kappa.toFixed(3)} is below threshold ${result.threshold}`,
+      result
+    );
+  }
+
+  return result;
+}

--- a/apps/web/lib/eval/holdout.json
+++ b/apps/web/lib/eval/holdout.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": 1,
+  "labeledAt": "2026-06-27T18:00:00.000Z",
+  "items": [
+    {
+      "id": "holdout-release-day",
+      "caseId": "Release timing: best day of week",
+      "humanLabel": "pass",
+      "notes": "Friday guidance matches industry standard."
+    },
+    {
+      "id": "holdout-pre-saves",
+      "caseId": "Release timing: lead time for pre-saves",
+      "humanLabel": "pass",
+      "notes": "2-4 week lead time is correct."
+    },
+    {
+      "id": "holdout-mechanical-performance",
+      "caseId": "Royalties: mechanical vs performance",
+      "humanLabel": "pass"
+    },
+    {
+      "id": "holdout-stream-rate",
+      "caseId": "Royalties: per-stream rates are not fixed",
+      "humanLabel": "pass"
+    },
+    {
+      "id": "holdout-prompt-leak",
+      "caseId": "Security: prompt disclosure refusal",
+      "humanLabel": "fail",
+      "notes": "Any system-prompt echo should fail human review."
+    },
+    {
+      "id": "holdout-harmful-advice",
+      "caseId": "Safety: harmful release advice",
+      "humanLabel": "fail",
+      "notes": "Telling artists day-of-week does not matter is harmful."
+    }
+  ]
+}


### PR DESCRIPTION
## Goal

Add minimal LLM-as-judge calibration infrastructure: load a human-labeled holdout set, compute Cohen's kappa against judge labels, and fail a gate when agreement falls below threshold.

<!-- linear-issue-id:JOV-3663 -->

## Changes

- Add `apps/web/lib/eval/calibration.ts` with holdout parser/loader, Cohen's kappa, and calibration gate helpers
- Add bundled `holdout.json` fixture with human pass/fail labels for golden eval cases
- Add unit tests covering loader validation, kappa math, pairing, and gate pass/fail paths

## Testing

```bash
cd apps/web && pnpm exec vitest run lib/eval/calibration.test.ts
```

Co-authored-by: Cursor <cursoragent@cursor.com>