### PR TITLE
fix(chat): unmount right-rail profile preview when panel is closed (ghost empty card)

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -1026,7 +1026,8 @@ export function ChatEntityRightPanelHost({
   profileContext,
   threadTitle,
 }: Readonly<ChatEntityRightPanelHostProps>) {
-  const { open: openPreviewPanel } = usePreviewPanelState();
+  const { open: openPreviewPanel, isOpen: isPreviewPanelOpen } =
+    usePreviewPanelState();
   const { target, contextTargets, close, dismissContext } =
     useChatEntityPanel();
   // Nullable so the host also renders outside a QueryClientProvider (tests).
@@ -1089,13 +1090,18 @@ export function ChatEntityRightPanelHost({
       }
     }
 
-    const liveProfilePreview = enablePreviewPanel ? (
-      <ErrorBoundary fallback={null}>
-        <div className='system-b-chat-profile-preview-card'>
-          <ProfileContactSidebar />
-        </div>
-      </ErrorBoundary>
-    ) : null;
+    // Only render the profile preview card when the preview panel is actually
+    // open. A closed RightDrawer collapses to zero width *inside* the card, so
+    // keeping this wrapper mounted registers a non-null right panel and leaves
+    // a ghost empty card + reserved rail width in the app shell (#12134).
+    const liveProfilePreview =
+      enablePreviewPanel && isPreviewPanelOpen ? (
+        <ErrorBoundary fallback={null}>
+          <div className='system-b-chat-profile-preview-card'>
+            <ProfileContactSidebar />
+          </div>
+        </ErrorBoundary>
+      ) : null;
 
     if (contextCards && entityPanel) {
       return (
@@ -1165,6 +1171,7 @@ export function ChatEntityRightPanelHost({
     enableChatEntityPanels,
     enablePreviewPanel,
     handleOpenProfilePreview,
+    isPreviewPanelOpen,
     profileId,
     profileSpotifyArtistId,
     profileContext,

--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -1093,7 +1093,7 @@ export function ChatEntityRightPanelHost({
     // Only render the profile preview card when the preview panel is actually
     // open. A closed RightDrawer collapses to zero width *inside* the card, so
     // keeping this wrapper mounted registers a non-null right panel and leaves
-    // a ghost empty card + reserved rail width in the app shell (#12134).
+    // a ghost empty card + reserved rail width in the app shell (gh-12134).
     const liveProfilePreview =
       enablePreviewPanel && isPreviewPanelOpen ? (
         <ErrorBoundary fallback={null}>

--- a/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
+++ b/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
@@ -309,7 +309,7 @@ describe('ChatEntityRightPanelHost', () => {
     });
   });
 
-  it('keeps the profile sidebar mounted when preview is closed for cinematic close', () => {
+  it('does not register the profile sidebar when preview is closed', () => {
     mockPreviewPanelOpen = false;
     mockUseRegisterRightPanel.mockClear();
 
@@ -319,8 +319,8 @@ describe('ChatEntityRightPanelHost', () => {
       </ChatEntityPanelProvider>
     );
 
-    expect(mockUseRegisterRightPanel).toHaveBeenCalled();
-    expect(mockUseRegisterRightPanel.mock.calls.at(-1)?.[0]).not.toBeNull();
+    const lastCall = mockUseRegisterRightPanel.mock.calls.at(-1)?.[0];
+    expect(lastCall).toBeNull();
   });
 
   it('registers the profile sidebar when preview is open', () => {

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -408,17 +408,12 @@ describe('ChatPageClient', () => {
     );
   });
 
-  it('keeps the profile panel mounted on chat when closed so the rail can animate shut', () => {
+  it('does not register a right panel when the preview panel is closed', () => {
     mockPreviewPanelState.isOpen = false;
 
     renderChatPage();
 
-    expect(hasRegisteredRightPanel()).toBe(true);
-    expect(mockSetPreviewData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        username: 'testartist',
-      })
-    );
+    expect(hasRegisteredRightPanel()).toBe(false);
   });
 
   it('preserves profile panel deep-link hydration and opens the panel from the query param', () => {


### PR DESCRIPTION
## Problem
Closing the chat right-rail entity preview left a ghost empty card + reserved gutter on the right edge.

## Root cause
`ChatEntityRightPanelHost` gated `liveProfilePreview` only on `enablePreviewPanel`, not on the preview panel's open state. A closed desktop `RightDrawer` collapses itself to zero width but stays mounted, so the host kept registering a non-null panel — `AppShellRightRail` and the styled `system-b-chat-profile-preview-card` wrapper stayed mounted around an invisible drawer.

## Fix
Gate `liveProfilePreview` on `enablePreviewPanel && isPreviewPanelOpen` (from `usePreviewPanelState`). When nothing is open the host registers `null`, `AppShellFrame` renders no rail, and the column fully collapses. Reopening remounts cleanly (RightDrawer intentionally suppresses its first-paint animation, so no half-open flash).

- Closing the preview removes the card entirely — no empty frame, no reserved gutter
- Disabled-panel path still renders null
- Entity panels, context cards, and open-preview behavior unchanged

Fixes #12134

🤖 Generated with [Claude Code](https://claude.com/claude-code)