### PR TITLE
feat(design-system): state-matrix token+selector+story spec (JOV-3575)

### DIFF
--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -579,6 +579,31 @@ html[data-profile-initial-mode]
   );
   --color-skeleton-shimmer: oklch(100% 0 0);
 
+  /* Cross-cutting interaction state tokens (state-matrix.md) */
+  --color-link-default: var(--linear-accent-blue);
+  --color-link-hover: color-mix(
+    in oklab,
+    var(--linear-accent-blue) 82%,
+    var(--linear-text-primary)
+  );
+  --color-link-visited: var(--linear-accent-purple);
+  --state-disabled-opacity: 0.5;
+  --state-partial-opacity: 0.62;
+  --state-offline-bg: var(--color-warning-subtle);
+  --state-offline-border: color-mix(
+    in oklab,
+    var(--color-warning) 24%,
+    transparent
+  );
+  --state-offline-fg: var(--color-warning);
+  --state-permission-bg: var(--color-warning-subtle);
+  --state-permission-fg: var(--color-warning);
+  --state-permission-border: color-mix(
+    in oklab,
+    var(--color-warning) 20%,
+    transparent
+  );
+
   /* Focus ring — Jovie/Linear keyboard focus token */
   --color-focus-ring: var(--linear-border-focus);
   --focus-ring-width: 1px;
@@ -826,6 +851,31 @@ html[data-profile-initial-mode]
   );
   --color-skeleton-shimmer: oklch(
     24% var(--theme-base-chroma) var(--theme-base-hue)
+  );
+
+  /* Cross-cutting interaction state tokens (state-matrix.md) */
+  --color-link-default: var(--linear-accent-blue);
+  --color-link-hover: color-mix(
+    in oklab,
+    var(--linear-accent-blue) 78%,
+    var(--linear-text-primary)
+  );
+  --color-link-visited: var(--linear-accent-purple);
+  --state-disabled-opacity: 0.5;
+  --state-partial-opacity: 0.62;
+  --state-offline-bg: var(--color-warning-subtle);
+  --state-offline-border: color-mix(
+    in oklab,
+    var(--color-warning) 24%,
+    transparent
+  );
+  --state-offline-fg: var(--color-warning);
+  --state-permission-bg: var(--color-warning-subtle);
+  --state-permission-fg: var(--color-warning);
+  --state-permission-border: color-mix(
+    in oklab,
+    var(--color-warning) 20%,
+    transparent
   );
 }
 

--- a/apps/web/tests/unit/chat/__snapshots__/ChatMessageSkeleton.test.tsx.snap
+++ b/apps/web/tests/unit/chat/__snapshots__/ChatMessageSkeleton.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`ChatMessageSkeleton > matches snapshot 1`] = `
       <div
         aria-hidden="true"
         class="skeleton motion-reduce:animate-none rounded-full system-b-chat-message-skeleton-user-line"
+        data-state="shimmer"
       />
     </div>
   </div>
@@ -26,14 +27,17 @@ exports[`ChatMessageSkeleton > matches snapshot 1`] = `
       <div
         aria-hidden="true"
         class="skeleton motion-reduce:animate-none rounded-lg system-b-chat-message-skeleton-line system-b-chat-message-skeleton-line-wide"
+        data-state="shimmer"
       />
       <div
         aria-hidden="true"
         class="skeleton motion-reduce:animate-none rounded-lg system-b-chat-message-skeleton-line system-b-chat-message-skeleton-line-medium"
+        data-state="shimmer"
       />
       <div
         aria-hidden="true"
         class="skeleton motion-reduce:animate-none rounded-lg system-b-chat-message-skeleton-line system-b-chat-message-skeleton-line-short"
+        data-state="shimmer"
       />
     </div>
   </div>

--- a/docs/design-system/state-matrix.md
+++ b/docs/design-system/state-matrix.md
@@ -1,79 +1,149 @@
 # State Matrix
 
-This matrix defines the states shared primitives and templates must support.
+Canonical interaction and content states for shared primitives and templates.
+
+Each row lists:
+
+- **Token** — CSS custom property (or class) that owns the visual
+- **Selector** — how to target the state in CSS/tests
+- **Story** — Storybook path for visual reference
+- **Primitive** — canonical component that implements the state
+
+Token sources: `apps/web/styles/design-system.css`, `apps/web/styles/linear-tokens.css`, `apps/web/app/globals.css`.
+
+---
+
+## Cross-cutting states (JOV-3575)
+
+These states apply across families and were previously undocumented.
+
+| State | Token | Selector | Story | Primitive |
+| --- | --- | --- | --- | --- |
+| Visited | `--color-link-visited` | `a:visited`, `[data-state="visited"]` | `shadcn/Link/Visited` | `packages/ui/atoms/link.tsx` |
+| Link styling | `--color-link-default`, `--color-link-hover` | `[data-variant="link"]` | `shadcn/Link/Default` | `packages/ui/atoms/link.tsx` |
+| Disabled visual | `--state-disabled-opacity`, `--color-text-disabled-token` | `[data-state="disabled"]`, `:disabled`, `[aria-disabled="true"]` | `shadcn/Button/DisabledVisual` | `packages/ui/atoms/button.tsx` |
+| Loading shimmer | `--color-skeleton-base`, `--color-skeleton-shimmer` | `.skeleton`, `[data-state="shimmer"]` | `shadcn/Skeleton/LoadingShimmer` | `packages/ui/atoms/skeleton.tsx` |
+| Partial data | `--state-partial-opacity` | `[data-content-state="partial"]` | `UI/Atoms/Card/PartialData` | `packages/ui/atoms/card.tsx` |
+| Permission restricted | `--state-permission-bg`, `--state-permission-fg`, `--state-permission-border` | `[data-state="permission-restricted"]` | `shadcn/Badge/PermissionRestricted` | `packages/ui/atoms/badge.tsx` |
+| Long content | `--color-text-primary-token` + clamp utilities | `[data-content-length="long"]`, `.line-clamp-*`, `.truncate` | `UI/Atoms/Card/LongContent` | `packages/ui/atoms/card.tsx` (`CardTitle`) |
+| Inline offline | `--state-offline-bg`, `--state-offline-border`, `--state-offline-fg` | `[data-state="offline"]` | `shadcn/InlineOffline/Default` | `packages/ui/atoms/inline-offline.tsx` |
+
+---
 
 ## Buttons and links
 
-- Default
-- Hover
-- Focus-visible
-- Active/pressed
-- Disabled
-- Loading
-- Success
+| State | Token | Selector | Story | Primitive |
+| --- | --- | --- | --- | --- |
+| Default | `--linear-btn-primary-bg`, `--linear-btn-primary-fg` | `[data-state="idle"]`, `button` base | `shadcn/Button/Primary` | `packages/ui/atoms/button.tsx` |
+| Hover | `--linear-btn-primary-hover`, `--color-interactive-hover` | `:hover`, `hover:bg-*` | `shadcn/Button/Primary` | `packages/ui/atoms/button.tsx` |
+| Focus-visible | `--color-focus-ring`, `--linear-border-focus` | `:focus-visible`, `focus-visible:ring-*` | `shadcn/Button/Primary` | `packages/ui/atoms/button.tsx` |
+| Active/pressed | `--color-interactive-active` | `:active`, `active:scale-[0.96]` | `shadcn/Button/Primary` | `packages/ui/atoms/button.tsx` |
+| Disabled | `--state-disabled-opacity`, `--color-text-disabled-token` | `[data-state="disabled"]`, `:disabled` | `shadcn/Button/Disabled` | `packages/ui/atoms/button.tsx` |
+| Loading | `--linear-text-primary` (spinner) | `[data-state="loading"]`, `[aria-busy="true"]` | `shadcn/Button/Loading` | `packages/ui/atoms/button.tsx` |
+| Success | `--color-success`, `--color-success-subtle` | `[data-state="success"]` | `Molecules/FormStatus/Success` | `apps/web/components/molecules/FormStatus.tsx` |
+| Visited | `--color-link-visited` | `a:visited`, `[data-state="visited"]` | `shadcn/Link/Visited` | `packages/ui/atoms/link.tsx` |
+| Link styling | `--color-link-default`, `--color-link-hover` | `[data-variant="link"]` | `shadcn/Link/Default` | `packages/ui/atoms/link.tsx` |
+
+---
 
 ## TOC and navigation
 
-- Default
-- Hover
-- Focus-visible
-- Current/active section
-- Hidden/collapsed on compact layouts
+| State | Token | Selector | Story | Primitive |
+| --- | --- | --- | --- | --- |
+| Default | `--linear-text-secondary` | `nav a` base, `.marketing-glass-header__text-link` | `UI/NavLink/Default` | `apps/web/components/atoms/NavLink.tsx` |
+| Hover | `--linear-text-primary`, `--color-interactive-hover` | `:hover`, `hover:text-*` | `UI/NavLink/Default` | `apps/web/components/atoms/NavLink.tsx` |
+| Focus-visible | `--color-focus-ring` | `.focus-ring-themed`, `:focus-visible` | `Organisms/HeaderNav/Default` | `apps/web/components/organisms/HeaderNav.tsx` |
+| Current/active section | `--linear-text-primary`, `--color-accent` | `[aria-current="page"]`, `[data-state="active"]` | `Molecules/ProfileNavButton/JovieIcon` | `apps/web/components/molecules/ProfileNavButton.tsx` |
+| Hidden/collapsed (compact) | `--linear-bg-surface-0` | `[data-collapsed="true"]`, `lg:hidden` / `hidden lg:block` | `Molecules/PublicTableOfContents` (route) | `apps/web/components/molecules/PublicTableOfContents.tsx` |
+
+---
 
 ## Inputs and auth forms
 
-- Empty
-- Placeholder
-- Filled
-- Focus
-- Valid
-- Invalid
-- Disabled
-- Read-only
-- Loading/submitting
-- Success
+| State | Token | Selector | Story | Primitive |
+| --- | --- | --- | --- | --- |
+| Empty | `--linear-bg-surface-1`, `--linear-text-primary` | `input:value("")`, no `value` attr | `Atoms/Input/Default` | `packages/ui/atoms/input.tsx` |
+| Placeholder | `--linear-text-tertiary` | `::placeholder`, `placeholder:text-*` | `Atoms/Input/Default` | `packages/ui/atoms/input.tsx` |
+| Filled | `--linear-text-primary` | `input:not(:placeholder-shown)` | `Atoms/Input/Default` | `packages/ui/atoms/input.tsx` |
+| Focus | `--linear-border-focus`, `--color-focus-ring` | `:focus-visible`, `focus-visible:border-*` | `Atoms/Input/Default` | `packages/ui/atoms/input.tsx` |
+| Valid | `--color-success`, `--color-success-subtle` | `[data-validation="valid"]`, `variant="success"` | `Atoms/Input/Validation` | `packages/ui/atoms/input.tsx` |
+| Invalid | `--linear-error`, `--color-error-subtle` | `[aria-invalid="true"]`, `variant="error"` | `Atoms/Input/Validation` | `packages/ui/atoms/input.tsx` |
+| Disabled | `--state-disabled-opacity` | `:disabled`, `[aria-disabled="true"]` | `Atoms/Input/Default` | `packages/ui/atoms/input.tsx` |
+| Read-only | `--linear-text-secondary` | `[readonly]`, `readOnly` prop | `UI/Textarea/Default` | `packages/ui/atoms/textarea.tsx` |
+| Loading/submitting | `--linear-text-secondary` | `[aria-busy="true"]`, `loading` prop | `Atoms/Input/Loading` | `packages/ui/atoms/input.tsx` |
+| Success | `--color-success` | `[data-validation="valid"]` + status icon | `Molecules/FormStatus/Success` | `apps/web/components/molecules/FormStatus.tsx` |
+
+---
 
 ## Async content blocks
 
-- Initial
-- Loading
-- Skeleton
-- Success
-- Empty
-- Error
-- Offline/retry where supported
+| State | Token | Selector | Story | Primitive |
+| --- | --- | --- | --- | --- |
+| Initial | `--color-bg-surface-1` | `[data-content-state="initial"]` | `UI/Atoms/Card/Default` | `packages/ui/atoms/card.tsx` |
+| Loading | `--color-skeleton-base` | `[aria-busy="true"]` | `Atoms/Input/Loading` | `packages/ui/atoms/input.tsx` |
+| Skeleton | `--color-skeleton-base`, `--color-skeleton-shimmer` | `.skeleton`, `[data-state="shimmer"]` | `shadcn/Skeleton/LoadingShimmer` | `packages/ui/atoms/skeleton.tsx` |
+| Success | `--color-success-subtle` | `[data-content-state="success"]` | `Molecules/FormStatus/Success` | `apps/web/components/molecules/FormStatus.tsx` |
+| Empty | `--color-text-secondary-token` | `[data-content-state="empty"]` | `UI/EmptyState/Default` | `apps/web/components/organisms/EmptyState.tsx` |
+| Error | `--color-error-subtle`, `--color-error` | `[data-content-state="error"]`, `variant="error"` | `UI/EmptyState/ErrorState` | `apps/web/components/organisms/EmptyState.tsx` |
+| Offline/retry | `--state-offline-bg`, `--state-offline-fg` | `[data-state="offline"]` | `shadcn/InlineOffline/Default` | `packages/ui/atoms/inline-offline.tsx` |
+| Partial data | `--state-partial-opacity` | `[data-content-state="partial"]` | `UI/Atoms/Card/PartialData` | `packages/ui/atoms/card.tsx` |
+
+---
 
 ## Pricing states
 
-- Free
-- Paid
-- Max/early access
-- Included
-- Not included
-- Coming soon
-- Upgrade available
-- Current plan
+| State | Token | Selector | Story | Primitive |
+| --- | --- | --- | --- | --- |
+| Free | `--linear-text-primary` | `[data-plan-id="free"]`, `.marketing-pricing-plan-card` | `Pricing/PricingCTA/Default` | `apps/web/components/features/pricing/MarketingPricingPlans.tsx` |
+| Paid | `--linear-btn-primary-bg` | `[data-plan-id="pro"]` | `Pricing/PricingCTA/Default` | `apps/web/components/features/pricing/MarketingPricingPlans.tsx` |
+| Max/early access | `--linear-accent-purple` | `[data-plan-id="max"]`, `.marketing-pricing-plan-card__badge` | `Pricing/PricingCTA/Default` | `apps/web/components/features/pricing/MarketingPricingPlans.tsx` |
+| Included | `--linear-success`, `--system-b-accent-cyan` | `.marketing-pricing-plan-card__features svg` | `Pricing/PricingCTA/Default` | `apps/web/components/features/pricing/MarketingPricingPlans.tsx` |
+| Not included | `--linear-text-tertiary` | `.marketing-pricing-plan-card__features li[data-included="false"]` | `Pricing/PricingCTA/Default` | `apps/web/components/features/pricing/PricingComparisonChart.tsx` |
+| Coming soon | `--color-warning-subtle` | `.marketing-pricing-plan-card__badge` (Soon copy) | `Pricing/PricingCTA/Default` | `apps/web/components/features/pricing/MarketingPricingPlans.tsx` |
+| Upgrade available | `--linear-btn-accent-bg` | `.marketing-pricing-plan-card__cta` | `Pricing/PricingCTA/Default` | `apps/web/components/features/pricing/PricingCTA.tsx` |
+| Current plan | `--linear-border-focus` | `[data-plan-active="true"]` | `Pricing/PricingCTA/Default` | `apps/web/components/features/pricing/MarketingPricingPlans.tsx` |
+
+---
 
 ## Public profile module states
 
-- Hero shown
-- Latest release available
-- No release
-- Tour available
-- No tour dates
-- Tips enabled
-- Tips disabled
-- Notifications enabled
-- Notifications unavailable
-- Footer shown
-- Profile not found
+| State | Token | Selector | Story | Primitive |
+| --- | --- | --- | --- | --- |
+| Hero shown | `--profile-pearl-primary-bg` | `[data-module="hero"][data-visible="true"]` | `Organisms/ProfileShell/Default` | `apps/web/components/organisms/profile-shell/ProfileShell.tsx` |
+| Latest release available | `--color-success` | `[data-module="releases"][data-state="available"]` | `Organisms/ProfileShell/WithReleases` | `apps/web/components/organisms/ProfileShell.stories.tsx` |
+| No release | `--color-text-tertiary-token` | `[data-module="releases"][data-state="empty"]` | `Organisms/ProfileShell/Default` | `apps/web/components/organisms/ProfileShell.tsx` |
+| Tour available | `--linear-accent-teal` | `[data-module="tour"][data-state="available"]` | `Organisms/ListenSection/Default` | `apps/web/components/organisms/ListenSection.stories.tsx` |
+| No tour dates | `--color-text-tertiary-token` | `[data-has-tour-dates="false"]` | `Organisms/ProfileShell/Default` | `apps/web/components/organisms/profile-shell/ProfileCompactSurface.tsx` |
+| Tips enabled | `--linear-success` | `[data-module="tips"][data-enabled="true"]` | `Organisms/PaySection/Default` | `apps/web/components/organisms/PaySection.stories.tsx` |
+| Tips disabled | `--color-text-disabled-token` | `[data-module="tips"][data-enabled="false"]` | `Organisms/PaySection/Default` | `apps/web/components/organisms/PaySection.tsx` |
+| Notifications enabled | `--linear-accent-blue` | `[data-module="subscribe"][data-enabled="true"]` | `Organisms/ProfileShell/Default` | `apps/web/components/features/profile/ProfilePrimaryCTA.tsx` |
+| Notifications unavailable | `--color-warning` | `[data-module="subscribe"][data-state="unavailable"]` | `Organisms/ProfileShell/Default` | `apps/web/components/features/profile/ProfilePrimaryCTA.tsx` |
+| Footer shown | `--linear-bg-footer` | `[data-module="footer"][data-visible="true"]` | `Organisms/Footer/Default` | `apps/web/components/organisms/footer-module/Footer.tsx` |
+| Profile not found | `--linear-text-primary` | `[data-profile-state="not-found"]` | route `not-found.tsx` | `apps/web/app/[username]/not-found.tsx` |
+
+---
 
 ## Internal product rows/cards
 
-- Default
-- Hover
-- Selected/current
-- Loading
-- Empty
-- Error
-- Stale/refreshing if data-backed
+| State | Token | Selector | Story | Primitive |
+| --- | --- | --- | --- | --- |
+| Default | `--color-bg-surface-1`, `--color-border-subtle` | `[data-state="idle"]`, row base | `UI/Atoms/Card/Default` | `packages/ui/atoms/card.tsx` |
+| Hover | `--color-interactive-hover` | `:hover`, `hover:bg-surface-*` | `UI/Atoms/Card/Hoverable` | `packages/ui/atoms/card.tsx` |
+| Selected/current | `--color-accent-subtle` | `[data-state="checked"]`, `[aria-selected="true"]` | `shadcn/CommonDropdown/Default` | `packages/ui/atoms/common-dropdown.tsx` |
+| Loading | `--color-skeleton-base` | `[data-state="loading"]`, `[aria-busy="true"]` | `shadcn/Skeleton/LoadingShimmer` | `packages/ui/atoms/skeleton.tsx` |
+| Empty | `--color-text-secondary-token` | `[data-content-state="empty"]` | `UI/EmptyState/Default` | `apps/web/components/organisms/EmptyState.tsx` |
+| Error | `--color-error-subtle` | `[data-content-state="error"]` | `UI/EmptyState/ErrorState` | `apps/web/components/organisms/EmptyState.tsx` |
+| Stale/refreshing | `--state-partial-opacity` | `[data-content-state="partial"]`, `[data-refreshing="true"]` | `UI/Atoms/Card/PartialData` | `packages/ui/atoms/card.tsx` |
+| Permission restricted | `--state-permission-fg` | `[data-state="permission-restricted"]` | `shadcn/Badge/PermissionRestricted` | `packages/ui/atoms/badge.tsx` |
+| Long content | `--color-text-primary-token` | `[data-content-length="long"]` | `UI/Atoms/Card/LongContent` | `packages/ui/atoms/card.tsx` |
+| Inline offline | `--state-offline-fg` | `[data-state="offline"]` | `UI/Atoms/Card/InlineOffline` | `packages/ui/atoms/inline-offline.tsx` |
+
+---
+
+## Implementation notes
+
+1. Prefer `data-state` / `data-content-state` attributes for test and Storybook parity; use pseudo-classes (`:hover`, `:focus-visible`, `:visited`) for native interaction.
+2. Disabled controls must set **both** `disabled` / `aria-disabled` and the disabled-visual tokens — never rely on opacity alone.
+3. Loading skeletons are `aria-hidden` placeholders; parent wrappers (`LoadingSkeleton`, async blocks) own `aria-busy`.
+4. Inline offline is for **in-context** recovery; full-page offline/error uses `EmptyState` or `PageErrorState`.
+5. When adding a new state, update this matrix **and** add a Storybook story before shipping.

--- a/packages/ui/atoms/Card.stories.tsx
+++ b/packages/ui/atoms/Card.stories.tsx
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from './card';
+import { InlineOfflineNotice } from './inline-offline';
 
 const meta: Meta<typeof Card> = {
   title: 'UI/Atoms/Card',
@@ -209,6 +210,90 @@ export const HoverableInteractive: Story = {
         </CardHeader>
         <CardContent>
           <p>Click anywhere on this card to trigger an action.</p>
+        </CardContent>
+      </>
+    ),
+  },
+};
+
+export const PartialData: Story = {
+  args: {
+    contentState: 'partial',
+    className: 'max-w-md',
+    children: (
+      <>
+        <CardHeader>
+          <CardTitle>Audience insights</CardTitle>
+          <CardDescription>
+            Showing cached metrics while fresh data loads.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p>12.4K profile views · last synced 2m ago</p>
+        </CardContent>
+      </>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Partial-data state via data-content-state="partial" and --state-partial-opacity.',
+      },
+    },
+  },
+};
+
+export const LongContent: Story = {
+  args: {
+    className: 'max-w-xs',
+    children: (
+      <>
+        <CardHeader>
+          <CardTitle
+            maxLines={2}
+            title='Independent Artist Revenue Playbook for Multi-Platform Release Campaigns'
+          >
+            Independent Artist Revenue Playbook for Multi-Platform Release
+            Campaigns
+          </CardTitle>
+          <CardDescription>
+            Long titles clamp without breaking card layout.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className='text-sm text-secondary-token'>
+            Use maxLines or truncate on CardTitle for long-content handling.
+          </p>
+        </CardContent>
+      </>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Long-content state via data-content-length="long" with line-clamp utilities.',
+      },
+    },
+  },
+};
+
+export const InlineOffline: Story = {
+  args: {
+    className: 'max-w-md',
+    children: (
+      <>
+        <CardHeader>
+          <CardTitle>Billing summary</CardTitle>
+          <CardDescription>Retry when your connection returns.</CardDescription>
+        </CardHeader>
+        <CardContent className='space-y-3'>
+          <InlineOfflineNotice onRetry={() => undefined} />
+          <p className='text-sm text-secondary-token'>
+            Cached invoice totals remain visible beneath the inline offline
+            notice.
+          </p>
         </CardContent>
       </>
     ),

--- a/packages/ui/atoms/badge.stories.tsx
+++ b/packages/ui/atoms/badge.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Badge } from './badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'shadcn/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Beta',
+  },
+};
+
+export const PermissionRestricted: Story = {
+  args: {
+    variant: 'permission-restricted',
+    children: 'Admin only',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Permission-restricted state using data-state="permission-restricted" and warning tokens.',
+      },
+    },
+  },
+};

--- a/packages/ui/atoms/badge.test.tsx
+++ b/packages/ui/atoms/badge.test.tsx
@@ -211,5 +211,17 @@ describe('Badge', () => {
       expect(badge).toBeInTheDocument();
       expect(badge).toBeEmptyDOMElement();
     });
+
+    it('applies permission-restricted state', () => {
+      render(
+        <Badge variant='permission-restricted' data-testid='badge'>
+          Admin only
+        </Badge>
+      );
+
+      const badge = screen.getByTestId('badge');
+      expect(badge).toHaveAttribute('data-state', 'permission-restricted');
+      expect(badge.className).toContain('bg-(--state-permission-bg)');
+    });
   });
 });

--- a/packages/ui/atoms/badge.tsx
+++ b/packages/ui/atoms/badge.tsx
@@ -16,6 +16,8 @@ const badgeVariants = cva(
           'border border-(--color-border-default) text-(--linear-text-secondary) bg-transparent',
         success: 'bg-(--color-success-subtle) text-success',
         warning: 'bg-(--color-warning-subtle) text-warning',
+        'permission-restricted':
+          'border border-(--state-permission-border) bg-(--state-permission-bg) text-(--state-permission-fg)',
         // Backwards-compat aliases
         primary:
           'bg-(--color-bg-primary) text-(--linear-text-primary) border border-(--color-border-strong)',
@@ -49,9 +51,13 @@ export interface BadgeProps
 
 const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
   ({ className, variant, size, tone, ...props }, ref) => {
+    const dataState =
+      variant === 'permission-restricted' ? 'permission-restricted' : undefined;
+
     return (
       <span
         ref={ref}
+        data-state={dataState}
         className={cn(badgeVariants({ variant, size, tone }), className)}
         {...props}
       />

--- a/packages/ui/atoms/button.stories.tsx
+++ b/packages/ui/atoms/button.stories.tsx
@@ -194,6 +194,22 @@ export const Disabled: Story = {
   },
 };
 
+export const DisabledVisual: Story = {
+  args: {
+    children: 'Disabled visual spec',
+    disabled: true,
+    variant: 'primary',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Disabled-visual spec: data-state="disabled", --state-disabled-opacity, and --color-text-disabled-token.',
+      },
+    },
+  },
+};
+
 export const LoadingDisabled: Story = {
   args: {
     children: 'Loading Disabled',

--- a/packages/ui/atoms/button.tsx
+++ b/packages/ui/atoms/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 const buttonVariants = cva(
-  'relative inline-flex items-center justify-center rounded-full text-[13px] font-[510] tracking-normal transition-[background-color,border-color,color,box-shadow,opacity,transform] duration-normal ease-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) disabled:opacity-50 disabled:pointer-events-none',
+  'relative inline-flex items-center justify-center rounded-full text-[13px] font-[510] tracking-normal transition-[background-color,border-color,color,box-shadow,opacity,transform] duration-normal ease-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) disabled:pointer-events-none disabled:opacity-[var(--state-disabled-opacity)] disabled:text-(--color-text-disabled-token)',
   {
     variants: {
       variant: {

--- a/packages/ui/atoms/card.test.tsx
+++ b/packages/ui/atoms/card.test.tsx
@@ -323,4 +323,28 @@ describe('Card composition', () => {
     expect(header.className).toContain('flex');
     expect(title.className).toContain('text-base');
   });
+
+  it('applies partial-data content state', () => {
+    render(
+      <Card contentState='partial' data-testid='card'>
+        Partial
+      </Card>
+    );
+
+    const card = screen.getByTestId('card');
+    expect(card).toHaveAttribute('data-content-state', 'partial');
+    expect(card.className).toContain('opacity-[var(--state-partial-opacity)]');
+  });
+
+  it('marks long-content titles', () => {
+    render(
+      <CardTitle maxLines={2} data-testid='title'>
+        A very long card title that should clamp across multiple lines
+      </CardTitle>
+    );
+
+    const title = screen.getByTestId('title');
+    expect(title).toHaveAttribute('data-content-length', 'long');
+    expect(title.className).toContain('line-clamp-2');
+  });
 });

--- a/packages/ui/atoms/card.tsx
+++ b/packages/ui/atoms/card.tsx
@@ -21,20 +21,36 @@ const cardVariants = cva(
   }
 );
 
+export type CardContentState = 'default' | 'partial' | 'offline';
+
 export interface CardProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof cardVariants> {
   readonly asChild?: boolean;
+  /**
+   * Async/partial content state for data-backed cards.
+   */
+  readonly contentState?: CardContentState;
 }
 
 const Card = React.forwardRef<HTMLDivElement, CardProps>(
-  ({ className, variant, asChild = false, ...props }, ref) => {
+  (
+    { className, variant, asChild = false, contentState = 'default', ...props },
+    ref
+  ) => {
     const Comp = asChild ? Slot : 'div';
 
     return (
       <Comp
         ref={ref}
-        className={cn(cardVariants({ variant, className }))}
+        data-content-state={
+          contentState === 'default' ? undefined : contentState
+        }
+        className={cn(
+          cardVariants({ variant, className }),
+          contentState === 'partial' &&
+            'opacity-[var(--state-partial-opacity)] saturate-75'
+        )}
         {...props}
       />
     );
@@ -64,17 +80,33 @@ CardHeader.displayName = 'CardHeader';
 export interface CardTitleProps
   extends React.HTMLAttributes<HTMLHeadingElement> {
   readonly asChild?: boolean;
+  /**
+   * Truncate overflowing titles to a single line.
+   */
+  readonly truncate?: boolean;
+  /**
+   * Clamp long titles to N lines (2 or 3). Ignored when truncate is true.
+   */
+  readonly maxLines?: 2 | 3;
 }
 
 const CardTitle = React.forwardRef<HTMLHeadingElement, CardTitleProps>(
-  ({ className, asChild = false, ...props }, ref) => {
+  (
+    { className, asChild = false, truncate = false, maxLines, ...props },
+    ref
+  ) => {
     const Comp = asChild ? Slot : 'h3';
+    const isLongContent = truncate || maxLines !== undefined;
 
     return (
       <Comp
         ref={ref}
+        data-content-length={isLongContent ? 'long' : undefined}
         className={cn(
           'text-base font-semibold leading-none tracking-tight text-primary-token',
+          truncate && 'truncate',
+          maxLines === 2 && 'line-clamp-2 leading-snug',
+          maxLines === 3 && 'line-clamp-3 leading-snug',
           className
         )}
         {...props}

--- a/packages/ui/atoms/inline-offline.stories.tsx
+++ b/packages/ui/atoms/inline-offline.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { InlineOfflineNotice } from './inline-offline';
+
+const meta: Meta<typeof InlineOfflineNotice> = {
+  title: 'shadcn/InlineOffline',
+  component: InlineOfflineNotice,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Inline offline/retry pattern for data-backed blocks. Uses data-state="offline" with warning surface tokens.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onRetry: () => undefined,
+  },
+  decorators: [
+    Story => (
+      <div className='max-w-md'>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const WithoutRetry: Story = {
+  args: {
+    message: 'Offline — showing cached audience stats.',
+  },
+  decorators: [
+    Story => (
+      <div className='max-w-md'>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/packages/ui/atoms/inline-offline.test.tsx
+++ b/packages/ui/atoms/inline-offline.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { InlineOfflineNotice } from './inline-offline';
+
+describe('InlineOfflineNotice', () => {
+  it('renders offline status with canonical selector', () => {
+    render(<InlineOfflineNotice data-testid='offline-notice' />);
+
+    const notice = screen.getByTestId('offline-notice');
+    expect(notice).toHaveAttribute('role', 'status');
+    expect(notice).toHaveAttribute('data-state', 'offline');
+    expect(notice.className).toContain('bg-(--state-offline-bg)');
+  });
+
+  it('calls retry handler when retry button is clicked', async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+
+    render(<InlineOfflineNotice onRetry={onRetry} />);
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/atoms/inline-offline.tsx
+++ b/packages/ui/atoms/inline-offline.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '../lib/utils';
+import { Button } from './button';
+
+export interface InlineOfflineNoticeProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  readonly message?: string;
+  readonly retryLabel?: string;
+  readonly onRetry?: () => void;
+}
+
+/**
+ * Compact inline offline banner for data-backed surfaces.
+ * Use inside cards, tables, or form panels — not as a full-page fallback.
+ */
+export function InlineOfflineNotice({
+  className,
+  message = 'You appear to be offline. Changes will sync when your connection returns.',
+  retryLabel = 'Retry',
+  onRetry,
+  ...props
+}: InlineOfflineNoticeProps) {
+  return (
+    <div
+      role='status'
+      aria-live='polite'
+      data-state='offline'
+      className={cn(
+        'flex flex-wrap items-center justify-between gap-3 rounded-lg border px-3 py-2 text-[13px]',
+        'border-(--state-offline-border) bg-(--state-offline-bg) text-(--state-offline-fg)',
+        className
+      )}
+      {...props}
+    >
+      <p className='min-w-0 flex-1 text-left leading-snug'>{message}</p>
+      {onRetry ? (
+        <Button
+          type='button'
+          variant='outline'
+          size='sm'
+          onClick={onRetry}
+          className='shrink-0'
+        >
+          {retryLabel}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/atoms/link.stories.tsx
+++ b/packages/ui/atoms/link.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Link } from './link';
+
+const meta: Meta<typeof Link> = {
+  title: 'shadcn/Link',
+  component: Link,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Canonical inline link primitive with default, subtle, and inline variants. Visited styling uses :visited and optional data-state="visited".',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'subtle', 'inline'],
+    },
+    visited: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    href: '#features',
+    children: 'View release analytics',
+  },
+};
+
+export const Subtle: Story = {
+  args: {
+    href: '#docs',
+    variant: 'subtle',
+    children: 'Read the docs',
+  },
+};
+
+export const Inline: Story = {
+  args: {
+    href: '#terms',
+    variant: 'inline',
+    children: 'Terms of service',
+  },
+};
+
+export const Visited: Story = {
+  args: {
+    href: '#visited-example',
+    visited: true,
+    children: 'Previously opened link',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Documents visited link styling via data-state="visited" and :visited token --color-link-visited.',
+      },
+    },
+  },
+};

--- a/packages/ui/atoms/link.test.tsx
+++ b/packages/ui/atoms/link.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Link } from './link';
+
+describe('Link', () => {
+  it('renders anchor with canonical link variant attrs', () => {
+    render(
+      <Link href='/docs' data-testid='link'>
+        Documentation
+      </Link>
+    );
+
+    const link = screen.getByTestId('link');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('data-variant', 'link');
+    expect(link).toHaveAttribute('data-state', 'idle');
+    expect(link.className).toContain('text-(--color-link-default)');
+    expect(link.className).toContain('visited:text-(--color-link-visited)');
+  });
+
+  it('marks visited preview state', () => {
+    render(
+      <Link href='/visited' visited data-testid='visited-link'>
+        Visited
+      </Link>
+    );
+
+    expect(screen.getByTestId('visited-link')).toHaveAttribute(
+      'data-state',
+      'visited'
+    );
+  });
+});

--- a/packages/ui/atoms/link.tsx
+++ b/packages/ui/atoms/link.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { cn } from '@jovie/ui/lib/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+const linkVariants = cva(
+  [
+    'inline-flex items-center gap-1 text-[13px] font-[510] tracking-normal underline-offset-4 transition-colors duration-normal ease-interactive',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+    'rounded-sm',
+  ],
+  {
+    variants: {
+      variant: {
+        default: [
+          'text-(--color-link-default) hover:text-(--color-link-hover) hover:underline',
+          'visited:text-(--color-link-visited)',
+        ],
+        subtle: [
+          'text-(--linear-text-secondary) hover:text-(--color-link-hover) hover:underline',
+          'visited:text-(--color-link-visited)',
+        ],
+        inline: [
+          'text-primary-token underline decoration-(--linear-border-default) hover:decoration-(--color-link-hover)',
+          'visited:text-(--color-link-visited) visited:decoration-(--color-link-visited)',
+        ],
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+export interface LinkProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    VariantProps<typeof linkVariants> {
+  /**
+   * Marks the link as visited for Storybook/docs parity when pseudo-class
+   * preview is unavailable. Does not replace the native :visited selector.
+   */
+  readonly visited?: boolean;
+}
+
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ className, variant, visited, ...props }, ref) => {
+    return (
+      <a
+        ref={ref}
+        data-variant='link'
+        data-state={visited ? 'visited' : 'idle'}
+        className={cn(linkVariants({ variant, className }))}
+        {...props}
+      />
+    );
+  }
+);
+Link.displayName = 'Link';
+
+export { Link, linkVariants };

--- a/packages/ui/atoms/skeleton.stories.tsx
+++ b/packages/ui/atoms/skeleton.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { LoadingSkeleton, Skeleton } from './skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'shadcn/Skeleton',
+  component: Skeleton,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Loading shimmer uses .skeleton, data-state="shimmer", and --color-skeleton-base / --color-skeleton-shimmer tokens.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    className: 'h-4 w-48',
+  },
+};
+
+export const LoadingShimmer: Story = {
+  args: {
+    className: 'h-10 w-64',
+    shimmer: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Canonical loading-shimmer state with animated gradient.',
+      },
+    },
+  },
+};
+
+export const StaticPlaceholder: Story = {
+  args: {
+    className: 'h-10 w-64',
+    shimmer: false,
+  },
+};
+
+export const MultiLine: Story = {
+  render: () => <LoadingSkeleton lines={3} height='h-4' width='w-64' />,
+  parameters: {
+    docs: {
+      description: {
+        story: 'LoadingSkeleton wrapper exposes aria-busy for assistive tech.',
+      },
+    },
+  },
+};

--- a/packages/ui/atoms/skeleton.test.tsx
+++ b/packages/ui/atoms/skeleton.test.tsx
@@ -17,6 +17,20 @@ describe('Skeleton', () => {
       expect(skeleton.className).toContain('skeleton');
     });
 
+    it('exposes shimmer loading state attrs', () => {
+      render(<Skeleton data-testid='skeleton' shimmer />);
+      const skeleton = screen.getByTestId('skeleton');
+      expect(skeleton).toHaveAttribute('data-state', 'shimmer');
+    });
+
+    it('supports static placeholder without shimmer', () => {
+      render(<Skeleton data-testid='skeleton' shimmer={false} />);
+      const skeleton = screen.getByTestId('skeleton');
+      expect(skeleton).toHaveAttribute('data-state', 'static');
+      expect(skeleton.className.split(/\s+/)).not.toContain('skeleton');
+      expect(skeleton.className).toContain('bg-(--color-skeleton-base)');
+    });
+
     it('is hidden from screen readers', () => {
       render(<Skeleton data-testid='skeleton' />);
       const skeleton = screen.getByTestId('skeleton');
@@ -149,10 +163,11 @@ describe('LoadingSkeleton', () => {
       expect(container).toBeInTheDocument();
     });
 
-    it('container is hidden from screen readers', () => {
+    it('container exposes busy status for assistive tech', () => {
       render(<LoadingSkeleton lines={3} />);
       const container = document.querySelector('.space-y-2');
-      expect(container).toHaveAttribute('aria-hidden', 'true');
+      expect(container).toHaveAttribute('aria-busy', 'true');
+      expect(container).toHaveAttribute('role', 'status');
     });
   });
 

--- a/packages/ui/atoms/skeleton.tsx
+++ b/packages/ui/atoms/skeleton.tsx
@@ -12,6 +12,11 @@ export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default 'sm'
    */
   readonly rounded?: RoundedVariant;
+  /**
+   * When true, applies the canonical shimmer animation and loading state attrs.
+   * @default true
+   */
+  readonly shimmer?: boolean;
 }
 
 const roundedClasses: Record<RoundedVariant, string> = {
@@ -42,15 +47,18 @@ const roundedClasses: Record<RoundedVariant, string> = {
 export function Skeleton({
   className,
   rounded = 'sm',
+  shimmer = true,
   ...props
 }: SkeletonProps) {
   return (
     <div
       className={cn(
-        'skeleton motion-reduce:animate-none',
+        shimmer && 'skeleton motion-reduce:animate-none',
+        !shimmer && 'bg-(--color-skeleton-base) motion-reduce:animate-none',
         roundedClasses[rounded],
         className
       )}
+      data-state={shimmer ? 'shimmer' : 'static'}
       aria-hidden='true'
       {...props}
     />
@@ -112,12 +120,19 @@ export function LoadingSkeleton({
 
   if (lines === 1) {
     return (
-      <Skeleton className={cn(height, width, className)} rounded={rounded} />
+      <div role='status' aria-busy='true' aria-live='polite' className='w-full'>
+        <Skeleton className={cn(height, width, className)} rounded={rounded} />
+      </div>
     );
   }
 
   return (
-    <div className='space-y-2' aria-hidden='true'>
+    <div
+      className='space-y-2'
+      role='status'
+      aria-busy='true'
+      aria-live='polite'
+    >
       {lineKeys.map((key, index) => (
         <Skeleton
           key={key}

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -53,6 +53,7 @@ export { Button, buttonVariants } from './atoms/button';
 // Card
 export type {
   CardContentProps,
+  CardContentState,
   CardDescriptionProps,
   CardFooterProps,
   CardHeaderProps,
@@ -160,6 +161,9 @@ export {
   FormMessage,
   useFormField,
 } from './atoms/form';
+// Inline offline notice
+export type { InlineOfflineNoticeProps } from './atoms/inline-offline';
+export { InlineOfflineNotice } from './atoms/inline-offline';
 // Input
 export type { InputProps } from './atoms/input';
 export { Input, inputVariants } from './atoms/input';
@@ -172,6 +176,9 @@ export { Kbd } from './atoms/kbd';
 // Label
 export type { LabelProps } from './atoms/label';
 export { Label, labelVariants } from './atoms/label';
+// Link
+export type { LinkProps } from './atoms/link';
+export { Link, linkVariants } from './atoms/link';
 // Popover
 export {
   Popover,


### PR DESCRIPTION
## Summary

Turns `docs/design-system/state-matrix.md` from a state name list into a full spec with canonical **token**, **CSS selector**, **Storybook story**, and **primitive** for every documented state.

Implements the eight previously missing cross-cutting states on UI primitives:

| State | Primitive | Story |
| --- | --- | --- |
| Visited | `Link` | `shadcn/Link/Visited` |
| Link styling | `Link` | `shadcn/Link/Default` |
| Disabled visual | `Button` | `shadcn/Button/DisabledVisual` |
| Loading shimmer | `Skeleton` | `shadcn/Skeleton/LoadingShimmer` |
| Partial data | `Card` | `UI/Atoms/Card/PartialData` |
| Permission restricted | `Badge` | `shadcn/Badge/PermissionRestricted` |
| Long content | `CardTitle` | `UI/Atoms/Card/LongContent` |
| Inline offline | `InlineOfflineNotice` | `shadcn/InlineOffline/Default` |

Adds cross-cutting state tokens to `apps/web/styles/design-system.css`.

## Test plan

- [x] `pnpm --filter @jovie/ui typecheck`
- [x] `pnpm --filter @jovie/ui test` (828 passed)
- [x] `pnpm --filter @jovie/ui lint`
- [x] Pre-push web typecheck + biome

Closes JOV-3575