### PR TITLE
ci: fix 2 CI flake sources — LHCI PROTOCOL_TIMEOUT + noauth timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5258,4 +5258,4 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-node-pnpm
       - name: Run Lighthouse CI against production
-        run: pnpm --filter web exec lhci autorun --config=.lighthouserc.json
+        run: for attempt in 1 2 3; do if pnpm --filter web exec lhci autorun --config=.lighthouserc.json; then exit 0; fi; echo "Lighthouse production attempt $attempt failed (PROTOCOL_TIMEOUT), retrying after 10s..."; sleep 10; done; echo "All 3 Lighthouse production attempts failed."; exit 1

--- a/apps/web/playwright.config.noauth.ts
+++ b/apps/web/playwright.config.noauth.ts
@@ -26,6 +26,8 @@ const shouldSkipManagedWebServer = process.env.E2E_SKIP_WEB_SERVER === '1';
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
+  timeout: 120_000,
+  expect: { timeout: 25_000 },
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,


### PR DESCRIPTION
## What

Two CI flake fixes from failure analysis:

### 1. Production Lighthouse PROTOCOL_TIMEOUT (~30% failure rate)
No retry mechanism existed. Now wraps in 3 attempts with 10s cooldown.

### 2. playwright.config.noauth.ts missing explicit timeouts
Used Playwright defaults (30s test, 5s expect) vs primary config (120s, 25s). The viewport stability test (~825 lines) ran under these tight timeouts and regularly failed.