### PR TITLE
refactor(ui): migrate library buttons

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
@@ -456,41 +457,47 @@ export function CalendarPageClient() {
         <div className='flex h-full min-h-0 flex-col gap-4'>
           <div className='flex flex-wrap items-center justify-between gap-2'>
             <div className='system-b-calendar-month-control inline-flex min-w-0 items-center gap-1'>
-              <button
+              <Button
                 type='button'
+                variant='ghost'
+                size='icon'
                 onClick={() => {
                   const next = new Date(cursor);
                   next.setMonth(cursor.getMonth() - 1);
                   setCursor(startOfMonth(next));
                 }}
-                className='system-b-calendar-icon-button grid h-7 w-7 place-items-center transition-colors duration-subtle ease-subtle'
+                className='system-b-calendar-action-ghost h-7 w-7 transition-colors duration-subtle ease-subtle'
                 aria-label='Previous Month'
               >
                 <ChevronLeft className='h-4 w-4' strokeWidth={2.25} />
-              </button>
+              </Button>
               <h2 className='system-b-calendar-month-label'>
                 {MONTH_NAMES[cursor.getMonth()]} {cursor.getFullYear()}
               </h2>
-              <button
+              <Button
                 type='button'
+                variant='ghost'
+                size='icon'
                 onClick={() => {
                   const next = new Date(cursor);
                   next.setMonth(cursor.getMonth() + 1);
                   setCursor(startOfMonth(next));
                 }}
-                className='system-b-calendar-icon-button grid h-7 w-7 place-items-center transition-colors duration-subtle ease-subtle'
+                className='system-b-calendar-action-ghost h-7 w-7 transition-colors duration-subtle ease-subtle'
                 aria-label='Next Month'
               >
                 <ChevronRight className='h-4 w-4' strokeWidth={2.25} />
-              </button>
+              </Button>
             </div>
-            <button
+            <Button
               type='button'
+              variant='ghost'
+              size='sm'
               onClick={() => setCursor(startOfMonth(new Date()))}
-              className='system-b-calendar-toolbar-button h-7 px-3 font-caption transition-colors duration-subtle ease-subtle'
+              className='system-b-calendar-action-ghost h-7 px-3 font-caption transition-colors duration-subtle ease-subtle'
             >
               Today
-            </button>
+            </Button>
           </div>
 
           <div className='system-b-calendar-panel overflow-hidden'>

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -785,18 +785,25 @@ function LibrarySavedViewRow({
   readonly onClick: () => void;
 }) {
   return (
-    <button
-      type='button'
-      onClick={onClick}
-      aria-pressed={active}
+    <Button
+      asChild
+      variant={active ? 'secondary' : 'tertiary'}
+      size='sm'
+      static
       className={cn(
-        'system-b-library-rail-button flex h-7 w-full items-center gap-2 border px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface) outline-none',
-        active && 'system-b-library-rail-button--active'
+        'flex h-7 w-full items-center justify-start gap-2 border px-2 transition-colors duration-fast ease-subtle focus-visible:ring-offset-(--linear-app-content-surface)',
+        active
+          ? 'border-default bg-surface-1 text-primary-token'
+          : 'border-transparent text-secondary-token hover:border-default hover:bg-surface-1 hover:text-primary-token'
       )}
     >
-      <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
-      <span className='system-b-library-rail-count tabular-nums'>{count}</span>
-    </button>
+      <button type='button' onClick={onClick} aria-pressed={active}>
+        <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
+        <span className='system-b-library-rail-count tabular-nums'>
+          {count}
+        </span>
+      </button>
+    </Button>
   );
 }
 
@@ -879,13 +886,15 @@ function LibraryRail({
         <div className='flex items-center justify-between gap-2 border-t border-subtle pb-1 pt-2'>
           <p className='system-b-library-rail-title'>Filters</p>
           {hasActiveFilters(filters) ? (
-            <button
+            <Button
               type='button'
+              variant='tertiary'
+              size='sm'
               onClick={onClearFilters}
-              className='system-b-library-clear-button px-1.5 py-0.5'
+              className='h-auto rounded-xs px-1.5 py-0.5 text-tertiary-token hover:bg-surface-1 hover:text-primary-token'
             >
               Clear Filters ({activeFilterCount})
-            </button>
+            </Button>
           ) : null}
         </div>
 
@@ -1004,23 +1013,30 @@ function FilterSection({
 
   return (
     <div className='pt-2'>
-      <button
-        id={buttonId}
-        type='button'
-        aria-controls={panelId}
-        aria-expanded={open}
-        onClick={() => setOpen(value => !value)}
-        className='system-b-library-filter-section-button flex h-6 w-full items-center justify-between px-1'
+      <Button
+        asChild
+        variant='tertiary'
+        size='sm'
+        static
+        className='flex h-6 w-full items-center justify-between px-1 font-medium text-tertiary-token hover:bg-surface-1 hover:text-primary-token'
       >
-        <span>{label}</span>
-        <ChevronDown
-          className={cn(
-            'h-3 w-3 transition-transform duration-subtle ease-subtle',
-            !open && '-rotate-90'
-          )}
-          aria-hidden='true'
-        />
-      </button>
+        <button
+          id={buttonId}
+          type='button'
+          aria-controls={panelId}
+          aria-expanded={open}
+          onClick={() => setOpen(value => !value)}
+        >
+          <span>{label}</span>
+          <ChevronDown
+            className={cn(
+              'h-3 w-3 transition-transform duration-subtle ease-subtle',
+              !open && '-rotate-90'
+            )}
+            aria-hidden='true'
+          />
+        </button>
+      </Button>
       {open ? (
         <section
           id={panelId}
@@ -1310,74 +1326,81 @@ const AssetCard = memo(function AssetCard({
           className='system-b-library-card-selected-frame pointer-events-none absolute inset-0'
         />
       ) : null}
-      <button
-        type='button'
-        onClick={onSelect}
-        aria-label={`View ${asset.title}`}
+      <Button
+        asChild
+        variant='tertiary'
+        size='sm'
+        static
         className={cn(
-          'system-b-library-card-button flex h-full w-full flex-col text-left',
+          'flex h-full w-full flex-col items-stretch justify-start rounded-none p-0 text-left transition-colors duration-fast ease-subtle hover:bg-transparent active:bg-transparent',
           LIBRARY_CARD_FOCUS_CLASS
         )}
       >
-        <div
-          className={cn(
-            'system-b-library-card-artwork relative overflow-hidden',
-            getLibraryAspectRatioClass(aspectRatio)
-          )}
+        <button
+          type='button'
+          onClick={onSelect}
+          aria-label={`View ${asset.title}`}
         >
-          <LibraryMediaThumbnail asset={asset} size='card' />
-          <span
+          <div
             className={cn(
-              'system-b-library-card-status absolute left-2 top-2 border px-1.5 py-0.5 leading-4',
-              libraryApprovalStatusClasses(asset.approvalStatus)
+              'system-b-library-card-artwork relative overflow-hidden',
+              getLibraryAspectRatioClass(aspectRatio)
             )}
-            data-testid={`library-approval-status-${asset.id}`}
           >
-            {formatLibraryApprovalStatus(asset.approvalStatus)}
-          </span>
-        </div>
-        <div className='min-w-0 p-3'>
-          <div className='flex min-w-0 items-start justify-between gap-2'>
-            <div className='min-w-0'>
-              <h2 className='system-b-library-card-title truncate'>
-                {asset.title}
-              </h2>
-              <p className='system-b-library-card-meta mt-0.5 truncate'>
-                {asset.artist}
-              </p>
-            </div>
-            <span className='system-b-library-card-count shrink-0 tabular-nums'>
-              {getLibraryItemKind(asset) === 'merch'
-                ? (asset.salePriceLabel ?? 'Merch')
-                : formatCompactCount(asset.providerCount)}
+            <LibraryMediaThumbnail asset={asset} size='card' />
+            <span
+              className={cn(
+                'system-b-library-card-status absolute left-2 top-2 border px-1.5 py-0.5 leading-4',
+                libraryApprovalStatusClasses(asset.approvalStatus)
+              )}
+              data-testid={`library-approval-status-${asset.id}`}
+            >
+              {formatLibraryApprovalStatus(asset.approvalStatus)}
             </span>
           </div>
-          <div className='system-b-library-card-summary mt-2 flex min-w-0 items-center gap-1.5'>
-            {getLibraryItemKind(asset) === 'merch' ? (
-              <Shirt className='h-3 w-3 shrink-0' />
-            ) : (
-              <Disc3 className='h-3 w-3 shrink-0' />
-            )}
-            <span>{formatLibraryItemType(asset)}</span>
-            {getLibraryItemKind(asset) === 'release' ? (
-              <>
-                <span className='opacity-50'>.</span>
-                <span>{asset.trackCount} Tracks</span>
-              </>
-            ) : null}
-          </div>
-          <div className='mt-3 flex flex-wrap gap-1.5'>
-            {asset.assetKinds.slice(0, 3).map(kind => (
-              <AssetKindPill key={kind} kind={kind} />
-            ))}
-            {asset.assetKinds.length > 3 ? (
-              <span className='system-b-library-card-more-pill inline-flex h-6 items-center px-2'>
-                +{asset.assetKinds.length - 3}
+          <div className='min-w-0 p-3'>
+            <div className='flex min-w-0 items-start justify-between gap-2'>
+              <div className='min-w-0'>
+                <h2 className='system-b-library-card-title truncate'>
+                  {asset.title}
+                </h2>
+                <p className='system-b-library-card-meta mt-0.5 truncate'>
+                  {asset.artist}
+                </p>
+              </div>
+              <span className='system-b-library-card-count shrink-0 tabular-nums'>
+                {getLibraryItemKind(asset) === 'merch'
+                  ? (asset.salePriceLabel ?? 'Merch')
+                  : formatCompactCount(asset.providerCount)}
               </span>
-            ) : null}
+            </div>
+            <div className='system-b-library-card-summary mt-2 flex min-w-0 items-center gap-1.5'>
+              {getLibraryItemKind(asset) === 'merch' ? (
+                <Shirt className='h-3 w-3 shrink-0' />
+              ) : (
+                <Disc3 className='h-3 w-3 shrink-0' />
+              )}
+              <span>{formatLibraryItemType(asset)}</span>
+              {getLibraryItemKind(asset) === 'release' ? (
+                <>
+                  <span className='opacity-50'>.</span>
+                  <span>{asset.trackCount} Tracks</span>
+                </>
+              ) : null}
+            </div>
+            <div className='mt-3 flex flex-wrap gap-1.5'>
+              {asset.assetKinds.slice(0, 3).map(kind => (
+                <AssetKindPill key={kind} kind={kind} />
+              ))}
+              {asset.assetKinds.length > 3 ? (
+                <span className='system-b-library-card-more-pill inline-flex h-6 items-center px-2'>
+                  +{asset.assetKinds.length - 3}
+                </span>
+              ) : null}
+            </div>
           </div>
-        </div>
-      </button>
+        </button>
+      </Button>
       {hasPreview ? (
         <button
           type='button'

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -6194,8 +6194,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 :where(.system-b-library-artwork-shell),
 :where(.system-b-library-status-pill),
 :where(.system-b-library-count-pill),
-:where(.system-b-library-rail-button),
-:where(.system-b-library-filter-section-button),
 :where(.system-b-library-filter-row),
 :where(.system-b-library-kind-pill),
 :where(.system-b-library-provider-link) {
@@ -6204,8 +6202,7 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 
 /* Buttons + icon buttons are pill / hover-circle per System B (DESIGN.md:
    App buttons, inputs, controls → 9999px). */
-:where(.system-b-library-action),
-:where(.system-b-library-icon-button) {
+:where(.system-b-library-action) {
   border-radius: var(--radius-full);
 }
 
@@ -6289,7 +6286,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 
 :where(.system-b-library-filter-pill),
 :where(.system-b-library-rail-count),
-:where(.system-b-library-clear-button),
 :where(.system-b-library-filter-count),
 :where(.system-b-library-card-count),
 :where(.system-b-library-audio-hint),
@@ -6298,30 +6294,23 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   font-size: var(--text-2xs);
 }
 
-:where(.system-b-library-rail-button),
 :where(.system-b-library-filter-row),
 :where(.system-b-library-action),
-:where(.system-b-library-icon-button),
 :where(.system-b-library-provider-link) {
   transition-duration: var(--duration-fast);
   transition-property: background-color, border-color, box-shadow, color;
   transition-timing-function: var(--ease-subtle);
 }
 
-:where(.system-b-library-rail-button),
 :where(.system-b-library-filter-row) {
   color: var(--color-text-secondary-token);
   font-size: var(--text-xs);
 }
 
-:where(
-  .system-b-library-rail-button:not(.system-b-library-rail-button--active)
-),
 :where(.system-b-library-filter-row:not(.system-b-library-filter-row--active)) {
   border-color: transparent;
 }
 
-:where(.system-b-library-rail-button--active),
 :where(.system-b-library-filter-row--active) {
   border-color: var(--color-border-default);
   background: var(--system-b-bg-surface-1);
@@ -6329,38 +6318,9 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(
-  .system-b-library-rail-button:not(.system-b-library-rail-button--active):hover
-),
-:where(
   .system-b-library-filter-row:not(.system-b-library-filter-row--active):hover
 ) {
   border-color: var(--color-border-default);
-  background: var(--system-b-bg-surface-1);
-  color: var(--color-text-primary-token);
-}
-
-:where(.system-b-library-clear-button) {
-  border-radius: var(--radius-xs);
-  transition-duration: var(--duration-fast);
-  transition-property: background-color, color;
-  transition-timing-function: var(--ease-subtle);
-}
-
-:where(.system-b-library-clear-button:hover) {
-  background: var(--system-b-bg-surface-1);
-  color: var(--color-text-primary-token);
-}
-
-:where(.system-b-library-filter-section-button) {
-  color: var(--color-text-tertiary-token);
-  font-size: var(--text-2xs);
-  font-weight: var(--font-weight-medium);
-  transition-duration: var(--duration-fast);
-  transition-property: background-color, color;
-  transition-timing-function: var(--ease-subtle);
-}
-
-:where(.system-b-library-filter-section-button:hover) {
   background: var(--system-b-bg-surface-1);
   color: var(--color-text-primary-token);
 }
@@ -6425,12 +6385,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   box-shadow:
     inset 2px 0 0 0 var(--color-border-default),
     inset 0 0 0 1px var(--color-border-subtle);
-}
-
-:where(.system-b-library-card-button) {
-  transition-duration: var(--duration-fast);
-  transition-property: background-color, box-shadow;
-  transition-timing-function: var(--ease-subtle);
 }
 
 :where(.system-b-library-card-status) {
@@ -6600,8 +6554,7 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 
 /* Issue #12317 — System B compliance: pill action buttons + borderless
    circular icon buttons. Overrides the shared --radius-md primitive above. */
-:where(.system-b-library-action),
-:where(.system-b-library-icon-button) {
+:where(.system-b-library-action) {
   border-radius: var(--radius-full);
 }
 
@@ -6676,22 +6629,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 :where(.system-b-library-drawer-kicker) {
   color: var(--color-text-primary-token);
   font-weight: var(--font-weight-semibold);
-}
-
-/* Borderless icon buttons; the round hover background reads as a hover-circle. */
-:where(.system-b-library-icon-button) {
-  border-radius: var(--radius-full);
-  color: var(--color-text-tertiary-token);
-}
-
-:where(.system-b-library-icon-button:hover) {
-  background: var(--system-b-bg-surface-1);
-  color: var(--color-text-primary-token);
-}
-
-:where(.system-b-library-icon-button--bordered:hover) {
-  border-color: var(--color-border-default);
-  background: var(--system-b-bg-surface-2);
 }
 
 :where(.system-b-library-drawer-artwork) {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -6676,18 +6676,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   background: var(--system-b-bg-surface-1);
 }
 
-:where(.system-b-calendar-icon-button),
-:where(.system-b-calendar-toolbar-button) {
-  border-radius: var(--radius-pill);
-  color: var(--color-text-tertiary-token);
-}
-
-:where(.system-b-calendar-icon-button:hover),
-:where(.system-b-calendar-toolbar-button:hover) {
-  background: var(--system-b-bg-surface-0);
-  color: var(--color-text-primary-token);
-}
-
 :where(.system-b-calendar-panel) {
   border: 1px solid var(--system-b-app-frame-seam);
   border-radius: var(--radius-lg);
@@ -6703,7 +6691,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   border-bottom: 1px solid var(--system-b-app-frame-seam);
 }
 
-:where(.system-b-calendar-toolbar-button),
 :where(.system-b-calendar-detail-section-heading),
 :where(.system-b-calendar-warning-heading),
 :where(.system-b-calendar-error-text),

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -244,7 +244,7 @@ describe('LibrarySurface', () => {
     expect(source).toContain('releaseStatusClasses');
     expect(source).toContain('libraryApprovalStatusClasses');
     expect(source).toContain('system-b-library-filter-pill-active');
-    expect(source).toContain('system-b-library-rail-button--active');
+    expect(source).toContain("variant={active ? 'secondary' : 'tertiary'}");
     expect(source).toContain('system-b-library-card--selected');
     expect(source).toContain('system-b-library-table-row-selected');
     expect(source).toContain('ReleaseAudioAssetPanel');

--- a/apps/web/tests/unit/library/library-system-b-compliance.test.ts
+++ b/apps/web/tests/unit/library/library-system-b-compliance.test.ts
@@ -57,10 +57,11 @@ describe('library right-rail System B structural compliance', () => {
     );
   });
 
-  it('makes library buttons and icon buttons pill / hover-circle', () => {
+  it('keeps remaining library action buttons pill-shaped and retires old icon button CSS', () => {
     expect(css).toMatch(
-      /:where\(\.system-b-library-action\),\s*:where\(\.system-b-library-icon-button\)\s*\{\s*border-radius: var\(--radius-full\);/
+      /:where\(\.system-b-library-action\)\s*\{\s*border-radius: var\(--radius-full\);/
     );
+    expect(css).not.toContain('system-b-library-icon-button');
   });
 
   it('edits approval status inline in Details without a native select', () => {


### PR DESCRIPTION
## Summary

DS_FOUNDATION_V1 Wave 1 Button canon stack slice 6/9.

Migrate library rail, filter, clear, icon, and card buttons off system-b CSS.

Size: 4 files, +113/-152.

## Stack

#12830 -> #12831 -> #12832 -> #12833 -> #12834 -> #12835 -> #12836 -> #12837 -> #12838

## Local Verification

- pnpm --filter @jovie/ui exec vitest run atoms/button.test.tsx atoms/alert-dialog.test.tsx
- pnpm --filter @jovie/web lint:button-canon-ratchet
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web exec vitest run focused migrated-surface tests (11 files, 92 tests passed; jsdom printed HTMLMediaElement.pause not-implemented noise but exit code was 0)
- biome check --write on all 37 changed files
- rg scan: no system-b-*-button matches in apps/web/app, apps/web/components, or apps/web/styles/design-system.css on the top branch

bug-to-test: not applicable — design-system feature/refactor stack with targeted component and surface guard tests.

## Visual Evidence

![Canonical Button visual evidence](https://gist.githubusercontent.com/itstimwhite/cb803281120e5d4cd3a397a315e0007e/raw/130594180afe8812100e60518dd84c10f3ef185a/jovie-button-canon-12830.svg)

Stack evidence captured locally from `http://localhost:3010/ui/buttons` on the rebased stack. Playwright verified rendered `data-variant` values: `primary`, `secondary`, `tertiary`, `ghost`, `link`; destructive appears as `data-destructive`, not as a variant.
