### PR TITLE
fix(hermes): make watch-cron alerts plain English

### DIFF
--- a/scripts/hermes/jobs/agent-config-health.ts
+++ b/scripts/hermes/jobs/agent-config-health.ts
@@ -15,6 +15,7 @@ import { pathToFileURL } from 'node:url';
 import { HERMES_PATHS } from '../lib/hermes-paths';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
 import { sendTelegram } from '../lib/telegram-client';
+import { formatTimBrief } from '../lib/tim-brief';
 
 const JOB = 'agent-config-health';
 const VERCEL_AI_GATEWAY_URL = 'https://ai-gateway.vercel.sh';
@@ -325,6 +326,27 @@ function formatFinding(finding: ConfigFinding): string {
   return `${finding.file}:${finding.path} ${finding.code}`;
 }
 
+/**
+ * Telegram-facing brief for Tim (GH #13123) — plain-English problem/action
+ * per finding, codes/paths pushed to a footnoted Refs line instead of
+ * inline jargon. `formatFinding` above stays technical for logs/stdout.
+ */
+export function buildAgentConfigHealthBrief(
+  errors: ReadonlyArray<ConfigFinding>
+): string {
+  return formatTimBrief(
+    errors.map(finding => ({
+      problem: finding.message,
+      action: `Reply "do this" and Hermes fixes the ${finding.file} config, or reply Skip if it's intentional.`,
+      defaultAction: 'Left as-is — the config stays unchanged until you reply.',
+      ref: `${finding.code} (${finding.path})`,
+    })),
+    {
+      title: `Hermes agent config: ${errors.length} issue${errors.length === 1 ? '' : 's'} ${errors.length === 1 ? 'needs' : 'need'} a look`,
+    }
+  );
+}
+
 export async function runAgentConfigHealth(options?: {
   readonly hermesConfigPath?: string;
   readonly openClawConfigPath?: string;
@@ -355,13 +377,7 @@ export async function runAgentConfigHealth(options?: {
   });
 
   if (errors.length > 0 && options?.notify !== false) {
-    const details = errors
-      .slice(0, 8)
-      .map(finding => `- ${formatFinding(finding)}`)
-      .join('\n');
-    await sendTelegram(
-      `Hermes/OpenClaw agent config health failed (${errors.length} error${errors.length === 1 ? '' : 's'}).\n${details}\nRun: tsx scripts/hermes/jobs/agent-config-health.ts`
-    );
+    await sendTelegram(buildAgentConfigHealthBrief(errors));
   }
 
   return {

--- a/scripts/hermes/lib/tim-brief.ts
+++ b/scripts/hermes/lib/tim-brief.ts
@@ -1,0 +1,75 @@
+/**
+ * Tim Communication Filter (GH #13123) — shared formatter for Hermes-Air
+ * alerts sent directly to Tim (Telegram/Slack). Watch-cron output was
+ * landing as a wall of internal error codes; Tim's ask was plain-English
+ * items he can reply to and move on:
+ *
+ *   "Give me three actionable items where I can just respond to you with
+ *   what to do and then go do it. Don't send me a bunch of issue codes and
+ *   technical jargon."
+ *
+ * Rules enforced here:
+ * 1. Max 3 items per message; the rest are deferred, not dropped.
+ * 2. Each item is one-line problem + one-line action + one-line default.
+ * 3. Internal IDs/codes never appear inline — they go in a footnoted
+ *    "Refs:" block at the end.
+ * 4. Every item ends with a reply contract: Do this / Skip / Defer.
+ */
+
+export interface TimBriefItem {
+  /** One-line plain-English description of what's wrong. No internal IDs/codes. */
+  readonly problem: string;
+  /** One sentence: what Tim needs to do. */
+  readonly action: string;
+  /** One sentence: what happens if Tim does nothing. */
+  readonly defaultAction: string;
+  /** Internal ID/error code for this item — surfaced only in the footnote block. */
+  readonly ref?: string;
+}
+
+const DEFAULT_MAX_ITEMS = 3;
+
+export function formatTimBrief(
+  items: ReadonlyArray<TimBriefItem>,
+  options?: { readonly title?: string; readonly maxItems?: number }
+): string {
+  if (items.length === 0) return '';
+
+  const maxItems = Math.max(0, options?.maxItems ?? DEFAULT_MAX_ITEMS);
+  const shown = items.slice(0, maxItems);
+  const deferredCount = items.length - shown.length;
+
+  const lines: string[] = [];
+  if (options?.title) lines.push(options.title, '');
+
+  shown.forEach((item, index) => {
+    lines.push(
+      `${index + 1}. ${item.problem}`,
+      `   Action: ${item.action}`,
+      `   Default: ${item.defaultAction}`,
+      `   Reply: Do this / Skip / Defer`,
+      ''
+    );
+  });
+
+  if (deferredCount > 0) {
+    lines.push(
+      `(+${deferredCount} more deferred — reply "more" to see them.)`,
+      ''
+    );
+  }
+
+  // Only footnote refs for items actually described above — a ref for a
+  // deferred, undescribed item would be a floating code with no context,
+  // which is the exact confusion this formatter exists to remove.
+  const refs = [
+    ...new Set(
+      shown.map(item => item.ref).filter((ref): ref is string => Boolean(ref))
+    ),
+  ];
+  if (refs.length > 0) {
+    lines.push(`Refs: ${refs.join(', ')}`);
+  }
+
+  return lines.join('\n').trimEnd();
+}

--- a/scripts/lib/__tests__/agent-config-health.test.mjs
+++ b/scripts/lib/__tests__/agent-config-health.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildAgentConfigHealthBrief,
   parseHermesFallbackProviders,
   validateHermesConfigText,
   validateOpenClawConfig,
@@ -135,5 +136,68 @@ describe('validateOpenClawConfig', () => {
     expect(
       findings.filter(finding => finding.severity === 'error')
     ).toHaveLength(6);
+  });
+});
+
+describe('buildAgentConfigHealthBrief', () => {
+  it('GH #13123: sends Tim the human message, not the raw file/path/code jargon', () => {
+    const brief = buildAgentConfigHealthBrief([
+      {
+        severity: 'error',
+        file: 'hermes',
+        path: 'fallback_providers[line 4].model',
+        code: 'hermes_broken_fallback_model',
+        message:
+          'Hermes fallback model nex-agi/nex-n2-pro is a known broken global fallback for local agents.',
+      },
+    ]);
+
+    expect(brief).toContain(
+      '1. Hermes fallback model nex-agi/nex-n2-pro is a known broken global fallback for local agents.'
+    );
+    expect(brief).toContain('Reply: Do this / Skip / Defer');
+    // Neither the raw code/path pair nor the bracket-index YAML path may
+    // appear next to the problem/action lines — only in the Refs footer.
+    const actionLine = brief
+      .split('\n')
+      .find(line => line.trim().startsWith('Action:'));
+    expect(actionLine).not.toContain('fallback_providers[line 4]');
+    expect(brief).not.toContain(
+      'hermes:fallback_providers[line 4].model hermes_broken_fallback_model'
+    );
+    expect(brief).toContain(
+      'Refs: hermes_broken_fallback_model (fallback_providers[line 4].model)'
+    );
+  });
+
+  it('caps at 3 issues and defers the rest instead of dumping a wall of codes', () => {
+    const errors = Array.from({ length: 5 }, (_, i) => ({
+      severity: 'error',
+      file: 'hermes',
+      path: `fallback_providers[line ${i}].model`,
+      code: `code-${i}`,
+      message: `Problem number ${i}.`,
+    }));
+
+    const brief = buildAgentConfigHealthBrief(errors);
+
+    expect(brief).toContain('1. Problem number 0.');
+    expect(brief).toContain('3. Problem number 2.');
+    expect(brief).not.toContain('4. Problem number 3.');
+    expect(brief).toContain('(+2 more deferred — reply "more" to see them.)');
+  });
+
+  it('uses singular grammar in the title for exactly one issue', () => {
+    const brief = buildAgentConfigHealthBrief([
+      {
+        severity: 'error',
+        file: 'hermes',
+        path: 'fallback_providers[line 0].model',
+        code: 'code-0',
+        message: 'Problem number 0.',
+      },
+    ]);
+
+    expect(brief).toContain('Hermes agent config: 1 issue needs a look');
   });
 });

--- a/scripts/lib/__tests__/tim-brief.test.mjs
+++ b/scripts/lib/__tests__/tim-brief.test.mjs
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatTimBrief } from '../../hermes/lib/tim-brief.ts';
+
+describe('formatTimBrief', () => {
+  it('returns empty string for no items', () => {
+    expect(formatTimBrief([])).toBe('');
+  });
+
+  it('formats each item as problem/action/default/reply with no inline refs', () => {
+    const text = formatTimBrief([
+      {
+        problem: 'The invoice sync stalled.',
+        action: 'Check Stripe dashboard for the retry queue.',
+        defaultAction: 'Left as-is — it retries automatically in an hour.',
+        ref: 'billing_sync_stall',
+      },
+    ]);
+
+    expect(text).toContain('1. The invoice sync stalled.');
+    expect(text).toContain(
+      'Action: Check Stripe dashboard for the retry queue.'
+    );
+    expect(text).toContain(
+      'Default: Left as-is — it retries automatically in an hour.'
+    );
+    expect(text).toContain('Reply: Do this / Skip / Defer');
+    // The code must not appear next to the problem line — only in the footer.
+    expect(text.split('\n')[0]).not.toContain('billing_sync_stall');
+    expect(text).toContain('Refs: billing_sync_stall');
+  });
+
+  it('caps at 3 items by default, reports the deferred count, and only footnotes shown refs', () => {
+    const items = Array.from({ length: 5 }, (_, i) => ({
+      problem: `Problem ${i + 1}`,
+      action: `Action ${i + 1}`,
+      defaultAction: `Default ${i + 1}`,
+      ref: `code-${i + 1}`,
+    }));
+
+    const text = formatTimBrief(items);
+
+    expect(text).toContain('1. Problem 1');
+    expect(text).toContain('2. Problem 2');
+    expect(text).toContain('3. Problem 3');
+    expect(text).not.toContain('4. Problem 4');
+    expect(text).not.toContain('5. Problem 5');
+    expect(text).toContain('(+2 more deferred — reply "more" to see them.)');
+    // Deferred items 4 and 5 have no visible problem statement, so their
+    // codes must not leak into the footer either.
+    expect(text).toContain('Refs: code-1, code-2, code-3');
+  });
+
+  it('does not print a deferred line when the item count exactly matches the cap', () => {
+    const items = Array.from({ length: 3 }, (_, i) => ({
+      problem: `Problem ${i + 1}`,
+      action: `Action ${i + 1}`,
+      defaultAction: `Default ${i + 1}`,
+    }));
+
+    const text = formatTimBrief(items);
+
+    expect(text).not.toContain('deferred');
+  });
+
+  it('dedupes repeated ref codes in the footer', () => {
+    const text = formatTimBrief([
+      {
+        problem: 'Problem 1',
+        action: 'Action 1',
+        defaultAction: 'Default 1',
+        ref: 'dup_code',
+      },
+      {
+        problem: 'Problem 2',
+        action: 'Action 2',
+        defaultAction: 'Default 2',
+        ref: 'dup_code',
+      },
+    ]);
+
+    expect(text).toContain('Refs: dup_code');
+    expect(text).not.toContain('dup_code, dup_code');
+  });
+
+  it('honors a custom maxItems and an optional title', () => {
+    const items = Array.from({ length: 2 }, (_, i) => ({
+      problem: `Problem ${i + 1}`,
+      action: `Action ${i + 1}`,
+      defaultAction: `Default ${i + 1}`,
+    }));
+
+    const text = formatTimBrief(items, { maxItems: 1, title: 'Heads up' });
+
+    expect(text.startsWith('Heads up\n\n1. Problem 1')).toBe(true);
+    expect(text).not.toContain('2. Problem 2');
+    expect(text).toContain('(+1 more deferred — reply "more" to see them.)');
+  });
+
+  it('omits the Refs line when no item has a ref', () => {
+    const text = formatTimBrief([
+      {
+        problem: 'Something needs attention.',
+        action: 'Take a look.',
+        defaultAction: 'Nothing happens.',
+      },
+    ]);
+
+    expect(text).not.toContain('Refs:');
+  });
+});


### PR DESCRIPTION
## Summary

- Recovered the stranded #13123 shipper branch and rebased it onto current origin/main.
- Adds `formatTimBrief()` for Hermes alerts sent to Tim: max 3 plain-English items, explicit action/default/reply contract, and refs moved to a footer.
- Wires agent config health Telegram notifications through the shared formatter while keeping technical finding output for logs.
- Adds focused regression coverage for the formatter and agent config health brief.

Fixes #13123

## Validation

- `PATH=/Users/timwhite/.hermes/node/bin:/opt/homebrew/bin:$PATH pnpm exec vitest run scripts/lib/__tests__/tim-brief.test.mjs scripts/lib/__tests__/agent-config-health.test.mjs` -> 2 files passed, 15 tests passed.
- `PATH=/Users/timwhite/.hermes/node/bin:/opt/homebrew/bin:$PATH pnpm exec biome check scripts/hermes/jobs/agent-config-health.ts scripts/hermes/lib/tim-brief.ts scripts/lib/__tests__/agent-config-health.test.mjs scripts/lib/__tests__/tim-brief.test.mjs` -> passed, no fixes applied.
- `coderabbit review --agent --type committed --base origin/main -c AGENTS.md` -> review completed, findings: 0.
- `PATH=/Users/timwhite/.hermes/node/bin:/opt/homebrew/bin:$PATH git push -u origin HEAD` -> pre-push hook passed: Biome changed-files check, web proxy guard, Tailwind guard, web typecheck.

## Notes

- First push attempt failed because the hook picked Node 24/pnpm 11 from the ambient PATH; reran with repo-required Node 22/pnpm 9.15.4 and the hook passed.
- No migrations or UI screenshots required; this is Hermes alert text formatting and tests.
