### PR TITLE
feat(ci): add guarded UI fast-track lane

### DIFF
--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -13,12 +13,28 @@
    - If a PR is later hard-gated with `needs-human`, `hold`, or `gated`, remove
      `merge-queue` so it stops occupying Graphite queue slots.
    - `fast` is not a general priority label. Use it only for PRs explicitly
-     classified as emergency/hotfix/incident; ordinary generated branches with
-     `fast` are gated for human review by the merge-queue guard.
+     classified as emergency/hotfix/incident, or for the guarded UI fast lane
+     below. Ordinary generated branches with `fast` are gated for human review
+     by the merge-queue guard.
 3. Graphite enqueues the PR, rebases it on `main`, waits for the required checks, and squash-merges.
 4. `linear-sync-on-merge.yml` transitions the Linear issue to `Done` on merge as before.
 
 Do **not** use `gh pr merge --auto` to merge to `main` — with the native queue retired it merges directly and **bypasses Graphite**. Use the label.
+
+## Guarded UI fast lane
+
+Small visual-only PRs can use Graphite fast-track without waiting behind
+unrelated backend trains when all of the following are true: labels `ui`,
+`fast-track-ui`, `fast`, and `merge-queue`; changed files limited to UI visual
+surfaces, design docs/assets, or the directly affected UI test; PR body
+before/after screenshots plus an eligibility/checks audit trail; narrow
+typecheck, Biome/lint, and affected component/test evidence when one exists.
+
+The fast lane fails closed for auth, billing, DB/migrations, API routes,
+entitlements, data writes, security/CSP, infra/cron, routing behavior, package
+manifests, CI, and broad refactors. Repo-side classification lives in
+`scripts/lib/merge-queue-guard.mjs` (`uiFastTrackPolicy`), and the regression
+coverage is in `scripts/lib/__tests__/merge-queue-guard.test.mjs`.
 
 ## Verified configuration (2026-06-20, JOV-3291 / #11175)
 

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -13,6 +13,7 @@ import {
   parseRequiredStatusChecksFromYaml,
   preQueueFreshnessDecision,
   requiredStatusDecision,
+  uiFastTrackPolicy,
   validateAggregateRequiredChecks,
   validateLiveMergeQueueRuleset,
   validateMergeQueueRepoConfig,
@@ -25,6 +26,28 @@ const greenStatuses = [
   { name: 'Migration Guard', conclusion: 'SUCCESS' },
   { name: 'Fork PR Gate', state: 'SUCCESS' },
 ];
+
+function buildUiFastTrackBody({
+  checks = null,
+  heading = true,
+  screenshots = true,
+  why = true,
+} = {}) {
+  return [
+    heading ? '## Fast-track UI eligibility' : null,
+    why ? 'Why eligible: UI-only visual token/layout fix.' : null,
+    screenshots
+      ? 'Before: ![before](https://github.com/user-attachments/assets/before.png)'
+      : null,
+    screenshots
+      ? 'After: ![after](https://github.com/user-attachments/assets/after.png)'
+      : null,
+    checks ??
+      'Checks run: pnpm --filter @jovie/web run typecheck -- --pretty false; pnpm biome check --write apps/web/components/features/profile/ProfileHeader.tsx; vitest ProfileHeader.test.tsx',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
 
 describe('merge queue pre-queue freshness', () => {
   it('waits for CI after a stale head is rebased and pushed', () => {
@@ -168,6 +191,149 @@ describe('fast-track policy', () => {
 
     expect(policy.removeFast).toBe(false);
     expect(policy.allowed).toBe(true);
+  });
+
+  it('does not trust generated PR prose for emergency fast-track classification', () => {
+    const policy = fastTrackPolicy({
+      headRefName: 'codex/jov-123-normal-work',
+      labels: [{ name: 'fast' }],
+      title: 'Hotfix sev0 production incident',
+      body: 'Emergency hotfix requested.',
+    });
+
+    expect(policy.removeFast).toBe(true);
+    expect(policy.allowed).toBe(false);
+  });
+
+  it('permits generated UI fast-track when labels, files, screenshots, checks, and audit trail are present', () => {
+    const policy = fastTrackPolicy({
+      headRefName: 'codex/jov-3894-text-token-fix',
+      labels: [{ name: 'fast' }, { name: 'ui' }, { name: 'fast-track-ui' }],
+      title: 'fix(ui): reduce oversized title token',
+      changedFiles: [
+        'apps/web/components/features/profile/ProfileHeader.tsx',
+        'apps/web/tests/unit/profile/ProfileHeader.test.tsx',
+      ],
+      body: buildUiFastTrackBody(),
+    });
+
+    expect(policy.allowed).toBe(true);
+    expect(policy.removeFast).toBe(false);
+    expect(policy.uiFastTrack.eligible).toBe(true);
+  });
+
+  it.each([
+    [
+      'screenshot evidence',
+      {
+        checks: 'Checks run: typecheck; biome; affected component test.',
+        screenshots: false,
+      },
+      'missing before/after screenshot evidence in PR body',
+    ],
+    [
+      'typecheck evidence',
+      { checks: 'Checks run: biome; affected component test.' },
+      'missing narrow typecheck evidence in PR body',
+    ],
+    [
+      'lint evidence',
+      { checks: 'Checks run: typecheck; affected component test.' },
+      'missing narrow lint/Biome evidence in PR body',
+    ],
+    [
+      'eligibility audit trail',
+      { why: false },
+      'missing fast-track UI eligibility audit trail in PR body',
+    ],
+  ])('denies UI fast-track when %s is missing', (_name, bodyOptions, blocker) => {
+    const policy = uiFastTrackPolicy({
+      headRefName: 'codex/jov-3894-text-token-fix',
+      labels: [{ name: 'ui' }, { name: 'fast-track-ui' }],
+      changedFiles: ['apps/web/components/features/profile/ProfileHeader.tsx'],
+      body: buildUiFastTrackBody(bodyOptions),
+    });
+
+    expect(policy.eligible).toBe(false);
+    expect(policy.blockers).toContain(blocker);
+  });
+
+  it('ignores negated evidence claims in the fast-track UI section', () => {
+    const policy = uiFastTrackPolicy({
+      labels: [{ name: 'ui' }, { name: 'fast-track-ui' }],
+      changedFiles: ['apps/web/components/features/profile/ProfileHeader.tsx'],
+      body: [
+        '## Fast-track UI eligibility',
+        'Why eligible: UI-only visual token/layout fix.',
+        'Before: ![before](https://github.com/user-attachments/assets/before.png)',
+        'After: ![after](https://github.com/user-attachments/assets/after.png)',
+        'Checks run: typecheck not run; biome missing; no affected component test.',
+      ].join('\n'),
+    });
+
+    expect(policy.eligible).toBe(false);
+    expect(policy.blockers).toEqual(
+      expect.arrayContaining([
+        'missing narrow typecheck evidence in PR body',
+        'missing narrow lint/Biome evidence in PR body',
+      ])
+    );
+  });
+
+  it('denies UI fast-track when changed files are unavailable', () => {
+    const policy = uiFastTrackPolicy({
+      labels: [{ name: 'ui' }, { name: 'fast-track-ui' }],
+      body: buildUiFastTrackBody({
+        checks: 'Checks run: typecheck; biome; affected component test.',
+      }),
+    });
+
+    expect(policy.eligible).toBe(false);
+    expect(policy.blockers).toContain(
+      'changed files are required to classify UI-only fast-track'
+    );
+  });
+
+  it('warns but does not block when affected test evidence is absent', () => {
+    const policy = uiFastTrackPolicy({
+      labels: [{ name: 'ui' }, { name: 'fast-track-ui' }],
+      changedFiles: ['apps/web/components/features/profile/ProfileHeader.tsx'],
+      body: buildUiFastTrackBody({
+        checks: 'Checks run: typecheck; biome.',
+      }),
+    });
+
+    expect(policy.eligible).toBe(true);
+    expect(policy.warnings).toContain(
+      'no affected component/test evidence found; PR body must explain if none exists'
+    );
+  });
+
+  it('denies UI fast-track for API, auth, billing, DB, security, infra, and routing paths', () => {
+    const policy = uiFastTrackPolicy({
+      labels: [{ name: 'ui' }, { name: 'fast-track-ui' }],
+      changedFiles: [
+        'apps/web/app/api/profile/route.ts',
+        'apps/web/lib/entitlements/server.ts',
+        'apps/web/drizzle/migrations/0099_add_billing.sql',
+        '.github/workflows/ci.yml',
+        'apps/web/lib/security/csp.ts',
+      ],
+      body: buildUiFastTrackBody({
+        checks: 'Checks run: typecheck; biome; affected component test.',
+      }),
+    });
+
+    expect(policy.eligible).toBe(false);
+    expect(policy.blockers).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('API route or server write path'),
+        expect.stringContaining('entitlements or access control'),
+        expect.stringContaining('database schema or migration'),
+        expect.stringContaining('infra, cron, CI, or routing behavior'),
+        expect.stringContaining('security, CSP, or secret handling'),
+      ])
+    );
   });
 });
 

--- a/scripts/lib/merge-queue-guard.mjs
+++ b/scripts/lib/merge-queue-guard.mjs
@@ -1,5 +1,7 @@
 export const MERGE_QUEUE_LABEL = 'merge-queue';
 export const FAST_TRACK_LABEL = 'fast';
+export const FAST_TRACK_UI_LABEL = 'fast-track-ui';
+export const UI_LABEL = 'ui';
 export const NEEDS_CONFLICT_RESOLUTION_LABEL = 'needs-conflict-resolution';
 
 export const REQUIRED_MERGE_STATUSES = [
@@ -111,6 +113,64 @@ const HOT_FILE_PATTERNS = [
   /^skills-lock\.json$/,
 ];
 
+const UI_FAST_TRACK_INELIGIBLE_FILE_PATTERNS = [
+  {
+    reason: 'auth or identity surface',
+    pattern:
+      /(^|\/)(auth|clerk|proxy|proxy-state|middleware)(\/|\.|-)|^proxy\.(ts|js|mjs)$/,
+  },
+  {
+    reason: 'billing or payment surface',
+    pattern: /(^|\/)(stripe|billing|payment|checkout|subscription)(\/|\.|-)/,
+  },
+  {
+    reason: 'database schema or migration',
+    pattern:
+      /(^|\/)(drizzle\/migrations|migrations|schema|schemas)(\/|$)|(^|\/)(schema|db-schema)\.(ts|tsx|js|mjs|sql|json)$/,
+  },
+  {
+    reason: 'API route or server write path',
+    pattern:
+      /^apps\/web\/app\/api\/|(^|\/)(route|actions|server-actions|mutation|write|persistence)\.(ts|tsx|js|mjs)$/,
+  },
+  {
+    reason: 'entitlements or access control',
+    pattern: /(^|\/)(entitlements|permissions|access-control)(\/|\.|-)/,
+  },
+  {
+    reason: 'security, CSP, or secret handling',
+    pattern:
+      /(^|\/)(security|csp|content-security-policy|secrets?)(\/|\.|-)|(^|\/)(gitleaks|trufflehog|codeql|scorecard)(\/|\.|-)/,
+  },
+  {
+    reason: 'infra, cron, CI, or routing behavior',
+    pattern:
+      /^\.github\/|^scripts\/|^infra\/|^vercel\.json$|(^|\/)(cron|routing|router|rewrite|redirect|proxy)(\/|\.|-)/,
+  },
+  {
+    reason: 'package or toolchain manifest',
+    pattern:
+      /(^|\/)(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|turbo\.json|biome\.json|tsconfig\.json|vitest\.config\.)/,
+  },
+];
+
+const UI_FAST_TRACK_ELIGIBLE_FILE_PATTERNS = [
+  /^apps\/web\/components\/.*\.(css|ts|tsx|js|jsx)$/,
+  /^apps\/web\/app\/(?!api\/).*\.(css|ts|tsx|js|jsx|mdx)$/,
+  /^apps\/web\/styles\/.*\.(css|ts|tsx|js|jsx)$/,
+  /^apps\/web\/public\/.*\.(png|jpg|jpeg|webp|gif|svg)$/,
+  /^apps\/web\/tests\/.*\.(test|spec)\.(ts|tsx|js|jsx)$/,
+  /^docs\/design-system\/.*\.(md|mdx|png|jpg|jpeg|webp|gif)$/,
+  /^DESIGN\.md$/,
+];
+
+const SCREENSHOT_EVIDENCE_RE =
+  /!\[[^\]]*](?:\([^)]+\))|<img\b|https?:\/\/\S+(?:\.png|\.jpe?g|\.gif|\.webp)|github\.com\/user-attachments\/assets\/|user-images\.githubusercontent\.com\//i;
+
+const CHECK_EVIDENCE_RE = /\b(typecheck|pnpm\s+[^`\n]*typecheck)\b/i;
+const LINT_EVIDENCE_RE = /\b(biome|lint)\b/i;
+const AFFECTED_TEST_EVIDENCE_RE = /\b(vitest|test|spec|affected component)\b/i;
+
 const KEYWORD_HOT_KEYS = [
   {
     key: 'hot:ratchet-baseline',
@@ -160,10 +220,146 @@ export function isEmergencyFastTrack(pr) {
   );
   if ([...EMERGENCY_LABELS].some(label => labels.has(label))) return true;
   if (/^hotfix\//i.test(pr.headRefName ?? '')) return true;
-  const text = `${pr.title ?? ''}\n${pr.body ?? ''}`;
-  return /\b(emergency|hotfix|incident|production outage|sev[ -]?[012])\b/i.test(
-    text
+  return false;
+}
+
+function normalizePath(file = '') {
+  return file.replace(/^\.\//, '');
+}
+
+function fileMatchesAny(file, entries) {
+  const normalized = normalizePath(file);
+  return (
+    entries.find(entry => {
+      const pattern = entry instanceof RegExp ? entry : entry.pattern;
+      return pattern.test(normalized);
+    }) ?? null
   );
+}
+
+function extractUiFastTrackSection(body = '') {
+  const lines = body.split('\n');
+  const start = lines.findIndex(line =>
+    /^##\s+Fast-track UI eligibility\s*$/i.test(line.trim())
+  );
+  if (start < 0) return '';
+  const sectionLines = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^##\s+/.test(line.trim())) break;
+    sectionLines.push(line);
+  }
+  return sectionLines.join('\n');
+}
+
+function isNegatedEvidenceLine(line = '') {
+  return /\b(no|not|without|missing|skipped|did not|not run|none)\b/i.test(
+    line
+  );
+}
+
+function sectionHasLine(section, predicate) {
+  return section
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .filter(line => !isNegatedEvidenceLine(line))
+    .some(predicate);
+}
+
+function hasUiFastTrackEvidence(body = '') {
+  const section = extractUiFastTrackSection(body);
+  const beforeScreenshot = sectionHasLine(
+    section,
+    line => /\bbefore\b/i.test(line) && SCREENSHOT_EVIDENCE_RE.test(line)
+  );
+  const afterScreenshot = sectionHasLine(
+    section,
+    line => /\bafter\b/i.test(line) && SCREENSHOT_EVIDENCE_RE.test(line)
+  );
+
+  return {
+    screenshot: beforeScreenshot && afterScreenshot,
+    typecheck: sectionHasLine(section, line => CHECK_EVIDENCE_RE.test(line)),
+    lint: sectionHasLine(section, line => LINT_EVIDENCE_RE.test(line)),
+    affectedTest: sectionHasLine(section, line =>
+      AFFECTED_TEST_EVIDENCE_RE.test(line)
+    ),
+    auditTrail:
+      section.length > 0 &&
+      sectionHasLine(section, line =>
+        /\bwhy eligible\b|\beligible because\b/i.test(line)
+      ) &&
+      sectionHasLine(section, line =>
+        /\bchecks? run\b|\bverification\b/i.test(line)
+      ),
+  };
+}
+
+export function uiFastTrackPolicy(pr) {
+  const labels = new Set(
+    normalizeLabelNames(pr.labels).map(label => label.toLowerCase())
+  );
+  const changedFiles = (pr.changedFiles ?? pr.files ?? []).map(normalizePath);
+  const blockers = [];
+  const warnings = [];
+
+  if (!labels.has(UI_LABEL)) {
+    blockers.push(`missing required label: ${UI_LABEL}`);
+  }
+  if (!labels.has(FAST_TRACK_UI_LABEL)) {
+    blockers.push(`missing required label: ${FAST_TRACK_UI_LABEL}`);
+  }
+
+  if (changedFiles.length === 0) {
+    blockers.push('changed files are required to classify UI-only fast-track');
+  }
+
+  for (const file of changedFiles) {
+    const ineligible = fileMatchesAny(
+      file,
+      UI_FAST_TRACK_INELIGIBLE_FILE_PATTERNS
+    );
+    if (ineligible) {
+      blockers.push(`${file}: ${ineligible.reason}`);
+      continue;
+    }
+    if (!fileMatchesAny(file, UI_FAST_TRACK_ELIGIBLE_FILE_PATTERNS)) {
+      blockers.push(`${file}: not an allowed UI-only visual path`);
+    }
+  }
+
+  const evidence = hasUiFastTrackEvidence(pr.body ?? '');
+  if (!evidence.screenshot) {
+    blockers.push('missing before/after screenshot evidence in PR body');
+  }
+  if (!evidence.typecheck) {
+    blockers.push('missing narrow typecheck evidence in PR body');
+  }
+  if (!evidence.lint) {
+    blockers.push('missing narrow lint/Biome evidence in PR body');
+  }
+  if (!evidence.affectedTest) {
+    warnings.push(
+      'no affected component/test evidence found; PR body must explain if none exists'
+    );
+  }
+  if (!evidence.auditTrail) {
+    blockers.push('missing fast-track UI eligibility audit trail in PR body');
+  }
+
+  return {
+    requested: labels.has(FAST_TRACK_UI_LABEL),
+    eligible: blockers.length === 0,
+    blockers,
+    warnings,
+    labels: {
+      hasUi: labels.has(UI_LABEL),
+      hasFastTrackUi: labels.has(FAST_TRACK_UI_LABEL),
+      hasFast: labels.has(FAST_TRACK_LABEL),
+    },
+    evidence,
+    changedFiles,
+  };
 }
 
 export function fastTrackPolicy(pr) {
@@ -171,15 +367,20 @@ export function fastTrackPolicy(pr) {
   const hasFast = labels.has(FAST_TRACK_LABEL);
   const generated = isAutonomousBranch(pr.headRefName ?? '');
   const emergency = isEmergencyFastTrack(pr);
+  const uiFastTrack = uiFastTrackPolicy(pr);
+  const allowedFastTrack = emergency || uiFastTrack.eligible;
   return {
     hasFast,
     generated,
     emergency,
-    allowed: !hasFast || !generated || emergency,
-    removeFast: hasFast && generated && !emergency,
+    uiFastTrack,
+    allowed: !hasFast || !generated || allowedFastTrack,
+    removeFast: hasFast && generated && !allowedFastTrack,
     reason:
-      hasFast && generated && !emergency
-        ? 'ordinary generated PRs may not use fast-track without emergency/hotfix classification'
+      hasFast && generated && !allowedFastTrack
+        ? uiFastTrack.requested
+          ? `UI fast-track denied: ${uiFastTrack.blockers.join('; ')}`
+          : 'ordinary generated PRs may not use fast-track without emergency/hotfix classification'
         : '',
   };
 }


### PR DESCRIPTION
## Summary
- Adds a guarded `fast-track-ui` lane to the merge-queue fast-track policy.
- Allows generated PRs to keep `fast` only for trusted emergency labels/hotfix branches or for UI-only PRs with `ui` + `fast-track-ui`, safe changed files, screenshots, typecheck/lint evidence, and an eligibility audit trail.
- Documents the guarded UI fast lane in `.github/MERGE_QUEUE.md`.

## Fast-track UI eligibility audit
- This PR itself is **not** a UI fast-track candidate; it changes merge-queue policy code/docs and should use the normal infra lane.
- The new lane fails closed for auth, billing, DB/migrations, API routes, entitlements, data writes, security/CSP, infra/cron, routing behavior, package manifests, CI, and broad refactors.
- PR prose alone can no longer authorize generated emergency fast-track; trusted labels or `hotfix/*` branch naming are required.

## JOV-3894
- Could not apply this lane to JOV-3894: GitHub search found PR #3894 (`fix(db): preserve proxied drizzle method context to avoid query._prepare errors`) already merged, and it was a DB fix, not a UI-only visual/taste/token/layout PR.

## Verification
- `pnpm install --frozen-lockfile` — passed, installed missing worktree dependencies.
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/merge-queue-guard.test.mjs` — passed: 1 test file, 29 tests.
- `pnpm ci:merge-queue:check` — passed: `Repo config OK — required aggregates: CI / PR Ready, CI / Migration Guard, Fork PR Gate, PR Size Guard`.
- `pnpm run typecheck` — passed: 4 successful, 4 total; 4 cached.
- `pnpm biome check scripts/lib/merge-queue-guard.mjs scripts/lib/__tests__/merge-queue-guard.test.mjs .github/MERGE_QUEUE.md` — passed: checked 2 files, no fixes applied.
- Pre-commit hook — passed: gitleaks no leaks, trufflehog no verified/unverified secrets, `next:proxy-guard` passed.
- Pre-push hook — passed: changed-file Biome, `next:proxy-guard`, `tailwind:check`, and `@jovie/web` typecheck.
- CodeRabbit local review: first two runs completed and findings were fixed; final rerun was blocked by CodeRabbit rate limit (`waitTime: 44 minutes`) after the fixes.

Closes #13028
