### PR TITLE
feat(merch): bias model A/B by artist selection

### DIFF
--- a/apps/web/lib/db/schema/merch.ts
+++ b/apps/web/lib/db/schema/merch.ts
@@ -83,6 +83,8 @@ export interface MerchLearningSnapshot {
   motifs: string[];
   selectedOverOptionIds: string[];
   rejectedAttributes: string[];
+  /** Image model that produced this design's graphic — feeds the A/B bias. */
+  imageModelKey?: string;
 }
 
 export interface MerchVisibilityRules {

--- a/apps/web/lib/merch/design-generation.test.ts
+++ b/apps/web/lib/merch/design-generation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { selectionCountsToWeights } from './design-generation';
+
+describe('selectionCountsToWeights', () => {
+  it('is empty (equal weighting) with no selection history', () => {
+    expect(selectionCountsToWeights([])).toEqual({});
+  });
+
+  it('Laplace-smooths: weight = 1 + picks', () => {
+    expect(
+      selectionCountsToWeights([
+        { modelKey: 'gpt-image-1.5', count: 4 },
+        { modelKey: 'recraft-v3', count: 1 },
+      ])
+    ).toEqual({ 'gpt-image-1.5': 5, 'recraft-v3': 2 });
+  });
+
+  it('skips rows with no recorded model (legacy designs)', () => {
+    expect(
+      selectionCountsToWeights([
+        { modelKey: null, count: 9 },
+        { modelKey: 'recraft-v3', count: 2 },
+      ])
+    ).toEqual({ 'recraft-v3': 3 });
+  });
+
+  it('never produces a zero/negative weight that could lock a model out', () => {
+    const w = selectionCountsToWeights([
+      { modelKey: 'gpt-image-1.5', count: 0 },
+      { modelKey: 'recraft-v3', count: -3 },
+    ]);
+    for (const v of Object.values(w)) expect(v).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/lib/merch/design-generation.ts
+++ b/apps/web/lib/merch/design-generation.ts
@@ -17,11 +17,12 @@ import 'server-only';
 
 import { randomUUID } from 'node:crypto';
 import { put } from '@vercel/blob';
-import { eq } from 'drizzle-orm';
+import { sql as drizzleSql, eq } from 'drizzle-orm';
 import { uploadBufferToBlob } from '@/app/api/images/upload/lib/blob-upload';
 import { db } from '@/lib/db';
 import {
   type MerchArtistBrief,
+  merchCards,
   merchDesignOptions,
   merchGenerationBatches,
 } from '@/lib/db/schema/merch';
@@ -128,6 +129,55 @@ function defaultPricing() {
 }
 
 /**
+ * Selection is the win signal: a model whose design the artist picks earns a
+ * higher weight. `weight = 1 + picks` (Laplace-smoothed) so an unpicked model
+ * still starts at 1 and stays in rotation via the selector's floor — the A/B
+ * gently converges to the artist's preferred aesthetic without ever locking a
+ * model out. Pure + exported for testing.
+ */
+export function selectionCountsToWeights(
+  rows: readonly { readonly modelKey: string | null; readonly count: number }[]
+): Record<string, number> {
+  const weights: Record<string, number> = {};
+  for (const { modelKey, count } of rows) {
+    if (modelKey) weights[modelKey] = 1 + Math.max(0, count);
+  }
+  return weights;
+}
+
+/** Per-artist model weights from how often each model's design was selected. */
+async function getModelSelectionWeights(
+  profileId: string
+): Promise<Record<string, number>> {
+  try {
+    const rows = await db
+      .select({
+        modelKey: drizzleSql<
+          string | null
+        >`${merchDesignOptions.learning}->>'imageModelKey'`,
+        count: drizzleSql<number>`count(*)::int`,
+      })
+      .from(merchCards)
+      .innerJoin(
+        merchDesignOptions,
+        eq(merchCards.selectedDesignOptionId, merchDesignOptions.id)
+      )
+      .where(eq(merchCards.creatorProfileId, profileId))
+      .groupBy(drizzleSql`${merchDesignOptions.learning}->>'imageModelKey'`);
+    return selectionCountsToWeights(rows);
+  } catch (error) {
+    // Never let a weights read break generation — fall back to equal weighting.
+    logger.warn(
+      '[merch-designs] model weight read failed; using equal weights',
+      {
+        err: error instanceof Error ? error.message : String(error),
+      }
+    );
+    return {};
+  }
+}
+
+/**
  * Fire-and-forget: render the fulfillment-accurate Printful mockup for each
  * design (the alpha graphic on the real default product) and attach it. The
  * selected card then prefers the truthful Printful photo over the alpha preview
@@ -198,6 +248,9 @@ export async function generateMerchDesigns(params: {
     status: 'generating',
   });
 
+  // Bias model selection toward the artist's previously-picked aesthetic.
+  const modelWeights = await getModelSelectionWeights(params.profileId);
+
   const directions = STYLE_DIRECTIONS.slice(0, count);
   const grossMargin =
     pricing.retailPriceCents -
@@ -212,6 +265,7 @@ export async function generateMerchDesigns(params: {
         try {
           const graphic = await generatePrintGraphic({
             prompt: buildImagePrompt(name, params.prompt, direction.style),
+            selection: { weights: modelWeights },
           });
           const previewUrl = await uploadAlphaPng(
             `merch/generated/${params.profileId}/${generationId}/${optionId}.png`,
@@ -266,6 +320,7 @@ export async function generateMerchDesigns(params: {
               motifs: [direction.label],
               selectedOverOptionIds: [],
               rejectedAttributes: [],
+              imageModelKey: graphic.modelKey,
             },
           });
 


### PR DESCRIPTION
## Summary

Biases merch image-model selection toward the artist's previously selected designs. This is a non-visual backend/selection change; the screenshot below is included for the taste-gate evidence contract, while the actual proof is the focused unit test and typecheck evidence.

![Merch/library product context](https://raw.githubusercontent.com/JovieInc/Jovie/3e4d357385b266363abd13c200e91f2b9c88fb16/apps/web/public/product-screenshots/design-studio-shell-library.png)

- Persist each design's `imageModelKey` in the learning snapshot (jsonb, no migration).
- `getModelSelectionWeights(profileId)`: counts how often each model's design got picked by joining merch cards to selected merch design options, per artist.
- `weight = 1 + picks` (Laplace-smoothed) feeds the bandit; the selector floor keeps every model in rotation so it converges to the artist's taste without locking a model out.
- Best-effort: a weights-read failure falls back to equal weighting and never breaks generation.

## Test plan

- [x] `pnpm biome check --write apps/web/lib/db/schema/merch.ts apps/web/lib/merch/design-generation.ts apps/web/lib/merch/design-generation.test.ts`
- [x] `pnpm --filter web exec vitest run lib/merch/design-generation.test.ts` (4 tests)
- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] Pre-push: Biome changed-files check, proxy guard, Tailwind guard, web typecheck