### PR TITLE
ci: wire 7 more jobs to self-hosted runner (10 total)

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -13,9 +13,13 @@ runs:
     - name: Trust workspace for git (self-hosted ownership)
       shell: bash
       run: |
-        git config --global --get-all safe.directory \
-          | grep -qxF "$GITHUB_WORKSPACE" \
-          || git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        # No-op when git is not in PATH (minimal self-hosted runner environments).
+        # The safe.directory concern only applies when git is actually used.
+        if command -v git &>/dev/null; then
+          git config --global --get-all safe.directory \
+            | grep -qxF "$GITHUB_WORKSPACE" \
+            || git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        fi
 
     - name: Setup pnpm
       uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -20,4 +20,4 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install --offline --frozen-lockfile
+      run: pnpm install --frozen-lockfile

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -4,6 +4,19 @@ description: 'Sets up Node.js, pnpm, and installs dependencies with optimal cach
 runs:
   using: 'composite'
   steps:
+    # Self-hosted runners reuse a workspace whose owner can differ from the job
+    # user, tripping git's dubious-ownership guard. That makes turbo's SCM probe
+    # report the checkout as "not part of a Git repository" and breaks
+    # `turbo --affected` (typecheck/build/unit tests). Trust the workspace so SCM
+    # detection works. No-op on hosted runners. Idempotent to avoid bloating the
+    # self-hosted ~/.gitconfig across runs.
+    - name: Trust workspace for git (self-hosted ownership)
+      shell: bash
+      run: |
+        git config --global --get-all safe.directory \
+          | grep -qxF "$GITHUB_WORKSPACE" \
+          || git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
     - name: Setup pnpm
       uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       

--- a/.github/workflows/runner-health-monitor.yml
+++ b/.github/workflows/runner-health-monitor.yml
@@ -1,0 +1,129 @@
+name: Runner Health Monitor
+
+# Heartbeat fallback: when the self-hosted OrbStack runner pool goes offline
+# (MBP sleep/reboot/travel), auto-flip CI_FAST_RUNNER from jovie-runner to
+# ubuntu-latest so CI doesn't queue forever. Flips back when runners return.
+#
+# Detects 2+ consecutive lost heartbeats before flipping to avoid flapping
+# on brief network blips.
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'   # every 5 minutes
+  workflow_dispatch:         # manual trigger for testing
+
+permissions:
+  contents: read
+  actions: write             # needed to read runners + update repo variables
+
+jobs:
+  monitor:
+    name: Check runner health
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TARGET_VARIABLE: CI_FAST_RUNNER
+      OFFLINE_TARGET: ubuntu-latest
+      ONLINE_TARGET: jovie-runner
+    steps:
+      - name: Query runner status
+        id: runners
+        run: |
+          set -euo pipefail
+
+          STATE_FILE="${{ runner.temp }}/runner-health-state"
+          PREV="${{ runner.temp }}/runner-health-prev"
+
+          # Fetch runners (online, offline — just not removed)
+          RUNNERS=$(gh api repos/JovieInc/Jovie/actions/runners --jq \
+            '[.runners[] | select(.labels[].name == "jovie-runner") | {name: .name, status: .status, busy: .busy}]')
+
+          TOTAL=$(echo "$RUNNERS" | jq length)
+          ONLINE=$(echo "$RUNNERS" | jq '[.[] | select(.status == "online")] | length')
+          OFFLINE=$(echo "$RUNNERS" | jq '[.[] | select(.status == "offline")] | length')
+
+          echo "total=$TOTAL"
+          echo "online=$ONLINE"
+          echo "offline=$OFFLINE"
+          echo "runner_list=$RUNNERS"
+
+          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+          echo "online=$ONLINE" >> "$GITHUB_OUTPUT"
+
+          # Determine current health state
+          if [ "$ONLINE" -eq 0 ]; then
+            echo "health=down" >> "$GITHUB_OUTPUT"
+          elif [ "$ONLINE" -ge 1 ]; then
+            echo "health=up" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Flip to GitHub-hosted fallback if runners are down
+        if: steps.runners.outputs.health == 'down'
+        env:
+          PREV_FLIP_FILE: ${{ runner.temp }}/last-flipped
+        run: |
+          set -euo pipefail
+
+          CURRENT=$(gh api repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER --jq '.value' 2>/dev/null || echo "")
+
+          if [ "$CURRENT" = "ubuntu-latest" ]; then
+            echo "Already on fallback (ubuntu-latest). No action needed."
+            exit 0
+          fi
+
+          # Require 2+ consecutive detections before flipping (anti-flap)
+          CONSECUTIVE_FILE="${{ runner.temp }}/runner-down-count"
+          COUNT=0
+          if [ -f "$CONSECUTIVE_FILE" ]; then
+            COUNT=$(cat "$CONSECUTIVE_FILE")
+          fi
+          COUNT=$((COUNT + 1))
+          echo "$COUNT" > "$CONSECUTIVE_FILE"
+
+          FLAP_THRESHOLD=2  # require 2+ consecutive checks (~10 min) before flipping
+          if [ "$COUNT" -lt "$FLAP_THRESHOLD" ]; then
+            echo "First detection of runner outage. Need $((FLAP_THRESHOLD - COUNT)) more. (count=$COUNT)"
+            exit 0
+          fi
+
+          echo "Runners offline for $COUNT consecutive checks. Flipping CI_FAST_RUNNER → ubuntu-latest..."
+          gh api -X PATCH repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER \
+            -f name=CI_FAST_RUNNER -f value=ubuntu-latest 2>&1
+
+          echo "last_flip=down" > "$PREV_FLIP_FILE"
+
+      - name: Restore self-hosted runners when they come back
+        if: steps.runners.outputs.health == 'up'
+        run: |
+          set -euo pipefail
+
+          CURRENT=$(gh api repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER --jq '.value' 2>/dev/null || echo "")
+
+          if [ "$CURRENT" = "jovie-runner" ]; then
+            echo "Already on self-hosted (jovie-runner). No action needed."
+            exit 0
+          fi
+
+          # Only restore if we were previously on fallback (debounce: 2 checks)
+          CONSECUTIVE_FILE="${{ runner.temp }}/runner-up-count"
+          COUNT=0
+          if [ -f "$CONSECUTIVE_FILE" ]; then
+            COUNT=$(cat "$CONSECUTIVE_FILE")
+          fi
+          COUNT=$((COUNT + 1))
+          echo "$COUNT" > "$CONSECUTIVE_FILE"
+
+          FLAP_THRESHOLD=2
+          if [ "$COUNT" -lt "$FLAP_THRESHOLD" ]; then
+            echo "First detection of runner recovery. Need $((FLAP_THRESHOLD - COUNT)) more. (count=$COUNT)"
+            exit 0
+          fi
+
+          echo "Runners back for $COUNT consecutive checks. Restoring CI_FAST_RUNNER → jovie-runner..."
+          gh api -X PATCH repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER \
+            -f name=CI_FAST_RUNNER -f value=jovie-runner 2>&1
+
+      - name: Log health state
+        run: |
+          echo "::notice::Runner health: online=${{ steps.runners.outputs.online }}/${{ steps.runners.outputs.total }}"


### PR DESCRIPTION
## Problem

Only 3/47 CI jobs use our self-hosted OrbStack arm64 runner pool (5 runners, 10 vCPUs, 23 Gi RAM). Two problems:

**1. Speed:** 44 jobs queue on GitHub's shared `ubuntu-latest` pool, adding 4+ min of queue wait per job. Worst bottleneck: `Path Changes` is the gatekeeper for ***every*** CI run — can't start downstream jobs until it completes.

**2. Resilience:** If the MBP goes down (sleep/reboot/travel), all jobs targeting `jovie-runner` queue forever with no automatic fallback.

## Changes

### Part A — More jobs on self-hosted runner

Wired 8 more jobs to `CI_FAST_RUNNER`:

| Job | Why safe |
|-----|----------|
| **`ci-path-changes`** | JS GitHub Action, no Docker |
| `ci-biome` | Node.js (setup-node-pnpm) |
| `ci-guardrails` | Node.js (setup-node) |
| `ci-structural-contract` | Node.js+Python |
| `ci-risk-classifier` | Node.js (setup-node-pnpm) |
| `ci-env-example-guard` | bash/grep only |
| `ci-fast` | Aggregator |
| `ci-integration-ready` | Aggregator |

**Before:** 3 jobs on self-hosted  
**After: 11 jobs on self-hosted**  
36 jobs remain on `ubuntu-latest` (Playwright, Lighthouse, Vercel deploy, neon-db).

### Part B — Auto-fallback when MBP is down

`runner-health-monitor.yml` — scheduled every 5 minutes:

- Checks if any `jovie-runner` runner is online
- If all 5 offline for **2+ consecutive checks (~10 min)** → flips `CI_FAST_RUNNER` to `ubuntu-latest`
- When runners come back → restores to `jovie-runner`
- Anti-flap: 2-check debounce in both directions

## Impact

| | Before | After |
|---|---|---|
| Self-hosted jobs | 3 (6%) | **11 (24%)** |
| MBP goes down | jobs queue forever | **auto-fallback in ~10 min** |
| Path Changes queue | 4+ min waiting | **instant pickup**