### PR TITLE
fix: update CI actions from Node.js 20 to Node.js 24 runtime

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -30,7 +30,7 @@ runs:
     # stalling at 0 B/s and eating the whole job timeout (Typecheck cancelled
     # at 10m during the "Post Run" cache save, 2026-07-06).
     - name: Setup Node.js with pnpm cache
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22'
         cache: ${{ runner.environment == 'github-hosted' && 'pnpm' || '' }}

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -189,7 +189,7 @@ jobs:
           steps.trigger.outputs.should_continue == 'true' &&
           steps.branch-check.outputs.is_agent_branch == 'true' &&
           steps.trigger.outputs.trigger_type == 'ci_failure'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
             scripts/lib/pr-check-failures.mjs
@@ -428,7 +428,7 @@ jobs:
           private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
             scripts/lib/upsert-pr-comment.sh
@@ -497,7 +497,7 @@ jobs:
           echo "PR is from the same repository. Proceeding."
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
             scripts/lib/upsert-pr-comment.sh

--- a/.github/workflows/github-ai-dispatcher.yml
+++ b/.github/workflows/github-ai-dispatcher.yml
@@ -60,7 +60,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
 


### PR DESCRIPTION
## Summary

Fixes the "Node.js 20 is deprecated" deprecation warning appearing in CI jobs.

## Changes

Updates three action references that were pinned to versions using Node.js 20 runtime:

### actions/setup-node: v4.4.0 → v6.4.0
- Composite action `.github/actions/setup-node-pnpm/action.yml`
- `.github/workflows/github-ai-dispatcher.yml`

v5.0.0 was the first release to upgrade from Node 20 to Node 24 runtime. v6.4.0 is the current latest (still on Node 24).

### actions/checkout: v4.2.2 → v7.0.0
- `.github/workflows/agent-pipeline.yml` (3 occurrences)

v4.x uses Node 20; v6+ uses Node 24 runtime.

## Affected Jobs

The following CI jobs currently trigger the deprecation warning:
- Lint (.github#2)
- Structural Contract (.github#2) 
- CI Risk Classifier (.github#8)
- Typecheck (.github#2)

These go through the shared `setup-node-pnpm` composite action, which was the primary source of the warnings.

## Verification

All other pinned actions in both `Jovie/.github` and `JovieInc/.github` were audited and confirmed to already target Node 24:
- `actions/github-script@v9.0.0`
- `actions/cache@v6.1.0` / `v5.0.4`
- `actions/setup-python@v6.3.0`
- `actions/create-github-app-token@v3.2.0`
- `actions/upload-artifact@v7.0.1`
- `actions/download-artifact@v8.0.1`
- `pnpm/action-setup@v6.0.9` (composite)