### PR TITLE
ci: merge-queue watchdog — reject unset/epoch-0 timestamps, 7d stall sanity cap, daily kick cap

### DIFF
--- a/scripts/merge-queue-watchdog.sh
+++ b/scripts/merge-queue-watchdog.sh
@@ -47,9 +47,19 @@ REPO="${REPO:-JovieInc/Jovie}"
 DRY_RUN="${DRY_RUN:-0}"
 STALL_MINUTES="${STALL_MINUTES:-45}"
 COOLDOWN_HOURS="${COOLDOWN_HOURS:-2}"
+# Sanity cap (#13343): a stall longer than this is a data error (unset/epoch-0
+# enqueue timestamp computing a ~56-year stall), never a real queue stall.
+# Skip such PRs instead of kicking them.
+MAX_STALL_MINUTES="${MAX_STALL_MINUTES:-10080}"  # 7 days
+# Hard cap on label-cycle kicks per PR per UTC day, on top of COOLDOWN_HOURS.
+MAX_KICKS_PER_DAY="${MAX_KICKS_PER_DAY:-4}"
 KICK_MARKER="merge-queue-watchdog-kick"
+# Timestamps before this are unset/zeroed data (epoch 0, Go zero time, etc.),
+# not real label events. 2020-01-01T00:00:00Z.
+MIN_VALID_EPOCH=1577836800
 
 now_epoch="$(date -u +%s)"
+today_utc="$(date -u +%Y-%m-%d)"
 
 label() {  # label <num> <label>
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would +$2 on #$1"; return 0; }
@@ -64,19 +74,32 @@ unlabel() {  # unlabel <num> <label>
 }
 
 # Minutes since the most recent `merge-queue` label event on this PR, read
-# from the issue timeline. Empty output means "could not determine" (treated
-# as not-yet-stale so we never act on incomplete data).
+# from the issue timeline, echoed as "<minutes> <timestamp>". Empty output
+# means "could not determine a valid timestamp" (treated as not-yet-stale so
+# we never act on incomplete data).
+#
+# Null-safety (#13343): with --paginate the per-page jq filter can emit `null`
+# lines (pages with no matching event) alongside a real timestamp, and the API
+# can surface unset/zeroed timestamps. Naively parsing those computed stalls
+# from epoch 0 (~29.7M minutes) and mass-kicked freshly-enrolled PRs. We now
+# (a) keep only ISO-8601-shaped lines, (b) reject epochs before
+# MIN_VALID_EPOCH, and (c) validate the parsed epoch is numeric.
 label_age_minutes() {  # label_age_minutes <num>
   local n="$1"
   local labeled_at
   labeled_at="$(gh_retry api "repos/${REPO}/issues/${n}/timeline" --paginate \
     --jq '[.[] | select(.event=="labeled" and .label.name=="merge-queue") | .created_at] | last' \
-    2>/dev/null || true)"
+    2>/dev/null | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' | tail -n1 || true)"
   [[ -z "$labeled_at" || "$labeled_at" == "null" ]] && { echo ""; return 0; }
   local labeled_epoch
   labeled_epoch="$(date -u -d "$labeled_at" +%s 2>/dev/null \
-    || python3 -c "import datetime,sys; print(int(datetime.datetime.strptime(sys.argv[1], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc).timestamp()))" "$labeled_at")"
-  echo $(( (now_epoch - labeled_epoch) / 60 ))
+    || python3 -c "import datetime,sys; print(int(datetime.datetime.strptime(sys.argv[1], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc).timestamp()))" "$labeled_at" 2>/dev/null \
+    || true)"
+  if ! [[ "$labeled_epoch" =~ ^[0-9]+$ ]] || [[ "$labeled_epoch" -lt "$MIN_VALID_EPOCH" ]]; then
+    echo ""
+    return 0
+  fi
+  echo "$(( (now_epoch - labeled_epoch) / 60 )) ${labeled_at}"
 }
 
 # Hours since the last watchdog-kick marker comment on this PR. Empty output
@@ -99,6 +122,18 @@ record_kick() {  # record_kick <num> <body>
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would record kick comment on #$n"; return 0; }
   bash "$(dirname "${BASH_SOURCE[0]}")/lib/upsert-pr-comment.sh" "$n" "$KICK_MARKER" "$body" \
     || echo "    !! failed to record kick comment on #$n"
+}
+
+# Kicks recorded today (UTC) for this PR, parsed from the marker comment body
+# ("kicks <YYYY-MM-DD>: <n>"). 0 when never kicked or last kick was another day.
+kick_count_today() {  # kick_count_today <num>
+  local n="$1" body count
+  body="$(gh_retry api "repos/${REPO}/issues/${n}/comments" --paginate \
+    --jq "[.[] | select(.body | contains(\"<!-- bot-comment:${KICK_MARKER} -->\")) | .body] | last" \
+    2>/dev/null || true)"
+  [[ -z "$body" || "$body" == "null" ]] && { echo 0; return 0; }
+  count="$(grep -oE "kicks ${today_utc}: [0-9]+" <<<"$body" | grep -oE '[0-9]+$' | tail -n1 || true)"
+  echo "${count:-0}"
 }
 
 check_failures_for_pr() {  # check_failures_for_pr <num>
@@ -185,9 +220,15 @@ while IFS= read -r pr; do
   m="$(jq -r '.m' <<<"$pr")"
   ms="$(jq -r '.ms' <<<"$pr")"
 
-  age_min="$(label_age_minutes "$n")"
-  if [[ -z "$age_min" ]]; then
-    echo "  #$n  $t  ?? could not determine label age; skipping"
+  age_out="$(label_age_minutes "$n")"
+  if [[ -z "$age_out" ]]; then
+    echo "  #$n  $t  ?? no valid merge-queue label timestamp; skipping (not kicking on incomplete data)"
+    continue
+  fi
+  age_min="${age_out%% *}"
+  labeled_at="${age_out#* }"
+  if [[ "$age_min" -gt "$MAX_STALL_MINUTES" ]]; then
+    echo "  #$n  $t  ?? computed stall ${age_min}m exceeds ${MAX_STALL_MINUTES}m sanity cap (timestamp source: ${labeled_at}); treating as data error and skipping"
     continue
   fi
   if [[ "$age_min" -lt "$STALL_MINUTES" ]]; then
@@ -218,10 +259,17 @@ while IFS= read -r pr; do
     continue
   fi
 
+  kicks_today="$(kick_count_today "$n")"
+  if [[ "$kicks_today" -ge "$MAX_KICKS_PER_DAY" ]]; then
+    echo "  #$n  $t  STALLED but already kicked ${kicks_today}x today (>= ${MAX_KICKS_PER_DAY}/day cap) -> skip"
+    skipped_cooldown=$((skipped_cooldown + 1))
+    continue
+  fi
+
   echo "  #$n  $t  STALLED (age=${age_min}m, clean+green) -> label-cycle merge-queue"
   unlabel "$n" merge-queue
   label "$n" merge-queue
-  record_kick "$n" "Merge-queue watchdog: label-cycled \`merge-queue\` after ${age_min}m stalled with no terminal check failures (kicked at $(date -u +%Y-%m-%dT%H:%M:%SZ))."
+  record_kick "$n" "Merge-queue watchdog: label-cycled \`merge-queue\` after ${age_min}m stalled with no terminal check failures (kicked at $(date -u +%Y-%m-%dT%H:%M:%SZ)). Timestamp source: \`merge-queue\` labeled event at ${labeled_at} from the issue timeline. kicks ${today_utc}: $((kicks_today + 1))"
   kicked=$((kicked + 1))
 done < <(jq -c '.[]' <<<"$CANDIDATES")
 

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -582,8 +582,24 @@ JSON
             f'bash "{_WATCHDOG_SCRIPT}"'
         )
 
+    @staticmethod
+    def _stale_ts(minutes: int = 120) -> str:
+        """A merge-queue label timestamp `minutes` in the past — recently stale.
+
+        Fixtures must use realistic stall ages: the watchdog now treats stalls
+        beyond MAX_STALL_MINUTES (7 days) as data errors from unset/zeroed
+        timestamps and skips them (#13343), so a hardcoded 2020 date would be
+        rejected rather than kicked.
+        """
+        import datetime
+
+        return (
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(minutes=minutes)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
     def test_stale_clean_pr_gets_label_cycled(self, tmp_path: Path) -> None:
-        stale_ts = "2020-01-01T00:00:00Z"
+        stale_ts = self._stale_ts()
         pr_list = (
             '[{"n":100,"t":"Stale clean PR","m":"MERGEABLE","ms":"CLEAN",'
             '"head":"tim/jov-100","L":["merge-queue"]}]'
@@ -636,7 +652,7 @@ JSON
         assert "skipped (fresh, <45m): 1" in result.stdout
 
     def test_recent_kick_is_skipped_via_cooldown(self, tmp_path: Path) -> None:
-        stale_ts = "2020-01-01T00:00:00Z"
+        stale_ts = self._stale_ts()
         recent_kick_ts = subprocess.run(
             ["date", "-u", "+%Y-%m-%dT%H:%M:%SZ"], capture_output=True, text=True, check=True
         ).stdout.strip()
@@ -672,7 +688,7 @@ JSON
     def test_conflicting_pr_gets_conflict_label_without_dequeue(
         self, tmp_path: Path
     ) -> None:
-        stale_ts = "2020-01-01T00:00:00Z"
+        stale_ts = self._stale_ts()
         pr_list = (
             '[{"n":103,"t":"Conflicting PR","m":"CONFLICTING","ms":"DIRTY",'
             '"head":"tim/jov-103","L":["merge-queue"]}]'
@@ -696,7 +712,7 @@ JSON
         assert "conflicts flagged: 1" in result.stdout
 
     def test_terminal_red_check_dequeues(self, tmp_path: Path) -> None:
-        stale_ts = "2020-01-01T00:00:00Z"
+        stale_ts = self._stale_ts()
         pr_list = (
             '[{"n":104,"t":"Red CI PR","m":"MERGEABLE","ms":"CLEAN",'
             '"head":"tim/jov-104","L":["merge-queue"]}]'
@@ -725,7 +741,7 @@ JSON
     ) -> None:
         # gh pr checks --required with --jq exits 8 on pending checks even with
         # valid JSON output (same behavior drain-pr-queue.sh guards against).
-        stale_ts = "2020-01-01T00:00:00Z"
+        stale_ts = self._stale_ts()
         pr_list = (
             '[{"n":105,"t":"Pending checks PR","m":"MERGEABLE","ms":"UNSTABLE",'
             '"head":"tim/jov-105","L":["merge-queue"]}]'
@@ -749,3 +765,57 @@ JSON
         # it falls through to the stuck-clean kick path instead.
         assert "dequeued (terminal red): 0" in result.stdout
         assert "kicked (label-cycled): 1" in result.stdout
+
+    def test_epoch_zero_timestamp_is_skipped_not_kicked(self, tmp_path: Path) -> None:
+        # Regression for #13343: an unset/epoch-0 enqueue timestamp computed a
+        # ~29.7M-minute "stall" and mass label-cycled freshly-enrolled PRs.
+        # Timestamps before 2020 are unset/zeroed data — skip, never kick.
+        pr_list = (
+            '[{"n":106,"t":"Epoch-zero PR","m":"MERGEABLE","ms":"CLEAN",'
+            '"head":"tim/jov-106","L":["merge-queue"]}]'
+        )
+        timeline = (
+            '[{"event":"labeled","label":{"name":"merge-queue"},'
+            '"created_at":"1970-01-01T00:00:00Z"}]'
+        )
+        self._fake_gh(
+            tmp_path,
+            pr_list_json=pr_list,
+            timeline_by_pr={106: timeline},
+            comments_by_pr={106: "[]"},
+            checks_by_pr={106: ("[]", 0)},
+        )
+
+        result = self._run_watchdog(tmp_path, extra_env="STALL_MINUTES=45")
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "no valid merge-queue label timestamp" in result.stdout
+        assert "kicked (label-cycled): 0" in result.stdout
+        assert "would -merge-queue" not in result.stdout
+
+    def test_absurdly_old_stall_is_treated_as_data_error(self, tmp_path: Path) -> None:
+        # Regression for #13343: a computed stall beyond MAX_STALL_MINUTES
+        # (default 7 days) can only come from bad timestamp data — the
+        # watchdog must skip it rather than kick, and must cite the timestamp.
+        pr_list = (
+            '[{"n":107,"t":"Ancient stall PR","m":"MERGEABLE","ms":"CLEAN",'
+            '"head":"tim/jov-107","L":["merge-queue"]}]'
+        )
+        timeline = (
+            '[{"event":"labeled","label":{"name":"merge-queue"},'
+            '"created_at":"2024-01-01T00:00:00Z"}]'
+        )
+        self._fake_gh(
+            tmp_path,
+            pr_list_json=pr_list,
+            timeline_by_pr={107: timeline},
+            comments_by_pr={107: "[]"},
+            checks_by_pr={107: ("[]", 0)},
+        )
+
+        result = self._run_watchdog(tmp_path, extra_env="STALL_MINUTES=45")
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "sanity cap" in result.stdout
+        assert "2024-01-01T00:00:00Z" in result.stdout
+        assert "kicked (label-cycled): 0" in result.stdout


### PR DESCRIPTION
## Problem
The watchdog kicked 5 freshly-enrolled PRs claiming `stalled 29721473m` (~56.5 years) — stall computed from an unset/epoch-0 enqueue timestamp (#13343).

## What changed
`scripts/merge-queue-watchdog.sh`:
- `label_age_minutes` now (a) keeps only strictly ISO-8601-shaped lines from the paginated timeline query (with `--paginate`, per-page jq emits stray `null` lines), (b) rejects epochs before 2020-01-01 (`MIN_VALID_EPOCH`) as unset/zeroed data, (c) validates the parsed epoch is numeric, and (d) returns the timestamp source alongside the age.
- Sanity cap: computed stalls beyond `MAX_STALL_MINUTES` (default 7 days) are treated as data errors and skipped, never kicked.
- Kick comment now cites the exact timestamp source used (acceptance requirement).
- New `MAX_KICKS_PER_DAY` (default 4) on top of the existing 2h cooldown, tracked in the marker comment body (`kicks YYYY-MM-DD: N`).

`scripts/tests/test_gh_retry.py`:
- Existing watchdog fixtures used a hardcoded 2020 timestamp as "stale" — that now correctly reads as a data error, so fixtures use a dynamic now-2h timestamp (more realistic anyway).
- Two new regression tests: epoch-0 timestamp → skipped not kicked; >7d stall → data-error skip citing the timestamp.

## Assumptions
- 2020-01-01 as the validity floor and 7d as the stall cap are reasonable defaults; both are env-tunable.

## Verification
Sandbox has no npm registry access (dispatch-approved constraint), so verification was targeted per file type.
```
$ bash -n scripts/merge-queue-watchdog.sh   # OK
$ python3 -m pytest scripts/tests/test_gh_retry.py -q
22 passed in 1.15s
```

## Acceptance mapping
- never reports stall >7d ✅ · invalid timestamps skipped, not kicked ✅ · kick comment includes timestamp source ✅ · kicks capped per PR per day ✅

Dispatch: thread cmr8gcqgx26if07adig4stylt · Fixes #13343
