### PR TITLE
refactor(proxy): centralize degraded HTTP response into auth-degraded-fallback

### DIFF
--- a/apps/web/lib/auth/auth-degraded-fallback.ts
+++ b/apps/web/lib/auth/auth-degraded-fallback.ts
@@ -98,6 +98,28 @@ export function buildAuthDegradedHtmlResponse(): Response {
 }
 
 /**
+ * Returns a 503 JSON response for API/fetch callers (no Accept: text/html).
+ * Reuse this alongside buildAuthDegradedHtmlResponse wherever proxy.ts
+ * distinguishes browser navigation from API requests on degraded auth paths.
+ */
+export function buildAuthDegradedJsonResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'Service temporarily unavailable',
+      message: 'Authentication service is initializing. Please try again.',
+    }),
+    {
+      status: 503,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': '5',
+        'Cache-Control': 'no-store',
+      },
+    }
+  );
+}
+
+/**
  * Returns true if the request's Accept header indicates a browser navigation
  * (i.e., the caller expects an HTML document).
  *

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/audience/public-profile-block';
 import {
   buildAuthDegradedHtmlResponse,
+  buildAuthDegradedJsonResponse,
   isBrowserNavigation,
 } from '@/lib/auth/auth-degraded-fallback';
 import { buildProtectedAuthRedirectUrl } from '@/lib/auth/build-auth-route-url';
@@ -800,19 +801,7 @@ export default async function middleware(
     if (isBrowserNavigation(req.headers.get('accept'))) {
       return buildAuthDegradedHtmlResponse();
     }
-    return new NextResponse(
-      JSON.stringify({
-        error: 'Service temporarily unavailable',
-        message: 'Authentication service is initializing. Please try again.',
-      }),
-      {
-        status: 503,
-        headers: {
-          'Content-Type': 'application/json',
-          'Retry-After': '5',
-        },
-      }
-    );
+    return buildAuthDegradedJsonResponse();
   }
 
   const clerkPathInfo: ClerkBypassPathInfo = pathInfo;
@@ -870,19 +859,7 @@ export default async function middleware(
     if (isBrowserNavigation(req.headers.get('accept'))) {
       return buildAuthDegradedHtmlResponse();
     }
-    return new NextResponse(
-      JSON.stringify({
-        error: 'Service temporarily unavailable',
-        message: 'Authentication service is initializing. Please try again.',
-      }),
-      {
-        status: 503,
-        headers: {
-          'Content-Type': 'application/json',
-          'Retry-After': '5',
-        },
-      }
-    );
+    return buildAuthDegradedJsonResponse();
   }
 
   try {
@@ -910,19 +887,7 @@ export default async function middleware(
       if (isBrowserNavigation(req.headers.get('accept'))) {
         return buildAuthDegradedHtmlResponse();
       }
-      return new NextResponse(
-        JSON.stringify({
-          error: 'Service temporarily unavailable',
-          message: 'Authentication service is initializing. Please try again.',
-        }),
-        {
-          status: 503,
-          headers: {
-            'Content-Type': 'application/json',
-            'Retry-After': '5',
-          },
-        }
-      );
+      return buildAuthDegradedJsonResponse();
     }
     throw error;
   }

--- a/apps/web/tests/unit/middleware/proxy-regions.contract.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-regions.contract.test.ts
@@ -32,6 +32,8 @@ const mocks = vi.hoisted(() => ({
   isMaliciousProbePath: vi.fn(),
   createProbeDropResponse: vi.fn(),
   buildAuthDegradedHtmlResponse: vi.fn(),
+  buildAuthDegradedJsonResponse: vi.fn(),
+  isBrowserNavigation: vi.fn().mockReturnValue(true),
   resolveClerkKeys: vi.fn(),
   isStagingHost: vi.fn(),
   captureError: vi.fn(),
@@ -58,6 +60,8 @@ vi.mock('@/lib/security/probe-detection', () => ({
 
 vi.mock('@/lib/auth/auth-degraded-fallback', () => ({
   buildAuthDegradedHtmlResponse: mocks.buildAuthDegradedHtmlResponse,
+  buildAuthDegradedJsonResponse: mocks.buildAuthDegradedJsonResponse,
+  isBrowserNavigation: mocks.isBrowserNavigation,
 }));
 
 vi.mock('@/lib/auth/staging-clerk-keys', () => ({


### PR DESCRIPTION
## Summary

- Extracts `buildAuthDegradedJsonResponse()` into `auth-degraded-fallback.ts` alongside the existing `buildAuthDegradedHtmlResponse()`, removing three identical inline JSON blocks from `proxy.ts`
- Adds `Cache-Control: no-store` to the JSON 503 response (matches the HTML response's headers; prevents CDN/browser caching of auth-error responses)
- Updates `proxy-regions.contract.test.ts` mock to include the new exports

Closes #11956

## Verification

```
✓ tests/unit/middleware/proxy-auth-degraded-html.test.ts (14 tests)
✓ tests/unit/middleware/proxy-regions.contract.test.ts (5 tests)
Total: 19/19 passed

Typecheck: 0 errors
Biome: 0 issues
```

**Diff:** 3 files changed, +30 / -39 (net -9 lines)

## Test plan

- [x] All 14 proxy-auth-degraded-html tests pass (covers all 4 degraded sites: FAPI decode failure, clerkConfigMissing, !selectedMiddleware, staging throw)
- [x] proxy-regions contract test passes
- [x] Typecheck passes
- [x] Biome passes
- [x] Testing subagent: PASS
- [x] Review subagent: PASS (correct deduplication, Cache-Control: no-store appropriate, all 3 call sites were equivalent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)