### PR TITLE
feat(ui): canonical ProgressBar loading primitive + loading-states guide (#12884)

### DIFF
--- a/docs/LOADING_STATES.md
+++ b/docs/LOADING_STATES.md
@@ -1,0 +1,76 @@
+# Canonical Loading States
+
+Three loading states, each with one job. **Never mix them** — a spinner inside a
+skeleton is wrong, a full-page progress bar for a list load is wrong.
+
+Source of truth: `@jovie/ui` (`Skeleton`, `LoadingSkeleton`, `ProgressBar`) and
+`apps/web/components/atoms/LoadingSpinner.tsx` (`Spinner`).
+
+## When to use each
+
+| State | Use for | Do NOT use for |
+|-------|---------|----------------|
+| **Skeleton** | Predictable page/list loads where the loaded layout is known ahead of time | In-flight button actions; unknown-shape content |
+| **Spinner** | Buttons and inline in-flight actions (save, submit, refresh) | Full-page loads; anything where you can mirror the layout |
+| **ProgressBar** | Long uploads/imports where a real percent is known | Loads with no measurable percent; short actions |
+
+Decision rule: **known layout → Skeleton. Known percent → ProgressBar.
+Everything else short and inline → Spinner.**
+
+## Skeleton — predictable loads
+
+Mirror the loaded layout 1:1 so nothing shifts when real content arrives
+(`.claude/rules/ui.md` → Layout Shift Prevention). Placeholders use the canonical
+skeleton tone (`--color-skeleton-base` + shimmer), not `bg-surface-1` directly.
+
+```tsx
+import { Skeleton, LoadingSkeleton } from '@jovie/ui';
+
+// A single placeholder sized to the real element
+<Skeleton className="h-10 w-10" rounded="full" />   // avatar
+
+// Multi-line text (last line 75% width)
+<LoadingSkeleton lines={3} height="h-4" />
+```
+
+Skeleton is `aria-hidden`; `LoadingSkeleton` wraps in `role="status" aria-busy`.
+
+## Spinner — in-flight actions
+
+Inline only. Sizes `sm | md | lg`, tones `primary | muted | inverse`.
+
+```tsx
+import { Spinner } from '@/components/atoms/LoadingSpinner';
+
+<Button disabled={isSaving}>
+  {isSaving && <Spinner size="sm" tone="inverse" />}
+  Save
+</Button>
+```
+
+`Spinner` is an alias of `LoadingSpinner`. It renders an `<output>` with an
+`aria-label` and respects `prefers-reduced-motion`.
+
+## ProgressBar — long uploads/imports
+
+Only when a real percent is known. Percent + optional label slot.
+
+```tsx
+import { ProgressBar } from '@jovie/ui';
+
+<ProgressBar value={62} label="Importing releases" />
+<ProgressBar value={40} size="sm" ariaLabel="Upload progress" showValue={false} />
+```
+
+Track is `bg-surface-2`, fill is `bg-accent`, width transitions with
+`duration-normal` and stops under reduced motion. Value is clamped to 0–100.
+Exposes `role="progressbar"` with `aria-valuenow/min/max`.
+
+## Migrating existing surfaces
+
+Existing ad-hoc bars (`ReleaseTaskProgressBar`, `ImportProgressBanner`,
+`ProfileCompletionCard`) predate the canonical `ProgressBar`. Converge each one
+onto the primitive when you next touch it — but only with a browser layout-shift
+check, since track/label composition is taste-sensitive. Do not attempt a bulk
+mechanical sweep: those bars carry custom label logic and live on
+taste-sensitive surfaces, so each conversion needs its own visual review.

--- a/packages/ui/atoms/progress.stories.tsx
+++ b/packages/ui/atoms/progress.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { ProgressBar } from './progress';
+
+const meta: Meta<typeof ProgressBar> = {
+  title: 'shadcn/ProgressBar',
+  component: ProgressBar,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Canonical determinate progress bar for uploads/imports. Track is bg-surface-2, fill is bg-accent. Use only when a real percent is known — otherwise use Skeleton (page/list loads) or Spinner (in-flight actions). Never mix.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    value: 62,
+  },
+  decorators: [
+    Story => (
+      <div className='w-80'>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithLabel: Story = {
+  args: {
+    label: 'Importing releases',
+  },
+};
+
+export const PercentOnly: Story = {
+  args: {
+    value: 40,
+  },
+};
+
+export const NoHeader: Story = {
+  args: {
+    value: 75,
+    showValue: false,
+    ariaLabel: 'Upload progress',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    value: 30,
+    size: 'sm',
+    label: 'Uploading track',
+  },
+};
+
+export const Complete: Story = {
+  args: {
+    value: 100,
+    label: 'Import complete',
+  },
+};

--- a/packages/ui/atoms/progress.test.tsx
+++ b/packages/ui/atoms/progress.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ProgressBar } from './progress';
+
+describe('ProgressBar', () => {
+  it('exposes accessible progressbar semantics', () => {
+    render(<ProgressBar value={40} ariaLabel='Upload progress' />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '40');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+    expect(bar).toHaveAttribute('aria-label', 'Upload progress');
+  });
+
+  it('renders the label slot and percent by default', () => {
+    render(<ProgressBar value={62} label='Importing releases' />);
+    expect(screen.getByText('Importing releases')).toBeInTheDocument();
+    expect(screen.getByText('62%')).toBeInTheDocument();
+  });
+
+  it('drops the redundant aria-label when a visible label is present', () => {
+    render(<ProgressBar value={10} label='Uploading' />);
+    expect(screen.getByRole('progressbar')).not.toHaveAttribute('aria-label');
+  });
+
+  it('derives the accessible name from the visible label', () => {
+    render(<ProgressBar value={10} label='Importing releases' />);
+    // Accessible name is computed from aria-labelledby → the label span.
+    expect(
+      screen.getByRole('progressbar', { name: 'Importing releases' })
+    ).toBeInTheDocument();
+  });
+
+  it('forwards arbitrary props (data-testid) to the wrapper', () => {
+    render(<ProgressBar value={10} data-testid='import-progress' />);
+    expect(screen.getByTestId('import-progress')).toBeInTheDocument();
+  });
+
+  it('hides the percent when showValue is false', () => {
+    render(<ProgressBar value={80} label='Sync' showValue={false} />);
+    expect(screen.queryByText('80%')).not.toBeInTheDocument();
+  });
+
+  it('clamps values above 100 and below 0', () => {
+    const { rerender } = render(<ProgressBar value={150} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '100'
+    );
+    rerender(<ProgressBar value={-20} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '0'
+    );
+  });
+
+  it('coerces NaN to 0', () => {
+    render(<ProgressBar value={Number.NaN} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '0'
+    );
+  });
+
+  it('sets the fill width to the clamped percent', () => {
+    render(<ProgressBar value={62} label='x' />);
+    const fill = screen.getByRole('progressbar').firstElementChild;
+    expect(fill).toHaveStyle({ width: '62%' });
+  });
+
+  it('applies the small track height', () => {
+    render(<ProgressBar value={30} size='sm' />);
+    expect(screen.getByRole('progressbar')).toHaveClass('h-1');
+  });
+
+  it('applies the default medium track height', () => {
+    render(<ProgressBar value={30} />);
+    expect(screen.getByRole('progressbar')).toHaveClass('h-2');
+  });
+
+  it('rounds fractional percentages', () => {
+    render(<ProgressBar value={62.6} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '63'
+    );
+  });
+
+  it('renders no header row when label is absent and showValue is false', () => {
+    const { container } = render(
+      <ProgressBar value={50} showValue={false} ariaLabel='Sync' />
+    );
+    expect(screen.queryByText('50%')).not.toBeInTheDocument();
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.children).toHaveLength(1);
+    expect(wrapper?.firstElementChild).toHaveAttribute('role', 'progressbar');
+  });
+
+  it('shows only the percent in the header when no label is provided', () => {
+    render(<ProgressBar value={45} />);
+    expect(screen.getByText('45%')).toBeInTheDocument();
+  });
+
+  it('respects reduced motion on the fill transition', () => {
+    render(<ProgressBar value={30} />);
+    const fill = screen.getByRole('progressbar').firstElementChild;
+    expect(fill?.className).toContain('motion-reduce:transition-none');
+  });
+});

--- a/packages/ui/atoms/progress.tsx
+++ b/packages/ui/atoms/progress.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import type { HTMLAttributes, ReactNode } from 'react';
+import { useId } from 'react';
+
+import { cn } from '../lib/utils';
+
+type ProgressSize = 'sm' | 'md';
+
+export interface ProgressBarProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Completion percentage, 0–100. Values outside the range are clamped.
+   */
+  readonly value: number;
+  /**
+   * Optional label rendered above the bar (left side).
+   * Use for "Importing releases", "Uploading track", etc.
+   */
+  readonly label?: ReactNode;
+  /**
+   * Show the numeric percent on the right of the label row.
+   * @default true
+   */
+  readonly showValue?: boolean;
+  /**
+   * Track height.
+   * @default 'md'
+   */
+  readonly size?: ProgressSize;
+  /**
+   * Accessible name used when no visible `label` is provided.
+   * @default 'Progress'
+   */
+  readonly ariaLabel?: string;
+}
+
+const trackHeight: Record<ProgressSize, string> = {
+  sm: 'h-1',
+  md: 'h-2',
+};
+
+const clampPercent = (value: number): number => {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(100, Math.max(0, Math.round(value)));
+};
+
+/**
+ * Canonical determinate progress bar for long-running actions
+ * (uploads, imports). Shows a percent and an optional label slot.
+ *
+ * Loading-state contract (see docs/LOADING_STATES.md):
+ * use a ProgressBar only when real percent is known. For predictable
+ * page/list loads use `Skeleton`; for in-flight buttons/actions use
+ * `Spinner`. Never mix (no spinner inside a skeleton).
+ *
+ * Keep `label`/`showValue` stable for a mounted instance — toggling
+ * either flips the header row on/off and would shift the track. Reset
+ * with a `key` remount if the header composition must change.
+ *
+ * @example
+ * ```tsx
+ * <ProgressBar value={62} label="Importing releases" />
+ * <ProgressBar value={40} size="sm" ariaLabel="Upload progress" showValue={false} />
+ * ```
+ */
+export function ProgressBar({
+  value,
+  label,
+  showValue = true,
+  size = 'md',
+  ariaLabel = 'Progress',
+  className,
+  ...rest
+}: ProgressBarProps) {
+  const percent = clampPercent(value);
+  const hasLabel = label != null;
+  const showHeader = hasLabel || showValue;
+  const labelId = useId();
+
+  return (
+    <div className={cn('w-full', className)} {...rest}>
+      {showHeader && (
+        <div className='mb-1 flex items-center justify-between gap-2 text-sm'>
+          <span
+            id={hasLabel ? labelId : undefined}
+            className='text-secondary-token'
+          >
+            {label}
+          </span>
+          {showValue && (
+            <span className='text-tertiary-token tabular-nums'>{percent}%</span>
+          )}
+        </div>
+      )}
+      <div
+        role='progressbar'
+        aria-label={hasLabel ? undefined : ariaLabel}
+        aria-labelledby={hasLabel ? labelId : undefined}
+        aria-valuenow={percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className={cn(
+          'w-full overflow-hidden rounded-full bg-surface-2',
+          trackHeight[size]
+        )}
+      >
+        <div
+          className={cn(
+            'h-full rounded-full bg-accent',
+            'transition-[width] duration-normal ease-out motion-reduce:transition-none'
+          )}
+          // Inline width is dynamic data (clamped 0–100), not a static design
+          // value — do not convert to an arbitrary Tailwind class.
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -186,6 +186,9 @@ export {
   PopoverContent,
   PopoverTrigger,
 } from './atoms/popover';
+// Progress
+export type { ProgressBarProps } from './atoms/progress';
+export { ProgressBar } from './atoms/progress';
 // Radio Group
 export { RadioGroup, RadioGroupItem } from './atoms/radio-group';
 // Searchable Submenu


### PR DESCRIPTION
Closes #12884

<!-- linear-issue-id: none (ad-hoc GitHub issue #12884) -->

## What this ships

Canonical loading states, done the lazy-correct way: **build only what was
missing, don't duplicate what already exists.**

Auditing the codebase first (prior-art gate) showed two of the three requested
primitives are **already canonical**:

| Primitive | Status |
|-----------|--------|
| `Skeleton` / `LoadingSkeleton` | ✅ already in `@jovie/ui` (`packages/ui/atoms/skeleton.tsx`), shimmer via `--color-skeleton-base` |
| `Spinner` (sm/md/lg + tones) | ✅ already exists as `LoadingSpinner`/`Spinner` (`apps/web/components/atoms/LoadingSpinner.tsx`) |
| **`ProgressBar` (percent + label)** | ❌ **missing** — `ProgressIndicator` is a multi-step wizard, not a percent bar. **This PR adds it.** |

So this PR adds the one genuinely-missing primitive plus the canonical rules doc,
rather than re-implementing Skeleton/Spinner and creating drift.

### Added
- **`packages/ui/atoms/progress.tsx`** — determinate `ProgressBar` (`value` 0–100,
  optional `label` slot, `showValue`, `size` sm/md).
  - Dep-light: **no `motion`/framer** (keeps `@jovie/ui`'s React/Radix/CVA/Tailwind boundary); CSS `transition-[width]`, reduced-motion safe.
  - Token-only styling: track `bg-surface-2`, fill `bg-accent` (no arbitrary hex/px).
  - Accessible: `role="progressbar"` + `aria-valuenow/min/max`; accessible **name** via `aria-labelledby` (visible label) or `aria-label` fallback.
  - Value clamped (NaN→0, <0→0, >100→100, rounds floats); spreads `...rest` like sibling `Skeleton`.
- **`progress.test.tsx`** — 15 tests (a11y name, clamping, rounding, header logic, sizes, fill width, reduced-motion, prop forwarding).
- **`progress.stories.tsx`** — WithLabel / PercentOnly / NoHeader / Small / Complete.
- **`docs/LOADING_STATES.md`** — migration guide: when to use Skeleton vs Spinner vs ProgressBar, "never mix", token rules, migration guidance.
- **`packages/ui/index.ts`** — export `ProgressBar` + `ProgressBarProps`.

## Acceptance mapping (#12884)

- [x] `Skeleton` primitive in `@jovie/ui` (matches loaded content) — **already existed**, confirmed canonical.
- [x] `Spinner` with sm/md/lg — **already existed** (`LoadingSpinner`/`Spinner`).
- [x] `ProgressBar` with percent + label slot — **added here**.
- [x] Migration guide: when to use each — `docs/LOADING_STATES.md`.
- [ ] **Audit + fix 10+ existing loading surfaces — deferred (needs human taste).** See below.
- [x] Skeletons use a canonical placeholder tone — existing `--color-skeleton-base` (purpose-built loading tone; forcing literal `surface-1` would kill shimmer contrast).

## Deferred (needs human taste — not auto-shipped)

The "audit and fix 10+ existing loading surfaces" sweep is **intentionally not in
this PR.** It is a taste-touching, cross-surface visual change that (a) would blow
the 800-line/40-file PR size cap, (b) requires per-surface browser layout-shift QA,
and (c) touches surfaces with custom label logic (`ReleaseTaskProgressBar`,
`ImportProgressBanner`, `ProfileCompletionCard`). Per the autonomous-shipping
doctrine, taste-touching work goes to the human-taste queue, not an autonomous
mechanical sweep. The canonical primitive + guide land first so those migrations
have a target to converge on.

> Follow-up tracking: Linear MCP was unavailable in this session (auth), so a
> Linear ticket could not be filed programmatically. This PR + issue #12884 are
> the tracking anchor for the migration sweep; it needs a Linear ID + human taste
> review before pickup.

## Verification

```
# @jovie/ui unit tests (new ProgressBar)
$ pnpm --filter @jovie/ui exec vitest run atoms/progress.test.tsx
  Test Files  1 passed (1)
       Tests  15 passed (15)

# @jovie/ui typecheck
$ pnpm --filter @jovie/ui run typecheck        → tsc --noEmit, 0 errors

# web typecheck (export is additive; consumed cross-package)
$ pnpm --filter @jovie/web run typecheck -- --pretty false  → 0 errors

# formatting/lint
$ biome check packages/ui/atoms/progress.*     → clean, no fixes
```

Reviews run before opening:
- **CodeRabbit** (`coderabbit review --agent -t uncommitted`): 4 findings — 2 trivial nits applied (`toHaveClass` precision, Tailwind width in story), doc reworded to remove orphan-follow-up wording; 1 "always reserve header space" **skipped with reason** (would regress the intentional headerless bar — the headerless variant is prop-stable, documented in JSDoc).
- **Review subagent**: found + fixed an a11y **blocker** (visible label had no accessible name → wired `aria-labelledby`); added `...rest` forwarding.
- **Security subagent**: no findings (presentational; `width` interpolation is a clamped number, CSS-injection-proof).
- **Testing subagent**: 4 branch-coverage gaps identified → all added.

## Cost Impact

None. No cron, no external API calls, no scheduled work, no new runtime deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
