### PR TITLE
chore(codex): Packaged Mac app opens to a blank/black window when signed-out (all envs) — no sign-in aff (#12822)

### DIFF
--- a/apps/desktop/electron-builder.local.yml
+++ b/apps/desktop/electron-builder.local.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Local Auth
+        CFBundleURLSchemes:
+          - jovie-local
   notarize: false
   target:
     - target: dir

--- a/apps/desktop/electron-builder.staging.yml
+++ b/apps/desktop/electron-builder.staging.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Staging Auth
+        CFBundleURLSchemes:
+          - jovie-staging
   notarize: true
   target:
     - target: dmg

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -166,10 +166,11 @@ test('desktop macOS entitlements keep only allow-jit (no sandbox-weakening flags
   }
 });
 
-test('desktop production bundle declares the jovie auth protocol', async () => {
-  const [builderConfig, mainSource, stagingConfig, localConfig] =
+test('desktop bundles declare per-env auth URL schemes', async () => {
+  const [builderConfig, protocolSource, mainSource, stagingConfig, localConfig] =
     await Promise.all([
       readFile(join(desktopRoot, 'electron-builder.yml'), 'utf8'),
+      readFile(join(desktopRoot, 'src/desktop-auth-protocol.ts'), 'utf8'),
       readFile(join(desktopRoot, 'src/main.ts'), 'utf8'),
       readFile(join(desktopRoot, 'electron-builder.staging.yml'), 'utf8'),
       readFile(join(desktopRoot, 'electron-builder.local.yml'), 'utf8'),
@@ -178,10 +179,40 @@ test('desktop production bundle declares the jovie auth protocol', async () => {
   assert.match(builderConfig, /CFBundleURLTypes:/);
   assert.match(builderConfig, /CFBundleURLName: Jovie Auth/);
   assert.match(builderConfig, /CFBundleURLSchemes:\s*\n\s*- jovie/);
-  assert.match(mainSource, /if \(APP_ENV !== 'production'\)/);
-  assert.match(mainSource, /setAsDefaultProtocolClient\('jovie'\)/);
-  assert.doesNotMatch(stagingConfig, /CFBundleURLTypes:/);
-  assert.doesNotMatch(localConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLName: Jovie Staging Auth/);
+  assert.match(stagingConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-staging/);
+  assert.match(localConfig, /CFBundleURLTypes:/);
+  assert.match(localConfig, /CFBundleURLName: Jovie Local Auth/);
+  assert.match(localConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-local/);
+  assert.match(protocolSource, /production: 'jovie'/);
+  assert.match(protocolSource, /staging: 'jovie-staging'/);
+  assert.match(protocolSource, /local: 'jovie-local'/);
+  assert.match(mainSource, /getDesktopAuthScheme\(APP_ENV\)/);
+  assert.match(mainSource, /setAsDefaultProtocolClient\(scheme\)/);
+  assert.doesNotMatch(mainSource, /if \(APP_ENV !== 'production'\) \{\s*return;\s*\}/);
+});
+
+test('signed-out desktop launch recovers to a visible sign-in surface', async () => {
+  const mainSource = await readFile(join(desktopRoot, 'src/main.ts'), 'utf8');
+
+  assert.match(mainSource, /function isAnyDesktopWindowVisible\(\): boolean/);
+  assert.match(mainSource, /function ensureSignedOutSignInSurface\(win: BrowserWindow\)/);
+  assert.match(mainSource, /function loadMainWindowAuthHandoff\(/);
+  assert.match(mainSource, /const DESKTOP_VISIBILITY_FALLBACK_MS = 2_000;/);
+  assert.match(
+    mainSource,
+    /maybeShowDesktopAuthHandoff\(resolveNavigationUrl\(validatedURL\), \{\s*mainWin: win,\s*\}\)/
+  );
+  assert.match(
+    mainSource,
+    /maybeShowDesktopAuthHandoff\(navigationUrl, \{ mainWin: win \}\)/
+  );
+  assert.match(mainSource, /loadMainWindowAuthHandoff\(win, initialAuthUrl\)/);
+  assert.doesNotMatch(
+    mainSource,
+    /if \(win\.isDestroyed\(\) \|\| isAuthHandoffOpen\(\) \|\| win\.isVisible\(\)\) return;/
+  );
 });
 
 test('desktop navigation uses explicit URL disposition allowlists', async () => {

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -167,14 +167,19 @@ test('desktop macOS entitlements keep only allow-jit (no sandbox-weakening flags
 });
 
 test('desktop bundles declare per-env auth URL schemes', async () => {
-  const [builderConfig, protocolSource, mainSource, stagingConfig, localConfig] =
-    await Promise.all([
-      readFile(join(desktopRoot, 'electron-builder.yml'), 'utf8'),
-      readFile(join(desktopRoot, 'src/desktop-auth-protocol.ts'), 'utf8'),
-      readFile(join(desktopRoot, 'src/main.ts'), 'utf8'),
-      readFile(join(desktopRoot, 'electron-builder.staging.yml'), 'utf8'),
-      readFile(join(desktopRoot, 'electron-builder.local.yml'), 'utf8'),
-    ]);
+  const [
+    builderConfig,
+    protocolSource,
+    mainSource,
+    stagingConfig,
+    localConfig,
+  ] = await Promise.all([
+    readFile(join(desktopRoot, 'electron-builder.yml'), 'utf8'),
+    readFile(join(desktopRoot, 'src/desktop-auth-protocol.ts'), 'utf8'),
+    readFile(join(desktopRoot, 'src/main.ts'), 'utf8'),
+    readFile(join(desktopRoot, 'electron-builder.staging.yml'), 'utf8'),
+    readFile(join(desktopRoot, 'electron-builder.local.yml'), 'utf8'),
+  ]);
 
   assert.match(builderConfig, /CFBundleURLTypes:/);
   assert.match(builderConfig, /CFBundleURLName: Jovie Auth/);
@@ -190,14 +195,20 @@ test('desktop bundles declare per-env auth URL schemes', async () => {
   assert.match(protocolSource, /local: 'jovie-local'/);
   assert.match(mainSource, /getDesktopAuthScheme\(APP_ENV\)/);
   assert.match(mainSource, /setAsDefaultProtocolClient\(scheme\)/);
-  assert.doesNotMatch(mainSource, /if \(APP_ENV !== 'production'\) \{\s*return;\s*\}/);
+  assert.doesNotMatch(
+    mainSource,
+    /if \(APP_ENV !== 'production'\) \{\s*return;\s*\}/
+  );
 });
 
 test('signed-out desktop launch recovers to a visible sign-in surface', async () => {
   const mainSource = await readFile(join(desktopRoot, 'src/main.ts'), 'utf8');
 
   assert.match(mainSource, /function isAnyDesktopWindowVisible\(\): boolean/);
-  assert.match(mainSource, /function ensureSignedOutSignInSurface\(win: BrowserWindow\)/);
+  assert.match(
+    mainSource,
+    /function ensureSignedOutSignInSurface\(win: BrowserWindow\)/
+  );
   assert.match(mainSource, /function loadMainWindowAuthHandoff\(/);
   assert.match(mainSource, /const DESKTOP_VISIBILITY_FALLBACK_MS = 2_000;/);
   assert.match(

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -39,6 +39,10 @@ import {
   parseUrl,
   type UrlDisposition,
 } from './navigation';
+import {
+  getDesktopAuthProtocol,
+  getDesktopAuthScheme,
+} from './desktop-auth-protocol';
 import { decideRendererRecovery } from './renderer-recovery';
 import { SYSTEM_B_DESKTOP_TOKENS } from './system-b-tokens';
 import { sanitizeWindowState, type WindowState } from './window-state';
@@ -90,7 +94,8 @@ const DESKTOP_AUTH_HANDOFF_PATH = '/desktop-auth';
 const DESKTOP_AUTH_START_PATH = '/auth/start';
 const DESKTOP_AUTH_NATIVE_COMPLETE_PATH = '/auth/native-complete';
 const DESKTOP_RETURN_PARAM = 'desktop_return';
-const AUTH_RETURN_PROTOCOL = 'jovie:';
+const AUTH_RETURN_PROTOCOL = getDesktopAuthProtocol(APP_ENV);
+const AUTH_RETURN_SCHEME = getDesktopAuthScheme(APP_ENV);
 const AUTH_RETURN_HOST = 'auth';
 const AUTH_RETURN_COMPLETE_PATH = '/complete';
 const LEGACY_AUTH_RETURN_HOST = 'auth-return';
@@ -144,6 +149,9 @@ const AUTH_HANDOFF_WINDOW_BOUNDS = {
   minWidth: 680,
   minHeight: 460,
 } as const;
+// If neither the main nor handoff window becomes visible shortly after launch,
+// force a recoverable sign-in surface instead of leaving the user on black.
+const DESKTOP_VISIBILITY_FALLBACK_MS = 2_000;
 const AUTH_COMPLETION_REPLAY_TTL_MS = 60_000;
 const reportDesktopSecurityEvent = createDesktopSecurityReporter();
 
@@ -525,6 +533,43 @@ function isAuthHandoffOpen(): boolean {
   return Boolean(authHandoffWindow && !authHandoffWindow.isDestroyed());
 }
 
+function isAnyDesktopWindowVisible(): boolean {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed() && win.isVisible()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function loadMainWindowAuthHandoff(
+  win: BrowserWindow,
+  authUrl: string
+): void {
+  if (win.isDestroyed()) return;
+  void win.loadURL(buildDesktopAuthHandoffUrl(authUrl));
+}
+
+function ensureSignedOutSignInSurface(win: BrowserWindow): void {
+  if (win.isDestroyed() || isAnyDesktopWindowVisible()) return;
+
+  const current = win.webContents.getURL();
+  if (!current || current === 'about:blank') {
+    const authUrl = buildCentralDesktopAuthUrl('sign_in', '/app');
+    loadMainWindowAuthHandoff(win, authUrl);
+  }
+
+  if (
+    authHandoffWindow &&
+    !authHandoffWindow.isDestroyed() &&
+    !authHandoffWindow.isVisible()
+  ) {
+    showWindowNow(authHandoffWindow);
+  }
+
+  showWindowNow(win);
+}
+
 function hideMainWindowForAuthHandoff(): void {
   if (!mainWindow || mainWindow.isDestroyed()) return;
   mainWindowHiddenForAuthHandoff = true;
@@ -678,7 +723,23 @@ function showDesktopAuthHandoff(authUrl: string): void {
     `${authHandoffWindow.webContents.getUserAgent()} ${DESKTOP_USER_AGENT_PRODUCT}`
   );
 
+  const handoffVisibilityFallback = setTimeout(() => {
+    if (
+      !authHandoffWindow ||
+      authHandoffWindow.isDestroyed() ||
+      authHandoffWindow.isVisible()
+    ) {
+      return;
+    }
+
+    restoreMainWindowAfterAuthHandoff();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      ensureSignedOutSignInSurface(mainWindow);
+    }
+  }, DESKTOP_VISIBILITY_FALLBACK_MS);
+
   authHandoffWindow.once('ready-to-show', () => {
+    clearTimeout(handoffVisibilityFallback);
     hideMainWindowForAuthHandoff();
     if (authHandoffWindow) showWindow(authHandoffWindow);
   });
@@ -716,11 +777,17 @@ function showDesktopAuthHandoff(authUrl: string): void {
   showWindow(authHandoffWindow);
 }
 
-function maybeShowDesktopAuthHandoff(urlString: string): boolean {
+function maybeShowDesktopAuthHandoff(
+  urlString: string,
+  options?: { readonly mainWin?: BrowserWindow }
+): boolean {
   const authUrl = buildDesktopBrowserAuthUrl(urlString);
   if (!authUrl) return false;
 
   showDesktopAuthHandoff(authUrl);
+  if (options?.mainWin) {
+    loadMainWindowAuthHandoff(options.mainWin, authUrl);
+  }
   return true;
 }
 
@@ -851,14 +918,9 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   // sign in. If nothing has become visible shortly after launch, force a
   // usable sign-in surface into THIS (main) window, which we know can render.
   const initialVisibilityFallback = setTimeout(() => {
-    if (win.isDestroyed() || isAuthHandoffOpen() || win.isVisible()) return;
-    const current = win.webContents.getURL();
-    if (!current || current === 'about:blank') {
-      const authUrl = buildCentralDesktopAuthUrl('sign_in', '/app');
-      void win.loadURL(buildDesktopAuthHandoffUrl(authUrl));
-    }
-    showWindowNow(win);
-  }, 6000);
+    if (win.isDestroyed()) return;
+    ensureSignedOutSignInSurface(win);
+  }, DESKTOP_VISIBILITY_FALLBACK_MS);
 
   win.once('ready-to-show', () => {
     clearTimeout(initialVisibilityFallback);
@@ -901,8 +963,11 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
 
         if (
           typeof validatedURL === 'string' &&
-          maybeShowDesktopAuthHandoff(resolveNavigationUrl(validatedURL))
+          maybeShowDesktopAuthHandoff(resolveNavigationUrl(validatedURL), {
+            mainWin: win,
+          })
         ) {
+          ensureSignedOutSignInSurface(win);
           return;
         }
 
@@ -990,7 +1055,7 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   // dedicated handoff; all other safe URLs open in the system browser.
   win.webContents.on('will-navigate', (event, url) => {
     const navigationUrl = resolveNavigationUrl(url);
-    if (maybeShowDesktopAuthHandoff(navigationUrl)) {
+    if (maybeShowDesktopAuthHandoff(navigationUrl, { mainWin: win })) {
       event.preventDefault();
       return;
     }
@@ -1015,7 +1080,7 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
 
   win.webContents.on('will-redirect', (event, url, _isInPlace, isMainFrame) => {
     const navigationUrl = resolveNavigationUrl(url);
-    if (maybeShowDesktopAuthHandoff(navigationUrl)) {
+    if (maybeShowDesktopAuthHandoff(navigationUrl, { mainWin: win })) {
       event.preventDefault();
       return;
     }
@@ -1037,7 +1102,7 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   // navigation guards. Internal targets stay in the app, safe external links
   // open in the system browser, and unsafe protocols are silently dropped.
   win.webContents.setWindowOpenHandler(({ url }) => {
-    if (maybeShowDesktopAuthHandoff(url)) {
+    if (maybeShowDesktopAuthHandoff(url, { mainWin: win })) {
       return { action: 'deny' };
     }
 
@@ -1076,7 +1141,7 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   const initialAuthUrl = buildDesktopBrowserAuthUrl(initialUrl);
   if (initialAuthUrl) {
     showDesktopAuthHandoff(initialAuthUrl);
-    void win.loadURL(buildDesktopAuthHandoffUrl(initialAuthUrl));
+    loadMainWindowAuthHandoff(win, initialAuthUrl);
   } else {
     void win.loadURL(initialUrl);
   }
@@ -1390,13 +1455,7 @@ ipcMain.handle(
 );
 
 function registerAuthReturnProtocol(): void {
-  // Only the canonical production bundle (app.jov.ie) may own jovie:// deep
-  // links. Staging/local shells use separate bundle IDs and must not compete
-  // with the installed production handler — see apps/desktop/BUILDS.md.
-  if (APP_ENV !== 'production') {
-    return;
-  }
-
+  const scheme = AUTH_RETURN_SCHEME;
   const defaultAppProcess = process as NodeJS.Process & {
     readonly defaultApp?: boolean;
   };
@@ -1406,13 +1465,13 @@ function registerAuthReturnProtocol(): void {
     process.argv.length >= 2 &&
     !app.isPackaged
   ) {
-    app.setAsDefaultProtocolClient('jovie', process.execPath, [
+    app.setAsDefaultProtocolClient(scheme, process.execPath, [
       path.resolve(process.argv[1]),
     ]);
     return;
   }
 
-  app.setAsDefaultProtocolClient('jovie');
+  app.setAsDefaultProtocolClient(scheme);
 }
 
 if (gotSingleInstanceLock) {
@@ -1452,7 +1511,7 @@ if (gotSingleInstanceLock) {
       return;
     }
 
-    if (url.startsWith('jovie://auth/complete')) {
+    if (url.startsWith(`${AUTH_RETURN_PROTOCOL}//${AUTH_RETURN_HOST}/complete`)) {
       reportDesktopSecurityEvent('auth-deep-link-invalid-params');
       return;
     }

--- a/apps/web/app/(auth)/auth/native-return/page.test.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.test.tsx
@@ -60,6 +60,16 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     );
   });
 
+  it('uses the staging desktop shell scheme when shell=staging', () => {
+    setSearchParams(`code=${CODE}&state=${STATE}&shell=staging`);
+    render(<NativeReturnPage />);
+
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      `jovie-staging://auth/complete?code=${CODE}&state=${STATE}`
+    );
+  });
+
   it('shows a recovery message and no deep link when required params are missing', () => {
     setSearchParams(`state=${STATE}`);
     render(<NativeReturnPage />);

--- a/apps/web/app/(auth)/auth/native-return/page.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { buildElectronAuthCompleteUrl } from '@jovie/auth-routing';
+import {
+  buildElectronAuthCompleteUrl,
+  isElectronAuthShell,
+} from '@jovie/auth-routing';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useMemo } from 'react';
@@ -34,8 +37,11 @@ function NativeReturnContent() {
       rawDesktopFlow && DESKTOP_FLOW_PATTERN.test(rawDesktopFlow)
         ? rawDesktopFlow
         : null;
+    const rawShell = searchParams.get('shell');
+    const shell =
+      rawShell && isElectronAuthShell(rawShell) ? rawShell : 'production';
 
-    return buildElectronAuthCompleteUrl({ code, state, desktopFlow });
+    return buildElectronAuthCompleteUrl({ code, state, desktopFlow, shell });
   }, [searchParams]);
 
   useEffect(() => {

--- a/apps/web/app/auth/callback/route.test.ts
+++ b/apps/web/app/auth/callback/route.test.ts
@@ -69,7 +69,7 @@ describe('GET /auth/callback', () => {
     expect(response.status).toBe(307);
     const location = response.headers.get('location');
     expect(location).toBe(
-      'https://jov.ie/auth/native-return?code=00000000000040008000000000000001&state=state_123'
+      'https://jov.ie/auth/native-return?code=00000000000040008000000000000001&state=state_123&shell=production'
     );
     // The browser must never receive a bare custom-scheme redirect here.
     expect(location?.startsWith('jovie://')).toBe(false);
@@ -110,7 +110,7 @@ describe('GET /auth/callback', () => {
     );
 
     expect(response.headers.get('location')).toBe(
-      'https://jov.ie/auth/native-return?code=00000000000040008000000000000001&state=state_123&desktop_flow=flow_nonce_abcdef123456'
+      'https://jov.ie/auth/native-return?code=00000000000040008000000000000001&state=state_123&shell=production&desktop_flow=flow_nonce_abcdef123456'
     );
   });
 

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -4,6 +4,7 @@ import {
   createAuthAnalyticsEvent,
   type NativeAuthClient,
   resolveAuthCallback,
+  resolveElectronAuthShell,
 } from '@jovie/auth-routing';
 import { NextResponse } from 'next/server';
 import { APP_ROUTES } from '@/constants/routes';
@@ -95,6 +96,7 @@ export async function GET(request: Request) {
       const bounce = new URL('/auth/native-return', request.url);
       bounce.searchParams.set('code', exchangeCode);
       bounce.searchParams.set('state', stateRecord.state);
+      bounce.searchParams.set('shell', resolveElectronAuthShell(request.url));
       if (stateRecord.desktopFlow) {
         bounce.searchParams.set('desktop_flow', stateRecord.desktopFlow);
       }

--- a/packages/auth-routing/auth-routing.test.ts
+++ b/packages/auth-routing/auth-routing.test.ts
@@ -3,6 +3,8 @@ import {
   buildAuthStartUrl,
   buildElectronAuthCompleteUrl,
   buildIosAuthCompleteUrl,
+  getElectronAuthScheme,
+  resolveElectronAuthShell,
   buildNativeExchangeCodeRecord,
   classifyNavigation,
   createAuthAnalyticsEvent,
@@ -264,6 +266,34 @@ describe('auth routing boundary', () => {
     ).toBe(
       'jovie://auth/complete?code=c&state=s&desktop_flow=desktop_flow_nonce_12345'
     );
+    expect(
+      buildElectronAuthCompleteUrl({
+        code: 'c',
+        state: 's',
+        shell: 'staging',
+      })
+    ).toBe('jovie-staging://auth/complete?code=c&state=s');
+    expect(
+      buildElectronAuthCompleteUrl({
+        code: 'c',
+        state: 's',
+        shell: 'local',
+      })
+    ).toBe('jovie-local://auth/complete?code=c&state=s');
+  });
+
+  it('resolves electron auth shells from request origin', () => {
+    expect(resolveElectronAuthShell('https://jov.ie/auth/callback')).toBe(
+      'production'
+    );
+    expect(
+      resolveElectronAuthShell('https://staging.jov.ie/auth/callback')
+    ).toBe('staging');
+    expect(resolveElectronAuthShell('http://localhost:3112/auth/callback')).toBe(
+      'local'
+    );
+    expect(getElectronAuthScheme('staging')).toBe('jovie-staging');
+    expect(getElectronAuthScheme('local')).toBe('jovie-local');
   });
 
   it('creates analytics payloads without leaking return URLs or token values', () => {

--- a/packages/auth-routing/auth-routing.test.ts
+++ b/packages/auth-routing/auth-routing.test.ts
@@ -3,13 +3,13 @@ import {
   buildAuthStartUrl,
   buildElectronAuthCompleteUrl,
   buildIosAuthCompleteUrl,
-  getElectronAuthScheme,
-  resolveElectronAuthShell,
   buildNativeExchangeCodeRecord,
   classifyNavigation,
   createAuthAnalyticsEvent,
   createAuthStateRecord,
+  getElectronAuthScheme,
   resolveAuthCallback,
+  resolveElectronAuthShell,
   sanitizeReturnTo,
   validateNativeExchange,
 } from './index';
@@ -289,9 +289,9 @@ describe('auth routing boundary', () => {
     expect(
       resolveElectronAuthShell('https://staging.jov.ie/auth/callback')
     ).toBe('staging');
-    expect(resolveElectronAuthShell('http://localhost:3112/auth/callback')).toBe(
-      'local'
-    );
+    expect(
+      resolveElectronAuthShell('http://localhost:3112/auth/callback')
+    ).toBe('local');
     expect(getElectronAuthScheme('staging')).toBe('jovie-staging');
     expect(getElectronAuthScheme('local')).toBe('jovie-local');
   });

--- a/packages/auth-routing/index.ts
+++ b/packages/auth-routing/index.ts
@@ -83,6 +83,43 @@ const ELECTRON_AUTH_COMPLETE_URL = 'jovie://auth/complete';
 const IOS_UNIVERSAL_AUTH_COMPLETE_PATH = '/auth/ios/complete';
 const DEFAULT_DOCS_URL = 'https://docs.jov.ie';
 
+/** Per-shell custom URL schemes so prod/staging/local Mac apps do not compete. */
+export const ELECTRON_AUTH_SCHEME_BY_SHELL = {
+  production: 'jovie',
+  staging: 'jovie-staging',
+  local: 'jovie-local',
+} as const;
+
+export type ElectronAuthShell = keyof typeof ELECTRON_AUTH_SCHEME_BY_SHELL;
+
+const ELECTRON_AUTH_SHELLS = new Set<string>(
+  Object.keys(ELECTRON_AUTH_SCHEME_BY_SHELL)
+);
+
+export function isElectronAuthShell(value: string): value is ElectronAuthShell {
+  return ELECTRON_AUTH_SHELLS.has(value);
+}
+
+export function getElectronAuthScheme(shell: ElectronAuthShell): string {
+  return ELECTRON_AUTH_SCHEME_BY_SHELL[shell];
+}
+
+export function resolveElectronAuthShell(origin: string): ElectronAuthShell {
+  try {
+    const parsed = new URL(origin);
+    if (parsed.hostname === 'staging.jov.ie') {
+      return 'staging';
+    }
+    if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+      return 'local';
+    }
+  } catch {
+    // Fall through to production.
+  }
+
+  return 'production';
+}
+
 const RETURN_BLOCKED_PREFIXES = [
   '/api',
   '/__clerk',
@@ -352,8 +389,10 @@ export function buildElectronAuthCompleteUrl(input: {
   readonly code: string;
   readonly state: string;
   readonly desktopFlow?: string | null;
+  readonly shell?: ElectronAuthShell;
 }): string {
-  return buildUrlWithCodeAndState(ELECTRON_AUTH_COMPLETE_URL, input);
+  const scheme = getElectronAuthScheme(input.shell ?? 'production');
+  return buildUrlWithCodeAndState(`${scheme}://auth/complete`, input);
 }
 
 export function resolveAuthCallback(input: {


### PR DESCRIPTION
Closes #12822

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12822-2026-07-03T14-00-32-338z.log`