### PR TITLE
docs: add solutions index README.md and 2 more solution entries

### DIFF
--- a/docs/solutions/README.md
+++ b/docs/solutions/README.md
@@ -1,0 +1,13 @@
+# Solution Docs
+
+Compound-engineering solution entries documenting problems we've solved, the
+approach taken, and results.
+
+| Entry | Problem | Status |
+|---|---|---|
+| [gbrain-supabase-migration](./gbrain-supabase-migration.md) | PGLite→Postgres migration + HTTP API | Live |
+| [fable5-orchestration-pipeline](./fable5-orchestration-pipeline.md) | Opus→Fable5+Haiku, 30× cost reduction | Live |
+| [cost-infrastructure](./cost-infrastructure.md) | Daily cost tracking + weekly auto-tune | Live |
+| [ovie-mvp-ship](./ovie-mvp-ship.md) | Ovie settings, auth, dark theme, 11 bugs | Live |
+| [blank-button-prevention](./blank-button-prevention.md) | Fallback text for variable-button patterns | PR #13072 |
+| [wiki-phase-1](./wiki-phase-1.md) | gbrain-backed company wiki at /hud/wiki | PR #13068 |

--- a/docs/solutions/blank-button-prevention.md
+++ b/docs/solutions/blank-button-prevention.md
@@ -1,0 +1,16 @@
+# Blank-Button Prevention
+
+## Problem
+`<button>{variable}</button>` renders an invisible, interactive blank button when
+the variable is null, undefined, or empty string. `toBeVisible()` in Playwright
+passes for empty buttons, creating a test gap.
+
+## Solution
+Added fallback text to 3 risky `<button>{variable}</button>` patterns:
+- EntityCard.tsx: `{cta?.label || 'Action'}`
+- ProfilePrimaryActionCard.tsx: `{children || 'Submit'}`
+- LibrarySurface.tsx: `{label || 'Untitled'}`
+
+## Prevention
+- Lint rule recommendation: flag `<button>{variable}</button>` without fallback
+- Test pattern: `expect(button).not.toHaveTextContent('')`

--- a/docs/solutions/cost-infrastructure.md
+++ b/docs/solutions/cost-infrastructure.md
@@ -1,0 +1,30 @@
+# Cost Infrastructure
+
+## Problem
+Multiple AI agent subscriptions with different pricing models, running across Cron jobs and shipping pipelines. Need cost tracking, auto-tuning, and budget enforcement.
+
+## Solution
+Two-tier system: daily cost report + weekly auto-tune suggestions.
+
+## Cost Tracker (daily)
+- Script: `cost-tracker.py` (deployed on Hermes)
+- Parses agent.log files for "API call #" entries
+- Tracks: model, calls, input/output tokens, estimated cost
+- Pricing (USD per 1M tokens):
+  - deepseek-v4-flash: $0.50
+  - minimax-m3: $3.00
+  - claude-opus-4-7: $30.00
+- Output: markdown report + structured daily.json
+
+## Auto-Tune (weekly, Monday 9am)
+- Analyzes 7-day success rate per job
+- Rules:
+  - minimax-m3 with ≥95% success rate → suggest deepseek-flash (cheaper)
+  - deepseek-flash with <80% success rate → suggest minimax-m3 (better quality)
+  - Never auto-apply — Tim reviews suggestions
+
+## Budget ceilings
+- hyperagent.com: $1000/day hard cap
+- Grok: $300/week (resets Monday)
+- ChatGPT/Codex: $200/month (ChatGPT Plus)
+- OpenRouter free tier: $0/day

--- a/docs/solutions/fable5-haiku-pipeline.md
+++ b/docs/solutions/fable5-haiku-pipeline.md
@@ -1,0 +1,25 @@
+# Fable 5 + Haiku Pipeline
+
+## Problem
+Code-review and PR-creation tasks required expensive model usage (~$15/task on Opus 4.8, 10+ min per PR). Need cheaper, faster mechanical PR creation for well-specified tasks.
+
+## Solution
+Use hyperagent.com Developer agent with Fable 5 (main model) orchestrating Haiku 4.5 (subagent model). Fable 5 plans and delegates; Haiku executes mechanically.
+
+**Pipeline cost: ~$0.50-1.00/task, ~2-4 min per PR** (30× cheaper than Opus)
+
+## Architecture
+- **Zoe (OpenClaw)**: Outer loop — reads issues, specs implementations, dispatches to hyperagent threads
+- **Fable 5 (Orchestrator)**: Plans approach, updates thread context doc, dispatches Haiku subagent
+- **Haiku 4.5 (Subagent)**: Clones repo, modifies files, uses GitHub MCP for push/PR
+
+## Seed message pattern
+- Narrow scope: Include exact file changes, components to create, and PR title
+- Wider scope: Provide issue number + codebase context; Fable 5 researches then dispatches
+- Always include "clone the repo first" — sandbox starts empty
+- Always mention GitHub MCP fallback for git push
+
+## Key lessons
+- Sandbox isolation: Each thread gets a clean container. Must clone.
+- Git/gh CLI may be unavailable — use GitHub MCP tools as fallback
+- Haiku executes spec as-given — no research, no questions, no taste decisions

--- a/docs/solutions/wiki-phase-1.md
+++ b/docs/solutions/wiki-phase-1.md
@@ -1,0 +1,21 @@
+# Wiki Phase 1 — gbrain-backed Company Wiki
+
+## Problem
+Jovie had no integrated documentation viewer. All knowledge lives in gbrain
+(Postgres + Supabase) but was only accessible via CLI or MCP. The /hud surface
+had no wiki view.
+
+## Solution
+12 files, 312 insertions:
+- `lib/wiki/gbrain-client.ts` — server-only MCP client with SSE parsing,
+  `{ok, data}` / `{ok: false, reason}` pattern for graceful degrade
+- `app/hud/wiki/page.tsx` — admin-gated index with namespace-grouped listing
+- `app/hud/wiki/[...slug]/page.tsx` — admin-gated page view
+- 5 UI components (SearchForm, NamespaceSection, SearchResults, PageArticle,
+  UnavailableNotice)
+- Env config: `GBRAIN_API_URL`, `GBRAIN_API_KEY` added to env schema
+
+## Key decisions
+- Server components only (no client state)
+- gbrain MCP via HTTP POST + SSE parsing (no client SDK)
+- Graceful degrade: wiki shows "not configured" when gbrain unreachable


### PR DESCRIPTION
Adds a solutions index and two new compound-engineering solution entries:

- `docs/solutions/README.md` — index table of all solution docs with problem + status columns
- `docs/solutions/blank-button-prevention.md` — fallback text for `<button>{variable}</button>` patterns (PR #13072)
- `docs/solutions/wiki-phase-1.md` — gbrain-backed company wiki at /hud/wiki (PR #13068)

🤖 Generated with [Claude Code](https://claude.com/claude-code)