### PR TITLE
feat(feedback): 👍/👎 controls on every chat message + tool result (UI, 2/2)

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -615,6 +615,7 @@ export function JovieChat({
                 inlineChatError={inlineChatError}
                 isStuckToBottom={isStuckToBottom}
                 onScrollToBottom={() => scrollToBottom()}
+                conversationId={activeConversationId ?? conversationId}
               />
             )}
           </div>

--- a/apps/web/components/jovie/JovieChatSections.tsx
+++ b/apps/web/components/jovie/JovieChatSections.tsx
@@ -151,6 +151,8 @@ interface ChatThreadMessage {
   readonly status?: string;
   readonly parts: MessagePart[];
   readonly toolStepCapExhausted?: boolean;
+  /** Persisted chat turn id — enables 👍/👎 model attribution (JOV #11460). */
+  readonly turnId?: string;
 }
 
 interface ChatThreadMessagesProps {
@@ -170,6 +172,8 @@ interface ChatThreadMessagesProps {
   readonly inlineChatError: ReactNode;
   readonly isStuckToBottom: boolean;
   readonly onScrollToBottom: () => void;
+  /** Conversation id for 👍/👎 feedback attribution. */
+  readonly conversationId?: string | null;
 }
 
 export function ChatThreadMessages({
@@ -189,6 +193,7 @@ export function ChatThreadMessages({
   inlineChatError,
   isStuckToBottom,
   onScrollToBottom,
+  conversationId,
 }: ChatThreadMessagesProps) {
   return (
     <div>
@@ -231,6 +236,9 @@ export function ChatThreadMessages({
                     profileId={profileId}
                     skipEntrance={knownMessageIds.has(message.id)}
                     toolStepCapExhausted={message.toolStepCapExhausted}
+                    turnId={message.turnId}
+                    conversationId={conversationId ?? undefined}
+                    enableFeedback
                   />
                 </div>
               </div>
@@ -260,6 +268,9 @@ export function ChatThreadMessages({
                   profileId={profileId}
                   skipEntrance={knownMessageIds.has(message.id)}
                   toolStepCapExhausted={message.toolStepCapExhausted}
+                  turnId={message.turnId}
+                  conversationId={conversationId ?? undefined}
+                  enableFeedback
                 />
               </div>
             );

--- a/apps/web/components/jovie/components/ChatFeedbackControl.test.tsx
+++ b/apps/web/components/jovie/components/ChatFeedbackControl.test.tsx
@@ -1,3 +1,4 @@
+import { TooltipProvider } from '@jovie/ui';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatFeedbackControl } from './ChatFeedbackControl';
@@ -12,6 +13,10 @@ function mockFetchOk() {
   return fetchMock;
 }
 
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
 describe('ChatFeedbackControl', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
@@ -23,7 +28,7 @@ describe('ChatFeedbackControl', () => {
   });
 
   it('renders thumbs up and thumbs down controls', () => {
-    render(<ChatFeedbackControl messageId='msg-1' />);
+    renderWithProvider(<ChatFeedbackControl messageId='msg-1' />);
 
     expect(screen.getByTestId('chat-feedback-control')).toBeInTheDocument();
     expect(
@@ -37,7 +42,7 @@ describe('ChatFeedbackControl', () => {
   it('posts an up vote with full attribution payload', async () => {
     const fetchMock = mockFetchOk();
 
-    render(
+    renderWithProvider(
       <ChatFeedbackControl
         messageId='msg-1'
         turnId='123e4567-e89b-42d3-a456-426614174000'
@@ -72,7 +77,7 @@ describe('ChatFeedbackControl', () => {
   it('undoes the vote when the active vote is clicked again', async () => {
     const fetchMock = mockFetchOk();
 
-    render(<ChatFeedbackControl messageId='msg-2' />);
+    renderWithProvider(<ChatFeedbackControl messageId='msg-2' />);
 
     const downButton = screen.getByRole('button', { name: 'Bad response' });
     fireEvent.click(downButton);
@@ -93,7 +98,7 @@ describe('ChatFeedbackControl', () => {
   it('switches the vote when the other thumb is clicked', async () => {
     const fetchMock = mockFetchOk();
 
-    render(<ChatFeedbackControl messageId='msg-3' />);
+    renderWithProvider(<ChatFeedbackControl messageId='msg-3' />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Good response' }));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
@@ -114,7 +119,7 @@ describe('ChatFeedbackControl', () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: false });
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<ChatFeedbackControl messageId='msg-4' />);
+    renderWithProvider(<ChatFeedbackControl messageId='msg-4' />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Good response' }));
 

--- a/apps/web/components/jovie/components/ChatFeedbackControl.test.tsx
+++ b/apps/web/components/jovie/components/ChatFeedbackControl.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatFeedbackControl } from './ChatFeedbackControl';
+
+vi.mock('@/lib/sentry/client-lite', () => ({
+  addBreadcrumb: vi.fn(),
+}));
+
+function mockFetchOk() {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('ChatFeedbackControl', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('renders thumbs up and thumbs down controls', () => {
+    render(<ChatFeedbackControl messageId='msg-1' />);
+
+    expect(screen.getByTestId('chat-feedback-control')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Good response' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Bad response' })
+    ).toBeInTheDocument();
+  });
+
+  it('posts an up vote with full attribution payload', async () => {
+    const fetchMock = mockFetchOk();
+
+    render(
+      <ChatFeedbackControl
+        messageId='msg-1'
+        turnId='123e4567-e89b-42d3-a456-426614174000'
+        conversationId='123e4567-e89b-42d3-a456-426614174001'
+        toolCallId='call-9'
+        toolName='createMerch'
+        excerpt='Generated a band tee'
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Good response' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/chat/feedback');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      messageId: 'msg-1',
+      vote: 'up',
+      turnId: '123e4567-e89b-42d3-a456-426614174000',
+      conversationId: '123e4567-e89b-42d3-a456-426614174001',
+      toolCallId: 'call-9',
+      toolName: 'createMerch',
+      messageExcerpt: 'Generated a band tee',
+    });
+
+    expect(screen.getByTestId('chat-feedback-control')).toHaveAttribute(
+      'data-vote',
+      'up'
+    );
+  });
+
+  it('undoes the vote when the active vote is clicked again', async () => {
+    const fetchMock = mockFetchOk();
+
+    render(<ChatFeedbackControl messageId='msg-2' />);
+
+    const downButton = screen.getByRole('button', { name: 'Bad response' });
+    fireEvent.click(downButton);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(downButton);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const secondBody = JSON.parse(
+      (fetchMock.mock.calls[1][1] as RequestInit).body as string
+    );
+    expect(secondBody.vote).toBeNull();
+    expect(screen.getByTestId('chat-feedback-control')).not.toHaveAttribute(
+      'data-vote'
+    );
+  });
+
+  it('switches the vote when the other thumb is clicked', async () => {
+    const fetchMock = mockFetchOk();
+
+    render(<ChatFeedbackControl messageId='msg-3' />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Good response' }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: 'Bad response' }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const secondBody = JSON.parse(
+      (fetchMock.mock.calls[1][1] as RequestInit).body as string
+    );
+    expect(secondBody.vote).toBe('down');
+    expect(screen.getByTestId('chat-feedback-control')).toHaveAttribute(
+      'data-vote',
+      'down'
+    );
+  });
+
+  it('rolls the vote back when the request fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ChatFeedbackControl messageId='msg-4' />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Good response' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-feedback-control')).not.toHaveAttribute(
+        'data-vote'
+      )
+    );
+  });
+});

--- a/apps/web/components/jovie/components/ChatFeedbackControl.tsx
+++ b/apps/web/components/jovie/components/ChatFeedbackControl.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { Button, SimpleTooltip } from '@jovie/ui';
+import { ThumbsDown, ThumbsUp } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+import { addBreadcrumb } from '@/lib/sentry/client-lite';
+import { cn } from '@/lib/utils';
+
+type FeedbackVote = 'up' | 'down';
+
+export interface ChatFeedbackTarget {
+  /** Chat message id (timeline/client id) the vote refers to. */
+  readonly messageId: string;
+  /** Persisted chat turn id — lets the server attribute the producing model. */
+  readonly turnId?: string;
+  readonly conversationId?: string;
+  /** Tool call id when the vote targets a tool/skill result. */
+  readonly toolCallId?: string;
+  /** Tool/skill name when the vote targets a tool/skill result. */
+  readonly toolName?: string;
+  /** Client-side model fallback (server resolves from the turn when it can). */
+  readonly modelUsed?: string;
+  /** Short excerpt of the voted content — makes rows self-describing for Eve. */
+  readonly excerpt?: string;
+}
+
+interface ChatFeedbackControlProps extends ChatFeedbackTarget {
+  readonly className?: string;
+}
+
+const EXCERPT_MAX_LENGTH = 500;
+
+async function postVote(
+  target: ChatFeedbackTarget,
+  vote: FeedbackVote | null
+): Promise<boolean> {
+  try {
+    const response = await fetch('/api/chat/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      keepalive: true,
+      body: JSON.stringify({
+        messageId: target.messageId,
+        vote,
+        ...(target.turnId ? { turnId: target.turnId } : {}),
+        ...(target.conversationId
+          ? { conversationId: target.conversationId }
+          : {}),
+        ...(target.toolCallId ? { toolCallId: target.toolCallId } : {}),
+        ...(target.toolName ? { toolName: target.toolName } : {}),
+        ...(target.modelUsed ? { modelUsed: target.modelUsed } : {}),
+        ...(target.excerpt
+          ? { messageExcerpt: target.excerpt.slice(0, EXCERPT_MAX_LENGTH) }
+          : {}),
+      }),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 👍/👎 feedback control rendered beside every assistant message and every
+ * tool/skill result in chat (JOV #11460). Votes persist to the in-app
+ * feedback store with model attribution so the per-workflow A/B bake-off
+ * can score models by real user signal.
+ *
+ * Optimistic + idempotent: clicking a vote applies instantly, clicking the
+ * same vote again undoes it, and a failed request rolls the UI back.
+ */
+export function ChatFeedbackControl({
+  className,
+  ...target
+}: ChatFeedbackControlProps) {
+  const [vote, setVote] = useState<FeedbackVote | null>(null);
+  const inFlightRef = useRef(false);
+
+  const handleVote = useCallback(
+    (nextVote: FeedbackVote) => {
+      if (inFlightRef.current) return;
+      const previousVote = vote;
+      // Clicking the active vote undoes it.
+      const resolvedVote = previousVote === nextVote ? null : nextVote;
+      setVote(resolvedVote);
+      inFlightRef.current = true;
+      void postVote(target, resolvedVote).then(ok => {
+        inFlightRef.current = false;
+        if (!ok) {
+          setVote(previousVote);
+          addBreadcrumb({
+            category: 'ai-chat',
+            message: 'chat_feedback_vote_failed',
+            level: 'warning',
+            data: {
+              messageId: target.messageId,
+              toolCallId: target.toolCallId,
+            },
+          });
+        }
+      });
+    },
+    [target, vote]
+  );
+
+  return (
+    <div
+      data-testid='chat-feedback-control'
+      data-message-id={target.messageId}
+      data-tool-call-id={target.toolCallId || undefined}
+      data-vote={vote ?? undefined}
+      className={cn('flex items-center', className)}
+    >
+      <SimpleTooltip
+        content={vote === 'up' ? 'Remove rating' : 'Good response'}
+      >
+        <Button
+          type='button'
+          variant='ghost'
+          size='icon'
+          onClick={() => handleVote('up')}
+          className='h-7 w-7 shadow-none'
+          aria-label='Good response'
+          aria-pressed={vote === 'up'}
+          data-testid='chat-feedback-thumbs-up'
+        >
+          <ThumbsUp
+            className={cn(
+              'h-3.5 w-3.5',
+              vote === 'up' ? 'text-accent-blue' : 'text-secondary-token'
+            )}
+            {...(vote === 'up' ? { fill: 'currentColor' } : {})}
+          />
+        </Button>
+      </SimpleTooltip>
+      <SimpleTooltip
+        content={vote === 'down' ? 'Remove rating' : 'Bad response'}
+      >
+        <Button
+          type='button'
+          variant='ghost'
+          size='icon'
+          onClick={() => handleVote('down')}
+          className='h-7 w-7 shadow-none'
+          aria-label='Bad response'
+          aria-pressed={vote === 'down'}
+          data-testid='chat-feedback-thumbs-down'
+        >
+          <ThumbsDown
+            className={cn(
+              'h-3.5 w-3.5',
+              vote === 'down' ? 'text-accent-blue' : 'text-secondary-token'
+            )}
+            {...(vote === 'down' ? { fill: 'currentColor' } : {})}
+          />
+        </Button>
+      </SimpleTooltip>
+    </div>
+  );
+}

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -32,7 +32,7 @@ interface ChatMessageProps {
   readonly skipEntrance?: boolean;
   /** Show the inline continue affordance after a tool-step cap stop. */
   readonly toolStepCapExhausted?: boolean;
-  /** Persisted chat turn id — enables 👍/👎 model attribution (JOV #11460). */
+  /** Persisted chat turn id — enables model attribution for feedback votes. */
   readonly turnId?: string;
   /** Conversation id for feedback rows. */
   readonly conversationId?: string;

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -11,6 +11,7 @@ import { getRenderableToolEvents, ToolPartsRenderer } from '../tool-ui';
 import type { MessagePart } from '../types';
 import { getMessageText } from '../utils';
 import { AssistantMessageText } from './AssistantMessageText';
+import { ChatFeedbackControl } from './ChatFeedbackControl';
 import { ChatStepLimitAffordance } from './ChatStepLimitAffordance';
 import { ImageAttachmentChip } from './ImageAttachmentChip';
 import { TokenizedText } from './TokenizedText';
@@ -31,6 +32,16 @@ interface ChatMessageProps {
   readonly skipEntrance?: boolean;
   /** Show the inline continue affordance after a tool-step cap stop. */
   readonly toolStepCapExhausted?: boolean;
+  /** Persisted chat turn id — enables 👍/👎 model attribution (JOV #11460). */
+  readonly turnId?: string;
+  /** Conversation id for feedback rows. */
+  readonly conversationId?: string;
+  /**
+   * Render 👍/👎 feedback controls on assistant messages and tool results.
+   * Enabled on the authenticated app chat surface; off for onboarding and
+   * other anonymous embeds where votes cannot be attributed to a user.
+   */
+  readonly enableFeedback?: boolean;
   /**
    * Render generic app tool cards/status rows. Callers with surface-specific
    * tool cards can opt out and render their own tool UI beside the message.
@@ -52,7 +63,10 @@ function areChatMessagePropsEqual(
     previous.profileId === next.profileId &&
     previous.skipEntrance === next.skipEntrance &&
     previous.renderTools === next.renderTools &&
-    previous.toolStepCapExhausted === next.toolStepCapExhausted
+    previous.toolStepCapExhausted === next.toolStepCapExhausted &&
+    previous.turnId === next.turnId &&
+    previous.conversationId === next.conversationId &&
+    previous.enableFeedback === next.enableFeedback
   );
 }
 
@@ -66,6 +80,9 @@ export const ChatMessage = memo(function ChatMessage({
   skipEntrance,
   renderTools = true,
   toolStepCapExhausted = false,
+  turnId,
+  conversationId,
+  enableFeedback = false,
 }: ChatMessageProps) {
   const isUser = role === 'user';
   const { copy, isSuccess: fallbackCopySuccess } = useClipboard();
@@ -218,6 +235,11 @@ export const ChatMessage = memo(function ChatMessage({
                   profileId={profileId}
                   variant='chat'
                   hasMessageText={Boolean(messageText)}
+                  feedback={
+                    enableFeedback && !isStreaming
+                      ? { messageId: id, turnId, conversationId }
+                      : undefined
+                  }
                 />
               ) : null}
 
@@ -236,26 +258,36 @@ export const ChatMessage = memo(function ChatMessage({
               style={isStreaming ? { pointerEvents: 'none' } : undefined}
             >
               {!isStreaming ? (
-                <SimpleTooltip
-                  content={isCopySuccess ? 'Copied!' : 'Copy response'}
-                >
-                  <Button
-                    type='button'
-                    variant='ghost'
-                    size='icon'
-                    onClick={handleCopyMessage}
-                    className='h-7 w-7 shadow-none'
-                    aria-label={
-                      isCopySuccess ? 'Copied to clipboard' : 'Copy message'
-                    }
+                <>
+                  <SimpleTooltip
+                    content={isCopySuccess ? 'Copied!' : 'Copy response'}
                   >
-                    {isCopySuccess ? (
-                      <Check className='system-b-chat-copy-icon' />
-                    ) : (
-                      <Copy className='system-b-chat-copy-icon' />
-                    )}
-                  </Button>
-                </SimpleTooltip>
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='icon'
+                      onClick={handleCopyMessage}
+                      className='h-7 w-7 shadow-none'
+                      aria-label={
+                        isCopySuccess ? 'Copied to clipboard' : 'Copy message'
+                      }
+                    >
+                      {isCopySuccess ? (
+                        <Check className='system-b-chat-copy-icon' />
+                      ) : (
+                        <Copy className='system-b-chat-copy-icon' />
+                      )}
+                    </Button>
+                  </SimpleTooltip>
+                  {enableFeedback ? (
+                    <ChatFeedbackControl
+                      messageId={id}
+                      turnId={turnId}
+                      conversationId={conversationId}
+                      excerpt={messageText}
+                    />
+                  ) : null}
+                </>
               ) : null}
             </div>
           ) : null}

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -21,6 +21,7 @@ import { ChatAlbumArtCard } from './components/ChatAlbumArtCard';
 import { ChatAnalyticsCard } from './components/ChatAnalyticsCard';
 import { ChatArtifactErrorCard } from './components/ChatArtifactErrorCard';
 import { ChatAvatarUploadCard } from './components/ChatAvatarUploadCard';
+import { ChatFeedbackControl } from './components/ChatFeedbackControl';
 import { ChatLinkConfirmationCard } from './components/ChatLinkConfirmationCard';
 import { ChatLinkRemovalCard } from './components/ChatLinkRemovalCard';
 import { ChatMerchActionCard } from './components/ChatMerchActionCard';
@@ -46,11 +47,52 @@ import { isChatAlbumArtToolResult } from './types';
 
 type ToolRendererVariant = 'chat' | 'inline';
 
+/**
+ * Feedback context for 👍/👎 votes on tool/skill results (JOV #11460).
+ * Provided by the authenticated chat surface; absent = controls hidden.
+ */
+export interface ChatToolFeedbackContext {
+  readonly messageId: string;
+  readonly turnId?: string;
+  readonly conversationId?: string;
+}
+
 interface ToolPartsRendererProps {
   readonly parts: readonly MessagePart[];
   readonly profileId?: string;
   readonly variant: ToolRendererVariant;
   readonly hasMessageText?: boolean;
+  readonly feedback?: ChatToolFeedbackContext;
+}
+
+/** Tool states that accept feedback (in-flight work is not votable). */
+const FEEDBACK_ELIGIBLE_STATES: ReadonlySet<PersistedToolEvent['state']> =
+  new Set(['succeeded', 'failed']);
+
+function ToolEventFeedback({
+  event,
+  feedback,
+  className,
+}: Readonly<{
+  event: PersistedToolEvent;
+  feedback: ChatToolFeedbackContext | undefined;
+  className?: string;
+}>) {
+  if (!feedback || !FEEDBACK_ELIGIBLE_STATES.has(event.state)) {
+    return null;
+  }
+
+  return (
+    <ChatFeedbackControl
+      messageId={feedback.messageId}
+      turnId={feedback.turnId}
+      conversationId={feedback.conversationId}
+      toolCallId={event.toolCallId}
+      toolName={event.toolName}
+      excerpt={event.summary ?? undefined}
+      className={className}
+    />
+  );
 }
 
 function isInsightsResult(result: unknown): result is ChatInsightsToolResult {
@@ -164,12 +206,14 @@ function ToolActivityRow({
   multiple,
   index,
   count,
+  feedback,
 }: Readonly<{
   event: PersistedToolEvent;
   variant: ToolRendererVariant;
   multiple: boolean;
   index: number;
   count: number;
+  feedback?: ChatToolFeedbackContext;
 }>) {
   const body = getToolStatusBody(event);
   const nextStep = getToolStatusNextStep(event);
@@ -267,6 +311,11 @@ function ToolActivityRow({
           </details>
         ) : null}
       </div>
+      <ToolEventFeedback
+        event={event}
+        feedback={feedback}
+        className='shrink-0 opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover/message:opacity-100'
+      />
     </div>
   );
 }
@@ -274,9 +323,11 @@ function ToolActivityRow({
 function ToolActivityFeed({
   events,
   variant,
+  feedback,
 }: Readonly<{
   events: readonly PersistedToolEvent[];
   variant: ToolRendererVariant;
+  feedback?: ChatToolFeedbackContext;
 }>) {
   if (events.length === 0) {
     return null;
@@ -302,6 +353,7 @@ function ToolActivityFeed({
           multiple={multiple}
           index={index}
           count={events.length}
+          feedback={feedback}
         />
       ))}
     </div>
@@ -652,11 +704,13 @@ function renderToolActivityGroups({
   profileId,
   variant,
   hasMessageText,
+  feedback,
 }: Readonly<{
   events: readonly PersistedToolEvent[];
   profileId?: string;
   variant: ToolRendererVariant;
   hasMessageText: boolean;
+  feedback?: ChatToolFeedbackContext;
 }>): ReactNode[] {
   const elements: ReactNode[] = [];
   let statusEvents: PersistedToolEvent[] = [];
@@ -672,7 +726,11 @@ function renderToolActivityGroups({
         key={`activity:${key}`}
         className={cn(hasMessageText && variant === 'chat' && 'mt-2.5')}
       >
-        <ToolActivityFeed events={statusEvents} variant={variant} />
+        <ToolActivityFeed
+          events={statusEvents}
+          variant={variant}
+          feedback={feedback}
+        />
       </div>
     );
     statusEvents = [];
@@ -697,6 +755,11 @@ function renderToolActivityGroups({
         className={cn(hasMessageText && variant === 'chat' && 'mt-3')}
       >
         {artifactCard}
+        <ToolEventFeedback
+          event={event}
+          feedback={feedback}
+          className='mt-1 opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover/message:opacity-100'
+        />
       </div>
     );
   }
@@ -715,6 +778,7 @@ export function ToolPartsRenderer({
   profileId,
   variant,
   hasMessageText = false,
+  feedback,
 }: ToolPartsRendererProps) {
   const events = useMemo(() => getRenderableToolEvents(parts), [parts]);
   const loggedFallbackToolCallsRef = useRef<Set<string>>(new Set());
@@ -756,6 +820,7 @@ export function ToolPartsRenderer({
         profileId,
         variant,
         hasMessageText,
+        feedback,
       })}
     </>
   );


### PR DESCRIPTION
## Summary

Part **2/2** of #11460 — UI wiring for in-chat 👍/👎 feedback. Sibling of #13152 (server store + `POST /api/chat/feedback`); **land #13152 first** — this compiles independently, but votes 404 until the API exists.

- **`ChatFeedbackControl`**: optimistic thumbs pair (ghost icon buttons matching the copy-button pattern). Clicking the active vote undoes it; a failed request rolls the UI back. Posts `{messageId, vote, turnId, conversationId, toolCallId, toolName, messageExcerpt}` to `/api/chat/feedback`.
- **Every assistant message**: control renders in the existing copy row (`system-b-chat-copy-row`), same 7×7 hover-reveal affordance as Copy — no layout shift (row height already reserved).
- **Every tool/skill result**: control on each tool status row and under each artifact card (succeeded/failed states only; in-flight work isn't votable), hover-revealed via the existing `group/message` scope.
- **Attribution plumbing**: `turnId` (already carried on timeline messages, including server-reloaded ones) + `conversationId` now thread through `ChatThreadMessages → ChatMessage → ToolPartsRenderer`, so the server can resolve `model_used` from `chat_turns`.
- Feedback is gated to the authenticated app chat surface (`enableFeedback` — off for onboarding/anonymous embeds where votes can't be attributed to a user).

## Testing

- `ChatFeedbackControl.test.tsx`: renders both controls, posts full attribution payload, undo-on-second-click, vote switching, rollback on failed request.
- Biome 2.5.1 clean on all touched files.

bug-to-test: n/a — feature PR with new unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
