### PR TITLE
feat(chat): teleprompter showcase interstitial with A/B conversion gate

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -90,6 +90,7 @@ import {
   createMerchPreviewTool,
   createMerchSelectTool,
 } from '@/lib/chat/tools/merch-tools';
+import { createProposeVideoRecordingTool } from '@/lib/chat/tools/propose-video-recording';
 import { createRetouchImageTool } from '@/lib/chat/tools/retouch-image';
 import {
   type ChatTurnSource,
@@ -1980,6 +1981,7 @@ function buildChatTools(
   albumArtEnabled: boolean,
   canAccessMerchCreation: boolean,
   canAccessAiRetouching: boolean,
+  teleprompterRecordingEnabled: boolean,
   userEntitlements: Awaited<
     ReturnType<
       typeof import('@/lib/entitlements/server').getCurrentUserEntitlements
@@ -2149,6 +2151,13 @@ function buildChatTools(
           }),
           showMerchSales: createMerchSalesTool(resolvedProfileId),
           showArtistPayouts: createMerchPayoutsTool(resolvedProfileId),
+        }
+      : {}),
+    ...(teleprompterRecordingEnabled
+      ? {
+          proposeVideoRecording: createProposeVideoRecordingTool({
+            clerkUserId,
+          }),
         }
       : {}),
   };
@@ -2405,6 +2414,10 @@ export async function POST(req: Request) {
   const albumArtFeatureEnabled = await getAppFlagValue('ALBUM_ART_GENERATION', {
     userId,
   });
+  const teleprompterRecordingEnabled = await getAppFlagValue(
+    'TELEPROMPTER_RECORDING',
+    { userId }
+  );
   const albumArtCapability = resolveAlbumArtCapability({
     featureEnabled: albumArtFeatureEnabled,
     providerConfigured: isXaiConfigured(),
@@ -2722,6 +2735,7 @@ export async function POST(req: Request) {
             albumArtEnabled,
             planLimits.booleans.canAccessMerchCreation,
             planLimits.booleans.canAccessAiRetouching,
+            teleprompterRecordingEnabled,
             currentUserEntitlements,
             reservedTurn
           ),

--- a/apps/web/components/jovie/components/ChatVideoRecordingProposalCard.tsx
+++ b/apps/web/components/jovie/components/ChatVideoRecordingProposalCard.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { Button } from '@jovie/ui';
+import { Check, Loader2, Upload, Video } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { TeleprompterShowcaseInterstitial } from '@/components/jovie/components/TeleprompterShowcaseInterstitial';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+import { trackTeleprompterFunnel } from '@/lib/teleprompter/analytics';
+import { shouldShowTeleprompterShowcase } from '@/lib/teleprompter/persistence';
+import { startTeleprompterRecording } from '@/lib/teleprompter/recorder';
+import type { VideoRecordingProposalPayload } from '@/lib/teleprompter/types';
+import {
+  getTeleprompterVideoAcceptTypes,
+  uploadRecordableVideo,
+} from '@/lib/teleprompter/upload-video';
+import { cn } from '@/lib/utils';
+
+interface ChatVideoRecordingProposalCardProps {
+  readonly profileId: string;
+  readonly payload: VideoRecordingProposalPayload;
+}
+
+type UploadState = 'idle' | 'uploading' | 'success' | 'error';
+
+export function ChatVideoRecordingProposalCard({
+  profileId,
+  payload,
+}: ChatVideoRecordingProposalCardProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const trackedProposalRef = useRef(false);
+  const [showcaseOpen, setShowcaseOpen] = useState(false);
+  const [uploadState, setUploadState] = useState<UploadState>('idle');
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (trackedProposalRef.current) return;
+    trackedProposalRef.current = true;
+    trackTeleprompterFunnel('teleprompter_proposal_impression', {
+      profileId,
+      kind: payload.kind,
+      showcaseVariant: payload.showcaseVariant,
+      title: payload.title,
+    });
+  }, [profileId, payload]);
+
+  useEffect(() => {
+    return () => {
+      if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+    };
+  }, []);
+
+  const recordingContext = useMemo(
+    () => ({
+      profileId,
+      kind: payload.kind,
+      title: payload.title,
+      script: payload.script,
+      showcaseVariant: payload.showcaseVariant,
+      source: 'chat_proposal' as const,
+    }),
+    [profileId, payload]
+  );
+
+  const openRecorder = useCallback(() => {
+    startTeleprompterRecording(recordingContext);
+  }, [recordingContext]);
+
+  const openShowcaseOrRecorder = useCallback(() => {
+    if (shouldShowTeleprompterShowcase(profileId, payload.showcaseVariant)) {
+      setShowcaseOpen(true);
+      return;
+    }
+    openRecorder();
+  }, [profileId, payload.showcaseVariant, openRecorder]);
+
+  const scheduleShowcaseOnHover = () => {
+    if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+    hoverTimerRef.current = setTimeout(() => {
+      if (shouldShowTeleprompterShowcase(profileId, payload.showcaseVariant)) {
+        setShowcaseOpen(true);
+      }
+    }, 280);
+  };
+
+  const cancelShowcaseOnHover = () => {
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  };
+
+  const handleUploadClick = () => {
+    if (uploadState === 'uploading') return;
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+
+    setUploadState('uploading');
+    setUploadError(null);
+    try {
+      await uploadRecordableVideo({
+        file,
+        profileId,
+        kind: payload.kind,
+        showcaseVariant: payload.showcaseVariant,
+      });
+      setUploadState('success');
+    } catch (error) {
+      setUploadState('error');
+      setUploadError(
+        error instanceof Error ? error.message : 'Upload failed. Try again.'
+      );
+    }
+  };
+
+  if (uploadState === 'success') {
+    return (
+      <ContentSurfaceCard
+        className='system-b-chat-video-recording-state-card'
+        data-testid='chat-video-recording-upload-success'
+      >
+        <div className='flex items-center gap-2 text-success'>
+          <Check className='h-4 w-4' aria-hidden='true' />
+          <span className='text-sm font-medium'>Video uploaded to Library</span>
+        </div>
+      </ContentSurfaceCard>
+    );
+  }
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type='file'
+        accept={getTeleprompterVideoAcceptTypes()}
+        className='hidden'
+        tabIndex={-1}
+        onChange={handleFileChange}
+      />
+      <ContentSurfaceCard
+        className='system-b-chat-video-recording-card p-4'
+        data-testid='chat-video-recording-proposal-card'
+      >
+        <div className='flex flex-col gap-3'>
+          <div>
+            <p className='text-sm font-semibold text-primary-token'>
+              {payload.title}
+            </p>
+            <p className='mt-1 line-clamp-3 text-xs leading-5 text-secondary-token'>
+              {payload.script}
+            </p>
+          </div>
+          <div className='flex flex-wrap gap-2'>
+            <Button
+              type='button'
+              size='sm'
+              variant='outline'
+              onClick={handleUploadClick}
+              disabled={uploadState === 'uploading'}
+              data-testid='chat-video-recording-upload'
+            >
+              {uploadState === 'uploading' ? (
+                <Loader2 className='mr-1.5 h-3.5 w-3.5 animate-spin' />
+              ) : (
+                <Upload className='mr-1.5 h-3.5 w-3.5' aria-hidden='true' />
+              )}
+              Upload Video
+            </Button>
+            <Button
+              type='button'
+              size='sm'
+              className={cn('bg-btn-primary text-btn-primary-foreground')}
+              onClick={openShowcaseOrRecorder}
+              onMouseEnter={scheduleShowcaseOnHover}
+              onMouseLeave={cancelShowcaseOnHover}
+              onFocus={scheduleShowcaseOnHover}
+              onBlur={cancelShowcaseOnHover}
+              data-testid='chat-video-recording-record-in-app'
+            >
+              <Video className='mr-1.5 h-3.5 w-3.5' aria-hidden='true' />
+              Record In App
+            </Button>
+          </div>
+          {uploadState === 'error' && uploadError ? (
+            <p className='text-xs text-error' role='alert'>
+              {uploadError}
+            </p>
+          ) : null}
+        </div>
+      </ContentSurfaceCard>
+
+      <TeleprompterShowcaseInterstitial
+        open={showcaseOpen}
+        onOpenChange={setShowcaseOpen}
+        profileId={profileId}
+        kind={payload.kind}
+        title={payload.title}
+        script={payload.script}
+        showcaseVariant={payload.showcaseVariant}
+        onStartRecording={openRecorder}
+      />
+    </>
+  );
+}

--- a/apps/web/components/jovie/components/TeleprompterNotchVisual.tsx
+++ b/apps/web/components/jovie/components/TeleprompterNotchVisual.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import { cn } from '@/lib/utils';
+
+interface TeleprompterNotchVisualProps {
+  readonly script: string;
+  readonly className?: string;
+}
+
+const PHONE_SHELL_STYLE: CSSProperties = {
+  backgroundColor: 'color-mix(in oklab, var(--color-accent-blue) 8%, #0a0a0f)',
+};
+
+/**
+ * Hero visual for the teleprompter showcase — a phone silhouette with a
+ * notch-adjacent script preview, inspired by Moody's teleprompter demo.
+ */
+export function TeleprompterNotchVisual({
+  script,
+  className,
+}: TeleprompterNotchVisualProps) {
+  const preview =
+    script.length > 120 ? `${script.slice(0, 117).trimEnd()}…` : script;
+
+  return (
+    <div
+      className={cn(
+        'relative mx-auto aspect-[10/16] w-full max-w-[220px] overflow-hidden rounded-[28px] border border-white/14 shadow-[0_24px_60px_rgba(0,0,0,0.45)]',
+        className
+      )}
+      style={PHONE_SHELL_STYLE}
+      data-testid='teleprompter-notch-visual'
+    >
+      <div
+        aria-hidden='true'
+        className='absolute left-1/2 top-2 h-5 w-24 -translate-x-1/2 rounded-full bg-black dark:bg-black'
+      />
+      <div className='absolute inset-x-3 top-10 bottom-4 flex flex-col items-center justify-start px-2 pt-3 text-center'>
+        <p className='text-[11px] font-medium leading-snug tracking-[-0.01em] text-white/88 dark:text-white/88'>
+          {preview}
+        </p>
+        <span
+          aria-hidden='true'
+          className='mt-3 h-1 w-10 rounded-full bg-accent-blue/70'
+        />
+      </div>
+      <span
+        aria-hidden='true'
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(113,112,255,0.18),transparent_55%)]'
+      />
+    </div>
+  );
+}

--- a/apps/web/components/jovie/components/TeleprompterShowcaseInterstitial.tsx
+++ b/apps/web/components/jovie/components/TeleprompterShowcaseInterstitial.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { Button } from '@jovie/ui';
+import { X } from 'lucide-react';
+import type { CSSProperties } from 'react';
+import { useEffect, useRef } from 'react';
+import { TeleprompterNotchVisual } from '@/components/jovie/components/TeleprompterNotchVisual';
+import { trackTeleprompterFunnel } from '@/lib/teleprompter/analytics';
+import type {
+  RecordableVideoKind,
+  TeleprompterShowcaseVariant,
+} from '@/lib/teleprompter/types';
+import { cn } from '@/lib/utils';
+
+export interface TeleprompterShowcaseInterstitialProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly profileId: string;
+  readonly kind: RecordableVideoKind;
+  readonly title: string;
+  readonly script: string;
+  readonly showcaseVariant: TeleprompterShowcaseVariant;
+  readonly onStartRecording: () => void;
+}
+
+const SHOWCASE_GRADIENT_STYLE: CSSProperties = {
+  background:
+    'radial-gradient(120% 100% at 50% -8%, color-mix(in oklab, var(--color-accent-blue) 36%, #101020) 0%, #0a0a12 58%)',
+};
+
+export function TeleprompterShowcaseInterstitial({
+  open,
+  onOpenChange,
+  profileId,
+  kind,
+  title,
+  script,
+  showcaseVariant,
+  onStartRecording,
+}: TeleprompterShowcaseInterstitialProps) {
+  const trackedImpressionRef = useRef(false);
+
+  useEffect(() => {
+    if (!open || trackedImpressionRef.current) return;
+    trackedImpressionRef.current = true;
+    trackTeleprompterFunnel('teleprompter_showcase_impression', {
+      profileId,
+      kind,
+      showcaseVariant,
+      title,
+    });
+  }, [open, profileId, kind, showcaseVariant, title]);
+
+  if (!open) return null;
+
+  const handleDismiss = () => {
+    trackTeleprompterFunnel('teleprompter_showcase_dismissed', {
+      profileId,
+      kind,
+      showcaseVariant,
+      title,
+    });
+    onOpenChange(false);
+  };
+
+  const handleStart = () => {
+    onStartRecording();
+    onOpenChange(false);
+  };
+
+  return (
+    <div
+      className='fixed inset-0 z-50 flex items-center justify-center p-4'
+      data-testid='teleprompter-showcase-interstitial'
+    >
+      <button
+        type='button'
+        aria-label='Dismiss Teleprompter Preview'
+        className='absolute inset-0 bg-black/55 backdrop-blur-sm'
+        onClick={handleDismiss}
+      />
+      <div
+        role='dialog'
+        aria-modal='true'
+        aria-labelledby='teleprompter-showcase-title'
+        className={cn(
+          'relative z-10',
+          'relative w-full max-w-lg overflow-hidden rounded-3xl border border-white/12',
+          'p-6 text-white shadow-[0_28px_80px_rgba(0,0,0,0.5)] dark:text-white sm:p-8'
+        )}
+        style={SHOWCASE_GRADIENT_STYLE}
+      >
+        <button
+          type='button'
+          onClick={handleDismiss}
+          className='absolute right-4 top-4 inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/14 bg-white/8 text-white/80 transition-colors hover:bg-white/14 dark:text-white/80'
+          aria-label='Dismiss Teleprompter Preview'
+        >
+          <X className='h-4 w-4' aria-hidden='true' />
+        </button>
+
+        <div className='grid gap-6 sm:grid-cols-[minmax(0,1fr)_180px] sm:items-center'>
+          <div className='min-w-0'>
+            <p className='text-2xs font-medium text-white/65 dark:text-white/65'>
+              {title}
+            </p>
+            <h2
+              id='teleprompter-showcase-title'
+              className='mt-2 text-xl font-semibold tracking-[-0.02em] text-white dark:text-white'
+            >
+              {'Record With A Voice Following Teleprompter'}
+            </h2>
+            <p className='mt-2 max-w-[34ch] text-sm leading-5 text-white/72 dark:text-white/72'>
+              Jovie scrolls your script in real time as you speak, so you keep
+              eye contact with the camera.
+            </p>
+            <div className='mt-6 flex flex-wrap gap-3'>
+              <Button
+                type='button'
+                size='sm'
+                className='bg-white text-black hover:bg-white/92 dark:bg-white dark:text-black dark:hover:bg-white/92'
+                onClick={handleStart}
+                data-testid='teleprompter-showcase-start'
+              >
+                Start Recording
+              </Button>
+              <Button
+                type='button'
+                size='sm'
+                variant='outline'
+                className='border-white/20 bg-transparent text-white hover:bg-white/10 dark:text-white'
+                onClick={handleDismiss}
+              >
+                Not Now
+              </Button>
+            </div>
+          </div>
+          <TeleprompterNotchVisual script={script} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -15,6 +15,7 @@ import {
 import { getToolUiConfig } from '@/lib/chat/tool-ui-registry';
 import { env } from '@/lib/env-client';
 import { addBreadcrumb } from '@/lib/sentry/client-lite';
+import { isVideoRecordingProposalPayload } from '@/lib/teleprompter/types';
 import { cn } from '@/lib/utils';
 import { ChatAlbumArtCard } from './components/ChatAlbumArtCard';
 import { ChatAnalyticsCard } from './components/ChatAnalyticsCard';
@@ -33,6 +34,7 @@ import {
   isChatMerchDesignCarouselResult,
 } from './components/ChatMerchDesignCarousel';
 import { ChatPitchCard } from './components/ChatPitchCard';
+import { ChatVideoRecordingProposalCard } from './components/ChatVideoRecordingProposalCard';
 import type {
   ChatInsightsToolResult,
   MessagePart,
@@ -539,8 +541,26 @@ function renderMerchActionArtifact(
   );
 }
 
+function renderVideoRecordingArtifact(
+  event: PersistedToolEvent,
+  profileId?: string
+): ReactNode {
+  if (!profileId || !isVideoRecordingProposalPayload(event.output)) {
+    return null;
+  }
+
+  return (
+    <ChatVideoRecordingProposalCard
+      profileId={profileId}
+      payload={event.output}
+    />
+  );
+}
+
 const ARTIFACT_RENDERERS: Partial<Record<string, ArtifactRenderer>> = {
   proposeAvatarUpload: event => renderAvatarUploadArtifact(event),
+  proposeVideoRecording: (event, profileId) =>
+    renderVideoRecordingArtifact(event, profileId),
   proposeProfileEdit: (event, profileId) =>
     renderProfileEditArtifact(event, profileId),
   proposeSocialLink: (event, profileId) =>

--- a/apps/web/lib/chat/system-prompt.ts
+++ b/apps/web/lib/chat/system-prompt.ts
@@ -190,6 +190,9 @@ Use the generateReleasePitch tool when the artist asks for a release pitch or wh
 ## Voice Promo (gh-9808)
 Use the voicePromo tool when the artist says "clone my voice", "voice promo", "radio drop", "DJ liner", "promo audio from my voice", or "generate a drop with my cloned voice". It generates short playable promo audio (radio station liner) from a cloned ElevenLabs voiceId + text/script. Always confirm voiceId (user provides or from prior clone flow). This is a premium tool. Keep scripts short (<280 chars ideal for radio). Pass style or targetStation when provided for personalization. The output is base64 audio ready for playback/download.
 
+## In-App Video Recording
+Use proposeVideoRecording when you have written a short talking-head script for a promo, thank-you, or behind-the-scenes video and the artist should record it in Jovie. Pass the script you wrote, a concise title, and the kind. The card offers Upload video and Record in app; do not start recording yourself.
+
 ## Merch Creation
 Use merch tools immediately when the artist asks to make, preview, publish, pause, kill, bring back, rank, optimize, or inspect merch. createMerch and previewMerchOptions always produce exactly three options. After showing options, ask the artist to pick 1, 2, or 3, or describe a change.
 Use createMerchAlternativeItem when the artist asks for the same saved design on another product. Do not regenerate the design unless they ask for a different concept.

--- a/apps/web/lib/chat/tool-ui-registry.ts
+++ b/apps/web/lib/chat/tool-ui-registry.ts
@@ -323,6 +323,14 @@ export const TOOL_UI_REGISTRY = {
     successTitle: 'Checkout ready',
     errorTitle: "Couldn't prepare checkout",
   },
+  proposeVideoRecording: {
+    label: 'Video recording',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Preparing your recording…',
+    successTitle: 'Ready to record',
+    errorTitle: "Couldn't prepare your recording",
+  },
 } as const satisfies Record<string, ToolUiConfig>;
 
 function startCaseFromCamelCase(value: string): string {

--- a/apps/web/lib/chat/tools/propose-video-recording.ts
+++ b/apps/web/lib/chat/tools/propose-video-recording.ts
@@ -1,0 +1,62 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { getTeleprompterShowcaseVariant } from '@/lib/flags/server';
+import {
+  RECORDABLE_VIDEO_KINDS,
+  type RecordableVideoKind,
+  type VideoRecordingProposalPayload,
+} from '@/lib/teleprompter/types';
+
+export { isVideoRecordingProposalPayload } from '@/lib/teleprompter/types';
+
+import { chatToolSchema } from '@/lib/chat/strict-schema';
+
+const KIND_LABELS: Record<RecordableVideoKind, string> = {
+  promo: 'Promo video',
+  thank_you: 'Thank-you video',
+  bts: 'Behind-the-scenes video',
+};
+
+export function createProposeVideoRecordingTool(options: {
+  readonly clerkUserId: string;
+}) {
+  return tool({
+    description:
+      'Propose recording a short talking-head video in the Jovie app. Use when Jovie has written a promo, thank-you, or behind-the-scenes script and the artist should record it. Shows Upload video and Record in app actions with an optional teleprompter showcase.',
+    inputSchema: chatToolSchema({
+      kind: z
+        .enum(RECORDABLE_VIDEO_KINDS)
+        .describe('What type of recordable video this proposal is for.'),
+      title: z
+        .string()
+        .min(3)
+        .max(120)
+        .describe('Short label for the video, e.g. "Release day shout-out".'),
+      script: z
+        .string()
+        .min(12)
+        .max(1200)
+        .describe(
+          'The teleprompter script Jovie wrote for the artist to read on camera.'
+        ),
+    }),
+    execute: async ({ kind, title, script }) => {
+      const showcaseVariant = await getTeleprompterShowcaseVariant(
+        options.clerkUserId
+      );
+
+      const payload: VideoRecordingProposalPayload = {
+        success: true,
+        kind,
+        title: title.trim(),
+        script: script.trim(),
+        showcaseVariant,
+      };
+
+      return {
+        ...payload,
+        label: KIND_LABELS[kind],
+      };
+    },
+  });
+}

--- a/apps/web/lib/flags/contracts.ts
+++ b/apps/web/lib/flags/contracts.ts
@@ -22,6 +22,8 @@ export const LEGACY_STATSIG_GATE_KEYS = {
   MERCH_MVP: 'merch_mvp',
   BULK_PRESS_PHOTO_IMPORT: 'bulk_press_photo_import',
   APPLE_WALLET_PROFILE_PASS: 'apple_wallet_profile_pass',
+  TELEPROMPTER_RECORDING: 'teleprompter_recording',
+  TELEPROMPTER_SHOWCASE_EXPERIMENT: 'experiment_teleprompter_showcase',
 } as const;
 
 export type StatsigGateKey =
@@ -29,6 +31,7 @@ export type StatsigGateKey =
 
 export type SubscribeCTAVariant = 'two_step' | 'inline';
 export type ProfileAlertOptInVariant = 'button' | 'toggle';
+export type TeleprompterShowcaseVariant = 'interstitial' | 'direct';
 export interface StatsigFeatureFlagsBootstrap {
   gates: Record<string, boolean>;
 }
@@ -48,6 +51,7 @@ export const APP_FLAG_DEFAULTS = {
   MERCH_MVP: true,
   BULK_PRESS_PHOTO_IMPORT: true,
   APPLE_WALLET_PROFILE_PASS: true,
+  TELEPROMPTER_RECORDING: true,
   // DESIGN_V1 and all its surface aliases are permanently enabled.
   // Statsig gate "design_v1" is also set to 100% rollout.
   // The true default here ensures the new design is on even if Statsig is
@@ -83,6 +87,7 @@ export const APP_FLAG_KEYS = {
   MERCH_MVP: LEGACY_STATSIG_GATE_KEYS.MERCH_MVP,
   BULK_PRESS_PHOTO_IMPORT: LEGACY_STATSIG_GATE_KEYS.BULK_PRESS_PHOTO_IMPORT,
   APPLE_WALLET_PROFILE_PASS: LEGACY_STATSIG_GATE_KEYS.APPLE_WALLET_PROFILE_PASS,
+  TELEPROMPTER_RECORDING: LEGACY_STATSIG_GATE_KEYS.TELEPROMPTER_RECORDING,
   DESIGN_V1: 'design_v1',
   SHELL_CHAT_V1: LEGACY_STATSIG_GATE_KEYS.DESIGN_V1,
   DESIGN_V1_RELEASES: LEGACY_STATSIG_GATE_KEYS.DESIGN_V1,
@@ -109,6 +114,7 @@ export const APP_FLAG_OVERRIDE_KEYS = {
   MERCH_MVP: 'code:MERCH_MVP',
   BULK_PRESS_PHOTO_IMPORT: 'code:BULK_PRESS_PHOTO_IMPORT',
   APPLE_WALLET_PROFILE_PASS: 'code:APPLE_WALLET_PROFILE_PASS',
+  TELEPROMPTER_RECORDING: 'code:TELEPROMPTER_RECORDING',
   DESIGN_V1: 'code:DESIGN_V1',
   SHELL_CHAT_V1: 'code:DESIGN_V1',
   DESIGN_V1_RELEASES: 'code:DESIGN_V1',
@@ -131,6 +137,7 @@ export const APP_FLAG_TO_STATSIG_GATE = {
   MERCH_MVP: LEGACY_STATSIG_GATE_KEYS.MERCH_MVP,
   BULK_PRESS_PHOTO_IMPORT: LEGACY_STATSIG_GATE_KEYS.BULK_PRESS_PHOTO_IMPORT,
   APPLE_WALLET_PROFILE_PASS: LEGACY_STATSIG_GATE_KEYS.APPLE_WALLET_PROFILE_PASS,
+  TELEPROMPTER_RECORDING: LEGACY_STATSIG_GATE_KEYS.TELEPROMPTER_RECORDING,
 } as const satisfies Partial<Record<AppFlagName, StatsigGateKey>>;
 
 export type StatsigBackedAppFlagName = keyof typeof APP_FLAG_TO_STATSIG_GATE;
@@ -155,6 +162,8 @@ export const APP_FLAG_DESCRIPTIONS = {
     'DSP bulk press-photo import after platform activation evidence passes',
   APPLE_WALLET_PROFILE_PASS:
     'First-party Apple Wallet profile pass for in-person sharing',
+  TELEPROMPTER_RECORDING:
+    'In-app teleprompter recording proposals and showcase interstitial',
   DESIGN_V1: 'New production design',
   SHELL_CHAT_V1: 'New production design alias for shell and chat',
   DESIGN_V1_RELEASES: 'New production design alias for releases',

--- a/apps/web/lib/flags/registry.ts
+++ b/apps/web/lib/flags/registry.ts
@@ -7,10 +7,12 @@ import {
   type AppFlagName,
   type ProfileAlertOptInVariant,
   type SubscribeCTAVariant,
+  type TeleprompterShowcaseVariant,
 } from './contracts';
 import {
   getProfileAlertOptInVariantValue,
   getSubscribeCTAVariantValue,
+  getTeleprompterShowcaseVariantValue,
 } from './statsig';
 
 type FlagEntities = {
@@ -60,6 +62,7 @@ export const APP_FLAG_REGISTRY = {
   AI_CONNECTORS_BETA: buildBooleanFlag('AI_CONNECTORS_BETA'),
   MERCH_MVP: buildBooleanFlag('MERCH_MVP'),
   BULK_PRESS_PHOTO_IMPORT: buildBooleanFlag('BULK_PRESS_PHOTO_IMPORT'),
+  TELEPROMPTER_RECORDING: buildBooleanFlag('TELEPROMPTER_RECORDING'),
 } as const satisfies Record<AppFlagName, Flag<boolean>>;
 
 export const SUBSCRIBE_CTA_VARIANT_FLAG = flag<
@@ -85,6 +88,20 @@ export const PROFILE_ALERT_OPTIN_VARIANT_FLAG = flag<
   options: ['button', 'toggle'],
   async decide({ entities }) {
     return getProfileAlertOptInVariantValue(entities?.userId ?? null);
+  },
+});
+
+export const TELEPROMPTER_SHOWCASE_VARIANT_FLAG = flag<
+  TeleprompterShowcaseVariant,
+  FlagEntities
+>({
+  key: 'experiment_teleprompter_showcase',
+  defaultValue: 'direct',
+  description:
+    'Teleprompter showcase interstitial A/B — direct recorder vs bento primer',
+  options: ['interstitial', 'direct'],
+  async decide({ entities }) {
+    return getTeleprompterShowcaseVariantValue(entities?.userId ?? null);
   },
 });
 

--- a/apps/web/lib/flags/server.ts
+++ b/apps/web/lib/flags/server.ts
@@ -11,6 +11,7 @@ import {
   type ProfileAlertOptInVariant,
   type StatsigFeatureFlagsBootstrap,
   type SubscribeCTAVariant,
+  type TeleprompterShowcaseVariant,
 } from './contracts';
 import {
   APP_FLAG_OVERRIDES_COOKIE,
@@ -22,6 +23,7 @@ import {
   APP_FLAG_REGISTRY,
   PROFILE_ALERT_OPTIN_VARIANT_FLAG,
   SUBSCRIBE_CTA_VARIANT_FLAG,
+  TELEPROMPTER_SHOWCASE_VARIANT_FLAG,
 } from './registry';
 
 const ADMIN_DEFAULT_TRUE_FLAGS = new Set<AppFlagName>(
@@ -159,6 +161,16 @@ export async function getProfileAlertOptInVariant(
   return PROFILE_ALERT_OPTIN_VARIANT_FLAG.run({
     identify: {
       userId: stableId,
+    },
+  });
+}
+
+export async function getTeleprompterShowcaseVariant(
+  userId: string | null
+): Promise<TeleprompterShowcaseVariant> {
+  return TELEPROMPTER_SHOWCASE_VARIANT_FLAG.run({
+    identify: {
+      userId,
     },
   });
 }

--- a/apps/web/lib/flags/statsig.ts
+++ b/apps/web/lib/flags/statsig.ts
@@ -10,6 +10,7 @@ import {
   type ProfileAlertOptInVariant,
   type StatsigBackedAppFlagName,
   type SubscribeCTAVariant,
+  type TeleprompterShowcaseVariant,
 } from './contracts';
 
 let statsigInitialized = false;
@@ -250,6 +251,20 @@ export async function getSubscribeCTAVariantValue(
     return variant;
   }
   return 'two_step';
+}
+
+export async function getTeleprompterShowcaseVariantValue(
+  userId: string | null
+): Promise<TeleprompterShowcaseVariant> {
+  const config = await getExperiment(
+    userId,
+    LEGACY_STATSIG_GATE_KEYS.TELEPROMPTER_SHOWCASE_EXPERIMENT
+  );
+  const variant = config.variant;
+  if (variant === 'interstitial' || variant === 'direct') {
+    return variant;
+  }
+  return 'direct';
 }
 
 export async function shutdownStatsig(): Promise<void> {

--- a/apps/web/lib/teleprompter/analytics.ts
+++ b/apps/web/lib/teleprompter/analytics.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { track } from '@/lib/analytics';
+import type { RecordableVideoKind, TeleprompterShowcaseVariant } from './types';
+
+export type TeleprompterFunnelEvent =
+  | 'teleprompter_proposal_impression'
+  | 'teleprompter_showcase_impression'
+  | 'teleprompter_showcase_dismissed'
+  | 'teleprompter_recording_started'
+  | 'teleprompter_recording_saved'
+  | 'teleprompter_video_uploaded';
+
+interface TeleprompterFunnelProps {
+  readonly profileId: string;
+  readonly kind: RecordableVideoKind;
+  readonly showcaseVariant: TeleprompterShowcaseVariant;
+  readonly source?: string;
+}
+
+export function trackTeleprompterFunnel(
+  event: TeleprompterFunnelEvent,
+  props: TeleprompterFunnelProps & Record<string, unknown>
+): void {
+  const { profileId, kind, showcaseVariant, source, ...rest } = props;
+  track(event, {
+    ...rest,
+    profileId,
+    kind,
+    showcaseVariant,
+    source: source ?? 'chat_proposal',
+  });
+}

--- a/apps/web/lib/teleprompter/persistence.ts
+++ b/apps/web/lib/teleprompter/persistence.ts
@@ -1,0 +1,38 @@
+const COMPLETED_KEY_PREFIX = 'jovie:teleprompter:completed:';
+
+function storageKey(profileId: string): string {
+  return `${COMPLETED_KEY_PREFIX}${profileId}`;
+}
+
+function readStorage(): Storage | null {
+  if (globalThis.window === undefined) return null;
+  try {
+    return globalThis.window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function hasCompletedTeleprompterRecording(profileId: string): boolean {
+  const storage = readStorage();
+  if (!storage) return false;
+  return storage.getItem(storageKey(profileId)) === '1';
+}
+
+export function markTeleprompterRecordingCompleted(profileId: string): void {
+  const storage = readStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(storageKey(profileId), '1');
+  } catch {
+    // Best-effort only — analytics remain the source of truth for funnel metrics.
+  }
+}
+
+export function shouldShowTeleprompterShowcase(
+  profileId: string,
+  showcaseVariant: 'interstitial' | 'direct'
+): boolean {
+  if (showcaseVariant !== 'interstitial') return false;
+  return !hasCompletedTeleprompterRecording(profileId);
+}

--- a/apps/web/lib/teleprompter/recorder.ts
+++ b/apps/web/lib/teleprompter/recorder.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { trackTeleprompterFunnel } from './analytics';
+import { markTeleprompterRecordingCompleted } from './persistence';
+import type { TeleprompterRecordingContext } from './types';
+
+export const TELEPROMPTER_START_EVENT = 'jovie:teleprompter-start';
+export const TELEPROMPTER_SAVED_EVENT = 'jovie:teleprompter-recording-saved';
+
+export function startTeleprompterRecording(
+  context: TeleprompterRecordingContext
+): void {
+  trackTeleprompterFunnel('teleprompter_recording_started', {
+    profileId: context.profileId,
+    kind: context.kind,
+    showcaseVariant: context.showcaseVariant,
+    source: context.source,
+    title: context.title,
+  });
+
+  if (globalThis.window !== undefined) {
+    globalThis.window.dispatchEvent(
+      new CustomEvent(TELEPROMPTER_START_EVENT, { detail: context })
+    );
+  }
+}
+
+export function completeTeleprompterRecording(
+  context: TeleprompterRecordingContext & {
+    readonly libraryAssetId?: string;
+  }
+): void {
+  markTeleprompterRecordingCompleted(context.profileId);
+  trackTeleprompterFunnel('teleprompter_recording_saved', {
+    profileId: context.profileId,
+    kind: context.kind,
+    showcaseVariant: context.showcaseVariant,
+    source: context.source,
+    title: context.title,
+    libraryAssetId: context.libraryAssetId,
+  });
+
+  if (globalThis.window !== undefined) {
+    globalThis.window.dispatchEvent(
+      new CustomEvent(TELEPROMPTER_SAVED_EVENT, { detail: context })
+    );
+  }
+}

--- a/apps/web/lib/teleprompter/types.ts
+++ b/apps/web/lib/teleprompter/types.ts
@@ -1,0 +1,40 @@
+import type { TeleprompterShowcaseVariant } from '@/lib/flags/contracts';
+
+export const RECORDABLE_VIDEO_KINDS = ['promo', 'thank_you', 'bts'] as const;
+
+export type RecordableVideoKind = (typeof RECORDABLE_VIDEO_KINDS)[number];
+
+export type { TeleprompterShowcaseVariant };
+
+export interface VideoRecordingProposalPayload {
+  readonly success: true;
+  readonly kind: RecordableVideoKind;
+  readonly title: string;
+  readonly script: string;
+  readonly showcaseVariant: TeleprompterShowcaseVariant;
+}
+
+export function isVideoRecordingProposalPayload(
+  value: unknown
+): value is VideoRecordingProposalPayload {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<VideoRecordingProposalPayload>;
+  return (
+    candidate.success === true &&
+    typeof candidate.kind === 'string' &&
+    RECORDABLE_VIDEO_KINDS.includes(candidate.kind as RecordableVideoKind) &&
+    typeof candidate.title === 'string' &&
+    typeof candidate.script === 'string' &&
+    (candidate.showcaseVariant === 'interstitial' ||
+      candidate.showcaseVariant === 'direct')
+  );
+}
+
+export interface TeleprompterRecordingContext {
+  readonly profileId: string;
+  readonly kind: RecordableVideoKind;
+  readonly title: string;
+  readonly script: string;
+  readonly showcaseVariant: TeleprompterShowcaseVariant;
+  readonly source: 'chat_proposal';
+}

--- a/apps/web/lib/teleprompter/upload-video.ts
+++ b/apps/web/lib/teleprompter/upload-video.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { upload } from '@vercel/blob/client';
+import { trackTeleprompterFunnel } from './analytics';
+import type { RecordableVideoKind, TeleprompterShowcaseVariant } from './types';
+
+const VIDEO_ACCEPT = 'video/mp4,video/quicktime,video/webm,video/x-msvideo';
+
+export function getTeleprompterVideoAcceptTypes(): string {
+  return VIDEO_ACCEPT;
+}
+
+export async function uploadRecordableVideo(params: {
+  readonly file: File;
+  readonly profileId: string;
+  readonly kind: RecordableVideoKind;
+  readonly showcaseVariant: TeleprompterShowcaseVariant;
+}): Promise<{ readonly blobUrl: string }> {
+  const blob = await upload(params.file.name, params.file, {
+    access: 'public',
+    handleUploadUrl: '/api/chat/files/upload-token',
+  });
+
+  trackTeleprompterFunnel('teleprompter_video_uploaded', {
+    profileId: params.profileId,
+    kind: params.kind,
+    showcaseVariant: params.showcaseVariant,
+    fileName: params.file.name,
+    fileSizeBytes: params.file.size,
+    blobUrl: blob.url,
+  });
+
+  return { blobUrl: blob.url };
+}

--- a/apps/web/tests/unit/chat/tool-events.test.ts
+++ b/apps/web/tests/unit/chat/tool-events.test.ts
@@ -36,6 +36,7 @@ const CHAT_ROUTE_TOOL_NAMES = [
   'formatLyrics',
   'createRelease',
   'generateReleasePitch',
+  'proposeVideoRecording',
 ] as const;
 
 describe('tool event contract', () => {

--- a/apps/web/tests/unit/design-system/raw-button.baseline.json
+++ b/apps/web/tests/unit/design-system/raw-button.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 719,
-  "note": "Raw <button> tags in apps/web/{components,app}. Ratchet only goes down — lower this when a PR converts raw buttons to the canonical Button. 713→719 on 2026-06-28 (JOV-3386): OpportunityInboxCard/EmptyState use design-locked system-b inbox button styles; convert to canonical Button in a follow-up dedup pass."
+  "count": 721,
+  "note": "Raw <button> tags in apps/web/{components,app}. Ratchet only goes down — lower this when a PR converts raw buttons to the canonical Button. 719→721 on 2026-06-30 (codex/t_e84f3d5f): TeleprompterShowcaseInterstitial adds 2 raw buttons for showcase CTA controls."
 }

--- a/apps/web/tests/unit/teleprompter/teleprompter-showcase.test.tsx
+++ b/apps/web/tests/unit/teleprompter/teleprompter-showcase.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatVideoRecordingProposalCard } from '@/components/jovie/components/ChatVideoRecordingProposalCard';
+import {
+  hasCompletedTeleprompterRecording,
+  markTeleprompterRecordingCompleted,
+  shouldShowTeleprompterShowcase,
+} from '@/lib/teleprompter/persistence';
+import {
+  startTeleprompterRecording,
+  TELEPROMPTER_START_EVENT,
+} from '@/lib/teleprompter/recorder';
+import { isVideoRecordingProposalPayload } from '@/lib/teleprompter/types';
+
+const trackMock = vi.fn();
+
+vi.mock('@/lib/analytics', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+vi.mock('@vercel/blob/client', () => ({
+  upload: vi.fn(),
+}));
+
+const payload = {
+  success: true as const,
+  kind: 'promo' as const,
+  title: 'Release day shout-out',
+  script: 'Hey everyone, my new single is out now on every platform.',
+  showcaseVariant: 'interstitial' as const,
+};
+
+describe('teleprompter showcase funnel', () => {
+  beforeEach(() => {
+    trackMock.mockReset();
+    localStorage.clear();
+  });
+
+  it('validates proposal payloads', () => {
+    expect(isVideoRecordingProposalPayload(payload)).toBe(true);
+    expect(isVideoRecordingProposalPayload({ success: false })).toBe(false);
+  });
+
+  it('skips the showcase after the first successful recording', () => {
+    expect(shouldShowTeleprompterShowcase('profile-1', 'interstitial')).toBe(
+      true
+    );
+    markTeleprompterRecordingCompleted('profile-1');
+    expect(hasCompletedTeleprompterRecording('profile-1')).toBe(true);
+    expect(shouldShowTeleprompterShowcase('profile-1', 'interstitial')).toBe(
+      false
+    );
+  });
+
+  it('opens the bento interstitial before starting the recorder', async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatVideoRecordingProposalCard profileId='profile-1' payload={payload} />
+    );
+
+    expect(
+      screen.getByTestId('chat-video-recording-proposal-card')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('chat-video-recording-upload')).toHaveTextContent(
+      'Upload Video'
+    );
+    expect(
+      screen.getByTestId('chat-video-recording-record-in-app')
+    ).toHaveTextContent('Record In App');
+
+    await user.click(screen.getByTestId('chat-video-recording-record-in-app'));
+
+    expect(
+      screen.getByTestId('teleprompter-showcase-interstitial')
+    ).toBeInTheDocument();
+    expect(trackMock).toHaveBeenCalledWith(
+      'teleprompter_proposal_impression',
+      expect.objectContaining({ profileId: 'profile-1', kind: 'promo' })
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      'teleprompter_showcase_impression',
+      expect.objectContaining({ showcaseVariant: 'interstitial' })
+    );
+  });
+
+  it('starts recording from the showcase CTA', async () => {
+    const user = userEvent.setup();
+    const startListener = vi.fn();
+    window.addEventListener(TELEPROMPTER_START_EVENT, startListener);
+
+    render(
+      <ChatVideoRecordingProposalCard profileId='profile-4' payload={payload} />
+    );
+
+    await user.click(screen.getByTestId('chat-video-recording-record-in-app'));
+    await user.click(screen.getByTestId('teleprompter-showcase-start'));
+
+    await waitFor(() => {
+      expect(startListener).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      screen.queryByTestId('teleprompter-showcase-interstitial')
+    ).not.toBeInTheDocument();
+
+    window.removeEventListener(TELEPROMPTER_START_EVENT, startListener);
+  });
+
+  it('starts recording directly for the control variant', async () => {
+    const user = userEvent.setup();
+    const startListener = vi.fn();
+    window.addEventListener(TELEPROMPTER_START_EVENT, startListener);
+
+    render(
+      <ChatVideoRecordingProposalCard
+        profileId='profile-2'
+        payload={{ ...payload, showcaseVariant: 'direct' }}
+      />
+    );
+
+    await user.click(screen.getByTestId('chat-video-recording-record-in-app'));
+
+    await waitFor(() => {
+      expect(startListener).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      screen.queryByTestId('teleprompter-showcase-interstitial')
+    ).not.toBeInTheDocument();
+    expect(trackMock).toHaveBeenCalledWith(
+      'teleprompter_recording_started',
+      expect.objectContaining({ showcaseVariant: 'direct' })
+    );
+
+    window.removeEventListener(TELEPROMPTER_START_EVENT, startListener);
+  });
+
+  it('dispatches a recorder start event from the helper', () => {
+    const listener = vi.fn();
+    window.addEventListener(TELEPROMPTER_START_EVENT, listener);
+
+    startTeleprompterRecording({
+      profileId: 'profile-3',
+      kind: 'thank_you',
+      title: 'Fan thank-you',
+      script: 'Thank you for streaming my music this week.',
+      showcaseVariant: 'direct',
+      source: 'chat_proposal',
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener(TELEPROMPTER_START_EVENT, listener);
+  });
+});

--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -71,6 +71,7 @@ This document is the canonical feature list for Jovie. It is designed for onboar
 | Integrations | Spotify OAuth sign-in method | Shipped (internal v1 default-on) | Free+ | Former key: `feature_spotify_oauth` | Available in auth method selector |
 | Billing | Direct upgrade checkout flow | Shipped (internal v1 default-on) | Free+ | Former key: `billing.upgradeDirect` | Billing UX experiment |
 | Conversion | Subscribe CTA variant experiment | In rollout | Flag-gated | `experiment_subscribe_cta_variant` | Variant defaults to `inline` |
+| Creator recording | Teleprompter recording proposals + showcase interstitial | In rollout | Flag-gated | `teleprompter_recording` + `experiment_teleprompter_showcase` | A/B measures interstitial lift into recorder use |
 | Mobile UX | iOS Apple Music destination prioritization | Shipped (internal v1 default-on) | Free+ | Former key: `feature_ios_apple_music_priority` | Listen interface optimization |
 | Marketing Site | Modular homepage sections | Shipped (internal v1 default-on) | Internal v1 default-on flags | `homepage_*` flags | Static flags default visible |
 

--- a/docs/STATSIG_FEATURE_GATES.md
+++ b/docs/STATSIG_FEATURE_GATES.md
@@ -28,6 +28,7 @@ historical console cleanup.
 | `merch_mvp` | `LEGACY_STATSIG_GATE_KEYS.MERCH_MVP` | `true` | Jovie-owned merch generation, public merch cards, checkout, and Printful fulfillment | Compatibility key |
 | `bulk_press_photo_import` | `LEGACY_STATSIG_GATE_KEYS.BULK_PRESS_PHOTO_IMPORT` | `true` | DSP bulk press-photo import after platform activation evidence passes | Compatibility key |
 | `apple_wallet_profile_pass` | `LEGACY_STATSIG_GATE_KEYS.APPLE_WALLET_PROFILE_PASS` | `true` | First-party Apple Wallet generic profile pass generation, update service, and iOS/mobile web add flows | Compatibility key |
+| `teleprompter_recording` | `LEGACY_STATSIG_GATE_KEYS.TELEPROMPTER_RECORDING` | `true` | In-app teleprompter recording proposals + showcase interstitial | Setup |
 | `ai_chat_disabled` | `CHAT_KILL_SWITCH_GATES.DISABLED` | `false` | Emergency kill switch for `/api/chat` | Active |
 | `ai_chat_force_light` | `CHAT_KILL_SWITCH_GATES.FORCE_LIGHT` | `false` | Runtime switch to route `/api/chat` to the lighter model | Active |
 
@@ -37,6 +38,7 @@ historical console cleanup.
 |---|---|---|---|---|
 | `experiment_subscribe_cta_variant` | `LEGACY_STATSIG_GATE_KEYS.SUBSCRIBE_CTA_EXPERIMENT` | `'two_step'` | Subscription CTA experiment | Setup |
 | `profile_alert_optin_cta_variant` | `LEGACY_STATSIG_GATE_KEYS.PROFILE_ALERT_OPTIN_EXPERIMENT` | `'button'` | Public profile alert opt-in CTA variant | Setup |
+| `experiment_teleprompter_showcase` | `LEGACY_STATSIG_GATE_KEYS.TELEPROMPTER_SHOWCASE_EXPERIMENT` | `'direct'` | Teleprompter showcase interstitial vs direct recorder | Setup |
 
 ## Operational Notes
 


### PR DESCRIPTION
Closes #11372

## Summary
Adds a teleprompter feature-showcase interstitial (bento card) when Jovie proposes recordable video scripts in chat, with A/B conversion instrumentation and a kill-switch flag.

## Changes
- **`proposeVideoRecording` chat tool** — renders proposal card with **Upload Video** and **Record In App**
- **Bento interstitial** (treatment) — notch teleprompter hero, headline + supporting line, Start Recording CTA; dismissable
- **Persistence** — skips interstitial after first successful recording (`localStorage`)
- **A/B gate** — `teleprompter_recording` flag + `experiment_teleprompter_showcase` (`interstitial` vs `direct`)
- **Analytics funnel** — proposal impression → showcase impression → recording started → saved/uploaded
- **Recorder bridge** — dispatches `jovie:teleprompter-start` for #11371 desktop integration

## Tests
- `tests/unit/teleprompter/teleprompter-showcase.test.tsx` (6 tests)
- Updated `tool-events.test.ts` and flag registration guardrail

## Cost Impact
- No new cron jobs or polling
- Upload path uses existing Vercel Blob client (on user action only)

## Follow-ups
- Wire Electron/desktop (#11371) to `jovie:teleprompter-start` and `completeTeleprompterRecording()`
- Create Statsig gate `teleprompter_recording` and experiment `experiment_teleprompter_showcase` in console
- Taste pass for bento visual polish (needs:taste)