### PR TITLE
feat(connectors): enrichment pipelines for gmail/calendar graph facts (JOV-3114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
+## [Unreleased]
+
+> Connector enrichment turns synced Gmail and Calendar objects into graph facts and calendar suggestions.
+
+### Added
+
+- **Connector enrichment pipelines (JOV-3114)**: adds `lib/connectors/enrichment/` with per-provider gmail/calendar pipelines that emit `context_facts`, memory graph observations, and `suggested_actions`; extends `context_fact_kind` for entity mentions; refactors `extractAndPropose` to sync Gmail `external_objects` then run the enrichment runner. Apple Photos deferred until JOV-2919.
+
 ## [26.6.60] - 2026-06-28
 
 > Catalog collaborator signal matching resolves external mentions to discography releases with confidence scoring.

--- a/apps/web/drizzle/migrations/0065_connector_enrichment_context_facts.sql
+++ b/apps/web/drizzle/migrations/0065_connector_enrichment_context_facts.sql
@@ -1,0 +1,7 @@
+-- JOV-3114: Connector enrichment pipelines — extend context_fact_kind for graph facts
+ALTER TYPE "public"."context_fact_kind" ADD VALUE IF NOT EXISTS 'event_signal';--> statement-breakpoint
+ALTER TYPE "public"."context_fact_kind" ADD VALUE IF NOT EXISTS 'tour_date_known';--> statement-breakpoint
+ALTER TYPE "public"."context_fact_kind" ADD VALUE IF NOT EXISTS 'person_mentioned';--> statement-breakpoint
+ALTER TYPE "public"."context_fact_kind" ADD VALUE IF NOT EXISTS 'song_mentioned';--> statement-breakpoint
+ALTER TYPE "public"."context_fact_kind" ADD VALUE IF NOT EXISTS 'location_mentioned';--> statement-breakpoint
+ALTER TYPE "public"."context_fact_kind" ADD VALUE IF NOT EXISTS 'studio_location';

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1782642684524,
       "tag": "0064_charming_night_nurse",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1782700000000,
+      "tag": "0065_connector_enrichment_context_facts",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/connectors/enrichment/context-facts.ts
+++ b/apps/web/lib/connectors/enrichment/context-facts.ts
@@ -1,0 +1,87 @@
+import 'server-only';
+
+import { db } from '@/lib/db';
+import { contextFacts } from '@/lib/db/schema/connectors';
+import { contextFactKindEnum } from '@/lib/db/schema/enums';
+import type {
+  ExtractedEntityMention,
+  ExtractedEventFact,
+  PersistedContextFact,
+} from './types';
+
+type ContextFactKind = (typeof contextFactKindEnum.enumValues)[number];
+
+export async function persistEntityMentionFacts(input: {
+  readonly userId: string;
+  readonly sourceObjectId: string;
+  readonly sourceRefs: readonly Record<string, unknown>[];
+  readonly mentions: readonly ExtractedEntityMention[];
+}): Promise<readonly PersistedContextFact[]> {
+  if (input.mentions.length === 0) return [];
+
+  const rows = await db
+    .insert(contextFacts)
+    .values(
+      input.mentions.map(mention => ({
+        userId: input.userId,
+        kind: mention.factKind satisfies ContextFactKind,
+        sourceObjectId: input.sourceObjectId,
+        sourceRefs: input.sourceRefs,
+        data: {
+          entityType: mention.type,
+          name: mention.name,
+          ...(mention.metadata ?? {}),
+        },
+        confidence: mention.confidence.toFixed(2),
+      }))
+    )
+    .returning({
+      id: contextFacts.id,
+      kind: contextFacts.kind,
+      data: contextFacts.data,
+      confidence: contextFacts.confidence,
+      sourceObjectId: contextFacts.sourceObjectId,
+    });
+
+  return rows;
+}
+
+export async function persistEventSignalFacts(input: {
+  readonly userId: string;
+  readonly sourceObjectId: string | null;
+  readonly events: readonly ExtractedEventFact[];
+}): Promise<readonly PersistedContextFact[]> {
+  if (input.events.length === 0) return [];
+
+  const rows = await db
+    .insert(contextFacts)
+    .values(
+      input.events.map(event => ({
+        userId: input.userId,
+        kind: event.kind satisfies ContextFactKind,
+        sourceObjectId: input.sourceObjectId,
+        sourceRefs: event.sourceRefs,
+        data: {
+          title: event.title,
+          startsAt: event.startsAt,
+          endsAt: event.endsAt ?? null,
+          venueName: event.venueName ?? null,
+          city: event.city ?? null,
+          region: event.region ?? null,
+          country: event.country ?? null,
+          rationale: event.rationale,
+        },
+        confidence: event.confidence.toFixed(2),
+        expiresAt: new Date(event.startsAt),
+      }))
+    )
+    .returning({
+      id: contextFacts.id,
+      kind: contextFacts.kind,
+      data: contextFacts.data,
+      confidence: contextFacts.confidence,
+      sourceObjectId: contextFacts.sourceObjectId,
+    });
+
+  return rows;
+}

--- a/apps/web/lib/connectors/enrichment/index.ts
+++ b/apps/web/lib/connectors/enrichment/index.ts
@@ -1,0 +1,21 @@
+export {
+  extractCalendarMentions,
+  extractGmailMentions,
+} from './parse-mentions';
+export {
+  CONNECTOR_ENRICHMENT_PIPELINE_ORDER,
+  CONNECTOR_ENRICHMENT_PIPELINES,
+  getConnectorEnrichmentPipeline,
+} from './registry';
+export { runConnectorEnrichment } from './runner';
+export { resolveConnectorEnrichmentContext } from './scope';
+export type {
+  ConnectorEnrichmentAccountContext,
+  ConnectorEnrichmentPipeline,
+  ConnectorEnrichmentPipelineResult,
+  ConnectorEnrichmentProviderId,
+  ConnectorEnrichmentRunResult,
+  ConnectorEnrichmentScope,
+  ExtractedEntityMention,
+  ExtractedEventFact,
+} from './types';

--- a/apps/web/lib/connectors/enrichment/memory-bridge.test.ts
+++ b/apps/web/lib/connectors/enrichment/memory-bridge.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { memoryFixtureScope } from '@/lib/memory/dev-fixtures';
+import { MemoryFixtureStore } from '@/lib/memory/fixture-store';
+import { ConnectorMemoryBridge } from './memory-bridge';
+
+describe('ConnectorMemoryBridge', () => {
+  it('writes evidence-backed entity observations for gmail mentions', async () => {
+    const store = new MemoryFixtureStore();
+    const bridge = new ConnectorMemoryBridge(store);
+
+    const result = await bridge.bridgeEntityMentions({
+      scope: memoryFixtureScope,
+      sourceType: 'gmail_message',
+      externalId: 'gmail:fixture-msg-001',
+      sourceMetadata: {
+        subject: 'Booking Confirmation — Output Brooklyn',
+        from: 'bookings@outputclub.com',
+      },
+      mentions: [
+        {
+          type: 'location',
+          name: 'Output Brooklyn',
+          confidence: 0.78,
+          factKind: 'location_mentioned',
+        },
+        {
+          type: 'company',
+          name: 'Output Club Bookings',
+          confidence: 0.72,
+          factKind: 'person_mentioned',
+        },
+      ],
+    });
+
+    expect(result.observationsCreated).toBe(2);
+    expect(result.entitiesCreated).toBe(2);
+    expect(store.observations).toHaveLength(2);
+    expect(
+      store.observations.every(observation =>
+        Boolean(observation.sourceRecordId)
+      )
+    ).toBe(true);
+  });
+});

--- a/apps/web/lib/connectors/enrichment/memory-bridge.ts
+++ b/apps/web/lib/connectors/enrichment/memory-bridge.ts
@@ -1,0 +1,141 @@
+import 'server-only';
+
+import { defaultMemoryStore } from '@/lib/memory/drizzle-store';
+import { buildEvidenceMetadata } from '@/lib/memory/evidence';
+import { MemoryIdentityResolver } from '@/lib/memory/identity-resolver';
+import type { MemoryScope, MemoryStore } from '@/lib/memory/types';
+import type { ExtractedEntityMention, ExtractedEventFact } from './types';
+
+export interface MemoryBridgeResult {
+  readonly observationsCreated: number;
+  readonly entitiesCreated: number;
+}
+
+export class ConnectorMemoryBridge {
+  private readonly resolver: MemoryIdentityResolver;
+
+  constructor(private readonly store: MemoryStore = defaultMemoryStore) {
+    this.resolver = new MemoryIdentityResolver(store);
+  }
+
+  async bridgeEntityMentions(input: {
+    readonly scope: MemoryScope;
+    readonly sourceType: 'gmail_message' | 'calendar_event';
+    readonly externalId: string;
+    readonly sourceMetadata: Record<string, unknown>;
+    readonly mentions: readonly ExtractedEntityMention[];
+  }): Promise<MemoryBridgeResult> {
+    if (input.mentions.length === 0) {
+      return { observationsCreated: 0, entitiesCreated: 0 };
+    }
+
+    const sourceRecord = await this.store.upsertSourceRecord(input.scope, {
+      sourceType: input.sourceType,
+      externalId: input.externalId,
+      metadata: input.sourceMetadata,
+    });
+    const evidence = [{ sourceRecordId: sourceRecord.id }];
+
+    let observationsCreated = 0;
+    let entitiesCreated = 0;
+
+    for (const mention of input.mentions) {
+      const resolved = await this.resolver.resolve(input.scope, {
+        type: mention.type,
+        name: mention.name,
+        confidence: mention.confidence.toFixed(2),
+        metadata: buildEvidenceMetadata(evidence, {
+          connectorEnrichment: true,
+          factKind: mention.factKind,
+          ...(mention.metadata ?? {}),
+        }),
+        evidence,
+      });
+
+      if (resolved.created) entitiesCreated += 1;
+
+      await this.store.createObservation(input.scope, {
+        entityId: resolved.entityId,
+        sourceRecordId: sourceRecord.id,
+        fact: `${mention.name} mentioned in ${input.sourceType.replace('_', ' ')}`,
+        confidence: mention.confidence.toFixed(2),
+        metadata: buildEvidenceMetadata(evidence, {
+          connectorEnrichment: true,
+          factKind: mention.factKind,
+        }),
+      });
+      observationsCreated += 1;
+    }
+
+    return { observationsCreated, entitiesCreated };
+  }
+
+  async bridgeEventFacts(input: {
+    readonly scope: MemoryScope;
+    readonly sourceType: 'gmail_message' | 'calendar_event';
+    readonly externalId: string;
+    readonly sourceMetadata: Record<string, unknown>;
+    readonly events: readonly ExtractedEventFact[];
+  }): Promise<MemoryBridgeResult> {
+    if (input.events.length === 0) {
+      return { observationsCreated: 0, entitiesCreated: 0 };
+    }
+
+    const sourceRecord = await this.store.upsertSourceRecord(input.scope, {
+      sourceType: input.sourceType,
+      externalId: input.externalId,
+      metadata: input.sourceMetadata,
+    });
+    const evidence = [{ sourceRecordId: sourceRecord.id }];
+
+    let observationsCreated = 0;
+    let entitiesCreated = 0;
+
+    for (const event of input.events) {
+      const eventEntity = await this.resolver.resolve(input.scope, {
+        type: 'event',
+        name: event.title,
+        confidence: event.confidence.toFixed(2),
+        metadata: buildEvidenceMetadata(evidence, {
+          connectorEnrichment: true,
+          startsAt: event.startsAt,
+          venueName: event.venueName,
+        }),
+        evidence,
+      });
+
+      if (eventEntity.created) entitiesCreated += 1;
+
+      await this.store.createObservation(input.scope, {
+        entityId: eventEntity.entityId,
+        sourceRecordId: sourceRecord.id,
+        fact: `Tour date signal: ${event.title} on ${event.startsAt}`,
+        confidence: event.confidence.toFixed(2),
+        metadata: buildEvidenceMetadata(evidence, {
+          connectorEnrichment: true,
+          kind: event.kind,
+          startsAt: event.startsAt,
+          venueName: event.venueName,
+        }),
+      });
+      observationsCreated += 1;
+
+      if (event.venueName) {
+        const venue = await this.resolver.resolve(input.scope, {
+          type: 'location',
+          name: event.venueName,
+          confidence: Math.min(event.confidence, 0.85).toFixed(2),
+          metadata: buildEvidenceMetadata(evidence, {
+            connectorEnrichment: true,
+            city: event.city,
+            country: event.country,
+          }),
+          evidence,
+        });
+        if (venue.created) entitiesCreated += 1;
+      }
+    }
+
+    return { observationsCreated, entitiesCreated };
+  }
+}

--- a/apps/web/lib/connectors/enrichment/parse-mentions.test.ts
+++ b/apps/web/lib/connectors/enrichment/parse-mentions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { FIXTURE_BOOKING_EMAILS } from '@/lib/connectors/gmail/__fixtures__/booking-emails';
+import {
+  extractCalendarMentions,
+  extractGmailMentions,
+} from './parse-mentions';
+
+describe('connector enrichment parse-mentions', () => {
+  it('extracts sender and venue mentions from booking fixture emails', () => {
+    const output = FIXTURE_BOOKING_EMAILS.slice(0, 3).flatMap(email =>
+      extractGmailMentions({
+        subject: email.subject,
+        from: email.from,
+        snippet: email.snippet,
+      })
+    );
+
+    expect(output.some(mention => mention.name.includes('Output'))).toBe(true);
+    expect(
+      output.some(mention => mention.factKind === 'location_mentioned')
+    ).toBe(true);
+    expect(output.every(mention => mention.confidence >= 0.7)).toBe(true);
+  });
+
+  it('returns no mentions for prompt-injection fixture email', () => {
+    const injection = FIXTURE_BOOKING_EMAILS.find(
+      email => email.id === 'fixture-msg-005'
+    );
+    expect(injection).toBeDefined();
+
+    const mentions = extractGmailMentions({
+      subject: injection!.subject,
+      from: injection!.from,
+      snippet: injection!.snippet,
+    });
+
+    expect(mentions.some(mention => mention.type === 'location')).toBe(false);
+  });
+
+  it('extracts studio location mentions from calendar payloads', () => {
+    const mentions = extractCalendarMentions({
+      summary: 'Studio session at Dim Mak Studio',
+      location: 'Dim Mak Studio, Los Angeles',
+      startsAt: '2026-06-01T22:00:00.000Z',
+    });
+
+    expect(
+      mentions.some(mention => mention.factKind === 'studio_location')
+    ).toBe(true);
+    expect(mentions.some(mention => mention.name.includes('Dim Mak'))).toBe(
+      true
+    );
+  });
+});

--- a/apps/web/lib/connectors/enrichment/parse-mentions.ts
+++ b/apps/web/lib/connectors/enrichment/parse-mentions.ts
@@ -1,0 +1,146 @@
+import type { ExtractedEntityMention } from './types';
+
+export interface GmailObjectPayload {
+  readonly subject?: string;
+  readonly from?: string;
+  readonly date?: string;
+  readonly snippet?: string;
+}
+
+export interface CalendarObjectPayload {
+  readonly summary?: string;
+  readonly location?: string;
+  readonly startsAt?: string;
+  readonly endsAt?: string;
+}
+
+const BOOKING_SUBJECT_RE =
+  /(?:—|-)\s*([^,]+?)(?:\s*,|\s+\w+\s+\d{1,2}\s+\d{4})/;
+const VENUE_IN_SNIPPET_RE =
+  /(?:at|@)\s+([A-Z][A-Za-z0-9'&\-\s]{2,60}?)(?:\s+on\b|,|\.|\s+\d)/;
+const PERSON_FROM_RE = /^([^<@]+?)(?:\s*<|$)/;
+const STUDIO_RE = /\b(studio|rehearsal|session)\b/i;
+
+function uniqueMentions(
+  mentions: readonly ExtractedEntityMention[]
+): ExtractedEntityMention[] {
+  const seen = new Set<string>();
+  const result: ExtractedEntityMention[] = [];
+
+  for (const mention of mentions) {
+    const key = `${mention.type}:${mention.name.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(mention);
+  }
+
+  return result;
+}
+
+function parseSenderName(from: string): ExtractedEntityMention | null {
+  const trimmed = from.trim();
+  if (!trimmed) return null;
+
+  const match = trimmed.match(PERSON_FROM_RE);
+  const name = match?.[1]?.trim().replace(/^"|"$/g, '');
+  if (!name || name.length < 2) return null;
+
+  const isCompany =
+    name.includes('@') ||
+    /\.(com|org|net|de|uk)$/i.test(name) ||
+    /\b(bookings?|info|noreply|artists?)\b/i.test(name);
+
+  return {
+    type: isCompany ? 'company' : 'person',
+    name,
+    confidence: isCompany ? 0.72 : 0.8,
+    factKind: 'person_mentioned',
+    metadata: { source: 'gmail_from' },
+  };
+}
+
+function parseVenueFromSubject(subject: string): ExtractedEntityMention | null {
+  const match = subject.match(BOOKING_SUBJECT_RE);
+  const venue = match?.[1]?.trim();
+  if (!venue || venue.length < 2) return null;
+
+  const isStudio = STUDIO_RE.test(venue);
+  return {
+    type: isStudio ? 'studio' : 'location',
+    name: venue,
+    confidence: 0.78,
+    factKind: isStudio ? 'studio_location' : 'location_mentioned',
+    metadata: { source: 'gmail_subject' },
+  };
+}
+
+function parseVenueFromSnippet(snippet: string): ExtractedEntityMention | null {
+  const match = snippet.match(VENUE_IN_SNIPPET_RE);
+  const venue = match?.[1]?.trim();
+  if (!venue || venue.length < 2) return null;
+
+  const isStudio = STUDIO_RE.test(venue);
+  return {
+    type: isStudio ? 'studio' : 'location',
+    name: venue,
+    confidence: 0.74,
+    factKind: isStudio ? 'studio_location' : 'location_mentioned',
+    metadata: { source: 'gmail_snippet' },
+  };
+}
+
+export function extractGmailMentions(
+  payload: GmailObjectPayload
+): ExtractedEntityMention[] {
+  const mentions: ExtractedEntityMention[] = [];
+
+  if (payload.from) {
+    const sender = parseSenderName(payload.from);
+    if (sender) mentions.push(sender);
+  }
+
+  if (payload.subject) {
+    const venue = parseVenueFromSubject(payload.subject);
+    if (venue) mentions.push(venue);
+  }
+
+  if (payload.snippet) {
+    const venue = parseVenueFromSnippet(payload.snippet);
+    if (venue) mentions.push(venue);
+  }
+
+  return uniqueMentions(mentions);
+}
+
+export function extractCalendarMentions(
+  payload: CalendarObjectPayload
+): ExtractedEntityMention[] {
+  const mentions: ExtractedEntityMention[] = [];
+
+  if (payload.location?.trim()) {
+    const location = payload.location.trim();
+    const isStudio = STUDIO_RE.test(location);
+    mentions.push({
+      type: isStudio ? 'studio' : 'location',
+      name: location,
+      confidence: 0.86,
+      factKind: isStudio ? 'studio_location' : 'location_mentioned',
+      metadata: { source: 'calendar_location' },
+    });
+  }
+
+  if (payload.summary?.trim()) {
+    const summary = payload.summary.trim();
+    if (STUDIO_RE.test(summary)) {
+      mentions.push({
+        type: 'event',
+        name: summary,
+        confidence: 0.7,
+        factKind: 'location_mentioned',
+        metadata: { source: 'calendar_summary' },
+      });
+    }
+  }
+
+  return uniqueMentions(mentions);
+}

--- a/apps/web/lib/connectors/enrichment/photos.ts
+++ b/apps/web/lib/connectors/enrichment/photos.ts
@@ -1,0 +1,9 @@
+/**
+ * Apple Photos connector enrichment — deferred (JOV-3114 out-of-scope).
+ *
+ * Ship now: gmail + google_calendar pipelines only.
+ * Re-evaluate when: JOV-2919 ConnectorDefinition manifest adds apple_photos provider.
+ * Then: people-in-photo matching → "post this photo" suggestions.
+ */
+
+export const APPLE_PHOTOS_ENRICHMENT_DEFERRED = true as const;

--- a/apps/web/lib/connectors/enrichment/pipelines/calendar.ts
+++ b/apps/web/lib/connectors/enrichment/pipelines/calendar.ts
@@ -1,0 +1,241 @@
+import 'server-only';
+
+import { and, desc, eq } from 'drizzle-orm';
+import {
+  listCalendarEvents,
+  SyncTokenExpiredError,
+} from '@/lib/connectors/google-calendar/list-events';
+import { CONNECTOR_PROVIDERS } from '@/lib/connectors/registry';
+import { loadDecryptedToken } from '@/lib/connectors/token-vault';
+import { db } from '@/lib/db';
+import { externalObjects } from '@/lib/db/schema/connectors';
+import { logger } from '@/lib/utils/logger';
+import {
+  persistEntityMentionFacts,
+  persistEventSignalFacts,
+} from '../context-facts';
+import { ConnectorMemoryBridge } from '../memory-bridge';
+import {
+  type CalendarObjectPayload,
+  extractCalendarMentions,
+} from '../parse-mentions';
+import type {
+  ConnectorEnrichmentAccountContext,
+  ConnectorEnrichmentPipeline,
+  ConnectorEnrichmentPipelineResult,
+  ExtractedEventFact,
+} from '../types';
+
+const CALENDAR_OBJECT_KIND = 'calendar_event';
+const MAX_OBJECTS_PER_RUN = 100;
+
+function normalizeCalendarPayload(event: {
+  id: string;
+  summary: string;
+  location?: string;
+  start: { dateTime?: string; date?: string };
+  end: { dateTime?: string; date?: string };
+  etag: string;
+}): CalendarObjectPayload & { providerId: string; etag: string } {
+  return {
+    providerId: event.id,
+    etag: event.etag,
+    summary: event.summary,
+    location: event.location,
+    startsAt: event.start.dateTime ?? event.start.date,
+    endsAt: event.end.dateTime ?? event.end.date,
+  };
+}
+
+export const calendarEnrichmentPipeline: ConnectorEnrichmentPipeline = {
+  provider: CONNECTOR_PROVIDERS.google_calendar,
+
+  async run(
+    context: ConnectorEnrichmentAccountContext
+  ): Promise<ConnectorEnrichmentPipelineResult> {
+    const accountId = context.calendarAccountId;
+    if (!accountId) {
+      return emptyResult(CONNECTOR_PROVIDERS.google_calendar);
+    }
+
+    const tokens = await loadDecryptedToken(accountId);
+    if (!tokens) {
+      logger.error('[connector-enrichment/calendar] Token load failed', {
+        userId: context.scope.userId,
+      });
+      return emptyResult(CONNECTOR_PROVIDERS.google_calendar);
+    }
+
+    let calendarEvents;
+    try {
+      const result = await listCalendarEvents(tokens.accessToken);
+      calendarEvents = result.items;
+    } catch (error) {
+      if (error instanceof SyncTokenExpiredError) {
+        const result = await listCalendarEvents(tokens.accessToken);
+        calendarEvents = result.items;
+      } else {
+        throw error;
+      }
+    }
+
+    await Promise.allSettled(
+      calendarEvents.map(event => {
+        const payload = normalizeCalendarPayload(event);
+        return db
+          .insert(externalObjects)
+          .values({
+            connectorAccountId: accountId,
+            provider: CONNECTOR_PROVIDERS.google_calendar,
+            kind: CALENDAR_OBJECT_KIND,
+            providerId: payload.providerId,
+            payload: {
+              summary: payload.summary,
+              location: payload.location,
+              startsAt: payload.startsAt,
+              endsAt: payload.endsAt,
+            },
+            etag: payload.etag,
+          })
+          .onConflictDoUpdate({
+            target: [
+              externalObjects.connectorAccountId,
+              externalObjects.kind,
+              externalObjects.providerId,
+            ],
+            set: {
+              payload: {
+                summary: payload.summary,
+                location: payload.location,
+                startsAt: payload.startsAt,
+                endsAt: payload.endsAt,
+              },
+              etag: payload.etag,
+              fetchedAt: new Date(),
+            },
+          });
+      })
+    );
+
+    const objects = await db
+      .select({
+        id: externalObjects.id,
+        providerId: externalObjects.providerId,
+        payload: externalObjects.payload,
+      })
+      .from(externalObjects)
+      .where(
+        and(
+          eq(externalObjects.connectorAccountId, accountId),
+          eq(externalObjects.kind, CALENDAR_OBJECT_KIND)
+        )
+      )
+      .orderBy(desc(externalObjects.fetchedAt))
+      .limit(MAX_OBJECTS_PER_RUN);
+
+    const bridge = new ConnectorMemoryBridge();
+    let contextFactsCreated = 0;
+    let memoryObservationsCreated = 0;
+    let memoryEntitiesCreated = 0;
+    const gmailEventFacts: ExtractedEventFact[] = [];
+
+    for (const object of objects) {
+      const payload = object.payload as CalendarObjectPayload;
+      const mentions = extractCalendarMentions(payload);
+      const sourceRefs = [
+        {
+          provider: CONNECTOR_PROVIDERS.google_calendar,
+          providerId: object.providerId,
+          summary: payload.summary ?? null,
+        },
+      ];
+
+      const mentionFacts = await persistEntityMentionFacts({
+        userId: context.scope.userId,
+        sourceObjectId: object.id,
+        sourceRefs,
+        mentions,
+      });
+      contextFactsCreated += mentionFacts.length;
+
+      const memoryMentions = await bridge.bridgeEntityMentions({
+        scope: context.scope,
+        sourceType: 'calendar_event',
+        externalId: `calendar:${object.providerId}`,
+        sourceMetadata: {
+          summary: payload.summary,
+          location: payload.location,
+          startsAt: payload.startsAt,
+          connectorEnrichment: true,
+        },
+        mentions,
+      });
+      memoryObservationsCreated += memoryMentions.observationsCreated;
+      memoryEntitiesCreated += memoryMentions.entitiesCreated;
+
+      if (payload.summary && payload.startsAt) {
+        gmailEventFacts.push({
+          kind: 'tour_date_known',
+          title: payload.summary,
+          startsAt: payload.startsAt,
+          endsAt: payload.endsAt ?? null,
+          venueName: payload.location ?? null,
+          confidence: 0.92,
+          rationale:
+            'Existing Google Calendar event synced for graph enrichment',
+          sourceRefs,
+        });
+      }
+    }
+
+    if (gmailEventFacts.length > 0) {
+      const persisted = await persistEventSignalFacts({
+        userId: context.scope.userId,
+        sourceObjectId: objects[0]?.id ?? null,
+        events: gmailEventFacts,
+      });
+      contextFactsCreated += persisted.length;
+
+      const primary = objects[0];
+      if (primary) {
+        const memoryEvents = await bridge.bridgeEventFacts({
+          scope: context.scope,
+          sourceType: 'calendar_event',
+          externalId: `calendar:${primary.providerId}`,
+          sourceMetadata: { connectorEnrichment: true },
+          events: gmailEventFacts,
+        });
+        memoryObservationsCreated += memoryEvents.observationsCreated;
+        memoryEntitiesCreated += memoryEvents.entitiesCreated;
+      }
+    }
+
+    logger.info('[connector-enrichment/calendar] Complete', {
+      userId: context.scope.userId,
+      externalObjectsProcessed: objects.length,
+      contextFactsCreated,
+    });
+
+    return {
+      provider: CONNECTOR_PROVIDERS.google_calendar,
+      externalObjectsProcessed: objects.length,
+      contextFactsCreated,
+      memoryObservationsCreated,
+      memoryEntitiesCreated,
+      suggestionsCreated: 0,
+    };
+  },
+};
+
+function emptyResult(
+  provider: ConnectorEnrichmentPipelineResult['provider']
+): ConnectorEnrichmentPipelineResult {
+  return {
+    provider,
+    externalObjectsProcessed: 0,
+    contextFactsCreated: 0,
+    memoryObservationsCreated: 0,
+    memoryEntitiesCreated: 0,
+    suggestionsCreated: 0,
+  };
+}

--- a/apps/web/lib/connectors/enrichment/pipelines/gmail.ts
+++ b/apps/web/lib/connectors/enrichment/pipelines/gmail.ts
@@ -1,0 +1,231 @@
+import 'server-only';
+
+import { and, desc, eq } from 'drizzle-orm';
+import { extractEventSignal } from '@/lib/connectors/gmail/extract-event-signal';
+import {
+  hasOverlappingEvent,
+  listCalendarEvents,
+  SyncTokenExpiredError,
+} from '@/lib/connectors/google-calendar/list-events';
+import { CONNECTOR_PROVIDERS } from '@/lib/connectors/registry';
+import { loadDecryptedToken } from '@/lib/connectors/token-vault';
+import { db } from '@/lib/db';
+import { externalObjects } from '@/lib/db/schema/connectors';
+import { logger } from '@/lib/utils/logger';
+import {
+  persistEntityMentionFacts,
+  persistEventSignalFacts,
+} from '../context-facts';
+import { ConnectorMemoryBridge } from '../memory-bridge';
+import {
+  extractGmailMentions,
+  type GmailObjectPayload,
+} from '../parse-mentions';
+import { emitCalendarCreateSuggestions } from '../suggestions';
+import type {
+  ConnectorEnrichmentAccountContext,
+  ConnectorEnrichmentPipeline,
+  ConnectorEnrichmentPipelineResult,
+  ExtractedEventFact,
+} from '../types';
+
+const GMAIL_OBJECT_KIND = 'gmail_message';
+const MAX_OBJECTS_PER_RUN = 50;
+
+function toEventFacts(
+  events: Awaited<ReturnType<typeof extractEventSignal>>['events']
+): ExtractedEventFact[] {
+  return events.map(event => ({
+    kind: 'event_signal' as const,
+    title: event.title,
+    startsAt: event.startsAt,
+    endsAt: event.endsAt,
+    venueName: event.venueName,
+    city: event.city,
+    region: event.region,
+    country: event.country,
+    confidence: event.confidence,
+    rationale: event.rationale,
+    sourceRefs: [event.sourceRef],
+  }));
+}
+
+export const gmailEnrichmentPipeline: ConnectorEnrichmentPipeline = {
+  provider: CONNECTOR_PROVIDERS.gmail,
+
+  async run(
+    context: ConnectorEnrichmentAccountContext
+  ): Promise<ConnectorEnrichmentPipelineResult> {
+    const accountId = context.gmailAccountId;
+    if (!accountId) {
+      return emptyResult(CONNECTOR_PROVIDERS.gmail);
+    }
+
+    const objects = await db
+      .select({
+        id: externalObjects.id,
+        providerId: externalObjects.providerId,
+        payload: externalObjects.payload,
+      })
+      .from(externalObjects)
+      .where(
+        and(
+          eq(externalObjects.connectorAccountId, accountId),
+          eq(externalObjects.kind, GMAIL_OBJECT_KIND)
+        )
+      )
+      .orderBy(desc(externalObjects.fetchedAt))
+      .limit(MAX_OBJECTS_PER_RUN);
+
+    if (objects.length === 0) {
+      logger.info(
+        '[connector-enrichment/gmail] No external objects to enrich',
+        {
+          userId: context.scope.userId,
+        }
+      );
+      return emptyResult(CONNECTOR_PROVIDERS.gmail);
+    }
+
+    const bridge = new ConnectorMemoryBridge();
+    let contextFactsCreated = 0;
+    let memoryObservationsCreated = 0;
+    let memoryEntitiesCreated = 0;
+
+    for (const object of objects) {
+      const payload = object.payload as GmailObjectPayload;
+      const mentions = extractGmailMentions(payload);
+      const sourceRefs = [
+        {
+          provider: CONNECTOR_PROVIDERS.gmail,
+          providerId: object.providerId,
+          subject: payload.subject ?? null,
+        },
+      ];
+
+      const mentionFacts = await persistEntityMentionFacts({
+        userId: context.scope.userId,
+        sourceObjectId: object.id,
+        sourceRefs,
+        mentions,
+      });
+      contextFactsCreated += mentionFacts.length;
+
+      const memoryResult = await bridge.bridgeEntityMentions({
+        scope: context.scope,
+        sourceType: 'gmail_message',
+        externalId: `gmail:${object.providerId}`,
+        sourceMetadata: {
+          subject: payload.subject,
+          from: payload.from,
+          date: payload.date,
+          connectorEnrichment: true,
+        },
+        mentions,
+      });
+      memoryObservationsCreated += memoryResult.observationsCreated;
+      memoryEntitiesCreated += memoryResult.entitiesCreated;
+    }
+
+    const extractorInput = objects.map(object => {
+      const payload = object.payload as GmailObjectPayload;
+      return {
+        messageId: object.providerId,
+        subject: payload.subject ?? '(no subject)',
+        from: payload.from ?? '',
+        date: payload.date ?? '',
+        snippet: payload.snippet ?? '',
+      };
+    });
+
+    const extraction = await extractEventSignal(
+      extractorInput,
+      context.scope.userId
+    );
+    const eventFacts = toEventFacts(extraction.events);
+
+    if (eventFacts.length > 0) {
+      const primaryObject = objects[0];
+      if (primaryObject) {
+        const persisted = await persistEventSignalFacts({
+          userId: context.scope.userId,
+          sourceObjectId: primaryObject.id,
+          events: eventFacts,
+        });
+        contextFactsCreated += persisted.length;
+
+        const memoryEvents = await bridge.bridgeEventFacts({
+          scope: context.scope,
+          sourceType: 'gmail_message',
+          externalId: `gmail:${primaryObject.providerId}`,
+          sourceMetadata: {
+            connectorEnrichment: true,
+            batchSize: objects.length,
+          },
+          events: eventFacts,
+        });
+        memoryObservationsCreated += memoryEvents.observationsCreated;
+        memoryEntitiesCreated += memoryEvents.entitiesCreated;
+      }
+    }
+
+    let suggestionsCreated = 0;
+    if (eventFacts.length > 0 && context.calendarAccountId) {
+      const calendarTokens = await loadDecryptedToken(
+        context.calendarAccountId
+      );
+      if (calendarTokens) {
+        let calendarEvents;
+        try {
+          const result = await listCalendarEvents(calendarTokens.accessToken);
+          calendarEvents = result.items;
+        } catch (error) {
+          if (error instanceof SyncTokenExpiredError) {
+            const result = await listCalendarEvents(calendarTokens.accessToken);
+            calendarEvents = result.items;
+          } else {
+            throw error;
+          }
+        }
+
+        suggestionsCreated = await emitCalendarCreateSuggestions({
+          userId: context.scope.userId,
+          calendarAccountId: context.calendarAccountId,
+          events: eventFacts,
+          hasCalendarConflict: startsAt =>
+            hasOverlappingEvent(startsAt, calendarEvents, 6),
+        });
+      }
+    }
+
+    logger.info('[connector-enrichment/gmail] Complete', {
+      userId: context.scope.userId,
+      externalObjectsProcessed: objects.length,
+      contextFactsCreated,
+      memoryObservationsCreated,
+      suggestionsCreated,
+    });
+
+    return {
+      provider: CONNECTOR_PROVIDERS.gmail,
+      externalObjectsProcessed: objects.length,
+      contextFactsCreated,
+      memoryObservationsCreated,
+      memoryEntitiesCreated,
+      suggestionsCreated,
+    };
+  },
+};
+
+function emptyResult(
+  provider: ConnectorEnrichmentPipelineResult['provider']
+): ConnectorEnrichmentPipelineResult {
+  return {
+    provider,
+    externalObjectsProcessed: 0,
+    contextFactsCreated: 0,
+    memoryObservationsCreated: 0,
+    memoryEntitiesCreated: 0,
+    suggestionsCreated: 0,
+  };
+}

--- a/apps/web/lib/connectors/enrichment/registry.test.ts
+++ b/apps/web/lib/connectors/enrichment/registry.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { CONNECTOR_PROVIDERS } from '@/lib/connectors/registry';
+import { APPLE_PHOTOS_ENRICHMENT_DEFERRED } from './photos';
+import {
+  CONNECTOR_ENRICHMENT_PIPELINE_ORDER,
+  CONNECTOR_ENRICHMENT_PIPELINES,
+  getConnectorEnrichmentPipeline,
+} from './registry';
+
+describe('connector enrichment registry (JOV-3114)', () => {
+  it('registers gmail and google_calendar pipelines in stable order', () => {
+    expect(CONNECTOR_ENRICHMENT_PIPELINE_ORDER).toEqual([
+      CONNECTOR_PROVIDERS.gmail,
+      CONNECTOR_PROVIDERS.google_calendar,
+    ]);
+    expect(Object.keys(CONNECTOR_ENRICHMENT_PIPELINES)).toEqual(
+      CONNECTOR_ENRICHMENT_PIPELINE_ORDER
+    );
+  });
+
+  it('returns pipeline executors by provider id', () => {
+    const gmail = getConnectorEnrichmentPipeline(CONNECTOR_PROVIDERS.gmail);
+    const calendar = getConnectorEnrichmentPipeline(
+      CONNECTOR_PROVIDERS.google_calendar
+    );
+
+    expect(gmail.provider).toBe(CONNECTOR_PROVIDERS.gmail);
+    expect(calendar.provider).toBe(CONNECTOR_PROVIDERS.google_calendar);
+    expect(typeof gmail.run).toBe('function');
+    expect(typeof calendar.run).toBe('function');
+  });
+
+  it('keeps Apple Photos enrichment explicitly deferred', () => {
+    expect(APPLE_PHOTOS_ENRICHMENT_DEFERRED).toBe(true);
+    expect(CONNECTOR_ENRICHMENT_PIPELINE_ORDER).not.toContain('apple_photos');
+  });
+});

--- a/apps/web/lib/connectors/enrichment/registry.ts
+++ b/apps/web/lib/connectors/enrichment/registry.ts
@@ -1,0 +1,28 @@
+import { CONNECTOR_PROVIDERS } from '@/lib/connectors/registry';
+import { calendarEnrichmentPipeline } from './pipelines/calendar';
+import { gmailEnrichmentPipeline } from './pipelines/gmail';
+import type {
+  ConnectorEnrichmentPipeline,
+  ConnectorEnrichmentProviderId,
+} from './types';
+
+/**
+ * Per-connector enrichment pipelines (JOV-3114).
+ * Apple Photos is deferred — add `apple_photos` here when JOV-2919 lands.
+ */
+export const CONNECTOR_ENRICHMENT_PIPELINES = {
+  [CONNECTOR_PROVIDERS.gmail]: gmailEnrichmentPipeline,
+  [CONNECTOR_PROVIDERS.google_calendar]: calendarEnrichmentPipeline,
+} as const satisfies Record<
+  ConnectorEnrichmentProviderId,
+  ConnectorEnrichmentPipeline
+>;
+
+export const CONNECTOR_ENRICHMENT_PIPELINE_ORDER: readonly ConnectorEnrichmentProviderId[] =
+  [CONNECTOR_PROVIDERS.gmail, CONNECTOR_PROVIDERS.google_calendar];
+
+export function getConnectorEnrichmentPipeline(
+  provider: ConnectorEnrichmentProviderId
+): ConnectorEnrichmentPipeline {
+  return CONNECTOR_ENRICHMENT_PIPELINES[provider];
+}

--- a/apps/web/lib/connectors/enrichment/runner.ts
+++ b/apps/web/lib/connectors/enrichment/runner.ts
@@ -1,0 +1,67 @@
+import 'server-only';
+
+import { isMissingConnectorSchemaError } from '@/lib/connectors/schema-errors';
+import { captureError } from '@/lib/error-tracking';
+import { logger } from '@/lib/utils/logger';
+import { CONNECTOR_ENRICHMENT_PIPELINE_ORDER } from './registry';
+import { resolveConnectorEnrichmentContext } from './scope';
+import type { ConnectorEnrichmentRunResult } from './types';
+
+const EMPTY_RESULT: ConnectorEnrichmentRunResult = {
+  pipelines: [],
+  totalSuggestionsCreated: 0,
+};
+
+/**
+ * Runs all registered connector enrichment pipelines for a user.
+ * Turns synced external_objects into context_facts + memory graph observations.
+ */
+export async function runConnectorEnrichment(
+  userId: string
+): Promise<ConnectorEnrichmentRunResult> {
+  try {
+    const context = await resolveConnectorEnrichmentContext(userId);
+    if (!context) {
+      logger.info('[connector-enrichment] Skipping — no connected scope', {
+        userId,
+      });
+      return EMPTY_RESULT;
+    }
+
+    const pipelines = [];
+    let totalSuggestionsCreated = 0;
+
+    for (const provider of CONNECTOR_ENRICHMENT_PIPELINE_ORDER) {
+      const accountId =
+        provider === 'gmail'
+          ? context.gmailAccountId
+          : context.calendarAccountId;
+      if (!accountId) continue;
+
+      const { getConnectorEnrichmentPipeline } = await import('./registry');
+      const pipeline = getConnectorEnrichmentPipeline(provider);
+      const result = await pipeline.run(context);
+      pipelines.push(result);
+      totalSuggestionsCreated += result.suggestionsCreated;
+    }
+
+    logger.info('[connector-enrichment] Run complete', {
+      userId,
+      pipelineCount: pipelines.length,
+      totalSuggestionsCreated,
+    });
+
+    return { pipelines, totalSuggestionsCreated };
+  } catch (error) {
+    if (isMissingConnectorSchemaError(error)) {
+      logger.warn(
+        '[connector-enrichment] Connector schema not migrated; skipping run',
+        { userId }
+      );
+      return EMPTY_RESULT;
+    }
+
+    await captureError('Connector enrichment run failed', error, { userId });
+    throw error;
+  }
+}

--- a/apps/web/lib/connectors/enrichment/scope.ts
+++ b/apps/web/lib/connectors/enrichment/scope.ts
@@ -1,0 +1,71 @@
+import 'server-only';
+
+import { and, eq } from 'drizzle-orm';
+import { CONNECTOR_PROVIDERS } from '@/lib/connectors/registry';
+import { db } from '@/lib/db';
+import { connectorAccounts } from '@/lib/db/schema/connectors';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import type {
+  ConnectorEnrichmentAccountContext,
+  ConnectorEnrichmentScope,
+} from './types';
+
+async function resolveCreatorProfileId(
+  userId: string,
+  connectorProfileId: string | null
+): Promise<string | null> {
+  if (connectorProfileId) return connectorProfileId;
+
+  const [profile] = await db
+    .select({ id: creatorProfiles.id })
+    .from(creatorProfiles)
+    .where(eq(creatorProfiles.userId, userId))
+    .limit(1);
+
+  return profile?.id ?? null;
+}
+
+export async function resolveConnectorEnrichmentContext(
+  userId: string
+): Promise<ConnectorEnrichmentAccountContext | null> {
+  const accounts = await db
+    .select({
+      id: connectorAccounts.id,
+      provider: connectorAccounts.provider,
+      creatorProfileId: connectorAccounts.creatorProfileId,
+    })
+    .from(connectorAccounts)
+    .where(
+      and(
+        eq(connectorAccounts.userId, userId),
+        eq(connectorAccounts.status, 'connected')
+      )
+    );
+
+  const gmail = accounts.find(
+    row => row.provider === CONNECTOR_PROVIDERS.gmail
+  );
+  const calendar = accounts.find(
+    row => row.provider === CONNECTOR_PROVIDERS.google_calendar
+  );
+
+  const creatorProfileId = await resolveCreatorProfileId(
+    userId,
+    gmail?.creatorProfileId ?? calendar?.creatorProfileId ?? null
+  );
+
+  if (!creatorProfileId) {
+    return null;
+  }
+
+  const scope: ConnectorEnrichmentScope = {
+    userId,
+    creatorProfileId,
+  };
+
+  return {
+    scope,
+    gmailAccountId: gmail?.id ?? null,
+    calendarAccountId: calendar?.id ?? null,
+  };
+}

--- a/apps/web/lib/connectors/enrichment/suggestions.ts
+++ b/apps/web/lib/connectors/enrichment/suggestions.ts
@@ -1,0 +1,73 @@
+import 'server-only';
+
+import { db } from '@/lib/db';
+import { suggestedActions } from '@/lib/db/schema/connectors';
+import { captureError } from '@/lib/error-tracking';
+import type { ExtractedEventFact } from './types';
+
+const MIN_SUGGESTION_CONFIDENCE = 0.7;
+
+export async function emitCalendarCreateSuggestions(input: {
+  readonly userId: string;
+  readonly calendarAccountId: string;
+  readonly events: readonly ExtractedEventFact[];
+  readonly hasCalendarConflict: (startsAt: string) => boolean;
+}): Promise<number> {
+  let created = 0;
+
+  for (const event of input.events) {
+    if (event.confidence < MIN_SUGGESTION_CONFIDENCE) continue;
+    if (input.hasCalendarConflict(event.startsAt)) continue;
+
+    const messageId = String(
+      event.sourceRefs[0]?.messageId ?? event.sourceRefs[0]?.providerId ?? ''
+    );
+    const sourceRef = {
+      messageId,
+      subject: String(event.sourceRefs[0]?.subject ?? event.title),
+    };
+
+    const payload = {
+      title: event.title,
+      startsAt: event.startsAt,
+      endsAt: event.endsAt ?? null,
+      venueName: event.venueName ?? null,
+      city: event.city ?? null,
+      region: event.region ?? null,
+      country: event.country ?? null,
+      rationale: event.rationale,
+      confidence: event.confidence,
+    };
+
+    try {
+      const inserted = await db
+        .insert(suggestedActions)
+        .values({
+          userId: input.userId,
+          kind: 'calendar.create_event',
+          targetConnectorAccountId: input.calendarAccountId,
+          payload,
+          status: 'pending',
+          sourceRefs: [sourceRef],
+          rationale: event.rationale,
+          idempotencyKey: `${input.userId}-${messageId}-${event.startsAt}`,
+          sideEffects: [],
+        })
+        .onConflictDoNothing()
+        .returning({ id: suggestedActions.id });
+
+      if (inserted.length > 0) created += 1;
+    } catch (error) {
+      await captureError(
+        'Failed to insert connector enrichment suggestion',
+        error,
+        {
+          userId: input.userId,
+          eventTitle: event.title,
+        }
+      );
+    }
+  }
+
+  return created;
+}

--- a/apps/web/lib/connectors/enrichment/types.ts
+++ b/apps/web/lib/connectors/enrichment/types.ts
@@ -1,0 +1,72 @@
+import type { ConnectorProviderId } from '@/lib/connectors/types';
+import type { ContextFact } from '@/lib/db/schema/connectors';
+import type { MemoryEntityType } from '@/lib/db/schema/memory';
+
+/** Scope required for connector enrichment + memory graph writes. */
+export interface ConnectorEnrichmentScope {
+  readonly userId: string;
+  readonly creatorProfileId: string;
+}
+
+export interface ConnectorEnrichmentAccountContext {
+  readonly scope: ConnectorEnrichmentScope;
+  readonly gmailAccountId: string | null;
+  readonly calendarAccountId: string | null;
+}
+
+export type ConnectorEnrichmentProviderId = Extract<
+  ConnectorProviderId,
+  'gmail' | 'google_calendar'
+>;
+
+export interface ExtractedEntityMention {
+  readonly type: MemoryEntityType;
+  readonly name: string;
+  readonly confidence: number;
+  readonly factKind:
+    | 'person_mentioned'
+    | 'song_mentioned'
+    | 'location_mentioned'
+    | 'studio_location';
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface ExtractedEventFact {
+  readonly kind: 'event_signal' | 'tour_date_known';
+  readonly title: string;
+  readonly startsAt: string;
+  readonly endsAt?: string | null;
+  readonly venueName?: string | null;
+  readonly city?: string | null;
+  readonly region?: string | null;
+  readonly country?: string | null;
+  readonly confidence: number;
+  readonly rationale: string;
+  readonly sourceRefs: readonly Record<string, unknown>[];
+}
+
+export interface ConnectorEnrichmentPipelineResult {
+  readonly provider: ConnectorEnrichmentProviderId;
+  readonly externalObjectsProcessed: number;
+  readonly contextFactsCreated: number;
+  readonly memoryObservationsCreated: number;
+  readonly memoryEntitiesCreated: number;
+  readonly suggestionsCreated: number;
+}
+
+export interface ConnectorEnrichmentRunResult {
+  readonly pipelines: readonly ConnectorEnrichmentPipelineResult[];
+  readonly totalSuggestionsCreated: number;
+}
+
+export interface ConnectorEnrichmentPipeline {
+  readonly provider: ConnectorEnrichmentProviderId;
+  run(
+    context: ConnectorEnrichmentAccountContext
+  ): Promise<ConnectorEnrichmentPipelineResult>;
+}
+
+export type PersistedContextFact = Pick<
+  ContextFact,
+  'id' | 'kind' | 'data' | 'confidence' | 'sourceObjectId'
+>;

--- a/apps/web/lib/connectors/extract-and-propose.ts
+++ b/apps/web/lib/connectors/extract-and-propose.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import { and, eq } from 'drizzle-orm';
+import { runConnectorEnrichment } from '@/lib/connectors/enrichment';
 import {
   buildGmailBookingQuery,
   type GmailMessage,
@@ -7,23 +8,10 @@ import {
   getHeader,
   listGmailMessages,
 } from '@/lib/connectors/gmail/client';
-import {
-  extractEventSignal,
-  type GmailMessageInput,
-} from '@/lib/connectors/gmail/extract-event-signal';
-import {
-  hasOverlappingEvent,
-  listCalendarEvents,
-  SyncTokenExpiredError,
-} from '@/lib/connectors/google-calendar/list-events';
 import { CONNECTOR_PROVIDERS } from '@/lib/connectors/registry';
 import { loadDecryptedToken } from '@/lib/connectors/token-vault';
 import { db } from '@/lib/db';
-import {
-  connectorAccounts,
-  externalObjects,
-  suggestedActions,
-} from '@/lib/db/schema/connectors';
+import { connectorAccounts, externalObjects } from '@/lib/db/schema/connectors';
 import { env } from '@/lib/env-server';
 import { captureError } from '@/lib/error-tracking';
 import { logger } from '@/lib/utils/logger';
@@ -35,17 +23,20 @@ const DEFAULT_GMAIL_WINDOW_DAYS = 30;
  *
  * Steps:
  * 1. Load decrypted tokens for the user's Gmail + Calendar connector accounts.
- * 2. Fetch Gmail booking candidates via narrow query.
- * 3. Extract event signals via AI Gateway.
- * 4. Check Calendar for existing events (dedup).
- * 5. Write new suggested_actions rows for candidates without Calendar conflicts.
+ * 2. Fetch Gmail booking candidates via narrow query and persist external_objects.
+ * 3. Run connector enrichment pipelines (context_facts + memory graph + suggestions).
  *
  * @returns Number of new suggested actions created.
  */
 export async function extractAndPropose(userId: string): Promise<number> {
-  // -------------------------------------------------------------------------
-  // 1. Resolve connector accounts
-  // -------------------------------------------------------------------------
+  const synced = await syncGmailExternalObjects(userId);
+  if (!synced) return 0;
+
+  const enrichment = await runConnectorEnrichment(userId);
+  return enrichment.totalSuggestionsCreated;
+}
+
+async function syncGmailExternalObjects(userId: string): Promise<boolean> {
   const [gmailAccount, calendarAccount] = await Promise.all([
     db
       .select({ id: connectorAccounts.id })
@@ -77,22 +68,15 @@ export async function extractAndPropose(userId: string): Promise<number> {
     logger.info('[extract-and-propose] Skipping — connectors not connected', {
       userId,
     });
-    return 0;
+    return false;
   }
 
-  const [gmailTokens, calendarTokens] = await Promise.all([
-    loadDecryptedToken(gmailAccount.id),
-    loadDecryptedToken(calendarAccount.id),
-  ]);
-
-  if (!gmailTokens || !calendarTokens) {
+  const gmailTokens = await loadDecryptedToken(gmailAccount.id);
+  if (!gmailTokens) {
     logger.error('[extract-and-propose] Token load failed', { userId });
-    return 0;
+    return false;
   }
 
-  // -------------------------------------------------------------------------
-  // 2. Fetch Gmail booking candidates
-  // -------------------------------------------------------------------------
   const historyWindowDays =
     parseInt(env.GMAIL_HISTORY_WINDOW_DAYS ?? '', 10) ||
     DEFAULT_GMAIL_WINDOW_DAYS;
@@ -109,17 +93,16 @@ export async function extractAndPropose(userId: string): Promise<number> {
     logger.info('[extract-and-propose] No Gmail booking candidates found', {
       userId,
     });
-    return 0;
+    return true;
   }
 
-  // Fetch full metadata for each message (up to 20).
   const messageDetails = await Promise.allSettled(
     messageStubs
       .slice(0, 20)
       .map(stub => getGmailMessage(gmailTokens.accessToken, stub.id))
   );
 
-  const messages: GmailMessageInput[] = messageDetails
+  const messages = messageDetails
     .filter(
       (r): r is PromiseFulfilledResult<GmailMessage> => r.status === 'fulfilled'
     )
@@ -131,7 +114,6 @@ export async function extractAndPropose(userId: string): Promise<number> {
       snippet: r.value.snippet ?? '',
     }));
 
-  // Store normalized (non-body) message metadata in external_objects.
   await Promise.allSettled(
     messages.map(m =>
       db
@@ -152,97 +134,21 @@ export async function extractAndPropose(userId: string): Promise<number> {
     )
   );
 
-  // -------------------------------------------------------------------------
-  // 3. Extract event signals via AI
-  // -------------------------------------------------------------------------
-  const extraction = await extractEventSignal(messages, userId);
-
-  if (extraction.events.length === 0) {
-    logger.info('[extract-and-propose] No event signals extracted', { userId });
-    return 0;
-  }
-
-  // -------------------------------------------------------------------------
-  // 4. Check Calendar for conflicts
-  // -------------------------------------------------------------------------
-  let calendarEvents;
-  try {
-    const calResult = await listCalendarEvents(calendarTokens.accessToken);
-    calendarEvents = calResult.items;
-  } catch (err) {
-    if (err instanceof SyncTokenExpiredError) {
-      const calResult = await listCalendarEvents(calendarTokens.accessToken);
-      calendarEvents = calResult.items;
-    } else {
-      throw err;
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // 5. Write suggested_actions for non-duplicate events
-  // -------------------------------------------------------------------------
-  let created = 0;
-
-  for (const event of extraction.events) {
-    if (event.confidence < 0.7) {
-      logger.info('[extract-and-propose] Skipping low-confidence event', {
-        title: event.title,
-        confidence: event.confidence,
-      });
-      continue;
-    }
-
-    if (hasOverlappingEvent(event.startsAt, calendarEvents, 6)) {
-      logger.info(
-        '[extract-and-propose] Calendar conflict detected, skipping',
-        {
-          title: event.title,
-        }
-      );
-      continue;
-    }
-
-    const payload = {
-      title: event.title,
-      startsAt: event.startsAt,
-      endsAt: event.endsAt,
-      venueName: event.venueName,
-      city: event.city,
-      region: event.region,
-      country: event.country,
-      rationale: event.rationale,
-      confidence: event.confidence,
-    };
-
-    try {
-      await db
-        .insert(suggestedActions)
-        .values({
-          userId,
-          kind: 'calendar.create_event',
-          targetConnectorAccountId: calendarAccount.id,
-          payload,
-          status: 'pending',
-          sourceRefs: [event.sourceRef],
-          rationale: event.rationale,
-          idempotencyKey: `${userId}-${event.sourceRef.messageId}-${event.startsAt}`,
-          sideEffects: [],
-        })
-        .onConflictDoNothing();
-
-      created++;
-    } catch (err) {
-      await captureError('Failed to insert suggested_action', err, {
-        userId,
-        eventTitle: event.title,
-      });
-    }
-  }
-
-  logger.info('[extract-and-propose] Complete', {
+  logger.info('[extract-and-propose] Gmail external_objects synced', {
     userId,
-    created,
-    total: extraction.events.length,
+    messageCount: messages.length,
   });
-  return created;
+
+  return true;
+}
+
+export async function extractAndProposeWithErrorCapture(
+  userId: string
+): Promise<number> {
+  try {
+    return await extractAndPropose(userId);
+  } catch (error) {
+    await captureError('extractAndPropose failed', error, { userId });
+    throw error;
+  }
 }

--- a/apps/web/lib/connectors/schema-errors.ts
+++ b/apps/web/lib/connectors/schema-errors.ts
@@ -3,6 +3,8 @@ import { getDeepErrorMessage, unwrapPgError } from '@/lib/db/errors';
 /** Connector v1 tables introduced in migration 0048 (JOV-2229). */
 export const CONNECTOR_SCHEMA_TABLES = [
   'connector_accounts',
+  'context_facts',
+  'external_objects',
   'suggested_actions',
   'workflow_runs',
 ] as const;

--- a/apps/web/lib/db/schema/enums.ts
+++ b/apps/web/lib/db/schema/enums.ts
@@ -749,6 +749,13 @@ export const contextFactKindEnum = pgEnum('context_fact_kind', [
   'social_engagement',
   'playlist_placement',
   'other',
+  // Connector enrichment (JOV-3114) — also created in migration 0048 for greenfield DBs
+  'event_signal',
+  'tour_date_known',
+  'person_mentioned',
+  'song_mentioned',
+  'location_mentioned',
+  'studio_location',
 ]);
 
 export const suggestedActionStatusEnum = pgEnum('suggested_action_status', [


### PR DESCRIPTION
Linear: https://linear.app/jovie/issue/JOV-3114

<!-- linear-issue-id:JOV-3114 -->

## Summary

Adds `lib/connectors/enrichment/` — per-connector pipelines that turn synced `external_objects` into `context_facts`, memory graph observations, and `suggested_actions`. Refactors `extractAndPropose` to sync Gmail objects then delegate enrichment to the runner.

## Changes

- **Gmail pipeline**: entity mention extraction (people/locations/studios) + event signals via existing AI extractor → `context_facts` + memory observations + calendar suggestions
- **Calendar pipeline**: syncs calendar events to `external_objects`, emits tour-date facts + location/studio mentions into memory graph
- **Migration 0065**: extends `context_fact_kind` with connector enrichment values
- **Deferred**: Apple Photos connector (`photos.ts` stub) until JOV-2919

## Validation

- `pnpm --filter @jovie/web exec vitest run lib/connectors tests/unit/memory/memory-core-services.test.ts tests/integration/connectors` — 95 passed
- `pnpm --filter @jovie/web run typecheck` — pass
- `pnpm biome check --write apps/web/lib/connectors/enrichment` — pass
- `pnpm --filter @jovie/web run migration:validate` — pass

## Rollback

Revert PR; migration 0065 only adds enum values (non-destructive). Enrichment runner no-ops when connector schema is missing.

## Deferred follow-ups

- JOV-2918: WorkflowDefinition registry (move executors out of `lib/connectors/`)
- JOV-2919: Apple Photos connector manifest