### PR TITLE
feat(ios): slide-over left drawer nav with threads and search

### DIFF
--- a/apps/ios/Jovie.xcodeproj/project.pbxproj
+++ b/apps/ios/Jovie.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		A0B10F000000000000000020 /* AuthScreenStyleGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B10F000000000000000021 /* AuthScreenStyleGuardTests.swift */; };
 		A0A344000000000000000002 /* AppShellIntentNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A344000000000000000001 /* AppShellIntentNavigation.swift */; };
 		A0A344000000000000000004 /* AppShellIntentNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A344000000000000000003 /* AppShellIntentNavigationTests.swift */; };
+		A0J0V36330000000000000002 /* AppShellLeftDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V36330000000000000001 /* AppShellLeftDrawer.swift */; };
+		A0J0V36330000000000000004 /* AppShellDrawerThreadsFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V36330000000000000003 /* AppShellDrawerThreadsFilterTests.swift */; };
 		E1F2A3B4C5D6E7F8A9B0C1D2 /* SettingsEscapeTrapGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E2D3C4B5A697886756453E /* SettingsEscapeTrapGuardTests.swift */; };
 		A0J0V25490000000000000002 /* ChatCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000001 /* ChatCache.swift */; };
 		A0J0V25490000000000000004 /* ChatRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000003 /* ChatRepository.swift */; };
@@ -144,6 +146,8 @@
 		A0B10F000000000000000021 /* AuthScreenStyleGuardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthScreenStyleGuardTests.swift; sourceTree = "<group>"; };
 		A0A344000000000000000001 /* AppShellIntentNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellIntentNavigation.swift; sourceTree = "<group>"; };
 		A0A344000000000000000003 /* AppShellIntentNavigationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellIntentNavigationTests.swift; sourceTree = "<group>"; };
+		A0J0V36330000000000000001 /* AppShellLeftDrawer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellLeftDrawer.swift; sourceTree = "<group>"; };
+		A0J0V36330000000000000003 /* AppShellDrawerThreadsFilterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellDrawerThreadsFilterTests.swift; sourceTree = "<group>"; };
 		F1E2D3C4B5A697886756453E /* SettingsEscapeTrapGuardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsEscapeTrapGuardTests.swift; sourceTree = "<group>"; };
 		A0J0V25490000000000000001 /* ChatCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatCache.swift; sourceTree = "<group>"; };
 		A0J0V25490000000000000003 /* ChatRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatRepository.swift; sourceTree = "<group>"; };
@@ -268,6 +272,7 @@
 				178C37B20F46EAF919EB2031 /* ScreenBrightnessManagerTests.swift */,
 				A0J0V26350000000000000003 /* MobileAuthFinalizationTests.swift */,
 				A0A344000000000000000003 /* AppShellIntentNavigationTests.swift */,
+				A0J0V36330000000000000003 /* AppShellDrawerThreadsFilterTests.swift */,
 				5615484B29C6B6E26EE5E92B /* IntentNavigationStoreTests.swift */,
 				F4562819B40056163650929C /* JovieAppIntentsTests.swift */,
 			);
@@ -296,6 +301,7 @@
 			isa = PBXGroup;
 			children = (
 				A0A344000000000000000001 /* AppShellIntentNavigation.swift */,
+				A0J0V36330000000000000001 /* AppShellLeftDrawer.swift */,
 				4C2C97BF3A0B42C58A62529F /* AppShellView.swift */,
 			);
 			name = AppShell;
@@ -612,6 +618,7 @@
 				A0J0V26350000000000000004 /* MobileAuthFinalizationTests.swift in Sources */,
 				A0B10F000000000000000020 /* AuthScreenStyleGuardTests.swift in Sources */,
 				A0A344000000000000000004 /* AppShellIntentNavigationTests.swift in Sources */,
+				A0J0V36330000000000000004 /* AppShellDrawerThreadsFilterTests.swift in Sources */,
 				E1F2A3B4C5D6E7F8A9B0C1D2 /* SettingsEscapeTrapGuardTests.swift in Sources */,
 				71B98E46403E1759256C61A5 /* IntentNavigationStoreTests.swift in Sources */,
 				F232904F618A4671B805D0BC /* JovieAppIntentsTests.swift in Sources */,
@@ -652,6 +659,7 @@
 				A13F86A7D4F0C7F83D2BB000 /* ScreenBrightnessManager.swift in Sources */,
 				6E62396A29D88F275920CA48 /* JovieTheme.swift in Sources */,
 				A0A344000000000000000002 /* AppShellIntentNavigation.swift in Sources */,
+				A0J0V36330000000000000002 /* AppShellLeftDrawer.swift in Sources */,
 				5F4F3551CC9F4C09A2520AEB /* AppShellView.swift in Sources */,
 				F95545618F95E792DCBCA7DF /* AuthScreen.swift in Sources */,
 				74E75D0A3C816805F65FA48A /* DashboardView.swift in Sources */,

--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -198,8 +198,12 @@ private struct AppContentView: View {
           billingURL: appState.billingURL,
           chatEnabled: false,
           recentConversations: chatRepository?.conversations ?? [],
+          activeConversationID: chatRepository?.activeConversationID,
           onSelectConversation: { conversationID in
             Task { await chatRepository?.openConversation(conversationID) }
+          },
+          onStartNewChat: {
+            chatRepository?.startNewConversation()
           },
           onLogout: onLogout
         ) {
@@ -225,8 +229,12 @@ private struct AppContentView: View {
           billingURL: appState.billingURL,
           chatEnabled: appState.loadedDashboardResponse != nil,
           recentConversations: chatRepository?.conversations ?? [],
+          activeConversationID: chatRepository?.activeConversationID,
           onSelectConversation: { conversationID in
             Task { await chatRepository?.openConversation(conversationID) }
+          },
+          onStartNewChat: {
+            chatRepository?.startNewConversation()
           },
           onLogout: onLogout
         ) {

--- a/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
@@ -52,32 +52,34 @@ struct AppShellLeftDrawer: View {
     )
   }
 
-  var body: some View {
-    GeometryReader { proxy in
-      let openOffset = drawerWidth + proxy.safeAreaInsets.leading
-      let progress = isPresented
-        ? max(0, min(1, 1 + (dragOffset / openOffset)))
-        : max(0, min(1, dragOffset / openOffset))
+  private var isVisible: Bool {
+    isPresented || dragOffset != 0
+  }
 
-      ZStack(alignment: .leading) {
-        if isPresented || dragOffset != 0 {
+  var body: some View {
+    if isVisible {
+      GeometryReader { proxy in
+        let openOffset = drawerWidth + proxy.safeAreaInsets.leading
+        let progress = isPresented
+          ? max(0, min(1, 1 + (dragOffset / openOffset)))
+          : max(0, min(1, dragOffset / openOffset))
+
+        ZStack(alignment: .leading) {
           Color.black
             .opacity(0.42 * progress)
             .ignoresSafeArea()
             .onTapGesture { closeDrawer() }
             .accessibilityHidden(true)
-        }
 
-        drawerPanel(openOffset: openOffset)
-          .offset(x: drawerOffset(openOffset: openOffset))
-          .gesture(drawerDragGesture(openOffset: openOffset))
+          drawerPanel(openOffset: openOffset)
+            .offset(x: drawerOffset(openOffset: openOffset))
+            .gesture(drawerDragGesture(openOffset: openOffset))
+        }
+        .animation(animation, value: isPresented)
+        .animation(animation, value: dragOffset)
       }
-      .animation(animation, value: isPresented)
-      .animation(animation, value: dragOffset)
+      .accessibilityIdentifier("shell-drawer")
     }
-    .allowsHitTesting(isPresented || dragOffset != 0)
-    .accessibilityElement(children: isPresented ? .contain : .ignore)
-    .accessibilityIdentifier("shell-drawer")
   }
 
   @ViewBuilder

--- a/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
@@ -1,0 +1,440 @@
+import SwiftUI
+
+enum JovieMotion {
+  static let cinematicDuration: Double = 0.42
+  static let cinematic = Animation.timingCurve(0.22, 1, 0.36, 1, duration: cinematicDuration)
+}
+
+enum AppShellDrawerThreadsFilter {
+  static func filtered(
+    conversations: [MobileConversationSummary],
+    query: String
+  ) -> [MobileConversationSummary] {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return conversations }
+
+    return conversations.filter { conversation in
+      let title = conversation.title ?? "New Conversation"
+      return title.localizedCaseInsensitiveContains(trimmed)
+    }
+  }
+}
+
+struct AppShellLeftDrawer: View {
+  @Binding var isPresented: Bool
+  let profile: AppShellProfile
+  let isOffline: Bool
+  let chatEnabled: Bool
+  let selectedTab: AppShellTab
+  let recentConversations: [MobileConversationSummary]
+  let activeConversationID: String?
+  let onSelectTab: (AppShellTab) -> Void
+  let onStartNewChat: () -> Void
+  let onSelectConversation: (String) -> Void
+  let onOpenSettings: () -> Void
+
+  @State private var threadSearch = ""
+  @State private var dragOffset: CGFloat = 0
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  private var drawerWidth: CGFloat {
+    min(320, UIScreen.main.bounds.width * 0.86)
+  }
+
+  private var animation: Animation {
+    reduceMotion ? .easeInOut(duration: 0.2) : JovieMotion.cinematic
+  }
+
+  private var filteredConversations: [MobileConversationSummary] {
+    AppShellDrawerThreadsFilter.filtered(
+      conversations: recentConversations,
+      query: threadSearch
+    )
+  }
+
+  var body: some View {
+    GeometryReader { proxy in
+      let openOffset = drawerWidth + proxy.safeAreaInsets.leading
+      let progress = isPresented
+        ? max(0, min(1, 1 + (dragOffset / openOffset)))
+        : max(0, min(1, dragOffset / openOffset))
+
+      ZStack(alignment: .leading) {
+        if isPresented || dragOffset != 0 {
+          Color.black
+            .opacity(0.42 * progress)
+            .ignoresSafeArea()
+            .onTapGesture { closeDrawer() }
+            .accessibilityHidden(true)
+        }
+
+        drawerPanel(openOffset: openOffset)
+          .offset(x: drawerOffset(openOffset: openOffset))
+          .gesture(drawerDragGesture(openOffset: openOffset))
+      }
+      .animation(animation, value: isPresented)
+      .animation(animation, value: dragOffset)
+    }
+    .allowsHitTesting(isPresented || dragOffset != 0)
+    .accessibilityElement(children: isPresented ? .contain : .ignore)
+    .accessibilityIdentifier("shell-drawer")
+  }
+
+  @ViewBuilder
+  private func drawerPanel(openOffset: CGFloat) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        Text("Jovie")
+          .font(JovieFont.display(size: 22))
+          .foregroundStyle(JovieColor.textPrimary)
+
+        Spacer(minLength: 0)
+
+        Button(action: closeDrawer) {
+          Image(systemName: "xmark")
+        }
+        .buttonStyle(JovieIconButtonStyle())
+        .accessibilityLabel("Close navigation drawer")
+        .accessibilityIdentifier("shell-drawer-close")
+      }
+      .padding(.horizontal, JovieSpacing.large)
+      .padding(.top, JovieSpacing.large)
+      .padding(.bottom, JovieSpacing.medium)
+
+      ScrollView {
+        VStack(alignment: .leading, spacing: JovieSpacing.xLarge) {
+          DrawerAccountHeader(profile: profile, isOffline: isOffline)
+
+          DrawerSurfaceSwitcher(
+            chatEnabled: chatEnabled,
+            selectedTab: selectedTab,
+            onSelectTab: { tab in
+              onSelectTab(tab)
+              closeDrawer()
+            }
+          )
+
+          if chatEnabled {
+            DrawerNewChatButton {
+              onStartNewChat()
+              closeDrawer()
+            }
+
+            DrawerThreadsSection(
+              searchText: $threadSearch,
+              conversations: filteredConversations,
+              totalCount: recentConversations.count,
+              activeConversationID: activeConversationID,
+              onSelectConversation: { conversationID in
+                onSelectConversation(conversationID)
+                closeDrawer()
+              }
+            )
+          }
+
+          DrawerSettingsRow {
+            onOpenSettings()
+            closeDrawer()
+          }
+        }
+        .padding(.horizontal, JovieSpacing.large)
+        .padding(.bottom, JovieSpacing.xxLarge)
+      }
+    }
+    .frame(width: drawerWidth, alignment: .leading)
+    .frame(maxHeight: .infinity)
+    .background(JovieColor.surface0)
+    .overlay(alignment: .trailing) {
+      Rectangle()
+        .fill(JovieColor.borderSubtle)
+        .frame(width: 1)
+    }
+    .clipShape(
+      .rect(
+        topLeadingRadius: 0,
+        bottomLeadingRadius: 0,
+        bottomTrailingRadius: JovieRadius.xLarge,
+        topTrailingRadius: JovieRadius.xLarge
+      )
+    )
+    .shadow(color: .black.opacity(0.28), radius: 24, x: 8)
+  }
+
+  private func drawerOffset(openOffset: CGFloat) -> CGFloat {
+    if isPresented {
+      return min(0, dragOffset)
+    }
+    return -openOffset + max(0, dragOffset)
+  }
+
+  private func drawerDragGesture(openOffset: CGFloat) -> some Gesture {
+    DragGesture(minimumDistance: 8, coordinateSpace: .global)
+      .onChanged { value in
+        guard !reduceMotion else { return }
+
+        if isPresented {
+          dragOffset = min(0, value.translation.width)
+        } else if value.startLocation.x < 28, value.translation.width > 0 {
+          dragOffset = min(value.translation.width, openOffset)
+        }
+      }
+      .onEnded { value in
+        guard !reduceMotion else { return }
+
+        let predicted = value.predictedEndTranslation.width
+        if isPresented {
+          if value.translation.width < -72 || predicted < -120 {
+            closeDrawer()
+          } else {
+            dragOffset = 0
+          }
+          return
+        }
+
+        if value.startLocation.x < 28,
+           value.translation.width > 72 || predicted > 120
+        {
+          openDrawer()
+        }
+        dragOffset = 0
+      }
+  }
+
+  private func openDrawer() {
+    dragOffset = 0
+    isPresented = true
+  }
+
+  private func closeDrawer() {
+    dragOffset = 0
+    isPresented = false
+    threadSearch = ""
+  }
+}
+
+private struct DrawerAccountHeader: View {
+  let profile: AppShellProfile
+  let isOffline: Bool
+
+  var body: some View {
+    HStack(spacing: JovieSpacing.medium) {
+      DashboardAvatarView(
+        name: profile.displayName,
+        avatarURL: profile.avatarURL
+      )
+      .frame(width: 40, height: 40)
+
+      VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
+        Text(profile.displayName)
+          .font(JovieFont.body(size: 16, weight: .semibold))
+          .foregroundStyle(JovieColor.textPrimary)
+          .lineLimit(1)
+
+        Text(isOffline ? "Offline" : profile.secondaryText)
+          .font(JovieFont.body(size: 13, weight: .medium))
+          .foregroundStyle(JovieColor.textTertiary)
+          .lineLimit(1)
+      }
+
+      Spacer(minLength: 0)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityIdentifier("shell-drawer-account")
+  }
+}
+
+private struct DrawerSurfaceSwitcher: View {
+  let chatEnabled: Bool
+  let selectedTab: AppShellTab
+  let onSelectTab: (AppShellTab) -> Void
+
+  private var surfaces: [AppShellTab] {
+    chatEnabled ? [.profile, .chat] : [.profile]
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.small) {
+      Text("Surfaces")
+        .font(JovieFont.body(size: 13, weight: .semibold))
+        .foregroundStyle(JovieColor.textTertiary)
+
+      HStack(spacing: JovieSpacing.small) {
+        ForEach(surfaces, id: \.self) { tab in
+          DrawerSurfaceButton(
+            tab: tab,
+            isSelected: selectedTab == tab,
+            action: { onSelectTab(tab) }
+          )
+        }
+      }
+    }
+    .accessibilityIdentifier("shell-drawer-surfaces")
+  }
+}
+
+private struct DrawerSurfaceButton: View {
+  let tab: AppShellTab
+  let isSelected: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: JovieSpacing.small) {
+        Image(systemName: tab.systemImage)
+          .font(.system(size: 14, weight: .semibold))
+
+        Text(tab.title)
+          .font(JovieFont.body(size: 15, weight: .semibold))
+      }
+      .foregroundStyle(isSelected ? JovieColor.textPrimary : JovieColor.textSecondary)
+      .padding(.horizontal, JovieSpacing.medium)
+      .padding(.vertical, 11)
+      .frame(maxWidth: .infinity)
+      .background(
+        isSelected ? JovieColor.surface1 : Color.clear,
+        in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous)
+      )
+      .overlay {
+        RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous)
+          .stroke(isSelected ? JovieColor.borderDefault : Color.clear, lineWidth: 1)
+      }
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(tab.title)
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    .accessibilityIdentifier("shell-drawer-surface-\(tab.accessibilityID)")
+  }
+}
+
+private struct DrawerNewChatButton: View {
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: JovieSpacing.medium) {
+        Image(systemName: "square.and.pencil")
+          .frame(width: 22)
+
+        Text("New chat")
+          .lineLimit(1)
+
+        Spacer(minLength: 0)
+      }
+      .font(JovieFont.body(size: 18, weight: .semibold))
+      .foregroundStyle(JovieColor.textPrimary)
+      .padding(.vertical, 13)
+      .padding(.horizontal, JovieSpacing.medium)
+      .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("New chat")
+    .accessibilityIdentifier("shell-drawer-new-chat")
+  }
+}
+
+private struct DrawerThreadsSection: View {
+  @Binding var searchText: String
+  let conversations: [MobileConversationSummary]
+  let totalCount: Int
+  let activeConversationID: String?
+  let onSelectConversation: (String) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.medium) {
+      Text("Threads")
+        .font(JovieFont.body(size: 13, weight: .semibold))
+        .foregroundStyle(JovieColor.textTertiary)
+
+      HStack(spacing: JovieSpacing.small) {
+        Image(systemName: "magnifyingglass")
+          .font(.system(size: 14, weight: .medium))
+          .foregroundStyle(JovieColor.textTertiary)
+
+        TextField("Search threads", text: $searchText)
+          .textInputAutocapitalization(.never)
+          .disableAutocorrection(true)
+          .font(JovieFont.body(size: 15))
+          .foregroundStyle(JovieColor.textPrimary)
+      }
+      .padding(.horizontal, JovieSpacing.medium)
+      .padding(.vertical, 11)
+      .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
+      .accessibilityIdentifier("shell-drawer-search")
+
+      if totalCount == 0 {
+        Text("Start a conversation to see recent conversations here.")
+          .font(JovieFont.body(size: 15))
+          .foregroundStyle(JovieColor.textTertiary)
+          .fixedSize(horizontal: false, vertical: true)
+      } else if conversations.isEmpty {
+        Text("No threads match your search.")
+          .font(JovieFont.body(size: 15))
+          .foregroundStyle(JovieColor.textTertiary)
+          .fixedSize(horizontal: false, vertical: true)
+      } else {
+        VStack(spacing: JovieSpacing.xSmall) {
+          ForEach(conversations) { conversation in
+            DrawerThreadRow(
+              conversation: conversation,
+              isActive: activeConversationID == conversation.id,
+              action: { onSelectConversation(conversation.id) }
+            )
+          }
+        }
+      }
+    }
+    .accessibilityIdentifier("shell-drawer-threads")
+  }
+}
+
+private struct DrawerThreadRow: View {
+  let conversation: MobileConversationSummary
+  let isActive: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: JovieSpacing.medium) {
+        Text(conversation.title ?? "New Conversation")
+          .font(JovieFont.body(size: 15, weight: isActive ? .semibold : .regular))
+          .foregroundStyle(isActive ? JovieColor.textPrimary : JovieColor.textSecondary)
+          .lineLimit(1)
+
+        Spacer(minLength: 0)
+      }
+      .padding(.vertical, JovieSpacing.small)
+      .padding(.horizontal, JovieSpacing.small)
+      .background(
+        isActive ? JovieColor.surface1 : Color.clear,
+        in: RoundedRectangle(cornerRadius: JovieRadius.small, style: .continuous)
+      )
+    }
+    .buttonStyle(.plain)
+    .accessibilityIdentifier("shell-drawer-thread-\(conversation.id)")
+  }
+}
+
+private struct DrawerSettingsRow: View {
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: JovieSpacing.medium) {
+        Image(systemName: "gearshape")
+          .frame(width: 22)
+
+        Text("Settings")
+          .lineLimit(1)
+
+        Spacer(minLength: 0)
+      }
+      .font(JovieFont.body(size: 18, weight: .semibold))
+      .foregroundStyle(JovieColor.textSecondary)
+      .padding(.vertical, 13)
+      .padding(.horizontal, JovieSpacing.medium)
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Settings")
+    .accessibilityIdentifier("shell-drawer-settings")
+  }
+}

--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -78,7 +78,6 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
   @State private var didOpenLaunchSettings = false
   @State private var chatDraft = ""
   @State private var intentStore = IntentNavigationStore.shared
-  @State private var edgeDragOffset: CGFloat = 0
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   init(
@@ -274,15 +273,8 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
 
   private var edgeSwipeToOpenDrawer: some Gesture {
     DragGesture(minimumDistance: 12, coordinateSpace: .global)
-      .onChanged { value in
-        guard !isShowingDrawer, !reduceMotion else { return }
-        guard value.startLocation.x < 28, value.translation.width > 0 else { return }
-        edgeDragOffset = value.translation.width
-      }
       .onEnded { value in
         guard !isShowingDrawer, !reduceMotion else { return }
-        defer { edgeDragOffset = 0 }
-
         guard value.startLocation.x < 28 else { return }
         if value.translation.width > 72 || value.predictedEndTranslation.width > 120 {
           openDrawer()

--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-enum AppShellTab: Equatable {
+enum AppShellTab: Equatable, Hashable {
   case chat
   case profile
 
@@ -65,17 +65,21 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
   let billingURL: URL
   let chatEnabled: Bool
   let recentConversations: [MobileConversationSummary]
+  let activeConversationID: String?
   let onSelectConversation: (String) -> Void
+  let onStartNewChat: () -> Void
   let onLogout: @MainActor () async -> Void
   @ViewBuilder let profileContent: ProfileContent
   let chatContent: (Binding<String>) -> ChatContent
 
   @State private var selectedTab: AppShellTab
   @State private var navigationPath: [AppShellRoute] = []
-  @State private var isShowingMenu = false
+  @State private var isShowingDrawer = false
   @State private var didOpenLaunchSettings = false
   @State private var chatDraft = ""
   @State private var intentStore = IntentNavigationStore.shared
+  @State private var edgeDragOffset: CGFloat = 0
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   init(
     profile: AppShellProfile,
@@ -85,7 +89,9 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
     billingURL: URL,
     chatEnabled: Bool = false,
     recentConversations: [MobileConversationSummary] = [],
+    activeConversationID: String? = nil,
     onSelectConversation: @escaping (String) -> Void = { _ in },
+    onStartNewChat: @escaping () -> Void = {},
     onLogout: @escaping @MainActor () async -> Void,
     @ViewBuilder profileContent: () -> ProfileContent,
     @ViewBuilder chatContent: @escaping (Binding<String>) -> ChatContent
@@ -96,7 +102,9 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
     self.billingURL = billingURL
     self.chatEnabled = chatEnabled
     self.recentConversations = recentConversations
+    self.activeConversationID = activeConversationID
     self.onSelectConversation = onSelectConversation
+    self.onStartNewChat = onStartNewChat
     self.onLogout = onLogout
     self.profileContent = profileContent()
     self.chatContent = chatContent
@@ -121,6 +129,7 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
         bottomBar
       }
       .simultaneousGesture(pageSwipe)
+      .simultaneousGesture(edgeSwipeToOpenDrawer)
       .navigationBarHidden(true)
       .navigationDestination(for: AppShellRoute.self) { route in
         switch route {
@@ -135,26 +144,28 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
           .navigationBarBackButtonHidden()
         }
       }
+      .overlay {
+        AppShellLeftDrawer(
+          isPresented: $isShowingDrawer,
+          profile: profile,
+          isOffline: isOffline,
+          chatEnabled: chatEnabled,
+          selectedTab: selectedTab,
+          recentConversations: recentConversations,
+          activeConversationID: activeConversationID,
+          onSelectTab: selectTab,
+          onStartNewChat: startNewChat,
+          onSelectConversation: { conversationID in
+            onSelectConversation(conversationID)
+            selectTab(.chat)
+          },
+          onOpenSettings: {
+            navigationPath.append(.settings)
+          }
+        )
+      }
     }
     .background(JovieColor.backgroundBase)
-    .fullScreenCover(isPresented: $isShowingMenu) {
-      AppNavigationMenu(
-        profile: profile,
-        isOffline: isOffline,
-        chatEnabled: chatEnabled,
-        recentConversations: recentConversations,
-        onSelectConversation: { conversationID in
-          onSelectConversation(conversationID)
-          selectedTab = .chat
-          isShowingMenu = false
-        },
-        onOpenSettings: {
-          isShowingMenu = false
-          navigationPath.append(.settings)
-        },
-        onClose: { isShowingMenu = false }
-      )
-    }
     .task(id: opensSettingsOnLaunch) {
       guard opensSettingsOnLaunch, didOpenLaunchSettings == false else { return }
       didOpenLaunchSettings = true
@@ -195,6 +206,23 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
     }
   }
 
+  private func selectTab(_ tab: AppShellTab) {
+    withAnimation(.easeInOut(duration: 0.25)) {
+      selectedTab = tab
+    }
+  }
+
+  private func startNewChat() {
+    onStartNewChat()
+    chatDraft = ""
+    selectTab(.chat)
+  }
+
+  private func openDrawer() {
+    guard !isShowingDrawer else { return }
+    isShowingDrawer = true
+  }
+
   // Horizontally paged primary screens. The floating bottom bar drives the same
   // `selectedTab` selection so taps and the horizontal swipe gesture stay in sync,
   // and each screen keeps its own vertical scrolling (the swipe is recognized
@@ -225,10 +253,13 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
   private var pageSwipe: some Gesture {
     DragGesture(minimumDistance: 24)
       .onEnded { value in
+        guard !isShowingDrawer else { return }
+
         let horizontal = value.translation.width
         guard chatEnabled,
               abs(horizontal) > 60,
-              abs(horizontal) > abs(value.translation.height) * 1.5
+              abs(horizontal) > abs(value.translation.height) * 1.5,
+              value.startLocation.x >= 28 || horizontal < 0
         else { return }
 
         withAnimation(.easeInOut(duration: 0.28)) {
@@ -241,8 +272,37 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
       }
   }
 
+  private var edgeSwipeToOpenDrawer: some Gesture {
+    DragGesture(minimumDistance: 12, coordinateSpace: .global)
+      .onChanged { value in
+        guard !isShowingDrawer, !reduceMotion else { return }
+        guard value.startLocation.x < 28, value.translation.width > 0 else { return }
+        edgeDragOffset = value.translation.width
+      }
+      .onEnded { value in
+        guard !isShowingDrawer, !reduceMotion else { return }
+        defer { edgeDragOffset = 0 }
+
+        guard value.startLocation.x < 28 else { return }
+        if value.translation.width > 72 || value.predictedEndTranslation.width > 120 {
+          openDrawer()
+        }
+      }
+  }
+
   private var shellToolbar: some View {
-    HStack(alignment: .firstTextBaseline, spacing: JovieSpacing.medium) {
+    HStack(alignment: .center, spacing: JovieSpacing.medium) {
+      Button(action: openDrawer) {
+        DashboardAvatarView(
+          name: profile.displayName,
+          avatarURL: profile.avatarURL
+        )
+        .frame(width: 32, height: 32)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Open navigation drawer")
+      .accessibilityIdentifier("shell-drawer-open")
+
       VStack(alignment: .leading, spacing: 2) {
         Text(selectedTab.title)
           .font(JovieFont.display(size: 22))
@@ -271,8 +331,7 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
     .background(JovieColor.backgroundBase.opacity(0.96))
   }
 
-  // Floating, icon-only bottom bar: primary destinations live in one capsule, with
-  // an overflow "More" control in its own adjacent capsule (drawer trigger).
+  // Floating, icon-only bottom bar: primary destinations live in one capsule.
   private var bottomBar: some View {
     HStack(spacing: JovieSpacing.small) {
       HStack(spacing: 4) {
@@ -283,10 +342,6 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
       }
       .padding(6)
       .modifier(BottomBarSurface())
-
-      moreButton
-        .padding(6)
-        .modifier(BottomBarSurface())
     }
     .padding(.bottom, JovieSpacing.medium)
   }
@@ -314,21 +369,6 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
     .accessibilityAddTraits(isSelected ? [.isSelected] : [])
     .accessibilityIdentifier(tab.accessibilityID)
   }
-
-  private var moreButton: some View {
-    Button {
-      isShowingMenu = true
-    } label: {
-      Image(systemName: "ellipsis")
-        .font(.system(size: 18, weight: .semibold))
-        .foregroundStyle(JovieColor.textSecondary)
-        .frame(width: 48, height: 40)
-        .contentShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
-    }
-    .buttonStyle(.plain)
-    .accessibilityLabel("More")
-    .accessibilityIdentifier("shell-more")
-  }
 }
 
 private struct BottomBarSurface: ViewModifier {
@@ -350,149 +390,5 @@ private struct BottomBarSurface: ViewModifier {
           }
       }
     }
-  }
-}
-
-private struct AppNavigationMenu: View {
-  let profile: AppShellProfile
-  let isOffline: Bool
-  let chatEnabled: Bool
-  let recentConversations: [MobileConversationSummary]
-  let onSelectConversation: (String) -> Void
-  let onOpenSettings: () -> Void
-  let onClose: () -> Void
-
-  var body: some View {
-    ZStack {
-      JovieColor.backgroundBase.ignoresSafeArea()
-
-      VStack(alignment: .leading, spacing: JovieSpacing.xLarge) {
-        HStack {
-          Text("Jovie")
-            .font(JovieFont.display(size: 30))
-            .foregroundStyle(JovieColor.textPrimary)
-
-          Spacer()
-
-          Button(action: onClose) {
-            Image(systemName: "xmark")
-          }
-          .buttonStyle(JovieIconButtonStyle())
-          .accessibilityLabel("Close Menu")
-        }
-
-        MenuAccountView(profile: profile, isOffline: isOffline)
-
-        VStack(spacing: JovieSpacing.small) {
-          MenuRow(
-            title: "Settings",
-            systemImage: "gearshape",
-            isSelected: false,
-            action: onOpenSettings
-          )
-        }
-
-        if chatEnabled {
-          VStack(alignment: .leading, spacing: JovieSpacing.medium) {
-            Text("Recent")
-              .font(JovieFont.body(size: 13, weight: .semibold))
-              .foregroundStyle(JovieColor.textTertiary)
-
-            if recentConversations.isEmpty {
-              Text("Start a conversation to see recent conversations here.")
-                .font(JovieFont.body(size: 15))
-                .foregroundStyle(JovieColor.textTertiary)
-                .fixedSize(horizontal: false, vertical: true)
-            } else {
-              VStack(spacing: JovieSpacing.small) {
-                ForEach(recentConversations.prefix(5)) { conversation in
-                  Button {
-                    onSelectConversation(conversation.id)
-                  } label: {
-                    HStack {
-                      Text(conversation.title ?? "New Conversation")
-                        .font(JovieFont.body(size: 15))
-                        .foregroundStyle(JovieColor.textPrimary)
-                        .lineLimit(1)
-                      Spacer()
-                    }
-                    .padding(.vertical, JovieSpacing.small)
-                  }
-                  .buttonStyle(.plain)
-                }
-              }
-            }
-          }
-          .padding(.top, JovieSpacing.medium)
-        }
-
-        Spacer(minLength: 0)
-      }
-      .padding(.horizontal, JovieSpacing.xLarge)
-      .padding(.top, JovieSpacing.xxLarge)
-      .padding(.bottom, JovieSpacing.xLarge)
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-    .accessibilityIdentifier("shell-menu")
-  }
-}
-
-private struct MenuAccountView: View {
-  let profile: AppShellProfile
-  let isOffline: Bool
-
-  var body: some View {
-    HStack(spacing: JovieSpacing.medium) {
-      DashboardAvatarView(
-        name: profile.displayName,
-        avatarURL: profile.avatarURL
-      )
-      .frame(width: 36, height: 36)
-
-      VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
-        Text(profile.displayName)
-          .font(JovieFont.body(size: 15, weight: .semibold))
-          .foregroundStyle(JovieColor.textPrimary)
-          .lineLimit(1)
-
-        Text(isOffline ? "Offline" : profile.secondaryText)
-          .font(JovieFont.body(size: 13, weight: .medium))
-          .foregroundStyle(JovieColor.textTertiary)
-          .lineLimit(1)
-      }
-
-      Spacer(minLength: 0)
-    }
-  }
-}
-
-private struct MenuRow: View {
-  let title: String
-  let systemImage: String
-  let isSelected: Bool
-  let action: () -> Void
-
-  var body: some View {
-    Button(action: action) {
-      HStack(spacing: JovieSpacing.medium) {
-        Image(systemName: systemImage)
-          .frame(width: 22)
-
-        Text(title)
-          .lineLimit(1)
-
-        Spacer(minLength: 0)
-      }
-      .font(JovieFont.body(size: 18, weight: .semibold))
-      .foregroundStyle(isSelected ? JovieColor.textPrimary : JovieColor.textSecondary)
-      .padding(.vertical, 13)
-      .padding(.horizontal, JovieSpacing.medium)
-      .background(
-        isSelected ? JovieColor.surface1 : Color.clear,
-        in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous)
-      )
-    }
-    .buttonStyle(.plain)
-    .accessibilityLabel(title)
   }
 }

--- a/apps/ios/JovieTests/AppShellDrawerThreadsFilterTests.swift
+++ b/apps/ios/JovieTests/AppShellDrawerThreadsFilterTests.swift
@@ -1,0 +1,59 @@
+import Testing
+@testable import Jovie
+
+struct AppShellDrawerThreadsFilterTests {
+  private let conversations = [
+    MobileConversationSummary(
+      id: "conv-1",
+      title: "Launch follow-up",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+      latestMessageRole: "assistant",
+      latestTurnStatus: "completed"
+    ),
+    MobileConversationSummary(
+      id: "conv-2",
+      title: "Release strategy",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-03T00:00:00Z",
+      latestMessageRole: "assistant",
+      latestTurnStatus: "completed"
+    ),
+  ]
+
+  @Test func emptyQueryReturnsAllConversations() {
+    let filtered = AppShellDrawerThreadsFilter.filtered(
+      conversations: conversations,
+      query: "   "
+    )
+
+    #expect(filtered == conversations)
+  }
+
+  @Test func queryMatchesConversationTitlesCaseInsensitively() {
+    let filtered = AppShellDrawerThreadsFilter.filtered(
+      conversations: conversations,
+      query: "LAUNCH"
+    )
+
+    #expect(filtered.map(\.id) == ["conv-1"])
+  }
+
+  @Test func queryFallsBackToNewConversationTitle() {
+    let untitled = MobileConversationSummary(
+      id: "conv-3",
+      title: nil,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-04T00:00:00Z",
+      latestMessageRole: "assistant",
+      latestTurnStatus: "completed"
+    )
+
+    let filtered = AppShellDrawerThreadsFilter.filtered(
+      conversations: [untitled],
+      query: "new"
+    )
+
+    #expect(filtered.map(\.id) == ["conv-3"])
+  }
+}

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -274,26 +274,34 @@ final class JovieUITests: XCTestCase {
     }
   }
 
-  func testShellMenuAndSettingsNavigationAreFullScreen() {
+  func testShellDrawerAndSettingsNavigation() {
     let app = launchMockApp(launchArgument: "-ui-testing-ready", expectedElementDescription: "\"Copy URL\"") {
       $0.buttons["Copy URL"]
     }
 
-    app.buttons["More"].tap()
+    app.buttons["Open navigation drawer"].tap()
     XCTAssertTrue(
-      app.staticTexts["Jovie"].waitForExistence(timeout: 3),
-      "Shell navigation did not reveal the menu.\n\(app.debugDescription)"
+      app.otherElements["shell-drawer"].waitForExistence(timeout: 3),
+      "Shell navigation did not reveal the left drawer.\n\(app.debugDescription)"
     )
     XCTAssertTrue(
       app.staticTexts["Start a conversation to see recent conversations here."].exists,
-      "Shell menu did not show the empty recent conversations state.\n\(app.debugDescription)"
+      "Shell drawer did not show the empty recent conversations state.\n\(app.debugDescription)"
+    )
+    XCTAssertTrue(app.buttons["New chat"].exists)
+    XCTAssertTrue(app.buttons["Settings"].exists)
+
+    app.buttons["Close navigation drawer"].tap()
+    XCTAssertTrue(
+      app.buttons["Copy URL"].waitForExistence(timeout: 3),
+      "Closing the drawer did not restore the profile surface.\n\(app.debugDescription)"
     )
 
-    app.buttons["Close Menu"].tap()
-    app.buttons["Open Settings"].tap()
+    app.buttons["Open navigation drawer"].tap()
+    app.buttons["Settings"].tap()
     XCTAssertTrue(
       app.staticTexts["Settings"].waitForExistence(timeout: 3),
-      "Shell navigation did not open settings.\n\(app.debugDescription)"
+      "Shell navigation did not open settings from the drawer.\n\(app.debugDescription)"
     )
   }
 


### PR DESCRIPTION
## Goal

Implement JOV-3633 — iOS left drawer navigation that mirrors the desktop left rail, giving creators account context, surface switching, New chat, searchable threads, and Settings in a cinematic slide-over panel.

<!-- linear-issue-id:JOV-3633 -->

## Changes

- **New `AppShellLeftDrawer`**: slide-over left drawer with 420ms cinematic easing (`cubic-bezier(0.22, 1, 0.36, 1)`), dimmed backdrop, and drag-to-dismiss
- **Account header**: avatar, display name, and handle/offline state
- **Surface switcher**: Profile / Chat pills matching bottom-nav destinations
- **New chat**: clears active conversation and switches to Chat
- **Threads + search**: full conversation list with case-insensitive title filter
- **Settings row**: navigates to existing Settings push destination
- **Open triggers**: avatar tap in shell toolbar + left-edge swipe (28pt hot zone)
- **Removed**: full-screen More menu and overflow button from bottom bar
- **Tests**: `AppShellDrawerThreadsFilterTests` + updated `testShellDrawerAndSettingsNavigation` UI test

## Testing

```bash
cd apps/ios
./scripts/run-xcodebuild.sh build
./scripts/run-xcodebuild.sh test -only-testing:JovieTests/AppShellDrawerThreadsFilterTests -only-testing:JovieTests/AppShellIntentNavigationTests -only-testing:JovieTests/SettingsEscapeTrapGuardTests
```

Manual: tap avatar or swipe from left edge → drawer slides in over content (not full-screen) → New chat / thread select / Settings work → backdrop tap or X closes.

---
*Generated by Cursor agent*