### PR TITLE
design-system: motion-craft doctrine (.claude/rules/motion.md) + easing gap tokens

### DIFF
--- a/.claude/rules/motion.md
+++ b/.claude/rules/motion.md
@@ -1,0 +1,152 @@
+# Motion
+
+Animation doctrine for Jovie UI. Sibling of `ui.md` — read that first for the component hierarchy and the No Decorative Hover Motion rule. Always reference `design-system.css` tokens; never hardcode durations, easings, or scale values (enforced by `@jovie/no-raw-motion-values`).
+
+> **Attribution:** Adapted from Emil Kowalski's `emil-design-eng` skill
+> (https://github.com/emilkowalski/skills), MIT License — copyright notice per
+> the repository LICENSE file. Reconciled to Jovie System B tokens; where the
+> source and Jovie doctrine disagree (e.g. press scale), Jovie wins.
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files, to deal in the Software
+> without restriction, subject to inclusion of the above copyright notice.
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+
+## 1. Should this animate at all?
+
+Ask how often the user sees it:
+
+| Frequency | Decision |
+| --- | --- |
+| 100+ times/day (keyboard shortcuts, command palette toggle) | No animation. Ever. |
+| Tens of times/day (hover, list navigation) | Remove or drastically reduce |
+| Occasional (modals, drawers, toasts) | Standard animation |
+| Rare/first-time (onboarding, celebrations) | Can add delight |
+
+**Never animate keyboard-initiated actions.** Animation makes repeated actions feel slow and disconnected.
+
+Every animation needs a purpose: spatial consistency, state indication, feedback, explanation, or preventing a jarring change. "It looks cool" is not a purpose for anything seen often. This composes with ui.md's **No Decorative Hover Motion** rule — no lift-on-hover polish moves.
+
+## 2. Duration — System B token map
+
+UI animations stay under 300ms. The two-tier intent vocabulary (`DESIGN.md → Motion`) is the default: SUBTLE for micro-interactions, CINEMATIC for high-impact reveals. The full ladder:
+
+| Element | Token | Value |
+| --- | --- | --- |
+| Opacity flick, skeleton swap | `--duration-instant` | 50ms |
+| Button press feedback | `--duration-fast` … `--duration-normal` | 100–160ms |
+| Tooltips, small popovers | `--duration-fast` … `--duration-subtle` | 100–150ms |
+| Hover, focus, color, icon swap, toast | `--duration-subtle` | 150ms |
+| Dropdowns, selects | `--duration-subtle` … `--duration-slow` | 150–250ms |
+| List/height collapse | `--duration-slow` | 250ms |
+| Modals, drawers, surface morphs | `--duration-cinematic` | 420ms |
+| Marketing/explanatory | may exceed the ladder — still token-based | — |
+
+All duration tokens zero out under `prefers-reduced-motion: reduce` (handled centrally in `design-system.css`) — using tokens is what makes your animation accessible for free. Do not add per-component reduced-motion overrides for duration; do remove transform-based *movement* (translate) under reduced motion while keeping opacity/color transitions that aid comprehension.
+
+Perceived performance: a 150ms dropdown feels more responsive than a 400ms one; `ease-out` at the same duration feels faster than `ease-in` because the user sees immediate movement.
+
+## 3. Easing decision tree — System B token map
+
+```
+Entering or exiting the screen?
+  → var(--ease-out)                  /* starts fast; feels responsive */
+Moving/morphing while on screen?
+  → var(--ease-in-out)               /* natural accel/decel */
+Drawer / sheet open-close?
+  → var(--ease-drawer)               /* iOS-like settle */
+Hover / color / focus micro-change?
+  → var(--ease-subtle)               /* System B subtle easing */
+High-impact reveal (modal, composer morph)?
+  → var(--ease-cinematic)
+Constant motion (marquee, progress, spinner)?
+  → linear                           /* the CSS keyword */
+Playful overshoot (rare, opt-in)?
+  → var(--ease-spring)
+Default when unsure → var(--ease-out)
+```
+
+Rules:
+
+- **Never use `ease-in` for UI.** It delays the initial movement — the exact moment the user is watching. It has no token on purpose.
+- **Never use raw `cubic-bezier(...)` in component code.** System B curves are already the "strong custom curves" the craft calls for; the built-in CSS keywords (`ease`, `ease-out`) are too weak.
+- **Trap:** `--ease-linear` is a legacy alias of `--ease-interactive` and is *not* linear. For constant motion use the CSS keyword `linear`; never reach for `--ease-linear`.
+- Prefer the pre-composed patterns (`--transition-colors`, `--transition-transform`, `--transition-collapse`, …) before composing your own.
+
+## 4. Component rules
+
+### Press feedback
+
+Every pressable element scales down on `:active`. Jovie's canonical press scale is **`var(--scale-press)` (0.96)** — per ui.md, not the source's 0.97.
+
+```css
+.button {
+  transition: transform var(--duration-normal) var(--ease-out);
+}
+.button:active {
+  transform: scale(var(--scale-press));
+}
+```
+
+Press feedback must be tactile and interruptible; provide a static opt-out when motion would distract (ui.md).
+
+### Never animate from `scale(0)`
+
+Nothing real appears from nothing. Enter from `scale(0.95)` or higher, combined with `opacity: 0`.
+
+### Origin-aware popovers
+
+Popovers scale from their trigger, not center: `transform-origin: var(--radix-popover-content-transform-origin)` (Radix) or `var(--transform-origin)` (Base UI). **Exception: modals stay centered** — they are not anchored to a trigger.
+
+### Tooltips
+
+Delay the first tooltip; once one is open, adjacent tooltips open instantly (skip delay + skip animation). Animate at `--duration-fast` with `--ease-out`.
+
+### Transitions over keyframes for dynamic UI
+
+CSS transitions can be interrupted and retargeted mid-animation; keyframes restart from zero. Anything rapidly triggered (toasts, toggles) uses transitions. Use `@starting-style` for enter animations where support allows; fall back to the `data-mounted` attribute pattern.
+
+### Asymmetric timing
+
+Slow where the user is deciding, fast where the system is responding. Hold-to-confirm presses can be long and `linear`; release/response snaps back at `--duration-subtle` with `--ease-out`. Exits are generally faster than enters.
+
+### Stagger
+
+When a list enters together, stagger 30–80ms per item, `--ease-out`, translateY ≤ 8px. Stagger is decorative — never block interaction while it plays.
+
+### Blur to mask imperfect crossfades
+
+If a two-state crossfade shows both states overlapping, a transient `filter: blur(2px)` bridges them. Keep blur small — heavy blur is expensive, especially in Safari.
+
+## 5. Performance
+
+- **Only animate `transform` and `opacity`.** Animating `width`/`height`/`padding`/`margin` triggers layout + paint. (`--transition-collapse` is the sanctioned exception for expand/collapse.)
+- Prefer `translateY(100%)` percentages over pixel values — they adapt to content size.
+- Don't animate CSS variables on a parent during drag — it recalculates all children. Set `transform` directly on the element.
+- Motion (Framer Motion) shorthand props (`x`, `y`, `scale`) run on the main thread. Under load, use the full `transform` string, plain CSS, or WAAPI (`element.animate`) — those stay off the main thread.
+- Springs (Motion) are for drag/gesture interactions that can be interrupted mid-motion; they keep velocity where CSS restarts. Keep bounce subtle (0.1–0.3) and out of most UI.
+
+## 6. Accessibility
+
+- Reduced motion means *fewer and gentler*, not zero: keep opacity/color, remove movement. Duration tokens already zero out globally — see §2.
+- Gate hover animations behind `@media (hover: hover) and (pointer: fine)` — touch devices fire hover on tap.
+
+## 7. Review checklist
+
+When reviewing animation code, output a single markdown table with `| Before | After | Why |` columns, one row per issue. Check for:
+
+| Issue | Fix |
+| --- | --- |
+| `transition: all` | Name exact properties, or use a `--transition-*` pattern |
+| Raw `cubic-bezier(...)` / raw `ms` values | System B tokens (`--ease-*`, `--duration-*`) |
+| `scale(0)` entry | `scale(0.95)` + `opacity: 0` |
+| `ease-in` anywhere | `var(--ease-out)` or per the tree in §3 |
+| `--ease-linear` on constant motion | CSS keyword `linear` |
+| `transform-origin: center` on popover | Trigger-anchored origin var (modals exempt) |
+| Animation on keyboard action | Remove it |
+| UI duration > 300ms outside CINEMATIC intent | `--duration-subtle`/`--duration-slow` |
+| Hover animation without media query | `@media (hover: hover) and (pointer: fine)` |
+| Keyframes on rapidly-triggered element | CSS transitions |
+| No `:active` press feedback on pressable | `scale(var(--scale-press))` |
+| Same enter/exit speed on hold patterns | Exit faster than enter |
+| List items all appear at once | 30–80ms stagger |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] **Motion doctrine + easing gap tokens (GH-13636)**: `.claude/rules/motion.md` adapts Emil Kowalski's motion-craft rules (MIT, attribution in-file) onto System B tokens — duration table, easing decision tree, press/enter/popover/perf/a11y rules, review checklist. `design-system.css` gains `--ease-drawer` (iOS-like drawer settle curve) and `--scale-press` (0.96 canonical press feedback). Doctrine + additive tokens only; no component changes.
+
 - **Plan-locked chat tools now explain and offer an upgrade instead of erroring (GH-13304)**: Asking Jovie for album art, photo retouching, or merch on the Free plan no longer dead-ends the conversation. Jovie describes what it would create, and a single upgrade prompt appears inline — with copy sourced from the plan registry so it always names the right plan.
 
 - [internal] **AEO citation monitoring + brand integrity (GH-11037)**: Pure-function modules `lib/aeo/citation-monitor.ts` and `lib/aeo/brand-integrity.ts` implement share-of-citation measurement (tracks whether Jovie profile URLs are cited by answer engines for canonical artist queries) and same-name entity disambiguation (scores KB-anchor coverage, flags missing MusicBrainz/Wikidata/ISNI identifiers, and produces a disambiguating checklist mapping to schema.org fields). 47 unit tests. No migrations.

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1436,6 +1436,13 @@ html[data-profile-initial-mode]
   /* Legacy alias */
   --ease-subtle: var(--ds-motion-subtle-easing);
   --ease-cinematic: var(--ds-motion-cinematic-easing);
+  /* Drawer/sheet settle curve (iOS-like; adapted from emil-design-eng, MIT —
+     see .claude/rules/motion.md for the easing decision tree) */
+  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+
+  /* Canonical press-feedback scale for pressable elements
+     (.claude/rules/ui.md + .claude/rules/motion.md — tactile, interruptible) */
+  --scale-press: 0.96;
 
   /* Pre-composed transition patterns (extracted from Linear)
      Use duration custom properties so prefers-reduced-motion overrides work */


### PR DESCRIPTION
## Problem
Agents writing animation code had no repo doctrine for motion — easing/duration/press-feedback decisions were re-derived per PR, drifting off System B tokens.

## What changed
- **`.claude/rules/motion.md`** (new, sibling of ui.md) — Emil Kowalski's motion-craft rules adapted onto System B tokens: should-it-animate frequency table, duration ladder mapped to `--duration-*` tokens, easing decision tree mapped to `--ease-*` tokens, press/enter/popover/tooltip/stagger rules, transform+opacity perf canon, reduced-motion + hover-media-query a11y, and a `| Before | After | Why |` review checklist. Self-promo stripped (animations.dev plugs, "Initial Response" ad block, Sonner marketing). MIT attribution + license notice kept in-file.
- **`apps/web/styles/design-system.css`** — two additive tokens where System B had gaps: `--ease-drawer: cubic-bezier(0.32, 0.72, 0, 1)` (iOS-like drawer settle) and `--scale-press: 0.96` (canonical press feedback). System B's existing `--ease-out`/`--ease-in-out` already are strong custom curves — NOT overridden.
- **CHANGELOG.md** — `[Unreleased]` `[internal]` entry.

## Assumptions
- Spec file (`workspace-veronica/tasks/motion-craft-doctrine-13636.md`) lives on the dispatching machine, not this sandbox — worked from the issue body's scope, which is complete.
- **Press scale reconciled to 0.96** (ui.md's existing canon), not the source's 0.97 — Jovie doctrine wins on conflict; noted in motion.md.
- LICENSE file read directly per repo rule: MIT confirmed, but the copyright line reads "Copyright (c) 2026 Matt Pocock" (repo appears scaffolded from Pocock's skills template). Attribution in motion.md cites the repo + MIT and defers to the LICENSE file rather than asserting an author name on the copyright line.
- `--ease-linear` legacy-alias trap (it aliases `--ease-interactive`, which is not linear) documented in the doctrine rather than changed — off-scope.
- Doctrine cross-references only; no ui.md edits (minimal diff). If #13219 (tokens.json pipeline) lands first, the two new tokens should be added to its `tokens.json` seed in a follow-up sync — flagged in that PR's wave model as additive.

## Verification
Sandbox registry egress denied (`registry.npmjs.org` → 403; network-access request filed, unanswered — same constraint as #13403/#13404/#13621), so the pnpm gate could not run locally. **Verification deferred to CI** (`ci-fast`, Unit Tests, Structural Contract, Build). Static checks run locally:

```
$ curl -s -o /dev/null -w "%{http_code}" https://registry.npmjs.org/
403
$ python3 token-audit
braces balanced: True
tokens referenced in motion.md missing from css: NONE
$ grep -rn "ease-drawer|scale-press" (excl. design-system.css)
(no clashes)
```

Base-clobber check: blob SHAs of both edited files at branch head matched the tarball base before push (css `0756b8a6`, changelog `aa687b83`).

## Cost Impact
None — docs + two CSS custom properties.

Dispatch ID: not provided (issue-driven dispatch for GH-13636, JOV-4130)
Fixes #13636

🤖 Generated with [Claude Code](https://claude.com/claude-code)