### PR TITLE
chore(codex): Support page: CTA uses dark-backdrop button in light section (#12955)

### DIFF
--- a/apps/web/app/(marketing)/support/SupportContent.tsx
+++ b/apps/web/app/(marketing)/support/SupportContent.tsx
@@ -104,7 +104,12 @@ export function SupportCta() {
             })
           }
         >
-          <a href={`mailto:${SUPPORT_EMAIL}`}>Contact Support</a>
+          <a
+            href={`mailto:${SUPPORT_EMAIL}`}
+            className='public-action-secondary'
+          >
+            Contact Support
+          </a>
         </Button>
       </section>
     </MarketingContainer>

--- a/apps/web/tests/unit/SupportPage.test.tsx
+++ b/apps/web/tests/unit/SupportPage.test.tsx
@@ -44,8 +44,8 @@ describe('SupportPage', () => {
     const contactButton = screen.getByRole('link', {
       name: /send email to support team/i,
     });
+    expect(contactButton).toHaveClass('public-action-secondary');
     expect(contactButton).not.toHaveClass('public-action-primary');
-    expect(contactButton.className).toMatch(/bg-btn-secondary/);
   });
 
   it('has proper accessibility attributes', () => {


### PR DESCRIPTION
Closes #12955

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12955-2026-07-03T18-51-05-673z.log`