### PR TITLE
docs(marketing): architecture + composition rules (PR2/5)

### DIFF
--- a/docs/marketing/ARCHITECTURE.md
+++ b/docs/marketing/ARCHITECTURE.md
@@ -1,0 +1,343 @@
+<!--
+spec-version: 1.0.0
+doc-freshness: docs/marketing/ARCHITECTURE.md
+-->
+# Marketing Architecture
+
+> **This is a commentary doc.** Normative rules (chooseWhen, legality, ordering,
+> ctaCadence, decision table, lifecycle, hierarchy contracts, degradation
+> ladders) live in the typed registry at `apps/web/data/marketing/`. This file
+> owns rationale + the canon precedence table + naming/versioning/evolution
+> strategy. Agents: start at [`AGENT_GUIDE.md`](./AGENT_GUIDE.md) — it is the
+> sole entrypoint (≤400 lines). This file is reference.
+
+spec-version: 1.0.0 · registry: `apps/web/data/marketing/index.ts` ·
+charter: `.context/marketing-architecture/GOAL.md` (amended, sole authority) ·
+reviews: CEO + Eng + Design + DX (all CLEAR, final gate A, 2026-07-06).
+
+## 1. What this is
+
+A permanent architecture that every current and future Jovie marketing page is
+built from. The "React + design-system equivalent of Tailwind for marketing
+pages." A future autonomous agent receives only `{businessObjective,
+targetAudience, desiredConversion, availableAssets}` and generates a beautiful,
+performant, accessible landing page **without inventing new layouts** — by
+selecting recipes and section variants from this system.
+
+The contract for consumer agents:
+> A composition needs ONLY `docs/marketing/AGENT_GUIDE.md` +
+> `apps/web/data/marketing/` (the typed registry). Reading any other file is
+> optional commentary.
+
+## 2. System shape
+
+```
+GOAL.md (charter) ──▶ research digests ──▶ typed registry (apps/web/data/marketing/)
+                                                  │ owns ALL normative rules
+                                                  │ - sections.ts: taxonomy + variants + chooseWhen + lifecycle
+                                                  │ - recipes.ts:  11 recipes + arc + ctaCadence + hierarchy
+                                                  │ - composition.ts: resolveComposition(brief) → tuple (Zod)
+                                                  │ - routeManifest.ts: route ⇔ recipeId | exempt
+                                                  │
+                         docs/marketing/*.md ◀────┘ owns rationale only; links by stable id
+                                                  │
+                         manifest gate (vitest) ──▶ enforces: kebab ids, anchor parity, ratchets,
+                                                  │   proven-recipe reference routes, golden-fixture
+                                                  │   determinism (3 briefs × 2 runs tuple-diff)
+                                                  │
+                         consumer agents ◀────── resolveComposition(brief) → MarketingComposition
+                                                  │ bounded taste only within degradation rung
+                                                  ▼
+                         marketing pages (fully static, dark-only)
+```
+
+## 3. Grammar (first principles)
+
+The smallest complete grammar required to describe every Jovie marketing page.
+
+| Grammar | Defined in | Rule |
+|---|---|---|
+| **page** | `recipes.ts` | A page = a recipe (ordered sections) + one big idea + CTA cadence. Recipes are two-tier: `proven` (shipped reference route) vs `stub` (order + arc only). |
+| **layout** | `sections.ts` `VariantLayout` | `centered \| split \| contained \| full-bleed`. The primary axis in every prior-art system. |
+| **spacing** | DESIGN.md (inherited) | `section-spacing-linear` tokens; spacing-only transitions; one container width (`page \| prose`). NOT restated. |
+| **hierarchy** | `recipes.ts` `PageHierarchyContract` | One big idea; seeFirst/second/third; emphasis budget (max 1 display-scale moment, 1 full-bleed break, 1 hero-weight proof element). |
+| **responsive** | `sections.ts` `responsiveContract` | A fixed contract per variant (Tailwind Plus stance): grid 3→2→1 collapse, split→stack at md, priority-based slot hiding. NOT per-breakpoint style overrides. |
+| **interaction** | `sections.ts` `accessibility` + capture states | Form-bearing sections require submitting/success/error/already-subscribed states with height-stable slots (layout-shift contract). |
+| **animation** | Motion budget (charter design law #9, T2) | Scroll-reveal OFF by default; max 1 cinematic moment/page (hero media only); subtle tier elsewhere; reduced-motion mandatory. |
+| **visual rhythm** | `sections.ts` `contentBudgets` + emphasis budget | Per-slot character budgets per breakpoint; `text-wrap: balance` default; one accent reserved for conversion affordances. |
+| **content hierarchy** | `recipes.ts` `arc` + `hierarchy` + `minContent/maxContent` | Emotional arc per recipe (artist arc ≠ B2B arc); content density bounds. |
+
+Every rule exists for a reason — see the research digests at
+`.context/marketing-architecture/research/`. Anti-patterns are encoded as
+`neverUse` on sections and recipes.
+
+## 4. Section taxonomy
+
+17 sections (capped to prevent variant explosion — prior-art §8 finding 2).
+Nav / Footer / Subfooter are EXCLUDED per charter delta #9 (layout-owned chrome).
+
+| # | id | industry / Jovie delta | proof class |
+|---|---|---|---|
+| 1 | `hero` | industry (7/7) | none |
+| 2 | `logo-cloud` | industry (6/7) | trust |
+| 3 | `feature-grid` | industry (7/7) | none |
+| 4 | `feature-split` | industry (7/7) | none |
+| 5 | `how-it-works` | industry (PUI) — promoted to first-class | none |
+| 6 | `social-proof` | industry (6/7) | **proof** (zero-proof gated) |
+| 7 | `stats` | industry (4/7) | **proof** (zero-proof gated) |
+| 8 | `pricing` | industry (7/7) | none |
+| 9 | `comparison` | industry (4/7) | none |
+| 10 | `faq` | industry (7/7) | none |
+| 11 | `cta` | industry (6/7) | none |
+| 12 | `spec-wall` | **Jovie delta** | none |
+| 13 | `capture` | **Jovie delta** (fan-capture product demo) | none |
+| 14 | `monetization` | **Jovie delta** | none |
+| 15 | `ownership` | **Jovie delta** (artist-recipe emotional differentiator) | none |
+| 16 | `content-prose` | industry (2/7) | none |
+| 17 | `blog-feed` | industry (5/7) | none |
+
+Full per-section definitions (required/optional inputs, variants, responsive,
+a11y, content budgets, failure modes, never-use rules): see
+[`SECTION_CATALOG.md`](./SECTION_CATALOG.md) for rationale + the registry
+(`apps/web/data/marketing/sections.ts`) for normative rules.
+
+## 5. Variant system
+
+Variants are typed tuples over orthogonal axes (prior-art §4 recommendation),
+NOT arbitrary names. This is the Jovie delta that prevents the shadcn/Relume
+variant-explosion failure mode (245 heroes, 311 features).
+
+```
+variant = { layout, media, mediaPosition?, columns?, density?, alignment? }
+variant id DERIVED mechanically: {layout}[-{media}[-{mediaPosition}]][-{columns}{density?}]
+examples: hero/centered-phone, feature-grid/3-large, feature-split/screenshot-right
+```
+
+Per-section legal subsets keep the space small. Every section has exactly one
+`defaultVariant` (no-match fallback — never "agent judgment"). Variant
+selection is a TOTAL ORDER per section (no chooseWhen ties).
+
+Variants without a shipped exemplar are `status: 'unproven'` and require
+`humanOptIn` (manifest field per DX2) on first use.
+
+## 6. Composition rules
+
+See [`COMPOSITION_RULES.md`](./COMPOSITION_RULES.md) for rationale. Normative
+rules live in `sections.ts` (`illegalAfter`, `requiresPrior`,
+`audienceLegality`) and `recipes.ts` (`sectionOrder`, `arc`,
+`ctaCadence`).
+
+The load-bearing laws:
+- Hero is always first.
+- Pricing never before value proposition (illegalAfter `hero`; requiresPrior `hero, feature-grid`).
+- Testimonials only after credibility exists (social-proof requiresPrior `hero, feature-grid`).
+- FAQ near objections (illegalAfter `hero`; handles objections that arise AFTER value).
+- CTA cadence is a declared budget; mid-page CTAs only after proof beats.
+- Zero-proof path: proof/trust sections ILLEGAL without verified data — substitute = screenshot-registry product render or OMIT.
+- Page-length caps per recipe (`maxContent`).
+- Artist arc has NO problem-agitation beat (creator R9) — encoded as audienceLegality on sections + neverUse on recipes.
+
+## 7. Recipe system
+
+11 recipes, two-tier (Design F10): proven (shipped reference route) vs stub
+(order + arc only; first implementation promotes).
+
+| id | status | reference | audience |
+|---|---|---|---|
+| `homepage` | proven | `/new` | general |
+| `pricing` | proven | `/pricing` | general |
+| `artist-lp` | proven | `/artist-profiles` | artist |
+| `feature` | proven | `/artist-notifications` | artist |
+| `comparison` | proven | `/compare/linktree` | general |
+| `launch` | proven | `/launch` | general |
+| `seo` | proven | `/about` | general |
+| `blog-landing` | proven | `/blog` | general |
+| `waitlist` | stub | — | general |
+| `agency-lp` | stub | — | agency |
+| `enterprise` | stub | — | enterprise-buyer |
+
+Full per-recipe definitions (section order, arc, hierarchy, ctaCadence,
+substitutions, fallbacks, min/max content): see
+[`RECIPE_CATALOG.md`](./RECIPE_CATALOG.md) for rationale + the registry
+(`apps/web/data/marketing/recipes.ts`) for normative rules.
+
+## 8. Decision engine
+
+`resolveComposition(brief)` → `MarketingComposition`. Deterministic algorithm
+owned by `composition.ts`. Determinism boundary (D1=B):
+
+- **DETERMINISTIC (machine)**: recipe, section order, variants, CTA cadence.
+- **BOUNDED TASTE (human, post-ship feedback)**: imagery-within-ladder, density, copy.
+
+Algorithm:
+1. Recipe selection: walk `RECIPE_DECISION_TABLE`; first match wins.
+2. Section sequence: take `recipe.sectionOrder`.
+3. Legality filter: drop sections illegal for the audience (`audienceLegality`).
+4. Zero-proof filter: drop proof/trust sections without verified data.
+5. Ordering legality: drop sections whose `illegalAfter`/`requiresPrior` are violated.
+6. Variant selection: per section, walk variants; first match wins; no-match → `defaultVariant`.
+7. CTA position assignment: hero=primary, cta section=primary (terminal), capture=primary (waitlist/blog-landing).
+8. Trace: record every step for the AGENT_GUIDE worked example + failure messages.
+
+The output tuple (`MarketingComposition`) has an owned Zod schema (DX11):
+`{ specVersion, recipeId, sections: [{sectionId, variantId, ctaPosition, proofVerified, degradationRung}], primaryCtaLabel, secondaryCtaLabel?, ctaCadence, trace }`.
+
+The golden-fixture determinism gate (3 blind briefs × 2 runs → identical tuples)
+is a committed vitest test that runs on every PR forever — not one-shot.
+
+## 9. Naming conventions
+
+| Convention | Source | Rule |
+|---|---|---|
+| kebab-case ids | charter delta #9 | All section/variant/recipe ids kebab-case; regex-asserted `/^[a-z][a-z0-9-]*$/` in the manifest gate. |
+| Anchor rule | DX12 | `#section-{sectionId}` and `#recipe-{recipeId}` — manifest gate asserts docs⇔registry parity. |
+| Variant id | prior-art §4 | DERIVED from the typed axis tuple, not invented. |
+| CamelCase→kebab mapping | E6 | `artistProfilePageOrder.ts` camelCase → registry kebab (see codebase-baseline §5). `specWall` → `spec-wall`, `howItWorks` → `how-it-works`, `finalCta` → `cta`, `socialProof` → `social-proof`, `outcomes` → `feature-grid`. |
+| Barrel exports | DX4 | `apps/web/data/marketing/index.ts` exports `MARKETING_SECTIONS`/`MARKETING_RECIPES`/`MARKETING_ROUTE_MANIFEST`/`MARKETING_SPEC_VERSION`/`resolveComposition` + all types. |
+
+## 10. Lifecycle + versioning
+
+`MARKETING_SPEC_VERSION` lives in `composition.ts`, re-exported from `index.ts`,
+echoed into docs via the `spec-version:` freshness marker (this file's header).
+Spec-doc version drift fails Structural Contract doc-freshness (E13).
+
+| Bump type | When |
+|---|---|
+| **patch** | Doc-only rationale edits; no registry change. |
+| **minor** | Add a section, recipe, or variant; add a route mapping. Backward-compatible. |
+| **major** | Remove or deprecate a section/recipe/variant; change a chooseWhen predicate; reorder a recipe's sectionOrder. Requires lifecycle fields (`status: 'deprecated'`, `deprecatedSince`, `replacedBy`) + canon precedence update. |
+
+Section/variant lifecycle: `status: 'active' | 'deprecated' | 'removed'`.
+`deprecated` requires `deprecatedSince` + `replacedBy` (must reference an active
+id, test-asserted). `removed` usage = hard fail naming `replacedBy`.
+
+Two ratchets (decrease-only baselines):
+- **Exemption ratchet**: unsanctioned exemptions (missing `linearId`/`approvedBy`/`prUrl`) must not increase. Baseline: 0.
+- **Deprecation ratchet**: deprecated section/variant usage count must not increase. Baseline: 0.
+
+When the spec version bumps: see [`AGENT_GUIDE.md`](./AGENT_GUIDE.md) §"When the
+spec version bumps" (4-step procedure).
+
+## 11. Canon precedence table (charter delta #6, DX12)
+
+> Adding 5 docs and deleting 0 canon lines fails review. Rules that affect
+> composition MUST migrate INTO the registry so composition requires zero
+> DESIGN.md/ui.md reads. The `needed for composition?` column is the
+> load-bearing distinction.
+
+| Rule | Old canon | New owner | Needed for composition? | Action |
+|---|---|---|---|---|
+| Dark-only theme for marketing | DESIGN.md System A | charter delta #9 + AGENT_GUIDE §Inherited | yes (variant `theme` axis excluded) | MIGRATED — delete the marketing-theme prose from DESIGN.md in the canon-deletion PR |
+| Fully static (`revalidate = false`) | .claude/rules/ui.md | AGENT_GUIDE §Inherited | yes (composition emits static only) | STAYS in ui.md (also applies to non-marketing); AGENT_GUIDE references |
+| One body face, one container width | DESIGN.md | AGENT_GUIDE §Inherited | yes (registry does not model these axes) | MIGRATED reference — delete the per-section restatements from DESIGN.md |
+| Section spacing (`section-spacing-linear`) | DESIGN.md | `sections.ts` `responsiveContract` + DESIGN.md tokens | yes (variant contracts reference it) | STAYS in DESIGN.md (token definitions); AGENT_GUIDE references |
+| Eyebrow text banned by default | .claude/rules/ui.md | `sections.ts` `optionalInputs` (eyebrow is optional; banned unless section declares it) | yes | MIGRATED — delete the marketing-eyebrow rule from ui.md |
+| Logo Cloud / Metrics / Testimonials fake-proof rules | .claude/rules/ui.md | `sections.ts` `proofClass: 'trust'/'proof'` + `neverUse` | yes (zero-proof path) | MIGRATED — delete the marketing-specific fake-proof rules from ui.md |
+| Founder-first proof banned near top of artist pages | .claude/rules/ui.md | `social-proof` `neverUse` + `artist-lp` `neverUse` | yes (audience-gated legality) | MIGRATED — delete from ui.md |
+| Default marketing composition = one headline, one subhead, one visual | .claude/rules/ui.md | `recipes.ts` `PageHierarchyContract` + `hero` content budgets | yes | MIGRATED — delete the default-composition rule from ui.md |
+| Layout-shift contract (height-stable slots) | .claude/rules/ui.md | `capture` `accessibility` + `faq` `accessibility` + DESIGN.md | yes (interaction states) | STAYS in ui.md (applies app-wide); AGENT_GUIDE references |
+| Screenshot registry scenario IDs | `lib/screenshots/registry.ts` | `sections.ts` `MARKETING_DEGRADATION_LADDERS` sourceConstraint | yes (proof asset binding) | STAYS (system of record); registry references |
+| Copy-in-data files | .claude/rules/code-style.md | AGENT_GUIDE §Inherited | yes (composition assumes copy-in-data) | STAYS in code-style.md (applies app-wide) |
+
+The canon-deletion PR (PR5, smoke-lane class — `.claude/rules/*` is agent
+control plane, high-risk) physically deletes the MIGRATED rows from DESIGN.md
+and ui.md. Stays-rows are referenced, not duplicated.
+
+## 12. Extension rules
+
+Adding a new section/recipe/variant:
+1. Add to the registry (`sections.ts` or `recipes.ts`) with a kebab-case id.
+2. Declare `status: 'unproven'` if no shipped exemplar; first use requires `humanOptIn` (DX2).
+3. Add a golden-fixture brief that exercises the new path (determinism regression-tested forever).
+4. Bump `MARKETING_SPEC_VERSION` (minor for addition).
+5. Add the docs anchor (`#section-{id}` or `#recipe-{id}`) — manifest gate asserts parity.
+6. If the addition MIGRATES a canon rule, add it to the precedence table + schedule the canon-deletion.
+
+Adding a new route:
+1. Add to `routeManifest.ts` with `recipeId` or sanctioned `exempt` (DX2: `linearId` + `approvedBy` + `prUrl`).
+2. If exempt and unsanctioned, the exemption ratchet fails — must carry all three fields.
+
+## 13. Migration strategy
+
+The artist-lp recipe imports/derives from `ARTIST_PROFILE_SECTION_ORDER`
+(`apps/web/data/artistProfilePageOrder.ts`) — order-equivalence is a
+follow-up Linear issue (filed at ship time), not blocking. The existing
+`artistProfilePageOrder.ts` + `artistNotificationsPageOrder.ts` become
+instances of the general registry (E6 derivation).
+
+Render-time recipe verification (DX8): sections render
+`data-testid="marketing-section-{sectionId}"`; registry gains `component` path
+per section; manifest test statically asserts proven-recipe reference routes
+import components 1:1 with recipe sectionIds. Full render-time verification =
+Linear follow-up filed at ship time.
+
+## 14. Future evolution strategy
+
+- **Stable for years** is the wrong contract (CEO S10). The spec has a version
+  field + quarterly-review trigger + Extension Rules (§12).
+- **Conversion-instrumentation contract** (CEO cherry-pick 5, docs-only): every
+  generated page emits section-level conversion signal so the decision engine
+  gains data over time. Implementation is a Linear follow-up.
+- **Claude Design synchronization**: the code repo is the source of truth; the
+  Claude Design project mirrors (per prior decision). Spec states this
+  direction explicitly.
+- **`trafficSource` semantics** (adversarial A6): the `trafficSource` enum
+  includes `'home'` which is used by the decision table as "this brief targets
+  the home route," NOT "visitor came from the homepage." A future spec version
+  may split this into `routeRole` (home/marketing/blog) vs `trafficSource`
+  (search/social/referral/etc.) for semantic clarity. Documented here; not
+  blocking v1.0.0.
+- **`fan` audience** (adversarial J1): `fan` is in the audience enum but has no
+  recipe yet — fan briefs fall to `seo` (catch-all). A `fan-lp` recipe (arc:
+  consume → discover → follow → listen) is a Linear follow-up. Until it exists,
+  fan is a documented phantom audience.
+- **Problem-section legality** (adversarial G1): there is no `problem` section
+  type in the registry (per prior-art §2 — problem is a COPY PATTERN inside
+  feature sections, not a section type). The artist-arc "no problem beat" rule
+  (creator R9) is therefore encoded at the copy level (the `neverUse` on
+  `feature-split` warns against problem-agitation copy for artist audience) and
+  at the recipe level (`artist-lp` `neverUse`), not at the section-type level.
+  If a future `problem-agitation` section is added per Extension Rules (§12),
+  it MUST carry `audienceLegality` illegal for `audience=artist`.
+
+## 15. Linear follow-ups (filed at ship time per no-orphan rule)
+
+1. **JOV-TBD**: Migrate `artistProfilePageOrder.ts` to be an instance of the
+   general marketing registry (E6 derivation). Order-equivalence test.
+2. **JOV-TBD**: Render-time recipe verification via layout-guard/E2E lanes
+   (DX8): sections render `data-testid`; proven-recipe reference routes
+   import components 1:1 with recipe sectionIds.
+3. **JOV-TBD**: `fan-lp` recipe (stub) — arc: consume → discover → follow →
+   listen. Removes the `fan` phantom-audience gap (adversarial J1).
+4. **JOV-TBD**: `newsletter-signup` recipe (stub) — `hero → capture → faq →
+   cta` for standalone newsletter signup pages (adversarial C1). Today
+   `desiredConversion='subscribe'` with `intent≠'blog-index'` falls to seo.
+5. **JOV-TBD**: `security` / `trust-center` recipe (stub) — enterprise
+   security/compliance page with SOC2/GDPR badges, sub-processor list
+   (adversarial C2). Today enterprise security is in `faq`; a standalone
+   `/security` LP needs its own recipe.
+6. **JOV-TBD**: `integrations-lp` recipe (stub) — integrations catalog with
+   per-integration detail (adversarial C3). Today `/integrations` has no recipe.
+7. **JOV-TBD**: `founder-letter` vs `release-notes` variant disambiguation
+   (adversarial B2) — add an `editorialForm` Brief field OR allow 2
+   `content-prose` slots in `launch`. Today both variants target the same
+   slot; `founder-letter` wins on declared order, `release-notes` is unreachable.
+8. **JOV-TBD**: DESIGN.md System A marketing-theme prose deletion — coordinated
+   with the ongoing System A retirement (2026-06-18 founder-directed). The
+   registry references "charter delta #9 + AGENT_GUIDE §Inherited" as the
+   binding contract; the physical DESIGN.md deletion ships in a later PR.
+9. **JOV-TBD**: Split `trafficSource='home'` into `routeRole` vs `trafficSource`
+   (adversarial A6) — semantic clarity for v2.0.
+
+## 16. Documentation map
+
+| File | Owns | Lines |
+|---|---|---|
+| `AGENT_GUIDE.md` | Sole entrypoint for consumer agents (procedure + worked example + failure table + escape hatch). | ≤400 |
+| `SECTION_CATALOG.md` | Per-section rationale + exemplar. Normative rules in registry. | ~30 lines/section |
+| `RECIPE_CATALOG.md` | Per-recipe rationale + arc + decision tree. Normative rules in registry. | ~50 lines/recipe |
+| `COMPOSITION_RULES.md` | Composition-rule rationale (ordering, CTA cadence, zero-proof, page-length). Normative rules in registry. | ~300 |
+| `ARCHITECTURE.md` (this file) | Master spec + grammar + naming/versioning/precedence/evolution. | ~400 |
+
+Index entry: CLAUDE.md Documentation Map row → `docs/marketing/AGENT_GUIDE.md`
+(per E7 — REPLACES a row, doesn't add; CLAUDE.md is at the 119/120 line cap).

--- a/docs/marketing/ARCHITECTURE.md
+++ b/docs/marketing/ARCHITECTURE.md
@@ -302,31 +302,31 @@ Linear follow-up filed at ship time.
 
 ## 15. Linear follow-ups (filed at ship time per no-orphan rule)
 
-1. **JOV-TBD**: Migrate `artistProfilePageOrder.ts` to be an instance of the
+1. **JOV-4064**: Migrate `artistProfilePageOrder.ts` to be an instance of the
    general marketing registry (E6 derivation). Order-equivalence test.
-2. **JOV-TBD**: Render-time recipe verification via layout-guard/E2E lanes
+2. **JOV-4065**: Render-time recipe verification via layout-guard/E2E lanes
    (DX8): sections render `data-testid`; proven-recipe reference routes
    import components 1:1 with recipe sectionIds.
-3. **JOV-TBD**: `fan-lp` recipe (stub) — arc: consume → discover → follow →
+3. **JOV-4066**: `fan-lp` recipe (stub) — arc: consume → discover → follow →
    listen. Removes the `fan` phantom-audience gap (adversarial J1).
-4. **JOV-TBD**: `newsletter-signup` recipe (stub) — `hero → capture → faq →
+4. **JOV-4067**: `newsletter-signup` recipe (stub) — `hero → capture → faq →
    cta` for standalone newsletter signup pages (adversarial C1). Today
    `desiredConversion='subscribe'` with `intent≠'blog-index'` falls to seo.
-5. **JOV-TBD**: `security` / `trust-center` recipe (stub) — enterprise
+5. **JOV-4068**: `security` / `trust-center` recipe (stub) — enterprise
    security/compliance page with SOC2/GDPR badges, sub-processor list
    (adversarial C2). Today enterprise security is in `faq`; a standalone
    `/security` LP needs its own recipe.
-6. **JOV-TBD**: `integrations-lp` recipe (stub) — integrations catalog with
+6. **JOV-4069**: `integrations-lp` recipe (stub) — integrations catalog with
    per-integration detail (adversarial C3). Today `/integrations` has no recipe.
-7. **JOV-TBD**: `founder-letter` vs `release-notes` variant disambiguation
+7. **JOV-4070**: `founder-letter` vs `release-notes` variant disambiguation
    (adversarial B2) — add an `editorialForm` Brief field OR allow 2
    `content-prose` slots in `launch`. Today both variants target the same
    slot; `founder-letter` wins on declared order, `release-notes` is unreachable.
-8. **JOV-TBD**: DESIGN.md System A marketing-theme prose deletion — coordinated
+8. **JOV-4071**: DESIGN.md System A marketing-theme prose deletion — coordinated
    with the ongoing System A retirement (2026-06-18 founder-directed). The
    registry references "charter delta #9 + AGENT_GUIDE §Inherited" as the
    binding contract; the physical DESIGN.md deletion ships in a later PR.
-9. **JOV-TBD**: Split `trafficSource='home'` into `routeRole` vs `trafficSource`
+9. **JOV-4072**: Split `trafficSource='home'` into `routeRole` vs `trafficSource`
    (adversarial A6) — semantic clarity for v2.0.
 
 ## 16. Documentation map

--- a/docs/marketing/COMPOSITION_RULES.md
+++ b/docs/marketing/COMPOSITION_RULES.md
@@ -1,0 +1,194 @@
+<!--
+spec-version: 1.0.0
+doc-freshness: docs/marketing/COMPOSITION_RULES.md
+-->
+# Marketing Composition Rules
+
+> **This is a commentary doc.** Normative composition rules live in the typed
+> registry: `sections.ts` (`illegalAfter`, `requiresPrior`, `audienceLegality`,
+> `neverUse`), `recipes.ts` (`sectionOrder`, `arc`, `ctaCadence`,
+> `maxContent`), and `composition.ts` (the filter pipeline). This file owns
+> the rationale. Agents: start at [`AGENT_GUIDE.md`](./AGENT_GUIDE.md).
+
+The composition rules cluster into seven laws, each with a reason and a
+machine-checkable home.
+
+## Law 1 — Hero is always first
+
+Every recipe's `sectionOrder[0] === 'hero'`. The hero does one loud thing:
+state the category/outcome claim, show one proof object, offer one dominant CTA.
+
+**Reason:** the hero sets the frame; everything else answers objections to it
+(B2B C1, C2). Multiple audiences or feature-listing in the hero dilutes
+conversion (B2B anti-patterns #1, #2).
+
+**Home:** `recipes.ts` `sectionOrder[0]` + `sections.ts` `hero.illegalAfter: []`.
+
+## Law 2 — Pricing never before value proposition
+
+`pricing` has `illegalAfter: ['hero']` and `requiresPrior: ['hero', 'feature-grid']`.
+Pricing needs value framing first (B2B C7: every observed property puts at least
+a headline claim or logo strip before pricing). On artist LPs, pricing is
+`one-liner-link` variant embedded in `monetization`, not a full pricing section
+(creator R8).
+
+**Reason:** cost without value is friction (B2B anti-pattern #7).
+
+**Home:** `sections.ts` `pricing.illegalAfter` + `pricing.requiresPrior` + `pricing.audienceLegality`.
+
+## Law 3 — Testimonials only after credibility exists
+
+`social-proof` has `illegalAfter: ['hero']` and `requiresPrior: ['hero', 'feature-grid']`.
+Proof is a gradient, not a top beat (B2B C4): 3–5 beats escalating in
+specificity — logos → metrics → case study → named-human quote → scale number.
+
+**Reason:** proof answers the objection alive at that scroll depth. Aggregate
+doubt early, capability doubt mid, personal-risk doubt late, commitment doubt
+at the close (B2B C4).
+
+**Home:** `sections.ts` `social-proof.illegalAfter` + `social-proof.requiresPrior` + `social-proof.failureModes`.
+
+## Law 4 — FAQ near objections
+
+`faq` has `illegalAfter: ['hero']` and `requiresPrior: ['hero', 'feature-grid']`.
+FAQ handles objections that arise AFTER value/proof, not before. On pricing
+pages, FAQ sits between comparison and the close (B2B C7). Missing FAQ on a
+paid product is the observed gap (B2B anti-pattern #9 — Linear is the gap).
+
+**Reason:** FAQ is structural objection-handling, placed at the moment of
+decision doubt.
+
+**Home:** `sections.ts` `faq.illegalAfter` + `faq.requiresPrior` + `faq.failureModes`.
+
+## Law 5 — CTA cadence is a declared budget
+
+Every recipe declares `ctaCadence` (strategy + primaryLabel + cadence).
+Either sparse (≤3, hero + close) or dense-tiered (one primary label repeated
+verbatim, all others visually tertiary). Mid-page CTAs only after proof beats.
+
+**Reason:** cadence is a budget, not a count (B2B C6). One primary CTA label
+repeated verbatim throughout a page — not varied per section. Multiple distinct
+primary asks on one page is anti-pattern #6.
+
+**Home:** `recipes.ts` `ctaCadence` per recipe + `sections.ts` `cta.illegalAfter: ['hero']`.
+
+## Law 6 — Zero-proof path (charter design law #9)
+
+Proof/trust sections (`social-proof`, `stats`, `logo-cloud`) are ILLEGAL
+without verified data. Substitute = screenshot-registry product render
+(`SCREENSHOT_SCENARIO_IDS` membership) or OMIT the section. Fabricated or
+placeholder data is forbidden at every rung of every degradation ladder.
+
+`resolveComposition` drops proof/trust sections without verified assets in step
+4 (zero-proof filter). The artist-recipe `fallbacks` name the omission
+explicitly.
+
+**Reason:** unattributable or fabricated metrics never appear on observed
+sites (B2B C4, creator R3 — "every metric was specific and attributable"). The
+success case IS the AI-slop failure case without this law (CEO F3, Design F16).
+
+**Home:** `sections.ts` `proofClass` + `MARKETING_DEGRADATION_LADDERS` + `composition.ts` zero-proof filter + recipe `fallbacks`.
+
+## Law 7 — Emotional arc per recipe (Design F3)
+
+Every recipe declares `arc` (ordered beats). The artist arc differs from the B2B
+arc:
+
+| Beat order | Artist arc (creator R9) | B2B arc (B2B C2) |
+|---|---|---|
+| 1 | recognition ("this is for people like me") | problem/agitation |
+| 2 | identity ("that could be MY page") | solution |
+| 3 | aspiration ("artists I admire are here") | capability |
+| 4 | capability ("I can capture every fan") | proof |
+| 5 | money-reality ("real people earn; here is the take-rate") | trust/compliance |
+| 6 | relatability ("even small artists succeed") | — |
+| 7 | low-risk action ("claim it now") | action |
+
+The artist arc has NO problem/agitation beat — encoded as `audienceLegality` on
+sections (any problem-shaped section is illegal for `audience=artist`) +
+`artist-lp` `neverUse`. Audience input changes section LEGALITY, not just
+selection.
+
+**Reason:** the product is framed as amplification of an identity the artist
+already has, not as a fix for a deficiency (creator-economy research §3).
+
+**Home:** `recipes.ts` `arc` + `sections.ts` `audienceLegality` + `composition.ts` audience-legality filter.
+
+## Page-class rules
+
+| Page class | Recipe | Rule |
+|---|---|---|
+| SEO pages | `seo` | FAQPage schema required; ≤2 `content-prose` beats; long-form cap. |
+| Campaign pages | `launch` | Long-form allowed; ≤2 `content-prose` beats; date-stamped announcement. |
+| Comparison pages | `comparison` | Verdict above the fold (desktop); zero-proof law applies to competitor claims too. |
+| Documentation pages | (exempt — not recipe-composable) | `/changelog`, `/blog/[slug]`, `/blog/authors/*` are exempt per routeManifest. |
+| Long-form pages | `launch`, `seo` | `maxContent.maxLongFormSections: 2` cap; emphasis budget still holds. |
+
+## Page-length caps
+
+Every recipe declares `maxContent.maxSections`. The cap prevents the
+emphasis-budget violation (every section shouting). Homepage: 12. Pricing: 8.
+Artist LP: 13. Launch: 14 (allows 2 long-form). SEO: 6. Waitlist: 5.
+
+**Home:** `recipes.ts` `maxContent` per recipe.
+
+## Allowed transitions
+
+The `illegalAfter` field on each section defines the allowed-transition graph.
+A section may follow any section NOT in its `illegalAfter`. The graph is
+acyclic (sectionOrder is a list, not a DAG). The manifest gate statically
+asserts no recipe's sectionOrder violates any section's `illegalAfter`.
+
+## Illegal combinations
+
+Encoded as `neverUse` on sections + recipes. Examples:
+- `pricing` immediately after `hero` (illegalAfter).
+- `social-proof` immediately after `hero` (illegalAfter; proof is a gradient).
+- `comparison` above the fold when `audience=artist` (audienceLegality).
+- Problem-agitation sections for `audience=artist` (creator R9).
+- Demo-gate / enterprise / security / ROI-calculator on artist-audience recipes (creator R10).
+- Full pricing table on artist LP (creator R8 — use `monetization` one-liner).
+- Founder-first proof near top of artist page (DESIGN.md ui.md smell).
+- Multiple distinct primary CTA verbs on one page (B2B C6 invariant).
+
+## Maximum page length
+
+Per recipe (`maxContent.maxSections`). The hard cap is 14 (launch). Beyond
+that, the emphasis budget breaks: every section cannot stay quiet if there are
+20 of them.
+
+## Rules for long-form pages
+
+`launch` and `seo` allow up to 2 `content-prose` beats. Long-form prose uses
+the `prose` container (680px canonical per DESIGN.md). The emphasis budget
+still holds: max 1 display-scale moment, 1 full-bleed break, 1 hero-weight
+proof element — even on long-form pages.
+
+## Rules for SEO pages
+
+`seo` recipe: `hero` → `content-prose` (or `faq` for pure FAQ pages) → `faq` → `cta`.
+FAQPage schema is required (the whole point of this recipe is structured
+data). ≤2 `content-prose` beats. The `structured-data-list` variant of `faq`
+is the SEO default.
+
+## Rules for campaign pages
+
+`launch` recipe: long-form narrative; date-stamped announcement; up to 14
+sections with 2 `content-prose` beats allowed. The `founder-letter` and
+`release-notes` variants of `content-prose` are the campaign-editorial devices.
+
+## Rules for documentation pages
+
+Documentation pages (`/changelog`, `/blog/[slug]`, `/blog/authors/*`) are
+exempt per `routeManifest` — they are dynamic content pages rendered by
+dedicated organisms (`BlogPostPage`, `lib/changelog-parser.ts`), not
+section-composed. The manifest gate enforces the exemption carries
+`linearId` + `approvedBy` + `prUrl` (DX2 sanctioned exemption).
+
+## Rules for comparison pages
+
+`comparison` recipe: `hero` → `comparison` → `feature-grid` → `faq` → `cta`.
+Verdict visible above the fold on desktop (`aboveTheFoldContract.desktop:
+['hero', 'comparison']`). Zero-proof law applies to competitor claims too —
+fabricated competitor features fail the gate. For `audience=artist`,
+`comparison` is illegal above the fold (creator R9 — reads as agitation).


### PR DESCRIPTION
Retargeted to main after PR1 (#13460) merged and its branch was deleted. Same content as the original PR2.

Master spec + composition-rule rationale. Normative rules live in the typed registry (PR1 #13460, now merged); these docs own rationale only and link by stable id.

ARCHITECTURE.md (343 lines): system shape, grammar, section taxonomy, variant system, composition rules, recipe system, decision engine, naming, lifecycle + versioning, canon precedence table (with needed-for-composition column), extension rules, migration, future evolution, 9 Linear follow-ups (JOV-4064 through JOV-4072).

COMPOSITION_RULES.md (194 lines): 7 laws rationale + page-class rules + page-length caps.

Both docs carry spec-version: 1.0.0 freshness markers.