### PR TITLE
fix(analytics): avoid inline GA consent scripts

### DIFF
--- a/apps/web/app/ga-consent-init.js/route.test.ts
+++ b/apps/web/app/ga-consent-init.js/route.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { GET } from './route';
+
+describe('/ga-consent-init.js', () => {
+  it('serves the GA consent bootstrap as same-origin JavaScript', async () => {
+    const response = GET();
+    const body = await response.text();
+
+    expect(response.headers.get('Content-Type')).toBe(
+      'text/javascript; charset=utf-8'
+    );
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=300');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(body).toContain("gtag('consent', 'default'");
+    expect(body).toContain('jv_cc_required=1');
+  });
+});

--- a/apps/web/app/ga-consent-init.js/route.ts
+++ b/apps/web/app/ga-consent-init.js/route.ts
@@ -1,0 +1,13 @@
+import { buildGoogleConsentInitScript } from '@/lib/tracking/google-consent-mode';
+
+export const dynamic = 'force-static';
+
+export function GET(): Response {
+  return new Response(buildGoogleConsentInitScript(), {
+    headers: {
+      'Cache-Control': 'public, max-age=300',
+      'Content-Type': 'text/javascript; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -16,7 +16,6 @@ import { InstantlyPixel } from '@/components/providers/InstantlyPixel';
 import { getRootLayoutChromeState } from '@/lib/demo-recording';
 import { publicEnv } from '@/lib/env-public';
 import {
-  buildGoogleConsentInitScript,
   isValidGaMeasurementId,
   shouldMountGoogleAnalytics,
 } from '@/lib/tracking/google-consent-mode';
@@ -252,13 +251,10 @@ export default async function RootLayout({
         {/* eslint-disable-next-line @next/next/no-sync-scripts -- Must run before React hydration; next/script nonce drift causes local E2E console errors. */}
         <script src='/theme-init.js' />
         {shouldMountGa && isValidGaMeasurementId(gaMeasurementId) ? (
-          <script
-            id='ga-consent-init'
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: script body is generated from a validated GA measurement ID.
-            dangerouslySetInnerHTML={{
-              __html: buildGoogleConsentInitScript(gaMeasurementId),
-            }}
-          />
+          <>
+            {/* eslint-disable-next-line @next/next/no-sync-scripts -- Must run before the GA loader so consent defaults are queued before gtag.js executes. */}
+            <script id='ga-consent-init' src='/ga-consent-init.js' />
+          </>
         ) : null}
       </head>
       <body className={bodyClassName}>

--- a/apps/web/components/providers/GoogleAnalytics.test.tsx
+++ b/apps/web/components/providers/GoogleAnalytics.test.tsx
@@ -1,0 +1,98 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GoogleAnalytics } from './GoogleAnalytics';
+
+type AnalyticsWindow = Window & {
+  dataLayer?: unknown[][];
+  gtag?: ReturnType<typeof vi.fn>;
+};
+
+const mockPublicEnv = vi.hoisted(() => ({
+  NEXT_PUBLIC_GA_MEASUREMENT_ID: 'G-TMY7Z8HK47' as string | undefined,
+}));
+
+vi.mock('next/script', () => ({
+  default: ({
+    children,
+    id,
+    src,
+  }: {
+    readonly children?: React.ReactNode;
+    readonly id?: string;
+    readonly src?: string;
+  }) => (
+    <div data-testid={id} data-src={src}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@/lib/env-client', () => ({
+  env: {
+    IS_E2E: false,
+    IS_TEST: false,
+  },
+}));
+
+vi.mock('@/lib/env-public', () => ({
+  publicEnv: mockPublicEnv,
+}));
+
+vi.mock('@/lib/demo-recording', () => ({
+  isDemoRecordingClient: () => false,
+}));
+
+describe('GoogleAnalytics', () => {
+  beforeEach(() => {
+    mockPublicEnv.NEXT_PUBLIC_GA_MEASUREMENT_ID = 'G-TMY7Z8HK47';
+    (window as AnalyticsWindow).dataLayer = undefined;
+    (window as AnalyticsWindow).gtag = vi.fn();
+  });
+
+  it('configures GA from the client bundle instead of rendering inline script children', () => {
+    const { queryByTestId, getByTestId } = render(<GoogleAnalytics />);
+
+    expect(getByTestId('ga-gtag-loader')).toHaveAttribute(
+      'data-src',
+      'https://www.googletagmanager.com/gtag/js?id=G-TMY7Z8HK47'
+    );
+    expect(queryByTestId('ga-config')).not.toBeInTheDocument();
+    expect((window as AnalyticsWindow).gtag).toHaveBeenCalledWith(
+      'js',
+      expect.any(Date)
+    );
+    expect((window as AnalyticsWindow).gtag).toHaveBeenCalledWith(
+      'config',
+      'G-TMY7Z8HK47'
+    );
+  });
+
+  it('queues GA configuration in dataLayer when gtag is not loaded yet', () => {
+    (window as AnalyticsWindow).gtag = undefined;
+
+    const { getByTestId } = render(<GoogleAnalytics />);
+
+    expect(getByTestId('ga-gtag-loader')).toHaveAttribute(
+      'data-src',
+      'https://www.googletagmanager.com/gtag/js?id=G-TMY7Z8HK47'
+    );
+    expect((window as AnalyticsWindow).dataLayer?.[0]?.[0]).toBe('js');
+    expect((window as AnalyticsWindow).dataLayer?.[0]?.[1]).toBeInstanceOf(
+      Date
+    );
+    expect((window as AnalyticsWindow).dataLayer?.[1]).toEqual([
+      'config',
+      'G-TMY7Z8HK47',
+    ]);
+  });
+
+  it('skips rendering and configuration when the GA measurement ID is missing', () => {
+    mockPublicEnv.NEXT_PUBLIC_GA_MEASUREMENT_ID = undefined;
+
+    const { queryByTestId } = render(<GoogleAnalytics />);
+
+    expect(queryByTestId('ga-gtag-loader')).not.toBeInTheDocument();
+    expect(queryByTestId('ga-config')).not.toBeInTheDocument();
+    expect((window as AnalyticsWindow).gtag).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/providers/GoogleAnalytics.tsx
+++ b/apps/web/components/providers/GoogleAnalytics.tsx
@@ -8,7 +8,6 @@ import { env } from '@/lib/env-client';
 import { publicEnv } from '@/lib/env-public';
 import {
   applyGoogleConsentMode,
-  buildGoogleAnalyticsConfigScript,
   consentToGoogleConsentMode,
   isCookieBannerRequiredFromClient,
   isValidGaMeasurementId,
@@ -24,6 +23,11 @@ function isConsentPayload(value: unknown): value is Consent {
   );
 }
 
+type AnalyticsWindow = Window & {
+  dataLayer?: unknown[][];
+  gtag?: (...args: unknown[]) => void;
+};
+
 export function GoogleAnalytics() {
   const measurementId = publicEnv.NEXT_PUBLIC_GA_MEASUREMENT_ID;
   const isPassive = env.IS_TEST || env.IS_E2E;
@@ -33,6 +37,16 @@ export function GoogleAnalytics() {
   useEffect(() => {
     if (skip) return;
     if (globalThis.window === undefined) return;
+
+    const analyticsWindow = globalThis.window as AnalyticsWindow;
+    const gtag =
+      analyticsWindow.gtag ??
+      ((...args: unknown[]) => {
+        analyticsWindow.dataLayer = analyticsWindow.dataLayer ?? [];
+        analyticsWindow.dataLayer.push(args);
+      });
+    gtag('js', new Date());
+    gtag('config', measurementId);
 
     const syncConsent = (value: unknown) => {
       if (!isConsentPayload(value)) return;
@@ -61,20 +75,15 @@ export function GoogleAnalytics() {
       globalThis.removeEventListener('jvconsent:ready', onReady);
       unsubConsent?.();
     };
-  }, [skip]);
+  }, [measurementId, skip]);
 
   if (skip) return null;
 
   return (
-    <>
-      <Script
-        id='ga-gtag-loader'
-        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
-        strategy='afterInteractive'
-      />
-      <Script id='ga-config' strategy='afterInteractive'>
-        {buildGoogleAnalyticsConfigScript(measurementId)}
-      </Script>
-    </>
+    <Script
+      id='ga-gtag-loader'
+      src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+      strategy='afterInteractive'
+    />
   );
 }

--- a/apps/web/lib/tracking/google-consent-mode.ts
+++ b/apps/web/lib/tracking/google-consent-mode.ts
@@ -129,8 +129,8 @@ export function applyGoogleConsentMode(state: GoogleConsentModeState): void {
   analyticsWindow?.gtag?.('consent', 'update', state);
 }
 
-export function buildGoogleConsentInitScript(measurementId: string): string {
-  if (!isValidGaMeasurementId(measurementId)) {
+export function buildGoogleConsentInitScript(measurementId?: string): string {
+  if (measurementId !== undefined && !isValidGaMeasurementId(measurementId)) {
     throw new Error('Invalid GA measurement ID');
   }
 

--- a/apps/web/tests/unit/app/root-layout-scripts.test.ts
+++ b/apps/web/tests/unit/app/root-layout-scripts.test.ts
@@ -16,4 +16,15 @@ describe('root layout scripts', () => {
     expect(layoutSource).toContain("<script src='/theme-init.js' />");
     expect(layoutSource).not.toContain('beforeInteractive');
   });
+
+  it('loads GA consent init as a same-origin script instead of CSP-blocked inline code', () => {
+    const gaConsentTag = layoutSource.match(
+      /<script(?=[^>]*id='ga-consent-init')(?=[^>]*src='\/ga-consent-init\.js')[^>]*\/>/
+    )?.[0];
+
+    expect(gaConsentTag).toBeDefined();
+    expect(layoutSource).not.toContain('buildGoogleConsentInitScript');
+    expect(layoutSource).not.toContain('dangerouslySetInnerHTML');
+    expect(layoutSource).not.toContain('buildGoogleAnalyticsConfigScript');
+  });
 });

--- a/apps/web/tests/unit/lib/content-security-policy.test.ts
+++ b/apps/web/tests/unit/lib/content-security-policy.test.ts
@@ -13,6 +13,7 @@ describe('buildContentSecurityPolicy', () => {
     const csp = buildContentSecurityPolicy({ nonce, isDev: false });
     const scriptSrc = findDirective(csp, 'script-src');
 
+    expect(scriptSrc).toContain("'self'");
     expect(scriptSrc).toContain(`'nonce-${nonce}'`);
     expect(scriptSrc).not.toContain("'unsafe-inline'");
   });

--- a/apps/web/tests/unit/tracking/google-analytics.test.tsx
+++ b/apps/web/tests/unit/tracking/google-analytics.test.tsx
@@ -73,17 +73,17 @@ describe('GoogleAnalytics', () => {
     cleanup();
   });
 
-  it('renders gtag loader and config scripts', () => {
+  it('renders the gtag loader and configures GA without inline script children', () => {
     const { container } = render(<GoogleAnalytics />);
     const scripts = getScripts(container);
 
-    expect(scripts).toHaveLength(2);
+    expect(scripts).toHaveLength(1);
     expect(scripts[0]?.id).toBe('ga-gtag-loader');
     expect(scripts[0]?.getAttribute('src')).toBe(
       'https://www.googletagmanager.com/gtag/js?id=G-TMY7Z8HK47'
     );
-    expect(scripts[1]?.id).toBe('ga-config');
-    expect(scripts[1]?.textContent).toContain("gtag('config', 'G-TMY7Z8HK47')");
+    expect(globalThis.gtag).toHaveBeenCalledWith('js', expect.any(Date));
+    expect(globalThis.gtag).toHaveBeenCalledWith('config', 'G-TMY7Z8HK47');
   });
 
   it('returns null when measurement ID is missing', () => {

--- a/apps/web/tests/unit/tracking/google-consent-mode.test.ts
+++ b/apps/web/tests/unit/tracking/google-consent-mode.test.ts
@@ -141,4 +141,10 @@ describe('google-consent-mode', () => {
       "gtag('config', 'G-TMY7Z8HK47')"
     );
   });
+
+  it('builds a measurement-independent consent init script for the CSP-safe route', () => {
+    expect(buildGoogleConsentInitScript()).toContain(
+      "gtag('consent', 'default'"
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #12650

- Move `ga-consent-init` out of root-layout inline HTML and into a static same-origin `/ga-consent-init.js` route allowed by existing `script-src 'self'`.
- Remove the inline `ga-config` Next script; configure GA from the client bundle and queue through `dataLayer` if `gtag` is not loaded yet.
- Add regression coverage for the external consent script route, GA provider behavior, root layout script shape, and CSP `script-src 'self'` contract.

## Acceptance Evidence

Production is affected today:

```text
Playwright against https://jov.ie/signin before this patch:
status: 200
script#ga-consent-init: src=null, nonce=null, inlineLength=1736
CSP console error includes hash sha256-10mdStbS5FsxO5o5mUoGLmIeAbLhb6GzReTI5H9pN/U= for ga-consent-init
CSP console error includes hash sha256-veo+qifFoX7qG9ff/2VXFLxJfOVV4C+yMlQen6v53wA= for ga-config
```

Local post-fix browser smoke:

```text
/signin: status=200, final url=http://localhost:3000/waitlist, CSP nonce present, script#ga-consent-init src=/ga-consent-init.js, inlineLength=0, CSP/GA console messages=[]
/app: status=200, final url=http://localhost:3000/app, CSP nonce present, script#ga-consent-init src=/ga-consent-init.js, inlineLength=0, CSP/GA console messages=[]
/ga-consent-init.js: status=200, content-type=text/javascript; charset=utf-8, routeHasConsentDefault=true
```

Note: local `/signin` and `/app` emitted unrelated `DATABASE_URL environment variable is not set` dev-server logs under the mock auth setup, but the page responses returned 200 and the browser CSP/GA message filter was empty.

## Test plan

```text
pnpm --filter @jovie/web exec biome check --write components/providers/GoogleAnalytics.tsx components/providers/GoogleAnalytics.test.tsx app/ga-consent-init.js/route.ts app/ga-consent-init.js/route.test.ts app/layout.tsx tests/unit/app/root-layout-scripts.test.ts tests/unit/lib/content-security-policy.test.ts tests/unit/tracking/google-consent-mode.test.ts lib/tracking/google-consent-mode.ts
Checked 9 files in 37ms. No fixes applied.
```

```text
pnpm --filter @jovie/web exec vitest run app/ga-consent-init.js/route.test.ts components/providers/GoogleAnalytics.test.tsx tests/unit/app/root-layout-scripts.test.ts tests/unit/tracking/google-consent-mode.test.ts tests/unit/lib/content-security-policy.test.ts
Test Files  5 passed (5)
Tests  34 passed (34)
```

```text
pnpm --filter @jovie/web run typecheck -- --pretty false
@jovie/web typecheck completed with exit code 0
```

```text
pnpm turbo typecheck --filter=@jovie/web
Tasks: 3 successful, 3 total
```

```text
pnpm --filter @jovie/web exec eslint --config eslint.config.js --max-warnings=0 app/layout.tsx components/providers/GoogleAnalytics.tsx components/providers/GoogleAnalytics.test.tsx
exit code 0
```

```text
git diff --check
exit code 0
```

```text
pre-commit hook
PASS: gitleaks, trufflehog, next:proxy-guard, Biome staged check, staged ESLint, a11y:check:staged, staged typecheck
```

```text
pre-push hook
PASS: biome-pre-push, next:proxy-guard, tailwind:check, typecheck
```

## Reviews

- Testing subagent: requested stronger root-layout and CSP `'self'` assertions; fixed.
- Security subagent: no issues found.
- Review subagent: found missing no-sync-scripts suppression; fixed.
- CodeRabbit local review: fixed actionable findings for MIME type, brittle tests, `nosniff`, missing skip-path coverage, and `dataLayer` queue fallback. Final rerun after the last fix was attempted but CodeRabbit returned a recoverable rate limit (`waitTime: 33 minutes`).

## Risk

CSP/security-adjacent change. This PR intentionally does not enable automerge; it should get human/security review before landing.
