### PR TITLE
feat(inbox): report-back card UI — metric delta, sparkline, breakdown, next-step CTA (part 2/2)

### DIFF
--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxFeed.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxFeed.tsx
@@ -3,6 +3,7 @@
 import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
 import { cn } from '@/lib/utils';
 import { OpportunityInboxCard } from './OpportunityInboxCard';
+import { OpportunityInboxReportCard } from './OpportunityInboxReportCard';
 
 export interface OpportunityInboxFeedProps {
   readonly cards: readonly OpportunityInboxCardViewModel[];
@@ -13,8 +14,10 @@ export interface OpportunityInboxFeedProps {
     rating: 'positive' | 'negative',
     comment?: string
   ) => void;
+  readonly onNextStep?: (id: string) => void;
   readonly pendingActionId?: string | null;
   readonly pendingFeedbackId?: string | null;
+  readonly pendingNextStepId?: string | null;
   readonly className?: string;
 }
 
@@ -23,8 +26,10 @@ export function OpportunityInboxFeed({
   onApprove,
   onDismiss,
   onFeedback,
+  onNextStep,
   pendingActionId = null,
   pendingFeedbackId = null,
+  pendingNextStepId = null,
   className,
 }: OpportunityInboxFeedProps) {
   return (
@@ -35,18 +40,29 @@ export function OpportunityInboxFeed({
     >
       <div className='system-b-opportunity-inbox-section-label'>Today</div>
       <div className='system-b-opportunity-inbox-feed-list'>
-        {cards.map(card => (
-          <OpportunityInboxCard
-            key={card.id}
-            card={card}
-            onApprove={onApprove}
-            onDismiss={onDismiss}
-            onFeedback={onFeedback}
-            isApproving={pendingActionId === card.id}
-            isDismissing={pendingActionId === card.id}
-            isSubmittingFeedback={pendingFeedbackId === card.id}
-          />
-        ))}
+        {cards.map(card =>
+          card.category === 'report' && card.report ? (
+            <OpportunityInboxReportCard
+              key={card.id}
+              card={card}
+              onNextStep={onNextStep ?? onApprove}
+              onDismiss={onDismiss}
+              isSubmittingNextStep={pendingNextStepId === card.id}
+              isDismissing={pendingActionId === card.id}
+            />
+          ) : (
+            <OpportunityInboxCard
+              key={card.id}
+              card={card}
+              onApprove={onApprove}
+              onDismiss={onDismiss}
+              onFeedback={onFeedback}
+              isApproving={pendingActionId === card.id}
+              isDismissing={pendingActionId === card.id}
+              isSubmittingFeedback={pendingFeedbackId === card.id}
+            />
+          )
+        )}
       </div>
     </section>
   );

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
@@ -69,8 +69,12 @@ export function OpportunityInboxPageClient({
   const [rejectedTourDates, setRejectedTourDates] = useState(
     initialTourDates.rejected
   );
-  const { approveMutation, dismissMutation, feedbackMutation } =
-    useOpportunityInboxMutations();
+  const {
+    approveMutation,
+    dismissMutation,
+    feedbackMutation,
+    nextStepMutation,
+  } = useOpportunityInboxMutations();
   const { confirmMutation, rejectMutation, undoRejectMutation } =
     useTourDateReviewMutations();
 
@@ -91,6 +95,10 @@ export function OpportunityInboxPageClient({
 
   const pendingFeedbackId = feedbackMutation.isPending
     ? (feedbackMutation.variables?.suggestedActionId ?? null)
+    : null;
+
+  const pendingNextStepId = nextStepMutation.isPending
+    ? (nextStepMutation.variables ?? null)
     : null;
 
   const pendingTourDateActionId = useMemo(() => {
@@ -138,6 +146,14 @@ export function OpportunityInboxPageClient({
       rating,
       comment,
       pathname,
+    });
+  };
+
+  const handleNextStep = (id: string) => {
+    nextStepMutation.mutate(id, {
+      onSuccess: () => {
+        setCards(current => current.filter(card => card.id !== id));
+      },
     });
   };
 
@@ -239,8 +255,10 @@ export function OpportunityInboxPageClient({
           onApprove={handleApprove}
           onDismiss={handleDismiss}
           onFeedback={handleFeedback}
+          onNextStep={handleNextStep}
           pendingActionId={pendingActionId}
           pendingFeedbackId={pendingFeedbackId}
+          pendingNextStepId={pendingNextStepId}
         />
       ) : null}
 

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxReportCard.stories.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxReportCard.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { OpportunityInboxReportCard } from './OpportunityInboxReportCard';
+
+const meta: Meta<typeof OpportunityInboxReportCard> = {
+  title: 'Features/OpportunityInbox/OpportunityInboxReportCard',
+  component: OpportunityInboxReportCard,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OpportunityInboxReportCard>;
+
+export const PositiveLift: Story = {
+  args: {
+    card: {
+      id: 'story-report-1',
+      typeLabel: 'Report',
+      createdAt: '2026-07-04T10:00:00.000Z',
+      title: 'Thumbnail experiment finished',
+      why: 'Challenger A beat your baseline over the 14-day window. Watch-minutes per impression drove the call.',
+      primaryActionLabel: 'Run on 3 more videos',
+      status: 'pending',
+      category: 'report',
+      report: {
+        metricLabel: 'views',
+        deltaPercent: 5.4,
+        deltaDisplay: '+5.4%',
+        direction: 'up',
+        series: [120, 132, 128, 150, 148, 163, 171],
+        items: [
+          { label: 'Challenger A', deltaPercent: 5.4, detail: 'promoted' },
+          { label: 'Challenger B', deltaPercent: 1.2 },
+          { label: 'Baseline', deltaPercent: 0 },
+        ],
+        experimentId: 'exp-42',
+        nextStep: {
+          label: 'Run on 3 more videos',
+          kind: 'experiment.start',
+          payload: { videoCount: 3 },
+        },
+      },
+    },
+    onNextStep: () => undefined,
+    onDismiss: () => undefined,
+    className: 'w-[42rem] max-w-full',
+  },
+};
+
+export const NegativeResult: Story = {
+  args: {
+    ...PositiveLift.args,
+    card: {
+      id: 'story-report-2',
+      typeLabel: 'Report',
+      createdAt: '2026-07-03T10:00:00.000Z',
+      title: 'Smart link CTA experiment finished',
+      why: 'The variant underperformed — Jovie reverted to your baseline automatically.',
+      primaryActionLabel: 'Try a new variant',
+      status: 'pending',
+      category: 'report',
+      report: {
+        metricLabel: 'link clicks',
+        deltaPercent: -2.1,
+        deltaDisplay: '−2.1%',
+        direction: 'down',
+        series: [88, 84, 90, 81, 79, 82],
+        items: [{ label: 'Variant', deltaPercent: -2.1 }],
+        experimentId: 'exp-43',
+        nextStep: {
+          label: 'Try a new variant',
+          kind: 'experiment.start',
+        },
+      },
+    },
+  },
+};

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxReportCard.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxReportCard.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
+import { OpportunityInboxReportCard } from './OpportunityInboxReportCard';
+
+const REPORT_CARD: OpportunityInboxCardViewModel = {
+  id: 'report-1',
+  typeLabel: 'Report',
+  createdAt: '2026-07-04T10:00:00.000Z',
+  title: 'Thumbnail experiment finished',
+  why: 'Jovie measured the results of your experiment.',
+  primaryActionLabel: 'Run on 3 more videos',
+  status: 'pending',
+  category: 'report',
+  report: {
+    metricLabel: 'views',
+    deltaPercent: 5.4,
+    deltaDisplay: '+5.4%',
+    direction: 'up',
+    series: [120, 132, 128, 150, 171],
+    items: [
+      { label: 'Challenger A', deltaPercent: 5.4, detail: 'promoted' },
+      { label: 'Baseline', deltaPercent: 0 },
+    ],
+    experimentId: 'exp-42',
+    nextStep: {
+      label: 'Run on 3 more videos',
+      kind: 'experiment.start',
+    },
+  },
+};
+
+describe('OpportunityInboxReportCard', () => {
+  it('renders metric delta, sparkline, and next-step CTA', () => {
+    render(
+      <OpportunityInboxReportCard
+        card={REPORT_CARD}
+        onNextStep={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText('Thumbnail experiment finished')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('opportunity-inbox-report-delta')
+    ).toHaveTextContent('+5.4%');
+    expect(screen.getByText('views')).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: 'Metric trend' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('opportunity-inbox-report-next-step')
+    ).toHaveTextContent('Run on 3 more videos');
+  });
+
+  it('reveals the per-item breakdown on expand', () => {
+    render(
+      <OpportunityInboxReportCard
+        card={REPORT_CARD}
+        onNextStep={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('opportunity-inbox-report-breakdown')
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Show Breakdown/ }));
+
+    expect(
+      screen.getByTestId('opportunity-inbox-report-breakdown')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Challenger A')).toBeInTheDocument();
+    expect(screen.getByText('promoted')).toBeInTheDocument();
+  });
+
+  it('fires next-step and dismiss handlers', () => {
+    const onNextStep = vi.fn();
+    const onDismiss = vi.fn();
+
+    render(
+      <OpportunityInboxReportCard
+        card={REPORT_CARD}
+        onNextStep={onNextStep}
+        onDismiss={onDismiss}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('opportunity-inbox-report-next-step'));
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(onNextStep).toHaveBeenCalledWith('report-1');
+    expect(onDismiss).toHaveBeenCalledWith('report-1');
+  });
+
+  it('renders nothing when report data is missing', () => {
+    const { container } = render(
+      <OpportunityInboxReportCard
+        card={{ ...REPORT_CARD, report: undefined }}
+        onNextStep={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxReportCard.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxReportCard.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import {
+  ArrowRight,
+  ChevronDown,
+  Minus,
+  TrendingDown,
+  TrendingUp,
+} from 'lucide-react';
+import { useId, useState } from 'react';
+import { Sparkline } from '@/components/shell/Sparkline';
+import { formatReportDelta } from '@/lib/connectors/opportunity-inbox-report';
+import { formatOpportunityInboxRelativeTime } from '@/lib/connectors/opportunity-inbox-time';
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
+import { cn } from '@/lib/utils';
+
+export interface OpportunityInboxReportCardProps {
+  readonly card: OpportunityInboxCardViewModel;
+  readonly onNextStep: (id: string) => void;
+  readonly onDismiss: (id: string) => void;
+  readonly isSubmittingNextStep?: boolean;
+  readonly isDismissing?: boolean;
+  readonly className?: string;
+}
+
+/**
+ * Report-back card variant (GH #13178): renders a measured experiment result
+ * — metric delta, sparkline from real series data, per-item breakdown on
+ * expand — and a next-step CTA that emits a new pending suggested_action
+ * linked to the parent experiment.
+ */
+export function OpportunityInboxReportCard({
+  card,
+  onNextStep,
+  onDismiss,
+  isSubmittingNextStep = false,
+  isDismissing = false,
+  className,
+}: OpportunityInboxReportCardProps) {
+  const breakdownId = useId();
+  const [expanded, setExpanded] = useState(false);
+  const report = card.report;
+  const relativeTime = formatOpportunityInboxRelativeTime(card.createdAt);
+  const isBusy = isSubmittingNextStep || isDismissing;
+
+  if (!report) {
+    return null;
+  }
+
+  const DirectionIcon =
+    report.direction === 'up'
+      ? TrendingUp
+      : report.direction === 'down'
+        ? TrendingDown
+        : Minus;
+
+  return (
+    <article
+      className={cn(
+        'system-b-opportunity-inbox-card system-b-opportunity-inbox-report-card',
+        className
+      )}
+      data-testid={`opportunity-inbox-report-card-${card.id}`}
+    >
+      <header className='system-b-opportunity-inbox-card-meta'>
+        <span className='system-b-opportunity-inbox-card-type'>
+          {card.typeLabel}
+        </span>
+        <span
+          aria-hidden='true'
+          className='system-b-opportunity-inbox-card-dot'
+        >
+          ·
+        </span>
+        <time
+          className='system-b-opportunity-inbox-card-time'
+          dateTime={card.createdAt}
+        >
+          {relativeTime}
+        </time>
+      </header>
+
+      <h2 className='system-b-opportunity-inbox-card-title'>{card.title}</h2>
+
+      <div className='system-b-opportunity-inbox-report-metric'>
+        <span
+          className='system-b-opportunity-inbox-report-delta'
+          data-direction={report.direction}
+          data-testid='opportunity-inbox-report-delta'
+        >
+          <DirectionIcon
+            aria-hidden='true'
+            className='system-b-opportunity-inbox-report-delta-icon'
+          />
+          {report.deltaDisplay}
+        </span>
+        <span className='system-b-opportunity-inbox-report-metric-label'>
+          {report.metricLabel}
+        </span>
+        {report.series.length >= 2 ? (
+          <Sparkline
+            points={report.series}
+            trend={report.direction}
+            ariaLabel='Metric trend'
+            className='system-b-opportunity-inbox-report-sparkline'
+          />
+        ) : null}
+      </div>
+
+      <p className='system-b-opportunity-inbox-card-why'>{card.why}</p>
+
+      {report.items.length > 0 ? (
+        <>
+          <button
+            type='button'
+            className='system-b-opportunity-inbox-report-expand'
+            aria-expanded={expanded}
+            aria-controls={breakdownId}
+            onClick={() => setExpanded(open => !open)}
+          >
+            {expanded ? 'Hide Breakdown' : 'Show Breakdown'}
+            <ChevronDown
+              aria-hidden='true'
+              className={cn(
+                'system-b-opportunity-inbox-report-expand-icon',
+                expanded && 'system-b-opportunity-inbox-report-expand-icon-open'
+              )}
+            />
+          </button>
+          {expanded ? (
+            <ul
+              id={breakdownId}
+              className='system-b-opportunity-inbox-report-breakdown'
+              data-testid='opportunity-inbox-report-breakdown'
+            >
+              {report.items.map(item => (
+                <li
+                  key={item.label}
+                  className='system-b-opportunity-inbox-report-breakdown-item'
+                >
+                  <span className='system-b-opportunity-inbox-report-breakdown-label'>
+                    {item.label}
+                  </span>
+                  {item.detail ? (
+                    <span className='system-b-opportunity-inbox-report-breakdown-detail'>
+                      {item.detail}
+                    </span>
+                  ) : null}
+                  {typeof item.deltaPercent === 'number' ? (
+                    <span
+                      className='system-b-opportunity-inbox-report-breakdown-delta'
+                      data-direction={
+                        item.deltaPercent > 0
+                          ? 'up'
+                          : item.deltaPercent < 0
+                            ? 'down'
+                            : 'flat'
+                      }
+                    >
+                      {formatReportDelta(item.deltaPercent)}
+                    </span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </>
+      ) : null}
+
+      <div className='system-b-opportunity-inbox-card-actions'>
+        <button
+          type='button'
+          className='system-b-opportunity-inbox-dismiss'
+          disabled={isBusy}
+          onClick={() => onDismiss(card.id)}
+        >
+          Dismiss
+        </button>
+        {report.nextStep ? (
+          <button
+            type='button'
+            className='system-b-opportunity-inbox-primary'
+            disabled={isBusy}
+            onClick={() => onNextStep(card.id)}
+            data-testid='opportunity-inbox-report-next-step'
+          >
+            {isSubmittingNextStep ? 'Queuing…' : report.nextStep.label}
+            <ArrowRight className='system-b-opportunity-inbox-primary-icon' />
+          </button>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -7800,6 +7800,118 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   line-height: 1.55;
 }
 
+:where(.system-b-opportunity-inbox-report-metric) {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+:where(.system-b-opportunity-inbox-report-delta) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--color-text-primary-token);
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Green/red carry semantic meaning here: measured lift vs measured drop. */
+:where(.system-b-opportunity-inbox-report-delta[data-direction="up"]) {
+  color: var(--color-accent-green);
+}
+
+:where(.system-b-opportunity-inbox-report-delta[data-direction="down"]) {
+  color: var(--color-accent-red);
+}
+
+:where(.system-b-opportunity-inbox-report-delta-icon) {
+  width: var(--space-4);
+  height: var(--space-4);
+}
+
+:where(.system-b-opportunity-inbox-report-metric-label) {
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-xs);
+}
+
+:where(.system-b-opportunity-inbox-report-sparkline) {
+  display: block;
+  width: calc(var(--space-12) * 2);
+  height: calc(var(--space-6) + var(--space-1));
+  margin-left: auto;
+}
+
+:where(.system-b-opportunity-inbox-report-expand) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  align-self: flex-start;
+  border: none;
+  background: transparent;
+  color: var(--color-text-quaternary-token);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-medium);
+  padding: 0;
+  transition: color var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-opportunity-inbox-report-expand:hover) {
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-opportunity-inbox-report-expand-icon) {
+  width: var(--space-3);
+  height: var(--space-3);
+  transition: transform var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-opportunity-inbox-report-expand-icon-open) {
+  transform: rotate(180deg);
+}
+
+:where(.system-b-opportunity-inbox-report-breakdown) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+:where(.system-b-opportunity-inbox-report-breakdown-item) {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+}
+
+:where(.system-b-opportunity-inbox-report-breakdown-label) {
+  color: var(--color-text-secondary-token);
+}
+
+:where(.system-b-opportunity-inbox-report-breakdown-detail) {
+  color: var(--color-text-quaternary-token);
+}
+
+:where(.system-b-opportunity-inbox-report-breakdown-delta) {
+  margin-left: auto;
+  color: var(--color-text-tertiary-token);
+  font-variant-numeric: tabular-nums;
+}
+
+:where(
+  .system-b-opportunity-inbox-report-breakdown-delta[data-direction="up"]
+) {
+  color: var(--color-accent-green);
+}
+
+:where(
+  .system-b-opportunity-inbox-report-breakdown-delta[data-direction="down"]
+) {
+  color: var(--color-accent-red);
+}
+
 :where(.system-b-chat-generation-artifact-surface) {
   width: 100%;
   max-width: 520px;


### PR DESCRIPTION
## Problem
Render the measured experiment result as a first-class inbox card (GH #13178, part 2 of 2 — stacked on #13408, lands after it).

## What changed
- `OpportunityInboxReportCard.tsx` (new): report variant of the inbox card — metric delta with semantic up/down color, sparkline from real series data via the canonical `@/components/shell/Sparkline` primitive (adopted, not rebuilt), per-item breakdown on expand, next-step CTA + dismiss. Reuses the existing `system-b-opportunity-inbox-card` shell classes.
- `OpportunityInboxFeed.tsx`: renders the report variant when `card.category === 'report'`; falls back to the standard card otherwise.
- `OpportunityInboxPageClient.tsx`: wires `nextStepMutation` (from part 1) with optimistic card removal + pending state.
- `design-system.css`: on-token `system-b-opportunity-inbox-report-*` classes (delta, metric row, sparkline sizing, expand affordance, breakdown list). Green/red used strictly semantically (measured lift vs drop).
- Storybook: `OpportunityInboxReportCard.stories.tsx` (PositiveLift + NegativeResult).
- Unit tests: render (delta, sparkline, CTA), expand breakdown, handler wiring, missing-report degrade (`OpportunityInboxReportCard.test.tsx`).

## Assumptions
- Breakdown expand is a user-initiated accordion (collapsed by default) — content insertion on explicit click, matching the existing comment-shell affordance on the base card.
- Shell `Sparkline` trend palette (cyan up / rose down) is its canonical contract; not re-themed here.

## Verification
Same sandbox constraint as part 1 (registry.npmjs.org 403 — full probe log there). Standalone biome 2.5.1: all 6 changed files lint + format clean. Typecheck + vitest + Storybook build deferred to CI. Do not enqueue until CI is green.

## Cost Impact
None — presentation only.

Dispatch: hyperagent thread cmr8ygtrh2d4006adjmt8774h
Closes #13178

🤖 Generated with [Claude Code](https://claude.com/claude-code)