### PR TITLE
feat(agent): adopt last30days skill + Idea Radar + market-research (GH-10926)

### DIFF
--- a/.claude/commands/market-research.md
+++ b/.claude/commands/market-research.md
@@ -1,0 +1,116 @@
+---
+description: Market-complaint research — find all user complaints and pain points about a competitor app, platform, or category across YouTube, Reddit, App Store, X, and TikTok using /last30days
+tags: [research, market-intel, competitors, icp]
+---
+
+# /market-research — Market-Complaint Research
+
+Find all public complaints, pain points, and frustrations about a competitor app or
+category. Used for RP-clone research, pep-AI ICP profiling, and go/no-go decisions.
+Powered by `/last30days`.
+
+## Arguments
+
+```
+/market-research <target>
+/market-research <target> --window <days>   # default: 30
+/market-research <target> --sources <list>  # default: reddit,hn,youtube,x,tiktok
+```
+
+**Target examples:**
+- `DistroKid` — specific competitor
+- `music distribution platforms` — category
+- `TuneCore` — specific competitor
+- `streaming royalties` — pain-point category
+
+## Phase 1: Run multi-query /last30days sweep
+
+Fire three query variants in parallel (to surface complaints from different angles):
+
+```
+/last30days "<target> complaints problems frustrated" --days <window>
+/last30days "<target> worst thing hate review" --days <window>
+/last30days "<target> switched left left why alternative" --days <window>
+```
+
+Merge results. Deduplicate by URL.
+
+## Phase 2: Extract complaint taxonomy
+
+From the merged brief, cluster complaints into themes:
+
+| Theme | Example | Frequency | Severity (1-5) |
+|-------|---------|-----------|----------------|
+| Pricing | "they take 30% off the top" | high | 4 |
+| Support | "support takes weeks to respond" | medium | 3 |
+| … | … | … | … |
+
+Sort by (frequency × severity) descending.
+
+## Phase 3: ICP pain-point brief
+
+Emit a structured brief for product/ICP use:
+
+```markdown
+## Market Research: <target>
+
+**Window:** last <N> days  
+**Sources:** <list>
+
+### Top Complaints (ranked by frequency × severity)
+
+1. **<Theme>** (freq: high, sev: 4/5)
+   > "<most-upvoted direct quote>"
+   - <2nd supporting quote>
+   Source: <URL>
+
+2. **<Theme>** …
+
+### Unmet Needs
+
+<What users explicitly say they wish existed / would pay for>
+
+### Switching Triggers
+
+<What finally made users leave / consider leaving>
+
+### Jovie Opportunity
+
+<1-2 sentence take: does this open a clear wedge for Jovie?>
+```
+
+## Phase 4: Optional — App Store reviews
+
+If `--sources` includes `appstore`:
+
+```bash
+# Use browse to fetch App Store reviews sorted by "Most Critical"
+/browse "https://apps.apple.com/us/app/<slug>/reviews?sort=mostCritical"
+# Extract top 10 1-2 star reviews; add to complaint taxonomy
+```
+
+## Output
+
+Save the brief to `.context/market-research/<target>-<date>.md` for future reference.
+
+If run from a Hermes context (no interactive session), emit JSON:
+
+```json
+{
+  "target": "<target>",
+  "window_days": 30,
+  "top_complaints": [
+    {"theme": "Pricing", "frequency": "high", "severity": 4, "quote": "…", "url": "…"}
+  ],
+  "unmet_needs": ["…"],
+  "switching_triggers": ["…"],
+  "opportunity_signal": "…"
+}
+```
+
+## Rules
+
+- Stick to `/last30days` for signal gathering — do not manually search each platform.
+- Quote real posts, not paraphrases. Always include the source URL.
+- Keep cost under $0.30 per research run (3 last30days calls × $0.10 cap each).
+- Do NOT invent complaints. If `/last30days` returns no results for a query, say so.

--- a/.claude/rules/gstack.md
+++ b/.claude/rules/gstack.md
@@ -28,6 +28,8 @@ This repo includes [gstack](https://github.com/garrytan/gstack) as a git submodu
 | QA Swarm (flaky-hunter) | `/qa-swarm-flaky-hunter` | Flake rerun, cluster, and auto-quarantine |
 | Lavish | `/lavish` | Turn agent responses into rich HTML artifacts the user can annotate and send targeted feedback on (design comps, reports, dashboards, review surfaces) |
 | Upgrade | `/gstack-upgrade` | Upgrade gstack to latest version |
+| Last 30 Days | `/last30days` | Multi-source signal search (Reddit/HN/X/YouTube/TikTok/Polymarket/GitHub) scored by real engagement; synthesized to one brief. Use for idea discovery and market research. (mvanhorn) |
+| Idea Radar | `/idea-radar` | Weekly discovery sweep — calls /last30days across creator/music/SaaS signals, evaluates via 10x→MVP→MRR-score pipeline, delivers Slack cards, reconciles reactions. (Jovie AgentOS) |
 
 ## Setup
 
@@ -66,6 +68,9 @@ Key routing rules:
 - Continuous QA swarm recipes (diff review, explore, vision, jury, test-gen, flakes) → invoke matching `/qa-swarm-*` command; load `qa-swarm` skill
 - A shared link/tool/product with no context expecting an opinion or evaluation → invoke `tool-discovery` instead of asking the human to research it first
 - HTML artifact, design comp, review surface, dashboard, deck, report for human annotation → invoke `lavish` to open it in the browser-based review loop instead of embedding a screenshot
+- Market research, competitor complaints, "what are people saying about X", ICP pain points, RP-clone/pep-AI research → invoke `last30days` for multi-source signal gathering
+- Idea Radar sweep, weekly idea discovery, "find new product ideas", SaaS signal discovery → invoke `idea-radar`
+- "find complaints about app X", "what do users hate about Y", "App Store reviews for Z" → invoke `market-research` command (calls `/last30days` internally)
 
 ## gbrain (long-term memory layer)
 

--- a/.claude/skills/idea-radar/SKILL.md
+++ b/.claude/skills/idea-radar/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: idea-radar
+description: |
+  Weekly idea-discovery sweep (epic GH-10354). Discovers new software/MRR
+  opportunities across Reddit, HN, X, YouTube, TikTok, Polymarket, and GitHub
+  using /last30days, evaluates each via the 10x → thin-MVP → MRR-per-effort
+  pipeline, delivers ranked cards to Slack #idea-radar, and reconciles
+  thumbs-up/down reactions to update learned-preferences. Runs once a week;
+  idempotent. (Jovie AgentOS)
+argument-hint: "[--dry-run] [--reconcile-only]"
+author: jovie-agentos
+metadata:
+  hermes:
+    tags: [idea-radar, discovery, weekly, slack]
+    category: product-discovery
+    schedule: "0 9 * * 1"  # Monday 09:00 local
+    cost-cap: 1.00
+---
+
+# Idea Radar — Weekly Discovery Sweep
+
+Continuous idea discovery loop from epic [GH-10354](https://github.com/JovieInc/Jovie/issues/10354).
+One run = discover → evaluate → deliver → reconcile.
+
+## Arguments
+
+- `--dry-run` — run discovery and evaluation but skip Slack posting and Linear issue creation
+- `--reconcile-only` — skip discovery; only reconcile reactions/comments from the previous week's cards
+
+## Phase 0: Prerequisites
+
+```bash
+# Confirm Slack bot is in #idea-radar
+# If channel does not exist, stop and message Tim: "Create #idea-radar and invite the Jovie bot."
+```
+
+Load learned preferences from gbrain:
+```
+mcp__gbrain__query: "idea-radar learned preferences user feedback"
+```
+Store as `learnedPrefs` — used to deprioritize rejected themes and boost approved ones.
+
+Load Linear idea-radar ledger to avoid re-posting:
+```
+mcp__claude_ai_Linear__list_issues: { team: "Jovie", label: "idea-radar" }
+```
+Store existing idea titles as `seenIdeas` (dedup set).
+
+---
+
+## Phase 1: Discover (call /last30days)
+
+Run two tiers of sweeps **in parallel** using `/last30days`:
+
+### Tier A — Adjacent (creator / music / marketing / fitness / health)
+
+```
+/last30days "indie hacker SaaS launch new product creator tools" \
+  --sources reddit,hn,producthunt,youtube,github --days 7
+/last30days "musician artist income tools revenue" \
+  --sources reddit,hn,x,youtube --days 7
+/last30days "fitness health app launch subscription" \
+  --sources reddit,hn,tiktok --days 7
+```
+
+### Tier B — Wildcard (any domain with strong MRR signal)
+
+```
+/last30days "launched profitable bootstrapped indie side project" \
+  --sources reddit,hn,polymarket --days 7
+/last30days "acquired micro-saas flippa acquire.com" \
+  --sources reddit,hn --days 7
+```
+
+Merge all briefs. Deduplicate by URL. Filter out any idea whose title fuzzy-matches
+an entry in `seenIdeas` or a rejected theme from `learnedPrefs`.
+
+**Cost gate:** each `/last30days` call must stay under $0.20. Total phase 1 budget: $0.60.
+
+---
+
+## Phase 2: Evaluate each candidate idea
+
+For each distinct idea/product signal (cap: 20 per sweep to bound cost):
+
+### 2.1 Find same/similar + adjacent variants
+
+```
+mcp__gbrain__search: "<idea title> similar products alternatives"
+/last30days "<idea title> competitor complaints" --sources reddit,hn --days 90
+```
+
+### 2.2 10x the idea
+
+> "What would 10× this look like if it had 100× the resources and ambition?"
+
+Prompt a model (via `free-model-router.ts` or the current session model):
+```
+Given: <idea title and description>
+Adjacent signals: <top 3 from 2.1>
+
+1. 10× version: <one-sentence 10× statement>
+2. Thin MVP of the 10×: <what is the smallest version that proves the 10× hypothesis?>
+3. MRR opportunity score (0–10):
+   reach × frequency × annoyance × WTP × ATP ÷ effort
+   Explain each dimension in one word.
+```
+
+### 2.3 Compute go/no-go
+
+- Score ≥ 7 → **GO** (post to #idea-radar, open Linear issue)
+- Score 5–6 → **MAYBE** (post with lower priority label)
+- Score < 5 → **SKIP** (log to gbrain as low-signal, do not post)
+
+Apply `learnedPrefs` boost/penalty: +1 for themes Tim has 👍'd before, −1 for themes he has 👎'd.
+
+---
+
+## Phase 3: Deliver to Slack #idea-radar
+
+For each GO/MAYBE idea (skip if `--dry-run`):
+
+Post a card to `#idea-radar`:
+
+```
+🎯 *<idea title>* — Score: <X>/10  |  <adjacent-domain tag>
+
+> <10× statement>
+
+**Thin MVP:** <1 sentence>
+**Signal source:** <top URL from /last30days>
+**Engagement:** <score> on <source>
+
+👍 = go build (opens Linear issue)  👎 = reject (logged)
+```
+
+Record the Slack message timestamp + idea metadata to gbrain:
+```
+mcp__gbrain__put_page:
+  slug: "idea-radar/<iso-date>/<slug>"
+  content: { title, score, slack_ts, status: "pending" }
+```
+
+Open a Linear issue (child of GH-10354 / JOV-3200):
+```
+mcp__claude_ai_Linear__create_issue:
+  team: "Jovie"
+  title: "[idea-radar] <title>"
+  description: |
+    Score: <X>/10
+    10×: <statement>
+    Thin MVP: <description>
+    Signal: <top URL>
+    Slack thread: <link>
+  labels: ["idea-radar", "discovery"]
+  parent: <JOV-3200 or the Linear equivalent of GH-10354>
+```
+
+---
+
+## Phase 4: Reconcile reactions (always runs, even with --reconcile-only)
+
+Load last week's idea-radar gbrain pages:
+```
+mcp__gbrain__search: "idea-radar status:pending"
+```
+
+For each pending idea, fetch Slack reactions:
+```
+# Use Slack API via browse or MCP
+GET https://slack.com/api/reactions.get?channel=<#idea-radar>&timestamp=<slack_ts>
+```
+
+Act on each:
+- 👍 → update Linear to `In Progress`, update gbrain `status: "go"`, update `learnedPrefs` with the idea's domain/theme as a positive signal
+- 👎 → update Linear to `Cancelled`, update gbrain `status: "rejected"`, add domain/theme to `learnedPrefs` negative signals, record reason from Tim's reply comment if present
+- No reaction after 7 days → update gbrain `status: "expired"`, close the Linear issue as `Won't Fix`
+
+---
+
+## Phase 5: Distill learned preferences
+
+After reconciliation, update the living preferences note in gbrain:
+
+```
+mcp__gbrain__put_page:
+  slug: "idea-radar/learned-preferences"
+  content: |
+    # Idea Radar Learned Preferences
+    Updated: <iso date>
+
+    ## Boost (Tim has approved signals like these)
+    <bulleted list of domains/themes with 👍 count>
+
+    ## Suppress (Tim has rejected signals like these)
+    <bulleted list with 👎 count and optional reason>
+
+    ## Score distribution
+    Avg score of GO ideas: <X>
+    Total ideas evaluated: <N>
+    Acceptance rate: <N go / N total>
+```
+
+---
+
+## Output
+
+```
+Idea Radar sweep complete.
+
+Discovered: <N> raw signals
+Evaluated: <N> candidates  
+GO: <N> | MAYBE: <N> | Skipped: <N>
+Posted to #idea-radar: <N> cards
+Reactions reconciled: <N>
+Estimated cost: $<X>
+```
+
+## Hermes schedule (config.air.template.yaml)
+
+This skill runs weekly via Hermes-Air. The schedule entry is:
+```yaml
+schedules:
+  - name: idea-radar-sweep
+    cron: "0 9 * * 1"   # Monday 09:00 local
+    skill: idea-radar
+    cost_cap_usd: 1.00
+```

--- a/.claude/skills/last30days/SKILL.md
+++ b/.claude/skills/last30days/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: last30days
+description: |
+  Multi-source signal search across Reddit, HN, X/Twitter, YouTube, TikTok,
+  Polymarket, GitHub, and the web — scored by real engagement (upvotes, likes,
+  prediction money) and synthesized to one brief. Use for Idea Radar discovery
+  sweeps and market-complaint research (ICP pain points, competitor complaints,
+  RP-clone signals). Globally installed via mvanhorn/last30days-skill v3.8.3+.
+argument-hint: "last30days <topic> | last30days competitors of <app X> complaints"
+author: mvanhorn
+metadata:
+  hermes:
+    tags: [research, signals, reddit, youtube, tiktok, market-intel]
+    category: research
+    cost-cap: 0.10
+---
+
+# last30days (project reference)
+
+The `last30days` skill is globally installed at `~/.claude/skills/last30days/` via
+[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill). This
+project-level file registers it as a Jovie project dependency so `skills-lock.json`
+and routing rules stay in sync.
+
+**Invoke it directly** — the harness loads the global install automatically:
+
+```
+/last30days <topic>
+```
+
+## Example invocations for Jovie use-cases
+
+```
+# Idea Radar sweep — adjacent creator/music SaaS signals this week
+/last30days "indie hacker SaaS creator tools launched" --days 7
+
+# Market-complaint research — competitor pain points
+/last30days "DistroKid complaints problems artists" --days 30
+/last30days "TuneCore frustrated reddit" --days 30
+
+# ICP discovery — what artists complain about on YouTube/TikTok
+/last30days "music distribution royalties complaints" --days 30
+```
+
+## Keys and sessions
+
+The skill works without keys (falls back to public search APIs). For full
+coverage including authenticated Reddit/X/TikTok results, provide via Doppler:
+
+| Env var | Source | Notes |
+|---------|--------|-------|
+| `SCRAPECREATORS_API_KEY` | ScrapeCr | Primary — unlocks YouTube, TikTok, Instagram |
+| `BRAVE_API_KEY` | Brave | Web search fallback |
+| `OPENROUTER_API_KEY` | OpenRouter | Synthesis model (uses free tier by default) |
+
+See `~/.claude/skills/last30days/SKILL.md` for the full contract and engine details.
+
+## Cost cap
+
+Each `/last30days` call should cost < $0.10. The Idea Radar weekly sweep caps
+total spend at $1.00 across all calls. Monitor via Doppler cost dashboard.

--- a/apps/web/tests/unit/skills-last30days.test.ts
+++ b/apps/web/tests/unit/skills-last30days.test.ts
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Regression guard for GH-10926: last30days skill adoption + Idea Radar wiring.
+// Mirrors the lavish skill test pattern (skills-lavish.test.ts).
+
+// tests/unit/skills-last30days.test.ts → tests/unit → tests → apps/web → apps → repo root
+const repoRoot = join(fileURLToPath(import.meta.url), '../../../../../');
+
+describe('last30days skill adoption (GH-10926)', () => {
+  it('project-level SKILL.md exists at .claude/skills/last30days/SKILL.md', () => {
+    const skillPath = join(repoRoot, '.claude/skills/last30days/SKILL.md');
+    expect(existsSync(skillPath), `missing: ${skillPath}`).toBe(true);
+  });
+
+  it('SKILL.md declares the last30days skill and mvanhorn source', () => {
+    const skillPath = join(repoRoot, '.claude/skills/last30days/SKILL.md');
+    const content = readFileSync(skillPath, 'utf8');
+    expect(content).toContain('name: last30days');
+    expect(content).toContain('mvanhorn');
+    expect(content).toContain('last30days-skill');
+  });
+
+  it('skills-lock.json registers mvanhorn/last30days-skill', () => {
+    const lockPath = join(repoRoot, 'skills-lock.json');
+    expect(existsSync(lockPath), `missing: ${lockPath}`).toBe(true);
+    const lock = JSON.parse(readFileSync(lockPath, 'utf8'));
+    expect(lock.skills).toHaveProperty('last30days');
+    expect(lock.skills.last30days.source).toBe('mvanhorn/last30days-skill');
+  });
+
+  it('gstack routing table routes market research and idea radar to /last30days', () => {
+    const gstackPath = join(repoRoot, '.claude/rules/gstack.md');
+    const content = readFileSync(gstackPath, 'utf8');
+    expect(content).toContain('/last30days');
+    expect(content).toContain('market');
+    expect(content).toContain('idea-radar');
+  });
+
+  it('idea-radar skill exists and references last30days', () => {
+    const skillPath = join(repoRoot, '.claude/skills/idea-radar/SKILL.md');
+    expect(existsSync(skillPath), `missing: ${skillPath}`).toBe(true);
+    const content = readFileSync(skillPath, 'utf8');
+    expect(content).toContain('idea-radar');
+    expect(content).toContain('/last30days');
+    // must cap cost (acceptance criteria)
+    expect(content).toContain('cost-cap');
+  });
+
+  it('market-research command exists and references last30days', () => {
+    const cmdPath = join(repoRoot, '.claude/commands/market-research.md');
+    expect(existsSync(cmdPath), `missing: ${cmdPath}`).toBe(true);
+    const content = readFileSync(cmdPath, 'utf8');
+    expect(content).toContain('/last30days');
+    // cost cap required
+    expect(content).toContain('$0.30');
+  });
+
+  it('Hermes Air config template includes idea-radar schedule', () => {
+    const configPath = join(
+      repoRoot,
+      'scripts/hermes/config.air.template.yaml'
+    );
+    expect(existsSync(configPath), `missing: ${configPath}`).toBe(true);
+    const content = readFileSync(configPath, 'utf8');
+    expect(content).toContain('idea-radar-sweep');
+    expect(content).toContain('0 9 * * 1');
+    // must reference the cost cap
+    expect(content).toContain('cost_cap_usd');
+  });
+});

--- a/scripts/hermes/config.air.template.yaml
+++ b/scripts/hermes/config.air.template.yaml
@@ -127,6 +127,24 @@ sub_agents:
       - merge_pr
       - push_branch
 
+  - name: idea-radar
+    description: Weekly idea discovery sweep using last30days. Searches creator/SaaS signals, evaluates via 10x pipeline, posts Slack cards, reconciles reactions.
+    mcp_allowlist: [gbrain, linear]
+    skills:
+      - idea-radar
+      - last30days
+    cost_cap_usd: 1.00
+    cannot:
+      - edit_code
+      - spend_money
+
+schedules:
+  - name: idea-radar-sweep
+    cron: "0 9 * * 1"   # Monday 09:00 local (Idea Radar weekly sweep — GH-10926 / GH-10354)
+    agent: idea-radar
+    skill: idea-radar
+    cost_cap_usd: 1.00
+
 routing:
   default: chief
   intent_map:
@@ -141,3 +159,6 @@ routing:
     pr: code-orchestrator
     ci: code-orchestrator
     deploy: code-orchestrator
+    idea-radar: idea-radar
+    market-research: idea-radar
+    idea: idea-radar

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -12,6 +12,15 @@
       "sourceType": "github",
       "skillPath": "skills/lavish/SKILL.md",
       "computedHash": "c3a0299d820bc3b30613d7740718b194511201319047fa9d3075e0ab1e596bde"
+    },
+    "last30days": {
+      "source": "mvanhorn/last30days-skill",
+      "sourceType": "github",
+      "skillPath": "skills/last30days/SKILL.md",
+      "computedHash": "7a17dc6cd15eed851dac592324911b1e984cbe9bc5b8d584ee0aa602acf59cbb",
+      "globalInstall": true,
+      "globalPath": "~/.claude/skills/last30days/SKILL.md",
+      "version": "3.8.3"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Installs `mvanhorn/last30days-skill` v3.8.3 as a project-level skill reference (globally pre-installed; thin wrapper with Jovie-specific usage examples)
- Adds **Idea Radar** weekly sweep skill (`.claude/skills/idea-radar/SKILL.md`) — calls `/last30days` across creator/music/SaaS signals, evaluates via 10x→MVP→MRR pipeline, delivers Slack cards, reconciles reactions; cost cap $1.00/sweep
- Adds **`/market-research`** slash command (`.claude/commands/market-research.md`) — 3 parallel last30days queries, complaint taxonomy, ICP brief; cost cap $0.30/run
- Registers skill in `skills-lock.json`
- Routes market-research and idea-radar invocations in `.claude/rules/gstack.md`
- Schedules `idea-radar-sweep` weekly cron (Mon 09:00) in Hermes Air config template
- 7-test regression suite (all green): `apps/web/tests/unit/skills-last30days.test.ts`

Closes GH-10926. Related epic: GH-10354 (Idea Radar).

## Test plan

- [x] `pnpm --filter web exec vitest run tests/unit/skills-last30days.test.ts` → 7/7 pass
- [x] `pnpm biome check` → clean
- [x] `pnpm --filter @jovie/web run typecheck` → clean
- [x] Pre-commit hooks (gitleaks, trufflehog, lint-staged) → all pass
- [x] Pre-push hooks (biome, proxy-guard, tailwind:check, typecheck) → all pass

## Cost Impact

- `/last30days` calls: $0.10 cap per call (capped in SCRAPECREATORS_API_KEY or Brave + OpenRouter budget)
- `/market-research` per run: $0.30 (3 calls × $0.10)
- Idea Radar weekly sweep: $1.00 cap total; scaling factor O(1) — fixed number of queries per sweep regardless of user count

🤖 Generated with [Claude Code](https://claude.com/claude-code)