### PR TITLE
fix(test): make quarantine-ledger test tolerate entry count changes

### DIFF
--- a/apps/web/tests/unit/lib/testing/quarantine-ledger.test.ts
+++ b/apps/web/tests/unit/lib/testing/quarantine-ledger.test.ts
@@ -16,9 +16,19 @@ describe('quarantine ledger', () => {
     );
 
     expect(isQuarantineLedgerValid(parsed)).toBe(true);
-    expect(parsed.ledger.entries).toHaveLength(3);
-    expect(parsed.unitPaths).toHaveLength(2);
-    expect(parsed.e2ePaths).toHaveLength(1);
+
+    // Count entries dynamically so the test tolerates additions/removals in
+    // tests/quarantine.json — only the structural guarantees matter here.
+    const expectedUnitCount = parsed.ledger.entries.filter(
+      entry => entry.kind === 'unit'
+    ).length;
+    const expectedE2eCount = parsed.ledger.entries.filter(
+      entry => entry.kind === 'e2e'
+    ).length;
+
+    expect(parsed.ledger.entries.length).toBeGreaterThan(0);
+    expect(parsed.unitPaths).toHaveLength(expectedUnitCount);
+    expect(parsed.e2ePaths).toHaveLength(expectedE2eCount);
     expect(parsed.summary.withinRetryBudget).toBe(true);
   });
 


### PR DESCRIPTION
## Why

quarantine-ledger.test.ts asserted hardcoded entry counts (3 total, 2 unit, 1 e2e) against tests/quarantine.json. As new flakes land, those constants rot and break unrelated PRs' CI (e.g. #12434: fix(ci) for supply-chain provenance that didn't touch quarantine at all).

## What changed

Count entries dynamically from parsed.ledger.entries so only the real invariants are guaranteed:
- ledger parses without structural issues (isQuarantineLedgerValid)
- unitPaths/e2ePaths match the actual entries of each kind
- retry budget is still within bounds

## Verification

- 5/5 quarantine-ledger tests pass
- Does not modify quarantine.json
- Follows existing patterns in the file (test 2 uses manual fixture, test 3-5 build ad-hoc)