### PR TITLE
feat(ui): add canonical destructive ConfirmDialog

### DIFF
--- a/apps/web/components/features/dashboard/organisms/DataPrivacySection.tsx
+++ b/apps/web/components/features/dashboard/organisms/DataPrivacySection.tsx
@@ -1,18 +1,9 @@
 'use client';
 
-import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  Button,
-  Input,
-} from '@jovie/ui';
+import { Button, Input } from '@jovie/ui';
 import { Download, Trash2 } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import { ConfirmDialog } from '@/components/molecules/ConfirmDialog';
 import { SettingsActionRow } from '@/components/molecules/settings/SettingsActionRow';
 import { SettingsPanel } from '@/components/molecules/settings/SettingsPanel';
 import { useAuthSafe } from '@/hooks/useClerkSafe';
@@ -30,18 +21,16 @@ export function DataPrivacySection() {
     exportMutation.mutate();
   }, [exportMutation]);
 
-  const handleDelete = useCallback(() => {
+  const handleDelete = useCallback(async () => {
     if (confirmText !== 'DELETE') return;
-    deleteMutation.mutate(
-      { confirmation: 'DELETE' },
-      {
-        onSuccess: () => {
-          setDeleteDialogOpen(false);
-          // Sign out to clear session cookies, then redirect to home
-          signOut({ redirectUrl: '/' });
-        },
-      }
-    );
+    try {
+      await deleteMutation.mutateAsync({ confirmation: 'DELETE' });
+      setDeleteDialogOpen(false);
+      // Sign out to clear session cookies, then redirect to home.
+      signOut({ redirectUrl: '/' });
+    } catch {
+      // useDeleteAccountMutation surfaces the failure toast.
+    }
   }, [confirmText, deleteMutation, signOut]);
 
   return (
@@ -78,64 +67,45 @@ export function DataPrivacySection() {
                 onClick={() => setDeleteDialogOpen(true)}
                 className='w-full shrink-0 sm:w-auto'
               >
-                Delete account
+                Delete Account
               </Button>
             }
           />
         </div>
       </SettingsPanel>
 
-      <AlertDialog
+      <ConfirmDialog
         open={deleteDialogOpen}
         onOpenChange={open => {
           setDeleteDialogOpen(open);
           if (!open) setConfirmText('');
         }}
+        title='Delete your account?'
+        description='This will permanently delete your account, profile, links, contacts, and all associated data. You will be signed out immediately. This action cannot be undone.'
+        cancelLabel='Cancel'
+        confirmLabel='Permanently Delete Account'
+        variant='destructive'
+        onConfirm={handleDelete}
+        isLoading={deleteMutation.isPending}
+        confirmDisabled={confirmText !== 'DELETE'}
+        onCancel={() => setConfirmText('')}
       >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete your account?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete your account, profile, links,
-              contacts, and all associated data. You will be signed out
-              immediately. This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <div className='py-4'>
-            <label
-              htmlFor='delete-confirm'
-              className='mb-2 block text-app text-secondary-token'
-            >
-              Type <strong>DELETE</strong> to confirm
-            </label>
-            <Input
-              id='delete-confirm'
-              value={confirmText}
-              onChange={e => setConfirmText(e.target.value)}
-              placeholder='DELETE'
-              autoComplete='off'
-            />
-          </div>
-          <AlertDialogFooter>
-            <AlertDialogCancel
-              onClick={() => {
-                setConfirmText('');
-              }}
-            >
-              Cancel
-            </AlertDialogCancel>
-            <Button
-              variant='destructive'
-              onClick={handleDelete}
-              disabled={confirmText !== 'DELETE' || deleteMutation.isPending}
-            >
-              {deleteMutation.isPending
-                ? 'Deleting...'
-                : 'Permanently Delete Account'}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        <div className='py-4'>
+          <label
+            htmlFor='delete-confirm'
+            className='mb-2 block text-app text-secondary-token'
+          >
+            Type <strong>DELETE</strong> to confirm
+          </label>
+          <Input
+            id='delete-confirm'
+            value={confirmText}
+            onChange={e => setConfirmText(e.target.value)}
+            placeholder='DELETE'
+            autoComplete='off'
+          />
+        </div>
+      </ConfirmDialog>
     </div>
   );
 }

--- a/apps/web/components/molecules/ConfirmDialog.tsx
+++ b/apps/web/components/molecules/ConfirmDialog.tsx
@@ -1,29 +1,3 @@
-'use client';
-
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@jovie/ui';
-import { useRef, useState } from 'react';
-
-export interface ConfirmDialogProps {
-  readonly open: boolean;
-  readonly onOpenChange: (open: boolean) => void;
-  readonly title: string;
-  readonly description: string;
-  readonly confirmLabel?: string;
-  readonly cancelLabel?: string;
-  readonly variant?: 'default' | 'destructive';
-  readonly onConfirm: () => void | Promise<void>;
-  readonly isLoading?: boolean;
-}
-
 /**
  * Reusable confirmation dialog. Drop-in replacement for native `confirm()`.
  *
@@ -43,55 +17,5 @@ export interface ConfirmDialogProps {
  *   - DESIGN.md → "Confirmations & Destructive Actions" for copy rules and decision table
  *   - AGENTS.md → "4f. No Native Browser Dialogs" for the lint policy
  */
-export function ConfirmDialog({
-  open,
-  onOpenChange,
-  title,
-  description,
-  confirmLabel = 'Confirm',
-  cancelLabel = 'Cancel',
-  variant = 'default',
-  onConfirm,
-  isLoading = false,
-}: ConfirmDialogProps) {
-  const [isPending, setIsPending] = useState(false);
-  const handlingRef = useRef(false);
-
-  const handleConfirm = async () => {
-    if (handlingRef.current) return;
-    handlingRef.current = true;
-    setIsPending(true);
-    try {
-      await onConfirm();
-      onOpenChange(false);
-    } finally {
-      setIsPending(false);
-      handlingRef.current = false;
-    }
-  };
-
-  const loading = isLoading || isPending;
-
-  return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription>{description}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={loading}>
-            {cancelLabel}
-          </AlertDialogCancel>
-          <AlertDialogAction
-            onClick={handleConfirm}
-            disabled={loading}
-            variant={variant === 'destructive' ? 'destructive' : 'primary'}
-          >
-            {loading ? 'Please wait...' : confirmLabel}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  );
-}
+export type { ConfirmDialogProps } from '@jovie/ui';
+export { ConfirmDialog } from '@jovie/ui';

--- a/apps/web/components/organisms/billing/BillingActionsSection.tsx
+++ b/apps/web/components/organisms/billing/BillingActionsSection.tsx
@@ -1,20 +1,10 @@
 'use client';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-  Button,
-} from '@jovie/ui';
+import { Button } from '@jovie/ui';
 import { CreditCard, XCircle } from 'lucide-react';
 import { motion } from 'motion/react';
 import { BillingPortalLink } from '@/components/molecules/BillingPortalLink';
+import { ConfirmDialog } from '@/components/molecules/ConfirmDialog';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { track } from '@/lib/analytics';
@@ -49,90 +39,95 @@ export function BillingActionsSection({
             Payment &amp; Invoices
           </BillingPortalLink>
 
-          <AlertDialog
+          <Button
+            variant='ghost'
+            size='sm'
+            className='justify-start text-destructive hover:bg-error-subtle hover:text-destructive'
+            onClick={() => {
+              track('subscription_cancel_clicked', {
+                source: 'billing_dashboard',
+              });
+              setCancelDialogOpen(true);
+            }}
+          >
+            <XCircle className='mr-2 h-4 w-4' />
+            Cancel Subscription
+          </Button>
+
+          <ConfirmDialog
             open={cancelDialogOpen}
             onOpenChange={setCancelDialogOpen}
-          >
-            <AlertDialogTrigger asChild>
-              <Button
-                variant='ghost'
-                size='sm'
-                className='justify-start text-destructive hover:bg-red-500/10 dark:text-red-400 dark:hover:bg-red-500/10'
-                onClick={() => {
-                  track('subscription_cancel_clicked', {
-                    source: 'billing_dashboard',
-                  });
-                }}
-              >
-                <XCircle className='mr-2 h-4 w-4' />
-                Cancel Subscription
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Cancel your subscription?</AlertDialogTitle>
-                <AlertDialogDescription asChild>
-                  <div className='space-y-3'>
-                    <p>
-                      Your Pro access continues until the end of your current
-                      billing period. After that, you&apos;ll lose access to:
-                    </p>
-                    <ul className='space-y-2'>
-                      <li className='flex items-start gap-2 text-app'>
-                        <XCircle className='mt-0.5 h-4 w-4 shrink-0 text-destructive' />
-                        <span>
-                          <strong>Branding removal</strong> - Jovie branding
-                          will reappear on your profile
-                        </span>
-                      </li>
-                      <li className='flex items-start gap-2'>
-                        <XCircle className='mt-0.5 h-4 w-4 shrink-0 text-destructive' />
-                        <span>
-                          <strong>Advanced analytics</strong> - Retention drops
-                          from 90 days to 7 days
-                        </span>
-                      </li>
-                      <li className='flex items-start gap-2'>
-                        <XCircle className='mt-0.5 h-4 w-4 shrink-0 text-destructive' />
-                        <span>
-                          <strong>Contact export</strong> - You won&apos;t be
-                          able to export audience contacts
-                        </span>
-                      </li>
-                      <li className='flex items-start gap-2'>
-                        <XCircle className='mt-0.5 h-4 w-4 shrink-0 text-destructive' />
-                        <span>
-                          <strong>Unlimited contacts</strong> - Contact limit
-                          drops to 100
-                        </span>
-                      </li>
-                      <li className='flex items-start gap-2'>
-                        <XCircle className='mt-0.5 h-4 w-4 shrink-0 text-destructive' />
-                        <span>
-                          <strong>Self-filtering</strong> - Your own visits will
-                          count in analytics
-                        </span>
-                      </li>
-                    </ul>
-                    <p className='text-secondary-token'>
-                      You won&apos;t be charged again. You can re-subscribe any
-                      time.
-                    </p>
-                  </div>
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Keep Subscription</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={handleCancelSubscription}
-                  disabled={cancelMutationPending}
-                  className='bg-red-600 text-white dark:text-white hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-800'
-                >
-                  {cancelMutationPending ? 'Cancelling...' : 'Yes, Cancel'}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+            title='Cancel your subscription?'
+            body={
+              <div className='space-y-3'>
+                <p>
+                  Your Pro access continues until the end of your current
+                  billing period. After that, you&apos;ll lose access to:
+                </p>
+                <ul className='space-y-2'>
+                  <li className='flex items-start gap-2 text-app'>
+                    <XCircle
+                      className='mt-0.5 h-4 w-4 shrink-0 text-destructive'
+                      aria-hidden='true'
+                    />
+                    <span>
+                      <strong>Branding removal</strong> - Jovie branding will
+                      reappear on your profile
+                    </span>
+                  </li>
+                  <li className='flex items-start gap-2'>
+                    <XCircle
+                      className='mt-0.5 h-4 w-4 shrink-0 text-destructive'
+                      aria-hidden='true'
+                    />
+                    <span>
+                      <strong>Advanced analytics</strong> - Retention drops from
+                      90 days to 7 days
+                    </span>
+                  </li>
+                  <li className='flex items-start gap-2'>
+                    <XCircle
+                      className='mt-0.5 h-4 w-4 shrink-0 text-destructive'
+                      aria-hidden='true'
+                    />
+                    <span>
+                      <strong>Contact export</strong> - You won&apos;t be able
+                      to export audience contacts
+                    </span>
+                  </li>
+                  <li className='flex items-start gap-2'>
+                    <XCircle
+                      className='mt-0.5 h-4 w-4 shrink-0 text-destructive'
+                      aria-hidden='true'
+                    />
+                    <span>
+                      <strong>Unlimited contacts</strong> - Contact limit drops
+                      to 100
+                    </span>
+                  </li>
+                  <li className='flex items-start gap-2'>
+                    <XCircle
+                      className='mt-0.5 h-4 w-4 shrink-0 text-destructive'
+                      aria-hidden='true'
+                    />
+                    <span>
+                      <strong>Self-filtering</strong> - Your own visits will
+                      count in analytics
+                    </span>
+                  </li>
+                </ul>
+                <p className='text-secondary-token'>
+                  You won&apos;t be charged again. You can re-subscribe any
+                  time.
+                </p>
+              </div>
+            }
+            cancelLabel='Keep Subscription'
+            confirmLabel='Cancel Subscription'
+            variant='destructive'
+            onConfirm={handleCancelSubscription}
+            isLoading={cancelMutationPending}
+          />
         </div>
       </ContentSurfaceCard>
     </motion.div>

--- a/apps/web/tests/components/BillingDashboard.test.tsx
+++ b/apps/web/tests/components/BillingDashboard.test.tsx
@@ -347,8 +347,12 @@ describe('BillingDashboard', () => {
       expect(screen.getByText('Cancel your subscription?')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Keep Subscription')).toBeInTheDocument();
-    expect(screen.getByText('Yes, Cancel')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Keep Subscription' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Cancel Subscription' })
+    ).toBeInTheDocument();
   });
 
   it('renders partial UI when pricing fails but billing succeeds', async () => {

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -1412,7 +1412,7 @@ describe('TasksPageClient', () => {
       deleteItem?.onClick?.();
     });
 
-    const dialog = screen.getByRole('alertdialog');
+    const dialog = screen.getByRole('dialog', { name: 'Delete task?' });
     expect(dialog).toHaveTextContent('Delete task?');
     expect(dialog).toHaveTextContent(mockTaskTwo.title);
 

--- a/apps/web/tests/unit/design-system/destructive-confirm-dialog-audit.test.ts
+++ b/apps/web/tests/unit/design-system/destructive-confirm-dialog-audit.test.ts
@@ -1,0 +1,105 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WEB_ROOT = process.cwd().endsWith('/apps/web')
+  ? process.cwd()
+  : join(process.cwd(), 'apps', 'web');
+const SCAN_DIRS = [join(WEB_ROOT, 'components'), join(WEB_ROOT, 'app', 'app')];
+const SOURCE_EXT = /\.(tsx|ts)$/;
+
+const DIRECT_DESTRUCTIVE_ALERT_DIALOG_ALLOWLIST = new Set([
+  'components/organisms/profile-notifications-menu/ProfileNotificationsMenu.tsx',
+  'components/features/admin/DeleteCreatorDialog.tsx',
+  'components/features/admin/BulkDeleteCreatorDialog.tsx',
+  'components/features/admin/admin-users-table/AdminUsersTableUnified.tsx',
+]);
+
+const REQUIRED_DESTRUCTIVE_FLOWS = [
+  {
+    name: 'delete release',
+    file: 'components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx',
+  },
+  {
+    name: 'remove contact',
+    file: 'components/features/dashboard/organisms/ContactsManager.tsx',
+  },
+  {
+    name: 'disconnect platform',
+    file: 'components/features/dashboard/organisms/settings-artist-profile-section/ConnectedDspList.tsx',
+  },
+  {
+    name: 'disconnect integration',
+    file: 'components/features/dashboard/organisms/SettingsTouringSection.tsx',
+  },
+  {
+    name: 'delete account',
+    file: 'components/features/dashboard/organisms/DataPrivacySection.tsx',
+  },
+  {
+    name: 'cancel subscription',
+    file: 'components/organisms/billing/BillingActionsSection.tsx',
+  },
+] as const;
+
+function walk(dir: string, out: string[]): void {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      if (entry === 'node_modules' || entry === '.next') continue;
+      walk(full, out);
+      continue;
+    }
+    if (SOURCE_EXT.test(entry)) out.push(full);
+  }
+}
+
+function findDirectDestructiveAlertDialogActions(): string[] {
+  const files: string[] = [];
+  for (const dir of SCAN_DIRS) walk(dir, files);
+
+  return files.flatMap(file => {
+    const source = readFileSync(file, 'utf8');
+    const destructiveActionTag =
+      /<AlertDialogAction\b[^>]*variant=(?:'|")destructive(?:'|")[^>]*>/;
+    if (!destructiveActionTag.test(source)) return [];
+
+    const repoRelative = relative(WEB_ROOT, file);
+    return DIRECT_DESTRUCTIVE_ALERT_DIALOG_ALLOWLIST.has(repoRelative)
+      ? []
+      : [repoRelative];
+  });
+}
+
+describe('destructive action ConfirmDialog audit', () => {
+  it('keeps the required destructive flows on the canonical ConfirmDialog', () => {
+    const missing = REQUIRED_DESTRUCTIVE_FLOWS.flatMap(({ name, file }) => {
+      const source = readFileSync(join(WEB_ROOT, file), 'utf8');
+      const destructiveConfirmDialog =
+        /<ConfirmDialog\b[\s\S]*?variant=(?:'|"|\{[^}]*['"])destructive(?:'|"|['"][^}]*\})/;
+      const usesConfirmDialog = destructiveConfirmDialog.test(source);
+
+      return usesConfirmDialog ? [] : [`${name}: ${file}`];
+    });
+
+    expect(
+      missing,
+      `Destructive flows must use ConfirmDialog with variant='destructive'. Missing:\n${missing.join(
+        '\n'
+      )}`
+    ).toEqual([]);
+  });
+
+  it('blocks new raw destructive AlertDialogAction usage outside the allowlist', () => {
+    const unconfirmedActions = findDirectDestructiveAlertDialogActions();
+
+    expect(
+      unconfirmedActions,
+      `Use ConfirmDialog for destructive actions instead of raw AlertDialogAction. New raw usages:\n${unconfirmedActions.join(
+        '\n'
+      )}`
+    ).toEqual([]);
+  });
+});

--- a/packages/ui/confirm-dialog.test.tsx
+++ b/packages/ui/confirm-dialog.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ConfirmDialog } from './confirm-dialog';
+
+describe('ConfirmDialog', () => {
+  it('renders title, body, cancel slot, and destructive confirm slot', () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title='Delete this release?'
+        description='This removes the release from your profile.'
+        cancelLabel='Keep Release'
+        confirmLabel='Delete Release'
+        variant='destructive'
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Delete this release?')).toBeInTheDocument();
+    expect(
+      screen.getByText('This removes the release from your profile.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Keep Release' })
+    ).toBeInTheDocument();
+
+    const confirm = screen.getByRole('button', { name: 'Delete Release' });
+    expect(confirm).toHaveAttribute('data-destructive', 'true');
+    expect(confirm.className).toContain('bg-error');
+  });
+
+  it('closes as cancel when Escape is pressed', () => {
+    const onCancel = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        title='Remove contact?'
+        description='The contact will no longer appear in your audience.'
+        onCancel={onCancel}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onCancel).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('closes as cancel when the outside overlay is clicked', () => {
+    const onCancel = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        title='Disconnect platform?'
+        description='Jovie will stop syncing this platform.'
+        onCancel={onCancel}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('dialog-overlay'));
+
+    expect(onCancel).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps focus inside the dialog', async () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title='Leave team?'
+        description='You will lose access to this workspace.'
+        onConfirm={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+    });
+  });
+
+  it('blocks confirm when confirmDisabled is true', () => {
+    const onConfirm = vi.fn();
+
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title='Delete your account?'
+        description='This action cannot be undone.'
+        confirmDisabled={true}
+        onConfirm={onConfirm}
+      >
+        <input aria-label='Type DELETE to confirm' />
+      </ConfirmDialog>
+    );
+
+    const confirm = screen.getByRole('button', { name: 'Confirm' });
+    expect(confirm).toBeDisabled();
+    fireEvent.click(confirm);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('keeps the dialog open and shows an error when confirm fails', async () => {
+    const onOpenChange = vi.fn();
+    const onError = vi.fn();
+
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        title='Cancel subscription?'
+        description='Your subscription will end after the current billing period.'
+        confirmLabel='Cancel Subscription'
+        variant='destructive'
+        onConfirm={async () => {
+          throw new Error('Request failed');
+        }}
+        onError={onError}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Cancel Subscription' })
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Action failed. Please try again.'
+    );
+    expect(onError).toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/ui/confirm-dialog.tsx
+++ b/packages/ui/confirm-dialog.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { type MouseEvent, type ReactNode, useRef, useState } from 'react';
+import { Button } from './atoms/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './atoms/dialog';
+
+export interface ConfirmDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly title: ReactNode;
+  readonly body?: ReactNode;
+  /**
+   * @deprecated Use body. Kept for existing app callers during migration.
+   */
+  readonly description?: ReactNode;
+  readonly confirmLabel?: ReactNode;
+  readonly cancelLabel?: ReactNode;
+  readonly variant?: 'default' | 'destructive';
+  readonly onConfirm: () => void | Promise<void>;
+  readonly onCancel?: () => void;
+  readonly onError?: (error: unknown) => void;
+  readonly isLoading?: boolean;
+  readonly confirmDisabled?: boolean;
+  readonly children?: ReactNode;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  body,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  onConfirm,
+  onCancel,
+  onError,
+  isLoading = false,
+  confirmDisabled = false,
+  children,
+}: ConfirmDialogProps) {
+  const [isPending, setIsPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const handlingRef = useRef(false);
+  const loading = isLoading || isPending;
+  const content = body ?? description;
+
+  const closeAsCancel = () => {
+    if (loading) return;
+    onCancel?.();
+    onOpenChange(false);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (loading && !nextOpen) return;
+    if (nextOpen) setErrorMessage(null);
+    if (!nextOpen) onCancel?.();
+    onOpenChange(nextOpen);
+  };
+
+  const handleConfirm = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    if (handlingRef.current || loading || confirmDisabled) return;
+    handlingRef.current = true;
+    setIsPending(true);
+    setErrorMessage(null);
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } catch (error) {
+      onError?.(error);
+      setErrorMessage('Action failed. Please try again.');
+    } finally {
+      setIsPending(false);
+      handlingRef.current = false;
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        hideClose
+        overlayProps={{ onClick: closeAsCancel }}
+        onEscapeKeyDown={event => {
+          event.preventDefault();
+          if (loading) {
+            return;
+          }
+          closeAsCancel();
+        }}
+        onInteractOutside={event => {
+          if (loading) event.preventDefault();
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {content ? (
+            <DialogDescription asChild={typeof content !== 'string'}>
+              {content}
+            </DialogDescription>
+          ) : null}
+        </DialogHeader>
+        {children}
+        {errorMessage ? (
+          <p className='text-sm text-error' role='alert'>
+            {errorMessage}
+          </p>
+        ) : null}
+        <DialogFooter>
+          <Button
+            variant='secondary'
+            disabled={loading}
+            onClick={closeAsCancel}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={loading || confirmDisabled}
+            variant='primary'
+            destructive={variant === 'destructive'}
+          >
+            {loading ? 'Please wait...' : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -261,6 +261,9 @@ export {
 // Tooltip Shortcut (helper for label + keyboard shortcut pattern)
 export type { TooltipShortcutProps } from './atoms/tooltip-shortcut';
 export { TooltipShortcut } from './atoms/tooltip-shortcut';
+// Confirm Dialog
+export type { ConfirmDialogProps } from './confirm-dialog';
+export { ConfirmDialog } from './confirm-dialog';
 export {
   CHECKBOX_RADIO_ITEM_BASE,
   contextMenuContentClasses,


### PR DESCRIPTION
## Summary
- Add canonical `ConfirmDialog` to `@jovie/ui` with title/body/cancel/confirm slots, destructive confirm styling, Escape cancel, outside-click cancel, focus trap, disabled confirm, async pending, and visible failure fallback.
- Re-export the app `ConfirmDialog` wrapper from `@jovie/ui` for compatibility, then migrate delete account and cancel subscription off raw `AlertDialog` while preserving account `DELETE` typed confirmation.
- Add a destructive-confirm audit covering the required destructive flows and blocking new raw destructive `AlertDialogAction` usage outside the documented legacy allowlist.

Closes #12886

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm biome check --write packages/ui/confirm-dialog.tsx packages/ui/confirm-dialog.test.tsx packages/ui/index.ts apps/web/components/molecules/ConfirmDialog.tsx apps/web/components/organisms/billing/BillingActionsSection.tsx apps/web/components/features/dashboard/organisms/DataPrivacySection.tsx apps/web/tests/unit/design-system/destructive-confirm-dialog-audit.test.ts` -> `Checked 7 files ...`
- `pnpm --filter @jovie/ui test -- confirm-dialog` -> `Test Files 1 passed`, `Tests 6 passed`
- `pnpm --filter @jovie/ui run typecheck` -> `tsc --noEmit` passed
- `pnpm --filter @jovie/web exec vitest run --config=vitest.config.mts tests/unit/design-system/destructive-confirm-dialog-audit.test.ts` -> `Test Files 1 passed`, `Tests 2 passed`
- `pnpm --filter @jovie/web run lint:no-native-dialogs` -> `No native browser dialogs found.`
- `pnpm --filter @jovie/web exec vitest run --config=vitest.config.mts tests/components/dashboard/LinkActions.negative.critical.test.tsx tests/components/dashboard/LinkActions.click.test.tsx tests/components/dashboard/LinkActions.keyboard.test.tsx` -> `Test Files 3 passed`, `Tests 19 passed`
- `pnpm --filter @jovie/web run typecheck -- --pretty false` -> passed
- `pnpm --filter @jovie/web run test:bug-to-test` -> `bug-to-test: not applicable (not a bug fix PR)`
- Pre-commit hook -> gitleaks/trufflehog clean, next proxy guard passed, staged Biome/a11y/ESLint/typecheck passed
- Pre-push hook -> changed-file Biome passed, next proxy guard passed, Tailwind guard passed, web typecheck passed
- `coderabbit review --agent -c AGENTS.md -t uncommitted` -> first run completed with findings; fixed actionable major/minor items. Required rerun attempted twice after diff changes, but CodeRabbit returned `rate_limit` with 45-46 minute wait.

## QA Notes
- Layout/state coverage: component tests cover closed/open rendering, destructive confirm token path, Escape cancel, outside-click cancel, focus trap, disabled confirm, and failed async confirm staying open with visible error.
- Delete account keeps the typed `DELETE` confirmation and only signs out after `mutateAsync` succeeds.
- Cancel subscription now uses canonical destructive confirm copy (`Cancel Subscription`) and token-based destructive styling instead of ad hoc red classes.

## Existing Related PRs
This issue already had earlier open attempts (#12908 and #12937). This PR is from the requested 2026-07-04 worktree/branch and includes the migration plus audit/test evidence for this run.