### PR TITLE
fix(hermes): skip type:epic issues in codex shipper to stop claim/release loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] Codex issue shipper now skips `type:epic` pointer issues (they have no code of their own), fixing the claim/find-nothing/release/re-claim loop on epics like #12729. Adds a `skippedEpic` scan counter. (#12846)
 - [internal] Schedule the codex kanban ship loop via Houston launchd (`co.jovie.hermes.cron-codex-kanban-ship`, every 15m) with PAUSE-respecting `scripts/hermes/ship-loop.sh`.
 
 > Connector enrichment turns synced Gmail and Calendar objects into graph facts and calendar suggestions; assistant chat replies surface entity mentions as subdued accent spans that reveal detail cards on hover.

--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -6,8 +6,8 @@
  * eligible issue, writes dispatch context to gbrain, then starts a
  * coder-profile agent to ship it.
  *
- * Issues labeled `no-auto` or already claimed/blocked are excluded.
- * All other open issues are dispatchable.
+ * Issues labeled `no-auto`, `type:epic` (pointer trackers with no code), or
+ * already claimed/blocked are excluded. All other open issues are dispatchable.
  *
  * The empty-queue path is intentionally cheap: GitHub scan, log, exit. No
  * gbrain query, model call, subagent, or CodeRabbit work happens unless an
@@ -38,6 +38,7 @@ import {
   CODEX_CLAIM_LABEL,
   CODEX_TRUSTED_LABEL,
   type DispatchPlan,
+  EPIC_LABEL,
   type FinisherRunner,
   finishDispatch,
   type GbrainContext,
@@ -1116,6 +1117,9 @@ async function main(): Promise<void> {
           const skippedNoAuto = issues.filter(issue =>
             labelNames(issue).includes(NO_AUTO_LABEL)
           ).length;
+          const skippedEpic = issues.filter(issue =>
+            labelNames(issue).includes(EPIC_LABEL)
+          ).length;
           const capacity = systemCapacity(config);
           const batch = plans.slice(0, capacity.allowedAgents);
 
@@ -1126,6 +1130,7 @@ async function main(): Promise<void> {
             dispatchableCount: plans.length,
             skippedHuman,
             skippedNoAuto,
+            skippedEpic,
             batchCount: batch.length,
             maxIssuesPerRun: config.maxIssuesPerRun,
             maxParallelAgents: config.maxParallelAgents,

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -4,6 +4,7 @@ export const CODEX_CLAIM_LABEL = 'codex-in-progress';
 export const CODEX_BLOCKED_LABEL = 'codex-blocked';
 export const HUMAN_REVIEW_LABEL = 'human-review-required';
 export const NO_AUTO_LABEL = 'no-auto';
+export const EPIC_LABEL = 'type:epic';
 
 export interface GithubIssueLabel {
   readonly name: string;
@@ -220,6 +221,13 @@ export function isAlreadyClaimedOrBlocked(issue: GithubIssue): boolean {
   return labels.has(CODEX_CLAIM_LABEL) || labels.has(CODEX_BLOCKED_LABEL);
 }
 
+// Epic pointers (`type:epic`) track child phases and have no code of their own,
+// so the shipper claims them, finds nothing to ship, releases, and re-claims in
+// a loop (see #12729/#12846). Treat epics as never directly dispatchable.
+export function isEpicPointer(issue: GithubIssue): boolean {
+  return labelNames(issue).includes(EPIC_LABEL);
+}
+
 export function isTrustedCodexIssue(issue: GithubIssue): boolean {
   return labelNames(issue).includes(CODEX_TRUSTED_LABEL);
 }
@@ -231,6 +239,7 @@ export function eligibleCodexIssues(
     issue =>
       !isHumanReviewRequired(issue) &&
       !isAlreadyClaimedOrBlocked(issue) &&
+      !isEpicPointer(issue) &&
       !labelNames(issue).includes(NO_AUTO_LABEL)
   );
 }

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -7,6 +7,7 @@ import {
   CODEX_BLOCKED_LABEL,
   CODEX_CLAIM_LABEL,
   CODEX_TRUSTED_LABEL,
+  EPIC_LABEL,
   eligibleCodexIssues,
   finishDispatch,
   loadShipperConfig,
@@ -44,7 +45,7 @@ describe('codex issue shipper planner', () => {
     expect(buildDispatchPlans([], config)).toEqual([]);
   });
 
-  it('filters no-auto, claimed, and blocked issues before dispatch', () => {
+  it('filters no-auto, claimed, blocked, and epic issues before dispatch', () => {
     const ready = issue({ number: 1, title: 'Fix docs typo' });
     const noAuto = issue({
       number: 2,
@@ -58,12 +59,17 @@ describe('codex issue shipper planner', () => {
       number: 4,
       labels: [{ name: 'codex' }, { name: CODEX_BLOCKED_LABEL }],
     });
+    // Epic pointer: no code of its own; claiming it loops forever (#12729/#12846).
+    const epic = issue({
+      number: 5,
+      labels: [{ name: 'codex' }, { name: EPIC_LABEL }],
+    });
 
-    expect(eligibleCodexIssues([ready, noAuto, claimed, blocked])).toEqual([
-      ready,
-    ]);
     expect(
-      buildDispatchPlans([ready, noAuto, claimed, blocked], config)
+      eligibleCodexIssues([ready, noAuto, claimed, blocked, epic])
+    ).toEqual([ready]);
+    expect(
+      buildDispatchPlans([ready, noAuto, claimed, blocked, epic], config)
     ).toHaveLength(1);
   });
 


### PR DESCRIPTION
## What & why

Issue **#12729** ("Migrate issue tracking Linear → GitHub Issues") is a `type:epic`
**pointer** — it tracks four child phases and its acceptance criteria is *"closes when
phase 4 completes and the subscription is cancelled."* There is **no code to ship in the
epic itself**, and cancelling the paid Linear subscription is a human billing/credential
action. So the epic stays open and human-gated (already labeled `blocked` / `blocked:payments`
/ `ai:needs-review`).

The real, shippable bug is the **retry loop it caused**: the codex issue shipper auto-claimed
#12729, found nothing to ship, released, and re-claimed it **~20 times today** (see the
"Agent exited 0 but no open PR exists" comment spam on #12729). That gap was filed as **#12846**.

This PR fixes the gap at the root: `eligibleCodexIssues` now excludes `type:epic` issues,
which are pointer trackers by definition and never directly dispatchable — matching the
existing epic-skip convention already used in `scripts/linear-query-todo.mjs` and
`scripts/ship-swarm/next-batch.mjs`.

## Changes

- `scripts/hermes/lib/codex-issue-shipper.ts` — add `EPIC_LABEL = 'type:epic'` +
  `isEpicPointer()` helper (mirrors `isHumanReviewRequired`/`isAlreadyClaimedOrBlocked`);
  wire it into `eligibleCodexIssues`.
- `scripts/hermes/jobs/codex-issue-shipper.ts` — add a `skippedEpic` scan counter to the
  `scanned` log event (parallel to `skippedNoAuto`) so the drop is observable, not silent;
  update the file-header doc.
- `scripts/lib/__tests__/codex-issue-shipper.test.mjs` — extend the filter test with an
  epic fixture (positive+negative assertion: epic dropped, ready issue survives).

## Verification

```
# focused test
$ pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/codex-issue-shipper.test.mjs
 Test Files  1 passed (1)
      Tests  25 passed (25)

# full scripts suite (no sibling breakage)
$ pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__
 Test Files  21 passed (21)
      Tests  246 passed (246)

# biome (read-only, as pre-push)
$ pnpm biome check <touched files>
 Checked 3 files in 34ms. No fixes applied.

# CodeRabbit (uncommitted)
 {"type":"complete","status":"review_completed","findings":0}

# pre-push typecheck (tsconfig.typecheck.json) — passed on push
```

Independent review + security and testing subagents both returned **SHIP**: the exclusion
only *removes* an issue class from auto-dispatch (no smuggle-in / DoS vector; `type:epic` is
a human/automation triage label), and matches sibling-script precedent.

## Bug-to-test

Bugfix ships with a regression test (the epic fixture in the filter test). It fails on the
pre-fix state (epic would be dispatched) and passes after.

## Scope note

This does **not** close #12729. The epic remains open and human-gated on the phase-4
subscription cancellation. This PR closes the operational-gap follow-up #12846.

Closes #12846
Refs #12729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
