### PR TITLE
fix(pipeline): add checkout steps and make Linear dispatcher configurable

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -433,6 +433,13 @@ jobs:
           app-id: ${{ vars.JOVIE_BOT_APP_ID }}
           private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
 
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: |
+            scripts/lib/upsert-pr-comment.sh
+          sparse-checkout-cone-mode: false
+
       - name: Label and comment systemic blocker
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -494,6 +501,13 @@ jobs:
             exit 1
           fi
           echo "PR is from the same repository. Proceeding."
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: |
+            scripts/lib/upsert-pr-comment.sh
+          sparse-checkout-cone-mode: false
 
       - name: Request unprivileged remediation
         env:

--- a/.github/workflows/linear-ai-dispatcher.yml
+++ b/.github/workflows/linear-ai-dispatcher.yml
@@ -40,8 +40,8 @@ jobs:
     timeout-minutes: 10
     permissions: {}
     env:
-      PROJECT_NAME: ${{ inputs.project_name || 'Design V1 Rollout / Flag Hardening' }}
-      READY_LABEL: ${{ inputs.ready_label || 'automated' }}
+      PROJECT_NAME: ${{ inputs.project_name || vars.LINEAR_PROJECT_NAME || 'Design V1 Rollout / Flag Hardening' }}
+      READY_LABEL: ${{ inputs.ready_label || vars.LINEAR_READY_LABEL || 'automated' }}
       MAX_DISPATCH: ${{ inputs.max_dispatch || '2' }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
       MAX_OPEN_AGENT_PRS: '5'
@@ -52,6 +52,18 @@ jobs:
         with:
           app-id: ${{ vars.JOVIE_BOT_APP_ID }}
           private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
+
+      - name: Validate configuration
+        run: |
+          if [[ -z "$PROJECT_NAME" ]]; then
+            echo "::error::PROJECT_NAME is not set. Configure it via the workflow_dispatch input 'project_name' or the repo variable 'LINEAR_PROJECT_NAME'."
+            exit 1
+          fi
+          if [[ -z "$READY_LABEL" ]]; then
+            echo "::error::READY_LABEL is not set. Configure it via the workflow_dispatch input 'ready_label' or the repo variable 'LINEAR_READY_LABEL'."
+            exit 1
+          fi
+          echo "Dispatching Linear issues from project '$PROJECT_NAME' with label '$READY_LABEL'"
 
       - name: Find capacity and dispatch candidates
         env:


### PR DESCRIPTION
## Summary

Fixes two blockers in the autonomous shipping pipeline:

### 1. Missing `actions/checkout` in `agent-pipeline.yml`

The `systemic-report` and `fix` jobs both call `bash scripts/lib/upsert-pr-comment.sh` but never checked out the repository first. This caused the workflow to fail with a "file not found" error.

**Fix:** Added a sparse `actions/checkout` step (checking out only `scripts/lib/upsert-pr-comment.sh`) before each invocation.

### 2. Hardcoded project/label in `linear-ai-dispatcher.yml`

`PROJECT_NAME` and `READY_LABEL` were hardcoded to `"Design V1 Rollout / Flag Hardening"` and `"automated"` respectively, making it impossible to reuse the dispatcher for other projects without editing the workflow file.

**Fix:** Made both values configurable via GitHub repo vars (`vars.LINEAR_PROJECT_NAME`, `vars.LINEAR_READY_LABEL`) with `workflow_dispatch` inputs taking precedence, then repo vars, then the original hardcoded defaults. Added a validation step that fails fast with a clear error message if neither is set.

## Files Changed
- `.github/workflows/agent-pipeline.yml`
- `.github/workflows/linear-ai-dispatcher.yml`