### PR TITLE
agent-os: visual QA review store (part 1/2 — land first)

### DIFF
--- a/apps/web/lib/agent-os/visual-qa/review.ts
+++ b/apps/web/lib/agent-os/visual-qa/review.ts
@@ -1,0 +1,313 @@
+import type { Dirent } from 'node:fs';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { z } from 'zod';
+import {
+  type AgentRunArtifact,
+  parseAgentRunArtifact,
+} from '@/lib/agent-os/artifact';
+import type {
+  VisualQaDiffRunSummary,
+  VisualQaSurfaceDiffRecord,
+} from '@/lib/agent-os/visual-qa/diff-artifacts';
+import {
+  assertValidVisualQaRunId,
+  getVisualQaRootDirectory,
+  resolveVisualQaRunRelativePath,
+} from '@/lib/agent-os/visual-qa/paths';
+
+export const VISUAL_QA_REVIEW_FILE_NAME = 'review.json';
+
+export const VISUAL_QA_REVIEW_DECISIONS = ['accepted', 'rejected'] as const;
+export type VisualQaReviewDecision =
+  (typeof VISUAL_QA_REVIEW_DECISIONS)[number];
+
+export const VISUAL_QA_FOLLOW_UP_ACTIONS = [
+  'd2_review',
+  'design_html_builder',
+] as const;
+export type VisualQaFollowUpAction =
+  (typeof VISUAL_QA_FOLLOW_UP_ACTIONS)[number];
+
+export const VisualQaSurfaceReviewRecordSchema = z.object({
+  surfaceId: z.string().trim().min(1),
+  decision: z.enum(VISUAL_QA_REVIEW_DECISIONS),
+  reviewer: z.string().trim().min(1),
+  reviewedAt: z.string().datetime(),
+  notes: z.string().trim().min(1).nullable(),
+  followUpAction: z.enum(VISUAL_QA_FOLLOW_UP_ACTIONS).nullable(),
+  dispatchId: z.string().trim().min(1).nullable(),
+});
+export type VisualQaSurfaceReviewRecord = z.infer<
+  typeof VisualQaSurfaceReviewRecordSchema
+>;
+
+export const VisualQaRunReviewFileSchema = z.object({
+  runId: z.string().trim().min(1),
+  reviews: z.record(z.string(), VisualQaSurfaceReviewRecordSchema),
+});
+export type VisualQaRunReviewFile = z.infer<typeof VisualQaRunReviewFileSchema>;
+
+export interface VisualQaReviewSurface extends VisualQaSurfaceDiffRecord {
+  readonly review: VisualQaSurfaceReviewRecord | null;
+}
+
+export interface VisualQaReviewRun {
+  readonly runId: string;
+  readonly computedAt: string;
+  readonly passed: boolean;
+  readonly surfaces: readonly VisualQaReviewSurface[];
+}
+
+export class VisualQaReviewError extends Error {
+  constructor(
+    message: string,
+    readonly code: 'not_found' | 'already_reviewed'
+  ) {
+    super(message);
+    this.name = 'VisualQaReviewError';
+  }
+}
+
+function isDiffRunSummary(value: unknown): value is VisualQaDiffRunSummary {
+  if (!value || typeof value !== 'object') return false;
+  const summary = value as Partial<VisualQaDiffRunSummary>;
+  return (
+    typeof summary.runId === 'string' &&
+    typeof summary.computedAt === 'string' &&
+    typeof summary.passed === 'boolean' &&
+    Array.isArray(summary.surfaces) &&
+    summary.surfaces.every(
+      surface =>
+        surface !== null &&
+        typeof surface === 'object' &&
+        typeof surface.surfaceId === 'string' &&
+        typeof surface.title === 'string' &&
+        typeof surface.status === 'string'
+    )
+  );
+}
+
+function isFileMissingError(error: unknown): boolean {
+  return (
+    error instanceof Error && 'code' in error && error.code === 'ENOENT'
+  );
+}
+
+async function readDiffRunSummary(
+  runId: string
+): Promise<VisualQaDiffRunSummary | null> {
+  try {
+    const raw = await readFile(
+      resolveVisualQaRunRelativePath(runId, 'diff-summary.json'),
+      'utf8'
+    );
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isDiffRunSummary(parsed) || parsed.runId !== runId) {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    if (isFileMissingError(error)) return null;
+    throw error;
+  }
+}
+
+export async function readVisualQaRunReview(
+  runId: string
+): Promise<VisualQaRunReviewFile> {
+  const safeRunId = assertValidVisualQaRunId(runId);
+  try {
+    const raw = await readFile(
+      resolveVisualQaRunRelativePath(safeRunId, VISUAL_QA_REVIEW_FILE_NAME),
+      'utf8'
+    );
+    const parsed = VisualQaRunReviewFileSchema.safeParse(JSON.parse(raw));
+    if (parsed.success && parsed.data.runId === safeRunId) {
+      return parsed.data;
+    }
+  } catch (error) {
+    if (!isFileMissingError(error)) throw error;
+  }
+
+  return { runId: safeRunId, reviews: {} };
+}
+
+async function writeVisualQaRunReview(
+  review: VisualQaRunReviewFile
+): Promise<void> {
+  await writeFile(
+    resolveVisualQaRunRelativePath(review.runId, VISUAL_QA_REVIEW_FILE_NAME),
+    `${JSON.stringify(review, null, 2)}\n`,
+    'utf8'
+  );
+}
+
+export async function getVisualQaReviewRun(
+  runId: string
+): Promise<VisualQaReviewRun | null> {
+  return toReviewRun(assertValidVisualQaRunId(runId));
+}
+
+async function toReviewRun(runId: string): Promise<VisualQaReviewRun | null> {
+  const summary = await readDiffRunSummary(runId);
+  if (!summary) return null;
+
+  const reviewFile = await readVisualQaRunReview(runId);
+
+  return {
+    runId: summary.runId,
+    computedAt: summary.computedAt,
+    passed: summary.passed,
+    surfaces: summary.surfaces.map(surface => ({
+      ...surface,
+      review: reviewFile.reviews[surface.surfaceId] ?? null,
+    })),
+  };
+}
+
+export async function listVisualQaReviewRuns(
+  limit = 6
+): Promise<readonly VisualQaReviewRun[]> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(getVisualQaRootDirectory(), {
+      withFileTypes: true,
+    });
+  } catch (error) {
+    if (isFileMissingError(error)) return [];
+    throw error;
+  }
+
+  const runs: VisualQaReviewRun[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    let run: VisualQaReviewRun | null = null;
+    try {
+      run = await toReviewRun(entry.name);
+    } catch {
+      // Skip runs with unreadable/invalid ids or corrupt summaries.
+      continue;
+    }
+    if (run) runs.push(run);
+  }
+
+  return runs
+    .sort(
+      (a, b) =>
+        new Date(b.computedAt).getTime() - new Date(a.computedAt).getTime()
+    )
+    .slice(0, limit);
+}
+
+export async function reviewVisualQaSurface(params: {
+  readonly runId: string;
+  readonly surfaceId: string;
+  readonly decision: VisualQaReviewDecision;
+  readonly notes: string | null;
+  readonly reviewer: string;
+  readonly followUpAction: VisualQaFollowUpAction | null;
+  readonly dispatchId: string | null;
+}): Promise<VisualQaSurfaceReviewRecord> {
+  const summary = await readDiffRunSummary(params.runId);
+  if (!summary) {
+    throw new VisualQaReviewError(
+      'Visual QA run not found.',
+      'not_found'
+    );
+  }
+
+  const surface = summary.surfaces.find(
+    candidate => candidate.surfaceId === params.surfaceId
+  );
+  if (!surface) {
+    throw new VisualQaReviewError(
+      'Visual QA surface not found.',
+      'not_found'
+    );
+  }
+
+  const reviewFile = await readVisualQaRunReview(params.runId);
+  if (reviewFile.reviews[params.surfaceId]) {
+    throw new VisualQaReviewError(
+      'Visual QA surface has already been reviewed.',
+      'already_reviewed'
+    );
+  }
+
+  const record: VisualQaSurfaceReviewRecord = {
+    surfaceId: params.surfaceId,
+    decision: params.decision,
+    reviewer: params.reviewer,
+    reviewedAt: new Date().toISOString(),
+    notes: params.notes?.trim() ? params.notes.trim() : null,
+    followUpAction: params.decision === 'rejected' ? params.followUpAction : null,
+    dispatchId: params.dispatchId,
+  };
+
+  await writeVisualQaRunReview({
+    runId: reviewFile.runId,
+    reviews: { ...reviewFile.reviews, [params.surfaceId]: record },
+  });
+
+  return record;
+}
+
+/**
+ * Stamps a run's review decisions onto an AgentRunArtifact whose
+ * metadata.visualQaDiff matches the reviewed run: records per-surface
+ * decisions under metadata.visualQaReview and resolves the human gate to
+ * approved/rejected once every drifted surface has a decision.
+ */
+export function applyVisualQaReviewToAgentRunArtifact(
+  artifact: AgentRunArtifact,
+  reviewFile: VisualQaRunReviewFile
+): AgentRunArtifact {
+  const visualQaDiff = artifact.metadata?.visualQaDiff as
+    | { runId?: unknown; surfaces?: readonly { surfaceId?: unknown; status?: unknown }[] }
+    | undefined;
+
+  if (!visualQaDiff || visualQaDiff.runId !== reviewFile.runId) {
+    return artifact;
+  }
+
+  const driftedSurfaceIds = (visualQaDiff.surfaces ?? [])
+    .filter(surface => surface.status === 'drift_detected')
+    .map(surface => surface.surfaceId)
+    .filter((surfaceId): surfaceId is string => typeof surfaceId === 'string');
+
+  const decisions = driftedSurfaceIds
+    .map(surfaceId => reviewFile.reviews[surfaceId])
+    .filter(
+      (record): record is VisualQaSurfaceReviewRecord => record !== undefined
+    );
+  const allReviewed =
+    driftedSurfaceIds.length > 0 &&
+    decisions.length === driftedSurfaceIds.length;
+  const anyRejected = decisions.some(record => record.decision === 'rejected');
+  const latestReviewedAt = decisions
+    .map(record => record.reviewedAt)
+    .sort()
+    .at(-1);
+
+  const shouldResolveHumanGate = allReviewed && artifact.humanGate.required;
+
+  return parseAgentRunArtifact({
+    ...artifact,
+    metadata: {
+      ...artifact.metadata,
+      visualQaReview: {
+        runId: reviewFile.runId,
+        reviews: reviewFile.reviews,
+      },
+    },
+    humanGate: shouldResolveHumanGate
+      ? {
+          ...artifact.humanGate,
+          status: anyRejected ? 'rejected' : 'approved',
+          reviewer: decisions[0]?.reviewer ?? artifact.humanGate.reviewer,
+          reviewedAt: latestReviewedAt ?? artifact.humanGate.reviewedAt,
+        }
+      : artifact.humanGate,
+  });
+}

--- a/apps/web/lib/agent-os/visual-qa/review.ts
+++ b/apps/web/lib/agent-os/visual-qa/review.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/agent-os/visual-qa/paths';
 
 export const VISUAL_QA_REVIEW_FILE_NAME = 'review.json';
+export const VISUAL_QA_ARTIFACT_FILE_NAME = 'artifact.json';
 
 export const VISUAL_QA_REVIEW_DECISIONS = ['accepted', 'rejected'] as const;
 export type VisualQaReviewDecision =
@@ -251,6 +252,41 @@ export async function reviewVisualQaSurface(params: {
   });
 
   return record;
+}
+
+/**
+ * Applies the run's current review decisions to the AgentRunArtifact
+ * persisted at agentos/runs/visual-qa/<runId>/artifact.json (written by the
+ * capture harness when artifact persistence is enabled). Returns false when
+ * no artifact file exists for the run.
+ */
+export async function applyVisualQaReviewToRunArtifactFile(
+  runId: string
+): Promise<boolean> {
+  const safeRunId = assertValidVisualQaRunId(runId);
+  const artifactPath = resolveVisualQaRunRelativePath(
+    safeRunId,
+    VISUAL_QA_ARTIFACT_FILE_NAME
+  );
+
+  let raw: string;
+  try {
+    raw = await readFile(artifactPath, 'utf8');
+  } catch (error) {
+    if (isFileMissingError(error)) return false;
+    throw error;
+  }
+
+  const artifact = parseAgentRunArtifact(JSON.parse(raw));
+  const reviewFile = await readVisualQaRunReview(safeRunId);
+  const updated = applyVisualQaReviewToAgentRunArtifact(artifact, reviewFile);
+
+  await writeFile(
+    artifactPath,
+    `${JSON.stringify(updated, null, 2)}\n`,
+    'utf8'
+  );
+  return true;
 }
 
 /**

--- a/apps/web/lib/agent-os/visual-qa/review.ts
+++ b/apps/web/lib/agent-os/visual-qa/review.ts
@@ -89,9 +89,7 @@ function isDiffRunSummary(value: unknown): value is VisualQaDiffRunSummary {
 }
 
 function isFileMissingError(error: unknown): boolean {
-  return (
-    error instanceof Error && 'code' in error && error.code === 'ENOENT'
-  );
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
 }
 
 async function readDiffRunSummary(
@@ -193,12 +191,11 @@ export async function listVisualQaReviewRuns(
     if (run) runs.push(run);
   }
 
-  return runs
-    .sort(
-      (a, b) =>
-        new Date(b.computedAt).getTime() - new Date(a.computedAt).getTime()
-    )
-    .slice(0, limit);
+  const sortedRuns = runs.toSorted(
+    (a, b) =>
+      new Date(b.computedAt).getTime() - new Date(a.computedAt).getTime()
+  );
+  return sortedRuns.slice(0, limit);
 }
 
 export async function reviewVisualQaSurface(params: {
@@ -212,20 +209,14 @@ export async function reviewVisualQaSurface(params: {
 }): Promise<VisualQaSurfaceReviewRecord> {
   const summary = await readDiffRunSummary(params.runId);
   if (!summary) {
-    throw new VisualQaReviewError(
-      'Visual QA run not found.',
-      'not_found'
-    );
+    throw new VisualQaReviewError('Visual QA run not found.', 'not_found');
   }
 
-  const surface = summary.surfaces.find(
+  const surfaceExists = summary.surfaces.some(
     candidate => candidate.surfaceId === params.surfaceId
   );
-  if (!surface) {
-    throw new VisualQaReviewError(
-      'Visual QA surface not found.',
-      'not_found'
-    );
+  if (!surfaceExists) {
+    throw new VisualQaReviewError('Visual QA surface not found.', 'not_found');
   }
 
   const reviewFile = await readVisualQaRunReview(params.runId);
@@ -242,7 +233,8 @@ export async function reviewVisualQaSurface(params: {
     reviewer: params.reviewer,
     reviewedAt: new Date().toISOString(),
     notes: params.notes?.trim() ? params.notes.trim() : null,
-    followUpAction: params.decision === 'rejected' ? params.followUpAction : null,
+    followUpAction:
+      params.decision === 'rejected' ? params.followUpAction : null,
     dispatchId: params.dispatchId,
   };
 
@@ -300,7 +292,10 @@ export function applyVisualQaReviewToAgentRunArtifact(
   reviewFile: VisualQaRunReviewFile
 ): AgentRunArtifact {
   const visualQaDiff = artifact.metadata?.visualQaDiff as
-    | { runId?: unknown; surfaces?: readonly { surfaceId?: unknown; status?: unknown }[] }
+    | {
+        runId?: unknown;
+        surfaces?: readonly { surfaceId?: unknown; status?: unknown }[];
+      }
     | undefined;
 
   if (!visualQaDiff || visualQaDiff.runId !== reviewFile.runId) {
@@ -321,10 +316,13 @@ export function applyVisualQaReviewToAgentRunArtifact(
     driftedSurfaceIds.length > 0 &&
     decisions.length === driftedSurfaceIds.length;
   const anyRejected = decisions.some(record => record.decision === 'rejected');
-  const latestReviewedAt = decisions
-    .map(record => record.reviewedAt)
-    .sort()
-    .at(-1);
+  const latestReviewedAt = decisions.reduce<string | undefined>(
+    (latest, record) =>
+      latest === undefined || record.reviewedAt > latest
+        ? record.reviewedAt
+        : latest,
+    undefined
+  );
 
   const shouldResolveHumanGate = allReviewed && artifact.humanGate.required;
 

--- a/apps/web/tests/unit/agent-os/visual-qa/review.test.ts
+++ b/apps/web/tests/unit/agent-os/visual-qa/review.test.ts
@@ -1,10 +1,11 @@
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
 import { getVisualQaRootDirectory } from '@/lib/agent-os/visual-qa/paths';
 import {
   applyVisualQaReviewToAgentRunArtifact,
+  applyVisualQaReviewToRunArtifactFile,
   getVisualQaReviewRun,
   listVisualQaReviewRuns,
   readVisualQaRunReview,
@@ -224,6 +225,42 @@ describe('visual-qa review store', () => {
     expect(updated.humanGate.status).toBe('rejected');
     expect(updated.humanGate.reviewer).toBe('admin@jovie.test');
     expect(updated.metadata.visualQaReview).toMatchObject({ runId });
+  });
+
+  it('updates a persisted artifact.json when present and reports absence otherwise', async () => {
+    await seedRun();
+
+    expect(await applyVisualQaReviewToRunArtifactFile(runId)).toBe(false);
+
+    const artifactPath = path.join(
+      getVisualQaRootDirectory(),
+      runId,
+      'artifact.json'
+    );
+    await writeFile(
+      artifactPath,
+      `${JSON.stringify(buildArtifact(), null, 2)}\n`,
+      'utf8'
+    );
+
+    await reviewVisualQaSurface({
+      runId,
+      surfaceId: 'shell-desktop-idle',
+      decision: 'accepted',
+      notes: null,
+      reviewer: 'admin@jovie.test',
+      followUpAction: null,
+      dispatchId: null,
+    });
+
+    expect(await applyVisualQaReviewToRunArtifactFile(runId)).toBe(true);
+
+    const persisted = JSON.parse(await readFile(artifactPath, 'utf8')) as {
+      humanGate: { status: string };
+      metadata: { visualQaReview?: { runId: string } };
+    };
+    expect(persisted.humanGate.status).toBe('approved');
+    expect(persisted.metadata.visualQaReview?.runId).toBe(runId);
   });
 
   it('leaves the artifact untouched when the run id does not match', async () => {

--- a/apps/web/tests/unit/agent-os/visual-qa/review.test.ts
+++ b/apps/web/tests/unit/agent-os/visual-qa/review.test.ts
@@ -1,0 +1,238 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
+import { getVisualQaRootDirectory } from '@/lib/agent-os/visual-qa/paths';
+import {
+  applyVisualQaReviewToAgentRunArtifact,
+  getVisualQaReviewRun,
+  listVisualQaReviewRuns,
+  readVisualQaRunReview,
+  reviewVisualQaSurface,
+  VisualQaReviewError,
+} from '@/lib/agent-os/visual-qa/review';
+
+const runId = 'unit-review-demo';
+
+function buildDiffSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    runId,
+    computedAt: '2026-07-06T00:00:00.000Z',
+    passed: false,
+    surfaces: [
+      {
+        surfaceId: 'shell-desktop-idle',
+        title: 'Shell Desktop Idle',
+        baselinePath: 'shell-desktop-idle/baseline-dark.png',
+        afterPath: 'shell-desktop-idle/after-dark.png',
+        overlayPath: `${runId}/shell-desktop-idle/diff-overlay.png`,
+        rawDiffRatio: 0.12,
+        weightedDriftScore: 0.09,
+        threshold: 0.02,
+        status: 'drift_detected',
+        regionScores: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+async function seedRun(): Promise<void> {
+  const runDirectory = path.join(getVisualQaRootDirectory(), runId);
+  await mkdir(runDirectory, { recursive: true });
+  await writeFile(
+    path.join(runDirectory, 'diff-summary.json'),
+    `${JSON.stringify(buildDiffSummary(), null, 2)}\n`,
+    'utf8'
+  );
+}
+
+function buildArtifact(): AgentRunArtifact {
+  return {
+    id: 'run-visual-qa-1',
+    source: 'ci',
+    sourceRunId: null,
+    kind: 'qa',
+    status: 'review',
+    title: 'Visual QA run',
+    summary: 'Post-deploy visual QA diff run.',
+    modelRoute: 'deterministic',
+    allowedActions: ['read'],
+    forbiddenActions: [],
+    humanApprovalRequired: true,
+    humanGate: {
+      required: true,
+      status: 'pending',
+      reason: 'Visual drift requires review.',
+      reviewer: null,
+      reviewedAt: null,
+    },
+    linearIssueId: null,
+    linearIssueUrl: null,
+    pullRequestUrl: null,
+    adminSurface: '/app/admin/ops',
+    verificationGates: [],
+    costEstimate: null,
+    blockedReason: null,
+    createdAt: '2026-07-06T00:00:00.000Z',
+    updatedAt: '2026-07-06T00:00:00.000Z',
+    metadata: {
+      visualQaDiff: {
+        runId,
+        surfaces: [
+          { surfaceId: 'shell-desktop-idle', status: 'drift_detected' },
+        ],
+      },
+    },
+  };
+}
+
+describe('visual-qa review store', () => {
+  afterEach(async () => {
+    await rm(path.join(getVisualQaRootDirectory(), runId), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('lists runs with null review state before any decision', async () => {
+    await seedRun();
+
+    const runs = await listVisualQaReviewRuns();
+    const run = runs.find(candidate => candidate.runId === runId);
+
+    expect(run).toBeDefined();
+    expect(run?.surfaces).toHaveLength(1);
+    expect(run?.surfaces[0]?.review).toBeNull();
+  });
+
+  it('persists an accept decision and surfaces it on reads', async () => {
+    await seedRun();
+
+    const record = await reviewVisualQaSurface({
+      runId,
+      surfaceId: 'shell-desktop-idle',
+      decision: 'accepted',
+      notes: 'Intentional redesign.',
+      reviewer: 'admin@jovie.test',
+      followUpAction: null,
+      dispatchId: null,
+    });
+
+    expect(record.decision).toBe('accepted');
+    expect(record.notes).toBe('Intentional redesign.');
+    expect(record.followUpAction).toBeNull();
+
+    const run = await getVisualQaReviewRun(runId);
+    expect(run?.surfaces[0]?.review?.decision).toBe('accepted');
+
+    const reviewFile = await readVisualQaRunReview(runId);
+    expect(reviewFile.reviews['shell-desktop-idle']?.reviewer).toBe(
+      'admin@jovie.test'
+    );
+  });
+
+  it('records follow-up routing on reject', async () => {
+    await seedRun();
+
+    const record = await reviewVisualQaSurface({
+      runId,
+      surfaceId: 'shell-desktop-idle',
+      decision: 'rejected',
+      notes: null,
+      reviewer: 'admin@jovie.test',
+      followUpAction: 'd2_review',
+      dispatchId: 'dispatch-123',
+    });
+
+    expect(record.followUpAction).toBe('d2_review');
+    expect(record.dispatchId).toBe('dispatch-123');
+  });
+
+  it('rejects double reviews of the same surface', async () => {
+    await seedRun();
+
+    await reviewVisualQaSurface({
+      runId,
+      surfaceId: 'shell-desktop-idle',
+      decision: 'accepted',
+      notes: null,
+      reviewer: 'admin@jovie.test',
+      followUpAction: null,
+      dispatchId: null,
+    });
+
+    await expect(
+      reviewVisualQaSurface({
+        runId,
+        surfaceId: 'shell-desktop-idle',
+        decision: 'rejected',
+        notes: null,
+        reviewer: 'admin@jovie.test',
+        followUpAction: 'd2_review',
+        dispatchId: null,
+      })
+    ).rejects.toMatchObject({ code: 'already_reviewed' });
+  });
+
+  it('throws not_found for unknown runs and surfaces', async () => {
+    await expect(
+      reviewVisualQaSurface({
+        runId: 'missing-run',
+        surfaceId: 'shell-desktop-idle',
+        decision: 'accepted',
+        notes: null,
+        reviewer: 'admin@jovie.test',
+        followUpAction: null,
+        dispatchId: null,
+      })
+    ).rejects.toBeInstanceOf(VisualQaReviewError);
+
+    await seedRun();
+
+    await expect(
+      reviewVisualQaSurface({
+        runId,
+        surfaceId: 'missing-surface',
+        decision: 'accepted',
+        notes: null,
+        reviewer: 'admin@jovie.test',
+        followUpAction: null,
+        dispatchId: null,
+      })
+    ).rejects.toMatchObject({ code: 'not_found' });
+  });
+
+  it('resolves the artifact human gate once all drifted surfaces are reviewed', async () => {
+    await seedRun();
+    await reviewVisualQaSurface({
+      runId,
+      surfaceId: 'shell-desktop-idle',
+      decision: 'rejected',
+      notes: null,
+      reviewer: 'admin@jovie.test',
+      followUpAction: 'd2_review',
+      dispatchId: null,
+    });
+
+    const reviewFile = await readVisualQaRunReview(runId);
+    const updated = applyVisualQaReviewToAgentRunArtifact(
+      buildArtifact(),
+      reviewFile
+    );
+
+    expect(updated.humanGate.status).toBe('rejected');
+    expect(updated.humanGate.reviewer).toBe('admin@jovie.test');
+    expect(updated.metadata.visualQaReview).toMatchObject({ runId });
+  });
+
+  it('leaves the artifact untouched when the run id does not match', async () => {
+    const artifact = buildArtifact();
+    const updated = applyVisualQaReviewToAgentRunArtifact(artifact, {
+      runId: 'some-other-run',
+      reviews: {},
+    });
+
+    expect(updated).toEqual(artifact);
+  });
+});


### PR DESCRIPTION
**Problem:** Visual QA runs (post-deploy capture harness, #13273) write diff summaries to `agentos/runs/visual-qa/<runId>/` but there is no way to record an admin's accept/reject decision or reflect it on the AgentRunArtifact. (Part 1/2 of #8226 — land first.)

## What changed
- `lib/agent-os/visual-qa/review.ts`: filesystem-backed review store — `review.json` sidecar per run with per-surface `accepted`/`rejected` records (reviewer, notes, follow-up action, dispatch id); `listVisualQaReviewRuns()` / `getVisualQaReviewRun()` merge diff summaries with review state; `applyVisualQaReviewToAgentRunArtifact()` stamps `metadata.visualQaReview` and resolves the human gate to approved/rejected once every drifted surface is reviewed (only when `humanGate.required`, preserving schema invariants).
- Unit tests covering list/read/write, double-review 409 semantics, not-found errors, and human-gate resolution.

## Assumptions
- AgentRunArtifacts are not DB-persisted (HUD uses fixtures; workflow runs return them transiently), so the durable review record lives in the run directory beside `diff-summary.json`, mirroring how `attach-artifact.ts` layers diff data onto artifacts. `applyVisualQaReviewToAgentRunArtifact` is the hook for whatever loads artifacts.
- A surface review is immutable once made (409 on re-review), same as design-lab proposals.

## Verification
Local `pnpm install` was blocked (sandbox: registry.npmjs.org 403, network grant requested but not approved during the run), so lint/typecheck/test could not run locally:
```
$ curl -s -o /dev/null -w "%{http_code}" https://registry.npmjs.org/pnpm
403
```
Verification deferred to CI — `Unit Tests` lane runs `tests/unit/agent-os/visual-qa/review.test.ts`. Keeping as draft until CI is green.

Dispatch: issue-8226 · Closes nothing on its own; part 2 completes #8226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)