### PR TITLE
Train: codex queue pipeline scoreboard

### DIFF
--- a/docs/CRON_REGISTRY.md
+++ b/docs/CRON_REGISTRY.md
@@ -25,6 +25,14 @@ Scheduled workflows in `.github/workflows/`. Not Vercel crons — these run on G
 | `Test Coverage Audit` | `0 6 * * *` UTC | Regenerates [`docs/TEST_COVERAGE_HEATMAP.md`](TEST_COVERAGE_HEATMAP.md) from [`TEST_RISK_REGISTER.md`](TEST_RISK_REGISTER.md) + v8 coverage. Commits if changed. | `.github/workflows/test-coverage-audit.yml` |
 | `Neon Ephemeral Branch Cleanup` | (see workflow) | Reaps Neon branches created by per-PR ephemeral DB tests. | `.github/workflows/neon-ephemeral-branch-cleanup.yml` |
 
+## Local Hermes Launchd Schedule
+
+These are machine-local Hermes jobs, not Vercel production crons. They run from launchd on the operator Mac and write to `~/.hermes`.
+
+| Unit | Schedule | Purpose | Source |
+|------|----------|---------|--------|
+| `co.jovie.hermes.cron-pipeline-scoreboard` | every 60 min | Computes the daily codex shipping funnel, writes `pipeline-scoreboard-latest.json` + gbrain `ops/pipeline-scoreboard/latest`, and alerts on 12h shipper stalls. | `scripts/hermes/jobs/pipeline-scoreboard.ts` |
+
 ## Production Schedule
 
 Source of truth: `apps/web/vercel.json`. The Vercel project's Root Directory is set to `apps/web/` (verified via `vercel project inspect jovie`), so Vercel reads that file, not the repo-root `vercel.json`. The root-level `vercel.json` exists for historical reasons and is **not** what Vercel consumes — keep both in sync until it can be deleted (see JOV-1901 / AUTOMATION_AUDIT.md for the original deletion intent).

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "video:footer:generate": "doppler run --project jovie-web --config dev -- tsx scripts/generate-footer-cta-video.ts",
     "hermes:worker": "pnpm --filter @jovie/web run hermes:worker",
     "hermes:codex-shipper": "tsx scripts/hermes/jobs/codex-issue-shipper.ts",
+    "hermes:pipeline-scoreboard": "tsx scripts/hermes/jobs/pipeline-scoreboard.ts",
     "ds:offscale": "node scripts/ds-offscale-report.mjs",
     "ds:llms-manifest": "node scripts/generate-llms-design-manifest.mjs",
     "ds:llms-manifest:check": "node scripts/generate-llms-design-manifest.mjs --check"

--- a/scripts/hermes/jobs/daily-briefing.ts
+++ b/scripts/hermes/jobs/daily-briefing.ts
@@ -14,11 +14,16 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
 import { chat } from '../lib/free-model-router';
 import { gbrainRecall } from '../lib/gbrain';
 import { HERMES_PATHS } from '../lib/hermes-paths';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import {
+  readLatestScoreboard,
+  renderPipelineScoreboard,
+} from '../lib/pipeline-scoreboard';
 import { sendTelegram } from '../lib/telegram-client';
 
 const JOB = 'daily-briefing';
@@ -123,6 +128,36 @@ function totalPaidSpendYesterday(): number {
   }
 }
 
+export function latestPipelineScoreboard(): string {
+  const scoreboard = readLatestScoreboard(
+    `${HERMES_PATHS.stateDir}/pipeline-scoreboard-latest.json`
+  );
+  return scoreboard ? renderPipelineScoreboard(scoreboard) : '';
+}
+
+export function buildDailyBriefingContext(args: {
+  readonly mergedPrs: ReadonlyArray<{
+    readonly number: number;
+    readonly title: string;
+  }>;
+  readonly voiceMemos: number;
+  readonly dispatches: number;
+  readonly paidSpend: number;
+  readonly pipelineScoreboard?: string;
+}): string {
+  return JSON.stringify(
+    {
+      mergedPrs: args.mergedPrs.map(p => `#${p.number} ${p.title}`),
+      voiceMemosIngested: args.voiceMemos,
+      tasksDispatched: args.dispatches,
+      paidSpendUsd: args.paidSpend,
+      pipelineScoreboard: args.pipelineScoreboard ?? '',
+    },
+    null,
+    2
+  );
+}
+
 async function main(): Promise<void> {
   await withJobLogging(JOB, async () => {
     const { since, until } = yesterdayRange();
@@ -138,17 +173,15 @@ async function main(): Promise<void> {
       until
     );
     const paidSpend = totalPaidSpendYesterday();
+    const pipelineScoreboard = latestPipelineScoreboard();
 
-    const context = JSON.stringify(
-      {
-        mergedPrs: merged.map(p => `#${p.number} ${p.title}`),
-        voiceMemosIngested: voiceMemos,
-        tasksDispatched: dispatches,
-        paidSpendUsd: paidSpend,
-      },
-      null,
-      2
-    );
+    const context = buildDailyBriefingContext({
+      mergedPrs: merged,
+      voiceMemos,
+      dispatches,
+      paidSpend,
+      pipelineScoreboard,
+    });
 
     // Recall durable founder context (priorities, decisions, open threads) so the
     // brief is memory-aware, not just yesterday's mechanical counts. Soft-degrades to ''.
@@ -172,7 +205,7 @@ async function main(): Promise<void> {
         },
         {
           role: 'user',
-          content: `Yesterday's data (UTC):\n\`\`\`json\n${context}\n\`\`\`${memoryBlock}`,
+          content: `Yesterday's data (UTC):\n\`\`\`json\n${context}\n\`\`\`\n\nInclude the pipeline scoreboard as a compact section in the daily digest.${memoryBlock}`,
         },
       ],
       { caller: JOB, need: 'reasoning', maxTokens: 600, temperature: 0.4 }
@@ -191,7 +224,12 @@ async function main(): Promise<void> {
   });
 }
 
-void main().catch(err => {
-  console.error(`[${JOB}] fatal:`, err);
-  process.exit(0);
-});
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch(err => {
+    console.error(`[${JOB}] fatal:`, err);
+    process.exit(0);
+  });
+}

--- a/scripts/hermes/jobs/pipeline-scoreboard.ts
+++ b/scripts/hermes/jobs/pipeline-scoreboard.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env tsx
+/**
+ * Pipeline Scoreboard — Hermes (read-only).
+ *
+ * Computes the daily codex issue shipper funnel and writes it to local state,
+ * gbrain, and ops notifications. This is local control-plane telemetry, not a
+ * production app cron.
+ */
+
+import { execFileSync } from 'node:child_process';
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+import { gbrainLearn } from '../lib/gbrain';
+import { HERMES_PATHS } from '../lib/hermes-paths';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { notifyOps } from '../lib/ops-notify';
+import {
+  buildPipelineScoreboard,
+  dailyWindow,
+  type JobLogEntry,
+  last12HoursWindow,
+  readJsonlEntries,
+  readLatestCiMetrics,
+  readLatestScoreboard,
+  renderPipelineScoreboard,
+} from '../lib/pipeline-scoreboard';
+
+const JOB = 'pipeline-scoreboard';
+const REPO = process.env.HERMES_GITHUB_REPO ?? 'JovieInc/Jovie';
+const ISSUE_LIMIT = process.env.HERMES_PIPELINE_SCOREBOARD_ISSUE_LIMIT ?? '500';
+const PR_LIMIT = process.env.HERMES_PIPELINE_SCOREBOARD_PR_LIMIT ?? '100';
+const SCOREBOARD_JSONL = join(
+  HERMES_PATHS.stateDir,
+  'pipeline-scoreboard.jsonl'
+);
+const SCOREBOARD_LATEST = join(
+  HERMES_PATHS.stateDir,
+  'pipeline-scoreboard-latest.json'
+);
+const ALERT_STATE = join(
+  HERMES_PATHS.stateDir,
+  'pipeline-scoreboard-alerts.json'
+);
+const CI_METRICS_LATEST = join(HERMES_PATHS.stateDir, 'ci-metrics-latest.json');
+
+interface GhIssue {
+  readonly number: number;
+  readonly title: string;
+  readonly body?: string | null;
+  readonly url: string;
+  readonly updatedAt?: string;
+  readonly labels: ReadonlyArray<{ readonly name: string }>;
+}
+
+interface GhPr {
+  readonly number: number;
+  readonly title: string;
+  readonly mergedAt: string;
+  readonly labels?: ReadonlyArray<{ readonly name: string }>;
+}
+
+function gh(args: readonly string[], timeoutMs = 30_000): string {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    timeout: timeoutMs,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+}
+
+function fetchCodexIssues(): GhIssue[] {
+  return JSON.parse(
+    gh([
+      'issue',
+      'list',
+      '--repo',
+      REPO,
+      '--state',
+      'open',
+      '--label',
+      'codex',
+      '--limit',
+      ISSUE_LIMIT,
+      '--json',
+      'number,title,body,url,updatedAt,labels',
+    ])
+  ) as GhIssue[];
+}
+
+function fetchMergedPrsSince(since: string): GhPr[] {
+  const prs = JSON.parse(
+    gh([
+      'pr',
+      'list',
+      '--repo',
+      REPO,
+      '--state',
+      'merged',
+      '--limit',
+      PR_LIMIT,
+      '--json',
+      'number,title,mergedAt,labels',
+    ])
+  ) as GhPr[];
+  return prs.filter(pr => pr.mergedAt >= since);
+}
+
+function filterEntries(
+  entries: ReadonlyArray<JobLogEntry>,
+  since: string,
+  until: string
+): JobLogEntry[] {
+  return entries.filter(
+    entry =>
+      typeof entry.ts === 'string' && entry.ts >= since && entry.ts < until
+  );
+}
+
+function alertKey(rule: string, windowSince: string): string {
+  return `${rule}:${windowSince.slice(0, 10)}`;
+}
+
+export function readAlertState(path = ALERT_STATE): Record<string, string> {
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Record<
+      string,
+      string
+    >;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function writeAlertState(
+  state: Record<string, string>,
+  path = ALERT_STATE
+): void {
+  writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+export async function notifyNewAlarms(
+  body: string,
+  alarms: ReadonlyArray<{ readonly rule: string }>,
+  windowSince: string
+): Promise<ReadonlyArray<string>> {
+  if (alarms.length === 0) return [];
+  const state = readAlertState();
+  const keys = alarms.map(alarm => alertKey(alarm.rule, windowSince));
+  const fresh = keys.filter(key => !state[key]);
+  if (fresh.length === 0) return [];
+  await notifyOps(`Pipeline scoreboard alert\n\n${body}`);
+  const now = new Date().toISOString();
+  for (const key of fresh) state[key] = now;
+  writeAlertState(state);
+  return fresh;
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const now = new Date();
+    const daily = dailyWindow(now);
+    const alarmWindow = last12HoursWindow(now);
+    const allEntries = readJsonlEntries(HERMES_PATHS.jobsLog);
+    const dailyEntries = filterEntries(allEntries, daily.since, daily.until);
+    const alarmEntries = filterEntries(
+      allEntries,
+      alarmWindow.since,
+      alarmWindow.until
+    );
+    const issues = fetchCodexIssues();
+    const mergedDaily = fetchMergedPrsSince(daily.since);
+    const mergedWeekly = fetchMergedPrsSince(
+      new Date(Date.parse(daily.until) - 7 * 86_400_000).toISOString()
+    );
+    const previous = readLatestScoreboard(SCOREBOARD_LATEST);
+    const ciMetrics = readLatestCiMetrics(CI_METRICS_LATEST);
+
+    const scoreboard = buildPipelineScoreboard({
+      ts: now.toISOString(),
+      window: daily,
+      issues,
+      previous,
+      jobLogEntries: dailyEntries,
+      ciMetrics,
+      mergedPrs: mergedDaily,
+    });
+    const alarmScoreboard = buildPipelineScoreboard({
+      ts: now.toISOString(),
+      window: alarmWindow,
+      issues,
+      previous,
+      jobLogEntries: alarmEntries,
+      ciMetrics,
+      mergedPrs: mergedDaily,
+    });
+    // The daily scoreboard owns blocked-count deltas; the rolling 12h
+    // scoreboard owns "claims but no ships" stall detection.
+    const mergedAlarms = [
+      ...scoreboard.alarms.filter(alarm => alarm.rule === 'blocked_delta'),
+      ...alarmScoreboard.alarms.filter(
+        alarm => alarm.rule === 'zero_ships_after_claims'
+      ),
+    ];
+    const finalScoreboard = {
+      ...scoreboard,
+      alarms: mergedAlarms,
+      gates: {
+        ...scoreboard.gates,
+        tasteLabeledPrsWeek: mergedWeekly.filter(pr =>
+          (pr.labels ?? []).some(label => label.name.includes('taste'))
+        ).length,
+      },
+    };
+    const body = renderPipelineScoreboard(finalScoreboard);
+
+    mkdirSync(HERMES_PATHS.stateDir, { recursive: true });
+    appendFileSync(SCOREBOARD_JSONL, `${JSON.stringify(finalScoreboard)}\n`);
+    writeFileSync(
+      SCOREBOARD_LATEST,
+      `${JSON.stringify(finalScoreboard, null, 2)}\n`
+    );
+
+    const gbrainOk = gbrainLearn({
+      slug: 'ops/pipeline-scoreboard/latest',
+      title: 'Pipeline scoreboard (latest)',
+      body,
+      tags: ['type:pipeline-scoreboard', 'area:codex-issue-shipper'],
+      type: 'pipeline-scoreboard',
+    });
+
+    const sentAlertKeys = await notifyNewAlarms(
+      body,
+      finalScoreboard.alarms,
+      now.toISOString()
+    );
+
+    logJobEvent({
+      job: JOB,
+      event: 'scored',
+      ready: finalScoreboard.funnel.ready,
+      claimed: finalScoreboard.funnel.claimed,
+      blocked: finalScoreboard.funnel.blocked,
+      claims: finalScoreboard.shipper.claims,
+      ships: finalScoreboard.shipper.ships,
+      merges: finalScoreboard.queue.merges,
+      alarms: finalScoreboard.alarms.map(alarm => alarm.rule),
+      sentAlertKeys,
+      gbrainOk,
+    });
+
+    process.stdout.write(`${body}\n`);
+  });
+}
+
+void main().catch(async err => {
+  const error = err instanceof Error ? err.message : String(err);
+  logJobEvent({
+    job: JOB,
+    event: 'fatal',
+    error,
+  });
+  console.error(`[${JOB}] fatal:`, err);
+  await notifyOps(`Pipeline scoreboard job failed: ${error}`);
+  process.exit(0);
+});

--- a/scripts/hermes/launchd/README.md
+++ b/scripts/hermes/launchd/README.md
@@ -19,6 +19,7 @@ The Hermes gateway itself is managed by the installed Hermes CLI as `ai.hermes.g
 | `co.jovie.hermes.cron-pr-monitor.plist.template` | every 10 min | Detect stuck PRs |
 | `co.jovie.hermes.cron-ci-monitor.plist.template` | every 10 min | Detect CI failures on main |
 | `co.jovie.hermes.cron-codex-issue-shipper.plist.template` | every 15 min | Claim one open GitHub issue labeled `codex` and dispatch a coder-profile agent |
+| `co.jovie.hermes.cron-pipeline-scoreboard.plist.template` | every 60 min | Write daily pipeline scoreboard to local state + gbrain, and alert on 12h shipper stalls |
 | `co.jovie.hermes.cron-agent-config-health.plist.template` | every 15 min | Detect invalid Hermes/OpenClaw agent config before gateway churn |
 | `co.jovie.hermes.cron-cost-monitor.plist.template` | every 60 min | Cost kill switch |
 | `co.jovie.hermes.cron-daily-briefing.plist.template` | 07:00 daily | Morning briefing to Telegram |

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-pipeline-scoreboard.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-pipeline-scoreboard.plist.template
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-pipeline-scoreboard</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/pipeline-scoreboard.ts</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>3600</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.bun/bin:{{HOME}}/.hermes/bin:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-pipeline-scoreboard.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-pipeline-scoreboard.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/lib/pipeline-scoreboard.ts
+++ b/scripts/hermes/lib/pipeline-scoreboard.ts
@@ -1,0 +1,447 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+import {
+  CODEX_BLOCKED_LABEL,
+  CODEX_CLAIM_LABEL,
+  CODEX_SOURCE_LABEL,
+  EPIC_LABEL,
+  type GithubIssue,
+  HUMAN_REVIEW_LABEL,
+  labelNames,
+  NO_AUTO_LABEL,
+} from './codex-issue-shipper';
+
+export const PIPELINE_SCOREBOARD_SCHEMA_VERSION = 1;
+export const BLOCKED_DELTA_CRITICAL_THRESHOLD = 15;
+
+export interface PipelineScoreboardWindow {
+  readonly since: string;
+  readonly until: string;
+}
+
+export interface PipelineScoreboard {
+  readonly schemaVersion: number;
+  readonly ts: string;
+  readonly window: PipelineScoreboardWindow;
+  readonly funnel: {
+    readonly ready: number;
+    readonly claimed: number;
+    readonly inProgress: number;
+    readonly blocked: number;
+    readonly deltas: {
+      readonly ready: number;
+      readonly claimed: number;
+      readonly inProgress: number;
+      readonly blocked: number;
+    };
+  };
+  readonly shipper: {
+    readonly claims: number;
+    readonly ships: number;
+    readonly failuresByCategory: Record<string, number>;
+    readonly retriesUsed: number;
+    readonly costPerShippedIssueUsd: number | null;
+  };
+  readonly queue: {
+    readonly merges: number;
+    readonly mqAttemptsPerMerge: number | null;
+    readonly timeToMergeSeconds: {
+      readonly p50: number;
+      readonly p95: number;
+    };
+  };
+  readonly gates: {
+    readonly tasteLabeledPrsWeek: number;
+    readonly autofixInterventions: number;
+  };
+  readonly alarms: ReadonlyArray<PipelineScoreboardAlarm>;
+}
+
+export interface PipelineScoreboardAlarm {
+  readonly rule: 'blocked_delta' | 'zero_ships_after_claims';
+  readonly severity: 'warning' | 'critical';
+  readonly message: string;
+}
+
+export interface JobLogEntry {
+  readonly job?: string;
+  readonly event?: string;
+  readonly ts?: string;
+  readonly issue?: number;
+  readonly cost?: number;
+  readonly [key: string]: unknown;
+}
+
+export interface PipelineScoreboardInput {
+  readonly ts: string;
+  readonly window: PipelineScoreboardWindow;
+  readonly issues: ReadonlyArray<GithubIssue>;
+  readonly previous?: PipelineScoreboard | null;
+  readonly jobLogEntries?: ReadonlyArray<JobLogEntry>;
+  readonly ciMetrics?: {
+    readonly throughput?: {
+      readonly queueWaitSeconds?: {
+        readonly p50?: number;
+        readonly p95?: number;
+      };
+    };
+    readonly latency?: {
+      readonly readyToMergeSeconds?: {
+        readonly p50?: number;
+        readonly p95?: number;
+      };
+    };
+  } | null;
+  readonly mergedPrs?: ReadonlyArray<{
+    readonly labels?: ReadonlyArray<{ readonly name?: string } | string>;
+  }>;
+}
+
+const FAILURE_EVENTS = new Set([
+  'agent_failed',
+  'deterministic_finish_failed',
+  'dispatch_failed',
+  'gbrain_failed',
+  'missing_pr_release_claim',
+]);
+
+const RETRY_EVENTS = new Set([
+  'agent_interrupted_release_claim',
+  'missing_pr_release_claim',
+  'restart_recovered_claim',
+]);
+
+const AUTOFIX_EVENTS = new Set([
+  'deterministic_finish_shipped',
+  'agent_no_work_fallback',
+]);
+
+const CLAIM_EVENTS = new Set([
+  'agent_succeeded',
+  'agent_failed',
+  'gbrain_failed',
+  'agent_interrupted_release_claim',
+  'missing_pr_release_claim',
+]);
+
+const SHIP_EVENTS = new Set([
+  'pr_found_after_success',
+  'deterministic_finish_shipped',
+]);
+
+export function dailyWindow(now = new Date()): PipelineScoreboardWindow {
+  const until = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+  const since = new Date(until.getTime() - 86_400_000);
+  return { since: since.toISOString(), until: until.toISOString() };
+}
+
+export function last12HoursWindow(now = new Date()): PipelineScoreboardWindow {
+  return {
+    since: new Date(now.getTime() - 12 * 3_600_000).toISOString(),
+    until: now.toISOString(),
+  };
+}
+
+function isBetween(
+  ts: string | undefined,
+  window: PipelineScoreboardWindow
+): boolean {
+  return typeof ts === 'string' && ts >= window.since && ts < window.until;
+}
+
+export function readJsonlEntries(path: string): JobLogEntry[] {
+  if (!existsSync(path)) return [];
+  try {
+    return readFileSync(path, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .flatMap(line => {
+        try {
+          return [JSON.parse(line) as JobLogEntry];
+        } catch {
+          return [];
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPercentileRecord(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return ['p50', 'p95'].every(
+    key => value[key] === undefined || typeof value[key] === 'number'
+  );
+}
+
+function isPipelineScoreboard(value: unknown): value is PipelineScoreboard {
+  if (!isRecord(value)) return false;
+  return (
+    value.schemaVersion === PIPELINE_SCOREBOARD_SCHEMA_VERSION &&
+    isRecord(value.window) &&
+    typeof value.window.since === 'string' &&
+    typeof value.window.until === 'string' &&
+    isRecord(value.funnel) &&
+    isRecord(value.shipper) &&
+    isRecord(value.queue) &&
+    isRecord(value.gates) &&
+    Array.isArray(value.alarms)
+  );
+}
+
+function isCiMetricsSnapshot(
+  value: unknown
+): value is NonNullable<PipelineScoreboardInput['ciMetrics']> {
+  if (!isRecord(value)) return false;
+  const throughput = value.throughput;
+  const latency = value.latency;
+  return (
+    (throughput === undefined ||
+      (isRecord(throughput) &&
+        (throughput.queueWaitSeconds === undefined ||
+          isPercentileRecord(throughput.queueWaitSeconds)))) &&
+    (latency === undefined ||
+      (isRecord(latency) &&
+        (latency.readyToMergeSeconds === undefined ||
+          isPercentileRecord(latency.readyToMergeSeconds))))
+  );
+}
+
+export function readLatestScoreboard(path: string): PipelineScoreboard | null {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    return isPipelineScoreboard(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readLatestCiMetrics(
+  path: string
+): PipelineScoreboardInput['ciMetrics'] {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    return isCiMetricsSnapshot(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function issueHas(issue: GithubIssue, label: string): boolean {
+  return labelNames(issue).includes(label);
+}
+
+function funnelCounts(issues: ReadonlyArray<GithubIssue>) {
+  const codexIssues = issues.filter(issue =>
+    issueHas(issue, CODEX_SOURCE_LABEL)
+  );
+  const claimed = codexIssues.filter(issue =>
+    issueHas(issue, CODEX_CLAIM_LABEL)
+  ).length;
+  const blocked = codexIssues.filter(issue =>
+    issueHas(issue, CODEX_BLOCKED_LABEL)
+  ).length;
+  const ready = codexIssues.filter(issue => {
+    const labels = new Set(labelNames(issue));
+    return (
+      !labels.has(CODEX_CLAIM_LABEL) &&
+      !labels.has(CODEX_BLOCKED_LABEL) &&
+      !labels.has(HUMAN_REVIEW_LABEL) &&
+      !labels.has(NO_AUTO_LABEL) &&
+      !labels.has(EPIC_LABEL)
+    );
+  }).length;
+  return {
+    ready,
+    claimed,
+    inProgress: claimed,
+    blocked,
+  };
+}
+
+function delta(current: number, previous: number | undefined): number {
+  return current - (previous ?? 0);
+}
+
+function failureCategory(entry: JobLogEntry): string {
+  if (typeof entry.error === 'string' && entry.error.trim()) {
+    const compact = entry.error
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .slice(0, 48);
+    return compact || String(entry.event ?? 'unknown');
+  }
+  return String(entry.event ?? 'unknown');
+}
+
+function countBy<T>(
+  items: ReadonlyArray<T>,
+  key: (item: T) => string
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const item of items) {
+    const k = key(item);
+    counts[k] = (counts[k] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function labelList(
+  labels: ReadonlyArray<{ readonly name?: string } | string> | undefined
+): ReadonlyArray<string> {
+  return (labels ?? [])
+    .map(label => (typeof label === 'string' ? label : label.name))
+    .filter((label): label is string => Boolean(label));
+}
+
+function countUniqueIssues(
+  entries: ReadonlyArray<JobLogEntry>,
+  eventNames: ReadonlySet<string>
+): number {
+  let withoutIssue = 0;
+  const issues = new Set<number>();
+  for (const entry of entries) {
+    if (!eventNames.has(String(entry.event))) continue;
+    if (typeof entry.issue === 'number') {
+      issues.add(entry.issue);
+    } else {
+      withoutIssue += 1;
+    }
+  }
+  return issues.size + withoutIssue;
+}
+
+export function buildPipelineScoreboard(
+  input: PipelineScoreboardInput
+): PipelineScoreboard {
+  const counts = funnelCounts(input.issues);
+  const previousFunnel = input.previous?.funnel;
+  const entries = (input.jobLogEntries ?? []).filter(entry =>
+    isBetween(entry.ts, input.window)
+  );
+  const shipperEntries = entries.filter(
+    entry => entry.job === 'codex-issue-shipper'
+  );
+  const claims = countUniqueIssues(shipperEntries, CLAIM_EVENTS);
+  const ships = countUniqueIssues(shipperEntries, SHIP_EVENTS);
+  const failures = shipperEntries.filter(entry =>
+    FAILURE_EVENTS.has(String(entry.event))
+  );
+  const retriesUsed = shipperEntries.filter(entry =>
+    RETRY_EVENTS.has(String(entry.event))
+  ).length;
+  const totalCost = shipperEntries
+    .map(entry => (typeof entry.cost === 'number' ? entry.cost : 0))
+    .reduce((sum, value) => sum + value, 0);
+  const merges = input.mergedPrs?.length ?? 0;
+  const mqAttempts = input.mergedPrs?.filter(pr =>
+    labelList(pr.labels).includes('merge-queue')
+  ).length;
+  const readyToMerge = input.ciMetrics?.latency?.readyToMergeSeconds;
+  const gateEntries = shipperEntries;
+
+  const scoreboard: PipelineScoreboard = {
+    schemaVersion: PIPELINE_SCOREBOARD_SCHEMA_VERSION,
+    ts: input.ts,
+    window: input.window,
+    funnel: {
+      ...counts,
+      deltas: {
+        ready: delta(counts.ready, previousFunnel?.ready),
+        claimed: delta(counts.claimed, previousFunnel?.claimed),
+        inProgress: delta(counts.inProgress, previousFunnel?.inProgress),
+        blocked: delta(counts.blocked, previousFunnel?.blocked),
+      },
+    },
+    shipper: {
+      claims,
+      ships,
+      failuresByCategory: countBy(failures, failureCategory),
+      retriesUsed,
+      costPerShippedIssueUsd:
+        ships > 0 ? Number((totalCost / ships).toFixed(4)) : null,
+    },
+    queue: {
+      merges,
+      mqAttemptsPerMerge:
+        merges > 0 && typeof mqAttempts === 'number'
+          ? Number((mqAttempts / merges).toFixed(2))
+          : null,
+      timeToMergeSeconds: {
+        p50: readyToMerge?.p50 ?? 0,
+        p95: readyToMerge?.p95 ?? 0,
+      },
+    },
+    gates: {
+      tasteLabeledPrsWeek:
+        input.mergedPrs?.filter(pr =>
+          labelList(pr.labels).some(label => label.includes('taste'))
+        ).length ?? 0,
+      autofixInterventions: gateEntries.filter(entry =>
+        AUTOFIX_EVENTS.has(String(entry.event))
+      ).length,
+    },
+    alarms: [],
+  };
+
+  return { ...scoreboard, alarms: evaluatePipelineAlarms(scoreboard) };
+}
+
+export function evaluatePipelineAlarms(
+  scoreboard: PipelineScoreboard
+): ReadonlyArray<PipelineScoreboardAlarm> {
+  const alarms: PipelineScoreboardAlarm[] = [];
+  const windowLabel = `${scoreboard.window.since} to ${scoreboard.window.until}`;
+  if (scoreboard.funnel.deltas.blocked > BLOCKED_DELTA_CRITICAL_THRESHOLD) {
+    alarms.push({
+      rule: 'blocked_delta',
+      severity: 'critical',
+      message: `Blocked issue count increased by ${scoreboard.funnel.deltas.blocked} from ${windowLabel}.`,
+    });
+  }
+  if (scoreboard.shipper.claims > 0 && scoreboard.shipper.ships === 0) {
+    alarms.push({
+      rule: 'zero_ships_after_claims',
+      severity: 'critical',
+      message: `Shipper recorded ${scoreboard.shipper.claims} claim attempt(s) and 0 shipped PRs from ${windowLabel}.`,
+    });
+  }
+  return alarms;
+}
+
+function signed(value: number): string {
+  return value > 0 ? `+${value}` : String(value);
+}
+
+function fmtSeconds(seconds: number): string {
+  if (!seconds) return '0m';
+  return `${Math.round(seconds / 60)}m`;
+}
+
+export function renderPipelineScoreboard(
+  scoreboard: PipelineScoreboard
+): string {
+  const failureText = Object.entries(scoreboard.shipper.failuresByCategory)
+    .map(([key, value]) => `${key}:${value}`)
+    .join(', ');
+  return [
+    `Pipeline scoreboard (${scoreboard.window.since.slice(0, 10)} UTC)`,
+    `Funnel: ready ${scoreboard.funnel.ready} (${signed(scoreboard.funnel.deltas.ready)}) · claimed ${scoreboard.funnel.claimed} (${signed(scoreboard.funnel.deltas.claimed)}) · in-progress ${scoreboard.funnel.inProgress} (${signed(scoreboard.funnel.deltas.inProgress)}) · blocked ${scoreboard.funnel.blocked} (${signed(scoreboard.funnel.deltas.blocked)})`,
+    `Shipper: claims ${scoreboard.shipper.claims} · ships ${scoreboard.shipper.ships} · retries ${scoreboard.shipper.retriesUsed} · cost/ship $${scoreboard.shipper.costPerShippedIssueUsd ?? 0}`,
+    `Failures: ${failureText || 'none'}`,
+    `Queue: merges ${scoreboard.queue.merges} · MQ attempts/merge ${scoreboard.queue.mqAttemptsPerMerge ?? 'n/a'} · time-to-merge p50 ${fmtSeconds(scoreboard.queue.timeToMergeSeconds.p50)} / p95 ${fmtSeconds(scoreboard.queue.timeToMergeSeconds.p95)}`,
+    `Gates: taste-labeled PRs/week ${scoreboard.gates.tasteLabeledPrsWeek} · autofix interventions ${scoreboard.gates.autofixInterventions}`,
+    scoreboard.alarms.length
+      ? `Alarms: ${scoreboard.alarms.map(alarm => alarm.message).join(' ')}`
+      : 'Alarms: none',
+  ].join('\n');
+}

--- a/scripts/lib/__tests__/pipeline-scoreboard.test.mjs
+++ b/scripts/lib/__tests__/pipeline-scoreboard.test.mjs
@@ -1,0 +1,379 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { buildDailyBriefingContext } from '../../hermes/jobs/daily-briefing.ts';
+import {
+  buildPipelineScoreboard,
+  dailyWindow,
+  evaluatePipelineAlarms,
+  last12HoursWindow,
+  renderPipelineScoreboard,
+} from '../../hermes/lib/pipeline-scoreboard.ts';
+
+function issue(number, labels) {
+  return {
+    number,
+    title: `Issue ${number}`,
+    body: '',
+    url: `https://github.com/JovieInc/Jovie/issues/${number}`,
+    labels: labels.map(name => ({ name })),
+  };
+}
+
+describe('pipeline scoreboard windows', () => {
+  it('uses the previous UTC day for daily scoreboards', () => {
+    expect(dailyWindow(new Date('2026-07-03T16:20:00Z'))).toEqual({
+      since: '2026-07-02T00:00:00.000Z',
+      until: '2026-07-03T00:00:00.000Z',
+    });
+  });
+
+  it('uses a rolling 12h window for stall alarms', () => {
+    expect(last12HoursWindow(new Date('2026-07-03T16:20:00Z'))).toEqual({
+      since: '2026-07-03T04:20:00.000Z',
+      until: '2026-07-03T16:20:00.000Z',
+    });
+  });
+});
+
+describe('pipeline scoreboard compute', () => {
+  const window = {
+    since: '2026-07-02T00:00:00.000Z',
+    until: '2026-07-03T00:00:00.000Z',
+  };
+
+  it('returns zeroed metrics for the empty path', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T00:00:00.000Z',
+      window,
+      issues: [],
+      jobLogEntries: [],
+      mergedPrs: [],
+    });
+
+    expect(scoreboard.funnel).toMatchObject({
+      ready: 0,
+      claimed: 0,
+      inProgress: 0,
+      blocked: 0,
+    });
+    expect(scoreboard.shipper.claims).toBe(0);
+    expect(scoreboard.shipper.ships).toBe(0);
+    expect(scoreboard.alarms).toEqual([]);
+  });
+
+  it('computes funnel deltas against the previous local snapshot', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T00:00:00.000Z',
+      window,
+      issues: [
+        issue(1, ['codex']),
+        issue(2, ['codex', 'codex-in-progress']),
+        issue(3, ['codex', 'codex-blocked']),
+        issue(4, ['codex', 'codex-blocked']),
+        issue(5, ['codex', 'human-review-required']),
+        issue(6, ['codex', 'no-auto']),
+        issue(7, ['codex', 'type:epic']),
+      ],
+      previous: {
+        schemaVersion: 1,
+        ts: '2026-07-02T00:00:00.000Z',
+        window,
+        funnel: {
+          ready: 3,
+          claimed: 0,
+          inProgress: 0,
+          blocked: 1,
+          deltas: { ready: 0, claimed: 0, inProgress: 0, blocked: 0 },
+        },
+        shipper: {
+          claims: 0,
+          ships: 0,
+          failuresByCategory: {},
+          retriesUsed: 0,
+          costPerShippedIssueUsd: null,
+        },
+        queue: {
+          merges: 0,
+          mqAttemptsPerMerge: null,
+          timeToMergeSeconds: { p50: 0, p95: 0 },
+        },
+        gates: { tasteLabeledPrsWeek: 0, autofixInterventions: 0 },
+        alarms: [],
+      },
+    });
+
+    expect(scoreboard.funnel.ready).toBe(1);
+    expect(scoreboard.funnel.claimed).toBe(1);
+    expect(scoreboard.funnel.blocked).toBe(2);
+    expect(scoreboard.funnel.deltas).toEqual({
+      ready: -2,
+      claimed: 1,
+      inProgress: 1,
+      blocked: 1,
+    });
+  });
+
+  it('fires the blocked-delta alarm when blocked grows by more than 15/day', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T00:00:00.000Z',
+      window,
+      issues: Array.from({ length: 17 }, (_, index) =>
+        issue(index + 1, ['codex', 'codex-blocked'])
+      ),
+      previous: {
+        schemaVersion: 1,
+        ts: '2026-07-02T00:00:00.000Z',
+        window,
+        funnel: {
+          ready: 0,
+          claimed: 0,
+          inProgress: 0,
+          blocked: 1,
+          deltas: { ready: 0, claimed: 0, inProgress: 0, blocked: 0 },
+        },
+        shipper: {
+          claims: 0,
+          ships: 0,
+          failuresByCategory: {},
+          retriesUsed: 0,
+          costPerShippedIssueUsd: null,
+        },
+        queue: {
+          merges: 0,
+          mqAttemptsPerMerge: null,
+          timeToMergeSeconds: { p50: 0, p95: 0 },
+        },
+        gates: { tasteLabeledPrsWeek: 0, autofixInterventions: 0 },
+        alarms: [],
+      },
+    });
+
+    expect(scoreboard.alarms.map(alarm => alarm.rule)).toContain(
+      'blocked_delta'
+    );
+  });
+
+  it('fires the simulated stall alarm when claims have no ships', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T12:00:00.000Z',
+      window: {
+        since: '2026-07-03T00:00:00.000Z',
+        until: '2026-07-03T12:00:00.000Z',
+      },
+      issues: [],
+      jobLogEntries: [
+        {
+          job: 'codex-issue-shipper',
+          event: 'agent_failed',
+          ts: '2026-07-03T06:00:00.000Z',
+          error: 'agent exited without PR',
+        },
+      ],
+    });
+
+    expect(scoreboard.shipper.claims).toBe(1);
+    expect(scoreboard.shipper.ships).toBe(0);
+    expect(scoreboard.alarms).toEqual([
+      expect.objectContaining({ rule: 'zero_ships_after_claims' }),
+    ]);
+  });
+
+  it('counts pre-agent claim failures as claims and failure categories', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T12:00:00.000Z',
+      window,
+      issues: [],
+      jobLogEntries: [
+        {
+          job: 'codex-issue-shipper',
+          event: 'gbrain_failed',
+          ts: '2026-07-02T06:00:00.000Z',
+          issue: 123,
+          error: 'gbrain capture failed: Page not found',
+        },
+      ],
+    });
+
+    expect(scoreboard.shipper.claims).toBe(1);
+    expect(scoreboard.shipper.failuresByCategory).toEqual({
+      gbrain_capture_failed_page_not_found: 1,
+    });
+    expect(scoreboard.alarms.map(alarm => alarm.rule)).toContain(
+      'zero_ships_after_claims'
+    );
+  });
+
+  it('deduplicates deterministic finisher ship events by issue', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T12:00:00.000Z',
+      window,
+      issues: [],
+      jobLogEntries: [
+        {
+          job: 'codex-issue-shipper',
+          event: 'deterministic_finish_shipped',
+          ts: '2026-07-02T06:00:00.000Z',
+          issue: 123,
+        },
+        {
+          job: 'codex-issue-shipper',
+          event: 'pr_found_after_success',
+          ts: '2026-07-02T06:01:00.000Z',
+          issue: 123,
+        },
+      ],
+    });
+
+    expect(scoreboard.shipper.ships).toBe(1);
+  });
+
+  it('uses only shipper costs for cost per shipped issue', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T12:00:00.000Z',
+      window,
+      issues: [],
+      jobLogEntries: [
+        {
+          job: 'codex-issue-shipper',
+          event: 'pr_found_after_success',
+          ts: '2026-07-02T06:00:00.000Z',
+          issue: 123,
+          cost: 2,
+        },
+        {
+          job: 'daily-briefing',
+          event: 'sent',
+          ts: '2026-07-02T06:00:00.000Z',
+          cost: 98,
+        },
+      ],
+    });
+
+    expect(scoreboard.shipper.costPerShippedIssueUsd).toBe(2);
+  });
+
+  it('renders alarm messages with the evaluated window', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T12:00:00.000Z',
+      window,
+      issues: [],
+      jobLogEntries: [
+        {
+          job: 'codex-issue-shipper',
+          event: 'gbrain_failed',
+          ts: '2026-07-02T06:00:00.000Z',
+          issue: 123,
+        },
+      ],
+    });
+
+    expect(scoreboard.alarms[0].message).toContain(window.since);
+    expect(scoreboard.alarms[0].message).toContain(window.until);
+  });
+
+  it('does not fire the stall alarm without claims or when a ship exists', () => {
+    expect(
+      evaluatePipelineAlarms(
+        buildPipelineScoreboard({
+          ts: '2026-07-03T12:00:00.000Z',
+          window,
+          issues: [],
+          jobLogEntries: [],
+        })
+      )
+    ).toEqual([]);
+
+    expect(
+      buildPipelineScoreboard({
+        ts: '2026-07-03T12:00:00.000Z',
+        window,
+        issues: [],
+        jobLogEntries: [
+          {
+            job: 'codex-issue-shipper',
+            event: 'agent_succeeded',
+            ts: '2026-07-02T06:00:00.000Z',
+          },
+          {
+            job: 'codex-issue-shipper',
+            event: 'pr_found_after_success',
+            ts: '2026-07-02T06:10:00.000Z',
+          },
+        ],
+      }).alarms
+    ).toEqual([]);
+  });
+
+  it('renders the digest scoreboard section', () => {
+    const body = renderPipelineScoreboard(
+      buildPipelineScoreboard({
+        ts: '2026-07-03T00:00:00.000Z',
+        window,
+        issues: [issue(1, ['codex'])],
+        jobLogEntries: [],
+        ciMetrics: {
+          latency: { readyToMergeSeconds: { p50: 600, p95: 900 } },
+        },
+        mergedPrs: [{ labels: [{ name: 'merge-queue' }] }],
+      })
+    );
+
+    expect(body).toContain('Pipeline scoreboard');
+    expect(body).toContain('Funnel: ready 1');
+    expect(body).toContain('Queue: merges 1');
+    expect(body).toContain('time-to-merge p50 10m / p95 15m');
+  });
+});
+
+describe('pipeline scoreboard digest and schedule wiring', () => {
+  const repoRoot = resolve(import.meta.dirname, '..', '..', '..');
+
+  it('includes scoreboard text in the daily briefing context', () => {
+    const context = buildDailyBriefingContext({
+      mergedPrs: [{ number: 1, title: 'Ship scoreboard' }],
+      voiceMemos: 0,
+      dispatches: 2,
+      paidSpend: 0,
+      pipelineScoreboard: 'Pipeline scoreboard\nFunnel: ready 1',
+    });
+
+    expect(context).toContain('Pipeline scoreboard');
+    expect(context).toContain('Funnel: ready 1');
+    expect(context).toContain('#1 Ship scoreboard');
+  });
+
+  it('keeps package script, launchd unit, and cron registry wired together', () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(repoRoot, 'package.json'), 'utf8')
+    );
+    const plist = readFileSync(
+      resolve(
+        repoRoot,
+        'scripts/hermes/launchd/co.jovie.hermes.cron-pipeline-scoreboard.plist.template'
+      ),
+      'utf8'
+    );
+    const cronRegistry = readFileSync(
+      resolve(repoRoot, 'docs/CRON_REGISTRY.md'),
+      'utf8'
+    );
+
+    expect(packageJson.scripts['hermes:pipeline-scoreboard']).toBe(
+      'tsx scripts/hermes/jobs/pipeline-scoreboard.ts'
+    );
+    expect(plist).toContain(
+      '<string>co.jovie.hermes.cron-pipeline-scoreboard</string>'
+    );
+    expect(plist).toContain(
+      '<string>{{JOVIE_REPO}}/scripts/hermes/jobs/pipeline-scoreboard.ts</string>'
+    );
+    expect(plist).toContain('<key>StartInterval</key>');
+    expect(plist).toContain('<integer>3600</integer>');
+    expect(cronRegistry).toContain('co.jovie.hermes.cron-pipeline-scoreboard');
+    expect(cronRegistry).toContain(
+      'scripts/hermes/jobs/pipeline-scoreboard.ts'
+    );
+  });
+});

--- a/scripts/loop-integration-ship.sh
+++ b/scripts/loop-integration-ship.sh
@@ -17,7 +17,13 @@ fi
 
 echo "==> Local verify (integration fast path)"
 pnpm --filter @jovie/web run typecheck -- --pretty false
-pnpm biome check --write "$(git diff --name-only "origin/${INTEGRATION_BRANCH}"...HEAD | grep -E '\.(ts|tsx|js|mjs)$' || true)" 2>/dev/null || pnpm biome check apps/web
+CHANGED_CODE_FILES=()
+while IFS= read -r file; do
+  [[ -n "$file" ]] && CHANGED_CODE_FILES+=("$file")
+done < <(git diff --name-only "origin/${INTEGRATION_BRANCH}"...HEAD | grep -E '\.(ts|tsx|js|mjs)$' || true)
+if (( ${#CHANGED_CODE_FILES[@]} > 0 )); then
+  pnpm biome check --write "${CHANGED_CODE_FILES[@]}"
+fi
 
 echo "==> Push $FEATURE_BRANCH"
 git push -u origin "$FEATURE_BRANCH"


### PR DESCRIPTION
## Summary
- Adds Hermes pipeline scoreboard metrics for codex issue funnel, shipper outcomes, queue latency, gate/autofix signals, and alarm rules.
- Writes append-only/latest local scoreboard state, updates gbrain `ops/pipeline-scoreboard/latest`, and includes the latest scoreboard in the daily briefing digest.
- Adds hourly launchd wiring so the 12h stalled-shipper alarm can fire without waiting for the next daily brief.
- Fixes `loop-integration-ship.sh` changed-file Biome invocation so integration shipping checks only changed code files.

Closes #12620

## Verification
- `pnpm exec biome check scripts/hermes/lib/pipeline-scoreboard.ts scripts/hermes/jobs/pipeline-scoreboard.ts scripts/hermes/jobs/daily-briefing.ts scripts/lib/__tests__/pipeline-scoreboard.test.mjs scripts/hermes/launchd/co.jovie.hermes.cron-pipeline-scoreboard.plist.template scripts/hermes/launchd/README.md docs/CRON_REGISTRY.md package.json` — passed.
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/pipeline-scoreboard.test.mjs` — 1 file passed, 14 tests passed.
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/pipeline-scoreboard.test.mjs lib/__tests__/ship-ledger.test.mjs lib/__tests__/merge-queue-guard.test.mjs` — 3 files passed, 43 tests passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- Failure-path smoke: invalid `HERMES_GITHUB_REPO` exits 0, logs `error`/`fatal`, and writes no scoreboard state.
- `coderabbit review --agent -c AGENTS.md -t uncommitted` — completed once; actionable findings fixed. Final rerun blocked by CodeRabbit rate limit (`waitTime: 45 minutes`) after fixes.
- `./scripts/loop-integration-ship.sh 'integration/codex-queue' 'codex/gh-12620-pipeline-scoreboard-daily-funnel-metrics-ready-c-2026-07-03T23-20-19-026z' 'Pipeline scoreboard: daily funnel metrics (ready/claimed/blocked/retries/merges/MQ attempts) to digest + gbrain'` — local verify passed, feature PR #13023 created and squash-merged into `integration/codex-queue`.

## Cost Impact
- External API calls: GitHub CLI reads only, hourly local Hermes job. No production app cron, no paid third-party API calls added.
- Monthly projection: local GitHub reads only; bounded by `HERMES_PIPELINE_SCOREBOARD_ISSUE_LIMIT` and `HERMES_PIPELINE_SCOREBOARD_PR_LIMIT`.
- Scaling factor: O(open codex issues + sampled merged PRs) per run, bounded by env-configurable limits.
- Monthly cost estimate: $0 direct provider spend; uses existing local Hermes/GitHub/gbrain surfaces.
