### PR TITLE
fix(infra): redis keepalive ping in /api/health to stop upstash auto-archive

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -11,6 +11,30 @@ import {
   getClientIP,
   healthLimiter,
 } from '@/lib/rate-limit';
+import { getRedis } from '@/lib/redis';
+
+const REDIS_KEEPALIVE_TIMEOUT_MS = 2000;
+
+/**
+ * Issue one cheap Redis command per health invocation so the free-tier Upstash
+ * DB never goes idle long enough (~14 days) to auto-archive. Archiving makes
+ * every rate limiter error and fall back to in-memory, fanning out the
+ * [CRITICAL] alert cluster (JOV-11962). Fail-soft and timeout-bounded — health
+ * must stay green even when Redis is unreachable or unconfigured.
+ */
+async function pingRedisKeepalive(): Promise<void> {
+  try {
+    const redis = getRedis({
+      signal: AbortSignal.timeout(REDIS_KEEPALIVE_TIMEOUT_MS),
+    });
+    await redis?.ping();
+  } catch (error) {
+    void captureWarning('Redis keepalive ping failed', error, {
+      service: 'redis',
+      route: '/api/health',
+    });
+  }
+}
 
 function hasTrustedAutomationBypass(request: Request): boolean {
   const configuredSecret = env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim();
@@ -61,6 +85,11 @@ export async function GET(request: Request) {
     }
   }
 
+  // Keep the Upstash DB warm. Started here so it runs concurrently with the DB
+  // check and never delays the happy path; awaited before each response so the
+  // command is guaranteed to flush before the serverless function freezes.
+  const keepalive = pingRedisKeepalive();
+
   // Minimal response - only status and timestamp (no environment details)
   const summary: Record<string, unknown> = {
     status: 'checking',
@@ -71,6 +100,7 @@ export async function GET(request: Request) {
     const databaseUrl = env.DATABASE_URL;
 
     if (!databaseUrl) {
+      await keepalive;
       summary.status = 'degraded';
       summary.database = 'unavailable';
       return NextResponse.json(summary, {
@@ -81,6 +111,8 @@ export async function GET(request: Request) {
 
     // Pure connectivity check — SELECT 1 proves DB is reachable, no table dependency
     await db.execute(drizzleSql`SELECT 1`);
+
+    await keepalive;
 
     // Success: return canonical {"status":"ok"} only (no timestamp/database).
     // 503 responses include extra diagnostic fields — the asymmetry is intentional.
@@ -95,6 +127,7 @@ export async function GET(request: Request) {
       }
     );
   } catch (error) {
+    await keepalive;
     void captureWarning('Health check degraded', error, {
       service: 'health',
       route: '/api/health',

--- a/apps/web/tests/unit/api/health/main.critical.test.ts
+++ b/apps/web/tests/unit/api/health/main.critical.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockHealthLimiterLimit = vi.hoisted(() => vi.fn());
 const mockDbExecute = vi.hoisted(() => vi.fn());
 const mockCaptureWarning = vi.hoisted(() => vi.fn());
+const mockGetRedis = vi.hoisted(() => vi.fn());
+const mockPing = vi.hoisted(() => vi.fn());
 const mockEnv = vi.hoisted(() => ({
   DATABASE_URL: 'postgres://test:test@localhost:5432/test',
   VERCEL_AUTOMATION_BYPASS_SECRET: undefined as string | undefined,
@@ -20,6 +22,10 @@ vi.mock('@/lib/db', () => ({
   db: {
     execute: mockDbExecute,
   },
+}));
+
+vi.mock('@/lib/redis', () => ({
+  getRedis: mockGetRedis,
 }));
 
 vi.mock('@/lib/error-tracking', () => ({
@@ -42,6 +48,8 @@ describe('@critical GET /api/health', () => {
       remaining: 29,
       reset: new Date(Date.now() + 60000),
     });
+    mockPing.mockResolvedValue('PONG');
+    mockGetRedis.mockReturnValue({ ping: mockPing });
   });
 
   it('returns 429 when rate limited', async () => {
@@ -129,5 +137,54 @@ describe('@critical GET /api/health', () => {
       expect.any(Error),
       expect.objectContaining({ service: 'health', route: '/api/health' })
     );
+  });
+
+  // Redis keepalive (JOV-11962): one cheap command per invocation keeps the
+  // free-tier Upstash DB from auto-archiving after ~14 days of inactivity.
+  it('issues exactly one Redis keepalive command per invocation', async () => {
+    mockDbExecute.mockResolvedValue(undefined);
+
+    const { GET } = await import('@/app/api/health/route');
+    const response = await GET(new Request('http://localhost/api/health'));
+
+    expect(response.status).toBe(200);
+    expect(mockPing).toHaveBeenCalledTimes(1);
+  });
+
+  it('still pings to keep the DB warm even when the DB check fails', async () => {
+    mockDbExecute.mockRejectedValue(new Error('Connection refused'));
+
+    const { GET } = await import('@/app/api/health/route');
+    const response = await GET(new Request('http://localhost/api/health'));
+
+    expect(response.status).toBe(503);
+    expect(mockPing).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays green and fail-soft when the keepalive ping throws', async () => {
+    mockDbExecute.mockResolvedValue(undefined);
+    mockPing.mockRejectedValue(new Error('Upstash archived'));
+
+    const { GET } = await import('@/app/api/health/route');
+    const response = await GET(new Request('http://localhost/api/health'));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ok' });
+    expect(mockCaptureWarning).toHaveBeenCalledWith(
+      'Redis keepalive ping failed',
+      expect.any(Error),
+      expect.objectContaining({ service: 'redis', route: '/api/health' })
+    );
+  });
+
+  it('stays green when Redis is unconfigured (getRedis returns null)', async () => {
+    mockDbExecute.mockResolvedValue(undefined);
+    mockGetRedis.mockReturnValue(null);
+
+    const { GET } = await import('@/app/api/health/route');
+    const response = await GET(new Request('http://localhost/api/health'));
+
+    expect(response.status).toBe(200);
+    expect(mockPing).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/unit/api/health/main.critical.test.ts
+++ b/apps/web/tests/unit/api/health/main.critical.test.ts
@@ -187,4 +187,20 @@ describe('@critical GET /api/health', () => {
     expect(response.status).toBe(200);
     expect(mockPing).not.toHaveBeenCalled();
   });
+
+  it('does not issue a keepalive ping on the rate-limited path', async () => {
+    mockHealthLimiterLimit.mockResolvedValue({
+      success: false,
+      limit: 30,
+      remaining: 0,
+      reset: new Date(Date.now() + 60000),
+      reason: 'Rate limit exceeded',
+    });
+
+    const { GET } = await import('@/app/api/health/route');
+    const response = await GET(new Request('http://localhost/api/health'));
+
+    expect(response.status).toBe(429);
+    expect(mockPing).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-11962 -->
Closes #11962

## Problem
Free-tier Upstash Redis auto-archives after ~14 days with no commands. Once archived, every rate limiter errors and falls back to in-memory, fanning out the `JOVIE-WEB-N2..NT` `[CRITICAL]` alert cluster + N2 "Redis not configured", and degrading rate limiting (in-memory limiters don't share state across instances). Confirmed by Tim 2026-06-25: env vars are set in prod — the DB was archived for inactivity. Manual restore clears it but it recurs every ~2 weeks.

The `/api/health` endpoint (hit by uptime/canary/deploy monitors) only touched Redis indirectly via `healthLimiter` — and the automation-bypass path skips that — so health traffic alone didn't keep the DB warm.

## Fix
Add one fail-soft, timeout-bounded `redis.ping()` per `/api/health` invocation:
- Started **concurrently** with the DB `SELECT 1` so it never slows the happy path; awaited before each response so the command flushes before the serverless function freezes.
- **Fail-soft:** any error/timeout/abort is swallowed into a `captureWarning`; health stays `200`/green when Redis is unreachable or unconfigured (`getRedis()` returns `null` → no-op).
- **Bounded:** native `AbortSignal.timeout(2000)` caps the Upstash REST call (security rule "Server-Side External HTTP Must Be Bounded").
- No new cron, no `vercel.json` change — modifies an existing route only.

## Acceptance criteria
- [x] `/api/health` issues exactly one cheap Redis command per invocation (`redis.ping()`).
- [x] Health endpoint still returns 200 + green when Redis is unreachable/unconfigured.
- [x] Keepalive command runs on success, DB-missing-url, and DB-throws paths (DB stays warm even when degraded).
- [ ] Upstash DB no longer auto-archives / `[CRITICAL]` cluster does not recur over 30 days — **observational, verify in prod ops**.

## Cost Impact
- **External API calls:** +1 Upstash REST command (`PING`) per `/api/health` invocation. Health is hit by uptime/canary/deploy monitors (~1/min worst case ≈ 1,440/day), well within the Upstash free-tier 10k-commands/day budget.
- **Scaling factor:** O(1) per request — single ping, no loop/fan-out. Independent of user count.
- **Net:** trivial spend; eliminates a recurring manual human restore every ~2 weeks.

## Verification
```
typecheck: pnpm --filter @jovie/web run typecheck -- --pretty false   → clean
biome:     pnpm biome check apps/web/app/api/health/route.ts          → no fixes
tests:     pnpm --filter web exec vitest run tests/unit/api/health/   → 11 files, 26 passed
           main.critical.test.ts (10 tests) — incl. 5 new keepalive cases:
             ✓ issues exactly one Redis keepalive command per invocation
             ✓ still pings to keep the DB warm even when the DB check fails
             ✓ stays green and fail-soft when the keepalive ping throws
             ✓ stays green when Redis is unconfigured (getRedis returns null)
             ✓ does not issue a keepalive ping on the rate-limited path
```

## Reviews
- **Code review (subagent, opus):** CLEAN — verified one-ping-per-invocation on all non-429 paths, no 200→500 flip (ping promise is swallowed), timer-free after switching to `AbortSignal.timeout`.
- **Security review (subagent, opus):** No new findings — fail-soft, leak-free (no secrets in warning payload), one bounded command per request. Noted a **pre-existing** `getClientIP` header-spoof weakness affecting the IP rate limit on all public routes (out of scope, not introduced by this change). Linear MCP is unauthenticated in this automated session, so a follow-up issue could not be auto-filed — flagging here so it can be tracked: harden `getClientIP` to trust only the platform-injected client IP (rightmost hop on Vercel) instead of client-supplied `cf-connecting-ip`/`x-forwarded-for`.
- **CodeRabbit:** first pass flagged manual `AbortController`+`setTimeout` → applied its suggestion (native `AbortSignal.timeout`). Re-review hit the plan rate limit (23-min wait); the sole prior finding is resolved.

## Bug-to-test
Regression coverage added in `main.critical.test.ts` (5 keepalive cases above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
