### PR TITLE
fix(codex-shipper): skip issues labeled invalid to stop retry loop

### DIFF
--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -6,7 +6,8 @@
  * eligible issue, writes dispatch context to gbrain, then starts a
  * coder-profile agent to ship it.
  *
- * Issues labeled `no-auto`, `type:epic` (pointer trackers with no code), or
+ * Issues labeled `no-auto`, `type:epic` (pointer trackers with no code),
+ * `invalid` (triaged not-real-work, e.g. misrouted foreign-repo issues), or
  * already claimed/blocked are excluded. All other open issues are dispatchable.
  *
  * The empty-queue path is intentionally cheap: GitHub scan, log, exit. No
@@ -48,6 +49,7 @@ import {
   type GbrainContext,
   type GithubIssue,
   HUMAN_REVIEW_LABEL,
+  INVALID_LABEL,
   labelNames,
   loadShipperConfig,
   NO_AUTO_LABEL,
@@ -1249,6 +1251,9 @@ async function main(): Promise<void> {
           const skippedEpic = issues.filter(issue =>
             labelNames(issue).includes(EPIC_LABEL)
           ).length;
+          const skippedInvalid = issues.filter(issue =>
+            labelNames(issue).includes(INVALID_LABEL)
+          ).length;
           const capacity = systemCapacity(config);
           const batch = plans.slice(0, capacity.allowedAgents);
 
@@ -1260,6 +1265,7 @@ async function main(): Promise<void> {
             skippedHuman,
             skippedNoAuto,
             skippedEpic,
+            skippedInvalid,
             batchCount: batch.length,
             maxIssuesPerRun: config.maxIssuesPerRun,
             maxParallelAgents: config.maxParallelAgents,

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -5,6 +5,12 @@ export const CODEX_BLOCKED_LABEL = 'codex-blocked';
 export const HUMAN_REVIEW_LABEL = 'human-review-required';
 export const NO_AUTO_LABEL = 'no-auto';
 export const EPIC_LABEL = 'type:epic';
+// Issues a human or triage agent has already marked `invalid` (e.g. misrouted
+// foreign-repo issues like the "LYB" body/fitness suite, #12675-#12678) are not
+// real work. Without this skip the shipper re-claims an OPEN `invalid` issue
+// every run — it stays in the claim queue, so it loops forever (69+ comments and
+// ~7 claim/release cycles on #12678). Treat `invalid` as permanent do-not-dispatch.
+export const INVALID_LABEL = 'invalid';
 
 export interface GithubIssueLabel {
   readonly name: string;
@@ -240,6 +246,7 @@ export function eligibleCodexIssues(
       !isHumanReviewRequired(issue) &&
       !isAlreadyClaimedOrBlocked(issue) &&
       !isEpicPointer(issue) &&
+      !labelNames(issue).includes(INVALID_LABEL) &&
       !labelNames(issue).includes(NO_AUTO_LABEL)
   );
 }

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -13,7 +13,7 @@ import {
   EPIC_LABEL,
   eligibleCodexIssues,
   finishDispatch,
-  isRecoverableDetritus,
+  INVALID_LABEL,
   loadShipperConfig,
   NO_AUTO_LABEL,
   parseAgentChain,
@@ -50,7 +50,7 @@ describe('codex issue shipper planner', () => {
     expect(buildDispatchPlans([], config)).toEqual([]);
   });
 
-  it('filters no-auto, claimed, blocked, and epic issues before dispatch', () => {
+  it('filters no-auto, claimed, blocked, epic, and invalid issues before dispatch', () => {
     const ready = issue({ number: 1, title: 'Fix docs typo' });
     const noAuto = issue({
       number: 2,
@@ -69,12 +69,21 @@ describe('codex issue shipper planner', () => {
       number: 5,
       labels: [{ name: 'codex' }, { name: EPIC_LABEL }],
     });
+    // Triaged `invalid` (e.g. misrouted "LYB" foreign-repo issues #12675-#12678):
+    // re-claiming an OPEN invalid issue loops forever (69+ comments on #12678).
+    const invalid = issue({
+      number: 6,
+      labels: [{ name: 'codex' }, { name: INVALID_LABEL }],
+    });
 
     expect(
-      eligibleCodexIssues([ready, noAuto, claimed, blocked, epic])
+      eligibleCodexIssues([ready, noAuto, claimed, blocked, epic, invalid])
     ).toEqual([ready]);
     expect(
-      buildDispatchPlans([ready, noAuto, claimed, blocked, epic], config)
+      buildDispatchPlans(
+        [ready, noAuto, claimed, blocked, epic, invalid],
+        config
+      )
     ).toHaveLength(1);
   });
 


### PR DESCRIPTION
## What

Adds an `invalid`-label skip to the codex issue-shipper so it stops re-claiming
GitHub issues a human/triage agent has already marked `invalid`.

`eligibleCodexIssues` already skips `human-review-required`, `type:epic`,
`no-auto`, and claimed/blocked issues. It did **not** skip `invalid`, so an OPEN
issue labeled `invalid` stayed in the claim queue and got re-claimed every run —
claim → agent exits with no PR → release → re-claim, forever.

## Why (the incident)

Issue #12678 ("LYB tests: settings/profile mutation suite") is a **misrouted
foreign-repo issue** — it targets a body/fitness app (`ProfileSettingsViewV2`,
`ChangePasswordView`, `AuthAccountManaging`, `BodyScore`, kg↔lb/cm↔in unit
conversion), none of which exist in Jovie's iOS app:

```
$ find apps/ios -name "*.swift" | wc -l        # 75 files
$ grep -rli "ProfileSettingsViewV2|ChangePasswordView|AuthAccountManaging|BodyScore|healthkit|supabase" apps/ios
(no matches)
$ find apps/ios -name AuthManager.swift        # none — issue cites AuthManager.swift:98
```

It was correctly labeled `invalid` on prior runs, but the shipper kept
re-claiming it anyway (**69+ comments, ~7 claim/release cycles**). Same shape as
sibling misroutes #12675/#12676/#12677. Per-issue re-triage was treading water;
the durable fix is the queue guardrail.

## Change

- `eligibleCodexIssues` now excludes `INVALID_LABEL` (`invalid`), matching the
  existing `isEpicPointer` guardrail added in #12862.
- `scanned` job log gains a `skippedInvalid` counter so the suppression is
  observable (not a silent skip) — mirrors `skippedEpic`/`skippedNoAuto`.
- Header doc comment updated to list `invalid` among excluded labels.

If an issue is later re-triaged as real work, removing the `invalid` label makes
it eligible again on the next scan — no permanent lockout.

## Verification

```
$ pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/codex-issue-shipper.test.mjs
 Test Files  1 passed (1)
      Tests  30 passed (30)

$ pnpm biome check scripts/hermes/lib/codex-issue-shipper.ts scripts/hermes/jobs/codex-issue-shipper.ts scripts/lib/__tests__/codex-issue-shipper.test.mjs
Checked 3 files. No fixes applied.

$ coderabbit review --agent -c AGENTS.md -t uncommitted
findings: 0
```

Test updated: `filters no-auto, claimed, blocked, epic, and invalid issues before dispatch` now asserts an `invalid`-labeled issue is excluded.

## Scope note — #12678 itself is NOT resolved by this PR

This PR fixes the **shipper loop**, not the LYB test suite #12678 asks for (that
work belongs in a different repo). #12678 still needs a **human to close or
re-route** it to the correct project — an autonomous coder can't close an issue
it didn't create, and the issue's stated ask targets a foreign codebase. I've
left `codex-in-progress` removed and `invalid` + `ai:needs-review` in place.

Refs #12678 (does not close).

## Cost Impact

None. No new external API calls, cron jobs, or scheduled work — this narrows the
shipper's dispatch set (strictly fewer agent runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
