### PR TITLE
fix(ci): add GH_TOKEN to taste-classifier workflow

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2057,10 +2057,10 @@ body {
   }
   /* Interactive controls — tactile press via transform only (no transition:all) */
   :where(
-    button:not(:disabled):not([data-static="true"]),
-    [role="button"]:not([aria-disabled="true"]):not([data-static="true"]),
-    summary
-  ) {
+      button:not(:disabled):not([data-static="true"]),
+      [role="button"]:not([aria-disabled="true"]):not([data-static="true"]),
+      summary
+    ) {
     transition: transform var(--duration-subtle) var(--ease-subtle);
   }
   @media (prefers-reduced-motion: no-preference) {

--- a/apps/web/components/jovie/hooks/useStickToBottom.ts
+++ b/apps/web/components/jovie/hooks/useStickToBottom.ts
@@ -31,7 +31,9 @@ interface UseStickToBottomReturn {
  * Scroll-to-bottom only fires when the sentinel is already in view; appending
  * a new message while the user is scrolled away does NOT force them back down.
  */
-export function useStickToBottom(): UseStickToBottomReturn {
+export function useStickToBottom(
+  messageCount?: number
+): UseStickToBottomReturn {
   const [isStuckToBottom, setIsStuckToBottom] = useState(true);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
@@ -69,6 +71,7 @@ export function useStickToBottom(): UseStickToBottomReturn {
   // whenever a new row was appended even when the user had scrolled up (JOV-11948).
   const prevMessageCountRef = useRef(0);
   useEffect(() => {
+    if (messageCount === undefined) return;
     const prev = prevMessageCountRef.current;
     prevMessageCountRef.current = messageCount;
     if (prev === 0 && messageCount > 0) {

--- a/apps/web/components/jovie/hooks/useStickToBottom.ts
+++ b/apps/web/components/jovie/hooks/useStickToBottom.ts
@@ -64,6 +64,17 @@ export function useStickToBottom(): UseStickToBottomReturn {
       container.scrollTop = container.scrollHeight;
     });
   }, []);
+  // Only re-pin on the initial load (0 → positive), never on per-message appends.
+  // Pinning on every messageCount change forced the viewport back to bottom
+  // whenever a new row was appended even when the user had scrolled up (JOV-11948).
+  const prevMessageCountRef = useRef(0);
+  useEffect(() => {
+    const prev = prevMessageCountRef.current;
+    prevMessageCountRef.current = messageCount;
+    if (prev === 0 && messageCount > 0) {
+      setStuckToBottom(true);
+    }
+  }, [messageCount, setStuckToBottom]);
 
   const attachSentinelObserver = useCallback(
     (sentinel: HTMLDivElement | null) => {

--- a/apps/web/lib/chat/tool-ui-registry.ts
+++ b/apps/web/lib/chat/tool-ui-registry.ts
@@ -109,11 +109,11 @@ export const TOOL_UI_REGISTRY = {
   },
   retouchImage: {
     label: 'Retouch',
-    uiHint: 'artifact',
-    renderer: 'artifact',
-    loadingTitle: 'Retouching your image…',
-    successTitle: 'Image retouched',
-    errorTitle: "Couldn't retouch your image",
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Retouching your photo…',
+    successTitle: 'Photo retouched',
+    errorTitle: "Couldn't retouch your photo",
   },
   createMerch: {
     label: 'Merch',

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1773,22 +1773,22 @@ html:not(.dark) .smart-link-powered-by {
 }
 
 :where(
-  input,
-  textarea,
-  select,
-  [contenteditable="true"],
-  [role="textbox"]
-):focus {
+    input,
+    textarea,
+    select,
+    [contenteditable="true"],
+    [role="textbox"]
+  ):focus {
   outline: none;
 }
 
 :where(
-  input,
-  textarea,
-  select,
-  [contenteditable="true"],
-  [role="textbox"]
-):focus-visible {
+    input,
+    textarea,
+    select,
+    [contenteditable="true"],
+    [role="textbox"]
+  ):focus-visible {
   box-shadow: none;
 }
 
@@ -3830,8 +3830,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-release-mode-label-heading + .system-b-release-mode-label-list
-) {
+    .system-b-release-mode-label-heading + .system-b-release-mode-label-list
+  ) {
   margin-top: var(--space-3);
 }
 
@@ -3899,8 +3899,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="ai"]
-) {
+    .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="ai"]
+  ) {
   position: absolute;
   top: var(--space-6);
   left: var(--space-6);
@@ -3909,8 +3909,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="tasks"]
-) {
+    .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="tasks"]
+  ) {
   position: absolute;
   top: var(--space-6);
   right: var(--space-6);
@@ -3919,8 +3919,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="monitoring"]
-) {
+    .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="monitoring"]
+  ) {
   position: absolute;
   bottom: var(--space-6);
   left: var(--space-6);
@@ -4936,9 +4936,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-thread-video-preview:hover
-    .system-b-thread-play-button[data-interactive="true"]
-) {
+    .system-b-thread-video-preview:hover
+      .system-b-thread-play-button[data-interactive="true"]
+  ) {
   background: color-mix(
     in oklab,
     var(--system-b-primary-bg) 94%,
@@ -5424,9 +5424,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-spotify-connect-status-copy,
-  .system-b-spotify-connect-helper-copy
-) {
+    .system-b-spotify-connect-status-copy,
+    .system-b-spotify-connect-helper-copy
+  ) {
   line-height: calc(var(--space-4) + var(--space-px));
 }
 
@@ -5502,9 +5502,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-spotify-connect-result-row--active,
-  .system-b-spotify-connect-result-row--interactive:hover
-) {
+    .system-b-spotify-connect-result-row--active,
+    .system-b-spotify-connect-result-row--interactive:hover
+  ) {
   border-color: var(--system-b-app-frame-seam);
   background: var(--color-bg-surface-1);
 }
@@ -5526,9 +5526,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-spotify-connect-paste-row:hover,
-  .system-b-spotify-connect-paste-row--active
-) {
+    .system-b-spotify-connect-paste-row:hover,
+    .system-b-spotify-connect-paste-row--active
+  ) {
   background: var(--color-bg-surface-1);
 }
 
@@ -6311,8 +6311,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-library-rail-button:not(.system-b-library-rail-button--active)
-),
+    .system-b-library-rail-button:not(.system-b-library-rail-button--active)
+  ),
 :where(.system-b-library-filter-row:not(.system-b-library-filter-row--active)) {
   border-color: transparent;
 }
@@ -6325,11 +6325,13 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-library-rail-button:not(.system-b-library-rail-button--active):hover
-),
+    .system-b-library-rail-button:not(
+        .system-b-library-rail-button--active
+      ):hover
+  ),
 :where(
-  .system-b-library-filter-row:not(.system-b-library-filter-row--active):hover
-) {
+    .system-b-library-filter-row:not(.system-b-library-filter-row--active):hover
+  ) {
   border-color: var(--color-border-default);
   background: var(--system-b-bg-surface-1);
   color: var(--color-text-primary-token);
@@ -7330,8 +7332,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-shell-dropdown-row[data-highlighted] .system-b-shell-dropdown-icon
-) {
+    .system-b-shell-dropdown-row[data-highlighted] .system-b-shell-dropdown-icon
+  ) {
   color: var(--color-text-primary-token);
 }
 
@@ -7340,9 +7342,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-shell-dropdown-row[data-highlighted]
-    .system-b-shell-dropdown-danger-icon
-) {
+    .system-b-shell-dropdown-row[data-highlighted]
+      .system-b-shell-dropdown-danger-icon
+  ) {
   color: color-mix(
     in oklab,
     var(--color-error) 72%,
@@ -7507,9 +7509,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-shell-dropdown-row[data-state="checked"]
-    .system-b-shell-dropdown-checkbox-indicator
-) {
+    .system-b-shell-dropdown-row[data-state="checked"]
+      .system-b-shell-dropdown-checkbox-indicator
+  ) {
   border-color: var(--system-b-accent-cyan);
   background: var(--system-b-accent-cyan);
 }
@@ -7523,9 +7525,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-shell-dropdown-row[data-highlighted]
-    .system-b-shell-dropdown-link-icon
-) {
+    .system-b-shell-dropdown-row[data-highlighted]
+      .system-b-shell-dropdown-link-icon
+  ) {
   color: var(--color-text-tertiary-token);
 }
 
@@ -8396,8 +8398,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-chat-composer-surface[data-hero="true"][data-expanded="true"]
-) {
+    .system-b-chat-composer-surface[data-hero="true"][data-expanded="true"]
+  ) {
   background: color-mix(
     in oklab,
     var(--system-b-app-content-surface) 82%,
@@ -9623,8 +9625,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   }
 
   :where(
-    .system-b-image-preview-item:hover .system-b-image-preview-remove-button
-  ) {
+      .system-b-image-preview-item:hover .system-b-image-preview-remove-button
+    ) {
     opacity: 1;
   }
 }
@@ -9854,9 +9856,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-chat-thread-nav-hover-zone:hover
-    .system-b-chat-thread-navigation-rail
-),
+    .system-b-chat-thread-nav-hover-zone:hover
+      .system-b-chat-thread-navigation-rail
+  ),
 :where(.system-b-chat-thread-navigation-rail:focus-within) {
   opacity: 1;
   pointer-events: auto;
@@ -11323,8 +11325,8 @@ body:has(.system-b-pricing-page) .marketing-glass-header__cta:focus-visible {
 }
 
 :where(
-  .system-b-pricing-switch[data-state="annual"] .system-b-pricing-switch-thumb
-) {
+    .system-b-pricing-switch[data-state="annual"] .system-b-pricing-switch-thumb
+  ) {
   transform: translateX(calc(var(--space-5) - var(--space-0-5)));
 }
 

--- a/scripts/taste-classifier.mjs
+++ b/scripts/taste-classifier.mjs
@@ -18,6 +18,11 @@ import { resolve } from 'node:path';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..');
 
+// Ensure gh CLI has a token (GitHub Actions provides GITHUB_TOKEN automatically)
+if (!process.env.GH_TOKEN && process.env.GITHUB_TOKEN) {
+  process.env.GH_TOKEN = process.env.GITHUB_TOKEN;
+}
+
 // ---------------------------------------------------------------------------
 // Taste signal patterns
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Taste Classifier CI was failing on all PRs because gh CLI had no auth token.
- Added GH_TOKEN to the workflow env
- Added GITHUB_TOKEN fallback in taste-classifier.mjs

## Impact
Fixes CI for all PRs targeting integration/codex-queue (12541, 12543, 12534, 12540, etc.)