### PR TITLE
fix(profile-rail): composer hardening vs stacked Radix modal teardown + e2e interaction matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- **Chat stays responsive with the Live Profile rail open (GH-13220)**: Opening your profile rail — or its actions menu and UTM Builder — no longer leaves the chat box unable to accept clicks or typing.
+- [internal] **Profile rail composer hardening (GH-13221/GH-13225)**: Profile-actions kebab is now a non-modal `CommonDropdown` (new `modal` prop passed through to Radix), the UTM Builder dialog open is deferred past the menu teardown, and a defensive guard clears any stuck `body[style*="pointer-events: none"]` after dialog close. New Playwright matrix `chat-composer-right-rail.spec.ts` asserts composer focus/typing, body pointer-events, and elementFromPoint invariants across rail/menu/dialog/edit-mode open-close cycles.
+
 - **Plan-locked chat tools now explain and offer an upgrade instead of erroring (GH-13304)**: Asking Jovie for album art, photo retouching, or merch on the Free plan no longer dead-ends the conversation. Jovie describes what it would create, and a single upgrade prompt appears inline — with copy sourced from the plan registry so it always names the right plan.
 
 - [internal] **AEO citation monitoring + brand integrity (GH-11037)**: Pure-function modules `lib/aeo/citation-monitor.ts` and `lib/aeo/brand-integrity.ts` implement share-of-citation measurement (tracks whether Jovie profile URLs are cited by answer engines for canonical artist queries) and same-name entity disambiguation (scores KB-anchor coverage, flags missing MusicBrainz/Wikidata/ISNI identifiers, and produces a disambiguating checklist mapping to schema.org fields). 47 unit tests. No migrations.

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
@@ -191,6 +191,28 @@ function ProfileBentoView({
 }>) {
   const [utmOpen, setUtmOpen] = useState(false);
 
+  // Open the UTM dialog only after the profile-actions menu has fully torn
+  // down. Mounting a modal Dialog synchronously from a DropdownMenu item's
+  // onSelect stacks two Radix modal layers whose unmount/restore can race and
+  // leave `pointer-events: none` stuck on <body>, deadening the chat composer
+  // (gh-13221).
+  const openUtmDialog = useCallback(() => {
+    globalThis.setTimeout(() => setUtmOpen(true), 0);
+  }, []);
+
+  // Defensive guard (gh-13221): after the dialog (or menu) teardown settles,
+  // clear any body pointer-events lock a stacked-layer race left behind so
+  // the rest of the app — the chat composer in particular — stays clickable.
+  useEffect(() => {
+    if (utmOpen) return;
+    const frame = globalThis.requestAnimationFrame(() => {
+      if (document.body.style.pointerEvents === 'none') {
+        document.body.style.pointerEvents = '';
+      }
+    });
+    return () => globalThis.cancelAnimationFrame(frame);
+  }, [utmOpen]);
+
   const artist = buildPreviewArtistFromProfile({
     username: previewData.username,
     displayName: previewData.displayName,
@@ -229,7 +251,7 @@ function ProfileBentoView({
       id: 'utm-builder',
       label: 'UTM Builder',
       icon: <SlidersHorizontal className='h-3.5 w-3.5' />,
-      onClick: () => setUtmOpen(true),
+      onClick: openUtmDialog,
     },
     { type: 'separator', id: 'profile-actions-separator' },
     {
@@ -259,6 +281,10 @@ function ProfileBentoView({
           <CommonDropdown
             items={menuItems}
             align='end'
+            // Non-modal: this menu launches the UTM Builder dialog, and a
+            // modal menu + modal dialog stack can leave the body
+            // pointer-events lock behind on teardown (gh-13221).
+            modal={false}
             aria-label='Profile Actions'
             trigger={
               <Button

--- a/apps/web/tests/e2e/chat-composer-right-rail.spec.ts
+++ b/apps/web/tests/e2e/chat-composer-right-rail.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * E2E: Chat composer × Live Profile right rail interaction matrix (gh-13225).
+ *
+ * The composer-blocked regression (gh-13221) shipped invisibly because nothing
+ * in CI exercised the composer while the profile rail / its kebab menu / the
+ * UTM Builder dialog were open. Stacked Radix modal layers (DropdownMenu →
+ * Dialog) can race on teardown and leave `pointer-events: none` stuck on
+ * <body>, deadening the composer.
+ *
+ * After every rail/menu/dialog open-close cycle we assert three invariants:
+ *   (a) the composer is focusable and accepts typed text,
+ *   (b) `getComputedStyle(document.body).pointerEvents !== 'none'`,
+ *   (c) `document.elementFromPoint()` at the composer center resolves inside
+ *       the composer surface (no invisible interceptor).
+ *
+ * Run:
+ *   doppler run -- pnpm --filter web exec playwright test chat-composer-right-rail --project=chromium
+ *
+ * @see apps/web/components/molecules/drawer/RightDrawer.tsx (desktop inline vs mobile overlay)
+ * @see apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
+ * @see apps/web/components/features/profile/UtmBuilderDialog.tsx
+ */
+
+import { expect, type Page, test } from '@playwright/test';
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  ensureSignedInUser,
+  hasClerkCredentials,
+} from '../helpers/clerk-auth';
+import {
+  smokeNavigateWithRetry,
+  waitForHydration,
+} from './utils/smoke-test-utils';
+
+// Case-insensitive accessible-name match — the source label is
+// 'Chat Message Input' (ChatInput.tsx); getByLabel keeps this resilient to
+// casing churn that has already gone stale in older specs.
+const COMPOSER_LABEL = /chat message input/i;
+const RAIL_TOGGLE = '[data-testid="artist-profile-rail-toggle"]';
+const KEBAB_TRIGGER = 'button[aria-label="Profile Actions"]';
+const EDIT_PROFILE_BUTTON = 'button:has-text("Edit Profile")';
+const DONE_BUTTON = 'button[aria-label="Done"]';
+const UTM_MENU_ITEM = '[role="menuitem"]:has-text("UTM Builder")';
+const MENU_CONTENT = '[data-menu-surface="toolbar"]';
+
+function composer(page: Page) {
+  return page.getByLabel(COMPOSER_LABEL).last();
+}
+
+/** Invariant (b): the stacked-layer teardown never leaves body inert. */
+async function expectBodyInteractive(page: Page) {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () => globalThis.getComputedStyle(document.body).pointerEvents
+        ),
+      { timeout: 5_000 }
+    )
+    .not.toBe('none');
+}
+
+/** Invariants (a) + (c): composer focusable, typeable, and hit-testable. */
+async function expectComposerUsable(page: Page, marker: string) {
+  const input = composer(page);
+  await expect(input).toBeVisible({ timeout: 10_000 });
+
+  // (c) elementFromPoint at composer center resolves to (or inside) the input.
+  const hit = await input.evaluate(element => {
+    const rect = element.getBoundingClientRect();
+    const target = document.elementFromPoint(
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2
+    );
+    return target ? element === target || element.contains(target) : false;
+  });
+  expect(hit, 'elementFromPoint at composer center must hit the input').toBe(
+    true
+  );
+
+  // (a) focus + type real text.
+  await input.click();
+  await expect(input).toBeFocused();
+  await input.fill('');
+  await input.pressSequentially(marker, { delay: 10 });
+  await expect(input).toHaveValue(new RegExp(marker));
+  await input.fill('');
+}
+
+async function expectInvariants(page: Page, marker: string) {
+  await expectBodyInteractive(page);
+  await expectComposerUsable(page, marker);
+}
+
+async function openChatWithComposer(page: Page) {
+  await ensureSignedInUser(page);
+  await smokeNavigateWithRetry(page, APP_ROUTES.CHAT, { timeout: 60_000 });
+  await waitForHydration(page);
+  await expect(composer(page)).toBeVisible({ timeout: 30_000 });
+}
+
+async function openRail(page: Page) {
+  const toggle = page.locator(RAIL_TOGGLE);
+  await expect(toggle).toBeVisible({ timeout: 15_000 });
+  const pressed = await toggle.getAttribute('aria-pressed');
+  if (pressed !== 'true') {
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  }
+  // The bento view renders the kebab once preview data hydrates.
+  await expect(page.locator(KEBAB_TRIGGER)).toBeVisible({ timeout: 20_000 });
+}
+
+async function closeRail(page: Page) {
+  const toggle = page.locator(RAIL_TOGGLE);
+  const pressed = await toggle.getAttribute('aria-pressed');
+  if (pressed === 'true') {
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+  }
+}
+
+async function openKebabMenu(page: Page) {
+  await page.locator(KEBAB_TRIGGER).click();
+  await expect(page.locator(MENU_CONTENT).last()).toBeVisible({
+    timeout: 5_000,
+  });
+}
+
+test.describe('Chat composer × profile rail interaction matrix', () => {
+  test.beforeEach(() => {
+    if (!hasClerkCredentials()) {
+      test.skip(true, 'Clerk credentials not configured');
+    }
+  });
+
+  test('rail open → composer stays usable', async ({ page }) => {
+    await openChatWithComposer(page);
+    await openRail(page);
+    await expectInvariants(page, 'rail-open');
+  });
+
+  test('kebab menu open/close cycles keep composer usable', async ({
+    page,
+  }) => {
+    await openChatWithComposer(page);
+    await openRail(page);
+
+    // Close via outside-click.
+    await openKebabMenu(page);
+    await page.mouse.click(20, 200);
+    await expect(page.locator(MENU_CONTENT)).toHaveCount(0);
+    await expectInvariants(page, 'menu-outside-click');
+
+    // Close via ESC.
+    await openKebabMenu(page);
+    await page.keyboard.press('Escape');
+    await expect(page.locator(MENU_CONTENT)).toHaveCount(0);
+    await expectInvariants(page, 'menu-escape');
+  });
+
+  test('UTM Builder dialog open/close never deadens the composer', async ({
+    page,
+  }) => {
+    await openChatWithComposer(page);
+    await openRail(page);
+
+    // Open the dialog from the kebab menu (the stacked-layer path, gh-13221).
+    await openKebabMenu(page);
+    await page.locator(UTM_MENU_ITEM).click();
+    const dialog = page.getByRole('dialog').filter({ hasText: 'UTM Builder' });
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Dialog traps focus while open; ESC closes the dialog only — the rail
+    // (and its kebab) must survive because RightDrawer's Escape handler
+    // defers to open modal dialogs.
+    await page.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+    await expect(page.locator(KEBAB_TRIGGER)).toBeVisible();
+    await expectInvariants(page, 'dialog-escape');
+
+    // Re-open and close via the Copy link path.
+    await openKebabMenu(page);
+    await page.locator(UTM_MENU_ITEM).click();
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.getByRole('textbox').first().fill('instagram');
+    await dialog.getByRole('button', { name: /copy/i }).click();
+    await page.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+    await expectInvariants(page, 'dialog-copy-close');
+  });
+
+  test('edit mode round-trip and rail close keep composer usable end-to-end', async ({
+    page,
+  }) => {
+    await openChatWithComposer(page);
+    await openRail(page);
+
+    // Flip to edit mode and back.
+    await page.locator(EDIT_PROFILE_BUTTON).click();
+    await expect(page.locator(DONE_BUTTON)).toBeVisible({ timeout: 10_000 });
+    await expectInvariants(page, 'edit-mode');
+    await page.locator(DONE_BUTTON).click();
+    await expect(page.locator(EDIT_PROFILE_BUTTON)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expectInvariants(page, 'view-mode-return');
+
+    // Close the rail — composer regains full usability.
+    await closeRail(page);
+    await expectInvariants(page, 'rail-closed');
+  });
+
+  test('sub-lg overlay branch recovers the composer on rail close', async ({
+    page,
+  }) => {
+    // Just below the lg breakpoint the RightDrawer renders as a full-screen
+    // overlay (`fixed inset-0 z-50`) that legitimately covers the composer —
+    // assert it fully recovers once closed.
+    await page.setViewportSize({ width: 1023, height: 800 });
+    await openChatWithComposer(page);
+
+    const toggle = page.locator(RAIL_TOGGLE);
+    test.skip(
+      !(await toggle.isVisible().catch(() => false)),
+      'Rail toggle not rendered at this viewport'
+    );
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    await expectInvariants(page, 'mobile-overlay-recovered');
+  });
+});

--- a/packages/ui/atoms/common-dropdown-types.ts
+++ b/packages/ui/atoms/common-dropdown-types.ts
@@ -226,6 +226,15 @@ export interface CommonDropdownProps {
   readonly onOpenChange?: (open: boolean) => void;
 
   /**
+   * Modality of the dropdown menu (Radix `modal`, default true).
+   * Pass false when the menu launches other modal layers (e.g. a Dialog)
+   * so the menu never takes the body pointer-events lock — stacked
+   * modal layers can race on teardown and leave the page inert.
+   * Only applies to `variant='dropdown'`.
+   */
+  readonly modal?: boolean;
+
+  /**
    * Disable portal rendering (render in DOM position)
    */
   readonly disablePortal?: boolean;

--- a/packages/ui/atoms/common-dropdown.tsx
+++ b/packages/ui/atoms/common-dropdown.tsx
@@ -46,6 +46,7 @@ export function CommonDropdown(props: CommonDropdownProps) {
     sideOffset = 4,
     open,
     onOpenChange,
+    modal = true,
     disablePortal = false,
     portalProps,
     contentClassName,
@@ -151,7 +152,11 @@ export function CommonDropdown(props: CommonDropdownProps) {
   }
 
   return (
-    <DropdownMenuPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+    <DropdownMenuPrimitive.Root
+      open={open}
+      onOpenChange={handleOpenChange}
+      modal={modal}
+    >
       <DropdownMenuPrimitive.Trigger
         asChild
         disabled={disabled}


### PR DESCRIPTION
## Problem
Opening the Live Profile right rail (view mode) can leave the chat composer unresponsive — clicks and typing go dead (P1, founder repro Jul 4). Root cause (gh-13221): the profile-actions kebab (Radix modal DropdownMenu) synchronously mounts the UTM Builder Dialog (Radix modal Dialog) from its item `onSelect`; the two modal layers race on teardown and leave `pointer-events: none` stuck on `<body>`.

## What changed
- **`CommonDropdown` (packages/ui)**: exposes the Radix `modal` prop (default `true`, dropdown variant only) so menus that launch other modal layers can opt out of the body pointer-events lock.
- **`ProfileBentoView` (ProfileContactSidebar.tsx)**: profile-actions kebab is now `modal={false}`; the UTM dialog open is deferred one tick past the menu teardown (`setTimeout 0`); a defensive effect clears any stuck `body{pointer-events:none}` after the dialog closes. Three layers of defense per the fix directions on gh-13221.
- **New Playwright matrix** `apps/web/tests/e2e/chat-composer-right-rail.spec.ts` (gh-13225): after every rail/menu/dialog/edit-mode open-close cycle asserts (a) composer focusable + accepts typed text, (b) `body` pointerEvents !== 'none', (c) `elementFromPoint` at composer center hits the input. Covers outside-click + ESC menu closes, dialog ESC-closes-dialog-only, copy-path close, edit-mode round trip, rail close end-to-end, and a 1023px viewport for the sub-lg overlay branch. Reuses existing Clerk auth fixtures; skips when credentials are absent (same gate as chat-composer.spec.ts). No new CI job.

## Not changed (scope notes)
- **Preview-bento dead space (gh-13224)**: already fixed on main — `heroClassName` is now `aspect-4/5 max-h-115` (the fixed `h-115` is gone) and the child issue is closed. No re-churn.
- Kebab 'Close' item / visible X (gh-13222) ships separately in #13648; this PR doesn't touch the menu items list, so no conflict beyond trivial adjacency in `ProfileBentoView` (`modal={false}` + one `onClick` swap).

## Assumptions
- Root cause is the stacked-modal teardown race per gh-13221's high-confidence hypothesis; the fix applies all three suggested directions (non-modal menu, deferred dialog open, defensive restore) so the repair holds even if only one mechanism is live.
- The new spec's composer locator uses `getByLabel(/chat message input/i)` — the source label is `Chat Message Input`; several older specs carry a stale lowercase attribute selector (pre-existing, not touched here).

## Verification
Local `pnpm install` is not possible in this sandbox (npm registry egress blocked — access requested and not granted; no Doppler token), so the local gate could not run. **Verification deferred to CI.** Commands CI must run (standard merge gate):

```
pnpm install && pnpm turbo lint typecheck test:fast --affected && pnpm run build:web
```

Static verification performed: full-diff review by a fresh-context verifier agent (initial FAIL caught a stale composer-selector casing, fixed; re-verified PASS); all spec selectors checked against source (`artist-profile-rail-toggle`, `Profile Actions`, `UTM Builder`, `Done`, `Edit Profile`, `data-menu-surface='toolbar'`, `Chat Message Input`); files rebased against live main HEAD (no drift).

## Cost Impact
None — no external API calls, cron jobs, or new dependencies.

Fixes #13221
Closes #13225
Part of #13220

Dispatch ID: profile-rail-composer-13220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
