### PR TITLE
chore(codex): iOS: consolidate redundant "Offline" indicators to one affordance per screen (#12950)

### DIFF
--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -324,6 +324,15 @@ final class JovieUITests: XCTestCase {
       "Offline chat should show exactly one status indicator in the shell header.\n\(app.debugDescription)"
     )
     XCTAssertTrue(
+      app.staticTexts["Offline"].exists,
+      "Shell header did not show the canonical offline status.\n\(app.debugDescription)"
+    )
+    XCTAssertEqual(
+      app.staticTexts.matching(NSPredicate(format: "label == %@", "Offline")).count,
+      1,
+      "Offline chat launch showed more than one standalone offline status indicator.\n\(app.debugDescription)"
+    )
+    XCTAssertTrue(
       app.staticTexts["Offline. Drafts stay on this device and cached history remains available."].exists,
       "Offline chat empty state did not explain draft/cache behavior.\n\(app.debugDescription)"
     )
@@ -342,6 +351,10 @@ final class JovieUITests: XCTestCase {
       app.staticTexts.matching(offlineStatusPredicate).count,
       1,
       "Opening the drawer must not add another Offline status indicator.\n\(app.debugDescription)"
+    )
+    XCTAssertFalse(
+      app.descendants(matching: .any)["shell-drawer-account"].staticTexts["Offline"].exists,
+      "Drawer account header showed a redundant offline status.\n\(app.debugDescription)"
     )
   }
 


### PR DESCRIPTION
Closes #12950

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12950-2026-07-03T19-40-42-820z.log`