### PR TITLE
feat(onboarding): scripted response bank + Jovie voice lint

### DIFF
--- a/apps/web/lib/chat/onboarding-script/script.ts
+++ b/apps/web/lib/chat/onboarding-script/script.ts
@@ -1,0 +1,169 @@
+/**
+ * Deterministic onboarding response bank (JOV-3806).
+ *
+ * These are the scripted lines Jovie speaks when the LLM is unavailable
+ * (provider error, kill switch). The engine (`engine.ts`) picks the step;
+ * this file owns the words. Every line must pass `lintVoice` — enforced by
+ * `voice-lint.test.ts` — and follow the persona canon: short, warm to
+ * musicians, ruthless to bad systems, real numbers, no hedging, no emoji.
+ *
+ * Template slots: `{name}`, `{followers}`, `{handle}` — filled by the engine.
+ *
+ * Editing rule: changing a line's text requires a NEW variant key. PR2 keys
+ * conversion stats to `key`; silently re-texting a key corrupts attribution.
+ */
+
+export type ScriptStepId =
+  | 'greet'
+  | 'get_artist'
+  | 'confirm_artist'
+  | 'confirm_artist_no_data'
+  | 'handle'
+  | 'ask_audience'
+  | 'instant_access'
+  | 'waitlist'
+  | 'done'
+  | 'stream_error';
+
+export interface ScriptLine {
+  readonly key: `${ScriptStepId}:${string}`;
+  readonly stepId: ScriptStepId;
+  readonly variant: string;
+  readonly text: string;
+}
+
+function line(stepId: ScriptStepId, variant: string, text: string): ScriptLine {
+  return { key: `${stepId}:${variant}`, stepId, variant, text };
+}
+
+export const SCRIPT_LINES: readonly ScriptLine[] = [
+  line(
+    'greet',
+    'v1',
+    "Hey — I'm Jovie. Heads up, I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?"
+  ),
+  line(
+    'greet',
+    'v2',
+    "Hey, I'm Jovie. I run the release side so you can stay on the music. Quick heads up: I'll remember this chat if you sign up. What are you working on right now?"
+  ),
+
+  line(
+    'get_artist',
+    'v1',
+    "Let's skip the small talk — pull up your Spotify so I'm working with real numbers, not vibes. Pick your artist below."
+  ),
+  line(
+    'get_artist',
+    'v2',
+    'First move: find you on Spotify. Everything downstream gets sharper once I can see the real numbers. Pick your artist below.'
+  ),
+
+  line(
+    'confirm_artist',
+    'v1',
+    "Pulled you up. {followers} Spotify followers — that's a real audience, and the question now is whether your release setup respects it. Next: lock your handle before someone else grabs it."
+  ),
+  line(
+    'confirm_artist',
+    'v2',
+    "{name}, locked in. {followers} followers on Spotify. Most artists at your size are still running a bare link page — that's the gap we close. Next: your handle."
+  ),
+
+  line(
+    'confirm_artist_no_data',
+    'v1',
+    "Locked in. Spotify is being slow with the numbers, but we don't need them to keep moving. Next: lock your handle before someone else grabs it."
+  ),
+
+  line(
+    'handle',
+    'v1',
+    'Claiming @{handle} for you — checking it now. This is the link everything else hangs off, so we get it right first.'
+  ),
+
+  line(
+    'ask_audience',
+    'v1',
+    'One thing before I route you: roughly how big is your audience right now? Under 500, a few thousand, more? Real answer beats a flattering one.'
+  ),
+
+  line(
+    'instant_access',
+    'v1',
+    'You clear the bar. Checkout takes about a minute, and the free tier exists if you want to start there — the numbers will make the case either way.'
+  ),
+
+  line(
+    'waitlist',
+    'v1',
+    "Putting you on the early list — I'll ping you when you're up, and we pick this up exactly where we left off. Nothing gets lost."
+  ),
+
+  line(
+    'done',
+    'v1',
+    "You're set from my side. The card above is your next move — take it when you're ready."
+  ),
+
+  line(
+    'stream_error',
+    'v1',
+    'Lost my thread mid-sentence. Say that again and I pick it right up.'
+  ),
+] as const;
+
+/** All lines for one step, in declaration order. */
+export function linesForStep(stepId: ScriptStepId): readonly ScriptLine[] {
+  return SCRIPT_LINES.filter(scriptLine => scriptLine.stepId === stepId);
+}
+
+/**
+ * Stable per-conversation variant pick: one visitor sees one variant for a
+ * given step across retries, while variants spread across visitors — which is
+ * what PR2's conversion attribution needs.
+ */
+export function pickLine(stepId: ScriptStepId, sessionId: string): ScriptLine {
+  const candidates = linesForStep(stepId);
+  if (candidates.length === 0) {
+    throw new Error(`No script lines defined for step ${stepId}`);
+  }
+  let hash = 0;
+  for (let i = 0; i < sessionId.length; i += 1) {
+    hash = (hash * 31 + sessionId.charCodeAt(i)) >>> 0;
+  }
+  const picked = candidates[hash % candidates.length];
+  if (!picked) {
+    throw new Error(`Variant pick failed for step ${stepId}`);
+  }
+  return picked;
+}
+
+/** Mid-stream error line (used as the `onError` text — no SSE swap possible). */
+export const STREAM_ERROR_LINE = SCRIPT_LINES.find(
+  scriptLine => scriptLine.stepId === 'stream_error'
+) as ScriptLine;
+
+export function formatFollowers(count: number): string {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+  }
+  if (count >= 1_000) {
+    return `${(count / 1_000).toFixed(1).replace(/\.0$/, '')}k`;
+  }
+  return String(count);
+}
+
+/** Fill `{name}` / `{followers}` / `{handle}` slots. */
+export function renderLine(
+  scriptLine: ScriptLine,
+  slots: { name?: string | null; followers?: number | null; handle?: string }
+): string {
+  return scriptLine.text
+    .replaceAll('{name}', slots.name ?? 'Artist')
+    .replaceAll(
+      '{followers}',
+      slots.followers != null ? formatFollowers(slots.followers) : 'your'
+    )
+    .replaceAll('{handle}', slots.handle ?? 'your-handle');
+}

--- a/apps/web/lib/chat/tools/onboarding-tool-impls.ts
+++ b/apps/web/lib/chat/tools/onboarding-tool-impls.ts
@@ -182,6 +182,76 @@ export interface NextStepCardPayload {
   readonly decision: AccessDecision;
 }
 
+export interface ConfirmSpotifyArtistOutput {
+  readonly action: 'spotify_artist_confirmed';
+  readonly spotifyArtistId: string;
+  readonly artist: {
+    readonly id: string;
+    readonly name: string;
+    readonly url: string;
+    readonly imageUrl: string | null;
+    readonly followers: number | null;
+    readonly popularity: number | null;
+    readonly genres: readonly string[];
+  } | null;
+  readonly summary: string;
+}
+
+/**
+ * Shared confirm-artist implementation: record the pick on the turn state,
+ * fetch Spotify enrichment (best-effort), and return the card payload.
+ * Called by both the LLM tool below and the deterministic fallback engine
+ * (`lib/chat/onboarding-script/engine.ts`) so the two paths cannot drift.
+ */
+export async function buildConfirmSpotifyArtistOutput(
+  spotifyArtistId: string,
+  state: OnboardingTurnState
+): Promise<ConfirmSpotifyArtistOutput> {
+  state.spotifyArtistId = spotifyArtistId;
+  state.spotifyArtistName = null;
+  state.spotifyImageUrl = null;
+  state.spotifyGenres = [];
+  state.spotifyPopularity = null;
+  state.spotifyFollowers = null;
+  let artist: Awaited<ReturnType<typeof getSpotifyArtist>> = null;
+
+  try {
+    artist = await getSpotifyArtist(spotifyArtistId);
+  } catch (error) {
+    logger.warn('Onboarding Spotify artist enrichment failed', {
+      error,
+      spotifyArtistId,
+    });
+  }
+
+  if (artist) {
+    state.spotifyArtistName = artist.name;
+    state.spotifyImageUrl = artist.images?.[0]?.url ?? null;
+    state.spotifyGenres = artist.genres ?? [];
+    state.spotifyPopularity = artist.popularity ?? null;
+    state.spotifyFollowers = artist.followers?.total ?? null;
+  }
+
+  return {
+    action: 'spotify_artist_confirmed' as const,
+    spotifyArtistId,
+    artist: artist
+      ? {
+          id: artist.id,
+          name: artist.name,
+          url: buildSpotifyArtistUrl(artist.id),
+          imageUrl: artist.images?.[0]?.url ?? null,
+          followers: artist.followers?.total ?? null,
+          popularity: artist.popularity ?? null,
+          genres: artist.genres?.slice(0, 3) ?? [],
+        }
+      : null,
+    summary: artist
+      ? `${artist.name} matched on Spotify.`
+      : 'Spotify artist selected.',
+  };
+}
+
 export interface CheckoutCardPayload {
   readonly action: 'propose_checkout';
   readonly plan: 'free' | 'pro' | 'max' | null;
@@ -214,51 +284,8 @@ export function buildOnboardingTools(state: OnboardingTurnState): ToolSet {
     confirmSpotifyArtist: tool({
       description: TOOL_SCHEMAS.confirmSpotifyArtist.description,
       inputSchema: TOOL_SCHEMAS.confirmSpotifyArtist.inputSchema,
-      execute: async ({ spotifyArtistId }) => {
-        state.spotifyArtistId = spotifyArtistId;
-        state.spotifyArtistName = null;
-        state.spotifyImageUrl = null;
-        state.spotifyGenres = [];
-        state.spotifyPopularity = null;
-        state.spotifyFollowers = null;
-        let artist: Awaited<ReturnType<typeof getSpotifyArtist>> = null;
-
-        try {
-          artist = await getSpotifyArtist(spotifyArtistId);
-        } catch (error) {
-          logger.warn('Onboarding Spotify artist enrichment failed', {
-            error,
-            spotifyArtistId,
-          });
-        }
-
-        if (artist) {
-          state.spotifyArtistName = artist.name;
-          state.spotifyImageUrl = artist.images?.[0]?.url ?? null;
-          state.spotifyGenres = artist.genres ?? [];
-          state.spotifyPopularity = artist.popularity ?? null;
-          state.spotifyFollowers = artist.followers?.total ?? null;
-        }
-
-        return {
-          action: 'spotify_artist_confirmed' as const,
-          spotifyArtistId,
-          artist: artist
-            ? {
-                id: artist.id,
-                name: artist.name,
-                url: buildSpotifyArtistUrl(artist.id),
-                imageUrl: artist.images?.[0]?.url ?? null,
-                followers: artist.followers?.total ?? null,
-                popularity: artist.popularity ?? null,
-                genres: artist.genres?.slice(0, 3) ?? [],
-              }
-            : null,
-          summary: artist
-            ? `${artist.name} matched on Spotify.`
-            : 'Spotify artist selected.',
-        };
-      },
+      execute: async ({ spotifyArtistId }) =>
+        buildConfirmSpotifyArtistOutput(spotifyArtistId, state),
     }),
 
     checkHandle: tool({

--- a/apps/web/lib/chat/voice-lint.ts
+++ b/apps/web/lib/chat/voice-lint.ts
@@ -1,0 +1,87 @@
+/**
+ * Jovie voice lint (JOV-3806).
+ *
+ * Machine-checkable subset of the Jovie persona canon
+ * (ops `01-canon/04-jovie-persona.md`) and the onboarding prompt's NEVER
+ * list. Used three ways:
+ *
+ *  1. Unit tests assert every deterministic script line passes.
+ *  2. Unit tests assert prompt calibration examples pass.
+ *  3. The self-improvement job (PR2) gates LLM-response candidates before
+ *     they can be promoted into the deterministic response bank.
+ *
+ * Rules here catch what regexes can catch (banned phrases, corporate verbs,
+ * hedging, emoji, shouting). Rhythm and warmth stay human-judged.
+ */
+
+export interface VoiceLintViolation {
+  readonly rule: string;
+  readonly match: string;
+}
+
+export interface VoiceLintResult {
+  readonly ok: boolean;
+  readonly violations: readonly VoiceLintViolation[];
+}
+
+interface VoiceRule {
+  readonly name: string;
+  readonly pattern: RegExp;
+}
+
+const VOICE_RULES: readonly VoiceRule[] = [
+  {
+    name: 'banned-phrase',
+    pattern:
+      /\b(excited to share|thrilled to announce|let that sink in|here's the truth|at the end of the day|here's the thing|let me tell you|i've been thinking about|game.changer|unlock your potential)\b/i,
+  },
+  {
+    name: 'corporate-verb',
+    pattern:
+      /\b(leverage|robust|delve|showcase|intricate|vibrant|tapestry|underscore|foster|comprehensive|nuanced|multifaceted|pivotal|elevate|empower|seamless|synergy)\b/i,
+  },
+  {
+    name: 'hedging',
+    pattern: /\b(might|maybe|perhaps|i think|i believe|it seems like)\b/i,
+  },
+  {
+    name: 'apology',
+    pattern: /\b(sorry|apologies|apologize|my bad)\b/i,
+  },
+  {
+    name: 'emoji',
+    pattern: /[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{FE0F}]/u,
+  },
+  {
+    name: 'shouting',
+    // 4+ letter all-caps word. Allow known initialisms artists actually use.
+    pattern: /\b(?!ISRC\b|DSPs?\b|IRPAA\b)[A-Z]{4,}\b/,
+  },
+  {
+    name: 'multi-exclamation',
+    pattern: /!{2,}/,
+  },
+  {
+    name: 'cheerleading',
+    pattern: /\b(amazing|awesome journey|super excited|can't wait)\b/i,
+  },
+  {
+    name: 'vague-quantifier',
+    pattern: /\b(a lot of|tons of|countless|so many)\b/i,
+  },
+];
+
+/**
+ * Lint a single user-facing Jovie line. Returns every rule violation so
+ * tests and the promotion gate can report precisely what failed.
+ */
+export function lintVoice(text: string): VoiceLintResult {
+  const violations: VoiceLintViolation[] = [];
+  for (const rule of VOICE_RULES) {
+    const match = rule.pattern.exec(text);
+    if (match) {
+      violations.push({ rule: rule.name, match: match[0] });
+    }
+  }
+  return { ok: violations.length === 0, violations };
+}

--- a/apps/web/tests/unit/lib/chat/voice-lint.test.ts
+++ b/apps/web/tests/unit/lib/chat/voice-lint.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  renderLine,
+  SCRIPT_LINES,
+  STREAM_ERROR_LINE,
+} from '@/lib/chat/onboarding-script/script';
+import { lintVoice } from '@/lib/chat/voice-lint';
+
+describe('lintVoice', () => {
+  it.each([
+    ['banned-phrase', "Excited to share what we've built!"],
+    ['banned-phrase', "Here's the thing about release plans."],
+    ['corporate-verb', 'Leverage your robust fanbase.'],
+    ['hedging', 'Maybe you could perhaps try a link page.'],
+    ['apology', 'Sorry, something went wrong on our end.'],
+    ['emoji', 'Welcome to Jovie 🎵'],
+    ['shouting', 'This is HUGE for your release.'],
+    ['multi-exclamation', 'Let’s go!!'],
+    ['cheerleading', "That's amazing, superstar."],
+    ['vague-quantifier', 'You have a lot of followers.'],
+  ])('flags %s', (rule, text) => {
+    const result = lintVoice(text);
+    expect(result.ok).toBe(false);
+    expect(result.violations.map(violation => violation.rule)).toContain(rule);
+  });
+
+  it('passes clean Jovie-voice copy', () => {
+    const result = lintVoice(
+      'Your release week starts two weeks before the song is out. 47k followers deserve better than a timestamp.'
+    );
+    expect(result.violations).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it('allows music-industry initialisms', () => {
+    expect(lintVoice('Jovie builds release pages from your ISRC.').ok).toBe(
+      true
+    );
+  });
+});
+
+describe('script lines respect the Jovie voice canon', () => {
+  it.each(
+    SCRIPT_LINES.map(line => [line.key, line] as const)
+  )('%s passes the voice lint', (_key, line) => {
+    const rendered = renderLine(line, {
+      name: 'Test Artist',
+      followers: 12_300,
+      handle: 'testartist',
+    });
+    const result = lintVoice(rendered);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('has a lint-clean stream error line', () => {
+    expect(lintVoice(STREAM_ERROR_LINE.text).ok).toBe(true);
+  });
+
+  it('keeps script line keys unique', () => {
+    const keys = SCRIPT_LINES.map(line => line.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});


### PR DESCRIPTION
## Summary
Part 1/3 of JOV-3806 (onboarding must never block on LLM failure).

- New `lib/chat/onboarding-script/script.ts`: deterministic onboarding response bank, written in Jovie's voice per the persona canon (ops `01-canon/04-jovie-persona.md`). Stable per-session variant pick; editing a line requires a new variant key (conversion attribution lands in the follow-up PR).
- New `lib/chat/voice-lint.ts`: machine-checkable voice rules (banned phrases, corporate verbs, hedging, emoji, shouting). Every script line is lint-gated in `voice-lint.test.ts`.
- Refactor: `buildConfirmSpotifyArtistOutput` extracted from the `confirmSpotifyArtist` tool so the LLM tool and the fallback engine (next PR) share one implementation.

## Verification
- `vitest run tests/unit/lib/chat/voice-lint.test.ts` — 27 passed
- `lib/chat/tools` + `tests/unit/chat` suites — 827 passed
- Typecheck + biome clean

Stack: 1/3 (this) → #12699 → #12700

<!-- linear-issue-id:JOV-3806 -->