### PR TITLE
chore(codex): Per-env desktop deep-link schemes so auth returns to the correct app (Staging/Local) (#12927)

### DIFF
--- a/apps/desktop/electron-builder.local.yml
+++ b/apps/desktop/electron-builder.local.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Local Auth
+        CFBundleURLSchemes:
+          - jovie-local
   notarize: false
   target:
     - target: dir

--- a/apps/desktop/electron-builder.staging.yml
+++ b/apps/desktop/electron-builder.staging.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Staging Auth
+        CFBundleURLSchemes:
+          - jovie-staging
   notarize: true
   target:
     - target: dmg

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -166,7 +166,7 @@ test('desktop macOS entitlements keep only allow-jit (no sandbox-weakening flags
   }
 });
 
-test('desktop production bundle declares the jovie auth protocol', async () => {
+test('desktop bundles declare per-env auth URL schemes', async () => {
   const [builderConfig, mainSource, stagingConfig, localConfig] =
     await Promise.all([
       readFile(join(desktopRoot, 'electron-builder.yml'), 'utf8'),
@@ -178,10 +178,18 @@ test('desktop production bundle declares the jovie auth protocol', async () => {
   assert.match(builderConfig, /CFBundleURLTypes:/);
   assert.match(builderConfig, /CFBundleURLName: Jovie Auth/);
   assert.match(builderConfig, /CFBundleURLSchemes:\s*\n\s*- jovie/);
-  assert.match(mainSource, /if \(APP_ENV !== 'production'\)/);
-  assert.match(mainSource, /setAsDefaultProtocolClient\('jovie'\)/);
-  assert.doesNotMatch(stagingConfig, /CFBundleURLTypes:/);
-  assert.doesNotMatch(localConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLName: Jovie Staging Auth/);
+  assert.match(stagingConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-staging/);
+  assert.match(localConfig, /CFBundleURLTypes:/);
+  assert.match(localConfig, /CFBundleURLName: Jovie Local Auth/);
+  assert.match(localConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-local/);
+  assert.match(mainSource, /const AUTH_RETURN_SCHEME =/);
+  assert.match(mainSource, /setAsDefaultProtocolClient\(AUTH_RETURN_SCHEME\)/);
+  assert.doesNotMatch(
+    mainSource,
+    /if \(APP_ENV !== 'production'\) \{\s*return;\s*\}/
+  );
 });
 
 test('desktop navigation uses explicit URL disposition allowlists', async () => {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -90,7 +90,13 @@ const DESKTOP_AUTH_HANDOFF_PATH = '/desktop-auth';
 const DESKTOP_AUTH_START_PATH = '/auth/start';
 const DESKTOP_AUTH_NATIVE_COMPLETE_PATH = '/auth/native-complete';
 const DESKTOP_RETURN_PARAM = 'desktop_return';
-const AUTH_RETURN_PROTOCOL = 'jovie:';
+const AUTH_RETURN_SCHEME =
+  APP_ENV === 'staging'
+    ? 'jovie-staging'
+    : APP_ENV === 'local'
+      ? 'jovie-local'
+      : 'jovie';
+const AUTH_RETURN_PROTOCOL = `${AUTH_RETURN_SCHEME}:`;
 const AUTH_RETURN_HOST = 'auth';
 const AUTH_RETURN_COMPLETE_PATH = '/complete';
 const LEGACY_AUTH_RETURN_HOST = 'auth-return';
@@ -1390,13 +1396,8 @@ ipcMain.handle(
 );
 
 function registerAuthReturnProtocol(): void {
-  // Only the canonical production bundle (app.jov.ie) may own jovie:// deep
-  // links. Staging/local shells use separate bundle IDs and must not compete
-  // with the installed production handler — see apps/desktop/BUILDS.md.
-  if (APP_ENV !== 'production') {
-    return;
-  }
-
+  // Each desktop env owns a distinct custom scheme so auth callbacks never
+  // open the wrong installed app (jovie / jovie-staging / jovie-local).
   const defaultAppProcess = process as NodeJS.Process & {
     readonly defaultApp?: boolean;
   };
@@ -1406,13 +1407,13 @@ function registerAuthReturnProtocol(): void {
     process.argv.length >= 2 &&
     !app.isPackaged
   ) {
-    app.setAsDefaultProtocolClient('jovie', process.execPath, [
+    app.setAsDefaultProtocolClient(AUTH_RETURN_SCHEME, process.execPath, [
       path.resolve(process.argv[1]),
     ]);
     return;
   }
 
-  app.setAsDefaultProtocolClient('jovie');
+  app.setAsDefaultProtocolClient(AUTH_RETURN_SCHEME);
 }
 
 if (gotSingleInstanceLock) {
@@ -1452,7 +1453,7 @@ if (gotSingleInstanceLock) {
       return;
     }
 
-    if (url.startsWith('jovie://auth/complete')) {
+    if (url.startsWith(`${AUTH_RETURN_SCHEME}://auth/complete`)) {
       reportDesktopSecurityEvent('auth-deep-link-invalid-params');
       return;
     }

--- a/apps/web/app/(auth)/auth/native-return/page.test.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.test.tsx
@@ -35,22 +35,53 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     // jsdom cannot navigate to a custom scheme; swallow the auto-fire assign.
     Object.defineProperty(globalThis, 'location', {
       configurable: true,
-      value: { href: 'http://localhost/' },
+      value: { href: 'http://localhost/', origin: 'http://localhost:3000' },
     });
   });
 
-  it('renders an Open Jovie button pointing at the jovie:// deep link', () => {
+  it('renders an Open Jovie button pointing at the jovie-local:// deep link on localhost', () => {
     setSearchParams(`code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`);
     render(<NativeReturnPage />);
 
     const link = screen.getByRole('link', { name: 'Open Jovie' });
     expect(link).toHaveAttribute(
       'href',
-      `jovie://auth/complete?code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`
+      `jovie-local://auth/complete?code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`
     );
   });
 
   it('preserves the deep link without desktop_flow when absent', () => {
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      `jovie-local://auth/complete?code=${CODE}&state=${STATE}`
+    );
+  });
+
+  it('uses jovie-staging:// on staging.jov.ie', () => {
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://staging.jov.ie/',
+        origin: 'https://staging.jov.ie',
+      },
+    });
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      `jovie-staging://auth/complete?code=${CODE}&state=${STATE}`
+    );
+  });
+
+  it('uses jovie:// on production jov.ie', () => {
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: { href: 'https://jov.ie/', origin: 'https://jov.ie' },
+    });
     setSearchParams(`code=${CODE}&state=${STATE}`);
     render(<NativeReturnPage />);
 

--- a/apps/web/app/(auth)/auth/native-return/page.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { buildElectronAuthCompleteUrl } from '@jovie/auth-routing';
+import {
+  buildElectronAuthCompleteUrl,
+  resolveElectronAuthScheme,
+} from '@jovie/auth-routing';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useMemo } from 'react';
@@ -35,7 +38,12 @@ function NativeReturnContent() {
         ? rawDesktopFlow
         : null;
 
-    return buildElectronAuthCompleteUrl({ code, state, desktopFlow });
+    const origin =
+      typeof globalThis.location !== 'undefined'
+        ? globalThis.location.origin
+        : null;
+    const scheme = resolveElectronAuthScheme({ origin });
+    return buildElectronAuthCompleteUrl({ code, state, desktopFlow, scheme });
   }, [searchParams]);
 
   useEffect(() => {

--- a/packages/auth-routing/auth-routing.test.ts
+++ b/packages/auth-routing/auth-routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildAuthStartUrl,
+  buildElectronAuthCompleteBaseUrl,
   buildElectronAuthCompleteUrl,
   buildIosAuthCompleteUrl,
   buildNativeExchangeCodeRecord,
@@ -8,6 +9,7 @@ import {
   createAuthAnalyticsEvent,
   createAuthStateRecord,
   resolveAuthCallback,
+  resolveElectronAuthScheme,
   sanitizeReturnTo,
   validateNativeExchange,
 } from './index';
@@ -264,6 +266,31 @@ describe('auth routing boundary', () => {
     ).toBe(
       'jovie://auth/complete?code=c&state=s&desktop_flow=desktop_flow_nonce_12345'
     );
+  });
+
+  it('resolves per-env electron auth schemes from web origin', () => {
+    expect(resolveElectronAuthScheme({ origin: 'https://jov.ie' })).toBe(
+      'jovie'
+    );
+    expect(
+      resolveElectronAuthScheme({ origin: 'https://staging.jov.ie' })
+    ).toBe('jovie-staging');
+    expect(resolveElectronAuthScheme({ origin: 'http://localhost:3000' })).toBe(
+      'jovie-local'
+    );
+    expect(resolveElectronAuthScheme({ hostname: '127.0.0.1' })).toBe(
+      'jovie-local'
+    );
+    expect(buildElectronAuthCompleteBaseUrl('jovie-staging')).toBe(
+      'jovie-staging://auth/complete'
+    );
+    expect(
+      buildElectronAuthCompleteUrl({
+        code: 'c',
+        state: 's',
+        scheme: 'jovie-local',
+      })
+    ).toBe('jovie-local://auth/complete?code=c&state=s');
   });
 
   it('creates analytics payloads without leaking return URLs or token values', () => {

--- a/packages/auth-routing/index.ts
+++ b/packages/auth-routing/index.ts
@@ -79,6 +79,14 @@ export interface AuthAnalyticsEventPayload {
 const AUTH_STATE_TTL_MS = 10 * 60 * 1000;
 const NATIVE_EXCHANGE_TTL_MS = 5 * 60 * 1000;
 const IOS_AUTH_COMPLETE_URL = 'ie.jov.jovie://auth/complete';
+
+export const ELECTRON_AUTH_SCHEMES = [
+  'jovie',
+  'jovie-staging',
+  'jovie-local',
+] as const;
+export type ElectronAuthScheme = (typeof ELECTRON_AUTH_SCHEMES)[number];
+
 const ELECTRON_AUTH_COMPLETE_URL = 'jovie://auth/complete';
 const IOS_UNIVERSAL_AUTH_COMPLETE_PATH = '/auth/ios/complete';
 const DEFAULT_DOCS_URL = 'https://docs.jov.ie';
@@ -348,12 +356,37 @@ export function buildIosUniversalAuthCompleteUrl(input: {
   );
 }
 
+export function resolveElectronAuthScheme(input: {
+  readonly origin?: string | null;
+  readonly hostname?: string | null;
+}): ElectronAuthScheme {
+  const hostname =
+    input.hostname ??
+    (input.origin ? new URL(input.origin).hostname : null);
+  if (!hostname) return 'jovie';
+  if (hostname === 'staging.jov.ie') return 'jovie-staging';
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    return 'jovie-local';
+  }
+  return 'jovie';
+}
+
+export function buildElectronAuthCompleteBaseUrl(
+  scheme: ElectronAuthScheme = 'jovie'
+): string {
+  return `${scheme}://auth/complete`;
+}
+
 export function buildElectronAuthCompleteUrl(input: {
   readonly code: string;
   readonly state: string;
   readonly desktopFlow?: string | null;
+  readonly scheme?: ElectronAuthScheme;
 }): string {
-  return buildUrlWithCodeAndState(ELECTRON_AUTH_COMPLETE_URL, input);
+  const baseUrl = input.scheme
+    ? buildElectronAuthCompleteBaseUrl(input.scheme)
+    : ELECTRON_AUTH_COMPLETE_URL;
+  return buildUrlWithCodeAndState(baseUrl, input);
 }
 
 export function resolveAuthCallback(input: {


### PR DESCRIPTION
Closes #12927

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12927-2026-07-03T15-15-27-133z.log`