### PR TITLE
feat(qa): exploratory journey scout + product-promise registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,9 @@ output/
 # QA swarm runtime artifacts (findings, remediation manifests, Eve queue)
 .context/qa-swarm/
 
+# Journey scout reports + evidence (Production Journey Auditor)
+.context/journey-scout/
+
 # Ruflo MCP local state (sqlite + vector index, never committed)
 .claude-flow/
 .swarm/

--- a/apps/web/lib/qa/product-promises.test.ts
+++ b/apps/web/lib/qa/product-promises.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
+import { getProductPromise, PRODUCT_PROMISES } from './product-promises';
+
+const APP_ROUTE_VALUES = new Set<string>(Object.values(APP_ROUTES));
+
+describe('PRODUCT_PROMISES registry', () => {
+  it('encodes at least the signup onboarding promise', () => {
+    expect(
+      getProductPromise('anonymous-signup-onboarding-starts')
+    ).toBeDefined();
+  });
+
+  it('has unique ids', () => {
+    const ids = PRODUCT_PROMISES.map(p => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it.each(
+    PRODUCT_PROMISES.map(p => [p.id, p] as const)
+  )('%s is well-formed', (_id, promise) => {
+    // Self-guarding: a typo entrypoint that is not a real route fails here.
+    expect(
+      APP_ROUTE_VALUES.has(promise.entrypoint),
+      `entrypoint ${promise.entrypoint} is not an APP_ROUTES value`
+    ).toBe(true);
+    expect(promise.promise.length).toBeGreaterThan(0);
+    expect(promise.successSignals.length).toBeGreaterThan(0);
+    expect(promise.unacceptableFailures.length).toBeGreaterThan(0);
+    expect(promise.suggestedCoverage.length).toBeGreaterThan(0);
+  });
+
+  it('points the signup promise at the deepened canary specs', () => {
+    const signup = getProductPromise('anonymous-signup-onboarding-starts');
+    expect(signup?.entrypoint).toBe(APP_ROUTES.START);
+    expect(signup?.suggestedCoverage.join(' ')).toContain(
+      'canary-onboarding-turn.spec.ts'
+    );
+  });
+});

--- a/apps/web/lib/qa/product-promises.ts
+++ b/apps/web/lib/qa/product-promises.ts
@@ -1,0 +1,121 @@
+/**
+ * Product promise registry (Production Journey Auditor).
+ *
+ * A small, typed catalog of the critical user promises Jovie must keep. Each
+ * entry names the entrypoint, the signals that prove the promise is kept, the
+ * failure states that are never acceptable, and where deterministic coverage
+ * lives (or should).
+ *
+ * This is load-bearing, not documentation: `scripts/journey-scout.ts` reads it
+ * as its seed config (entrypoints + expected/unacceptable signals), and
+ * `product-promises.test.ts` asserts every entrypoint is a real APP_ROUTES path.
+ * A registry nothing consumes is ceremony — keep it wired.
+ */
+
+import { APP_ROUTES } from '@/constants/routes';
+
+export interface ProductPromise {
+  /** Stable kebab-case id. */
+  readonly id: string;
+  /** Human summary of the promise. */
+  readonly promise: string;
+  /** Route the journey starts from — must be an APP_ROUTES value. */
+  readonly entrypoint: string;
+  /** Whether the entrypoint is reachable without auth. */
+  readonly anonymous: boolean;
+  /** Observable signals that prove the promise is kept (testids / copy). */
+  readonly successSignals: readonly string[];
+  /** States that are never acceptable (what the scout flags). */
+  readonly unacceptableFailures: readonly string[];
+  /** Where deterministic coverage lives, or the suggestion if absent. */
+  readonly suggestedCoverage: readonly string[];
+}
+
+export const PRODUCT_PROMISES: readonly ProductPromise[] = [
+  {
+    id: 'anonymous-signup-onboarding-starts',
+    promise:
+      'An anonymous visitor who lands on /start sees an initialized interview, can send a first answer, and gets an AI reply or a clear fallback.',
+    entrypoint: APP_ROUTES.START,
+    anonymous: true,
+    successSignals: [
+      'testid:onboarding-chat',
+      'testid:onboarding-empty-intro',
+      'composer input editable (role=textbox name=/chat message input/i)',
+      'turn resolves to an assistant reply (testid:chat-message-reply) or a known fallback',
+    ],
+    unacceptableFailures: [
+      'onboarding-chat container present but interview never initializes',
+      'composer never becomes editable (stuck loading)',
+      'POST /api/chat returns 500 / INTERNAL_ERROR on a real turn',
+      'indefinite spinner with no reply and no fallback',
+    ],
+    suggestedCoverage: [
+      'tests/e2e/canary-auth-signup-onboarding.spec.ts (init, gated)',
+      'tests/e2e/canary-onboarding-turn.spec.ts (real turn, nightly)',
+    ],
+  },
+  {
+    id: 'logged-in-dashboard-loads',
+    promise:
+      'A signed-in creator who opens /app sees their dashboard render with real chrome, not an error or perpetual skeleton.',
+    entrypoint: APP_ROUTES.DASHBOARD,
+    anonymous: false,
+    successSignals: [
+      'dashboard shell renders',
+      'no error boundary / 500',
+      'skeletons resolve to content within budget',
+    ],
+    unacceptableFailures: [
+      'error boundary or 500 on load',
+      'perpetual skeleton / infinite loading',
+      'redirect loop back to sign-in while authenticated',
+    ],
+    suggestedCoverage: [
+      'tests/e2e/dashboard-pages-health.spec.ts',
+      'add: deterministic /app load assertion under bypass auth',
+    ],
+  },
+  {
+    id: 'primary-connect-actions-work-or-explain',
+    promise:
+      'Connect actions either work, or clearly explain why a platform is unavailable — never a dead button.',
+    entrypoint: APP_ROUTES.SETTINGS_CONNECTORS,
+    anonymous: false,
+    successSignals: [
+      'connect CTA triggers an OAuth/connect flow or navigation',
+      'unavailable platforms show an explicit disabled + reason state',
+    ],
+    unacceptableFailures: [
+      'connect button does nothing on click (dead CTA)',
+      'no explanation when a connector is unavailable',
+      'silent failure with no toast / state change',
+    ],
+    suggestedCoverage: [
+      'tests/e2e/connectors-magic-moment.spec.ts',
+      'add: dead-CTA assertion per connector row',
+    ],
+  },
+  {
+    id: 'usage-metrics-show-data-or-explicit-state',
+    promise:
+      'Usage/earnings metrics show real data, or an explicit empty / loading / error state — never a blank or fake number.',
+    entrypoint: APP_ROUTES.EARNINGS,
+    anonymous: false,
+    successSignals: [
+      'real metric values render',
+      'OR an explicit empty-state / loading / error component renders',
+    ],
+    unacceptableFailures: [
+      'blank region where metrics should be',
+      'hardcoded / placeholder numbers presented as real',
+      'spinner that never resolves',
+    ],
+    suggestedCoverage: ['add: earnings empty/loading/error-state assertions'],
+  },
+] as const;
+
+/** Look up a promise by id. */
+export function getProductPromise(id: string): ProductPromise | undefined {
+  return PRODUCT_PROMISES.find(p => p.id === id);
+}

--- a/apps/web/scripts/journey-scout.ts
+++ b/apps/web/scripts/journey-scout.ts
@@ -1,0 +1,436 @@
+/**
+ * Journey Scout — exploratory crawler for the Production Journey Auditor.
+ *
+ * Reads the product-promise registry, visits each entrypoint, observes the
+ * before/after state of clicking the primary CTA (screenshot + DOM text +
+ * accessibility tree), and classifies what it finds into a fixed taxonomy.
+ * It is REPORT-ONLY by default: it writes a markdown report + evidence to
+ * .context/journey-scout/<runId>/ and files ZERO issues unless --file-issues
+ * is passed (which currently only prints what it *would* file — wiring it to
+ * Linear is a deliberate follow-up, not a silent capability).
+ *
+ * ponytail: standalone Playwright script rather than extending route-qa.ts.
+ * route-qa sweeps route *status*; this clicks CTAs, diffs state, and classifies
+ * journeys — different job. It reuses route-qa's conventions (BASE_URL default,
+ * /api/dev/test-auth bootstrap) without coupling to its internals.
+ *
+ * Run:  doppler run --project jovie-web --config dev -- pnpm tsx scripts/journey-scout.ts
+ *       JOURNEY_SCOUT_BASE_URL=https://staging.jov.ie ... (defaults to localhost:3000)
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { type Browser, chromium, type Page } from 'playwright';
+import {
+  PRODUCT_PROMISES,
+  type ProductPromise,
+} from '../lib/qa/product-promises';
+
+const BASE_URL =
+  process.env.JOURNEY_SCOUT_BASE_URL?.trim() || 'http://localhost:3000';
+const FILE_ISSUES = process.argv.includes('--file-issues');
+const RUN_ID = new Date()
+  .toISOString()
+  .replace(/[:.]/g, '-')
+  .replace('T', '_')
+  .slice(0, 19);
+const OUT_DIR = join(
+  process.cwd(),
+  '..',
+  '..',
+  '.context',
+  'journey-scout',
+  RUN_ID
+);
+
+type Classification =
+  | 'dead-cta'
+  | 'broken-journey-start'
+  | 'infinite-pending'
+  | 'silent-auth-failure'
+  | 'ai-contract-failure'
+  | 'no-empty-state-recovery'
+  | 'fake-metric-or-control'
+  | 'visual-brokenness'
+  | 'acceptable-expectation-mismatch';
+
+/** Classifications that represent a real broken promise (worth a test/issue). */
+const BROKEN: ReadonlySet<Classification> = new Set([
+  'dead-cta',
+  'broken-journey-start',
+  'infinite-pending',
+  'silent-auth-failure',
+  'ai-contract-failure',
+  'no-empty-state-recovery',
+  'fake-metric-or-control',
+  'visual-brokenness',
+]);
+
+interface Finding {
+  readonly promiseId: string;
+  readonly route: string;
+  readonly classification: Classification;
+  readonly severity: 'P0' | 'P1' | 'P2';
+  readonly evidence: string[];
+  readonly beforeShot?: string;
+  readonly afterShot?: string;
+}
+
+// Tokens / secrets / PII are stripped from any saved DOM text.
+const SECRET_PATTERN =
+  /(?:token|key|secret|password|authorization|cookie|bearer|email)[=: ][^\s"']{4,}/gi;
+const TOKEN_SHAPED = /\b(?:sk|pk|rk|whsec|ey)[A-Za-z0-9_-]{8,}\b/g;
+const EMAIL = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+
+function redact(text: string): string {
+  return text
+    .replace(SECRET_PATTERN, '[REDACTED]')
+    .replace(TOKEN_SHAPED, '[REDACTED]')
+    .replace(EMAIL, '[REDACTED-EMAIL]');
+}
+
+async function bootstrapAuth(page: Page, persona: string): Promise<void> {
+  // Local dev auth bypass (see .claude/rules/auth.md). No-op-safe on prod URLs
+  // (the route 404s there; the scout still records what an anon user sees).
+  try {
+    await page.goto(
+      `${BASE_URL}/api/dev/test-auth/enter?persona=${persona}&redirect=/app`,
+      { waitUntil: 'domcontentloaded', timeout: 30_000 }
+    );
+  } catch {
+    /* best-effort */
+  }
+}
+
+async function capture(
+  page: Page,
+  label: string
+): Promise<{ shot: string; text: string; a11y: string }> {
+  const shot = join(OUT_DIR, `${label}.png`);
+  try {
+    await page.screenshot({ path: shot, fullPage: true });
+  } catch {
+    /* page may be navigating */
+  }
+  const text = redact(
+    (await page
+      .locator('body')
+      .innerText()
+      .catch(() => '')) || ''
+  );
+  // page.accessibility was removed in newer Playwright; use the ARIA snapshot
+  // when available and degrade gracefully otherwise.
+  let a11y = '{}';
+  try {
+    const snapshot = await page
+      .locator('body')
+      .ariaSnapshot()
+      .catch(() => '');
+    a11y = redact(String(snapshot)).slice(0, 4000);
+  } catch {
+    /* a11y snapshot unavailable — screenshot + DOM text still captured */
+  }
+  return { shot, text, a11y };
+}
+
+/** Heuristic: the primary CTA on a journey-start surface. */
+async function findPrimaryCta(page: Page) {
+  const candidates = [
+    page.locator('[data-testid*="cta"]:visible').first(),
+    page
+      .getByRole('button', {
+        name: /get started|start|sign up|connect|continue|send message/i,
+      })
+      .first(),
+    page
+      .getByRole('link', { name: /get started|start|sign up|continue/i })
+      .first(),
+  ];
+  for (const c of candidates) {
+    if (
+      await c
+        .count()
+        .then(n => n > 0)
+        .catch(() => false)
+    ) {
+      if (await c.isVisible().catch(() => false)) return c;
+    }
+  }
+  return null;
+}
+
+function hasSpinnerOnly(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  return t.length < 40 && /loading|loading…|please wait|^$/.test(t);
+}
+
+async function scoutPromise(
+  page: Page,
+  promise: ProductPromise
+): Promise<Finding | null> {
+  const route = promise.entrypoint;
+  const evidence: string[] = [];
+
+  // --- Load the entrypoint ---
+  const pageErrors: string[] = [];
+  page.on('pageerror', e => pageErrors.push(e.message));
+  let status = 0;
+  try {
+    const resp = await page.goto(`${BASE_URL}${route}`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 45_000,
+    });
+    status = resp?.status() ?? 0;
+  } catch (e) {
+    evidence.push(`navigation threw: ${(e as Error).message}`);
+    const before = await capture(page, `${promise.id}-load-error`);
+    return {
+      promiseId: promise.id,
+      route,
+      classification: 'broken-journey-start',
+      severity: 'P0',
+      evidence,
+      beforeShot: before.shot,
+    };
+  }
+
+  const before = await capture(page, `${promise.id}-before`);
+
+  if (status >= 500) {
+    evidence.push(`entrypoint returned HTTP ${status}`);
+    return {
+      promiseId: promise.id,
+      route,
+      classification: 'broken-journey-start',
+      severity: 'P0',
+      evidence,
+      beforeShot: before.shot,
+    };
+  }
+
+  // Unexpected bounce to sign-in while we expected an authed surface.
+  if (!promise.anonymous && /\/(signin|sign-in|signup)\b/.test(page.url())) {
+    evidence.push(`redirected to ${page.url()} (auth bounce)`);
+    return {
+      promiseId: promise.id,
+      route,
+      classification: 'silent-auth-failure',
+      severity: 'P1',
+      evidence,
+      beforeShot: before.shot,
+    };
+  }
+
+  // --- Promise-specific deep check: the anonymous onboarding turn ---
+  if (promise.id === 'anonymous-signup-onboarding-starts') {
+    const composer = page.getByRole('textbox', {
+      name: /chat message input/i,
+    });
+    // Wait for hydration: the composer is server-rendered but only editable
+    // once the client mounts. Poll up to 20s before declaring the init broken.
+    const editable = await composer
+      .waitFor({ state: 'visible', timeout: 20_000 })
+      .then(() => composer.isEditable())
+      .catch(() => false);
+    if (!editable) {
+      evidence.push('composer never became editable');
+      return {
+        promiseId: promise.id,
+        route,
+        classification: 'broken-journey-start',
+        severity: 'P0',
+        evidence,
+        beforeShot: before.shot,
+      };
+    }
+    await composer.fill('I make indie pop, help me set up my profile.');
+    await page
+      .getByRole('button', { name: /send message/i })
+      .click()
+      .catch(() => {});
+    // Wait for a reply, a known fallback, or give up (infinite/error).
+    const reply = page.getByTestId('chat-message-reply');
+    const fallback = page.getByText(
+      /Jovie hit a temporary issue|still connecting|temporarily unavailable/i
+    );
+    const resolved = await reply
+      .or(fallback)
+      .first()
+      .isVisible({ timeout: 45_000 })
+      .catch(() => false);
+    const after = await capture(page, `${promise.id}-after-turn`);
+    if (!resolved) {
+      evidence.push(
+        'turn produced neither an AI reply nor a known fallback within 45s (stuck/loading or 500)'
+      );
+      return {
+        promiseId: promise.id,
+        route,
+        classification: 'ai-contract-failure',
+        severity: 'P0',
+        evidence,
+        beforeShot: before.shot,
+        afterShot: after.shot,
+      };
+    }
+    return null; // promise kept
+  }
+
+  // --- Generic CTA click + state diff for the other promises ---
+  const cta = await findPrimaryCta(page);
+  if (!cta) {
+    // No CTA + a near-empty body with no explicit empty-state component.
+    if (hasSpinnerOnly(before.text)) {
+      evidence.push('surface shows only a spinner / blank with no CTA');
+      return {
+        promiseId: promise.id,
+        route,
+        classification: 'infinite-pending',
+        severity: 'P1',
+        evidence,
+        beforeShot: before.shot,
+      };
+    }
+    return null; // nothing actionable to classify; not necessarily broken
+  }
+
+  const urlBefore = page.url();
+  await cta.click({ timeout: 5_000 }).catch(() => {});
+  await page.waitForTimeout(1500);
+  const after = await capture(page, `${promise.id}-after`);
+  const urlChanged = page.url() !== urlBefore;
+  const domChanged = after.text.trim() !== before.text.trim();
+
+  if (!urlChanged && !domChanged && pageErrors.length === 0) {
+    evidence.push('primary CTA produced no navigation and no DOM change');
+    return {
+      promiseId: promise.id,
+      route,
+      classification: 'dead-cta',
+      severity: 'P1',
+      evidence,
+      beforeShot: before.shot,
+      afterShot: after.shot,
+    };
+  }
+
+  if (hasSpinnerOnly(after.text)) {
+    evidence.push('after CTA, surface is stuck on a spinner');
+    return {
+      promiseId: promise.id,
+      route,
+      classification: 'infinite-pending',
+      severity: 'P1',
+      evidence,
+      beforeShot: before.shot,
+      afterShot: after.shot,
+    };
+  }
+
+  return null; // promise kept (acceptable)
+}
+
+/** A proposed deterministic Playwright test for a confirmed broken promise. */
+function proposeTest(finding: Finding): string {
+  return [
+    '```ts',
+    `// Proposed regression test for ${finding.promiseId} (${finding.classification})`,
+    `test('${finding.promiseId}: journey is not ${finding.classification}', async ({ page }) => {`,
+    `  const resp = await page.goto('${finding.route}');`,
+    `  expect(resp?.status() ?? 0).toBeLessThan(400);`,
+    finding.classification === 'ai-contract-failure'
+      ? [
+          `  const composer = page.getByRole('textbox', { name: /chat message input/i });`,
+          `  await expect(composer).toBeEditable();`,
+          `  await composer.fill('test answer');`,
+          `  await page.getByRole('button', { name: /send message/i }).click();`,
+          `  const reply = page.getByTestId('chat-message-reply');`,
+          `  const fallback = page.getByText(/temporary issue|still connecting|temporarily unavailable/i);`,
+          `  await expect(reply.or(fallback).first()).toBeVisible({ timeout: 45_000 });`,
+        ].join('\n')
+      : finding.classification === 'dead-cta'
+        ? `  // Click the primary CTA and assert navigation or a visible state change.`
+        : `  // Assert an explicit empty/loading/error state, never a blank or spinner.`,
+    `});`,
+    '```',
+  ].join('\n');
+}
+
+function writeReport(findings: Finding[]): string {
+  const broken = findings.filter(f => BROKEN.has(f.classification));
+  const lines: string[] = [
+    `# Journey Scout report — ${RUN_ID}`,
+    '',
+    `- Base URL: ${BASE_URL}`,
+    `- Promises checked: ${PRODUCT_PROMISES.length}`,
+    `- Findings: ${findings.length} (${broken.length} broken)`,
+    `- Mode: report-only${FILE_ISSUES ? ' (--file-issues: would file below)' : ''}`,
+    '',
+    '> Report-only. No Linear issues created. Each broken promise below includes',
+    '> evidence and a proposed deterministic regression test.',
+    '',
+  ];
+
+  if (findings.length === 0) {
+    lines.push('All promises kept. No findings.');
+  }
+
+  for (const f of findings) {
+    lines.push(`## ${f.promiseId} — \`${f.classification}\` (${f.severity})`);
+    lines.push(`- Route: \`${f.route}\``);
+    for (const e of f.evidence) lines.push(`- Evidence: ${e}`);
+    if (f.beforeShot) lines.push(`- Before: \`${f.beforeShot}\``);
+    if (f.afterShot) lines.push(`- After: \`${f.afterShot}\``);
+    if (BROKEN.has(f.classification)) {
+      lines.push('', '### Proposed test', proposeTest(f));
+    }
+    lines.push('');
+  }
+
+  const reportPath = join(OUT_DIR, 'report.md');
+  writeFileSync(reportPath, lines.join('\n'), 'utf8');
+  return reportPath;
+}
+
+async function main(): Promise<void> {
+  mkdirSync(OUT_DIR, { recursive: true });
+  let browser: Browser | null = null;
+  const findings: Finding[] = [];
+
+  try {
+    browser = await chromium.launch();
+    for (const promise of PRODUCT_PROMISES) {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      try {
+        if (!promise.anonymous) await bootstrapAuth(page, 'creator-ready');
+        const finding = await scoutPromise(page, promise);
+        if (finding) findings.push(finding);
+        process.stdout.write(
+          `· ${promise.id}: ${finding ? finding.classification : 'ok'}\n`
+        );
+      } catch (e) {
+        process.stdout.write(
+          `· ${promise.id}: scout error — ${(e as Error).message}\n`
+        );
+      } finally {
+        await context.close().catch(() => {});
+      }
+    }
+  } finally {
+    await browser?.close().catch(() => {});
+  }
+
+  const reportPath = writeReport(findings);
+  const broken = findings.filter(f => BROKEN.has(f.classification));
+  process.stdout.write(`\nReport: ${reportPath}\n`);
+  if (FILE_ISSUES && broken.length > 0) {
+    process.stdout.write(
+      `--file-issues: would file ${broken.length} Linear issue(s) — wiring is a deliberate follow-up, not yet implemented.\n`
+    );
+  }
+  // Report-only: never non-zero on findings (don't break CI by surfacing noise).
+  process.exit(0);
+}
+
+void main();

--- a/apps/web/tests/journey-auditor/README.md
+++ b/apps/web/tests/journey-auditor/README.md
@@ -1,0 +1,131 @@
+# Production Journey Auditor
+
+A layered QA system for the critical user journeys Jovie must never break —
+starting with the one that broke in production with no test to catch it:
+**anonymous signup → AI onboarding interview**.
+
+The original break slipped through because the existing canary only checked that
+the `onboarding-chat` container string was in the SSR HTML and that `POST
+/api/chat` *reached* the Turnstile gate. Neither verified the interview
+*initialized* (starter prompt visible, composer usable) or that a real turn
+*responded*. This system closes that gap and generalizes it.
+
+## Layers
+
+| Layer | File | Runs | Catches |
+|---|---|---|---|
+| **Init canary (gated)** | `tests/e2e/canary-auth-signup-onboarding.spec.ts` | every PR (nightly tag) + prod smoke | interview never initializes, composer stuck, console/network errors — **deterministic, no LLM** |
+| **Full-turn canary (nightly)** | `tests/e2e/canary-onboarding-turn.spec.ts` | nightly only | a real `/api/chat` turn that 500s, hangs, or returns neither a reply nor a known fallback |
+| **Production smoke** | `pnpm qa:journey:smoke` | post-deploy / schedule | the journey broken on the live site, with a compact failure packet |
+| **Pure assertion helpers** | `lib/canaries/auth-signup-onboarding.ts` | shared by spec + cron | one source of truth for init markers + the known-fallback contract |
+| **Product-promise registry** | `lib/qa/product-promises.ts` | consumed by the scout + a unit test | drift between promises and routes |
+| **Exploratory scout** | `scripts/journey-scout.ts` | ad-hoc / manual | unknown journey breaks across the taxonomy — **report-only** |
+
+### Why local = full turn, prod = init only
+
+Turnstile gates the onboarding turn in production, so a real turn can't complete
+there without solving a CAPTCHA. On the local/CI dev server Turnstile is bypassed
+(`NEXT_PUBLIC_E2E_MODE=1` → `shouldBypassTurnstileForLocalRuntime`), so the
+full turn is exercisable. The split is honest, not a gap:
+
+- **Local/CI** runs the real turn (`canary-onboarding-turn.spec.ts`).
+- **Prod smoke** verifies the interview *initializes* + the gate responds — the
+  exact depth the production break needed.
+
+## Run it
+
+### Locally
+
+```bash
+# 1. Start a browse-compatible dev server (Turnstile bypassed)
+pnpm run dev:web:browse        # serves http://localhost:3000
+
+# 2. Init canary (deterministic, fast)
+pnpm --filter @jovie/web exec playwright test tests/e2e/canary-auth-signup-onboarding.spec.ts
+
+# 3. Full real-LLM turn (nightly-class; needs the bypass server above)
+pnpm --filter @jovie/web exec playwright test tests/e2e/canary-onboarding-turn.spec.ts
+
+# 4. Registry unit test
+pnpm --filter @jovie/web exec vitest run lib/qa/product-promises.test.ts lib/canaries/auth-signup-onboarding.test.ts
+
+# 5. Exploratory scout (report-only, files ZERO issues)
+doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web exec tsx scripts/journey-scout.ts
+#   → writes .context/journey-scout/<runId>/report.md + screenshots
+```
+
+### In CI
+
+- The init canary is tagged `@canary @nightly @auth-signup-onboarding` and its
+  deterministic assertions gate merges (CI fails if the interview does not
+  initialize). It needs no LLM.
+- The full-turn spec runs in the **nightly lane only** — real model calls must
+  not gate deploys (`.claude/rules/testing.md`: "real network → nightly").
+
+### After deploy (production smoke)
+
+```bash
+# Defaults to https://jov.ie; override with BASE_URL.
+pnpm --filter @jovie/web run qa:journey:smoke
+BASE_URL=https://staging.jov.ie pnpm --filter @jovie/web run qa:journey:smoke
+```
+
+On failure the synthetic config retains trace/video/screenshot **and** the
+`journey-failure-packet` reporter writes a compact, redacted JSON per failure:
+
+```jsonc
+// test-results/journey-failure-packets/<test>.json
+{
+  "route": "/start",
+  "failedStep": "onboarding interview never initialized its starter prompt",
+  "status": "failed",
+  "screenshotPath": "…/test-failed-1.png",
+  "videoPath": "…/video.webm",
+  "tracePath": "…/trace.zip",
+  "consoleErrors": ["…"],
+  "failedRequests": ["POST …/api/chat"],
+  "errors": ["…redacted assertion…"]
+}
+```
+
+## The conversion loop
+
+```
+production bug → scout reproduction → product promise → deterministic test → fix
+```
+
+The scout classifies findings into a fixed taxonomy (`dead-cta`,
+`broken-journey-start`, `infinite-pending`, `silent-auth-failure`,
+`ai-contract-failure`, `no-empty-state-recovery`, `fake-metric-or-control`,
+`visual-brokenness`, `acceptable-expectation-mismatch`). For every **confirmed
+broken** promise it emits a proposed Playwright test in `report.md`. Promote that
+into a real spec, fix the bug, and the journey is now permanently guarded. See
+`example-failure-report.md` for a real run.
+
+## Anti-silent-quarantine policy
+
+If `canary-onboarding-turn.spec.ts` flakes, **do not silent-skip it** — a
+quarantined journey detector recreates the exact "no test caught it" failure.
+Quarantining it requires a filed Linear issue with the flake evidence, never a
+quiet entry in `quarantine.json`.
+
+## Safety
+
+- Anonymous / dev-bypass sessions only — no real customer data is created.
+- The scout stops at CTA click + observe; it never submits the waitlist/checkout
+  forms, so no external emails or irreversible third-party actions fire.
+- All saved artifacts (DOM text, a11y snapshots, failure packets) are redacted of
+  cookies, token-shaped strings, and emails.
+- The scout is **report-only**; `--file-issues` is opt-in and currently only
+  prints what it would file (Linear wiring is a deliberate follow-up).
+
+## Current known break
+
+As of this change, the anonymous onboarding **turn** 500s in the local/CI dev
+runtime (`stream.pipeThrough is not a function`, AI SDK v6
+`toUIMessageStreamResponse`). It reproduces only under the Turbopack dev runtime;
+the production path is Turnstile-gated and could not be exercised end-to-end to
+confirm. The leak-guard wrapper, model id, and gateway config were all excluded
+as causes. The full-turn canary currently captures this with a clear diagnosis
+(an accepted Definition-of-Done outcome). Root-cause investigation:
+**JOV-3693** (does it affect prod, or only Turbopack dev?).

--- a/apps/web/tests/journey-auditor/example-failure-report.md
+++ b/apps/web/tests/journey-auditor/example-failure-report.md
@@ -1,0 +1,45 @@
+# Journey Scout report — example
+
+> A real run of `scripts/journey-scout.ts` against a local dev server, committed
+> as a reference. Live runs land in `.context/journey-scout/<runId>/report.md`
+> (gitignored) with before/after screenshots.
+
+# Journey Scout report — 2026-06-29_00-59-24
+
+- Base URL: http://localhost:3000
+- Promises checked: 4
+- Findings: 1 (1 broken)
+- Mode: report-only
+
+> Report-only. No Linear issues created. Each broken promise below includes
+> evidence and a proposed deterministic regression test.
+
+## anonymous-signup-onboarding-starts — `ai-contract-failure` (P0)
+- Route: `/start`
+- Evidence: turn produced neither an AI reply nor a known fallback within 45s (stuck/loading or 500)
+- Before: `…/anonymous-signup-onboarding-starts-before.png`
+- After: `…/anonymous-signup-onboarding-starts-after-turn.png`
+
+### Proposed test
+```ts
+// Proposed regression test for anonymous-signup-onboarding-starts (ai-contract-failure)
+test('anonymous-signup-onboarding-starts: journey is not ai-contract-failure', async ({ page }) => {
+  const resp = await page.goto('/start');
+  expect(resp?.status() ?? 0).toBeLessThan(400);
+  const composer = page.getByRole('textbox', { name: /chat message input/i });
+  await expect(composer).toBeEditable();
+  await composer.fill('test answer');
+  await page.getByRole('button', { name: /send message/i }).click();
+  const reply = page.getByTestId('chat-message-reply');
+  const fallback = page.getByText(/temporary issue|still connecting|temporarily unavailable/i);
+  await expect(reply.or(fallback).first()).toBeVisible({ timeout: 45_000 });
+});
+```
+
+---
+
+**What this run demonstrates.** The scout visited four product promises, kept
+three (`ok`), and flagged exactly one real break — the anonymous onboarding turn,
+which 500s in the dev runtime — at P0 with before/after evidence and a ready-to-
+promote regression test. It filed zero Linear issues. That is the intended
+behavior: low-noise, evidence-first, report-only.


### PR DESCRIPTION
## What (Part 2 of 2)

The exploratory layer of the Production Journey Auditor. Sibling to the regression-net PR (#12341) — independent, no shared imports.

- **`lib/qa/product-promises.ts`** — a typed registry of critical user promises (entrypoint, success signals, unacceptable failures, suggested coverage), seeded with four: anonymous signup onboarding starts, logged-in dashboard loads, primary connect actions work-or-explain, usage metrics show data-or-explicit-state. A self-guarding unit test asserts every entrypoint is a real `APP_ROUTES` value. **Consumed by the scout** as seed config (load-bearing, not docs).
- **`scripts/journey-scout.ts` (`qa:journey:scout`)** — a report-only Playwright crawler that visits each promise entrypoint, clicks the primary CTA, diffs before/after state (screenshot + DOM + ARIA snapshot), and classifies findings into a fixed 9-way taxonomy (`dead-cta`, `broken-journey-start`, `infinite-pending`, `silent-auth-failure`, `ai-contract-failure`, `no-empty-state-recovery`, `fake-metric-or-control`, `visual-brokenness`, `acceptable-expectation-mismatch`). Writes a markdown report + evidence to `.context/journey-scout/` (gitignored) and files **zero** issues by default; emits a proposed regression test per confirmed break. Redacts cookies, tokens, and emails from artifacts.
- **README + example failure report** under `apps/web/tests/journey-auditor/`.

## Verification

- `product-promises.test.ts` passes (7 tests). Typecheck clean on touched files; biome clean.
- Real scout run against a live dev server: precise, **1 P0 finding** (`ai-contract-failure` on `/start`) + 3 `ok`, **zero** Linear issues filed, with a ready-to-promote proposed test. See `example-failure-report.md`.

## Cost impact

None. The scout is manual/on-demand; it never submits forms (stops at CTA click + observe), so no external emails or irreversible third-party actions.

## Notes

- The `qa:journey:scout` package script ships in the sibling PR #12341 (kept there to avoid a package.json merge conflict between siblings); this PR adds the script file it runs. Both land close together.
- Ad-hoc work; the onboarding turn the scout flags has its root cause tracked in **JOV-3693**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)