### PR TITLE
fix(ios): replace python3 with plutil in write-configuration.sh

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: iOS best-practices lint
         run: bash scripts/ios-best-practices-lint.sh apps/ios/Jovie
 
+      - name: Test write-configuration script
+        run: node --test apps/ios/scripts/write-configuration.test.mjs
+
       - name: Ensure iOS local configuration exists
         run: bash apps/ios/scripts/ensure-configuration.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] **iOS write-configuration resilience (GH-11003)**: Rewrote `apps/ios/scripts/write-configuration.sh` to use `/usr/bin/plutil` (always present on macOS) instead of `python3`, preventing failures when a broken Homebrew interpreter (e.g. pyexpat/libexpat symbol mismatch with python@3.14) is first on PATH. Adds a `TARGET_PLIST` env override for testability and four regression tests (`write-configuration.test.mjs`) run in `ios-ci.yml`.
 - **Smoother icon transitions (GH-11472)**: Copy buttons and the mobile menu now morph between states with a soft, interruptible animation instead of snapping. Adds shared animation primitives (`lib/animation/motion-primitives.ts` + `AnimatedIconSwap`) for icon swaps, staggered entrances, and layered depth shadows.
 - [internal] **Tool discovery skill (GH-13124)**: New `.claude/skills/tool-discovery/SKILL.md` — when a link/tool is shared without context, the agent searches GitHub (`gh search repos`) and the web for docs/pricing/reviews and returns a structured evaluation instead of asking for manual research or a gated unlock action.
 - [internal] **Ovie HUD auto-reload (GH-12988)**: Electron now polls `/api/health/build-info` every 60 seconds and reloads `/hud` windows when the deployed commit/build fingerprint changes, with no-store build-info responses so running operator shells pick up new HUD deploys without a manual restart.

--- a/apps/ios/scripts/write-configuration.sh
+++ b/apps/ios/scripts/write-configuration.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-TARGET_PLIST="$IOS_DIR/Jovie/Configuration.local.plist"
+TARGET_PLIST="${TARGET_PLIST:-$IOS_DIR/Jovie/Configuration.local.plist}"
 
 CLERK_PUBLISHABLE_KEY="${CLERK_PUBLISHABLE_KEY:-${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-pk_test_ci_placeholder}}"
 API_BASE_URL="${API_BASE_URL:-http://localhost:3100}"
@@ -18,27 +18,20 @@ OBSERVABILITY_INGEST_SECRET="${JOVIE_IOS_OBSERVABILITY_INGEST_SECRET:-${OBSERVAB
 CLERK_REDIRECT_URL="${CLERK_REDIRECT_URL:-${JOVIE_IOS_CLERK_REDIRECT_URL:-ie.jov.jovie://callback}}"
 CLERK_CALLBACK_URL_SCHEME="${CLERK_CALLBACK_URL_SCHEME:-${JOVIE_IOS_CLERK_CALLBACK_URL_SCHEME:-ie.jov.jovie}}"
 
-python3 - <<PY
-import plistlib
-from pathlib import Path
+mkdir -p "$(dirname "$TARGET_PLIST")"
 
-target = Path(r"$TARGET_PLIST")
-target.parent.mkdir(parents=True, exist_ok=True)
-
-payload = {
-    "ClerkPublishableKey": r"$CLERK_PUBLISHABLE_KEY",
-    "ApiBaseUrl": r"$API_BASE_URL",
-    "WebBaseUrl": r"$WEB_BASE_URL",
-    "SentryDsn": r"$SENTRY_DSN",
-    "ObservabilityEnvironment": r"$OBSERVABILITY_ENVIRONMENT",
-    "ObservabilityIngestUrl": r"$OBSERVABILITY_INGEST_URL",
-    "ObservabilityIngestSecret": r"$OBSERVABILITY_INGEST_SECRET",
-    "ClerkRedirectUrl": r"$CLERK_REDIRECT_URL",
-    "ClerkCallbackUrlScheme": r"$CLERK_CALLBACK_URL_SCHEME",
-}
-
-with target.open("wb") as file_handle:
-    plistlib.dump(payload, file_handle, sort_keys=False)
-PY
+# ponytail: use /usr/bin/plutil (always present on macOS) instead of python3 to
+# avoid breakage from a broken Homebrew python on PATH (e.g. pyexpat/libexpat
+# symbol mismatch with python@3.14).
+/usr/bin/plutil -create xml1 "$TARGET_PLIST"
+/usr/bin/plutil -insert ClerkPublishableKey    -string "$CLERK_PUBLISHABLE_KEY"    "$TARGET_PLIST"
+/usr/bin/plutil -insert ApiBaseUrl             -string "$API_BASE_URL"             "$TARGET_PLIST"
+/usr/bin/plutil -insert WebBaseUrl             -string "$WEB_BASE_URL"             "$TARGET_PLIST"
+/usr/bin/plutil -insert SentryDsn              -string "$SENTRY_DSN"               "$TARGET_PLIST"
+/usr/bin/plutil -insert ObservabilityEnvironment -string "$OBSERVABILITY_ENVIRONMENT" "$TARGET_PLIST"
+/usr/bin/plutil -insert ObservabilityIngestUrl -string "$OBSERVABILITY_INGEST_URL" "$TARGET_PLIST"
+/usr/bin/plutil -insert ObservabilityIngestSecret -string "$OBSERVABILITY_INGEST_SECRET" "$TARGET_PLIST"
+/usr/bin/plutil -insert ClerkRedirectUrl       -string "$CLERK_REDIRECT_URL"       "$TARGET_PLIST"
+/usr/bin/plutil -insert ClerkCallbackUrlScheme -string "$CLERK_CALLBACK_URL_SCHEME" "$TARGET_PLIST"
 
 echo "Wrote $TARGET_PLIST"

--- a/apps/ios/scripts/write-configuration.test.mjs
+++ b/apps/ios/scripts/write-configuration.test.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'write-configuration.sh'
+);
+
+function runScript(t, extraEnv = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'write-config-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const plistPath = path.join(root, 'Configuration.local.plist');
+  execFileSync('bash', [scriptPath], {
+    env: {
+      ...process.env,
+      CLERK_PUBLISHABLE_KEY: 'pk_test_example',
+      TARGET_PLIST: plistPath,
+      ...extraEnv,
+    },
+    encoding: 'utf8',
+  });
+  return { plistPath, root };
+}
+
+// --- resilience test ---
+
+test('succeeds even when python3 on PATH is broken', t => {
+  const root = mkdtempSync(path.join(tmpdir(), 'broken-python-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // Fake python3 that exits non-zero to simulate a broken Homebrew install
+  // (e.g. pyexpat/libexpat _XML_SetAllocTrackerActivationThreshold mismatch).
+  const fakePython3 = path.join(root, 'python3');
+  writeFileSync(
+    fakePython3,
+    '#!/usr/bin/env bash\necho "python3: broken" >&2\nexit 1\n'
+  );
+  chmodSync(fakePython3, 0o755);
+
+  const plistPath = path.join(root, 'Configuration.local.plist');
+  execFileSync('bash', [scriptPath], {
+    env: {
+      ...process.env,
+      PATH: `${root}:${process.env.PATH}`, // broken python3 is first on PATH
+      CLERK_PUBLISHABLE_KEY: 'pk_test_example',
+      TARGET_PLIST: plistPath,
+    },
+    encoding: 'utf8',
+  });
+
+  const contents = readFileSync(plistPath, 'utf8');
+  assert.match(contents, /<key>ClerkPublishableKey<\/key>/);
+  assert.match(contents, /<string>pk_test_example<\/string>/);
+});
+
+// --- correctness tests ---
+
+test('writes all nine expected plist keys', t => {
+  const { plistPath } = runScript(t, {
+    CLERK_PUBLISHABLE_KEY: 'pk_test_example',
+    API_BASE_URL: 'https://api.jov.ie',
+    WEB_BASE_URL: 'https://jov.ie',
+    JOVIE_IOS_SENTRY_DSN: 'https://sentry.example.com/1',
+    JOVIE_IOS_OBSERVABILITY_ENVIRONMENT: 'staging',
+    JOVIE_IOS_OBSERVABILITY_INGEST_URL: 'https://ingest.example.com',
+    JOVIE_IOS_OBSERVABILITY_INGEST_SECRET: 'secret-token',
+    CLERK_REDIRECT_URL: 'ie.jov.jovie://callback',
+    CLERK_CALLBACK_URL_SCHEME: 'ie.jov.jovie',
+  });
+
+  const contents = readFileSync(plistPath, 'utf8');
+  for (const key of [
+    'ClerkPublishableKey',
+    'ApiBaseUrl',
+    'WebBaseUrl',
+    'SentryDsn',
+    'ObservabilityEnvironment',
+    'ObservabilityIngestUrl',
+    'ObservabilityIngestSecret',
+    'ClerkRedirectUrl',
+    'ClerkCallbackUrlScheme',
+  ]) {
+    assert.match(
+      contents,
+      new RegExp(`<key>${key}</key>`),
+      `missing key: ${key}`
+    );
+  }
+  assert.match(contents, /<string>https:\/\/api\.jov\.ie<\/string>/);
+  assert.match(contents, /<string>staging<\/string>/);
+  assert.match(contents, /<string>ie\.jov\.jovie:\/\/callback<\/string>/);
+});
+
+test('handles empty optional values without breaking the plist', t => {
+  // Leave SENTRY_DSN and ingest fields unset; script defaults them to empty.
+  const { plistPath } = runScript(t);
+
+  const contents = readFileSync(plistPath, 'utf8');
+  assert.match(contents, /^<\?xml/, 'not a valid XML plist');
+  assert.match(contents, /<key>SentryDsn<\/key>/, 'SentryDsn key absent');
+  assert.match(contents, /<key>ClerkPublishableKey<\/key>/);
+});
+
+test('produces a well-formed plist that plutil accepts', t => {
+  const { plistPath } = runScript(t);
+  // plutil -lint exits 0 on a valid plist
+  execFileSync('/usr/bin/plutil', ['-lint', plistPath], { encoding: 'utf8' });
+});


### PR DESCRIPTION
## Summary

- `apps/ios/scripts/write-configuration.sh` now uses `/usr/bin/plutil` (always available on macOS) instead of a `python3` heredoc to write `Configuration.local.plist`. Fixes local iOS builds that fail when a broken Homebrew interpreter (e.g. `python@3.14` with a `pyexpat`/`libexpat` `_XML_SetAllocTrackerActivationThreshold` symbol mismatch) is first on PATH.
- Adds a `TARGET_PLIST` env override so tests can redirect script output to a temp directory without needing the repo structure.
- Adds `apps/ios/scripts/write-configuration.test.mjs` — 4 regression tests using `node:test`: broken-python resilience, all 9 key correctness, empty optionals, and `plutil -lint` well-formedness.
- `ios-ci.yml` runs the new test suite between the best-practices lint and xcodebuild steps.

## Root cause

The script's `python3` heredoc was using the system PATH to find Python. On machines where `brew install python@3.14` or a Python upgrade left a broken interpreter first on PATH (manifesting as `ImportError: cannot import name 'plistlib'` or a `libexpat` symbol mismatch), the script would fail and block `git commit` hooks and Xcode builds.

## Fix

`/usr/bin/plutil` is always at that absolute path on macOS (it is part of `CoreFoundation`). `plutil -create xml1` + `plutil -insert -string` handles XML escaping, empty strings, and special characters identically to `plistlib.dump`. Key ordering changes (alphabetical vs insertion order) but `NSDictionary` lookups in Swift are key-based so this is functionally equivalent.

## Test plan

- [x] `node --test apps/ios/scripts/write-configuration.test.mjs` — 4/4 pass locally
- [x] Pre-push hooks (Biome, typecheck, proxy guard, Tailwind) — all green
- [ ] `ios-ci.yml` "Test write-configuration script" step — will verify on macOS runner

Fixes #11003

🤖 Generated with [Claude Code](https://claude.com/claude-code)