### PR TITLE
feat(onboarding): qualifying interview scoring — admit-or-waitlist with problem capture

### DIFF
--- a/apps/web/app/api/onboarding/intake/route.ts
+++ b/apps/web/app/api/onboarding/intake/route.ts
@@ -22,6 +22,7 @@ import {
   submitWaitlistAccessRequest,
   type WaitlistAccessOutcome,
 } from '@/lib/waitlist/access-request';
+import { scoreOnboardingInterview } from '@/lib/waitlist/interview-scoring';
 
 export const runtime = 'nodejs';
 
@@ -235,12 +236,31 @@ export async function POST(request: Request) {
     });
     const dbUser = await ensureIntakeUser({ clerkUserId, email: emailRaw });
 
+    const interviewResponses = {
+      currentWorkflow: parsed.data.metadata.currentWorkflow ?? null,
+      biggestBlocker: parsed.data.metadata.biggestBlocker ?? null,
+      launchGoal: parsed.data.metadata.launchGoal ?? null,
+    };
+    const interviewScore = scoreOnboardingInterview({
+      payload: parsed.data.waitlist,
+      responses: interviewResponses,
+    });
+    // Enrich the stored interview with the canonical problem statement and
+    // the deterministic score so Eve can query demand signal directly from
+    // `user_interviews.metadata` without re-deriving it.
+    const interviewMetadata = {
+      ...parsed.data.metadata,
+      problemStatement: interviewResponses.biggestBlocker,
+      interviewScore: interviewScore.score,
+      interviewSignals: interviewScore.signals,
+    };
+
     let interviewId: string;
     try {
       interviewId = await upsertOnboardingInterview({
         userId: dbUser.id,
         transcript: parsed.data.transcript,
-        metadata: parsed.data.metadata,
+        metadata: interviewMetadata,
       });
     } catch (error) {
       await captureError('onboarding intake transcript save failed', error, {
@@ -259,6 +279,7 @@ export async function POST(request: Request) {
       fullName,
       data: parsed.data.waitlist,
       source: 'onboarding_chat',
+      interviewResponses,
     });
 
     // Best-effort attach of the access decision to the interview row. The
@@ -270,7 +291,7 @@ export async function POST(request: Request) {
       await upsertOnboardingInterview({
         userId: dbUser.id,
         transcript: parsed.data.transcript,
-        metadata: parsed.data.metadata,
+        metadata: interviewMetadata,
         outcome: access.outcome,
         waitlistEntryId: access.entryId,
       });

--- a/apps/web/lib/db/schema/user-interviews.ts
+++ b/apps/web/lib/db/schema/user-interviews.ts
@@ -48,6 +48,12 @@ export interface InterviewMetadata {
   submittedFrom?: string | null;
   summary_structured?: InterviewSummaryStructured | null;
   summary_error?: string | null;
+  /** Canonical problem statement captured for demand analysis (Eve). */
+  problemStatement?: string | null;
+  /** Deterministic admit-or-waitlist score (0-100) from interview-scoring. */
+  interviewScore?: number | null;
+  /** Signal names that contributed to interviewScore. */
+  interviewSignals?: readonly string[] | null;
 }
 
 export const userInterviews = pgTable(

--- a/apps/web/lib/waitlist/access-request.ts
+++ b/apps/web/lib/waitlist/access-request.ts
@@ -21,6 +21,10 @@ import {
 import { insertWaitlistAuditLog } from '@/lib/waitlist/audit';
 import { enqueueWaitlistEmailJob } from '@/lib/waitlist/email-jobs';
 import {
+  type InterviewResponses,
+  scoreOnboardingInterview,
+} from '@/lib/waitlist/interview-scoring';
+import {
   evaluateWaitlistQualification,
   type QualificationDecision,
 } from '@/lib/waitlist/qualification';
@@ -52,6 +56,12 @@ export interface WaitlistAccessRequestInput {
   readonly fullName: string;
   readonly data: WaitlistRequestPayload;
   readonly source?: string;
+  /**
+   * Free-text answers from the qualifying onboarding interview. When
+   * provided, they are scored deterministically and can admit a gate-on
+   * signup (`qualified_interview_signal`).
+   */
+  readonly interviewResponses?: InterviewResponses;
 }
 
 export interface WaitlistAccessRequestResult {
@@ -248,6 +258,7 @@ async function decideAccess(params: {
   readonly emailRaw: string;
   readonly email: string;
   readonly data: WaitlistRequestPayload;
+  readonly interviewResponses?: InterviewResponses;
 }): Promise<{
   readonly outcome: WaitlistAccessOutcome;
   readonly approval: WaitlistApprovalResult | null;
@@ -264,10 +275,16 @@ async function decideAccess(params: {
 
   const settings = await getWaitlistSettings(params.tx);
   const mode = settings.gateEnabled ? 'waitlist_enabled' : 'open_signup';
+  const interview = params.interviewResponses
+    ? scoreOnboardingInterview({
+        payload: params.data,
+        responses: params.interviewResponses,
+      })
+    : null;
   const qualification = evaluateWaitlistQualification({
     email: params.email,
     payload: params.data,
-    config: { mode },
+    config: { mode, interview },
   });
 
   if (qualification.status === 'blocked') {
@@ -459,6 +476,7 @@ export async function submitWaitlistAccessRequest(
           emailRaw,
           email: normalizedEmail,
           data: input.data,
+          interviewResponses: input.interviewResponses,
         });
 
         const nextStatus = decision.qualification.status;

--- a/apps/web/lib/waitlist/interview-scoring.ts
+++ b/apps/web/lib/waitlist/interview-scoring.ts
@@ -1,0 +1,128 @@
+import type { WaitlistRequestPayload } from '@/lib/validation/schemas';
+
+/**
+ * Deterministic scorer for the qualifying onboarding interview (JOV-3380).
+ *
+ * Scores the intake-chat answers to decide admit-vs-waitlist when the
+ * waitlist gate is ON. This intentionally mirrors the philosophy of
+ * `lib/chat/tools/onboarding-access-eval.ts` (server owns the decision,
+ * never an LLM) but operates on the structured intake-form payload used by
+ * `POST /api/onboarding/intake` rather than chat-tool signal.
+ *
+ * Pure function, no I/O — safe to call from routes and inside the
+ * access-request transaction path.
+ */
+
+export interface InterviewResponses {
+  /** "What are you working on or releasing next?" */
+  readonly currentWorkflow?: string | null;
+  /** "What is the most annoying part of that workflow right now?" */
+  readonly biggestBlocker?: string | null;
+  /** "What would make Jovie obviously useful for you this quarter?" */
+  readonly launchGoal?: string | null;
+}
+
+export interface InterviewScoreInput {
+  readonly payload: WaitlistRequestPayload;
+  readonly responses: InterviewResponses;
+}
+
+export interface InterviewScoreResult {
+  /** 0-100 aggregate intent score. */
+  readonly score: number;
+  /** True when the score clears INTERVIEW_ADMIT_THRESHOLD. */
+  readonly admit: boolean;
+  /** Signal names that contributed to the score (for audit + Eve analysis). */
+  readonly signals: readonly string[];
+}
+
+/** Score at or above which a gate-on signup is admitted with full access. */
+export const INTERVIEW_ADMIT_THRESHOLD = 60;
+
+/** Release-cycle language indicating an active, near-term music workflow. */
+const ACTIVE_RELEASE_PATTERN =
+  /\b(releas\w*|single|ep|album|mixtape|tour\w*|drop\w*|rollout|distribut\w*|pre-?save|catalog|show|gig|festival)\b/i;
+
+/** Role language indicating a high-intent artist/manager/label persona. */
+const HIGH_INTENT_ROLE_PATTERN =
+  /\b(artist|band|manager|label|producer|songwriter|dj|booking)\b/i;
+
+/** Minimum trimmed length for a problem statement to count as substantive. */
+const SUBSTANTIVE_PROBLEM_MIN_LENGTH = 20;
+
+function hasText(value: string | null | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Score the qualifying interview and return an admit-or-waitlist
+ * recommendation.
+ *
+ * Signal weights (capped at 100):
+ *  - Spotify artist identity (URL + name)                 +30
+ *  - Spotify URL alone                                    +15
+ *  - Active release language in workflow/goal answers     +25
+ *  - Substantive problem statement (biggest blocker)      +20
+ *  - High-intent role language anywhere in answers        +10
+ *  - Paid plan interest                                   +15
+ *
+ * Threshold 60 is deliberately conservative: an artist with a Spotify
+ * identity, an active release, and a real problem statement clears it;
+ * empty or low-signal submissions stay waitlisted (demand-gated growth).
+ */
+export function scoreOnboardingInterview(
+  input: InterviewScoreInput
+): InterviewScoreResult {
+  const { payload, responses } = input;
+  const signals: string[] = [];
+  let score = 0;
+
+  const hasSpotifyUrl = hasText(payload.spotifyUrl);
+  const hasSpotifyName = hasText(payload.spotifyArtistName);
+  if (hasSpotifyUrl && hasSpotifyName) {
+    score += 30;
+    signals.push('spotify_artist_identity');
+  } else if (hasSpotifyUrl) {
+    score += 15;
+    signals.push('spotify_url');
+  }
+
+  const workflowText = [responses.currentWorkflow, responses.launchGoal]
+    .filter(hasText)
+    .join(' ');
+  if (ACTIVE_RELEASE_PATTERN.test(workflowText)) {
+    score += 25;
+    signals.push('active_release_language');
+  }
+
+  const problemStatement = responses.biggestBlocker?.trim() ?? '';
+  if (problemStatement.length >= SUBSTANTIVE_PROBLEM_MIN_LENGTH) {
+    score += 20;
+    signals.push('substantive_problem_statement');
+  }
+
+  const allAnswerText = [
+    responses.currentWorkflow,
+    responses.biggestBlocker,
+    responses.launchGoal,
+    payload.heardAbout,
+  ]
+    .filter(hasText)
+    .join(' ');
+  if (HIGH_INTENT_ROLE_PATTERN.test(allAnswerText)) {
+    score += 10;
+    signals.push('high_intent_role');
+  }
+
+  if (hasText(payload.selectedPlan) && payload.selectedPlan !== 'free') {
+    score += 15;
+    signals.push('paid_plan_interest');
+  }
+
+  const finalScore = Math.min(score, 100);
+  return {
+    score: finalScore,
+    admit: finalScore >= INTERVIEW_ADMIT_THRESHOLD,
+    signals,
+  };
+}

--- a/apps/web/lib/waitlist/qualification.ts
+++ b/apps/web/lib/waitlist/qualification.ts
@@ -5,6 +5,7 @@ export type WaitlistMode = 'open_signup' | 'waitlist_enabled' | 'hard_closed';
 export type QualificationReasonCode =
   | 'qualified_open_signup'
   | 'qualified_auto_accept'
+  | 'qualified_interview_signal'
   | 'waitlist_gate_enabled'
   | 'waitlist_capacity_full'
   | 'hard_closed'
@@ -15,6 +16,17 @@ export interface QualificationConfig {
   readonly mode: WaitlistMode;
   readonly autoAcceptReserved?: boolean;
   readonly blockedEmailDomains?: readonly string[];
+  /**
+   * Deterministic interview-score result from
+   * `lib/waitlist/interview-scoring.ts`. When present and `admit` is true,
+   * a gate-on signup is approved instead of waitlisted
+   * (`qualified_interview_signal`).
+   */
+  readonly interview?: {
+    readonly score: number;
+    readonly admit: boolean;
+    readonly signals: readonly string[];
+  } | null;
 }
 
 export interface QualificationDecision {
@@ -82,6 +94,19 @@ export function evaluateWaitlistQualification(params: {
       status: 'approved',
       reasonCode: 'qualified_open_signup',
       details: { mode: params.config.mode },
+    };
+  }
+
+  if (params.config.interview?.admit) {
+    return {
+      qualified: true,
+      status: 'approved',
+      reasonCode: 'qualified_interview_signal',
+      details: {
+        mode: params.config.mode,
+        interviewScore: params.config.interview.score,
+        interviewSignals: params.config.interview.signals,
+      },
     };
   }
 

--- a/apps/web/tests/unit/lib/waitlist/interview-scoring.test.ts
+++ b/apps/web/tests/unit/lib/waitlist/interview-scoring.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { WaitlistRequestPayload } from '@/lib/validation/schemas';
+import {
+  INTERVIEW_ADMIT_THRESHOLD,
+  scoreOnboardingInterview,
+} from '@/lib/waitlist/interview-scoring';
+
+const basePayload = {
+  primaryGoal: null,
+  primarySocialUrl: 'https://instagram.com/example',
+  spotifyUrl: null,
+  spotifyArtistName: null,
+  heardAbout: null,
+  selectedPlan: null,
+} satisfies WaitlistRequestPayload;
+
+describe('scoreOnboardingInterview', () => {
+  it('admits a high-intent artist with Spotify identity, active release, and a real problem statement', () => {
+    const result = scoreOnboardingInterview({
+      payload: {
+        ...basePayload,
+        spotifyUrl: 'https://open.spotify.com/artist/abc123',
+        spotifyArtistName: 'Example Artist',
+      },
+      responses: {
+        currentWorkflow: 'Releasing a single next month with a small tour',
+        biggestBlocker:
+          'Coordinating pre-save links and fan follow-up takes me days every release',
+        launchGoal: 'Get the rollout automated end to end',
+      },
+    });
+
+    expect(result.admit).toBe(true);
+    expect(result.score).toBeGreaterThanOrEqual(INTERVIEW_ADMIT_THRESHOLD);
+    expect(result.signals).toContain('spotify_artist_identity');
+    expect(result.signals).toContain('active_release_language');
+    expect(result.signals).toContain('substantive_problem_statement');
+  });
+
+  it('waitlists an empty or low-signal submission', () => {
+    const result = scoreOnboardingInterview({
+      payload: basePayload,
+      responses: {
+        currentWorkflow: 'stuff',
+        biggestBlocker: 'idk',
+        launchGoal: null,
+      },
+    });
+
+    expect(result.admit).toBe(false);
+    expect(result.score).toBeLessThan(INTERVIEW_ADMIT_THRESHOLD);
+    expect(result.signals).toHaveLength(0);
+  });
+
+  it('gives partial credit for a Spotify URL without an artist name', () => {
+    const withName = scoreOnboardingInterview({
+      payload: {
+        ...basePayload,
+        spotifyUrl: 'https://open.spotify.com/artist/abc123',
+        spotifyArtistName: 'Example Artist',
+      },
+      responses: {},
+    });
+    const withoutName = scoreOnboardingInterview({
+      payload: {
+        ...basePayload,
+        spotifyUrl: 'https://open.spotify.com/artist/abc123',
+      },
+      responses: {},
+    });
+
+    expect(withName.score).toBeGreaterThan(withoutName.score);
+    expect(withoutName.signals).toContain('spotify_url');
+    expect(withoutName.signals).not.toContain('spotify_artist_identity');
+  });
+
+  it('counts paid plan interest and role language as signal', () => {
+    const result = scoreOnboardingInterview({
+      payload: { ...basePayload, selectedPlan: 'pro' },
+      responses: {
+        currentWorkflow: 'I manage three artists at an indie label',
+      },
+    });
+
+    expect(result.signals).toContain('paid_plan_interest');
+    expect(result.signals).toContain('high_intent_role');
+  });
+
+  it('never scores above 100 and stays deterministic', () => {
+    const input = {
+      payload: {
+        ...basePayload,
+        spotifyUrl: 'https://open.spotify.com/artist/abc123',
+        spotifyArtistName: 'Example Artist',
+        selectedPlan: 'pro',
+        heardAbout: 'A producer friend',
+      },
+      responses: {
+        currentWorkflow: 'Album rollout with a festival tour as an artist',
+        biggestBlocker:
+          'Keeping every DSP profile, smart link, and merch drop in sync',
+        launchGoal: 'Automate the release checklist',
+      },
+    } as const;
+
+    const first = scoreOnboardingInterview(input);
+    const second = scoreOnboardingInterview(input);
+
+    expect(first.score).toBeLessThanOrEqual(100);
+    expect(first).toEqual(second);
+  });
+});

--- a/apps/web/tests/unit/lib/waitlist/qualification.test.ts
+++ b/apps/web/tests/unit/lib/waitlist/qualification.test.ts
@@ -54,6 +54,63 @@ describe('evaluateWaitlistQualification', () => {
     });
   });
 
+  it('admits gate-on signups when the interview score clears the threshold', () => {
+    expect(
+      evaluateWaitlistQualification({
+        email: 'artist@example.com',
+        payload,
+        config: {
+          mode: 'waitlist_enabled',
+          interview: {
+            score: 75,
+            admit: true,
+            signals: ['spotify_artist_identity', 'active_release_language'],
+          },
+        },
+      })
+    ).toMatchObject({
+      qualified: true,
+      status: 'approved',
+      reasonCode: 'qualified_interview_signal',
+      details: { interviewScore: 75 },
+    });
+  });
+
+  it('keeps gate-on signups waitlisted when the interview score is below threshold', () => {
+    expect(
+      evaluateWaitlistQualification({
+        email: 'artist@example.com',
+        payload,
+        config: {
+          mode: 'waitlist_enabled',
+          interview: { score: 20, admit: false, signals: [] },
+        },
+      })
+    ).toMatchObject({
+      qualified: true,
+      status: 'waitlisted',
+      reasonCode: 'waitlist_gate_enabled',
+    });
+  });
+
+  it('does not let interview signal bypass a blocked email domain', () => {
+    expect(
+      evaluateWaitlistQualification({
+        email: 'artist@blocked.test',
+        payload,
+        config: {
+          mode: 'waitlist_enabled',
+          blockedEmailDomains: ['blocked.test'],
+          interview: { score: 100, admit: true, signals: ['spotify_url'] },
+        },
+      })
+    ).toMatchObject({
+      qualified: false,
+      status: 'blocked',
+      reasonCode: 'blocked_email_domain',
+    });
+  });
+
   it('blocks configured email domains', () => {
     expect(
       evaluateWaitlistQualification({


### PR DESCRIPTION
## Problem
With the waitlist gate ON, the onboarding intake pipeline waitlists every signup — interview answers are collected but never scored, so high-intent artists/managers/labels can't be admitted automatically (GH #11497, JOV-3380 under demand-gated growth epic JOV-3379).

## What changed
Most of #11497 already existed (`WaitlistIntakeChat` interview, `/api/onboarding/intake`, `user_interviews` Eve-readable table, admit/waitlist outcome views, existing render test). This PR closes the one real gap — **deterministic scoring wired into the intake path** — plus richer problem capture:

- **New `lib/waitlist/interview-scoring.ts`** — pure, deterministic scorer (0–100) over the intake payload + free-text answers. Signals: Spotify artist identity (+30) / URL only (+15), active-release language (+25), substantive problem statement (+20), artist/manager/label role language (+10), paid plan interest (+15). Admit threshold 60 (conservative: identity + active release + real problem clears it; low-signal stays waitlisted). Server owns the decision — same philosophy as `onboarding-access-eval.ts`, no LLM.
- **`lib/waitlist/qualification.ts`** — new `qualified_interview_signal` reason code; gate-on signups with `interview.admit` are approved. Blocked-domain and invalid-URL checks still run first (interview signal cannot bypass them).
- **`lib/waitlist/access-request.ts`** — threads optional `interviewResponses` through `decideAccess` into qualification. No behavior change when absent.
- **`app/api/onboarding/intake/route.ts`** — passes interview responses to the access request and enriches `user_interviews.metadata` with `problemStatement`, `interviewScore`, `interviewSignals` so Eve can query demand signal directly.
- **`lib/db/schema/user-interviews.ts`** — typed the new metadata fields (jsonb only — **no migration**).
- **Tests** — new `interview-scoring.test.ts` (5 cases incl. determinism + cap), 3 new qualification cases (admit, below-threshold, no-bypass-of-blocked-domain). Render test for the interview component already exists (`WaitlistIntakeChat.test.tsx`).

## Assumptions
- Threshold 60 and signal weights are a first calibration; the full audit trail (`qualificationResult.details` + interview metadata) supports retroactive tuning. Flagging as a conservative call, not a taste decision — default remains waitlist.
- `heardAbout` counts toward role-language signal; sentiment analysis intentionally skipped per dispatch ("basic keyword check is fine").
- Open PR #13243 changes the post-signup redirect default (`/start`); zero file overlap with this PR and directionally compatible (users land on the interview surface).

## Verification
Sandbox could not run the local gate: `registry.npmjs.org` returns 403 (network-access request went unanswered in an unattended run), so `pnpm install` → `turbo lint typecheck test:fast` → `build:web` could not execute locally.

```
$ curl -s -o /dev/null -w "%{http_code}" https://registry.npmjs.org/pnpm
403
```

**Verification deferred to CI** — this PR stays DRAFT until `ci-fast`, `Unit Tests`, and the merge-gate lanes are green. Changes were statically reviewed against strict-mode typing, canonical imports (`@/lib/db`, `logger`, no raw routes), and repo DB rules (no transactions added; scorer is pure).

## Cost Impact
None — pure function on the existing request path; no new external API calls, cron jobs, or queries.

Closes #11497
Dispatch: Fable Developer / thread cmr7sbt2w1ytg06adhu3mrk5c

🤖 Generated with [Claude Code](https://claude.com/claude-code)