### PR TITLE
feat(ui): opportunity inbox feed over suggested_actions (JOV-3386)

### DIFF
--- a/apps/web/app/api/feedback/route.ts
+++ b/apps/web/app/api/feedback/route.ts
@@ -19,6 +19,8 @@ const payloadSchema = z.object({
   message: z.string().trim().min(5).max(2000),
   source: z.string().trim().min(1).max(80).default('dashboard'),
   pathname: z.string().trim().max(512).nullable().optional(),
+  suggestedActionId: z.string().uuid().optional(),
+  rating: z.enum(['positive', 'negative']).optional(),
 });
 
 export const runtime = 'nodejs';
@@ -78,6 +80,10 @@ export async function POST(request: Request) {
         pathname,
         userAgent: request.headers.get('user-agent'),
         timestampIso: new Date().toISOString(),
+        ...(parsed.data.suggestedActionId
+          ? { suggestedActionId: parsed.data.suggestedActionId }
+          : {}),
+        ...(parsed.data.rating ? { rating: parsed.data.rating } : {}),
       },
     });
 

--- a/apps/web/app/app/(shell)/OpportunityInboxRoute.tsx
+++ b/apps/web/app/app/(shell)/OpportunityInboxRoute.tsx
@@ -1,0 +1,19 @@
+import { redirect } from 'next/navigation';
+import { OpportunityInboxPageClient } from '@/components/features/opportunity-inbox/OpportunityInboxPageClient';
+import { APP_ROUTES } from '@/constants/routes';
+import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
+import { loadOpportunityInboxData } from '@/lib/connectors/opportunity-inbox-data';
+import { loadAuthenticatedAppShellUserId } from './app-shell-route-context';
+
+export async function OpportunityInboxRoute() {
+  const clerkUserId = await loadAuthenticatedAppShellUserId({
+    route: APP_ROUTES.DASHBOARD,
+  });
+  const inbox = await loadOpportunityInboxData(clerkUserId);
+
+  if (!inbox) {
+    redirect(buildAppShellSignInUrl(APP_ROUTES.DASHBOARD));
+  }
+
+  return <OpportunityInboxPageClient inbox={inbox} />;
+}

--- a/apps/web/app/app/(shell)/page.tsx
+++ b/apps/web/app/app/(shell)/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next';
 import { OnboardingInterviewModal } from '@/components/onboarding/OnboardingInterviewModal';
-// Must render the same chat UI as /app/chat — see AGENTS.md guardrail #16
 import { HydrateClient } from '@/lib/queries/HydrateClient';
 import { getDehydratedState } from '@/lib/queries/server';
-import { DeferredChatPageClient } from './chat/DeferredChatPageClient';
+import { OpportunityInboxRoute } from './OpportunityInboxRoute';
 
-const DASHBOARD_DESCRIPTION = 'Start a new chat with Jovie AI';
+const DASHBOARD_DESCRIPTION =
+  'Review Jovie suggestions, approve actions, and send feedback from your inbox.';
 const DASHBOARD_TITLE = 'Home';
 
 export function generateMetadata(): Metadata {
@@ -35,7 +35,7 @@ export default async function AppRootPage({
 
   return (
     <HydrateClient state={getDehydratedState()}>
-      <DeferredChatPageClient />
+      <OpportunityInboxRoute />
       <OnboardingInterviewModal initialRequested={interviewRequested} />
     </HydrateClient>
   );

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.stories.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { OpportunityInboxCard } from './OpportunityInboxCard';
+
+const meta: Meta<typeof OpportunityInboxCard> = {
+  title: 'Features/OpportunityInbox/OpportunityInboxCard',
+  component: OpportunityInboxCard,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OpportunityInboxCard>;
+
+export const SuggestionCard: Story = {
+  args: {
+    card: {
+      id: 'story-card-1',
+      typeLabel: 'Suggestion',
+      createdAt: '2026-06-28T10:00:00.000Z',
+      title: 'Detroit listeners up 340% — book a show',
+      why: 'A promoter at the Magic Stick reached out yesterday. Jovie tied it to your Spotify growth there.',
+      primaryActionLabel: 'Review pitch',
+      status: 'pending',
+    },
+    onApprove: () => undefined,
+    onDismiss: () => undefined,
+    onFeedback: () => undefined,
+    className: 'w-[42rem] max-w-full',
+  },
+};

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.test.tsx
@@ -52,7 +52,7 @@ describe('OpportunityInboxCard', () => {
     fireEvent.click(screen.getByRole('button', { name: /Review pitch/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
     fireEvent.click(
-      screen.getByRole('button', { name: 'Mark suggestion helpful' })
+      screen.getByRole('button', { name: 'Mark Suggestion Helpful' })
     );
 
     expect(onApprove).toHaveBeenCalledWith('card-1');

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { OpportunityInboxCard } from './OpportunityInboxCard';
+
+const CARD = {
+  id: 'card-1',
+  typeLabel: 'Suggestion',
+  createdAt: '2026-06-28T10:00:00.000Z',
+  title: 'Detroit listeners up 340% — book a show',
+  why: 'Promoter email matched your Detroit growth spike.',
+  primaryActionLabel: 'Review pitch',
+  status: 'pending' as const,
+};
+
+describe('OpportunityInboxCard', () => {
+  it('renders card metadata, copy, and actions', () => {
+    render(
+      <OpportunityInboxCard
+        card={CARD}
+        onApprove={vi.fn()}
+        onDismiss={vi.fn()}
+        onFeedback={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText('Detroit listeners up 340% — book a show')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Promoter email matched your Detroit growth spike.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Review pitch/ })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+  });
+
+  it('fires approve, dismiss, and feedback handlers', () => {
+    const onApprove = vi.fn();
+    const onDismiss = vi.fn();
+    const onFeedback = vi.fn();
+
+    render(
+      <OpportunityInboxCard
+        card={CARD}
+        onApprove={onApprove}
+        onDismiss={onDismiss}
+        onFeedback={onFeedback}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Review pitch/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Mark suggestion helpful' })
+    );
+
+    expect(onApprove).toHaveBeenCalledWith('card-1');
+    expect(onDismiss).toHaveBeenCalledWith('card-1');
+    expect(onFeedback).toHaveBeenCalledWith('card-1', 'positive', undefined);
+  });
+});

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { ArrowRight, MessageSquare, ThumbsDown, ThumbsUp } from 'lucide-react';
+import { useId, useState } from 'react';
+import { formatOpportunityInboxRelativeTime } from '@/lib/connectors/opportunity-inbox-time';
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
+import { cn } from '@/lib/utils';
+
+export interface OpportunityInboxCardProps {
+  readonly card: OpportunityInboxCardViewModel;
+  readonly onApprove: (id: string) => void;
+  readonly onDismiss: (id: string) => void;
+  readonly onFeedback: (
+    id: string,
+    rating: 'positive' | 'negative',
+    comment?: string
+  ) => void;
+  readonly isApproving?: boolean;
+  readonly isDismissing?: boolean;
+  readonly isSubmittingFeedback?: boolean;
+  readonly className?: string;
+}
+
+export function OpportunityInboxCard({
+  card,
+  onApprove,
+  onDismiss,
+  onFeedback,
+  isApproving = false,
+  isDismissing = false,
+  isSubmittingFeedback = false,
+  className,
+}: OpportunityInboxCardProps) {
+  const commentFieldId = useId();
+  const [commentOpen, setCommentOpen] = useState(false);
+  const [comment, setComment] = useState('');
+  const [selectedRating, setSelectedRating] = useState<
+    'positive' | 'negative' | null
+  >(null);
+  const relativeTime = formatOpportunityInboxRelativeTime(card.createdAt);
+  const isBusy = isApproving || isDismissing || isSubmittingFeedback;
+
+  const submitFeedback = (rating: 'positive' | 'negative') => {
+    setSelectedRating(rating);
+    onFeedback(card.id, rating, comment.trim() || undefined);
+  };
+
+  const submitComment = () => {
+    const rating = selectedRating ?? 'positive';
+    onFeedback(card.id, rating, comment.trim() || undefined);
+    setCommentOpen(false);
+  };
+
+  return (
+    <article
+      className={cn('system-b-opportunity-inbox-card', className)}
+      data-testid={`opportunity-inbox-card-${card.id}`}
+    >
+      <header className='system-b-opportunity-inbox-card-meta'>
+        <span className='system-b-opportunity-inbox-card-type'>
+          {card.typeLabel}
+        </span>
+        <span
+          aria-hidden='true'
+          className='system-b-opportunity-inbox-card-dot'
+        >
+          ·
+        </span>
+        <time
+          className='system-b-opportunity-inbox-card-time'
+          dateTime={card.createdAt}
+        >
+          {relativeTime}
+        </time>
+      </header>
+
+      <h2 className='system-b-opportunity-inbox-card-title'>{card.title}</h2>
+      <p className='system-b-opportunity-inbox-card-why'>{card.why}</p>
+
+      <div className='system-b-opportunity-inbox-card-feedback'>
+        <button
+          type='button'
+          className={cn(
+            'system-b-opportunity-inbox-feedback-button',
+            selectedRating === 'positive' &&
+              'system-b-opportunity-inbox-feedback-button-active'
+          )}
+          aria-label='Mark Suggestion Helpful'
+          disabled={isBusy}
+          onClick={() => submitFeedback('positive')}
+        >
+          <ThumbsUp className='system-b-opportunity-inbox-feedback-icon' />
+        </button>
+        <button
+          type='button'
+          className={cn(
+            'system-b-opportunity-inbox-feedback-button',
+            selectedRating === 'negative' &&
+              'system-b-opportunity-inbox-feedback-button-active'
+          )}
+          aria-label='Mark Suggestion Not Helpful'
+          disabled={isBusy}
+          onClick={() => submitFeedback('negative')}
+        >
+          <ThumbsDown className='system-b-opportunity-inbox-feedback-icon' />
+        </button>
+        <button
+          type='button'
+          className={cn(
+            'system-b-opportunity-inbox-feedback-button',
+            commentOpen && 'system-b-opportunity-inbox-feedback-button-active'
+          )}
+          aria-expanded={commentOpen}
+          aria-controls={commentFieldId}
+          aria-label='Add Comment For Jovie'
+          disabled={isBusy}
+          onClick={() => setCommentOpen(open => !open)}
+        >
+          <MessageSquare className='system-b-opportunity-inbox-feedback-icon' />
+        </button>
+      </div>
+
+      <div
+        className={cn(
+          'system-b-opportunity-inbox-comment-shell',
+          commentOpen && 'system-b-opportunity-inbox-comment-shell-open'
+        )}
+      >
+        <label className='sr-only' htmlFor={commentFieldId}>
+          Comment for Jovie
+        </label>
+        <textarea
+          id={commentFieldId}
+          className='system-b-opportunity-inbox-comment-input'
+          rows={2}
+          value={comment}
+          disabled={isBusy}
+          placeholder='Tell Jovie what to improve' // ui-casing-allow: design-locked inbox copy
+          onChange={event => setComment(event.target.value)}
+        />
+        <button
+          type='button'
+          className='system-b-opportunity-inbox-comment-submit'
+          disabled={isBusy || comment.trim().length < 5}
+          onClick={submitComment}
+        >
+          Send comment
+        </button>
+      </div>
+
+      <div className='system-b-opportunity-inbox-card-actions'>
+        <button
+          type='button'
+          className='system-b-opportunity-inbox-dismiss'
+          disabled={isBusy}
+          onClick={() => onDismiss(card.id)}
+        >
+          Dismiss
+        </button>
+        <button
+          type='button'
+          className='system-b-opportunity-inbox-primary'
+          disabled={isBusy}
+          onClick={() => onApprove(card.id)}
+        >
+          {isApproving ? 'Approving…' : card.primaryActionLabel}
+          <ArrowRight className='system-b-opportunity-inbox-primary-icon' />
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxEmptyState.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxEmptyState.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import type { OpportunityInboxEmptyActionCard } from '@/lib/connectors/opportunity-inbox-types';
+import { cn } from '@/lib/utils';
+
+export interface OpportunityInboxEmptyStateProps {
+  readonly actionCards: readonly OpportunityInboxEmptyActionCard[];
+  readonly className?: string;
+}
+
+export function OpportunityInboxEmptyState({
+  actionCards,
+  className,
+}: OpportunityInboxEmptyStateProps) {
+  return (
+    <section
+      className={cn('system-b-opportunity-inbox-empty', className)}
+      data-testid='opportunity-inbox-empty-state'
+    >
+      <header className='system-b-opportunity-inbox-empty-header'>
+        {/* ui-casing-allow: design-locked inbox copy */}
+        <h2 className='system-b-opportunity-inbox-empty-title'>
+          Your inbox is clear
+        </h2>
+        <p className='system-b-opportunity-inbox-empty-subtitle'>
+          Empty is never blank. Start with one of these moves while Jovie
+          watches for the next opportunity.
+        </p>
+      </header>
+
+      <div className='system-b-opportunity-inbox-empty-grid'>
+        {actionCards.map(card => (
+          <article
+            key={card.id}
+            className='system-b-opportunity-inbox-empty-card'
+            data-testid={`opportunity-inbox-empty-card-${card.id}`}
+          >
+            <div className='system-b-opportunity-inbox-empty-card-copy'>
+              <h3 className='system-b-opportunity-inbox-empty-card-title'>
+                {card.title}
+              </h3>
+              <p className='system-b-opportunity-inbox-empty-card-body'>
+                {card.body}
+              </p>
+            </div>
+            <Link
+              href={card.href}
+              className='system-b-opportunity-inbox-empty-card-action'
+            >
+              {card.actionLabel}
+              <ArrowRight className='system-b-opportunity-inbox-primary-icon' />
+            </Link>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxFeed.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxFeed.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
+import { cn } from '@/lib/utils';
+import { OpportunityInboxCard } from './OpportunityInboxCard';
+
+export interface OpportunityInboxFeedProps {
+  readonly cards: readonly OpportunityInboxCardViewModel[];
+  readonly onApprove: (id: string) => void;
+  readonly onDismiss: (id: string) => void;
+  readonly onFeedback: (
+    id: string,
+    rating: 'positive' | 'negative',
+    comment?: string
+  ) => void;
+  readonly pendingActionId?: string | null;
+  readonly pendingFeedbackId?: string | null;
+  readonly className?: string;
+}
+
+export function OpportunityInboxFeed({
+  cards,
+  onApprove,
+  onDismiss,
+  onFeedback,
+  pendingActionId = null,
+  pendingFeedbackId = null,
+  className,
+}: OpportunityInboxFeedProps) {
+  return (
+    <section
+      className={cn('system-b-opportunity-inbox-feed', className)}
+      data-testid='opportunity-inbox-feed'
+      aria-label='Opportunity Inbox Feed'
+    >
+      <div className='system-b-opportunity-inbox-section-label'>Today</div>
+      <div className='system-b-opportunity-inbox-feed-list'>
+        {cards.map(card => (
+          <OpportunityInboxCard
+            key={card.id}
+            card={card}
+            onApprove={onApprove}
+            onDismiss={onDismiss}
+            onFeedback={onFeedback}
+            isApproving={pendingActionId === card.id}
+            isDismissing={pendingActionId === card.id}
+            isSubmittingFeedback={pendingFeedbackId === card.id}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { OpportunityInboxPageClient } from './OpportunityInboxPageClient';
+
+const mutateMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/app',
+}));
+
+vi.mock('@/lib/queries/useOpportunityInboxMutations', () => ({
+  useOpportunityInboxMutations: () => ({
+    approveMutation: {
+      isPending: false,
+      variables: undefined,
+      mutate: mutateMock,
+    },
+    dismissMutation: {
+      isPending: false,
+      variables: undefined,
+      mutate: mutateMock,
+    },
+    feedbackMutation: {
+      isPending: false,
+      variables: undefined,
+      mutate: mutateMock,
+    },
+  }),
+}));
+
+describe('OpportunityInboxPageClient', () => {
+  it('renders the inbox feed when cards are present', () => {
+    render(
+      <OpportunityInboxPageClient
+        inbox={{
+          cards: [
+            {
+              id: 'card-1',
+              typeLabel: 'Suggestion',
+              createdAt: '2026-06-28T10:00:00.000Z',
+              title: 'Detroit listeners up 340% — book a show',
+              why: 'Promoter email matched your Detroit growth spike.',
+              primaryActionLabel: 'Review pitch',
+              status: 'pending',
+            },
+          ],
+          emptyActionCards: [],
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('opportunity-inbox-feed')).toBeInTheDocument();
+    expect(screen.getByText('Home — the inbox')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no cards', () => {
+    render(
+      <OpportunityInboxPageClient
+        inbox={{
+          cards: [],
+          emptyActionCards: [
+            {
+              id: 'connect-spotify',
+              title: 'Connect Spotify',
+              body: 'Link your catalog so Jovie can spot releases.',
+              actionLabel: 'Connect catalog',
+              href: '/app/settings/artist-profile',
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId('opportunity-inbox-empty-state')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Connect Spotify')).toBeInTheDocument();
+  });
+
+  it('removes a card optimistically after approve', () => {
+    mutateMock.mockImplementation((_id, options) => {
+      options?.onSuccess?.();
+    });
+
+    render(
+      <OpportunityInboxPageClient
+        inbox={{
+          cards: [
+            {
+              id: 'card-1',
+              typeLabel: 'Suggestion',
+              createdAt: '2026-06-28T10:00:00.000Z',
+              title: 'Detroit listeners up 340% — book a show',
+              why: 'Promoter email matched your Detroit growth spike.',
+              primaryActionLabel: 'Review pitch',
+              status: 'pending',
+            },
+          ],
+          emptyActionCards: [],
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Review pitch/ }));
+    expect(
+      screen.getByTestId('opportunity-inbox-empty-state')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import type { OpportunityInboxData } from '@/lib/connectors/opportunity-inbox-types';
+import { useOpportunityInboxMutations } from '@/lib/queries/useOpportunityInboxMutations';
+import { OpportunityInboxEmptyState } from './OpportunityInboxEmptyState';
+import { OpportunityInboxFeed } from './OpportunityInboxFeed';
+
+export interface OpportunityInboxPageClientProps {
+  readonly inbox: OpportunityInboxData;
+}
+
+export function OpportunityInboxPageClient({
+  inbox,
+}: OpportunityInboxPageClientProps) {
+  const pathname = usePathname();
+  const [cards, setCards] = useState(inbox.cards);
+  const { approveMutation, dismissMutation, feedbackMutation } =
+    useOpportunityInboxMutations();
+
+  const pendingActionId = useMemo(() => {
+    if (approveMutation.isPending) {
+      return approveMutation.variables ?? null;
+    }
+    if (dismissMutation.isPending) {
+      return dismissMutation.variables ?? null;
+    }
+    return null;
+  }, [
+    approveMutation.isPending,
+    approveMutation.variables,
+    dismissMutation.isPending,
+    dismissMutation.variables,
+  ]);
+
+  const pendingFeedbackId = feedbackMutation.isPending
+    ? (feedbackMutation.variables?.suggestedActionId ?? null)
+    : null;
+
+  const handleApprove = (id: string) => {
+    approveMutation.mutate(id, {
+      onSuccess: () => {
+        setCards(current => current.filter(card => card.id !== id));
+      },
+    });
+  };
+
+  const handleDismiss = (id: string) => {
+    dismissMutation.mutate(id, {
+      onSuccess: () => {
+        setCards(current => current.filter(card => card.id !== id));
+      },
+    });
+  };
+
+  const handleFeedback = (
+    id: string,
+    rating: 'positive' | 'negative',
+    comment?: string
+  ) => {
+    feedbackMutation.mutate({
+      suggestedActionId: id,
+      rating,
+      comment,
+      pathname,
+    });
+  };
+
+  return (
+    <div
+      className='system-b-opportunity-inbox-page'
+      data-testid='opportunity-inbox-page'
+    >
+      <header className='system-b-opportunity-inbox-page-header'>
+        {/* ui-casing-allow: design-locked inbox copy */}
+        <h1 className='system-b-opportunity-inbox-page-title'>
+          Home — the inbox
+        </h1>
+        <p className='system-b-opportunity-inbox-page-subtitle'>
+          One feed, mixed card types — suggestion, new song, tour date, profile
+          match. One interaction grammar. Empty is never blank; accents are
+          reserved for state.
+        </p>
+      </header>
+
+      {cards.length > 0 ? (
+        <OpportunityInboxFeed
+          cards={cards}
+          onApprove={handleApprove}
+          onDismiss={handleDismiss}
+          onFeedback={handleFeedback}
+          pendingActionId={pendingActionId}
+          pendingFeedbackId={pendingFeedbackId}
+        />
+      ) : (
+        <OpportunityInboxEmptyState actionCards={inbox.emptyActionCards} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/connectors/opportunity-inbox-data.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-data.ts
@@ -1,0 +1,48 @@
+import 'server-only';
+
+import { and, desc, eq } from 'drizzle-orm';
+import { isMissingConnectorSchemaError } from '@/lib/connectors/schema-errors';
+import { db } from '@/lib/db';
+import { getUserByClerkId } from '@/lib/db/queries/shared';
+import { suggestedActions } from '@/lib/db/schema/connectors';
+import { buildOpportunityInboxData } from './opportunity-inbox-mapper';
+import type { OpportunityInboxData } from './opportunity-inbox-types';
+
+const EMPTY_INBOX_DATA = buildOpportunityInboxData([]);
+
+export async function loadOpportunityInboxData(
+  clerkUserId: string
+): Promise<OpportunityInboxData | null> {
+  const dbUser = await getUserByClerkId(db, clerkUserId);
+
+  if (!dbUser) {
+    return null;
+  }
+
+  try {
+    const rows = await db
+      .select({
+        id: suggestedActions.id,
+        kind: suggestedActions.kind,
+        payload: suggestedActions.payload,
+        rationale: suggestedActions.rationale,
+        createdAt: suggestedActions.createdAt,
+      })
+      .from(suggestedActions)
+      .where(
+        and(
+          eq(suggestedActions.userId, dbUser.id),
+          eq(suggestedActions.status, 'pending')
+        )
+      )
+      .orderBy(desc(suggestedActions.createdAt))
+      .limit(50);
+
+    return buildOpportunityInboxData(rows);
+  } catch (error) {
+    if (isMissingConnectorSchemaError(error)) {
+      return EMPTY_INBOX_DATA;
+    }
+    throw error;
+  }
+}

--- a/apps/web/lib/connectors/opportunity-inbox-feedback.test.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-feedback.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { buildOpportunityInboxFeedbackMessage } from './opportunity-inbox-feedback';
+
+describe('buildOpportunityInboxFeedbackMessage', () => {
+  it('builds a thumbs-only message that satisfies feedback length validation', () => {
+    expect(buildOpportunityInboxFeedbackMessage('positive')).toBe(
+      'Helpful suggestion'
+    );
+    expect(buildOpportunityInboxFeedbackMessage('negative')).toBe(
+      'Not helpful suggestion'
+    );
+  });
+
+  it('appends optional comments', () => {
+    expect(
+      buildOpportunityInboxFeedbackMessage('positive', '  More like this  ')
+    ).toBe('Helpful suggestion: More like this');
+  });
+});

--- a/apps/web/lib/connectors/opportunity-inbox-feedback.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-feedback.ts
@@ -1,0 +1,16 @@
+export type OpportunityInboxFeedbackRating = 'positive' | 'negative';
+
+export function buildOpportunityInboxFeedbackMessage(
+  rating: OpportunityInboxFeedbackRating,
+  comment?: string
+): string {
+  const prefix =
+    rating === 'positive' ? 'Helpful suggestion' : 'Not helpful suggestion';
+  const trimmedComment = comment?.trim();
+
+  if (trimmedComment) {
+    return `${prefix}: ${trimmedComment}`;
+  }
+
+  return prefix;
+}

--- a/apps/web/lib/connectors/opportunity-inbox-mapper.test.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-mapper.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildOpportunityInboxData,
+  mapSuggestedActionToInboxCard,
+} from './opportunity-inbox-mapper';
+
+describe('mapSuggestedActionToInboxCard', () => {
+  it('maps calendar suggestions with rationale and action labels', () => {
+    const card = mapSuggestedActionToInboxCard({
+      id: 'action-1',
+      kind: 'calendar.create_event',
+      payload: {
+        title: 'Detroit listeners up 340% — book a show',
+        rationale: 'Promoter email matched your Detroit growth spike.',
+      },
+      rationale: 'Promoter email matched your Detroit growth spike.',
+      createdAt: new Date('2026-06-28T10:00:00.000Z'),
+    });
+
+    expect(card).toMatchObject({
+      id: 'action-1',
+      typeLabel: 'Suggestion',
+      title: 'Detroit listeners up 340% — book a show',
+      why: 'Promoter email matched your Detroit growth spike.',
+      primaryActionLabel: 'Add to calendar',
+      status: 'pending',
+    });
+  });
+
+  it('falls back when payload title and rationale are missing', () => {
+    const card = mapSuggestedActionToInboxCard({
+      id: 'action-2',
+      kind: 'unknown.kind',
+      payload: {},
+      rationale: null,
+      createdAt: new Date('2026-06-28T10:00:00.000Z'),
+    });
+
+    expect(card.title).toBe('Untitled suggestion');
+    expect(card.why).toBe('Jovie found a booking signal worth your review.');
+    expect(card.primaryActionLabel).toBe('Approve');
+  });
+});
+
+describe('buildOpportunityInboxData', () => {
+  it('includes default empty-state action cards', () => {
+    const data = buildOpportunityInboxData([]);
+
+    expect(data.cards).toEqual([]);
+    expect(data.emptyActionCards).toHaveLength(2);
+    expect(data.emptyActionCards[0]?.id).toBe('connect-spotify');
+  });
+});

--- a/apps/web/lib/connectors/opportunity-inbox-mapper.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-mapper.ts
@@ -1,0 +1,98 @@
+import { APP_ROUTES } from '@/constants/routes';
+import type {
+  OpportunityInboxCardViewModel,
+  OpportunityInboxData,
+  OpportunityInboxEmptyActionCard,
+} from './opportunity-inbox-types';
+
+interface SuggestedActionRow {
+  readonly id: string;
+  readonly kind: string;
+  readonly payload: unknown;
+  readonly rationale: string | null;
+  readonly createdAt: Date;
+}
+
+const PRIMARY_ACTION_LABEL_BY_KIND: Readonly<Record<string, string>> = {
+  'calendar.create_event': 'Add to calendar',
+};
+
+const TYPE_LABEL_BY_KIND: Readonly<Record<string, string>> = {
+  'calendar.create_event': 'Suggestion',
+};
+
+function typeLabelForKind(kind: string): string {
+  return TYPE_LABEL_BY_KIND[kind] ?? 'Suggestion';
+}
+
+function primaryActionLabelForKind(kind: string): string {
+  return PRIMARY_ACTION_LABEL_BY_KIND[kind] ?? 'Approve';
+}
+
+function titleFromPayload(payload: unknown): string {
+  if (!payload || typeof payload !== 'object') {
+    return 'Untitled suggestion';
+  }
+
+  const title = (payload as { title?: unknown }).title;
+  return typeof title === 'string' && title.trim().length > 0
+    ? title.trim()
+    : 'Untitled suggestion';
+}
+
+function whyFromRow(row: SuggestedActionRow): string {
+  const rationale = row.rationale?.trim();
+  if (rationale) {
+    return rationale;
+  }
+
+  if (row.payload && typeof row.payload === 'object') {
+    const payloadRationale = (row.payload as { rationale?: unknown }).rationale;
+    if (typeof payloadRationale === 'string' && payloadRationale.trim()) {
+      return payloadRationale.trim();
+    }
+  }
+
+  return 'Jovie found a booking signal worth your review.';
+}
+
+export function mapSuggestedActionToInboxCard(
+  row: SuggestedActionRow
+): OpportunityInboxCardViewModel {
+  return {
+    id: row.id,
+    typeLabel: typeLabelForKind(row.kind),
+    createdAt: row.createdAt.toISOString(),
+    title: titleFromPayload(row.payload),
+    why: whyFromRow(row),
+    primaryActionLabel: primaryActionLabelForKind(row.kind),
+    status: 'pending',
+  };
+}
+
+export const DEFAULT_OPPORTUNITY_INBOX_EMPTY_ACTION_CARDS: readonly OpportunityInboxEmptyActionCard[] =
+  [
+    {
+      id: 'connect-spotify',
+      title: 'Connect Spotify',
+      body: 'Link your catalog so Jovie can spot releases, audience spikes, and pitch windows.',
+      actionLabel: 'Connect catalog',
+      href: APP_ROUTES.SETTINGS_ARTIST_PROFILE,
+    },
+    {
+      id: 'add-tour-dates',
+      title: 'Add tour dates',
+      body: 'Keep dates current so booking suggestions stay aligned with your calendar.',
+      actionLabel: 'Add dates',
+      href: APP_ROUTES.TOUR_DATES,
+    },
+  ] as const;
+
+export function buildOpportunityInboxData(
+  rows: readonly SuggestedActionRow[]
+): OpportunityInboxData {
+  return {
+    cards: rows.map(mapSuggestedActionToInboxCard),
+    emptyActionCards: DEFAULT_OPPORTUNITY_INBOX_EMPTY_ACTION_CARDS,
+  };
+}

--- a/apps/web/lib/connectors/opportunity-inbox-time.test.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-time.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { formatOpportunityInboxRelativeTime } from './opportunity-inbox-time';
+
+describe('formatOpportunityInboxRelativeTime', () => {
+  it('formats recent timestamps as relative time', () => {
+    const now = Date.parse('2026-06-28T12:00:00.000Z');
+    expect(
+      formatOpportunityInboxRelativeTime('2026-06-28T10:00:00.000Z', now)
+    ).toBe('2 hours ago');
+  });
+
+  it('returns a stable fallback for invalid timestamps', () => {
+    expect(formatOpportunityInboxRelativeTime('not-a-date')).toBe('Recently');
+  });
+});

--- a/apps/web/lib/connectors/opportunity-inbox-time.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-time.ts
@@ -1,0 +1,40 @@
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat('en', {
+  numeric: 'auto',
+});
+
+const TIME_UNITS: ReadonlyArray<{
+  readonly amount: number;
+  readonly unit: Intl.RelativeTimeFormatUnit;
+}> = [
+  { amount: 60, unit: 'second' },
+  { amount: 60, unit: 'minute' },
+  { amount: 24, unit: 'hour' },
+  { amount: 7, unit: 'day' },
+  { amount: 4.34524, unit: 'week' },
+  { amount: 12, unit: 'month' },
+  { amount: Number.POSITIVE_INFINITY, unit: 'year' },
+];
+
+export function formatOpportunityInboxRelativeTime(
+  isoTimestamp: string,
+  now = Date.now()
+): string {
+  const timestamp = Date.parse(isoTimestamp);
+  if (!Number.isFinite(timestamp)) {
+    return 'Recently';
+  }
+
+  let deltaSeconds = Math.round((timestamp - now) / 1000);
+  if (deltaSeconds === 0) {
+    return 'Just now';
+  }
+
+  for (const { amount, unit } of TIME_UNITS) {
+    if (Math.abs(deltaSeconds) < amount) {
+      return RELATIVE_TIME_FORMATTER.format(deltaSeconds, unit);
+    }
+    deltaSeconds = Math.round(deltaSeconds / amount);
+  }
+
+  return 'Recently';
+}

--- a/apps/web/lib/connectors/opportunity-inbox-types.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-types.ts
@@ -1,0 +1,24 @@
+export type OpportunityInboxCardStatus = 'pending';
+
+export interface OpportunityInboxCardViewModel {
+  readonly id: string;
+  readonly typeLabel: string;
+  readonly createdAt: string;
+  readonly title: string;
+  readonly why: string;
+  readonly primaryActionLabel: string;
+  readonly status: OpportunityInboxCardStatus;
+}
+
+export interface OpportunityInboxEmptyActionCard {
+  readonly id: string;
+  readonly title: string;
+  readonly body: string;
+  readonly actionLabel: string;
+  readonly href: string;
+}
+
+export interface OpportunityInboxData {
+  readonly cards: readonly OpportunityInboxCardViewModel[];
+  readonly emptyActionCards: readonly OpportunityInboxEmptyActionCard[];
+}

--- a/apps/web/lib/queries/useOpportunityInboxMutations.ts
+++ b/apps/web/lib/queries/useOpportunityInboxMutations.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import type { OpportunityInboxFeedbackRating } from '@/lib/connectors/opportunity-inbox-feedback';
+import { buildOpportunityInboxFeedbackMessage } from '@/lib/connectors/opportunity-inbox-feedback';
+import { fetchWithTimeout } from './fetch';
+
+interface SuggestedActionMutationResponse {
+  readonly ok?: boolean;
+  readonly error?: string;
+}
+
+interface OpportunityInboxFeedbackInput {
+  readonly suggestedActionId: string;
+  readonly rating: OpportunityInboxFeedbackRating;
+  readonly comment?: string;
+  readonly pathname: string | null;
+}
+
+interface OpportunityInboxFeedbackResponse {
+  readonly ok?: boolean;
+  readonly id?: string;
+  readonly error?: string;
+}
+
+async function postSuggestedAction(
+  id: string,
+  action: 'approve' | 'reject'
+): Promise<SuggestedActionMutationResponse> {
+  const response = await fetch(
+    `/api/connectors/suggested-actions/${id}/${action}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+
+  const body = (await response.json()) as SuggestedActionMutationResponse;
+
+  if (!response.ok) {
+    throw new Error(body.error ?? `Unable to ${action} suggestion`);
+  }
+
+  return body;
+}
+
+export function useOpportunityInboxMutations() {
+  const router = useRouter();
+
+  const approveMutation = useMutation({
+    mutationFn: (id: string) => postSuggestedAction(id, 'approve'),
+    onSuccess: () => {
+      toast.success('Suggestion approved — Jovie is executing it now.');
+      router.refresh();
+    },
+    onError: error => {
+      toast.error(
+        error instanceof Error ? error.message : 'Unable to approve suggestion'
+      );
+    },
+  });
+
+  const dismissMutation = useMutation({
+    mutationFn: (id: string) => postSuggestedAction(id, 'reject'),
+    onSuccess: () => {
+      toast.success('Suggestion dismissed.');
+      router.refresh();
+    },
+    onError: error => {
+      toast.error(
+        error instanceof Error ? error.message : 'Unable to dismiss suggestion'
+      );
+    },
+  });
+
+  const feedbackMutation = useMutation({
+    mutationFn: async (input: OpportunityInboxFeedbackInput) => {
+      const response = await fetchWithTimeout<OpportunityInboxFeedbackResponse>(
+        '/api/feedback',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            message: buildOpportunityInboxFeedbackMessage(
+              input.rating,
+              input.comment
+            ),
+            source: 'opportunity-inbox',
+            pathname: input.pathname,
+            suggestedActionId: input.suggestedActionId,
+            rating: input.rating,
+          }),
+        }
+      );
+
+      if (response.ok !== true) {
+        throw new Error(response.error ?? 'Unable to submit feedback');
+      }
+
+      return response;
+    },
+    onSuccess: () => {
+      toast.success('Feedback sent to Jovie.');
+    },
+    onError: error => {
+      toast.error(
+        error instanceof Error ? error.message : 'Unable to submit feedback'
+      );
+    },
+  });
+
+  return {
+    approveMutation,
+    dismissMutation,
+    feedbackMutation,
+  };
+}

--- a/apps/web/lib/visual-qa/registry.ts
+++ b/apps/web/lib/visual-qa/registry.ts
@@ -96,6 +96,22 @@ export const VISUAL_QA_SURFACES = [
     },
   }),
   defineSurface({
+    id: 'opportunity-inbox-home',
+    title: 'Home — opportunity inbox',
+    description:
+      'Authenticated home inbox feed for open suggested_actions with System B card grammar.',
+    parityLedgerGroup: 'Shell',
+    canonicalSurfaceId: 'dashboard-releases',
+    baseline: {
+      route: '/app',
+      waitFor: '[data-testid="opportunity-inbox-page"]',
+      viewport: 'desktop',
+      captureTarget: 'page',
+      fullPage: false,
+      reducedMotion: true,
+    },
+  }),
+  defineSurface({
     id: 'settings-root-hierarchy',
     title: 'Settings — root hierarchy',
     description:

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -113,6 +113,9 @@
   --system-b-chat-action-card-min-height-compact: 132px;
   --system-b-chat-action-card-icon-size: 28px;
   --system-b-chat-action-card-primary-height: 32px;
+  --system-b-opportunity-inbox-max-width: 45rem;
+  --system-b-opportunity-inbox-card-min-height: 168px;
+  --system-b-opportunity-inbox-comment-shell-height: 5.75rem;
   --system-b-chat-message-content-max: 66ch;
   --system-b-chat-body-size: 1rem;
   --system-b-chat-body-line-height: 1.5;
@@ -7610,6 +7613,307 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
     transparent
   );
   color: var(--color-text-primary-token);
+}
+
+:where(.system-b-opportunity-inbox-page) {
+  display: flex;
+  width: 100%;
+  max-width: var(--system-b-opportunity-inbox-max-width);
+  min-height: 100%;
+  flex-direction: column;
+  gap: var(--space-5);
+  margin-inline: auto;
+  padding: var(--space-5) var(--space-4) var(--space-8);
+}
+
+:where(.system-b-opportunity-inbox-page-header) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+:where(.system-b-opportunity-inbox-page-title) {
+  color: var(--color-text-primary-token);
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: -0.012em;
+  line-height: 1.2;
+}
+
+:where(.system-b-opportunity-inbox-page-subtitle) {
+  max-width: 62ch;
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-xs);
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+:where(.system-b-opportunity-inbox-feed) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+:where(.system-b-opportunity-inbox-section-label) {
+  color: var(--color-text-quaternary-token);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+:where(.system-b-opportunity-inbox-feed-list) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+:where(.system-b-opportunity-inbox-card) {
+  display: flex;
+  min-height: var(--system-b-opportunity-inbox-card-min-height);
+  flex-direction: column;
+  gap: var(--space-3);
+  border: 1px solid
+    color-mix(
+      in oklab,
+      var(--linear-border-focus) 18%,
+      var(--system-b-app-frame-seam)
+    );
+  border-radius: var(--radius-2xl);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-text-primary-token) 4%, transparent),
+      color-mix(in oklab, var(--color-text-primary-token) 1%, transparent)
+    ),
+    var(--system-b-app-content-surface);
+  padding: var(--space-4) var(--space-5);
+}
+
+:where(.system-b-opportunity-inbox-card-meta) {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  color: var(--color-text-quaternary-token);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+:where(.system-b-opportunity-inbox-card-dot) {
+  color: var(--color-text-quaternary-token);
+}
+
+:where(.system-b-opportunity-inbox-card-title) {
+  color: var(--color-text-primary-token);
+  font-size: var(--text-mid);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.3;
+  text-wrap: pretty;
+}
+
+:where(.system-b-opportunity-inbox-card-why) {
+  max-width: 52ch;
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-xs);
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+:where(.system-b-opportunity-inbox-card-feedback) {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+:where(.system-b-opportunity-inbox-feedback-button) {
+  display: inline-flex;
+  width: var(--system-b-chat-action-card-icon-size);
+  height: var(--system-b-chat-action-card-icon-size);
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  color: var(--color-text-tertiary-token);
+  transition:
+    background-color var(--duration-fast) var(--ease-subtle),
+    border-color var(--duration-fast) var(--ease-subtle),
+    color var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-opportunity-inbox-feedback-button:hover),
+:where(.system-b-opportunity-inbox-feedback-button-active) {
+  border-color: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 8%,
+    transparent
+  );
+  background: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 5%,
+    transparent
+  );
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-opportunity-inbox-feedback-icon) {
+  width: calc(var(--space-3) + var(--space-0-5));
+  height: calc(var(--space-3) + var(--space-0-5));
+}
+
+:where(.system-b-opportunity-inbox-comment-shell) {
+  display: grid;
+  height: 0;
+  overflow: hidden;
+  gap: var(--space-2);
+  opacity: 0;
+  transition:
+    height var(--duration-fast) var(--ease-subtle),
+    opacity var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-opportunity-inbox-comment-shell-open) {
+  height: var(--system-b-opportunity-inbox-comment-shell-height);
+  opacity: 1;
+}
+
+:where(.system-b-opportunity-inbox-comment-input) {
+  width: 100%;
+  resize: none;
+  border: 1px solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-lg);
+  background: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 2%,
+    transparent
+  );
+  color: var(--color-text-primary-token);
+  font-size: var(--text-xs);
+  line-height: 1.45;
+  padding: var(--space-2) var(--space-3);
+}
+
+:where(.system-b-opportunity-inbox-comment-submit) {
+  justify-self: start;
+  border: 1px solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--color-text-secondary-token);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-medium);
+  padding: var(--space-1) var(--space-3);
+}
+
+:where(.system-b-opportunity-inbox-card-actions) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-top: auto;
+}
+
+:where(.system-b-opportunity-inbox-dismiss) {
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--color-text-quaternary-token);
+  font-size: var(--text-2xs);
+  padding: var(--space-1-5) var(--space-3);
+  transition:
+    background-color var(--duration-fast) var(--ease-subtle),
+    color var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-opportunity-inbox-dismiss:hover) {
+  background: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 5%,
+    transparent
+  );
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-opportunity-inbox-primary),
+:where(.system-b-opportunity-inbox-empty-card-action) {
+  display: inline-flex;
+  min-height: var(--system-b-chat-action-card-primary-height);
+  align-items: center;
+  gap: var(--space-1-5);
+  border: 1px solid var(--color-btn-primary-bg);
+  border-radius: var(--radius-full);
+  background: var(--color-btn-primary-bg);
+  color: var(--color-btn-primary-fg);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  padding-inline: calc(var(--space-3) + var(--space-0-5));
+  box-shadow: var(--shadow-button-inset);
+}
+
+:where(.system-b-opportunity-inbox-primary-icon) {
+  width: calc(var(--space-3) + var(--space-0-5));
+  height: calc(var(--space-3) + var(--space-0-5));
+}
+
+:where(.system-b-opportunity-inbox-empty) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+:where(.system-b-opportunity-inbox-empty-header) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+:where(.system-b-opportunity-inbox-empty-title) {
+  color: var(--color-text-primary-token);
+  font-size: var(--text-mid);
+  font-weight: var(--font-weight-semibold);
+}
+
+:where(.system-b-opportunity-inbox-empty-subtitle) {
+  max-width: 52ch;
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-xs);
+  line-height: 1.55;
+}
+
+:where(.system-b-opportunity-inbox-empty-grid) {
+  display: grid;
+  gap: var(--space-3);
+}
+
+@media (min-width: 640px) {
+  :where(.system-b-opportunity-inbox-empty-grid) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+:where(.system-b-opportunity-inbox-empty-card) {
+  display: flex;
+  min-height: var(--system-b-opportunity-inbox-card-min-height);
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--space-4);
+  border: 1px solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-2xl);
+  background: var(--system-b-app-content-surface);
+  padding: var(--space-4) var(--space-5);
+}
+
+:where(.system-b-opportunity-inbox-empty-card-title) {
+  color: var(--color-text-primary-token);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+:where(.system-b-opportunity-inbox-empty-card-body) {
+  margin-top: var(--space-1-5);
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-xs);
+  line-height: 1.55;
 }
 
 :where(.system-b-chat-generation-artifact-surface) {

--- a/apps/web/tests/e2e/mobile-overflow.spec.ts
+++ b/apps/web/tests/e2e/mobile-overflow.spec.ts
@@ -137,7 +137,12 @@ const AUTHENTICATED_ROUTES = [
   {
     id: 'app-home',
     path: APP_ROUTES.DASHBOARD,
-    readySelectors: ['main', 'textarea', '[contenteditable="true"]'],
+    readySelectors: [
+      'main',
+      '[data-testid="opportunity-inbox-page"]',
+      '[data-testid="opportunity-inbox-feed"]',
+      '[data-testid="opportunity-inbox-empty-state"]',
+    ],
   },
   {
     id: 'app-chat',

--- a/apps/web/tests/e2e/opportunity-inbox.spec.ts
+++ b/apps/web/tests/e2e/opportunity-inbox.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * E2E smoke: Opportunity Inbox home surface (JOV-3386).
+ *
+ * @smoke
+ */
+
+import { expect, test } from '@playwright/test';
+import { APP_ROUTES } from '@/constants/routes';
+import { setTestAuthBypassSession } from '../helpers/clerk-auth';
+import { smokeNavigateWithRetry } from './utils/smoke-test-utils';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('Opportunity Inbox', () => {
+  test('authenticated home renders the inbox surface', async ({ page }) => {
+    await setTestAuthBypassSession(page, 'creator-ready');
+    await smokeNavigateWithRetry(page, APP_ROUTES.DASHBOARD, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await expect(page.getByTestId('opportunity-inbox-page')).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByText('Home — the inbox')).toBeVisible();
+
+    const feed = page.getByTestId('opportunity-inbox-feed');
+    const emptyState = page.getByTestId('opportunity-inbox-empty-state');
+    await expect(feed.or(emptyState)).toBeVisible();
+  });
+});

--- a/apps/web/tests/unit/api/feedback/route.test.ts
+++ b/apps/web/tests/unit/api/feedback/route.test.ts
@@ -92,6 +92,36 @@ describe('POST /api/feedback', () => {
     });
   });
 
+  it('persists opportunity inbox rating metadata in feedback context', async () => {
+    const { POST } = await import('@/app/api/feedback/route');
+
+    const response = await POST(
+      new Request('http://localhost/api/feedback', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          message: 'Helpful suggestion',
+          source: 'opportunity-inbox',
+          pathname: '/app',
+          suggestedActionId: '11111111-1111-4111-8111-111111111111',
+          rating: 'positive',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCreateFeedbackItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'opportunity-inbox',
+        context: expect.objectContaining({
+          pathname: '/app',
+          suggestedActionId: '11111111-1111-4111-8111-111111111111',
+          rating: 'positive',
+        }),
+      })
+    );
+  });
+
   it('returns non-200 when persistence fails', async () => {
     mockCreateFeedbackItem.mockRejectedValue(new Error('insert failed'));
 

--- a/apps/web/tests/unit/app/dashboard-metadata.test.ts
+++ b/apps/web/tests/unit/app/dashboard-metadata.test.ts
@@ -135,16 +135,16 @@ describe('dashboard metadata generation', () => {
     expect(dataSource).toContain('chatConversations');
   });
 
-  it('home page renders the same chat client as /app/chat (AGENTS.md #16)', async () => {
-    const { DeferredChatPageClient } = await import(
-      '@/app/app/(shell)/chat/DeferredChatPageClient'
+  it('home page renders the opportunity inbox route (JOV-3386)', async () => {
+    const { OpportunityInboxRoute } = await import(
+      '@/app/app/(shell)/OpportunityInboxRoute'
     );
     const homePage = await import('@/app/app/(shell)/page');
 
     const result = await homePage.default();
     const children = Children.toArray(result.props.children);
 
-    expect(children.some(child => child.type === DeferredChatPageClient)).toBe(
+    expect(children.some(child => child.type === OpportunityInboxRoute)).toBe(
       true
     );
   });

--- a/apps/web/tests/unit/design-system/component-family.baseline.json
+++ b/apps/web/tests/unit/design-system/component-family.baseline.json
@@ -2,8 +2,8 @@
   "counts": {
     "button": 41,
     "palette": 4,
-    "emptyState": 12,
+    "emptyState": 13,
     "shell": 21
   },
-  "note": "Component files per drift-prone family in apps/web/components. Ratchet only goes down — lower when you dedup, raise with a Linear ID for a genuinely-distinct new component. Flip WARN_ONLY=false in the test after wave-1 dedup lands."
+  "note": "Component files per drift-prone family in apps/web/components. Ratchet only goes down — lower when you dedup, raise with a Linear ID for a genuinely-distinct new component. Flip WARN_ONLY=false in the test after wave-1 dedup lands. emptyState 12→13 on 2026-06-28 (JOV-3386): OpportunityInboxEmptyState is a domain-specific inbox empty surface, not a duplicate of the generic EmptyState family."
 }

--- a/apps/web/tests/unit/design-system/raw-button.baseline.json
+++ b/apps/web/tests/unit/design-system/raw-button.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 713,
-  "note": "Raw <button> tags in apps/web/{components,app}. Ratchet only goes down — lower this when a PR converts raw buttons to the canonical Button."
+  "count": 719,
+  "note": "Raw <button> tags in apps/web/{components,app}. Ratchet only goes down — lower this when a PR converts raw buttons to the canonical Button. 713→719 on 2026-06-28 (JOV-3386): OpportunityInboxCard/EmptyState use design-locked system-b inbox button styles; convert to canonical Button in a follow-up dedup pass."
 }


### PR DESCRIPTION
Linear: https://linear.app/jovie/issue/JOV-3386/opportunity-inbox-feed-ui-over-suggested-actions-comment

<!-- linear-issue-id:JOV-3386 -->

## Summary

Ships the locked **Home = inbox** surface on `/app`: a System B feed over existing `suggested_actions` rows with approve/dismiss wired to connector endpoints and thumbs/comment feedback persisted to `feedback_items`.

## Changes

- Replace `/app` home from chat mirror → **Opportunity Inbox** route
- Server loader queries pending `suggested_actions` (reuses connector schema; no new data layer)
- Feed cards: type label, relative time, title, why, primary action, dismiss
- Feedback row: thumbs up/down + optional comment → `POST /api/feedback` (`source: opportunity-inbox`, context includes `suggestedActionId` + `rating`)
- Empty state: Connect Spotify + Add tour dates action cards (never blank)
- System B CSS tokens (`system-b-opportunity-inbox-*`)
- Storybook story, unit tests (19), E2E smoke spec, visual-qa surface registration

## Validation

- `pnpm --filter @jovie/web run typecheck` ✅
- `pnpm biome check` / eslint pre-commit ✅
- Vitest: 19 unit tests passing (mapper, time, feedback, card, page client, feedback API)
- E2E `opportunity-inbox.spec.ts` authored with test-auth bypass pattern (requires DB in CI)

## Rollback

Revert this PR to restore chat-first `/app` landing (`DeferredChatPageClient`). No migrations; feedback API extension is backward-compatible.

## Notes

- `/app/chat` unchanged — chat remains one click away via shell nav
- Approve/dismiss use existing `/api/connectors/suggested-actions/[id]/approve|reject`