### PR TITLE
chore: trial lavish-axi for the HTML-artifact review loop (Eve/design) (#10931)

### DIFF
--- a/.claude/rules/gstack.md
+++ b/.claude/rules/gstack.md
@@ -26,6 +26,7 @@ This repo includes [gstack](https://github.com/garrytan/gstack) as a git submodu
 | QA Swarm (design jury) | `/qa-swarm-design-jury` | Change-aware capture plus multi-LLM design jury |
 | QA Swarm (test-gen) | `/qa-swarm-test-gen` | Test generation and fuzz swarm for high-risk contracts |
 | QA Swarm (flaky-hunter) | `/qa-swarm-flaky-hunter` | Flake rerun, cluster, and auto-quarantine |
+| Lavish | `/lavish` | Turn agent responses into rich HTML artifacts the user can annotate and send targeted feedback on (design comps, reports, dashboards, review surfaces) |
 | Upgrade | `/gstack-upgrade` | Upgrade gstack to latest version |
 
 ## Setup
@@ -64,6 +65,7 @@ Key routing rules:
 - Clerk user management, instance inspection, auth debugging → invoke `clerk-cli`
 - Continuous QA swarm recipes (diff review, explore, vision, jury, test-gen, flakes) → invoke matching `/qa-swarm-*` command; load `qa-swarm` skill
 - A shared link/tool/product with no context expecting an opinion or evaluation → invoke `tool-discovery` instead of asking the human to research it first
+- HTML artifact, design comp, review surface, dashboard, deck, report for human annotation → invoke `lavish` to open it in the browser-based review loop instead of embedding a screenshot
 
 ## gbrain (long-term memory layer)
 

--- a/.claude/skills/lavish/SKILL.md
+++ b/.claude/skills/lavish/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: lavish
+description: Turn complex or visual agent responses into rich, reviewable HTML artifacts the user can annotate and send feedback on, using the lavish-axi CLI. Use when about to give a plan, comparison, diagram, table, code diff, report, or anything easier to grasp visually than as prose.
+argument-hint: <what the artifact should show>
+author: Kun Chen (kunchenguid)
+metadata:
+  hermes:
+    tags: [html, review, artifacts, visualization]
+    category: productivity
+---
+
+# Lavish Editor
+
+Lavish Editor helps agents turn rich HTML artifacts into collaborative human review surfaces. Whenever you are about to give user a complex response that will be easier to understand via a rich / interactive page, consider using Lavish Editor. First generate an interactive HTML artifact according to user request, then run `npx -y lavish-axi <html-file>` so the user can visually review it, annotate elements or selected text, queue prompts, and send feedback back through `npx -y lavish-axi poll`.
+
+You do not need lavish-axi installed globally - invoke it with `npx -y lavish-axi <html-file>`.
+If lavish-axi output shows a follow-up command starting with `lavish-axi`, run it as `npx -y lavish-axi ...` instead.
+
+## Request
+
+$ARGUMENTS
+
+If the request above is non-empty, the user invoked `/lavish` explicitly - build an HTML artifact for that request now, following the workflow below.
+If it is empty, infer what to visualize from the conversation.
+
+## When to use
+
+Use lavish-axi when the user asks for a visual artifact, HTML explainer, interactive prototype, review surface, product or technical plan, comparison, report, or browser-based feedback loop
+
+## Workflow
+
+1. Create the HTML artifact (default location `.lavish/<name>.html` in the working directory).
+2. Run `npx -y lavish-axi <html-file>` to open or resume a review session in the browser.
+3. Run `npx -y lavish-axi poll <html-file>` to long-poll for the user's annotations, queued prompts, and browser-reported `layout_warnings`.
+   The poll stays silent until the user acts or the real browser reports fresh layout warnings - leave it running, never kill it.
+   If your harness limits how long a foreground command may run, run the poll as a background task; if it gets killed or times out anyway, just re-run it - queued feedback is never lost.
+4. If poll returns `layout_warnings`, follow the returned `next_step`: fix and re-check fresh error-severity findings, but proceed with a note instead of looping when every current warning is persistent or low-severity.
+5. Apply human feedback, then poll again with `--agent-reply "<message>"` to reply in the browser and keep the loop going.
+6. Run `npx -y lavish-axi end <html-file>` when the review is finished.
+7. If the user ends the session from the browser instead, `npx -y lavish-axi <html-file>` refuses to reopen it and says so - only pass `--reopen` when the user asks for further review or something genuinely important needs their visual attention. Otherwise deliver remaining updates directly in this conversation.
+
+## Visual guidance
+
+- Use visual hierarchy to make the most important decisions, risks, tradeoffs, and next actions obvious at a glance
+- Use visual structure such as sections, cards, tables, diagrams, annotated snippets, and side-by-side comparisons instead of long prose
+- Choose typography, spacing, color, and layout deliberately so the artifact has a clear point of view
+- Prevent horizontal overflow at every nesting level: nested grid/flex children also need minmax(0, 1fr) tracks and min-width: 0, especially when badges, labels, or status text use wide pixel or monospace fonts; wrap, truncate, or contain long unbreakable text deliberately
+- When the artifact would describe existing or current UI or state, show it instead: capture screenshots of the real pages (run the app read-only if needed) and embed them, rather than explaining the current look in prose; reserve prose for what cannot be shown such as rationale, trade-offs, and open questions
+
+## Playbooks
+
+Run `npx -y lavish-axi playbook <id>` for focused, detailed guidance on any of these.
+One artifact often combines several playbooks (for example a plan that includes a comparison and a diagram), so MUST open each matching playbook before writing HTML.
+For flows, architecture, state, or sequence diagrams, do not hand-build boxes-and-arrows from div/flexbox; open the diagram playbook and use Mermaid unless SVG is needed for richly annotated nodes.
+
+- `diagram` - Map relationships, flows, state, and architecture
+- `table` - Turn dense records into scan-friendly review surfaces
+- `comparison` - Show options, tradeoffs, and current vs target behavior
+- `plan` - Explain a product or technical plan before implementation
+- `code` - Render source code, code files, patches, PR diffs, and before/after code inside Lavish artifacts
+- `input` - Must be used when the agent needs to collect user input on decisions, choices, preferences, triage, scope, or other structured feedback from within the artifact
+- `slides` - Create a deliberate presentation when slides are requested
+
+## Commands & rules
+
+- Run `npx -y lavish-axi <html-file>` to open or resume a Lavish Editor session. If the user explicitly ended the session from the browser, this refuses to reopen it and explains why instead of reopening uninvited - pass `--reopen` only when the user asks for further review or something important needs their visual attention
+- Unless the user specifies another location, create HTML artifacts in the current working directory under `.lavish/`
+- Lavish serves the html file through a local express.js server. If your html needs to reference other filesystem assets such as images, CSS, fonts, and local scripts, copy them into the same directory as the HTML file, then reference them with relative paths from that directory. Never prepend `/` to those asset paths - root paths won't work
+- Run `npx -y lavish-axi poll <html-file>` to wait for user feedback or browser-reported layout_warnings. It long-polls and stays silent until the user sends feedback, ends the session, or the real browser reports fresh layout_warnings, so leave it running - never kill it. Fix and re-check fresh error-severity layout_warnings before involving the human; if the poll says every current warning is persistent or low-severity, proceed with a note instead of looping. If your harness limits how long a foreground command may run, run the poll as a background task; if it gets killed or times out anyway, just re-run it - queued feedback is never lost. When it reports the session ended, stop polling and do not reopen it uninvited - deliver remaining updates in this conversation instead
+- Run `npx -y lavish-axi end <html-file>` to end a session as the agent - ending it this way still allows a plain reopen later. When the user ends it from the browser instead, a later `npx -y lavish-axi <html-file>` refuses to reopen it without `--reopen`
+- Run `npx -y lavish-axi export <html-file> [--out <path>]` to write a portable copy of the artifact - one HTML file with its LOCAL assets inlined - so it opens with no Lavish server and no sibling files. Remote CDN/font references are left as links, so it needs network to render those. Users can also export from the browser chrome's overflow menu
+- Run `npx -y lavish-axi share <html-file> [--password <pw>] [--token <t>]` to publish the artifact on ht-ml.app (https://ht-ml.app), a third-party hosting service not part of Lavish, and get back a visitable URL. Shares are PUBLIC by default, so anyone with the link can open them. Pass --password to publish a PRIVATE password-protected page; viewers must supply the password to view. Local assets are inlined; remote refs load over the network. It returns the url plus a secret update_key for managing the page later. Use --token or LAVISH_AXI_HTML_APP_TOKEN only when you have an optional bearer token; it is never required. Users can also publish from the browser chrome's overflow menu
+- Run `npx -y lavish-axi stop` to shut down the background server (it also self-stops when idle or after the last session ends with nothing connected)
+- Run `npx -y lavish-axi playbook <playbook_id>` for focused artifact guidance. One artifact often combines several playbooks (for example a plan that includes a comparison and a diagram), so MUST open each matching playbook before writing HTML.
+- Lavish does not auto-inject any design system - artifacts stay portable so they render identically when opened directly without lavish-axi running. Before writing any HTML, decide the design direction in this strict priority order, and only move to the next step when the current one truly yields nothing: (1) if the user asked for a specific look or named design system, use that; (2) otherwise you must first inspect the project the artifact is about - the subject or product whose content or UI it represents, which may differ from your current working directory - and match that project's design system: Tailwind or theme config, shared CSS variables or design tokens, component library, brand assets, or existing styled pages. If the artifact previews, proposes, or mocks a specific app's UI, render it in that app's own design system so it faithfully shows the product, even when you are running in a different repo; (3) only when both steps come up empty, use the Lavish-recommended Tailwind CSS browser runtime v4 + DaisyUI v5, available via CDN - run `npx -y lavish-axi design` for a content-to-playbook router, a copy-pasteable CDN snippet, a Mermaid CDN snippet/init for diagrams, and the DaisyUI component reference, and prefer the Tailwind/DaisyUI CDN snippet over hand-writing styles unless explicitly instructed otherwise by the user. When you deliver the artifact, state which of the three design sources you used and why.
+- Use lavish-axi when the user asks for a visual artifact, HTML explainer, interactive prototype, review surface, product or technical plan, comparison, report, or browser-based feedback loop

--- a/apps/web/tests/unit/skills-lavish.test.ts
+++ b/apps/web/tests/unit/skills-lavish.test.ts
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// ponytail: one test file to lock the lavish skill installation; fails if the
+// skill is removed or skills-lock.json is corrupted.
+
+// tests/unit/skills-lavish.test.ts → tests/unit → tests → apps/web → apps → repo root
+const repoRoot = join(fileURLToPath(import.meta.url), '../../../../../');
+
+describe('lavish skill installation', () => {
+  it('SKILL.md exists at .claude/skills/lavish/SKILL.md', () => {
+    const skillPath = join(repoRoot, '.claude/skills/lavish/SKILL.md');
+    expect(existsSync(skillPath), `missing: ${skillPath}`).toBe(true);
+  });
+
+  it('SKILL.md declares the lavish skill name and author', () => {
+    const skillPath = join(repoRoot, '.claude/skills/lavish/SKILL.md');
+    const content = readFileSync(skillPath, 'utf8');
+    expect(content).toContain('name: lavish');
+    expect(content).toContain('kunchenguid');
+    // core capability: open HTML in browser for annotation
+    expect(content).toContain('lavish-axi');
+  });
+
+  it('skills-lock.json contains the lavish entry pointing to kunchenguid/lavish-axi', () => {
+    const lockPath = join(repoRoot, 'skills-lock.json');
+    expect(existsSync(lockPath), `missing: ${lockPath}`).toBe(true);
+    const lock = JSON.parse(readFileSync(lockPath, 'utf8'));
+    expect(lock.skills).toHaveProperty('lavish');
+    expect(lock.skills.lavish.source).toBe('kunchenguid/lavish-axi');
+  });
+
+  it('gstack routing table mentions lavish for HTML artifact review loop', () => {
+    const gstackPath = join(repoRoot, '.claude/rules/gstack.md');
+    const content = readFileSync(gstackPath, 'utf8');
+    expect(content).toContain('/lavish');
+    // verify it is in the routing rules, not just the table
+    expect(content).toContain('HTML artifact');
+  });
+});

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -6,6 +6,12 @@
       "sourceType": "github",
       "skillPath": "skills/find-skills/SKILL.md",
       "computedHash": "9e1c8b3103f92fa8092568a44fe64858de7c5c9dc65ce4bea8f168080e889cfd"
+    },
+    "lavish": {
+      "source": "kunchenguid/lavish-axi",
+      "sourceType": "github",
+      "skillPath": "skills/lavish/SKILL.md",
+      "computedHash": "c3a0299d820bc3b30613d7740718b194511201319047fa9d3075e0ab1e596bde"
     }
   }
 }


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (claude-sonnet-4-6). Closes #10931.

Card: t_9d55758f
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- error rate + p95 latency on affected surface
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.