### PR TITLE
test(e2e): realign golden path with collapsed homepage; widen OTP cold-start budget

### DIFF
--- a/apps/web/tests/e2e/golden-path.spec.ts
+++ b/apps/web/tests/e2e/golden-path.spec.ts
@@ -442,45 +442,22 @@ test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Live Profile'
       timeout: 30_000,
     });
 
-    // A signup CTA must be visible — either the claim input or a signup link
-    const signupCta = page
-      .locator('#handle-input')
-      .or(page.locator('a[href*="/signup"]').first());
-    await expect(signupCta.first()).toBeVisible({ timeout: 20_000 });
+    // The collapsed homepage (#11988) is hero + minimal footer: no claim
+    // input, no signup links — the funnel routes through the hero command
+    // center into /start chat. Assert the hero rendered, then enter the
+    // classic signup path directly (this spec's scope is signup →
+    // onboarding → live profile, not the chat funnel).
+    await expect(page.getByTestId('homepage-hero-command-center')).toBeVisible({
+      timeout: 20_000,
+    });
 
     // ──────────────────────────────────────────────────────────────────
     // STEP 2: Initiate signup
     // ──────────────────────────────────────────────────────────────────
-    const claimInput = page.locator('#handle-input');
-    const claimVisible = await claimInput
-      .isVisible({ timeout: 5_000 })
-      .catch(() => false);
-
-    if (claimVisible) {
-      // Use claim handle form — stores pendingClaim in sessionStorage
-      const testHandle = `gp-${Date.now().toString(36)}`;
-      await claimInput.fill(testHandle);
-
-      // Wait for the availability check to reach a terminal state. We
-      // can't just poll the spinner's visibility — the spinner is
-      // conditionally rendered (only present while `showChecking` is
-      // true), so `toBeHidden` passes both before the spinner mounts
-      // AND after the check completes. Instead, wait for the success
-      // helper text, which only appears in the available terminal state
-      // (the handle is generated with Date.now().toString(36) so a
-      // collision with an existing creator is extremely unlikely).
-      await expect(page.getByText(/is available — tap/i)).toBeVisible({
-        timeout: 10_000,
-      });
-
-      // Submit the form
-      await claimInput.press('Enter');
-    } else {
-      // Fall back to signup link
-      await page.locator('a[href*="/signup"]').first().click();
-    }
-
-    // Should navigate to signup or onboarding
+    await page.goto('/signup', {
+      waitUntil: 'domcontentloaded',
+      timeout: 30_000,
+    });
     await page.waitForURL(/\/(signup|onboarding)/, { timeout: 30_000 });
 
     // ──────────────────────────────────────────────────────────────────

--- a/apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts
+++ b/apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts
@@ -165,9 +165,12 @@ async function enterOtpCode(page: Page, code: string) {
     .first();
   const firstDigitInput = flow.getByLabel('Digit 1 of 6');
 
+  // The email→OTP transition includes an OTP send (Resend) + write on a
+  // cold ephemeral Neon branch; the first mobile run in CI regularly needs
+  // longer than the standard visibility budget (3×20s timeouts observed).
   await otpStep.waitFor({
     state: 'visible',
-    timeout: SMOKE_TIMEOUTS.VISIBILITY,
+    timeout: SMOKE_TIMEOUTS.VISIBILITY * 3,
   });
   await firstDigitInput.click();
   await firstDigitInput.pressSequentially(code);


### PR DESCRIPTION
## Summary
Fixes the two failing risk-triggered merge-gate lanes (attached logs from #12759's run):

**Golden Path (PR)** — `golden-path.spec.ts` step 1/2 waited for `#handle-input` / a `/signup` link on the homepage. Those were removed when the homepage collapsed to hero + minimal footer (#11988); the funnel now routes through the hero command center into `/start` chat. Because this lane only runs on high-risk PRs, the stale spec sat unnoticed until #12759 (env/config change) tripped it — 3×20s timeouts, deterministic failure. Step 1 now asserts `homepage-hero-command-center` renders; step 2 navigates to `/signup` directly (this spec's scope is the classic signup → onboarding → live-profile journey, not the chat funnel).

**E2E Smoke (PR Fast Feedback)** — `profile-fan-capture-golden-path.spec.ts` mobile email→OTP transition timed out 3× at 20s. The transition includes a Resend OTP send + a write on a cold ephemeral Neon branch, and the mobile variant runs first (coldest). Widened that single transition's budget to 3× (60s); the desktop variant passed in the same run once warm, and the OTP-step testid still exists — this is a cold-start budget issue, not a product regression.

## Verification
- Typecheck + biome clean. Deterministic failure reproduced locally: the hydrated homepage has `handleInput: false, signupLinks: 0` (Playwright DOM check), confirming the spec — not the product — was wrong.

Unblocks #12759 and any future high-risk PR whose queue draft runs these lanes.

<!-- linear-issue-id:JOV-3806 -->