### PR TITLE
ci: taste classifier — uncertainty defaults to llm-reviewable; per-SHA dedupe + comment upsert (workflow patch attached)

### DIFF
--- a/.github/workflows/taste-classifier.yml
+++ b/.github/workflows/taste-classifier.yml
@@ -30,23 +30,55 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Dedup guard (#13348): classify once per head SHA, not once per event.
+      # Re-fires on synchronize bursts were posting 2-3 duplicate classification
+      # comments per PR. The marker comment records the classified SHA; if it
+      # matches the current head, skip the whole run.
+      - name: Check for existing classification of this head SHA
+        id: dedupe
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- bot-comment:taste-classifier -->';
+            const headSha = context.payload.pull_request.head.sha;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+            const alreadyClassified = Boolean(
+              existing?.body?.includes(`<!-- classified-sha:${headSha} -->`)
+            );
+            core.setOutput('skip', alreadyClassified ? 'true' : 'false');
+            core.setOutput('comment_id', existing ? String(existing.id) : '');
+            if (alreadyClassified) {
+              core.info(`Head ${headSha} already classified in comment ${existing.id}; skipping.`);
+            }
+
       - name: Checkout repository
+        if: steps.dedupe.outputs.skip != 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Enable corepack
+        if: steps.dedupe.outputs.skip != 'true'
         run: corepack enable
 
       - name: Setup Node 24
+        if: steps.dedupe.outputs.skip != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.dedupe.outputs.skip != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run taste classifier
         id: classify
+        if: steps.dedupe.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -57,8 +89,10 @@ jobs:
           echo "classification=$CLASSIFICATION" >> "$GITHUB_OUTPUT"
 
       - name: Post classification comment and apply label
-        if: steps.classify.outputs.classification != ''
+        if: steps.dedupe.outputs.skip != 'true' && steps.classify.outputs.classification != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          EXISTING_COMMENT_ID: ${{ steps.dedupe.outputs.comment_id }}
         with:
           script: |
             const fs = require('fs');
@@ -66,7 +100,11 @@ jobs:
 
             const { pr: prNumber, classification: result, confidence, reason, signals } = classification;
 
-            // Build comment
+            // Build comment with dedupe markers
+            const marker = '<!-- bot-comment:taste-classifier -->';
+            const headSha = context.payload.pull_request.head.sha;
+            const shaMarker = `<!-- classified-sha:${headSha} -->`;
+
             const emoji = {
               'taste-required': '🎨',
               'llm-reviewable': '🤖',
@@ -74,7 +112,8 @@ jobs:
             };
             const emojiIcon = emoji[result] || '🔍';
 
-            let comment = `## ${emojiIcon} Taste Classifier: \`${result}\`\n\n`;
+            let comment = `${marker}\n${shaMarker}\n`;
+            comment += `## ${emojiIcon} Taste Classifier: \`${result}\`\n\n`;
             comment += `**Confidence:** ${(confidence * 100).toFixed(0)}%\n`;
             comment += `**Reason:** ${reason}\n\n`;
 
@@ -96,13 +135,23 @@ jobs:
 
             comment += '\n*— Taste classifier v1.0 (autonomous shipping system)*';
 
-            // Post comment
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: comment,
-            });
+            // Upsert: edit existing comment if one exists
+            const existingId = process.env.EXISTING_COMMENT_ID;
+            if (existingId) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: parseInt(existingId),
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment,
+              });
+            }
 
             // Apply label
             const labelMap = {

--- a/scripts/taste-classifier.mjs
+++ b/scripts/taste-classifier.mjs
@@ -10,7 +10,8 @@
  *
  * Exit codes:
  *   0 = classified successfully
- *   2 = classification uncertain (default to taste-required)
+ *   2 = classification uncertain (defaults to llm-reviewable — the taste
+ *       gate only applies on a positive material-UX signal, JOV-3592)
  */
 
 import { execSync } from 'node:child_process';
@@ -423,11 +424,17 @@ export function classifyTaste(pr) {
     };
   }
 
-  // Uncertain → default to taste-required
+  // Uncertain → default to llm-reviewable, NOT taste-required. Standing owner
+  // rule (2026-06-26, JOV-3592): the taste label applies ONLY on a positive
+  // material-UX-change signal; uncertain/non-visual work must auto-flow to
+  // strong LLM review. Defaulting uncertain to taste-required grew the human
+  // gate to 51% of bot PRs (#13348). Flipped-by-default cases carry a
+  // `default:flipped-to-llm-reviewable` signal for the weekly audit.
+  signals.push('default:flipped-to-llm-reviewable');
   return {
-    classification: 'taste-required',
+    classification: 'llm-reviewable',
     confidence: 0.5,
-    reason: `Uncertain classification (score: +${tasteScore.toFixed(1)} vs -${nonTasteScore.toFixed(1)}), defaulting to taste-required`,
+    reason: `Uncertain classification (score: +${tasteScore.toFixed(1)} vs -${nonTasteScore.toFixed(1)}) — no positive taste signal, defaulting to llm-reviewable (JOV-3592; logged for weekly audit)`,
     signals: signals.slice(0, 10),
     stats: {
       tasteFiles,


### PR DESCRIPTION
## Problem
(1) Classifier re-fires 2-3× per PR and posts a fresh comment each time (78 comments/12h). (2) 51% of PRs default to `taste-required` on uncertainty, throttling the autonomous funnel against the standing rule that the taste gate needs a positive material-UX signal (JOV-3592) (#13348).

## What changed
`scripts/taste-classifier.mjs` (pushed):
- Uncertain classification now defaults to `llm-reviewable` (was `taste-required`), with a `default:flipped-to-llm-reviewable` signal logged on every flipped case for the weekly audit. `taste-required` still fires on positive signals (force labels, taste-score ≥3, material-UX marker), and `taste-approved` remains terminal.

`.github/workflows/taste-classifier.yml` (**NOT pushed — GitHub App token lacks `workflows` permission, 403**). The dedupe half of the fix is in this ready-to-apply patch:
- Pre-step checks for an existing `<!-- bot-comment:taste-classifier -->` marker comment recording the current head SHA (`<!-- classified-sha:... -->`); if present, the entire job short-circuits (classify once per push-batch, not per event).
- The comment step upserts the single marker comment (edit in place) instead of `createComment` every run.
```diff
--- a/.github/workflows/taste-classifier.yml
+++ b/.github/workflows/taste-classifier.yml
@@ -30,23 +30,55 @@
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Dedup guard (#13348): classify once per head SHA, not once per event.
+      # Re-fires on synchronize bursts were posting 2-3 duplicate classification
+      # comments per PR. The marker comment records the classified SHA; if it
+      # matches the current head, skip the whole run.
+      - name: Check for existing classification of this head SHA
+        id: dedupe
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- bot-comment:taste-classifier -->';
+            const headSha = context.payload.pull_request.head.sha;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+            const alreadyClassified = Boolean(
+              existing?.body?.includes(`<!-- classified-sha:${headSha} -->`)
+            );
+            core.setOutput('skip', alreadyClassified ? 'true' : 'false');
+            core.setOutput('comment_id', existing ? String(existing.id) : '');
+            if (alreadyClassified) {
+              core.info(`Head ${headSha} already classified in comment ${existing.id}; skipping.`);
+            }
+
       - name: Checkout repository
+        if: steps.dedupe.outputs.skip != 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Enable corepack
+        if: steps.dedupe.outputs.skip != 'true'
         run: corepack enable
 
       - name: Setup Node 24
+        if: steps.dedupe.outputs.skip != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.dedupe.outputs.skip != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run taste classifier
         id: classify
+        if: steps.dedupe.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -57,14 +89,18 @@
           echo "classification=$CLASSIFICATION" >> "$GITHUB_OUTPUT"
 
       - name: Post classification comment and apply label
-        if: steps.classify.outputs.classification != ''
+        if: steps.dedupe.outputs.skip != 'true' && steps.classify.outputs.classification != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          EXISTING_COMMENT_ID: ${{ steps.dedupe.outputs.comment_id }}
         with:
           script: |
             const fs = require('fs');
             const classification = JSON.parse(fs.readFileSync('taste-classification.json', 'utf8'));
 
             const { pr: prNumber, classification: result, confidence, reason, signals } = classification;
+            const marker = '<!-- bot-comment:taste-classifier -->';
+            const headSha = context.payload.pull_request.head.sha;
 
             // Build comment
             const emoji = {
@@ -95,14 +131,25 @@
             }
 
             comment += '\n*— Taste classifier v1.0 (autonomous shipping system)*';
+            comment = `${marker}\n<!-- classified-sha:${headSha} -->\n${comment}`;
 
-            // Post comment
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: comment,
-            });
+            // Upsert: ONE classifier comment per PR, edited in place (#13348).
+            const existingId = process.env.EXISTING_COMMENT_ID;
+            if (existingId) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: Number(existingId),
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment,
+              });
+            }
 
             // Apply label
             const labelMap = {
```

## Assumptions
- Label behavior unchanged (addLabels is additive); the concurrency group already cancels concurrent duplicate runs — the upsert kills the residual sequential duplicates.

## Verification
Sandbox has no npm registry access (dispatch-approved constraint), so verification was targeted per file type.
```
$ node --check scripts/taste-classifier.mjs   # OK
$ /tmp/biome check scripts/taste-classifier.mjs  # clean
# patched workflow YAML validated with yaml.safe_load  # OK
```

## Acceptance mapping
- uncertain → llm-reviewable ✅ (script, pushed) · ≤1 classifier comment per PR ⏳ (workflow patch attached, blocked on app `workflows` permission) · flipped-by-default cases logged ✅

Dispatch: thread cmr8gcqgx26if07adig4stylt · Fixes #13348
