### PR TITLE
feat(chat): register artist-profile right rail on dashboard home (#12129)

### DIFF
--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
@@ -8,6 +8,14 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/app',
 }));
 
+vi.mock('@/hooks/useRegisterRightPanel', () => ({
+  useRegisterRightPanel: vi.fn(),
+}));
+
+vi.mock('@/features/dashboard/organisms/profile-contact-sidebar', () => ({
+  ProfileContactSidebar: () => null,
+}));
+
 vi.mock('@/lib/queries/useOpportunityInboxMutations', () => ({
   useOpportunityInboxMutations: () => ({
     approveMutation: {
@@ -29,6 +37,18 @@ vi.mock('@/lib/queries/useOpportunityInboxMutations', () => ({
 }));
 
 describe('OpportunityInboxPageClient', () => {
+  it('registers a non-null right panel for the artist-profile rail', async () => {
+    const { useRegisterRightPanel } = await import(
+      '@/hooks/useRegisterRightPanel'
+    );
+    render(
+      <OpportunityInboxPageClient inbox={{ cards: [], emptyActionCards: [] }} />
+    );
+    expect(vi.mocked(useRegisterRightPanel)).toHaveBeenCalledWith(
+      expect.anything()
+    );
+  });
+
   it('renders the inbox feed when cards are present', () => {
     render(
       <OpportunityInboxPageClient

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
@@ -1,11 +1,37 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { usePathname } from 'next/navigation';
 import { useMemo, useState } from 'react';
+import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
+import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import type { OpportunityInboxData } from '@/lib/connectors/opportunity-inbox-types';
 import { useOpportunityInboxMutations } from '@/lib/queries/useOpportunityInboxMutations';
 import { OpportunityInboxEmptyState } from './OpportunityInboxEmptyState';
 import { OpportunityInboxFeed } from './OpportunityInboxFeed';
+
+const ProfileContactSidebar = dynamic(
+  () =>
+    import('@/features/dashboard/organisms/profile-contact-sidebar').then(
+      mod => ({ default: mod.ProfileContactSidebar })
+    ),
+  { ssr: false }
+);
+
+// Registers the artist-profile right rail for the dashboard home route so the
+// ArtistProfileRailToggle in the shell header can animate it open/closed.
+function HomeRightPanelHost() {
+  const panel = useMemo(
+    () => (
+      <ErrorBoundary fallback={null}>
+        <ProfileContactSidebar />
+      </ErrorBoundary>
+    ),
+    []
+  );
+  useRegisterRightPanel(panel);
+  return null;
+}
 
 export interface OpportunityInboxPageClientProps {
   readonly inbox: OpportunityInboxData;
@@ -72,6 +98,7 @@ export function OpportunityInboxPageClient({
       className='system-b-opportunity-inbox-page'
       data-testid='opportunity-inbox-page'
     >
+      <HomeRightPanelHost />
       <header className='system-b-opportunity-inbox-page-header'>
         {/* ui-casing-allow: design-locked inbox copy */}
         <h1 className='system-b-opportunity-inbox-page-title'>


### PR DESCRIPTION
## What

Registers the artist-profile `ProfileContactSidebar` as the right panel for the dashboard home route (`/app`), so the `ArtistProfileRailToggle` button (already rendered in the top-right app-shell header when `DESIGN_V1` is on) animates the panel open/closed with the existing cinematic motion system.

## Why it was broken

`AppShellFrame` conditionally mounts `AppShellRightRail` only when `rightPanel` is non-null.  On chat routes, `ChatEntityRightPanelHost` always registers a `liveProfilePreview` panel → rail is always mounted → `RightDrawer` handles the 420ms cinematic width animation.  On the home route (`/app`), nothing registered a panel, so `rightPanel = null` → `AppShellRightRail` never rendered → clicking the toggle had no visible effect.

## What changed

**`OpportunityInboxPageClient.tsx`** — added a `HomeRightPanelHost` component that:
- Lazy-loads `ProfileContactSidebar` (same pattern as chat, `{ ssr: false }`)
- Wraps in `ErrorBoundary` so a panel crash can't bring down the page
- Calls `useRegisterRightPanel` with a stable memoized panel

**`OpportunityInboxPageClient.test.tsx`** — added mocks for `useRegisterRightPanel` and `ProfileContactSidebar`, plus a regression test that verifies the panel is registered on mount.

## Animation chain (no changes needed)

The cinematic open/close was already fully wired in `RightDrawer`:

```
AppShellRightRail (transition-[width,opacity,transform] duration-cinematic ease-cinematic motion-reduce:transition-none)
  └─ ProfileContactSidebar
       └─ EntitySidebarShell(isOpen from PreviewPanelContext)
            └─ RightDrawer(isOpen, width)
                 style={{ width: isOpen ? width : 0, transitionDuration: hasAnimated ? undefined : '0ms' }}
```

First-paint hydration flash is suppressed via `hasAnimated` + RAF (already in `RightDrawer`). `motion-reduce:transition-none` on `AppShellRightRail` covers the reduced-motion requirement.

## Verification

- 4/4 tests pass (`OpportunityInboxPageClient.test.tsx`)
- 29/29 shell component tests pass (including `AppShellRightRail`, `ArtistProfileRailToggle`)
- TypeCheck: exit 0
- Biome: no errors

Closes #12129