### PR TITLE
fix(ci): use exclusion-based agent branch pattern

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -16,7 +16,7 @@
 # when @claude is mentioned in a CodeRabbit review thread.
 #
 # SAFETY:
-# - Only runs on agent branches (linear/*, claude/*, codegen-bot/*, codex/*, fable/*, agent/*, zoe/*, */jov-*)
+# - Runs on all branches except known infrastructure branches (main, dependabot/*, gh-readonly-queue/*, renovate/*)
 # - Max 5 fix attempts per SHA to prevent infinite loops
 # - Escalates to 'needs-human' label after exhaustion
 # - Sensitive path detection prevents auto-merge on high-risk changes
@@ -164,11 +164,11 @@ jobs:
         run: |
           echo "Branch: $BRANCH"
 
-          if [[ "$BRANCH" =~ ^(linear/|claude/|codegen-bot/|codex/|fable/|agent/|zoe/) || "$BRANCH" =~ (^|/)jov-[0-9]+ ]]; then
+          if ! [[ "$BRANCH" =~ ^(main|dependabot/|gh-readonly-queue/|renovate/) ]]; then
             echo "Agent branch detected"
             echo "is_agent_branch=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Not an agent branch. Skipping."
+            echo "Not an agent branch (infrastructure). Skipping."
             echo "is_agent_branch=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -873,7 +873,7 @@ jobs:
           # Find open agent PRs with needs-human label
           STALE_PRS=$(gh pr list --state open --label needs-human --json number,headRefName,updatedAt,title --limit 50 \
             | jq -c --arg cutoff "$(date -u -d '48 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-48H +%Y-%m-%dT%H:%M:%SZ)" \
-            '[.[] | select(.headRefName | test("^(linear/|claude/|codegen-bot/|codex/)") or test("(^|/)jov-[0-9]+"; "i")) | select(.updatedAt < $cutoff)] | .[]')
+            '[.[] | select(.headRefName | test("^(main|dependabot/|gh-readonly-queue/|renovate/)") | not) | select(.updatedAt < $cutoff)] | .[]')
 
           if [[ -z "$STALE_PRS" ]]; then
             echo "No stale agent PRs found"


### PR DESCRIPTION
## Problem

The agent pipeline's branch detection maintained an explicit allowlist of agent prefixes (`linear/*`, `claude/*`, `codegen-bot/*`, `codex/*`, `fable/*`, `agent/*`, `zoe/*`, `*/jov-*`). Every new agent tool required a pipeline edit.

## Change

Switch to **exclusion-based** detection: treat any branch as an agent branch unless it matches infrastructure patterns (`main`, `dependabot/*`, `gh-readonly-queue/*`, `renovate/*`).

Covered in this PR:
- Guard step branch detection regex
- Stale needs-human PR cleanup filter
- File header comment documenting the approach

## Why

There's never a scenario where we don't want CI fixes and auto-approval on a development branch. Agent tooling evolves faster than this list — the new pattern automatically covers any future agent without CI edits.

## Test

`actionlint .github/workflows/agent-pipeline.yml` — matches previous warning set, no new findings.