### PR TITLE
visual-qa: golden-journey route registry + baseline compare core (part 1/3)

### DIFF
--- a/apps/web/lib/agent-os/golden-journey/compare.ts
+++ b/apps/web/lib/agent-os/golden-journey/compare.ts
@@ -1,0 +1,53 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { computePixelDiff } from '@/lib/agent-os/visual-qa/pixel-diff';
+
+/**
+ * Raw diff ratio above which a route is flagged for jury review.
+ * Below this, the change is treated as noise (fonts/AA jitter, timestamps).
+ */
+export const GOLDEN_JOURNEY_FLAG_DIFF_RATIO = 0.02;
+
+export interface GoldenJourneyDiffOutcome {
+  readonly rawDiffRatio: number;
+  readonly weightedDriftScore: number;
+  readonly flagged: boolean;
+  readonly overlay: Buffer;
+}
+
+export async function readOptionalPng(
+  filePath: string
+): Promise<Buffer | null> {
+  try {
+    return await fs.readFile(filePath);
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function compareAgainstGolden(params: {
+  readonly golden: Buffer;
+  readonly current: Buffer;
+  readonly flagDiffRatio?: number;
+}): Promise<GoldenJourneyDiffOutcome> {
+  const diff = await computePixelDiff(params.golden, params.current);
+  const flagDiffRatio = params.flagDiffRatio ?? GOLDEN_JOURNEY_FLAG_DIFF_RATIO;
+
+  return {
+    rawDiffRatio: diff.rawDiffRatio,
+    weightedDriftScore: diff.weightedDriftScore,
+    flagged: diff.rawDiffRatio >= flagDiffRatio,
+    overlay: diff.overlay,
+  };
+}
+
+export async function writeGolden(
+  goldenPath: string,
+  current: Buffer
+): Promise<void> {
+  await fs.mkdir(path.dirname(goldenPath), { recursive: true });
+  await fs.writeFile(goldenPath, current);
+}

--- a/apps/web/lib/agent-os/golden-journey/paths.ts
+++ b/apps/web/lib/agent-os/golden-journey/paths.ts
@@ -1,0 +1,98 @@
+import path from 'node:path';
+import { resolveMonorepoPath } from '@/lib/filesystem-paths';
+import { validatePathTraversal } from '@/lib/security/path-traversal';
+import { assertValidGoldenJourneyRouteId } from './routes';
+
+export const GOLDEN_JOURNEY_RUNS_ROOT_SEGMENTS = [
+  'agentos',
+  'runs',
+  'golden-journey',
+] as const;
+
+export const GOLDEN_JOURNEY_GOLDENS_ROOT_SEGMENTS = [
+  'agentos',
+  'golden-journey-goldens',
+] as const;
+
+const RUN_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,79}$/i;
+
+export function getGoldenJourneyRunsRootDirectory(): string {
+  return (
+    process.env.GOLDEN_JOURNEY_RUNS_DIR ??
+    resolveMonorepoPath(...GOLDEN_JOURNEY_RUNS_ROOT_SEGMENTS)
+  );
+}
+
+/**
+ * Rolling baseline directory. Populated by the previous accepted sweep
+ * (restored from the workflow cache in CI); when a route has no golden yet
+ * the current capture bootstraps it.
+ */
+export function getGoldenJourneyGoldensDirectory(): string {
+  return (
+    process.env.GOLDEN_JOURNEY_GOLDENS_DIR ??
+    resolveMonorepoPath(...GOLDEN_JOURNEY_GOLDENS_ROOT_SEGMENTS)
+  );
+}
+
+export function assertValidGoldenJourneyRunId(runId: string): string {
+  const safeRunId = runId.trim();
+  if (!RUN_ID_PATTERN.test(safeRunId)) {
+    throw new Error(`Invalid golden journey run id: ${runId}`);
+  }
+
+  return safeRunId;
+}
+
+export function resolveGoldenJourneyRunDirectory(runId: string): string {
+  const safeRunId = assertValidGoldenJourneyRunId(runId);
+  return validatePathTraversal(safeRunId, getGoldenJourneyRunsRootDirectory());
+}
+
+export function resolveGoldenJourneyScreenshotPath(
+  runId: string,
+  routeId: string
+): string {
+  const safeRunId = assertValidGoldenJourneyRunId(runId);
+  const safeRouteId = assertValidGoldenJourneyRouteId(routeId);
+  return validatePathTraversal(
+    path.join(safeRunId, `${safeRouteId}.png`),
+    getGoldenJourneyRunsRootDirectory()
+  );
+}
+
+export function resolveGoldenJourneyDiffOverlayPath(
+  runId: string,
+  routeId: string
+): string {
+  const safeRunId = assertValidGoldenJourneyRunId(runId);
+  const safeRouteId = assertValidGoldenJourneyRouteId(routeId);
+  return validatePathTraversal(
+    path.join(safeRunId, `${safeRouteId}.diff.png`),
+    getGoldenJourneyRunsRootDirectory()
+  );
+}
+
+export function resolveGoldenJourneyManifestPath(runId: string): string {
+  const safeRunId = assertValidGoldenJourneyRunId(runId);
+  return validatePathTraversal(
+    path.join(safeRunId, 'manifest.json'),
+    getGoldenJourneyRunsRootDirectory()
+  );
+}
+
+export function resolveGoldenJourneyIssueFilingsPath(runId: string): string {
+  const safeRunId = assertValidGoldenJourneyRunId(runId);
+  return validatePathTraversal(
+    path.join(safeRunId, 'issue-filings.json'),
+    getGoldenJourneyRunsRootDirectory()
+  );
+}
+
+export function resolveGoldenJourneyGoldenPath(routeId: string): string {
+  const safeRouteId = assertValidGoldenJourneyRouteId(routeId);
+  return validatePathTraversal(
+    `${safeRouteId}.png`,
+    getGoldenJourneyGoldensDirectory()
+  );
+}

--- a/apps/web/lib/agent-os/golden-journey/routes.ts
+++ b/apps/web/lib/agent-os/golden-journey/routes.ts
@@ -1,0 +1,95 @@
+import { APP_ROUTES } from '@/constants/routes';
+
+/**
+ * Golden-journey route registry (JOV #11815).
+ *
+ * Real routes in real states — captured post-deploy and compared against the
+ * previous accepted baseline, then run through the design-taste jury. This is
+ * the net for jank that component-level Storybook capture cannot see.
+ */
+
+export const GOLDEN_JOURNEY_AUTH_STATES = [
+  'logged-out',
+  'creator',
+  'creator-ready',
+] as const;
+
+export type GoldenJourneyAuthState =
+  (typeof GOLDEN_JOURNEY_AUTH_STATES)[number];
+
+export interface GoldenJourneyRoute {
+  /** Stable id, used for screenshot filenames and issue dedupe. */
+  readonly id: string;
+  /** App-relative path to capture. */
+  readonly path: string;
+  /**
+   * Auth state to capture in. Non-logged-out states bootstrap through the
+   * dev test-auth bypass (`/api/dev/test-auth/enter`) which only exists on
+   * non-production deploys / local servers.
+   */
+  readonly authState: GoldenJourneyAuthState;
+  /** Human description used in jury prompts and filed issues. */
+  readonly description: string;
+}
+
+const ROUTE_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,79}$/;
+
+export const GOLDEN_JOURNEY_ROUTES: readonly GoldenJourneyRoute[] = [
+  {
+    id: 'home-logged-out',
+    path: '/',
+    authState: 'logged-out',
+    description: 'Logged-out marketing homepage (hero + first proof beat).',
+  },
+  {
+    id: 'signin',
+    path: APP_ROUTES.SIGNIN,
+    authState: 'logged-out',
+    description: 'Sign-in surface, including Turnstile/SSO placement.',
+  },
+  {
+    id: 'onboarding',
+    path: APP_ROUTES.ONBOARDING,
+    authState: 'creator',
+    description: 'Onboarding entry for a signed-in, incomplete creator.',
+  },
+  {
+    id: 'chat',
+    path: APP_ROUTES.CHAT,
+    authState: 'creator-ready',
+    description: 'Chat home surface for a Pro-entitled creator.',
+  },
+  {
+    id: 'library',
+    path: APP_ROUTES.LIBRARY,
+    authState: 'creator-ready',
+    description: 'Library with the seeded creator fixture data.',
+  },
+  {
+    id: 'releases',
+    path: APP_ROUTES.RELEASES,
+    authState: 'creator-ready',
+    description: 'Releases workspace for the seeded creator.',
+  },
+  {
+    id: 'settings',
+    path: APP_ROUTES.SETTINGS,
+    authState: 'creator-ready',
+    description: 'Settings surface for the seeded creator.',
+  },
+] as const;
+
+export function assertValidGoldenJourneyRouteId(routeId: string): string {
+  const safeRouteId = routeId.trim();
+  if (!ROUTE_ID_PATTERN.test(safeRouteId)) {
+    throw new Error(`Invalid golden journey route id: ${routeId}`);
+  }
+
+  return safeRouteId;
+}
+
+export function getGoldenJourneyRoute(
+  routeId: string
+): GoldenJourneyRoute | null {
+  return GOLDEN_JOURNEY_ROUTES.find(route => route.id === routeId) ?? null;
+}

--- a/apps/web/lib/agent-os/golden-journey/types.ts
+++ b/apps/web/lib/agent-os/golden-journey/types.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+import { GOLDEN_JOURNEY_AUTH_STATES } from './routes';
+
+export const GOLDEN_JOURNEY_JURY_VERDICTS = [
+  'improvement',
+  'neutral',
+  'regression',
+  'broken',
+] as const;
+
+export type GoldenJourneyJuryVerdict =
+  (typeof GOLDEN_JOURNEY_JURY_VERDICTS)[number];
+
+export const GoldenJourneyJuryFindingSchema = z
+  .object({
+    summary: z.string().trim().min(1).max(500),
+    severity: z.enum(['low', 'medium', 'high']),
+  })
+  .strict();
+
+export const GoldenJourneyJuryResultSchema = z
+  .object({
+    verdict: z.enum(GOLDEN_JOURNEY_JURY_VERDICTS),
+    findings: z.array(GoldenJourneyJuryFindingSchema).max(10),
+    reasoning: z.string().trim().min(1).max(2000),
+  })
+  .strict();
+
+export type GoldenJourneyJuryResult = z.infer<
+  typeof GoldenJourneyJuryResultSchema
+>;
+
+export const GoldenJourneyRouteResultSchema = z
+  .object({
+    routeId: z.string().trim().min(1),
+    path: z.string().trim().min(1),
+    authState: z.enum(GOLDEN_JOURNEY_AUTH_STATES),
+    screenshot: z.string().trim().min(1),
+    /** True when no baseline existed and this capture seeded it. */
+    bootstrapped: z.boolean(),
+    diff: z.union([
+      z
+        .object({
+          rawDiffRatio: z.number().min(0).max(1),
+          weightedDriftScore: z.number().min(0).max(1),
+          flagged: z.boolean(),
+        })
+        .strict(),
+      z.null(),
+    ]),
+    jury: z.union([
+      z
+        .object({
+          model: z.string().trim().min(1),
+          result: GoldenJourneyJuryResultSchema,
+        })
+        .strict(),
+      z
+        .object({
+          skipped: z.literal(true),
+          reason: z.string().trim().min(1),
+        })
+        .strict(),
+      z.null(),
+    ]),
+  })
+  .strict();
+
+export type GoldenJourneyRouteResult = z.infer<
+  typeof GoldenJourneyRouteResultSchema
+>;
+
+export const GoldenJourneyIssueFilingSchema = z
+  .object({
+    routeId: z.string().trim().min(1),
+    title: z.string().trim().min(1).max(200),
+    body: z.string().trim().min(1),
+  })
+  .strict();
+
+export type GoldenJourneyIssueFiling = z.infer<
+  typeof GoldenJourneyIssueFilingSchema
+>;
+
+export const GoldenJourneySweepManifestSchema = z
+  .object({
+    runId: z.string().trim().min(1).max(80),
+    gitSha: z.union([z.string().trim().min(1).max(64), z.null()]),
+    computedAt: z.string().datetime(),
+    routes: z.array(GoldenJourneyRouteResultSchema),
+    issueFilings: z.array(GoldenJourneyIssueFilingSchema),
+    summary: z
+      .object({
+        routesTotal: z.number().int().min(0),
+        routesFlagged: z.number().int().min(0),
+        routesBootstrapped: z.number().int().min(0),
+        routesMissingCapture: z.number().int().min(0),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type GoldenJourneySweepManifest = z.infer<
+  typeof GoldenJourneySweepManifestSchema
+>;

--- a/apps/web/lib/constants/ai-models.ts
+++ b/apps/web/lib/constants/ai-models.ts
@@ -26,3 +26,6 @@ export const TITLE_MODEL = 'google/gemini-2.0-flash';
 /** Model used for YouTube packaging intelligence extraction */
 export const PACKAGING_INTELLIGENCE_MODEL =
   'anthropic/claude-haiku-4-5-20251001';
+
+/** Vision-capable model used for the golden-journey design-taste sweep */
+export const DESIGN_TASTE_SWEEP_MODEL = 'anthropic/claude-haiku-4-5-20251001';

--- a/apps/web/tests/unit/agent-os/golden-journey/routes.test.ts
+++ b/apps/web/tests/unit/agent-os/golden-journey/routes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertValidGoldenJourneyRouteId,
+  GOLDEN_JOURNEY_ROUTES,
+  getGoldenJourneyRoute,
+} from '@/lib/agent-os/golden-journey/routes';
+
+describe('GOLDEN_JOURNEY_ROUTES', () => {
+  it('has unique, filename-safe route ids', () => {
+    const ids = GOLDEN_JOURNEY_ROUTES.map(route => route.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(assertValidGoldenJourneyRouteId(id)).toBe(id);
+    }
+  });
+
+  it('covers logged-out and seeded logged-in states', () => {
+    const states = new Set(GOLDEN_JOURNEY_ROUTES.map(route => route.authState));
+    expect(states.has('logged-out')).toBe(true);
+    expect(states.has('creator-ready')).toBe(true);
+  });
+
+  it('uses app-relative paths', () => {
+    for (const route of GOLDEN_JOURNEY_ROUTES) {
+      expect(route.path.startsWith('/')).toBe(true);
+    }
+  });
+
+  it('rejects traversal-shaped route ids', () => {
+    expect(() => assertValidGoldenJourneyRouteId('../etc')).toThrow();
+    expect(() => assertValidGoldenJourneyRouteId('bad/slash')).toThrow();
+  });
+
+  it('looks up routes by id', () => {
+    expect(getGoldenJourneyRoute('home-logged-out')?.path).toBe('/');
+    expect(getGoldenJourneyRoute('nope')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem
Visual QA captures Storybook components in isolation — real routes in real states (Turnstile, onboarding dump, seeded library) are never screenshotted, so route-level jank ships undetected. (#11815)

## What changed (part 1/3 — land first)
Core golden-journey module under `apps/web/lib/agent-os/golden-journey/`:
- `routes.ts` — golden route registry (logged-out + seeded logged-in states via test-auth personas), 7 routes: home, signin, onboarding, chat, library, releases, settings.
- `types.ts` — zod manifest/jury/issue-filing schemas.
- `paths.ts` — run + rolling-golden path resolvers (traversal-guarded, env-overridable for tests/CI).
- `compare.ts` — baseline comparison reusing the existing `computePixelDiff` (sharp) from `lib/agent-os/visual-qa`; flag threshold 2% raw drift.
- `DESIGN_TASTE_SWEEP_MODEL` constant in `lib/constants/ai-models.ts` (vision-capable haiku via the AI gateway).
- Unit tests for the registry.

Stack: part 2/3 adds the sweep orchestrator + VLM jury; part 3/3 adds the Playwright capture harness + post-deploy workflow.

## Assumptions
- Rolling baseline (previous accepted sweep = golden) instead of repo-committed goldens — keeps PNGs out of git; goldens live in the workflow cache (part 3).
- Public profile route excluded from v1 (needs a stable seeded username); tracked in #11815's ladder.
- Sweep metadata DB table (`visual_regression_sweeps`) deferred: sandbox had no npm registry access, so a drizzle snapshot could not be generated safely; dispatch allowed artifact storage as the alternative. Follow-up noted on #11815.

## Verification
Sandbox had no npm registry access (network grant not approved), so `pnpm turbo lint typecheck test:fast` could not run locally. Ran Biome 2.5.1 (release binary) clean on all new files:
```
$ biome check apps/web/lib/agent-os/golden-journey ... 
Checked 14 files in 61ms. Fixed 5 files.  (re-check: no diagnostics)
```
Typecheck + unit tests deferred to CI on this PR — please treat CI as the verification gate before queueing.

Dispatch: ship-11815 · Part of #11815
