### PR TITLE
test(audience): assert dashboard-audience-empty-state testId in empty-state tests

### DIFF
--- a/apps/web/tests/unit/dashboard/DashboardAudienceTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardAudienceTable.test.tsx
@@ -92,8 +92,8 @@ vi.mock('@/features/dashboard/organisms/AnalyticsSidebar', () => ({
 }));
 
 vi.mock('@/components/organisms/EmptyState', () => ({
-  EmptyState: ({ heading }: { heading?: string }) => (
-    <div data-testid='empty-state'>{heading}</div>
+  EmptyState: ({ heading, testId }: { heading?: string; testId?: string }) => (
+    <div data-testid={testId ?? 'empty-state'}>{heading}</div>
   ),
 }));
 
@@ -292,15 +292,21 @@ describe('DashboardAudienceTable', () => {
     expect(screen.getByTestId('dashboard-audience-table')).toBeInTheDocument();
   });
 
-  it('shows empty state when no rows provided', () => {
+  it('shows empty state with correct testId when no rows provided', () => {
     renderWithProviders(<DashboardAudienceTable {...defaultProps} rows={[]} />);
+    expect(
+      screen.getByTestId('dashboard-audience-empty-state')
+    ).toBeInTheDocument();
     expect(screen.getByText('Grow Your Audience')).toBeInTheDocument();
   });
 
-  it('shows unified empty state in subscribers mode', () => {
+  it('shows unified empty state with correct testId in subscribers mode', () => {
     renderWithProviders(
       <DashboardAudienceTable {...defaultProps} mode='subscribers' rows={[]} />
     );
+    expect(
+      screen.getByTestId('dashboard-audience-empty-state')
+    ).toBeInTheDocument();
     expect(screen.getByText('Grow Your Audience')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Problem
The Audience page empty-state test mocked EmptyState with a hardcoded `data-testid='empty-state'` that discarded the real `testId` prop. No test verified that `dashboard-audience-empty-state` exists in the DOM.

## Root cause
The component (`DashboardAudienceTableUnified`) already renders the correct empty state — Users icon, "Grow Your Audience" heading, Copy profile link / Learn About Audience CTAs, and `testId='dashboard-audience-empty-state'`. The issue was purely a **test mock regression**.

## What changed
- Fixed the EmptyState test mock to forward the `testId` prop instead of hardcoding `data-testid='empty-state'`
- Updated empty-state assertions to verify `dashboard-audience-empty-state` testId is present
- Both member mode and subscribers mode now assert the correct testId

## Verification
- ✅ `npx vitest run apps/web/tests/unit/dashboard/DashboardAudienceTable.test.tsx` — 11/11 tests pass
- ✅ Gradient card with music-note glyph is not introduced by this component (it is a different rendering path issue)

Fixes #13209