### PR TITLE
feat(analytics): self-explanatory metric labels, invariant-safe empty states

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-analytics/DashboardAnalytics.tsx
+++ b/apps/web/components/features/dashboard/dashboard-analytics/DashboardAnalytics.tsx
@@ -1,12 +1,20 @@
 'use client';
 
-import { Globe, Link2, MapPin } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@jovie/ui';
+import { Globe, HelpCircle, Link2, MapPin } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import type { ComponentType, SVGProps } from 'react';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
 import { DashboardRefreshButton } from '@/features/dashboard/molecules/DashboardRefreshButton';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
+import {
+  type DashboardMetricKey,
+  getContradictoryMetrics,
+  isMetricEmpty,
+  METRIC_DEFINITIONS,
+  METRIC_EMPTY_LABELS,
+} from '@/lib/analytics/metric-definitions';
 import { usePlanGate } from '@/lib/queries';
 import { captureException } from '@/lib/sentry/client-lite';
 import { cn } from '@/lib/utils';
@@ -30,19 +38,27 @@ function formatLinkType(linkType: string): string {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Stat card — compact metric with optional meta line                */
+/*  Stat card — compact metric with definition tooltip                 */
 /* ------------------------------------------------------------------ */
 
 function StatCard({
   label,
   value,
   meta,
+  definition,
   loading,
+  suspect,
+  'data-testid': testId,
 }: {
   readonly label: string;
   readonly value: string;
   readonly meta?: string;
+  /** One-line definition shown in tooltip. */
+  readonly definition?: string;
   readonly loading?: boolean;
+  /** When true, value is contradictory — show a safe placeholder instead. */
+  readonly suspect?: boolean;
+  readonly 'data-testid'?: string;
 }) {
   if (loading) {
     return (
@@ -59,14 +75,42 @@ function StatCard({
   }
 
   return (
-    <ContentSurfaceCard className='p-4 lg:p-5'>
-      <p className='text-app text-secondary-token'>{label}</p>
-      <p className='mt-1 text-2xl font-semibold tracking-[-0.011em] text-primary-token tabular-nums'>
-        {value}
-      </p>
-      {meta && (
-        <p className='mt-1 text-2xs text-tertiary-token tabular-nums'>{meta}</p>
+    <ContentSurfaceCard className='p-4 lg:p-5' data-testid={testId}>
+      <div className='flex items-center gap-1'>
+        <p className='text-app text-secondary-token'>{label}</p>
+        {definition ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type='button'
+                className='text-tertiary-token transition-colors hover:text-secondary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                aria-label={`About ${label}`}
+              >
+                <HelpCircle className='h-3 w-3' />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side='top' className='max-w-[200px]'>
+              <p className='text-app'>{definition}</p>
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+      </div>
+      {suspect ? (
+        <p
+          className='mt-1 text-2xl font-semibold tracking-[-0.011em] text-tertiary-token'
+          title='Value may be inaccurate'
+          data-testid={testId ? `${testId}-suspect` : undefined}
+        >
+          —
+        </p>
+      ) : (
+        <p className='mt-1 text-2xl font-semibold tracking-[-0.011em] text-primary-token tabular-nums'>
+          {value}
+        </p>
       )}
+      {!suspect && meta ? (
+        <p className='mt-1 text-2xs text-tertiary-token tabular-nums'>{meta}</p>
+      ) : null}
     </ContentSurfaceCard>
   );
 }
@@ -173,6 +217,32 @@ export function DashboardAnalytics() {
   const fmt = numberFormatter;
   const showTipLinkVisits = (data?.tip_link_visits ?? 0) > 0;
 
+  // Identify contradictory metric values so we can hide them safely.
+  const contradictory: ReadonlySet<string> = loading
+    ? new Set<DashboardMetricKey>()
+    : getContradictoryMetrics({
+        profile_views: data?.profile_views,
+        unique_users: data?.unique_users,
+        subscribers: data?.subscribers,
+        listen_clicks: data?.listen_clicks,
+        total_clicks: data?.total_clicks,
+        identified_users: data?.identified_users,
+        capture_rate: data?.capture_rate,
+      });
+
+  // Resolve display value: explicit empty label, or formatted number.
+  // Returns '—' when data hasn't loaded yet (error/pre-fetch).
+  function displayValue(
+    key: Parameters<typeof isMetricEmpty>[0],
+    rawValue: number | undefined
+  ): string {
+    if (!loading && data === undefined) return '—';
+    if (!loading && isMetricEmpty(key, data ?? {})) {
+      return METRIC_EMPTY_LABELS[key];
+    }
+    return fmt.format(rawValue ?? 0);
+  }
+
   return (
     <div className='max-w-5xl space-y-8'>
       <h1 className='sr-only'>Analytics</h1>
@@ -206,33 +276,44 @@ export function DashboardAnalytics() {
         aria-labelledby={activeRangeTabId}
         className='space-y-6'
       >
-        {/* Primary metrics — conversion funnel as stat cards */}
+        {/* Primary metrics — conversion funnel */}
         <div className='grid grid-cols-1 gap-3 sm:grid-cols-3'>
           <StatCard
-            label='Profile Views'
-            value={fmt.format(data?.profile_views ?? 0)}
-            meta='Total page visits'
+            label={METRIC_DEFINITIONS.profile_views.label}
+            definition={METRIC_DEFINITIONS.profile_views.definition}
+            value={displayValue('profile_views', data?.profile_views)}
             loading={loading}
+            data-testid='stat-profile-views'
           />
           <StatCard
-            label='Unique Visitors'
-            value={fmt.format(data?.unique_users ?? 0)}
+            label={METRIC_DEFINITIONS.unique_users.label}
+            definition={METRIC_DEFINITIONS.unique_users.definition}
+            value={displayValue('unique_users', data?.unique_users)}
             meta={
-              (data?.profile_views ?? 0) > 0
+              !loading &&
+              (data?.profile_views ?? 0) > 0 &&
+              !contradictory.has('unique_users')
                 ? `${Math.round(((data?.unique_users ?? 0) / (data?.profile_views ?? 1)) * 100)}% of views`
                 : undefined
             }
             loading={loading}
+            suspect={contradictory.has('unique_users')}
+            data-testid='stat-unique-users'
           />
           <StatCard
-            label='Followers'
-            value={fmt.format(data?.subscribers ?? 0)}
+            label={METRIC_DEFINITIONS.subscribers.label}
+            definition={METRIC_DEFINITIONS.subscribers.definition}
+            value={displayValue('subscribers', data?.subscribers)}
             meta={
-              (data?.unique_users ?? 0) > 0
+              !loading &&
+              (data?.unique_users ?? 0) > 0 &&
+              !contradictory.has('subscribers')
                 ? `${Math.round(((data?.subscribers ?? 0) / (data?.unique_users ?? 1)) * 100)}% conversion`
                 : undefined
             }
             loading={loading}
+            suspect={contradictory.has('subscribers')}
+            data-testid='stat-subscribers'
           />
         </div>
 
@@ -247,27 +328,42 @@ export function DashboardAnalytics() {
               )}
             >
               <StatCard
-                label='Capture Rate'
-                value={`${data.capture_rate ?? 0}%`}
-                meta='Visitors to followers'
+                label={METRIC_DEFINITIONS.capture_rate.label}
+                definition={METRIC_DEFINITIONS.capture_rate.definition}
+                value={
+                  isMetricEmpty('capture_rate', data)
+                    ? METRIC_EMPTY_LABELS.capture_rate
+                    : `${data.capture_rate ?? 0}%`
+                }
+                suspect={contradictory.has('capture_rate')}
+                data-testid='stat-capture-rate'
               />
               <StatCard
-                label='Listen Clicks'
-                value={fmt.format(data.listen_clicks)}
+                label={METRIC_DEFINITIONS.listen_clicks.label}
+                definition={METRIC_DEFINITIONS.listen_clicks.definition}
+                value={displayValue('listen_clicks', data.listen_clicks)}
+                suspect={contradictory.has('listen_clicks')}
+                data-testid='stat-listen-clicks'
               />
               <StatCard
-                label='Identified Users'
-                value={fmt.format(data.identified_users)}
+                label={METRIC_DEFINITIONS.identified_users.label}
+                definition={METRIC_DEFINITIONS.identified_users.definition}
+                value={displayValue('identified_users', data.identified_users)}
+                suspect={contradictory.has('identified_users')}
+                data-testid='stat-identified-users'
               />
               <StatCard
-                label='Total Clicks'
-                value={fmt.format(data.total_clicks ?? 0)}
-                meta='All time'
+                label={METRIC_DEFINITIONS.total_clicks.label}
+                definition={METRIC_DEFINITIONS.total_clicks.definition}
+                value={displayValue('total_clicks', data.total_clicks)}
+                data-testid='stat-total-clicks'
               />
               {showTipLinkVisits ? (
                 <StatCard
-                  label='Tip Link Visits'
-                  value={fmt.format(data.tip_link_visits ?? 0)}
+                  label={METRIC_DEFINITIONS.tip_link_visits.label}
+                  definition={METRIC_DEFINITIONS.tip_link_visits.definition}
+                  value={displayValue('tip_link_visits', data.tip_link_visits)}
+                  data-testid='stat-tip-link-visits'
                 />
               ) : null}
             </div>

--- a/apps/web/lib/analytics/metric-definitions.ts
+++ b/apps/web/lib/analytics/metric-definitions.ts
@@ -1,0 +1,177 @@
+/**
+ * Canonical analytics metric definitions — single source of truth for labels,
+ * one-line definitions, and invariant guards used across analytics UIs.
+ *
+ * Every metric shown in the dashboard reads its label and definition from here.
+ * Guards prevent displaying logically impossible number combinations.
+ */
+
+export interface MetricDefinition {
+  readonly label: string;
+  /** One-line plain-language definition shown in tooltip/help UI. */
+  readonly definition: string;
+}
+
+/** All dashboard analytics metric keys. */
+export type DashboardMetricKey =
+  | 'profile_views'
+  | 'unique_users'
+  | 'subscribers'
+  | 'capture_rate'
+  | 'listen_clicks'
+  | 'identified_users'
+  | 'total_clicks'
+  | 'tip_link_visits';
+
+export const METRIC_DEFINITIONS: Record<DashboardMetricKey, MetricDefinition> =
+  {
+    profile_views: {
+      label: 'Profile Views',
+      definition:
+        'Total page visits, including repeat visits from the same person.',
+    },
+    unique_users: {
+      label: 'Unique Visitors',
+      definition:
+        'Individual people who visited your profile, counted once per person.',
+    },
+    subscribers: {
+      label: 'Followers',
+      definition:
+        'Fans who opted in to notifications — your capturable audience.',
+    },
+    capture_rate: {
+      label: 'Capture Rate',
+      definition:
+        'Percentage of unique visitors who became followers (subscribers ÷ unique visitors).',
+    },
+    listen_clicks: {
+      label: 'Listen Clicks',
+      definition:
+        'Clicks on streaming links (Spotify, Apple Music, etc.) from your profile.',
+    },
+    identified_users: {
+      label: 'Identified Users',
+      definition:
+        'Visitors matched to a known fan record with an email or phone number.',
+    },
+    total_clicks: {
+      label: 'Total Clicks',
+      definition: 'All link clicks on your profile across the selected period.',
+    },
+    tip_link_visits: {
+      label: 'Tip Link Visits',
+      definition: 'Visits to your tipping page from your profile.',
+    },
+  };
+
+/**
+ * Analytics invariant guards.
+ *
+ * Returns a set of metric keys whose values are suspect because they violate
+ * a known logical constraint. The UI should hide or mark these values instead
+ * of displaying them as-is.
+ *
+ * Invariants:
+ * - unique_users cannot exceed profile_views (deduplication only reduces the count)
+ * - subscribers cannot exceed unique_users (fans must have visited first)
+ * - listen_clicks cannot exceed total_clicks (listen is a subset of total)
+ * - identified_users cannot exceed unique_users (identified is a subset of unique)
+ * - capture_rate must be [0, 100] when unique_users > 0; undefined otherwise
+ */
+export function getContradictoryMetrics(metrics: {
+  readonly profile_views?: number;
+  readonly unique_users?: number;
+  readonly subscribers?: number;
+  readonly listen_clicks?: number;
+  readonly total_clicks?: number;
+  readonly identified_users?: number;
+  readonly capture_rate?: number;
+}): ReadonlySet<DashboardMetricKey> {
+  const suspect = new Set<DashboardMetricKey>();
+
+  const views = metrics.profile_views ?? 0;
+  const unique = metrics.unique_users ?? 0;
+  const subs = metrics.subscribers ?? 0;
+  const listen = metrics.listen_clicks ?? 0;
+  const total = metrics.total_clicks ?? 0;
+  const identified = metrics.identified_users ?? 0;
+  const captureRate = metrics.capture_rate ?? 0;
+
+  // unique visitors > total views is impossible
+  if (views === 0 && unique > 0) suspect.add('unique_users');
+  if (unique > views && views > 0) suspect.add('unique_users');
+
+  // subscribers > unique visitors is impossible
+  if (unique === 0 && subs > 0) suspect.add('subscribers');
+  if (subs > unique && unique > 0) suspect.add('subscribers');
+
+  // listen clicks > total clicks is impossible (listen is a subset)
+  // Also flag when total is absent but listen is non-zero (subset can't exceed missing total)
+  if (total === 0 && listen > 0) suspect.add('listen_clicks');
+  if (total > 0 && listen > total) suspect.add('listen_clicks');
+
+  // identified users > unique visitors is impossible
+  if (unique === 0 && identified > 0) suspect.add('identified_users');
+  if (identified > unique && unique > 0) suspect.add('identified_users');
+
+  // capture rate out of [0, 100] range
+  if (unique > 0 && (captureRate < 0 || captureRate > 100))
+    suspect.add('capture_rate');
+
+  return suspect;
+}
+
+/**
+ * Returns true when a metric value should display as an explicit empty state
+ * rather than the raw number.
+ *
+ * A metric is "empty" when it's zero AND none of its upstream funnel metrics
+ * are non-zero (to avoid the contradiction of "0 views but 4 clicks").
+ */
+export function isMetricEmpty(
+  key: DashboardMetricKey,
+  metrics: {
+    readonly profile_views?: number;
+    readonly unique_users?: number;
+    readonly subscribers?: number;
+    readonly listen_clicks?: number;
+    readonly total_clicks?: number;
+    readonly identified_users?: number;
+    readonly capture_rate?: number;
+    readonly tip_link_visits?: number;
+  }
+): boolean {
+  const v = metrics[key];
+  if (v === undefined || v === null || v > 0) return false;
+
+  // profile_views: no upstream — always a genuine zero
+  if (key === 'profile_views') return v === 0;
+
+  // downstream metrics: only mark empty if their upstream is also zero
+  // (prevents "No unique visitors yet" when profile_views > 0 but unique = 0)
+  const views = metrics.profile_views ?? 0;
+  const unique = metrics.unique_users ?? 0;
+
+  if (key === 'unique_users') return views === 0;
+  if (key === 'subscribers') return unique === 0;
+  if (key === 'capture_rate') return unique === 0;
+  if (key === 'listen_clicks') return views === 0;
+  if (key === 'total_clicks') return views === 0;
+  if (key === 'identified_users') return unique === 0;
+  if (key === 'tip_link_visits') return views === 0;
+
+  return false;
+}
+
+/** Empty-state label for each metric (shown in place of the number). */
+export const METRIC_EMPTY_LABELS: Record<DashboardMetricKey, string> = {
+  profile_views: 'No views yet',
+  unique_users: 'No visitors yet',
+  subscribers: 'No followers yet',
+  capture_rate: '—',
+  listen_clicks: 'No listen clicks yet',
+  identified_users: 'No identified users yet',
+  total_clicks: 'No clicks yet',
+  tip_link_visits: 'No tip visits yet',
+};

--- a/apps/web/tests/unit/analytics-metric-definitions.test.ts
+++ b/apps/web/tests/unit/analytics-metric-definitions.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getContradictoryMetrics,
+  isMetricEmpty,
+  METRIC_DEFINITIONS,
+  METRIC_EMPTY_LABELS,
+} from '@/lib/analytics/metric-definitions';
+
+// ---------------------------------------------------------------------------
+// Canonical definitions coverage
+// ---------------------------------------------------------------------------
+
+describe('METRIC_DEFINITIONS', () => {
+  it('every metric key has a label and definition', () => {
+    for (const [key, def] of Object.entries(METRIC_DEFINITIONS)) {
+      expect(def.label, `${key}.label`).toBeTruthy();
+      expect(def.definition, `${key}.definition`).toBeTruthy();
+    }
+  });
+
+  it('every metric key has a corresponding METRIC_EMPTY_LABELS entry', () => {
+    for (const key of Object.keys(METRIC_DEFINITIONS)) {
+      expect(
+        METRIC_EMPTY_LABELS[key as keyof typeof METRIC_EMPTY_LABELS],
+        `empty label for ${key}`
+      ).toBeTruthy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant / contradiction guards
+// ---------------------------------------------------------------------------
+
+describe('getContradictoryMetrics', () => {
+  it('returns empty set for fully consistent data', () => {
+    const result = getContradictoryMetrics({
+      profile_views: 100,
+      unique_users: 80,
+      subscribers: 20,
+      listen_clicks: 30,
+      total_clicks: 50,
+      identified_users: 40,
+      capture_rate: 25,
+    });
+    expect(result.size).toBe(0);
+  });
+
+  it('flags unique_users when it exceeds profile_views', () => {
+    const result = getContradictoryMetrics({
+      profile_views: 10,
+      unique_users: 20,
+    });
+    expect(result.has('unique_users')).toBe(true);
+  });
+
+  it('flags unique_users when profile_views is 0 but unique_users > 0', () => {
+    // The canonical contradiction: 0 views but non-zero visitors
+    const result = getContradictoryMetrics({
+      profile_views: 0,
+      unique_users: 5,
+    });
+    expect(result.has('unique_users')).toBe(true);
+  });
+
+  it('flags subscribers when unique_users is 0 but subscribers > 0', () => {
+    const result = getContradictoryMetrics({
+      profile_views: 0,
+      unique_users: 0,
+      subscribers: 3,
+    });
+    expect(result.has('subscribers')).toBe(true);
+  });
+
+  it('flags subscribers when they exceed unique_users', () => {
+    const result = getContradictoryMetrics({
+      profile_views: 100,
+      unique_users: 10,
+      subscribers: 15,
+    });
+    expect(result.has('subscribers')).toBe(true);
+  });
+
+  it('flags listen_clicks when they exceed total_clicks', () => {
+    const result = getContradictoryMetrics({
+      profile_views: 100,
+      total_clicks: 5,
+      listen_clicks: 10,
+    });
+    expect(result.has('listen_clicks')).toBe(true);
+  });
+
+  it('flags listen_clicks when total_clicks is absent but listen_clicks > 0', () => {
+    // total_clicks missing from API payload — listen can't be non-zero if total is unknown/0
+    const result = getContradictoryMetrics({
+      profile_views: 100,
+      listen_clicks: 5,
+    });
+    expect(result.has('listen_clicks')).toBe(true);
+  });
+
+  it('flags identified_users when they exceed unique_users', () => {
+    const result = getContradictoryMetrics({
+      profile_views: 100,
+      unique_users: 10,
+      identified_users: 20,
+    });
+    expect(result.has('identified_users')).toBe(true);
+  });
+
+  it('flags identified_users when unique_users is 0 but identified > 0', () => {
+    const result = getContradictoryMetrics({
+      profile_views: 0,
+      unique_users: 0,
+      identified_users: 2,
+    });
+    expect(result.has('identified_users')).toBe(true);
+  });
+
+  it('flags capture_rate above 100', () => {
+    const result = getContradictoryMetrics({
+      profile_views: 100,
+      unique_users: 50,
+      subscribers: 30,
+      capture_rate: 120,
+    });
+    expect(result.has('capture_rate')).toBe(true);
+  });
+
+  it('flags capture_rate below 0', () => {
+    const result = getContradictoryMetrics({
+      profile_views: 100,
+      unique_users: 50,
+      capture_rate: -5,
+    });
+    expect(result.has('capture_rate')).toBe(true);
+  });
+
+  it('does not flag profile_views itself (it is the root)', () => {
+    const result = getContradictoryMetrics({
+      profile_views: 0,
+      unique_users: 0,
+      subscribers: 0,
+    });
+    expect(result.has('profile_views')).toBe(false);
+  });
+
+  it('handles undefined metrics gracefully (no crash)', () => {
+    expect(() =>
+      getContradictoryMetrics({
+        profile_views: undefined,
+        unique_users: undefined,
+      })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty-state logic
+// ---------------------------------------------------------------------------
+
+describe('isMetricEmpty', () => {
+  it('returns true for profile_views when 0', () => {
+    expect(isMetricEmpty('profile_views', { profile_views: 0 })).toBe(true);
+  });
+
+  it('returns false for profile_views when > 0', () => {
+    expect(isMetricEmpty('profile_views', { profile_views: 5 })).toBe(false);
+  });
+
+  it('returns true for unique_users=0 when profile_views is also 0', () => {
+    expect(
+      isMetricEmpty('unique_users', { profile_views: 0, unique_users: 0 })
+    ).toBe(true);
+  });
+
+  it('returns false for unique_users=0 when profile_views > 0 (contradictory but not empty)', () => {
+    // 0 unique visitors despite 10 views is not "empty" — it's suspicious
+    expect(
+      isMetricEmpty('unique_users', { profile_views: 10, unique_users: 0 })
+    ).toBe(false);
+  });
+
+  it('returns true for subscribers=0 when unique_users is also 0', () => {
+    expect(
+      isMetricEmpty('subscribers', { unique_users: 0, subscribers: 0 })
+    ).toBe(true);
+  });
+
+  it('returns false for subscribers=0 when unique_users > 0 (0% conversion is valid)', () => {
+    expect(
+      isMetricEmpty('subscribers', { unique_users: 50, subscribers: 0 })
+    ).toBe(false);
+  });
+
+  it('returns false when value is positive', () => {
+    expect(
+      isMetricEmpty('listen_clicks', { profile_views: 100, listen_clicks: 3 })
+    ).toBe(false);
+  });
+
+  it('returns false when value is undefined (not yet loaded)', () => {
+    expect(isMetricEmpty('listen_clicks', { profile_views: 0 })).toBe(false);
+  });
+
+  it('returns true for capture_rate=0 when unique_users is also 0', () => {
+    expect(
+      isMetricEmpty('capture_rate', { unique_users: 0, capture_rate: 0 })
+    ).toBe(true);
+  });
+
+  it('returns false for capture_rate=0 when unique_users > 0 (0% conversion is valid)', () => {
+    expect(
+      isMetricEmpty('capture_rate', { unique_users: 50, capture_rate: 0 })
+    ).toBe(false);
+  });
+
+  it('returns true for tip_link_visits=0 when profile_views is also 0', () => {
+    expect(
+      isMetricEmpty('tip_link_visits', {
+        profile_views: 0,
+        tip_link_visits: 0,
+      })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a canonical `metric-definitions` module as the **single source of truth** for all dashboard analytics metric labels, one-line definitions, contradiction guards, and empty-state logic
- Wires a `HelpCircle` tooltip (using the project's `@jovie/ui` Tooltip component) into every `StatCard` — users can now read a plain-language definition for every number they see
- Replaces bare `0` with explicit empty labels ("No views yet", "No visitors yet", "No followers yet") when a metric is zero **and** its upstream is also zero — prevents nonsense like "No visitors yet" appearing when there are already views
- Hides contradictory values with `—` when the invariant guard flags an impossible combination (e.g. `unique_users > profile_views`, or `subscribers > unique_users`)
- Fixes primary stats grid showing `0 / 0 / 0` next to the error banner when data fails to load

## Files changed

| File | Change |
|---|---|
| `apps/web/lib/analytics/metric-definitions.ts` | New canonical module (labels, definitions, `getContradictoryMetrics`, `isMetricEmpty`, `METRIC_EMPTY_LABELS`) |
| `apps/web/components/features/dashboard/dashboard-analytics/DashboardAnalytics.tsx` | Uses definitions module; adds tooltips, empty states, contradiction safety |
| `apps/web/tests/unit/analytics-metric-definitions.test.ts` | 26 unit tests covering all invariant rules and empty-state edge cases |

## Verification

```
✓ tests/unit/analytics-metric-definitions.test.ts (26 tests) 3ms
Test Files  1 passed (1)
Tests       26 passed (26)
```

```
pnpm typecheck: clean (0 errors)
pnpm biome check: clean
```

Closes #12031