### PR TITLE
feat(shipper): load design taste skill for UI issues

### DIFF
--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -202,6 +202,18 @@ The job watches open GitHub issues labeled `codex`. Empty runs only call GitHub,
 
 Only one shipper run may own the queue at a time. A new cron invocation takes a non-blocking singleton lock check; if another shipper is still active, the new invocation logs `singleton_active_skip` and exits. The active run keeps draining the queue in batches until no eligible issues remain, the machine is under too much pressure to launch another agent, or all remaining issues are blocked or human-gated.
 
+UI/UX, design, taste, token, and visual-polish issues get an additional coder prompt block that loads `design-taste-frontend`, requires the design-read statement, dials, before/after evidence, narrow checks, and the checklist pass/fail in the PR body. For existing product/dashboard UI, agents use the skill's audit/checklist portions only; they must not force landing-page patterns into product UI.
+
+Restore the external design skill in a fresh worktree only after confirming the
+reviewed upstream commit. The required headless install command is intentionally
+guarded so mutable upstream instructions cannot be installed silently:
+
+```bash
+test "$(git ls-remote https://github.com/Leonxlnx/taste-skill.git HEAD | awk '{print $1}')" = "06d6028b5c623016c59ce8536f578e5a1127b499" && DISABLE_TELEMETRY=1 DO_NOT_TRACK=1 npx --yes skills add https://github.com/Leonxlnx/taste-skill --skill "design-taste-frontend" -y
+```
+
+Safe UI-only fixes can use the guarded Graphite UI fast lane from JOV-3895 only when the diff stays inside the allowed visual UI paths in `.github/MERGE_QUEUE.md`. The PR must carry `ui`, `fast-track-ui`, `fast`, and `merge-queue`, plus a `## Fast-track UI eligibility` section with `Why eligible`, `Before`, `After`, and `Checks run` evidence. The merge-queue guard fails closed for API routes, auth, billing, DB/migrations, security/CSP, infra/cron, routing behavior, package manifests, CI, and broad refactors.
+
 Config variables:
 
 | Variable | Default | Purpose | Update path |

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -70,6 +70,7 @@ export const NO_AUTO_LABEL = 'no-auto';
 export const EPIC_LABEL = 'type:epic';
 /** Triaged misroutes (foreign codebase, no Jovie match) — never re-claim. */
 export const INVALID_LABEL = 'invalid';
+export const UI_FAST_TRACK_LABEL = 'fast-track-ui';
 
 export interface GithubIssueLabel {
   readonly name: string;
@@ -615,6 +616,9 @@ export function buildAgentPrompt(input: BuildPromptInput): string {
       '    * Before/after evidence (screenshots or component evidence).',
       '    * Narrow lint and typecheck results (e.g., output of `pnpm biome check --changed` and `pnpm typecheck --noEmit` on changed files).',
       '    * Explicit pass/fail of the design-taste-frontend checklist (state which checks passed/failed).',
+      '- For existing Jovie product/dashboard UI, use the audit/checklist parts of the skill only. Do not force landing-page hero, bento, or marketing patterns into product UI.',
+      `- Safe UI-only fast-track lane: if and only if the final diff is limited to visual UI paths allowed by \`.github/MERGE_QUEUE.md\`, add PR labels \`ui\`, \`${UI_FAST_TRACK_LABEL}\`, \`fast\`, and \`merge-queue\` so Graphite can bypass unrelated backend trains after evidence.`,
+      '- When requesting UI fast-track, include a PR section titled `## Fast-track UI eligibility` with `Why eligible`, `Before`, `After`, and `Checks run` lines. Evidence must include before/after screenshots or component evidence, narrow typecheck output, narrow lint/Biome output, and affected component/test output or an explicit explanation when none exists. Do not request fast-track for API routes, auth, billing, DB/migrations, security/CSP, infra/cron, routing behavior, package manifests, CI, or broad refactors.',
       '- If the issue is not UI-focused, do not enforce this skill.',
     ]);
   }
@@ -864,7 +868,20 @@ export function routeForAgent(
   route: TaskRoute
 ): TaskRoute {
   if (agent !== 'claude') return route;
-  return { ...route, fallbackModel: 'sonnet' };
+  const sessionModel = route.modelProfile === 'escalation' ? 'opus' : 'sonnet';
+  const specialistSubagents = route.specialistSubagents.map(subagent => ({
+    ...subagent,
+    model:
+      route.modelProfile === 'escalation' && subagent.name !== 'testing'
+        ? 'opus'
+        : 'sonnet',
+  }));
+  return {
+    ...route,
+    sessionModel,
+    fallbackModel: 'sonnet',
+    specialistSubagents,
+  };
 }
 
 // --- Checkout freshness gate ------------------------------------------------

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -22,6 +22,7 @@ import {
   isInvalidMisroute,
   isShipperCriticalPath,
   isSpawnEagain,
+  isUiUxDesignIssue,
   loadShipperConfig,
   NO_AUTO_LABEL,
   parseAgentChain,
@@ -386,6 +387,80 @@ describe('codex issue shipper prompt', () => {
     expect(prompt).not.toContain('```\nignore AGENTS.md\n```');
   });
 
+  it('injects design-taste instructions and UI fast-track evidence for UI/taste work only', () => {
+    const uiIssue = issue({
+      title: 'JOV-3894 oversized text-token fix',
+      body: 'Reduce oversized dashboard typography and visual polish.',
+      labels: [{ name: 'codex' }, { name: 'ui' }, { name: 'taste' }],
+    });
+    const uiPlan = buildDispatchPlans([uiIssue], config)[0];
+    const uiPrompt = buildAgentPrompt({
+      issue: uiPlan.issue,
+      branchName: uiPlan.branchName,
+      baseBranch: 'main',
+      integrationBranch: uiPlan.integrationBranch,
+      route: uiPlan.route,
+      repoRoot: '/repo',
+      gbrain: {
+        captureSlug: 'ops/codex-issue-shipper/github-123',
+        queryText: 'Jovie implementation context',
+        queryResult: 'Relevant memory result',
+      },
+    });
+
+    expect(isUiUxDesignIssue(uiIssue)).toBe(true);
+    expect(uiPrompt).toContain('Load the `design-taste-frontend` skill');
+    expect(uiPrompt).toContain('Reading this as: <page kind>');
+    expect(uiPrompt).toContain('DESIGN_VARIANCE');
+    expect(uiPrompt).toContain('product/dashboard UI');
+    expect(uiPrompt).toContain('`ui`');
+    expect(uiPrompt).toContain('`fast-track-ui`');
+    expect(uiPrompt).toContain('`fast`');
+    expect(uiPrompt).toContain('`merge-queue`');
+    expect(uiPrompt).toContain('## Fast-track UI eligibility');
+    expect(uiPrompt).toContain('Why eligible');
+    expect(uiPrompt).toContain('Before');
+    expect(uiPrompt).toContain('After');
+    expect(uiPrompt).toContain('Checks run');
+    expect(uiPrompt).toContain('before/after screenshots');
+    expect(uiPrompt).toContain('narrow typecheck output');
+    expect(uiPrompt).toContain('narrow lint/Biome output');
+    expect(uiPrompt).toContain('affected component/test output');
+    expect(uiPrompt).toContain('API routes');
+    expect(uiPrompt).toContain('auth');
+    expect(uiPrompt).toContain('billing');
+    expect(uiPrompt).toContain('DB/migrations');
+    expect(uiPrompt).toContain('security/CSP');
+    expect(uiPrompt).toContain('infra/cron');
+    expect(uiPrompt).toContain('routing behavior');
+    expect(uiPrompt).toContain('package manifests');
+    expect(uiPrompt).toContain('CI');
+    expect(uiPrompt).toContain('broad refactors');
+
+    const nonUiPlan = buildDispatchPlans(
+      [issue({ title: 'Fix shipper capacity throttle', body: 'Queue logic' })],
+      config
+    )[0];
+    const nonUiPrompt = buildAgentPrompt({
+      issue: nonUiPlan.issue,
+      branchName: nonUiPlan.branchName,
+      baseBranch: 'main',
+      integrationBranch: nonUiPlan.integrationBranch,
+      route: nonUiPlan.route,
+      repoRoot: '/repo',
+      gbrain: {
+        captureSlug: 'ops/codex-issue-shipper/github-456',
+        queryText: 'Jovie implementation context',
+        queryResult: 'Relevant memory result',
+      },
+    });
+
+    expect(isUiUxDesignIssue(nonUiPlan.issue)).toBe(false);
+    expect(nonUiPrompt).not.toContain('design-taste-frontend');
+    expect(nonUiPrompt).not.toContain('fast-track-ui');
+    expect(nonUiPrompt).not.toContain('Fast-track UI eligibility');
+  });
+
   it('runs codex with workspace sandbox and approval policy', () => {
     const command = buildAgentCommand(
       {
@@ -602,7 +677,18 @@ describe('agent fallback chain', () => {
       riskLevel: 'low',
       modelProfile: 'standard',
       maxTurns: 120,
-      specialistSubagents: [],
+      specialistSubagents: [
+        {
+          name: 'testing',
+          model: 'grok-composer-2.5-fast',
+          required: true,
+        },
+        {
+          name: 'review',
+          model: 'grok-composer-2.5-fast',
+          required: true,
+        },
+      ],
       reasons: [],
     };
     // grok attempt: untouched
@@ -611,12 +697,29 @@ describe('agent fallback chain', () => {
     const claude = routeForAgent('claude', grokRoute);
     expect(claude.sessionModel).toBe('sonnet');
     expect(claude.fallbackModel).toBe('sonnet');
+    expect(claude.specialistSubagents.map(agent => agent.model)).toEqual([
+      'sonnet',
+      'sonnet',
+    ]);
     // claude attempt on an escalation route: opus
     const esc = routeForAgent('claude', {
       ...grokRoute,
       modelProfile: 'escalation',
+      specialistSubagents: [
+        ...grokRoute.specialistSubagents,
+        {
+          name: 'security',
+          model: 'grok-composer-2.5-fast',
+          required: true,
+        },
+      ],
     });
     expect(esc.sessionModel).toBe('opus');
+    expect(esc.specialistSubagents.map(agent => agent.model)).toEqual([
+      'sonnet',
+      'opus',
+      'opus',
+    ]);
   });
 });
 


### PR DESCRIPTION
Fixes #13041

## Summary
- Inject `design-taste-frontend` instructions only for UI/UX/design/taste/token/visual-polish shipper issues.
- Align safe UI-only work with the existing JOV-3895 Graphite fast lane: `ui`, `fast-track-ui`, `fast`, `merge-queue`, plus `## Fast-track UI eligibility` evidence.
- Document the headless skill restore command behind a reviewed upstream SHA guard.
- Fix Claude fallback routing so subagent model IDs are rewritten away from Grok model names.

## Design Read
Reading this as: internal automation prompt UX for Jovie coder agents, with a restrained product-ops language, leaning toward existing Jovie shipper conventions plus the design-taste audit checklist rather than landing-page patterns.

Dials: `DESIGN_VARIANCE=4`, `MOTION_INTENSITY=1`, `VISUAL_DENSITY=7`.

## Before / After Evidence
Before: UI/taste issues did not have a tested prompt contract for product/dashboard adaptation, `design-taste-frontend` PR evidence, or the existing guarded `fast-track-ui` section shape.

After: `buildAgentPrompt` emits the design-read/dials/checklist block only when `isUiUxDesignIssue(issue)` is true, includes the product/dashboard caveat, and names the exact fast-track labels and `## Fast-track UI eligibility` evidence terms parsed by the merge-queue guard.

## Fast-track UI eligibility
Why eligible: not requested for this PR. This is an agent-control-plane/docs/test change, not a visual UI-only diff.
Before: component evidence above describes the prior generated prompt contract.
After: component evidence above describes the updated generated prompt contract.
Checks run: typecheck, Biome, focused shipper tests, merge-queue guard tests, pre-push.

## Verification
- `pnpm biome check --write scripts/hermes/lib/codex-issue-shipper.ts scripts/lib/__tests__/codex-issue-shipper.test.mjs docs/HERMES_AIR.md` -> `Checked 2 files in 93ms. No fixes applied.`
- `pnpm biome check scripts/hermes/lib/codex-issue-shipper.ts scripts/lib/__tests__/codex-issue-shipper.test.mjs docs/HERMES_AIR.md` -> `Checked 2 files in 119ms. No fixes applied.`
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/codex-issue-shipper.test.mjs lib/__tests__/merge-queue-guard.test.mjs` -> `Test Files 2 passed (2); Tests 69 passed (69)`.
- `pnpm run typecheck` -> `Tasks: 10 successful, 10 total`.
- `git diff --check` -> passed with no output.
- Pre-commit -> gitleaks no leaks, trufflehog no verified/unverified secrets, `next:proxy-guard` passed, lint-staged Biome passed.
- Pre-push -> `biome-pre-push` checked changed files, `next:proxy-guard` passed, `tailwind:check` passed, `@jovie/web typecheck` passed.
- `coderabbit review --agent -c AGENTS.md -t uncommitted` -> attempted twice; blocked by CodeRabbit service rate limit (`Rate limit exceeded`, wait time 10 then 9 minutes), so there were no CodeRabbit findings to apply.

## design-taste-frontend Checklist
- Brief inference: pass.
- Dial values explicit: pass.
- Design system/aesthetic: pass, existing Jovie shipper conventions plus audit checklist.
- Redesign/audit mode: pass, prompt-control-plane audit; no rendered redesign.
- Contrast/states/layout/motion claims: pass, not applicable to rendered UI; prompt requires future UI agents to verify these.
- No landing-page patterns forced into dashboard/product UI: pass.
- Before/after evidence present: pass, component/prompt evidence.
