### PR TITLE
feat(onboarding): serve scripted fallback when the LLM fails

### DIFF
--- a/apps/web/app/api/chat/onboarding-handler.ts
+++ b/apps/web/app/api/chat/onboarding-handler.ts
@@ -5,10 +5,22 @@ import type { UIMessage } from 'ai';
 import { and, desc, sql as drizzleSql, eq, isNull } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import {
+  decideFallbackTurn,
+  type FallbackTurn,
+} from '@/lib/chat/onboarding-script/engine';
+import {
+  buildScriptedFallbackResponse,
+  type FallbackReason,
+} from '@/lib/chat/onboarding-script/respond';
+import { STREAM_ERROR_LINE } from '@/lib/chat/onboarding-script/script';
 import { sanitizeAssistantResponse } from '@/lib/chat/prompt-disclosure-guard';
 import { executeChatTurn, isClientDisconnect } from '@/lib/chat/run';
 import { sanitizeConversationTitle } from '@/lib/chat/title';
-import { encodeToolEvents } from '@/lib/chat/tool-events';
+import {
+  encodeToolEvents,
+  type PersistedToolEvent,
+} from '@/lib/chat/tool-events';
 import {
   buildOnboardingTools,
   createOnboardingTurnState,
@@ -203,20 +215,13 @@ export async function tryHandleAnonymousOnboardingChat(
   // Anonymous onboarding is a live route, not a default-off rollout. Reuse the
   // existing chat kill switch so unconfigured Statsig cannot disable /start.
   // Anonymous → pass `null` userId; Statsig falls back to public conditions.
+  // The switch no longer 503s onboarding: it skips the LLM dispatch and the
+  // deterministic script (JOV-3806) carries the conversation instead. Abuse
+  // controls (Turnstile, rate limits) below still run in full.
   const shouldBypassTurnstile = shouldBypassTurnstileForLocalRuntime(req);
   const chatDisabled = shouldBypassTurnstile
     ? false
     : await checkGateForUser(null, CHAT_DISABLED_GATE, false);
-  if (chatDisabled) {
-    return NextResponse.json(
-      {
-        error: 'Onboarding chat is temporarily unavailable',
-        errorCode: 'ONBOARDING_CHAT_DISABLED',
-        requestId,
-      },
-      { status: 503, headers: { ...corsHeaders, 'x-request-id': requestId } }
-    );
-  }
 
   // --- Session cookie: read existing or mint a new one ---
   const incomingCookieHeader = req.headers.get('cookie') || '';
@@ -421,7 +426,63 @@ export async function tryHandleAnonymousOnboardingChat(
   // until we have signal a real artist is on the other end — flipped via
   // confirmSpotifyArtist + recordInterviewSignal in a follow-up commit.
   const freeTierLimits = getEntitlements('free');
+
+  const responseHeaders: Record<string, string> = {
+    ...corsHeaders,
+    'x-request-id': requestId,
+    'x-chat-mode': 'onboarding',
+  };
+  if (mintedSessionCookie) {
+    responseHeaders['set-cookie'] =
+      buildSessionCookieHeader(mintedSessionCookie);
+  }
+
+  // Deterministic scripted fallback (JOV-3806): serves the onboarding rail
+  // without the LLM. Fresh state derivation — the LLM turn may have partially
+  // mutated `onboardingState` before failing.
+  const serveScriptedFallback = async (
+    reason: FallbackReason
+  ): Promise<Response> => {
+    const fallbackState = createOnboardingTurnState({
+      sessionId,
+      turnCount,
+      messages: uiMessages,
+    });
+    const turn: FallbackTurn = await decideFallbackTurn({
+      uiMessages,
+      state: fallbackState,
+    });
+    const built = buildScriptedFallbackResponse({
+      turn,
+      reason,
+      headers: responseHeaders,
+    });
+    await persistAnonymousAssistantRecord({
+      conversationId,
+      latestUserClientMessageId: latestUserMessage.clientMessageId,
+      content: turn.text,
+      toolCalls: built.persistedToolEvents,
+    });
+    Sentry.addBreadcrumb({
+      category: 'onboarding-chat',
+      message: 'scripted_fallback_dispatch',
+      level: 'warning',
+      data: { reason, lineKey: turn.line.key, turnCount },
+    });
+    return built.response;
+  };
+
+  const forcedFallbackReason: FallbackReason | null = chatDisabled
+    ? 'kill_switch'
+    : isLlmFailureInjected(req)
+      ? 'injected'
+      : null;
+
   try {
+    if (forcedFallbackReason) {
+      return await serveScriptedFallback(forcedFallbackReason);
+    }
+
     const turn = await executeChatTurn({
       uiMessages,
       artistContext: null,
@@ -455,16 +516,6 @@ export async function tryHandleAnonymousOnboardingChat(
       },
     });
 
-    const responseHeaders: Record<string, string> = {
-      ...corsHeaders,
-      'x-request-id': requestId,
-      'x-chat-mode': 'onboarding',
-    };
-    if (mintedSessionCookie) {
-      responseHeaders['set-cookie'] =
-        buildSessionCookieHeader(mintedSessionCookie);
-    }
-
     return turn.streamResult.toUIMessageStreamResponse({
       headers: responseHeaders,
       onFinish: async ({ responseMessage }) => {
@@ -474,8 +525,9 @@ export async function tryHandleAnonymousOnboardingChat(
           responseMessage,
         });
       },
-      onError: () =>
-        'Jovie hit a temporary issue while processing your message. Please retry or send a simpler next step.',
+      // Mid-stream failures cannot swap the Response for the scripted
+      // fallback; the lint-clean script line is the recovery copy instead.
+      onError: () => STREAM_ERROR_LINE.text,
     });
   } catch (error) {
     if (isClientDisconnect(error, req.signal)) {
@@ -484,22 +536,49 @@ export async function tryHandleAnonymousOnboardingChat(
         headers: { ...corsHeaders, 'x-request-id': requestId },
       });
     }
+    // The LLM failure still pages — the fallback masks the user impact, not
+    // the incident.
     Sentry.captureException(error, {
       tags: { feature: 'ai-chat', chat_mode: 'onboarding' },
       extra: { sessionId: sessionId.slice(0, 8), requestId, turnCount },
     });
-    return NextResponse.json(
-      {
-        error: 'Onboarding chat failed',
-        errorCode: 'INTERNAL_ERROR',
-        requestId,
-      },
-      {
-        status: 500,
-        headers: { ...corsHeaders, 'x-request-id': requestId },
-      }
-    );
+    try {
+      return await serveScriptedFallback('llm_error');
+    } catch (fallbackError) {
+      Sentry.captureException(fallbackError, {
+        tags: {
+          feature: 'ai-chat',
+          chat_mode: 'onboarding',
+          context: 'scripted_fallback_failed',
+        },
+        extra: { sessionId: sessionId.slice(0, 8), requestId, turnCount },
+      });
+      return NextResponse.json(
+        {
+          error: 'Onboarding chat failed',
+          errorCode: 'INTERNAL_ERROR',
+          requestId,
+        },
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'x-request-id': requestId },
+        }
+      );
+    }
   }
+}
+
+/**
+ * E2E-only LLM failure injection. Fails closed: the header is inert unless
+ * the server was started with `CHAT_LLM_FAILURE_INJECTION=1`, and production
+ * deploys ignore it unconditionally.
+ */
+function isLlmFailureInjected(req: Request): boolean {
+  return (
+    env.CHAT_LLM_FAILURE_INJECTION === '1' &&
+    env.VERCEL_ENV !== 'production' &&
+    req.headers.get('x-jovie-e2e-llm-failure') === '1'
+  );
 }
 
 interface LatestUserMessage {
@@ -601,11 +680,29 @@ async function persistAnonymousAssistantMessage({
   readonly latestUserClientMessageId: string;
   readonly responseMessage: UIMessage;
 }): Promise<void> {
-  const now = new Date();
   const assistantText = sanitizeAssistantResponse(
     extractUIMessageText(responseMessage.parts)
   ).text;
-  const toolCalls = encodeToolEvents(responseMessage.parts);
+  await persistAnonymousAssistantRecord({
+    conversationId,
+    latestUserClientMessageId,
+    content: assistantText,
+    toolCalls: encodeToolEvents(responseMessage.parts),
+  });
+}
+
+async function persistAnonymousAssistantRecord({
+  conversationId,
+  latestUserClientMessageId,
+  content,
+  toolCalls,
+}: {
+  readonly conversationId: string;
+  readonly latestUserClientMessageId: string;
+  readonly content: string;
+  readonly toolCalls: PersistedToolEvent[] | undefined;
+}): Promise<void> {
+  const now = new Date();
   await db
     .insert(chatMessages)
     .values({
@@ -613,7 +710,7 @@ async function persistAnonymousAssistantMessage({
       clientMessageId: `assistant:${latestUserClientMessageId}`,
       role: 'assistant',
       content:
-        assistantText ||
+        content ||
         (toolCalls && toolCalls.length > 0
           ? ''
           : 'Done. What would you like to do next?'),

--- a/apps/web/app/api/chat/onboarding-handler.ts
+++ b/apps/web/app/api/chat/onboarding-handler.ts
@@ -48,6 +48,7 @@ import {
   verifyTurnstileToken,
 } from '@/lib/turnstile/verify';
 import { extractClientIPFromRequest } from '@/lib/utils/ip-extraction';
+import { logger } from '@/lib/utils/logger';
 
 /** Existing Statsig kill switch for all `/api/chat` traffic. */
 const CHAT_DISABLED_GATE = 'ai_chat_disabled';
@@ -537,7 +538,12 @@ export async function tryHandleAnonymousOnboardingChat(
       });
     }
     // The LLM failure still pages — the fallback masks the user impact, not
-    // the incident.
+    // the incident. The logger line keeps the failure visible in local dev,
+    // where Sentry is a no-op and the fallback would otherwise hide it.
+    logger.error(
+      '[onboarding-chat] LLM turn failed; serving scripted fallback',
+      { error, requestId, turnCount }
+    );
     Sentry.captureException(error, {
       tags: { feature: 'ai-chat', chat_mode: 'onboarding' },
       extra: { sessionId: sessionId.slice(0, 8), requestId, turnCount },

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -905,7 +905,7 @@ export function OnboardingChat({
   });
 
   const submitText = useCallback(
-    (rawText: string) => {
+    (rawText: string, metadata?: Record<string, unknown>) => {
       const text = composeMessage(chipTray.chips, rawText).trim();
       if (!text || isBusy || localAutomationBypass === null) return;
       if (isAwaitingFirstToken) {
@@ -922,7 +922,7 @@ export function OnboardingChat({
           surface: 'start_chat',
         });
       }
-      sendMessage({ text });
+      sendMessage({ text, ...(metadata ? { metadata } : {}) });
       chipTray.clear();
       setHasSentFirst(true);
       setComposerInput('');
@@ -971,7 +971,12 @@ export function OnboardingChat({
   const handleArtistSelect = useCallback(
     (artist: OnboardingArtistSelection) => {
       setSelectedArtist(artist);
-      submitText(formatArtistSelectionMessage(artist));
+      // The Spotify id rides as message metadata (not visible text) so the
+      // server — LLM tools and the deterministic fallback engine alike — can
+      // confirm the exact artist without parsing the display name.
+      submitText(formatArtistSelectionMessage(artist), {
+        spotifyArtistId: artist.id,
+      });
     },
     [formatArtistSelectionMessage, submitText]
   );

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -52,6 +52,12 @@ export const ServerEnvSchema = z.object({
     .optional(),
   VERCEL_AUTOMATION_BYPASS_SECRET: z.string().optional(),
   PUBLIC_NOAUTH_SMOKE: z.string().optional(),
+  /**
+   * E2E-only: lets tests force the onboarding LLM path to fail so the
+   * deterministic fallback can be exercised. Hard-ignored on production
+   * deploys regardless of value (see onboarding-handler.ts).
+   */
+  CHAT_LLM_FAILURE_INJECTION: z.string().optional(),
 
   // Clerk server-side configuration
   CLERK_SECRET_KEY: z.string().optional(),
@@ -379,6 +385,7 @@ export const ENV_KEYS = [
   'VERCEL_URL',
   'VERCEL_AUTOMATION_BYPASS_SECRET',
   'PUBLIC_NOAUTH_SMOKE',
+  'CHAT_LLM_FAILURE_INJECTION',
   'CLERK_SECRET_KEY',
   'CLERK_WEBHOOK_SECRET',
   'CLERK_PUBLISHABLE_KEY_STAGING',

--- a/apps/web/playwright.config.smoke.ts
+++ b/apps/web/playwright.config.smoke.ts
@@ -106,6 +106,10 @@ export default defineConfig({
             PORT: managedWebServerPort,
             NEXT_PUBLIC_E2E_MODE: '1',
             NEXT_DISABLE_TOOLBAR: '1',
+            // Arms the onboarding LLM-failure fallback spec. Inert unless a
+            // request also carries x-jovie-e2e-llm-failure; hard-ignored on
+            // production deploys (see onboarding-handler.ts).
+            CHAT_LLM_FAILURE_INJECTION: '1',
             E2E_USE_TEST_AUTH_BYPASS: useTestAuthBypass ? '1' : '0',
             E2E_WEB_SERVER_WARMUP: webServerWarmupProfile,
             ...(useTestAuthBypass

--- a/apps/web/tests/e2e/smoke-manifest.ts
+++ b/apps/web/tests/e2e/smoke-manifest.ts
@@ -20,6 +20,7 @@ export const DESKTOP_SMOKE_SPECS = [
   'golden-path.spec.ts',
   'profile-fan-capture-golden-path.spec.ts',
   'onboarding-robot.smoke.spec.ts',
+  'start-onboarding-llm-failure.spec.ts',
   'signup-funnel.smoke.spec.ts',
   'smoke-auth.spec.ts',
   'shell-chat-v1.spec.ts',

--- a/apps/web/tests/e2e/start-onboarding-llm-failure.spec.ts
+++ b/apps/web/tests/e2e/start-onboarding-llm-failure.spec.ts
@@ -1,0 +1,84 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from './setup';
+import { waitForHydration } from './utils/smoke-test-utils';
+
+/**
+ * Onboarding must never be blocked by LLM failure (JOV-3806).
+ *
+ * Every /api/chat request in this spec carries `x-jovie-e2e-llm-failure: 1`,
+ * which the server honors only because the smoke web server runs with
+ * `CHAT_LLM_FAILURE_INJECTION=1` (see playwright.config.smoke.ts). The LLM
+ * path is skipped entirely; the deterministic script must carry the
+ * conversation: greet → artist picker → confirm, with real tool cards and
+ * no error UI.
+ */
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const COMPOSER_TEXTAREA = '[aria-label="Chat message input" i]';
+
+async function injectLlmFailureHeader(page: Page) {
+  await page.route('**/api/chat', async route => {
+    await route.continue({
+      headers: {
+        ...route.request().headers(),
+        'x-jovie-e2e-llm-failure': '1',
+      },
+    });
+  });
+}
+
+async function sendComposerMessage(page: Page, text: string) {
+  await page.locator(COMPOSER_TEXTAREA).fill(text);
+  const sendButton = page.getByRole('button', { name: 'Send message' });
+  await expect(sendButton).toBeEnabled();
+  await sendButton.click();
+}
+
+test.describe('onboarding chat with the LLM down', () => {
+  test.setTimeout(240_000);
+
+  test.beforeEach(async ({ page }) => {
+    page.setDefaultNavigationTimeout(180_000);
+    await page.addInitScript(() => {
+      localStorage.setItem('__dev_toolbar_hidden', '1');
+    });
+    await injectLlmFailureHeader(page);
+  });
+
+  test('deterministic script carries the visitor to the artist picker', async ({
+    page,
+  }) => {
+    await page.goto('/start', { waitUntil: 'domcontentloaded' });
+    await waitForHydration(page);
+
+    // Turn 1: scripted greeting streams back instead of a 500.
+    const firstResponse = page.waitForResponse('**/api/chat');
+    await sendComposerMessage(page, 'hey, I want in');
+    const first = await firstResponse;
+    expect(first.status()).toBe(200);
+    expect(first.headers()['x-fallback-reason']).toBe('injected');
+    expect(first.headers()['x-onboarding-fallback']).toMatch(/^greet:/);
+    await expect(page.getByText(/I'm Jovie/).first()).toBeVisible();
+
+    // No error UI anywhere.
+    await expect(
+      page.getByRole('alert').filter({ hasText: 'Message paused' })
+    ).toHaveCount(0);
+
+    // Turn 2: the script opens the real artist picker card.
+    const secondResponse = page.waitForResponse('**/api/chat');
+    await sendComposerMessage(page, 'I am Test Artist');
+    const second = await secondResponse;
+    expect(second.status()).toBe(200);
+    expect(second.headers()['x-onboarding-fallback']).toMatch(/^get_artist:/);
+    await expect(page.getByTestId('onboarding-artist-picker')).toBeVisible();
+
+    await expect(
+      page.getByRole('alert').filter({ hasText: 'Message paused' })
+    ).toHaveCount(0);
+
+    // The scripted rail keeps the composer usable for the next turn.
+    await expect(page.locator(COMPOSER_TEXTAREA)).toBeEditable();
+  });
+});

--- a/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
+++ b/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
@@ -193,24 +193,176 @@ describe('tryHandleAnonymousOnboardingChat', () => {
     );
   });
 
-  it('returns 503 when the global chat kill-switch is enabled', async () => {
+  it('serves the scripted fallback when the global chat kill-switch is enabled', async () => {
     vi.resetModules();
     stubRuntimeEnv({ nodeEnv: 'production' });
     hoisted.checkGateForUserMock.mockResolvedValue(true);
+    hoisted.isTurnstileConfiguredMock.mockReturnValue(true);
+    hoisted.verifyTurnstileTokenMock.mockResolvedValue({ success: true });
     const { tryHandleAnonymousOnboardingChat } = await import(
       '@/app/api/chat/onboarding-handler'
     );
     const req = makeRequest({
       mode: 'onboarding',
+      turnstileToken: 'tok',
       messages: [userMessage('hi')],
     });
     const result = await tryHandleAnonymousOnboardingChat(req, 'req-2');
     expect(result).not.toBeNull();
-    expect(result?.status).toBe(503);
-    const body = await result?.json();
-    expect(body.errorCode).toBe('ONBOARDING_CHAT_DISABLED');
-    // Dispatch must NOT have been called when the gate is closed.
+    // The kill switch no longer blocks onboarding — the deterministic script
+    // answers instead (JOV-3806).
+    expect(result?.status).toBe(200);
+    expect(result?.headers.get('x-fallback-reason')).toBe('kill_switch');
+    expect(result?.headers.get('x-onboarding-fallback')).toMatch(/^greet:/);
+    expect(await result?.text()).toContain("I'm Jovie");
+    // The LLM must NOT have been called when the gate is closed.
     expect(hoisted.executeChatTurnMock).not.toHaveBeenCalled();
+  });
+
+  it('serves the scripted fallback when executeChatTurn throws', async () => {
+    vi.resetModules();
+    stubRuntimeEnv();
+    hoisted.executeChatTurnMock.mockRejectedValue(
+      new Error('anthropic 529 overloaded')
+    );
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest({
+      mode: 'onboarding',
+      messages: [userMessage('hi, I want in')],
+    });
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-llm-down');
+
+    expect(result?.status).toBe(200);
+    expect(result?.headers.get('x-fallback-reason')).toBe('llm_error');
+    expect(result?.headers.get('x-onboarding-fallback')).toMatch(/^greet:/);
+    // Fresh session still gets its cookie even on the fallback path.
+    expect(result?.headers.get('set-cookie')).toContain(
+      'jovie_onboarding_session='
+    );
+    expect(await result?.text()).toContain("I'm Jovie");
+    // The LLM failure still pages.
+    expect(hoisted.captureExceptionMock).toHaveBeenCalled();
+  });
+
+  it('opens the artist picker via fallback on a later turn when the LLM is down', async () => {
+    vi.resetModules();
+    stubRuntimeEnv();
+    hoisted.executeChatTurnMock.mockRejectedValue(new Error('provider down'));
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest({
+      mode: 'onboarding',
+      messages: [
+        userMessage('hey'),
+        {
+          id: crypto.randomUUID(),
+          role: 'assistant' as const,
+          parts: [{ type: 'text', text: 'What are you working on?' }],
+        },
+        userMessage('I am Test Artist'),
+      ],
+    });
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-picker');
+
+    expect(result?.status).toBe(200);
+    expect(result?.headers.get('x-onboarding-fallback')).toMatch(
+      /^get_artist:/
+    );
+    const body = await result?.text();
+    expect(body).toContain('open_artist_picker');
+    expect(body).toContain('searchSpotifyArtist');
+  });
+
+  it('honors LLM failure injection only when the server env enables it', async () => {
+    vi.resetModules();
+    stubRuntimeEnv();
+    vi.stubEnv('CHAT_LLM_FAILURE_INJECTION', '1');
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest(
+      { mode: 'onboarding', messages: [userMessage('hi')] },
+      '',
+      { 'x-jovie-e2e-llm-failure': '1' }
+    );
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-inject');
+
+    expect(result?.status).toBe(200);
+    expect(result?.headers.get('x-fallback-reason')).toBe('injected');
+    expect(hoisted.executeChatTurnMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores the injection header when the env flag is not set', async () => {
+    vi.resetModules();
+    stubRuntimeEnv();
+    hoisted.executeChatTurnMock.mockResolvedValue({
+      streamResult: {
+        toUIMessageStreamResponse: ({
+          headers,
+        }: {
+          headers: Record<string, string>;
+        }) => new Response('ok', { status: 200, headers }),
+      },
+      selectedModel: 'anthropic/claude-haiku-4-5-20251001',
+      systemPrompt: '',
+      toolNames: [],
+      modelMessages: [],
+    });
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest(
+      { mode: 'onboarding', messages: [userMessage('hi')] },
+      '',
+      { 'x-jovie-e2e-llm-failure': '1' }
+    );
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-noinject');
+
+    expect(result?.status).toBe(200);
+    expect(result?.headers.get('x-fallback-reason')).toBeNull();
+    expect(hoisted.executeChatTurnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores the injection header on production deploys even with the env flag', async () => {
+    vi.resetModules();
+    stubRuntimeEnv({ nodeEnv: 'production', vercelEnv: 'production' });
+    vi.stubEnv('CHAT_LLM_FAILURE_INJECTION', '1');
+    hoisted.checkGateForUserMock.mockResolvedValue(false);
+    hoisted.isTurnstileConfiguredMock.mockReturnValue(true);
+    hoisted.verifyTurnstileTokenMock.mockResolvedValue({ success: true });
+    hoisted.executeChatTurnMock.mockResolvedValue({
+      streamResult: {
+        toUIMessageStreamResponse: ({
+          headers,
+        }: {
+          headers: Record<string, string>;
+        }) => new Response('ok', { status: 200, headers }),
+      },
+      selectedModel: 'anthropic/claude-haiku-4-5-20251001',
+      systemPrompt: '',
+      toolNames: [],
+      modelMessages: [],
+    });
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest(
+      {
+        mode: 'onboarding',
+        turnstileToken: 'tok',
+        messages: [userMessage('hi')],
+      },
+      '',
+      { 'x-jovie-e2e-llm-failure': '1' }
+    );
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-prod');
+
+    expect(result?.status).toBe(200);
+    expect(result?.headers.get('x-fallback-reason')).toBeNull();
+    expect(hoisted.executeChatTurnMock).toHaveBeenCalledTimes(1);
   });
 
   it('returns 400 when the messages array is missing', async () => {

--- a/apps/web/tests/unit/lib/chat/onboarding-script/respond.test.ts
+++ b/apps/web/tests/unit/lib/chat/onboarding-script/respond.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import type { FallbackTurn } from '@/lib/chat/onboarding-script/engine';
+import { buildScriptedFallbackResponse } from '@/lib/chat/onboarding-script/respond';
+import { SCRIPT_LINES } from '@/lib/chat/onboarding-script/script';
+
+const GET_ARTIST_LINE = SCRIPT_LINES.find(line => line.stepId === 'get_artist');
+
+function makeTurn(): FallbackTurn {
+  if (!GET_ARTIST_LINE) throw new Error('missing get_artist line');
+  return {
+    line: GET_ARTIST_LINE,
+    text: GET_ARTIST_LINE.text,
+    toolEvents: [
+      {
+        toolName: 'searchSpotifyArtist',
+        input: { query: 'test artist' },
+        output: {
+          action: 'open_artist_picker',
+          query: 'test artist',
+          summary: 'Pick the matching Spotify artist.',
+        },
+      },
+    ],
+  };
+}
+
+describe('buildScriptedFallbackResponse', () => {
+  it('streams UIMessage chunks the onboarding client can render', async () => {
+    const { response, persistedToolEvents } = buildScriptedFallbackResponse({
+      turn: makeTurn(),
+      reason: 'llm_error',
+      headers: { 'x-request-id': 'req-1' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-onboarding-fallback')).toBe(
+      GET_ARTIST_LINE?.key
+    );
+    expect(response.headers.get('x-fallback-reason')).toBe('llm_error');
+    expect(response.headers.get('x-request-id')).toBe('req-1');
+
+    const body = await response.text();
+    const chunks = body
+      .split('\n')
+      .filter(chunkLine => chunkLine.startsWith('data: '))
+      .map(chunkLine => chunkLine.slice('data: '.length))
+      .filter(payload => payload !== '[DONE]')
+      .map(payload => JSON.parse(payload) as Record<string, unknown>);
+
+    const types = chunks.map(chunk => chunk.type);
+    expect(types).toContain('start');
+    expect(types).toContain('text-delta');
+    expect(types).toContain('tool-input-available');
+    expect(types).toContain('tool-output-available');
+    expect(types).toContain('finish');
+
+    const toolInput = chunks.find(
+      chunk => chunk.type === 'tool-input-available'
+    );
+    const toolOutput = chunks.find(
+      chunk => chunk.type === 'tool-output-available'
+    );
+    expect(toolInput?.toolName).toBe('searchSpotifyArtist');
+    expect(toolInput?.toolCallId).toBeTruthy();
+    expect(toolOutput?.toolCallId).toBe(toolInput?.toolCallId);
+    expect(
+      (toolOutput?.output as Record<string, unknown> | undefined)?.action
+    ).toBe('open_artist_picker');
+
+    const deltas = chunks
+      .filter(chunk => chunk.type === 'text-delta')
+      .map(chunk => chunk.delta)
+      .join('');
+    expect(deltas).toBe(GET_ARTIST_LINE?.text);
+
+    // Persistence payload matches the v2 tool-event schema the claim flow reads.
+    expect(persistedToolEvents).toHaveLength(1);
+    expect(persistedToolEvents?.[0]).toMatchObject({
+      schemaVersion: 2,
+      toolName: 'searchSpotifyArtist',
+      state: 'succeeded',
+      uiHint: 'artifact',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Part 3/3 of JOV-3806 — onboarding chat no longer blocks on LLM failure.

- `onboarding-handler.ts`: when `executeChatTurn` throws, or the `ai_chat_disabled` kill switch is on, the deterministic script answers (200 + `x-onboarding-fallback` / `x-fallback-reason` headers) instead of 500/503. The LLM failure still pages Sentry. Fallback turns persist through the same path as LLM turns. Abuse controls (Turnstile, rate limits) unchanged and still run under the kill switch.
- Mid-stream errors now return the lint-clean scripted recovery line.
- Fail-closed E2E injection: `x-jovie-e2e-llm-failure` header is honored only when the server runs with `CHAT_LLM_FAILURE_INJECTION=1` AND not on a production deploy.
- Artist picker selection now rides the Spotify id as UIMessage metadata (invisible to the user) — fixes a pre-existing gap where neither the LLM nor the fallback reliably knew the picked artist id.
- New deploy-gating smoke spec `start-onboarding-llm-failure.spec.ts` (added to `DESKTOP_SMOKE_SPECS`): with every /api/chat forced to skip the LLM, the scripted rail must carry the visitor to the artist picker with zero error UI.

## Verification
- `onboarding-handler.test.ts` — 19 passed (kill switch → fallback, LLM throw → fallback, injection env/prod gating, persistence-fail 503 unchanged)
- `start-onboarding-llm-failure.spec.ts` — 1 passed against smoke config (real dev server)
- `start-onboarding-chat.spec.ts` regression — 9 passed
- Typecheck + biome clean

## Cost Impact
None. The fallback path makes zero LLM calls (that is the point); the only external call is the existing Spotify artist lookup on confirm, already null-degraded.

Stack: #12698 → #12699 → 3/3 (this)

<!-- linear-issue-id:JOV-3806 -->