### PR TITLE
docs(product): proactive outreach discovery spike (Boardy-style) [#12169]

### DIFF
--- a/docs/product/proactive-outreach-discovery-spike.md
+++ b/docs/product/proactive-outreach-discovery-spike.md
@@ -1,0 +1,205 @@
+# Proactive Outreach Discovery Spike (Boardy.ai-style)
+
+Discovery spike for **GitHub #12169**. Output: build-vs-adopt verdict, consent
+model, and a Phase-1 thin-slice spec with a go/no-go. This is a strategy
+document — no feature code ships from this issue. Implementation is tracked as
+follow-up issues (see [Follow-ups](#follow-ups)).
+
+> **gbrain note:** the Air-hosted brain was mid-migration during this spike and
+> returned no usable results; competitive context below is grounded in the
+> public Boardy surface + verified codebase facts, not gbrain recall. Re-run a
+> gbrain query when it is back if deeper prior-art is needed.
+
+## TL;DR — Go / No-Go
+
+**GO on Phase 1 (message), NO-GO on Phase 2 (voice) until Phase 1 proves lift.**
+
+The surprising finding: **most of the "lake" is already built.** The send path,
+the consent ledger, the TTS provider, and even the release-timing "brain" all
+exist in-repo today. What is missing is a single, small bridge — pushing the
+*artist-facing* release opportunity the system already computes to an
+*artist-facing* outbound channel, behind a new artist-outreach consent toggle.
+The issue's premise that the SMS send path is "stubbed" is **stale** — it is
+wired to Twilio and merely flag-gated (`OUTBOUND_SMS_ENABLED`).
+
+The one correction that changes the plan: the existing release-notification
+pipeline is **fan-facing**, not artist-facing (details below). So Phase 1 is a
+new thin slice that *reuses primitives*, not a flip of an existing switch.
+
+## Boardy.ai teardown (grounded; unknowns marked)
+
+- **What it is:** an AI "superconnector" persona (founder Andrew D'Souza,
+  ex-Clearco). You talk/message Boardy; it learns who you are and what you want,
+  then proactively makes warm, double-opt-in intros from its network.
+- **Copyable decisions:**
+  1. **Voice/conversational agent as the interface** — a call extracts richer
+     context than a form and feels high-trust.
+  2. **A persona, not a tool** — "Boardy" is a memorable, shareable character.
+  3. **Proactive outbound *with a reason*** — it reaches out to you.
+  4. **Double-opt-in** — quality + safety + network effect (every member is both
+     supply and demand).
+  5. **Outcome framing** — sells intros / $ matched, not features.
+  6. **Referral-native virality** — every intro exposes a new person.
+  7. **Scarcity launch** — "free for the next N".
+- **Unknowns (do NOT fabricate):** telephony/voice/LLM stack, call lengths, real
+  retention/conversion metrics. A deep Exa research report was commissioned and
+  is **pending**; fold it in when it lands and revise the stack section if it
+  contradicts the assumptions here.
+
+## Transfer to Jovie — the artist-vs-fan distinction (key insight)
+
+Boardy's wedge is "I know who you should meet before you do." Jovie's analog is
+**"I know what you should ship before you do"**: message/call the artist *before*
+a release with ready-to-go posts/merch/campaign.
+
+The trap to avoid: assuming the existing notification pipeline already does this.
+It does not — it points the other way.
+
+| | **Existing pipeline (fan-facing)** | **This issue (artist-facing)** |
+|---|---|---|
+| Recipient | The artist's **fans/subscribers** | The **artist** (the Jovie user) |
+| Trigger | Release goes live | Release **upcoming** (T-minus) |
+| Intent | "New music from X is out" | "Your release drops Friday — want me to ship your posts?" |
+| Consent basis | Fan SMS opt-in (TCPA, `notificationSubscriptions`) | Artist opt-in to be nudged about their own work |
+| Code today | `cron/send-release-notifications` + `fanReleaseNotifications` | `MemoryOpportunityGenerator.buildReleaseOpportunities` (in-app only) |
+
+The artist-facing brain **already exists**:
+`apps/web/lib/memory/opportunity-generator.ts` computes a "release in the next 7
+days" opportunity per artist (`buildReleaseOpportunities`, `approvalRequired:
+true`) — it just surfaces in-app (pull), never pushed. Phase 1 = give that
+opportunity a push channel.
+
+## Build vs. Adopt verdict (prior-art gate)
+
+Category: *proactive, consent-gated outbound messaging for an existing user
+base, timed off release data.* Nearly every component is already adopted or
+in-repo. **Net: assembly, not building.**
+
+| Component | Verdict | What exists today | Gap for Phase 1 |
+|---|---|---|---|
+| **SMS send path** | **Adopt (in-repo)** | `lib/notifications/providers/sms/outbound-sms.ts` → Twilio, flag-gated `OUTBOUND_SMS_ENABLED` | Send via the **suppression-checked `sendNotification` service** (as the fan cron does), **not** raw `sendOutboundSms()` — the raw primitive skips the STOP ledger |
+| **Consent ledger** | **Adopt (in-repo)** | `notificationContacts` (`smsConsentAt`, `smsConsentTextHash`, `smsConsentVersion`, `smsStatus`); STOP/HELP in `api/webhooks/sms` | Track artist-outreach consent **and opt-out independently** from the fan path (scope/purpose field or per-artist toggle gating the new ledger) — a version string alone does **not** isolate STOP state on the shared `smsStatus` |
+| **Release-timing brain** | **Adopt (in-repo)** | `MemoryOpportunityGenerator.buildReleaseOpportunities` (T-7 window) | Bridge opportunity → outbound send |
+| **Scheduling** | **Adopt (in-repo)** | Existing cron fleet (`cron/frequent`, `daily-maintenance`) | Add one sub-step; **do not** add a new cron route |
+| **TTS / voice** | **Adopt (in-repo)** | ElevenLabs adopted: `ELEVENLABS_API_KEY` + `voice-promo.ts` makes a live TTS call (`voice-clone.ts` is still a stubbed contract) | Phase 2 only |
+| **Inbound STT** | **Adopt (in-repo)** | Web Speech API: `lib/chat/transcriber.ts`, `useSpeechRecognition` | Server STT is Phase 2+ |
+| **AI phone calls** | **Adopt (evaluate)** | None | Phase 2: evaluate **Vapi / Retell / Bland** (Twilio+TTS+LLM wrappers) vs raw Twilio. **Do not build a calling stack.** |
+
+**No net-new external primitives to build or adopt.** Phase 1 adds only a thin
+opt-in toggle, a cron sub-step, and a dedupe ledger — all wrappers over parts
+that already exist in-repo. No new provider, no new TTS/telephony, no new cron
+route.
+
+## Consent & legal model
+
+Reuse the TCPA machinery already built (GitHub #8068), do **not** reinvent it.
+
+- **Phase 1 (artist SMS):** artist opts in to proactive release nudges via an
+  explicit settings toggle. Persist consent through the existing
+  `notificationContacts` primitives with a **new consent version string**
+  (e.g. `artist_outreach_v1`). But a version string alone does **not** scope
+  opt-out — `smsStatus` is global per phone, so artist and fan STOP state would
+  collide. Track artist-outreach consent and opt-out **independently** (a
+  scope/purpose field, or a per-artist toggle that gates the new ledger), and
+  define the global-STOP ↔ toggle interaction explicitly. STOP/HELP inbound is
+  still honored by the existing `api/webhooks/sms` handler for any sender.
+- **Phase 2 (voice):** AI calls are higher TCPA risk and need **separate express
+  consent** (voice is not covered by an SMS opt-in). Mirror Boardy: opt-in /
+  inbound-initiated, earn the right to call. Gate calls behind their own consent
+  version and a per-artist toggle.
+- **Hard line:** no cold outreach. Every recipient is an existing, opted-in
+  Jovie user being messaged about **their own** release.
+
+**Phase-1 TCPA gates the implementer must not skip** (surfaced by security
+review — none reopen the build-vs-adopt decision, all are Phase-1 acceptance
+criteria):
+
+- **Send through the suppression gate.** Use the `sendNotification` service /
+  channel handler, not raw `sendOutboundSms()` — suppression
+  (`isPhoneSmsSuppressed()` → `smsStatus = stopped/blocked`) is enforced in the
+  service layer, not the raw primitive. Raw sends would text a STOP'd artist.
+- **Quiet hours.** No quiet-hours logic exists in-repo today. An engagement
+  nudge is closer to solicitation than the fan transactional path — gate sends
+  to ~8am–9pm in the **artist's** local time zone (state mini-TCPA laws are
+  stricter).
+- **Disclosure in the opt-in text.** The `artist_outreach_v1` consent copy (the
+  string hashed into `smsConsentTextHash`) must state message frequency
+  (~1/release), "Msg & data rates may apply", and STOP/HELP instructions.
+- **A2P 10DLC use case.** Artist engagement is a **different** campaign/use case
+  than fan release alerts. Confirm it's covered by an existing 10DLC
+  registration or register a new campaign before enabling the flag — otherwise
+  carriers filter/block.
+- **Global STOP ↔ per-artist toggle.** Inbound STOP flips the **global**
+  `notificationContacts.smsStatus`. Define the intended interaction with the new
+  per-artist outreach toggle so opt-out is unambiguous and auditable.
+- **Consent provenance.** Record when/where/how the artist flipped the toggle
+  (timestamp + consent text hash + version minimum; an audit row is better) so
+  the opt-in is defensible.
+
+## Phase 1 thin slice (recommended next step)
+
+**Goal:** for artists who opt in, send one SMS at T-minus (release in the next 7
+days) with a CTA into the release plan — "Your release `<title>` drops `<date>`.
+I've drafted your cross-platform posts. Open Jovie to ship them."
+
+**Wiring (smallest correct path):**
+1. Settings toggle → write `artist_outreach_v1` consent via existing
+   `notificationContacts` primitives.
+2. New cron **sub-step** (folded into an existing cron, per `infra.md` — no new
+   route) reads `MemoryOpportunityGenerator` release opportunities for opted-in
+   artists and sends via the **suppression-checked `sendNotification` service**
+   (the same path the fan cron uses) — never the raw `sendOutboundSms()`
+   primitive, which skips the STOP ledger.
+3. Durable dedupe/state in a table (not in-memory, per `security.md`); reuse the
+   `fanReleaseNotifications` status pattern as the template for an
+   `artistReleaseNudges` ledger. **Dedupe on an immutable `release_id` (not the
+   release date)** so a moved release date can't trigger a duplicate send; store
+   the date as a separate column for tracking.
+4. Measure: opt-in rate, message→open rate, release-plan activation lift,
+   free→Pro conversion among nudged vs. not.
+
+**Cost Impact (order-of-magnitude — verify provider pricing before ship):**
+- SMS: ~1 message per opted-in artist per release. At 1,000 opted-in artists
+  releasing monthly ≈ **~1,000 SMS/month** ≈ low single-digit dollars at Twilio
+  list (~$0.0079/segment) + A2P 10DLC fees. **O(opted-in artists), not O(users)**
+  — no per-user API loops.
+- No new external polling; the brain is local DB.
+
+**MRR framing (decision-as-system, per operating principles):**
+- **Ship now:** Phase 1 (message) — reach = all artists, frequency = every
+  release, annoyance solved = "launching is work" (the core wedge), cost = LOW.
+- **Re-evaluate when:** nudged-cohort free→Pro conversion or release-plan
+  activation beats control by a pre-registered margin (set the threshold before
+  launch).
+- **Then:** if lift is real, fund Phase 2 (voice); if flat, stop at message and
+  do not spend voice minutes.
+
+## Phase 2 (voice) — sketch only, NO-GO until Phase 1 proves lift
+
+Opt-in voice check-in/onboarding via ElevenLabs (already adopted), then
+release-week AI calls for high-value artists via an adopted call layer
+(Vapi/Retell/Bland over Twilio). Separate express voice consent. Voice minutes
+meter fast — reserve for high-value moments only.
+
+## What NOT to build (flag the ocean)
+
+- **No "Jovie superconnector network."** Do not build an artist↔collaborator
+  intro graph now. That is the ocean. (Closest analog: GitHub #8677 collaborator
+  matching — keep it separate and later.)
+- **No new cron route**, no polling external APIs, no per-user API loops, no
+  in-memory dedupe (`infra.md`, `security.md`).
+- **No new TTS/telephony build** — adopt.
+- **No persona/voice-character work** in Phase 1 — message first, earn voice.
+
+## Follow-ups
+
+Per `.claude/rules/linear.md`, the deferred phases are tracked in Linear, not as
+orphan bullets:
+
+- **Phase 1 (message), Required:**
+  [JOV-3697](https://linear.app/jovie/issue/JOV-3697) — artist-facing proactive
+  release-moment SMS thin slice.
+- **Phase 2 (voice), Candidate:**
+  [JOV-3698](https://linear.app/jovie/issue/JOV-3698) — opt-in voice check-in +
+  release-week calls; `blockedBy` JOV-3697 (Phase-1 lift).
+- **Exa Boardy report:** fold into the teardown + stack section when it lands.

--- a/docs/product/proactive-outreach-discovery-spike.md
+++ b/docs/product/proactive-outreach-discovery-spike.md
@@ -2,7 +2,7 @@
 
 Discovery spike for **GitHub #12169**. Output: build-vs-adopt verdict, consent
 model, and a Phase-1 thin-slice spec with a go/no-go. This is a strategy
-document — no feature code ships from this issue. Implementation is tracked as
+document: no feature code ships from this issue. Implementation is tracked as
 follow-up issues (see [Follow-ups](#follow-ups)).
 
 > **gbrain note:** the Air-hosted brain was mid-migration during this spike and
@@ -10,16 +10,16 @@ follow-up issues (see [Follow-ups](#follow-ups)).
 > public Boardy surface + verified codebase facts, not gbrain recall. Re-run a
 > gbrain query when it is back if deeper prior-art is needed.
 
-## TL;DR — Go / No-Go
+## TL;DR: Go / No-Go
 
 **GO on Phase 1 (message), NO-GO on Phase 2 (voice) until Phase 1 proves lift.**
 
 The surprising finding: **most of the "lake" is already built.** The send path,
 the consent ledger, the TTS provider, and even the release-timing "brain" all
-exist in-repo today. What is missing is a single, small bridge — pushing the
+exist in-repo today. What is missing is a single, small bridge: pushing the
 *artist-facing* release opportunity the system already computes to an
 *artist-facing* outbound channel, behind a new artist-outreach consent toggle.
-The issue's premise that the SMS send path is "stubbed" is **stale** — it is
+The issue's premise that the SMS send path is "stubbed" is **stale**: it is
 wired to Twilio and merely flag-gated (`OUTBOUND_SMS_ENABLED`).
 
 The one correction that changes the plan: the existing release-notification
@@ -32,41 +32,41 @@ new thin slice that *reuses primitives*, not a flip of an existing switch.
   ex-Clearco). You talk/message Boardy; it learns who you are and what you want,
   then proactively makes warm, double-opt-in intros from its network.
 - **Copyable decisions:**
-  1. **Voice/conversational agent as the interface** — a call extracts richer
+  1. **Voice/conversational agent as the interface**: a call extracts richer
      context than a form and feels high-trust.
-  2. **A persona, not a tool** — "Boardy" is a memorable, shareable character.
-  3. **Proactive outbound *with a reason*** — it reaches out to you.
-  4. **Double-opt-in** — quality + safety + network effect (every member is both
+  2. **A persona, not a tool**: "Boardy" is a memorable, shareable character.
+  3. **Proactive outbound *with a reason***: it reaches out to you.
+  4. **Double-opt-in**: quality + safety + network effect (every member is both
      supply and demand).
-  5. **Outcome framing** — sells intros / $ matched, not features.
-  6. **Referral-native virality** — every intro exposes a new person.
-  7. **Scarcity launch** — "free for the next N".
+  5. **Outcome framing**: sells intros / $ matched, not features.
+  6. **Referral-native virality**: every intro exposes a new person.
+  7. **Scarcity launch**: "free for the next N".
 - **Unknowns (do NOT fabricate):** telephony/voice/LLM stack, call lengths, real
   retention/conversion metrics. A deep Exa research report was commissioned and
   is **pending**; fold it in when it lands and revise the stack section if it
   contradicts the assumptions here.
 
-## Transfer to Jovie — the artist-vs-fan distinction (key insight)
+## Transfer to Jovie: the artist-vs-fan distinction (key insight)
 
 Boardy's wedge is "I know who you should meet before you do." Jovie's analog is
 **"I know what you should ship before you do"**: message/call the artist *before*
 a release with ready-to-go posts/merch/campaign.
 
 The trap to avoid: assuming the existing notification pipeline already does this.
-It does not — it points the other way.
+It does not: it points the other way.
 
 | | **Existing pipeline (fan-facing)** | **This issue (artist-facing)** |
 |---|---|---|
 | Recipient | The artist's **fans/subscribers** | The **artist** (the Jovie user) |
 | Trigger | Release goes live | Release **upcoming** (T-minus) |
-| Intent | "New music from X is out" | "Your release drops Friday — want me to ship your posts?" |
+| Intent | "New music from X is out" | "Your release drops Friday: want me to ship your posts?" |
 | Consent basis | Fan SMS opt-in (TCPA, `notificationSubscriptions`) | Artist opt-in to be nudged about their own work |
 | Code today | `cron/send-release-notifications` + `fanReleaseNotifications` | `MemoryOpportunityGenerator.buildReleaseOpportunities` (in-app only) |
 
 The artist-facing brain **already exists**:
 `apps/web/lib/memory/opportunity-generator.ts` computes a "release in the next 7
 days" opportunity per artist (`buildReleaseOpportunities`, `approvalRequired:
-true`) — it just surfaces in-app (pull), never pushed. Phase 1 = give that
+true`): it just surfaces in-app (pull), never pushed. Phase 1 = give that
 opportunity a push channel.
 
 ## Build vs. Adopt verdict (prior-art gate)
@@ -77,8 +77,8 @@ in-repo. **Net: assembly, not building.**
 
 | Component | Verdict | What exists today | Gap for Phase 1 |
 |---|---|---|---|
-| **SMS send path** | **Adopt (in-repo)** | `lib/notifications/providers/sms/outbound-sms.ts` → Twilio, flag-gated `OUTBOUND_SMS_ENABLED` | Send via the **suppression-checked `sendNotification` service** (as the fan cron does), **not** raw `sendOutboundSms()` — the raw primitive skips the STOP ledger |
-| **Consent ledger** | **Adopt (in-repo)** | `notificationContacts` (`smsConsentAt`, `smsConsentTextHash`, `smsConsentVersion`, `smsStatus`); STOP/HELP in `api/webhooks/sms` | Track artist-outreach consent **and opt-out independently** from the fan path (scope/purpose field or per-artist toggle gating the new ledger) — a version string alone does **not** isolate STOP state on the shared `smsStatus` |
+| **SMS send path** | **Adopt (in-repo)** | `lib/notifications/providers/sms/outbound-sms.ts` → Twilio, flag-gated `OUTBOUND_SMS_ENABLED` | Send via the **suppression-checked `sendNotification` service** (as the fan cron does), **not** raw `sendOutboundSms()`: the raw primitive skips the STOP ledger |
+| **Consent ledger** | **Adopt (in-repo)** | `notificationContacts` (`smsConsentAt`, `smsConsentTextHash`, `smsConsentVersion`, `smsStatus`); STOP/HELP in `api/webhooks/sms` | Track artist-outreach consent **and opt-out independently** from the fan path (scope/purpose field or per-artist toggle gating the new ledger): a version string alone does **not** isolate STOP state on the shared `smsStatus` |
 | **Release-timing brain** | **Adopt (in-repo)** | `MemoryOpportunityGenerator.buildReleaseOpportunities` (T-7 window) | Bridge opportunity → outbound send |
 | **Scheduling** | **Adopt (in-repo)** | Existing cron fleet (`cron/frequent`, `daily-maintenance`) | Add one sub-step; **do not** add a new cron route |
 | **TTS / voice** | **Adopt (in-repo)** | ElevenLabs adopted: `ELEVENLABS_API_KEY` + `voice-promo.ts` makes a live TTS call (`voice-clone.ts` is still a stubbed contract) | Phase 2 only |
@@ -86,7 +86,7 @@ in-repo. **Net: assembly, not building.**
 | **AI phone calls** | **Adopt (evaluate)** | None | Phase 2: evaluate **Vapi / Retell / Bland** (Twilio+TTS+LLM wrappers) vs raw Twilio. **Do not build a calling stack.** |
 
 **No net-new external primitives to build or adopt.** Phase 1 adds only a thin
-opt-in toggle, a cron sub-step, and a dedupe ledger — all wrappers over parts
+opt-in toggle, a cron sub-step, and a dedupe ledger: all wrappers over parts
 that already exist in-repo. No new provider, no new TTS/telephony, no new cron
 route.
 
@@ -98,7 +98,7 @@ Reuse the TCPA machinery already built (GitHub #8068), do **not** reinvent it.
   explicit settings toggle. Persist consent through the existing
   `notificationContacts` primitives with a **new consent version string**
   (e.g. `artist_outreach_v1`). But a version string alone does **not** scope
-  opt-out — `smsStatus` is global per phone, so artist and fan STOP state would
+  opt-out: `smsStatus` is global per phone, so artist and fan STOP state would
   collide. Track artist-outreach consent and opt-out **independently** (a
   scope/purpose field, or a per-artist toggle that gates the new ledger), and
   define the global-STOP ↔ toggle interaction explicitly. STOP/HELP inbound is
@@ -111,15 +111,15 @@ Reuse the TCPA machinery already built (GitHub #8068), do **not** reinvent it.
   Jovie user being messaged about **their own** release.
 
 **Phase-1 TCPA gates the implementer must not skip** (surfaced by security
-review — none reopen the build-vs-adopt decision, all are Phase-1 acceptance
+review: none reopen the build-vs-adopt decision, all are Phase-1 acceptance
 criteria):
 
 - **Send through the suppression gate.** Use the `sendNotification` service /
-  channel handler, not raw `sendOutboundSms()` — suppression
+  channel handler, not raw `sendOutboundSms()`: suppression
   (`isPhoneSmsSuppressed()` → `smsStatus = stopped/blocked`) is enforced in the
   service layer, not the raw primitive. Raw sends would text a STOP'd artist.
 - **Quiet hours.** No quiet-hours logic exists in-repo today. An engagement
-  nudge is closer to solicitation than the fan transactional path — gate sends
+  nudge is closer to solicitation than the fan transactional path: gate sends
   to ~8am–9pm in the **artist's** local time zone (state mini-TCPA laws are
   stricter).
 - **Disclosure in the opt-in text.** The `artist_outreach_v1` consent copy (the
@@ -127,7 +127,7 @@ criteria):
   (~1/release), "Msg & data rates may apply", and STOP/HELP instructions.
 - **A2P 10DLC use case.** Artist engagement is a **different** campaign/use case
   than fan release alerts. Confirm it's covered by an existing 10DLC
-  registration or register a new campaign before enabling the flag — otherwise
+  registration or register a new campaign before enabling the flag: otherwise
   carriers filter/block.
 - **Global STOP ↔ per-artist toggle.** Inbound STOP flips the **global**
   `notificationContacts.smsStatus`. Define the intended interaction with the new
@@ -139,16 +139,16 @@ criteria):
 ## Phase 1 thin slice (recommended next step)
 
 **Goal:** for artists who opt in, send one SMS at T-minus (release in the next 7
-days) with a CTA into the release plan — "Your release `<title>` drops `<date>`.
+days) with a CTA into the release plan: "Your release `<title>` drops `<date>`.
 I've drafted your cross-platform posts. Open Jovie to ship them."
 
 **Wiring (smallest correct path):**
 1. Settings toggle → write `artist_outreach_v1` consent via existing
    `notificationContacts` primitives.
-2. New cron **sub-step** (folded into an existing cron, per `infra.md` — no new
+2. New cron **sub-step** (folded into an existing cron, per `infra.md`: no new
    route) reads `MemoryOpportunityGenerator` release opportunities for opted-in
    artists and sends via the **suppression-checked `sendNotification` service**
-   (the same path the fan cron uses) — never the raw `sendOutboundSms()`
+   (the same path the fan cron uses): never the raw `sendOutboundSms()`
    primitive, which skips the STOP ledger.
 3. Durable dedupe/state in a table (not in-memory, per `security.md`); reuse the
    `fanReleaseNotifications` status pattern as the template for an
@@ -158,15 +158,15 @@ I've drafted your cross-platform posts. Open Jovie to ship them."
 4. Measure: opt-in rate, message→open rate, release-plan activation lift,
    free→Pro conversion among nudged vs. not.
 
-**Cost Impact (order-of-magnitude — verify provider pricing before ship):**
+**Cost Impact (order-of-magnitude: verify provider pricing before ship):**
 - SMS: ~1 message per opted-in artist per release. At 1,000 opted-in artists
   releasing monthly ≈ **~1,000 SMS/month** ≈ low single-digit dollars at Twilio
   list (~$0.0079/segment) + A2P 10DLC fees. **O(opted-in artists), not O(users)**
-  — no per-user API loops.
+ : no per-user API loops.
 - No new external polling; the brain is local DB.
 
 **MRR framing (decision-as-system, per operating principles):**
-- **Ship now:** Phase 1 (message) — reach = all artists, frequency = every
+- **Ship now:** Phase 1 (message): reach = all artists, frequency = every
   release, annoyance solved = "launching is work" (the core wedge), cost = LOW.
 - **Re-evaluate when:** nudged-cohort free→Pro conversion or release-plan
   activation beats control by a pre-registered margin (set the threshold before
@@ -174,22 +174,22 @@ I've drafted your cross-platform posts. Open Jovie to ship them."
 - **Then:** if lift is real, fund Phase 2 (voice); if flat, stop at message and
   do not spend voice minutes.
 
-## Phase 2 (voice) — sketch only, NO-GO until Phase 1 proves lift
+## Phase 2 (voice): sketch only, NO-GO until Phase 1 proves lift
 
 Opt-in voice check-in/onboarding via ElevenLabs (already adopted), then
 release-week AI calls for high-value artists via an adopted call layer
 (Vapi/Retell/Bland over Twilio). Separate express voice consent. Voice minutes
-meter fast — reserve for high-value moments only.
+meter fast: reserve for high-value moments only.
 
 ## What NOT to build (flag the ocean)
 
 - **No "Jovie superconnector network."** Do not build an artist↔collaborator
   intro graph now. That is the ocean. (Closest analog: GitHub #8677 collaborator
-  matching — keep it separate and later.)
+  matching: keep it separate and later.)
 - **No new cron route**, no polling external APIs, no per-user API loops, no
   in-memory dedupe (`infra.md`, `security.md`).
-- **No new TTS/telephony build** — adopt.
-- **No persona/voice-character work** in Phase 1 — message first, earn voice.
+- **No new TTS/telephony build**: adopt.
+- **No persona/voice-character work** in Phase 1: message first, earn voice.
 
 ## Follow-ups
 
@@ -197,9 +197,9 @@ Per `.claude/rules/linear.md`, the deferred phases are tracked in Linear, not as
 orphan bullets:
 
 - **Phase 1 (message), Required:**
-  [JOV-3697](https://linear.app/jovie/issue/JOV-3697) — artist-facing proactive
+  [JOV-3697](https://linear.app/jovie/issue/JOV-3697): artist-facing proactive
   release-moment SMS thin slice.
 - **Phase 2 (voice), Candidate:**
-  [JOV-3698](https://linear.app/jovie/issue/JOV-3698) — opt-in voice check-in +
+  [JOV-3698](https://linear.app/jovie/issue/JOV-3698): opt-in voice check-in +
   release-week calls; `blockedBy` JOV-3697 (Phase-1 lift).
 - **Exa Boardy report:** fold into the teardown + stack section when it lands.


### PR DESCRIPTION
Closes #12169

## What this is

A **discovery/strategy spike** (no feature code). Adds one doc —
`docs/product/proactive-outreach-discovery-spike.md` — that satisfies the four
acceptance criteria on the issue: Boardy teardown, build-vs-adopt verdict,
consent/legal model, and a Phase-1 thin-slice spec + MRR estimate + go/no-go.

## Headline recommendation

**GO on Phase 1 (message), NO-GO on Phase 2 (voice) until Phase 1 proves lift.**

The spike's load-bearing finding is that **most of the "lake" is already built**,
and that the issue's own premises were partly stale — corrected here against the
actual code:

| Issue assumption | Verified reality |
|---|---|
| SMS send path is "stubbed" (#12150) | **Wired to Twilio**, merely flag-gated (`OUTBOUND_SMS_ENABLED`) |
| Reuse the existing release-notification pipeline | That pipeline is **fan-facing** (Jovie→fans). This issue wants **artist-facing** (Jovie→artist) — different recipient, trigger, consent basis |
| Need to assemble a release-timing brain | `MemoryOpportunityGenerator.buildReleaseOpportunities` already computes the artist-facing T-7 nudge — it just surfaces in-app, never pushed |
| Adopt ElevenLabs / TCPA consent | Both already adopted in-repo |

So Phase 1 is a small bridge (opt-in toggle + cron sub-step + dedupe ledger) over
already-adopted parts — **no net-new provider, TTS, telephony, or cron route.**

## Verification

- `pnpm doc:freshness:check` → `doc-freshness: ok (25 cross-link files, 115 AGENTS map lines)`
- All file/path references in the doc verified to exist (outbound-sms, opportunity-generator, transcriber, voice-clone/promo, webhooks/sms, send-release-notifications cron).
- **Review subagent (opus):** all 6 codebase claims confirmed ACCURATE; no rule violations; no fabricated metrics. Flagged that `voice-clone.ts` is a stubbed contract (vs live `voice-promo.ts`) → corrected in the doc.
- **Security subagent (opus):** consent model SOUND but surfaced TCPA must-nots → folded into the doc + JOV-3697 acceptance criteria: send via the **suppression-checked `sendNotification` service** (not raw `sendOutboundSms()`, which skips the STOP ledger), quiet hours, frequency/rates disclosure, A2P 10DLC new-campaign, global-STOP↔toggle scoping, consent provenance.
- **CodeRabbit (local, `-t uncommitted`):** ran twice; both rounds' actionable findings fixed (unstable dedupe key → immutable `release_id`; consent scoping; "build nothing net-new" overstatement). Third confirmation pass was **rate-limited** (metered plan, 6-min wait) — disclosed honestly; all prior findings are addressed.

## Follow-ups (per `.claude/rules/linear.md`)

- **JOV-3697** (Required, → GitHub #12443) — Phase 1: artist-facing proactive release-moment SMS thin slice. Acceptance criteria carry the TCPA gates above.
- **JOV-3698** (Candidate, `blockedBy` JOV-3697) — Phase 2: opt-in voice (ElevenLabs + adopted AI-call layer).
- Exa Boardy teardown report: fold in when it lands.

## Cost impact

None from this PR (docs only). Phase 1 estimate is documented as ~1k SMS/month
at 1k opted-in artists — **O(opted-in artists), not O(users)** — pending provider-pricing verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)