### PR TITLE
chore(codex): Per-env desktop deep-link schemes so auth returns to the correct app (Staging/Local) (#12927)

### DIFF
--- a/apps/desktop/electron-builder.local.yml
+++ b/apps/desktop/electron-builder.local.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Local Auth
+        CFBundleURLSchemes:
+          - jovie-local
   notarize: false
   target:
     - target: dir

--- a/apps/desktop/electron-builder.staging.yml
+++ b/apps/desktop/electron-builder.staging.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Staging Auth
+        CFBundleURLSchemes:
+          - jovie-staging
   notarize: true
   target:
     - target: dmg

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -166,7 +166,7 @@ test('desktop macOS entitlements keep only allow-jit (no sandbox-weakening flags
   }
 });
 
-test('desktop production bundle declares the jovie auth protocol', async () => {
+test('desktop bundles declare per-env auth URL schemes', async () => {
   const [builderConfig, mainSource, stagingConfig, localConfig] =
     await Promise.all([
       readFile(join(desktopRoot, 'electron-builder.yml'), 'utf8'),
@@ -178,10 +178,17 @@ test('desktop production bundle declares the jovie auth protocol', async () => {
   assert.match(builderConfig, /CFBundleURLTypes:/);
   assert.match(builderConfig, /CFBundleURLName: Jovie Auth/);
   assert.match(builderConfig, /CFBundleURLSchemes:\s*\n\s*- jovie/);
-  assert.match(mainSource, /if \(APP_ENV !== 'production'\)/);
-  assert.match(mainSource, /setAsDefaultProtocolClient\('jovie'\)/);
-  assert.doesNotMatch(stagingConfig, /CFBundleURLTypes:/);
-  assert.doesNotMatch(localConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLName: Jovie Staging Auth/);
+  assert.match(stagingConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-staging/);
+  assert.match(localConfig, /CFBundleURLTypes:/);
+  assert.match(localConfig, /CFBundleURLName: Jovie Local Auth/);
+  assert.match(localConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-local/);
+  assert.match(mainSource, /function getAuthReturnScheme\(\): string/);
+  assert.match(mainSource, /if \(APP_ENV === 'staging'\) return 'jovie-staging';/);
+  assert.match(mainSource, /if \(APP_ENV === 'local'\) return 'jovie-local';/);
+  assert.match(mainSource, /setAsDefaultProtocolClient\(AUTH_RETURN_SCHEME\)/);
+  assert.doesNotMatch(mainSource, /if \(APP_ENV !== 'production'\) \{\s*return;\s*\}/);
 });
 
 test('desktop navigation uses explicit URL disposition allowlists', async () => {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -90,7 +90,14 @@ const DESKTOP_AUTH_HANDOFF_PATH = '/desktop-auth';
 const DESKTOP_AUTH_START_PATH = '/auth/start';
 const DESKTOP_AUTH_NATIVE_COMPLETE_PATH = '/auth/native-complete';
 const DESKTOP_RETURN_PARAM = 'desktop_return';
-const AUTH_RETURN_PROTOCOL = 'jovie:';
+function getAuthReturnScheme(): string {
+  if (APP_ENV === 'staging') return 'jovie-staging';
+  if (APP_ENV === 'local') return 'jovie-local';
+  return 'jovie';
+}
+
+const AUTH_RETURN_SCHEME = getAuthReturnScheme();
+const AUTH_RETURN_PROTOCOL = `${AUTH_RETURN_SCHEME}:`;
 const AUTH_RETURN_HOST = 'auth';
 const AUTH_RETURN_COMPLETE_PATH = '/complete';
 const LEGACY_AUTH_RETURN_HOST = 'auth-return';
@@ -1390,13 +1397,8 @@ ipcMain.handle(
 );
 
 function registerAuthReturnProtocol(): void {
-  // Only the canonical production bundle (app.jov.ie) may own jovie:// deep
-  // links. Staging/local shells use separate bundle IDs and must not compete
-  // with the installed production handler — see apps/desktop/BUILDS.md.
-  if (APP_ENV !== 'production') {
-    return;
-  }
-
+  // Each desktop bundle registers its own custom scheme so auth callbacks
+  // return to the matching env (jovie / jovie-staging / jovie-local).
   const defaultAppProcess = process as NodeJS.Process & {
     readonly defaultApp?: boolean;
   };
@@ -1406,13 +1408,13 @@ function registerAuthReturnProtocol(): void {
     process.argv.length >= 2 &&
     !app.isPackaged
   ) {
-    app.setAsDefaultProtocolClient('jovie', process.execPath, [
+    app.setAsDefaultProtocolClient(AUTH_RETURN_SCHEME, process.execPath, [
       path.resolve(process.argv[1]),
     ]);
     return;
   }
 
-  app.setAsDefaultProtocolClient('jovie');
+  app.setAsDefaultProtocolClient(AUTH_RETURN_SCHEME);
 }
 
 if (gotSingleInstanceLock) {
@@ -1452,7 +1454,7 @@ if (gotSingleInstanceLock) {
       return;
     }
 
-    if (url.startsWith('jovie://auth/complete')) {
+    if (url.startsWith(`${AUTH_RETURN_SCHEME}://auth/complete`)) {
       reportDesktopSecurityEvent('auth-deep-link-invalid-params');
       return;
     }

--- a/apps/web/app/(auth)/auth/native-return/page.test.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.test.tsx
@@ -29,14 +29,18 @@ function setSearchParams(query: string) {
   searchParamsMock.mockReturnValue(new URLSearchParams(query));
 }
 
+function mockLocation(origin: string) {
+  Object.defineProperty(globalThis, 'location', {
+    configurable: true,
+    value: { href: `${origin}/`, origin },
+  });
+}
+
 describe('NativeReturnPage (desktop auth bounce)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // jsdom cannot navigate to a custom scheme; swallow the auto-fire assign.
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: { href: 'http://localhost/' },
-    });
+    mockLocation('https://jov.ie');
   });
 
   it('renders an Open Jovie button pointing at the jovie:// deep link', () => {
@@ -75,5 +79,27 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     render(<NativeReturnPage />);
 
     expect(screen.queryByRole('link', { name: 'Open Jovie' })).toBeNull();
+  });
+
+  it('uses jovie-staging:// on staging.jov.ie', () => {
+    mockLocation('https://staging.jov.ie');
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      `jovie-staging://auth/complete?code=${CODE}&state=${STATE}`
+    );
+  });
+
+  it('uses jovie-local:// on localhost', () => {
+    mockLocation('http://localhost:3112');
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      `jovie-local://auth/complete?code=${CODE}&state=${STATE}`
+    );
   });
 });

--- a/apps/web/app/(auth)/auth/native-return/page.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { buildElectronAuthCompleteUrl } from '@jovie/auth-routing';
+import {
+  buildElectronAuthCompleteUrl,
+  resolveElectronAuthSchemeFromOrigin,
+} from '@jovie/auth-routing';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useMemo } from 'react';
@@ -35,7 +38,17 @@ function NativeReturnContent() {
         ? rawDesktopFlow
         : null;
 
-    return buildElectronAuthCompleteUrl({ code, state, desktopFlow });
+    const origin =
+      typeof globalThis.location !== 'undefined'
+        ? globalThis.location.origin
+        : 'https://jov.ie';
+
+    return buildElectronAuthCompleteUrl({
+      code,
+      state,
+      desktopFlow,
+      scheme: resolveElectronAuthSchemeFromOrigin(origin),
+    });
   }, [searchParams]);
 
   useEffect(() => {

--- a/packages/auth-routing/auth-routing.test.ts
+++ b/packages/auth-routing/auth-routing.test.ts
@@ -8,6 +8,8 @@ import {
   createAuthAnalyticsEvent,
   createAuthStateRecord,
   resolveAuthCallback,
+  resolveElectronAuthSchemeFromAppEnv,
+  resolveElectronAuthSchemeFromOrigin,
   sanitizeReturnTo,
   validateNativeExchange,
 } from './index';
@@ -264,6 +266,38 @@ describe('auth routing boundary', () => {
     ).toBe(
       'jovie://auth/complete?code=c&state=s&desktop_flow=desktop_flow_nonce_12345'
     );
+    expect(
+      buildElectronAuthCompleteUrl({
+        code: 'c',
+        state: 's',
+        scheme: 'jovie-staging',
+      })
+    ).toBe('jovie-staging://auth/complete?code=c&state=s');
+    expect(
+      buildElectronAuthCompleteUrl({
+        code: 'c',
+        state: 's',
+        scheme: 'jovie-local',
+      })
+    ).toBe('jovie-local://auth/complete?code=c&state=s');
+  });
+
+  it('resolves per-env electron auth schemes from origin and app env', () => {
+    expect(resolveElectronAuthSchemeFromOrigin('https://jov.ie')).toBe('jovie');
+    expect(resolveElectronAuthSchemeFromOrigin('https://staging.jov.ie')).toBe(
+      'jovie-staging'
+    );
+    expect(resolveElectronAuthSchemeFromOrigin('http://localhost:3112')).toBe(
+      'jovie-local'
+    );
+    expect(resolveElectronAuthSchemeFromOrigin('http://127.0.0.1:3112')).toBe(
+      'jovie-local'
+    );
+    expect(resolveElectronAuthSchemeFromAppEnv('production')).toBe('jovie');
+    expect(resolveElectronAuthSchemeFromAppEnv('staging')).toBe(
+      'jovie-staging'
+    );
+    expect(resolveElectronAuthSchemeFromAppEnv('local')).toBe('jovie-local');
   });
 
   it('creates analytics payloads without leaking return URLs or token values', () => {

--- a/packages/auth-routing/index.ts
+++ b/packages/auth-routing/index.ts
@@ -79,7 +79,37 @@ export interface AuthAnalyticsEventPayload {
 const AUTH_STATE_TTL_MS = 10 * 60 * 1000;
 const NATIVE_EXCHANGE_TTL_MS = 5 * 60 * 1000;
 const IOS_AUTH_COMPLETE_URL = 'ie.jov.jovie://auth/complete';
-const ELECTRON_AUTH_COMPLETE_URL = 'jovie://auth/complete';
+const ELECTRON_AUTH_COMPLETE_SCHEME = 'jovie';
+const ELECTRON_AUTH_COMPLETE_URL = `${ELECTRON_AUTH_COMPLETE_SCHEME}://auth/complete`;
+
+export const ELECTRON_AUTH_SCHEME_BY_APP_ENV = {
+  production: 'jovie',
+  staging: 'jovie-staging',
+  local: 'jovie-local',
+} as const;
+
+export type ElectronAppEnv = keyof typeof ELECTRON_AUTH_SCHEME_BY_APP_ENV;
+
+export function resolveElectronAuthSchemeFromAppEnv(
+  appEnv: ElectronAppEnv
+): string {
+  return ELECTRON_AUTH_SCHEME_BY_APP_ENV[appEnv];
+}
+
+export function resolveElectronAuthSchemeFromOrigin(origin: string): string {
+  const hostname = new URL(origin).hostname;
+  if (hostname === 'staging.jov.ie') {
+    return ELECTRON_AUTH_SCHEME_BY_APP_ENV.staging;
+  }
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    return ELECTRON_AUTH_SCHEME_BY_APP_ENV.local;
+  }
+  return ELECTRON_AUTH_SCHEME_BY_APP_ENV.production;
+}
+
+function buildElectronAuthCompleteBaseUrl(scheme: string): string {
+  return `${scheme}://auth/complete`;
+}
 const IOS_UNIVERSAL_AUTH_COMPLETE_PATH = '/auth/ios/complete';
 const DEFAULT_DOCS_URL = 'https://docs.jov.ie';
 
@@ -352,8 +382,13 @@ export function buildElectronAuthCompleteUrl(input: {
   readonly code: string;
   readonly state: string;
   readonly desktopFlow?: string | null;
+  readonly scheme?: string;
 }): string {
-  return buildUrlWithCodeAndState(ELECTRON_AUTH_COMPLETE_URL, input);
+  const scheme = input.scheme ?? ELECTRON_AUTH_COMPLETE_SCHEME;
+  return buildUrlWithCodeAndState(
+    buildElectronAuthCompleteBaseUrl(scheme),
+    input
+  );
 }
 
 export function resolveAuthCallback(input: {


### PR DESCRIPTION
Closes #12927

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12927-2026-07-03T19-41-49-646z.log`