### PR TITLE
feat(ui): canonicalize button atom

### DIFF
--- a/apps/web/tests/unit/ErrorBoundary.test.tsx
+++ b/apps/web/tests/unit/ErrorBoundary.test.tsx
@@ -414,9 +414,11 @@ describe('ErrorBoundary', () => {
       const goHomeButton = screen.getByRole('button', { name: /go home/i });
 
       // Button uses CVA with Tailwind classes (variant='primary', size='sm')
+      expect(tryAgainButton).toHaveAttribute('data-variant', 'primary');
       expect(tryAgainButton).toHaveClass('bg-btn-primary');
-      // Button uses CVA with Tailwind classes (variant='outline', size='sm')
-      expect(goHomeButton).toHaveClass('border-default');
+      // Button uses CVA with Tailwind classes (variant='secondary', size='sm')
+      expect(goHomeButton).toHaveAttribute('data-variant', 'secondary');
+      expect(goHomeButton).toHaveClass('bg-btn-secondary');
     });
   });
 });

--- a/packages/ui/atoms/alert-dialog.test.tsx
+++ b/packages/ui/atoms/alert-dialog.test.tsx
@@ -233,7 +233,7 @@ describe('AlertDialog', () => {
     it('supports variant prop', () => {
       render(<TestAlertDialog open={true} actionVariant='destructive' />);
       const action = screen.getByTestId('alert-dialog-action');
-      expect(action.className).toContain('bg-[var(--color-error)]');
+      expect(action.className).toContain('bg-error');
       expect(action.className).toContain(
         'text-[var(--color-error-foreground)]'
       );

--- a/packages/ui/atoms/alert-dialog.tsx
+++ b/packages/ui/atoms/alert-dialog.tsx
@@ -12,7 +12,7 @@ import {
   titleStyles,
 } from '../lib/overlay-styles';
 import { cn } from '../lib/utils';
-import { buttonVariants } from './button';
+import { Button } from './button';
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -139,48 +139,54 @@ const AlertDialogDescription = React.forwardRef<
 AlertDialogDescription.displayName =
   AlertDialogPrimitive.Description.displayName;
 
+type AlertDialogActionVariant =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'ghost'
+  | 'link'
+  | 'destructive';
+
 interface AlertDialogActionProps
   extends React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> {
-  variant?:
-    | 'primary'
-    | 'accent'
-    | 'secondary'
-    | 'ghost'
-    | 'outline'
-    | 'destructive'
-    | 'link'
-    | 'frosted'
-    | 'frosted-ghost'
-    | 'frosted-outline';
+  readonly variant?: AlertDialogActionVariant;
+  readonly destructive?: boolean;
 }
 
 const AlertDialogAction = React.forwardRef<
   React.ComponentRef<typeof AlertDialogPrimitive.Action>,
   AlertDialogActionProps
->(({ className, variant, ...props }, ref) => (
-  <AlertDialogPrimitive.Action
-    ref={ref}
-    className={cn(buttonVariants({ variant }), className)}
-    data-testid='alert-dialog-action'
-    {...props}
-  />
-));
+>(({ className, variant = 'primary', destructive = false, ...props }, ref) => {
+  const buttonVariant = variant === 'destructive' ? 'primary' : variant;
+
+  return (
+    <Button
+      asChild
+      variant={buttonVariant}
+      destructive={destructive || variant === 'destructive'}
+      className={className}
+    >
+      <AlertDialogPrimitive.Action
+        ref={ref}
+        data-testid='alert-dialog-action'
+        {...props}
+      />
+    </Button>
+  );
+});
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
 const AlertDialogCancel = React.forwardRef<
   React.ComponentRef<typeof AlertDialogPrimitive.Cancel>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Cancel
-    ref={ref}
-    className={cn(
-      buttonVariants({ variant: 'outline' }),
-      'mt-2 sm:mt-0',
-      className
-    )}
-    data-testid='alert-dialog-cancel'
-    {...props}
-  />
+  <Button asChild variant='secondary' className={cn('mt-2 sm:mt-0', className)}>
+    <AlertDialogPrimitive.Cancel
+      ref={ref}
+      data-testid='alert-dialog-cancel'
+      {...props}
+    />
+  </Button>
 ));
 AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 

--- a/packages/ui/atoms/button.test.tsx
+++ b/packages/ui/atoms/button.test.tsx
@@ -2,11 +2,15 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { render, screen } from '@testing-library/react';
 import * as React from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Button } from './button';
 
 describe('Button', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('System B typography contract', () => {
     it('keeps shared button tracking neutral and non-negative', () => {
       const source = readFileSync(
@@ -21,7 +25,8 @@ describe('Button', () => {
       render(
         <>
           <Button>Primary</Button>
-          <Button variant='whitePill'>White Pill</Button>
+          <Button variant='secondary'>Secondary</Button>
+          <Button variant='tertiary'>Tertiary</Button>
         </>
       );
 
@@ -38,6 +43,15 @@ describe('Button', () => {
     expect(btn).toBeInTheDocument();
   });
 
+  it('defaults to the canonical primary md button contract', () => {
+    render(<Button>Press</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('data-variant', 'primary');
+    expect(btn).toHaveAttribute('data-size', 'md');
+    expect(btn.className).toContain('h-9');
+    expect(btn.className).toContain('bg-btn-primary');
+  });
+
   it('applies variant and size classes', () => {
     render(
       <Button variant='secondary' size='sm'>
@@ -49,20 +63,63 @@ describe('Button', () => {
     expect(btn.className).toContain('h-7');
   });
 
-  it('keeps the legacy accent variant neutral instead of accent-filled', () => {
-    const source = readFileSync(path.join(process.cwd(), 'atoms/button.tsx'), {
-      encoding: 'utf8',
-    });
-    const accentVariantSource = source.match(/accent:\s*'(?<classes>[^']+)'/)
-      ?.groups?.classes;
+  it('maps deprecated variants to canonical variants with a warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    expect(accentVariantSource).toBeDefined();
-    expect(accentVariantSource).toContain('bg-btn-primary');
-    expect(accentVariantSource).toContain('text-btn-primary-foreground');
-    expect(accentVariantSource).not.toMatch(
-      /\bbg-accent\b|text-accent-foreground|text-on-accent|hover:bg-accent|\bbg-(?:blue|purple|violet|indigo)-\d/
+    render(
+      <>
+        <Button variant='accent'>Upgrade</Button>
+        <Button variant='outline'>More</Button>
+        <Button variant='destructive'>Delete</Button>
+      </>
     );
 
+    const btn = screen.getByRole('button', { name: 'Upgrade' });
+    expect(btn).toHaveAttribute('data-variant', 'primary');
+    expect(btn).not.toHaveAttribute('data-destructive');
+    expect(screen.getByRole('button', { name: 'More' })).toHaveAttribute(
+      'data-variant',
+      'secondary'
+    );
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveAttribute(
+      'data-destructive',
+      'true'
+    );
+    expect(warn).toHaveBeenCalledWith(
+      '[Button] variant="accent" is deprecated. Use variant="primary" instead.'
+    );
+  });
+
+  it('maps deprecated sizes to canonical sizes with a warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <>
+        <Button size='default'>Default</Button>
+        <Button size='xl'>Extra Large</Button>
+        <Button size='hero'>Hero</Button>
+      </>
+    );
+
+    expect(screen.getByRole('button', { name: 'Default' })).toHaveAttribute(
+      'data-size',
+      'md'
+    );
+    expect(screen.getByRole('button', { name: 'Extra Large' })).toHaveAttribute(
+      'data-size',
+      'lg'
+    );
+    expect(screen.getByRole('button', { name: 'Hero' })).toHaveAttribute(
+      'data-size',
+      'lg'
+    );
+    expect(warn).toHaveBeenCalledWith(
+      '[Button] size="default" is deprecated. Use size="md" instead.'
+    );
+  });
+
+  it('keeps the legacy accent alias neutral instead of accent-filled', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     render(<Button variant='accent'>Upgrade</Button>);
     const btn = screen.getByRole('button', { name: 'Upgrade' });
     expect(btn.className).toContain('bg-btn-primary');
@@ -105,6 +162,26 @@ describe('Button', () => {
     expect(btn.className).toContain('hover:border-(--linear-border-default)');
   });
 
+  it.each([
+    'primary',
+    'secondary',
+    'tertiary',
+    'ghost',
+    'link',
+  ] as const)('applies destructive styling to the %s variant through a prop', variant => {
+    render(
+      <Button variant={variant} destructive>
+        Delete
+      </Button>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('data-variant', variant);
+    expect(btn).toHaveAttribute('data-destructive', 'true');
+    expect(btn.className).toContain(
+      variant === 'primary' ? 'bg-error' : 'text-error'
+    );
+  });
+
   it('forwards refs', () => {
     const ref = React.createRef<HTMLButtonElement>();
     render(<Button ref={ref}>Hi</Button>);
@@ -129,20 +206,6 @@ describe('Button', () => {
     render(<Button loading>Load</Button>);
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
     expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true');
-  });
-  it('applies xl size classes', () => {
-    render(<Button size='xl'>Press</Button>);
-    const btn = screen.getByRole('button');
-    expect(btn.className).toContain('h-12');
-    expect(btn.className).toContain('rounded-full');
-  });
-
-  it('applies hero size classes', () => {
-    render(<Button size='hero'>Press</Button>);
-    const btn = screen.getByRole('button');
-    expect(btn.className).toContain('h-14');
-    expect(btn.className).toContain('rounded-full');
-    expect(btn.className).toContain('font-semibold');
   });
   // href prop removed; use asChild with an anchor element instead
 });

--- a/packages/ui/atoms/button.tsx
+++ b/packages/ui/atoms/button.tsx
@@ -10,59 +10,162 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        // Core variants — Linear-aligned shadows and radii
         primary:
-          'border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset hover:border-(--linear-btn-primary-hover) hover:bg-(--linear-btn-primary-hover)',
-        // EVENT: central actions stay neutral; keep this legacy variant as a
-        // primary alias so old callers do not render accent-filled CTAs.
-        accent:
           'border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset hover:border-(--linear-btn-primary-hover) hover:bg-(--linear-btn-primary-hover)',
         secondary:
           'border border-(--linear-border-subtle) bg-btn-secondary text-btn-secondary-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_1px_1px_rgba(0,0,0,0.08)] hover:border-(--linear-border-default) hover:bg-(--linear-btn-secondary-hover)',
+        tertiary:
+          'border border-transparent bg-transparent text-secondary-token shadow-none hover:bg-interactive-hover hover:text-primary-token active:bg-interactive-active',
         ghost:
-          'hover:bg-interactive-hover active:bg-interactive-active text-secondary-token hover:text-primary-token',
-        outline:
-          'border border-default bg-transparent hover:bg-surface-hover active:bg-interactive-active shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]',
-        // Destructive variant
-        destructive:
-          'bg-[var(--color-error)] text-[var(--color-error-foreground)] hover:opacity-90',
-        // Link variant
-        link: 'text-primary underline-offset-4 hover:underline p-0 h-auto',
-        // Frosted glass variants (glassmorphism) - using design tokens
-        frosted:
-          'backdrop-blur-sm bg-surface-0/60 dark:bg-surface-1/30 hover:bg-surface-1/80 dark:hover:bg-surface-2/40 border border-subtle',
-        'frosted-ghost':
-          'backdrop-blur-sm bg-surface-0/30 dark:bg-surface-1/10 hover:bg-surface-1/50 dark:hover:bg-surface-2/20 border border-subtle',
-        'frosted-outline':
-          'backdrop-blur-sm bg-transparent border border-subtle hover:bg-surface-1/20 dark:hover:bg-surface-2/10',
-        // Canonical white pill CTA — high-contrast hero/auth pill used across
-        // marketing headers and homepage sign-in.
-        whitePill:
-          'border border-white/88 bg-white text-black shadow-[0_8px_20px_rgba(0,0,0,0.14),inset_0_1px_0_rgba(255,255,255,0.72)] hover:bg-white/95 font-medium tracking-normal sm:shadow-[0_10px_24px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.72)]',
+          'border border-transparent bg-transparent text-tertiary-token shadow-none hover:bg-interactive-hover hover:text-primary-token active:bg-interactive-active',
+        link: 'h-auto border-0 bg-transparent p-0 text-primary underline-offset-4 shadow-none hover:underline',
       },
       size: {
-        default:
-          'h-8 px-3 py-1.5 before:absolute before:left-1/2 before:top-1/2 before:h-10 before:min-w-10 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
         sm: 'h-7 px-2.5 text-xs before:absolute before:left-1/2 before:top-1/2 before:h-10 before:min-w-10 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
-        lg: 'h-10 px-4 py-2 text-sm',
-        xl: 'h-12 px-6 py-3 text-sm',
-        hero: 'h-14 px-10 py-4 text-base font-semibold',
-        icon: 'h-10 w-10',
+        md: 'h-9 px-3 text-[13px] before:absolute before:left-1/2 before:top-1/2 before:h-11 before:min-w-11 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
+        lg: 'h-11 px-5 text-sm before:absolute before:left-1/2 before:top-1/2 before:h-11 before:min-w-11 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
+        icon: 'h-9 w-9 px-0 before:absolute before:left-1/2 before:top-1/2 before:h-11 before:w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
       },
     },
+    compoundVariants: [
+      {
+        variant: 'link',
+        size: ['sm', 'md', 'lg', 'icon'],
+        className:
+          'h-auto min-h-0 w-auto min-w-0 px-0 py-0 before:hidden disabled:opacity-60',
+      },
+    ],
     defaultVariants: {
       variant: 'primary',
-      size: 'default',
+      size: 'md',
     },
   }
 );
 
+type CanonicalButtonVariantProps = VariantProps<typeof buttonVariants>;
+export type ButtonVariant = NonNullable<CanonicalButtonVariantProps['variant']>;
+export type ButtonSize = NonNullable<CanonicalButtonVariantProps['size']>;
+
+type DeprecatedButtonVariant =
+  | 'accent'
+  | 'outline'
+  | 'destructive'
+  | 'frosted'
+  | 'frosted-ghost'
+  | 'frosted-outline'
+  | 'whitePill';
+type DeprecatedButtonSize = 'default' | 'xl' | 'hero';
+
+const DEPRECATED_VARIANT_ALIASES: Record<
+  DeprecatedButtonVariant,
+  ButtonVariant
+> = {
+  accent: 'primary',
+  outline: 'secondary',
+  destructive: 'primary',
+  frosted: 'secondary',
+  'frosted-ghost': 'ghost',
+  'frosted-outline': 'secondary',
+  whitePill: 'primary',
+};
+
+const DEPRECATED_SIZE_ALIASES: Record<DeprecatedButtonSize, ButtonSize> = {
+  default: 'md',
+  xl: 'lg',
+  hero: 'lg',
+};
+
+const DESTRUCTIVE_CLASSES: Record<ButtonVariant, string> = {
+  primary:
+    'border-error bg-error text-[var(--color-error-foreground)] hover:border-error/90 hover:bg-error/90',
+  secondary:
+    'border-error/30 bg-error-subtle text-error hover:border-error/45 hover:bg-error-subtle hover:text-error',
+  tertiary: 'text-error hover:bg-error-subtle hover:text-error',
+  ghost: 'text-error hover:bg-error-subtle hover:text-error',
+  link: 'text-error hover:text-error',
+};
+
+const warnedDeprecatedValues = new Set<string>();
+
+function isProductionEnvironment(): boolean {
+  return (
+    (
+      globalThis as {
+        readonly process?: {
+          readonly env?: { readonly NODE_ENV?: string };
+        };
+      }
+    ).process?.env?.NODE_ENV === 'production'
+  );
+}
+
+function warnDeprecatedButtonValue(
+  kind: 'variant' | 'size',
+  value: string,
+  replacement: string
+): void {
+  if (isProductionEnvironment()) return;
+  const key = `${kind}:${value}`;
+  if (warnedDeprecatedValues.has(key)) return;
+  warnedDeprecatedValues.add(key);
+  console.warn(
+    `[Button] ${kind}="${value}" is deprecated. Use ${kind}="${replacement}" instead.`
+  );
+}
+
+function isDeprecatedButtonVariant(
+  variant: ButtonVariant | DeprecatedButtonVariant
+): variant is DeprecatedButtonVariant {
+  return variant in DEPRECATED_VARIANT_ALIASES;
+}
+
+function isDeprecatedButtonSize(
+  size: ButtonSize | DeprecatedButtonSize
+): size is DeprecatedButtonSize {
+  return size in DEPRECATED_SIZE_ALIASES;
+}
+
+function normalizeButtonVariant({
+  variant,
+  destructive,
+}: {
+  readonly variant?: ButtonVariant | DeprecatedButtonVariant | null;
+  readonly destructive: boolean;
+}): { readonly variant: ButtonVariant; readonly destructive: boolean } {
+  const requested = variant ?? 'primary';
+  if (!isDeprecatedButtonVariant(requested)) {
+    return { variant: requested, destructive };
+  }
+
+  const replacement = DEPRECATED_VARIANT_ALIASES[requested];
+  warnDeprecatedButtonValue('variant', requested, replacement);
+  return {
+    variant: replacement,
+    destructive: destructive || requested === 'destructive',
+  };
+}
+
+function normalizeButtonSize(
+  size?: ButtonSize | DeprecatedButtonSize | null
+): ButtonSize {
+  const requested = size ?? 'md';
+  if (!isDeprecatedButtonSize(requested)) {
+    return requested;
+  }
+
+  const replacement = DEPRECATED_SIZE_ALIASES[requested];
+  warnDeprecatedButtonValue('size', requested, replacement);
+  return replacement;
+}
+
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'size'> {
+  readonly variant?: ButtonVariant | DeprecatedButtonVariant | null;
+  readonly size?: ButtonSize | DeprecatedButtonSize | null;
   readonly asChild?: boolean;
   readonly loading?: boolean;
   readonly static?: boolean;
+  readonly destructive?: boolean;
 }
 
 // Helper to compute data-state attribute
@@ -95,7 +198,7 @@ function ButtonContent({
   return (
     <span
       className={cn(
-        'inline-flex items-center gap-1.5',
+        'inline-flex items-center justify-center gap-1.5',
         loading ? 'opacity-0' : 'opacity-100'
       )}
     >
@@ -113,6 +216,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       asChild = false,
       loading = false,
       static: isStatic = false,
+      destructive = false,
       disabled,
       children,
       ...props
@@ -122,17 +226,31 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : 'button';
     const isDisabled = disabled || loading;
     const dataState = getDataState(loading, isDisabled);
+    const normalizedVariant = normalizeButtonVariant({
+      variant,
+      destructive,
+    });
+    const normalizedSize = normalizeButtonSize(size);
 
     const sharedProps = {
       ref,
       className: cn(
-        buttonVariants({ variant, size, className }),
+        buttonVariants({
+          variant: normalizedVariant.variant,
+          size: normalizedSize,
+        }),
+        normalizedVariant.destructive &&
+          DESTRUCTIVE_CLASSES[normalizedVariant.variant],
+        className,
         !isStatic && !isDisabled && 'active:scale-[0.96]',
         isDisabled && 'pointer-events-none'
       ),
       'aria-disabled': isDisabled || undefined,
       'aria-busy': loading || undefined,
       'data-state': dataState,
+      'data-variant': normalizedVariant.variant,
+      'data-size': normalizedSize,
+      'data-destructive': normalizedVariant.destructive ? 'true' : undefined,
     };
 
     // In asChild mode (Radix Slot), React.Children.only requires a single child.


### PR DESCRIPTION
## Summary

DS_FOUNDATION_V1 Wave 1 Button canon stack slice 1/9.

Canonicalize the pure @jovie/ui Button atom and unit tests.

Size: 4 files, +280/-93.

## Stack

#12830 -> #12831 -> #12832 -> #12833 -> #12834 -> #12835 -> #12836 -> #12837 -> #12838

## Local Verification

- pnpm --filter @jovie/ui exec vitest run atoms/button.test.tsx atoms/alert-dialog.test.tsx
- pnpm --filter @jovie/web lint:button-canon-ratchet
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web exec vitest run focused migrated-surface tests (11 files, 92 tests passed; jsdom printed HTMLMediaElement.pause not-implemented noise but exit code was 0)
- biome check --write on all 37 changed files
- rg scan: no system-b-*-button matches in apps/web/app, apps/web/components, or apps/web/styles/design-system.css on the top branch

bug-to-test: not applicable — design-system feature/refactor stack with targeted component and surface guard tests.

## Visual Evidence

![Canonical Button visual evidence](https://gist.githubusercontent.com/itstimwhite/cb803281120e5d4cd3a397a315e0007e/raw/130594180afe8812100e60518dd84c10f3ef185a/jovie-button-canon-12830.svg)

Captured locally from `http://localhost:3010/ui/buttons` on the rebased stack. Playwright verified rendered `data-variant` values: `primary`, `secondary`, `tertiary`, `ghost`, `link`; destructive appears as `data-destructive`, not as a variant.
