### PR TITLE
fix: download page iPhone card dead div → disabled button (#12954)

### DIFF
--- a/apps/web/app/(marketing)/download/page.tsx
+++ b/apps/web/app/(marketing)/download/page.tsx
@@ -257,9 +257,13 @@ export default function DownloadPage() {
                         {platform.action}
                       </a>
                     ) : (
-                      <div className='system-b-download-platform-inactive'>
+                      <button
+                        type='button'
+                        disabled
+                        className='system-b-download-platform-inactive'
+                      >
                         {platform.action}
-                      </div>
+                      </button>
                     )}
                   </div>
                 );


### PR DESCRIPTION
Fixes #12954

The iPhone platform card's action slot rendered a bare `<div>` ("Internal alpha only") — no role, no semantics for assistive tech. It now renders a `<button type="button" disabled>` with the same `system-b-download-platform-inactive` class, so it is exposed to AT as a disabled control. Tailwind preflight resets button background/font, so the visual is unchanged. No CSS changes; single-file diff.