### PR TITLE
feat(inbox): tour-date confirm/reject cards + confirmed & hidden rejected sections (part 2/2)

### DIFF
--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
@@ -225,9 +225,7 @@ describe('OpportunityInboxPageClient', () => {
     expect(rejectedSection).toBeInTheDocument();
     // Hidden by default: the details disclosure starts collapsed.
     expect(rejectedSection).not.toHaveAttribute('open');
-    expect(
-      screen.getByText('Rejected Tour Dates (1)')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Rejected Tour Dates (1)')).toBeInTheDocument();
   });
 
   it('restores a rejected tour date via undo', () => {

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
@@ -36,6 +36,39 @@ vi.mock('@/lib/queries/useOpportunityInboxMutations', () => ({
   }),
 }));
 
+const tourDateMutateMock = vi.fn();
+
+vi.mock('@/lib/queries/useTourDateReviewMutations', () => ({
+  useTourDateReviewMutations: () => ({
+    confirmMutation: {
+      isPending: false,
+      variables: undefined,
+      mutate: tourDateMutateMock,
+    },
+    rejectMutation: {
+      isPending: false,
+      variables: undefined,
+      mutate: tourDateMutateMock,
+    },
+    undoRejectMutation: {
+      isPending: false,
+      variables: undefined,
+      mutate: tourDateMutateMock,
+    },
+  }),
+}));
+
+const pendingTourDate = {
+  id: 'td-1',
+  title: 'Saint Andrews Hall',
+  startDate: '2026-08-14T00:00:00.000Z',
+  startTime: '7:00 PM',
+  venueName: 'Saint Andrews Hall',
+  location: 'Detroit, MI',
+  providerLabel: 'Bandsintown',
+  status: 'pending' as const,
+};
+
 describe('OpportunityInboxPageClient', () => {
   it('registers a non-null right panel for the artist-profile rail', async () => {
     const { useRegisterRightPanel } = await import(
@@ -56,13 +89,13 @@ describe('OpportunityInboxPageClient', () => {
           cards: [
             {
               id: 'card-1',
-              category: 'suggestion',
               typeLabel: 'Suggestion',
               createdAt: '2026-06-28T10:00:00.000Z',
               title: 'Detroit listeners up 340% — book a show',
               why: 'Promoter email matched your Detroit growth spike.',
               primaryActionLabel: 'Review pitch',
               status: 'pending',
+              category: 'suggestion',
             },
           ],
           emptyActionCards: [],
@@ -109,13 +142,13 @@ describe('OpportunityInboxPageClient', () => {
           cards: [
             {
               id: 'card-1',
-              category: 'suggestion',
               typeLabel: 'Suggestion',
               createdAt: '2026-06-28T10:00:00.000Z',
               title: 'Detroit listeners up 340% — book a show',
               why: 'Promoter email matched your Detroit growth spike.',
               primaryActionLabel: 'Review pitch',
               status: 'pending',
+              category: 'suggestion',
             },
           ],
           emptyActionCards: [],
@@ -126,6 +159,103 @@ describe('OpportunityInboxPageClient', () => {
     fireEvent.click(screen.getByRole('button', { name: /Review pitch/ }));
     expect(
       screen.getByTestId('opportunity-inbox-empty-state')
+    ).toBeInTheDocument();
+  });
+
+  it('renders pending tour-date cards and confirms optimistically', () => {
+    tourDateMutateMock.mockImplementation((_id, options) => {
+      options?.onSuccess?.();
+    });
+
+    render(
+      <OpportunityInboxPageClient
+        inbox={{
+          cards: [],
+          emptyActionCards: [],
+          tourDates: {
+            pending: [pendingTourDate],
+            confirmed: [],
+            rejected: [],
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId('opportunity-inbox-tour-date-review')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('opportunity-inbox-empty-state')
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Confirm date/ }));
+
+    expect(
+      screen.queryByTestId('opportunity-inbox-tour-date-review')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('opportunity-inbox-confirmed-tour-dates')
+    ).toBeInTheDocument();
+  });
+
+  it('moves a rejected tour date into the hidden rejected section', () => {
+    tourDateMutateMock.mockImplementation((_id, options) => {
+      options?.onSuccess?.();
+    });
+
+    render(
+      <OpportunityInboxPageClient
+        inbox={{
+          cards: [],
+          emptyActionCards: [],
+          tourDates: {
+            pending: [pendingTourDate],
+            confirmed: [],
+            rejected: [],
+          },
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+
+    const rejectedSection = screen.getByTestId(
+      'opportunity-inbox-rejected-tour-dates'
+    );
+    expect(rejectedSection).toBeInTheDocument();
+    // Hidden by default: the details disclosure starts collapsed.
+    expect(rejectedSection).not.toHaveAttribute('open');
+    expect(
+      screen.getByText('Rejected Tour Dates (1)')
+    ).toBeInTheDocument();
+  });
+
+  it('restores a rejected tour date via undo', () => {
+    tourDateMutateMock.mockImplementation((_id, options) => {
+      options?.onSuccess?.();
+    });
+
+    render(
+      <OpportunityInboxPageClient
+        inbox={{
+          cards: [],
+          emptyActionCards: [],
+          tourDates: {
+            pending: [],
+            confirmed: [],
+            rejected: [{ ...pendingTourDate, status: 'rejected' as const }],
+          },
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+
+    expect(
+      screen.queryByTestId('opportunity-inbox-rejected-tour-dates')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('opportunity-inbox-tour-date-review')
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
@@ -5,10 +5,20 @@ import { usePathname } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
-import type { OpportunityInboxData } from '@/lib/connectors/opportunity-inbox-types';
+import {
+  EMPTY_OPPORTUNITY_INBOX_TOUR_DATES,
+  type OpportunityInboxData,
+  type OpportunityInboxTourDateItem,
+} from '@/lib/connectors/opportunity-inbox-types';
 import { useOpportunityInboxMutations } from '@/lib/queries/useOpportunityInboxMutations';
+import { useTourDateReviewMutations } from '@/lib/queries/useTourDateReviewMutations';
 import { OpportunityInboxEmptyState } from './OpportunityInboxEmptyState';
 import { OpportunityInboxFeed } from './OpportunityInboxFeed';
+import { OpportunityInboxTourDateCard } from './OpportunityInboxTourDateCard';
+import {
+  OpportunityInboxConfirmedTourDates,
+  OpportunityInboxRejectedTourDates,
+} from './OpportunityInboxTourDateSections';
 
 const ProfileContactSidebar = dynamic(
   () =>
@@ -37,13 +47,31 @@ export interface OpportunityInboxPageClientProps {
   readonly inbox: OpportunityInboxData;
 }
 
+function sortByStartDate(
+  items: readonly OpportunityInboxTourDateItem[]
+): OpportunityInboxTourDateItem[] {
+  return [...items].sort((a, b) => a.startDate.localeCompare(b.startDate));
+}
+
 export function OpportunityInboxPageClient({
   inbox,
 }: OpportunityInboxPageClientProps) {
   const pathname = usePathname();
   const [cards, setCards] = useState(inbox.cards);
+  const initialTourDates = inbox.tourDates ?? EMPTY_OPPORTUNITY_INBOX_TOUR_DATES;
+  const [pendingTourDates, setPendingTourDates] = useState(
+    initialTourDates.pending
+  );
+  const [confirmedTourDates, setConfirmedTourDates] = useState(
+    initialTourDates.confirmed
+  );
+  const [rejectedTourDates, setRejectedTourDates] = useState(
+    initialTourDates.rejected
+  );
   const { approveMutation, dismissMutation, feedbackMutation } =
     useOpportunityInboxMutations();
+  const { confirmMutation, rejectMutation, undoRejectMutation } =
+    useTourDateReviewMutations();
 
   const pendingActionId = useMemo(() => {
     if (approveMutation.isPending) {
@@ -62,6 +90,25 @@ export function OpportunityInboxPageClient({
 
   const pendingFeedbackId = feedbackMutation.isPending
     ? (feedbackMutation.variables?.suggestedActionId ?? null)
+    : null;
+
+  const pendingTourDateActionId = useMemo(() => {
+    if (confirmMutation.isPending) {
+      return confirmMutation.variables ?? null;
+    }
+    if (rejectMutation.isPending) {
+      return rejectMutation.variables ?? null;
+    }
+    return null;
+  }, [
+    confirmMutation.isPending,
+    confirmMutation.variables,
+    rejectMutation.isPending,
+    rejectMutation.variables,
+  ]);
+
+  const pendingUndoId = undoRejectMutation.isPending
+    ? (undoRejectMutation.variables ?? null)
     : null;
 
   const handleApprove = (id: string) => {
@@ -93,6 +140,57 @@ export function OpportunityInboxPageClient({
     });
   };
 
+  const handleConfirmTourDate = (id: string) => {
+    const item = pendingTourDates.find(candidate => candidate.id === id);
+    confirmMutation.mutate(id, {
+      onSuccess: () => {
+        setPendingTourDates(current =>
+          current.filter(candidate => candidate.id !== id)
+        );
+        if (item) {
+          setConfirmedTourDates(current =>
+            sortByStartDate([...current, { ...item, status: 'confirmed' }])
+          );
+        }
+      },
+    });
+  };
+
+  const handleRejectTourDate = (id: string) => {
+    const item = pendingTourDates.find(candidate => candidate.id === id);
+    rejectMutation.mutate(id, {
+      onSuccess: () => {
+        setPendingTourDates(current =>
+          current.filter(candidate => candidate.id !== id)
+        );
+        if (item) {
+          setRejectedTourDates(current => [
+            { ...item, status: 'rejected' },
+            ...current,
+          ]);
+        }
+      },
+    });
+  };
+
+  const handleUndoRejectTourDate = (id: string) => {
+    const item = rejectedTourDates.find(candidate => candidate.id === id);
+    undoRejectMutation.mutate(id, {
+      onSuccess: () => {
+        setRejectedTourDates(current =>
+          current.filter(candidate => candidate.id !== id)
+        );
+        if (item) {
+          setPendingTourDates(current =>
+            sortByStartDate([...current, { ...item, status: 'pending' }])
+          );
+        }
+      },
+    });
+  };
+
+  const hasReviewableItems = cards.length > 0 || pendingTourDates.length > 0;
+
   return (
     <div
       className='system-b-opportunity-inbox-page'
@@ -111,6 +209,29 @@ export function OpportunityInboxPageClient({
         </p>
       </header>
 
+      {pendingTourDates.length > 0 ? (
+        <section
+          className='system-b-opportunity-inbox-feed'
+          data-testid='opportunity-inbox-tour-date-review'
+          aria-label='Tour Dates To Review'
+        >
+          <div className='system-b-opportunity-inbox-section-label'>
+            Tour Dates To Review
+          </div>
+          <div className='system-b-opportunity-inbox-feed-list'>
+            {pendingTourDates.map(item => (
+              <OpportunityInboxTourDateCard
+                key={item.id}
+                item={item}
+                onConfirm={handleConfirmTourDate}
+                onReject={handleRejectTourDate}
+                isBusy={pendingTourDateActionId === item.id}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
       {cards.length > 0 ? (
         <OpportunityInboxFeed
           cards={cards}
@@ -120,9 +241,18 @@ export function OpportunityInboxPageClient({
           pendingActionId={pendingActionId}
           pendingFeedbackId={pendingFeedbackId}
         />
-      ) : (
+      ) : null}
+
+      {!hasReviewableItems ? (
         <OpportunityInboxEmptyState actionCards={inbox.emptyActionCards} />
-      )}
+      ) : null}
+
+      <OpportunityInboxConfirmedTourDates items={confirmedTourDates} />
+      <OpportunityInboxRejectedTourDates
+        items={rejectedTourDates}
+        onUndoReject={handleUndoRejectTourDate}
+        pendingUndoId={pendingUndoId}
+      />
     </div>
   );
 }

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
@@ -58,7 +58,8 @@ export function OpportunityInboxPageClient({
 }: OpportunityInboxPageClientProps) {
   const pathname = usePathname();
   const [cards, setCards] = useState(inbox.cards);
-  const initialTourDates = inbox.tourDates ?? EMPTY_OPPORTUNITY_INBOX_TOUR_DATES;
+  const initialTourDates =
+    inbox.tourDates ?? EMPTY_OPPORTUNITY_INBOX_TOUR_DATES;
   const [pendingTourDates, setPendingTourDates] = useState(
     initialTourDates.pending
   );

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxTourDateCard.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxTourDateCard.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { Check } from 'lucide-react';
+import { formatTourDateDisplay } from '@/lib/connectors/opportunity-inbox-tour-dates';
+import type { OpportunityInboxTourDateItem } from '@/lib/connectors/opportunity-inbox-types';
+import { cn } from '@/lib/utils';
+
+export interface OpportunityInboxTourDateCardProps {
+  readonly item: OpportunityInboxTourDateItem;
+  readonly onConfirm: (id: string) => void;
+  readonly onReject: (id: string) => void;
+  readonly isBusy?: boolean;
+  readonly className?: string;
+}
+
+/**
+ * Confirm/reject card for a detected tour date. Confirmed dates publish to
+ * the public profile; rejected dates move to the hidden rejected section.
+ */
+export function OpportunityInboxTourDateCard({
+  item,
+  onConfirm,
+  onReject,
+  isBusy = false,
+  className,
+}: OpportunityInboxTourDateCardProps) {
+  return (
+    <article
+      className={cn('system-b-opportunity-inbox-card', className)}
+      data-testid={`opportunity-inbox-tour-date-card-${item.id}`}
+    >
+      <header className='system-b-opportunity-inbox-card-meta'>
+        <span className='system-b-opportunity-inbox-card-type'>Tour date</span>
+        <span
+          aria-hidden='true'
+          className='system-b-opportunity-inbox-card-dot'
+        >
+          ·
+        </span>
+        <span className='system-b-opportunity-inbox-card-time'>
+          Detected via {item.providerLabel}
+        </span>
+      </header>
+
+      <h2 className='system-b-opportunity-inbox-card-title'>{item.title}</h2>
+      <p className='system-b-opportunity-inbox-card-why'>
+        {formatTourDateDisplay(item.startDate, item.startTime)} —{' '}
+        {item.venueName}, {item.location}. Confirm to show this date on your
+        profile.
+      </p>
+
+      <div className='system-b-opportunity-inbox-card-actions'>
+        <button
+          type='button'
+          className='system-b-opportunity-inbox-dismiss'
+          disabled={isBusy}
+          onClick={() => onReject(item.id)}
+        >
+          Reject
+        </button>
+        <button
+          type='button'
+          className='system-b-opportunity-inbox-primary'
+          disabled={isBusy}
+          onClick={() => onConfirm(item.id)}
+        >
+          {isBusy ? 'Saving…' : 'Confirm date'}
+          <Check className='system-b-opportunity-inbox-primary-icon' />
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxTourDateSections.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxTourDateSections.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { formatTourDateDisplay } from '@/lib/connectors/opportunity-inbox-tour-dates';
+import type { OpportunityInboxTourDateItem } from '@/lib/connectors/opportunity-inbox-types';
+
+interface TourDateRowProps {
+  readonly item: OpportunityInboxTourDateItem;
+  readonly action?: ReactNode;
+}
+
+function TourDateRow({ item, action }: TourDateRowProps) {
+  return (
+    <li
+      className='flex items-center justify-between gap-3 py-1.5'
+      data-testid={`opportunity-inbox-tour-date-row-${item.id}`}
+    >
+      <div className='min-w-0'>
+        <span className='block truncate text-sm text-primary-token'>
+          {item.title}
+        </span>
+        <span className='block truncate text-xs text-secondary-token'>
+          {formatTourDateDisplay(item.startDate, item.startTime)} ·{' '}
+          {item.venueName}, {item.location}
+        </span>
+      </div>
+      {action}
+    </li>
+  );
+}
+
+export interface OpportunityInboxConfirmedTourDatesProps {
+  readonly items: readonly OpportunityInboxTourDateItem[];
+}
+
+/** Visible list of confirmed upcoming tour dates (mirrors the profile). */
+export function OpportunityInboxConfirmedTourDates({
+  items,
+}: OpportunityInboxConfirmedTourDatesProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className='system-b-opportunity-inbox-feed'
+      data-testid='opportunity-inbox-confirmed-tour-dates'
+      aria-label='Confirmed Tour Dates'
+    >
+      <div className='system-b-opportunity-inbox-section-label'>
+        Confirmed Tour Dates
+      </div>
+      <ul className='m-0 list-none p-0'>
+        {items.map(item => (
+          <TourDateRow key={item.id} item={item} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export interface OpportunityInboxRejectedTourDatesProps {
+  readonly items: readonly OpportunityInboxTourDateItem[];
+  readonly onUndoReject: (id: string) => void;
+  readonly pendingUndoId?: string | null;
+}
+
+/**
+ * Hidden-by-default rejected bucket. Collapsed behind a disclosure so
+ * rejected signals stay out of the way but remain auditable and undoable.
+ */
+export function OpportunityInboxRejectedTourDates({
+  items,
+  onUndoReject,
+  pendingUndoId = null,
+}: OpportunityInboxRejectedTourDatesProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <details
+      className='system-b-opportunity-inbox-feed'
+      data-testid='opportunity-inbox-rejected-tour-dates'
+    >
+      <summary className='system-b-opportunity-inbox-section-label cursor-pointer list-none select-none'>
+        Rejected Tour Dates ({items.length})
+      </summary>
+      <ul className='m-0 list-none p-0'>
+        {items.map(item => (
+          <TourDateRow
+            key={item.id}
+            item={item}
+            action={
+              <button
+                type='button'
+                className='system-b-opportunity-inbox-dismiss shrink-0'
+                disabled={pendingUndoId === item.id}
+                onClick={() => onUndoReject(item.id)}
+              >
+                {pendingUndoId === item.id ? 'Restoring…' : 'Undo'}
+              </button>
+            }
+          />
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/apps/web/lib/queries/useTourDateReviewMutations.ts
+++ b/apps/web/lib/queries/useTourDateReviewMutations.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import {
+  confirmEvent,
+  type EventActionResult,
+  rejectEvent,
+  undoRejectEvent,
+} from '@/app/app/(shell)/dashboard/tour-dates/events-actions';
+
+function assertOk(result: EventActionResult, failureMessage: string): void {
+  if (!result.ok) {
+    throw new Error(failureMessage);
+  }
+}
+
+/**
+ * Confirm / reject / undo-reject mutations for detected tour dates in the
+ * Opportunity Inbox. Wraps the trust-gate server actions from the tour-dates
+ * dashboard so both surfaces share one moderation path.
+ */
+export function useTourDateReviewMutations() {
+  const router = useRouter();
+
+  const confirmMutation = useMutation({
+    mutationFn: async (id: string) => {
+      assertOk(await confirmEvent(id), 'Unable to confirm tour date');
+    },
+    onSuccess: () => {
+      toast.success('Tour date confirmed — it now shows on your profile.');
+      router.refresh();
+    },
+    onError: error => {
+      toast.error(
+        error instanceof Error ? error.message : 'Unable to confirm tour date'
+      );
+    },
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: async (id: string) => {
+      assertOk(await rejectEvent(id), 'Unable to reject tour date');
+    },
+    onSuccess: () => {
+      toast.success('Tour date rejected — moved to your rejected list.');
+      router.refresh();
+    },
+    onError: error => {
+      toast.error(
+        error instanceof Error ? error.message : 'Unable to reject tour date'
+      );
+    },
+  });
+
+  const undoRejectMutation = useMutation({
+    mutationFn: async (id: string) => {
+      assertOk(await undoRejectEvent(id), 'Unable to restore tour date');
+    },
+    onSuccess: () => {
+      toast.success('Tour date restored to review.');
+      router.refresh();
+    },
+    onError: error => {
+      toast.error(
+        error instanceof Error ? error.message : 'Unable to restore tour date'
+      );
+    },
+  });
+
+  return { confirmMutation, rejectMutation, undoRejectMutation };
+}


### PR DESCRIPTION
## Problem
Re-dispatch of #11508 part 2 — PRs #13264/#13265 were closed by the auto-merge cron and their branches deleted. Investigation showed **part 1 already landed on main** as ad5c570 (Graphite squash of #13264; PR shows closed-unmerged, which is the known Graphite pattern). Only the part-2 UI was lost, so this PR recreates part 2 alone, based directly on main. A recreated part-1 branch would be an empty diff — intentionally not recreated.

## What changed
Byte-identical recreation of verified PR #13265 (head e560f17):
- `OpportunityInboxTourDateCard` (new): confirm/reject card for a pending detected tour date — provider meta line, UTC-anchored date + venue/location, `Confirm date` primary / `Reject` dismiss. Reuses existing `system-b-opportunity-inbox-card` classes (no new CSS).
- `OpportunityInboxTourDateSections` (new): visible "Confirmed Tour Dates" list and a collapsed-by-default `<details>` "Rejected Tour Dates (n)" section with per-row Undo.
- `useTourDateReviewMutations` (new): wraps the existing trust-gate server actions (`confirmEvent` / `rejectEvent` / `undoRejectEvent`) so both surfaces share one moderation path; toasts + `router.refresh()`.
- `OpportunityInboxPageClient`: renders "Tour Dates To Review" pending cards above the suggestion feed, confirmed + hidden rejected sections below; optimistic moves between pending/confirmed/rejected; empty state only when no suggestion cards AND no pending tour dates.
- Tests: confirm-optimistic-move, reject-to-hidden-section (asserts disclosure starts collapsed), undo-restore.

Confirmed dates appear on the public profile via the existing `confirmationStatus='confirmed'` gate — no profile changes needed. No schema changes, no new dependencies. 5 files, ~520 lines (under the 800-line cap).

## Assumptions
- Part 1 landing commit ad5c570 is authoritative: all 10 part-1 files on current main are byte-identical to the verified part-1 head 7c461d8 (checked programmatically).
- Rejected bucket stays a collapsed `<details>` (hidden by default, auditable, undoable), per the verified design.

## Verification
- Deterministic byte-verification: the 5 changed files on this branch are byte-identical to verified PR #13265 head e560f17, and every other file matches current main exactly (tarball diff, 0 differences).
- Local `pnpm install` blocked again (`registry.npmjs.org` → 403 in sandbox). Commands that must pass in CI:
```
pnpm install && pnpm turbo lint typecheck test:fast --affected && pnpm run build:web
```
Deferring to CI merge gates (`ci-fast`, `Unit Tests`, `Structural Contract`) — same posture the original verified PR shipped with.

## Links
Closes #11508. Dispatch: issue #11508 re-dispatch (tim-approved). Supersedes #13265; part 1 = ad5c570 (#13264).

🤖 Generated with [Claude Code](https://claude.com/claude-code)