### PR TITLE
feat(tracker): GitHub-Issues-first tracker shim (Linear migration phase 1)

### DIFF
--- a/scripts/lib/__tests__/tracker.test.mjs
+++ b/scripts/lib/__tests__/tracker.test.mjs
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildIssueCreateArgs,
+  fileGithubIssue,
+  parseIssueNumber,
+  shouldMirrorLinear,
+} from '../tracker.mjs';
+
+const URL = 'https://github.com/JovieInc/Jovie/issues/1234\n';
+
+describe('buildIssueCreateArgs', () => {
+  it('builds a stdin-body create with one --label per label', () => {
+    expect(
+      buildIssueCreateArgs({ title: 'Bug: x', labels: ['P0', 'qa-swarm'] })
+    ).toEqual([
+      'issue',
+      'create',
+      '--title',
+      'Bug: x',
+      '--body-file',
+      '-',
+      '--label',
+      'P0',
+      '--label',
+      'qa-swarm',
+    ]);
+  });
+});
+
+describe('parseIssueNumber', () => {
+  it('extracts the number from a gh create URL', () => {
+    expect(parseIssueNumber(URL)).toBe(1234);
+  });
+  it('returns null for non-issue output', () => {
+    expect(parseIssueNumber('something went wrong')).toBeNull();
+    expect(parseIssueNumber('')).toBeNull();
+  });
+});
+
+describe('fileGithubIssue', () => {
+  it('returns success with number, identifier, and url', () => {
+    const calls = [];
+    const exec = (args, input) => {
+      calls.push({ args, input });
+      return URL;
+    };
+    const result = fileGithubIssue(
+      { title: 'T', body: 'B', labels: ['P1'] },
+      exec
+    );
+    expect(result).toMatchObject({
+      success: true,
+      number: 1234,
+      identifier: '#1234',
+      url: URL.trim(),
+      labelsDropped: false,
+    });
+    expect(calls[0].input).toBe('B');
+  });
+
+  it('retries without labels when the labeled create fails, and flags it', () => {
+    let call = 0;
+    const exec = args => {
+      call++;
+      if (args.includes('--label')) throw new Error('label not found');
+      return URL;
+    };
+    const result = fileGithubIssue(
+      { title: 'T', body: 'B', labels: ['nope'] },
+      exec
+    );
+    expect(call).toBe(2);
+    expect(result.success).toBe(true);
+    expect(result.labelsDropped).toBe(true);
+  });
+
+  it('never throws — returns success:false with the error message', () => {
+    const exec = () => {
+      throw new Error('gh: not logged in');
+    };
+    const result = fileGithubIssue({ title: 'T', body: 'B' }, exec);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not logged in');
+    expect(result.url).toBeNull();
+  });
+});
+
+describe('shouldMirrorLinear', () => {
+  it('mirrors by default and stops on TRACKER_GITHUB_ONLY=1', () => {
+    expect(shouldMirrorLinear({})).toBe(true);
+    expect(shouldMirrorLinear({ TRACKER_GITHUB_ONLY: '1' })).toBe(false);
+    expect(shouldMirrorLinear({ TRACKER_GITHUB_ONLY: '0' })).toBe(true);
+  });
+});

--- a/scripts/lib/tracker.mjs
+++ b/scripts/lib/tracker.mjs
@@ -1,0 +1,80 @@
+/**
+ * Tracker facade — GitHub Issues first.
+ *
+ * Phase 1 of the Linear → GitHub Issues migration: a single place that files
+ * tracker issues via the `gh` CLI so consumers stop hard-coding Linear.
+ * Consumers dual-write (GitHub primary, Linear mirror) during the parallel-run
+ * window and drop the mirror by setting TRACKER_GITHUB_ONLY=1.
+ *
+ * Deliberately create-only for now: claim/transition land with the
+ * orchestrator swap (phase 2), which is their first real consumer.
+ *
+ * Return shape mirrors scripts/qa-swarm/linear.mjs#fileLinearIssue so
+ * consumers can treat the two trackers interchangeably: never throws,
+ * `{ success, identifier, url }` on success, `{ success: false, error }` on
+ * failure.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/** @param {{ title: string, labels?: readonly string[] }} input */
+export function buildIssueCreateArgs({ title, labels = [] }) {
+  const args = ['issue', 'create', '--title', title, '--body-file', '-'];
+  for (const label of labels) {
+    args.push('--label', label);
+  }
+  return args;
+}
+
+/** @param {string} url */
+export function parseIssueNumber(url) {
+  const match = /\/issues\/(\d+)\s*$/.exec(url ?? '');
+  return match ? Number(match[1]) : null;
+}
+
+function defaultExec(args, input) {
+  return execFileSync('gh', args, { encoding: 'utf8', input });
+}
+
+/**
+ * File a GitHub issue. Never throws.
+ *
+ * @param {{ title: string, body: string, labels?: readonly string[] }} input
+ * @param {(args: string[], input: string) => string} [exec] injectable for tests
+ * @returns {{ success: boolean, number?: number | null, identifier?: string, url?: string | null, labelsDropped?: boolean, error?: string }}
+ */
+export function fileGithubIssue(input, exec = defaultExec) {
+  const { title, body, labels = [] } = input;
+  try {
+    let url;
+    let labelsDropped = false;
+    try {
+      url = exec(buildIssueCreateArgs({ title, labels }), body).trim();
+    } catch (error) {
+      // `gh issue create --label` fails on labels missing from the repo.
+      // Losing a label is better than losing the issue — retry label-less.
+      if (labels.length === 0) throw error;
+      url = exec(buildIssueCreateArgs({ title, labels: [] }), body).trim();
+      labelsDropped = true;
+    }
+    const number = parseIssueNumber(url);
+    return {
+      success: true,
+      number,
+      identifier: number ? `#${number}` : url,
+      url,
+      labelsDropped,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      url: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/** Mirror-to-Linear is on unless the cutover flag is set. */
+export function shouldMirrorLinear(env = process.env) {
+  return env.TRACKER_GITHUB_ONLY !== '1';
+}

--- a/scripts/qa-swarm/propose.mjs
+++ b/scripts/qa-swarm/propose.mjs
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-
+import { fileGithubIssue, shouldMirrorLinear } from '../lib/tracker.mjs';
 import {
   enqueueForEve,
   shouldFastTrack,
@@ -55,32 +55,45 @@ export async function proposeQaSwarmFindings(input) {
         ? `P0 QA: ${finding.title}`
         : `QA swarm (${recipe.id}): ${finding.title}`;
 
-    const linearResult = dryRun
-      ? {
-          success: true,
-          identifier: 'DRY-RUN',
-          url: null,
-          queued: false,
-          dryRun: true,
-        }
-      : await fileLinearIssue({
+    // GitHub Issues is the primary tracker; Linear stays as a mirror during
+    // the migration parallel-run and drops out with TRACKER_GITHUB_ONLY=1.
+    const githubResult = dryRun
+      ? { success: true, identifier: 'DRY-RUN', url: null, dryRun: true }
+      : fileGithubIssue({
           title: issueTitle,
-          description,
+          body: description,
           labels: [...recipe.labels],
-          source: `qa-swarm:${recipe.id}`,
         });
+
+    const linearResult =
+      dryRun || !shouldMirrorLinear()
+        ? {
+            success: true,
+            identifier: dryRun ? 'DRY-RUN' : 'SKIPPED',
+            url: null,
+            queued: false,
+            dryRun,
+          }
+        : await fileLinearIssue({
+            title: issueTitle,
+            description,
+            labels: [...recipe.labels],
+            source: `qa-swarm:${recipe.id}`,
+          });
+
+    const trackerIssueUrl = githubResult.url ?? linearResult.url ?? null;
 
     let remediationPath = null;
     let eveQueued = false;
     if (shouldFastTrack(finding, eveEnabled)) {
       remediationPath = writeRemediationManifest(finding, {
         recipeId: input.recipeId,
-        linearIssueUrl: linearResult.url ?? null,
+        linearIssueUrl: trackerIssueUrl,
         gbrainSlug: gbrain.slug,
       });
     } else if (eveEnabled) {
       enqueueForEve(finding, {
-        linearIssueUrl: linearResult.url ?? null,
+        linearIssueUrl: trackerIssueUrl,
         gbrainSlug: gbrain.slug,
       });
       eveQueued = true;
@@ -91,6 +104,7 @@ export async function proposeQaSwarmFindings(input) {
       priority: finding.priority,
       gbrainSlug: gbrain.slug,
       gbrainPagePath: gbrain.pagePath,
+      github: githubResult,
       linear: linearResult,
       remediationPath,
       eveQueued,


### PR DESCRIPTION
Phase 1 of the Linear → GitHub Issues migration: a tracker facade so agent tooling stops hard-coding Linear, with qa-swarm as the first dual-writing consumer.

## What changed

- **`scripts/lib/tracker.mjs`** — files tracker issues via the `gh` CLI. Same never-throw result contract as `fileLinearIssue` (`{success, identifier, url}` / `{success:false, error}`), so consumers treat the two trackers interchangeably. Unknown labels degrade gracefully (retry label-less, flag `labelsDropped`) instead of dropping the issue. Create-only by design — claim/transition land with the orchestrator swap (phase 2), their first real consumer.
- **`scripts/qa-swarm/propose.mjs`** — files a GitHub issue as the primary tracker record and keeps the Linear write as a mirror during the parallel-run window. `TRACKER_GITHUB_ONLY=1` cuts the mirror at cutover. Remediation manifests / Eve enqueue use whichever tracker URL exists.
- **`scripts/lib/__tests__/tracker.test.mjs`** — arg building, URL parsing, label-retry, never-throw, and mirror-flag behavior (7 tests, injected exec — no network).

## Verification

- `vitest run --root scripts` — tracker suite 7/7; full workspace-scripts suite 188 passed.
- Pre-existing failures (NOT this PR): 3 tests in `lib/__tests__/codex-issue-shipper.test.mjs` fail on env-dependent expectations (module untouched since #10889; imports disjoint from this diff).
- Dry-run smoke of `proposeQaSwarmFindings` produces the new `github` + `linear` result fields.

## Migration plan context

Phase 2 (orchestrator swap + Hermes-Air intake), phase 3 (docs/skills sweep), phase 4 (backfill + Linear sunset) are tracked in the migration epic issues.

## Cost Impact

None — `gh` calls against the repo's own GitHub API quota, one per filed finding, same volume that previously went to Linear.
