### PR TITLE
fix(dashboard): eliminate UI jank in chat panels, settings, and calendar (JOV-3800)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ### Fixed
 
+- **Smoother dashboard interactions (JOV-3800)**: opening a release, contact, or tour-date panel from chat now shows the details instantly instead of a brief loading state; settings pages no longer nudge when a change is being saved; and the calendar keeps its layout steady while it first loads.
 - [internal] Pre-push Biome gate scopes to changed files (mirroring CI) instead of a repo-wide `biome check .`, so pre-existing Biome drift on `main` no longer blocks `git push` from every worktree and stops training agents toward the `JOVIE_SKIP_PRE_PUSH_GATE=1` escape hatch (GitHub #12475).
 - [internal] Cleared the pre-existing Biome drift on `main` that #12475 unblocked (GitHub #12482): `biome format` reflow of `globals.css` + `design-system.css` (whitespace-only — design tokens byte-identical with whitespace stripped) and `biome migrate` on `biome.json` (schema `2.4.8`→`2.5.1`, deprecated `recommended: false`→`preset: "none"`). `biome ci .` is now clean. The issue's `setup.ts` and public-SVG `noSvgWithoutTitle` buckets were already non-issues on current main (Biome 2.5.1 does not lint raw `.svg` files).
 - **Library share links no longer error on re-open**: opening a release that already has share settings — or two tabs opening it at once — previously returned a 500. The "ensure share settings exist" path is now idempotent under a concurrent first-open race via an `ON CONFLICT DO NOTHING` insert plus re-read (GitHub #12407).

--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -464,7 +464,7 @@ export function CalendarPageClient() {
                   setCursor(startOfMonth(next));
                 }}
                 className='system-b-calendar-icon-button grid h-7 w-7 place-items-center transition-colors duration-subtle ease-subtle'
-                aria-label='Previous month'
+                aria-label='Previous Month'
               >
                 <ChevronLeft className='h-4 w-4' strokeWidth={2.25} />
               </button>
@@ -479,7 +479,7 @@ export function CalendarPageClient() {
                   setCursor(startOfMonth(next));
                 }}
                 className='system-b-calendar-icon-button grid h-7 w-7 place-items-center transition-colors duration-subtle ease-subtle'
-                aria-label='Next month'
+                aria-label='Next Month'
               >
                 <ChevronRight className='h-4 w-4' strokeWidth={2.25} />
               </button>
@@ -680,7 +680,7 @@ export function CalendarPageClient() {
                 <div className='mt-4'>
                   <div className='flex items-center justify-between'>
                     <h4 className='system-b-calendar-warning-heading font-medium'>
-                      Pending review · {pendingSelectedEvents.length}
+                      Pending Review · {pendingSelectedEvents.length}
                     </h4>
                   </div>
                   <ul className='mt-2 flex flex-col gap-2'>
@@ -774,11 +774,16 @@ export function CalendarPageClient() {
             </section>
           )}
 
-          {isLoading && (
-            <div className='system-b-calendar-loading-text'>
-              Loading calendar…
-            </div>
-          )}
+          {/* Always rendered so cold-load → loaded never changes page height */}
+          <div
+            className={cn(
+              'system-b-calendar-loading-text',
+              !isLoading && 'invisible'
+            )}
+            aria-hidden={!isLoading}
+          >
+            Loading calendar…
+          </div>
         </div>
       </PageContent>
     </PageShell>

--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@jovie/ui';
+import { QueryClientContext } from '@tanstack/react-query';
 import {
   Calendar,
   CheckSquare,
@@ -21,6 +22,7 @@ import { useRouter } from 'next/navigation';
 import {
   type ReactNode,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useState,
@@ -46,6 +48,7 @@ import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { resolveChatRailContextLabel } from '@/lib/chat/context-label';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { usePlanGate } from '@/lib/queries';
+import { prefetchChatEntityPanelData } from '@/lib/queries/prefetch-dashboard';
 import { useContactsQuery } from '@/lib/queries/useContactsQuery';
 import { type EventRecord, useEventsQuery } from '@/lib/queries/useEventsQuery';
 import { useReleaseEntityQuery } from '@/lib/queries/useReleaseEntityQuery';
@@ -1021,6 +1024,15 @@ export function ChatEntityRightPanelHost({
   const { open: openPreviewPanel } = usePreviewPanelState();
   const { target, contextTargets, close, dismissContext } =
     useChatEntityPanel();
+  // Nullable so the host also renders outside a QueryClientProvider (tests).
+  const queryClient = useContext(QueryClientContext);
+
+  // Warm the panel data caches up front so clicking an entity chip opens a
+  // fully-painted panel — never a loading state on drawer open (JOV-3800).
+  useEffect(() => {
+    if (!enableChatEntityPanels || !profileId || !queryClient) return;
+    prefetchChatEntityPanelData(queryClient, profileId);
+  }, [enableChatEntityPanels, profileId, queryClient]);
 
   const handleOpenProfilePreview = useCallback(() => {
     close();

--- a/apps/web/components/features/dashboard/molecules/SettingsStatusPill.test.tsx
+++ b/apps/web/components/features/dashboard/molecules/SettingsStatusPill.test.tsx
@@ -1,0 +1,55 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SettingsStatusPill } from './SettingsStatusPill';
+
+// Layout-shift guard (JOV-3800): the pill must stay mounted with reserved
+// height in every state so Saving… → Saved → idle never shifts settings forms.
+
+function renderPill(status: {
+  saving: boolean;
+  success: boolean | null;
+  error: string | null;
+}) {
+  const { container, unmount } = render(<SettingsStatusPill status={status} />);
+  return { pill: container.firstElementChild as HTMLElement, unmount };
+}
+
+describe('SettingsStatusPill', () => {
+  it('keeps an invisible reserved-height container while idle instead of unmounting', () => {
+    const { pill } = renderPill({ saving: false, success: null, error: null });
+    expect(pill).not.toBeNull();
+    expect(pill.dataset.state).toBe('idle');
+    expect(pill.className).toContain('min-h-4');
+    expect(pill.className).toContain('invisible');
+    expect(pill.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('renders every active state inside the same reserved-height container', () => {
+    const cases = [
+      {
+        status: { saving: true, success: null, error: null },
+        state: 'saving',
+        text: 'Saving…',
+      },
+      {
+        status: { saving: false, success: true, error: null },
+        state: 'saved',
+        text: 'Saved',
+      },
+      {
+        status: { saving: false, success: null, error: 'Save failed hard' },
+        state: 'error',
+        text: 'Save failed hard',
+      },
+    ] as const;
+
+    for (const { status, state, text } of cases) {
+      const { pill, unmount } = renderPill(status);
+      expect(pill.dataset.state).toBe(state);
+      expect(pill.className).toContain('min-h-4');
+      expect(pill.className).not.toContain('invisible');
+      expect(pill.textContent).toContain(text);
+      unmount();
+    }
+  });
+});

--- a/apps/web/components/features/dashboard/molecules/SettingsStatusPill.tsx
+++ b/apps/web/components/features/dashboard/molecules/SettingsStatusPill.tsx
@@ -27,18 +27,18 @@ export function SettingsStatusPill({
 }: SettingsStatusPillProps) {
   const resolvedState = resolveState({ state, status });
 
-  if (!resolvedState) {
-    return null;
-  }
-
+  // Always render the container so Saving… → Saved → idle transitions never
+  // shift the surrounding form layout; idle just renders it invisible.
   return (
     <div
       className={cn(
-        'text-xs',
+        'min-h-4 text-xs',
         resolvedState === 'error' ? 'text-destructive' : 'text-secondary-token',
+        !resolvedState && 'invisible',
         className
       )}
       aria-live='polite'
+      data-state={resolvedState ?? 'idle'}
     >
       {resolvedState === 'saving' && 'Saving…'}
       {resolvedState === 'saved' && 'Saved'}

--- a/apps/web/components/features/dashboard/organisms/SettingsSmsAccessSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsSmsAccessSection.tsx
@@ -19,24 +19,17 @@ export function SettingsSmsAccessSection({
 
   const hasRequested = alreadyRequested || isSuccess;
 
-  let statusPill: React.ReactNode = null;
-  if (isPending) {
-    statusPill = (
-      <SettingsStatusPill
-        status={{ saving: true, success: null, error: null }}
-      />
-    );
-  } else if (isError) {
-    statusPill = (
-      <SettingsStatusPill
-        status={{
-          saving: false,
-          success: null,
-          error: error?.message ?? 'Request failed',
-        }}
-      />
-    );
-  }
+  // Always mounted so the header layout never shifts when the request
+  // starts or fails; the pill reserves its own space while idle.
+  const statusPill = (
+    <SettingsStatusPill
+      status={{
+        saving: isPending,
+        success: null,
+        error: isError ? (error?.message ?? 'Request failed') : null,
+      }}
+    />
+  );
 
   return (
     <SettingsPanel

--- a/apps/web/lib/queries/prefetch-dashboard.test.ts
+++ b/apps/web/lib/queries/prefetch-dashboard.test.ts
@@ -1,0 +1,51 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/releases/release-matrix-loader', () => ({
+  loadReleaseMatrix: vi.fn().mockResolvedValue([{ id: 'rel-1' }]),
+}));
+vi.mock('@/app/app/(shell)/dashboard/tour-dates/actions', () => ({
+  loadTourDates: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/app/app/(shell)/dashboard/presence/actions', () => ({
+  loadDspPresenceForProfile: vi.fn(),
+}));
+vi.mock('@/app/app/(shell)/dashboard/tasks/task-actions', () => ({
+  getTasks: vi.fn(),
+}));
+vi.mock('./fetch', () => ({
+  createQueryFn: vi.fn(() => vi.fn()),
+  fetchWithTimeout: vi.fn().mockResolvedValue([{ id: 'contact-1' }]),
+}));
+// Avoid the heavy @/lib/queries barrel that useEventsQuery pulls in.
+vi.mock('./useEventsQuery', () => ({
+  tourDateToEventRecord: (td: unknown) => td,
+}));
+
+import { queryKeys } from './keys';
+import { prefetchChatEntityPanelData } from './prefetch-dashboard';
+
+// Perceived-instant guard (JOV-3800): chat entity panels must be warmed under
+// the exact query keys the panel hooks read, so opening a panel from an
+// entity chip paints content instead of a loading state.
+describe('prefetchChatEntityPanelData', () => {
+  it('warms releases, contacts, and events caches under the hook query keys', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    prefetchChatEntityPanelData(queryClient, 'profile-1');
+
+    await vi.waitFor(() => {
+      expect(
+        queryClient.getQueryData(queryKeys.releases.matrix('profile-1'))
+      ).toEqual([{ id: 'rel-1' }]);
+      expect(
+        queryClient.getQueryData(queryKeys.contacts.list('profile-1'))
+      ).toEqual([{ id: 'contact-1' }]);
+      expect(
+        queryClient.getQueryData(queryKeys.events.list('profile-1'))
+      ).toEqual([]);
+    });
+  });
+});

--- a/apps/web/lib/queries/prefetch-dashboard.ts
+++ b/apps/web/lib/queries/prefetch-dashboard.ts
@@ -1,11 +1,14 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { loadDspPresenceForProfile } from '@/app/app/(shell)/dashboard/presence/actions';
 import { getTasks } from '@/app/app/(shell)/dashboard/tasks/task-actions';
+import { loadTourDates } from '@/app/app/(shell)/dashboard/tour-dates/actions';
 import { loadReleaseMatrix } from '@/lib/releases/release-matrix-loader';
 import { DEFAULT_TASK_WORKSPACE_FILTERS } from '@/lib/tasks/query-defaults';
+import type { DashboardContact } from '@/types/contacts';
 import { FREQUENT_CACHE } from './cache-strategies';
 import { createQueryFn, fetchWithTimeout } from './fetch';
 import { queryKeys } from './keys';
+import { tourDateToEventRecord } from './useEventsQuery';
 
 const fetchEarnings = createQueryFn('/api/dashboard/earnings');
 
@@ -72,4 +75,40 @@ export function prefetchForRoute(
       break;
     // 'profile' is chat-driven — no data prefetch needed
   }
+}
+
+/**
+ * Warm the caches behind the chat entity right panels (releases matrix,
+ * contacts, events) so opening a panel from an entity chip paints content
+ * immediately instead of a loading state. Keys and fetchers mirror
+ * useReleasesQuery / useContactsQuery / useEventsQuery exactly.
+ */
+export function prefetchChatEntityPanelData(
+  queryClient: QueryClient,
+  profileId: string
+): void {
+  const { staleTime } = FREQUENT_CACHE;
+
+  queryClient.prefetchQuery({
+    queryKey: queryKeys.releases.matrix(profileId),
+    queryFn: () => loadReleaseMatrix(profileId),
+    staleTime,
+  });
+  queryClient.prefetchQuery({
+    queryKey: queryKeys.contacts.list(profileId),
+    queryFn: ({ signal }) =>
+      fetchWithTimeout<DashboardContact[]>(
+        `/api/dashboard/contacts?profileId=${encodeURIComponent(profileId)}`,
+        { signal }
+      ),
+    staleTime,
+  });
+  queryClient.prefetchQuery({
+    queryKey: queryKeys.events.list(profileId),
+    queryFn: async () => {
+      const dates = await loadTourDates(profileId);
+      return dates.map(tourDateToEventRecord);
+    },
+    staleTime,
+  });
 }

--- a/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
+++ b/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
@@ -179,7 +179,7 @@ describe('CalendarPageClient', () => {
     );
 
     const bulkSlot = screen
-      .getByText('Pending review · 1')
+      .getByText('Pending Review · 1')
       .closest('div')
       ?.parentElement?.querySelector('.system-b-calendar-bulk-action-slot');
     expect(bulkSlot).toBeInTheDocument();


### PR DESCRIPTION
Eliminates three verified perceived-jank sources in the authenticated `/app/*` surfaces (JOV-3800). House rules enforced: perceived-instant on drawer open, and no layout shift on state transitions.

<!-- linear-issue-id:a9bd96e8-f262-4459-bb67-c0b7e0b9f0d6 -->

## What changed

1. **Chat entity panels no longer show "Loading…" on open** — `ChatEntityRightPanelHost` previously fetched the full contacts/events lists (and the releases matrix when uncached) at panel-open time. The host now warms all three caches up front via a new `prefetchChatEntityPanelData()` in `lib/queries/prefetch-dashboard.ts`, using the exact query keys + fetchers the panel hooks read. Uses `QueryClientContext` (nullable) so the host still renders outside a provider (matches existing unit-test harness).
2. **`SettingsStatusPill` reserves its space** — it used to unmount while idle, so `Saving… → Saved → idle` shifted settings forms in 5 sections. It now always renders a `min-h-4` container (invisible while idle) with a permanently mounted `aria-live` region. `SettingsSmsAccessSection` now passes status unconditionally so the panel-header actions slot stays mounted too.
3. **Calendar loading text keeps page height stable** — the `Loading calendar…` block after the grid now always renders and toggles `invisible`/`aria-hidden` instead of mounting/unmounting on cold load.

Drive-by (forced by commit gate): three pre-existing Title Case lint violations in the calendar file (`Previous Month`, `Next Month`, `Pending Review`).

## Verified non-issues (investigated, intentionally untouched)

- ThreadsPageClient skeleton: only fires on true cold load (TanStack v5 `isLoading` semantics + query key shared with the sidebar).
- ReleaseCatalogPageClient: `placeholderData` already prevents refetch flash.

## Guardrails (same PR)

- `SettingsStatusPill.test.tsx` — pill stays mounted with reserved height in idle/saving/saved/error states (fails on the old `return null`).
- `prefetch-dashboard.test.ts` — prefetch populates the releases/contacts/events caches under the exact hook query keys.

## Screenshot

Artist-profile settings — one of the five sections where `SettingsStatusPill` now reserves its space (header row right of "View as Visitor"); Saving…/Saved no longer shifts the form. The other two fixes are interaction-timing changes (chat panel paints instantly from warmed cache; calendar keeps page height on cold load) — regression tests are the evidence for those.

![Artist profile settings with reserved status pill slot](https://raw.githubusercontent.com/JovieInc/Jovie/screenshots/jov-3800-ui-jank/jov-3800-settings.png)

## Cost Impact

- **External API calls**: none. Prefetch issues ≤3 internal requests per chat session — the same queries the dashboard already runs, deduped by TanStack cache under the same keys/presets. Scaling O(1) per session.

## Verification

- `pnpm --filter @jovie/web run typecheck` — clean
- `pnpm biome check` on touched files — clean
- `vitest run` on 8 affected test files (new + existing chat host/calendar/settings suites) — 38/38 pass

## Test plan

- `pnpm run dev:web:browse` → `/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/chat` → click a release/contact/tour-date entity chip → panel paints content with no loading state.
- Settings → toggle any setting → Saving…/Saved appears without the header or form moving.

