### PR TITLE
chore: repo license hygiene + public/private separation (post LYB-LICENSE fix) (#10987)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Jovie
 
+> **Internal team only.** This repository is proprietary and confidential (© Jovie Technology Inc.). It is public only to use GitHub Actions CI minutes. External contributions are not accepted.
+
 ## ⚠️ CRITICAL: BRANCH PROTECTION RULES
 
 ### **NEVER PUSH TO MAIN OR PRODUCTION**
@@ -10,18 +12,9 @@
 - If the pipeline is stuck, fix issues on your feature branch or `main` and let CI handle the rest
 - Direct pushes to protected branches will be rejected and can break the pipeline
 
-## Contributor License Agreement (CLA)
+## Ownership
 
-By submitting a pull request to this repository, you agree that:
-
-1. Your contributions are your original work (or you have the right to submit them)
-2. You grant Jovie Technology Inc. a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, reproduce, modify, distribute, and sublicense your contributions as part of the Jovie platform
-3. You understand that your contributions may be used in a proprietary product
-4. You have the legal authority to grant these rights
-
-If you are contributing on behalf of your employer, you confirm that your employer has authorized you to make the contribution under these terms.
-
-For significant contributions, we may ask you to sign a formal CLA document.
+All contributions to this repository are work product of Jovie Technology Inc. (or are made by contractors/employees under an existing agreement). No external CLA is required because external contributions are not accepted.
 
 ### **Branch Protection**
 
@@ -72,7 +65,7 @@ For significant contributions, we may ask you to sign a formal CLA document.
    git add .
    git commit -m "feat: add new artist profile customization options"
    ```
-2. Push to your fork:
+2. Push your branch:
    ```bash
    git push origin feature/your-feature-name
    ```
@@ -341,12 +334,11 @@ SPOTIFY_CLIENT_SECRET=your-spotify-client-secret
 - Open an issue on GitHub
 - Contact the maintainers
 
-## Community Guidelines
+## Team Guidelines
 
-- Be respectful and inclusive
-- Help others learn and grow
-- Follow the established patterns
-- Contribute to documentation
-- Report bugs and security issues
+- Follow the established patterns and code style
+- Keep changes focused and reviewable (one PR per concern)
+- Contribute to documentation when you change behaviour
+- Report security issues via the process in [SECURITY.md](SECURITY.md)
 
-Thank you for contributing to Jovie! 🎵
+Thank you for contributing to Jovie.

--- a/README.md
+++ b/README.md
@@ -436,7 +436,9 @@ This project has evolved through several migrations:
 
 ## Contributing
 
-1. **Fork** the repository
+> **Internal team only.** JovieInc/Jovie is a proprietary codebase made public solely to use GitHub Actions CI minutes on the free tier. External contributions are not accepted.
+
+1. **Clone** the repository (no fork needed — push directly to feature branches)
 2. **Create branch** - `feat/your-feature` or `fix/your-bug`
 3. **Commit format** - Use conventional commits:
    - `feat:` - New features
@@ -480,6 +482,8 @@ It classifies open PRs as `DIRTY`, `BEHIND`, `BLOCKED`, `UNSTABLE`, or `MERGEABL
 This project is proprietary and confidential. All rights reserved by Jovie Technology Inc.
 
 See [LICENSE](LICENSE) for full terms. Unauthorized copying, distribution, or use of this software is strictly prohibited.
+
+> **Note:** This repository is public only to use GitHub Actions CI minutes on the free tier. It is not an open-source project. See [docs/REPO-POLICY.md](docs/REPO-POLICY.md) for the full public/private repo policy.
 
 ### Release Versioning & Changelog
 

--- a/apps/web/tests/unit/ci/repo-license-hygiene.test.ts
+++ b/apps/web/tests/unit/ci/repo-license-hygiene.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Repo license hygiene guardrails (JovieInc/Jovie#10987).
+ *
+ * These tests ensure the public repo never accidentally re-grows
+ * open-source contribution signals or permissive license claims.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
+
+function readFile(relative: string): string {
+  return readFileSync(resolve(repoRoot, relative), 'utf8');
+}
+
+describe('repo license hygiene', () => {
+  it('LICENSE is proprietary (not MIT/Apache/GPL)', () => {
+    const license = readFile('LICENSE');
+    expect(license).toContain('Jovie Technology Inc.');
+    expect(license).not.toMatch(/MIT License/i);
+    expect(license).not.toMatch(/Apache License/i);
+    expect(license).not.toMatch(/GNU (General|Lesser) Public License/i);
+  });
+
+  it('README Contributing section does not invite forking', () => {
+    const readme = readFile('README.md');
+    const contributingSection = readme.slice(readme.indexOf('## Contributing'));
+    // "Fork the repository" is an OSS-contribution signal — must not appear
+    expect(contributingSection).not.toMatch(/\bfork\b the repository/i);
+  });
+
+  it('README notes public-for-CI-only status', () => {
+    const readme = readFile('README.md');
+    expect(readme).toMatch(
+      /public.*only.*CI minutes|CI minutes.*public.*only/i
+    );
+  });
+
+  it('CONTRIBUTING.md does not present as an open-source project', () => {
+    const contributing = readFile('CONTRIBUTING.md');
+    // Must declare internal-only at the top
+    expect(contributing).toMatch(/Internal team only/i);
+    // Must not tell contributors to push to their fork
+    expect(contributing).not.toMatch(/push.*your fork/i);
+    // CLA for external contributors is gone
+    expect(contributing).not.toMatch(/Contributor License Agreement \(CLA\)/i);
+  });
+
+  it('REPO-POLICY.md exists and describes the public-for-CI constraint', () => {
+    expect(existsSync(resolve(repoRoot, 'docs/REPO-POLICY.md'))).toBe(true);
+    const policy = readFile('docs/REPO-POLICY.md');
+    expect(policy).toMatch(/public.*CI minutes|CI minutes.*public/i);
+    expect(policy).toMatch(/must never land/i);
+    expect(policy).toMatch(/Jovie Technology Inc/i);
+  });
+
+  it('first-party workspace package.json files have no permissive license field', () => {
+    const workspacePackages = [
+      'package.json',
+      'apps/web/package.json',
+      'packages/ui/package.json',
+      'packages/auth-routing/package.json',
+      'packages/extension-contracts/package.json',
+    ];
+
+    const permissiveSpdx =
+      /^(MIT|Apache-2\.0|BSD-[23]-Clause|ISC|MPL-2\.0|CC0)$/i;
+
+    for (const rel of workspacePackages) {
+      const pkgPath = resolve(repoRoot, rel);
+      if (!existsSync(pkgPath)) continue;
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+        license?: string;
+      };
+      if (pkg.license) {
+        expect(
+          pkg.license,
+          `${rel} must not carry a permissive OSS license identifier`
+        ).not.toMatch(permissiveSpdx);
+      }
+    }
+  });
+});

--- a/docs/REPO-POLICY.md
+++ b/docs/REPO-POLICY.md
@@ -1,0 +1,47 @@
+# Repository Policy — JovieInc
+
+## Why repos are public
+
+`JovieInc/Jovie` and `JovieInc/logyourbody` are made **public only to use GitHub Actions CI minutes on the free tier**. Neither is an intentional open-source release. Both are proprietary codebases owned by Jovie Technology Inc.
+
+If a GitHub Team plan (unlimited private CI minutes) becomes cost-effective, both repos should move private. The license in each repo already reflects proprietary terms.
+
+## Repo visibility map
+
+| Repo | Visibility | Reason |
+|------|-----------|--------|
+| `JovieInc/Jovie` | Public | CI minutes |
+| `JovieInc/logyourbody` | Public | CI minutes |
+| `JovieInc/gbrain` | Private | Contains personal knowledge graph — must stay private |
+| ceo-plans / agent configs | Private / local | Strategic content — never in public repos |
+| Hermes configs (`~/.hermes/`) | Local only | Secrets and orchestration logic — never committed to public repos |
+
+## What must never land in public repos
+
+- **gbrain content** — personal knowledge graph entries, meeting notes, strategic context
+- **ceo-plans** — kept in `~/.gstack/projects/…/ceo-plans/` (local machine) or a private repo
+- **Secrets or credentials** — even expired; use Doppler + `gitleaks` gate (see `JovieInc/Jovie#10940`)
+- **Agent configs with private topology** — Hermes service config, Tailscale IPs, orchestration scripts
+- **Investor/legal documents** — keep in Google Drive or a dedicated private repo
+
+## License signaling
+
+Every Jovie-owned package must carry proprietary terms:
+
+- Root `LICENSE` file → "© Jovie Technology Inc. All rights reserved."
+- No `"license": "MIT"` (or any OSS SPDX identifier) in first-party `package.json` files.
+- Vendored third-party tools (e.g. `.agents/skills/gstack/`) may retain their upstream MIT license — that is a dependency credit, not a claim about the enclosing codebase.
+
+## Contributing
+
+Only Jovie Technology Inc. employees and contractors with an existing IP-assignment agreement may contribute. The repos are not open to external pull requests. See `CONTRIBUTING.md` for internal workflow.
+
+## Dependency credits vs. OSS claims
+
+Legitimate dependency-credit pages (e.g. `shared/legal/open-source-licenses.md`, iOS "Open Source Licenses" screen) credit the open-source libraries Jovie *uses*. These are fine. They must not be mistaken for — or expanded into — a claim that Jovie's own code is open source.
+
+## Related issues
+
+- `JovieInc/Jovie#10411` — credential leak; requires human key rotation
+- `JovieInc/Jovie#10940` — CI gitleaks / secret-scan hardening (route to OWL)
+- `JovieInc/logyourbody#402` — LYB LICENSE MIT→proprietary fix


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (claude-sonnet-4-6). Closes #10987.

Card: t_11b726ec
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- error rate + p95 latency on affected surface
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.