### PR TITLE
ci: auto-ready idempotency — verify draft flip, single upsert comment, 6h attempt cooldown

### DIFF
--- a/scripts/auto-ready-agent-drafts.sh
+++ b/scripts/auto-ready-agent-drafts.sh
@@ -8,7 +8,8 @@
 # Opt out per-PR with any of: needs-human, hold, gated, fast.
 #
 # Env:
-#   DRY_RUN=1   classify and print only; flip no PRs
+#   DRY_RUN=1                 classify and print only; flip no PRs
+#   ATTEMPT_COOLDOWN_HOURS    min hours between flip attempts per PR (default 6)
 set -euo pipefail
 
 # shellcheck source=./scripts/lib/gh-retry.sh
@@ -17,17 +18,50 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/gh-retry.sh"
 REPO="${REPO:-JovieInc/Jovie}"
 DRY_RUN="${DRY_RUN:-0}"
 AGENT_RE='^(tim/|codex/|agent/|claude/|linear/|dependabot/)'
+# Idempotency guard (#13342): one marker comment per PR, edited in place, and a
+# hard cap of one flip attempt per PR per ATTEMPT_COOLDOWN_HOURS. Without this,
+# a PR the token cannot actually flip (see #13122) gets an identical
+# "Enrolling in merge queue" comment every cron cycle — 221 in 12h observed.
+READY_MARKER="auto-ready"
+ATTEMPT_COOLDOWN_HOURS="${ATTEMPT_COOLDOWN_HOURS:-6}"
+now_epoch="$(date -u +%s)"
 
-mark_ready() {  # mark_ready <num>
+mark_ready() {  # mark_ready <num> — returns non-zero when the flip call failed
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would mark #$1 ready"; return 0; }
-  gh_retry pr ready "$1" -R "$REPO" >/dev/null 2>&1 \
-    && echo "    ✓ marked #$1 ready" || echo "    !! failed to mark #$1 ready"
+  if gh_retry pr ready "$1" -R "$REPO" >/dev/null 2>&1; then
+    echo "    ✓ marked #$1 ready"
+    return 0
+  fi
+  echo "    !! failed to mark #$1 ready"
+  return 1
 }
 
-comment() {  # comment <num> <body>
-  [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would comment on #$1"; return 0; }
-  gh_retry pr comment "$1" -R "$REPO" --body "$2" >/dev/null 2>&1 \
-    && echo "    ✓ commented on #$1" || echo "    !! failed to comment on #$1"
+# Upsert the single auto-ready status comment (edited in place on repeat runs).
+upsert_status_comment() {  # upsert_status_comment <num> <body>
+  [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would upsert status comment on #$1"; return 0; }
+  GITHUB_REPOSITORY="$REPO" bash "$(dirname "${BASH_SOURCE[0]}")/lib/upsert-pr-comment.sh" "$1" "$READY_MARKER" "$2" \
+    && echo "    ✓ upserted status comment on #$1" || echo "    !! failed to upsert status comment on #$1"
+}
+
+# Hours since the last auto-ready attempt marker comment on this PR. Empty
+# output means "never attempted" (treated as cooldown-elapsed).
+last_attempt_age_hours() {  # last_attempt_age_hours <num>
+  local n="$1"
+  local updated_at
+  updated_at="$(gh_retry api "repos/${REPO}/issues/${n}/comments" --paginate \
+    --jq "[.[] | select(.body | contains(\"<!-- bot-comment:${READY_MARKER} -->\")) | .updated_at] | last" \
+    2>/dev/null | grep -E '^[0-9]{4}-' | tail -n1 || true)"
+  [[ -z "$updated_at" || "$updated_at" == "null" ]] && { echo ""; return 0; }
+  local updated_epoch
+  updated_epoch="$(date -u -d "$updated_at" +%s 2>/dev/null \
+    || python3 -c "import datetime,sys; print(int(datetime.datetime.strptime(sys.argv[1], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc).timestamp()))" "$updated_at")"
+  echo $(( (now_epoch - updated_epoch) / 3600 ))
+}
+
+# Re-query the PR and confirm the draft flip actually landed before claiming
+# success — `gh pr ready` can fail silently on token-permission gaps (#13122).
+is_still_draft() {  # is_still_draft <num> — echoes true/false/unknown
+  gh_retry pr view "$1" -R "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo "unknown"
 }
 
 check_failures_for_pr() {  # check_failures_for_pr <num>
@@ -128,8 +162,29 @@ echo "$SNAP" | jq -c '.[]
   | while read -r pr; do
     n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
     echo "  #$n  $t"
-    mark_ready "$n"
-    comment "$n" "🤖 Auto-ready: all required checks passing. Enrolling in merge queue."
+
+    # Idempotency guard (#13342): at most one attempt per PR per cooldown window.
+    attempt_age_h="$(last_attempt_age_hours "$n")"
+    if [[ -n "$attempt_age_h" && "$attempt_age_h" -lt "$ATTEMPT_COOLDOWN_HOURS" ]]; then
+      echo "    ~ last attempt ${attempt_age_h}h ago (< ${ATTEMPT_COOLDOWN_HOURS}h cooldown); skipping"
+      continue
+    fi
+
+    if ! mark_ready "$n"; then
+      upsert_status_comment "$n" "⚠️ Auto-ready: all required checks are passing, but marking this PR ready for review **failed** (likely a token-permission gap — see #13122). A human needs to flip it to ready. Will retry in ${ATTEMPT_COOLDOWN_HOURS}h. _(last attempt: $(date -u +%Y-%m-%dT%H:%M:%SZ))_"
+      continue
+    fi
+
+    [[ "$DRY_RUN" == "1" ]] && continue
+
+    # Verify the flip actually landed before claiming enrollment — enrolling a
+    # PR that is still a draft is a no-op and just spams the timeline.
+    still_draft="$(is_still_draft "$n")"
+    if [[ "$still_draft" == "false" ]]; then
+      upsert_status_comment "$n" "🤖 Auto-ready: all required checks passing — marked ready for review and enrolling in merge queue. _(verified ready at $(date -u +%Y-%m-%dT%H:%M:%SZ))_"
+    else
+      upsert_status_comment "$n" "⚠️ Auto-ready: \`gh pr ready\` reported success but the PR still shows draft=${still_draft} — the flip did not land (see #13122). A human needs to mark it ready. Will retry in ${ATTEMPT_COOLDOWN_HOURS}h. _(last attempt: $(date -u +%Y-%m-%dT%H:%M:%SZ))_"
+    fi
   done
 
 echo "=== done (DRY_RUN=$DRY_RUN) ==="


### PR DESCRIPTION
## Problem
Auto-Ready Agent Drafts posted 221 identical "Enrolling in merge queue" comments in 12h across 6 draft PRs it could never actually flip (#13342).

## What changed
`scripts/auto-ready-agent-drafts.sh`:
- `mark_ready` now returns failure instead of swallowing it; on failure the script posts ONE `<!-- bot-comment:auto-ready -->` marker comment (via the existing `upsert-pr-comment.sh` helper) explaining the token-permission gap (#13122) instead of the success message.
- After a successful `gh pr ready`, the script re-queries `isDraft` and only claims enrollment when the flip actually landed; otherwise it posts a single actionable failure comment.
- Hard cap: one attempt per PR per `ATTEMPT_COOLDOWN_HOURS` (default 6h), keyed off the marker comment's `updated_at` — same pattern as the watchdog's kick cooldown.

## Assumptions
- The marker-comment cooldown is the idempotency source of truth (no new state store needed).
- Dropping the per-`synchronize` trigger for this workflow is handled separately in the #13349 PR (workflow files need `workflows` app permission — see that PR).

## Verification
Sandbox has no npm registry access (dispatch-approved constraint), so verification was targeted per file type.
```
$ bash -n scripts/auto-ready-agent-drafts.sh   # OK
# fake-gh harness smoke:
=== no marker ===   -> "#42 ... [dry-run] would mark #42 ready"
=== recent marker => "~ last attempt 0h ago (< 6h cooldown); skipping"
```

## Acceptance mapping
- stuck draft PR gets ≤1 auto-ready comment ✅ (upsert = one comment, edited in place)
- single actionable failure comment on flip failure ✅
- no repeat comments across 3 consecutive cron cycles ✅ (6h cooldown > 3×15min cycles)

Dispatch: thread cmr8gcqgx26if07adig4stylt · Fixes #13342
