### PR TITLE
fix(settings): use canonical sidebar nav row helper (JOV-3584)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/SettingsPolished.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsPolished.tsx
@@ -12,11 +12,11 @@ import {
   useState,
 } from 'react';
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
+import { getSidebarNavRowClassName } from '@/components/shell/SidebarNavItem';
 import { APP_ROUTES } from '@/constants/routes';
 import { SettingsErrorState } from '@/features/dashboard/molecules/SettingsErrorState';
 import { AccountSettingsSection } from '@/features/dashboard/organisms/account-settings';
 import { DataPrivacySection } from '@/features/dashboard/organisms/DataPrivacySection';
-
 import { SettingsAdPixelsSection } from '@/features/dashboard/organisms/SettingsAdPixelsSection';
 import { SettingsAnalyticsSection } from '@/features/dashboard/organisms/SettingsAnalyticsSection';
 import { SettingsAudienceSection } from '@/features/dashboard/organisms/SettingsAudienceSection';
@@ -31,7 +31,6 @@ import { SettingsArtistProfileSection } from '@/features/dashboard/organisms/set
 import { publicEnv } from '@/lib/env-public';
 import { useAppFlag } from '@/lib/flags/client';
 import { useBillingStatusQuery } from '@/lib/queries';
-import { cn } from '@/lib/utils';
 import type { Artist } from '@/types/db';
 
 interface SettingsPolishedProps {
@@ -106,33 +105,34 @@ const SettingsSidebar = memo(
                   const href = useRouteLinks
                     ? getFocusedSettingsHref(section.id)
                     : `#${section.id}`;
+                  const rowClassName = getSidebarNavRowClassName({
+                    active: isActive,
+                    className:
+                      'grid-cols-[minmax(0,1fr)] before:hidden after:hidden text-left',
+                  });
+                  const rowContent = (
+                    <span className='min-w-0 truncate text-left justify-self-start'>
+                      {section.title}
+                    </span>
+                  );
+
                   return (
                     <li key={section.id}>
                       {useRouteLinks ? (
                         <Link
                           href={href}
                           aria-current={isActive ? 'page' : undefined}
-                          className={cn(
-                            'flex min-h-7 items-center rounded-full px-2.5 py-1 text-xs tracking-[-0.012em] transition-colors',
-                            isActive
-                              ? 'border border-(--linear-app-frame-seam) bg-surface-0 text-primary-token'
-                              : 'border border-transparent text-secondary-token hover:bg-surface-0 hover:text-primary-token'
-                          )}
+                          className={rowClassName}
                         >
-                          {section.title}
+                          {rowContent}
                         </Link>
                       ) : (
                         <a
                           href={href}
                           aria-current={isActive ? 'page' : undefined}
-                          className={cn(
-                            'flex min-h-7 items-center rounded-full px-2.5 py-1 text-xs tracking-[-0.012em] transition-colors',
-                            isActive
-                              ? 'border border-(--linear-app-frame-seam) bg-surface-0 text-primary-token'
-                              : 'border border-transparent text-secondary-token hover:bg-surface-0 hover:text-primary-token'
-                          )}
+                          className={rowClassName}
                         >
-                          {section.title}
+                          {rowContent}
                         </a>
                       )}
                     </li>
@@ -201,7 +201,7 @@ export function SettingsPolished({
       ) : (
         <div className='text-center py-4'>
           <h3 className='text-sm font-caption text-primary-token mb-3'>
-            Account settings unavailable
+            Account Settings Unavailable
           </h3>
           <p className='text-app text-secondary-token'>
             Clerk is not configured (missing publishable key). Set
@@ -254,7 +254,7 @@ export function SettingsPolished({
         id: 'touring',
         title: 'Touring',
         description:
-          'Connect Bandsintown to display tour dates on your profile.',
+          'Connect Bandsintown to display tour dates on your profile.', // ui-casing-allow: Bandsintown brand name
         render: () => <SettingsTouringSection profileId={artist.id} />,
       },
     ],
@@ -318,7 +318,7 @@ export function SettingsPolished({
             {
               id: 'payments',
               title: 'Payments',
-              description: 'Connect Stripe to receive payments from fans.',
+              description: 'Connect Stripe to receive payments from fans.', // ui-casing-allow: Stripe brand name
               render: () => <SettingsPaymentsSection />,
             },
           ]

--- a/apps/web/tests/unit/dashboard/SettingsPolished.test.tsx
+++ b/apps/web/tests/unit/dashboard/SettingsPolished.test.tsx
@@ -98,6 +98,11 @@ describe('SettingsPolished', () => {
     ).toHaveLength(0);
     expect(screen.queryByText('ACCOUNT')).not.toBeInTheDocument();
     expect(screen.getByText('Account', { selector: 'p' })).toBeVisible();
+
+    const accountNavLink = screen.getByRole('link', { name: 'Account' });
+    expect(accountNavLink.className).toContain('h-7');
+    expect(accountNavLink.className).toContain('px-2.5');
+    expect(accountNavLink.className).not.toContain('py-1');
   });
 
   it('keeps the full settings navigation visible when a section is focused', () => {

--- a/apps/web/tests/unit/design-system/sidebar-nav-row-ratchet.test.ts
+++ b/apps/web/tests/unit/design-system/sidebar-nav-row-ratchet.test.ts
@@ -1,0 +1,140 @@
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Hand-rolled shell sidebar nav-row drift ratchet.
+ *
+ * Flags inline nav-row class strings that duplicate the canonical shell chrome
+ * (`getSidebarNavRowClassName` / `SidebarNavItem`) instead of importing the
+ * helper. The count may only go DOWN.
+ *
+ * WARN_ONLY: ships warn-mode first (JOV-3584) so the mechanism lands without
+ * blocking unrelated PRs that touch legacy sidebar primitives. Flip to false
+ * once remaining offenders are migrated.
+ *
+ * Sibling of component-family-ratchet.test.ts / raw-button-ratchet.test.ts.
+ */
+
+const WARN_ONLY = true;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WEB_ROOT = join(__dirname, '..', '..', '..');
+const SCAN_DIRS = ['components', 'app'].map(directory =>
+  join(WEB_ROOT, directory)
+);
+const BASELINE_PATH = join(__dirname, 'sidebar-nav-row.baseline.json');
+
+const CANONICAL_HELPER_IMPORT = /getSidebarNavRowClassName/;
+
+// Distinct hand-rolled settings/sidebar nav row signature from JOV-3584.
+const HAND_ROLLED_SETTINGS_NAV_ROW =
+  /['"`]flex min-h-7 items-center rounded-full px-2\.5 py-1/g;
+
+// Broader shell nav-row chrome duplicated outside the helper.
+const HAND_ROLLED_SHELL_NAV_ROW =
+  /(?:className=\{cn\(|className=['"`])[^;]*?(?:flex|grid)[^'"]*?(?:min-h-7|h-7)[^'"]*?rounded-full[^'"]*?px-2\.5/g;
+
+const SOURCE_EXT = /\.(tsx|ts)$/;
+
+const ALLOWLIST = new Set([
+  'components/organisms/sidebar/menu.tsx',
+  'components/organisms/sidebar/group.tsx',
+  'components/molecules/tab-bar/TabBar.tsx',
+  'components/molecules/drawer/DrawerCardActionBar.tsx',
+  'components/organisms/UnifiedSidebar.tsx',
+  'components/features/dashboard/organisms/SettingsTouringSection.tsx',
+  'components/features/dashboard/organisms/releases/cells/SmartLinkCell.tsx',
+  'app/app/(shell)/threads/ThreadsPageClient.tsx',
+]);
+
+function walk(directory: string, output: string[]): void {
+  if (!existsSync(directory)) return;
+
+  for (const entry of readdirSync(directory)) {
+    const fullPath = join(directory, entry);
+    const stats = statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      if (entry === 'node_modules' || entry === '.next') continue;
+      walk(fullPath, output);
+      continue;
+    }
+
+    if (SOURCE_EXT.test(entry)) {
+      output.push(fullPath);
+    }
+  }
+}
+
+function countHandRolledNavRows(): number {
+  const files: string[] = [];
+  for (const directory of SCAN_DIRS) walk(directory, files);
+
+  let total = 0;
+
+  for (const file of files) {
+    const relativePath = relative(WEB_ROOT, file);
+    if (ALLOWLIST.has(relativePath)) continue;
+
+    const content = readFileSync(file, 'utf8');
+    if (CANONICAL_HELPER_IMPORT.test(content)) continue;
+
+    const settingsMatches = content.match(HAND_ROLLED_SETTINGS_NAV_ROW);
+    const shellMatches = content.match(HAND_ROLLED_SHELL_NAV_ROW);
+
+    total += (settingsMatches?.length ?? 0) + (shellMatches?.length ?? 0);
+  }
+
+  return total;
+}
+
+describe('design-system sidebar-nav-row ratchet', () => {
+  it('hand-rolled shell nav rows do not grow above the baseline', () => {
+    const current = countHandRolledNavRows();
+
+    if (!existsSync(BASELINE_PATH)) {
+      writeFileSync(
+        BASELINE_PATH,
+        `${JSON.stringify(
+          {
+            count: current,
+            note:
+              'Hand-rolled shell sidebar nav-row class strings in apps/web/{components,app} ' +
+              'outside getSidebarNavRowClassName(). Ratchet only goes down — lower when you ' +
+              'migrate offenders to SidebarNavItem helpers. Flip WARN_ONLY=false in the test ' +
+              'after legacy sidebar primitives converge.',
+          },
+          null,
+          2
+        )}\n`
+      );
+    }
+
+    const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as {
+      count: number;
+    };
+
+    if (current > baseline.count) {
+      const message =
+        `Hand-rolled sidebar nav-row styling rose to ${current} (baseline ${baseline.count}). ` +
+        'Use getSidebarNavRowClassName() / SidebarNavItem instead of inline nav-row classes. ' +
+        'If this is a genuinely distinct surface, add it to the allowlist with a Linear ID.';
+
+      if (WARN_ONLY) {
+        console.warn(`[sidebar-nav-row ratchet — WARN] ${message}`);
+      } else {
+        expect.fail(message);
+      }
+    }
+
+    expect(current).toBeLessThanOrEqual(baseline.count);
+  });
+});

--- a/apps/web/tests/unit/design-system/sidebar-nav-row.baseline.json
+++ b/apps/web/tests/unit/design-system/sidebar-nav-row.baseline.json
@@ -1,0 +1,4 @@
+{
+  "count": 0,
+  "note": "Hand-rolled shell sidebar nav-row class strings in apps/web/{components,app} outside getSidebarNavRowClassName(). Ratchet only goes down — lower when you migrate offenders to SidebarNavItem helpers. Flip WARN_ONLY=false in the test after legacy sidebar primitives converge."
+}


### PR DESCRIPTION
## Summary

- Replace hand-rolled settings sidebar nav classes in `SettingsPolished` with `getSidebarNavRowClassName()` so settings navigation matches shell chrome
- Add `sidebar-nav-row` ratchet test (warn-only) to prevent new inline nav-row styling drift outside the canonical helper

## Linear

JOV-3584

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm biome:check`
- [x] `vitest run tests/unit/dashboard/SettingsPolished.test.tsx tests/unit/design-system/sidebar-nav-row-ratchet.test.ts`
- [ ] Visual check: settings sidebar active/inactive states match shell nav rows