### PR TITLE
fix(hermes): capture failure no longer blocks dispatch

### DIFF
--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -554,13 +554,15 @@ export function buildGbrainQuery(issue: GithubIssue): string {
 }
 
 export function gbrainContextBlocker(context: GbrainContext): string | null {
+  // Only block on query failures — the query is the actual coordination gate
+  // (checks ownership/existing work). Capture failures are audit-log writes;
+  // a write failure is non-blocking when gbrain is alive and queries succeed.
+  // Capture can fail under system memory pressure (OOM kills bun) without
+  // affecting gbrain reachability or the coordination data we actually need.
   const failures = context.queryResult
     .split('\n')
     .map(line => line.trim())
-    .filter(line => /^gbrain (query|capture) failed:/i.test(line));
-  if (context.captureSlug.includes('(capture failed)')) {
-    failures.push(`gbrain capture failed for ${context.captureSlug}`);
-  }
+    .filter(line => /^gbrain query failed:/i.test(line));
   if (failures.length === 0) return null;
   return [
     'system-blocker: gbrain coordination preflight failed, so no coding agent may start.',


### PR DESCRIPTION
## What

`gbrainContextBlocker` was blocking dispatch whenever `gbrain capture` failed, treating it the same as a query failure.

## Why this is wrong

- **Query** = the actual coordination gate (checks ownership, existing work, agent assignment). Query failure → gbrain unreachable → block.
- **Capture** = audit-log write (records what we're about to dispatch). Write failure is non-blocking when gbrain is healthy.

## Root cause of capture failures

Under system memory pressure (oMLX server using 20GB, Next.js dev server 12GB on a 32GB machine), spawning a new bun process for `gbrain capture` gets OOM-killed by the OS → `execFileSync` throws "Command failed" → every issue gets `codex-blocked` indefinitely.

The gbrain HTTP health check at 127.0.0.1:7801 would show `status: ok` — gbrain is alive. Only the subprocess spawn was failing due to memory pressure.

## Fix

Filter `gbrainContextBlocker` to only check for `gbrain query failed:` lines. Capture failures are still logged in `captureSlug` for debugging but do not block dispatch.

## Ship Validation

- Typecheck: clean
- Biome: clean
- No tests affected (pure logic change in a lib function)

<!-- linear-issue-id: JOV-3979 -->