### PR TITLE
chore(codex): PR Size Guard opt-out label (big-pr/codemod) does not retrigger the check when added after (#12735)

### DIFF
--- a/.github/workflows/pr-size-guard-label-override.yml
+++ b/.github/workflows/pr-size-guard-label-override.yml
@@ -1,0 +1,49 @@
+name: PR Size Guard Label Override
+
+# When big-pr/codemod is applied AFTER pr-size-guard.yml already failed, the
+# required "PR Size Guard" context stays red until a new push. This workflow
+# posts a passing check-run override (no size recomputation) on label events.
+#
+# Intentionally NOT merged into pr-size-guard.yml: re-running the size job on
+# labeled/unlabeled shares its cancel-in-progress concurrency group and can
+# leave CANCELLED/QUEUED runs as the latest required context → PR BLOCKED
+# (JOV-3580). This workflow uses a separate concurrency group and the Checks
+# API only — it cannot cancel the real size-computation job.
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: pr-size-label-override-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  override:
+    name: PR Size Guard Label Override
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.head.ref != 'screenshots/auto-update' &&
+      (
+        github.event.label.name == 'big-pr' ||
+        github.event.label.name == 'codemod'
+      )
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Post passing PR Size Guard check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LABEL: ${{ github.event.label.name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/pr-size-guard-label-override.mjs

--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -12,8 +12,9 @@ name: PR Size Guard
 # merge loop does this constantly) cancels the in-flight run via
 # cancel-in-progress, leaving a CANCELLED/QUEUED run as the latest for a
 # required context → GitHub pins the PR BLOCKED even though it's green
-# (JOV-3580). The big-pr/codemod opt-out is still honored: it's read via
-# `gh pr view` at run time, which works on push events too.
+# (JOV-3580). The big-pr/codemod opt-out is still honored on push via
+# `gh pr view` at run time. When the label lands after a failing run,
+# pr-size-guard-label-override.yml posts a passing check-run override.
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
+++ b/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  PR_SIZE_GUARD_CHECK_NAME,
+  SIZE_GUARD_OPT_OUT_LABELS,
+  buildSizeGuardOverrideCheckRun,
+  isSizeGuardOptOutLabel,
+} from '../pr-size-guard-label-override.mjs';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..');
+const SIZE_GUARD_WORKFLOW = resolve(
+  REPO_ROOT,
+  '.github/workflows/pr-size-guard.yml'
+);
+const OVERRIDE_WORKFLOW = resolve(
+  REPO_ROOT,
+  '.github/workflows/pr-size-guard-label-override.yml'
+);
+
+describe('pr-size-guard label override helpers', () => {
+  it('recognizes only big-pr and codemod as opt-out labels', () => {
+    expect(SIZE_GUARD_OPT_OUT_LABELS).toEqual(['big-pr', 'codemod']);
+    expect(isSizeGuardOptOutLabel('big-pr')).toBe(true);
+    expect(isSizeGuardOptOutLabel('codemod')).toBe(true);
+    expect(isSizeGuardOptOutLabel('merge-queue')).toBe(false);
+    expect(isSizeGuardOptOutLabel('testing')).toBe(false);
+  });
+
+  it('builds a completed success check-run for the PR Size Guard context', () => {
+    const payload = buildSizeGuardOverrideCheckRun({
+      headSha: 'abc123def456',
+      label: 'big-pr',
+      runUrl: 'https://github.com/JovieInc/Jovie/actions/runs/1',
+    });
+
+    expect(payload.name).toBe(PR_SIZE_GUARD_CHECK_NAME);
+    expect(payload.head_sha).toBe('abc123def456');
+    expect(payload.status).toBe('completed');
+    expect(payload.conclusion).toBe('success');
+    expect(payload.output.title).toContain('Opt-out');
+    expect(payload.output.summary).toContain('`big-pr`');
+    expect(payload.output.summary).toContain('not recomputed');
+  });
+
+  it('rejects unsupported labels and missing head sha', () => {
+    expect(() =>
+      buildSizeGuardOverrideCheckRun({
+        headSha: 'abc',
+        label: 'testing',
+        runUrl: 'https://example.com',
+      })
+    ).toThrow(/unsupported opt-out label/);
+
+    expect(() =>
+      buildSizeGuardOverrideCheckRun({
+        headSha: '',
+        label: 'big-pr',
+        runUrl: 'https://example.com',
+      })
+    ).toThrow(/headSha is required/);
+  });
+});
+
+describe('pr-size-guard workflow invariants (JOV-3580 + label override)', () => {
+  it('keeps the primary size guard off labeled events', () => {
+    const workflow = readFileSync(SIZE_GUARD_WORKFLOW, 'utf8');
+
+    expect(workflow).toContain('types: [opened, synchronize, reopened]');
+    expect(workflow).not.toMatch(/types:\s*\[[^\]]*labeled/);
+    expect(workflow).toContain('group: pr-size-${{ github.event.pull_request.number }}');
+    expect(workflow).toContain('cancel-in-progress: true');
+    expect(workflow).toContain('JOV-3580');
+  });
+
+  it('uses a separate labeled workflow that posts a PR Size Guard check override', () => {
+    const workflow = readFileSync(OVERRIDE_WORKFLOW, 'utf8');
+
+    expect(workflow).toContain('types: [labeled]');
+    expect(workflow).toContain("github.event.label.name == 'big-pr'");
+    expect(workflow).toContain("github.event.label.name == 'codemod'");
+    expect(workflow).toContain('checks: write');
+    expect(workflow).toContain(
+      'group: pr-size-label-override-${{ github.event.pull_request.number }}'
+    );
+    expect(workflow).toContain('cancel-in-progress: false');
+    expect(workflow).not.toContain('group: pr-size-${{ github.event.pull_request.number }}');
+    expect(workflow).toContain('node scripts/pr-size-guard-label-override.mjs');
+    expect(workflow).toContain('JOV-3580');
+  });
+});

--- a/scripts/lib/pr-size-guard-label-override.mjs
+++ b/scripts/lib/pr-size-guard-label-override.mjs
@@ -1,0 +1,59 @@
+/**
+ * PR Size Guard label override.
+ *
+ * When big-pr/codemod is applied after pr-size-guard.yml already failed, posts a
+ * passing "PR Size Guard" check-run via the Checks API (status override only).
+ * See .github/workflows/pr-size-guard-label-override.yml and JOV-3580.
+ */
+
+/** Required branch-protection context name — must match pr-size-guard.yml job name. */
+export const PR_SIZE_GUARD_CHECK_NAME = 'PR Size Guard';
+
+/** Labels that opt out of the size cap (must match pr-size-guard.yml). */
+export const SIZE_GUARD_OPT_OUT_LABELS = Object.freeze(['big-pr', 'codemod']);
+
+/**
+ * @param {string} label
+ * @returns {boolean}
+ */
+export function isSizeGuardOptOutLabel(label) {
+  return SIZE_GUARD_OPT_OUT_LABELS.includes(String(label));
+}
+
+/**
+ * @param {{
+ *   headSha: string;
+ *   label: string;
+ *   runUrl: string;
+ * }} input
+ */
+export function buildSizeGuardOverrideCheckRun(input) {
+  const headSha = String(input.headSha ?? '').trim();
+  const label = String(input.label ?? '').trim();
+  const runUrl = String(input.runUrl ?? '').trim();
+
+  if (!headSha) {
+    throw new Error('headSha is required');
+  }
+  if (!isSizeGuardOptOutLabel(label)) {
+    throw new Error(`unsupported opt-out label: ${label || '(empty)'}`);
+  }
+
+  return {
+    name: PR_SIZE_GUARD_CHECK_NAME,
+    head_sha: headSha,
+    status: 'completed',
+    conclusion: 'success',
+    details_url: runUrl || undefined,
+    output: {
+      title: 'Opt-out label applied',
+      summary: [
+        `Label \`${label}\` opts this PR out of the size cap.`,
+        '',
+        'Status override only — size was not recomputed on this event.',
+        'Prefer adding the label before opening the PR, or push after labeling,',
+        'so the primary size-guard run records the bypass directly.',
+      ].join('\n'),
+    },
+  };
+}

--- a/scripts/pr-size-guard-label-override.mjs
+++ b/scripts/pr-size-guard-label-override.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * CLI entry for pr-size-guard-label-override workflow.
+ * Posts a passing "PR Size Guard" check-run when big-pr/codemod is applied.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { buildSizeGuardOverrideCheckRun } from './lib/pr-size-guard-label-override.mjs';
+
+const headSha = process.env.HEAD_SHA ?? '';
+const label = process.env.LABEL ?? '';
+const runUrl = process.env.RUN_URL ?? '';
+const repository = process.env.GITHUB_REPOSITORY ?? '';
+
+if (!repository) {
+  console.error('GITHUB_REPOSITORY is required');
+  process.exit(1);
+}
+
+const payload = buildSizeGuardOverrideCheckRun({ headSha, label, runUrl });
+
+execFileSync(
+  'gh',
+  ['api', `repos/${repository}/check-runs`, '--input', '-'],
+  {
+    input: JSON.stringify(payload),
+    stdio: ['pipe', 'inherit', 'inherit'],
+    encoding: 'utf8',
+  }
+);
+
+console.log(`Posted passing "${payload.name}" check for ${headSha.slice(0, 7)}`);


### PR DESCRIPTION
Closes #12735

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/logs/codex-issue-shipper/github-12735-2026-07-03T01-35-59-545z.log`