### PR TITLE
analytics: agent task result log + release-step classification + opportunity cycle time

### DIFF
--- a/apps/web/drizzle/migrations/0070_agent_task_analytics.sql
+++ b/apps/web/drizzle/migrations/0070_agent_task_analytics.sql
@@ -107,3 +107,4 @@ CREATE INDEX IF NOT EXISTS "release_cycle_step_events_user_release_idx"
 --> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "release_cycle_step_events_release_step_uniq"
   ON "release_cycle_step_events" ("release_id", "step");
+-- gate-evidence re-run trigger

--- a/apps/web/drizzle/migrations/0070_agent_task_analytics.sql
+++ b/apps/web/drizzle/migrations/0070_agent_task_analytics.sql
@@ -1,0 +1,109 @@
+-- #12140 / #12144 / #12145: agent-task analytics batch.
+-- Opportunity lifecycle timestamps, workflow-level step result log, and
+-- manual-vs-automated release-cycle step classification.
+
+-- #12140: opportunity lifecycle start. Backfill existing rows as created_at
+-- (labeled assumption per issue acceptance).
+ALTER TABLE "suggested_actions" ADD COLUMN IF NOT EXISTS "detected_at" timestamp with time zone;
+--> statement-breakpoint
+UPDATE "suggested_actions" SET "detected_at" = "created_at" WHERE "detected_at" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "suggested_actions" ALTER COLUMN "detected_at" SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE "suggested_actions" ALTER COLUMN "detected_at" SET NOT NULL;
+--> statement-breakpoint
+
+-- #12140: opportunity lifecycle end (set when a run reaches completed).
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "shipped_at" timestamp with time zone;
+--> statement-breakpoint
+
+-- #12145: workflow-level result log.
+CREATE TABLE IF NOT EXISTS "workflow_step_results" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "run_id" uuid NOT NULL,
+  "step" text NOT NULL,
+  "agent" text NOT NULL,
+  "status" text NOT NULL,
+  "tokens_in" integer,
+  "tokens_out" integer,
+  "cost_usd" numeric(12, 6),
+  "latency_ms" integer,
+  "linked_opportunity_id" uuid,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workflow_step_results_run_id_workflow_runs_id_fk'
+  ) THEN
+    ALTER TABLE "workflow_step_results"
+      ADD CONSTRAINT "workflow_step_results_run_id_workflow_runs_id_fk"
+      FOREIGN KEY ("run_id") REFERENCES "public"."workflow_runs"("id")
+      ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workflow_step_results_linked_opportunity_id_fk'
+  ) THEN
+    ALTER TABLE "workflow_step_results"
+      ADD CONSTRAINT "workflow_step_results_linked_opportunity_id_fk"
+      FOREIGN KEY ("linked_opportunity_id") REFERENCES "public"."suggested_actions"("id")
+      ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workflow_step_results_agent_created_idx"
+  ON "workflow_step_results" ("agent", "created_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workflow_step_results_run_id_idx"
+  ON "workflow_step_results" ("run_id");
+--> statement-breakpoint
+
+-- #12144: manual-vs-automated release-cycle step classification.
+CREATE TABLE IF NOT EXISTS "release_cycle_step_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "release_id" text NOT NULL,
+  "step" text NOT NULL,
+  "source" text NOT NULL,
+  "workflow_run_id" uuid,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'release_cycle_step_events_user_id_users_id_fk'
+  ) THEN
+    ALTER TABLE "release_cycle_step_events"
+      ADD CONSTRAINT "release_cycle_step_events_user_id_users_id_fk"
+      FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+      ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'release_cycle_step_events_workflow_run_id_workflow_runs_id_fk'
+  ) THEN
+    ALTER TABLE "release_cycle_step_events"
+      ADD CONSTRAINT "release_cycle_step_events_workflow_run_id_workflow_runs_id_fk"
+      FOREIGN KEY ("workflow_run_id") REFERENCES "public"."workflow_runs"("id")
+      ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "release_cycle_step_events_user_release_idx"
+  ON "release_cycle_step_events" ("user_id", "release_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "release_cycle_step_events_release_step_uniq"
+  ON "release_cycle_step_events" ("release_id", "step");

--- a/apps/web/drizzle/migrations/0070_agent_task_analytics.sql
+++ b/apps/web/drizzle/migrations/0070_agent_task_analytics.sql
@@ -107,4 +107,3 @@ CREATE INDEX IF NOT EXISTS "release_cycle_step_events_user_release_idx"
 --> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "release_cycle_step_events_release_step_uniq"
   ON "release_cycle_step_events" ("release_id", "step");
--- gate-evidence re-run trigger

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1783000050000,
       "tag": "0069_chat_message_feedback",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1783000100000,
+      "tag": "0070_agent_task_analytics",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/analytics/agent-task-metrics.test.ts
+++ b/apps/web/lib/analytics/agent-task-metrics.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDbInsert = vi.hoisted(() => vi.fn());
+const mockDbExecute = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: mockDbInsert,
+    execute: mockDbExecute,
+  },
+}));
+
+import {
+  getAgentTaskMetrics,
+  recordWorkflowStepResult,
+} from './agent-task-metrics';
+
+describe('recordWorkflowStepResult', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('inserts a step result row with normalized values', async () => {
+    const values = vi.fn().mockResolvedValue(undefined);
+    mockDbInsert.mockReturnValue({ values });
+
+    await recordWorkflowStepResult({
+      runId: 'run-1',
+      step: 'execute_approved_action',
+      agent: 'execute_approved_action',
+      status: 'success',
+      costUsd: 0.001234,
+      latencyMs: 812,
+      linkedOpportunityId: 'opp-1',
+    });
+
+    expect(values).toHaveBeenCalledWith({
+      runId: 'run-1',
+      step: 'execute_approved_action',
+      agent: 'execute_approved_action',
+      status: 'success',
+      tokensIn: null,
+      tokensOut: null,
+      costUsd: '0.001234',
+      latencyMs: 812,
+      linkedOpportunityId: 'opp-1',
+    });
+  });
+
+  it('is fail-soft: a throwing insert never propagates', async () => {
+    mockDbInsert.mockReturnValue({
+      values: vi.fn().mockRejectedValue(new Error('relation does not exist')),
+    });
+
+    await expect(
+      recordWorkflowStepResult({
+        runId: 'run-1',
+        step: 'step',
+        agent: 'agent',
+        status: 'failed',
+      })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('getAgentTaskMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps aggregate rows into per-agent metrics', async () => {
+    mockDbExecute.mockResolvedValue({
+      rows: [
+        {
+          agent: 'execute_approved_action',
+          total_tasks: 10,
+          success_count: 8,
+          override_count: 1,
+          retried_count: 1,
+          total_cost_usd: '0.500000',
+          opportunity_count: 5,
+          median_ttr_ms: 900,
+        },
+      ],
+    });
+
+    const [row] = await getAgentTaskMetrics({
+      since: new Date('2026-06-01T00:00:00Z'),
+      until: new Date('2026-07-01T00:00:00Z'),
+    });
+
+    expect(row).toEqual({
+      agent: 'execute_approved_action',
+      totalTasks: 10,
+      successRate: 0.8,
+      humanOverrideRate: 0.1,
+      retriedRate: 0.1,
+      totalCostUsd: 0.5,
+      costPerOpportunityUsd: 0.1,
+      medianTimeToResolutionMs: 900,
+    });
+  });
+
+  it('returns null cost-per-opportunity when no opportunities are linked', async () => {
+    mockDbExecute.mockResolvedValue({
+      rows: [
+        {
+          agent: 'a',
+          total_tasks: 2,
+          success_count: 2,
+          override_count: 0,
+          retried_count: 0,
+          total_cost_usd: null,
+          opportunity_count: 0,
+          median_ttr_ms: null,
+        },
+      ],
+    });
+
+    const [row] = await getAgentTaskMetrics({
+      since: new Date('2026-06-01T00:00:00Z'),
+      until: new Date('2026-07-01T00:00:00Z'),
+    });
+
+    expect(row.costPerOpportunityUsd).toBeNull();
+    expect(row.medianTimeToResolutionMs).toBeNull();
+    expect(row.totalCostUsd).toBe(0);
+  });
+});

--- a/apps/web/lib/analytics/agent-task-metrics.ts
+++ b/apps/web/lib/analytics/agent-task-metrics.ts
@@ -168,7 +168,8 @@ export async function getAgentTaskMetrics(
 
   return rows.map(row => {
     const total = Number(row.total_tasks) || 0;
-    const totalCost = row.total_cost_usd == null ? 0 : Number(row.total_cost_usd);
+    const totalCost =
+      row.total_cost_usd == null ? 0 : Number(row.total_cost_usd);
     const opportunities = Number(row.opportunity_count) || 0;
     return {
       agent: row.agent,

--- a/apps/web/lib/analytics/agent-task-metrics.ts
+++ b/apps/web/lib/analytics/agent-task-metrics.ts
@@ -1,0 +1,186 @@
+/**
+ * Agent task result log — workflow-level metrics (#12145).
+ *
+ * Records one `workflow_step_results` row per executed workflow step and
+ * derives multi-agent contribution metrics:
+ * - agent task success rate
+ * - % tasks requiring human override
+ * - automation throughput per agent
+ * - cost per revenue opportunity identified (Σ cost / count suggested_actions)
+ * - time-to-resolution per workflow chain (sum of step latencies)
+ * - hallucination correction rate (retried / total)
+ *
+ * LLM-level cost observability lives in Agnost/OpenTelemetry (#10360); this
+ * module is the workflow-run-level result layer that reconciles against it.
+ */
+
+import 'server-only';
+
+import { sql as drizzleSql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { workflowStepResults } from '@/lib/db/schema/connectors';
+import { logger } from '@/lib/utils/logger';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WorkflowStepResultStatus =
+  | 'success'
+  | 'failed'
+  | 'human_override'
+  | 'retried';
+
+export interface RecordWorkflowStepResultInput {
+  readonly runId: string;
+  readonly step: string;
+  readonly agent: string;
+  readonly status: WorkflowStepResultStatus;
+  readonly tokensIn?: number | null;
+  readonly tokensOut?: number | null;
+  readonly costUsd?: number | null;
+  readonly latencyMs?: number | null;
+  readonly linkedOpportunityId?: string | null;
+}
+
+export interface AgentTaskMetricsRow {
+  readonly agent: string;
+  /** Total step results in window (throughput per agent). */
+  readonly totalTasks: number;
+  /** success / total. */
+  readonly successRate: number;
+  /** human_override / total. */
+  readonly humanOverrideRate: number;
+  /** retried / total (hallucination correction rate). */
+  readonly retriedRate: number;
+  /** Σ cost_usd in window. */
+  readonly totalCostUsd: number;
+  /** Σ cost_usd / count(distinct linked_opportunity_id); null when no opportunities linked. */
+  readonly costPerOpportunityUsd: number | null;
+  /** Median of per-run summed step latency (time-to-resolution per workflow chain), ms. */
+  readonly medianTimeToResolutionMs: number | null;
+}
+
+export interface AgentTaskMetricsWindow {
+  readonly since: Date;
+  readonly until: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Record (fail-soft — instrumentation must never break the workflow)
+// ---------------------------------------------------------------------------
+
+export async function recordWorkflowStepResult(
+  input: RecordWorkflowStepResultInput
+): Promise<void> {
+  try {
+    await db.insert(workflowStepResults).values({
+      runId: input.runId,
+      step: input.step,
+      agent: input.agent,
+      status: input.status,
+      tokensIn: input.tokensIn ?? null,
+      tokensOut: input.tokensOut ?? null,
+      costUsd: input.costUsd != null ? input.costUsd.toFixed(6) : null,
+      latencyMs: input.latencyMs ?? null,
+      linkedOpportunityId: input.linkedOpportunityId ?? null,
+    });
+  } catch (err) {
+    // Fail-soft: a metrics write must never fail the workflow it observes.
+    logger.error('[agent-task-metrics] failed to record step result', {
+      runId: input.runId,
+      step: input.step,
+      agent: input.agent,
+      err,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-agent metrics over a time window. One query, grouped by agent.
+ */
+export async function getAgentTaskMetrics(
+  window: AgentTaskMetricsWindow
+): Promise<AgentTaskMetricsRow[]> {
+  const result = await db.execute<{
+    agent: string;
+    total_tasks: number;
+    success_count: number;
+    override_count: number;
+    retried_count: number;
+    total_cost_usd: string | null;
+    opportunity_count: number;
+    median_ttr_ms: number | null;
+  }>(drizzleSql`
+    WITH step_rows AS (
+      SELECT *
+      FROM workflow_step_results
+      WHERE created_at >= ${window.since} AND created_at < ${window.until}
+    ),
+    run_latency AS (
+      SELECT agent, run_id, SUM(COALESCE(latency_ms, 0)) AS run_latency_ms
+      FROM step_rows
+      GROUP BY agent, run_id
+    ),
+    run_median AS (
+      SELECT
+        agent,
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY run_latency_ms) AS median_ttr_ms
+      FROM run_latency
+      GROUP BY agent
+    )
+    SELECT
+      s.agent,
+      COUNT(*)::int AS total_tasks,
+      COUNT(*) FILTER (WHERE s.status = 'success')::int AS success_count,
+      COUNT(*) FILTER (WHERE s.status = 'human_override')::int AS override_count,
+      COUNT(*) FILTER (WHERE s.status = 'retried')::int AS retried_count,
+      SUM(s.cost_usd) AS total_cost_usd,
+      COUNT(DISTINCT s.linked_opportunity_id) FILTER (
+        WHERE s.linked_opportunity_id IS NOT NULL
+      )::int AS opportunity_count,
+      MAX(m.median_ttr_ms) AS median_ttr_ms
+    FROM step_rows s
+    LEFT JOIN run_median m ON m.agent = s.agent
+    GROUP BY s.agent
+    ORDER BY s.agent
+  `);
+
+  const rows =
+    (
+      result as {
+        rows?: Array<{
+          agent: string;
+          total_tasks: number;
+          success_count: number;
+          override_count: number;
+          retried_count: number;
+          total_cost_usd: string | null;
+          opportunity_count: number;
+          median_ttr_ms: number | null;
+        }>;
+      }
+    ).rows ?? [];
+
+  return rows.map(row => {
+    const total = Number(row.total_tasks) || 0;
+    const totalCost = row.total_cost_usd == null ? 0 : Number(row.total_cost_usd);
+    const opportunities = Number(row.opportunity_count) || 0;
+    return {
+      agent: row.agent,
+      totalTasks: total,
+      successRate: total > 0 ? Number(row.success_count) / total : 0,
+      humanOverrideRate: total > 0 ? Number(row.override_count) / total : 0,
+      retriedRate: total > 0 ? Number(row.retried_count) / total : 0,
+      totalCostUsd: totalCost,
+      costPerOpportunityUsd:
+        opportunities > 0 ? totalCost / opportunities : null,
+      medianTimeToResolutionMs:
+        row.median_ttr_ms == null ? null : Number(row.median_ttr_ms),
+    };
+  });
+}

--- a/apps/web/lib/analytics/opportunity-cycle-time.ts
+++ b/apps/web/lib/analytics/opportunity-cycle-time.ts
@@ -1,0 +1,103 @@
+/**
+ * Opportunity lifecycle cycle-time (#12140).
+ *
+ * cycle_time = workflow_runs.shipped_at − suggested_actions.detected_at,
+ * linked via workflow_runs.step_outputs ->> 'approvalId'.
+ *
+ * Aggregates median + p90 cycle time per opportunity type (suggested_actions.kind)
+ * and per artist (user), over a rolling window (default 30 days).
+ */
+
+import 'server-only';
+
+import { sql as drizzleSql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+
+export interface OpportunityCycleTimeQuery {
+  /** Window start (default: 30 days ago). */
+  readonly since?: Date;
+  /** Window end (default: now). */
+  readonly until?: Date;
+  /** Restrict to one artist/user. */
+  readonly userId?: string;
+}
+
+export interface OpportunityCycleTimeRow {
+  readonly userId: string;
+  /** Opportunity type = suggested_actions.kind. */
+  readonly kind: string;
+  readonly shippedCount: number;
+  readonly medianCycleTimeMs: number;
+  readonly p90CycleTimeMs: number;
+}
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Median + p90 opportunity→ship cycle time per artist, per opportunity type.
+ * Only counts opportunities whose linked run actually shipped in the window.
+ */
+export async function getOpportunityCycleTime(
+  query: OpportunityCycleTimeQuery = {}
+): Promise<OpportunityCycleTimeRow[]> {
+  const until = query.until ?? new Date();
+  const since = query.since ?? new Date(until.getTime() - THIRTY_DAYS_MS);
+
+  const userFilter = query.userId
+    ? drizzleSql`AND sa.user_id = ${query.userId}`
+    : drizzleSql``;
+
+  const result = await db.execute<{
+    user_id: string;
+    kind: string;
+    shipped_count: number;
+    median_cycle_ms: number | null;
+    p90_cycle_ms: number | null;
+  }>(drizzleSql`
+    WITH shipped AS (
+      SELECT
+        sa.user_id,
+        sa.kind,
+        EXTRACT(EPOCH FROM (wr.shipped_at - sa.detected_at)) * 1000
+          AS cycle_ms
+      FROM workflow_runs wr
+      JOIN suggested_actions sa
+        ON sa.id = (wr.step_outputs ->> 'approvalId')::uuid
+      WHERE wr.shipped_at IS NOT NULL
+        AND wr.shipped_at >= ${since}
+        AND wr.shipped_at < ${until}
+        AND wr.step_outputs ->> 'approvalId' IS NOT NULL
+        ${userFilter}
+    )
+    SELECT
+      user_id,
+      kind,
+      COUNT(*)::int AS shipped_count,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY cycle_ms) AS median_cycle_ms,
+      PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY cycle_ms) AS p90_cycle_ms
+    FROM shipped
+    GROUP BY user_id, kind
+    ORDER BY user_id, kind
+  `);
+
+  const rows =
+    (
+      result as {
+        rows?: Array<{
+          user_id: string;
+          kind: string;
+          shipped_count: number;
+          median_cycle_ms: number | null;
+          p90_cycle_ms: number | null;
+        }>;
+      }
+    ).rows ?? [];
+
+  return rows.map(row => ({
+    userId: row.user_id,
+    kind: row.kind,
+    shippedCount: Number(row.shipped_count) || 0,
+    medianCycleTimeMs: Math.max(0, Number(row.median_cycle_ms ?? 0)),
+    p90CycleTimeMs: Math.max(0, Number(row.p90_cycle_ms ?? 0)),
+  }));
+}

--- a/apps/web/lib/analytics/release-cycle-classification.test.ts
+++ b/apps/web/lib/analytics/release-cycle-classification.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: vi.fn(),
+    execute: vi.fn(),
+  },
+}));
+
+import {
+  RELEASE_CYCLE_STEP_KEYS,
+  RELEASE_CYCLE_STEPS,
+  deriveReleaseAutomationSummary,
+  isReleaseCycleStepKey,
+} from './release-cycle-classification';
+
+describe('RELEASE_CYCLE_STEPS', () => {
+  it('defines the canonical release-cycle step list per the demo workflow', () => {
+    expect(RELEASE_CYCLE_STEP_KEYS).toEqual([
+      'metadata',
+      'smart_links',
+      'pre_save',
+      'press',
+      'playlists',
+      'content_posts',
+      'fan_notifications',
+      'merch',
+      'reporting',
+    ]);
+  });
+
+  it('has unique keys and positive baseline minutes on every step', () => {
+    expect(new Set(RELEASE_CYCLE_STEP_KEYS).size).toBe(
+      RELEASE_CYCLE_STEPS.length
+    );
+    for (const step of RELEASE_CYCLE_STEPS) {
+      expect(step.baselineManualMinutes).toBeGreaterThan(0);
+    }
+  });
+
+  it('validates step keys', () => {
+    expect(isReleaseCycleStepKey('merch')).toBe(true);
+    expect(isReleaseCycleStepKey('not_a_step')).toBe(false);
+  });
+});
+
+describe('deriveReleaseAutomationSummary', () => {
+  it('counts automated, manual, skipped, and untracked steps', () => {
+    const summary = deriveReleaseAutomationSummary([
+      { step: 'metadata', source: 'automation' },
+      { step: 'smart_links', source: 'automation' },
+      { step: 'pre_save', source: 'manual' },
+      { step: 'press', source: 'skipped' },
+    ]);
+
+    expect(summary.automatedSteps).toBe(2);
+    expect(summary.manualSteps).toBe(1);
+    expect(summary.skippedSteps).toBe(1);
+    // 9 canonical steps − 4 recorded = 5 untracked
+    expect(summary.untrackedSteps).toBe(5);
+  });
+
+  it('derives manual tasks eliminated as the automated-step count', () => {
+    const summary = deriveReleaseAutomationSummary([
+      { step: 'metadata', source: 'automation' },
+      { step: 'merch', source: 'automation' },
+      { step: 'reporting', source: 'manual' },
+    ]);
+
+    expect(summary.manualTasksEliminated).toBe(2);
+  });
+
+  it('computes the time-saved proxy from per-step baseline minutes', () => {
+    const summary = deriveReleaseAutomationSummary([
+      { step: 'metadata', source: 'automation' }, // 30
+      { step: 'merch', source: 'automation' }, // 120
+      { step: 'press', source: 'manual' }, // not saved
+    ]);
+
+    expect(summary.timeSavedMinutes).toBe(150);
+  });
+
+  it('ignores unknown step keys and later events win per step', () => {
+    const summary = deriveReleaseAutomationSummary([
+      { step: 'bogus_step', source: 'automation' },
+      { step: 'metadata', source: 'manual' },
+      { step: 'metadata', source: 'automation' },
+    ]);
+
+    expect(summary.automatedSteps).toBe(1);
+    expect(summary.manualSteps).toBe(0);
+    expect(summary.manualTasksEliminated).toBe(1);
+  });
+
+  it('returns all-untracked for an empty event set', () => {
+    const summary = deriveReleaseAutomationSummary([]);
+    expect(summary.automatedSteps).toBe(0);
+    expect(summary.manualSteps).toBe(0);
+    expect(summary.skippedSteps).toBe(0);
+    expect(summary.untrackedSteps).toBe(RELEASE_CYCLE_STEPS.length);
+    expect(summary.manualTasksEliminated).toBe(0);
+    expect(summary.timeSavedMinutes).toBe(0);
+  });
+});

--- a/apps/web/lib/analytics/release-cycle-classification.test.ts
+++ b/apps/web/lib/analytics/release-cycle-classification.test.ts
@@ -8,10 +8,10 @@ vi.mock('@/lib/db', () => ({
 }));
 
 import {
-  RELEASE_CYCLE_STEP_KEYS,
-  RELEASE_CYCLE_STEPS,
   deriveReleaseAutomationSummary,
   isReleaseCycleStepKey,
+  RELEASE_CYCLE_STEP_KEYS,
+  RELEASE_CYCLE_STEPS,
 } from './release-cycle-classification';
 
 describe('RELEASE_CYCLE_STEPS', () => {

--- a/apps/web/lib/analytics/release-cycle-classification.ts
+++ b/apps/web/lib/analytics/release-cycle-classification.ts
@@ -108,10 +108,11 @@ export async function recordReleaseCycleStepEvent(
         },
       });
   } catch (err) {
-    logger.error(
-      '[release-cycle-classification] failed to record step event',
-      { releaseId: input.releaseId, step: input.step, err }
-    );
+    logger.error('[release-cycle-classification] failed to record step event', {
+      releaseId: input.releaseId,
+      step: input.step,
+      err,
+    });
   }
 }
 

--- a/apps/web/lib/analytics/release-cycle-classification.ts
+++ b/apps/web/lib/analytics/release-cycle-classification.ts
@@ -1,0 +1,212 @@
+/**
+ * Manual-vs-automated release-cycle step classification (#12144).
+ *
+ * Canonical release-cycle step list (anchored to the release-workflow demo,
+ * #8684), per-step baseline manual minutes, event recording, and the
+ * per-release automation summary that yields the VC-traction metric
+ * "N manual tasks eliminated per release cycle".
+ *
+ * BASELINE ASSUMPTION (labeled): the per-step manual-minutes baseline models
+ * what a non-Jovie artist does by hand, from the founder's 15-year workflow
+ * canon. It is a stated assumption, not a measurement.
+ */
+
+import 'server-only';
+
+import { sql as drizzleSql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { releaseCycleStepEvents } from '@/lib/db/schema/connectors';
+import { logger } from '@/lib/utils/logger';
+
+// ---------------------------------------------------------------------------
+// Canonical step list
+// ---------------------------------------------------------------------------
+
+export type ReleaseCycleStepSource = 'automation' | 'manual' | 'skipped';
+
+export interface ReleaseCycleStepDefinition {
+  readonly key: string;
+  readonly label: string;
+  /**
+   * Baseline minutes a non-Jovie artist spends doing this step manually.
+   * Labeled assumption (founder workflow canon), used for the time-saved proxy.
+   */
+  readonly baselineManualMinutes: number;
+}
+
+/** Canonical release-cycle steps, in lifecycle order (per #8684 demo workflow). */
+export const RELEASE_CYCLE_STEPS: readonly ReleaseCycleStepDefinition[] = [
+  { key: 'metadata', label: 'Release metadata', baselineManualMinutes: 30 },
+  { key: 'smart_links', label: 'Smart links', baselineManualMinutes: 25 },
+  { key: 'pre_save', label: 'Pre-save campaign', baselineManualMinutes: 30 },
+  { key: 'press', label: 'Press / EPK', baselineManualMinutes: 90 },
+  { key: 'playlists', label: 'Playlist pitching', baselineManualMinutes: 60 },
+  {
+    key: 'content_posts',
+    label: 'Content posts',
+    baselineManualMinutes: 45,
+  },
+  {
+    key: 'fan_notifications',
+    label: 'Fan notifications (SMS/email)',
+    baselineManualMinutes: 30,
+  },
+  { key: 'merch', label: 'Merch drop', baselineManualMinutes: 120 },
+  { key: 'reporting', label: 'Reporting', baselineManualMinutes: 30 },
+] as const;
+
+export const RELEASE_CYCLE_STEP_KEYS: readonly string[] =
+  RELEASE_CYCLE_STEPS.map(step => step.key);
+
+export function isReleaseCycleStepKey(key: string): boolean {
+  return RELEASE_CYCLE_STEP_KEYS.includes(key);
+}
+
+// ---------------------------------------------------------------------------
+// Recording (fail-soft)
+// ---------------------------------------------------------------------------
+
+export interface RecordReleaseCycleStepEventInput {
+  readonly userId: string;
+  readonly releaseId: string;
+  readonly step: string;
+  readonly source: ReleaseCycleStepSource;
+  readonly workflowRunId?: string | null;
+}
+
+/**
+ * Record how a release-cycle step was executed. Upserts on (releaseId, step)
+ * so re-runs keep the latest classification. Fail-soft: classification must
+ * never break the workflow that reports it.
+ */
+export async function recordReleaseCycleStepEvent(
+  input: RecordReleaseCycleStepEventInput
+): Promise<void> {
+  if (!isReleaseCycleStepKey(input.step)) {
+    logger.warn('[release-cycle-classification] unknown step key', {
+      step: input.step,
+      releaseId: input.releaseId,
+    });
+  }
+
+  try {
+    await db
+      .insert(releaseCycleStepEvents)
+      .values({
+        userId: input.userId,
+        releaseId: input.releaseId,
+        step: input.step,
+        source: input.source,
+        workflowRunId: input.workflowRunId ?? null,
+      })
+      .onConflictDoUpdate({
+        target: [releaseCycleStepEvents.releaseId, releaseCycleStepEvents.step],
+        set: {
+          source: input.source,
+          workflowRunId: input.workflowRunId ?? null,
+          createdAt: drizzleSql`now()`,
+        },
+      });
+  } catch (err) {
+    logger.error(
+      '[release-cycle-classification] failed to record step event',
+      { releaseId: input.releaseId, step: input.step, err }
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Derivation (pure — unit-testable without a DB)
+// ---------------------------------------------------------------------------
+
+export interface ReleaseStepClassification {
+  readonly step: string;
+  readonly source: ReleaseCycleStepSource;
+}
+
+export interface ReleaseAutomationSummary {
+  readonly automatedSteps: number;
+  readonly manualSteps: number;
+  readonly skippedSteps: number;
+  /** Canonical steps with no recorded event (untracked — counted as skipped-unknown). */
+  readonly untrackedSteps: number;
+  /**
+   * Baseline manual steps (all canonical steps, labeled assumption) minus
+   * steps actually done manually. Skipped/untracked steps do not count as
+   * eliminated — Jovie didn't do them.
+   */
+  readonly manualTasksEliminated: number;
+  /** Time-saved proxy: Σ baselineManualMinutes of automated steps. */
+  readonly timeSavedMinutes: number;
+}
+
+/**
+ * Derive the per-release summary from recorded step classifications.
+ * manual_tasks_eliminated = automated steps (each one would have been manual
+ * under the labeled baseline where a non-Jovie artist does every step by hand).
+ */
+export function deriveReleaseAutomationSummary(
+  events: readonly ReleaseStepClassification[]
+): ReleaseAutomationSummary {
+  const byStep = new Map<string, ReleaseCycleStepSource>();
+  for (const event of events) {
+    if (isReleaseCycleStepKey(event.step)) {
+      byStep.set(event.step, event.source);
+    }
+  }
+
+  let automatedSteps = 0;
+  let manualSteps = 0;
+  let skippedSteps = 0;
+  let untrackedSteps = 0;
+  let timeSavedMinutes = 0;
+
+  for (const definition of RELEASE_CYCLE_STEPS) {
+    const source = byStep.get(definition.key);
+    if (source === 'automation') {
+      automatedSteps += 1;
+      timeSavedMinutes += definition.baselineManualMinutes;
+    } else if (source === 'manual') {
+      manualSteps += 1;
+    } else if (source === 'skipped') {
+      skippedSteps += 1;
+    } else {
+      untrackedSteps += 1;
+    }
+  }
+
+  return {
+    automatedSteps,
+    manualSteps,
+    skippedSteps,
+    untrackedSteps,
+    manualTasksEliminated: automatedSteps,
+    timeSavedMinutes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+export async function getReleaseAutomationSummary(
+  releaseId: string
+): Promise<ReleaseAutomationSummary> {
+  const result = await db.execute<{
+    step: string;
+    source: ReleaseCycleStepSource;
+  }>(drizzleSql`
+    SELECT step, source
+    FROM release_cycle_step_events
+    WHERE release_id = ${releaseId}
+  `);
+
+  const rows =
+    (
+      result as {
+        rows?: Array<{ step: string; source: ReleaseCycleStepSource }>;
+      }
+    ).rows ?? [];
+
+  return deriveReleaseAutomationSummary(rows);
+}

--- a/apps/web/lib/connectors/workflows/execute-approved-action.ts
+++ b/apps/web/lib/connectors/workflows/execute-approved-action.ts
@@ -15,13 +15,13 @@
  */
 
 import { and, eq } from 'drizzle-orm';
+import { recordWorkflowStepResult } from '@/lib/analytics/agent-task-metrics';
 import type { CalendarApiClient } from '@/lib/connectors/google-calendar/create-event';
 import { createCalendarEvent } from '@/lib/connectors/google-calendar/create-event';
 import { db } from '@/lib/db';
 import { suggestedActions, workflowRuns } from '@/lib/db/schema/connectors';
 import { captureError } from '@/lib/error-tracking';
 import { logger } from '@/lib/utils/logger';
-import { recordWorkflowStepResult } from '@/lib/analytics/agent-task-metrics';
 import { recordWorkflowRunOutcome } from './outcome-attribution';
 
 /** Agent identifier written to workflow_step_results rows for this executor. */

--- a/apps/web/lib/connectors/workflows/execute-approved-action.ts
+++ b/apps/web/lib/connectors/workflows/execute-approved-action.ts
@@ -21,7 +21,11 @@ import { db } from '@/lib/db';
 import { suggestedActions, workflowRuns } from '@/lib/db/schema/connectors';
 import { captureError } from '@/lib/error-tracking';
 import { logger } from '@/lib/utils/logger';
+import { recordWorkflowStepResult } from '@/lib/analytics/agent-task-metrics';
 import { recordWorkflowRunOutcome } from './outcome-attribution';
+
+/** Agent identifier written to workflow_step_results rows for this executor. */
+const EXECUTOR_AGENT = 'execute_approved_action';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -42,7 +46,14 @@ export async function markWorkflowCompleted(
 ): Promise<void> {
   await db
     .update(workflowRuns)
-    .set({ status: 'completed', stepOutputs: result, updatedAt: new Date() })
+    .set({
+      status: 'completed',
+      stepOutputs: result,
+      // Opportunity lifecycle end (#12140): the automation's output is
+      // published/sent when the run reaches completed.
+      shippedAt: new Date(),
+      updatedAt: new Date(),
+    })
     .where(
       and(
         eq(workflowRuns.id, workflowRunId),
@@ -101,6 +112,7 @@ export async function executeApprovedAction(
   input: ExecuteApprovedActionInput
 ): Promise<void> {
   const { workflowRunId, calendarClient } = input;
+  const executionStartedAtMs = Date.now();
 
   // 1. Load the workflow_runs row
   const [run] = await db
@@ -185,10 +197,23 @@ export async function executeApprovedAction(
     });
 
     // 6. CAS: running → completed
-    await markWorkflowCompleted(
-      workflowRunId,
-      result as unknown as Record<string, unknown>
-    );
+    // Merge into existing stepOutputs so approvalId survives completion —
+    // the cycle-time join (#12140) and outcome attribution both read
+    // step_outputs ->> 'approvalId' on completed runs.
+    await markWorkflowCompleted(workflowRunId, {
+      ...stepOutputs,
+      ...(result as unknown as Record<string, unknown>),
+    });
+
+    // Workflow-level result log (#12145) — fail-soft, never throws.
+    await recordWorkflowStepResult({
+      runId: workflowRunId,
+      step: 'execute_approved_action',
+      agent: EXECUTOR_AGENT,
+      status: 'success',
+      latencyMs: Date.now() - executionStartedAtMs,
+      linkedOpportunityId: approvalId,
+    });
 
     logger.info('[execute-approved-action] Workflow completed', {
       workflowRunId,
@@ -207,5 +232,15 @@ export async function executeApprovedAction(
       approvalId,
     });
     await markWorkflowFailed(workflowRunId, errorMessage);
+
+    // Workflow-level result log (#12145) — fail-soft, never throws.
+    await recordWorkflowStepResult({
+      runId: workflowRunId,
+      step: 'execute_approved_action',
+      agent: EXECUTOR_AGENT,
+      status: 'failed',
+      latencyMs: Date.now() - executionStartedAtMs,
+      linkedOpportunityId: approvalId,
+    });
   }
 }

--- a/apps/web/lib/db/schema/connectors.ts
+++ b/apps/web/lib/db/schema/connectors.ts
@@ -467,6 +467,15 @@ export const suggestedActions = pgTable(
     executedAt: timestamp('executed_at', { withTimezone: true }),
     executionResult: jsonb('execution_result'),
 
+    /**
+     * When the detector emitted this opportunity (opportunity lifecycle start).
+     * Backfilled as `created_at` for pre-existing rows (labeled assumption).
+     * Cycle time = linked run's `shipped_at` − `detected_at`.
+     */
+    detectedAt: timestamp('detected_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -534,6 +543,12 @@ export const workflowRuns = pgTable(
      * cron tick so lambda timeouts cannot orphan rows in `running` forever.
      */
     leaseExpiresAt: timestamp('lease_expires_at', { withTimezone: true }),
+
+    /**
+     * When the run reached `completed` and its output was published/sent
+     * (opportunity lifecycle end). Set by the executor's completed transition.
+     */
+    shippedAt: timestamp('shipped_at', { withTimezone: true }),
 
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
@@ -610,3 +625,112 @@ export const insertWorkflowRunOutcomeSchema =
   createInsertSchema(workflowRunOutcomes);
 export const selectWorkflowRunOutcomeSchema =
   createSelectSchema(workflowRunOutcomes);
+
+// ---------------------------------------------------------------------------
+// workflow_step_results
+// ---------------------------------------------------------------------------
+
+/**
+ * Workflow-level result log (#12145): one row per executed workflow step,
+ * tying an agent task outcome to its cost and the opportunity it served.
+ *
+ * Powers: agent task success rate, % human override, throughput per agent,
+ * cost per opportunity identified, time-to-resolution per workflow chain,
+ * and hallucination correction rate (retried / total).
+ *
+ * `status` and `agent` are text (not enums) per the schema convention that
+ * new kinds must not require a migration. Known statuses:
+ * `success` | `failed` | `human_override` | `retried`.
+ */
+export const workflowStepResults = pgTable(
+  'workflow_step_results',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    runId: uuid('run_id')
+      .notNull()
+      .references(() => workflowRuns.id, { onDelete: 'cascade' }),
+    /** Step name within the workflow (matches `workflow_runs.current_step` vocabulary). */
+    step: text('step').notNull(),
+    /** Agent/executor identifier, e.g. `execute_approved_action`. */
+    agent: text('agent').notNull(),
+    status: text('status').notNull(),
+    tokensIn: integer('tokens_in'),
+    tokensOut: integer('tokens_out'),
+    /** LLM + execution cost in USD. Cross-checks against Agnost LLM-level cost. */
+    costUsd: numeric('cost_usd', { precision: 12, scale: 6 }),
+    latencyMs: integer('latency_ms'),
+    /** The suggested_action (opportunity) this step served, when known. */
+    linkedOpportunityId: uuid('linked_opportunity_id').references(
+      () => suggestedActions.id,
+      { onDelete: 'set null' }
+    ),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  t => [
+    index('workflow_step_results_agent_created_idx').on(t.agent, t.createdAt),
+    index('workflow_step_results_run_id_idx').on(t.runId),
+  ]
+);
+
+export type WorkflowStepResult = typeof workflowStepResults.$inferSelect;
+export type NewWorkflowStepResult = typeof workflowStepResults.$inferInsert;
+export const insertWorkflowStepResultSchema =
+  createInsertSchema(workflowStepResults);
+export const selectWorkflowStepResultSchema =
+  createSelectSchema(workflowStepResults);
+
+// ---------------------------------------------------------------------------
+// release_cycle_step_events
+// ---------------------------------------------------------------------------
+
+/**
+ * Manual-vs-automated release-cycle step classification (#12144).
+ * One row per (release, step) execution, tagged with how it was done:
+ * `automation` (workflow_run did it) | `manual` (artist action, no linked run)
+ * | `skipped`. Canonical step vocabulary lives in
+ * `lib/analytics/release-cycle-classification.ts`.
+ */
+export const releaseCycleStepEvents = pgTable(
+  'release_cycle_step_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    /** Release/catalog asset id (text, matching `workflow_run_outcomes.release_id`). */
+    releaseId: text('release_id').notNull(),
+    /** Canonical release-cycle step key (see RELEASE_CYCLE_STEPS). */
+    step: text('step').notNull(),
+    /** `automation` | `manual` | `skipped`. Text (not enum) — no migration for new sources. */
+    source: text('source').notNull(),
+    /** The workflow_run that executed this step, when source = automation. */
+    workflowRunId: uuid('workflow_run_id').references(() => workflowRuns.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  t => [
+    index('release_cycle_step_events_user_release_idx').on(
+      t.userId,
+      t.releaseId
+    ),
+    uniqueIndex('release_cycle_step_events_release_step_uniq').on(
+      t.releaseId,
+      t.step
+    ),
+  ]
+);
+
+export type ReleaseCycleStepEvent = typeof releaseCycleStepEvents.$inferSelect;
+export type NewReleaseCycleStepEvent =
+  typeof releaseCycleStepEvents.$inferInsert;
+export const insertReleaseCycleStepEventSchema = createInsertSchema(
+  releaseCycleStepEvents
+);
+export const selectReleaseCycleStepEventSchema = createSelectSchema(
+  releaseCycleStepEvents
+);


### PR DESCRIPTION
## Problem

Three VC-traction analytics metrics cannot be produced today: workflow-level agent task outcomes aren't logged (#12145), release-cycle steps aren't classified manual-vs-automated (#12144), and opportunity→ship cycle time has no timestamps to measure (#12140).

## What changed

One consolidated analytics batch (all `area:analytics`):

**#12140 — Opportunity lifecycle cycle-time**
- `suggested_actions.detected_at` (timestamptz, NOT NULL, default now; backfilled as `created_at` — labeled assumption per issue acceptance)
- `workflow_runs.shipped_at` (timestamptz), set on the executor's `running → completed` transition
- `lib/analytics/opportunity-cycle-time.ts`: median + p90 cycle time per artist per opportunity type, rolling 30-day default, joined via `step_outputs ->> 'approvalId'`

**#12145 — Agent task result log**
- New `workflow_step_results` table: `{ run_id, step, agent, status, tokens_in, tokens_out, cost_usd, latency_ms, linked_opportunity_id }`
- `lib/analytics/agent-task-metrics.ts`: fail-soft `recordWorkflowStepResult()` + `getAgentTaskMetrics()` returning per-agent success rate, human-override %, throughput, Σ cost, cost-per-opportunity, median time-to-resolution (per-run summed latency), retried rate (hallucination-correction proxy)
- Wired into `execute-approved-action.ts` success + failure paths (latency measured from executor entry)

**#12144 — Manual-vs-automated release-cycle classification**
- New `release_cycle_step_events` table (upsert-unique on `(release_id, step)`)
- `lib/analytics/release-cycle-classification.ts`: canonical `RELEASE_CYCLE_STEPS` list (metadata, smart links, pre-save, press, playlists, content posts, fan notifications, merch, reporting — per #8684 demo workflow) with per-step baseline manual minutes (labeled assumption, founder workflow canon); `recordReleaseCycleStepEvent()`; `deriveReleaseAutomationSummary()` (pure, unit-tested) + `getReleaseAutomationSummary()` query

Also: `markWorkflowCompleted` caller now merges the result into existing `stepOutputs` instead of replacing them, so `approvalId` survives completion — the cycle-time join, the `workflow_runs_execute_approved_action_approval_uniq` index, and existing outcome attribution all read `step_outputs ->> 'approvalId'` on completed runs and were silently losing it.

## Assumptions

- `detected_at` backfill = `created_at` for pre-existing rows (issue-mandated labeled assumption).
- `manual_tasks_eliminated` = count of automated steps (conservative reading: a skipped/untracked step was not eliminated by Jovie — the literal issue formula `baseline − actual manual` would count skipped steps as wins). Baseline minutes per step are stated assumptions, not measurements.
- #12145 lists #10367 (workflow registry) and #10360 (Agnost) as dependencies. The result log lands independently: `agent`/`step` are text (no enum) so registry typing slots in later, and `cost_usd`/`tokens_*` are nullable until the Agnost LLM-cost layer feeds them. Conservative call: don't block the row schema on either.
- gbrain FTS had no canonical analytics-pattern pages for this surface (queried, empty) — followed the existing `workflow_run_outcomes` / `outcome-attribution.ts` in-repo pattern instead.

## Verification

Sandbox could not run the local gate: `registry.npmjs.org` is blocked (403 via egress proxy; network-access request not granted this run), so `pnpm install` was impossible.

```
$ curl -s -o /dev/null -w "%{http_code}" https://registry.npmjs.org/pnpm
403
```

Compensating controls: opened as **draft**; CI runs the same gates locally required (`ci-fast` typecheck/biome, `Unit Tests`, `Structural Contract`, build). Will promote to ready only when CI is green. New unit tests: `lib/analytics/release-cycle-classification.test.ts`, `lib/analytics/agent-task-metrics.test.ts` (mocked db, matching `outcome-attribution.test.ts` patterns).

## Cost Impact

- **External API calls**: none.
- **DB writes**: +1 `workflow_step_results` insert per workflow step execution (fail-soft), +1 upsert per release-cycle step classification. O(1) per workflow run; no cron, no polling.
- **Queries**: analytics reads are on-demand aggregate queries (indexed on `agent, created_at` / `run_id` / `user_id, release_id`).

## Migration

`0070_agent_task_analytics.sql` — additive only (2 columns, 2 tables, indexes), idempotent guards (`IF NOT EXISTS` / conname checks), constraint names ≤63 chars. No snapshot file (matches 0068/0069 convention). Backfill `UPDATE` touches only rows where `detected_at IS NULL`.

Closes #12145
Closes #12144
Closes #12140

Dispatch: analytics-metrics-batch (Zoe → Fable Developer, 2026-07-05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
