### PR TITLE
feat(ci): read-only CI throughput + latency metrics job (Hermes)

### DIFF
--- a/scripts/hermes/jobs/ci-metrics.ts
+++ b/scripts/hermes/jobs/ci-metrics.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env tsx
+/**
+ * CI Metrics — Hermes (read-only).
+ *
+ * Measures the merge pipeline so we can name the real ceiling before optimizing
+ * anything. PRIMARY signal is throughput (merged-PRs/day, runner-hours per
+ * merged PR, flaky-rerun rate, queue-wait); latency P50/P75/P95 (gate wall-clock
+ * + full PR-open→merge) is a SECONDARY diagnostic. See docs/PR_FLOW.md:
+ * "Throughput ceiling is CI cost and queue reliability, not merge wiring."
+ *
+ * This job ONLY reads (gh api) and writes local state + a gbrain snapshot. It
+ * does NOT run experiments, edit CI, or auto-merge anything. The append-only
+ * JSONL is the history a human (or a future, separately-reviewed experiment
+ * loop) reads to decide what to optimize.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { summarizeCiMetrics } from '../../lib/ci-metrics-compute.mjs';
+import { parseMergeQueueTimeline } from '../../lib/merge-queue-guard.mjs';
+import { gbrainLearn } from '../lib/gbrain';
+import { HERMES_PATHS } from '../lib/hermes-paths';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+
+const JOB = 'ci-metrics';
+const RUN_SAMPLE = 100;
+const PR_SAMPLE = 50;
+const METRICS_JSONL = join(HERMES_PATHS.stateDir, 'ci-metrics.jsonl');
+const METRICS_LATEST = join(HERMES_PATHS.stateDir, 'ci-metrics-latest.json');
+
+interface WorkflowRun {
+  readonly id: number;
+  readonly created_at: string;
+  readonly updated_at: string;
+  readonly run_attempt: number;
+  readonly status: string;
+  readonly conclusion: string | null;
+}
+
+interface MergedPr {
+  readonly number: number;
+  readonly createdAt: string;
+  readonly mergedAt: string | null;
+}
+
+function gh(args: readonly string[], timeoutMs = 30_000): string {
+  return execFileSync('gh', [...args], {
+    encoding: 'utf8',
+    timeout: timeoutMs,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+}
+
+function resolveRepo(): string {
+  const out = gh(['repo', 'view', '--json', 'nameWithOwner']);
+  return (JSON.parse(out) as { nameWithOwner: string }).nameWithOwner;
+}
+
+function fetchCiRuns(repo: string): WorkflowRun[] {
+  const out = gh([
+    'api',
+    `repos/${repo}/actions/workflows/ci.yml/runs?event=pull_request&per_page=${RUN_SAMPLE}`,
+  ]);
+  return (
+    (JSON.parse(out) as { workflow_runs?: WorkflowRun[] }).workflow_runs ?? []
+  );
+}
+
+function fetchMergedPrs(): MergedPr[] {
+  const out = gh([
+    'pr',
+    'list',
+    '--state',
+    'merged',
+    '--limit',
+    String(PR_SAMPLE),
+    '--json',
+    'number,createdAt,mergedAt',
+  ]);
+  return JSON.parse(out) as MergedPr[];
+}
+
+function fetchTimeline(repo: string, prNumber: number) {
+  // ponytail: first 100 timeline events captures the merge-queue label + merge
+  // events for nearly all PRs; skip --paginate to bound per-tick API cost.
+  try {
+    const out = gh(
+      ['api', `repos/${repo}/issues/${prNumber}/timeline?per_page=100`],
+      20_000
+    );
+    return parseMergeQueueTimeline(JSON.parse(out));
+  } catch {
+    return null;
+  }
+}
+
+function fmtMin(seconds: number): string {
+  return `${Math.round(seconds / 60)}m`;
+}
+
+function renderBody(m: ReturnType<typeof summarizeCiMetrics>): string {
+  const t = m.throughput;
+  const l = m.latency;
+  return [
+    `Window: ${m.window.mergedPrs} merged PRs · ${m.window.ciRuns} CI runs · ${m.window.spanDays}d span`,
+    `Throughput (primary): ${t.mergedPrsPerDay}/day · ${t.ciRunHoursPerMergedPr ?? '?'} runner-h/PR · flaky ${(t.flakyRerunRate * 100).toFixed(1)}% · queue-wait p50 ${fmtMin(t.queueWaitSeconds.p50)} / p95 ${fmtMin(t.queueWaitSeconds.p95)}`,
+    `Latency (secondary): gate p50 ${fmtMin(l.gateWallclockSeconds.p50)} / p75 ${fmtMin(l.gateWallclockSeconds.p75)} / p95 ${fmtMin(l.gateWallclockSeconds.p95)} · full-merge p50 ${fmtMin(l.fullMergeTimeSeconds.p50)} / p95 ${fmtMin(l.fullMergeTimeSeconds.p95)}`,
+    `Samples: gate ${m.sampleSizes.gate} · full-merge ${m.sampleSizes.fullMerge} · queue-wait ${m.sampleSizes.queueWait}`,
+  ].join('\n');
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const repo = resolveRepo();
+    const runs = fetchCiRuns(repo);
+    const prs = fetchMergedPrs();
+    const timelineResults = prs
+      .map(pr => fetchTimeline(repo, pr.number))
+      .filter((t): t is NonNullable<typeof t> => t !== null);
+
+    const metrics = summarizeCiMetrics({
+      ts: new Date().toISOString(),
+      runs,
+      prs,
+      timelineResults,
+    });
+
+    mkdirSync(HERMES_PATHS.stateDir, { recursive: true });
+    appendFileSync(METRICS_JSONL, `${JSON.stringify(metrics)}\n`);
+    writeFileSync(METRICS_LATEST, `${JSON.stringify(metrics, null, 2)}\n`);
+
+    // Idempotent snapshot page (history lives in the JSONL); makes "what's our
+    // current CI throughput/latency" recallable across sessions.
+    gbrainLearn({
+      slug: 'ci-metrics/latest',
+      title: 'CI metrics (latest snapshot)',
+      body: renderBody(metrics),
+      tags: ['type:ci-metrics'],
+      type: 'ci-metrics',
+    });
+
+    logJobEvent({
+      job: JOB,
+      event: 'measured',
+      mergedPrsPerDay: metrics.throughput.mergedPrsPerDay,
+      runnerHoursPerPr: metrics.throughput.ciRunHoursPerMergedPr,
+      flakyRerunRate: metrics.throughput.flakyRerunRate,
+      queueWaitP95: metrics.throughput.queueWaitSeconds.p95,
+      gateP95: metrics.latency.gateWallclockSeconds.p95,
+      fullMergeP95: metrics.latency.fullMergeTimeSeconds.p95,
+      samples: metrics.sampleSizes,
+    });
+
+    process.stdout.write(`${renderBody(metrics)}\n`);
+  });
+}
+
+void main().catch(err => {
+  console.error(`[${JOB}] fatal:`, err);
+  // exit 0 so launchd does not thrash on a transient gh/network error.
+  process.exit(0);
+});

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-ci-metrics.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-ci-metrics.plist.template
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-ci-metrics</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/ci-metrics.ts</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>3600</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.bun/bin:{{HOME}}/.hermes/bin:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-ci-metrics.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-ci-metrics.err.log</string>
+</dict>
+</plist>

--- a/scripts/lib/__tests__/ci-duration-ratchet.test.mjs
+++ b/scripts/lib/__tests__/ci-duration-ratchet.test.mjs
@@ -3,6 +3,7 @@ import {
   checkRatchet,
   computeElapsedSeconds,
   computeP95,
+  computePercentile,
   formatDuration,
   RATCHET_SCHEMA_VERSION,
   validateDurationRatchet,
@@ -39,6 +40,41 @@ describe('computeP95', () => {
     const input = [300, 100, 200];
     computeP95(input);
     expect(input).toEqual([300, 100, 200]);
+  });
+});
+
+describe('computePercentile', () => {
+  it('returns 0 for empty or invalid input', () => {
+    expect(computePercentile([], 50)).toBe(0);
+    expect(computePercentile([10, 20], 0)).toBe(0);
+    expect(computePercentile([10, 20], Number.NaN)).toBe(0);
+  });
+
+  it('computes p50/p75/p95 (nearest-rank) for a 5-element array', () => {
+    const xs = [10, 20, 30, 40, 50];
+    // p50: ceil(0.50*5)-1 = 3-1 = 2 → 30
+    expect(computePercentile(xs, 50)).toBe(30);
+    // p75: ceil(0.75*5)-1 = 4-1 = 3 → 40
+    expect(computePercentile(xs, 75)).toBe(40);
+    // p95: ceil(0.95*5)-1 = 5-1 = 4 → 50
+    expect(computePercentile(xs, 95)).toBe(50);
+  });
+
+  it('handles unsorted input without mutating it', () => {
+    const xs = [50, 10, 40, 20, 30];
+    expect(computePercentile(xs, 50)).toBe(30);
+    expect(xs).toEqual([50, 10, 40, 20, 30]);
+  });
+
+  it('clamps p > 100 to the max value', () => {
+    expect(computePercentile([1, 2, 3], 150)).toBe(3);
+  });
+
+  it('computeP95 is computePercentile(., 95)', () => {
+    const xs = Array.from({ length: 37 }, (_, i) => i * 7 + 3);
+    expect(computeP95(xs)).toBe(computePercentile(xs, 95));
+    expect(computeP95([])).toBe(computePercentile([], 95));
+    expect(computeP95([42])).toBe(computePercentile([42], 95));
   });
 });
 

--- a/scripts/lib/__tests__/ci-metrics-compute.test.mjs
+++ b/scripts/lib/__tests__/ci-metrics-compute.test.mjs
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CI_METRICS_SCHEMA_VERSION,
+  ciRunHours,
+  completedDurationsSeconds,
+  flakyRerunRate,
+  fullMergeTimesSeconds,
+  gateDurationsSeconds,
+  mergedThroughput,
+  percentilesOf,
+  queueWaitSeconds,
+  summarizeCiMetrics,
+} from '../ci-metrics-compute.mjs';
+
+const run = (
+  createdAt,
+  updatedAt,
+  attempt = 1,
+  status = 'completed',
+  conclusion = 'success'
+) => ({
+  status,
+  conclusion,
+  created_at: createdAt,
+  updated_at: updatedAt,
+  run_attempt: attempt,
+});
+
+describe('gateDurationsSeconds', () => {
+  it('counts SUCCESSFUL completed runs only (matches the ratchet)', () => {
+    const runs = [
+      run('2026-06-19T10:00:00Z', '2026-06-19T10:10:00Z'), // 600 success
+      run('2026-06-19T11:00:00Z', '2026-06-19T11:05:00Z'), // 300 success
+      run('2026-06-19T12:00:00Z', '2026-06-19T12:00:00Z'), // 0 → dropped
+      run(
+        '2026-06-19T13:00:00Z',
+        '2026-06-19T13:30:00Z',
+        1,
+        'completed',
+        'failure'
+      ), // excluded
+      { ...run('a', 'b'), status: 'in_progress' }, // dropped
+    ];
+    expect(gateDurationsSeconds(runs)).toEqual([600, 300]);
+  });
+
+  it('returns [] for nullish input', () => {
+    expect(gateDurationsSeconds(undefined)).toEqual([]);
+  });
+});
+
+describe('completedDurationsSeconds', () => {
+  it('counts ALL completed runs regardless of conclusion (slot-hours basis)', () => {
+    const runs = [
+      run('2026-06-19T10:00:00Z', '2026-06-19T10:10:00Z'), // 600 success
+      run(
+        '2026-06-19T13:00:00Z',
+        '2026-06-19T13:30:00Z',
+        1,
+        'completed',
+        'failure'
+      ), // 1800 failure counts
+      { ...run('a', 'b'), status: 'in_progress' }, // dropped
+    ];
+    expect(completedDurationsSeconds(runs)).toEqual([600, 1800]);
+  });
+});
+
+describe('fullMergeTimesSeconds', () => {
+  it('computes createdAt→mergedAt for merged PRs', () => {
+    const prs = [
+      { createdAt: '2026-06-19T10:00:00Z', mergedAt: '2026-06-19T10:30:00Z' }, // 1800
+      { createdAt: '2026-06-19T10:00:00Z', mergedAt: null }, // dropped
+    ];
+    expect(fullMergeTimesSeconds(prs)).toEqual([1800]);
+  });
+});
+
+describe('flakyRerunRate', () => {
+  it('is the fraction of runs with run_attempt > 1', () => {
+    const runs = [
+      run('a', 'b', 1),
+      run('a', 'b', 2),
+      run('a', 'b', 3),
+      run('a', 'b', 1),
+    ];
+    expect(flakyRerunRate(runs)).toBe(0.5);
+  });
+  it('is 0 with no runs', () => {
+    expect(flakyRerunRate([])).toBe(0);
+  });
+});
+
+describe('ciRunHours', () => {
+  it('sums all completed run wall-clock into hours (incl. failures)', () => {
+    const runs = [
+      run('2026-06-19T10:00:00Z', '2026-06-19T10:30:00Z'), // 1800s success
+      run(
+        '2026-06-19T11:00:00Z',
+        '2026-06-19T11:30:00Z',
+        1,
+        'completed',
+        'failure'
+      ), // 1800s failure
+    ];
+    expect(ciRunHours(runs)).toBe(1); // 3600s — failures burn slots too
+  });
+});
+
+describe('mergedThroughput', () => {
+  it('averages merged PRs across the window span (>=1 day floor)', () => {
+    const prs = [
+      { mergedAt: '2026-06-10T00:00:00Z' },
+      { mergedAt: '2026-06-12T00:00:00Z' },
+      { mergedAt: '2026-06-14T00:00:00Z' }, // span = 4 days, 3 PRs → 0.75/day
+    ];
+    const t = mergedThroughput(prs);
+    expect(t.mergedCount).toBe(3);
+    expect(t.spanDays).toBe(4);
+    expect(t.mergedPrsPerDay).toBeCloseTo(0.75, 5);
+  });
+
+  it('clamps span to 1 day for a same-day burst', () => {
+    const prs = [
+      { mergedAt: '2026-06-10T09:00:00Z' },
+      { mergedAt: '2026-06-10T10:00:00Z' },
+    ];
+    expect(mergedThroughput(prs).mergedPrsPerDay).toBe(2); // 2 / max(span,1)
+  });
+
+  it('returns zeros for no merged PRs', () => {
+    expect(mergedThroughput([])).toEqual({
+      mergedPrsPerDay: 0,
+      spanDays: 0,
+      mergedCount: 0,
+    });
+  });
+});
+
+describe('queueWaitSeconds', () => {
+  it('extracts positive queuedToMergedSeconds', () => {
+    const tl = [
+      { queuedToMergedSeconds: 120 },
+      { queuedToMergedSeconds: null },
+      { queuedToMergedSeconds: 0 },
+      { queuedToMergedSeconds: 300 },
+    ];
+    expect(queueWaitSeconds(tl)).toEqual([120, 300]);
+  });
+});
+
+describe('percentilesOf', () => {
+  it('returns p50/p75/p95', () => {
+    expect(percentilesOf([10, 20, 30, 40, 50])).toEqual({
+      p50: 30,
+      p75: 40,
+      p95: 50,
+    });
+  });
+  it('returns zeros for empty', () => {
+    expect(percentilesOf([])).toEqual({ p50: 0, p75: 0, p95: 0 });
+  });
+});
+
+describe('summarizeCiMetrics', () => {
+  it('assembles a complete record with primary throughput + secondary latency', () => {
+    const runs = [
+      run('2026-06-19T10:00:00Z', '2026-06-19T10:10:00Z', 1), // 600
+      run('2026-06-19T11:00:00Z', '2026-06-19T11:20:00Z', 2), // 1200, rerun
+    ];
+    const prs = [
+      { createdAt: '2026-06-18T10:00:00Z', mergedAt: '2026-06-18T11:00:00Z' }, // 3600
+      { createdAt: '2026-06-19T10:00:00Z', mergedAt: '2026-06-19T12:00:00Z' }, // 7200
+    ];
+    const timelineResults = [
+      { queuedToMergedSeconds: 240 },
+      { queuedToMergedSeconds: 480 },
+    ];
+    const out = summarizeCiMetrics({
+      ts: '2026-06-19T13:00:00Z',
+      runs,
+      prs,
+      timelineResults,
+    });
+
+    expect(out.schemaVersion).toBe(CI_METRICS_SCHEMA_VERSION);
+    expect(out.ts).toBe('2026-06-19T13:00:00Z');
+    // span = 25h = 1.042d; p50 of two values is the lower (nearest-rank).
+    expect(out.window).toEqual({ mergedPrs: 2, ciRuns: 2, spanDays: 1.042 });
+    expect(out.throughput.flakyRerunRate).toBe(0.5);
+    expect(out.throughput.queueWaitSeconds).toEqual({
+      p50: 240,
+      p75: 480,
+      p95: 480,
+    });
+    // ciRunHours = (600+1200)/3600 = 0.5; per merged PR = 0.5/2 = 0.25
+    expect(out.throughput.ciRunHoursPerMergedPr).toBe(0.25);
+    expect(out.latency.gateWallclockSeconds.p95).toBe(1200);
+    expect(out.latency.fullMergeTimeSeconds).toEqual({
+      p50: 3600,
+      p75: 7200,
+      p95: 7200,
+    });
+    expect(out.sampleSizes).toEqual({ gate: 2, fullMerge: 2, queueWait: 2 });
+  });
+});

--- a/scripts/lib/ci-duration-ratchet.mjs
+++ b/scripts/lib/ci-duration-ratchet.mjs
@@ -12,15 +12,27 @@
 export const RATCHET_SCHEMA_VERSION = 1;
 
 /**
- * Compute the p95 of an array of numbers.
- * Uses the nearest-rank method (ceiling of 0.95 × n, 1-indexed).
+ * Compute the p-th percentile of an array of numbers.
+ * Uses the nearest-rank method (ceiling of (p/100) × n, 1-indexed).
+ * `p` is a percentile in (0, 100]; values above 100 clamp to 100.
+ * Returns 0 for empty/invalid input. Does not mutate the input.
+ */
+export function computePercentile(durations, p) {
+  if (!Array.isArray(durations) || durations.length === 0) return 0;
+  if (!Number.isFinite(p) || p <= 0) return 0;
+  const pct = Math.min(100, p) / 100;
+  const sorted = [...durations].sort((a, b) => a - b);
+  const index = Math.ceil(pct * sorted.length) - 1;
+  return sorted[Math.max(0, index)];
+}
+
+/**
+ * Compute the p95 of an array of numbers (nearest-rank). Kept as a named
+ * helper for the ratchet; equivalent to computePercentile(durations, 95).
  * Returns 0 for empty arrays.
  */
 export function computeP95(durations) {
-  if (!Array.isArray(durations) || durations.length === 0) return 0;
-  const sorted = [...durations].sort((a, b) => a - b);
-  const index = Math.ceil(0.95 * sorted.length) - 1;
-  return sorted[Math.max(0, index)];
+  return computePercentile(durations, 95);
 }
 
 /**

--- a/scripts/lib/ci-metrics-compute.mjs
+++ b/scripts/lib/ci-metrics-compute.mjs
@@ -1,0 +1,154 @@
+/**
+ * CI metrics — pure aggregation helpers.
+ *
+ * Read-only measurement of the merge pipeline. PRIMARY signal is throughput
+ * (the real ceiling per docs/PR_FLOW.md: "Throughput ceiling is CI cost and
+ * queue reliability, not merge wiring"); latency percentiles are SECONDARY
+ * diagnostics. No experiment loop, no auto keep/rollback lives here — this
+ * module only computes numbers from already-fetched GitHub data so the I/O job
+ * (scripts/hermes/jobs/ci-metrics.ts) and unit tests share one tested core.
+ *
+ * Percentiles use the same nearest-rank method as the duration ratchet, so the
+ * gate p95 we report agrees with .github/workflows/ci-duration-ratchet.yml.
+ */
+
+import {
+  computeElapsedSeconds,
+  computePercentile,
+} from './ci-duration-ratchet.mjs';
+
+export const CI_METRICS_SCHEMA_VERSION = 1;
+
+/** {p50,p75,p95} of an array (0s when empty). */
+export function percentilesOf(values) {
+  return {
+    p50: computePercentile(values, 50),
+    p75: computePercentile(values, 75),
+    p95: computePercentile(values, 95),
+  };
+}
+
+/**
+ * Wall-clock seconds for every completed run (any conclusion). This is the
+ * slot-hours basis: failed/cancelled runs still burn runner slots.
+ */
+export function completedDurationsSeconds(runs) {
+  return (runs ?? [])
+    .filter(r => r && r.status === 'completed' && r.created_at && r.updated_at)
+    .map(r => computeElapsedSeconds(r.created_at, r.updated_at))
+    .filter(s => Number.isFinite(s) && s > 0);
+}
+
+/**
+ * Gate wall-clock seconds for SUCCESSFUL PR runs only (conclusion === 'success'),
+ * matching .github/workflows/ci-duration-ratchet.yml (which queries
+ * status=success) so our gate p95 is comparable to the nightly ratchet.
+ * Failed/cancelled runs are captured by flakyRerunRate + ciRunHours, not here —
+ * a run that failed and got re-run shouldn't inflate "how long a passing gate takes".
+ */
+export function gateDurationsSeconds(runs) {
+  return completedDurationsSeconds(
+    (runs ?? []).filter(r => r && r.conclusion === 'success')
+  );
+}
+
+/** Full PR lifetime seconds (createdAt → mergedAt) for merged PRs. */
+export function fullMergeTimesSeconds(prs) {
+  return (prs ?? [])
+    .filter(p => p && p.createdAt && p.mergedAt)
+    .map(p => computeElapsedSeconds(p.createdAt, p.mergedAt))
+    .filter(s => Number.isFinite(s) && s > 0);
+}
+
+/**
+ * Fraction of CI runs that needed a re-run (run_attempt > 1) — a flaky-rerun
+ * proxy. Reruns burn the runner slots that are the throughput ceiling, so this
+ * is a primary, not cosmetic, signal. Returns 0 when there are no runs.
+ */
+export function flakyRerunRate(runs) {
+  const list = (runs ?? []).filter(r => r && Number.isFinite(r.run_attempt));
+  if (list.length === 0) return 0;
+  const reran = list.filter(r => r.run_attempt > 1).length;
+  return reran / list.length;
+}
+
+/** Total CI runner wall-clock hours across all completed runs (a slot-hours proxy). */
+export function ciRunHours(runs) {
+  const totalSeconds = completedDurationsSeconds(runs).reduce(
+    (a, b) => a + b,
+    0
+  );
+  return totalSeconds / 3600;
+}
+
+/**
+ * Average merged-PRs/day across the sampled window. spanDays is the spread
+ * between the earliest and latest mergedAt; clamped to >= 1 so a burst of PRs
+ * merged within one day can't report an absurd rate.
+ * Returns { mergedPrsPerDay, spanDays, mergedCount }.
+ */
+export function mergedThroughput(prs) {
+  const merged = (prs ?? []).filter(p => p && p.mergedAt);
+  const mergedCount = merged.length;
+  if (mergedCount === 0)
+    return { mergedPrsPerDay: 0, spanDays: 0, mergedCount: 0 };
+  const times = merged
+    .map(p => new Date(p.mergedAt).getTime())
+    .filter(Number.isFinite);
+  const spanMs = Math.max(...times) - Math.min(...times);
+  const spanDays = spanMs / 86_400_000;
+  const effectiveDays = Math.max(spanDays, 1);
+  return {
+    mergedPrsPerDay: mergedCount / effectiveDays,
+    spanDays: Number(spanDays.toFixed(3)),
+    mergedCount,
+  };
+}
+
+/** Queue-wait seconds from parseMergeQueueTimeline results (queuedToMergedSeconds). */
+export function queueWaitSeconds(timelineResults) {
+  return (timelineResults ?? [])
+    .map(t => t && t.queuedToMergedSeconds)
+    .filter(s => Number.isFinite(s) && s > 0);
+}
+
+/**
+ * Assemble the one-line metrics record. Pure: callers pass `ts` so tests stay
+ * deterministic (Date.now lives in the I/O job, not here).
+ */
+export function summarizeCiMetrics({ ts, runs, prs, timelineResults }) {
+  const gate = gateDurationsSeconds(runs);
+  const fullMerge = fullMergeTimesSeconds(prs);
+  const queueWaits = queueWaitSeconds(timelineResults);
+  const { mergedPrsPerDay, spanDays, mergedCount } = mergedThroughput(prs);
+
+  return {
+    schemaVersion: CI_METRICS_SCHEMA_VERSION,
+    ts,
+    window: {
+      mergedPrs: (prs ?? []).length,
+      ciRuns: (runs ?? []).length,
+      spanDays,
+    },
+    // PRIMARY: throughput is the real ceiling.
+    throughput: {
+      mergedPrsPerDay: Number(mergedPrsPerDay.toFixed(2)),
+      ciRunHoursPerMergedPr:
+        mergedCount > 0
+          ? Number((ciRunHours(runs) / mergedCount).toFixed(3))
+          : null,
+      flakyRerunRate: Number(flakyRerunRate(runs).toFixed(4)),
+      queueWaitSeconds: percentilesOf(queueWaits),
+    },
+    // SECONDARY: latency diagnostics.
+    latency: {
+      gateWallclockSeconds: percentilesOf(gate),
+      fullMergeTimeSeconds: percentilesOf(fullMerge),
+    },
+    sampleSizes: {
+      gate: gate.length,
+      fullMerge: fullMerge.length,
+      queueWait: queueWaits.length,
+    },
+  };
+}


### PR DESCRIPTION
## What

A read-only Hermes cron (`scripts/hermes/jobs/ci-metrics.ts`) that measures the merge pipeline so we can name the real CI ceiling before optimizing anything.

- **PRIMARY (throughput):** merged-PRs/day, runner-hours per merged PR, flaky-rerun rate, queue-wait P50/P75/P95.
- **SECONDARY (latency):** gate wall-clock + full PR-open→merge P50/P75/P95.
- Generalizes `computeP95` → `computePercentile(arr, p)` in `scripts/lib/ci-duration-ratchet.mjs` (kept `computeP95` as the 95 case).
- Pure aggregation in `scripts/lib/ci-metrics-compute.mjs` (unit-tested); reuses `parseMergeQueueTimeline`.
- Writes `~/.hermes/state/ci-metrics.jsonl` (append-only history) + `ci-metrics-latest.json` + a gbrain snapshot. launchd template auto-deploys via `bootstrap-air.sh` (hourly).

## Why this shape (autoplan review)

Scoped down from an "always-on optimizer". This PR is **measurement only**: no experiment loop, no CI self-merge lane. Per `docs/PR_FLOW.md` the ceiling is *throughput*, not per-PR latency; a self-judging loop on ~50-PR percentiles + self-merging CI edits is statistically unsound and recreates the 2026-06-22 queue-collapse risk. Name the ceiling first; a later, separately-reviewed optimizer consumes this data.

## Real-data finding (smoke run)

- Gate p95 ≈ **62m** vs the nightly ratchet's committed baseline **15m** (ceiling 18m) → baseline is stale / breaching. Follow-up filed.
- Queue-wait p95 ≈ **939m (15.6h)** dwarfs the gate (62m) → bottleneck is queue/throughput, not gate latency.

## Verification

- `137` unit tests pass (`scripts/vitest.config.mts`).
- Smoke run vs real `gh api` emits finite percentiles + one JSONL line.
- Cross-check: gate p95 matches the ratchet's exact method within noise (62m both ways).
- Test plan: `~/.gstack/projects/JovieInc-Jovie/ci-metrics-test-plan.md`.

## Cost Impact

New hourly Hermes cron: ~53 `gh api` calls/run ≈ **1.3k/day**, well under the 5k/hr authenticated limit. $0 (gh CLI). Read-only.

## Risk / merge

Touches the agent control plane (`scripts/hermes`) → risk classifier blocks unattended auto-merge by design. **Auto-merge not enabled**; human review. launchd activation happens post-merge via `bootstrap-air.sh` on the stable node.

## Follow-ups (separate issues)

Experiment loop (blocked by this; A/A noise-floor gate; non-repo levers only) · hyperagent harvest-then-retire · dog-food loop + skill org · Jovie CLI/MCP spec · HUD RAM+pause · stale ratchet baseline (62m vs 15m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)