### PR TITLE
feat(hermes): ship ledger — machine-global shipper lock + restart recovery journal

### DIFF
--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -49,6 +49,13 @@ import {
 import { tryWithHeavyJobLock } from '../lib/heavy-job-lock';
 import { HERMES_PATHS } from '../lib/hermes-paths';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import {
+  journalEnd,
+  journalStart,
+  planRecovery,
+  readJournal,
+  SHIP_OWNER_LOCK,
+} from '../lib/ship-ledger';
 
 const JOB = 'codex-issue-shipper';
 
@@ -740,6 +747,15 @@ async function dispatchPlan(
   const dispatch = prepared.plan;
   try {
     claimIssue(config, dispatch);
+    journalStart({
+      job: JOB,
+      repo: config.repo,
+      issue: dispatch.issue.number,
+      branch: dispatch.branchName,
+      worktree: prepared.repoRoot,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    });
 
     let gbrain: GbrainContext;
     try {
@@ -891,7 +907,68 @@ async function dispatchPlan(
       successCommentPosted,
     });
   } finally {
+    // Terminal for every path (success, blocked, released, thrown): the
+    // dispatch is no longer in flight, so a restart must not "recover" it.
+    journalEnd(dispatch.issue.number, config.repo);
     cleanupWorktree(config, prepared.repoRoot);
+  }
+}
+
+/**
+ * Restart recovery: release claims journaled by a previous shipper process
+ * that died mid-dispatch (auto-update, crash, kickstart -k). The issue goes
+ * back to the dispatchable pool; the worktree is pruned. Runs once per
+ * process, under the ship-owner lock, before any new dispatch.
+ */
+function recoverStaleJobs(config: ShipperConfig): void {
+  const { stale, live } = planRecovery(readJournal());
+  for (const entry of stale) {
+    try {
+      run(
+        [
+          'gh',
+          'issue',
+          'edit',
+          String(entry.issue),
+          '--repo',
+          entry.repo,
+          '--remove-label',
+          CODEX_CLAIM_LABEL,
+        ],
+        config
+      );
+    } catch {
+      // Label already gone (or gh hiccup) — recovery stays best-effort.
+    }
+    try {
+      commentIssue(
+        config,
+        entry.issue,
+        `Jovie agent (codex issue shipper) restarted mid-dispatch (owner pid ${entry.pid} gone). Claim released for retry.`
+      );
+    } catch {
+      // Comment is informational only.
+    }
+    if (entry.worktree && existsSync(entry.worktree)) {
+      cleanupWorktree(config, entry.worktree);
+    }
+    journalEnd(entry.issue, entry.repo);
+    logJobEvent({
+      job: JOB,
+      event: 'restart_recovered_claim',
+      issue: entry.issue,
+      repo: entry.repo,
+      deadPid: entry.pid,
+      startedAt: entry.startedAt,
+    });
+  }
+  if (stale.length > 0 || live.length > 0) {
+    logJobEvent({
+      job: JOB,
+      event: 'restart_recovery_done',
+      recovered: stale.length,
+      stillLive: live.length,
+    });
   }
 }
 
@@ -938,6 +1015,7 @@ async function main(): Promise<void> {
     const lockResult = await tryWithHeavyJobLock(
       JOB,
       async () => {
+        recoverStaleJobs(config);
         let controlLabelsEnsured = false;
 
         for (;;) {
@@ -1003,7 +1081,9 @@ async function main(): Promise<void> {
           await dispatchBatch(config, batch);
         }
       },
-      { staleMs: config.singletonLockStaleMs }
+      // Machine-global lock: profile-scoped HERMES_HOME must not yield two
+      // "singletons" racing one GitHub queue (JovieInc/Jovie#12723).
+      { staleMs: config.singletonLockStaleMs, lockPath: SHIP_OWNER_LOCK }
     );
 
     if (!lockResult.acquired) {

--- a/scripts/hermes/lib/heavy-job-lock.ts
+++ b/scripts/hermes/lib/heavy-job-lock.ts
@@ -18,7 +18,7 @@ import { dirname } from 'node:path';
 
 import { HERMES_PATHS } from './hermes-paths';
 
-const LOCK = HERMES_PATHS.heavyJobLock;
+const DEFAULT_LOCK = HERMES_PATHS.heavyJobLock;
 const STALE_MS = 5 * 60 * 1000;
 
 export interface HeavyJobLockOwner {
@@ -47,11 +47,11 @@ function isProcessAlive(pid: number): boolean {
  * they won — the kernel makes the create-if-not-exists atomic. This
  * replaces the prior TOCTOU pattern (exists → write).
  */
-function tryClaim(caller: string): boolean {
-  mkdirSync(dirname(LOCK), { recursive: true });
+function tryClaim(caller: string, lock: string): boolean {
+  mkdirSync(dirname(lock), { recursive: true });
   let fd: number;
   try {
-    fd = openSync(LOCK, 'wx');
+    fd = openSync(lock, 'wx');
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === 'EEXIST') return false;
@@ -65,9 +65,9 @@ function tryClaim(caller: string): boolean {
   return true;
 }
 
-function readLockOwner(): HeavyJobLockOwner | null {
+function readLockOwner(lock: string): HeavyJobLockOwner | null {
   try {
-    return JSON.parse(readFileSync(LOCK, 'utf8')) as HeavyJobLockOwner;
+    return JSON.parse(readFileSync(lock, 'utf8')) as HeavyJobLockOwner;
   } catch {
     return null;
   }
@@ -78,12 +78,12 @@ function readLockOwner(): HeavyJobLockOwner | null {
  * remove it so the next claim attempt can succeed. Returns true if we
  * removed it.
  */
-function reapIfStale(staleMs = STALE_MS): boolean {
-  const data = readLockOwner();
+function reapIfStale(lock: string, staleMs = STALE_MS): boolean {
+  const data = readLockOwner(lock);
   if (!data) {
     // Unreadable lock — assume corrupt, try to remove.
     try {
-      unlinkSync(LOCK);
+      unlinkSync(lock);
       return true;
     } catch {
       return false;
@@ -96,7 +96,7 @@ function reapIfStale(staleMs = STALE_MS): boolean {
   const dead = typeof data.pid === 'number' ? !isProcessAlive(data.pid) : true;
   if (dead || age > staleMs) {
     try {
-      unlinkSync(LOCK);
+      unlinkSync(lock);
       return true;
     } catch {
       return false;
@@ -108,20 +108,21 @@ function reapIfStale(staleMs = STALE_MS): boolean {
 export async function tryWithHeavyJobLock<T>(
   caller: string,
   fn: () => Promise<T>,
-  options: { readonly staleMs?: number } = {}
+  options: { readonly staleMs?: number; readonly lockPath?: string } = {}
 ): Promise<HeavyJobLockResult<T>> {
+  const lock = options.lockPath ?? DEFAULT_LOCK;
   if (
-    !tryClaim(caller) &&
-    (!reapIfStale(options.staleMs) || !tryClaim(caller))
+    !tryClaim(caller, lock) &&
+    (!reapIfStale(lock, options.staleMs) || !tryClaim(caller, lock))
   ) {
-    return { acquired: false, owner: readLockOwner() };
+    return { acquired: false, owner: readLockOwner(lock) };
   }
 
   try {
     return { acquired: true, value: await fn() };
   } finally {
     try {
-      unlinkSync(LOCK);
+      unlinkSync(lock);
     } catch {
       // best effort
     }
@@ -131,25 +132,30 @@ export async function tryWithHeavyJobLock<T>(
 export async function withHeavyJobLock<T>(
   caller: string,
   fn: () => Promise<T>,
-  options: { readonly timeoutMs?: number; readonly staleMs?: number } = {}
+  options: {
+    readonly timeoutMs?: number;
+    readonly staleMs?: number;
+    readonly lockPath?: string;
+  } = {}
 ): Promise<T> {
   const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
   const deadline = Date.now() + timeoutMs;
+  const lock = options.lockPath ?? DEFAULT_LOCK;
 
   while (Date.now() < deadline) {
-    if (tryClaim(caller)) {
+    if (tryClaim(caller, lock)) {
       try {
         return await fn();
       } finally {
         try {
-          unlinkSync(LOCK);
+          unlinkSync(lock);
         } catch {
           // best effort
         }
       }
     }
     // Couldn't claim; check for stale and retry.
-    if (!reapIfStale(options.staleMs)) {
+    if (!reapIfStale(lock, options.staleMs)) {
       await new Promise(resolve => setTimeout(resolve, 2000));
     }
   }

--- a/scripts/hermes/lib/ship-ledger.ts
+++ b/scripts/hermes/lib/ship-ledger.ts
@@ -1,0 +1,136 @@
+/**
+ * Ship ledger — machine-global shipper ownership + durable in-flight job
+ * journal, so a shipper restart (auto-update, crash, launchd kickstart)
+ * never strands claimed issues, stale claim labels, or orphaned worktrees.
+ *
+ * Two pieces:
+ *
+ * 1. SHIP_OWNER_LOCK — a single lock path for "the machine's shipper".
+ *    Deliberately anchored at ~/.hermes/state (NOT HERMES_HOME, which is
+ *    env-overridable per Hermes profile). Two shipper instances running
+ *    under different profiles (launchd vs. gateway/summer) previously
+ *    resolved different lock files and raced the same GitHub issue queue
+ *    (JovieInc/Jovie#12723). One fixed path = one owner per machine.
+ *
+ * 2. Journal — every dispatched job is recorded before the coding agent
+ *    starts and removed when the dispatch reaches a terminal state. On
+ *    startup, entries whose owner pid is dead are recovered: claim label
+ *    released, worktree pruned, entry dropped. Work is requeued, not lost.
+ *
+ * The file formats are the cross-process contract: the Ovie Mac app reads
+ * and writes the same lock + journal so app restarts and shipper restarts
+ * share one recovery story. Keep both formats append-simple JSON.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/** Machine-global — see module doc for why this must not use HERMES_HOME. */
+export const SHIP_OWNER_LOCK = join(
+  homedir(),
+  '.hermes',
+  'state',
+  'ship-owner.lock'
+);
+
+export const INFLIGHT_JOURNAL = join(
+  homedir(),
+  '.hermes',
+  'state',
+  'inflight-ship-jobs.json'
+);
+
+export interface InflightJob {
+  readonly job: string;
+  readonly repo: string;
+  readonly issue: number;
+  readonly branch: string;
+  readonly worktree: string;
+  readonly pid: number;
+  readonly startedAt: string;
+}
+
+export interface RecoveryPlan {
+  readonly stale: ReadonlyArray<InflightJob>;
+  readonly live: ReadonlyArray<InflightJob>;
+}
+
+export function readJournal(path: string = INFLIGHT_JOURNAL): InflightJob[] {
+  if (!existsSync(path)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is InflightJob =>
+        typeof e === 'object' &&
+        e !== null &&
+        typeof (e as InflightJob).issue === 'number' &&
+        typeof (e as InflightJob).pid === 'number'
+    );
+  } catch {
+    // Corrupt journal: recovering nothing is safer than crashing the
+    // shipper. Stale claims will self-surface as codex-in-progress churn.
+    return [];
+  }
+}
+
+function writeJournal(entries: ReadonlyArray<InflightJob>, path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(entries, null, 2));
+  renameSync(tmp, path); // atomic swap — a crash mid-write never corrupts
+}
+
+export function journalStart(
+  entry: InflightJob,
+  path: string = INFLIGHT_JOURNAL
+): void {
+  const entries = readJournal(path).filter(
+    e => !(e.issue === entry.issue && e.repo === entry.repo)
+  );
+  entries.push(entry);
+  writeJournal(entries, path);
+}
+
+export function journalEnd(
+  issue: number,
+  repo: string,
+  path: string = INFLIGHT_JOURNAL
+): void {
+  const entries = readJournal(path);
+  const kept = entries.filter(e => !(e.issue === issue && e.repo === repo));
+  if (kept.length !== entries.length) writeJournal(kept, path);
+}
+
+export function defaultIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pure planner: split journal entries into live (owner pid still running —
+ * leave alone) and stale (owner dead — release claim, prune worktree).
+ * The caller executes the side effects and drops recovered entries.
+ */
+export function planRecovery(
+  entries: ReadonlyArray<InflightJob>,
+  isAlive: (pid: number) => boolean = defaultIsAlive
+): RecoveryPlan {
+  const stale: InflightJob[] = [];
+  const live: InflightJob[] = [];
+  for (const entry of entries) {
+    (isAlive(entry.pid) ? live : stale).push(entry);
+  }
+  return { stale, live };
+}

--- a/scripts/lib/__tests__/ship-ledger.test.mjs
+++ b/scripts/lib/__tests__/ship-ledger.test.mjs
@@ -1,0 +1,152 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { tryWithHeavyJobLock } from '../../hermes/lib/heavy-job-lock.ts';
+import {
+  journalEnd,
+  journalStart,
+  planRecovery,
+  readJournal,
+} from '../../hermes/lib/ship-ledger.ts';
+
+const cleanups = [];
+afterEach(() => {
+  while (cleanups.length)
+    rmSync(cleanups.pop(), { recursive: true, force: true });
+});
+
+function tmp() {
+  const dir = mkdtempSync(join(tmpdir(), 'ship-ledger-'));
+  cleanups.push(dir);
+  return dir;
+}
+
+function entry(overrides = {}) {
+  return {
+    job: 'codex-issue-shipper',
+    repo: 'JovieInc/Jovie',
+    issue: 101,
+    branch: 'codex/gh-101',
+    worktree: '/tmp/wt-101',
+    pid: process.pid,
+    startedAt: '2026-07-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('ship-ledger journal', () => {
+  it('returns [] for a missing journal', () => {
+    expect(readJournal(join(tmp(), 'nope.json'))).toEqual([]);
+  });
+
+  it('returns [] for a corrupt journal instead of throwing', () => {
+    const path = join(tmp(), 'journal.json');
+    writeFileSync(path, '{not json');
+    expect(readJournal(path)).toEqual([]);
+    writeFileSync(path, '{"an":"object, not an array"}');
+    expect(readJournal(path)).toEqual([]);
+  });
+
+  it('drops malformed entries but keeps valid ones', () => {
+    const path = join(tmp(), 'journal.json');
+    writeFileSync(path, JSON.stringify([entry(), { junk: true }, null]));
+    const read = readJournal(path);
+    expect(read).toHaveLength(1);
+    expect(read[0].issue).toBe(101);
+  });
+
+  it('round-trips start/end and only removes the matching issue+repo', () => {
+    const path = join(tmp(), 'journal.json');
+    journalStart(entry({ issue: 1 }), path);
+    journalStart(entry({ issue: 2 }), path);
+    journalStart(entry({ issue: 1, repo: 'JovieInc/Ops' }), path);
+    expect(readJournal(path)).toHaveLength(3);
+
+    journalEnd(1, 'JovieInc/Jovie', path);
+    const after = readJournal(path);
+    expect(after).toHaveLength(2);
+    expect(after.map(e => `${e.repo}#${e.issue}`).sort()).toEqual([
+      'JovieInc/Jovie#2',
+      'JovieInc/Ops#1',
+    ]);
+  });
+
+  it('re-journaling the same issue+repo replaces the prior entry', () => {
+    const path = join(tmp(), 'journal.json');
+    journalStart(entry({ branch: 'first' }), path);
+    journalStart(entry({ branch: 'second' }), path);
+    const read = readJournal(path);
+    expect(read).toHaveLength(1);
+    expect(read[0].branch).toBe('second');
+  });
+
+  it('writes are atomic (no partial tmp file left behind)', () => {
+    const path = join(tmp(), 'journal.json');
+    journalStart(entry(), path);
+    expect(() => readFileSync(`${path}.tmp`)).toThrow();
+    expect(readJournal(path)).toHaveLength(1);
+  });
+});
+
+describe('ship-ledger recovery planning', () => {
+  it('splits entries by owner liveness', () => {
+    const dead = entry({ issue: 1, pid: 99_999_999 });
+    const alive = entry({ issue: 2, pid: process.pid });
+    const plan = planRecovery([dead, alive], pid => pid === process.pid);
+    expect(plan.stale.map(e => e.issue)).toEqual([1]);
+    expect(plan.live.map(e => e.issue)).toEqual([2]);
+  });
+
+  it('handles an empty journal', () => {
+    expect(planRecovery([])).toEqual({ stale: [], live: [] });
+  });
+});
+
+describe('heavy-job-lock lockPath option', () => {
+  it('locks at different paths are independent; same path excludes', async () => {
+    const dir = tmp();
+    const lockA = join(dir, 'a.lock');
+    const lockB = join(dir, 'b.lock');
+
+    const outer = await tryWithHeavyJobLock(
+      'test-outer',
+      async () => {
+        // A held: same path must be refused…
+        const samePathResult = await tryWithHeavyJobLock(
+          'test-inner-same',
+          async () => 'won',
+          { lockPath: lockA, staleMs: 60_000 }
+        );
+        // …but a different path is a different lock.
+        const otherPathResult = await tryWithHeavyJobLock(
+          'test-inner-other',
+          async () => 'won',
+          { lockPath: lockB, staleMs: 60_000 }
+        );
+        return { samePathResult, otherPathResult };
+      },
+      { lockPath: lockA, staleMs: 60_000 }
+    );
+
+    expect(outer.acquired).toBe(true);
+    expect(outer.value.samePathResult.acquired).toBe(false);
+    expect(outer.value.samePathResult.owner?.caller).toBe('test-outer');
+    expect(outer.value.otherPathResult.acquired).toBe(true);
+  });
+
+  it('breaks a lock whose owner pid is dead', async () => {
+    const lock = join(tmp(), 'stale.lock');
+    writeFileSync(
+      lock,
+      JSON.stringify({ caller: 'ghost', pid: 99_999_999, ts: Date.now() })
+    );
+    const result = await tryWithHeavyJobLock('test-reaper', async () => 'won', {
+      lockPath: lock,
+      staleMs: 60_000,
+    });
+    expect(result.acquired).toBe(true);
+    expect(result.value).toBe('won');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #12723 and the general "shipper restart drops in-flight work" problem (Ovie slice 1) with one mechanism both the launchd shipper and the Ovie Mac app can share.

**Root cause of #12723:** the shipper's singleton lock lives under `HERMES_HOME`, which is env-overridable per Hermes profile — the launchd instance locked `~/.hermes/state/…` while the gateway/summer instance locked `~/.hermes/profiles/summer/state/…`. Two locks, two "singletons", one GitHub queue.

**Restart problem:** any shipper death mid-dispatch (auto-update, crash, `kickstart -k`) stranded issues as `codex-in-progress` with orphaned worktrees — 6 issues were manually unstuck this way on 2026-07-02 alone.

## Changes
- `scripts/hermes/lib/ship-ledger.ts` (new): `SHIP_OWNER_LOCK` anchored at `~/.hermes/state` (deliberately **not** `HERMES_HOME`); durable `inflight-ship-jobs.json` journal (atomic tmp+rename writes, corrupt-tolerant reads); pure `planRecovery(entries, isAlive)`.
- `scripts/hermes/lib/heavy-job-lock.ts`: optional `lockPath` (defaults unchanged — existing heavy-job callers unaffected).
- `scripts/hermes/jobs/codex-issue-shipper.ts`: acquires the machine-global lock; recovers stale journal entries on startup (release claim label + comment + prune worktree + requeue); journals every dispatch start and terminal end (`finally` — covers success/blocked/released/thrown).

The lock + journal file formats are the cross-process contract the Ovie Mac app will consume, so app restarts and shipper restarts share one recovery story.

## Stack
Stacked on #12687 (grok agent recovery) — diff includes its commit until it lands.

## Verification
- `vitest run lib/__tests__/ship-ledger.test.mjs lib/__tests__/codex-issue-shipper.test.mjs` → **24 passed** (10 new)
- Live smoke: seeded a dead-pid journal entry → startup recovery released it (`restart_recovered_claim` + `restart_recovery_done` events), journal drained, lock released cleanly
- Dry-run shipper pass under the new global lock: scan + plan normally

## Cost Impact
None — no new external API calls beyond one best-effort `gh issue edit`/comment per recovered claim (only fires after an unclean restart).

Closes #12723

🤖 Generated with [Claude Code](https://claude.com/claude-code)