### PR TITLE
fix(ci): add fable/*, agent/*, zoe/* to agent pipeline branch patterns

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -16,7 +16,7 @@
 # when @claude is mentioned in a CodeRabbit review thread.
 #
 # SAFETY:
-# - Only runs on agent branches (linear/*, claude/*, codegen-bot/*, codex/*, */jov-*)
+# - Only runs on agent branches (linear/*, claude/*, codegen-bot/*, codex/*, fable/*, agent/*, zoe/*, */jov-*)
 # - Max 5 fix attempts per SHA to prevent infinite loops
 # - Escalates to 'needs-human' label after exhaustion
 # - Sensitive path detection prevents auto-merge on high-risk changes
@@ -164,7 +164,7 @@ jobs:
         run: |
           echo "Branch: $BRANCH"
 
-          if [[ "$BRANCH" =~ ^(linear/|claude/|codegen-bot/|codex/) || "$BRANCH" =~ (^|/)jov-[0-9]+ ]]; then
+          if [[ "$BRANCH" =~ ^(linear/|claude/|codegen-bot/|codex/|fable/|agent/|zoe/) || "$BRANCH" =~ (^|/)jov-[0-9]+ ]]; then
             echo "Agent branch detected"
             echo "is_agent_branch=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Problem

The agent-pipeline.yml workflow auto-fixes CI failures (typecheck, lint) on agent branches. But it only covered `linear/*`, `claude/*`, `codegen-bot/*`, `codex/*`, and `*/jov-*`.

The F5 pipeline creates branches under `fable/*` and `agent/*`, and Zoe uses `zoe/*`. Typecheck/lint failures on these branches silently accumulated — 21 PRs stuck because no auto-fix triggered.

## Change

Add `fable/*`, `agent/*`, `zoe/*` to the branch pattern regex in the guard step.

## Rollback

Revert the regex change in `.github/workflows/agent-pipeline.yml`.