### PR TITLE
chore(codex): Next dev server on :3000 returns 404 for known routes (/hud, /signin, /app/admin/ops) — st (#12899)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,11 +7,11 @@
     "node": ">=22.13.0 <23"
   },
   "scripts": {
-    "dev": "doppler run -- node scripts/dev-fast.mjs",
+    "dev": "NODE_OPTIONS=--max-old-space-size=8192 doppler run -- node scripts/dev-fast.mjs",
     "dev:fast": "node scripts/dev-fast.mjs",
     "dev:local": "node scripts/dev-fast.mjs",
     "dev:local:browse": "tsx scripts/drizzle-migrate.ts || echo '[dev:browse] drizzle:migrate failed - starting dev anyway (see error above)'; E2E_USE_TEST_AUTH_BYPASS=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 node scripts/dev-fast.mjs",
-    "dev:local:playwright": "NEXT_PUBLIC_E2E_MODE=1 NEXT_DISABLE_TOOLBAR=1 node scripts/dev-fast.mjs --webpack",
+    "dev:local:playwright": "NEXT_PUBLIC_E2E_MODE=1 NEXT_DISABLE_TOOLBAR=1 node scripts/dev-fast.mjs -- --webpack",
     "validate-env": "tsx scripts/validate-env.ts",
     "check:signup-readiness": "tsx scripts/check-signup-readiness.ts",
     "seo:ratchet": "vitest run tests/unit/seo --config=vitest.config.mts",

--- a/apps/web/scripts/dev-fast.mjs
+++ b/apps/web/scripts/dev-fast.mjs
@@ -41,11 +41,11 @@ const nextDev = spawn(
   process.execPath,
   [nextBin, 'dev', '-p', port, ...extraArgs],
   {
-  cwd: webRoot,
-  env: {
-    ...process.env,
-    NODE_OPTIONS: nodeOptions,
-  },
+    cwd: webRoot,
+    env: {
+      ...process.env,
+      NODE_OPTIONS: nodeOptions,
+    },
     stdio: 'inherit',
   }
 );

--- a/apps/web/scripts/dev-fast.mjs
+++ b/apps/web/scripts/dev-fast.mjs
@@ -2,15 +2,19 @@ import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resetNextCacheIfStale } from './dev-next-cache-guard.mjs';
+import {
+  ensureDevNextCacheFresh,
+  formatDevRouteDiscoveryLog,
+} from './ensure-dev-next-cache.mjs';
 
 const require = createRequire(import.meta.url);
 const nextBin = require.resolve('next/dist/bin/next');
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const webRoot = path.resolve(scriptDir, '..');
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const webRoot = path.resolve(scriptsDir, '..');
 const appDir = path.join(webRoot, 'app');
 const nextDir = path.join(webRoot, '.next');
 
+const port = process.env.PORT || '3100';
 const heapFlag = '--max-old-space-size=8192';
 const networkFamilyFlag = '--no-network-family-autoselection';
 const existingNodeOptions = process.env.NODE_OPTIONS || '';
@@ -25,59 +29,26 @@ if (!existingNodeOptions.includes(networkFamilyFlag)) {
 }
 
 const nodeOptions = nodeOptionParts.filter(Boolean).join(' ');
-const forceReset = process.env.JOVIE_DEV_RESET_NEXT_CACHE === '1';
-const extraArgs = process.argv.slice(2);
-const nextArgs = ['dev'];
-if (process.env.PORT) {
-  nextArgs.push('-p', process.env.PORT);
-}
-nextArgs.push(...extraArgs);
+const routeSummary = ensureDevNextCacheFresh({ appDir, nextDir });
 
-const cacheState = await resetNextCacheIfStale({
-  appDir,
-  nextDir,
-  forceReset,
-  log: message => console.error(message),
-});
+console.error(formatDevRouteDiscoveryLog(routeSummary));
 
-let loggedRouteDiscovery = false;
+const passthroughIndex = process.argv.indexOf('--');
+const extraArgs =
+  passthroughIndex === -1 ? [] : process.argv.slice(passthroughIndex + 1);
 
-const nextDev = spawn(process.execPath, [nextBin, ...nextArgs], {
+const nextDev = spawn(
+  process.execPath,
+  [nextBin, 'dev', '-p', port, ...extraArgs],
+  {
+  cwd: webRoot,
   env: {
     ...process.env,
     NODE_OPTIONS: nodeOptions,
   },
-  stdio: ['inherit', 'pipe', 'pipe'],
-});
-
-const logRouteDiscovery = line => {
-  if (loggedRouteDiscovery) {
-    return;
+    stdio: 'inherit',
   }
-
-  if (!/(Ready in|Local:)/i.test(line)) {
-    return;
-  }
-
-  loggedRouteDiscovery = true;
-  console.error(
-    `[dev] Discovered ${cacheState.pageCount} App Router page routes before first compile`
-  );
-};
-
-const relay = (stream, writer) => {
-  stream.on('data', chunk => {
-    const text = chunk.toString();
-    writer.write(chunk);
-
-    for (const line of text.split(/\r?\n/)) {
-      logRouteDiscovery(line);
-    }
-  });
-};
-
-relay(nextDev.stdout, process.stdout);
-relay(nextDev.stderr, process.stderr);
+);
 
 nextDev.on('exit', (code, signal) => {
   if (signal) {

--- a/apps/web/scripts/ensure-dev-next-cache.mjs
+++ b/apps/web/scripts/ensure-dev-next-cache.mjs
@@ -1,7 +1,12 @@
 import { readdirSync, rmSync, statSync } from 'node:fs';
 import path from 'node:path';
 
-const ROUTE_FILE_NAMES = new Set(['page.tsx', 'page.ts', 'route.ts', 'route.tsx']);
+const ROUTE_FILE_NAMES = new Set([
+  'page.tsx',
+  'page.ts',
+  'route.ts',
+  'route.tsx',
+]);
 
 /**
  * @param {string} dir

--- a/apps/web/scripts/ensure-dev-next-cache.mjs
+++ b/apps/web/scripts/ensure-dev-next-cache.mjs
@@ -1,0 +1,169 @@
+import { readdirSync, rmSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const ROUTE_FILE_NAMES = new Set(['page.tsx', 'page.ts', 'route.ts', 'route.tsx']);
+
+/**
+ * @param {string} dir
+ * @param {(fullPath: string, fileName: string) => void} onMatch
+ */
+function walkAppDir(dir, onMatch) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkAppDir(entryPath, onMatch);
+      continue;
+    }
+
+    if (!ROUTE_FILE_NAMES.has(entry.name)) {
+      continue;
+    }
+
+    onMatch(entryPath, entry.name);
+  }
+}
+
+/**
+ * @param {string} appDir
+ */
+export function scanAppRouteSources(appDir) {
+  /** @type {{ pageRoutes: number; apiRoutes: number; newestMtimeMs: number }} */
+  const summary = {
+    pageRoutes: 0,
+    apiRoutes: 0,
+    newestMtimeMs: 0,
+  };
+
+  walkAppDir(appDir, (fullPath, fileName) => {
+    const { mtimeMs } = statSync(fullPath);
+
+    if (fileName.startsWith('page.')) {
+      summary.pageRoutes += 1;
+    } else {
+      summary.apiRoutes += 1;
+    }
+
+    if (mtimeMs > summary.newestMtimeMs) {
+      summary.newestMtimeMs = mtimeMs;
+    }
+  });
+
+  return summary;
+}
+
+/**
+ * @param {string} dir
+ */
+function getNewestFileMtimeMsInTree(dir) {
+  /** @type {number | null} */
+  let newestMtimeMs = null;
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nestedNewest = getNewestFileMtimeMsInTree(entryPath);
+      if (
+        nestedNewest !== null &&
+        (newestMtimeMs === null || nestedNewest > newestMtimeMs)
+      ) {
+        newestMtimeMs = nestedNewest;
+      }
+      continue;
+    }
+
+    const { mtimeMs } = statSync(entryPath);
+    if (newestMtimeMs === null || mtimeMs > newestMtimeMs) {
+      newestMtimeMs = mtimeMs;
+    }
+  }
+
+  return newestMtimeMs;
+}
+
+/**
+ * @param {string} compiledRoutesDir
+ */
+export function getCompiledRoutesMtimeMs(compiledRoutesDir) {
+  try {
+    const newestFileMtimeMs = getNewestFileMtimeMsInTree(compiledRoutesDir);
+    if (newestFileMtimeMs !== null) {
+      return newestFileMtimeMs;
+    }
+
+    return statSync(compiledRoutesDir).mtimeMs;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * @param {{
+ *   appDir: string;
+ *   nextDir: string;
+ *   forceReset?: boolean;
+ *   skipStaleCheck?: boolean;
+ * }} options
+ */
+export function ensureDevNextCacheFresh(options) {
+  const {
+    appDir,
+    nextDir,
+    forceReset = process.env.JOVIE_DEV_RESET_NEXT_CACHE === '1',
+    skipStaleCheck = process.env.JOVIE_DEV_SKIP_STALE_CACHE_CHECK === '1',
+  } = options;
+
+  const routeSources = scanAppRouteSources(appDir);
+  const compiledRoutesDir = path.join(nextDir, 'server', 'app');
+  const compiledMtimeMs = getCompiledRoutesMtimeMs(compiledRoutesDir);
+
+  /** @type {'forced' | 'stale' | 'fresh' | 'missing'} */
+  let cacheState = 'missing';
+
+  if (forceReset) {
+    cacheState = 'forced';
+    rmSync(nextDir, { force: true, recursive: true });
+  } else if (!skipStaleCheck && compiledMtimeMs !== null) {
+    if (routeSources.newestMtimeMs > compiledMtimeMs) {
+      cacheState = 'stale';
+      rmSync(nextDir, { force: true, recursive: true });
+    } else {
+      cacheState = 'fresh';
+    }
+  }
+
+  return {
+    ...routeSources,
+    cacheState,
+    compiledMtimeMs,
+  };
+}
+
+/**
+ * @param {{
+ *   pageRoutes: number;
+ *   apiRoutes: number;
+ *   cacheState: 'forced' | 'stale' | 'fresh' | 'missing';
+ * }} summary
+ */
+export function formatDevRouteDiscoveryLog(summary) {
+  const totalRoutes = summary.pageRoutes + summary.apiRoutes;
+  const cacheMessage =
+    summary.cacheState === 'forced'
+      ? 'wiped .next (JOVIE_DEV_RESET_NEXT_CACHE=1)'
+      : summary.cacheState === 'stale'
+        ? 'wiped stale .next (source routes newer than compiled cache)'
+        : summary.cacheState === 'fresh'
+          ? 'compiled route cache is fresh'
+          : 'no compiled route cache yet';
+
+  return `[jovie-dev] Route discovery: ${totalRoutes} source routes (${summary.pageRoutes} pages, ${summary.apiRoutes} handlers); ${cacheMessage}`;
+}

--- a/apps/web/scripts/ensure-dev-next-cache.test.mjs
+++ b/apps/web/scripts/ensure-dev-next-cache.test.mjs
@@ -9,7 +9,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import test from 'node:test';
+import { test } from 'vitest';
 
 import {
   ensureDevNextCacheFresh,

--- a/apps/web/scripts/ensure-dev-next-cache.test.mjs
+++ b/apps/web/scripts/ensure-dev-next-cache.test.mjs
@@ -1,5 +1,12 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -24,7 +31,10 @@ test('scanAppRouteSources counts page and route handlers', () => {
     mkdirSync(path.join(root, 'hud'), { recursive: true });
     mkdirSync(path.join(root, 'api', 'health'), { recursive: true });
     touch(path.join(root, 'hud', 'page.tsx'), new Date('2026-07-01T00:00:00Z'));
-    touch(path.join(root, 'api', 'health', 'route.ts'), new Date('2026-07-02T00:00:00Z'));
+    touch(
+      path.join(root, 'api', 'health', 'route.ts'),
+      new Date('2026-07-02T00:00:00Z')
+    );
 
     const summary = scanAppRouteSources(root);
 
@@ -49,8 +59,14 @@ test('ensureDevNextCacheFresh wipes .next when source routes are newer', () => {
     mkdirSync(path.join(appDir, 'hud'), { recursive: true });
     mkdirSync(compiledRoutesDir, { recursive: true });
 
-    touch(path.join(compiledRoutesDir, 'manifest.json'), new Date('2026-06-20T00:00:00Z'));
-    touch(path.join(appDir, 'hud', 'page.tsx'), new Date('2026-07-03T00:00:00Z'));
+    touch(
+      path.join(compiledRoutesDir, 'manifest.json'),
+      new Date('2026-06-20T00:00:00Z')
+    );
+    touch(
+      path.join(appDir, 'hud', 'page.tsx'),
+      new Date('2026-07-03T00:00:00Z')
+    );
 
     const summary = ensureDevNextCacheFresh({
       appDir,
@@ -61,10 +77,7 @@ test('ensureDevNextCacheFresh wipes .next when source routes are newer', () => {
 
     assert.equal(summary.cacheState, 'stale');
     assert.throws(() => statSync(nextDir), /ENOENT/);
-    assert.match(
-      formatDevRouteDiscoveryLog(summary),
-      /wiped stale \.next/
-    );
+    assert.match(formatDevRouteDiscoveryLog(summary), /wiped stale \.next/);
   } finally {
     rmSync(root, { force: true, recursive: true });
   }
@@ -80,8 +93,14 @@ test('ensureDevNextCacheFresh keeps cache when compiled routes are newer', () =>
     mkdirSync(path.join(appDir, 'hud'), { recursive: true });
     mkdirSync(compiledRoutesDir, { recursive: true });
 
-    touch(path.join(appDir, 'hud', 'page.tsx'), new Date('2026-06-20T00:00:00Z'));
-    touch(path.join(compiledRoutesDir, 'manifest.json'), new Date('2026-07-03T00:00:00Z'));
+    touch(
+      path.join(appDir, 'hud', 'page.tsx'),
+      new Date('2026-06-20T00:00:00Z')
+    );
+    touch(
+      path.join(compiledRoutesDir, 'manifest.json'),
+      new Date('2026-07-03T00:00:00Z')
+    );
 
     const summary = ensureDevNextCacheFresh({
       appDir,

--- a/apps/web/scripts/ensure-dev-next-cache.test.mjs
+++ b/apps/web/scripts/ensure-dev-next-cache.test.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  ensureDevNextCacheFresh,
+  formatDevRouteDiscoveryLog,
+  getCompiledRoutesMtimeMs,
+  scanAppRouteSources,
+} from './ensure-dev-next-cache.mjs';
+
+function touch(filePath, mtime) {
+  writeFileSync(filePath, `// ${path.basename(filePath)}\n`);
+  const atime = mtime;
+  utimesSync(filePath, atime, mtime);
+}
+
+test('scanAppRouteSources counts page and route handlers', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'jovie-dev-cache-scan-'));
+
+  try {
+    mkdirSync(path.join(root, 'hud'), { recursive: true });
+    mkdirSync(path.join(root, 'api', 'health'), { recursive: true });
+    touch(path.join(root, 'hud', 'page.tsx'), new Date('2026-07-01T00:00:00Z'));
+    touch(path.join(root, 'api', 'health', 'route.ts'), new Date('2026-07-02T00:00:00Z'));
+
+    const summary = scanAppRouteSources(root);
+
+    assert.equal(summary.pageRoutes, 1);
+    assert.equal(summary.apiRoutes, 1);
+    assert.equal(
+      summary.newestMtimeMs,
+      statSync(path.join(root, 'api', 'health', 'route.ts')).mtimeMs
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test('ensureDevNextCacheFresh wipes .next when source routes are newer', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'jovie-dev-cache-stale-'));
+  const appDir = path.join(root, 'app');
+  const nextDir = path.join(root, '.next');
+  const compiledRoutesDir = path.join(nextDir, 'server', 'app');
+
+  try {
+    mkdirSync(path.join(appDir, 'hud'), { recursive: true });
+    mkdirSync(compiledRoutesDir, { recursive: true });
+
+    touch(path.join(compiledRoutesDir, 'manifest.json'), new Date('2026-06-20T00:00:00Z'));
+    touch(path.join(appDir, 'hud', 'page.tsx'), new Date('2026-07-03T00:00:00Z'));
+
+    const summary = ensureDevNextCacheFresh({
+      appDir,
+      nextDir,
+      skipStaleCheck: false,
+      forceReset: false,
+    });
+
+    assert.equal(summary.cacheState, 'stale');
+    assert.throws(() => statSync(nextDir), /ENOENT/);
+    assert.match(
+      formatDevRouteDiscoveryLog(summary),
+      /wiped stale \.next/
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test('ensureDevNextCacheFresh keeps cache when compiled routes are newer', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'jovie-dev-cache-fresh-'));
+  const appDir = path.join(root, 'app');
+  const nextDir = path.join(root, '.next');
+  const compiledRoutesDir = path.join(nextDir, 'server', 'app');
+
+  try {
+    mkdirSync(path.join(appDir, 'hud'), { recursive: true });
+    mkdirSync(compiledRoutesDir, { recursive: true });
+
+    touch(path.join(appDir, 'hud', 'page.tsx'), new Date('2026-06-20T00:00:00Z'));
+    touch(path.join(compiledRoutesDir, 'manifest.json'), new Date('2026-07-03T00:00:00Z'));
+
+    const summary = ensureDevNextCacheFresh({
+      appDir,
+      nextDir,
+      skipStaleCheck: false,
+      forceReset: false,
+    });
+
+    assert.equal(summary.cacheState, 'fresh');
+    assert.ok(statSync(nextDir).isDirectory());
+    assert.match(
+      formatDevRouteDiscoveryLog(summary),
+      /compiled route cache is fresh/
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test('getCompiledRoutesMtimeMs returns null when compiled routes are missing', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'jovie-dev-cache-missing-'));
+
+  try {
+    assert.equal(
+      getCompiledRoutesMtimeMs(path.join(root, 'server', 'app')),
+      null
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});

--- a/turbo.json
+++ b/turbo.json
@@ -103,7 +103,14 @@
       "cache": false,
       "persistent": true,
       "interruptible": true,
-      "inputs": ["app/**/page.tsx", "app/**/route.ts", "app/**/layout.tsx"]
+      "inputs": [
+        "app/**/page.tsx",
+        "app/**/page.ts",
+        "app/**/route.ts",
+        "app/**/route.tsx",
+        "app/**/layout.tsx",
+        "app/**/layout.ts"
+      ]
     },
     "test": {
       "description": "Runs the full Vitest unit/integration test suite with coverage output",


### PR DESCRIPTION
Closes #12899

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12899-2026-07-03T13-56-39-362z.log`