### PR TITLE
fix: enable experimental.authInterrupts for /hud unauthorized()/forbidden()

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -457,6 +457,8 @@ const nextConfig = {
     // cacheComponents: true requires additional configuration, disabled for now
     // Turbopack filesystem cache for faster dev server startup
     turbopackFileSystemCacheForDev: true,
+    // Enable auth interrupts for unauthorized()/forbidden() in server components
+    authInterrupts: true,
     // Cache client-side RSC responses to prevent skeleton flashes on navigation.
     // Next.js 15+ defaults dynamic routes to 0s (always re-fetch), which causes
     // unnecessary skeleton loaders on every page switch. Mutations that need


### PR DESCRIPTION
## What
Enables `experimental.authInterrupts` in `next.config.js` so that `unauthorized()` and `forbidden()` from `next/navigation` work in the `/hud` route.

## Why
The `/hud` page (shipped in #12910) uses `unauthorized()` and `forbidden()` for auth gating. Without this flag, Next.js 16 returns a 500 error: `unauthorized() is experimental and only allowed when experimental.authInterrupts is enabled`.

## How to test
1. Start dev server: `PORT=3112 pnpm dev:web:fast`
2. Visit `http://localhost:3112/hud` — should get 401 (not 500)
3. With admin auth, should see the full HUD dashboard

Discovered during dogfood testing.