### PR TITLE
chat: rotate model on thumbs-down with auto-revert after 3 clean turns

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -455,6 +455,16 @@ function normalizeToolIntent(value: unknown): string | null {
   return /^[a-z][a-z0-9_:-]{0,63}$/i.test(trimmed) ? trimmed : null;
 }
 
+/**
+ * 👎 model-rotation step (JOV-3362 / #11461). Only a small non-negative
+ * integer is accepted; the actual model is resolved server-side from the
+ * vetted rotation chain, so the client can never name a model directly.
+ */
+function normalizeModelRotationStep(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) return 0;
+  return Math.min(Math.max(value, 0), 8);
+}
+
 function normalizeClientId(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
@@ -2417,6 +2427,7 @@ export async function POST(req: Request) {
   const clientMessageId = normalizeClientId(body.clientMessageId);
   const source = normalizeChatTurnSource(body.source);
   const toolIntent = normalizeToolIntent(body.toolIntent);
+  const modelRotationStep = normalizeModelRotationStep(body.modelRotationStep);
   const resolvedProfileId = toNullableString(profileId);
   const resolvedConversationId = toNullableString(conversationId);
   const albumArtFeatureEnabled = await getAppFlagValue('ALBUM_ART_GENERATION', {
@@ -2804,6 +2815,7 @@ export async function POST(req: Request) {
       accountContext,
       insightsEnabled,
       forceLightModel,
+      modelRotationStep,
       lastUserText: userText,
       tools: wrapToolSetFailSoft(tools),
       signal: req.signal,

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -79,6 +79,7 @@ export function JovieChat({
     hasMessages,
     isLoadingConversation,
     conversationTitle,
+    modelRotationNotice,
     status,
     activeConversationId,
     inputRef,
@@ -498,21 +499,35 @@ export function JovieChat({
   } as const;
 
   const composerSurface = (
-    <ChatComposerSurface
-      chatInputProps={chatInputProps}
-      showThreadView={showThreadView}
-      isRateLimited={isRateLimited}
-      showManifest={showManifest}
-      manifestCollapsed={manifestCollapsed}
-      showChips={showChips}
-      pendingFiles={pendingFiles}
-      aggregate={aggregate}
-      isUploading={isUploading}
-      isPro={isProUser}
-      onRemoveFile={removeFile}
-      onCollapseManifest={() => setManifestCollapsed(true)}
-      onExpandManifest={() => setManifestCollapsed(false)}
-    />
+    <>
+      {/* 👎 recovery loop (JOV-3362 / #11461): quiet status line while the
+          conversation is rotated onto a fallback model. aria-live so screen
+          readers hear the switch; auto-clears after 3 clean turns. */}
+      {modelRotationNotice ? (
+        <p
+          aria-live='polite'
+          data-testid='chat-model-rotation-notice'
+          className='mb-1.5 px-1 text-xs text-secondary-token'
+        >
+          {modelRotationNotice}
+        </p>
+      ) : null}
+      <ChatComposerSurface
+        chatInputProps={chatInputProps}
+        showThreadView={showThreadView}
+        isRateLimited={isRateLimited}
+        showManifest={showManifest}
+        manifestCollapsed={manifestCollapsed}
+        showChips={showChips}
+        pendingFiles={pendingFiles}
+        aggregate={aggregate}
+        isUploading={isUploading}
+        isPro={isProUser}
+        onRemoveFile={removeFile}
+        onCollapseManifest={() => setManifestCollapsed(true)}
+        onExpandManifest={() => setManifestCollapsed(false)}
+      />
+    </>
   );
 
   const inlineChatError =

--- a/apps/web/components/jovie/components/ChatFeedbackControl.tsx
+++ b/apps/web/components/jovie/components/ChatFeedbackControl.tsx
@@ -3,6 +3,10 @@
 import { Button, SimpleTooltip } from '@jovie/ui';
 import { ThumbsDown, ThumbsUp } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
+import {
+  recordThumbsDownRotation,
+  undoThumbsDownRotation,
+} from '@/lib/chat/model-rotation-store';
 import { addBreadcrumb } from '@/lib/sentry/client-lite';
 import { cn } from '@/lib/utils';
 
@@ -83,11 +87,25 @@ export function ChatFeedbackControl({
       // Clicking the active vote undoes it.
       const resolvedVote = previousVote === nextVote ? null : nextVote;
       setVote(resolvedVote);
+      // 👎 recovery loop (JOV-3362 / #11461): a thumbs-down rotates the
+      // conversation's NEXT turn to a different model in the fallback chain.
+      // Applied optimistically alongside the vote; rolled back with it.
+      if (resolvedVote === 'down') {
+        recordThumbsDownRotation(target.conversationId);
+      } else if (previousVote === 'down') {
+        // Undo or flip to 👍 — either way the dislike was retracted.
+        undoThumbsDownRotation(target.conversationId);
+      }
       inFlightRef.current = true;
       void postVote(target, resolvedVote).then(ok => {
         inFlightRef.current = false;
         if (!ok) {
           setVote(previousVote);
+          if (resolvedVote === 'down') {
+            undoThumbsDownRotation(target.conversationId);
+          } else if (previousVote === 'down') {
+            recordThumbsDownRotation(target.conversationId);
+          }
           addBreadcrumb({
             category: 'ai-chat',
             message: 'chat_feedback_vote_failed',

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -5,7 +5,14 @@ import { useAsyncRateLimiter } from '@tanstack/react-pacer';
 import { useQueryClient } from '@tanstack/react-query';
 import { DefaultChatTransport, type UIMessage } from 'ai';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import { track } from '@/lib/analytics';
 import { matchCommand } from '@/lib/chat/command-registry';
 import {
@@ -13,6 +20,12 @@ import {
   readComposerDraft,
   saveComposerDraft,
 } from '@/lib/chat/composer-draft-store';
+import {
+  modelRotationNoticeForStep,
+  readModelRotationStep,
+  recordAssistantTurnClean,
+  subscribeModelRotation,
+} from '@/lib/chat/model-rotation-store';
 import { consumePendingChatPrompt } from '@/lib/chat/open-chat-with-prompt';
 import { trimMessagesForChatRequest } from '@/lib/chat/request-validation';
 import { isRecoverableToolErrorCode } from '@/lib/chat/tool-errors';
@@ -531,6 +544,11 @@ export function useJovieChat({
         adoptServerConversationId(metadata.conversationId, 'completed');
       }
 
+      // 👎 recovery loop (JOV-3362 / #11461): count clean assistant turns so
+      // a rotated conversation auto-reverts to the default model after 3
+      // completions without a new thumbs-down.
+      recordAssistantTurnClean(finishedConversationId);
+
       queryClient.invalidateQueries({
         queryKey: queryKeys.chat.usage(),
       });
@@ -703,6 +721,20 @@ export function useJovieChat({
   const isLoading = status === 'streaming' || status === 'submitted';
   const hasMessages = messages.length > 0;
 
+  // Reactive view of the 👎 model-rotation state (JOV-3362 / #11461). The
+  // store mutates from ChatFeedbackControl (a different component), so the
+  // hook subscribes rather than reading module state during render only.
+  const rotationSnapshot = useCallback(
+    () => readModelRotationStep(activeConversationId),
+    [activeConversationId]
+  );
+  const modelRotationStep = useSyncExternalStore(
+    subscribeModelRotation,
+    rotationSnapshot,
+    () => 0
+  );
+  const modelRotationNotice = modelRotationNoticeForStep(modelRotationStep);
+
   useEffect(() => {
     if (status !== 'ready') return;
     queryClient.invalidateQueries({
@@ -855,12 +887,19 @@ export function useJovieChat({
       const toolIntent =
         options?.toolIntent ?? inferToolIntentFromPrompt(trimmedText);
 
+      // 👎 recovery loop (JOV-3362 / #11461): after a thumbs-down, route this
+      // conversation's next turn to the next model in the fallback chain. The
+      // client only transmits an integer step; the server resolves + clamps
+      // the actual model from its own vetted chain.
+      const modelRotationStep = readModelRotationStep(activeConversationId);
+
       const sendOptions = {
         body: {
           clientTurnId,
           clientMessageId: `${clientTurnId}:user`,
           source: options?.source ?? 'typed',
           ...(toolIntent ? { toolIntent } : {}),
+          ...(modelRotationStep > 0 ? { modelRotationStep } : {}),
         },
       };
       dispatchTimelineEvent({
@@ -1053,6 +1092,8 @@ export function useJovieChat({
     activeConversationId,
     /** Auto-generated or user-set conversation title (null if not yet generated) */
     conversationTitle,
+    /** Quiet status line while the conversation is rotated off the default model (👎 recovery). */
+    modelRotationNotice,
     // Refs
     inputRef,
     // Handlers

--- a/apps/web/lib/chat/model-rotation-store.test.ts
+++ b/apps/web/lib/chat/model-rotation-store.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CHAT_MODEL,
+  CHAT_MODEL_ROTATION_CHAIN,
+  resolveRotatedChatModel,
+} from '@/lib/constants/ai-models';
+import {
+  AUTO_REVERT_CLEAN_STREAK,
+  friendlyModelLabel,
+  modelRotationNoticeForStep,
+  readModelRotationStep,
+  recordAssistantTurnClean,
+  recordThumbsDownRotation,
+  resetModelRotationStoreForTests,
+  subscribeModelRotation,
+  undoThumbsDownRotation,
+} from './model-rotation-store';
+
+const CONVO = 'conv-a';
+const OTHER = 'conv-b';
+const MAX_STEP = CHAT_MODEL_ROTATION_CHAIN.length - 1;
+
+describe('model-rotation-store', () => {
+  beforeEach(() => {
+    resetModelRotationStoreForTests();
+  });
+
+  it('starts every conversation at step 0 (default model)', () => {
+    expect(readModelRotationStep(CONVO)).toBe(0);
+    expect(readModelRotationStep(null)).toBe(0);
+  });
+
+  it('a thumbs-down advances the rotation step', () => {
+    recordThumbsDownRotation(CONVO);
+    expect(readModelRotationStep(CONVO)).toBe(Math.min(1, MAX_STEP));
+  });
+
+  it('rotation is per-conversation, never global', () => {
+    recordThumbsDownRotation(CONVO);
+    expect(readModelRotationStep(OTHER)).toBe(0);
+    expect(readModelRotationStep(null)).toBe(0);
+  });
+
+  it('repeated thumbs-downs clamp at the end of the chain', () => {
+    for (let i = 0; i < 10; i++) {
+      recordThumbsDownRotation(CONVO);
+    }
+    expect(readModelRotationStep(CONVO)).toBe(MAX_STEP);
+  });
+
+  it('undoing a thumbs-down steps back toward the default', () => {
+    recordThumbsDownRotation(CONVO);
+    undoThumbsDownRotation(CONVO);
+    expect(readModelRotationStep(CONVO)).toBe(0);
+    // Undo with no prior rotation is a no-op.
+    undoThumbsDownRotation(CONVO);
+    expect(readModelRotationStep(CONVO)).toBe(0);
+  });
+
+  it(`auto-reverts to the default model after ${AUTO_REVERT_CLEAN_STREAK} clean assistant turns`, () => {
+    recordThumbsDownRotation(CONVO);
+    for (let i = 0; i < AUTO_REVERT_CLEAN_STREAK - 1; i++) {
+      recordAssistantTurnClean(CONVO);
+      expect(readModelRotationStep(CONVO)).toBeGreaterThan(0);
+    }
+    recordAssistantTurnClean(CONVO);
+    expect(readModelRotationStep(CONVO)).toBe(0);
+  });
+
+  it('a new thumbs-down resets the clean streak', () => {
+    recordThumbsDownRotation(CONVO);
+    recordAssistantTurnClean(CONVO);
+    recordAssistantTurnClean(CONVO);
+    // 👎 arrives before the third clean turn — streak must restart.
+    recordThumbsDownRotation(CONVO);
+    recordAssistantTurnClean(CONVO);
+    recordAssistantTurnClean(CONVO);
+    expect(readModelRotationStep(CONVO)).toBeGreaterThan(0);
+    recordAssistantTurnClean(CONVO);
+    expect(readModelRotationStep(CONVO)).toBe(0);
+  });
+
+  it('clean turns on a non-rotated conversation are a no-op', () => {
+    recordAssistantTurnClean(CONVO);
+    expect(readModelRotationStep(CONVO)).toBe(0);
+  });
+
+  it('notifies subscribers on every mutation', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeModelRotation(listener);
+    recordThumbsDownRotation(CONVO);
+    expect(listener).toHaveBeenCalledTimes(1);
+    recordAssistantTurnClean(CONVO);
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsubscribe();
+    recordThumbsDownRotation(CONVO);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('modelRotationNoticeForStep is null at step 0 and names the rotated model above it', () => {
+    expect(modelRotationNoticeForStep(0)).toBeNull();
+    const notice = modelRotationNoticeForStep(1);
+    expect(notice).toContain('Switched to');
+    expect(notice).toContain(friendlyModelLabel(resolveRotatedChatModel(1)));
+  });
+
+  it('friendlyModelLabel produces a human-readable name', () => {
+    expect(friendlyModelLabel('google/gemini-2.5-pro')).toBe('Gemini 2.5 Pro');
+  });
+});
+
+describe('resolveRotatedChatModel (server-side clamp)', () => {
+  it('returns the default model for step 0, undefined, negatives, and non-integers', () => {
+    expect(resolveRotatedChatModel(0)).toBe(CHAT_MODEL);
+    expect(resolveRotatedChatModel(undefined)).toBe(CHAT_MODEL);
+    expect(resolveRotatedChatModel(-3)).toBe(CHAT_MODEL);
+    expect(resolveRotatedChatModel(1.5)).toBe(CHAT_MODEL);
+    expect(resolveRotatedChatModel(Number.NaN)).toBe(CHAT_MODEL);
+  });
+
+  it('selects chain entries and clamps out-of-range steps to the last entry', () => {
+    expect(resolveRotatedChatModel(1)).toBe(CHAT_MODEL_ROTATION_CHAIN[1]);
+    expect(resolveRotatedChatModel(999)).toBe(
+      CHAT_MODEL_ROTATION_CHAIN[CHAT_MODEL_ROTATION_CHAIN.length - 1]
+    );
+  });
+
+  it('never returns a model outside the vetted chain', () => {
+    for (const step of [0, 1, 2, 3, 8, 100]) {
+      expect(CHAT_MODEL_ROTATION_CHAIN).toContain(
+        resolveRotatedChatModel(step)
+      );
+    }
+  });
+});

--- a/apps/web/lib/chat/model-rotation-store.ts
+++ b/apps/web/lib/chat/model-rotation-store.ts
@@ -1,0 +1,168 @@
+/**
+ * Per-conversation model-rotation state for the 👎 recovery loop (JOV-3362 /
+ * GitHub #11461).
+ *
+ * When a user thumbs-down an assistant message, the NEXT message in that
+ * conversation is routed to a different model in the fallback chain
+ * (trial-and-error self-heal). After {@link AUTO_REVERT_CLEAN_STREAK}
+ * consecutive assistant turns without a new 👎, the conversation auto-reverts
+ * to the default model.
+ *
+ * State is module-scoped and keyed by conversation id — the same pattern as
+ * `composer-draft-store.ts`. It survives thread switches within a session and
+ * never affects other conversations. The client only ever transmits an
+ * integer step; the server resolves the actual model id from its own chain
+ * (`resolveRotatedChatModel`), so a hostile client cannot select an arbitrary
+ * model.
+ */
+
+import {
+  CHAT_MODEL_ROTATION_CHAIN,
+  resolveRotatedChatModel,
+} from '@/lib/constants/ai-models';
+
+/** Consecutive clean assistant turns before reverting to the default model. */
+export const AUTO_REVERT_CLEAN_STREAK = 3;
+
+const NEW_CHAT_KEY = '__new__';
+const ROTATION_CACHE_LIMIT = 50;
+const MAX_ROTATION_STEP = CHAT_MODEL_ROTATION_CHAIN.length - 1;
+
+interface RotationState {
+  /** Index into the rotation chain. 0 = default model. */
+  step: number;
+  /** Assistant turns completed without a 👎 since the last rotation. */
+  cleanStreak: number;
+}
+
+const rotationByConversationId = new Map<string, RotationState>();
+const listeners = new Set<() => void>();
+
+function rotationKey(conversationId: string | null | undefined): string {
+  return conversationId ?? NEW_CHAT_KEY;
+}
+
+function notifyListeners(): void {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // A broken subscriber must never affect chat state.
+    }
+  }
+}
+
+function pruneRotationCache(): void {
+  while (rotationByConversationId.size > ROTATION_CACHE_LIMIT) {
+    const oldestKey = rotationByConversationId.keys().next().value;
+    if (!oldestKey) break;
+    rotationByConversationId.delete(oldestKey);
+  }
+}
+
+function writeState(key: string, state: RotationState): void {
+  if (state.step <= 0) {
+    rotationByConversationId.delete(key);
+  } else {
+    rotationByConversationId.set(key, state);
+    pruneRotationCache();
+  }
+  notifyListeners();
+}
+
+/** Current rotation step for a conversation (0 = default model). */
+export function readModelRotationStep(
+  conversationId: string | null | undefined
+): number {
+  return rotationByConversationId.get(rotationKey(conversationId))?.step ?? 0;
+}
+
+/**
+ * Record a 👎 on an assistant message: advance to the next model in the
+ * chain (clamped) and reset the clean streak.
+ */
+export function recordThumbsDownRotation(
+  conversationId: string | null | undefined
+): void {
+  const key = rotationKey(conversationId);
+  const current = rotationByConversationId.get(key);
+  writeState(key, {
+    step: Math.min((current?.step ?? 0) + 1, MAX_ROTATION_STEP),
+    cleanStreak: 0,
+  });
+}
+
+/**
+ * Undo of a 👎 (user re-clicked the active vote). Reverts the most recent
+ * rotation increment. Best-effort: if messages were sent between the vote and
+ * the undo, this simply steps back one link in the chain.
+ */
+export function undoThumbsDownRotation(
+  conversationId: string | null | undefined
+): void {
+  const key = rotationKey(conversationId);
+  const current = rotationByConversationId.get(key);
+  if (!current) return;
+  writeState(key, {
+    step: Math.max(current.step - 1, 0),
+    cleanStreak: current.cleanStreak,
+  });
+}
+
+/**
+ * Record a successfully completed assistant turn. After
+ * {@link AUTO_REVERT_CLEAN_STREAK} consecutive clean turns while rotated,
+ * the conversation reverts to the default model.
+ */
+export function recordAssistantTurnClean(
+  conversationId: string | null | undefined
+): void {
+  const key = rotationKey(conversationId);
+  const current = rotationByConversationId.get(key);
+  if (!current || current.step <= 0) return;
+  const cleanStreak = current.cleanStreak + 1;
+  writeState(
+    key,
+    cleanStreak >= AUTO_REVERT_CLEAN_STREAK
+      ? { step: 0, cleanStreak: 0 }
+      : { step: current.step, cleanStreak }
+  );
+}
+
+/** Subscribe to rotation-state changes (for `useSyncExternalStore`). */
+export function subscribeModelRotation(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Human-readable label for a gateway model id (e.g. "Gemini 2.5 Pro"). */
+export function friendlyModelLabel(modelId: string): string {
+  const name = modelId.split('/')[1] ?? modelId;
+  return name
+    .replace(/-\d{8}$/, '')
+    .split('-')
+    .map(part =>
+      /^\d/.test(part)
+        ? part
+        : part.charAt(0).toUpperCase() + part.slice(1)
+    )
+    .join(' ');
+}
+
+/**
+ * User-facing notice for the active rotation, or null when the conversation
+ * is on the default model.
+ */
+export function modelRotationNoticeForStep(step: number): string | null {
+  if (step <= 0) return null;
+  const model = resolveRotatedChatModel(step);
+  return `Switched to ${friendlyModelLabel(model)} for better quality`;
+}
+
+/** Test helper — reset module state between unit tests. */
+export function resetModelRotationStoreForTests(): void {
+  rotationByConversationId.clear();
+  listeners.clear();
+}

--- a/apps/web/lib/chat/model-rotation-store.ts
+++ b/apps/web/lib/chat/model-rotation-store.ts
@@ -144,9 +144,7 @@ export function friendlyModelLabel(modelId: string): string {
     .replace(/-\d{8}$/, '')
     .split('-')
     .map(part =>
-      /^\d/.test(part)
-        ? part
-        : part.charAt(0).toUpperCase() + part.slice(1)
+      /^\d/.test(part) ? part : part.charAt(0).toUpperCase() + part.slice(1)
     )
     .join(' ');
 }

--- a/apps/web/lib/chat/request-validation.ts
+++ b/apps/web/lib/chat/request-validation.ts
@@ -26,6 +26,7 @@ export type ChatRequestBody = {
   clientMessageId?: unknown;
   source?: unknown;
   toolIntent?: unknown;
+  modelRotationStep?: unknown;
 };
 
 type MessagePart = { type: string; text?: string };

--- a/apps/web/lib/chat/run.ts
+++ b/apps/web/lib/chat/run.ts
@@ -32,7 +32,10 @@ import type {
   ChatTelemetry,
   ReleaseContext,
 } from '@/lib/chat/types';
-import { CHAT_MODEL, CHAT_MODEL_LIGHT } from '@/lib/constants/ai-models';
+import {
+  CHAT_MODEL_LIGHT,
+  resolveRotatedChatModel,
+} from '@/lib/constants/ai-models';
 import type { getEntitlements as GetEntitlements } from '@/lib/entitlements/registry';
 import { startChatTurnLangfuseTrace } from '@/lib/observability/langfuse';
 
@@ -134,6 +137,14 @@ export interface ExecuteChatTurnInput {
   insightsEnabled: boolean;
   accountContext?: ChatAccountContext;
   forceLightModel: boolean;
+  /**
+   * 👎 model-rotation step for this conversation (JOV-3362 / #11461).
+   * 0/undefined = default model. Positive values select the matching entry
+   * in `CHAT_MODEL_ROTATION_CHAIN` (clamped server-side) so a disliked
+   * response is retried on a different model. Never overrides the
+   * light-model path (cost lever / onboarding stay on Haiku).
+   */
+  modelRotationStep?: number;
   /** Precomputed once per turn to avoid repeated message scans. */
   lastUserText?: string;
   /**
@@ -207,6 +218,7 @@ export async function executeChatTurn(
     insightsEnabled,
     accountContext,
     forceLightModel,
+    modelRotationStep,
     lastUserText,
     tools,
     signal,
@@ -266,7 +278,12 @@ export async function executeChatTurn(
       planLimits.booleans.aiCanUseTools,
       lastUserText
     );
-  const selectedModel = shouldUseLightModel ? CHAT_MODEL_LIGHT : CHAT_MODEL;
+  // 👎 rotation (JOV-3362 / #11461): a disliked response routes the next
+  // turn to a different chain model. Light-model routing wins — it is the
+  // incident cost lever and the free-plan/onboarding path.
+  const selectedModel = shouldUseLightModel
+    ? CHAT_MODEL_LIGHT
+    : resolveRotatedChatModel(modelRotationStep);
 
   // Tag the request scope with chat-specific dimensions so all telemetry
   // events for this turn (errors, perf, breadcrumbs) are filterable
@@ -276,6 +293,7 @@ export async function executeChatTurn(
   telemetry?.setTags?.({
     chat_model: selectedModel,
     chat_force_light: String(forceLightModel),
+    chat_model_rotation_step: String(modelRotationStep ?? 0),
     chat_has_tools: String(planLimits.booleans.aiCanUseTools),
   });
   if (resolvedConversationId) {

--- a/apps/web/lib/constants/ai-models.ts
+++ b/apps/web/lib/constants/ai-models.ts
@@ -14,6 +14,37 @@ export const CHAT_MODEL = 'anthropic/claude-sonnet-4-20250514';
 /** Lightweight chat model for simple tool-calling tasks (profile edits, link adds) */
 export const CHAT_MODEL_LIGHT = 'anthropic/claude-haiku-4-5-20251001';
 
+/**
+ * Fallback chain for the 👎 model-rotation recovery loop (JOV-3362 / #11461).
+ *
+ * Index 0 is the default chat model. When a user thumbs-down a response, the
+ * conversation's next turn is routed to the next entry. Google models are
+ * proven working through the gateway (TITLE_MODEL); do not append providers
+ * that are not enabled on the gateway account.
+ */
+export const CHAT_MODEL_ROTATION_CHAIN: readonly string[] = [
+  CHAT_MODEL,
+  'google/gemini-2.5-pro',
+];
+
+/**
+ * Resolve a rotation step (client-supplied integer) to a chain model.
+ * Clamps out-of-range values so a hostile or stale client can only ever
+ * select a model from the vetted chain.
+ */
+export function resolveRotatedChatModel(step: number | undefined): string {
+  const chain = CHAT_MODEL_ROTATION_CHAIN;
+  if (
+    typeof step !== 'number' ||
+    !Number.isInteger(step) ||
+    step <= 0 ||
+    chain.length === 0
+  ) {
+    return CHAT_MODEL;
+  }
+  return chain[Math.min(step, chain.length - 1)] ?? CHAT_MODEL;
+}
+
 /** Model used for AI-generated analytics insights */
 export const INSIGHT_MODEL = 'anthropic/claude-haiku-4-5-20251001';
 

--- a/apps/web/tests/unit/chat/ai-model-identifiers.test.ts
+++ b/apps/web/tests/unit/chat/ai-model-identifiers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { CHAT_MODEL, TITLE_MODEL } from '@/lib/constants/ai-models';
+import {
+  CHAT_MODEL,
+  CHAT_MODEL_ROTATION_CHAIN,
+  TITLE_MODEL,
+} from '@/lib/constants/ai-models';
 
 /**
  * Tests that AI Gateway model identifiers use the correct format.
@@ -36,5 +40,16 @@ describe('AI Gateway model identifiers', () => {
 
   it('TITLE_MODEL specifies the google provider', () => {
     expect(TITLE_MODEL.split('/')[0]).toBe('google');
+  });
+
+  it('every CHAT_MODEL_ROTATION_CHAIN entry uses provider/model format', () => {
+    for (const identifier of CHAT_MODEL_ROTATION_CHAIN) {
+      expect(identifier).toMatch(GATEWAY_ID_PATTERN);
+      expect(identifier).not.toContain(':');
+    }
+  });
+
+  it('CHAT_MODEL_ROTATION_CHAIN starts with the default chat model', () => {
+    expect(CHAT_MODEL_ROTATION_CHAIN[0]).toBe(CHAT_MODEL);
   });
 });

--- a/apps/web/tests/unit/chat/run.parity.test.ts
+++ b/apps/web/tests/unit/chat/run.parity.test.ts
@@ -25,7 +25,11 @@ import type {
   ChatTelemetry,
   ReleaseContext,
 } from '@/lib/chat/types';
-import { CHAT_MODEL, CHAT_MODEL_LIGHT } from '@/lib/constants/ai-models';
+import {
+  CHAT_MODEL,
+  CHAT_MODEL_LIGHT,
+  CHAT_MODEL_ROTATION_CHAIN,
+} from '@/lib/constants/ai-models';
 
 // Mock the AI SDK so tests don't hit the gateway. We only care that
 // `streamText` is invoked with the right shape; the returned object is
@@ -178,6 +182,47 @@ describe('executeChatTurn — parity assertions', () => {
       planLimits: paidPlanLimits,
     });
     expect(turn.selectedModel).toBe(CHAT_MODEL);
+  });
+
+  it('rotates to the fallback chain model when modelRotationStep is set (👎 recovery, #11461)', async () => {
+    const turn = await executeChatTurn({
+      ...baseInput,
+      uiMessages: [
+        userMessage(
+          'walk me through how Spotify editorial pitching actually works for an indie artist with 500 followers'
+        ),
+      ],
+      planLimits: paidPlanLimits,
+      modelRotationStep: 1,
+    });
+    expect(turn.selectedModel).toBe(CHAT_MODEL_ROTATION_CHAIN[1]);
+    expect(turn.selectedModel).not.toBe(CHAT_MODEL);
+  });
+
+  it('rotation never overrides the light-model path', async () => {
+    const turn = await executeChatTurn({
+      ...baseInput,
+      uiMessages: [userMessage('change my bio to: New bio text')],
+      planLimits: freePlanLimits,
+      modelRotationStep: 1,
+    });
+    expect(turn.selectedModel).toBe(CHAT_MODEL_LIGHT);
+  });
+
+  it('clamps out-of-range rotation steps to the end of the chain', async () => {
+    const turn = await executeChatTurn({
+      ...baseInput,
+      uiMessages: [
+        userMessage(
+          'walk me through how Spotify editorial pitching actually works for an indie artist with 500 followers'
+        ),
+      ],
+      planLimits: paidPlanLimits,
+      modelRotationStep: 999,
+    });
+    expect(turn.selectedModel).toBe(
+      CHAT_MODEL_ROTATION_CHAIN[CHAT_MODEL_ROTATION_CHAIN.length - 1]
+    );
   });
 
   it('honors forceLightModel override regardless of heuristic', async () => {


### PR DESCRIPTION
## Problem
A 👎 on a chat response currently only records feedback — the very next turn runs on the same model, so a user stuck with a bad answer has no instant recovery loop (#11461, JOV-3362).

## What changed
- **`lib/constants/ai-models.ts`** — new `CHAT_MODEL_ROTATION_CHAIN` (`CHAT_MODEL` → `google/gemini-2.5-pro`) + `resolveRotatedChatModel(step)` which clamps any client-supplied step into the vetted chain.
- **`lib/chat/model-rotation-store.ts` (new)** — per-conversation rotation state (module-scoped Map, same pattern as `composer-draft-store.ts`): 👎 advances the step and zeroes the clean streak; 3 consecutive clean assistant turns auto-revert to the default model; undo/flip-to-👍 steps back; subscriber API for `useSyncExternalStore`.
- **`ChatFeedbackControl.tsx`** — a 👎 optimistically records a rotation for the conversation (rolled back if the vote POST fails or the vote is undone/flipped).
- **`useJovieChat.ts`** — sends `modelRotationStep` (integer only) in the chat request body when rotated; counts clean turns in `onFinish`; exposes `modelRotationNotice` reactively.
- **`JovieChat.tsx`** — quiet `aria-live` status line above the composer: “Switched to Gemini 2.5 Pro for better quality” while rotated.
- **`route.ts` / `request-validation.ts` / `run.ts`** — `normalizeModelRotationStep` (int, 0–8) → `executeChatTurn({ modelRotationStep })` → model selection via `resolveRotatedChatModel`. Light-model routing (`forceLightModel` / free-plan heuristic) always wins, so the incident cost lever and onboarding stay on Haiku. Telemetry tag `chat_model_rotation_step` added. The rotated model is recorded on `chat_turns.model` by the existing #11460 pipeline, so retry votes stay attributable.

## Assumptions
- **Chain = Sonnet → Gemini 2.5 Pro only.** The Google provider is proven working through the gateway (`TITLE_MODEL`); OpenAI et al. were not added because gateway enablement is unverified. Extending the chain is a one-line change.
- The issue body also asks for freeform “why?” reason capture + an explicit “Try again” affordance; this PR ships the dispatched scope (rotation-on-next-message + indicator + auto-revert). Reason capture is tracked by the parent #11459 cluster.
- Client transmits only an integer step; the server resolves and clamps the model from its own chain — a hostile client can never name an arbitrary model.
- Rotation state is session-scoped per conversation (same durability class as composer drafts), not persisted to the DB.

## Verification
**Deferred to CI.** The sandbox cannot reach registry.npmjs.org (403 after a network-access request went unanswered), so `pnpm install` / `turbo lint typecheck test:fast` / `build:web` could not run locally:
```
$ curl -s -o /dev/null -w "%{http_code}" https://registry.npmjs.org/pnpm
403
```
Tests added for CI to execute:
- `apps/web/lib/chat/model-rotation-store.test.ts` — rotation, clamp, per-conversation isolation, undo, 3-clean-turn auto-revert, streak reset, subscriber notify.
- `apps/web/tests/unit/chat/run.parity.test.ts` — rotated model selected at step 1, light-model path never overridden, out-of-range clamp.
- `apps/web/tests/unit/chat/ai-model-identifiers.test.ts` — chain entries use gateway `provider/model` format; chain[0] === CHAT_MODEL.

## Dispatch
- Dispatch ID: hyperagent thread `cmr7saxmh1wqt07adpp6r84sj`
- Closes #11461

🤖 Generated with [Claude Code](https://claude.com/claude-code)