### PR TITLE
test(design-system): extend drift lint guard to cover 8 component files (#11274)

### DIFF
--- a/apps/web/tests/unit/app/exp-drift-lint-guard.test.ts
+++ b/apps/web/tests/unit/app/exp-drift-lint-guard.test.ts
@@ -11,6 +11,29 @@ const EXP_DRIFT_TARGETS = [
   'apps/web/app/exp/shell-v1/page.tsx',
 ] as const;
 
+/**
+ * The 8 component files from #11274 that had format drift and/or ESLint
+ * label-casing violations. Once the pre-push gate (`biome check .`) catches
+ * these, any agent touching unrelated code would get a confusing pre-push
+ * failure — so the guard locks the fixed state in permanently.
+ */
+const COMPONENT_DRIFT_TARGETS = [
+  'apps/web/components/features/admin/ShippingVelocityChart.tsx',
+  'apps/web/components/features/admin/admin-creator-profiles/AdminCreatorsPageWrapper.tsx',
+  'apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx',
+  'apps/web/components/features/admin/agent-os/ApprovalQueuePanel.tsx',
+  'apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx',
+  'apps/web/components/features/demo/DemoSettingsPanel.tsx',
+  'apps/web/components/features/demo/DemoTimWhiteProfileSurface.tsx',
+  'apps/web/components/features/dev/DevToolbar.tsx',
+] as const;
+
+/** Files that had `@jovie/canonical-ui-label-casing` violations in #11274. */
+const LABEL_CASING_TARGETS = [
+  'components/features/demo/DemoTimWhiteProfileSurface.tsx',
+  'components/features/dev/DevToolbar.tsx',
+] as const;
+
 function run(command: string) {
   return execSync(command, {
     cwd: repoRoot,
@@ -29,6 +52,48 @@ describe('exp drift lint guard (#11224 follow-up)', () => {
     const files = EXP_DRIFT_TARGETS.map(target =>
       target.replace('apps/web/', '')
     ).join(' ');
+
+    let eslintOutput = '';
+    try {
+      eslintOutput = execSync(
+        `pnpm exec eslint --cache --cache-location .cache/eslint --format json ${files}`,
+        {
+          cwd: webRoot,
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+          timeout: 120_000,
+        }
+      );
+    } catch (error) {
+      const execError = error as { stdout?: string };
+      eslintOutput = execError.stdout ?? '';
+      if (!eslintOutput) throw error;
+    }
+
+    const results = JSON.parse(eslintOutput) as Array<{
+      messages: Array<{ ruleId?: string; severity: number }>;
+    }>;
+
+    const labelCasingErrors = results.flatMap(result =>
+      result.messages.filter(
+        message =>
+          message.ruleId === '@jovie/canonical-ui-label-casing' &&
+          message.severity === 2
+      )
+    );
+
+    expect(labelCasingErrors).toEqual([]);
+  }, 120_000);
+});
+
+describe('component drift lint guard (#11274)', () => {
+  it('keeps the 8 component files Biome-clean so pre-push hooks do not fail on unrelated work', () => {
+    const files = COMPONENT_DRIFT_TARGETS.join(' ');
+    expect(() => run(`pnpm biome check ${files}`)).not.toThrow();
+  });
+
+  it('keeps canonical UI label casing clean on the two previously-violated component files', () => {
+    const files = LABEL_CASING_TARGETS.join(' ');
 
     let eslintOutput = '';
     try {


### PR DESCRIPTION
## Summary

- Extends `apps/web/tests/unit/app/exp-drift-lint-guard.test.ts` with two new `describe` blocks covering the 8 component files from GH-11274
- New Biome-clean guard asserts all 8 admin/demo/dev files remain format-clean so future agents don't hit confusing pre-push failures
- New ESLint guard asserts the two previously-violated files (`DemoTimWhiteProfileSurface.tsx`, `DevToolbar.tsx`) stay free of `@jovie/canonical-ui-label-casing` errors

The source files themselves were already fixed by prior sweeps (committed before this issue was filed). This PR locks the fixed state in permanently.

## Test plan

- [x] `pnpm --filter web exec vitest run tests/unit/app/exp-drift-lint-guard.test.ts` — 4/4 pass
- [x] `pnpm --filter @jovie/web run typecheck` — clean
- [x] `pnpm biome check <file>` — clean
- [x] Pre-commit hooks (lint-staged, ESLint, typecheck) — all green

## Verification evidence

```
✓ tests/unit/app/exp-drift-lint-guard.test.ts (4 tests) 2775ms
    ✓ keeps the three exp pages Biome-clean (323ms)
    ✓ keeps canonical UI label casing clean on the three exp pages (1359ms)
    ✓ keeps the 8 component files Biome-clean (311ms)
    ✓ keeps canonical UI label casing clean on the two previously-violated component files (864ms)
Test Files  1 passed (1)
     Tests  4 passed (4)
```

Closes GH-11274

🤖 Generated with [Claude Code](https://claude.com/claude-code)