### PR TITLE
feat(onboarding): serve promoted script lines from the response bank

### DIFF
--- a/apps/web/lib/chat/onboarding-script/engine.ts
+++ b/apps/web/lib/chat/onboarding-script/engine.ts
@@ -10,7 +10,8 @@ import {
   buildConfirmSpotifyArtistOutput,
   type OnboardingTurnState,
 } from '@/lib/chat/tools/onboarding-tool-impls';
-import { pickLine, renderLine, type ScriptLine } from './script';
+import { loadScriptBank, pickFromBank } from './line-source';
+import { renderLine, type ScriptLine, type ScriptStepId } from './script';
 
 /**
  * Deterministic onboarding fallback engine (JOV-3806).
@@ -175,10 +176,10 @@ function decisionTurn(
     uiMessages: readonly UIMessage[];
     state: OnboardingTurnState;
   }>,
-  existingDecisionKind: string | null
+  existingDecisionKind: string | null,
+  pick: (stepId: ScriptStepId) => ScriptLine
 ): FallbackTurn {
   const { uiMessages, state } = input;
-  const sessionId = state.sessionId;
 
   // Terminal decision already made — point back at the card.
   if (existingDecisionKind && existingDecisionKind !== 'needs_more_info') {
@@ -198,7 +199,7 @@ function decisionTurn(
         },
       });
     }
-    const line = pickLine('done', sessionId);
+    const line = pick('done');
     return { line, text: renderLine(line, {}), toolEvents: events };
   }
 
@@ -231,15 +232,15 @@ function decisionTurn(
         summary: 'Checkout handoff ready.',
       },
     });
-    const line = pickLine('instant_access', sessionId);
+    const line = pick('instant_access');
     return { line, text: renderLine(line, {}), toolEvents: events };
   }
   if (decision.kind === 'waitlist') {
     events.push(proposeNextStepEvent(decision));
-    const line = pickLine('waitlist', sessionId);
+    const line = pick('waitlist');
     return { line, text: renderLine(line, {}), toolEvents: events };
   }
-  const line = pickLine('ask_audience', sessionId);
+  const line = pick('ask_audience');
   return { line, text: renderLine(line, {}), toolEvents: events };
 }
 
@@ -257,6 +258,10 @@ export async function decideFallbackTurn(
 ): Promise<FallbackTurn> {
   const { uiMessages, state } = input;
   const sessionId = state.sessionId;
+  // Seeds merged with nightly-promoted lines (DB failure degrades to seeds).
+  const bank = await loadScriptBank();
+  const pick = (stepId: ScriptStepId): ScriptLine =>
+    pickFromBank(bank, stepId, sessionId);
   const latest = lastUserMessage(uiMessages);
   const selectedArtistId = parseArtistSelection(latest);
 
@@ -268,8 +273,8 @@ export async function decideFallbackTurn(
     );
     const hasData = state.spotifyFollowers !== null;
     const line = hasData
-      ? pickLine('confirm_artist', sessionId)
-      : pickLine('confirm_artist_no_data', sessionId);
+      ? pick('confirm_artist')
+      : pick('confirm_artist_no_data');
     return {
       line,
       text: renderLine(line, {
@@ -289,11 +294,11 @@ export async function decideFallbackTurn(
   // No artist yet: greet on the very first turn, otherwise open the picker.
   if (!state.spotifyArtistId) {
     if (state.turnCount <= 1) {
-      const line = pickLine('greet', sessionId);
+      const line = pick('greet');
       return { line, text: renderLine(line, {}), toolEvents: [] };
     }
     const query = latest ? messageText(latest).slice(0, 50) : '';
-    const line = pickLine('get_artist', sessionId);
+    const line = pick('get_artist');
     return {
       line,
       text: renderLine(line, {}),
@@ -314,7 +319,7 @@ export async function decideFallbackTurn(
   // Artist confirmed but handle not checked yet.
   if (!findLatestToolOutput(uiMessages, 'check_handle')) {
     const handle = handleFromArtistName(state.spotifyArtistName ?? '');
-    const line = pickLine('handle', sessionId);
+    const line = pick('handle');
     return {
       line,
       text: renderLine(line, { handle }),
@@ -342,5 +347,5 @@ export async function decideFallbackTurn(
       ? existingDecision.decision.kind
       : null
     : null;
-  return decisionTurn(input, existingDecisionKind);
+  return decisionTurn(input, existingDecisionKind, pick);
 }

--- a/apps/web/lib/chat/onboarding-script/line-source.ts
+++ b/apps/web/lib/chat/onboarding-script/line-source.ts
@@ -1,0 +1,124 @@
+import 'server-only';
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { onboardingScriptLines } from '@/lib/db/schema/onboarding-script';
+import { logger } from '@/lib/utils/logger';
+import {
+  hashSessionId,
+  isScriptStepId,
+  linesForStep,
+  SCRIPT_STEP_IDS,
+  type ScriptLine,
+  type ScriptStepId,
+} from './script';
+
+/**
+ * Servable line bank: code seeds merged with DB rows (JOV-3806).
+ *
+ * Seeds always serve (their text lives in code; a DB seed row only
+ * contributes its tuned weight). Promoted rows — lint-gated LLM responses
+ * that out-converted the seeds — serve from DB text. Any DB failure
+ * degrades to seeds-only: the fallback path must never gain a hard DB
+ * dependency beyond what the handler already has.
+ */
+
+export interface ServableLine {
+  readonly line: ScriptLine;
+  readonly weight: number;
+}
+
+export type ScriptBank = ReadonlyMap<ScriptStepId, readonly ServableLine[]>;
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+let cache: { bank: ScriptBank; expiresAt: number } | null = null;
+
+/** Test hook. */
+export function resetScriptBankCache(): void {
+  cache = null;
+}
+
+function seedBank(): Map<ScriptStepId, ServableLine[]> {
+  const bank = new Map<ScriptStepId, ServableLine[]>();
+  for (const stepId of SCRIPT_STEP_IDS) {
+    bank.set(
+      stepId,
+      linesForStep(stepId).map(line => ({ line, weight: 100 }))
+    );
+  }
+  return bank;
+}
+
+export async function loadScriptBank(): Promise<ScriptBank> {
+  if (cache && Date.now() < cache.expiresAt) return cache.bank;
+
+  const bank = seedBank();
+  try {
+    const rows = await db
+      .select()
+      .from(onboardingScriptLines)
+      .where(eq(onboardingScriptLines.status, 'active'));
+    for (const row of rows) {
+      if (!isScriptStepId(row.stepId)) continue;
+      const entries = bank.get(row.stepId);
+      if (!entries) continue;
+      const seedIndex = entries.findIndex(
+        entry => entry.line.key === row.lineKey
+      );
+      if (seedIndex >= 0) {
+        // Seed row: DB contributes the tuned weight; text stays code-side.
+        const seed = entries[seedIndex];
+        if (seed) entries[seedIndex] = { line: seed.line, weight: row.weight };
+        continue;
+      }
+      entries.push({
+        line: {
+          key: row.lineKey as ScriptLine['key'],
+          stepId: row.stepId,
+          variant: row.variant,
+          text: row.text,
+        },
+        weight: row.weight,
+      });
+    }
+  } catch (error) {
+    logger.warn('Onboarding script bank DB load failed; serving seeds', {
+      error,
+    });
+  }
+
+  cache = { bank, expiresAt: Date.now() + CACHE_TTL_MS };
+  return bank;
+}
+
+/**
+ * Deterministic weighted pick: the session hash lands in [0, totalWeight),
+ * so one visitor sees a stable line while weights shape the distribution
+ * across visitors.
+ */
+export function pickFromBank(
+  bank: ScriptBank,
+  stepId: ScriptStepId,
+  sessionId: string
+): ScriptLine {
+  const entries = bank.get(stepId) ?? [];
+  const total = entries.reduce(
+    (sum, entry) => sum + Math.max(entry.weight, 0),
+    0
+  );
+  if (entries.length === 0 || total <= 0) {
+    // Bank rows exhausted or all zero-weight — seeds are the floor.
+    const seeds = linesForStep(stepId);
+    const seed = seeds[hashSessionId(sessionId) % Math.max(seeds.length, 1)];
+    if (!seed) throw new Error(`No script lines defined for step ${stepId}`);
+    return seed;
+  }
+  let cursor = hashSessionId(sessionId) % total;
+  for (const entry of entries) {
+    cursor -= Math.max(entry.weight, 0);
+    if (cursor < 0) return entry.line;
+  }
+  const last = entries[entries.length - 1];
+  if (!last) throw new Error(`Weighted pick failed for step ${stepId}`);
+  return last.line;
+}

--- a/apps/web/lib/chat/onboarding-script/line-source.ts
+++ b/apps/web/lib/chat/onboarding-script/line-source.ts
@@ -118,7 +118,7 @@ export function pickFromBank(
     cursor -= Math.max(entry.weight, 0);
     if (cursor < 0) return entry.line;
   }
-  const last = entries[entries.length - 1];
+  const last = entries.at(-1);
   if (!last) throw new Error(`Weighted pick failed for step ${stepId}`);
   return last.line;
 }

--- a/apps/web/lib/chat/onboarding-script/script.ts
+++ b/apps/web/lib/chat/onboarding-script/script.ts
@@ -118,25 +118,47 @@ export function linesForStep(stepId: ScriptStepId): readonly ScriptLine[] {
   return SCRIPT_LINES.filter(scriptLine => scriptLine.stepId === stepId);
 }
 
+/** Stable 32-bit hash of the onboarding session id (variant assignment). */
+export function hashSessionId(sessionId: string): number {
+  let hash = 0;
+  for (let i = 0; i < sessionId.length; i += 1) {
+    hash = (hash * 31 + sessionId.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
 /**
  * Stable per-conversation variant pick: one visitor sees one variant for a
  * given step across retries, while variants spread across visitors — which is
- * what PR2's conversion attribution needs.
+ * what conversion attribution needs.
  */
 export function pickLine(stepId: ScriptStepId, sessionId: string): ScriptLine {
   const candidates = linesForStep(stepId);
   if (candidates.length === 0) {
     throw new Error(`No script lines defined for step ${stepId}`);
   }
-  let hash = 0;
-  for (let i = 0; i < sessionId.length; i += 1) {
-    hash = (hash * 31 + sessionId.charCodeAt(i)) >>> 0;
-  }
-  const picked = candidates[hash % candidates.length];
+  const picked = candidates[hashSessionId(sessionId) % candidates.length];
   if (!picked) {
     throw new Error(`Variant pick failed for step ${stepId}`);
   }
   return picked;
+}
+
+export const SCRIPT_STEP_IDS: readonly ScriptStepId[] = [
+  'greet',
+  'get_artist',
+  'confirm_artist',
+  'confirm_artist_no_data',
+  'handle',
+  'ask_audience',
+  'instant_access',
+  'waitlist',
+  'done',
+  'stream_error',
+];
+
+export function isScriptStepId(value: string): value is ScriptStepId {
+  return (SCRIPT_STEP_IDS as readonly string[]).includes(value);
 }
 
 /** Mid-stream error line (used as the `onError` text — no SSE swap possible). */

--- a/apps/web/lib/chat/onboarding-script/script.ts
+++ b/apps/web/lib/chat/onboarding-script/script.ts
@@ -121,8 +121,8 @@ export function linesForStep(stepId: ScriptStepId): readonly ScriptLine[] {
 /** Stable 32-bit hash of the onboarding session id (variant assignment). */
 export function hashSessionId(sessionId: string): number {
   let hash = 0;
-  for (let i = 0; i < sessionId.length; i += 1) {
-    hash = (hash * 31 + sessionId.charCodeAt(i)) >>> 0;
+  for (const char of sessionId) {
+    hash = (hash * 31 + (char.codePointAt(0) ?? 0)) >>> 0;
   }
   return hash;
 }

--- a/apps/web/tests/unit/lib/chat/onboarding-script/engine.test.ts
+++ b/apps/web/tests/unit/lib/chat/onboarding-script/engine.test.ts
@@ -6,6 +6,14 @@ const hoisted = vi.hoisted(() => ({
 }));
 
 vi.mock('server-only', () => ({}));
+// No DB in unit tests — loadScriptBank degrades to code seeds.
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: () => {
+      throw new Error('no db in unit tests');
+    },
+  },
+}));
 vi.mock('@/lib/spotify', () => ({
   getSpotifyArtist: hoisted.getSpotifyArtistMock,
   buildSpotifyArtistUrl: (id: string) =>

--- a/apps/web/tests/unit/lib/chat/onboarding-script/line-source.test.ts
+++ b/apps/web/tests/unit/lib/chat/onboarding-script/line-source.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  dbSelectMock: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/db', () => ({
+  db: { select: hoisted.dbSelectMock },
+}));
+
+import {
+  loadScriptBank,
+  pickFromBank,
+  resetScriptBankCache,
+} from '@/lib/chat/onboarding-script/line-source';
+import { linesForStep } from '@/lib/chat/onboarding-script/script';
+
+function mockActiveRows(rows: readonly Record<string, unknown>[]) {
+  hoisted.dbSelectMock.mockImplementation(() => ({
+    from: () => ({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  }));
+}
+
+const PROMOTED_ROW = {
+  id: 'row-1',
+  lineKey: 'waitlist:cand_ab12cd34',
+  stepId: 'waitlist',
+  variant: 'cand_ab12cd34',
+  text: 'Early list, real spots — you keep your place and we pick up right here.',
+  source: 'promoted',
+  status: 'active',
+  weight: 100_000, // dominate the pick for the test
+  impressions: 50,
+  conversions: 30,
+};
+
+describe('loadScriptBank', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    resetScriptBankCache();
+  });
+
+  it('serves seeds when the DB read fails', async () => {
+    hoisted.dbSelectMock.mockImplementation(() => {
+      throw new Error('db down');
+    });
+    const bank = await loadScriptBank();
+    expect(bank.get('greet')).toHaveLength(linesForStep('greet').length);
+    const line = pickFromBank(bank, 'greet', 'session-1');
+    expect(line.stepId).toBe('greet');
+  });
+
+  it('merges active promoted rows and serves them by weight', async () => {
+    mockActiveRows([PROMOTED_ROW]);
+    const bank = await loadScriptBank();
+    expect(bank.get('waitlist')).toHaveLength(
+      linesForStep('waitlist').length + 1
+    );
+    // Weight 100000 vs seed 100 → any session lands on the promoted line.
+    const line = pickFromBank(bank, 'waitlist', 'any-session');
+    expect(line.key).toBe('waitlist:cand_ab12cd34');
+    expect(line.text).toContain('Early list');
+  });
+
+  it('applies DB weight to seed rows without overriding code text', async () => {
+    const seed = linesForStep('greet')[0];
+    if (!seed) throw new Error('no greet seed');
+    mockActiveRows([
+      {
+        ...PROMOTED_ROW,
+        lineKey: seed.key,
+        stepId: 'greet',
+        variant: seed.variant,
+        text: 'STALE DB COPY THAT MUST NOT SERVE',
+        source: 'seed',
+        weight: 100_000,
+      },
+    ]);
+    const bank = await loadScriptBank();
+    const line = pickFromBank(bank, 'greet', 'any-session');
+    expect(line.key).toBe(seed.key);
+    expect(line.text).toBe(seed.text);
+  });
+
+  it('caches between calls', async () => {
+    mockActiveRows([]);
+    await loadScriptBank();
+    await loadScriptBank();
+    expect(hoisted.dbSelectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores rows with unknown step ids', async () => {
+    mockActiveRows([
+      { ...PROMOTED_ROW, stepId: 'not_a_step', lineKey: 'not_a_step:v1' },
+    ]);
+    const bank = await loadScriptBank();
+    const line = pickFromBank(bank, 'waitlist', 'any-session');
+    expect(line.stepId).toBe('waitlist');
+  });
+});


### PR DESCRIPTION
## Summary
Part 5/7 of JOV-3806 — the fallback engine serves the tunable response bank.

- New `lib/chat/onboarding-script/line-source.ts`: code seeds merged with active `onboarding_script_lines` rows (5-min cached single indexed select, deterministic weighted pick per session). Any DB failure degrades to code seeds — the fallback path gains no hard DB dependency.
- Seed text always serves from code (a DB seed row only contributes its tuned weight); promoted rows serve DB text.
- Engine picks via the bank; `script.ts` exports the shared session hash + step-id guard.

## Verification
- `line-source.test.ts` — 5 passed (DB-failure degradation, promoted-line serving, seed text never overridden by stale DB copy, cache, unknown-step rows ignored)
- Engine suite still 19 passed. Typecheck + biome clean.

Stack: #12698 → #12699 → #12700 → #12711 → 5/7 (this) → #12718 → #12714

<!-- linear-issue-id:JOV-3806 -->