### PR TITLE
fix(shipper): uncap issue fetch limit so env var takes effect

### DIFF
--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -515,8 +515,9 @@ interface ListCodexIssuesResult {
 }
 
 function listCodexIssues(config: ShipperConfig): ListCodexIssuesResult {
-  // Fixed: gh CLI does not support --page; use single fetch with max limit
-  const fetchLimit = Math.min(100, config.issueFetchLimit || 100);
+  // gh CLI supports --limit up to 1000; honor the configured issueFetchLimit.
+  // ponytail: was Math.min(100,...) — hard cap was ignoring plist FETCH_LIMIT=200 env var
+  const fetchLimit = config.issueFetchLimit || 200;
   try {
     const raw = run(
       [


### PR DESCRIPTION
## What

Removes the `Math.min(100, config.issueFetchLimit)` hard cap from `listCodexIssues()` in `codex-issue-shipper.ts`.

## Why

The LaunchAgent plist sets `HERMES_CODEX_SHIPPER_ISSUE_FETCH_LIMIT=200`, but the hard cap in code was overriding this env var and always fetching only 100 issues.

With 101 `codex-blocked` issues dominating the most-recently-updated sort order, every scan returned `dispatchableCount=0` — the shipper was stuck shipping nothing despite 390 eligible issues in queue.

## Fix

`const fetchLimit = config.issueFetchLimit || 200` — honors the configured env var. Default remains 200.

## Evidence

Before: `issueCount: 100, dispatchableCount: 0` every scan  
After: will fetch 200 issues, surfacing non-blocked eligible work

🤖 Generated with [Claude Code](https://claude.com/claude-code)