### PR TITLE
feat(feedback): chat 👍/👎 vote store + model attribution (server, 1/2)

### DIFF
--- a/apps/web/app/api/chat/feedback/route.ts
+++ b/apps/web/app/api/chat/feedback/route.ts
@@ -1,0 +1,147 @@
+/**
+ * In-chat 👍/👎 feedback capture (JOV #11460).
+ *
+ * POST /api/chat/feedback — records, updates, or removes a vote on an
+ * assistant message or tool/skill result. Rows land in the unified
+ * `feedback_items` store (see `lib/db/schema/feedback.ts`) so Eve can query
+ * them via SQL for the model A/B bake-off loop.
+ *
+ * Attribution: when the client supplies a `turnId`, the producing model is
+ * resolved server-side from `chat_turns.model` (server truth — survives
+ * reloads and cannot be spoofed). The client-provided `modelUsed` is only a
+ * fallback for turns persisted before the model column existed.
+ *
+ * Idempotency: one row per (user, message, tool call). Re-voting updates the
+ * row in place; `vote: null` removes it.
+ */
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema/auth';
+import { chatTurns } from '@/lib/db/schema/chat';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { captureError } from '@/lib/error-tracking';
+import { deleteChatMessageVote, upsertChatMessageVote } from '@/lib/feedback';
+import { parseJsonBody } from '@/lib/http/parse-json';
+import { createRateLimitHeaders, generalLimiter } from '@/lib/rate-limit';
+import { logger } from '@/lib/utils/logger';
+
+const payloadSchema = z.object({
+  messageId: z.string().trim().min(1).max(128),
+  /** 'up' | 'down' to vote, null to undo the current vote. */
+  vote: z.enum(['up', 'down']).nullable(),
+  conversationId: z.string().uuid().optional(),
+  turnId: z.string().uuid().optional(),
+  toolCallId: z.string().trim().max(128).optional(),
+  toolName: z.string().trim().max(120).optional(),
+  /** Client-side fallback only — server resolves from chat_turns when possible. */
+  modelUsed: z.string().trim().max(120).optional(),
+  messageExcerpt: z.string().trim().max(1000).optional(),
+});
+
+export const runtime = 'nodejs';
+
+/** Votes are tiny; excerpt alone capped at 1000 chars. */
+const MAX_BODY_SIZE = 8 * 1024;
+
+export async function POST(request: Request) {
+  try {
+    const { userId: clerkId } = await getCachedAuth();
+    if (!clerkId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const rateLimit = await generalLimiter.limit(clerkId);
+    if (!rateLimit.success) {
+      return NextResponse.json(
+        { error: 'Too many feedback submissions' },
+        { status: 429, headers: createRateLimitHeaders(rateLimit) }
+      );
+    }
+
+    const parsedBody = await parseJsonBody<unknown>(request, {
+      route: '/api/chat/feedback',
+      maxBodySize: MAX_BODY_SIZE,
+    });
+    if (!parsedBody.ok) {
+      return parsedBody.response;
+    }
+
+    const parsed = payloadSchema.safeParse(parsedBody.data);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+
+    const userRecord = await db.query.users.findFirst({
+      where: eq(users.clerkId, clerkId),
+      columns: { id: true },
+    });
+    if (!userRecord) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { messageId, vote, toolCallId, toolName, messageExcerpt } =
+      parsed.data;
+
+    if (vote === null) {
+      await deleteChatMessageVote({
+        userId: userRecord.id,
+        messageId,
+        toolCallId,
+      });
+      return NextResponse.json({ ok: true, vote: null });
+    }
+
+    // Server-truth model + conversation attribution via the persisted turn.
+    // Ownership is asserted — a turn belonging to another user is ignored
+    // rather than leaking its metadata.
+    let resolvedModel: string | null = null;
+    let resolvedConversationId: string | null = null;
+    let resolvedTurnId: string | null = null;
+    if (parsed.data.turnId) {
+      const turn = await db.query.chatTurns.findFirst({
+        where: eq(chatTurns.id, parsed.data.turnId),
+        columns: { id: true, userId: true, conversationId: true, model: true },
+      });
+      if (turn && turn.userId === userRecord.id) {
+        resolvedTurnId = turn.id;
+        resolvedConversationId = turn.conversationId;
+        resolvedModel = turn.model;
+      }
+    }
+
+    const entitlements = await getCurrentUserEntitlements();
+
+    const item = await upsertChatMessageVote({
+      userId: userRecord.id,
+      messageId,
+      vote,
+      conversationId: resolvedConversationId ?? parsed.data.conversationId,
+      turnId: resolvedTurnId,
+      toolCallId,
+      toolName,
+      modelUsed: resolvedModel ?? parsed.data.modelUsed ?? null,
+      plan: entitlements.plan,
+      messageExcerpt,
+      context: {
+        userAgent: request.headers.get('user-agent'),
+        timestampIso: new Date().toISOString(),
+        modelSource: resolvedModel ? 'turn' : 'client',
+      },
+    });
+
+    return NextResponse.json({ ok: true, id: item.id, vote });
+  } catch (error) {
+    logger.error('[api/chat/feedback] Failed to record vote:', error);
+    await captureError('Chat feedback vote failed', error, {
+      route: '/api/chat/feedback',
+      method: 'POST',
+    });
+    return NextResponse.json(
+      { error: 'Unable to record feedback' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -96,6 +96,7 @@ import {
   type ChatTurnSource,
   markChatTurnStreaming,
   persistTerminalAssistantMessage,
+  recordChatTurnModel,
   reserveChatTurn,
   TURN_IN_PROGRESS_ERROR_CODE,
 } from '@/lib/chat/turns';
@@ -600,11 +601,14 @@ function buildChatTurnMetadata(input: {
   readonly turnId: string;
   readonly requestId: string;
   readonly toolStepCapExhausted?: boolean;
+  /** Resolved model id that produced the turn (feedback attribution). */
+  readonly model?: string;
 }) {
   return {
     conversationId: input.conversationId,
     turnId: input.turnId,
     requestId: input.requestId,
+    ...(input.model ? { model: input.model } : {}),
     ...(input.toolStepCapExhausted
       ? { toolStepCapExhausted: true as const }
       : {}),
@@ -2808,6 +2812,25 @@ export async function POST(req: Request) {
       onStreamError: persistStreamFailure,
     });
 
+    // Record the producing model on the turn row (fire-and-forget) so 👍/👎
+    // feedback votes can attribute this output to a model server-side, even
+    // when the vote arrives after a page reload (JOV #11460).
+    if (reservedTurn) {
+      recordChatTurnModel(reservedTurn.turnId, turn.selectedModel).catch(
+        error => {
+          Sentry.addBreadcrumb({
+            category: 'ai-chat',
+            message: 'chat_turn_model_record_failed',
+            level: 'warning',
+            data: {
+              turnId: reservedTurn.turnId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          });
+        }
+      );
+    }
+
     return turn.streamResult.toUIMessageStreamResponse({
       headers: {
         ...corsHeaders,
@@ -2825,6 +2848,7 @@ export async function POST(req: Request) {
               conversationId: reservedTurn.conversationId,
               turnId: reservedTurn.turnId,
               requestId,
+              model: turn.selectedModel,
               toolStepCapExhausted: turn.turnSignals.toolStepCapExhausted,
             })
           : undefined,

--- a/apps/web/drizzle/migrations/0069_chat_message_feedback.sql
+++ b/apps/web/drizzle/migrations/0069_chat_message_feedback.sql
@@ -1,0 +1,58 @@
+-- JOV #11460: in-chat 👍/👎 feedback capture on every assistant message and
+-- tool/skill result. Extends the existing feedback_items store (no parallel
+-- table) and records the producing model on chat_turns for vote attribution.
+ALTER TABLE "chat_turns" ADD COLUMN IF NOT EXISTS "model" text;
+--> statement-breakpoint
+ALTER TABLE "feedback_items" ADD COLUMN IF NOT EXISTS "message_id" text;
+--> statement-breakpoint
+ALTER TABLE "feedback_items" ADD COLUMN IF NOT EXISTS "conversation_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "feedback_items" ADD COLUMN IF NOT EXISTS "turn_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "feedback_items" ADD COLUMN IF NOT EXISTS "tool_call_id" text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "feedback_items" ADD COLUMN IF NOT EXISTS "tool_name" text;
+--> statement-breakpoint
+ALTER TABLE "feedback_items" ADD COLUMN IF NOT EXISTS "model_used" text;
+--> statement-breakpoint
+ALTER TABLE "feedback_items" ADD COLUMN IF NOT EXISTS "plan" text;
+--> statement-breakpoint
+ALTER TABLE "feedback_items" ADD COLUMN IF NOT EXISTS "vote" text;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'feedback_items_conversation_id_chat_conversations_id_fk'
+  ) THEN
+    ALTER TABLE "feedback_items"
+      ADD CONSTRAINT "feedback_items_conversation_id_chat_conversations_id_fk"
+      FOREIGN KEY ("conversation_id") REFERENCES "public"."chat_conversations"("id")
+      ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'feedback_items_turn_id_chat_turns_id_fk'
+  ) THEN
+    ALTER TABLE "feedback_items"
+      ADD CONSTRAINT "feedback_items_turn_id_chat_turns_id_fk"
+      FOREIGN KEY ("turn_id") REFERENCES "public"."chat_turns"("id")
+      ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "feedback_items_vote_unique"
+  ON "feedback_items" ("user_id", "message_id", "tool_call_id")
+  WHERE "message_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "feedback_items_vote_model_idx"
+  ON "feedback_items" ("model_used", "vote")
+  WHERE "vote" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "feedback_items_conversation_idx"
+  ON "feedback_items" ("conversation_id")
+  WHERE "conversation_id" IS NOT NULL;

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -491,6 +491,13 @@
       "when": 1783000000000,
       "tag": "0068_public_profile_capture_dismissals",
       "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1783000050000,
+      "tag": "0069_chat_message_feedback",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/chat/turns.ts
+++ b/apps/web/lib/chat/turns.ts
@@ -252,6 +252,22 @@ export async function reserveChatTurn(input: {
   };
 }
 
+/**
+ * Records the resolved model id (`anthropic/...`) that is producing this
+ * turn's assistant output. Fire-and-forget from the chat route right after
+ * model selection so 👍/👎 feedback rows can attribute votes to the
+ * producing model even when the stream later fails (JOV #11460).
+ */
+export async function recordChatTurnModel(
+  turnId: string,
+  model: string
+): Promise<void> {
+  await db
+    .update(chatTurns)
+    .set({ model, updatedAt: new Date() })
+    .where(eq(chatTurns.id, turnId));
+}
+
 export async function markChatTurnStreaming(turnId: string): Promise<void> {
   const now = new Date();
   await db

--- a/apps/web/lib/db/schema/chat.ts
+++ b/apps/web/lib/db/schema/chat.ts
@@ -91,6 +91,13 @@ export const chatTurns = pgTable(
     clientTurnId: text('client_turn_id').notNull(),
     status: chatTurnStatusEnum('status').notNull().default('reserved'),
     source: text('source').notNull().default('typed'),
+    /**
+     * Resolved model id (`anthropic/...`) that produced this turn's
+     * assistant output. Recorded when the turn starts streaming so 👍/👎
+     * feedback rows can attribute votes to the producing model (JOV #11460,
+     * feeds the per-workflow model A/B bake-off). Null on pre-feature turns.
+     */
+    model: text('model'),
     toolIntent: text('tool_intent'),
     errorCode: text('error_code'),
     errorMessage: text('error_message'),

--- a/apps/web/lib/db/schema/feedback.ts
+++ b/apps/web/lib/db/schema/feedback.ts
@@ -1,16 +1,50 @@
+import { sql as drizzleSql } from 'drizzle-orm';
 import {
   index,
   jsonb,
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { users } from './auth';
+import { chatConversations, chatTurns } from './chat';
 
 export const feedbackStatusEnumValues = ['pending', 'dismissed'] as const;
 
+/**
+ * Vote values for in-chat 👍/👎 feedback rows (JOV #11460).
+ * Rows without a vote are classic free-text feedback submissions.
+ */
+export const feedbackVoteEnumValues = ['up', 'down'] as const;
+
+export type FeedbackVote = (typeof feedbackVoteEnumValues)[number];
+
+/**
+ * Unified in-app feedback store.
+ *
+ * Two row shapes share this table (extended per JOV #11460 — do NOT create
+ * a parallel table):
+ *
+ * 1. Classic free-text feedback (`message_id IS NULL`): dashboard/chat
+ *    feedback form submissions. `message` holds the user's text.
+ * 2. Chat thumbs votes (`message_id IS NOT NULL`): one row per
+ *    (user, chat message, tool call) with `vote` set to 'up'/'down'.
+ *    Votes are idempotent — re-voting updates the row in place
+ *    (see `feedback_items_vote_unique`), and undoing a vote deletes it.
+ *
+ * Vote rows are Eve-readable via plain SQL, e.g.:
+ *
+ *   SELECT model_used, vote, COUNT(*)
+ *   FROM feedback_items
+ *   WHERE vote IS NOT NULL
+ *   GROUP BY 1, 2;
+ *
+ * `model_used` is required for the model A/B bake-off loop — it is resolved
+ * server-side from `chat_turns.model` whenever a turn id is provided.
+ */
 export const feedbackItems = pgTable(
   'feedback_items',
   {
@@ -27,6 +61,31 @@ export const feedbackItems = pgTable(
       .$type<Record<string, unknown>>()
       .notNull()
       .default({}),
+    /** Chat message id the vote refers to (client/timeline message id). */
+    messageId: text('message_id'),
+    /** Conversation containing the voted message. */
+    conversationId: uuid('conversation_id').references(
+      () => chatConversations.id,
+      { onDelete: 'set null' }
+    ),
+    /** Persisted chat turn — server-truth join key for model attribution. */
+    turnId: uuid('turn_id').references(() => chatTurns.id, {
+      onDelete: 'set null',
+    }),
+    /**
+     * Tool call the vote targets. Empty string = message-level vote.
+     * NOT NULL so the idempotency unique index binds without NULL escape
+     * hatches (Postgres treats NULLs as distinct in unique indexes).
+     */
+    toolCallId: text('tool_call_id').notNull().default(''),
+    /** Tool/skill name that produced the voted output (tool votes only). */
+    toolName: text('tool_name'),
+    /** Model id that produced the voted output. Required for A/B bake-offs. */
+    modelUsed: text('model_used'),
+    /** The voter's plan at vote time (free/pro/...). */
+    plan: text('plan'),
+    /** 👍 = 'up', 👎 = 'down'. Null on classic feedback rows. */
+    vote: text('vote', { enum: feedbackVoteEnumValues }),
     dismissedAt: timestamp('dismissed_at'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
@@ -37,6 +96,20 @@ export const feedbackItems = pgTable(
       table.createdAt
     ),
     userIdx: index('feedback_items_user_idx').on(table.userId),
+    /**
+     * Idempotent votes: one row per (user, message, tool call). Partial on
+     * message_id so classic free-text feedback rows are unaffected.
+     */
+    voteUniqueIdx: uniqueIndex('feedback_items_vote_unique')
+      .on(table.userId, table.messageId, table.toolCallId)
+      .where(drizzleSql`${table.messageId} IS NOT NULL`),
+    /** Eve's bake-off query path: votes grouped by model. */
+    voteModelIdx: index('feedback_items_vote_model_idx')
+      .on(table.modelUsed, table.vote)
+      .where(drizzleSql`${table.vote} IS NOT NULL`),
+    conversationIdx: index('feedback_items_conversation_idx')
+      .on(table.conversationId)
+      .where(drizzleSql`${table.conversationId} IS NOT NULL`),
   })
 );
 

--- a/apps/web/lib/db/schema/index.ts
+++ b/apps/web/lib/db/schema/index.ts
@@ -432,8 +432,10 @@ export {
 // Feedback
 export {
   type FeedbackItem,
+  type FeedbackVote,
   feedbackItems,
   feedbackStatusEnumValues,
+  feedbackVoteEnumValues,
   insertFeedbackItemSchema,
   type NewFeedbackItem,
   selectFeedbackItemSchema,

--- a/apps/web/lib/feedback.ts
+++ b/apps/web/lib/feedback.ts
@@ -2,7 +2,7 @@ import { and, desc, sql as drizzleSql, eq } from 'drizzle-orm';
 
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema/auth';
-import { feedbackItems } from '@/lib/db/schema/feedback';
+import { type FeedbackVote, feedbackItems } from '@/lib/db/schema/feedback';
 
 export type FeedbackContext = Record<string, unknown> & {
   pathname: string | null;
@@ -156,4 +156,99 @@ export async function getFeedbackCounts() {
     console.error('[feedback] getFeedbackCounts failed:', error);
     return EMPTY_FEEDBACK_COUNTS;
   }
+}
+
+export interface ChatMessageVoteInput {
+  readonly userId: string;
+  readonly messageId: string;
+  readonly vote: FeedbackVote;
+  readonly conversationId?: string | null;
+  readonly turnId?: string | null;
+  readonly toolCallId?: string | null;
+  readonly toolName?: string | null;
+  readonly modelUsed?: string | null;
+  readonly plan?: string | null;
+  readonly messageExcerpt?: string | null;
+  readonly context?: Record<string, unknown>;
+}
+
+/**
+ * Idempotent 👍/👎 vote upsert for a chat message or tool result
+ * (JOV #11460). One row per (user, message, tool call) — re-voting updates
+ * the existing row in place via the `feedback_items_vote_unique` index.
+ */
+export async function upsertChatMessageVote(
+  input: ChatMessageVoteInput
+): Promise<{ id: string }> {
+  const now = new Date();
+  const toolCallId = input.toolCallId ?? '';
+  const message =
+    input.messageExcerpt?.trim() ||
+    `Chat ${toolCallId ? 'tool result' : 'message'} vote`;
+
+  const [item] = await db
+    .insert(feedbackItems)
+    .values({
+      userId: input.userId,
+      message,
+      source: 'chat_thumbs',
+      status: 'pending',
+      context: input.context ?? {},
+      messageId: input.messageId,
+      conversationId: input.conversationId ?? null,
+      turnId: input.turnId ?? null,
+      toolCallId,
+      toolName: input.toolName ?? null,
+      modelUsed: input.modelUsed ?? null,
+      plan: input.plan ?? null,
+      vote: input.vote,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        feedbackItems.userId,
+        feedbackItems.messageId,
+        feedbackItems.toolCallId,
+      ],
+      targetWhere: drizzleSql`${feedbackItems.messageId} IS NOT NULL`,
+      set: {
+        vote: input.vote,
+        message,
+        context: input.context ?? {},
+        conversationId: input.conversationId ?? null,
+        turnId: input.turnId ?? null,
+        toolName: input.toolName ?? null,
+        modelUsed: input.modelUsed ?? null,
+        plan: input.plan ?? null,
+        updatedAt: now,
+      },
+    })
+    .returning({ id: feedbackItems.id });
+
+  if (!item) {
+    throw new Error('Chat vote persistence returned no row');
+  }
+
+  return item;
+}
+
+/**
+ * Removes a previously recorded vote (the user un-voted). Idempotent —
+ * deleting a vote that does not exist is a no-op.
+ */
+export async function deleteChatMessageVote(input: {
+  readonly userId: string;
+  readonly messageId: string;
+  readonly toolCallId?: string | null;
+}): Promise<void> {
+  await db
+    .delete(feedbackItems)
+    .where(
+      and(
+        eq(feedbackItems.userId, input.userId),
+        eq(feedbackItems.messageId, input.messageId),
+        eq(feedbackItems.toolCallId, input.toolCallId ?? '')
+      )
+    );
 }

--- a/apps/web/tests/unit/api/chat/feedback-route.test.ts
+++ b/apps/web/tests/unit/api/chat/feedback-route.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---- hoisted mocks ----
+const mockGetCachedAuth = vi.hoisted(() => vi.fn());
+const mockUsersFindFirst = vi.hoisted(() => vi.fn());
+const mockChatTurnsFindFirst = vi.hoisted(() => vi.fn());
+const mockGetCurrentUserEntitlements = vi.hoisted(() => vi.fn());
+const mockUpsertChatMessageVote = vi.hoisted(() => vi.fn());
+const mockDeleteChatMessageVote = vi.hoisted(() => vi.fn());
+const mockCaptureError = vi.hoisted(() => vi.fn());
+const mockLimit = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ success: true })
+);
+
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: mockGetCachedAuth,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    query: {
+      users: { findFirst: mockUsersFindFirst },
+      chatTurns: { findFirst: mockChatTurnsFindFirst },
+    },
+  },
+}));
+
+vi.mock('@/lib/entitlements/server', () => ({
+  getCurrentUserEntitlements: mockGetCurrentUserEntitlements,
+}));
+
+vi.mock('@/lib/feedback', () => ({
+  upsertChatMessageVote: mockUpsertChatMessageVote,
+  deleteChatMessageVote: mockDeleteChatMessageVote,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mockCaptureError,
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  generalLimiter: { limit: mockLimit },
+  createRateLimitHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock('@/lib/http/parse-json', () => ({
+  parseJsonBody: vi.fn(async (request: Request) => {
+    const body = await request.json();
+    return { ok: true, data: body };
+  }),
+}));
+
+import { POST } from '@/app/api/chat/feedback/route';
+
+const TURN_ID = '123e4567-e89b-42d3-a456-426614174000';
+const CONVERSATION_ID = '123e4567-e89b-42d3-a456-426614174001';
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/chat/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/chat/feedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLimit.mockResolvedValue({ success: true });
+    mockGetCachedAuth.mockResolvedValue({ userId: 'clerk_123' });
+    mockUsersFindFirst.mockResolvedValue({ id: 'user-uuid-1' });
+    mockGetCurrentUserEntitlements.mockResolvedValue({ plan: 'pro' });
+    mockUpsertChatMessageVote.mockResolvedValue({ id: 'feedback-1' });
+    mockDeleteChatMessageVote.mockResolvedValue(undefined);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mockGetCachedAuth.mockResolvedValue({ userId: null });
+
+    const response = await POST(makeRequest({ messageId: 'm1', vote: 'up' }));
+
+    expect(response.status).toBe(401);
+    expect(mockUpsertChatMessageVote).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid payloads', async () => {
+    const response = await POST(
+      makeRequest({ messageId: '', vote: 'sideways' })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockUpsertChatMessageVote).not.toHaveBeenCalled();
+  });
+
+  it('persists a vote with server-resolved model from the owned turn', async () => {
+    mockChatTurnsFindFirst.mockResolvedValue({
+      id: TURN_ID,
+      userId: 'user-uuid-1',
+      conversationId: CONVERSATION_ID,
+      model: 'anthropic/claude-sonnet-4.5',
+    });
+
+    const response = await POST(
+      makeRequest({
+        messageId: 'm1',
+        vote: 'up',
+        turnId: TURN_ID,
+        toolCallId: 'call-1',
+        toolName: 'createMerch',
+        modelUsed: 'client-spoofed-model',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpsertChatMessageVote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-uuid-1',
+        messageId: 'm1',
+        vote: 'up',
+        turnId: TURN_ID,
+        conversationId: CONVERSATION_ID,
+        toolCallId: 'call-1',
+        toolName: 'createMerch',
+        modelUsed: 'anthropic/claude-sonnet-4.5',
+        plan: 'pro',
+      })
+    );
+  });
+
+  it('ignores a turn belonging to another user', async () => {
+    mockChatTurnsFindFirst.mockResolvedValue({
+      id: TURN_ID,
+      userId: 'someone-else',
+      conversationId: CONVERSATION_ID,
+      model: 'anthropic/claude-sonnet-4.5',
+    });
+
+    const response = await POST(
+      makeRequest({
+        messageId: 'm1',
+        vote: 'down',
+        turnId: TURN_ID,
+        modelUsed: 'client-fallback-model',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpsertChatMessageVote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        turnId: null,
+        modelUsed: 'client-fallback-model',
+      })
+    );
+  });
+
+  it('deletes the vote when vote is null (undo)', async () => {
+    const response = await POST(
+      makeRequest({ messageId: 'm1', vote: null, toolCallId: 'call-1' })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteChatMessageVote).toHaveBeenCalledWith({
+      userId: 'user-uuid-1',
+      messageId: 'm1',
+      toolCallId: 'call-1',
+    });
+    expect(mockUpsertChatMessageVote).not.toHaveBeenCalled();
+  });
+
+  it('rate limits before persisting', async () => {
+    mockLimit.mockResolvedValue({ success: false });
+
+    const response = await POST(makeRequest({ messageId: 'm1', vote: 'up' }));
+
+    expect(response.status).toBe(429);
+    expect(mockUpsertChatMessageVote).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Part **1/2** of #11460 — server-side store + API for in-chat 👍/👎 feedback capture. (Part 2/2, the UI wiring, is the sibling PR `agent/jov-11460-chat-feedback-ui`; land this one first.)

- **Extends the existing `feedback_items` store** (no parallel table) with vote columns: `message_id`, `conversation_id`, `turn_id`, `tool_call_id`, `tool_name`, `model_used`, `plan`, `vote`.
- **Idempotent votes**: partial unique index on `(user_id, message_id, tool_call_id) WHERE message_id IS NOT NULL` — re-voting upserts in place, `vote: null` deletes (undo). Classic free-text feedback rows are untouched.
- **`model_used` is server-truth**: new `chat_turns.model` column is recorded right after model selection in the chat route; `POST /api/chat/feedback` resolves the model from the (ownership-checked) turn, falling back to the client value only for pre-feature turns. This is the attribution the model A/B bake-off framework (JOV-3363) depends on.
- **Eve-queryable via SQL**, e.g.:
  ```sql
  SELECT model_used, vote, COUNT(*) FROM feedback_items
  WHERE vote IS NOT NULL GROUP BY 1, 2;
  ```
- New migration `0069_chat_message_feedback.sql` (additive only, `IF NOT EXISTS` guards) + journal entry.
- `buildChatTurnMetadata` now carries `model` so the client can attribute fresh streams too.

## Testing

- `apps/web/tests/unit/api/chat/feedback-route.test.ts`: auth gate, payload validation, server-resolved model from owned turn, foreign-turn ownership rejection, undo-delete path, rate limiting.
- Biome 2.5.1 clean on all touched files.

## Cost Impact

- No new cron/polling/external APIs. One extra indexed DB read (turn lookup) + one upsert per explicit user vote; one fire-and-forget `UPDATE chat_turns` per chat turn.

bug-to-test: n/a — feature PR with new unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
