### PR TITLE
chore(codex): Ovie: schedule codex-kanban-ship loop via launchd (gateway cron stalled since Jun 23) (#12722)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] Schedule the codex kanban ship loop via Houston launchd (`co.jovie.hermes.cron-codex-kanban-ship`, every 15m) with PAUSE-respecting `scripts/hermes/ship-loop.sh`.
+
 > Connector enrichment turns synced Gmail and Calendar objects into graph facts and calendar suggestions; assistant chat replies surface entity mentions as subdued accent spans that reveal detail cards on hover.
 
 ### Added

--- a/scripts/hermes/bootstrap-pro-launchd.sh
+++ b/scripts/hermes/bootstrap-pro-launchd.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Houston (MacBook Pro) launchd installer for coder/shipping loops.
+# Idempotent: re-renders Pro-only plist templates and bootstraps them.
+#
+# Usage:
+#   ./scripts/hermes/bootstrap-pro-launchd.sh
+#   ./scripts/hermes/bootstrap-pro-launchd.sh --reconfigure
+#   ./scripts/hermes/bootstrap-pro-launchd.sh --uninstall
+#
+set -euo pipefail
+
+MODE="install"
+for arg in "$@"; do
+  case "$arg" in
+    --reconfigure) MODE="reconfigure" ;;
+    --uninstall) MODE="uninstall" ;;
+    *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HERMES_HOME="${HOME}/.hermes"
+LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
+PRO_TEMPLATE_DIR="${REPO_ROOT}/scripts/hermes/launchd/pro"
+
+log() { printf "\033[1;34m▶\033[0m %s\n" "$*"; }
+ok() { printf "\033[1;32m✓\033[0m %s\n" "$*"; }
+die() { printf "\033[1;31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required tool: $1"
+}
+
+render_plist() {
+  local tmpl="$1"
+  local out="$2"
+  HOME_V="$HOME" REPO_V="$REPO_ROOT" NODE_BIN_V="$(dirname "$(command -v node)")" \
+  python3 - "$tmpl" "$out" <<'PYEOF'
+import os, sys
+src, dst = sys.argv[1], sys.argv[2]
+mapping = {
+    "{{HOME}}": os.environ["HOME_V"],
+    "{{JOVIE_REPO}}": os.environ["REPO_V"],
+    "{{NODE_BIN_DIR}}": os.environ["NODE_BIN_V"],
+}
+with open(src, "r", encoding="utf-8") as f:
+    content = f.read()
+for key, value in mapping.items():
+    content = content.replace(key, value)
+with open(dst, "w", encoding="utf-8") as f:
+    f.write(content)
+PYEOF
+}
+
+pro_labels() {
+  local tmpl label
+  for tmpl in "${PRO_TEMPLATE_DIR}"/*.plist.template; do
+    [[ -f "$tmpl" ]] || continue
+    label="$(basename "$tmpl" .plist.template)"
+    printf '%s\n' "$label"
+  done
+}
+
+if [[ "$MODE" == "uninstall" ]]; then
+  log "Uninstalling Houston launchd units"
+  while IFS= read -r label; do
+    [[ -n "$label" ]] || continue
+    launchctl bootout "gui/$(id -u)/${label}" 2>/dev/null || true
+    rm -f "${LAUNCH_AGENTS}/${label}.plist"
+    ok "removed $label"
+  done < <(pro_labels)
+  exit 0
+fi
+
+require_cmd node
+require_cmd python3
+require_cmd launchctl
+chmod +x "${REPO_ROOT}/scripts/hermes/ship-loop.sh"
+
+mkdir -p "$HERMES_HOME/logs/launchd" "$LAUNCH_AGENTS"
+
+log "Rendering Houston launchd plists (mode=$MODE)"
+while IFS= read -r label; do
+  [[ -n "$label" ]] || continue
+  tmpl="${PRO_TEMPLATE_DIR}/${label}.plist.template"
+  out="${LAUNCH_AGENTS}/${label}.plist"
+  render_plist "$tmpl" "$out"
+  ok "rendered $label"
+done < <(pro_labels)
+
+if [[ "$MODE" == "reconfigure" ]]; then
+  log "Reconfigure complete. Restart with:"
+  echo "  launchctl kickstart -k gui/\$(id -u)/co.jovie.hermes.cron-codex-kanban-ship"
+  exit 0
+fi
+
+log "Bootstrapping Houston launchd units"
+while IFS= read -r label; do
+  [[ -n "$label" ]] || continue
+  plist="${LAUNCH_AGENTS}/${label}.plist"
+  launchctl bootout "gui/$(id -u)/${label}" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$plist"
+  ok "bootstrapped $label"
+done < <(pro_labels)
+
+ok "Houston launchd bootstrap complete."
+log "Force a run: launchctl kickstart -k gui/\$(id -u)/co.jovie.hermes.cron-codex-kanban-ship"
+log "Tail logs: tail -f ~/.hermes/logs/launchd/cron-codex-kanban-ship.log ~/.hermes/logs/ship-loop.log"

--- a/scripts/hermes/launchd/README.md
+++ b/scripts/hermes/launchd/README.md
@@ -25,6 +25,24 @@ The Hermes gateway itself is managed by the installed Hermes CLI as `ai.hermes.g
 | `co.jovie.hermes.cron-deterministic-tracker.plist.template` | 03:00 daily | Self-improvement clustering |
 | `co.jovie.hermes.cron-free-model-health.plist.template` | 02:00 daily | Free-model rankings refresh |
 
+## Houston (MacBook Pro) units
+
+Coder/shipping loops run on Houston, not Hermes-Air. Pro-only templates live in `pro/` and are installed by `scripts/hermes/bootstrap-pro-launchd.sh` (not `bootstrap-air.sh`).
+
+| File | Schedule | Purpose |
+|---|---|---|
+| `pro/co.jovie.hermes.cron-codex-kanban-ship.plist.template` | every 15 min | Launch `scripts/hermes/ship-loop.sh` → `~/.hermes/scripts/codex-kanban-ship.py` (PAUSE + gbrain gated) |
+
+Install on the Pro:
+
+```bash
+./scripts/hermes/bootstrap-pro-launchd.sh
+launchctl kickstart -k gui/$(id -u)/co.jovie.hermes.cron-codex-kanban-ship
+tail -f ~/.hermes/logs/launchd/cron-codex-kanban-ship.log ~/.hermes/logs/ship-loop.log
+```
+
+Ship outcomes append to `~/.hermes/events/events.jsonl` from `codex-kanban-ship.py`.
+
 ## Logs
 
 Every unit writes stdout/stderr to `~/.hermes/logs/launchd/<label>.log` so failures are diagnosable without `launchctl print`.

--- a/scripts/hermes/launchd/pro/co.jovie.hermes.cron-codex-kanban-ship.plist.template
+++ b/scripts/hermes/launchd/pro/co.jovie.hermes.cron-codex-kanban-ship.plist.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-codex-kanban-ship</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/ship-loop.sh</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{{JOVIE_REPO}}</string>
+    <key>StartInterval</key>
+    <integer>900</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>HERMES_SHIP</key>
+        <string>1</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.grok/bin:{{NODE_BIN_DIR}}:{{HOME}}/.bun/bin:{{HOME}}/.hermes/bin:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-codex-kanban-ship.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-codex-kanban-ship.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/ship-loop.sh
+++ b/scripts/hermes/ship-loop.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Cron/launchd wrapper: launch one ready codex kanban card shipper without
+# blocking the scheduler. codex-kanban-ship.py can run >120s; Hermes gateway
+# cron no-agent jobs time out at 120s, so this wrapper starts a single-flight
+# background worker and exits.
+set -uo pipefail
+
+export PATH="${HOME}/.grok/bin:${HOME}/.local/bin:${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export HERMES_SHIP=1
+
+HERMES_HOME="${HERMES_HOME:-${HOME}/.hermes}"
+LOCKDIR="${HERMES_HOME}/scripts/.locks/ship-loop-wrapper.lockd"
+LOGDIR="${HERMES_HOME}/logs"
+KANBAN_SHIP="${HERMES_HOME}/scripts/codex-kanban-ship.py"
+
+mkdir -p "${HERMES_HOME}/scripts/.locks" "$LOGDIR"
+
+pause_active() {
+  [[ "${HERMES_PAUSE:-}" == "1" ]] && return 0
+  [[ -f "${HERMES_HOME}/PAUSE" ]] && return 0
+  [[ -f "${HERMES_HOME}/shipping-paused" ]] && return 0
+  return 1
+}
+
+if pause_active; then
+  echo "$(date -u +%FT%TZ) ship-loop SKIP: pause sentinel active (HERMES_PAUSE/PAUSE/shipping-paused)" \
+    | tee -a "${LOGDIR}/ship-loop.log"
+  exit 0
+fi
+
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+  echo "ship-loop already launched/running (wrapper lock held); skipping"
+  exit 0
+fi
+
+if [[ ! -f "$KANBAN_SHIP" ]]; then
+  echo "$(date -u +%FT%TZ) ship-loop ABORT: missing ${KANBAN_SHIP}" | tee -a "${LOGDIR}/ship-loop.log"
+  rm -rf "$LOCKDIR"
+  exit 2
+fi
+
+# --- gbrain preflight: fail closed if the brain is dead ---
+# "Dead" = doctor can't run / times out / returns invalid JSON / status=error|fail.
+# NOT gated on health_score quality (warnings are fine) — only reachability.
+gbrain_alive() {
+  local out status gbrain_bin
+  gbrain_bin="${HERMES_GBRAIN_BIN:-${HERMES_HOME}/bin/gbrain}"
+  if [[ ! -x "$gbrain_bin" ]]; then
+    gbrain_bin="$(command -v gbrain || true)"
+  fi
+  if [[ -z "$gbrain_bin" ]]; then
+    return 1
+  fi
+  out="$(timeout 30 "$gbrain_bin" doctor --fast --json 2>/dev/null)" || return 1
+  [[ -z "$out" ]] && return 1
+  status="$(printf '%s' "$out" | python3 -c 'import sys,json;
+try:
+    d=json.load(sys.stdin); print(d.get("status","")); sys.exit(0)
+except Exception:
+    sys.exit(1)' 2>/dev/null)" || return 1
+  case "$status" in
+    error|fail|failed|dead|"") return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+if ! gbrain_alive; then
+  echo "$(date -u +%FT%TZ) ship-loop ABORT: gbrain is dead/unreachable — refusing to ship blind" \
+    | tee -a "${LOGDIR}/ship-loop.log"
+  rm -rf "$LOCKDIR"
+  exit 3
+fi
+
+echo "$(date -u +%FT%TZ) ship-loop preflight OK: gbrain alive" >>"${LOGDIR}/ship-loop.log"
+
+(
+  trap 'rm -rf "$LOCKDIR"' EXIT
+  nohup python3 "$KANBAN_SHIP" --apply --coder-timeout 1800 >>"${LOGDIR}/ship-loop.log" 2>&1 &
+  disown
+) &
+wait $! 2>/dev/null || true
+echo "ship-loop launched background shipper log=${LOGDIR}/ship-loop.log"
+exit 0

--- a/scripts/lib/__tests__/hermes-launchd.test.mjs
+++ b/scripts/lib/__tests__/hermes-launchd.test.mjs
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
+
+function renderTemplate(templatePath, mapping) {
+  let content = readFileSync(templatePath, 'utf8');
+  for (const [key, value] of Object.entries(mapping)) {
+    content = content.replaceAll(key, value);
+  }
+  return content;
+}
+
+describe('hermes launchd pro templates', () => {
+  it('renders codex kanban ship plist with 15m schedule and ship-loop entrypoint', () => {
+    const templatePath = join(
+      REPO_ROOT,
+      'scripts/hermes/launchd/pro/co.jovie.hermes.cron-codex-kanban-ship.plist.template'
+    );
+    const rendered = renderTemplate(templatePath, {
+      '{{HOME}}': '/Users/tester',
+      '{{JOVIE_REPO}}': '/Users/tester/Jovie',
+      '{{NODE_BIN_DIR}}': '/Users/tester/.nvm/versions/node/v22.13.0/bin',
+    });
+
+    expect(rendered).toContain('<string>co.jovie.hermes.cron-codex-kanban-ship</string>');
+    expect(rendered).toContain('<integer>900</integer>');
+    expect(rendered).toContain('/Users/tester/Jovie/scripts/hermes/ship-loop.sh');
+    expect(rendered).toContain('/Users/tester/.hermes/logs/launchd/cron-codex-kanban-ship.log');
+    expect(rendered).toContain('<key>HERMES_SHIP</key>');
+  });
+});
+
+describe('ship-loop pause semantics', () => {
+  it('documents pause sentinels in the wrapper script', () => {
+    const script = readFileSync(
+      join(REPO_ROOT, 'scripts/hermes/ship-loop.sh'),
+      'utf8'
+    );
+    expect(script).toContain('HERMES_PAUSE');
+    expect(script).toContain('shipping-paused');
+    expect(script).toContain('${HERMES_HOME}/PAUSE');
+    expect(script).toContain('codex-kanban-ship.py');
+  });
+});


### PR DESCRIPTION
Closes #12722

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/logs/codex-issue-shipper/github-12722-2026-07-03T02-09-54-506z.log`