### PR TITLE
feat(hermes): agentcookie integration spike — always-on MBP session sync (GH-10930)

### DIFF
--- a/scripts/hermes/jobs/agentcookie-sync.ts
+++ b/scripts/hermes/jobs/agentcookie-sync.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env tsx
+/**
+ * agentcookie-sync — Hermes-Air eval/spike job (JOV-3205 / GH-10930)
+ *
+ * Evaluates what agentcookie would sync from the daily-driver Mac to the
+ * Hermes-Air (agent Mac) over Tailscale. Defaults to DRY_RUN mode —
+ * nothing is actually synced unless AGENTCOOKIE_LIVE=1 is set.
+ *
+ * Usage:
+ *   # Dry-run (safe — no credentials transferred):
+ *   tsx scripts/hermes/jobs/agentcookie-sync.ts
+ *
+ *   # Live sync (REQUIRES Tim's approval + AGENTCOOKIE_LIVE=1):
+ *   AGENTCOOKIE_LIVE=1 tsx scripts/hermes/jobs/agentcookie-sync.ts
+ *
+ * launchd: co.jovie.hermes.cron-agentcookie-sync
+ * Schedule: every 30 minutes (when live mode is enabled by Tim)
+ * Node: runs on the SOURCE Mac (daily-driver MBP); pushes to Air.
+ */
+
+import {
+  checkPrerequisites,
+  evaluateSyncCandidates,
+  partitionDomains,
+  runSync,
+} from '../lib/agentcookie';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { sendTelegram } from '../lib/telegram-client';
+
+const JOB = 'agentcookie-sync';
+const DRY_RUN = process.env.AGENTCOOKIE_LIVE !== '1';
+
+// The Tailscale hostname of the Air (agent box). Resolved dynamically if
+// AGENTCOOKIE_TARGET_HOST is not set.
+const TARGET_HOST = process.env.AGENTCOOKIE_TARGET_HOST ?? 'hermes-air';
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    // 1. Prerequisite check
+    const prereqs = await checkPrerequisites();
+
+    logJobEvent({
+      job: JOB,
+      event: 'prereqs',
+      cliInstalled: prereqs.cliInstalled,
+      tailscaleConnected: prereqs.tailscaleConnected,
+      sourceHost: prereqs.targetHost,
+    });
+
+    if (!prereqs.cliInstalled) {
+      const msg =
+        '[agentcookie-sync] agentcookie CLI not installed.\n' +
+        'Install from https://github.com/mvanhorn/agentcookie and re-run.';
+      await sendTelegram(msg).catch(() => undefined);
+      throw new Error('agentcookie CLI not found');
+    }
+
+    if (!prereqs.tailscaleConnected) {
+      const msg =
+        '[agentcookie-sync] Tailscale is not running — skipping sync.';
+      await sendTelegram(msg).catch(() => undefined);
+      // Not a hard error: Tailscale may be temporarily disconnected.
+      logJobEvent({
+        job: JOB,
+        event: 'skip',
+        reason: 'tailscale-not-connected',
+      });
+      return;
+    }
+
+    // 2. Discover what agentcookie would sync
+    let candidates: readonly string[];
+    try {
+      const evaluation = await evaluateSyncCandidates();
+      candidates = evaluation.domains;
+      logJobEvent({
+        job: JOB,
+        event: 'candidates-discovered',
+        count: candidates.length,
+      });
+    } catch (err) {
+      // agentcookie list failed — CLI may not be configured yet.
+      const msg =
+        '[agentcookie-sync] Could not list cookie candidates.\n' +
+        `Error: ${err instanceof Error ? err.message : String(err)}\n\n` +
+        'Run `agentcookie setup` on the source Mac first.';
+      await sendTelegram(msg).catch(() => undefined);
+      throw err;
+    }
+
+    // 3. Partition against blocklist + allowlist
+    const manifest = partitionDomains(candidates);
+
+    logJobEvent({
+      job: JOB,
+      event: 'manifest',
+      eligible: manifest.eligible.length,
+      blocked: manifest.blocked.length,
+      notInAllowlist: manifest.notInAllowlist.length,
+      eligibleDomains: manifest.eligible,
+      blockedDomains: manifest.blocked,
+    });
+
+    if (manifest.eligible.length === 0) {
+      logJobEvent({
+        job: JOB,
+        event: 'skip',
+        reason: 'no-eligible-domains',
+      });
+      return;
+    }
+
+    // 4. Sync (or dry-run)
+    const result = await runSync(TARGET_HOST, manifest.eligible, DRY_RUN);
+
+    logJobEvent({
+      job: JOB,
+      event: 'result',
+      ...result,
+    });
+
+    // 5. Alert on errors
+    if (result.errors.length > 0) {
+      const msg =
+        `[agentcookie-sync] ${result.errors.length} sync error(s):\n` +
+        result.errors.slice(0, 5).join('\n');
+      await sendTelegram(msg).catch(() => undefined);
+    }
+
+    // 6. Summary notification on live runs
+    if (!DRY_RUN && result.synced > 0) {
+      const msg =
+        `✅ agentcookie-sync: synced ${result.synced} domain(s) to ${TARGET_HOST} ` +
+        `in ${result.durationMs}ms`;
+      await sendTelegram(msg).catch(() => undefined);
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          mode: DRY_RUN ? 'dry-run' : 'live',
+          eligible: manifest.eligible,
+          blocked: manifest.blocked.length,
+          notInAllowlist: manifest.notInAllowlist.length,
+          result,
+        },
+        null,
+        2
+      )
+    );
+  });
+}
+
+main().catch(err => {
+  console.error('[agentcookie-sync] fatal:', err);
+  process.exit(1);
+});

--- a/scripts/hermes/launchd/pro/co.jovie.hermes.cron-agentcookie-sync.plist.template
+++ b/scripts/hermes/launchd/pro/co.jovie.hermes.cron-agentcookie-sync.plist.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  agentcookie-sync launchd plist — runs on the SOURCE Mac (daily-driver MBP).
+
+  Security gate: does nothing without AGENTCOOKIE_LIVE=1 in the environment.
+  Bootstrap: rendered by scripts/hermes/bootstrap-pro-launchd.sh.
+  Tim approval required before loading: launchctl load ~/Library/LaunchAgents/co.jovie.hermes.cron-agentcookie-sync.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-agentcookie-sync</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/agentcookie-sync.ts</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>1800</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>AGENTCOOKIE_TARGET_HOST</key>
+        <string>hermes-air</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.bun/bin:{{HOME}}/.hermes/bin:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-agentcookie-sync.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-agentcookie-sync.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/lib/__tests__/agentcookie.test.ts
+++ b/scripts/hermes/lib/__tests__/agentcookie.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COOKIE_ALLOWLIST,
+  COOKIE_BLOCKLIST,
+  isAllowed,
+  isBlocked,
+  partitionDomains,
+} from '../agentcookie';
+
+describe('agentcookie blocklist / allowlist', () => {
+  // -------------------------------------------------------------------
+  // isBlocked
+  // -------------------------------------------------------------------
+  describe('isBlocked', () => {
+    it('blocks exact blocklisted domains', () => {
+      for (const domain of ['stripe.com', 'github.com', 'chase.com']) {
+        expect(isBlocked(domain), `expected ${domain} to be blocked`).toBe(
+          true
+        );
+      }
+    });
+
+    it('blocks subdomains of blocklisted domains', () => {
+      expect(isBlocked('dashboard.stripe.com')).toBe(true);
+      expect(isBlocked('api.github.com')).toBe(true);
+      expect(isBlocked('sub.bankofamerica.com')).toBe(true);
+    });
+
+    it('does not block unrelated domains', () => {
+      expect(isBlocked('artists.spotify.com')).toBe(false);
+      expect(isBlocked('linear.app')).toBe(false);
+      expect(isBlocked('posthog.com')).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      expect(isBlocked('STRIPE.COM')).toBe(true);
+      expect(isBlocked('GitHub.com')).toBe(true);
+    });
+
+    it('strips leading dot before matching', () => {
+      expect(isBlocked('.stripe.com')).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // isAllowed
+  // -------------------------------------------------------------------
+  describe('isAllowed', () => {
+    it('allows exact allowlisted domains', () => {
+      for (const domain of ['artists.spotify.com', 'linear.app']) {
+        expect(isAllowed(domain), `expected ${domain} to be allowed`).toBe(
+          true
+        );
+      }
+    });
+
+    it('allows subdomains of allowlisted domains', () => {
+      // analytics.spotify.com is in the allowlist itself
+      expect(isAllowed('analytics.spotify.com')).toBe(true);
+    });
+
+    it('does not allow arbitrary domains', () => {
+      expect(isAllowed('example.com')).toBe(false);
+      expect(isAllowed('twitter.com')).toBe(false);
+      expect(isAllowed('youtube.com')).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      expect(isAllowed('Artists.Spotify.COM')).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // partitionDomains
+  // -------------------------------------------------------------------
+  describe('partitionDomains', () => {
+    it('partitions a mixed list correctly', () => {
+      const candidates = [
+        'artists.spotify.com', // allowed
+        'linear.app', // allowed
+        'stripe.com', // blocked
+        'github.com', // blocked
+        'example.com', // not in allowlist
+        'twitter.com', // not in allowlist
+      ];
+
+      const manifest = partitionDomains(candidates);
+
+      expect(manifest.eligible).toEqual(['artists.spotify.com', 'linear.app']);
+      expect(manifest.blocked).toEqual(['stripe.com', 'github.com']);
+      expect(manifest.notInAllowlist).toEqual(['example.com', 'twitter.com']);
+    });
+
+    it('returns empty arrays for an empty input', () => {
+      const manifest = partitionDomains([]);
+      expect(manifest.eligible).toHaveLength(0);
+      expect(manifest.blocked).toHaveLength(0);
+      expect(manifest.notInAllowlist).toHaveLength(0);
+    });
+
+    it('blocked takes precedence over not-in-allowlist', () => {
+      // A domain that is both blocked AND not in the allowlist should appear
+      // only in blocked (blocked check runs first).
+      const manifest = partitionDomains(['stripe.com']);
+      expect(manifest.blocked).toContain('stripe.com');
+      expect(manifest.notInAllowlist).not.toContain('stripe.com');
+      expect(manifest.eligible).not.toContain('stripe.com');
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Invariant: nothing in the allowlist should be blocked
+  // -------------------------------------------------------------------
+  describe('allowlist / blocklist mutual exclusivity', () => {
+    it('has no domain in both lists', () => {
+      for (const domain of COOKIE_ALLOWLIST) {
+        expect(
+          isBlocked(domain),
+          `${domain} is in COOKIE_ALLOWLIST but also matches COOKIE_BLOCKLIST`
+        ).toBe(false);
+      }
+    });
+
+    it('COOKIE_BLOCKLIST contains high-value financial and identity domains', () => {
+      expect(COOKIE_BLOCKLIST).toContain('stripe.com');
+      expect(COOKIE_BLOCKLIST).toContain('github.com');
+      expect(COOKIE_BLOCKLIST).toContain('1password.com');
+      expect(COOKIE_BLOCKLIST).toContain('aws.amazon.com');
+    });
+
+    it('COOKIE_ALLOWLIST contains the primary analytics targets', () => {
+      expect(COOKIE_ALLOWLIST).toContain('artists.spotify.com');
+      expect(COOKIE_ALLOWLIST).toContain('music.apple.com');
+    });
+  });
+});

--- a/scripts/hermes/lib/agentcookie.ts
+++ b/scripts/hermes/lib/agentcookie.ts
@@ -1,0 +1,323 @@
+/**
+ * agentcookie integration — Hermes-Air spike (JOV-3205 / GH-10930)
+ *
+ * Wraps the `agentcookie` CLI (mvanhorn/agentcookie) for one-way,
+ * encrypted cookie + bearer-token sync from the daily-driver Mac to
+ * the agent Mac over Tailscale (AES-256-GCM in transit).
+ *
+ * SECURITY POSTURE CHANGE — this replicates Tim's real logged-in sessions
+ * to the agent box. Defaults to DRY_RUN=true.  Never syncs without an
+ * explicit AGENTCOOKIE_LIVE=1 env var override AND Tailscale connectivity.
+ *
+ * Governance:
+ *   - In-perimeter (Tailscale): no vendor-cloud credential storage.
+ *   - Blocklist-first: only domains in ALLOWED_DOMAINS are eligible.
+ *   - Audit log written to ~/.hermes/logs/agentcookie.jsonl on every run.
+ */
+
+import { execFile } from 'node:child_process';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+import { HERMES_PATHS } from './hermes-paths';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Blocklist: domains whose cookies/tokens must NEVER be synced.
+// Add conservatively; removal requires explicit review.
+// ---------------------------------------------------------------------------
+export const COOKIE_BLOCKLIST: readonly string[] = [
+  // Banking & finance
+  'bankofamerica.com',
+  'chase.com',
+  'wellsfargo.com',
+  'schwab.com',
+  'fidelity.com',
+  'robinhood.com',
+  'mercury.com',
+
+  // Password managers & identity
+  '1password.com',
+  'bitwarden.com',
+  'keychain.apple.com',
+  'accounts.google.com', // Google identity — scope narrower if needed
+  'appleid.apple.com',
+
+  // Healthcare / HIPAA
+  'epic.com',
+  'mychart.com',
+
+  // Stripe & payments (handled via Doppler, not cookie sync)
+  'stripe.com',
+  'dashboard.stripe.com',
+
+  // Source code infra (use `gh auth` / Doppler instead)
+  'github.com',
+  'gitlab.com',
+
+  // Cloud providers (use IAM roles / Doppler)
+  'aws.amazon.com',
+  'console.cloud.google.com',
+  'portal.azure.com',
+  'vercel.com',
+  'neon.tech',
+
+  // Email — high blast-radius if agent box is compromised
+  'mail.google.com',
+  'outlook.live.com',
+
+  // Legal / government
+  'irs.gov',
+  'uscis.gov',
+];
+
+// ---------------------------------------------------------------------------
+// Allowlist: only these domain patterns may be considered for sync.
+// Conservative starting set for the spike — expand after Tim review.
+// ---------------------------------------------------------------------------
+export const COOKIE_ALLOWLIST: readonly string[] = [
+  // Authenticated analytics — primary motivation for this spike
+  'artists.spotify.com',
+  'analytics.spotify.com',
+  'music.apple.com',
+  'connect.apple.com',
+
+  // Social platform insights (read-only analytics sessions)
+  'instagram.com',
+  'creators.instagram.com',
+  'business.facebook.com',
+  'tiktok.com',
+
+  // Jovie tooling
+  'app.posthog.com',
+  'analytics.amplitude.com',
+
+  // Linear (read-only project management)
+  'linear.app',
+];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+export interface AgentcookiePrereqs {
+  readonly cliInstalled: boolean;
+  readonly tailscaleConnected: boolean;
+  readonly targetHost: string | null;
+}
+
+export interface SyncManifest {
+  readonly eligible: readonly string[];
+  readonly blocked: readonly string[];
+  readonly notInAllowlist: readonly string[];
+}
+
+export interface SyncResult {
+  readonly dryRun: boolean;
+  readonly synced: number;
+  readonly blocked: number;
+  readonly skipped: number;
+  readonly errors: readonly string[];
+  readonly durationMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Blocklist / allowlist helpers
+// ---------------------------------------------------------------------------
+
+/** Returns true if the domain (or any parent) is on the blocklist. */
+export function isBlocked(domain: string): boolean {
+  const d = domain.toLowerCase().replace(/^\./, '');
+  return COOKIE_BLOCKLIST.some(
+    blocked => d === blocked || d.endsWith(`.${blocked}`)
+  );
+}
+
+/** Returns true if the domain is within an explicitly allowed domain. */
+export function isAllowed(domain: string): boolean {
+  const d = domain.toLowerCase().replace(/^\./, '');
+  return COOKIE_ALLOWLIST.some(
+    allowed => d === allowed || d.endsWith(`.${allowed}`)
+  );
+}
+
+/**
+ * Given a list of candidate domains, partition into eligible, blocked, and
+ * not-in-allowlist buckets.
+ */
+export function partitionDomains(domains: readonly string[]): SyncManifest {
+  const eligible: string[] = [];
+  const blocked: string[] = [];
+  const notInAllowlist: string[] = [];
+
+  for (const domain of domains) {
+    if (isBlocked(domain)) {
+      blocked.push(domain);
+    } else if (!isAllowed(domain)) {
+      notInAllowlist.push(domain);
+    } else {
+      eligible.push(domain);
+    }
+  }
+
+  return { eligible, blocked, notInAllowlist };
+}
+
+// ---------------------------------------------------------------------------
+// Prerequisites check
+// ---------------------------------------------------------------------------
+
+/** Check whether agentcookie CLI is installed and Tailscale is up. */
+export async function checkPrerequisites(): Promise<AgentcookiePrereqs> {
+  const cliInstalled = await checkCli();
+  const { connected, host } = await checkTailscale();
+  return {
+    cliInstalled,
+    tailscaleConnected: connected,
+    targetHost: host,
+  };
+}
+
+async function checkCli(): Promise<boolean> {
+  try {
+    await execFileAsync('agentcookie', ['--version'], { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function checkTailscale(): Promise<{
+  connected: boolean;
+  host: string | null;
+}> {
+  try {
+    const { stdout } = await execFileAsync('tailscale', ['status', '--json'], {
+      timeout: 10_000,
+    });
+    const status = JSON.parse(stdout) as {
+      Self?: { HostName?: string };
+      BackendState?: string;
+    };
+    const connected = status.BackendState === 'Running';
+    const host = status.Self?.HostName ?? null;
+    return { connected, host };
+  } catch {
+    return { connected: false, host: null };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run evaluation (safe — no credentials leave the source machine)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run agentcookie in list mode to discover what would be synced.
+ * Never transfers credentials.
+ */
+export async function evaluateSyncCandidates(): Promise<{
+  readonly domains: readonly string[];
+  readonly rawOutput: string;
+}> {
+  const { stdout } = await execFileAsync(
+    'agentcookie',
+    ['list', '--format', 'json'],
+    { timeout: 30_000 }
+  );
+
+  const parsed = JSON.parse(stdout) as { domains?: string[] };
+  return {
+    domains: parsed.domains ?? [],
+    rawOutput: stdout,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Live sync (REQUIRES explicit AGENTCOOKIE_LIVE=1 env + Tailscale)
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a live credential sync to the target Tailscale host.
+ *
+ * Gated: only runs when AGENTCOOKIE_LIVE=1 is explicitly set.
+ * Only domains that pass the allowlist AND are not blocked are synced.
+ */
+export async function runSync(
+  targetHost: string,
+  eligibleDomains: readonly string[],
+  dryRun = true
+): Promise<SyncResult> {
+  const start = Date.now();
+
+  if (dryRun) {
+    writeAuditLog({
+      event: 'dry-run',
+      targetHost,
+      eligibleCount: eligibleDomains.length,
+    });
+    return {
+      dryRun: true,
+      synced: 0,
+      blocked: 0,
+      skipped: eligibleDomains.length,
+      errors: [],
+      durationMs: Date.now() - start,
+    };
+  }
+
+  if (process.env.AGENTCOOKIE_LIVE !== '1') {
+    throw new Error(
+      'agentcookie live sync requires AGENTCOOKIE_LIVE=1 env var. ' +
+        'This is a deliberate safety gate — set it only when Tim has approved.'
+    );
+  }
+
+  const errors: string[] = [];
+  let synced = 0;
+
+  for (const domain of eligibleDomains) {
+    try {
+      await execFileAsync(
+        'agentcookie',
+        ['push', '--domain', domain, '--target', targetHost, '--encrypt'],
+        { timeout: 30_000 }
+      );
+      synced++;
+    } catch (err) {
+      errors.push(
+        `${domain}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  const result: SyncResult = {
+    dryRun: false,
+    synced,
+    blocked: 0,
+    skipped: eligibleDomains.length - synced - errors.length,
+    errors,
+    durationMs: Date.now() - start,
+  };
+
+  writeAuditLog({ event: 'live-sync', targetHost, result });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Audit log (required for security-posture transparency)
+// ---------------------------------------------------------------------------
+const AUDIT_LOG = join(HERMES_PATHS.logsDir, 'agentcookie.jsonl');
+
+function writeAuditLog(entry: Record<string, unknown>): void {
+  try {
+    mkdirSync(join(homedir(), '.hermes', 'logs'), { recursive: true });
+    appendFileSync(
+      AUDIT_LOG,
+      `${JSON.stringify({ ...entry, ts: new Date().toISOString() })}\n`
+    );
+  } catch {
+    // never throw from audit log
+  }
+}

--- a/scripts/vitest.config.mts
+++ b/scripts/vitest.config.mts
@@ -1,9 +1,17 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  root: __dirname,
   test: {
     environment: 'node',
-    include: ['lib/__tests__/**/*.test.mjs'],
+    include: [
+      'lib/__tests__/**/*.test.mjs',
+      'hermes/lib/__tests__/**/*.test.ts',
+    ],
     name: 'workspace-scripts',
   },
 });


### PR DESCRIPTION
## Summary

Spike implementation for [GH-10930](https://github.com/JovieInc/Jovie/issues/10930): adopts `mvanhorn/agentcookie` for one-way, encrypted (AES-256-GCM over Tailscale) cookie + bearer-token sync from the daily-driver MBP to Hermes-Air.

**This is an eval/spike.** Nothing syncs until Tim explicitly sets `AGENTCOOKIE_LIVE=1`. The job is safe to run in dry-run mode immediately.

### Files changed

| File | Purpose |
|------|---------|
| `scripts/hermes/lib/agentcookie.ts` | Core module: blocklist, allowlist, `partitionDomains`, prerequisites check, dry-run + live sync |
| `scripts/hermes/jobs/agentcookie-sync.ts` | Cron job: dry-run by default, Tailscale pre-check, manifest logging, Telegram alerts |
| `scripts/hermes/launchd/pro/co.jovie.hermes.cron-agentcookie-sync.plist.template` | launchd plist for the source Mac (30-min schedule, `RunAtLoad=false`) |
| `scripts/hermes/lib/__tests__/agentcookie.test.ts` | 15 unit tests: blocklist, allowlist, partitioning, mutual-exclusivity invariants |
| `scripts/vitest.config.mts` | Root pin so hermes TS tests resolve from any CWD |

### Security design

- **Default = dry-run.** Nothing is transferred without `AGENTCOOKIE_LIVE=1`.
- **Allowlist-first model**: only explicitly listed domains are eligible (Spotify for Artists, Apple Music, Linear, social analytics).
- **Blocklist covers**: banking, identity/auth, payment infra (Stripe), source-control (GitHub), cloud IAM (AWS/GCP/Azure/Vercel/Neon), email — full list in `agentcookie.ts`.
- **In-perimeter only**: Tailscale check required before any attempt.
- **Audit log**: every run (dry or live) writes to `~/.hermes/logs/agentcookie.jsonl`.
- **Mutual exclusivity enforced by test**: no domain in the allowlist may also appear on the blocklist.

### To activate (after Tim's explicit go)

1. Install agentcookie on the source Mac: see [mvanhorn/agentcookie](https://github.com/mvanhorn/agentcookie)
2. Run `agentcookie setup` on the source Mac
3. Load the launchd plist (after rendering with `bootstrap-pro-launchd.sh`)
4. Set `AGENTCOOKIE_LIVE=1` in the plist's `EnvironmentVariables` dict

### Risks / follow-ups

- ToS exposure if sessions drive scraping — needs explicit ToS review before use on social platforms ([GH-10411](https://github.com/JovieInc/Jovie/issues/10411))
- Blast-radius if the agent box is compromised: mitigated by allowlist scope
- agentcookie's `list --format json` interface is assumed; verify against the actual CLI before activating
- `agentcookie push --domain --target --encrypt` flags need validation against actual CLI

## Test plan

- [x] 15 unit tests pass (`agentcookie.test.ts`): blocklist/allowlist matching, partition logic, mutual-exclusivity invariant
- [x] Pre-existing 5 failures in `workspace-scripts` are on `main` before this PR (confirmed via stash test)
- [x] Biome clean on all 5 changed files
- [x] Pre-push typecheck passed
- [x] Secret scan (gitleaks + trufflehog): no findings

Closes #10930

🤖 Generated with [Claude Code](https://claude.com/claude-code)