### PR TITLE
ci: move heavy jobs off self-hosted; drop phantom ci-build deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,8 +655,8 @@ jobs:
     # Draft PRs skip; ready PRs + pushes + merge queue run typecheck
     # Note: Runs in parallel with lint for speed (no dependency on cache-warm)
     needs: [ci-path-changes]
-    # Heavy job: runs on self-hosted jovie-runner pool for ARM64 + local turbo cache.
-    runs-on: [self-hosted, jovie-runner]
+    # Runs on GitHub-hosted runners (typecheck --force means no turbo cache benefit).
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name != 'pull_request' || needs.ci-path-changes.outputs.has_code_changes == 'true') }}
     steps:
@@ -2610,8 +2610,8 @@ jobs:
     # Parallel with typecheck/build for faster CI.
     # Path-gated: skips test execution when no test-relevant files changed.
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'main' || startsWith(github.event.pull_request.base.ref, 'gtmq_'))) || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') }}
-    # Heavy job (5 shards): runs on self-hosted jovie-runner pool for speed + local deps.
-    runs-on: [self-hosted, jovie-runner]
+    # 5-shard unit tests on GitHub-hosted runners for reliability (turbo remote cache works on any runner).
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Changes

### 1. Move typecheck + unit tests to GitHub-hosted runners
- **ci-typecheck**: `[self-hosted, jovie-runner]` → `ubuntu-latest`
  - Runs `--force` (no turbo cache benefit), zero reason to pin to a specific host
- **ci-unit-tests** (5 shards): `[self-hosted, jovie-runner]` → `ubuntu-latest`
  - Turbo remote cache works on any runner; ci-biome already proved GH-hosted is more reliable

### 2. Drop phantom ci-build dependencies from 6 downstream jobs
ci-build runs `pnpm turbo build --affected` on the self-hosted pool but produces only an 8 KB `build-manifest.json` that nobody downloads. The real build artifact (`.next bundle`) comes from `ci-build-public` (GitHub-hosted).

Removed `ci-build` from the `needs:` array of:
- `ci-e2e-migrate` (was blocking DB migrations behind `ci-build`)
- `ci-e2e-tests` (was blocking E2E behind `ci-build`)
- `ci-smoke-required` (was blocking smoke tests behind `ci-build`)
- `ci-homepage-smoke` (was blocking homepage health check behind `ci-build`)
- `ci-summary` (PR summary comment, informational only)
- `BUILD_RUN_FULL_CI` env var → now reads from `needs.ci-path-changes.outputs.run_build`

## Effect
- Frees the 5-runner OrbStack pool to only handle Build + Lighthouse
- E2E/smoke/migrate pipeline starts as soon as `ci-fast` + `neon-db` are ready, no longer serialized behind `ci-build`
- Machine load drops further; merge queue throughput increases