### PR TITLE
ci: add Golden Path (PR) launch-gate job

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -304,7 +304,7 @@ Generated from `.github/ci-harness/manifest.json`. Do not hand-edit this block; 
 | --- | --- | --- |
 | Fast Gate | Cheap deterministic checks required for every merge candidate. | `ci-fast`, `Unit Tests` |
 | Structural Contract | Mechanical architecture, workflow, docs, and repo-rule checks. | `Structural Contract`, `CI Risk Classifier` |
-| Risk-Triggered Smoke | Focused smoke validation for sensitive auth, billing, DB, config, and agent-control-plane changes. | `E2E Smoke (PR Fast Feedback)` |
+| Risk-Triggered Smoke | Focused smoke validation for sensitive auth, billing, DB, config, and agent-control-plane changes. | `E2E Smoke (PR Fast Feedback)`, `Golden Path (PR)` |
 | Preview Evidence | Preview deploys and visual/a11y/performance evidence for review. | `Build (public routes)`, `Lighthouse (public routes PR)`, `Lighthouse (dashboard PR)`, `Lighthouse (onboarding PR)`, `Lighthouse (admin PR)`, `Preview Deploy (PR)` |
 | Main Deploy | Post-merge staging, canary, production promotion, and deploy-health gates. | none |
 | Scheduled Cleanup | Report-first cleanup loops for flakes, coverage drift, harness health, and main-CI repair. | none |
@@ -325,6 +325,7 @@ Generated from `.github/ci-harness/manifest.json`. Do not hand-edit this block; 
 | `Lighthouse (onboarding PR)` | preview-evidence | `pnpm --filter=@jovie/web run test:lighthouse:onboarding:pr` |
 | `Lighthouse (admin PR)` | preview-evidence | `pnpm --filter=@jovie/web run test:lighthouse:admin:pr` |
 | `E2E Smoke (PR Fast Feedback)` | risk-triggered-smoke | `pnpm run test:web:smoke` |
+| `Golden Path (PR)` | risk-triggered-smoke | `doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test:e2e:golden-path:ci` |
 | `Preview Deploy (PR)` | preview-evidence | `pnpm run build:web` |
 
 ### Risk-Triggered Evidence

--- a/.github/ci-harness/manifest.json
+++ b/.github/ci-harness/manifest.json
@@ -128,6 +128,14 @@
       "remediation": "A sensitive change requires smoke evidence. Use the Playwright report and keep full E2E out of the default PR path."
     },
     {
+      "id": "ci-golden-path",
+      "name": "Golden Path (PR)",
+      "tier": "risk-triggered-smoke",
+      "mergeGate": true,
+      "nextLocalCommand": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test:e2e:golden-path:ci",
+      "remediation": "The launch-gate golden path (signup -> onboarding -> import -> live public profile) regressed. Reproduce locally with the pinned Doppler command; do not weaken the spec to pass."
+    },
+    {
       "id": "ci-pr-vercel-preview",
       "name": "Preview Deploy (PR)",
       "tier": "preview-evidence",

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -137,7 +137,7 @@ Generated from `.github/ci-harness/manifest.json`. Do not hand-edit this block; 
 | --- | --- | --- |
 | Fast Gate | Cheap deterministic checks required for every merge candidate. | `ci-fast`, `Unit Tests` |
 | Structural Contract | Mechanical architecture, workflow, docs, and repo-rule checks. | `Structural Contract`, `CI Risk Classifier` |
-| Risk-Triggered Smoke | Focused smoke validation for sensitive auth, billing, DB, config, and agent-control-plane changes. | `E2E Smoke (PR Fast Feedback)` |
+| Risk-Triggered Smoke | Focused smoke validation for sensitive auth, billing, DB, config, and agent-control-plane changes. | `E2E Smoke (PR Fast Feedback)`, `Golden Path (PR)` |
 | Preview Evidence | Preview deploys and visual/a11y/performance evidence for review. | `Build (public routes)`, `Lighthouse (public routes PR)`, `Lighthouse (dashboard PR)`, `Lighthouse (onboarding PR)`, `Lighthouse (admin PR)`, `Preview Deploy (PR)` |
 | Main Deploy | Post-merge staging, canary, production promotion, and deploy-health gates. | none |
 | Scheduled Cleanup | Report-first cleanup loops for flakes, coverage drift, harness health, and main-CI repair. | none |
@@ -158,6 +158,7 @@ Generated from `.github/ci-harness/manifest.json`. Do not hand-edit this block; 
 | `Lighthouse (onboarding PR)` | preview-evidence | `pnpm --filter=@jovie/web run test:lighthouse:onboarding:pr` |
 | `Lighthouse (admin PR)` | preview-evidence | `pnpm --filter=@jovie/web run test:lighthouse:admin:pr` |
 | `E2E Smoke (PR Fast Feedback)` | risk-triggered-smoke | `pnpm run test:web:smoke` |
+| `Golden Path (PR)` | risk-triggered-smoke | `doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test:e2e:golden-path:ci` |
 | `Preview Deploy (PR)` | preview-evidence | `pnpm run build:web` |
 
 ### Risk-Triggered Evidence

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
       run_promptfoo_evals: ${{ steps.detect.outputs.run_promptfoo_evals }}
       run_golden_eval_set: ${{ steps.detect.outputs.run_golden_eval_set }}
       run_e2e: ${{ steps.detect.outputs.run_e2e }}
+      run_golden_path: ${{ steps.detect.outputs.run_golden_path }}
       run_drizzle: ${{ steps.detect.outputs.run_drizzle }}
       run_neon: ${{ steps.detect.outputs.run_neon }}
       has_code_changes: ${{ steps.detect.outputs.has_code_changes }}
@@ -99,7 +100,7 @@ jobs:
         if: steps.graphite.outputs.skip == 'true'
         run: |
           echo "Graphite CI optimizer requested skip — CI will be skipped."
-          for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_drizzle run_neon has_code_changes; do
+          for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_golden_path run_drizzle run_neon has_code_changes; do
             echo "$t=false" >> "$GITHUB_OUTPUT"
           done
 
@@ -120,7 +121,7 @@ jobs:
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # Manual dispatch: run everything
             echo "Manual dispatch: running all checks"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_drizzle run_neon has_code_changes; do
+            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_golden_path run_drizzle run_neon has_code_changes; do
               echo "$t=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -138,7 +139,7 @@ jobs:
             echo "has_code_changes=true" >> "$GITHUB_OUTPUT"
             echo "run_promptfoo_evals=true" >> "$GITHUB_OUTPUT"
             echo "run_golden_eval_set=true" >> "$GITHUB_OUTPUT"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_e2e run_drizzle run_neon; do
+            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_e2e run_golden_path run_drizzle run_neon; do
               echo "$t=false" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -149,7 +150,7 @@ jobs:
           # into Neon, Lighthouse, or Playwright work by label accident.
           if [[ "$FULL_CI_LABEL" == "true" ]]; then
             echo "Forcing full CI run due to 'testing' label"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_drizzle run_neon has_code_changes; do
+            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_golden_path run_drizzle run_neon has_code_changes; do
               echo "$t=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -159,7 +160,7 @@ jobs:
           if ! echo "$CHANGED_FILES" | grep -q -E '^\.github/' &&
             ! echo "$CHANGED_FILES" | grep -q -v -E '\.(md|txt)$'; then
             echo "Only documentation files changed"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_drizzle run_neon has_code_changes; do
+            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_golden_path run_drizzle run_neon has_code_changes; do
               echo "$t=false" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -239,6 +240,18 @@ jobs:
             echo "run_e2e=false" >> "$GITHUB_OUTPUT"
           fi
 
+          # Launch-gate golden path (JOV-3758). Mirrors docs/launch/LAUNCH_GATES.md's
+          # path list: onboarding routes/components/libs, auth signup/signin entrypoints,
+          # dashboard shell/releases flows, billing/checkout API routes used by the golden
+          # path, golden-path Playwright specs + helpers, and launch-gate CI/Lighthouse/perf
+          # config. Docs-only changes never reach here (handled by the docs-only guard above).
+          LAUNCH_GATE_PATTERN='^(apps/web/app/onboarding/|apps/web/components/features/onboarding/|apps/web/components/features/dashboard/organisms/onboarding|apps/web/components/features/dashboard/organisms/apple-style-onboarding|apps/web/lib/onboarding/|apps/web/app/\(auth\)/|apps/web/app/signin/|apps/web/app/signup/|apps/web/app/sign-in/|apps/web/app/sign-up/|apps/web/app/app/\(shell\)/dashboard/|apps/web/app/app/\(shell\)/layout\.tsx|apps/web/components/features/dashboard/|apps/web/lib/releases/|apps/web/app/api/stripe/|apps/web/app/api/billing/|apps/web/app/api/checkout/|apps/web/lib/stripe/|apps/web/tests/e2e/golden-path\.spec\.ts|apps/web/tests/helpers/clerk-auth\.ts|apps/web/tests/global-setup\.ts|apps/web/playwright\.config\.ts|\.github/workflows/ci\.yml|apps/web/\.lighthouserc\.dashboard\.pr\.json|apps/web/\.lighthouserc\.onboarding\.pr\.json|docs/launch/LAUNCH_GATES\.md|apps/web/package.*\.json|package.*\.json)'
+          if echo "$CHANGED_FILES" | grep -q -E "$LAUNCH_GATE_PATTERN"; then
+            echo "run_golden_path=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_golden_path=false" >> "$GITHUB_OUTPUT"
+          fi
+
           # Drizzle paths
           DRIZZLE_PATTERN='^(apps/web/drizzle/|apps/web/lib/db/|apps/web/drizzle\.config\.ts|drizzle\.kit\.(m?js|ts))'
           if echo "$CHANGED_FILES" | grep -q -E "$DRIZZLE_PATTERN"; then
@@ -263,6 +276,7 @@ jobs:
           if [[ "$IS_FORK" == "true" ]]; then
             echo "Fork PR: disabling e2e and build"
             echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+            echo "run_golden_path=false" >> "$GITHUB_OUTPUT"
             echo "run_build=false" >> "$GITHUB_OUTPUT"
             echo "run_public_lighthouse=false" >> "$GITHUB_OUTPUT"
             echo "run_dashboard_lighthouse=false" >> "$GITHUB_OUTPUT"
@@ -3059,6 +3073,186 @@ jobs:
 
       - name: Cleanup ephemeral Neon branch
         if: always() && steps.check_changes.outputs.run_full_ci == 'true' && needs.neon-db.result != 'success' && steps.neon-branch.outputs.branch_id != ''
+        continue-on-error: true
+        run: |
+          curl -sS -X DELETE \
+            -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            "https://console.neon.tech/api/v2/projects/${{ vars.NEON_PROJECT_ID }}/branches/${{ steps.neon-branch.outputs.branch_id }}"
+
+  ci-golden-path:
+    name: Golden Path (PR)
+    environment: Preview – jovie
+    # Launch-gate job (JOV-3758): full signup -> onboarding -> music import -> live
+    # public profile -> Stripe checkout journey against REAL Clerk + an ephemeral
+    # Neon branch. Required for launch-candidate PRs per docs/launch/LAUNCH_GATES.md.
+    # Unlike ci-e2e-smoke this must NOT set NEXT_PUBLIC_CLERK_MOCK or
+    # E2E_USE_TEST_AUTH_BYPASS — those make golden-path.spec.ts self-skip.
+    # Path-triggered (not always-on): the spec has a 600s timeout, so always-on would
+    # blow the CI budget and churn the Clerk dev-instance 100-user cap.
+    needs: [ci-fast, ci-path-changes, ci-risk-classifier, ci-build-public, neon-db]
+    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'main' || startsWith(github.event.pull_request.base.ref, 'gtmq_')) && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-build-public.outputs.has_artifact == 'true' && (needs.ci-path-changes.outputs.run_golden_path == 'true' || contains(github.event.pull_request.labels.*.name, 'launch-candidate') || contains(github.event.pull_request.labels.*.name, 'testing')) && (needs.neon-db.result == 'success' || needs.neon-db.result == 'skipped'))) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # Constant group so at most ONE golden-path job runs repo-wide. This serializes
+    # both the Neon endpoint pool AND the Clerk dev instance: the spec's
+    # purgeStaleClerkTestUsers deletes ALL gp-* users, so two concurrent runs would
+    # delete each other's sessions and flake. Do not parameterize this group.
+    concurrency:
+      group: neon-endpoint-pool-ci-golden-path
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Download Neon DB connection artifact
+        if: needs.neon-db.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: neon-db-connection-${{ github.run_id }}
+          path: /tmp/neon-db-connection
+
+      - name: Resolve DATABASE_URL from Neon artifact
+        if: needs.neon-db.result == 'success'
+        id: resolve-golden-path-neon-db-url
+        uses: ./.github/actions/resolve-neon-database-url
+        with:
+          connection_file: /tmp/neon-db-connection/connection.json
+          candidate_json_key: db_url
+          fallback_json_key: db_url_pooled
+
+      - name: Export DATABASE_URL (shared ephemeral branch)
+        if: needs.neon-db.result == 'success'
+        run: echo "DATABASE_URL=${{ steps.resolve-golden-path-neon-db-url.outputs.database_url }}" >> "$GITHUB_ENV"
+
+      - name: Create ephemeral Neon database branch (with retry)
+        id: neon-branch
+        if: needs.neon-db.result != 'success'
+        uses: ./.github/actions/neon-create-branch-with-retry
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: golden-path-${{ github.run_id }}-${{ github.run_attempt }}
+          role: neondb_owner
+          api_key: ${{ secrets.NEON_API_KEY }}
+          protected_branches: main,development,preview,br-main,br-production
+
+      - name: Resolve DATABASE_URL (fallback Neon ephemeral)
+        if: needs.neon-db.result != 'success'
+        id: resolve-golden-path-fallback-neon-db-url
+        uses: ./.github/actions/resolve-neon-database-url
+        with:
+          candidate_url: ${{ steps.neon-branch.outputs.db_url }}
+          fallback_candidate_url: ${{ steps.neon-branch.outputs.db_url_pooled }}
+          credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
+          credential_fallback_url: ${{ secrets.DATABASE_URL }}
+
+      - name: Export DATABASE_URL (fallback ephemeral branch)
+        if: needs.neon-db.result != 'success'
+        run: echo "DATABASE_URL=${{ steps.resolve-golden-path-fallback-neon-db-url.outputs.database_url }}" >> "$GITHUB_ENV"
+
+      - name: Run migrations (ephemeral Neon)
+        run: pnpm --filter=@jovie/web run drizzle:migrate:ci
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+          NODE_ENV: test
+          GIT_BRANCH: pr-${{ github.event.pull_request.number }}
+          ALLOW_PROD_MIGRATIONS: 'true'
+
+      - name: Cache Playwright Browsers
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-chromium-
+
+      - name: Install Playwright (Chromium)
+        run: pnpm --filter=@jovie/web exec playwright install chromium
+
+      - name: Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextjs-build-${{ github.run_id }}
+          path: /tmp/nextjs-build-download
+
+      - name: Extract build artifact
+        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+
+      - name: Run Golden Path (Chromium, real Clerk)
+        run: |
+          cd apps/web
+
+          if [ ! -f .next/standalone/apps/web/server.js ]; then
+            echo "::error::Standalone server not found — ci-build-public artifact is required for the golden path"
+            exit 1
+          fi
+
+          # Standalone production server (not next dev) to avoid CI OOM/timeouts.
+          # REAL Clerk: no NEXT_PUBLIC_CLERK_MOCK / E2E_USE_TEST_AUTH_BYPASS here —
+          # those flags make golden-path.spec.ts self-skip.
+          export DATABASE_URL="${{ env.DATABASE_URL }}"
+          export NODE_ENV=test
+          export CI=true
+          export VERCEL_ENV=development
+          export NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}"
+          export CLERK_SECRET_KEY="${{ secrets.CLERK_SECRET_KEY }}"
+          export FLAGS_SECRET="${{ secrets.FLAGS_SECRET }}"
+          export SPOTIFY_CLIENT_ID="${{ secrets.SPOTIFY_CLIENT_ID }}"
+          export SPOTIFY_CLIENT_SECRET="${{ secrets.SPOTIFY_CLIENT_SECRET }}"
+          export MUSICFETCH_API_TOKEN="${{ secrets.MUSICFETCH_API_TOKEN }}"
+          export UPSTASH_REDIS_REST_URL="${{ secrets.UPSTASH_REDIS_REST_URL }}"
+          export UPSTASH_REDIS_REST_TOKEN="${{ secrets.UPSTASH_REDIS_REST_TOKEN }}"
+
+          PORT=3100 node .next/standalone/apps/web/server.js &
+          SERVER_PID=$!
+          trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
+
+          SERVER_READY=false
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3100 > /dev/null 2>&1; then
+              SERVER_READY=true
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "$SERVER_READY" = "false" ]; then
+            echo "::error::Standalone server failed to start within 30s"
+            exit 1
+          fi
+
+          cd "$GITHUB_WORKSPACE"
+          BASE_URL=http://localhost:3100 E2E_SKIP_WEB_SERVER=1 pnpm --filter @jovie/web run test:e2e:golden-path:ci
+        env:
+          # Duplicated on the Playwright-runner process: global-setup calls clerkSetup
+          # and the spec queries the DB + Clerk API directly, so these must be present
+          # for both the server and the runner. UPSTASH_* is optional (spec degrades to
+          # the in-memory rate-limit fallback when unset).
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          FLAGS_SECRET: ${{ secrets.FLAGS_SECRET }}
+          SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
+          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+          MUSICFETCH_API_TOKEN: ${{ secrets.MUSICFETCH_API_TOKEN }}
+          UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+          UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+
+      - name: Upload Playwright Artifacts on Failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: golden-path-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
+          retention-days: 3
+
+      - name: Cleanup ephemeral Neon branch
+        if: always() && needs.neon-db.result != 'success' && steps.neon-branch.outputs.branch_id != ''
         continue-on-error: true
         run: |
           curl -sS -X DELETE \

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -254,7 +254,7 @@ Generated from `.github/ci-harness/manifest.json`. Do not hand-edit this block; 
 | --- | --- | --- |
 | Fast Gate | Cheap deterministic checks required for every merge candidate. | `ci-fast`, `Unit Tests` |
 | Structural Contract | Mechanical architecture, workflow, docs, and repo-rule checks. | `Structural Contract`, `CI Risk Classifier` |
-| Risk-Triggered Smoke | Focused smoke validation for sensitive auth, billing, DB, config, and agent-control-plane changes. | `E2E Smoke (PR Fast Feedback)` |
+| Risk-Triggered Smoke | Focused smoke validation for sensitive auth, billing, DB, config, and agent-control-plane changes. | `E2E Smoke (PR Fast Feedback)`, `Golden Path (PR)` |
 | Preview Evidence | Preview deploys and visual/a11y/performance evidence for review. | `Build (public routes)`, `Lighthouse (public routes PR)`, `Lighthouse (dashboard PR)`, `Lighthouse (onboarding PR)`, `Lighthouse (admin PR)`, `Preview Deploy (PR)` |
 | Main Deploy | Post-merge staging, canary, production promotion, and deploy-health gates. | none |
 | Scheduled Cleanup | Report-first cleanup loops for flakes, coverage drift, harness health, and main-CI repair. | none |
@@ -275,6 +275,7 @@ Generated from `.github/ci-harness/manifest.json`. Do not hand-edit this block; 
 | `Lighthouse (onboarding PR)` | preview-evidence | `pnpm --filter=@jovie/web run test:lighthouse:onboarding:pr` |
 | `Lighthouse (admin PR)` | preview-evidence | `pnpm --filter=@jovie/web run test:lighthouse:admin:pr` |
 | `E2E Smoke (PR Fast Feedback)` | risk-triggered-smoke | `pnpm run test:web:smoke` |
+| `Golden Path (PR)` | risk-triggered-smoke | `doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test:e2e:golden-path:ci` |
 | `Preview Deploy (PR)` | preview-evidence | `pnpm run build:web` |
 
 ### Risk-Triggered Evidence


### PR DESCRIPTION
## Summary

Implements the `Golden Path (PR)` launch-gate CI job that `docs/launch/LAUNCH_GATES.md` requires but that was never wired into `.github/workflows/ci.yml` (JOV-3758).

`ci-golden-path` runs `apps/web/tests/e2e/golden-path.spec.ts` (signup → onboarding → music import → live public profile → Stripe checkout) against **real Clerk** and an ephemeral Neon branch. It is modeled on `ci-e2e-smoke` with these deliberate differences:

- **Real Clerk, no mock/bypass.** It does NOT set `NEXT_PUBLIC_CLERK_MOCK` or `E2E_USE_TEST_AUTH_BYPASS` — those flags make `golden-path.spec.ts` self-skip. No `E2E_CLERK_ADMIN_*` is passed; the admin sub-check self-skips without creds (desired; the ephemeral DB has no admin row).
- **Env on both the server and the Playwright runner.** `global-setup.ts` calls `clerkSetup()` and the spec queries the DB + Clerk API directly, so `DATABASE_URL`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `FLAGS_SECRET`, `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `MUSICFETCH_API_TOKEN`, and (optional) `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` are exported for both.
- **Serves the standalone build on :3100** and runs `BASE_URL=http://localhost:3100 E2E_SKIP_WEB_SERVER=1 pnpm --filter @jovie/web run test:e2e:golden-path:ci`.
- **Constant concurrency group** `neon-endpoint-pool-ci-golden-path` (`cancel-in-progress: false`) so at most ONE golden-path job runs repo-wide. This serializes the Neon endpoint pool AND the Clerk dev instance — the spec's `purgeStaleClerkTestUsers` deletes ALL `gp-*` users, so two concurrent runs would delete each other's sessions.
- **Path-triggered, not always-on.** A new `run_golden_path` output in `ci-path-changes` mirrors the LAUNCH_GATES.md path list (onboarding/auth/dashboard-shell/releases/billing routes, golden-path spec + helpers, launch-gate CI/Lighthouse config). Docs-only never triggers it. The job also fires on the `launch-candidate` or `testing` label, or `workflow_dispatch`.
- **Separate required check.** `ci-golden-path` is intentionally NOT added to `PR Ready`'s `needs`/aggregation — LAUNCH_GATES.md lists it as its own required launch-gate job.
- Manifest entry added to `.github/ci-harness/manifest.json` (`tier: risk-triggered-smoke`, `mergeGate: true`); generated docs regenerated via `pnpm ci:harness:docs`.

## Verification

- `pnpm ci:harness:check` — PASS (manifest valid; generated docs current after regen).
- `pnpm ci:merge-queue:check` — PASS (required aggregates unchanged).
- `actionlint .github/workflows/ci.yml` — exit 0 (only the pre-existing benign `SC2034 i appears unused` shellcheck note in the readiness loop, identical to every other job).

## Secrets pre-flight

All required secrets exist in the `Preview – jovie` environment (verified via `gh api`): `DATABASE_URL`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `FLAGS_SECRET`, `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `MUSICFETCH_API_TOKEN`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`. `NEON_API_KEY` + `vars.NEON_PROJECT_ID` are already used by the sibling smoke job.

## Landmine check: baked-in Clerk key

`ci-build-public` builds the standalone artifact with `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}` (ci.yml ~L1065) — the SAME real dev key this job pairs with `CLERK_SECRET_KEY`. So the baked publishable key matches the runtime secret key; no separate build step is needed. (The smoke job only enters mock mode because it additionally sets `NEXT_PUBLIC_CLERK_MOCK=1` at runtime, which this job deliberately omits.)

## Merge blocker — REBASE required

**This PR must be REBASED onto `main` after JOV-3757 (spec realignment) merges, before being marked ready.** Until then the job would exercise the old checkout-based golden-path spec, which may fail without Stripe secrets in the Preview environment. Since `ci.yml` matches the launch-gate path list, the new job self-triggers on this PR — that run is the acceptance evidence after the rebase.

bug-to-test: waived — CI-configuration change.

Refs JOV-3758.

<!-- linear-issue-id:9f05572b-9f30-4f4c-8827-bc4b9aa5f690 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
