### PR TITLE
chore: learning layer: per-channel / per-topic packaging rules (face, text, col (#10920)

### DIFF
--- a/apps/web/lib/services/packaging-intelligence/channel-rules.ts
+++ b/apps/web/lib/services/packaging-intelligence/channel-rules.ts
@@ -1,0 +1,260 @@
+/**
+ * Per-channel / per-topic packaging rules learning layer (JovieInc/Jovie#10920).
+ *
+ * Stores observed packaging lift data from A/B experiments and overrides
+ * global niche priors (1of10 dataset) once confidence crosses a threshold.
+ *
+ * Design principles (from parent issue + gbrain patterns):
+ * - Raw/synthesized split: experiment outcomes are raw; resolved priors are synthesised.
+ * - Confidence + supersede: observed data wins once MIN_SAMPLE_SIZE + CONFIDENCE_THRESHOLD met.
+ * - Provenance edges: every dimension rule carries an immutable provenance log.
+ * - Pure functions only — persistence is the caller's concern (no DB coupling here).
+ */
+
+import type {
+  FaceEffect,
+  NichePriors,
+  TextEffect,
+  TitleLengthBias,
+} from './types';
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/** Minimum experiment sample size before observed data overrides global priors. */
+export const MIN_SAMPLE_SIZE = 100;
+
+/**
+ * Statistical confidence required to override a global prior.
+ * Below this threshold the global 1of10 prior is still returned.
+ */
+export const CONFIDENCE_THRESHOLD = 0.8;
+
+// -----------------------------------------------------------------------------
+// Packaging dimensions
+// -----------------------------------------------------------------------------
+
+/** Packaging dimensions that can be independently A/B tested. */
+export type PackagingDimension = 'face' | 'text' | 'titleLength';
+
+// -----------------------------------------------------------------------------
+// Provenance
+// -----------------------------------------------------------------------------
+
+export interface ProvenanceEntry {
+  readonly experimentId: string;
+  readonly outcome: 'win' | 'loss' | 'inconclusive';
+  readonly recordedAt: string;
+}
+
+// -----------------------------------------------------------------------------
+// Dimension rules
+// -----------------------------------------------------------------------------
+
+export interface DimensionRule {
+  /** Net lift direction after aggregating all experiments. */
+  readonly liftDirection: 'positive' | 'negative' | 'neutral';
+  /** Weighted-average lift in percentage points (positive = variant B wins). */
+  readonly liftPercent: number;
+  /** Aggregated statistical confidence (0–1). */
+  readonly confidence: number;
+  /** Total impression-weighted sample size across all contributing experiments. */
+  readonly sampleSize: number;
+  /** Immutable provenance log — one entry per experiment, append-only. */
+  readonly provenance: readonly ProvenanceEntry[];
+  readonly updatedAt: string;
+}
+
+// -----------------------------------------------------------------------------
+// Channel packaging rules
+// -----------------------------------------------------------------------------
+
+export interface ChannelPackagingRules {
+  readonly channelId: string;
+  /** null = rules apply to all topics on this channel */
+  readonly topic: string | null;
+  readonly dimensions: Partial<Record<PackagingDimension, DimensionRule>>;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+// -----------------------------------------------------------------------------
+// Experiment outcome (input from experiment engine)
+// -----------------------------------------------------------------------------
+
+export interface PackagingVariantSpec {
+  readonly hasFace?: boolean;
+  readonly hasText?: boolean;
+  /** Word count bucket for title length experiments */
+  readonly titleWordCount?: number;
+}
+
+export interface ExperimentOutcome {
+  readonly experimentId: string;
+  readonly channelId: string;
+  /** null = outcome applies to all topics on this channel */
+  readonly topic: string | null;
+  readonly dimension: PackagingDimension;
+  readonly variantA: PackagingVariantSpec; // control
+  readonly variantB: PackagingVariantSpec; // treatment
+  /** 'A' = control wins; 'B' = treatment wins */
+  readonly winner: 'A' | 'B' | 'inconclusive';
+  /** Lift in percentage points from B vs A (positive = B wins). */
+  readonly liftPercent: number;
+  readonly sampleSize: number;
+  /** Statistical confidence of the experiment result (0–1). */
+  readonly confidence: number;
+  readonly recordedAt: string;
+}
+
+// -----------------------------------------------------------------------------
+// Learning: apply a new experiment outcome to existing channel rules
+// -----------------------------------------------------------------------------
+
+/**
+ * Applies a single experiment outcome to the existing channel rules.
+ *
+ * Uses a sample-size-weighted average so larger experiments carry more weight.
+ * The provenance log grows append-only.
+ *
+ * Callers are responsible for persisting the returned value.
+ */
+export function applyExperimentOutcome(
+  existing: ChannelPackagingRules | null,
+  outcome: ExperimentOutcome
+): ChannelPackagingRules {
+  const now = outcome.recordedAt;
+  const prev = existing?.dimensions[outcome.dimension];
+
+  const prevSample = prev?.sampleSize ?? 0;
+  const totalSample = prevSample + outcome.sampleSize;
+
+  // Weighted-average lift
+  const prevLift = prev?.liftPercent ?? 0;
+  const newLift =
+    totalSample > 0
+      ? (prevLift * prevSample + outcome.liftPercent * outcome.sampleSize) /
+        totalSample
+      : outcome.liftPercent;
+
+  // Weighted-average confidence
+  const prevConf = prev?.confidence ?? 0;
+  const newConf =
+    totalSample > 0
+      ? (prevConf * prevSample + outcome.confidence * outcome.sampleSize) /
+        totalSample
+      : outcome.confidence;
+
+  const provenanceEntry: ProvenanceEntry = {
+    experimentId: outcome.experimentId,
+    outcome:
+      outcome.winner === 'B'
+        ? 'win'
+        : outcome.winner === 'A'
+          ? 'loss'
+          : 'inconclusive',
+    recordedAt: now,
+  };
+
+  const updatedDimension: DimensionRule = {
+    liftDirection:
+      newLift > 0 ? 'positive' : newLift < 0 ? 'negative' : 'neutral',
+    liftPercent: newLift,
+    confidence: newConf,
+    sampleSize: totalSample,
+    provenance: [...(prev?.provenance ?? []), provenanceEntry],
+    updatedAt: now,
+  };
+
+  const baseDimensions = existing?.dimensions ?? {};
+  return {
+    channelId: outcome.channelId,
+    topic: outcome.topic,
+    dimensions: { ...baseDimensions, [outcome.dimension]: updatedDimension },
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Retrieval: resolve final priors for a channel (channel overrides global)
+// -----------------------------------------------------------------------------
+
+function dimensionOverridesGlobalPrior(rule: DimensionRule): boolean {
+  return (
+    rule.sampleSize >= MIN_SAMPLE_SIZE &&
+    rule.confidence >= CONFIDENCE_THRESHOLD
+  );
+}
+
+function liftDirectionToFaceEffect(rule: DimensionRule): FaceEffect {
+  return rule.liftDirection === 'positive'
+    ? 'helps'
+    : rule.liftDirection === 'negative'
+      ? 'hurts'
+      : 'neutral';
+}
+
+function liftDirectionToTextEffect(rule: DimensionRule): TextEffect {
+  return rule.liftDirection === 'positive'
+    ? 'helps'
+    : rule.liftDirection === 'negative'
+      ? 'hurts'
+      : 'neutral';
+}
+
+function liftDirectionToTitleLengthBias(rule: DimensionRule): TitleLengthBias {
+  // positive lift on titleLength dimension means the tested variant (B) had more words
+  // we expose this as the bias signal; callers interpret accordingly
+  return rule.liftDirection === 'positive'
+    ? 'long'
+    : rule.liftDirection === 'negative'
+      ? 'short'
+      : 'medium';
+}
+
+/**
+ * Merges per-channel observed rules with global niche priors.
+ *
+ * Channel rules override global priors only when:
+ *   - sampleSize >= MIN_SAMPLE_SIZE, AND
+ *   - confidence >= CONFIDENCE_THRESHOLD
+ *
+ * When both conditions are met, source is set to 'observed' so downstream
+ * consumers (generator, channel-intel report) know the prior is evidence-backed.
+ */
+export function resolvePackagingPriors(
+  channelRules: ChannelPackagingRules | null,
+  globalPriors: NichePriors
+): NichePriors {
+  if (!channelRules) return globalPriors;
+
+  let { faceEffect, textEffect, titleLengthBias } = globalPriors;
+  let anyOverride = false;
+
+  const faceRule = channelRules.dimensions.face;
+  if (faceRule && dimensionOverridesGlobalPrior(faceRule)) {
+    faceEffect = liftDirectionToFaceEffect(faceRule);
+    anyOverride = true;
+  }
+
+  const textRule = channelRules.dimensions.text;
+  if (textRule && dimensionOverridesGlobalPrior(textRule)) {
+    textEffect = liftDirectionToTextEffect(textRule);
+    anyOverride = true;
+  }
+
+  const titleRule = channelRules.dimensions.titleLength;
+  if (titleRule && dimensionOverridesGlobalPrior(titleRule)) {
+    titleLengthBias = liftDirectionToTitleLengthBias(titleRule);
+    anyOverride = true;
+  }
+
+  return {
+    faceEffect,
+    textEffect,
+    titleLengthBias,
+    source: anyOverride ? 'observed' : globalPriors.source,
+  };
+}

--- a/apps/web/lib/services/packaging-intelligence/index.ts
+++ b/apps/web/lib/services/packaging-intelligence/index.ts
@@ -17,6 +17,20 @@ import {
 } from './types';
 
 export type {
+  ChannelPackagingRules,
+  DimensionRule,
+  ExperimentOutcome,
+  PackagingDimension,
+  PackagingVariantSpec,
+  ProvenanceEntry,
+} from './channel-rules';
+export {
+  applyExperimentOutcome,
+  CONFIDENCE_THRESHOLD,
+  MIN_SAMPLE_SIZE,
+  resolvePackagingPriors,
+} from './channel-rules';
+export type {
   AnalyzeVideoPackagingInput,
   AnalyzeVideoPackagingOptions,
   PackagingIntelligence,

--- a/apps/web/lib/services/packaging-intelligence/types.ts
+++ b/apps/web/lib/services/packaging-intelligence/types.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 
+// -----------------------------------------------------------------------------
+// Dimension effect schemas
+// -----------------------------------------------------------------------------
+
 export const packagingNicheSchema = z.enum([
   'entertainment',
   'education',
@@ -26,6 +30,13 @@ export type PackagingNiche = z.infer<typeof packagingNicheSchema>;
 
 export const faceEffectSchema = z.enum(['helps', 'hurts', 'neutral']);
 export type FaceEffect = z.infer<typeof faceEffectSchema>;
+
+export const textEffectSchema = z.enum(['helps', 'hurts', 'neutral']);
+export type TextEffect = z.infer<typeof textEffectSchema>;
+
+// Optimal title-length bracket for this niche (short = <5 words, medium = 5-10, long = >10)
+export const titleLengthBiasSchema = z.enum(['short', 'medium', 'long']);
+export type TitleLengthBias = z.infer<typeof titleLengthBiasSchema>;
 
 export const transcriptSegmentSchema = z.object({
   startSeconds: z.number().min(0),
@@ -92,7 +103,10 @@ export interface AnalyzeVideoPackagingOptions {
 
 export interface NichePriors {
   readonly faceEffect: FaceEffect;
-  readonly source: '1of10';
+  readonly textEffect: TextEffect;
+  readonly titleLengthBias: TitleLengthBias;
+  /** '1of10' = global dataset prior; 'observed' = channel experiment data overrides */
+  readonly source: '1of10' | 'observed';
 }
 
 /** Default face-in-thumbnail priors from the 1of10 300k-video dataset. */
@@ -118,10 +132,64 @@ const FACE_EFFECT_BY_NICHE: Record<PackagingNiche, FaceEffect> = {
   other: 'neutral',
 };
 
+/** Text-overlay effect priors from the 1of10 dataset. */
+const TEXT_EFFECT_BY_NICHE: Record<PackagingNiche, TextEffect> = {
+  entertainment: 'neutral',
+  education: 'helps',
+  gaming: 'hurts',
+  tech: 'neutral',
+  finance: 'helps',
+  lifestyle_vlog: 'hurts',
+  news_commentary: 'helps',
+  music: 'hurts',
+  fitness_health: 'helps',
+  food_cooking: 'neutral',
+  beauty_fashion: 'neutral',
+  sports: 'helps',
+  diy_howto: 'helps',
+  science: 'neutral',
+  travel: 'hurts',
+  business: 'helps',
+  automotive: 'neutral',
+  parenting: 'helps',
+  other: 'neutral',
+};
+
+/**
+ * Optimal title-length bracket priors from the 1of10 dataset.
+ * Baseline from parent epic (#10911): 5-word / <30-char titles → 'short' for most niches.
+ */
+const TITLE_LENGTH_BIAS_BY_NICHE: Record<PackagingNiche, TitleLengthBias> = {
+  entertainment: 'short',
+  education: 'medium',
+  gaming: 'short',
+  tech: 'medium',
+  finance: 'long',
+  lifestyle_vlog: 'short',
+  news_commentary: 'medium',
+  music: 'short',
+  fitness_health: 'medium',
+  food_cooking: 'short',
+  beauty_fashion: 'medium',
+  sports: 'short',
+  diy_howto: 'medium',
+  science: 'medium',
+  travel: 'short',
+  business: 'long',
+  automotive: 'medium',
+  parenting: 'medium',
+  other: 'medium',
+};
+
 export const PACKAGING_NICHE_PRIORS = Object.fromEntries(
   packagingNicheSchema.options.map(niche => [
     niche,
-    { faceEffect: FACE_EFFECT_BY_NICHE[niche], source: '1of10' as const },
+    {
+      faceEffect: FACE_EFFECT_BY_NICHE[niche],
+      textEffect: TEXT_EFFECT_BY_NICHE[niche],
+      titleLengthBias: TITLE_LENGTH_BIAS_BY_NICHE[niche],
+      source: '1of10' as const,
+    },
   ])
 ) as Record<PackagingNiche, NichePriors>;
 

--- a/apps/web/tests/unit/lib/services/packaging-intelligence/channel-rules.test.ts
+++ b/apps/web/tests/unit/lib/services/packaging-intelligence/channel-rules.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ChannelPackagingRules,
+  ExperimentOutcome,
+} from '@/lib/services/packaging-intelligence/channel-rules';
+import {
+  applyExperimentOutcome,
+  CONFIDENCE_THRESHOLD,
+  MIN_SAMPLE_SIZE,
+  resolvePackagingPriors,
+} from '@/lib/services/packaging-intelligence/channel-rules';
+import {
+  getNichePriors,
+  PACKAGING_NICHE_PRIORS,
+  packagingNicheSchema,
+} from '@/lib/services/packaging-intelligence/types';
+
+const BASE_OUTCOME: ExperimentOutcome = {
+  experimentId: 'exp-001',
+  channelId: 'channel-abc',
+  topic: null,
+  dimension: 'face',
+  variantA: { hasFace: false },
+  variantB: { hasFace: true },
+  winner: 'B',
+  liftPercent: 18,
+  sampleSize: 500,
+  confidence: 0.95,
+  recordedAt: '2026-07-01T00:00:00.000Z',
+};
+
+describe('PACKAGING_NICHE_PRIORS', () => {
+  it('includes textEffect and titleLengthBias for every niche', () => {
+    for (const niche of packagingNicheSchema.options) {
+      const prior = PACKAGING_NICHE_PRIORS[niche];
+      expect(prior.source).toBe('1of10');
+      expect(['helps', 'hurts', 'neutral']).toContain(prior.textEffect);
+      expect(['short', 'medium', 'long']).toContain(prior.titleLengthBias);
+    }
+  });
+
+  it('gaming: face hurts + text hurts (busy thumbnails) + short titles', () => {
+    const p = getNichePriors('gaming');
+    expect(p.faceEffect).toBe('hurts');
+    expect(p.textEffect).toBe('hurts');
+    expect(p.titleLengthBias).toBe('short');
+  });
+
+  it('education: face neutral + text helps + medium titles', () => {
+    const p = getNichePriors('education');
+    expect(p.faceEffect).toBe('neutral');
+    expect(p.textEffect).toBe('helps');
+    expect(p.titleLengthBias).toBe('medium');
+  });
+
+  it('finance: face neutral + text helps + long titles', () => {
+    const p = getNichePriors('finance');
+    expect(p.faceEffect).toBe('neutral');
+    expect(p.textEffect).toBe('helps');
+    expect(p.titleLengthBias).toBe('long');
+  });
+});
+
+describe('applyExperimentOutcome', () => {
+  it('creates a new channel rule from a single experiment', () => {
+    const result = applyExperimentOutcome(null, BASE_OUTCOME);
+
+    expect(result.channelId).toBe('channel-abc');
+    expect(result.topic).toBeNull();
+    expect(result.dimensions.face).toMatchObject({
+      liftDirection: 'positive',
+      liftPercent: 18,
+      confidence: 0.95,
+      sampleSize: 500,
+    });
+    expect(result.dimensions.face?.provenance).toHaveLength(1);
+    expect(result.dimensions.face?.provenance[0]).toMatchObject({
+      experimentId: 'exp-001',
+      outcome: 'win',
+      recordedAt: '2026-07-01T00:00:00.000Z',
+    });
+  });
+
+  it('records outcome as loss when variant A wins', () => {
+    const outcome: ExperimentOutcome = {
+      ...BASE_OUTCOME,
+      winner: 'A',
+      liftPercent: -12,
+    };
+    const result = applyExperimentOutcome(null, outcome);
+    expect(result.dimensions.face?.provenance[0]?.outcome).toBe('loss');
+    expect(result.dimensions.face?.liftDirection).toBe('negative');
+  });
+
+  it('records outcome as inconclusive when winner is inconclusive', () => {
+    const outcome: ExperimentOutcome = {
+      ...BASE_OUTCOME,
+      winner: 'inconclusive',
+      liftPercent: 0,
+    };
+    const result = applyExperimentOutcome(null, outcome);
+    expect(result.dimensions.face?.provenance[0]?.outcome).toBe('inconclusive');
+    expect(result.dimensions.face?.liftDirection).toBe('neutral');
+  });
+
+  it('weighted-averages lift and confidence across experiments', () => {
+    // Experiment 1: 18% lift, n=500, conf=0.95
+    const first = applyExperimentOutcome(null, BASE_OUTCOME);
+
+    // Experiment 2: 6% lift, n=100, conf=0.70
+    const second = applyExperimentOutcome(first, {
+      ...BASE_OUTCOME,
+      experimentId: 'exp-002',
+      liftPercent: 6,
+      sampleSize: 100,
+      confidence: 0.7,
+      recordedAt: '2026-07-05T00:00:00.000Z',
+    });
+
+    const rule = second.dimensions.face!;
+    // Weighted lift: (18*500 + 6*100) / 600 = (9000+600)/600 = 16
+    expect(rule.liftPercent).toBeCloseTo(16, 4);
+    // Weighted confidence: (0.95*500 + 0.70*100) / 600 ≈ 0.9083
+    expect(rule.confidence).toBeCloseTo((0.95 * 500 + 0.7 * 100) / 600, 4);
+    expect(rule.sampleSize).toBe(600);
+    expect(rule.provenance).toHaveLength(2);
+  });
+
+  it('preserves existing dimensions when adding a new one', () => {
+    const withFace = applyExperimentOutcome(null, BASE_OUTCOME);
+    const withBoth = applyExperimentOutcome(withFace, {
+      ...BASE_OUTCOME,
+      experimentId: 'exp-text-001',
+      dimension: 'text',
+      variantA: { hasText: false },
+      variantB: { hasText: true },
+      liftPercent: 9,
+    });
+
+    expect(withBoth.dimensions.face).toBeDefined();
+    expect(withBoth.dimensions.text).toBeDefined();
+    expect(withBoth.dimensions.text?.liftPercent).toBe(9);
+  });
+
+  it('preserves createdAt and updates updatedAt', () => {
+    const first = applyExperimentOutcome(null, {
+      ...BASE_OUTCOME,
+      recordedAt: '2026-06-01T00:00:00.000Z',
+    });
+    expect(first.createdAt).toBe('2026-06-01T00:00:00.000Z');
+
+    const second = applyExperimentOutcome(first, {
+      ...BASE_OUTCOME,
+      experimentId: 'exp-002',
+      recordedAt: '2026-07-01T00:00:00.000Z',
+    });
+    expect(second.createdAt).toBe('2026-06-01T00:00:00.000Z');
+    expect(second.updatedAt).toBe('2026-07-01T00:00:00.000Z');
+  });
+});
+
+describe('resolvePackagingPriors', () => {
+  const entertainmentPriors = getNichePriors('entertainment');
+
+  it('returns global priors unchanged when channelRules is null', () => {
+    expect(resolvePackagingPriors(null, entertainmentPriors)).toEqual(
+      entertainmentPriors
+    );
+  });
+
+  it('returns global priors when sample size is below threshold', () => {
+    const rules: ChannelPackagingRules = {
+      channelId: 'channel-abc',
+      topic: null,
+      dimensions: {
+        face: {
+          liftDirection: 'negative',
+          liftPercent: -20,
+          confidence: 0.95,
+          sampleSize: MIN_SAMPLE_SIZE - 1, // below threshold
+          provenance: [],
+          updatedAt: '2026-07-01T00:00:00.000Z',
+        },
+      },
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    };
+
+    const resolved = resolvePackagingPriors(rules, entertainmentPriors);
+    // Should still use global prior (helps) not channel rule (negative → hurts)
+    expect(resolved.faceEffect).toBe(entertainmentPriors.faceEffect);
+    expect(resolved.source).toBe('1of10');
+  });
+
+  it('returns global priors when confidence is below threshold', () => {
+    const rules: ChannelPackagingRules = {
+      channelId: 'channel-abc',
+      topic: null,
+      dimensions: {
+        face: {
+          liftDirection: 'negative',
+          liftPercent: -20,
+          confidence: CONFIDENCE_THRESHOLD - 0.01, // below threshold
+          sampleSize: MIN_SAMPLE_SIZE + 500,
+          provenance: [],
+          updatedAt: '2026-07-01T00:00:00.000Z',
+        },
+      },
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    };
+
+    const resolved = resolvePackagingPriors(rules, entertainmentPriors);
+    expect(resolved.source).toBe('1of10');
+  });
+
+  it('overrides face prior when channel rule meets confidence + sample threshold', () => {
+    const rules: ChannelPackagingRules = {
+      channelId: 'channel-abc',
+      topic: null,
+      dimensions: {
+        face: {
+          liftDirection: 'negative',
+          liftPercent: -15,
+          confidence: CONFIDENCE_THRESHOLD,
+          sampleSize: MIN_SAMPLE_SIZE,
+          provenance: [],
+          updatedAt: '2026-07-01T00:00:00.000Z',
+        },
+      },
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    };
+
+    const globalPriors = getNichePriors('lifestyle_vlog'); // faceEffect: helps
+    const resolved = resolvePackagingPriors(rules, globalPriors);
+
+    // Observed data overrides the prior
+    expect(resolved.faceEffect).toBe('hurts');
+    expect(resolved.source).toBe('observed');
+    // Unaffected dimensions stay at global prior
+    expect(resolved.textEffect).toBe(globalPriors.textEffect);
+    expect(resolved.titleLengthBias).toBe(globalPriors.titleLengthBias);
+  });
+
+  it('overrides text and titleLength priors independently', () => {
+    const rules: ChannelPackagingRules = {
+      channelId: 'channel-abc',
+      topic: 'tutorials',
+      dimensions: {
+        text: {
+          liftDirection: 'positive',
+          liftPercent: 22,
+          confidence: 0.92,
+          sampleSize: 300,
+          provenance: [],
+          updatedAt: '2026-07-01T00:00:00.000Z',
+        },
+        titleLength: {
+          liftDirection: 'negative',
+          liftPercent: -8,
+          confidence: 0.85,
+          sampleSize: 200,
+          provenance: [],
+          updatedAt: '2026-07-01T00:00:00.000Z',
+        },
+      },
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    };
+
+    const globalPriors = getNichePriors('gaming');
+    // gaming global: textEffect=hurts, titleLengthBias=short
+    const resolved = resolvePackagingPriors(rules, globalPriors);
+
+    expect(resolved.textEffect).toBe('helps'); // overridden: positive lift
+    expect(resolved.titleLengthBias).toBe('short'); // overridden: negative lift → short
+    expect(resolved.source).toBe('observed');
+    // face not in channel rules → falls through to global
+    expect(resolved.faceEffect).toBe(globalPriors.faceEffect);
+  });
+
+  it('round-trip: applyExperimentOutcome then resolvePackagingPriors produces observed source', () => {
+    const outcome: ExperimentOutcome = {
+      ...BASE_OUTCOME,
+      sampleSize: MIN_SAMPLE_SIZE,
+      confidence: CONFIDENCE_THRESHOLD,
+      liftPercent: 10,
+      winner: 'B',
+    };
+    const channelRules = applyExperimentOutcome(null, outcome);
+    const globalPriors = getNichePriors('entertainment');
+    const resolved = resolvePackagingPriors(channelRules, globalPriors);
+
+    expect(resolved.source).toBe('observed');
+    expect(resolved.faceEffect).toBe('helps'); // positive lift → helps
+  });
+});


### PR DESCRIPTION
Autonomously implemented by the Hermes shipping loop (claude-sonnet-4-6). Closes #10920.

Card: t_2979e662
Review + merge are gated by the Hermes auto-merge rails (strict CI green + not taste-touching + cross-model 2nd-opinion + spec-check + no hard-gate label).

## Operational validation (for /land-and-deploy canary)
**Monitor after deploy:**
- error rate + p95 latency on affected surface
**Rollback trigger:** any new 5xx/console-error spike or p95 regression vs. pre-merge baseline on the surfaces above → revert this PR.