### PR TITLE
feat(ci): add intelligent PR conflict/freshness handler

### DIFF
--- a/.github/workflows/pr-conflict-handler.yml
+++ b/.github/workflows/pr-conflict-handler.yml
@@ -1,0 +1,75 @@
+name: PR Conflict Handler
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Apply safe mutations (labels/update-branch/guarded rebase). Defaults to dry-run.'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      max_concurrent:
+        description: 'Maximum CI-heavy PR freshness re-triggers, including in-flight CI.'
+        required: false
+        default: '2'
+  schedule:
+    # Read-only audit. Do not auto-push/rebase the fleet on a tight cadence.
+    - cron: '17 15 * * 1-5'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+  statuses: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  plan:
+    name: Classify and plan PR freshness
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-conflict-handler-${{ github.repository }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22.13.1'
+
+      - name: Run handler
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MODE="--dry-run"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.apply }}" == "true" ]]; then
+            MODE="--apply"
+          fi
+
+          node scripts/pr-conflict-handler.mjs "$MODE" \
+            --repo "${{ github.repository }}" \
+            --max-concurrent "${{ inputs.max_concurrent || '2' }}" \
+            --json | tee pr-conflict-handler-plan.log
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo '## PR conflict handler plan'
+            echo
+            echo '```text'
+            sed -n '1,160p' pr-conflict-handler-plan.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -452,6 +452,16 @@ This project has evolved through several migrations:
 - **Required Checks** - Typecheck, lint, fast tests
 - **Auto-Merge** - Enabled for Dependabot and approved PRs
 
+### PR Freshness / Conflict Handling
+
+Use the hardened PR conflict handler in dry-run mode before touching stale PRs:
+
+```bash
+node scripts/pr-conflict-handler.mjs --dry-run --max-concurrent 2
+```
+
+It classifies open PRs as `DIRTY`, `BEHIND`, `BLOCKED`, `UNSTABLE`, or `MERGEABLE`, orders safe work by base-branch dependency and diff size, respects in-flight CI, and caps CI-heavy re-triggers for the Neon pool. See [docs/pr-conflict-handler.md](docs/pr-conflict-handler.md) for apply-mode guardrails.
+
 ## Support
 
 - **Documentation** - Check [/docs](/docs) directory

--- a/docs/pr-conflict-handler.md
+++ b/docs/pr-conflict-handler.md
@@ -1,0 +1,68 @@
+# PR conflict and freshness handler
+
+`scripts/pr-conflict-handler.mjs` is the read-only-by-default control loop for keeping open PRs fresh without causing CI cancellation cascades.
+
+## Design goals
+
+The handler is intentionally conservative. It does **not** rebase the whole fleet. It classifies every open PR, orders the safe work, and only mutates a bounded number of CI-heavy PRs per run.
+
+| Classification | Signal | Action |
+| --- | --- | --- |
+| `DIRTY` | `mergeable=CONFLICTING` or `mergeStateStatus=DIRTY` | Internal branch: attempt guarded rebase with safe autoresolution only; fork/non-trivial conflict: label `needs-manual-rebase`. |
+| `BEHIND` | `mergeStateStatus=BEHIND` and mergeable | Use GitHub `update-branch`; cheaper and less risky than force-rebase. |
+| `BLOCKED` | required aggregate check failing/missing or `mergeStateStatus=BLOCKED` | Do **not** rebase. Label/flag for CI repair because rebasing just wastes CI. |
+| `UNSTABLE` | `mergeStateStatus=UNSTABLE` or any check is running/queued | Wait. Pushing would cancel the in-flight run via concurrency groups. |
+| `MERGEABLE` | mergeable and not stale | No-op. |
+
+Required checks default to Jovie's merge gate aggregates: `CI / PR Ready`, `CI / Migration Guard`, and `Fork PR Gate`. Duplicate cancelled check-runs are tolerated when a successful aggregate context exists, matching the repo's merge-queue lessons.
+
+## Ordering and cascade avoidance
+
+Planning is deterministic and dependency-aware:
+
+1. Build a base-branch graph from open PR `baseRefName`/`headRefName`.
+2. Process roots before children so stacked or integration-base PRs settle before dependent branches.
+3. Within each level, process smallest diff first, then oldest PR, then PR number.
+4. Cap CI-heavy re-triggers with `--max-concurrent` (default `2`). The cap subtracts PRs whose CI is already in flight, so a run with two in-flight PRs schedules zero new update/rebase pushes.
+
+This is Neon-pool aware: the default stays below the 4-slot ephemeral branch pool, leaving room for normal developer CI and avoiding pool starvation.
+
+## Conflict handling policy
+
+The only automatic conflict resolution currently considered safe is lockfile-only conflict regeneration:
+
+- rebase in a temporary clone,
+- if the only conflicted path is `pnpm-lock.yaml`, take the rebased side and run `corepack pnpm install --lockfile-only --ignore-scripts`,
+- push with `git push --force-with-lease` only after the rebase succeeds.
+
+Any other conflict path is labeled `needs-manual-rebase` and skipped. Fork/cross-repository PRs are never mutated with the internal branch flow.
+
+## Usage
+
+Dry-run is the default and performs only read-only GitHub API calls:
+
+```bash
+node scripts/pr-conflict-handler.mjs --dry-run --max-concurrent 2
+```
+
+Emit the structured JSON plan too:
+
+```bash
+node scripts/pr-conflict-handler.mjs --dry-run --json
+```
+
+Apply safe mutations (labels, GitHub update-branch, guarded rebase flow):
+
+```bash
+node scripts/pr-conflict-handler.mjs --apply --max-concurrent 2
+```
+
+Every decision is logged as structured JSON with PR number, state, action, reason, base/head refs, whether the branch is internal, and whether the action triggers CI.
+
+## Tests
+
+Pure classification, check summarization, ordering, capacity, fork-safety, and conflict-autoresolution policy are tested without hitting the GitHub API:
+
+```bash
+pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/pr-conflict-handler.test.mjs
+```

--- a/package.json
+++ b/package.json
@@ -159,6 +159,8 @@
     "ci:merge-queue:check": "node scripts/ci-merge-queue-check.mjs validate",
     "ci:merge-queue:verify": "node scripts/ci-merge-queue-check.mjs verify",
     "ci:typecheck-gate-guard": "node scripts/ci-typecheck-gate-guard.mjs",
+    "pr:conflict:dry-run": "node scripts/pr-conflict-handler.mjs --dry-run",
+    "pr:conflict:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__/pr-conflict-handler.test.mjs",
     "ci:harness:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__",
     "doc:freshness:check": "node scripts/doc-freshness-lint.mjs",
     "doc:freshness:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__/doc-freshness.test.mjs",

--- a/scripts/lib/__tests__/pr-conflict-handler.test.mjs
+++ b/scripts/lib/__tests__/pr-conflict-handler.test.mjs
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPlan,
+  classifyPr,
+  isSafeAutoResolvableConflict,
+  orderPrsDependencyAware,
+  summarizeChecks,
+} from '../pr-conflict-handler.mjs';
+
+function pr(overrides) {
+  return {
+    number: 1,
+    title: 'Example PR',
+    createdAt: '2026-06-01T00:00:00Z',
+    baseRefName: 'main',
+    headRefName: 'tim/example',
+    headRepositoryOwner: { login: 'JovieInc' },
+    isCrossRepository: false,
+    isDraft: false,
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    labels: [],
+    statusCheckRollup: [],
+    changedFiles: 1,
+    additions: 5,
+    deletions: 1,
+    ...overrides,
+  };
+}
+
+const greenRequired = [
+  {
+    __typename: 'CheckRun',
+    name: 'PR Ready',
+    status: 'COMPLETED',
+    conclusion: 'SUCCESS',
+  },
+  {
+    __typename: 'CheckRun',
+    name: 'Migration Guard',
+    status: 'COMPLETED',
+    conclusion: 'SUCCESS',
+  },
+  { __typename: 'StatusContext', context: 'Fork PR Gate', state: 'SUCCESS' },
+];
+
+describe('PR freshness classification', () => {
+  it('classifies true conflicts before CI failures so they are not generic blocked PRs', () => {
+    const result = classifyPr(
+      pr({
+        mergeable: 'CONFLICTING',
+        mergeStateStatus: 'DIRTY',
+        statusCheckRollup: [
+          ...greenRequired,
+          { name: 'PR Ready', status: 'COMPLETED', conclusion: 'FAILURE' },
+        ],
+      })
+    );
+
+    expect(result.state).toBe('DIRTY');
+    expect(result.reason).toContain('mergeable=CONFLICTING');
+  });
+
+  it('classifies in-flight CI as UNSTABLE and waits to avoid cancellation churn', () => {
+    const result = classifyPr(
+      pr({
+        mergeStateStatus: 'UNSTABLE',
+        statusCheckRollup: [
+          ...greenRequired,
+          { name: 'Typecheck', status: 'IN_PROGRESS', conclusion: null },
+        ],
+      })
+    );
+
+    expect(result.state).toBe('UNSTABLE');
+    expect(result.reason).toContain('CI in flight');
+  });
+
+  it('classifies failing required checks as BLOCKED instead of rebasing', () => {
+    const result = classifyPr(
+      pr({
+        mergeStateStatus: 'BLOCKED',
+        statusCheckRollup: [
+          { name: 'PR Ready', status: 'COMPLETED', conclusion: 'FAILURE' },
+          {
+            name: 'Migration Guard',
+            status: 'COMPLETED',
+            conclusion: 'SUCCESS',
+          },
+          {
+            __typename: 'StatusContext',
+            context: 'Fork PR Gate',
+            state: 'SUCCESS',
+          },
+        ],
+      })
+    );
+
+    expect(result.state).toBe('BLOCKED');
+    expect(result.reason).toContain('PR Ready:FAILURE');
+  });
+
+  it('classifies mergeable stale branches as BEHIND for update-branch', () => {
+    const result = classifyPr(
+      pr({ mergeStateStatus: 'BEHIND', statusCheckRollup: greenRequired })
+    );
+
+    expect(result.state).toBe('BEHIND');
+  });
+
+  it('does not treat fork PRs as internal branches', () => {
+    const result = classifyPr(
+      pr({
+        headRefName: 'contributor/fix',
+        headRepositoryOwner: { login: 'external-user' },
+        isCrossRepository: true,
+        mergeStateStatus: 'BEHIND',
+        statusCheckRollup: greenRequired,
+      })
+    );
+
+    expect(result.internal).toBe(false);
+    expect(result.reason).toContain('fork or cross-repository head');
+  });
+});
+
+describe('check summarization', () => {
+  it('uses the successful duplicate required context to tolerate cancelled zombie checks', () => {
+    const result = summarizeChecks([
+      {
+        name: 'PR Ready',
+        status: 'COMPLETED',
+        conclusion: 'CANCELLED',
+        completedAt: '2026-06-01T00:05:00Z',
+      },
+      {
+        name: 'PR Ready',
+        status: 'COMPLETED',
+        conclusion: 'SUCCESS',
+        completedAt: '2026-06-01T00:04:00Z',
+      },
+      {
+        name: 'Migration Guard',
+        status: 'COMPLETED',
+        conclusion: 'SUCCESS',
+      },
+      {
+        __typename: 'StatusContext',
+        context: 'Fork PR Gate',
+        state: 'SUCCESS',
+      },
+    ]);
+
+    expect(
+      result.required.find(check => check.name === 'CI / PR Ready').state
+    ).toBe('SUCCESS');
+  });
+});
+
+describe('dependency-aware ordering and Neon capacity', () => {
+  it('orders smaller/older roots first and children after their base PR', () => {
+    const parent = pr({
+      number: 10,
+      headRefName: 'tim/parent',
+      baseRefName: 'main',
+      createdAt: '2026-06-02T00:00:00Z',
+      changedFiles: 5,
+    });
+    const child = pr({
+      number: 11,
+      headRefName: 'tim/child',
+      baseRefName: 'tim/parent',
+      createdAt: '2026-06-01T00:00:00Z',
+      changedFiles: 1,
+    });
+    const smallRoot = pr({
+      number: 9,
+      headRefName: 'tim/small-root',
+      baseRefName: 'main',
+      createdAt: '2026-06-03T00:00:00Z',
+      changedFiles: 1,
+    });
+
+    expect(
+      orderPrsDependencyAware([child, parent, smallRoot]).map(
+        item => item.number
+      )
+    ).toEqual([9, 10, 11]);
+  });
+
+  it('caps CI-heavy re-triggers by subtracting in-flight CI from max concurrency', () => {
+    const plan = buildPlan(
+      [
+        pr({
+          number: 1,
+          mergeStateStatus: 'UNSTABLE',
+          statusCheckRollup: [{ name: 'Typecheck', status: 'IN_PROGRESS' }],
+        }),
+        pr({
+          number: 2,
+          mergeStateStatus: 'BEHIND',
+          statusCheckRollup: greenRequired,
+        }),
+        pr({
+          number: 3,
+          mergeStateStatus: 'BEHIND',
+          statusCheckRollup: greenRequired,
+        }),
+      ],
+      { maxConcurrent: 2 }
+    );
+
+    expect(plan.capacity.currentCiInFlight).toBe(1);
+    expect(plan.items.find(item => item.number === 2).action).toBe(
+      'update_branch'
+    );
+    expect(plan.items.find(item => item.number === 3).action).toBe(
+      'wait_capacity'
+    );
+  });
+
+  it('skips update-branch for forks even when they are behind', () => {
+    const plan = buildPlan([
+      pr({
+        number: 4,
+        mergeStateStatus: 'BEHIND',
+        headRepositoryOwner: { login: 'someone-else' },
+        isCrossRepository: true,
+        statusCheckRollup: greenRequired,
+      }),
+    ]);
+
+    expect(plan.items[0].action).toBe('skip_fork');
+  });
+});
+
+describe('safe conflict autoresolution policy', () => {
+  it('only considers lockfile-only conflicts safe for automated regeneration', () => {
+    expect(isSafeAutoResolvableConflict(['pnpm-lock.yaml'])).toBe(true);
+    expect(
+      isSafeAutoResolvableConflict(['pnpm-lock.yaml', 'apps/web/app/page.tsx'])
+    ).toBe(false);
+    expect(isSafeAutoResolvableConflict([])).toBe(false);
+  });
+});

--- a/scripts/lib/pr-conflict-handler.mjs
+++ b/scripts/lib/pr-conflict-handler.mjs
@@ -1,0 +1,501 @@
+export const DEFAULT_REQUIRED_CHECKS = Object.freeze([
+  'CI / PR Ready',
+  'CI / Migration Guard',
+  'Fork PR Gate',
+]);
+
+export const DEFAULT_MANUAL_REBASE_LABEL = 'needs-manual-rebase';
+export const DEFAULT_BLOCKED_LABEL = 'needs-ci-fix';
+
+const TERMINAL_FAILURES = new Set([
+  'FAILURE',
+  'ERROR',
+  'TIMED_OUT',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+  'STALE',
+]);
+
+const RUNNING_STATES = new Set([
+  'PENDING',
+  'EXPECTED',
+  'QUEUED',
+  'REQUESTED',
+  'WAITING',
+  'IN_PROGRESS',
+  'IN_PROGRESS_MANUAL',
+]);
+
+const SUCCESS_STATES = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
+
+function upper(value) {
+  return String(value ?? '').toUpperCase();
+}
+
+function timeValue(value) {
+  const parsed = Date.parse(value ?? '');
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function checkTimestamp(check) {
+  return Math.max(timeValue(check.completedAt), timeValue(check.startedAt));
+}
+
+function normalizeCheckName(name) {
+  return String(name ?? '')
+    .replace(/^CI\s*\/\s*/i, '')
+    .trim();
+}
+
+function canonicalRequiredKey(name) {
+  return normalizeCheckName(name).toLowerCase();
+}
+
+function labelNames(labels = []) {
+  return labels
+    .map(label => (typeof label === 'string' ? label : label?.name))
+    .filter(Boolean);
+}
+
+function checkName(check) {
+  return check.name ?? check.context ?? '';
+}
+
+function checkState(check) {
+  if (check.__typename === 'StatusContext') {
+    return upper(check.state);
+  }
+  const status = upper(check.status);
+  if (status && status !== 'COMPLETED') return status;
+  return upper(check.conclusion || check.state || check.status);
+}
+
+function isRunningCheck(check) {
+  return RUNNING_STATES.has(checkState(check));
+}
+
+function isTerminalFailure(check) {
+  return TERMINAL_FAILURES.has(checkState(check));
+}
+
+function isSuccessLike(check) {
+  return SUCCESS_STATES.has(checkState(check));
+}
+
+function newestCheck(checks) {
+  return [...checks].sort((a, b) => checkTimestamp(b) - checkTimestamp(a))[0];
+}
+
+export function summarizeChecks(
+  statusCheckRollup = [],
+  requiredChecks = DEFAULT_REQUIRED_CHECKS
+) {
+  const requiredByKey = new Map(
+    requiredChecks.map(name => [canonicalRequiredKey(name), name])
+  );
+  const required = new Map(
+    requiredChecks.map(name => [
+      canonicalRequiredKey(name),
+      { name, checks: [] },
+    ])
+  );
+  const running = [];
+  const failing = [];
+
+  for (const check of statusCheckRollup ?? []) {
+    const name = checkName(check);
+    const key = canonicalRequiredKey(name);
+    if (isRunningCheck(check)) {
+      running.push({ name, state: checkState(check) });
+    }
+    if (isTerminalFailure(check)) {
+      failing.push({ name, state: checkState(check) });
+    }
+    if (requiredByKey.has(key)) {
+      required.get(key).checks.push(check);
+    }
+  }
+
+  const requiredResults = [...required.values()].map(entry => {
+    const latest = newestCheck(entry.checks);
+    const successful = entry.checks.some(isSuccessLike);
+    const active = entry.checks.find(isRunningCheck);
+    const terminalFailure = newestCheck(entry.checks.filter(isTerminalFailure));
+    let state = 'MISSING';
+    if (active) state = checkState(active);
+    else if (terminalFailure && !successful)
+      state = checkState(terminalFailure);
+    else if (successful) state = 'SUCCESS';
+    else if (latest) state = checkState(latest);
+
+    return {
+      name: entry.name,
+      state,
+      latestName: latest ? checkName(latest) : '',
+      count: entry.checks.length,
+    };
+  });
+
+  return {
+    running,
+    failing,
+    required: requiredResults,
+    runningRequired: requiredResults.filter(result =>
+      RUNNING_STATES.has(result.state)
+    ),
+    failingRequired: requiredResults.filter(result =>
+      TERMINAL_FAILURES.has(result.state)
+    ),
+    missingRequired: requiredResults.filter(
+      result => result.state === 'MISSING'
+    ),
+    nonGreenRequired: requiredResults.filter(
+      result => result.state !== 'SUCCESS' && !RUNNING_STATES.has(result.state)
+    ),
+  };
+}
+
+export function isInternalPr(pr, repoOwner = 'JovieInc') {
+  const owner = pr.headRepositoryOwner?.login ?? '';
+  return (
+    pr.isCrossRepository !== true &&
+    owner.toLowerCase() === repoOwner.toLowerCase()
+  );
+}
+
+export function isConflictPr(pr) {
+  return pr.mergeable === 'CONFLICTING' || pr.mergeStateStatus === 'DIRTY';
+}
+
+export function classifyPr(
+  pr,
+  { requiredChecks = DEFAULT_REQUIRED_CHECKS, repoOwner = 'JovieInc' } = {}
+) {
+  const checks = summarizeChecks(pr.statusCheckRollup ?? [], requiredChecks);
+  const labels = labelNames(pr.labels);
+  const internal = isInternalPr(pr, repoOwner);
+  const mergeStateStatus = pr.mergeStateStatus ?? 'UNKNOWN';
+  const mergeable = pr.mergeable ?? 'UNKNOWN';
+  const reasons = [];
+  let state = 'UNKNOWN';
+
+  if (isConflictPr(pr)) {
+    state = 'DIRTY';
+    reasons.push(
+      `mergeable=${mergeable}`,
+      `mergeStateStatus=${mergeStateStatus}`
+    );
+  } else if (mergeStateStatus === 'UNSTABLE' || checks.running.length > 0) {
+    state = 'UNSTABLE';
+    const runningNames = checks.running.slice(0, 4).map(check => check.name);
+    reasons.push(
+      runningNames.length > 0
+        ? `CI in flight: ${runningNames.join(', ')}`
+        : `mergeStateStatus=${mergeStateStatus}`
+    );
+  } else if (
+    mergeStateStatus === 'BLOCKED' ||
+    checks.failingRequired.length > 0 ||
+    checks.missingRequired.length > 0
+  ) {
+    state = 'BLOCKED';
+    const blocked = checks.nonGreenRequired.map(
+      check => `${check.name}:${check.state}`
+    );
+    reasons.push(
+      blocked.length > 0
+        ? `required checks not green: ${blocked.join(', ')}`
+        : `mergeStateStatus=${mergeStateStatus}`
+    );
+  } else if (mergeStateStatus === 'BEHIND' && mergeable === 'MERGEABLE') {
+    state = 'BEHIND';
+    reasons.push('base moved and GitHub reports branch is mergeable');
+  } else if (mergeable === 'MERGEABLE') {
+    state = 'MERGEABLE';
+    reasons.push(`mergeStateStatus=${mergeStateStatus}`);
+  } else {
+    reasons.push(
+      `mergeable=${mergeable}`,
+      `mergeStateStatus=${mergeStateStatus}`
+    );
+  }
+
+  if (pr.isDraft) reasons.push('draft PR');
+  if (!internal) reasons.push('fork or cross-repository head');
+
+  return {
+    number: pr.number,
+    state,
+    action: '',
+    reason: reasons.filter(Boolean).join('; '),
+    internal,
+    labels,
+    checks,
+    pr,
+  };
+}
+
+function diffSize(pr) {
+  return (
+    Number(pr.changedFiles ?? 0) * 100_000 +
+    Number(pr.additions ?? 0) +
+    Number(pr.deletions ?? 0)
+  );
+}
+
+function stableCompare(a, b) {
+  const base = String(a.baseRefName ?? '').localeCompare(
+    String(b.baseRefName ?? '')
+  );
+  if (base !== 0) return base;
+  const size = diffSize(a) - diffSize(b);
+  if (size !== 0) return size;
+  const created = timeValue(a.createdAt) - timeValue(b.createdAt);
+  if (created !== 0) return created;
+  return Number(a.number ?? 0) - Number(b.number ?? 0);
+}
+
+export function orderPrsDependencyAware(prs) {
+  const byHead = new Map();
+  for (const pr of prs) {
+    if (pr.headRefName) byHead.set(pr.headRefName, pr);
+  }
+
+  const children = new Map(prs.map(pr => [pr.number, []]));
+  const indegree = new Map(prs.map(pr => [pr.number, 0]));
+  for (const pr of prs) {
+    const parent = byHead.get(pr.baseRefName);
+    if (parent && parent.number !== pr.number) {
+      children.get(parent.number).push(pr);
+      indegree.set(pr.number, indegree.get(pr.number) + 1);
+    }
+  }
+
+  const ready = prs
+    .filter(pr => indegree.get(pr.number) === 0)
+    .sort(stableCompare);
+  const ordered = [];
+  while (ready.length > 0) {
+    const next = ready.shift();
+    ordered.push(next);
+    for (const child of children.get(next.number).sort(stableCompare)) {
+      indegree.set(child.number, indegree.get(child.number) - 1);
+      if (indegree.get(child.number) === 0) {
+        ready.push(child);
+        ready.sort(stableCompare);
+      }
+    }
+  }
+
+  if (ordered.length !== prs.length) {
+    const seen = new Set(ordered.map(pr => pr.number));
+    ordered.push(...prs.filter(pr => !seen.has(pr.number)).sort(stableCompare));
+  }
+
+  return ordered;
+}
+
+function actionTriggersCi(action) {
+  return ['update_branch', 'attempt_rebase_safe_autoresolve'].includes(action);
+}
+
+export function decideAction(classification, context = {}) {
+  const {
+    manualRebaseLabel = DEFAULT_MANUAL_REBASE_LABEL,
+    blockedLabel = DEFAULT_BLOCKED_LABEL,
+    availableCiSlots = 0,
+    plannedCiTriggers = 0,
+  } = context;
+  const pr = classification.pr;
+
+  if (pr.isDraft) {
+    return {
+      action: 'skip_draft',
+      triggersCi: false,
+      reason: 'draft PRs are not freshness-managed',
+    };
+  }
+
+  if (classification.state === 'UNSTABLE') {
+    return {
+      action: 'wait_ci',
+      triggersCi: false,
+      reason: 'CI is already in flight; pushing now would cancel the run',
+    };
+  }
+
+  if (classification.state === 'BLOCKED') {
+    return {
+      action: 'flag_blocked_checks',
+      label: blockedLabel,
+      triggersCi: false,
+      reason:
+        'required checks are failing or absent; do not rebase and waste CI',
+    };
+  }
+
+  if (classification.state === 'MERGEABLE') {
+    return {
+      action: 'noop_clean',
+      triggersCi: false,
+      reason: 'PR is mergeable/clean enough; leave it alone',
+    };
+  }
+
+  if (classification.state === 'BEHIND') {
+    if (!classification.internal) {
+      return {
+        action: 'skip_fork',
+        triggersCi: false,
+        reason:
+          'fork/cross-repo PR: do not mutate branch with internal update flow',
+      };
+    }
+    if (plannedCiTriggers >= availableCiSlots) {
+      return {
+        action: 'wait_capacity',
+        triggersCi: false,
+        reason: 'Neon/CI re-trigger capacity is full for this run',
+      };
+    }
+    return {
+      action: 'update_branch',
+      triggersCi: true,
+      reason:
+        'mergeable but behind; prefer GitHub update-branch over force-rebase',
+    };
+  }
+
+  if (classification.state === 'DIRTY') {
+    if (classification.checks.running.length > 0) {
+      return {
+        action: 'wait_ci',
+        triggersCi: false,
+        reason:
+          'conflicted, but CI is in flight; wait to avoid cancellation churn',
+      };
+    }
+    if (!classification.internal) {
+      return {
+        action: 'label_needs_manual_rebase',
+        label: manualRebaseLabel,
+        triggersCi: false,
+        reason: 'fork/cross-repo conflict requires human-owned rebase',
+      };
+    }
+    if (plannedCiTriggers >= availableCiSlots) {
+      return {
+        action: 'wait_capacity',
+        triggersCi: false,
+        reason: 'Neon/CI re-trigger capacity is full for this run',
+      };
+    }
+    return {
+      action: 'attempt_rebase_safe_autoresolve',
+      label: manualRebaseLabel,
+      triggersCi: true,
+      reason:
+        'true merge conflict; try safe rebase/autoresolve, label for manual rebase if non-trivial',
+    };
+  }
+
+  return {
+    action: 'skip_unknown',
+    triggersCi: false,
+    reason: 'mergeability state is unknown; no mutation',
+  };
+}
+
+export function buildPlan(
+  prs,
+  {
+    maxConcurrent = 2,
+    requiredChecks = DEFAULT_REQUIRED_CHECKS,
+    repoOwner = 'JovieInc',
+    manualRebaseLabel = DEFAULT_MANUAL_REBASE_LABEL,
+    blockedLabel = DEFAULT_BLOCKED_LABEL,
+  } = {}
+) {
+  const orderedPrs = orderPrsDependencyAware(prs);
+  const classifications = orderedPrs.map(pr =>
+    classifyPr(pr, { requiredChecks, repoOwner })
+  );
+  const currentCiInFlight = classifications.filter(
+    item => item.state === 'UNSTABLE'
+  ).length;
+  const availableCiSlots = Math.max(0, maxConcurrent - currentCiInFlight);
+  let plannedCiTriggers = 0;
+
+  const items = classifications.map(classification => {
+    const decision = decideAction(classification, {
+      manualRebaseLabel,
+      blockedLabel,
+      availableCiSlots,
+      plannedCiTriggers,
+    });
+    if (actionTriggersCi(decision.action)) plannedCiTriggers += 1;
+    return {
+      ...classification,
+      action: decision.action,
+      actionReason: decision.reason,
+      label: decision.label,
+      triggersCi: decision.triggersCi,
+    };
+  });
+
+  return {
+    items,
+    summary: summarizePlan(items),
+    capacity: {
+      maxConcurrent,
+      currentCiInFlight,
+      availableCiSlots,
+      plannedCiTriggers,
+    },
+  };
+}
+
+export function summarizePlan(items) {
+  const byState = {};
+  const byAction = {};
+  for (const item of items) {
+    byState[item.state] = (byState[item.state] ?? 0) + 1;
+    byAction[item.action] = (byAction[item.action] ?? 0) + 1;
+  }
+  return {
+    total: items.length,
+    byState,
+    byAction,
+    manualRebaseCandidates: items
+      .filter(item => item.action === 'label_needs_manual_rebase')
+      .map(item => item.number),
+  };
+}
+
+export function formatPlan(plan, { dryRun = true } = {}) {
+  const lines = [
+    `PR freshness plan (dryRun=${dryRun}, maxConcurrent=${plan.capacity.maxConcurrent}, currentCiInFlight=${plan.capacity.currentCiInFlight}, newTriggerSlots=${plan.capacity.availableCiSlots})`,
+    `Summary states: ${JSON.stringify(plan.summary.byState)}`,
+    `Summary actions: ${JSON.stringify(plan.summary.byAction)}`,
+    'Order:',
+  ];
+
+  for (const item of plan.items) {
+    lines.push(
+      `  #${item.number} ${item.state} -> ${item.action} :: ${item.actionReason} (${item.pr.title ?? ''})`
+    );
+  }
+
+  const manual = plan.summary.manualRebaseCandidates;
+  lines.push(
+    `needs-manual-rebase candidates: ${manual.length > 0 ? manual.map(n => `#${n}`).join(', ') : 'none'}`
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+export function isSafeAutoResolvableConflict(unmergedPaths) {
+  return (
+    unmergedPaths.length > 0 &&
+    unmergedPaths.every(path => path === 'pnpm-lock.yaml')
+  );
+}

--- a/scripts/pr-conflict-handler.mjs
+++ b/scripts/pr-conflict-handler.mjs
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+import { execFile, execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import {
+  buildPlan,
+  DEFAULT_BLOCKED_LABEL,
+  DEFAULT_MANUAL_REBASE_LABEL,
+  DEFAULT_REQUIRED_CHECKS,
+  formatPlan,
+  isSafeAutoResolvableConflict,
+} from './lib/pr-conflict-handler.mjs';
+
+const execFileAsync = promisify(execFile);
+
+function parseArgs(argv) {
+  const options = {
+    repo: 'JovieInc/Jovie',
+    repoOwner: 'JovieInc',
+    dryRun: true,
+    maxConcurrent: 2,
+    limit: 200,
+    apply: false,
+    json: false,
+    manualRebaseLabel: DEFAULT_MANUAL_REBASE_LABEL,
+    blockedLabel: DEFAULT_BLOCKED_LABEL,
+    requiredChecks: [...DEFAULT_REQUIRED_CHECKS],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case '--repo':
+        options.repo = argv[++index];
+        options.repoOwner = options.repo.split('/')[0] ?? options.repoOwner;
+        break;
+      case '--max-concurrent':
+        options.maxConcurrent = Number.parseInt(argv[++index], 10);
+        break;
+      case '--limit':
+        options.limit = Number.parseInt(argv[++index], 10);
+        break;
+      case '--required-check':
+        options.requiredChecks.push(argv[++index]);
+        break;
+      case '--required-checks':
+        options.requiredChecks = argv[++index]
+          .split(',')
+          .map(value => value.trim())
+          .filter(Boolean);
+        break;
+      case '--manual-rebase-label':
+        options.manualRebaseLabel = argv[++index];
+        break;
+      case '--blocked-label':
+        options.blockedLabel = argv[++index];
+        break;
+      case '--apply':
+        options.apply = true;
+        options.dryRun = false;
+        break;
+      case '--dry-run':
+        options.dryRun = true;
+        options.apply = false;
+        break;
+      case '--json':
+        options.json = true;
+        break;
+      case '--help':
+      case '-h':
+        printUsage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isInteger(options.maxConcurrent) || options.maxConcurrent < 1) {
+    throw new Error('--max-concurrent must be a positive integer');
+  }
+  if (!Number.isInteger(options.limit) || options.limit < 1) {
+    throw new Error('--limit must be a positive integer');
+  }
+  return options;
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/pr-conflict-handler.mjs [options]
+
+Classifies open PRs and plans safe freshness actions. Defaults to read-only dry-run.
+
+Options:
+  --dry-run                    Print classification/order/actions without mutations (default)
+  --apply                      Execute safe mutations (labels, update-branch, guarded rebase)
+  --repo OWNER/REPO            Repository (default: JovieInc/Jovie)
+  --max-concurrent N           Cap CI-heavy retriggers including in-flight CI (default: 2)
+  --limit N                    Max open PRs to inspect (default: 200)
+  --required-checks a,b,c      Required aggregate checks to use for BLOCKED classification
+  --manual-rebase-label NAME   Label for non-trivial conflicts (default: needs-manual-rebase)
+  --blocked-label NAME         Label for failing required checks (default: needs-ci-fix)
+  --json                       Emit JSON plan as well as logs
+`);
+}
+
+function logDecision(item, extra = {}) {
+  console.log(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      pr: item.number,
+      state: item.state,
+      action: item.action,
+      reason: item.actionReason,
+      classificationReason: item.reason,
+      base: item.pr.baseRefName,
+      head: item.pr.headRefName,
+      internal: item.internal,
+      triggersCi: item.triggersCi,
+      ...extra,
+    })
+  );
+}
+
+async function ghJson(args, { retries = 3 } = {}) {
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync('gh', args, {
+        encoding: 'utf8',
+        maxBuffer: 50 * 1024 * 1024,
+      });
+      return JSON.parse(stdout);
+    } catch (error) {
+      const stderr = error.stderr ?? '';
+      const rateLimited = /rate limit|secondary rate|abuse/i.test(stderr);
+      if (!rateLimited || attempt === retries) throw error;
+      const delayMs = Math.min(30_000, 2000 * 2 ** (attempt - 1));
+      console.error(
+        `[gh-retry] ${args.join(' ')} hit rate limit; retry ${attempt}/${retries} in ${delayMs}ms`
+      );
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error('unreachable');
+}
+
+async function fetchOpenPrs(options) {
+  const fields = [
+    'number',
+    'title',
+    'url',
+    'author',
+    'createdAt',
+    'updatedAt',
+    'isDraft',
+    'mergeable',
+    'mergeStateStatus',
+    'baseRefName',
+    'headRefName',
+    'headRepository',
+    'headRepositoryOwner',
+    'isCrossRepository',
+    'labels',
+    'statusCheckRollup',
+    'changedFiles',
+    'additions',
+    'deletions',
+    'maintainerCanModify',
+  ];
+  return ghJson([
+    'pr',
+    'list',
+    '--repo',
+    options.repo,
+    '--state',
+    'open',
+    '--limit',
+    String(options.limit),
+    '--json',
+    fields.join(','),
+  ]);
+}
+
+async function ensureLabel(repo, label, color, description) {
+  try {
+    await execFileAsync(
+      'gh',
+      [
+        'label',
+        'create',
+        label,
+        '--repo',
+        repo,
+        '--color',
+        color,
+        '--description',
+        description,
+      ],
+      { encoding: 'utf8' }
+    );
+  } catch (error) {
+    const stderr = `${error.stderr ?? ''}${error.stdout ?? ''}`;
+    if (/already exists/i.test(stderr)) return;
+    throw error;
+  }
+}
+
+async function addLabel(repo, number, label) {
+  await execFileAsync(
+    'gh',
+    ['pr', 'edit', String(number), '--repo', repo, '--add-label', label],
+    {
+      encoding: 'utf8',
+    }
+  );
+}
+
+async function updateBranch(repo, number) {
+  await execFileAsync(
+    'gh',
+    ['pr', 'update-branch', String(number), '--repo', repo],
+    {
+      encoding: 'utf8',
+    }
+  );
+}
+
+function runGit(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function runGh(args, cwd) {
+  return execFileSync('gh', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function conflictedPaths(cwd) {
+  const output = runGit(['diff', '--name-only', '--diff-filter=U'], cwd);
+  return output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+}
+
+function trySafeRebase({ repo, pr }) {
+  const workdir = mkdtempSync(join(tmpdir(), `jovie-pr-${pr.number}-rebase-`));
+  try {
+    // gh repo clone wires up token-based auth (GH_TOKEN) so the later
+    // --force-with-lease push works in CI without embedding credentials.
+    runGh(['repo', 'clone', repo, '.', '--', '--no-tags'], workdir);
+    runGit(
+      ['fetch', 'origin', pr.baseRefName, pr.headRefName, '--depth', '50'],
+      workdir
+    );
+    runGit(
+      ['checkout', '-B', pr.headRefName, `origin/${pr.headRefName}`],
+      workdir
+    );
+    try {
+      runGit(['rebase', `origin/${pr.baseRefName}`], workdir);
+    } catch (_error) {
+      const paths = conflictedPaths(workdir);
+      if (!isSafeAutoResolvableConflict(paths)) {
+        runGit(['rebase', '--abort'], workdir);
+        return {
+          ok: false,
+          label: true,
+          reason: `non-trivial conflict paths: ${paths.join(', ') || 'unknown'}`,
+        };
+      }
+      runGit(['checkout', '--theirs', 'pnpm-lock.yaml'], workdir);
+      execFileSync(
+        'corepack',
+        ['pnpm', 'install', '--lockfile-only', '--ignore-scripts'],
+        {
+          cwd: workdir,
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }
+      );
+      runGit(['add', 'pnpm-lock.yaml'], workdir);
+      runGit(['rebase', '--continue'], workdir);
+    }
+    runGit(
+      ['push', '--force-with-lease', 'origin', `HEAD:${pr.headRefName}`],
+      workdir
+    );
+    return {
+      ok: true,
+      label: false,
+      reason: 'rebased and pushed with --force-with-lease',
+    };
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+}
+
+async function executePlan(plan, options) {
+  if (options.dryRun) return [];
+  const results = [];
+  await ensureLabel(
+    options.repo,
+    options.manualRebaseLabel,
+    'B60205',
+    'Conflict handler found a non-trivial rebase that needs a human'
+  );
+  await ensureLabel(
+    options.repo,
+    options.blockedLabel,
+    'D93F0B',
+    'Required checks are failing; fix CI before freshness updates'
+  );
+
+  for (const item of plan.items) {
+    logDecision(item, { phase: 'execute' });
+    try {
+      if (item.action === 'flag_blocked_checks' && item.label) {
+        await addLabel(options.repo, item.number, item.label);
+        results.push({ pr: item.number, ok: true, action: item.action });
+      } else if (item.action === 'label_needs_manual_rebase' && item.label) {
+        await addLabel(options.repo, item.number, item.label);
+        results.push({ pr: item.number, ok: true, action: item.action });
+      } else if (item.action === 'update_branch') {
+        await updateBranch(options.repo, item.number);
+        results.push({ pr: item.number, ok: true, action: item.action });
+      } else if (item.action === 'attempt_rebase_safe_autoresolve') {
+        const result = trySafeRebase({ repo: options.repo, pr: item.pr });
+        if (!result.ok && result.label) {
+          await addLabel(options.repo, item.number, options.manualRebaseLabel);
+        }
+        results.push({ pr: item.number, action: item.action, ...result });
+      }
+    } catch (error) {
+      results.push({
+        pr: item.number,
+        ok: false,
+        action: item.action,
+        error: error.message,
+      });
+      console.error(
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          pr: item.number,
+          action: item.action,
+          error: error.message,
+        })
+      );
+    }
+  }
+  return results;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const prs = await fetchOpenPrs(options);
+  const plan = buildPlan(prs, options);
+
+  console.log(formatPlan(plan, { dryRun: options.dryRun }));
+  for (const item of plan.items) logDecision(item, { phase: 'plan' });
+  if (options.json) console.log(JSON.stringify(plan, null, 2));
+
+  const results = await executePlan(plan, options);
+  if (results.length > 0) {
+    console.log(
+      JSON.stringify({ ts: new Date().toISOString(), results }, null, 2)
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a hardened, read-only-by-default PR conflict/freshness handler for open Jovie PRs.

## Design

### Classification table

| State | Signal | Action |
| --- | --- | --- |
| `DIRTY` | `mergeable=CONFLICTING` or `mergeStateStatus=DIRTY` | True conflict. Internal branch can enter guarded rebase flow; non-trivial/fork conflicts get `needs-manual-rebase`. |
| `BEHIND` | `mergeStateStatus=BEHIND` and mergeable | Prefer GitHub `update-branch` over force-rebase to reduce CI churn/conflict risk. |
| `BLOCKED` | Required gate checks failing/missing or `mergeStateStatus=BLOCKED` | Do not rebase; flag checks instead because rebasing just wastes CI. |
| `UNSTABLE` | CI running/queued or `mergeStateStatus=UNSTABLE` | Wait; do not push and cancel an in-flight run. |
| `MERGEABLE` | Clean enough / mergeable | No-op. |

Required checks default to Jovie's gate aggregates: `CI / PR Ready`, `CI / Migration Guard`, and `Fork PR Gate`.

### Ordering / cascade avoidance

- Builds a base-branch graph from open PR heads/bases and processes parents before dependent PRs.
- Deterministic ordering within each layer: smallest diff, then oldest PR, then PR number.
- Only plans CI-heavy actions up to `--max-concurrent` (default `2`).
- Subtracts PRs whose CI is already in flight from available slots, so it does not add work when the Neon pool is already busy.
- Never disturbs drafts, forks, or PRs with running CI.

### Conflict resolution safety

- Automatic resolution is restricted to lockfile-only conflicts (`pnpm-lock.yaml`) regenerated with `corepack pnpm install --lockfile-only --ignore-scripts`.
- Non-trivial conflicts are labeled `needs-manual-rebase` instead of guessed.
- Rebase pushes use `git push --force-with-lease` only.

### Workflow posture

Adds `.github/workflows/pr-conflict-handler.yml` as a dry-run scheduled audit plus manual dispatch. Apply mode is manual-only; there is no auto-merge and no tight loop force-pushing the fleet.

## Dry-run evidence against current open PRs

```text
PR freshness plan (dryRun=true, maxConcurrent=2, currentCiInFlight=2, newTriggerSlots=0)
Summary states: {"UNSTABLE":2,"BLOCKED":6,"DIRTY":3,"MERGEABLE":1}
Summary actions: {"skip_draft":4,"wait_capacity":3,"flag_blocked_checks":4,"noop_clean":1}
Order:
  #12278 UNSTABLE -> skip_draft :: draft PRs are not freshness-managed (docs: refresh doc-gardening seed freshness marker)
  #12336 BLOCKED -> skip_draft :: draft PRs are not freshness-managed ([Graphite MQ] Draft PR GROUP:spec_8ca6c6 (PRs 12210))
  #12207 UNSTABLE -> skip_draft :: draft PRs are not freshness-managed (test(design-system): confirm drift stack landed and tighten baseline (#11312))
  #12123 DIRTY -> wait_capacity :: Neon/CI re-trigger capacity is full for this run (perf(ci): rebalance public Lighthouse fan-out off the merge-queue long-pole shard)
  #11988 BLOCKED -> flag_blocked_checks :: required checks are failing or absent; do not rebase and waste CI (v26.6.55 feat(home): collapse homepage to hero + minimal footer)
  #12160 DIRTY -> wait_capacity :: Neon/CI re-trigger capacity is full for this run (perf(ci): move heavy DB-touching jobs to main-only to cut Neon cost)
  #12291 BLOCKED -> skip_draft :: draft PRs are not freshness-managed ([Graphite MQ] Draft PR GROUP:spec_344fba (PRs 12282))
  #12339 MERGEABLE -> noop_clean :: PR is mergeable/clean enough; leave it alone (chore: update product screenshots)
  #12108 BLOCKED -> flag_blocked_checks :: required checks are failing or absent; do not rebase and waste CI (chore: jOV-1853: OPS: Default Alive War Room)
  #12245 DIRTY -> wait_capacity :: Neon/CI re-trigger capacity is full for this run (fix(ci): move Lighthouse jobs to post-merge for ≤10m p50)
  #12301 BLOCKED -> flag_blocked_checks :: required checks are failing or absent; do not rebase and waste CI (feat(dashboard): ship unified Jovie work activity surface (JOV-3624))
  #12300 BLOCKED -> flag_blocked_checks :: required checks are failing or absent; do not rebase and waste CI (refactor(flags): consolidate feature-flag systems into lib/flags (JOV-3628))
needs-manual-rebase candidates: none
```

## Tests

```text
RUN  v4.1.8 /Users/timwhite/Jovie-pr-conflict-handler/scripts

 ✓  workspace-scripts  lib/__tests__/pr-conflict-handler.test.mjs (10 tests) 10ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

## Files

- `scripts/pr-conflict-handler.mjs`
- `scripts/lib/pr-conflict-handler.mjs`
- `scripts/lib/__tests__/pr-conflict-handler.test.mjs`
- `.github/workflows/pr-conflict-handler.yml`
- `docs/pr-conflict-handler.md`
- `README.md`
- `package.json`
