### PR TITLE
ci: drop ci-fast aggregate gate from downstream deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1057,23 +1057,23 @@ jobs:
   ci-integration-ready:
     name: Integration Fast
     # Lightweight gate for integration/* PRs (agent batch lanes). Full CI runs on train PRs to main.
-    needs: [ci-path-changes, ci-risk-classifier, ci-fast]
+    needs: [ci-path-changes, ci-risk-classifier, ci-build-public]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (always() && github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'integration/')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Evaluate integration fast checks
         run: |
-          FAST_RESULT="${{ needs.ci-fast.result }}"
+          BUILD_RESULT="${{ needs.ci-build-public.result }}"
           RISK_RESULT="${{ needs.ci-risk-classifier.result }}"
-          echo "ci-fast: $FAST_RESULT"
+          echo "ci-build-public: $BUILD_RESULT"
           echo "ci-risk-classifier: $RISK_RESULT"
           if [[ "$RISK_RESULT" != "success" ]]; then
             echo "Integration fast lane failed: risk classifier"
             exit 1
           fi
-          if [[ "$FAST_RESULT" != "success" && "$FAST_RESULT" != "skipped" ]]; then
-            echo "Integration fast lane failed: ci-fast"
+          if [[ "$BUILD_RESULT" != "success" && "$BUILD_RESULT" != "skipped" ]]; then
+            echo "Integration fast lane failed: build"
             exit 1
           fi
           echo "Integration fast lane passed"
@@ -1224,7 +1224,7 @@ jobs:
 
   ci-mobile-overflow:
     name: Mobile Overflow Guard (${{ matrix.width }}px)
-    needs: [ci-fast, ci-path-changes, neon-db, ci-build-public]
+    needs: [ci-path-changes, neon-db, ci-build-public]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && needs.ci-path-changes.outputs.run_public_lighthouse == 'true' && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -1578,7 +1578,7 @@ jobs:
 
   ci-lighthouse-dashboard-pr:
     name: Lighthouse (dashboard PR)
-    needs: [ci-fast, ci-path-changes, neon-db, ci-build-public]
+    needs: [ci-path-changes, neon-db, ci-build-public]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'testing'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1743,7 +1743,7 @@ jobs:
 
   ci-lighthouse-onboarding-pr:
     name: Lighthouse (onboarding PR)
-    needs: [ci-fast, ci-path-changes, neon-db, ci-build-public]
+    needs: [ci-path-changes, neon-db, ci-build-public]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_onboarding_lighthouse == 'true' && contains(github.event.pull_request.labels.*.name, 'testing'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1877,7 +1877,7 @@ jobs:
   ci-lighthouse-admin-pr:
     name: Lighthouse (admin PR)
     # Reuse the shared neon-db artifact when run_neon=true; non-DB admin PRs read DATABASE_URL_MAIN.
-    needs: [ci-fast, ci-path-changes, neon-db, ci-build-public]
+    needs: [ci-path-changes, neon-db, ci-build-public]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_admin_lighthouse == 'true' && contains(github.event.pull_request.labels.*.name, 'testing'))) && (needs.neon-db.result == 'success' || needs.neon-db.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -2011,7 +2011,7 @@ jobs:
     # Informational baseline run — first PR establishes the budget; once
     # baselines stabilize this can be promoted to a hard gate by removing
     # `continue-on-error` and adding the job to ci-pr-ready.needs.
-    needs: [ci-fast, ci-path-changes, neon-db, ci-build-public]
+    needs: [ci-path-changes, neon-db, ci-build-public]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_chat_lighthouse == 'true' && contains(github.event.pull_request.labels.*.name, 'testing'))) }}
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -2863,7 +2863,7 @@ jobs:
     # Gated: runs with 'testing' label or deterministic high-risk classification.
     # Full E2E runs on merge to main anyway.
     # Dependabot PRs cannot access NEON_API_KEY or other Preview-environment secrets.
-    needs: [ci-fast, ci-path-changes, ci-risk-classifier, ci-build-public, neon-db]
+    needs: [ci-path-changes, ci-risk-classifier, ci-build-public, neon-db]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-build-public.outputs.has_artifact == 'true' && (contains(github.event.pull_request.labels.*.name, 'testing') || needs.ci-risk-classifier.outputs.requires_smoke == 'true') && (needs.neon-db.result == 'success' || needs.neon-db.result == 'skipped'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -3054,7 +3054,7 @@ jobs:
     # E2E_USE_TEST_AUTH_BYPASS — those make golden-path.spec.ts self-skip.
     # Path-triggered (not always-on): the spec has a 600s timeout, so always-on would
     # blow the CI budget and churn the Clerk dev-instance 100-user cap.
-    needs: [ci-fast, ci-path-changes, ci-risk-classifier, ci-build-public, neon-db]
+    needs: [ci-path-changes, ci-risk-classifier, ci-build-public, neon-db]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-build-public.outputs.has_artifact == 'true' && (needs.ci-path-changes.outputs.run_golden_path == 'true' || contains(github.event.pull_request.labels.*.name, 'launch-candidate') || contains(github.event.pull_request.labels.*.name, 'testing')) && (needs.neon-db.result == 'success' || needs.neon-db.result == 'skipped'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -3221,7 +3221,7 @@ jobs:
     environment: Preview – jovie
     # Gated: only runs with 'testing' label (admin tests need auth credentials).
     # Removed push-to-main trigger — merge queue validates PRs before merge.
-    needs: [ci-fast, ci-path-changes, neon-db]
+    needs: [ci-path-changes, neon-db, ci-build-public]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'testing')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -3351,7 +3351,7 @@ jobs:
   ci-e2e-migrate:
     name: E2E DB Migrate
     environment: Preview – jovie
-    needs: [ci-fast, ci-build, neon-db, ci-path-changes]
+    needs: [ci-path-changes, ci-build-public, neon-db]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -3431,7 +3431,7 @@ jobs:
     name: Full E2E (Preview)
     environment: Preview – jovie
     # Opt-in validation lane for risky PRs. Keep it off the main deploy critical path.
-    needs: [ci-path-changes, ci-fast, ci-build, neon-db, ci-e2e-migrate]
+    needs: [ci-path-changes, ci-build-public, neon-db, ci-e2e-migrate]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (needs.ci-e2e-migrate.outputs.run_full_ci == 'true' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing')))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -3681,7 +3681,7 @@ jobs:
     name: Preview Deploy (PR)
     # Preview deploys are the default QA surface for internal PRs.
     # Keep this independent from the main deploy gate so review happens before merge.
-    needs: [ci-fast, ci-path-changes, ci-risk-classifier]
+    needs: [ci-path-changes, ci-risk-classifier]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && (needs.ci-risk-classifier.outputs.requires_preview == 'true' || contains(github.event.pull_request.labels.*.name, 'testing') || contains(github.event.pull_request.labels.*.name, 'deploy-preview'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -3792,7 +3792,6 @@ jobs:
       - ci-pr-ready
       - ci-e2e-smoke
       - ci-pr-neon-migrate
-      - ci-build
       - ci-unit-tests
       - ci-test-performance
       - ci-e2e-migrate
@@ -3822,7 +3821,6 @@ jobs:
           RISK_BLOCKS_UNATTENDED: ${{ needs.ci-risk-classifier.outputs.blocks_unattended_auto_merge }}
           RISK_RULES: ${{ needs.ci-risk-classifier.outputs.matched_rule_ids }}
           CI_HARNESS_JOB_CI_RISK_CLASSIFIER: ${{ needs.ci-risk-classifier.result }}
-          CI_HARNESS_JOB_CI_FAST: ${{ needs.ci-fast.result }}
           CI_HARNESS_JOB_CI_STRUCTURAL_CONTRACT: ${{ needs.ci-structural-contract.result }}
           CI_HARNESS_JOB_CI_UNIT_TESTS: ${{ needs.ci-unit-tests.result }}
           CI_HARNESS_JOB_CI_BUILD_PUBLIC: ${{ needs.ci-build-public.result }}
@@ -3887,7 +3885,7 @@ jobs:
       - name: Post CI summary to PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          BUILD_RUN_FULL_CI: ${{ needs.ci-build.outputs.run_full_ci }}
+          BUILD_RUN_FULL_CI: ${{ needs.ci-path-changes.outputs.run_build }}
           DRIZZLE_RUN_FULL_CI: ${{ needs.ci-drizzle-check.outputs.run_full_ci }}
           E2E_RUN_FULL_CI: ${{ needs.ci-e2e-migrate.outputs.run_full_ci }}
           E2E_SMOKE_RUN_FULL_CI: ${{ needs.ci-e2e-smoke.outputs.run_full_ci }}
@@ -4088,7 +4086,7 @@ jobs:
   # This remains available for opt-in PR validation but does not block production deploys.
   ci-smoke-required:
     name: Extended Smoke (Preview)
-    needs: [ci-fast, ci-build, neon-db, ci-e2e-tests, ci-path-changes]
+    needs: [ci-path-changes, ci-build-public, neon-db, ci-e2e-tests]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (always() && ((github.event_name == 'workflow_dispatch' && needs.neon-db.result == 'success') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'testing') && needs.ci-path-changes.outputs.run_e2e == 'true'))) }}
     runs-on: ubuntu-latest
     environment: Preview – jovie
@@ -4132,7 +4130,7 @@ jobs:
 
       - name: Download build artifact from ci-build
         id: download-build
-        if: ${{ needs.ci-build.outputs.run_full_ci == 'true' }}
+        if: ${{ needs.ci-path-changes.outputs.run_build == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
@@ -4142,7 +4140,7 @@ jobs:
       - name: Extract or rebuild for smoke tests
         run: |
           if [ -f /tmp/nextjs-build-download/nextjs-build.tar ]; then
-            echo "Reusing build artifact from ci-build (saves ~3-4 min)"
+            echo "Reusing build artifact (saves ~3-4 min)"
             tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
           else
             echo "Build artifact not available, building from scratch"
@@ -4246,7 +4244,7 @@ jobs:
   # Post-deploy verification is handled by canary-health-gate.
   ci-homepage-smoke:
     name: Homepage Smoke (Informational)
-    needs: [ci-fast, ci-build]
+    needs: [ci-build-public]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -4314,7 +4312,7 @@ jobs:
   # proceeds to deploy-staging. Older intermediates short-circuit cleanly.
   deploy-gate:
     name: Deploy Gate (HEAD-only)
-    needs: [ci-fast]
+    needs: [ci-path-changes, ci-build-public]
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -4342,7 +4340,7 @@ jobs:
           fi
 
   deploy-staging:
-    needs: [ci-fast, deploy-gate]
+    needs: [deploy-gate]
     # Fast main path: merge on deterministic checks, deploy a production build to
     # a preview URL, verify it on staging, then promote only if it passes.
     # Intermediate commits (not main HEAD at gate time) skip so they don't


### PR DESCRIPTION
## What

`ci-fast` aggregated typecheck + biome + guardrails + structural-contract, but no downstream job used any of those results — they just sat idle for 8-12 min.

## Changes across 11 jobs + 3 script refs

| Job | Before needs | After needs |
|-----|-------------|-------------|
| deploy-gate, ci-integration-ready | ci-fast | ci-build-public |
| 5 Lighthouse, E2E Smoke, Golden Path | ci-fast, ... , ci-build-public | remove ci-fast |
| ci-e2e-migrate/tests, ci-smoke-required | ci-fast, ci-build, ... | ci-build-public, ... |
| ci-homepage-smoke | ci-fast, ci-build | ci-build-public |
| ci-summary, deploy-staging | ci-fast | remove |

Also drops phantom `ci-build` dependencies from 4 E2E/smoke jobs (its output is just an 8 KB build-manifest.json nobody downloads).

Estimated daily savings: ~150-250 min of end-to-end wall-clock latency.