### PR TITLE
feat(chat): progressive disclosure entity accent spans + hover cards (JOV-3116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
-> Connector enrichment turns synced Gmail and Calendar objects into graph facts and calendar suggestions.
+> Connector enrichment turns synced Gmail and Calendar objects into graph facts and calendar suggestions; assistant chat replies surface entity mentions as subdued accent spans that reveal detail cards on hover.
 
 ### Added
 
 - **Connector enrichment pipelines (JOV-3114)**: adds `lib/connectors/enrichment/` with per-provider gmail/calendar pipelines that emit `context_facts`, memory graph observations, and `suggested_actions`; extends `context_fact_kind` for entity mentions; refactors `extractAndPropose` to sync Gmail `external_objects` then run the enrichment runner. Apple Photos deferred until JOV-2919.
+- **Chat progressive disclosure entity accents (JOV-3116)**: assistant responses parse `@kind:id[label]` wire tokens into per-type System B accent spans (release violet, artist purple, track blue, event orange) with hairline underlines instead of pills; hover/tap/focus opens the existing entity detail card with accent-tinted eyebrow copy. User bubbles keep rich input chips unchanged.
 
 ## [26.6.60] - 2026-06-28
 

--- a/apps/web/components/jovie/components/AssistantMessageText.test.tsx
+++ b/apps/web/components/jovie/components/AssistantMessageText.test.tsx
@@ -1,0 +1,55 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { fastRender } from '@/tests/utils/fast-render';
+import { AssistantMessageText } from './AssistantMessageText';
+
+vi.mock('./ChatMarkdown', () => ({
+  ChatMarkdown: ({ content }: { content: string }) => (
+    <div data-testid='chat-markdown'>{content}</div>
+  ),
+}));
+
+describe('AssistantMessageText', () => {
+  it('delegates plain assistant copy to ChatMarkdown', () => {
+    fastRender(
+      <AssistantMessageText content='Here is a plain assistant reply.' />
+    );
+
+    expect(screen.getByTestId('chat-markdown')).toHaveTextContent(
+      'Here is a plain assistant reply.'
+    );
+    expect(screen.queryByTestId('entity-mention-span')).toBeNull();
+  });
+
+  it('renders entity wire tokens as subdued mention spans with hover cards', async () => {
+    const user = userEvent.setup();
+    fastRender(
+      <AssistantMessageText content='Listen to @release:rel_1[Sober] tonight.' />
+    );
+
+    const span = screen.getByTestId('entity-mention-span');
+    expect(span).toHaveTextContent('Sober');
+    expect(span).toHaveClass('system-b-entity-mention-span');
+    const markdownSegments = screen.getAllByTestId('chat-markdown');
+    expect(markdownSegments[0]).toHaveTextContent('Listen to');
+    expect(markdownSegments[1]).toHaveTextContent('tonight.');
+    expect(screen.queryByText('@release:rel_1[Sober]')).toBeNull();
+
+    await user.click(screen.getByTestId('entity-chip-popover-trigger'));
+    const content = await screen.findByTestId('entity-chip-popover-content');
+    expect(content).toHaveAttribute('data-entity-kind', 'release');
+    expect(content.textContent).toContain('Sober');
+  });
+
+  it('renders skill tokens as neutral assistant mentions', () => {
+    fastRender(
+      <AssistantMessageText content='Try /skill:generateAlbumArt next.' />
+    );
+
+    expect(screen.getByTestId('assistant-skill-mention')).toHaveTextContent(
+      'Generate album art'
+    );
+    expect(screen.queryByText('/skill:generateAlbumArt')).toBeNull();
+  });
+});

--- a/apps/web/components/jovie/components/AssistantMessageText.tsx
+++ b/apps/web/components/jovie/components/AssistantMessageText.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useMemo } from 'react';
+import { type ChatToken, parseTokens } from '@/lib/chat/tokens';
+import { skillById } from '@/lib/commands/registry';
+import { ChatMarkdown } from './ChatMarkdown';
+import { EntityChipPopover } from './EntityChipPopover';
+import { EntityMentionSpan } from './EntityMentionSpan';
+import { useEntityResolution } from './EntityResolutionProvider';
+
+function tokenKey(token: ChatToken, index: number): string {
+  if (token.type === 'text') return `t:${index}:${token.value.length}`;
+  if (token.type === 'entity') {
+    return `${token.kind}:${token.id}:${index}`;
+  }
+  return `skill:${token.id}:${index}`;
+}
+
+interface AssistantMessageTextProps {
+  readonly content: string;
+  readonly isStreaming?: boolean;
+}
+
+/**
+ * Renders assistant reply text with progressive-disclosure entity spans.
+ * Wire tokens become subdued accent underlines; hover opens the detail card.
+ * Plain markdown segments still flow through `ChatMarkdown`.
+ */
+export function AssistantMessageText({
+  content,
+  isStreaming = false,
+}: AssistantMessageTextProps) {
+  const tokens = useMemo(() => parseTokens(content), [content]);
+
+  if (tokens.length === 1 && tokens[0]?.type === 'text') {
+    return <ChatMarkdown content={content} isStreaming={isStreaming} />;
+  }
+
+  return (
+    <>
+      {tokens.map((token, index) => {
+        const key = tokenKey(token, index);
+        if (token.type === 'text') {
+          return (
+            <ChatMarkdown
+              key={key}
+              content={token.value}
+              isStreaming={isStreaming}
+            />
+          );
+        }
+        if (token.type === 'entity') {
+          return (
+            <AssistantEntityMention
+              key={key}
+              kind={token.kind}
+              id={token.id}
+              label={token.label}
+            />
+          );
+        }
+        return <AssistantSkillMention key={key} id={token.id} />;
+      })}
+    </>
+  );
+}
+
+interface AssistantEntityMentionProps {
+  readonly kind: 'release' | 'artist' | 'track' | 'event';
+  readonly id: string;
+  readonly label: string;
+}
+
+function AssistantEntityMention({
+  kind,
+  id,
+  label,
+}: AssistantEntityMentionProps) {
+  const { ref: resolved } = useEntityResolution(kind, id);
+
+  return (
+    <EntityChipPopover kind={kind} id={id} label={label} entity={resolved}>
+      <EntityMentionSpan kind={kind} label={label} />
+    </EntityChipPopover>
+  );
+}
+
+function AssistantSkillMention({ id }: { readonly id: string }) {
+  const label = skillById(id)?.label ?? id;
+  return (
+    <span
+      className='system-b-assistant-skill-mention'
+      data-testid='assistant-skill-mention'
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { getRenderableToolEvents, ToolPartsRenderer } from '../tool-ui';
 import type { MessagePart } from '../types';
 import { getMessageText } from '../utils';
-import { ChatMarkdown } from './ChatMarkdown';
+import { AssistantMessageText } from './AssistantMessageText';
 import { ImageAttachmentChip } from './ImageAttachmentChip';
 import { TokenizedText } from './TokenizedText';
 
@@ -199,7 +199,7 @@ export const ChatMessage = memo(function ChatMessage({
                   data-testid='chat-message-reply'
                   className='system-b-chat-message-reply'
                 >
-                  <ChatMarkdown
+                  <AssistantMessageText
                     content={messageText}
                     isStreaming={Boolean(isStreaming)}
                   />

--- a/apps/web/components/jovie/components/EntityChip.tsx
+++ b/apps/web/components/jovie/components/EntityChip.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react';
 import Image from 'next/image';
 import { type CSSProperties } from 'react';
 import type { EntityKind } from '@/lib/chat/tokens';
+import { ENTITY_KIND_ACCENT_VAR } from './entity-accent';
 
 export interface EntityChipData {
   readonly kind: EntityKind;
@@ -37,13 +38,6 @@ const KIND_PREFIX: Record<EntityKind, string> = {
   event: 'Event',
 };
 
-const KIND_ACCENT_VAR: Record<EntityKind, string> = {
-  release: '--system-b-entity-chip-release-accent',
-  artist: '--system-b-entity-chip-artist-accent',
-  track: '--system-b-entity-chip-track-accent',
-  event: '--system-b-entity-chip-event-accent',
-};
-
 /**
  * Non-interactive presentational chip primitive. Interaction (click, popover,
  * keyboard activation) is the wrapper's job — wrapping `EntityChip` in
@@ -70,7 +64,7 @@ export function EntityChip({
       }
     : {};
   const accentStyle = {
-    '--jovie-entity-accent': `var(${KIND_ACCENT_VAR[data.kind]})`,
+    '--jovie-entity-accent': `var(${ENTITY_KIND_ACCENT_VAR[data.kind]})`,
   } as CSSProperties;
 
   const commonClassName = 'system-b-entity-chip';

--- a/apps/web/components/jovie/components/EntityChipPopover.tsx
+++ b/apps/web/components/jovie/components/EntityChipPopover.tsx
@@ -4,6 +4,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@jovie/ui';
 import { ArrowUpRight } from 'lucide-react';
 import Image from 'next/image';
 import {
+  type CSSProperties,
   type KeyboardEvent,
   type ReactNode,
   type PointerEvent as ReactPointerEvent,
@@ -19,6 +20,7 @@ import type { EntityKind } from '@/lib/chat/tokens';
 import type { EntityRef, EntityRefMeta } from '@/lib/commands/entities';
 import { useAppFlag } from '@/lib/flags/client';
 import { getInitials } from '@/lib/utils/initials';
+import { ENTITY_KIND_ACCENT_VAR } from './entity-accent';
 
 const HOVER_OPEN_DELAY_MS = 200;
 const HOVER_CLOSE_DELAY_MS = 120;
@@ -177,6 +179,12 @@ export function EntityChipPopover({
         sideOffset={6}
         align='start'
         testId='entity-chip-popover-content'
+        data-entity-kind={kind}
+        style={
+          {
+            '--jovie-entity-accent': `var(${ENTITY_KIND_ACCENT_VAR[kind]})`,
+          } as CSSProperties
+        }
         onPointerEnter={() => {
           // Keep the popover open while the cursor is over its content.
           clearTimers();

--- a/apps/web/components/jovie/components/EntityMentionSpan.test.tsx
+++ b/apps/web/components/jovie/components/EntityMentionSpan.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { fastRender } from '@/tests/utils/fast-render';
+import { EntityMentionSpan } from './EntityMentionSpan';
+
+describe('EntityMentionSpan', () => {
+  it.each([
+    ['release', '--system-b-entity-chip-release-accent'],
+    ['artist', '--system-b-entity-chip-artist-accent'],
+    ['track', '--system-b-entity-chip-track-accent'],
+    ['event', '--system-b-entity-chip-event-accent'],
+  ] as const)('maps kind=%s to the System B accent variable', (kind, accentVar) => {
+    fastRender(<EntityMentionSpan kind={kind} label={`${kind} label`} />);
+
+    const span = screen.getByTestId('entity-mention-span');
+    expect(span).toHaveTextContent(`${kind} label`);
+    expect(span).toHaveAttribute('data-entity-kind', kind);
+    expect(span).toHaveClass('system-b-entity-mention-span');
+    expect(span.style.getPropertyValue('--jovie-entity-accent')).toBe(
+      `var(${accentVar})`
+    );
+  });
+});

--- a/apps/web/components/jovie/components/EntityMentionSpan.tsx
+++ b/apps/web/components/jovie/components/EntityMentionSpan.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { type CSSProperties } from 'react';
+import type { EntityKind } from '@/lib/chat/tokens';
+import { ENTITY_KIND_ACCENT_VAR } from './entity-accent';
+
+interface EntityMentionSpanProps {
+  readonly kind: EntityKind;
+  readonly label: string;
+}
+
+/**
+ * Subdued inline entity mention for assistant transcript copy.
+ * Progressive disclosure: tinted label + hairline accent underline at rest;
+ * hover/focus detail lives in the wrapping `EntityChipPopover` trigger.
+ */
+export function EntityMentionSpan({ kind, label }: EntityMentionSpanProps) {
+  const accentStyle = {
+    '--jovie-entity-accent': `var(${ENTITY_KIND_ACCENT_VAR[kind]})`,
+  } as CSSProperties;
+
+  return (
+    <span
+      className='system-b-entity-mention-span'
+      style={accentStyle}
+      data-testid='entity-mention-span'
+      data-entity-kind={kind}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/components/jovie/components/entity-accent.ts
+++ b/apps/web/components/jovie/components/entity-accent.ts
@@ -1,0 +1,13 @@
+import type { EntityKind } from '@/lib/chat/tokens';
+
+/** Per-kind System B accent aliases for entity chips and inline mention spans. */
+export const ENTITY_KIND_ACCENT_VAR: Record<EntityKind, string> = {
+  release: '--system-b-entity-chip-release-accent',
+  artist: '--system-b-entity-chip-artist-accent',
+  track: '--system-b-entity-chip-track-accent',
+  event: '--system-b-entity-chip-event-accent',
+};
+
+export function entityAccentCssVar(kind: EntityKind): string {
+  return `var(${ENTITY_KIND_ACCENT_VAR[kind]})`;
+}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -92,9 +92,9 @@
   --system-b-app-content-surface: var(--app-shell-content-surface);
   --system-b-accent-cyan: var(--geist-cyan-solid);
   --system-b-entity-chip-release-accent: var(--color-accent);
-  --system-b-entity-chip-artist-accent: var(--color-info);
-  --system-b-entity-chip-track-accent: var(--color-accent-pink);
-  --system-b-entity-chip-event-accent: var(--color-success);
+  --system-b-entity-chip-artist-accent: var(--color-accent-purple);
+  --system-b-entity-chip-track-accent: var(--color-accent-blue);
+  --system-b-entity-chip-event-accent: var(--color-accent-orange);
   --system-b-entity-chip-on-light-text: var(--color-text-primary-token);
   --system-b-chat-message-max-width: 78%;
   --system-b-chat-user-bubble-bg: var(--color-text-primary-token);
@@ -4622,6 +4622,41 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   background: var(--system-b-bg-surface-1);
 }
 
+.system-b-entity-mention-span {
+  display: inline;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--jovie-entity-accent) 28%, transparent);
+  color: color-mix(
+    in srgb,
+    var(--jovie-entity-accent) 72%,
+    var(--color-text-primary-token) 28%
+  );
+  text-decoration: none;
+  transition:
+    border-color var(--system-b-duration-fast) var(--system-b-ease),
+    color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-entity-chip-trigger:hover) .system-b-entity-mention-span,
+:where(.system-b-entity-chip-trigger:focus-visible)
+  .system-b-entity-mention-span {
+  border-bottom-color: color-mix(
+    in srgb,
+    var(--jovie-entity-accent) 52%,
+    transparent
+  );
+  color: color-mix(
+    in srgb,
+    var(--jovie-entity-accent) 82%,
+    var(--color-text-primary-token) 18%
+  );
+}
+
+.system-b-assistant-skill-mention {
+  color: var(--color-text-secondary-token);
+  font-weight: var(--font-weight-medium);
+}
+
 .system-b-entity-chip {
   display: inline-flex;
   align-items: center;
@@ -5104,7 +5139,11 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(.system-b-entity-chip-popover-eyebrow) {
-  color: var(--color-text-tertiary-token);
+  color: color-mix(
+    in srgb,
+    var(--jovie-entity-accent, var(--color-text-tertiary-token)) 68%,
+    var(--color-text-tertiary-token) 32%
+  );
   font-family: var(--font-caption);
   font-size: var(--text-2xs);
 }

--- a/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it } from 'vitest';
 const webRoot = path.resolve(__dirname, '../../..');
 
 const guardedFiles = [
+  'components/jovie/components/AssistantMessageText.tsx',
   'components/jovie/components/ChatGenerationArtifactSurface.tsx',
   'components/jovie/components/ChatPitchCard.tsx',
   'components/jovie/components/EntityChip.tsx',
   'components/jovie/components/EntityChipPopover.tsx',
+  'components/jovie/components/EntityMentionSpan.tsx',
   'components/jovie/components/EntityPreviewPane.tsx',
   'components/jovie/components/SkillChip.tsx',
   'components/shell/DspAvatarStack.tsx',
@@ -75,6 +77,19 @@ describe('entity rich chip System B style guard', () => {
     expect(transcriptDotInnerCss).toContain(
       'background: var(--jovie-entity-accent);'
     );
+  });
+
+  it('keeps assistant entity mention spans on named System B primitives', () => {
+    const source = readFileSync(
+      path.join(webRoot, 'styles/design-system.css'),
+      'utf8'
+    );
+    const mentionCss = source.match(
+      /\.system-b-entity-mention-span\s*\{[\s\S]*?\n\}/
+    )?.[0];
+
+    expect(mentionCss).toContain('var(--jovie-entity-accent)');
+    expect(mentionCss).not.toContain('border-radius: var(--radius-full)');
   });
 
   it('keeps entity chip popover internals on named System B primitives', () => {


### PR DESCRIPTION
## Goal

Make the memory graph legible in assistant chat replies: entity mentions render as subdued per-type accent spans that reveal detail cards on hover, without turning the transcript into a wall of pills.

<!-- linear-issue-id:JOV-3116 -->

## Changes

- Add `EntityMentionSpan` + `AssistantMessageText` to parse `@kind:id[label]` wire tokens in assistant replies
- Map entity kinds to System B accent spectrum (release violet, artist purple, track blue, event orange)
- Reuse `EntityChipPopover` hover detail cards with accent-tinted eyebrow copy
- Keep user-message rich chips unchanged (progressive disclosure applies to assistant copy)
- Add unit tests + System B style guard coverage

## Testing

- `pnpm --filter @jovie/web test -- components/jovie/components/EntityMentionSpan.test.tsx components/jovie/components/AssistantMessageText.test.tsx tests/unit/chat/entity-rich-chip-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck`

🤖 Generated with [Cursor](https://cursor.com)