### PR TITLE
docs(ci): record PR Size Guard as a required check on main (#12131)

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -4,20 +4,22 @@ This document tracks the required CI checks for the `main` branch.
 
 ## Current Configuration
 
-**Last Updated**: 2026-02-10
+**Last Updated**: 2026-06-29
 
 ### Required Status Checks
 
-The following checks must pass before merging to `main`:
+The following check contexts must pass before merging to `main`. This list
+mirrors ruleset 10512119 — verify with:
 
-1. **Lint** - Code quality linting
-2. **Env Example Guard** - Prevents secret leaks in .env.example
-3. **Typecheck** - TypeScript type safety validation
-4. **Guardrails (proxy + format)** - Code formatting + Next.js proxy security
-5. **ci-fast** - Meta-gate aggregating fast checks
-6. **Migration Guard** - Database migration validation
-7. **CodeQL** - SAST security scanning
-8. **A11y (axe)** - WCAG 2.1 AA accessibility audit on public routes (via `ci-pr-ready` gate)
+```bash
+gh api repos/JovieInc/Jovie/rulesets/10512119 \
+  --jq '.rules[]|select(.type=="required_status_checks")|.parameters.required_status_checks[].context'
+```
+
+1. **PR Ready** - Aggregate fast lane (`ci-fast`: typecheck + biome lint + server boundaries + guardrails)
+2. **Migration Guard** - Database migration validation (path-gated to DB/schema changes)
+3. **Fork PR Gate** - Blocks unreviewed external fork PRs; auto-passes for agents + team
+4. **PR Size Guard** - Caps PR size (800 lines / 40 files) to force small, reviewable PRs; `big-pr` label opts out
 
 ### Configuration Details
 
@@ -52,6 +54,10 @@ Full configuration is tracked in `/Users/timwhite/.claude/plans/glistening-dazzl
 
 ## History
 
+- **2026-06-29**: Added **PR Size Guard** to required status checks (ruleset 10512119, GH #12131)
+  - Caps PRs at 800 lines / 40 files (repo vars `PR_MAX_LINES` / `PR_MAX_FILES`); `big-pr` label opts out
+  - Closes the gap where oversized PRs could merge despite the size-guard workflow failing
+  - Also refreshed the required-checks list above to the current aggregate gates (PR Ready / Migration Guard / Fork PR Gate / PR Size Guard); the prior list predated the `PR Ready` aggregation
 - **2026-02-10**: Added A11y (axe) check to `ci-pr-ready` gate
   - Runs axe-core WCAG 2.1 AA audit on 5 public routes (no auth needed)
   - Path-gated: skips when no UI-relevant files changed

--- a/.github/rulesets/branch-protection.yml
+++ b/.github/rulesets/branch-protection.yml
@@ -39,7 +39,8 @@
 #    When agent-remediation pushes a fix, old informational approvals
 #    are dismissed. This keeps the audit trail accurate.
 #
-# 4. Simplified status checks: only PR Ready + Migration Guard
+# 4. Simplified status checks: PR Ready + Migration Guard + Fork PR Gate
+#    + PR Size Guard (the full live required set on ruleset 10512119).
 #    PR Ready aggregates only the fast deterministic lane:
 #    ci-fast (typecheck + lint + server boundaries + guardrails).
 #    Slower checks run post-merge or in nightly/manual lanes, which keeps
@@ -112,6 +113,13 @@ rules:
         # Blocks fork PRs from external contributors until a human
         # collaborator submits an APPROVE review. See design decision #7.
         - context: 'Fork PR Gate'
+
+        # PR Size Guard: Caps PR size (800 lines / 40 files, tunable via repo
+        # vars PR_MAX_LINES / PR_MAX_FILES) to force small, reviewable PRs.
+        # Runs as its own workflow (.github/workflows/pr-size-guard.yml), so
+        # the live context is the bare job name with no "CI /" prefix. Approved
+        # mechanical codemods opt out with the `big-pr` label.
+        - context: 'PR Size Guard'
 
   # ── Merge Queue: Graphite (not GitHub-native) ──────────────────────────
   # The native `merge_queue` rule was retired 2026-06-18 — Graphite owns the


### PR DESCRIPTION
<!-- linear-issue-id: none -->
Closes #12131

## What & why

Issue #12131 asked a repo/org admin to add the **`PR Size Guard`** required status check to GitHub ruleset **10512119** (main branch protection). That admin step has since been completed — **the check is already enforced live**. This PR only closes the resulting repo drift: two reference/tracking docs still listed the old required-checks set and didn't mention `PR Size Guard`.

The actual gate (live ruleset) is the source of truth. **Neither edited file is auto-applied** by any workflow (grep of `.github/workflows/` finds nothing that consumes `.github/rulesets/branch-protection.yml`) — they are a reference template and a human tracker doc.

## Acceptance criterion — already satisfied live

```
$ gh api repos/JovieInc/Jovie/rulesets/10512119 \
    --jq '.rules[]|select(.type=="required_status_checks")|.parameters.required_status_checks[].context'
PR Ready
Migration Guard
Fork PR Gate
PR Size Guard          ← present
```

The issue's acceptance check (`… returns a list that includes PR Size Guard`) passes. The admin action does **not** need to be repeated.

## Changes (docs only)

- **`.github/rulesets/branch-protection.yml`** — add `- context: 'PR Size Guard'` to the `required_status_checks` list (bare context: it runs as its own workflow `pr-size-guard.yml`, so no `CI /` prefix); refresh the stale design-decision #4 comment to name all four required contexts.
- **`.github/BRANCH_PROTECTION.md`** — replace the pre-aggregation required-checks list (Lint/Typecheck/CodeQL/A11y/…) with the current live set (PR Ready, Migration Guard, Fork PR Gate, PR Size Guard), add the `gh api` verify command, and add a 2026-06-29 history entry.

## Verification

- **Live ruleset read** — confirmed `PR Size Guard` is a required context (output above).
- **YAML parses** and as-code list now resolves to `["CI / PR Ready","CI / Migration Guard","Fork PR Gate","PR Size Guard"]`.
- **CodeRabbit** (`coderabbit review --agent -c AGENTS.md -t uncommitted`): **0 findings**.
- **Review subagent (opus):** ship — context string matches the live job name; dropping CodeQL/Lint/etc. from the doc is accurate (they are not live required contexts).
- **Security subagent (opus):** ship — diff only *adds* one context (nothing removed/weakened); no secret leakage; no workflow applies these files, so no apply risk.

## Bug-to-test
`bug-to-test: waived — docs/control-plane reference files only, no code path changed.`

## Note on the reference `.yml`
`.github/rulesets/branch-protection.yml` is an **aspirational target** (its own comments call for `required_signatures` "after agent signing is configured" and strict status checks), so it is intentionally stricter than the current interim live ruleset on some fields. That is by design, not drift. `PR Size Guard` belongs in both the target and the live config — and after this PR they agree on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)