### PR TITLE
Capture flow: single-field email/SMS

### DIFF
--- a/apps/web/app/api/profile/capture-dismissal/route.ts
+++ b/apps/web/app/api/profile/capture-dismissal/route.ts
@@ -1,0 +1,211 @@
+import { and, eq, gt } from 'drizzle-orm';
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createRateLimitedResponse } from '@/app/api/notifications/route-helpers';
+import { AUDIENCE_ANON_COOKIE } from '@/constants/app';
+import { db } from '@/lib/db';
+import { publicProfileCaptureDismissals } from '@/lib/db/schema/analytics';
+import { isSecureEnv } from '@/lib/env-server';
+import { captureError } from '@/lib/error-tracking';
+import { generalLimiter, getClientIP } from '@/lib/rate-limit';
+import { uuidSchema } from '@/lib/validation/schemas/base';
+
+export const runtime = 'nodejs';
+
+const DISMISSAL_DAYS = 7;
+const DISMISSAL_SESSION_CAP = 3;
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+const dismissalSchema = z.object({
+  artist_id: uuidSchema,
+  source: z.string().min(1).max(80).optional(),
+});
+
+function buildNextEligibleAt(now = new Date()) {
+  return new Date(now.getTime() + DISMISSAL_DAYS * 24 * 60 * 60 * 1000);
+}
+
+async function resolveAudienceId() {
+  const cookieStore = await cookies();
+  const existing = cookieStore.get(AUDIENCE_ANON_COOKIE)?.value;
+  if (existing) return { audienceId: existing, shouldSetCookie: false };
+
+  const audienceId = crypto.randomUUID();
+  return { audienceId, shouldSetCookie: true };
+}
+
+function setAudienceCookie(response: NextResponse, audienceId: string) {
+  response.cookies.set(AUDIENCE_ANON_COOKIE, audienceId, {
+    httpOnly: true,
+    secure: isSecureEnv(),
+    sameSite: 'lax',
+    maxAge: COOKIE_MAX_AGE_SECONDS,
+    path: '/',
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const clientIp = getClientIP(request);
+  const rateLimitResult = await generalLimiter.limit(clientIp);
+
+  if (!rateLimitResult.success) {
+    return createRateLimitedResponse(rateLimitResult);
+  }
+
+  const parsed = dismissalSchema.pick({ artist_id: true }).safeParse({
+    artist_id: request.nextUrl.searchParams.get('artist_id'),
+  });
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: 'Invalid request data' },
+      { status: 400, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+
+  const { audienceId, shouldSetCookie } = await resolveAudienceId();
+  const now = new Date();
+
+  try {
+    const [dismissal] = await db
+      .select({
+        id: publicProfileCaptureDismissals.id,
+        sessionCount: publicProfileCaptureDismissals.sessionCount,
+        nextEligibleAt: publicProfileCaptureDismissals.nextEligibleAt,
+      })
+      .from(publicProfileCaptureDismissals)
+      .where(
+        and(
+          eq(
+            publicProfileCaptureDismissals.creatorProfileId,
+            parsed.data.artist_id
+          ),
+          eq(publicProfileCaptureDismissals.audienceId, audienceId),
+          gt(publicProfileCaptureDismissals.nextEligibleAt, now)
+        )
+      )
+      .limit(1);
+
+    const suppressed = Boolean(
+      dismissal && dismissal.sessionCount < DISMISSAL_SESSION_CAP
+    );
+
+    if (dismissal && suppressed) {
+      await db
+        .update(publicProfileCaptureDismissals)
+        .set({
+          sessionCount: dismissal.sessionCount + 1,
+          updatedAt: now,
+        })
+        .where(eq(publicProfileCaptureDismissals.id, dismissal.id));
+    }
+
+    const response = NextResponse.json(
+      {
+        success: true,
+        suppressed,
+        sessionCount: dismissal?.sessionCount ?? 0,
+        nextEligibleAt: dismissal?.nextEligibleAt?.toISOString() ?? null,
+      },
+      {
+        headers: { 'Cache-Control': 'no-store' },
+      }
+    );
+    if (shouldSetCookie) {
+      setAudienceCookie(response, audienceId);
+    }
+    return response;
+  } catch (error) {
+    await captureError('Profile capture dismissal status failed', error, {
+      artistId: parsed.data.artist_id,
+    });
+    return NextResponse.json(
+      { success: false, error: 'Unable to load dismissal state' },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const clientIp = getClientIP(request);
+  const rateLimitResult = await generalLimiter.limit(clientIp);
+
+  if (!rateLimitResult.success) {
+    return createRateLimitedResponse(rateLimitResult);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Invalid request data' },
+      { status: 400, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+
+  const parsed = dismissalSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: 'Invalid request data' },
+      { status: 400, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+
+  const { audienceId, shouldSetCookie } = await resolveAudienceId();
+  const now = new Date();
+  const nextEligibleAt = buildNextEligibleAt(now);
+
+  try {
+    await db
+      .insert(publicProfileCaptureDismissals)
+      .values({
+        creatorProfileId: parsed.data.artist_id,
+        audienceId,
+        sessionCount: 0,
+        source: parsed.data.source,
+        dismissedAt: now,
+        nextEligibleAt,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          publicProfileCaptureDismissals.creatorProfileId,
+          publicProfileCaptureDismissals.audienceId,
+        ],
+        set: {
+          sessionCount: 0,
+          source: parsed.data.source,
+          dismissedAt: now,
+          nextEligibleAt,
+          updatedAt: now,
+        },
+      });
+
+    const response = NextResponse.json(
+      {
+        success: true,
+        suppressed: true,
+        sessionCap: DISMISSAL_SESSION_CAP,
+        nextEligibleAt: nextEligibleAt.toISOString(),
+      },
+      {
+        headers: { 'Cache-Control': 'no-store' },
+      }
+    );
+    if (shouldSetCookie) {
+      setAudienceCookie(response, audienceId);
+    }
+    return response;
+  } catch (error) {
+    await captureError('Profile capture dismissal persist failed', error, {
+      artistId: parsed.data.artist_id,
+    });
+    return NextResponse.json(
+      { success: false, error: 'Unable to save dismissal' },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+}

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useProfileNotifications } from '@/components/organisms/profile-shell/ProfileNotificationsContext';
 import { useUserSafe } from '@/hooks/useClerkSafe';
 import { track } from '@/lib/analytics';
+import { captureError } from '@/lib/error-tracking';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
 import { readArtistEmailReadyFromSettings } from '@/lib/notifications/artist-email';
 import { normalizeSubscriptionEmail } from '@/lib/notifications/validation';
@@ -68,6 +69,22 @@ function birthdayDigitsToStorage(digits: string): string {
 }
 
 const MAX_BIRTHDAY_AGE_YEARS = 120;
+const CAPTURE_SUCCESS_HOLD_MS = 1200;
+
+function maskCapturedContact(value: string, channel: 'email' | 'sms') {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if (channel === 'sms') {
+    const digits = trimmed.replaceAll(/[^\d]/g, '');
+    return digits.length >= 4 ? `••• ${digits.slice(-4)}` : 'Your phone';
+  }
+
+  const [local = '', domain = ''] = trimmed.split('@');
+  if (!domain) return 'Your email';
+  const visible = local.slice(0, Math.min(2, local.length));
+  return `${visible}${local.length > 2 ? '•••' : '•'}@${domain}`;
+}
 
 function isValidBirthdayDigits(digits: string): boolean {
   if (digits.length !== 8) {
@@ -158,6 +175,7 @@ export function ProfileInlineNotificationsCTA({
     isResending,
     handleChannelChange,
     handleEmailChange,
+    handlePhoneChange,
     handleOtpChange,
     handleSubscribe,
     handleVerifyOtp,
@@ -167,6 +185,12 @@ export function ProfileInlineNotificationsCTA({
     subscribedChannels,
     openSubscription,
     hydrationStatus,
+    phoneInput,
+    country,
+    setCountry,
+    isCountryOpen,
+    setIsCountryOpen,
+    channel,
   } = useSubscriptionForm({
     artist,
     source,
@@ -193,6 +217,10 @@ export function ProfileInlineNotificationsCTA({
   const [nameInput, setNameInput] = useState('');
   const [birthdayInput, setBirthdayInput] = useState('');
   const [birthdayHintShown, setBirthdayHintShown] = useState(false);
+  const [successContactEcho, setSuccessContactEcho] = useState<string | null>(
+    null
+  );
+  const [captureSuppressed, setCaptureSuppressed] = useState(false);
   const [alertPrefs, setAlertPrefs] = useState<
     Record<NotificationContentType, boolean>
   >(() => {
@@ -212,6 +240,9 @@ export function ProfileInlineNotificationsCTA({
   const hasAutoOpenedRef = useRef(false);
   const activatedInCurrentFlowRef = useRef(false);
   const otpVerificationInFlightRef = useRef(false);
+  const captureSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
   const previousOtpLengthRef = useRef(otpCode.length);
   const pendingCompletedOtpRef = useRef<string | null>(null);
   const autoSubmittedOtpRef = useRef<string | null>(null);
@@ -229,7 +260,14 @@ export function ProfileInlineNotificationsCTA({
       subscriptionDetails.sms &&
       !hasEmailContact
   );
-  const flowChannel = isSmsOnlyManageFlow ? 'sms' : 'email';
+  const flowChannel =
+    flowOrigin === 'subscribe'
+      ? channel === 'sms'
+        ? 'sms'
+        : 'email'
+      : isSmsOnlyManageFlow
+        ? 'sms'
+        : 'email';
   const showArtistEmailSection = flowChannel === 'email';
   const primaryUserEmail = user?.primaryEmailAddress?.emailAddress ?? '';
   const resolvedSource = resolveNotificationSource(source, sourceContext);
@@ -263,6 +301,14 @@ export function ProfileInlineNotificationsCTA({
     setAlertPrefs(DEFAULT_ALERT_PREFS);
     onSubscriptionActivated?.();
   }, [onSubscriptionActivated]);
+
+  useEffect(() => {
+    return () => {
+      if (captureSuccessTimerRef.current) {
+        clearTimeout(captureSuccessTimerRef.current);
+      }
+    };
+  }, []);
 
   const syncPreferencesFromStatus = useCallback(() => {
     if (isSubscribed) {
@@ -336,6 +382,32 @@ export function ProfileInlineNotificationsCTA({
   useEffect(() => {
     onRegisterReveal?.(openFlow);
   }, [onRegisterReveal, openFlow]);
+
+  useEffect(() => {
+    if (isSubscribed) {
+      setCaptureSuppressed(false);
+      return;
+    }
+
+    let isActive = true;
+    fetch(`/api/profile/capture-dismissal?artist_id=${artist.id}`, {
+      cache: 'no-store',
+    })
+      .then(async response => {
+        if (!response.ok) return;
+        const data = (await response.json()) as {
+          readonly suppressed?: boolean;
+        };
+        if (isActive) {
+          setCaptureSuppressed(Boolean(data.suppressed));
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      isActive = false;
+    };
+  }, [artist.id, isSubscribed]);
 
   useEffect(() => {
     if (!isFlowOpen) return;
@@ -420,6 +492,8 @@ export function ProfileInlineNotificationsCTA({
       case 'email':
         handleClose();
         return;
+      case 'capture_success':
+        return;
       case 'otp':
         setStep('email');
         return;
@@ -449,19 +523,59 @@ export function ProfileInlineNotificationsCTA({
     }
 
     if (result === 'subscribed') {
+      const captureChannel = channel === 'sms' ? 'sms' : 'email';
+      const contactValue =
+        captureChannel === 'sms'
+          ? phoneInput
+          : (normalizeSubscriptionEmail(emailInput) ??
+            subscriptionDetails.email ??
+            emailInput);
       subscribedEmailRef.current =
         normalizeSubscriptionEmail(emailInput) ??
         subscriptionDetails.email ??
         '';
       markSubscriptionActivated();
-      setStep('name');
+      setSuccessContactEcho(maskCapturedContact(contactValue, captureChannel));
+      setStep('capture_success');
+      if (captureSuccessTimerRef.current) {
+        clearTimeout(captureSuccessTimerRef.current);
+      }
+      captureSuccessTimerRef.current = setTimeout(() => {
+        setStep('name');
+      }, CAPTURE_SUCCESS_HOLD_MS);
     }
   }, [
+    channel,
     emailInput,
     handleSubscribe,
     markSubscriptionActivated,
+    phoneInput,
     subscriptionDetails.email,
   ]);
+
+  const handleDismissCapture = useCallback(async () => {
+    try {
+      const response = await fetch('/api/profile/capture-dismissal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          artist_id: artist.id,
+          source: resolvedSource,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Capture dismissal failed');
+      }
+
+      handleClose();
+    } catch (error) {
+      void captureError('Profile capture dismissal failed', error, {
+        artistId: artist.id,
+        artistHandle: artist.handle,
+      });
+    }
+  }, [artist.handle, artist.id, handleClose, resolvedSource]);
 
   const handleOtpSubmit = useCallback(async () => {
     if (otpVerificationInFlightRef.current) return;
@@ -705,6 +819,10 @@ export function ProfileInlineNotificationsCTA({
     return null;
   }
 
+  if (!isSubscribed && captureSuppressed) {
+    return null;
+  }
+
   const triggerLabel = isSubscribed
     ? 'Manage alerts'
     : (triggerLabelProp ?? 'Get alerts');
@@ -735,10 +853,13 @@ export function ProfileInlineNotificationsCTA({
         presentation={isInline ? 'inline' : presentation}
         artistName={artist.name}
         channel={flowChannel}
+        country={country}
         step={step}
         accentHex={accentHex}
         portalContainer={portalContainer}
         emailInput={emailInput}
+        phoneInput={phoneInput}
+        successContactEcho={successContactEcho}
         otpCode={otpCode}
         nameInput={nameInput}
         birthdayInput={birthdayInput}
@@ -750,6 +871,7 @@ export function ProfileInlineNotificationsCTA({
         birthdayHintShown={birthdayHintShown}
         resendCooldownEnd={resendCooldownEnd}
         isResending={isResending}
+        isCountryOpen={isCountryOpen}
         contentPrefs={alertPrefs}
         canEditPreferences={canEditPreferences}
         canGoBackFromPreferences={
@@ -761,8 +883,13 @@ export function ProfileInlineNotificationsCTA({
         showArtistEmailSection={showArtistEmailSection}
         onClose={handleClose}
         onBack={handleBack}
+        onChannelChange={handleChannelChange}
+        onCountryOpenChange={setIsCountryOpen}
+        onCountrySelect={setCountry}
         onEmailChange={handleEmailChange}
+        onPhoneChange={handlePhoneChange}
         onEmailSubmit={handleEmailSubmit}
+        onDismissCapture={handleDismissCapture}
         onOtpChange={handleOtpChange}
         onOtpComplete={handleOtpComplete}
         onOtpSubmit={handleOtpSubmit}

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
@@ -6,7 +6,9 @@ import {
   Check,
   ChevronLeft,
   Mail,
+  MessageCircle,
   Music2,
+  Send,
   Shirt,
   X,
 } from 'lucide-react';
@@ -20,12 +22,17 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { OtpInput } from '@/features/auth/atoms/otp-input';
+import {
+  type CountryOption,
+  CountrySelector,
+} from '@/features/profile/notifications';
 import { PROFILE_Z } from '@/lib/profile/z-index-constants';
 import { cn } from '@/lib/utils';
 import type { NotificationContentType } from '@/types/notifications';
 
 export type ProfileMobileNotificationsFlowStep =
   | 'email'
+  | 'capture_success'
   | 'otp'
   | 'name'
   | 'birthday'
@@ -38,9 +45,12 @@ interface ProfileMobileNotificationsFlowProps {
   readonly portalContainer?: HTMLElement | null;
   readonly artistName: string;
   readonly channel?: 'email' | 'sms';
+  readonly country: CountryOption;
   readonly step: ProfileMobileNotificationsFlowStep;
   readonly accentHex?: string | null;
   readonly emailInput: string;
+  readonly phoneInput: string;
+  readonly successContactEcho?: string | null;
   readonly otpCode: string;
   readonly nameInput: string;
   readonly birthdayInput: string;
@@ -52,6 +62,7 @@ interface ProfileMobileNotificationsFlowProps {
   readonly birthdayHintShown: boolean;
   readonly resendCooldownEnd: number;
   readonly isResending: boolean;
+  readonly isCountryOpen: boolean;
   readonly contentPrefs: Record<NotificationContentType, boolean>;
   readonly canEditPreferences?: boolean;
   readonly canGoBackFromPreferences?: boolean;
@@ -60,8 +71,13 @@ interface ProfileMobileNotificationsFlowProps {
   readonly showArtistEmailSection?: boolean;
   readonly onClose: () => void;
   readonly onBack: () => void;
+  readonly onChannelChange: (channel: 'email' | 'sms') => void;
+  readonly onCountryOpenChange: (open: boolean) => void;
+  readonly onCountrySelect: (country: CountryOption) => void;
   readonly onEmailChange: (value: string) => void;
+  readonly onPhoneChange: (value: string) => void;
   readonly onEmailSubmit: () => void;
+  readonly onDismissCapture?: () => void;
   readonly onOtpChange: (value: string) => void;
   readonly onOtpComplete: (value: string) => void;
   readonly onOtpSubmit: () => void;
@@ -76,9 +92,12 @@ interface ProfileMobileNotificationsFlowProps {
 }
 
 const FLOW_TRANSITION = {
-  duration: 0.22,
+  duration: 0.42,
   ease: [0.22, 1, 0.36, 1] as const,
 };
+
+const CAPTURE_CONSENT_COPY =
+  'By submitting, you agree to receive updates from this artist and Jovie. Reply STOP to opt out. Message and data rates may apply.';
 
 const MONTH_OPTIONS = [
   'January',
@@ -154,7 +173,7 @@ function ScreenShell({
   /**
    * `compact` vertically centers the title + field + CTA as one balanced group
    * instead of stretching the field region and pinning the footer to the bottom.
-   * Used for short single-field steps (e.g. Email Alerts) so the field and CTA
+   * Used for short single-field steps so the field and CTA
    * read as one unit with no dead vertical space (JOV-3555).
    */
   compact = false,
@@ -310,6 +329,76 @@ function LabeledInput({
   );
 }
 
+function InlineCaptureField({
+  channel,
+  country,
+  isCountryOpen,
+  value,
+  placeholder,
+  isSubmitting,
+  onCountryOpenChange,
+  onCountrySelect,
+  onValueChange,
+  onSubmit,
+}: Readonly<{
+  channel: 'email' | 'sms';
+  country: CountryOption;
+  isCountryOpen: boolean;
+  value: string;
+  placeholder: string;
+  isSubmitting: boolean;
+  onCountryOpenChange: (open: boolean) => void;
+  onCountrySelect: (country: CountryOption) => void;
+  onValueChange: (value: string) => void;
+  onSubmit: () => void;
+}>) {
+  return (
+    <div className='rounded-[var(--profile-action-radius)] border border-white/10 bg-white/[0.035] p-1.5'>
+      <div className='flex min-h-13 items-center gap-1'>
+        {channel === 'sms' ? (
+          <CountrySelector
+            country={country}
+            isOpen={isCountryOpen}
+            onOpenChange={onCountryOpenChange}
+            onSelect={onCountrySelect}
+          />
+        ) : (
+          <span className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-white/46'>
+            <Mail className='size-4.5' />
+          </span>
+        )}
+        <input
+          data-testid='mobile-email-input'
+          type={channel === 'sms' ? 'tel' : 'email'}
+          inputMode={channel === 'sms' ? 'tel' : 'email'}
+          autoComplete={channel === 'sms' ? 'tel' : 'email'}
+          value={value}
+          placeholder={placeholder}
+          onChange={event => onValueChange(event.target.value)}
+          onKeyDown={event => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              onSubmit();
+            }
+          }}
+          disabled={isSubmitting}
+          aria-label={channel === 'sms' ? 'Phone Number' : 'Email Address'}
+          className='h-11 min-w-0 flex-1 bg-transparent px-1 text-base font-medium tracking-[-0.005em] dark:text-white placeholder:text-white/30 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60'
+        />
+        <button
+          type='button'
+          onClick={onSubmit}
+          disabled={isSubmitting}
+          className='inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white text-black transition-opacity duration-subtle hover:opacity-92 disabled:cursor-not-allowed disabled:opacity-55 dark:bg-white dark:text-black'
+          aria-label='Submit'
+        >
+          <Send className='size-4' />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function BirthdaySelectors({
   value,
   onChange,
@@ -402,9 +491,12 @@ export function ProfileMobileNotificationsFlow({
   portalContainer,
   artistName,
   channel = 'email',
+  country,
   step,
   accentHex = '#8b5cf6',
   emailInput,
+  phoneInput,
+  successContactEcho = null,
   otpCode,
   nameInput,
   birthdayInput,
@@ -416,6 +508,7 @@ export function ProfileMobileNotificationsFlow({
   birthdayHintShown,
   resendCooldownEnd,
   isResending,
+  isCountryOpen,
   contentPrefs,
   canEditPreferences = false,
   canGoBackFromPreferences = false,
@@ -423,8 +516,13 @@ export function ProfileMobileNotificationsFlow({
   showArtistEmailSection = false,
   onClose,
   onBack,
+  onChannelChange,
+  onCountryOpenChange,
+  onCountrySelect,
   onEmailChange,
+  onPhoneChange,
   onEmailSubmit,
+  onDismissCapture,
   onOtpChange,
   onOtpComplete,
   onOtpSubmit,
@@ -527,41 +625,95 @@ export function ProfileMobileNotificationsFlow({
 
   const screen = (() => {
     if (step === 'email') {
+      const isSms = channel === 'sms';
+      const fieldValue = isSms ? phoneInput : emailInput;
       return (
         <ScreenShell
           compact
-          title={channel === 'sms' ? 'Text Alerts' : 'Email Alerts'}
-          body={`${artistName} alerts.`}
+          title='Get Updates'
+          body={`${artistName}: music, shows, merch.`}
           footer={
-            <div className='space-y-3'>
+            <div className='min-h-27 space-y-3'>
               {error ? (
                 <p className='text-sm text-red-400' role='alert'>
                   {error}
                 </p>
               ) : null}
-              <PrimaryButton onClick={onEmailSubmit} disabled={isSubmitting}>
-                Continue
-              </PrimaryButton>
+              <p className='text-xs leading-4 text-white/42'>
+                {CAPTURE_CONSENT_COPY}
+              </p>
+              <div className='flex items-center justify-between gap-3'>
+                <button
+                  type='button'
+                  onClick={() => onChannelChange(isSms ? 'email' : 'sms')}
+                  disabled={isSubmitting}
+                  className='inline-flex h-9 items-center gap-1.5 rounded-full px-1 text-xs font-semibold text-white/62 transition-colors duration-subtle hover:text-white disabled:cursor-not-allowed disabled:opacity-50'
+                >
+                  {isSms ? (
+                    <Mail className='size-3.5' />
+                  ) : (
+                    <MessageCircle className='size-3.5' />
+                  )}
+                  {isSms ? 'Use Email' : 'Use SMS'}
+                </button>
+                {onDismissCapture ? (
+                  <button
+                    type='button'
+                    onClick={onDismissCapture}
+                    disabled={isSubmitting}
+                    className='inline-flex h-9 items-center rounded-full px-1 text-xs font-semibold text-white/48 transition-colors duration-subtle hover:text-white/70 disabled:cursor-not-allowed disabled:opacity-50'
+                  >
+                    Not Now
+                  </button>
+                ) : null}
+              </div>
             </div>
           }
         >
-          <LabeledInput
-            label={channel === 'sms' ? 'Phone number' : 'Email address'}
-            value={emailInput}
-            placeholder={channel === 'sms' ? '(555) 123-4567' : 'you@email.com'}
-            type={channel === 'sms' ? 'tel' : 'email'}
-            inputMode={channel === 'sms' ? 'tel' : 'email'}
-            autoComplete={channel === 'sms' ? 'tel' : 'email'}
-            onChange={onEmailChange}
-            onKeyDown={event => {
-              if (event.key === 'Enter') {
-                event.preventDefault();
-                onEmailSubmit();
-              }
-            }}
-            disabled={isSubmitting}
-            testId='mobile-email-input'
+          <InlineCaptureField
+            channel={channel}
+            country={country}
+            isCountryOpen={isCountryOpen}
+            value={fieldValue}
+            placeholder={isSms ? '555 123 4567' : 'you@email.com'}
+            isSubmitting={isSubmitting}
+            onCountryOpenChange={onCountryOpenChange}
+            onCountrySelect={onCountrySelect}
+            onValueChange={isSms ? onPhoneChange : onEmailChange}
+            onSubmit={onEmailSubmit}
           />
+        </ScreenShell>
+      );
+    }
+
+    if (step === 'capture_success') {
+      return (
+        <ScreenShell
+          compact
+          title='You’re On The List'
+          body={
+            successContactEcho
+              ? `Updates are on for ${successContactEcho}.`
+              : `${artistName} updates are on.`
+          }
+          footer={
+            <p className='min-h-10 text-sm text-white/46'>
+              Setting up your preferences...
+            </p>
+          }
+        >
+          <div className='flex min-h-28 items-center justify-center'>
+            <div
+              className='flex h-20 w-20 items-center justify-center rounded-full border border-white/10 bg-white/[0.045] shadow-[0_20px_44px_rgba(0,0,0,0.28)]'
+              style={
+                {
+                  boxShadow: `0 20px 44px rgba(0,0,0,0.28), inset 0 0 0 1px ${accentHex}55`,
+                } as CSSProperties
+              }
+            >
+              <Check className='h-9 w-9 dark:text-white' />
+            </div>
+          </div>
         </ScreenShell>
       );
     }

--- a/apps/web/components/features/profile/artist-notifications-cta/useSubscriptionForm.ts
+++ b/apps/web/components/features/profile/artist-notifications-cta/useSubscriptionForm.ts
@@ -22,6 +22,7 @@ import {
   useSubscribeNotificationsMutation,
   useVerifyEmailOtpMutation,
 } from '@/lib/queries/useNotificationStatusQuery';
+import { getNotificationCaptureError } from '@/lib/validation/schemas/notifications';
 import type { Artist } from '@/types/db';
 import type { NotificationChannel } from '@/types/notifications';
 import {
@@ -233,8 +234,14 @@ export function useSubscriptionForm({
         const normalizedPhone = normalizeSubscriptionPhone(
           buildPhoneE164(phoneInput, country.dialCode)
         );
-        if (!normalizedPhone) {
-          updateError('Please enter a valid phone number', origin);
+        const sharedError = getNotificationCaptureError({
+          channel: 'sms',
+          value:
+            normalizedPhone ?? buildPhoneE164(phoneInput, country.dialCode),
+          country_code: country.code,
+        });
+        if (sharedError) {
+          updateError(sharedError, origin);
           return false;
         }
 
@@ -243,20 +250,27 @@ export function useSubscriptionForm({
       }
 
       const trimmedEmail = emailInput.trim();
-      if (!trimmedEmail) {
-        updateError('Email address is required', origin);
-        return false;
-      }
-
-      if (!normalizeSubscriptionEmail(trimmedEmail)) {
-        updateError('Please enter a valid email address', origin);
+      const sharedError = getNotificationCaptureError({
+        channel: 'email',
+        value: trimmedEmail,
+      });
+      if (sharedError) {
+        updateError(sharedError, origin);
         return false;
       }
 
       clearError();
       return true;
     },
-    [channel, clearError, country.dialCode, emailInput, phoneInput, updateError]
+    [
+      channel,
+      clearError,
+      country.code,
+      country.dialCode,
+      emailInput,
+      phoneInput,
+      updateError,
+    ]
   );
 
   const handleFieldBlur = useCallback(() => {

--- a/apps/web/components/features/profile/notifications/CountrySelector.tsx
+++ b/apps/web/components/features/profile/notifications/CountrySelector.tsx
@@ -29,63 +29,10 @@ function CountryFlag({ code }: { readonly code: string }) {
   );
 }
 
-// Countries supported by Twilio SMS (sorted by usage/popularity)
+// Public fan-capture SMS is limited to US/CAN for consent and deliverability.
 export const COUNTRY_OPTIONS: CountryOption[] = [
-  // North America
   { code: 'US', dialCode: '+1', label: 'United States' },
   { code: 'CA', dialCode: '+1', label: 'Canada' },
-  { code: 'MX', dialCode: '+52', label: 'Mexico' },
-  // Europe
-  { code: 'GB', dialCode: '+44', label: 'United Kingdom' },
-  { code: 'DE', dialCode: '+49', label: 'Germany' },
-  { code: 'FR', dialCode: '+33', label: 'France' },
-  { code: 'ES', dialCode: '+34', label: 'Spain' },
-  { code: 'IT', dialCode: '+39', label: 'Italy' },
-  { code: 'NL', dialCode: '+31', label: 'Netherlands' },
-  { code: 'BE', dialCode: '+32', label: 'Belgium' },
-  { code: 'CH', dialCode: '+41', label: 'Switzerland' },
-  { code: 'AT', dialCode: '+43', label: 'Austria' },
-  { code: 'SE', dialCode: '+46', label: 'Sweden' },
-  { code: 'NO', dialCode: '+47', label: 'Norway' },
-  { code: 'DK', dialCode: '+45', label: 'Denmark' },
-  { code: 'FI', dialCode: '+358', label: 'Finland' },
-  { code: 'IE', dialCode: '+353', label: 'Ireland' },
-  { code: 'PT', dialCode: '+351', label: 'Portugal' },
-  { code: 'PL', dialCode: '+48', label: 'Poland' },
-  { code: 'CZ', dialCode: '+420', label: 'Czech Republic' },
-  { code: 'GR', dialCode: '+30', label: 'Greece' },
-  { code: 'RO', dialCode: '+40', label: 'Romania' },
-  { code: 'HU', dialCode: '+36', label: 'Hungary' },
-  // Asia Pacific
-  { code: 'AU', dialCode: '+61', label: 'Australia' },
-  { code: 'NZ', dialCode: '+64', label: 'New Zealand' },
-  { code: 'JP', dialCode: '+81', label: 'Japan' },
-  { code: 'KR', dialCode: '+82', label: 'South Korea' },
-  { code: 'SG', dialCode: '+65', label: 'Singapore' },
-  { code: 'HK', dialCode: '+852', label: 'Hong Kong' },
-  { code: 'TW', dialCode: '+886', label: 'Taiwan' },
-  { code: 'MY', dialCode: '+60', label: 'Malaysia' },
-  { code: 'PH', dialCode: '+63', label: 'Philippines' },
-  { code: 'TH', dialCode: '+66', label: 'Thailand' },
-  { code: 'ID', dialCode: '+62', label: 'Indonesia' },
-  { code: 'VN', dialCode: '+84', label: 'Vietnam' },
-  { code: 'IN', dialCode: '+91', label: 'India' },
-  { code: 'PK', dialCode: '+92', label: 'Pakistan' },
-  // Middle East
-  { code: 'IL', dialCode: '+972', label: 'Israel' },
-  { code: 'AE', dialCode: '+971', label: 'United Arab Emirates' },
-  { code: 'SA', dialCode: '+966', label: 'Saudi Arabia' },
-  // South America
-  { code: 'BR', dialCode: '+55', label: 'Brazil' },
-  { code: 'AR', dialCode: '+54', label: 'Argentina' },
-  { code: 'CL', dialCode: '+56', label: 'Chile' },
-  { code: 'CO', dialCode: '+57', label: 'Colombia' },
-  { code: 'PE', dialCode: '+51', label: 'Peru' },
-  // Africa
-  { code: 'ZA', dialCode: '+27', label: 'South Africa' },
-  { code: 'NG', dialCode: '+234', label: 'Nigeria' },
-  { code: 'KE', dialCode: '+254', label: 'Kenya' },
-  { code: 'EG', dialCode: '+20', label: 'Egypt' },
 ];
 
 interface CountryOptionButtonProps {

--- a/apps/web/drizzle/migrations/0068_public_profile_capture_dismissals.sql
+++ b/apps/web/drizzle/migrations/0068_public_profile_capture_dismissals.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS "public_profile_capture_dismissals" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"creator_profile_id" uuid NOT NULL,
+	"audience_id" text NOT NULL,
+	"session_count" integer DEFAULT 0 NOT NULL,
+	"source" text,
+	"dismissed_at" timestamp DEFAULT now() NOT NULL,
+	"next_eligible_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'public_profile_capture_dismissals_creator_profile_id_creator_profiles_id_fk'
+  ) THEN
+    ALTER TABLE "public_profile_capture_dismissals"
+      ADD CONSTRAINT "public_profile_capture_dismissals_creator_profile_id_creator_profiles_id_fk"
+      FOREIGN KEY ("creator_profile_id") REFERENCES "public"."creator_profiles"("id")
+      ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "public_profile_capture_dismissals_profile_audience_unique" ON "public_profile_capture_dismissals" USING btree ("creator_profile_id","audience_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "public_profile_capture_dismissals_profile_next_eligible_idx" ON "public_profile_capture_dismissals" USING btree ("creator_profile_id","next_eligible_at");

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1782950000000,
       "tag": "0067_violet_kinsey_walden",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1783000000000,
+      "tag": "0068_public_profile_capture_dismissals",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema/analytics.ts
+++ b/apps/web/lib/db/schema/analytics.ts
@@ -145,6 +145,31 @@ export const audienceReferrers = pgTable(
   })
 );
 
+export const publicProfileCaptureDismissals = pgTable(
+  'public_profile_capture_dismissals',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    creatorProfileId: uuid('creator_profile_id')
+      .notNull()
+      .references(() => creatorProfiles.id, { onDelete: 'cascade' }),
+    audienceId: text('audience_id').notNull(),
+    sessionCount: integer('session_count').default(0).notNull(),
+    source: text('source'),
+    dismissedAt: timestamp('dismissed_at').defaultNow().notNull(),
+    nextEligibleAt: timestamp('next_eligible_at').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  table => ({
+    profileAudienceUnique: uniqueIndex(
+      'public_profile_capture_dismissals_profile_audience_unique'
+    ).on(table.creatorProfileId, table.audienceId),
+    profileNextEligibleIdx: index(
+      'public_profile_capture_dismissals_profile_next_eligible_idx'
+    ).on(table.creatorProfileId, table.nextEligibleAt),
+  })
+);
+
 // Normalized audience action history (replaces JSONB latest_actions)
 export const audienceActions = pgTable(
   'audience_actions',

--- a/apps/web/lib/db/schema/index.ts
+++ b/apps/web/lib/db/schema/index.ts
@@ -82,6 +82,7 @@ export {
   type NewTip,
   type NotificationSubscription,
   notificationSubscriptions,
+  publicProfileCaptureDismissals,
   selectAudienceBlockSchema,
   selectClickEventSchema,
   selectNotificationSubscriptionSchema,

--- a/apps/web/lib/notifications/domain.ts
+++ b/apps/web/lib/notifications/domain.ts
@@ -655,14 +655,15 @@ export const subscribeToNotificationsDomain = async (
 
     if (!result.success) {
       const props = extractPayloadProps(bodyObject);
+      const validationErrors = result.error.issues.map(issue => issue.message);
       await trackSubscribeError({
         artist_id: props.artist_id,
         error_type: 'validation_error',
-        validation_errors: result.error.format()._errors,
+        validation_errors: validationErrors,
         source: props.source,
         source_context: props.source_context,
       });
-      return buildSubscribeValidationError();
+      return buildSubscribeValidationError(validationErrors[0]);
     }
 
     const {
@@ -702,16 +703,21 @@ export const subscribeToNotificationsDomain = async (
       );
     }
 
-    // US-only guard for SMS channel
-    if (channel === 'sms' && country_code && country_code !== 'US') {
+    // US/CAN-only guard for SMS channel. The shared schema already rejects
+    // omitted/unsupported country codes; this branch preserves explicit domain
+    // telemetry for any future call-site that reaches this layer.
+    if (
+      channel === 'sms' &&
+      (!country_code || !['US', 'CA'].includes(country_code.toUpperCase()))
+    ) {
       await trackSubscribeError({
         artist_id,
-        error_type: 'sms_us_only',
+        error_type: 'sms_us_can_only',
         source,
         source_context,
       });
       return buildSubscribeValidationError(
-        'SMS notifications are currently available in the US only.'
+        'SMS notifications are available in the US and Canada only.'
       );
     }
 

--- a/apps/web/lib/notifications/validation.ts
+++ b/apps/web/lib/notifications/validation.ts
@@ -1,11 +1,7 @@
-const EMAIL_REGEX =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/; // NOSONAR (S5852) - ReDoS bounded by EMAIL_MAX_LENGTH = 254 check applied before this regex
+import { getNotificationCaptureError } from '@/lib/validation/schemas/notifications';
 
 const EMAIL_MAX_LENGTH = 254;
 const PHONE_MAX_LENGTH = 32;
-
-/** Matches whitespace and C0/C1 control characters using Unicode property escapes */
-const CONTROL_OR_SPACE_REGEX = /[\s\p{Cc}]/gu;
 
 export function normalizeSubscriptionEmail(
   raw: string | null | undefined
@@ -14,8 +10,9 @@ export function normalizeSubscriptionEmail(
   const trimmed = raw.trim();
   if (!trimmed) return null;
   if (trimmed.length > EMAIL_MAX_LENGTH) return null;
-  if (CONTROL_OR_SPACE_REGEX.test(trimmed)) return null;
-  if (!EMAIL_REGEX.test(trimmed)) return null;
+  if (getNotificationCaptureError({ channel: 'email', value: trimmed })) {
+    return null;
+  }
   return trimmed.toLowerCase();
 }
 

--- a/apps/web/lib/validation/schemas/notifications.ts
+++ b/apps/web/lib/validation/schemas/notifications.ts
@@ -26,6 +26,127 @@ export const notificationChannelSchema = z.enum(['email', 'sms']);
  */
 export type NotificationChannel = z.infer<typeof notificationChannelSchema>;
 
+const EMAIL_MAX_LENGTH = 254;
+const PHONE_MAX_LENGTH = 32;
+const EMAIL_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/; // NOSONAR (S5852) - bounded by EMAIL_MAX_LENGTH before regex use
+const CONTROL_OR_SPACE_REGEX = /[\s\p{Cc}]/gu;
+const E164_PHONE_REGEX = /^\+[1-9]\d{6,14}$/;
+
+export const NOTIFICATION_CAPTURE_ERROR_MESSAGES = {
+  emailRequired: 'Email address is required.',
+  emailTooLong: 'Email address must be 254 characters or fewer.',
+  emailNoSpaces: 'Email address cannot contain spaces or control characters.',
+  emailFormat:
+    'Email address must include a local part, @, domain, and top-level domain.',
+  phoneRequired: 'Phone number is required.',
+  phoneTooLong: 'Phone number must be 32 characters or fewer.',
+  phoneFormat: 'Phone number must be a valid US or Canadian number.',
+  smsCountry: 'SMS notifications are available in the US and Canada only.',
+} as const;
+
+export const notificationCaptureSchema = z
+  .object({
+    channel: notificationChannelSchema.extract(['email', 'sms']),
+    value: z.string(),
+    country_code: z
+      .string()
+      .length(2)
+      .regex(/^[a-zA-Z]{2}$/)
+      .optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.channel === 'email') {
+      const trimmed = data.value.trim();
+
+      if (!trimmed) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailRequired,
+          path: ['value'],
+        });
+        return;
+      }
+
+      if (trimmed.length > EMAIL_MAX_LENGTH) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailTooLong,
+          path: ['value'],
+        });
+        return;
+      }
+
+      if (CONTROL_OR_SPACE_REGEX.test(trimmed)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailNoSpaces,
+          path: ['value'],
+        });
+        return;
+      }
+
+      if (!EMAIL_REGEX.test(trimmed)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailFormat,
+          path: ['value'],
+        });
+      }
+      return;
+    }
+
+    const countryCode = data.country_code?.toUpperCase();
+    if (countryCode !== 'US' && countryCode !== 'CA') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.smsCountry,
+        path: ['country_code'],
+      });
+      return;
+    }
+
+    const trimmed = data.value.trim();
+    if (!trimmed) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneRequired,
+        path: ['value'],
+      });
+      return;
+    }
+
+    if (trimmed.length > PHONE_MAX_LENGTH) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneTooLong,
+        path: ['value'],
+      });
+      return;
+    }
+
+    if (!E164_PHONE_REGEX.test(trimmed)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneFormat,
+        path: ['value'],
+      });
+    }
+  });
+
+export type NotificationCaptureInput = z.infer<
+  typeof notificationCaptureSchema
+>;
+
+export function getNotificationCaptureError(
+  input: NotificationCaptureInput
+): string | null {
+  const parsed = notificationCaptureSchema.safeParse(input);
+  return parsed.success
+    ? null
+    : (parsed.error.issues[0]?.message ?? 'Invalid notification contact.');
+}
+
 // =============================================================================
 // Notification Unsubscribe Method Type
 // =============================================================================
@@ -74,21 +195,28 @@ export const subscribeSchema = z
     source_context: z.record(z.string(), z.unknown()).optional(),
   })
   .superRefine((data, ctx) => {
-    if (data.channel === 'email' && !data.email) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Email is required for email notifications.',
-        path: ['email'],
-      });
+    const capturePath =
+      data.channel === 'email'
+        ? 'email'
+        : data.country_code?.toUpperCase() !== 'US' &&
+            data.country_code?.toUpperCase() !== 'CA'
+          ? 'country_code'
+          : 'phone';
+    const contactError = getNotificationCaptureError({
+      channel: data.channel,
+      value: data.channel === 'email' ? (data.email ?? '') : (data.phone ?? ''),
+      country_code: data.country_code,
+    });
+
+    if (!contactError) {
+      return;
     }
 
-    if (data.channel === 'sms' && !data.phone) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Phone number is required for SMS notifications.',
-        path: ['phone'],
-      });
-    }
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: contactError,
+      path: [capturePath],
+    });
   });
 
 /**

--- a/apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts
+++ b/apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts
@@ -139,7 +139,7 @@ async function submitEmailStep(
   const input = flow.locator('[data-testid="mobile-email-input"]').first();
   await input.fill(email);
 
-  const submitBtn = emailStep.getByRole('button', { name: /^continue$/i });
+  const submitBtn = emailStep.getByRole('button', { name: /^submit$/i });
   await expect(submitBtn).toBeEnabled();
 
   if (options.waitForSubscribe) {

--- a/apps/web/tests/e2e/profile-subscribe-e2e.spec.ts
+++ b/apps/web/tests/e2e/profile-subscribe-e2e.spec.ts
@@ -138,7 +138,7 @@ async function submitEmail(
   const input = flow.locator('[data-testid="mobile-email-input"]').first();
   await input.fill(email);
 
-  const submitBtn = emailStep.getByRole('button', { name: /^continue$/i });
+  const submitBtn = emailStep.getByRole('button', { name: /^submit$/i });
   await expect(submitBtn).toBeEnabled();
 
   if (options.waitForSubscribe) {

--- a/apps/web/tests/lib/notifications/validation.test.ts
+++ b/apps/web/tests/lib/notifications/validation.test.ts
@@ -8,8 +8,61 @@ import {
   normalizeSubscriptionEmail,
   normalizeSubscriptionPhone,
 } from '@/lib/notifications/validation';
+import {
+  getNotificationCaptureError,
+  NOTIFICATION_CAPTURE_ERROR_MESSAGES,
+} from '@/lib/validation/schemas/notifications';
 
 describe('Notification Validation', () => {
+  describe('getNotificationCaptureError', () => {
+    it('names exact email validation rules', () => {
+      expect(getNotificationCaptureError({ channel: 'email', value: '' })).toBe(
+        NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailRequired
+      );
+      expect(
+        getNotificationCaptureError({ channel: 'email', value: 'fan@domain' })
+      ).toBe(NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailFormat);
+      expect(
+        getNotificationCaptureError({
+          channel: 'email',
+          value: 'fan @domain.com',
+        })
+      ).toBe(NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailNoSpaces);
+    });
+
+    it('accepts valid email capture input', () => {
+      expect(
+        getNotificationCaptureError({
+          channel: 'email',
+          value: 'fan@example.com',
+        })
+      ).toBeNull();
+    });
+
+    it('limits SMS capture to US and Canada', () => {
+      expect(
+        getNotificationCaptureError({
+          channel: 'sms',
+          value: '+15551234567',
+          country_code: 'GB',
+        })
+      ).toBe(NOTIFICATION_CAPTURE_ERROR_MESSAGES.smsCountry);
+      expect(
+        getNotificationCaptureError({
+          channel: 'sms',
+          value: '+15551234567',
+        })
+      ).toBe(NOTIFICATION_CAPTURE_ERROR_MESSAGES.smsCountry);
+      expect(
+        getNotificationCaptureError({
+          channel: 'sms',
+          value: '+15551234567',
+          country_code: 'CA',
+        })
+      ).toBeNull();
+    });
+  });
+
   describe('normalizeSubscriptionEmail', () => {
     it('should return null for null or undefined input', () => {
       expect(normalizeSubscriptionEmail(null)).toBeNull();

--- a/apps/web/tests/unit/api/profile/capture-dismissal.test.ts
+++ b/apps/web/tests/unit/api/profile/capture-dismissal.test.ts
@@ -1,0 +1,216 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCookiesGet = vi.hoisted(() => vi.fn());
+const mockDbLimit = vi.hoisted(() => vi.fn());
+const mockDbSet = vi.hoisted(() => vi.fn());
+const mockDbValues = vi.hoisted(() => vi.fn());
+const mockDbOnConflictDoUpdate = vi.hoisted(() => vi.fn());
+const mockGeneralLimiterLimit = vi.hoisted(() => vi.fn());
+const mockCaptureError = vi.hoisted(() => vi.fn());
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...clauses: unknown[]) => ({ clauses, op: 'and' })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ left, op: 'eq', right })),
+  gt: vi.fn((left: unknown, right: unknown) => ({ left, op: 'gt', right })),
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({
+    get: mockCookiesGet,
+  })),
+}));
+
+vi.mock('@/app/api/notifications/route-helpers', () => ({
+  createRateLimitedResponse: vi.fn(
+    () =>
+      new Response(JSON.stringify({ success: false, code: 'rate_limited' }), {
+        status: 429,
+      })
+  ),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: mockDbLimit,
+    update: vi.fn().mockReturnThis(),
+    set: mockDbSet,
+    insert: vi.fn().mockReturnThis(),
+    values: mockDbValues,
+  },
+}));
+
+vi.mock('@/lib/db/schema/analytics', () => ({
+  publicProfileCaptureDismissals: {
+    id: 'id',
+    creatorProfileId: 'creator_profile_id',
+    audienceId: 'audience_id',
+    sessionCount: 'session_count',
+    source: 'source',
+    dismissedAt: 'dismissed_at',
+    nextEligibleAt: 'next_eligible_at',
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+  },
+}));
+
+vi.mock('@/lib/env-server', () => ({
+  isSecureEnv: vi.fn(() => false),
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mockCaptureError,
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  generalLimiter: {
+    limit: mockGeneralLimiterLimit,
+  },
+  getClientIP: vi.fn(() => '127.0.0.1'),
+}));
+
+const artistId = '123e4567-e89b-12d3-a456-426614174000';
+
+function getRequest(cookie?: string) {
+  return new NextRequest(
+    `http://localhost/api/profile/capture-dismissal?artist_id=${artistId}`,
+    {
+      headers: cookie ? { cookie } : undefined,
+    }
+  );
+}
+
+function postRequest(body: unknown, cookie?: string) {
+  return new NextRequest('http://localhost/api/profile/capture-dismissal', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(cookie ? { cookie } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('/api/profile/capture-dismissal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockCookiesGet.mockReturnValue(undefined);
+    mockDbLimit.mockResolvedValue([]);
+    mockDbSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    mockDbValues.mockReturnValue({
+      onConflictDoUpdate: mockDbOnConflictDoUpdate,
+    });
+    mockDbOnConflictDoUpdate.mockResolvedValue(undefined);
+    mockGeneralLimiterLimit.mockResolvedValue({
+      success: true,
+      limit: 100,
+      remaining: 99,
+      reset: new Date(Date.now() + 60_000),
+    });
+  });
+
+  it('returns the empty eligible state and issues an audience cookie', async () => {
+    const { GET } = await import('@/app/api/profile/capture-dismissal/route');
+
+    const response = await GET(getRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toMatchObject({
+      success: true,
+      suppressed: false,
+      sessionCount: 0,
+      nextEligibleAt: null,
+    });
+    expect(response.headers.get('set-cookie')).toContain('jv_aid=');
+  });
+
+  it('persists a seven-day dismissal on the anonymous audience id', async () => {
+    mockCookiesGet.mockReturnValue({ value: 'audience-123' });
+    const { POST } = await import('@/app/api/profile/capture-dismissal/route');
+
+    const response = await POST(
+      postRequest({ artist_id: artistId, source: 'profile_inline' })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.suppressed).toBe(true);
+    expect(data.nextEligibleAt).toEqual(expect.any(String));
+    expect(mockDbValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creatorProfileId: artistId,
+        audienceId: 'audience-123',
+        sessionCount: 0,
+        source: 'profile_inline',
+        nextEligibleAt: expect.any(Date),
+      })
+    );
+    expect(mockDbOnConflictDoUpdate).toHaveBeenCalled();
+  });
+
+  it('suppresses and increments while below the three-session cap', async () => {
+    mockCookiesGet.mockReturnValue({ value: 'audience-123' });
+    const nextEligibleAt = new Date(Date.now() + 86_400_000);
+    mockDbLimit.mockResolvedValue([
+      { id: 'dismissal-1', sessionCount: 2, nextEligibleAt },
+    ]);
+    const { GET } = await import('@/app/api/profile/capture-dismissal/route');
+
+    const response = await GET(getRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.suppressed).toBe(true);
+    expect(data.sessionCount).toBe(2);
+    expect(mockDbSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionCount: 3,
+        updatedAt: expect.any(Date),
+      })
+    );
+  });
+
+  it('stops suppressing after three dismissed sessions', async () => {
+    mockCookiesGet.mockReturnValue({ value: 'audience-123' });
+    mockDbLimit.mockResolvedValue([
+      {
+        id: 'dismissal-1',
+        sessionCount: 3,
+        nextEligibleAt: new Date(Date.now() + 86_400_000),
+      },
+    ]);
+    const { GET } = await import('@/app/api/profile/capture-dismissal/route');
+
+    const response = await GET(getRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.suppressed).toBe(false);
+    expect(mockDbSet).not.toHaveBeenCalled();
+  });
+
+  it('returns a retryable server error when dismissal persistence fails', async () => {
+    mockDbOnConflictDoUpdate.mockRejectedValue(new Error('db down'));
+    const { POST } = await import('@/app/api/profile/capture-dismissal/route');
+
+    const response = await POST(postRequest({ artist_id: artistId }));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({
+      success: false,
+      error: 'Unable to save dismissal',
+    });
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      'Profile capture dismissal persist failed',
+      expect.any(Error),
+      expect.objectContaining({ artistId })
+    );
+  });
+});

--- a/apps/web/tests/unit/lib/notifications/domain.test.ts
+++ b/apps/web/tests/unit/lib/notifications/domain.test.ts
@@ -100,6 +100,7 @@ vi.mock('@/lib/tracking/fire-subscribe-event', () => ({
 }));
 
 // Import once after all mocks are set up
+import { db } from '@/lib/db';
 import {
   getNotificationStatusDomain,
   subscribeToNotificationsDomain,
@@ -109,6 +110,8 @@ import {
 describe('notifications/domain', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(db.limit).mockReset().mockResolvedValue([]);
+    vi.mocked(db.execute).mockReset().mockResolvedValue(undefined);
   });
 
   describe('subscribeToNotificationsDomain', () => {
@@ -163,6 +166,7 @@ describe('notifications/domain', () => {
         artist_id: artistId,
         phone: '+15551234567',
         channel: 'sms',
+        country_code: 'US',
         source: 'alerts-landing',
       });
 

--- a/apps/web/tests/unit/profile/ProfileInlineNotificationsCTA.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileInlineNotificationsCTA.test.tsx
@@ -170,7 +170,7 @@ describe('ProfileInlineNotificationsCTA', () => {
     expect(formState.handleChannelChange).toHaveBeenCalledWith('email');
     expect(formState.openSubscription).toHaveBeenCalled();
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
-    expect(screen.getByText('Email Alerts')).toBeInTheDocument();
+    expect(screen.getByText('Get Updates')).toBeInTheDocument();
     expect(screen.getByTestId('mobile-email-input')).toBeInTheDocument();
     expect(screen.queryByText('Sent by Test Artist')).not.toBeInTheDocument();
   }, 10_000);
@@ -182,7 +182,7 @@ describe('ProfileInlineNotificationsCTA', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /get alerts/i }));
 
-    expect(await screen.findByText('Email Alerts')).toBeInTheDocument();
+    expect(await screen.findByText('Get Updates')).toBeInTheDocument();
   });
 
   it('routes subscribed users into manage mode when a handler is provided', () => {
@@ -254,7 +254,7 @@ describe('ProfileInlineNotificationsCTA', () => {
       />
     );
 
-    expect(await screen.findByText('Email Alerts')).toBeInTheDocument();
+    expect(await screen.findByText('Get Updates')).toBeInTheDocument();
 
     mockUseProfileNotifications.mockReturnValue(
       buildProfileNotifications({
@@ -291,7 +291,7 @@ describe('ProfileInlineNotificationsCTA', () => {
       <ProfileInlineNotificationsCTA artist={makeArtist()} autoOpen />
     );
 
-    expect(await screen.findByText('Email Alerts')).toBeInTheDocument();
+    expect(await screen.findByText('Get Updates')).toBeInTheDocument();
 
     mockUseProfileNotifications.mockReturnValue(
       buildProfileNotifications({
@@ -332,7 +332,7 @@ describe('ProfileInlineNotificationsCTA', () => {
       <ProfileInlineNotificationsCTA artist={makeArtist()} autoOpen />
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Continue' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit' }));
     expect(await screen.findByText('Enter the code')).toBeInTheDocument();
 
     mockUseSubscriptionForm.mockReturnValue(
@@ -383,7 +383,7 @@ describe('ProfileInlineNotificationsCTA', () => {
       <ProfileInlineNotificationsCTA artist={makeArtist()} autoOpen />
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Continue' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit' }));
     expect(await screen.findByText('Enter the code')).toBeInTheDocument();
 
     mockUseSubscriptionForm.mockReturnValue(

--- a/apps/web/tests/unit/profile/inline-notifications-cta.test.tsx
+++ b/apps/web/tests/unit/profile/inline-notifications-cta.test.tsx
@@ -118,6 +118,8 @@ function buildProfileNotifications(
 function buildFormState(overrides: Record<string, unknown> = {}) {
   return {
     emailInput: 'fan@test.com',
+    phoneInput: '',
+    country: { code: 'US', dialCode: '+1', label: 'United States' },
     error: null,
     otpCode: '',
     isSubmitting: false,
@@ -125,15 +127,20 @@ function buildFormState(overrides: Record<string, unknown> = {}) {
     isResending: false,
     handleChannelChange: vi.fn(),
     handleEmailChange: vi.fn(),
+    handlePhoneChange: vi.fn(),
     handleOtpChange: vi.fn(),
     handleSubscribe: vi.fn().mockResolvedValue('error'),
     handleVerifyOtp: vi.fn().mockResolvedValue('error'),
     handleResendOtp: vi.fn().mockResolvedValue(true),
     notificationsState: 'idle',
     notificationsEnabled: true,
+    channel: 'email',
     subscribedChannels: {},
     openSubscription: vi.fn(),
     hydrationStatus: 'done',
+    isCountryOpen: false,
+    setCountry: vi.fn(),
+    setIsCountryOpen: vi.fn(),
     ...overrides,
   };
 }
@@ -197,7 +204,7 @@ describe('ProfileInlineNotificationsCTA flow', () => {
     render(<ProfileInlineNotificationsCTA artist={makeArtist()} />);
 
     fireEvent.click(screen.getByRole('button', { name: /get alerts/i }));
-    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
 
     await waitFor(() => {
       expect(handleSubscribe).toHaveBeenCalledTimes(1);
@@ -249,7 +256,7 @@ describe('ProfileInlineNotificationsCTA flow', () => {
     render(<ProfileInlineNotificationsCTA artist={makeArtist()} />);
 
     fireEvent.click(screen.getByRole('button', { name: /get alerts/i }));
-    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
     fireEvent.click(await screen.findByRole('button', { name: /^verify$/i }));
 
     expect(await screen.findByTestId('mobile-name-input')).toBeInTheDocument();

--- a/apps/web/tests/unit/profile/notifications-otp-step.test.tsx
+++ b/apps/web/tests/unit/profile/notifications-otp-step.test.tsx
@@ -150,7 +150,7 @@ describe('public profile notifications OTP step', () => {
   it('renders OTP verification UI in ArtistNotificationsCTA after email entry', async () => {
     render(<ArtistNotificationsCTA artist={artist} autoOpen />);
 
-    fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /^submit$/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Enter the code')).toBeInTheDocument();
@@ -166,7 +166,7 @@ describe('public profile notifications OTP step', () => {
   it('renders OTP verification UI in TwoStepNotificationsCTA after email entry', async () => {
     render(<TwoStepNotificationsCTA artist={artist} startExpanded />);
 
-    fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /^submit$/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Enter the code')).toBeInTheDocument();

--- a/apps/web/tests/unit/profile/subscription-form-states.test.tsx
+++ b/apps/web/tests/unit/profile/subscription-form-states.test.tsx
@@ -113,6 +113,15 @@ function buildProfileNotifications(overrides: Record<string, unknown> = {}) {
 function buildFormState(overrides: Record<string, unknown> = {}) {
   return {
     emailInput: '',
+    phoneInput: '',
+    country: {
+      code: 'US',
+      name: 'United States',
+      dialCode: '+1',
+      flag: 'US',
+    },
+    isCountryOpen: false,
+    channel: 'email',
     error: null,
     otpCode: '',
     isSubmitting: false,
@@ -123,6 +132,9 @@ function buildFormState(overrides: Record<string, unknown> = {}) {
     subscribedChannels: {},
     handleChannelChange: vi.fn(),
     handleEmailChange: vi.fn(),
+    handlePhoneChange: vi.fn(),
+    setCountry: vi.fn(),
+    setIsCountryOpen: vi.fn(),
     handleOtpChange: vi.fn(),
     handleSubscribe: vi.fn().mockResolvedValue(undefined),
     handleVerifyOtp: vi.fn().mockResolvedValue(undefined),
@@ -187,7 +199,7 @@ describe('ArtistNotificationsCTA full-screen alert flow states', () => {
   it('opens directly to email entry for unsubscribed fans', async () => {
     await renderCTA();
 
-    expect(await screen.findByText('Email Alerts')).toBeInTheDocument();
+    expect(await screen.findByText('Get Updates')).toBeInTheDocument();
     expect(screen.getByTestId('mobile-email-input')).toHaveAttribute(
       'type',
       'email'
@@ -207,9 +219,9 @@ describe('ArtistNotificationsCTA full-screen alert flow states', () => {
     await renderCTA();
 
     const user = userEvent.setup();
-    await screen.findByText('Email Alerts');
+    await screen.findByText('Get Updates');
 
-    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     expect(handleSubscribe).toHaveBeenCalledTimes(1);
     expect(await screen.findByText('Enter the code')).toBeInTheDocument();
@@ -244,8 +256,8 @@ describe('ArtistNotificationsCTA full-screen alert flow states', () => {
     await renderCTA();
 
     const user = userEvent.setup();
-    await screen.findByText('Email Alerts');
-    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await screen.findByText('Get Updates');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
     await screen.findByText('Enter the code');
     await user.click(screen.getByRole('button', { name: 'Verify' }));
 

--- a/apps/web/tests/unit/profile/subscription-sms-flow.test.tsx
+++ b/apps/web/tests/unit/profile/subscription-sms-flow.test.tsx
@@ -113,6 +113,15 @@ function buildProfileNotifications(overrides: Record<string, unknown> = {}) {
 function buildFormState(overrides: Record<string, unknown> = {}) {
   return {
     emailInput: '',
+    phoneInput: '',
+    country: {
+      code: 'US',
+      name: 'United States',
+      dialCode: '+1',
+      flag: 'US',
+    },
+    isCountryOpen: false,
+    channel: 'email',
     error: null,
     otpCode: '',
     isSubmitting: false,
@@ -123,6 +132,9 @@ function buildFormState(overrides: Record<string, unknown> = {}) {
     subscribedChannels: {},
     handleChannelChange: vi.fn(),
     handleEmailChange: vi.fn(),
+    handlePhoneChange: vi.fn(),
+    setCountry: vi.fn(),
+    setIsCountryOpen: vi.fn(),
     handleOtpChange: vi.fn(),
     handleSubscribe: vi.fn().mockResolvedValue(undefined),
     handleVerifyOtp: vi.fn().mockResolvedValue(undefined),
@@ -165,7 +177,7 @@ describe('ArtistNotificationsCTA SMS manage flow', () => {
   it('removes the retired inline phone composer from the auto-open flow', async () => {
     await renderCTA();
 
-    expect(await screen.findByText('Email Alerts')).toBeInTheDocument();
+    expect(await screen.findByText('Get Updates')).toBeInTheDocument();
     expect(screen.queryByTestId('country-selector')).not.toBeInTheDocument();
     expect(screen.queryByText('Stay in the Loop')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Reworked public profile capture to one inline email/SMS field with embedded submit pill, visible consent copy, SMS toggle, masked success echo, 1.2s success hold, and 420ms step transition.
- Added shared client/server capture validation schema for exact email/SMS errors, including US/CAN-only SMS, and reused it in subscribe domain + client form validation.
- Added server-persisted `jv_aid` dismissal cap via `/api/profile/capture-dismissal` and `public_profile_capture_dismissals` migration: 7 days or 3 sessions, retryable failure path.

Fixes #13062

## Design Read
Reading this as: public profile capture card for cold/warmed fans, with a quiet premium product language, leaning toward Jovie System B public variant.

Dials: `DESIGN_VARIANCE=medium-low`, `MOTION_INTENSITY=low`, `VISUAL_DENSITY=medium`.

## Before / After Evidence
- Before component evidence: existing flow tests asserted the retired `Email Alerts` heading and external `Continue` button.
- After component evidence: updated tests assert `Get Updates`, the embedded `Submit` pill, SMS toggle, validation errors, OTP handoff, and SMS manage behavior.
- Screenshot attempt: `PORT=3101 ... pnpm --filter @jovie/web run dev:local:playwright` started, but `curl -I 'http://localhost:3101/dualipa?mode=subscribe'` did not return after 40s because local dev had no `DATABASE_URL` (`DATABASE_URL environment variable is not set` in server log). No screenshot was captured from this worktree.

## Design Checklist
- PASS: Contrast/theme guard via staged ESLint and a11y hook; explicit dark/light button foreground/background pairs.
- PASS: States covered for empty, invalid email, pending OTP, subscribed success hold, SMS-only manage, dismissal empty/suppressed/cap/failure.
- PASS: Layout shift mitigated with stable field height, reserved consent/error footer height, fixed submit button dimensions, and unchanged inline flow shell dimensions.
- PASS: Motion claim implemented as 420ms flow transition and 1.2s success hold.
- PASS: No dead-end on network failure: subscribe input state is preserved by `useSubscriptionForm`; dismissal POST failure logs and keeps the capture open.
- FAIL: Real screenshot capture unavailable locally due missing `DATABASE_URL`.

## Verification
- `pnpm biome check --write apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx apps/web/components/features/profile/artist-notifications-cta/useSubscriptionForm.ts apps/web/components/features/profile/notifications/CountrySelector.tsx apps/web/lib/db/schema/analytics.ts apps/web/lib/db/schema/index.ts apps/web/lib/notifications/domain.ts apps/web/lib/notifications/validation.ts apps/web/lib/validation/schemas/notifications.ts apps/web/app/api/profile/capture-dismissal/route.ts apps/web/tests/lib/notifications/validation.test.ts apps/web/tests/unit/lib/notifications/domain.test.ts apps/web/tests/unit/profile/inline-notifications-cta.test.tsx apps/web/tests/unit/profile/subscription-form-states.test.tsx apps/web/tests/unit/profile/subscription-sms-flow.test.tsx apps/web/tests/unit/api/profile/capture-dismissal.test.ts` -> `Checked 16 files in 22ms. No fixes applied.`
- `pnpm --filter @jovie/web run typecheck -- --pretty false` -> passed.
- `pnpm --filter @jovie/web run test -- tests/lib/notifications/validation.test.ts tests/unit/lib/notifications/domain.test.ts tests/unit/profile/inline-notifications-cta.test.tsx tests/unit/profile/useSubscriptionForm.test.tsx tests/unit/profile/subscription-form-states.test.tsx tests/unit/profile/subscription-sms-flow.test.tsx tests/unit/api/profile/capture-dismissal.test.ts` -> `Test Files 7 passed (7); Tests 64 passed (64)`.
- `pnpm --filter @jovie/web run migration:validate` -> `All migrations are properly registered and idempotent`.
- `pnpm --filter @jovie/web run migration:guard` -> `Migration Guard: No migration changes detected`.
- Pre-commit hook -> passed gitleaks, trufflehog, next proxy guard, typecheck cache warm, migration validate/guard, Biome, ESLint, staged a11y, and local typecheck.
- Pre-push hook -> passed changed-file Biome, next proxy guard, Tailwind guard, and typecheck.

## Review Notes
- Required subagents completed: testing, review, security.
- Local CodeRabbit was run three times: `coderabbit review --agent -c AGENTS.md -t uncommitted`; each attempt failed before review with service `rate_limit` (`waitTime` progressed from 1 minute to 29 seconds to 7 minutes). No actionable CodeRabbit findings were returned.
- Parent spec artifact from #13060 returned `{"error":"Not authenticated"}` via curl, so implementation followed #13062 acceptance text and in-repo contracts.