### PR TITLE
refactor(ui): migrate chat control buttons

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
@@ -456,41 +457,47 @@ export function CalendarPageClient() {
         <div className='flex h-full min-h-0 flex-col gap-4'>
           <div className='flex flex-wrap items-center justify-between gap-2'>
             <div className='system-b-calendar-month-control inline-flex min-w-0 items-center gap-1'>
-              <button
+              <Button
                 type='button'
+                variant='ghost'
+                size='icon'
                 onClick={() => {
                   const next = new Date(cursor);
                   next.setMonth(cursor.getMonth() - 1);
                   setCursor(startOfMonth(next));
                 }}
-                className='system-b-calendar-icon-button grid h-7 w-7 place-items-center transition-colors duration-subtle ease-subtle'
+                className='system-b-calendar-action-ghost h-7 w-7 transition-colors duration-subtle ease-subtle'
                 aria-label='Previous Month'
               >
                 <ChevronLeft className='h-4 w-4' strokeWidth={2.25} />
-              </button>
+              </Button>
               <h2 className='system-b-calendar-month-label'>
                 {MONTH_NAMES[cursor.getMonth()]} {cursor.getFullYear()}
               </h2>
-              <button
+              <Button
                 type='button'
+                variant='ghost'
+                size='icon'
                 onClick={() => {
                   const next = new Date(cursor);
                   next.setMonth(cursor.getMonth() + 1);
                   setCursor(startOfMonth(next));
                 }}
-                className='system-b-calendar-icon-button grid h-7 w-7 place-items-center transition-colors duration-subtle ease-subtle'
+                className='system-b-calendar-action-ghost h-7 w-7 transition-colors duration-subtle ease-subtle'
                 aria-label='Next Month'
               >
                 <ChevronRight className='h-4 w-4' strokeWidth={2.25} />
-              </button>
+              </Button>
             </div>
-            <button
+            <Button
               type='button'
+              variant='ghost'
+              size='sm'
               onClick={() => setCursor(startOfMonth(new Date()))}
-              className='system-b-calendar-toolbar-button h-7 px-3 font-caption transition-colors duration-subtle ease-subtle'
+              className='system-b-calendar-action-ghost h-7 px-3 font-caption transition-colors duration-subtle ease-subtle'
             >
               Today
-            </button>
+            </Button>
           </div>
 
           <div className='system-b-calendar-panel overflow-hidden'>

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -785,18 +785,25 @@ function LibrarySavedViewRow({
   readonly onClick: () => void;
 }) {
   return (
-    <button
-      type='button'
-      onClick={onClick}
-      aria-pressed={active}
+    <Button
+      asChild
+      variant={active ? 'secondary' : 'tertiary'}
+      size='sm'
+      static
       className={cn(
-        'system-b-library-rail-button flex h-7 w-full items-center gap-2 border px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface) outline-none',
-        active && 'system-b-library-rail-button--active'
+        'flex h-7 w-full items-center justify-start gap-2 border px-2 transition-colors duration-fast ease-subtle focus-visible:ring-offset-(--linear-app-content-surface)',
+        active
+          ? 'border-default bg-surface-1 text-primary-token'
+          : 'border-transparent text-secondary-token hover:border-default hover:bg-surface-1 hover:text-primary-token'
       )}
     >
-      <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
-      <span className='system-b-library-rail-count tabular-nums'>{count}</span>
-    </button>
+      <button type='button' onClick={onClick} aria-pressed={active}>
+        <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
+        <span className='system-b-library-rail-count tabular-nums'>
+          {count}
+        </span>
+      </button>
+    </Button>
   );
 }
 
@@ -879,13 +886,15 @@ function LibraryRail({
         <div className='flex items-center justify-between gap-2 border-t border-subtle pb-1 pt-2'>
           <p className='system-b-library-rail-title'>Filters</p>
           {hasActiveFilters(filters) ? (
-            <button
+            <Button
               type='button'
+              variant='tertiary'
+              size='sm'
               onClick={onClearFilters}
-              className='system-b-library-clear-button px-1.5 py-0.5'
+              className='h-auto rounded-xs px-1.5 py-0.5 text-tertiary-token hover:bg-surface-1 hover:text-primary-token'
             >
               Clear Filters ({activeFilterCount})
-            </button>
+            </Button>
           ) : null}
         </div>
 
@@ -1004,23 +1013,30 @@ function FilterSection({
 
   return (
     <div className='pt-2'>
-      <button
-        id={buttonId}
-        type='button'
-        aria-controls={panelId}
-        aria-expanded={open}
-        onClick={() => setOpen(value => !value)}
-        className='system-b-library-filter-section-button flex h-6 w-full items-center justify-between px-1'
+      <Button
+        asChild
+        variant='tertiary'
+        size='sm'
+        static
+        className='flex h-6 w-full items-center justify-between px-1 font-medium text-tertiary-token hover:bg-surface-1 hover:text-primary-token'
       >
-        <span>{label}</span>
-        <ChevronDown
-          className={cn(
-            'h-3 w-3 transition-transform duration-subtle ease-subtle',
-            !open && '-rotate-90'
-          )}
-          aria-hidden='true'
-        />
-      </button>
+        <button
+          id={buttonId}
+          type='button'
+          aria-controls={panelId}
+          aria-expanded={open}
+          onClick={() => setOpen(value => !value)}
+        >
+          <span>{label}</span>
+          <ChevronDown
+            className={cn(
+              'h-3 w-3 transition-transform duration-subtle ease-subtle',
+              !open && '-rotate-90'
+            )}
+            aria-hidden='true'
+          />
+        </button>
+      </Button>
       {open ? (
         <section
           id={panelId}
@@ -1310,74 +1326,81 @@ const AssetCard = memo(function AssetCard({
           className='system-b-library-card-selected-frame pointer-events-none absolute inset-0'
         />
       ) : null}
-      <button
-        type='button'
-        onClick={onSelect}
-        aria-label={`View ${asset.title}`}
+      <Button
+        asChild
+        variant='tertiary'
+        size='sm'
+        static
         className={cn(
-          'system-b-library-card-button flex h-full w-full flex-col text-left',
+          'flex h-full w-full flex-col items-stretch justify-start rounded-none p-0 text-left transition-colors duration-fast ease-subtle hover:bg-transparent active:bg-transparent',
           LIBRARY_CARD_FOCUS_CLASS
         )}
       >
-        <div
-          className={cn(
-            'system-b-library-card-artwork relative overflow-hidden',
-            getLibraryAspectRatioClass(aspectRatio)
-          )}
+        <button
+          type='button'
+          onClick={onSelect}
+          aria-label={`View ${asset.title}`}
         >
-          <LibraryMediaThumbnail asset={asset} size='card' />
-          <span
+          <div
             className={cn(
-              'system-b-library-card-status absolute left-2 top-2 border px-1.5 py-0.5 leading-4',
-              libraryApprovalStatusClasses(asset.approvalStatus)
+              'system-b-library-card-artwork relative overflow-hidden',
+              getLibraryAspectRatioClass(aspectRatio)
             )}
-            data-testid={`library-approval-status-${asset.id}`}
           >
-            {formatLibraryApprovalStatus(asset.approvalStatus)}
-          </span>
-        </div>
-        <div className='min-w-0 p-3'>
-          <div className='flex min-w-0 items-start justify-between gap-2'>
-            <div className='min-w-0'>
-              <h2 className='system-b-library-card-title truncate'>
-                {asset.title}
-              </h2>
-              <p className='system-b-library-card-meta mt-0.5 truncate'>
-                {asset.artist}
-              </p>
-            </div>
-            <span className='system-b-library-card-count shrink-0 tabular-nums'>
-              {getLibraryItemKind(asset) === 'merch'
-                ? (asset.salePriceLabel ?? 'Merch')
-                : formatCompactCount(asset.providerCount)}
+            <LibraryMediaThumbnail asset={asset} size='card' />
+            <span
+              className={cn(
+                'system-b-library-card-status absolute left-2 top-2 border px-1.5 py-0.5 leading-4',
+                libraryApprovalStatusClasses(asset.approvalStatus)
+              )}
+              data-testid={`library-approval-status-${asset.id}`}
+            >
+              {formatLibraryApprovalStatus(asset.approvalStatus)}
             </span>
           </div>
-          <div className='system-b-library-card-summary mt-2 flex min-w-0 items-center gap-1.5'>
-            {getLibraryItemKind(asset) === 'merch' ? (
-              <Shirt className='h-3 w-3 shrink-0' />
-            ) : (
-              <Disc3 className='h-3 w-3 shrink-0' />
-            )}
-            <span>{formatLibraryItemType(asset)}</span>
-            {getLibraryItemKind(asset) === 'release' ? (
-              <>
-                <span className='opacity-50'>.</span>
-                <span>{asset.trackCount} Tracks</span>
-              </>
-            ) : null}
-          </div>
-          <div className='mt-3 flex flex-wrap gap-1.5'>
-            {asset.assetKinds.slice(0, 3).map(kind => (
-              <AssetKindPill key={kind} kind={kind} />
-            ))}
-            {asset.assetKinds.length > 3 ? (
-              <span className='system-b-library-card-more-pill inline-flex h-6 items-center px-2'>
-                +{asset.assetKinds.length - 3}
+          <div className='min-w-0 p-3'>
+            <div className='flex min-w-0 items-start justify-between gap-2'>
+              <div className='min-w-0'>
+                <h2 className='system-b-library-card-title truncate'>
+                  {asset.title}
+                </h2>
+                <p className='system-b-library-card-meta mt-0.5 truncate'>
+                  {asset.artist}
+                </p>
+              </div>
+              <span className='system-b-library-card-count shrink-0 tabular-nums'>
+                {getLibraryItemKind(asset) === 'merch'
+                  ? (asset.salePriceLabel ?? 'Merch')
+                  : formatCompactCount(asset.providerCount)}
               </span>
-            ) : null}
+            </div>
+            <div className='system-b-library-card-summary mt-2 flex min-w-0 items-center gap-1.5'>
+              {getLibraryItemKind(asset) === 'merch' ? (
+                <Shirt className='h-3 w-3 shrink-0' />
+              ) : (
+                <Disc3 className='h-3 w-3 shrink-0' />
+              )}
+              <span>{formatLibraryItemType(asset)}</span>
+              {getLibraryItemKind(asset) === 'release' ? (
+                <>
+                  <span className='opacity-50'>.</span>
+                  <span>{asset.trackCount} Tracks</span>
+                </>
+              ) : null}
+            </div>
+            <div className='mt-3 flex flex-wrap gap-1.5'>
+              {asset.assetKinds.slice(0, 3).map(kind => (
+                <AssetKindPill key={kind} kind={kind} />
+              ))}
+              {asset.assetKinds.length > 3 ? (
+                <span className='system-b-library-card-more-pill inline-flex h-6 items-center px-2'>
+                  +{asset.assetKinds.length - 3}
+                </span>
+              ) : null}
+            </div>
           </div>
-        </div>
-      </button>
+        </button>
+      </Button>
       {hasPreview ? (
         <button
           type='button'

--- a/apps/web/app/ui/buttons/page.tsx
+++ b/apps/web/app/ui/buttons/page.tsx
@@ -50,32 +50,50 @@ export default function ButtonsPage() {
     <div>
       <h1 className='mb-1 text-lg font-semibold text-primary-token'>Button</h1>
       <p className='mb-8 text-[13px] text-tertiary-token'>
-        Matches Linear.app — font weight 510, tracking -0.011em, 8px radius,
-        32px default height
+        Canonical variants: primary, secondary, tertiary, ghost, and link.
+        Destructive is a tone prop, not a standalone variant.
       </p>
 
       {/* Variants */}
       <Section title='Variants'>
         <Stack title='primary'>
-          <Button variant='primary'>Save changes</Button>
+          <Button variant='primary'>Save Changes</Button>
         </Stack>
         <Stack title='secondary'>
           <Button variant='secondary'>Cancel</Button>
         </Stack>
+        <Stack title='tertiary'>
+          <Button variant='tertiary'>Dismiss</Button>
+        </Stack>
         <Stack title='ghost'>
-          <Button variant='ghost'>View details</Button>
-        </Stack>
-        <Stack title='outline'>
-          <Button variant='outline'>Export</Button>
-        </Stack>
-        <Stack title='destructive'>
-          <Button variant='destructive'>Delete</Button>
-        </Stack>
-        <Stack title='upgrade'>
-          <Button variant='primary'>Upgrade</Button>
+          <Button variant='ghost'>View Details</Button>
         </Stack>
         <Stack title='link'>
-          <Button variant='link'>Learn more</Button>
+          <Button variant='link'>Learn More</Button>
+        </Stack>
+      </Section>
+
+      {/* Destructive tone */}
+      <Section title='Destructive Tone'>
+        <Stack title='primary destructive'>
+          <Button destructive variant='primary'>
+            Delete
+          </Button>
+        </Stack>
+        <Stack title='secondary destructive'>
+          <Button destructive variant='secondary'>
+            Remove
+          </Button>
+        </Stack>
+        <Stack title='tertiary destructive'>
+          <Button destructive variant='tertiary'>
+            Reject
+          </Button>
+        </Stack>
+        <Stack title='ghost destructive'>
+          <Button destructive variant='ghost'>
+            Clear
+          </Button>
         </Stack>
       </Section>
 
@@ -84,10 +102,10 @@ export default function ButtonsPage() {
         <Stack title='sm'>
           <Button size='sm'>Small</Button>
         </Stack>
-        <Stack title='default (32px)'>
-          <Button>Default</Button>
+        <Stack title='md (default)'>
+          <Button size='md'>Medium</Button>
         </Stack>
-        <Stack title='lg (40px)'>
+        <Stack title='lg'>
           <Button size='lg'>Large</Button>
         </Stack>
       </Section>
@@ -97,7 +115,7 @@ export default function ButtonsPage() {
         <Stack title='icon left'>
           <Button variant='primary'>
             <Plus className='h-4 w-4' />
-            New release
+            New Release
           </Button>
         </Stack>
         <Stack title='icon right'>
@@ -113,7 +131,7 @@ export default function ButtonsPage() {
           <Button variant='secondary' size='icon' aria-label='Archive'>
             <Archive className='h-4 w-4' />
           </Button>
-          <Button variant='destructive' size='icon' aria-label='Delete'>
+          <Button destructive variant='ghost' size='icon' aria-label='Delete'>
             <Trash2 className='h-4 w-4' />
           </Button>
         </Stack>
@@ -171,7 +189,7 @@ export default function ButtonsPage() {
 
       {/* Secondary hover demo — previously broken */}
       <Section title='Secondary Hover (was broken — verify hover works)'>
-        <Button variant='secondary'>Hover me</Button>
+        <Button variant='secondary'>Hover Me</Button>
         <Button variant='secondary'>
           <Archive className='h-4 w-4' />
           Archive

--- a/apps/web/components/atoms/Button.stories.tsx
+++ b/apps/web/components/atoms/Button.stories.tsx
@@ -15,24 +15,16 @@ const meta: Meta<typeof Button> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    size: {
-      control: { type: 'select' },
-      options: ['default', 'sm', 'lg', 'icon'],
-    },
     variant: {
       control: { type: 'select' },
-      options: [
-        'primary',
-        'accent',
-        'secondary',
-        'outline',
-        'ghost',
-        'destructive',
-        'link',
-        'frosted',
-        'frosted-ghost',
-        'frosted-outline',
-      ],
+      options: ['primary', 'secondary', 'tertiary', 'ghost', 'link'],
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg', 'icon'],
+    },
+    destructive: {
+      control: { type: 'boolean' },
     },
     disabled: {
       control: { type: 'boolean' },
@@ -45,42 +37,64 @@ type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
   args: {
-    children: 'Button',
+    children: 'Primary',
     variant: 'primary',
   },
 };
 
 export const Secondary: Story = {
   args: {
-    children: 'Button',
+    children: 'Secondary',
     variant: 'secondary',
   },
 };
 
-export const Outline: Story = {
+export const Tertiary: Story = {
   args: {
-    children: 'Button',
-    variant: 'outline',
+    children: 'Tertiary',
+    variant: 'tertiary',
   },
 };
 
 export const Ghost: Story = {
   args: {
-    children: 'Button',
+    children: 'Ghost',
     variant: 'ghost',
+  },
+};
+
+export const Link: Story = {
+  args: {
+    children: 'Link',
+    variant: 'link',
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    children: 'Delete',
+    destructive: true,
+    variant: 'primary',
   },
 };
 
 export const Large: Story = {
   args: {
-    children: 'Button',
+    children: 'Large',
     size: 'lg',
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    children: 'Medium',
+    size: 'md',
   },
 };
 
 export const Small: Story = {
   args: {
-    children: 'Button',
+    children: 'Small',
     size: 'sm',
   },
 };
@@ -89,5 +103,58 @@ export const Disabled: Story = {
   args: {
     children: 'Button',
     disabled: true,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className='flex flex-col gap-4 p-8'>
+      <div>
+        <h3 className='mb-2 font-semibold text-sm'>Canonical Variants</h3>
+        <div className='flex flex-wrap gap-2'>
+          <Button variant='primary'>Primary</Button>
+          <Button variant='secondary'>Secondary</Button>
+          <Button variant='tertiary'>Tertiary</Button>
+          <Button variant='ghost'>Ghost</Button>
+          <Button variant='link'>Link</Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 className='mb-2 font-semibold text-sm'>Destructive Tone</h3>
+        <div className='flex flex-wrap gap-2'>
+          <Button destructive variant='primary'>
+            Primary
+          </Button>
+          <Button destructive variant='secondary'>
+            Secondary
+          </Button>
+          <Button destructive variant='tertiary'>
+            Tertiary
+          </Button>
+          <Button destructive variant='ghost'>
+            Ghost
+          </Button>
+          <Button destructive variant='link'>
+            Link
+          </Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 className='mb-2 font-semibold text-sm'>Sizes</h3>
+        <div className='flex flex-wrap items-center gap-2'>
+          <Button size='sm'>Small</Button>
+          <Button size='md'>Medium</Button>
+          <Button size='lg'>Large</Button>
+          <Button aria-label='Icon button' size='icon'>
+            +
+          </Button>
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'fullscreen',
   },
 };

--- a/apps/web/components/features/dashboard/atoms/CopyLinkInput.tsx
+++ b/apps/web/components/features/dashboard/atoms/CopyLinkInput.tsx
@@ -10,6 +10,7 @@
  * - Visual feedback on copy
  */
 
+import { Button } from '@jovie/ui';
 import {
   type MouseEvent,
   useCallback,
@@ -111,7 +112,7 @@ export function CopyLinkInput({
         readOnly
         value={displayValue ?? url}
         onClick={handleInputClick}
-        aria-label='URL to copy'
+        aria-label='URL To Copy'
         data-copied={isCopied ? 'true' : undefined}
         className={cn(
           'system-b-copy-link-input w-full rounded-full border px-2.5 py-1.5 pr-9',
@@ -122,14 +123,19 @@ export function CopyLinkInput({
           inputClassName
         )}
       />
-      <button
+      <Button
         type='button'
+        variant='ghost'
+        size='icon'
         onClick={handleCopy}
         aria-label={isCopied ? 'Copied to clipboard' : 'Copy to clipboard'}
         title={isCopied ? 'Copied!' : 'Copy to clipboard'}
         data-copied={isCopied ? 'true' : undefined}
         className={cn(
-          'system-b-copy-link-button absolute right-1.5 rounded-full border p-1',
+          'absolute inset-y-0 right-1.5 my-auto h-6 w-6 rounded-full border p-1',
+          isCopied
+            ? 'border-success/20 bg-success-subtle text-success'
+            : 'border-transparent text-tertiary-token hover:border-subtle hover:bg-surface-1 hover:text-primary-token',
           buttonClassName
         )}
       >
@@ -148,7 +154,7 @@ export function CopyLinkInput({
           />
         </span>
         <span className='sr-only'>{isCopied ? 'Copied' : 'Copy'}</span>
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/web/components/jovie/components/ChatComposerToolbar.tsx
+++ b/apps/web/components/jovie/components/ChatComposerToolbar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -135,12 +136,15 @@ export function ComposerAttachButton({
   return (
     <DropdownMenu open={plusMenuOpen} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
-        <button
+        <Button
           type='button'
+          variant='ghost'
+          size='icon'
           onMouseDown={onMouseDown}
           disabled={isProcessing || isLoading || isSubmitting || disabled}
           className={cn(
-            'system-b-chat-composer-icon-button flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+            'h-9 w-9 shrink-0 border border-transparent bg-surface-0 text-tertiary-token hover:border-subtle hover:bg-surface-1 hover:text-primary-token',
+            plusMenuOpen && 'border-subtle bg-surface-1 text-primary-token',
             'disabled:cursor-not-allowed disabled:opacity-50'
           )}
           aria-label='Attach Files'
@@ -150,7 +154,7 @@ export function ComposerAttachButton({
           ) : (
             <Plus className='h-4 w-4' strokeWidth={2.25} />
           )}
-        </button>
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align='start'
@@ -243,8 +247,10 @@ export function ComposerMicButton({
 
   return (
     <SimpleTooltip content={tooltip}>
-      <button
+      <Button
         type='button'
+        variant='ghost'
+        size='icon'
         onPointerDown={handlePointerDown}
         onPointerUp={handlePointerEnd}
         onPointerCancel={handlePointerEnd}
@@ -254,10 +260,11 @@ export function ComposerMicButton({
         data-testid='dictation-toggle'
         data-active={isListening ? 'true' : undefined}
         className={cn(
-          'system-b-chat-composer-icon-button flex h-9 w-9 shrink-0 items-center justify-center rounded-full touch-none select-none',
+          'h-9 w-9 shrink-0 touch-none select-none border border-transparent bg-surface-0 hover:border-subtle hover:bg-surface-1 hover:text-primary-token',
           !isSupported
             ? 'text-quaternary-token'
             : !isListening && 'text-tertiary-token',
+          isListening && 'border-default bg-surface-2 text-primary-token',
           'disabled:cursor-not-allowed disabled:opacity-50'
         )}
         aria-label={label}
@@ -268,7 +275,7 @@ export function ComposerMicButton({
         ) : (
           <Mic className='h-4 w-4' strokeWidth={2.25} />
         )}
-      </button>
+      </Button>
     </SimpleTooltip>
   );
 }

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SimpleTooltip, Skeleton } from '@jovie/ui';
+import { Button, SimpleTooltip, Skeleton } from '@jovie/ui';
 import { Check, Copy } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import { memo, useEffect, useRef, useState } from 'react';
@@ -239,10 +239,12 @@ export const ChatMessage = memo(function ChatMessage({
                 <SimpleTooltip
                   content={isCopySuccess ? 'Copied!' : 'Copy response'}
                 >
-                  <button
+                  <Button
                     type='button'
+                    variant='ghost'
+                    size='icon'
                     onClick={handleCopyMessage}
-                    className='system-b-chat-copy-button'
+                    className='h-7 w-7 shadow-none'
                     aria-label={
                       isCopySuccess ? 'Copied to clipboard' : 'Copy message'
                     }
@@ -252,7 +254,7 @@ export const ChatMessage = memo(function ChatMessage({
                     ) : (
                       <Copy className='system-b-chat-copy-icon' />
                     )}
-                  </button>
+                  </Button>
                 </SimpleTooltip>
               ) : null}
             </div>

--- a/apps/web/components/jovie/components/ChatPitchCard.tsx
+++ b/apps/web/components/jovie/components/ChatPitchCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { CopyToggleIcon } from '@/components/atoms/CopyToggleIcon';
@@ -72,14 +73,16 @@ function CopyButton({
   }, [copied]);
 
   return (
-    <button
+    <Button
       type='button'
+      variant='ghost'
+      size='icon'
       onClick={handleCopy}
-      className='system-b-chat-pitch-copy-button focus-ring'
+      className='h-6 w-6 rounded-md focus-ring'
       aria-label={`Copy ${platform} pitch`}
     >
       <CopyToggleIcon copied={copied} size='system-b-chat-pitch-copy-icon' />
-    </button>
+    </Button>
   );
 }
 

--- a/apps/web/components/jovie/components/ImagePreviewStrip.tsx
+++ b/apps/web/components/jovie/components/ImagePreviewStrip.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import Image from 'next/image';
@@ -33,7 +34,7 @@ export function ImagePreviewStrip({
           {images.map(image => (
             <motion.div
               key={image.id}
-              className='system-b-image-preview-item'
+              className='system-b-image-preview-item group/image-preview'
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
@@ -51,14 +52,16 @@ export function ImagePreviewStrip({
                   {image.name}
                 </p>
               </div>
-              <button
+              <Button
                 type='button'
+                variant='ghost'
+                size='icon'
                 onClick={() => onRemove(image.id)}
-                className='system-b-image-preview-remove-button'
+                className='absolute right-1.5 top-1.5 h-6 w-6 rounded-lg border border-white/15 bg-black/55 text-white opacity-100 transition-opacity duration-fast ease-subtle hover:bg-black/55 hover:text-white focus-visible:opacity-100 dark:text-white md:opacity-0 md:group-hover/image-preview:opacity-100'
                 aria-label={`Remove ${image.name}`}
               >
                 <X className='h-3.5 w-3.5' />
-              </button>
+              </Button>
             </motion.div>
           ))}
         </AnimatePresence>

--- a/apps/web/components/jovie/components/SuggestedPrompts.tsx
+++ b/apps/web/components/jovie/components/SuggestedPrompts.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import {
   Camera,
   Disc3,
@@ -159,7 +160,8 @@ export function SuggestedPrompts({
     resolvedAlbumArtCapability.availability === 'unavailable'
       ? {
           icon: 'Camera',
-          label: 'Draft album-art brief',
+          // eslint-disable-next-line @jovie/canonical-ui-label-casing -- title-case hyphen false positive
+          label: 'Draft Album-art Brief',
           prompt:
             'Draft an album-art brief for my latest release with visual direction, mood, palette, typography, and production notes.',
           accent: 'purple',
@@ -279,9 +281,11 @@ export function SuggestedPrompts({
           const IconComponent = ICON_MAP[suggestion.icon];
 
           return (
-            <button
+            <Button
               key={suggestion.label}
               type='button'
+              variant='tertiary'
+              size='sm'
               onClick={() => {
                 if (
                   !(
@@ -295,7 +299,7 @@ export function SuggestedPrompts({
               disabled={
                 suggestion.label === 'Generate Album Art' && albumArtDisabled
               }
-              className='group system-b-chat-suggested-prompts-flat-button'
+              className='group h-auto w-full justify-start rounded-full px-3 py-2 text-left text-secondary-token hover:bg-surface-0 hover:text-primary-token disabled:cursor-not-allowed disabled:opacity-50'
               aria-label={suggestion.label}
               title={
                 suggestion.label === 'Generate Album Art'
@@ -309,7 +313,7 @@ export function SuggestedPrompts({
                 ) : null}
               </span>
               <span className='min-w-0 truncate'>{suggestion.label}</span>
-            </button>
+            </Button>
           );
         })}
       </div>

--- a/apps/web/components/shell/ThreadVideoCard.tsx
+++ b/apps/web/components/shell/ThreadVideoCard.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { Maximize2, Mic2, Play } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { ThreadCardIconBtn } from './ThreadCardIconBtn';
 
 export interface ThreadVideoCardProps {
@@ -43,20 +45,28 @@ export function ThreadVideoCard({
               'aria-label': `Play ${title}`,
             }
           : {})}
-        className='system-b-thread-media-preview system-b-thread-video-preview'
+        className='system-b-thread-media-preview system-b-thread-video-preview group'
       >
         <span aria-hidden='true' className='system-b-thread-video-backdrop' />
         <span className='system-b-thread-play-shell'>
-          <span
-            className='system-b-thread-play-button'
-            data-interactive={onPlay ? 'true' : 'false'}
+          <Button
+            asChild
+            variant='primary'
+            size='icon'
+            static
+            className={cn(
+              'h-12 w-12 shadow-none transition-colors duration-fast ease-subtle',
+              onPlay ? 'group-hover:bg-btn-primary-hover' : 'bg-btn-primary/40'
+            )}
           >
-            <Play
-              className='h-4 w-4 translate-x-px'
-              strokeWidth={2.5}
-              fill='currentColor'
-            />
-          </span>
+            <span data-interactive={onPlay ? 'true' : 'false'}>
+              <Play
+                className='h-4 w-4 translate-x-px'
+                strokeWidth={2.5}
+                fill='currentColor'
+              />
+            </span>
+          </Button>
         </span>
         <span className='system-b-thread-duration-badge'>
           {formatDuration(durationSec)}
@@ -66,7 +76,7 @@ export function ThreadVideoCard({
         <Mic2 className='system-b-thread-media-icon' strokeWidth={2.25} />
         <span className='system-b-thread-media-label'>{title}</span>
         {onFullscreen && (
-          <ThreadCardIconBtn label='Full-screen' onClick={onFullscreen}>
+          <ThreadCardIconBtn label='Fullscreen' onClick={onFullscreen}>
             <Maximize2 className='h-3 w-3' strokeWidth={2.25} />
           </ThreadCardIconBtn>
         )}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -8178,25 +8178,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   text-decoration-line: underline;
 }
 
-:where(.system-b-chat-pitch-copy-button) {
-  display: inline-flex;
-  width: var(--space-6);
-  height: var(--space-6);
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-md);
-  color: var(--color-text-tertiary-token);
-  transition:
-    background-color var(--duration-fast) var(--ease-subtle),
-    color var(--duration-fast) var(--ease-subtle);
-}
-
-:where(.system-b-chat-pitch-copy-button:hover) {
-  background: var(--system-b-bg-surface-2);
-  color: var(--color-text-secondary-token);
-}
-
 :where(.system-b-chat-pitch-copy-icon) {
   width: calc(var(--space-3) + var(--space-0-5));
   height: calc(var(--space-3) + var(--space-0-5));
@@ -8357,37 +8338,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
     var(--system-b-bg-surface-0)
   );
   color: var(--color-text-primary-token);
-}
-
-.system-b-copy-link-button {
-  top: 50%;
-  transform: translateY(-50%);
-  border-color: transparent;
-  color: var(--color-text-tertiary-token);
-  transition:
-    background-color var(--duration-fast) var(--ease-subtle),
-    border-color var(--duration-fast) var(--ease-subtle),
-    color var(--duration-fast) var(--ease-subtle);
-}
-
-.system-b-copy-link-button:hover {
-  border-color: var(--system-b-app-frame-seam);
-  background: var(--system-b-bg-surface-1);
-  color: var(--color-text-primary-token);
-}
-
-.system-b-copy-link-button[data-copied="true"] {
-  border-color: color-mix(
-    in oklab,
-    var(--color-success) 32%,
-    var(--system-b-app-frame-seam)
-  );
-  background: color-mix(
-    in oklab,
-    var(--color-success) 10%,
-    var(--system-b-bg-surface-1)
-  );
-  color: var(--color-success);
 }
 
 .system-b-copy-link-icon {
@@ -9483,32 +9433,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 :where(.system-b-chat-message-row:hover .system-b-chat-copy-row),
 :where(.system-b-chat-message-row:focus-within .system-b-chat-copy-row) {
   opacity: 1;
-}
-
-:where(.system-b-chat-copy-button) {
-  display: inline-flex;
-  width: calc(var(--space-6) + var(--space-1));
-  height: calc(var(--space-6) + var(--space-1));
-  align-items: center;
-  justify-content: center;
-  border: 1px solid transparent;
-  border-radius: var(--radius-full);
-  background: transparent;
-  color: var(--color-text-tertiary-token);
-  box-shadow: none;
-  transition:
-    background-color var(--duration-subtle) var(--ease-subtle),
-    color var(--duration-subtle) var(--ease-subtle);
-}
-
-:where(.system-b-chat-copy-button:hover),
-:where(.system-b-chat-copy-button:focus-visible) {
-  background: var(--system-b-bg-surface-1);
-  color: var(--color-text-secondary-token);
-}
-
-:where(.system-b-chat-copy-button:focus-visible) {
-  outline: none;
 }
 
 :where(.system-b-chat-copy-icon) {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -6194,8 +6194,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 :where(.system-b-library-artwork-shell),
 :where(.system-b-library-status-pill),
 :where(.system-b-library-count-pill),
-:where(.system-b-library-rail-button),
-:where(.system-b-library-filter-section-button),
 :where(.system-b-library-filter-row),
 :where(.system-b-library-kind-pill),
 :where(.system-b-library-provider-link) {
@@ -6204,8 +6202,7 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 
 /* Buttons + icon buttons are pill / hover-circle per System B (DESIGN.md:
    App buttons, inputs, controls → 9999px). */
-:where(.system-b-library-action),
-:where(.system-b-library-icon-button) {
+:where(.system-b-library-action) {
   border-radius: var(--radius-full);
 }
 
@@ -6289,7 +6286,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 
 :where(.system-b-library-filter-pill),
 :where(.system-b-library-rail-count),
-:where(.system-b-library-clear-button),
 :where(.system-b-library-filter-count),
 :where(.system-b-library-card-count),
 :where(.system-b-library-audio-hint),
@@ -6298,30 +6294,23 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   font-size: var(--text-2xs);
 }
 
-:where(.system-b-library-rail-button),
 :where(.system-b-library-filter-row),
 :where(.system-b-library-action),
-:where(.system-b-library-icon-button),
 :where(.system-b-library-provider-link) {
   transition-duration: var(--duration-fast);
   transition-property: background-color, border-color, box-shadow, color;
   transition-timing-function: var(--ease-subtle);
 }
 
-:where(.system-b-library-rail-button),
 :where(.system-b-library-filter-row) {
   color: var(--color-text-secondary-token);
   font-size: var(--text-xs);
 }
 
-:where(
-  .system-b-library-rail-button:not(.system-b-library-rail-button--active)
-),
 :where(.system-b-library-filter-row:not(.system-b-library-filter-row--active)) {
   border-color: transparent;
 }
 
-:where(.system-b-library-rail-button--active),
 :where(.system-b-library-filter-row--active) {
   border-color: var(--color-border-default);
   background: var(--system-b-bg-surface-1);
@@ -6329,38 +6318,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-library-rail-button:not(.system-b-library-rail-button--active):hover
-),
-:where(
   .system-b-library-filter-row:not(.system-b-library-filter-row--active):hover
 ) {
   border-color: var(--color-border-default);
-  background: var(--system-b-bg-surface-1);
-  color: var(--color-text-primary-token);
-}
-
-:where(.system-b-library-clear-button) {
-  border-radius: var(--radius-xs);
-  transition-duration: var(--duration-fast);
-  transition-property: background-color, color;
-  transition-timing-function: var(--ease-subtle);
-}
-
-:where(.system-b-library-clear-button:hover) {
-  background: var(--system-b-bg-surface-1);
-  color: var(--color-text-primary-token);
-}
-
-:where(.system-b-library-filter-section-button) {
-  color: var(--color-text-tertiary-token);
-  font-size: var(--text-2xs);
-  font-weight: var(--font-weight-medium);
-  transition-duration: var(--duration-fast);
-  transition-property: background-color, color;
-  transition-timing-function: var(--ease-subtle);
-}
-
-:where(.system-b-library-filter-section-button:hover) {
   background: var(--system-b-bg-surface-1);
   color: var(--color-text-primary-token);
 }
@@ -6425,12 +6385,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   box-shadow:
     inset 2px 0 0 0 var(--color-border-default),
     inset 0 0 0 1px var(--color-border-subtle);
-}
-
-:where(.system-b-library-card-button) {
-  transition-duration: var(--duration-fast);
-  transition-property: background-color, box-shadow;
-  transition-timing-function: var(--ease-subtle);
 }
 
 :where(.system-b-library-card-status) {
@@ -6600,8 +6554,7 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 
 /* Issue #12317 — System B compliance: pill action buttons + borderless
    circular icon buttons. Overrides the shared --radius-md primitive above. */
-:where(.system-b-library-action),
-:where(.system-b-library-icon-button) {
+:where(.system-b-library-action) {
   border-radius: var(--radius-full);
 }
 
@@ -6678,22 +6631,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   font-weight: var(--font-weight-semibold);
 }
 
-/* Borderless icon buttons; the round hover background reads as a hover-circle. */
-:where(.system-b-library-icon-button) {
-  border-radius: var(--radius-full);
-  color: var(--color-text-tertiary-token);
-}
-
-:where(.system-b-library-icon-button:hover) {
-  background: var(--system-b-bg-surface-1);
-  color: var(--color-text-primary-token);
-}
-
-:where(.system-b-library-icon-button--bordered:hover) {
-  border-color: var(--color-border-default);
-  background: var(--system-b-bg-surface-2);
-}
-
 :where(.system-b-library-drawer-artwork) {
   border-radius: var(--radius-lg);
 }
@@ -6739,18 +6676,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   background: var(--system-b-bg-surface-1);
 }
 
-:where(.system-b-calendar-icon-button),
-:where(.system-b-calendar-toolbar-button) {
-  border-radius: var(--radius-pill);
-  color: var(--color-text-tertiary-token);
-}
-
-:where(.system-b-calendar-icon-button:hover),
-:where(.system-b-calendar-toolbar-button:hover) {
-  background: var(--system-b-bg-surface-0);
-  color: var(--color-text-primary-token);
-}
-
 :where(.system-b-calendar-panel) {
   border: 1px solid var(--system-b-app-frame-seam);
   border-radius: var(--radius-lg);
@@ -6766,7 +6691,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   border-bottom: 1px solid var(--system-b-app-frame-seam);
 }
 
-:where(.system-b-calendar-toolbar-button),
 :where(.system-b-calendar-detail-section-heading),
 :where(.system-b-calendar-warning-heading),
 :where(.system-b-calendar-error-text),

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -8795,40 +8795,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   gap: var(--space-1-5);
 }
 
-:where(.system-b-chat-suggested-prompts-flat-button) {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  gap: var(--space-2);
-  border-radius: var(--radius-full);
-  background: transparent;
-  color: var(--color-text-secondary-token);
-  font-size: 12.5px;
-  padding: var(--space-2) var(--space-3);
-  text-align: left;
-  transition:
-    background-color var(--duration-fast) var(--ease-subtle),
-    color var(--duration-fast) var(--ease-subtle);
-}
-
-:where(.system-b-chat-suggested-prompts-flat-button:enabled:hover) {
-  background: var(--surface-0);
-  color: var(--color-text-primary-token);
-}
-
-:where(.system-b-chat-suggested-prompts-flat-button:disabled) {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-:where(.system-b-chat-suggested-prompts-flat-button:focus-visible) {
-  border-color: var(--color-border-focus);
-  background: var(--surface-0);
-  outline: none;
-  box-shadow: 0 0 0 2px
-    color-mix(in oklab, var(--color-border-focus) 12%, transparent);
-}
-
 :where(.system-b-chat-suggested-prompts-rail-wrapper) {
   width: 100%;
   max-width: 46rem;
@@ -9611,39 +9577,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
     color-mix(in oklab, black 25%, transparent),
     transparent
   );
-}
-
-:where(.system-b-image-preview-remove-button) {
-  position: absolute;
-  top: var(--space-1-5);
-  right: var(--space-1-5);
-  display: flex;
-  width: var(--space-6);
-  height: var(--space-6);
-  align-items: center;
-  justify-content: center;
-  border: 1px solid color-mix(in oklab, white 15%, transparent);
-  border-radius: var(--radius-lg);
-  background: color-mix(in oklab, black 55%, transparent);
-  color: white;
-  opacity: 1;
-  transition: opacity var(--duration-fast) var(--ease-subtle);
-}
-
-@media (hover: hover) {
-  :where(.system-b-image-preview-remove-button) {
-    opacity: 0;
-  }
-
-  :where(
-    .system-b-image-preview-item:hover .system-b-image-preview-remove-button
-  ) {
-    opacity: 1;
-  }
-}
-
-:where(.system-b-image-preview-remove-button:focus-visible) {
-  opacity: 1;
 }
 
 :where(.system-b-chat-avatar-upload-state-card) {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -4631,24 +4631,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   gap: var(--space-1);
 }
 
-:where(.system-b-chat-profile-preview-phone-button) {
-  height: var(--space-6);
-  border-radius: var(--radius-md);
-  background: color-mix(
-    in oklab,
-    var(--color-text-tertiary-token) 22%,
-    transparent
-  );
-}
-
-:where(.system-b-chat-profile-preview-phone-button-muted) {
-  background: color-mix(
-    in oklab,
-    var(--color-text-tertiary-token) 14%,
-    transparent
-  );
-}
-
 :where(.system-b-chat-profile-preview-device-icon) {
   position: absolute;
   bottom: var(--space-4);
@@ -4970,34 +4952,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   inset: 0;
   display: grid;
   place-items: center;
-}
-
-:where(.system-b-thread-play-button) {
-  display: grid;
-  width: var(--space-12);
-  height: var(--space-12);
-  place-items: center;
-  border-radius: var(--radius-full);
-  background: var(--system-b-primary-bg);
-  color: var(--system-b-primary-fg);
-  transition:
-    background-color var(--system-b-duration-fast) var(--system-b-ease),
-    opacity var(--system-b-duration-fast) var(--system-b-ease);
-}
-
-:where(
-  .system-b-thread-video-preview:hover
-    .system-b-thread-play-button[data-interactive="true"]
-) {
-  background: color-mix(
-    in oklab,
-    var(--system-b-primary-bg) 94%,
-    var(--system-b-bg-surface-2)
-  );
-}
-
-:where(.system-b-thread-play-button[data-interactive="false"]) {
-  background: color-mix(in oklab, var(--system-b-primary-bg) 42%, transparent);
 }
 
 :where(.system-b-thread-duration-badge) {
@@ -8600,39 +8554,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   padding-bottom: calc(var(--space-5) + var(--space-0-5));
   color: var(--color-text-tertiary-token);
   font-size: var(--text-xs);
-}
-
-:where(.system-b-chat-composer-icon-button) {
-  border: 1px solid transparent;
-  background: color-mix(
-    in oklab,
-    var(--system-b-app-content-surface) 88%,
-    var(--system-b-bg-surface-0)
-  );
-  transition:
-    background-color var(--duration-fast) var(--ease-subtle),
-    border-color var(--duration-fast) var(--ease-subtle),
-    color var(--duration-fast) var(--ease-subtle),
-    box-shadow var(--duration-fast) var(--ease-subtle);
-}
-
-:where(.system-b-chat-composer-icon-button:not(:disabled):hover),
-:where(.system-b-chat-composer-icon-button[data-state="open"]) {
-  border-color: var(--system-b-app-shell-border);
-  background: var(--system-b-bg-surface-1);
-  color: var(--color-text-primary-token);
-  box-shadow: inset 0 0 0 1px
-    color-mix(in oklab, var(--system-b-app-shell-border) 40%, transparent);
-}
-
-:where(.system-b-chat-composer-icon-button[data-active="true"]) {
-  border-color: var(--color-border-default);
-  background: var(--system-b-bg-surface-2);
-  color: var(--color-text-primary-token);
-}
-
-:where(.system-b-chat-composer-icon-button:disabled) {
-  color: var(--color-text-quaternary-token);
 }
 
 :where(.system-b-chat-composer-primary-action) {

--- a/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
@@ -22,6 +22,16 @@ vi.mock('motion/react', () => ({
 }));
 
 vi.mock('@jovie/ui', () => ({
+  Button: ({
+    children,
+    size,
+    variant,
+    ...props
+  }: ComponentProps<'button'> & { size?: string; variant?: string }) => (
+    <button data-size={size} data-variant={variant} {...props}>
+      {children}
+    </button>
+  ),
   SimpleTooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 

--- a/apps/web/tests/unit/chat/ChatMessage.memo.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.memo.test.tsx
@@ -24,6 +24,16 @@ vi.mock('motion/react', () => ({
 }));
 
 vi.mock('@jovie/ui', () => ({
+  Button: ({
+    children,
+    size,
+    variant,
+    ...props
+  }: ComponentProps<'button'> & { size?: string; variant?: string }) => (
+    <button data-size={size} data-variant={variant} {...props}>
+      {children}
+    </button>
+  ),
   SimpleTooltip: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -26,9 +26,13 @@ vi.mock('motion/react', () => ({
 vi.mock('@jovie/ui', () => ({
   Button: ({
     children,
+    size,
+    variant,
     ...props
   }: ComponentProps<'button'> & { size?: string; variant?: string }) => (
-    <button {...props}>{children}</button>
+    <button data-size={size} data-variant={variant} {...props}>
+      {children}
+    </button>
   ),
   Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
   PopoverContent: ({
@@ -204,7 +208,9 @@ describe('ChatMessage', () => {
       'system-b-chat-message-reply'
     );
     const copyButton = screen.getByRole('button', { name: 'Copy message' });
-    expect(copyButton).toHaveClass('system-b-chat-copy-button');
+    expect(copyButton).toHaveAttribute('data-variant', 'ghost');
+    expect(copyButton).toHaveAttribute('data-size', 'icon');
+    expect(copyButton).toHaveClass('h-7');
     expect(copyButton.querySelector('.system-b-chat-copy-icon')).toBeTruthy();
   });
 

--- a/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
+++ b/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
@@ -139,7 +139,7 @@ describe('SuggestedPrompts', () => {
     getByRole('button', { name: 'Generate Album Art' }).click();
     expect(onSelect).not.toHaveBeenCalled();
 
-    const draftBrief = getByRole('button', { name: 'Draft album-art brief' });
+    const draftBrief = getByRole('button', { name: 'Draft Album-art Brief' });
     expect(draftBrief).toBeEnabled();
 
     draftBrief.click();
@@ -164,7 +164,7 @@ describe('SuggestedPrompts', () => {
     getByRole('button', { name: 'Generate Album Art' }).click();
 
     expect(onSelect).not.toHaveBeenCalled();
-    expect(queryByRole('button', { name: 'Draft album-art brief' })).toBeNull();
+    expect(queryByRole('button', { name: 'Draft Album-art Brief' })).toBeNull();
   });
 
   it('omits "Generate album art" entirely when provider is unavailable and surfaces the brief in its place', () => {
@@ -184,7 +184,7 @@ describe('SuggestedPrompts', () => {
     expect(queryByRole('button', { name: 'Generate Album Art' })).toBeNull();
 
     // Brief fallback still surfaces a useful creative action.
-    const draftBrief = getByRole('button', { name: 'Draft album-art brief' });
+    const draftBrief = getByRole('button', { name: 'Draft Album-art Brief' });
     expect(draftBrief).toBeEnabled();
     draftBrief.click();
     expect(onSelect).toHaveBeenCalledWith(
@@ -207,7 +207,7 @@ describe('SuggestedPrompts', () => {
 
     expect(queryByRole('button', { name: 'Generate Album Art' })).toBeNull();
     expect(
-      getByRole('button', { name: 'Draft album-art brief' })
+      getByRole('button', { name: 'Draft Album-art Brief' })
     ).toBeEnabled();
   });
 
@@ -230,7 +230,7 @@ describe('SuggestedPrompts', () => {
 
     // Brief fallback still surfaces for the free-tier user.
     expect(
-      getByRole('button', { name: 'Draft album-art brief' })
+      getByRole('button', { name: 'Draft Album-art Brief' })
     ).toBeEnabled();
   });
 });

--- a/apps/web/tests/unit/chat/chat-composer-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-composer-system-b-style-guard.test.ts
@@ -47,11 +47,17 @@ describe('chat composer System B source contract', () => {
       'system-b-chat-composer-thread-scroll-padding',
       'system-b-chat-composer-surface',
       'system-b-chat-composer-picker-shell',
-      'system-b-chat-composer-icon-button',
       'system-b-chat-composer-primary-action',
       'system-b-chat-composer-menu',
     ]) {
       expect(styles).toContain(className);
     }
+
+    const toolbarSource = readFileSync(
+      resolve(appRoot, 'components/jovie/components/ChatComposerToolbar.tsx'),
+      'utf8'
+    );
+    expect(toolbarSource).toContain("variant='ghost'");
+    expect(toolbarSource).not.toContain('system-b-chat-composer-icon-button');
   });
 });

--- a/apps/web/tests/unit/chat/chat-message-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-message-system-b-style-guard.test.ts
@@ -53,7 +53,6 @@ describe('ChatMessage System B source contract', () => {
       'system-b-chat-assistant-stack',
       'system-b-chat-message-reply',
       'system-b-chat-copy-row',
-      'system-b-chat-copy-button',
       'system-b-chat-copy-icon',
     ];
 
@@ -61,6 +60,9 @@ describe('ChatMessage System B source contract', () => {
       expect(source).toContain(className);
       expect(styles).toContain(`.${className}`);
     }
+
+    expect(source).not.toContain('system-b-chat-copy-button');
+    expect(styles).not.toContain('system-b-chat-copy-button');
   });
 
   it('keeps user-bubble light-surface text on the canonical System B alias', () => {

--- a/apps/web/tests/unit/dashboard/copy-link-input-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/copy-link-input-system-b-style-guard.test.ts
@@ -29,11 +29,13 @@ describe('CopyLinkInput System B source contract', () => {
 
     for (const className of [
       'system-b-copy-link-input',
-      'system-b-copy-link-button',
       'system-b-copy-link-icon',
     ]) {
       expect(source).toContain(className);
     }
+
+    expect(source).toContain("variant='ghost'");
+    expect(source).not.toContain('system-b-copy-link-button');
 
     expect(source).toContain('data-copied');
     expect(source).toContain('data-visible');
@@ -43,6 +45,7 @@ describe('CopyLinkInput System B source contract', () => {
       'h-7',
       'h-9',
       'right-1.5',
+      'inset-y-0',
       'p-1',
       'h-3.5 w-3.5',
     ]) {
@@ -59,12 +62,12 @@ describe('CopyLinkInput System B source contract', () => {
     for (const selector of [
       '.system-b-copy-link-input',
       '.system-b-copy-link-input[data-copied="true"]',
-      '.system-b-copy-link-button',
-      '.system-b-copy-link-button[data-copied="true"]',
       '.system-b-copy-link-icon',
       '.system-b-copy-link-icon[data-visible="true"]',
     ]) {
       expect(styles).toContain(selector);
     }
+
+    expect(styles).not.toContain('system-b-copy-link-button');
   });
 });

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -244,7 +244,7 @@ describe('LibrarySurface', () => {
     expect(source).toContain('releaseStatusClasses');
     expect(source).toContain('libraryApprovalStatusClasses');
     expect(source).toContain('system-b-library-filter-pill-active');
-    expect(source).toContain('system-b-library-rail-button--active');
+    expect(source).toContain("variant={active ? 'secondary' : 'tertiary'}");
     expect(source).toContain('system-b-library-card--selected');
     expect(source).toContain('system-b-library-table-row-selected');
     expect(source).toContain('ReleaseAudioAssetPanel');

--- a/apps/web/tests/unit/library/library-system-b-compliance.test.ts
+++ b/apps/web/tests/unit/library/library-system-b-compliance.test.ts
@@ -57,10 +57,11 @@ describe('library right-rail System B structural compliance', () => {
     );
   });
 
-  it('makes library buttons and icon buttons pill / hover-circle', () => {
+  it('keeps remaining library action buttons pill-shaped and retires old icon button CSS', () => {
     expect(css).toMatch(
-      /:where\(\.system-b-library-action\),\s*:where\(\.system-b-library-icon-button\)\s*\{\s*border-radius: var\(--radius-full\);/
+      /:where\(\.system-b-library-action\)\s*\{\s*border-radius: var\(--radius-full\);/
     );
+    expect(css).not.toContain('system-b-library-icon-button');
   });
 
   it('edits approval status inline in Details without a native select', () => {

--- a/packages/ui/atoms/alert-dialog.test.tsx
+++ b/packages/ui/atoms/alert-dialog.test.tsx
@@ -233,7 +233,7 @@ describe('AlertDialog', () => {
     it('supports variant prop', () => {
       render(<TestAlertDialog open={true} actionVariant='destructive' />);
       const action = screen.getByTestId('alert-dialog-action');
-      expect(action.className).toContain('bg-[var(--color-error)]');
+      expect(action.className).toContain('bg-error');
       expect(action.className).toContain(
         'text-[var(--color-error-foreground)]'
       );

--- a/packages/ui/atoms/alert-dialog.tsx
+++ b/packages/ui/atoms/alert-dialog.tsx
@@ -12,7 +12,7 @@ import {
   titleStyles,
 } from '../lib/overlay-styles';
 import { cn } from '../lib/utils';
-import { buttonVariants } from './button';
+import { Button } from './button';
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -139,48 +139,54 @@ const AlertDialogDescription = React.forwardRef<
 AlertDialogDescription.displayName =
   AlertDialogPrimitive.Description.displayName;
 
+type AlertDialogActionVariant =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'ghost'
+  | 'link'
+  | 'destructive';
+
 interface AlertDialogActionProps
   extends React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> {
-  variant?:
-    | 'primary'
-    | 'accent'
-    | 'secondary'
-    | 'ghost'
-    | 'outline'
-    | 'destructive'
-    | 'link'
-    | 'frosted'
-    | 'frosted-ghost'
-    | 'frosted-outline';
+  readonly variant?: AlertDialogActionVariant;
+  readonly destructive?: boolean;
 }
 
 const AlertDialogAction = React.forwardRef<
   React.ComponentRef<typeof AlertDialogPrimitive.Action>,
   AlertDialogActionProps
->(({ className, variant, ...props }, ref) => (
-  <AlertDialogPrimitive.Action
-    ref={ref}
-    className={cn(buttonVariants({ variant }), className)}
-    data-testid='alert-dialog-action'
-    {...props}
-  />
-));
+>(({ className, variant = 'primary', destructive = false, ...props }, ref) => {
+  const buttonVariant = variant === 'destructive' ? 'primary' : variant;
+
+  return (
+    <Button
+      asChild
+      variant={buttonVariant}
+      destructive={destructive || variant === 'destructive'}
+      className={className}
+    >
+      <AlertDialogPrimitive.Action
+        ref={ref}
+        data-testid='alert-dialog-action'
+        {...props}
+      />
+    </Button>
+  );
+});
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
 const AlertDialogCancel = React.forwardRef<
   React.ComponentRef<typeof AlertDialogPrimitive.Cancel>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Cancel
-    ref={ref}
-    className={cn(
-      buttonVariants({ variant: 'outline' }),
-      'mt-2 sm:mt-0',
-      className
-    )}
-    data-testid='alert-dialog-cancel'
-    {...props}
-  />
+  <Button asChild variant='secondary' className={cn('mt-2 sm:mt-0', className)}>
+    <AlertDialogPrimitive.Cancel
+      ref={ref}
+      data-testid='alert-dialog-cancel'
+      {...props}
+    />
+  </Button>
 ));
 AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 

--- a/packages/ui/atoms/button.stories.tsx
+++ b/packages/ui/atoms/button.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Button> = {
     docs: {
       description: {
         component:
-          'Primary button component with comprehensive variants, loading states, and full accessibility support. Built on Radix UI Slot primitive for flexible composition.',
+          'Canonical Button component with five variants, three sizes, destructive tone, loading states, and Radix Slot composition.',
       },
     },
   },
@@ -17,24 +17,17 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     variant: {
       control: { type: 'select' },
-      options: [
-        'primary',
-        'accent',
-        'secondary',
-        'ghost',
-        'outline',
-        'destructive',
-        'link',
-        'frosted',
-        'frosted-ghost',
-        'frosted-outline',
-      ],
+      options: ['primary', 'secondary', 'tertiary', 'ghost', 'link'],
       description: 'Visual style variant',
     },
     size: {
       control: { type: 'select' },
-      options: ['default', 'sm', 'lg', 'icon'],
+      options: ['sm', 'md', 'lg', 'icon'],
       description: 'Button size',
+    },
+    destructive: {
+      control: { type: 'boolean' },
+      description: 'Apply destructive tone to the selected variant',
     },
     loading: {
       control: { type: 'boolean' },
@@ -62,17 +55,17 @@ export const Primary: Story = {
   },
 };
 
-export const NeutralAlias: Story = {
-  args: {
-    children: 'Neutral Alias',
-    variant: 'accent',
-  },
-};
-
 export const Secondary: Story = {
   args: {
     children: 'Secondary Button',
     variant: 'secondary',
+  },
+};
+
+export const Tertiary: Story = {
+  args: {
+    children: 'Tertiary Button',
+    variant: 'tertiary',
   },
 };
 
@@ -83,17 +76,11 @@ export const Ghost: Story = {
   },
 };
 
-export const Outline: Story = {
-  args: {
-    children: 'Outline Button',
-    variant: 'outline',
-  },
-};
-
 export const Destructive: Story = {
   args: {
     children: 'Delete',
-    variant: 'destructive',
+    variant: 'primary',
+    destructive: true,
   },
 };
 
@@ -101,37 +88,6 @@ export const Link: Story = {
   args: {
     children: 'Link Button',
     variant: 'link',
-  },
-};
-
-// Frosted Glass Variants
-export const Frosted: Story = {
-  args: {
-    children: 'Frosted Button',
-    variant: 'frosted',
-  },
-  parameters: {
-    backgrounds: { default: 'dark' },
-  },
-};
-
-export const FrostedGhost: Story = {
-  args: {
-    children: 'Frosted Ghost',
-    variant: 'frosted-ghost',
-  },
-  parameters: {
-    backgrounds: { default: 'dark' },
-  },
-};
-
-export const FrostedOutline: Story = {
-  args: {
-    children: 'Frosted Outline',
-    variant: 'frosted-outline',
-  },
-  parameters: {
-    backgrounds: { default: 'dark' },
   },
 };
 
@@ -143,10 +99,10 @@ export const Small: Story = {
   },
 };
 
-export const Default: Story = {
+export const Medium: Story = {
   args: {
-    children: 'Default Button',
-    size: 'default',
+    children: 'Medium Button',
+    size: 'md',
   },
 };
 
@@ -272,21 +228,31 @@ export const AllVariants: Story = {
         <h3 className='text-sm font-semibold mb-2'>Core Variants</h3>
         <div className='flex gap-2 flex-wrap'>
           <Button variant='primary'>Primary</Button>
-          <Button variant='accent'>Neutral Alias</Button>
           <Button variant='secondary'>Secondary</Button>
+          <Button variant='tertiary'>Tertiary</Button>
           <Button variant='ghost'>Ghost</Button>
-          <Button variant='outline'>Outline</Button>
-          <Button variant='destructive'>Destructive</Button>
           <Button variant='link'>Link</Button>
         </div>
       </div>
 
       <div>
-        <h3 className='text-sm font-semibold mb-2'>Frosted Variants</h3>
+        <h3 className='text-sm font-semibold mb-2'>Destructive Tone</h3>
         <div className='flex gap-2 flex-wrap'>
-          <Button variant='frosted'>Frosted</Button>
-          <Button variant='frosted-ghost'>Frosted Ghost</Button>
-          <Button variant='frosted-outline'>Frosted Outline</Button>
+          <Button variant='primary' destructive>
+            Primary
+          </Button>
+          <Button variant='secondary' destructive>
+            Secondary
+          </Button>
+          <Button variant='tertiary' destructive>
+            Tertiary
+          </Button>
+          <Button variant='ghost' destructive>
+            Ghost
+          </Button>
+          <Button variant='link' destructive>
+            Link
+          </Button>
         </div>
       </div>
 
@@ -294,7 +260,7 @@ export const AllVariants: Story = {
         <h3 className='text-sm font-semibold mb-2'>Sizes</h3>
         <div className='flex gap-2 items-center flex-wrap'>
           <Button size='sm'>Small</Button>
-          <Button size='default'>Default</Button>
+          <Button size='md'>Medium</Button>
           <Button size='lg'>Large</Button>
           <Button size='icon'>
             <svg

--- a/packages/ui/atoms/button.test.tsx
+++ b/packages/ui/atoms/button.test.tsx
@@ -2,11 +2,15 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { render, screen } from '@testing-library/react';
 import * as React from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Button } from './button';
 
 describe('Button', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('System B typography contract', () => {
     it('keeps shared button tracking neutral and non-negative', () => {
       const source = readFileSync(
@@ -21,7 +25,8 @@ describe('Button', () => {
       render(
         <>
           <Button>Primary</Button>
-          <Button variant='whitePill'>White Pill</Button>
+          <Button variant='secondary'>Secondary</Button>
+          <Button variant='tertiary'>Tertiary</Button>
         </>
       );
 
@@ -38,6 +43,15 @@ describe('Button', () => {
     expect(btn).toBeInTheDocument();
   });
 
+  it('defaults to the canonical primary md button contract', () => {
+    render(<Button>Press</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('data-variant', 'primary');
+    expect(btn).toHaveAttribute('data-size', 'md');
+    expect(btn.className).toContain('h-9');
+    expect(btn.className).toContain('bg-btn-primary');
+  });
+
   it('applies variant and size classes', () => {
     render(
       <Button variant='secondary' size='sm'>
@@ -49,20 +63,63 @@ describe('Button', () => {
     expect(btn.className).toContain('h-7');
   });
 
-  it('keeps the legacy accent variant neutral instead of accent-filled', () => {
-    const source = readFileSync(path.join(process.cwd(), 'atoms/button.tsx'), {
-      encoding: 'utf8',
-    });
-    const accentVariantSource = source.match(/accent:\s*'(?<classes>[^']+)'/)
-      ?.groups?.classes;
+  it('maps deprecated variants to canonical variants with a warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    expect(accentVariantSource).toBeDefined();
-    expect(accentVariantSource).toContain('bg-btn-primary');
-    expect(accentVariantSource).toContain('text-btn-primary-foreground');
-    expect(accentVariantSource).not.toMatch(
-      /\bbg-accent\b|text-accent-foreground|text-on-accent|hover:bg-accent|\bbg-(?:blue|purple|violet|indigo)-\d/
+    render(
+      <>
+        <Button variant='accent'>Upgrade</Button>
+        <Button variant='outline'>More</Button>
+        <Button variant='destructive'>Delete</Button>
+      </>
     );
 
+    const btn = screen.getByRole('button', { name: 'Upgrade' });
+    expect(btn).toHaveAttribute('data-variant', 'primary');
+    expect(btn).not.toHaveAttribute('data-destructive');
+    expect(screen.getByRole('button', { name: 'More' })).toHaveAttribute(
+      'data-variant',
+      'secondary'
+    );
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveAttribute(
+      'data-destructive',
+      'true'
+    );
+    expect(warn).toHaveBeenCalledWith(
+      '[Button] variant="accent" is deprecated. Use variant="primary" instead.'
+    );
+  });
+
+  it('maps deprecated sizes to canonical sizes with a warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <>
+        <Button size='default'>Default</Button>
+        <Button size='xl'>Extra Large</Button>
+        <Button size='hero'>Hero</Button>
+      </>
+    );
+
+    expect(screen.getByRole('button', { name: 'Default' })).toHaveAttribute(
+      'data-size',
+      'md'
+    );
+    expect(screen.getByRole('button', { name: 'Extra Large' })).toHaveAttribute(
+      'data-size',
+      'lg'
+    );
+    expect(screen.getByRole('button', { name: 'Hero' })).toHaveAttribute(
+      'data-size',
+      'lg'
+    );
+    expect(warn).toHaveBeenCalledWith(
+      '[Button] size="default" is deprecated. Use size="md" instead.'
+    );
+  });
+
+  it('keeps the legacy accent alias neutral instead of accent-filled', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     render(<Button variant='accent'>Upgrade</Button>);
     const btn = screen.getByRole('button', { name: 'Upgrade' });
     expect(btn.className).toContain('bg-btn-primary');
@@ -105,6 +162,26 @@ describe('Button', () => {
     expect(btn.className).toContain('hover:border-(--linear-border-default)');
   });
 
+  it.each([
+    'primary',
+    'secondary',
+    'tertiary',
+    'ghost',
+    'link',
+  ] as const)('applies destructive styling to the %s variant through a prop', variant => {
+    render(
+      <Button variant={variant} destructive>
+        Delete
+      </Button>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('data-variant', variant);
+    expect(btn).toHaveAttribute('data-destructive', 'true');
+    expect(btn.className).toContain(
+      variant === 'primary' ? 'bg-error' : 'text-error'
+    );
+  });
+
   it('forwards refs', () => {
     const ref = React.createRef<HTMLButtonElement>();
     render(<Button ref={ref}>Hi</Button>);
@@ -129,20 +206,6 @@ describe('Button', () => {
     render(<Button loading>Load</Button>);
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
     expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true');
-  });
-  it('applies xl size classes', () => {
-    render(<Button size='xl'>Press</Button>);
-    const btn = screen.getByRole('button');
-    expect(btn.className).toContain('h-12');
-    expect(btn.className).toContain('rounded-full');
-  });
-
-  it('applies hero size classes', () => {
-    render(<Button size='hero'>Press</Button>);
-    const btn = screen.getByRole('button');
-    expect(btn.className).toContain('h-14');
-    expect(btn.className).toContain('rounded-full');
-    expect(btn.className).toContain('font-semibold');
   });
   // href prop removed; use asChild with an anchor element instead
 });

--- a/packages/ui/atoms/button.tsx
+++ b/packages/ui/atoms/button.tsx
@@ -10,59 +10,162 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        // Core variants — Linear-aligned shadows and radii
         primary:
-          'border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset hover:border-(--linear-btn-primary-hover) hover:bg-(--linear-btn-primary-hover)',
-        // EVENT: central actions stay neutral; keep this legacy variant as a
-        // primary alias so old callers do not render accent-filled CTAs.
-        accent:
           'border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset hover:border-(--linear-btn-primary-hover) hover:bg-(--linear-btn-primary-hover)',
         secondary:
           'border border-(--linear-border-subtle) bg-btn-secondary text-btn-secondary-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_1px_1px_rgba(0,0,0,0.08)] hover:border-(--linear-border-default) hover:bg-(--linear-btn-secondary-hover)',
+        tertiary:
+          'border border-transparent bg-transparent text-secondary-token shadow-none hover:bg-interactive-hover hover:text-primary-token active:bg-interactive-active',
         ghost:
-          'hover:bg-interactive-hover active:bg-interactive-active text-secondary-token hover:text-primary-token',
-        outline:
-          'border border-default bg-transparent hover:bg-surface-hover active:bg-interactive-active shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]',
-        // Destructive variant
-        destructive:
-          'bg-[var(--color-error)] text-[var(--color-error-foreground)] hover:opacity-90',
-        // Link variant
-        link: 'text-primary underline-offset-4 hover:underline p-0 h-auto',
-        // Frosted glass variants (glassmorphism) - using design tokens
-        frosted:
-          'backdrop-blur-sm bg-surface-0/60 dark:bg-surface-1/30 hover:bg-surface-1/80 dark:hover:bg-surface-2/40 border border-subtle',
-        'frosted-ghost':
-          'backdrop-blur-sm bg-surface-0/30 dark:bg-surface-1/10 hover:bg-surface-1/50 dark:hover:bg-surface-2/20 border border-subtle',
-        'frosted-outline':
-          'backdrop-blur-sm bg-transparent border border-subtle hover:bg-surface-1/20 dark:hover:bg-surface-2/10',
-        // Canonical white pill CTA — high-contrast hero/auth pill used across
-        // marketing headers and homepage sign-in.
-        whitePill:
-          'border border-white/88 bg-white text-black shadow-[0_8px_20px_rgba(0,0,0,0.14),inset_0_1px_0_rgba(255,255,255,0.72)] hover:bg-white/95 font-medium tracking-normal sm:shadow-[0_10px_24px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.72)]',
+          'border border-transparent bg-transparent text-tertiary-token shadow-none hover:bg-interactive-hover hover:text-primary-token active:bg-interactive-active',
+        link: 'h-auto border-0 bg-transparent p-0 text-primary underline-offset-4 shadow-none hover:underline',
       },
       size: {
-        default:
-          'h-8 px-3 py-1.5 before:absolute before:left-1/2 before:top-1/2 before:h-10 before:min-w-10 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
         sm: 'h-7 px-2.5 text-xs before:absolute before:left-1/2 before:top-1/2 before:h-10 before:min-w-10 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
-        lg: 'h-10 px-4 py-2 text-sm',
-        xl: 'h-12 px-6 py-3 text-sm',
-        hero: 'h-14 px-10 py-4 text-base font-semibold',
-        icon: 'h-10 w-10',
+        md: 'h-9 px-3 text-[13px] before:absolute before:left-1/2 before:top-1/2 before:h-11 before:min-w-11 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
+        lg: 'h-11 px-5 text-sm before:absolute before:left-1/2 before:top-1/2 before:h-11 before:min-w-11 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
+        icon: 'h-9 w-9 px-0 before:absolute before:left-1/2 before:top-1/2 before:h-11 before:w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
       },
     },
+    compoundVariants: [
+      {
+        variant: 'link',
+        size: ['sm', 'md', 'lg', 'icon'],
+        className:
+          'h-auto min-h-0 w-auto min-w-0 px-0 py-0 before:hidden disabled:opacity-60',
+      },
+    ],
     defaultVariants: {
       variant: 'primary',
-      size: 'default',
+      size: 'md',
     },
   }
 );
 
+type CanonicalButtonVariantProps = VariantProps<typeof buttonVariants>;
+export type ButtonVariant = NonNullable<CanonicalButtonVariantProps['variant']>;
+export type ButtonSize = NonNullable<CanonicalButtonVariantProps['size']>;
+
+type DeprecatedButtonVariant =
+  | 'accent'
+  | 'outline'
+  | 'destructive'
+  | 'frosted'
+  | 'frosted-ghost'
+  | 'frosted-outline'
+  | 'whitePill';
+type DeprecatedButtonSize = 'default' | 'xl' | 'hero';
+
+const DEPRECATED_VARIANT_ALIASES: Record<
+  DeprecatedButtonVariant,
+  ButtonVariant
+> = {
+  accent: 'primary',
+  outline: 'secondary',
+  destructive: 'primary',
+  frosted: 'secondary',
+  'frosted-ghost': 'ghost',
+  'frosted-outline': 'secondary',
+  whitePill: 'primary',
+};
+
+const DEPRECATED_SIZE_ALIASES: Record<DeprecatedButtonSize, ButtonSize> = {
+  default: 'md',
+  xl: 'lg',
+  hero: 'lg',
+};
+
+const DESTRUCTIVE_CLASSES: Record<ButtonVariant, string> = {
+  primary:
+    'border-error bg-error text-[var(--color-error-foreground)] hover:border-error/90 hover:bg-error/90',
+  secondary:
+    'border-error/30 bg-error-subtle text-error hover:border-error/45 hover:bg-error-subtle hover:text-error',
+  tertiary: 'text-error hover:bg-error-subtle hover:text-error',
+  ghost: 'text-error hover:bg-error-subtle hover:text-error',
+  link: 'text-error hover:text-error',
+};
+
+const warnedDeprecatedValues = new Set<string>();
+
+function isProductionEnvironment(): boolean {
+  return (
+    (
+      globalThis as {
+        readonly process?: {
+          readonly env?: { readonly NODE_ENV?: string };
+        };
+      }
+    ).process?.env?.NODE_ENV === 'production'
+  );
+}
+
+function warnDeprecatedButtonValue(
+  kind: 'variant' | 'size',
+  value: string,
+  replacement: string
+): void {
+  if (isProductionEnvironment()) return;
+  const key = `${kind}:${value}`;
+  if (warnedDeprecatedValues.has(key)) return;
+  warnedDeprecatedValues.add(key);
+  console.warn(
+    `[Button] ${kind}="${value}" is deprecated. Use ${kind}="${replacement}" instead.`
+  );
+}
+
+function isDeprecatedButtonVariant(
+  variant: ButtonVariant | DeprecatedButtonVariant
+): variant is DeprecatedButtonVariant {
+  return variant in DEPRECATED_VARIANT_ALIASES;
+}
+
+function isDeprecatedButtonSize(
+  size: ButtonSize | DeprecatedButtonSize
+): size is DeprecatedButtonSize {
+  return size in DEPRECATED_SIZE_ALIASES;
+}
+
+function normalizeButtonVariant({
+  variant,
+  destructive,
+}: {
+  readonly variant?: ButtonVariant | DeprecatedButtonVariant | null;
+  readonly destructive: boolean;
+}): { readonly variant: ButtonVariant; readonly destructive: boolean } {
+  const requested = variant ?? 'primary';
+  if (!isDeprecatedButtonVariant(requested)) {
+    return { variant: requested, destructive };
+  }
+
+  const replacement = DEPRECATED_VARIANT_ALIASES[requested];
+  warnDeprecatedButtonValue('variant', requested, replacement);
+  return {
+    variant: replacement,
+    destructive: destructive || requested === 'destructive',
+  };
+}
+
+function normalizeButtonSize(
+  size?: ButtonSize | DeprecatedButtonSize | null
+): ButtonSize {
+  const requested = size ?? 'md';
+  if (!isDeprecatedButtonSize(requested)) {
+    return requested;
+  }
+
+  const replacement = DEPRECATED_SIZE_ALIASES[requested];
+  warnDeprecatedButtonValue('size', requested, replacement);
+  return replacement;
+}
+
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'size'> {
+  readonly variant?: ButtonVariant | DeprecatedButtonVariant | null;
+  readonly size?: ButtonSize | DeprecatedButtonSize | null;
   readonly asChild?: boolean;
   readonly loading?: boolean;
   readonly static?: boolean;
+  readonly destructive?: boolean;
 }
 
 // Helper to compute data-state attribute
@@ -95,7 +198,7 @@ function ButtonContent({
   return (
     <span
       className={cn(
-        'inline-flex items-center gap-1.5',
+        'inline-flex items-center justify-center gap-1.5',
         loading ? 'opacity-0' : 'opacity-100'
       )}
     >
@@ -113,6 +216,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       asChild = false,
       loading = false,
       static: isStatic = false,
+      destructive = false,
       disabled,
       children,
       ...props
@@ -122,17 +226,31 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : 'button';
     const isDisabled = disabled || loading;
     const dataState = getDataState(loading, isDisabled);
+    const normalizedVariant = normalizeButtonVariant({
+      variant,
+      destructive,
+    });
+    const normalizedSize = normalizeButtonSize(size);
 
     const sharedProps = {
       ref,
       className: cn(
-        buttonVariants({ variant, size, className }),
+        buttonVariants({
+          variant: normalizedVariant.variant,
+          size: normalizedSize,
+        }),
+        normalizedVariant.destructive &&
+          DESTRUCTIVE_CLASSES[normalizedVariant.variant],
+        className,
         !isStatic && !isDisabled && 'active:scale-[0.96]',
         isDisabled && 'pointer-events-none'
       ),
       'aria-disabled': isDisabled || undefined,
       'aria-busy': loading || undefined,
       'data-state': dataState,
+      'data-variant': normalizedVariant.variant,
+      'data-size': normalizedSize,
+      'data-destructive': normalizedVariant.destructive ? 'true' : undefined,
     };
 
     // In asChild mode (Radix Slot), React.Children.only requires a single child.


### PR DESCRIPTION
## Summary

DS_FOUNDATION_V1 Wave 1 Button canon stack slice 5/9.

Migrate chat composer, profile-preview phone, and thread play controls off system-b CSS.

Size: 4 files, +41/-97.

## Stack

#12830 -> #12831 -> #12832 -> #12833 -> #12834 -> #12835 -> #12836 -> #12837 -> #12838

## Local Verification

- pnpm --filter @jovie/ui exec vitest run atoms/button.test.tsx atoms/alert-dialog.test.tsx
- pnpm --filter @jovie/web lint:button-canon-ratchet
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web exec vitest run focused migrated-surface tests (11 files, 92 tests passed; jsdom printed HTMLMediaElement.pause not-implemented noise but exit code was 0)
- biome check --write on all 37 changed files
- rg scan: no system-b-*-button matches in apps/web/app, apps/web/components, or apps/web/styles/design-system.css on the top branch

bug-to-test: not applicable — design-system feature/refactor stack with targeted component and surface guard tests.

## Visual Evidence

![Canonical Button visual evidence](https://gist.githubusercontent.com/itstimwhite/cb803281120e5d4cd3a397a315e0007e/raw/130594180afe8812100e60518dd84c10f3ef185a/jovie-button-canon-12830.svg)

Stack evidence captured locally from `http://localhost:3010/ui/buttons` on the rebased stack. Playwright verified rendered `data-variant` values: `primary`, `secondary`, `tertiary`, `ghost`, `link`; destructive appears as `data-destructive`, not as a variant.
