### PR TITLE
chore(codex): Packaged Mac app opens to a blank/black window when signed-out (all envs) — no sign-in aff (#12822)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
-- [internal] **Codex issue shipper stale-checkout fail-closed gate (GH-12841)**: primary `~/Jovie` checkout must be clean `main` at `origin/main` before dispatch; unsafe drift logs `stale_checkout_abort` + Telegram/Slack and refuses to ship; safe detritus auto-heals for the next launchd tick; adds `shipper-gated-entrypoint.py` (gbrain/grok preflight) and blocks `git checkout` in the primary repo from agent bash hooks.
-- [internal] **Dev server stale `.next` cache guard (GH-12899)**: `node scripts/dev.mjs` now wipes `.next` when app route sources are newer than the compiled manifest, logs the on-disk route count at first compile, and Turbo `dev` restarts when `page.tsx` / `route.ts` / `layout.tsx` inputs change.
+- [internal] **Desktop signed-out recovery (GH-12822)**: Prime the main window with the sign-in handoff when auth redirects are intercepted, recover immediately from `about:blank`, and register per-env deep-link schemes (`jovie-staging://`, `jovie-local://`) so staging/local Mac apps receive auth callbacks without stealing production `jovie://` handlers.
+
 - [internal] **Dev server resource hygiene (GH-12902)**: `pnpm dev` now starts web-only fast dev instead of all workspace Next.js servers; use `pnpm run dev:all` for the full turbo dev matrix. Added `pnpm run dev:cleanup` / `dev:cleanup:force` to report or terminate stale `next dev` / `turbo dev` processes (default threshold: 4h).
 - [internal] **Desktop build clarity (GH-12900)**: Documented the canonical production/staging/local Electron shells (`apps/desktop/BUILDS.md`), restricted `jovie://` URL registration to production only, disabled auto-update on local shells, gated CDP behind `JOVIE_DEV=1`, and added `pnpm run desktop:audit` for `/Applications` hygiene.
 - **iOS chat entity chip thumbnails (GH-12708)**: Inline transcript entity mentions now render as pill chips with a fixed 16×16 thumbnail slot using the shared `AvatarImageCache` loader (no raw `AsyncImage`); unresolved entities keep the accent-dot fallback.

--- a/apps/desktop/electron-builder.local.yml
+++ b/apps/desktop/electron-builder.local.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Local Auth
+        CFBundleURLSchemes:
+          - jovie-local
   notarize: false
   target:
     - target: dir

--- a/apps/desktop/electron-builder.staging.yml
+++ b/apps/desktop/electron-builder.staging.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Staging Auth
+        CFBundleURLSchemes:
+          - jovie-staging
   notarize: true
   target:
     - target: dmg

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -178,10 +178,17 @@ test('desktop production bundle declares the jovie auth protocol', async () => {
   assert.match(builderConfig, /CFBundleURLTypes:/);
   assert.match(builderConfig, /CFBundleURLName: Jovie Auth/);
   assert.match(builderConfig, /CFBundleURLSchemes:\s*\n\s*- jovie/);
-  assert.match(mainSource, /if \(APP_ENV !== 'production'\)/);
-  assert.match(mainSource, /setAsDefaultProtocolClient\('jovie'\)/);
-  assert.doesNotMatch(stagingConfig, /CFBundleURLTypes:/);
-  assert.doesNotMatch(localConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLName: Jovie Staging Auth/);
+  assert.match(stagingConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-staging/);
+  assert.match(localConfig, /CFBundleURLTypes:/);
+  assert.match(localConfig, /CFBundleURLName: Jovie Local Auth/);
+  assert.match(localConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-local/);
+  assert.match(mainSource, /function getDesktopAuthReturnScheme\(\)/);
+  assert.match(mainSource, /app\.setAsDefaultProtocolClient\(scheme\)/);
+  assert.match(mainSource, /function primeMainWindowAuthHandoff/);
+  assert.match(mainSource, /function recoverMainWindowFromBlank/);
+  assert.match(mainSource, /primeMainWindowAuthHandoff\(authUrl\)/);
 });
 
 test('desktop navigation uses explicit URL disposition allowlists', async () => {

--- a/apps/desktop/scripts/smoke-native-auth.mjs
+++ b/apps/desktop/scripts/smoke-native-auth.mjs
@@ -2,6 +2,17 @@ import { Buffer } from 'node:buffer';
 import { execFileSync } from 'node:child_process';
 
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3112';
+
+function resolveElectronAuthScheme(hostname) {
+  if (hostname === 'staging.jov.ie') return 'jovie-staging';
+  if (hostname === 'localhost' || hostname === '127.0.0.1') return 'jovie-local';
+  return 'jovie';
+}
+
+function getElectronAuthCompletePrefix(baseUrl = BASE_URL) {
+  const scheme = resolveElectronAuthScheme(new URL(baseUrl).hostname);
+  return `${scheme}://auth/complete?`;
+}
 const ELECTRON_CDP_URL =
   process.env.ELECTRON_CDP_URL ?? 'http://localhost:9223';
 const MACOS_PROTOCOL_OPEN_BUNDLE_ID =
@@ -663,7 +674,7 @@ async function requestRedirect(page, targetUrl, label) {
 
 async function requestNativeCallbackRedirect(page, callbackPath, label) {
   const redirectUrl = await requestRedirect(page, callbackPath, label);
-  if (redirectUrl.startsWith('jovie://auth/complete?')) {
+  if (redirectUrl.startsWith(getElectronAuthCompletePrefix())) {
     return redirectUrl;
   }
 
@@ -686,6 +697,7 @@ async function requestNativeCallbackRedirect(page, callbackPath, label) {
 }
 
 function waitForNativeProtocolRequest(page, label, timeout = 60_000) {
+  const authCompletePrefix = getElectronAuthCompletePrefix();
   return new Promise((resolve, reject) => {
     const timeoutId = setTimeout(() => {
       page.off('request', onRequest);
@@ -694,7 +706,7 @@ function waitForNativeProtocolRequest(page, label, timeout = 60_000) {
 
     function onRequest(request) {
       const requestUrl = request.url();
-      if (!requestUrl.startsWith('jovie://auth/complete?')) return;
+      if (!requestUrl.startsWith(authCompletePrefix)) return;
       clearTimeout(timeoutId);
       page.off('request', onRequest);
       resolve(requestUrl);
@@ -705,6 +717,7 @@ function waitForNativeProtocolRequest(page, label, timeout = 60_000) {
 }
 
 function waitForNativeRedirectResponse(page, label, timeout = 60_000) {
+  const authCompletePrefix = getElectronAuthCompletePrefix();
   return new Promise((resolve, reject) => {
     const timeoutId = setTimeout(() => {
       page.off('response', onResponse);
@@ -713,7 +726,7 @@ function waitForNativeRedirectResponse(page, label, timeout = 60_000) {
 
     function onResponse(response) {
       const location = response.headers().location;
-      if (!location?.startsWith('jovie://auth/complete?')) return;
+      if (!location?.startsWith(authCompletePrefix)) return;
       clearTimeout(timeoutId);
       page.off('response', onResponse);
       resolve(location);
@@ -780,8 +793,9 @@ async function completeBrowserAuthState(page, authPageUrl, email) {
 async function requestNativeCallback(page, authUrl, email) {
   const authCallbackUrl = await requestRedirect(page, authUrl, 'auth start');
   const parsedAuthCallback = new URL(authCallbackUrl);
-  if (parsedAuthCallback.protocol === 'jovie:') {
-    if (!authCallbackUrl.startsWith('jovie://auth/complete?')) {
+  const expectedScheme = resolveElectronAuthScheme(new URL(BASE_URL).hostname);
+  if (parsedAuthCallback.protocol === `${expectedScheme}:`) {
+    if (!authCallbackUrl.startsWith(getElectronAuthCompletePrefix())) {
       throw new Error(
         `Auth start did not return the Electron app callback: ${authCallbackUrl}`
       );

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -90,9 +90,9 @@ const DESKTOP_AUTH_HANDOFF_PATH = '/desktop-auth';
 const DESKTOP_AUTH_START_PATH = '/auth/start';
 const DESKTOP_AUTH_NATIVE_COMPLETE_PATH = '/auth/native-complete';
 const DESKTOP_RETURN_PARAM = 'desktop_return';
-const AUTH_RETURN_PROTOCOL = 'jovie:';
 const AUTH_RETURN_HOST = 'auth';
 const AUTH_RETURN_COMPLETE_PATH = '/complete';
+const LEGACY_AUTH_RETURN_PROTOCOL = 'jovie:';
 const LEGACY_AUTH_RETURN_HOST = 'auth-return';
 const DICTATION_STATUS_CHANNEL = 'dictation-status';
 const TRAY_SET_STATE_CHANNEL = 'tray-set-state';
@@ -408,11 +408,25 @@ function buildDesktopAuthHandoffUrl(authUrl: string): string {
   return url.toString();
 }
 
+function getDesktopAuthReturnScheme(): string {
+  if (APP_ENV === 'staging') return 'jovie-staging';
+  if (APP_ENV === 'local') return 'jovie-local';
+  return 'jovie';
+}
+
+function getDesktopAuthReturnProtocol(): string {
+  return `${getDesktopAuthReturnScheme()}:`;
+}
+
+function getDesktopAuthCompletePrefix(): string {
+  return `${getDesktopAuthReturnScheme()}://auth/complete`;
+}
+
 function parseDesktopAuthReturnDeepLink(urlString: string) {
   return parseAuthReturnDeepLink(
     urlString,
     parseUrl,
-    AUTH_RETURN_PROTOCOL,
+    getDesktopAuthReturnProtocol(),
     AUTH_RETURN_HOST,
     AUTH_RETURN_COMPLETE_PATH
   );
@@ -430,7 +444,7 @@ function parseLegacyAuthReturnRouteDeepLink(urlString: string): string | null {
   const parsed = parseUrl(urlString);
   if (
     !parsed ||
-    parsed.protocol !== AUTH_RETURN_PROTOCOL ||
+    parsed.protocol !== LEGACY_AUTH_RETURN_PROTOCOL ||
     parsed.hostname !== LEGACY_AUTH_RETURN_HOST
   ) {
     return null;
@@ -716,11 +730,29 @@ function showDesktopAuthHandoff(authUrl: string): void {
   showWindow(authHandoffWindow);
 }
 
+function primeMainWindowAuthHandoff(authUrl: string): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  void mainWindow.loadURL(buildDesktopAuthHandoffUrl(authUrl));
+}
+
+function recoverMainWindowFromBlank(): void {
+  if (!mainWindow || mainWindow.isDestroyed() || isAuthHandoffOpen()) return;
+  if (mainWindow.webContents.getURL() !== 'about:blank') return;
+
+  const authUrl = buildCentralDesktopAuthUrl('sign_in', '/app');
+  void mainWindow.loadURL(buildDesktopAuthHandoffUrl(authUrl));
+  showWindowNow(mainWindow);
+}
+
 function maybeShowDesktopAuthHandoff(urlString: string): boolean {
   const authUrl = buildDesktopBrowserAuthUrl(urlString);
   if (!authUrl) return false;
 
   showDesktopAuthHandoff(authUrl);
+  // Passive redirects (e.g. signed-out /app/chat → /signin) cancel in-window
+  // navigation and strand the main view on about:blank. Prime the main window
+  // with the handoff surface so a failed separate handoff window still recovers.
+  primeMainWindowAuthHandoff(authUrl);
   return true;
 }
 
@@ -929,6 +961,9 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   let rendererCrashReloadCount = 0;
   win.webContents.on('did-finish-load', () => {
     rendererCrashReloadCount = 0;
+    if (win === mainWindow) {
+      recoverMainWindowFromBlank();
+    }
   });
   win.webContents.on('render-process-gone', (_event, details) => {
     const action = decideRendererRecovery({
@@ -1390,13 +1425,7 @@ ipcMain.handle(
 );
 
 function registerAuthReturnProtocol(): void {
-  // Only the canonical production bundle (app.jov.ie) may own jovie:// deep
-  // links. Staging/local shells use separate bundle IDs and must not compete
-  // with the installed production handler — see apps/desktop/BUILDS.md.
-  if (APP_ENV !== 'production') {
-    return;
-  }
-
+  const scheme = getDesktopAuthReturnScheme();
   const defaultAppProcess = process as NodeJS.Process & {
     readonly defaultApp?: boolean;
   };
@@ -1406,13 +1435,13 @@ function registerAuthReturnProtocol(): void {
     process.argv.length >= 2 &&
     !app.isPackaged
   ) {
-    app.setAsDefaultProtocolClient('jovie', process.execPath, [
+    app.setAsDefaultProtocolClient(scheme, process.execPath, [
       path.resolve(process.argv[1]),
     ]);
     return;
   }
 
-  app.setAsDefaultProtocolClient('jovie');
+  app.setAsDefaultProtocolClient(scheme);
 }
 
 if (gotSingleInstanceLock) {
@@ -1423,10 +1452,10 @@ if (gotSingleInstanceLock) {
       return;
     }
 
+    const authCompletePrefix = getDesktopAuthCompletePrefix();
     const invalidAuthReturn = argv.some(
       arg =>
-        arg.startsWith(`${AUTH_RETURN_PROTOCOL}//${AUTH_RETURN_HOST}`) &&
-        !parseDesktopAuthReturnDeepLink(arg)
+        arg.startsWith(`${authCompletePrefix}?`) && !parseDesktopAuthReturnDeepLink(arg)
     );
     if (invalidAuthReturn) {
       reportDesktopSecurityEvent('auth-deep-link-invalid-params');
@@ -1452,7 +1481,7 @@ if (gotSingleInstanceLock) {
       return;
     }
 
-    if (url.startsWith('jovie://auth/complete')) {
+    if (url.startsWith(`${getDesktopAuthCompletePrefix()}?`)) {
       reportDesktopSecurityEvent('auth-deep-link-invalid-params');
       return;
     }

--- a/apps/web/app/(auth)/auth/native-return/page.test.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.test.tsx
@@ -50,6 +50,20 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     );
   });
 
+  it('uses the staging deep-link scheme on staging.jov.ie', () => {
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: { hostname: 'staging.jov.ie', href: 'https://staging.jov.ie/' },
+    });
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      `jovie-staging://auth/complete?code=${CODE}&state=${STATE}`
+    );
+  });
+
   it('preserves the deep link without desktop_flow when absent', () => {
     setSearchParams(`code=${CODE}&state=${STATE}`);
     render(<NativeReturnPage />);

--- a/apps/web/app/(auth)/auth/native-return/page.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { buildElectronAuthCompleteUrl } from '@jovie/auth-routing';
+import {
+  buildElectronAuthCompleteUrl,
+  resolveElectronAuthScheme,
+} from '@jovie/auth-routing';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useMemo } from 'react';
@@ -35,7 +38,12 @@ function NativeReturnContent() {
         ? rawDesktopFlow
         : null;
 
-    return buildElectronAuthCompleteUrl({ code, state, desktopFlow });
+    const scheme =
+      typeof globalThis.location !== 'undefined'
+        ? resolveElectronAuthScheme(globalThis.location.hostname)
+        : 'jovie';
+
+    return buildElectronAuthCompleteUrl({ code, state, desktopFlow, scheme });
   }, [searchParams]);
 
   useEffect(() => {

--- a/packages/auth-routing/auth-routing.test.ts
+++ b/packages/auth-routing/auth-routing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildAuthStartUrl,
   buildElectronAuthCompleteUrl,
+  resolveElectronAuthScheme,
   buildIosAuthCompleteUrl,
   buildNativeExchangeCodeRecord,
   classifyNavigation,
@@ -264,6 +265,16 @@ describe('auth routing boundary', () => {
     ).toBe(
       'jovie://auth/complete?code=c&state=s&desktop_flow=desktop_flow_nonce_12345'
     );
+    expect(
+      buildElectronAuthCompleteUrl({
+        code: 'c',
+        state: 's',
+        scheme: 'jovie-staging',
+      })
+    ).toBe('jovie-staging://auth/complete?code=c&state=s');
+    expect(resolveElectronAuthScheme('staging.jov.ie')).toBe('jovie-staging');
+    expect(resolveElectronAuthScheme('localhost')).toBe('jovie-local');
+    expect(resolveElectronAuthScheme('jov.ie')).toBe('jovie');
   });
 
   it('creates analytics payloads without leaking return URLs or token values', () => {

--- a/packages/auth-routing/index.ts
+++ b/packages/auth-routing/index.ts
@@ -79,9 +79,37 @@ export interface AuthAnalyticsEventPayload {
 const AUTH_STATE_TTL_MS = 10 * 60 * 1000;
 const NATIVE_EXCHANGE_TTL_MS = 5 * 60 * 1000;
 const IOS_AUTH_COMPLETE_URL = 'ie.jov.jovie://auth/complete';
-const ELECTRON_AUTH_COMPLETE_URL = 'jovie://auth/complete';
 const IOS_UNIVERSAL_AUTH_COMPLETE_PATH = '/auth/ios/complete';
 const DEFAULT_DOCS_URL = 'https://docs.jov.ie';
+
+/** Per-env Electron deep-link schemes so staging/local apps don't steal prod callbacks. */
+export const ELECTRON_AUTH_SCHEMES = [
+  'jovie',
+  'jovie-staging',
+  'jovie-local',
+] as const;
+export type ElectronAuthScheme = (typeof ELECTRON_AUTH_SCHEMES)[number];
+
+const ELECTRON_AUTH_SCHEME_BY_HOST: Record<string, ElectronAuthScheme> = {
+  'jov.ie': 'jovie',
+  'staging.jov.ie': 'jovie-staging',
+  localhost: 'jovie-local',
+  '127.0.0.1': 'jovie-local',
+};
+
+export function isElectronAuthScheme(value: string): value is ElectronAuthScheme {
+  return (ELECTRON_AUTH_SCHEMES as readonly string[]).includes(value);
+}
+
+export function resolveElectronAuthScheme(hostname: string): ElectronAuthScheme {
+  return ELECTRON_AUTH_SCHEME_BY_HOST[hostname] ?? 'jovie';
+}
+
+export function buildElectronAuthCompleteBaseUrl(
+  scheme: ElectronAuthScheme = 'jovie'
+): string {
+  return `${scheme}://auth/complete`;
+}
 
 const RETURN_BLOCKED_PREFIXES = [
   '/api',
@@ -352,8 +380,13 @@ export function buildElectronAuthCompleteUrl(input: {
   readonly code: string;
   readonly state: string;
   readonly desktopFlow?: string | null;
+  readonly scheme?: ElectronAuthScheme;
 }): string {
-  return buildUrlWithCodeAndState(ELECTRON_AUTH_COMPLETE_URL, input);
+  const scheme = input.scheme ?? 'jovie';
+  if (!isElectronAuthScheme(scheme)) {
+    throw new Error('Invalid electron auth scheme');
+  }
+  return buildUrlWithCodeAndState(buildElectronAuthCompleteBaseUrl(scheme), input);
 }
 
 export function resolveAuthCallback(input: {


### PR DESCRIPTION
Closes #12822

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12822-2026-07-03T19-42-55-456z.log`