### PR TITLE
fix(e2e): golden path channel switch when Pro creator defaults to SMS

### DIFF
--- a/apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts
+++ b/apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts
@@ -107,6 +107,17 @@ async function openSubscribeFlow(page: Page) {
     state: 'visible',
     timeout: SMOKE_TIMEOUTS.VISIBILITY,
   });
+
+  // If the flow defaulted to SMS (Pro creator, smsEnabled=true), switch to email.
+  // The "Use Email" button is visible only when channel='sms'.
+  const useEmailBtn = flow.getByRole('button', { name: 'Use Email' });
+  if (await useEmailBtn.isVisible().catch(() => false)) {
+    await useEmailBtn.click();
+    await flow
+      .locator('[data-testid="mobile-email-input"][type="email"]:visible')
+      .first()
+      .waitFor({ state: 'visible', timeout: SMOKE_TIMEOUTS.QUICK });
+  }
 }
 
 async function setupProfileSubscribePage(


### PR DESCRIPTION
## Summary

PR #13093 introduced `smsEnabled`-aware channel defaulting: when a creator is Pro, the capture flow starts in SMS mode (`channel='sms'`).

The golden path E2E test fills an email address into the capture field without first checking the channel. When `channel='sms'`, digits from the email incidentally pass E164 validation, so `subscribe` is called with `channel: 'sms'`, returns `pendingConfirmation: false`, and the flow skips OTP entirely — causing the test to time out waiting for the OTP step.

**Fix:** after opening the subscribe flow, detect SMS mode via the "Use Email" toggle button and click it before filling the email address.

## Test plan
- [ ] Golden path E2E passes on CI (email golden path always uses email channel regardless of creator plan)
- [ ] No production code changed — test-only fix
- [ ] Existing unit tests unaffected

<!-- linear-issue-id:gh-13062 -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)