### PR TITLE
docs(memory): complete MEMORY_CORE_ARCHITECTURE acceptance (JOV-2705)

### DIFF
--- a/apps/web/tests/unit/memory/memory-adr-contract.test.ts
+++ b/apps/web/tests/unit/memory/memory-adr-contract.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, it } from 'vitest';
 
 const REPO_ROOT = join(process.cwd(), '../..');
 const MEMORY_ADR_PATH = join(REPO_ROOT, 'docs/MEMORY_ADR.md');
+const MEMORY_CORE_ARCH_PATH = join(
+  REPO_ROOT,
+  'docs/MEMORY_CORE_ARCHITECTURE.md'
+);
 const WEB_ROOT = join(REPO_ROOT, 'apps/web');
 
 const REQUIRED_ADR_SECTIONS = [
@@ -12,6 +16,15 @@ const REQUIRED_ADR_SECTIONS = [
   '## Context',
   '## Current file map',
   '## Forbidden couplings',
+] as const;
+
+const REQUIRED_MEMORY_CORE_SECTIONS = [
+  '## Decision',
+  '## Why WDK stays in AgentOS',
+  '## Product workflow boundaries',
+  '## v0 shipped target',
+  '## Technology decision table',
+  '## Linear triage',
 ] as const;
 
 const PRODUCT_MEMORY_PATHS = [
@@ -94,13 +107,40 @@ describe('MEMORY ADR contract (JOV-2705)', () => {
     }
   });
 
+  it('keeps docs/MEMORY_CORE_ARCHITECTURE.md present with required sections', () => {
+    expect(existsSync(MEMORY_CORE_ARCH_PATH)).toBe(true);
+
+    const arch = readFileSync(MEMORY_CORE_ARCH_PATH, 'utf8');
+    expect(arch).toContain('Issue: JOV-2705');
+    expect(arch).toContain('Trigger.dev');
+    expect(arch).toContain('OpenAI Agents SDK');
+    expect(arch).toContain('studio-session-loop.ts');
+    expect(arch).toContain('Graphiti');
+    expect(arch).toContain('Honcho');
+
+    for (const section of REQUIRED_MEMORY_CORE_SECTIONS) {
+      expect(arch, `missing ${section}`).toContain(section);
+    }
+  });
+
   it('links AgentOS architecture without collapsing the runtime split', () => {
     const agentOsAdrPath = join(REPO_ROOT, 'docs/AGENT_OS_ARCHITECTURE.md');
     expect(existsSync(agentOsAdrPath)).toBe(true);
 
     const agentOsAdr = readFileSync(agentOsAdrPath, 'utf8');
+    expect(agentOsAdr).toContain('MEMORY_CORE_ARCHITECTURE.md');
     expect(agentOsAdr).toContain('MEMORY_ADR.md');
     expect(agentOsAdr).toContain('JOV-2705');
+  });
+
+  it('documents the product-memory split in AUTOMATION_AUDIT.md', () => {
+    const automationAuditPath = join(REPO_ROOT, 'docs/AUTOMATION_AUDIT.md');
+    expect(existsSync(automationAuditPath)).toBe(true);
+
+    const audit = readFileSync(automationAuditPath, 'utf8');
+    expect(audit).toContain('JOV-2705');
+    expect(audit).toContain('MEMORY_CORE_ARCHITECTURE.md');
+    expect(audit).toContain('Trigger.dev');
   });
 
   it('blocks product memory modules from importing AgentOS WDK workflow code', () => {

--- a/docs/AGENT_OS_ARCHITECTURE.md
+++ b/docs/AGENT_OS_ARCHITECTURE.md
@@ -100,7 +100,8 @@ Do not install Trigger in this wave. Revisit it only if WDK fails one of these p
 
 ## Related ADRs
 
-- [`docs/MEMORY_ADR.md`](./MEMORY_ADR.md) (JOV-2705) — product memory workflows use a separate durable runtime from internal AgentOS WDK. Customer memory loops must not import `workflows/agent-os-dry-run.ts`; WDK remains internal operator orchestration only.
+- [`docs/MEMORY_CORE_ARCHITECTURE.md`](./MEMORY_CORE_ARCHITECTURE.md) (JOV-2705) — product memory stack: Trigger.dev + Agents SDK + Memory Core; WDK stays internal-only.
+- [`docs/MEMORY_ADR.md`](./MEMORY_ADR.md) (JOV-2705) — import-boundary guardrails; customer memory loops must not import `workflows/agent-os-dry-run.ts`.
 
 ## Linear Dedupe
 

--- a/docs/AUTOMATION_AUDIT.md
+++ b/docs/AUTOMATION_AUDIT.md
@@ -22,6 +22,18 @@ Accepted direction:
 
 No cron or workflow triggers were changed by this decision note.
 
+### 0.1 Product memory runtime split (JOV-2705)
+
+Creator-facing product memory uses a **separate durable stack** from internal AgentOS WDK. Canonical architecture: [`docs/MEMORY_CORE_ARCHITECTURE.md`](MEMORY_CORE_ARCHITECTURE.md). Import boundaries: [`docs/MEMORY_ADR.md`](MEMORY_ADR.md).
+
+| Layer | Internal AgentOS | Product memory |
+| --- | --- | --- |
+| Durable runner | Vercel Workflow/WDK (`workflows/agent-os-dry-run.ts`) | Trigger.dev via `WorkflowRunner` when cross-step durability ships; v0 runs inline |
+| Cognition | Bounded agent adapters + artifact builders | OpenAI Agents SDK via `AgentHarness` (AI SDK Gateway interim for chat/simple extraction) |
+| Store | `AgentRunArtifact`, admin ops tables | Neon `memory_*` via `lib/memory/*` |
+
+**Does not change §0 AgentOS direction:** WDK dry-run proof for the operator control plane remains in flight. Trigger.dev is **not** an AgentOS-WDK-failure fallback for product memory — it is the planned product workflow runner ([JOV-1945](https://linear.app/jovie/issue/JOV-1945)). No cron entries or GitHub Actions triggers were added for memory workflows in this decision.
+
 ---
 
 ## 1. Cron Registry

--- a/docs/MEMORY_ADR.md
+++ b/docs/MEMORY_ADR.md
@@ -107,6 +107,7 @@ Planned implementations:
 
 ## References
 
+- [`docs/MEMORY_CORE_ARCHITECTURE.md`](./MEMORY_CORE_ARCHITECTURE.md) — canonical product memory stack decision (JOV-2705)
 - [`docs/AGENT_OS_ARCHITECTURE.md`](./AGENT_OS_ARCHITECTURE.md) — internal control plane
 - [`apps/web/lib/db/schema/memory.ts`](../apps/web/lib/db/schema/memory.ts) — product memory schema
 - [`apps/web/tests/unit/memory/memory-adr-contract.test.ts`](../apps/web/tests/unit/memory/memory-adr-contract.test.ts) — import-boundary guardrail

--- a/docs/MEMORY_CORE_ARCHITECTURE.md
+++ b/docs/MEMORY_CORE_ARCHITECTURE.md
@@ -1,0 +1,157 @@
+# Memory Core Architecture — Product Memory Stack
+
+> Issue: JOV-2705
+> Status: Accepted
+> Date: 2026-06-28
+> Parent: [JOV-2704](https://linear.app/jovie/issue/JOV-2704/memory-ship-v0-studio-session-memory-loop) (memory-ship-v0-studio-session-memory-loop)
+> Milestone: M0 — Decision + schema
+> Schema: JOV-2706 (Memory Core v0 evidence-backed entity graph)
+> Import boundaries: [`docs/MEMORY_ADR.md`](./MEMORY_ADR.md)
+
+## Decision
+
+Creator-facing product memory and internal AgentOS orchestration are **separate durable stacks** that share Neon Postgres but never share workflow runtimes:
+
+| Surface | Durable runner | Cognition harness | Canonical store |
+| --- | --- | --- | --- |
+| Internal AgentOS / Hermes / Ruflo | Vercel Workflow/WDK ([JOV-1922](./AGENT_OS_ARCHITECTURE.md)) | Deterministic artifact builders + bounded agent adapters | `AgentRunArtifact` + admin ops tables |
+| Customer product memory | Trigger.dev behind `WorkflowRunner` (when cross-step durability ships) | OpenAI Agents SDK behind `AgentHarness` | `memory_*` tables via `lib/memory/*` |
+
+**Ship now (v0):** studio-session memory runs inline from `lib/workflows/memory/studio-session-loop.ts` through `AgentHarness`. WDK dry-run proof continues for operator control plane only.
+
+**Re-evaluate when:** first production memory workflow needs cross-step resume, retry, or customer-visible run status outside a request handler — then implement `TriggerWorkflowRunner` per [`docs/MEMORY_ADR.md`](./MEMORY_ADR.md).
+
+## Why WDK stays in AgentOS (and product memory does not use it)
+
+AgentOS v1 accepted WDK as the **internal** durable coordinator ([`docs/AGENT_OS_ARCHITECTURE.md`](./AGENT_OS_ARCHITECTURE.md)). That proof path is still valid:
+
+- `workflows/agent-os-dry-run.ts` compiles and emits `AgentRunArtifact` evidence for `/app/admin/ops`.
+- WDK satisfies operator visibility, retry, and step boundaries for **non-customer** experiments.
+- Ripping WDK out of AgentOS would stall the dry-run gate without improving creator memory.
+
+Product memory has different constraints:
+
+- Writes are scoped to `userId` + `creatorProfileId` with provenance on every fact.
+- Durability must survive Vercel request timeouts, fan-out enrichment, and media waits.
+- Customer-visible workflow state must not route through admin-only WDK compile gates.
+
+**Therefore:** WDK remains the internal coordinator; product memory selects Trigger.dev (via `WorkflowRunner`) when inline execution is insufficient. The stacks are complementary, not contradictory.
+
+## Product workflow boundaries
+
+### Trigger.dev — durable product jobs
+
+Owns:
+
+- Cross-step resume, retry, and queue semantics for creator memory loops
+- Fan-out enrichment, waits, and media-processing jobs
+- Customer-visible workflow/run status (future creator UI)
+
+Does not own:
+
+- Canonical fact storage (delegates to Memory Core)
+- Extraction reasoning (delegates to Agent SDK harness)
+- Internal operator dispatch (AgentOS WDK path)
+
+### OpenAI Agents SDK — product cognition harness
+
+Owns:
+
+- Extraction, planning, reasoning, and tool orchestration behind `AgentHarness`
+- Structured outputs that map to Memory Core entities and observations
+
+Does not own:
+
+- Durable job scheduling (Trigger.dev)
+- Long-term canonical storage (Memory Core / Neon)
+- Operator gate evidence (AgentOS WDK)
+
+Until Agents SDK migration completes, the existing **AI SDK Gateway** path remains valid for chat and simple structured extraction in non-memory surfaces.
+
+### Memory Core — canonical memory store
+
+Owns:
+
+- Evidence-backed entity graph in `apps/web/lib/db/schema/memory.ts` (12 tables, JOV-2706)
+- Ingest, graph, enrichment, and review in `apps/web/lib/memory/*`
+- Permissions, provenance, and creator-scoped read APIs under `app/api/memory/*`
+
+Does not own:
+
+- Workflow durability (Trigger.dev)
+- Internal operator artifacts (`AgentRunArtifact`)
+- Session/founder recall (`MEMORY.md`, gbrain) or design-lab taste memory
+
+## v0 shipped target: studio-session memory loop
+
+The v0 loop is the reference product memory workflow:
+
+```
+apps/web/lib/workflows/memory/studio-session-loop.ts
+  → AgentHarness (lib/agents/agent-harness.ts)
+  → MemoryStore (lib/memory/*)
+  → memory_* tables
+```
+
+- Gate: `MEMORY_STUDIO_SESSION_V0` feature flag
+- Triggered inline from demo scripts, cron hooks, or API routes — **not** AgentOS WDK
+- Full evidence/provenance on every fact (source records + observations)
+- No social/write scopes in v0
+
+Future production durability wraps the same entrypoint with `TriggerWorkflowRunner` without changing Memory Core contracts.
+
+## Technology decision table
+
+| Technology | Role in Jovie memory stack | Verdict |
+| --- | --- | --- |
+| **Trigger.dev** | Durable product memory jobs, retries, fan-out, waits, customer-visible run state | **Selected** for product `WorkflowRunner` when inline execution is insufficient |
+| **Vercel Workflow / WDK** | Internal AgentOS dry-run, operator gate evidence, Hermes/Ruflo dispatch visibility | **Keep** for control plane only; never product memory runner |
+| **Cloudflare Workflows** | Alternative edge-durable orchestration | **Deferred** — no Neon/Drizzle integration path aligned with current Next.js deploy model |
+| **Composio** | Third-party tool/action composition layer | **Deferred** — product memory v0 uses bounded in-repo tools via AgentHarness |
+| **Honcho** | Session/persona memory SaaS | **Deferred** — not canonical; Neon `memory_*` is SoT |
+| **Graphiti / Zep** | External temporal knowledge graphs | **Deferred** — not canonical memory; may inform enrichment patterns only |
+| **Anthropic Managed Agents** | Hosted agent runtime | **Deferred** for product memory — Jovie-owned harness + provenance required |
+| **OpenAI Agents SDK** | Product agent harness behind `AgentHarness` | **Selected** target for extraction/planning; AI SDK Gateway remains interim for chat/simple extraction |
+
+### Explicitly deferred as canonical memory
+
+The following are **not** Jovie's canonical memory store in v0–v1:
+
+- Graphiti / Zep external knowledge graphs
+- Honcho session memory
+- Anthropic Managed Agents memory surfaces
+- Agent session memory (`MEMORY.md`, gbrain founder recall)
+- AgentOS design-lab taste memory (`lib/agent-os/design-lab/taste-memory.ts`)
+
+Neon Postgres + Drizzle `memory_*` schema remains the single source of truth for creator product memory.
+
+## Configuration
+
+| Concern | Gate / secret |
+| --- | --- |
+| Internal WDK | `AGENT_OS_WORKFLOWS_ENABLED`, Vercel Workflow compile |
+| Product Trigger.dev (future) | `TRIGGER_API_KEY`, task-scoped secrets; isolated from admin routes |
+| Studio-session v0 | `MEMORY_STUDIO_SESSION_V0` feature flag |
+| Memory store | Neon Postgres via existing `lib/db` connection |
+
+## Linear triage — AgentOS / Trigger / WDK issues
+
+| Issue | Disposition | Notes |
+| --- | --- | --- |
+| JOV-1922 | **Still valid** | Internal AgentOS WDK ADR; unchanged by product memory split |
+| JOV-1901 | **Still valid** | Automation audit; see updated §0 product-memory note in [`AUTOMATION_AUDIT.md`](./AUTOMATION_AUDIT.md) |
+| JOV-1945 | **Still valid** | Trigger.dev local worker POC — now scoped to **product** `WorkflowRunner`, not AgentOS fallback |
+| JOV-2704 | **Parent epic** | memory-ship-v0-studio-session-memory-loop |
+| JOV-2705 | **This doc** | Architecture decision + runtime split |
+| JOV-2706 | **Still valid** | Memory Core schema (12 tables) |
+| JOV-3081 | **Still valid** | Headroom context compression (inference cost) |
+| AgentOS "install Trigger if WDK fails" criteria ([AGENT_OS_ARCHITECTURE.md](./AGENT_OS_ARCHITECTURE.md) §Trigger Fallback) | **Superseded for product memory** | Product path selects Trigger.dev directly; WDK-failure fallback applies to **internal** coordinator only |
+
+Issues proposing WDK as the durable runner for creator memory ingestion should be closed or re-scoped to internal operator experiments.
+
+## Related docs
+
+- [`docs/MEMORY_ADR.md`](./MEMORY_ADR.md) — import-boundary guardrails and forbidden couplings
+- [`docs/AGENT_OS_ARCHITECTURE.md`](./AGENT_OS_ARCHITECTURE.md) — internal control plane
+- [`apps/web/lib/db/schema/memory.ts`](../apps/web/lib/db/schema/memory.ts) — product memory schema
+- [`apps/web/tests/unit/memory/memory-adr-contract.test.ts`](../apps/web/tests/unit/memory/memory-adr-contract.test.ts) — regression guardrail


### PR DESCRIPTION
## Summary

Completes JOV-2705 acceptance criteria beyond the initial MEMORY_ADR merge (#12101).

- Adds `docs/MEMORY_CORE_ARCHITECTURE.md` — canonical product memory stack with technology decision table, deferred alternatives (Graphiti/Zep/Honcho/Anthropic), v0 studio-session target, and Linear triage
- Updates `docs/AUTOMATION_AUDIT.md` §0.1 with product-memory runtime split (Trigger.dev for product, WDK stays internal)
- Cross-links `docs/AGENT_OS_ARCHITECTURE.md` and `docs/MEMORY_ADR.md`
- Extends `memory-adr-contract.test.ts` guardrails (7 tests)

## Linear

<!-- linear-issue-id:JOV-2705 -->

Closes JOV-2705

## Verification

```bash
pnpm exec vitest run tests/unit/memory/memory-adr-contract.test.ts  # 7 passed
pnpm biome check docs/MEMORY_CORE_ARCHITECTURE.md docs/AUTOMATION_AUDIT.md
```

## Bug-to-Test

Regression guardrail: `apps/web/tests/unit/memory/memory-adr-contract.test.ts` — would fail if required architecture docs or import boundaries regress.

## Risks

None — docs + contract test only; no runtime behavior change.