### PR TITLE
chore: prod bug: editing artist profile in chat triggers a full-page refresh mi (#11367)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/links/hooks/useProfileEditor.ts
+++ b/apps/web/components/features/dashboard/organisms/links/hooks/useProfileEditor.ts
@@ -8,7 +8,6 @@
  * debounced auto-save.
  */
 
-import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
@@ -110,7 +109,6 @@ export function useProfileEditor(
   options: UseProfileEditorOptions = {}
 ): UseProfileEditorReturn {
   const { debounceMs = PACER_TIMING.SAVE_DEBOUNCE_MS } = options;
-  const router = useRouter();
   const dashboardData = useDashboardData();
 
   // Profile mutation hooks
@@ -149,6 +147,7 @@ export function useProfileEditor(
     displayName: string;
     username: string;
   } | null>(null);
+  const wasEditingRef = useRef(false);
 
   // Track pending save data for comparison
   const pendingDataRef = useRef<{
@@ -229,8 +228,6 @@ export function useProfileEditor(
         if (result.warning) {
           toast.message(result.warning);
         }
-
-        router.refresh();
       } catch (error) {
         const message =
           error instanceof Error ? error.message : 'Failed to update profile';
@@ -249,7 +246,6 @@ export function useProfileEditor(
       artist?.name,
       profileId,
       profileMutation,
-      router,
     ]
   );
   /* eslint-enable react-hooks/preserve-manual-memoization */
@@ -277,7 +273,10 @@ export function useProfileEditor(
     };
   }, [profileSaveStatus.success]);
 
-  // Sync state when selected profile changes
+  // Sync state when selected profile changes. Skip while inline editing so a
+  // server re-render cannot clobber in-progress keystrokes (chat profile rail).
+  // Also skip display/username adoption when exiting edit — the server snapshot
+  // may still be stale while auto-save has the typed value.
   useEffect(() => {
     if (!dashboardData.selectedProfile) {
       setArtist(null);
@@ -285,26 +284,39 @@ export function useProfileEditor(
       setProfileUsername('');
       setEditingField(null);
       lastProfileSavedRef.current = null;
+      wasEditingRef.current = false;
+      return;
+    }
+
+    const wasEditing = wasEditingRef.current;
+
+    if (editingField !== null) {
+      wasEditingRef.current = true;
       return;
     }
 
     setArtist(
       convertDrizzleCreatorProfileToArtist(dashboardData.selectedProfile)
     );
-    setProfileDisplayName(dashboardData.selectedProfile.displayName ?? '');
-    setProfileUsername(dashboardData.selectedProfile.username ?? '');
 
-    lastProfileSavedRef.current = {
-      displayName: dashboardData.selectedProfile.displayName ?? '',
-      username: dashboardData.selectedProfile.username ?? '',
-    };
-    setProfileSaveStatus({
-      saving: false,
-      success: null,
-      error: null,
-      lastSaved: null,
-    });
-  }, [dashboardData.selectedProfile]);
+    if (!wasEditing) {
+      setProfileDisplayName(dashboardData.selectedProfile.displayName ?? '');
+      setProfileUsername(dashboardData.selectedProfile.username ?? '');
+
+      lastProfileSavedRef.current = {
+        displayName: dashboardData.selectedProfile.displayName ?? '',
+        username: dashboardData.selectedProfile.username ?? '',
+      };
+      setProfileSaveStatus({
+        saving: false,
+        success: null,
+        error: null,
+        lastSaved: null,
+      });
+    }
+
+    wasEditingRef.current = false;
+  }, [dashboardData.selectedProfile, editingField]);
 
   // Focus input when entering edit mode
   useEffect(() => {
@@ -331,10 +343,9 @@ export function useProfileEditor(
       const avatarUrl = await avatarMutation.mutateAsync(file);
       setArtist(prev => (prev ? { ...prev, image_url: avatarUrl } : prev));
       toast.success('Profile photo updated');
-      router.refresh();
       return avatarUrl;
     },
-    [avatarMutation, router]
+    [avatarMutation]
   );
 
   // Handle display name change with auto-save

--- a/apps/web/components/features/profile/profile-surface-state.ts
+++ b/apps/web/components/features/profile/profile-surface-state.ts
@@ -290,7 +290,8 @@ export function resolveProfileSurfaceState(params: {
     : rawHeroImageUrl;
   const releaseVisibility = getProfileReleaseVisibility(
     latestRelease,
-    profileSettings
+    profileSettings,
+    now
   );
   const latestVisibleRelease =
     releaseVisibility?.show && latestRelease ? latestRelease : null;

--- a/apps/web/tests/unit/dashboard/useProfileEditor.test.tsx
+++ b/apps/web/tests/unit/dashboard/useProfileEditor.test.tsx
@@ -1,0 +1,149 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useProfileEditor } from '@/components/features/dashboard/organisms/links/hooks/useProfileEditor';
+
+const mockRefresh = vi.fn();
+const mockMutateAsync = vi.fn();
+
+const dashboardData = {
+  selectedProfile: {
+    id: 'profile_chat_1',
+    displayName: 'Original Name',
+    username: 'original-handle',
+    creatorType: 'artist' as const,
+  },
+};
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+  }),
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
+  useDashboardData: () => dashboardData,
+}));
+
+vi.mock('@/lib/queries', () => ({
+  useProfileSaveMutation: () => ({
+    mutateAsync: mockMutateAsync,
+  }),
+  useAvatarMutation: () => ({
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/pacer/hooks/useAutoSave', () => ({
+  useAutoSave: ({
+    saveFn,
+  }: {
+    saveFn: (data: { displayName: string; username: string }) => Promise<void>;
+  }) => ({
+    save: (data: { displayName: string; username: string }) => {
+      void saveFn(data);
+    },
+    flush: async () => {},
+    cancel: () => {},
+  }),
+}));
+
+vi.mock('@/types/db', () => ({
+  convertDrizzleCreatorProfileToArtist: vi.fn(profile => ({
+    id: profile.id,
+    owner_user_id: 'user_123',
+    handle: profile.username,
+    spotify_id: '',
+    name: profile.displayName,
+    image_url: undefined,
+    tagline: undefined,
+    theme: undefined,
+    settings: { hide_branding: false },
+    spotify_url: undefined,
+    apple_music_url: undefined,
+    youtube_url: undefined,
+    venmo_handle: undefined,
+    published: true,
+    is_verified: false,
+    is_featured: false,
+    marketing_opt_out: false,
+    created_at: new Date().toISOString(),
+  })),
+}));
+
+describe('useProfileEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dashboardData.selectedProfile = {
+      id: 'profile_chat_1',
+      displayName: 'Original Name',
+      username: 'original-handle',
+      creatorType: 'artist',
+    };
+    mockMutateAsync.mockResolvedValue({
+      profile: {
+        id: dashboardData.selectedProfile.id,
+        displayName: 'Updated Name',
+        username: dashboardData.selectedProfile.username,
+        avatarUrl: null,
+        creatorType: 'artist',
+        isPublic: true,
+      },
+    });
+  });
+
+  it('does not call router.refresh after profile auto-save', async () => {
+    const { result } = renderHook(() => useProfileEditor({ debounceMs: 100 }));
+
+    await act(async () => {
+      result.current.setEditingField('displayName');
+      result.current.handleDisplayNameChange('Updated Name');
+      await Promise.resolve();
+    });
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      updates: {
+        displayName: 'Updated Name',
+        username: dashboardData.selectedProfile.username,
+      },
+    });
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does not reset in-progress display name when selectedProfile changes during edit', async () => {
+    const { result, rerender } = renderHook(() =>
+      useProfileEditor({ debounceMs: 100 })
+    );
+
+    act(() => {
+      result.current.setEditingField('displayName');
+      result.current.handleDisplayNameChange('Typing In Progress');
+    });
+
+    expect(result.current.profileDisplayName).toBe('Typing In Progress');
+
+    dashboardData.selectedProfile = {
+      ...dashboardData.selectedProfile,
+      displayName: 'Server Snapshot',
+    };
+    rerender();
+
+    expect(result.current.profileDisplayName).toBe('Typing In Progress');
+    expect(mockRefresh).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleInputBlur();
+    });
+
+    expect(result.current.profileDisplayName).toBe('Typing In Progress');
+    expect(result.current.editingField).toBeNull();
+  });
+});


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (grok-composer-2.5-fast). Closes #11367.

Card: t_d90bb971
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- client console errors + render of affected pages
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.