### PR TITLE
fix(ci): version-stamp test fixture breaks every month rollover

### DIFF
--- a/scripts/version-stamp.test.mjs
+++ b/scripts/version-stamp.test.mjs
@@ -158,10 +158,15 @@ test('main release path: real stamp keeps the version fan-out consistent (versio
     }
     void manifestGlobs;
 
-    const current = JSON.parse(
-      readFileSync(join(tmp, 'version.json'), 'utf-8')
-    ).version;
-    const [yy, mm] = current.split('.');
+    // Derive the seed from the CURRENT UTC calendar (matching
+    // computeNextVersion's yy/mm formatting), not from the copied repo's
+    // version.json. That file drifts every month as the repo gets stamped,
+    // so pinning the seed to whatever month it happens to say breaks this
+    // test on every month rollover (version-check.mjs validates against
+    // the real UTC calendar, not the fixture's origin month).
+    const now = new Date();
+    const yy = now.getUTCFullYear() % 100;
+    const mm = now.getUTCMonth() + 1;
     const target = `${yy}.${mm}.999`;
 
     execFileSync('node', ['scripts/version-stamp.mjs', '--set', target], {


### PR DESCRIPTION
## Root cause

`scripts/version-stamp.test.mjs`'s "main release path: real stamp keeps the version fan-out consistent (version:check passes)" test seeded its temp `version.json` target by copying the **live repo's** `version.json` and reusing its `yy.mm` (e.g. `26.6.61` → target `26.6.999`), rather than deriving the target from the actual current UTC calendar month.

`scripts/version-check.mjs` validates the fan-out against real wall-clock UTC time (`now.getUTCFullYear() % 100` / `now.getUTCMonth() + 1`), not against whatever month the copied `version.json` happens to say. Once the calendar rolled over to July while the repo's committed `version.json` was still on June (`26.6.61`), this test failed on every PR's Guardrails (proxy) job with:

```
Versioning audit failed:
- version.json (26.6.999) does not match current UTC calendar (26.7.x).
```

A classic month-rollover time bomb — the fixture was implicitly coupled to "whatever month `version.json` last got stamped," not to the calendar `version-check.mjs` actually validates against.

## Fix

Derive `yy`/`mm` from `new Date()` inside the test, using the exact same computation `version-check.mjs` and `computeNextVersion` use (`getUTCFullYear() % 100`, `getUTCMonth() + 1`, no zero-padding), instead of parsing the copied `version.json`. This makes the seed always match whatever month CI actually runs in, so the test is rollover-proof going forward.

I scanned the rest of the file for other hardcoded `26.6`/`2026-06` fixtures. All other occurrences (`computeNextVersion`, `setManifestVersion`, `promoteChangelog`, `planStamp` unit tests) pass a **fixed reference `Date` as an explicit argument** to the function under test — they never call `version-check.mjs` or depend on real wall-clock time, so they're correctly pinned and were left untouched. Only the one test that shells out to `version-check.mjs` (which reads `new Date()` internally) was broken.

## Verification

**Before fix** (reproduced with the exact CI invocation, `node --test scripts/version-stamp.test.mjs`, run 2026-07-02 UTC):
```
not ok 6 - main release path: real stamp keeps the version fan-out consistent (version:check passes)
  error: |-
    Command failed: node scripts/version-check.mjs
    Versioning audit failed:
    - version.json (26.6.999) does not match current UTC calendar (26.7.x).
# pass 6
# fail 1
```

**After fix**:
```
ok 6 - main release path: real stamp keeps the version fan-out consistent (version:check passes)
# tests 7
# pass 7
# fail 0
```

Also ran the full CI "Script unit tests" step invocation (all 5 files together): `32 pass / 0 fail`.

`pnpm biome check --write scripts/version-stamp.test.mjs` — clean, no changes needed.

bug-to-test: the fixed test IS the regression test (now rollover-proof — it derives its seed from the real UTC calendar every run, so it can't drift out of sync with `version-check.mjs` again).

Fixes JOV-3777.

<!-- linear-issue-id:3fcc9faa-1b10-40e2-90eb-249a21e4a87b -->