### PR TITLE
refactor(ui): migrate calendar buttons

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
@@ -456,41 +457,47 @@ export function CalendarPageClient() {
         <div className='flex h-full min-h-0 flex-col gap-4'>
           <div className='flex flex-wrap items-center justify-between gap-2'>
             <div className='system-b-calendar-month-control inline-flex min-w-0 items-center gap-1'>
-              <button
+              <Button
                 type='button'
+                variant='ghost'
+                size='icon'
                 onClick={() => {
                   const next = new Date(cursor);
                   next.setMonth(cursor.getMonth() - 1);
                   setCursor(startOfMonth(next));
                 }}
-                className='system-b-calendar-icon-button grid h-7 w-7 place-items-center transition-colors duration-subtle ease-subtle'
+                className='system-b-calendar-action-ghost h-7 w-7 transition-colors duration-subtle ease-subtle'
                 aria-label='Previous Month'
               >
                 <ChevronLeft className='h-4 w-4' strokeWidth={2.25} />
-              </button>
+              </Button>
               <h2 className='system-b-calendar-month-label'>
                 {MONTH_NAMES[cursor.getMonth()]} {cursor.getFullYear()}
               </h2>
-              <button
+              <Button
                 type='button'
+                variant='ghost'
+                size='icon'
                 onClick={() => {
                   const next = new Date(cursor);
                   next.setMonth(cursor.getMonth() + 1);
                   setCursor(startOfMonth(next));
                 }}
-                className='system-b-calendar-icon-button grid h-7 w-7 place-items-center transition-colors duration-subtle ease-subtle'
+                className='system-b-calendar-action-ghost h-7 w-7 transition-colors duration-subtle ease-subtle'
                 aria-label='Next Month'
               >
                 <ChevronRight className='h-4 w-4' strokeWidth={2.25} />
-              </button>
+              </Button>
             </div>
-            <button
+            <Button
               type='button'
+              variant='ghost'
+              size='sm'
               onClick={() => setCursor(startOfMonth(new Date()))}
-              className='system-b-calendar-toolbar-button h-7 px-3 font-caption transition-colors duration-subtle ease-subtle'
+              className='system-b-calendar-action-ghost h-7 px-3 font-caption transition-colors duration-subtle ease-subtle'
             >
               Today
-            </button>
+            </Button>
           </div>
 
           <div className='system-b-calendar-panel overflow-hidden'>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -6676,18 +6676,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   background: var(--system-b-bg-surface-1);
 }
 
-:where(.system-b-calendar-icon-button),
-:where(.system-b-calendar-toolbar-button) {
-  border-radius: var(--radius-pill);
-  color: var(--color-text-tertiary-token);
-}
-
-:where(.system-b-calendar-icon-button:hover),
-:where(.system-b-calendar-toolbar-button:hover) {
-  background: var(--system-b-bg-surface-0);
-  color: var(--color-text-primary-token);
-}
-
 :where(.system-b-calendar-panel) {
   border: 1px solid var(--system-b-app-frame-seam);
   border-radius: var(--radius-lg);
@@ -6703,7 +6691,6 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   border-bottom: 1px solid var(--system-b-app-frame-seam);
 }
 
-:where(.system-b-calendar-toolbar-button),
 :where(.system-b-calendar-detail-section-heading),
 :where(.system-b-calendar-warning-heading),
 :where(.system-b-calendar-error-text),


### PR DESCRIPTION
## Summary

DS_FOUNDATION_V1 Wave 1 Button canon stack slice 7/9.

Migrate calendar icon and toolbar buttons off system-b CSS.

Size: 2 files, +16/-22.

## Stack

#12830 -> #12831 -> #12832 -> #12833 -> #12834 -> #12835 -> #12836 -> #12837 -> #12838

## Local Verification

- pnpm --filter @jovie/ui exec vitest run atoms/button.test.tsx atoms/alert-dialog.test.tsx
- pnpm --filter @jovie/web lint:button-canon-ratchet
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web exec vitest run focused migrated-surface tests (11 files, 92 tests passed; jsdom printed HTMLMediaElement.pause not-implemented noise but exit code was 0)
- biome check --write on all 37 changed files
- rg scan: no system-b-*-button matches in apps/web/app, apps/web/components, or apps/web/styles/design-system.css on the top branch

bug-to-test: not applicable — design-system feature/refactor stack with targeted component and surface guard tests.

## Visual Evidence

![Canonical Button visual evidence](https://gist.githubusercontent.com/itstimwhite/cb803281120e5d4cd3a397a315e0007e/raw/130594180afe8812100e60518dd84c10f3ef185a/jovie-button-canon-12830.svg)

Stack evidence captured locally from `http://localhost:3010/ui/buttons` on the rebased stack. Playwright verified rendered `data-variant` values: `primary`, `secondary`, `tertiary`, `ghost`, `link`; destructive appears as `data-destructive`, not as a variant.
