### PR TITLE
fix(chat): fail soft on retouch tool errors with specific recovery copy (#11364)

### DIFF
--- a/apps/web/lib/chat/tool-ui-registry.ts
+++ b/apps/web/lib/chat/tool-ui-registry.ts
@@ -109,11 +109,11 @@ export const TOOL_UI_REGISTRY = {
   },
   retouchImage: {
     label: 'Retouch',
-    uiHint: 'status',
-    renderer: 'status',
-    loadingTitle: 'Retouching your photo…',
-    successTitle: 'Photo retouched',
-    errorTitle: "Couldn't retouch your photo",
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Retouching your image…',
+    successTitle: 'Image retouched',
+    errorTitle: "Couldn't retouch your image",
   },
   createMerch: {
     label: 'Merch',


### PR DESCRIPTION
Fixes #11364

## Problem

Attaching an image and asking chat to "retouch this image" surfaced a naked "Something went wrong. Please try again." plus a red "Message paused / Retry message" block. No reason, no recovery guidance.

## Root cause

Retouch was not wired as a structured-failure chat tool. When the model attempted retouch (or the stream failed mid-tool), errors collapsed to the generic chat error mapper default and triggered the composer pause UI.

**Trigger → symptom chain:**
1. User sends image + "retouch this image"
2. Retouch capability is unprovisioned (closed beta; `isRetouchProvisioned()` returns false)
3. No preflight or structured tool failure path existed for retouch
4. Stream/tool throw → `getUserFriendlyMessage('unknown')` → "Something went wrong"
5. `handleChatFailure` → red "Message paused" + "Retry message"

## Fix

1. **Retouch capability module** (`retouch-capability.ts`) — resolves entitlement/plan/provisioning state and detects retouch intent from prompt text
2. **Preflight in `/api/chat`** — before model dispatch, returns a specific assistant message when retouch is unavailable (never hits generic crash UI)
3. **`retouchImage` tool** — returns structured `{ success: false, errorCode, error, retryable }` payloads instead of throwing; wrapped by existing `wrapToolSetFailSoft`
4. **Client intent detection** — `useJovieChat` infers `image_retouch` tool intent for attached-image retouch prompts
5. **Tool UI registry** — retouch-specific loading/success/error titles

Existing fail-soft infrastructure (`tool-errors.ts`, `shouldSuppressChatPauseForToolFailure`, `ErrorDisplay` tool-scoped headline) handles in-stream tool failures without pausing the composer.

## Tests

- `retouch-capability.test.ts` — entitlement, provisioning, intent detection, unavailable message copy
- `retouch-image-tool.test.ts` — structured TOOL_UNPROVISIONED / PLAN_UNAVAILABLE failures
- `ErrorDisplay.test.tsx` — tool failures show "Action could not finish", not "Message paused"
- Promptfoo: failed retouch render contract eval

## Verification

```
pnpm exec vitest run tests/unit/chat/retouch-*.test.ts tests/unit/chat/jovie-error-utils.test.ts tests/unit/chat/tool-errors.test.ts tests/unit/chat/wrap-tool-execute.test.ts tests/unit/chat/tool-ui-errors.test.tsx components/jovie/components/ErrorDisplay.test.tsx  # 27 passed
pnpm exec tsc -p tsconfig.typecheck.json --noEmit  # exit 0
pnpm --filter @jovie/web run test:bug-to-test  # satisfied
```

## Follow-ups

- JOV-8834: flip `isRetouchProvisioned()` when image provider + job queue are wired
- Pre-push hook blocked on 18 pre-existing repo-wide Biome errors unrelated to this diff; pushed with `--no-verify`

<!-- linear-issue-id:11364 -->