### PR TITLE
routes: land settings/referral page and classify it in shell-nav coverage

### DIFF
--- a/apps/web/app/app/(shell)/settings/referral/page.tsx
+++ b/apps/web/app/app/(shell)/settings/referral/page.tsx
@@ -1,0 +1,70 @@
+import { SettingsSection } from '@/features/dashboard/organisms/SettingsSection';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { publicEnv } from '@/lib/env-public';
+import {
+  DEFAULT_COMMISSION_DURATION_MONTHS,
+  DEFAULT_COMMISSION_RATE_BPS,
+} from '@/lib/referrals/config';
+import {
+  getInternalUserId,
+  getOrCreateReferralCode,
+} from '@/lib/referrals/service';
+import { logger } from '@/lib/utils/logger';
+import { ReferralCodeCopyClient } from './ReferralCodeCopyClient';
+
+export const runtime = 'nodejs';
+
+const COMMISSION_PERCENT = DEFAULT_COMMISSION_RATE_BPS / 100;
+
+async function loadReferralCode(): Promise<string | null> {
+  try {
+    const { userId: clerkUserId } = await getCachedAuth();
+    if (!clerkUserId) {
+      return null;
+    }
+
+    const internalUserId = await getInternalUserId(clerkUserId);
+    if (!internalUserId) {
+      return null;
+    }
+
+    const result = await getOrCreateReferralCode(internalUserId);
+    return result.code;
+  } catch (error) {
+    logger.error('Failed to load referral code for settings page:', error);
+    return null;
+  }
+}
+
+export default async function SettingsReferralPage() {
+  const code = await loadReferralCode();
+  const shareUrl = code
+    ? `${publicEnv.NEXT_PUBLIC_APP_URL}/signup?ref=${encodeURIComponent(code)}`
+    : null;
+
+  return (
+    <SettingsSection
+      id='referral'
+      title='Referral'
+      description={`Earn ${COMMISSION_PERCENT}% of every payment from artists you refer, for up to ${DEFAULT_COMMISSION_DURATION_MONTHS} months.`}
+    >
+      {code && shareUrl ? (
+        <div className='space-y-3'>
+          <ReferralCodeCopyClient shareUrl={shareUrl} code={code} />
+          <p className='text-xs text-secondary-token'>
+            Your code{' '}
+            <span className='font-medium text-primary-token'>{code}</span> is
+            applied when someone subscribes through your link.
+          </p>
+        </div>
+      ) : (
+        <div className='py-4'>
+          <p className='text-app text-secondary'>
+            Your referral code isn&apos;t available right now. Refresh the page
+            to try again.
+          </p>
+        </div>
+      )}
+    </SettingsSection>
+  );
+}

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -45,6 +45,8 @@ const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
     'Unified autonomous work feed is reachable from direct app links until nav placement is finalised',
   '/app/lyrics/[trackId]':
     'Cinematic lyrics surface reached from the AudioBar lyrics button',
+  '/app/settings/referral':
+    'Referral code page reached from share/referral flows; Settings IA nav placement lands with the Settings sidebar consolidation (#13134)',
 };
 
 interface ShellPage {


### PR DESCRIPTION
## Problem
`shell-nav-coverage.test.ts` fails repo-wide: `app/settings/referral/page.tsx` (carried by in-flight PR stacks) is unclassified in the nav-coverage allowlist (#13346). Main has the orphaned `ReferralCodeCopyClient.tsx` but no `page.tsx`, so the allowlist entry alone would fail the allowlist-staleness test.

## What changed
- Landed `apps/web/app/app/(shell)/settings/referral/page.tsx` **verbatim from PR #13134's branch** (the Settings IA consolidation that owns this surface). Identical content means #13134 rebases conflict-free; all referenced modules (`lib/referrals/config`, `lib/referrals/service`, `SettingsSection`, the client component) already exist on main.
- Classified `/app/settings/referral` in `INTENTIONAL_INTERNAL_ROUTES` with a rationale pointing at #13134 for the eventual Settings IA nav placement.

## Assumptions
- Coordinated with #13134 by copying its file exactly rather than inventing a variant; when #13134 lands its nav entry, the allowlist entry can be dropped in that PR (noted in the rationale string).

## Verification
Sandbox has no npm registry access (dispatch-approved constraint), so verification was targeted per file type. Test logic re-implemented in plain node (vitest deps unavailable):
```
page exists: true
allowlist entry present: true
stale allowlist entries: []
$ /tmp/biome check page.tsx shell-nav-coverage.test.ts  # clean
```

Dispatch: thread cmr8gcqgx26if07adig4stylt · Fixes #13346
