### PR TITLE
download: single primary hero CTA — iPhone status becomes badge + text link

### DIFF
--- a/apps/web/app/(marketing)/download/page.tsx
+++ b/apps/web/app/(marketing)/download/page.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@jovie/ui';
+import { Badge, Button } from '@jovie/ui';
 import {
   ArrowDownToLine,
   Check,
@@ -176,12 +176,15 @@ export default function DownloadPage() {
                         Download for Mac
                       </a>
                     </Button>
-                    <Link
-                      href='#ios-alpha'
-                      className='system-b-download-secondary-link'
-                    >
-                      iPhone status
-                    </Link>
+                    <div className='flex items-center gap-2'>
+                      <Badge variant='outline'>iPhone Alpha</Badge>
+                      <Link
+                        href='#ios-alpha'
+                        className='text-sm font-medium text-secondary-token underline underline-offset-4 transition-colors duration-subtle hover:text-primary-token'
+                      >
+                        See status
+                      </Link>
+                    </div>
                   </div>
                   <div className='system-b-download-meta'>
                     <span>Developer ID signed</span>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2096,29 +2096,6 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   text-wrap: balance;
 }
 
-:where(.system-b-download-secondary-link) {
-  display: inline-flex;
-  height: calc(var(--space-10) + var(--space-1));
-  align-items: center;
-  border-radius: var(--system-b-radius-pill);
-  color: color-mix(in oklab, var(--system-b-text-primary) 72%, transparent);
-  font-size: var(--text-mid);
-  font-weight: var(--font-weight-semibold);
-  padding-inline: var(--space-4);
-  transition: color var(--system-b-duration-fast) var(--system-b-ease);
-}
-
-:where(.system-b-download-secondary-link:hover) {
-  color: var(--system-b-text-primary);
-}
-
-:where(.system-b-download-secondary-link:focus-visible) {
-  box-shadow:
-    0 0 0 2px var(--system-b-cinematic-black),
-    0 0 0 4px color-mix(in oklab, var(--system-b-text-primary) 35%, transparent);
-  outline: none;
-}
-
 :where(.system-b-download-meta) {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Problem
The download page hero rendered the iPhone status link as a peer CTA button (44px semibold pill via `system-b-download-secondary-link`) equal in visual weight to "Download for Mac", but it only jumps to `#ios-alpha`.

## What changed
- Hero: replaced the pill link with a status badge (`<Badge variant='outline'>iPhone Alpha</Badge>`, canonical `@jovie/ui` atom) + a tertiary underlined text link "See status" -> `#ios-alpha`. "Download for Mac" is now the single primary CTA in the hero.
- Removed the now-dead `.system-b-download-secondary-link` rules from `design-system.css` (this page was the only consumer).
- CHANGELOG `[Unreleased]` entry added.

## Assumptions
- Badge copy "iPhone Alpha" (Title Case per casing lint; 'iPhone' is a BRAND_WORD) + link copy "See status"; kept the existing `#ios-alpha` anchor target.
- Tertiary link styled with named token utilities only (`text-secondary-token`, `duration-subtle`, etc.) - no new arbitrary values, ratchet unaffected.

## Verification
Sandbox could NOT run the local gate: registry.npmjs.org is blocked (HTTP 403, network-access request unanswered), so `pnpm install` / `pnpm turbo lint typecheck test:fast` / `pnpm run build:web` could not execute. Verification deferred to CI merge gate (ci-fast, Unit Tests, Structural Contract, Build). Static checks done locally: JSX balanced, zero remaining references to the removed CSS class (`grep -c` = 0), all Tailwind utilities are named tokens already used elsewhere in the repo, `Badge` exported from `@jovie/ui` barrel.

Diff base verified against branch head `80cce98e` (blob SHAs matched for all 3 files before push - no clobber risk).

## Dispatch
- Dispatch ID: not provided (issue-driven dispatch for GH-12953)
- Fixes #12953

🤖 Generated with [Claude Code](https://claude.com/claude-code)
