### PR TITLE
chore(codex): Support page: bypasses marketing-h2-linear heading tokens (#12957)

### DIFF
--- a/apps/web/app/(marketing)/support/SupportContent.tsx
+++ b/apps/web/app/(marketing)/support/SupportContent.tsx
@@ -44,7 +44,7 @@ export function SupportChannels() {
   return (
     <MarketingContainer width='prose' className='pb-16'>
       <section>
-        <h2 className='text-2xl font-semibold text-primary-token'>
+        <h2 className='marketing-h2-linear text-primary-token'>
           How can we help?
         </h2>
         <div className='mt-6 grid gap-8 sm:grid-cols-3'>
@@ -86,7 +86,7 @@ export function SupportCta() {
   return (
     <MarketingContainer width='prose' className='pb-24'>
       <section>
-        <h2 className='text-2xl font-semibold text-primary-token'>
+        <h2 className='marketing-h2-linear text-primary-token'>
           Still need help?
         </h2>
         <p className='mt-4 text-base leading-relaxed text-secondary-token'>

--- a/apps/web/tests/unit/SupportPage.test.tsx
+++ b/apps/web/tests/unit/SupportPage.test.tsx
@@ -80,6 +80,15 @@ describe('SupportPage', () => {
 
     const heading = screen.getByRole('heading', { level: 1 });
     expect(heading).toHaveClass('marketing-h1-linear');
+
+    const sectionHeadings = screen.getAllByRole('heading', { level: 2 });
+    expect(sectionHeadings).toHaveLength(3);
+    for (const sectionHeading of sectionHeadings) {
+      expect(sectionHeading).toHaveClass('marketing-h2-linear');
+      expect(sectionHeading).toHaveClass('text-primary-token');
+      expect(sectionHeading).not.toHaveClass('text-2xl');
+      expect(sectionHeading).not.toHaveClass('font-semibold');
+    }
   });
 
   it('renders within a MarketingHero component', () => {


### PR DESCRIPTION
Closes #12957

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12957-2026-07-03T18-31-34-192z.log`