### PR TITLE
docs(ui): align button examples with canon

### DIFF
--- a/apps/web/app/ui/buttons/page.tsx
+++ b/apps/web/app/ui/buttons/page.tsx
@@ -50,32 +50,50 @@ export default function ButtonsPage() {
     <div>
       <h1 className='mb-1 text-lg font-semibold text-primary-token'>Button</h1>
       <p className='mb-8 text-[13px] text-tertiary-token'>
-        Matches Linear.app — font weight 510, tracking -0.011em, 8px radius,
-        32px default height
+        Canonical variants: primary, secondary, tertiary, ghost, and link.
+        Destructive is a tone prop, not a standalone variant.
       </p>
 
       {/* Variants */}
       <Section title='Variants'>
         <Stack title='primary'>
-          <Button variant='primary'>Save changes</Button>
+          <Button variant='primary'>Save Changes</Button>
         </Stack>
         <Stack title='secondary'>
           <Button variant='secondary'>Cancel</Button>
         </Stack>
+        <Stack title='tertiary'>
+          <Button variant='tertiary'>Dismiss</Button>
+        </Stack>
         <Stack title='ghost'>
-          <Button variant='ghost'>View details</Button>
-        </Stack>
-        <Stack title='outline'>
-          <Button variant='outline'>Export</Button>
-        </Stack>
-        <Stack title='destructive'>
-          <Button variant='destructive'>Delete</Button>
-        </Stack>
-        <Stack title='upgrade'>
-          <Button variant='primary'>Upgrade</Button>
+          <Button variant='ghost'>View Details</Button>
         </Stack>
         <Stack title='link'>
-          <Button variant='link'>Learn more</Button>
+          <Button variant='link'>Learn More</Button>
+        </Stack>
+      </Section>
+
+      {/* Destructive tone */}
+      <Section title='Destructive Tone'>
+        <Stack title='primary destructive'>
+          <Button destructive variant='primary'>
+            Delete
+          </Button>
+        </Stack>
+        <Stack title='secondary destructive'>
+          <Button destructive variant='secondary'>
+            Remove
+          </Button>
+        </Stack>
+        <Stack title='tertiary destructive'>
+          <Button destructive variant='tertiary'>
+            Reject
+          </Button>
+        </Stack>
+        <Stack title='ghost destructive'>
+          <Button destructive variant='ghost'>
+            Clear
+          </Button>
         </Stack>
       </Section>
 
@@ -84,10 +102,10 @@ export default function ButtonsPage() {
         <Stack title='sm'>
           <Button size='sm'>Small</Button>
         </Stack>
-        <Stack title='default (32px)'>
-          <Button>Default</Button>
+        <Stack title='md (default)'>
+          <Button size='md'>Medium</Button>
         </Stack>
-        <Stack title='lg (40px)'>
+        <Stack title='lg'>
           <Button size='lg'>Large</Button>
         </Stack>
       </Section>
@@ -97,7 +115,7 @@ export default function ButtonsPage() {
         <Stack title='icon left'>
           <Button variant='primary'>
             <Plus className='h-4 w-4' />
-            New release
+            New Release
           </Button>
         </Stack>
         <Stack title='icon right'>
@@ -113,7 +131,7 @@ export default function ButtonsPage() {
           <Button variant='secondary' size='icon' aria-label='Archive'>
             <Archive className='h-4 w-4' />
           </Button>
-          <Button variant='destructive' size='icon' aria-label='Delete'>
+          <Button destructive variant='ghost' size='icon' aria-label='Delete'>
             <Trash2 className='h-4 w-4' />
           </Button>
         </Stack>
@@ -171,7 +189,7 @@ export default function ButtonsPage() {
 
       {/* Secondary hover demo — previously broken */}
       <Section title='Secondary Hover (was broken — verify hover works)'>
-        <Button variant='secondary'>Hover me</Button>
+        <Button variant='secondary'>Hover Me</Button>
         <Button variant='secondary'>
           <Archive className='h-4 w-4' />
           Archive

--- a/apps/web/components/atoms/Button.stories.tsx
+++ b/apps/web/components/atoms/Button.stories.tsx
@@ -15,24 +15,16 @@ const meta: Meta<typeof Button> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    size: {
-      control: { type: 'select' },
-      options: ['default', 'sm', 'lg', 'icon'],
-    },
     variant: {
       control: { type: 'select' },
-      options: [
-        'primary',
-        'accent',
-        'secondary',
-        'outline',
-        'ghost',
-        'destructive',
-        'link',
-        'frosted',
-        'frosted-ghost',
-        'frosted-outline',
-      ],
+      options: ['primary', 'secondary', 'tertiary', 'ghost', 'link'],
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg', 'icon'],
+    },
+    destructive: {
+      control: { type: 'boolean' },
     },
     disabled: {
       control: { type: 'boolean' },
@@ -45,42 +37,64 @@ type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
   args: {
-    children: 'Button',
+    children: 'Primary',
     variant: 'primary',
   },
 };
 
 export const Secondary: Story = {
   args: {
-    children: 'Button',
+    children: 'Secondary',
     variant: 'secondary',
   },
 };
 
-export const Outline: Story = {
+export const Tertiary: Story = {
   args: {
-    children: 'Button',
-    variant: 'outline',
+    children: 'Tertiary',
+    variant: 'tertiary',
   },
 };
 
 export const Ghost: Story = {
   args: {
-    children: 'Button',
+    children: 'Ghost',
     variant: 'ghost',
+  },
+};
+
+export const Link: Story = {
+  args: {
+    children: 'Link',
+    variant: 'link',
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    children: 'Delete',
+    destructive: true,
+    variant: 'primary',
   },
 };
 
 export const Large: Story = {
   args: {
-    children: 'Button',
+    children: 'Large',
     size: 'lg',
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    children: 'Medium',
+    size: 'md',
   },
 };
 
 export const Small: Story = {
   args: {
-    children: 'Button',
+    children: 'Small',
     size: 'sm',
   },
 };
@@ -89,5 +103,58 @@ export const Disabled: Story = {
   args: {
     children: 'Button',
     disabled: true,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className='flex flex-col gap-4 p-8'>
+      <div>
+        <h3 className='mb-2 font-semibold text-sm'>Canonical Variants</h3>
+        <div className='flex flex-wrap gap-2'>
+          <Button variant='primary'>Primary</Button>
+          <Button variant='secondary'>Secondary</Button>
+          <Button variant='tertiary'>Tertiary</Button>
+          <Button variant='ghost'>Ghost</Button>
+          <Button variant='link'>Link</Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 className='mb-2 font-semibold text-sm'>Destructive Tone</h3>
+        <div className='flex flex-wrap gap-2'>
+          <Button destructive variant='primary'>
+            Primary
+          </Button>
+          <Button destructive variant='secondary'>
+            Secondary
+          </Button>
+          <Button destructive variant='tertiary'>
+            Tertiary
+          </Button>
+          <Button destructive variant='ghost'>
+            Ghost
+          </Button>
+          <Button destructive variant='link'>
+            Link
+          </Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 className='mb-2 font-semibold text-sm'>Sizes</h3>
+        <div className='flex flex-wrap items-center gap-2'>
+          <Button size='sm'>Small</Button>
+          <Button size='md'>Medium</Button>
+          <Button size='lg'>Large</Button>
+          <Button aria-label='Icon button' size='icon'>
+            +
+          </Button>
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'fullscreen',
   },
 };

--- a/packages/ui/atoms/button.stories.tsx
+++ b/packages/ui/atoms/button.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Button> = {
     docs: {
       description: {
         component:
-          'Primary button component with comprehensive variants, loading states, and full accessibility support. Built on Radix UI Slot primitive for flexible composition.',
+          'Canonical Button component with five variants, three sizes, destructive tone, loading states, and Radix Slot composition.',
       },
     },
   },
@@ -17,24 +17,17 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     variant: {
       control: { type: 'select' },
-      options: [
-        'primary',
-        'accent',
-        'secondary',
-        'ghost',
-        'outline',
-        'destructive',
-        'link',
-        'frosted',
-        'frosted-ghost',
-        'frosted-outline',
-      ],
+      options: ['primary', 'secondary', 'tertiary', 'ghost', 'link'],
       description: 'Visual style variant',
     },
     size: {
       control: { type: 'select' },
-      options: ['default', 'sm', 'lg', 'icon'],
+      options: ['sm', 'md', 'lg', 'icon'],
       description: 'Button size',
+    },
+    destructive: {
+      control: { type: 'boolean' },
+      description: 'Apply destructive tone to the selected variant',
     },
     loading: {
       control: { type: 'boolean' },
@@ -62,17 +55,17 @@ export const Primary: Story = {
   },
 };
 
-export const NeutralAlias: Story = {
-  args: {
-    children: 'Neutral Alias',
-    variant: 'accent',
-  },
-};
-
 export const Secondary: Story = {
   args: {
     children: 'Secondary Button',
     variant: 'secondary',
+  },
+};
+
+export const Tertiary: Story = {
+  args: {
+    children: 'Tertiary Button',
+    variant: 'tertiary',
   },
 };
 
@@ -83,17 +76,11 @@ export const Ghost: Story = {
   },
 };
 
-export const Outline: Story = {
-  args: {
-    children: 'Outline Button',
-    variant: 'outline',
-  },
-};
-
 export const Destructive: Story = {
   args: {
     children: 'Delete',
-    variant: 'destructive',
+    variant: 'primary',
+    destructive: true,
   },
 };
 
@@ -101,37 +88,6 @@ export const Link: Story = {
   args: {
     children: 'Link Button',
     variant: 'link',
-  },
-};
-
-// Frosted Glass Variants
-export const Frosted: Story = {
-  args: {
-    children: 'Frosted Button',
-    variant: 'frosted',
-  },
-  parameters: {
-    backgrounds: { default: 'dark' },
-  },
-};
-
-export const FrostedGhost: Story = {
-  args: {
-    children: 'Frosted Ghost',
-    variant: 'frosted-ghost',
-  },
-  parameters: {
-    backgrounds: { default: 'dark' },
-  },
-};
-
-export const FrostedOutline: Story = {
-  args: {
-    children: 'Frosted Outline',
-    variant: 'frosted-outline',
-  },
-  parameters: {
-    backgrounds: { default: 'dark' },
   },
 };
 
@@ -143,10 +99,10 @@ export const Small: Story = {
   },
 };
 
-export const Default: Story = {
+export const Medium: Story = {
   args: {
-    children: 'Default Button',
-    size: 'default',
+    children: 'Medium Button',
+    size: 'md',
   },
 };
 
@@ -272,21 +228,31 @@ export const AllVariants: Story = {
         <h3 className='text-sm font-semibold mb-2'>Core Variants</h3>
         <div className='flex gap-2 flex-wrap'>
           <Button variant='primary'>Primary</Button>
-          <Button variant='accent'>Neutral Alias</Button>
           <Button variant='secondary'>Secondary</Button>
+          <Button variant='tertiary'>Tertiary</Button>
           <Button variant='ghost'>Ghost</Button>
-          <Button variant='outline'>Outline</Button>
-          <Button variant='destructive'>Destructive</Button>
           <Button variant='link'>Link</Button>
         </div>
       </div>
 
       <div>
-        <h3 className='text-sm font-semibold mb-2'>Frosted Variants</h3>
+        <h3 className='text-sm font-semibold mb-2'>Destructive Tone</h3>
         <div className='flex gap-2 flex-wrap'>
-          <Button variant='frosted'>Frosted</Button>
-          <Button variant='frosted-ghost'>Frosted Ghost</Button>
-          <Button variant='frosted-outline'>Frosted Outline</Button>
+          <Button variant='primary' destructive>
+            Primary
+          </Button>
+          <Button variant='secondary' destructive>
+            Secondary
+          </Button>
+          <Button variant='tertiary' destructive>
+            Tertiary
+          </Button>
+          <Button variant='ghost' destructive>
+            Ghost
+          </Button>
+          <Button variant='link' destructive>
+            Link
+          </Button>
         </div>
       </div>
 
@@ -294,7 +260,7 @@ export const AllVariants: Story = {
         <h3 className='text-sm font-semibold mb-2'>Sizes</h3>
         <div className='flex gap-2 items-center flex-wrap'>
           <Button size='sm'>Small</Button>
-          <Button size='default'>Default</Button>
+          <Button size='md'>Medium</Button>
           <Button size='lg'>Large</Button>
           <Button size='icon'>
             <svg


### PR DESCRIPTION
## Summary

DS_FOUNDATION_V1 Wave 1 Button canon stack slice 2/9.

Align Button stories/showcase examples and AlertDialog destructive mapping with canonical variants.

Size: 3 files, +162/-111.

## Stack

#12830 -> #12831 -> #12832 -> #12833 -> #12834 -> #12835 -> #12836 -> #12837 -> #12838

## Local Verification

- pnpm --filter @jovie/ui exec vitest run atoms/button.test.tsx atoms/alert-dialog.test.tsx
- pnpm --filter @jovie/web lint:button-canon-ratchet
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web exec vitest run focused migrated-surface tests (11 files, 92 tests passed; jsdom printed HTMLMediaElement.pause not-implemented noise but exit code was 0)
- biome check --write on all 37 changed files
- rg scan: no system-b-*-button matches in apps/web/app, apps/web/components, or apps/web/styles/design-system.css on the top branch

bug-to-test: not applicable — design-system feature/refactor stack with targeted component and surface guard tests.

## Visual Evidence

![Canonical Button visual evidence](https://gist.githubusercontent.com/itstimwhite/cb803281120e5d4cd3a397a315e0007e/raw/130594180afe8812100e60518dd84c10f3ef185a/jovie-button-canon-12830.svg)

Stack evidence captured locally from `http://localhost:3010/ui/buttons` on the rebased stack. Playwright verified rendered `data-variant` values: `primary`, `secondary`, `tertiary`, `ghost`, `link`; destructive appears as `data-destructive`, not as a variant.
