### PR TITLE
fix(chat): full-viewport ambient background gradient (JOV-3614)

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -536,6 +536,20 @@ export function JovieChat({
           designV1ChatEntitiesEnabled ? 'true' : undefined
         }
       >
+        {/* Ambient background wash — fills the full chat viewport so the
+            gradient never clips to a content-sized region (#12135 / JOV-3614).
+            Pure background: pointer-events-none, painted behind the positioned
+            siblings below by DOM order; top-weighted so it fades out well
+            above the opaque composer dock. No layout shift. */}
+        <div
+          aria-hidden='true'
+          data-testid='chat-ambient-gradient'
+          className='pointer-events-none absolute inset-0 h-full w-full'
+          style={{
+            background:
+              'radial-gradient(120% 80% at 50% 0%, color-mix(in oklab, var(--color-accent-blue) 6%, transparent), transparent 60%)',
+          }}
+        />
         {/* Registers entity providers (release, artist) for the slash menu */}
         {profileId ? <ChatProvidersRegistrar profileId={profileId} /> : null}
 


### PR DESCRIPTION
## Summary

The chat surface's ambient gradient was clipped to a content-sized region (the empty-state logo glow box) instead of spanning the full viewport, leaving flat/cut-off areas.

This adds a dedicated full-bleed ambient layer as the first child of the chat root container (`data-testid='chat-content'`, which is `relative h-full` and fills the chat pane): `pointer-events-none absolute inset-0 h-full w-full`, a subtle System-B-tokenized radial wash (`color-mix` on `--color-accent-blue` at 6%) anchored at top-center and fading to transparent by 60% height — so it never creates a flat band against the opaque composer dock.

- Pure background: behind all positioned siblings by DOM order, no z-index games, no layout shift
- Spans the full chat viewport edge-to-edge and top-to-bottom at all heights and on resize
- System B tokens only; no hardcoded colors

Fixes #12135 (JOV-3614). Part of the 2026-06-27 chat-polish cluster (#12133/#12134).