### PR TITLE
chore: verify fan email + SMS signup works end-to-end on public profiles (GTM c (#11369)

### DIFF
--- a/apps/web/lib/e2e/runtime.ts
+++ b/apps/web/lib/e2e/runtime.ts
@@ -1,8 +1,23 @@
 import { publicEnv } from '@/lib/env-public';
 
+/** Clerk test-mode OTP; reused for fan email capture in local/CI E2E. */
+export const FAN_CAPTURE_E2E_OTP_CODE = '424242';
+
 export function isE2EFastOnboardingEnabled(): boolean {
   return (
     process.env.E2E_FAST_ONBOARDING === '1' ||
+    publicEnv.NEXT_PUBLIC_E2E_MODE === '1'
+  );
+}
+
+/** Deterministic fan-capture OTP — never enabled in production deploys. */
+export function isDeterministicFanCaptureOtpEnabled(): boolean {
+  if (process.env.VERCEL_ENV === 'production') {
+    return false;
+  }
+
+  return (
+    process.env.E2E_USE_TEST_AUTH_BYPASS === '1' ||
     publicEnv.NEXT_PUBLIC_E2E_MODE === '1'
   );
 }

--- a/apps/web/lib/notifications/domain.ts
+++ b/apps/web/lib/notifications/domain.ts
@@ -3,14 +3,12 @@ import { createFingerprint } from '@/app/api/audience/lib/audience-utils';
 import { AUDIENCE_IDENTIFIED_COOKIE, BASE_URL } from '@/constants/app';
 import { db } from '@/lib/db';
 import {
-  audienceMembers,
   type FanNotificationPreferences,
   notificationSubscriptions,
 } from '@/lib/db/schema/analytics';
 import { users } from '@/lib/db/schema/auth';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { captureError } from '@/lib/error-tracking';
-import { withSystemIngestionSession } from '@/lib/ingestion/session';
 import {
   extractPayloadProps,
   inferChannel,
@@ -33,7 +31,7 @@ import { syncAudienceAlertState } from '@/lib/notifications/audience-alert-state
 import {
   buildEmailOtpExpiry,
   EMAIL_OTP_TTL_MINUTES,
-  generateEmailOtpCode,
+  generateFanCaptureEmailOtpCode,
   hashEmailOtp,
   isValidEmailOtpFormat,
 } from '@/lib/notifications/email-otp';
@@ -192,37 +190,53 @@ async function upsertAudienceMember(
   const fingerprint = createFingerprint(ipAddress, userAgent);
   const now = new Date();
 
-  await withSystemIngestionSession(async tx => {
-    await tx
-      .insert(audienceMembers)
-      .values({
-        creatorProfileId: artist_id,
-        fingerprint,
-        type: 'email',
-        displayName: 'Subscriber',
-        email: normalizedEmail,
-        firstSeenAt: now,
-        lastSeenAt: now,
-        visits: 0,
-        engagementScore: 0,
-        intentLevel: 'low',
-        deviceType: 'unknown',
-        referrerHistory: [],
-        latestActions: [],
-        tags: [],
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoUpdate({
-        target: [audienceMembers.creatorProfileId, audienceMembers.fingerprint],
-        set: {
-          type: 'email',
-          email: normalizedEmail,
-          lastSeenAt: now,
-          updatedAt: now,
-        },
-      });
-  });
+  // Use core columns only so fan capture works on DB branches that have not yet
+  // picked up optional audience summary migrations (latest_referrer_url, etc.).
+  // Drizzle's insert() always emits the full schema column list and fails when
+  // those optional columns are absent — same class of bug as audience/visit.
+  await db.execute(drizzleSql`
+    INSERT INTO audience_members (
+      creator_profile_id,
+      fingerprint,
+      type,
+      display_name,
+      first_seen_at,
+      last_seen_at,
+      visits,
+      engagement_score,
+      intent_level,
+      device_type,
+      referrer_history,
+      latest_actions,
+      email,
+      tags,
+      created_at,
+      updated_at
+    ) VALUES (
+      ${artist_id},
+      ${fingerprint},
+      'email',
+      'Subscriber',
+      ${now},
+      ${now},
+      0,
+      0,
+      'low',
+      'unknown',
+      '[]'::jsonb,
+      '[]'::jsonb,
+      ${normalizedEmail},
+      '[]'::jsonb,
+      ${now},
+      ${now}
+    )
+    ON CONFLICT (creator_profile_id, fingerprint)
+    DO UPDATE SET
+      type = 'email',
+      email = EXCLUDED.email,
+      last_seen_at = EXCLUDED.last_seen_at,
+      updated_at = EXCLUDED.updated_at
+  `);
 }
 
 async function upsertAudienceMemberBestEffort(
@@ -401,7 +415,7 @@ interface EmailOtpResult {
 }
 
 function createEmailOtp(): EmailOtpResult {
-  const otpCode = generateEmailOtpCode();
+  const otpCode = generateFanCaptureEmailOtpCode();
   return {
     otpCode,
     otpHash: hashEmailOtp(otpCode),
@@ -900,6 +914,21 @@ export const verifyEmailOtpDomain = async (
       emailOtpAttempts: 0,
     })
     .where(eq(notificationSubscriptions.id, subscription.id));
+
+  // Subscribe-time audience upsert is best-effort; ensure a row exists after
+  // confirmation so Pro creators see the fan in audience immediately.
+  const artistResult = await fetchArtistProfile(
+    parsed.data.artist_id,
+    undefined
+  );
+  if (isArtistProfileResult(artistResult) && artistResult.dynamicEnabled) {
+    await upsertAudienceMemberBestEffort(
+      parsed.data.artist_id,
+      normalizedEmail,
+      null,
+      null
+    );
+  }
 
   // JOV-1842: propagate confirmed alert state to audience_members.
   await syncAudienceAlertState(parsed.data.artist_id, {

--- a/apps/web/lib/notifications/email-otp.ts
+++ b/apps/web/lib/notifications/email-otp.ts
@@ -1,4 +1,8 @@
 import { createHash, randomInt } from 'node:crypto';
+import {
+  FAN_CAPTURE_E2E_OTP_CODE,
+  isDeterministicFanCaptureOtpEnabled,
+} from '@/lib/e2e/runtime';
 
 const EMAIL_OTP_LENGTH = 6;
 export const EMAIL_OTP_TTL_MINUTES = 10;
@@ -9,6 +13,14 @@ const normalizeOtp = (value: string) => value.trim();
 
 export function generateEmailOtpCode(): string {
   return randomInt(0, 1_000_000).toString().padStart(EMAIL_OTP_LENGTH, '0');
+}
+
+/** Fan-capture subscribe flow only — deterministic in local/CI E2E. */
+export function generateFanCaptureEmailOtpCode(): string {
+  if (isDeterministicFanCaptureOtpEnabled()) {
+    return FAN_CAPTURE_E2E_OTP_CODE;
+  }
+  return generateEmailOtpCode();
 }
 
 export function hashEmailOtp(code: string): string {

--- a/apps/web/playwright.config.smoke.mobile.ts
+++ b/apps/web/playwright.config.smoke.mobile.ts
@@ -99,6 +99,7 @@ export default defineConfig({
             ...process.env,
             NODE_ENV: 'test',
             PORT: managedWebServerPort,
+            NEXT_PUBLIC_E2E_MODE: '1',
             NEXT_DISABLE_TOOLBAR: '1',
             E2E_USE_TEST_AUTH_BYPASS: useTestAuthBypass ? '1' : '0',
             E2E_WEB_SERVER_WARMUP: webServerWarmupProfile,

--- a/apps/web/playwright.config.smoke.ts
+++ b/apps/web/playwright.config.smoke.ts
@@ -104,6 +104,7 @@ export default defineConfig({
             ...process.env,
             NODE_ENV: 'test',
             PORT: managedWebServerPort,
+            NEXT_PUBLIC_E2E_MODE: '1',
             NEXT_DISABLE_TOOLBAR: '1',
             E2E_USE_TEST_AUTH_BYPASS: useTestAuthBypass ? '1' : '0',
             E2E_WEB_SERVER_WARMUP: webServerWarmupProfile,

--- a/apps/web/tests/e2e/helpers/fan-capture-golden-path.ts
+++ b/apps/web/tests/e2e/helpers/fan-capture-golden-path.ts
@@ -1,0 +1,131 @@
+import { neon } from '@neondatabase/serverless';
+
+export function hasFanCaptureDatabase(): boolean {
+  const url = process.env.DATABASE_URL;
+  return Boolean(url && !url.includes('dummy'));
+}
+
+function getSql() {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl || dbUrl.includes('dummy')) {
+    throw new Error(
+      'DATABASE_URL is required for fan capture golden-path checks'
+    );
+  }
+  return neon(dbUrl);
+}
+
+export async function getCreatorProfileIdByUsername(
+  username: string
+): Promise<string | null> {
+  const sql = getSql();
+  const rows = await sql`
+    SELECT id
+    FROM creator_profiles
+    WHERE username_normalized = ${username.toLowerCase()}
+    LIMIT 1
+  `;
+  return rows[0]?.id ?? null;
+}
+
+export async function cleanupFanCaptureTestData(params: {
+  readonly creatorProfileId: string;
+  readonly email?: string | null;
+  readonly phone?: string | null;
+}): Promise<void> {
+  const sql = getSql();
+  const normalizedEmail = params.email?.trim().toLowerCase() ?? null;
+  const normalizedPhone = params.phone?.trim() ?? null;
+
+  if (normalizedEmail) {
+    await sql`
+      DELETE FROM notification_subscriptions
+      WHERE creator_profile_id = ${params.creatorProfileId}
+        AND channel = 'email'
+        AND lower(email) = ${normalizedEmail}
+    `;
+    await sql`
+      DELETE FROM audience_members
+      WHERE creator_profile_id = ${params.creatorProfileId}
+        AND lower(email) = ${normalizedEmail}
+    `;
+  }
+
+  if (normalizedPhone) {
+    await sql`
+      DELETE FROM notification_subscriptions
+      WHERE creator_profile_id = ${params.creatorProfileId}
+        AND channel = 'sms'
+        AND phone = ${normalizedPhone}
+    `;
+    await sql`
+      DELETE FROM audience_members
+      WHERE creator_profile_id = ${params.creatorProfileId}
+        AND phone = ${normalizedPhone}
+    `;
+  }
+}
+
+export async function assertConfirmedEmailSubscription(params: {
+  readonly creatorProfileId: string;
+  readonly email: string;
+}): Promise<void> {
+  const sql = getSql();
+  const normalizedEmail = params.email.trim().toLowerCase();
+  const rows = await sql`
+    SELECT confirmed_at
+    FROM notification_subscriptions
+    WHERE creator_profile_id = ${params.creatorProfileId}
+      AND channel = 'email'
+      AND lower(email) = ${normalizedEmail}
+    LIMIT 1
+  `;
+
+  if (!rows[0]?.confirmed_at) {
+    throw new Error(
+      `Expected confirmed email subscription for ${normalizedEmail} on profile ${params.creatorProfileId}`
+    );
+  }
+}
+
+export async function assertAudienceMemberForEmail(params: {
+  readonly creatorProfileId: string;
+  readonly email: string;
+}): Promise<void> {
+  const sql = getSql();
+  const normalizedEmail = params.email.trim().toLowerCase();
+  const rows = await sql`
+    SELECT id, has_active_alerts
+    FROM audience_members
+    WHERE creator_profile_id = ${params.creatorProfileId}
+      AND lower(email) = ${normalizedEmail}
+    LIMIT 1
+  `;
+
+  if (!rows[0]?.id) {
+    throw new Error(
+      `Expected audience_members row for ${normalizedEmail} on profile ${params.creatorProfileId}`
+    );
+  }
+}
+
+export async function assertSmsSubscriptionRow(params: {
+  readonly creatorProfileId: string;
+  readonly phone: string;
+}): Promise<void> {
+  const sql = getSql();
+  const rows = await sql`
+    SELECT id, phone
+    FROM notification_subscriptions
+    WHERE creator_profile_id = ${params.creatorProfileId}
+      AND channel = 'sms'
+      AND phone = ${params.phone}
+    LIMIT 1
+  `;
+
+  if (!rows[0]?.id) {
+    throw new Error(
+      `Expected SMS notification_subscriptions row for ${params.phone} on profile ${params.creatorProfileId}`
+    );
+  }
+}

--- a/apps/web/tests/e2e/helpers/fan-capture-golden-path.ts
+++ b/apps/web/tests/e2e/helpers/fan-capture-golden-path.ts
@@ -66,13 +66,13 @@ export async function cleanupFanCaptureTestData(params: {
   }
 }
 
-export async function assertConfirmedEmailSubscription(params: {
+export async function assertEmailCaptureComplete(params: {
   readonly creatorProfileId: string;
   readonly email: string;
 }): Promise<void> {
   const sql = getSql();
   const normalizedEmail = params.email.trim().toLowerCase();
-  const rows = await sql`
+  const [subscription] = await sql`
     SELECT confirmed_at
     FROM notification_subscriptions
     WHERE creator_profile_id = ${params.creatorProfileId}
@@ -80,32 +80,21 @@ export async function assertConfirmedEmailSubscription(params: {
       AND lower(email) = ${normalizedEmail}
     LIMIT 1
   `;
-
-  if (!rows[0]?.confirmed_at) {
-    throw new Error(
-      `Expected confirmed email subscription for ${normalizedEmail} on profile ${params.creatorProfileId}`
-    );
-  }
-}
-
-export async function assertAudienceMemberForEmail(params: {
-  readonly creatorProfileId: string;
-  readonly email: string;
-}): Promise<void> {
-  const sql = getSql();
-  const normalizedEmail = params.email.trim().toLowerCase();
-  const rows = await sql`
-    SELECT id, has_active_alerts
+  const [audience] = await sql`
+    SELECT id
     FROM audience_members
     WHERE creator_profile_id = ${params.creatorProfileId}
       AND lower(email) = ${normalizedEmail}
     LIMIT 1
   `;
 
-  if (!rows[0]?.id) {
+  if (!subscription?.confirmed_at) {
     throw new Error(
-      `Expected audience_members row for ${normalizedEmail} on profile ${params.creatorProfileId}`
+      `Expected confirmed email subscription for ${normalizedEmail}`
     );
+  }
+  if (!audience?.id) {
+    throw new Error(`Expected audience_members row for ${normalizedEmail}`);
   }
 }
 
@@ -115,7 +104,7 @@ export async function assertSmsSubscriptionRow(params: {
 }): Promise<void> {
   const sql = getSql();
   const rows = await sql`
-    SELECT id, phone
+    SELECT id
     FROM notification_subscriptions
     WHERE creator_profile_id = ${params.creatorProfileId}
       AND channel = 'sms'
@@ -124,8 +113,6 @@ export async function assertSmsSubscriptionRow(params: {
   `;
 
   if (!rows[0]?.id) {
-    throw new Error(
-      `Expected SMS notification_subscriptions row for ${params.phone} on profile ${params.creatorProfileId}`
-    );
+    throw new Error(`Expected SMS subscription row for ${params.phone}`);
   }
 }

--- a/apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts
+++ b/apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts
@@ -1,0 +1,392 @@
+import { createHash } from 'node:crypto';
+import { type Page, type Route } from '@playwright/test';
+import { FAN_CAPTURE_E2E_OTP_CODE } from '@/lib/e2e/runtime';
+import {
+  assertAudienceMemberForEmail,
+  assertConfirmedEmailSubscription,
+  assertSmsSubscriptionRow,
+  cleanupFanCaptureTestData,
+  getCreatorProfileIdByUsername,
+  hasFanCaptureDatabase,
+} from './helpers/fan-capture-golden-path';
+import { expect, test } from './setup';
+import {
+  SMOKE_TIMEOUTS,
+  smokeNavigate,
+  TEST_PROFILES,
+  waitForHydration,
+} from './utils/smoke-test-utils';
+
+/**
+ * Fan capture golden path (JOV-3343 / #11369)
+ *
+ * End-to-end guardrail for public-profile email + SMS capture. Uses real
+ * notification APIs (no subscribe/verify mocks) and verifies durable rows in
+ * notification_subscriptions + audience_members.
+ *
+ * Email OTP is deterministic in CI/local E2E (424242) — same contract as
+ * Clerk +clerk_test verification.
+ *
+ * @smoke @critical @fan-capture
+ */
+
+test.use({ storageState: { cookies: [], origins: [] } });
+test.describe.configure({ mode: 'serial' });
+
+const NOTIFICATIONS_TRIGGER_SELECTOR = [
+  '[data-testid="profile-inline-notifications-trigger"]',
+  '[data-testid="profile-home-alerts-row"]',
+  '[data-testid="profile-home-alerts-fallback-card"]',
+].join(', ');
+const VISIBLE_EMAIL_STEP_SELECTOR =
+  '[data-testid="profile-mobile-notifications-step-email"]:visible';
+const VISIBLE_EMAIL_INPUT_SELECTOR =
+  '[data-testid="mobile-email-input"]:visible';
+
+function buildTestEmail(runId: string): string {
+  return `fan-capture+${runId}@test.jov.ie`;
+}
+
+function buildTestPhone(runId: string): string {
+  const suffix = [...createHash('sha256').update(runId).digest()]
+    .map(byte => (byte % 10).toString())
+    .join('')
+    .slice(-10)
+    .padStart(10, '0');
+  return `+1${suffix}`;
+}
+
+async function interceptAnalyticsOnly(page: Page) {
+  await page.route('**/api/profile/view', (route: Route) =>
+    route.fulfill({ status: 200, body: '{}' })
+  );
+  await page.route('**/api/audience/visit', (route: Route) =>
+    route.fulfill({ status: 200, body: '{}' })
+  );
+  await page.route('**/api/track', (route: Route) =>
+    route.fulfill({ status: 200, body: '{}' })
+  );
+  await page.route('**/api/px', (route: Route) =>
+    route.fulfill({ status: 204, body: '' })
+  );
+}
+
+async function getActiveNotificationsFlow(page: Page) {
+  const dialogFlow = page
+    .locator('[role="dialog"][data-testid="profile-mobile-notifications-flow"]')
+    .first();
+  const dialogVisible = await dialogFlow
+    .waitFor({ state: 'visible', timeout: SMOKE_TIMEOUTS.QUICK })
+    .then(() => true)
+    .catch(() => false);
+
+  if (dialogVisible) {
+    return dialogFlow;
+  }
+
+  return page
+    .locator('[data-testid="profile-mobile-notifications-flow"]:visible')
+    .first();
+}
+
+async function openSubscribeFlow(page: Page) {
+  const emailStep = page.locator(VISIBLE_EMAIL_STEP_SELECTOR).first();
+  const emailVisible = await emailStep
+    .waitFor({ state: 'visible', timeout: SMOKE_TIMEOUTS.QUICK })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!emailVisible) {
+    const trigger = page.locator(NOTIFICATIONS_TRIGGER_SELECTOR).first();
+    await trigger.waitFor({
+      state: 'visible',
+      timeout: SMOKE_TIMEOUTS.VISIBILITY,
+    });
+    await trigger.click();
+    await emailStep.waitFor({
+      state: 'visible',
+      timeout: SMOKE_TIMEOUTS.VISIBILITY,
+    });
+  }
+
+  const flow = await getActiveNotificationsFlow(page);
+  await flow.locator(VISIBLE_EMAIL_INPUT_SELECTOR).first().waitFor({
+    state: 'visible',
+    timeout: SMOKE_TIMEOUTS.VISIBILITY,
+  });
+}
+
+async function setupProfileSubscribePage(
+  page: Page,
+  viewport: { readonly width: number; readonly height: number }
+) {
+  await interceptAnalyticsOnly(page);
+  await page.setViewportSize(viewport);
+
+  const response = await smokeNavigate(
+    page,
+    `/${TEST_PROFILES.DUALIPA}?mode=subscribe`,
+    { timeout: 120_000 }
+  );
+  expect(response?.status() ?? 0).toBeLessThan(500);
+
+  await waitForHydration(page);
+  await openSubscribeFlow(page);
+}
+
+async function submitEmailStep(
+  page: Page,
+  email: string,
+  options: { readonly waitForSubscribe?: boolean } = {}
+) {
+  const flow = await getActiveNotificationsFlow(page);
+  const emailStep = flow
+    .locator('[data-testid="profile-mobile-notifications-step-email"]')
+    .first();
+  const input = flow.locator('[data-testid="mobile-email-input"]').first();
+  await input.fill(email);
+
+  const submitBtn = emailStep.getByRole('button', { name: /^continue$/i });
+  await expect(submitBtn).toBeEnabled();
+
+  if (options.waitForSubscribe) {
+    await Promise.all([
+      page.waitForResponse(
+        response =>
+          response.url().includes('/api/notifications/subscribe') &&
+          response.request().method() === 'POST',
+        { timeout: SMOKE_TIMEOUTS.VISIBILITY }
+      ),
+      submitBtn.click(),
+    ]);
+    return;
+  }
+
+  await submitBtn.click();
+}
+
+async function enterOtpCode(page: Page, code: string) {
+  const flow = await getActiveNotificationsFlow(page);
+  const otpStep = flow
+    .locator('[data-testid="profile-mobile-notifications-step-otp"]')
+    .first();
+  const firstDigitInput = flow.getByLabel('Digit 1 of 6');
+
+  await otpStep.waitFor({
+    state: 'visible',
+    timeout: SMOKE_TIMEOUTS.VISIBILITY,
+  });
+  await firstDigitInput.click();
+  await firstDigitInput.pressSequentially(code);
+}
+
+async function skipNameAndBirthday(page: Page) {
+  const flow = await getActiveNotificationsFlow(page);
+  const nameStep = flow
+    .locator('[data-testid="profile-mobile-notifications-step-name"]')
+    .first();
+  await nameStep.waitFor({
+    state: 'visible',
+    timeout: SMOKE_TIMEOUTS.VISIBILITY,
+  });
+  await nameStep.getByRole('button', { name: /^continue$/i }).click();
+
+  const birthdayStep = flow
+    .locator('[data-testid="profile-mobile-notifications-step-birthday"]')
+    .first();
+  await birthdayStep.waitFor({
+    state: 'visible',
+    timeout: SMOKE_TIMEOUTS.VISIBILITY,
+  });
+  await birthdayStep.getByRole('button', { name: /^continue$/i }).click();
+  await birthdayStep.getByRole('button', { name: /^continue$/i }).click();
+
+  await expect(
+    flow
+      .locator('[data-testid="profile-mobile-notifications-step-done"]')
+      .first()
+  ).toBeVisible({ timeout: SMOKE_TIMEOUTS.VISIBILITY });
+}
+
+test.describe('Fan capture golden path @smoke @critical', () => {
+  test.setTimeout(240_000);
+
+  test.beforeEach(async () => {
+    if (!hasFanCaptureDatabase()) {
+      test.skip(true, 'DATABASE_URL not available for fan capture golden path');
+    }
+
+    const deterministicOtpEnabled =
+      process.env.E2E_USE_TEST_AUTH_BYPASS === '1' ||
+      process.env.NEXT_PUBLIC_E2E_MODE === '1';
+    if (!deterministicOtpEnabled) {
+      test.skip(
+        true,
+        'Fan capture golden path requires E2E_USE_TEST_AUTH_BYPASS=1 or NEXT_PUBLIC_E2E_MODE=1'
+      );
+    }
+  });
+
+  test('mobile: email subscribe → OTP → audience row', async ({ page }) => {
+    const runId = `${Date.now().toString(36)}-mobile`;
+    const testEmail = buildTestEmail(runId);
+    const creatorProfileId = await getCreatorProfileIdByUsername(
+      TEST_PROFILES.DUALIPA
+    );
+
+    if (!creatorProfileId) {
+      test.skip(true, `${TEST_PROFILES.DUALIPA} profile not seeded`);
+      return;
+    }
+
+    await cleanupFanCaptureTestData({
+      creatorProfileId,
+      email: testEmail,
+    });
+
+    try {
+      await setupProfileSubscribePage(page, { width: 375, height: 812 });
+      await submitEmailStep(page, testEmail, { waitForSubscribe: true });
+
+      await enterOtpCode(page, FAN_CAPTURE_E2E_OTP_CODE);
+
+      await page.waitForResponse(
+        response =>
+          response.url().includes('/api/notifications/verify-email-otp') &&
+          response.request().method() === 'POST' &&
+          response.status() < 400,
+        { timeout: SMOKE_TIMEOUTS.VISIBILITY }
+      );
+
+      await skipNameAndBirthday(page);
+
+      await assertConfirmedEmailSubscription({
+        creatorProfileId,
+        email: testEmail,
+      });
+      await assertAudienceMemberForEmail({
+        creatorProfileId,
+        email: testEmail,
+      });
+    } finally {
+      await cleanupFanCaptureTestData({
+        creatorProfileId,
+        email: testEmail,
+      });
+    }
+  });
+
+  test('desktop: email subscribe → OTP → audience row', async ({ page }) => {
+    const runId = `${Date.now().toString(36)}-desktop`;
+    const testEmail = buildTestEmail(runId);
+    const creatorProfileId = await getCreatorProfileIdByUsername(
+      TEST_PROFILES.DUALIPA
+    );
+
+    if (!creatorProfileId) {
+      test.skip(true, `${TEST_PROFILES.DUALIPA} profile not seeded`);
+      return;
+    }
+
+    await cleanupFanCaptureTestData({
+      creatorProfileId,
+      email: testEmail,
+    });
+
+    try {
+      await setupProfileSubscribePage(page, { width: 1280, height: 800 });
+      await submitEmailStep(page, testEmail, { waitForSubscribe: true });
+      await enterOtpCode(page, FAN_CAPTURE_E2E_OTP_CODE);
+
+      await page.waitForResponse(
+        response =>
+          response.url().includes('/api/notifications/verify-email-otp') &&
+          response.request().method() === 'POST' &&
+          response.status() < 400,
+        { timeout: SMOKE_TIMEOUTS.VISIBILITY }
+      );
+
+      await skipNameAndBirthday(page);
+
+      await assertConfirmedEmailSubscription({
+        creatorProfileId,
+        email: testEmail,
+      });
+      await assertAudienceMemberForEmail({
+        creatorProfileId,
+        email: testEmail,
+      });
+    } finally {
+      await cleanupFanCaptureTestData({
+        creatorProfileId,
+        email: testEmail,
+      });
+    }
+  });
+
+  test('mobile: SMS subscribe persists notification row', async ({ page }) => {
+    const runId = `${Date.now().toString(36)}-sms`;
+    const testPhone = buildTestPhone(runId);
+    const creatorProfileId = await getCreatorProfileIdByUsername(
+      TEST_PROFILES.DUALIPA
+    );
+
+    if (!creatorProfileId) {
+      test.skip(true, `${TEST_PROFILES.DUALIPA} profile not seeded`);
+      return;
+    }
+
+    await cleanupFanCaptureTestData({
+      creatorProfileId,
+      phone: testPhone,
+    });
+
+    try {
+      await setupProfileSubscribePage(page, { width: 375, height: 812 });
+
+      const subscribeResult = await page.evaluate(
+        async ({ artistId, phone }: { artistId: string; phone: string }) => {
+          const response = await fetch('/api/notifications/subscribe', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              artist_id: artistId,
+              channel: 'sms',
+              phone,
+              country_code: 'US',
+              source: 'profile_bell',
+            }),
+          });
+
+          const body = (await response.json().catch(() => null)) as {
+            success?: boolean;
+            error?: string;
+          } | null;
+
+          return {
+            status: response.status,
+            success: body?.success ?? false,
+            error: body?.error ?? null,
+          };
+        },
+        { artistId: creatorProfileId, phone: testPhone }
+      );
+
+      expect(
+        subscribeResult.status,
+        `SMS subscribe failed: ${subscribeResult.error ?? subscribeResult.status}`
+      ).toBeLessThan(500);
+      expect(subscribeResult.success).toBe(true);
+
+      await assertSmsSubscriptionRow({
+        creatorProfileId,
+        phone: testPhone,
+      });
+    } finally {
+      await cleanupFanCaptureTestData({
+        creatorProfileId,
+        phone: testPhone,
+      });
+    }
+  });
+});

--- a/apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts
+++ b/apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts
@@ -2,8 +2,7 @@ import { createHash } from 'node:crypto';
 import { type Page, type Route } from '@playwright/test';
 import { FAN_CAPTURE_E2E_OTP_CODE } from '@/lib/e2e/runtime';
 import {
-  assertAudienceMemberForEmail,
-  assertConfirmedEmailSubscription,
+  assertEmailCaptureComplete,
   assertSmsSubscriptionRow,
   cleanupFanCaptureTestData,
   getCreatorProfileIdByUsername,
@@ -17,18 +16,7 @@ import {
   waitForHydration,
 } from './utils/smoke-test-utils';
 
-/**
- * Fan capture golden path (JOV-3343 / #11369)
- *
- * End-to-end guardrail for public-profile email + SMS capture. Uses real
- * notification APIs (no subscribe/verify mocks) and verifies durable rows in
- * notification_subscriptions + audience_members.
- *
- * Email OTP is deterministic in CI/local E2E (424242) — same contract as
- * Clerk +clerk_test verification.
- *
- * @smoke @critical @fan-capture
- */
+/** Fan capture golden path (#11369): public-profile email + SMS, real APIs, DB rows. @smoke @critical */
 
 test.use({ storageState: { cookies: [], origins: [] } });
 test.describe.configure({ mode: 'serial' });
@@ -42,6 +30,11 @@ const VISIBLE_EMAIL_STEP_SELECTOR =
   '[data-testid="profile-mobile-notifications-step-email"]:visible';
 const VISIBLE_EMAIL_INPUT_SELECTOR =
   '[data-testid="mobile-email-input"]:visible';
+
+const EMAIL_VIEWPORTS = [
+  { label: 'mobile', width: 375, height: 812 },
+  { label: 'desktop', width: 1280, height: 800 },
+] as const;
 
 function buildTestEmail(runId: string): string {
   return `fan-capture+${runId}@test.jov.ie`;
@@ -208,6 +201,44 @@ async function skipNameAndBirthday(page: Page) {
   ).toBeVisible({ timeout: SMOKE_TIMEOUTS.VISIBILITY });
 }
 
+async function runEmailGoldenPath(
+  page: Page,
+  viewport: { readonly width: number; readonly height: number },
+  label: string
+) {
+  const runId = `${Date.now().toString(36)}-${label}`;
+  const testEmail = buildTestEmail(runId);
+  const creatorProfileId = await getCreatorProfileIdByUsername(
+    TEST_PROFILES.DUALIPA
+  );
+
+  if (!creatorProfileId) {
+    test.skip(true, `${TEST_PROFILES.DUALIPA} profile not seeded`);
+    return;
+  }
+
+  await cleanupFanCaptureTestData({ creatorProfileId, email: testEmail });
+
+  try {
+    await setupProfileSubscribePage(page, viewport);
+    await submitEmailStep(page, testEmail, { waitForSubscribe: true });
+    await enterOtpCode(page, FAN_CAPTURE_E2E_OTP_CODE);
+
+    await page.waitForResponse(
+      response =>
+        response.url().includes('/api/notifications/verify-email-otp') &&
+        response.request().method() === 'POST' &&
+        response.status() < 400,
+      { timeout: SMOKE_TIMEOUTS.VISIBILITY }
+    );
+
+    await skipNameAndBirthday(page);
+    await assertEmailCaptureComplete({ creatorProfileId, email: testEmail });
+  } finally {
+    await cleanupFanCaptureTestData({ creatorProfileId, email: testEmail });
+  }
+}
+
 test.describe('Fan capture golden path @smoke @critical', () => {
   test.setTimeout(240_000);
 
@@ -227,102 +258,11 @@ test.describe('Fan capture golden path @smoke @critical', () => {
     }
   });
 
-  test('mobile: email subscribe → OTP → audience row', async ({ page }) => {
-    const runId = `${Date.now().toString(36)}-mobile`;
-    const testEmail = buildTestEmail(runId);
-    const creatorProfileId = await getCreatorProfileIdByUsername(
-      TEST_PROFILES.DUALIPA
-    );
-
-    if (!creatorProfileId) {
-      test.skip(true, `${TEST_PROFILES.DUALIPA} profile not seeded`);
-      return;
-    }
-
-    await cleanupFanCaptureTestData({
-      creatorProfileId,
-      email: testEmail,
+  for (const { label, width, height } of EMAIL_VIEWPORTS) {
+    test(`${label}: email subscribe → OTP → audience row`, async ({ page }) => {
+      await runEmailGoldenPath(page, { width, height }, label);
     });
-
-    try {
-      await setupProfileSubscribePage(page, { width: 375, height: 812 });
-      await submitEmailStep(page, testEmail, { waitForSubscribe: true });
-
-      await enterOtpCode(page, FAN_CAPTURE_E2E_OTP_CODE);
-
-      await page.waitForResponse(
-        response =>
-          response.url().includes('/api/notifications/verify-email-otp') &&
-          response.request().method() === 'POST' &&
-          response.status() < 400,
-        { timeout: SMOKE_TIMEOUTS.VISIBILITY }
-      );
-
-      await skipNameAndBirthday(page);
-
-      await assertConfirmedEmailSubscription({
-        creatorProfileId,
-        email: testEmail,
-      });
-      await assertAudienceMemberForEmail({
-        creatorProfileId,
-        email: testEmail,
-      });
-    } finally {
-      await cleanupFanCaptureTestData({
-        creatorProfileId,
-        email: testEmail,
-      });
-    }
-  });
-
-  test('desktop: email subscribe → OTP → audience row', async ({ page }) => {
-    const runId = `${Date.now().toString(36)}-desktop`;
-    const testEmail = buildTestEmail(runId);
-    const creatorProfileId = await getCreatorProfileIdByUsername(
-      TEST_PROFILES.DUALIPA
-    );
-
-    if (!creatorProfileId) {
-      test.skip(true, `${TEST_PROFILES.DUALIPA} profile not seeded`);
-      return;
-    }
-
-    await cleanupFanCaptureTestData({
-      creatorProfileId,
-      email: testEmail,
-    });
-
-    try {
-      await setupProfileSubscribePage(page, { width: 1280, height: 800 });
-      await submitEmailStep(page, testEmail, { waitForSubscribe: true });
-      await enterOtpCode(page, FAN_CAPTURE_E2E_OTP_CODE);
-
-      await page.waitForResponse(
-        response =>
-          response.url().includes('/api/notifications/verify-email-otp') &&
-          response.request().method() === 'POST' &&
-          response.status() < 400,
-        { timeout: SMOKE_TIMEOUTS.VISIBILITY }
-      );
-
-      await skipNameAndBirthday(page);
-
-      await assertConfirmedEmailSubscription({
-        creatorProfileId,
-        email: testEmail,
-      });
-      await assertAudienceMemberForEmail({
-        creatorProfileId,
-        email: testEmail,
-      });
-    } finally {
-      await cleanupFanCaptureTestData({
-        creatorProfileId,
-        email: testEmail,
-      });
-    }
-  });
+  }
 
   test('mobile: SMS subscribe persists notification row', async ({ page }) => {
     const runId = `${Date.now().toString(36)}-sms`;

--- a/apps/web/tests/e2e/smoke-manifest.ts
+++ b/apps/web/tests/e2e/smoke-manifest.ts
@@ -18,6 +18,7 @@
 export const DESKTOP_SMOKE_SPECS = [
   'smoke-public.spec.ts',
   'golden-path.spec.ts',
+  'profile-fan-capture-golden-path.spec.ts',
   'onboarding-robot.smoke.spec.ts',
   'signup-funnel.smoke.spec.ts',
   'smoke-auth.spec.ts',

--- a/apps/web/tests/unit/lib/notifications/audience-upsert.integration.test.ts
+++ b/apps/web/tests/unit/lib/notifications/audience-upsert.integration.test.ts
@@ -1,0 +1,94 @@
+import { and, sql as drizzleSql, eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { createFingerprint } from '@/app/api/audience/lib/audience-utils';
+import { db } from '@/lib/db';
+import { getDeepErrorMessage } from '@/lib/db/errors';
+import { audienceMembers } from '@/lib/db/schema/analytics';
+
+const CREATOR_PROFILE_ID = 'a96b46e1-1250-4e7c-98b2-9e271eb72c37';
+
+const hasRealDatabase =
+  Boolean(process.env.DATABASE_URL) &&
+  !process.env.DATABASE_URL?.includes('dummy');
+
+describe('audience upsert via db client', () => {
+  it.skipIf(!hasRealDatabase)(
+    'inserts a subscriber row using core columns only',
+    async () => {
+      const runId = Date.now().toString();
+      const email = `fan-capture-integration+${runId}@test.jov.ie`;
+      const fingerprint = createFingerprint('127.0.0.1', `vitest-${runId}`);
+      const now = new Date();
+
+      try {
+        await db.execute(drizzleSql`
+        INSERT INTO audience_members (
+          creator_profile_id,
+          fingerprint,
+          type,
+          display_name,
+          first_seen_at,
+          last_seen_at,
+          visits,
+          engagement_score,
+          intent_level,
+          device_type,
+          referrer_history,
+          latest_actions,
+          email,
+          tags,
+          created_at,
+          updated_at
+        ) VALUES (
+          ${CREATOR_PROFILE_ID},
+          ${fingerprint},
+          'email',
+          'Subscriber',
+          ${now},
+          ${now},
+          0,
+          0,
+          'low',
+          'unknown',
+          '[]'::jsonb,
+          '[]'::jsonb,
+          ${email},
+          '[]'::jsonb,
+          ${now},
+          ${now}
+        )
+        ON CONFLICT (creator_profile_id, fingerprint)
+        DO UPDATE SET
+          type = 'email',
+          email = EXCLUDED.email,
+          last_seen_at = EXCLUDED.last_seen_at,
+          updated_at = EXCLUDED.updated_at
+      `);
+
+        const [row] = await db
+          .select({ id: audienceMembers.id })
+          .from(audienceMembers)
+          .where(
+            and(
+              eq(audienceMembers.creatorProfileId, CREATOR_PROFILE_ID),
+              eq(audienceMembers.email, email)
+            )
+          )
+          .limit(1);
+
+        expect(row?.id).toBeTruthy();
+      } catch (error) {
+        throw new Error(getDeepErrorMessage(error));
+      } finally {
+        await db
+          .delete(audienceMembers)
+          .where(
+            and(
+              eq(audienceMembers.creatorProfileId, CREATOR_PROFILE_ID),
+              eq(audienceMembers.email, email)
+            )
+          );
+      }
+    }
+  );
+});

--- a/apps/web/tests/unit/lib/notifications/domain.test.ts
+++ b/apps/web/tests/unit/lib/notifications/domain.test.ts
@@ -23,6 +23,9 @@ vi.mock('@/lib/db', () => ({
     onConflictDoNothing: vi.fn().mockReturnThis(),
     onConflictDoUpdate: vi.fn().mockReturnThis(),
     returning: vi.fn().mockResolvedValue([{ id: 'sub-1' }]),
+    execute: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
     delete: vi.fn().mockReturnThis(),
   },
 }));
@@ -190,9 +193,6 @@ describe('notifications/domain', () => {
     it('keeps the subscribe success path when audience enrichment fails', async () => {
       const artistId = '123e4567-e89b-12d3-a456-426614174000';
       const { db } = await import('@/lib/db');
-      const { withSystemIngestionSession } = await import(
-        '@/lib/ingestion/session'
-      );
       const { captureError } = await import('@/lib/error-tracking');
 
       vi.mocked(db.limit)
@@ -208,7 +208,7 @@ describe('notifications/domain', () => {
         ])
         .mockResolvedValueOnce([]);
 
-      vi.mocked(withSystemIngestionSession).mockRejectedValueOnce(
+      vi.mocked(db.execute).mockRejectedValueOnce(
         new Error('column "latest_referrer_url" does not exist')
       );
 

--- a/apps/web/tests/unit/lib/notifications/email-otp.test.ts
+++ b/apps/web/tests/unit/lib/notifications/email-otp.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('email OTP generation', () => {
+  const originalBypass = process.env.E2E_USE_TEST_AUTH_BYPASS;
+  const originalE2eMode = process.env.NEXT_PUBLIC_E2E_MODE;
+  const originalVercelEnv = process.env.VERCEL_ENV;
+
+  afterEach(() => {
+    if (originalBypass === undefined) {
+      delete process.env.E2E_USE_TEST_AUTH_BYPASS;
+    } else {
+      process.env.E2E_USE_TEST_AUTH_BYPASS = originalBypass;
+    }
+
+    if (originalE2eMode === undefined) {
+      delete process.env.NEXT_PUBLIC_E2E_MODE;
+    } else {
+      process.env.NEXT_PUBLIC_E2E_MODE = originalE2eMode;
+    }
+
+    if (originalVercelEnv === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = originalVercelEnv;
+    }
+
+    vi.resetModules();
+  });
+
+  it('returns the deterministic fan-capture OTP when E2E bypass is enabled', async () => {
+    process.env.E2E_USE_TEST_AUTH_BYPASS = '1';
+    vi.resetModules();
+
+    const { generateFanCaptureEmailOtpCode } = await import(
+      '@/lib/notifications/email-otp'
+    );
+
+    expect(generateFanCaptureEmailOtpCode()).toBe('424242');
+    expect(generateFanCaptureEmailOtpCode()).toBe('424242');
+  });
+
+  it('never returns the deterministic OTP from generateEmailOtpCode', async () => {
+    process.env.E2E_USE_TEST_AUTH_BYPASS = '1';
+    vi.resetModules();
+
+    const { generateEmailOtpCode } = await import(
+      '@/lib/notifications/email-otp'
+    );
+
+    const codes = new Set(
+      Array.from({ length: 20 }, () => generateEmailOtpCode())
+    );
+
+    expect(codes.has('424242')).toBe(false);
+    expect(codes.size).toBeGreaterThan(1);
+    for (const code of codes) {
+      expect(code).toMatch(/^\d{6}$/);
+    }
+  });
+
+  it('returns random fan-capture codes when E2E bypass is disabled', async () => {
+    delete process.env.E2E_USE_TEST_AUTH_BYPASS;
+    delete process.env.NEXT_PUBLIC_E2E_MODE;
+    vi.resetModules();
+
+    const { generateFanCaptureEmailOtpCode } = await import(
+      '@/lib/notifications/email-otp'
+    );
+
+    const codes = new Set(
+      Array.from({ length: 20 }, () => generateFanCaptureEmailOtpCode())
+    );
+
+    expect(codes.size).toBeGreaterThan(1);
+    for (const code of codes) {
+      expect(code).toMatch(/^\d{6}$/);
+    }
+  });
+
+  it('disables deterministic fan-capture OTP on production deploys', async () => {
+    process.env.E2E_USE_TEST_AUTH_BYPASS = '1';
+    process.env.VERCEL_ENV = 'production';
+    vi.resetModules();
+
+    const { generateFanCaptureEmailOtpCode } = await import(
+      '@/lib/notifications/email-otp'
+    );
+
+    const codes = new Set(
+      Array.from({ length: 20 }, () => generateFanCaptureEmailOtpCode())
+    );
+
+    expect(codes.has('424242')).toBe(false);
+    expect(codes.size).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (grok-composer-2.5-fast). Closes #11369.

Card: t_2e984ae4
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- error rate + p95 latency on affected surface
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.