### PR TITLE
fix(auth): fail open on degraded rate-limit backend + human-readable 429 on /auth/start

### DIFF
--- a/apps/web/app/auth/start/route.test.ts
+++ b/apps/web/app/auth/start/route.test.ts
@@ -44,6 +44,15 @@ vi.mock('@/lib/server-analytics', () => ({
   trackServerEvent: hoisted.trackServerEvent,
 }));
 
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 const { GET } = await import('./route');
 
 describe('GET /auth/start', () => {
@@ -132,7 +141,7 @@ describe('GET /auth/start', () => {
     expect(hoisted.localLimiter.limit).not.toHaveBeenCalled();
   });
 
-  it('keeps Redis-required rate limiting fail-closed in production', async () => {
+  it('fails open in production when the limiter backend is unavailable', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     hoisted.generalLimiter.limit.mockResolvedValueOnce({
       success: false,
@@ -149,8 +158,93 @@ describe('GET /auth/start', () => {
       )
     );
 
-    expect(response.status).toBe(429);
+    expect(response.status).toBe(307);
     expect(hoisted.localLimiter.limit).not.toHaveBeenCalled();
     vi.unstubAllEnvs();
+  });
+
+  it('fails open in production when the limit came from the degraded memory fallback', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    hoisted.generalLimiter.limit.mockResolvedValueOnce({
+      success: false,
+      degraded: true,
+      limit: 60,
+      remaining: 0,
+      reset: new Date(Date.now() + 60_000),
+    });
+
+    const response = await GET(
+      new Request(
+        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Fchat%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
+      )
+    );
+
+    expect(response.status).toBe(307);
+    expect(hoisted.localLimiter.limit).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it('still enforces a healthy-backend 429 in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    hoisted.generalLimiter.limit.mockResolvedValueOnce({
+      success: false,
+      limit: 60,
+      remaining: 0,
+      reset: new Date(Date.now() + 60_000),
+    });
+
+    const response = await GET(
+      new Request(
+        'http://localhost:3112/auth/start?client=electron&intent=sign_in&return_to=%2Fapp%2Fchat%3Fruntime%3Delectron&code_challenge=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&code_challenge_method=S256'
+      )
+    );
+
+    expect(response.status).toBe(429);
+    vi.unstubAllEnvs();
+  });
+
+  it('renders a human-readable HTML page for browser-navigated 429s', async () => {
+    hoisted.generalLimiter.limit.mockResolvedValueOnce({
+      success: false,
+      limit: 60,
+      remaining: 0,
+      reset: new Date(Date.now() + 30_000),
+    });
+
+    const response = await GET(
+      new Request(
+        'http://localhost:3112/auth/start?client=web&intent=sign_in&return_to=%2Fapp',
+        { headers: { accept: 'text/html,application/xhtml+xml' } }
+      )
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(response.headers.get('retry-after')).toBeTruthy();
+    const body = await response.text();
+    expect(body).toContain('Too many sign-in attempts');
+    expect(body).toContain('Try again');
+    expect(body).toContain('http-equiv="refresh"');
+    expect(body).not.toContain('{"error"');
+  });
+
+  it('keeps JSON 429s for non-browser clients', async () => {
+    hoisted.generalLimiter.limit.mockResolvedValueOnce({
+      success: false,
+      limit: 60,
+      remaining: 0,
+      reset: new Date(Date.now() + 30_000),
+    });
+
+    const response = await GET(
+      new Request(
+        'http://localhost:3112/auth/start?client=web&intent=sign_in&return_to=%2Fapp',
+        { headers: { accept: 'application/json' } }
+      )
+    );
+
+    expect(response.status).toBe(429);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'Too many auth attempts' });
   });
 });

--- a/apps/web/app/auth/start/route.ts
+++ b/apps/web/app/auth/start/route.ts
@@ -14,6 +14,7 @@ import { createStoredAuthState } from '@/lib/auth/routing-state.server';
 import { env } from '@/lib/env';
 import { captureError } from '@/lib/error-tracking';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
+import type { RateLimitResult } from '@/lib/rate-limit';
 import {
   createRateLimiter,
   createRateLimitHeaders,
@@ -22,6 +23,7 @@ import {
   RATE_LIMITERS,
 } from '@/lib/rate-limit';
 import { trackServerEvent } from '@/lib/server-analytics';
+import { logger } from '@/lib/utils/logger';
 
 export const runtime = 'nodejs';
 
@@ -40,17 +42,82 @@ function isLocalRuntime(): boolean {
   return env.NODE_ENV !== 'production';
 }
 
-async function limitAuthStart(key: string) {
+async function limitAuthStart(key: string): Promise<RateLimitResult> {
   const rateLimit = await generalLimiter.limit(key);
-  if (
-    rateLimit.success ||
-    !isLocalRuntime() ||
-    rateLimit.unavailable !== true
-  ) {
+  if (rateLimit.success) {
     return rateLimit;
   }
 
-  return LOCAL_AUTH_START_LIMITER.limit(key);
+  const backendDegraded =
+    rateLimit.unavailable === true || rateLimit.degraded === true;
+  if (!backendDegraded) {
+    // A healthy durable backend rejected the request — enforce the limit.
+    return rateLimit;
+  }
+
+  if (isLocalRuntime()) {
+    return LOCAL_AUTH_START_LIMITER.limit(key);
+  }
+
+  // Production with a degraded/unavailable limiter backend: treat the
+  // auth-start limit as advisory (log + allow). A per-instance memory bucket
+  // keyed by IP over-blocks real users behind carrier CGNAT during a Redis
+  // outage, dead-ending sign-in. Bot defense is unaffected — Clerk still
+  // gates the actual auth attempt; this limiter is only a pre-filter.
+  logger.warn(
+    'Rate-limit backend degraded — allowing auth start (advisory limit)',
+    { key },
+    'auth/start'
+  );
+  return { ...rateLimit, success: true, reason: undefined };
+}
+
+function wantsHtmlResponse(request: Request): boolean {
+  const accept = request.headers.get('accept') ?? '';
+  return accept.includes('text/html');
+}
+
+function getRetryAfterSeconds(rateLimit: RateLimitResult): number {
+  const resetMs =
+    rateLimit.reset instanceof Date ? rateLimit.reset.getTime() : Date.now();
+  return Math.min(60, Math.max(3, Math.ceil((resetMs - Date.now()) / 1000)));
+}
+
+/**
+ * /auth/start is browser-navigated, so a 429 must render a human-readable
+ * page — never raw JSON. Auto-retries via meta refresh honoring Retry-After,
+ * with a manual retry CTA as fallback. Static markup only (no user input).
+ */
+function createRateLimitedHtmlResponse(
+  rateLimit: RateLimitResult
+): NextResponse {
+  const retryAfterSeconds = getRetryAfterSeconds(rateLimit);
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="refresh" content="${retryAfterSeconds}" />
+<title>Too many sign-in attempts — Jovie</title>
+</head>
+<body style="margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0b0b0b;color:#f5f4f0;font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+<main style="max-width:400px;padding:32px 24px;text-align:center;">
+<h1 style="margin:0 0 12px;font-size:20px;font-weight:600;letter-spacing:-0.01em;">Too many sign-in attempts</h1>
+<p style="margin:0 0 24px;font-size:15px;line-height:1.5;color:#a1a1a6;">Wait a moment and try again. This page will retry automatically in ${retryAfterSeconds} seconds.</p>
+<button type="button" onclick="location.reload()" style="appearance:none;border:0;cursor:pointer;background:#f5f4f0;color:#0b0b0b;font-size:15px;font-weight:600;font-family:inherit;padding:10px 24px;border-radius:9999px;">Try again</button>
+</main>
+</body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: 429,
+    headers: {
+      ...NO_STORE_HEADERS,
+      ...createRateLimitHeaders(rateLimit),
+      'Content-Type': 'text/html; charset=utf-8',
+      'Retry-After': String(retryAfterSeconds),
+    },
+  });
 }
 
 function getAuthPageForIntent(intent: AuthIntent): string {
@@ -92,6 +159,10 @@ export async function GET(request: Request) {
         result: 'blocked',
         reason: 'rate_limited',
       });
+    }
+
+    if (wantsHtmlResponse(request)) {
+      return createRateLimitedHtmlResponse(rateLimit);
     }
 
     return NextResponse.json(

--- a/apps/web/lib/rate-limit/rate-limiter.ts
+++ b/apps/web/lib/rate-limit/rate-limiter.ts
@@ -23,6 +23,34 @@ export type RateLimiterBackend = 'redis' | 'memory';
 const REDIS_RATE_LIMIT_TIMEOUT_MS = 750;
 
 /**
+ * Circuit breaker for a dead/degraded Redis backend.
+ *
+ * When a Redis call fails (error or timeout), the circuit opens for a short
+ * TTL and all limiters skip the Redis call (and its 750ms timeout budget)
+ * during that window, going straight to the memory fallback. This prevents
+ * every rate-limited route from paying +750ms latency per request while the
+ * Redis backend is down (e.g. an archived Upstash DB).
+ *
+ * Module-level by design: serverless instances share limiter modules, and the
+ * failure signal applies to the shared Redis backend, not a single limiter.
+ */
+const REDIS_CIRCUIT_OPEN_MS = 30_000;
+let redisCircuitOpenUntil = 0;
+
+function isRedisCircuitOpen(): boolean {
+  return Date.now() < redisCircuitOpenUntil;
+}
+
+function openRedisCircuit(): void {
+  redisCircuitOpenUntil = Date.now() + REDIS_CIRCUIT_OPEN_MS;
+}
+
+/** Test-only helper to reset the shared Redis circuit breaker. */
+export function resetRedisCircuitBreaker(): void {
+  redisCircuitOpenUntil = 0;
+}
+
+/**
  * Options for creating a rate limiter
  */
 export interface RateLimiterOptions {
@@ -88,8 +116,8 @@ export class RateLimiter {
    * Returns a consistent result regardless of backend
    */
   async limit(identifier: string): Promise<RateLimitResult> {
-    // Try Redis first if available
-    if (this.redisLimiter) {
+    // Try Redis first if available and the shared failure circuit is closed
+    if (this.redisLimiter && !isRedisCircuitOpen()) {
       try {
         const result = await withTimeout(this.redisLimiter.limit(identifier), {
           timeoutMs: REDIS_RATE_LIMIT_TIMEOUT_MS,
@@ -108,6 +136,9 @@ export class RateLimiter {
       } catch (error) {
         // Log error and fall back to memory — this means rate limits for this
         // request are enforced in-memory only and won't persist across deploys.
+        // Open the circuit so subsequent requests skip the Redis timeout
+        // entirely while the backend is known-degraded.
+        openRedisCircuit();
         const message = `[RateLimit:${this.config.name}] Redis error, falling back to in-memory: ${error}`;
         console.error(message);
         this.options.logger(message);
@@ -125,8 +156,15 @@ export class RateLimiter {
       };
     }
 
-    // Fall back to in-memory
-    return this.memoryLimiter.limit(identifier);
+    // Fall back to in-memory. When Redis was expected (preferRedis), flag the
+    // result as degraded so user-critical callers can treat it as advisory —
+    // a per-instance memory bucket over-blocks real users behind shared IPs
+    // (mobile CGNAT) during a Redis outage.
+    const memoryResult = await this.memoryLimiter.limit(identifier);
+    if (this.options.preferRedis) {
+      return { ...memoryResult, degraded: true };
+    }
+    return memoryResult;
   }
 
   /**

--- a/apps/web/lib/rate-limit/types.ts
+++ b/apps/web/lib/rate-limit/types.ts
@@ -22,6 +22,12 @@ export interface RateLimitResult {
   reason?: string;
   /** Whether the backing limiter is unavailable rather than exhausted */
   unavailable?: boolean;
+  /**
+   * Whether the result came from the per-instance memory fallback because the
+   * durable (Redis) backend was expected but unavailable. Callers on
+   * user-critical paths may treat a degraded limit as advisory.
+   */
+  degraded?: boolean;
 }
 
 /**

--- a/apps/web/tests/unit/lib/rate-limit/rate-limiter.test.ts
+++ b/apps/web/tests/unit/lib/rate-limit/rate-limiter.test.ts
@@ -59,6 +59,7 @@ import {
   createRateLimiter,
   isRateLimitingEnabled,
   RateLimiter,
+  resetRedisCircuitBreaker,
 } from '@/lib/rate-limit/rate-limiter';
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -73,6 +74,7 @@ const baseConfig = {
 describe('rate-limiter.ts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetRedisCircuitBreaker();
     MockMemoryClass.mock.calls = [];
     MockMemoryClass.mock.instances = [];
     // Default: Redis is available (factory returns the mock)
@@ -217,10 +219,10 @@ describe('rate-limiter.ts', () => {
       expect(logger).toHaveBeenCalledWith(
         expect.stringContaining('Redis error')
       );
-      expect(result).toEqual(memoryResult);
+      expect(result).toEqual({ ...memoryResult, degraded: true });
     });
 
-    it('uses memory limiter directly when Redis is not configured', async () => {
+    it('uses memory limiter directly (flagged degraded) when Redis is not configured', async () => {
       mockCreateRedisRateLimiter.mockReturnValue(null);
       const memoryResult = {
         success: true,
@@ -233,8 +235,24 @@ describe('rate-limiter.ts', () => {
       const limiter = new RateLimiter(baseConfig, { warnOnFallback: false });
       const result = await limiter.limit('user-1');
 
-      expect(result).toEqual(memoryResult);
+      expect(result).toEqual({ ...memoryResult, degraded: true });
       expect(mockRedisLimiter.limit).not.toHaveBeenCalled();
+    });
+
+    it('does not flag memory results as degraded when preferRedis is false', async () => {
+      const memoryResult = {
+        success: true,
+        limit: 10,
+        remaining: 7,
+        reset: new Date(),
+      };
+      mockMemoryInstance.limit.mockResolvedValue(memoryResult);
+
+      const limiter = new RateLimiter(baseConfig, { preferRedis: false });
+      const result = await limiter.limit('user-1');
+
+      expect(result).toEqual(memoryResult);
+      expect(result.degraded).toBeUndefined();
     });
 
     it('returns bounded failure when Redis is unavailable and requireRedis is true', async () => {
@@ -266,6 +284,84 @@ describe('rate-limiter.ts', () => {
       expect(result.remaining).toBe(0);
       expect(result.reason).toContain('temporarily unavailable');
       expect(mockMemoryInstance.limit).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── 3b. Circuit breaker ───────────────────────────────────────────
+  describe('circuit breaker', () => {
+    it('skips Redis for subsequent requests after a Redis failure', async () => {
+      mockRedisLimiter.limit.mockRejectedValue(new Error('Redis down'));
+      const memoryResult = {
+        success: true,
+        limit: 10,
+        remaining: 9,
+        reset: new Date(),
+      };
+      mockMemoryInstance.limit.mockResolvedValue(memoryResult);
+
+      const limiter = new RateLimiter(baseConfig, { warnOnFallback: false });
+
+      // First call hits Redis, fails, opens the circuit
+      await limiter.limit('user-1');
+      expect(mockRedisLimiter.limit).toHaveBeenCalledTimes(1);
+
+      // Second call skips Redis entirely while the circuit is open
+      const result = await limiter.limit('user-1');
+      expect(mockRedisLimiter.limit).toHaveBeenCalledTimes(1);
+      expect(result.degraded).toBe(true);
+    });
+
+    it('shares the open circuit across limiter instances', async () => {
+      mockRedisLimiter.limit.mockRejectedValue(new Error('Redis down'));
+      mockMemoryInstance.limit.mockResolvedValue({
+        success: true,
+        limit: 10,
+        remaining: 9,
+        reset: new Date(),
+      });
+
+      const first = new RateLimiter(baseConfig, { warnOnFallback: false });
+      await first.limit('user-1');
+      expect(mockRedisLimiter.limit).toHaveBeenCalledTimes(1);
+
+      const second = new RateLimiter(baseConfig, { warnOnFallback: false });
+      await second.limit('user-1');
+      expect(mockRedisLimiter.limit).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries Redis after the circuit TTL elapses', async () => {
+      vi.useFakeTimers();
+      try {
+        mockRedisLimiter.limit.mockRejectedValueOnce(new Error('Redis down'));
+        mockMemoryInstance.limit.mockResolvedValue({
+          success: true,
+          limit: 10,
+          remaining: 9,
+          reset: new Date(),
+        });
+
+        const limiter = new RateLimiter(baseConfig, { warnOnFallback: false });
+        await limiter.limit('user-1');
+        expect(mockRedisLimiter.limit).toHaveBeenCalledTimes(1);
+
+        // Circuit open: Redis skipped
+        await limiter.limit('user-1');
+        expect(mockRedisLimiter.limit).toHaveBeenCalledTimes(1);
+
+        // After the 30s TTL, Redis is retried
+        vi.advanceTimersByTime(30_001);
+        mockRedisLimiter.limit.mockResolvedValue({
+          success: true,
+          limit: 10,
+          remaining: 9,
+          reset: Date.now() + 60_000,
+        });
+        const result = await limiter.limit('user-1');
+        expect(mockRedisLimiter.limit).toHaveBeenCalledTimes(2);
+        expect(result.degraded).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## Problem
Prod sign-in is dead-ending for real users: `/auth/start` returns a raw-JSON `429 {"error":"Too many auth attempts"}` on mobile web while the Redis rate-limit backend is down — a per-instance memory bucket keyed by carrier-CGNAT IP blocks legitimate users, and every rate-limited route pays a +750ms Redis timeout per request during the outage.

## What changed
- **Fail-open on degraded backend (auth-start only)** — `apps/web/app/auth/start/route.ts`: when the limit result is `unavailable` or `degraded` in production, the auth-start limit is treated as advisory (log + allow) instead of enforcing the per-instance memory bucket. Bot defense is unaffected: Clerk still gates the actual auth attempt; this limiter is a pre-filter. Dev/test keeps the existing local-memory fallback. A healthy-backend 429 is still enforced.
- **`degraded` flag** — `apps/web/lib/rate-limit/types.ts` + `rate-limiter.ts`: memory-fallback results from a Redis-preferring limiter now carry `degraded: true` so user-critical callers can distinguish "backend down" from "limit genuinely exceeded". Covers both outage shapes (Redis client errors AND Redis unconfigured). Additive — all other callers only read `success`, no behavior change elsewhere.
- **Circuit breaker on dead Redis** — `rate-limiter.ts`: module-level circuit caches the last Redis failure for 30s; while open, all limiters skip the Redis call (and its 750ms timeout budget) and go straight to the memory fallback. Retries Redis after the TTL.
- **Human-readable 429** — `/auth/start` is browser-navigated; when the client accepts `text/html`, the 429 now renders a minimal inline-styled dark page ("Too many sign-in attempts. Wait a moment and try again."), auto-retries via `meta refresh` honoring the Retry-After window, and includes a Try-again CTA. JSON is preserved for API clients. Never raw JSON in a browser.

## Assumptions
- The issue's proposed fix reverses the previous "fail-closed in production on `unavailable`" behavior; the existing route test asserting fail-closed was updated to assert fail-open per the issue's decision-free spec (Tim-filed).
- `degraded` is set whenever a `preferRedis` limiter serves from memory (including Redis-unconfigured), since both shapes produce the same CGNAT over-blocking. Non-auth routes are unaffected (they only read `success`).
- The retry CTA uses an inline `onclick` reload; if CSP strips it, the meta-refresh auto-retry still recovers the user. Static markup only — no user input interpolated.
- Circuit breaker is module-level per the issue spec; a Redis blip pauses durable limiting for ≤30s per instance (fallback memory limits still apply).
- Real Redis is being redeployed in parallel (#13168); the circuit breaker is complementary, primary fixes are 1 and 3.

## Verification
Sandbox cannot reach registry.npmjs.org (403; network-access request unanswered — same constraint as #13268/#13269/#13311), so `pnpm install` / `turbo lint typecheck test:fast` / `build:web` run in the CI merge gate instead:
```
$ curl -s -o /dev/null -w "%{http_code}" https://registry.npmjs.org/pnpm
403
```
Ran instead (verbatim):
```
$ /tmp/biome check apps/web/app/auth/start/route.ts apps/web/app/auth/start/route.test.ts \
    apps/web/lib/rate-limit/rate-limiter.ts apps/web/lib/rate-limit/types.ts \
    apps/web/tests/unit/lib/rate-limit/rate-limiter.test.ts
Checked 5 files in 20ms. No fixes applied.   # biome 2.5.1 standalone
```
Tests added/updated for CI:
- `route.test.ts`: prod fail-open on `unavailable` and on `degraded`; healthy-backend 429 still enforced; HTML 429 for browser Accept headers (content, retry-after, meta refresh, no raw JSON); JSON 429 preserved for API clients; existing dev-fallback tests unchanged.
- `rate-limiter.test.ts`: `degraded` flag on Redis-error and Redis-unconfigured fallbacks; no flag when `preferRedis: false`; circuit breaker skips Redis after failure, is shared across instances, and retries after the 30s TTL (fake timers).

## Cost Impact
- No new external API calls, crons, or deps. During a Redis outage this *reduces* latency (-750ms/request on rate-limited routes) and Upstash call volume while the circuit is open.

## Links
- Fixes #13299
- Related: #13168 (Redis re-provision, trigger), #11962 (keepalive), #12622 (auth surface audit)
- Dispatch: Fable Developer / GH-13299 (thread cmr8fr8562bb907ad8sem661e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
