### PR TITLE
ci: guard against self-hosted runner label drift

### DIFF
--- a/docs/PR_FLOW.md
+++ b/docs/PR_FLOW.md
@@ -147,6 +147,19 @@ cron tick and rescues those PRs:
 | `drain-pr-queue.sh` (terminal-failure-only) | Zombie-check churn dequeuing green PRs |
 | `taste-classifier.mjs` | Taste-flagged PRs are routed to LLM review, not held |
 | Risk-tiered triggers | Heavy scans saturating runners on the PR path |
+| `runner-health-monitor.yml` label-drift guard | Self-hosted runners impersonating GitHub-hosted labels |
+
+### Runner label policy
+
+Self-hosted runners must use **explicit labels only** (`self-hosted`, `Linux`,
+`ARM64`, `jovie-runner`) and must **never** carry GitHub-hosted labels
+(`ubuntu-latest`, `macos-latest`, `windows-latest`). A self-hosted runner
+labeled `ubuntu-latest` hijacks every `runs-on: ubuntu-latest` workflow onto an
+incomplete toolchain — on 2026-07-08 this stranded 37 open PRs on OrbStack
+runners missing `gh`, Docker, and `unzip`. The scheduled
+`runner-health-monitor.yml` fails loudly (`::error::` + red workflow) when any
+self-hosted runner carries a forbidden label; fix by removing that label from
+the runner, never by renaming workflows around it.
 
 ## What broke on 2026-06-22
 


### PR DESCRIPTION
## ⚠️ PARTIALLY BLOCKED — workflow half needs a human push

**Problem:** On 2026-07-08, self-hosted OrbStack runners carried the custom label `ubuntu-latest`, hijacking `runs-on: ubuntu-latest` workflows onto incomplete runners and stranding 37 open PRs. Labels were fixed operationally; this PR adds the permanent repo guard + policy doc.

**What changed (committed):**
- `docs/PR_FLOW.md` — new "Runner label policy" section + guardrails-table row: self-hosted runners use explicit labels only (`jovie-runner`, etc.), never GitHub-hosted labels.

**What is BLOCKED (needs `workflow` scope):**
- `.github/workflows/runner-health-monitor.yml` — the agent's GitHub token lacks the `workflow` scope, so both the git trees API and contents API return 403 for any commit touching `.github/workflows/*`:
  - `POST /git/trees: 403 Resource not accessible by integration`
  - `PUT /contents/.github/workflows/runner-health-monitor.yml: 403 refusing to allow a GitHub App to create or update workflow ... without workflows permission`
- **Human step:** push the fully validated file below to this branch (`fable/ci-runner-label-drift-guard`), or grant the integration `workflow` scope and ask Fable to re-push. The full validated file is byte-exact in the agent sandbox; the only change vs `main` is the new header comment + this new job (existing `monitor` job untouched):

<details><summary>New <code>label-drift-guard</code> job (add as first job; also add the incident note to the header comment)</summary>

```yaml
  label-drift-guard:
    name: Guard self-hosted runner labels
    runs-on: ubuntu-latest
    timeout-minutes: 2
    env:
      GH_TOKEN: ${{ github.token }}
    steps:
      - name: Fail if self-hosted runners carry GitHub-hosted labels
        run: |
          set -euo pipefail

          # Every runner returned by this endpoint is self-hosted, so any of
          # them carrying a GitHub-hosted label is drift by definition.
          OFFENDERS=$(gh api repos/JovieInc/Jovie/actions/runners --jq \
            '[.runners[] | select([.labels[].name] | any(. == "ubuntu-latest" or . == "macos-latest" or . == "windows-latest")) | {name: .name, labels: [.labels[].name]}]')

          COUNT=$(echo "$OFFENDERS" | jq length)
          if [ "$COUNT" -gt 0 ]; then
            DETAIL=$(echo "$OFFENDERS" | jq -r '[.[] | "\(.name) [\(.labels | join(","))]"] | join("; ")')
            echo "::error::Self-hosted runner label drift: $COUNT runner(s) carry forbidden GitHub-hosted labels (ubuntu-latest/macos-latest/windows-latest): $DETAIL. Remove the forbidden labels — self-hosted runners must use explicit labels only (jovie-runner). See docs/PR_FLOW.md."
            exit 1
          fi

          echo "OK: no self-hosted runners carry GitHub-hosted labels."
```

Header comment addition (after the anti-flap paragraph):

```yaml
# Also guards against runner label drift: self-hosted runners must never
# carry GitHub-hosted labels (ubuntu-latest, macos-latest, windows-latest).
# A self-hosted runner labeled ubuntu-latest hijacks every workflow written
# for GitHub-hosted runners onto an incomplete toolchain (2026-07-08
# incident: 37 open PRs stuck on OrbStack runners missing gh/docker/unzip).
```

</details>

Design note: the guard is a **separate job** so a drift failure can't break the existing CI_FAST_RUNNER health-flip logic. The monitor's intentional `OFFLINE_TARGET: ubuntu-latest` fallback is a `runs-on` target (repo variable), not a runner label — the guard only inspects registered self-hosted runner labels, so no false positive there.

**Assumptions:**
- No dispatch ID was provided with this task; dispatched by Summer 2026-07-08 (runner label drift incident follow-up).
- `docs/PR_FLOW.md` chosen over `AGENTS.md` per dispatch preference.
- All runners returned by `GET /repos/.../actions/runners` are self-hosted, so any of them carrying a GitHub-hosted label is drift by definition.

**Verification (run in sandbox against the full intended file):**

```
$ python3 validate.py   # yaml.safe_load + bash -n on every extracted run block (GH expressions stubbed)
YAML parse: OK
jobs: ['label-drift-guard', 'monitor']
bash -n label-drift-guard step[0] (Fail if self-hosted runners carry GitHub-hosted labels): OK
bash -n monitor step[0] (Query runner status): OK
bash -n monitor step[1] (Flip to GitHub-hosted fallback if runners are down): OK
bash -n monitor step[2] (Restore self-hosted runners when they come back): OK
bash -n monitor step[3] (Log health state): OK
validated 5 embedded bash blocks

$ # functional test of the guard's jq filter against mock runner payloads
count=1 detail=orbstack-runner-1 [self-hosted,Linux,ARM64,jovie-runner,ubuntu-latest]
clean count=0
```

Diff size: docs +17 lines; workflow +~35 lines (pending) — well under 200. No product code touched. Do not merge until the workflow file lands.
