### PR TITLE
fix(ci): add Chrome flags to prevent LHCI PROTOCOL_TIMEOUT on production Lighthouse

### DIFF
--- a/apps/web/.lighthouserc.json
+++ b/apps/web/.lighthouserc.json
@@ -2,6 +2,11 @@
   "ci": {
     "collect": {
       "numberOfRuns": 3,
+      "settings": {
+        "chromeFlags": "--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage",
+        "maxWaitForLoad": 60000,
+        "maxWaitForFcp": 30000
+      },
       "url": ["https://jov.ie/", "https://jov.ie/tim"]
     },
     "assert": {


### PR DESCRIPTION
## Problem

The `lighthouse-ci` job consistently fails on ubuntu-latest runners with:

```
Runtime error encountered: Waiting for DevTools protocol response has exceeded the allotted time. (Method: DOMSnapshot.disable)
```

This occurs because Chrome's DevTools Protocol calls (`DOMSnapshot.disable`, `CSS.getMatchedStylesForNode`) time out under shared-memory pressure in the CI container. Despite 3 retries in the bash loop + 3 `numberOfRuns` in config (9 total attempts), every attempt fails with PROTOCOL_TIMEOUT.

## Root Cause

The production Lighthouse CI config (`apps/web/.lighthouserc.json`) was missing `chromeFlags` in its `collect.settings`. The public-launch config (`.lighthouserc.public-launch.json`) already had the needed flags and works reliably.

## Fix

Added to `apps/web/.lighthouserc.json` collect settings:

- **`chromeFlags`**: `--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage`
  - `--disable-dev-shm-usage`: Forces Chrome to use `/tmp` instead of `/dev/shm`, avoiding shared-memory contention in Docker/CI
  - `--no-sandbox`: Required for running Chrome in unprivileged containers
- **`maxWaitForLoad: 60000`**: Increases the navigation load wait timeout from the default (30s) to 60s, giving the page more time to settle
- **`maxWaitForFcp: 30000`**: Increases the First Contentful Paint wait timeout from default (15s) to 30s

## Testing

- Existing `.lighthouserc.public-launch.json` already uses identical `chromeFlags` and passes reliably
- The retry loop (3 attempts) and `numberOfRuns: 3` remain as additional safety nets