### PR TITLE
visual-qa: golden-journey capture harness + post-deploy sweep wiring (part 3/3)

### DIFF
--- a/apps/web/playwright.config.golden-journey.ts
+++ b/apps/web/playwright.config.golden-journey.ts
@@ -1,0 +1,88 @@
+/**
+ * Playwright Configuration – Golden Journey Capture (JOV #11815)
+ *
+ * Captures route-level screenshots of the golden journey set (logged-out +
+ * seeded logged-in states) for the post-deploy design-taste sweep.
+ *
+ * Usage:
+ *   pnpm --filter web golden-journey:capture
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+const extraHTTPHeaders: Record<string, string> = {};
+if (process.env.VERCEL_AUTOMATION_BYPASS_SECRET) {
+  extraHTTPHeaders['x-vercel-protection-bypass'] =
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  extraHTTPHeaders['x-vercel-set-bypass-cookie'] = 'samesitenone';
+}
+
+// Pin Doppler scope explicitly so worktrees never inherit whichever scope
+// happens to be active in the parent shell. See .claude/rules/environment.md.
+const webServerCommand = process.env.DATABASE_URL
+  ? 'pnpm run dev:local'
+  : 'doppler run --project jovie-web --config dev -- pnpm run dev:local';
+const baseURL = process.env.BASE_URL || 'http://localhost:3110';
+const managedWebServerUrl = new URL(baseURL);
+if (!managedWebServerUrl.port) {
+  managedWebServerUrl.port = '3110';
+}
+const managedWebServerPort = managedWebServerUrl.port;
+
+export default defineConfig({
+  testDir: './tests/golden-journey',
+  testMatch: '**/capture.spec.ts',
+  fullyParallel: false, // Sequential for deterministic captures
+  forbidOnly: true,
+  retries: 1,
+  workers: 1,
+  reporter: [['line']],
+
+  timeout: 120_000,
+  expect: { timeout: 20_000 },
+
+  use: {
+    baseURL,
+    trace: 'off',
+    video: 'off',
+    navigationTimeout: 90_000,
+    actionTimeout: 30_000,
+    ...(Object.keys(extraHTTPHeaders).length > 0 && { extraHTTPHeaders }),
+  },
+
+  projects: [
+    {
+      name: 'golden-journey',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+        deviceScaleFactor: 1,
+        colorScheme: 'dark',
+      },
+    },
+  ],
+
+  ...(process.env.BASE_URL
+    ? {}
+    : {
+        webServer: {
+          command: webServerCommand,
+          env: {
+            ...process.env,
+            NODE_ENV: 'test',
+            PORT: managedWebServerPort,
+            NEXT_DISABLE_TOOLBAR: '1',
+            NEXT_PUBLIC_E2E_MODE: '1',
+            NEXT_PUBLIC_CLERK_PROXY_DISABLED: '1',
+            // Logged-in golden journeys bootstrap through the dev test-auth
+            // bypass personas (see .claude/rules/auth.md).
+            E2E_USE_TEST_AUTH_BYPASS: '1',
+          },
+          url: managedWebServerUrl.origin,
+          reuseExistingServer: process.env.REUSE_EXISTING_SERVER === '1',
+          timeout: 300_000,
+          stdout: 'pipe',
+          stderr: 'pipe',
+        },
+      }),
+});

--- a/apps/web/tests/golden-journey/capture.spec.ts
+++ b/apps/web/tests/golden-journey/capture.spec.ts
@@ -1,0 +1,53 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { test } from '@playwright/test';
+import { resolveGoldenJourneyScreenshotPath } from '../../lib/agent-os/golden-journey/paths';
+import {
+  GOLDEN_JOURNEY_ROUTES,
+  type GoldenJourneyRoute,
+} from '../../lib/agent-os/golden-journey/routes';
+import { hideTransientUI, waitForSettle } from '../product-screenshots/helpers';
+
+/**
+ * Golden-journey route capture (JOV #11815).
+ *
+ * Navigates each registered route in its declared auth state and writes a
+ * full-page screenshot into the sweep run directory. The comparison + jury
+ * pass runs afterwards via `scripts/golden-journey-sweep.ts`.
+ */
+
+const RUN_ID = process.env.GOLDEN_JOURNEY_RUN_ID ?? 'local';
+
+function bootstrapUrl(route: GoldenJourneyRoute): string {
+  if (route.authState === 'logged-out') {
+    return route.path;
+  }
+
+  const params = new URLSearchParams({
+    persona: route.authState,
+    redirect: route.path,
+  });
+  return `/api/dev/test-auth/enter?${params.toString()}`;
+}
+
+test.describe('golden journey capture', () => {
+  for (const route of GOLDEN_JOURNEY_ROUTES) {
+    test(`captures ${route.id}`, async ({ page }) => {
+      await page.goto(bootstrapUrl(route), { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle').catch(() => {});
+      await waitForSettle(page);
+      await hideTransientUI(page);
+
+      const screenshotPath = resolveGoldenJourneyScreenshotPath(
+        RUN_ID,
+        route.id
+      );
+      await mkdir(dirname(screenshotPath), { recursive: true });
+      await page.screenshot({
+        path: screenshotPath,
+        fullPage: true,
+        animations: 'disabled',
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Problem
Part 3/3 of the golden-journey sweep stack (#11815) — the capture harness + post-deploy CI wiring.

## What changed
- `tests/golden-journey/capture.spec.ts` — Playwright capture: navigates each registered route (test-auth persona bootstrap for logged-in states), settles + hides transient UI (reuses product-screenshot helpers), writes full-page PNGs into the sweep run dir.
- `playwright.config.golden-journey.ts` — dedicated config mirroring `playwright.config.screenshots.ts` (dark, 1440x900, sequential, managed dev server locally / `BASE_URL` in CI).

## ⚠️ Human step required — workflow file
The GitHub integration token cannot write `.github/workflows/**` (403, missing `workflows` permission), so the workflow could not be pushed. **Someone with repo write needs to add `.github/workflows/golden-journey-sweep.yml`** with the content below (also mirrors the acceptance criteria: post-deploy trigger via `workflow_run` on CI + daily schedule, rolling goldens via Actions cache, artifact upload, auto-filed issues for confirmed regressions):

```yaml
# Golden-journey capture + post-deploy design-taste jury sweep (JOV #11815).
#
# After CI completes on main (i.e. after the deploy pipeline for that commit),
# capture the golden-journey route set (logged-out + seeded logged-in states),
# diff each route against the rolling golden baseline (restored from the
# workflow cache; previous accepted sweep = baseline), send flagged routes to
# the VLM design-taste jury, and auto-file GitHub issues for confirmed
# regressions. Results live in the run artifact; goldens roll via the cache.
name: Golden Journey Sweep

on:
  workflow_run:
    workflows: ['CI']
    types: [completed]
    branches: [main]
  schedule:
    - cron: '30 9 * * *'
  workflow_dispatch:

permissions: {}

concurrency:
  group: golden-journey-sweep
  cancel-in-progress: true

jobs:
  sweep:
    name: Capture + Taste Jury
    runs-on: ubuntu-latest
    timeout-minutes: 40
    # For workflow_run triggers, only sweep successful CI runs (deploy path).
    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
    permissions:
      contents: read
      issues: write
    defaults:
      run:
        working-directory: apps/web
    env:
      GOLDEN_JOURNEY_RUN_ID: sweep-${{ github.run_id }}
      NEXT_DISABLE_TOOLBAR: '1'
      NEXT_PUBLIC_CLERK_PROXY_DISABLED: '1'
      E2E_USE_TEST_AUTH_BYPASS: '1'
      DATABASE_URL: ${{ secrets.DATABASE_URL }}

    steps:
      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

      - uses: ./.github/actions/setup-node-pnpm

      - name: Install Playwright Chromium
        run: pnpm exec playwright install --with-deps chromium

      - name: Restore golden baselines
        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
        with:
          path: agentos/golden-journey-goldens
          key: golden-journey-goldens-${{ github.run_id }}
          restore-keys: |
            golden-journey-goldens-

      - name: Build production app
        run: pnpm run build

      - name: Start production server
        run: |
          if [ -f .next/standalone/apps/web/server.js ]; then
            node .next/standalone/apps/web/server.js &
          else
            pnpm run start &
          fi
          for _attempt in $(seq 1 30); do
            if curl -fsS http://localhost:3000 >/dev/null 2>&1; then
              exit 0
            fi
            sleep 2
          done
          echo "Timed out waiting for the production server to start."
          exit 1

      - name: Capture golden journey routes
        timeout-minutes: 20
        run: |
          pnpm exec playwright test \
            --config=playwright.config.golden-journey.ts \
            --project=golden-journey
        env:
          BASE_URL: http://localhost:3000

      - name: Run diff + design-taste jury sweep
        id: sweep
        continue-on-error: true
        run: |
          pnpm exec tsx scripts/golden-journey-sweep.ts \
            --run-id="$GOLDEN_JOURNEY_RUN_ID" \
            --git-sha="$GITHUB_SHA"
        env:
          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}

      - name: Save golden baselines
        if: always()
        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
        with:
          path: agentos/golden-journey-goldens
          key: golden-journey-goldens-${{ github.run_id }}

      - name: Upload sweep artifact
        if: always()
        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
        with:
          name: golden-journey-${{ github.run_id }}
          path: agentos/runs/golden-journey/
          retention-days: 14
          if-no-files-found: warn

      - name: File issues for flagged routes
        if: steps.sweep.outcome == 'failure'
        working-directory: .
        env:
          GH_TOKEN: ${{ github.token }}
        run: |
          FILINGS="agentos/runs/golden-journey/${GOLDEN_JOURNEY_RUN_ID}/issue-filings.json"
          if [ ! -f "$FILINGS" ]; then
            echo "Sweep failed before producing issue filings; check the sweep step logs."
            exit 1
          fi
          COUNT=$(jq 'length' "$FILINGS")
          echo "Flagged filings: $COUNT"
          for i in $(seq 0 $((COUNT - 1))); do
            TITLE=$(jq -r ".[$i].title" "$FILINGS")
            ROUTE=$(jq -r ".[$i].routeId" "$FILINGS")
            # Dedupe: skip when an open issue for this route already exists.
            EXISTING=$(gh issue list --state open \
              --search "in:title \"[golden-journey] ${ROUTE}:\"" \
              --json number --jq 'length')
            if [ "$EXISTING" -gt 0 ]; then
              echo "Open issue already exists for ${ROUTE}; skipping."
              continue
            fi
            jq -r ".[$i].body" "$FILINGS" > /tmp/issue-body.md
            {
              echo ""
              echo "Run artifact: golden-journey-${GITHUB_RUN_ID} (workflow run ${GITHUB_RUN_ID}, commit ${GITHUB_SHA::8})"
            } >> /tmp/issue-body.md
            gh issue create \
              --title "$TITLE" \
              --body-file /tmp/issue-body.md \
              --label "testing" || echo "Failed to file issue for ${ROUTE}"
          done
```

## Verification
Biome clean (see part 1; same sandbox constraint — typecheck defers to CI at land time).

Dispatch: ship-11815 · Part of #11815 · Stacked on part 2
