### PR TITLE
fix(ui): collapse approval status to inline Details control (JOV-3678)

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
@@ -1753,8 +1754,9 @@ function ApprovalStatusEditor({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
+        <Button
           type='button'
+          variant='ghost'
           disabled={isDisabled}
           aria-label='Approval Status'
           data-testid={`library-approval-status-select-${asset.id}`}
@@ -1769,7 +1771,7 @@ function ApprovalStatusEditor({
             className='h-3 w-3 shrink-0 opacity-70'
             aria-hidden='true'
           />
-        </button>
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align='start'

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -1,6 +1,11 @@
 'use client';
 
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@jovie/ui';
+import {
   type ColumnDef,
   createColumnHelper,
   type RowSelectionState,
@@ -30,7 +35,6 @@ import {
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import {
-  type ChangeEvent,
   type CSSProperties,
   cloneElement,
   createContext,
@@ -56,6 +60,10 @@ import {
   DrawerSection,
   DrawerSurfaceCard,
 } from '@/components/molecules/drawer';
+import {
+  TOOLBAR_MENU_CONTENT_CLASS,
+  ToolbarMenuChoiceItem,
+} from '@/components/molecules/menus/ToolbarMenuPrimitives';
 import { PageShell } from '@/components/organisms/PageShell';
 import { useTrackAudioPlayer } from '@/components/organisms/release-sidebar/useTrackAudioPlayer';
 import {
@@ -1709,20 +1717,13 @@ function ApprovalStatusEditor({
 }) {
   const [saving, setSaving] = useState(false);
 
-  async function handleChange(event: ChangeEvent<HTMLSelectElement>) {
-    const nextStatus = event.target.value;
-    if (
-      !profileId ||
-      !LIBRARY_APPROVAL_STATUSES.includes(nextStatus as LibraryApprovalStatus)
-    ) {
+  async function handleSelect(nextStatus: LibraryApprovalStatus) {
+    if (!profileId || nextStatus === asset.approvalStatus) {
       return;
     }
 
-    const approvalStatus = nextStatus as LibraryApprovalStatus;
-    if (approvalStatus === asset.approvalStatus) return;
-
     setSaving(true);
-    onStatusChange(asset.id, approvalStatus);
+    onStatusChange(asset.id, nextStatus);
 
     try {
       const response = await fetch('/api/library/approval-status', {
@@ -1732,7 +1733,7 @@ function ApprovalStatusEditor({
           profileId,
           assetId: asset.id,
           itemKind: getLibraryItemKind(asset),
-          approvalStatus,
+          approvalStatus: nextStatus,
         }),
       });
 
@@ -1747,35 +1748,57 @@ function ApprovalStatusEditor({
     }
   }
 
-  // The "Approval" DrawerSection already labels this control, so the select
-  // stands on its own (no stacked label, no nested card) — click-to-edit with
-  // an a11y label (issue #12317).
-  const selectId = useId();
+  const isDisabled = disabled || saving || !profileId;
+
   return (
-    <div>
-      <label htmlFor={selectId} className='sr-only'>
-        Approval Status
-      </label>
-      <select
-        id={selectId}
-        value={asset.approvalStatus}
-        onChange={event => {
-          void handleChange(event);
-        }}
-        disabled={disabled || saving || !profileId}
-        data-testid={`library-approval-status-select-${asset.id}`}
-        className={cn(
-          'system-b-library-action system-b-library-action--standard h-8 w-full border border-subtle px-2',
-          LIBRARY_BUTTON_FOCUS_CLASS
-        )}
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type='button'
+          disabled={isDisabled}
+          aria-label='Approval Status'
+          data-testid={`library-approval-status-select-${asset.id}`}
+          className={cn(
+            'system-b-library-status-pill inline-flex h-6 items-center gap-1 border px-2',
+            libraryApprovalStatusClasses(asset.approvalStatus),
+            LIBRARY_BUTTON_FOCUS_CLASS
+          )}
+        >
+          <span>{formatLibraryApprovalStatus(asset.approvalStatus)}</span>
+          <ChevronDown
+            className='h-3 w-3 shrink-0 opacity-70'
+            aria-hidden='true'
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align='start'
+        sideOffset={4}
+        data-menu-surface='toolbar'
+        className={TOOLBAR_MENU_CONTENT_CLASS}
       >
         {LIBRARY_APPROVAL_STATUSES.map(status => (
-          <option key={status} value={status}>
-            {formatLibraryApprovalStatus(status)}
-          </option>
+          <ToolbarMenuChoiceItem
+            key={status}
+            active={status === asset.approvalStatus}
+            leadingVisual={
+              <span
+                aria-hidden='true'
+                className={cn(
+                  'h-2 w-2 shrink-0 rounded-full',
+                  libraryApprovalStatusDotClasses(status)
+                )}
+              />
+            }
+            label={formatLibraryApprovalStatus(status)}
+            onSelect={() => {
+              void handleSelect(status);
+            }}
+            disabled={isDisabled || status === asset.approvalStatus}
+          />
         ))}
-      </select>
-    </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -1961,15 +1984,6 @@ function AssetDrawer({
 
             <div className='flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain lg:px-0 lg:pt-0'>
               <div className='space-y-2.5'>
-                <DrawerSection surface='card' title='Approval'>
-                  <ApprovalStatusEditor
-                    asset={current}
-                    profileId={profileId}
-                    disabled={!open}
-                    onStatusChange={onApprovalStatusChange}
-                  />
-                </DrawerSection>
-
                 {isMerch ? (
                   <DrawerSection surface='card' title='Merch'>
                     <p className='system-b-library-drawer-panel-copy leading-5 text-secondary-token'>
@@ -2025,6 +2039,17 @@ function AssetDrawer({
 
                 <DrawerSection surface='card' title='Details'>
                   <dl>
+                    <MetadataRow
+                      label='Approval Status'
+                      value={
+                        <ApprovalStatusEditor
+                          asset={current}
+                          profileId={profileId}
+                          disabled={!open}
+                          onStatusChange={onApprovalStatusChange}
+                        />
+                      }
+                    />
                     <MetadataRow
                       label={isMerch ? 'Updated' : 'Release Date'}
                       value={formatLibraryReleaseDate(current.releaseDate)}

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -381,16 +381,16 @@ describe('LibrarySurface', () => {
     });
   });
 
-  it('keeps the approval status select labelled after the inline refactor', () => {
-    // The visible label became sr-only (#12317 subtraction); guard a11y wiring.
+  it('keeps the approval status inline control labelled after the details refactor', () => {
     renderLibrary([buildAsset({ approvalStatus: 'draft' })]);
 
     fireEvent.click(screen.getByTestId('library-release-row-release-1'));
 
-    const select = screen.getByTestId(
+    const trigger = screen.getByTestId(
       'library-approval-status-select-release-1'
     );
-    expect(select).toHaveAccessibleName('Approval Status');
+    expect(trigger).toHaveAccessibleName('Approval Status');
+    expect(trigger.tagName).toBe('BUTTON');
   });
 
   it('renders release assets with grid cards and a read-only detail drawer', () => {
@@ -421,11 +421,11 @@ describe('LibrarySurface', () => {
       'href',
       'https://open.spotify.com/album/take-me-over'
     );
-    // Approval editor is a bare, accessible select (no stacked label / nested
-    // card) — labeled only by its aria-label now that the section heading owns
-    // the visible title (issue #12317).
+    // Approval status is one inline metadata control in Details — no nested
+    // Approval card, no native select (JOV-3678).
+    expect(screen.getByText('Approval Status')).toBeInTheDocument();
     expect(
-      screen.getByRole('combobox', { name: 'Approval Status' })
+      screen.getByRole('button', { name: 'Approval Status' })
     ).toBeInTheDocument();
     const drawer = within(screen.getByTestId('library-asset-drawer'));
     expect(

--- a/apps/web/tests/unit/library/library-system-b-compliance.test.ts
+++ b/apps/web/tests/unit/library/library-system-b-compliance.test.ts
@@ -62,4 +62,12 @@ describe('library right-rail System B structural compliance', () => {
       /:where\(\.system-b-library-action\),\s*:where\(\.system-b-library-icon-button\)\s*\{\s*border-radius: var\(--radius-full\);/
     );
   });
+
+  it('edits approval status inline in Details without a native select', () => {
+    expect(surface).toContain("label='Approval Status'");
+    expect(surface).toContain('ApprovalStatusEditor');
+    expect(surface).not.toMatch(/<DrawerSection[^>]*title='Approval'/);
+    expect(surface).not.toMatch(/<select[^>]*library-approval-status-select/);
+    expect(surface).toContain('TOOLBAR_MENU_CONTENT_CLASS');
+  });
 });


### PR DESCRIPTION
## Summary

Collapses the library asset drawer approval status from a 3-layer nested structure (Approval card → inner surface → native `<select>`) into a single inline control in the **Details** metadata panel.

- Removed the standalone **Approval** `DrawerSection` card
- Added **Approval Status** as the first row in Details
- Replaced native select with a System B status pill trigger + toolbar menu (`ToolbarMenuChoiceItem`)
- Values unchanged: Draft / Needs Review / Approved / Archived

Parent: JOV-3675

## Test plan

- [x] `pnpm --filter @jovie/web run typecheck`
- [x] Biome check on changed files
- [x] `vitest run tests/unit/library/LibrarySurface.test.tsx`
- [x] `vitest run tests/unit/library/library-system-b-compliance.test.ts`
- [x] `vitest run tests/unit/library/approval-status.test.ts`
- [ ] Manual: open Library → inspect asset → confirm Approval Status is inline in Details, menu opens on click, status persists