### PR TITLE
feat(inbox): subtle usage pill + limits popover (top-right of home)

### DIFF
--- a/apps/web/app/api/usage/summary/route.ts
+++ b/apps/web/app/api/usage/summary/route.ts
@@ -1,16 +1,10 @@
 import { and, count, eq, gte, isNotNull, min } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
-import { getCachedAuth } from '@/lib/auth/cached';
 import { isMissingConnectorSchemaError } from '@/lib/connectors/schema-errors';
 import { db } from '@/lib/db';
 import { getUserByClerkId } from '@/lib/db/queries/shared';
 import { suggestedActions } from '@/lib/db/schema/connectors';
-import {
-  getPlanDisplayName,
-  type PlanId,
-  resolveCanonicalPlanId,
-} from '@/lib/entitlements/registry';
-import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { getPlanDisplayName, type PlanId } from '@/lib/entitlements/registry';
 import {
   getRemainingPercent,
   getUsageLimits,
@@ -18,6 +12,7 @@ import {
   LIVE_ACTION_WINDOW_MS,
   type UsageSummaryData,
 } from '@/lib/usage/limits';
+import { requireUsageAuth } from '@/lib/usage/require-usage-auth';
 import { logger } from '@/lib/utils/logger';
 
 export const runtime = 'nodejs';
@@ -159,28 +154,11 @@ function buildUsageSummary(params: {
 }
 
 export async function GET() {
-  let userId: string | null;
-  try {
-    ({ userId } = await getCachedAuth());
-  } catch (error) {
-    // Clerk throws when middleware didn't run (e.g., matcher misconfiguration).
-    // Return 401 for that case, but let unexpected errors propagate to Sentry.
-    const message = error instanceof Error ? error.message : '';
-    if (message.includes('clerkMiddleware')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    throw error;
+  const auth = await requireUsageAuth();
+  if (auth.response) {
+    return auth.response;
   }
-  if (!userId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const entitlements = await getCurrentUserEntitlements();
-  if (!entitlements.isAuthenticated || !entitlements.userId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const plan = resolveCanonicalPlanId(entitlements.plan) ?? 'free';
+  const { userId, plan } = auth;
 
   const now = new Date();
   const week = getWeeklyUsageWindow(now);

--- a/apps/web/app/api/usage/summary/route.ts
+++ b/apps/web/app/api/usage/summary/route.ts
@@ -1,0 +1,198 @@
+import { and, count, eq, gte, isNotNull, min } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { isMissingConnectorSchemaError } from '@/lib/connectors/schema-errors';
+import { db } from '@/lib/db';
+import { getUserByClerkId } from '@/lib/db/queries/shared';
+import { suggestedActions } from '@/lib/db/schema/connectors';
+import {
+  getPlanDisplayName,
+  type PlanId,
+  resolveCanonicalPlanId,
+} from '@/lib/entitlements/registry';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import {
+  getRemainingPercent,
+  getUsageLimits,
+  getWeeklyUsageWindow,
+  LIVE_ACTION_WINDOW_MS,
+  type UsageSummaryData,
+} from '@/lib/usage/limits';
+import { logger } from '@/lib/utils/logger';
+
+export const runtime = 'nodejs';
+
+const CACHE_HEADERS = {
+  'Cache-Control': 'private, max-age=30, stale-while-revalidate=120',
+} as const;
+
+interface UsageCounts {
+  readonly suggestionsThisWeek: number;
+  readonly liveActionsInWindow: number;
+  readonly oldestLiveActionAt: Date | null;
+  readonly stale: boolean;
+}
+
+const EMPTY_COUNTS: UsageCounts = {
+  suggestionsThisWeek: 0,
+  liveActionsInWindow: 0,
+  oldestLiveActionAt: null,
+  stale: false,
+};
+
+/**
+ * Real usage counts from `suggested_actions`:
+ * - suggestions surfaced this calendar week (createdAt >= UTC Monday)
+ * - live actions executed in the trailing 5-hour window (executedAt)
+ *
+ * Fails soft: any DB error (including missing connector schema) degrades to
+ * zero counts flagged `_stale` instead of throwing — the pill still renders.
+ */
+async function loadUsageCounts(
+  clerkUserId: string,
+  weekStart: Date,
+  windowStart: Date
+): Promise<UsageCounts> {
+  try {
+    const dbUser = await getUserByClerkId(db, clerkUserId);
+    if (!dbUser) {
+      return EMPTY_COUNTS;
+    }
+
+    const [suggestionRows, liveActionRows] = await Promise.all([
+      db
+        .select({ value: count() })
+        .from(suggestedActions)
+        .where(
+          and(
+            eq(suggestedActions.userId, dbUser.id),
+            gte(suggestedActions.createdAt, weekStart)
+          )
+        ),
+      db
+        .select({
+          value: count(),
+          oldest: min(suggestedActions.executedAt),
+        })
+        .from(suggestedActions)
+        .where(
+          and(
+            eq(suggestedActions.userId, dbUser.id),
+            isNotNull(suggestedActions.executedAt),
+            gte(suggestedActions.executedAt, windowStart)
+          )
+        ),
+    ]);
+
+    const oldestRaw = liveActionRows[0]?.oldest ?? null;
+
+    return {
+      suggestionsThisWeek: suggestionRows[0]?.value ?? 0,
+      liveActionsInWindow: liveActionRows[0]?.value ?? 0,
+      oldestLiveActionAt: oldestRaw ? new Date(oldestRaw) : null,
+      stale: false,
+    };
+  } catch (error) {
+    if (!isMissingConnectorSchemaError(error)) {
+      logger.warn('Usage summary counts unavailable; serving degraded data', {
+        error,
+      });
+    }
+    return { ...EMPTY_COUNTS, stale: true };
+  }
+}
+
+function buildUsageSummary(params: {
+  readonly plan: PlanId;
+  readonly counts: UsageCounts;
+  readonly weekResetAt: Date;
+}): UsageSummaryData {
+  const { plan, counts, weekResetAt } = params;
+  const limits = getUsageLimits(plan);
+
+  const suggestionsRemaining = Math.max(
+    0,
+    limits.suggestionsPerWeek - counts.suggestionsThisWeek
+  );
+  const liveActionsRemaining = Math.max(
+    0,
+    limits.liveActionsPer5h - counts.liveActionsInWindow
+  );
+
+  const suggestionsRemainingPercent = getRemainingPercent(
+    counts.suggestionsThisWeek,
+    limits.suggestionsPerWeek
+  );
+  const liveActionsRemainingPercent = getRemainingPercent(
+    counts.liveActionsInWindow,
+    limits.liveActionsPer5h
+  );
+
+  const liveActionsResetAt = counts.oldestLiveActionAt
+    ? new Date(
+        counts.oldestLiveActionAt.getTime() + LIVE_ACTION_WINDOW_MS
+      ).toISOString()
+    : null;
+
+  return {
+    plan,
+    planDisplayName: getPlanDisplayName(plan),
+    suggestions: {
+      used: counts.suggestionsThisWeek,
+      limit: limits.suggestionsPerWeek,
+      remaining: suggestionsRemaining,
+      remainingPercent: suggestionsRemainingPercent,
+      resetAt: weekResetAt.toISOString(),
+    },
+    liveActions: {
+      used: counts.liveActionsInWindow,
+      limit: limits.liveActionsPer5h,
+      remaining: liveActionsRemaining,
+      resetAt: liveActionsResetAt,
+    },
+    remainingPercent: Math.min(
+      suggestionsRemainingPercent,
+      liveActionsRemainingPercent
+    ),
+    ...(counts.stale ? { _stale: true as const } : {}),
+  };
+}
+
+export async function GET() {
+  let userId: string | null;
+  try {
+    ({ userId } = await getCachedAuth());
+  } catch (error) {
+    // Clerk throws when middleware didn't run (e.g., matcher misconfiguration).
+    // Return 401 for that case, but let unexpected errors propagate to Sentry.
+    const message = error instanceof Error ? error.message : '';
+    if (message.includes('clerkMiddleware')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    throw error;
+  }
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const entitlements = await getCurrentUserEntitlements();
+  if (!entitlements.isAuthenticated || !entitlements.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const plan = resolveCanonicalPlanId(entitlements.plan) ?? 'free';
+
+  const now = new Date();
+  const week = getWeeklyUsageWindow(now);
+  const windowStart = new Date(now.getTime() - LIVE_ACTION_WINDOW_MS);
+
+  const counts = await loadUsageCounts(userId, week.start, windowStart);
+
+  const summary = buildUsageSummary({
+    plan,
+    counts,
+    weekResetAt: week.resetAt,
+  });
+
+  return NextResponse.json(summary, { headers: CACHE_HEADERS });
+}

--- a/apps/web/components/atoms/BrandLogo.tsx
+++ b/apps/web/components/atoms/BrandLogo.tsx
@@ -16,7 +16,7 @@ export interface BrandLogoProps {
 
 const TONE_CLASSES: Record<BrandLogoTone, string | undefined> = {
   auto: undefined,
-  white: 'text-white',
+  white: 'text-white dark:text-white',
   color: 'text-accent',
   muted: 'text-muted-foreground/50',
 };

--- a/apps/web/components/features/dashboard/atoms/HeaderUsagePill.tsx
+++ b/apps/web/components/features/dashboard/atoms/HeaderUsagePill.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@jovie/ui';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { memo } from 'react';
+import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
+import { env } from '@/lib/env-client';
+import { useUsageSummaryQuery } from '@/lib/queries';
+import { formatResetDay, formatResetIn } from '@/lib/usage/limits';
+
+/**
+ * Subtle top-right usage pill + limits popover (Opportunity Inbox home).
+ *
+ * Quiet, glanceable chrome: the pill shows the overall remaining percent
+ * (the tighter of the weekly suggestions and 5-hr live-actions quotas).
+ * Click opens a popover with both quotas, their resets, and a link to the
+ * full usage page. Doubles as an upgrade entry point.
+ *
+ * Layout-shift guard: the pill reserves its footprint while loading
+ * (invisible placeholder value) and uses tabular numerals with a fixed
+ * min-width so value updates never reflow the header.
+ */
+
+const PILL_CLASSES =
+  'inline-flex min-w-14 items-center justify-center gap-1.5 rounded-full border border-subtle bg-surface-1 px-2.5 py-1.5 text-app font-caption text-secondary-token transition-colors hover:bg-surface-2 hover:text-primary-token';
+
+export const HeaderUsagePill = memo(function HeaderUsagePill() {
+  const pathname = usePathname();
+  const isPassiveRuntime = env.IS_E2E;
+  const isDemoRoute = isDemoRoutePath(pathname);
+  const { data } = useUsageSummaryQuery({
+    enabled: !isPassiveRuntime && !isDemoRoute,
+  });
+
+  if (isPassiveRuntime || isDemoRoute) {
+    return null;
+  }
+
+  if (!data) {
+    // Reserve the pill's footprint while loading so the header never shifts.
+    return (
+      <span
+        className={PILL_CLASSES}
+        aria-hidden
+        data-testid='usage-pill-loading'
+      >
+        <span className='tabular-nums opacity-0'>100%</span>
+      </span>
+    );
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type='button'
+          className={PILL_CLASSES}
+          aria-label={`Jovie usage: ${data.remainingPercent}% remaining. Open usage details.`}
+          data-testid='usage-pill'
+        >
+          <span className='tabular-nums'>{data.remainingPercent}%</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align='end' className='w-72 p-0' testId='usage-popover'>
+        <div className='border-b border-subtle px-4 py-3'>
+          <p className='text-app font-caption font-medium text-primary-token'>
+            Jovie Usage · {data.planDisplayName}
+          </p>
+        </div>
+        <dl className='space-y-3 px-4 py-3'>
+          <div className='flex items-baseline justify-between gap-3'>
+            <dt className='text-app font-caption text-primary-token'>
+              Suggestions
+            </dt>
+            <dd className='text-right text-app font-caption text-secondary-token'>
+              <span className='tabular-nums'>
+                This week · {data.suggestions.remainingPercent}% left
+              </span>
+              <span className='block text-tertiary-token'>
+                Resets {formatResetDay(data.suggestions.resetAt)}
+              </span>
+            </dd>
+          </div>
+          <div className='flex items-baseline justify-between gap-3'>
+            <dt className='text-app font-caption text-primary-token'>
+              Live actions
+            </dt>
+            <dd className='text-right text-app font-caption text-secondary-token'>
+              <span className='tabular-nums'>
+                5-hr window · {data.liveActions.used}/{data.liveActions.limit}
+              </span>
+              <span className='block text-tertiary-token'>
+                {data.liveActions.resetAt
+                  ? `Resets in ${formatResetIn(data.liveActions.resetAt)}`
+                  : 'Window clear'}
+              </span>
+            </dd>
+          </div>
+        </dl>
+        <div className='border-t border-subtle px-4 py-2.5'>
+          <Link
+            href={APP_ROUTES.SETTINGS_USAGE}
+            className='text-app font-caption text-secondary-token transition-colors hover:text-primary-token'
+          >
+            Learn more about limits
+          </Link>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+});

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -34,6 +34,7 @@ import {
   useTableMeta,
 } from '@/contexts/TableMetaContext';
 import { HeaderChatUsageIndicator } from '@/features/dashboard/atoms/HeaderChatUsageIndicator';
+import { HeaderUsagePill } from '@/features/dashboard/atoms/HeaderUsagePill';
 import { RightRailKeyboardHandler } from '@/hooks/RightRailKeyboardHandler';
 import { useAuthRouteConfig } from '@/hooks/useAuthRouteConfig';
 import { useDashboardShortcuts } from '@/hooks/useDashboardShortcuts';
@@ -118,12 +119,17 @@ function AuthShellWrapperInner({
     !config.isDemoRoute &&
     (config.isChatRoute || pathname === APP_ROUTES.DASHBOARD);
 
+  // Home/inbox glanceable usage pill (top-right, quiet chrome).
+  const showUsagePill =
+    !config.isDemoRoute && pathname === APP_ROUTES.DASHBOARD;
+
   // Determine header action: use custom actions from context if available,
   // otherwise fall back to default based on route type
   const defaultHeaderAction = useMemo(
     () => (
       <>
         {showArtistProfileRailToggle ? <ArtistProfileRailToggle /> : null}
+        {showUsagePill ? <HeaderUsagePill /> : null}
         {config.showChatUsageIndicator && !config.isDemoRoute ? (
           <HeaderChatUsageIndicator />
         ) : null}
@@ -135,6 +141,7 @@ function AuthShellWrapperInner({
       config.showChatUsageIndicator,
       isElectron,
       showArtistProfileRailToggle,
+      showUsagePill,
     ]
   );
   // Wrap page-injected header elements in ErrorBoundary so a throwing badge/action

--- a/apps/web/lib/queries/index.ts
+++ b/apps/web/lib/queries/index.ts
@@ -247,6 +247,12 @@ export {
   chatUsageQueryOptions,
   useChatUsageQuery,
 } from './useChatUsageQuery';
+// Plan usage summary (header usage pill + limits popover)
+export {
+  type UsageSummaryData,
+  usageSummaryQueryOptions,
+  useUsageSummaryQuery,
+} from './useUsageSummaryQuery';
 // Confirm chat edit mutation
 export {
   type ConfirmChatEditInput,

--- a/apps/web/lib/queries/index.ts
+++ b/apps/web/lib/queries/index.ts
@@ -247,12 +247,6 @@ export {
   chatUsageQueryOptions,
   useChatUsageQuery,
 } from './useChatUsageQuery';
-// Plan usage summary (header usage pill + limits popover)
-export {
-  type UsageSummaryData,
-  usageSummaryQueryOptions,
-  useUsageSummaryQuery,
-} from './useUsageSummaryQuery';
 // Confirm chat edit mutation
 export {
   type ConfirmChatEditInput,
@@ -492,7 +486,6 @@ export {
 } from './useReleaseMutations';
 // Release queries and mutations
 export { useReleasesQuery } from './useReleasesQuery';
-
 export {
   type ReleaseTrack,
   useReleaseTracksQuery,
@@ -541,6 +534,12 @@ export {
 export { useTrackingMutation } from './useTrackingMutation';
 // Unified artist search query
 export { useUnifiedArtistSearchQuery } from './useUnifiedArtistSearchQuery';
+// Plan usage summary (header usage pill + limits popover)
+export {
+  type UsageSummaryData,
+  usageSummaryQueryOptions,
+  useUsageSummaryQuery,
+} from './useUsageSummaryQuery';
 // User avatar upload mutation
 export {
   type UseUserAvatarMutationOptions,

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -349,6 +349,12 @@ export const queryKeys = {
       [...queryKeys.opportunityInbox.all, 'pending-cards'] as const,
   },
 
+  // Plan usage (header usage pill + limits popover)
+  usage: {
+    all: ['usage'] as const,
+    summary: () => [...queryKeys.usage.all, 'summary'] as const,
+  },
+
   // Audience infinite scroll
   audience: {
     all: ['audience'] as const,

--- a/apps/web/lib/queries/useUsageSummaryQuery.ts
+++ b/apps/web/lib/queries/useUsageSummaryQuery.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { UsageSummaryData } from '@/lib/usage/limits';
+import { FREQUENT_BACKGROUND_CACHE } from './cache-strategies';
+import { createQueryFn, FetchError } from './fetch';
+import { queryKeys } from './keys';
+
+export type { UsageSummaryData };
+
+const fetchUsageSummary = createQueryFn<UsageSummaryData>('/api/usage/summary');
+
+export const usageSummaryQueryOptions = {
+  queryKey: queryKeys.usage.summary(),
+  queryFn: fetchUsageSummary,
+  ...FREQUENT_BACKGROUND_CACHE,
+  retry: (failureCount: number, error: Error) => {
+    if (error instanceof FetchError && !error.isRetryable()) {
+      return false;
+    }
+    return failureCount < 1;
+  },
+  retryDelay: (attempt: number) => Math.min(1000 * 2 ** attempt, 10000),
+} as const;
+
+export function useUsageSummaryQuery(options?: { enabled?: boolean }) {
+  const { enabled = true } = options ?? {};
+
+  return useQuery<UsageSummaryData, Error>({
+    ...usageSummaryQueryOptions,
+    enabled,
+  });
+}

--- a/apps/web/lib/queries/useUsageSummaryQuery.ts
+++ b/apps/web/lib/queries/useUsageSummaryQuery.ts
@@ -10,8 +10,15 @@ export type { UsageSummaryData };
 
 const fetchUsageSummary = createQueryFn<UsageSummaryData>('/api/usage/summary');
 
+/**
+ * Query options for the plan usage summary. `queryKey` is a getter so
+ * importing `@/lib/queries` does not crash tests that mock a partial
+ * `queryKeys` object without a `usage` namespace.
+ */
 export const usageSummaryQueryOptions = {
-  queryKey: queryKeys.usage.summary(),
+  get queryKey() {
+    return queryKeys.usage.summary();
+  },
   queryFn: fetchUsageSummary,
   ...FREQUENT_BACKGROUND_CACHE,
   retry: (failureCount: number, error: Error) => {
@@ -21,13 +28,14 @@ export const usageSummaryQueryOptions = {
     return failureCount < 1;
   },
   retryDelay: (attempt: number) => Math.min(1000 * 2 ** attempt, 10000),
-} as const;
+};
 
 export function useUsageSummaryQuery(options?: { enabled?: boolean }) {
   const { enabled = true } = options ?? {};
 
   return useQuery<UsageSummaryData, Error>({
     ...usageSummaryQueryOptions,
+    queryKey: queryKeys.usage.summary(),
     enabled,
   });
 }

--- a/apps/web/lib/usage/limits.ts
+++ b/apps/web/lib/usage/limits.ts
@@ -1,0 +1,142 @@
+/**
+ * Jovie usage limits — display caps + pure window/percent helpers for the
+ * header usage pill and limits popover (Opportunity Inbox, issue #11566).
+ *
+ * These caps are the single tunable source for the usage summary surface.
+ * They are DISPLAY caps for the glanceable usage pill; once server-side
+ * enforcement lands they should migrate into the entitlement registry
+ * (`lib/entitlements/registry.ts`) alongside the other numeric limits.
+ *
+ * Pure module: safe to import from both server routes and client components.
+ */
+
+import type { PlanId } from '@/lib/entitlements/registry';
+
+// ---------------------------------------------------------------------------
+// Caps
+// ---------------------------------------------------------------------------
+
+export interface JovieUsageLimits {
+  /** Max suggestions surfaced per calendar week (UTC, Monday start). */
+  readonly suggestionsPerWeek: number;
+  /** Max live actions executed within a rolling 5-hour window. */
+  readonly liveActionsPer5h: number;
+}
+
+/** Rolling window for live actions: 5 hours, in milliseconds. */
+export const LIVE_ACTION_WINDOW_MS = 5 * 60 * 60 * 1000;
+
+const USAGE_LIMITS: Record<PlanId, JovieUsageLimits> = {
+  free: { suggestionsPerWeek: 15, liveActionsPer5h: 5 },
+  trial: { suggestionsPerWeek: 75, liveActionsPer5h: 25 },
+  pro: { suggestionsPerWeek: 75, liveActionsPer5h: 25 },
+  max: { suggestionsPerWeek: 200, liveActionsPer5h: 100 },
+};
+
+export function getUsageLimits(plan: PlanId): JovieUsageLimits {
+  return USAGE_LIMITS[plan];
+}
+
+// ---------------------------------------------------------------------------
+// Windows
+// ---------------------------------------------------------------------------
+
+export interface WeeklyUsageWindow {
+  /** Start of the current usage week (UTC Monday 00:00). */
+  readonly start: Date;
+  /** Start of the next usage week — when the weekly counter resets. */
+  readonly resetAt: Date;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Current calendar-week window, UTC, starting Monday 00:00. */
+export function getWeeklyUsageWindow(now = new Date()): WeeklyUsageWindow {
+  const daysSinceMonday = (now.getUTCDay() + 6) % 7;
+  const start = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() - daysSinceMonday
+    )
+  );
+  return { start, resetAt: new Date(start.getTime() + 7 * DAY_MS) };
+}
+
+// ---------------------------------------------------------------------------
+// Percentages
+// ---------------------------------------------------------------------------
+
+/** Percent of a quota still remaining, clamped to 0–100. */
+export function getRemainingPercent(used: number, limit: number): number {
+  if (limit <= 0) return 0;
+  const remaining = Math.max(0, limit - used);
+  return Math.round(Math.min(1, remaining / limit) * 100);
+}
+
+// ---------------------------------------------------------------------------
+// Summary payload shape (shared by the API route and the client hook)
+// ---------------------------------------------------------------------------
+
+export interface UsageSummaryData {
+  readonly plan: PlanId;
+  readonly planDisplayName: string;
+  readonly suggestions: {
+    readonly used: number;
+    readonly limit: number;
+    readonly remaining: number;
+    readonly remainingPercent: number;
+    /** ISO timestamp — start of next week (UTC Monday). */
+    readonly resetAt: string;
+  };
+  readonly liveActions: {
+    readonly used: number;
+    readonly limit: number;
+    readonly remaining: number;
+    /**
+     * ISO timestamp when the oldest action in the rolling window ages out.
+     * Null when no live actions were executed in the current window.
+     */
+    readonly resetAt: string | null;
+  };
+  /** Overall remaining percent — the tighter of the two quotas. */
+  readonly remainingPercent: number;
+  /** Present when counts were unavailable and the snapshot is degraded. */
+  readonly _stale?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Client-side formatting
+// ---------------------------------------------------------------------------
+
+/** "Resets <day>" — short weekday name for a weekly reset, e.g. "Mon". */
+export function formatResetDay(value: string | null | undefined): string {
+  if (!value) return '—';
+  const resetAt = new Date(value);
+  if (Number.isNaN(resetAt.getTime())) return '—';
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    timeZone: 'UTC',
+  }).format(resetAt);
+}
+
+/** "Resets in <time>" — compact duration until an ISO timestamp, e.g. "3h 05m". */
+export function formatResetIn(
+  value: string | null | undefined,
+  now = new Date()
+): string {
+  if (!value) return '—';
+  const resetAt = new Date(value);
+  if (Number.isNaN(resetAt.getTime())) return '—';
+
+  const deltaMs = resetAt.getTime() - now.getTime();
+  if (deltaMs <= 0) return 'now';
+
+  const totalMinutes = Math.ceil(deltaMs / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours <= 0) return `${minutes}m`;
+  if (minutes === 0) return `${hours}h`;
+  return `${hours}h ${String(minutes).padStart(2, '0')}m`;
+}

--- a/apps/web/lib/usage/limits.ts
+++ b/apps/web/lib/usage/limits.ts
@@ -10,6 +10,7 @@
  * Pure module: safe to import from both server routes and client components.
  */
 
+import { computeRatePercent } from '@/lib/analytics/metrics';
 import type { PlanId } from '@/lib/entitlements/registry';
 
 // ---------------------------------------------------------------------------
@@ -69,9 +70,8 @@ export function getWeeklyUsageWindow(now = new Date()): WeeklyUsageWindow {
 
 /** Percent of a quota still remaining, clamped to 0–100. */
 export function getRemainingPercent(used: number, limit: number): number {
-  if (limit <= 0) return 0;
   const remaining = Math.max(0, limit - used);
-  return Math.round(Math.min(1, remaining / limit) * 100);
+  return computeRatePercent(remaining, limit, 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/lib/usage/require-usage-auth.ts
+++ b/apps/web/lib/usage/require-usage-auth.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getCachedAuth } from '@/lib/auth/cached';
-import { type PlanId, resolveCanonicalPlanId } from '@/lib/entitlements/registry';
+import {
+  type PlanId,
+  resolveCanonicalPlanId,
+} from '@/lib/entitlements/registry';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 
 interface UsageAuthSuccess {

--- a/apps/web/lib/usage/require-usage-auth.ts
+++ b/apps/web/lib/usage/require-usage-auth.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { type PlanId, resolveCanonicalPlanId } from '@/lib/entitlements/registry';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+
+interface UsageAuthSuccess {
+  readonly response: null;
+  readonly userId: string;
+  readonly plan: PlanId;
+}
+
+interface UsageAuthFailure {
+  readonly response: NextResponse;
+  readonly userId?: undefined;
+  readonly plan?: undefined;
+}
+
+export type UsageAuthResult = UsageAuthSuccess | UsageAuthFailure;
+
+const unauthorized = (): UsageAuthFailure => ({
+  response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+});
+
+/**
+ * Shared auth preamble for usage endpoints: resolves the Clerk user and the
+ * canonical plan id, degrading Clerk middleware misconfiguration to a 401
+ * (unexpected errors propagate to Sentry). Extracted from
+ * `app/api/chat/usage/route.ts`'s inline preamble so new usage routes do not
+ * copy-paste it (SonarCloud new-code duplication gate).
+ */
+export async function requireUsageAuth(): Promise<UsageAuthResult> {
+  let userId: string | null;
+  try {
+    ({ userId } = await getCachedAuth());
+  } catch (error) {
+    // Clerk throws when middleware didn't run (e.g., matcher misconfiguration).
+    const message = error instanceof Error ? error.message : '';
+    if (message.includes('clerkMiddleware')) {
+      return unauthorized();
+    }
+    throw error;
+  }
+  if (!userId) {
+    return unauthorized();
+  }
+
+  const entitlements = await getCurrentUserEntitlements();
+  if (!entitlements.isAuthenticated || !entitlements.userId) {
+    return unauthorized();
+  }
+
+  return {
+    response: null,
+    userId,
+    plan: resolveCanonicalPlanId(entitlements.plan) ?? 'free',
+  };
+}

--- a/apps/web/tests/unit/dashboard/HeaderUsagePill.test.tsx
+++ b/apps/web/tests/unit/dashboard/HeaderUsagePill.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { HeaderUsagePill } from '@/features/dashboard/atoms/HeaderUsagePill';
+import { fastRender } from '@/tests/utils/fast-render';
+
+const mockUseUsageSummaryQuery = vi.fn();
+const mockUsePathname = vi.fn(() => '/app');
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock('@/lib/queries', () => ({
+  useUsageSummaryQuery: () => mockUseUsageSummaryQuery(),
+}));
+
+const SUMMARY = {
+  plan: 'pro' as const,
+  planDisplayName: 'Pro',
+  suggestions: {
+    used: 12,
+    limit: 75,
+    remaining: 63,
+    remainingPercent: 84,
+    resetAt: '2026-07-06T00:00:00.000Z',
+  },
+  liveActions: {
+    used: 3,
+    limit: 25,
+    remaining: 22,
+    resetAt: '2026-07-02T16:00:00.000Z',
+  },
+  remainingPercent: 84,
+};
+
+describe('HeaderUsagePill', () => {
+  it('renders the overall remaining percent in the pill', () => {
+    mockUseUsageSummaryQuery.mockReturnValue({ data: SUMMARY });
+
+    const { getByTestId } = fastRender(<HeaderUsagePill />);
+
+    expect(getByTestId('usage-pill').textContent).toContain('84%');
+  });
+
+  it('reserves the pill footprint while loading (no layout shift)', () => {
+    mockUseUsageSummaryQuery.mockReturnValue({ data: undefined });
+
+    const { getByTestId, queryByTestId } = fastRender(<HeaderUsagePill />);
+
+    expect(getByTestId('usage-pill-loading')).toBeDefined();
+    expect(queryByTestId('usage-pill')).toBeNull();
+  });
+
+  it('opens the limits popover with plan, weekly, 5-hr, and learn-more rows', () => {
+    mockUseUsageSummaryQuery.mockReturnValue({ data: SUMMARY });
+
+    const { getByTestId, getByText, getByRole } = fastRender(
+      <HeaderUsagePill />
+    );
+
+    fireEvent.click(getByTestId('usage-pill'));
+
+    expect(getByText('Jovie Usage · Pro')).toBeDefined();
+    expect(getByText('Suggestions')).toBeDefined();
+    expect(getByText(/This week · 84% left/)).toBeDefined();
+    expect(getByText(/Resets Mon/)).toBeDefined();
+    expect(getByText('Live actions')).toBeDefined();
+    expect(getByText(/5-hr window · 3\/25/)).toBeDefined();
+    expect(
+      getByRole('link', { name: 'Learn more about limits' })
+    ).toBeDefined();
+  });
+
+  it('renders nothing on demo routes', () => {
+    mockUsePathname.mockReturnValueOnce('/demo/showcase');
+    mockUseUsageSummaryQuery.mockReturnValue({ data: SUMMARY });
+
+    const { queryByTestId } = fastRender(<HeaderUsagePill />);
+
+    expect(queryByTestId('usage-pill')).toBeNull();
+    expect(queryByTestId('usage-pill-loading')).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/lib/queries/useAccountMutations.test.tsx
+++ b/apps/web/tests/unit/lib/queries/useAccountMutations.test.tsx
@@ -35,6 +35,10 @@ vi.mock('@/lib/queries/keys', () => ({
       conversation: (id: string) => ['chat', 'conversation', id] as const,
       usage: () => ['chat', 'usage'] as const,
     },
+    usage: {
+      all: ['usage'] as const,
+      summary: () => ['usage', 'summary'] as const,
+    },
     user: {
       all: ['user'] as const,
       profile: () => ['user', 'profile'] as const,

--- a/apps/web/tests/unit/lib/queries/useBillingMutations.test.tsx
+++ b/apps/web/tests/unit/lib/queries/useBillingMutations.test.tsx
@@ -42,6 +42,10 @@ vi.mock('@/lib/queries/keys', () => ({
       conversation: (id: string) => ['chat', 'conversation', id] as const,
       usage: () => ['chat', 'usage'] as const,
     },
+    usage: {
+      all: ['usage'] as const,
+      summary: () => ['usage', 'summary'] as const,
+    },
   },
 }));
 

--- a/apps/web/tests/unit/lib/queries/useSettingsMutation.test.tsx
+++ b/apps/web/tests/unit/lib/queries/useSettingsMutation.test.tsx
@@ -58,6 +58,10 @@ vi.mock('@/lib/queries/keys', () => ({
       conversation: (id: string) => ['chat', 'conversation', id] as const,
       usage: () => ['chat', 'usage'] as const,
     },
+    usage: {
+      all: ['usage'] as const,
+      summary: () => ['usage', 'summary'] as const,
+    },
   },
 }));
 

--- a/apps/web/tests/unit/lib/usage-limits.test.ts
+++ b/apps/web/tests/unit/lib/usage-limits.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatResetDay,
+  formatResetIn,
+  getRemainingPercent,
+  getUsageLimits,
+  getWeeklyUsageWindow,
+  LIVE_ACTION_WINDOW_MS,
+} from '@/lib/usage/limits';
+
+describe('getWeeklyUsageWindow', () => {
+  it('starts the window on UTC Monday 00:00', () => {
+    // Thursday 2026-07-02 15:30 UTC → week starts Monday 2026-06-29
+    const now = new Date('2026-07-02T15:30:00.000Z');
+    const window = getWeeklyUsageWindow(now);
+
+    expect(window.start.toISOString()).toBe('2026-06-29T00:00:00.000Z');
+    expect(window.resetAt.toISOString()).toBe('2026-07-06T00:00:00.000Z');
+  });
+
+  it('treats Sunday as the last day of the week', () => {
+    // Sunday 2026-07-05 → week still starts Monday 2026-06-29
+    const now = new Date('2026-07-05T10:00:00.000Z');
+    const window = getWeeklyUsageWindow(now);
+
+    expect(window.start.toISOString()).toBe('2026-06-29T00:00:00.000Z');
+    expect(window.resetAt.toISOString()).toBe('2026-07-06T00:00:00.000Z');
+  });
+
+  it('starts a fresh window on Monday itself', () => {
+    const now = new Date('2026-07-06T00:00:00.000Z');
+    const window = getWeeklyUsageWindow(now);
+
+    expect(window.start.toISOString()).toBe('2026-07-06T00:00:00.000Z');
+    expect(window.resetAt.toISOString()).toBe('2026-07-13T00:00:00.000Z');
+  });
+});
+
+describe('getRemainingPercent', () => {
+  it('returns 100 when nothing is used', () => {
+    expect(getRemainingPercent(0, 25)).toBe(100);
+  });
+
+  it('returns 0 when the quota is exhausted or exceeded', () => {
+    expect(getRemainingPercent(25, 25)).toBe(0);
+    expect(getRemainingPercent(30, 25)).toBe(0);
+  });
+
+  it('rounds to whole percent', () => {
+    expect(getRemainingPercent(1, 3)).toBe(67);
+  });
+
+  it('returns 0 for a non-positive limit', () => {
+    expect(getRemainingPercent(0, 0)).toBe(0);
+  });
+});
+
+describe('getUsageLimits', () => {
+  it('never decreases caps when upgrading plans', () => {
+    const free = getUsageLimits('free');
+    const pro = getUsageLimits('pro');
+    const max = getUsageLimits('max');
+
+    expect(pro.suggestionsPerWeek).toBeGreaterThanOrEqual(
+      free.suggestionsPerWeek
+    );
+    expect(max.suggestionsPerWeek).toBeGreaterThanOrEqual(
+      pro.suggestionsPerWeek
+    );
+    expect(pro.liveActionsPer5h).toBeGreaterThanOrEqual(free.liveActionsPer5h);
+    expect(max.liveActionsPer5h).toBeGreaterThanOrEqual(pro.liveActionsPer5h);
+  });
+
+  it('defines positive caps for every plan', () => {
+    for (const plan of ['free', 'trial', 'pro', 'max'] as const) {
+      const limits = getUsageLimits(plan);
+      expect(limits.suggestionsPerWeek).toBeGreaterThan(0);
+      expect(limits.liveActionsPer5h).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('formatResetDay', () => {
+  it('formats an ISO timestamp as a short UTC weekday', () => {
+    expect(formatResetDay('2026-07-06T00:00:00.000Z')).toBe('Mon');
+  });
+
+  it('degrades gracefully on missing or invalid input', () => {
+    expect(formatResetDay(null)).toBe('—');
+    expect(formatResetDay('not-a-date')).toBe('—');
+  });
+});
+
+describe('formatResetIn', () => {
+  const now = new Date('2026-07-02T12:00:00.000Z');
+
+  it('formats hours and minutes', () => {
+    expect(formatResetIn('2026-07-02T15:05:00.000Z', now)).toBe('3h 05m');
+  });
+
+  it('formats minutes only under an hour', () => {
+    expect(formatResetIn('2026-07-02T12:42:00.000Z', now)).toBe('42m');
+  });
+
+  it('formats whole hours without minutes', () => {
+    expect(formatResetIn('2026-07-02T14:00:00.000Z', now)).toBe('2h');
+  });
+
+  it('returns "now" for past timestamps', () => {
+    expect(formatResetIn('2026-07-02T11:00:00.000Z', now)).toBe('now');
+  });
+
+  it('degrades gracefully on missing or invalid input', () => {
+    expect(formatResetIn(null, now)).toBe('—');
+    expect(formatResetIn('not-a-date', now)).toBe('—');
+  });
+});
+
+describe('LIVE_ACTION_WINDOW_MS', () => {
+  it('is exactly five hours', () => {
+    expect(LIVE_ACTION_WINDOW_MS).toBe(5 * 60 * 60 * 1000);
+  });
+});

--- a/apps/web/tests/unit/links/useLinksPersistence.test.ts
+++ b/apps/web/tests/unit/links/useLinksPersistence.test.ts
@@ -37,6 +37,10 @@ vi.mock('@/lib/queries/keys', () => ({
       all: ['chat'],
       usage: () => ['chat', 'usage'],
     },
+    usage: {
+      all: ['usage'],
+      summary: () => ['usage', 'summary'],
+    },
     dashboard: {
       socialLinks: (id: string) => ['dashboard', 'social-links', id],
     },


### PR DESCRIPTION
## Summary

Subtle top-right usage pill + limits popover on the Opportunity Inbox home — a glanceable usage surface and upgrade entry point per Tim's Home Inbox comp.

Closes #11566

## What's here

- **`HeaderUsagePill`** — quiet pill in the shell header (home route only) showing the overall remaining percent (the tighter of the two quotas). Click opens a popover:
  - `Jovie Usage · <plan>`
  - `Suggestions — This week <%> left · Resets <day>`
  - `Live actions — 5-hr window <n>/<cap> · Resets in <time>`
  - `Learn more about limits` → `/app/settings/usage` (full page retained)
- **`GET /api/usage/summary`** — real data: counts from `suggested_actions` (suggestions created this UTC week; actions executed in the trailing 5-hr window) + plan from `getCurrentUserEntitlements()`. Fails soft: any DB/schema error degrades to a zero-count `_stale` snapshot instead of throwing (migration-drift-safe).
- **`lib/usage/limits.ts`** — per-plan display caps (single tunable place; doc-noted to migrate into the entitlement registry once enforcement lands — kept out of the registry now to avoid churning the exact-equality entitlements-matrix contract tests), week-window/percent helpers, shared payload type, client formatters.
- **`useUsageSummaryQuery`** — TanStack hook mirroring `useChatUsageQuery` (FREQUENT_BACKGROUND_CACHE, non-retryable FetchError handling), new `usage.summary` query key.

## Acceptance

- [x] Pill renders usage % top-right of home
- [x] Popover shows weekly + 5-hr limits + resets + Learn more
- [x] Values from real data (entitlements plan + `suggested_actions` counts)
- [x] No layout shift — loading state reserves the pill footprint; `tabular-nums` + fixed `min-w` so value updates never reflow

## Notes for review

- Display caps (free 15/wk · 5 per 5h, pro/trial 75 · 25, max 200 · 100) are initial values in one place — flag if you want different numbers.
- Pill is gated to the home route (`/app`) per the comp; widening it shell-wide is a one-line change.
- Existing `HeaderChatUsageIndicator` (chat-route message quota) is untouched.

## Tests

- `tests/unit/lib/usage-limits.test.ts` — week window (Mon UTC start, Sunday edge, Monday rollover), percent clamping, cap monotonicity across plans, reset-day/duration formatters.
- `tests/unit/dashboard/HeaderUsagePill.test.tsx` — pill renders %, loading placeholder reserves footprint, popover content rows + learn-more link, hidden on demo routes.

## Cost Impact

- **External API calls**: none. Two indexed DB counts per request on `/api/usage/summary` (uses `suggested_actions_user_status_created_idx`), client-cached via FREQUENT_BACKGROUND_CACHE + `Cache-Control: private, max-age=30`.
- **Scaling factor**: O(1) queries per pill load; no cron, no polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
