### PR TITLE
feat(homepage): wire homepage to use Section Registry

### DIFF
--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -22,6 +22,7 @@ import {
 import { publicEnv } from '@/lib/env-public';
 import { FEATURE_FLAGS } from '@/lib/flags/marketing-static';
 import { getMarketingExportImage } from '@/lib/screenshots/registry';
+import { composeHomepageSections } from '@/lib/sections/registry';
 
 // Below-the-fold sections are dynamic-loaded so their `motion/react`
 // hydration cost doesn't compete with above-the-fold work.
@@ -357,23 +358,57 @@ function HomepageFaq() {
   );
 }
 
+/**
+ * Homepage section renderer — resolves registry section IDs to production
+ * components. New sections added to `composeHomepageSections` must have a
+ * corresponding case here.
+ */
+function HomepageSection({ sectionId }: Readonly<{ sectionId: string }>) {
+  switch (sectionId) {
+    case 'homepage-product-statement':
+      return <HomepageProductStatement />;
+    case 'homepage-go-live-steps':
+      return <HomepageGoLiveStepsSection />;
+    case 'homepage-workspace-section':
+      return <HomepageWorkspaceSectionLazy screenshot={WORKSPACE_SCREENSHOT} />;
+    case 'homepage-artist-profiles-carousel':
+      return (
+        <HomepageArtistProfilesCarouselLazy cards={ARTIST_PROFILE_CARDS} />
+      );
+    case 'friday-rhythm-section':
+      return <FridayRhythmSectionLazy />;
+    case 'home-bento-pairs':
+      return <HomeBentoPairs />;
+    case 'home-loop-diagram':
+      return <HomeLoopDiagramSection />;
+    case 'home-stat-quote':
+      return <HomeStatQuoteSection />;
+    case 'homepage-v2-pricing':
+      return <HomepageV2Pricing />;
+    case 'homepage-faq':
+      return <HomepageFaq />;
+    case 'homepage-v2-final-cta':
+      return <HomepageV2FinalCta />;
+    default:
+      return null;
+  }
+}
+
 function HomepageUnlockedSections() {
+  const { bodyIds } = composeHomepageSections({
+    showGoLive: FEATURE_FLAGS.SHOW_HOMEPAGE_GO_LIVE_SECTION,
+    showFridayRhythm: FEATURE_FLAGS.SHOW_HOMEPAGE_FRIDAY_RHYTHM,
+    showHomeRefresh2026: FEATURE_FLAGS.SHOW_HOME_REFRESH_2026,
+    showV2Pricing: FEATURE_FLAGS.SHOW_HOMEPAGE_V2_PRICING,
+    showFaq: FEATURE_FLAGS.SHOW_HOMEPAGE_FAQ,
+    showV2FinalCta: FEATURE_FLAGS.SHOW_HOMEPAGE_V2_FINAL_CTA,
+  });
+
   return (
     <>
-      <HomepageProductStatement />
-      {FEATURE_FLAGS.SHOW_HOMEPAGE_GO_LIVE_SECTION ? (
-        <HomepageGoLiveStepsSection />
-      ) : null}
-      <HomepageWorkspaceSectionLazy screenshot={WORKSPACE_SCREENSHOT} />
-      <HomepageArtistProfilesCarouselLazy cards={ARTIST_PROFILE_CARDS} />
-      {FEATURE_FLAGS.SHOW_HOMEPAGE_FRIDAY_RHYTHM ? (
-        <FridayRhythmSectionLazy />
-      ) : null}
-      {FEATURE_FLAGS.SHOW_HOME_REFRESH_2026 ? <HomeBentoPairs /> : null}
-      {FEATURE_FLAGS.SHOW_HOME_REFRESH_2026 ? <HomeLoopDiagramSection /> : null}
-      {FEATURE_FLAGS.SHOW_HOME_REFRESH_2026 ? <HomeStatQuoteSection /> : null}
-      {FEATURE_FLAGS.SHOW_HOMEPAGE_V2_PRICING ? <HomepageV2Pricing /> : null}
-      {FEATURE_FLAGS.SHOW_HOMEPAGE_FAQ ? <HomepageFaq /> : null}
+      {bodyIds.map(sectionId => (
+        <HomepageSection key={sectionId} sectionId={sectionId} />
+      ))}
     </>
   );
 }
@@ -381,6 +416,15 @@ function HomepageUnlockedSections() {
 function HomepageStoryStack({
   showUnlockedSections,
 }: Readonly<{ showUnlockedSections: boolean }>) {
+  const { finalCtaId } = composeHomepageSections({
+    showGoLive: FEATURE_FLAGS.SHOW_HOMEPAGE_GO_LIVE_SECTION,
+    showFridayRhythm: FEATURE_FLAGS.SHOW_HOMEPAGE_FRIDAY_RHYTHM,
+    showHomeRefresh2026: FEATURE_FLAGS.SHOW_HOME_REFRESH_2026,
+    showV2Pricing: FEATURE_FLAGS.SHOW_HOMEPAGE_V2_PRICING,
+    showFaq: FEATURE_FLAGS.SHOW_HOMEPAGE_FAQ,
+    showV2FinalCta: FEATURE_FLAGS.SHOW_HOMEPAGE_V2_FINAL_CTA,
+  });
+
   const className = showUnlockedSections
     ? 'homepage-story-stack homepage-story-stack--proof-transition'
     : 'homepage-story-stack';
@@ -392,7 +436,7 @@ function HomepageStoryStack({
       data-testid='homepage-story-stack'
     >
       {showUnlockedSections ? <HomepageUnlockedSections /> : null}
-      {FEATURE_FLAGS.SHOW_HOMEPAGE_V2_FINAL_CTA ? <HomepageV2FinalCta /> : null}
+      {finalCtaId ? <HomepageSection sectionId={finalCtaId} /> : null}
     </div>
   );
 }

--- a/apps/web/lib/sections/registry.ts
+++ b/apps/web/lib/sections/registry.ts
@@ -117,3 +117,70 @@ export function getCanonicalForCategory(
   const inCategory = getSectionsByCategory(category);
   return inCategory.find(v => v.canonical) ?? inCategory[0];
 }
+
+// ─── Homepage composition ───────────────────────────────────────────────────
+
+/** Feature flags that affect homepage section composition. */
+export interface HomepageCompositionFlags {
+  /** `SHOW_HOMEPAGE_GO_LIVE_SECTION` */
+  readonly showGoLive: boolean;
+  /** `SHOW_HOMEPAGE_FRIDAY_RHYTHM` */
+  readonly showFridayRhythm: boolean;
+  /** `SHOW_HOME_REFRESH_2026` */
+  readonly showHomeRefresh2026: boolean;
+  /** `SHOW_HOMEPAGE_V2_PRICING` */
+  readonly showV2Pricing: boolean;
+  /** `SHOW_HOMEPAGE_FAQ` */
+  readonly showFaq: boolean;
+  /** `SHOW_HOMEPAGE_V2_FINAL_CTA` */
+  readonly showV2FinalCta: boolean;
+}
+
+/**
+ * Composes ordered homepage body-section IDs from feature flags.
+ *
+ * The hero is rendered separately (outside the story stack) and is NOT
+ * included here. Returns body sections and a separate final CTA so the
+ * page can keep the CTA outside the `showUnlockedSections` gate.
+ *
+ * Every id returned by this function must have a corresponding case in
+ * the page's `HomepageSection` renderer switch.
+ */
+export function composeHomepageSections(flags: HomepageCompositionFlags): {
+  readonly bodyIds: readonly string[];
+  readonly finalCtaId: string | null;
+} {
+  const sections: string[] = [];
+
+  sections.push('homepage-product-statement');
+
+  if (flags.showGoLive) {
+    sections.push('homepage-go-live-steps');
+  }
+
+  sections.push('homepage-workspace-section');
+  sections.push('homepage-artist-profiles-carousel');
+
+  if (flags.showFridayRhythm) {
+    sections.push('friday-rhythm-section');
+  }
+
+  if (flags.showHomeRefresh2026) {
+    sections.push('home-bento-pairs');
+    sections.push('home-loop-diagram');
+    sections.push('home-stat-quote');
+  }
+
+  if (flags.showV2Pricing) {
+    sections.push('homepage-v2-pricing');
+  }
+
+  if (flags.showFaq) {
+    sections.push('homepage-faq');
+  }
+
+  return {
+    bodyIds: sections,
+    finalCtaId: flags.showV2FinalCta ? 'homepage-v2-final-cta' : null,
+  };
+}


### PR DESCRIPTION
## Summary

Wires the homepage (`/`) to use the Section Registry (`lib/sections/registry.ts`) for composing body sections instead of hardcoded ordering in `page.tsx`.

## Pattern

### Before

`page.tsx` had `HomepageUnlockedSections()` with inline JSX that hardcoded component order and feature-flag branching:

```tsx
function HomepageUnlockedSections() {
  return (
    <>
      <HomepageProductStatement />
      {FEATURE_FLAGS.SHOW_HOMEPAGE_GO_LIVE_SECTION ? (
        <HomepageGoLiveStepsSection />
      ) : null}
      <HomepageWorkspaceSectionLazy screenshot={WORKSPACE_SCREENSHOT} />
      ...
    </>
  );
}
```

### After

Section ordering lives in `composeHomepageSections()` in the registry:

```ts
const { bodyIds, finalCtaId } = composeHomepageSections(flags);

// Returns e.g.:
// bodyIds: ['homepage-product-statement', 'homepage-go-live-steps', ...]
// finalCtaId: 'homepage-v2-final-cta'
```

A `HomepageSection` renderer switch maps each ID to the production component:

```tsx
function HomepageSection({ sectionId }) {
  switch (sectionId) {
    case 'homepage-product-statement': return <HomepageProductStatement />;
    case 'homepage-go-live-steps': return <HomepageGoLiveStepsSection />;
    ...
  }
}
```

The page iterates the ordered IDs:

```tsx
{bodyIds.map(sectionId => (
  <HomepageSection key={sectionId} sectionId={sectionId} />
))}
```

## Changes

| File | What |
|------|------|
| `apps/web/lib/sections/registry.ts` | Add `HomepageCompositionFlags` type and `composeHomepageSections()` — ordered section IDs based on feature flags |
| `apps/web/app/(home)/page.tsx` | Add `HomepageSection` renderer; `HomepageUnlockedSections` and `HomepageStoryStack` read from registry |

## Preserved

- Hero rendering (`MarketingHero` + command center)
- System B button config (`size='md'`, secondary variant)
- All feature flags — every flag still defaults to `false`
- `HomepageTrackedLink` for analytics
- Dynamic loading patterns (`*Lazy.tsx` wrappers, motion TBT optimization)
- `HomepageProductStatement` AI composer section under its flag
- Schema scripts, `AuthRedirectHandler`, SEO metadata
