### PR TITLE
test(e2e): realign golden path to reverse-trial activation — live public profile, not checkout

### DIFF
--- a/apps/web/tests/e2e/billing-checkout.spec.ts
+++ b/apps/web/tests/e2e/billing-checkout.spec.ts
@@ -1,0 +1,273 @@
+import { setupClerkTestingToken } from '@clerk/testing/playwright';
+import { expect, type Page, test } from '@playwright/test';
+import { APP_ROUTES } from '@/constants/routes';
+import { ensureSignedInUser } from '../helpers/clerk-auth';
+
+/**
+ * Billing Checkout E2E — Money-path regression coverage
+ *
+ * Checkout is a post-activation upgrade path under the reverse-trial model
+ * (no card at signup) — kept as money-path regression coverage,
+ * intentionally NOT part of the new-artist golden path (JOV-3757). The
+ * golden path's "first value" moment is a live public profile, not a
+ * paywall; see golden-path.spec.ts for that journey.
+ *
+ * Uses the standing E2E test user (via ensureSignedInUser) rather than
+ * fresh-signup machinery, since this test only exercises the authenticated
+ * checkout API surface.
+ */
+
+/* ------------------------------------------------------------------ */
+/*  Environment gates                                                   */
+/* ------------------------------------------------------------------ */
+
+const REQUIRED_ENV = {
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+  CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
+  DATABASE_URL: process.env.DATABASE_URL,
+} as const;
+
+const IS_LOCAL_AUTH_BYPASS =
+  process.env.E2E_USE_TEST_AUTH_BYPASS === '1' ||
+  process.env.NEXT_PUBLIC_CLERK_MOCK === '1' ||
+  process.env.NEXT_PUBLIC_CLERK_PROXY_DISABLED === '1';
+
+function hasRealEnv(): boolean {
+  return Object.values(REQUIRED_ENV).every(
+    v => v && !v.includes('mock') && !v.includes('dummy')
+  );
+}
+
+/** Block fire-and-forget tracking calls that trigger slow Turbopack cascades. */
+async function interceptTrackingCalls(page: Page) {
+  await page.route('**/api/profile/view', r =>
+    r.fulfill({ status: 200, body: '{}' })
+  );
+  await page.route('**/api/audience/visit', r =>
+    r.fulfill({ status: 200, body: '{}' })
+  );
+  await page.route('**/api/track', r => r.fulfill({ status: 200, body: '{}' }));
+}
+
+interface CheckoutAttempt {
+  readonly status: number;
+  readonly url: string | null;
+  readonly body: string;
+}
+
+async function refreshClerkSessionForApi(page: Page): Promise<boolean> {
+  // Re-arm the Clerk testing token for this retry path (a fresh call is
+  // required after a 401 — this is deliberate, not leftover duplication
+  // from the initial setupClerkTestingToken call in the test body). Log on
+  // failure so a broken setup surfaces here rather than as a later 401.
+  await setupClerkTestingToken({ page }).catch(err => {
+    console.warn(
+      '[billing-checkout] setupClerkTestingToken failed during session refresh:',
+      err instanceof Error ? err.message : String(err)
+    );
+  });
+  await page.goto(APP_ROUTES.CHAT, {
+    waitUntil: 'domcontentloaded',
+    timeout: 120_000,
+  });
+
+  if (/\/sign-?in/.test(page.url())) {
+    return false;
+  }
+
+  return page
+    .evaluate(async () => {
+      const clerk = (window as any).Clerk;
+      if (!clerk) return true;
+      if (!clerk.loaded) {
+        await new Promise<void>(resolve => {
+          const startedAt = Date.now();
+          const tick = () => {
+            if (clerk.loaded || Date.now() - startedAt > 15_000) {
+              resolve();
+              return;
+            }
+            window.setTimeout(tick, 100);
+          };
+          tick();
+        });
+      }
+
+      if (!clerk.user?.id || !clerk.session) return false;
+      await clerk.session.getToken({ skipCache: true }).catch(() => null);
+      return true;
+    })
+    .catch(() => false);
+}
+
+async function createCheckoutSessionFromBrowser(
+  page: Page,
+  priceId: string
+): Promise<CheckoutAttempt> {
+  return page.evaluate(async targetPriceId => {
+    const clerk = (window as any).Clerk;
+    const token = await clerk?.session
+      ?.getToken({ skipCache: true })
+      .catch(() => null);
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+    };
+    if (token) {
+      headers.authorization = `Bearer ${token}`;
+    }
+
+    const response = await fetch('/api/stripe/checkout', {
+      method: 'POST',
+      headers,
+      credentials: 'include',
+      body: JSON.stringify({ priceId: targetPriceId }),
+    });
+    const body = await response.text();
+    if (!response.ok) {
+      return { status: response.status, url: null, body };
+    }
+
+    const json = JSON.parse(body) as { url?: string };
+    return { status: response.status, url: json.url ?? null, body };
+  }, priceId);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test suite                                                          */
+/* ------------------------------------------------------------------ */
+
+test.describe('Billing Checkout: Stripe checkout session creation', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test.beforeEach(async ({ page }) => {
+    if (IS_LOCAL_AUTH_BYPASS) {
+      test.skip(true, 'Billing checkout requires real Clerk auth');
+    }
+    if (!hasRealEnv()) {
+      test.skip(true, 'Real Clerk/DB env vars not configured');
+    }
+    if (process.env.CLERK_TESTING_SETUP_SUCCESS !== 'true') {
+      test.skip(true, 'Clerk testing setup was not successful');
+    }
+    if (
+      !process.env.E2E_CLERK_USER_USERNAME ||
+      !(
+        process.env.E2E_CLERK_USER_USERNAME.includes('+clerk_test') ||
+        process.env.E2E_CLERK_USER_PASSWORD
+      )
+    ) {
+      test.skip(
+        true,
+        'E2E_CLERK_USER_USERNAME/PASSWORD not configured for standing test user'
+      );
+    }
+
+    await interceptTrackingCalls(page);
+  });
+
+  test('creates a Stripe checkout session for the Pro monthly plan', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+
+    await setupClerkTestingToken({ page });
+    await ensureSignedInUser(page);
+
+    // Get available pricing. Local Next can restart under memory pressure,
+    // so retry request-level ECONNRESET failures.
+    let pricingJson: {
+      pricingOptions?: Array<{
+        priceId?: string;
+        description?: string;
+        amount?: number;
+      }>;
+      options?: Array<{
+        priceId?: string;
+        description?: string;
+        amount?: number;
+      }>;
+    } | null = null;
+
+    await expect
+      .poll(
+        async () => {
+          try {
+            const pricingResponse = await page.request.get(
+              '/api/stripe/pricing-options',
+              { timeout: 60_000 }
+            );
+            if (!pricingResponse.ok()) {
+              return `http-${pricingResponse.status()}`;
+            }
+
+            pricingJson = (await pricingResponse.json()) as NonNullable<
+              typeof pricingJson
+            >;
+            return 'ready';
+          } catch {
+            return 'request-error';
+          }
+        },
+        { timeout: 180_000, intervals: [2_000, 5_000, 10_000] }
+      )
+      .toBe('ready');
+
+    const allOptions =
+      pricingJson!.pricingOptions ?? pricingJson!.options ?? [];
+
+    // Find the primary paid Pro monthly plan specifically.
+    const proMonthlyOption = allOptions.find(
+      o => o.description === 'Pro' && o.amount === 3900 && o.priceId
+    );
+    expect(
+      proMonthlyOption,
+      'Pro monthly pricing option not returned — billing misconfigured'
+    ).toBeTruthy();
+
+    const proMonthlyPriceId = proMonthlyOption!.priceId!;
+    expect(
+      proMonthlyOption!.amount,
+      'Pro monthly price should be $39/mo (3900 cents)'
+    ).toBe(3900);
+
+    // Create checkout session with Pro monthly price
+    let checkoutUrl: string | null = null;
+    await expect
+      .poll(
+        async () => {
+          try {
+            let checkoutAttempt = await createCheckoutSessionFromBrowser(
+              page,
+              proMonthlyPriceId
+            );
+
+            if (checkoutAttempt.status === 401) {
+              const refreshed = await refreshClerkSessionForApi(page);
+              if (!refreshed) return 'http-401';
+              checkoutAttempt = await createCheckoutSessionFromBrowser(
+                page,
+                proMonthlyPriceId
+              );
+            }
+
+            if (checkoutAttempt.status < 200 || checkoutAttempt.status >= 300) {
+              return `http-${checkoutAttempt.status}`;
+            }
+
+            checkoutUrl = checkoutAttempt.url;
+            return checkoutUrl ?? 'missing-url';
+          } catch {
+            return 'request-error';
+          }
+        },
+        { timeout: 180_000, intervals: [2_000, 5_000, 10_000] }
+      )
+      .toMatch(/^https:\/\/checkout\.stripe\.com\//);
+
+    expect(
+      checkoutUrl,
+      'Stripe checkout URL missing — checkout session not created'
+    ).toMatch(/^https:\/\/checkout\.stripe\.com\//);
+  });
+});

--- a/apps/web/tests/e2e/golden-path.spec.ts
+++ b/apps/web/tests/e2e/golden-path.spec.ts
@@ -1,6 +1,6 @@
 import { setupClerkTestingToken } from '@clerk/testing/playwright';
 import { neon } from '@neondatabase/serverless';
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import { APP_ROUTES } from '@/constants/routes';
 import {
   ensureSignedInUser,
@@ -10,13 +10,18 @@ import {
 } from '../helpers/clerk-auth';
 
 /**
- * Golden Path E2E — Signup -> Onboarding -> Music Fetch -> Stripe
+ * Golden Path E2E — Signup -> Onboarding -> Music Fetch -> Live Profile
  *
  * Tests the complete new-user journey end to end with REAL data:
  * - No mocks for music fetch
  * - No pre-authenticated state
  * - Real Clerk auth (test environment)
- * - Real Stripe checkout session (test mode)
+ *
+ * Jovie's pricing is a 14-day reverse trial with NO card required at signup
+ * (see docs/PRICING-PHILOSOPHY.md), so the golden path's "first value" moment
+ * is the artist's public profile going live with imported music — not a
+ * paywall. Checkout is a post-activation upgrade path, not part of this
+ * journey; it is covered separately by billing-checkout.spec.ts (JOV-3757).
  *
  * Test artist: "Tim White" (~50 releases, deterministic)
  */
@@ -288,80 +293,6 @@ async function interceptTrackingCalls(page: Page) {
   await page.route('**/api/track', r => r.fulfill({ status: 200, body: '{}' }));
 }
 
-interface CheckoutAttempt {
-  readonly status: number;
-  readonly url: string | null;
-  readonly body: string;
-}
-
-async function refreshClerkSessionForApi(page: Page): Promise<boolean> {
-  await setupClerkTestingToken({ page }).catch(() => {});
-  await page.goto('/app/chat', {
-    waitUntil: 'domcontentloaded',
-    timeout: 120_000,
-  });
-
-  if (/\/sign-?in/.test(page.url())) {
-    return false;
-  }
-
-  return page
-    .evaluate(async () => {
-      const clerk = (window as any).Clerk;
-      if (!clerk) return true;
-      if (!clerk.loaded) {
-        await new Promise<void>(resolve => {
-          const startedAt = Date.now();
-          const tick = () => {
-            if (clerk.loaded || Date.now() - startedAt > 15_000) {
-              resolve();
-              return;
-            }
-            window.setTimeout(tick, 100);
-          };
-          tick();
-        });
-      }
-
-      if (!clerk.user?.id || !clerk.session) return false;
-      await clerk.session.getToken({ skipCache: true }).catch(() => null);
-      return true;
-    })
-    .catch(() => false);
-}
-
-async function createCheckoutSessionFromBrowser(
-  page: Page,
-  priceId: string
-): Promise<CheckoutAttempt> {
-  return page.evaluate(async targetPriceId => {
-    const clerk = (window as any).Clerk;
-    const token = await clerk?.session
-      ?.getToken({ skipCache: true })
-      .catch(() => null);
-    const headers: Record<string, string> = {
-      'content-type': 'application/json',
-    };
-    if (token) {
-      headers.authorization = `Bearer ${token}`;
-    }
-
-    const response = await fetch('/api/stripe/checkout', {
-      method: 'POST',
-      headers,
-      credentials: 'include',
-      body: JSON.stringify({ priceId: targetPriceId }),
-    });
-    const body = await response.text();
-    if (!response.ok) {
-      return { status: response.status, url: null, body };
-    }
-
-    const json = JSON.parse(body) as { url?: string };
-    return { status: response.status, url: json.url ?? null, body };
-  }, priceId);
-}
-
 /**
  * Create a brand-new Clerk test user session.
  * Uses `+clerk_test` email suffix which auto-verifies in Clerk test mode.
@@ -473,7 +404,7 @@ async function createFreshUser(page: import('@playwright/test').Page) {
 /*  Test suite                                                          */
 /* ------------------------------------------------------------------ */
 
-test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Stripe', () => {
+test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Live Profile', () => {
   test.describe.configure({ mode: 'serial' });
 
   // Fresh browser — no inherited auth state
@@ -497,7 +428,7 @@ test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Stripe', () =
     await interceptTrackingCalls(page);
   });
 
-  test('complete user journey from signup to paid subscription', async ({
+  test('complete user journey from signup to live public profile', async ({
     page,
     browser,
   }) => {
@@ -691,14 +622,9 @@ test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Stripe', () =
       console.log('[golden-path] Profile DB check:', JSON.stringify(check));
     }
 
-    // Verify DSP links are persisted by checking the DB directly.
-    // We can't render the public listen page in this test because:
-    // 1. The fire-and-forget Spotify import saturates the Neon WebSocket pool
-    // 2. The proxy middleware needs a full DB query to check user state
-    // 3. Combined, this causes page loads to hang/timeout
-    //
-    // Instead, we hard-assert the spotify_url was saved to the profile,
-    // which is the prerequisite for DSP buttons rendering on the listen page.
+    // Verify DSP links are persisted by checking the DB directly first, as a
+    // fast, unambiguous signal before STEP 8 renders the public listen page.
+    // This hard-asserts the prerequisite for DSP buttons rendering there.
     {
       const dbUrl = process.env.DATABASE_URL!;
       const sql = neon(dbUrl);
@@ -770,103 +696,57 @@ test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Stripe', () =
     }
 
     // ──────────────────────────────────────────────────────────────────
-    // STEP 8: Stripe checkout session creation
+    // STEP 8: First value — the artist's public profile is LIVE
     // ──────────────────────────────────────────────────────────────────
+    // Reverse-trial pricing means there is no paywall between signup and
+    // value: the artist's first "win" is a live, public, shareable profile
+    // with their music imported. Render it as an anonymous fan would —
+    // fresh browser context, no auth — the way a real fan clicking a link
+    // in bio would land here.
+    const fanContext = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    const fanPage = await fanContext.newPage();
+    await interceptTrackingCalls(fanPage);
 
-    // Get available pricing. Local Next can restart under memory pressure after
-    // MusicFetch enrichment, so retry request-level ECONNRESET failures.
-    let pricingJson: {
-      pricingOptions?: Array<{
-        priceId?: string;
-        description?: string;
-        amount?: number;
-      }>;
-      options?: Array<{
-        priceId?: string;
-        description?: string;
-        amount?: number;
-      }>;
-    } | null = null;
+    try {
+      await expect(async () => {
+        const response = await fanPage.goto(`/${uniqueHandle}?mode=listen`, {
+          waitUntil: 'domcontentloaded',
+          timeout: 60_000,
+        });
+        expect(
+          response?.status() ?? 0,
+          'Public profile did not render live'
+        ).toBe(200);
 
-    await expect
-      .poll(
-        async () => {
-          try {
-            const pricingResponse = await page.request.get(
-              '/api/stripe/pricing-options',
-              { timeout: 60_000 }
-            );
-            if (!pricingResponse.ok()) {
-              return `http-${pricingResponse.status()}`;
-            }
+        // The h1 must render the imported artist's real display name (not
+        // just any non-empty heading), so this can't pass on a placeholder
+        // or unrelated page.
+        const h1 = fanPage.locator('h1').first();
+        await expect(h1, 'Artist name missing on public profile').toBeVisible({
+          timeout: 10_000,
+        });
+        await expect(
+          h1,
+          'Artist name does not match imported artist'
+        ).toHaveText(/tim white/i, { timeout: 10_000 });
 
-            pricingJson = (await pricingResponse.json()) as NonNullable<
-              typeof pricingJson
-            >;
-            return 'ready';
-          } catch {
-            return 'request-error';
-          }
-        },
-        { timeout: 180_000, intervals: [2_000, 5_000, 10_000] }
-      )
-      .toBe('ready');
-
-    const allOptions =
-      pricingJson!.pricingOptions ?? pricingJson!.options ?? [];
-
-    // Find the primary paid Pro monthly plan specifically.
-    const proMonthlyOption = allOptions.find(
-      o => o.description === 'Pro' && o.amount === 3900 && o.priceId
-    );
-    expect(
-      proMonthlyOption,
-      'Pro monthly pricing option not returned — billing misconfigured'
-    ).toBeTruthy();
-
-    const proMonthlyPriceId = proMonthlyOption!.priceId!;
-    expect(
-      proMonthlyOption!.amount,
-      'Pro monthly price should be $39/mo (3900 cents)'
-    ).toBe(3900);
-
-    // Create checkout session with Pro monthly price
-    let checkoutUrl: string | null = null;
-    await expect
-      .poll(
-        async () => {
-          try {
-            let checkoutAttempt = await createCheckoutSessionFromBrowser(
-              page,
-              proMonthlyPriceId
-            );
-
-            if (checkoutAttempt.status === 401) {
-              const refreshed = await refreshClerkSessionForApi(page);
-              if (!refreshed) return 'http-401';
-              checkoutAttempt = await createCheckoutSessionFromBrowser(
-                page,
-                proMonthlyPriceId
-              );
-            }
-
-            if (checkoutAttempt.status < 200 || checkoutAttempt.status >= 300) {
-              return `http-${checkoutAttempt.status}`;
-            }
-
-            checkoutUrl = checkoutAttempt.url;
-            return checkoutUrl ?? 'missing-url';
-          } catch {
-            return 'request-error';
-          }
-        },
-        { timeout: 180_000, intervals: [2_000, 5_000, 10_000] }
-      )
-      .toMatch(/^https:\/\/checkout\.stripe\.com\//);
-
-    expect(
-      checkoutUrl,
-      'Stripe checkout URL missing — checkout session not created'
-    ).toMatch(/^https:\/\/checkout\.stripe\.com\//);
+        // Verify the imported Spotify link is actually rendered — not just a
+        // generic tab bar, which would pass even if DSP import silently failed.
+        await expect(
+          fanPage
+            .locator('a[href*="spotify"]')
+            .filter({ visible: true })
+            .first(),
+          'No Spotify listen link — imported DSP content not live'
+        ).toBeVisible({ timeout: 10_000 });
+      }).toPass({
+        timeout: 180_000,
+        intervals: [5_000, 10_000, 20_000],
+      });
+    } finally {
+      await fanContext.close();
+    }
   });
 });


### PR DESCRIPTION
## What changed

Realigns `golden-path.spec.ts` with Jovie's actual pricing model (14-day reverse trial, no card required at signup — see `docs/PRICING-PHILOSOPHY.md`). The golden path's "first value" moment for a new artist is their public profile going live with imported music, not a Stripe paywall.

- **`golden-path.spec.ts`**: Removed the Stripe checkout section entirely — `CheckoutAttempt` interface, `refreshClerkSessionForApi`, `createCheckoutSessionFromBrowser`, and the old STEP 8 (pricing-options poll, Pro=$39/3900 assertion, checkout-session poll, `checkout.stripe.com` assertion). Replaced STEP 8 with **"First value — the artist's public profile is LIVE"**: an anonymous fan browser context (fresh `storageState`) visits `/${uniqueHandle}?mode=listen` and asserts HTTP 200, the artist's real name in a visible `h1`, and a visible Spotify listen link — proving DSP import actually made it to the public page, not just the DB. All other golden-path machinery (Clerk test-user purge, rate-limit clearing, DB user pre-seeding, Spotify URL DB write, admin dashboard sub-check, retries) is unchanged.
- **`billing-checkout.spec.ts`** (new): Relocated (not deleted) the Stripe checkout-session coverage, framed as a post-activation upgrade path. Uses the standing E2E test user via `ensureSignedInUser` + `setupClerkTestingToken` instead of fresh-signup machinery, since it only exercises the authenticated checkout API surface.

## Why

Golden path was asserting a flow (mandatory Stripe checkout during onboarding) that doesn't reflect the product: Jovie signup never requires a card, and checkout only becomes relevant well after activation. The old STEP 8 was also increasingly the flakiest part of the suite (pricing/checkout API polling) despite testing something outside the actual new-artist journey. Splitting it out gives the golden path a tighter, more honest "did onboarding actually work for a new user" signal, while keeping the money-path (checkout session creation) covered separately with a cheaper, more targeted test.

## Verification evidence

**Typecheck:** `pnpm --filter @jovie/web run typecheck -- --pretty false` — clean, exit 0.

**Biome:** `pnpm biome check --write apps/web/tests/e2e/golden-path.spec.ts apps/web/tests/e2e/billing-checkout.spec.ts` — no issues.

**Golden path — 3 consecutive green runs** (`doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test:e2e:golden-path:ci`):

```
Run 1:  1 skipped
        1 passed (1.4m)
Run 2:  1 skipped
        1 passed (1.6m)
Run 3:  1 skipped
        1 passed (1.3m)
```

(The "1 skipped" entry in each run is a sibling test in the same glob match, not this test self-skipping.)

**Billing checkout spec — ran (not self-skipped)** (`doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web exec playwright test tests/e2e/billing-checkout.spec.ts --project=chromium`):

```
[chromium] › tests/e2e/billing-checkout.spec.ts:169:7 › Billing Checkout: Stripe checkout session creation › creates a Stripe checkout session for the Pro monthly plan
1 skipped
1 passed (1.2m)
```

Confirmed the test actually executed the full checkout flow (pricing-options fetch, Pro/$39 assertion, checkout-session creation, `checkout.stripe.com` URL assertion) using the standing `E2E_CLERK_USER_USERNAME`/`PASSWORD` test user configured in this Doppler `dev` scope — it did not hit its own skip conditions.

**Clerk test-user cleanup:** `doppler run --project jovie-web --config dev -- pnpm tsx apps/web/scripts/cleanup-e2e-users.ts --force` — ran after all E2E runs, deleted 1 leftover Clerk user + DB record.

**CodeRabbit pre-commit review** (`coderabbit review --agent --type uncommitted --base main -c AGENTS.md`): raised one `major` finding — that `browser.newContext()` for the new fan context in STEP 8 might not inherit `baseURL`, breaking the relative `fanPage.goto(...)` call. Verified empirically this does not reproduce in this repo/Playwright-version combination: (1) all 3 live golden-path runs passed, including the fan-context navigation; (2) a standalone Playwright test confirmed `browser.newContext({ storageState })` (no explicit `baseURL`) correctly resolves relative `goto()` calls against the configured `baseURL` in this setup; (3) this exact pattern (`browser.newContext()` + relative `goto`) is already used in 12+ other places across `apps/web/tests/e2e/*.spec.ts`, including the pre-existing (unmodified) `adminContext` block later in this same file. Treating as a false positive rather than making a speculative change.

## Notes

- `bug-to-test: this PR is itself test coverage`
- Reference: JOV-3757

<!-- linear-issue-id:8b12529c-7405-4ddc-9a1d-d857962430bd -->