### PR TITLE
chore: inline usage meter in account menu (Codex-style): subtle % + expandable (#11373)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
@@ -9,9 +9,9 @@ import { UpgradeButton } from '@/components/molecules/UpgradeButton';
 import { APP_ROUTES } from '@/constants/routes';
 import type { ChatUsageState } from '@/lib/chat-usage/copy';
 import { getChatUsageCopy } from '@/lib/chat-usage/copy';
+import { formatResetAt, getMonthlyUsage } from '@/lib/chat-usage/metrics';
 import { env } from '@/lib/env-client';
 import { useChatUsageQuery } from '@/lib/queries';
-import type { ChatUsageData } from '@/lib/queries/useChatUsageQuery';
 import { cn } from '@/lib/utils';
 
 const USAGE_PANEL_MIN_HEIGHT_CLASS = 'min-h-86';
@@ -38,19 +38,6 @@ function formatNumber(value: number): string {
   return new Intl.NumberFormat('en-US').format(value);
 }
 
-function formatResetAt(value: string | null | undefined): string {
-  if (!value) return 'Reset timing unavailable';
-  const resetAt = new Date(value);
-  if (Number.isNaN(resetAt.getTime())) return 'Reset timing unavailable';
-
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  }).format(resetAt);
-}
-
 function getStatusToneClasses(state: ChatUsageState): string {
   if (state === 'healthy') {
     return 'border-success/25 bg-success/10 text-success';
@@ -73,23 +60,6 @@ function getProgressToneClasses(state: ChatUsageState): string {
   }
 
   return 'bg-error/10 [&::-moz-progress-bar]:bg-error [&::-webkit-progress-bar]:bg-error/10 [&::-webkit-progress-value]:bg-error';
-}
-
-function getMonthlyUsage(data: ChatUsageData): {
-  readonly limit: number;
-  readonly used: number;
-  readonly remaining: number;
-  readonly resetAt: string | null | undefined;
-} {
-  const limit = data.monthlyLimit ?? data.dailyLimit * 30;
-  const used = data.monthlyUsed ?? data.used;
-
-  return {
-    limit,
-    used,
-    remaining: data.monthlyRemaining ?? Math.max(0, limit - used),
-    resetAt: data.monthlyResetAt,
-  };
 }
 
 interface UsageMeterRowProps {

--- a/apps/web/components/organisms/user-button/UsageMenuItem.tsx
+++ b/apps/web/components/organisms/user-button/UsageMenuItem.tsx
@@ -67,11 +67,12 @@ export function UsageMenuItem({
 
   return (
     <div className='border-t border-subtle/60' data-testid='usage-menu-item'>
-      <button
+      <Button
         type='button'
+        variant='ghost'
         onClick={toggleExpanded}
         aria-expanded={expanded}
-        className='flex w-full cursor-pointer items-center gap-2 px-2.5 py-2 text-left text-app text-secondary-token transition-colors hover:bg-interactive-hover focus-visible:outline-none focus-visible:bg-interactive-hover'
+        className='h-auto w-full justify-start gap-2 rounded-none px-2.5 py-2 text-left text-app font-normal text-secondary-token hover:text-secondary-token focus-visible:bg-interactive-hover'
       >
         <span className='min-w-0 flex-1'>Usage remaining</span>
         <span className='shrink-0 tabular-nums text-tertiary-token'>
@@ -91,7 +92,7 @@ export function UsageMenuItem({
         ) : (
           <ChevronRight className='h-3.5 w-3.5 shrink-0 text-tertiary-token' />
         )}
-      </button>
+      </Button>
 
       {expanded ? (
         <div className='pb-2'>

--- a/apps/web/components/organisms/user-button/UsageMenuItem.tsx
+++ b/apps/web/components/organisms/user-button/UsageMenuItem.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { Button } from '@jovie/ui';
+import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
+import Link from 'next/link';
+import { useState } from 'react';
+import { APP_ROUTES } from '@/constants/routes';
+import { getChatUsageCopy } from '@/lib/chat-usage/copy';
+import {
+  formatUsageResetDate,
+  formatUsageResetTime,
+  getMonthlyUsage,
+  getOverallRemainingPercent,
+  getRemainingPercent,
+} from '@/lib/chat-usage/metrics';
+import { env } from '@/lib/env-client';
+import { useChatUsageQuery } from '@/lib/queries';
+import { cn } from '@/lib/utils';
+
+interface UsageMenuItemProps {
+  readonly usageStatsUrl: string;
+  readonly onUpgrade?: () => void;
+  readonly upgradeLabel?: string;
+  readonly isUpgradeLoading?: boolean;
+}
+
+interface UsageWindowRowProps {
+  readonly label: string;
+  readonly remainingPercent: number;
+  readonly resetLabel: string;
+}
+
+function UsageWindowRow({
+  label,
+  remainingPercent,
+  resetLabel,
+}: UsageWindowRowProps) {
+  return (
+    <div className='flex items-center justify-between gap-3 px-2.5 py-1.5 text-2xs text-secondary-token'>
+      <span>{label}</span>
+      <span className='tabular-nums text-tertiary-token'>
+        {remainingPercent}% · {resetLabel}
+      </span>
+    </div>
+  );
+}
+
+export function UsageMenuItem({
+  usageStatsUrl,
+  onUpgrade,
+  upgradeLabel = 'Upgrade to Pro',
+  isUpgradeLoading = false,
+}: UsageMenuItemProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { data, isLoading, error } = useChatUsageQuery({
+    enabled: !env.IS_E2E,
+  });
+
+  const overallPercent =
+    data !== undefined ? getOverallRemainingPercent(data) : null;
+  const copy = data ? getChatUsageCopy(data) : null;
+  const showUpgradeNudge = copy !== null && copy.state !== 'healthy';
+
+  const toggleExpanded = () => {
+    setExpanded(current => !current);
+  };
+
+  return (
+    <div className='border-t border-subtle/60' data-testid='usage-menu-item'>
+      <button
+        type='button'
+        onClick={toggleExpanded}
+        aria-expanded={expanded}
+        className='flex w-full cursor-pointer items-center gap-2 px-2.5 py-2 text-left text-app text-secondary-token transition-colors hover:bg-interactive-hover focus-visible:outline-none focus-visible:bg-interactive-hover'
+      >
+        <span className='min-w-0 flex-1'>Usage remaining</span>
+        <span className='shrink-0 tabular-nums text-tertiary-token'>
+          {isLoading ? (
+            <span
+              className='inline-block h-3 w-8 animate-pulse rounded bg-surface-2 motion-reduce:animate-none'
+              aria-hidden
+            />
+          ) : error || overallPercent === null ? (
+            '—'
+          ) : (
+            `${overallPercent}%`
+          )}
+        </span>
+        {expanded ? (
+          <ChevronDown className='h-3.5 w-3.5 shrink-0 text-tertiary-token' />
+        ) : (
+          <ChevronRight className='h-3.5 w-3.5 shrink-0 text-tertiary-token' />
+        )}
+      </button>
+
+      {expanded ? (
+        <div className='pb-2'>
+          {data ? (
+            <div className='space-y-0.5'>
+              <UsageWindowRow
+                label='Daily'
+                remainingPercent={getRemainingPercent(
+                  data.remaining,
+                  data.dailyLimit
+                )}
+                resetLabel={formatUsageResetTime(data.resetAt)}
+              />
+              <UsageWindowRow
+                label='Monthly'
+                remainingPercent={getRemainingPercent(
+                  getMonthlyUsage(data).remaining,
+                  getMonthlyUsage(data).limit
+                )}
+                resetLabel={formatUsageResetDate(getMonthlyUsage(data).resetAt)}
+              />
+            </div>
+          ) : (
+            <p className='px-2.5 py-1.5 text-2xs text-tertiary-token'>
+              {isLoading
+                ? 'Loading usage…'
+                : 'Usage details are unavailable right now.'}
+            </p>
+          )}
+
+          {showUpgradeNudge && copy ? (
+            <div className='px-2.5 pt-1'>
+              {data?.plan === 'free' && onUpgrade ? (
+                <Button
+                  type='button'
+                  variant='secondary'
+                  size='sm'
+                  className='h-7 w-full justify-center text-2xs'
+                  onClick={onUpgrade}
+                  disabled={isUpgradeLoading}
+                >
+                  {isUpgradeLoading ? 'Opening…' : upgradeLabel}
+                </Button>
+              ) : (
+                <Button
+                  asChild
+                  variant='secondary'
+                  size='sm'
+                  className='h-7 w-full justify-center text-2xs'
+                >
+                  <Link href={APP_ROUTES.PRICING}>{copy.ctaLabel}</Link>
+                </Button>
+              )}
+            </div>
+          ) : null}
+
+          <div className='px-2.5 pt-1'>
+            <Link
+              href={usageStatsUrl}
+              className={cn(
+                'inline-flex items-center gap-1 text-2xs text-secondary-token transition-colors hover:text-primary-token'
+              )}
+            >
+              Learn more
+              <ExternalLink className='h-3 w-3' aria-hidden />
+            </Link>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/organisms/user-button/UserButton.tsx
+++ b/apps/web/components/organisms/user-button/UserButton.tsx
@@ -5,7 +5,6 @@ import { Button, CommonDropdown } from '@jovie/ui';
 import {
   CreditCard,
   FileText,
-  Gauge,
   HelpCircle,
   Keyboard,
   LogOut,
@@ -29,6 +28,7 @@ import { useFeedbackMutation } from '@/lib/queries';
 import { Icon } from '../../atoms/Icon';
 import { Avatar } from '../../molecules/Avatar/Avatar';
 import type { UserButtonProps } from './types';
+import { UsageMenuItem } from './UsageMenuItem';
 import { useUserButton } from './useUserButton';
 
 const DashboardFeedbackModal = dynamic(
@@ -61,7 +61,7 @@ interface BuildDropdownItemsParams {
     hasAccess: boolean;
     installUrl: string | null;
   };
-  handleUsageStats: () => void;
+  usageStatsUrl: string;
   handleManageBilling: () => void;
   handleUpgrade: () => void;
   upgradeLabel: string;
@@ -92,7 +92,7 @@ function buildDropdownItems({
   handleProfile,
   handleSettings,
   iosAlphaAccess,
-  handleUsageStats,
+  usageStatsUrl,
   handleManageBilling,
   handleUpgrade,
   upgradeLabel,
@@ -154,6 +154,18 @@ function buildDropdownItems({
       onClick: handleSettings,
       shortcut: 'G S',
     },
+    {
+      type: 'custom',
+      id: 'usage-menu',
+      render: () => (
+        <UsageMenuItem
+          usageStatsUrl={usageStatsUrl}
+          onUpgrade={handleUpgrade}
+          upgradeLabel={upgradeLabel}
+          isUpgradeLoading={loading.upgrade}
+        />
+      ),
+    },
   ];
 
   if (iosAlphaAccess.hasAccess) {
@@ -169,14 +181,6 @@ function buildDropdownItems({
       },
     });
   }
-
-  items.push({
-    type: 'action',
-    id: 'usage-stats',
-    label: 'Usage Stats',
-    icon: Gauge,
-    onClick: handleUsageStats,
-  });
 
   if (!isElectronRuntime) {
     items.push({
@@ -388,7 +392,6 @@ export function UserButton({
     handleManageBilling,
     handleProfile,
     handleSettings,
-    handleUsageStats,
     handleSignOut,
     handleUpgrade,
     loading,
@@ -488,7 +491,7 @@ export function UserButton({
     handleProfile,
     handleSettings,
     iosAlphaAccess,
-    handleUsageStats,
+    usageStatsUrl: APP_ROUTES.SETTINGS_USAGE,
     handleManageBilling,
     handleUpgrade,
     upgradeLabel: menuActions.upgradeLabel,

--- a/apps/web/lib/chat-usage/metrics.ts
+++ b/apps/web/lib/chat-usage/metrics.ts
@@ -1,0 +1,67 @@
+import type { ChatUsageData } from '@/lib/queries/useChatUsageQuery';
+
+export interface MonthlyUsageSnapshot {
+  readonly limit: number;
+  readonly used: number;
+  readonly remaining: number;
+  readonly resetAt: string | null | undefined;
+}
+
+export function getMonthlyUsage(data: ChatUsageData): MonthlyUsageSnapshot {
+  const limit = data.monthlyLimit ?? data.dailyLimit * 30;
+  const used = data.monthlyUsed ?? data.used;
+
+  return {
+    limit,
+    used,
+    remaining: data.monthlyRemaining ?? Math.max(0, limit - used),
+    resetAt: data.monthlyResetAt,
+  };
+}
+
+export function getRemainingPercent(remaining: number, limit: number): number {
+  if (limit <= 0) return 0;
+  return Math.round((Math.max(0, remaining) / limit) * 100);
+}
+
+export function getOverallRemainingPercent(data: ChatUsageData): number {
+  const monthly = getMonthlyUsage(data);
+  const dailyPercent = getRemainingPercent(data.remaining, data.dailyLimit);
+  const monthlyPercent = getRemainingPercent(monthly.remaining, monthly.limit);
+  return Math.min(dailyPercent, monthlyPercent);
+}
+
+export function formatResetAt(value: string | null | undefined): string {
+  if (!value) return 'Reset timing unavailable';
+  const resetAt = new Date(value);
+  if (Number.isNaN(resetAt.getTime())) return 'Reset timing unavailable';
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(resetAt);
+}
+
+export function formatUsageResetTime(value: string | null | undefined): string {
+  if (!value) return '—';
+  const resetAt = new Date(value);
+  if (Number.isNaN(resetAt.getTime())) return '—';
+
+  return new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(resetAt);
+}
+
+export function formatUsageResetDate(value: string | null | undefined): string {
+  if (!value) return '—';
+  const resetAt = new Date(value);
+  if (Number.isNaN(resetAt.getTime())) return '—';
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+  }).format(resetAt);
+}

--- a/apps/web/tests/components/user-button.test.tsx
+++ b/apps/web/tests/components/user-button.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/lib/queries', () => ({
   useCheckoutMutation: vi.fn(),
   usePortalMutation: vi.fn(),
   useFeedbackMutation: vi.fn(),
+  useChatUsageQuery: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -58,6 +59,7 @@ import { useAuthSafe, useUserSafe } from '@/hooks/useClerkSafe';
 import { track } from '@/lib/analytics';
 import {
   useBillingStatusQuery,
+  useChatUsageQuery,
   useCheckoutMutation,
   useFeedbackMutation,
   usePortalMutation,
@@ -72,6 +74,7 @@ const flushMicrotasks = async () => {
 };
 
 const mockUseBillingStatusQuery = vi.mocked(useBillingStatusQuery);
+const mockUseChatUsageQuery = vi.mocked(useChatUsageQuery);
 const mockUsePricingOptionsQuery = vi.mocked(usePricingOptionsQuery);
 const mockUseCheckoutMutation = vi.mocked(useCheckoutMutation);
 const mockUsePortalMutation = vi.mocked(usePortalMutation);
@@ -139,6 +142,25 @@ describe('UserButton billing actions', () => {
       mutateAsync: vi.fn().mockResolvedValue({ ok: true, id: 'feedback_test' }),
       isPending: false,
       isError: false,
+    } as any);
+
+    mockUseChatUsageQuery.mockReturnValue({
+      data: {
+        plan: 'free',
+        dailyLimit: 10,
+        used: 4,
+        remaining: 6,
+        resetAt: '2026-05-23T07:00:00.000Z',
+        monthlyLimit: 310,
+        monthlyUsed: 24,
+        monthlyRemaining: 286,
+        monthlyResetAt: '2026-06-01T00:00:00.000Z',
+        isExhausted: false,
+        warningThreshold: 2,
+        isNearLimit: false,
+      },
+      isLoading: false,
+      error: null,
     } as any);
 
     mockUseUserSafe.mockReturnValue({
@@ -600,7 +622,7 @@ describe('UserButton billing actions', () => {
     expect(document.querySelector('.animate-pulse')).toBeNull();
   });
 
-  it('shows a usage stats entry and routes there from the user menu', async () => {
+  it('shows an inline usage remaining row in the user menu', async () => {
     mockUseBillingStatusQuery.mockReturnValue({
       data: { isPro: false, plan: null, hasStripeCustomer: false },
       isLoading: false,
@@ -611,8 +633,9 @@ describe('UserButton billing actions', () => {
     render(<UserButton showUserInfo />);
 
     await user.click(screen.getByText('Adele Adkins'));
-    await user.click(await screen.findByText('Usage Stats'));
 
-    expect(pushMock).toHaveBeenCalledWith(APP_ROUTES.SETTINGS_USAGE);
+    expect(screen.getByText('Usage remaining')).toBeInTheDocument();
+    expect(screen.getByText('60%')).toBeInTheDocument();
+    expect(screen.queryByText('Usage Stats')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/lib/chat-usage-metrics.test.ts
+++ b/apps/web/tests/unit/lib/chat-usage-metrics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatUsageResetDate,
+  formatUsageResetTime,
+  getMonthlyUsage,
+  getOverallRemainingPercent,
+  getRemainingPercent,
+} from '@/lib/chat-usage/metrics';
+import type { ChatUsageData } from '@/lib/queries/useChatUsageQuery';
+
+const baseUsage: ChatUsageData = {
+  plan: 'free',
+  dailyLimit: 10,
+  used: 4,
+  remaining: 6,
+  resetAt: '2026-05-23T19:27:00.000Z',
+  monthlyLimit: 310,
+  monthlyUsed: 24,
+  monthlyRemaining: 286,
+  monthlyResetAt: '2026-06-01T00:00:00.000Z',
+  isExhausted: false,
+  warningThreshold: 2,
+  isNearLimit: false,
+};
+
+describe('chat usage metrics', () => {
+  it('derives monthly usage from the same fields as the settings page', () => {
+    expect(getMonthlyUsage(baseUsage)).toEqual({
+      limit: 310,
+      used: 24,
+      remaining: 286,
+      resetAt: '2026-06-01T00:00:00.000Z',
+    });
+  });
+
+  it('computes remaining percent from quota left', () => {
+    expect(getRemainingPercent(6, 10)).toBe(60);
+    expect(getRemainingPercent(286, 310)).toBe(92);
+  });
+
+  it('uses the tighter window for the collapsed menu percent', () => {
+    expect(getOverallRemainingPercent(baseUsage)).toBe(60);
+
+    expect(
+      getOverallRemainingPercent({
+        ...baseUsage,
+        remaining: 9,
+        monthlyRemaining: 50,
+      })
+    ).toBe(16);
+  });
+
+  it('formats compact reset labels for the inline menu', () => {
+    expect(formatUsageResetTime('2026-05-23T19:27:00.000Z')).toMatch(/PM|AM/);
+    expect(formatUsageResetTime(null)).toBe('—');
+    expect(formatUsageResetDate('2026-06-01T00:00:00.000Z')).toMatch(
+      /May 31|Jun 1/
+    );
+  });
+});

--- a/apps/web/tests/unit/user-button/UsageMenuItem.test.tsx
+++ b/apps/web/tests/unit/user-button/UsageMenuItem.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { UsageMenuItem } from '@/components/organisms/user-button/UsageMenuItem';
+import { APP_ROUTES } from '@/constants/routes';
+import type { ChatUsageData } from '@/lib/queries/useChatUsageQuery';
+
+const mockUseChatUsageQuery = vi.fn();
+
+vi.mock('@/lib/queries', () => ({
+  useChatUsageQuery: () => mockUseChatUsageQuery(),
+}));
+
+const baseUsage: ChatUsageData = {
+  plan: 'free',
+  dailyLimit: 10,
+  used: 9,
+  remaining: 1,
+  resetAt: '2026-05-23T19:27:00.000Z',
+  monthlyLimit: 310,
+  monthlyUsed: 24,
+  monthlyRemaining: 286,
+  monthlyResetAt: '2026-06-01T00:00:00.000Z',
+  isExhausted: false,
+  warningThreshold: 2,
+  isNearLimit: true,
+};
+
+describe('UsageMenuItem', () => {
+  it('shows a collapsed usage remaining percent for authed menu users', () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: baseUsage,
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <UsageMenuItem
+        usageStatsUrl={APP_ROUTES.SETTINGS_USAGE}
+        onUpgrade={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Usage remaining')).toBeInTheDocument();
+    expect(screen.getByText('10%')).toBeInTheDocument();
+  });
+
+  it('expands inline to daily and monthly breakdown without navigating away', async () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: baseUsage,
+      isLoading: false,
+      error: null,
+    });
+
+    const user = userEvent.setup();
+    render(
+      <UsageMenuItem
+        usageStatsUrl={APP_ROUTES.SETTINGS_USAGE}
+        onUpgrade={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /usage remaining/i }));
+
+    expect(screen.getByText('Daily')).toBeInTheDocument();
+    expect(screen.getByText(/10% ·/)).toBeInTheDocument();
+    expect(screen.getByText('Monthly')).toBeInTheDocument();
+    expect(screen.getByText('Monthly').closest('div')?.textContent).toMatch(
+      /92% · (May 31|Jun 1)/
+    );
+    expect(screen.getByRole('link', { name: /learn more/i })).toHaveAttribute(
+      'href',
+      APP_ROUTES.SETTINGS_USAGE
+    );
+  });
+
+  it('surfaces a neutral upgrade nudge when near the limit', async () => {
+    const onUpgrade = vi.fn();
+    mockUseChatUsageQuery.mockReturnValue({
+      data: baseUsage,
+      isLoading: false,
+      error: null,
+    });
+
+    const user = userEvent.setup();
+    render(
+      <UsageMenuItem
+        usageStatsUrl={APP_ROUTES.SETTINGS_USAGE}
+        onUpgrade={onUpgrade}
+        upgradeLabel='Upgrade to Pro'
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /usage remaining/i }));
+    await user.click(screen.getByRole('button', { name: /upgrade to pro/i }));
+
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (grok-composer-2.5-fast). Closes #11373.

Card: t_d00f7b87
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- client console errors + render of affected pages
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.