### PR TITLE
fix(ci): accept previous UTC month in version-check calendar audit

### DIFF
--- a/scripts/version-check.mjs
+++ b/scripts/version-check.mjs
@@ -32,10 +32,22 @@ if (!parsed) {
   const now = new Date();
   const yy = now.getUTCFullYear() % 100;
   const mm = now.getUTCMonth() + 1;
+  // Stamping is main-only and happens post-merge, so version.json lawfully
+  // lags the calendar between a UTC month rollover and the first release of
+  // the new month. Accept the previous month as a grace window; anything
+  // older is real CalVer drift (broke every branch on 2026-07-01 while main
+  // still read 26.6.x).
+  const prev = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1)
+  );
+  const prevYy = prev.getUTCFullYear() % 100;
+  const prevMm = prev.getUTCMonth() + 1;
+  const matchesCurrent = year === yy && month === mm;
+  const matchesPrevious = year === prevYy && month === prevMm;
 
-  if (year !== yy || month !== mm) {
+  if (!matchesCurrent && !matchesPrevious) {
     errors.push(
-      `version.json (${currentVersion}) does not match current UTC calendar (${yy}.${mm}.x).`
+      `version.json (${currentVersion}) does not match current UTC calendar (${yy}.${mm}.x) or the previous month (${prevYy}.${prevMm}.x).`
     );
   }
 }


### PR DESCRIPTION
## Summary

Second (remaining) layer of the 2026-07-01 month-rollover CI breakage. #12657 fixed the test *fixture*, but the `Guardrails (proxy)` job also runs `node scripts/version-check.mjs` against the repo itself — and the calendar audit requires `version.json` to match the **current** UTC month. Stamping is main-only and post-merge, so `version.json` lawfully lags between month rollover and the first release of the new month; main (26.6.61) is still red in July even after #12657.

Fix: accept the previous UTC month as a grace window. Two or more months behind still fails as real CalVer drift.

## Verification

On this branch (rebased on main incl. #12657):

```
node scripts/version-check.mjs              # Versioning audit passed (repo at 26.6.61, July)
node --test scripts/version-stamp.test.mjs  # 7/7 pass
```

On main: `node scripts/version-check.mjs` exits 1 with `version.json (26.6.61) does not match current UTC calendar (26.7.x)`.

## Notes

- Follow-up to #12657 (fixture layer); this unblocks `Guardrails (proxy)` → `ci-fast` → `Preview Deploy` → `PR Ready` cascade on all open PRs.
- No Linear issue — ad-hoc main-red CI hotfix discovered while shipping #12652 (sibling fix #12657 tracked JOV-3777).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
