### PR TITLE
feat(library): right-rail System B compliance for badges, buttons, providers

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -46,6 +46,7 @@ import {
   useState,
 } from 'react';
 import { toast } from 'sonner';
+import { ProviderIcon } from '@/components/atoms/ProviderIcon';
 import { LibraryAssetSharePanel } from '@/components/features/library-asset-share/LibraryAssetSharePanel';
 import { LibraryAssetShareUrlCell } from '@/components/features/library-asset-share/LibraryAssetShareUrlCell';
 import { LibraryShareDropCreator } from '@/components/features/library-share/LibraryShareDropCreator';
@@ -79,6 +80,7 @@ import { useRegisterHeaderSearch } from '@/contexts/HeaderActionsContext';
 import { useRegisterShellSidebarOverride } from '@/contexts/ShellSidebarOverrideContext';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { SKELETON_ROW_COUNT } from '@/lib/constants/layout';
+import type { ProviderKey } from '@/lib/discography/types';
 import {
   formatLibraryApprovalStatus,
   LIBRARY_APPROVAL_STATUSES,
@@ -1628,10 +1630,10 @@ function PreviewActionButton({
       aria-pressed={isPreviewPlaying}
       tabIndex={disabledTabIndex}
       className={cn(
-        'system-b-library-action inline-flex items-center justify-center gap-1.5 border border-subtle',
+        'system-b-library-action inline-flex items-center justify-center gap-1.5',
         compact
           ? 'system-b-library-action--icon'
-          : 'system-b-library-action--standard',
+          : 'system-b-library-action--standard border border-subtle',
         LIBRARY_BUTTON_FOCUS_CLASS
       )}
     >
@@ -1709,7 +1711,6 @@ function ApprovalStatusEditor({
   ) => void;
 }) {
   const [saving, setSaving] = useState(false);
-  const selectId = useId();
 
   async function handleChange(event: ChangeEvent<HTMLSelectElement>) {
     const nextStatus = event.target.value;
@@ -1749,34 +1750,29 @@ function ApprovalStatusEditor({
     }
   }
 
+  // The "Approval" DrawerSection already labels this control, so the select
+  // stands on its own (no stacked label, no nested card) — click-to-edit with
+  // an a11y label (issue #12317).
   return (
-    <div className='system-b-library-drawer-panel mt-4 px-3 py-3'>
-      <label
-        htmlFor={selectId}
-        className='system-b-library-drawer-panel-heading mb-2 block font-semibold text-primary-token'
-      >
-        Approval Status
-      </label>
-      <select
-        id={selectId}
-        value={asset.approvalStatus}
-        onChange={event => {
-          void handleChange(event);
-        }}
-        disabled={disabled || saving || !profileId}
-        data-testid={`library-approval-status-select-${asset.id}`}
-        className={cn(
-          'system-b-library-action system-b-library-action--standard h-8 w-full border border-subtle px-2',
-          LIBRARY_BUTTON_FOCUS_CLASS
-        )}
-      >
-        {LIBRARY_APPROVAL_STATUSES.map(status => (
-          <option key={status} value={status}>
-            {formatLibraryApprovalStatus(status)}
-          </option>
-        ))}
-      </select>
-    </div>
+    <select
+      aria-label='Approval Status'
+      value={asset.approvalStatus}
+      onChange={event => {
+        void handleChange(event);
+      }}
+      disabled={disabled || saving || !profileId}
+      data-testid={`library-approval-status-select-${asset.id}`}
+      className={cn(
+        'system-b-library-action system-b-library-action--standard h-8 w-full border border-subtle px-2',
+        LIBRARY_BUTTON_FOCUS_CLASS
+      )}
+    >
+      {LIBRARY_APPROVAL_STATUSES.map(status => (
+        <option key={status} value={status}>
+          {formatLibraryApprovalStatus(status)}
+        </option>
+      ))}
+    </select>
   );
 }
 
@@ -1851,7 +1847,7 @@ function AssetDrawer({
         {...closedInteractiveProps}
         aria-label={`Open ${current.title}`}
         className={cn(
-          'system-b-library-icon-button system-b-library-icon-button--bordered grid h-7 w-7 place-items-center',
+          'system-b-library-icon-button grid h-7 w-7 place-items-center',
           LIBRARY_ICON_FOCUS_CLASS
         )}
       >
@@ -2110,7 +2106,10 @@ function AssetDrawer({
                               LIBRARY_CARD_FOCUS_CLASS
                             )}
                           >
-                            <Music2 className='h-3.5 w-3.5 text-tertiary-token' />
+                            <ProviderIcon
+                              provider={provider.key as ProviderKey}
+                              className='h-3.5 w-3.5'
+                            />
                             <span className='min-w-0 flex-1 truncate'>
                               {provider.label}
                             </span>

--- a/apps/web/lib/library/approval-status.ts
+++ b/apps/web/lib/library/approval-status.ts
@@ -32,7 +32,9 @@ export function libraryApprovalStatusClasses(
   status: LibraryApprovalStatus
 ): string {
   if (status === 'approved') {
-    return 'border-success/20 bg-success/10 text-success';
+    // Distinct from release "Released" (green/success) so the two badges never
+    // share a color — System B accent spectrum (issue #12317).
+    return 'border-accent-purple/20 bg-accent-purple/10 text-accent-purple';
   }
   if (status === 'needs_review') {
     return 'border-warning/20 bg-warning/10 text-warning';
@@ -46,7 +48,7 @@ export function libraryApprovalStatusClasses(
 export function libraryApprovalStatusDotClasses(
   status: LibraryApprovalStatus
 ): string {
-  if (status === 'approved') return 'bg-success';
+  if (status === 'approved') return 'bg-accent-purple';
   if (status === 'needs_review') return 'bg-warning';
   if (status === 'archived') return 'bg-tertiary-token';
   return 'bg-secondary-token';

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -6570,6 +6570,23 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   padding-inline: 0;
 }
 
+/* Issue #12317 — System B compliance: pill action buttons + borderless
+   circular icon buttons. Overrides the shared --radius-md primitive above. */
+:where(.system-b-library-action),
+:where(.system-b-library-icon-button) {
+  border-radius: var(--radius-full);
+}
+
+/* Compact icon-mode actions read as borderless hover-circles, matching the
+   drawer header icon buttons. */
+:where(.system-b-library-action--icon) {
+  background: transparent;
+}
+
+:where(.system-b-library-action--icon:hover) {
+  background: var(--system-b-bg-surface-1);
+}
+
 :where(.system-b-library-metadata-row) {
   grid-template-columns: 96px minmax(0, 1fr);
 }
@@ -6637,19 +6654,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   color: var(--color-text-tertiary-token);
 }
 
-:where(.system-b-library-icon-button--bordered) {
-  border: 1px solid var(--color-border-subtle);
-  background: var(--system-b-bg-surface-1);
-}
-
 :where(.system-b-library-icon-button:hover) {
   background: var(--system-b-bg-surface-1);
   color: var(--color-text-primary-token);
-}
-
-:where(.system-b-library-icon-button--bordered:hover) {
-  border-color: var(--color-border-default);
-  background: var(--system-b-bg-surface-2);
 }
 
 :where(.system-b-library-drawer-artwork),

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -406,6 +406,12 @@ describe('LibrarySurface', () => {
       'href',
       'https://open.spotify.com/album/take-me-over'
     );
+    // Approval editor is a bare, accessible select (no stacked label / nested
+    // card) — labeled only by its aria-label now that the section heading owns
+    // the visible title (issue #12317).
+    expect(
+      screen.getByRole('combobox', { name: 'Approval Status' })
+    ).toBeInTheDocument();
     const drawer = within(screen.getByTestId('library-asset-drawer'));
     expect(
       drawer.getAllByRole('button', {

--- a/apps/web/tests/unit/library/approval-status.test.ts
+++ b/apps/web/tests/unit/library/approval-status.test.ts
@@ -4,6 +4,7 @@ import {
   isLibraryApprovalStatus,
   isLibraryReleaseApprovedForPublic,
   libraryApprovalStatusClasses,
+  libraryApprovalStatusDotClasses,
 } from '@/lib/library/approval-status';
 
 describe('library approval status helpers', () => {
@@ -20,9 +21,18 @@ describe('library approval status helpers', () => {
   });
 
   it('maps approval statuses to semantic classes', () => {
-    expect(libraryApprovalStatusClasses('approved')).toContain('text-success');
     expect(libraryApprovalStatusClasses('needs_review')).toContain(
       'text-warning'
+    );
+  });
+
+  it('gives Approved its own accent, never the green that Released uses', () => {
+    const approved = libraryApprovalStatusClasses('approved');
+    // Released (release status) is green/success; Approved must not collide.
+    expect(approved).not.toContain('text-success');
+    expect(approved).toContain('text-accent-purple');
+    expect(libraryApprovalStatusDotClasses('approved')).toBe(
+      'bg-accent-purple'
     );
   });
 


### PR DESCRIPTION
Closes #12317.

## What & why
The Library page/right-rail drawer ignored System B in four spots. This brings it back on-grid (token-correct, no taste gate).

- **Badge accent colors** — `Approved` and `Released` both rendered green (`text-success`). `Approved` now uses its own accent (`text-accent-purple`); `Released` stays green, `Scheduled` blue/info, `Needs Review` orange/warning. No two semantically different *accent* badges share a color.
- **Pill buttons / hover-circle icon buttons** — `system-b-library-action` + `system-b-library-icon-button` are now `radius-full`. Compact icon-mode actions and the drawer-header external-link/close buttons are borderless with a surface-1 hover-circle. Removed the now-dead `--bordered` icon-button variant.
- **Provider icons** — provider rows render brand icons via `ProviderIcon` (SocialIcon-backed, contrast-safe, graceful fallback for unknown keys) instead of a generic note glyph.
- **Inline / click-to-edit approval** — the `Approval` `DrawerSection` already titles the control, so the editor drops its redundant stacked `<label>` and nested card and renders a single inline, click-to-edit `<select>` labeled by `aria-label` (subtraction / no-redundant-chrome).

## Acceptance criteria
- [x] No two semantically different badges share one color (Approved purple ≠ Released green) — locked by a regression test.
- [x] Buttons/icon-buttons match System B (pill / borderless hover-circle).
- [x] Providers show icons.

## Verification
```
pnpm --filter @jovie/web run typecheck -- --pretty false      # clean
pnpm --filter @jovie/web exec vitest run tests/unit/library tests/unit/design-system
  # Test Files  20 passed (20) · Tests  83 passed (83)
pnpm biome check apps/web/... + eslint (UI-label-casing, boundaries)  # clean (pre-commit)
coderabbit review --agent -t uncommitted                      # 0 findings
```
Reviewed by review + security + testing subagents (all SHIP / PASS). Added a regression test asserting Approved never reuses `text-success`, and a drawer assertion that the approval `<select>` stays reachable by role + accessible name after the markup change.

## Risk / layout shift
CSS-token + small markup change. Radius/color/border edits are border-box (fixed footprints, no reflow); the approval-editor restructure is a static design change, not a state transition — no CLS introduced. The shared `system-b-library-action` radius also applies to the in-drawer share buttons (LibraryAssetShare*), which is consistent System B pill styling, not a regression.

## Test plan
- Open Library → grid/table → inspect an asset to open the right-rail drawer.
- Confirm `Approved` (purple) vs `Released` (green) badges differ; buttons are pills; drawer-header icon buttons are borderless circles with a hover ring; provider rows show brand icons; the Approval control is a single inline select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)