### PR TITLE
chore(codex): Support page: CTA uses dark-backdrop button in light section (#12955)

### DIFF
--- a/apps/web/app/(marketing)/support/SupportContent.tsx
+++ b/apps/web/app/(marketing)/support/SupportContent.tsx
@@ -94,6 +94,7 @@ export function SupportCta() {
         </p>
         <Button
           asChild
+          variant='secondary'
           className='mt-6'
           aria-label={`Send email to support team at ${SUPPORT_EMAIL}`}
           onClick={() =>
@@ -103,9 +104,7 @@ export function SupportCta() {
             })
           }
         >
-          <a href={`mailto:${SUPPORT_EMAIL}`} className='public-action-primary'>
-            Contact Support
-          </a>
+          <a href={`mailto:${SUPPORT_EMAIL}`}>Contact Support</a>
         </Button>
       </section>
     </MarketingContainer>

--- a/apps/web/tests/unit/SupportPage.test.tsx
+++ b/apps/web/tests/unit/SupportPage.test.tsx
@@ -38,6 +38,16 @@ describe('SupportPage', () => {
     expect(contactButton).toHaveTextContent('Contact Support');
   });
 
+  it('uses secondary CTA styling on the light support section', () => {
+    render(<SupportPage />);
+
+    const contactButton = screen.getByRole('link', {
+      name: /send email to support team/i,
+    });
+    expect(contactButton).not.toHaveClass('public-action-primary');
+    expect(contactButton.className).toMatch(/bg-btn-secondary/);
+  });
+
   it('has proper accessibility attributes', () => {
     render(<SupportPage />);
 


### PR DESCRIPTION
Closes #12955

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12955-2026-07-03T18-32-42-165z.log`