### PR TITLE
chore(ui): migrate marketing rules to registry (PR5/5)

### DIFF
--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -155,13 +155,10 @@ The `DashboardHeader` breadcrumb already renders the page name prominently. Do N
 - Jovie product UI must feel closer to Linear than generic AI-generated dashboards: compact, quiet, precise, and premium.
 - Default to small typography, restrained weight changes, and clean spacing before adding decorative treatment.
 - Do **NOT** use all-caps labels, eyebrow text, or section headers as a default styling move; use normal Title Case labels unless an existing canonical pattern explicitly calls for something else.
-- For marketing sections, the default composition is: one headline, one subhead, one visual. Do not add eyebrow text, labels, proof bars, separators, helper rows, or extra wrapper cards unless a human explicitly asks for that exact element.
-- Eyebrow text is banned by default on marketing pages. Only add an eyebrow when a human explicitly requests it for that exact section.
-- For homepage-style marketing heroes, treat the first viewport like a poster: do not inset the hero inside a floating card, and do not push the primary proof element below the fold with a `100vh` shell plus extra stacked content. The initial viewport must include the full hero composition and the first proof beat together.
+- For marketing sections, the default composition, eyebrow rules, above-the-fold contract, AI-mockup bans, and fake-proof/founder-first bans are now owned normatively by the marketing registry (`apps/web/data/marketing/`) — see `docs/marketing/AGENT_GUIDE.md`. The rules below are retained only where they apply to non-marketing UI.
 - Do **NOT** wrap content in a Card when the parent surface (Sheet, Drawer, existing Card) already provides visual grouping; first solve hierarchy with spacing, alignment, type, and surface contrast.
 - Nested decorative carding around a phone, screenshot, or demo is banned by default. If the visual already lives inside a phone, drawer, or screenshot, do not wrap it in extra floating cards just to make it feel designed.
 - Borders are a supporting tool, not the main design language; if a border can be removed without losing meaning, remove it.
-- Avoid the common AI mockup pattern of tiny uppercase eyebrow + long explanatory paragraph inside a large rounded bordered card.
 - Prefer one compact, well-set label and one clear body line over stacked label, headline, description, and chrome all saying the same thing.
 - When revising a marketing layout and the direction is unclear, do not add explanatory copy or chrome as a hedge. The fallback is subtraction: headline, subhead, one visual.
 - When implementing or revising UI, compare the result against this smell test: if it looks like a generic AI admin template, it is off-style and should be simplified.
@@ -289,4 +286,4 @@ When building or iterating on the Artist Profiles landing page:
 - Keep this page distinct from generic bio-link competitors and generic creator-site tools.
 - Keep copy in data files, not inline JSX.
 - Iterate section by section in browser instead of trying to style the whole page in one pass.
-- Do not use fake stats, fake testimonials, or founder-first proof near the top of the page.
+- Marketing fake-proof/founder-first rules are now owned normatively by the marketing registry (`apps/web/data/marketing/`) — see `docs/marketing/AGENT_GUIDE.md` (zero-proof path: proof/trust sections illegal without verified data).


### PR DESCRIPTION
Canon precedence deletion: migrate the marketing-specific rules from .claude/rules/ui.md INTO the typed marketing registry (PR1 #13460), per the canon precedence table (ARCHITECTURE.md §11, DX12).

Migrated to registry (deleted from ui.md):
- marketing default composition -> recipes.ts PageHierarchyContract
- eyebrow banned by default on marketing -> sections.ts optionalInputs
- homepage hero first-viewport poster rule -> recipes.ts aboveTheFoldContract
- AI mockup eyebrow+paragraph pattern -> sections.ts neverUse on hero
- fake stats/testimonials/founder-first -> sections.ts proofClass + neverUse

Retained in ui.md (apply app-wide): all-caps labels, Card wrapping, nested decorative carding, borders, one compact label, subtraction fallback, AI admin template smell test, copy in data files, iterate section by section.

**Risk: agent-control-plane (high)** — .claude/rules/* is the agent control plane. Per PR_FLOW.md, this PR gets needs-human hold by design (not a bug). The deletion is mechanical (5 lines removed, 2 added explaining the migration) and the registry is verified green (33/33 manifest gate tests).

Stack: PR5 of 5 (top). Depends on PR4.