### PR TITLE
chore(codex): Mobile chat (iOS): keyboard never dismisses — blocks new messages from view (no dismiss-on (#12741)

### DIFF
--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -428,10 +428,12 @@ private struct MobileChatPlaceholderView: View {
         .padding(.horizontal, JovieSpacing.xLarge)
 
         Spacer(minLength: 48)
-
+      }
+      .safeAreaInset(edge: .bottom, spacing: 0) {
         ChatComposerPreview(draft: $draft, isOffline: isOffline)
           .padding(.horizontal, JovieSpacing.large)
           .padding(.bottom, JovieSpacing.medium)
+          .background(JovieColor.backgroundBase)
       }
     }
     .accessibilityIdentifier("mobile-chat")
@@ -441,17 +443,20 @@ private struct MobileChatPlaceholderView: View {
 private struct ChatComposerPreview: View {
   @Binding var draft: String
   let isOffline: Bool
+  @FocusState private var isComposerFocused: Bool
 
   var body: some View {
     ChatComposerBar(
       draft: $draft,
+      isFocused: $isComposerFocused,
       placeholder: isOffline ? "Ask Jovie (offline)" : "Ask Jovie",
       isSending: false,
       isPlusEnabled: true,
       onSend: { draft = "" },
       onSelectWorkflow: { action in
         draft = action.prompt
-      }
+      },
+      onDraftEdited: {}
     )
   }
 }

--- a/apps/ios/Jovie/Features/Chat/ComposerWorkflowSheet.swift
+++ b/apps/ios/Jovie/Features/Chat/ComposerWorkflowSheet.swift
@@ -138,11 +138,13 @@ private struct ComposerWorkflowTile: View {
 
 struct ChatComposerBar: View {
   @Binding var draft: String
+  @FocusState.Binding var isFocused: Bool
   let placeholder: String
   let isSending: Bool
   let isPlusEnabled: Bool
   let onSend: () -> Void
   let onSelectWorkflow: (ComposerWorkflowAction) -> Void
+  let onDraftEdited: () -> Void
 
   @State private var isShowingWorkflowSheet = false
 
@@ -168,11 +170,15 @@ struct ChatComposerBar: View {
       .accessibilityElement(children: .ignore)
 
       TextField(placeholder, text: $draft)
+        .focused($isFocused)
         .textInputAutocapitalization(.sentences)
         .disableAutocorrection(false)
         .font(JovieFont.body(size: 16))
         .foregroundStyle(JovieColor.textPrimary)
         .frame(height: 52)
+        .onChange(of: draft) {
+          onDraftEdited()
+        }
 
       Button(action: onSend) {
         Image(systemName: isSending ? "ellipsis" : "arrow.up")

--- a/apps/ios/Jovie/Features/Chat/MobileChatView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatView.swift
@@ -1,102 +1,158 @@
 import SwiftUI
 
+enum MobileChatKeyboardPolicy {
+  /// Dismiss when the assistant starts streaming only if the user has not typed since send.
+  static func shouldDismissOnStreamingStart(userEditedSinceSend: Bool) -> Bool {
+    !userEditedSinceSend
+  }
+}
+
 struct MobileChatView: View {
   @Bindable var repository: ChatRepository
   @Binding var draft: String
   let webBaseURL: URL
 
+  @FocusState private var isComposerFocused: Bool
   @State private var isAtBottom = true
+  @State private var userEditedSinceSend = false
 
   var body: some View {
     ZStack {
       JovieColor.backgroundBase.ignoresSafeArea()
 
-      VStack(spacing: 0) {
+      Group {
         if repository.timeline.isEmpty {
           emptyState
         } else {
-          ScrollViewReader { proxy in
-            ScrollView {
-              LazyVStack(alignment: .leading, spacing: JovieSpacing.large) {
-                ForEach(repository.timeline) { item in
-                  MobileChatMessageRow(item: item, webBaseURL: webBaseURL) {
-                    guard let clientTurnId = item.clientTurnId else { return }
-                    Task { await repository.retry(clientTurnId: clientTurnId) }
-                  }
-                }
-              }
-              .padding(.horizontal, JovieSpacing.large)
-              .padding(.top, JovieSpacing.xLarge)
-              .padding(.bottom, JovieSpacing.medium)
-
-              // ponytail: onAppear/onDisappear of this sentinel tracks whether the user is near
-              // the bottom without needing coordinate-space math
-              Color.clear
-                .frame(height: 1)
-                .id("chat-bottom")
-                .onAppear { isAtBottom = true }
-                .onDisappear { isAtBottom = false }
-            }
-            .onChange(of: repository.timeline.count) {
-              guard isAtBottom else { return }
-              withAnimation(.easeOut(duration: 0.25)) {
-                proxy.scrollTo("chat-bottom", anchor: .bottom)
-              }
-            }
-            .onChange(of: repository.timeline.last?.content) {
-              guard isAtBottom else { return }
-              proxy.scrollTo("chat-bottom", anchor: .bottom)
-            }
-            .overlay(alignment: .bottomTrailing) {
-              if !isAtBottom {
-                Button {
-                  isAtBottom = true
-                  withAnimation(.easeOut(duration: 0.25)) {
-                    proxy.scrollTo("chat-bottom", anchor: .bottom)
-                  }
-                } label: {
-                  Image(systemName: "arrow.down")
-                }
-                .buttonStyle(JovieIconButtonStyle())
-                .padding(.trailing, JovieSpacing.large)
-                .padding(.bottom, JovieSpacing.medium)
-                .transition(.opacity.combined(with: .scale(scale: 0.85)))
-                .animation(.spring(duration: 0.2), value: isAtBottom)
-                .accessibilityLabel("Scroll to latest message")
-              }
-            }
-          }
+          transcriptView
         }
-
-        if let errorMessage = repository.lastErrorMessage, repository.isOffline {
-          Text(errorMessage)
-            .font(JovieFont.body(size: 13))
-            .foregroundStyle(JovieColor.textTertiary)
-            .multilineTextAlignment(.center)
-            .padding(.horizontal, JovieSpacing.large)
-            .padding(.bottom, JovieSpacing.small)
-        }
-
-        ChatComposerView(
-          draft: $draft,
-          isSending: repository.isSending,
-          isOffline: repository.isOffline,
-          onSend: {
-            let text = draft
-            draft = ""
-            Task { await repository.send(text: text) }
-          },
-          onSelectWorkflow: { action in
-            draft = action.prompt
-          }
-        )
-        .padding(.horizontal, JovieSpacing.large)
-        .padding(.bottom, JovieSpacing.medium)
+      }
+      .safeAreaInset(edge: .bottom, spacing: 0) {
+        composerChrome
       }
     }
     .accessibilityIdentifier("mobile-chat")
     .task {
       await repository.refreshConversations()
+    }
+  }
+
+  @ViewBuilder
+  private var transcriptView: some View {
+    ScrollViewReader { proxy in
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: JovieSpacing.large) {
+          ForEach(repository.timeline) { item in
+            MobileChatMessageRow(item: item, webBaseURL: webBaseURL) {
+              guard let clientTurnId = item.clientTurnId else { return }
+              Task { await repository.retry(clientTurnId: clientTurnId) }
+            }
+          }
+        }
+        .padding(.horizontal, JovieSpacing.large)
+        .padding(.top, JovieSpacing.xLarge)
+        .padding(.bottom, JovieSpacing.medium)
+
+        // ponytail: onAppear/onDisappear of this sentinel tracks whether the user is near
+        // the bottom without needing coordinate-space math
+        Color.clear
+          .frame(height: 1)
+          .id("chat-bottom")
+          .onAppear { isAtBottom = true }
+          .onDisappear { isAtBottom = false }
+      }
+      .defaultScrollAnchor(.bottom)
+      .scrollDismissesKeyboard(.interactively)
+      .contentShape(Rectangle())
+      .simultaneousGesture(
+        TapGesture().onEnded {
+          isComposerFocused = false
+        }
+      )
+      .onChange(of: repository.timeline.count) {
+        scrollToBottomIfPinned(using: proxy, animated: true)
+      }
+      .onChange(of: repository.timeline.last?.content) {
+        scrollToBottomIfPinned(using: proxy, animated: false)
+      }
+      .onChange(of: repository.timeline.last?.status) {
+        guard repository.timeline.last?.status == .streaming else { return }
+        guard MobileChatKeyboardPolicy.shouldDismissOnStreamingStart(
+          userEditedSinceSend: userEditedSinceSend
+        ) else { return }
+        isComposerFocused = false
+      }
+      .onChange(of: isComposerFocused) {
+        scrollToBottomIfPinned(using: proxy, animated: true)
+      }
+      .overlay(alignment: .bottomTrailing) {
+        if !isAtBottom {
+          Button {
+            isAtBottom = true
+            withAnimation(.easeOut(duration: 0.25)) {
+              proxy.scrollTo("chat-bottom", anchor: .bottom)
+            }
+          } label: {
+            Image(systemName: "arrow.down")
+          }
+          .buttonStyle(JovieIconButtonStyle())
+          .padding(.trailing, JovieSpacing.large)
+          .padding(.bottom, JovieSpacing.medium)
+          .transition(.opacity.combined(with: .scale(scale: 0.85)))
+          .animation(.spring(duration: 0.2), value: isAtBottom)
+          .accessibilityLabel("Scroll to latest message")
+        }
+      }
+    }
+  }
+
+  private var composerChrome: some View {
+    VStack(spacing: 0) {
+      if let errorMessage = repository.lastErrorMessage, repository.isOffline {
+        Text(errorMessage)
+          .font(JovieFont.body(size: 13))
+          .foregroundStyle(JovieColor.textTertiary)
+          .multilineTextAlignment(.center)
+          .padding(.horizontal, JovieSpacing.large)
+          .padding(.bottom, JovieSpacing.small)
+      }
+
+      ChatComposerView(
+        draft: $draft,
+        isComposerFocused: $isComposerFocused,
+        isSending: repository.isSending,
+        isOffline: repository.isOffline,
+        onSend: {
+          let text = draft
+          draft = ""
+          userEditedSinceSend = false
+          Task { await repository.send(text: text) }
+        },
+        onSelectWorkflow: { action in
+          draft = action.prompt
+          userEditedSinceSend = true
+        },
+        onDraftEdited: {
+          userEditedSinceSend = true
+        }
+      )
+      .padding(.horizontal, JovieSpacing.large)
+      .padding(.bottom, JovieSpacing.medium)
+    }
+    .background(JovieColor.backgroundBase)
+  }
+
+  private func scrollToBottomIfPinned(
+    using proxy: ScrollViewProxy,
+    animated: Bool
+  ) {
+    guard isAtBottom else { return }
+    if animated {
+      withAnimation(.easeOut(duration: 0.25)) {
+        proxy.scrollTo("chat-bottom", anchor: .bottom)
+      }
+    } else {
+      proxy.scrollTo("chat-bottom", anchor: .bottom)
     }
   }
 
@@ -221,19 +277,23 @@ private struct MobileChatMessageRow: View {
 
 private struct ChatComposerView: View {
   @Binding var draft: String
+  @FocusState.Binding var isComposerFocused: Bool
   let isSending: Bool
   let isOffline: Bool
   let onSend: () -> Void
   let onSelectWorkflow: (ComposerWorkflowAction) -> Void
+  let onDraftEdited: () -> Void
 
   var body: some View {
     ChatComposerBar(
       draft: $draft,
+      isFocused: $isComposerFocused,
       placeholder: isOffline ? "Ask Jovie (offline)" : "Ask Jovie",
       isSending: isSending,
       isPlusEnabled: !isSending,
       onSend: onSend,
-      onSelectWorkflow: onSelectWorkflow
+      onSelectWorkflow: onSelectWorkflow,
+      onDraftEdited: onDraftEdited
     )
   }
 }

--- a/apps/ios/JovieTests/AppShellChatFirstTests.swift
+++ b/apps/ios/JovieTests/AppShellChatFirstTests.swift
@@ -51,4 +51,12 @@ struct AppShellChatFirstTests {
   @Test func resolvedInitialTabPassesThroughProfileTab() {
     #expect(resolveShellInitialTab(.profile, chatEnabled: true) == .profile)
   }
+
+  @Test func keyboardDismissesOnStreamingStartWhenUserHasNotEditedSinceSend() {
+    #expect(MobileChatKeyboardPolicy.shouldDismissOnStreamingStart(userEditedSinceSend: false))
+  }
+
+  @Test func keyboardStaysOpenOnStreamingStartWhenUserEditedSinceSend() {
+    #expect(MobileChatKeyboardPolicy.shouldDismissOnStreamingStart(userEditedSinceSend: true) == false)
+  }
 }


### PR DESCRIPTION
Closes #12741

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/logs/codex-issue-shipper/github-12741-2026-07-03T01-34-28-795z.log`