### PR TITLE
chore: blocked 'connect' from 'egojgbuon2z2yahy.public.blob.vercel-storage.com' (#11374)

### DIFF
--- a/apps/web/constants/platforms/cdn-domains.ts
+++ b/apps/web/constants/platforms/cdn-domains.ts
@@ -93,6 +93,9 @@ export const INFRASTRUCTURE_MEDIA_DOMAINS: readonly string[] = [
 export const INFRASTRUCTURE_CONNECT_DOMAINS: readonly string[] = [
   // Vercel dashboard/API (chat surface deployment status, toolbar)
   'vercel.com',
+  // Vercel Blob client uploads + direct browser fetches
+  '*.blob.vercel-storage.com',
+  '*.public.blob.vercel-storage.com',
 ];
 
 /**

--- a/apps/web/tests/unit/constants/platforms/cdn-domains-sync.test.ts
+++ b/apps/web/tests/unit/constants/platforms/cdn-domains-sync.test.ts
@@ -61,6 +61,12 @@ describe('CDN domain registry', () => {
       const domains = getCspConnectSrcDomains();
       expect(domains).toContain('https://vercel.com');
     });
+
+    it('includes Vercel Blob storage for client-side uploads', () => {
+      const domains = getCspConnectSrcDomains();
+      expect(domains).toContain('https://*.blob.vercel-storage.com');
+      expect(domains).toContain('https://*.public.blob.vercel-storage.com');
+    });
   });
 
   describe('getCspImgSrcDomains', () => {

--- a/apps/web/tests/unit/lib/content-security-policy.test.ts
+++ b/apps/web/tests/unit/lib/content-security-policy.test.ts
@@ -71,6 +71,17 @@ describe('buildContentSecurityPolicy', () => {
     expect(connectSrc).toContain('https://vercel.com');
   });
 
+  it('includes Vercel Blob storage in connect-src for client uploads', () => {
+    const csp = buildContentSecurityPolicy({
+      nonce: 'test-nonce',
+      isDev: false,
+    });
+    const connectSrc = findDirective(csp, 'connect-src');
+
+    expect(connectSrc).toContain('https://*.blob.vercel-storage.com');
+    expect(connectSrc).toContain('https://*.public.blob.vercel-storage.com');
+  });
+
   it('includes Sentry regional ingest wildcard in connect-src', () => {
     const csp = buildContentSecurityPolicy({
       nonce: 'test-nonce',


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (grok-composer-2.5-fast). Closes #11374.

Card: t_c9bca5ba
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- error rate + p95 latency on affected surface
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.