### PR TITLE
chore(biome): clear pre-existing format + config drift (#12482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 ### Fixed
 
 - [internal] Pre-push Biome gate scopes to changed files (mirroring CI) instead of a repo-wide `biome check .`, so pre-existing Biome drift on `main` no longer blocks `git push` from every worktree and stops training agents toward the `JOVIE_SKIP_PRE_PUSH_GATE=1` escape hatch (GitHub #12475).
+- [internal] Cleared the pre-existing Biome drift on `main` that #12475 unblocked (GitHub #12482): `biome format` reflow of `globals.css` + `design-system.css` (whitespace-only — design tokens byte-identical with whitespace stripped) and `biome migrate` on `biome.json` (schema `2.4.8`→`2.5.1`, deprecated `recommended: false`→`preset: "none"`). `biome ci .` is now clean. The issue's `setup.ts` and public-SVG `noSvgWithoutTitle` buckets were already non-issues on current main (Biome 2.5.1 does not lint raw `.svg` files).
 - **Library share links no longer error on re-open**: opening a release that already has share settings — or two tabs opening it at once — previously returned a 500. The "ensure share settings exist" path is now idempotent under a concurrent first-open race via an `ON CONFLICT DO NOTHING` insert plus re-read (GitHub #12407).
 
 ### Changed

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2057,10 +2057,10 @@ body {
   }
   /* Interactive controls — tactile press via transform only (no transition:all) */
   :where(
-      button:not(:disabled):not([data-static="true"]),
-      [role="button"]:not([aria-disabled="true"]):not([data-static="true"]),
-      summary
-    ) {
+    button:not(:disabled):not([data-static="true"]),
+    [role="button"]:not([aria-disabled="true"]):not([data-static="true"]),
+    summary
+  ) {
     transition: transform var(--duration-subtle) var(--ease-subtle);
   }
   @media (prefers-reduced-motion: no-preference) {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1773,22 +1773,22 @@ html:not(.dark) .smart-link-powered-by {
 }
 
 :where(
-    input,
-    textarea,
-    select,
-    [contenteditable="true"],
-    [role="textbox"]
-  ):focus {
+  input,
+  textarea,
+  select,
+  [contenteditable="true"],
+  [role="textbox"]
+):focus {
   outline: none;
 }
 
 :where(
-    input,
-    textarea,
-    select,
-    [contenteditable="true"],
-    [role="textbox"]
-  ):focus-visible {
+  input,
+  textarea,
+  select,
+  [contenteditable="true"],
+  [role="textbox"]
+):focus-visible {
   box-shadow: none;
 }
 
@@ -3830,8 +3830,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-release-mode-label-heading + .system-b-release-mode-label-list
-  ) {
+  .system-b-release-mode-label-heading + .system-b-release-mode-label-list
+) {
   margin-top: var(--space-3);
 }
 
@@ -3899,8 +3899,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="ai"]
-  ) {
+  .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="ai"]
+) {
   position: absolute;
   top: var(--space-6);
   left: var(--space-6);
@@ -3909,8 +3909,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="tasks"]
-  ) {
+  .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="tasks"]
+) {
   position: absolute;
   top: var(--space-6);
   right: var(--space-6);
@@ -3919,8 +3919,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="monitoring"]
-  ) {
+  .system-b-release-operating-system-slot[data-layout="desktop"][data-slot="monitoring"]
+) {
   position: absolute;
   bottom: var(--space-6);
   left: var(--space-6);
@@ -4936,9 +4936,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-thread-video-preview:hover
-      .system-b-thread-play-button[data-interactive="true"]
-  ) {
+  .system-b-thread-video-preview:hover
+    .system-b-thread-play-button[data-interactive="true"]
+) {
   background: color-mix(
     in oklab,
     var(--system-b-primary-bg) 94%,
@@ -5424,9 +5424,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-spotify-connect-status-copy,
-    .system-b-spotify-connect-helper-copy
-  ) {
+  .system-b-spotify-connect-status-copy,
+  .system-b-spotify-connect-helper-copy
+) {
   line-height: calc(var(--space-4) + var(--space-px));
 }
 
@@ -5502,9 +5502,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-spotify-connect-result-row--active,
-    .system-b-spotify-connect-result-row--interactive:hover
-  ) {
+  .system-b-spotify-connect-result-row--active,
+  .system-b-spotify-connect-result-row--interactive:hover
+) {
   border-color: var(--system-b-app-frame-seam);
   background: var(--color-bg-surface-1);
 }
@@ -5526,9 +5526,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-spotify-connect-paste-row:hover,
-    .system-b-spotify-connect-paste-row--active
-  ) {
+  .system-b-spotify-connect-paste-row:hover,
+  .system-b-spotify-connect-paste-row--active
+) {
   background: var(--color-bg-surface-1);
 }
 
@@ -6311,8 +6311,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-library-rail-button:not(.system-b-library-rail-button--active)
-  ),
+  .system-b-library-rail-button:not(.system-b-library-rail-button--active)
+),
 :where(.system-b-library-filter-row:not(.system-b-library-filter-row--active)) {
   border-color: transparent;
 }
@@ -6325,13 +6325,11 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-library-rail-button:not(
-        .system-b-library-rail-button--active
-      ):hover
-  ),
+  .system-b-library-rail-button:not(.system-b-library-rail-button--active):hover
+),
 :where(
-    .system-b-library-filter-row:not(.system-b-library-filter-row--active):hover
-  ) {
+  .system-b-library-filter-row:not(.system-b-library-filter-row--active):hover
+) {
   border-color: var(--color-border-default);
   background: var(--system-b-bg-surface-1);
   color: var(--color-text-primary-token);
@@ -7332,8 +7330,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-shell-dropdown-row[data-highlighted] .system-b-shell-dropdown-icon
-  ) {
+  .system-b-shell-dropdown-row[data-highlighted] .system-b-shell-dropdown-icon
+) {
   color: var(--color-text-primary-token);
 }
 
@@ -7342,9 +7340,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-shell-dropdown-row[data-highlighted]
-      .system-b-shell-dropdown-danger-icon
-  ) {
+  .system-b-shell-dropdown-row[data-highlighted]
+    .system-b-shell-dropdown-danger-icon
+) {
   color: color-mix(
     in oklab,
     var(--color-error) 72%,
@@ -7509,9 +7507,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-shell-dropdown-row[data-state="checked"]
-      .system-b-shell-dropdown-checkbox-indicator
-  ) {
+  .system-b-shell-dropdown-row[data-state="checked"]
+    .system-b-shell-dropdown-checkbox-indicator
+) {
   border-color: var(--system-b-accent-cyan);
   background: var(--system-b-accent-cyan);
 }
@@ -7525,9 +7523,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-shell-dropdown-row[data-highlighted]
-      .system-b-shell-dropdown-link-icon
-  ) {
+  .system-b-shell-dropdown-row[data-highlighted]
+    .system-b-shell-dropdown-link-icon
+) {
   color: var(--color-text-tertiary-token);
 }
 
@@ -8398,8 +8396,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-chat-composer-surface[data-hero="true"][data-expanded="true"]
-  ) {
+  .system-b-chat-composer-surface[data-hero="true"][data-expanded="true"]
+) {
   background: color-mix(
     in oklab,
     var(--system-b-app-content-surface) 82%,
@@ -9625,8 +9623,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   }
 
   :where(
-      .system-b-image-preview-item:hover .system-b-image-preview-remove-button
-    ) {
+    .system-b-image-preview-item:hover .system-b-image-preview-remove-button
+  ) {
     opacity: 1;
   }
 }
@@ -9856,9 +9854,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-    .system-b-chat-thread-nav-hover-zone:hover
-      .system-b-chat-thread-navigation-rail
-  ),
+  .system-b-chat-thread-nav-hover-zone:hover
+    .system-b-chat-thread-navigation-rail
+),
 :where(.system-b-chat-thread-navigation-rail:focus-within) {
   opacity: 1;
   pointer-events: auto;
@@ -11325,8 +11323,8 @@ body:has(.system-b-pricing-page) .marketing-glass-header__cta:focus-visible {
 }
 
 :where(
-    .system-b-pricing-switch[data-state="annual"] .system-b-pricing-switch-thumb
-  ) {
+  .system-b-pricing-switch[data-state="annual"] .system-b-pricing-switch-thumb
+) {
   transform: translateX(calc(var(--space-5) - var(--space-0-5)));
 }
 

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -32,7 +32,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": false,
+      "preset": "none",
       "a11y": {
         "noAccessKey": "error",
         "noAriaHiddenOnFocusable": "error",


### PR DESCRIPTION
## Summary

Closes #12482.

Clears the pre-existing Biome drift on `main` that #12475 (scoping the pre-push gate to changed files) unblocked but left behind. A clean `origin/main` checkout had Biome violations no longer caught by the scoped local gate and not caught by CI — so whoever next touched these files would inherit the failure. This removes the trap.

<!-- linear-issue-id: none — ad-hoc GitHub issue #12482 -->

## What changed (per the issue's 4 buckets)

| Bucket | Finding | Action |
|---|---|---|
| **CSS format** — `apps/web/app/globals.css`, `apps/web/styles/design-system.css` | 2 real `format` errors | `biome format --write` — **whitespace-only reflow** |
| **`biome.json`** — schema `2.4.8` vs CLI `2.5.1` + deprecated `recommended` | 2 infos | `biome migrate`: schema → `2.5.1`, `recommended: false` → `preset: "none"` |
| **`apps/web/tests/setup.ts:93`** — organizeImports | **already clean on current main** | none needed |
| **public `**/*.svg`** — 15× `noSvgWithoutTitle` | **phantom** — Biome 2.5.1 does not lint raw `.svg` files; 0 `noSvgWithoutTitle` JSX violations repo-wide | none needed |

Two of the four buckets are non-issues on current `main`, verified independently (below). No SVG exclusion or hand-edits were warranted.

## Safety of the change

- **CSS is semantics-preserving**: both files are **byte-identical when all whitespace is stripped** (sha256 match, old vs new). No OKLCH/hex color, custom-property value, media query, or selector specificity changed. The only non-whitespace-looking hunk is a long `:where(...)` selector collapsed onto one line — same selector text.
- **`biome.json` is behavior-preserving**: `preset: "none"` is Biome's official successor to `recommended: false` (reproduced by re-running `biome migrate` on the pre-change config). The explicit per-rule a11y/correctness/security config below it is byte-identical. No recommended-preset rule silently toggled.

## Verification

```
biome ci .                          → exit 0  (Checked 7048 files, no fixes applied; 0 errors / 0 infos)
pnpm --filter @jovie/web typecheck  → exit 0
design-system content-guard tests   → 8 files, 33 tests, all PASS
  (globals-ui-feel-style-guard, surface-elevation-guardrails, profile-shell-token-contract,
   arbitrary-values-ratchet, server-imports-ratchet, …) — these readFileSync the CSS files,
   so they confirm the reflow broke no token contract
CodeRabbit (--agent -t uncommitted) → 0 findings
git diff --name-only | grep version-fanout → none (CHANGELOG adds an [Unreleased] bullet only)
```

Subagent review: **opus review → APPROVE**, **opus security → SECURE** (no lint-coverage weakening, no secrets, no new external origins), **sonnet testing → PASS** (no new test warranted; formatting/config-only per `.claude/rules/testing.md`).

## Cost impact

None. Tooling/formatting + lint-config migration only. No runtime, API, cron, or dependency change.

## Risk

Low. Whitespace reflow + behavior-identical lint-config migration. No TypeScript or runtime code touched.
