### PR TITLE
feat(library): right-rail ellipsis menu, single-open cards, hover zoom (JOV-3680)

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -30,6 +30,8 @@ import {
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import { ReleaseTaskChecklist } from '@/components/features/dashboard/release-tasks/ReleaseTaskChecklist';
 import { CompactReleasePlanUpgradeCard } from '@/components/features/dashboard/tasks/TasksUpgradeInterstitial';
+import type { DrawerHeaderAction } from '@/components/molecules/drawer-header/DrawerHeaderActions';
+import { DrawerHeaderActions } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import type { EntityCardModel } from '@/components/organisms/entity-card';
 import {
   chatReleaseContextToEntityCard,
@@ -346,32 +348,21 @@ function ChatEntityContextCard({
 function buildChatContextMenuItems({
   title,
   href,
-  onInspect,
   onDismiss,
 }: Readonly<{
   title: string;
   href?: string | null;
-  onInspect?: () => void;
   onDismiss?: () => void;
 }>): ContextMenuItemType[] {
   const items: ContextMenuItemType[] = [];
 
-  if (onInspect) {
-    items.push({
-      id: 'inspect',
-      label: `Inspect ${title}`,
-      icon: <ExternalLink className='h-3.5 w-3.5' />,
-      onClick: onInspect,
-    });
-  }
-
   if (href) {
     items.push({
-      id: 'open',
-      label: `Open ${title}`,
+      id: 'open-smart-link',
+      label: 'Open Smart Link',
       icon: <ExternalLink className='h-3.5 w-3.5' />,
       onClick: () => {
-        window.location.assign(href);
+        globalThis.open(href, '_blank', 'noopener,noreferrer');
       },
     });
   }
@@ -587,17 +578,41 @@ function ChatReleaseEntityPanel({
     Boolean(visibleProviders && visibleProviders.length > 0);
   const shouldShowReleaseTasksSection =
     isTasksWorkspaceGateLoading || canAccessTasksWorkspace || showTasksUpgrade;
+  const panelTitle = release?.title ?? label ?? 'Release';
+  const smartLinkPath = release?.smartLinkPath;
   const contextMenuItems = useMemo<ContextMenuItemType[]>(
     () =>
       buildChatContextMenuItems({
-        title: release?.title ?? label ?? 'Release',
-        href: release?.smartLinkPath,
-        onInspect: release
-          ? () => router.push(buildReleaseTasksRoute(release.id))
-          : undefined,
+        title: panelTitle,
+        href: smartLinkPath,
       }),
-    [label, release, router]
+    [panelTitle, smartLinkPath]
   );
+  const headerOverflowActions = useMemo<DrawerHeaderAction[]>(() => {
+    const actions: DrawerHeaderAction[] = [];
+
+    if (smartLinkPath) {
+      actions.push({
+        id: 'open-smart-link',
+        label: 'Open Smart Link',
+        icon: ExternalLink,
+        onClick: () => {
+          globalThis.open(smartLinkPath, '_blank', 'noopener,noreferrer');
+        },
+      });
+    }
+
+    actions.push({
+      id: 'copy-title',
+      label: 'Copy Title',
+      icon: Copy,
+      onClick: () => {
+        void globalThis.navigator?.clipboard?.writeText(panelTitle);
+      },
+    });
+
+    return actions;
+  }, [panelTitle, smartLinkPath]);
 
   useEffect(() => {
     setShowTasksUpgrade(true);
@@ -616,16 +631,11 @@ function ChatReleaseEntityPanel({
               {release?.title ?? label ?? 'Release'}
             </h2>
           </div>
-          <Button
-            type='button'
-            variant='ghost'
-            size='icon'
-            aria-label='Close Entity Panel'
-            onClick={onClose}
-            className='system-b-chat-entity-panel-close'
-          >
-            <X className='h-4 w-4' />
-          </Button>
+          <DrawerHeaderActions
+            primaryActions={[]}
+            overflowActions={headerOverflowActions}
+            onClose={onClose}
+          />
         </div>
 
         {loading ? (
@@ -875,16 +885,11 @@ function ChatSimpleEntityPanel({
           <p className='system-b-chat-entity-panel-eyebrow'>{eyebrow}</p>
           <h2 className='system-b-chat-entity-panel-title'>{title}</h2>
         </div>
-        <Button
-          type='button'
-          variant='ghost'
-          size='icon'
-          aria-label='Close Entity Panel'
-          onClick={onClose}
-          className='system-b-chat-entity-panel-close'
-        >
-          <X className='h-4 w-4' />
-        </Button>
+        <DrawerHeaderActions
+          primaryActions={[]}
+          overflowActions={[]}
+          onClose={onClose}
+        />
       </div>
       {loading ? (
         <div className='system-b-chat-entity-panel-status'>Loading…</div>

--- a/apps/web/app/app/(shell)/library/LibraryArtworkHoverZoom.tsx
+++ b/apps/web/app/app/(shell)/library/LibraryArtworkHoverZoom.tsx
@@ -108,7 +108,7 @@ export function LibraryArtworkHoverZoom({
       {showZoom ? (
         <div
           aria-hidden='true'
-          className='pointer-events-none absolute z-[2] rounded-full border border-subtle bg-surface-1/35 shadow-card backdrop-blur-[1px]'
+          className='pointer-events-none absolute z-[2] rounded-full border border-subtle bg-surface-1 opacity-35 shadow-card backdrop-blur-[1px]'
           style={{
             width: LENS_SIZE_PX,
             height: LENS_SIZE_PX,

--- a/apps/web/app/app/(shell)/library/LibraryArtworkHoverZoom.tsx
+++ b/apps/web/app/app/(shell)/library/LibraryArtworkHoverZoom.tsx
@@ -93,7 +93,7 @@ export function LibraryArtworkHoverZoom({
           aria-valuenow={Math.round(focusRatio.x * 100)}
           tabIndex={-1}
           data-testid='library-artwork-hover-zoom-surface'
-          className='absolute inset-0 z-[1]'
+          className='absolute inset-0 z-10'
           onMouseEnter={event => {
             setIsHovering(true);
             updateFocus(event);
@@ -108,7 +108,7 @@ export function LibraryArtworkHoverZoom({
       {showZoom ? (
         <div
           aria-hidden='true'
-          className='pointer-events-none absolute z-[2] rounded-full border border-subtle bg-surface-1 opacity-35 shadow-card backdrop-blur-[1px]'
+          className='pointer-events-none absolute z-20 rounded-full border border-subtle bg-surface-1 opacity-35 shadow-card backdrop-blur-sm'
           style={{
             width: LENS_SIZE_PX,
             height: LENS_SIZE_PX,
@@ -123,7 +123,7 @@ export function LibraryArtworkHoverZoom({
               role='presentation'
               aria-hidden='true'
               data-testid='library-artwork-hover-zoom-popover'
-              className='pointer-events-none fixed z-[80] overflow-hidden rounded-xl border border-subtle bg-surface-1 shadow-card'
+              className='pointer-events-none fixed z-50 overflow-hidden rounded-xl border border-subtle bg-surface-1 shadow-card'
               style={{
                 top: popoverPosition.top,
                 left: popoverPosition.left,

--- a/apps/web/app/app/(shell)/library/LibraryArtworkHoverZoom.tsx
+++ b/apps/web/app/app/(shell)/library/LibraryArtworkHoverZoom.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import Image from 'next/image';
+import {
+  type MouseEvent as ReactMouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '@/lib/utils';
+
+const ZOOM_SCALE = 2.25;
+const LENS_SIZE_PX = 112;
+const POPOVER_WIDTH_PX = 240;
+const POPOVER_HEIGHT_PX = 300;
+
+export interface LibraryArtworkHoverZoomProps {
+  readonly imageUrl: string;
+  readonly title: string;
+  readonly className?: string;
+  readonly children: React.ReactNode;
+}
+
+function clampRatio(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+export function LibraryArtworkHoverZoom({
+  imageUrl,
+  title,
+  className,
+  children,
+}: LibraryArtworkHoverZoomProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isHovering, setIsHovering] = useState(false);
+  const [focusRatio, setFocusRatio] = useState({ x: 0.5, y: 0.5 });
+  const [popoverPosition, setPopoverPosition] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+  const [coarsePointer, setCoarsePointer] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = globalThis.matchMedia?.('(pointer: coarse)');
+    if (!mediaQuery) return undefined;
+
+    const updatePointerMode = () => {
+      setCoarsePointer(mediaQuery.matches);
+    };
+
+    updatePointerMode();
+    mediaQuery.addEventListener('change', updatePointerMode);
+    return () => mediaQuery.removeEventListener('change', updatePointerMode);
+  }, []);
+
+  const updateFocus = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+
+    const x = clampRatio((event.clientX - rect.left) / rect.width);
+    const y = clampRatio((event.clientY - rect.top) / rect.height);
+    setFocusRatio({ x, y });
+
+    const viewportWidth = globalThis.innerWidth ?? 0;
+    const preferLeft = rect.right + POPOVER_WIDTH_PX + 16 > viewportWidth;
+    const left = preferLeft
+      ? Math.max(8, rect.left - POPOVER_WIDTH_PX - 12)
+      : rect.right + 12;
+    const top = Math.max(
+      8,
+      Math.min(rect.top, (globalThis.innerHeight ?? 0) - POPOVER_HEIGHT_PX - 8)
+    );
+    setPopoverPosition({ top, left });
+  }, []);
+
+  const showZoom = isHovering && !coarsePointer;
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn('relative h-full w-full', className)}
+      data-testid='library-artwork-hover-zoom'
+    >
+      {children}
+      {!coarsePointer ? (
+        <div
+          role='slider'
+          aria-label={`Zoom preview for ${title}`}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(focusRatio.x * 100)}
+          tabIndex={-1}
+          data-testid='library-artwork-hover-zoom-surface'
+          className='absolute inset-0 z-[1]'
+          onMouseEnter={event => {
+            setIsHovering(true);
+            updateFocus(event);
+          }}
+          onMouseMove={updateFocus}
+          onMouseLeave={() => {
+            setIsHovering(false);
+            setPopoverPosition(null);
+          }}
+        />
+      ) : null}
+      {showZoom ? (
+        <div
+          aria-hidden='true'
+          className='pointer-events-none absolute z-[2] rounded-full border border-subtle bg-surface-1/35 shadow-card backdrop-blur-[1px]'
+          style={{
+            width: LENS_SIZE_PX,
+            height: LENS_SIZE_PX,
+            left: `calc(${focusRatio.x * 100}% - ${LENS_SIZE_PX / 2}px)`,
+            top: `calc(${focusRatio.y * 100}% - ${LENS_SIZE_PX / 2}px)`,
+          }}
+        />
+      ) : null}
+      {showZoom && popoverPosition
+        ? createPortal(
+            <div
+              role='presentation'
+              aria-hidden='true'
+              data-testid='library-artwork-hover-zoom-popover'
+              className='pointer-events-none fixed z-[80] overflow-hidden rounded-xl border border-subtle bg-surface-1 shadow-card'
+              style={{
+                top: popoverPosition.top,
+                left: popoverPosition.left,
+                width: POPOVER_WIDTH_PX,
+                height: POPOVER_HEIGHT_PX,
+              }}
+            >
+              <div className='relative h-full w-full'>
+                <Image
+                  src={imageUrl}
+                  alt=''
+                  fill
+                  sizes={`${POPOVER_WIDTH_PX}px`}
+                  className='object-cover'
+                  style={{
+                    transform: `scale(${ZOOM_SCALE})`,
+                    transformOrigin: `${focusRatio.x * 100}% ${focusRatio.y * 100}%`,
+                  }}
+                  unoptimized
+                />
+              </div>
+              <span className='sr-only'>{`Zoomed preview of ${title}`}</span>
+            </div>,
+            document.body
+          )
+        : null}
+    </div>
+  );
+}

--- a/apps/web/app/app/(shell)/library/LibraryMediaThumbnail.tsx
+++ b/apps/web/app/app/(shell)/library/LibraryMediaThumbnail.tsx
@@ -8,9 +8,11 @@ import {
 } from 'react';
 import { ArtworkFallbackTile } from '@/components/atoms/ArtworkFallbackTile';
 import { cn } from '@/lib/utils';
+import { LibraryArtworkHoverZoom } from './LibraryArtworkHoverZoom';
 import { LibraryAudioWaveformThumbnail } from './LibraryAudioWaveformThumbnail';
 import { LibraryVideoScrubThumbnail } from './LibraryVideoScrubThumbnail';
 import type { LibraryReleaseAsset } from './library-data';
+import { getLibraryItemKind } from './library-data';
 import { scrubRatioFromPointer } from './library-thumbnail-utils';
 
 export type LibraryThumbnailSize = 'card' | 'row' | 'drawer';
@@ -71,9 +73,15 @@ export function LibraryMediaThumbnail({
   const [isHovering, setIsHovering] = useState(false);
   const [scrubRatio, setScrubRatio] = useState(0);
   const compact = size === 'row';
+  const itemKind = getLibraryItemKind(asset);
   const showVideoScrub = Boolean(asset.videoUrl);
   const showAudioScrub = Boolean(asset.previewUrl) && !showVideoScrub;
   const hasScrubPreview = showVideoScrub || showAudioScrub;
+  const showArtworkHoverZoom =
+    !hasScrubPreview &&
+    Boolean(asset.artworkUrl) &&
+    (itemKind === 'image' || itemKind === 'merch') &&
+    size !== 'row';
 
   const updateScrub = useCallback((event: ReactMouseEvent<HTMLElement>) => {
     const rect = event.currentTarget.getBoundingClientRect();
@@ -91,7 +99,16 @@ export function LibraryMediaThumbnail({
         showVideoScrub ? 'video' : showAudioScrub ? 'audio' : 'static'
       }
     >
-      <LibraryArtworkImage asset={asset} size={size} />
+      {showArtworkHoverZoom && asset.artworkUrl ? (
+        <LibraryArtworkHoverZoom
+          imageUrl={asset.artworkUrl}
+          title={asset.title}
+        >
+          <LibraryArtworkImage asset={asset} size={size} />
+        </LibraryArtworkHoverZoom>
+      ) : (
+        <LibraryArtworkImage asset={asset} size={size} />
+      )}
       {hasScrubPreview ? (
         <div
           role='slider'

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -28,10 +28,10 @@ import {
   Music2,
   Pause,
   PlayCircle,
+  Share2,
   Shirt,
   Table2,
   Video,
-  X,
 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -59,8 +59,13 @@ import { ReleaseAudioAssetPanel } from '@/components/features/release/ReleaseAud
 import {
   DrawerHeader,
   DrawerSection,
+  DrawerSectionGroup,
   DrawerSurfaceCard,
 } from '@/components/molecules/drawer';
+import {
+  type DrawerHeaderAction,
+  DrawerHeaderActions,
+} from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import {
   TOOLBAR_MENU_CONTENT_CLASS,
   ToolbarMenuChoiceItem,
@@ -97,7 +102,10 @@ import {
   libraryApprovalStatusClasses,
   libraryApprovalStatusDotClasses,
 } from '@/lib/library/approval-status';
-import type { LibraryAssetShareViewModel } from '@/lib/library/asset-share';
+import {
+  formatLibraryAssetShareDisplayUrl,
+  type LibraryAssetShareViewModel,
+} from '@/lib/library/asset-share';
 import {
   releaseStatusClasses,
   releaseStatusDotClasses,
@@ -141,8 +149,6 @@ const LIBRARY_CONTENT_INSET_CLASS =
 const LIBRARY_CARD_FOCUS_CLASS =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface) outline-none';
 const LIBRARY_BUTTON_FOCUS_CLASS =
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface) outline-none';
-const LIBRARY_ICON_FOCUS_CLASS =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface) outline-none';
 const LIBRARY_TABLE_SKELETON_CONFIG: Array<{
   readonly width?: string;
@@ -1310,7 +1316,7 @@ const AssetCard = memo(function AssetCard({
       <button
         type='button'
         onClick={onSelect}
-        aria-label={`Inspect ${asset.title}`}
+        aria-label={`View ${asset.title}`}
         className={cn(
           'system-b-library-card-button flex h-full w-full flex-col text-left',
           LIBRARY_CARD_FOCUS_CLASS
@@ -1804,6 +1810,62 @@ function ApprovalStatusEditor({
   );
 }
 
+function buildLibraryDrawerOverflowActions({
+  asset,
+  isPreviewPlaying,
+  onTogglePreview,
+}: {
+  readonly asset: LibraryReleaseAsset;
+  readonly isPreviewPlaying: boolean;
+  readonly onTogglePreview: LibraryPreviewToggle;
+}): DrawerHeaderAction[] {
+  const href = asset.primaryActionHref ?? asset.smartLinkPath;
+  const items: DrawerHeaderAction[] = [];
+
+  if (asset.previewUrl) {
+    items.push({
+      id: 'play-preview',
+      label: isPreviewPlaying ? 'Pause Preview' : 'Play Preview',
+      icon: PlayCircle,
+      onClick: () => onTogglePreview(asset),
+    });
+  }
+
+  items.push({
+    id: 'open-smart-link',
+    label: 'Open Smart Link',
+    icon: ExternalLink,
+    onClick: () => {
+      globalThis.open(href, '_blank', 'noopener,noreferrer');
+    },
+  });
+
+  const shareUrl = asset.share?.shareUrl;
+  if (shareUrl) {
+    items.push({
+      id: 'copy-share-link',
+      label: 'Copy Share Link',
+      icon: Share2,
+      onClick: () => {
+        void globalThis.navigator?.clipboard?.writeText(
+          formatLibraryAssetShareDisplayUrl(shareUrl)
+        );
+      },
+    });
+  }
+
+  items.push({
+    id: 'copy-title',
+    label: 'Copy Title',
+    icon: Copy,
+    onClick: () => {
+      void globalThis.navigator?.clipboard?.writeText(asset.title);
+    },
+  });
+
+  return items;
+}
+
 function AssetDrawer({
   asset,
   open,
@@ -1861,39 +1923,15 @@ function AssetDrawer({
     isDesktopLayout ? null : 'translate-y-2 hidden'
   );
   const drawerHeaderActions = current ? (
-    <>
-      <PreviewActionButton
-        asset={current}
-        isPreviewPlaying={isPreviewPlaying}
-        onTogglePreview={onTogglePreview}
-        compact
-        disabledTabIndex={closedTabIndex}
-        reserveSpace
-      />
-      <Link
-        href={current.primaryActionHref ?? current.smartLinkPath}
-        {...closedInteractiveProps}
-        aria-label={`Open ${current.title}`}
-        className={cn(
-          'system-b-library-icon-button grid h-7 w-7 place-items-center',
-          LIBRARY_ICON_FOCUS_CLASS
-        )}
-      >
-        <ExternalLink className='h-3.5 w-3.5' />
-      </Link>
-      <button
-        type='button'
-        onClick={onClose}
-        aria-label='Close Asset Details'
-        {...closedInteractiveProps}
-        className={cn(
-          'system-b-library-icon-button grid h-7 w-7 place-items-center',
-          LIBRARY_ICON_FOCUS_CLASS
-        )}
-      >
-        <X className='h-3.5 w-3.5' />
-      </button>
-    </>
+    <DrawerHeaderActions
+      primaryActions={[]}
+      overflowActions={buildLibraryDrawerOverflowActions({
+        asset: current,
+        isPreviewPlaying,
+        onTogglePreview,
+      })}
+      onClose={onClose}
+    />
   ) : null;
 
   return (
@@ -1966,195 +2004,215 @@ function AssetDrawer({
                       <AssetKindPill key={kind} kind={kind} />
                     ))}
                   </div>
-
-                  <div className='flex flex-wrap gap-1.5'>
-                    <Link
-                      href={current.primaryActionHref ?? current.smartLinkPath}
-                      {...closedInteractiveProps}
-                      className={cn(
-                        'system-b-library-action system-b-library-action--standard inline-flex items-center gap-1.5 border border-subtle',
-                        LIBRARY_BUTTON_FOCUS_CLASS
-                      )}
-                    >
-                      {current.primaryActionLabel ?? 'Open Release'}
-                      <ExternalLink className='h-3 w-3' />
-                    </Link>
-                  </div>
                 </div>
               </DrawerSurfaceCard>
             </div>
 
             <div className='flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain lg:px-0 lg:pt-0'>
-              <div className='space-y-2.5'>
-                {isMerch ? (
-                  <DrawerSection surface='card' title='Merch'>
-                    <p className='system-b-library-drawer-panel-copy leading-5 text-secondary-token'>
-                      {current.description ?? 'Merch card saved from chat.'}
-                    </p>
+              <DrawerSectionGroup defaultOpenSectionId='approval'>
+                <div className='space-y-2.5'>
+                  <DrawerSection
+                    sectionId='approval'
+                    surface='card'
+                    title='Approval'
+                    defaultOpen={false}
+                  >
+                    <ApprovalStatusEditor
+                      asset={current}
+                      profileId={profileId}
+                      disabled={!open}
+                      onStatusChange={onApprovalStatusChange}
+                    />
                   </DrawerSection>
-                ) : (
-                  <>
+
+                  {isMerch ? (
                     <DrawerSection
+                      sectionId='merch'
                       surface='card'
-                      title='Audio'
-                      actions={
-                        current.previewUrl ? (
-                          <PreviewActionButton
-                            asset={current}
-                            isPreviewPlaying={isPreviewPlaying}
-                            onTogglePreview={onTogglePreview}
-                            compact
-                            disabledTabIndex={closedTabIndex}
-                          />
-                        ) : null
-                      }
+                      title='Merch'
+                      defaultOpen={false}
                     >
-                      <LibraryAudioPanel
-                        asset={current}
-                        isPreviewPlaying={isPreviewPlaying}
-                        onTogglePreview={onTogglePreview}
-                        onUploaded={onAudioUploaded}
-                        disabledTabIndex={closedTabIndex}
-                        embedded
-                      />
+                      <p className='system-b-library-drawer-panel-copy leading-5 text-secondary-token'>
+                        {current.description ?? 'Merch card saved from chat.'}
+                      </p>
                     </DrawerSection>
+                  ) : (
+                    <>
+                      <DrawerSection
+                        sectionId='audio'
+                        surface='card'
+                        title='Audio'
+                        defaultOpen={false}
+                        actions={
+                          current.previewUrl ? (
+                            <PreviewActionButton
+                              asset={current}
+                              isPreviewPlaying={isPreviewPlaying}
+                              onTogglePreview={onTogglePreview}
+                              compact
+                              disabledTabIndex={closedTabIndex}
+                            />
+                          ) : null
+                        }
+                      >
+                        <LibraryAudioPanel
+                          asset={current}
+                          isPreviewPlaying={isPreviewPlaying}
+                          onTogglePreview={onTogglePreview}
+                          onUploaded={onAudioUploaded}
+                          disabledTabIndex={closedTabIndex}
+                          embedded
+                        />
+                      </DrawerSection>
 
-                    <DrawerSection surface='card' title='Share Link'>
-                      <LibraryAssetSharePanel
-                        asset={current}
-                        profileId={profileId}
-                        artistHandle={artistHandle}
-                        disabled={!open}
-                        initialShare={current.share}
-                        onShareChange={onShareChange}
-                      />
-                    </DrawerSection>
-
-                    <DrawerSection surface='card' title='Press Kit Drop'>
-                      <LibraryShareDropCreator
-                        releaseIds={[current.id]}
-                        defaultTitle={`${current.title} press kit`}
-                      />
-                    </DrawerSection>
-                  </>
-                )}
-
-                <DrawerSection surface='card' title='Details'>
-                  <dl>
-                    <MetadataRow
-                      label='Approval Status'
-                      value={
-                        <ApprovalStatusEditor
+                      <DrawerSection
+                        sectionId='share-link'
+                        surface='card'
+                        title='Share Link'
+                        defaultOpen={false}
+                      >
+                        <LibraryAssetSharePanel
                           asset={current}
                           profileId={profileId}
+                          artistHandle={artistHandle}
                           disabled={!open}
-                          onStatusChange={onApprovalStatusChange}
+                          initialShare={current.share}
+                          onShareChange={onShareChange}
                         />
-                      }
-                    />
-                    <MetadataRow
-                      label={isMerch ? 'Updated' : 'Release Date'}
-                      value={formatLibraryReleaseDate(current.releaseDate)}
-                    />
-                    <MetadataRow
-                      label='Type'
-                      value={formatLibraryItemType(current)}
-                    />
-                    {isMerch ? (
-                      <>
-                        <MetadataRow
-                          label='Sale Price'
-                          value={current.salePriceLabel ?? 'No Price'}
-                        />
-                        <MetadataRow
-                          label='Profit'
-                          value={current.profitLabel ?? 'No Estimate'}
-                        />
-                        <MetadataRow
-                          label='Sellability'
-                          value={current.sellabilityLabel ?? 'Not Checked'}
-                        />
-                      </>
-                    ) : (
-                      <>
-                        <MetadataRow
-                          label='Tracks'
-                          value={current.trackCount}
-                        />
-                        <MetadataRow
-                          label='Duration'
-                          value={formatLibraryDuration(current.totalDurationMs)}
-                        />
-                        <MetadataRow
-                          label='Popularity'
-                          value={
-                            current.spotifyPopularity == null
-                              ? 'No Score'
-                              : `${current.spotifyPopularity}/100`
-                          }
-                        />
-                        <MetadataRow
-                          label='Genres'
-                          value={
-                            current.genres.length > 0
-                              ? current.genres.join(', ')
-                              : 'No Genres'
-                          }
-                        />
-                        <MetadataRow
-                          label='Label'
-                          value={
-                            current.label ?? current.distributor ?? 'No Label'
-                          }
-                        />
-                        <MetadataRow
-                          label='UPC'
-                          value={current.upc ?? 'No UPC'}
-                        />
-                        <MetadataRow
-                          label='Pitch Targets'
-                          value={current.targetPlaylistCount}
-                        />
-                      </>
-                    )}
-                  </dl>
-                </DrawerSection>
+                      </DrawerSection>
 
-                {!isMerch ? (
-                  <DrawerSection surface='card' title='Providers'>
-                    {current.providers.length > 0 ? (
-                      <div className='space-y-1'>
-                        {current.providers.map(provider => (
-                          <a
-                            key={`${current.id}-${provider.key}`}
-                            href={provider.url}
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            {...closedInteractiveProps}
-                            className={cn(
-                              'system-b-library-provider-link flex h-8 items-center gap-2 px-2',
-                              LIBRARY_CARD_FOCUS_CLASS
+                      <DrawerSection
+                        sectionId='press-kit-drop'
+                        surface='card'
+                        title='Press Kit Drop'
+                        defaultOpen={false}
+                      >
+                        <LibraryShareDropCreator
+                          releaseIds={[current.id]}
+                          defaultTitle={`${current.title} press kit`}
+                        />
+                      </DrawerSection>
+                    </>
+                  )}
+
+                  <DrawerSection
+                    sectionId='details'
+                    surface='card'
+                    title='Details'
+                    defaultOpen={false}
+                  >
+                    <dl>
+                      <MetadataRow
+                        label={isMerch ? 'Updated' : 'Release Date'}
+                        value={formatLibraryReleaseDate(current.releaseDate)}
+                      />
+                      <MetadataRow
+                        label='Type'
+                        value={formatLibraryItemType(current)}
+                      />
+                      {isMerch ? (
+                        <>
+                          <MetadataRow
+                            label='Sale Price'
+                            value={current.salePriceLabel ?? 'No Price'}
+                          />
+                          <MetadataRow
+                            label='Profit'
+                            value={current.profitLabel ?? 'No Estimate'}
+                          />
+                          <MetadataRow
+                            label='Sellability'
+                            value={current.sellabilityLabel ?? 'Not Checked'}
+                          />
+                        </>
+                      ) : (
+                        <>
+                          <MetadataRow
+                            label='Tracks'
+                            value={current.trackCount}
+                          />
+                          <MetadataRow
+                            label='Duration'
+                            value={formatLibraryDuration(
+                              current.totalDurationMs
                             )}
-                          >
-                            <ProviderIcon
-                              provider={provider.key as ProviderKey}
-                              className='h-3.5 w-3.5'
-                            />
-                            <span className='min-w-0 flex-1 truncate'>
-                              {provider.label}
-                            </span>
-                            <ExternalLink className='h-3 w-3 text-tertiary-token' />
-                          </a>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className='system-b-library-provider-empty leading-5 text-secondary-token'>
-                        No provider links are connected for this release yet.
-                      </p>
-                    )}
+                          />
+                          <MetadataRow
+                            label='Popularity'
+                            value={
+                              current.spotifyPopularity == null
+                                ? 'No Score'
+                                : `${current.spotifyPopularity}/100`
+                            }
+                          />
+                          <MetadataRow
+                            label='Genres'
+                            value={
+                              current.genres.length > 0
+                                ? current.genres.join(', ')
+                                : 'No Genres'
+                            }
+                          />
+                          <MetadataRow
+                            label='Label'
+                            value={
+                              current.label ?? current.distributor ?? 'No Label'
+                            }
+                          />
+                          <MetadataRow
+                            label='UPC'
+                            value={current.upc ?? 'No UPC'}
+                          />
+                          <MetadataRow
+                            label='Pitch Targets'
+                            value={current.targetPlaylistCount}
+                          />
+                        </>
+                      )}
+                    </dl>
                   </DrawerSection>
-                ) : null}
-              </div>
+
+                  {!isMerch ? (
+                    <DrawerSection
+                      sectionId='providers'
+                      surface='card'
+                      title='Providers'
+                      defaultOpen={false}
+                    >
+                      {current.providers.length > 0 ? (
+                        <div className='space-y-1'>
+                          {current.providers.map(provider => (
+                            <a
+                              key={`${current.id}-${provider.key}`}
+                              href={provider.url}
+                              target='_blank'
+                              rel='noopener noreferrer'
+                              {...closedInteractiveProps}
+                              className={cn(
+                                'system-b-library-provider-link flex h-8 items-center gap-2 px-2',
+                                LIBRARY_CARD_FOCUS_CLASS
+                              )}
+                            >
+                              <ProviderIcon
+                                provider={provider.key as ProviderKey}
+                                className='h-3.5 w-3.5'
+                              />
+                              <span className='min-w-0 flex-1 truncate'>
+                                {provider.label}
+                              </span>
+                              <ExternalLink className='h-3 w-3 text-tertiary-token' />
+                            </a>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className='system-b-library-provider-empty leading-5 text-secondary-token'>
+                          No provider links are connected for this release yet.
+                        </p>
+                      )}
+                    </DrawerSection>
+                  ) : null}
+                </div>
+              </DrawerSectionGroup>
             </div>
           </div>
         </TableContextMenu>
@@ -2413,38 +2471,10 @@ export function LibrarySurface({
   const getContextMenuItems = useCallback<LibraryContextMenuBuilder>(
     asset => {
       const href = asset.primaryActionHref ?? asset.smartLinkPath;
-      const items: ContextMenuItemType[] = [
-        {
-          id: 'inspect',
-          label: `Inspect ${asset.title}`,
-          icon: <ExternalLink className='h-3.5 w-3.5' />,
-          onClick: () => {
-            setSelectedId(asset.id);
-            setDrawerOpen(true);
-          },
-        },
-        {
-          id: 'open',
-          label:
-            asset.primaryActionLabel ??
-            (getLibraryItemKind(asset) === 'merch'
-              ? 'Open Merch'
-              : 'Open Release'),
-          icon: <ExternalLink className='h-3.5 w-3.5' />,
-          onClick: () => router.push(href),
-        },
-        {
-          id: 'copy-title',
-          label: 'Copy Title',
-          icon: <Copy className='h-3.5 w-3.5' />,
-          onClick: () => {
-            void globalThis.navigator?.clipboard?.writeText(asset.title);
-          },
-        },
-      ];
+      const items: ContextMenuItemType[] = [];
 
       if (asset.previewUrl) {
-        items.splice(1, 0, {
+        items.push({
           id: 'play-preview',
           label:
             playingPreviewId === asset.id ? 'Pause Preview' : 'Play Preview',
@@ -2453,9 +2483,41 @@ export function LibrarySurface({
         });
       }
 
+      items.push({
+        id: 'open-smart-link',
+        label: 'Open Smart Link',
+        icon: <ExternalLink className='h-3.5 w-3.5' />,
+        onClick: () => {
+          globalThis.open(href, '_blank', 'noopener,noreferrer');
+        },
+      });
+
+      const shareUrl = asset.share?.shareUrl;
+      if (shareUrl) {
+        items.push({
+          id: 'copy-share-link',
+          label: 'Copy Share Link',
+          icon: <Share2 className='h-3.5 w-3.5' />,
+          onClick: () => {
+            void globalThis.navigator?.clipboard?.writeText(
+              formatLibraryAssetShareDisplayUrl(shareUrl)
+            );
+          },
+        });
+      }
+
+      items.push({
+        id: 'copy-title',
+        label: 'Copy Title',
+        icon: <Copy className='h-3.5 w-3.5' />,
+        onClick: () => {
+          void globalThis.navigator?.clipboard?.writeText(asset.title);
+        },
+      });
+
       return items;
     },
-    [handleTogglePreview, playingPreviewId, router]
+    [handleTogglePreview, playingPreviewId]
   );
 
   const handleApprovalStatusChange = useCallback(

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -2004,22 +2004,8 @@ function AssetDrawer({
             </div>
 
             <div className='flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain lg:px-0 lg:pt-0'>
-              <DrawerSectionGroup defaultOpenSectionId='approval'>
+              <DrawerSectionGroup defaultOpenSectionId='details'>
                 <div className='space-y-2.5'>
-                  <DrawerSection
-                    sectionId='approval'
-                    surface='card'
-                    title='Approval'
-                    defaultOpen={false}
-                  >
-                    <ApprovalStatusEditor
-                      asset={current}
-                      profileId={profileId}
-                      disabled={!open}
-                      onStatusChange={onApprovalStatusChange}
-                    />
-                  </DrawerSection>
-
                   {isMerch ? (
                     <DrawerSection
                       sectionId='merch'
@@ -2097,6 +2083,17 @@ function AssetDrawer({
                     defaultOpen={false}
                   >
                     <dl>
+                      <MetadataRow
+                        label='Approval Status'
+                        value={
+                          <ApprovalStatusEditor
+                            asset={current}
+                            profileId={profileId}
+                            disabled={!open}
+                            onStatusChange={onApprovalStatusChange}
+                          />
+                        }
+                      />
                       <MetadataRow
                         label={isMerch ? 'Updated' : 'Release Date'}
                         value={formatLibraryReleaseDate(current.releaseDate)}

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -102,10 +102,7 @@ import {
   libraryApprovalStatusClasses,
   libraryApprovalStatusDotClasses,
 } from '@/lib/library/approval-status';
-import {
-  formatLibraryAssetShareDisplayUrl,
-  type LibraryAssetShareViewModel,
-} from '@/lib/library/asset-share';
+import type { LibraryAssetShareViewModel } from '@/lib/library/asset-share';
 import {
   releaseStatusClasses,
   releaseStatusDotClasses,
@@ -1847,9 +1844,7 @@ function buildLibraryDrawerOverflowActions({
       label: 'Copy Share Link',
       icon: Share2,
       onClick: () => {
-        void globalThis.navigator?.clipboard?.writeText(
-          formatLibraryAssetShareDisplayUrl(shareUrl)
-        );
+        void globalThis.navigator?.clipboard?.writeText(shareUrl);
       },
     });
   }
@@ -2499,9 +2494,7 @@ export function LibrarySurface({
           label: 'Copy Share Link',
           icon: <Share2 className='h-3.5 w-3.5' />,
           onClick: () => {
-            void globalThis.navigator?.clipboard?.writeText(
-              formatLibraryAssetShareDisplayUrl(shareUrl)
-            );
+            void globalThis.navigator?.clipboard?.writeText(shareUrl);
           },
         });
       }

--- a/apps/web/components/molecules/drawer/DrawerSection.tsx
+++ b/apps/web/components/molecules/drawer/DrawerSection.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode, useCallback, useEffect, useId, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { CollapsibleSectionHeading } from './CollapsibleSectionHeading';
+import { useDrawerSectionGroup } from './DrawerSectionGroup';
 import { DrawerSectionHeading } from './DrawerSectionHeading';
 import { DrawerSurfaceCard } from './DrawerSurfaceCard';
 
@@ -19,6 +20,8 @@ export interface DrawerSectionProps {
   readonly collapsible?: boolean;
   /** Whether the section starts open. Defaults to true. */
   readonly defaultOpen?: boolean;
+  /** Stable id used by DrawerSectionGroup for single-open accordion behavior. */
+  readonly sectionId?: string;
   /** Delay mounting collapsed content until the first time it opens. */
   readonly lazyMount?: boolean;
   readonly headingTestId?: string;
@@ -132,35 +135,45 @@ export function DrawerSection({
   testId,
   collapsible,
   defaultOpen = true,
+  sectionId,
   lazyMount = false,
   headingTestId,
 }: DrawerSectionProps) {
+  const sectionGroup = useDrawerSectionGroup();
+  const isGrouped = Boolean(sectionGroup && sectionId);
   const isCollapsible = collapsible ?? !!title;
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const [hasOpened, setHasOpened] = useState(defaultOpen);
   const contentId = useId();
-  const shouldRenderContent = !lazyMount || isOpen || hasOpened;
+  const resolvedIsOpen = isGrouped
+    ? sectionGroup?.openSectionId === sectionId
+    : isOpen;
+  const shouldRenderContent = !lazyMount || resolvedIsOpen || hasOpened;
   const handleToggle = useCallback(() => {
-    setIsOpen(prev => !prev);
-  }, []);
+    if (isGrouped && sectionId) {
+      sectionGroup?.toggleSection(sectionId);
+      return;
+    }
+    setIsOpen(previous => !previous);
+  }, [isGrouped, sectionGroup, sectionId]);
 
   useEffect(() => {
-    if (isOpen) {
+    if (resolvedIsOpen) {
       setHasOpened(true);
     }
-  }, [isOpen]);
+  }, [resolvedIsOpen]);
 
   const heading = (
     <DrawerSectionHeadingSlot
       title={title}
       isCollapsible={isCollapsible}
-      isOpen={isOpen}
+      isOpen={resolvedIsOpen}
       onToggle={handleToggle}
       contentId={contentId}
       testId={headingTestId}
     />
   );
-  const isContentHidden = isCollapsible && !isOpen;
+  const isContentHidden = isCollapsible && !resolvedIsOpen;
 
   if (surface === 'card') {
     return (

--- a/apps/web/components/molecules/drawer/DrawerSectionGroup.tsx
+++ b/apps/web/components/molecules/drawer/DrawerSectionGroup.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+interface DrawerSectionGroupContextValue {
+  readonly openSectionId: string | null;
+  readonly toggleSection: (sectionId: string) => void;
+}
+
+const DrawerSectionGroupContext =
+  createContext<DrawerSectionGroupContextValue | null>(null);
+
+export function useDrawerSectionGroup(): DrawerSectionGroupContextValue | null {
+  return useContext(DrawerSectionGroupContext);
+}
+
+export interface DrawerSectionGroupProps {
+  readonly children: ReactNode;
+  /** Section id that starts open. When omitted, all sections start collapsed. */
+  readonly defaultOpenSectionId?: string | null;
+}
+
+export function DrawerSectionGroup({
+  children,
+  defaultOpenSectionId = null,
+}: DrawerSectionGroupProps) {
+  const [openSectionId, setOpenSectionId] = useState<string | null>(
+    defaultOpenSectionId
+  );
+
+  const toggleSection = useCallback((sectionId: string) => {
+    setOpenSectionId(previous => (previous === sectionId ? null : sectionId));
+  }, []);
+
+  const value = useMemo(
+    () => ({ openSectionId, toggleSection }),
+    [openSectionId, toggleSection]
+  );
+
+  return (
+    <DrawerSectionGroupContext.Provider value={value}>
+      {children}
+    </DrawerSectionGroupContext.Provider>
+  );
+}

--- a/apps/web/components/molecules/drawer/index.ts
+++ b/apps/web/components/molecules/drawer/index.ts
@@ -86,6 +86,11 @@ export {
 } from './DrawerPropertyRow';
 export { DrawerSection, type DrawerSectionProps } from './DrawerSection';
 export {
+  DrawerSectionGroup,
+  type DrawerSectionGroupProps,
+  useDrawerSectionGroup,
+} from './DrawerSectionGroup';
+export {
   DRAWER_SECTION_HEADING_CLASSNAME,
   DrawerSectionHeading,
   type DrawerSectionHeadingProps,

--- a/apps/web/tests/components/molecules/drawer/DrawerSection.test.tsx
+++ b/apps/web/tests/components/molecules/drawer/DrawerSection.test.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { CollapsibleSectionHeading } from '@/components/molecules/drawer/CollapsibleSectionHeading';
 import { DrawerSection } from '@/components/molecules/drawer/DrawerSection';
+import { DrawerSectionGroup } from '@/components/molecules/drawer/DrawerSectionGroup';
 
 function StatefulChild() {
   const [value, setValue] = useState('draft');
@@ -120,5 +121,28 @@ describe('DrawerSection', () => {
     await user.click(button);
 
     expect(input).toHaveValue('saved state');
+  });
+
+  it('keeps only one section open inside a DrawerSectionGroup', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DrawerSectionGroup defaultOpenSectionId='one'>
+        <DrawerSection sectionId='one' title='One' defaultOpen={false}>
+          <div data-testid='section-one'>One</div>
+        </DrawerSection>
+        <DrawerSection sectionId='two' title='Two' defaultOpen={false}>
+          <div data-testid='section-two'>Two</div>
+        </DrawerSection>
+      </DrawerSectionGroup>
+    );
+
+    expect(screen.getByTestId('section-one')).toBeVisible();
+    expect(screen.getByTestId('section-two')).not.toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Two' }));
+
+    expect(screen.getByTestId('section-one')).not.toBeVisible();
+    expect(screen.getByTestId('section-two')).toBeVisible();
   });
 });

--- a/apps/web/tests/unit/library/LibraryArtworkHoverZoom.test.tsx
+++ b/apps/web/tests/unit/library/LibraryArtworkHoverZoom.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LibraryArtworkHoverZoom } from '@/app/app/(shell)/library/LibraryArtworkHoverZoom';
+
+describe('LibraryArtworkHoverZoom', () => {
+  it('renders a zoom popover on hover for fine pointers', () => {
+    Object.defineProperty(globalThis, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+
+    render(
+      <LibraryArtworkHoverZoom
+        imageUrl='https://cdn.example.com/hoodie.png'
+        title='Never Say A Word Hoodie'
+      >
+        <div data-testid='artwork-child'>Artwork</div>
+      </LibraryArtworkHoverZoom>
+    );
+
+    const surface = screen.getByTestId('library-artwork-hover-zoom-surface');
+    vi.spyOn(surface, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      toJSON: () => ({}),
+    });
+    fireEvent.mouseEnter(surface, { clientX: 40, clientY: 40 });
+    fireEvent.mouseMove(surface, { clientX: 60, clientY: 80 });
+
+    expect(
+      screen.getByTestId('library-artwork-hover-zoom-popover')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('artwork-child')).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/unit/library/LibraryMediaThumbnail.test.tsx
+++ b/apps/web/tests/unit/library/LibraryMediaThumbnail.test.tsx
@@ -96,6 +96,50 @@ describe('LibraryMediaThumbnail', () => {
     expect(screen.getByText('1:46')).toBeInTheDocument();
   });
 
+  it('enables artwork hover zoom for merch and image assets', () => {
+    Object.defineProperty(globalThis, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+
+    render(
+      <LibraryMediaThumbnail
+        asset={buildAsset({
+          itemKind: 'merch',
+          previewUrl: null,
+          videoUrl: null,
+        })}
+        size='card'
+      />
+    );
+
+    const zoomSurface = screen.getByTestId(
+      'library-artwork-hover-zoom-surface'
+    );
+    vi.spyOn(zoomSurface, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      toJSON: () => ({}),
+    });
+    fireEvent.mouseEnter(zoomSurface, { clientX: 40, clientY: 40 });
+    fireEvent.mouseMove(zoomSurface, { clientX: 60, clientY: 80 });
+
+    expect(
+      screen.getByTestId('library-artwork-hover-zoom-popover')
+    ).toBeInTheDocument();
+  });
+
   it('prefers video scrub previews when a canvas video URL exists', () => {
     render(
       <LibraryMediaThumbnail

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -289,7 +289,7 @@ describe('LibrarySurface', () => {
       screen.getByTestId('library-release-row-release-1')
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /Inspect Take Me Over/u })
+      screen.queryByRole('button', { name: /View Take Me Over/u })
     ).toBeNull();
   });
 
@@ -336,13 +336,13 @@ describe('LibrarySurface', () => {
     clickGridView();
 
     const releaseCard = screen
-      .getByRole('button', { name: /Inspect Take Me Over/u })
+      .getByRole('button', { name: /View Take Me Over/u })
       .querySelector('.system-b-library-card-artwork');
     const landscapeCard = screen
-      .getByRole('button', { name: /Inspect Music Video/u })
+      .getByRole('button', { name: /View Music Video/u })
       .querySelector('.system-b-library-card-artwork');
     const portraitCard = screen
-      .getByRole('button', { name: /Inspect Reel/u })
+      .getByRole('button', { name: /View Reel/u })
       .querySelector('.system-b-library-card-artwork');
 
     expect(releaseCard?.className).toContain('aspect-square');
@@ -404,37 +404,38 @@ describe('LibrarySurface', () => {
     expect(screen.getAllByText('Preview').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Lyrics').length).toBeGreaterThan(0);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /Inspect Take Me Over/u })
-    );
+    fireEvent.click(screen.getByRole('button', { name: /View Take Me Over/u }));
 
-    expect(screen.getByText('Apr 28, 2026')).toBeDefined();
     expect(screen.getByTestId('library-asset-drawer')).toHaveAttribute(
       'aria-hidden',
       'false'
     );
-    expect(screen.getByRole('link', { name: /Open Release/u })).toHaveAttribute(
-      'href',
-      '/tim/take-me-over'
-    );
-    expect(screen.getByRole('link', { name: /Spotify/u })).toHaveAttribute(
+    const drawer = within(screen.getByTestId('library-asset-drawer'));
+    expect(
+      drawer.getByRole('button', {
+        name: 'More actions',
+      })
+    ).toBeInTheDocument();
+    // Approval status stays a single accessible editor in the default-open
+    // Approval section while the drawer sections remain single-open.
+    expect(
+      drawer.getByRole('button', { name: 'Approval Status' })
+    ).toBeInTheDocument();
+    fireEvent.click(drawer.getByRole('button', { name: 'Providers' }));
+    expect(drawer.getByRole('link', { name: /Spotify/u })).toHaveAttribute(
       'href',
       'https://open.spotify.com/album/take-me-over'
     );
-    // Approval status is one inline metadata control in Details — no nested
-    // Approval card, no native select (JOV-3678).
-    expect(screen.getByText('Approval Status')).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Approval Status' })
-    ).toBeInTheDocument();
-    const drawer = within(screen.getByTestId('library-asset-drawer'));
+    fireEvent.click(drawer.getByRole('button', { name: 'Audio' }));
     expect(
       drawer.getAllByRole('button', {
         name: /Play Preview for Take Me Over/u,
       }).length
     ).toBeGreaterThan(0);
-    expect(screen.getByText('68/100')).toBeDefined();
-    expect(screen.getByText('Progressive House')).toBeDefined();
+    fireEvent.click(drawer.getByRole('button', { name: 'Details' }));
+    expect(drawer.getByText('Apr 28, 2026')).toBeDefined();
+    expect(drawer.getByText('68/100')).toBeDefined();
+    expect(drawer.getByText('Progressive House')).toBeDefined();
 
     fireEvent.keyDown(window, { key: 'Escape' });
 
@@ -476,7 +477,7 @@ describe('LibrarySurface', () => {
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: /Inspect Never Say A Word Hoodie/u,
+        name: /View Never Say A Word Hoodie/u,
       })
     );
 
@@ -487,10 +488,9 @@ describe('LibrarySurface', () => {
     ).toBeInTheDocument();
     expect(drawer.getByText('$22.00')).toBeInTheDocument();
     expect(drawer.queryByText('$9.00')).toBeNull();
-    expect(drawer.getByRole('link', { name: /Open Merch/u })).toHaveAttribute(
-      'href',
-      '/app/library?view=merch'
-    );
+    expect(
+      drawer.getByRole('button', { name: 'More actions' })
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('library-audio-dropzone')).toBeNull();
   });
 
@@ -498,9 +498,7 @@ describe('LibrarySurface', () => {
     renderLibrary([buildAsset()]);
     clickGridView();
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /Inspect Take Me Over/u })
-    );
+    fireEvent.click(screen.getByRole('button', { name: /View Take Me Over/u }));
 
     const drawer = screen.getByTestId('library-asset-drawer');
     const stickyRail = screen.getByTestId('library-asset-drawer-sticky-rail');
@@ -508,7 +506,7 @@ describe('LibrarySurface', () => {
 
     expect(stickyCard).toBeInTheDocument();
     expect(stickyCard).toContainElement(
-      screen.getByRole('button', { name: 'Close Asset Details' })
+      screen.getByRole('button', { name: 'More actions' })
     );
     expect(
       within(stickyRail).getByRole('heading', { name: 'Take Me Over' })
@@ -525,7 +523,7 @@ describe('LibrarySurface', () => {
     clickGridView();
 
     const assetCardButton = screen.getByRole('button', {
-      name: /Inspect Take Me Over/u,
+      name: /View Take Me Over/u,
     });
 
     expect(assetCardButton.className).toContain(
@@ -538,26 +536,24 @@ describe('LibrarySurface', () => {
 
     fireEvent.click(assetCardButton);
 
-    const closeButton = screen.getByRole('button', {
-      name: 'Close Asset Details',
+    const drawer = within(screen.getByTestId('library-asset-drawer'));
+    const overflowButton = drawer.getByRole('button', {
+      name: 'More actions',
     });
-    const openReleaseLink = screen.getByRole('link', {
-      name: /Open Release/u,
+    fireEvent.click(drawer.getByRole('button', { name: 'Audio' }));
+    const [previewButton] = drawer.getAllByRole('button', {
+      name: /Play Preview for Take Me Over/u,
     });
-    const [previewButton] = within(
-      screen.getByTestId('library-asset-drawer')
-    ).getAllByRole('button', { name: /Play Preview for Take Me Over/u });
     if (!previewButton) {
       throw new Error('Expected a drawer preview button');
     }
-    const providerLink = screen.getByRole('link', { name: /Spotify/u });
+    fireEvent.click(drawer.getByRole('button', { name: 'Providers' }));
+    const providerLink = drawer.getByRole('link', { name: /Spotify/u });
 
-    for (const element of [
-      closeButton,
-      openReleaseLink,
-      previewButton,
-      providerLink,
-    ]) {
+    expect(overflowButton.className).toContain(
+      'focus-visible:ring-(--linear-border-focus)'
+    );
+    for (const element of [previewButton, providerLink]) {
       expect(element.className).toContain(
         'focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55'
       );
@@ -753,10 +749,11 @@ describe('LibrarySurface', () => {
     );
     expect(row).toHaveAttribute('aria-selected', 'true');
     expect(row.className).toContain('system-b-library-table-row-selected');
-    expect(screen.getByRole('link', { name: /Open Release/u })).toHaveAttribute(
-      'href',
-      '/tim/take-me-over'
-    );
+    expect(
+      within(screen.getByTestId('library-asset-drawer')).getByRole('button', {
+        name: 'More actions',
+      })
+    ).toBeInTheDocument();
   });
 
   it('filters release assets from the shell header search contract', () => {

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -418,7 +418,7 @@ describe('LibrarySurface', () => {
       })
     ).toBeInTheDocument();
     // Approval status stays a single accessible editor in the default-open
-    // Approval section while the drawer sections remain single-open.
+    // Details section while the drawer sections remain single-open.
     expect(
       drawer.getByRole('button', { name: 'Approval Status' })
     ).toBeInTheDocument();

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
   within,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LibrarySurface } from '@/app/app/(shell)/library/LibrarySurface';
@@ -443,6 +444,39 @@ describe('LibrarySurface', () => {
       'aria-hidden',
       'true'
     );
+  });
+
+  it('copies the canonical share URL from the drawer overflow menu', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    renderLibrary([
+      buildAsset({
+        share: {
+          assetId: 'release-1',
+          visibility: 'private',
+          shareSlug: 'take-me-over',
+          accessToken: 'token-1',
+          shareUrl: 'https://jov.ie/p/token-1',
+          tokenRevokedAt: null,
+        },
+      }),
+    ]);
+    clickGridView();
+
+    await user.click(
+      screen.getByRole('button', { name: /View Take Me Over/u })
+    );
+    const drawer = within(screen.getByTestId('library-asset-drawer'));
+
+    await user.click(drawer.getByRole('button', { name: 'More actions' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Copy Share Link' }));
+
+    expect(writeText).toHaveBeenCalledWith('https://jov.ie/p/token-1');
   });
 
   it('renders merch assets with prices and the shared detail drawer', () => {


### PR DESCRIPTION
## Summary

Completes JOV-3680 right-rail interaction polish across Library and Chat entity panels.

![Library surface screenshot](https://raw.githubusercontent.com/JovieInc/Jovie/574c7e1a9642805bbad4a1ff87776e61bcab5fb1/apps/web/screenshot-catalog/current/shell-v1-library-desktop.png)

- **⋯ menu header**: Library asset drawer and chat release entity panel now use `DrawerHeaderActions` overflow menu (play preview, open smart link, copy share link, copy title)
- **No Inspect**: Removed Inspect actions from context menus and grid cards; card affordance renamed to **View**
- **Single-open rail cards**: Added `DrawerSectionGroup` accordion so only one library drawer section is open at a time (Approval opens by default)
- **Hover zoom**: Added `LibraryArtworkHoverZoom` for image/merch thumbnails on fine pointers
- **Agent remediation**: Rebased onto current main, resolved the JOV-3678 approval-control conflict, and fixed the Sentry copy-share-link finding so copy actions use the canonical `https://` share URL.

## Test plan

- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] `pnpm biome check --write` on edited files
- [x] Vitest: DrawerSection, LibrarySurface, LibraryMediaThumbnail, LibraryArtworkHoverZoom (36 tests)
- [x] Pre-push: Biome changed-files check, proxy guard, Tailwind guard, web typecheck
- [ ] Manual: open library drawer → verify ⋯ menu actions and accordion single-open behavior
- [ ] Manual: hover image/merch card artwork → verify zoom popover (desktop only)
- [ ] Manual: chat release panel → verify ⋯ menu and no Inspect action