### PR TITLE
fix(ci): retry Neon DB connectivity probe on transient failures

### DIFF
--- a/apps/web/tests/e2e/verify-neon-db-connectivity.ts
+++ b/apps/web/tests/e2e/verify-neon-db-connectivity.ts
@@ -1,6 +1,12 @@
 import { neon } from '@neondatabase/serverless';
 
 const databaseUrl = process.env.DATABASE_URL?.trim();
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 2_000;
+
+async function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 async function main() {
   if (!databaseUrl) {
@@ -8,13 +14,30 @@ async function main() {
   }
 
   const sql = neon(databaseUrl);
-  const rows = await sql`SELECT 1 as ok`;
 
-  if (!rows?.[0]?.ok) {
-    throw new Error('Neon connectivity probe returned an unexpected response');
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const rows = await sql`SELECT 1 as ok`;
+
+      if (!rows?.[0]?.ok) {
+        throw new Error(
+          'Neon connectivity probe returned an unexpected response'
+        );
+      }
+
+      console.log('Neon DB connectivity OK');
+      return;
+    } catch (error) {
+      if (attempt < MAX_RETRIES) {
+        console.warn(
+          `Neon connectivity attempt ${attempt}/${MAX_RETRIES} failed, retrying in ${RETRY_DELAY_MS}ms...`
+        );
+        await sleep(RETRY_DELAY_MS);
+      } else {
+        throw error;
+      }
+    }
   }
-
-  console.log('Neon DB connectivity OK');
 }
 
 void main().catch(error => {


### PR DESCRIPTION
## Problem

Neon's serverless Postgres has intermittent connection drops during peak routing. The  step was failing on ~50% of main CI runs (8 of the last 10), killing Lighthouse shards before the test even ran.

The profile mobile viewport stability test never actually failed — it never got a chance to run.

## Fix

Add 3 attempts with 2s delay to the  script:

- Attempt 1 fails → 2s wait → attempt 2
- Attempt 2 fails → 2s wait → attempt 3
- Attempt 3 fails → exit 1 (still fail-fast for persistent outages)

A transient routing blip won't kill the CI run anymore. A real outage still catches within ~6s.

## Testing

- Post-merge: main CI should hit far fewer spurious Neon-related failures
- The fail-fast behavior is preserved for persistent outages