### PR TITLE
feat(inbox): tour-date signal detection + trust-gate data layer (part 1/2)

### DIFF
--- a/apps/web/app/app/(shell)/OpportunityInboxRoute.tsx
+++ b/apps/web/app/app/(shell)/OpportunityInboxRoute.tsx
@@ -3,13 +3,39 @@ import { OpportunityInboxPageClient } from '@/components/features/opportunity-in
 import { APP_ROUTES } from '@/constants/routes';
 import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
 import { loadOpportunityInboxData } from '@/lib/connectors/opportunity-inbox-data';
+import { logger } from '@/lib/utils/logger';
 import { loadAuthenticatedAppShellUserId } from './app-shell-route-context';
+import { getDashboardShellData } from './dashboard/actions';
+
+/**
+ * Resolve the selected profile id for the tour-date inbox sections. Fail-soft:
+ * the inbox must still render suggested-action cards when dashboard shell
+ * data is unavailable, so any error degrades to null (sections omitted).
+ */
+async function resolveSelectedProfileId(
+  clerkUserId: string
+): Promise<string | null> {
+  try {
+    const dashboardData = await getDashboardShellData(clerkUserId);
+    if (dashboardData.dashboardLoadError) {
+      return null;
+    }
+    return dashboardData.selectedProfile?.id ?? null;
+  } catch (error) {
+    logger.error(
+      '[opportunity-inbox] selected profile resolution failed; skipping tour-date sections',
+      error
+    );
+    return null;
+  }
+}
 
 export async function OpportunityInboxRoute() {
   const clerkUserId = await loadAuthenticatedAppShellUserId({
     route: APP_ROUTES.DASHBOARD,
   });
-  const inbox = await loadOpportunityInboxData(clerkUserId);
+  const profileId = await resolveSelectedProfileId(clerkUserId);
+  const inbox = await loadOpportunityInboxData(clerkUserId, { profileId });
 
   if (!inbox) {
     redirect(buildAppShellSignInUrl(APP_ROUTES.DASHBOARD));

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.stories.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.stories.tsx
@@ -22,6 +22,7 @@ export const SuggestionCard: Story = {
       why: 'A promoter at the Magic Stick reached out yesterday. Jovie tied it to your Spotify growth there.',
       primaryActionLabel: 'Review pitch',
       status: 'pending',
+      category: 'suggestion',
     },
     onApprove: () => undefined,
     onDismiss: () => undefined,

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxCard.test.tsx
@@ -10,6 +10,7 @@ const CARD = {
   why: 'Promoter email matched your Detroit growth spike.',
   primaryActionLabel: 'Review pitch',
   status: 'pending' as const,
+  category: 'suggestion' as const,
 };
 
 describe('OpportunityInboxCard', () => {

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
@@ -56,6 +56,7 @@ describe('OpportunityInboxPageClient', () => {
           cards: [
             {
               id: 'card-1',
+              category: 'suggestion',
               typeLabel: 'Suggestion',
               createdAt: '2026-06-28T10:00:00.000Z',
               title: 'Detroit listeners up 340% — book a show',
@@ -108,6 +109,7 @@ describe('OpportunityInboxPageClient', () => {
           cards: [
             {
               id: 'card-1',
+              category: 'suggestion',
               typeLabel: 'Suggestion',
               createdAt: '2026-06-28T10:00:00.000Z',
               title: 'Detroit listeners up 340% — book a show',

--- a/apps/web/lib/connectors/opportunity-inbox-data.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-data.ts
@@ -1,23 +1,116 @@
 import 'server-only';
 
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, gte } from 'drizzle-orm';
 import { isMissingConnectorSchemaError } from '@/lib/connectors/schema-errors';
 import { db } from '@/lib/db';
 import { getUserByClerkId } from '@/lib/db/queries/shared';
 import { suggestedActions } from '@/lib/db/schema/connectors';
+import { tourDates } from '@/lib/db/schema/tour';
+import { logger } from '@/lib/utils/logger';
 import { buildOpportunityInboxData } from './opportunity-inbox-mapper';
-import type { OpportunityInboxData } from './opportunity-inbox-types';
+import { mapTourDateRowToInboxItem } from './opportunity-inbox-tour-dates';
+import type {
+  OpportunityInboxData,
+  OpportunityInboxTourDates,
+} from './opportunity-inbox-types';
 
 const EMPTY_INBOX_DATA = buildOpportunityInboxData([]);
 
+const PENDING_TOUR_DATE_LIMIT = 20;
+const CONFIRMED_TOUR_DATE_LIMIT = 10;
+const REJECTED_TOUR_DATE_LIMIT = 20;
+
+const TOUR_DATE_SELECTION = {
+  id: tourDates.id,
+  title: tourDates.title,
+  startDate: tourDates.startDate,
+  startTime: tourDates.startTime,
+  venueName: tourDates.venueName,
+  city: tourDates.city,
+  region: tourDates.region,
+  country: tourDates.country,
+  provider: tourDates.provider,
+  confirmationStatus: tourDates.confirmationStatus,
+};
+
+/**
+ * Detected tour-date signals awaiting the creator's confirm/reject call, plus
+ * the visible confirmed list and the hidden rejected bucket.
+ *
+ * Fail-soft: any query error degrades to empty sections so the inbox feed
+ * still renders (same posture as the suggested-actions migration-drift guard).
+ */
+async function loadTourDateSections(
+  profileId: string
+): Promise<OpportunityInboxTourDates> {
+  try {
+    const now = new Date();
+
+    const [pending, confirmed, rejected] = await Promise.all([
+      db
+        .select(TOUR_DATE_SELECTION)
+        .from(tourDates)
+        .where(
+          and(
+            eq(tourDates.profileId, profileId),
+            eq(tourDates.confirmationStatus, 'pending')
+          )
+        )
+        .orderBy(tourDates.startDate)
+        .limit(PENDING_TOUR_DATE_LIMIT),
+      db
+        .select(TOUR_DATE_SELECTION)
+        .from(tourDates)
+        .where(
+          and(
+            eq(tourDates.profileId, profileId),
+            eq(tourDates.confirmationStatus, 'confirmed'),
+            gte(tourDates.startDate, now)
+          )
+        )
+        .orderBy(tourDates.startDate)
+        .limit(CONFIRMED_TOUR_DATE_LIMIT),
+      db
+        .select(TOUR_DATE_SELECTION)
+        .from(tourDates)
+        .where(
+          and(
+            eq(tourDates.profileId, profileId),
+            eq(tourDates.confirmationStatus, 'rejected')
+          )
+        )
+        .orderBy(desc(tourDates.startDate))
+        .limit(REJECTED_TOUR_DATE_LIMIT),
+    ]);
+
+    return {
+      pending: pending.map(mapTourDateRowToInboxItem),
+      confirmed: confirmed.map(mapTourDateRowToInboxItem),
+      rejected: rejected.map(mapTourDateRowToInboxItem),
+    };
+  } catch (error) {
+    logger.error(
+      '[opportunity-inbox] tour-date sections load failed; degrading to empty',
+      error
+    );
+    return { pending: [], confirmed: [], rejected: [] };
+  }
+}
+
 export async function loadOpportunityInboxData(
-  clerkUserId: string
+  clerkUserId: string,
+  options?: { readonly profileId?: string | null }
 ): Promise<OpportunityInboxData | null> {
   const dbUser = await getUserByClerkId(db, clerkUserId);
 
   if (!dbUser) {
     return null;
   }
+
+  const profileId = options?.profileId ?? null;
+  const tourDateSections = profileId
+    ? await loadTourDateSections(profileId)
+    : undefined;
 
   try {
     const rows = await db
@@ -38,10 +131,12 @@ export async function loadOpportunityInboxData(
       .orderBy(desc(suggestedActions.createdAt))
       .limit(50);
 
-    return buildOpportunityInboxData(rows);
+    return buildOpportunityInboxData(rows, tourDateSections);
   } catch (error) {
     if (isMissingConnectorSchemaError(error)) {
-      return EMPTY_INBOX_DATA;
+      return tourDateSections
+        ? buildOpportunityInboxData([], tourDateSections)
+        : EMPTY_INBOX_DATA;
     }
     throw error;
   }

--- a/apps/web/lib/connectors/opportunity-inbox-mapper.test.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-mapper.test.ts
@@ -51,3 +51,66 @@ describe('buildOpportunityInboxData', () => {
     expect(data.emptyActionCards[0]?.id).toBe('connect-spotify');
   });
 });
+
+describe('tour-date classification in the mapper', () => {
+  it('labels tour-date-looking calendar signals as tour date cards', () => {
+    const card = mapSuggestedActionToInboxCard({
+      id: 'action-3',
+      kind: 'calendar.create_event',
+      payload: {
+        title: 'Show at Saint Andrews Hall',
+        venueName: 'Saint Andrews Hall',
+        city: 'Detroit',
+      },
+      rationale: 'Promoter email proposed a Detroit tour stop.',
+      createdAt: new Date('2026-06-28T10:00:00.000Z'),
+    });
+
+    expect(card.category).toBe('tour_date');
+    expect(card.typeLabel).toBe('Tour date');
+    expect(card.primaryActionLabel).toBe('Confirm date');
+  });
+
+  it('keeps non-tour calendar signals as suggestions', () => {
+    const card = mapSuggestedActionToInboxCard({
+      id: 'action-4',
+      kind: 'calendar.create_event',
+      payload: { title: 'Weekly catalog review' },
+      rationale: 'Recurring planning block.',
+      createdAt: new Date('2026-06-28T10:00:00.000Z'),
+    });
+
+    expect(card.category).toBe('suggestion');
+    expect(card.typeLabel).toBe('Suggestion');
+    expect(card.primaryActionLabel).toBe('Add to calendar');
+  });
+});
+
+describe('buildOpportunityInboxData tour-date sections', () => {
+  it('passes tour-date sections through when provided', () => {
+    const tourDates = {
+      pending: [
+        {
+          id: 'td-1',
+          title: 'Saint Andrews Hall',
+          startDate: '2026-08-14T00:00:00.000Z',
+          startTime: null,
+          venueName: 'Saint Andrews Hall',
+          location: 'Detroit, MI',
+          providerLabel: 'Bandsintown',
+          status: 'pending' as const,
+        },
+      ],
+      confirmed: [],
+      rejected: [],
+    };
+
+    const data = buildOpportunityInboxData([], tourDates);
+    expect(data.tourDates).toEqual(tourDates);
+  });
+
+  it('omits tour-date sections when not provided', () => {
+    const data = buildOpportunityInboxData([]);
+    expect(data.tourDates).toBeUndefined();
+  });
+});

--- a/apps/web/lib/connectors/opportunity-inbox-mapper.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-mapper.ts
@@ -1,8 +1,11 @@
 import { APP_ROUTES } from '@/constants/routes';
+import { classifySuggestedActionCategory } from './opportunity-inbox-tour-dates';
 import type {
+  OpportunityInboxCardCategory,
   OpportunityInboxCardViewModel,
   OpportunityInboxData,
   OpportunityInboxEmptyActionCard,
+  OpportunityInboxTourDates,
 } from './opportunity-inbox-types';
 
 interface SuggestedActionRow {
@@ -21,11 +24,23 @@ const TYPE_LABEL_BY_KIND: Readonly<Record<string, string>> = {
   'calendar.create_event': 'Suggestion',
 };
 
-function typeLabelForKind(kind: string): string {
+function typeLabelFor(
+  kind: string,
+  category: OpportunityInboxCardCategory
+): string {
+  if (category === 'tour_date') {
+    return 'Tour date';
+  }
   return TYPE_LABEL_BY_KIND[kind] ?? 'Suggestion';
 }
 
-function primaryActionLabelForKind(kind: string): string {
+function primaryActionLabelFor(
+  kind: string,
+  category: OpportunityInboxCardCategory
+): string {
+  if (category === 'tour_date') {
+    return 'Confirm date';
+  }
   return PRIMARY_ACTION_LABEL_BY_KIND[kind] ?? 'Approve';
 }
 
@@ -59,14 +74,16 @@ function whyFromRow(row: SuggestedActionRow): string {
 export function mapSuggestedActionToInboxCard(
   row: SuggestedActionRow
 ): OpportunityInboxCardViewModel {
+  const category = classifySuggestedActionCategory(row);
   return {
     id: row.id,
-    typeLabel: typeLabelForKind(row.kind),
+    typeLabel: typeLabelFor(row.kind, category),
     createdAt: row.createdAt.toISOString(),
     title: titleFromPayload(row.payload),
     why: whyFromRow(row),
-    primaryActionLabel: primaryActionLabelForKind(row.kind),
+    primaryActionLabel: primaryActionLabelFor(row.kind, category),
     status: 'pending',
+    category,
   };
 }
 
@@ -89,10 +106,12 @@ export const DEFAULT_OPPORTUNITY_INBOX_EMPTY_ACTION_CARDS: readonly OpportunityI
   ] as const;
 
 export function buildOpportunityInboxData(
-  rows: readonly SuggestedActionRow[]
+  rows: readonly SuggestedActionRow[],
+  tourDates?: OpportunityInboxTourDates
 ): OpportunityInboxData {
   return {
     cards: rows.map(mapSuggestedActionToInboxCard),
     emptyActionCards: DEFAULT_OPPORTUNITY_INBOX_EMPTY_ACTION_CARDS,
+    ...(tourDates ? { tourDates } : {}),
   };
 }

--- a/apps/web/lib/connectors/opportunity-inbox-tour-dates.test.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-tour-dates.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifySuggestedActionCategory,
+  formatTourDateDisplay,
+  formatTourDateLocation,
+  looksLikeTourDateSignal,
+  mapTourDateRowToInboxItem,
+} from './opportunity-inbox-tour-dates';
+
+describe('looksLikeTourDateSignal', () => {
+  it('classifies tour/event kinds as tour dates by construction', () => {
+    for (const kind of ['tour_date.detected', 'tour.sync', 'event.detected']) {
+      expect(
+        looksLikeTourDateSignal({ kind, payload: {}, rationale: null })
+      ).toBe(true);
+    }
+  });
+
+  it('classifies calendar events with venue-shaped payloads as tour dates', () => {
+    expect(
+      looksLikeTourDateSignal({
+        kind: 'calendar.create_event',
+        payload: { title: 'Detroit', venueName: 'Saint Andrews Hall' },
+        rationale: null,
+      })
+    ).toBe(true);
+    expect(
+      looksLikeTourDateSignal({
+        kind: 'calendar.create_event',
+        payload: { title: 'Detroit', city: 'Detroit' },
+        rationale: null,
+      })
+    ).toBe(true);
+  });
+
+  it('classifies calendar events with tour keywords in text as tour dates', () => {
+    expect(
+      looksLikeTourDateSignal({
+        kind: 'calendar.create_event',
+        payload: { title: 'Summer festival slot — tickets on sale Friday' },
+        rationale: null,
+      })
+    ).toBe(true);
+    expect(
+      looksLikeTourDateSignal({
+        kind: 'calendar.create_event',
+        payload: {},
+        rationale: 'Promoter confirmed the concert date for August.',
+      })
+    ).toBe(true);
+  });
+
+  it('leaves non-tour calendar events and other kinds as suggestions', () => {
+    expect(
+      looksLikeTourDateSignal({
+        kind: 'calendar.create_event',
+        payload: { title: 'Weekly catalog review' },
+        rationale: 'Recurring planning block.',
+      })
+    ).toBe(false);
+    expect(
+      looksLikeTourDateSignal({
+        kind: 'merch.create_drop',
+        payload: { title: 'Tour tee restock' },
+        rationale: null,
+      })
+    ).toBe(false);
+  });
+
+  it('handles non-object payloads without throwing', () => {
+    expect(
+      looksLikeTourDateSignal({
+        kind: 'calendar.create_event',
+        payload: null,
+        rationale: null,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('classifySuggestedActionCategory', () => {
+  it('maps the boolean signal onto card categories', () => {
+    expect(
+      classifySuggestedActionCategory({
+        kind: 'tour_date.detected',
+        payload: {},
+        rationale: null,
+      })
+    ).toBe('tour_date');
+    expect(
+      classifySuggestedActionCategory({
+        kind: 'calendar.create_event',
+        payload: { title: 'Weekly catalog review' },
+        rationale: null,
+      })
+    ).toBe('suggestion');
+  });
+});
+
+describe('mapTourDateRowToInboxItem', () => {
+  const row = {
+    id: 'td-1',
+    title: null,
+    startDate: new Date('2026-08-14T00:00:00.000Z'),
+    startTime: '7:00 PM',
+    venueName: 'Saint Andrews Hall',
+    city: 'Detroit',
+    region: 'MI',
+    country: 'US',
+    provider: 'bandsintown',
+    confirmationStatus: 'pending' as const,
+  };
+
+  it('falls back to the venue name when title is missing', () => {
+    const item = mapTourDateRowToInboxItem(row);
+    expect(item).toMatchObject({
+      id: 'td-1',
+      title: 'Saint Andrews Hall',
+      venueName: 'Saint Andrews Hall',
+      location: 'Detroit, MI',
+      providerLabel: 'Bandsintown',
+      status: 'pending',
+    });
+    expect(item.startDate).toBe('2026-08-14T00:00:00.000Z');
+  });
+
+  it('labels unknown providers as detected', () => {
+    const item = mapTourDateRowToInboxItem({
+      ...row,
+      provider: 'mystery_source',
+    });
+    expect(item.providerLabel).toBe('Detected');
+  });
+});
+
+describe('formatTourDateLocation', () => {
+  it('prefers region over country and skips blanks', () => {
+    expect(
+      formatTourDateLocation({ city: 'Detroit', region: 'MI', country: 'US' })
+    ).toBe('Detroit, MI');
+    expect(
+      formatTourDateLocation({ city: 'London', region: null, country: 'UK' })
+    ).toBe('London, UK');
+    expect(
+      formatTourDateLocation({ city: 'London', region: '  ', country: 'UK' })
+    ).toBe('London, UK');
+  });
+});
+
+describe('formatTourDateDisplay', () => {
+  it('formats UTC-anchored dates with optional wall time', () => {
+    expect(formatTourDateDisplay('2026-08-14T00:00:00.000Z', '7:00 PM')).toBe(
+      'Fri, Aug 14, 2026 · 7:00 PM'
+    );
+    expect(formatTourDateDisplay('2026-08-14T00:00:00.000Z', null)).toBe(
+      'Fri, Aug 14, 2026'
+    );
+  });
+
+  it('returns the raw string for unparseable dates', () => {
+    expect(formatTourDateDisplay('not-a-date', null)).toBe('not-a-date');
+  });
+});

--- a/apps/web/lib/connectors/opportunity-inbox-tour-dates.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-tour-dates.ts
@@ -1,0 +1,151 @@
+import type {
+  OpportunityInboxCardCategory,
+  OpportunityInboxTourDateItem,
+} from './opportunity-inbox-types';
+
+/**
+ * Pure tour-date signal classification + row mapping for the Opportunity
+ * Inbox. No server imports so the classifier stays unit-testable and safe to
+ * share with client view code.
+ */
+
+interface TourDateSignalInput {
+  readonly kind: string;
+  readonly payload: unknown;
+  readonly rationale: string | null;
+}
+
+/** Kinds that are tour/event signals by construction. */
+const TOUR_DATE_KIND_PREFIXES = ['tour_date', 'tour.', 'event.'] as const;
+
+/** Kinds that MAY carry a tour date depending on payload content. */
+const CANDIDATE_KINDS = new Set(['calendar.create_event']);
+
+/** Payload fields that indicate structured event/venue data. */
+const VENUE_FIELDS = ['venueName', 'venue', 'city', 'location'] as const;
+
+const TOUR_KEYWORD_PATTERN =
+  /\b(tour|concert|gig|festival|headlin\w*|support slot|opening for|on sale|tickets?|venue|live at|show at|residency)\b/i;
+
+function payloadRecord(payload: unknown): Record<string, unknown> | null {
+  return payload && typeof payload === 'object'
+    ? (payload as Record<string, unknown>)
+    : null;
+}
+
+function hasVenueShapedPayload(payload: unknown): boolean {
+  const record = payloadRecord(payload);
+  if (!record) {
+    return false;
+  }
+  return VENUE_FIELDS.some(field => {
+    const value = record[field];
+    return typeof value === 'string' && value.trim().length > 0;
+  });
+}
+
+function textSignals(input: TourDateSignalInput): string {
+  const record = payloadRecord(input.payload);
+  const title = record?.title;
+  const payloadRationale = record?.rationale;
+  return [
+    typeof title === 'string' ? title : '',
+    typeof payloadRationale === 'string' ? payloadRationale : '',
+    input.rationale ?? '',
+  ].join(' ');
+}
+
+/**
+ * Detects whether an incoming suggested-action signal looks like a tour
+ * date/event. Kind-prefix matches are definitive; candidate kinds (calendar
+ * events) qualify via structured venue fields or tour keywords in the
+ * title/rationale.
+ */
+export function looksLikeTourDateSignal(input: TourDateSignalInput): boolean {
+  const kind = input.kind.toLowerCase();
+  if (TOUR_DATE_KIND_PREFIXES.some(prefix => kind.startsWith(prefix))) {
+    return true;
+  }
+  if (!CANDIDATE_KINDS.has(kind)) {
+    return false;
+  }
+  return (
+    hasVenueShapedPayload(input.payload) ||
+    TOUR_KEYWORD_PATTERN.test(textSignals(input))
+  );
+}
+
+export function classifySuggestedActionCategory(
+  input: TourDateSignalInput
+): OpportunityInboxCardCategory {
+  return looksLikeTourDateSignal(input) ? 'tour_date' : 'suggestion';
+}
+
+/** Minimal row shape needed from `tour_dates` to build an inbox item. */
+export interface TourDateInboxRow {
+  readonly id: string;
+  readonly title: string | null;
+  readonly startDate: Date;
+  readonly startTime: string | null;
+  readonly venueName: string;
+  readonly city: string;
+  readonly region: string | null;
+  readonly country: string;
+  readonly provider: string;
+  readonly confirmationStatus: 'pending' | 'confirmed' | 'rejected';
+}
+
+const PROVIDER_LABELS: Readonly<Record<string, string>> = {
+  bandsintown: 'Bandsintown',
+  songkick: 'Songkick',
+  manual: 'Manual',
+  admin_import: 'Import',
+};
+
+export function formatTourDateLocation(row: {
+  readonly city: string;
+  readonly region: string | null;
+  readonly country: string;
+}): string {
+  const regionOrCountry = row.region?.trim() || row.country;
+  return [row.city, regionOrCountry].filter(Boolean).join(', ');
+}
+
+const TOUR_DATE_DISPLAY_FORMAT = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+/**
+ * Deterministic (UTC-anchored) display date so server and client render the
+ * same string — venue-local wall time is carried separately in `startTime`.
+ */
+export function formatTourDateDisplay(
+  startDate: string,
+  startTime: string | null
+): string {
+  const parsed = new Date(startDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return startDate;
+  }
+  const datePart = TOUR_DATE_DISPLAY_FORMAT.format(parsed);
+  return startTime ? `${datePart} · ${startTime}` : datePart;
+}
+
+export function mapTourDateRowToInboxItem(
+  row: TourDateInboxRow
+): OpportunityInboxTourDateItem {
+  return {
+    id: row.id,
+    title: row.title?.trim() || row.venueName,
+    startDate: row.startDate.toISOString(),
+    startTime: row.startTime,
+    venueName: row.venueName,
+    location: formatTourDateLocation(row),
+    providerLabel: PROVIDER_LABELS[row.provider] ?? 'Detected',
+    status: row.confirmationStatus,
+  };
+}

--- a/apps/web/lib/connectors/opportunity-inbox-types.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-types.ts
@@ -1,5 +1,7 @@
 export type OpportunityInboxCardStatus = 'pending';
 
+export type OpportunityInboxCardCategory = 'suggestion' | 'tour_date';
+
 export interface OpportunityInboxCardViewModel {
   readonly id: string;
   readonly typeLabel: string;
@@ -8,7 +10,31 @@ export interface OpportunityInboxCardViewModel {
   readonly why: string;
   readonly primaryActionLabel: string;
   readonly status: OpportunityInboxCardStatus;
+  readonly category: OpportunityInboxCardCategory;
 }
+
+export interface OpportunityInboxTourDateItem {
+  readonly id: string;
+  readonly title: string;
+  readonly startDate: string;
+  readonly startTime: string | null;
+  readonly venueName: string;
+  readonly location: string;
+  readonly providerLabel: string;
+  readonly status: 'pending' | 'confirmed' | 'rejected';
+}
+
+export interface OpportunityInboxTourDates {
+  readonly pending: readonly OpportunityInboxTourDateItem[];
+  readonly confirmed: readonly OpportunityInboxTourDateItem[];
+  readonly rejected: readonly OpportunityInboxTourDateItem[];
+}
+
+export const EMPTY_OPPORTUNITY_INBOX_TOUR_DATES: OpportunityInboxTourDates = {
+  pending: [],
+  confirmed: [],
+  rejected: [],
+};
 
 export interface OpportunityInboxEmptyActionCard {
   readonly id: string;
@@ -21,4 +47,5 @@ export interface OpportunityInboxEmptyActionCard {
 export interface OpportunityInboxData {
   readonly cards: readonly OpportunityInboxCardViewModel[];
   readonly emptyActionCards: readonly OpportunityInboxEmptyActionCard[];
+  readonly tourDates?: OpportunityInboxTourDates;
 }


### PR DESCRIPTION
## Problem
Detected tour dates (provider-synced + tour-date-looking calendar signals) have no Opportunity Inbox surface — the trust gate exists in the DB but the creator has nowhere in the inbox to review them. (#11508, part 1/2)

## What changed
- `lib/connectors/opportunity-inbox-tour-dates.ts` (new): pure tour-date signal classifier (`looksLikeTourDateSignal`) — kind-prefix matches (`tour_date`/`tour.`/`event.`) are definitive; `calendar.create_event` qualifies via venue-shaped payload fields or tour keywords in title/rationale. Plus `tour_dates` row → inbox item mapper and deterministic UTC-anchored date/location formatters.
- Card view model gains a `category` field (`suggestion` | `tour_date`); tour-date-classified suggested actions get `Tour date` type label + `Confirm date` primary action.
- `loadOpportunityInboxData` accepts an optional `profileId` and loads pending / confirmed-upcoming / rejected `tour_dates` sections (fail-soft: any query error degrades to empty sections; existing missing-connector-schema guard now still returns tour sections).
- `OpportunityInboxRoute` resolves the selected profile via the cached `getDashboardShellData` (fail-soft to null → sections omitted).
- Tests: classifier truth table, row mapper, formatters, mapper classification cases, pass-through of tour sections. Existing card literals updated for the new `category` field.

No UI renders the new sections yet — that lands in part 2 (stacked on this PR). No schema changes, no new dependencies.

## Assumptions
- Selected-profile resolution via `getDashboardShellData(clerkUserId).selectedProfile` matches the profile the tour-date trust-gate actions operate on (`getDashboardDataEssential().selectedProfile`); both derive from the same dashboard core.
- Display dates are UTC-anchored (venue-local wall time carried separately in `startTime`) to keep SSR/client render deterministic.

## Verification
Local verification blocked: sandbox has no repo deps and `registry.npmjs.org` returns 403 (network access requested, not granted during the run). Commands that must pass in CI:
```
pnpm install && pnpm turbo lint typecheck test:fast --affected && pnpm run build:web
```
Deferring to CI merge gates (`ci-fast`, `Unit Tests`, `Structural Contract`). New/changed unit tests: `lib/connectors/opportunity-inbox-tour-dates.test.ts`, `lib/connectors/opportunity-inbox-mapper.test.ts`, `components/features/opportunity-inbox/OpportunityInboxCard.test.tsx`.

## Links
Closes nothing on its own — part of #11508 (closes with part 2). Dispatch: issue #11508 (tim-approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
