### PR TITLE
fix(rtr): scope GMV + merch-card resolution by owning creatorProfileId

### DIFF
--- a/apps/web/app/app/(shell)/admin/ops/ReleaseToRevenueGmvPanel.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/ReleaseToRevenueGmvPanel.tsx
@@ -1,31 +1,15 @@
 import { ContentMetricRow } from '@/components/molecules/ContentMetricRow';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { formatUsd } from '@/lib/admin/format';
-import { getDesignPartnerReleaseGmvSnapshot } from '@/lib/release-to-revenue/gmv-attribution';
+import { getAllTenantsReleaseGmvSnapshot } from '@/lib/release-to-revenue/gmv-attribution';
 
 function formatGmvFromCents(gmvCents: number): string {
   return formatUsd(gmvCents / 100);
 }
 
 export async function ReleaseToRevenueGmvPanel() {
-  const snapshot = await getDesignPartnerReleaseGmvSnapshot();
-
-  if (!snapshot) {
-    return (
-      <ContentSurfaceCard
-        surface='details'
-        className='space-y-2 p-3'
-        data-testid='release-to-revenue-gmv-panel'
-      >
-        <p className='text-app font-medium text-primary-token'>
-          Release-to-Revenue GMV
-        </p>
-        <p className='text-app text-secondary-token'>
-          Design partner is not configured in this environment.
-        </p>
-      </ContentSurfaceCard>
-    );
-  }
+  const snapshot = await getAllTenantsReleaseGmvSnapshot();
+  const creatorLabel = snapshot.tenantCount === 1 ? 'creator' : 'creators';
 
   return (
     <ContentSurfaceCard
@@ -38,7 +22,8 @@ export async function ReleaseToRevenueGmvPanel() {
           Release-to-Revenue GMV
         </p>
         <p className='text-app text-secondary-token'>
-          Store GMV per autopilot release for @{snapshot.creatorUsername}
+          Store GMV per autopilot release across{' '}
+          {snapshot.tenantCount.toLocaleString('en-US')} {creatorLabel}
         </p>
       </div>
 
@@ -54,7 +39,7 @@ export async function ReleaseToRevenueGmvPanel() {
               data-testid={`release-gmv-row-${release.workflowRunId}`}
             >
               <ContentMetricRow
-                label={`${release.releaseTitle} (${release.orderCount.toLocaleString('en-US')} orders)`}
+                label={`${release.creatorUsername ? `@${release.creatorUsername}` : 'Unknown creator'} · ${release.releaseTitle} (${release.orderCount.toLocaleString('en-US')} orders)`}
                 value={formatGmvFromCents(release.gmvCents)}
               />
             </div>

--- a/apps/web/lib/merch/orders.ts
+++ b/apps/web/lib/merch/orders.ts
@@ -248,7 +248,8 @@ export async function createMerchCheckoutSession(
   });
   const printfulExternalId = `jovie_merch_${crypto.randomUUID()}`;
   const releaseWorkflowRunId = await resolveReleaseWorkflowRunIdForMerchCard(
-    row.card.id
+    row.card.id,
+    row.card.creatorProfileId
   );
 
   const [order] = await db

--- a/apps/web/lib/release-to-revenue/distribution-drafts.ts
+++ b/apps/web/lib/release-to-revenue/distribution-drafts.ts
@@ -31,9 +31,12 @@ function buildAbsoluteUrl(path: string): string {
 
 export async function resolveMerchDropLink(input: {
   readonly creatorUsername: string;
+  readonly creatorProfileId: string;
   readonly releaseId: string | null;
 }): Promise<string | null> {
-  if (!input.releaseId) {
+  // Fall back to the creator's merch landing without a DB lookup when we can't
+  // owner-scope the release batch query (no release id, or no owning creator).
+  if (!input.releaseId || !input.creatorProfileId) {
     return buildAbsoluteUrl(`/${input.creatorUsername}/merch`);
   }
 
@@ -44,6 +47,7 @@ export async function resolveMerchDropLink(input: {
     .from(merchGenerationBatches)
     .where(
       and(
+        eq(merchGenerationBatches.creatorProfileId, input.creatorProfileId),
         eq(merchGenerationBatches.command, RELEASE_AUTOPILOT_MERCH_COMMAND),
         like(
           merchGenerationBatches.prompt,
@@ -124,6 +128,7 @@ export async function generateDistributionDraftsForRun(input: {
   const releaseLink = buildAbsoluteUrl(releasePath);
   const merchDropLink = await resolveMerchDropLink({
     creatorUsername: designPartner.creatorUsername,
+    creatorProfileId: designPartner.creatorProfileId,
     releaseId: input.stepOutputs.releaseId,
   });
 

--- a/apps/web/lib/release-to-revenue/gmv-attribution.test.ts
+++ b/apps/web/lib/release-to-revenue/gmv-attribution.test.ts
@@ -1,3 +1,5 @@
+import { getTableName } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockResolveMerchCardIdsForRun = vi.hoisted(() => vi.fn());
@@ -16,8 +18,127 @@ vi.mock('@/lib/db', () => ({
 import {
   buildReleaseGmvRowForRun,
   computeStoreGmvCents,
+  getPaidOrdersForMerchCards,
+  getReleaseGmvSnapshotForUser,
   isReleaseGmvCountableStatus,
+  resolveReleaseWorkflowRunIdForMerchCard,
 } from './gmv-attribution';
+import type { ReleaseToRevenueRunStepOutputs } from './types';
+
+const dialect = new PgDialect();
+
+interface OrderFixture {
+  readonly id: string;
+  readonly creatorProfileId: string;
+  readonly merchCardId: string;
+  readonly subtotalCents: number;
+  readonly status: string;
+}
+
+interface RunFixture {
+  readonly id: string;
+  readonly stepOutputs: ReleaseToRevenueRunStepOutputs;
+}
+
+const captured: {
+  orderQuery: { sql: string; params: unknown[] } | null;
+  runQuery: { sql: string; params: unknown[] } | null;
+} = { orderQuery: null, runQuery: null };
+
+/**
+ * Table-routing fake `db.select()` that faithfully applies the rendered WHERE
+ * predicate against a two-tenant fixture. `merch_orders` rows only survive when
+ * their owner + card id are both bound in the query, so dropping the owner
+ * predicate would leak the other tenant's order and fail the test.
+ */
+function installFakeDb(opts: {
+  readonly orders?: readonly OrderFixture[];
+  readonly runs?: readonly RunFixture[];
+}) {
+  captured.orderQuery = null;
+  captured.runQuery = null;
+
+  mockDbSelect.mockImplementation(() => {
+    let table = '';
+    const chain = {
+      from(t: unknown) {
+        table = getTableName(t as never);
+        return chain;
+      },
+      where(cond: unknown) {
+        const q = dialect.sqlToQuery(cond as never);
+        const params = q.params as unknown[];
+
+        if (table === 'merch_orders') {
+          captured.orderQuery = { sql: q.sql, params };
+          const matched = (opts.orders ?? []).filter(
+            order =>
+              params.includes(order.creatorProfileId) &&
+              params.includes(order.merchCardId)
+          );
+          return Promise.resolve(
+            matched.map(order => ({
+              id: order.id,
+              merchCardId: order.merchCardId,
+              subtotalCents: order.subtotalCents,
+              status: order.status,
+            }))
+          );
+        }
+
+        // workflow_runs — chainable so both `.where().orderBy()` (snapshot scan)
+        // and `.where().orderBy().limit(n)` (explicit run lookup) resolve.
+        // Faithfully apply the owner predicate: when the query is user-scoped,
+        // only runs whose owner userId is bound survive (so dropping the
+        // `user_id` predicate would leak the other tenant's run and fail a test).
+        captured.runQuery = { sql: q.sql, params };
+        const userScoped = q.sql.includes('"workflow_runs"."user_id"');
+        const runs = (opts.runs ?? []).filter(run =>
+          userScoped
+            ? params.includes(run.stepOutputs.designPartner?.userId)
+            : true
+        );
+        const runsChain = {
+          orderBy: () => runsChain,
+          limit: (n: number) => Promise.resolve(runs.slice(0, n)),
+          then: (
+            res: (value: readonly RunFixture[]) => unknown,
+            rej?: (reason: unknown) => unknown
+          ) => Promise.resolve(runs).then(res, rej),
+        };
+        return runsChain;
+      },
+    };
+    return chain;
+  });
+}
+
+function stepOutputsFor(input: {
+  readonly creatorProfileId: string;
+  readonly creatorUsername: string;
+  readonly userId: string;
+  readonly merchCardIds: readonly string[];
+}): ReleaseToRevenueRunStepOutputs {
+  return {
+    releaseId: `release-${input.creatorUsername}`,
+    triggerSource: 'catalog',
+    triggeredAt: '2026-06-19T00:00:00.000Z',
+    designPartner: {
+      creatorUsername: input.creatorUsername,
+      creatorProfileId: input.creatorProfileId,
+      userId: input.userId,
+      store: { provider: 'printful', scope: 'default' },
+      socialAccount: { platform: 'instagram', handle: input.creatorUsername },
+      smsListId: `sms-${input.creatorUsername}`,
+    },
+    release: {
+      title: `Release for ${input.creatorUsername}`,
+      artworkUrl: null,
+      links: [],
+    },
+    storeListing: { merchCardIds: [...input.merchCardIds] },
+  };
+}
 
 describe('release-to-revenue GMV attribution', () => {
   it('counts only paid Printful-backed order subtotals toward GMV', () => {
@@ -45,6 +166,55 @@ describe('release-to-revenue GMV attribution', () => {
         { subtotalCents: 1500, status: 'failed' },
       ])
     ).toEqual({ gmvCents: 0, orderCount: 0 });
+  });
+});
+
+describe('getPaidOrdersForMerchCards tenant isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns only the owning creator orders even when a foreign card id is requested', async () => {
+    installFakeDb({
+      orders: [
+        {
+          id: 'order-A',
+          creatorProfileId: 'profile-A',
+          merchCardId: 'card-A',
+          subtotalCents: 2500,
+          status: 'paid',
+        },
+        {
+          id: 'order-B',
+          creatorProfileId: 'profile-B',
+          merchCardId: 'card-B',
+          subtotalCents: 9900,
+          status: 'paid',
+        },
+      ],
+    });
+
+    const orders = await getPaidOrdersForMerchCards(
+      ['card-A', 'card-B'],
+      'profile-A'
+    );
+
+    expect(orders.map(order => order.id)).toEqual(['order-A']);
+    // Owner predicate must be present in the rendered query.
+    expect(captured.orderQuery?.sql).toContain(
+      '"merch_orders"."creator_profile_id"'
+    );
+    expect(captured.orderQuery?.params).toContain('profile-A');
+    expect(captured.orderQuery?.params).not.toContain('profile-B');
+  });
+
+  it('fails closed (no query) when the owner is missing', async () => {
+    installFakeDb({ orders: [] });
+
+    const orders = await getPaidOrdersForMerchCards(['card-A'], '');
+
+    expect(orders).toEqual([]);
+    expect(mockDbSelect).not.toHaveBeenCalled();
   });
 });
 
@@ -82,34 +252,200 @@ describe('buildReleaseGmvRowForRun', () => {
 
     const row = await buildReleaseGmvRowForRun({
       workflowRunId: 'run-1',
-      stepOutputs: {
-        releaseId: 'release-1',
-        triggerSource: 'catalog',
-        triggeredAt: '2026-06-19T00:00:00.000Z',
-        designPartner: {
-          creatorUsername: 'tim',
-          creatorProfileId: 'profile-1',
-          userId: 'user-1',
-          store: { provider: 'printful', scope: 'default' },
-          socialAccount: { platform: 'instagram', handle: 'tim' },
-          smsListId: 'sms-1',
-        },
-        release: {
-          title: 'Night Drive',
-          artworkUrl: null,
-          links: [],
-        },
-        storeListing: { merchCardIds: ['card-1', 'card-2'] },
-      },
+      stepOutputs: stepOutputsFor({
+        creatorProfileId: 'profile-1',
+        creatorUsername: 'tim',
+        userId: 'user-1',
+        merchCardIds: ['card-1', 'card-2'],
+      }),
     });
 
     expect(row).toMatchObject({
       workflowRunId: 'run-1',
-      releaseId: 'release-1',
-      releaseTitle: 'Night Drive',
+      releaseTitle: 'Release for tim',
+      creatorUsername: 'tim',
       merchCardIds: ['card-1', 'card-2'],
       orderCount: 2,
       gmvCents: 5000,
     });
+  });
+
+  it('owner-scopes the order query so a foreign card in the listing cannot count', async () => {
+    // Listing contains a foreign card; orders for it belong to another tenant.
+    mockResolveMerchCardIdsForRun.mockResolvedValue(['card-A', 'card-B']);
+    installFakeDb({
+      orders: [
+        {
+          id: 'order-A',
+          creatorProfileId: 'profile-A',
+          merchCardId: 'card-A',
+          subtotalCents: 2500,
+          status: 'paid',
+        },
+        {
+          id: 'order-B',
+          creatorProfileId: 'profile-B',
+          merchCardId: 'card-B',
+          subtotalCents: 9900,
+          status: 'paid',
+        },
+      ],
+    });
+
+    const row = await buildReleaseGmvRowForRun({
+      workflowRunId: 'run-A',
+      stepOutputs: stepOutputsFor({
+        creatorProfileId: 'profile-A',
+        creatorUsername: 'tenant-a',
+        userId: 'user-A',
+        merchCardIds: ['card-A', 'card-B'],
+      }),
+    });
+
+    expect(row.gmvCents).toBe(2500);
+    expect(row.orderCount).toBe(1);
+    expect(captured.orderQuery?.params).toContain('profile-A');
+    expect(captured.orderQuery?.params).not.toContain('profile-B');
+  });
+});
+
+describe('getReleaseGmvSnapshotForUser tenant isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveMerchCardIdsForRun.mockImplementation(
+      async (stepOutputs: ReleaseToRevenueRunStepOutputs) =>
+        stepOutputs.storeListing?.merchCardIds ?? []
+    );
+  });
+
+  it('returns only the queried user own orders and totals', async () => {
+    installFakeDb({
+      // Two tenants each have a run + a paid order. Tenant A's snapshot must
+      // surface only A's run and only A's order.
+      runs: [
+        {
+          id: 'run-A',
+          stepOutputs: stepOutputsFor({
+            creatorProfileId: 'profile-A',
+            creatorUsername: 'tenant-a',
+            userId: 'user-A',
+            merchCardIds: ['card-A'],
+          }),
+        },
+        {
+          id: 'run-B',
+          stepOutputs: stepOutputsFor({
+            creatorProfileId: 'profile-B',
+            creatorUsername: 'tenant-b',
+            userId: 'user-B',
+            merchCardIds: ['card-B'],
+          }),
+        },
+      ],
+      orders: [
+        {
+          id: 'order-A',
+          creatorProfileId: 'profile-A',
+          merchCardId: 'card-A',
+          subtotalCents: 2500,
+          status: 'paid',
+        },
+        // Tenant B's paid order — must never appear in tenant A's snapshot.
+        {
+          id: 'order-B',
+          creatorProfileId: 'profile-B',
+          merchCardId: 'card-B',
+          subtotalCents: 9900,
+          status: 'paid',
+        },
+      ],
+    });
+
+    const snapshot = await getReleaseGmvSnapshotForUser({ userId: 'user-A' });
+
+    expect(snapshot.creatorUsername).toBe('tenant-a');
+    expect(snapshot.totalGmvCents).toBe(2500);
+    expect(snapshot.releases).toHaveLength(1);
+    expect(snapshot.releases[0]?.workflowRunId).toBe('run-A');
+    expect(snapshot.releases[0]?.gmvCents).toBe(2500);
+
+    // The run scan is scoped to the queried user, and the order scan to that
+    // run's creator. Both predicates must be present in the rendered queries.
+    expect(captured.runQuery?.sql).toContain('"workflow_runs"."user_id"');
+    expect(captured.runQuery?.params).toContain('user-A');
+    expect(captured.orderQuery?.params).toContain('profile-A');
+    expect(captured.orderQuery?.params).not.toContain('profile-B');
+  });
+
+  it('fails closed for a blank userId instead of returning every tenant', async () => {
+    installFakeDb({
+      runs: [
+        {
+          id: 'run-A',
+          stepOutputs: stepOutputsFor({
+            creatorProfileId: 'profile-A',
+            creatorUsername: 'tenant-a',
+            userId: 'user-A',
+            merchCardIds: ['card-A'],
+          }),
+        },
+      ],
+      orders: [
+        {
+          id: 'order-A',
+          creatorProfileId: 'profile-A',
+          merchCardId: 'card-A',
+          subtotalCents: 2500,
+          status: 'paid',
+        },
+      ],
+    });
+
+    const snapshot = await getReleaseGmvSnapshotForUser({ userId: '' });
+
+    expect(snapshot.releases).toEqual([]);
+    expect(snapshot.totalGmvCents).toBe(0);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveReleaseWorkflowRunIdForMerchCard tenant isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('owner-scopes the run lookup to the merch card creator', async () => {
+    installFakeDb({
+      runs: [
+        {
+          id: 'run-A',
+          stepOutputs: stepOutputsFor({
+            creatorProfileId: 'profile-A',
+            creatorUsername: 'tenant-a',
+            userId: 'user-A',
+            merchCardIds: ['card-A'],
+          }),
+        },
+      ],
+    });
+
+    const runId = await resolveReleaseWorkflowRunIdForMerchCard(
+      'card-A',
+      'profile-A'
+    );
+
+    expect(runId).toBe('run-A');
+    // The JSONB owner predicate binds the creator profile id.
+    expect(captured.runQuery?.params).toContain('profile-A');
+    expect(captured.runQuery?.params).not.toContain('profile-B');
+  });
+
+  it('fails closed (no query) when the creator owner is missing', async () => {
+    installFakeDb({ runs: [] });
+
+    const runId = await resolveReleaseWorkflowRunIdForMerchCard('card-A', '');
+
+    expect(runId).toBeNull();
+    expect(mockDbSelect).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/release-to-revenue/gmv-attribution.ts
+++ b/apps/web/lib/release-to-revenue/gmv-attribution.ts
@@ -4,9 +4,9 @@ import { and, sql as drizzleSql, eq, inArray } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { workflowRuns } from '@/lib/db/schema/connectors';
 import { type MerchOrder, merchOrders } from '@/lib/db/schema/merch';
-import { resolveDesignPartnerConfig } from './design-partner-config';
 import { resolveMerchCardIdsForRun } from './store-listing';
 import type {
+  AllTenantsReleaseGmvSnapshot,
   DesignPartnerReleaseGmvSnapshot,
   ReleaseGmvPerRunRow,
   ReleaseToRevenueRunStepOutputs,
@@ -52,12 +52,20 @@ export function computeStoreGmvCents(
   return { gmvCents, orderCount };
 }
 
+/**
+ * Fetch paid orders for the given merch cards, scoped to the owning creator.
+ *
+ * The `creatorProfileId` predicate is the tenant-isolation boundary: a merch card
+ * id list that was contaminated upstream (or a foreign id) can never count another
+ * creator's orders toward this creator's GMV. An empty owner id fails closed.
+ */
 export async function getPaidOrdersForMerchCards(
-  merchCardIds: readonly string[]
+  merchCardIds: readonly string[],
+  creatorProfileId: string
 ): Promise<
   Pick<MerchOrder, 'id' | 'merchCardId' | 'subtotalCents' | 'status'>[]
 > {
-  if (merchCardIds.length === 0) {
+  if (merchCardIds.length === 0 || !creatorProfileId) {
     return [];
   }
 
@@ -69,21 +77,33 @@ export async function getPaidOrdersForMerchCards(
       status: merchOrders.status,
     })
     .from(merchOrders)
-    .where(inArray(merchOrders.merchCardId, [...merchCardIds]));
+    .where(
+      and(
+        eq(merchOrders.creatorProfileId, creatorProfileId),
+        inArray(merchOrders.merchCardId, [...merchCardIds])
+      )
+    );
 }
 
 export async function buildReleaseGmvRowForRun(input: {
   readonly workflowRunId: string;
   readonly stepOutputs: ReleaseToRevenueRunStepOutputs;
 }): Promise<ReleaseGmvPerRunRow> {
+  const creatorProfileId =
+    input.stepOutputs.designPartner?.creatorProfileId ?? '';
   const merchCardIds = await resolveMerchCardIdsForRun(input.stepOutputs);
-  const orders = await getPaidOrdersForMerchCards(merchCardIds);
+  const orders = await getPaidOrdersForMerchCards(
+    merchCardIds,
+    creatorProfileId
+  );
   const { gmvCents, orderCount } = computeStoreGmvCents(orders);
 
   return {
     workflowRunId: input.workflowRunId,
     releaseId: input.stepOutputs.releaseId,
     releaseTitle: input.stepOutputs.release.title,
+    creatorProfileId,
+    creatorUsername: input.stepOutputs.designPartner?.creatorUsername ?? '',
     triggeredAt: input.stepOutputs.triggeredAt,
     merchCardIds,
     orderCount,
@@ -91,27 +111,14 @@ export async function buildReleaseGmvRowForRun(input: {
   };
 }
 
-export async function getDesignPartnerReleaseGmvSnapshot(): Promise<DesignPartnerReleaseGmvSnapshot | null> {
-  const designPartner = await resolveDesignPartnerConfig();
-  if (!designPartner) {
-    return null;
-  }
+interface ReleaseRunRow {
+  readonly id: string;
+  readonly stepOutputs: unknown;
+}
 
-  const runs = await db
-    .select({
-      id: workflowRuns.id,
-      stepOutputs: workflowRuns.stepOutputs,
-      createdAt: workflowRuns.createdAt,
-    })
-    .from(workflowRuns)
-    .where(
-      and(
-        eq(workflowRuns.userId, designPartner.userId),
-        eq(workflowRuns.kind, RELEASE_TO_REVENUE_WORKFLOW_KIND)
-      )
-    )
-    .orderBy(drizzleSql`${workflowRuns.createdAt} DESC`);
-
+async function buildReleaseGmvRows(
+  runs: readonly ReleaseRunRow[]
+): Promise<ReleaseGmvPerRunRow[]> {
   const releases: ReleaseGmvPerRunRow[] = [];
   for (const run of runs) {
     const stepOutputs = run.stepOutputs as ReleaseToRevenueRunStepOutputs;
@@ -125,29 +132,108 @@ export async function getDesignPartnerReleaseGmvSnapshot(): Promise<DesignPartne
       })
     );
   }
+  return releases;
+}
 
-  const totalGmvCents = releases.reduce(
-    (sum, release) => sum + release.gmvCents,
-    0
-  );
+function sumGmvCents(releases: readonly ReleaseGmvPerRunRow[]): number {
+  return releases.reduce((sum, release) => sum + release.gmvCents, 0);
+}
+
+/**
+ * Select release-to-revenue runs ordered newest-first. When `ownerUserId` is
+ * provided the result is scoped to that user (ownership-filtered); pass `null`
+ * only for the admin/global all-tenants view.
+ */
+async function selectReleaseRuns(
+  ownerUserId: string | null
+): Promise<ReleaseRunRow[]> {
+  // Only `null` means "all tenants". An empty/blank userId is never a valid
+  // tenant — fail closed instead of falling through to the global query.
+  if (ownerUserId !== null && !ownerUserId) {
+    return [];
+  }
+
+  const predicate =
+    ownerUserId === null
+      ? eq(workflowRuns.kind, RELEASE_TO_REVENUE_WORKFLOW_KIND)
+      : and(
+          eq(workflowRuns.userId, ownerUserId),
+          eq(workflowRuns.kind, RELEASE_TO_REVENUE_WORKFLOW_KIND)
+        );
+
+  return db
+    .select({
+      id: workflowRuns.id,
+      stepOutputs: workflowRuns.stepOutputs,
+    })
+    .from(workflowRuns)
+    .where(predicate)
+    .orderBy(drizzleSql`${workflowRuns.createdAt} DESC`);
+}
+
+/**
+ * Ownership-filtered release GMV snapshot for a single user. Each run's GMV is
+ * additionally scoped to its own creator profile inside {@link buildReleaseGmvRowForRun}.
+ */
+export async function getReleaseGmvSnapshotForUser(input: {
+  readonly userId: string;
+}): Promise<DesignPartnerReleaseGmvSnapshot> {
+  const runs = await selectReleaseRuns(input.userId);
+  const releases = await buildReleaseGmvRows(runs);
 
   return {
-    creatorUsername: designPartner.creatorUsername,
+    creatorUsername: releases[0]?.creatorUsername ?? '',
     generatedAtIso: new Date().toISOString(),
     releases,
-    totalGmvCents,
+    totalGmvCents: sumGmvCents(releases),
+  };
+}
+
+/**
+ * Admin/global release GMV snapshot across every tenant. Each release row is still
+ * owner-scoped at the order level, so no creator's GMV bleeds into another's row.
+ *
+ * SECURITY INVARIANT: this returns cross-tenant revenue and MUST only be called
+ * from an admin-gated surface. Its sole caller is `ReleaseToRevenueGmvPanel`, which
+ * renders under `app/app/(shell)/admin/layout.tsx` — that layout redirects any
+ * request lacking `hasAdminRole` (and middleware already gates `/app/admin`). Do
+ * not call this from a non-admin route/action. Use {@link getReleaseGmvSnapshotForUser}
+ * for any creator-facing surface.
+ */
+export async function getAllTenantsReleaseGmvSnapshot(): Promise<AllTenantsReleaseGmvSnapshot> {
+  const runs = await selectReleaseRuns(null);
+  const releases = await buildReleaseGmvRows(runs);
+  const tenantCount = new Set(
+    releases.map(release => release.creatorProfileId).filter(Boolean)
+  ).size;
+
+  return {
+    generatedAtIso: new Date().toISOString(),
+    releases,
+    totalGmvCents: sumGmvCents(releases),
+    tenantCount,
   };
 }
 
 export async function resolveReleaseWorkflowRunIdForMerchCard(
-  merchCardId: string
+  merchCardId: string,
+  creatorProfileId: string
 ): Promise<string | null> {
+  if (!creatorProfileId) {
+    return null;
+  }
+
+  // Only consider runs owned by the same creator as the merch card. Without this
+  // predicate a buyer's card could resolve to another tenant's release run.
+  const ownerPredicate = drizzleSql`${workflowRuns.stepOutputs}->'designPartner'->>'creatorProfileId' = ${creatorProfileId}`;
+
   const [explicit] = await db
     .select({ id: workflowRuns.id })
     .from(workflowRuns)
     .where(
       and(
         eq(workflowRuns.kind, RELEASE_TO_REVENUE_WORKFLOW_KIND),
+        ownerPredicate,
         drizzleSql`${workflowRuns.stepOutputs}->'storeListing'->'merchCardIds' @> ${JSON.stringify([merchCardId])}::jsonb`
       )
     )
@@ -165,7 +251,12 @@ export async function resolveReleaseWorkflowRunIdForMerchCard(
       createdAt: workflowRuns.createdAt,
     })
     .from(workflowRuns)
-    .where(eq(workflowRuns.kind, RELEASE_TO_REVENUE_WORKFLOW_KIND))
+    .where(
+      and(
+        eq(workflowRuns.kind, RELEASE_TO_REVENUE_WORKFLOW_KIND),
+        ownerPredicate
+      )
+    )
     .orderBy(drizzleSql`${workflowRuns.createdAt} DESC`);
 
   for (const run of runs) {

--- a/apps/web/lib/release-to-revenue/store-listing.test.ts
+++ b/apps/web/lib/release-to-revenue/store-listing.test.ts
@@ -1,8 +1,62 @@
-import { describe, expect, it } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDbSelect = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mockDbSelect,
+  },
+}));
+
 import {
+  findMerchCardIdsForRelease,
   mergeStoreListingMerchCardIds,
   normalizeStoreListing,
+  resolveMerchCardIdsForRun,
 } from './store-listing';
+import type { ReleaseToRevenueRunStepOutputs } from './types';
+
+const dialect = new PgDialect();
+
+interface MerchBatchRow {
+  readonly merchCardId: string | null;
+  readonly creatorProfileId: string;
+}
+
+/**
+ * Fake `merch_generation_batches` query that faithfully applies the rendered
+ * WHERE predicate to a two-tenant fixture, and records the SQL so a test can
+ * assert the owner predicate is present.
+ */
+function fakeBatchSelect(rows: readonly MerchBatchRow[]) {
+  let captured: { sql: string; params: unknown[] } | null = null;
+  const chain = {
+    from: () => chain,
+    where: (cond: unknown) => {
+      const q = dialect.sqlToQuery(cond as never);
+      captured = { sql: q.sql, params: q.params };
+      const params = q.params as unknown[];
+      // Predicate shape: creator_profile_id = $1 AND command = $2 AND prompt LIKE $3 AND selected IS NOT NULL.
+      // Owner scoping requires the row's creator to be one of the bound params.
+      const matching = rows.filter(
+        row => row.merchCardId !== null && params.includes(row.creatorProfileId)
+      );
+      return Promise.resolve(
+        matching.map(row => ({ merchCardId: row.merchCardId }))
+      );
+    },
+  };
+  mockDbSelect.mockReturnValue(chain);
+  return {
+    get sql() {
+      return captured?.sql ?? '';
+    },
+    get params() {
+      return captured?.params ?? [];
+    },
+  };
+}
 
 describe('release-to-revenue store listing helpers', () => {
   it('deduplicates linked merch card ids', () => {
@@ -20,5 +74,100 @@ describe('release-to-revenue store listing helpers', () => {
         'card-b',
       ])
     ).toEqual({ merchCardIds: ['card-a', 'card-b'] });
+  });
+});
+
+describe('findMerchCardIdsForRelease tenant isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('scopes the query to the owning creator and never returns another tenant card', async () => {
+    const capture = fakeBatchSelect([
+      { merchCardId: 'card-A', creatorProfileId: 'profile-A' },
+      { merchCardId: 'card-B', creatorProfileId: 'profile-B' },
+    ]);
+
+    const cards = await findMerchCardIdsForRelease('release-1', 'profile-A');
+
+    // Behavioral: only the owner's card comes back.
+    expect(cards).toEqual(['card-A']);
+    expect(cards).not.toContain('card-B');
+
+    // Regression guard: the WHERE clause carries the owner predicate. If a future
+    // edit drops it, the rendered SQL/params lose the owner and this fails.
+    expect(capture.sql).toContain(
+      '"merch_generation_batches"."creator_profile_id"'
+    );
+    expect(capture.params).toContain('profile-A');
+    expect(capture.params).not.toContain('profile-B');
+  });
+
+  it('fails closed (no query) when the owner is missing', async () => {
+    fakeBatchSelect([]);
+
+    const cards = await findMerchCardIdsForRelease('release-1', '');
+
+    expect(cards).toEqual([]);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveMerchCardIdsForRun tenant isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const baseStepOutputs = (
+    overrides: Partial<ReleaseToRevenueRunStepOutputs> = {}
+  ): ReleaseToRevenueRunStepOutputs => ({
+    releaseId: 'release-1',
+    triggerSource: 'catalog',
+    triggeredAt: '2026-06-19T00:00:00.000Z',
+    designPartner: {
+      creatorUsername: 'tenant-a',
+      creatorProfileId: 'profile-A',
+      userId: 'user-A',
+      store: { provider: 'printful', scope: 'default' },
+      socialAccount: { platform: 'instagram', handle: 'tenant-a' },
+      smsListId: 'sms-a',
+    },
+    release: { title: 'Night Drive', artworkUrl: null, links: [] },
+    ...overrides,
+  });
+
+  it('returns linked ids without a query when the run already has a store listing', async () => {
+    const ids = await resolveMerchCardIdsForRun(
+      baseStepOutputs({ storeListing: { merchCardIds: ['card-A'] } })
+    );
+
+    expect(ids).toEqual(['card-A']);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it('discovers cards scoped to the run owner', async () => {
+    const capture = fakeBatchSelect([
+      { merchCardId: 'card-A', creatorProfileId: 'profile-A' },
+      { merchCardId: 'card-B', creatorProfileId: 'profile-B' },
+    ]);
+
+    const ids = await resolveMerchCardIdsForRun(baseStepOutputs());
+
+    expect(ids).toEqual(['card-A']);
+    expect(capture.params).toContain('profile-A');
+  });
+
+  it('fails closed when the run has no creator owner on the discovery path', async () => {
+    fakeBatchSelect([]);
+
+    const ids = await resolveMerchCardIdsForRun(
+      baseStepOutputs({
+        designPartner:
+          undefined as unknown as ReleaseToRevenueRunStepOutputs['designPartner'],
+      })
+    );
+
+    expect(ids).toEqual([]);
+    expect(mockDbSelect).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/release-to-revenue/store-listing.ts
+++ b/apps/web/lib/release-to-revenue/store-listing.ts
@@ -37,9 +37,24 @@ export function mergeStoreListingMerchCardIds(
   });
 }
 
+/**
+ * Resolve the merch cards generated for a release, scoped to the owning creator.
+ *
+ * The `creatorProfileId` predicate is the tenant-isolation boundary: without it,
+ * one creator's release run could pick up another creator's merch cards that share
+ * the same `release_id:` prompt prefix (JOV cross-tenant GMV leak). Always pass the
+ * owning creator profile id; an empty id fails closed and returns no cards.
+ */
 export async function findMerchCardIdsForRelease(
-  releaseId: string
+  releaseId: string,
+  creatorProfileId: string
 ): Promise<string[]> {
+  // Fail closed: an empty owner would search across tenants, and an empty
+  // releaseId would match every release-prefixed batch (`release_id:%`).
+  if (!creatorProfileId || !releaseId) {
+    return [];
+  }
+
   const batches = await db
     .select({
       merchCardId: merchGenerationBatches.selectedMerchCardId,
@@ -47,6 +62,7 @@ export async function findMerchCardIdsForRelease(
     .from(merchGenerationBatches)
     .where(
       and(
+        eq(merchGenerationBatches.creatorProfileId, creatorProfileId),
         eq(merchGenerationBatches.command, RELEASE_AUTOPILOT_MERCH_COMMAND),
         like(
           merchGenerationBatches.prompt,
@@ -77,7 +93,14 @@ export async function resolveMerchCardIdsForRun(
     return [];
   }
 
-  return findMerchCardIdsForRelease(stepOutputs.releaseId);
+  // Owner-scope the discovery query to the run's creator. Fail closed when the
+  // owner is missing rather than searching across every tenant's merch cards.
+  const creatorProfileId = stepOutputs.designPartner?.creatorProfileId;
+  if (!creatorProfileId) {
+    return [];
+  }
+
+  return findMerchCardIdsForRelease(stepOutputs.releaseId, creatorProfileId);
 }
 
 export async function linkMerchCardToReleaseRun(input: {

--- a/apps/web/lib/release-to-revenue/types.ts
+++ b/apps/web/lib/release-to-revenue/types.ts
@@ -91,6 +91,10 @@ export interface ReleaseGmvPerRunRow {
   readonly workflowRunId: string;
   readonly releaseId: string | null;
   readonly releaseTitle: string;
+  /** Canonical owning-tenant key (from the run's design partner snapshot). */
+  readonly creatorProfileId: string;
+  /** Owning creator's username — display only, not a tenant key. */
+  readonly creatorUsername: string;
   readonly triggeredAt: string;
   readonly merchCardIds: readonly string[];
   readonly orderCount: number;
@@ -98,11 +102,20 @@ export interface ReleaseGmvPerRunRow {
   readonly gmvCents: number;
 }
 
+/** Single-creator (ownership-filtered) release GMV snapshot. */
 export interface DesignPartnerReleaseGmvSnapshot {
   readonly creatorUsername: string;
   readonly generatedAtIso: string;
   readonly releases: readonly ReleaseGmvPerRunRow[];
   readonly totalGmvCents: number;
+}
+
+/** Admin/global release GMV snapshot spanning every tenant's runs. */
+export interface AllTenantsReleaseGmvSnapshot {
+  readonly generatedAtIso: string;
+  readonly releases: readonly ReleaseGmvPerRunRow[];
+  readonly totalGmvCents: number;
+  readonly tenantCount: number;
 }
 
 export interface ManualReleaseTriggerInput {

--- a/apps/web/lib/services/release-autopilot/merch-drop.ts
+++ b/apps/web/lib/services/release-autopilot/merch-drop.ts
@@ -38,8 +38,15 @@ function releasePromptPrefix(releaseId: string): string {
 }
 
 async function findExistingReleaseMerchDrop(
-  releaseId: string
+  releaseId: string,
+  creatorProfileId: string
 ): Promise<ReleaseAutopilotMerchDropResult | null> {
+  // Owner-scope the lookup so one creator's release never resolves to another
+  // creator's existing merch drop. Fail closed on a missing owner.
+  if (!creatorProfileId) {
+    return null;
+  }
+
   const [batch] = await db
     .select({
       generationId: merchGenerationBatches.id,
@@ -48,6 +55,7 @@ async function findExistingReleaseMerchDrop(
     .from(merchGenerationBatches)
     .where(
       and(
+        eq(merchGenerationBatches.creatorProfileId, creatorProfileId),
         eq(merchGenerationBatches.command, RELEASE_AUTOPILOT_MERCH_COMMAND),
         like(
           merchGenerationBatches.prompt,
@@ -90,7 +98,10 @@ export async function generateReleaseMerchDrop(params: {
   readonly releaseId: string;
   readonly clerkUserId: string;
 }): Promise<ReleaseAutopilotMerchDropResult> {
-  const existing = await findExistingReleaseMerchDrop(params.releaseId);
+  const existing = await findExistingReleaseMerchDrop(
+    params.releaseId,
+    params.profileId
+  );
   if (existing) {
     return existing;
   }


### PR DESCRIPTION
Closes #12450

Child of #12151 (Release-to-Revenue GA), Slice 5 of 6. **⚠️ payment/data-high — requires human risk sign-off (tenant isolation on revenue data).**

## Problem (Hazards 3 + 4 — cross-tenant GMV leak)

`store-listing.ts` and `gmv-attribution.ts` matched merch cards / orders / runs by `releaseId` or `release_id:` prompt prefix with **no `creatorProfileId` filter**, so Artist B's release run could pick up Artist A's merch cards and count A's GMV.

## What changed

**Owner-scope every merch-card / order / run query (all fail closed on a missing owner):**
- `getPaidOrdersForMerchCards(merchCardIds, creatorProfileId)` — filters `merchOrders.creatorProfileId`. This is the money query: even a contaminated card-id list can never count another tenant's order.
- `findMerchCardIdsForRelease(releaseId, creatorProfileId)` — filters `merchGenerationBatches.creatorProfileId`; also fails closed on an empty `releaseId` (would otherwise match `release_id:%`).
- `resolveReleaseWorkflowRunIdForMerchCard(merchCardId, creatorProfileId)` — owner-scopes runs via the `stepOutputs->'designPartner'->>'creatorProfileId'` JSONB path; merch checkout (`lib/merch/orders.ts`) passes `row.card.creatorProfileId`.
- `resolveMerchCardIdsForRun` / `buildReleaseGmvRowForRun` derive the owner from `stepOutputs.designPartner.creatorProfileId` and thread it through.

**Snapshots:**
- Add `getReleaseGmvSnapshotForUser({ userId })` (ownership-filtered) — consumed by Slice 6.
- Add `getAllTenantsReleaseGmvSnapshot()` and repoint admin `ReleaseToRevenueGmvPanel` to it, so admin no longer silently shows only the legacy design partner.
- `selectReleaseRuns` fails closed on a **blank** `userId` instead of falling back to the global all-tenants query (an empty user id is never a valid tenant).

**Defense-in-depth (same `release_id` prompt-prefix pattern, per "fix all instances"):**
- `release-autopilot/merch-drop.ts` `findExistingReleaseMerchDrop` and `distribution-drafts.ts` `resolveMerchDropLink` now carry the same `creatorProfileId` predicate.

## Acceptance criteria

- ✅ Two creators each with a paid order on their own card → each GMV snapshot returns only their own orders/totals (`getReleaseGmvSnapshotForUser` two-tenant test).
- ✅ `findMerchCardIdsForRelease` never returns another tenant's card (two-tenant test).
- ✅ No merch/order/run query selects without an owner predicate — asserted directly against the rendered SQL (`PgDialect.sqlToQuery`) in tests.
- ✅ Admin panel repointed to an explicit all-tenants query.

## Verification

```
typecheck (@jovie/web)         → exit 0
biome check (9 changed files)  → clean
vitest lib/release-to-revenue
  + lib/services/release-autopilot
  + outcome-attribution         → 39 passed
```

Tests are genuine regression guards (mutation-verified): removing the `creator_profile_id` / `user_id` predicates makes the two-tenant tests fail; restoring makes them pass. Coverage spans owner-predicate presence in rendered SQL, fail-closed-on-missing-owner (no query issued), the contaminated-listing money-neutralization case, and the blank-`userId` fail-closed case.

Reviewed by adversarial security + correctness subagents and two local CodeRabbit passes.

## Reviewer decision point

`getAllTenantsReleaseGmvSnapshot` returns cross-tenant revenue and is **not** guarded by an in-function admin check. Access is enforced at the route layer (its only caller, `ReleaseToRevenueGmvPanel`, renders under `app/app/(shell)/admin/layout.tsx`, which hard-redirects any request lacking `hasAdminRole`; middleware also gates `/app/admin`). This matches the codebase's auth-at-the-boundary pattern (the function it replaces had no internal check either) and keeps the data layer reusable/testable. A `SECURITY INVARIANT` JSDoc documents the contract. CodeRabbit suggested an in-function admin assert — flagged here so a human can decide; happy to add it if preferred.

## Follow-ups

- #12474 — owner-filter the cosmetic `merchCardIds` **display** array for pre-existing contaminated listings (money already neutralized; only matters once the per-user snapshot is creator-facing in Slice 6).
- #12475 — pre-existing repo-wide biome violations on `main` fail the local `biome check .` pre-push gate (4 files identical to main; this push used the sanctioned `JOVIE_SKIP_PRE_PUSH_GATE=1`, not `--no-verify`; the 9 changed files are biome-clean).

## Cost Impact

None — no new external API calls, cron jobs, or scheduled work. Pure query-scoping change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
