### PR TITLE
test(ci): assert attest-build-provenance is sha-pinned, not a fixed sha

### DIFF
--- a/apps/web/tests/unit/ci/supply-chain-provenance.test.ts
+++ b/apps/web/tests/unit/ci/supply-chain-provenance.test.ts
@@ -99,8 +99,12 @@ describe('supply chain provenance guardrails', () => {
     expect(buildStep).toContain('vercel build');
     expect(packageStep).toContain('tar -czf /tmp/vercel-build-output.tar.gz');
     expect(packageStep).toContain('.vercel/output');
-    expect(attestStep).toContain(
-      'uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32'
+    // Assert the action is pinned to a full 40-char commit SHA (supply-chain
+    // intent: SHA, not a mutable tag), without hardcoding which SHA — so
+    // dependabot pin bumps don't redden this guardrail. The optional trailing
+    // `# vX.Y.Z` pin comment is allowed.
+    expect(attestStep).toMatch(
+      /^\s*uses: actions\/attest-build-provenance@[0-9a-f]{40}(?:\s+#.*)?$/m
     );
     expect(attestStep).toContain(
       'subject-path: /tmp/vercel-build-output.tar.gz'


### PR DESCRIPTION
## Summary

Fixes the deterministically-failing `supply-chain-provenance` unit test that was reddening the `Unit Tests` merge gate (shard 4/5) on **every** PR, stalling the autonomous merge queue.

The test hardcoded the expected `actions/attest-build-provenance` commit SHA. A dependabot pin bump in `ci.yml` drifted the actual pin away from the asserted value:

- Test expected: `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32`
- `ci.yml` (`deploy-staging`, line 4383) actually pins: `actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1`

## Fix

Replace the exact-SHA `toContain` assertion with a regex that asserts the action is pinned to **any full 40-char commit SHA** (the real supply-chain intent — SHA, not a mutable tag), without hardcoding *which* SHA. Future dependabot pin bumps no longer break the guardrail. The optional trailing `# vX.Y.Z` pin comment is allowed.

```ts
expect(attestStep).toMatch(
  /^\s*uses: actions\/attest-build-provenance@[0-9a-f]{40}(?:\s+#.*)?$/m
);
```

This is the robust option called out in the issue's acceptance criteria — the guardrail still **fails closed** on tag pins (`@v4`, `@main`), partial/over-long SHAs, uppercase hex, and a different action repo.

## Verification

Focused test (the failure shard):
```
$ pnpm --filter @jovie/web exec vitest run tests/unit/ci/supply-chain-provenance.test.ts
 ✓ tests/unit/ci/supply-chain-provenance.test.ts (3 tests) 5ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full `tests/unit/ci/` directory (via testing subagent):
```
 Test Files  6 passed (6)
      Tests  93 passed (93)
```

Regex behavior (negative + positive cases, via `node`):
```
real (SHA+comment) -> true   (want true)
SHA no comment     -> true   (want true)
tag pin (@v4.1.1)  -> false  (want false)
short sha          -> false  (want false)
trailing junk      -> false  (want false)
```

No other assertion was touched — `attestations: write` / `id-token: write` permissions, step ordering (build → package → attest → deploy), commit-signature audit, and branch-protection `required_signatures` are all retained. Grep confirms the stale SHA `a2bbfa25…` no longer appears anywhere in the repo.

Pre-commit hook ran typecheck + eslint + biome green. Local CodeRabbit review run; its suggestion (anchor with bare `$`) was adapted to allow the real `# v4.1.1` pin comment, otherwise it would have re-broken the test.

## Acceptance criteria

- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/ci/supply-chain-provenance.test.ts` passes locally
- [x] Assertion no longer hardcodes a specific action SHA (robust to future pin bumps)
- [ ] `Unit Tests` shard 4/5 green on this PR — pending CI

## Risk

Infra / CI control-plane, test-only change. No runtime, app, auth, billing, or migration surface. One file, +4/-2.

No Linear issue — ad-hoc (codex GitHub-issue shipper, GitHub #12425).

Closes #12425
