### PR TITLE
Ovie UX guardrail: require make-interfaces-better/design-review standards

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -203,6 +203,18 @@ The example above says one thing three times. Jovie should say it once.
 - Hover feedback should stay visual, not positional. Prefer color, border, or shadow changes. Do not make the interface jump on hover unless the motion communicates direct manipulation.
 - Before shipping a UI, run this check: does it look like a generic AI-generated SaaS mockup? If yes, remove chrome until it feels native to Jovie
 
+### Ovie Ops Cockpit Guardrail
+
+Ovie UI/UX work must use the make-interfaces-better path: load gstack `/design-review`, load `design-taste-frontend` where available, and run the checklist in `docs/ovie-design-guardrails.md`.
+
+Before changing Ovie UI, include the Design Read line:
+
+`Reading this as: <page kind> for <audience>, with a <vibe> language, leaning toward <design system or aesthetic>`
+
+Ovie should read as a macOS ops cockpit: dense but calm, fast, native-feeling, and focused on operator decisions. Do not import landing-page patterns, decorative AI-dashboard chrome, oversized hero/card structures, or motion that makes controls jump.
+
+Ovie UI PRs require before/after screenshots or component evidence and explicit pass/fail for hierarchy, spacing, typography scale, visual density, interaction states, contrast, macOS-native affordances, and no layout jank.
+
 ---
 
 ## Subtraction Principle

--- a/docs/ovie-design-guardrails.md
+++ b/docs/ovie-design-guardrails.md
@@ -1,0 +1,44 @@
+# Ovie Design Guardrails
+
+Ovie is Jovie's local macOS ops cockpit. Treat Ovie UI work as product/admin UI, not marketing or landing-page work: dense but calm, fast, native-feeling, and stripped of AI-slop decoration.
+
+## Required Routing
+
+Any Ovie UI or UX task must run through the existing make-interfaces-better guardrail:
+
+- Load gstack `/design-review` before marking visual work complete.
+- Load `design-taste-frontend` where available and run its audit checklist.
+- Read `DESIGN.md` and this file before changing Ovie UI.
+- Preserve Ovie's local dirty state first. If `~/JovieInc/ovie` has uncommitted changes, inspect them and avoid overwriting unrelated work.
+
+## Design Read
+
+Before editing Ovie UI, write this one-line statement in the agent notes and PR:
+
+`Reading this as: <page kind> for <audience>, with a <vibe> language, leaning toward <design system or aesthetic>`
+
+For most Ovie work, the default read should be:
+
+`Reading this as: macOS ops cockpit for Jovie operators, with a calm dense native language, leaning toward Linear-style product UI adapted to macOS.`
+
+Set the design dials from that read:
+
+- `DESIGN_VARIANCE`: low to medium. Use known Jovie and macOS patterns before inventing new chrome.
+- `MOTION_INTENSITY`: low. Motion should clarify state, never decorate.
+- `VISUAL_DENSITY`: medium to high. Ovie should scan quickly without feeling crowded.
+
+## Completion Evidence
+
+Ovie UI PRs cannot be marked complete without visible proof:
+
+- Before/after screenshots for rendered UI changes, or component evidence when a full app capture is not practical.
+- A pass/fail checklist covering hierarchy, spacing, typography scale, visual density, interaction states, contrast, macOS-native affordances, and no layout jank.
+- Notes for any failed checklist item, with the linked follow-up Linear issue if it is intentionally not fixed in the PR.
+
+## Ovie-Specific Taste Rules
+
+- Prefer native macOS affordances: menu bar expectations, compact controls, clear keyboard paths, stable panels, and familiar status language.
+- Preserve the ops-cockpit purpose. The interface should make queue state, agent health, blocked work, and next actions easier to scan.
+- Avoid random web patterns: oversized heroes, decorative gradients, promotional sections, feature cards, and landing-page explanation stacks.
+- Avoid generic AI-admin styling: too many rounded bordered panels, icon-on-color squares, all-caps labels, excessive badges, and helper text that repeats visible state.
+- Layout state changes must not jump. Loading, empty, error, degraded, populated, focused, hover, selected, and disabled states need reserved space or stable containers.

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -353,6 +353,15 @@ export function isUiUxDesignIssue(issue: GithubIssue): boolean {
   return keywords.some(k => text.includes(k));
 }
 
+export function isOvieIssue(issue: GithubIssue): boolean {
+  const text = issueText(issue).toLowerCase();
+  return /\bovie\b/.test(text) || labelNames(issue).includes('area:ovie');
+}
+
+export function isOvieUiUxDesignIssue(issue: GithubIssue): boolean {
+  return isOvieIssue(issue) && isUiUxDesignIssue(issue);
+}
+
 export function eligibleCodexIssues(
   issues: ReadonlyArray<GithubIssue>
 ): ReadonlyArray<GithubIssue> {
@@ -622,6 +631,19 @@ export function buildAgentPrompt(input: BuildPromptInput): string {
       `- Safe UI-only fast-track lane: if and only if the final diff is limited to visual UI paths allowed by \`.github/MERGE_QUEUE.md\`, add PR labels \`ui\`, \`${UI_FAST_TRACK_LABEL}\`, \`fast\`, and \`merge-queue\` so Graphite can bypass unrelated backend trains after evidence.`,
       '- When requesting UI fast-track, include a PR section titled `## Fast-track UI eligibility` with `Why eligible`, `Before`, `After`, and `Checks run` lines. Evidence must include before/after screenshots or component evidence, narrow typecheck output, narrow lint/Biome output, and affected component/test output or an explicit explanation when none exists. Do not request fast-track for API routes, auth, billing, DB/migrations, security/CSP, infra/cron, routing behavior, package manifests, CI, or broad refactors.',
       '- If the issue is not UI-focused, do not enforce this skill.',
+    ]);
+  }
+
+  if (isOvieUiUxDesignIssue(input.issue)) {
+    result = result.concat([
+      '',
+      '## Ovie UX Guardrail (JOV-3897)',
+      '- Treat Ovie as a consumer of the make-interfaces-better/design-review guardrail: load `/design-review` for visual QA and `design-taste-frontend` where available.',
+      "- Start every Ovie UI change with this one-line Design Read: 'Reading this as: <page kind> for <audience>, with a <vibe> language, leaning toward <design system or aesthetic>'.",
+      '- Adapt the guardrail to Ovie as a macOS ops cockpit: dense but calm, fast, native-feeling, no AI-slop decoration, and no random web landing-page patterns.',
+      '- Ovie UI PRs need before/after screenshots or component evidence, plus explicit pass/fail for hierarchy, spacing, typography scale, visual density, interaction states, contrast, macOS-native affordances, and no layout jank.',
+      '- If the local Ovie repo is dirty, inspect and preserve that state before editing it; do not overwrite unrelated uncommitted Ovie work.',
+      '- Reference `docs/ovie-design-guardrails.md` and `DESIGN.md` in the PR body when the change touches Ovie UI/UX.',
     ]);
   }
 

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -20,6 +20,7 @@ import {
   INVALID_LABEL,
   isAlreadyClaimedOrBlocked,
   isInvalidMisroute,
+  isOvieUiUxDesignIssue,
   isShipperCriticalPath,
   isSpawnEagain,
   isUiUxDesignIssue,
@@ -54,6 +55,25 @@ function issue(overrides = {}) {
     labels: [{ name: 'codex' }, { name: CODEX_TRUSTED_LABEL }],
     ...overrides,
   };
+}
+
+function buildPromptForIssue(overrides = {}) {
+  const plan = buildDispatchPlans([issue(overrides)], config)[0];
+  const prompt = buildAgentPrompt({
+    issue: plan.issue,
+    branchName: plan.branchName,
+    baseBranch: 'main',
+    integrationBranch: plan.integrationBranch,
+    route: plan.route,
+    repoRoot: '/repo',
+    gbrain: {
+      captureSlug: 'ops/codex-issue-shipper/github-123',
+      queryText: 'Jovie implementation context',
+      queryResult: 'Relevant memory result',
+    },
+  });
+
+  return { plan, prompt };
 }
 
 describe('spawn EAGAIN recovery helpers', () => {
@@ -305,6 +325,70 @@ describe('codex issue shipper prompt', () => {
     expect(prompt).toContain(
       'Captured slug: ops/codex-issue-shipper/github-123'
     );
+  });
+
+  it('adds Ovie-specific make-interfaces-better guardrails to Ovie UX prompts', () => {
+    const { plan, prompt } = buildPromptForIssue({
+      title: 'Ovie UX guardrail: require design review standards',
+      body: 'Update Ovie interface review routing.',
+      labels: [
+        { name: 'codex' },
+        { name: CODEX_TRUSTED_LABEL },
+        { name: 'area:ui' },
+      ],
+    });
+
+    expect(isOvieUiUxDesignIssue(plan.issue)).toBe(true);
+    expect(prompt).toContain('## Ovie UX Guardrail (JOV-3897)');
+    expect(prompt).toContain('make-interfaces-better/design-review');
+    expect(prompt).toContain('macOS ops cockpit');
+    expect(prompt).toContain('before/after screenshots or component evidence');
+    expect(prompt).toContain('macOS-native affordances');
+    expect(prompt).toContain('no layout jank');
+    expect(prompt).toContain('docs/ovie-design-guardrails.md');
+  });
+
+  it('adds Ovie UX guardrails when Ovie is label-only and the body is empty', () => {
+    const { plan, prompt } = buildPromptForIssue({
+      title: 'Require interface review standards',
+      body: '',
+      labels: [
+        { name: 'codex' },
+        { name: CODEX_TRUSTED_LABEL },
+        { name: 'area:ovie' },
+        { name: 'area:ui' },
+      ],
+    });
+
+    expect(isOvieUiUxDesignIssue(plan.issue)).toBe(true);
+    expect(prompt).toContain('## Ovie UX Guardrail (JOV-3897)');
+  });
+
+  it('does not add Ovie guardrails to non-Ovie UI prompts', () => {
+    const { plan, prompt } = buildPromptForIssue({
+      title: 'Improve dashboard interface spacing',
+      body: 'Polish the dashboard layout.',
+      labels: [
+        { name: 'codex' },
+        { name: CODEX_TRUSTED_LABEL },
+        { name: 'area:ui' },
+      ],
+    });
+
+    expect(isOvieUiUxDesignIssue(plan.issue)).toBe(false);
+    expect(prompt).toContain('## UI/UX Design Skill Instructions');
+    expect(prompt).not.toContain('## Ovie UX Guardrail (JOV-3897)');
+  });
+
+  it('does not add Ovie UX guardrails to non-UI Ovie prompts', () => {
+    const { plan, prompt } = buildPromptForIssue({
+      title: 'Ovie shipper retry logs',
+      body: 'Improve retry diagnostics for automation.',
+      labels: [{ name: 'codex' }, { name: CODEX_TRUSTED_LABEL }],
+    });
+
+    expect(isOvieUiUxDesignIssue(plan.issue)).toBe(false);
+    expect(prompt).not.toContain('## Ovie UX Guardrail (JOV-3897)');
   });
 
   it('captures issue body and labels for gbrain', () => {


### PR DESCRIPTION
Fixes #13042

## Summary

Adds Ovie as an explicit consumer of the make-interfaces-better / gstack `/design-review` guardrail for UI/UX work.

Changes:
- Added `docs/ovie-design-guardrails.md` with Ovie-specific design routing, Design Read, evidence, checklist, macOS affordance, and no-layout-jank requirements.
- Updated `DESIGN.md` with the Ovie ops-cockpit guardrail.
- Updated the codex issue shipper prompt so Ovie UI/UX issues automatically receive Ovie-specific guardrail instructions.
- Added shipper tests for Ovie UI happy path, label-only Ovie routing, non-Ovie UI negative path, and Ovie non-UI negative path.

## Design Read

Reading this as: documentation and shipper guardrail for Jovie/Ovie coder agents, with a calm operational language, leaning toward Linear-style product/admin UI adapted to macOS.

Dials: `DESIGN_VARIANCE=low`, `MOTION_INTENSITY=low`, `VISUAL_DENSITY=medium-high`.

## Before / After Evidence

Before: Ovie UI/UX issues received only the generic UI/UX design-skill prompt and Ovie docs did not define the make-interfaces-better/design-review completion contract.

After: Ovie UI/UX issues receive a dedicated `## Ovie UX Guardrail (JOV-3897)` prompt section, and `docs/ovie-design-guardrails.md` plus `DESIGN.md` require the Design Read, before/after screenshots or component evidence, and explicit pass/fail checklist.

Screenshots: not applicable; this PR changes docs and shipper prompt generation, not rendered UI.

## Verification

- `gbrain query "Jovie Ovie design-review make interfaces better design-taste-frontend JOV-3897 guardrail" --json` — completed; no additional results.
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/codex-issue-shipper.test.mjs` — passed, 44 tests.
- `pnpm biome check DESIGN.md docs/ovie-design-guardrails.md scripts/hermes/lib/codex-issue-shipper.ts scripts/lib/__tests__/codex-issue-shipper.test.mjs` — passed, checked 2 files, no fixes applied.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed, no diagnostics.
- `pnpm run test:bug-to-test` — passed, not applicable.
- `git diff --check -- DESIGN.md docs/ovie-design-guardrails.md scripts/hermes/lib/codex-issue-shipper.ts scripts/lib/__tests__/codex-issue-shipper.test.mjs` — passed.
- Pre-push gate during integration shipping — passed `biome-pre-push`, `next:proxy-guard`, `tailwind:check`, and web `typecheck`.
- Testing subagent — found label-only/negative coverage gaps; fixed with additional tests.
- Review subagent — no blocking issues found.
- CodeRabbit local review — completed once; fixed its trivial helper-extraction finding. Required rerun after the diff changed was attempted and blocked by external rate limit (`Rate limit exceeded`, waitTime `8 minutes`).

## Design Checklist

- Hierarchy: pass.
- Spacing: pass.
- Typography scale: pass.
- Visual density: pass.
- Interaction states: pass by requirement text; no UI changed.
- Contrast: pass by requirement text; no UI changed.
- macOS-native affordances: pass.
- No layout jank: pass by requirement text; no UI changed.
