### PR TITLE
fix: replace useless cat in autofix context script (SC2002)

### DIFF
--- a/.github/workflows/main-autofix.yml
+++ b/.github/workflows/main-autofix.yml
@@ -304,7 +304,7 @@ jobs:
 
             LOG_PREVIEW=$(head -n 180 /tmp/autofix-context/failed-logs.txt)
             SUSPECT_FILES=$(cat /tmp/autofix-context/suspect-files.txt)
-            COMMITS_RANGE=$(cat /tmp/autofix-context/commits-since-green.txt 2>/dev/null | tr '\n' ' ' | tr -s ' ')
+            COMMITS_RANGE=$(tr '\n' ' ' < /tmp/autofix-context/commits-since-green.txt 2>/dev/null | tr -s ' ')
 
             SYSTEM_PROMPT=$(
               cat <<'SYSTEMEOF'


### PR DESCRIPTION
Actionlint catches `cat file | cmd` as SC2002 (useless cat) in `main-autofix.yml`. This is a style-only shellcheck warning — no functional change.\n\nSwitch to `cmd < file` syntax.\n\nThis was blocking PR #13575 (drain-pr-queue jq guard) from passing the Structural Contract check.