### PR TITLE
refactor(ci): extract shared ratchet core

### DIFF
--- a/scripts/ci-duration-ratchet.mjs
+++ b/scripts/ci-duration-ratchet.mjs
@@ -23,6 +23,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  buildDurationRatchetUpdate,
   checkRatchet,
   formatDuration,
   validateDurationRatchet,
@@ -146,8 +147,16 @@ function runUpdate(args) {
 
   const baseline = loadBaseline();
   const currentP95 = baseline.slo.p95GateSeconds;
+  const sampleSize = rawSampleSize
+    ? Number(rawSampleSize)
+    : baseline.sampleSize;
 
-  if (!force && newP95 > currentP95) {
+  const result = buildDurationRatchetUpdate(baseline, newP95, {
+    force,
+    sampleSize,
+  });
+
+  if (!result.ok) {
     console.error(
       `[ci-duration-ratchet] ✗ Refusing to raise p95 from ${currentP95}s to ${newP95}s.`
     );
@@ -158,18 +167,7 @@ function runUpdate(args) {
     return;
   }
 
-  const sampleSize = rawSampleSize
-    ? Number(rawSampleSize)
-    : baseline.sampleSize;
-
-  const updated = {
-    ...baseline,
-    updatedAt: new Date().toISOString(),
-    sampleSize: sampleSize || 0,
-    slo: { ...baseline.slo, p95GateSeconds: newP95 },
-  };
-
-  writeFileSync(baselinePath(), `${JSON.stringify(updated, null, 2)}\n`);
+  writeFileSync(baselinePath(), `${JSON.stringify(result.updated, null, 2)}\n`);
   console.log(
     `[ci-duration-ratchet] ✓ Baseline updated: ${currentP95}s → ${newP95}s (${formatDuration(newP95)})`
   );

--- a/scripts/lib/__tests__/ratchet-core.test.mjs
+++ b/scripts/lib/__tests__/ratchet-core.test.mjs
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRatchetUpdate,
+  compareRatchet,
+  isLooseningBaseline,
+  RATCHET_CORE_SCHEMA_VERSION,
+  RATCHET_DIRECTIONS,
+  validateRatchetConfig,
+} from '../ratchet-core.mjs';
+
+const ratchet = overrides => ({
+  schemaVersion: RATCHET_CORE_SCHEMA_VERSION,
+  dimension: 'metric',
+  direction: RATCHET_DIRECTIONS.LOCK_DOWN,
+  baseline: 900,
+  sampleSize: 50,
+  policy: { marginFraction: 0.2, improveEpsilon: 0.02, minSampleSize: 0 },
+  ...overrides,
+});
+
+describe('ratchet core validation', () => {
+  it('accepts lock_down/lock_up configs and rejects invalid shape', () => {
+    expect(validateRatchetConfig(ratchet()).ok).toBe(true);
+    expect(
+      validateRatchetConfig(ratchet({ direction: RATCHET_DIRECTIONS.LOCK_UP }))
+        .ok
+    ).toBe(true);
+    expect(validateRatchetConfig(null).ok).toBe(false);
+    expect(validateRatchetConfig(ratchet({ direction: 'sideways' })).ok).toBe(
+      false
+    );
+  });
+});
+
+describe('compareRatchet', () => {
+  it('lock_down passes within ceiling, fails above it, and proposes tighter baseline', () => {
+    expect(compareRatchet(895, ratchet())).toMatchObject({
+      ok: true,
+      status: 'pass',
+      threshold: 1080,
+      headroom: 185,
+    });
+    expect(compareRatchet(1100, ratchet())).toMatchObject({
+      ok: false,
+      status: 'regression',
+      headroom: -20,
+    });
+    expect(compareRatchet(800, ratchet())).toMatchObject({
+      ok: true,
+      status: 'improvement',
+      proposeNewBaseline: 800,
+    });
+  });
+
+  it('lock_up passes above floor, fails below it, and improves above baseline', () => {
+    const lockUp = ratchet({
+      direction: RATCHET_DIRECTIONS.LOCK_UP,
+      baseline: 6,
+      policy: { marginFraction: 0.25, improveEpsilon: 0.02, minSampleSize: 0 },
+    });
+    expect(compareRatchet(5, lockUp)).toMatchObject({
+      ok: true,
+      status: 'pass',
+      threshold: 4.5,
+      headroom: 0.5,
+    });
+    expect(compareRatchet(4, lockUp)).toMatchObject({
+      ok: false,
+      status: 'regression',
+      headroom: -0.5,
+    });
+    expect(compareRatchet(8, lockUp)).toMatchObject({
+      ok: true,
+      status: 'improvement',
+      proposeNewBaseline: 8,
+    });
+  });
+
+  it('supports minSampleSize and expiring waivers', () => {
+    const policy = { ...ratchet().policy, minSampleSize: 20 };
+    expect(
+      compareRatchet({ value: 5000, sampleSize: 3 }, ratchet({ policy }))
+    ).toMatchObject({ ok: true, status: 'insufficient_data' });
+    expect(
+      compareRatchet({ value: 5000, sampleSize: 25 }, ratchet({ policy }))
+    ).toMatchObject({ ok: false, status: 'regression' });
+    expect(
+      compareRatchet(
+        5000,
+        ratchet({
+          policy: {
+            ...ratchet().policy,
+            waiver: { until: '2999-01-01T00:00:00Z' },
+          },
+        })
+      )
+    ).toMatchObject({ ok: true, status: 'waived' });
+  });
+});
+
+describe('baseline updates', () => {
+  it('detects loosening per direction and refuses it unless forced', () => {
+    const lockUp = ratchet({
+      direction: RATCHET_DIRECTIONS.LOCK_UP,
+      baseline: 6,
+    });
+    expect(isLooseningBaseline(950, ratchet())).toBe(true);
+    expect(isLooseningBaseline(850, ratchet())).toBe(false);
+    expect(isLooseningBaseline(5, lockUp)).toBe(true);
+    expect(isLooseningBaseline(7, lockUp)).toBe(false);
+    expect(
+      buildRatchetUpdate(ratchet(), { value: 800, sampleSize: 40 })
+    ).toMatchObject({
+      ok: true,
+      updated: { baseline: 800, sampleSize: 40 },
+    });
+    expect(buildRatchetUpdate(ratchet(), { value: 1000 })).toMatchObject({
+      ok: false,
+      updated: null,
+    });
+    expect(
+      buildRatchetUpdate(lockUp, { value: 5 }, { force: true })
+    ).toMatchObject({ ok: true, updated: { baseline: 5 } });
+  });
+});

--- a/scripts/lib/ci-duration-ratchet.mjs
+++ b/scripts/lib/ci-duration-ratchet.mjs
@@ -1,13 +1,15 @@
 /**
- * CI Duration Ratchet — core library.
+ * CI Duration Ratchet — compatibility library.
  *
- * Computes p95 wall-clock of recent PR merge-gate CI runs and checks whether
- * the measured value exceeds the committed baseline + margin.
- *
- * The ratchet lockfile lives at .github/ci-harness/duration-ratchet.json.
- * It is updated by scripts/ci-duration-ratchet.mjs (the CLI) and by the
- * nightly .github/workflows/ci-duration-ratchet.yml workflow when p95 improves.
+ * The duration ratchet keeps its schema v1 lockfile and public exports, while
+ * delegating generic comparison/update concerns to scripts/lib/ratchet-core.mjs.
  */
+
+import {
+  buildRatchetUpdate,
+  compareRatchet,
+  RATCHET_DIRECTIONS,
+} from './ratchet-core.mjs';
 
 export const RATCHET_SCHEMA_VERSION = 1;
 
@@ -35,6 +37,32 @@ export function formatDuration(seconds) {
   return `${m}m ${s}s`;
 }
 
+export function durationRatchetToCore(baseline) {
+  return {
+    schemaVersion: 1,
+    dimension: 'ci-duration',
+    direction: RATCHET_DIRECTIONS.LOCK_DOWN,
+    baseline: baseline.slo.p95GateSeconds,
+    sampleSize: baseline.sampleSize ?? 0,
+    updatedAt: baseline.updatedAt,
+    policy: {
+      marginFraction: baseline.slo.marginFraction,
+      improveEpsilon: baseline.slo.improveEpsilon ?? 0,
+      minSampleSize: baseline.slo.minSampleSize ?? 0,
+      waiver: baseline.waiver ?? null,
+    },
+  };
+}
+
+export function coreRatchetToDuration(coreRatchet, currentBaseline) {
+  return {
+    ...currentBaseline,
+    updatedAt: coreRatchet.updatedAt,
+    sampleSize: coreRatchet.sampleSize ?? currentBaseline.sampleSize ?? 0,
+    slo: { ...currentBaseline.slo, p95GateSeconds: coreRatchet.baseline },
+  };
+}
+
 /**
  * Check whether a measured p95 exceeds the ratchet ceiling.
  *
@@ -44,17 +72,41 @@ export function formatDuration(seconds) {
  *             ceilingSeconds: number, headroomSeconds: number, marginFraction: number }}
  */
 export function checkRatchet(measuredP95Seconds, baseline) {
-  const baselineP95 = baseline.slo.p95GateSeconds;
-  const margin = baseline.slo.marginFraction;
-  const ceiling = baselineP95 * (1 + margin);
-  const headroom = ceiling - measuredP95Seconds;
-  return {
-    ok: measuredP95Seconds <= ceiling,
+  const result = compareRatchet(
     measuredP95Seconds,
-    baselineP95Seconds: baselineP95,
-    ceilingSeconds: ceiling,
-    headroomSeconds: headroom,
-    marginFraction: margin,
+    durationRatchetToCore(baseline)
+  );
+  return {
+    ok: result.ok,
+    status: result.status,
+    measuredP95Seconds: result.measured,
+    baselineP95Seconds: result.baseline,
+    ceilingSeconds: result.threshold,
+    headroomSeconds: result.headroom,
+    marginFraction: result.marginFraction,
+    improvedBy: result.improvedBy,
+    proposeNewBaseline: result.proposeNewBaseline,
+    reason: result.reason,
+  };
+}
+
+export function buildDurationRatchetUpdate(
+  baseline,
+  measuredP95Seconds,
+  options = {}
+) {
+  const result = buildRatchetUpdate(
+    durationRatchetToCore(baseline),
+    { value: measuredP95Seconds, sampleSize: options.sampleSize },
+    options
+  );
+
+  if (!result.ok) return result;
+
+  return {
+    ok: true,
+    errors: [],
+    updated: coreRatchetToDuration(result.updated, baseline),
   };
 }
 
@@ -100,6 +152,13 @@ export function validateDurationRatchet(baseline) {
     ) {
       errors.push('slo.marginFraction must be a non-negative number');
     }
+  }
+
+  if (
+    baseline.sampleSize !== undefined &&
+    !Number.isInteger(baseline.sampleSize)
+  ) {
+    errors.push('sampleSize must be an integer when present');
   }
 
   return { ok: errors.length === 0, errors };

--- a/scripts/lib/ratchet-core.mjs
+++ b/scripts/lib/ratchet-core.mjs
@@ -1,0 +1,198 @@
+/** Shared numeric ratchet core for lock_down and lock_up metrics. */
+export const RATCHET_CORE_SCHEMA_VERSION = 1;
+export const RATCHET_DIRECTIONS = Object.freeze({
+  LOCK_DOWN: 'lock_down',
+  LOCK_UP: 'lock_up',
+});
+
+const DIRECTIONS = new Set(Object.values(RATCHET_DIRECTIONS));
+const isNumber = value =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0;
+const isPositive = value => isNumber(value) && value > 0;
+const isCount = value => Number.isInteger(value) && value >= 0;
+
+export function normalizeMeasurement(measurement, fallbackSampleSize) {
+  return typeof measurement === 'number'
+    ? { value: measurement, sampleSize: fallbackSampleSize }
+    : {
+        value: measurement?.value,
+        sampleSize: measurement?.sampleSize ?? fallbackSampleSize,
+      };
+}
+
+export function activeWaiver(waiver, now = new Date()) {
+  const until = waiver?.until ?? waiver?.expiresAt;
+  const untilMs = typeof until === 'string' ? new Date(until).getTime() : NaN;
+  return Number.isFinite(untilMs) && untilMs > now.getTime() ? waiver : null;
+}
+
+export function defaultRatchetPolicy(policy = {}) {
+  return {
+    marginFraction: 0,
+    improveEpsilon: 0,
+    minSampleSize: 0,
+    waiver: null,
+    ...policy,
+  };
+}
+
+export function validateRatchetConfig(ratchet) {
+  if (!ratchet || typeof ratchet !== 'object') {
+    return { ok: false, errors: ['ratchet must be a JSON object'] };
+  }
+  const policy = defaultRatchetPolicy(ratchet.policy);
+  const errors = [];
+  if (ratchet.schemaVersion !== RATCHET_CORE_SCHEMA_VERSION) {
+    errors.push(
+      `schemaVersion must be ${RATCHET_CORE_SCHEMA_VERSION}; got ${ratchet.schemaVersion}`
+    );
+  }
+  if (typeof ratchet.dimension !== 'string' || ratchet.dimension.length === 0) {
+    errors.push('dimension must be a non-empty string');
+  }
+  if (!DIRECTIONS.has(ratchet.direction)) {
+    errors.push('direction must be "lock_down" or "lock_up"');
+  }
+  if (!isPositive(ratchet.baseline)) {
+    errors.push('baseline must be a positive number');
+  }
+  if (!ratchet.policy || typeof ratchet.policy !== 'object') {
+    errors.push('policy must be an object');
+  }
+  if (!isNumber(policy.marginFraction)) {
+    errors.push('policy.marginFraction must be a non-negative number');
+  }
+  if (!isNumber(policy.improveEpsilon)) {
+    errors.push('policy.improveEpsilon must be a non-negative number');
+  }
+  if (!isCount(policy.minSampleSize)) {
+    errors.push('policy.minSampleSize must be a non-negative integer');
+  }
+  if (policy.waiver != null && typeof policy.waiver !== 'object') {
+    errors.push('policy.waiver must be null or an object');
+  }
+  if (ratchet.sampleSize !== undefined && !isCount(ratchet.sampleSize)) {
+    errors.push('sampleSize must be a non-negative integer when present');
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+export function compareRatchet(measurement, ratchet, options = {}) {
+  const validation = validateRatchetConfig(ratchet);
+  if (!validation.ok) {
+    throw new Error(`Invalid ratchet config: ${validation.errors.join('; ')}`);
+  }
+  const { value: measured, sampleSize } = normalizeMeasurement(
+    measurement,
+    ratchet.sampleSize
+  );
+  if (!isNumber(measured)) {
+    throw new Error(
+      `measurement value must be a non-negative number; got ${measured}`
+    );
+  }
+
+  const policy = defaultRatchetPolicy(ratchet.policy);
+  const lockDown = ratchet.direction === RATCHET_DIRECTIONS.LOCK_DOWN;
+  const threshold =
+    ratchet.baseline *
+    (lockDown ? 1 + policy.marginFraction : 1 - policy.marginFraction);
+  const withinThreshold = lockDown
+    ? measured <= threshold
+    : measured >= threshold;
+  const headroom = lockDown ? threshold - measured : measured - threshold;
+  const improvedBy = Math.max(
+    0,
+    lockDown
+      ? (ratchet.baseline - measured) / ratchet.baseline
+      : (measured - ratchet.baseline) / ratchet.baseline
+  );
+  const waiver = activeWaiver(policy.waiver, options.now);
+  const enoughSamples =
+    policy.minSampleSize === 0 ||
+    (typeof sampleSize === 'number' && sampleSize >= policy.minSampleSize);
+
+  let status = 'pass';
+  let ok = withinThreshold;
+  if (waiver) {
+    status = 'waived';
+    ok = true;
+  } else if (!enoughSamples) {
+    status = 'insufficient_data';
+    ok = true;
+  } else if (!withinThreshold) {
+    status = 'regression';
+    ok = false;
+  } else if (improvedBy > policy.improveEpsilon) {
+    status = 'improvement';
+  }
+
+  return {
+    ok,
+    status,
+    direction: ratchet.direction,
+    measured,
+    baseline: ratchet.baseline,
+    threshold,
+    headroom,
+    marginFraction: policy.marginFraction,
+    improveEpsilon: policy.improveEpsilon,
+    improvedBy,
+    sampleSize,
+    reason: status,
+    ...(status === 'improvement' ? { proposeNewBaseline: measured } : {}),
+    ...(waiver ? { waiver } : {}),
+  };
+}
+
+export function isLooseningBaseline(nextBaseline, ratchet) {
+  if (!isPositive(nextBaseline)) {
+    throw new Error(
+      `next baseline must be a positive number; got ${nextBaseline}`
+    );
+  }
+  return ratchet.direction === RATCHET_DIRECTIONS.LOCK_DOWN
+    ? nextBaseline > ratchet.baseline
+    : nextBaseline < ratchet.baseline;
+}
+
+export function buildRatchetUpdate(ratchet, measurement, options = {}) {
+  const validation = validateRatchetConfig(ratchet);
+  if (!validation.ok)
+    return { ok: false, errors: validation.errors, updated: null };
+  const { value: baseline, sampleSize } = normalizeMeasurement(
+    measurement,
+    ratchet.sampleSize
+  );
+  if (!isPositive(baseline)) {
+    return {
+      ok: false,
+      errors: [`next baseline must be a positive number; got ${baseline}`],
+      updated: null,
+    };
+  }
+  if (sampleSize !== undefined && !isCount(sampleSize)) {
+    return {
+      ok: false,
+      errors: [`sampleSize must be a non-negative integer; got ${sampleSize}`],
+      updated: null,
+    };
+  }
+  if (!options.force && isLooseningBaseline(baseline, ratchet)) {
+    return {
+      ok: false,
+      errors: ['refusing to loosen baseline'],
+      updated: null,
+    };
+  }
+  return {
+    ok: true,
+    errors: [],
+    updated: {
+      ...ratchet,
+      baseline,
+      sampleSize: sampleSize ?? ratchet.sampleSize ?? 0,
+      updatedAt: (options.now ?? new Date()).toISOString(),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Extracts a metric-agnostic shared ratchet core for CI/script ratchets.
- Supports both `lock_down` (ceilings/regression caps) and `lock_up` (floors/minimums) policies.
- Rewrites the CI duration ratchet library as a compatibility layer so existing CLI behavior is preserved.

## Validation
- `pnpm run ci:harness:test` — 11 files / 123 tests passed locally in this checkout, including both ratchet suites.
- Prior full validation from implementation pass: vitest scripts suite 126 tests passed.
- `pnpm biome check scripts/lib/ratchet-core.mjs scripts/lib/__tests__/ratchet-core.test.mjs scripts/lib/ci-duration-ratchet.mjs scripts/ci-duration-ratchet.mjs` — passed.
- Force-push pre-push hooks passed: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint.

## Notes
- Slice A of the broader Ratchet + Escalation system; see `/Users/timwhite/ratchet-escalation-system.md`.
- PR diff is intentionally focused on the shared ratchet extraction plus CI duration compatibility path.
