### PR TITLE
chat: welcome state — circle logo, greeting, pill composer, staggered enter

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -603,7 +603,9 @@ export function JovieChat({
                 className='flex flex-1 flex-col items-center justify-center'
                 data-testid='chat-empty-state-viewport'
               >
-                <ChatEmptyStateComposerRegion>
+                <ChatEmptyStateComposerRegion
+                  greetingName={displayName ?? username ?? null}
+                >
                   {composerSurface}
                   {inlineChatError ? (
                     <div className='mt-3 w-full'>{inlineChatError}</div>

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { ChatEmptyStateComposerRegion } from './ChatEmptyStateComposerRegion';
 
 describe('ChatEmptyStateComposerRegion', () => {
-  it('softens the background logo with a radial edge fade', () => {
+  it('renders the circle brand logo as ambient texture', () => {
     render(
       <ChatEmptyStateComposerRegion>
         <div data-testid='composer-child' />
@@ -12,10 +12,54 @@ describe('ChatEmptyStateComposerRegion', () => {
     );
 
     const logo = screen.getByTestId('chat-empty-state-logo');
-    const mask = logo.style.maskImage;
+    expect(logo.style.opacity).toBe('0.18');
+    expect(logo.getAttribute('aria-hidden')).toBe('true');
+  });
 
-    expect(mask).toContain('radial-gradient');
-    expect(mask).toContain('transparent 86%');
-    expect(logo.className).toContain('opacity-70');
+  it('greets by display name when provided', () => {
+    render(
+      <ChatEmptyStateComposerRegion greetingName='Tim'>
+        <div data-testid='composer-child' />
+      </ChatEmptyStateComposerRegion>
+    );
+
+    expect(screen.getByTestId('chat-empty-state-greeting').textContent).toBe(
+      'Hi, Tim'
+    );
+  });
+
+  it('falls back to a generic greeting without a display name', () => {
+    render(
+      <ChatEmptyStateComposerRegion greetingName='  '>
+        <div data-testid='composer-child' />
+      </ChatEmptyStateComposerRegion>
+    );
+
+    expect(screen.getByTestId('chat-empty-state-greeting').textContent).toBe(
+      'Hi there'
+    );
+  });
+
+  it('staggers the enter animation across logo, greeting, and composer', () => {
+    render(
+      <ChatEmptyStateComposerRegion>
+        <div data-testid='composer-child' />
+      </ChatEmptyStateComposerRegion>
+    );
+
+    const region = screen.getByTestId('chat-empty-state-composer-region');
+    expect(region.className).toContain('chat-stagger');
+  });
+
+  it('hides the welcome header when an above slot is provided', () => {
+    render(
+      <ChatEmptyStateComposerRegion above={<div data-testid='above-slot' />}>
+        <div data-testid='composer-child' />
+      </ChatEmptyStateComposerRegion>
+    );
+
+    expect(screen.getByTestId('above-slot')).toBeTruthy();
+    expect(screen.queryByTestId('chat-empty-state-logo')).toBeNull();
+    expect(screen.queryByTestId('chat-empty-state-greeting')).toBeNull();
   });
 });

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
@@ -1,41 +1,56 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
+import { BrandLogo } from '@/components/atoms/BrandLogo';
 
 import { CHAT_CONTENT_SHELL_CLASSNAME } from '../chat-layout';
+
+const AMBIENT_LOGO_OPACITY = 0.18;
 
 export function ChatEmptyStateComposerRegion({
   above,
   children,
+  greetingName,
 }: {
   readonly above?: ReactNode;
   readonly children: ReactNode;
+  readonly greetingName?: string | null;
 }) {
+  const trimmedName = greetingName?.trim();
+  const greeting = trimmedName ? `Hi, ${trimmedName}` : 'Hi there';
+  const showWelcomeHeader = !above;
+
   return (
     <div
-      className={`${CHAT_CONTENT_SHELL_CLASSNAME} relative flex min-h-full flex-col items-center justify-center px-1 py-8`}
+      className={`${CHAT_CONTENT_SHELL_CLASSNAME} chat-stagger relative flex min-h-full flex-col items-center justify-center px-1 py-8`}
       data-testid='chat-empty-state-composer-region'
     >
-      <div
-        className='pointer-events-none absolute left-1/2 top-1/2 h-[min(46vw,28rem)] w-[min(46vw,28rem)] -translate-x-1/2 -translate-y-[60%] opacity-70 drop-shadow-[0_0_34px_rgba(68,188,255,0.14)] max-sm:h-[min(72vw,18rem)] max-sm:w-[min(72vw,18rem)]'
-        style={{
-          maskImage:
-            'radial-gradient(ellipse at center, black 38%, rgba(0,0,0,0.55) 56%, rgba(0,0,0,0.2) 72%, transparent 86%)',
-          WebkitMaskImage:
-            'radial-gradient(ellipse at center, black 38%, rgba(0,0,0,0.55) 56%, rgba(0,0,0,0.2) 72%, transparent 86%)',
-        }}
-        data-testid='chat-empty-state-logo'
-      >
-        <JovieMarkElectric
-          className='h-full w-full'
-          idSeed='chat-empty-state-logo'
-        />
-      </div>
       {above ? (
         <div className='absolute inset-x-0 bottom-1/2 z-10 mb-12 max-h-[min(46vh,24rem)] overflow-y-auto overscroll-contain px-1 pb-1'>
           {above}
         </div>
+      ) : null}
+      {showWelcomeHeader ? (
+        <div
+          aria-hidden='true'
+          className='relative z-10 mb-4'
+          style={{ opacity: AMBIENT_LOGO_OPACITY }}
+          data-testid='chat-empty-state-logo'
+        >
+          <BrandLogo
+            size={56}
+            className='text-primary-token'
+            aria-hidden={true}
+          />
+        </div>
+      ) : null}
+      {showWelcomeHeader ? (
+        <h2
+          className='relative z-10 mb-6 text-2xl font-semibold text-primary-token'
+          data-testid='chat-empty-state-greeting'
+        >
+          {greeting}
+        </h2>
       ) : null}
       <div
         className='relative z-10 w-full'

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -112,7 +112,7 @@ function geometryFor(
   if (stacked) return { width, maxWidth, borderRadius: 28 };
   if (mode === 'entity') return { width, maxWidth, borderRadius: 24 };
   if (variant === 'hero' && usePillLayout) {
-    return { width, maxWidth, borderRadius: 999 };
+    return { width, maxWidth, borderRadius: 9999 };
   }
   if (variant === 'hero') return { width, maxWidth, borderRadius: 24 };
   return { width, maxWidth, borderRadius: 28 };

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -354,7 +354,7 @@ describe('ChatInput', () => {
     const surface = screen.getByTestId('chat-composer-surface');
     expect(surface.getAttribute('data-variant')).toBe('hero');
     expect(surface.style.maxWidth).toBe('min(calc(100vw - 32px), 45rem)');
-    expect(surface.style.borderRadius).toBe('999px');
+    expect(surface.style.borderRadius).toBe('9999px');
 
     expect(screen.getByTestId('chat-composer-input-row').className).toContain(
       'min-h-13'
@@ -419,7 +419,7 @@ describe('ChatInput', () => {
     );
 
     const surface = screen.getByTestId('chat-composer-surface');
-    expect(surface.style.borderRadius).toBe('999px');
+    expect(surface.style.borderRadius).toBe('9999px');
     expect(surface).not.toHaveAttribute('data-expanded');
 
     const inputRow = screen.getByTestId('chat-composer-input-row');


### PR DESCRIPTION
## Problem
Chat empty state renders a giant ambient mark with no greeting; welcome-state spec (#13166) approved a circle logo + greeting + pill composer with staggered enter.

## What changed
- `ChatEmptyStateComposerRegion`: replaced the oversized masked `JovieMarkElectric` background with the approved welcome stack — circle `BrandLogo` at 0.18 opacity (ambient texture), `Hi, {displayName}` greeting with `Hi there` fallback, then the composer. Adopted the existing (previously unused) `.chat-stagger` utility from globals.css for the staggered logo → greeting → composer enter animation (has reduced-motion handling built in; opacity/transform only, no layout shift).
- `ChatInput`: hero pill radius 999 → 9999 per spec acceptance (`border-radius: 9999px`).
- `JovieChat`: passes `greetingName={displayName ?? username ?? null}` into the region.
- Tests: rewrote `ChatEmptyStateComposerRegion.test.tsx` (ambient opacity, greeting, fallback, stagger, above-slot behavior); updated `ChatInput.test.tsx` radius assertions 999px → 9999px.

## Assumptions
- **Did NOT touch `BrandLogo.tsx`** — open PR #13621 modifies it; circle treatment is done via the default `rounded` prop + wrapper opacity, avoiding a conflict. BrandLogo already renders `rounded-full` by default.
- When the `above` slot is provided (onboarding intro suggestions), the logo/greeting header is suppressed — the absolutely-positioned intro would overlap it. Onboarding empty state without the intro shows the `Hi there` fallback.
- Greeting falls back `displayName → username → "Hi there"`.
- The dispatch referenced a spec file on a local machine path not available in this environment; implemented from the issue body spec + acceptance criteria, which carry the same 4 components.
- Kept greeting typography quiet (text-2xl, semibold, primary token) per no-AI-slop rules; dark-first token colors via `text-primary-token` / currentColor on the logo.

## Verification
**Local verification blocked** — sandbox denied registry.npmjs.org access (requested, not granted within run), so `pnpm install && turbo lint typecheck test:fast --affected && build:web` could not run locally. Verification deferred to CI (`ci-fast`, Unit Tests). PR stays **draft** until CI is green.

Commands attempted:
\`\`\`
corepack prepare pnpm@9.15.4 --activate
→ Error: Server answered with HTTP 403 ... registry.npmjs.org/pnpm/-/pnpm-9.15.4.tgz
\`\`\`

Dispatch ID: chat-welcome-13166
Fixes #13166

🤖 Generated with [Claude Code](https://claude.com/claude-code)