### PR TITLE
feat(hud): add read-only company wiki at /hud/wiki backed by gbrain

### DIFF
--- a/apps/web/app/hud/wiki/[...slug]/page.tsx
+++ b/apps/web/app/hud/wiki/[...slug]/page.tsx
@@ -1,8 +1,10 @@
 import { notFound } from 'next/navigation';
-import { getCurrentAdminPageAccess, redirectToLogin } from '@/lib/getCurrentAdminPageAccess';
-import { getPage } from '@/lib/wiki/gbrain-client';
-import { titleFromSlug } from '@/lib/wiki/format';
 import { WikiPageArticle } from '@/components/features/admin/wiki/WikiPageArticle';
+import {
+  getCurrentAdminPageAccess,
+  redirectToLogin,
+} from '@/lib/getCurrentAdminPageAccess';
+import { getPage } from '@/lib/wiki/gbrain-client';
 
 interface Props {
   params: Promise<{ slug: string[] }>;
@@ -19,7 +21,7 @@ export default async function WikiPageView({ params }: Props) {
   if (!page || !page.compiled_truth) notFound();
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
+    <div className='mx-auto max-w-4xl px-4 py-8'>
       <WikiPageArticle page={page} />
     </div>
   );

--- a/apps/web/app/hud/wiki/[...slug]/page.tsx
+++ b/apps/web/app/hud/wiki/[...slug]/page.tsx
@@ -3,7 +3,7 @@ import { WikiPageArticle } from '@/components/features/admin/wiki/WikiPageArticl
 import {
   getCurrentAdminPageAccess,
   redirectToLogin,
-} from '@/lib/getCurrentAdminPageAccess';
+} from '@/lib/admin/page-access';
 import { getPage } from '@/lib/wiki/gbrain-client';
 
 interface Props {

--- a/apps/web/app/hud/wiki/[...slug]/page.tsx
+++ b/apps/web/app/hud/wiki/[...slug]/page.tsx
@@ -1,0 +1,26 @@
+import { notFound } from 'next/navigation';
+import { getCurrentAdminPageAccess, redirectToLogin } from '@/lib/getCurrentAdminPageAccess';
+import { getPage } from '@/lib/wiki/gbrain-client';
+import { titleFromSlug } from '@/lib/wiki/format';
+import { WikiPageArticle } from '@/components/features/admin/wiki/WikiPageArticle';
+
+interface Props {
+  params: Promise<{ slug: string[] }>;
+}
+
+export default async function WikiPageView({ params }: Props) {
+  const access = await getCurrentAdminPageAccess();
+  if (!access.isAdmin) redirectToLogin();
+
+  const { slug: slugParts } = await params;
+  const slug = slugParts.join('/');
+
+  const page = await getPage(slug);
+  if (!page || !page.compiled_truth) notFound();
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <WikiPageArticle page={page} />
+    </div>
+  );
+}

--- a/apps/web/app/hud/wiki/[...slug]/page.tsx
+++ b/apps/web/app/hud/wiki/[...slug]/page.tsx
@@ -1,9 +1,6 @@
-import { notFound } from 'next/navigation';
+import { forbidden, notFound, unauthorized } from 'next/navigation';
 import { WikiPageArticle } from '@/components/features/admin/wiki/WikiPageArticle';
-import {
-  getCurrentAdminPageAccess,
-  redirectToLogin,
-} from '@/lib/admin/page-access';
+import { getCurrentAdminPageAccess } from '@/lib/admin/page-access';
 import { getPage } from '@/lib/wiki/gbrain-client';
 
 interface Props {
@@ -12,7 +9,8 @@ interface Props {
 
 export default async function WikiPageView({ params }: Props) {
   const access = await getCurrentAdminPageAccess();
-  if (!access.isAdmin) redirectToLogin();
+  if (!access.isAuthenticated) unauthorized();
+  if (!access.hasAdminRole) forbidden();
 
   const { slug: slugParts } = await params;
   const slug = slugParts.join('/');

--- a/apps/web/app/hud/wiki/page.tsx
+++ b/apps/web/app/hud/wiki/page.tsx
@@ -1,0 +1,43 @@
+import { getCurrentAdminPageAccess, redirectToLogin } from '@/lib/getCurrentAdminPageAccess';
+import { listPages, searchPages } from '@/lib/wiki/gbrain-client';
+import { groupByNamespace } from '@/lib/wiki/namespace';
+import { WikiSearchForm } from '@/components/features/admin/wiki/WikiSearchForm';
+import { WikiSearchResults } from '@/components/features/admin/wiki/WikiSearchResults';
+import { WikiNamespaceSection } from '@/components/features/admin/wiki/WikiNamespaceSection';
+import { WikiUnavailableNotice } from '@/components/features/admin/wiki/WikiUnavailableNotice';
+
+interface Props {
+  searchParams: Promise<{ q?: string }>;
+}
+
+export default async function WikiIndexPage({ searchParams }: Props) {
+  const access = await getCurrentAdminPageAccess();
+  if (!access.isAdmin) redirectToLogin();
+
+  const { q } = await searchParams;
+  const hasQuery = typeof q === 'string' && q.trim().length > 0;
+
+  const pages = hasQuery
+    ? await searchPages(q.trim())
+    : await listPages();
+
+  const noBackend = hasQuery ? false : pages.length === 0;
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold tracking-tight">Company Wiki</h1>
+      <WikiSearchForm initialQuery={q} />
+      {noBackend ? (
+        <WikiUnavailableNotice />
+      ) : hasQuery ? (
+        <WikiSearchResults results={pages} query={q || ''} />
+      ) : (
+        <div className="mt-6 space-y-8">
+          {groupByNamespace(pages).map(group => (
+            <WikiNamespaceSection key={group.namespace} group={group} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/hud/wiki/page.tsx
+++ b/apps/web/app/hud/wiki/page.tsx
@@ -1,10 +1,13 @@
-import { getCurrentAdminPageAccess, redirectToLogin } from '@/lib/getCurrentAdminPageAccess';
-import { listPages, searchPages } from '@/lib/wiki/gbrain-client';
-import { groupByNamespace } from '@/lib/wiki/namespace';
+import { WikiNamespaceSection } from '@/components/features/admin/wiki/WikiNamespaceSection';
 import { WikiSearchForm } from '@/components/features/admin/wiki/WikiSearchForm';
 import { WikiSearchResults } from '@/components/features/admin/wiki/WikiSearchResults';
-import { WikiNamespaceSection } from '@/components/features/admin/wiki/WikiNamespaceSection';
 import { WikiUnavailableNotice } from '@/components/features/admin/wiki/WikiUnavailableNotice';
+import {
+  getCurrentAdminPageAccess,
+  redirectToLogin,
+} from '@/lib/getCurrentAdminPageAccess';
+import { listPages, searchPages } from '@/lib/wiki/gbrain-client';
+import { groupByNamespace } from '@/lib/wiki/namespace';
 
 interface Props {
   searchParams: Promise<{ q?: string }>;
@@ -17,22 +20,20 @@ export default async function WikiIndexPage({ searchParams }: Props) {
   const { q } = await searchParams;
   const hasQuery = typeof q === 'string' && q.trim().length > 0;
 
-  const pages = hasQuery
-    ? await searchPages(q.trim())
-    : await listPages();
+  const pages = hasQuery ? await searchPages(q.trim()) : await listPages();
 
   const noBackend = hasQuery ? false : pages.length === 0;
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
-      <h1 className="mb-6 text-2xl font-bold tracking-tight">Company Wiki</h1>
+    <div className='mx-auto max-w-4xl px-4 py-8'>
+      <h1 className='mb-6 text-2xl font-bold tracking-tight'>Company Wiki</h1>
       <WikiSearchForm initialQuery={q} />
       {noBackend ? (
         <WikiUnavailableNotice />
       ) : hasQuery ? (
         <WikiSearchResults results={pages} query={q || ''} />
       ) : (
-        <div className="mt-6 space-y-8">
+        <div className='mt-6 space-y-8'>
           {groupByNamespace(pages).map(group => (
             <WikiNamespaceSection key={group.namespace} group={group} />
           ))}

--- a/apps/web/app/hud/wiki/page.tsx
+++ b/apps/web/app/hud/wiki/page.tsx
@@ -1,11 +1,9 @@
+import { forbidden, unauthorized } from 'next/navigation';
 import { WikiNamespaceSection } from '@/components/features/admin/wiki/WikiNamespaceSection';
 import { WikiSearchForm } from '@/components/features/admin/wiki/WikiSearchForm';
 import { WikiSearchResults } from '@/components/features/admin/wiki/WikiSearchResults';
 import { WikiUnavailableNotice } from '@/components/features/admin/wiki/WikiUnavailableNotice';
-import {
-  getCurrentAdminPageAccess,
-  redirectToLogin,
-} from '@/lib/admin/page-access';
+import { getCurrentAdminPageAccess } from '@/lib/admin/page-access';
 import { listPages, searchPages } from '@/lib/wiki/gbrain-client';
 import { groupByNamespace } from '@/lib/wiki/namespace';
 
@@ -15,7 +13,8 @@ interface Props {
 
 export default async function WikiIndexPage({ searchParams }: Props) {
   const access = await getCurrentAdminPageAccess();
-  if (!access.isAdmin) redirectToLogin();
+  if (!access.isAuthenticated) unauthorized();
+  if (!access.hasAdminRole) forbidden();
 
   const { q } = await searchParams;
   const hasQuery = typeof q === 'string' && q.trim().length > 0;

--- a/apps/web/app/hud/wiki/page.tsx
+++ b/apps/web/app/hud/wiki/page.tsx
@@ -5,7 +5,7 @@ import { WikiUnavailableNotice } from '@/components/features/admin/wiki/WikiUnav
 import {
   getCurrentAdminPageAccess,
   redirectToLogin,
-} from '@/lib/getCurrentAdminPageAccess';
+} from '@/lib/admin/page-access';
 import { listPages, searchPages } from '@/lib/wiki/gbrain-client';
 import { groupByNamespace } from '@/lib/wiki/namespace';
 

--- a/apps/web/components/features/admin/wiki/WikiNamespaceSection.tsx
+++ b/apps/web/components/features/admin/wiki/WikiNamespaceSection.tsx
@@ -1,0 +1,26 @@
+import type { NamespaceGroup } from '@/lib/wiki/namespace';
+import { slugToHref, titleFromSlug } from '@/lib/wiki/format';
+
+interface Props { group: NamespaceGroup }
+
+export function WikiNamespaceSection({ group }: Props) {
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-semibold capitalize text-gray-700 dark:text-gray-300">
+        {group.namespace}
+      </h2>
+      <ul className="space-y-1">
+        {group.pages.map(page => (
+          <li key={page.slug}>
+            <a
+              href={slugToHref(page.slug)}
+              className="block rounded-md px-3 py-1.5 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-gray-800"
+            >
+              {page.title || titleFromSlug(page.slug)}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/features/admin/wiki/WikiNamespaceSection.tsx
+++ b/apps/web/components/features/admin/wiki/WikiNamespaceSection.tsx
@@ -1,20 +1,22 @@
-import type { NamespaceGroup } from '@/lib/wiki/namespace';
 import { slugToHref, titleFromSlug } from '@/lib/wiki/format';
+import type { NamespaceGroup } from '@/lib/wiki/namespace';
 
-interface Props { group: NamespaceGroup }
+interface Props {
+  group: NamespaceGroup;
+}
 
 export function WikiNamespaceSection({ group }: Props) {
   return (
     <section>
-      <h2 className="mb-3 text-lg font-semibold capitalize text-gray-700 dark:text-gray-300">
+      <h2 className='mb-3 text-lg font-semibold capitalize text-gray-700 dark:text-gray-300'>
         {group.namespace}
       </h2>
-      <ul className="space-y-1">
+      <ul className='space-y-1'>
         {group.pages.map(page => (
           <li key={page.slug}>
             <a
               href={slugToHref(page.slug)}
-              className="block rounded-md px-3 py-1.5 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-gray-800"
+              className='block rounded-md px-3 py-1.5 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-gray-800'
             >
               {page.title || titleFromSlug(page.slug)}
             </a>

--- a/apps/web/components/features/admin/wiki/WikiPageArticle.tsx
+++ b/apps/web/components/features/admin/wiki/WikiPageArticle.tsx
@@ -1,24 +1,22 @@
-import { LegalMarkdownReader } from '@/components/legal/LegalMarkdownReader';
-import { createMarkdownDocument } from '@/lib/content/markdown';
+import { createMarkdownDocument } from '@/lib/docs/getMarkdownDocument';
+import { LegalMarkdownReader } from '@/components/molecules/LegalMarkdownReader';
 
 interface Props {
-  page: { slug: string; title: string; compiled_truth?: string };
+  readonly page: { readonly slug: string; readonly title: string; readonly compiled_truth?: string };
 }
 
-export function WikiPageArticle({ page }: Props) {
+export async function WikiPageArticle({ page }: Props) {
   const document = page.compiled_truth
-    ? createMarkdownDocument(page.compiled_truth)
+    ? await createMarkdownDocument(page.compiled_truth)
     : null;
 
   return (
     <article>
-      <h1 className='mb-6 text-2xl font-bold tracking-tight'>{page.title}</h1>
+      <h1 className="mb-6 text-2xl font-bold tracking-tight">{page.title}</h1>
       {document ? (
-        <LegalMarkdownReader document={document} />
+        <LegalMarkdownReader html={document.html} />
       ) : (
-        <p className='text-gray-500 dark:text-gray-400'>
-          This wiki page has no content.
-        </p>
+        <p className="text-gray-500 dark:text-gray-400">This wiki page has no content.</p>
       )}
     </article>
   );

--- a/apps/web/components/features/admin/wiki/WikiPageArticle.tsx
+++ b/apps/web/components/features/admin/wiki/WikiPageArticle.tsx
@@ -1,5 +1,5 @@
-import { createMarkdownDocument } from '@/lib/content/markdown';
 import { LegalMarkdownReader } from '@/components/legal/LegalMarkdownReader';
+import { createMarkdownDocument } from '@/lib/content/markdown';
 
 interface Props {
   page: { slug: string; title: string; compiled_truth?: string };
@@ -12,11 +12,13 @@ export function WikiPageArticle({ page }: Props) {
 
   return (
     <article>
-      <h1 className="mb-6 text-2xl font-bold tracking-tight">{page.title}</h1>
+      <h1 className='mb-6 text-2xl font-bold tracking-tight'>{page.title}</h1>
       {document ? (
         <LegalMarkdownReader document={document} />
       ) : (
-        <p className="text-gray-500 dark:text-gray-400">This wiki page has no content.</p>
+        <p className='text-gray-500 dark:text-gray-400'>
+          This wiki page has no content.
+        </p>
       )}
     </article>
   );

--- a/apps/web/components/features/admin/wiki/WikiPageArticle.tsx
+++ b/apps/web/components/features/admin/wiki/WikiPageArticle.tsx
@@ -1,8 +1,12 @@
-import { createMarkdownDocument } from '@/lib/docs/getMarkdownDocument';
 import { LegalMarkdownReader } from '@/components/molecules/LegalMarkdownReader';
+import { createMarkdownDocument } from '@/lib/docs/getMarkdownDocument';
 
 interface Props {
-  readonly page: { readonly slug: string; readonly title: string; readonly compiled_truth?: string };
+  readonly page: {
+    readonly slug: string;
+    readonly title: string;
+    readonly compiled_truth?: string;
+  };
 }
 
 export async function WikiPageArticle({ page }: Props) {
@@ -12,11 +16,13 @@ export async function WikiPageArticle({ page }: Props) {
 
   return (
     <article>
-      <h1 className="mb-6 text-2xl font-bold tracking-tight">{page.title}</h1>
+      <h1 className='mb-6 text-2xl font-bold tracking-tight'>{page.title}</h1>
       {document ? (
         <LegalMarkdownReader html={document.html} />
       ) : (
-        <p className="text-gray-500 dark:text-gray-400">This wiki page has no content.</p>
+        <p className='text-gray-500 dark:text-gray-400'>
+          This wiki page has no content.
+        </p>
       )}
     </article>
   );

--- a/apps/web/components/features/admin/wiki/WikiPageArticle.tsx
+++ b/apps/web/components/features/admin/wiki/WikiPageArticle.tsx
@@ -1,0 +1,23 @@
+import { createMarkdownDocument } from '@/lib/content/markdown';
+import { LegalMarkdownReader } from '@/components/legal/LegalMarkdownReader';
+
+interface Props {
+  page: { slug: string; title: string; compiled_truth?: string };
+}
+
+export function WikiPageArticle({ page }: Props) {
+  const document = page.compiled_truth
+    ? createMarkdownDocument(page.compiled_truth)
+    : null;
+
+  return (
+    <article>
+      <h1 className="mb-6 text-2xl font-bold tracking-tight">{page.title}</h1>
+      {document ? (
+        <LegalMarkdownReader document={document} />
+      ) : (
+        <p className="text-gray-500 dark:text-gray-400">This wiki page has no content.</p>
+      )}
+    </article>
+  );
+}

--- a/apps/web/components/features/admin/wiki/WikiSearchForm.tsx
+++ b/apps/web/components/features/admin/wiki/WikiSearchForm.tsx
@@ -1,14 +1,16 @@
-interface Props { initialQuery?: string }
+interface Props {
+  initialQuery?: string;
+}
 
 export function WikiSearchForm({ initialQuery }: Props) {
   return (
-    <form action="/hud/wiki" method="GET" className="mb-6">
+    <form action='/hud/wiki' method='GET' className='mb-6'>
       <input
-        type="search"
-        name="q"
+        type='search'
+        name='q'
         defaultValue={initialQuery || ''}
-        placeholder="Search wiki..."
-        className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        placeholder='Search wiki...'
+        className='w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white'
       />
     </form>
   );

--- a/apps/web/components/features/admin/wiki/WikiSearchForm.tsx
+++ b/apps/web/components/features/admin/wiki/WikiSearchForm.tsx
@@ -1,0 +1,15 @@
+interface Props { initialQuery?: string }
+
+export function WikiSearchForm({ initialQuery }: Props) {
+  return (
+    <form action="/hud/wiki" method="GET" className="mb-6">
+      <input
+        type="search"
+        name="q"
+        defaultValue={initialQuery || ''}
+        placeholder="Search wiki..."
+        className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+      />
+    </form>
+  );
+}

--- a/apps/web/components/features/admin/wiki/WikiSearchResults.tsx
+++ b/apps/web/components/features/admin/wiki/WikiSearchResults.tsx
@@ -1,0 +1,31 @@
+import { slugToHref, titleFromSlug } from '@/lib/wiki/format';
+
+interface Props {
+  results: { slug: string; title: string; score?: number; chunk_text?: string }[];
+  query: string;
+}
+
+export function WikiSearchResults({ results, query }: Props) {
+  return (
+    <div className="mt-6">
+      <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        {results.length} result{results.length !== 1 ? 's' : ''} for "{query}"
+      </p>
+      <ul className="space-y-3">
+        {results.map(r => (
+          <li key={r.slug} className="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+            <a
+              href={slugToHref(r.slug)}
+              className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {r.title || titleFromSlug(r.slug)}
+            </a>
+            {r.chunk_text && (
+              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 line-clamp-2">{r.chunk_text}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/components/features/admin/wiki/WikiSearchResults.tsx
+++ b/apps/web/components/features/admin/wiki/WikiSearchResults.tsx
@@ -1,27 +1,37 @@
 import { slugToHref, titleFromSlug } from '@/lib/wiki/format';
 
 interface Props {
-  results: { slug: string; title: string; score?: number; chunk_text?: string }[];
+  results: {
+    slug: string;
+    title: string;
+    score?: number;
+    chunk_text?: string;
+  }[];
   query: string;
 }
 
 export function WikiSearchResults({ results, query }: Props) {
   return (
-    <div className="mt-6">
-      <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+    <div className='mt-6'>
+      <p className='mb-4 text-sm text-gray-500 dark:text-gray-400'>
         {results.length} result{results.length !== 1 ? 's' : ''} for "{query}"
       </p>
-      <ul className="space-y-3">
+      <ul className='space-y-3'>
         {results.map(r => (
-          <li key={r.slug} className="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+          <li
+            key={r.slug}
+            className='rounded-lg border border-gray-200 p-3 dark:border-gray-700'
+          >
             <a
               href={slugToHref(r.slug)}
-              className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+              className='font-medium text-blue-600 hover:underline dark:text-blue-400'
             >
               {r.title || titleFromSlug(r.slug)}
             </a>
             {r.chunk_text && (
-              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 line-clamp-2">{r.chunk_text}</p>
+              <p className='mt-1 text-sm text-gray-600 dark:text-gray-400 line-clamp-2'>
+                {r.chunk_text}
+              </p>
             )}
           </li>
         ))}

--- a/apps/web/components/features/admin/wiki/WikiUnavailableNotice.tsx
+++ b/apps/web/components/features/admin/wiki/WikiUnavailableNotice.tsx
@@ -1,0 +1,12 @@
+export function WikiUnavailableNotice() {
+  return (
+    <div className="mt-12 text-center">
+      <p className="text-lg text-gray-500 dark:text-gray-400">
+        Wiki source not configured.
+      </p>
+      <p className="mt-2 text-sm text-gray-400 dark:text-gray-500">
+        Set <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">GBRAIN_API_KEY</code> to enable the company wiki.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/features/admin/wiki/WikiUnavailableNotice.tsx
+++ b/apps/web/components/features/admin/wiki/WikiUnavailableNotice.tsx
@@ -1,11 +1,15 @@
 export function WikiUnavailableNotice() {
   return (
-    <div className="mt-12 text-center">
-      <p className="text-lg text-gray-500 dark:text-gray-400">
+    <div className='mt-12 text-center'>
+      <p className='text-lg text-gray-500 dark:text-gray-400'>
         Wiki source not configured.
       </p>
-      <p className="mt-2 text-sm text-gray-400 dark:text-gray-500">
-        Set <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">GBRAIN_API_KEY</code> to enable the company wiki.
+      <p className='mt-2 text-sm text-gray-400 dark:text-gray-500'>
+        Set{' '}
+        <code className='rounded bg-gray-100 px-1 dark:bg-gray-800'>
+          GBRAIN_API_KEY
+        </code>{' '}
+        to enable the company wiki.
       </p>
     </div>
   );

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -255,7 +255,8 @@ export function buildLibraryViewRoute(
   return `${APP_ROUTES.LIBRARY}?view=${encodeURIComponent(view)}`;
 }
 
-export const buildWikiPageHref = (slug: string) => `${APP_ROUTES.HUD_WIKI}/${encodeURIComponent(slug)}` as const;
+export const buildWikiPageHref = (slug: string) =>
+  `${APP_ROUTES.HUD_WIKI}/${encodeURIComponent(slug)}` as const;
 
 export function isDemoRoutePath(pathname: string | null | undefined): boolean {
   return (

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -123,6 +123,7 @@ export const APP_ROUTES = {
   HUD: '/hud',
   /** Token-only TV/wallboard view of the Ops HUD. */
   HUD_TV: '/hud-tv',
+  HUD_WIKI: '/hud/wiki' as const,
 
   // Marketing
   HOME: '/',
@@ -253,6 +254,8 @@ export function buildLibraryViewRoute(
 
   return `${APP_ROUTES.LIBRARY}?view=${encodeURIComponent(view)}`;
 }
+
+export const buildWikiPageHref = (slug: string) => `${APP_ROUTES.HUD_WIKI}/${encodeURIComponent(slug)}` as const;
 
 export function isDemoRoutePath(pathname: string | null | undefined): boolean {
   return (

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -168,6 +168,8 @@ export const ServerEnvSchema = z.object({
   HUD_GITHUB_OWNER: z.string().optional(),
   HUD_GITHUB_REPO: z.string().optional(),
   HUD_GITHUB_WORKFLOW: z.string().optional(),
+  GBRAIN_API_URL: z.string().optional(),
+  GBRAIN_API_KEY: z.string().optional(),
 
   // Revalidation
   REVALIDATE_SECRET: z.string().optional(),
@@ -450,6 +452,8 @@ export const ENV_KEYS = [
   'HUD_GITHUB_OWNER',
   'HUD_GITHUB_REPO',
   'HUD_GITHUB_WORKFLOW',
+  'GBRAIN_API_URL',
+  'GBRAIN_API_KEY',
   'REVALIDATE_SECRET',
   'APPLE_MUSIC_KEY_ID',
   'APPLE_MUSIC_TEAM_ID',

--- a/apps/web/lib/wiki/format.ts
+++ b/apps/web/lib/wiki/format.ts
@@ -1,0 +1,10 @@
+export function titleFromSlug(slug: string): string {
+  const parts = slug.split('/');
+  return parts[parts.length - 1]
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+export function slugToHref(slug: string): string {
+  return `/hud/wiki/${encodeURIComponent(slug)}`;
+}

--- a/apps/web/lib/wiki/gbrain-client.ts
+++ b/apps/web/lib/wiki/gbrain-client.ts
@@ -1,4 +1,4 @@
-import { env } from '@/env-server-schema';
+import { env } from '@/lib/env-server';
 
 interface McpRequest {
   jsonrpc: '2.0';

--- a/apps/web/lib/wiki/gbrain-client.ts
+++ b/apps/web/lib/wiki/gbrain-client.ts
@@ -17,7 +17,10 @@ interface McpResponse {
   error?: { code: number; message: string };
 }
 
-async function mcpCall<T>(method: string, params: Record<string, unknown>): Promise<{ ok: true; data: T } | { ok: false; reason: string }> {
+async function mcpCall<T>(
+  method: string,
+  params: Record<string, unknown>
+): Promise<{ ok: true; data: T } | { ok: false; reason: string }> {
   const apiUrl = env.GBRAIN_API_URL || 'http://127.0.0.1:7801';
   const apiKey = env.GBRAIN_API_KEY;
 
@@ -37,8 +40,8 @@ async function mcpCall<T>(method: string, params: Record<string, unknown>): Prom
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-        'Accept': 'application/json, text/event-stream',
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json, text/event-stream',
       },
       body: JSON.stringify(request),
       cache: 'no-store',
@@ -51,7 +54,10 @@ async function mcpCall<T>(method: string, params: Record<string, unknown>): Prom
     const mcpResponse: McpResponse = JSON.parse(jsonStr);
 
     if (mcpResponse.error) {
-      return { ok: false, reason: `gbrain error: ${mcpResponse.error.message}` };
+      return {
+        ok: false,
+        reason: `gbrain error: ${mcpResponse.error.message}`,
+      };
     }
 
     const contentBlock = mcpResponse.result?.content?.[0];
@@ -66,7 +72,10 @@ async function mcpCall<T>(method: string, params: Record<string, unknown>): Prom
     const parsed = JSON.parse(contentBlock.text);
     return { ok: true, data: parsed as T };
   } catch (e) {
-    return { ok: false, reason: `gbrain unreachable: ${e instanceof Error ? e.message : 'unknown error'}` };
+    return {
+      ok: false,
+      reason: `gbrain unreachable: ${e instanceof Error ? e.message : 'unknown error'}`,
+    };
   }
 }
 
@@ -79,20 +88,47 @@ export interface GbrainPage {
   tags?: string[];
 }
 
-export async function listPages(limit = 50, sort = 'updated_desc'): Promise<{ slug: string; title: string; type?: string; updated_at?: string; tags?: string[] }[]> {
+export async function listPages(
+  limit = 50,
+  sort = 'updated_desc'
+): Promise<
+  {
+    slug: string;
+    title: string;
+    type?: string;
+    updated_at?: string;
+    tags?: string[];
+  }[]
+> {
   const result = await mcpCall<GbrainPage[]>('page/list', { limit, sort });
   if (!result.ok) return [];
   return result.data;
 }
 
-export async function getPage(slug: string): Promise<{ slug: string; title: string; compiled_truth?: string } | null> {
-  const result = await mcpCall<GbrainPage>('page/get', { slug, include_compiled_truth: true });
+export async function getPage(
+  slug: string
+): Promise<{ slug: string; title: string; compiled_truth?: string } | null> {
+  const result = await mcpCall<GbrainPage>('page/get', {
+    slug,
+    include_compiled_truth: true,
+  });
   if (!result.ok) return null;
-  return { slug: result.data.slug, title: result.data.title, compiled_truth: result.data.compiled_truth };
+  return {
+    slug: result.data.slug,
+    title: result.data.title,
+    compiled_truth: result.data.compiled_truth,
+  };
 }
 
-export async function searchPages(query: string, limit = 20): Promise<{ slug: string; title: string; score?: number; chunk_text?: string }[]> {
-  const result = await mcpCall<Array<{ slug: string; title: string; score?: number; chunk_text?: string }>>('search/query', { query, limit });
+export async function searchPages(
+  query: string,
+  limit = 20
+): Promise<
+  { slug: string; title: string; score?: number; chunk_text?: string }[]
+> {
+  const result = await mcpCall<
+    Array<{ slug: string; title: string; score?: number; chunk_text?: string }>
+  >('search/query', { query, limit });
   if (!result.ok) return [];
   return result.data;
 }

--- a/apps/web/lib/wiki/gbrain-client.ts
+++ b/apps/web/lib/wiki/gbrain-client.ts
@@ -1,0 +1,98 @@
+import { env } from '@/env-server-schema';
+
+interface McpRequest {
+  jsonrpc: '2.0';
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+interface McpResponse {
+  jsonrpc: '2.0';
+  id: string;
+  result?: {
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  };
+  error?: { code: number; message: string };
+}
+
+async function mcpCall<T>(method: string, params: Record<string, unknown>): Promise<{ ok: true; data: T } | { ok: false; reason: string }> {
+  const apiUrl = env.GBRAIN_API_URL || 'http://127.0.0.1:7801';
+  const apiKey = env.GBRAIN_API_KEY;
+
+  if (!apiKey) {
+    return { ok: false, reason: 'GBRAIN_API_KEY not configured' };
+  }
+
+  try {
+    const request: McpRequest = {
+      jsonrpc: '2.0',
+      id: crypto.randomUUID(),
+      method,
+      params,
+    };
+
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+        'Accept': 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(request),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(8000),
+    });
+
+    const raw = await response.text();
+    const lines = raw.split('\n').filter(l => l.startsWith('data: '));
+    const jsonStr = lines.map(l => l.slice(6)).join('');
+    const mcpResponse: McpResponse = JSON.parse(jsonStr);
+
+    if (mcpResponse.error) {
+      return { ok: false, reason: `gbrain error: ${mcpResponse.error.message}` };
+    }
+
+    const contentBlock = mcpResponse.result?.content?.[0];
+    if (!contentBlock) {
+      return { ok: false, reason: 'empty gbrain response' };
+    }
+
+    if (mcpResponse.result?.isError) {
+      return { ok: false, reason: `gbrain error: ${contentBlock.text}` };
+    }
+
+    const parsed = JSON.parse(contentBlock.text);
+    return { ok: true, data: parsed as T };
+  } catch (e) {
+    return { ok: false, reason: `gbrain unreachable: ${e instanceof Error ? e.message : 'unknown error'}` };
+  }
+}
+
+export interface GbrainPage {
+  slug: string;
+  title: string;
+  compiled_truth?: string;
+  type?: string;
+  updated_at?: string;
+  tags?: string[];
+}
+
+export async function listPages(limit = 50, sort = 'updated_desc'): Promise<{ slug: string; title: string; type?: string; updated_at?: string; tags?: string[] }[]> {
+  const result = await mcpCall<GbrainPage[]>('page/list', { limit, sort });
+  if (!result.ok) return [];
+  return result.data;
+}
+
+export async function getPage(slug: string): Promise<{ slug: string; title: string; compiled_truth?: string } | null> {
+  const result = await mcpCall<GbrainPage>('page/get', { slug, include_compiled_truth: true });
+  if (!result.ok) return null;
+  return { slug: result.data.slug, title: result.data.title, compiled_truth: result.data.compiled_truth };
+}
+
+export async function searchPages(query: string, limit = 20): Promise<{ slug: string; title: string; score?: number; chunk_text?: string }[]> {
+  const result = await mcpCall<Array<{ slug: string; title: string; score?: number; chunk_text?: string }>>('search/query', { query, limit });
+  if (!result.ok) return [];
+  return result.data;
+}

--- a/apps/web/lib/wiki/namespace.ts
+++ b/apps/web/lib/wiki/namespace.ts
@@ -1,0 +1,21 @@
+import type { GbrainPage } from './gbrain-client';
+
+export interface NamespaceGroup {
+  namespace: string;
+  pages: { slug: string; title: string; updated_at?: string; tags?: string[] }[];
+}
+
+export function groupByNamespace(pages: { slug: string; title: string; updated_at?: string; tags?: string[] }[]): NamespaceGroup[] {
+  const groups = new Map<string, NamespaceGroup>();
+
+  for (const page of pages) {
+    const lastSlash = page.slug.lastIndexOf('/');
+    const namespace = lastSlash > 0 ? page.slug.slice(0, lastSlash) : 'other';
+    if (!groups.has(namespace)) {
+      groups.set(namespace, { namespace, pages: [] });
+    }
+    groups.get(namespace)!.pages.push(page);
+  }
+
+  return Array.from(groups.values()).sort((a, b) => a.namespace.localeCompare(b.namespace));
+}

--- a/apps/web/lib/wiki/namespace.ts
+++ b/apps/web/lib/wiki/namespace.ts
@@ -1,11 +1,16 @@
-import type { GbrainPage } from './gbrain-client';
-
 export interface NamespaceGroup {
   namespace: string;
-  pages: { slug: string; title: string; updated_at?: string; tags?: string[] }[];
+  pages: {
+    slug: string;
+    title: string;
+    updated_at?: string;
+    tags?: string[];
+  }[];
 }
 
-export function groupByNamespace(pages: { slug: string; title: string; updated_at?: string; tags?: string[] }[]): NamespaceGroup[] {
+export function groupByNamespace(
+  pages: { slug: string; title: string; updated_at?: string; tags?: string[] }[]
+): NamespaceGroup[] {
   const groups = new Map<string, NamespaceGroup>();
 
   for (const page of pages) {
@@ -17,5 +22,7 @@ export function groupByNamespace(pages: { slug: string; title: string; updated_a
     groups.get(namespace)!.pages.push(page);
   }
 
-  return Array.from(groups.values()).sort((a, b) => a.namespace.localeCompare(b.namespace));
+  return Array.from(groups.values()).sort((a, b) =>
+    a.namespace.localeCompare(b.namespace)
+  );
 }


### PR DESCRIPTION
Closes #13013 (Phase 1 — read-only)

- /hud/wiki index with namespace-grouped page listing + ?q= search
- /hud/wiki/[...slug] individual page view with markdown rendering
- Admin-gated via getCurrentAdminPageAccess() (same as /hud)
- Graceful degrade when gbrain not configured
- 12 files, 312 insertions