### PR TITLE
feat(hermes): add gbrain health summary cron

### DIFF
--- a/docs/CRON_REGISTRY.md
+++ b/docs/CRON_REGISTRY.md
@@ -32,6 +32,7 @@ These are machine-local Hermes jobs, not Vercel production crons. They run from 
 | Unit | Schedule | Purpose | Source |
 |------|----------|---------|--------|
 | `co.jovie.hermes.cron-pipeline-scoreboard` | every 60 min | Computes the daily codex shipping funnel, writes `pipeline-scoreboard-latest.json` + gbrain `ops/pipeline-scoreboard/latest`, and alerts on 12h shipper stalls. | `scripts/hermes/jobs/pipeline-scoreboard.ts` |
+| `co.jovie.hermes.cron-gbrain-health-summary` | 07:15 local daily | Runs bounded gbrain doctor/search probes, writes `ops/gbrain-health/latest`, and posts the summary to Telegram/Slack through existing ops notification helpers. | `scripts/hermes/jobs/gbrain-health-summary.ts` |
 
 ## Production Schedule
 

--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -131,6 +131,11 @@ tail -50 ~/.hermes/logs/codex-issue-shipper/*.log 2>/dev/null  # after a non-dry
 tsx scripts/hermes/jobs/agent-config-health.ts
 tail -50 ~/.hermes/logs/launchd/cron-agent-config-health.err.log
 
+# Latest gbrain health summary written by Hermes
+gbrain search "ops/gbrain-health/latest" --limit 3
+tail -50 ~/.hermes/logs/launchd/cron-gbrain-health-summary.log \
+  ~/.hermes/logs/launchd/cron-gbrain-health-summary.err.log
+
 # Free-model rankings
 cat ~/.hermes/state/model-router-rankings.json | jq .
 ```

--- a/docs/spikes/gbrain-knowledge-compounding.md
+++ b/docs/spikes/gbrain-knowledge-compounding.md
@@ -1,0 +1,26 @@
+# GBrain Knowledge Compounding Spike
+
+> Issue: [#13048](https://github.com/JovieInc/Jovie/issues/13048)
+
+Goal: turn recurring source data into durable gbrain summaries with source
+links, timestamps, operational facts, and stable decision records.
+
+## Connectors
+
+Sources: GitHub, Linear, Hermes/OpenClaw, Stripe reports, CRM/Airtable,
+Slack/Telegram, Sentry/Vercel, and Web/Exa. Guardrails: bounded summarized
+notes, no raw logs/customer polling/contact dumps, and explicit web budget.
+
+## Proposed Jobs
+
+| Job | Schedule | Script | Delivery | Cost |
+|---|---:|---|---|---|
+| GBrain health summary | Daily 07:15 local | `scripts/hermes/jobs/gbrain-health-summary.ts` | Telegram/Slack + `ops/gbrain-health/latest` | Two local CLI calls/day |
+| Agent performance digest | Daily 07:30 local | Extend `pipeline-scoreboard.ts` or sibling digest | Telegram + `ops/agent-health/latest` | Local logs unless GitHub enrichment is added |
+| Hourly degradation alert | Hourly | Reuse health summary with transition state | Telegram/Slack on change | Local CLI calls |
+| Weekly trend scrape | Mondays 08:00 local | New Exa/web research job | GBrain + Telegram excerpt | Needs approved provider budget |
+| Monthly KR snapshot | First day 08:00 local | New metrics collector | GBrain structured claims | Prefer existing reports |
+
+No Vercel cron is added. These are Hermes-Air control-plane jobs, not product
+traffic. Decision flow: search gbrain, read current repo docs, make a quantified
+Ship now / Re-evaluate when / Then decision, then write the durable learning.

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "ci:harness:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__",
     "doc:freshness:check": "node scripts/doc-freshness-lint.mjs",
     "doc:freshness:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__/doc-freshness.test.mjs",
+    "hermes:gbrain-health": "tsx scripts/hermes/jobs/gbrain-health-summary.ts",
     "doc:gardening:run": "node scripts/doc-gardening-agent.mjs",
     "qa:swarm:list": "node scripts/qa-swarm/cli.mjs list",
     "qa:swarm:propose": "node scripts/qa-swarm/cli.mjs propose",

--- a/scripts/hermes/jobs/gbrain-health-summary.ts
+++ b/scripts/hermes/jobs/gbrain-health-summary.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env tsx
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+import { gbrainLearn } from '../lib/gbrain';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { notifyOps } from '../lib/ops-notify';
+
+const JOB = 'gbrain-health-summary';
+const GBRAIN = process.env.HERMES_GBRAIN_BIN ?? 'gbrain';
+
+type HealthStatus = 'healthy' | 'degraded' | 'down';
+type HealthCheck = {
+  readonly name: string;
+  readonly ok: boolean;
+  readonly detail: string;
+  readonly durationMs: number;
+};
+
+type HealthSummary = {
+  readonly status: HealthStatus;
+  readonly generatedAt: string;
+  readonly checks: readonly HealthCheck[];
+  readonly recommendation: string;
+};
+
+type GBrainExec = (
+  file: string,
+  args: readonly string[],
+  options: {
+    readonly encoding: 'utf8';
+    readonly timeout: number;
+    readonly maxBuffer?: number;
+  }
+) => string;
+
+function summarizeOutput(output: string, maxChars = 700): string {
+  const cleaned = output.replace(/\s+/g, ' ').trim();
+  if (!cleaned) return 'empty output';
+  return cleaned.length > maxChars
+    ? `${cleaned.slice(0, maxChars)}...`
+    : cleaned;
+}
+
+function statusFromDoctor(output: string): { ok: boolean; detail: string } {
+  const text = output.trim();
+  if (!text) return { ok: false, detail: 'doctor returned empty output' };
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    const status = parsed.status;
+    const healthScore = parsed.health_score ?? parsed.healthScore;
+    const ok =
+      status === 'ok' ||
+      status === 'healthy' ||
+      (typeof healthScore === 'number' && healthScore >= 0.8);
+    if (typeof status !== 'string')
+      return { ok, detail: summarizeOutput(text) };
+    const score =
+      typeof healthScore === 'number' ? ` health_score=${healthScore}` : '';
+    return { ok, detail: `status=${status}${score}` };
+  } catch {
+    const lower = text.toLowerCase();
+    const negative =
+      /\b(unhealthy|not\s+ok|not\s+healthy|down|degraded|fail(ed|ing)?)\b/.test(
+        lower
+      );
+    return {
+      ok: !negative && (lower.includes('healthy') || lower.includes('ok')),
+      detail: summarizeOutput(text),
+    };
+  }
+}
+
+function timedCheck(
+  name: string,
+  run: () => { readonly ok: boolean; readonly detail: string }
+): HealthCheck {
+  const started = Date.now();
+  try {
+    const result = run();
+    return {
+      name,
+      ok: result.ok,
+      detail: result.detail,
+      durationMs: Date.now() - started,
+    };
+  } catch (err) {
+    return {
+      name,
+      ok: false,
+      detail: err instanceof Error ? err.message : String(err),
+      durationMs: Date.now() - started,
+    };
+  }
+}
+
+export function buildGBrainHealthSummary(args: {
+  readonly generatedAt: string;
+  readonly checks: readonly HealthCheck[];
+}): HealthSummary {
+  const failed = args.checks.filter(check => !check.ok);
+  const status: HealthStatus =
+    args.checks.length === 0 || failed.length === args.checks.length
+      ? 'down'
+      : failed.length === 0
+        ? 'healthy'
+        : 'degraded';
+  const recommendation =
+    status === 'healthy'
+      ? 'No operator action needed.'
+      : 'Check gbrain doctor output, gbrain serve launchd status, and recent Hermes/OpenClaw logs before changing model or connector configuration.';
+
+  return {
+    status,
+    generatedAt: args.generatedAt,
+    checks: args.checks,
+    recommendation,
+  };
+}
+
+export function renderGBrainHealthSummary(summary: HealthSummary): string {
+  const lines = [
+    `GBrain health summary: ${summary.status}`,
+    `Generated: ${summary.generatedAt}`,
+    '',
+    ...summary.checks.map(
+      check =>
+        `- ${check.ok ? 'OK' : 'FAIL'} ${check.name} (${check.durationMs}ms): ${check.detail}`
+    ),
+    '',
+    `Recommendation: ${summary.recommendation}`,
+  ];
+  return lines.join('\n');
+}
+
+export function collectGBrainHealthSummary(options?: {
+  readonly exec?: GBrainExec;
+  readonly now?: Date;
+}): HealthSummary {
+  const exec = options?.exec ?? execFileSync;
+  const generatedAt = (options?.now ?? new Date()).toISOString();
+  const checks = [
+    timedCheck('doctor', () =>
+      statusFromDoctor(
+        exec(GBRAIN, ['doctor', '--fast', '--json'], {
+          encoding: 'utf8',
+          timeout: 30_000,
+          maxBuffer: 2 * 1024 * 1024,
+        })
+      )
+    ),
+    timedCheck('search', () => {
+      const out = exec(
+        GBRAIN,
+        ['search', 'gbrain health summary smoke', '--limit', '1'],
+        {
+          encoding: 'utf8',
+          timeout: 30_000,
+          maxBuffer: 2 * 1024 * 1024,
+        }
+      );
+      const found = out.trim().length > 0;
+      return {
+        ok: found,
+        detail: found ? 'search returned output' : 'empty output',
+      };
+    }),
+  ];
+
+  return buildGBrainHealthSummary({ generatedAt, checks });
+}
+
+export async function runGBrainHealthSummary(options?: {
+  readonly exec?: GBrainExec;
+  readonly learn?: typeof gbrainLearn;
+  readonly notify?: boolean;
+  readonly writeToGBrain?: boolean;
+  readonly notifyOps?: (text: string) => Promise<void>;
+  readonly now?: Date;
+}): Promise<{
+  readonly summary: HealthSummary;
+  readonly body: string;
+  readonly gbrainOk: boolean;
+}> {
+  const summary = collectGBrainHealthSummary({
+    exec: options?.exec,
+    now: options?.now,
+  });
+  const body = renderGBrainHealthSummary(summary);
+  const learn = options?.learn ?? gbrainLearn;
+  const gbrainOk =
+    options?.writeToGBrain === false
+      ? true
+      : learn({
+          slug: 'ops/gbrain-health/latest',
+          title: 'GBrain health summary (latest)',
+          body,
+          tags: [
+            'type:gbrain-health',
+            'area:memory',
+            `status:${summary.status}`,
+          ],
+          type: 'gbrain-health',
+        });
+
+  logJobEvent({
+    job: JOB,
+    event: 'summarized',
+    status: summary.status,
+    checks: summary.checks.map(check => ({
+      name: check.name,
+      ok: check.ok,
+      durationMs: check.durationMs,
+    })),
+    gbrainOk,
+    notified: options?.notify !== false,
+  });
+
+  if (options?.notify !== false) {
+    try {
+      await (options?.notifyOps ?? notifyOps)(body);
+    } catch (err) {
+      logJobEvent({
+        job: JOB,
+        event: 'notify-error',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { summary, body, gbrainOk };
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const run = await runGBrainHealthSummary();
+    process.stdout.write(`${run.body}\n`);
+    if (run.summary.status === 'down' || !run.gbrainOk) {
+      process.exitCode = 1;
+    }
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch(err => {
+    console.error(`[${JOB}] fatal:`, err);
+    process.exit(1);
+  });
+}

--- a/scripts/hermes/launchd/README.md
+++ b/scripts/hermes/launchd/README.md
@@ -20,6 +20,7 @@ The Hermes gateway itself is managed by the installed Hermes CLI as `ai.hermes.g
 | `co.jovie.hermes.cron-ci-monitor.plist.template` | every 10 min | Detect CI failures on main |
 | `co.jovie.hermes.cron-codex-issue-shipper.plist.template` | every 15 min | Claim one open GitHub issue labeled `codex` and dispatch a coder-profile agent |
 | `co.jovie.hermes.cron-pipeline-scoreboard.plist.template` | every 60 min | Write daily pipeline scoreboard to local state + gbrain, and alert on 12h shipper stalls |
+| `co.jovie.hermes.cron-gbrain-health-summary.plist.template` | 07:15 local daily | Probe gbrain, write latest health summary back to gbrain, and notify ops |
 | `co.jovie.hermes.cron-agent-config-health.plist.template` | every 15 min | Detect invalid Hermes/OpenClaw agent config before gateway churn |
 | `co.jovie.hermes.cron-cost-monitor.plist.template` | every 60 min | Cost kill switch |
 | `co.jovie.hermes.cron-daily-briefing.plist.template` | 07:00 daily | Morning briefing to Telegram |

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-gbrain-health-summary.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-gbrain-health-summary.plist.template
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-gbrain-health-summary</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/gbrain-health-summary.ts</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>7</integer>
+        <key>Minute</key>
+        <integer>15</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>HERMES_GBRAIN_BIN</key>
+        <string>{{GBRAIN_BIN}}</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.bun/bin:{{HOME}}/.hermes/bin:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-gbrain-health-summary.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-gbrain-health-summary.err.log</string>
+</dict>
+</plist>

--- a/scripts/lib/__tests__/gbrain-health-summary.test.mjs
+++ b/scripts/lib/__tests__/gbrain-health-summary.test.mjs
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildGBrainHealthSummary,
+  collectGBrainHealthSummary,
+  runGBrainHealthSummary,
+} from '../../hermes/jobs/gbrain-health-summary.ts';
+
+const generatedAt = '2026-07-04T10:00:00.000Z';
+const check = (name, ok, detail = 'ok') => ({
+  name,
+  ok,
+  detail,
+  durationMs: 1,
+});
+
+describe('gbrain health summary', () => {
+  it('classifies probe results', () => {
+    expect(
+      buildGBrainHealthSummary({
+        generatedAt,
+        checks: [check('doctor', true)],
+      }).status
+    ).toBe('healthy');
+    expect(
+      buildGBrainHealthSummary({
+        generatedAt,
+        checks: [check('doctor', true), check('search', false, 'timeout')],
+      }).status
+    ).toBe('degraded');
+    expect(buildGBrainHealthSummary({ generatedAt, checks: [] }).status).toBe(
+      'down'
+    );
+  });
+
+  it('handles healthy JSON, empty search, and command failures', () => {
+    const now = new Date(generatedAt);
+    const exec = (_file, args) =>
+      args[0] === 'doctor'
+        ? JSON.stringify({ status: 'ok', health_score: 0.95 })
+        : '';
+    const healthy = collectGBrainHealthSummary({ exec, now });
+    expect(healthy.status).toBe('degraded');
+    expect(healthy.checks[1].detail).toBe('empty output');
+
+    const down = collectGBrainHealthSummary({
+      exec: () => {
+        throw new Error('gbrain unavailable');
+      },
+      now,
+    });
+    expect(down.status).toBe('down');
+    expect(down.checks).toHaveLength(2);
+    expect(down.checks.every(result => !result.ok && result.detail)).toBe(true);
+  });
+
+  it('writes a stable gbrain page and notifies ops', async () => {
+    const learned = [];
+    const notifications = [];
+    const exec = (_file, args) =>
+      args[0] === 'doctor'
+        ? JSON.stringify({ status: 'ok', health_score: 0.91 })
+        : 'smoke result';
+    const run = await runGBrainHealthSummary({
+      exec,
+      learn: args => {
+        learned.push(args);
+        return true;
+      },
+      notifyOps: async text => {
+        notifications.push(text);
+      },
+      now: new Date(generatedAt),
+    });
+    expect(run.gbrainOk).toBe(true);
+    expect(learned[0]).toEqual(
+      expect.objectContaining({ slug: 'ops/gbrain-health/latest' })
+    );
+    expect(notifications[0]).toContain('GBrain health summary: healthy');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Hermes-Air `gbrain-health-summary` job that probes `gbrain doctor` and a bounded search smoke, writes `ops/gbrain-health/latest`, and notifies ops through the existing Telegram/Slack helper.
- Add the launchd template, package script, runbook/cron registry entries, and a compact spike covering connector candidates plus proposed knowledge-compounding jobs.
- Cover healthy, degraded, down, write, and notification paths with focused script tests.

## Cost Impact
- **External API calls**: 0 new external calls in the starter job. The job uses local `gbrain` CLI calls and existing ops notification helpers.
- **Monthly projection**: ~60 local gbrain CLI calls/month at daily cadence (2 calls/run x ~30 runs/month).
- **Scaling factor**: O(1) per run.
- **Monthly cost estimate**: $0 for the starter job. Proposed Web/Exa research remains documented only and requires an explicit provider budget before enabling.

## Verification
- `pnpm install --frozen-lockfile` — passed
- `pnpm biome check --write scripts/hermes/jobs/gbrain-health-summary.ts scripts/lib/__tests__/gbrain-health-summary.test.mjs docs/spikes/gbrain-knowledge-compounding.md docs/CRON_REGISTRY.md docs/HERMES_AIR.md scripts/hermes/launchd/README.md package.json` — passed, `Checked 3 files ... No fixes applied`
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/gbrain-health-summary.test.mjs lib/__tests__/agent-config-health.test.mjs lib/__tests__/pipeline-scoreboard.test.mjs` — passed, `Test Files 3 passed (3); Tests 22 passed (22)`
- `pnpm run typecheck` — passed, `Tasks: 3 successful, 3 total`
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- Runtime healthy smoke with fake `gbrain` — passed; output included `GBrain health summary: healthy` and `search returned output` without echoing the fake sensitive search payload
- Runtime failure smoke with `HERMES_GBRAIN_BIN=/usr/bin/false` — passed; output included `GBrain health summary: down` and `failure_exit=1`
- `git diff --check` — passed
- Pre-push hook — passed: Biome changed-files check, `next:proxy-guard`, `tailwind:check`, and web typecheck
- Secret scans in pre-commit — passed: gitleaks and TruffleHog reported no findings

## CodeRabbit
- Ran `coderabbit review --agent -c AGENTS.md -t uncommitted` repeatedly after quota delays.
- Fixed valid findings: notification failures are logged separately after `summarized`, docs use `ops/gbrain-health/latest`, runbook avoids rerunning the side-effecting job for status checks, stderr log is included, fallback doctor parsing handles negative phrases, empty search degrades, and launchd schedule wording matches the registry.
- Skipped two final findings as not applicable: Hermes local jobs follow existing `process.env.HERMES_GBRAIN_BIN` pattern rather than app `lib/env.ts`, and notification failures should not turn a healthy gbrain summary into a false gbrain-health failure.

Fixes #13048
