### PR TITLE
fix(security): allowlist JOV-2940 remediated commit in gitleaks history scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4089,7 +4089,7 @@ jobs:
   ci-smoke-required:
     name: Extended Smoke (Preview)
     needs: [ci-fast, ci-build, neon-db, ci-e2e-tests, ci-path-changes]
-    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'testing') && needs.ci-path-changes.outputs.run_e2e == 'true'))) }}
+    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (always() && ((github.event_name == 'workflow_dispatch' && needs.neon-db.result == 'success') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'testing') && needs.ci-path-changes.outputs.run_e2e == 'true'))) }}
     runs-on: ubuntu-latest
     environment: Preview – jovie
     timeout-minutes: 20

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -104,7 +104,14 @@ regexes = [
 ]
 
 # Specific commit SHAs to ignore (for known false positives in history)
-commits = []
+# 75ef52d12 — introduced .claude/settings.local.json.backup (Neon connection strings)
+# and docs/testing-clerk.md (Clerk sk_test key) in screenshots auto-commit #10692.
+# Both were redacted in JOV-2940 (commit 77cbe76c5). Allowlist the introducing commit so
+# history scans (workflow_dispatch / scheduled full / `--log-opts` ranges that collapse to
+# near-full history on shallow fetches) don't flag already-remediated secrets.
+commits = [
+    "75ef52d12656b4841c3080ea0d20ff2f74b37c63",
+]
 
 # =============================================================================
 # Custom Rules — close gaps that allowed JOV-2940 to land


### PR DESCRIPTION
## What

Two surgical CI/security hygiene fixes that unblock the 13 open dependabot PRs (#13417, #13419, #13415, #13410, #13423, #13412, #13424, #13422, #13421, #13420, #13418, #13416, #13413) and stop future false failures on manual CI reruns.

## Fix 1 — `.gitleaks.toml` allowlist (commit 1)

`Secret Scan (gitleaks + trufflehog)` failed on `workflow_dispatch` CI reruns, flagging 4 historical leaks in commit `75ef52d12` (#10692, screenshots auto-commit):

- `.claude/settings.local.json.backup:183,184,186` — 3 Neon connection strings
- `docs/testing-clerk.md:78` — Clerk `sk_test_` key

**Both files were already redacted in JOV-2940** (commit `77cbe76c5`, #10849). The secrets no longer exist in the working tree. But gitleaks history scans still flag the introducing commit because on `workflow_dispatch` reruns, `scan-secrets.sh` does `git fetch origin main --depth=1`, so `--log-opts="origin/main..HEAD"` collapses to ~full history (7283 commits scanned).

**Fix:** add `75ef52d12656b4841c3080ea0d20ff2f74b37c63` to the existing `commits` allowlist in `.gitleaks.toml` (the field was already present and empty `commits = []` precisely for this use). Narrow and documented.

## Fix 2 — gate `ci-smoke-required` workflow_dispatch on neon-db success (commit 2)

`Extended Smoke (Preview)` failed on `workflow_dispatch` reruns of dependabot branches with:

```
Unable to download artifact(s): Artifact not found for name: neon-db-connection-28826436629
```

Root cause: `ci-smoke-required`'s `if:` ran on `workflow_dispatch` unconditionally, but `neon-db`'s `if:` only accepts `push`/`pull_request` (no `workflow_dispatch` branch) and excludes `dependabot[bot]`. So on manual reruns of dependabot branches, neon-db skipped (no artifact) while Extended Smoke still ran and then failed downloading the missing artifact.

**Fix:** add `needs.neon-db.result == 'success'` to the `workflow_dispatch` branch of `ci-smoke-required`'s `if:`. Now smoke skips cleanly when neon-db skips on manual reruns, and still runs when neon-db runs on a real dispatch over a backend branch. `pull_request` branch unchanged (already excludes dependabot + requires `testing` label + `run_e2e`).

## Verification

- TOML parses cleanly (`allowlist.commits = ["75ef52d12…"]`).
- `git log -S sk_test_RS2raun9… -- docs/testing-clerk.md` and `git log -- .claude/settings.local.json.backup` both confirm the introducing commit is `75ef52d12` and the removal is `77cbe76c5` (JOV-2940).
- YAML parses; `actionlint .github/workflows/ci.yml` exit=0 (only pre-existing shellcheck infos).
- The 4 secrets are confirmed absent from the current tree.

## Unblocks

After this lands, the 13 dependabot PRs (already rebased via `@dependabot rebase` and now running fresh `pull_request`-event CI) auto-merge through Graphite. Manual reruns of CI on dependabot branches will also be clean.

## Risk

Low. Both changes are surgical:
- Allowlisting a single already-remediated commit (no change to active scanning of new commits).
- One `if:` expression gating smoke on neon-db having actually run.

Neither `Secret Scan` nor `Extended Smoke` is a required check (required = `PR Ready`, `Migration Guard`, `Fork PR Gate`, `PR Size Guard` per ruleset 10512119). The 13 dependabot PRs were blocked because Graphite's merge queue treats the latest run's non-success jobs as blocking, and the latest runs were the failing `workflow_dispatch` reruns.

## Files changed

- `.gitleaks.toml` — 1 commit added to `commits` allowlist
- `.github/workflows/ci.yml` — 1 `if:` expression on `ci-smoke-required`