### PR TITLE
feat(profile): add PAC Statsig variant slots

### DIFF
--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -21,10 +21,12 @@ import {
 import { toPublicContacts } from '@/lib/contacts/mapper';
 import { getReleasesForProfileLite } from '@/lib/discography/queries';
 import { getEntityIdentityLinks } from '@/lib/entity/queries';
+import { DEFAULT_PROFILE_PAC_ASSIGNMENT } from '@/lib/flags/profile-pac';
 // ISR-safe: profile-variant.ts does NOT import cookies() — no dynamic opt-in
 import {
   getMerchMvpEnabled,
   getProfileAlertOptInVariant,
+  getProfilePacAssignment,
 } from '@/lib/flags/profile-variant';
 import { getLiveMerchCardsForProfile } from '@/lib/merch/service';
 import { buildProfileAeoContent } from '@/lib/profile/aeo-content';
@@ -246,6 +248,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     allReleases,
     merchCards,
     alertOptInVariant,
+    profilePacAssignment,
     entityLinks,
   ] = await Promise.all([
     tourDatesPromise.catch(() => [] as TourDateViewModel[]),
@@ -255,6 +258,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     // AnonCookieBootstrap resolves the per-user variant on the client side.
     // .catch ensures a Statsig outage doesn't fail the whole ISR page render.
     getProfileAlertOptInVariant(null).catch(() => 'button' as const),
+    getProfilePacAssignment(null).catch(() => DEFAULT_PROFILE_PAC_ASSIGNMENT),
     entityLinksPromise.catch(() => []),
   ]);
   const tourDates = [...tourDatesRaw].sort(
@@ -343,6 +347,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
         pressPhotos={pressPhotos}
         subscribeTwoStep
         alertOptInVariant={alertOptInVariant}
+        profilePacAssignment={profilePacAssignment}
         genres={genres}
         tourDates={tourDates}
         visitTrackingToken={visitTrackingToken}

--- a/apps/web/app/api/profile/audience-anon-cookie/route.ts
+++ b/apps/web/app/api/profile/audience-anon-cookie/route.ts
@@ -1,15 +1,19 @@
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { AUDIENCE_ANON_COOKIE } from '@/constants/app';
-import { getProfileAlertOptInVariant } from '@/lib/flags/server';
+import { DEFAULT_PROFILE_PAC_ASSIGNMENT } from '@/lib/flags/profile-pac';
+import {
+  getProfileAlertOptInVariant,
+  getProfilePacAssignment,
+} from '@/lib/flags/server';
 
 /**
  * Thin GET route that reads the httpOnly jv_aid cookie and returns the
- * per-user Statsig alertOptInVariant.
+ * per-user Statsig profile variants.
  *
  * Called from the AnonCookieBootstrap client component so the public profile
  * route can be ISR-cached (no cookies() in the RSC tree) while still
- * delivering the correct A/B test variant to real visitors on the client side.
+ * delivering the correct A/B test variants to real visitors on the client side.
  *
  * No auth required — this is a public, anonymous endpoint.
  * Cache-Control: no-store so each real visitor gets their own variant.
@@ -20,17 +24,19 @@ export async function GET(): Promise<NextResponse> {
 
   // Best-effort: fall back to the default variant if Statsig is unavailable.
   // The client component already handles null/missing responses gracefully.
-  let alertOptInVariant: Awaited<
-    ReturnType<typeof getProfileAlertOptInVariant>
-  >;
-  try {
-    alertOptInVariant = await getProfileAlertOptInVariant(stableId);
-  } catch {
-    alertOptInVariant = 'button';
-  }
+  const [alertOptInResult, profilePacResult] = await Promise.allSettled([
+    getProfileAlertOptInVariant(stableId),
+    getProfilePacAssignment(stableId),
+  ]);
+  const alertOptInVariant =
+    alertOptInResult.status === 'fulfilled' ? alertOptInResult.value : 'button';
+  const profilePac =
+    profilePacResult.status === 'fulfilled'
+      ? profilePacResult.value
+      : DEFAULT_PROFILE_PAC_ASSIGNMENT;
 
   return NextResponse.json(
-    { alertOptInVariant },
+    { alertOptInVariant, profilePac },
     {
       headers: {
         'Cache-Control': 'no-store',

--- a/apps/web/components/features/profile/AnonCookieBootstrap.tsx
+++ b/apps/web/components/features/profile/AnonCookieBootstrap.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
+import type { ProfilePacAssignment } from '@/lib/flags/profile-pac';
 
 interface AnonCookieBootstrapProps {
   /**
@@ -11,6 +12,7 @@ interface AnonCookieBootstrapProps {
    * react if the user has been assigned a different variant.
    */
   readonly onVariantResolved?: (variant: ProfileAlertOptInVariant) => void;
+  readonly onProfilePacResolved?: (assignment: ProfilePacAssignment) => void;
 }
 
 /**
@@ -32,24 +34,35 @@ interface AnonCookieBootstrapProps {
  */
 export function AnonCookieBootstrap({
   onVariantResolved,
+  onProfilePacResolved,
 }: AnonCookieBootstrapProps) {
   useEffect(() => {
-    if (!onVariantResolved) return;
+    if (!onVariantResolved && !onProfilePacResolved) return;
 
     void fetch('/api/profile/audience-anon-cookie', {
       method: 'GET',
       credentials: 'same-origin',
     })
       .then(res => (res.ok ? res.json() : null))
-      .then((data: { alertOptInVariant: ProfileAlertOptInVariant } | null) => {
-        if (data?.alertOptInVariant) {
-          onVariantResolved(data.alertOptInVariant);
+      .then(
+        (
+          data: {
+            alertOptInVariant?: ProfileAlertOptInVariant;
+            profilePac?: ProfilePacAssignment;
+          } | null
+        ) => {
+          if (data?.alertOptInVariant) {
+            onVariantResolved?.(data.alertOptInVariant);
+          }
+          if (data?.profilePac) {
+            onProfilePacResolved?.(data.profilePac);
+          }
         }
-      })
+      )
       .catch(() => {
         // Best-effort: analytics and the default CTA variant are unaffected.
       });
-  }, [onVariantResolved]);
+  }, [onProfilePacResolved, onVariantResolved]);
 
   return null;
 }

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -20,6 +20,11 @@ import { useReleaseAwareNow } from '@/hooks/useReleaseAwareNow';
 import { useTourDateProximity } from '@/hooks/useTourDateProximity';
 import type { UserLocation } from '@/hooks/useUserLocation';
 import { useUserLocation } from '@/hooks/useUserLocation';
+import {
+  DEFAULT_PROFILE_PAC_ASSIGNMENT,
+  type ProfilePacAssignment,
+  type ProfilePacS2Slot,
+} from '@/lib/flags/profile-pac';
 import type { PublicMerchCard } from '@/lib/merch/types';
 import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import { getProfileReleaseVisibility } from '@/lib/profile/release-visibility';
@@ -42,6 +47,7 @@ interface ProfileHomeRailProps {
   readonly onPlayClick?: () => void;
   readonly onAlertsClick?: (context: NotificationSourceContext) => void;
   readonly isSubscribed?: boolean;
+  readonly profilePacAssignment?: ProfilePacAssignment;
   readonly viewerLocation?: UserLocation | null;
   readonly resolveNearbyTour?: boolean;
   readonly merchCards?: readonly PublicMerchCard[];
@@ -124,6 +130,36 @@ function HomeAlertsCard({
   );
 }
 
+function getS2OrderedItems({
+  assignedSlot,
+  merchItems,
+  showItems,
+}: Readonly<{
+  assignedSlot: ProfilePacS2Slot;
+  merchItems: readonly EntityCardModel[];
+  showItems: readonly EntityCardModel[];
+}>) {
+  const slotBuckets: Record<ProfilePacS2Slot, readonly EntityCardModel[]> = {
+    merch: merchItems,
+    tip: [],
+    tickets: showItems,
+    rsvp: showItems,
+  };
+  const preferredItems = slotBuckets[assignedSlot];
+  const fallbackItems =
+    assignedSlot === 'tickets' || assignedSlot === 'rsvp'
+      ? merchItems
+      : showItems;
+
+  return preferredItems.length > 0
+    ? [...preferredItems, ...fallbackItems]
+    : [...merchItems, ...showItems];
+}
+
+export const __profileHomeRailTestUtils = {
+  getS2OrderedItems,
+};
+
 export function ProfileHomeRail({
   artist,
   latestRelease,
@@ -133,6 +169,7 @@ export function ProfileHomeRail({
   renderMode = 'interactive',
   onAlertsClick,
   isSubscribed = false,
+  profilePacAssignment = DEFAULT_PROFILE_PAC_ASSIGNMENT,
   viewerLocation,
   resolveNearbyTour = true,
   merchCards = [],
@@ -166,7 +203,10 @@ export function ProfileHomeRail({
   // One ordered card list — featured item first, then the rest. No stacked
   // sections: a single carousel is the profile home surface.
   const carouselItems = useMemo<EntityCardModel[]>(() => {
-    const items: EntityCardModel[] = [];
+    const featuredItems: EntityCardModel[] = [];
+    const releaseItems: EntityCardModel[] = [];
+    const merchItems: EntityCardModel[] = [];
+    const showItems: EntityCardModel[] = [];
 
     // Featured: the latest release when it's visible per profile settings.
     const hasFeaturedRelease = Boolean(
@@ -181,7 +221,7 @@ export function ProfileHomeRail({
           null);
 
     if (hasFeaturedRelease && latestRelease) {
-      items.push(
+      featuredItems.push(
         releaseToEntityCard(
           {
             id: featuredReleaseId ?? undefined,
@@ -197,7 +237,7 @@ export function ProfileHomeRail({
     } else if (upcomingTourDates.length === 0 && featuredPlaylistFallback) {
       // Fallback feature when there's no release or upcoming show: the
       // artist's confirmed "This Is" playlist, as a music card.
-      items.push({
+      featuredItems.push({
         id: `playlist-${featuredPlaylistFallback.playlistId}`,
         kind: 'music',
         href: featuredPlaylistFallback.url,
@@ -219,12 +259,14 @@ export function ProfileHomeRail({
       if (release.slug === '' || release.slug === featuredReleaseSlug) {
         continue;
       }
-      items.push(releaseToEntityCard(release, { handle: artist.handle, now }));
+      releaseItems.push(
+        releaseToEntityCard(release, { handle: artist.handle, now })
+      );
     }
 
     // Shoppable merch (revenue) next.
     for (const card of merchCards) {
-      items.push(merchToEntityCard(card, { handle: artist.handle }));
+      merchItems.push(merchToEntityCard(card, { handle: artist.handle }));
     }
 
     // Upcoming shows, nearest-to-viewer first when geo resolved.
@@ -232,7 +274,7 @@ export function ProfileHomeRail({
       a.id === nearbyTourDateId ? -1 : b.id === nearbyTourDateId ? 1 : 0
     );
     for (const show of shows) {
-      items.push(
+      showItems.push(
         showToEntityCard({
           id: show.id,
           title: show.title,
@@ -244,7 +286,15 @@ export function ProfileHomeRail({
       );
     }
 
-    return items;
+    return [
+      ...featuredItems,
+      ...getS2OrderedItems({
+        assignedSlot: profilePacAssignment.s2Slot,
+        merchItems,
+        showItems,
+      }),
+      ...releaseItems,
+    ];
   }, [
     artist.handle,
     featuredPlaylistFallback,
@@ -252,6 +302,7 @@ export function ProfileHomeRail({
     merchCards,
     nearbyTourDateId,
     now,
+    profilePacAssignment.s2Slot,
     releases,
     releaseVisibility?.show,
     upcomingTourDates,

--- a/apps/web/components/features/profile/StaticArtistPage.tsx
+++ b/apps/web/components/features/profile/StaticArtistPage.tsx
@@ -4,6 +4,7 @@ import { ProfileCompactTemplate } from '@/features/profile/templates/ProfileComp
 import { buildProfilePublicViewModel } from '@/features/profile/view-models';
 import type { DiscogRelease } from '@/lib/db/schema/content';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
+import type { ProfilePacAssignment } from '@/lib/flags/profile-pac';
 import type { PublicMerchCard } from '@/lib/merch/types';
 import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
@@ -31,6 +32,7 @@ export interface StaticArtistPageProps {
   readonly pressPhotos?: PressPhoto[];
   readonly subscribeTwoStep?: boolean;
   readonly alertOptInVariant?: ProfileAlertOptInVariant;
+  readonly profilePacAssignment?: ProfilePacAssignment;
   readonly genres?: string[] | null;
   readonly tourDates?: TourDateViewModel[];
   readonly visitTrackingToken?: string;
@@ -62,6 +64,7 @@ export function StaticArtistPage({
   enableDynamicEngagement = false,
   subscribeTwoStep = false,
   alertOptInVariant = 'button',
+  profilePacAssignment,
   genres,
   pressPhotos = [],
   allowPhotoDownloads = false,
@@ -93,6 +96,7 @@ export function StaticArtistPage({
     enableDynamicEngagement,
     subscribeTwoStep,
     alertOptInVariant,
+    profilePacAssignment,
     genres,
     pressPhotos,
     allowPhotoDownloads,
@@ -121,6 +125,7 @@ export function StaticArtistPage({
       enableDynamicEngagement={viewModel.enableDynamicEngagement}
       subscribeTwoStep={viewModel.subscribeTwoStep}
       alertOptInVariant={viewModel.alertOptInVariant}
+      profilePacAssignment={viewModel.profilePacAssignment}
       genres={viewModel.genres}
       pressPhotos={viewModel.pressPhotos}
       allowPhotoDownloads={viewModel.allowPhotoDownloads}

--- a/apps/web/components/features/profile/contracts.ts
+++ b/apps/web/components/features/profile/contracts.ts
@@ -1,5 +1,6 @@
 import type { DiscogRelease } from '@/lib/db/schema/content';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
+import type { ProfilePacAssignment } from '@/lib/flags/profile-pac';
 import type { PublicMerchCard } from '@/lib/merch/types';
 import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
@@ -163,6 +164,7 @@ export interface ProfilePublicViewModel {
   readonly pressPhotos: PressPhoto[];
   readonly subscribeTwoStep: boolean;
   readonly alertOptInVariant: ProfileAlertOptInVariant;
+  readonly profilePacAssignment: ProfilePacAssignment;
   readonly genres?: string[] | null;
   readonly tourDates: TourDateViewModel[];
   readonly visitTrackingToken?: string;

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -29,6 +29,10 @@ import { track } from '@/lib/analytics';
 import { Mark } from '@/lib/brand/primitives';
 import { sortDSPsByGeoPopularity } from '@/lib/dsp';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
+import {
+  DEFAULT_PROFILE_PAC_ASSIGNMENT,
+  type ProfilePacAssignment,
+} from '@/lib/flags/profile-pac';
 import type { PublicMerchCard } from '@/lib/merch/types';
 import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import { CONTENT_SAFE_AREA_BOTTOM_PADDING } from '@/lib/profile/nav-constants';
@@ -148,6 +152,7 @@ interface ProfileCompactSurfaceProps {
   readonly enableDynamicEngagement?: boolean;
   readonly subscribeTwoStep?: boolean;
   readonly alertOptInVariant?: ProfileAlertOptInVariant;
+  readonly profilePacAssignment?: ProfilePacAssignment;
   readonly genres?: string[] | null;
   readonly pressPhotos?: PressPhoto[];
   readonly allowPhotoDownloads?: boolean;
@@ -240,6 +245,7 @@ export function ProfileCompactSurface({
   enableDynamicEngagement = false,
   subscribeTwoStep = false,
   alertOptInVariant = 'button',
+  profilePacAssignment = DEFAULT_PROFILE_PAC_ASSIGNMENT,
   genres,
   pressPhotos = [],
   allowPhotoDownloads = false,
@@ -745,6 +751,7 @@ export function ProfileCompactSurface({
                 onPlayClick={onPlayClick}
                 onAlertsClick={openNotifications}
                 isSubscribed={homeAlertsSubscribed}
+                profilePacAssignment={profilePacAssignment}
                 viewerLocation={viewerLocation}
                 resolveNearbyTour={resolveNearbyTour}
                 merchCards={merchCards}

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -27,6 +27,10 @@ import {
 import type { PublicRelease } from '@/features/profile/releases/types';
 import { sortDSPsByGeoPopularity } from '@/lib/dsp';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
+import {
+  DEFAULT_PROFILE_PAC_ASSIGNMENT,
+  type ProfilePacAssignment,
+} from '@/lib/flags/profile-pac';
 import { useNotifications } from '@/lib/hooks/useNotifications';
 import type { PublicMerchCard } from '@/lib/merch/types';
 import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
@@ -70,6 +74,7 @@ interface ProfileCompactTemplateProps {
   readonly enableDynamicEngagement?: boolean;
   readonly subscribeTwoStep?: boolean;
   readonly alertOptInVariant?: ProfileAlertOptInVariant;
+  readonly profilePacAssignment?: ProfilePacAssignment;
   readonly genres?: string[] | null;
   readonly pressPhotos?: PressPhoto[];
   readonly allowPhotoDownloads?: boolean;
@@ -208,6 +213,7 @@ export function ProfileCompactTemplate({
   enableDynamicEngagement = false,
   subscribeTwoStep = false,
   alertOptInVariant = 'button',
+  profilePacAssignment = DEFAULT_PROFILE_PAC_ASSIGNMENT,
   genres,
   pressPhotos = [],
   allowPhotoDownloads = false,
@@ -227,6 +233,8 @@ export function ProfileCompactTemplate({
   // updates this state, so real visitors see their assigned experiment variant.
   const [resolvedAlertOptInVariant, setResolvedAlertOptInVariant] =
     useState<ProfileAlertOptInVariant>(alertOptInVariant);
+  const [resolvedProfilePacAssignment, setResolvedProfilePacAssignment] =
+    useState<ProfilePacAssignment>(profilePacAssignment);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerView, setDrawerView] = useState<DrawerView>('menu');
   const [drawerPresentation, setDrawerPresentation] =
@@ -700,7 +708,10 @@ export function ProfileCompactTemplate({
     <ProfileNotificationsContext.Provider value={notificationsContextValue}>
       {/* Resolves the per-user jv_aid variant client-side after ISR hydration.
           Renders null; updates resolvedAlertOptInVariant state on mount. */}
-      <AnonCookieBootstrap onVariantResolved={setResolvedAlertOptInVariant} />
+      <AnonCookieBootstrap
+        onVariantResolved={setResolvedAlertOptInVariant}
+        onProfilePacResolved={setResolvedProfilePacAssignment}
+      />
       <PublicProfileLayoutShell
         artistName={artist.name}
         heroImageUrl={heroImageUrl}
@@ -727,6 +738,7 @@ export function ProfileCompactTemplate({
               enableDynamicEngagement={enableDynamicEngagement}
               subscribeTwoStep={subscribeTwoStep}
               alertOptInVariant={resolvedAlertOptInVariant}
+              profilePacAssignment={resolvedProfilePacAssignment}
               genres={genres}
               pressPhotos={pressPhotos}
               allowPhotoDownloads={allowPhotoDownloads}

--- a/apps/web/components/features/profile/view-models.ts
+++ b/apps/web/components/features/profile/view-models.ts
@@ -1,5 +1,9 @@
 import type { DiscogRelease } from '@/lib/db/schema/content';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
+import {
+  DEFAULT_PROFILE_PAC_ASSIGNMENT,
+  type ProfilePacAssignment,
+} from '@/lib/flags/profile-pac';
 import type { PublicMerchCard } from '@/lib/merch/types';
 import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
@@ -30,6 +34,7 @@ interface BuildProfilePublicViewModelInput {
   readonly pressPhotos?: PressPhoto[];
   readonly subscribeTwoStep?: boolean;
   readonly alertOptInVariant?: ProfileAlertOptInVariant;
+  readonly profilePacAssignment?: ProfilePacAssignment;
   readonly genres?: string[] | null;
   readonly tourDates?: TourDateViewModel[];
   readonly visitTrackingToken?: string;
@@ -64,6 +69,7 @@ export function buildProfilePublicViewModel({
   pressPhotos = [],
   subscribeTwoStep = false,
   alertOptInVariant = 'button',
+  profilePacAssignment = DEFAULT_PROFILE_PAC_ASSIGNMENT,
   genres,
   tourDates = [],
   visitTrackingToken,
@@ -102,6 +108,7 @@ export function buildProfilePublicViewModel({
     pressPhotos,
     subscribeTwoStep,
     alertOptInVariant,
+    profilePacAssignment,
     genres,
     tourDates,
     visitTrackingToken,

--- a/apps/web/lib/flags/contracts.ts
+++ b/apps/web/lib/flags/contracts.ts
@@ -4,6 +4,7 @@ export const LEGACY_STATSIG_GATE_KEYS = {
   IOS_APPLE_MUSIC_PRIORITY: 'feature_ios_apple_music_priority',
   SUBSCRIBE_CTA_EXPERIMENT: 'experiment_subscribe_cta_variant',
   PROFILE_ALERT_OPTIN_EXPERIMENT: 'profile_alert_optin_cta_variant',
+  PROFILE_PAC_VARIANT_SLOTS_EXPERIMENT: 'profile_pac_variant_slots',
   SPOTIFY_OAUTH: 'feature_spotify_oauth',
   STRIPE_CONNECT_ENABLED: 'stripe-connect-enabled',
   SHOW_EXAMPLE_PROFILES_CAROUSEL: 'show_example_profiles_carousel',

--- a/apps/web/lib/flags/profile-pac.test.ts
+++ b/apps/web/lib/flags/profile-pac.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PROFILE_PAC_ASSIGNMENT,
+  evaluateProfilePacPromotion,
+  parseProfilePacAssignment,
+} from './profile-pac';
+
+describe('parseProfilePacAssignment', () => {
+  it('accepts only the three locked PAC slots from Statsig config', () => {
+    expect(
+      parseProfilePacAssignment({
+        copy_arm: 'alternate',
+        trigger_threshold: 'track_complete',
+        s2_slot: 'tickets',
+        rendering: 'not-allowed',
+      })
+    ).toEqual({
+      copyArm: 'alternate',
+      triggerThreshold: 'track_complete',
+      s2Slot: 'tickets',
+    });
+  });
+
+  it('falls back to defaults for malformed or unknown values', () => {
+    expect(
+      parseProfilePacAssignment({
+        copyArm: 'icon-x',
+        triggerThreshold: '5s',
+        s2Slot: 'video',
+      })
+    ).toEqual(DEFAULT_PROFILE_PAC_ASSIGNMENT);
+  });
+});
+
+describe('evaluateProfilePacPromotion', () => {
+  it('promotes an S1 arm when capture lift is significant and guardrails pass', () => {
+    const recommendation = evaluateProfilePacPromotion({
+      slot: 'copyArm',
+      control: {
+        arm: 'default',
+        exposures: 1000,
+        captures: 100,
+        dismissals: 90,
+      },
+      candidate: {
+        arm: 'alternate',
+        exposures: 1000,
+        captures: 150,
+        dismissals: 80,
+      },
+    });
+
+    expect(recommendation).toMatchObject({
+      slot: 'copyArm',
+      winningArm: 'alternate',
+      previousArm: 'default',
+      reason: 'capture_rate_significant',
+      configPatch: { copyArm: 'alternate' },
+      reversible: true,
+    });
+  });
+
+  it('blocks promotion when capture rate or dismissal rate degrades', () => {
+    expect(
+      evaluateProfilePacPromotion({
+        slot: 'triggerThreshold',
+        control: {
+          arm: '30s',
+          exposures: 1000,
+          captures: 100,
+          dismissals: 90,
+        },
+        candidate: {
+          arm: 'track_complete',
+          exposures: 1000,
+          captures: 99,
+          dismissals: 80,
+        },
+      })
+    ).toBeNull();
+
+    expect(
+      evaluateProfilePacPromotion({
+        slot: 'triggerThreshold',
+        control: {
+          arm: '30s',
+          exposures: 1000,
+          captures: 100,
+          dismissals: 90,
+        },
+        candidate: {
+          arm: 'track_complete',
+          exposures: 1000,
+          captures: 140,
+          dismissals: 91,
+        },
+      })
+    ).toBeNull();
+  });
+
+  it('requires trusted S2 reward lift and significance before promotion', () => {
+    expect(
+      evaluateProfilePacPromotion({
+        slot: 's2Slot',
+        control: {
+          arm: 'merch',
+          exposures: 1000,
+          captures: 100,
+          dismissals: 90,
+          revenueCents: 20_000,
+        },
+        candidate: {
+          arm: 'tickets',
+          exposures: 1000,
+          captures: 150,
+          dismissals: 80,
+          revenueCents: 35_000,
+        },
+      })
+    ).toMatchObject({
+      reason: 'revenue_reward_significant',
+      configPatch: { s2Slot: 'tickets' },
+    });
+
+    expect(
+      evaluateProfilePacPromotion({
+        slot: 's2Slot',
+        control: {
+          arm: 'merch',
+          exposures: 1000,
+          captures: 100,
+          dismissals: 90,
+          revenueCents: 20_000,
+        },
+        candidate: {
+          arm: 'tickets',
+          exposures: 1000,
+          captures: 150,
+          dismissals: 80,
+          revenueCents: 20_100,
+        },
+        minRewardLiftCents: 1,
+      })
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/flags/profile-pac.ts
+++ b/apps/web/lib/flags/profile-pac.ts
@@ -1,0 +1,229 @@
+export type ProfilePacCopyArm = 'default' | 'alternate';
+export type ProfilePacTriggerThreshold = '30s' | 'track_complete';
+export type ProfilePacS2Slot = 'merch' | 'tip' | 'tickets' | 'rsvp';
+export type ProfilePacSlotKey = 'copyArm' | 'triggerThreshold' | 's2Slot';
+
+export interface ProfilePacAssignment {
+  readonly copyArm: ProfilePacCopyArm;
+  readonly triggerThreshold: ProfilePacTriggerThreshold;
+  readonly s2Slot: ProfilePacS2Slot;
+}
+
+export interface ProfilePacArmMetrics {
+  readonly arm: string;
+  readonly exposures: number;
+  readonly captures: number;
+  readonly dismissals: number;
+  readonly revenueCents?: number;
+}
+
+export interface ProfilePacPromotionInput {
+  readonly slot: ProfilePacSlotKey;
+  readonly control: ProfilePacArmMetrics;
+  readonly candidate: ProfilePacArmMetrics;
+  readonly minExposuresPerArm?: number;
+  readonly zScoreThreshold?: number;
+  readonly minRewardLiftCents?: number;
+}
+
+export interface ProfilePacPromotionRecommendation {
+  readonly slot: ProfilePacSlotKey;
+  readonly winningArm: string;
+  readonly previousArm: string;
+  readonly reason: 'capture_rate_significant' | 'revenue_reward_significant';
+  readonly zScore: number;
+  readonly doNoHarm: {
+    readonly captureRateDelta: number;
+    readonly dismissalRateDelta: number;
+  };
+  readonly configPatch: Partial<ProfilePacAssignment>;
+  readonly reversible: true;
+}
+
+export const DEFAULT_PROFILE_PAC_ASSIGNMENT: ProfilePacAssignment = {
+  copyArm: 'default',
+  triggerThreshold: '30s',
+  s2Slot: 'merch',
+};
+
+const COPY_ARMS = new Set<ProfilePacCopyArm>(['default', 'alternate']);
+const TRIGGER_THRESHOLDS = new Set<ProfilePacTriggerThreshold>([
+  '30s',
+  'track_complete',
+]);
+const S2_SLOTS = new Set<ProfilePacS2Slot>(['merch', 'tip', 'tickets', 'rsvp']);
+
+function readString(config: Record<string, unknown>, keys: readonly string[]) {
+  for (const key of keys) {
+    const value = config[key];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  return null;
+}
+
+export function parseProfilePacAssignment(
+  config: Record<string, unknown>
+): ProfilePacAssignment {
+  const copyArm = readString(config, ['copyArm', 'copy_arm']);
+  const triggerThreshold = readString(config, [
+    'triggerThreshold',
+    'trigger_threshold',
+  ]);
+  const s2Slot = readString(config, ['s2Slot', 's2_slot']);
+
+  return {
+    copyArm: COPY_ARMS.has(copyArm as ProfilePacCopyArm)
+      ? (copyArm as ProfilePacCopyArm)
+      : DEFAULT_PROFILE_PAC_ASSIGNMENT.copyArm,
+    triggerThreshold: TRIGGER_THRESHOLDS.has(
+      triggerThreshold as ProfilePacTriggerThreshold
+    )
+      ? (triggerThreshold as ProfilePacTriggerThreshold)
+      : DEFAULT_PROFILE_PAC_ASSIGNMENT.triggerThreshold,
+    s2Slot: S2_SLOTS.has(s2Slot as ProfilePacS2Slot)
+      ? (s2Slot as ProfilePacS2Slot)
+      : DEFAULT_PROFILE_PAC_ASSIGNMENT.s2Slot,
+  };
+}
+
+function rate(numerator: number, denominator: number) {
+  return denominator > 0 ? numerator / denominator : 0;
+}
+
+function twoProportionZScore(params: {
+  readonly controlSuccesses: number;
+  readonly controlTotal: number;
+  readonly candidateSuccesses: number;
+  readonly candidateTotal: number;
+}) {
+  const { controlSuccesses, controlTotal, candidateSuccesses, candidateTotal } =
+    params;
+  if (controlTotal <= 0 || candidateTotal <= 0) {
+    return 0;
+  }
+
+  const pooled =
+    (controlSuccesses + candidateSuccesses) / (controlTotal + candidateTotal);
+  const standardError = Math.sqrt(
+    pooled * (1 - pooled) * (1 / controlTotal + 1 / candidateTotal)
+  );
+  if (standardError === 0) {
+    return 0;
+  }
+
+  return (
+    (candidateSuccesses / candidateTotal - controlSuccesses / controlTotal) /
+    standardError
+  );
+}
+
+function buildPatch(
+  slot: ProfilePacSlotKey,
+  winningArm: string
+): Partial<ProfilePacAssignment> {
+  if (slot === 'copyArm' && COPY_ARMS.has(winningArm as ProfilePacCopyArm)) {
+    return { copyArm: winningArm as ProfilePacCopyArm };
+  }
+  if (
+    slot === 'triggerThreshold' &&
+    TRIGGER_THRESHOLDS.has(winningArm as ProfilePacTriggerThreshold)
+  ) {
+    return { triggerThreshold: winningArm as ProfilePacTriggerThreshold };
+  }
+  if (slot === 's2Slot' && S2_SLOTS.has(winningArm as ProfilePacS2Slot)) {
+    return { s2Slot: winningArm as ProfilePacS2Slot };
+  }
+  return {};
+}
+
+export function evaluateProfilePacPromotion(
+  input: ProfilePacPromotionInput
+): ProfilePacPromotionRecommendation | null {
+  const minExposuresPerArm = input.minExposuresPerArm ?? 200;
+  if (
+    input.control.exposures < minExposuresPerArm ||
+    input.candidate.exposures < minExposuresPerArm
+  ) {
+    return null;
+  }
+
+  const controlCaptureRate = rate(
+    input.control.captures,
+    input.control.exposures
+  );
+  const candidateCaptureRate = rate(
+    input.candidate.captures,
+    input.candidate.exposures
+  );
+  const controlDismissalRate = rate(
+    input.control.dismissals,
+    input.control.exposures
+  );
+  const candidateDismissalRate = rate(
+    input.candidate.dismissals,
+    input.candidate.exposures
+  );
+  const doNoHarm = {
+    captureRateDelta: candidateCaptureRate - controlCaptureRate,
+    dismissalRateDelta: candidateDismissalRate - controlDismissalRate,
+  };
+
+  if (doNoHarm.captureRateDelta < 0 || doNoHarm.dismissalRateDelta > 0) {
+    return null;
+  }
+
+  const zScoreThreshold = input.zScoreThreshold ?? 1.96;
+  let zScore: number;
+  let reason: ProfilePacPromotionRecommendation['reason'];
+
+  if (input.slot === 's2Slot') {
+    const controlReward = rate(
+      input.control.revenueCents ?? 0,
+      input.control.exposures
+    );
+    const candidateReward = rate(
+      input.candidate.revenueCents ?? 0,
+      input.candidate.exposures
+    );
+    if (candidateReward - controlReward < (input.minRewardLiftCents ?? 1)) {
+      return null;
+    }
+    zScore = twoProportionZScore({
+      controlSuccesses: input.control.captures,
+      controlTotal: input.control.exposures,
+      candidateSuccesses: input.candidate.captures,
+      candidateTotal: input.candidate.exposures,
+    });
+    reason = 'revenue_reward_significant';
+  } else {
+    zScore = twoProportionZScore({
+      controlSuccesses: input.control.captures,
+      controlTotal: input.control.exposures,
+      candidateSuccesses: input.candidate.captures,
+      candidateTotal: input.candidate.exposures,
+    });
+    reason = 'capture_rate_significant';
+  }
+
+  if (zScore < zScoreThreshold) {
+    return null;
+  }
+
+  const configPatch = buildPatch(input.slot, input.candidate.arm);
+  if (Object.keys(configPatch).length === 0) {
+    return null;
+  }
+
+  return {
+    slot: input.slot,
+    winningArm: input.candidate.arm,
+    previousArm: input.control.arm,
+    reason,
+    zScore,
+    doNoHarm,
+    configPatch,
+    reversible: true,
+  };
+}

--- a/apps/web/lib/flags/profile-variant.ts
+++ b/apps/web/lib/flags/profile-variant.ts
@@ -15,8 +15,10 @@
  */
 import 'server-only';
 import type { ProfileAlertOptInVariant } from './contracts';
+import type { ProfilePacAssignment } from './profile-pac';
 import {
   getProfileAlertOptInVariantValue,
+  getProfilePacAssignmentValue,
   getStatsigGateValue,
 } from './statsig';
 
@@ -32,6 +34,12 @@ export async function getProfileAlertOptInVariant(
   stableId: string | null
 ): Promise<ProfileAlertOptInVariant> {
   return getProfileAlertOptInVariantValue(stableId);
+}
+
+export async function getProfilePacAssignment(
+  stableId: string | null
+): Promise<ProfilePacAssignment> {
+  return getProfilePacAssignmentValue(stableId);
 }
 
 /**

--- a/apps/web/lib/flags/registry.ts
+++ b/apps/web/lib/flags/registry.ts
@@ -10,7 +10,12 @@ import {
   type TeleprompterShowcaseVariant,
 } from './contracts';
 import {
+  DEFAULT_PROFILE_PAC_ASSIGNMENT,
+  type ProfilePacAssignment,
+} from './profile-pac';
+import {
   getProfileAlertOptInVariantValue,
+  getProfilePacAssignmentValue,
   getSubscribeCTAVariantValue,
   getTeleprompterShowcaseVariantValue,
 } from './statsig';
@@ -88,6 +93,22 @@ export const PROFILE_ALERT_OPTIN_VARIANT_FLAG = flag<
   options: ['button', 'toggle'],
   async decide({ entities }) {
     return getProfileAlertOptInVariantValue(entities?.userId ?? null);
+  },
+});
+
+export const PROFILE_PAC_VARIANT_SLOTS_FLAG = flag<
+  ProfilePacAssignment,
+  FlagEntities
+>({
+  key: 'profile_pac_variant_slots',
+  defaultValue: {
+    ...DEFAULT_PROFILE_PAC_ASSIGNMENT,
+  },
+  description:
+    'Public profile Primary Action Card variant slots: S1 copy arm, S1 trigger threshold, S2 monetization slot',
+  options: [{ label: 'Default', value: DEFAULT_PROFILE_PAC_ASSIGNMENT }],
+  async decide({ entities }) {
+    return getProfilePacAssignmentValue(entities?.userId ?? null);
   },
 });
 

--- a/apps/web/lib/flags/server.ts
+++ b/apps/web/lib/flags/server.ts
@@ -19,9 +19,11 @@ import {
   parseAppFlagOverrides,
 } from './overrides';
 import { getFlagOverrideMap } from './overrides-store.server';
+import type { ProfilePacAssignment } from './profile-pac';
 import {
   APP_FLAG_REGISTRY,
   PROFILE_ALERT_OPTIN_VARIANT_FLAG,
+  PROFILE_PAC_VARIANT_SLOTS_FLAG,
   SUBSCRIBE_CTA_VARIANT_FLAG,
   TELEPROMPTER_SHOWCASE_VARIANT_FLAG,
 } from './registry';
@@ -159,6 +161,16 @@ export async function getProfileAlertOptInVariant(
   stableId: string | null
 ): Promise<ProfileAlertOptInVariant> {
   return PROFILE_ALERT_OPTIN_VARIANT_FLAG.run({
+    identify: {
+      userId: stableId,
+    },
+  });
+}
+
+export async function getProfilePacAssignment(
+  stableId: string | null
+): Promise<ProfilePacAssignment> {
+  return PROFILE_PAC_VARIANT_SLOTS_FLAG.run({
     identify: {
       userId: stableId,
     },

--- a/apps/web/lib/flags/statsig.ts
+++ b/apps/web/lib/flags/statsig.ts
@@ -12,6 +12,11 @@ import {
   type SubscribeCTAVariant,
   type TeleprompterShowcaseVariant,
 } from './contracts';
+import {
+  DEFAULT_PROFILE_PAC_ASSIGNMENT,
+  type ProfilePacAssignment,
+  parseProfilePacAssignment,
+} from './profile-pac';
 
 let statsigInitialized = false;
 let statsigClient: Statsig | null = null;
@@ -237,6 +242,19 @@ export async function getProfileAlertOptInVariantValue(
     return variant;
   }
   return 'button';
+}
+
+export async function getProfilePacAssignmentValue(
+  stableId: string | null
+): Promise<ProfilePacAssignment> {
+  const config = await getExperiment(
+    stableId,
+    LEGACY_STATSIG_GATE_KEYS.PROFILE_PAC_VARIANT_SLOTS_EXPERIMENT
+  );
+  if (Object.keys(config).length === 0) {
+    return DEFAULT_PROFILE_PAC_ASSIGNMENT;
+  }
+  return parseProfilePacAssignment(config);
 }
 
 export async function getSubscribeCTAVariantValue(

--- a/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { ProfileHomeRail } from '@/features/profile/ProfileHomeRail';
+import type { EntityCardModel } from '@/components/organisms/entity-card';
+import {
+  __profileHomeRailTestUtils,
+  ProfileHomeRail,
+} from '@/features/profile/ProfileHomeRail';
 import type { ProfilePrimaryActionCardRelease } from '@/features/profile/ProfilePrimaryActionCard';
 import type { PublicRelease } from '@/features/profile/releases/types';
 import type { Artist } from '@/types/db';
@@ -54,6 +58,66 @@ function makePublicRelease(
 }
 
 describe('ProfileHomeRail', () => {
+  it('orders approved S2 cards by PAC slot without duplicating ticket and RSVP buckets', () => {
+    const merchCard = {
+      id: 'merch-1',
+      kind: 'merch',
+      imageAlt: 'Merch',
+      title: 'Tour Tee',
+    } satisfies EntityCardModel;
+    const showCard = {
+      id: 'show-1',
+      kind: 'show',
+      imageAlt: 'Show',
+      title: 'The Novo',
+    } satisfies EntityCardModel;
+
+    expect(
+      __profileHomeRailTestUtils
+        .getS2OrderedItems({
+          assignedSlot: 'tickets',
+          merchItems: [merchCard],
+          showItems: [showCard],
+        })
+        .map(item => item.id)
+    ).toEqual(['show-1', 'merch-1']);
+
+    expect(
+      __profileHomeRailTestUtils
+        .getS2OrderedItems({
+          assignedSlot: 'rsvp',
+          merchItems: [merchCard],
+          showItems: [showCard],
+        })
+        .map(item => item.id)
+    ).toEqual(['show-1', 'merch-1']);
+  });
+
+  it('falls back to existing merch and show order when the assigned S2 slot is unavailable', () => {
+    const merchCard = {
+      id: 'merch-1',
+      kind: 'merch',
+      imageAlt: 'Merch',
+      title: 'Tour Tee',
+    } satisfies EntityCardModel;
+    const showCard = {
+      id: 'show-1',
+      kind: 'show',
+      imageAlt: 'Show',
+      title: 'The Novo',
+    } satisfies EntityCardModel;
+
+    expect(
+      __profileHomeRailTestUtils
+        .getS2OrderedItems({
+          assignedSlot: 'tip',
+          merchItems: [merchCard],
+          showItems: [showCard],
+        })
+        .map(item => item.id)
+    ).toEqual(['merch-1', 'show-1']);
+  });
+
   it('renders alerts above content cards in the home rail DOM order (JOV-11084)', () => {
     render(
       <ProfileHomeRail

--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -74,6 +74,7 @@ This document is the canonical feature list for Jovie. It is designed for onboar
 | Integrations | Spotify OAuth sign-in method | Shipped (internal v1 default-on) | Free+ | Former key: `feature_spotify_oauth` | Available in auth method selector |
 | Billing | Direct upgrade checkout flow | Shipped (internal v1 default-on) | Free+ | Former key: `billing.upgradeDirect` | Billing UX experiment |
 | Conversion | Subscribe CTA variant experiment | In rollout | Flag-gated | `experiment_subscribe_cta_variant` | Variant defaults to `inline` |
+| Conversion | Public profile PAC variant slots | In rollout | Flag-gated | `profile_pac_variant_slots` | Three-slot Statsig experiment: S1 copy arm, S1 trigger threshold, S2 monetization slot |
 | Creator recording | Teleprompter recording proposals + showcase interstitial | In rollout | Flag-gated | `teleprompter_recording` + `experiment_teleprompter_showcase` | A/B measures interstitial lift into recorder use |
 | Mobile UX | iOS Apple Music destination prioritization | Shipped (internal v1 default-on) | Free+ | Former key: `feature_ios_apple_music_priority` | Listen interface optimization |
 | Marketing Site | Modular homepage sections | Shipped (internal v1 default-on) | Internal v1 default-on flags | `homepage_*` flags | Static flags default visible |

--- a/docs/STATSIG_FEATURE_GATES.md
+++ b/docs/STATSIG_FEATURE_GATES.md
@@ -38,6 +38,7 @@ historical console cleanup.
 |---|---|---|---|---|
 | `experiment_subscribe_cta_variant` | `LEGACY_STATSIG_GATE_KEYS.SUBSCRIBE_CTA_EXPERIMENT` | `'two_step'` | Subscription CTA experiment | Setup |
 | `profile_alert_optin_cta_variant` | `LEGACY_STATSIG_GATE_KEYS.PROFILE_ALERT_OPTIN_EXPERIMENT` | `'button'` | Public profile alert opt-in CTA variant | Setup |
+| `profile_pac_variant_slots` | `LEGACY_STATSIG_GATE_KEYS.PROFILE_PAC_VARIANT_SLOTS_EXPERIMENT` | `{ copyArm: 'default', triggerThreshold: '30s', s2Slot: 'merch' }` | Public profile Primary Action Card slot assignment: S1 copy, S1 trigger threshold, S2 monetization slot | Setup |
 | `experiment_teleprompter_showcase` | `LEGACY_STATSIG_GATE_KEYS.TELEPROMPTER_SHOWCASE_EXPERIMENT` | `'direct'` | Teleprompter showcase interstitial vs direct recorder | Setup |
 
 ## Operational Notes


### PR DESCRIPTION
## Summary
- Add a typed `profile_pac_variant_slots` Statsig experiment contract for the three locked PAC slots: S1 copy arm, S1 trigger threshold, and S2 monetization slot.
- Extend the existing anonymous profile bootstrap route so real visitors get server-resolved PAC assignment from the httpOnly `jv_aid` cookie without making `/[username]` dynamic.
- Thread the assignment through the public profile model and use the S2 slot to order approved home-rail merch/show cards with deterministic fallback when a chosen arm is unavailable.
- Add a pure promotion recommendation helper with do-no-harm guardrails and reversible config patches; no new experiment engine or client-side Statsig SDK.
- Document the experiment in the Statsig gates doc and feature registry.

Fixes #13064

## Design Read
Reading this as: public creator profile conversion surface for cold and returning fans, with a quiet premium utility language, leaning toward Jovie’s Linear-inspired profile design system.

Dials: `DESIGN_VARIANCE=low`, `MOTION_INTENSITY=low`, `VISUAL_DENSITY=medium`.

## Before/After Evidence
Before: public profile only resolved the existing alert opt-in variant (`profile_alert_optin_cta_variant`) and home rail ordered merch before shows unconditionally.

After: component evidence in `ProfileHomeRail.test.tsx` proves S2 `tickets`/`rsvp` prioritizes show cards, `tip` falls back to existing merch/show order, and no duplicate show bucket is rendered. `profile-pac.test.ts` proves malformed Statsig config falls back to defaults and promotion guardrails block capture/dismissal regressions.

No screenshot captured because this diff does not introduce new UI rendering, styling, layout, or motion; it only changes typed assignment plumbing and existing approved card order.

## Design-Taste Frontend Checklist
- Contrast: Pass, no new colors or styles.
- States: Pass, malformed/missing Statsig config and unavailable S2 slots fall back deterministically.
- Layout shift: Pass, no new mounted surfaces; existing cards are reordered only when data exists.
- Motion claims: Pass, no motion changes.
- Copy/rendering variants: Pass, no new rendering arms; slots use existing approved card pool.

## Verification
- `pnpm install --frozen-lockfile` ✅ lockfile up to date, dependencies installed.
- `pnpm exec biome check apps/web/lib/flags/profile-pac.ts apps/web/lib/flags/profile-pac.test.ts apps/web/lib/flags/contracts.ts apps/web/lib/flags/statsig.ts apps/web/lib/flags/profile-variant.ts apps/web/lib/flags/registry.ts apps/web/lib/flags/server.ts apps/web/app/api/profile/audience-anon-cookie/route.ts 'apps/web/app/[username]/page.tsx' apps/web/components/features/profile/AnonCookieBootstrap.tsx apps/web/components/features/profile/StaticArtistPage.tsx apps/web/components/features/profile/view-models.ts apps/web/components/features/profile/contracts.ts apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx apps/web/components/features/profile/templates/ProfileCompactSurface.tsx apps/web/components/features/profile/ProfileHomeRail.tsx apps/web/tests/unit/profile/ProfileHomeRail.test.tsx docs/STATSIG_FEATURE_GATES.md docs/FEATURE_REGISTRY.md` ✅ `Checked 17 files in 38ms. No fixes applied.`
- `pnpm --filter @jovie/web exec vitest run lib/flags/profile-pac.test.ts tests/unit/profile/ProfileHomeRail.test.tsx tests/unit/profile/ProfilePrimaryActionCard.test.tsx tests/unit/lib/feature-flags-registry.test.ts tests/unit/lib/feature-flags-server.test.ts` ✅ `Test Files 5 passed (5); Tests 41 passed (41)`.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` ✅ completed with no TypeScript errors.
- Pre-commit hook ✅ gitleaks no leaks, trufflehog no verified/unverified secrets, next proxy guard, staged Biome/a11y, ESLint, and web typecheck passed.
- Pre-push hook ✅ changed-file Biome, next proxy guard, Tailwind guard, and web typecheck passed.

## Review Notes
- Testing subagent completed and recommended the focused Vitest/typecheck set used above.
- Security subagent completed; implementation keeps assignment server-resolved from the httpOnly anonymous cookie, avoids client Statsig SDK, and keeps promotion inputs as trusted server aggregate inputs rather than public telemetry.
- Review subagent completed; implementation follows the ISR-safe resolver path and documents the Statsig key.
- Local CodeRabbit review: first run produced one valid finding about independent fallbacks in `audience-anon-cookie`; fixed with `Promise.allSettled` and revalidated. A second CodeRabbit run entered heartbeat mode with no new findings before being stopped to avoid a dangling process.

<!-- agent-run-artifact {"issue":13064,"branch":"codex/gh-13064-pac-variant-slots-statsig-auto-promotion-copy-ar-2026-07-04T12-51-14-818z","commit":"d6d28c1b99","verification":{"biome":"passed","vitest":"passed","typecheck":"passed","precommit":"passed","prepush":"passed","coderabbit":"valid finding fixed; rerun heartbeat without new findings"},"design_read":"Reading this as: public creator profile conversion surface for cold and returning fans, with a quiet premium utility language, leaning toward Jovie’s Linear-inspired profile design system.","subagents":{"testing":"completed","security":"completed","review":"completed"}} -->