### PR TITLE
chore(codex): iOS drawer: surface-switcher tab label wraps to 3 lines ("Aud ienc e") (#12948)

### DIFF
--- a/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
@@ -174,7 +174,7 @@ private struct DrawerSurfaceButton: View {
 
   var body: some View {
     Button(action: action) {
-      HStack(spacing: JovieSpacing.small) {
+      VStack(spacing: JovieSpacing.xSmall) {
         Image(systemName: tab.systemImage)
           .font(.system(size: 14, weight: .semibold))
 
@@ -182,10 +182,11 @@ private struct DrawerSurfaceButton: View {
           .font(JovieFont.body(size: 15, weight: .semibold))
           .lineLimit(1)
           .minimumScaleFactor(0.85)
-          .allowsTightening(true)
+          .multilineTextAlignment(.center)
+          .frame(maxWidth: .infinity)
       }
       .foregroundStyle(isSelected ? JovieColor.textPrimary : JovieColor.textSecondary)
-      .padding(.horizontal, JovieSpacing.medium)
+      .padding(.horizontal, JovieSpacing.small)
       .padding(.vertical, 11)
       .frame(maxWidth: .infinity)
       .background(

--- a/apps/ios/Jovie/Features/Chat/MobileChatView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatView.swift
@@ -328,7 +328,7 @@ enum MobileChatProseTone {
 
 // MARK: - Inline prose flow (GH-12708 entity chip thumbnails v2)
 
-private enum MobileChatFlowToken: Hashable {
+enum MobileChatFlowToken: Hashable {
   case textWord(String)
   case entity(kind: MobileChatEntityKind, id: String, label: String)
   case skill(id: String, label: String)

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -209,6 +209,44 @@ final class JovieUITests: XCTestCase {
     )
   }
 
+  // GH-12948: "Audience" must stay on one line in the drawer surface switcher.
+  func testDrawerSurfaceSwitcherLabelsStaySingleLine() {
+    let app = launchMockApp(launchArgument: "-ui-testing-ready", expectedElementDescription: "\"Copy URL\"") {
+      $0.buttons["Copy URL"]
+    }
+
+    app.buttons["Open navigation drawer"].tap()
+
+    let profileSurface = app.buttons["shell-drawer-surface-shell-tab-profile"]
+    let audienceSurface = app.buttons["shell-drawer-surface-shell-tab-audience"]
+    let chatSurface = app.buttons["shell-drawer-surface-shell-tab-chat"]
+    XCTAssertTrue(
+      profileSurface.waitForExistence(timeout: 3),
+      "Profile drawer surface did not appear.\n\(app.debugDescription)"
+    )
+    XCTAssertTrue(
+      audienceSurface.waitForExistence(timeout: 3),
+      "Audience drawer surface did not appear.\n\(app.debugDescription)"
+    )
+    XCTAssertTrue(
+      chatSurface.waitForExistence(timeout: 3),
+      "Chat drawer surface did not appear.\n\(app.debugDescription)"
+    )
+
+    // Wrapped labels stack vertically and make the offending tab much taller.
+    let heights = [
+      profileSurface.frame.height,
+      audienceSurface.frame.height,
+      chatSurface.frame.height,
+    ]
+    XCTAssertLessThanOrEqual(
+      heights.max()! - heights.min()!,
+      4,
+      "Surface tab heights diverged — a label likely wrapped.\n\(app.debugDescription)"
+    )
+    XCTAssertEqual(audienceSurface.label, "Audience")
+  }
+
   // JOV-3670 evidence (b): removing the bottom pill's safeAreaInset must not
   // leave a ghost reserved footprint. Assert the composer/content region
   // extends to fill the reclaimed space, and that layout stays stable across


### PR DESCRIPTION
Closes #12948

Opened by the codex-issue-shipper **deterministic finisher**: the coding
agent produced this diff but exited without opening a PR. Pre-commit hooks
(lint-staged, typecheck) passed at commit time; CI is the merge gate as
usual.

Agent log: `/Users/timwhite/.hermes/profiles/summer/logs/codex-issue-shipper/github-12948-2026-07-03T20-25-40-848z.log`