### PR TITLE
chore(codex): [shipper] codex-issue-shipper dies on spawnSync gh EAGAIN — no recovery, no retry (#12959)

### DIFF
--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -49,7 +49,6 @@ import {
   GhEagainBackoff,
   type GithubIssue,
   HUMAN_REVIEW_LABEL,
-  isSpawnEagain,
   labelNames,
   loadShipperConfig,
   NO_AUTO_LABEL,
@@ -72,6 +71,11 @@ import {
   SHIP_OWNER_LOCK,
 } from '../lib/ship-ledger';
 import { sendSlack } from '../lib/slack-client';
+import {
+  isSpawnResourceUnavailable,
+  SpawnResourceGuard,
+  SpawnResourceUnavailableError,
+} from '../lib/spawn-resource';
 import { sendTelegram } from '../lib/telegram-client';
 
 const JOB = 'codex-issue-shipper';
@@ -104,6 +108,10 @@ async function handleSpawnEagain(
     await sleep(backoff.sleepMs);
   }
 }
+
+const spawnResourceGuard = new SpawnResourceGuard({
+  onEvent: entry => logJobEvent({ job: JOB, ...entry }),
+});
 
 /**
  * Sentinel file that, when present, pauses the shipper.
@@ -168,15 +176,18 @@ function loadHermesEnv(): void {
 
 function run(args: ReadonlyArray<string>, config: ShipperConfig): string {
   try {
-    return execFileSync(args[0], args.slice(1), {
+    const result = execFileSync(args[0], args.slice(1), {
       cwd: config.repoRoot,
       encoding: 'utf8',
       timeout: 30_000,
       maxBuffer: 5 * 1024 * 1024,
     });
+    spawnResourceGuard.recordSuccess();
+    return result;
   } catch (err) {
-    if (isSpawnEagain(err)) {
-      throw new SpawnEagainError(shortError(err), args[0] ?? 'unknown');
+    if (isSpawnResourceUnavailable(err)) {
+      spawnResourceGuard.recordFailure(args[0], err);
+      throw new SpawnResourceUnavailableError(args[0], err);
     }
     throw err;
   }
@@ -249,7 +260,7 @@ function spawnSyncSafe(
   command: string,
   args: ReadonlyArray<string>,
   cwd: string
-): { readonly status: number | null } {
+): { readonly status: number | null; readonly resourceUnavailable: boolean } {
   try {
     const result = execFileSync(command, args, {
       cwd,
@@ -258,13 +269,18 @@ function spawnSyncSafe(
       stdio: 'ignore',
     });
     void result;
-    return { status: 0 };
+    spawnResourceGuard.recordSuccess();
+    return { status: 0, resourceUnavailable: false };
   } catch (err) {
+    if (isSpawnResourceUnavailable(err)) {
+      spawnResourceGuard.recordFailure(command, err);
+      return { status: null, resourceUnavailable: true };
+    }
     const status =
       typeof (err as { status?: unknown }).status === 'number'
         ? ((err as { status: number }).status ?? 1)
         : 1;
-    return { status };
+    return { status, resourceUnavailable: false };
   }
 }
 
@@ -319,16 +335,19 @@ function cleanupWorktree(config: ShipperConfig, repoRoot: string): void {
   }
 }
 
-function detectRepoRoot(): string {
+function detectRepoRoot(): string | null {
   if (process.env.HERMES_JOVIE_REPO) return process.env.HERMES_JOVIE_REPO;
   try {
-    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
       encoding: 'utf8',
       timeout: 10_000,
     }).trim();
+    spawnResourceGuard.recordSuccess();
+    return root;
   } catch (err) {
-    if (isSpawnEagain(err)) {
-      throw new SpawnEagainError(shortError(err), 'git');
+    if (isSpawnResourceUnavailable(err)) {
+      spawnResourceGuard.recordFailure('git', err);
+      return null;
     }
     throw err;
   }
@@ -439,10 +458,10 @@ async function notifyStaleCheckoutAbort(
   await Promise.all([sendTelegram(message), sendSlack(message)]);
 }
 
-function detectGithubRepo(repoRoot: string): string {
+function detectGithubRepo(repoRoot: string): string | null {
   if (process.env.GH_REPO) return process.env.GH_REPO;
   try {
-    return execFileSync(
+    const repo = execFileSync(
       'gh',
       ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
       {
@@ -451,35 +470,63 @@ function detectGithubRepo(repoRoot: string): string {
         timeout: 30_000,
       }
     ).trim();
+    spawnResourceGuard.recordSuccess();
+    return repo;
   } catch (err) {
-    if (isSpawnEagain(err)) {
-      throw new SpawnEagainError(shortError(err), 'gh');
+    if (isSpawnResourceUnavailable(err)) {
+      spawnResourceGuard.recordFailure('gh', err);
+      return null;
     }
     throw err;
   }
 }
 
-function listCodexIssues(config: ShipperConfig): ReadonlyArray<GithubIssue> {
+interface ListCodexIssuesResult {
+  readonly issues: ReadonlyArray<GithubIssue>;
+  readonly resourceUnavailable: boolean;
+}
+
+function listCodexIssues(config: ShipperConfig): ListCodexIssuesResult {
   // Fixed: gh CLI does not support --page; use single fetch with max limit
   const fetchLimit = Math.min(100, config.issueFetchLimit || 100);
-  const raw = run(
-    [
-      'gh',
-      'issue',
-      'list',
-      '--repo',
-      config.repo,
-      '--state',
-      'open',
-      '--limit',
-      String(fetchLimit),
-      '--json',
-      'number,title,body,url,updatedAt,labels',
-    ],
-    config
-  );
-  const issues = JSON.parse(raw) as GithubIssue[];
-  return issues.slice(0, config.issueFetchLimit || 100);
+  try {
+    const raw = run(
+      [
+        'gh',
+        'issue',
+        'list',
+        '--repo',
+        config.repo,
+        '--state',
+        'open',
+        '--limit',
+        String(fetchLimit),
+        '--json',
+        'number,title,body,url,updatedAt,labels',
+      ],
+      config
+    );
+    const issues = JSON.parse(raw) as GithubIssue[];
+    return {
+      issues: issues.slice(0, config.issueFetchLimit || 100),
+      resourceUnavailable: false,
+    };
+  } catch (err) {
+    if (err instanceof SpawnResourceUnavailableError) {
+      return { issues: [], resourceUnavailable: true };
+    }
+    throw err;
+  }
+}
+
+async function handleSpawnResourcePressure(context: string): Promise<void> {
+  await spawnResourceGuard.maybeBackoff();
+  logJobEvent({
+    job: JOB,
+    event: 'spawn_resource_skip',
+    context,
+    consecutive: spawnResourceGuard.consecutiveFailures,
+  });
 }
 
 function ensureLabel(
@@ -1277,6 +1324,10 @@ async function runShipper(): Promise<void> {
   }
 
   const repoRoot = detectRepoRoot();
+  if (!repoRoot) {
+    await handleSpawnResourcePressure('detect_repo_root');
+    return;
+  }
   // JOV-3838 / #12841: fail-closed when the primary checkout is hijacked off
   // fresh main. Skipped in dry-run so dev/CI worktrees are never reset.
   if (process.env.HERMES_CODEX_SHIPPER_DRY_RUN !== '1') {
@@ -1294,6 +1345,10 @@ async function runShipper(): Promise<void> {
     }
   }
   const repo = detectGithubRepo(repoRoot);
+  if (!repo) {
+    await handleSpawnResourcePressure('detect_github_repo');
+    return;
+  }
   const config = loadShipperConfig(process.env, repoRoot, repo);
 
   await withJobLogging(JOB, async () => {
@@ -1304,16 +1359,12 @@ async function runShipper(): Promise<void> {
         let controlLabelsEnsured = false;
 
         for (;;) {
-          let issues: ReadonlyArray<GithubIssue>;
-          try {
-            issues = listCodexIssues(config);
-          } catch (err) {
-            if (err instanceof SpawnEagainError) {
-              await handleSpawnEagain(err, 'listCodexIssues');
-              return;
-            }
-            throw err;
+          const listed = listCodexIssues(config);
+          if (listed.resourceUnavailable) {
+            await handleSpawnResourcePressure('list_codex_issues');
+            return;
           }
+          const issues = listed.issues;
           const plans = buildDispatchPlans(issues, config);
           const skippedHuman = issues.filter(issue =>
             labelNames(issue).includes(HUMAN_REVIEW_LABEL)
@@ -1396,6 +1447,16 @@ async function runShipper(): Promise<void> {
 }
 
 void main().catch(err => {
+  if (err instanceof SpawnResourceUnavailableError) {
+    logJobEvent({
+      job: JOB,
+      event: 'spawn_resource_skip',
+      context: 'main_uncaught',
+      command: err.command,
+      error: err.message,
+    });
+    return;
+  }
   logJobEvent({
     job: JOB,
     event: 'fatal',

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-codex-issue-shipper.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-codex-issue-shipper.plist.template
@@ -12,6 +12,8 @@
     <string>{{JOVIE_REPO}}</string>
     <key>StartInterval</key>
     <integer>900</integer>
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
     <key>RunAtLoad</key>
     <false/>
     <key>KeepAlive</key>

--- a/scripts/hermes/lib/spawn-resource.ts
+++ b/scripts/hermes/lib/spawn-resource.ts
@@ -1,0 +1,87 @@
+/**
+ * Guards against macOS spawn resource exhaustion (EAGAIN / EMFILE / ENOMEM).
+ * Used by codex-issue-shipper so one failed `gh` spawn does not fatal the job.
+ */
+
+export const DEFAULT_SPAWN_EAGAIN_THRESHOLD = 3;
+export const DEFAULT_SPAWN_EAGAIN_BACKOFF_MS = 60_000;
+
+export class SpawnResourceUnavailableError extends Error {
+  readonly command: string;
+  readonly cause: unknown;
+
+  constructor(command: string, cause: unknown) {
+    const detail =
+      cause instanceof Error ? cause.message : String(cause ?? 'unknown');
+    super(`spawn resource unavailable for ${command}: ${detail}`);
+    this.name = 'SpawnResourceUnavailableError';
+    this.command = command;
+    this.cause = cause;
+  }
+}
+
+export function isSpawnResourceUnavailable(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code === 'EAGAIN' || code === 'EMFILE' || code === 'ENOMEM') {
+    return true;
+  }
+
+  const message = err.message;
+  return (
+    /\bEAGAIN\b/.test(message) ||
+    /\bEMFILE\b/.test(message) ||
+    /\bENOMEM\b/.test(message) ||
+    /resource temporarily unavailable/i.test(message)
+  );
+}
+
+export interface SpawnResourceGuardOptions {
+  readonly threshold?: number;
+  readonly backoffMs?: number;
+  readonly onEvent?: (entry: Record<string, unknown>) => void;
+}
+
+export class SpawnResourceGuard {
+  private consecutive = 0;
+  private readonly threshold: number;
+  private readonly backoffMs: number;
+  private readonly onEvent: (entry: Record<string, unknown>) => void;
+
+  constructor(options: SpawnResourceGuardOptions = {}) {
+    this.threshold = options.threshold ?? DEFAULT_SPAWN_EAGAIN_THRESHOLD;
+    this.backoffMs = options.backoffMs ?? DEFAULT_SPAWN_EAGAIN_BACKOFF_MS;
+    this.onEvent = options.onEvent ?? (() => {});
+  }
+
+  get consecutiveFailures(): number {
+    return this.consecutive;
+  }
+
+  recordFailure(command: string, err: unknown): void {
+    this.consecutive += 1;
+    this.onEvent({
+      event: 'gh_eagain_skip',
+      command,
+      consecutive: this.consecutive,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  recordSuccess(): void {
+    this.consecutive = 0;
+  }
+
+  async maybeBackoff(): Promise<void> {
+    if (this.consecutive < this.threshold) return;
+
+    this.onEvent({
+      event: 'gh_eagain_backoff',
+      consecutive: this.consecutive,
+      backoffMs: this.backoffMs,
+    });
+    await new Promise(resolve => setTimeout(resolve, this.backoffMs));
+    this.consecutive = 0;
+  }
+}

--- a/scripts/lib/__tests__/spawn-resource.test.mjs
+++ b/scripts/lib/__tests__/spawn-resource.test.mjs
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_SPAWN_EAGAIN_BACKOFF_MS,
+  DEFAULT_SPAWN_EAGAIN_THRESHOLD,
+  isSpawnResourceUnavailable,
+  SpawnResourceGuard,
+  SpawnResourceUnavailableError,
+} from '../../hermes/lib/spawn-resource.ts';
+
+describe('spawn resource helpers', () => {
+  it('detects EAGAIN spawn failures by errno and message', () => {
+    expect(
+      isSpawnResourceUnavailable(
+        Object.assign(new Error('spawnSync gh EAGAIN'), { code: 'EAGAIN' })
+      )
+    ).toBe(true);
+    expect(isSpawnResourceUnavailable(new Error('spawnSync gh EAGAIN'))).toBe(
+      true
+    );
+    expect(
+      isSpawnResourceUnavailable(
+        Object.assign(new Error('too many open files'), { code: 'EMFILE' })
+      )
+    ).toBe(true);
+    expect(isSpawnResourceUnavailable(new Error('command not found'))).toBe(
+      false
+    );
+  });
+
+  it('wraps spawn resource failures with command context', () => {
+    const cause = Object.assign(new Error('spawnSync gh EAGAIN'), {
+      code: 'EAGAIN',
+    });
+    const err = new SpawnResourceUnavailableError('gh', cause);
+    expect(err.command).toBe('gh');
+    expect(err.message).toContain('gh');
+    expect(err.message).toContain('EAGAIN');
+  });
+
+  it('logs gh_eagain_skip and backs off after consecutive failures', async () => {
+    vi.useFakeTimers();
+    const events = [];
+    const guard = new SpawnResourceGuard({
+      threshold: 2,
+      backoffMs: 1_000,
+      onEvent: entry => events.push(entry),
+    });
+
+    guard.recordFailure('gh', new Error('spawnSync gh EAGAIN'));
+    expect(events.at(-1)).toMatchObject({
+      event: 'gh_eagain_skip',
+      command: 'gh',
+      consecutive: 1,
+    });
+
+    guard.recordFailure('gh', new Error('spawnSync gh EAGAIN'));
+    const backoff = guard.maybeBackoff();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await backoff;
+
+    expect(events.at(-1)).toMatchObject({
+      event: 'gh_eagain_backoff',
+      consecutive: 2,
+      backoffMs: 1_000,
+    });
+    expect(guard.consecutiveFailures).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it('resets the consecutive counter after a successful spawn', () => {
+    const guard = new SpawnResourceGuard({
+      threshold: DEFAULT_SPAWN_EAGAIN_THRESHOLD,
+      backoffMs: DEFAULT_SPAWN_EAGAIN_BACKOFF_MS,
+    });
+    guard.recordFailure('gh', new Error('spawnSync gh EAGAIN'));
+    guard.recordFailure('gh', new Error('spawnSync gh EAGAIN'));
+    guard.recordSuccess();
+    expect(guard.consecutiveFailures).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #12959

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12959-2026-07-03T19-24-10-353z.log`