### PR TITLE
chore(codex): Tracker migration phase 2: GitHub-native orchestrator dispatch + Hermes-Air intake (#12725)

### DIFF
--- a/scripts/github-transition-issue.mjs
+++ b/scripts/github-transition-issue.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { normalizeIssueNumber, transitionIssue } from './lib/tracker.mjs';
+
+const number = normalizeIssueNumber(process.argv[2]);
+const target = (process.argv[3] ?? 'in-review').trim().toLowerCase();
+const comment = process.argv[4];
+const repo = process.env.GITHUB_REPOSITORY;
+
+const statusMap = {
+  'in-progress': 'in-progress',
+  'in progress': 'in-progress',
+  'in-review': 'in-review',
+  'in review': 'in-review',
+  done: 'done',
+  closed: 'done',
+};
+
+if (!number || !statusMap[target]) process.exit(1);
+
+const result = transitionIssue({
+  number,
+  repo,
+  status: statusMap[target],
+  comment,
+});
+
+if (!result.success) {
+  console.error(result.error ?? 'transition failed');
+  process.exit(1);
+}
+
+console.log(`#${number} -> ${target}`);

--- a/scripts/hermes/lib/hermes-paths.ts
+++ b/scripts/hermes/lib/hermes-paths.ts
@@ -24,6 +24,7 @@ export const HERMES_PATHS = {
   heavyJobLock: join(HERMES_HOME, 'state', 'heavy-job.lock'),
   modelRankings: join(HERMES_HOME, 'state', 'model-router-rankings.json'),
   linearQueue: join(HERMES_HOME, 'state', 'linear-queue.jsonl'),
+  trackerQueue: join(HERMES_HOME, 'state', 'tracker-queue.jsonl'),
   telegramChatId: join(HERMES_HOME, 'state', 'telegram-chat-id'),
 } as const;
 


### PR DESCRIPTION
Closes #12725

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12725-2026-07-03T14-01-45-367z.log`