### PR TITLE
fix(chat): align Top Signals count with rendered preview (#11368)

### DIFF
--- a/apps/web/components/jovie/components/ChatAnalyticsCard.tsx
+++ b/apps/web/components/jovie/components/ChatAnalyticsCard.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { Sparkles } from 'lucide-react';
+import { ChevronRight, Sparkles } from 'lucide-react';
+import Link from 'next/link';
 import { InsightCategoryIcon } from '@/components/features/dashboard/insights/InsightCategoryIcon';
+import { APP_ROUTES } from '@/constants/routes';
 import { cn } from '@/lib/utils';
 import type { ChatInsightsToolResult } from '../types';
 
@@ -9,10 +11,26 @@ interface ChatAnalyticsCardProps {
   readonly result: ChatInsightsToolResult;
 }
 
+export function formatChatActiveSignalsLabel(
+  displayedCount: number,
+  totalActive: number
+): string {
+  const signalWord = totalActive === 1 ? 'signal' : 'signals';
+
+  if (displayedCount < totalActive) {
+    return `Showing ${displayedCount} of ${totalActive} active ${signalWord}`;
+  }
+
+  return `${totalActive} active ${signalWord}`;
+}
+
 export function ChatAnalyticsCard({ result }: ChatAnalyticsCardProps) {
   if (!result.success || result.insights.length === 0) {
     return null;
   }
+
+  const displayedCount = result.insights.length;
+  const hasMoreSignals = displayedCount < result.totalActive;
 
   return (
     <section
@@ -20,19 +38,32 @@ export function ChatAnalyticsCard({ result }: ChatAnalyticsCardProps) {
       data-testid='chat-analytics-card'
       aria-label={result.title}
     >
-      <div className='flex items-start gap-3'>
-        <div className='flex h-5 w-5 shrink-0 items-center justify-center text-tertiary-token'>
-          <Sparkles className='h-4 w-4' strokeWidth={2.2} />
+      <div className='flex items-start justify-between gap-3'>
+        <div className='flex min-w-0 items-start gap-3'>
+          <div className='flex h-5 w-5 shrink-0 items-center justify-center text-tertiary-token'>
+            <Sparkles className='h-4 w-4' strokeWidth={2.2} />
+          </div>
+          <div className='min-w-0'>
+            <p className='text-sm font-semibold leading-5 text-primary-token'>
+              {result.title}
+            </p>
+            <p
+              className='mt-1 text-xs leading-5 text-tertiary-token'
+              data-testid='chat-analytics-signal-count'
+            >
+              {formatChatActiveSignalsLabel(displayedCount, result.totalActive)}
+            </p>
+          </div>
         </div>
-        <div className='min-w-0'>
-          <p className='text-sm font-semibold leading-5 text-primary-token'>
-            {result.title}
-          </p>
-          <p className='mt-1 text-xs leading-5 text-tertiary-token'>
-            {result.totalActive} active{' '}
-            {result.totalActive === 1 ? 'signal' : 'signals'}
-          </p>
-        </div>
+        {hasMoreSignals ? (
+          <Link
+            href={APP_ROUTES.INSIGHTS}
+            className='inline-flex shrink-0 items-center gap-1 rounded-lg border border-transparent px-1.5 py-1 text-2xs font-caption text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-primary-token'
+          >
+            <span>View all</span>
+            <ChevronRight className='h-3 w-3' aria-hidden='true' />
+          </Link>
+        ) : null}
       </div>
 
       <ul

--- a/apps/web/tests/unit/chat/ChatAnalyticsCard.test.tsx
+++ b/apps/web/tests/unit/chat/ChatAnalyticsCard.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import {
+  ChatAnalyticsCard,
+  formatChatActiveSignalsLabel,
+} from '@/components/jovie/components/ChatAnalyticsCard';
+import type { ChatInsightsToolResult } from '@/components/jovie/types';
+import type { InsightResponse } from '@/types/insights';
+
+function createInsight(
+  overrides: Partial<InsightResponse> = {}
+): InsightResponse {
+  return {
+    id: 'insight-1',
+    insightType: 'city_growth',
+    category: 'growth',
+    priority: 'high',
+    title: 'Fans in Austin are trending up',
+    description: 'Austin traffic increased week over week.',
+    actionSuggestion: 'Schedule a show announcement for Austin.',
+    confidence: '0.87',
+    status: 'active',
+    periodStart: '2026-03-01T00:00:00.000Z',
+    periodEnd: '2026-03-07T00:00:00.000Z',
+    createdAt: '2026-03-08T00:00:00.000Z',
+    expiresAt: '2026-03-15T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createResult(
+  overrides: Partial<ChatInsightsToolResult> = {}
+): ChatInsightsToolResult {
+  return {
+    success: true,
+    title: 'Top signals',
+    totalActive: 1,
+    insights: [createInsight()],
+    ...overrides,
+  };
+}
+
+describe('formatChatActiveSignalsLabel', () => {
+  it('uses the total count when every rendered signal is shown', () => {
+    expect(formatChatActiveSignalsLabel(3, 3)).toBe('3 active signals');
+    expect(formatChatActiveSignalsLabel(1, 1)).toBe('1 active signal');
+  });
+
+  it('clarifies preview truncation when the list shows fewer than total active', () => {
+    expect(formatChatActiveSignalsLabel(3, 99)).toBe(
+      'Showing 3 of 99 active signals'
+    );
+    expect(formatChatActiveSignalsLabel(1, 2)).toBe(
+      'Showing 1 of 2 active signals'
+    );
+  });
+});
+
+describe('ChatAnalyticsCard', () => {
+  it('renders nothing when there are no insights to show', () => {
+    const { container } = render(
+      <ChatAnalyticsCard
+        result={createResult({ success: false, insights: [], totalActive: 99 })}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows a matching count when all active signals are rendered', () => {
+    render(
+      <ChatAnalyticsCard
+        result={createResult({
+          totalActive: 2,
+          insights: [
+            createInsight({ id: 'insight-1' }),
+            createInsight({
+              id: 'insight-2',
+              title: 'Chicago listeners are surging',
+            }),
+          ],
+        })}
+      />
+    );
+
+    expect(screen.getByTestId('chat-analytics-signal-count')).toHaveTextContent(
+      '2 active signals'
+    );
+    expect(screen.queryByRole('link', { name: /View all/i })).toBeNull();
+    expect(screen.getAllByTestId('chat-analytics-signal-card')).toHaveLength(2);
+  });
+
+  it('shows a truncated preview label and view-all path when only top signals render', () => {
+    render(
+      <ChatAnalyticsCard
+        result={createResult({
+          totalActive: 99,
+          insights: [
+            createInsight({ id: 'insight-1' }),
+            createInsight({
+              id: 'insight-2',
+              title: 'Chicago listeners are surging',
+            }),
+            createInsight({
+              id: 'insight-3',
+              title: 'Spotify saves are climbing',
+            }),
+          ],
+        })}
+      />
+    );
+
+    expect(screen.getByTestId('chat-analytics-signal-count')).toHaveTextContent(
+      'Showing 3 of 99 active signals'
+    );
+    expect(screen.getAllByTestId('chat-analytics-signal-card')).toHaveLength(3);
+    expect(screen.getByRole('link', { name: /View all/i })).toHaveAttribute(
+      'href',
+      '/app/insights'
+    );
+  });
+});

--- a/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
@@ -25,6 +25,12 @@ vi.mock('@jovie/ui', () => ({
   SimpleTooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
 vi.mock('next/dynamic', () => ({
   default:
     () =>
@@ -99,6 +105,13 @@ describe('ChatMessage analytics cards', () => {
     expect(signalCard).toBeTruthy();
     expect(signalCard.className).toContain('min-w-[min(20rem,84vw)]');
     expect(screen.getByText('Top signals')).toBeTruthy();
+    expect(screen.getByTestId('chat-analytics-signal-count')).toHaveTextContent(
+      'Showing 1 of 2 active signals'
+    );
+    expect(screen.getByRole('link', { name: /View all/i })).toHaveAttribute(
+      'href',
+      '/app/insights'
+    );
     expect(
       screen.getByText('Subscribers are picking up in Chicago')
     ).toBeTruthy();


### PR DESCRIPTION
Fixes #11368

## Problem
The `showTopInsights` chat tool returns the full active-signal count (`totalActive`) alongside a top-3 preview slice. `ChatAnalyticsCard` displayed the total ("99 active signals") while rendering only the preview cards, creating a credibility-breaking mismatch.

## Root cause
`getInsightsSummary()` intentionally returns `totalActive` = DB count and `insights` = top 3 after dedup/sort. The UI showed the total without indicating truncation.

## Fix
- Show **"Showing N of M active signals"** when the preview is truncated
- Show **"N active signals"** when all rendered signals are shown
- Add **View all** link to `/app/insights` when truncated (matches dashboard widget pattern)

## Tests
- New `ChatAnalyticsCard.test.tsx` — regression for 3-of-99 mismatch + matching counts
- Updated `ChatMessage.analytics-card.test.tsx` — integration assertion

```bash
npx vitest run tests/unit/chat/ChatAnalyticsCard.test.tsx tests/unit/chat/ChatMessage.analytics-card.test.tsx
# 8 passed
```

## Bug-to-test
Regression tests added in `ChatAnalyticsCard.test.tsx`.

## Risk
Low — UI-only; no API/schema changes.