### PR TITLE
chore(codex): Candidate follow-up: Re-evaluate merge-queue throughput after CI merge-time initiative (RE (#12771)

### DIFF
--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -50,7 +50,7 @@ These settings have no CLI/API; confirm in the Graphite UI after any queue incid
 | Bisect on batch failure | **On** | One bad PR must not fail its siblings — isolate culprit, requeue rest |
 | CI optimization | **On** | `optimize_ci` job in `ci.yml` skips redundant PR CI Graphite re-validates |
 | Queue timeout | **≤ 60 min** | Prevents a regression from hanging the queue |
-| Max queue depth | **12** | Matches `READY_THRESHOLD` in `agent-pipeline.yml` pressure guard |
+| Max queue depth | **12** | Source-of-record: `GRAPHITE_QUEUE_POLICY.maxQueueDepth` in `scripts/lib/merge-queue-guard.mjs`; agent workflows read it via `node scripts/ci-merge-queue-check.mjs max-queue-depth` |
 | Per-agent enqueue rate | **≤ 6/hour** | Prevents one agent from flooding the queue (set in Graphite if available) |
 | Push actor | `graphite-app` | Must be able to push through protected `main` |
 

--- a/.github/workflows/agent-landing-sweep.yml
+++ b/.github/workflows/agent-landing-sweep.yml
@@ -20,7 +20,7 @@
 # 5. Scope judge = success
 # 6. CodeRabbit not blocking (no CHANGES_REQUESTED)
 # 7. CI harness risk classifier does not block unattended auto-merge
-# 8. Queue pressure guard: defers if 12+ other PRs already queued for auto-merge
+# 8. Queue pressure guard: defers when merge-queue depth hits GRAPHITE_QUEUE_POLICY.maxQueueDepth
 #
 # RELATIONSHIP TO agent-pipeline.yml:
 # This workflow is idempotent. Enabling auto-merge on an already-queued PR is
@@ -77,9 +77,9 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
-          READY_THRESHOLD: '12'
         run: |
           set -euo pipefail
+          READY_THRESHOLD=$(node scripts/ci-merge-queue-check.mjs max-queue-depth)
 
           echo "=== Agent Landing Sweep ==="
           echo "Repository: $GH_REPO"

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -671,7 +671,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBER="${{ needs.guard.outputs.pr_number }}"
-          READY_THRESHOLD=12
+          READY_THRESHOLD=$(node scripts/ci-merge-queue-check.mjs max-queue-depth)
 
           OPEN_PRS=$(gh pr list --state open --base main --limit 100 --json number,isDraft,mergeStateStatus,labels,headRefName)
 

--- a/scripts/ci-merge-queue-check.mjs
+++ b/scripts/ci-merge-queue-check.mjs
@@ -117,9 +117,12 @@ async function main() {
     case 'policy':
       printPolicySummary();
       break;
+    case 'max-queue-depth':
+      console.log(String(GRAPHITE_QUEUE_POLICY.maxQueueDepth));
+      break;
     default:
       console.error(
-        'Usage: node scripts/ci-merge-queue-check.mjs <validate|verify|policy>'
+        'Usage: node scripts/ci-merge-queue-check.mjs <validate|verify|policy|max-queue-depth>'
       );
       process.exitCode = 1;
   }

--- a/scripts/hermes/jobs/ci-metrics.ts
+++ b/scripts/hermes/jobs/ci-metrics.ts
@@ -106,12 +106,14 @@ function fmtMin(seconds: number): string {
 function renderBody(m: ReturnType<typeof summarizeCiMetrics>): string {
   const t = m.throughput;
   const l = m.latency;
+  const v = m.throughputVerdict;
   return [
     `Window: ${m.window.mergedPrs} merged PRs · ${m.window.ciRuns} CI runs · ${m.window.spanDays}d span`,
     `Throughput (primary): ${t.mergedPrsPerDay}/day · ${t.ciRunHoursPerMergedPr ?? '?'} runner-h/PR · flaky ${(t.flakyRerunRate * 100).toFixed(1)}% · queue-wait p50 ${fmtMin(t.queueWaitSeconds.p50)} / p95 ${fmtMin(t.queueWaitSeconds.p95)}`,
     `Latency (secondary): gate p50 ${fmtMin(l.gateWallclockSeconds.p50)} / p75 ${fmtMin(l.gateWallclockSeconds.p75)} / p95 ${fmtMin(l.gateWallclockSeconds.p95)} · full-merge p50 ${fmtMin(l.fullMergeTimeSeconds.p50)} / p95 ${fmtMin(l.fullMergeTimeSeconds.p95)}`,
     `Ready→merged (target p50<10m / p95<15m): p50 ${fmtMin(l.readyToMergeSeconds.p50)} / p75 ${fmtMin(l.readyToMergeSeconds.p75)} / p95 ${fmtMin(l.readyToMergeSeconds.p95)}`,
     `Samples: gate ${m.sampleSizes.gate} · full-merge ${m.sampleSizes.fullMerge} · queue-wait ${m.sampleSizes.queueWait} · ready-to-merge ${m.sampleSizes.readyToMerge}`,
+    `Throughput verdict: ${v.status} — ${v.reason} (action: ${v.action})`,
   ].join('\n');
 }
 
@@ -156,6 +158,8 @@ async function main(): Promise<void> {
       fullMergeP95: metrics.latency.fullMergeTimeSeconds.p95,
       readyToMergeP50: metrics.latency.readyToMergeSeconds.p50,
       readyToMergeP95: metrics.latency.readyToMergeSeconds.p95,
+      throughputVerdictStatus: metrics.throughputVerdict.status,
+      throughputVerdictAction: metrics.throughputVerdict.action,
       samples: metrics.sampleSizes,
     });
 

--- a/scripts/lib/__tests__/ci-metrics-compute.test.mjs
+++ b/scripts/lib/__tests__/ci-metrics-compute.test.mjs
@@ -3,12 +3,16 @@ import {
   CI_METRICS_SCHEMA_VERSION,
   ciRunHours,
   completedDurationsSeconds,
+  evaluateMergeQueueThroughput,
   flakyRerunRate,
   fullMergeTimesSeconds,
   gateDurationsSeconds,
   mergedThroughput,
+  MIN_READY_TO_MERGE_SAMPLES,
   percentilesOf,
   queueWaitSeconds,
+  READY_TO_MERGE_P50_TARGET_SECONDS,
+  READY_TO_MERGE_P95_TARGET_SECONDS,
   readyToMergeSeconds,
   summarizeCiMetrics,
 } from '../ci-metrics-compute.mjs';
@@ -179,6 +183,69 @@ describe('percentilesOf', () => {
   });
 });
 
+const metricsFixture = (overrides = {}) => ({
+  latency: {
+    readyToMergeSeconds: { p50: 480, p75: 600, p95: 840 },
+  },
+  sampleSizes: { readyToMerge: MIN_READY_TO_MERGE_SAMPLES },
+  ...overrides,
+});
+
+const afterEvalWindow = new Date('2026-07-10T12:00:00Z');
+
+describe('evaluateMergeQueueThroughput', () => {
+  it('defers before the 2026-07-09 evaluation window', () => {
+    const verdict = evaluateMergeQueueThroughput(metricsFixture(), {
+      now: new Date('2026-07-02T12:00:00Z'),
+    });
+    expect(verdict.status).toBe('defer');
+    expect(verdict.action).toBe('wait_for_evaluation_window');
+  });
+
+  it('requires minimum samples after the evaluation window', () => {
+    const verdict = evaluateMergeQueueThroughput(
+      metricsFixture({ sampleSizes: { readyToMerge: 3 } }),
+      { now: afterEvalWindow }
+    );
+    expect(verdict.status).toBe('insufficient_data');
+    expect(verdict.action).toBe('collect_more_samples');
+  });
+
+  it('closes the follow-up when p50 and p95 are on target', () => {
+    const verdict = evaluateMergeQueueThroughput(
+      metricsFixture({
+        latency: {
+          readyToMergeSeconds: {
+            p50: READY_TO_MERGE_P50_TARGET_SECONDS - 60,
+            p75: 700,
+            p95: READY_TO_MERGE_P95_TARGET_SECONDS - 60,
+          },
+        },
+      }),
+      { now: afterEvalWindow }
+    );
+    expect(verdict.status).toBe('on_target');
+    expect(verdict.action).toBe('close_follow_up');
+  });
+
+  it('recommends raising max queue depth when p95 is off target', () => {
+    const verdict = evaluateMergeQueueThroughput(
+      metricsFixture({
+        latency: {
+          readyToMergeSeconds: {
+            p50: READY_TO_MERGE_P50_TARGET_SECONDS - 60,
+            p75: 1200,
+            p95: READY_TO_MERGE_P95_TARGET_SECONDS + 120,
+          },
+        },
+      }),
+      { now: afterEvalWindow }
+    );
+    expect(verdict.status).toBe('off_target');
+    expect(verdict.action).toContain('raise_max_queue_depth_12_to_16');
+  });
+});
+
 describe('summarizeCiMetrics', () => {
   it('assembles a complete record with primary throughput + secondary latency', () => {
     const runs = [
@@ -229,5 +296,7 @@ describe('summarizeCiMetrics', () => {
       queueWait: 2,
       readyToMerge: 2,
     });
+    expect(out.throughputVerdict.status).toBe('defer');
+    expect(out.throughputVerdict.action).toBe('wait_for_evaluation_window');
   });
 });

--- a/scripts/lib/ci-metrics-compute.mjs
+++ b/scripts/lib/ci-metrics-compute.mjs
@@ -19,6 +19,12 @@ import {
 
 export const CI_METRICS_SCHEMA_VERSION = 1;
 
+/** Ready→merged merge-time targets (docs/PR_FLOW.md, gbrain ci-metrics/latest). */
+export const READY_TO_MERGE_P50_TARGET_SECONDS = 600; // 10m
+export const READY_TO_MERGE_P95_TARGET_SECONDS = 900; // 15m
+/** Minimum ready→merged samples before a throughput verdict is actionable. */
+export const MIN_READY_TO_MERGE_SAMPLES = 10;
+
 /** {p50,p75,p95} of an array (0s when empty). */
 export function percentilesOf(values) {
   return {
@@ -128,6 +134,91 @@ export function readyToMergeSeconds(timelineResults) {
  * Assemble the one-line metrics record. Pure: callers pass `ts` so tests stay
  * deterministic (Date.now lives in the I/O job, not here).
  */
+/**
+ * Verdict for merge-queue throughput re-evaluation (GH #12771).
+ * Returns a machine-readable action without mutating CI config.
+ */
+export function evaluateMergeQueueThroughput(metrics, options = {}) {
+  const now = options.now ?? new Date();
+  const eligibleAfter =
+    options.eligibleAfter ?? new Date('2026-07-09T00:00:00Z');
+  const sampleCount = metrics?.sampleSizes?.readyToMerge ?? 0;
+  const p50 = metrics?.latency?.readyToMergeSeconds?.p50 ?? 0;
+  const p95 = metrics?.latency?.readyToMergeSeconds?.p95 ?? 0;
+
+  if (now < eligibleAfter) {
+    return {
+      status: 'defer',
+      reason: `Re-evaluation eligible after ${eligibleAfter.toISOString().slice(0, 10)}`,
+      sampleCount,
+      p50Seconds: p50,
+      p95Seconds: p95,
+      targets: {
+        p50Seconds: READY_TO_MERGE_P50_TARGET_SECONDS,
+        p95Seconds: READY_TO_MERGE_P95_TARGET_SECONDS,
+      },
+      action: 'wait_for_evaluation_window',
+    };
+  }
+
+  if (sampleCount < MIN_READY_TO_MERGE_SAMPLES) {
+    return {
+      status: 'insufficient_data',
+      reason: `Need >=${MIN_READY_TO_MERGE_SAMPLES} ready→merged samples (have ${sampleCount})`,
+      sampleCount,
+      p50Seconds: p50,
+      p95Seconds: p95,
+      targets: {
+        p50Seconds: READY_TO_MERGE_P50_TARGET_SECONDS,
+        p95Seconds: READY_TO_MERGE_P95_TARGET_SECONDS,
+      },
+      action: 'collect_more_samples',
+    };
+  }
+
+  const p50OnTarget = p50 > 0 && p50 < READY_TO_MERGE_P50_TARGET_SECONDS;
+  const p95OnTarget = p95 > 0 && p95 < READY_TO_MERGE_P95_TARGET_SECONDS;
+
+  if (p50OnTarget && p95OnTarget) {
+    return {
+      status: 'on_target',
+      reason: 'Ready→merged p50 and p95 are within targets',
+      sampleCount,
+      p50Seconds: p50,
+      p95Seconds: p95,
+      targets: {
+        p50Seconds: READY_TO_MERGE_P50_TARGET_SECONDS,
+        p95Seconds: READY_TO_MERGE_P95_TARGET_SECONDS,
+      },
+      action: 'close_follow_up',
+    };
+  }
+
+  const actions = [];
+  if (!p95OnTarget) {
+    actions.push('raise_max_queue_depth_12_to_16');
+  }
+  if (!p50OnTarget) {
+    actions.push('tune_unit_test_shards');
+  }
+
+  return {
+    status: 'off_target',
+    reason:
+      p95 > READY_TO_MERGE_P95_TARGET_SECONDS
+        ? `Ready→merged p95 ${Math.round(p95 / 60)}m exceeds ${READY_TO_MERGE_P95_TARGET_SECONDS / 60}m target`
+        : `Ready→merged p50 ${Math.round(p50 / 60)}m exceeds ${READY_TO_MERGE_P50_TARGET_SECONDS / 60}m target`,
+    sampleCount,
+    p50Seconds: p50,
+    p95Seconds: p95,
+    targets: {
+      p50Seconds: READY_TO_MERGE_P50_TARGET_SECONDS,
+      p95Seconds: READY_TO_MERGE_P95_TARGET_SECONDS,
+    },
+    action: actions.join(';'),
+  };
+}
+
 export function summarizeCiMetrics({ ts, runs, prs, timelineResults }) {
   const gate = gateDurationsSeconds(runs);
   const fullMerge = fullMergeTimesSeconds(prs);
@@ -166,5 +257,11 @@ export function summarizeCiMetrics({ ts, runs, prs, timelineResults }) {
       queueWait: queueWaits.length,
       readyToMerge: readyToMerge.length,
     },
+    throughputVerdict: evaluateMergeQueueThroughput({
+      latency: {
+        readyToMergeSeconds: percentilesOf(readyToMerge),
+      },
+      sampleSizes: { readyToMerge: readyToMerge.length },
+    }),
   };
 }


### PR DESCRIPTION
Closes #12771

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/logs/codex-issue-shipper/github-12771-2026-07-03T04-13-54-645z.log`