### PR TITLE
feat(hud): server-side PR title humanizer for the What Shipped feed

### DIFF
--- a/apps/web/app/api/ops/humanize-pr-title/route.ts
+++ b/apps/web/app/api/ops/humanize-pr-title/route.ts
@@ -1,0 +1,78 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authorizeHud } from '@/lib/auth/hud';
+import { captureError } from '@/lib/error-tracking';
+import { humanizePrTitle } from '@/lib/hud/humanize-pr-title';
+import { logger } from '@/lib/utils/logger';
+
+/**
+ * Server-side PR title humanizer for the /hud What Shipped feed.
+ *
+ * POST { number, title } -> { title } (emoji + plain-English text).
+ *
+ * The LLM is called at most once per PR number — results are cached in Redis
+ * with no expiry, portable with the Python sidecar's per-PR cache. Model
+ * failures degrade to the raw title so the feed never breaks.
+ */
+
+export const runtime = 'nodejs';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+const requestSchema = z
+  .object({
+    number: z.number().int().positive(),
+    title: z.string().trim().min(1).max(300),
+  })
+  .strict();
+
+export async function POST(request: NextRequest): Promise<Response> {
+  try {
+    const kioskToken = new URL(request.url).searchParams.get('kiosk');
+    const auth = await authorizeHud(kioskToken);
+
+    if (!auth.ok) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON body' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const parsed = requestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Expected { number: positive int, title: string }' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const result = await humanizePrTitle(parsed.data);
+
+    return NextResponse.json(
+      { title: result.title, source: result.source },
+      { headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    logger.error('[ops/humanize-pr-title] Failed to humanize title', error);
+    await captureError('PR title humanize failed', error, {
+      route: '/api/ops/humanize-pr-title',
+      method: 'POST',
+    });
+
+    return NextResponse.json(
+      { error: 'Failed to humanize PR title' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/api/ops/what-shipped/route.ts
+++ b/apps/web/app/api/ops/what-shipped/route.ts
@@ -6,6 +6,7 @@ import {
   EMPTY_WHAT_SHIPPED_RESPONSE,
   readWhatShippedFromDisk,
 } from '@/lib/hud/what-shipped';
+import { readWhatShippedFromGitHub } from '@/lib/hud/what-shipped-github';
 import { logger } from '@/lib/utils/logger';
 
 export const runtime = 'nodejs';
@@ -24,7 +25,14 @@ export async function GET(request: NextRequest): Promise<Response> {
       );
     }
 
-    const payload = await readWhatShippedFromDisk();
+    // Primary source: the sidecar-written local JSON cache (dev machine).
+    // Fallback: recently merged PRs from GitHub with server-side humanized
+    // titles, so the feed works wherever the web app is deployed.
+    const diskPayload = await readWhatShippedFromDisk();
+    const payload = diskPayload.available
+      ? diskPayload
+      : await readWhatShippedFromGitHub();
+
     return NextResponse.json(payload, { headers: NO_STORE_HEADERS });
   } catch (error) {
     logger.error('[ops/what-shipped] Failed to read what shipped feed', error);

--- a/apps/web/lib/hud/humanize-pr-title.ts
+++ b/apps/web/lib/hud/humanize-pr-title.ts
@@ -1,0 +1,146 @@
+import 'server-only';
+
+import { gateway, generateText } from '@/lib/ai/sdk';
+import { buildAiTelemetry } from '@/lib/ai/telemetry';
+import { TITLE_MODEL } from '@/lib/constants/ai-models';
+import { getRedis } from '@/lib/redis';
+import { logger } from '@/lib/utils/logger';
+
+/**
+ * Server-side PR title humanizer for the /hud "What Shipped" feed.
+ *
+ * Mirrors the Python sidecar (`~/.hermes/scripts/what_shipped.py`): rewrite a
+ * raw PR title into an emoji-prefixed plain-English line, call the LLM at most
+ * once per PR, and never let a model failure break the feed (fall back to the
+ * raw title).
+ *
+ * Cache entries are keyed by PR number with no expiry, so results produced by
+ * the sidecar and by this route are interchangeable.
+ */
+
+/**
+ * Same intent as the Python sidecar prompt so cached titles stay stylistically
+ * consistent regardless of which side produced them.
+ */
+export const HUMANIZE_PR_TITLE_PROMPT = `You rewrite GitHub pull request titles for a "What shipped" feed read by a non-technical founder.
+
+Rewrite the PR title as: one fitting emoji, a space, then a short plain-English description of what changed (at most 10 words), written in past tense.
+
+Rules:
+- Drop conventional-commit prefixes (feat:, fix:, chore:, scope tags).
+- No jargon, no ticket numbers, no quotes, no trailing punctuation.
+- Describe the user-visible outcome, not the implementation.
+- Return only the rewritten title.`;
+
+/** Hard timeout on the LLM call, matching the Python sidecar's 8s gate. */
+export const HUMANIZE_PR_TITLE_TIMEOUT_MS = 8_000;
+
+const MAX_INPUT_TITLE_LENGTH = 300;
+const MAX_OUTPUT_TITLE_LENGTH = 140;
+const CACHE_KEY_PREFIX = 'hud:pr-title:v1:';
+
+export type HumanizedPrTitleSource = 'cache' | 'model' | 'fallback';
+
+export interface HumanizePrTitleInput {
+  readonly number: number;
+  readonly title: string;
+}
+
+export interface HumanizePrTitleResult {
+  readonly title: string;
+  readonly source: HumanizedPrTitleSource;
+}
+
+export function humanizedPrTitleCacheKey(prNumber: number): string {
+  return `${CACHE_KEY_PREFIX}${prNumber}`;
+}
+
+function sanitizeTitle(raw: string, maxLength: number): string {
+  const singleLine = raw
+    .replaceAll(/\s+/g, ' ')
+    .trim()
+    .replaceAll(/^["'`]+|["'`]+$/g, '')
+    .trim();
+
+  return singleLine.length > maxLength
+    ? singleLine.slice(0, maxLength).trimEnd()
+    : singleLine;
+}
+
+async function readCachedTitle(prNumber: number): Promise<string | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  try {
+    const cached = await redis.get<string>(humanizedPrTitleCacheKey(prNumber));
+    if (typeof cached === 'string' && cached.trim().length > 0) {
+      return cached;
+    }
+  } catch (error) {
+    logger.error('[hud/humanize-pr-title] Redis read failed', error);
+  }
+
+  return null;
+}
+
+async function writeCachedTitle(
+  prNumber: number,
+  title: string
+): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+
+  try {
+    // Intentionally no TTL: humanized titles are immutable per PR.
+    await redis.set(humanizedPrTitleCacheKey(prNumber), title);
+  } catch (error) {
+    logger.error('[hud/humanize-pr-title] Redis write failed', error);
+  }
+}
+
+/**
+ * Humanize a PR title, calling the LLM at most once per PR number.
+ *
+ * Never throws: any cache/model failure degrades to the sanitized raw title so
+ * the What Shipped feed keeps rendering.
+ */
+export async function humanizePrTitle(
+  input: HumanizePrTitleInput
+): Promise<HumanizePrTitleResult> {
+  const rawTitle = sanitizeTitle(input.title, MAX_INPUT_TITLE_LENGTH);
+  if (!rawTitle) {
+    return { title: input.title.trim(), source: 'fallback' };
+  }
+
+  const cached = await readCachedTitle(input.number);
+  if (cached) {
+    return { title: cached, source: 'cache' };
+  }
+
+  try {
+    const { text } = await generateText({
+      model: gateway(TITLE_MODEL),
+      system: HUMANIZE_PR_TITLE_PROMPT,
+      prompt: rawTitle,
+      maxOutputTokens: 60,
+      abortSignal: AbortSignal.timeout(HUMANIZE_PR_TITLE_TIMEOUT_MS),
+      experimental_telemetry: buildAiTelemetry({
+        functionId: 'hud-humanize-pr-title',
+        metadata: { prNumber: input.number },
+      }),
+    });
+
+    const humanized = sanitizeTitle(text, MAX_OUTPUT_TITLE_LENGTH);
+    if (!humanized) {
+      return { title: rawTitle, source: 'fallback' };
+    }
+
+    // Only cache successful model output — a cached fallback would freeze the
+    // raw title forever.
+    await writeCachedTitle(input.number, humanized);
+    return { title: humanized, source: 'model' };
+  } catch (error) {
+    logger.error('[hud/humanize-pr-title] Model call failed', error);
+    return { title: rawTitle, source: 'fallback' };
+  }
+}

--- a/apps/web/lib/hud/what-shipped-github.ts
+++ b/apps/web/lib/hud/what-shipped-github.ts
@@ -1,0 +1,177 @@
+import 'server-only';
+
+import { env } from '@/lib/env-server';
+import { captureError } from '@/lib/error-tracking';
+import { serverFetch } from '@/lib/http/server-fetch';
+import { humanizePrTitle } from '@/lib/hud/humanize-pr-title';
+import {
+  EMPTY_WHAT_SHIPPED_RESPONSE,
+  type WhatShippedItem,
+  type WhatShippedResponse,
+} from '@/lib/hud/what-shipped';
+import { getRedis } from '@/lib/redis';
+import { logger } from '@/lib/utils/logger';
+
+/**
+ * GitHub-backed fallback source for the /hud "What Shipped" feed.
+ *
+ * The primary source is `~/.hermes/state/what_shipped.json`, written by the
+ * Python sidecar on the dev machine. On deployments where that file does not
+ * exist (Vercel, Cloudflare), this module fetches recently merged PRs straight
+ * from GitHub and humanizes their titles via `humanizePrTitle` (LLM called at
+ * most once per PR, cached in Redis with no expiry).
+ */
+
+const MERGED_WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_ITEMS = 10;
+const FEED_CACHE_KEY = 'hud:what-shipped:github-feed:v1';
+const FEED_CACHE_TTL_SECONDS = 60;
+
+interface GitHubPullSummary {
+  readonly number: number;
+  readonly title: string;
+  readonly merged_at: string | null;
+  readonly html_url: string;
+}
+
+function isGitHubPullSummary(value: unknown): value is GitHubPullSummary {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.number === 'number' &&
+    typeof record.title === 'string' &&
+    typeof record.html_url === 'string' &&
+    (typeof record.merged_at === 'string' || record.merged_at === null)
+  );
+}
+
+async function readCachedFeed(): Promise<WhatShippedResponse | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  try {
+    const cached = await redis.get<WhatShippedResponse>(FEED_CACHE_KEY);
+    if (cached && Array.isArray(cached.items)) {
+      return cached;
+    }
+  } catch (error) {
+    logger.error('[hud/what-shipped-github] Redis read failed', error);
+  }
+
+  return null;
+}
+
+async function writeCachedFeed(feed: WhatShippedResponse): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+
+  try {
+    await redis.set(FEED_CACHE_KEY, feed, { ex: FEED_CACHE_TTL_SECONDS });
+  } catch (error) {
+    logger.error('[hud/what-shipped-github] Redis write failed', error);
+  }
+}
+
+async function fetchRecentlyMergedPulls(
+  token: string,
+  owner: string,
+  repo: string
+): Promise<GitHubPullSummary[]> {
+  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls?state=closed&sort=updated&direction=desc&per_page=50`;
+
+  const response = await serverFetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    cache: 'no-store',
+    context: 'GitHub merged pulls',
+    retry: {
+      maxRetries: 2,
+      baseDelayMs: 500,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error (${response.status})`);
+  }
+
+  const payload: unknown = await response.json();
+  if (!Array.isArray(payload)) {
+    throw new Error('Unexpected GitHub API response for merged pulls');
+  }
+
+  const cutoff = Date.now() - MERGED_WINDOW_MS;
+
+  return payload
+    .filter(isGitHubPullSummary)
+    .filter(pull => {
+      if (!pull.merged_at) return false;
+      const mergedAt = Date.parse(pull.merged_at);
+      return Number.isFinite(mergedAt) && mergedAt >= cutoff;
+    })
+    .sort(
+      (a, b) => Date.parse(b.merged_at ?? '') - Date.parse(a.merged_at ?? '')
+    )
+    .slice(0, MAX_ITEMS);
+}
+
+/**
+ * Build the What Shipped feed from GitHub with humanized titles.
+ *
+ * Returns the empty payload when HUD GitHub credentials are not configured or
+ * the GitHub call fails — the feed degrades, it never throws to the route.
+ */
+export async function readWhatShippedFromGitHub(): Promise<WhatShippedResponse> {
+  const token = env.HUD_GITHUB_TOKEN;
+  const owner = env.HUD_GITHUB_OWNER;
+  const repo = env.HUD_GITHUB_REPO;
+
+  if (!token || !owner || !repo) {
+    return EMPTY_WHAT_SHIPPED_RESPONSE;
+  }
+
+  const cached = await readCachedFeed();
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const pulls = await fetchRecentlyMergedPulls(token, owner, repo);
+
+    const items: WhatShippedItem[] = await Promise.all(
+      pulls.map(async (pull): Promise<WhatShippedItem> => {
+        const humanized = await humanizePrTitle({
+          number: pull.number,
+          title: pull.title,
+        });
+
+        return {
+          number: pull.number,
+          title: humanized.title,
+          merged_at: pull.merged_at ?? '',
+          url: pull.html_url,
+        };
+      })
+    );
+
+    const feed: WhatShippedResponse = {
+      generatedAt: new Date().toISOString(),
+      items,
+      available: true,
+    };
+
+    await writeCachedFeed(feed);
+    return feed;
+  } catch (error) {
+    logger.error(
+      '[hud/what-shipped-github] Failed to build GitHub feed',
+      error
+    );
+    await captureError('What shipped GitHub fallback failed', error, {
+      context: 'hud_what_shipped_github',
+    });
+    return EMPTY_WHAT_SHIPPED_RESPONSE;
+  }
+}

--- a/apps/web/tests/lib/hud/humanize-pr-title.test.ts
+++ b/apps/web/tests/lib/hud/humanize-pr-title.test.ts
@@ -13,8 +13,8 @@ vi.mock('@/lib/redis', () => ({
 }));
 
 import {
-  humanizePrTitle,
   humanizedPrTitleCacheKey,
+  humanizePrTitle,
 } from '@/lib/hud/humanize-pr-title';
 
 interface RedisStub {

--- a/apps/web/tests/lib/hud/humanize-pr-title.test.ts
+++ b/apps/web/tests/lib/hud/humanize-pr-title.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const generateTextMock = vi.fn();
+const getRedisMock = vi.fn();
+
+vi.mock('@/lib/ai/sdk', () => ({
+  generateText: (...args: unknown[]) => generateTextMock(...args),
+  gateway: (modelId: string) => modelId,
+}));
+
+vi.mock('@/lib/redis', () => ({
+  getRedis: () => getRedisMock(),
+}));
+
+import {
+  humanizePrTitle,
+  humanizedPrTitleCacheKey,
+} from '@/lib/hud/humanize-pr-title';
+
+interface RedisStub {
+  readonly get: ReturnType<typeof vi.fn>;
+  readonly set: ReturnType<typeof vi.fn>;
+}
+
+function stubRedis(overrides: Partial<RedisStub> = {}): RedisStub {
+  const redis: RedisStub = {
+    get: overrides.get ?? vi.fn().mockResolvedValue(null),
+    set: overrides.set ?? vi.fn().mockResolvedValue('OK'),
+  };
+  getRedisMock.mockReturnValue(redis);
+  return redis;
+}
+
+describe('humanizedPrTitleCacheKey', () => {
+  it('keys the cache by PR number', () => {
+    expect(humanizedPrTitleCacheKey(12895)).toBe('hud:pr-title:v1:12895');
+  });
+});
+
+describe('humanizePrTitle', () => {
+  beforeEach(() => {
+    generateTextMock.mockReset();
+    getRedisMock.mockReset();
+  });
+
+  it('returns the cached title without calling the model', async () => {
+    const redis = stubRedis({
+      get: vi.fn().mockResolvedValue('🚀 Shipped the new merch page'),
+    });
+
+    const result = await humanizePrTitle({
+      number: 12895,
+      title: 'feat(merch): add merch page',
+    });
+
+    expect(result).toEqual({
+      title: '🚀 Shipped the new merch page',
+      source: 'cache',
+    });
+    expect(redis.get).toHaveBeenCalledWith('hud:pr-title:v1:12895');
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+
+  it('calls the model on cache miss and caches the result with no expiry', async () => {
+    const redis = stubRedis();
+    generateTextMock.mockResolvedValue({
+      text: '  "✨ Made release setup faster"  ',
+    });
+
+    const result = await humanizePrTitle({
+      number: 42,
+      title: 'perf(release): speed up setup flow',
+    });
+
+    expect(result).toEqual({
+      title: '✨ Made release setup faster',
+      source: 'model',
+    });
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    expect(redis.set).toHaveBeenCalledWith(
+      'hud:pr-title:v1:42',
+      '✨ Made release setup faster'
+    );
+  });
+
+  it('falls back to the raw title when the model call fails', async () => {
+    const redis = stubRedis();
+    generateTextMock.mockRejectedValue(new Error('gateway timeout'));
+
+    const result = await humanizePrTitle({
+      number: 7,
+      title: 'fix(auth): resolve login redirect loop',
+    });
+
+    expect(result).toEqual({
+      title: 'fix(auth): resolve login redirect loop',
+      source: 'fallback',
+    });
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it('falls back without caching when the model returns empty text', async () => {
+    const redis = stubRedis();
+    generateTextMock.mockResolvedValue({ text: '   ' });
+
+    const result = await humanizePrTitle({
+      number: 9,
+      title: 'chore: bump dependencies',
+    });
+
+    expect(result).toEqual({
+      title: 'chore: bump dependencies',
+      source: 'fallback',
+    });
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it('still humanizes when Redis is unavailable', async () => {
+    getRedisMock.mockReturnValue(null);
+    generateTextMock.mockResolvedValue({ text: '🧹 Cleaned up old scripts' });
+
+    const result = await humanizePrTitle({
+      number: 11,
+      title: 'chore(scripts): remove dead code',
+    });
+
+    expect(result).toEqual({
+      title: '🧹 Cleaned up old scripts',
+      source: 'model',
+    });
+  });
+});


### PR DESCRIPTION
Closes #12895

## What

Moves the What Shipped PR title humanizer off the dev-machine Python sidecar and into the Jovie web app, so the `/hud` feed works wherever the app is deployed.

- **`POST /api/ops/humanize-pr-title`** — takes `{ number, title }`, returns `{ title }` (emoji + plain-English text). Auth via `authorizeHud` (admin session or `?kiosk=` token), strict zod body validation.
- **`lib/hud/humanize-pr-title.ts`** — the humanizer: LLM call through the app's AI SDK chokepoint (`@/lib/ai/sdk` → Vercel AI Gateway, `TITLE_MODEL` = `google/gemini-2.0-flash`, the app's cheap title model), 8s hard timeout matching the sidecar, results cached in Upstash Redis keyed by PR number with **no expiry** (`hud:pr-title:v1:<n>`). LLM is called at most once per PR; failures degrade to the raw title and are never cached.
- **`lib/hud/what-shipped-github.ts`** — GitHub-backed fallback feed: when `~/.hermes/state/what_shipped.json` is unavailable (any non-dev-Mac deploy), fetch PRs merged in the last 24h via the existing `HUD_GITHUB_TOKEN/OWNER/REPO` env (same creds the HUD shipping-velocity route uses), humanize titles server-side, cache the assembled feed 60s in Redis.
- **`/api/ops/what-shipped`** — now falls back to the GitHub feed when the disk cache is missing. `<WhatShipped />` needs no changes: it keeps polling the same endpoint and now gets humanized titles everywhere.
- Unit tests for the humanizer (cache hit, model call + sanitize + no-expiry cache write, fallback on error/empty output, Redis-unavailable path).

## Decisions & flags

- **Cache store:** Upstash Redis (the app's existing KV) rather than a new Supabase table — no migration, matches the issue's "or Vercel KV" option, and cache keys are portable by PR number.
- **Model:** issue says "deepseek-flash via the Vercel AI gateway, or whichever model the model_router routes to" — the app has no deepseek registration; `TITLE_MODEL` (gemini-2.0-flash) is the established cheap title model at the same cost class, routed through the same gateway chokepoint as all other app LLM calls.
- **Prompt parity:** the Python sidecar (`~/.hermes/scripts/what_shipped.py`) isn't reachable from this environment, so `HUMANIZE_PR_TITLE_PROMPT` reimplements its intent (emoji + short plain-English past-tense line, no commit-prefix jargon). Cache entries are interchangeable either way since they're keyed by PR number. If the sidecar prompt differs materially, diff and sync the constant.
- **Component fallback shape:** rather than fanning out per-row LLM calls from the client, the fallback runs server-side inside the endpoint `<WhatShipped />` already polls. The standalone route is still exposed per the acceptance criteria.
- Python sidecar stays as-is (out of scope per issue).

## Verification

Sandbox has no npm registry access, so please rely on CI: `vitest tests/lib/hud/humanize-pr-title.test.ts`, typecheck, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)