### PR TITLE
chore(codex): iOS: consolidate redundant "Offline" indicators to one affordance per screen (#12950)

### DIFF
--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -288,7 +288,6 @@ private struct AppContentView: View {
         ) {
           DashboardView(
             state: appState.dashboardState,
-            isOffline: appState.isOffline,
             brightnessManager: appState.brightnessManager,
             showVenueModeOnLaunch: appState.launchMode.opensVenueModeOnLaunch,
             loadAppleWalletProfilePass: {

--- a/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
@@ -27,7 +27,6 @@ enum AppShellDrawerThreadsFilter {
 struct AppShellLeftDrawer: View {
   let isPresented: Bool
   let profile: AppShellProfile
-  let isOffline: Bool
   let chatEnabled: Bool
   let audienceEnabled: Bool
   let selectedTab: AppShellTab
@@ -69,7 +68,7 @@ struct AppShellLeftDrawer: View {
             onSelectTab: onSelectTab
           )
 
-          DrawerAccountHeader(profile: profile, isOffline: isOffline)
+          DrawerAccountHeader(profile: profile)
 
           if chatEnabled {
             DrawerNewChatButton(action: onStartNewChat)
@@ -104,7 +103,6 @@ struct AppShellLeftDrawer: View {
 
 private struct DrawerAccountHeader: View {
   let profile: AppShellProfile
-  let isOffline: Bool
 
   var body: some View {
     HStack(spacing: JovieSpacing.medium) {
@@ -120,7 +118,7 @@ private struct DrawerAccountHeader: View {
           .foregroundStyle(JovieColor.textPrimary)
           .lineLimit(1)
 
-        Text(isOffline ? "Offline" : profile.secondaryText)
+        Text(profile.secondaryText)
           .font(JovieFont.body(size: 13, weight: .medium))
           .foregroundStyle(JovieColor.textTertiary)
           .lineLimit(1)

--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -156,7 +156,6 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
           AppShellLeftDrawer(
             isPresented: isShowingDrawer,
             profile: profile,
-            isOffline: isOffline,
             chatEnabled: chatEnabled,
             audienceEnabled: audienceEnabled,
             selectedTab: selectedTab,

--- a/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
+++ b/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
@@ -129,7 +129,6 @@ struct DashboardAvatarView: View {
 
 struct DashboardView: View {
   let state: DashboardLoadState
-  let isOffline: Bool
   let brightnessManager: BrightnessControlling
   let showVenueModeOnLaunch: Bool
   let loadAppleWalletProfilePass: @Sendable () async throws -> Data
@@ -144,7 +143,6 @@ struct DashboardView: View {
 
   init(
     state: DashboardLoadState,
-    isOffline: Bool,
     brightnessManager: BrightnessControlling,
     showVenueModeOnLaunch: Bool = false,
     loadAppleWalletProfilePass: @escaping @Sendable () async throws -> Data = {
@@ -153,7 +151,6 @@ struct DashboardView: View {
     onRetry: @escaping () async -> Void
   ) {
     self.state = state
-    self.isOffline = isOffline
     self.brightnessManager = brightnessManager
     self.showVenueModeOnLaunch = showVenueModeOnLaunch
     self.loadAppleWalletProfilePass = loadAppleWalletProfilePass
@@ -230,15 +227,6 @@ struct DashboardView: View {
       }
 
       Spacer()
-
-      if isOffline {
-        Text("Offline")
-          .font(JovieFont.body(size: 12, weight: .medium))
-          .foregroundStyle(JovieColor.textTertiary)
-          .padding(.horizontal, 10)
-          .padding(.vertical, 6)
-          .background(JovieColor.surface1, in: Capsule())
-      }
     }
     .padding(.bottom, JovieSpacing.large)
     .overlay(alignment: .bottom) {

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -283,6 +283,23 @@ final class JovieUITests: XCTestCase {
       "Offline chat empty state did not explain draft/cache behavior.\n\(app.debugDescription)"
     )
     XCTAssertTrue(app.textFields["Ask Jovie (offline)"].exists)
+
+    let offlineStatusPredicate = NSPredicate(format: "label == %@", "Offline")
+    XCTAssertEqual(
+      app.staticTexts.matching(offlineStatusPredicate).count,
+      1,
+      "Offline chat should show exactly one status indicator (shell header subtitle).\n\(app.debugDescription)"
+    )
+
+    app.buttons["Open navigation drawer"].tap()
+    XCTAssertTrue(
+      app.descendants(matching: .any)["shell-drawer"].waitForExistence(timeout: 3),
+      "Shell navigation did not reveal the left drawer.\n\(app.debugDescription)"
+    )
+    XCTAssertTrue(
+      app.staticTexts["@tim"].exists,
+      "Drawer account subtitle should keep the @handle while offline.\n\(app.debugDescription)"
+    )
   }
 
   // JOV-3608: entity/skill chat tokens must render as clean label text, with


### PR DESCRIPTION
Closes #12950

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12950-2026-07-03T18-35-45-983z.log`