### PR TITLE
fix: guard Hermes agent config drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ### Fixed
 
+- [internal] **Hermes/OpenClaw agent config health**: adds a launchd-backed sentinel for recurring Telegram-dispatched agent failures, catching stale Hermes fallback models, paid OpenRouter fallbacks, and schema-clobbered OpenClaw `memorySearch` blocks before gateway churn.
 - **Smoother dashboard interactions (JOV-3800)**: opening a release, contact, or tour-date panel from chat now shows the details instantly instead of a brief loading state; settings pages no longer nudge when a change is being saved; and the calendar keeps its layout steady while it first loads.
 - [internal] Pre-push Biome gate scopes to changed files (mirroring CI) instead of a repo-wide `biome check .`, so pre-existing Biome drift on `main` no longer blocks `git push` from every worktree and stops training agents toward the `JOVIE_SKIP_PRE_PUSH_GATE=1` escape hatch (GitHub #12475).
 - [internal] Cleared the pre-existing Biome drift on `main` that #12475 unblocked (GitHub #12482): `biome format` reflow of `globals.css` + `design-system.css` (whitespace-only — design tokens byte-identical with whitespace stripped) and `biome migrate` on `biome.json` (schema `2.4.8`→`2.5.1`, deprecated `recommended: false`→`preset: "none"`). `biome ci .` is now clean. The issue's `setup.ts` and public-SVG `noSvgWithoutTitle` buckets were already non-issues on current main (Biome 2.5.1 does not lint raw `.svg` files).

--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -125,6 +125,10 @@ tail -50 ~/.hermes/logs/dispatch.jsonl | jq .
 tail -50 ~/.hermes/logs/launchd/cron-codex-issue-shipper.log
 tail -50 ~/.hermes/logs/codex-issue-shipper/*.log 2>/dev/null  # after a non-dry-run agent dispatch
 
+# Hermes/OpenClaw agent config health
+tsx scripts/hermes/jobs/agent-config-health.ts
+tail -50 ~/.hermes/logs/launchd/cron-agent-config-health.err.log
+
 # Free-model rankings
 cat ~/.hermes/state/model-router-rankings.json | jq .
 ```
@@ -227,9 +231,22 @@ Ship now / Re-evaluate when / Then:
 
 1. Check launchd state: `launchctl print gui/$(id -u)/ai.hermes.gateway | grep -A 3 "last exit"`
 2. Tail gateway log: `tail -100 ~/.hermes/logs/gateway.error.log`
-3. Confirm the supported Hermes gateway command works: `hermes gateway status`
-4. Re-run bootstrap: `./scripts/hermes/bootstrap-air.sh` (idempotent)
-5. If config is corrupt: `mv ~/.hermes/config.yaml ~/.hermes/config.yaml.bak && ./scripts/hermes/bootstrap-air.sh --reconfigure`
+3. Run the config sentinel: `tsx scripts/hermes/jobs/agent-config-health.ts`
+4. Confirm the supported Hermes gateway command works: `hermes gateway status`
+5. Re-run bootstrap: `./scripts/hermes/bootstrap-air.sh` (idempotent)
+6. If config is corrupt: `mv ~/.hermes/config.yaml ~/.hermes/config.yaml.bak && ./scripts/hermes/bootstrap-air.sh --reconfigure`
+
+### Agents keep failing after Telegram dispatch
+
+Run the config sentinel before changing models or restarting services:
+
+```bash
+tsx scripts/hermes/jobs/agent-config-health.ts
+tail -20 ~/.hermes/logs/jobs.jsonl | jq 'select(.job == "agent-config-health")'
+```
+
+It fails on the recurring local-agent patterns that caused OpenClaw/Hermes churn:
+schema-clobbered `memorySearch` blocks in `~/.openclaw/openclaw.json`, Vercel AI Gateway embedding model names without the `openai/` prefix, and stale Hermes fallbacks such as `nex-agi/nex-n2-pro`.
 
 ### Voice memo ingest stopped working
 

--- a/scripts/hermes/jobs/agent-config-health.ts
+++ b/scripts/hermes/jobs/agent-config-health.ts
@@ -1,0 +1,396 @@
+#!/usr/bin/env tsx
+/**
+ * Agent Config Health — Hermes-Air
+ *
+ * Guards the local agent control plane against config drift found in
+ * Telegram/OpenClaw incidents: stale Hermes model fallbacks and invalid
+ * OpenClaw memorySearch schema rewrites.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { HERMES_PATHS } from '../lib/hermes-paths';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { sendTelegram } from '../lib/telegram-client';
+
+const JOB = 'agent-config-health';
+const VERCEL_AI_GATEWAY_URL = 'https://ai-gateway.vercel.sh';
+const BROKEN_FALLBACK_MODELS = new Set([
+  'nex-agi/nex-n2-pro:free',
+  'nex-agi/nex-n2-pro-free',
+]);
+
+export interface ConfigFinding {
+  readonly severity: 'error' | 'warning';
+  readonly file: 'hermes' | 'openclaw';
+  readonly path: string;
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface AgentConfigHealthResult {
+  readonly findings: ConfigFinding[];
+  readonly checked: {
+    readonly hermesConfigPath: string;
+    readonly openClawConfigPath: string;
+  };
+}
+
+interface HermesFallbackProvider {
+  readonly provider?: string;
+  readonly model?: string;
+  readonly line: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function pathFor(parent: string, key: string | number): string {
+  if (typeof key === 'number') return `${parent}[${key}]`;
+  return parent ? `${parent}.${key}` : key;
+}
+
+function cleanYamlScalar(value: string): string {
+  return value
+    .replace(/\s+#.*$/, '')
+    .trim()
+    .replace(/^['"]|['"]$/g, '');
+}
+
+function parseYamlKeyValue(
+  text: string
+): { key: string; value: string } | null {
+  const match = text.match(/^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$/);
+  if (!match) return null;
+  return { key: match[1], value: cleanYamlScalar(match[2]) };
+}
+
+export function parseHermesFallbackProviders(
+  yamlText: string
+): HermesFallbackProvider[] {
+  const providers: HermesFallbackProvider[] = [];
+  const lines = yamlText.split(/\r?\n/);
+  let inFallbackBlock = false;
+  let blockIndent = 0;
+  let current: { provider?: string; model?: string; line: number } | null =
+    null;
+
+  const pushCurrent = (): void => {
+    if (current) providers.push(current);
+    current = null;
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const rawLine = lines[index].replace(/\t/g, '  ');
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const indent = rawLine.length - rawLine.trimStart().length;
+
+    if (!inFallbackBlock) {
+      const fallbackMatch = rawLine.match(/^(\s*)fallback_providers\s*:/);
+      if (fallbackMatch) {
+        inFallbackBlock = true;
+        blockIndent = fallbackMatch[1].length;
+      }
+      continue;
+    }
+
+    if (indent <= blockIndent && !trimmed.startsWith('-')) {
+      break;
+    }
+
+    if (trimmed.startsWith('-')) {
+      pushCurrent();
+      current = { line: index + 1 };
+      const inline = trimmed.slice(1).trim();
+      const pair = parseYamlKeyValue(inline);
+      if (pair && (pair.key === 'provider' || pair.key === 'model')) {
+        current[pair.key] = pair.value;
+      }
+      continue;
+    }
+
+    if (!current) continue;
+    const pair = parseYamlKeyValue(trimmed);
+    if (pair && (pair.key === 'provider' || pair.key === 'model')) {
+      current[pair.key] = pair.value;
+    }
+  }
+
+  pushCurrent();
+  return providers;
+}
+
+export function validateHermesConfigText(yamlText: string): ConfigFinding[] {
+  const findings: ConfigFinding[] = [];
+  for (const provider of parseHermesFallbackProviders(yamlText)) {
+    const providerName = provider.provider?.toLowerCase();
+    const model = provider.model?.toLowerCase();
+    const normalizedModel = model?.replace(/:/g, '-');
+    const path = `fallback_providers[line ${provider.line}]`;
+
+    if (!providerName || !model) {
+      findings.push({
+        severity: 'warning',
+        file: 'hermes',
+        path,
+        code: 'hermes_fallback_incomplete',
+        message: 'Hermes fallback provider is missing provider or model.',
+      });
+      continue;
+    }
+
+    if (model && BROKEN_FALLBACK_MODELS.has(model)) {
+      findings.push({
+        severity: 'error',
+        file: 'hermes',
+        path: `${path}.model`,
+        code: 'hermes_broken_fallback_model',
+        message:
+          'Hermes fallback model nex-agi/nex-n2-pro is a known broken global fallback for local agents.',
+      });
+    } else if (normalizedModel && BROKEN_FALLBACK_MODELS.has(normalizedModel)) {
+      findings.push({
+        severity: 'error',
+        file: 'hermes',
+        path: `${path}.model`,
+        code: 'hermes_broken_fallback_model',
+        message:
+          'Hermes fallback model nex-agi/nex-n2-pro is a known broken global fallback for local agents.',
+      });
+    }
+
+    if (providerName === 'openrouter' && !model.endsWith(':free')) {
+      findings.push({
+        severity: 'error',
+        file: 'hermes',
+        path: `${path}.model`,
+        code: 'hermes_paid_openrouter_fallback',
+        message:
+          'OpenRouter Hermes fallbacks must be explicitly free models; use a :free model or local Ollama fallback.',
+      });
+    }
+  }
+  return findings;
+}
+
+function validateMemorySearch(
+  memorySearch: unknown,
+  path: string
+): ConfigFinding[] {
+  const findings: ConfigFinding[] = [];
+  if (!isRecord(memorySearch)) {
+    findings.push({
+      severity: 'error',
+      file: 'openclaw',
+      path,
+      code: 'openclaw_memory_search_shape',
+      message: 'OpenClaw memorySearch must be an object.',
+    });
+    return findings;
+  }
+
+  const remote = isRecord(memorySearch.remote) ? memorySearch.remote : null;
+  const provider =
+    typeof memorySearch.provider === 'string' ? memorySearch.provider : null;
+  const model =
+    typeof memorySearch.model === 'string' ? memorySearch.model : null;
+  const baseUrl =
+    remote && typeof remote.baseUrl === 'string' ? remote.baseUrl : null;
+  const apiKey = remote ? remote.apiKey : undefined;
+
+  if (isRecord(apiKey)) {
+    findings.push({
+      severity: 'error',
+      file: 'openclaw',
+      path: `${path}.remote.apiKey`,
+      code: 'openclaw_memory_search_env_api_key',
+      message:
+        'OpenClaw memorySearch remote.apiKey cannot be an {env: ...} object in the current gateway schema.',
+    });
+  }
+
+  if (baseUrl === VERCEL_AI_GATEWAY_URL && provider !== 'openai-compatible') {
+    findings.push({
+      severity: 'error',
+      file: 'openclaw',
+      path: `${path}.provider`,
+      code: 'openclaw_memory_search_provider',
+      message:
+        'OpenClaw memorySearch through Vercel AI Gateway must use provider openai-compatible.',
+    });
+  }
+
+  if (baseUrl === VERCEL_AI_GATEWAY_URL && model === 'text-embedding-3-small') {
+    findings.push({
+      severity: 'error',
+      file: 'openclaw',
+      path: `${path}.model`,
+      code: 'openclaw_memory_search_model_prefix',
+      message:
+        'OpenClaw memorySearch through Vercel AI Gateway must use openai/text-embedding-3-small.',
+    });
+  }
+
+  return findings;
+}
+
+export function validateOpenClawConfig(config: unknown): ConfigFinding[] {
+  const findings: ConfigFinding[] = [];
+
+  const visit = (value: unknown, path: string): void => {
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => visit(item, pathFor(path, index)));
+      return;
+    }
+    if (!isRecord(value)) return;
+
+    for (const [key, child] of Object.entries(value)) {
+      const childPath = pathFor(path, key);
+      if (key === 'memorySearch') {
+        findings.push(...validateMemorySearch(child, childPath));
+      }
+      visit(child, childPath);
+    }
+  };
+
+  visit(config, '');
+  return findings;
+}
+
+function defaultOpenClawConfigPath(): string {
+  const home = process.env.OPENCLAW_HOME ?? join(homedir(), '.openclaw');
+  return process.env.OPENCLAW_CONFIG ?? join(home, 'openclaw.json');
+}
+
+function readOpenClawConfig(path: string): ConfigFinding[] {
+  if (!existsSync(path)) {
+    return [
+      {
+        severity: 'warning',
+        file: 'openclaw',
+        path,
+        code: 'openclaw_config_missing',
+        message: 'OpenClaw config file was not found.',
+      },
+    ];
+  }
+  try {
+    return validateOpenClawConfig(JSON.parse(readFileSync(path, 'utf8')));
+  } catch (err) {
+    return [
+      {
+        severity: 'error',
+        file: 'openclaw',
+        path,
+        code: 'openclaw_config_parse_error',
+        message: err instanceof Error ? err.message : String(err),
+      },
+    ];
+  }
+}
+
+function readHermesConfig(path: string): ConfigFinding[] {
+  if (!existsSync(path)) {
+    return [
+      {
+        severity: 'warning',
+        file: 'hermes',
+        path,
+        code: 'hermes_config_missing',
+        message: 'Hermes config file was not found.',
+      },
+    ];
+  }
+  try {
+    return validateHermesConfigText(readFileSync(path, 'utf8'));
+  } catch (err) {
+    return [
+      {
+        severity: 'error',
+        file: 'hermes',
+        path,
+        code: 'hermes_config_read_error',
+        message: err instanceof Error ? err.message : String(err),
+      },
+    ];
+  }
+}
+
+function formatFinding(finding: ConfigFinding): string {
+  return `${finding.file}:${finding.path} ${finding.code}`;
+}
+
+export async function runAgentConfigHealth(options?: {
+  readonly hermesConfigPath?: string;
+  readonly openClawConfigPath?: string;
+  readonly notify?: boolean;
+}): Promise<AgentConfigHealthResult> {
+  const hermesConfigPath = options?.hermesConfigPath ?? HERMES_PATHS.config;
+  const openClawConfigPath =
+    options?.openClawConfigPath ?? defaultOpenClawConfigPath();
+  const findings = [
+    ...readHermesConfig(hermesConfigPath),
+    ...readOpenClawConfig(openClawConfigPath),
+  ];
+
+  const errors = findings.filter(finding => finding.severity === 'error');
+  logJobEvent({
+    job: JOB,
+    event: 'checked',
+    hermesConfigPath,
+    openClawConfigPath,
+    errors: errors.length,
+    warnings: findings.length - errors.length,
+    findings: findings.map(finding => ({
+      severity: finding.severity,
+      file: finding.file,
+      path: finding.path,
+      code: finding.code,
+    })),
+  });
+
+  if (errors.length > 0 && options?.notify !== false) {
+    const details = errors
+      .slice(0, 8)
+      .map(finding => `- ${formatFinding(finding)}`)
+      .join('\n');
+    await sendTelegram(
+      `Hermes/OpenClaw agent config health failed (${errors.length} error${errors.length === 1 ? '' : 's'}).\n${details}\nRun: tsx scripts/hermes/jobs/agent-config-health.ts`
+    );
+  }
+
+  return {
+    findings,
+    checked: { hermesConfigPath, openClawConfigPath },
+  };
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const result = await runAgentConfigHealth();
+    const errors = result.findings.filter(
+      finding => finding.severity === 'error'
+    );
+    if (errors.length > 0) {
+      for (const finding of errors) {
+        console.error(`[${JOB}] ${formatFinding(finding)}`);
+      }
+      process.exitCode = 1;
+    }
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch(err => {
+    console.error(`[${JOB}] fatal:`, err);
+    process.exit(1);
+  });
+}

--- a/scripts/hermes/launchd/README.md
+++ b/scripts/hermes/launchd/README.md
@@ -19,6 +19,7 @@ The Hermes gateway itself is managed by the installed Hermes CLI as `ai.hermes.g
 | `co.jovie.hermes.cron-pr-monitor.plist.template` | every 10 min | Detect stuck PRs |
 | `co.jovie.hermes.cron-ci-monitor.plist.template` | every 10 min | Detect CI failures on main |
 | `co.jovie.hermes.cron-codex-issue-shipper.plist.template` | every 15 min | Claim one open GitHub issue labeled `codex` and dispatch a coder-profile agent |
+| `co.jovie.hermes.cron-agent-config-health.plist.template` | every 15 min | Detect invalid Hermes/OpenClaw agent config before gateway churn |
 | `co.jovie.hermes.cron-cost-monitor.plist.template` | every 60 min | Cost kill switch |
 | `co.jovie.hermes.cron-daily-briefing.plist.template` | 07:00 daily | Morning briefing to Telegram |
 | `co.jovie.hermes.cron-deterministic-tracker.plist.template` | 03:00 daily | Self-improvement clustering |

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-agent-config-health.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-agent-config-health.plist.template
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-agent-config-health</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/agent-config-health.ts</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>900</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>OPENCLAW_HOME</key>
+        <string>{{HOME}}/.openclaw</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.bun/bin:{{HOME}}/.hermes/bin:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-agent-config-health.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-agent-config-health.err.log</string>
+</dict>
+</plist>

--- a/scripts/lib/__tests__/agent-config-health.test.mjs
+++ b/scripts/lib/__tests__/agent-config-health.test.mjs
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseHermesFallbackProviders,
+  validateHermesConfigText,
+  validateOpenClawConfig,
+} from '../../hermes/jobs/agent-config-health.ts';
+
+describe('parseHermesFallbackProviders', () => {
+  it('parses fallback provider entries from the Hermes config', () => {
+    expect(
+      parseHermesFallbackProviders(`
+provider: openrouter
+model: deepseek/deepseek-r1:free
+fallback_providers:
+  - provider: openrouter
+    model: deepseek/deepseek-r1:free
+  - provider: ollama
+    model: qwen3:4b-q4_K_M
+`)
+    ).toEqual([
+      { line: 5, provider: 'openrouter', model: 'deepseek/deepseek-r1:free' },
+      { line: 7, provider: 'ollama', model: 'qwen3:4b-q4_K_M' },
+    ]);
+  });
+});
+
+describe('validateHermesConfigText', () => {
+  it('rejects the known broken nex-agi fallback variants', () => {
+    const findings = validateHermesConfigText(`
+fallback_providers:
+  - provider: openrouter
+    model: nex-agi/nex-n2-pro:free
+  - provider: openrouter
+    model: nex-agi/nex-n2-pro-free
+`);
+
+    expect(findings.map(finding => finding.code)).toEqual([
+      'hermes_broken_fallback_model',
+      'hermes_broken_fallback_model',
+      'hermes_paid_openrouter_fallback',
+    ]);
+  });
+
+  it('rejects paid OpenRouter fallbacks but accepts local Ollama fallback', () => {
+    const findings = validateHermesConfigText(`
+fallback_providers:
+  - provider: openrouter
+    model: nvidia/nemotron-3-super-120b-a12b
+  - provider: ollama
+    model: qwen3:4b-q4_K_M
+`);
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        code: 'hermes_paid_openrouter_fallback',
+        path: 'fallback_providers[line 3].model',
+        severity: 'error',
+      }),
+    ]);
+  });
+});
+
+describe('validateOpenClawConfig', () => {
+  it('accepts the current OpenClaw memorySearch schema for Vercel AI Gateway', () => {
+    const findings = validateOpenClawConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: 'openai-compatible',
+            remote: {
+              baseUrl: 'https://ai-gateway.vercel.sh',
+            },
+            model: 'openai/text-embedding-3-small',
+            fallback: 'none',
+          },
+        },
+      },
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it('flags the schema clobber that prevents OpenClaw gateway startup', () => {
+    const findings = validateOpenClawConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: 'openai',
+            remote: {
+              baseUrl: 'https://ai-gateway.vercel.sh',
+              apiKey: { env: 'AI_GATEWAY_API_KEY' },
+            },
+            model: 'text-embedding-3-small',
+            fallback: 'none',
+          },
+        },
+        list: [
+          { id: 'main' },
+          {
+            id: 'summer',
+            memorySearch: {
+              provider: 'openai',
+              remote: {
+                baseUrl: 'https://ai-gateway.vercel.sh',
+                apiKey: { env: 'AI_GATEWAY_API_KEY' },
+              },
+              model: 'text-embedding-3-small',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'openclaw_memory_search_env_api_key',
+          path: 'agents.defaults.memorySearch.remote.apiKey',
+        }),
+        expect.objectContaining({
+          code: 'openclaw_memory_search_provider',
+          path: 'agents.defaults.memorySearch.provider',
+        }),
+        expect.objectContaining({
+          code: 'openclaw_memory_search_model_prefix',
+          path: 'agents.defaults.memorySearch.model',
+        }),
+        expect.objectContaining({
+          code: 'openclaw_memory_search_env_api_key',
+          path: 'agents.list[1].memorySearch.remote.apiKey',
+        }),
+      ])
+    );
+    expect(
+      findings.filter(finding => finding.severity === 'error')
+    ).toHaveLength(6);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `agent-config-health`, a Hermes/OpenClaw sentinel that catches the recurring Telegram-dispatched agent failure patterns found locally: broken Hermes fallback models, paid OpenRouter fallbacks, and schema-clobbered OpenClaw `memorySearch` config.
- Installs the sentinel as a 15-minute launchd job through the existing Hermes bootstrap path and documents the runbook recovery flow.
- Adds `CHANGELOG.md` `Unreleased` notes and focused Vitest coverage for the config parser/validator.

## Failure Patterns Found
- OpenClaw gateway startup failed when agents rewrote `~/.openclaw/openclaw.json` with invalid `memorySearch.remote.apiKey` object schema and the wrong Vercel AI Gateway embedding provider/model prefix.
- Hermes/Summer/Eve cron paths used stale `nex-agi/nex-n2-pro` fallback models, causing repeated provider failures after Telegram dispatch.
- OpenRouter credit/auth and session-capacity failures caused repeated retries without a usable fallback provider.
- Maddie image-generation sessions hit OpenRouter 402/no-provider-key loops.
- Madison/source lookup work guessed domains instead of resolving the canonical source.
- A shipping-self-heal cron used an unsafe `mktemp` template and collided.

## Live Machine Repair
- Replaced the active local Hermes fallback in `~/.hermes/config.yaml` from `nex-agi/nex-n2-pro:free` to the local Ollama fallback `qwen3:4b-q4_K_M` after backing up the file to `~/.hermes/config.yaml.bak-20260703-agent-config-health`.
- Verified `pnpm exec tsx scripts/hermes/jobs/agent-config-health.ts` now exits cleanly against the live `~/.hermes/config.yaml` and `~/.openclaw/openclaw.json`.

## Test plan
- [x] `./scripts/setup.sh`
- [x] `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__ --cache false` — 18 files, 220 tests
- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] `pnpm run typecheck`
- [x] `pnpm exec tsx scripts/hermes/jobs/agent-config-health.ts`
- [x] `plutil -lint scripts/hermes/launchd/co.jovie.hermes.cron-agent-config-health.plist.template`
- [x] pre-commit secret scans, Biome, proxy guard
- [x] pre-push Biome, proxy guard, Tailwind guard, web typecheck

🤖 Generated with [Codex](https://openai.com/codex)