### PR TITLE
fix(chat): capture + flush real chat stream errors; add authed prod chat canary (GH #13300)

### DIFF
--- a/.github/scripts/parse-synthetic-test-results.js
+++ b/.github/scripts/parse-synthetic-test-results.js
@@ -1,6 +1,6 @@
 const fs = require('node:fs');
 
-const DEFAULT_RESULT_FILES = legacyCanaryEnabled => [
+const DEFAULT_RESULT_FILES = (legacyCanaryEnabled, chatCanaryEnabled = false) => [
   {
     name: 'synthetic-auth-ui',
     path: 'apps/web/test-results/synthetic-auth-ui-results.json',
@@ -25,6 +25,11 @@ const DEFAULT_RESULT_FILES = legacyCanaryEnabled => [
     name: 'synthetic-legacy-otp',
     path: 'apps/web/test-results/synthetic-legacy-otp-results.json',
     required: legacyCanaryEnabled,
+  },
+  {
+    name: 'synthetic-chat-turn',
+    path: 'apps/web/test-results/synthetic-chat-turn-results.json',
+    required: chatCanaryEnabled,
   },
 ];
 

--- a/.github/scripts/parse-synthetic-test-results.js
+++ b/.github/scripts/parse-synthetic-test-results.js
@@ -1,6 +1,9 @@
 const fs = require('node:fs');
 
-const DEFAULT_RESULT_FILES = (legacyCanaryEnabled, chatCanaryEnabled = false) => [
+const DEFAULT_RESULT_FILES = (
+  legacyCanaryEnabled,
+  chatCanaryEnabled = false
+) => [
   {
     name: 'synthetic-auth-ui',
     path: 'apps/web/test-results/synthetic-auth-ui-results.json',

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -115,6 +115,7 @@ import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { sqlAny } from '@/lib/db/sql-helpers';
 import { upsertRelease } from '@/lib/discography/queries';
 import { generateUniqueSlug } from '@/lib/discography/slug';
+import { captureError } from '@/lib/error-tracking';
 import { scheduleOnlineScoring } from '@/lib/eval/scorers/online';
 import { checkGatesForUser, getAppFlagValue } from '@/lib/flags/server';
 import { createAuthenticatedCorsHeaders } from '@/lib/http/headers';
@@ -180,6 +181,14 @@ import { detectPlatform } from '@/lib/utils/platform-detection/detector';
 export const dynamic = 'force-dynamic';
 
 export const maxDuration = 60;
+
+/**
+ * How long to wait for Sentry to deliver buffered events before letting the
+ * lambda suspend. Streaming responses freeze the function as soon as the last
+ * chunk (or the error response) is sent, which silently drops undelivered
+ * events — the reason GH #13300's day-long outage never reached Sentry.
+ */
+const SENTRY_FLUSH_TIMEOUT_MS = 2000;
 
 /**
  * Statsig gate keys for the chat kill switch. Declared as const so typos fail
@@ -2201,8 +2210,16 @@ async function fetchOptionalReleases(
 
 /**
  * Build a standardized error response for chat streaming failures.
+ *
+ * Uses `captureError` (canonical wrapper) instead of raw
+ * `Sentry.captureException`: it logs the real exception to stdout so the
+ * failure is findable in Vercel logs by the on-screen reference id
+ * (`requestId`) even when the Sentry event is dropped, and it guards on SDK
+ * initialization. `Sentry.flush` afterwards guarantees the event leaves the
+ * lambda before the 500 response suspends it (GH #13300: a full day of
+ * CHAT_STREAM_FAILED produced zero Sentry events).
  */
-function buildChatErrorResponse(
+async function buildChatErrorResponse(
   error: unknown,
   userId: string,
   messageCount: number,
@@ -2211,10 +2228,16 @@ function buildChatErrorResponse(
   conversationId: string | null,
   corsHeaders: Record<string, string>
 ) {
-  Sentry.captureException(error, {
-    tags: { feature: 'ai-chat' },
-    extra: { userId, messageCount, requestId, profileId, conversationId },
+  await captureError('Chat stream failed', error, {
+    feature: 'ai-chat',
+    mode: 'route-catch',
+    userId,
+    messageCount,
+    requestId,
+    profileId,
+    conversationId,
   });
+  await Sentry.flush(SENTRY_FLUSH_TIMEOUT_MS).catch(() => null);
 
   const message =
     error instanceof Error ? error.message : 'An unexpected error occurred';
@@ -2776,8 +2799,23 @@ export async function POST(req: Request) {
             data: breadcrumb.data,
           })
         ),
-      captureException: (error, context) =>
-        Sentry.captureException(error, context),
+      // Mid-stream failures (`streamText.onError` in `executeChatTurn`) are
+      // the path that stamps CHAT_STREAM_FAILED on the turn while the HTTP
+      // response is already 200 — the lambda suspends right after the stream
+      // closes, so capture through `captureError` (stdout log keyed by the
+      // on-screen requestId + SDK-guarded Sentry send) and flush before
+      // yielding (GH #13300).
+      captureException: async (error, context) => {
+        await captureError('Chat stream failed', error, {
+          feature: 'ai-chat',
+          mode: 'stream',
+          requestId,
+          userId,
+          ...(context?.tags ?? {}),
+          ...(context?.extra ?? {}),
+        });
+        await Sentry.flush(SENTRY_FLUSH_TIMEOUT_MS).catch(() => null);
+      },
     };
     let streamFailurePersisted = false;
     const persistStreamFailure = async (error: unknown) => {

--- a/apps/web/lib/chat/types.ts
+++ b/apps/web/lib/chat/types.ts
@@ -63,5 +63,5 @@ export interface ChatTelemetry {
   captureException?(
     error: unknown,
     context: { tags?: Record<string, string>; extra?: Record<string, unknown> }
-  ): void;
+  ): void | Promise<void>;
 }

--- a/apps/web/tests/e2e/synthetic-chat-turn.spec.ts
+++ b/apps/web/tests/e2e/synthetic-chat-turn.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * Production authenticated chat-turn canary (GH #13300).
+ *
+ * The detector this incident needed: web chat was down for a full day —
+ * every message failed with `CHAT_STREAM_FAILED` — while nothing reached
+ * Sentry and no synthetic exercised the authenticated `/api/chat` path
+ * (existing prod synthetics are all unauthenticated; the onboarding-turn
+ * canary now serves a scripted fallback on LLM failure, which masks exactly
+ * this class of outage).
+ *
+ * What it does: mints a short-lived session JWT for a DEDICATED canary user
+ * via the Clerk Backend API, POSTs one real message to `/api/chat`, and
+ * asserts the SSE stream terminates with a finish part and no error part /
+ * CHAT_STREAM_FAILED marker. API-level (no browser page) so it is cheap and
+ * Turnstile-free — Turnstile gates onboarding, not the authenticated route.
+ *
+ * Required env (all in Doppler prd; step is gated in synthetic-monitoring.yml
+ * until they are provisioned):
+ *  - CLERK_SECRET_KEY                      — prod Clerk backend key (existing)
+ *  - E2E_PROD_CHAT_CANARY_USER_ID          — Clerk user id of the canary user
+ *  - E2E_PROD_CHAT_CANARY_PROFILE_ID       — that user's creator profile id
+ *
+ * Cost: one LLM turn per run (every 15 min during business hours). The
+ * message asks for a one-word reply to keep tokens minimal.
+ *
+ * QUARANTINE POLICY: if this spec flakes, do NOT silent-skip it — that
+ * recreates the "no test caught it" failure. File an issue and quarantine
+ * explicitly.
+ *
+ * @canary @chat
+ */
+
+import { randomUUID } from 'node:crypto';
+import { expect, test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_TEST_BASE_URL ??
+  process.env.BASE_URL ??
+  'https://jov.ie';
+
+const CLERK_API_URL = 'https://api.clerk.com/v1';
+
+/** Single bounded budget for the real LLM turn to resolve. */
+const TURN_RESOLVE_TIMEOUT = 60_000;
+
+interface ClerkSession {
+  readonly id: string;
+}
+
+function requiredEnv(): {
+  ok: boolean;
+  missing: string[];
+  clerkSecretKey: string;
+  userId: string;
+  profileId: string;
+} {
+  const clerkSecretKey = process.env.CLERK_SECRET_KEY ?? '';
+  const userId = process.env.E2E_PROD_CHAT_CANARY_USER_ID ?? '';
+  const profileId = process.env.E2E_PROD_CHAT_CANARY_PROFILE_ID ?? '';
+  const missing = [
+    ...(clerkSecretKey ? [] : ['CLERK_SECRET_KEY']),
+    ...(userId ? [] : ['E2E_PROD_CHAT_CANARY_USER_ID']),
+    ...(profileId ? [] : ['E2E_PROD_CHAT_CANARY_PROFILE_ID']),
+  ];
+  return { ok: missing.length === 0, missing, clerkSecretKey, userId, profileId };
+}
+
+async function clerkFetch(
+  secretKey: string,
+  path: string,
+  init?: RequestInit
+): Promise<Response> {
+  return fetch(`${CLERK_API_URL}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${secretKey}`,
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+  });
+}
+
+test.describe('Authenticated prod chat turn', () => {
+  test('one real /api/chat message streams to a finish part without CHAT_STREAM_FAILED', async () => {
+    test.setTimeout(120_000);
+
+    const env = requiredEnv();
+    if (!env.ok) {
+      // The workflow step is variable-gated; missing env here means the gate
+      // was enabled before Doppler was provisioned. Fail loudly — a silently
+      // skipped canary is the failure mode this spec exists to prevent.
+      throw new Error(
+        `Chat canary enabled but missing env: ${env.missing.join(', ')}. ` +
+          'Provision the canary user secrets in Doppler prd or disable the ' +
+          'E2E_PROD_CHAT_CANARY repo variable.'
+      );
+    }
+
+    // 1. Mint a session + short-lived session JWT for the canary user.
+    const sessionRes = await clerkFetch(env.clerkSecretKey, '/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ user_id: env.userId }),
+    });
+    expect(
+      sessionRes.ok,
+      `Clerk session create failed: ${sessionRes.status} ${await sessionRes
+        .clone()
+        .text()
+        .catch(() => '')}`
+    ).toBe(true);
+    const session = (await sessionRes.json()) as ClerkSession;
+
+    try {
+      const tokenRes = await clerkFetch(
+        env.clerkSecretKey,
+        `/sessions/${session.id}/tokens`,
+        { method: 'POST', body: JSON.stringify({}) }
+      );
+      expect(
+        tokenRes.ok,
+        `Clerk session token mint failed: ${tokenRes.status}`
+      ).toBe(true);
+      const { jwt } = (await tokenRes.json()) as { jwt: string };
+      expect(typeof jwt, 'Clerk returned no session JWT').toBe('string');
+
+      // 2. Send one minimal real chat turn.
+      const clientTurnId = randomUUID();
+      const controller = new AbortController();
+      const timeout = setTimeout(
+        () => controller.abort(),
+        TURN_RESOLVE_TIMEOUT
+      );
+
+      let chatRes: Response;
+      try {
+        chatRes = await fetch(`${BASE_URL}/api/chat`, {
+          method: 'POST',
+          signal: controller.signal,
+          headers: {
+            Authorization: `Bearer ${jwt}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            profileId: env.profileId,
+            clientTurnId,
+            clientMessageId: clientTurnId,
+            source: 'typed',
+            messages: [
+              {
+                id: clientTurnId,
+                role: 'user',
+                parts: [
+                  {
+                    type: 'text',
+                    text: 'Canary health check: reply with the single word pong. Do not use any tools.',
+                  },
+                ],
+              },
+            ],
+          }),
+        });
+
+        // Kill switch (`ai_chat_disabled`) intentionally 503s all chat
+        // traffic — that is an operator decision, not an outage regression.
+        if (chatRes.status === 503) {
+          const body = await chatRes.text();
+          if (body.includes('ai_chat_disabled') || body.includes('disabled')) {
+            console.log(
+              '[Synthetic][warning] chat canary: /api/chat returned 503 kill-switch; treating as intentional.'
+            );
+            return;
+          }
+          throw new Error(`Chat canary got 503 (not kill-switch): ${body}`);
+        }
+
+        expect(
+          chatRes.ok,
+          `Chat canary POST /api/chat failed: ${chatRes.status} ${await chatRes
+            .clone()
+            .text()
+            .catch(() => '')}`
+        ).toBe(true);
+
+        // 3. Drain the SSE stream and assert a clean finish.
+        const streamText = await chatRes.text();
+
+        expect(
+          streamText,
+          `Chat stream carried CHAT_STREAM_FAILED (requestId ${chatRes.headers.get('x-request-id')})`
+        ).not.toContain('CHAT_STREAM_FAILED');
+        expect(
+          streamText,
+          'Chat stream carried an error part'
+        ).not.toContain('"type":"error"');
+        expect(
+          streamText,
+          'Chat stream never reached a finish part'
+        ).toContain('"type":"finish"');
+      } finally {
+        clearTimeout(timeout);
+      }
+    } finally {
+      // 4. Revoke the canary session (best-effort hygiene).
+      await clerkFetch(
+        env.clerkSecretKey,
+        `/sessions/${session.id}/revoke`,
+        { method: 'POST' }
+      ).catch(() => null);
+    }
+  });
+});

--- a/apps/web/tests/e2e/synthetic-chat-turn.spec.ts
+++ b/apps/web/tests/e2e/synthetic-chat-turn.spec.ts
@@ -64,7 +64,13 @@ function requiredEnv(): {
     ...(userId ? [] : ['E2E_PROD_CHAT_CANARY_USER_ID']),
     ...(profileId ? [] : ['E2E_PROD_CHAT_CANARY_PROFILE_ID']),
   ];
-  return { ok: missing.length === 0, missing, clerkSecretKey, userId, profileId };
+  return {
+    ok: missing.length === 0,
+    missing,
+    clerkSecretKey,
+    userId,
+    profileId,
+  };
 }
 
 async function clerkFetch(
@@ -190,24 +196,20 @@ test.describe('Authenticated prod chat turn', () => {
           streamText,
           `Chat stream carried CHAT_STREAM_FAILED (requestId ${chatRes.headers.get('x-request-id')})`
         ).not.toContain('CHAT_STREAM_FAILED');
-        expect(
-          streamText,
-          'Chat stream carried an error part'
-        ).not.toContain('"type":"error"');
-        expect(
-          streamText,
-          'Chat stream never reached a finish part'
-        ).toContain('"type":"finish"');
+        expect(streamText, 'Chat stream carried an error part').not.toContain(
+          '"type":"error"'
+        );
+        expect(streamText, 'Chat stream never reached a finish part').toContain(
+          '"type":"finish"'
+        );
       } finally {
         clearTimeout(timeout);
       }
     } finally {
       // 4. Revoke the canary session (best-effort hygiene).
-      await clerkFetch(
-        env.clerkSecretKey,
-        `/sessions/${session.id}/revoke`,
-        { method: 'POST' }
-      ).catch(() => null);
+      await clerkFetch(env.clerkSecretKey, `/sessions/${session.id}/revoke`, {
+        method: 'POST',
+      }).catch(() => null);
     }
   });
 });

--- a/apps/web/tests/unit/chat/chat-route-error-capture.test.ts
+++ b/apps/web/tests/unit/chat/chat-route-error-capture.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression contract for GH #13300: web chat failed all day with
+ * CHAT_STREAM_FAILED while the underlying exception never reached Sentry or
+ * the Vercel logs.
+ *
+ * The chat route's two terminal error paths (the route-level catch and the
+ * mid-stream telemetry hook) must capture through `captureError` — which
+ * logs the real exception to stdout keyed by the on-screen reference id
+ * (`requestId`) and guards on Sentry SDK initialization — and must flush
+ * Sentry before the lambda suspends, because streaming responses freeze the
+ * function the moment the response ends and drop unsent events.
+ *
+ * A source-level contract (rather than invoking the 3k-line route module)
+ * keeps this deterministic and dependency-free while preventing the exact
+ * regression: someone deleting the capture/flush from either catch path.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const routeSource = readFileSync(
+  join(__dirname, '../../../app/api/chat/route.ts'),
+  'utf8'
+);
+
+describe('chat route error capture contract (GH #13300)', () => {
+  it('imports the canonical captureError wrapper', () => {
+    expect(routeSource).toContain(
+      "import { captureError } from '@/lib/error-tracking';"
+    );
+  });
+
+  it('captures the real exception on both terminal error paths', () => {
+    const captures = routeSource.match(
+      /captureError\('Chat stream failed', error/g
+    );
+    // 1: route-level catch (buildChatErrorResponse)
+    // 2: mid-stream telemetry captureException hook
+    expect(captures?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it('keys the capture context by the on-screen reference id (requestId)', () => {
+    const routeCatch = routeSource.slice(
+      routeSource.indexOf("captureError('Chat stream failed'")
+    );
+    expect(routeCatch).toContain('requestId');
+  });
+
+  it('flushes Sentry before the lambda can suspend on both paths', () => {
+    const flushes = routeSource.match(
+      /Sentry\.flush\(SENTRY_FLUSH_TIMEOUT_MS\)/g
+    );
+    expect(flushes?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Problem
Web chat was down for a full day (GH #13300): every message failed with `CHAT_STREAM_FAILED` while the underlying exception never reached Sentry or the Vercel logs, and no synthetic exercised the authenticated web `/api/chat` path (prod synthetics are all unauthenticated; the onboarding-turn canary now serves a scripted fallback that masks exactly this outage class).

## What changed
**1. Instrumentation — both terminal chat error paths now capture through the canonical `captureError` wrapper and flush Sentry before the lambda suspends** (`apps/web/app/api/chat/route.ts`):
- `buildChatErrorResponse` (route-level catch): raw `Sentry.captureException` → `await captureError('Chat stream failed', error, { feature, mode: 'route-catch', userId, messageCount, requestId, profileId, conversationId })` + `Sentry.flush(2000)`. `captureError` also logs the real exception to stdout, so the failure is findable in Vercel logs by the on-screen reference id even if the Sentry event drops.
- The mid-stream telemetry `captureException` hook (the path that stamps `CHAT_STREAM_FAILED` on a turn while the HTTP response is already 200): same `captureError` + flush treatment. This is the likely swallow point — streamed responses freeze the lambda the moment the stream closes, dropping unsent Sentry events, and nothing ever hit stdout.
- `ChatTelemetry.captureException` widened to `void | Promise<void>` (`lib/chat/types.ts`) so the hook can be awaited (run.ts already awaits it).

**2. Prod authenticated chat-turn canary** (`apps/web/tests/e2e/synthetic-chat-turn.spec.ts`):
- API-level Playwright spec: mints a short-lived session JWT for a dedicated canary user via the Clerk Backend API (`POST /v1/sessions` → `/v1/sessions/{id}/tokens`), POSTs one minimal real message to `/api/chat`, asserts the SSE stream reaches a finish part with no error part / `CHAT_STREAM_FAILED`, then revokes the session. Turnstile-free (it gates onboarding, not the authed route). Kill-switch 503 is treated as intentional (warning, not failure).
- `.github/scripts/parse-synthetic-test-results.js` registers the result file (required only when the canary is enabled).

**3. Regression contract test** (`apps/web/tests/unit/chat/chat-route-error-capture.test.ts`): source-level assertions that both catch paths keep `captureError` + `Sentry.flush` — prevents regression-by-deletion without loading the 3k-line route module.

## NOT in this PR (blocked / human steps — also posted on #13300)
- **`.github/workflows/synthetic-monitoring.yml` wiring**: my token cannot write workflow files (403 `Resource not accessible by integration`). Exact step to add is posted on the issue; the parser change here is inert until it lands.
- **Canary provisioning (Tim)**: create a dedicated prod canary user + profile, add `E2E_PROD_CHAT_CANARY_USER_ID` / `E2E_PROD_CHAT_CANARY_PROFILE_ID` to Doppler prd, set repo variable `E2E_PROD_CHAT_CANARY=1`.
- **Root cause of the outage itself**: needs the Vercel log lookup for reference `cba9cf14-fd6d-4d80-ad25-b986144b69bb` (no Vercel access from this sandbox). Once this PR deploys, the next failure lands in Sentry + Vercel logs keyed by the reference id. Prime suspects, in order: (1) Redis-dependent step during the Upstash archive window (#13168); (2) `chat_turns.model` attribution write from #13152 (merged Jul 4 20:44, ~2.5h before first failing screenshot — migration-drift class); (3) JOVIE-WEB-P8 `TypeError: s.map is not a function`.

## Assumptions
- The mid-stream telemetry hook reuses the message `Chat stream failed` for all its captures, including the prompt-leak marker capture in `run.ts` — grouping is by error instance, so Sentry issues stay distinct; the console line label is slightly generic for the leak case. Conservative reading; happy to split messages if preferred.
- `Sentry.flush(2000)` bounds added latency on the error path only (never the happy path).

## Cost Impact
- No new external calls on the happy path. On error paths: one Sentry flush (≤2s). Canary (once enabled): 1 minimal LLM turn per 15-min business-hours tick (~60/day) against the dedicated canary profile — that's the price of detecting a P0 chat outage within 15 min (acceptance criterion on #13300).

## Verification
**Deferred to CI.** Sandbox cannot reach registry.npmjs.org (403; network-access request went unanswered), so `pnpm install` / `turbo lint typecheck test:fast` / `build:web` could not run locally:
```
$ curl -s -o /dev/null -w "%{http_code}" https://registry.npmjs.org/pnpm
403
```
Ran what is dependency-free:
```
$ node -e "require('./.github/scripts/parse-synthetic-test-results.js').DEFAULT_RESULT_FILES(true,true)"  # all six result files, chat required only when enabled
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/synthetic-monitoring.yml'))"            # workflow yaml OK (local copy)
```
Edited files diffed against main@9acea508 — only the intended changes (84 changed lines + 2 new files, well under the 800-line cap).

## Dispatch
- Dispatch ID: hyperagent thread `cmr8frd6r29yn06ad1zmraece`
- Closes-when-root-caused: #13300 (this PR ships instrumentation + canary; root-cause fix follows once the error is visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
