### PR TITLE
chore(codex): Per-env desktop deep-link schemes so auth returns to the correct app (Staging/Local) (#12927)

### DIFF
--- a/apps/desktop/electron-builder.local.yml
+++ b/apps/desktop/electron-builder.local.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Local Auth
+        CFBundleURLSchemes:
+          - jovie-local
   notarize: false
   target:
     - target: dir

--- a/apps/desktop/electron-builder.staging.yml
+++ b/apps/desktop/electron-builder.staging.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Staging Auth
+        CFBundleURLSchemes:
+          - jovie-staging
   notarize: true
   target:
     - target: dmg

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -166,7 +166,7 @@ test('desktop macOS entitlements keep only allow-jit (no sandbox-weakening flags
   }
 });
 
-test('desktop production bundle declares the jovie auth protocol', async () => {
+test('desktop bundles declare per-env auth URL schemes', async () => {
   const [builderConfig, mainSource, stagingConfig, localConfig] =
     await Promise.all([
       readFile(join(desktopRoot, 'electron-builder.yml'), 'utf8'),
@@ -178,10 +178,21 @@ test('desktop production bundle declares the jovie auth protocol', async () => {
   assert.match(builderConfig, /CFBundleURLTypes:/);
   assert.match(builderConfig, /CFBundleURLName: Jovie Auth/);
   assert.match(builderConfig, /CFBundleURLSchemes:\s*\n\s*- jovie/);
-  assert.match(mainSource, /if \(APP_ENV !== 'production'\)/);
-  assert.match(mainSource, /setAsDefaultProtocolClient\('jovie'\)/);
-  assert.doesNotMatch(stagingConfig, /CFBundleURLTypes:/);
-  assert.doesNotMatch(localConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLName: Jovie Staging Auth/);
+  assert.match(stagingConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-staging/);
+  assert.match(localConfig, /CFBundleURLTypes:/);
+  assert.match(localConfig, /CFBundleURLName: Jovie Local Auth/);
+  assert.match(localConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-local/);
+  assert.match(mainSource, /const AUTH_RETURN_SCHEME =/);
+  assert.match(mainSource, /\? 'jovie-staging'/);
+  assert.match(mainSource, /\? 'jovie-local'/);
+  assert.match(mainSource, /setAsDefaultProtocolClient\(AUTH_RETURN_SCHEME\)/);
+  assert.doesNotMatch(
+    mainSource,
+    /function registerAuthReturnProtocol[\s\S]*?if \(APP_ENV !== 'production'\)/
+  );
+  assert.doesNotMatch(mainSource, /setAsDefaultProtocolClient\('jovie'\)/);
 });
 
 test('desktop navigation uses explicit URL disposition allowlists', async () => {

--- a/apps/desktop/scripts/smoke-native-auth.mjs
+++ b/apps/desktop/scripts/smoke-native-auth.mjs
@@ -2,6 +2,23 @@ import { Buffer } from 'node:buffer';
 import { execFileSync } from 'node:child_process';
 
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3112';
+
+function resolveElectronAuthSchemeFromHost(hostname) {
+  const normalized = hostname.trim().toLowerCase();
+  if (normalized === 'staging.jov.ie') {
+    return 'jovie-staging';
+  }
+  if (normalized === 'localhost' || normalized === '127.0.0.1') {
+    return 'jovie-local';
+  }
+  return 'jovie';
+}
+
+const ELECTRON_AUTH_SCHEME = resolveElectronAuthSchemeFromHost(
+  new URL(BASE_URL).hostname
+);
+const ELECTRON_AUTH_PROTOCOL = `${ELECTRON_AUTH_SCHEME}:`;
+const ELECTRON_AUTH_COMPLETE_PREFIX = `${ELECTRON_AUTH_SCHEME}://auth/complete?`;
 const ELECTRON_CDP_URL =
   process.env.ELECTRON_CDP_URL ?? 'http://localhost:9223';
 const MACOS_PROTOCOL_OPEN_BUNDLE_ID =
@@ -663,7 +680,7 @@ async function requestRedirect(page, targetUrl, label) {
 
 async function requestNativeCallbackRedirect(page, callbackPath, label) {
   const redirectUrl = await requestRedirect(page, callbackPath, label);
-  if (redirectUrl.startsWith('jovie://auth/complete?')) {
+  if (redirectUrl.startsWith(ELECTRON_AUTH_COMPLETE_PREFIX)) {
     return redirectUrl;
   }
 
@@ -694,7 +711,7 @@ function waitForNativeProtocolRequest(page, label, timeout = 60_000) {
 
     function onRequest(request) {
       const requestUrl = request.url();
-      if (!requestUrl.startsWith('jovie://auth/complete?')) return;
+      if (!requestUrl.startsWith(ELECTRON_AUTH_COMPLETE_PREFIX)) return;
       clearTimeout(timeoutId);
       page.off('request', onRequest);
       resolve(requestUrl);
@@ -713,7 +730,7 @@ function waitForNativeRedirectResponse(page, label, timeout = 60_000) {
 
     function onResponse(response) {
       const location = response.headers().location;
-      if (!location?.startsWith('jovie://auth/complete?')) return;
+      if (!location?.startsWith(ELECTRON_AUTH_COMPLETE_PREFIX)) return;
       clearTimeout(timeoutId);
       page.off('response', onResponse);
       resolve(location);
@@ -780,8 +797,8 @@ async function completeBrowserAuthState(page, authPageUrl, email) {
 async function requestNativeCallback(page, authUrl, email) {
   const authCallbackUrl = await requestRedirect(page, authUrl, 'auth start');
   const parsedAuthCallback = new URL(authCallbackUrl);
-  if (parsedAuthCallback.protocol === 'jovie:') {
-    if (!authCallbackUrl.startsWith('jovie://auth/complete?')) {
+  if (parsedAuthCallback.protocol === ELECTRON_AUTH_PROTOCOL) {
+    if (!authCallbackUrl.startsWith(ELECTRON_AUTH_COMPLETE_PREFIX)) {
       throw new Error(
         `Auth start did not return the Electron app callback: ${authCallbackUrl}`
       );

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -90,7 +90,13 @@ const DESKTOP_AUTH_HANDOFF_PATH = '/desktop-auth';
 const DESKTOP_AUTH_START_PATH = '/auth/start';
 const DESKTOP_AUTH_NATIVE_COMPLETE_PATH = '/auth/native-complete';
 const DESKTOP_RETURN_PARAM = 'desktop_return';
-const AUTH_RETURN_PROTOCOL = 'jovie:';
+const AUTH_RETURN_SCHEME =
+  APP_ENV === 'staging'
+    ? 'jovie-staging'
+    : APP_ENV === 'local'
+      ? 'jovie-local'
+      : 'jovie';
+const AUTH_RETURN_PROTOCOL = `${AUTH_RETURN_SCHEME}:`;
 const AUTH_RETURN_HOST = 'auth';
 const AUTH_RETURN_COMPLETE_PATH = '/complete';
 const LEGACY_AUTH_RETURN_HOST = 'auth-return';
@@ -1390,13 +1396,8 @@ ipcMain.handle(
 );
 
 function registerAuthReturnProtocol(): void {
-  // Only the canonical production bundle (app.jov.ie) may own jovie:// deep
-  // links. Staging/local shells use separate bundle IDs and must not compete
-  // with the installed production handler — see apps/desktop/BUILDS.md.
-  if (APP_ENV !== 'production') {
-    return;
-  }
-
+  // Each desktop shell owns a distinct custom scheme so auth callbacks never
+  // open the wrong installed app. See apps/desktop/BUILDS.md.
   const defaultAppProcess = process as NodeJS.Process & {
     readonly defaultApp?: boolean;
   };
@@ -1406,13 +1407,13 @@ function registerAuthReturnProtocol(): void {
     process.argv.length >= 2 &&
     !app.isPackaged
   ) {
-    app.setAsDefaultProtocolClient('jovie', process.execPath, [
+    app.setAsDefaultProtocolClient(AUTH_RETURN_SCHEME, process.execPath, [
       path.resolve(process.argv[1]),
     ]);
     return;
   }
 
-  app.setAsDefaultProtocolClient('jovie');
+  app.setAsDefaultProtocolClient(AUTH_RETURN_SCHEME);
 }
 
 if (gotSingleInstanceLock) {
@@ -1452,7 +1453,7 @@ if (gotSingleInstanceLock) {
       return;
     }
 
-    if (url.startsWith('jovie://auth/complete')) {
+    if (url.startsWith(`${AUTH_RETURN_SCHEME}://auth/complete`)) {
       reportDesktopSecurityEvent('auth-deep-link-invalid-params');
       return;
     }

--- a/apps/web/app/(auth)/auth/native-return/page.test.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.test.tsx
@@ -29,17 +29,21 @@ function setSearchParams(query: string) {
   searchParamsMock.mockReturnValue(new URLSearchParams(query));
 }
 
+function mockLocation(hostname: string) {
+  Object.defineProperty(globalThis, 'location', {
+    configurable: true,
+    value: { href: `https://${hostname}/`, hostname },
+  });
+}
+
 describe('NativeReturnPage (desktop auth bounce)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLocation('jov.ie');
     // jsdom cannot navigate to a custom scheme; swallow the auto-fire assign.
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: { href: 'http://localhost/' },
-    });
   });
 
-  it('renders an Open Jovie button pointing at the jovie:// deep link', () => {
+  it('renders an Open Jovie button pointing at the production jovie:// deep link', () => {
     setSearchParams(`code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`);
     render(<NativeReturnPage />);
 
@@ -47,6 +51,28 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     expect(link).toHaveAttribute(
       'href',
       `jovie://auth/complete?code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`
+    );
+  });
+
+  it('uses jovie-staging:// on staging.jov.ie', () => {
+    mockLocation('staging.jov.ie');
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      `jovie-staging://auth/complete?code=${CODE}&state=${STATE}`
+    );
+  });
+
+  it('uses jovie-local:// on localhost', () => {
+    mockLocation('localhost');
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      `jovie-local://auth/complete?code=${CODE}&state=${STATE}`
     );
   });
 

--- a/apps/web/app/(auth)/auth/native-return/page.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { buildElectronAuthCompleteUrl } from '@jovie/auth-routing';
+import {
+  buildElectronAuthCompleteUrl,
+  resolveElectronAuthSchemeFromHost,
+} from '@jovie/auth-routing';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useMemo } from 'react';
@@ -35,7 +38,18 @@ function NativeReturnContent() {
         ? rawDesktopFlow
         : null;
 
-    return buildElectronAuthCompleteUrl({ code, state, desktopFlow });
+    const hostname =
+      typeof globalThis.location !== 'undefined'
+        ? globalThis.location.hostname
+        : '';
+    const scheme = resolveElectronAuthSchemeFromHost(hostname);
+
+    return buildElectronAuthCompleteUrl({
+      code,
+      state,
+      desktopFlow,
+      scheme,
+    });
   }, [searchParams]);
 
   useEffect(() => {

--- a/packages/auth-routing/auth-routing.test.ts
+++ b/packages/auth-routing/auth-routing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildAuthStartUrl,
   buildElectronAuthCompleteUrl,
+  resolveElectronAuthSchemeFromHost,
   buildIosAuthCompleteUrl,
   buildNativeExchangeCodeRecord,
   classifyNavigation,
@@ -264,6 +265,32 @@ describe('auth routing boundary', () => {
     ).toBe(
       'jovie://auth/complete?code=c&state=s&desktop_flow=desktop_flow_nonce_12345'
     );
+  });
+
+  it('resolves per-env electron auth schemes from hostnames', () => {
+    expect(resolveElectronAuthSchemeFromHost('jov.ie')).toBe('jovie');
+    expect(resolveElectronAuthSchemeFromHost('staging.jov.ie')).toBe(
+      'jovie-staging'
+    );
+    expect(resolveElectronAuthSchemeFromHost('localhost')).toBe('jovie-local');
+    expect(resolveElectronAuthSchemeFromHost('127.0.0.1')).toBe('jovie-local');
+  });
+
+  it('builds electron auth complete URLs for each desktop scheme', () => {
+    expect(
+      buildElectronAuthCompleteUrl({
+        code: 'c',
+        state: 's',
+        scheme: 'jovie-staging',
+      })
+    ).toBe('jovie-staging://auth/complete?code=c&state=s');
+    expect(
+      buildElectronAuthCompleteUrl({
+        code: 'c',
+        state: 's',
+        scheme: 'jovie-local',
+      })
+    ).toBe('jovie-local://auth/complete?code=c&state=s');
   });
 
   it('creates analytics payloads without leaking return URLs or token values', () => {

--- a/packages/auth-routing/index.ts
+++ b/packages/auth-routing/index.ts
@@ -79,7 +79,35 @@ export interface AuthAnalyticsEventPayload {
 const AUTH_STATE_TTL_MS = 10 * 60 * 1000;
 const NATIVE_EXCHANGE_TTL_MS = 5 * 60 * 1000;
 const IOS_AUTH_COMPLETE_URL = 'ie.jov.jovie://auth/complete';
-const ELECTRON_AUTH_COMPLETE_URL = 'jovie://auth/complete';
+const ELECTRON_AUTH_COMPLETE_PATH = 'auth/complete';
+
+export const ELECTRON_AUTH_SCHEMES = [
+  'jovie',
+  'jovie-staging',
+  'jovie-local',
+] as const;
+export type ElectronAuthScheme = (typeof ELECTRON_AUTH_SCHEMES)[number];
+
+const DEFAULT_ELECTRON_AUTH_SCHEME: ElectronAuthScheme = 'jovie';
+
+export function resolveElectronAuthSchemeFromHost(
+  hostname: string
+): ElectronAuthScheme {
+  const normalized = hostname.trim().toLowerCase();
+  if (normalized === 'staging.jov.ie') {
+    return 'jovie-staging';
+  }
+  if (normalized === 'localhost' || normalized === '127.0.0.1') {
+    return 'jovie-local';
+  }
+  return DEFAULT_ELECTRON_AUTH_SCHEME;
+}
+
+function buildElectronAuthCompleteBaseUrl(
+  scheme: ElectronAuthScheme = DEFAULT_ELECTRON_AUTH_SCHEME
+): string {
+  return `${scheme}://${ELECTRON_AUTH_COMPLETE_PATH}`;
+}
 const IOS_UNIVERSAL_AUTH_COMPLETE_PATH = '/auth/ios/complete';
 const DEFAULT_DOCS_URL = 'https://docs.jov.ie';
 
@@ -352,8 +380,12 @@ export function buildElectronAuthCompleteUrl(input: {
   readonly code: string;
   readonly state: string;
   readonly desktopFlow?: string | null;
+  readonly scheme?: ElectronAuthScheme;
 }): string {
-  return buildUrlWithCodeAndState(ELECTRON_AUTH_COMPLETE_URL, input);
+  return buildUrlWithCodeAndState(
+    buildElectronAuthCompleteBaseUrl(input.scheme),
+    input
+  );
 }
 
 export function resolveAuthCallback(input: {


### PR DESCRIPTION
Closes #12927

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12927-2026-07-03T20-26-15-179z.log`