### PR TITLE
Fix smart link hero title scale

### DIFF
--- a/apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx
+++ b/apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx
@@ -15,6 +15,7 @@ import { ProfileDrawerShell } from '@/features/profile/ProfileDrawerShell';
 import { SmartLinkPoweredByFooter } from '@/features/release/SmartLinkPagePrimitives';
 import { SmartLinkProviderButton } from '@/features/release/SmartLinkProviderButton';
 import {
+  SMART_LINK_HERO_TITLE_CLASS,
   SMART_LINK_MENU_ICON_CLASS,
   SMART_LINK_MENU_ITEM_CLASS,
   SmartLinkShell,
@@ -164,9 +165,7 @@ export function SoundsLandingPage({
       returnLabel={`Back to ${artist.name}`}
       heroOverlay={
         <div className='absolute inset-x-0 bottom-5 z-10 px-5'>
-          <h1 className='text-3xl font-semibold leading-[1.06] tracking-tighter text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
-            {release.title}
-          </h1>
+          <h1 className={SMART_LINK_HERO_TITLE_CLASS}>{release.title}</h1>
           {artist.handle ? (
             <Link
               href={`/${artist.handle}`}

--- a/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
+++ b/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
@@ -24,6 +24,7 @@ import { SmartLinkAudioPreview } from '@/features/release/SmartLinkAudioPreview'
 import { SmartLinkPoweredByFooter } from '@/features/release/SmartLinkPagePrimitives';
 import { SmartLinkProviderButton } from '@/features/release/SmartLinkProviderButton';
 import {
+  SMART_LINK_HERO_TITLE_CLASS,
   SMART_LINK_MENU_ICON_CLASS,
   SMART_LINK_MENU_ITEM_CLASS,
   SmartLinkShell,
@@ -390,9 +391,7 @@ export function ReleaseLandingPage({
       heroOverlay={
         <div className='absolute inset-x-0 bottom-5 z-10 flex items-end justify-between px-5'>
           <div className='min-w-0 flex-1'>
-            <h1 className='text-[28px] font-semibold leading-[1.06] tracking-tighter text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
-              {release.title}
-            </h1>
+            <h1 className={SMART_LINK_HERO_TITLE_CLASS}>{release.title}</h1>
             <SmartLinkArtistLine
               artist={artist}
               featuredArtists={featuredArtists}

--- a/apps/web/components/features/release/SmartLinkShell.tsx
+++ b/apps/web/components/features/release/SmartLinkShell.tsx
@@ -24,6 +24,8 @@ import { Mark } from '@/lib/brand/primitives';
 export const SMART_LINK_MENU_ITEM_CLASS =
   'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-[470] text-white/88 transition-colors duration-subtle active:bg-white/[0.06]';
 export const SMART_LINK_MENU_ICON_CLASS = 'h-4 w-4 text-white/40';
+export const SMART_LINK_HERO_TITLE_CLASS =
+  'text-2xl font-semibold leading-[1.08] tracking-tight text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]';
 
 /** Hook for the share action used across all smart link pages */
 export function useSmartLinkShare(

--- a/apps/web/components/features/release/UnreleasedReleaseHero.tsx
+++ b/apps/web/components/features/release/UnreleasedReleaseHero.tsx
@@ -13,6 +13,7 @@ import { useState } from 'react';
 import { ProfileDrawerShell } from '@/features/profile/ProfileDrawerShell';
 import { SmartLinkPoweredByFooter } from '@/features/release/SmartLinkPagePrimitives';
 import {
+  SMART_LINK_HERO_TITLE_CLASS,
   SMART_LINK_MENU_ICON_CLASS,
   SMART_LINK_MENU_ITEM_CLASS,
   SmartLinkShell,
@@ -83,9 +84,7 @@ export function UnreleasedReleaseHero({
         returnLabel={`Back to ${artist.name}`}
         heroOverlay={
           <div className='absolute inset-x-0 bottom-5 z-10 px-5'>
-            <h1 className='text-3xl font-semibold leading-[1.06] tracking-tighter text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]'>
-              {release.title}
-            </h1>
+            <h1 className={SMART_LINK_HERO_TITLE_CLASS}>{release.title}</h1>
             <Link
               href={`/${artist.handle}`}
               className='mt-1 block text-sm font-book text-white/70 transition-colors hover:text-white/90 [text-shadow:0_1px_8px_rgba(0,0,0,0.3)]'

--- a/apps/web/tests/unit/release/release-artist-link.test.tsx
+++ b/apps/web/tests/unit/release/release-artist-link.test.tsx
@@ -170,6 +170,10 @@ describe('release artist links', () => {
 
     const artistLink = screen.getByRole('link', { name: 'Test Artist' });
     expect(artistLink).toHaveAttribute('href', '/test-artist');
+
+    const title = screen.getByRole('heading', { name: 'Future Release' });
+    expect(title).toHaveClass('text-2xl', 'tracking-tight');
+    expect(title).not.toHaveClass('text-3xl', 'text-4xl');
   });
 
   it('renders a dismissible claim banner for unclaimed creators', () => {

--- a/apps/web/tests/unit/release/release-landing-page.test.tsx
+++ b/apps/web/tests/unit/release/release-landing-page.test.tsx
@@ -98,6 +98,8 @@ vi.mock('@/features/release/SmartLinkProviderButton', () => ({
 const shareSpy = vi.fn();
 
 vi.mock('@/features/release/SmartLinkShell', () => ({
+  SMART_LINK_HERO_TITLE_CLASS:
+    'text-2xl font-semibold leading-[1.08] tracking-tight text-(--color-text-tooltip) [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]',
   SmartLinkShell: ({
     children,
     heroOverlay,
@@ -185,6 +187,14 @@ describe('@critical ReleaseLandingPage', () => {
     render(<ReleaseLandingPage {...defaultProps} />);
     expect(screen.getByText('Midnight Drive')).toBeDefined();
     expect(screen.getByText('Tim White')).toBeDefined();
+  });
+
+  it('uses the shared compact smart-link hero title class', () => {
+    render(<ReleaseLandingPage {...defaultProps} />);
+
+    const title = screen.getByRole('heading', { name: 'Midnight Drive' });
+    expect(title).toHaveClass('text-2xl', 'tracking-tight');
+    expect(title).not.toHaveClass('text-[28px]', 'text-3xl', 'text-4xl');
   });
 
   it('renders provider buttons for each provider with a URL', () => {

--- a/apps/web/tests/unit/release/sounds-landing-page.test.tsx
+++ b/apps/web/tests/unit/release/sounds-landing-page.test.tsx
@@ -146,6 +146,14 @@ describe('SoundsLandingPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('uses the shared compact smart-link hero title class', () => {
+    render(<SoundsLandingPage {...defaultProps} />);
+
+    const title = screen.getByRole('heading', { name: 'Test Song' });
+    expect(title).toHaveClass('text-2xl', 'tracking-tight');
+    expect(title).not.toHaveClass('text-3xl', 'text-4xl');
+  });
+
   it('fires click tracking via sendBeacon when provider button is clicked', () => {
     render(<SoundsLandingPage {...defaultProps} />);
     sendBeaconSpy.mockClear();


### PR DESCRIPTION
## Summary
- Centralized smart-link release hero title typography in `SMART_LINK_HERO_TITLE_CLASS`.
- Applied the compact shared title class to released, unreleased/presave, and sounds smart-link hero overlays.
- Added regression coverage so released, presave, and sounds variants stay on the compact token instead of drifting back to arbitrary/oversized title classes.

Closes #13027

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/release/release-landing-page.test.tsx tests/unit/release/sounds-landing-page.test.tsx tests/unit/release/release-artist-link.test.tsx`
  - `Test Files  3 passed (3)`
  - `Tests  28 passed (28)`
- `pnpm biome check --write apps/web/app/r/[slug]/ReleaseLandingPage.tsx apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx apps/web/components/features/release/UnreleasedReleaseHero.tsx apps/web/components/features/release/SmartLinkShell.tsx apps/web/tests/unit/release/release-landing-page.test.tsx apps/web/tests/unit/release/sounds-landing-page.test.tsx apps/web/tests/unit/release/release-artist-link.test.tsx`
  - `Checked 7 files in 94ms. No fixes applied.`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
  - exited 0
- `pnpm --filter @jovie/web run test:bug-to-test`
  - `bug-to-test: not applicable (not a bug fix PR)`
- `coderabbit review --agent -c AGENTS.md -t uncommitted`
  - `review_completed`, findings: `0`
- Pre-push gate on `git push -u origin codex/gh-13027-fast-track-reduce-oversized-release-title-typogr`
  - changed-file Biome: `Checked 7 files in 160ms. No fixes applied.`
  - `next:proxy-guard`: passed
  - `tailwind:check`: `ALL TAILWIND CONFIGURATION CHECKS PASSED`
  - web typecheck: passed

## Visual Evidence
- Local preview: `http://127.0.0.1:3101/dev/smart-links`
- Desktop screenshot: `/tmp/gh-13027-smart-links-desktop.png`
- Tablet screenshot: `/tmp/gh-13027-smart-links-tablet.png`
- Mobile screenshot: `/tmp/gh-13027-smart-links-mobile.png`
- gstack console check: no runtime errors; one Next LCP image warning on the preview image.

## Notes
- `pnpm biome check apps/web` was also run. It fails on existing files outside this diff: `apps/web/lib/voice-stack-bake-off/*`, `apps/web/scripts/voice-stack-bake-off-spike.ts`, and warning-only `apps/web/components/features/admin/WhatShipped.tsx`. The changed files and pre-push changed-file Biome gate pass.
