### PR TITLE
docs: Ovie = /hud route; label Swift menu-bar repo as archived

### DIFF
--- a/docs/OVIE.md
+++ b/docs/OVIE.md
@@ -1,0 +1,26 @@
+# Ovie
+
+**Ovie is the Jovie web app's `/hud` route.** The canonical Ovie surface is
+`apps/web/app/hud/` (admin Ops HUD), served by the production web app.
+
+## History
+
+The original Ovie plan was a standalone Swift menu-bar app at
+[`JovieInc/ovie`](https://github.com/JovieInc/ovie). After founder direction
+(2026-07), that plan was deprecated: the Swift codebase is a **launcher
+only**, and the repo is **archived (read-only)** on GitHub. Do not reference
+the Swift repo as the current Ovie surface; any remaining mentions of the
+Swift app should be labeled "archived".
+
+- Deprecation issue: [#12894](https://github.com/JovieInc/Jovie/issues/12894)
+- Current surface: `apps/web/app/hud/page.tsx` (+ `/hud/wiki`, see
+  `docs/solutions/wiki-phase-1.md`)
+
+## Where things live now
+
+| Concern | Location |
+|---|---|
+| Ovie UI | `apps/web/app/hud/` in this repo |
+| Shipper loop the old app monitored | `scripts/hermes/` in this repo |
+| Ship-ledger contract | `scripts/hermes/lib/ship-ledger.ts` |
+| Archived Swift launcher | `JovieInc/ovie` (read-only) |


### PR DESCRIPTION
## Problem
Docs had no canonical statement that Ovie = the Jovie web `/hud` route; the deprecated Swift menu-bar repo needed archived labeling (#12894).

## What changed
- New `docs/OVIE.md`: canonical note that Ovie is `apps/web/app/hud/`, Swift repo `JovieInc/ovie` is a launcher only and archived, plus a where-things-live-now table.
- Companion commit already landed on `JovieInc/ovie` main (JovieInc/ovie@4048cba): archived banner at the top of its README pointing to `/hud` (had to land before the repo goes read-only).

## Assumptions
- Repo-wide search found **zero** docs in this repo referencing `JovieInc/ovie`, `OvieTheme.swift`, or `OvieMainView.swift` as the current Ovie surface — so no existing docs needed edits; the affirmative note is the missing piece.
- `apps/web/app/hud/page.tsx` header comment and `scripts/hermes/lib/ship-ledger.ts` comments mention the "Ovie menu bar / Mac app" as a *consumer* of these surfaces — factually accurate while the launcher still runs; left untouched (minimal diff).
- Pre-existing dangling link in `docs/solutions/README.md` → `./ovie-mvp-ship.md` (file absent on main). Not fixed here (separate surface); flagging for follow-up.
- gbrain `decisions/ovie-convergence-roadmap` (2026-07-02) is consistent with this change; no strategy detail included in this public doc.

## Verification
Docs-only change (one new markdown file, no source/code/config touched). `pnpm turbo lint typecheck test:fast --affected` has no affected targets for a net-new `docs/*.md`; CI structural-contract (incl. `doc:freshness:check`) runs on this PR as the gate.

## Human step required (cannot be done via GitHub MCP)
Archiving `JovieInc/ovie` (Settings → Danger Zone → Archive this repository) is an admin dashboard action not exposed to the agent toolset. Called out on #12894.

Dispatch: #12894
Closes #12894 (pending the archive toggle above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)