### PR TITLE
fix(desktop): isolate Mac auth callback schemes

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -26,7 +26,7 @@ on:
     branches: [main]
     paths:
       - "VERSION"
-      - ".github/workflows/desktop-release.yml"  # explicit handling for desktop auth allowlist fixes (e.g. 9870/9812 Clerk wildcard; JOV-3835 CSP-watchdog blank-window fix)
+      - ".github/workflows/desktop-release.yml"  # explicit handling for desktop auth allowlist/scheme fixes (e.g. 9870/9812 Clerk wildcard; JOV-3835 CSP-watchdog blank-window fix; GH-12822 per-env callback schemes)
   workflow_dispatch:
     inputs:
       environment:

--- a/apps/desktop/electron-builder.local.yml
+++ b/apps/desktop/electron-builder.local.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Local Auth
+        CFBundleURLSchemes:
+          - jovie-local
   notarize: false
   target:
     - target: dir

--- a/apps/desktop/electron-builder.staging.yml
+++ b/apps/desktop/electron-builder.staging.yml
@@ -19,6 +19,10 @@ mac:
   extendInfo:
     NSAppTransportSecurity:
       NSAllowsArbitraryLoads: false
+    CFBundleURLTypes:
+      - CFBundleURLName: Jovie Staging Auth
+        CFBundleURLSchemes:
+          - jovie-staging
   notarize: true
   target:
     - target: dmg

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -115,6 +115,16 @@ test('desktop window fails into a branded Jovie recovery surface', async () => {
     mainSource,
     /hideMainWindowForAuthHandoff\(\);\s*if \(authHandoffWindow\) showWindow\(authHandoffWindow\);/
   );
+  assert.match(mainSource, /const initialVisibilityFallback = setTimeout/);
+  assert.match(mainSource, /current === 'about:blank'/);
+  assert.match(
+    mainSource,
+    /const authUrl = buildCentralDesktopAuthUrl\('sign_in', '\/app'\);/
+  );
+  assert.match(
+    mainSource,
+    /void win\.loadURL\(buildDesktopAuthHandoffUrl\(authUrl\)\);/
+  );
   assert.match(
     mainSource,
     /void win\.loadURL\(buildDesktopAuthHandoffUrl\(initialAuthUrl\)\);/
@@ -178,10 +188,19 @@ test('desktop production bundle declares the jovie auth protocol', async () => {
   assert.match(builderConfig, /CFBundleURLTypes:/);
   assert.match(builderConfig, /CFBundleURLName: Jovie Auth/);
   assert.match(builderConfig, /CFBundleURLSchemes:\s*\n\s*- jovie/);
-  assert.match(mainSource, /if \(APP_ENV !== 'production'\)/);
-  assert.match(mainSource, /setAsDefaultProtocolClient\('jovie'\)/);
-  assert.doesNotMatch(stagingConfig, /CFBundleURLTypes:/);
-  assert.doesNotMatch(localConfig, /CFBundleURLTypes:/);
+  assert.match(mainSource, /APP_ENV === 'staging'\s*\?\s*'jovie-staging'/);
+  assert.match(mainSource, /APP_ENV === 'local'\s*\?\s*'jovie-local'/);
+  assert.match(mainSource, /:\s*'jovie';/);
+  assert.match(
+    mainSource,
+    /app\.setAsDefaultProtocolClient\(AUTH_RETURN_SCHEME/
+  );
+  assert.match(stagingConfig, /CFBundleURLTypes:/);
+  assert.match(stagingConfig, /CFBundleURLName: Jovie Staging Auth/);
+  assert.match(stagingConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-staging/);
+  assert.match(localConfig, /CFBundleURLTypes:/);
+  assert.match(localConfig, /CFBundleURLName: Jovie Local Auth/);
+  assert.match(localConfig, /CFBundleURLSchemes:\s*\n\s*- jovie-local/);
 });
 
 test('desktop navigation uses explicit URL disposition allowlists', async () => {
@@ -408,6 +427,21 @@ test('native auth smoke keeps browser callbacks on the browser auth origin', asy
     smokeSource,
     /const BASE_URL = process\.env\.BASE_URL \?\? 'http:\/\/localhost:3112';/
   );
+  assert.match(
+    smokeSource,
+    /const NATIVE_AUTH_CALLBACK_SCHEME = getNativeAuthSchemeForBaseUrl\(BASE_URL\);/
+  );
+  assert.match(
+    smokeSource,
+    /if \(hostname === 'staging\.jov\.ie'\) return 'jovie-staging';/
+  );
+  assert.match(smokeSource, /if \(hostname === 'jov\.ie'\) return 'jovie';/);
+  assert.match(
+    smokeSource,
+    /hostname === 'localhost'[\s\S]*return 'jovie-local';/
+  );
+  assert.match(smokeSource, /return 'jovie';\s*\n}/);
+  assert.match(smokeSource, /NATIVE_AUTH_CALLBACK_PREFIX/);
   assert.match(smokeSource, /async function waitForDesktopAuthHandoff/);
   assert.match(smokeSource, /state === 'opened'/);
   assert.match(

--- a/apps/desktop/scripts/smoke-native-auth.mjs
+++ b/apps/desktop/scripts/smoke-native-auth.mjs
@@ -14,17 +14,34 @@ const SMOKE_CLIENT_IP =
 const CLEAR_ELECTRON_AUTH_ON_START =
   process.env.SMOKE_CLEAR_ELECTRON_AUTH === '1';
 const SKIP_START_SIGN_OUT = process.env.SMOKE_SKIP_START_SIGNOUT === '1';
+const NATIVE_AUTH_CALLBACK_SCHEME = getNativeAuthSchemeForBaseUrl(BASE_URL);
 const REQUEST_TIMEOUT_MS = parsePositiveInteger(
   process.env.SMOKE_REQUEST_TIMEOUT_MS,
   180_000
 );
 const SMOKE_AUTH_EVIDENCE_KEY = 'jovie.desktopAuth.smokeAuthEvidence';
+const NATIVE_AUTH_CALLBACK_PREFIX = `${NATIVE_AUTH_CALLBACK_SCHEME}://auth/complete?`;
 
 let playwrightChromium;
 
 function parsePositiveInteger(value, fallback) {
   const parsed = Number.parseInt(value ?? '', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getNativeAuthSchemeForBaseUrl(baseUrl) {
+  const hostname = new URL(baseUrl).hostname.toLowerCase();
+  if (hostname === 'jov.ie') return 'jovie';
+  if (hostname === 'staging.jov.ie') return 'jovie-staging';
+  if (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '[::1]' ||
+    hostname.endsWith('.localhost')
+  ) {
+    return 'jovie-local';
+  }
+  return 'jovie';
 }
 
 function sleep(ms) {
@@ -663,7 +680,7 @@ async function requestRedirect(page, targetUrl, label) {
 
 async function requestNativeCallbackRedirect(page, callbackPath, label) {
   const redirectUrl = await requestRedirect(page, callbackPath, label);
-  if (redirectUrl.startsWith('jovie://auth/complete?')) {
+  if (redirectUrl.startsWith(NATIVE_AUTH_CALLBACK_PREFIX)) {
     return redirectUrl;
   }
 
@@ -694,7 +711,7 @@ function waitForNativeProtocolRequest(page, label, timeout = 60_000) {
 
     function onRequest(request) {
       const requestUrl = request.url();
-      if (!requestUrl.startsWith('jovie://auth/complete?')) return;
+      if (!requestUrl.startsWith(NATIVE_AUTH_CALLBACK_PREFIX)) return;
       clearTimeout(timeoutId);
       page.off('request', onRequest);
       resolve(requestUrl);
@@ -713,7 +730,7 @@ function waitForNativeRedirectResponse(page, label, timeout = 60_000) {
 
     function onResponse(response) {
       const location = response.headers().location;
-      if (!location?.startsWith('jovie://auth/complete?')) return;
+      if (!location?.startsWith(NATIVE_AUTH_CALLBACK_PREFIX)) return;
       clearTimeout(timeoutId);
       page.off('response', onResponse);
       resolve(location);
@@ -780,8 +797,8 @@ async function completeBrowserAuthState(page, authPageUrl, email) {
 async function requestNativeCallback(page, authUrl, email) {
   const authCallbackUrl = await requestRedirect(page, authUrl, 'auth start');
   const parsedAuthCallback = new URL(authCallbackUrl);
-  if (parsedAuthCallback.protocol === 'jovie:') {
-    if (!authCallbackUrl.startsWith('jovie://auth/complete?')) {
+  if (authCallbackUrl.startsWith(NATIVE_AUTH_CALLBACK_PREFIX)) {
+    if (parsedAuthCallback.protocol !== `${NATIVE_AUTH_CALLBACK_SCHEME}:`) {
       throw new Error(
         `Auth start did not return the Electron app callback: ${authCallbackUrl}`
       );

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -90,7 +90,13 @@ const DESKTOP_AUTH_HANDOFF_PATH = '/desktop-auth';
 const DESKTOP_AUTH_START_PATH = '/auth/start';
 const DESKTOP_AUTH_NATIVE_COMPLETE_PATH = '/auth/native-complete';
 const DESKTOP_RETURN_PARAM = 'desktop_return';
-const AUTH_RETURN_PROTOCOL = 'jovie:';
+const AUTH_RETURN_SCHEME =
+  APP_ENV === 'staging'
+    ? 'jovie-staging'
+    : APP_ENV === 'local'
+      ? 'jovie-local'
+      : 'jovie';
+const AUTH_RETURN_PROTOCOL = `${AUTH_RETURN_SCHEME}:`;
 const AUTH_RETURN_HOST = 'auth';
 const AUTH_RETURN_COMPLETE_PATH = '/complete';
 const LEGACY_AUTH_RETURN_HOST = 'auth-return';
@@ -1390,13 +1396,6 @@ ipcMain.handle(
 );
 
 function registerAuthReturnProtocol(): void {
-  // Only the canonical production bundle (app.jov.ie) may own jovie:// deep
-  // links. Staging/local shells use separate bundle IDs and must not compete
-  // with the installed production handler — see apps/desktop/BUILDS.md.
-  if (APP_ENV !== 'production') {
-    return;
-  }
-
   const defaultAppProcess = process as NodeJS.Process & {
     readonly defaultApp?: boolean;
   };
@@ -1406,13 +1405,13 @@ function registerAuthReturnProtocol(): void {
     process.argv.length >= 2 &&
     !app.isPackaged
   ) {
-    app.setAsDefaultProtocolClient('jovie', process.execPath, [
+    app.setAsDefaultProtocolClient(AUTH_RETURN_SCHEME, process.execPath, [
       path.resolve(process.argv[1]),
     ]);
     return;
   }
 
-  app.setAsDefaultProtocolClient('jovie');
+  app.setAsDefaultProtocolClient(AUTH_RETURN_SCHEME);
 }
 
 if (gotSingleInstanceLock) {
@@ -1452,7 +1451,7 @@ if (gotSingleInstanceLock) {
       return;
     }
 
-    if (url.startsWith('jovie://auth/complete')) {
+    if (url.startsWith(`${AUTH_RETURN_PROTOCOL}//${AUTH_RETURN_HOST}`)) {
       reportDesktopSecurityEvent('auth-deep-link-invalid-params');
       return;
     }

--- a/apps/web/app/(auth)/auth/native-return/page.test.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.test.tsx
@@ -29,25 +29,43 @@ function setSearchParams(query: string) {
   searchParamsMock.mockReturnValue(new URLSearchParams(query));
 }
 
+function setLocationOrigin(origin: string) {
+  const hrefWrites: string[] = [];
+  let href = `${origin}/`;
+
+  Object.defineProperty(globalThis, 'location', {
+    configurable: true,
+    value: {
+      origin,
+      get href() {
+        return href;
+      },
+      set href(value: string) {
+        href = value;
+        hrefWrites.push(value);
+      },
+    },
+  });
+
+  return hrefWrites;
+}
+
 describe('NativeReturnPage (desktop auth bounce)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // jsdom cannot navigate to a custom scheme; swallow the auto-fire assign.
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: { href: 'http://localhost/' },
-    });
+    setLocationOrigin('https://jov.ie');
   });
 
   it('renders an Open Jovie button pointing at the jovie:// deep link', () => {
+    const hrefWrites = setLocationOrigin('https://jov.ie');
     setSearchParams(`code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`);
     render(<NativeReturnPage />);
 
+    const expectedDeepLink = `jovie://auth/complete?code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`;
     const link = screen.getByRole('link', { name: 'Open Jovie' });
-    expect(link).toHaveAttribute(
-      'href',
-      `jovie://auth/complete?code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`
-    );
+    expect(link).toHaveAttribute('href', expectedDeepLink);
+    expect(hrefWrites).toEqual([expectedDeepLink]);
   });
 
   it('preserves the deep link without desktop_flow when absent', () => {
@@ -58,6 +76,40 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
       'href',
       `jovie://auth/complete?code=${CODE}&state=${STATE}`
     );
+  });
+
+  it('uses the staging app scheme on staging origin', () => {
+    const hrefWrites = setLocationOrigin('https://staging.jov.ie');
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    const expectedDeepLink = `jovie-staging://auth/complete?code=${CODE}&state=${STATE}`;
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      expectedDeepLink
+    );
+    expect(hrefWrites).toEqual([expectedDeepLink]);
+  });
+
+  it('uses the local app scheme on localhost origin', () => {
+    const hrefWrites = setLocationOrigin('http://localhost:3112');
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+    render(<NativeReturnPage />);
+
+    const expectedDeepLink = `jovie-local://auth/complete?code=${CODE}&state=${STATE}`;
+    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+      'href',
+      expectedDeepLink
+    );
+    expect(hrefWrites).toEqual([expectedDeepLink]);
+  });
+
+  it('renders safely before browser location is available', () => {
+    Reflect.deleteProperty(globalThis, 'location');
+    setSearchParams(`code=${CODE}&state=${STATE}`);
+
+    expect(() => render(<NativeReturnPage />)).not.toThrow();
+    expect(screen.queryByRole('link', { name: 'Open Jovie' })).toBeNull();
   });
 
   it('shows a recovery message and no deep link when required params are missing', () => {

--- a/apps/web/app/(auth)/auth/native-return/page.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { buildElectronAuthCompleteUrl } from '@jovie/auth-routing';
+import {
+  buildElectronAuthCompleteUrl,
+  type ElectronAuthCompleteProtocol,
+  getElectronAuthCompleteProtocolForOrigin,
+} from '@jovie/auth-routing';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { Suspense, useEffect, useMemo } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 
 // Bounce page for the desktop (Electron) auth return.
 //
@@ -23,8 +27,18 @@ function sanitizeExchangeCode(value: string | null): string | null {
 
 function NativeReturnContent() {
   const searchParams = useSearchParams();
+  const [protocol, setProtocol] = useState<ElectronAuthCompleteProtocol | null>(
+    null
+  );
 
-  const deepLink = useMemo(() => {
+  useEffect(() => {
+    if (!globalThis.location) return;
+    setProtocol(
+      getElectronAuthCompleteProtocolForOrigin(globalThis.location.origin)
+    );
+  }, []);
+
+  const nativeReturnParams = useMemo(() => {
     const code = sanitizeExchangeCode(searchParams.get('code'));
     const state = sanitizeExchangeCode(searchParams.get('state'));
     if (!code || !state) return null;
@@ -35,11 +49,20 @@ function NativeReturnContent() {
         ? rawDesktopFlow
         : null;
 
-    return buildElectronAuthCompleteUrl({ code, state, desktopFlow });
+    return { code, state, desktopFlow };
   }, [searchParams]);
 
+  const deepLink = useMemo(() => {
+    if (!nativeReturnParams || !protocol) return null;
+
+    return buildElectronAuthCompleteUrl({
+      ...nativeReturnParams,
+      protocol,
+    });
+  }, [nativeReturnParams, protocol]);
+
   useEffect(() => {
-    if (deepLink) {
+    if (deepLink && globalThis.location) {
       globalThis.location.href = deepLink;
     }
   }, [deepLink]);
@@ -52,7 +75,7 @@ function NativeReturnContent() {
           Return To The App
         </h1>
         <p className='mt-3 text-sm leading-5 text-secondary-token'>
-          {deepLink
+          {deepLink || nativeReturnParams
             ? 'Authentication is complete. Continue in the Jovie desktop app.'
             : 'This sign-in link is missing required information. Start sign-in again from Jovie.'}
         </p>

--- a/packages/auth-routing/auth-routing.test.ts
+++ b/packages/auth-routing/auth-routing.test.ts
@@ -7,6 +7,7 @@ import {
   classifyNavigation,
   createAuthAnalyticsEvent,
   createAuthStateRecord,
+  getElectronAuthCompleteProtocolForOrigin,
   resolveAuthCallback,
   sanitizeReturnTo,
   validateNativeExchange,
@@ -264,6 +265,42 @@ describe('auth routing boundary', () => {
     ).toBe(
       'jovie://auth/complete?code=c&state=s&desktop_flow=desktop_flow_nonce_12345'
     );
+    expect(
+      buildElectronAuthCompleteUrl({
+        code: 'c',
+        state: 's',
+        protocol: 'jovie-staging',
+      })
+    ).toBe('jovie-staging://auth/complete?code=c&state=s');
+    expect(
+      buildElectronAuthCompleteUrl({
+        code: 'c',
+        state: 's',
+        protocol: 'jovie-local',
+      })
+    ).toBe('jovie-local://auth/complete?code=c&state=s');
+  });
+
+  it('derives the Electron callback protocol from the app origin', () => {
+    expect(getElectronAuthCompleteProtocolForOrigin('https://jov.ie')).toBe(
+      'jovie'
+    );
+    expect(
+      getElectronAuthCompleteProtocolForOrigin('https://staging.jov.ie')
+    ).toBe('jovie-staging');
+    expect(
+      getElectronAuthCompleteProtocolForOrigin('http://localhost:3112')
+    ).toBe('jovie-local');
+    expect(
+      getElectronAuthCompleteProtocolForOrigin('http://127.0.0.1:3112')
+    ).toBe('jovie-local');
+    expect(
+      getElectronAuthCompleteProtocolForOrigin('http://foo.localhost:3112')
+    ).toBe('jovie-local');
+    expect(getElectronAuthCompleteProtocolForOrigin('http://[::1]:3112')).toBe(
+      'jovie-local'
+    );
+    expect(getElectronAuthCompleteProtocolForOrigin('not a url')).toBe('jovie');
   });
 
   it('creates analytics payloads without leaking return URLs or token values', () => {

--- a/packages/auth-routing/index.ts
+++ b/packages/auth-routing/index.ts
@@ -21,6 +21,10 @@ export const AUTH_ANALYTICS_EVENTS = [
 export type AuthAnalyticsEventName = (typeof AUTH_ANALYTICS_EVENTS)[number];
 
 export type NativeAuthClient = Exclude<AuthClient, 'web'>;
+export type ElectronAuthCompleteProtocol =
+  | 'jovie'
+  | 'jovie-staging'
+  | 'jovie-local';
 export type NavigationDisposition =
   | 'internal'
   | 'external'
@@ -79,7 +83,7 @@ export interface AuthAnalyticsEventPayload {
 const AUTH_STATE_TTL_MS = 10 * 60 * 1000;
 const NATIVE_EXCHANGE_TTL_MS = 5 * 60 * 1000;
 const IOS_AUTH_COMPLETE_URL = 'ie.jov.jovie://auth/complete';
-const ELECTRON_AUTH_COMPLETE_URL = 'jovie://auth/complete';
+const DEFAULT_ELECTRON_AUTH_COMPLETE_PROTOCOL = 'jovie';
 const IOS_UNIVERSAL_AUTH_COMPLETE_PATH = '/auth/ios/complete';
 const DEFAULT_DOCS_URL = 'https://docs.jov.ie';
 
@@ -348,12 +352,40 @@ export function buildIosUniversalAuthCompleteUrl(input: {
   );
 }
 
+export function getElectronAuthCompleteProtocolForOrigin(
+  origin: string
+): ElectronAuthCompleteProtocol {
+  let parsed: URL;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return DEFAULT_ELECTRON_AUTH_COMPLETE_PROTOCOL;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (hostname === 'staging.jov.ie') return 'jovie-staging';
+  if (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '[::1]' ||
+    hostname.endsWith('.localhost')
+  ) {
+    return 'jovie-local';
+  }
+
+  return DEFAULT_ELECTRON_AUTH_COMPLETE_PROTOCOL;
+}
+
 export function buildElectronAuthCompleteUrl(input: {
   readonly code: string;
   readonly state: string;
   readonly desktopFlow?: string | null;
+  readonly protocol?: ElectronAuthCompleteProtocol;
 }): string {
-  return buildUrlWithCodeAndState(ELECTRON_AUTH_COMPLETE_URL, input);
+  return buildUrlWithCodeAndState(
+    `${input.protocol ?? DEFAULT_ELECTRON_AUTH_COMPLETE_PROTOCOL}://auth/complete`,
+    input
+  );
 }
 
 export function resolveAuthCallback(input: {


### PR DESCRIPTION
## Summary

Closes #12822.

- Route native desktop auth callbacks through env-specific schemes: `jovie://`, `jovie-staging://`, and `jovie-local://`.
- Derive the native-return deep-link protocol from the current web origin so staging/local do not transiently emit production `jovie://` callbacks.
- Register staging/local macOS bundle URL types and update the desktop native-auth smoke harness/contract tests for the new callback routing.
- Preserve the signed-out desktop recovery contract so passive auth redirects land on a usable sign-in surface instead of stranding the packaged window on `about:blank`.

## Verification

Local:

- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh` -> ready to develop
- `JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write packages/auth-routing/index.ts packages/auth-routing/auth-routing.test.ts apps/web/app/'(auth)'/auth/native-return/page.tsx apps/web/app/'(auth)'/auth/native-return/page.test.tsx apps/desktop/src/main.ts apps/desktop/scripts/smoke-native-auth.mjs apps/desktop/scripts/desktop-shell-contract.test.mjs apps/desktop/electron-builder.staging.yml apps/desktop/electron-builder.local.yml .github/workflows/desktop-release.yml`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/auth-routing run typecheck && pnpm --filter @jovie/auth-routing test` -> 1 file / 23 tests passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run app/'(auth)'/auth/native-return/page.test.tsx lib/desktop/auth-return.test.ts` -> 2 files / 14 tests passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` -> passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/desktop run prepare:assets`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/desktop run typecheck && pnpm --filter @jovie/desktop run test` -> desktop package tests passed, including desktop shell contract 10/10 and installed-app audit 4/4
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test:bug-to-test` -> no implementation test candidates for bug-to-test contract
- `JOVIE_AGENT_PROFILE=coder node scripts/desktop-release-guard.mjs --base origin/main` -> desktop release handled by `.github/workflows/desktop-release.yml`
- `JOVIE_AGENT_PROFILE=coder node --test scripts/desktop-release-guard.test.mjs` -> 7 tests passed
- `JOVIE_AGENT_PROFILE=coder coderabbit review --agent -c AGENTS.md -t uncommitted` -> actionable findings fixed; final rerun hit CodeRabbit rate limit, GitHub CodeRabbit/AI review checks were non-blocking/green on the first PR run
- `git diff --check` -> passed
- pre-commit hooks -> passed
- pre-push hooks -> passed twice, including the replacement branch push

CI from the first active PR run (#13022 before GitHub closed it unmerged):

- Green: Build, Typecheck, Lint, Guardrails (proxy), Structural Contract, Migration Guard, Secret Scan, Neon DB, DB Migrate, Drizzle Check, unit shards, Lighthouse public/admin/chat/onboarding/dashboard, A11y, Mobile Overflow, Admin E2E Smoke, E2E DB Migrate, Preview Deploy, and PR Ready.
- Remaining CI blockers after rerun were preview/auth E2E jobs outside this desktop callback diff: `E2E Smoke (PR Fast Feedback)` and `Golden Path (PR)`; `Full E2E (Preview) (1)` was still in quarantine retry, so GitHub had not exposed the final failed-job logs yet.

## Subagent Review

- testing: verified required desktop shell/auth callback contracts and focused test plan.
- security: reviewed per-env scheme isolation and origin-derived deep-link guardrails.
- review: caught server/pre-hydration `globalThis.location.origin` risk; fixed and covered with a no-location render test.
