### PR TITLE
fix(ci): make visual-a11y gate blocking (was advisory-only)

### DIFF
--- a/.github/workflows/visual-a11y.yml
+++ b/.github/workflows/visual-a11y.yml
@@ -43,89 +43,59 @@ jobs:
 
   storybook-a11y:
     name: Storybook A11y Checks
-    # Blocking — Storybook component a11y signal, path-gated to component/storybook changes.
-    # Failures block PRs via required status check in branch protection.
     needs: [ci-visual-path-changes]
     if: ${{ needs.ci-visual-path-changes.outputs.has_visual_changes == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright
-        run: pnpm --filter web exec playwright install chromium --with-deps
-
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter web exec playwright install chromium --with-deps
       - name: Run Storybook A11y Tests
         id: a11y-test
         run: pnpm --filter web test:a11y
-
       - name: A11y Results Summary
         if: always()
         run: |
           if [ "${{ steps.a11y-test.outcome }}" == "failure" ]; then
-            echo "## 🔍 A11y Check Results" >> "$GITHUB_STEP_SUMMARY"
+            echo "## A11y Check Results" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "❌ **Accessibility violations detected** — blocking this PR." >> "$GITHUB_STEP_SUMMARY"
+            echo "FAIL: Accessibility violations detected - blocking this PR." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Some components have accessibility issues (contrast, labels, etc.)." >> "$GITHUB_STEP_SUMMARY"
-            echo "Review the job logs for details." >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "To run locally: \`pnpm --filter web test:a11y\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "To run locally: pnpm --filter web test:a11y" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "## ✅ A11y Check Results" >> "$GITHUB_STEP_SUMMARY"
+            echo "## A11y Check Results" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "All Storybook components passed accessibility checks." >> "$GITHUB_STEP_SUMMARY"
+            echo "PASS: All Storybook components passed accessibility checks." >> "$GITHUB_STEP_SUMMARY"
           fi
 
   playwright-visual:
     name: Playwright Visual Regression
-    # Blocking — visual diff gate for component PRs, path-gated to component/ui changes.
-    # Failures block PRs via required status check in branch protection.
     needs: [ci-visual-path-changes]
     if: ${{ needs.ci-visual-path-changes.outputs.has_visual_changes == 'true' && (github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository) }}
-
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright
-        run: pnpm --filter web exec playwright install chromium chromium-headless-shell --with-deps
-
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter web exec playwright install chromium chromium-headless-shell --with-deps
       - name: Run Visual Regression Tests
         id: visual-test
         run: pnpm --filter web e2e:visual
         env:
           CI: true
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          # Skip auth-required tests in CI without secrets
           E2E_SKIP_AUTH: true
-
       - name: Upload Visual Diff Artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -135,24 +105,18 @@ jobs:
             apps/web/test-results/
             apps/web/playwright-report/
           retention-days: 7
-
       - name: Visual Test Results Summary
         if: always()
         run: |
           if [ "${{ steps.visual-test.outcome }}" == "failure" ]; then
-            echo "## 🖼️ Visual Regression Results" >> "$GITHUB_STEP_SUMMARY"
+            echo "## Visual Regression Results" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "❌ **Visual differences detected** — blocking this PR." >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Some pages have visual changes from the baseline." >> "$GITHUB_STEP_SUMMARY"
-            echo "Download the artifacts to review diff images." >> "$GITHUB_STEP_SUMMARY"
+            echo "FAIL: Visual differences detected - blocking this PR." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "If changes are intentional, update snapshots:" >> "$GITHUB_STEP_SUMMARY"
-            echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
             echo "pnpm --filter web e2e:visual:update" >> "$GITHUB_STEP_SUMMARY"
-            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "## ✅ Visual Regression Results" >> "$GITHUB_STEP_SUMMARY"
+            echo "## Visual Regression Results" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "All visual tests passed - no unexpected changes detected." >> "$GITHUB_STEP_SUMMARY"
+            echo "PASS: All visual tests passed - no unexpected changes detected." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/visual-a11y.yml
+++ b/.github/workflows/visual-a11y.yml
@@ -3,10 +3,6 @@ name: Visual & A11y Tests
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'apps/web/components/**'
-      - 'apps/web/.storybook/**'
-      - 'packages/ui/**'
 
 permissions:
   contents: read
@@ -17,10 +13,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ci-visual-path-changes:
+    name: Visual Path Detection
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      has_visual_changes: ${{ steps.detect.outputs.has_visual_changes }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Fetch base ref for diff comparison
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.base_ref }}" --depth=1 --no-tags
+      - name: Detect visual-relevant changes
+        id: detect
+        run: |
+          VISUAL_PATTERNS='^apps/web/components/|^apps/web/.storybook/|^packages/ui/'
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            CHANGED_FILES=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD 2>/dev/null || echo "")
+            if echo "$CHANGED_FILES" | grep -qE "$VISUAL_PATTERNS"; then
+              echo "has_visual_changes=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_visual_changes=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "has_visual_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
   storybook-a11y:
     name: Storybook A11y Checks
     # Blocking — Storybook component a11y signal, path-gated to component/storybook changes.
     # Failures block PRs via required status check in branch protection.
+    needs: [ci-visual-path-changes]
+    if: ${{ needs.ci-visual-path-changes.outputs.has_visual_changes == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -69,10 +95,8 @@ jobs:
     name: Playwright Visual Regression
     # Blocking — visual diff gate for component PRs, path-gated to component/ui changes.
     # Failures block PRs via required status check in branch protection.
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    # Skip on forks — secrets (DATABASE_URL) are not available
-    if: ${{ github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: [ci-visual-path-changes]
+    if: ${{ needs.ci-visual-path-changes.outputs.has_visual_changes == 'true' && (github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/visual-a11y.yml
+++ b/.github/workflows/visual-a11y.yml
@@ -19,9 +19,8 @@ concurrency:
 jobs:
   storybook-a11y:
     name: Storybook A11y Checks
-    # Advisory — Storybook component a11y signal, not a merge gate. PR Ready
-    # aggregates deterministic checks only; promote to blocking via ci-pr-ready.needs.
-    continue-on-error: true
+    # Blocking — Storybook component a11y signal, path-gated to component/storybook changes.
+    # Failures block PRs via required status check in branch protection.
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -46,28 +45,18 @@ jobs:
 
       - name: Run Storybook A11y Tests
         id: a11y-test
-        run: |
-          set +e
-          pnpm --filter web test:a11y
-          code=$?
-          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
-          if [ "$code" -ne 0 ]; then
-            echo "::warning::Storybook a11y exited $code (advisory — not a merge gate)"
-          fi
-          exit 0
+        run: pnpm --filter web test:a11y
 
       - name: A11y Results Summary
         if: always()
         run: |
           if [ "${{ steps.a11y-test.outcome }}" == "failure" ]; then
-            echo "::warning::⚠️ Accessibility violations detected in Storybook components. Check the test output above for details."
-            echo ""
             echo "## 🔍 A11y Check Results" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "⚠️ **Accessibility violations detected**" >> "$GITHUB_STEP_SUMMARY"
+            echo "❌ **Accessibility violations detected** — blocking this PR." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "Some components have accessibility issues (contrast, labels, etc.)." >> "$GITHUB_STEP_SUMMARY"
-            echo "These are logged as warnings - review the job output for details." >> "$GITHUB_STEP_SUMMARY"
+            echo "Review the job logs for details." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "To run locally: \`pnpm --filter web test:a11y\`" >> "$GITHUB_STEP_SUMMARY"
           else
@@ -78,8 +67,8 @@ jobs:
 
   playwright-visual:
     name: Playwright Visual Regression
-    # Advisory — visual diff signal for component PRs, not a merge gate.
-    continue-on-error: true
+    # Blocking — visual diff gate for component PRs, path-gated to component/ui changes.
+    # Failures block PRs via required status check in branch protection.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Skip on forks — secrets (DATABASE_URL) are not available
@@ -106,15 +95,7 @@ jobs:
 
       - name: Run Visual Regression Tests
         id: visual-test
-        run: |
-          set +e
-          pnpm --filter web e2e:visual
-          code=$?
-          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
-          if [ "$code" -ne 0 ]; then
-            echo "::warning::Playwright visual exited $code (advisory — not a merge gate)"
-          fi
-          exit 0
+        run: pnpm --filter web e2e:visual
         env:
           CI: true
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
@@ -135,11 +116,9 @@ jobs:
         if: always()
         run: |
           if [ "${{ steps.visual-test.outcome }}" == "failure" ]; then
-            echo "::warning::⚠️ Visual differences detected. Check the artifacts for diff images."
-            echo ""
             echo "## 🖼️ Visual Regression Results" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "⚠️ **Visual differences detected**" >> "$GITHUB_STEP_SUMMARY"
+            echo "❌ **Visual differences detected** — blocking this PR." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "Some pages have visual changes from the baseline." >> "$GITHUB_STEP_SUMMARY"
             echo "Download the artifacts to review diff images." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Implements Eve's plan (JOV-4042/JOV-4060 — fix-the-gates focus)

The `Visual & A11y Tests` workflow had both jobs running as advisory-only:
- `continue-on-error: true` — failures didn't affect PR status
- `set +e` + `exit 0` — exit codes were explicitly swallowed
- Step summary messages said "advisory — not a merge gate"

This made the visual/a11y signal useless as a gate — PRs with broken a11y or visual regressions could merge without anyone noticing.

## Changes

### visual-a11y.yml (workflow fix)
- Remove `continue-on-error: true` from both `storybook-a11y` and `playwright-visual` jobs
- Remove the `set +e` / `exit 0` pattern that swallowed all failures
- Let test exit codes propagate naturally — failures now block the PR
- Update step summary messages: ❌ instead of ⚠️, "blocking this PR" instead of advisory language

### Ruleset update (branch protection)
- Added `Storybook A11y Checks` and `Playwright Visual Regression` to required status checks on ruleset 10512119 (Main Branch Protection)
- These only run when their path triggers match (`apps/web/components/**`, `apps/web/.storybook/**`, `packages/ui/**`)
- PRs not touching those paths are unaffected

## Safety
- Both jobs remain path-gated — only trigger on component/storybook/ui changes
- `playwright-visual` uses fork detection (`if: !fork`) to avoid secret exposure on external PRs
- Snapshot updates are easy: `pnpm --filter web e2e:visual:update`

## Follow-up
- BRANCH_PROTECTION.md should be updated to reflect the new checks (defer to a docs pass)