### PR TITLE
ci: trigger hygiene — playbook + ready-to-apply workflow patches (blocked on app workflows permission)

### DIFF
--- a/.github/workflows/auto-ready-agent-drafts.yml
+++ b/.github/workflows/auto-ready-agent-drafts.yml
@@ -10,8 +10,12 @@ name: Auto-Ready Agent Drafts
 on:
   schedule:
     - cron: '*/15 * * * *'   # catch anything missed between CI events
+  # Trigger hygiene (#13349): no `synchronize` — every push starts CI, whose
+  # completion fires the workflow_run trigger below. A draft's checks can only
+  # turn green via a CI completion, so per-push spawns of this fleet-wide scan
+  # were pure duplication.
   pull_request:
-    types: [ready_for_review, reopened, synchronize]
+    types: [ready_for_review, reopened]
   workflow_run:
     workflows: ['CI']
     types: [completed]

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,8 +3,11 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
+  # Trigger hygiene (#13349): `assigned` dropped — the job-level `if:` already
+  # gates on @claude in body/title, which `opened` covers. Assignment events
+  # were pure duplicates that booted runners for no work.
   issues:
-    types: [opened, assigned]
+    types: [opened]
   # NOTE: pull_request_review AND pull_request_review_comment both removed.
   # Bot-submitted reviews/comments (CodeRabbit, Copilot) create
   # action_required runs that clog the CI queue and consume runner slots.

--- a/.github/workflows/github-ai-orchestrator.yml
+++ b/.github/workflows/github-ai-orchestrator.yml
@@ -27,6 +27,13 @@ env:
 jobs:
   guard:
     name: Guard + Deduplicate
+    # Trigger hygiene (#13349): `issues: labeled` fires for EVERY label event on
+    # every issue repo-wide, and GitHub cannot filter label names at the `on:`
+    # level. Gate at the job level so non-agent-ready label events conclude
+    # `skipped` without ever provisioning a runner — previously this job booted
+    # a runner just to echo "Label is not agent-ready; skipping".
+    # Keep in sync with env.AGENT_READY_LABEL (job-level `if:` cannot read env).
+    if: github.event_name != 'issues' || github.event.label.name == 'agent-ready'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/merge-queue-autoenroll.yml
+++ b/.github/workflows/merge-queue-autoenroll.yml
@@ -25,8 +25,12 @@ on:
   schedule:
     - cron: '*/20 * * * *'   # enroll: catch anything missed between events
     - cron: '*/10 * * * *'   # watchdog: rescue PRs stalled inside the queue
+  # Trigger hygiene (#13349): no `synchronize` — enrollment eligibility only
+  # changes when CI completes (workflow_run below) or a PR flips ready/reopens.
+  # Per-push spawns of this fleet-wide drain were pure duplication behind the
+  # shared mutex.
   pull_request:
-    types: [ready_for_review, reopened, synchronize]
+    types: [ready_for_review, reopened]
   workflow_run:
     workflows: ['CI']
     types: [completed]

--- a/docs/ci/trigger-hygiene.md
+++ b/docs/ci/trigger-hygiene.md
@@ -1,0 +1,1 @@
+placeholder-will-replace

--- a/docs/ci/trigger-hygiene.md
+++ b/docs/ci/trigger-hygiene.md
@@ -1,1 +1,56 @@
-placeholder-will-replace
+# Workflow trigger hygiene
+
+Why: at blitz volume the repo hit **3,770 workflow runs in 12h with ~53%
+concluding `skipped`** (#13349) — workflows spawning on events they immediately
+decide to ignore. Skipped runs still consume queue/scheduler overhead and
+pollute the Actions log, masking real failures. CI throughput is the binding
+constraint; spawn noise is the cheapest capacity to buy back.
+
+## Rules
+
+1. **Filter at the `on:` level whenever GitHub allows it** — event `types`,
+   `branches`, `paths`, `paths-ignore`. A non-matching event then never creates
+   a run at all. Do NOT add `paths` filters to workflows that produce required
+   status checks (path-skipped required checks stay pending and wedge the
+   merge queue) — use the path-changes job pattern inside CI instead.
+
+2. **Comment/review-driven workflows must stay broad** (`issue_comment`,
+   `pull_request_review` cannot filter body content at the `on:` level). Gate
+   with a **job-level `if:`** on the event payload — a job skipped by its `if:`
+   never provisions a runner. Never put the skip decision inside a `run:` step:
+   that boots a runner just to `exit 0` (this is what the AI Orchestrator guard
+   did for every non-`agent-ready` label event).
+
+3. **Fleet-wide scanners do not need per-push triggers.** Workflows that list
+   ALL open PRs and act on the fleet (merge-queue drain, auto-ready,
+   PR conflict handler) get zero extra coverage from `pull_request:
+   synchronize` — every push starts CI, whose completion already fires their
+   `workflow_run: [CI completed]` trigger. Per-push spawns just multiply
+   identical scans behind the shared mutex.
+
+4. **Deduplicate event types that add no coverage.** Example: `issues:
+   assigned` on Claude Code — the job only runs when the body/title contains
+   `@claude`, which `opened` already covers.
+
+5. **Measure before/after.** Runs-per-hour and skipped-share for a window:
+
+   ```bash
+   gh api "repos/JovieInc/Jovie/actions/runs?created=>$(date -u -d '12 hours ago' +%Y-%m-%dT%H:%M:%SZ)&per_page=100" \
+     --paginate --jq '.workflow_runs[] | [.name, .conclusion] | @tsv' \
+     | sort | uniq -c | sort -rn | head -30
+   ```
+
+   Acceptance for #13349: total runs/hr down ≥40% on a comparable-load day,
+   skipped share <20%, no legitimate trigger lost (spot-check one real event
+   per touched workflow).
+
+## Touched in #13349
+
+| Workflow | Change |
+| --- | --- |
+| `github-ai-orchestrator.yml` | Guard's label check moved from in-runner script to job-level `if:` |
+| `auto-ready-agent-drafts.yml` | Dropped `pull_request: synchronize` (covered by `workflow_run: CI completed`) |
+| `merge-queue-autoenroll.yml` | Dropped `pull_request: synchronize` (same) |
+| `pr-conflict-handler.yml` | Dropped `pull_request: synchronize` (same; see #13347) |
+| `claude.yml` | Dropped `issues: assigned` (no coverage beyond `opened`); documented broad-trigger rationale |
+| `taste-approve.yml` | Documented broad-trigger rationale (content triggers cannot be narrowed) |


### PR DESCRIPTION
## Problem
3,770 workflow runs in 12h, ~53% skipped — workflows spawning on events they immediately ignore (#13349).

## What changed (pushed)
- `docs/ci/trigger-hygiene.md`: the canonical cheap-gate playbook — when to filter at `on:` vs job-level `if:`, the fleet-scanner rule (workflow_run over per-push synchronize), and the before/after measurement command with acceptance thresholds.

## What is blocked (patches below — GitHub App token lacks `workflows` permission, every `.github/workflows/*` write 403s)
1. **github-ai-orchestrator.yml** — move the `agent-ready` label check from an in-runner script step to a job-level `if:`. Today every label event on every issue **boots a runner** just to echo "Label is not agent-ready; skipping". Biggest single win.
```diff
--- a/.github/workflows/github-ai-orchestrator.yml
+++ b/.github/workflows/github-ai-orchestrator.yml
@@ -27,6 +27,13 @@
 jobs:
   guard:
     name: Guard + Deduplicate
+    # Trigger hygiene (#13349): `issues: labeled` fires for EVERY label event on
+    # every issue repo-wide, and GitHub cannot filter label names at the `on:`
+    # level. Gate at the job level so non-agent-ready label events conclude
+    # `skipped` without ever provisioning a runner — previously this job booted
+    # a runner just to echo "Label is not agent-ready; skipping".
+    # Keep in sync with env.AGENT_READY_LABEL (job-level `if:` cannot read env).
+    if: github.event_name != 'issues' || github.event.label.name == 'agent-ready'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
```
2. **auto-ready-agent-drafts.yml** — drop `pull_request: synchronize` (fleet-wide scan; every push already fires its `workflow_run: CI completed` leg).
```diff
--- a/.github/workflows/auto-ready-agent-drafts.yml
+++ b/.github/workflows/auto-ready-agent-drafts.yml
@@ -10,8 +10,12 @@
 on:
   schedule:
     - cron: '*/15 * * * *'   # catch anything missed between CI events
+  # Trigger hygiene (#13349): no `synchronize` — every push starts CI, whose
+  # completion fires the workflow_run trigger below. A draft's checks can only
+  # turn green via a CI completion, so per-push spawns of this fleet-wide scan
+  # were pure duplication.
   pull_request:
-    types: [ready_for_review, reopened, synchronize]
+    types: [ready_for_review, reopened]
   workflow_run:
     workflows: ['CI']
     types: [completed]
```
3. **merge-queue-autoenroll.yml** — same synchronize drop for the drain.
```diff
--- a/.github/workflows/merge-queue-autoenroll.yml
+++ b/.github/workflows/merge-queue-autoenroll.yml
@@ -25,8 +25,12 @@
   schedule:
     - cron: '*/20 * * * *'   # enroll: catch anything missed between events
     - cron: '*/10 * * * *'   # watchdog: rescue PRs stalled inside the queue
+  # Trigger hygiene (#13349): no `synchronize` — enrollment eligibility only
+  # changes when CI completes (workflow_run below) or a PR flips ready/reopens.
+  # Per-push spawns of this fleet-wide drain were pure duplication behind the
+  # shared mutex.
   pull_request:
-    types: [ready_for_review, reopened, synchronize]
+    types: [ready_for_review, reopened]
   workflow_run:
     workflows: ['CI']
     types: [completed]
```
4. **claude.yml** — drop `issues: assigned` (job only runs on @claude in body/title, which `opened` covers; assignment events were pure duplicates) + document why `issue_comment` must stay broad.
```diff
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,10 +1,17 @@
 name: Claude Code
 
+# Trigger hygiene (#13349): comment-driven workflows cannot filter comment
+# content at the `on:` level, so `issue_comment` stays broad and the job-level
+# `if:` below is the cheap gate (a skipped job never provisions a runner).
+# See docs/ci/trigger-hygiene.md.
 on:
   issue_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    # `assigned` removed (#13349): the job only runs when the issue body/title
+    # contains @claude, which `opened` already covers — every assignment on a
+    # @claude issue was spawning a duplicate run.
+    types: [opened]
   # NOTE: pull_request_review AND pull_request_review_comment both removed.
   # Bot-submitted reviews/comments (CodeRabbit, Copilot) create
   # action_required runs that clog the CI queue and consume runner slots.
```
5. **taste-approve.yml** — doc comment only (content triggers can't be narrowed at `on:` level; job-level `if:` is already the cheap gate).
```diff
--- a/.github/workflows/taste-approve.yml
+++ b/.github/workflows/taste-approve.yml
@@ -13,6 +13,10 @@
 #   - On approval: remove `needs-human-taste`, add `merge-queue`, and hand off to
 #     Graphite. We do NOT bypass-merge; Graphite owns the actual merge.
 
+# Trigger hygiene (#13349): approval signals arrive as reviews/comments, whose
+# content GitHub cannot filter at the `on:` level — these triggers must stay
+# broad. The job-level `if:` below is the cheap gate (a skipped job never
+# provisions a runner). See docs/ci/trigger-hygiene.md.
 on:
   pull_request_review:
     types: [submitted]
```

(The pr-conflict-handler synchronize drop rides in the #13347 PR body.)

## Unblock options
- Grant the GitHub MCP app `workflows` permission and I'll push these directly, **or**
- apply the patches via any lane with workflow-write (Claude Code action, local `git apply`).

## Verification
All patched YAML validated with `yaml.safe_load`; job-level `if:` expressions use only `github.event.*` context (no env, which job-ifs can't read — noted inline).

Dispatch: thread cmr8gcqgx26if07adig4stylt · Fixes #13349
