### PR TITLE
ci: PR conflict handler — transient-error retry, degraded no-rollup fallback, stderr surfacing

### DIFF
--- a/.github/workflows/auto-ready-agent-drafts.yml
+++ b/.github/workflows/auto-ready-agent-drafts.yml
@@ -10,8 +10,12 @@ name: Auto-Ready Agent Drafts
 on:
   schedule:
     - cron: '*/15 * * * *'   # catch anything missed between CI events
+  # Trigger hygiene (#13349): no `synchronize` — every push starts CI, whose
+  # completion fires the workflow_run trigger below. A draft's checks can only
+  # turn green via a CI completion, so per-push spawns of this fleet-wide scan
+  # were pure duplication.
   pull_request:
-    types: [ready_for_review, reopened, synchronize]
+    types: [ready_for_review, reopened]
   workflow_run:
     workflows: ['CI']
     types: [completed]

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,8 +3,11 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
+  # Trigger hygiene (#13349): `assigned` dropped — the job-level `if:` already
+  # gates on @claude in body/title, which `opened` covers. Assignment events
+  # were pure duplicates that booted runners for no work.
   issues:
-    types: [opened, assigned]
+    types: [opened]
   # NOTE: pull_request_review AND pull_request_review_comment both removed.
   # Bot-submitted reviews/comments (CodeRabbit, Copilot) create
   # action_required runs that clog the CI queue and consume runner slots.

--- a/.github/workflows/github-ai-orchestrator.yml
+++ b/.github/workflows/github-ai-orchestrator.yml
@@ -27,6 +27,13 @@ env:
 jobs:
   guard:
     name: Guard + Deduplicate
+    # Trigger hygiene (#13349): `issues: labeled` fires for EVERY label event on
+    # every issue repo-wide, and GitHub cannot filter label names at the `on:`
+    # level. Gate at the job level so non-agent-ready label events conclude
+    # `skipped` without ever provisioning a runner — previously this job booted
+    # a runner just to echo "Label is not agent-ready; skipping".
+    # Keep in sync with env.AGENT_READY_LABEL (job-level `if:` cannot read env).
+    if: github.event_name != 'issues' || github.event.label.name == 'agent-ready'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/merge-queue-autoenroll.yml
+++ b/.github/workflows/merge-queue-autoenroll.yml
@@ -25,8 +25,12 @@ on:
   schedule:
     - cron: '*/20 * * * *'   # enroll: catch anything missed between events
     - cron: '*/10 * * * *'   # watchdog: rescue PRs stalled inside the queue
+  # Trigger hygiene (#13349): no `synchronize` — enrollment eligibility only
+  # changes when CI completes (workflow_run below) or a PR flips ready/reopens.
+  # Per-push spawns of this fleet-wide drain were pure duplication behind the
+  # shared mutex.
   pull_request:
-    types: [ready_for_review, reopened, synchronize]
+    types: [ready_for_review, reopened]
   workflow_run:
     workflows: ['CI']
     types: [completed]

--- a/.github/workflows/pr-conflict-handler.yml
+++ b/.github/workflows/pr-conflict-handler.yml
@@ -2,10 +2,13 @@ name: PR Conflict Handler
 
 # Automatically resolves merge conflicts on agent PRs.
 # Fires on:
-#   - PR push (detect conflicts immediately)
 #   - CI completion (conflict may surface as test failure)
 #   - Schedule weekday safety net
 #   - Manual dispatch
+#
+# NOTE: no `pull_request: synchronize` trigger. This is a FLEET-WIDE scan that
+# lists all open PRs, so per-push spawns are pure duplication: every push
+# already triggers CI, which fires the workflow_run below. Removed in #13359.
 
 on:
   workflow_dispatch:
@@ -25,8 +28,6 @@ on:
   schedule:
     # Read-only audit. Do not auto-push/rebase the fleet on a tight cadence.
     - cron: '17 15 * * 1-5'
-  pull_request:
-    types: [synchronize]
   workflow_run:
     workflows: ['CI']
     types: [completed]

--- a/.github/workflows/taste-classifier.yml
+++ b/.github/workflows/taste-classifier.yml
@@ -30,23 +30,55 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Dedup guard (#13348): classify once per head SHA, not once per event.
+      # Re-fires on synchronize bursts were posting 2-3 duplicate classification
+      # comments per PR. The marker comment records the classified SHA; if it
+      # matches the current head, skip the whole run.
+      - name: Check for existing classification of this head SHA
+        id: dedupe
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- bot-comment:taste-classifier -->';
+            const headSha = context.payload.pull_request.head.sha;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+            const alreadyClassified = Boolean(
+              existing?.body?.includes(`<!-- classified-sha:${headSha} -->`)
+            );
+            core.setOutput('skip', alreadyClassified ? 'true' : 'false');
+            core.setOutput('comment_id', existing ? String(existing.id) : '');
+            if (alreadyClassified) {
+              core.info(`Head ${headSha} already classified in comment ${existing.id}; skipping.`);
+            }
+
       - name: Checkout repository
+        if: steps.dedupe.outputs.skip != 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Enable corepack
+        if: steps.dedupe.outputs.skip != 'true'
         run: corepack enable
 
       - name: Setup Node 24
+        if: steps.dedupe.outputs.skip != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.dedupe.outputs.skip != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run taste classifier
         id: classify
+        if: steps.dedupe.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -57,8 +89,10 @@ jobs:
           echo "classification=$CLASSIFICATION" >> "$GITHUB_OUTPUT"
 
       - name: Post classification comment and apply label
-        if: steps.classify.outputs.classification != ''
+        if: steps.dedupe.outputs.skip != 'true' && steps.classify.outputs.classification != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          EXISTING_COMMENT_ID: ${{ steps.dedupe.outputs.comment_id }}
         with:
           script: |
             const fs = require('fs');
@@ -66,7 +100,11 @@ jobs:
 
             const { pr: prNumber, classification: result, confidence, reason, signals } = classification;
 
-            // Build comment
+            // Build comment with dedupe markers
+            const marker = '<!-- bot-comment:taste-classifier -->';
+            const headSha = context.payload.pull_request.head.sha;
+            const shaMarker = `<!-- classified-sha:${headSha} -->`;
+
             const emoji = {
               'taste-required': '🎨',
               'llm-reviewable': '🤖',
@@ -74,7 +112,8 @@ jobs:
             };
             const emojiIcon = emoji[result] || '🔍';
 
-            let comment = `## ${emojiIcon} Taste Classifier: \`${result}\`\n\n`;
+            let comment = `${marker}\n${shaMarker}\n`;
+            comment += `## ${emojiIcon} Taste Classifier: \`${result}\`\n\n`;
             comment += `**Confidence:** ${(confidence * 100).toFixed(0)}%\n`;
             comment += `**Reason:** ${reason}\n\n`;
 
@@ -96,13 +135,23 @@ jobs:
 
             comment += '\n*— Taste classifier v1.0 (autonomous shipping system)*';
 
-            // Post comment
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: comment,
-            });
+            // Upsert: edit existing comment if one exists
+            const existingId = process.env.EXISTING_COMMENT_ID;
+            if (existingId) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: parseInt(existingId),
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment,
+              });
+            }
 
             // Apply label
             const labelMap = {

--- a/docs/ci/trigger-hygiene.md
+++ b/docs/ci/trigger-hygiene.md
@@ -1,0 +1,1 @@
+placeholder-will-replace

--- a/docs/ci/trigger-hygiene.md
+++ b/docs/ci/trigger-hygiene.md
@@ -1,1 +1,56 @@
-placeholder-will-replace
+# Workflow trigger hygiene
+
+Why: at blitz volume the repo hit **3,770 workflow runs in 12h with ~53%
+concluding `skipped`** (#13349) — workflows spawning on events they immediately
+decide to ignore. Skipped runs still consume queue/scheduler overhead and
+pollute the Actions log, masking real failures. CI throughput is the binding
+constraint; spawn noise is the cheapest capacity to buy back.
+
+## Rules
+
+1. **Filter at the `on:` level whenever GitHub allows it** — event `types`,
+   `branches`, `paths`, `paths-ignore`. A non-matching event then never creates
+   a run at all. Do NOT add `paths` filters to workflows that produce required
+   status checks (path-skipped required checks stay pending and wedge the
+   merge queue) — use the path-changes job pattern inside CI instead.
+
+2. **Comment/review-driven workflows must stay broad** (`issue_comment`,
+   `pull_request_review` cannot filter body content at the `on:` level). Gate
+   with a **job-level `if:`** on the event payload — a job skipped by its `if:`
+   never provisions a runner. Never put the skip decision inside a `run:` step:
+   that boots a runner just to `exit 0` (this is what the AI Orchestrator guard
+   did for every non-`agent-ready` label event).
+
+3. **Fleet-wide scanners do not need per-push triggers.** Workflows that list
+   ALL open PRs and act on the fleet (merge-queue drain, auto-ready,
+   PR conflict handler) get zero extra coverage from `pull_request:
+   synchronize` — every push starts CI, whose completion already fires their
+   `workflow_run: [CI completed]` trigger. Per-push spawns just multiply
+   identical scans behind the shared mutex.
+
+4. **Deduplicate event types that add no coverage.** Example: `issues:
+   assigned` on Claude Code — the job only runs when the body/title contains
+   `@claude`, which `opened` already covers.
+
+5. **Measure before/after.** Runs-per-hour and skipped-share for a window:
+
+   ```bash
+   gh api "repos/JovieInc/Jovie/actions/runs?created=>$(date -u -d '12 hours ago' +%Y-%m-%dT%H:%M:%SZ)&per_page=100" \
+     --paginate --jq '.workflow_runs[] | [.name, .conclusion] | @tsv' \
+     | sort | uniq -c | sort -rn | head -30
+   ```
+
+   Acceptance for #13349: total runs/hr down ≥40% on a comparable-load day,
+   skipped share <20%, no legitimate trigger lost (spot-check one real event
+   per touched workflow).
+
+## Touched in #13349
+
+| Workflow | Change |
+| --- | --- |
+| `github-ai-orchestrator.yml` | Guard's label check moved from in-runner script to job-level `if:` |
+| `auto-ready-agent-drafts.yml` | Dropped `pull_request: synchronize` (covered by `workflow_run: CI completed`) |
+| `merge-queue-autoenroll.yml` | Dropped `pull_request: synchronize` (same) |
+| `pr-conflict-handler.yml` | Dropped `pull_request: synchronize` (same; see #13347) |
+| `claude.yml` | Dropped `issues: assigned` (no coverage beyond `opened`); documented broad-trigger rationale |
+| `taste-approve.yml` | Documented broad-trigger rationale (content triggers cannot be narrowed) |

--- a/scripts/auto-ready-agent-drafts.sh
+++ b/scripts/auto-ready-agent-drafts.sh
@@ -8,7 +8,8 @@
 # Opt out per-PR with any of: needs-human, hold, gated, fast.
 #
 # Env:
-#   DRY_RUN=1   classify and print only; flip no PRs
+#   DRY_RUN=1                 classify and print only; flip no PRs
+#   ATTEMPT_COOLDOWN_HOURS    min hours between flip attempts per PR (default 6)
 set -euo pipefail
 
 # shellcheck source=./scripts/lib/gh-retry.sh
@@ -17,17 +18,50 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/gh-retry.sh"
 REPO="${REPO:-JovieInc/Jovie}"
 DRY_RUN="${DRY_RUN:-0}"
 AGENT_RE='^(tim/|codex/|agent/|claude/|linear/|dependabot/)'
+# Idempotency guard (#13342): one marker comment per PR, edited in place, and a
+# hard cap of one flip attempt per PR per ATTEMPT_COOLDOWN_HOURS. Without this,
+# a PR the token cannot actually flip (see #13122) gets an identical
+# "Enrolling in merge queue" comment every cron cycle — 221 in 12h observed.
+READY_MARKER="auto-ready"
+ATTEMPT_COOLDOWN_HOURS="${ATTEMPT_COOLDOWN_HOURS:-6}"
+now_epoch="$(date -u +%s)"
 
-mark_ready() {  # mark_ready <num>
+mark_ready() {  # mark_ready <num> — returns non-zero when the flip call failed
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would mark #$1 ready"; return 0; }
-  gh_retry pr ready "$1" -R "$REPO" >/dev/null 2>&1 \
-    && echo "    ✓ marked #$1 ready" || echo "    !! failed to mark #$1 ready"
+  if gh_retry pr ready "$1" -R "$REPO" >/dev/null 2>&1; then
+    echo "    ✓ marked #$1 ready"
+    return 0
+  fi
+  echo "    !! failed to mark #$1 ready"
+  return 1
 }
 
-comment() {  # comment <num> <body>
-  [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would comment on #$1"; return 0; }
-  gh_retry pr comment "$1" -R "$REPO" --body "$2" >/dev/null 2>&1 \
-    && echo "    ✓ commented on #$1" || echo "    !! failed to comment on #$1"
+# Upsert the single auto-ready status comment (edited in place on repeat runs).
+upsert_status_comment() {  # upsert_status_comment <num> <body>
+  [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would upsert status comment on #$1"; return 0; }
+  GITHUB_REPOSITORY="$REPO" bash "$(dirname "${BASH_SOURCE[0]}")/lib/upsert-pr-comment.sh" "$1" "$READY_MARKER" "$2" \
+    && echo "    ✓ upserted status comment on #$1" || echo "    !! failed to upsert status comment on #$1"
+}
+
+# Hours since the last auto-ready attempt marker comment on this PR. Empty
+# output means "never attempted" (treated as cooldown-elapsed).
+last_attempt_age_hours() {  # last_attempt_age_hours <num>
+  local n="$1"
+  local updated_at
+  updated_at="$(gh_retry api "repos/${REPO}/issues/${n}/comments" --paginate \
+    --jq "[.[] | select(.body | contains(\"<!-- bot-comment:${READY_MARKER} -->\")) | .updated_at] | last" \
+    2>/dev/null | grep -E '^[0-9]{4}-' | tail -n1 || true)"
+  [[ -z "$updated_at" || "$updated_at" == "null" ]] && { echo ""; return 0; }
+  local updated_epoch
+  updated_epoch="$(date -u -d "$updated_at" +%s 2>/dev/null \
+    || python3 -c "import datetime,sys; print(int(datetime.datetime.strptime(sys.argv[1], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc).timestamp()))" "$updated_at")"
+  echo $(( (now_epoch - updated_epoch) / 3600 ))
+}
+
+# Re-query the PR and confirm the draft flip actually landed before claiming
+# success — `gh pr ready` can fail silently on token-permission gaps (#13122).
+is_still_draft() {  # is_still_draft <num> — echoes true/false/unknown
+  gh_retry pr view "$1" -R "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo "unknown"
 }
 
 check_failures_for_pr() {  # check_failures_for_pr <num>
@@ -128,8 +162,29 @@ echo "$SNAP" | jq -c '.[]
   | while read -r pr; do
     n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
     echo "  #$n  $t"
-    mark_ready "$n"
-    comment "$n" "🤖 Auto-ready: all required checks passing. Enrolling in merge queue."
+
+    # Idempotency guard (#13342): at most one attempt per PR per cooldown window.
+    attempt_age_h="$(last_attempt_age_hours "$n")"
+    if [[ -n "$attempt_age_h" && "$attempt_age_h" -lt "$ATTEMPT_COOLDOWN_HOURS" ]]; then
+      echo "    ~ last attempt ${attempt_age_h}h ago (< ${ATTEMPT_COOLDOWN_HOURS}h cooldown); skipping"
+      continue
+    fi
+
+    if ! mark_ready "$n"; then
+      upsert_status_comment "$n" "⚠️ Auto-ready: all required checks are passing, but marking this PR ready for review **failed** (likely a token-permission gap — see #13122). A human needs to flip it to ready. Will retry in ${ATTEMPT_COOLDOWN_HOURS}h. _(last attempt: $(date -u +%Y-%m-%dT%H:%M:%SZ))_"
+      continue
+    fi
+
+    [[ "$DRY_RUN" == "1" ]] && continue
+
+    # Verify the flip actually landed before claiming enrollment — enrolling a
+    # PR that is still a draft is a no-op and just spams the timeline.
+    still_draft="$(is_still_draft "$n")"
+    if [[ "$still_draft" == "false" ]]; then
+      upsert_status_comment "$n" "🤖 Auto-ready: all required checks passing — marked ready for review and enrolling in merge queue. _(verified ready at $(date -u +%Y-%m-%dT%H:%M:%SZ))_"
+    else
+      upsert_status_comment "$n" "⚠️ Auto-ready: \`gh pr ready\` reported success but the PR still shows draft=${still_draft} — the flip did not land (see #13122). A human needs to mark it ready. Will retry in ${ATTEMPT_COOLDOWN_HOURS}h. _(last attempt: $(date -u +%Y-%m-%dT%H:%M:%SZ))_"
+    fi
   done
 
 echo "=== done (DRY_RUN=$DRY_RUN) ==="

--- a/scripts/merge-queue-watchdog.sh
+++ b/scripts/merge-queue-watchdog.sh
@@ -47,9 +47,19 @@ REPO="${REPO:-JovieInc/Jovie}"
 DRY_RUN="${DRY_RUN:-0}"
 STALL_MINUTES="${STALL_MINUTES:-45}"
 COOLDOWN_HOURS="${COOLDOWN_HOURS:-2}"
+# Sanity cap (#13343): a stall longer than this is a data error (unset/epoch-0
+# enqueue timestamp computing a ~56-year stall), never a real queue stall.
+# Skip such PRs instead of kicking them.
+MAX_STALL_MINUTES="${MAX_STALL_MINUTES:-10080}"  # 7 days
+# Hard cap on label-cycle kicks per PR per UTC day, on top of COOLDOWN_HOURS.
+MAX_KICKS_PER_DAY="${MAX_KICKS_PER_DAY:-4}"
 KICK_MARKER="merge-queue-watchdog-kick"
+# Timestamps before this are unset/zeroed data (epoch 0, Go zero time, etc.),
+# not real label events. 2020-01-01T00:00:00Z.
+MIN_VALID_EPOCH=1577836800
 
 now_epoch="$(date -u +%s)"
+today_utc="$(date -u +%Y-%m-%d)"
 
 label() {  # label <num> <label>
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would +$2 on #$1"; return 0; }
@@ -64,19 +74,32 @@ unlabel() {  # unlabel <num> <label>
 }
 
 # Minutes since the most recent `merge-queue` label event on this PR, read
-# from the issue timeline. Empty output means "could not determine" (treated
-# as not-yet-stale so we never act on incomplete data).
+# from the issue timeline, echoed as "<minutes> <timestamp>". Empty output
+# means "could not determine a valid timestamp" (treated as not-yet-stale so
+# we never act on incomplete data).
+#
+# Null-safety (#13343): with --paginate the per-page jq filter can emit `null`
+# lines (pages with no matching event) alongside a real timestamp, and the API
+# can surface unset/zeroed timestamps. Naively parsing those computed stalls
+# from epoch 0 (~29.7M minutes) and mass-kicked freshly-enrolled PRs. We now
+# (a) keep only ISO-8601-shaped lines, (b) reject epochs before
+# MIN_VALID_EPOCH, and (c) validate the parsed epoch is numeric.
 label_age_minutes() {  # label_age_minutes <num>
   local n="$1"
   local labeled_at
   labeled_at="$(gh_retry api "repos/${REPO}/issues/${n}/timeline" --paginate \
     --jq '[.[] | select(.event=="labeled" and .label.name=="merge-queue") | .created_at] | last' \
-    2>/dev/null || true)"
+    2>/dev/null | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' | tail -n1 || true)"
   [[ -z "$labeled_at" || "$labeled_at" == "null" ]] && { echo ""; return 0; }
   local labeled_epoch
   labeled_epoch="$(date -u -d "$labeled_at" +%s 2>/dev/null \
-    || python3 -c "import datetime,sys; print(int(datetime.datetime.strptime(sys.argv[1], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc).timestamp()))" "$labeled_at")"
-  echo $(( (now_epoch - labeled_epoch) / 60 ))
+    || python3 -c "import datetime,sys; print(int(datetime.datetime.strptime(sys.argv[1], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc).timestamp()))" "$labeled_at" 2>/dev/null \
+    || true)"
+  if ! [[ "$labeled_epoch" =~ ^[0-9]+$ ]] || [[ "$labeled_epoch" -lt "$MIN_VALID_EPOCH" ]]; then
+    echo ""
+    return 0
+  fi
+  echo "$(( (now_epoch - labeled_epoch) / 60 )) ${labeled_at}"
 }
 
 # Hours since the last watchdog-kick marker comment on this PR. Empty output
@@ -99,6 +122,18 @@ record_kick() {  # record_kick <num> <body>
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would record kick comment on #$n"; return 0; }
   bash "$(dirname "${BASH_SOURCE[0]}")/lib/upsert-pr-comment.sh" "$n" "$KICK_MARKER" "$body" \
     || echo "    !! failed to record kick comment on #$n"
+}
+
+# Kicks recorded today (UTC) for this PR, parsed from the marker comment body
+# ("kicks <YYYY-MM-DD>: <n>"). 0 when never kicked or last kick was another day.
+kick_count_today() {  # kick_count_today <num>
+  local n="$1" body count
+  body="$(gh_retry api "repos/${REPO}/issues/${n}/comments" --paginate \
+    --jq "[.[] | select(.body | contains(\"<!-- bot-comment:${KICK_MARKER} -->\")) | .body] | last" \
+    2>/dev/null || true)"
+  [[ -z "$body" || "$body" == "null" ]] && { echo 0; return 0; }
+  count="$(grep -oE "kicks ${today_utc}: [0-9]+" <<<"$body" | grep -oE '[0-9]+$' | tail -n1 || true)"
+  echo "${count:-0}"
 }
 
 check_failures_for_pr() {  # check_failures_for_pr <num>
@@ -185,9 +220,15 @@ while IFS= read -r pr; do
   m="$(jq -r '.m' <<<"$pr")"
   ms="$(jq -r '.ms' <<<"$pr")"
 
-  age_min="$(label_age_minutes "$n")"
-  if [[ -z "$age_min" ]]; then
-    echo "  #$n  $t  ?? could not determine label age; skipping"
+  age_out="$(label_age_minutes "$n")"
+  if [[ -z "$age_out" ]]; then
+    echo "  #$n  $t  ?? no valid merge-queue label timestamp; skipping (not kicking on incomplete data)"
+    continue
+  fi
+  age_min="${age_out%% *}"
+  labeled_at="${age_out#* }"
+  if [[ "$age_min" -gt "$MAX_STALL_MINUTES" ]]; then
+    echo "  #$n  $t  ?? computed stall ${age_min}m exceeds ${MAX_STALL_MINUTES}m sanity cap (timestamp source: ${labeled_at}); treating as data error and skipping"
     continue
   fi
   if [[ "$age_min" -lt "$STALL_MINUTES" ]]; then
@@ -218,10 +259,17 @@ while IFS= read -r pr; do
     continue
   fi
 
+  kicks_today="$(kick_count_today "$n")"
+  if [[ "$kicks_today" -ge "$MAX_KICKS_PER_DAY" ]]; then
+    echo "  #$n  $t  STALLED but already kicked ${kicks_today}x today (>= ${MAX_KICKS_PER_DAY}/day cap) -> skip"
+    skipped_cooldown=$((skipped_cooldown + 1))
+    continue
+  fi
+
   echo "  #$n  $t  STALLED (age=${age_min}m, clean+green) -> label-cycle merge-queue"
   unlabel "$n" merge-queue
   label "$n" merge-queue
-  record_kick "$n" "Merge-queue watchdog: label-cycled \`merge-queue\` after ${age_min}m stalled with no terminal check failures (kicked at $(date -u +%Y-%m-%dT%H:%M:%SZ))."
+  record_kick "$n" "Merge-queue watchdog: label-cycled \`merge-queue\` after ${age_min}m stalled with no terminal check failures (kicked at $(date -u +%Y-%m-%dT%H:%M:%SZ)). Timestamp source: \`merge-queue\` labeled event at ${labeled_at} from the issue timeline. kicks ${today_utc}: $((kicks_today + 1))"
   kicked=$((kicked + 1))
 done < <(jq -c '.[]' <<<"$CANDIDATES")
 

--- a/scripts/pr-conflict-handler.mjs
+++ b/scripts/pr-conflict-handler.mjs
@@ -133,11 +133,24 @@ async function ghJson(args, { retries = 3 } = {}) {
       return JSON.parse(stdout);
     } catch (error) {
       const stderr = error.stderr ?? '';
-      const rateLimited = /rate limit|secondary rate|abuse/i.test(stderr);
-      if (!rateLimited || attempt === retries) throw error;
+      // Retry transient API failures, not just rate limits: the bulk
+      // `gh pr list --json statusCheckRollup` GraphQL query times out or
+      // errors under load at blitz-scale open-PR counts (#13347).
+      const transient =
+        /rate limit|secondary rate|abuse|something went wrong|timeout|timed out|502|503|504|connection reset|unexpected end of JSON/i.test(
+          `${stderr}${error.message ?? ''}`
+        );
+      if (!transient || attempt === retries) {
+        if (stderr) {
+          console.error(
+            `[gh] ${args.slice(0, 3).join(' ')} failed (attempt ${attempt}/${retries}): ${stderr.slice(0, 2000)}`
+          );
+        }
+        throw error;
+      }
       const delayMs = Math.min(30_000, 2000 * 2 ** (attempt - 1));
       console.error(
-        `[gh-retry] ${args.join(' ')} hit rate limit; retry ${attempt}/${retries} in ${delayMs}ms`
+        `[gh-retry] ${args.join(' ')} transient failure; retry ${attempt}/${retries} in ${delayMs}ms`
       );
       await new Promise(resolve => setTimeout(resolve, delayMs));
     }
@@ -162,13 +175,12 @@ async function fetchOpenPrs(options) {
     'headRepositoryOwner',
     'isCrossRepository',
     'labels',
-    'statusCheckRollup',
     'changedFiles',
     'additions',
     'deletions',
     'maintainerCanModify',
   ];
-  return ghJson([
+  const listArgs = [
     'pr',
     'list',
     '--repo',
@@ -178,8 +190,27 @@ async function fetchOpenPrs(options) {
     '--limit',
     String(options.limit),
     '--json',
-    fields.join(','),
-  ]);
+  ];
+  try {
+    return {
+      prs: await ghJson([
+        ...listArgs,
+        [...fields, 'statusCheckRollup'].join(','),
+      ]),
+      degradedChecks: false,
+    };
+  } catch (error) {
+    // statusCheckRollup is by far the heaviest field in this query — at
+    // blitz-scale open-PR counts the combined GraphQL query fails while the
+    // same query without rollups succeeds (#13347). Fall back to a degraded
+    // fetch so the handler keeps classifying from mergeable/mergeStateStatus
+    // instead of dying on every run.
+    console.error(
+      `[degraded] bulk PR fetch with statusCheckRollup failed (${error.message}); retrying without check rollups`
+    );
+    const prs = await ghJson([...listArgs, fields.join(',')]);
+    return { prs, degradedChecks: true };
+  }
 }
 
 async function ensureLabel(repo, label, color, description) {
@@ -360,7 +391,16 @@ async function executePlan(plan, options) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const prs = await fetchOpenPrs(options);
+  const { prs, degradedChecks } = await fetchOpenPrs(options);
+  if (degradedChecks) {
+    // Without check rollups, "required check missing" is indistinguishable
+    // from "not fetched" — drop required-check-based BLOCKED classification
+    // and rely on GitHub's own mergeStateStatus, which is still fetched.
+    options.requiredChecks = [];
+    console.error(
+      '[degraded] classifying without check rollups: required-check gating disabled for this run; mergeStateStatus still applies'
+    );
+  }
   const plan = buildPlan(prs, options);
 
   console.log(formatPlan(plan, { dryRun: options.dryRun }));
@@ -377,5 +417,11 @@ async function main() {
 
 main().catch(error => {
   console.error(error);
+  // Surface subprocess stderr — `console.error(error)` alone hides the gh
+  // CLI's actual failure reason, which made the 100%-failing-runs incident
+  // (#13347) undiagnosable from the Actions UI.
+  if (error?.stderr) {
+    console.error(`stderr: ${String(error.stderr).slice(0, 4000)}`);
+  }
   process.exitCode = 1;
 });

--- a/scripts/taste-classifier.mjs
+++ b/scripts/taste-classifier.mjs
@@ -10,7 +10,8 @@
  *
  * Exit codes:
  *   0 = classified successfully
- *   2 = classification uncertain (default to taste-required)
+ *   2 = classification uncertain (defaults to llm-reviewable — the taste
+ *       gate only applies on a positive material-UX signal, JOV-3592)
  */
 
 import { execSync } from 'node:child_process';
@@ -423,11 +424,17 @@ export function classifyTaste(pr) {
     };
   }
 
-  // Uncertain → default to taste-required
+  // Uncertain → default to llm-reviewable, NOT taste-required. Standing owner
+  // rule (2026-06-26, JOV-3592): the taste label applies ONLY on a positive
+  // material-UX-change signal; uncertain/non-visual work must auto-flow to
+  // strong LLM review. Defaulting uncertain to taste-required grew the human
+  // gate to 51% of bot PRs (#13348). Flipped-by-default cases carry a
+  // `default:flipped-to-llm-reviewable` signal for the weekly audit.
+  signals.push('default:flipped-to-llm-reviewable');
   return {
-    classification: 'taste-required',
+    classification: 'llm-reviewable',
     confidence: 0.5,
-    reason: `Uncertain classification (score: +${tasteScore.toFixed(1)} vs -${nonTasteScore.toFixed(1)}), defaulting to taste-required`,
+    reason: `Uncertain classification (score: +${tasteScore.toFixed(1)} vs -${nonTasteScore.toFixed(1)}) — no positive taste signal, defaulting to llm-reviewable (JOV-3592; logged for weekly audit)`,
     signals: signals.slice(0, 10),
     stats: {
       tasteFiles,

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -582,8 +582,24 @@ JSON
             f'bash "{_WATCHDOG_SCRIPT}"'
         )
 
+    @staticmethod
+    def _stale_ts(minutes: int = 120) -> str:
+        """A merge-queue label timestamp `minutes` in the past — recently stale.
+
+        Fixtures must use realistic stall ages: the watchdog now treats stalls
+        beyond MAX_STALL_MINUTES (7 days) as data errors from unset/zeroed
+        timestamps and skips them (#13343), so a hardcoded 2020 date would be
+        rejected rather than kicked.
+        """
+        import datetime
+
+        return (
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(minutes=minutes)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
     def test_stale_clean_pr_gets_label_cycled(self, tmp_path: Path) -> None:
-        stale_ts = "2020-01-01T00:00:00Z"
+        stale_ts = self._stale_ts()
         pr_list = (
             '[{"n":100,"t":"Stale clean PR","m":"MERGEABLE","ms":"CLEAN",'
             '"head":"tim/jov-100","L":["merge-queue"]}]'
@@ -636,7 +652,7 @@ JSON
         assert "skipped (fresh, <45m): 1" in result.stdout
 
     def test_recent_kick_is_skipped_via_cooldown(self, tmp_path: Path) -> None:
-        stale_ts = "2020-01-01T00:00:00Z"
+        stale_ts = self._stale_ts()
         recent_kick_ts = subprocess.run(
             ["date", "-u", "+%Y-%m-%dT%H:%M:%SZ"], capture_output=True, text=True, check=True
         ).stdout.strip()
@@ -672,7 +688,7 @@ JSON
     def test_conflicting_pr_gets_conflict_label_without_dequeue(
         self, tmp_path: Path
     ) -> None:
-        stale_ts = "2020-01-01T00:00:00Z"
+        stale_ts = self._stale_ts()
         pr_list = (
             '[{"n":103,"t":"Conflicting PR","m":"CONFLICTING","ms":"DIRTY",'
             '"head":"tim/jov-103","L":["merge-queue"]}]'
@@ -696,7 +712,7 @@ JSON
         assert "conflicts flagged: 1" in result.stdout
 
     def test_terminal_red_check_dequeues(self, tmp_path: Path) -> None:
-        stale_ts = "2020-01-01T00:00:00Z"
+        stale_ts = self._stale_ts()
         pr_list = (
             '[{"n":104,"t":"Red CI PR","m":"MERGEABLE","ms":"CLEAN",'
             '"head":"tim/jov-104","L":["merge-queue"]}]'
@@ -725,7 +741,7 @@ JSON
     ) -> None:
         # gh pr checks --required with --jq exits 8 on pending checks even with
         # valid JSON output (same behavior drain-pr-queue.sh guards against).
-        stale_ts = "2020-01-01T00:00:00Z"
+        stale_ts = self._stale_ts()
         pr_list = (
             '[{"n":105,"t":"Pending checks PR","m":"MERGEABLE","ms":"UNSTABLE",'
             '"head":"tim/jov-105","L":["merge-queue"]}]'
@@ -749,3 +765,57 @@ JSON
         # it falls through to the stuck-clean kick path instead.
         assert "dequeued (terminal red): 0" in result.stdout
         assert "kicked (label-cycled): 1" in result.stdout
+
+    def test_epoch_zero_timestamp_is_skipped_not_kicked(self, tmp_path: Path) -> None:
+        # Regression for #13343: an unset/epoch-0 enqueue timestamp computed a
+        # ~29.7M-minute "stall" and mass label-cycled freshly-enrolled PRs.
+        # Timestamps before 2020 are unset/zeroed data — skip, never kick.
+        pr_list = (
+            '[{"n":106,"t":"Epoch-zero PR","m":"MERGEABLE","ms":"CLEAN",'
+            '"head":"tim/jov-106","L":["merge-queue"]}]'
+        )
+        timeline = (
+            '[{"event":"labeled","label":{"name":"merge-queue"},'
+            '"created_at":"1970-01-01T00:00:00Z"}]'
+        )
+        self._fake_gh(
+            tmp_path,
+            pr_list_json=pr_list,
+            timeline_by_pr={106: timeline},
+            comments_by_pr={106: "[]"},
+            checks_by_pr={106: ("[]", 0)},
+        )
+
+        result = self._run_watchdog(tmp_path, extra_env="STALL_MINUTES=45")
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "no valid merge-queue label timestamp" in result.stdout
+        assert "kicked (label-cycled): 0" in result.stdout
+        assert "would -merge-queue" not in result.stdout
+
+    def test_absurdly_old_stall_is_treated_as_data_error(self, tmp_path: Path) -> None:
+        # Regression for #13343: a computed stall beyond MAX_STALL_MINUTES
+        # (default 7 days) can only come from bad timestamp data — the
+        # watchdog must skip it rather than kick, and must cite the timestamp.
+        pr_list = (
+            '[{"n":107,"t":"Ancient stall PR","m":"MERGEABLE","ms":"CLEAN",'
+            '"head":"tim/jov-107","L":["merge-queue"]}]'
+        )
+        timeline = (
+            '[{"event":"labeled","label":{"name":"merge-queue"},'
+            '"created_at":"2024-01-01T00:00:00Z"}]'
+        )
+        self._fake_gh(
+            tmp_path,
+            pr_list_json=pr_list,
+            timeline_by_pr={107: timeline},
+            comments_by_pr={107: "[]"},
+            checks_by_pr={107: ("[]", 0)},
+        )
+
+        result = self._run_watchdog(tmp_path, extra_env="STALL_MINUTES=45")
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "sanity cap" in result.stdout
+        assert "2024-01-01T00:00:00Z" in result.stdout
+        assert "kicked (label-cycled): 0" in result.stdout


### PR DESCRIPTION
## Problem
PR Conflict Handler failed 11/11 sampled runs while 4+ PRs sat drain-blocked (#13347).

## Diagnosis (log access unavailable — evidence-based)
- Job-log APIs are not exposed to this agent; diagnosis from run metadata + source:
- ALL event-triggered runs fail; schedule runs passed until Jul 2, failed Jul 3+ — failure onset tracks the open-PR count explosion, not a code change (scripts untouched since Jun 29).
- Failures are fast (~11s in the `Run handler` step) → a hard `gh` error, not rate-limit backoff.
- The handler's first call is `gh pr list --limit 200 --json ...statusCheckRollup...` — the rollup field makes this a very heavy GraphQL query that fails at blitz-scale PR counts. The old code only retried rate limits and hid the gh stderr (`console.error(error)` doesn't print `.stderr`), which is why 11 failures were undiagnosable from the Actions UI.

## What changed
`scripts/pr-conflict-handler.mjs`:
- `ghJson` retries transient GraphQL/timeout/5xx errors, not just rate limits, and prints gh stderr on final failure.
- Degraded fallback: if the bulk fetch WITH `statusCheckRollup` fails after retries, refetch WITHOUT it and classify from `mergeable`/`mergeStateStatus` (required-check gating disabled for that run — otherwise "not fetched" would read as "missing required check" and mislabel everything BLOCKED).
- `main().catch` now surfaces subprocess stderr so the next incident is diagnosable.

## Assumptions
- Root cause is the heavy rollup query; even if the true breakage is adjacent, the degraded path + stderr surfacing converts hard-fail-every-run into a working run + a diagnosable log line.
- Workflow trigger fix (drop redundant `pull_request: synchronize` — every push already fires the `workflow_run: CI completed` leg; #13293 tripled spawns for zero coverage) could NOT be pushed: the GitHub App token lacks `workflows` permission (403). Patch:
```diff
--- a/.github/workflows/pr-conflict-handler.yml
+++ b/.github/workflows/pr-conflict-handler.yml
@@ -25,8 +25,11 @@
   schedule:
     # Read-only audit. Do not auto-push/rebase the fleet on a tight cadence.
     - cron: '17 15 * * 1-5'
-  pull_request:
-    types: [synchronize]
+  # NOTE: no `pull_request: synchronize` trigger. This job is a FLEET-WIDE scan
+  # (it lists all open PRs), so per-push spawns are pure duplication: every push
+  # already leads to a CI completion, which fires the workflow_run trigger
+  # below. The synchronize leg added in #13293 tripled spawn volume at blitz
+  # load for zero added coverage (#13347, #13349).
   workflow_run:
     workflows: ['CI']
     types: [completed]
```
- Follow-up not implemented (needs state across runs): self-check that posts once to drain-blocked PRs after N consecutive handler failures.

## Verification
Sandbox has no npm registry access (dispatch-approved constraint), so verification was targeted per file type.
```
$ node --check scripts/pr-conflict-handler.mjs  # OK
# fake-gh harness: rollup query hard-fails -> retries -> degraded refetch -> plan emitted, exit 0
[degraded] classifying without check rollups: required-check gating disabled for this run...
Summary states: {"BEHIND":1} / actions: {"update_branch":1}  exit=0
$ /tmp/biome check scripts/pr-conflict-handler.mjs  # clean (formatted)
```

Dispatch: thread cmr8gcqgx26if07adig4stylt · Fixes #13347
