### PR TITLE
fix(web): guard paid usage counts regression and surface stale state (#11365)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
@@ -260,6 +260,7 @@ export function SettingsUsageStatsSection() {
   const copy = getChatUsageCopy(data);
   const showUpgradeCta = copy.state !== 'healthy';
   const monthly = getMonthlyUsage(data);
+  const isStale = data._stale === true;
 
   return (
     <UsagePanelShell>
@@ -293,6 +294,18 @@ export function SettingsUsageStatsSection() {
             </Button>
           ))}
       </div>
+
+      {isStale ? (
+        <div className='border-b border-(--linear-app-frame-seam) px-4 py-3.5 sm:px-5'>
+          <div className='flex items-start gap-2 text-warning'>
+            <AlertCircle className='mt-0.5 h-4 w-4 shrink-0' aria-hidden />
+            <p className='text-app leading-[18px]'>
+              Usage counts may be cached while billing syncs. Refresh in a
+              moment for the latest quota.
+            </p>
+          </div>
+        </div>
+      ) : null}
 
       <div className='divide-y divide-(--linear-app-frame-seam)'>
         <UsageMeterRow

--- a/apps/web/lib/queries/useChatUsageQuery.ts
+++ b/apps/web/lib/queries/useChatUsageQuery.ts
@@ -18,6 +18,8 @@ export interface ChatUsageData {
   isExhausted: boolean;
   warningThreshold: number;
   isNearLimit: boolean;
+  /** Present when billing was unavailable and the snapshot is cached or degraded. */
+  _stale?: boolean;
 }
 
 const fetchChatUsage = createQueryFn<ChatUsageData>('/api/chat/usage');

--- a/apps/web/tests/unit/api/chat/usage.test.ts
+++ b/apps/web/tests/unit/api/chat/usage.test.ts
@@ -139,6 +139,30 @@ describe('GET /api/chat/usage', () => {
     expect(body.remaining).toBe(88);
   });
 
+  it('returns pro limits for isPro rows with missing raw plan via entitlements (#11365)', async () => {
+    // Pre-fix route used resolveChatUsagePlan(billing.data?.plan), which maps null →
+    // free (10/day). Paid users with isPro=true but no plan string saw wrong/blank meters.
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue({
+      ...makeEntitlements({ plan: 'pro' }),
+      billingPlanMismatch: {
+        rawPlan: null,
+        normalizedPlan: 'pro',
+        reason: 'is_pro_true_with_non_paid_plan',
+      },
+    });
+    hoisted.getStatusMock.mockReturnValue({ remaining: 42, resetTime: 0 });
+
+    const { GET } = await import('@/app/api/chat/usage/route');
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.plan).toBe('pro');
+    expect(body.dailyLimit).toBe(100);
+    expect(body.used).toBe(58);
+    expect(body.remaining).toBe(42);
+  });
+
   it('returns degraded usage when billing is unavailable and no cache', async () => {
     hoisted.getCurrentUserEntitlementsMock.mockResolvedValue(
       makeEntitlements({

--- a/apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx
+++ b/apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx
@@ -116,6 +116,26 @@ describe('SettingsUsageStatsSection', () => {
     expect(screen.getByText('286 left')).toBeInTheDocument();
   });
 
+  it('surfaces a stale warning when usage data is degraded', () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: {
+        ...baseUsage,
+        plan: 'pro',
+        dailyLimit: 100,
+        _stale: true,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<SettingsUsageStatsSection />);
+
+    expect(
+      screen.getByText(/usage counts may be cached while billing syncs/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+  });
+
   it('renders pro plan state and plan action when near the limit', () => {
     mockUseChatUsageQuery.mockReturnValue({
       data: {


### PR DESCRIPTION
Fixes #11365

## Root cause

The chat usage API previously resolved plans from raw billing rows (`resolveChatUsagePlan(billing.data?.plan)`). When a paid user had `isPro=true` but a null/missing `plan` string (billing drift), the API mapped them to the free tier (10 messages/day). Combined with 503 responses when billing lookup failed, the settings usage panel and header indicator showed blank/error states instead of real counts.

JOV-3339 (#12060) already fixed the API to use `getCurrentUserEntitlements()` and degrade gracefully. This PR adds the #11365 guardrails on top.

## Changes

- Type `_stale` on `ChatUsageData` for cached/degraded snapshots
- Show a warning banner in `SettingsUsageStatsSection` when usage data is stale
- Add regression test: isPro + null raw plan → pro limits (100/day)
- Add UI test for stale warning banner

## Verification

- `pnpm --filter web exec vitest run tests/unit/api/chat/usage.test.ts tests/unit/dashboard/SettingsUsageStatsSection.test.tsx tests/unit/dashboard/HeaderChatUsageIndicator.test.tsx` — 20/20 passed
- `pnpm biome check --write` on changed files — exit 0
- `pnpm --filter @jovie/web run typecheck` — exit 0

bug-to-test: regression tests added in usage.test.ts and SettingsUsageStatsSection.test.tsx

<!-- linear-issue-id:JOV-3339 -->