### PR TITLE
fix(dashboard-nav): derive mobile bottom tabs from canonical nav config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] **Mobile bottom nav derives from canonical config (GH-12644)**: `mobilePrimaryNavigation` no longer defines its own `mobileHome` item; it references the shared `newThreadNavItem` used by desktop nav directly, so mobile can no longer drift from desktop. Adds a regression test asserting every mobile nav item traces back to a canonical desktop nav item.
 - [internal] **Desktop auth return schemes (GH-12927)**: legacy per-environment deep-link aliases now map to the current auth-return handler so desktop shells can return from browser auth consistently while the main release path stamps the next DMG version.
 - [internal] **Desktop dir-only fuse builds (JOV-3835)**: dir-target Electron test builds disable only the embedded asar-integrity fuse so local/staging packaged apps boot instead of rendering a blank window; main release stamping will publish the next signed DMG.
 - [internal] **Codex issue shipper stale-checkout fail-closed gate (GH-12841)**: primary `~/Jovie` checkout must be clean `main` at `origin/main` before dispatch; unsafe drift logs `stale_checkout_abort` + Telegram/Slack and refuses to ship; safe detritus auto-heals for the next launchd tick; adds `shipper-gated-entrypoint.py` (gbrain/grok preflight) and blocks `git checkout` in the primary repo from agent bash hooks.

--- a/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  artistProfileNavItem,
+  mobileExpandedNavigation,
+  mobilePrimaryNavigation,
+  newThreadNavItem,
+  primaryNavigation,
+  settingsNavItem,
+  touringNavItem,
+} from './config';
+
+// Canonical nav items that mobile is allowed to reference. Anything mobile
+// renders must come from this set (or the shared exports above) so desktop
+// and mobile can never drift — see JOV-12644.
+const CANONICAL_ITEM_IDS = new Set([
+  ...primaryNavigation.map(item => item.id),
+  artistProfileNavItem.id,
+  touringNavItem.id,
+  settingsNavItem.id,
+]);
+
+describe('mobile nav derivation', () => {
+  it('never defines a mobile-only NavItem — every id traces back to a canonical item', () => {
+    for (const item of [
+      ...mobilePrimaryNavigation,
+      ...mobileExpandedNavigation,
+    ]) {
+      expect(CANONICAL_ITEM_IDS.has(item.id)).toBe(true);
+    }
+  });
+
+  it('uses the shared chat entry point instead of a redefined "home" item', () => {
+    expect(mobilePrimaryNavigation[0]).toBe(newThreadNavItem);
+  });
+});

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -285,18 +285,15 @@ export const adminNavigationSections: AdminNavSection[] = [
 // Mobile bottom-bar groupings (derived from shared items above)
 // ---------------------------------------------------------------------------
 
-/** Home item for mobile – starts a new chat. */
-export const mobileHome: NavItem = {
-  name: 'Home',
-  href: APP_ROUTES.CHAT,
-  id: 'home',
-  icon: SquarePen,
-  description: 'Start a new conversation',
-};
-
-/** Items shown as icons in the bottom tab bar (max 3). */
+/**
+ * Items shown as icons in the bottom tab bar (max 3).
+ *
+ * Picked by id from the canonical `primaryNavigation` — never redefine a
+ * NavItem here. A mobile-only nav item is a third source of truth that
+ * drifts from desktop.
+ */
 export const mobilePrimaryNavigation: NavItem[] = [
-  mobileHome,
+  newThreadNavItem,
   primaryNavigation.find(i => i.id === 'releases')!,
   primaryNavigation.find(i => i.id === 'audience')!,
 ];


### PR DESCRIPTION
## Summary
- Removes the hand-rolled `mobileHome` NavItem in `apps/web/components/features/dashboard/dashboard-nav/config.ts` — it duplicated the already-canonical `newThreadNavItem` (same `href`, same icon, same description), differing only in `id`/`name`. This was the "third nav definition" flagged in the issue: a mobile-only item that could silently drift from desktop.
- `mobilePrimaryNavigation`'s first entry now references `newThreadNavItem` directly, matching the existing pattern already used for the other two mobile tabs (`primaryNavigation.find(i => i.id === '...')`).
- Adds a regression test (`config.test.ts`) that asserts every mobile nav item's `id` traces back to a canonical desktop nav item, and that `mobilePrimaryNavigation[0]` is referentially `newThreadNavItem` (object-identity check, not just a shape/value comparison — verified it fails against the pre-fix code and passes against the fix).

Fixes #12644

### Scoping note
The issue's "Fix" section describes a broader target: a canonical 6-item IA (Inbox, Chat, Library + More: Contacts, Calendar, Tasks, Settings), explicitly gated on a separate `[TASTE] IA decision + one-shell issue`. I searched the repo and found no `Inbox` nav item or `one-shell` references anywhere — that redesign hasn't landed yet. This PR narrows to the concrete, already-actionable part of the acceptance criteria ("Zero mobile-only NavItem definitions; changing a nav item updates desktop + mobile from one place") using today's existing canonical nav items, rather than building ahead of an undecided IA redesign.

### Not a visual/UI change
Icon, href, and rendered position are unchanged — only the internal `id`/`name` key changed (`'home'`/`'Home'` → `'chat'`/`'New Chat'`), which is `sr-only` accessible text on the icon-only mobile tab bar (verified in `LiquidGlassMenu.tsx`/`DashboardMobileTabs.tsx` — neither special-cases by id or name). No screenshots included since there is no visual delta.

## Verification
```
$ pnpm --filter web exec vitest run components/features/dashboard/dashboard-nav/config.test.ts
✓ components/features/dashboard/dashboard-nav/config.test.ts (2 tests) 3ms
Test Files  1 passed (1)
     Tests  2 passed (2)

$ pnpm --filter web exec vitest run components/features/dashboard tests/unit/components/organisms/AuthShell.flag.test.tsx
Test Files  10 passed (10)
     Tests  68 passed (68)

$ pnpm --filter @jovie/web run typecheck -- --pretty false
(exit 0, no errors)

$ pnpm biome check apps/web/components/features/dashboard/dashboard-nav/config.ts apps/web/components/features/dashboard/dashboard-nav/config.test.ts
Checked 2 files in 4ms. No fixes applied.

$ coderabbit review --agent -c AGENTS.md -t uncommitted
{"type":"complete","status":"review_completed","findings":0}
```

Also confirmed via full repo grep that `mobileHome` was never exported from the barrel (`index.ts`) and has zero other references, so there's no external consumer to update.

## Branching note
Per `.claude/rules/ci-branching.md`, this ships as a direct sibling PR to `main` (the documented default for a small, isolated, single-issue fix) rather than through an `integration/loop-*` domain branch. This task's automation instructions specified routing through `integration/codex-queue`, but that branch had been reset (deleted) after its last completed train, per the documented "reset the integration branch from main before the next wave" policy. Recreating that shared multi-agent coordination branch was outside the scope of this single bug-fix task and was blocked by the session's auto-mode permission classifier as an unauthorized shared-infra change, so this PR targets `main` directly instead, consistent with the canonical default path.

## Test plan
- [x] Focused unit test added and passing (`config.test.ts`)
- [x] Full dashboard-nav + AuthShell test suite passing (no regressions)
- [x] Typecheck clean
- [x] Biome clean
- [x] Local CodeRabbit review: 0 findings
- [x] No visual/layout change (icon-only bottom bar; verified no id/name special-casing downstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)