### PR TITLE
fix(ci): bump pnpm/action-setup to v6.0.9, reduce unit test retries to 0

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -22,7 +22,7 @@ runs:
         fi
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       
     # Actions-cache-backed pnpm caching is GitHub-hosted only. Self-hosted
     # runners (jovie-runner) keep a persistent pnpm store on disk, so the

--- a/apps/web/tests/quarantine.json
+++ b/apps/web/tests/quarantine.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "retryBudget": {
-    "unitDefaultRetries": 2,
+    "unitDefaultRetries": 0,
     "quarantineUnitRetries": 2,
     "e2eDefaultRetries": 0,
     "quarantineE2eRetries": 2,


### PR DESCRIPTION
## Problem

Two issues blocking the merge queue (21 PRs stuck):

1. **Typecheck fails on self-hosted runners** — The composite action `setup-node-pnpm` pins `pnpm/action-setup@v4.2.0`, which runs on Node.js 20. Self-hosted runners (Node.js 24) get the deprecation warning and `pnpm install` silently fails. Dependabot #13411 patched standalone workflows to v6.0.9 but missed the shared composite action.

2. **Unit tests cascade-cancel at 40-min timeout** — `unitDefaultRetries: 2` means every failing test runs 3×. With multiple failures across 5 shards, the job hits the 40-min wall and all in-progress splits get CANCELLED.

## Changes

- `.github/actions/setup-node-pnpm/action.yml`: Bump `pnpm/action-setup` SHA from v4.2.0 → v6.0.9
- `apps/web/tests/quarantine.json`: Set `unitDefaultRetries` from 2 → 0 (flaky tests belong in quarantine, not retry budget)

Rollback: revert either file.

## Verification

- Typecheck passes locally on main and PR branches
- Unit tests pass locally
- CI will verify after merge