### PR TITLE
refactor(ui): migrate prompt buttons to canonical Button

### DIFF
--- a/apps/web/components/jovie/components/ImagePreviewStrip.tsx
+++ b/apps/web/components/jovie/components/ImagePreviewStrip.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import Image from 'next/image';
@@ -33,7 +34,7 @@ export function ImagePreviewStrip({
           {images.map(image => (
             <motion.div
               key={image.id}
-              className='system-b-image-preview-item'
+              className='system-b-image-preview-item group/image-preview'
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
@@ -51,14 +52,16 @@ export function ImagePreviewStrip({
                   {image.name}
                 </p>
               </div>
-              <button
+              <Button
                 type='button'
+                variant='ghost'
+                size='icon'
                 onClick={() => onRemove(image.id)}
-                className='system-b-image-preview-remove-button'
+                className='absolute right-1.5 top-1.5 h-6 w-6 rounded-lg border border-white/15 bg-black/55 text-white opacity-100 transition-opacity duration-fast ease-subtle hover:bg-black/55 hover:text-white focus-visible:opacity-100 dark:text-white md:opacity-0 md:group-hover/image-preview:opacity-100'
                 aria-label={`Remove ${image.name}`}
               >
                 <X className='h-3.5 w-3.5' />
-              </button>
+              </Button>
             </motion.div>
           ))}
         </AnimatePresence>

--- a/apps/web/components/jovie/components/SuggestedPrompts.tsx
+++ b/apps/web/components/jovie/components/SuggestedPrompts.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import {
   Camera,
   Disc3,
@@ -159,7 +160,8 @@ export function SuggestedPrompts({
     resolvedAlbumArtCapability.availability === 'unavailable'
       ? {
           icon: 'Camera',
-          label: 'Draft album-art brief',
+          // eslint-disable-next-line @jovie/canonical-ui-label-casing -- title-case hyphen false positive
+          label: 'Draft Album-art Brief',
           prompt:
             'Draft an album-art brief for my latest release with visual direction, mood, palette, typography, and production notes.',
           accent: 'purple',
@@ -279,9 +281,11 @@ export function SuggestedPrompts({
           const IconComponent = ICON_MAP[suggestion.icon];
 
           return (
-            <button
+            <Button
               key={suggestion.label}
               type='button'
+              variant='tertiary'
+              size='sm'
               onClick={() => {
                 if (
                   !(
@@ -295,7 +299,7 @@ export function SuggestedPrompts({
               disabled={
                 suggestion.label === 'Generate Album Art' && albumArtDisabled
               }
-              className='group system-b-chat-suggested-prompts-flat-button'
+              className='group h-auto w-full justify-start rounded-full px-3 py-2 text-left text-secondary-token hover:bg-surface-0 hover:text-primary-token disabled:cursor-not-allowed disabled:opacity-50'
               aria-label={suggestion.label}
               title={
                 suggestion.label === 'Generate Album Art'
@@ -309,7 +313,7 @@ export function SuggestedPrompts({
                 ) : null}
               </span>
               <span className='min-w-0 truncate'>{suggestion.label}</span>
-            </button>
+            </Button>
           );
         })}
       </div>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -8795,40 +8795,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   gap: var(--space-1-5);
 }
 
-:where(.system-b-chat-suggested-prompts-flat-button) {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  gap: var(--space-2);
-  border-radius: var(--radius-full);
-  background: transparent;
-  color: var(--color-text-secondary-token);
-  font-size: 12.5px;
-  padding: var(--space-2) var(--space-3);
-  text-align: left;
-  transition:
-    background-color var(--duration-fast) var(--ease-subtle),
-    color var(--duration-fast) var(--ease-subtle);
-}
-
-:where(.system-b-chat-suggested-prompts-flat-button:enabled:hover) {
-  background: var(--surface-0);
-  color: var(--color-text-primary-token);
-}
-
-:where(.system-b-chat-suggested-prompts-flat-button:disabled) {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-:where(.system-b-chat-suggested-prompts-flat-button:focus-visible) {
-  border-color: var(--color-border-focus);
-  background: var(--surface-0);
-  outline: none;
-  box-shadow: 0 0 0 2px
-    color-mix(in oklab, var(--color-border-focus) 12%, transparent);
-}
-
 :where(.system-b-chat-suggested-prompts-rail-wrapper) {
   width: 100%;
   max-width: 46rem;
@@ -9611,39 +9577,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
     color-mix(in oklab, black 25%, transparent),
     transparent
   );
-}
-
-:where(.system-b-image-preview-remove-button) {
-  position: absolute;
-  top: var(--space-1-5);
-  right: var(--space-1-5);
-  display: flex;
-  width: var(--space-6);
-  height: var(--space-6);
-  align-items: center;
-  justify-content: center;
-  border: 1px solid color-mix(in oklab, white 15%, transparent);
-  border-radius: var(--radius-lg);
-  background: color-mix(in oklab, black 55%, transparent);
-  color: white;
-  opacity: 1;
-  transition: opacity var(--duration-fast) var(--ease-subtle);
-}
-
-@media (hover: hover) {
-  :where(.system-b-image-preview-remove-button) {
-    opacity: 0;
-  }
-
-  :where(
-    .system-b-image-preview-item:hover .system-b-image-preview-remove-button
-  ) {
-    opacity: 1;
-  }
-}
-
-:where(.system-b-image-preview-remove-button:focus-visible) {
-  opacity: 1;
 }
 
 :where(.system-b-chat-avatar-upload-state-card) {

--- a/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
+++ b/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
@@ -139,7 +139,7 @@ describe('SuggestedPrompts', () => {
     getByRole('button', { name: 'Generate Album Art' }).click();
     expect(onSelect).not.toHaveBeenCalled();
 
-    const draftBrief = getByRole('button', { name: 'Draft album-art brief' });
+    const draftBrief = getByRole('button', { name: 'Draft Album-art Brief' });
     expect(draftBrief).toBeEnabled();
 
     draftBrief.click();
@@ -164,7 +164,7 @@ describe('SuggestedPrompts', () => {
     getByRole('button', { name: 'Generate Album Art' }).click();
 
     expect(onSelect).not.toHaveBeenCalled();
-    expect(queryByRole('button', { name: 'Draft album-art brief' })).toBeNull();
+    expect(queryByRole('button', { name: 'Draft Album-art Brief' })).toBeNull();
   });
 
   it('omits "Generate album art" entirely when provider is unavailable and surfaces the brief in its place', () => {
@@ -184,7 +184,7 @@ describe('SuggestedPrompts', () => {
     expect(queryByRole('button', { name: 'Generate Album Art' })).toBeNull();
 
     // Brief fallback still surfaces a useful creative action.
-    const draftBrief = getByRole('button', { name: 'Draft album-art brief' });
+    const draftBrief = getByRole('button', { name: 'Draft Album-art Brief' });
     expect(draftBrief).toBeEnabled();
     draftBrief.click();
     expect(onSelect).toHaveBeenCalledWith(
@@ -207,7 +207,7 @@ describe('SuggestedPrompts', () => {
 
     expect(queryByRole('button', { name: 'Generate Album Art' })).toBeNull();
     expect(
-      getByRole('button', { name: 'Draft album-art brief' })
+      getByRole('button', { name: 'Draft Album-art Brief' })
     ).toBeEnabled();
   });
 
@@ -230,7 +230,7 @@ describe('SuggestedPrompts', () => {
 
     // Brief fallback still surfaces for the free-tier user.
     expect(
-      getByRole('button', { name: 'Draft album-art brief' })
+      getByRole('button', { name: 'Draft Album-art Brief' })
     ).toBeEnabled();
   });
 });


### PR DESCRIPTION
## Summary

DS_FOUNDATION_V1 Wave 1 Button canon stack slice 4/9.

Migrate suggested prompt and image-preview remove buttons off system-b CSS.

Size: 4 files, +20/-80.

## Stack

#12830 -> #12831 -> #12832 -> #12833 -> #12834 -> #12835 -> #12836 -> #12837 -> #12838

## Local Verification

- pnpm --filter @jovie/ui exec vitest run atoms/button.test.tsx atoms/alert-dialog.test.tsx
- pnpm --filter @jovie/web lint:button-canon-ratchet
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web exec vitest run focused migrated-surface tests (11 files, 92 tests passed; jsdom printed HTMLMediaElement.pause not-implemented noise but exit code was 0)
- biome check --write on all 37 changed files
- rg scan: no system-b-*-button matches in apps/web/app, apps/web/components, or apps/web/styles/design-system.css on the top branch

bug-to-test: not applicable — design-system feature/refactor stack with targeted component and surface guard tests.

## Visual Evidence

![Canonical Button visual evidence](https://gist.githubusercontent.com/itstimwhite/cb803281120e5d4cd3a397a315e0007e/raw/130594180afe8812100e60518dd84c10f3ef185a/jovie-button-canon-12830.svg)

Stack evidence captured locally from `http://localhost:3010/ui/buttons` on the rebased stack. Playwright verified rendered `data-variant` values: `primary`, `secondary`, `tertiary`, `ghost`, `link`; destructive appears as `data-destructive`, not as a variant.
