### PR TITLE
fix: sweep blank-button risk across remaining button components

### DIFF
--- a/apps/web/components/features/feedback/ErrorBanner.tsx
+++ b/apps/web/components/features/feedback/ErrorBanner.tsx
@@ -102,7 +102,7 @@ export function ErrorBanner({
           'border border-error/50 bg-error/15 text-error-foreground shadow-lg hover:bg-error/25 hover:border-error/70'
         )}
       >
-        {action.label}
+        {action.label || 'Action'}
       </button>
     );
   };

--- a/apps/web/components/features/profile/ProfileHeroCard.tsx
+++ b/apps/web/components/features/profile/ProfileHeroCard.tsx
@@ -228,7 +228,7 @@ export function ArtistHero({
                       {primaryActionKind === 'tickets' ? (
                         <Ticket className='mr-2 h-4 w-4' aria-hidden='true' />
                       ) : null}
-                      {primaryAction.label}
+                      {primaryAction.label || 'Open'}
                     </>
                   );
                   const label = primaryAction.ariaLabel ?? primaryAction.label;

--- a/apps/web/components/features/profile/ProfileMediaCard.tsx
+++ b/apps/web/components/features/profile/ProfileMediaCard.tsx
@@ -278,7 +278,7 @@ function CardAction({
             fill={action.icon === 'Play' ? 'currentColor' : 'none'}
           />
         ) : null}
-        <span className='truncate'>{action.label}</span>
+        <span className='truncate'>{action.label || 'Open'}</span>
       </span>
       {action.showChevron ? (
         <ChevronRight

--- a/apps/web/components/molecules/filters/FilterChip.tsx
+++ b/apps/web/components/molecules/filters/FilterChip.tsx
@@ -31,7 +31,7 @@ export function FilterChip({
         className
       )}
     >
-      {children}
+      {children || 'Filter'}
     </button>
   );
 }

--- a/apps/web/components/organisms/table/molecules/DisplayMenuDropdown.tsx
+++ b/apps/web/components/organisms/table/molecules/DisplayMenuDropdown.tsx
@@ -84,7 +84,7 @@ const ColumnToggleButton = memo(function ColumnToggleButton({
           : 'text-tertiary-token hover:bg-surface-1 hover:text-secondary-token'
       )}
     >
-      {label}
+      {label || 'Column'}
     </button>
   );
 });

--- a/apps/web/components/providers/SystemBErrorFallback.tsx
+++ b/apps/web/components/providers/SystemBErrorFallback.tsx
@@ -91,7 +91,7 @@ export function SystemBErrorFallback({
                 onClick={action.onClick}
                 className={actionClassName(action.variant)}
               >
-                {action.label}
+                {action.label || 'Action'}
               </button>
             );
           })}

--- a/apps/web/components/shell/LyricsHeader.tsx
+++ b/apps/web/components/shell/LyricsHeader.tsx
@@ -41,7 +41,7 @@ export function LyricsHeader({
           onClick={onArtistClick}
           className='inline-flex items-center no-underline hover:underline focus-visible:underline underline-offset-2 decoration-dotted text-tertiary-token hover:text-primary-token transition-colors duration-subtle ease-subtle truncate'
         >
-          {track.artist}
+          {track.artist || 'Unknown artist'}
         </button>
       ) : (
         <span className='text-tertiary-token truncate'>{track.artist}</span>


### PR DESCRIPTION
Follow-up sweep to #13069 / #13072. Adds fallback text to the remaining prop/data-fed button labels that could render blank:

- ErrorBanner.tsx: `action.label || 'Action'`
- SystemBErrorFallback.tsx: `action.label || 'Action'`
- LyricsHeader.tsx: `track.artist || 'Unknown artist'`
- DisplayMenuDropdown.tsx (ColumnToggleButton): `label || 'Column'`
- FilterChip.tsx: `children || 'Filter'`
- ProfileHeroCard.tsx: `primaryAction.label || 'Open'`
- ProfileMediaCard.tsx: `action.label || 'Open'`

Surveyed all 31 bare-expression button children in apps/web; the other 24 are literal-fed, guarded/defaulted, enum-typed, icon/JSX pass-throughs with aria-labels, or already covered by #13072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)