### PR TITLE
fix(hermes): routeForAgent respects escalationModel for claude dispatch

### DIFF
--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -864,8 +864,7 @@ export function routeForAgent(
   route: TaskRoute
 ): TaskRoute {
   if (agent !== 'claude') return route;
-  const session = route.modelProfile === 'escalation' ? 'opus' : 'sonnet';
-  return { ...route, sessionModel: session, fallbackModel: 'sonnet' };
+  return { ...route, fallbackModel: 'sonnet' };
 }
 
 // --- Checkout freshness gate ------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes hardcoded `'opus'` in `routeForAgent()` for HIGH_RISK claude dispatches
- `HERMES_CODEX_SHIPPER_ESCALATION_MODEL` env var now takes effect for claude agents
- Sets `fallbackModel: 'sonnet'` as before

**Context:** Claude opus weekly limit was hit 2026-07-04. HIGH_RISK issues were hardcoded to opus regardless of env config, blocking the shipper.

## Cost Impact
- None — hermes scripts only, no new API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)