### PR TITLE
ci: exclude drizzle migration meta snapshots from PR size guard

### DIFF
--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -63,7 +63,7 @@ jobs:
           esac
 
           # Exclude generated / lock / snapshot / vendored noise from the count.
-          EXCLUDE='pnpm-lock\.yaml|package-lock\.json|yarn\.lock|\.lock$|/generated/|\.gen\.|__snapshots__/|\.snap$|\.svg$|\.po$|/dist/|/build/|\.min\.'
+          EXCLUDE='pnpm-lock\.yaml|package-lock\.json|yarn\.lock|\.lock$|/generated/|\.gen\.|__snapshots__/|\.snap$|\.svg$|\.po$|/dist/|/build/|\.min\.|drizzle/migrations/meta/'
           rows=$(gh pr view "$PR" -R "$REPO" --json files -q '.files[] | "\(.additions+.deletions)\t\(.path)"')
           counted=$(printf '%s\n' "$rows" | grep -vE "$EXCLUDE" || true)
           lines=$(printf '%s\n' "$counted" | awk -F'\t' '{s+=$1} END{print s+0}')


### PR DESCRIPTION
## Summary
One-line EXCLUDE addition: `drizzle/migrations/meta/` snapshots are generated (drizzle-kit) and can be 25k+ lines, failing the size guard on every schema PR. First hit: #12711 (27,769 counted lines, 123 real).

Guardrail follow-through per the shame-on-me clause (JOV-3806 session). Labeled `needs-human` because it changes CI policy.

<!-- linear-issue-id:JOV-3806 -->