### PR TITLE
docs(marketing): section + recipe catalogs (PR3/5)

### DIFF
--- a/docs/marketing/RECIPE_CATALOG.md
+++ b/docs/marketing/RECIPE_CATALOG.md
@@ -1,0 +1,217 @@
+<!--
+spec-version: 1.0.0
+doc-freshness: docs/marketing/RECIPE_CATALOG.md
+-->
+# Marketing Recipe Catalog
+
+> **This is a commentary doc.** Per-recipe rationale + arc + decision tree.
+> Normative rules (sectionOrder, arc, hierarchy, ctaCadence, substitutions,
+> fallbacks, min/max content) live in `apps/web/data/marketing/recipes.ts`.
+> Anchors `#recipe-{id}` are parity-asserted against the registry by the
+> manifest gate.
+
+11 recipes, two-tier (Design F10): `proven` (shipped reference route) vs `stub`
+(order + arc only; first implementation goes through human taste feedback
+then promotes). CI refuses `proven` without a reference route.
+
+## #recipe-homepage (proven)
+
+**Reference:** `/new` (richest shipped homepage composition; live `/` currently
+renders hero-only). **Audience:** general. **Sections (9):** hero → logo-cloud
+→ feature-split ×3 → spec-wall → social-proof → pricing → cta.
+
+**Arc:** promise → permission → comprehension → depth → capability → detail →
+belief → price → action (B2B C2 canonical homepage macro-order).
+
+**CTA cadence:** sparse, "Get started" + "See a live profile", hero-and-close.
+
+**Decision tree:** `traffic=home OR (audience=general AND intent=category)`.
+Substitutions: `social-proof` → `stats` (if socialProof absent but stats
+verified); `pricing` → `monetization` (if audience=artist).
+
+**Never:** for audience=artist specifically (use artist-lp); as a feature page
+(use feature — narrower scope).
+
+## #recipe-pricing (proven)
+
+**Reference:** `/pricing`. **Audience:** general. **Sections (6):** hero →
+pricing → social-proof → comparison → faq → cta.
+
+**Arc:** frame → tiers → trust → compare → objection → action (B2B C7
+pricing-page grammar).
+
+**CTA cadence:** sparse, "Get started" + "Contact sales", hero-and-close.
+
+**Decision tree:** `intent=price AND conversion=start OR upgrade`. Fallbacks:
+omit social-proof if unverified (zero-proof wins over B2B C7 proof beat);
+omit comparison if featureRows missing (degrades to tier-cards + faq).
+
+**Never:** without FAQ (B2B anti-pattern #9 — Linear is the gap); on artist LP
+as a full pricing table (use artist-lp with monetization one-liner — creator R8).
+
+## #recipe-artist-lp (proven)
+
+**Reference:** `/artist-profiles` (canonical; `/artist-profile` is an alias).
+**Audience:** artist. **Sections (11):** hero → feature-split (adaptive) →
+feature-grid (outcomes) → capture → feature-split (reactivation) →
+monetization → spec-wall → how-it-works → social-proof → faq → cta.
+
+**Arc (creator R9 — NO problem/agitation beat):** recognition → identity →
+aspiration → capability (capture) → capability (reactivation) → money-reality →
+detail → low-risk → relatability → permission → action.
+
+**CTA cadence:** dense-tiered, "Claim your Jovie" (possession verb; cost-objection
+in button: "Try N days free"), every-2-3-sections-after-proof. Substitution:
+`feature-split` → `ownership` (REQUIRED when competing with DSPs/link-in-bio —
+creator R9).
+
+**Decision tree:** `audience=artist AND (intent=artist-profile OR
+conversion=claim-handle OR claim-profile)`.
+
+**Never:** with a problem-agitation section (creator R9); with comparison above
+the fold (creator R9); with founder-first proof near the top (DESIGN.md ui.md
+smell); with a demo-gate or "book a demo" CTA (creator R10); with
+enterprise/security/ROI-calculator sections (creator R10); with a full pricing
+table (creator R8); with quotes from famous artists (creator R5 —
+famous=profiles, quotes=small).
+
+## #recipe-feature (proven)
+
+**Reference:** `/artist-notifications` (also `/download`, `/pay`, `/voice`
+noindex). **Audience:** artist. **Sections (8):** hero → logo-cloud → capture →
+feature-split (reactivation) → feature-grid (benefits) → spec-wall → faq → cta.
+
+**Arc:** promise → permission → capability (capture) → capability (reactivate)
+→ breadth → detail → objection → action (B2B C8: feature page = homepage
+grammar at depth-1).
+
+**CTA cadence:** dense-tiered, "Get started", hero-and-close.
+
+**Decision tree:** `intent=feature AND conversion=start`. Substitution:
+`logo-cloud` → `feature-split` (if no logos — degradation: trust proof =
+product render).
+
+**Never:** as a retelling of the whole company story (B2B anti-pattern #14);
+for audience=general as the primary (feature pages assume the category framing
+already happened on homepage).
+
+## #recipe-agency-lp (stub)
+
+**No reference route.** **Audience:** agency. **Sections (8):** hero →
+logo-cloud → feature-grid → feature-split → social-proof → pricing → faq → cta.
+
+**Arc:** promise → permission → breadth → depth → belief → price → objection →
+action.
+
+**CTA cadence:** sparse, "Talk to us" (agency sales motion — NOT self-serve
+claim) + "See a demo roster", hero-and-close.
+
+**Decision tree:** `audience=agency AND conversion=book-demo OR start`. First
+implementation goes through taste feedback then promotes to proven.
+
+**Never:** with artist-arc CTA verbs (agency path is sales-led, not claim-led);
+without a real demo roster asset (degradation: screenshot-registry product
+render of multi-artist view).
+
+## #recipe-enterprise (stub)
+
+**No reference route.** **Audience:** enterprise-buyer. **Sections (8):** hero →
+logo-cloud → feature-split → stats → social-proof → comparison → faq → cta.
+
+**Arc:** promise → permission → depth → scale → belief → compare → objection →
+action.
+
+**CTA cadence:** sparse, "Contact sales" + "Get started", hero-and-close.
+
+**Decision tree:** `audience=enterprise-buyer AND conversion=contact-sales`.
+
+**Never:** for audience=artist (creator R10 — enterprise sections illegal on
+artist-audience recipes); without verified enterprise customer proof
+(zero-proof path: omit stats/social-proof).
+
+## #recipe-comparison (proven)
+
+**Reference:** `/compare/linktree` (also `/alternatives/*`). **Audience:**
+general. **Sections (5):** hero → comparison → feature-grid → faq → cta.
+
+**Arc:** frame → compare → breadth → objection → action.
+
+**CTA cadence:** sparse, "Get started", hero-and-close.
+
+**Decision tree:** `intent=compare AND conversion=start` (SEO programmatic from
+`content/comparisons/` or `content/alternatives/`). Fallbacks: FAIL if
+featureRows missing (comparison is the point — do not ship without it); FAIL
+if competitor feature data unverified (zero-proof law applies to competitor
+claims too).
+
+**Never:** with fabricated competitor features (zero-proof law); for
+audience=artist above the fold (creator R9 — reads as agitation).
+
+## #recipe-launch (proven)
+
+**Reference:** `/launch`. **Audience:** general. **Sections (11):** hero →
+logo-cloud → feature-split ×6 → content-prose (why-now) → comparison → cta.
+
+**Arc:** announce → permission → thesis → capability → why-now → compare →
+action (long-form launch narrative).
+
+**CTA cadence:** sparse, "Get started", hero-and-close. **Long-form cap:** 14
+sections, ≤2 content-prose beats.
+
+**Decision tree:** `intent=launch AND conversion=start` (announcement +
+long-form narrative).
+
+**Never:** with more than 2 content-prose beats (long-form cap; emphasis
+budget); without a real launch moment (launch recipes date-stamp the
+announcement).
+
+## #recipe-waitlist (stub)
+
+**No (marketing) reference route** — `app/waitlist/page.tsx` exists outside the
+group. **Audience:** general. **Sections (4):** hero → capture → faq → cta.
+
+**Arc:** promise → capture → objection → action.
+
+**CTA cadence:** sparse, "Request access", hero-only (capture IS the conversion
+— no competing CTA).
+
+**Decision tree:** `conversion=request-access OR (waitlistEnabled=true AND
+traffic=home)` — highest precedence in the decision table (flips homepage CTAs).
+
+**Never:** with multiple competing CTAs (capture is the conversion — one input,
+one submit); without interaction states on capture (Design F2:
+submitting/success/error/already-subscribed).
+
+## #recipe-seo (proven)
+
+**Reference:** `/about` (also `/support`). **Audience:** general. **Sections
+(4):** hero → content-prose → faq → cta.
+
+**Arc:** frame → depth → objection → action.
+
+**CTA cadence:** sparse, "Get started", hero-and-close.
+
+**Decision tree:** `intent=informational` (FAQPage schema + structured data).
+Substitution: `content-prose` → `faq` (for pure FAQ pages — about/support where
+FaqSection carries the answer). **Long-form cap:** 6 sections, ≤2
+content-prose beats.
+
+**Never:** without FAQPage schema (the whole point of this recipe is
+structured data); with more than 2 content-prose beats (long-form cap).
+
+## #recipe-blog-landing (proven)
+
+**Reference:** `/blog` (also `/blog/category/[slug]`). **Audience:** general.
+**Sections (4):** hero → blog-feed → capture → cta.
+
+**Arc:** frame → browse → subscribe → action.
+
+**CTA cadence:** sparse, "Get started", hero-and-close.
+
+**Decision tree:** `intent=blog-index AND conversion=start OR subscribe`.
+Fallback: FAIL if blog-feed posts <3 (blog-landing requires ≥3 posts — omit the
+section means no blog).
+
+**Never:** with <3 blog posts (zero-proof analog for content); with capture as
+the primary conversion (blog-landing primary = read posts; capture = secondary
+newsletter signup).

--- a/docs/marketing/SECTION_CATALOG.md
+++ b/docs/marketing/SECTION_CATALOG.md
@@ -1,0 +1,240 @@
+<!--
+spec-version: 1.0.0
+doc-freshness: docs/marketing/SECTION_CATALOG.md
+-->
+# Marketing Section Catalog
+
+> **This is a commentary doc.** Per-section rationale + exemplar. Normative
+> rules (variants, chooseWhen, content budgets, a11y, responsive, failure
+> modes, neverUse) live in `apps/web/data/marketing/sections.ts`. Anchors
+> `#section-{id}` are parity-asserted against the registry by the manifest gate.
+
+17 sections. Nav / Footer / Subfooter excluded (charter delta #9 — layout-owned
+chrome, not page-composable).
+
+## Industry stable core (≥6/7 prior-art systems)
+
+### #section-hero
+
+**Purpose:** State the one category/outcome claim + one dominant CTA + one
+proof object in the first viewport. Does one loud thing.
+
+**Rationale:** B2B C1 (above-the-fold contract), C9 (emphasis budget). The hero
+sets the frame; everything else answers objections to it. The hero-viewport
+proof makes the claim non-arguable before the visitor invests scroll effort.
+
+**Exemplar:** `/artist-profiles` (artist-lp), `/new` (homepage),
+`/about` (seo `centered-none` variant).
+
+**Variant notes:** `centered-phone` is the artist-recipe default (phone-framed
+profile = hero-weight proof). `centered-handle-claim` is the Linktree-style
+claim bar (creator R2 — unproven; first use requires humanOptIn). `split-screenshot-right`
+is the homepage default. `centered-none` is the SEO/blog-landing interior hero.
+
+### #section-logo-cloud
+
+**Purpose:** Cheap scale/permission proof directly after hero. Two semantic
+modes: customer logos (B2B) OR DSP/platform-reach row (artist — Spotify, Apple
+Music: where the artist publishes, not who the customer is).
+
+**Rationale:** B2B C2 (canonical homepage macro-order slot 2), C4 (proof
+gradient — aggregate logos early). Creator R6: artist pages show DSPs the
+artist reaches, not customer logos — a semantic flip encoded as the
+`platform-reach-row` variant.
+
+**Exemplar:** `/artist-profiles` (`trust` section, `inline-strip` variant),
+`/launch` (`supported-platforms`, `platform-reach-row`).
+
+**Zero-proof:** `proofClass: 'trust'` — illegal without verified logos.
+
+### #section-feature-grid
+
+**Purpose:** Breadth survey before depth. Headline + 3/4/6 cards, each one
+capability. The reader learns the scanning pattern once; variation is carried
+by content, not layout (B2B C3 — the "chapter" pattern).
+
+**Rationale:** B2B C3 (one rigid template per section type). The GOAL's own
+example (`3-large / 4-equal / 6-compact / icon-list`) maps to Tailwind Plus
+exactly (prior-art §4).
+
+**Exemplar:** `/artist-profiles` (`outcomes` section — "Built for Artists").
+
+### #section-feature-split
+
+**Purpose:** One capability per section, depth after breadth. Media + text,
+alternating. The most common "chapter" section type.
+
+**Rationale:** B2B C3, C8 (feature page = homepage grammar at depth). Subsumes
+the shipped `adaptive` and `reactivation` instances (E6 derivation).
+
+**Exemplar:** `/artist-profiles` (`adaptive` → `screenshot-right`;
+`reactivation` → `bordered-screenshot-left`).
+
+### #section-how-it-works
+
+**Purpose:** 3-step onboarding strip ("create → customize → share"). Jovie
+promotes this to first-class (PUI "Product Steps" — usually folded into
+features elsewhere).
+
+**Rationale:** Creator cluster E (3-step onboarding strip is category-native
+for identity products). B2B C3 (numbered/sequenced feature-narrative).
+
+**Exemplar:** `/artist-profiles` (`howItWorks` — "Live In 60 Seconds").
+
+### #section-social-proof
+
+**Purpose:** Belief transfer at mid-page. Proof is a GRADIENT, not a top beat
+(B2B C4) — 3–5 beats escalating in specificity. Two-rung aspiration for
+artist recipes (creator R2: recognizable + peer).
+
+**Rationale:** B2B C4 (proof escalation gradient), creator R3 (proof =
+recognizable faces + live pages, not quotes), R5 (famous=profiles,
+quotes=small/relatable — never the reverse).
+
+**Exemplar:** `/artist-profiles` (`socialProof` section, `artist-carousel`).
+
+**Zero-proof:** `proofClass: 'proof'` — illegal without verified data.
+Substitute = screenshot-registry product render or OMIT.
+
+### #section-stats
+
+**Purpose:** Scale metric before the final CTA (B2B C2 slot 5 — the closing
+argument). Daily-granularity counters outperform static totals (creator R10).
+
+**Rationale:** B2B candidate rule 16 (scale metric immediately before final
+CTA, only when the number is real). Pre-scale: SKIP the beat entirely (charter
+no-invented-metrics rule).
+
+**Exemplar:** none shipped yet (legacy `HomeStatQuoteSection` — first
+artist-recipe use requires humanOptIn per DX2).
+
+**Zero-proof:** `proofClass: 'proof'` — every metric must be specific and
+attributable (B2B C4). Count-up animations banned (motion budget — show final).
+
+### #section-pricing
+
+**Purpose:** Tier cards above fold + one recommended tier + comparison matrix +
+FAQ-as-objection-handler + dual-path close (B2B C7).
+
+**Rationale:** B2B C7 (remarkably uniform across 5 properties). Creator R8:
+no pricing table on artist LP — one-liner + link, cost-objection in CTA string
+(`one-liner-link` variant, embedded in `monetization`).
+
+**Exemplar:** `/pricing` (`tier-cards-recommended`).
+
+### #section-comparison
+
+**Purpose:** Feature-by-feature vs competitor. Verdict above the fold on
+desktop for the comparison-page recipe.
+
+**Rationale:** B2B C7 (comparison matrix below tier cards on pricing). Creator
+R9: comparison above the fold for `audience=artist` reads as agitation —
+encoded as `audienceLegality`.
+
+**Exemplar:** `/compare/linktree` (`feature-matrix`), `/launch`
+(`side-by-side-split` embedded).
+
+### #section-faq
+
+**Purpose:** Structural objection-handling. Near objections (after pricing on
+pricing-page; after proof on artist-lp). FAQPage schema on SEO pages.
+
+**Rationale:** B2B C7 (FAQ near objections — every observed property carries
+it except Linear, the gap). Creator cluster (no objection-handling on
+artist-recipe heroes).
+
+**Exemplar:** `/artist-profiles` (`faq`), `/about` (`structured-data-list`).
+
+### #section-cta
+
+**Purpose:** Final CTA restatement. Dual-path (self-serve + talk-to-us) for
+non-artist audiences; single claim for artist (creator F — one CTA string,
+possession verb, cost-objection in button).
+
+**Rationale:** B2B C6 (final CTA section is a universal named section type).
+C2 (closing argument after scale metric). Creator F (one CTA string repeated
+verbatim — not varied per section).
+
+**Exemplar:** `/artist-profiles` (`finalCta`).
+
+## Jovie deltas (no clean industry equivalent)
+
+### #section-spec-wall
+
+**Purpose:** Dense compact feature grid — "Details That Matter." Tiles carry a
+screenshot or icon; pure text = use `feature-grid` icon-list variant.
+
+**Rationale:** Jovie delta (prior-art §3). Closest industry name: Feature List
+/ dense compact grid. Documented as a Jovie delta per charter delta #4.
+
+**Exemplar:** `/artist-profiles` (`specWall` — dense-compact-grid),
+`/new` (`power-grid` — bento).
+
+### #section-capture
+
+**Purpose:** Fan-capture as a PRODUCT DEMO, not just an email form. Phone-framed
+capture demo for artist recipes; email-only for waitlist/blog-landing.
+
+**Rationale:** Jovie delta (prior-art §3). Capture is a product demo showing
+the value of capture, with interaction states (submitting/success/error/
+already-subscribed) per Design F2 layout-shift contract.
+
+**Exemplar:** `/artist-profiles` (`capture` — "Capture Every Fan", `product-demo`).
+
+### #section-monetization
+
+**Purpose:** Take-rate transparency + named micro case study with
+streaming-equivalence math ("$X = Y streams"). Never projected personal
+earnings (creator R3).
+
+**Rationale:** Jovie delta (prior-art §3). Creator R12 (take-rate/pricing
+transparency belongs on-page — hiding economics is a 2024-2026 trust smell).
+Creator R3 (streaming-equivalence is the signature pre-scale proof device).
+
+**Exemplar:** `/artist-profiles` (`monetization` — `take-rate-transparency`).
+
+### #section-ownership
+
+**Purpose:** Own-your-fans/data/earnings; export anytime; no gatekeeper. The
+artist-recipe emotional differentiator vs DSPs/link-in-bio.
+
+**Rationale:** Jovie delta. Creator R9 (ownership section REQUIRED in artist-lp
+recipes competing with DSPs/link-in-bio — the category's core emotional
+differentiator). Creator R6 (ownership/control beat precedes revenue proof
+for artist audiences).
+
+**Exemplar:** none shipped yet — first implementer creates the component; first
+use requires humanOptIn per DX2.
+
+## Long-form / editorial (SEO + blog-landing recipes)
+
+### #section-content-prose
+
+**Purpose:** Article body / long-form prose (680px `prose` container).
+Founder-letter and release-notes are variants for the launch recipe.
+
+**Rationale:** B2B C8 (feature page = homepage grammar at depth — content-prose
+is the editorial variant). Charter P4 rules for long-form pages.
+
+**Exemplar:** `/blog/[slug]` (article body — exempt as dynamic content page;
+first feature use requires component extraction).
+
+### #section-blog-feed
+
+**Purpose:** Featured post + grid. Featured spans full width above grid at md+.
+
+**Rationale:** B2B C2 (blog-landing is a distinct recipe). Prior-art §3
+(blog/content is 5/7 systems). Featured post is the editorial emphasis.
+
+**Exemplar:** `/blog` (`featured-grid`), `/blog/category/[slug]`
+(`category-filtered-grid`).
+
+---
+
+**Long-tail industry types deliberately NOT adopted** (prior-art §3): team,
+contact, gallery, timeline, integrations, case-studies, careers, about,
+download, awards, compliance, banner, problem (as a section), solution (as a
+section), benefits (as a section), workflow (as a section). Add only via the
+Extension Rules (ARCHITECTURE.md §12) when a recipe requires one. Problem,
+solution, benefits are COPY PATTERNS inside feature sections, not section
+types (prior-art §2).


### PR DESCRIPTION
Per-section + per-recipe rationale. Normative rules in registry (PR1 #13460); these catalogs own rationale + exemplar and link by stable id (#section-{id}, #recipe-{id} — manifest gate asserts parity).

SECTION_CATALOG.md (240 lines): 17 sections with purpose, rationale, exemplar, variant notes, zero-proof flags, never-use rules.

RECIPE_CATALOG.md (217 lines): 11 recipes (8 proven, 3 stub) with section order, emotional arc, CTA cadence, decision tree, substitutions, fallbacks, never-use.

Stack: PR3 of 5. Depends on PR2.