### PR TITLE
shell: OV brand skin — BrandLogo variant, wordmark, .ov-mode token overrides

### DIFF
--- a/apps/web/components/atoms/BrandLogo.tsx
+++ b/apps/web/components/atoms/BrandLogo.tsx
@@ -1,5 +1,10 @@
 import type { CSSProperties } from 'react';
-import { JOVIE_PATH, JOVIE_VIEWBOX } from '@/lib/brand/tokens';
+import {
+  BRAND_PATHS,
+  BRAND_WORDMARKS,
+  type BrandVariant,
+  JOVIE_VIEWBOX,
+} from '@/lib/brand/tokens';
 import { cn } from '@/lib/utils';
 
 export type BrandLogoTone = 'auto' | 'white' | 'color' | 'muted';
@@ -8,6 +13,7 @@ export interface BrandLogoProps {
   readonly size?: number;
   readonly className?: string;
   readonly tone?: BrandLogoTone;
+  readonly variant?: BrandVariant;
   readonly alt?: string;
   readonly rounded?: boolean;
   readonly style?: CSSProperties;
@@ -27,11 +33,13 @@ export function BrandLogo({
   size = 48,
   className,
   tone = 'auto',
-  alt = 'Jovie',
+  variant = 'jovie',
+  alt,
   rounded = true,
   style,
   'aria-hidden': ariaHidden,
 }: BrandLogoProps) {
+  const resolvedAlt = alt ?? BRAND_WORDMARKS[variant];
   return (
     <span
       className={cn(
@@ -42,6 +50,7 @@ export function BrandLogo({
       )}
       style={style}
       aria-hidden={ariaHidden}
+      data-brand-variant={variant}
     >
       <svg
         xmlns='http://www.w3.org/2000/svg'
@@ -51,10 +60,10 @@ export function BrandLogo({
         fill='currentColor'
         shapeRendering='geometricPrecision'
         role={ariaHidden ? undefined : 'img'}
-        aria-label={ariaHidden ? undefined : alt}
+        aria-label={ariaHidden ? undefined : resolvedAlt}
       >
-        {!ariaHidden && <title>{alt}</title>}
-        <path d={JOVIE_PATH} />
+        {!ariaHidden && <title>{resolvedAlt}</title>}
+        <path d={BRAND_PATHS[variant]} />
       </svg>
     </span>
   );

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -40,6 +40,7 @@ import { SidebarInstallBanner } from '@/features/feedback/SidebarInstallBanner';
 import { SidebarUpgradeBanner } from '@/features/feedback/SidebarUpgradeBanner';
 import { copyToClipboard } from '@/hooks/useClipboard';
 import { useProfileData } from '@/hooks/useProfileData';
+import { BRAND_WORDMARKS, type BrandVariant } from '@/lib/brand/tokens';
 import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
 import { env } from '@/lib/env-client';
 import { useAppFlag } from '@/lib/flags/client';
@@ -54,6 +55,8 @@ import { SidebarBottomNowPlayingBridge } from './SidebarBottomNowPlayingBridge';
 
 export interface UnifiedSidebarProps {
   readonly section: 'admin' | 'dashboard' | 'library' | 'settings';
+  /** Brand skin for the shell chrome. 'ov' is the internal/admin skin (JOV-4083). */
+  readonly variant?: BrandVariant;
 }
 
 const VERSION_DISMISSAL_KEY = 'jovie-version-update-dismissed';
@@ -195,6 +198,7 @@ function SidebarHeaderNav({
   isAdmin,
   hasMultipleProfiles,
   isDemoRoute,
+  variant = 'jovie',
   routeBackHref = APP_ROUTES.DASHBOARD,
   routeBackLabel = 'Back to App',
 }: Readonly<{
@@ -202,6 +206,7 @@ function SidebarHeaderNav({
   isAdmin: boolean;
   hasMultipleProfiles: boolean;
   isDemoRoute: boolean;
+  variant?: BrandVariant;
   routeBackHref?: string;
   routeBackLabel?: string;
 }>) {
@@ -255,8 +260,9 @@ function SidebarHeaderNav({
         if (hasMultipleProfiles && !isAdmin) {
           return <ProfileSwitcher />;
         }
-        // Clean header: Jovie logo + wordmark for identity (matches Linear's
+        // Clean header: brand logo + wordmark for identity (matches Linear's
         // workspace pill pattern). User menu lives in the bottom Settings button.
+        // Wordmark and logo variant are driven by the active brand skin.
         return (
           <div
             className={cn(
@@ -267,11 +273,12 @@ function SidebarHeaderNav({
             <BrandLogo
               size={14}
               tone='auto'
+              variant={variant}
               rounded={false}
               className='rounded-sm shrink-0'
             />
             <span className='truncate text-app tracking-tight text-sidebar-item-foreground [font-weight:var(--font-weight-nav)] group-data-[collapsible=icon]:hidden'>
-              Jovie
+              {BRAND_WORDMARKS[variant]}
             </span>
           </div>
         );
@@ -372,7 +379,10 @@ function ShellSidebarInstallBanner() {
  * The version string (vX.Y.Z + optional sha) is now rendered inside the user
  * menu (visible to everyone) instead of the previous admin-only footer.
  */
-export function UnifiedSidebar({ section }: UnifiedSidebarProps) {
+export function UnifiedSidebar({
+  section,
+  variant = 'jovie',
+}: UnifiedSidebarProps) {
   const { creatorProfiles } = useDashboardData();
   const shellChatV1Enabled = useAppFlag('DESIGN_V1');
   const sidebarOverride = useShellSidebarOverride();
@@ -394,7 +404,10 @@ export function UnifiedSidebar({ section }: UnifiedSidebarProps) {
       className={cn(
         'bg-base',
         '[--sidebar-width:var(--linear-app-sidebar-width)]',
-        'transition-[width,transform] duration-cinematic ease-cinematic'
+        'transition-[width,transform] duration-cinematic ease-cinematic',
+        // OV brand skin: class-based token override, same mechanism as `.dark`
+        // (see design-system.css → OV MODE). Zero layout impact.
+        variant === 'ov' && 'ov-mode'
       )}
     >
       <SidebarHeader
@@ -409,6 +422,7 @@ export function UnifiedSidebar({ section }: UnifiedSidebarProps) {
           isAdmin={isAdmin}
           hasMultipleProfiles={hasMultipleProfiles}
           isDemoRoute={isDemoRoute}
+          variant={variant}
           routeBackHref={sidebarOverride?.backHref}
           routeBackLabel={sidebarOverride?.backLabel}
         />

--- a/apps/web/lib/brand/tokens.ts
+++ b/apps/web/lib/brand/tokens.ts
@@ -15,8 +15,35 @@
 
 export const JOVIE_VIEWBOX = { width: 360, height: 360 } as const;
 
+/**
+ * Brand skin variants for the app shell (JOV-4083 / #13493).
+ * 'jovie' is the customer product; 'ov' is the internal/admin skin.
+ */
+export type BrandVariant = 'jovie' | 'ov';
+
 export const JOVIE_PATH =
   'M179.16,6 L182.24,6.05 C191.16,7.78 199.14,12.50 205.29,19.23 C213.24,27.93 218.16,40.00 218.16,53.37 C218.16,66.74 213.24,78.81 205.29,87.51 C198.59,94.85 189.70,99.79 179.80,101.08 L179.16,101.08 C156.96,101.08 136.86,109.92 122.33,124.21 C107.83,138.48 98.84,158.20 98.84,179.98 C98.84,201.76 107.82,221.48 122.33,235.75 C136.87,250.05 156.97,258.90 179.16,258.90 C201.36,258.90 221.46,250.06 235.99,235.77 C250.50,221.50 259.48,201.78 259.48,180.00 C259.48,162.45 253.67,146.25 243.85,133.18 C233.77,119.75 219.43,109.57 202.80,104.56 L200.69,103.92 C205.05,101.27 209.03,97.96 212.53,94.14 C222.10,83.67 228.03,69.25 228.03,53.37 C228.03,37.49 222.10,23.07 212.53,12.60 C211.09,11.03 209.58,9.54 207.98,8.16 L215.65,9.74 C256.09,18.09 291.46,40.04 316.56,70.49 C341.22,100.40 356.00,138.51 356.00,179.99 C356.00,228.04 336.19,271.54 304.17,303.04 C272.18,334.50 227.98,353.96 179.17,353.96 C130.38,353.96 86.17,334.49 54.17,303.02 C22.15,271.53 2.34,228.03 2.34,179.98 C2.34,131.93 22.15,88.42 54.17,56.93 C86.18,25.47 130.38,6 179.16,6 Z';
+
+/**
+ * OV mark path. PLACEHOLDER: reuses the Jovie mark path until Tim locks the
+ * OV mark (spelling, treatment, accent — taste-gated on JOV-4083). The OV
+ * identity is carried by the `.ov-mode` token overrides in design-system.css
+ * (`--ov-brand-accent` tint on the mark); swapping this constant is the only
+ * change needed once the final OV artwork lands.
+ */
+export const OV_PATH = JOVIE_PATH;
+
+/** Mark path per brand variant. */
+export const BRAND_PATHS: Record<BrandVariant, string> = {
+  jovie: JOVIE_PATH,
+  ov: OV_PATH,
+};
+
+/** Wordmark text per brand variant. */
+export const BRAND_WORDMARKS: Record<BrandVariant, string> = {
+  jovie: 'Jovie',
+  ov: 'OV',
+};
 
 /**
  * Per-pair tracking for the geometric JOVIE wordmark, in cap-height units.

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1586,7 +1586,7 @@ html[data-profile-initial-mode]
 
 /* OV mark carries the identity accent; treatment is CSS-driven so the
    taste-gated mark decision can land without touching components. */
-.ov-mode [data-brand-variant='ov'] {
+.ov-mode [data-brand-variant="ov"] {
   color: var(--ov-brand-accent);
 }
 

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1552,6 +1552,45 @@ html[data-profile-initial-mode]
 }
 
 /* ============================================
+   OV MODE (internal/admin brand skin — JOV-4083 / #13493)
+   Class-based token override, same mechanism as the :root.dark blocks above.
+   Applied on the shell/sidebar root when the OV skin is active. Overrides
+   only color tokens — zero layout impact by construction.
+
+   OV identity accent: System B violet (--color-accent-purple). PLACEHOLDER
+   pending Tim's taste call on the OV mark/accent; swap the single
+   --ov-brand-accent line once decided.
+   ============================================ */
+.ov-mode {
+  --ov-brand-accent: var(--color-accent-purple);
+
+  /* Sidebar chrome flips to the ink/dark ladder in OV mode regardless of
+     theme — the inversion is the skin in light mode; near-no-op in dark. */
+  --sidebar-background: 8 9 10;
+  --sidebar-foreground: 227 228 229;
+  --sidebar-primary: 227 228 229;
+  --sidebar-primary-foreground: 12 12 12;
+  --sidebar-accent: 255 255 255 / 0.03;
+  --sidebar-accent-active: 255 255 255 / 0.06;
+  --sidebar-accent-foreground: 227 228 229;
+  --sidebar-border: 255 255 255 / 0.06;
+  --sidebar-muted: 138 143 152;
+  --sidebar-muted-foreground: 138 143 152;
+  --sidebar-surface: 8 9 10;
+  --sidebar-surface-hover: 255 255 255 / 0.04;
+  --sidebar-input-background: 255 255 255 / 0.06;
+  --sidebar-input-border: 255 255 255 / 0.06;
+  --sidebar-item-foreground: 214 218 226;
+  --sidebar-item-icon: 116 120 128;
+}
+
+/* OV mark carries the identity accent; treatment is CSS-driven so the
+   taste-gated mark decision can land without touching components. */
+.ov-mode [data-brand-variant='ov'] {
+  color: var(--ov-brand-accent);
+}
+
+/* ============================================
    MENU/DROPDOWN TOKENS
    ============================================ */
 :root {

--- a/apps/web/tests/unit/atoms/BrandLogo.test.tsx
+++ b/apps/web/tests/unit/atoms/BrandLogo.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { BrandLogo } from '@/components/atoms/BrandLogo';
-import { JOVIE_PATH, JOVIE_VIEWBOX } from '@/lib/brand/tokens';
+import { BRAND_PATHS, JOVIE_PATH, JOVIE_VIEWBOX } from '@/lib/brand/tokens';
 import { expectNoA11yViolations } from '@/tests/utils/a11y';
 
 describe('BrandLogo', () => {
@@ -123,6 +123,30 @@ describe('BrandLogo', () => {
     const { container } = render(<BrandLogo />);
     const wrapper = container.querySelector('span');
     expect(wrapper).toHaveClass('inline-flex', 'shrink-0');
+  });
+
+  it('defaults to the jovie variant with data-brand-variant on wrapper', () => {
+    const { container } = render(<BrandLogo />);
+    const wrapper = container.querySelector('span');
+    expect(wrapper).toHaveAttribute('data-brand-variant', 'jovie');
+  });
+
+  it('renders the ov variant with the OV mark path and data attribute', () => {
+    const { container } = render(<BrandLogo variant='ov' />);
+    const wrapper = container.querySelector('span');
+    const path = container.querySelector('path');
+    expect(wrapper).toHaveAttribute('data-brand-variant', 'ov');
+    expect(path?.getAttribute('d')).toBe(BRAND_PATHS.ov);
+  });
+
+  it('defaults aria-label to "OV" for the ov variant', () => {
+    render(<BrandLogo variant='ov' />);
+    expect(screen.getByLabelText('OV')).toBeInTheDocument();
+  });
+
+  it('explicit alt overrides the variant default', () => {
+    render(<BrandLogo variant='ov' alt='Custom' />);
+    expect(screen.getByLabelText('Custom')).toBeInTheDocument();
   });
 
   it('passes a11y checks', async () => {


### PR DESCRIPTION
## Problem
Shell branding is hardcoded: `UnifiedSidebar` renders `<BrandLogo/>` + literal "Jovie"; `BrandLogo` has no variant prop; no token-override hook for the OV admin skin.

## What changed
- **`lib/brand/tokens.ts`** — `BrandVariant` type, `OV_PATH`, `BRAND_PATHS`, `BRAND_WORDMARKS`. `OV_PATH` is a deliberate placeholder aliasing `JOVIE_PATH` until the taste-gated OV mark lands; swapping one constant finishes it.
- **`components/atoms/BrandLogo.tsx`** — `variant?: 'jovie' | 'ov'` prop (default `'jovie'`, existing callers unchanged). Path + default alt derive from the variant; wrapper carries `data-brand-variant` so the mark treatment stays CSS-driven.
- **`components/organisms/UnifiedSidebar.tsx`** — optional `variant` prop; wordmark text + logo variant driven by it; `.ov-mode` class on the Sidebar root when `variant='ov'`.
- **`styles/design-system.css`** — `.ov-mode` token-override block next to the `:root.dark` sidebar block (same class-override mechanism). Flips `--sidebar-*` chrome to the ink/dark ladder and defines `--ov-brand-accent` (System B violet) tinting the OV mark via `[data-brand-variant='ov']`. Color tokens only — zero layout impact by construction.
- **`tests/unit/atoms/BrandLogo.test.tsx`** — 4 new tests for the variant branch.

## Assumptions (Blind-Spot Pass)
1. **Dispatch path drift:** spec said `components/shell/UnifiedSidebar.tsx`; the file lives at `components/organisms/UnifiedSidebar.tsx`. Edited the real file.
2. **TASTE GATE (per issue + gbrain `decisions/ov-mode-admin-split-2026-07-06`):** OV mark spelling/treatment/accent is Tim's call. Conservative default: reuse Jovie mark path, tint via `--ov-brand-accent` = `--color-accent-purple`, wordmark "OV". All three are single-line swaps once decided.
3. **`.ov-mode` scope:** applied on the Sidebar root (this issue's surface). #13492/#13494 can hoist the class to the app-shell root; the CSS block already covers `--app-shell-*`-adjacent chrome via the same class wherever it's applied.
4. Nothing sets `variant='ov'` yet — the mode flip mechanism is #13494 (switcher). This PR is inert until then.

## Verification
**Local verification blocked — do not promote until CI is green.** Sandbox registry egress denied (`registry.npmjs.org` → 403; network-access request pending), so `pnpm turbo lint typecheck test:fast --affected && pnpm run build:web` could not run locally. Static checks performed:

```
$ node --experimental-strip-types --check apps/web/lib/brand/tokens.ts
OK apps/web/lib/brand/tokens.ts
$ brace/paren balance on edited tsx: all balanced
```

Verification deferred to CI (`ci-fast` typecheck/biome, `Unit Tests`, `Build (public routes)`). PR stays **draft** until those pass.

## Scope
Variant prop + token overrides only. Navigation split (#13492) and switcher UI (#13494) are separate issues.

Dispatch ID: ov-brand-skin-13493
Closes #13493

🤖 Generated with [Claude Code](https://claude.com/claude-code)