### PR TITLE
chore(codex): iOS drawer: surface-switcher tab label wraps to 3 lines ("Aud ienc e") (#12948)

### DIFF
--- a/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
@@ -182,6 +182,9 @@ private struct DrawerSurfaceButton: View {
 
         Text(tab.title)
           .font(JovieFont.body(size: 15, weight: .semibold))
+          .lineLimit(1)
+          .minimumScaleFactor(0.85)
+          .allowsTightening(true)
       }
       .foregroundStyle(isSelected ? JovieColor.textPrimary : JovieColor.textSecondary)
       .padding(.horizontal, JovieSpacing.medium)

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -531,6 +531,38 @@ final class JovieUITests: XCTestCase {
     )
   }
 
+  // GH-12948: the Audience tab label must stay single-line in the drawer
+  // surface switcher. Wrapped labels stack to ~3 lines and read as broken.
+  func testDrawerSurfaceSwitcherLabelsStaySingleLine() {
+    let app = launchMockApp(launchArgument: "-ui-testing-ready", expectedElementDescription: "\"Copy URL\"") {
+      $0.buttons["Copy URL"]
+    }
+
+    app.buttons["Open navigation drawer"].tap()
+
+    let profileSurface = app.buttons["shell-drawer-surface-shell-tab-profile"]
+    let audienceSurface = app.buttons["shell-drawer-surface-shell-tab-audience"]
+    let chatSurface = app.buttons["shell-drawer-surface-shell-tab-chat"]
+    XCTAssertTrue(
+      profileSurface.waitForExistence(timeout: 3),
+      "Drawer surface switcher did not appear.\n\(app.debugDescription)"
+    )
+    XCTAssertTrue(audienceSurface.exists)
+    XCTAssertTrue(chatSurface.exists)
+
+    let profileHeight = profileSurface.frame.height
+    let audienceHeight = audienceSurface.frame.height
+    let chatHeight = chatSurface.frame.height
+    let maxSingleLineHeight = max(profileHeight, chatHeight) + 4
+
+    XCTAssertLessThanOrEqual(
+      audienceHeight,
+      maxSingleLineHeight,
+      "Audience drawer tab wrapped to multiple lines (height \(audienceHeight) vs peers \(profileHeight)/\(chatHeight)).\n\(app.debugDescription)"
+    )
+    attachScreenshot(named: "drawer-surface-switcher-labels", app: app)
+  }
+
   func testAudienceAskJovieCTAOpensScopedChat() {
     let app = launchMockApp(
       launchArgument: "-ui-testing-audience",


### PR DESCRIPTION
Closes #12948

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12948-2026-07-03T19-26-28-764z.log`