### PR TITLE
feat(ios): composer workflow bottom sheet (JOV-3639)

### DIFF
--- a/apps/ios/Jovie.xcodeproj/project.pbxproj
+++ b/apps/ios/Jovie.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		A0J0V25490000000000000006 /* MobileChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000005 /* MobileChatClient.swift */; };
 		A0J0V25490000000000000008 /* MobileChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000007 /* MobileChatModels.swift */; };
 		A0J0V2549000000000000000A /* MobileChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V25490000000000000009 /* MobileChatView.swift */; };
+		A0J0V36390000000000000002 /* ComposerWorkflowSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V36390000000000000001 /* ComposerWorkflowSheet.swift */; };
+		A0J0V36390000000000000004 /* ComposerWorkflowSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V36390000000000000003 /* ComposerWorkflowSheetTests.swift */; };
 		A0J0V2549000000000000000C /* ChatRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V2549000000000000000B /* ChatRepositoryTests.swift */; };
 		A0J0V2549000000000000000E /* MobileChatClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V2549000000000000000D /* MobileChatClientTests.swift */; };
 		A0J0V36070000000000000002 /* MobileChatContentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V36070000000000000001 /* MobileChatContentParser.swift */; };
@@ -164,6 +166,8 @@
 		A0J0V25490000000000000005 /* MobileChatClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatClient.swift; sourceTree = "<group>"; };
 		A0J0V25490000000000000007 /* MobileChatModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatModels.swift; sourceTree = "<group>"; };
 		A0J0V25490000000000000009 /* MobileChatView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatView.swift; sourceTree = "<group>"; };
+		A0J0V36390000000000000001 /* ComposerWorkflowSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComposerWorkflowSheet.swift; sourceTree = "<group>"; };
+		A0J0V36390000000000000003 /* ComposerWorkflowSheetTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComposerWorkflowSheetTests.swift; sourceTree = "<group>"; };
 		A0J0V2549000000000000000B /* ChatRepositoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatRepositoryTests.swift; sourceTree = "<group>"; };
 		A0J0V2549000000000000000D /* MobileChatClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatClientTests.swift; sourceTree = "<group>"; };
 		A0J0V36070000000000000001 /* MobileChatContentParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileChatContentParser.swift; sourceTree = "<group>"; };
@@ -282,6 +286,7 @@
 				F1E2D3C4B5A697886756453E /* SettingsEscapeTrapGuardTests.swift */,
 				A0J0V2549000000000000000B /* ChatRepositoryTests.swift */,
 				A0J0V2549000000000000000D /* MobileChatClientTests.swift */,
+				A0J0V36390000000000000003 /* ComposerWorkflowSheetTests.swift */,
 				A0J0V36070000000000000005 /* MobileChatContentParserTests.swift */,
 				191669F70597A1039C74C0B1 /* MeRepositoryTests.swift */,
 				B83A77F0A36DF3E6D5C77C2F /* MobileMeResponseTests.swift */,
@@ -437,6 +442,7 @@
 		A0J0V25490000000000000010 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
+				A0J0V36390000000000000001 /* ComposerWorkflowSheet.swift */,
 				A0J0V25490000000000000009 /* MobileChatView.swift */,
 				A0J0V36070000000000000003 /* MobileChatToolCardView.swift */,
 			);
@@ -631,6 +637,7 @@
 				EE4CBA88057592FAFCD7F926 /* AppStateTests.swift in Sources */,
 				A0J0V2549000000000000000C /* ChatRepositoryTests.swift in Sources */,
 				A0J0V2549000000000000000E /* MobileChatClientTests.swift in Sources */,
+				A0J0V36390000000000000004 /* ComposerWorkflowSheetTests.swift in Sources */,
 				A0J0V36070000000000000006 /* MobileChatContentParserTests.swift in Sources */,
 				FDD930D67ACF374B16E87FDE /* MeRepositoryTests.swift in Sources */,
 				CE7C4C47EFA23AFA2B205BE4 /* MobileMeResponseTests.swift in Sources */,
@@ -695,6 +702,7 @@
 				BE57F23AE56E75A83692D03D /* VenueModeView.swift in Sources */,
 				F3E8220C7612A63FF54DB345 /* NeedsOnboardingView.swift in Sources */,
 				F178AB3E908746C78645E4EE /* SettingsView.swift in Sources */,
+				A0J0V36390000000000000002 /* ComposerWorkflowSheet.swift in Sources */,
 				A0J0V2549000000000000000A /* MobileChatView.swift in Sources */,
 				A0J0V36070000000000000004 /* MobileChatToolCardView.swift in Sources */,
 				FA8D45F4123178BDD33F82C5 /* SplashView.swift in Sources */,

--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -435,40 +435,16 @@ private struct ChatComposerPreview: View {
   let isOffline: Bool
 
   var body: some View {
-    let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-
-    HStack(spacing: JovieSpacing.medium) {
-      TextField(isOffline ? "Ask Jovie (offline)" : "Ask Jovie", text: $draft)
-        .textInputAutocapitalization(.sentences)
-        .disableAutocorrection(false)
-        .font(JovieFont.body(size: 16))
-        .foregroundStyle(JovieColor.textPrimary)
-        .frame(height: 52)
-
-      Button {
-        draft = ""
-      } label: {
-        Image(systemName: "arrow.up")
-          .font(.system(size: 16, weight: .bold))
-          .foregroundStyle(trimmedDraft.isEmpty ? JovieColor.textTertiary : JovieColor.backgroundBase)
-          .frame(width: 36, height: 36)
-          .background(
-            trimmedDraft.isEmpty ? JovieColor.surface2 : Color.white,
-            in: Circle()
-          )
+    ChatComposerBar(
+      draft: $draft,
+      placeholder: isOffline ? "Ask Jovie (offline)" : "Ask Jovie",
+      isSending: false,
+      isPlusEnabled: true,
+      onSend: { draft = "" },
+      onSelectWorkflow: { action in
+        draft = action.prompt
       }
-      .buttonStyle(.plain)
-      .disabled(trimmedDraft.isEmpty)
-      .accessibilityLabel("Send")
-    }
-    .padding(.horizontal, JovieSpacing.large)
-    .frame(height: 64)
-    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
-    .overlay {
-      RoundedRectangle(cornerRadius: 28, style: .continuous)
-        .stroke(JovieColor.borderDefault, lineWidth: 1)
-    }
-    .accessibilityIdentifier("chat-composer")
+    )
   }
 }
 

--- a/apps/ios/Jovie/Features/Chat/ComposerWorkflowSheet.swift
+++ b/apps/ios/Jovie/Features/Chat/ComposerWorkflowSheet.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+
+enum ComposerWorkflowAction: String, CaseIterable, Identifiable {
+  case makeMerch
+  case smartLink
+  case camera
+  case photoFile
+  case releaseCampaign
+  case lyricVideo
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .makeMerch:
+      return "Make merch"
+    case .smartLink:
+      return "Smart link"
+    case .camera:
+      return "Camera"
+    case .photoFile:
+      return "Photo/file"
+    case .releaseCampaign:
+      return "Release campaign"
+    case .lyricVideo:
+      return "Lyric video"
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .makeMerch:
+      return "tshirt"
+    case .smartLink:
+      return "link"
+    case .camera:
+      return "camera"
+    case .photoFile:
+      return "photo.on.rectangle.angled"
+    case .releaseCampaign:
+      return "calendar.badge.clock"
+    case .lyricVideo:
+      return "play.rectangle"
+    }
+  }
+
+  var prompt: String {
+    switch self {
+    case .makeMerch:
+      return "Make merch for my latest release."
+    case .smartLink:
+      return "Help me set up a smart link for my release."
+    case .camera:
+      return "I want to take a photo for my release."
+    case .photoFile:
+      return "I want to upload a photo or file."
+    case .releaseCampaign:
+      return "Help me plan a release campaign."
+    case .lyricVideo:
+      return "Generate a lyric video for my latest release."
+    }
+  }
+
+  var accessibilityIdentifier: String {
+    "composer-workflow-\(rawValue)"
+  }
+}
+
+struct ComposerWorkflowSheet: View {
+  let onSelect: (ComposerWorkflowAction) -> Void
+
+  private let columns = [
+    GridItem(.flexible(), spacing: JovieSpacing.medium),
+    GridItem(.flexible(), spacing: JovieSpacing.medium),
+  ]
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.large) {
+      Capsule()
+        .fill(JovieColor.borderDefault)
+        .frame(width: 36, height: 4)
+        .frame(maxWidth: .infinity)
+
+      Text("Start a workflow")
+        .font(JovieFont.body(size: 15, weight: .semibold))
+        .foregroundStyle(JovieColor.textPrimary)
+
+      LazyVGrid(columns: columns, spacing: JovieSpacing.medium) {
+        ForEach(ComposerWorkflowAction.allCases) { action in
+          Button {
+            onSelect(action)
+          } label: {
+            ComposerWorkflowTile(action: action)
+          }
+          .buttonStyle(.plain)
+          .accessibilityLabel(action.title)
+          .accessibilityIdentifier(action.accessibilityIdentifier)
+        }
+      }
+    }
+    .padding(.horizontal, JovieSpacing.xLarge)
+    .padding(.top, JovieSpacing.medium)
+    .padding(.bottom, JovieSpacing.xLarge)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(JovieColor.surface0)
+    .accessibilityIdentifier("composer-workflow-sheet")
+    .accessibilityAddTraits(.isModal)
+  }
+}
+
+private struct ComposerWorkflowTile: View {
+  let action: ComposerWorkflowAction
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.small) {
+      Image(systemName: action.systemImage)
+        .font(.system(size: 18, weight: .semibold))
+        .foregroundStyle(JovieColor.textPrimary)
+        .frame(width: 36, height: 36)
+        .background(JovieColor.surface2, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+      Text(action.title)
+        .font(JovieFont.body(size: 14, weight: .semibold))
+        .foregroundStyle(JovieColor.textPrimary)
+        .multilineTextAlignment(.leading)
+        .lineLimit(2)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .frame(maxWidth: .infinity, minHeight: 92, alignment: .topLeading)
+    .padding(JovieSpacing.medium)
+    .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
+        .stroke(JovieColor.borderDefault, lineWidth: 1)
+    }
+  }
+}
+
+struct ChatComposerBar: View {
+  @Binding var draft: String
+  let placeholder: String
+  let isSending: Bool
+  let isPlusEnabled: Bool
+  let onSend: () -> Void
+  let onSelectWorkflow: (ComposerWorkflowAction) -> Void
+
+  @State private var isShowingWorkflowSheet = false
+
+  var body: some View {
+    let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    HStack(spacing: JovieSpacing.medium) {
+      Button {
+        isShowingWorkflowSheet = true
+      } label: {
+        Image(systemName: "plus")
+          .font(.system(size: 18, weight: .semibold))
+          .foregroundStyle(
+            isPlusEnabled ? JovieColor.textPrimary : JovieColor.textTertiary
+          )
+          .frame(width: 36, height: 36)
+          .background(JovieColor.surface2, in: Circle())
+      }
+      .buttonStyle(.plain)
+      .disabled(!isPlusEnabled)
+      .accessibilityLabel("Open workflow sheet")
+      .accessibilityIdentifier("chat-composer-plus")
+      .accessibilityElement(children: .ignore)
+
+      TextField(placeholder, text: $draft)
+        .textInputAutocapitalization(.sentences)
+        .disableAutocorrection(false)
+        .font(JovieFont.body(size: 16))
+        .foregroundStyle(JovieColor.textPrimary)
+        .frame(height: 52)
+
+      Button(action: onSend) {
+        Image(systemName: isSending ? "ellipsis" : "arrow.up")
+          .font(.system(size: 16, weight: .bold))
+          .foregroundStyle(
+            trimmedDraft.isEmpty || isSending
+              ? JovieColor.textTertiary
+              : JovieColor.backgroundBase
+          )
+          .frame(width: 36, height: 36)
+          .background(
+            trimmedDraft.isEmpty || isSending ? JovieColor.surface2 : Color.white,
+            in: Circle()
+          )
+      }
+      .buttonStyle(.plain)
+      .disabled(trimmedDraft.isEmpty || isSending)
+      .accessibilityLabel("Send")
+    }
+    .padding(.horizontal, JovieSpacing.large)
+    .frame(height: 64)
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 28, style: .continuous)
+        .stroke(JovieColor.borderDefault, lineWidth: 1)
+    }
+    .accessibilityIdentifier("chat-composer")
+    .sheet(isPresented: $isShowingWorkflowSheet) {
+      ComposerWorkflowSheet { action in
+        isShowingWorkflowSheet = false
+        onSelectWorkflow(action)
+      }
+      .presentationDetents([.height(ComposerWorkflowSheetHeight.estimated)])
+      .presentationDragIndicator(.visible)
+      .presentationBackground(JovieColor.surface0)
+    }
+  }
+}
+
+enum ComposerWorkflowSheetHeight {
+  static let estimated: CGFloat = 360
+}

--- a/apps/ios/Jovie/Features/Chat/MobileChatView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatView.swift
@@ -40,12 +40,16 @@ struct MobileChatView: View {
         ChatComposerView(
           draft: $draft,
           isSending: repository.isSending,
-          isOffline: repository.isOffline
-        ) {
-          let text = draft
-          draft = ""
-          Task { await repository.send(text: text) }
-        }
+          isOffline: repository.isOffline,
+          onSend: {
+            let text = draft
+            draft = ""
+            Task { await repository.send(text: text) }
+          },
+          onSelectWorkflow: { action in
+            draft = action.prompt
+          }
+        )
         .padding(.horizontal, JovieSpacing.large)
         .padding(.bottom, JovieSpacing.medium)
       }
@@ -180,43 +184,16 @@ private struct ChatComposerView: View {
   let isSending: Bool
   let isOffline: Bool
   let onSend: () -> Void
+  let onSelectWorkflow: (ComposerWorkflowAction) -> Void
 
   var body: some View {
-    let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-
-    HStack(spacing: JovieSpacing.medium) {
-      TextField(isOffline ? "Ask Jovie (offline)" : "Ask Jovie", text: $draft)
-        .textInputAutocapitalization(.sentences)
-        .disableAutocorrection(false)
-        .font(JovieFont.body(size: 16))
-        .foregroundStyle(JovieColor.textPrimary)
-        .frame(height: 52)
-
-      Button(action: onSend) {
-        Image(systemName: isSending ? "ellipsis" : "arrow.up")
-          .font(.system(size: 16, weight: .bold))
-          .foregroundStyle(
-            trimmedDraft.isEmpty || isSending
-              ? JovieColor.textTertiary
-              : JovieColor.backgroundBase
-          )
-          .frame(width: 36, height: 36)
-          .background(
-            trimmedDraft.isEmpty || isSending ? JovieColor.surface2 : Color.white,
-            in: Circle()
-          )
-      }
-      .buttonStyle(.plain)
-      .disabled(trimmedDraft.isEmpty || isSending)
-      .accessibilityLabel("Send")
-    }
-    .padding(.horizontal, JovieSpacing.large)
-    .frame(height: 64)
-    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
-    .overlay {
-      RoundedRectangle(cornerRadius: 28, style: .continuous)
-        .stroke(JovieColor.borderDefault, lineWidth: 1)
-    }
-    .accessibilityIdentifier("chat-composer")
+    ChatComposerBar(
+      draft: $draft,
+      placeholder: isOffline ? "Ask Jovie (offline)" : "Ask Jovie",
+      isSending: isSending,
+      isPlusEnabled: !isSending,
+      onSend: onSend,
+      onSelectWorkflow: onSelectWorkflow
+    )
   }
 }

--- a/apps/ios/JovieTests/ComposerWorkflowSheetTests.swift
+++ b/apps/ios/JovieTests/ComposerWorkflowSheetTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Jovie
+
+final class ComposerWorkflowSheetTests: XCTestCase {
+  func testWorkflowActionsExposeCanonicalGridLabels() {
+    let titles = ComposerWorkflowAction.allCases.map(\.title)
+    XCTAssertEqual(
+      titles,
+      [
+        "Make merch",
+        "Smart link",
+        "Camera",
+        "Photo/file",
+        "Release campaign",
+        "Lyric video",
+      ]
+    )
+  }
+
+  func testWorkflowActionsProvideNonEmptyPrompts() {
+    for action in ComposerWorkflowAction.allCases {
+      XCTAssertFalse(action.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      XCTAssertFalse(action.systemImage.isEmpty)
+      XCTAssertFalse(action.accessibilityIdentifier.isEmpty)
+    }
+  }
+
+  func testWorkflowSheetHeightReservesStableFootprint() {
+    XCTAssertGreaterThanOrEqual(ComposerWorkflowSheetHeight.estimated, 320)
+  }
+}

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -200,6 +200,51 @@ final class JovieUITests: XCTestCase {
     )
   }
 
+  func testChatComposerWorkflowSheetShowsWorkflowGrid() {
+    let app = launchMockApp(launchArgument: "-ui-testing-chat", expectedElementDescription: "\"Ask Jovie\"") {
+      $0.textFields["Ask Jovie"]
+    }
+
+    let plusButton = app.buttons["Open workflow sheet"]
+    XCTAssertTrue(
+      waitForHittable(plusButton, timeout: 3),
+      "Chat composer plus button did not become hittable.\n\(app.debugDescription)"
+    )
+
+    plusButton.tap()
+
+    XCTAssertTrue(
+      app.buttons["Make merch"].waitForExistence(timeout: 3),
+      "Workflow sheet did not appear.\n\(app.debugDescription)"
+    )
+    for title in [
+      "Make merch",
+      "Smart link",
+      "Camera",
+      "Photo/file",
+      "Release campaign",
+      "Lyric video",
+    ] {
+      XCTAssertTrue(
+        app.buttons[title].waitForExistence(timeout: 2),
+        "Workflow action \(title) did not appear.\n\(app.debugDescription)"
+      )
+    }
+
+    app.buttons["Make merch"].tap()
+
+    let input = app.textFields["Ask Jovie"]
+    XCTAssertTrue(
+      waitForHittable(input, timeout: 3),
+      "Chat composer input did not become hittable after workflow selection.\n\(app.debugDescription)"
+    )
+    XCTAssertEqual(
+      input.value as? String,
+      "Make merch for my latest release.",
+      "Workflow selection did not prefill the composer draft.\n\(app.debugDescription)"
+    )
+  }
+
   func testChatComposerPreservesDraftAcrossShellNavigation() {
     let app = launchMockApp(launchArgument: "-ui-testing-chat", expectedElementDescription: "\"Ask Jovie\"") {
       $0.textFields["Ask Jovie"]


### PR DESCRIPTION
## Goal

Add the chat composer + workflow bottom sheet on iOS with a 2-column grid of release workflows, matching JOV-3639.

<!-- linear-issue-id:JOV-3639 -->

## Changes

- Add `ComposerWorkflowSheet` with six workflow tiles: Make merch, Smart link, Camera, Photo/file, Release campaign, Lyric video
- Extract shared `ChatComposerBar` with leading + button and wire into `MobileChatView` and mock chat placeholder
- Selecting a workflow prefills the composer draft with the matching prompt
- Add unit coverage for workflow labels/prompts and a UI test for sheet open + draft prefill

## Testing

- `pnpm run ios:lint`
- `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieTests/ComposerWorkflowSheetTests`
- `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieUITests/JovieUITests/testChatComposerWorkflowSheetShowsWorkflowGrid`

Co-authored-by: Cursor <cursoragent@cursor.com>