### PR TITLE
fix(ci): scope pre-push biome gate to changed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ### Fixed
 
+- [internal] Pre-push Biome gate scopes to changed files (mirroring CI) instead of a repo-wide `biome check .`, so pre-existing Biome drift on `main` no longer blocks `git push` from every worktree and stops training agents toward the `JOVIE_SKIP_PRE_PUSH_GATE=1` escape hatch (GitHub #12475).
 - **Library share links no longer error on re-open**: opening a release that already has share settings — or two tabs opening it at once — previously returned a 500. The "ensure share settings exist" path is now idempotent under a concurrent first-open race via an `ON CONFLICT DO NOTHING` insert plus re-read (GitHub #12407).
 
 ### Changed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,7 +36,7 @@
     "typecheck": "node ../../scripts/typecheck-singleflight.mjs -- tsc -p tsconfig.typecheck.json --noEmit --incremental --tsBuildInfoFile .cache/tsbuildinfo",
     "typecheck:tests": "node ../../scripts/typecheck-singleflight.mjs -- tsc -p tsconfig.test.json --noEmit --incremental",
     "next:proxy-guard": "node scripts/next-proxy-guard.mjs",
-    "pre-push": "pnpm run next:proxy-guard && pnpm run tailwind:check && pnpm run typecheck && pnpm run lint",
+    "pre-push": "pnpm run next:proxy-guard && pnpm run tailwind:check && pnpm run typecheck",
     "ship": "pnpm run migration:guard && pnpm run migration:validate && pnpm run drizzle:migrate && pnpm run drizzle:check && pnpm run typecheck && pnpm run lint && pnpm run test",
     "ship:pr": "tsx scripts/ship-pr.ts",
     "check": "pnpm run validate && pnpm run build && pnpm run test",

--- a/docs/NO_MISTAKES_GATE.md
+++ b/docs/NO_MISTAKES_GATE.md
@@ -17,7 +17,7 @@ Repo-specific commands live in `.no-mistakes.yaml` and delegate to `scripts/hook
 
 | Step | Command | What it runs |
 | --- | --- | --- |
-| **lint** | `bash scripts/hooks/pre-push-gate.sh lint` | `pnpm run pre-push` (biome + proxy-guard + tailwind + typecheck + lint) |
+| **lint** | `bash scripts/hooks/pre-push-gate.sh lint` | `pnpm run pre-push`: biome check on changed files (full `biome check .` when no base ref), then proxy-guard + tailwind + typecheck. The single scoped biome step covers lint+format; the web `pre-push` no longer re-runs a repo-wide `biome lint .`. |
 | **test** | `bash scripts/hooks/pre-push-gate.sh test` | `pnpm --filter=@jovie/web run test:fast` |
 | **format** | `bash scripts/hooks/pre-push-gate.sh format` | `pnpm biome check --write .` |
 

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "prepare": "husky",
     "next:proxy-guard": "pnpm --filter=@jovie/web run next:proxy-guard",
     "typecheck:web:fast": "pnpm --filter @jovie/web run typecheck -- --pretty false",
-    "pre-push": "biome check . && pnpm --filter=@jovie/web run pre-push",
+    "pre-push": "bash scripts/hooks/biome-pre-push.sh && pnpm --filter=@jovie/web run pre-push",
     "pre-push:gate": "bash scripts/hooks/pre-push-gate.sh lint",
     "pre-push:gate:test": "bash scripts/hooks/pre-push-gate.sh test",
     "pre-push:gate:format": "bash scripts/hooks/pre-push-gate.sh format",

--- a/scripts/hooks/biome-pre-push.sh
+++ b/scripts/hooks/biome-pre-push.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Pre-push Biome check, scoped to the files this branch changed.
+#
+# Why scoped (gh#12475): the old repo-wide `biome check .` failed the pre-push
+# gate on PRE-EXISTING drift in files a branch never touched (apps/web/app/
+# globals.css, apps/web/styles/design-system.css, the biome.json schema pin).
+# A perpetually-red gate just trains everyone to reach for
+# JOVIE_SKIP_PRE_PUSH_GATE=1, which defeats the gate. CI already scopes Biome to
+# changed files (.github/workflows/ci.yml `ci-biome`), so this mirrors CI: you
+# only answer for what you changed.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+BIOME="$REPO_ROOT/node_modules/.bin/biome"
+
+# Pick the freshest available base ref to diff against. Skip any ref that points
+# at HEAD (e.g. pushing `main` itself with no `origin/main`): diffing HEAD
+# against HEAD finds nothing and would silently skip the commits being pushed.
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE=""
+for ref in origin/main main; do
+  if git rev-parse --verify -q "$ref" >/dev/null &&
+    [[ "$(git rev-parse "$ref")" != "$HEAD_SHA" ]]; then
+    BASE="$ref"
+    break
+  fi
+done
+
+if [[ -z "$BASE" ]]; then
+  # No usable base ref (shallow/detached clone, or base == HEAD) — fall back to a
+  # full check rather than silently linting nothing.
+  echo "[biome-pre-push] no usable base ref; checking whole repo"
+  exec "$BIOME" check .
+fi
+
+echo "[biome-pre-push] checking files changed since $BASE"
+# --changed diffs committed snapshots vs $BASE (matches CI), so uncommitted
+# working-tree edits are linted once committed — i.e. before they can be pushed.
+exec "$BIOME" check --changed --since="$BASE" --no-errors-on-unmatched .


### PR DESCRIPTION
Closes #12475

## Problem

The local pre-push gate ran repo-wide Biome in **two** places, both of which failed on **pre-existing drift on `main`** in files a branch never touched:

1. Root `pnpm run pre-push` → `biome check .` → 18 errors across `biome.json` (schema pin + deprecated `recommended`), `apps/web/tests/setup.ts` (organizeImports), `apps/web/app/globals.css` + `apps/web/styles/design-system.css` (format).
2. Web `pre-push` → `pnpm run lint` → `biome lint .` → 15 `a11y/noSvgWithoutTitle` errors on static `apps/web/public/**` SVGs.

CI never hits this: `ci-biome` scopes Biome to **changed files** on PRs (`.github/workflows/ci.yml`), and no merge-gate runs a repo-wide `biome lint .`. So a clean `origin/main` checkout could not `git push` from any worktree without the `JOVIE_SKIP_PRE_PUSH_GATE=1` escape hatch — which trains everyone to bypass the gate entirely.

## Fix (scope to changed files — the issue's accepted resolution)

Reformatting 14k lines of guarded design-token CSS + 15 static SVGs is a large, risky, taste-touching diff; scoping the gate is the durable fix and matches CI.

- **New `scripts/hooks/biome-pre-push.sh`** runs `biome check --changed --since=<base> --no-errors-on-unmatched .` against `origin/main` (fallback `main`, fallback full `biome check .`). It skips any base ref that points **at HEAD** so the commits being pushed are never silently skipped (caught in review).
- **`package.json`** `pre-push`: `biome check .` → `bash scripts/hooks/biome-pre-push.sh`.
- **`apps/web/package.json`** `pre-push`: drop the redundant repo-wide `&& pnpm run lint`. The root scoped `biome check` already lints changed files (a superset of `biome lint`), so changed-file coverage is unchanged — only the repo-wide pre-existing-drift failures go away.
- Doc + `[internal]` changelog note.

The single biome step now lives at the root gate, scoped; the web `pre-push` keeps proxy-guard + tailwind + typecheck.

## Verification

**End-to-end (the real proof):** this branch **pushed successfully through the unmodified pre-push hook** — scoped biome ✅ → proxy-guard ✅ → tailwind:check ✅ → typecheck ✅ — with no skip env var.

Helper behavior (manually verified):

| Scenario | Result |
|---|---|
| Clean tree (no committed diff vs `origin/main`) | `Checked 0 files` → exit 0 ✅ |
| Changed clean file (package.json) | checked → exit 0 ✅ |
| Changed file with `useConst`/format violation | `Found 2 errors` → **exit 1** ✅ (still catches) |
| Pre-existing drift files untouched (design-system.css etc.) | **not in the checked set** ✅ |
| Base ref == HEAD (e.g. pushing `main`, no `origin/main`) | falls back to full `biome check .` (never silently skips) ✅ |

`shellcheck scripts/hooks/biome-pre-push.sh` clean. `biome check` clean on all changed files. CodeRabbit local review (`--agent -c AGENTS.md -t uncommitted`): the one `major` (base-ref==HEAD silent-skip) and one `minor` (doc) findings are both addressed.

## Follow-up

The pre-existing Biome drift on `main` (the CSS format, `biome.json` schema/deprecation, `setup.ts` organizeImports, and the 15 SVG `noSvgWithoutTitle`) is **not** fixed here — it's intentionally left to whoever next touches those files (who now owns it, same as CI). CSS isn't even in CI's changed-file glob. Tracking issue filed: see comment below.

## Cost Impact

None. No new external calls, cron, or scheduled work — local dev-hook scoping only.