### PR TITLE
visual-qa: golden-journey sweep orchestrator + design-taste jury (part 2/3)

### DIFF
--- a/apps/web/lib/agent-os/golden-journey/sweep.ts
+++ b/apps/web/lib/agent-os/golden-journey/sweep.ts
@@ -1,0 +1,236 @@
+import { promises as fs } from 'node:fs';
+import { compareAgainstGolden, readOptionalPng, writeGolden } from './compare';
+import {
+  resolveGoldenJourneyDiffOverlayPath,
+  resolveGoldenJourneyGoldenPath,
+  resolveGoldenJourneyIssueFilingsPath,
+  resolveGoldenJourneyManifestPath,
+  resolveGoldenJourneyRunDirectory,
+  resolveGoldenJourneyScreenshotPath,
+} from './paths';
+import { GOLDEN_JOURNEY_ROUTES, type GoldenJourneyRoute } from './routes';
+import { evaluateRouteWithJury } from './taste-jury';
+import {
+  type GoldenJourneyIssueFiling,
+  type GoldenJourneyRouteResult,
+  type GoldenJourneySweepManifest,
+  GoldenJourneySweepManifestSchema,
+} from './types';
+
+export interface RunGoldenJourneySweepParams {
+  readonly runId: string;
+  readonly gitSha?: string | null;
+  /** When false, the VLM jury is skipped (e.g. no gateway credentials). */
+  readonly juryEnabled: boolean;
+  readonly jurySkipReason?: string;
+  readonly flagDiffRatio?: number;
+  readonly routes?: readonly GoldenJourneyRoute[];
+}
+
+export interface RunGoldenJourneySweepResult {
+  readonly manifest: GoldenJourneySweepManifest;
+  readonly manifestPath: string;
+  readonly issueFilingsPath: string;
+}
+
+function buildIssueFiling(
+  route: GoldenJourneyRoute,
+  result: GoldenJourneyRouteResult
+): GoldenJourneyIssueFiling {
+  const verdict =
+    result.jury && 'result' in result.jury
+      ? result.jury.result.verdict
+      : 'unreviewed';
+  const findings =
+    result.jury && 'result' in result.jury
+      ? result.jury.result.findings
+          .map(finding => `- [${finding.severity}] ${finding.summary}`)
+          .join('\n')
+      : '- Jury unavailable; flagged on pixel drift alone.';
+  const diffLine = result.diff
+    ? `Pixel drift: ${(result.diff.rawDiffRatio * 100).toFixed(2)}% of pixels changed vs the previous accepted baseline.`
+    : 'No baseline diff available.';
+
+  return {
+    routeId: route.id,
+    title: `[golden-journey] ${route.id}: ${verdict} on ${route.path}`,
+    body: [
+      `## Golden journey sweep flag`,
+      '',
+      `- Route: \`${route.path}\` (${route.id})`,
+      `- State: ${route.authState}`,
+      `- Surface: ${route.description}`,
+      `- Jury verdict: **${verdict}**`,
+      '',
+      diffLine,
+      '',
+      '### Findings',
+      findings,
+      '',
+      '_Screenshots + diff overlay are attached to the workflow run artifact._',
+      '',
+      'Part of #11815 (route-level golden-journey capture + design-taste jury).',
+    ].join('\n'),
+  };
+}
+
+function shouldFileIssue(result: GoldenJourneyRouteResult): boolean {
+  if (!result.diff?.flagged) {
+    return false;
+  }
+
+  if (result.jury && 'result' in result.jury) {
+    return (
+      result.jury.result.verdict === 'regression' ||
+      result.jury.result.verdict === 'broken'
+    );
+  }
+
+  // Flagged drift with no jury available — surface it rather than drop it.
+  return true;
+}
+
+function shouldPromoteToGolden(result: GoldenJourneyRouteResult): boolean {
+  if (!result.diff) {
+    return false;
+  }
+
+  if (!result.diff.flagged) {
+    return true;
+  }
+
+  if (result.jury && 'result' in result.jury) {
+    return (
+      result.jury.result.verdict === 'improvement' ||
+      result.jury.result.verdict === 'neutral'
+    );
+  }
+
+  // Conservative: keep the old baseline when the jury could not review.
+  return false;
+}
+
+async function sweepRoute(
+  route: GoldenJourneyRoute,
+  params: RunGoldenJourneySweepParams
+): Promise<GoldenJourneyRouteResult | null> {
+  const screenshotPath = resolveGoldenJourneyScreenshotPath(
+    params.runId,
+    route.id
+  );
+  const current = await readOptionalPng(screenshotPath);
+  if (!current) {
+    return null;
+  }
+
+  const goldenPath = resolveGoldenJourneyGoldenPath(route.id);
+  const golden = await readOptionalPng(goldenPath);
+
+  let diff: GoldenJourneyRouteResult['diff'] = null;
+  if (golden) {
+    const outcome = await compareAgainstGolden({
+      golden,
+      current,
+      flagDiffRatio: params.flagDiffRatio,
+    });
+    diff = {
+      rawDiffRatio: outcome.rawDiffRatio,
+      weightedDriftScore: outcome.weightedDriftScore,
+      flagged: outcome.flagged,
+    };
+    if (outcome.flagged) {
+      await fs.writeFile(
+        resolveGoldenJourneyDiffOverlayPath(params.runId, route.id),
+        outcome.overlay
+      );
+    }
+  }
+
+  let jury: GoldenJourneyRouteResult['jury'] = null;
+  const wantsJury = !golden || diff?.flagged === true;
+  if (wantsJury) {
+    if (params.juryEnabled) {
+      jury = await evaluateRouteWithJury({ route, current, golden });
+    } else {
+      jury = {
+        skipped: true,
+        reason: params.jurySkipReason ?? 'Jury disabled for this run.',
+      };
+    }
+  }
+
+  const result: GoldenJourneyRouteResult = {
+    routeId: route.id,
+    path: route.path,
+    authState: route.authState,
+    screenshot: `${route.id}.png`,
+    bootstrapped: !golden,
+    diff,
+    jury,
+  };
+
+  if (!golden || shouldPromoteToGolden(result)) {
+    await writeGolden(goldenPath, current);
+  }
+
+  return result;
+}
+
+export async function runGoldenJourneySweep(
+  params: RunGoldenJourneySweepParams
+): Promise<RunGoldenJourneySweepResult> {
+  const routes = params.routes ?? GOLDEN_JOURNEY_ROUTES;
+  const routeResults: GoldenJourneyRouteResult[] = [];
+  let routesMissingCapture = 0;
+
+  for (const route of routes) {
+    const result = await sweepRoute(route, params);
+    if (!result) {
+      routesMissingCapture += 1;
+      continue;
+    }
+    routeResults.push(result);
+  }
+
+  const issueFilings = routeResults
+    .filter(shouldFileIssue)
+    .map(result => {
+      const route = routes.find(entry => entry.id === result.routeId);
+      return route ? buildIssueFiling(route, result) : null;
+    })
+    .filter((filing): filing is GoldenJourneyIssueFiling => filing !== null);
+
+  const manifest = GoldenJourneySweepManifestSchema.parse({
+    runId: params.runId,
+    gitSha: params.gitSha ?? null,
+    computedAt: new Date().toISOString(),
+    routes: routeResults,
+    issueFilings,
+    summary: {
+      routesTotal: routeResults.length,
+      routesFlagged: routeResults.filter(result => result.diff?.flagged).length,
+      routesBootstrapped: routeResults.filter(result => result.bootstrapped)
+        .length,
+      routesMissingCapture,
+    },
+  } satisfies GoldenJourneySweepManifest);
+
+  await fs.mkdir(resolveGoldenJourneyRunDirectory(params.runId), {
+    recursive: true,
+  });
+
+  const manifestPath = resolveGoldenJourneyManifestPath(params.runId);
+  const issueFilingsPath = resolveGoldenJourneyIssueFilingsPath(params.runId);
+  await fs.writeFile(
+    manifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    'utf8'
+  );
+  await fs.writeFile(
+    issueFilingsPath,
+    `${JSON.stringify(issueFilings, null, 2)}\n`,
+    'utf8'
+  );
+
+  return { manifest, manifestPath, issueFilingsPath };
+}

--- a/apps/web/lib/agent-os/golden-journey/taste-jury.ts
+++ b/apps/web/lib/agent-os/golden-journey/taste-jury.ts
@@ -1,0 +1,79 @@
+import { DESIGN_TASTE_SWEEP_MODEL } from '@/lib/constants/ai-models';
+import type { GoldenJourneyRoute } from './routes';
+import {
+  type GoldenJourneyJuryResult,
+  GoldenJourneyJuryResultSchema,
+} from './types';
+
+const JURY_SYSTEM_PROMPT = [
+  'You are a senior product-design reviewer for Jovie, a premium music-artist',
+  'platform whose UI register is Linear-like: compact, quiet, precise.',
+  'You are shown a screenshot of a real route captured after a deploy, and',
+  '(when available) the previous accepted baseline of the same route.',
+  'Judge whether anything is visually broken, janky, misaligned, clipped,',
+  'overlapping, unstyled, placeholder-looking, or off-brand — and whether the',
+  'change relative to the baseline is an improvement or a regression.',
+  'Verdicts: "broken" = something is visibly wrong on first sight;',
+  '"regression" = worse than the baseline but functional;',
+  '"neutral" = expected/no meaningful change; "improvement" = better.',
+  'Content that is SUPPOSED to change (dates, dynamic data, imagery) is not a',
+  'finding. Report only what a founder would flag as jank.',
+].join(' ');
+
+export interface GoldenJourneyJuryEvaluation {
+  readonly model: string;
+  readonly result: GoldenJourneyJuryResult;
+}
+
+/**
+ * Evaluate a captured route screenshot with the design-taste jury model via
+ * the AI SDK gateway chokepoint. Callers gate invocation on gateway
+ * availability; this function assumes credentials are present.
+ */
+export async function evaluateRouteWithJury(params: {
+  readonly route: GoldenJourneyRoute;
+  readonly current: Buffer;
+  readonly golden: Buffer | null;
+  readonly model?: string;
+}): Promise<GoldenJourneyJuryEvaluation> {
+  // Lazy-load so deterministic paths (tests, compare-only runs) never touch
+  // the gateway module.
+  const { gateway, generateObject } = await import('@/lib/ai/sdk');
+  const model = params.model ?? DESIGN_TASTE_SWEEP_MODEL;
+
+  const content: Array<
+    { type: 'text'; text: string } | { type: 'image'; image: Buffer }
+  > = [
+    {
+      type: 'text',
+      text: [
+        `Route: ${params.route.path} (${params.route.id})`,
+        `State: ${params.route.authState}`,
+        `Surface: ${params.route.description}`,
+        'Current post-deploy capture:',
+      ].join('\n'),
+    },
+    { type: 'image', image: params.current },
+  ];
+
+  if (params.golden) {
+    content.push(
+      { type: 'text', text: 'Previous accepted baseline for comparison:' },
+      { type: 'image', image: params.golden }
+    );
+  } else {
+    content.push({
+      type: 'text',
+      text: 'No baseline exists yet — judge the capture on its own.',
+    });
+  }
+
+  const { object } = await generateObject({
+    model: gateway(model),
+    schema: GoldenJourneyJuryResultSchema,
+    system: JURY_SYSTEM_PROMPT,
+    messages: [{ role: 'user', content }],
+  });
+
+  return { model, result: object };
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -109,6 +109,8 @@
     "e2e:full:fast": "node scripts/run-playwright-fast.mjs",
     "e2e:visual": "playwright test tests/e2e/visual-regression.spec.ts",
     "e2e:visual:update": "playwright test tests/e2e/visual-regression.spec.ts --update-snapshots",
+    "golden-journey:capture": "playwright test --config=playwright.config.golden-journey.ts",
+    "golden-journey:sweep": "tsx scripts/golden-journey-sweep.ts",
     "screenshots": "pnpm run screenshots:seed && pnpm run screenshots:capture",
     "screenshots:capture": "playwright test --config=playwright.config.screenshots.ts",
     "screenshots:seed": "tsx tests/product-screenshots/seed.ts",

--- a/apps/web/scripts/golden-journey-sweep.ts
+++ b/apps/web/scripts/golden-journey-sweep.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env tsx
+/**
+ * Golden-journey sweep CLI (JOV #11815).
+ *
+ * Runs AFTER `golden-journey:capture` has populated the run directory:
+ *   1. Diffs each captured route against its rolling golden baseline.
+ *   2. Sends flagged (or baseline-less) routes to the design-taste jury.
+ *   3. Writes manifest.json + issue-filings.json into the run directory.
+ *
+ * Results are stored as workflow run artifacts; goldens roll forward via the
+ * workflow cache. (Durable DB persistence of sweep metadata is a tracked
+ * follow-up — see the PR for issue #11815.)
+ *
+ * Usage:
+ *   pnpm --filter web golden-journey:sweep -- --run-id=<id> [--git-sha=<sha>] [--no-jury]
+ */
+
+import process from 'node:process';
+import { runGoldenJourneySweep } from '@/lib/agent-os/golden-journey/sweep';
+
+interface CliOptions {
+  readonly runId: string;
+  readonly gitSha: string | null;
+  readonly juryDisabled: boolean;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  let runId = process.env.GOLDEN_JOURNEY_RUN_ID ?? '';
+  let gitSha: string | null = process.env.GITHUB_SHA ?? null;
+  let juryDisabled = false;
+
+  for (const arg of argv) {
+    if (arg.startsWith('--run-id=')) {
+      runId = arg.slice('--run-id='.length);
+    } else if (arg.startsWith('--git-sha=')) {
+      gitSha = arg.slice('--git-sha='.length);
+    } else if (arg === '--no-jury') {
+      juryDisabled = true;
+    }
+  }
+
+  if (!runId.trim()) {
+    throw new Error(
+      'Missing golden journey run id. Pass --run-id=<id> or GOLDEN_JOURNEY_RUN_ID.'
+    );
+  }
+
+  return { runId: runId.trim(), gitSha, juryDisabled };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  const gatewayKeyPresent = Boolean(process.env.AI_GATEWAY_API_KEY?.trim());
+  const juryEnabled = !options.juryDisabled && gatewayKeyPresent;
+  const jurySkipReason = options.juryDisabled
+    ? 'Jury disabled via --no-jury.'
+    : 'AI_GATEWAY_API_KEY not configured; skipped VLM review.';
+
+  const { manifest, manifestPath, issueFilingsPath } =
+    await runGoldenJourneySweep({
+      runId: options.runId,
+      gitSha: options.gitSha,
+      juryEnabled,
+      jurySkipReason,
+    });
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        manifestPath,
+        issueFilingsPath,
+        summary: manifest.summary,
+        juryEnabled,
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  if (manifest.issueFilings.length > 0) {
+    // Non-zero exit signals the workflow to surface flagged regressions.
+    process.exitCode = 2;
+  }
+}
+
+void main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/web/tests/unit/agent-os/golden-journey/sweep.test.ts
+++ b/apps/web/tests/unit/agent-os/golden-journey/sweep.test.ts
@@ -1,0 +1,150 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import sharp from 'sharp';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  compareAgainstGolden,
+  GOLDEN_JOURNEY_FLAG_DIFF_RATIO,
+} from '@/lib/agent-os/golden-journey/compare';
+import type { GoldenJourneyRoute } from '@/lib/agent-os/golden-journey/routes';
+import { runGoldenJourneySweep } from '@/lib/agent-os/golden-journey/sweep';
+import { GoldenJourneySweepManifestSchema } from '@/lib/agent-os/golden-journey/types';
+
+vi.mock('@/lib/ai/sdk', () => ({
+  gateway: vi.fn(),
+  generateObject: vi.fn(),
+}));
+
+async function solidPng(rgb: { r: number; g: number; b: number }) {
+  return sharp({
+    create: { width: 24, height: 24, channels: 3, background: rgb },
+  })
+    .png()
+    .toBuffer();
+}
+
+const ROUTE: GoldenJourneyRoute = {
+  id: 'home-logged-out',
+  path: '/',
+  authState: 'logged-out',
+  description: 'Test route.',
+};
+
+describe('compareAgainstGolden', () => {
+  it('does not flag identical captures', async () => {
+    const image = await solidPng({ r: 10, g: 10, b: 10 });
+    const outcome = await compareAgainstGolden({
+      golden: image,
+      current: image,
+    });
+    expect(outcome.rawDiffRatio).toBe(0);
+    expect(outcome.flagged).toBe(false);
+  });
+
+  it('flags captures whose drift exceeds the flag ratio', async () => {
+    const outcome = await compareAgainstGolden({
+      golden: await solidPng({ r: 10, g: 10, b: 10 }),
+      current: await solidPng({ r: 240, g: 240, b: 240 }),
+    });
+    expect(outcome.rawDiffRatio).toBeGreaterThan(
+      GOLDEN_JOURNEY_FLAG_DIFF_RATIO
+    );
+    expect(outcome.flagged).toBe(true);
+  });
+});
+
+describe('runGoldenJourneySweep', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(tmpdir(), 'golden-journey-'));
+    process.env.GOLDEN_JOURNEY_GOLDENS_DIR = path.join(workspace, 'goldens');
+    process.env.GOLDEN_JOURNEY_RUNS_DIR = path.join(workspace, 'runs');
+  });
+
+  afterEach(() => {
+    delete process.env.GOLDEN_JOURNEY_GOLDENS_DIR;
+    delete process.env.GOLDEN_JOURNEY_RUNS_DIR;
+    vi.restoreAllMocks();
+  });
+
+  it('bootstraps missing goldens and skips the jury when disabled', async () => {
+    const runId = `test-${Date.now().toString(36)}`;
+    const { mkdir } = await import('node:fs/promises');
+    const {
+      resolveGoldenJourneyScreenshotPath,
+      resolveGoldenJourneyGoldenPath,
+    } = await import('@/lib/agent-os/golden-journey/paths');
+
+    const screenshotPath = resolveGoldenJourneyScreenshotPath(runId, ROUTE.id);
+    await mkdir(path.dirname(screenshotPath), { recursive: true });
+    await writeFile(screenshotPath, await solidPng({ r: 10, g: 10, b: 10 }));
+
+    const { manifest, manifestPath } = await runGoldenJourneySweep({
+      runId,
+      gitSha: 'abc1234',
+      juryEnabled: false,
+      jurySkipReason: 'test run',
+      routes: [ROUTE],
+    });
+
+    expect(manifest.summary.routesBootstrapped).toBe(1);
+    expect(manifest.summary.routesFlagged).toBe(0);
+    expect(manifest.issueFilings).toHaveLength(0);
+    const routeResult = manifest.routes[0];
+    expect(routeResult?.bootstrapped).toBe(true);
+    expect(routeResult?.jury).toEqual({ skipped: true, reason: 'test run' });
+
+    // Golden seeded for the next run.
+    await expect(
+      readFile(resolveGoldenJourneyGoldenPath(ROUTE.id))
+    ).resolves.toBeInstanceOf(Buffer);
+
+    // Manifest on disk round-trips through the schema.
+    const persisted = JSON.parse(await readFile(manifestPath, 'utf8'));
+    expect(GoldenJourneySweepManifestSchema.parse(persisted).runId).toBe(runId);
+  });
+
+  it('files an issue and keeps the old golden on a jury-confirmed regression', async () => {
+    const runId = `test-reg-${Date.now().toString(36)}`;
+    const { mkdir } = await import('node:fs/promises');
+    const {
+      resolveGoldenJourneyScreenshotPath,
+      resolveGoldenJourneyGoldenPath,
+    } = await import('@/lib/agent-os/golden-journey/paths');
+
+    const golden = await solidPng({ r: 10, g: 10, b: 10 });
+    const goldenPath = resolveGoldenJourneyGoldenPath(ROUTE.id);
+    await mkdir(path.dirname(goldenPath), { recursive: true });
+    await writeFile(goldenPath, golden);
+
+    const screenshotPath = resolveGoldenJourneyScreenshotPath(runId, ROUTE.id);
+    await mkdir(path.dirname(screenshotPath), { recursive: true });
+    await writeFile(screenshotPath, await solidPng({ r: 240, g: 240, b: 240 }));
+
+    const sdk = await import('@/lib/ai/sdk');
+    vi.mocked(sdk.generateObject).mockResolvedValue({
+      object: {
+        verdict: 'broken',
+        findings: [{ summary: 'Everything is white.', severity: 'high' }],
+        reasoning: 'The page renders blank.',
+      },
+    } as never);
+
+    const { manifest } = await runGoldenJourneySweep({
+      runId,
+      juryEnabled: true,
+      routes: [ROUTE],
+    });
+
+    expect(manifest.summary.routesFlagged).toBe(1);
+    expect(manifest.issueFilings).toHaveLength(1);
+    expect(manifest.issueFilings[0]?.title).toContain(
+      '[golden-journey] home-logged-out: broken'
+    );
+
+    // Regression must NOT roll the golden forward.
+    await expect(readFile(goldenPath)).resolves.toEqual(golden);
+  });
+});


### PR DESCRIPTION
## Problem
Part 2/3 of the golden-journey sweep stack (#11815) — see part 1 for context.

## What changed
- `sweep.ts` — orchestrator: diffs each captured route against its rolling golden, routes flagged (or baseline-less) captures to the jury, writes `manifest.json` + `issue-filings.json` into the run dir. Golden promotion policy: unflagged → roll forward; flagged + jury says improvement/neutral → roll forward; regression/broken or jury unavailable → keep old baseline. Issues are filed for jury-confirmed regressions, and for flagged drift when the jury is unavailable (surface, don't drop).
- `taste-jury.ts` — VLM evaluation through the `@/lib/ai/sdk` gateway chokepoint (`generateObject` + zod schema, current capture + baseline images). Lazy-imported so deterministic paths never touch the gateway.
- `scripts/golden-journey-sweep.ts` — CLI (`--run-id`, `--git-sha`, `--no-jury`); jury fail-soft when `AI_GATEWAY_API_KEY` is absent; exit code 2 when filings exist so CI can react.
- `golden-journey:capture` / `golden-journey:sweep` package scripts.
- Unit tests: bootstrap + jury-skip path; jury-confirmed regression files an issue and does NOT roll the golden forward (SDK mocked).

## Assumptions
Same as part 1. Jury model = `DESIGN_TASTE_SWEEP_MODEL` (haiku 4.5, vision-capable, cheap).

## Verification
Biome 2.5.1 clean on all files (see part 1 — same sandbox constraint; typecheck/tests defer to CI at land time; stacked PRs run heavy CI when Graphite lands each member).

Dispatch: ship-11815 · Part of #11815 · Stacked on part 1
