### PR TITLE
ci: guard against self-hosted runner label drift

### DIFF
--- a/.github/workflows/runner-health-monitor.yml
+++ b/.github/workflows/runner-health-monitor.yml
@@ -6,6 +6,11 @@ name: Runner Health Monitor
 #
 # Detects 2+ consecutive lost heartbeats before flipping to avoid flapping
 # on brief network blips.
+#
+# Also guards against runner label drift: self-hosted runners must never carry
+# GitHub-hosted labels (`ubuntu-latest`, `macos-latest`, `windows-latest`). A
+# self-hosted runner labeled `ubuntu-latest` hijacks workflows intended for
+# GitHub-hosted runners onto an incomplete toolchain.
 
 on:
   schedule:
@@ -27,6 +32,22 @@ jobs:
       OFFLINE_TARGET: ubuntu-latest
       ONLINE_TARGET: jovie-runner
     steps:
+      - name: Detect self-hosted runner label drift
+        run: |
+          set -euo pipefail
+
+          OFFENDERS=$(gh api repos/JovieInc/Jovie/actions/runners --jq \
+            '[.runners[] | select([.labels[].name] | any(. == "ubuntu-latest" or . == "macos-latest" or . == "windows-latest")) | {name: .name, labels: [.labels[].name]}]')
+          COUNT=$(echo "$OFFENDERS" | jq length)
+
+          if [ "$COUNT" -gt 0 ]; then
+            DETAIL=$(echo "$OFFENDERS" | jq -r '[.[] | "\(.name) [\(.labels | join(","))]"] | join("; ")')
+            echo "::error::Self-hosted runner label drift: $COUNT runner(s) carry forbidden GitHub-hosted labels (ubuntu-latest/macos-latest/windows-latest): $DETAIL. Remove those labels; self-hosted runners must use explicit labels such as jovie-runner."
+            exit 1
+          fi
+
+          echo "OK: no self-hosted runners carry GitHub-hosted labels."
+
       - name: Query runner status
         id: runners
         run: |

--- a/docs/PR_FLOW.md
+++ b/docs/PR_FLOW.md
@@ -148,6 +148,14 @@ cron tick and rescues those PRs:
 | `taste-classifier.mjs` | Taste-flagged PRs are routed to LLM review, not held |
 | Risk-tiered triggers | Heavy scans saturating runners on the PR path |
 
+### Runner label policy
+
+Self-hosted runners must use explicit self-hosted labels only (`jovie-runner`,
+architecture labels, machine labels). Never add GitHub-hosted labels such as
+`ubuntu-latest`, `macos-latest`, or `windows-latest` to self-hosted runners: that
+routes ordinary hosted-runner jobs onto local machines with different toolchains.
+`runner-health-monitor` fails fast if this drift reappears.
+
 ## What broke on 2026-06-22
 
 The queue stalled for 6 hours and looked like "Graphite is paused." It wasn't.


### PR DESCRIPTION
## Summary
- Add a runner-label drift guard to `runner-health-monitor.yml`.
- Fails if any self-hosted runner carries GitHub-hosted labels: `ubuntu-latest`, `macos-latest`, `windows-latest`.
- Document policy in `docs/PR_FLOW.md`: self-hosted runners must use explicit labels only (`jovie-runner`, etc.).

## Why
On 2026-07-08, OrbStack self-hosted runners had `ubuntu-latest`, which routed normal GitHub-hosted jobs onto incomplete self-hosted runners and caused widespread CI failures/stuck PRs.

## Verification
```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/runner-health-monitor.yml')); print('YAML OK')"
# YAML OK
```

```bash
python3 - <<'PY' > /tmp/drift-script.sh
import yaml
with open('.github/workflows/runner-health-monitor.yml') as f:
    doc = yaml.safe_load(f)
for s in doc['jobs']['monitor']['steps']:
    if s.get('name') == 'Detect self-hosted runner label drift':
        print(s['run'])
PY
bash -n /tmp/drift-script.sh && echo "Shell syntax OK"
# Shell syntax OK
```

Draft PR only. Do not merge manually.
