### PR TITLE
dashboard: AI Visibility compact row — fix dead CTA, bot icon, table above fold

### DIFF
--- a/apps/web/components/features/dashboard/organisms/ai-crawler/AiCrawlerIntelligenceCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/ai-crawler/AiCrawlerIntelligenceCard.tsx
@@ -103,16 +103,16 @@ export function AiCrawlerIntelligenceCard({
           aria-hidden='true'
         />
       )}
-      <span className='shrink-0 text-sm font-[590] tracking-[-0.01em] text-primary-token'>
+      <span className='shrink-0 text-sm font-semibold text-primary-token'>
         AI Visibility
       </span>
-      <span className='min-w-0 flex-1 truncate text-left text-[11.5px] text-tertiary-token'>
+      <span className='min-w-0 flex-1 truncate text-left text-2xs text-tertiary-token'>
         {showTeaser
           ? 'See which AI services read your pages'
           : `${model.title} · ${model.meta}`}
       </span>
       {model.status ? (
-        <span className='inline-flex shrink-0 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.06em] text-secondary-token'>
+        <span className='inline-flex shrink-0 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-3xs font-medium uppercase tracking-wide text-secondary-token'>
           <span
             className='h-1.5 w-1.5 shrink-0 rounded-full'
             style={{ background: statusDotVar(model.status.tone) }}
@@ -147,7 +147,7 @@ export function AiCrawlerIntelligenceCard({
       onClick={handleOpen}
       className={cn(
         ROW_CLASS,
-        'text-left transition-colors duration-subtle hover:border-default hover:bg-surface-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]',
+        'text-left transition-colors duration-subtle hover:border-default hover:bg-surface-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--color-focus-ring)',
         className
       )}
       data-testid='ai-crawler-intelligence-card'

--- a/apps/web/components/features/dashboard/organisms/ai-crawler/AiCrawlerIntelligenceCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/ai-crawler/AiCrawlerIntelligenceCard.tsx
@@ -1,75 +1,35 @@
 'use client';
 
-import { Bot, Lock } from 'lucide-react';
+import { ChevronRight, Lock } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
 import { UpgradeButton } from '@/components/molecules/UpgradeButton';
-import { EntityCard } from '@/components/organisms/entity-card';
 import { aiCrawlerAnalyticsToEntityCard } from '@/components/organisms/entity-card/adapters';
+import {
+  KIND_PRESETS,
+  statusDotVar,
+} from '@/components/organisms/entity-card/kind-presets';
 import { track } from '@/lib/analytics';
 import { useAiCrawlerAnalyticsQuery } from '@/lib/queries/useAiCrawlerAnalyticsQuery';
 import { cn } from '@/lib/utils';
-import type { AiCrawlerAnalyticsResponse } from '@/types/ai-crawler-analytics';
 
 interface AiCrawlerIntelligenceCardProps {
   readonly onOpenDetail?: () => void;
   readonly className?: string;
 }
 
-function CardSkeleton({ className }: { readonly className?: string }) {
+const ROW_CLASS =
+  'flex min-h-12 w-full items-center gap-3 rounded-xl border border-subtle bg-surface-1 px-3 py-2';
+
+function RowSkeleton({ className }: { readonly className?: string }) {
   return (
     <div
-      className={cn(
-        'min-h-45 rounded-2xl border border-subtle bg-surface-1 p-4',
-        className
-      )}
+      className={cn(ROW_CLASS, className)}
       data-testid='ai-crawler-card-skeleton'
     >
-      <LoadingSkeleton
-        height='h-4'
-        width='w-28'
-        rounded='sm'
-        className='mb-3'
-      />
-      <LoadingSkeleton
-        height='h-8'
-        width='w-20'
-        rounded='sm'
-        className='mb-4'
-      />
-      <div className='space-y-2'>
-        <LoadingSkeleton height='h-3' width='w-full' rounded='sm' />
-        <LoadingSkeleton height='h-3' width='w-4/5' rounded='sm' />
-        <LoadingSkeleton height='h-3' width='w-3/5' rounded='sm' />
-      </div>
-    </div>
-  );
-}
-
-function TeaserOverlay({
-  analytics,
-}: {
-  readonly analytics: AiCrawlerAnalyticsResponse;
-}) {
-  return (
-    <div
-      className='absolute inset-0 flex flex-col items-center justify-center gap-3 rounded-2xl bg-surface-1/90 px-4 text-center backdrop-blur'
-      data-testid='ai-crawler-card-teaser'
-    >
-      <div className='flex h-9 w-9 items-center justify-center rounded-full bg-surface-0 text-secondary-token'>
-        <Lock className='h-4 w-4' aria-hidden='true' />
-      </div>
-      <div className='space-y-1'>
-        <p className='text-app font-semibold text-primary-token'>
-          {analytics.totalRequests > 0
-            ? `${analytics.totalRequests.toLocaleString()} AI reads in 30 days`
-            : 'See which AI services read your pages'}
-        </p>
-        <p className='text-xs text-secondary-token'>
-          Upgrade to Pro for named crawlers, counts, and trends.
-        </p>
-      </div>
-      <UpgradeButton size='sm'>Upgrade to Pro</UpgradeButton>
+      <LoadingSkeleton height='h-4' width='w-4' rounded='sm' />
+      <LoadingSkeleton height='h-4' width='w-24' rounded='sm' />
+      <LoadingSkeleton height='h-3' width='w-40' rounded='sm' />
     </div>
   );
 }
@@ -80,6 +40,7 @@ export function AiCrawlerIntelligenceCard({
 }: AiCrawlerIntelligenceCardProps) {
   const { data, isLoading, isError } = useAiCrawlerAnalyticsQuery();
   const hasTrackedViewRef = useRef(false);
+  const BotIcon = KIND_PRESETS.ai.icon;
 
   useEffect(() => {
     if (!data || hasTrackedViewRef.current) {
@@ -96,55 +57,107 @@ export function AiCrawlerIntelligenceCard({
   }, [data]);
 
   if (isLoading) {
-    return <CardSkeleton className={className} />;
+    return <RowSkeleton className={className} />;
   }
 
   if (isError || !data) {
     return (
       <div
-        className={cn(
-          'min-h-45 rounded-2xl border border-subtle bg-surface-1 p-4',
-          className
-        )}
+        className={cn(ROW_CLASS, className)}
         data-testid='ai-crawler-card-error'
       >
-        <div className='flex items-center gap-2 text-secondary-token'>
-          <Bot className='h-4 w-4' aria-hidden='true' />
-          <p className='text-app'>
-            AI crawler analytics temporarily unavailable.
-          </p>
-        </div>
+        <BotIcon
+          className='h-4 w-4 shrink-0 text-tertiary-token'
+          aria-hidden='true'
+        />
+        <p className='min-w-0 truncate text-app text-secondary-token'>
+          AI crawler analytics temporarily unavailable.
+        </p>
       </div>
     );
   }
 
-  const model = aiCrawlerAnalyticsToEntityCard(data);
+  const handleOpen = () => {
+    track('ai_crawler_card_opened', {
+      total_requests: data.totalRequests,
+      crawler_count: data.crawlers.length,
+    });
+    onOpenDetail?.();
+  };
+
+  const model = aiCrawlerAnalyticsToEntityCard(data, {
+    onOpenDetail: handleOpen,
+  });
   const showTeaser = data.isTeaser;
 
+  const rowContent = (
+    <>
+      {showTeaser ? (
+        <Lock
+          className='h-4 w-4 shrink-0 text-tertiary-token'
+          aria-hidden='true'
+        />
+      ) : (
+        <BotIcon
+          className='h-4 w-4 shrink-0 text-secondary-token'
+          aria-hidden='true'
+        />
+      )}
+      <span className='shrink-0 text-sm font-[590] tracking-[-0.01em] text-primary-token'>
+        AI Visibility
+      </span>
+      <span className='min-w-0 flex-1 truncate text-left text-[11.5px] text-tertiary-token'>
+        {showTeaser
+          ? 'See which AI services read your pages'
+          : `${model.title} · ${model.meta}`}
+      </span>
+      {model.status ? (
+        <span className='inline-flex shrink-0 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.06em] text-secondary-token'>
+          <span
+            className='h-1.5 w-1.5 shrink-0 rounded-full'
+            style={{ background: statusDotVar(model.status.tone) }}
+            aria-hidden='true'
+          />
+          {model.status.label}
+        </span>
+      ) : null}
+    </>
+  );
+
+  if (showTeaser) {
+    return (
+      <div
+        className={cn(ROW_CLASS, className)}
+        data-testid='ai-crawler-intelligence-card'
+      >
+        <div
+          className='flex min-w-0 flex-1 items-center gap-3'
+          data-testid='ai-crawler-card-teaser'
+        >
+          {rowContent}
+        </div>
+        <UpgradeButton size='sm'>Upgrade to Pro</UpgradeButton>
+      </div>
+    );
+  }
+
   return (
-    <div
-      className={cn('relative min-h-45', className)}
+    <button
+      type='button'
+      onClick={handleOpen}
+      className={cn(
+        ROW_CLASS,
+        'text-left transition-colors duration-subtle hover:border-default hover:bg-surface-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]',
+        className
+      )}
       data-testid='ai-crawler-intelligence-card'
+      aria-label='View AI visibility details'
     >
-      <EntityCard
-        model={model}
-        treatment='detailed'
-        surface='app'
-        className={cn(showTeaser && 'pointer-events-none select-none blur-sm')}
-        onClick={
-          !showTeaser
-            ? () => {
-                track('ai_crawler_card_opened', {
-                  total_requests: data.totalRequests,
-                  crawler_count: data.crawlers.length,
-                });
-                onOpenDetail?.();
-              }
-            : undefined
-        }
-        dataTestId='ai-crawler-entity-card'
+      {rowContent}
+      <ChevronRight
+        className='h-4 w-4 shrink-0 text-tertiary-token'
+        aria-hidden='true'
       />
-      {showTeaser ? <TeaserOverlay analytics={data} /> : null}
-    </div>
+    </button>
   );
 }

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
@@ -873,7 +873,7 @@ export const DashboardAudienceTableUnified = memo(
               <p className='sr-only'>{getSrDescription(rows.length === 0)}</p>
 
               <div className='flex-1 min-h-0 flex flex-col'>
-                <div className='shrink-0 border-b border-subtle px-4 py-3'>
+                <div className='shrink-0 border-b border-subtle px-4 py-2'>
                   <AiCrawlerIntelligenceCard
                     onOpenDetail={() => {
                       openPanel('ai-crawlers');

--- a/apps/web/components/organisms/entity-card/adapters.ts
+++ b/apps/web/components/organisms/entity-card/adapters.ts
@@ -342,21 +342,25 @@ export function aiCrawlerAnalyticsToEntityCard(
   analytics: Pick<
     AiCrawlerAnalyticsResponse,
     'totalRequests' | 'weeklyRequests' | 'crawlers' | 'isTeaser'
-  >
+  >,
+  options: Readonly<{ onOpenDetail?: () => void }> = {}
 ): EntityCardModel {
+  const preset = KIND_PRESETS.ai;
   const topCrawler = analytics.crawlers[0]?.name;
-  const meta =
-    analytics.crawlers.length > 1
-      ? `${analytics.crawlers.length} services tracked`
-      : (topCrawler ?? 'Waiting for first AI crawl');
+  const detail =
+    analytics.totalRequests > 0
+      ? analytics.crawlers.length > 1
+        ? `${analytics.crawlers.length} services tracked`
+        : (topCrawler ?? 'Last 30 days')
+      : 'Waiting for first AI crawl';
 
   return {
     id: 'ai-crawler-intelligence',
-    kind: 'music',
-    accent: 'blue',
-    eyebrow: 'AI Visibility',
+    kind: 'ai',
+    accent: preset.accent,
+    eyebrow: preset.eyebrow,
     title: `${analytics.totalRequests.toLocaleString()} reads`,
-    meta,
+    meta: detail,
     secondaryMeta:
       analytics.weeklyRequests > 0
         ? `${analytics.weeklyRequests.toLocaleString()} this week`
@@ -367,7 +371,13 @@ export function aiCrawlerAnalyticsToEntityCard(
         : { label: 'Collecting', tone: 'neutral' },
     cta: analytics.isTeaser
       ? { label: 'Upgrade to Pro', href: null, disabled: true }
-      : { label: 'View Details', href: null },
+      : {
+          label: preset.ctaLabel,
+          href: null,
+          onClick: options.onOpenDetail
+            ? () => options.onOpenDetail?.()
+            : undefined,
+        },
     interactive: true,
     imageAlt: 'AI crawler analytics',
   };

--- a/apps/web/components/organisms/entity-card/kind-presets.ts
+++ b/apps/web/components/organisms/entity-card/kind-presets.ts
@@ -1,4 +1,5 @@
 import {
+  Bot,
   type LucideIcon,
   Music2,
   Play,
@@ -45,6 +46,13 @@ export const KIND_PRESETS: Record<EntityKind, KindPreset> = {
     accent: 'blue',
     fallbackVariant: 'generic',
     ctaLabel: 'Tickets',
+  },
+  ai: {
+    eyebrow: 'AI Visibility',
+    icon: Bot,
+    accent: 'blue',
+    fallbackVariant: 'generic',
+    ctaLabel: 'View Details',
   },
 };
 

--- a/apps/web/components/organisms/entity-card/types.ts
+++ b/apps/web/components/organisms/entity-card/types.ts
@@ -1,7 +1,7 @@
 import type { MouseEvent } from 'react';
 
-/** The four entity kinds a card can represent across profile + chat. */
-export type EntityKind = 'merch' | 'music' | 'video' | 'show';
+/** The entity kinds a card can represent across profile + chat + dashboard. */
+export type EntityKind = 'merch' | 'music' | 'video' | 'show' | 'ai';
 
 /** Carbon accent palette name (maps to `--color-accent-<name>`). */
 export type EntityAccent =

--- a/apps/web/tests/unit/dashboard/ai-crawler/AiCrawlerIntelligenceCard.test.tsx
+++ b/apps/web/tests/unit/dashboard/ai-crawler/AiCrawlerIntelligenceCard.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { AiCrawlerIntelligenceCard } from '@/components/features/dashboard/organisms/ai-crawler/AiCrawlerIntelligenceCard';
@@ -79,7 +79,7 @@ const teaserAnalytics: AiCrawlerAnalyticsResponse = {
 };
 
 describe('AiCrawlerIntelligenceCard', () => {
-  it('reserves min-height while loading', () => {
+  it('reserves compact row height while loading', () => {
     hoisted.useAiCrawlerAnalyticsQueryMock.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -89,10 +89,10 @@ describe('AiCrawlerIntelligenceCard', () => {
     renderWithQueryClient(<AiCrawlerIntelligenceCard />);
 
     const skeleton = screen.getByTestId('ai-crawler-card-skeleton');
-    expect(skeleton).toHaveClass('min-h-45');
+    expect(skeleton).toHaveClass('min-h-12');
   });
 
-  it('reserves min-height on error without layout collapse', () => {
+  it('reserves compact row height on error without layout collapse', () => {
     hoisted.useAiCrawlerAnalyticsQueryMock.mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -102,13 +102,13 @@ describe('AiCrawlerIntelligenceCard', () => {
     renderWithQueryClient(<AiCrawlerIntelligenceCard />);
 
     const errorCard = screen.getByTestId('ai-crawler-card-error');
-    expect(errorCard).toHaveClass('min-h-45');
+    expect(errorCard).toHaveClass('min-h-12');
     expect(
       screen.getByText('AI crawler analytics temporarily unavailable.')
     ).toBeInTheDocument();
   });
 
-  it('renders pro analytics without teaser overlay', () => {
+  it('renders pro analytics as a compact clickable row', () => {
     hoisted.useAiCrawlerAnalyticsQueryMock.mockReturnValue({
       data: proAnalytics,
       isLoading: false,
@@ -117,33 +117,63 @@ describe('AiCrawlerIntelligenceCard', () => {
 
     renderWithQueryClient(<AiCrawlerIntelligenceCard />);
 
-    expect(screen.getByTestId('ai-crawler-intelligence-card')).toHaveClass(
-      'min-h-45'
-    );
-    expect(screen.getByTestId('ai-crawler-entity-card')).toBeInTheDocument();
-    expect(screen.getByText('420 reads')).toBeInTheDocument();
+    const row = screen.getByTestId('ai-crawler-intelligence-card');
+    expect(row).toHaveClass('min-h-12');
+    expect(row.tagName).toBe('BUTTON');
+    expect(screen.getByText('AI Visibility')).toBeInTheDocument();
+    expect(
+      screen.getByText('420 reads · 2 services tracked')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
     expect(
       screen.queryByTestId('ai-crawler-card-teaser')
     ).not.toBeInTheDocument();
   });
 
-  it('shows teaser overlay for free users while keeping card footprint', () => {
+  it('opens the detail panel when the row is clicked', async () => {
+    const { track } = await import('@/lib/analytics');
+    hoisted.useAiCrawlerAnalyticsQueryMock.mockReturnValue({
+      data: proAnalytics,
+      isLoading: false,
+      isError: false,
+    });
+    const onOpenDetail = vi.fn();
+
+    renderWithQueryClient(
+      <AiCrawlerIntelligenceCard onOpenDetail={onOpenDetail} />
+    );
+
+    fireEvent.click(screen.getByTestId('ai-crawler-intelligence-card'));
+
+    expect(onOpenDetail).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith('ai_crawler_card_opened', {
+      total_requests: 420,
+      crawler_count: 2,
+    });
+  });
+
+  it('shows upgrade CTA for free users instead of a dead detail row', () => {
     hoisted.useAiCrawlerAnalyticsQueryMock.mockReturnValue({
       data: teaserAnalytics,
       isLoading: false,
       isError: false,
     });
+    const onOpenDetail = vi.fn();
 
-    renderWithQueryClient(<AiCrawlerIntelligenceCard />);
-
-    expect(screen.getByTestId('ai-crawler-intelligence-card')).toHaveClass(
-      'min-h-45'
+    renderWithQueryClient(
+      <AiCrawlerIntelligenceCard onOpenDetail={onOpenDetail} />
     );
+
+    const row = screen.getByTestId('ai-crawler-intelligence-card');
+    expect(row).toHaveClass('min-h-12');
+    expect(row.tagName).not.toBe('BUTTON');
     const teaser = screen.getByTestId('ai-crawler-card-teaser');
-    expect(teaser).toBeInTheDocument();
     expect(
-      within(teaser).getByText('42 AI reads in 30 days')
+      within(teaser).getByText('See which AI services read your pages')
     ).toBeInTheDocument();
-    expect(within(teaser).getByText('Upgrade to Pro')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /upgrade to pro/i })
+    ).toBeInTheDocument();
+    expect(onOpenDetail).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem
The AI-crawler card on Audience rendered as a ~180px detailed card with a music-note glyph and a dead 'View Details' CTA, pushing the fan table below the fold.

Fixes #13489

## What changed
- **`AiCrawlerIntelligenceCard.tsx`** — replaced the `treatment='detailed'` EntityCard with a compact single-row treatment (`min-h-12`, ≤56px): bot icon · 'AI Visibility' · collapsed reads line ('420 reads · 2 services tracked' / '0 reads · Waiting for first AI crawl') · status chip (Active/Collecting, System B badge pattern with `statusDotVar`) · chevron. Entire row is a `<button>` wired to `onOpenDetail` → `openPanel('ai-crawlers')` → existing `AiCrawlerDetailPanel`. `ai_crawler_card_viewed` / `ai_crawler_card_opened` tracking preserved. Skeleton + error states are row-height (no layout shift).
- **`entity-card/types.ts` + `kind-presets.ts`** — added `ai` entity kind preset (lucide `Bot` icon, blue accent). No more music-note fallback.
- **`entity-card/adapters.ts`** — `aiCrawlerAnalyticsToEntityCard` now emits `kind: 'ai'`, collapses the wait state into the meta line, and accepts an `onOpenDetail` option so the CTA has a real `onClick` (was `href: null` with no handler = dead button).
- **`DashboardAudienceTableUnified.tsx`** — header slot padding `py-3` → `py-2`; combined with the ~130px height reduction the fan table is above the fold at 1440×900.
- **Pro teaser** — free users see the same row with a lock icon, teaser copy, and an inline `UpgradeButton` (no blurred dead zone).
- **Tests** — `AiCrawlerIntelligenceCard.test.tsx` updated: row height, row click opens panel + fires `ai_crawler_card_opened`, teaser shows upgrade CTA, loading/error reserve row height.

## Assumptions
- Row is rendered directly in `AiCrawlerIntelligenceCard` from the adapter model rather than adding a horizontal 'row' treatment to the shared `EntityCard` organism (EntityCard is a vertical-card layout; a row treatment there would be scope creep). Adapter + kind preset remain the single source for icon/status/copy.
- Teaser row is intentionally not clickable-to-panel; the only affordance is the upgrade CTA per acceptance criteria.

## Verification
Local `pnpm install` was impossible in this sandbox — registry.npmjs.org egress blocked (403) and network-access request not granted during the run:
```
$ curl -sI https://registry.npmjs.org/pnpm | head -1
HTTP/1.1 403 Forbidden
```
**Verification deferred to CI** (ci-fast typecheck/biome, Unit Tests, build). Dependency-free checks done locally: all class tokens used (`min-h-12`, `text-3xs`, `duration-subtle`, `hover:bg-surface-2`, `font-[590]`) match existing System B usage in `EntityCard`/`CircleIconButton`; no test iterates `KIND_PRESETS` exhaustively; `aiCrawlerAnalyticsToEntityCard` has no other consumers.

## Dispatch
- Dispatch: veronica/ai-visibility-compact-13489 (Zoe → Fable Developer)
- Issue: https://github.com/JovieInc/Jovie/issues/13489

🤖 Generated with [Claude Code](https://claude.com/claude-code)