### PR TITLE
fix: add fallback text to 3 buttons to prevent blank-button bug

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -798,7 +798,7 @@ function LibrarySavedViewRow({
       )}
     >
       <button type='button' onClick={onClick} aria-pressed={active}>
-        <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
+        <span className='min-w-0 flex-1 truncate text-left'>{label || 'Untitled'}</span>
         <span className='system-b-library-rail-count tabular-nums'>
           {count}
         </span>

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -798,7 +798,9 @@ function LibrarySavedViewRow({
       )}
     >
       <button type='button' onClick={onClick} aria-pressed={active}>
-        <span className='min-w-0 flex-1 truncate text-left'>{label || 'Untitled'}</span>
+        <span className='min-w-0 flex-1 truncate text-left'>
+          {label || 'Untitled'}
+        </span>
         <span className='system-b-library-rail-count tabular-nums'>
           {count}
         </span>

--- a/apps/web/components/features/profile/ProfilePrimaryActionCard.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryActionCard.tsx
@@ -554,7 +554,7 @@ function ActionCardShell({
   if (onClick) {
     return (
       <button type='button' onClick={onClick} {...sharedProps}>
-        {children}
+        {children || 'Submit'}
       </button>
     );
   }

--- a/apps/web/components/organisms/entity-card/EntityCard.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.test.tsx
@@ -116,4 +116,24 @@ describe('EntityCard', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Add To Calendar' }));
     expect(onCalendar).toHaveBeenCalledTimes(1);
   });
+
+  it('renders fallback text when cta.label is empty', () => {
+    const onAction = vi.fn();
+    const emptyLabel: EntityCardModel = {
+      id: 'e1',
+      kind: 'show',
+      title: 'Show',
+      imageAlt: 'Venue',
+      interactive: true,
+      cta: {
+        label: '',
+        onClick: onAction,
+      },
+    };
+
+    render(<EntityCard model={emptyLabel} treatment='compact' />);
+    const button = screen.getByRole('button');
+    expect(button).not.toHaveTextContent('');
+    expect(button).toHaveTextContent('Action');
+  });
 });

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -109,7 +109,7 @@ function EntityCtaControl({
 
   return (
     <button type='button' onClick={cta.onClick} className={className}>
-      {cta.label}
+      {cta?.label || 'Action'}
     </button>
   );
 }


### PR DESCRIPTION
Fixes blank-button risk (#13069)

- EntityCard.tsx: fallback for cta.label
- ProfilePrimaryActionCard.tsx: fallback for children
- LibrarySurface.tsx: fallback for label

Test: adds not.toHaveTextContent('') assertion where the EntityCard test exists.