### PR TITLE
chore(codex): Candidate follow-up: verify/repair smoke-native-auth.mjs against the /auth/native-return b (#12928)

### DIFF
--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -470,10 +470,14 @@ test('native auth smoke keeps browser callbacks on the browser auth origin', asy
     smokeSource,
     /new URL\(\s*`\/auth\/callback\?state=\$\{encodeURIComponent\(authState\)\}`,\s*BASE_URL\s*\)/
   );
-  assert.match(smokeSource, /parsed\.pathname === '\/auth\/native-return'/);
+  assert.match(smokeSource, /async function completeNativeReturnBounce/);
   assert.match(
     smokeSource,
-    /waitForNativeProtocolRequest\(page, '\/auth\/native-return'\)/
+    /parsedRedirect\.pathname !== '\/auth\/native-return'/
+  );
+  assert.match(
+    smokeSource,
+    /redirectUrl\.startsWith\(NATIVE_AUTH_CALLBACK_PREFIX\)/
   );
 });
 

--- a/apps/desktop/scripts/smoke-native-auth.mjs
+++ b/apps/desktop/scripts/smoke-native-auth.mjs
@@ -678,28 +678,40 @@ async function requestRedirect(page, targetUrl, label) {
   );
 }
 
+async function completeNativeReturnBounce(page, nativeReturnUrl, label) {
+  const parsed = new URL(nativeReturnUrl);
+  const callbackPromise = Promise.race([
+    waitForNativeProtocolRequest(page, parsed.pathname),
+    waitForNativeRedirectResponse(page, parsed.pathname),
+  ]);
+  await page.goto(nativeReturnUrl, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+  const nativeCallbackUrl = await callbackPromise;
+  if (!nativeCallbackUrl.startsWith(NATIVE_AUTH_CALLBACK_PREFIX)) {
+    throw new Error(
+      `${label} native-return bounce did not yield the Electron app callback: ${nativeCallbackUrl}`
+    );
+  }
+
+  return nativeCallbackUrl;
+}
+
 async function requestNativeCallbackRedirect(page, callbackPath, label) {
   const redirectUrl = await requestRedirect(page, callbackPath, label);
   if (redirectUrl.startsWith(NATIVE_AUTH_CALLBACK_PREFIX)) {
     return redirectUrl;
   }
 
-  const parsed = new URL(redirectUrl);
-  if (parsed.pathname === '/auth/native-return') {
-    const callbackPromise = Promise.race([
-      waitForNativeProtocolRequest(page, '/auth/native-return'),
-      waitForNativeRedirectResponse(page, '/auth/native-return'),
-    ]);
-    await page.goto(redirectUrl, {
-      waitUntil: 'domcontentloaded',
-      timeout: 60_000,
-    });
-    return await callbackPromise;
+  const parsedRedirect = new URL(redirectUrl);
+  if (parsedRedirect.pathname !== '/auth/native-return') {
+    throw new Error(
+      `${label} did not return the Electron app callback or native-return bounce: ${redirectUrl}`
+    );
   }
 
-  throw new Error(
-    `${label} did not return the Electron app callback: ${redirectUrl}`
-  );
+  return await completeNativeReturnBounce(page, redirectUrl, label);
 }
 
 function waitForNativeProtocolRequest(page, label, timeout = 60_000) {


### PR DESCRIPTION
Closes #12928

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12928-2026-07-03T15-33-31-690z.log`