### PR TITLE
Codex queue integration train

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -203,6 +203,18 @@ The example above says one thing three times. Jovie should say it once.
 - Hover feedback should stay visual, not positional. Prefer color, border, or shadow changes. Do not make the interface jump on hover unless the motion communicates direct manipulation.
 - Before shipping a UI, run this check: does it look like a generic AI-generated SaaS mockup? If yes, remove chrome until it feels native to Jovie
 
+### Ovie Ops Cockpit Guardrail
+
+Ovie UI/UX work must use the make-interfaces-better path: load gstack `/design-review`, load `design-taste-frontend` where available, and run the checklist in `docs/ovie-design-guardrails.md`.
+
+Before changing Ovie UI, include the Design Read line:
+
+`Reading this as: <page kind> for <audience>, with a <vibe> language, leaning toward <design system or aesthetic>`
+
+Ovie should read as a macOS ops cockpit: dense but calm, fast, native-feeling, and focused on operator decisions. Do not import landing-page patterns, decorative AI-dashboard chrome, oversized hero/card structures, or motion that makes controls jump.
+
+Ovie UI PRs require before/after screenshots or component evidence and explicit pass/fail for hierarchy, spacing, typography scale, visual density, interaction states, contrast, macOS-native affordances, and no layout jank.
+
 ---
 
 ## Subtraction Principle

--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -198,7 +198,7 @@ HERMES_CODEX_SHIPPER_DRY_RUN=1 tsx scripts/hermes/jobs/codex-issue-shipper.ts
 tsx scripts/hermes/jobs/codex-issue-shipper.ts
 ```
 
-The job watches open GitHub issues labeled `codex`. Empty runs only call GitHub, write a JSONL event, and exit. No gbrain query, model call, subagent, or CodeRabbit review starts until an eligible issue exists.
+The job watches open GitHub issues and filters out hard-skip labels (`no-auto`, `invalid`, `type:epic`, `human-review-required`, already-claimed, or blocked). Empty runs only call GitHub, write a JSONL event, and exit. No gbrain query, model call, subagent, or CodeRabbit review starts until an eligible issue exists.
 
 Only one shipper run may own the queue at a time. A new cron invocation takes a non-blocking singleton lock check; if another shipper is still active, the new invocation logs `singleton_active_skip` and exits. The active run keeps draining the queue in batches until no eligible issues remain, the machine is under too much pressure to launch another agent, or all remaining issues are blocked or human-gated.
 

--- a/docs/ovie-design-guardrails.md
+++ b/docs/ovie-design-guardrails.md
@@ -1,0 +1,44 @@
+# Ovie Design Guardrails
+
+Ovie is Jovie's local macOS ops cockpit. Treat Ovie UI work as product/admin UI, not marketing or landing-page work: dense but calm, fast, native-feeling, and stripped of AI-slop decoration.
+
+## Required Routing
+
+Any Ovie UI or UX task must run through the existing make-interfaces-better guardrail:
+
+- Load gstack `/design-review` before marking visual work complete.
+- Load `design-taste-frontend` where available and run its audit checklist.
+- Read `DESIGN.md` and this file before changing Ovie UI.
+- Preserve Ovie's local dirty state first. If `~/JovieInc/ovie` has uncommitted changes, inspect them and avoid overwriting unrelated work.
+
+## Design Read
+
+Before editing Ovie UI, write this one-line statement in the agent notes and PR:
+
+`Reading this as: <page kind> for <audience>, with a <vibe> language, leaning toward <design system or aesthetic>`
+
+For most Ovie work, the default read should be:
+
+`Reading this as: macOS ops cockpit for Jovie operators, with a calm dense native language, leaning toward Linear-style product UI adapted to macOS.`
+
+Set the design dials from that read:
+
+- `DESIGN_VARIANCE`: low to medium. Use known Jovie and macOS patterns before inventing new chrome.
+- `MOTION_INTENSITY`: low. Motion should clarify state, never decorate.
+- `VISUAL_DENSITY`: medium to high. Ovie should scan quickly without feeling crowded.
+
+## Completion Evidence
+
+Ovie UI PRs cannot be marked complete without visible proof:
+
+- Before/after screenshots for rendered UI changes, or component evidence when a full app capture is not practical.
+- A pass/fail checklist covering hierarchy, spacing, typography scale, visual density, interaction states, contrast, macOS-native affordances, and no layout jank.
+- Notes for any failed checklist item, with the linked follow-up Linear issue if it is intentionally not fixed in the PR.
+
+## Ovie-Specific Taste Rules
+
+- Prefer native macOS affordances: menu bar expectations, compact controls, clear keyboard paths, stable panels, and familiar status language.
+- Preserve the ops-cockpit purpose. The interface should make queue state, agent health, blocked work, and next actions easier to scan.
+- Avoid random web patterns: oversized heroes, decorative gradients, promotional sections, feature cards, and landing-page explanation stacks.
+- Avoid generic AI-admin styling: too many rounded bordered panels, icon-on-color squares, all-caps labels, excessive badges, and helper text that repeats visible state.
+- Layout state changes must not jump. Loading, empty, error, degraded, populated, focused, hover, selected, and disabled states need reserved space or stable containers.

--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -130,6 +130,24 @@ interface AgentRunResult {
   readonly error?: string;
   readonly logPath: string;
   readonly promptPath: string;
+  readonly statePath: string;
+}
+
+interface AgentAttemptState {
+  readonly job: typeof JOB;
+  readonly issue: number;
+  readonly branch: string;
+  readonly agent: ShipperConfig['agent'];
+  readonly model: string;
+  readonly repoRoot: string;
+  readonly promptPath: string;
+  readonly logPath: string;
+  readonly startedAt: string;
+  readonly updatedAt: string;
+  readonly status: 'running' | 'succeeded' | 'failed';
+  readonly exitStatus?: number | null;
+  readonly signal?: NodeJS.Signals | null;
+  readonly error?: string;
 }
 
 interface CapacitySnapshot {
@@ -144,6 +162,22 @@ interface CapacitySnapshot {
 function shortError(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
+}
+
+function writeAgentAttemptState(
+  statePath: string,
+  state: AgentAttemptState
+): void {
+  try {
+    writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'agent_attempt_state_write_failed',
+      statePath,
+      error: shortError(err),
+    });
+  }
 }
 
 function unquoteEnvValue(value: string): string {
@@ -852,7 +886,22 @@ function runAgent(
   const base = `github-${plan.issue.number}-${timestamp}`;
   const logPath = join(dir, `${base}.log`);
   const promptPath = join(dir, `${base}.prompt.md`);
+  const statePath = join(dir, `${base}.state.json`);
   writeFileSync(promptPath, prompt);
+  const startedAt = new Date().toISOString();
+  writeAgentAttemptState(statePath, {
+    job: JOB,
+    issue: plan.issue.number,
+    branch: plan.branchName,
+    agent: config.agent,
+    model: plan.route.sessionModel,
+    repoRoot,
+    promptPath,
+    logPath,
+    startedAt,
+    updatedAt: startedAt,
+    status: 'running',
+  });
   appendFileSync(
     logPath,
     [
@@ -860,7 +909,8 @@ function runAgent(
       `issue=${plan.issue.number}`,
       `branch=${plan.branchName}`,
       `model=${plan.route.sessionModel}`,
-      `started=${new Date().toISOString()}`,
+      `started=${startedAt}`,
+      `state=${statePath}`,
       '',
     ].join('\n')
   );
@@ -882,13 +932,29 @@ function runAgent(
     });
 
     const finish = (
-      result: Omit<AgentRunResult, 'logPath' | 'promptPath'>
+      result: Omit<AgentRunResult, 'logPath' | 'promptPath' | 'statePath'>
     ): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
       closeSync(fd);
-      resolve({ ...result, logPath, promptPath });
+      writeAgentAttemptState(statePath, {
+        job: JOB,
+        issue: plan.issue.number,
+        branch: plan.branchName,
+        agent: config.agent,
+        model: plan.route.sessionModel,
+        repoRoot,
+        promptPath,
+        logPath,
+        startedAt,
+        updatedAt: new Date().toISOString(),
+        status: result.ok ? 'succeeded' : 'failed',
+        exitStatus: result.status,
+        signal: result.signal,
+        error: result.error,
+      });
+      resolve({ ...result, logPath, promptPath, statePath });
     };
 
     timeout = setTimeout(() => {
@@ -1039,6 +1105,7 @@ async function dispatchPlan(
         error: agentResult.error,
         logPath: agentResult.logPath,
         promptPath: agentResult.promptPath,
+        statePath: agentResult.statePath,
         gbrainSlug: gbrain.captureSlug,
       });
 
@@ -1077,6 +1144,7 @@ async function dispatchPlan(
           '',
           agentResult.error ? `Error: \`${agentResult.error}\`` : null,
           `Log: \`${agentResult.logPath}\``,
+          `State: \`${agentResult.statePath}\``,
         ]
           .filter((line): line is string => line !== null)
           .join('\n')
@@ -1104,6 +1172,7 @@ async function dispatchPlan(
           agentResult.error ? `Error: \`${agentResult.error}\`` : null,
           `Log: \`${agentResult.logPath}\``,
           `Prompt: \`${agentResult.promptPath}\``,
+          `State: \`${agentResult.statePath}\``,
         ]
           .filter((line): line is string => line !== null)
           .join('\n')
@@ -1127,6 +1196,7 @@ async function dispatchPlan(
             branchName: dispatch.branchName,
             issue: dispatch.issue,
             logPath: agentResult.logPath,
+            statePath: agentResult.statePath,
           });
           pr = findPrForBranch(config, dispatch.branchName);
           logJobEvent({
@@ -1157,6 +1227,7 @@ async function dispatchPlan(
           '',
           `Log: \`${agentResult.logPath}\``,
           `Prompt: \`${agentResult.promptPath}\``,
+          `State: \`${agentResult.statePath}\``,
         ].join('\n')
       );
       logJobEvent({
@@ -1179,6 +1250,7 @@ async function dispatchPlan(
           `PR: ${pr.url}`,
           `GBrain dispatch slug: \`${gbrain.captureSlug}\``,
           `Log: \`${agentResult.logPath}\``,
+          `State: \`${agentResult.statePath}\``,
         ].join('\n')
       );
     } catch (err) {

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -593,6 +593,8 @@ export function buildAgentPrompt(input: BuildPromptInput): string {
     '- Use gbrain before planning. Start with the gbrain context below, then run a targeted `gbrain query` if the first results are not enough.',
     '- Use gstack workflows. For complex work run `/autoplan`; for bugs run `/investigate`; before shipping run exhaustive `/qa`; for PR creation use `/ship`.',
     '- Use subagents. At minimum dispatch testing and review subagents. Add security, performance, architecture, or design subagents when the risk profile calls for them.',
+    '- Keep progress file-backed: do not rely on chat-only handoff. Put the current state, blockers, and verification evidence in the PR body or GitHub issue comment, and preserve generated prompt/log/state artifact paths when available.',
+    '- When you create or update a PR, include the repo-standard hidden `<!-- agent-run-artifact ... -->` evidence block when the workflow provides one, and keep its verification gate statuses truthful.',
     '- Run local CodeRabbit review before shipping: `coderabbit review --agent -c AGENTS.md -t uncommitted`. Fix actionable issues, then rerun if the diff changed.',
     '- Exhaustively QA your own work. Run typecheck and focused tests. For UI edits, verify layout-shift states and capture screenshots. For backend/control-plane edits, test the failure path and the empty path.',
     '- Create a PR, link this GitHub issue with `Fixes #<issue-number>`, and include exact verification output in the PR body.',
@@ -760,17 +762,97 @@ export function buildFinishCommitMessage(issue: GithubIssue): string {
   ].join('\n');
 }
 
-export function buildFinishPrBody(issue: GithubIssue, logPath: string): string {
+function buildFinisherAgentRunArtifactComment(
+  issue: GithubIssue,
+  logPath: string,
+  statePath?: string
+): string {
+  const now = new Date().toISOString();
+  const queuedGate = (name: string, summary: string) => ({
+    name,
+    required: true,
+    status: 'queued',
+    evidenceUrl: null,
+    summary,
+    checkedAt: now,
+  });
+  const artifact = {
+    id: `hermes-codex-finish-github-${issue.number}`,
+    source: 'hermes',
+    sourceRunId: `github-${issue.number}`,
+    kind: 'workflow',
+    status: 'review',
+    title: `Deterministic finisher for GitHub #${issue.number}`,
+    summary:
+      'The coding agent exited with work but no PR; the Hermes deterministic finisher committed, pushed, and opened this PR for normal CI/review gates.',
+    modelRoute: 'deterministic',
+    allowedActions: ['open_pr'],
+    forbiddenActions: [
+      'merge',
+      'deploy',
+      'mutate_production_data',
+      'change_auth',
+      'change_billing',
+      'change_security',
+    ],
+    humanApprovalRequired: false,
+    humanGate: {
+      required: false,
+      status: 'not_required',
+      reason: null,
+      reviewer: null,
+      reviewedAt: null,
+    },
+    linearIssueId: null,
+    linearIssueUrl: null,
+    pullRequestUrl: null,
+    adminSurface: null,
+    verificationGates: [
+      queuedGate('gstack.qa.exhaustive', 'Awaiting QA evidence or PR update.'),
+      queuedGate('gstack.review', 'Awaiting review evidence or PR update.'),
+      queuedGate('gstack.ship', 'Finisher opened PR; ship gate is queued.'),
+      queuedGate('github.ci', 'PR CI will run after branch push.'),
+    ],
+    costEstimate: null,
+    blockedReason: null,
+    createdAt: now,
+    updatedAt: now,
+    metadata: {
+      issueNumber: issue.number,
+      issueUrl: issue.url,
+      logPath,
+      statePath: statePath ?? null,
+    },
+  };
+
+  return `<!-- agent-run-artifact\n${JSON.stringify(artifact, null, 2)}\n-->`;
+}
+
+export function buildFinishPrBody(
+  issue: GithubIssue,
+  logPath: string,
+  statePath?: string
+): string {
   return [
     `Fixes #${issue.number}`,
     '',
     'Opened by the codex-issue-shipper **deterministic finisher**: the coding',
-    'agent produced this diff but exited without opening a PR. Pre-commit hooks',
-    '(lint-staged, typecheck) passed at commit time; CI is the merge gate as',
-    'usual.',
+    'agent produced this diff but exited without opening a PR. The finisher',
+    'committed with hooks enabled, pushed the branch, and opened this PR so CI',
+    'and bot review can own the merge gate.',
     '',
     `Agent log: \`${logPath}\``,
-  ].join('\n');
+    statePath ? `Dispatch state: \`${statePath}\`` : null,
+    '',
+    'Verification evidence:',
+    '- Deterministic finisher completed `git commit` with repository hooks enabled.',
+    '- PR CI remains required before merge.',
+    '- Review the linked agent log/state artifact for any command output the agent produced before the finisher took over.',
+    '',
+    buildFinisherAgentRunArtifactComment(issue, logPath, statePath),
+  ]
+    .filter((line): line is string => line !== null)
+    .join('\n');
 }
 
 /**
@@ -785,6 +867,7 @@ export function finishDispatch(
     readonly branchName: string;
     readonly issue: GithubIssue;
     readonly logPath: string;
+    readonly statePath?: string;
   }
 ): void {
   const dirty = runInWorktree(['git', 'status', '--porcelain']).trim();
@@ -822,7 +905,7 @@ export function finishDispatch(
       '--title',
       `chore(codex): ${input.issue.title.replace(/\s+/g, ' ').trim().slice(0, 90)} (#${input.issue.number})`,
       '--body',
-      buildFinishPrBody(input.issue, input.logPath),
+      buildFinishPrBody(input.issue, input.logPath, input.statePath),
     ],
     { timeoutMs: 2 * 60 * 1000 }
   );

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -353,6 +353,15 @@ export function isUiUxDesignIssue(issue: GithubIssue): boolean {
   return keywords.some(k => text.includes(k));
 }
 
+export function isOvieIssue(issue: GithubIssue): boolean {
+  const text = issueText(issue).toLowerCase();
+  return /\bovie\b/.test(text) || labelNames(issue).includes('area:ovie');
+}
+
+export function isOvieUiUxDesignIssue(issue: GithubIssue): boolean {
+  return isOvieIssue(issue) && isUiUxDesignIssue(issue);
+}
+
 export function eligibleCodexIssues(
   issues: ReadonlyArray<GithubIssue>
 ): ReadonlyArray<GithubIssue> {
@@ -622,6 +631,19 @@ export function buildAgentPrompt(input: BuildPromptInput): string {
       `- Safe UI-only fast-track lane: if and only if the final diff is limited to visual UI paths allowed by \`.github/MERGE_QUEUE.md\`, add PR labels \`ui\`, \`${UI_FAST_TRACK_LABEL}\`, \`fast\`, and \`merge-queue\` so Graphite can bypass unrelated backend trains after evidence.`,
       '- When requesting UI fast-track, include a PR section titled `## Fast-track UI eligibility` with `Why eligible`, `Before`, `After`, and `Checks run` lines. Evidence must include before/after screenshots or component evidence, narrow typecheck output, narrow lint/Biome output, and affected component/test output or an explicit explanation when none exists. Do not request fast-track for API routes, auth, billing, DB/migrations, security/CSP, infra/cron, routing behavior, package manifests, CI, or broad refactors.',
       '- If the issue is not UI-focused, do not enforce this skill.',
+    ]);
+  }
+
+  if (isOvieUiUxDesignIssue(input.issue)) {
+    result = result.concat([
+      '',
+      '## Ovie UX Guardrail (JOV-3897)',
+      '- Treat Ovie as a consumer of the make-interfaces-better/design-review guardrail: load `/design-review` for visual QA and `design-taste-frontend` where available.',
+      "- Start every Ovie UI change with this one-line Design Read: 'Reading this as: <page kind> for <audience>, with a <vibe> language, leaning toward <design system or aesthetic>'.",
+      '- Adapt the guardrail to Ovie as a macOS ops cockpit: dense but calm, fast, native-feeling, no AI-slop decoration, and no random web landing-page patterns.',
+      '- Ovie UI PRs need before/after screenshots or component evidence, plus explicit pass/fail for hierarchy, spacing, typography scale, visual density, interaction states, contrast, macOS-native affordances, and no layout jank.',
+      '- If the local Ovie repo is dirty, inspect and preserve that state before editing it; do not overwrite unrelated uncommitted Ovie work.',
+      '- Reference `docs/ovie-design-guardrails.md` and `DESIGN.md` in the PR body when the change touches Ovie UI/UX.',
     ]);
   }
 

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -20,6 +20,7 @@ import {
   INVALID_LABEL,
   isAlreadyClaimedOrBlocked,
   isInvalidMisroute,
+  isOvieUiUxDesignIssue,
   isShipperCriticalPath,
   isSpawnEagain,
   isUiUxDesignIssue,
@@ -54,6 +55,25 @@ function issue(overrides = {}) {
     labels: [{ name: 'codex' }, { name: CODEX_TRUSTED_LABEL }],
     ...overrides,
   };
+}
+
+function buildPromptForIssue(overrides = {}) {
+  const plan = buildDispatchPlans([issue(overrides)], config)[0];
+  const prompt = buildAgentPrompt({
+    issue: plan.issue,
+    branchName: plan.branchName,
+    baseBranch: 'main',
+    integrationBranch: plan.integrationBranch,
+    route: plan.route,
+    repoRoot: '/repo',
+    gbrain: {
+      captureSlug: 'ops/codex-issue-shipper/github-123',
+      queryText: 'Jovie implementation context',
+      queryResult: 'Relevant memory result',
+    },
+  });
+
+  return { plan, prompt };
 }
 
 describe('spawn EAGAIN recovery helpers', () => {
@@ -305,6 +325,70 @@ describe('codex issue shipper prompt', () => {
     expect(prompt).toContain(
       'Captured slug: ops/codex-issue-shipper/github-123'
     );
+  });
+
+  it('adds Ovie-specific make-interfaces-better guardrails to Ovie UX prompts', () => {
+    const { plan, prompt } = buildPromptForIssue({
+      title: 'Ovie UX guardrail: require design review standards',
+      body: 'Update Ovie interface review routing.',
+      labels: [
+        { name: 'codex' },
+        { name: CODEX_TRUSTED_LABEL },
+        { name: 'area:ui' },
+      ],
+    });
+
+    expect(isOvieUiUxDesignIssue(plan.issue)).toBe(true);
+    expect(prompt).toContain('## Ovie UX Guardrail (JOV-3897)');
+    expect(prompt).toContain('make-interfaces-better/design-review');
+    expect(prompt).toContain('macOS ops cockpit');
+    expect(prompt).toContain('before/after screenshots or component evidence');
+    expect(prompt).toContain('macOS-native affordances');
+    expect(prompt).toContain('no layout jank');
+    expect(prompt).toContain('docs/ovie-design-guardrails.md');
+  });
+
+  it('adds Ovie UX guardrails when Ovie is label-only and the body is empty', () => {
+    const { plan, prompt } = buildPromptForIssue({
+      title: 'Require interface review standards',
+      body: '',
+      labels: [
+        { name: 'codex' },
+        { name: CODEX_TRUSTED_LABEL },
+        { name: 'area:ovie' },
+        { name: 'area:ui' },
+      ],
+    });
+
+    expect(isOvieUiUxDesignIssue(plan.issue)).toBe(true);
+    expect(prompt).toContain('## Ovie UX Guardrail (JOV-3897)');
+  });
+
+  it('does not add Ovie guardrails to non-Ovie UI prompts', () => {
+    const { plan, prompt } = buildPromptForIssue({
+      title: 'Improve dashboard interface spacing',
+      body: 'Polish the dashboard layout.',
+      labels: [
+        { name: 'codex' },
+        { name: CODEX_TRUSTED_LABEL },
+        { name: 'area:ui' },
+      ],
+    });
+
+    expect(isOvieUiUxDesignIssue(plan.issue)).toBe(false);
+    expect(prompt).toContain('## UI/UX Design Skill Instructions');
+    expect(prompt).not.toContain('## Ovie UX Guardrail (JOV-3897)');
+  });
+
+  it('does not add Ovie UX guardrails to non-UI Ovie prompts', () => {
+    const { plan, prompt } = buildPromptForIssue({
+      title: 'Ovie shipper retry logs',
+      body: 'Improve retry diagnostics for automation.',
+      labels: [{ name: 'codex' }, { name: CODEX_TRUSTED_LABEL }],
+    });
+
+    expect(isOvieUiUxDesignIssue(plan.issue)).toBe(false);
+    expect(prompt).not.toContain('## Ovie UX Guardrail (JOV-3897)');
   });
 
   it('captures issue body and labels for gbrain', () => {

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -291,6 +291,8 @@ describe('codex issue shipper prompt', () => {
     expect(prompt).toContain('Load gstack');
     expect(prompt).toContain('Use gbrain before planning');
     expect(prompt).toContain('Use subagents');
+    expect(prompt).toContain('Keep progress file-backed');
+    expect(prompt).toContain('agent-run-artifact');
     expect(prompt).toContain('/qa');
     expect(prompt).toContain('/ship');
     expect(prompt).toContain(
@@ -592,6 +594,7 @@ describe('deterministic finisher', () => {
       branchName: 'codex/gh-12721-x',
       issue,
       logPath: '/tmp/agent.log',
+      statePath: '/tmp/agent.state.json',
     });
     const cmds = calls.map(c => c.args.slice(0, 2).join(' '));
     expect(cmds).toEqual([
@@ -614,6 +617,21 @@ describe('deterministic finisher', () => {
     expect(prCreate).toContain('--head');
     expect(prCreate[prCreate.indexOf('--head') + 1]).toBe('codex/gh-12721-x');
     expect(prCreate[prCreate.indexOf('--body') + 1]).toContain('Fixes #12721');
+    expect(prCreate[prCreate.indexOf('--body') + 1]).toContain(
+      'Dispatch state: `/tmp/agent.state.json`'
+    );
+    expect(prCreate[prCreate.indexOf('--body') + 1]).toContain(
+      'Verification evidence:'
+    );
+    expect(prCreate[prCreate.indexOf('--body') + 1]).toContain(
+      '<!-- agent-run-artifact'
+    );
+    expect(prCreate[prCreate.indexOf('--body') + 1]).toContain(
+      '"source": "hermes"'
+    );
+    expect(prCreate[prCreate.indexOf('--body') + 1]).toContain(
+      '"status": "queued"'
+    );
   });
 
   it('finishDispatch skips commit when work is already committed', () => {
@@ -670,7 +688,7 @@ describe('agent fallback chain', () => {
     ).toEqual(['grok', 'claude']);
   });
 
-  it('routeForAgent rewrites the model only for claude attempts', () => {
+  it('routeForAgent rewrites only the fallback model for claude attempts', () => {
     const grokRoute = {
       sessionModel: 'grok-composer-2.5-fast',
       fallbackModel: 'grok-composer-2.5-fast',
@@ -693,7 +711,7 @@ describe('agent fallback chain', () => {
     };
     // grok attempt: untouched
     expect(routeForAgent('grok', grokRoute)).toBe(grokRoute);
-    // claude attempt: sonnet for standard risk
+    // claude attempt: route through Claude's model family.
     const claude = routeForAgent('claude', grokRoute);
     expect(claude.sessionModel).toBe('sonnet');
     expect(claude.fallbackModel).toBe('sonnet');


### PR DESCRIPTION
## Summary

Fixes #13039.
Fixes #13042.

Integration train from `integration/codex-queue` to `main` for codex issue shipper guardrail/control-plane updates.

Includes:
- #13091 Agent harness audit: make Jovie/OpenClaw loop file-backed and self-validating
- #13094 Ovie UX guardrail: require make-interfaces-better/design-review standards

## Verification before train

Feature PR #13091 local/integration verification:
- `pnpm biome check --write scripts/hermes/lib/codex-issue-shipper.ts scripts/hermes/jobs/codex-issue-shipper.ts scripts/lib/__tests__/codex-issue-shipper.test.mjs docs/HERMES_AIR.md` — passed.
- `pnpm exec vitest run scripts/lib/__tests__/codex-issue-shipper.test.mjs` — passed, 39 tests.
- `pnpm --filter @jovie/web run test:bug-to-test` — passed, not applicable.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- Integration script local verify and push pre-push gates passed before #13091 merged into `integration/codex-queue`.

Feature PR #13094 local/integration verification:
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/codex-issue-shipper.test.mjs` — passed, 44 tests.
- `pnpm biome check DESIGN.md docs/ovie-design-guardrails.md scripts/hermes/lib/codex-issue-shipper.ts scripts/lib/__tests__/codex-issue-shipper.test.mjs` — passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm run test:bug-to-test` — passed, not applicable.
- `git diff --check -- DESIGN.md docs/ovie-design-guardrails.md scripts/hermes/lib/codex-issue-shipper.ts scripts/lib/__tests__/codex-issue-shipper.test.mjs` — passed.
- Integration script local verify and push pre-push gates passed before #13094 merged into `integration/codex-queue`.
- CodeRabbit local review completed once and its trivial finding was fixed; rerun after the diff changed was attempted and blocked by external rate limit.

## Design Evidence For #13094

Design Read: Reading this as: documentation and shipper guardrail for Jovie/Ovie coder agents, with a calm operational language, leaning toward Linear-style product/admin UI adapted to macOS.

Before/after evidence: no rendered UI changed. Evidence is component/prompt-level: Ovie UI/UX shipper prompts now include `## Ovie UX Guardrail (JOV-3897)`, and docs require Design Read, screenshots/component evidence, pass/fail checklist, macOS-native affordances, and no layout jank.

Design checklist: hierarchy pass; spacing pass; typography scale pass; visual density pass; interaction states pass by requirement text/no UI changed; contrast pass by requirement text/no UI changed; macOS-native affordances pass; no layout jank pass by requirement text/no UI changed.

Full main-train CI remains required before merge.
