### PR TITLE
feat(desktop): macOS menu bar monitor via Electron Tray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,8 @@ apps/desktop/src/*
 !apps/desktop/src/desktop-security-reporting.ts
 !apps/desktop/src/window-state.ts
 !apps/desktop/src/renderer-recovery.ts
+!apps/desktop/src/tray.ts
+!apps/desktop/scripts/desktop-tray-contract.test.mjs
 apps/extension/
 .agents/
 

--- a/apps/desktop/scripts/desktop-tray-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-tray-contract.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const desktopRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test('tray module exports required types and classes', async () => {
+  const traySource = await readFile(join(desktopRoot, 'src/tray.ts'), 'utf8');
+
+  assert.match(traySource, /export type TrayAppState = 'idle' \| 'active' \| 'unread' \| 'error';/);
+  assert.match(traySource, /export class MenuBarTray/);
+  assert.match(traySource, /export \{ isTrayAppState \}/);
+  assert.match(traySource, /setState\(payload: TrayStatePayload\)/);
+  assert.match(traySource, /destroy\(\)/);
+});
+
+test('main.ts wires tray IPC handler on darwin', async () => {
+  const mainSource = await readFile(join(desktopRoot, 'src/main.ts'), 'utf8');
+
+  assert.match(mainSource, /TRAY_SET_STATE_CHANNEL = 'tray-set-state'/);
+  assert.match(mainSource, /TRAY_ACTION_CHANNEL = 'tray-action'/);
+  // handler may be on next line: ipcMain.handle(\n  TRAY_SET_STATE_CHANNEL,
+  assert.match(mainSource, /ipcMain\.handle\(\s*\n?\s*TRAY_SET_STATE_CHANNEL/);
+  assert.match(mainSource, /process\.platform === 'darwin'/);
+  assert.match(mainSource, /menuBarTray = new MenuBarTray\(/);
+});
+
+test('preload exposes setTrayState and onTrayAction on the bridge', async () => {
+  const preloadSource = await readFile(join(desktopRoot, 'src/preload.ts'), 'utf8');
+
+  assert.match(preloadSource, /TRAY_SET_STATE_CHANNEL = 'tray-set-state'/);
+  assert.match(preloadSource, /TRAY_ACTION_CHANNEL = 'tray-action'/);
+  assert.match(preloadSource, /setTrayState:/);
+  assert.match(preloadSource, /onTrayAction:/);
+  assert.match(preloadSource, /ipcRenderer\.invoke\(TRAY_SET_STATE_CHANNEL/);
+  assert.match(preloadSource, /ipcRenderer\.on\(TRAY_ACTION_CHANNEL/);
+});
+
+test('tray IPC channels match between main and preload', async () => {
+  const [mainSource, preloadSource] = await Promise.all([
+    readFile(join(desktopRoot, 'src/main.ts'), 'utf8'),
+    readFile(join(desktopRoot, 'src/preload.ts'), 'utf8'),
+  ]);
+
+  const extractChannel = (src, name) => {
+    const m = src.match(new RegExp(`${name}\\s*=\\s*'([^']+)'`));
+    return m?.[1];
+  };
+
+  const mainSetState = extractChannel(mainSource, 'TRAY_SET_STATE_CHANNEL');
+  const preloadSetState = extractChannel(preloadSource, 'TRAY_SET_STATE_CHANNEL');
+  const mainAction = extractChannel(mainSource, 'TRAY_ACTION_CHANNEL');
+  const preloadAction = extractChannel(preloadSource, 'TRAY_ACTION_CHANNEL');
+
+  assert.equal(mainSetState, preloadSetState, 'TRAY_SET_STATE_CHANNEL must match');
+  assert.equal(mainAction, preloadAction, 'TRAY_ACTION_CHANNEL must match');
+  assert.equal(mainSetState, 'tray-set-state');
+  assert.equal(mainAction, 'tray-action');
+});

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -11,6 +11,12 @@ import {
   screen,
   shell,
 } from 'electron';
+import {
+  isTrayAppState,
+  MenuBarTray,
+  type TrayAction,
+  type TrayStatePayload,
+} from './tray';
 import { autoUpdater } from 'electron-updater';
 import {
   bindPendingDesktopAuthCompletion,
@@ -89,6 +95,8 @@ const AUTH_RETURN_HOST = 'auth';
 const AUTH_RETURN_COMPLETE_PATH = '/complete';
 const LEGACY_AUTH_RETURN_HOST = 'auth-return';
 const DICTATION_STATUS_CHANNEL = 'dictation-status';
+const TRAY_SET_STATE_CHANNEL = 'tray-set-state';
+const TRAY_ACTION_CHANNEL = 'tray-action';
 const DESKTOP_RUNTIME_LABEL_BY_PLATFORM: Partial<
   Record<NodeJS.Platform, string>
 > = {
@@ -142,6 +150,7 @@ const reportDesktopSecurityEvent = createDesktopSecurityReporter();
 let updateReadyToInstall = false;
 let mainWindow: BrowserWindow | null = null;
 let authHandoffWindow: BrowserWindow | null = null;
+let menuBarTray: MenuBarTray | null = null;
 let pendingAuthCompletion: DesktopAuthCompletion | null = null;
 let recentAuthCompletion: RecentDesktopAuthCompletion | null = null;
 let pendingLegacyAuthReturnRoute: string | null = null;
@@ -1191,6 +1200,21 @@ function buildApplicationMenu(): Menu {
   return Menu.buildFromTemplate(template);
 }
 
+function handleTrayAction(action: TrayAction): void {
+  if (action === 'open-preferences') {
+    openPreferences();
+    return;
+  }
+
+  const win =
+    mainWindow && !mainWindow.isDestroyed() ? mainWindow : createWindow();
+  showWindow(win);
+
+  if (action === 'new-message') {
+    win.webContents.send(TRAY_ACTION_CHANNEL, action);
+  }
+}
+
 function sendToAppWindows(channel: UpdateChannel): void {
   for (const win of BrowserWindow.getAllWindows()) {
     const parsed = parseUrl(win.webContents.getURL());
@@ -1412,6 +1436,12 @@ app.whenReady().then(() => {
 
   registerAuthReturnProtocol();
   refreshApplicationMenu();
+
+  // macOS menu bar extra (NSStatusItem via Electron Tray)
+  if (process.platform === 'darwin') {
+    menuBarTray = new MenuBarTray(handleTrayAction);
+  }
+
   createWindow(
     pendingAuthCompletion
       ? new URL(DESKTOP_AUTH_NATIVE_COMPLETE_PATH, APP_URL).toString()
@@ -1456,5 +1486,24 @@ ipcMain.handle(
     }
 
     return getDesktopDictationStatus();
+  }
+);
+
+ipcMain.handle(
+  TRAY_SET_STATE_CHANNEL,
+  (event: IpcMainInvokeEvent, payload: unknown, ...rest: unknown[]) => {
+    if (!isTrustedIpcSender(event) || rest.length !== 0) {
+      return { ok: false, reason: 'invalid-request' };
+    }
+    if (
+      !menuBarTray ||
+      payload === null ||
+      typeof payload !== 'object' ||
+      !isTrayAppState((payload as Record<string, unknown>).state)
+    ) {
+      return { ok: false, reason: 'invalid-payload' };
+    }
+    menuBarTray.setState(payload as TrayStatePayload);
+    return { ok: true };
   }
 );

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -11,6 +11,8 @@ const CLOSE_DESKTOP_AUTH_WINDOW_CHANNEL = 'close-desktop-auth-window';
 const CONSUME_DESKTOP_AUTH_COMPLETION_CHANNEL =
   'consume-desktop-auth-completion';
 const DICTATION_STATUS_CHANNEL = 'dictation-status';
+const TRAY_SET_STATE_CHANNEL = 'tray-set-state';
+const TRAY_ACTION_CHANNEL = 'tray-action';
 
 interface MinimalDocument {
   readonly documentElement?: {
@@ -147,5 +149,27 @@ contextBridge.exposeInMainWorld('electronAPI', {
     /** Probe desktop dictation support without exposing node/native APIs. */
     getDictationStatus: () => {
       return ipcRenderer.invoke(DICTATION_STATUS_CHANNEL);
+    },
+
+    /**
+     * Push the current app state to the macOS menu bar extra.
+     * No-op on non-macOS or when the main process tray is unavailable.
+     */
+    setTrayState: (payload: { state: string; unreadCount?: number }) => {
+      return ipcRenderer.invoke(TRAY_SET_STATE_CHANNEL, payload) as Promise<{
+        ok: boolean;
+        reason?: string;
+      }>;
+    },
+
+    /**
+     * Subscribe to tray quick-action events (e.g. "new-message") fired by the
+     * main process when the user clicks a menu bar context-menu item.
+     */
+    onTrayAction: (cb: (action: string) => void): (() => void) => {
+      if (typeof cb !== 'function') return () => undefined;
+      const listener = (_: unknown, action: string) => cb(action);
+      ipcRenderer.on(TRAY_ACTION_CHANNEL, listener);
+      return () => ipcRenderer.removeListener(TRAY_ACTION_CHANNEL, listener);
     },
 });

--- a/apps/desktop/src/tray.ts
+++ b/apps/desktop/src/tray.ts
@@ -1,0 +1,213 @@
+import * as zlib from 'node:zlib';
+import { deflateSync } from 'node:zlib';
+import {
+  Menu,
+  type MenuItemConstructorOptions,
+  nativeImage,
+  Tray,
+} from 'electron';
+
+export type TrayAppState = 'idle' | 'active' | 'unread' | 'error';
+
+export interface TrayStatePayload {
+  readonly state: TrayAppState;
+  readonly unreadCount?: number;
+}
+
+export type TrayAction = 'open-chat' | 'new-message' | 'open-preferences';
+
+// ponytail: zlib.crc32 added in Node.js 22.2.0; repo requires 22.13+
+const zlibWithCrc = zlib as typeof zlib & {
+  crc32(data: Buffer, crc?: number): number;
+};
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const lenBuf = Buffer.allocUnsafe(4);
+  lenBuf.writeUInt32BE(data.length, 0);
+  const typeBuf = Buffer.from(type, 'ascii');
+  const crcBuf = Buffer.allocUnsafe(4);
+  crcBuf.writeUInt32BE(zlibWithCrc.crc32(data, zlibWithCrc.crc32(typeBuf)), 0);
+  return Buffer.concat([lenBuf, typeBuf, data, crcBuf]);
+}
+
+/**
+ * Builds an RGBA PNG Buffer containing a filled circle.
+ * withDot=true adds a smaller circle at top-right for the unread state.
+ * The resulting NativeImage should be marked as a template image so
+ * macOS handles dark/light mode colourisation automatically.
+ */
+function buildCirclePng(size: number, withDot: boolean): Buffer {
+  const rowStride = size * 4 + 1; // 1 filter byte + 4 RGBA bytes per pixel
+  const raw = Buffer.alloc(rowStride * size, 0); // transparent by default
+  const c = (size - 1) / 2;
+  const mainR = c * 0.68;
+
+  for (let y = 0; y < size; y++) {
+    raw[y * rowStride] = 0; // filter: None
+    for (let x = 0; x < size; x++) {
+      const dx = x - c;
+      const dy = y - c;
+      let opaque = dx * dx + dy * dy <= mainR * mainR;
+
+      if (withDot) {
+        const dotCx = size * 0.75;
+        const dotCy = size * 0.22;
+        const dotR = size * 0.18;
+        const ddx = x - dotCx;
+        const ddy = y - dotCy;
+        opaque = opaque || ddx * ddx + ddy * ddy <= dotR * dotR;
+      }
+
+      if (opaque) {
+        // R=0, G=0, B=0 (black); A=255 — template image, OS recolours it
+        raw[y * rowStride + 1 + x * 4 + 3] = 255;
+      }
+    }
+  }
+
+  const ihdr = Buffer.allocUnsafe(13);
+  ihdr.writeUInt32BE(size, 0); // width
+  ihdr.writeUInt32BE(size, 4); // height
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // color type: RGBA
+  // bytes 10-12 remain 0 (compression=0, filter=0, interlace=0)
+
+  const PNG_SIG = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  return Buffer.concat([
+    PNG_SIG,
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', deflateSync(raw)),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+// 44px buffer rendered at scaleFactor=2 → 22pt logical size in the menu bar
+const TRAY_RENDER_PX = 44;
+const TRAY_SCALE = 2;
+
+let baseIcon: ReturnType<typeof nativeImage.createFromBuffer> | null = null;
+let dotIcon: ReturnType<typeof nativeImage.createFromBuffer> | null = null;
+
+function getIcon(withDot: boolean) {
+  if (withDot) {
+    if (!dotIcon) {
+      dotIcon = nativeImage.createFromBuffer(
+        buildCirclePng(TRAY_RENDER_PX, true),
+        {
+          scaleFactor: TRAY_SCALE,
+        }
+      );
+      dotIcon.setTemplateImage(true);
+    }
+    return dotIcon;
+  }
+  if (!baseIcon) {
+    baseIcon = nativeImage.createFromBuffer(
+      buildCirclePng(TRAY_RENDER_PX, false),
+      {
+        scaleFactor: TRAY_SCALE,
+      }
+    );
+    baseIcon.setTemplateImage(true);
+  }
+  return baseIcon;
+}
+
+const TOOLTIP: Record<TrayAppState, string> = {
+  idle: 'Jovie',
+  active: 'Jovie — active run',
+  unread: 'Jovie — unread messages',
+  error: 'Jovie — error',
+};
+
+const STATE_TITLE: Record<TrayAppState, string> = {
+  idle: '',
+  active: '…',
+  unread: '', // replaced with count when unreadCount > 0
+  error: '!',
+};
+
+const STATE_LABEL: Record<TrayAppState, string> = {
+  idle: 'Ready',
+  active: 'Active run…',
+  unread: 'Unread',
+  error: 'Error — click to review',
+};
+
+/**
+ * MenuBarTray wraps Electron's Tray (which wraps NSStatusItem on macOS).
+ * Create one instance when the app is ready on macOS; call destroy() on quit.
+ */
+export class MenuBarTray {
+  private readonly tray: Tray;
+  private state: TrayAppState = 'idle';
+  private unreadCount = 0;
+  private readonly onAction: (action: TrayAction) => void;
+
+  constructor(onAction: (action: TrayAction) => void) {
+    this.tray = new Tray(getIcon(false));
+    this.tray.setToolTip('Jovie');
+    this.onAction = onAction;
+    this.rebuildMenu();
+  }
+
+  setState(payload: TrayStatePayload): void {
+    if (!isTrayAppState(payload.state)) return;
+    this.state = payload.state;
+    this.unreadCount =
+      typeof payload.unreadCount === 'number' && payload.unreadCount >= 0
+        ? Math.floor(payload.unreadCount)
+        : 0;
+    this.applyVisuals();
+    this.rebuildMenu();
+  }
+
+  destroy(): void {
+    if (!this.tray.isDestroyed()) this.tray.destroy();
+    baseIcon = null;
+    dotIcon = null;
+  }
+
+  private applyVisuals(): void {
+    const hasUnread = this.state === 'unread' && this.unreadCount > 0;
+    this.tray.setImage(getIcon(hasUnread));
+    this.tray.setToolTip(TOOLTIP[this.state]);
+    const title = hasUnread
+      ? this.unreadCount > 9
+        ? '9+'
+        : String(this.unreadCount)
+      : STATE_TITLE[this.state];
+    this.tray.setTitle(title);
+  }
+
+  private rebuildMenu(): void {
+    const hasUnread = this.state === 'unread' && this.unreadCount > 0;
+    const stateLabel = hasUnread
+      ? `${this.unreadCount} unread`
+      : STATE_LABEL[this.state];
+
+    const template: MenuItemConstructorOptions[] = [
+      { label: `Jovie — ${stateLabel}`, enabled: false },
+      { type: 'separator' },
+      { label: 'Open Chat', click: () => this.onAction('open-chat') },
+      { label: 'New Message', click: () => this.onAction('new-message') },
+      { type: 'separator' },
+      { label: 'Preferences…', click: () => this.onAction('open-preferences') },
+      { type: 'separator' },
+      { label: 'Quit Jovie', role: 'quit' },
+    ];
+
+    this.tray.setContextMenu(Menu.buildFromTemplate(template));
+  }
+}
+
+function isTrayAppState(value: unknown): value is TrayAppState {
+  return (
+    value === 'idle' ||
+    value === 'active' ||
+    value === 'unread' ||
+    value === 'error'
+  );
+}
+
+export { isTrayAppState };

--- a/apps/web/lib/desktop/electron-bridge.test.ts
+++ b/apps/web/lib/desktop/electron-bridge.test.ts
@@ -361,4 +361,83 @@ describe('electron-bridge — defensive guards', () => {
       bridgeMethod: 'getDictationStatus',
     });
   });
+
+  describe('setDesktopTrayState / onDesktopTrayAction — tray bridge', () => {
+    it('setDesktopTrayState silently no-ops when electronAPI is absent', async () => {
+      await expect(
+        __testing.setDesktopTrayState('idle')
+      ).resolves.toBeUndefined();
+      expect(captureWarningMock).not.toHaveBeenCalled();
+    });
+
+    it('setDesktopTrayState silently no-ops when setTrayState is missing (stale binary)', async () => {
+      setElectronAPI({ versions: { app: '0.1.0' } });
+      await expect(
+        __testing.setDesktopTrayState('active', 3)
+      ).resolves.toBeUndefined();
+      expect(captureWarningMock).not.toHaveBeenCalled();
+    });
+
+    it('setDesktopTrayState calls the bridge with state + unreadCount', async () => {
+      const setTrayState = vi.fn().mockResolvedValue({ ok: true });
+      setElectronAPI({ setTrayState });
+
+      await __testing.setDesktopTrayState('unread', 5);
+      expect(setTrayState).toHaveBeenCalledWith({
+        state: 'unread',
+        unreadCount: 5,
+      });
+    });
+
+    it('setDesktopTrayState omits unreadCount when not provided', async () => {
+      const setTrayState = vi.fn().mockResolvedValue({ ok: true });
+      setElectronAPI({ setTrayState });
+
+      await __testing.setDesktopTrayState('idle');
+      expect(setTrayState).toHaveBeenCalledWith({
+        state: 'idle',
+        unreadCount: undefined,
+      });
+    });
+
+    it('onDesktopTrayAction returns a noop unsubscribe when electronAPI is absent', () => {
+      const cb = vi.fn();
+      const unsub = __testing.onDesktopTrayAction(cb);
+      expect(typeof unsub).toBe('function');
+      expect(() => unsub()).not.toThrow();
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('onDesktopTrayAction returns a noop unsubscribe when onTrayAction is missing', () => {
+      setElectronAPI({ versions: { app: '0.1.0' } });
+      const cb = vi.fn();
+      const unsub = __testing.onDesktopTrayAction(cb);
+      expect(typeof unsub).toBe('function');
+      expect(() => unsub()).not.toThrow();
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('onDesktopTrayAction wires up the bridge listener and returns an unsubscribe', () => {
+      const mockUnsub = vi.fn();
+      const onTrayAction = vi.fn().mockReturnValue(mockUnsub);
+      setElectronAPI({ onTrayAction });
+
+      const cb = vi.fn();
+      const unsub = __testing.onDesktopTrayAction(cb);
+
+      expect(onTrayAction).toHaveBeenCalledWith(cb);
+      expect(typeof unsub).toBe('function');
+      unsub();
+      expect(mockUnsub).toHaveBeenCalledTimes(1);
+    });
+
+    it('onDesktopTrayAction falls back to noop when bridge returns non-function', () => {
+      const onTrayAction = vi.fn().mockReturnValue(undefined);
+      setElectronAPI({ onTrayAction });
+
+      const unsub = __testing.onDesktopTrayAction(vi.fn());
+      expect(typeof unsub).toBe('function');
+      expect(() => unsub()).not.toThrow();
+    });
+  });
 });

--- a/apps/web/lib/desktop/electron-bridge.ts
+++ b/apps/web/lib/desktop/electron-bridge.ts
@@ -54,6 +54,19 @@ export interface ElectronAPI {
    * whether Electron has explicitly allowed the trusted Web Speech fallback.
    */
   readonly getDictationStatus?: () => Promise<DesktopDictationStatus>;
+  /**
+   * Push the current app state to the macOS menu bar extra (NSStatusItem).
+   * No-op in non-Electron contexts or on non-macOS platforms.
+   */
+  readonly setTrayState?: (payload: {
+    state: string;
+    unreadCount?: number;
+  }) => Promise<{ ok: boolean; reason?: string }>;
+  /**
+   * Subscribe to tray quick-action events from the main process.
+   * Returns an unsubscribe function.
+   */
+  readonly onTrayAction?: (cb: (action: string) => void) => () => void;
 }
 
 export interface DesktopAuthCompletion {
@@ -540,6 +553,34 @@ export function useDesktopDictationStatus(): DesktopDictationStatus {
   return status;
 }
 
+export type DesktopTrayState = 'idle' | 'active' | 'unread' | 'error';
+
+/**
+ * Push state to the macOS menu bar extra.
+ * Silently no-ops when not running in Electron or when the installed binary
+ * predates the tray bridge (stale binary graceful degradation).
+ */
+export async function setDesktopTrayState(
+  state: DesktopTrayState,
+  unreadCount?: number
+): Promise<void> {
+  const api = getRawElectronAPI();
+  if (!api || typeof api.setTrayState !== 'function') return;
+  await api.setTrayState({ state, unreadCount });
+}
+
+/**
+ * Subscribe to quick-action events fired by the tray context menu.
+ * The `action` string is one of: 'open-chat' | 'new-message' | 'open-preferences'.
+ * Returns an unsubscribe function; safe to call in browser contexts (returns no-op).
+ */
+export function onDesktopTrayAction(cb: (action: string) => void): () => void {
+  const api = getRawElectronAPI();
+  if (!api || typeof api.onTrayAction !== 'function') return noopUnsubscribe;
+  const unsubscribe = api.onTrayAction(cb);
+  return typeof unsubscribe === 'function' ? unsubscribe : noopUnsubscribe;
+}
+
 // Exported for tests only — do not call directly from product code.
 export const __testing = {
   reset: () => reportedMissing.clear(),
@@ -551,5 +592,7 @@ export const __testing = {
   openDesktopAuthUrl,
   closeDesktopAuthWindow,
   consumeDesktopAuthCompletion,
+  setDesktopTrayState,
+  onDesktopTrayAction,
   RELEASE_DOWNLOAD_URL,
 };


### PR DESCRIPTION
## Summary

Implements the macOS menu bar presence for the Jovie desktop app (GH-12047). The issue body describes the feature in Swift/NSStatusItem terms, but the desktop app is Electron-based — this PR uses Electron's `Tray` API which wraps `NSStatusItem` on macOS.

- New `MenuBarTray` class in `apps/desktop/src/tray.ts`: state machine (idle/active/unread/error), programmatic PNG icon generation using Node.js 22 `zlib` builtins (no external deps), context menu with open-chat / new-message / open-preferences / quit
- IPC wiring in `main.ts`: `tray-set-state` handler with `isTrustedIpcSender` + payload validation; tray created only on `process.platform === 'darwin'`
- Bridge exposed in `preload.ts`: `setTrayState` and `onTrayAction` on `contextBridge.exposeInMainWorld`
- Renderer-side wrappers in `electron-bridge.ts`: `setDesktopTrayState()` and `onDesktopTrayAction()` with stale-binary graceful no-ops (methods are optional on `ElectronAPI`)

## Verification

```
pnpm --filter @jovie/desktop run typecheck  # ✅ clean
node --test apps/desktop/scripts/desktop-tray-contract.test.mjs  # ✅ 4/4 pass
pnpm --filter web exec vitest run lib/desktop/electron-bridge.test.ts  # ✅ 29/29 pass
pnpm biome check --write <all changed files>  # ✅ clean
pre-commit + pre-push hooks  # ✅ all passed
```

## Cost Impact

No external API calls, no cron jobs, no new dependencies. All PNG generation uses Node.js 22 built-ins.

Closes #12047