### PR TITLE
feat(hermes): agent fallback chain for the issue shipper

### DIFF
--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -46,6 +46,8 @@ import {
   labelNames,
   loadShipperConfig,
   NO_AUTO_LABEL,
+  parseAgentChain,
+  routeForAgent,
   type ShipperConfig,
   worktreeHasWork,
 } from '../lib/codex-issue-shipper';
@@ -775,41 +777,89 @@ async function dispatchPlan(
       return;
     }
 
-    const prompt = buildAgentPrompt({
-      issue: dispatch.issue,
-      branchName: dispatch.branchName,
-      baseBranch: 'main',
-      integrationBranch: dispatch.integrationBranch,
-      route: dispatch.route,
-      gbrain,
-      repoRoot: prepared.repoRoot,
-    });
+    const runInWorktree: FinisherRunner = (args, opts) =>
+      execFileSync(args[0], args.slice(1), {
+        cwd: prepared.repoRoot,
+        encoding: 'utf8',
+        timeout: opts?.timeoutMs ?? 30_000,
+        maxBuffer: 5 * 1024 * 1024,
+      });
+    const safeHasWork = (): boolean => {
+      try {
+        return worktreeHasWork(runInWorktree);
+      } catch {
+        return false;
+      }
+    };
 
-    const agentResult = await runAgent(
-      config,
-      dispatch,
-      prompt,
-      prepared.repoRoot
-    );
-    logJobEvent({
-      job: JOB,
-      event: agentResult.ok ? 'agent_succeeded' : 'agent_failed',
-      issue: dispatch.issue.number,
-      status: agentResult.status,
-      signal: agentResult.signal,
-      error: agentResult.error,
-      logPath: agentResult.logPath,
-      promptPath: agentResult.promptPath,
-      gbrainSlug: gbrain.captureSlug,
-    });
+    // Agent fallback chain: an attempt that ends with neither a PR nor work
+    // in the worktree (and wasn't killed by the system) hands the same
+    // dispatch to the next harness instead of burning a claim-release cycle.
+    const chain = parseAgentChain(process.env, config.agent);
+    let agentResult!: AgentRunResult;
+    let pr: { number: number; url: string } | null = null;
+    let isSystemKilled = false;
 
-    // SIGTERM or timeout = system interruption, release claim for retry
-    // Exit 137 (SIGKILL) or 143 (SIGTERM) means the agent was externally killed
-    const isSystemKilled =
-      agentResult.status === 143 ||
-      agentResult.status === 137 ||
-      agentResult.error?.includes('timeout') ||
-      agentResult.error?.includes('killed');
+    for (let attempt = 0; attempt < chain.length; attempt++) {
+      const agent = chain[attempt];
+      const attemptRoute = routeForAgent(agent, dispatch.route);
+      const attemptConfig = { ...config, agent };
+      const attemptDispatch = { ...dispatch, route: attemptRoute };
+      const prompt = buildAgentPrompt({
+        issue: attemptDispatch.issue,
+        branchName: attemptDispatch.branchName,
+        baseBranch: 'main',
+        integrationBranch: attemptDispatch.integrationBranch,
+        route: attemptRoute,
+        gbrain,
+        repoRoot: prepared.repoRoot,
+      });
+
+      agentResult = await runAgent(
+        attemptConfig,
+        attemptDispatch,
+        prompt,
+        prepared.repoRoot
+      );
+      logJobEvent({
+        job: JOB,
+        event: agentResult.ok ? 'agent_succeeded' : 'agent_failed',
+        issue: dispatch.issue.number,
+        agent,
+        attempt: attempt + 1,
+        status: agentResult.status,
+        signal: agentResult.signal,
+        error: agentResult.error,
+        logPath: agentResult.logPath,
+        promptPath: agentResult.promptPath,
+        gbrainSlug: gbrain.captureSlug,
+      });
+
+      // SIGTERM or timeout = system interruption — do not chain, release.
+      // A null exit status means the agent never ran to a decision — a
+      // spawn/infra failure (e.g. a harness binary missing), not a code
+      // verdict. Treat it like a system interruption: release, don't block.
+      isSystemKilled =
+        agentResult.status === 143 ||
+        agentResult.status === 137 ||
+        agentResult.status === null ||
+        Boolean(agentResult.error?.includes('timeout')) ||
+        Boolean(agentResult.error?.includes('killed'));
+      if (isSystemKilled) break;
+
+      pr = findPrForBranch(config, dispatch.branchName);
+      if (pr || safeHasWork()) break;
+
+      if (attempt < chain.length - 1) {
+        logJobEvent({
+          job: JOB,
+          event: 'agent_no_work_fallback',
+          issue: dispatch.issue.number,
+          fromAgent: agent,
+          toAgent: chain[attempt + 1],
+        });
+      }
+    }
 
     if (isSystemKilled) {
       releaseClaimForRetry(
@@ -854,7 +904,7 @@ async function dispatchPlan(
       return;
     }
 
-    let pr = findPrForBranch(config, dispatch.branchName);
+    if (!pr) pr = findPrForBranch(config, dispatch.branchName);
 
     // Deterministic finisher: the agent exited 0 without opening a PR, but
     // may have left real work in the worktree (grok 0.2.77 abandons the
@@ -863,13 +913,6 @@ async function dispatchPlan(
     // Pre-commit hooks gate the commit; any failure falls through to the
     // existing release-for-retry path.
     if (!pr) {
-      const runInWorktree: FinisherRunner = (args, opts) =>
-        execFileSync(args[0], args.slice(1), {
-          cwd: prepared.repoRoot,
-          encoding: 'utf8',
-          timeout: opts?.timeoutMs ?? 30_000,
-          maxBuffer: 5 * 1024 * 1024,
-        });
       try {
         if (worktreeHasWork(runInWorktree)) {
           finishDispatch(runInWorktree, {

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -669,3 +669,47 @@ export function finishDispatch(
     { timeoutMs: 2 * 60 * 1000 }
   );
 }
+
+// --- Agent fallback chain ---------------------------------------------------
+//
+// "Auto-retry when models fail": when the primary harness produces neither a
+// PR nor work in the worktree (grok 0.2.77 sometimes dies before writing
+// anything), the dispatch retries with the next harness in the chain instead
+// of burning a claim-release cycle. The deterministic finisher covers the
+// partial-work class; this covers the zero-work class. Claude fallback is
+// subscription-CLI ($0 marginal), per the shipping doctrine.
+
+const SHIPPER_AGENTS: ReadonlyArray<ShipperAgent> = ['claude', 'codex', 'grok'];
+
+export function parseAgentChain(
+  env: NodeJS.ProcessEnv,
+  primary: ShipperAgent
+): ShipperAgent[] {
+  const raw = env.HERMES_CODEX_SHIPPER_AGENT_CHAIN;
+  if (raw) {
+    const parsed = raw
+      .split(',')
+      .map(item => item.trim())
+      .filter((item): item is ShipperAgent =>
+        SHIPPER_AGENTS.includes(item as ShipperAgent)
+      );
+    const deduped = [...new Set(parsed)];
+    if (deduped.length > 0) return deduped;
+  }
+  // Default: grok primaries fall back to claude; other primaries run solo.
+  return primary === 'grok' ? ['grok', 'claude'] : [primary];
+}
+
+/**
+ * The configured models belong to the PRIMARY harness (e.g. grok model ids).
+ * A claude fallback attempt needs claude model names; other agents keep the
+ * configured route untouched.
+ */
+export function routeForAgent(
+  agent: ShipperAgent,
+  route: TaskRoute
+): TaskRoute {
+  if (agent !== 'claude') return route;
+  const session = route.modelProfile === 'escalation' ? 'opus' : 'sonnet';
+  return { ...route, sessionModel: session, fallbackModel: 'sonnet' };
+}

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -11,6 +11,8 @@ import {
   finishDispatch,
   loadShipperConfig,
   NO_AUTO_LABEL,
+  parseAgentChain,
+  routeForAgent,
   selectTaskRoute,
   shellQuote,
   worktreeHasWork,
@@ -461,5 +463,55 @@ describe('deterministic finisher', () => {
         logPath: '/tmp/agent.log',
       })
     ).toThrow('push rejected');
+  });
+});
+
+describe('agent fallback chain', () => {
+  it('grok primary defaults to a grok->claude chain', () => {
+    expect(parseAgentChain({}, 'grok')).toEqual(['grok', 'claude']);
+  });
+
+  it('non-grok primary runs solo by default', () => {
+    expect(parseAgentChain({}, 'claude')).toEqual(['claude']);
+    expect(parseAgentChain({}, 'codex')).toEqual(['codex']);
+  });
+
+  it('explicit HERMES_CODEX_SHIPPER_AGENT_CHAIN overrides, deduped + filtered', () => {
+    expect(
+      parseAgentChain(
+        { HERMES_CODEX_SHIPPER_AGENT_CHAIN: 'grok, claude, grok, bogus' },
+        'grok'
+      )
+    ).toEqual(['grok', 'claude']);
+  });
+
+  it('empty/garbage chain env falls back to the default', () => {
+    expect(
+      parseAgentChain({ HERMES_CODEX_SHIPPER_AGENT_CHAIN: ' , bogus ' }, 'grok')
+    ).toEqual(['grok', 'claude']);
+  });
+
+  it('routeForAgent rewrites the model only for claude attempts', () => {
+    const grokRoute = {
+      sessionModel: 'grok-composer-2.5-fast',
+      fallbackModel: 'grok-composer-2.5-fast',
+      riskLevel: 'low',
+      modelProfile: 'standard',
+      maxTurns: 120,
+      specialistSubagents: [],
+      reasons: [],
+    };
+    // grok attempt: untouched
+    expect(routeForAgent('grok', grokRoute)).toBe(grokRoute);
+    // claude attempt: sonnet for standard risk
+    const claude = routeForAgent('claude', grokRoute);
+    expect(claude.sessionModel).toBe('sonnet');
+    expect(claude.fallbackModel).toBe('sonnet');
+    // claude attempt on an escalation route: opus
+    const esc = routeForAgent('claude', {
+      ...grokRoute,
+      modelProfile: 'escalation',
+    });
+    expect(esc.sessionModel).toBe('opus');
   });
 });


### PR DESCRIPTION
Partial fix for #12616 (Tim's direction 2026-07-03). Completes auto-retry-when-models-fail for the GitHub-issue ship lane.

The deterministic finisher (#12753) rescues 'agent did work but never shipped'. This covers the remaining class: grok CLI sometimes exits with nothing written. Previously that churned a claim-release cycle every tick; now the same dispatch retries with the next harness before releasing.

## How it works
- parseAgentChain — default grok→claude when grok is primary (others run solo); overridable via HERMES_CODEX_SHIPPER_AGENT_CHAIN, deduped+validated.
- routeForAgent — a claude attempt rewrites grok model ids to sonnet (opus for escalation); other agents keep their route.
- Dispatch loops the chain: an attempt ending with no PR and no worktree work (and not system-killed) hands off to the next harness (agent_no_work_fallback event). Deterministic finisher + existing release/block paths run on the final attempt.
- Bonus: a null exit status (spawn/infra failure) now releases for retry instead of blocking the card.

claude is the fallback (subscription CLI, $0 marginal); verified it resolves first on the shipper launchd PATH.

## Verification
25 vitest tests pass (5 new); dry-run of the wired runner clean.

## Cost Impact
Net down: replaces per-tick claim-churn retries with one in-place claude attempt only when grok produced nothing.

Relates to #12616 (failure-taxonomy remainder stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)