### PR TITLE
fix(mobile-chat): auto-scroll to newest message on incoming iOS reply

### DIFF
--- a/apps/ios/Jovie/Features/Chat/MobileChatView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatView.swift
@@ -5,6 +5,8 @@ struct MobileChatView: View {
   @Binding var draft: String
   let webBaseURL: URL
 
+  @State private var isAtBottom = true
+
   var body: some View {
     ZStack {
       JovieColor.backgroundBase.ignoresSafeArea()
@@ -13,18 +15,56 @@ struct MobileChatView: View {
         if repository.timeline.isEmpty {
           emptyState
         } else {
-          ScrollView {
-            LazyVStack(alignment: .leading, spacing: JovieSpacing.large) {
-              ForEach(repository.timeline) { item in
-                MobileChatMessageRow(item: item, webBaseURL: webBaseURL) {
-                  guard let clientTurnId = item.clientTurnId else { return }
-                  Task { await repository.retry(clientTurnId: clientTurnId) }
+          ScrollViewReader { proxy in
+            ScrollView {
+              LazyVStack(alignment: .leading, spacing: JovieSpacing.large) {
+                ForEach(repository.timeline) { item in
+                  MobileChatMessageRow(item: item, webBaseURL: webBaseURL) {
+                    guard let clientTurnId = item.clientTurnId else { return }
+                    Task { await repository.retry(clientTurnId: clientTurnId) }
+                  }
                 }
               }
+              .padding(.horizontal, JovieSpacing.large)
+              .padding(.top, JovieSpacing.xLarge)
+              .padding(.bottom, JovieSpacing.medium)
+
+              // ponytail: onAppear/onDisappear of this sentinel tracks whether the user is near
+              // the bottom without needing coordinate-space math
+              Color.clear
+                .frame(height: 1)
+                .id("chat-bottom")
+                .onAppear { isAtBottom = true }
+                .onDisappear { isAtBottom = false }
             }
-            .padding(.horizontal, JovieSpacing.large)
-            .padding(.top, JovieSpacing.xLarge)
-            .padding(.bottom, JovieSpacing.medium)
+            .onChange(of: repository.timeline.count) {
+              guard isAtBottom else { return }
+              withAnimation(.easeOut(duration: 0.25)) {
+                proxy.scrollTo("chat-bottom", anchor: .bottom)
+              }
+            }
+            .onChange(of: repository.timeline.last?.content) {
+              guard isAtBottom else { return }
+              proxy.scrollTo("chat-bottom", anchor: .bottom)
+            }
+            .overlay(alignment: .bottomTrailing) {
+              if !isAtBottom {
+                Button {
+                  isAtBottom = true
+                  withAnimation(.easeOut(duration: 0.25)) {
+                    proxy.scrollTo("chat-bottom", anchor: .bottom)
+                  }
+                } label: {
+                  Image(systemName: "arrow.down")
+                }
+                .buttonStyle(JovieIconButtonStyle())
+                .padding(.trailing, JovieSpacing.large)
+                .padding(.bottom, JovieSpacing.medium)
+                .transition(.opacity.combined(with: .scale(scale: 0.85)))
+                .animation(.spring(duration: 0.2), value: isAtBottom)
+                .accessibilityLabel("Scroll to latest message")
+              }
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

- Wraps the `ScrollView` in `MobileChatView` with a `ScrollViewReader` and places an invisible 1pt sentinel (`Color.clear`) at the end of the message list
- `onAppear`/`onDisappear` on the sentinel tracks whether the user is at the bottom (`isAtBottom` state)
- New messages auto-scroll into view via `onChange(of: timeline.count)` (animated) when `isAtBottom == true`
- Streaming tokens maintain bottom position via `onChange(of: timeline.last?.content)` (no animation to avoid jank)
- Jump-to-latest button (`JovieIconButtonStyle` circle, `arrow.down` SF symbol) overlaid at bottom-trailing, visible only when `!isAtBottom`; tapping returns to bottom

Closes #12128

## Verification

**iOS lint (best-practices guardrails):**
```
iOS best-practices lint: clean ✓
```

**iOS build (xcodebuild):**
```
** BUILD SUCCEEDED **
```

**Testing subagent:** PASS — all acceptance criteria met:
- New messages auto-scroll when user is at/near bottom ✓
- Auto-scroll is suppressed when user has scrolled up ✓
- Jump-to-latest button returns to bottom ✓

**Review subagent:** PASS — no hard invariant violations, no layout shifts, `JovieIconButtonStyle` usage correct, `onChange` signatures correct for iOS 18 ✓

## Test plan

- [ ] Send a message in the iOS chat, verify the assistant reply scrolls into view automatically
- [ ] Scroll up in an active chat, then send a message — verify the auto-scroll is suppressed and the jump button appears
- [ ] Tap the jump button — verify it scrolls to the bottom and disappears
- [ ] Verify streaming tokens flow smoothly without jank when at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)