### PR TITLE
feat(merch): second native-alpha model (Recraft) in the A/B roster

### DIFF
--- a/apps/web/lib/merch/graphic-engine.test.ts
+++ b/apps/web/lib/merch/graphic-engine.test.ts
@@ -9,11 +9,51 @@ vi.mock('@ai-sdk/gateway', () => ({
 }));
 
 import {
+  alphaProviderOptions,
   generatePrintGraphic,
   MERCH_IMAGE_MODELS,
   selectMerchImageModel,
   weightedPick,
 } from './graphic-engine';
+
+describe('alphaProviderOptions', () => {
+  it('maps each native provider to its transparent option', () => {
+    expect(
+      alphaProviderOptions({
+        id: 'openai/gpt-image-1.5',
+        key: 'gpt-image-1.5',
+        alpha: 'native',
+        enabled: true,
+      })
+    ).toEqual({ openai: { background: 'transparent' } });
+    expect(
+      alphaProviderOptions({
+        id: 'recraft/recraft-v3',
+        key: 'recraft-v3',
+        alpha: 'native',
+        enabled: true,
+      })
+    ).toEqual({ recraft: { response_format: 'png' } });
+    expect(
+      alphaProviderOptions({
+        id: 'bfl/flux-2-pro',
+        key: 'flux-2-pro',
+        alpha: 'knockout',
+        enabled: false,
+      })
+    ).toBeUndefined();
+  });
+
+  it('has at least two enabled native-alpha models for a real A/B', () => {
+    const enabledNative = MERCH_IMAGE_MODELS.filter(
+      m => m.enabled && m.alpha === 'native'
+    );
+    expect(enabledNative.length).toBeGreaterThanOrEqual(2);
+    for (const m of enabledNative) {
+      expect(alphaProviderOptions(m)).toBeDefined();
+    }
+  });
+});
 
 describe('weightedPick', () => {
   const models = [{ key: 'a' }, { key: 'b' }, { key: 'c' }] as const;

--- a/apps/web/lib/merch/graphic-engine.ts
+++ b/apps/web/lib/merch/graphic-engine.ts
@@ -51,12 +51,22 @@ export const MERCH_IMAGE_MODELS: readonly MerchImageModelConfig[] = [
     enabled: true,
   },
   {
+    // Native transparent output, distinct clean-illustration aesthetic.
+    // Verified alpha-clean in scripts/merch-knockout-spike.ts.
+    id: 'recraft/recraft-v3',
+    key: 'recraft-v3',
+    alpha: 'native',
+    enabled: true,
+  },
+  {
     id: 'openai/gpt-image-1',
     key: 'gpt-image-1',
     alpha: 'native',
     enabled: false,
   },
   {
+    // Knockout via chroma-key proved unreliable (residual background blocks —
+    // see merch-knockout-spike.ts); needs a proper bg-removal model to enable.
     id: 'bfl/flux-2-pro',
     key: 'flux-2-pro',
     alpha: 'knockout',
@@ -163,6 +173,22 @@ function toBuffer(image: RawImage): Buffer {
 }
 
 /**
+ * Provider-specific request options that yield a native transparent background.
+ * gpt-image takes `background: transparent`; Recraft returns a transparent PNG.
+ */
+export function alphaProviderOptions(
+  model: MerchImageModelConfig
+): Record<string, Record<string, string>> | undefined {
+  if (model.id.startsWith('openai/gpt-image')) {
+    return { openai: { background: 'transparent' } };
+  }
+  if (model.id.startsWith('recraft/')) {
+    return { recraft: { response_format: 'png' } };
+  }
+  return undefined;
+}
+
+/**
  * Opaque output → alpha. Not yet implemented; `knockout` models stay disabled
  * until this lands so the roster never emits a white-boxed (non-alpha) graphic.
  */
@@ -187,13 +213,13 @@ export async function generatePrintGraphic(params: {
   const model = params.model ?? selectMerchImageModel(params.selection);
   const started = Date.now();
 
+  const providerOptions =
+    model.alpha === 'native' ? alphaProviderOptions(model) : undefined;
   const result = await generateImage({
     model: gateway.image(model.id),
     prompt: `${params.prompt}\n${ALPHA_DIRECTIVE}`,
     size: '1024x1024',
-    ...(model.alpha === 'native'
-      ? { providerOptions: { openai: { background: 'transparent' } } }
-      : {}),
+    ...(providerOptions ? { providerOptions } : {}),
   });
 
   const raw = toBuffer(result.images[0] as RawImage);

--- a/apps/web/scripts/merch-knockout-spike.ts
+++ b/apps/web/scripts/merch-knockout-spike.ts
@@ -1,0 +1,115 @@
+/**
+ * Knockout spike (throwaway) for #10 — enabling more models in the A/B.
+ * Tests two ways to get alpha-clean art from non-gpt-image models:
+ *  A) Recraft native transparent background (no knockout).
+ *  B) Flux on a flat chroma background → Sharp chroma-key knockout.
+ * Outputs each composited on hot pink so we can judge edge quality.
+ *
+ *   doppler run --project jovie-web --config dev -- \
+ *     pnpm --filter @jovie/web exec tsx scripts/merch-knockout-spike.ts
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { gateway } from '@ai-sdk/gateway';
+import { generateImage } from 'ai';
+import sharp from 'sharp';
+
+const OUT = resolve(process.cwd(), '../../.context/spike-merch');
+const SUBJECT =
+  'Vintage distressed band-merch graphic: a cool panda in sunglasses surfing a wave, red sun, palm trees, bold metal lettering "PANADA", retro cream/teal/red palette, high detail.';
+
+async function toBuf(r: {
+  images: { uint8Array?: Uint8Array; base64?: string }[];
+}): Promise<Buffer> {
+  const i = r.images[0];
+  return i.uint8Array
+    ? Buffer.from(i.uint8Array)
+    : Buffer.from(i.base64 ?? '', 'base64');
+}
+
+/** Remove pixels within `tol` RGB distance of the flat key color → alpha 0. */
+async function chromaKnockout(
+  png: Buffer,
+  key: { r: number; g: number; b: number },
+  tol: number
+): Promise<Buffer> {
+  const { data, info } = await sharp(png)
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const ch = info.channels;
+  for (let i = 0; i < data.length; i += ch) {
+    const dr = data[i] - key.r;
+    const dg = data[i + 1] - key.g;
+    const db = data[i + 2] - key.b;
+    if (Math.sqrt(dr * dr + dg * dg + db * db) < tol) data[i + 3] = 0;
+  }
+  return sharp(data, {
+    raw: { width: info.width, height: info.height, channels: ch },
+  })
+    .png()
+    .toBuffer();
+}
+
+async function onPink(png: Buffer, name: string) {
+  const pink = await sharp({
+    create: {
+      width: 1024,
+      height: 1024,
+      channels: 4,
+      background: { r: 233, g: 74, b: 156, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  const out = await sharp(pink)
+    .composite([{ input: png, gravity: 'center' }])
+    .png()
+    .toBuffer();
+  writeFileSync(resolve(OUT, `knockout-${name}-on-pink.png`), out);
+  const meta = await sharp(png).metadata();
+  console.log(
+    `  ${name}: hasAlpha=${meta.hasAlpha} bytes=${(png.length / 1024) | 0}KB`
+  );
+}
+
+async function main() {
+  mkdirSync(OUT, { recursive: true });
+
+  // A) Recraft native transparent
+  try {
+    const r = await generateImage({
+      model: gateway.image('recraft/recraft-v3'),
+      prompt: `${SUBJECT} Isolated on a fully transparent background, sticker style, die-cut.`,
+      size: '1024x1024',
+      providerOptions: { recraft: { response_format: 'png' } },
+    });
+    const buf = await toBuf(r);
+    writeFileSync(resolve(OUT, 'knockout-recraft.png'), buf);
+    await onPink(buf, 'recraft');
+  } catch (e) {
+    console.log(
+      `  recraft FAIL: ${e instanceof Error ? e.message : String(e)}`
+    );
+  }
+
+  // B) Flux on flat magenta → chroma-key knockout
+  try {
+    const r = await generateImage({
+      model: gateway.image('bfl/flux-2-pro'),
+      prompt: `${SUBJECT} The artwork sits on a completely flat, solid magenta (#FF00FF) background with no magenta anywhere in the artwork itself.`,
+      size: '1024x1024',
+    });
+    const raw = await toBuf(r);
+    writeFileSync(resolve(OUT, 'knockout-flux-raw.png'), raw);
+    const keyed = await chromaKnockout(raw, { r: 255, g: 0, b: 255 }, 110);
+    writeFileSync(resolve(OUT, 'knockout-flux-keyed.png'), keyed);
+    await onPink(keyed, 'flux-keyed');
+  } catch (e) {
+    console.log(`  flux FAIL: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  console.log(`Outputs in ${OUT}`);
+}
+
+void main();


### PR DESCRIPTION
Adds a real multi-model A/B to the merch graphic engine.

Knockout spike (scripts/merch-knockout-spike.ts) tested two ways to get alpha-clean art from non-gpt-image models:
- **Recraft v3 native transparent: clean** — perfect alpha edges, distinct clean-illustration aesthetic. Enabled.
- **Flux + Sharp chroma-key: not production-clean** — residual background blocks where the model didn't render a flat key color. Gated.

So the roster now has **two enabled native-alpha models** (gpt-image-1.5 + recraft-v3); the feedback bandit A/Bs them with clean alpha and no fragile knockout. Per-provider transparent options via `alphaProviderOptions()`. flux/grok/imagen stay gated until a proper background-removal model is added.

## Tests
- `alphaProviderOptions` per-provider mapping + a guard that ≥2 native-alpha models are enabled. 11 unit tests pass.

## Cost
Recraft generation is user-initiated per merch request via the existing gateway. No background/recurring cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)