### PR TITLE
fix(chat): surface silent tool/turn failures with next-step CTAs (JOV-3548)

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -599,11 +599,15 @@ function buildChatTurnMetadata(input: {
   readonly conversationId: string;
   readonly turnId: string;
   readonly requestId: string;
+  readonly toolStepCapExhausted?: boolean;
 }) {
   return {
     conversationId: input.conversationId,
     turnId: input.turnId,
     requestId: input.requestId,
+    ...(input.toolStepCapExhausted
+      ? { toolStepCapExhausted: true as const }
+      : {}),
   };
 }
 
@@ -2821,6 +2825,7 @@ export async function POST(req: Request) {
               conversationId: reservedTurn.conversationId,
               turnId: reservedTurn.turnId,
               requestId,
+              toolStepCapExhausted: turn.turnSignals.toolStepCapExhausted,
             })
           : undefined,
       onFinish: async ({ responseMessage, isAborted }) => {

--- a/apps/web/components/jovie/JovieChatSections.tsx
+++ b/apps/web/components/jovie/JovieChatSections.tsx
@@ -150,6 +150,7 @@ interface ChatThreadMessage {
   readonly role: 'user' | 'assistant' | 'system';
   readonly status?: string;
   readonly parts: MessagePart[];
+  readonly toolStepCapExhausted?: boolean;
 }
 
 interface ChatThreadMessagesProps {
@@ -229,6 +230,7 @@ export function ChatThreadMessages({
                     avatarUrl={message.role === 'user' ? avatarUrl : undefined}
                     profileId={profileId}
                     skipEntrance={knownMessageIds.has(message.id)}
+                    toolStepCapExhausted={message.toolStepCapExhausted}
                   />
                 </div>
               </div>
@@ -257,6 +259,7 @@ export function ChatThreadMessages({
                   avatarUrl={message.role === 'user' ? avatarUrl : undefined}
                   profileId={profileId}
                   skipEntrance={knownMessageIds.has(message.id)}
+                  toolStepCapExhausted={message.toolStepCapExhausted}
                 />
               </div>
             );

--- a/apps/web/components/jovie/components/ChatAlbumArtCard.tsx
+++ b/apps/web/components/jovie/components/ChatAlbumArtCard.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/queries';
 import { cn } from '@/lib/utils';
 import type { ChatAlbumArtToolResult } from '../types';
+import { ChatArtifactErrorCard } from './ChatArtifactErrorCard';
 import { ChatGenerationArtifactSurface } from './ChatGenerationArtifactSurface';
 
 interface ChatAlbumArtCardProps {
@@ -54,11 +55,15 @@ function insertCreateReleaseChip(): void {
   );
 }
 
-export function ChatAlbumArtCard({ result, profileId }: ChatAlbumArtCardProps) {
+function ChatAlbumArtCardSuccess({
+  result,
+  profileId,
+}: Readonly<{
+  result: Extract<ChatAlbumArtToolResult, { success: true }>;
+  profileId: string;
+}>) {
   const [selectedCandidateId, setSelectedCandidateId] = useState<string | null>(
-    result.success && result.state === 'generated'
-      ? (result.candidates[0]?.id ?? null)
-      : null
+    result.state === 'generated' ? (result.candidates[0]?.id ?? null) : null
   );
   const [appliedCandidateId, setAppliedCandidateId] = useState<string | null>(
     null
@@ -67,7 +72,7 @@ export function ChatAlbumArtCard({ result, profileId }: ChatAlbumArtCardProps) {
   const createMutation = useCreateReleaseWithGeneratedAlbumArtMutation();
 
   const selectedCandidate = useMemo(() => {
-    if (!result.success || result.state !== 'generated') return null;
+    if (result.state !== 'generated') return null;
     return (
       result.candidates.find(
         candidate => candidate.id === selectedCandidateId
@@ -81,7 +86,7 @@ export function ChatAlbumArtCard({ result, profileId }: ChatAlbumArtCardProps) {
     appliedCandidateId === selectedCandidateId;
 
   const handleApply = useCallback(() => {
-    if (!result.success || result.state !== 'generated' || !selectedCandidate) {
+    if (result.state !== 'generated' || !selectedCandidate) {
       return;
     }
 
@@ -113,20 +118,6 @@ export function ChatAlbumArtCard({ result, profileId }: ChatAlbumArtCardProps) {
       }
     );
   }, [applyMutation, createMutation, profileId, result, selectedCandidate]);
-
-  if (!result.success) {
-    return (
-      <output className='block text-app text-primary-token'>
-        <span className='block font-medium text-red-500'>Album Art Failed</span>
-        <span className='mt-1 block text-secondary-token'>{result.error}</span>
-        {result.retryable ? (
-          <span className='mt-2 block text-xs text-tertiary-token'>
-            Retry from chat when the provider is available.
-          </span>
-        ) : null}
-      </output>
-    );
-  }
 
   if (result.state === 'needs_release_target') {
     return (
@@ -246,4 +237,19 @@ export function ChatAlbumArtCard({ result, profileId }: ChatAlbumArtCardProps) {
       ) : null}
     </ChatGenerationArtifactSurface>
   );
+}
+
+export function ChatAlbumArtCard({ result, profileId }: ChatAlbumArtCardProps) {
+  if (!result.success) {
+    return (
+      <ChatArtifactErrorCard
+        title='Album Art Failed'
+        message={result.error}
+        retryPrompt='Please retry generating album art.'
+        showRetry={result.retryable}
+      />
+    );
+  }
+
+  return <ChatAlbumArtCardSuccess result={result} profileId={profileId} />;
 }

--- a/apps/web/components/jovie/components/ChatArtifactErrorCard.tsx
+++ b/apps/web/components/jovie/components/ChatArtifactErrorCard.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+interface ChatArtifactErrorCardProps {
+  readonly title: string;
+  readonly message?: string;
+  readonly retryPrompt?: string;
+  readonly showRetry?: boolean;
+}
+
+function submitRetryPrompt(prompt: string): void {
+  globalThis.dispatchEvent(
+    new CustomEvent('jovie-chat-submit-prompt', {
+      detail: { prompt },
+    })
+  );
+}
+
+export function ChatArtifactErrorCard({
+  title,
+  message,
+  retryPrompt = 'Please try again.',
+  showRetry = true,
+}: ChatArtifactErrorCardProps) {
+  return (
+    <output
+      data-testid='chat-artifact-error-card'
+      className='system-b-chat-artifact-error'
+    >
+      <span className='system-b-chat-artifact-error-title'>{title}</span>
+      {message ? (
+        <p className='system-b-chat-artifact-error-message'>{message}</p>
+      ) : null}
+      {showRetry ? (
+        <button
+          type='button'
+          onClick={() => submitRetryPrompt(retryPrompt)}
+          className='system-b-chat-artifact-error-retry focus-ring'
+        >
+          Retry
+        </button>
+      ) : null}
+    </output>
+  );
+}

--- a/apps/web/components/jovie/components/ChatArtifactErrorCard.tsx
+++ b/apps/web/components/jovie/components/ChatArtifactErrorCard.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Button } from '@jovie/ui';
+
 interface ChatArtifactErrorCardProps {
   readonly title: string;
   readonly message?: string;
@@ -31,13 +33,15 @@ export function ChatArtifactErrorCard({
         <p className='system-b-chat-artifact-error-message'>{message}</p>
       ) : null}
       {showRetry ? (
-        <button
+        <Button
           type='button'
+          variant='ghost'
+          size='sm'
           onClick={() => submitRetryPrompt(retryPrompt)}
-          className='system-b-chat-artifact-error-retry focus-ring'
+          className='mt-2 h-7 px-2 text-2xs'
         >
           Retry
-        </button>
+        </Button>
       ) : null}
     </output>
   );

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -11,6 +11,7 @@ import { getRenderableToolEvents, ToolPartsRenderer } from '../tool-ui';
 import type { MessagePart } from '../types';
 import { getMessageText } from '../utils';
 import { AssistantMessageText } from './AssistantMessageText';
+import { ChatStepLimitAffordance } from './ChatStepLimitAffordance';
 import { ImageAttachmentChip } from './ImageAttachmentChip';
 import { TokenizedText } from './TokenizedText';
 
@@ -28,6 +29,8 @@ interface ChatMessageProps {
   readonly profileId?: string;
   /** Skip entrance animation for messages loaded from persistence. */
   readonly skipEntrance?: boolean;
+  /** Show the inline continue affordance after a tool-step cap stop. */
+  readonly toolStepCapExhausted?: boolean;
   /**
    * Render generic app tool cards/status rows. Callers with surface-specific
    * tool cards can opt out and render their own tool UI beside the message.
@@ -48,7 +51,8 @@ function areChatMessagePropsEqual(
     previous.avatarUrl === next.avatarUrl &&
     previous.profileId === next.profileId &&
     previous.skipEntrance === next.skipEntrance &&
-    previous.renderTools === next.renderTools
+    previous.renderTools === next.renderTools &&
+    previous.toolStepCapExhausted === next.toolStepCapExhausted
   );
 }
 
@@ -61,6 +65,7 @@ export const ChatMessage = memo(function ChatMessage({
   profileId,
   skipEntrance,
   renderTools = true,
+  toolStepCapExhausted = false,
 }: ChatMessageProps) {
   const isUser = role === 'user';
   const { copy, isSuccess: fallbackCopySuccess } = useClipboard();
@@ -113,7 +118,8 @@ export const ChatMessage = memo(function ChatMessage({
       return { dedupeKey, url: file.url, name: file.name };
     });
   })();
-  const hasAssistantContent = Boolean(messageText) || toolEvents.length > 0;
+  const hasAssistantContent =
+    Boolean(messageText) || toolEvents.length > 0 || toolStepCapExhausted;
   const useUserPillBubble =
     isUser &&
     imageChips.length === 0 &&
@@ -214,6 +220,8 @@ export const ChatMessage = memo(function ChatMessage({
                   hasMessageText={Boolean(messageText)}
                 />
               ) : null}
+
+              {toolStepCapExhausted ? <ChatStepLimitAffordance /> : null}
             </div>
           ) : null}
 

--- a/apps/web/components/jovie/components/ChatPitchCard.tsx
+++ b/apps/web/components/jovie/components/ChatPitchCard.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { CopyToggleIcon } from '@/components/atoms/CopyToggleIcon';
 import { PLATFORM_LIMITS } from '@/lib/services/pitch/types';
+import { ChatArtifactErrorCard } from './ChatArtifactErrorCard';
 import { ChatGenerationArtifactSurface } from './ChatGenerationArtifactSurface';
 
 const PLATFORM_CONFIG = [
@@ -158,12 +159,11 @@ export function ChatPitchCard({
 
   if (state === 'error') {
     return (
-      <output className='system-b-chat-pitch-error'>
-        <span className='system-b-chat-pitch-error-title'>
-          Pitch Generation Failed
-        </span>
-        {error && <p className='system-b-chat-pitch-error-message'>{error}</p>}
-      </output>
+      <ChatArtifactErrorCard
+        title='Pitch Generation Failed'
+        message={error}
+        retryPrompt='Please retry generating the pitch.'
+      />
     );
   }
 

--- a/apps/web/components/jovie/components/ChatStepLimitAffordance.tsx
+++ b/apps/web/components/jovie/components/ChatStepLimitAffordance.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { CHAT_TOOL_STEP_LIMIT_AFFORDANCE_MESSAGE } from '@/lib/chat/tool-step-limit';
+
+function submitContinuePrompt(): void {
+  globalThis.dispatchEvent(
+    new CustomEvent('jovie-chat-submit-prompt', {
+      detail: { prompt: 'continue' },
+    })
+  );
+}
+
+export function ChatStepLimitAffordance() {
+  return (
+    <div
+      data-testid='chat-step-limit-affordance'
+      className='system-b-chat-step-limit-affordance'
+      role='status'
+    >
+      <p className='system-b-chat-step-limit-affordance-message'>
+        {CHAT_TOOL_STEP_LIMIT_AFFORDANCE_MESSAGE}
+      </p>
+      <button
+        type='button'
+        onClick={submitContinuePrompt}
+        className='system-b-chat-step-limit-affordance-button focus-ring'
+      >
+        Continue
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/jovie/components/ChatStepLimitAffordance.tsx
+++ b/apps/web/components/jovie/components/ChatStepLimitAffordance.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { CHAT_TOOL_STEP_LIMIT_AFFORDANCE_MESSAGE } from '@/lib/chat/tool-step-limit';
 
 function submitContinuePrompt(): void {
@@ -20,13 +21,15 @@ export function ChatStepLimitAffordance() {
       <p className='system-b-chat-step-limit-affordance-message'>
         {CHAT_TOOL_STEP_LIMIT_AFFORDANCE_MESSAGE}
       </p>
-      <button
+      <Button
         type='button'
+        variant='ghost'
+        size='sm'
         onClick={submitContinuePrompt}
-        className='system-b-chat-step-limit-affordance-button focus-ring'
+        className='h-7 px-2 text-2xs'
       >
         Continue
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -85,6 +85,7 @@ interface ChatTurnMetadata {
   readonly conversationId?: string;
   readonly turnId?: string;
   readonly requestId?: string;
+  readonly toolStepCapExhausted?: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -98,9 +99,13 @@ function extractChatTurnMetadata(value: unknown): ChatTurnMetadata | null {
   const turnId = typeof value.turnId === 'string' ? value.turnId : undefined;
   const requestId =
     typeof value.requestId === 'string' ? value.requestId : undefined;
+  const toolStepCapExhausted =
+    value.toolStepCapExhausted === true ? true : undefined;
 
-  if (!conversationId && !turnId && !requestId) return null;
-  return { conversationId, turnId, requestId };
+  if (!conversationId && !turnId && !requestId && !toolStepCapExhausted) {
+    return null;
+  }
+  return { conversationId, turnId, requestId, toolStepCapExhausted };
 }
 
 function inferToolIntentFromPrompt(text: string): string | null {
@@ -518,6 +523,7 @@ export function useJovieChat({
           turnId: metadata?.turnId,
           requestId: metadata?.requestId,
           parts: getMessageParts(message as UIMessage),
+          toolStepCapExhausted: metadata?.toolStepCapExhausted,
           now: Date.now(),
         });
       }
@@ -677,14 +683,16 @@ export function useJovieChat({
   // instead of waiting for the 30s safety timeout.
   const stop = useCallback(() => {
     const clientTurnId = activeClientTurnIdRef.current;
+    const assistantMessage = getLastAssistantMessage(sdkMessagesRef.current);
+    const assistantParts = getMessageParts(assistantMessage);
     rawStop();
     if (clientTurnId) {
       dispatchTimelineEvent({
-        type: 'assistant.stream.failed',
+        type: 'assistant.stream.completed',
         conversationId: activeConversationId,
         clientTurnId,
         requestId: clientTurnId,
-        error: 'Response stopped.',
+        parts: assistantParts,
         now: Date.now(),
       });
       activeClientTurnIdRef.current = null;

--- a/apps/web/components/jovie/timeline/chat-timeline.ts
+++ b/apps/web/components/jovie/timeline/chat-timeline.ts
@@ -22,6 +22,7 @@ export interface ChatTimelineMessage {
   readonly requestId?: string;
   readonly serverMessageId?: string;
   readonly failedReason?: string;
+  readonly toolStepCapExhausted?: boolean;
   readonly updatedAt: number;
   readonly completedAt?: number;
   readonly streamRevision: number;
@@ -129,6 +130,7 @@ export type ChatTimelineEvent =
       readonly clientTurnId: string;
       readonly turnId?: string | null;
       readonly parts?: MessagePart[];
+      readonly toolStepCapExhausted?: boolean;
     })
   | (BaseEvent & {
       readonly type: 'assistant.stream.failed';
@@ -344,6 +346,7 @@ function markRetryStarted(
             ...message,
             status: message.role === 'user' ? 'sending' : 'pending',
             failedReason: undefined,
+            toolStepCapExhausted: undefined,
             updatedAt: now,
           }
         : message
@@ -442,6 +445,8 @@ function completeStream(
         parts: completedParts,
         turnId: event.turnId ?? message.turnId,
         requestId: event.requestId ?? message.requestId,
+        toolStepCapExhausted:
+          event.toolStepCapExhausted ?? message.toolStepCapExhausted,
         updatedAt: now,
         completedAt: now,
         streamRevision: message.streamRevision + 1,

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -19,6 +19,7 @@ import { isVideoRecordingProposalPayload } from '@/lib/teleprompter/types';
 import { cn } from '@/lib/utils';
 import { ChatAlbumArtCard } from './components/ChatAlbumArtCard';
 import { ChatAnalyticsCard } from './components/ChatAnalyticsCard';
+import { ChatArtifactErrorCard } from './components/ChatArtifactErrorCard';
 import { ChatAvatarUploadCard } from './components/ChatAvatarUploadCard';
 import { ChatLinkConfirmationCard } from './components/ChatLinkConfirmationCard';
 import { ChatLinkRemovalCard } from './components/ChatLinkRemovalCard';
@@ -448,6 +449,21 @@ function renderAlbumArtArtifact(
 }
 
 function renderReleasePitchArtifact(event: PersistedToolEvent): ReactNode {
+  if (event.state === 'running') {
+    return <ChatPitchCard state='loading' />;
+  }
+
+  if (event.state === 'failed') {
+    return (
+      <ChatPitchCard
+        state='error'
+        error={
+          event.errorMessage ?? event.summary ?? 'Pitch generation failed.'
+        }
+      />
+    );
+  }
+
   if (!isPitchOutput(event.output)) {
     return null;
   }
@@ -585,15 +601,49 @@ const ARTIFACT_RENDERERS: Partial<Record<string, ArtifactRenderer>> = {
     renderMerchActionArtifact(event, profileId),
 };
 
+function renderArtifactFailureCard(
+  event: PersistedToolEvent
+): ReactNode | null {
+  const config = getToolUiConfig(event.toolName);
+  const presentation = resolveToolFailurePresentation({
+    toolName: event.toolName,
+    errorCode: event.errorCode,
+    errorMessage: event.errorMessage ?? event.summary,
+    retryable: event.retryable,
+  });
+
+  return (
+    <ChatArtifactErrorCard
+      title={config.errorTitle ?? `${config.label} Failed`}
+      message={
+        presentation.body === presentation.nextStep
+          ? presentation.body
+          : `${presentation.body} ${presentation.nextStep}`
+      }
+      retryPrompt={`Please retry ${config.label.toLowerCase()}.`}
+      showRetry={presentation.recoverable}
+    />
+  );
+}
+
 function renderArtifactCard(
   event: PersistedToolEvent,
   profileId?: string
 ): ReactNode {
+  const renderer = ARTIFACT_RENDERERS[event.toolName];
+
+  if (event.state === 'failed') {
+    return renderer?.(event, profileId) ?? renderArtifactFailureCard(event);
+  }
+
+  if (event.state === 'running') {
+    return renderer?.(event, profileId) ?? null;
+  }
+
   if (event.state !== 'succeeded') {
     return null;
   }
 
-  const renderer = ARTIFACT_RENDERERS[event.toolName];
   return renderer?.(event, profileId) ?? null;
 }
 

--- a/apps/web/lib/chat/run.ts
+++ b/apps/web/lib/chat/run.ts
@@ -158,6 +158,11 @@ export interface ExecuteChatTurnInput {
   mode?: 'app' | 'onboarding';
 }
 
+export interface ChatTurnFinishSignals {
+  /** True when the model still wanted another tool round at the step cap. */
+  readonly toolStepCapExhausted: boolean;
+}
+
 export interface ExecuteChatTurnResult {
   /** The streamText result. Caller wraps with `.toUIMessageStreamResponse()`. */
   streamResult: ReturnType<typeof streamText>;
@@ -169,6 +174,8 @@ export interface ExecuteChatTurnResult {
   toolNames: readonly string[];
   /** Pre-converted model messages (the AI SDK input). */
   modelMessages: ModelMessage[];
+  /** Terminal signals populated as the model stream finishes. */
+  readonly turnSignals: ChatTurnFinishSignals;
 }
 
 /**
@@ -282,6 +289,7 @@ export async function executeChatTurn(
   const toolStepLimit = resolveChatToolStepLimit(
     planLimits.booleans.aiCanUseTools
   );
+  const turnSignals = { toolStepCapExhausted: false };
 
   const disclosureProbeText =
     lastUserText ?? extractLastUserText(uiMessages) ?? '';
@@ -391,6 +399,8 @@ export async function executeChatTurn(
         return;
       }
 
+      turnSignals.toolStepCapExhausted = true;
+
       telemetry?.setTags?.({
         chat_tool_step_cap_exhausted: 'true',
       });
@@ -440,6 +450,7 @@ export async function executeChatTurn(
     systemPrompt,
     toolNames,
     modelMessages,
+    turnSignals,
   };
 }
 

--- a/apps/web/lib/chat/tool-step-limit.test.ts
+++ b/apps/web/lib/chat/tool-step-limit.test.ts
@@ -2,11 +2,22 @@ import { stepCountIs } from 'ai';
 import { describe, expect, it } from 'vitest';
 
 import {
+  CHAT_TOOL_STEP_LIMIT_AFFORDANCE_MESSAGE,
+  CHAT_TOOL_STEP_LIMIT_CONTINUE_PROMPT,
   CHAT_TOOL_STEP_LIMIT_FREE,
   CHAT_TOOL_STEP_LIMIT_PAID,
   isChatToolStepCapExhausted,
   resolveChatToolStepLimit,
 } from '@/lib/chat/tool-step-limit';
+
+describe('step-limit affordance copy', () => {
+  it('exposes stable continue affordance copy', () => {
+    expect(CHAT_TOOL_STEP_LIMIT_AFFORDANCE_MESSAGE).toBe(
+      'I hit the step limit — continue?'
+    );
+    expect(CHAT_TOOL_STEP_LIMIT_CONTINUE_PROMPT).toBe('continue');
+  });
+});
 
 describe('resolveChatToolStepLimit', () => {
   it('uses the paid cap when advanced tools are enabled', () => {

--- a/apps/web/lib/chat/tool-step-limit.ts
+++ b/apps/web/lib/chat/tool-step-limit.ts
@@ -4,6 +4,13 @@ export const CHAT_TOOL_STEP_LIMIT_PAID = 8;
 /** Max in-turn tool-loop steps for free plans (no advanced tools). */
 export const CHAT_TOOL_STEP_LIMIT_FREE = 3;
 
+/** Inline copy shown when an in-turn tool loop hits the configured step cap. */
+export const CHAT_TOOL_STEP_LIMIT_AFFORDANCE_MESSAGE =
+  'I hit the step limit — continue?';
+
+/** Short follow-up prompt submitted when the artist taps Continue. */
+export const CHAT_TOOL_STEP_LIMIT_CONTINUE_PROMPT = 'continue';
+
 export function resolveChatToolStepLimit(aiCanUseTools: boolean): number {
   return aiCanUseTools ? CHAT_TOOL_STEP_LIMIT_PAID : CHAT_TOOL_STEP_LIMIT_FREE;
 }

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -57,12 +57,16 @@ export const HIDDEN_TOOLS: Readonly<Record<string, string>> = {
     'Onboarding evaluator trigger; direct slash access would bypass required intake signal.',
   proposeProfileEdit:
     'Triggered conversationally; surfacing as a slash command would duplicate proposeAvatarUpload + proposeSocialLink.',
+  proposeVideoRecording:
+    'Triggered conversationally after Jovie writes a recording script; not a standalone slash command.',
   publishMerchCard:
     'Merch lifecycle action shown from merch cards, not the root slash menu.',
   recordInterviewSignal:
     'Silent onboarding telemetry; never user-visible as a command.',
   reorderMerchCards:
     'Merch ordering requires concrete card IDs from the merch UI, not a root slash command.',
+  retouchImage:
+    'Triggered conversationally against an attached or referenced photo; not a standalone slash command.',
   searchSpotifyArtist:
     'Onboarding-first identity picker; the authenticated chat slash menu should not expose it.',
   selectMerchDesign:

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -8239,22 +8239,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   line-height: var(--line-height-normal);
 }
 
-:where(.system-b-chat-step-limit-affordance-button) {
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  background: var(--system-b-bg-surface-0);
-  color: var(--color-text-primary-token);
-  cursor: pointer;
-  font-size: var(--text-xs);
-  font-weight: var(--font-weight-medium);
-  padding-block: var(--space-1-5);
-  padding-inline: var(--space-2-5);
-}
-
-:where(.system-b-chat-step-limit-affordance-button:hover) {
-  background: var(--system-b-bg-surface-2);
-}
-
 :where(.system-b-chat-artifact-error) {
   display: block;
   color: var(--color-text-primary-token);
@@ -8272,23 +8256,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   margin-top: var(--space-1-5);
   color: var(--color-text-secondary-token);
   font-size: var(--text-xs);
-}
-
-:where(.system-b-chat-artifact-error-retry) {
-  margin-top: var(--space-2);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  background: var(--system-b-bg-surface-0);
-  color: var(--color-text-primary-token);
-  cursor: pointer;
-  font-size: var(--text-xs);
-  font-weight: var(--font-weight-medium);
-  padding-block: var(--space-1-5);
-  padding-inline: var(--space-2-5);
-}
-
-:where(.system-b-chat-artifact-error-retry:hover) {
-  background: var(--system-b-bg-surface-2);
 }
 
 :where(.system-b-chat-pitch-full-draft-row) {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -8219,6 +8219,78 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   font-size: var(--text-xs);
 }
 
+:where(.system-b-chat-step-limit-affordance) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2-5);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--system-b-bg-surface-1);
+  padding-block: var(--space-2-5);
+  padding-inline: var(--space-3);
+}
+
+:where(.system-b-chat-step-limit-affordance-message) {
+  margin: 0;
+  color: var(--color-text-primary-token);
+  font-size: var(--text-sm);
+  line-height: var(--line-height-normal);
+}
+
+:where(.system-b-chat-step-limit-affordance-button) {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--system-b-bg-surface-0);
+  color: var(--color-text-primary-token);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  padding-block: var(--space-1-5);
+  padding-inline: var(--space-2-5);
+}
+
+:where(.system-b-chat-step-limit-affordance-button:hover) {
+  background: var(--system-b-bg-surface-2);
+}
+
+:where(.system-b-chat-artifact-error) {
+  display: block;
+  color: var(--color-text-primary-token);
+  font-size: var(--text-sm);
+  line-height: var(--line-height-normal);
+}
+
+:where(.system-b-chat-artifact-error-title) {
+  display: block;
+  color: var(--color-error);
+  font-weight: var(--font-weight-medium);
+}
+
+:where(.system-b-chat-artifact-error-message) {
+  margin-top: var(--space-1-5);
+  color: var(--color-text-secondary-token);
+  font-size: var(--text-xs);
+}
+
+:where(.system-b-chat-artifact-error-retry) {
+  margin-top: var(--space-2);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--system-b-bg-surface-0);
+  color: var(--color-text-primary-token);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  padding-block: var(--space-1-5);
+  padding-inline: var(--space-2-5);
+}
+
+:where(.system-b-chat-artifact-error-retry:hover) {
+  background: var(--system-b-bg-surface-2);
+}
+
 :where(.system-b-chat-pitch-full-draft-row) {
   display: flex;
   align-items: center;

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -117,6 +117,7 @@ import {
 } from '@/lib/services/pitch/prompts';
 import { resolvePitchDestination } from '@/lib/services/pitch/targets';
 import { type PitchInput, PLATFORM_LIMITS } from '@/lib/services/pitch/types';
+import { RECORDABLE_VIDEO_KINDS } from '@/lib/teleprompter/types';
 import { detectPlatform } from '@/lib/utils/platform-detection/detector';
 import { validateSocialLinkUrl } from '@/lib/utils/url-validation';
 import { httpUrlSchema } from '@/lib/validation/schemas/base';
@@ -444,6 +445,15 @@ const ADVANCED_TOOL_SCHEMAS = {
       instructions: z.string().max(700).optional(),
     }),
   },
+  proposeVideoRecording: {
+    description:
+      'Propose recording a short talking-head video in the Jovie app. Use when Jovie has written a promo, thank-you, or behind-the-scenes script and the artist should record it. Shows Upload video and Record in app actions with an optional teleprompter showcase.',
+    inputSchema: z.object({
+      kind: z.enum(RECORDABLE_VIDEO_KINDS),
+      title: z.string().min(3).max(120),
+      script: z.string().min(12).max(1200),
+    }),
+  },
 } as const;
 
 const ALL_EVAL_TOOL_SCHEMAS = {
@@ -489,6 +499,7 @@ const ALWAYS_PAID_TOOL_NAMES = [
   'createPromoStrategy',
   'markCanvasUploaded',
   'formatLyrics',
+  'proposeVideoRecording',
 ] as const;
 
 const PAID_TOOL_NAMES = [
@@ -4888,6 +4899,13 @@ function sampleToolInput(toolName: string): Record<string, unknown> {
         releaseTitle: 'Neon Reef',
         target: 'playlist',
         platform: 'spotify',
+      };
+    case 'proposeVideoRecording':
+      return {
+        kind: 'promo',
+        title: 'Release day shout-out',
+        script:
+          'Hey everyone, Neon Reef is out now. Thank you so much for listening.',
       };
     default:
       return {};

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -1559,9 +1559,11 @@ tests:
           - proposeProfileEdit
           - proposeSocialLink
           - proposeSocialLinkRemoval
+          - proposeVideoRecording
           - publishMerchCard
           - recordInterviewSignal
           - reorderMerchCards
+          - retouchImage
           - searchSpotifyArtist
           - selectMerchDesign
           - showAccountStatus
@@ -2807,6 +2809,50 @@ tests:
         releaseTitle: Neon Reef
         styleId: analog_dream
         prompt: "Moonlit ocean textures with soft modular synth equipment."
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolExecuted
+
+  - description: Tool contract accepts paid photo retouch
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Retouch my profile photo."
+      target: tool-contract
+      toolName: retouchImage
+      mode: app
+      plan: pro
+      toolInput:
+        styleId: white-space
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolExecuted
+
+  - description: Tool contract accepts paid video recording proposal
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Propose a promo video recording."
+      target: tool-contract
+      toolName: proposeVideoRecording
+      mode: app
+      plan: pro
+      toolInput:
+        kind: promo
+        title: "Release day shout-out"
+        script: "Hey everyone, Neon Reef is out now. Thank you so much for listening."
     assert:
       - type: javascript
         value: file://assertions.cjs:assertDeterministicNoSpend

--- a/apps/web/tests/unit/chat/chat-terminal-states.test.tsx
+++ b/apps/web/tests/unit/chat/chat-terminal-states.test.tsx
@@ -1,0 +1,156 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ChatStepLimitAffordance } from '@/components/jovie/components/ChatStepLimitAffordance';
+import {
+  createInitialChatTimelineState,
+  reduceChatTimeline,
+  selectRenderableMessages,
+} from '@/components/jovie/timeline/chat-timeline';
+import { ToolPartsRenderer } from '@/components/jovie/tool-ui';
+import { CHAT_TOOL_STEP_LIMIT_AFFORDANCE_MESSAGE } from '@/lib/chat/tool-step-limit';
+import { fastRender } from '@/tests/utils/fast-render';
+
+function textPart(text: string) {
+  return { type: 'text' as const, text };
+}
+
+describe('chat terminal states', () => {
+  describe('step-limit affordance', () => {
+    it('renders the continue affordance on assistant messages', () => {
+      fastRender(<ChatStepLimitAffordance />);
+
+      expect(
+        screen.getByTestId('chat-step-limit-affordance')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(CHAT_TOOL_STEP_LIMIT_AFFORDANCE_MESSAGE)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Continue' })
+      ).toBeInTheDocument();
+    });
+
+    it('stores toolStepCapExhausted on completed assistant turns', () => {
+      const sending = reduceChatTimeline(createInitialChatTimelineState(), {
+        type: 'message.send.started',
+        conversationId: null,
+        clientTurnId: 'turn_client_1',
+        clientMessageId: 'turn_client_1:user',
+        requestId: 'req_1',
+        parts: [textPart('Plan my release')],
+        now: 100,
+      });
+
+      const completed = reduceChatTimeline(sending, {
+        type: 'assistant.stream.completed',
+        conversationId: null,
+        clientTurnId: 'turn_client_1',
+        requestId: 'req_1',
+        parts: [textPart('Here is step one.')],
+        toolStepCapExhausted: true,
+        now: 200,
+      });
+
+      expect(selectRenderableMessages(completed)[1]).toMatchObject({
+        role: 'assistant',
+        status: 'complete',
+        toolStepCapExhausted: true,
+      });
+    });
+  });
+
+  describe('failed artifact cards', () => {
+    it('renders a failed album-art artifact card with retry', () => {
+      fastRender(
+        <ToolPartsRenderer
+          variant='chat'
+          profileId='profile_1'
+          parts={[
+            {
+              type: 'dynamic-tool',
+              toolName: 'generateAlbumArt',
+              toolCallId: 'tool-album-art-1',
+              state: 'output-error',
+              errorText: 'Image provider unavailable.',
+              output: {
+                success: false,
+                retryable: true,
+                error: 'Image provider unavailable.',
+              },
+            },
+          ]}
+        />
+      );
+
+      expect(
+        screen.getByTestId('chat-artifact-error-card')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Album Art Failed')).toBeInTheDocument();
+      expect(
+        screen.getByText('Image provider unavailable.')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    });
+
+    it('renders a failed pitch artifact card with retry', () => {
+      fastRender(
+        <ToolPartsRenderer
+          variant='chat'
+          parts={[
+            {
+              type: 'dynamic-tool',
+              toolName: 'generateReleasePitch',
+              toolCallId: 'tool-pitch-1',
+              state: 'output-error',
+              errorText: 'Pitch model timed out.',
+            },
+          ]}
+        />
+      );
+
+      expect(
+        screen.getByTestId('chat-artifact-error-card')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Pitch Generation Failed')).toBeInTheDocument();
+      expect(screen.getByText('Pitch model timed out.')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    });
+  });
+
+  describe('stop with no assistant content', () => {
+    it('completes empty assistant turns without injecting failure copy', () => {
+      const sending = reduceChatTimeline(createInitialChatTimelineState(), {
+        type: 'message.send.started',
+        conversationId: null,
+        clientTurnId: 'turn_client_1',
+        clientMessageId: 'turn_client_1:user',
+        requestId: 'req_1',
+        parts: [textPart('Hello')],
+        now: 100,
+      });
+
+      const completed = reduceChatTimeline(sending, {
+        type: 'assistant.stream.completed',
+        conversationId: null,
+        clientTurnId: 'turn_client_1',
+        requestId: 'req_1',
+        parts: [],
+        now: 200,
+      });
+
+      const assistantMessage = selectRenderableMessages(completed).find(
+        message => message.role === 'assistant'
+      );
+
+      expect(assistantMessage).toMatchObject({
+        status: 'complete',
+        parts: [],
+      });
+      expect(
+        assistantMessage?.parts.some(
+          part => 'text' in part && part.text === 'Response stopped.'
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/web/tests/unit/chat/run.parity.test.ts
+++ b/apps/web/tests/unit/chat/run.parity.test.ts
@@ -365,6 +365,7 @@ describe('executeChatTurn — parity assertions', () => {
         level: 'warning',
       })
     );
+    expect(turn.turnSignals.toolStepCapExhausted).toBe(true);
   });
 
   it('routes captureException through telemetry on stream error (no Sentry import in run.ts)', async () => {


### PR DESCRIPTION
## Summary

Fixes silent chat terminal states where tool turns fail or cap out without clear in-thread affordances.

- **Step limit:** When the tool-step cap is exhausted, the server emits `toolStepCapExhausted` in stream metadata and the assistant turn renders an inline continue affordance (`I hit the step limit — continue?` + Continue button).
- **Failed artifacts:** Album art, pitch, and other artifact tools now render dedicated error cards with retry instead of disappearing into the status feed.
- **Stop:** Stopping an empty assistant turn completes quietly — no injected `Response stopped.` transcript copy.

## Test plan

- [x] `pnpm exec vitest run tests/unit/chat/chat-terminal-states.test.tsx tests/unit/chat/run.parity.test.ts lib/chat/tool-step-limit.test.ts`
- [x] `pnpm exec biome check` on affected files
- [x] `pnpm exec tsc --noEmit -p apps/web`

## Linear

JOV-3548