### PR TITLE
feat(ios): ship profile settings account surface (JOV-3640)

### DIFF
--- a/apps/ios/Jovie/App/AppState.swift
+++ b/apps/ios/Jovie/App/AppState.swift
@@ -234,4 +234,12 @@ final class AppState {
   var billingURL: URL {
     continueOnWebURL.appending(path: "settings/billing")
   }
+
+  var editProfileURL: URL {
+    continueOnWebURL.appending(path: "settings/artist-profile")
+  }
+
+  var connectionsURL: URL {
+    continueOnWebURL.appending(path: "settings/connectors")
+  }
 }

--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -196,6 +196,8 @@ private struct AppContentView: View {
           initialTab: .profile,
           opensSettingsOnLaunch: appState.launchMode.opensSettingsOnLaunch,
           billingURL: appState.billingURL,
+          editProfileURL: appState.editProfileURL,
+          connectionsURL: appState.connectionsURL,
           chatEnabled: false,
           recentConversations: chatRepository?.conversations ?? [],
           onSelectConversation: { conversationID in
@@ -223,6 +225,8 @@ private struct AppContentView: View {
           initialTab: appState.launchMode.opensChatOnLaunch ? .chat : .profile,
           opensSettingsOnLaunch: appState.launchMode.opensSettingsOnLaunch,
           billingURL: appState.billingURL,
+          editProfileURL: appState.editProfileURL,
+          connectionsURL: appState.connectionsURL,
           chatEnabled: appState.loadedDashboardResponse?.chatEnabled ?? false,
           recentConversations: chatRepository?.conversations ?? [],
           onSelectConversation: { conversationID in

--- a/apps/ios/Jovie/Core/MobileMeResponse.swift
+++ b/apps/ios/Jovie/Core/MobileMeResponse.swift
@@ -15,6 +15,8 @@ struct MobileMeResponse: Codable, Equatable, Sendable {
   let appleWalletProfilePassAvailable: Bool
   let chatEnabled: Bool
   let continueOnWebURL: String
+  let plan: String
+  let isPro: Bool
 
   enum CodingKeys: String, CodingKey {
     case state
@@ -26,6 +28,8 @@ struct MobileMeResponse: Codable, Equatable, Sendable {
     case appleWalletProfilePassAvailable
     case chatEnabled
     case continueOnWebURL = "continueOnWebUrl"
+    case plan
+    case isPro
   }
 
   static let previewReady = MobileMeResponse(
@@ -37,7 +41,23 @@ struct MobileMeResponse: Codable, Equatable, Sendable {
     avatarURL: nil,
     appleWalletProfilePassAvailable: false,
     chatEnabled: true,
-    continueOnWebURL: "https://jov.ie/app"
+    continueOnWebURL: "https://jov.ie/app",
+    plan: "free",
+    isPro: false
+  )
+
+  static let previewReadyWithoutQR = MobileMeResponse(
+    state: .ready,
+    displayName: "Tim White",
+    username: "tim",
+    publicProfileURL: "https://jov.ie/tim",
+    qrPayload: nil,
+    avatarURL: nil,
+    appleWalletProfilePassAvailable: false,
+    chatEnabled: true,
+    continueOnWebURL: "https://jov.ie/app",
+    plan: "free",
+    isPro: false
   )
 
   static let previewNeedsOnboarding = MobileMeResponse(
@@ -49,6 +69,8 @@ struct MobileMeResponse: Codable, Equatable, Sendable {
     avatarURL: nil,
     appleWalletProfilePassAvailable: false,
     chatEnabled: false,
-    continueOnWebURL: "https://jov.ie/app"
+    continueOnWebURL: "https://jov.ie/app",
+    plan: "free",
+    isPro: false
   )
 }

--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -41,12 +41,16 @@ struct AppShellProfile: Equatable {
   let username: String?
   let publicProfileURL: String?
   let avatarURL: URL?
+  let plan: String
+  let isPro: Bool
 
   init(response: MobileMeResponse?) {
     displayName = response?.displayName ?? response?.username ?? "Jovie"
     username = response?.username
     publicProfileURL = response?.publicProfileURL
     avatarURL = response?.avatarURL.flatMap(URL.init(string:))
+    plan = response?.plan ?? "free"
+    isPro = response?.isPro ?? false
   }
 
   var secondaryText: String {
@@ -56,6 +60,23 @@ struct AppShellProfile: Equatable {
 
     return publicProfileURL ?? "Profile setup pending"
   }
+
+  var planLabel: String {
+    switch plan.lowercased() {
+    case "max":
+      return "Max"
+    case "pro":
+      return "Pro"
+    case "trial":
+      return "Trial"
+    default:
+      return "Free"
+    }
+  }
+
+  var showsUpgradeCTA: Bool {
+    !isPro && plan.lowercased() != "max"
+  }
 }
 
 struct AppShellView<ProfileContent: View, ChatContent: View>: View {
@@ -63,6 +84,8 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
   let isOffline: Bool
   let opensSettingsOnLaunch: Bool
   let billingURL: URL
+  let editProfileURL: URL
+  let connectionsURL: URL
   let chatEnabled: Bool
   let recentConversations: [MobileConversationSummary]
   let onSelectConversation: (String) -> Void
@@ -83,6 +106,8 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
     initialTab: AppShellTab = .profile,
     opensSettingsOnLaunch: Bool = false,
     billingURL: URL,
+    editProfileURL: URL,
+    connectionsURL: URL,
     chatEnabled: Bool = false,
     recentConversations: [MobileConversationSummary] = [],
     onSelectConversation: @escaping (String) -> Void = { _ in },
@@ -94,6 +119,8 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
     self.isOffline = isOffline
     self.opensSettingsOnLaunch = opensSettingsOnLaunch
     self.billingURL = billingURL
+    self.editProfileURL = editProfileURL
+    self.connectionsURL = connectionsURL
     self.chatEnabled = chatEnabled
     self.recentConversations = recentConversations
     self.onSelectConversation = onSelectConversation
@@ -128,7 +155,9 @@ struct AppShellView<ProfileContent: View, ChatContent: View>: View {
           SettingsView(
             profile: profile,
             buildInfo: .current(),
+            editProfileURL: editProfileURL,
             billingURL: billingURL,
+            connectionsURL: connectionsURL,
             onClose: { navigationPath.removeLast() },
             onLogout: onLogout
           )

--- a/apps/ios/Jovie/Features/Settings/SettingsView.swift
+++ b/apps/ios/Jovie/Features/Settings/SettingsView.swift
@@ -15,7 +15,9 @@ struct AppBuildInfo: Equatable {
 struct SettingsView: View {
   let profile: AppShellProfile
   let buildInfo: AppBuildInfo
+  let editProfileURL: URL
   let billingURL: URL
+  let connectionsURL: URL
   var onClose: (() -> Void)?
   let onLogout: @MainActor () async -> Void
 
@@ -27,6 +29,8 @@ struct SettingsView: View {
       VStack(alignment: .leading, spacing: JovieSpacing.xLarge) {
         header
         accountSection
+        planSection
+        connectionsSection
         linksSection
         buildSection
         logoutButton
@@ -61,28 +65,81 @@ struct SettingsView: View {
     VStack(alignment: .leading, spacing: JovieSpacing.medium) {
       SettingsSectionTitle("Account")
 
-      HStack(spacing: JovieSpacing.medium) {
-        DashboardAvatarView(
-          name: profile.displayName,
-          avatarURL: profile.avatarURL
-        )
-        .frame(width: 34, height: 34)
+      VStack(spacing: 0) {
+        HStack(spacing: JovieSpacing.medium) {
+          DashboardAvatarView(
+            name: profile.displayName,
+            avatarURL: profile.avatarURL
+          )
+          .frame(width: 34, height: 34)
 
-        VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
-          Text(profile.displayName)
-            .font(JovieFont.body(size: 15, weight: .semibold))
-            .foregroundStyle(JovieColor.textPrimary)
-            .lineLimit(1)
+          VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
+            Text(profile.displayName)
+              .font(JovieFont.body(size: 15, weight: .semibold))
+              .foregroundStyle(JovieColor.textPrimary)
+              .lineLimit(1)
 
-          Text(profile.secondaryText)
-            .font(JovieFont.body(size: 13))
-            .foregroundStyle(JovieColor.textTertiary)
-            .lineLimit(1)
+            Text(profile.secondaryText)
+              .font(JovieFont.body(size: 13))
+              .foregroundStyle(JovieColor.textTertiary)
+              .lineLimit(1)
+          }
+
+          Spacer(minLength: 0)
         }
+        .padding(JovieSpacing.medium)
 
-        Spacer(minLength: 0)
+        SettingsDivider()
+
+        SettingsLinkRow(title: "Edit Profile", systemImage: "person.crop.circle") {
+          openURL(editProfileURL)
+        }
       }
-      .padding(JovieSpacing.medium)
+      .background(JovieColor.surface0, in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
+    }
+  }
+
+  private var planSection: some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.medium) {
+      SettingsSectionTitle("Plan")
+
+      VStack(spacing: JovieSpacing.medium) {
+        VStack(spacing: 0) {
+          SettingsValueRow(title: "Current plan", value: profile.planLabel)
+
+          SettingsDivider()
+
+          SettingsLinkRow(title: "Billing", systemImage: "creditcard") {
+            openURL(billingURL)
+          }
+        }
+        .padding(.vertical, JovieSpacing.xSmall)
+        .background(JovieColor.surface0, in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
+
+        if profile.showsUpgradeCTA {
+          Button {
+            openURL(billingURL)
+          } label: {
+            Label("Upgrade", systemImage: "sparkles")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(JoviePillButtonStyle(filled: true))
+          .accessibilityIdentifier("settings-upgrade-button")
+        }
+      }
+    }
+  }
+
+  private var connectionsSection: some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.medium) {
+      SettingsSectionTitle("Connections")
+
+      VStack(spacing: 0) {
+        SettingsLinkRow(title: "Connected Accounts", systemImage: "link") {
+          openURL(connectionsURL)
+        }
+      }
+      .padding(.vertical, JovieSpacing.xSmall)
       .background(JovieColor.surface0, in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
     }
   }
@@ -94,12 +151,6 @@ struct SettingsView: View {
       VStack(spacing: 0) {
         SettingsLinkRow(title: "Support", systemImage: "questionmark.circle") {
           openURL(URL(string: "https://jov.ie/support")!)
-        }
-
-        SettingsDivider()
-
-        SettingsLinkRow(title: "Billing", systemImage: "creditcard") {
-          openURL(billingURL)
         }
 
         SettingsDivider()

--- a/apps/ios/JovieTests/AppStateTests.swift
+++ b/apps/ios/JovieTests/AppStateTests.swift
@@ -96,7 +96,9 @@ struct AppStateTests {
       avatarURL: nil,
       appleWalletProfilePassAvailable: false,
       chatEnabled: true,
-      continueOnWebURL: "https://jov.ie/app"
+      continueOnWebURL: "https://jov.ie/app",
+      plan: "pro",
+      isPro: true
     )
     let repository = MockRepository(
       nextResult: .success(MeRepositoryResult(response: fresh, isStale: false)),
@@ -167,6 +169,72 @@ struct AppStateTests {
     await appState.handleSignedInUserChange("user_123")
 
     #expect(appState.route == .needsOnboarding)
+    guard case let .loaded(response) = appState.dashboardState else {
+      Issue.record("Needs-onboarding profile must stay loaded for continue URL.")
+      return
+    }
+    #expect(response.state == .needsOnboarding)
+    #expect(appState.continueOnWebURL.absoluteString == "https://jov.ie/app")
+  }
+
+  @Test func coldProfileLoadShowsInteractiveShellBeforeNetworkReturns() async throws {
+    let repository = MockRepository(
+      nextResult: .success(
+        MeRepositoryResult(response: .previewReady, isStale: false)
+      ),
+      loadDelay: .milliseconds(300)
+    )
+    let appState = AppState(
+      configuration: configuration,
+      launchMode: .live,
+      repository: repository,
+      brightnessManager: MockBrightnessController()
+    )
+    appState.didLoadClerk = true
+
+    async let change: Void = appState.handleSignedInUserChange("user_123")
+
+    try await Task.sleep(for: .milliseconds(20))
+    #expect(appState.route == .ready)
+    #expect(appState.dashboardState == .loading)
+
+    await change
+
+    #expect(appState.dashboardState == .loaded(.previewReady))
+  }
+
+  @Test func cachedNeedsOnboardingSnapshotPreservesContinueOnWebURL() async throws {
+    let onboarding = MobileMeResponse(
+      state: .needsOnboarding,
+      displayName: nil,
+      username: nil,
+      publicProfileURL: nil,
+      qrPayload: nil,
+      avatarURL: nil,
+      appleWalletProfilePassAvailable: false,
+      chatEnabled: false,
+      continueOnWebURL: "https://jov.ie/onboarding/start",
+      plan: "free",
+      isPro: false
+    )
+    let repository = MockRepository(
+      nextResult: .success(
+        MeRepositoryResult(response: onboarding, isStale: false)
+      ),
+      cached: onboarding
+    )
+    let appState = AppState(
+      configuration: configuration,
+      launchMode: .live,
+      repository: repository,
+      brightnessManager: MockBrightnessController()
+    )
+    appState.didLoadClerk = true
+
+    await appState.handleSignedInUserChange("user_123")
+
+    #expect(appState.route == .needsOnboarding)
+    #expect(appState.continueOnWebURL.absoluteString == "https://jov.ie/onboarding/start")
   }
 
   @Test func signOutResetsRouteAndClearsActiveUserCache() async throws {
@@ -560,5 +628,22 @@ struct AppStateTests {
     )
 
     #expect(appState.billingURL.absoluteString == "https://jov.ie/app/settings/billing")
+  }
+
+  @Test func settingsHandoffURLsOpenWebProfileAndConnections() {
+    let repository = MockRepository(
+      nextResult: .success(
+        MeRepositoryResult(response: .previewReady, isStale: false)
+      )
+    )
+    let appState = AppState(
+      configuration: configuration,
+      launchMode: .live,
+      repository: repository,
+      brightnessManager: MockBrightnessController()
+    )
+
+    #expect(appState.editProfileURL.absoluteString == "https://jov.ie/app/settings/artist-profile")
+    #expect(appState.connectionsURL.absoluteString == "https://jov.ie/app/settings/connectors")
   }
 }

--- a/apps/ios/JovieTests/MobileMeResponseTests.swift
+++ b/apps/ios/JovieTests/MobileMeResponseTests.swift
@@ -14,7 +14,9 @@ struct MobileMeResponseTests {
         "avatarUrl": null,
         "appleWalletProfilePassAvailable": true,
         "chatEnabled": true,
-        "continueOnWebUrl": "https://jov.ie/app"
+        "continueOnWebUrl": "https://jov.ie/app",
+        "plan": "free",
+        "isPro": false
       }
       """.data(using: .utf8)!
 
@@ -24,6 +26,8 @@ struct MobileMeResponseTests {
     #expect(response.publicProfileURL == "https://jov.ie/tim")
     #expect(response.appleWalletProfilePassAvailable == true)
     #expect(response.chatEnabled == true)
+    #expect(response.plan == "free")
+    #expect(response.isPro == false)
   }
 
   @Test func decodesNeedsOnboardingResponse() throws {
@@ -37,7 +41,9 @@ struct MobileMeResponseTests {
         "avatarUrl": null,
         "appleWalletProfilePassAvailable": false,
         "chatEnabled": false,
-        "continueOnWebUrl": "https://jov.ie/app"
+        "continueOnWebUrl": "https://jov.ie/app",
+        "plan": "free",
+        "isPro": false
       }
       """.data(using: .utf8)!
 

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -81,6 +81,31 @@ final class JovieUITests: XCTestCase {
     }
 
     attachScreenshot(named: "settings", app: app)
+    for linkTitle in ["Edit Profile", "Billing", "Connected Accounts", "Support", "Privacy", "Terms"] {
+      XCTAssertTrue(
+        app.buttons[linkTitle].waitForExistence(timeout: 2),
+        "Settings row \(linkTitle) did not appear.\n\(app.debugDescription)"
+      )
+    }
+    XCTAssertTrue(
+      app.buttons["Upgrade"].waitForExistence(timeout: 2),
+      "Settings upgrade CTA did not appear for the preview free plan.\n\(app.debugDescription)"
+    )
+    XCTAssertTrue(
+      app.staticTexts["Current plan"].waitForExistence(timeout: 2),
+      "Settings plan summary did not appear.\n\(app.debugDescription)"
+    )
+    XCTAssertTrue(
+      app.staticTexts["Free"].waitForExistence(timeout: 2),
+      "Settings plan label did not appear.\n\(app.debugDescription)"
+    )
+    for valueTitle in ["Version", "Build"] {
+      XCTAssertTrue(
+        app.staticTexts[valueTitle].waitForExistence(timeout: 2),
+        "Settings value row \(valueTitle) did not appear.\n\(app.debugDescription)"
+      )
+    }
+
     app.buttons["Log Out"].tap()
 
     XCTAssertTrue(

--- a/apps/web/app/api/mobile/v1/me/route.ts
+++ b/apps/web/app/api/mobile/v1/me/route.ts
@@ -20,6 +20,14 @@ export interface MobileMeResponse {
   continueOnWebUrl: string;
   appleWalletProfilePassAvailable: boolean;
   chatEnabled: boolean;
+  plan: 'free' | 'trial' | 'pro' | 'max';
+  isPro: boolean;
+}
+
+function resolveMobilePlan(
+  isPro: boolean | null | undefined
+): MobileMeResponse['plan'] {
+  return isPro ? 'pro' : 'free';
 }
 
 function buildNeedsOnboardingResponse(): NextResponse {
@@ -33,6 +41,8 @@ function buildNeedsOnboardingResponse(): NextResponse {
     continueOnWebUrl: getAppUrl(),
     appleWalletProfilePassAvailable: false,
     chatEnabled: false,
+    plan: 'free',
+    isPro: false,
   };
 
   return NextResponse.json(payload, {
@@ -107,6 +117,7 @@ export async function GET(request: Request) {
         onboardingCompletedAt: profile.onboardingCompletedAt,
       });
     const chatEnabled = await isMobileChatEnabled(userId);
+    const isPro = session.user.isPro ?? false;
     const payload: MobileMeResponse = {
       state: 'ready',
       displayName: profile.displayName,
@@ -117,6 +128,8 @@ export async function GET(request: Request) {
       continueOnWebUrl: getAppUrl(),
       appleWalletProfilePassAvailable,
       chatEnabled,
+      plan: resolveMobilePlan(isPro),
+      isPro,
     };
 
     return NextResponse.json(payload, {

--- a/apps/web/tests/unit/api/mobile/v1/me.test.ts
+++ b/apps/web/tests/unit/api/mobile/v1/me.test.ts
@@ -131,6 +131,8 @@ describe('GET /api/mobile/v1/me', () => {
       continueOnWebUrl: 'https://jov.ie/app',
       appleWalletProfilePassAvailable: true,
       chatEnabled: true,
+      plan: 'free',
+      isPro: false,
     });
     expect(hoisted.isProfileCompleteMock).toHaveBeenCalledWith({
       username: 'djshadow',
@@ -139,6 +141,32 @@ describe('GET /api/mobile/v1/me', () => {
       isPublic: true,
       onboardingCompletedAt: new Date('2026-04-01T00:00:00.000Z'),
     });
+  });
+
+  it('returns pro plan metadata for paid users', async () => {
+    hoisted.getSessionContextMock.mockResolvedValue({
+      user: {
+        userStatus: 'active',
+        isPro: true,
+      },
+      profile: {
+        id: 'profile_123',
+        username: 'djshadow',
+        usernameNormalized: 'djshadow',
+        displayName: 'DJ Shadow',
+        avatarUrl: null,
+        isPublic: true,
+        onboardingCompletedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+    });
+
+    const { GET } = await routeModulePromise;
+    const response = await GET(makeRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.plan).toBe('pro');
+    expect(data.isPro).toBe(true);
   });
 
   it('reports chatEnabled from the mobile chat runtime switch', async () => {
@@ -187,6 +215,8 @@ describe('GET /api/mobile/v1/me', () => {
       continueOnWebUrl: 'https://jov.ie/app',
       appleWalletProfilePassAvailable: false,
       chatEnabled: false,
+      plan: 'free',
+      isPro: false,
     });
   });
 
@@ -213,6 +243,8 @@ describe('GET /api/mobile/v1/me', () => {
       continueOnWebUrl: 'https://jov.ie/app',
       appleWalletProfilePassAvailable: false,
       chatEnabled: false,
+      plan: 'free',
+      isPro: false,
     });
   });
 
@@ -248,6 +280,8 @@ describe('GET /api/mobile/v1/me', () => {
       continueOnWebUrl: 'https://jov.ie/app',
       appleWalletProfilePassAvailable: false,
       chatEnabled: false,
+      plan: 'free',
+      isPro: false,
     });
   });
 


### PR DESCRIPTION
## Goal

Ship the iOS Profile / Settings account surface required by JOV-3640: edit profile, upgrade CTA, manage connections, and sign out.

Linear: https://linear.app/jovie/issue/JOV-3640

<!-- linear-issue-id:JOV-3640 -->

## Changes

- Extend `/api/mobile/v1/me` with `plan` and `isPro` for upgrade-state rendering
- Restructure `SettingsView` with Account (Edit Profile), Plan (current plan + Upgrade CTA + Billing), and Connections (Connected Accounts) sections
- Add web handoff URLs in `AppState` for artist profile and connectors settings
- Update iOS unit/UI tests and feature-status ledger (IOS-013)

## Testing

- `pnpm run ios:test` — all JovieTests + JovieUITests passed (including settings upgrade/edit/connections assertions)
- `npx vitest run tests/unit/api/mobile/v1/me.test.ts` — 9/9 passed
- `pnpm run typecheck` — passed

## Rollback

Revert this PR; no migrations or destructive data changes.

bug-to-test: waived — feature surface expansion with new UI + API contract tests added in same PR.