### PR TITLE
feat(settings): Settings IA consolidation — 4-group sidebar with search

### DIFF
--- a/apps/web/app/app/(shell)/settings/layout.tsx
+++ b/apps/web/app/app/(shell)/settings/layout.tsx
@@ -1,4 +1,5 @@
 import { PageShell } from '@/components/organisms/PageShell';
+import { SettingsSidebar } from '@/features/settings/SettingsSidebar';
 
 export default function SettingsLayout({
   children,
@@ -7,14 +8,21 @@ export default function SettingsLayout({
 }>) {
   return (
     <PageShell
-      maxWidth='form'
+      maxWidth='wide'
       frame='none'
       contentPadding='none'
       scroll='page'
       surfaceClassName='pb-10'
       data-testid='settings-shell-content'
     >
-      <div className='space-y-6'>{children}</div>
+      <div className='flex items-start gap-8'>
+        {/* Grouped settings navigation — hidden on mobile, where the app
+            shell sidebar already exposes the settings sections. */}
+        <SettingsSidebar className='max-md:hidden' />
+        <div className='min-w-0 max-w-(--app-shell-content-max-form) flex-1 space-y-6'>
+          {children}
+        </div>
+      </div>
     </PageShell>
   );
 }

--- a/apps/web/components/features/settings/SettingsSidebar.tsx
+++ b/apps/web/components/features/settings/SettingsSidebar.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { Input } from '@jovie/ui';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
+import {
+  getSidebarNavIconClassName,
+  getSidebarNavRowClassName,
+} from '@/components/shell/SidebarNavItem';
+import { cn } from '@/lib/utils';
+import {
+  filterSettingsGroups,
+  isSettingsItemActive,
+  SETTINGS_SIDEBAR_GROUPS,
+} from './settings-sidebar-config';
+
+// SettingsSidebar — grouped navigation for the settings surface.
+// Renders the approved 4-group IA (Profile / Account / Workspace / Billing)
+// with a filter-as-you-type search input at the top. Rows reuse the canonical
+// shell nav chrome from SidebarNavItem so settings nav can never drift from
+// the app sidebar's look.
+
+export interface SettingsSidebarProps {
+  readonly className?: string;
+}
+
+export function SettingsSidebar({ className }: SettingsSidebarProps) {
+  const pathname = usePathname();
+  const { isAdmin } = useDashboardData();
+  const [query, setQuery] = useState('');
+
+  const groups = useMemo(
+    () => filterSettingsGroups(SETTINGS_SIDEBAR_GROUPS, query, { isAdmin }),
+    [query, isAdmin]
+  );
+
+  return (
+    <aside
+      className={cn('w-52 shrink-0', className)}
+      data-testid='settings-sidebar'
+    >
+      <div className='sticky top-6 space-y-4'>
+        <Input
+          type='search'
+          inputSize='sm'
+          value={query}
+          onChange={event => setQuery(event.target.value)}
+          placeholder='Search settings'
+          aria-label='Search settings'
+          data-testid='settings-sidebar-search'
+        />
+        <nav aria-label='Settings navigation' className='space-y-4'>
+          {groups.map(group => {
+            const groupActive = group.items.some(item =>
+              isSettingsItemActive(pathname, item.href)
+            );
+
+            return (
+              <div key={group.id} data-testid={`settings-group-${group.id}`}>
+                <p
+                  className={cn(
+                    'mb-1 px-2.5 text-2xs font-medium',
+                    groupActive ? 'text-primary-token' : 'text-tertiary-token'
+                  )}
+                >
+                  {group.label}
+                </p>
+                <ul className='space-y-px pl-2'>
+                  {group.items.map(item => {
+                    const active = isSettingsItemActive(pathname, item.href);
+
+                    return (
+                      <li key={item.id}>
+                        <Link
+                          href={item.href}
+                          aria-current={active ? 'page' : undefined}
+                          className={getSidebarNavRowClassName({
+                            active,
+                            nested: true,
+                            className: 'before:hidden after:hidden',
+                          })}
+                        >
+                          <item.icon
+                            className={getSidebarNavIconClassName({
+                              active,
+                              nested: true,
+                            })}
+                            strokeWidth={2.25}
+                            aria-hidden='true'
+                          />
+                          <span className='min-w-0 truncate text-left justify-self-start'>
+                            {item.label}
+                          </span>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          })}
+          {groups.length === 0 && (
+            <p className='px-2.5 text-xs text-tertiary-token'>
+              No settings match your search.
+            </p>
+          )}
+        </nav>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/components/features/settings/settings-sidebar-config.test.ts
+++ b/apps/web/components/features/settings/settings-sidebar-config.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  filterSettingsGroups,
+  isSettingsItemActive,
+  SETTINGS_SIDEBAR_GROUPS,
+} from './settings-sidebar-config';
+
+// Nav-structure snapshot: the settings IA is a reviewed fixture (approved
+// 2026-07-03 via Design Shootout, `settings-ia`). Changing the groups or
+// their membership requires a deliberate update here — see #12645.
+
+describe('SETTINGS_SIDEBAR_GROUPS', () => {
+  it('defines the approved 4-group IA', () => {
+    expect(SETTINGS_SIDEBAR_GROUPS.map(group => group.id)).toEqual([
+      'profile',
+      'account',
+      'workspace',
+      'billing',
+    ]);
+  });
+
+  it('assigns the 11 sub-pages (+admin) to their approved groups', () => {
+    const membership = Object.fromEntries(
+      SETTINGS_SIDEBAR_GROUPS.map(group => [
+        group.id,
+        group.items.map(item => item.id),
+      ])
+    );
+
+    expect(membership).toEqual({
+      profile: ['artist-profile', 'contacts', 'appearance'],
+      account: ['account', 'data-privacy', 'delete-account'],
+      workspace: ['connectors', 'retargeting-ads', 'admin'],
+      billing: ['billing', 'usage', 'referral'],
+    });
+  });
+
+  it('points every item at a settings route', () => {
+    for (const item of SETTINGS_SIDEBAR_GROUPS.flatMap(group => group.items)) {
+      expect(item.href.startsWith(`${APP_ROUTES.SETTINGS}/`)).toBe(true);
+    }
+  });
+
+  it('never reuses an item id across groups', () => {
+    const ids = SETTINGS_SIDEBAR_GROUPS.flatMap(group =>
+      group.items.map(item => item.id)
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('filterSettingsGroups', () => {
+  it('returns all non-admin items for an empty query', () => {
+    const groups = filterSettingsGroups(SETTINGS_SIDEBAR_GROUPS, '');
+    const ids = groups.flatMap(group => group.items.map(item => item.id));
+    expect(ids).not.toContain('admin');
+    expect(ids).toHaveLength(11);
+  });
+
+  it('includes admin-only items for admins', () => {
+    const groups = filterSettingsGroups(SETTINGS_SIDEBAR_GROUPS, '', {
+      isAdmin: true,
+    });
+    const ids = groups.flatMap(group => group.items.map(item => item.id));
+    expect(ids).toContain('admin');
+    expect(ids).toHaveLength(12);
+  });
+
+  it('filters by item label, case-insensitively', () => {
+    const groups = filterSettingsGroups(SETTINGS_SIDEBAR_GROUPS, 'PRIVACY');
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items.map(item => item.id)).toEqual(['data-privacy']);
+  });
+
+  it('matches a group label and keeps its visible items', () => {
+    const groups = filterSettingsGroups(SETTINGS_SIDEBAR_GROUPS, 'billing');
+    expect(groups.map(group => group.id)).toEqual(['billing']);
+    expect(groups[0].items.map(item => item.id)).toEqual([
+      'billing',
+      'usage',
+      'referral',
+    ]);
+  });
+
+  it('drops groups with no matching items', () => {
+    const groups = filterSettingsGroups(SETTINGS_SIDEBAR_GROUPS, 'referral');
+    expect(groups.map(group => group.id)).toEqual(['billing']);
+  });
+
+  it('returns an empty list when nothing matches', () => {
+    expect(
+      filterSettingsGroups(SETTINGS_SIDEBAR_GROUPS, 'zzz-no-match')
+    ).toEqual([]);
+  });
+
+  it('never surfaces admin-only items via search for non-admins', () => {
+    const groups = filterSettingsGroups(SETTINGS_SIDEBAR_GROUPS, 'admin');
+    const ids = groups.flatMap(group => group.items.map(item => item.id));
+    expect(ids).not.toContain('admin');
+  });
+});
+
+describe('isSettingsItemActive', () => {
+  it('matches exact paths', () => {
+    expect(
+      isSettingsItemActive(
+        APP_ROUTES.SETTINGS_BILLING,
+        APP_ROUTES.SETTINGS_BILLING
+      )
+    ).toBe(true);
+  });
+
+  it('matches nested paths', () => {
+    expect(
+      isSettingsItemActive(
+        `${APP_ROUTES.SETTINGS_CONNECTORS}/google`,
+        APP_ROUTES.SETTINGS_CONNECTORS
+      )
+    ).toBe(true);
+  });
+
+  it('does not match sibling prefixes', () => {
+    expect(
+      isSettingsItemActive(
+        `${APP_ROUTES.SETTINGS_BILLING}-history`,
+        APP_ROUTES.SETTINGS_BILLING
+      )
+    ).toBe(false);
+  });
+});

--- a/apps/web/components/features/settings/settings-sidebar-config.ts
+++ b/apps/web/components/features/settings/settings-sidebar-config.ts
@@ -1,0 +1,179 @@
+import {
+  Banknote,
+  Cable,
+  Contact,
+  Gauge,
+  Gift,
+  Lock,
+  type LucideIcon,
+  Palette,
+  ShieldCheck,
+  Target,
+  Trash2,
+  UserRound,
+  Wrench,
+} from 'lucide-react';
+import { APP_ROUTES } from '@/constants/routes';
+
+// Settings IA — approved 2026-07-03 via Design Shootout (`settings-ia`).
+// Groups the 11 settings sub-pages under 4 top-level groups. This config is
+// the single source of truth for the settings sidebar; the nav snapshot test
+// in settings-sidebar-config.test.ts locks the structure so changes require
+// a deliberate review (see #12645 IA guardrails).
+
+export interface SettingsSidebarItem {
+  readonly id: string;
+  readonly label: string;
+  readonly href: string;
+  readonly icon: LucideIcon;
+  /** Only rendered when the current user is an admin. */
+  readonly adminOnly?: boolean;
+}
+
+export interface SettingsSidebarGroup {
+  readonly id: string;
+  readonly label: string;
+  readonly items: readonly SettingsSidebarItem[];
+}
+
+export const SETTINGS_SIDEBAR_GROUPS: readonly SettingsSidebarGroup[] = [
+  {
+    id: 'profile',
+    label: 'Profile',
+    items: [
+      {
+        id: 'artist-profile',
+        label: 'Artist profile',
+        href: APP_ROUTES.SETTINGS_ARTIST_PROFILE,
+        icon: UserRound,
+      },
+      {
+        id: 'contacts',
+        label: 'Contacts',
+        href: APP_ROUTES.SETTINGS_CONTACTS,
+        icon: Contact,
+      },
+      {
+        id: 'appearance',
+        label: 'Appearance',
+        href: APP_ROUTES.SETTINGS_APPEARANCE,
+        icon: Palette,
+      },
+    ],
+  },
+  {
+    id: 'account',
+    label: 'Account',
+    items: [
+      {
+        id: 'account',
+        label: 'Account',
+        href: APP_ROUTES.SETTINGS_ACCOUNT,
+        icon: ShieldCheck,
+      },
+      {
+        id: 'data-privacy',
+        label: 'Data & privacy',
+        href: APP_ROUTES.SETTINGS_DATA_PRIVACY,
+        icon: Lock,
+      },
+      {
+        id: 'delete-account',
+        label: 'Delete account',
+        href: APP_ROUTES.SETTINGS_DELETE_ACCOUNT,
+        icon: Trash2,
+      },
+    ],
+  },
+  {
+    id: 'workspace',
+    label: 'Workspace',
+    items: [
+      {
+        id: 'connectors',
+        label: 'Connectors',
+        href: APP_ROUTES.SETTINGS_CONNECTORS,
+        icon: Cable,
+      },
+      {
+        id: 'retargeting-ads',
+        label: 'Retargeting ads',
+        href: APP_ROUTES.SETTINGS_RETARGETING_ADS,
+        icon: Target,
+      },
+      {
+        id: 'admin',
+        label: 'Admin',
+        href: APP_ROUTES.SETTINGS_ADMIN,
+        icon: Wrench,
+        adminOnly: true,
+      },
+    ],
+  },
+  {
+    id: 'billing',
+    label: 'Billing',
+    items: [
+      {
+        id: 'billing',
+        label: 'Billing',
+        href: APP_ROUTES.SETTINGS_BILLING,
+        icon: Banknote,
+      },
+      {
+        id: 'usage',
+        label: 'Usage',
+        href: APP_ROUTES.SETTINGS_USAGE,
+        icon: Gauge,
+      },
+      {
+        id: 'referral',
+        label: 'Referral',
+        href: APP_ROUTES.SETTINGS_REFERRAL,
+        icon: Gift,
+      },
+    ],
+  },
+];
+
+export interface FilterSettingsGroupsOptions {
+  readonly isAdmin?: boolean;
+}
+
+/**
+ * Filter the settings groups for the sidebar's search input.
+ *
+ * - Admin-only items are dropped unless `isAdmin` is true.
+ * - A query matches an item when it appears in the item label or the group
+ *   label (case-insensitive substring).
+ * - Groups with no visible items are dropped entirely.
+ */
+export function filterSettingsGroups(
+  groups: readonly SettingsSidebarGroup[],
+  query: string,
+  options: FilterSettingsGroupsOptions = {}
+): SettingsSidebarGroup[] {
+  const normalized = query.trim().toLowerCase();
+
+  return groups
+    .map(group => {
+      const groupMatches = group.label.toLowerCase().includes(normalized);
+      const items = group.items.filter(item => {
+        if (item.adminOnly && !options.isAdmin) {
+          return false;
+        }
+        if (!normalized) {
+          return true;
+        }
+        return groupMatches || item.label.toLowerCase().includes(normalized);
+      });
+
+      return { ...group, items };
+    })
+    .filter(group => group.items.length > 0);
+}
+
+/** Whether a settings nav item is active for the current pathname. */
+export function isSettingsItemActive(pathname: string, href: string): boolean {
+  return pathname === href || pathname.startsWith(`${href}/`);
+}

--- a/apps/web/components/shell/Tooltip.tsx
+++ b/apps/web/components/shell/Tooltip.tsx
@@ -121,6 +121,7 @@ function getTriggerChild({
 
   // Non-element / multi-child fallback: layout wrapper only. Seam offset is
   // measured via ref callback (no pointer/focus handlers on a static span).
+  // Handlers on a static <span> would trip a11y noStaticElementInteractions.
   return (
     <span
       ref={triggerRef}

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -71,6 +71,7 @@ export const APP_ROUTES = {
   SETTINGS_ANALYTICS: '/app/settings/analytics',
   SETTINGS_ADMIN: '/app/settings/admin',
   SETTINGS_RETARGETING_ADS: '/app/settings/retargeting-ads',
+  SETTINGS_REFERRAL: '/app/settings/referral',
   /** @deprecated Use SETTINGS_DATA_PRIVACY instead */
   SETTINGS_DELETE_ACCOUNT: '/app/settings/delete-account',
 


### PR DESCRIPTION
Fixes #12888 — Settings IA consolidation, approved 2026-07-03 via Design Shootout (card: settings-ia). Companion to #12645.

## What changed

- **New `SettingsSidebar`** (`apps/web/components/features/settings/`): grouped navigation for the settings surface with the approved 4-group IA — **Profile** (artist-profile, contacts, appearance), **Account** (account, data-privacy, delete-account), **Workspace** (connectors, retargeting-ads, admin), **Billing** (billing, usage, referral).
- **Search settings input** at the top — filters items as you type (matches item or group label, case-insensitive); groups with no matches collapse away.
- **Active state**: the active page row is highlighted via the canonical `getSidebarNavRowClassName` chrome from `SidebarNavItem` (no hand-rolled nav classes), and the containing group label is highlighted. Sub-pages are indented under their group label.
- **Layout** (`settings/layout.tsx`): renders the sidebar beside the existing content column (`maxWidth` widened to fit; content column stays capped at the form width). `scroll=page` and the `settings-shell-content` testid are preserved (locked by existing regression tests).
- **New `/app/settings/referral` page**: the issue routes Referral under Billing, but no page existed (the orphaned `ReferralCodeCopyClient` was never mounted). Added a server page using the existing `getOrCreateReferralCode` service + `SETTINGS_REFERRAL` route constant, with commission copy derived from `lib/referrals/config.ts` and a graceful fallback state.
- **Nav-structure snapshot test** (`settings-sidebar-config.test.ts`): locks the 4-group membership as a reviewed fixture (per the #12645 guardrails direction) and covers the search filter + admin gating + active-path logic.

## Decisions / flags

- **URLs unchanged.** The approved IA is a navigation grouping; all 11 sub-pages keep their existing `/app/settings/*` routes, so no cross-page links needed rewriting (the acceptance item is satisfied vacuously — verified via the existing alias-route regression tests).
- **Redirect stubs kept in nav as specced**: `appearance` currently redirects to `account`, and `delete-account` redirects to `data-privacy` (pre-existing behavior, asserted by `settings-shell-normalization.test.ts`). They are listed in their approved groups; clicking them lands on the redirect target. If those should become real pages (e.g. split theme out of Account into Appearance), that is a follow-up.
- **Admin gated**: the Admin item only renders for admins (`useDashboardData().isAdmin`), matching the page-level gate that bounces non-admins.
- **Mobile**: the in-page sidebar is hidden below `md`; the app-shell sidebar (`DashboardNav` settings mode) still provides settings navigation there. Desktop now shows both the shell settings groups and the new in-page sidebar — if the shell settings mode should be retired in favor of this sidebar, that is a deliberate follow-up to the IA epic, not snuck into this PR.
- **Arbitrary-values ratchet**: no new arbitrary Tailwind bracket values introduced (rows reuse the canonical nav chrome helpers).
- Referral share URL uses `/signup?ref=<code>`; signup-side auto-consumption of `ref` is a pre-existing gap (checkout already accepts `referralCode`).

## Verification

- Biome 2.5.1 `check` clean on all changed files.
- Sidebar config/filter/active logic executed against the new test assertions (all pass).
- Existing settings-layout regression contracts kept: `<PageShell`, `scroll=page`, `settings-shell-content` testid, alias-route redirects untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)