### PR TITLE
fix(sidebar): remove duplicate Settings and chat controls (JOV-3653)

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -41,7 +41,6 @@ import {
   newThreadNavItem,
   primaryNavigation,
   releasesNavItem,
-  settingsNavItem,
   touringNavItem,
   userSettingsNavigation,
 } from './config';
@@ -60,12 +59,6 @@ const searchNavItem: NavItem = {
 type DashboardNavSection = {
   readonly key: string;
   readonly label?: string;
-  readonly items: NavItem[];
-};
-
-type MoreNavSection = {
-  readonly key: 'more';
-  readonly label: string;
   readonly items: NavItem[];
 };
 
@@ -233,14 +226,10 @@ export function DashboardNav(_: DashboardNavProps) {
   // In the chat shell the artist row itself shows the display name, so keep the
   // section label generic to avoid duplicate "Tim White" buttons in the sidebar.
   const artistSettingsLabel =
-    shellChatV1Enabled && !isInSettings ? 'Artist' : artistName || 'Artist';
-  const moreLabel = 'More';
+    shellChatV1Enabled || isInSettings ? 'Artist' : artistName || 'Artist';
 
   // Memoize nav sections for dashboard (non-settings) mode
-  const { moreSection, navSections } = useMemo<{
-    readonly moreSection: MoreNavSection | null;
-    readonly navSections: DashboardNavSection[];
-  }>(() => {
+  const navSections = useMemo<readonly DashboardNavSection[]>(() => {
     const decorateItem = (item: NavItem): NavItem => {
       if (item.id === 'tasks') {
         return {
@@ -273,51 +262,40 @@ export function DashboardNav(_: DashboardNavProps) {
     const tasksItem = primaryNavigation.find(item => item.id === 'tasks');
 
     if (shellChatV1Enabled) {
-      return {
-        moreSection: {
-          key: 'more',
-          label: moreLabel,
-          items: [settingsNavItem].map(decorateItem),
+      return [
+        {
+          key: 'top',
+          items: [
+            decorateItem(newThreadNavItem),
+            searchNavItem,
+            decorateItem(releasesNavItem),
+          ],
         },
-        navSections: [
-          {
-            key: 'top',
-            items: [
-              decorateItem(newThreadNavItem),
-              searchNavItem,
-              decorateItem(releasesNavItem),
-            ],
-          },
-          {
-            key: 'artist',
-            label: artistSettingsLabel,
-            items: [
-              decorateItem(artistProfileNavItem),
-              decorateItem(touringNavItem),
-              ...(audienceItem ? [decorateItem(audienceItem)] : []),
-              ...(tasksItem ? [decorateItem(tasksItem)] : []),
-            ],
-          },
-        ],
-      };
+        {
+          key: 'artist',
+          label: artistSettingsLabel,
+          items: [
+            decorateItem(artistProfileNavItem),
+            decorateItem(touringNavItem),
+            ...(audienceItem ? [decorateItem(audienceItem)] : []),
+            ...(tasksItem ? [decorateItem(tasksItem)] : []),
+          ],
+        },
+      ];
     }
 
-    return {
-      moreSection: null,
-      navSections: [
-        {
-          key: 'primary',
-          items: primaryNavigation.map(decorateItem),
-        },
-      ],
-    };
+    return [
+      {
+        key: 'primary',
+        items: primaryNavigation.map(decorateItem),
+      },
+    ];
   }, [
     canAccessTasksWorkspace,
     isPlanGateLoading,
     artistName,
     artistSettingsLabel,
     isInSettings,
-    moreLabel,
     shellChatV1Enabled,
     taskStats,
     tasksSeenAt,
@@ -581,7 +559,7 @@ export function DashboardNav(_: DashboardNavProps) {
         {isInSettings ? (
           <>
             <SidebarCollapsibleGroup
-              label='General'
+              label='Account'
               defaultOpen
               storageKey='settings.general'
             >
@@ -628,9 +606,6 @@ export function DashboardNav(_: DashboardNavProps) {
                 normalizeTrailingSlash(pathname) === APP_ROUTES.CHATS
               }
               onThreadContextMenu={onThreadContextMenu}
-              onNewThread={() => {
-                router.push(APP_ROUTES.CHAT);
-              }}
               state={
                 conversationsError
                   ? 'error'
@@ -642,18 +617,6 @@ export function DashboardNav(_: DashboardNavProps) {
               tight
               collapsed={false}
             />
-          </div>
-        ) : null}
-
-        {moreSection ? (
-          <div data-nav-section={moreSection.key} className='mt-3'>
-            <SidebarCollapsibleGroup
-              label={moreSection.label}
-              defaultOpen={false}
-              storageKey={moreSection.key}
-            >
-              {renderSection(moreSection.items)}
-            </SidebarCollapsibleGroup>
           </div>
         ) : null}
 
@@ -670,7 +633,7 @@ export function DashboardNav(_: DashboardNavProps) {
                   className='space-y-2'
                   data-admin-section={section.label}
                 >
-                  <p className='px-2.5 pb-0.5 text-2xs font-semibold tracking-tight text-sidebar-muted/80 group-data-[collapsible=icon]:hidden'>
+                  <p className='px-2.5 pb-0.5 text-xs font-caption tracking-normal text-sidebar-muted/90 group-data-[collapsible=icon]:hidden'>
                     {section.label}
                   </p>
                   {renderSection(section.items)}

--- a/apps/web/components/organisms/SidebarCollapsibleGroup.tsx
+++ b/apps/web/components/organisms/SidebarCollapsibleGroup.tsx
@@ -94,7 +94,7 @@ export function SidebarCollapsibleGroup({
             )}
             aria-expanded={open}
           >
-            <span className='truncate group-data-[collapsible=icon]:hidden text-3xs font-semibold uppercase tracking-[0.08em]'>
+            <span className='truncate text-xs font-caption tracking-normal text-sidebar-muted/90 group-data-[collapsible=icon]:hidden'>
               {label}
             </span>
             {GroupIcon ? (

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -174,13 +174,13 @@ function SettingsNavigation({
       className='flex flex-1 flex-col gap-4 overflow-hidden pt-1'
     >
       <div>
-        <span className='mb-1.5 block px-2.5 text-2xs uppercase tracking-[0.08em] text-sidebar-muted group-data-[collapsible=icon]:hidden [font-weight:var(--font-weight-nav)]'>
+        <span className='mb-1.5 block px-2.5 text-xs font-caption tracking-normal text-sidebar-muted/90 group-data-[collapsible=icon]:hidden'>
           Account
         </span>
         <SettingsNavGroup items={userItems} pathname={pathname} />
       </div>
       <div>
-        <span className='mb-1.5 block px-2.5 text-2xs uppercase tracking-[0.08em] text-sidebar-muted group-data-[collapsible=icon]:hidden [font-weight:var(--font-weight-nav)]'>
+        <span className='mb-1.5 block px-2.5 text-xs font-caption tracking-normal text-sidebar-muted/90 group-data-[collapsible=icon]:hidden'>
           Artist
         </span>
         <SettingsNavGroup items={artistItems} pathname={pathname} />
@@ -353,7 +353,7 @@ function ShellSidebarInstallBanner() {
       open
       icon={RefreshCw}
       title={title}
-      description='An improved version of Jovie is available. Reload to update.'
+      description='A new version is available. Reload to update.'
       ctaLabel='Reload'
       ctaIcon={RefreshCw}
       onCta={reload}

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -324,7 +324,7 @@ export function SidebarThreadsSection({
   return (
     <div className='space-y-1.5'>
       <div className='flex items-center justify-between border-t border-[color-mix(in_oklab,var(--linear-app-frame-seam)_44%,transparent)] px-2.5 pb-0.5 pt-2'>
-        <span className='text-3xs font-semibold uppercase tracking-[0.08em] text-quaternary-token'>
+        <span className='text-xs font-caption tracking-normal text-sidebar-muted/90'>
           Chats
         </span>
         {unreadCount > 0 && (

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -201,7 +201,7 @@ describe('DashboardNav interactions', () => {
     expect(screen.getByLabelText('Command palette search')).toBeInTheDocument();
   });
 
-  it('groups the Design V1 shell into top nav, artist group, and More sections', () => {
+  it('groups the Design V1 shell into top nav and artist sections without duplicate Settings', () => {
     const { container } = renderDashboardNav({
       renderFn: render,
       appFlags: { DESIGN_V1: true },
@@ -220,7 +220,8 @@ describe('DashboardNav interactions', () => {
     expect(screen.queryByRole('button', { name: 'Work' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Catalog' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Growth' })).toBeNull();
-    expect(screen.getByRole('button', { name: 'More' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'More' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Settings' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Releases' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Artist' })).toHaveAttribute(
@@ -243,9 +244,7 @@ describe('DashboardNav interactions', () => {
       'href',
       APP_ROUTES.AUDIENCE
     );
-    expect(
-      container.querySelector('[data-nav-section="more"]')
-    ).toBeInTheDocument();
+    expect(container.querySelector('[data-nav-section="more"]')).toBeNull();
   });
 
   it('renders recent chats in the Design V1 sidebar as App Router links', () => {
@@ -315,9 +314,7 @@ describe('DashboardNav interactions', () => {
     });
 
     expect(screen.getAllByRole('link', { name: 'New Chat' })).toHaveLength(1);
-    expect(
-      screen.getByRole('button', { name: 'New Chat' })
-    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'New Chat' })).toBeNull();
   });
 
   it('navigates to chat and opens the profile rail from artist name off chat routes', async () => {

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -229,7 +229,7 @@ describe('DashboardNav', () => {
     });
   });
 
-  it('renders the grouped top nav, artist group, and More section', () => {
+  it('renders the grouped top nav and artist group without a duplicate Settings row', () => {
     const { getByRole, queryByRole } = renderDashboardNav({
       renderFn: fastRender,
       appFlags: { DESIGN_V1: true },
@@ -252,10 +252,8 @@ describe('DashboardNav', () => {
       'aria-expanded',
       'true'
     );
-    expect(getByRole('button', { name: 'More' })).toHaveAttribute(
-      'aria-expanded',
-      'false'
-    );
+    expect(queryByRole('button', { name: 'More' })).toBeNull();
+    expect(queryByRole('link', { name: 'Settings' })).toBeNull();
     expect(queryByRole('button', { name: 'Work' })).toBeNull();
     expect(queryByRole('button', { name: 'Catalog' })).toBeNull();
     expect(queryByRole('button', { name: 'Growth' })).toBeNull();
@@ -278,7 +276,7 @@ describe('DashboardNav', () => {
     );
   });
 
-  it('defaults More and Admin groups collapsed', () => {
+  it('defaults the Admin group collapsed', () => {
     const { getByRole } = renderDashboardNav({
       renderFn: fastRender,
       overrides: {
@@ -292,34 +290,9 @@ describe('DashboardNav', () => {
       },
     });
 
-    expect(getByRole('button', { name: 'More' })).toHaveAttribute(
-      'aria-expanded',
-      'false'
-    );
     expect(getByRole('button', { name: 'Admin' })).toHaveAttribute(
       'aria-expanded',
       'false'
-    );
-  });
-
-  it('remembers an expanded More group', () => {
-    localStorage.setItem('jovie:sidebar-section:more', 'open');
-
-    const { getByRole } = renderDashboardNav({
-      renderFn: fastRender,
-      overrides: {
-        selectedProfile: {
-          id: 'profile_123',
-          displayName: 'Tim White',
-          username: 'tim',
-          usernameNormalized: 'tim',
-        } as DashboardData['selectedProfile'],
-      },
-    });
-
-    expect(getByRole('button', { name: 'More' })).toHaveAttribute(
-      'aria-expanded',
-      'true'
     );
   });
 
@@ -346,7 +319,7 @@ describe('DashboardNav', () => {
     );
   });
 
-  it('renders settings groups with the selected artist name', () => {
+  it('renders settings groups with canonical Account and Artist labels', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.SETTINGS_ACCOUNT);
 
     const { getAllByText, getByRole, queryByText } = renderDashboardNav({
@@ -361,8 +334,8 @@ describe('DashboardNav', () => {
       },
     });
 
-    expect(getAllByText('General').length).toBeGreaterThan(0);
-    expect(getAllByText('Tim White').length).toBeGreaterThan(0);
+    expect(getAllByText('Account').length).toBeGreaterThan(0);
+    expect(getAllByText('Artist').length).toBeGreaterThan(0);
     expect(
       getByRole('link', { name: 'Audience & Tracking' }).getAttribute('href')
     ).toBe(APP_ROUTES.SETTINGS_AUDIENCE);


### PR DESCRIPTION
## Goal

Fix dashboard sidebar UI regressions tracked in JOV-3653: duplicate Settings entry, duplicate New Chat control, double active states, and inconsistent section labels.

<!-- linear-issue-id:JOV-3653 -->

## Changes

- Remove the redundant **More → Settings** nav row; the bottom Settings button remains the single canonical entry
- Remove the empty-state **New Chat** button from the threads section (top nav already provides it)
- Normalize section labels to **Account** / **Artist** / **Chats** with shell typography (no uppercase eyebrows)
- Align collapsible group, threads header, and settings sidebar labels to the same token contract

## Testing

- `pnpm exec vitest run tests/unit/dashboard/DashboardNav.test.tsx tests/components/dashboard/DashboardNav.interaction.test.tsx tests/unit/sidebar-row-alignment.test.tsx`
- `pnpm --filter @jovie/web run typecheck`
- `pnpm --filter @jovie/web run lint`

Co-authored-by: Cursor <cursoragent@cursor.com>