### PR TITLE
Strip container chrome from marketing home page feature sections

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -829,11 +829,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  overflow: hidden;
-  border: 1px solid rgba(5, 6, 8, 0.08);
-  border-radius: 8px;
-  background: #fff;
-  box-shadow: 0 18px 70px -56px rgba(0, 0, 0, 0.45);
   padding: clamp(2.35rem, 3.45vw, 3.55rem);
   scroll-snap-align: start;
 }
@@ -901,21 +896,24 @@ body:has(.home-viewport)::-webkit-scrollbar {
   gap: 0.75rem;
 }
 
-.homepage-outcome-release-card,
-.homepage-outcome-drawer,
-.homepage-outcome-share-card {
-  border: 1px solid rgba(5, 6, 8, 0.08);
-  border-radius: 8px;
-  background: #f7f7f8;
-  box-shadow: 0 14px 44px -36px rgba(0, 0, 0, 0.38);
-}
-
 .homepage-outcome-release-card {
   display: flex;
   flex-direction: column;
   min-height: 6.25rem;
   justify-content: flex-end;
   padding: 1rem;
+}
+
+.homepage-outcome-drawer {
+  padding: 1rem;
+}
+
+.homepage-outcome-share-card {
+  max-width: 17rem;
+  margin-left: auto;
+  padding: 1rem;
+  text-align: center;
+  color: #050608;
 }
 
 .homepage-outcome-release-card strong,
@@ -943,10 +941,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
   font-weight: 520;
   letter-spacing: -0.01em;
   color: rgb(5 6 8 / 0.52);
-}
-
-.homepage-outcome-drawer {
-  padding: 1rem;
 }
 
 .homepage-outcome-drawer__title {
@@ -1054,7 +1048,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
   padding: 1rem;
   text-align: center;
   color: #050608;
-  background: #f7f7f8;
 }
 
 .homepage-outcome-share-card p {

--- a/apps/web/components/features/home/HomeBentoPairs.tsx
+++ b/apps/web/components/features/home/HomeBentoPairs.tsx
@@ -81,9 +81,9 @@ export function HomeBentoPairs() {
 
 function BentoCardView({ card }: { readonly card: BentoCard }) {
   return (
-    <article className='flex flex-col overflow-hidden rounded-lg border border-black/[0.08] bg-white dark:bg-white shadow-[0_18px_70px_-56px_rgba(0,0,0,0.45)]'>
+    <article className='flex flex-col'>
       <div
-        className='relative h-80 overflow-hidden border-b border-black/[0.06]'
+        className='relative h-80 overflow-hidden'
         style={{
           background:
             'radial-gradient(120% 80% at 50% 0%, rgba(0,0,0,0.04) 0%, rgba(0,0,0,0) 60%), linear-gradient(180deg, #ffffff, #f6f6f7)',
@@ -166,7 +166,7 @@ function TourPreview() {
         {cities.map(c => (
           <li
             key={c.city}
-            className='flex items-center justify-between rounded-lg border border-black/[0.08] bg-white dark:bg-white px-3 py-2 font-[var(--marketing-font-body)] text-xs text-black dark:text-black shadow-[0_10px_32px_-28px_rgba(0,0,0,0.55)]'
+            className='flex items-center justify-between px-3 py-2 font-[var(--marketing-font-body)] text-xs text-black dark:text-black'
           >
             <span>{c.city}</span>
             <span className='text-black/45 dark:text-black/45'>{c.date}</span>


### PR DESCRIPTION
## Summary

Removes unnecessary container chrome (borders, rounded corners, shadows, white card backgrounds) from the marketing homepage feature sections so visual hierarchy comes from type weight, size, and spacing — not from boxes surrounding content.

## Changes

### `HomeBentoPairs.tsx` — `BentoCardView`
- Removed `rounded-lg border border-black/[0.08] bg-white dark:bg-white shadow-[0_18px_70px_-56px_rgba(0,0,0,0.45)]` from the article wrapper
- Removed `border-b border-black/[0.06]` from the preview media div

### `HomeBentoPairs.tsx` — Tour mini preview cards
- Removed `rounded-lg border border-black/[0.08] bg-white dark:bg-white shadow-[0_10px_32px_-28px_rgba(0,0,0,0.55)]` from list items

### `home.css` — Outcome section cards
- Removed borders, border-radius, white background, and box-shadow from `.homepage-outcome-card`
- Removed the combined rule for `.homepage-outcome-release-card`, `.homepage-outcome-drawer`, `.homepage-outcome-share-card` (border, border-radius, background, box-shadow)
- Removed `background: #f7f7f8` from `.homepage-outcome-share-card`
- Fixed duplicate rule definitions for `.homepage-outcome-drawer` and `.homepage-outcome-share-card`

## Acceptance Criteria
- Feature sections no longer use bordered/rounded white cards
- Preview media still display correctly
- Typography hierarchy is the primary visual differentiator
- Dark mode continues to work
- Responsive layout preserved
- Hero section and footer unchanged

## Reference
Task spec: `tasks/landing-home-page-container-strip.md`
Requested by: @veronica