### PR TITLE
fix(notifications): persist TCPA consent on legacy SMS subscribe

### DIFF
--- a/apps/web/lib/notifications/domain.ts
+++ b/apps/web/lib/notifications/domain.ts
@@ -1,4 +1,4 @@
-import { and, eq, or } from 'drizzle-orm';
+import { and, sql as drizzleSql, eq, or } from 'drizzle-orm';
 import { createFingerprint } from '@/app/api/audience/lib/audience-utils';
 import { AUDIENCE_IDENTIFIED_COOKIE, BASE_URL } from '@/constants/app';
 import { db } from '@/lib/db';
@@ -54,6 +54,10 @@ import {
   type NotificationSubscribeDomainResponse,
 } from '@/lib/notifications/response';
 import { sendNotification } from '@/lib/notifications/service';
+import {
+  type ConsentSnapshot,
+  getCurrentConsentSnapshot,
+} from '@/lib/notifications/sms-consent';
 import { isEmailSuppressed } from '@/lib/notifications/suppression';
 import {
   normalizeSubscriptionEmail,
@@ -439,7 +443,9 @@ function buildUpsertConfig(
   shouldVerifyEmail: boolean,
   emailOtp: EmailOtpResult | null,
   ipAddress: string | null,
-  source: string | undefined
+  source: string | undefined,
+  smsConsentSnapshot: ConsentSnapshot | null,
+  smsConsentAt: Date
 ) {
   const target =
     channel === 'email'
@@ -462,10 +468,19 @@ function buildUpsertConfig(
       }
     : {};
 
+  const smsConsentFields =
+    channel === 'sms' && smsConsentSnapshot
+      ? {
+          smsConsentAt: drizzleSql`COALESCE(${notificationSubscriptions.smsConsentAt}, ${smsConsentAt})`,
+          smsConsentTextHash: drizzleSql`COALESCE(${notificationSubscriptions.smsConsentTextHash}, ${smsConsentSnapshot.textHash})`,
+          smsConsentVersion: drizzleSql`COALESCE(${notificationSubscriptions.smsConsentVersion}, ${smsConsentSnapshot.version})`,
+        }
+      : {};
+
   const set =
     channel === 'email'
       ? { ...emailVerifyFields, ipAddress, source }
-      : { ipAddress, source };
+      : { ipAddress, source, ...smsConsentFields };
 
   return { target, set };
 }
@@ -528,6 +543,8 @@ function buildSubscriptionValues(params: {
   defaultPreferences: FanNotificationPreferences;
   shouldVerifyEmail: boolean;
   emailOtp: EmailOtpResult | null;
+  smsConsentSnapshot: ConsentSnapshot | null;
+  smsConsentAt: Date;
 }) {
   const {
     artist_id,
@@ -541,7 +558,10 @@ function buildSubscriptionValues(params: {
     defaultPreferences,
     shouldVerifyEmail,
     emailOtp,
+    smsConsentSnapshot,
+    smsConsentAt,
   } = params;
+
   return {
     creatorProfileId: artist_id,
     channel,
@@ -553,6 +573,13 @@ function buildSubscriptionValues(params: {
     source,
     preferences: defaultPreferences,
     confirmedAt: channel === 'sms' || shouldVerifyEmail ? null : new Date(),
+    ...(smsConsentSnapshot
+      ? {
+          smsConsentAt,
+          smsConsentTextHash: smsConsentSnapshot.textHash,
+          smsConsentVersion: smsConsentSnapshot.version,
+        }
+      : {}),
     emailOtpHash: emailOtp?.otpHash,
     emailOtpExpiresAt: emailOtp?.otpExpiresAt,
     emailOtpLastSentAt: emailOtp ? new Date() : null,
@@ -718,13 +745,18 @@ export const subscribeToNotificationsDomain = async (
       artist_id
     );
     const emailOtp = shouldVerifyEmail ? createEmailOtp() : null;
+    const smsConsentSnapshot =
+      channel === 'sms' ? getCurrentConsentSnapshot() : null;
+    const smsConsentAt = new Date();
 
     const upsertConfig = buildUpsertConfig(
       channel,
       shouldVerifyEmail,
       emailOtp,
       ipAddress,
-      source
+      source,
+      smsConsentSnapshot,
+      smsConsentAt
     );
 
     await db
@@ -742,6 +774,8 @@ export const subscribeToNotificationsDomain = async (
           defaultPreferences,
           shouldVerifyEmail,
           emailOtp,
+          smsConsentSnapshot,
+          smsConsentAt,
         })
       )
       .onConflictDoUpdate(upsertConfig);

--- a/apps/web/tests/unit/lib/notifications/domain.test.ts
+++ b/apps/web/tests/unit/lib/notifications/domain.test.ts
@@ -92,6 +92,10 @@ vi.mock('@/lib/error-tracking', () => ({
   captureError: vi.fn(),
 }));
 
+vi.mock('@/lib/tracking/fire-subscribe-event', () => ({
+  fireSubscribeCAPIEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Import once after all mocks are set up
 import {
   getNotificationStatusDomain,
@@ -130,6 +134,57 @@ describe('notifications/domain', () => {
       });
 
       expect(result.body.success).toBe(false);
+    });
+
+    it('persists TCPA consent hash and version on legacy SMS subscribe (JOV-1845)', async () => {
+      const artistId = '123e4567-e89b-12d3-a456-426614174000';
+      const { db } = await import('@/lib/db');
+      const { getCurrentConsentSnapshot } = await import(
+        '@/lib/notifications/sms-consent'
+      );
+
+      vi.mocked(db.limit)
+        .mockResolvedValueOnce([
+          {
+            id: artistId,
+            displayName: 'Test Artist',
+            username: 'testartist',
+            creatorIsPro: true,
+            creatorClerkId: null,
+            settings: null,
+          },
+        ])
+        .mockResolvedValueOnce([]);
+
+      const result = await subscribeToNotificationsDomain({
+        artist_id: artistId,
+        phone: '+15551234567',
+        channel: 'sms',
+        source: 'alerts-landing',
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.body.success).toBe(true);
+
+      const consentSnapshot = getCurrentConsentSnapshot();
+      expect(db.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'sms',
+          phone: '+15551234567',
+          smsConsentAt: expect.any(Date),
+          smsConsentTextHash: consentSnapshot.textHash,
+          smsConsentVersion: consentSnapshot.version,
+        })
+      );
+
+      expect(db.onConflictDoUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          set: expect.objectContaining({
+            smsConsentTextHash: expect.anything(),
+            smsConsentVersion: expect.anything(),
+          }),
+        })
+      );
     });
 
     it('keeps the subscribe success path when audience enrichment fails', async () => {


### PR DESCRIPTION
## Goal

Close JOV-1845 by persisting the canonical TCPA consent snapshot (timestamp, text hash, version) when fans subscribe via the legacy form-based SMS path (`POST /api/notifications/subscribe`), matching the native SMS intent/webhook audit trail.

## Changes

- Stamp `smsConsentAt`, `smsConsentTextHash`, and `smsConsentVersion` on SMS inserts in `subscribeToNotificationsDomain`
- Preserve first-write-wins consent fields on SMS upsert conflicts via `COALESCE`, consistent with `sms-webhook.ts`
- Add unit test asserting legacy SMS subscribe persists the canonical consent snapshot

## Testing

- `pnpm turbo typecheck --filter=@jovie/web`
- `pnpm vitest run tests/unit/lib/notifications/domain.test.ts -t "JOV-1845"`
- `pnpm vitest run tests/unit/lib/notifications/ tests/unit/api/notifications/` (106/108 pass; 2 pre-existing flaky domain tests)

---
Generated with Claude Code