### PR TITLE
fix(onboarding): silence welcome chat bootstrap failure toast (JOV-2955)

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -172,7 +172,7 @@ function getWelcomeChatBootstrapAnnouncement(
     case 'scheduled':
       return 'Still setting up your onboarding chat. Retrying now.';
     case 'failed':
-      return 'We could not start your onboarding chat. Refresh to try again.';
+      return '';
     default:
       return '';
   }
@@ -705,10 +705,9 @@ export function ChatPageClient({
         welcomeChatRetryCountRef.current >=
           WELCOME_CHAT_BOOTSTRAP_RETRY_DELAYS_MS.length
       ) {
-        setWelcomeChatBootstrapStatus('failed');
-        notifications.error(
-          'We could not start your onboarding chat. Refresh to try again.'
-        );
+        // Welcome chat bootstrap is a non-blocking enhancement. The chat shell
+        // remains usable even when auto-creating the welcome thread fails.
+        setWelcomeChatBootstrapStatus('done');
         return;
       }
 

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -532,4 +532,27 @@ describe('ChatPageClient', () => {
       'Starting your onboarding chat.'
     );
   });
+
+  it('does not show a destructive toast after welcome chat bootstrap retries exhaust', async () => {
+    vi.useFakeTimers();
+    mockSearchParams = new URLSearchParams('from=onboarding');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(null, {
+            status: 503,
+            statusText: 'Service Unavailable',
+          })
+        )
+      )
+    );
+
+    renderChatPage();
+
+    await vi.runAllTimersAsync();
+
+    expect(mockErrorNotification).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
 });


### PR DESCRIPTION
Auto-opened by autopilot for orphaned Codex branch. Branch may need rebase onto main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved welcome chat startup handling so exhausted or blocked retries no longer surface as an error state.
  * Suppressed the error announcement/notification for failed bootstrap attempts, reducing unnecessary alerts for users and screen readers.
  * Added coverage to ensure retry exhaustion does not show a destructive toast or alert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->