### PR TITLE
fix(e2e): add CHAT_LLM_FAILURE_INJECTION to CI, add github reporter, quarantine fan-capture flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3007,6 +3007,8 @@ jobs:
           export E2E_CLERK_USER_PASSWORD="${{ secrets.E2E_CLERK_USER_PASSWORD }}"
           export FLAGS_SECRET="${{ secrets.FLAGS_SECRET }}"
           export E2E_SKIP_WARMUP=1
+          # Arms the onboarding LLM-failure fallback spec; matches playwright.config.smoke.ts
+          export CHAT_LLM_FAILURE_INJECTION=1
 
           PORT=3100 node .next/standalone/apps/web/server.js &
           SERVER_PID=$!

--- a/apps/web/playwright.config.smoke.ts
+++ b/apps/web/playwright.config.smoke.ts
@@ -63,6 +63,7 @@ export default defineConfig({
   workers: getWorkers(8),
   reporter: [
     ['line'],
+    ['github'],
     ['html', { open: 'never' }],
     ['json', { outputFile: 'test-results/results.json' }],
   ],

--- a/apps/web/tests/quarantine.json
+++ b/apps/web/tests/quarantine.json
@@ -86,5 +86,17 @@
       "expiresAt": "2026-09-30",
       "consecutiveSuccesses": 0
     }
+,
+    {
+      "id": "e2e-fan-capture-otp-timeout",
+      "kind": "e2e",
+      "path": "apps/web/tests/e2e/profile-fan-capture-golden-path.spec.ts",
+      "owner": "platform",
+      "firstSeenAt": "2026-07-05",
+      "reproductionCommand": "cd apps/web && pnpm playwright test tests/e2e/profile-fan-capture-golden-path.spec.ts --project=chromium",
+      "fixIssueUrl": "https://linear.app/jovie/issue/JOV-13254",
+      "expiresAt": "2026-09-30",
+      "consecutiveSuccesses": 0
+    }
   ]
 }


### PR DESCRIPTION
## Problem
E2E Smoke (PR Fast Feedback) has a ~70% failure rate on main, blocking the merge queue (#13254).

Two root causes identified:

1. **start-onboarding-llm-failure.spec.ts** — The CI standalone server was missing `CHAT_LLM_FAILURE_INJECTION=1`, so the onboarding LLM-failure fallback path returned 503 instead of 200. This is a 100% reproducible CI config bug, not a flake.

2. **profile-fan-capture-golden-path.spec.ts** (mobile email OTP) — Timeout waiting for the OTP dialog on cold Neon ephemeral branches. An infrastructure-level flake.

## Changes
1. **`.github/workflows/ci.yml`** — Add `CHAT_LLM_FAILURE_INJECTION=1` to the ci-e2e-smoke standalone server env vars (matches `playwright.config.smoke.ts`)
2. **`apps/web/playwright.config.smoke.ts`** — Add `['github']` reporter so failing test names appear in PR annotations
3. **`apps/web/tests/quarantine.json`** — Add profile-fan-capture-golden-path.spec.ts to quarantine ledger for tracking and extra retries

## Testing
- CI will verify on push to this branch
- The onboarding LLM-failure test should now pass reliably since the server env matches the playwright config
- The fan-capture test gets quarantine tracking

Closes #13254