### PR TITLE
test: encode the intentional golden-path serialized Neon pool group (fixes 91%-failing main lane)

### DIFF
--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -557,6 +557,16 @@ describe('CI Neon endpoint pool concurrency (JOV-2497)', () => {
     }
   });
 
+  // ci-golden-path deliberately uses ONE constant repo-wide group: it must
+  // serialize the Clerk dev instance (purgeStaleClerkTestUsers deletes ALL
+  // gp-* users, so two concurrent runs would delete each other's sessions)
+  // as well as the Neon pool. See the concurrency comment on the
+  // ci-golden-path job in ci.yml — do not parameterize that group. Every
+  // other pool group must stay per-job scoped per JOV-2497.
+  const intentionallySerializedPoolGroups = [
+    'group: neon-endpoint-pool-ci-golden-path',
+  ] as const;
+
   it('scopes branch-creation pool per job so siblings in one workflow are not cancelled', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const poolGroups =
@@ -564,7 +574,22 @@ describe('CI Neon endpoint pool concurrency (JOV-2497)', () => {
 
     expect(poolGroups.length).toBeGreaterThan(0);
     for (const group of poolGroups) {
+      if (
+        intentionallySerializedPoolGroups.includes(
+          group.trim() as (typeof intentionallySerializedPoolGroups)[number]
+        )
+      ) {
+        continue;
+      }
       expect(group).toContain('${{ github.job }}');
+    }
+  });
+
+  it('keeps the serialized-group allowlist accurate against the workflow', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+
+    for (const group of intentionallySerializedPoolGroups) {
+      expect(workflow).toContain(group);
     }
   });
 


### PR DESCRIPTION
## Problem
`deploy-workflow.test.ts > scopes branch-creation pool per job` fails 91% on main (312 fails): it asserts every `neon-endpoint-pool-*` concurrency group contains `${{ github.job }}`, but `ci-golden-path` deliberately uses the constant group `neon-endpoint-pool-ci-golden-path` (#13345). This is test/workflow drift, not flake.

## What changed
Per the issue's option (b) — the hardcode is **intentional**: the `ci-golden-path` job comment in `ci.yml` says "Constant group so at most ONE golden-path job runs repo-wide... Do not parameterize this group" (it serializes the Clerk dev instance whose `purgeStaleClerkTestUsers` deletes ALL `gp-*` users, plus the Neon pool).
- The test now carries an explicit `intentionallySerializedPoolGroups` allowlist with that rationale, and skips those groups in the per-job assertion.
- A new companion test asserts the allowlist stays accurate against the workflow (an allowlisted group that disappears from `ci.yml` fails the test).

## Assumptions
- I could not check `git blame` for whether the hardcode was accidental, but the extensive in-workflow comment ("Do not parameterize this group") makes intent unambiguous.
- A one-line pointer comment for the top-of-file pool docs in `ci.yml` was prepared but NOT pushed: the GitHub App token lacks `workflows` permission (403 on any `.github/workflows/*` write). The contract is already documented at the job site in `ci.yml`, so acceptance is substantively met. Patch if wanted:
```diff
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@
   # sibling matrix jobs cancel each other within the same workflow run.
   # Pool groups include github.job so branch-creator siblings in one workflow (neon-db,
   # dashboard Lighthouse, E2E smoke fallback, admin smoke) do not queue-cancel each other.
+  # EXCEPTION: ci-golden-path uses one constant repo-wide group (no github.job) because
+  # it must also serialize the Clerk dev instance — see the comment on that job. The
+  # contract is asserted by apps/web/tests/unit/ci/deploy-workflow.test.ts (JOV-2497).
 
 jobs:
   # ── CI Optimizer + Centralized path-change detection (merged) ──────────
```

## Verification
Sandbox has no npm registry access (dispatch-approved constraint), so verification was targeted per file type. Test logic re-implemented and executed against `ci.yml` in plain node (vitest deps unavailable in sandbox):
```
NEON POOL TEST SIM: PASS  (per-job scoping, allowlist accuracy, create-jobs, consumer-jobs all green)
$ /tmp/biome check apps/web/tests/unit/ci/deploy-workflow.test.ts  # clean
```

Dispatch: thread cmr8gcqgx26if07adig4stylt · Fixes #13345
