### PR TITLE
feat(onboarding): deterministic fallback engine + scripted SSE responder

### DIFF
--- a/apps/web/lib/chat/onboarding-script/engine.ts
+++ b/apps/web/lib/chat/onboarding-script/engine.ts
@@ -1,0 +1,346 @@
+import 'server-only';
+import type { UIMessage } from 'ai';
+import {
+  type AccessDecision,
+  evaluateAccessSignal,
+} from '@/lib/chat/tools/onboarding-access-eval';
+import type { AudienceBand } from '@/lib/chat/tools/onboarding-signals';
+import { collapseInterviewSignals } from '@/lib/chat/tools/onboarding-signals';
+import {
+  buildConfirmSpotifyArtistOutput,
+  type OnboardingTurnState,
+} from '@/lib/chat/tools/onboarding-tool-impls';
+import { pickLine, renderLine, type ScriptLine } from './script';
+
+/**
+ * Deterministic onboarding fallback engine (JOV-3806).
+ *
+ * Stateless per-request: everything it needs is recovered from the inbound
+ * UIMessage history (tool outputs persist across turns on the client and in
+ * `chat_messages.tool_calls`). When the LLM is down, this walks the same
+ * intake rail the LLM walks: greet → pick artist → confirm → handle →
+ * access decision → checkout/waitlist. The words come from `script.ts`;
+ * the access decision comes from the same `evaluateAccessSignal` the LLM
+ * tool uses — the fallback never invents its own scoring.
+ */
+
+export interface FallbackToolEvent {
+  readonly toolName: string;
+  readonly input: Record<string, unknown>;
+  readonly output: Record<string, unknown>;
+}
+
+export interface FallbackTurn {
+  readonly line: ScriptLine;
+  readonly text: string;
+  readonly toolEvents: readonly FallbackToolEvent[];
+}
+
+interface LoosePart {
+  readonly type?: string;
+  readonly toolName?: string;
+  readonly text?: string;
+  readonly output?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function partsOf(message: UIMessage): readonly LoosePart[] {
+  return (message.parts ?? []) as readonly LoosePart[];
+}
+
+/** Latest occurrence of a tool output with the given `action` marker. */
+function findLatestToolOutput(
+  messages: readonly UIMessage[],
+  action: string
+): Record<string, unknown> | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (!message) continue;
+    for (const part of partsOf(message)) {
+      if (isRecord(part.output) && part.output.action === action) {
+        return part.output;
+      }
+    }
+  }
+  return null;
+}
+
+function lastUserMessage(messages: readonly UIMessage[]): UIMessage | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message?.role === 'user') return message;
+  }
+  return null;
+}
+
+function messageText(message: UIMessage): string {
+  return partsOf(message)
+    .filter(part => part.type === 'text' && typeof part.text === 'string')
+    .map(part => part.text)
+    .join('');
+}
+
+const SPOTIFY_ARTIST_URL_PATTERN = /open\.spotify\.com\/artist\/([A-Za-z0-9]+)/;
+
+/**
+ * Extract the picked Spotify artist id from the latest user message. The
+ * artist picker attaches it as UIMessage metadata (`spotifyArtistId`); a raw
+ * pasted Spotify artist URL also works.
+ */
+export function parseArtistSelection(message: UIMessage | null): string | null {
+  if (!message) return null;
+  const metadata = isRecord(message.metadata) ? message.metadata : null;
+  if (typeof metadata?.spotifyArtistId === 'string') {
+    return metadata.spotifyArtistId;
+  }
+  const match = SPOTIFY_ARTIST_URL_PATTERN.exec(messageText(message));
+  return match?.[1] ?? null;
+}
+
+const AUDIENCE_BANDS: readonly {
+  readonly max: number;
+  readonly band: AudienceBand;
+}[] = [
+  { max: 500, band: 'under_500' },
+  { max: 5_000, band: '500_to_5k' },
+  { max: 50_000, band: '5k_to_50k' },
+  { max: 500_000, band: '50k_to_500k' },
+  { max: Number.POSITIVE_INFINITY, band: 'over_500k' },
+];
+
+/**
+ * Best-effort audience-size parse from a free-text reply ("about 2k",
+ * "12,000 monthly", "under 500"). Returns null when no number is present.
+ */
+export function parseAudienceBand(text: string): AudienceBand | null {
+  const match = /(\d[\d,.]*)\s*(k|m|thousand|million)?/i.exec(text);
+  if (!match?.[1]) return null;
+  const base = Number.parseFloat(match[1].replaceAll(',', ''));
+  if (!Number.isFinite(base)) return null;
+  const unit = match[2]?.toLowerCase();
+  const multiplier =
+    unit === 'k' || unit === 'thousand'
+      ? 1_000
+      : unit === 'm' || unit === 'million'
+        ? 1_000_000
+        : 1;
+  const count = base * multiplier;
+  return AUDIENCE_BANDS.find(entry => count < entry.max)?.band ?? 'over_500k';
+}
+
+/** Slug a Spotify artist name into a handle candidate. */
+export function handleFromArtistName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replaceAll(/[\u0300-\u036f]/g, '')
+    .replaceAll(/[^a-z0-9]+/g, '')
+    .slice(0, 30);
+  return slug || 'artist';
+}
+
+function proposeNextStepEvent(decision: AccessDecision): FallbackToolEvent {
+  return {
+    toolName: 'proposeNextStep',
+    input: {},
+    output: {
+      action: 'propose_next_step',
+      decision,
+      summary: `Next step: ${decision.kind.replaceAll('_', ' ')}.`,
+    },
+  };
+}
+
+function decideAccess(
+  state: OnboardingTurnState,
+  extraBand: AudienceBand | null
+): AccessDecision {
+  const recordedAt = new Date().toISOString();
+  const signals = state.signals.map(signal => ({ ...signal, recordedAt }));
+  if (extraBand) {
+    signals.push({ audienceBand: extraBand, recordedAt });
+  }
+  return evaluateAccessSignal({
+    signal: collapseInterviewSignals(signals),
+    spotifyFollowers: state.spotifyFollowers,
+    turnCount: state.turnCount,
+  });
+}
+
+function decisionTurn(
+  input: Readonly<{
+    uiMessages: readonly UIMessage[];
+    state: OnboardingTurnState;
+  }>,
+  existingDecisionKind: string | null
+): FallbackTurn {
+  const { uiMessages, state } = input;
+  const sessionId = state.sessionId;
+
+  // Terminal decision already made — point back at the card.
+  if (existingDecisionKind && existingDecisionKind !== 'needs_more_info') {
+    const events: FallbackToolEvent[] = [];
+    if (
+      existingDecisionKind === 'instant_access' &&
+      !findLatestToolOutput(uiMessages, 'propose_checkout')
+    ) {
+      events.push({
+        toolName: 'proposeCheckout',
+        input: {},
+        output: {
+          action: 'propose_checkout',
+          plan: null,
+          handoffUrl: '/onboarding/checkout',
+          summary: 'Checkout handoff ready.',
+        },
+      });
+    }
+    const line = pickLine('done', sessionId);
+    return { line, text: renderLine(line, {}), toolEvents: events };
+  }
+
+  const latest = lastUserMessage(uiMessages);
+  const parsedBand = latest ? parseAudienceBand(messageText(latest)) : null;
+  const events: FallbackToolEvent[] = [];
+  if (parsedBand) {
+    events.push({
+      toolName: 'recordInterviewSignal',
+      input: { audienceBand: parsedBand },
+      output: {
+        action: 'signal_recorded',
+        signal: { audienceBand: parsedBand },
+        signalCount: state.signals.length + 1,
+        summary: 'Signal noted.',
+      },
+    });
+  }
+
+  const decision = decideAccess(state, parsedBand);
+  if (decision.kind === 'instant_access') {
+    events.push(proposeNextStepEvent(decision));
+    events.push({
+      toolName: 'proposeCheckout',
+      input: {},
+      output: {
+        action: 'propose_checkout',
+        plan: null,
+        handoffUrl: '/onboarding/checkout',
+        summary: 'Checkout handoff ready.',
+      },
+    });
+    const line = pickLine('instant_access', sessionId);
+    return { line, text: renderLine(line, {}), toolEvents: events };
+  }
+  if (decision.kind === 'waitlist') {
+    events.push(proposeNextStepEvent(decision));
+    const line = pickLine('waitlist', sessionId);
+    return { line, text: renderLine(line, {}), toolEvents: events };
+  }
+  const line = pickLine('ask_audience', sessionId);
+  return { line, text: renderLine(line, {}), toolEvents: events };
+}
+
+/**
+ * Decide the scripted assistant turn for the current conversation state.
+ * Async only because artist confirmation fetches Spotify enrichment
+ * (best-effort — a Spotify outage degrades to the no-data line, it never
+ * throws).
+ */
+export async function decideFallbackTurn(
+  input: Readonly<{
+    uiMessages: readonly UIMessage[];
+    state: OnboardingTurnState;
+  }>
+): Promise<FallbackTurn> {
+  const { uiMessages, state } = input;
+  const sessionId = state.sessionId;
+  const latest = lastUserMessage(uiMessages);
+  const selectedArtistId = parseArtistSelection(latest);
+
+  // The visitor just picked an artist — confirm it (Spotify enrichment).
+  if (selectedArtistId && state.spotifyArtistId !== selectedArtistId) {
+    const output = await buildConfirmSpotifyArtistOutput(
+      selectedArtistId,
+      state
+    );
+    const hasData = state.spotifyFollowers !== null;
+    const line = hasData
+      ? pickLine('confirm_artist', sessionId)
+      : pickLine('confirm_artist_no_data', sessionId);
+    return {
+      line,
+      text: renderLine(line, {
+        name: state.spotifyArtistName,
+        followers: state.spotifyFollowers,
+      }),
+      toolEvents: [
+        {
+          toolName: 'confirmSpotifyArtist',
+          input: { spotifyArtistId: selectedArtistId },
+          output: output as unknown as Record<string, unknown>,
+        },
+      ],
+    };
+  }
+
+  // No artist yet: greet on the very first turn, otherwise open the picker.
+  if (!state.spotifyArtistId) {
+    if (state.turnCount <= 1) {
+      const line = pickLine('greet', sessionId);
+      return { line, text: renderLine(line, {}), toolEvents: [] };
+    }
+    const query = latest ? messageText(latest).slice(0, 50) : '';
+    const line = pickLine('get_artist', sessionId);
+    return {
+      line,
+      text: renderLine(line, {}),
+      toolEvents: [
+        {
+          toolName: 'searchSpotifyArtist',
+          input: { query },
+          output: {
+            action: 'open_artist_picker',
+            query: query || null,
+            summary: 'Pick the matching Spotify artist.',
+          },
+        },
+      ],
+    };
+  }
+
+  // Artist confirmed but handle not checked yet.
+  if (!findLatestToolOutput(uiMessages, 'check_handle')) {
+    const handle = handleFromArtistName(state.spotifyArtistName ?? '');
+    const line = pickLine('handle', sessionId);
+    return {
+      line,
+      text: renderLine(line, { handle }),
+      toolEvents: [
+        {
+          toolName: 'checkHandle',
+          input: { handle },
+          output: {
+            action: 'check_handle',
+            handle,
+            summary: `Checking @${handle}.`,
+          },
+        },
+      ],
+    };
+  }
+
+  // Access decision phase.
+  const existingDecision = findLatestToolOutput(
+    uiMessages,
+    'propose_next_step'
+  );
+  const existingDecisionKind = isRecord(existingDecision?.decision)
+    ? typeof existingDecision.decision.kind === 'string'
+      ? existingDecision.decision.kind
+      : null
+    : null;
+  return decisionTurn(input, existingDecisionKind);
+}

--- a/apps/web/lib/chat/onboarding-script/respond.ts
+++ b/apps/web/lib/chat/onboarding-script/respond.ts
@@ -1,0 +1,115 @@
+import 'server-only';
+import { randomUUID } from 'node:crypto';
+import {
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  type UIMessageChunk,
+} from 'ai';
+import type { PersistedToolEvent } from '@/lib/chat/tool-events';
+import { getToolUiConfig } from '@/lib/chat/tool-ui-registry';
+import type { FallbackTurn } from './engine';
+
+/**
+ * Serialize a deterministic fallback turn (JOV-3806) as the UIMessage SSE
+ * stream the onboarding client (`useChat`) expects — same shape the LLM
+ * path streams, so the client renders scripted turns and LLM turns
+ * identically (text + tool cards).
+ */
+
+export type FallbackReason = 'llm_error' | 'kill_switch' | 'injected';
+
+export interface ScriptedFallbackResponseInput {
+  readonly turn: FallbackTurn;
+  readonly reason: FallbackReason;
+  readonly headers: Record<string, string>;
+}
+
+interface EmittedToolCall {
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly input: Record<string, unknown>;
+  readonly output: Record<string, unknown>;
+}
+
+function withToolCallIds(turn: FallbackTurn): readonly EmittedToolCall[] {
+  return turn.toolEvents.map(event => ({
+    toolCallId: randomUUID(),
+    toolName: event.toolName,
+    input: event.input,
+    output: event.output,
+  }));
+}
+
+/**
+ * Convert the emitted tool calls into the persisted `tool_calls` shape
+ * (schemaVersion 2) so claim-time state derivation treats fallback turns
+ * exactly like LLM turns.
+ */
+export function toPersistedToolEvents(
+  toolCalls: readonly EmittedToolCall[]
+): PersistedToolEvent[] | undefined {
+  if (toolCalls.length === 0) return undefined;
+  return toolCalls.map(call => ({
+    schemaVersion: 2,
+    toolCallId: call.toolCallId,
+    toolName: call.toolName,
+    state: 'succeeded',
+    input: call.input,
+    output: call.output,
+    summary:
+      typeof call.output.summary === 'string' ? call.output.summary : undefined,
+    uiHint: getToolUiConfig(call.toolName).uiHint,
+  }));
+}
+
+export interface BuiltScriptedFallback {
+  readonly response: Response;
+  readonly persistedToolEvents: PersistedToolEvent[] | undefined;
+}
+
+export function buildScriptedFallbackResponse(
+  input: ScriptedFallbackResponseInput
+): BuiltScriptedFallback {
+  const { turn, reason, headers } = input;
+  const toolCalls = withToolCallIds(turn);
+  const textId = randomUUID();
+
+  const stream = createUIMessageStream({
+    execute: ({ writer }) => {
+      writer.write({ type: 'start' });
+      writer.write({ type: 'start-step' });
+      writer.write({ type: 'text-start', id: textId });
+      writer.write({ type: 'text-delta', id: textId, delta: turn.text });
+      writer.write({ type: 'text-end', id: textId });
+      for (const call of toolCalls) {
+        writer.write({
+          type: 'tool-input-available',
+          toolCallId: call.toolCallId,
+          toolName: call.toolName,
+          input: call.input,
+        } as UIMessageChunk);
+        writer.write({
+          type: 'tool-output-available',
+          toolCallId: call.toolCallId,
+          output: call.output,
+        } as UIMessageChunk);
+      }
+      writer.write({ type: 'finish-step' });
+      writer.write({ type: 'finish', finishReason: 'stop' } as UIMessageChunk);
+    },
+  });
+
+  const response = createUIMessageStreamResponse({
+    stream,
+    headers: {
+      ...headers,
+      'x-onboarding-fallback': turn.line.key,
+      'x-fallback-reason': reason,
+    },
+  });
+
+  return {
+    response,
+    persistedToolEvents: toPersistedToolEvents(toolCalls),
+  };
+}

--- a/apps/web/tests/unit/lib/chat/onboarding-script/engine.test.ts
+++ b/apps/web/tests/unit/lib/chat/onboarding-script/engine.test.ts
@@ -1,0 +1,287 @@
+import type { UIMessage } from 'ai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  getSpotifyArtistMock: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/spotify', () => ({
+  getSpotifyArtist: hoisted.getSpotifyArtistMock,
+  buildSpotifyArtistUrl: (id: string) =>
+    `https://open.spotify.com/artist/${id}`,
+}));
+
+import {
+  decideFallbackTurn,
+  handleFromArtistName,
+  parseArtistSelection,
+  parseAudienceBand,
+} from '@/lib/chat/onboarding-script/engine';
+import { createOnboardingTurnState } from '@/lib/chat/tools/onboarding-tool-impls';
+
+const SESSION = '00112233-4455-6677-8899-aabbccddeeff';
+
+function user(text: string, metadata?: Record<string, unknown>): UIMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: 'user',
+    parts: [{ type: 'text', text }],
+    ...(metadata ? { metadata } : {}),
+  } as UIMessage;
+}
+
+function assistant(
+  text: string,
+  toolParts: readonly {
+    toolName: string;
+    output: Record<string, unknown>;
+  }[] = []
+): UIMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: 'assistant',
+    parts: [
+      { type: 'text', text },
+      ...toolParts.map(part => ({
+        type: `tool-${part.toolName}`,
+        toolCallId: crypto.randomUUID(),
+        state: 'output-available',
+        input: {},
+        output: part.output,
+      })),
+    ],
+  } as UIMessage;
+}
+
+function stateFor(messages: readonly UIMessage[]) {
+  return createOnboardingTurnState({
+    sessionId: SESSION,
+    turnCount: messages.filter(m => m.role === 'user').length,
+    messages,
+  });
+}
+
+async function decide(messages: readonly UIMessage[]) {
+  return decideFallbackTurn({
+    uiMessages: messages,
+    state: stateFor(messages),
+  });
+}
+
+const CONFIRMED_OUTPUT = {
+  action: 'spotify_artist_confirmed',
+  spotifyArtistId: 'artist-1',
+  artist: {
+    id: 'artist-1',
+    name: 'Test Artist',
+    url: 'https://open.spotify.com/artist/artist-1',
+    followers: 12_300,
+    popularity: 48,
+    genres: ['house'],
+  },
+};
+
+describe('parseArtistSelection', () => {
+  it('reads the spotifyArtistId from message metadata', () => {
+    expect(
+      parseArtistSelection(user('I picked X', { spotifyArtistId: 'abc123' }))
+    ).toBe('abc123');
+  });
+
+  it('parses a pasted Spotify artist URL', () => {
+    expect(
+      parseArtistSelection(
+        user('here https://open.spotify.com/artist/4uXYZ?si=1')
+      )
+    ).toBe('4uXYZ');
+  });
+
+  it('returns null for plain text', () => {
+    expect(parseArtistSelection(user('I am Test Artist'))).toBeNull();
+  });
+});
+
+describe('parseAudienceBand', () => {
+  it.each([
+    ['about 200 people', 'under_500'],
+    ['2k monthly', '500_to_5k'],
+    ['12,000 followers', '5k_to_50k'],
+    ['around 100k', '50k_to_500k'],
+    ['1.2m', 'over_500k'],
+    ['no idea honestly', null],
+  ])('%s → %s', (text, band) => {
+    expect(parseAudienceBand(text)).toBe(band);
+  });
+});
+
+describe('handleFromArtistName', () => {
+  it('slugs names to handle-safe strings', () => {
+    expect(handleFromArtistName('Tïesto & Friends!')).toBe('tiestofriends');
+    expect(handleFromArtistName('')).toBe('artist');
+  });
+});
+
+describe('decideFallbackTurn', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('greets on the first turn', async () => {
+    const turn = await decide([user('hey')]);
+    expect(turn.line.stepId).toBe('greet');
+    expect(turn.toolEvents).toHaveLength(0);
+    expect(turn.text).toContain("I'm Jovie");
+  });
+
+  it('opens the artist picker on later turns without an artist', async () => {
+    const turn = await decide([
+      user('hey'),
+      assistant('What are you working on?'),
+      user('I am Test Artist'),
+    ]);
+    expect(turn.line.stepId).toBe('get_artist');
+    expect(turn.toolEvents).toHaveLength(1);
+    expect(turn.toolEvents[0]?.toolName).toBe('searchSpotifyArtist');
+    expect(turn.toolEvents[0]?.output.action).toBe('open_artist_picker');
+    expect(turn.toolEvents[0]?.input.query).toBe('I am Test Artist');
+  });
+
+  it('confirms the artist when the user picks one (metadata id)', async () => {
+    hoisted.getSpotifyArtistMock.mockResolvedValue({
+      id: 'artist-1',
+      name: 'Test Artist',
+      images: [{ url: 'https://i.scdn.co/image/x' }],
+      genres: ['house'],
+      popularity: 48,
+      followers: { total: 12_300 },
+    });
+    const turn = await decide([
+      user('hey'),
+      assistant('Pick your artist below.', [
+        {
+          toolName: 'searchSpotifyArtist',
+          output: { action: 'open_artist_picker', query: 'test' },
+        },
+      ]),
+      user('I picked Test Artist on Spotify.', { spotifyArtistId: 'artist-1' }),
+    ]);
+    expect(turn.line.stepId).toBe('confirm_artist');
+    expect(turn.text).toContain('12.3k');
+    expect(turn.toolEvents[0]?.toolName).toBe('confirmSpotifyArtist');
+    expect(turn.toolEvents[0]?.output.action).toBe('spotify_artist_confirmed');
+  });
+
+  it('degrades to the no-data line when Spotify enrichment fails', async () => {
+    hoisted.getSpotifyArtistMock.mockRejectedValue(new Error('spotify down'));
+    const turn = await decide([
+      user('hey'),
+      user('I picked Test Artist on Spotify.', { spotifyArtistId: 'artist-1' }),
+    ]);
+    expect(turn.line.stepId).toBe('confirm_artist_no_data');
+    expect(turn.toolEvents[0]?.output.action).toBe('spotify_artist_confirmed');
+  });
+
+  it('moves to the handle check once the artist is confirmed', async () => {
+    const turn = await decide([
+      user('hey'),
+      assistant('Pulled you up.', [
+        { toolName: 'confirmSpotifyArtist', output: CONFIRMED_OUTPUT },
+      ]),
+      user('nice, what next?'),
+    ]);
+    expect(turn.line.stepId).toBe('handle');
+    expect(turn.toolEvents[0]?.toolName).toBe('checkHandle');
+    expect(turn.toolEvents[0]?.input.handle).toBe('testartist');
+    expect(turn.text).toContain('@testartist');
+  });
+
+  it('routes to instant access + checkout when followers clear the bar', async () => {
+    const turn = await decide([
+      user('hey'),
+      assistant('Pulled you up.', [
+        { toolName: 'confirmSpotifyArtist', output: CONFIRMED_OUTPUT },
+        {
+          toolName: 'checkHandle',
+          output: { action: 'check_handle', handle: 'testartist' },
+        },
+      ]),
+      user('ok done'),
+    ]);
+    expect(turn.line.stepId).toBe('instant_access');
+    const actions = turn.toolEvents.map(event => event.output.action);
+    expect(actions).toContain('propose_next_step');
+    expect(actions).toContain('propose_checkout');
+  });
+
+  it('waitlists low-signal visitors once the turn cap forces a decision', async () => {
+    const lowSignal = {
+      ...CONFIRMED_OUTPUT,
+      artist: { ...CONFIRMED_OUTPUT.artist, followers: 120 },
+    };
+    const turn = await decide([
+      user('hey'),
+      assistant('Pulled you up.', [
+        { toolName: 'confirmSpotifyArtist', output: lowSignal },
+        {
+          toolName: 'checkHandle',
+          output: { action: 'check_handle', handle: 'testartist' },
+        },
+      ]),
+      user('turn two'),
+      assistant('One thing before I route you: audience size?'),
+      user('like 300 people'),
+    ]);
+    // turnCount 3 forces a decision; 300 listeners → waitlist.
+    expect(turn.line.stepId).toBe('waitlist');
+    expect(turn.toolEvents.map(event => event.output.action)).toContain(
+      'propose_next_step'
+    );
+    // The parsed audience answer is recorded as a signal.
+    expect(turn.toolEvents.map(event => event.toolName)).toContain(
+      'recordInterviewSignal'
+    );
+  });
+
+  it('promotes to instant access when the audience reply clears the bar', async () => {
+    const lowSignal = {
+      ...CONFIRMED_OUTPUT,
+      artist: { ...CONFIRMED_OUTPUT.artist, followers: 120 },
+    };
+    const turn = await decide([
+      user('hey'),
+      assistant('Pulled you up.', [
+        { toolName: 'confirmSpotifyArtist', output: lowSignal },
+        {
+          toolName: 'checkHandle',
+          output: { action: 'check_handle', handle: 'testartist' },
+        },
+      ]),
+      user('around 20k on instagram'),
+    ]);
+    expect(turn.line.stepId).toBe('instant_access');
+  });
+
+  it('points back at the card once a terminal decision exists', async () => {
+    const turn = await decide([
+      user('hey'),
+      assistant('On the list.', [
+        { toolName: 'confirmSpotifyArtist', output: CONFIRMED_OUTPUT },
+        {
+          toolName: 'checkHandle',
+          output: { action: 'check_handle', handle: 'testartist' },
+        },
+        {
+          toolName: 'proposeNextStep',
+          output: {
+            action: 'propose_next_step',
+            decision: { kind: 'waitlist', rationale: 'x', score: 30 },
+          },
+        },
+      ]),
+      user('so now what'),
+    ]);
+    expect(turn.line.stepId).toBe('done');
+    expect(turn.toolEvents).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Part 2/3 of JOV-3806.

- New `lib/chat/onboarding-script/engine.ts`: stateless fallback state machine — greet → artist picker → confirm (Spotify enrichment, best-effort) → handle check → access decision → checkout/waitlist. State is recovered per-request from persisted tool outputs in conversation history; access decisions reuse the same `evaluateAccessSignal` the LLM tool calls, so the fallback can never invent access grants.
- New `lib/chat/onboarding-script/respond.ts`: streams scripted turns as the same UIMessage SSE shape the LLM path emits (text + `tool-input-available`/`tool-output-available`), so the client renders real cards; also produces the schemaVersion-2 persisted tool events the claim flow reads.
- Parses free-text audience answers ("like 2k") into `audienceBand` signals.

## Verification
- `engine.test.ts` — 19 passed (full state table, Spotify-failure degradation, URL/metadata artist parsing)
- Typecheck + biome clean

Stack: #12698 → 2/3 (this) → #12700

<!-- linear-issue-id:JOV-3806 -->