### PR TITLE
feat(hermes): deterministic finisher for agent-abandoned ship work

### DIFF
--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -38,6 +38,8 @@ import {
   CODEX_CLAIM_LABEL,
   CODEX_TRUSTED_LABEL,
   type DispatchPlan,
+  type FinisherRunner,
+  finishDispatch,
   type GbrainContext,
   type GithubIssue,
   HUMAN_REVIEW_LABEL,
@@ -45,6 +47,7 @@ import {
   loadShipperConfig,
   NO_AUTO_LABEL,
   type ShipperConfig,
+  worktreeHasWork,
 } from '../lib/codex-issue-shipper';
 import { tryWithHeavyJobLock } from '../lib/heavy-job-lock';
 import { HERMES_PATHS } from '../lib/hermes-paths';
@@ -851,7 +854,50 @@ async function dispatchPlan(
       return;
     }
 
-    const pr = findPrForBranch(config, dispatch.branchName);
+    let pr = findPrForBranch(config, dispatch.branchName);
+
+    // Deterministic finisher: the agent exited 0 without opening a PR, but
+    // may have left real work in the worktree (grok 0.2.77 abandons the
+    // long ship contract mid-task). Same trust model as the kanban lane —
+    // the model produces the diff, deterministic code owns commit/push/PR.
+    // Pre-commit hooks gate the commit; any failure falls through to the
+    // existing release-for-retry path.
+    if (!pr) {
+      const runInWorktree: FinisherRunner = (args, opts) =>
+        execFileSync(args[0], args.slice(1), {
+          cwd: prepared.repoRoot,
+          encoding: 'utf8',
+          timeout: opts?.timeoutMs ?? 30_000,
+          maxBuffer: 5 * 1024 * 1024,
+        });
+      try {
+        if (worktreeHasWork(runInWorktree)) {
+          finishDispatch(runInWorktree, {
+            repo: config.repo,
+            branchName: dispatch.branchName,
+            issue: dispatch.issue,
+            logPath: agentResult.logPath,
+          });
+          pr = findPrForBranch(config, dispatch.branchName);
+          logJobEvent({
+            job: JOB,
+            event: 'deterministic_finish_shipped',
+            issue: dispatch.issue.number,
+            branch: dispatch.branchName,
+            pr: pr?.number,
+          });
+        }
+      } catch (err) {
+        logJobEvent({
+          job: JOB,
+          event: 'deterministic_finish_failed',
+          issue: dispatch.issue.number,
+          branch: dispatch.branchName,
+          error: shortError(err),
+        });
+      }
+    }
+
     if (!pr) {
       releaseClaimForRetry(
         config,

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -562,3 +562,110 @@ export function buildAgentCommand(
     ],
   };
 }
+
+// --- Deterministic finisher -------------------------------------------------
+//
+// The kanban ship lane works because the MODEL only has to produce a diff —
+// deterministic code owns commit/push/PR. The issue lane historically trusted
+// the agent to run /ship itself, and grok CLI 0.2.77 abandons that long
+// contract mid-task (0 PRs from 334 "successful" runs, 2026-07-01..02).
+// classifyPostAgent + finishDispatch give this lane the same backstop: if the
+// agent exits 0 with real work in the worktree but no PR, the shipper commits,
+// pushes, and opens the PR itself. Pre-commit hooks still run — a diff that
+// fails lint/typecheck fails the finish and releases the claim as before.
+
+export interface FinisherRunner {
+  (args: ReadonlyArray<string>, opts?: { readonly timeoutMs?: number }): string;
+}
+
+/** Uncommitted changes or unpushed commits count as shippable work. */
+export function worktreeHasWork(runInWorktree: FinisherRunner): boolean {
+  const dirty = runInWorktree(['git', 'status', '--porcelain']).trim();
+  if (dirty.length > 0) return true;
+  const ahead = runInWorktree([
+    'git',
+    'rev-list',
+    '--count',
+    'origin/main..HEAD',
+  ]).trim();
+  return Number.parseInt(ahead, 10) > 0;
+}
+
+export function buildFinishCommitMessage(issue: GithubIssue): string {
+  const title = issue.title.replace(/\s+/g, ' ').trim().slice(0, 90);
+  return [
+    `chore(codex): ${title} (#${issue.number})`,
+    '',
+    'Deterministically finished by codex-issue-shipper: the coding agent',
+    'exited 0 with work in the worktree but no PR, so the shipper committed,',
+    'pushed, and opened the PR (same contract as the kanban ship lane).',
+  ].join('\n');
+}
+
+export function buildFinishPrBody(issue: GithubIssue, logPath: string): string {
+  return [
+    `Closes #${issue.number}`,
+    '',
+    'Opened by the codex-issue-shipper **deterministic finisher**: the coding',
+    'agent produced this diff but exited without opening a PR. Pre-commit hooks',
+    '(lint-staged, typecheck) passed at commit time; CI is the merge gate as',
+    'usual.',
+    '',
+    `Agent log: \`${logPath}\``,
+  ].join('\n');
+}
+
+/**
+ * Commit, push, and open the PR for work the agent left in the worktree.
+ * Throws on any step failure (caller releases the claim). All git/gh calls
+ * go through the injected runner so this stays unit-testable.
+ */
+export function finishDispatch(
+  runInWorktree: FinisherRunner,
+  input: {
+    readonly repo: string;
+    readonly branchName: string;
+    readonly issue: GithubIssue;
+    readonly logPath: string;
+  }
+): void {
+  const dirty = runInWorktree(['git', 'status', '--porcelain']).trim();
+  if (dirty.length > 0) {
+    runInWorktree(['git', 'add', '-A']);
+    runInWorktree(
+      [
+        'git',
+        '-c',
+        'user.name=Hermes',
+        '-c',
+        'user.email=hermes@jovie.co',
+        'commit',
+        '-m',
+        buildFinishCommitMessage(input.issue),
+      ],
+      // Pre-commit hooks run typecheck/lint on staged files — give them room.
+      { timeoutMs: 10 * 60 * 1000 }
+    );
+  }
+  runInWorktree(['git', 'push', '-u', 'origin', input.branchName], {
+    timeoutMs: 5 * 60 * 1000,
+  });
+  runInWorktree(
+    [
+      'gh',
+      'pr',
+      'create',
+      '--repo',
+      input.repo,
+      '--base',
+      'main',
+      '--head',
+      input.branchName,
+      '--title',
+      `chore(codex): ${input.issue.title.replace(/\s+/g, ' ').trim().slice(0, 90)} (#${input.issue.number})`,
+      '--body',
+      buildFinishPrBody(input.issue, input.logPath),
+    ],
+    { timeoutMs: 2 * 60 * 1000 }
+  );
+}

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -8,10 +8,12 @@ import {
   CODEX_CLAIM_LABEL,
   CODEX_TRUSTED_LABEL,
   eligibleCodexIssues,
+  finishDispatch,
   loadShipperConfig,
   NO_AUTO_LABEL,
   selectTaskRoute,
   shellQuote,
+  worktreeHasWork,
 } from '../../hermes/lib/codex-issue-shipper.ts';
 
 const config = {
@@ -352,5 +354,112 @@ describe('codex issue shipper prompt', () => {
     expect(command.args).not.toContain('--sandbox');
     expect(command.args).not.toContain('exec');
     expect(command.args).not.toContain('-C');
+  });
+});
+
+describe('deterministic finisher', () => {
+  const issue = {
+    number: 12721,
+    title:
+      'Ovie TS github-issue shipper:   grok agents abandon the ship contract',
+    body: '',
+    url: 'https://github.com/JovieInc/Jovie/issues/12721',
+    updatedAt: '2026-07-02T00:00:00.000Z',
+    labels: [],
+  };
+
+  function fakeRunner(responses) {
+    const calls = [];
+    const run = (args, opts) => {
+      calls.push({ args, opts });
+      const key = args.slice(0, 3).join(' ');
+      for (const [prefix, out] of Object.entries(responses)) {
+        if (key.startsWith(prefix)) return out;
+      }
+      return '';
+    };
+    return { run, calls };
+  }
+
+  it('worktreeHasWork: dirty tree counts', () => {
+    const { run } = fakeRunner({ 'git status --porcelain': ' M a.ts\n' });
+    expect(worktreeHasWork(run)).toBe(true);
+  });
+
+  it('worktreeHasWork: clean tree but unpushed commits count', () => {
+    const { run } = fakeRunner({
+      'git status --porcelain': '',
+      'git rev-list --count': '2\n',
+    });
+    expect(worktreeHasWork(run)).toBe(true);
+  });
+
+  it('worktreeHasWork: clean tree, no commits ahead — no work', () => {
+    const { run } = fakeRunner({
+      'git status --porcelain': '',
+      'git rev-list --count': '0\n',
+    });
+    expect(worktreeHasWork(run)).toBe(false);
+  });
+
+  it('finishDispatch commits dirty work, pushes, and opens the PR', () => {
+    const { run, calls } = fakeRunner({
+      'git status --porcelain': ' M a.ts\n',
+    });
+    finishDispatch(run, {
+      repo: 'JovieInc/Jovie',
+      branchName: 'codex/gh-12721-x',
+      issue,
+      logPath: '/tmp/agent.log',
+    });
+    const cmds = calls.map(c => c.args.slice(0, 2).join(' '));
+    expect(cmds).toEqual([
+      'git status',
+      'git add',
+      'git -c',
+      'git push',
+      'gh pr',
+    ]);
+    const commit = calls[2].args;
+    expect(commit).toContain('commit');
+    const msg = commit[commit.indexOf('-m') + 1];
+    expect(msg).toMatch(
+      /^chore\(codex\): Ovie TS github-issue shipper: grok agents abandon/
+    );
+    expect(msg).toContain('(#12721)');
+    // hooks get a long timeout
+    expect(calls[2].opts?.timeoutMs).toBeGreaterThan(60_000);
+    const prCreate = calls[4].args;
+    expect(prCreate).toContain('--head');
+    expect(prCreate[prCreate.indexOf('--head') + 1]).toBe('codex/gh-12721-x');
+    expect(prCreate[prCreate.indexOf('--body') + 1]).toContain('Closes #12721');
+  });
+
+  it('finishDispatch skips commit when work is already committed', () => {
+    const { run, calls } = fakeRunner({ 'git status --porcelain': '' });
+    finishDispatch(run, {
+      repo: 'JovieInc/Jovie',
+      branchName: 'codex/gh-12721-x',
+      issue,
+      logPath: '/tmp/agent.log',
+    });
+    const cmds = calls.map(c => c.args.slice(0, 2).join(' '));
+    expect(cmds).toEqual(['git status', 'git push', 'gh pr']);
+  });
+
+  it('finishDispatch propagates a failing step (caller releases the claim)', () => {
+    const run = args => {
+      if (args[0] === 'git' && args[1] === 'push')
+        throw new Error('push rejected');
+      return ' M a.ts\n';
+    };
+    expect(() =>
+      finishDispatch(run, {
+        repo: 'JovieInc/Jovie',
+        branchName: 'codex/gh-12721-x',
+        issue,
+        logPath: '/tmp/agent.log',
+      })
+    ).toThrow('push rejected');
   });
 });


### PR DESCRIPTION
## Summary
Fixes #12721 (JOV-3815). Restores the GitHub-issue ship lane from zero throughput.

**Problem:** grok CLI 0.2.77 abandons the shipper's long protocol prompt mid-task — agents exit 0 after doing real work but never commit/push/PR. Result: **0 PRs from 334 'successful' runs** (Jul 1–2), with each issue churned back into the queue. The kanban lane never had this failure mode because deterministic Python owns the ship mechanics and the model only supplies the diff.

**Fix:** give the issue lane the same contract as a backstop. When an agent exits 0 with no PR but real work in the worktree (dirty tree or unpushed commits), the shipper commits as Hermes (pre-commit hooks fully enforced — a diff that fails lint/typecheck fails the finish and releases the claim exactly as before), pushes the branch, and opens the PR with `Closes #N`. CI remains the merge gate.

## Changes
- `scripts/hermes/lib/codex-issue-shipper.ts`: `worktreeHasWork`, `finishDispatch`, commit-message/PR-body builders — runner injected, fully unit-testable.
- `scripts/hermes/jobs/codex-issue-shipper.ts`: on agent-exit-0-with-no-PR, attempt the deterministic finish before the existing release-for-retry fallback; new `deterministic_finish_shipped` / `deterministic_finish_failed` events.

## Verification
- `vitest run lib/__tests__/codex-issue-shipper.test.mjs` → **20 passed** (6 new: has-work detection ×3, full finish command sequence, already-committed path, failure propagation)
- Dry-run pass of the wired runner: clean scan/plan/finish cycle

## Cost Impact
None — replaces wasted agent re-runs with one `gh pr create` per finished dispatch; net API usage goes **down** (no more claim-churn retries per issue).

Closes #12721

🤖 Generated with [Claude Code](https://claude.com/claude-code)