### PR TITLE
chore(codex): Mobile chat (iOS): tool markup STILL leaks — <function_calls>/<invoke>/<function_result> d (#12740)

### DIFF
--- a/apps/ios/Jovie/Core/MobileChatContentParser.swift
+++ b/apps/ios/Jovie/Core/MobileChatContentParser.swift
@@ -29,6 +29,25 @@ enum MobileChatRenderableSegment: Equatable, Identifiable, Sendable {
 }
 
 enum MobileChatContentParser {
+  private enum ToolCallDialect {
+    case toolCall
+    case functionCalls
+
+    var openTag: String {
+      switch self {
+      case .toolCall: "<tool_call>"
+      case .functionCalls: "<function_calls>"
+      }
+    }
+
+    var closeTag: String {
+      switch self {
+      case .toolCall: "</tool_call>"
+      case .functionCalls: "</function_calls>"
+      }
+    }
+  }
+
   static func segments(
     from content: String,
     isStreaming: Bool
@@ -45,34 +64,34 @@ enum MobileChatContentParser {
     var cursor = sanitized.startIndex
 
     while cursor < sanitized.endIndex {
-      guard
-        let openRange = sanitized.range(
-          of: "<tool_call>",
-          range: cursor ..< sanitized.endIndex
-        )
-      else {
+      guard let nextBlock = nextToolCallBlock(in: sanitized, from: cursor) else {
         appendTextSegment(
-          String(sanitized[cursor...]).trimmingCharacters(in: .whitespacesAndNewlines),
+          sanitizeResidualToolMarkup(
+            String(sanitized[cursor...]).trimmingCharacters(in: .whitespacesAndNewlines)
+          ),
           to: &segments
         )
         break
       }
 
       appendTextSegment(
-        String(sanitized[cursor ..< openRange.lowerBound])
-          .trimmingCharacters(in: .whitespacesAndNewlines),
+        sanitizeResidualToolMarkup(
+          String(sanitized[cursor ..< nextBlock.openRange.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        ),
         to: &segments
       )
 
-      let afterOpen = openRange.upperBound
+      let afterOpen = nextBlock.openRange.upperBound
       guard
         let closeRange = sanitized.range(
-          of: "</tool_call>",
+          of: nextBlock.dialect.closeTag,
           range: afterOpen ..< sanitized.endIndex
         )
       else {
-        if let partial = parseToolCallBlock(
+        if let partial = parseToolInvocationBlock(
           String(sanitized[afterOpen...]),
+          dialect: nextBlock.dialect,
           isComplete: false,
           resultState: nil
         ) {
@@ -82,10 +101,12 @@ enum MobileChatContentParser {
       }
 
       let block = String(sanitized[afterOpen ..< closeRange.lowerBound])
-      if let model = parseToolCallBlock(
+      let toolName = extractToolName(from: block, dialect: nextBlock.dialect)
+      if let model = parseToolInvocationBlock(
         block,
+        dialect: nextBlock.dialect,
         isComplete: true,
-        resultState: resultStates[firstCapture(in: block, pattern: "<name>\\s*([^<]+?)\\s*</name>") ?? ""]
+        resultState: toolName.flatMap { resultStates[$0] }
       ) {
         segments.append(.toolCall(model))
       }
@@ -107,17 +128,68 @@ enum MobileChatContentParser {
       .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
+  private struct NextToolCallBlock {
+    let dialect: ToolCallDialect
+    let openRange: Range<String.Index>
+  }
+
+  private static func nextToolCallBlock(
+    in content: String,
+    from cursor: String.Index
+  ) -> NextToolCallBlock? {
+    let searchRange = cursor ..< content.endIndex
+    var earliest: NextToolCallBlock?
+
+    for dialect in [ToolCallDialect.toolCall, .functionCalls] {
+      guard let openRange = content.range(of: dialect.openTag, range: searchRange) else {
+        continue
+      }
+
+      if let current = earliest {
+        if openRange.lowerBound < current.openRange.lowerBound {
+          earliest = NextToolCallBlock(dialect: dialect, openRange: openRange)
+        }
+      } else {
+        earliest = NextToolCallBlock(dialect: dialect, openRange: openRange)
+      }
+    }
+
+    return earliest
+  }
+
+  private static func extractToolName(
+    from block: String,
+    dialect: ToolCallDialect
+  ) -> String? {
+    switch dialect {
+    case .toolCall:
+      return firstCapture(in: block, pattern: "<name>\\s*([^<]+?)\\s*</name>")
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .flatMap { $0.isEmpty ? nil : $0 }
+    case .functionCalls:
+      return extractInvokeToolName(from: block)
+    }
+  }
+
   private static func suppressIncompleteToolMarkup(_ content: String, isStreaming: Bool) -> String {
     guard isStreaming else { return content }
 
     var sanitized = content
+    let incompleteOpenTags = [
+      "<tool_result",
+      "<function_result",
+      "<tool_call",
+      "<function_calls",
+    ]
 
-    if let openRange = sanitized.range(
-      of: "<tool_result",
-      options: [.backwards, .caseInsensitive]
-    ) {
+    for openTag in incompleteOpenTags {
+      guard let openRange = sanitized.range(of: openTag, options: [.backwards, .caseInsensitive]) else {
+        continue
+      }
+
       let tail = sanitized[openRange.lowerBound...]
-      if !tail.contains("</tool_result>") {
+      let closeTag = closeTag(forIncompleteOpen: openTag)
+      if !tail.localizedCaseInsensitiveContains(closeTag) {
         sanitized = String(sanitized[..<openRange.lowerBound])
       }
     }
@@ -125,45 +197,144 @@ enum MobileChatContentParser {
     return sanitized
   }
 
+  private static func closeTag(forIncompleteOpen openTag: String) -> String {
+    let normalized = openTag.trimmingCharacters(in: CharacterSet(charactersIn: "<"))
+    return "</\(normalized)>"
+  }
+
   private static func stripToolResultMarkup(from content: String) -> String {
     var sanitized = content
-    while let range = sanitized.range(
-      of: "<tool_result>[\\s\\S]*?</tool_result>",
-      options: .regularExpression
-    ) {
-      sanitized.removeSubrange(range)
+    let patterns = [
+      "<tool_result>[\\s\\S]*?</tool_result>",
+      "<function_result>[\\s\\S]*?</function_result>",
+    ]
+
+    for pattern in patterns {
+      while let range = sanitized.range(of: pattern, options: [.regularExpression, .caseInsensitive]) {
+        sanitized.removeSubrange(range)
+      }
     }
+
     return sanitized
+  }
+
+  private static func sanitizeResidualToolMarkup(_ text: String) -> String {
+    guard !text.isEmpty else { return text }
+
+    var sanitized = text
+    let patterns = [
+      "<([a-z_]+_calls?)>[\\s\\S]*?</\\1>",
+      "<invoke[^>]*>[\\s\\S]*?</invoke>",
+      "<parameter[^>]*>[\\s\\S]*?</parameter>",
+      "<function_result>[\\s\\S]*?</function_result>",
+      "<tool_result>[\\s\\S]*?</tool_result>",
+    ]
+
+    for pattern in patterns {
+      while let range = sanitized.range(of: pattern, options: [.regularExpression, .caseInsensitive]) {
+        sanitized.removeSubrange(range)
+      }
+    }
+
+    return sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   private static func parseToolResultStates(from content: String) -> [String: MobileChatToolCallState] {
     var states: [String: MobileChatToolCallState] = [:]
-    let pattern = "<tool_result>([\\s\\S]*?)</tool_result>"
-    guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
-      return states
-    }
+    let fallbackToolName = extractMostRecentToolName(from: content)
+    let patterns = [
+      "<tool_result>([\\s\\S]*?)</tool_result>",
+      "<function_result>([\\s\\S]*?)</function_result>",
+    ]
 
-    let range = NSRange(content.startIndex..., in: content)
-    regex.enumerateMatches(in: content, range: range) { match, _, _ in
-      guard
-        let match,
-        let blockRange = Range(match.range(at: 1), in: content)
-      else {
-        return
+    for pattern in patterns {
+      guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+        continue
       }
 
-      let block = String(content[blockRange])
-      guard let toolName = firstCapture(in: block, pattern: "<name>\\s*([^<]+?)\\s*</name>") else {
-        return
+      let range = NSRange(content.startIndex..., in: content)
+      regex.enumerateMatches(in: content, range: range) { match, _, _ in
+        guard
+          let match,
+          let blockRange = Range(match.range(at: 1), in: content)
+        else {
+          return
+        }
+
+        let block = String(content[blockRange])
+        let toolName =
+          firstCapture(in: block, pattern: "<name>\\s*([^<]+?)\\s*</name>")
+            ?? firstCapture(in: block, pattern: "\"toolName\"\\s*:\\s*\"([^\"]+)\"")
+            ?? firstCapture(in: block, pattern: "\"name\"\\s*:\\s*\"([^\"]+)\"")
+            ?? fallbackToolName
+
+        guard let toolName else { return }
+
+        let trimmedName = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+
+        states[trimmedName] = resolveResultState(from: block)
       }
-
-      let trimmedName = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmedName.isEmpty else { return }
-
-      states[trimmedName] = resolveResultState(from: block)
     }
 
     return states
+  }
+
+  private static func extractMostRecentToolName(from content: String) -> String? {
+    var latest: (index: String.Index, name: String)?
+
+    let toolCallPattern = "<tool_call>[\\s\\S]*?<name>\\s*([^<]+?)\\s*</name>[\\s\\S]*?</tool_call>"
+    if let regex = try? NSRegularExpression(pattern: toolCallPattern, options: [.caseInsensitive]) {
+      let range = NSRange(content.startIndex..., in: content)
+      regex.enumerateMatches(in: content, range: range) { match, _, _ in
+        guard
+          let match,
+          let openRange = Range(match.range, in: content),
+          let nameRange = Range(match.range(at: 1), in: content)
+        else {
+          return
+        }
+
+        let name = String(content[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+
+        if let current = latest {
+          if openRange.lowerBound > current.index {
+            latest = (openRange.lowerBound, name)
+          }
+        } else {
+          latest = (openRange.lowerBound, name)
+        }
+      }
+    }
+
+    let functionCallsPattern =
+      "<function_calls>[\\s\\S]*?<invoke[^>]*name=[\"']([^\"']+)[\"'][\\s\\S]*?</function_calls>"
+    if let regex = try? NSRegularExpression(pattern: functionCallsPattern, options: [.caseInsensitive]) {
+      let range = NSRange(content.startIndex..., in: content)
+      regex.enumerateMatches(in: content, range: range) { match, _, _ in
+        guard
+          let match,
+          let openRange = Range(match.range, in: content),
+          let nameRange = Range(match.range(at: 1), in: content)
+        else {
+          return
+        }
+
+        let name = String(content[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+
+        if let current = latest {
+          if openRange.lowerBound > current.index {
+            latest = (openRange.lowerBound, name)
+          }
+        } else {
+          latest = (openRange.lowerBound, name)
+        }
+      }
+    }
+
+    return latest?.name
   }
 
   private static func resolveResultState(from block: String) -> MobileChatToolCallState {
@@ -190,6 +361,20 @@ enum MobileChatContentParser {
     return .succeeded
   }
 
+  private static func parseToolInvocationBlock(
+    _ block: String,
+    dialect: ToolCallDialect,
+    isComplete: Bool,
+    resultState: MobileChatToolCallState?
+  ) -> MobileChatToolCallCardModel? {
+    switch dialect {
+    case .toolCall:
+      return parseToolCallBlock(block, isComplete: isComplete, resultState: resultState)
+    case .functionCalls:
+      return parseFunctionCallsBlock(block, isComplete: isComplete, resultState: resultState)
+    }
+  }
+
   private static func parseToolCallBlock(
     _ block: String,
     isComplete: Bool,
@@ -203,12 +388,97 @@ enum MobileChatContentParser {
     guard !trimmedName.isEmpty else { return nil }
 
     let parameters = parseParameters(from: block)
+    return buildToolCallCard(
+      toolName: trimmedName,
+      parameters: parameters,
+      block: block,
+      isComplete: isComplete,
+      resultState: resultState
+    )
+  }
+
+  private static func parseFunctionCallsBlock(
+    _ block: String,
+    isComplete: Bool,
+    resultState: MobileChatToolCallState?
+  ) -> MobileChatToolCallCardModel? {
+    guard let toolName = extractInvokeToolName(from: block) else {
+      return nil
+    }
+
+    let parameters = parseInvokeParameters(from: block)
+    return buildToolCallCard(
+      toolName: toolName,
+      parameters: parameters,
+      block: block,
+      isComplete: isComplete,
+      resultState: resultState
+    )
+  }
+
+  private static func extractInvokeToolName(from block: String) -> String? {
+    let patterns = [
+      "<invoke[^>]*name=\"([^\"]+)\"",
+      "<invoke[^>]*name='([^']+)'",
+    ]
+
+    for pattern in patterns {
+      if let toolName = firstCapture(in: block, pattern: pattern) {
+        let trimmedName = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedName.isEmpty {
+          return trimmedName
+        }
+      }
+    }
+
+    return nil
+  }
+
+  private static func parseInvokeParameters(from block: String) -> [String: String] {
+    var values: [String: String] = [:]
+    let patterns = [
+      "<parameter[^>]*name=\"([^\"]+)\"[^>]*>([\\s\\S]*?)</parameter>",
+      "<parameter[^>]*name='([^']+)'[^>]*>([\\s\\S]*?)</parameter>",
+    ]
+
+    for pattern in patterns {
+      guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+        continue
+      }
+
+      let range = NSRange(block.startIndex..., in: block)
+      regex.enumerateMatches(in: block, range: range) { match, _, _ in
+        guard
+          let match,
+          let keyRange = Range(match.range(at: 1), in: block),
+          let valueRange = Range(match.range(at: 2), in: block)
+        else {
+          return
+        }
+
+        let key = String(block[keyRange])
+        let value = String(block[valueRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        values[key] = value
+      }
+    }
+
+    return values
+  }
+
+  private static func buildToolCallCard(
+    toolName: String,
+    parameters: [String: String],
+    block: String,
+    isComplete: Bool,
+    resultState: MobileChatToolCallState?
+  ) -> MobileChatToolCallCardModel {
     let state = resultState ?? (isComplete ? .running : .running)
 
     return MobileChatToolCallCardModel(
-      id: "tool:\(trimmedName):\(block.hashValue)",
-      toolName: trimmedName,
-      title: resolvedTitle(for: trimmedName, state: state),
+      id: "tool:\(toolName):\(block.hashValue)",
+      toolName: toolName,
+      title: resolvedTitle(for: toolName, state: state),
       body: summarizeParameters(parameters),
       state: state
     )
@@ -257,6 +527,7 @@ enum MobileChatContentParser {
       "artistName",
       "title",
       "name",
+      "productType",
       "query",
       "platform",
       "field",

--- a/apps/ios/JovieTests/MobileChatContentParserTests.swift
+++ b/apps/ios/JovieTests/MobileChatContentParserTests.swift
@@ -67,4 +67,77 @@ struct MobileChatContentParserTests {
     )
     #expect(MobileChatContentParser.displayText(from: content, isStreaming: false) == content)
   }
+
+  @Test func parsesFunctionCallsDialectIntoCardAndSuppressesRawMarkup() {
+    let content = """
+    Here are some ideas.
+    <function_calls><invoke name="createMerch"><parameter name="productType">hoodie</parameter><parameter name="artistName">Tim White</parameter><parameter name="artistGenres">pop, electronic</parameter></invoke></function_calls>
+    """
+
+    let segments = MobileChatContentParser.segments(from: content, isStreaming: false)
+
+    #expect(segments.count == 2)
+    #expect(segments[0] == .text("Here are some ideas."))
+
+    guard case let .toolCall(model) = segments[1] else {
+      Issue.record("Expected tool call segment")
+      return
+    }
+
+    #expect(model.toolName == "createMerch")
+    #expect(model.title == "Creating merch options…")
+    #expect(model.body == "Tim White · hoodie")
+    #expect(model.state == .running)
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: false) == "Here are some ideas.")
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: false).contains("<function_calls>") == false)
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: false).contains("<invoke") == false)
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: false).contains("<parameter") == false)
+  }
+
+  @Test func suppressesFunctionResultJsonDump() {
+    let content = """
+    <function_calls><invoke name="createMerch"><parameter name="productType">hoodie</parameter></invoke></function_calls>
+    <function_result>{"title":"Digital Noise Hoodie","price":46,"mockupUrl":"https://example.com/mockup.png"}</function_result>
+    """
+
+    let segments = MobileChatContentParser.segments(from: content, isStreaming: false)
+    guard case let .toolCall(model) = segments.first else {
+      Issue.record("Expected tool call segment")
+      return
+    }
+
+    #expect(model.toolName == "createMerch")
+    #expect(model.state == .succeeded)
+    #expect(model.title == "Merch options ready")
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: false).isEmpty)
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: false).contains("mockupUrl") == false)
+  }
+
+  @Test func suppressesUnknownToolMarkupDialect() {
+    let content = """
+    Before
+    <custom_tool_call><name>createMerch</name><parameters><artistName>Tim White</artistName></parameters></custom_tool_call>
+    After
+    """
+
+    let displayText = MobileChatContentParser.displayText(from: content, isStreaming: false)
+    #expect(displayText == "Before\n\nAfter")
+    #expect(displayText.contains("<custom_tool_call>") == false)
+    #expect(displayText.contains("<name>") == false)
+  }
+
+  @Test func suppressesIncompleteFunctionCallsWhileStreaming() {
+    let content = "Working on it <function_calls><invoke name=\"createMerch\"><parameter name=\"productType\">hood"
+
+    let segments = MobileChatContentParser.segments(from: content, isStreaming: true)
+
+    #expect(segments.count == 2)
+    #expect(segments[0] == .text("Working on it"))
+    guard case let .toolCall(model) = segments[1] else {
+      Issue.record("Expected partial tool call segment")
+      return
+    }
+    #expect(model.toolName == "createMerch")
+    #expect(MobileChatContentParser.displayText(from: content, isStreaming: true) == "Working on it")
+  }
 }


### PR DESCRIPTION
Closes #12740

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/logs/codex-issue-shipper/github-12740-2026-07-03T01-35-13-221z.log`