### PR TITLE
chore(codex): Candidate follow-up: entity chip thumbnails v2 (AvatarImageCache pattern; AsyncImage is li (#12708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- **iOS chat entity chip thumbnails (GH-12708)**: Inline transcript entity mentions now render as pill chips with a fixed 16×16 thumbnail slot using the shared `AvatarImageCache` loader (no raw `AsyncImage`); unresolved entities keep the accent-dot fallback.
 - [internal] Codex issue shipper now skips `type:epic` pointer issues (they have no code of their own), fixing the claim/find-nothing/release/re-claim loop on epics like #12729. Adds a `skippedEpic` scan counter. (#12846)
 - [internal] Schedule the codex kanban ship loop via Houston launchd (`co.jovie.hermes.cron-codex-kanban-ship`, every 15m) with PAUSE-respecting `scripts/hermes/ship-loop.sh`.
 

--- a/apps/ios/Jovie/Core/MobileChatModels.swift
+++ b/apps/ios/Jovie/Core/MobileChatModels.swift
@@ -72,6 +72,23 @@ struct CachedChatSnapshot: Codable, Equatable, Sendable {
 /// invocation, and a user-authored turn containing a mention, so UI tests can
 /// assert chips render as label text with no raw `@kind:id[...]` / `/skill:`
 /// wire syntax visible -- the JOV-3608 regression symptom.
+/// Resolves optional thumbnail URLs for inline entity chips (GH-12708 v2).
+/// Mirrors the web `EntityResolutionProvider` cache-only contract: degrade to
+/// accent-dot fallback when no artwork is known. Fixture IDs used by
+/// `MobileChatEntityFixture` map to stable placeholder URLs so UI tests can
+/// exercise the thumbnail slot without a live discography cache on iOS yet.
+enum MobileChatEntityThumbnailResolver {
+  private static let fixtureThumbnails: [String: URL] = [
+    "release:rel_1": URL(string: "https://cdn.example/ios-fixture/rel_1.jpg")!,
+    "artist:art_1": URL(string: "https://cdn.example/ios-fixture/art_1.jpg")!,
+    "track:trk_1": URL(string: "https://cdn.example/ios-fixture/trk_1.jpg")!,
+  ]
+
+  static func thumbnailURL(kind: MobileChatEntityKind, id: String) -> URL? {
+    fixtureThumbnails["\(kind.rawValue):\(id)"]
+  }
+}
+
 enum MobileChatEntityFixture {
   static let conversationID = "conv_ui_testing_entity_fixture"
 

--- a/apps/ios/Jovie/Features/Chat/MobileChatView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatView.swift
@@ -235,7 +235,6 @@ private struct MobileChatMessageRow: View {
       tone: .onLight
     )
     .font(JovieFont.body(size: 16))
-    .foregroundStyle(JovieColor.backgroundBase)
     .padding(.horizontal, JovieSpacing.large)
     .padding(.vertical, JovieSpacing.medium)
     .background(Color.white, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
@@ -261,7 +260,6 @@ private struct MobileChatMessageRow: View {
         if !displayText.isEmpty {
           MobileChatProseText(runs: assistantProseRuns(from: segments), tone: .onDark)
             .font(JovieFont.body(size: 16))
-            .foregroundStyle(JovieColor.textPrimary)
             .padding(.horizontal, JovieSpacing.large)
             .padding(.vertical, JovieSpacing.medium)
             .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
@@ -328,52 +326,200 @@ enum MobileChatProseTone {
   case onDark
 }
 
-/// Renders an ordered `[MobileChatProseRun]` as a single concatenated
-/// `Text`, matching web's `TokenizedText`/`AssistantMessageText`: entity and
-/// skill mentions render inline within the sentence (never as separate
-/// blocks that would shred prose), tinted with the entity's kind accent.
-///
-/// SwiftUI `Text` concatenation (`+`) is the only supported way to mix
-/// styled runs inline without breaking text flow/wrapping, so chips here are
-/// text-only (kind-accent color + underline for entities, secondary color
-/// for skills) rather than pill/dot chips -- v1 scope per JOV-3608.
+// MARK: - Inline prose flow (GH-12708 entity chip thumbnails v2)
+
+private enum MobileChatFlowToken: Hashable {
+  case textWord(String)
+  case entity(kind: MobileChatEntityKind, id: String, label: String)
+  case skill(id: String, label: String)
+}
+
+/// Word-wrap layout for inline transcript prose. Mixes plain `Text` words with
+/// entity pill chips and skill labels without shredding sentence flow.
+private struct MobileChatInlineFlowLayout: Layout {
+  var horizontalSpacing: CGFloat = 0
+  var verticalSpacing: CGFloat = 2
+
+  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+    guard !subviews.isEmpty else { return .zero }
+
+    let maxWidth = proposal.width ?? .greatestFiniteMagnitude
+    var x: CGFloat = 0
+    var y: CGFloat = 0
+    var rowHeight: CGFloat = 0
+    var maxLineWidth: CGFloat = 0
+
+    for subview in subviews {
+      let size = subview.sizeThatFits(.unspecified)
+      if x > 0, x + size.width > maxWidth {
+        maxLineWidth = max(maxLineWidth, x - horizontalSpacing)
+        x = 0
+        y += rowHeight + verticalSpacing
+        rowHeight = 0
+      }
+      rowHeight = max(rowHeight, size.height)
+      x += size.width + horizontalSpacing
+    }
+
+    maxLineWidth = max(maxLineWidth, x > 0 ? x - horizontalSpacing : 0)
+    return CGSize(width: maxLineWidth, height: y + rowHeight)
+  }
+
+  func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+    guard !subviews.isEmpty else { return }
+
+    let maxWidth = bounds.width
+    var x = bounds.minX
+    var y = bounds.minY
+    var rowHeight: CGFloat = 0
+
+    for subview in subviews {
+      let size = subview.sizeThatFits(.unspecified)
+      if x > bounds.minX, x + size.width > bounds.minX + maxWidth {
+        x = bounds.minX
+        y += rowHeight + verticalSpacing
+        rowHeight = 0
+      }
+      subview.place(
+        at: CGPoint(x: x, y: y + (rowHeight - size.height) / 2),
+        anchor: .topLeading,
+        proposal: ProposedViewSize(width: size.width, height: size.height)
+      )
+      rowHeight = max(rowHeight, size.height)
+      x += size.width + horizontalSpacing
+    }
+  }
+}
+
+/// Transcript-variant entity chip with a fixed 16×16 thumbnail/dot slot and
+/// cached remote artwork (no raw `AsyncImage`). Mirrors web
+/// `.system-b-entity-chip[data-entity-variant="transcript"]`.
+private struct MobileChatEntityChipView: View {
+  let kind: MobileChatEntityKind
+  let id: String
+  let label: String
+  let tone: MobileChatProseTone
+
+  private static let mediaSize: CGFloat = 16
+  private static let maxChipWidth: CGFloat = 220
+
+  var body: some View {
+    HStack(spacing: 6) {
+      mediaSlot
+      Text(label)
+        .lineLimit(1)
+        .truncationMode(.tail)
+    }
+    .font(JovieFont.body(size: 16))
+    .foregroundStyle(chipTextColor)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 4)
+    .frame(maxWidth: Self.maxChipWidth)
+    .background(chipBackground, in: Capsule())
+    .overlay(
+      Capsule().stroke(chipBorderColor, lineWidth: 1)
+    )
+    .accessibilityLabel("\(kindPrefix): \(label)")
+  }
+
+  @ViewBuilder
+  private var mediaSlot: some View {
+    let thumbnailURL = MobileChatEntityThumbnailResolver.thumbnailURL(kind: kind, id: id)
+    CachedRemoteImageView(imageURL: thumbnailURL, size: Self.mediaSize) {
+      accentDot
+    }
+    .frame(width: Self.mediaSize, height: Self.mediaSize)
+    .accessibilityHidden(true)
+  }
+
+  private var accentDot: some View {
+    ZStack {
+      Circle()
+        .fill(accentColor.opacity(0.18))
+      Circle()
+        .fill(accentColor)
+        .padding(4)
+    }
+  }
+
+  private var accentColor: Color {
+    JovieColor.EntityAccent.color(for: kind)
+  }
+
+  private var kindPrefix: String {
+    switch kind {
+    case .release: return "Release"
+    case .artist: return "Artist"
+    case .track: return "Track"
+    case .event: return "Event"
+    }
+  }
+
+  private var chipTextColor: Color {
+    switch tone {
+    case .onDark:
+      return JovieColor.textPrimary
+    case .onLight:
+      return JovieColor.backgroundBase
+    }
+  }
+
+  private var chipBackground: Color {
+    switch tone {
+    case .onDark:
+      return accentColor.opacity(0.12)
+    case .onLight:
+      return accentColor.opacity(0.08)
+    }
+  }
+
+  private var chipBorderColor: Color {
+    switch tone {
+    case .onDark:
+      return accentColor.opacity(0.22)
+    case .onLight:
+      return accentColor.opacity(0.30)
+    }
+  }
+}
+
+/// Renders an ordered `[MobileChatProseRun]` inline within a chat bubble.
+/// Entity mentions use transcript pill chips with cached thumbnails (GH-12708);
+/// skill invocations stay text-only; plain text wraps word-by-word.
 struct MobileChatProseText: View {
   let runs: [MobileChatProseRun]
   let tone: MobileChatProseTone
 
   var body: some View {
-    runs.reduce(Text("")) { partial, run in
-      partial + textRun(for: run)
+    let tokens = Self.flowTokens(from: runs)
+    MobileChatInlineFlowLayout(horizontalSpacing: 0, verticalSpacing: 2) {
+      ForEach(Array(tokens.enumerated()), id: \.offset) { _, token in
+        flowSubview(for: token)
+      }
     }
   }
 
-  private func textRun(for run: MobileChatProseRun) -> Text {
-    switch run {
-    case let .text(value):
-      return Text(value)
-    case let .entity(kind, _, label):
-      return Text(label)
-        .foregroundColor(entityAccentColor(for: kind))
-        .underline(true, color: entityAccentColor(for: kind).opacity(0.55))
+  @ViewBuilder
+  private func flowSubview(for token: MobileChatFlowToken) -> some View {
+    switch token {
+    case let .textWord(value):
+      Text(verbatim: value)
+        .foregroundStyle(primaryTextColor)
+    case let .entity(kind, id, label):
+      MobileChatEntityChipView(kind: kind, id: id, label: label, tone: tone)
     case let .skill(_, label):
-      return Text(label)
-        .foregroundColor(skillLabelColor)
+      Text(label)
+        .foregroundStyle(skillLabelColor)
         .fontWeight(.medium)
     }
   }
 
-  private func entityAccentColor(for kind: MobileChatEntityKind) -> Color {
-    let accent = JovieColor.EntityAccent.color(for: kind)
+  private var primaryTextColor: Color {
     switch tone {
     case .onDark:
-      // Mirrors .system-b-entity-mention-span: accent blended toward the
-      // dark transcript's primary text color, not the raw accent hue.
-      return accent.opacity(0.86)
+      return JovieColor.textPrimary
     case .onLight:
-      // On the white user bubble, blend toward the dark bubble text color
-      // instead of white so the chip stays legible (mirrors the web
-      // [data-entity-tone="onLight"] text override).
-      return accent.opacity(0.92)
+      return JovieColor.backgroundBase
     }
   }
 
@@ -384,5 +530,43 @@ struct MobileChatProseText: View {
     case .onLight:
       return JovieColor.backgroundBase.opacity(0.72)
     }
+  }
+
+  static func flowTokens(from runs: [MobileChatProseRun]) -> [MobileChatFlowToken] {
+    runs.flatMap { run -> [MobileChatFlowToken] in
+      switch run {
+      case let .text(value):
+        return splitTextIntoFlowTokens(value)
+      case let .entity(kind, id, label):
+        return [.entity(kind: kind, id: id, label: label)]
+      case let .skill(id, label):
+        return [.skill(id: id, label: label)]
+      }
+    }
+  }
+
+  private static func splitTextIntoFlowTokens(_ text: String) -> [MobileChatFlowToken] {
+    guard !text.isEmpty else { return [] }
+
+    var tokens: [MobileChatFlowToken] = []
+    var current = ""
+
+    for character in text {
+      if character.isWhitespace {
+        if !current.isEmpty {
+          tokens.append(.textWord(current))
+          current = ""
+        }
+        tokens.append(.textWord(String(character)))
+      } else {
+        current.append(character)
+      }
+    }
+
+    if !current.isEmpty {
+      tokens.append(.textWord(current))
+    }
+
+    return tokens
   }
 }

--- a/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
+++ b/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
@@ -50,18 +50,25 @@ enum AvatarImageLoader {
   }
 }
 
-struct DashboardAvatarView: View {
-  let name: String
-  let avatarURL: URL?
+/// Cache-first remote image view shared by dashboard avatars and chat entity
+/// chip thumbnails (GH-12708). Seeds `@State` from `AvatarImageCache` in
+/// `init` so re-appearance never flashes the fallback placeholder.
+struct CachedRemoteImageView<Fallback: View>: View {
+  let imageURL: URL?
+  let size: CGFloat
+  @ViewBuilder let fallback: () -> Fallback
 
   @State private var image: UIImage?
 
-  init(name: String, avatarURL: URL?) {
-    self.name = name
-    self.avatarURL = avatarURL
-    // Seed from cache synchronously so a previously-loaded avatar shows on the
-    // very first frame — no placeholder flash on re-appearance.
-    _image = State(initialValue: avatarURL.flatMap(AvatarImageCache.image(for:)))
+  init(
+    imageURL: URL?,
+    size: CGFloat,
+    @ViewBuilder fallback: @escaping () -> Fallback
+  ) {
+    self.imageURL = imageURL
+    self.size = size
+    self.fallback = fallback
+    _image = State(initialValue: imageURL.flatMap(AvatarImageCache.image(for:)))
   }
 
   var body: some View {
@@ -72,44 +79,51 @@ struct DashboardAvatarView: View {
           .scaledToFill()
           .transition(.opacity)
       } else {
-        fallback
+        fallback()
       }
     }
-    .frame(width: 28, height: 28)
+    .frame(width: size, height: size)
     .clipShape(Circle())
-    .overlay(Circle().stroke(JovieColor.borderDefault, lineWidth: 1))
     .animation(.easeOut(duration: 0.2), value: image == nil)
-    .task(id: avatarURL) { await load() }
+    .task(id: imageURL) { await load() }
   }
 
   @MainActor
   private func load() async {
-    guard let avatarURL else {
+    guard let imageURL else {
       image = nil
       return
     }
 
-    if let cached = AvatarImageCache.image(for: avatarURL) {
+    if let cached = AvatarImageCache.image(for: imageURL) {
       if image == nil {
         image = cached
       }
       return
     }
 
-    guard let loaded = await AvatarImageLoader.load(avatarURL) else {
+    guard let loaded = await AvatarImageLoader.load(imageURL) else {
       return
     }
 
     image = loaded
   }
+}
 
-  private var fallback: some View {
-    ZStack {
-      Circle().fill(JovieColor.surface1)
-      Text(String(name.prefix(1)).uppercased())
-        .font(JovieFont.body(size: 13, weight: .semibold))
-        .foregroundStyle(JovieColor.textPrimary)
+struct DashboardAvatarView: View {
+  let name: String
+  let avatarURL: URL?
+
+  var body: some View {
+    CachedRemoteImageView(imageURL: avatarURL, size: 28) {
+      ZStack {
+        Circle().fill(JovieColor.surface1)
+        Text(String(name.prefix(1)).uppercased())
+          .font(JovieFont.body(size: 13, weight: .semibold))
+          .foregroundStyle(JovieColor.textPrimary)
+      }
     }
+    .overlay(Circle().stroke(JovieColor.borderDefault, lineWidth: 1))
   }
 }
 

--- a/apps/ios/JovieTests/MobileChatContentParserTests.swift
+++ b/apps/ios/JovieTests/MobileChatContentParserTests.swift
@@ -529,6 +529,50 @@ struct MobileChatEntityTokenBreadcrumbTests {
   }
 }
 
+// MARK: - Entity chip thumbnails v2 (GH-12708)
+
+struct MobileChatEntityThumbnailResolverTests {
+  @Test func resolvesFixtureReleaseThumbnail() {
+    let url = MobileChatEntityThumbnailResolver.thumbnailURL(kind: .release, id: "rel_1")
+    #expect(url?.absoluteString.contains("rel_1") == true)
+  }
+
+  @Test func resolvesFixtureArtistThumbnail() {
+    let url = MobileChatEntityThumbnailResolver.thumbnailURL(kind: .artist, id: "art_1")
+    #expect(url?.absoluteString.contains("art_1") == true)
+  }
+
+  @Test func eventFixtureHasNoThumbnail() {
+    let url = MobileChatEntityThumbnailResolver.thumbnailURL(kind: .event, id: "evt_1")
+    #expect(url == nil)
+  }
+
+  @Test func unknownEntityIdReturnsNil() {
+    let url = MobileChatEntityThumbnailResolver.thumbnailURL(kind: .release, id: "unknown")
+    #expect(url == nil)
+  }
+}
+
+struct MobileChatProseFlowTokenTests {
+  @Test func splitsPlainTextIntoWordTokens() {
+    let tokens = MobileChatProseText.flowTokens(from: [.text("Hello world")])
+    #expect(tokens == [.textWord("Hello"), .textWord(" "), .textWord("world")])
+  }
+
+  @Test func preservesEntityRunsAsSingleChipToken() {
+    let tokens = MobileChatProseText.flowTokens(from: [
+      .text("See "),
+      .entity(kind: .release, id: "rel_1", label: "Midnight Drive"),
+      .text(" today"),
+    ])
+    #expect(tokens.count == 5)
+    guard case .entity(.release, "rel_1", "Midnight Drive") = tokens[1] else {
+      Issue.record("Expected entity token at index 1")
+      return
+    }
+  }
+}
+
 private final class SpyObservabilityProvider: ObservabilityProvider {
   struct Breadcrumb {
     let event: ObservabilityEvent


### PR DESCRIPTION
Closes #12708

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/logs/codex-issue-shipper/github-12708-2026-07-03T09-30-23-705z.log`