### PR TITLE
fix(ci): stop taste-classifier from reverting human taste decisions (JOV-3808)

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -106,6 +106,8 @@ Labels are part of the CI control plane, not just project organization. Apply in
 - Do **NOT** add `skip-migration-guard` unless a human explicitly instructs you to bypass the migration guard for that PR.
 - If a migration-related PR seems to require `skip-migration-guard`, stop and escalate with `needs-human` instead of applying the bypass yourself.
 
+- Never hand-edit the taste gate labels (`needs-human-taste`, `needs:taste`, `taste-approved`). The ONLY way to clear the gate is the `/approve` flow (`taste-approve.yml`): screenshot in the PR body + an `/approve`/`lgtm`/👍 comment from a maintainer. Hand-edits with a user token retrigger other label automation and get reverted (JOV-3808); the workflow's bot-token label surgery is the path that sticks.
+
 ## Auto-Merge Path Guardrails
 
 Not all PRs are safe for auto-merge. PRs touching high-risk paths require manual review.

--- a/.github/workflows/taste-approve.yml
+++ b/.github/workflows/taste-approve.yml
@@ -96,5 +96,7 @@ jobs:
           fi
 
           # 4. Clear the gate and hand to Graphite (do NOT bypass-merge).
-          gh pr edit "$PR" --repo "$REPO" --remove-label needs-human-taste --add-label merge-queue
-          gh pr comment "$PR" --repo "$REPO" --body "Taste approved by @$ACTOR ✅ — cleared \`needs-human-taste\` and enrolled in the Graphite merge queue. Graphite will land it once checks pass."
+          #    `taste-approved` is the durable record of the human decision —
+          #    the classifier treats it as terminal and never re-gates (JOV-3808).
+          gh pr edit "$PR" --repo "$REPO" --remove-label needs-human-taste --add-label merge-queue --add-label taste-approved
+          gh pr comment "$PR" --repo "$REPO" --body "Taste approved by @$ACTOR ✅ — cleared \`needs-human-taste\`, stamped \`taste-approved\`, and enrolled in the Graphite merge queue. Graphite will land it once checks pass."

--- a/.github/workflows/taste-classifier.yml
+++ b/.github/workflows/taste-classifier.yml
@@ -9,9 +9,12 @@ name: Taste Classifier
 #   - Posts classification as a PR comment
 #   - Applies the appropriate label: needs-human-taste, llm-review, or merge-queue
 
+# NOTE: no `labeled` trigger — labels don't change the diff, and re-classifying
+# on label events created a loop where the classifier reverted human unlabels
+# (JOV-3808, PR #12688). Classification runs only when the content changes.
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize, labeled]
+    types: [opened, ready_for_review, synchronize]
 
 permissions:
   pull-requests: write

--- a/scripts/lib/__tests__/taste-classifier.test.mjs
+++ b/scripts/lib/__tests__/taste-classifier.test.mjs
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { classifyTaste } from '../../taste-classifier.mjs';
+
+// Regression tests for the JOV-3808 taste-label loop (PR #12688): the
+// classifier reverted human unlabels, treated its own output label as a force
+// signal, and gated fix-typed PRs that policy says auto-flow.
+
+const TASTE_FILES = [
+  'apps/web/app/(marketing)/pricing/page.tsx',
+  'apps/web/styles/globals.css',
+];
+
+describe('classifyTaste — terminal human approval', () => {
+  it('never re-gates a PR carrying taste-approved, even a taste-heavy feat', () => {
+    const result = classifyTaste({
+      title: 'feat(home): new hero composition',
+      files: TASTE_FILES,
+      labels: ['taste-approved', 'ui'],
+    });
+    expect(result.classification).toBe('auto-ship');
+    expect(result.signals).toContain('label:taste-approved');
+  });
+});
+
+describe('classifyTaste — non-taste commit types auto-flow', () => {
+  it('classifies a fix-typed PR with taste-scoring files as llm-reviewable (the PR #12688 case)', () => {
+    const result = classifyTaste({
+      title: 'fix(dashboard): eliminate UI jank in chat panels',
+      files: TASTE_FILES,
+      labels: [],
+    });
+    expect(result.classification).toBe('llm-reviewable');
+    expect(result.signals).toContain('commit-type:fix');
+  });
+
+  it('still gates a fix-typed PR when the ux:material marker is present', () => {
+    const result = classifyTaste({
+      title: 'fix(home): rework hero visual hierarchy',
+      files: TASTE_FILES,
+      labels: ['ux:material'],
+    });
+    expect(result.classification).toBe('taste-required');
+  });
+
+  it('does not treat a stale needs-human-taste label as a force signal', () => {
+    const result = classifyTaste({
+      title: 'fix(chat): guard null session cookie',
+      files: ['apps/web/lib/chat/session.ts'],
+      labels: ['needs-human-taste'],
+    });
+    expect(result.classification).not.toBe('taste-required');
+  });
+});
+
+describe('classifyTaste — the gate still gates', () => {
+  it('keeps taste-required for a feat touching marketing surfaces', () => {
+    const result = classifyTaste({
+      title: 'feat(marketing): redesign pricing page',
+      files: TASTE_FILES,
+      labels: [],
+    });
+    expect(result.classification).toBe('taste-required');
+  });
+
+  it('human force labels still win on non-exempt commit types', () => {
+    const result = classifyTaste({
+      title: 'feat(profile): new listen panel',
+      files: ['apps/web/lib/profile/panel.ts'],
+      labels: ['design'],
+    });
+    expect(result.classification).toBe('taste-required');
+  });
+});

--- a/scripts/taste-classifier.mjs
+++ b/scripts/taste-classifier.mjs
@@ -15,6 +15,12 @@
 
 import { execSync } from 'node:child_process';
 import { resolve } from 'node:path';
+import {
+  conventionalCommitType,
+  hasMaterialUxMarker,
+  MATERIAL_UX_MARKER,
+  NON_TASTE_COMMIT_TYPES,
+} from './lib/taste-label-guard.mjs';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..');
 
@@ -128,8 +134,19 @@ const NON_TASTE_BODY_KEYWORDS = [
   /\bno\s+taste\s+gate\b/i,
 ];
 
-/** Labels that force a classification */
-const FORCE_TASTE_LABELS = ['needs-human-taste', 'design', 'ui', 'ux'];
+/**
+ * Labels that force a classification. Deliberately does NOT include
+ * `needs-human-taste` — that is this classifier's own OUTPUT, and treating it
+ * as an input made every prior classification sticky forever (JOV-3808).
+ */
+const FORCE_TASTE_LABELS = ['design', 'ui', 'ux'];
+
+/**
+ * Terminal human decision: taste-approve.yml adds this when a maintainer
+ * clears the gate via /approve. Approval is final for the PR — the classifier
+ * must never re-gate it, even on later pushes.
+ */
+const TASTE_APPROVED_LABEL = 'taste-approved';
 
 const FORCE_NON_TASTE_LABELS = ['dependencies', 'automated', 'bot', 'ci-infra'];
 
@@ -163,8 +180,20 @@ export function classifyTaste(pr) {
     };
   }
 
-  // Force labels override everything
   const labelNames = labels.map(l => (typeof l === 'string' ? l : l.name));
+
+  // Terminal human decision — a prior /approve is never re-litigated.
+  if (labelNames.includes(TASTE_APPROVED_LABEL)) {
+    return {
+      classification: 'auto-ship',
+      confidence: 1,
+      reason:
+        'Taste already approved by a human (taste-approved label) — never re-gated',
+      signals: [`label:${TASTE_APPROVED_LABEL}`],
+    };
+  }
+
+  // Force labels override everything
   if (FORCE_TASTE_LABELS.some(l => labelNames.includes(l))) {
     return {
       classification: 'taste-required',
@@ -193,6 +222,24 @@ export function classifyTaste(pr) {
       signals: labelNames
         .filter(l => AUTO_SHIP_LABELS.includes(l))
         .map(l => `label:${l}`),
+    };
+  }
+
+  // Non-taste conventional-commit types are never taste calls on their own
+  // (Tim's 2026-06-26 directive; same policy as lib/taste-label-guard.mjs).
+  // A fix/chore/refactor/etc. PR only gets the gate with an explicit
+  // `ux:material` marker — this is how PR #12688 (a fix) got mis-gated.
+  const commitType = conventionalCommitType(title);
+  if (
+    commitType &&
+    NON_TASTE_COMMIT_TYPES.has(commitType) &&
+    !hasMaterialUxMarker(labelNames)
+  ) {
+    return {
+      classification: 'llm-reviewable',
+      confidence: 0.9,
+      reason: `\`${commitType}\` changes are not taste calls — add \`${MATERIAL_UX_MARKER}\` if this PR makes a material UX change`,
+      signals: [`commit-type:${commitType}`],
     };
   }
 


### PR DESCRIPTION
Fixes the taste-label loop that reverted human taste decisions on PR #12688 (JOV-3808).

<!-- linear-issue-id:taste-loop-jov-3808 -->

## What was broken

On #12688, Tim manually removed `needs-human-taste`; the classifier re-applied it 71 seconds later. The churn also dequeued the PR mid-merge, so Graphite landed the squash and closed the PR unmerged, which silently broke the Linear merge-sync. Three separate loop engines:

1. `taste-classifier.yml` triggered on `pull_request: [labeled]` — any user-token label edit re-ran classification, which re-applied the label. Labels don't change the diff; the trigger only fed the loop.
2. The classifier counted `needs-human-taste` — **its own output** — in `FORCE_TASTE_LABELS`, making every prior classification sticky forever.
3. `taste-label-guard.yml` (auto-clears the gate on `fix:`/`chore:`/etc. per Tim's 2026-06-26 directive) can never fire on classifier-applied labels: `GITHUB_TOKEN` events don't trigger workflows. Every guard run in history is `skipped`.

## The fix

- **Trigger:** classify only on `opened` / `ready_for_review` / `synchronize`.
- **No self-force:** `needs-human-taste` removed from force labels (human `design`/`ui`/`ux` labels still force).
- **Policy folded in:** the classifier now applies the guard's exemption itself via the shared `scripts/lib/taste-label-guard.mjs` — non-taste commit types are `llm-reviewable` unless `ux:material` is present.
- **Durable approval:** `taste-approve.yml` stamps a terminal `taste-approved` label (created in repo); the classifier treats it as final and never re-gates. (This is also why #12688's `/approve` path worked — bot-token label surgery doesn't retrigger automation.)
- Rule added to `.claude/rules/release.md`: agents never hand-edit taste gate labels.

## Verification

- `vitest run` on `scripts/lib/__tests__/` — 38/38 pass (new classifier regression tests + existing guard suite).
- Regression cases: taste-approved is terminal; `fix:` + taste-heavy files → `llm-reviewable` (the exact #12688 shape); `fix:` + `ux:material` still gates; stale `needs-human-taste` no longer self-forces; `feat:` + marketing files still gates.

## Cost Impact

None — removes one workflow trigger (fewer Actions runs), no external API calls.
