### PR TITLE
feat(hud): add KPI subgrid and system health strip for HUD density pass (#12887)

### DIFF
--- a/apps/web/app/api/admin/hud/shipping-velocity/route.ts
+++ b/apps/web/app/api/admin/hud/shipping-velocity/route.ts
@@ -24,6 +24,8 @@ export interface DailyBucket {
   merged: number;
   opened: number;
   closed: number; // closed without merge
+  /** Median hours from PR creation to merge for PRs merged that day (null when no merges). */
+  mergeP50Hours?: number | null;
 }
 
 export interface ShippingVelocityResponse {
@@ -67,7 +69,13 @@ function buildEmptyBuckets(days: number): Map<string, DailyBucket> {
     const date = new Date(now);
     date.setUTCDate(date.getUTCDate() - i);
     const dateStr = date.toISOString().slice(0, 10);
-    buckets.set(dateStr, { date: dateStr, merged: 0, opened: 0, closed: 0 });
+    buckets.set(dateStr, {
+      date: dateStr,
+      merged: 0,
+      opened: 0,
+      closed: 0,
+      mergeP50Hours: null,
+    });
   }
 
   return buckets;
@@ -151,8 +159,21 @@ async function fetchPullRequestsFromGitHub(
   return nodes;
 }
 
+function medianHours(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    const low = sorted[mid - 1];
+    const high = sorted[mid];
+    if (low !== undefined && high !== undefined) return (low + high) / 2;
+  }
+  return sorted[mid] ?? null;
+}
+
 function computeBuckets(nodes: GitHubPrNode[], days: number): DailyBucket[] {
   const buckets = buildEmptyBuckets(days);
+  const mergeHoursByDate = new Map<string, number[]>();
 
   for (const node of nodes) {
     // Count by createdAt date (opened)
@@ -168,6 +189,15 @@ function computeBuckets(nodes: GitHubPrNode[], days: number): DailyBucket[] {
       const mergedBucket = buckets.get(mergedDate);
       if (mergedBucket) {
         mergedBucket.merged += 1;
+        const hoursToMerge =
+          (new Date(node.mergedAt).getTime() -
+            new Date(node.createdAt).getTime()) /
+          3_600_000;
+        if (Number.isFinite(hoursToMerge) && hoursToMerge >= 0) {
+          const hours = mergeHoursByDate.get(mergedDate) ?? [];
+          hours.push(hoursToMerge);
+          mergeHoursByDate.set(mergedDate, hours);
+        }
       }
     }
 
@@ -178,6 +208,13 @@ function computeBuckets(nodes: GitHubPrNode[], days: number): DailyBucket[] {
       if (closedBucket) {
         closedBucket.closed += 1;
       }
+    }
+  }
+
+  for (const [date, hours] of mergeHoursByDate) {
+    const bucket = buckets.get(date);
+    if (bucket) {
+      bucket.mergeP50Hours = medianHours(hours);
     }
   }
 

--- a/apps/web/app/api/admin/hud/shipping-velocity/route.ts
+++ b/apps/web/app/api/admin/hud/shipping-velocity/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import { env } from '@/lib/env-server';
 import { captureError } from '@/lib/error-tracking';
+import { medianNumber } from '@/lib/hud/number-series';
 import { getRedis } from '@/lib/redis';
 import { logger } from '@/lib/utils/logger';
 
@@ -159,16 +160,66 @@ async function fetchPullRequestsFromGitHub(
   return nodes;
 }
 
-function medianHours(values: number[]): number | null {
-  if (values.length === 0) return null;
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 === 0) {
-    const low = sorted[mid - 1];
-    const high = sorted[mid];
-    if (low !== undefined && high !== undefined) return (low + high) / 2;
+function incrementBucket(
+  buckets: Map<string, DailyBucket>,
+  date: string,
+  field: 'opened' | 'merged' | 'closed'
+): void {
+  const bucket = buckets.get(date);
+  if (!bucket) return;
+  bucket[field] += 1;
+}
+
+function hoursBetween(startIso: string, endIso: string): number | null {
+  const hours =
+    (new Date(endIso).getTime() - new Date(startIso).getTime()) / 3_600_000;
+  return Number.isFinite(hours) && hours >= 0 ? hours : null;
+}
+
+function appendMergeHours(
+  mergeHoursByDate: Map<string, number[]>,
+  date: string,
+  hoursToMerge: number | null
+): void {
+  if (hoursToMerge === null) return;
+  const hours = mergeHoursByDate.get(date) ?? [];
+  hours.push(hoursToMerge);
+  mergeHoursByDate.set(date, hours);
+}
+
+function countMergedPr(
+  node: GitHubPrNode,
+  buckets: Map<string, DailyBucket>,
+  mergeHoursByDate: Map<string, number[]>
+): void {
+  if (!node.merged || !node.mergedAt) return;
+  const mergedDate = toDateString(node.mergedAt);
+  incrementBucket(buckets, mergedDate, 'merged');
+  appendMergeHours(
+    mergeHoursByDate,
+    mergedDate,
+    hoursBetween(node.createdAt, node.mergedAt)
+  );
+}
+
+function countClosedPr(
+  node: GitHubPrNode,
+  buckets: Map<string, DailyBucket>
+): void {
+  if (node.merged || node.state !== 'CLOSED' || !node.closedAt) return;
+  incrementBucket(buckets, toDateString(node.closedAt), 'closed');
+}
+
+function finalizeMergeP50(
+  buckets: Map<string, DailyBucket>,
+  mergeHoursByDate: Map<string, number[]>
+): void {
+  for (const [date, hours] of mergeHoursByDate) {
+    const bucket = buckets.get(date);
+    if (bucket) {
+      bucket.mergeP50Hours = medianNumber(hours);
+    }
   }
-  return sorted[mid] ?? null;
 }
 
 function computeBuckets(nodes: GitHubPrNode[], days: number): DailyBucket[] {
@@ -176,102 +227,100 @@ function computeBuckets(nodes: GitHubPrNode[], days: number): DailyBucket[] {
   const mergeHoursByDate = new Map<string, number[]>();
 
   for (const node of nodes) {
-    // Count by createdAt date (opened)
-    const openedDate = toDateString(node.createdAt);
-    const openedBucket = buckets.get(openedDate);
-    if (openedBucket) {
-      openedBucket.opened += 1;
-    }
-
-    // Count merged PRs by mergedAt date
-    if (node.merged && node.mergedAt) {
-      const mergedDate = toDateString(node.mergedAt);
-      const mergedBucket = buckets.get(mergedDate);
-      if (mergedBucket) {
-        mergedBucket.merged += 1;
-        const hoursToMerge =
-          (new Date(node.mergedAt).getTime() -
-            new Date(node.createdAt).getTime()) /
-          3_600_000;
-        if (Number.isFinite(hoursToMerge) && hoursToMerge >= 0) {
-          const hours = mergeHoursByDate.get(mergedDate) ?? [];
-          hours.push(hoursToMerge);
-          mergeHoursByDate.set(mergedDate, hours);
-        }
-      }
-    }
-
-    // Count closed-without-merge PRs by closedAt date
-    if (!node.merged && node.state === 'CLOSED' && node.closedAt) {
-      const closedDate = toDateString(node.closedAt);
-      const closedBucket = buckets.get(closedDate);
-      if (closedBucket) {
-        closedBucket.closed += 1;
-      }
-    }
+    incrementBucket(buckets, toDateString(node.createdAt), 'opened');
+    countMergedPr(node, buckets, mergeHoursByDate);
+    countClosedPr(node, buckets);
   }
 
-  for (const [date, hours] of mergeHoursByDate) {
-    const bucket = buckets.get(date);
-    if (bucket) {
-      bucket.mergeP50Hours = medianHours(hours);
-    }
-  }
-
+  finalizeMergeP50(buckets, mergeHoursByDate);
   return Array.from(buckets.values());
+}
+
+function parseRange(request: Request): ValidRange {
+  const { searchParams } = new URL(request.url);
+  const rawRange = searchParams.get('range') ?? '7d';
+  if (rawRange === '30d' || rawRange === '1y') return rawRange;
+  return '7d';
+}
+
+async function authorizeAdmin(): Promise<Response | null> {
+  const entitlements = await getCurrentUserEntitlements();
+  if (!entitlements.isAuthenticated) {
+    return NextResponse.json(
+      { error: 'Unauthorized' },
+      { status: 401, headers: NO_STORE_HEADERS }
+    );
+  }
+  if (!entitlements.isAdmin) {
+    return NextResponse.json(
+      { error: 'Forbidden' },
+      { status: 403, headers: NO_STORE_HEADERS }
+    );
+  }
+  return null;
+}
+
+async function readCachedVelocity(
+  redis: ReturnType<typeof getRedis>,
+  cacheKey: string
+): Promise<ShippingVelocityResponse | null> {
+  if (!redis) return null;
+  try {
+    return (await redis.get<ShippingVelocityResponse>(cacheKey)) ?? null;
+  } catch (redisError) {
+    logger.error('[hud/shipping-velocity] Redis get failed', redisError);
+    return null;
+  }
+}
+
+async function cacheVelocity(
+  redis: ReturnType<typeof getRedis>,
+  cacheKey: string,
+  result: ShippingVelocityResponse
+): Promise<void> {
+  if (!redis) return;
+  try {
+    await redis.set(cacheKey, result, { ex: 20 * 60 });
+  } catch (redisError) {
+    logger.error('[hud/shipping-velocity] Redis set failed', redisError);
+  }
+}
+
+function emptyVelocityResponse(
+  days: number,
+  range: ValidRange
+): ShippingVelocityResponse {
+  return {
+    data: Array.from(buildEmptyBuckets(days).values()),
+    range,
+    cachedAt: new Date().toISOString(),
+  };
 }
 
 export async function GET(request: Request): Promise<Response> {
   try {
-    const entitlements = await getCurrentUserEntitlements();
-    if (!entitlements.isAuthenticated) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401, headers: NO_STORE_HEADERS }
-      );
-    }
-    if (!entitlements.isAdmin) {
-      return NextResponse.json(
-        { error: 'Forbidden' },
-        { status: 403, headers: NO_STORE_HEADERS }
-      );
-    }
+    const authResponse = await authorizeAdmin();
+    if (authResponse) return authResponse;
 
-    const { searchParams } = new URL(request.url);
-    const rawRange = searchParams.get('range') ?? '7d';
-    const range: ValidRange =
-      rawRange === '30d' ? '30d' : rawRange === '1y' ? '1y' : '7d';
+    const range = parseRange(request);
     const days = RANGE_DAYS[range] ?? 7;
 
-    // Try Redis cache first
     const redis = getRedis();
     const cacheKey = `hud:shipping-velocity:${range}`;
-
-    if (redis) {
-      try {
-        const cached = await redis.get<ShippingVelocityResponse>(cacheKey);
-        if (cached) {
-          return NextResponse.json(cached, {
-            status: 200,
-            headers: NO_STORE_HEADERS,
-          });
-        }
-      } catch (redisError) {
-        logger.error('[hud/shipping-velocity] Redis get failed', redisError);
-      }
+    const cached = await readCachedVelocity(redis, cacheKey);
+    if (cached) {
+      return NextResponse.json(cached, {
+        status: 200,
+        headers: NO_STORE_HEADERS,
+      });
     }
 
-    // Check GitHub token
     const token = env.HUD_GITHUB_TOKEN;
     const owner = env.HUD_GITHUB_OWNER;
     const repo = env.HUD_GITHUB_REPO;
 
     if (!token || !owner || !repo) {
-      const emptyResponse: ShippingVelocityResponse = {
-        data: Array.from(buildEmptyBuckets(days).values()),
-        range,
-        cachedAt: new Date().toISOString(),
-      };
+      const emptyResponse = emptyVelocityResponse(days, range);
       return NextResponse.json(emptyResponse, {
         status: 200,
         headers: NO_STORE_HEADERS,
@@ -297,14 +346,7 @@ export async function GET(request: Request): Promise<Response> {
       cachedAt: new Date().toISOString(),
     };
 
-    // Cache for 20 minutes
-    if (redis) {
-      try {
-        await redis.set(cacheKey, result, { ex: 20 * 60 });
-      } catch (redisError) {
-        logger.error('[hud/shipping-velocity] Redis set failed', redisError);
-      }
-    }
+    await cacheVelocity(redis, cacheKey, result);
 
     return NextResponse.json(result, {
       status: 200,

--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -22,6 +22,8 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 import { AgentOsRunsPanel } from '@/components/features/admin/agent-os';
 import { DesignProposalReviewPanel } from '@/components/features/admin/design-lab';
+import { HudKpiSubgrid } from '@/components/features/admin/hud/HudKpiSubgrid';
+import { HudSystemHealthStrip } from '@/components/features/admin/hud/HudSystemHealthStrip';
 import type { DailyBucket } from '@/components/features/admin/ShippingVelocityChart';
 import { ShippingVelocityChart } from '@/components/features/admin/ShippingVelocityChart';
 import { TimActionRequiredSection } from '@/components/features/admin/TimActionRequiredSection';
@@ -787,6 +789,8 @@ export function HudDashboardClient({
       <div className={outerClass}>
         <WhatShipped />
         <TimActionRequiredSection />
+        <HudKpiSubgrid metrics={metrics} />
+        <HudSystemHealthStrip metrics={metrics} />
         <DesignProposalReviewPanel />
 
         <div className='grid gap-3 md:grid-cols-2 xl:grid-cols-4'>

--- a/apps/web/components/features/admin/hud/HudKpiSubgrid.tsx
+++ b/apps/web/components/features/admin/hud/HudKpiSubgrid.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
 import type {
   DailyBucket,
   ShippingVelocityResponse,
 } from '@/app/api/admin/hud/shipping-velocity/route';
 import { ContentMetricCard } from '@/components/molecules/ContentMetricCard';
+import { medianNumber } from '@/lib/hud/number-series';
 import { isHudMetricValueAvailable } from '@/lib/hud/source-trust';
 import type { HudTone } from '@/lib/hud/tone-determination';
 import { FREQUENT_CACHE } from '@/lib/queries/cache-strategies';
@@ -29,18 +31,6 @@ function formatHours(hours: number | null): string {
   if (hours < 1) return `${Math.round(hours * 60)}m`;
   if (hours >= 48) return `${(hours / 24).toFixed(1)}d`;
   return `${hours.toFixed(1)}h`;
-}
-
-function median(values: readonly number[]): number | null {
-  if (values.length === 0) return null;
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 === 0) {
-    const low = sorted[mid - 1];
-    const high = sorted[mid];
-    if (low !== undefined && high !== undefined) return (low + high) / 2;
-  }
-  return sorted[mid] ?? null;
 }
 
 function deltaPercent(current: number, prior: number): number | null {
@@ -120,16 +110,14 @@ function DeltaLine({
 }>) {
   if (deltaPct === null) {
     return (
-      <span className='text-2xs text-tertiary-token'>
-        {'—'} vs prior 7d
-      </span>
+      <span className='text-2xs text-tertiary-token'>{'—'} vs prior 7d</span>
     );
   }
   const isFlat = Math.abs(deltaPct) < 0.05;
   const isGood = goodDirection === 'up' ? deltaPct > 0 : deltaPct < 0;
-  const tone: HudTone = isFlat ? 'neutral' : isGood ? 'good' : 'bad';
+  const tone: HudTone = getDeltaTone(isFlat, isGood);
   const accent = getAccentCssVars(HUD_TONE_ACCENT[tone]);
-  const arrow = isFlat ? '→' : deltaPct > 0 ? '↑' : '↓';
+  const arrow = getDeltaArrow(isFlat, deltaPct);
 
   return (
     <span
@@ -143,6 +131,45 @@ function DeltaLine({
     >
       {arrow} {Math.abs(deltaPct).toFixed(1)}% vs prior 7d
     </span>
+  );
+}
+
+function getDeltaTone(isFlat: boolean, isGood: boolean): HudTone {
+  if (isFlat) return 'neutral';
+  return isGood ? 'good' : 'bad';
+}
+
+function getDeltaArrow(isFlat: boolean, deltaPct: number): string {
+  if (isFlat) return '→';
+  return deltaPct > 0 ? '↑' : '↓';
+}
+
+function MetricSubtitle({
+  children,
+}: Readonly<{ readonly children: ReactNode }>) {
+  return <div className='grid gap-1'>{children}</div>;
+}
+
+function KpiMetricCard({
+  label,
+  value,
+  subtitle,
+  testId,
+}: Readonly<{
+  readonly label: string;
+  readonly value: string;
+  readonly subtitle: ReactNode;
+  readonly testId: string;
+}>) {
+  return (
+    <ContentMetricCard
+      label={label}
+      value={value}
+      subtitle={subtitle}
+      className={KPI_TILE_CLASS}
+      valueClassName={KPI_VALUE_CLASS}
+      data-testid={testId}
+    />
   );
 }
 
@@ -171,90 +198,89 @@ export function HudKpiSubgrid({
   const mergedLast7 = sumMerged(last7);
   const velocityDelta = deltaPercent(mergedLast7, sumMerged(prior7));
 
-  const mergeTimeLast7 = median(mergeP50Values(last7));
-  const mergeTimePrior7 = median(mergeP50Values(prior7));
+  const mergeTimeLast7 = medianNumber(mergeP50Values(last7));
+  const mergeTimePrior7 = medianNumber(mergeP50Values(prior7));
   const mergeTimeDelta =
     mergeTimeLast7 !== null && mergeTimePrior7 !== null
       ? deltaPercent(mergeTimeLast7, mergeTimePrior7)
       : null;
-
   const cashAvailable = isHudMetricValueAvailable(metrics.sources.mercury);
+  const cards: Array<{
+    label: string;
+    value: string;
+    subtitle: ReactNode;
+    testId: string;
+  }> = [
+    {
+      label: 'Ship velocity',
+      value: hasVelocityData ? mergedLast7.toLocaleString('en-US') : '—',
+      subtitle: (
+        <MetricSubtitle>
+          <span>PRs merged, last 7d</span>
+          <DeltaLine deltaPct={velocityDelta} goodDirection='up' />
+          <Sparkline values={buckets.map(bucket => bucket.merged)} />
+        </MetricSubtitle>
+      ),
+      testId: 'hud-kpi-ship-velocity',
+    },
+    {
+      label: 'PR merge time',
+      value: hasVelocityData ? formatHours(mergeTimeLast7) : '—',
+      subtitle: (
+        <MetricSubtitle>
+          <span>P50, last 7d</span>
+          <DeltaLine deltaPct={mergeTimeDelta} goodDirection='down' />
+          <Sparkline values={mergeP50Values(buckets)} />
+        </MetricSubtitle>
+      ),
+      testId: 'hud-kpi-merge-time',
+    },
+    {
+      label: 'Cash',
+      value: cashAvailable ? formatUsd(metrics.overview.balanceUsd) : '—',
+      subtitle: (
+        <MetricSubtitle>
+          <span className='tabular-nums'>
+            {cashAvailable
+              ? `Burn ${formatUsd(metrics.overview.burnRateUsd)} / 30d`
+              : 'Mercury data unavailable'}
+          </span>
+          {cashAvailable && metrics.overview.runwayMonths !== null ? (
+            <span className='tabular-nums'>
+              Runway {metrics.overview.runwayMonths.toFixed(1)} mo
+            </span>
+          ) : null}
+        </MetricSubtitle>
+      ),
+      testId: 'hud-kpi-cash',
+    },
+    {
+      label: 'Active agents',
+      value: metrics.aiOps.counts.running.toLocaleString('en-US'),
+      subtitle: (
+        <MetricSubtitle>
+          <span className='tabular-nums'>
+            Queued {metrics.aiOps.counts.queued.toLocaleString('en-US')} |
+            Review {metrics.aiOps.counts.review.toLocaleString('en-US')}
+          </span>
+          <span className='tabular-nums'>
+            {metrics.aiOps.mergeQueue.openAgentPrs} /{' '}
+            {metrics.aiOps.mergeQueue.openAgentPrThreshold} agent PRs open
+          </span>
+        </MetricSubtitle>
+      ),
+      testId: 'hud-kpi-active-agents',
+    },
+  ];
 
   return (
     <div
       className='grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4'
       data-testid='hud-kpi-subgrid'
     >
-      <ContentMetricCard
-        label='Ship velocity'
-        value={hasVelocityData ? mergedLast7.toLocaleString('en-US') : '—'}
-        subtitle={
-          <div className='grid gap-1'>
-            <span>PRs merged, last 7d</span>
-            <DeltaLine deltaPct={velocityDelta} goodDirection='up' />
-            <Sparkline values={buckets.map(bucket => bucket.merged)} />
-          </div>
-        }
-        className={KPI_TILE_CLASS}
-        valueClassName={KPI_VALUE_CLASS}
-        data-testid='hud-kpi-ship-velocity'
-      />
-      <ContentMetricCard
-        label='PR merge time'
-        value={hasVelocityData ? formatHours(mergeTimeLast7) : '—'}
-        subtitle={
-          <div className='grid gap-1'>
-            <span>P50, last 7d</span>
-            <DeltaLine deltaPct={mergeTimeDelta} goodDirection='down' />
-            <Sparkline values={mergeP50Values(buckets)} />
-          </div>
-        }
-        className={KPI_TILE_CLASS}
-        valueClassName={KPI_VALUE_CLASS}
-        data-testid='hud-kpi-merge-time'
-      />
-      <ContentMetricCard
-        label='Cash'
-        value={
-          cashAvailable ? formatUsd(metrics.overview.balanceUsd) : '—'
-        }
-        subtitle={
-          <div className='grid gap-1'>
-            <span className='tabular-nums'>
-              {cashAvailable
-                ? `Burn ${formatUsd(metrics.overview.burnRateUsd)} / 30d`
-                : 'Mercury data unavailable'}
-            </span>
-            {cashAvailable && metrics.overview.runwayMonths !== null ? (
-              <span className='tabular-nums'>
-                Runway {metrics.overview.runwayMonths.toFixed(1)} mo
-              </span>
-            ) : null}
-          </div>
-        }
-        className={KPI_TILE_CLASS}
-        valueClassName={KPI_VALUE_CLASS}
-        data-testid='hud-kpi-cash'
-      />
-      <ContentMetricCard
-        label='Active agents'
-        value={metrics.aiOps.counts.running.toLocaleString('en-US')}
-        subtitle={
-          <div className='grid gap-1'>
-            <span className='tabular-nums'>
-              Queued {metrics.aiOps.counts.queued.toLocaleString('en-US')} |
-              Review {metrics.aiOps.counts.review.toLocaleString('en-US')}
-            </span>
-            <span className='tabular-nums'>
-              {metrics.aiOps.mergeQueue.openAgentPrs} /{' '}
-              {metrics.aiOps.mergeQueue.openAgentPrThreshold} agent PRs open
-            </span>
-          </div>
-        }
-        className={KPI_TILE_CLASS}
-        valueClassName={KPI_VALUE_CLASS}
-        data-testid='hud-kpi-active-agents'
-      />
+      {cards.map(card => (
+        <KpiMetricCard key={card.testId} {...card} />
+      ))}
     </div>
   );
 }

--- a/apps/web/components/features/admin/hud/HudKpiSubgrid.tsx
+++ b/apps/web/components/features/admin/hud/HudKpiSubgrid.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type {
+  DailyBucket,
+  ShippingVelocityResponse,
+} from '@/app/api/admin/hud/shipping-velocity/route';
+import { ContentMetricCard } from '@/components/molecules/ContentMetricCard';
+import { isHudMetricValueAvailable } from '@/lib/hud/source-trust';
+import type { HudTone } from '@/lib/hud/tone-determination';
+import { FREQUENT_CACHE } from '@/lib/queries/cache-strategies';
+import { getAccentCssVars, HUD_TONE_ACCENT } from '@/lib/ui/accent-palette';
+import type { HudMetrics } from '@/types/hud';
+
+const KPI_TILE_CLASS = 'rounded-(--radius-md) p-3 shadow-card-elevated';
+const KPI_VALUE_CLASS =
+  'text-2xl font-[620] leading-none tracking-[-0.03em] tabular-nums sm:text-3xl';
+
+function formatUsd(value: number): string {
+  return value.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: value >= 1000 ? 0 : 2,
+  });
+}
+
+function formatHours(hours: number | null): string {
+  if (hours === null || !Number.isFinite(hours)) return '—';
+  if (hours < 1) return `${Math.round(hours * 60)}m`;
+  if (hours >= 48) return `${(hours / 24).toFixed(1)}d`;
+  return `${hours.toFixed(1)}h`;
+}
+
+function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    const low = sorted[mid - 1];
+    const high = sorted[mid];
+    if (low !== undefined && high !== undefined) return (low + high) / 2;
+  }
+  return sorted[mid] ?? null;
+}
+
+function deltaPercent(current: number, prior: number): number | null {
+  if (!Number.isFinite(current) || !Number.isFinite(prior) || prior === 0) {
+    return null;
+  }
+  return ((current - prior) / prior) * 100;
+}
+
+function sumMerged(buckets: readonly DailyBucket[]): number {
+  return buckets.reduce((total, bucket) => total + bucket.merged, 0);
+}
+
+function mergeP50Values(buckets: readonly DailyBucket[]): number[] {
+  const values: number[] = [];
+  for (const bucket of buckets) {
+    const value = bucket.mergeP50Hours ?? null;
+    if (value !== null && Number.isFinite(value)) values.push(value);
+  }
+  return values;
+}
+
+async function fetchShippingVelocity(
+  signal: AbortSignal
+): Promise<ShippingVelocityResponse> {
+  const response = await fetch('/api/admin/hud/shipping-velocity?range=30d', {
+    signal,
+    cache: 'no-store',
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status})`);
+  }
+  return (await response.json()) as ShippingVelocityResponse;
+}
+
+function Sparkline({
+  values,
+}: Readonly<{ readonly values: readonly number[] }>) {
+  if (values.length < 2) return null;
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const span = max - min || 1;
+  const step = 100 / (values.length - 1);
+  const points = values
+    .map((value, index) => {
+      const x = index * step;
+      const y = 26 - ((value - min) / span) * 24;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+
+  return (
+    <svg
+      viewBox='0 0 100 28'
+      preserveAspectRatio='none'
+      className='mt-1.5 h-7 w-full'
+      aria-hidden='true'
+    >
+      <title>Trend</title>
+      <polyline
+        points={points}
+        fill='none'
+        stroke='var(--color-accent)'
+        strokeWidth='1.5'
+        vectorEffect='non-scaling-stroke'
+      />
+    </svg>
+  );
+}
+
+function DeltaLine({
+  deltaPct,
+  goodDirection,
+}: Readonly<{
+  readonly deltaPct: number | null;
+  readonly goodDirection: 'up' | 'down';
+}>) {
+  if (deltaPct === null) {
+    return (
+      <span className='text-2xs text-tertiary-token'>
+        {'—'} vs prior 7d
+      </span>
+    );
+  }
+  const isFlat = Math.abs(deltaPct) < 0.05;
+  const isGood = goodDirection === 'up' ? deltaPct > 0 : deltaPct < 0;
+  const tone: HudTone = isFlat ? 'neutral' : isGood ? 'good' : 'bad';
+  const accent = getAccentCssVars(HUD_TONE_ACCENT[tone]);
+  const arrow = isFlat ? '→' : deltaPct > 0 ? '↑' : '↓';
+
+  return (
+    <span
+      className='text-2xs font-medium tabular-nums'
+      style={{
+        color:
+          tone === 'neutral'
+            ? 'var(--color-text-secondary-token)'
+            : accent.solid,
+      }}
+    >
+      {arrow} {Math.abs(deltaPct).toFixed(1)}% vs prior 7d
+    </span>
+  );
+}
+
+/**
+ * Dense 4-up KPI subgrid for the operator HUD (#12887): ship velocity,
+ * PR merge time, cash, and active agents. Each tile keeps its existing
+ * data source (shipping-velocity route, Mercury via HudMetrics, Hermes
+ * aiOps counts) and stacks to one column below 768px.
+ */
+export function HudKpiSubgrid({
+  metrics,
+}: Readonly<{ readonly metrics: HudMetrics }>) {
+  const velocityQuery = useQuery({
+    queryKey: ['hud', 'kpi', 'shipping-velocity', '30d'],
+    queryFn: ({ signal }) => fetchShippingVelocity(signal),
+    ...FREQUENT_CACHE,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+  });
+
+  const buckets = velocityQuery.data?.data ?? [];
+  const last7 = buckets.slice(-7);
+  const prior7 = buckets.slice(-14, -7);
+
+  const hasVelocityData = velocityQuery.data !== undefined;
+  const mergedLast7 = sumMerged(last7);
+  const velocityDelta = deltaPercent(mergedLast7, sumMerged(prior7));
+
+  const mergeTimeLast7 = median(mergeP50Values(last7));
+  const mergeTimePrior7 = median(mergeP50Values(prior7));
+  const mergeTimeDelta =
+    mergeTimeLast7 !== null && mergeTimePrior7 !== null
+      ? deltaPercent(mergeTimeLast7, mergeTimePrior7)
+      : null;
+
+  const cashAvailable = isHudMetricValueAvailable(metrics.sources.mercury);
+
+  return (
+    <div
+      className='grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4'
+      data-testid='hud-kpi-subgrid'
+    >
+      <ContentMetricCard
+        label='Ship velocity'
+        value={hasVelocityData ? mergedLast7.toLocaleString('en-US') : '—'}
+        subtitle={
+          <div className='grid gap-1'>
+            <span>PRs merged, last 7d</span>
+            <DeltaLine deltaPct={velocityDelta} goodDirection='up' />
+            <Sparkline values={buckets.map(bucket => bucket.merged)} />
+          </div>
+        }
+        className={KPI_TILE_CLASS}
+        valueClassName={KPI_VALUE_CLASS}
+        data-testid='hud-kpi-ship-velocity'
+      />
+      <ContentMetricCard
+        label='PR merge time'
+        value={hasVelocityData ? formatHours(mergeTimeLast7) : '—'}
+        subtitle={
+          <div className='grid gap-1'>
+            <span>P50, last 7d</span>
+            <DeltaLine deltaPct={mergeTimeDelta} goodDirection='down' />
+            <Sparkline values={mergeP50Values(buckets)} />
+          </div>
+        }
+        className={KPI_TILE_CLASS}
+        valueClassName={KPI_VALUE_CLASS}
+        data-testid='hud-kpi-merge-time'
+      />
+      <ContentMetricCard
+        label='Cash'
+        value={
+          cashAvailable ? formatUsd(metrics.overview.balanceUsd) : '—'
+        }
+        subtitle={
+          <div className='grid gap-1'>
+            <span className='tabular-nums'>
+              {cashAvailable
+                ? `Burn ${formatUsd(metrics.overview.burnRateUsd)} / 30d`
+                : 'Mercury data unavailable'}
+            </span>
+            {cashAvailable && metrics.overview.runwayMonths !== null ? (
+              <span className='tabular-nums'>
+                Runway {metrics.overview.runwayMonths.toFixed(1)} mo
+              </span>
+            ) : null}
+          </div>
+        }
+        className={KPI_TILE_CLASS}
+        valueClassName={KPI_VALUE_CLASS}
+        data-testid='hud-kpi-cash'
+      />
+      <ContentMetricCard
+        label='Active agents'
+        value={metrics.aiOps.counts.running.toLocaleString('en-US')}
+        subtitle={
+          <div className='grid gap-1'>
+            <span className='tabular-nums'>
+              Queued {metrics.aiOps.counts.queued.toLocaleString('en-US')} |
+              Review {metrics.aiOps.counts.review.toLocaleString('en-US')}
+            </span>
+            <span className='tabular-nums'>
+              {metrics.aiOps.mergeQueue.openAgentPrs} /{' '}
+              {metrics.aiOps.mergeQueue.openAgentPrThreshold} agent PRs open
+            </span>
+          </div>
+        }
+        className={KPI_TILE_CLASS}
+        valueClassName={KPI_VALUE_CLASS}
+        data-testid='hud-kpi-active-agents'
+      />
+    </div>
+  );
+}

--- a/apps/web/components/features/admin/hud/HudSystemHealthStrip.tsx
+++ b/apps/web/components/features/admin/hud/HudSystemHealthStrip.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/hud/tone-determination';
 import { FREQUENT_CACHE } from '@/lib/queries/cache-strategies';
 import { getAccentCssVars, HUD_TONE_ACCENT } from '@/lib/ui/accent-palette';
+import { cn } from '@/lib/utils';
 import type { HudMetrics } from '@/types/hud';
 import type {
   HudShipperState,
@@ -43,17 +44,18 @@ function StatusPill({
   tone,
 }: Readonly<{ readonly label: string; readonly tone: HudTone }>) {
   const accent = getAccentCssVars(HUD_TONE_ACCENT[tone]);
+  const color =
+    tone === 'neutral' ? 'var(--color-text-secondary-token)' : accent.solid;
 
   return (
     <span
-      className='inline-flex items-center rounded-full border px-2.5 py-0.5 text-2xs font-medium leading-none'
+      className={cn(
+        'inline-flex items-center rounded-full border px-2.5 py-0.5 text-2xs font-medium leading-none'
+      )}
       style={{
         borderColor: `color-mix(in oklab, ${accent.solid} 26%, var(--linear-app-frame-seam))`,
         backgroundColor: accent.subtle,
-        color:
-          tone === 'neutral'
-            ? 'var(--color-text-secondary-token)'
-            : accent.solid,
+        color,
       }}
     >
       {label}
@@ -67,6 +69,26 @@ interface HealthEntry {
   readonly tone: HudTone;
 }
 
+function shipperHealth(
+  shipper: HudShipperStatusPayload | undefined
+): Pick<HealthEntry, 'label' | 'tone'> {
+  if (shipper === undefined || shipper.availability === 'unavailable') {
+    return {
+      label: shipper === undefined ? '—' : 'No signal',
+      tone: 'neutral',
+    };
+  }
+  return {
+    label: shipperLabel(shipper.state),
+    tone: shipperTone(shipper.state),
+  };
+}
+
+function ledgerTone(quarantine: HudMetrics['testing']['quarantine']): HudTone {
+  if (!quarantine.isValid) return 'bad';
+  return quarantine.withinRetryBudget ? 'good' : 'warning';
+}
+
 function buildHealthEntries(
   metrics: HudMetrics,
   shipper: HudShipperStatusPayload | undefined
@@ -74,20 +96,12 @@ function buildHealthEntries(
   const quarantine = metrics.testing.quarantine;
   const jobsRunning =
     metrics.aiOps.counts.running + (shipper?.inFlightCount ?? 0);
+  const shipperStatus = shipperHealth(shipper);
 
   return [
     {
       name: 'Shipper',
-      label:
-        shipper === undefined
-          ? '—'
-          : shipper.availability === 'unavailable'
-            ? 'No signal'
-            : shipperLabel(shipper.state),
-      tone:
-        shipper === undefined || shipper.availability === 'unavailable'
-          ? 'neutral'
-          : shipperTone(shipper.state),
+      ...shipperStatus,
     },
     // No gbrain health source is wired into the HUD yet — render an honest
     // neutral pill rather than a fabricated status. Wire when a source lands.
@@ -102,11 +116,7 @@ function buildHealthEntries(
       label: quarantine.isValid
         ? `Valid | ${quarantine.activeCount.toLocaleString('en-US')} quarantined`
         : 'Invalid',
-      tone: quarantine.isValid
-        ? quarantine.withinRetryBudget
-          ? 'good'
-          : 'warning'
-        : 'bad',
+      tone: ledgerTone(quarantine),
     },
     {
       name: 'Jobs',

--- a/apps/web/components/features/admin/hud/HudSystemHealthStrip.tsx
+++ b/apps/web/components/features/admin/hud/HudSystemHealthStrip.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+import {
+  getDeploymentLabel,
+  getDeploymentTone,
+  type HudTone,
+} from '@/lib/hud/tone-determination';
+import { FREQUENT_CACHE } from '@/lib/queries/cache-strategies';
+import { getAccentCssVars, HUD_TONE_ACCENT } from '@/lib/ui/accent-palette';
+import type { HudMetrics } from '@/types/hud';
+import type {
+  HudShipperState,
+  HudShipperStatusPayload,
+} from '@/types/hud-shipper';
+
+function shipperTone(state: HudShipperState): HudTone {
+  if (state === 'running') return 'good';
+  if (state === 'paused') return 'warning';
+  if (state === 'error') return 'bad';
+  return 'neutral';
+}
+
+function shipperLabel(state: HudShipperState): string {
+  if (state === 'running') return 'Running';
+  if (state === 'paused') return 'Paused';
+  if (state === 'error') return 'Error';
+  if (state === 'idle') return 'Idle';
+  return 'Not Running';
+}
+
+async function fetchJson<T>(path: string, signal: AbortSignal): Promise<T> {
+  const response = await fetch(path, { signal, cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status})`);
+  }
+  return (await response.json()) as T;
+}
+
+function StatusPill({
+  label,
+  tone,
+}: Readonly<{ readonly label: string; readonly tone: HudTone }>) {
+  const accent = getAccentCssVars(HUD_TONE_ACCENT[tone]);
+
+  return (
+    <span
+      className='inline-flex items-center rounded-full border px-2.5 py-0.5 text-2xs font-medium leading-none'
+      style={{
+        borderColor: `color-mix(in oklab, ${accent.solid} 26%, var(--linear-app-frame-seam))`,
+        backgroundColor: accent.subtle,
+        color:
+          tone === 'neutral'
+            ? 'var(--color-text-secondary-token)'
+            : accent.solid,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+interface HealthEntry {
+  readonly name: string;
+  readonly label: string;
+  readonly tone: HudTone;
+}
+
+function buildHealthEntries(
+  metrics: HudMetrics,
+  shipper: HudShipperStatusPayload | undefined
+): HealthEntry[] {
+  const quarantine = metrics.testing.quarantine;
+  const jobsRunning =
+    metrics.aiOps.counts.running + (shipper?.inFlightCount ?? 0);
+
+  return [
+    {
+      name: 'Shipper',
+      label:
+        shipper === undefined
+          ? '—'
+          : shipper.availability === 'unavailable'
+            ? 'No signal'
+            : shipperLabel(shipper.state),
+      tone:
+        shipper === undefined || shipper.availability === 'unavailable'
+          ? 'neutral'
+          : shipperTone(shipper.state),
+    },
+    // No gbrain health source is wired into the HUD yet — render an honest
+    // neutral pill rather than a fabricated status. Wire when a source lands.
+    { name: 'gbrain', label: 'No signal', tone: 'neutral' },
+    {
+      name: 'CI',
+      label: getDeploymentLabel(metrics.deployments),
+      tone: getDeploymentTone(metrics.deployments),
+    },
+    {
+      name: 'Ledger',
+      label: quarantine.isValid
+        ? `Valid | ${quarantine.activeCount.toLocaleString('en-US')} quarantined`
+        : 'Invalid',
+      tone: quarantine.isValid
+        ? quarantine.withinRetryBudget
+          ? 'good'
+          : 'warning'
+        : 'bad',
+    },
+    {
+      name: 'Jobs',
+      label: `${jobsRunning.toLocaleString('en-US')} running`,
+      tone: jobsRunning > 0 ? 'good' : 'neutral',
+    },
+  ];
+}
+
+/**
+ * Single-row system health strip for the operator HUD (#12887): shipper,
+ * gbrain, CI, quarantine ledger, and jobs running. Pills reuse the HUD
+ * tone accent tokens; shipper status shares the existing
+ * ['hud', 'shipper'] query cache with HudShipperPanels.
+ */
+export function HudSystemHealthStrip({
+  metrics,
+}: Readonly<{ readonly metrics: HudMetrics }>) {
+  const shipperQuery = useQuery({
+    queryKey: ['hud', 'shipper'],
+    queryFn: ({ signal }) =>
+      fetchJson<HudShipperStatusPayload>('/api/admin/hud/shipper', signal),
+    ...FREQUENT_CACHE,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+  });
+
+  const entries = buildHealthEntries(metrics, shipperQuery.data);
+
+  return (
+    <ContentSurfaceCard
+      surface='details'
+      className='rounded-(--radius-md) p-3 shadow-card-elevated'
+      data-testid='hud-system-health-strip'
+    >
+      <div className='flex flex-wrap items-center gap-x-4 gap-y-2'>
+        <p className='text-2xs font-semibold tracking-normal text-tertiary-token'>
+          System health
+        </p>
+        {entries.map(entry => (
+          <div key={entry.name} className='flex items-center gap-1.5'>
+            <span className='text-2xs text-secondary-token'>{entry.name}</span>
+            <StatusPill label={entry.label} tone={entry.tone} />
+          </div>
+        ))}
+      </div>
+    </ContentSurfaceCard>
+  );
+}

--- a/apps/web/lib/hud/number-series.ts
+++ b/apps/web/lib/hud/number-series.ts
@@ -1,0 +1,11 @@
+export function medianNumber(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    const low = sorted[mid - 1];
+    const high = sorted[mid];
+    if (low !== undefined && high !== undefined) return (low + high) / 2;
+  }
+  return sorted[mid] ?? null;
+}


### PR DESCRIPTION
## Summary

HUD density pass per #12887 — adds a dense 4-up KPI subgrid and a system health strip to the `/hud` operator surface (shell branch of `HudDashboardClient`, mounted after `TimActionRequiredSection` to keep the test-enforced `WhatShipped`-first ordering).

### KPI subgrid (`HudKpiSubgrid`)
- **Ship velocity** — PRs merged last 7d, delta vs prior 7d, 30d sparkline. Source: existing `/api/admin/hud/shipping-velocity` route.
- **PR merge time** — P50 hours-to-merge last 7d + delta + sparkline. Computed in the existing shipping-velocity route from the `createdAt`/`mergedAt` fields it already fetches (additive optional `mergeP50Hours` per `DailyBucket`; chart consumers unaffected, stale Redis cache degrades to null and self-heals within the 20-min TTL).
- **Cash** — Mercury balance + burn + runway from `HudMetrics.overview`, gated on `isHudMetricValueAvailable(sources.mercury)`.
- **Active agents** — `aiOps.counts.running` with queued/review and agent-PR-queue context.

All values render `tabular-nums` (via `ContentMetricCard` canon), tiles use `--radius-md` + `shadow-card-elevated`, grid stacks to 1 column below 768px (`grid-cols-1 md:grid-cols-2 xl:grid-cols-4`).

### System health strip (`HudSystemHealthStrip`)
- **Shipper** — shares the existing `['hud','shipper']` react-query cache with `HudShipperPanels`.
- **gbrain** — no health source is wired into the HUD today; renders an honest neutral "No signal" pill instead of a fabricated status. Follow-up: wire a real gbrain heartbeat.
- **CI** — existing `getDeploymentTone`/`getDeploymentLabel` helpers over `metrics.deployments`.
- **Ledger** — quarantine ledger validity + active count + retry-budget warning tone.
- **Jobs running** — aiOps running + shipper in-flight count.

Pills reuse the HUD tone accent tokens (`HUD_TONE_ACCENT` + `getAccentCssVars`), same visual canon as `HudStatusPill`.

## Acceptance mapping

- [x] 4-up KPI grid: ship velocity / cash / PR merge time / active agents
- [x] Label + tabular value + delta + sparkline (sparkline/delta rendered where a history source exists; cash and agents have no time-series source today — no data fabricated)
- [x] System health strip: shipper / gbrain / CI / ledger / jobs running
- [x] Status pills use HUD accent tokens; tiles use `--radius-md` + `shadow-card-elevated`
- [x] All existing data sources preserved (no tiles removed, additive route change only)
- [x] Mobile stacks to 1 column below 768px

## Notes

- The visual mock referenced in the issue (`http://localhost:7788/`, card `hud-redesign`) is not reachable from this environment; layout follows the issue text + existing shell canon. Easy to iterate once the mock is shareable.
- `apps/web/app/api/hud/ai-ops` listed under affected files needed no change — active-agent counts already flow through `HudMetrics.aiOps`.
- Typecheck/tests not run in the authoring sandbox (registry egress blocked); relying on CI `ci-fast` + unit gates.

Closes #12887

🤖 Generated with [Claude Code](https://claude.com/claude-code)
