### PR TITLE
fix(sentry): suppress transient Degraded HTTP Operation alerts (JOV-3666)

### DIFF
--- a/apps/web/app/api/webhooks/sentry/route.ts
+++ b/apps/web/app/api/webhooks/sentry/route.ts
@@ -17,6 +17,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { env } from '@/lib/env';
 import { captureCriticalError } from '@/lib/error-tracking';
 import { ServerFetchTimeoutError, serverFetch } from '@/lib/http/server-fetch';
+import { isTransientInfraHttpIssue } from '@/lib/sentry/non-actionable-issues';
 import { logger } from '@/lib/utils/logger';
 import {
   acquireRecentDispatch,
@@ -147,6 +148,17 @@ export async function POST(request: NextRequest) {
     const culprit = issue.culprit || '';
     const message = issue.metadata?.value || issue.message || '';
     const url = issue.permalink || `https://sentry.io/issues/${issueId}/`;
+
+    if (isTransientInfraHttpIssue({ title, culprit })) {
+      logger.info(
+        '[Sentry Webhook] Skipping autofix for transient infra HTTP issue',
+        { issueId, title, culprit }
+      );
+      return NextResponse.json(
+        { received: true, skipped: true, reason: 'transient-infra-http' },
+        { headers: NO_STORE_HEADERS }
+      );
+    }
 
     // Extract stack trace from first exception if available
     const frames: SentryFrame[] | undefined =

--- a/apps/web/lib/sentry/non-actionable-issues.ts
+++ b/apps/web/lib/sentry/non-actionable-issues.ts
@@ -1,0 +1,51 @@
+/**
+ * Filters for Sentry issues that are known transient infra noise.
+ *
+ * "Degraded HTTP Operation" (ai_detected_http) on POST /pipeline is a recurring
+ * single-event blip from Upstash Redis REST pipeline latency during cold starts.
+ * It is not an application defect and should not trigger autofix or performance alerts.
+ */
+
+export interface SentryIssueSummary {
+  title?: string | null;
+  culprit?: string | null;
+}
+
+/** Transaction names excluded from performance tracing (0% sample rate). */
+export const TRANSIENT_INFRA_HTTP_TRANSACTIONS = [
+  'POST /pipeline', // Upstash Redis REST pipeline
+] as const;
+
+const DEGRADED_HTTP_OPERATION_TITLE = 'degraded http operation';
+
+function normalize(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+/**
+ * Returns true when a Sentry issue is a known transient infra latency blip.
+ */
+export function isTransientInfraHttpIssue(issue: SentryIssueSummary): boolean {
+  const title = normalize(issue.title);
+  const culprit = normalize(issue.culprit);
+
+  if (title !== DEGRADED_HTTP_OPERATION_TITLE) {
+    return false;
+  }
+
+  return TRANSIENT_INFRA_HTTP_TRANSACTIONS.some(
+    transaction => culprit === transaction.toLowerCase()
+  );
+}
+
+/**
+ * Returns true when a performance transaction should be excluded from tracing.
+ */
+export function isTransientInfraHttpTransaction(
+  transactionName: string | null | undefined
+): boolean {
+  const normalized = normalize(transactionName);
+  return TRANSIENT_INFRA_HTTP_TRANSACTIONS.some(
+    transaction => normalized === transaction.toLowerCase()
+  );
+}

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -9,11 +9,20 @@ import {
   getBaseServerConfig,
   isNonProductionServerNoise,
 } from '@/lib/sentry/config';
+import { isTransientInfraHttpTransaction } from '@/lib/sentry/non-actionable-issues';
 
 const baseConfig = getBaseServerConfig();
 
 Sentry.init({
   ...baseConfig,
+
+  tracesSampler: samplingContext => {
+    const name = samplingContext.name ?? '';
+    if (isTransientInfraHttpTransaction(name)) {
+      return 0;
+    }
+    return baseConfig.tracesSampleRate;
+  },
 
   beforeSend: createBeforeSendHook(event => {
     if (isNonProductionServerNoise(event)) {

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -8,6 +8,7 @@ import {
   getBaseServerConfig,
   isNonProductionServerNoise,
 } from '@/lib/sentry/config';
+import { isTransientInfraHttpTransaction } from '@/lib/sentry/non-actionable-issues';
 
 const baseConfig = getBaseServerConfig();
 
@@ -31,6 +32,11 @@ Sentry.init({
   tracesSampler: (samplingContext: SamplingContext) => {
     const name = samplingContext.name ?? '';
     if (HEALTH_ENDPOINT_PATTERN.test(name)) {
+      return 0;
+    }
+    // Upstash Redis pipeline latency blips during cold starts are transient infra
+    // noise (JOV-3666) — exclude from performance traces to avoid ai_detected_http alerts.
+    if (isTransientInfraHttpTransaction(name)) {
       return 0;
     }
     return baseConfig.tracesSampleRate;

--- a/apps/web/tests/unit/api/webhooks/sentry.test.ts
+++ b/apps/web/tests/unit/api/webhooks/sentry.test.ts
@@ -53,6 +53,51 @@ describe('POST /api/webhooks/sentry', () => {
     vi.resetModules();
   });
 
+  it('skips autofix for transient Degraded HTTP Operation on POST /pipeline', async () => {
+    mockAcquireRecentDispatch.mockResolvedValue({
+      acquired: true,
+      reason: 'acquired',
+    });
+
+    const { POST } = await import('@/app/api/webhooks/sentry/route');
+    const payload = {
+      data: {
+        issue: {
+          id: '3666',
+          title: 'Degraded HTTP Operation',
+          culprit: 'POST /pipeline',
+        },
+      },
+    };
+    const body = JSON.stringify(payload);
+    const request = new Request('https://example.com/api/webhooks/sentry', {
+      method: 'POST',
+      headers: {
+        'sentry-hook-signature': sign(body),
+      },
+      body,
+    });
+
+    const response = await POST(request as never);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      received: true,
+      skipped: true,
+      reason: 'transient-infra-http',
+    });
+    expect(mockServerFetch).not.toHaveBeenCalled();
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      '[Sentry Webhook] Skipping autofix for transient infra HTTP issue',
+      expect.objectContaining({
+        issueId: '3666',
+        title: 'Degraded HTTP Operation',
+        culprit: 'POST /pipeline',
+      })
+    );
+  });
+
   it('returns deduplicated response when a recent dispatch exists', async () => {
     mockAcquireRecentDispatch.mockResolvedValue({
       acquired: false,

--- a/apps/web/tests/unit/lib/sentry/non-actionable-issues.test.ts
+++ b/apps/web/tests/unit/lib/sentry/non-actionable-issues.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isTransientInfraHttpIssue,
+  isTransientInfraHttpTransaction,
+} from '@/lib/sentry/non-actionable-issues';
+
+describe('non-actionable Sentry issues', () => {
+  describe('isTransientInfraHttpIssue', () => {
+    it('matches Degraded HTTP Operation on POST /pipeline', () => {
+      expect(
+        isTransientInfraHttpIssue({
+          title: 'Degraded HTTP Operation',
+          culprit: 'POST /pipeline',
+        })
+      ).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+      expect(
+        isTransientInfraHttpIssue({
+          title: 'degraded http operation',
+          culprit: 'post /pipeline',
+        })
+      ).toBe(true);
+    });
+
+    it('does not match other degraded HTTP culprits', () => {
+      expect(
+        isTransientInfraHttpIssue({
+          title: 'Degraded HTTP Operation',
+          culprit: 'GET /api/health',
+        })
+      ).toBe(false);
+    });
+
+    it('does not match unrelated Sentry issues', () => {
+      expect(
+        isTransientInfraHttpIssue({
+          title: 'TypeError: Cannot read properties of undefined',
+          culprit: 'POST /pipeline',
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('isTransientInfraHttpTransaction', () => {
+    it('matches POST /pipeline', () => {
+      expect(isTransientInfraHttpTransaction('POST /pipeline')).toBe(true);
+    });
+
+    it('does not match unrelated transactions', () => {
+      expect(isTransientInfraHttpTransaction('GET /api/health')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Suppresses recurring Sentry `ai_detected_http` alerts for **Degraded HTTP Operation** on `POST /pipeline` — a known transient Upstash Redis cold-start latency blip (1 event / 0 users), not an application defect.

## Changes

- Add `lib/sentry/non-actionable-issues.ts` to classify transient infra HTTP issues
- Exclude `POST /pipeline` from Sentry performance traces (server + edge `tracesSampler`)
- Skip Sentry autofix webhook dispatch for these non-actionable issues

## Validation

- `vitest run tests/unit/lib/sentry/` — 355 passed
- `vitest run tests/unit/api/webhooks/sentry.test.ts` — 5 passed
- Pre-push: biome, typecheck, lint all green

## Rollback

Revert this PR; no schema/migration/infra changes.

## Related

- Linear: https://linear.app/jovie/issue/JOV-3666/degraded-http-operation
- Related infra tracking: JOV-2497 (Neon pooler latency)

<!-- linear-issue-id:JOV-3666 -->