### PR TITLE
fix(ios): occlude drawer base plane when closed (GH-12949)

### DIFF
--- a/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
@@ -29,10 +29,12 @@ enum AppShellDrawerThreadsFilter {
   }
 }
 
-// The drawer is always mounted as the recessed BASE plane behind the
-// elevated content card (see AppShellView.body). It never overlays, dims, or
-// offsets itself — AppShellView owns all drag/open state and moves the
-// content plane instead. This view is a pure, stateless surface switcher.
+// The drawer is mounted as the recessed BASE plane behind the elevated content
+// card (see AppShellView.body). It never overlays, dims, or offsets itself —
+// AppShellView owns all drag/open state, moves the content plane, and sets
+// base-plane opacity to 0 while fully closed (GH-12949) so translucent content
+// chrome cannot show drawer rows underneath. This view is a pure surface
+// switcher; hit-testing is gated on isPresented.
 struct AppShellLeftDrawer: View {
   let isPresented: Bool
   let profile: AppShellProfile

--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -50,6 +50,16 @@ func resolveShellInitialTab(_ initialTab: AppShellTab, chatEnabled: Bool) -> App
   }
 }
 
+// GH-12949: the recessed drawer base plane must be fully invisible while closed.
+// Content chrome (composer, toolbar) can be translucent, so occlusion alone is
+// not enough — opacity 0 when idle prevents thread rows from peeking through.
+func appShellDrawerBasePlaneOpacity(
+  isShowingDrawer: Bool,
+  drawerDragOffset: CGFloat
+) -> Double {
+  (isShowingDrawer || drawerDragOffset != 0) ? 1 : 0
+}
+
 private enum AppShellRoute: Hashable {
   case settings
 }
@@ -150,6 +160,10 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
         // Drawer is the recessed BASE plane of the ZStack: it never overlays or
         // dims content. The content container is the elevated plane that slides
         // right to reveal it, matching the ChatGPT/desktop-app model.
+        // When fully closed the base plane is opacity 0 (GH-12949) so translucent
+        // composer/toolbar regions cannot show drawer rows underneath.
+        let isDrawerBasePlaneVisible = isShowingDrawer || drawerDragOffset != 0
+
         ZStack(alignment: .leading) {
           AppShellLeftDrawer(
             isPresented: isShowingDrawer,
@@ -177,13 +191,20 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
               navigationPath.append(.settings)
             }
           )
-          // reduceMotion: the drawer beneath is otherwise fully static, so
-          // crossfade its opacity with the content card instead of relying on
-          // the (also-disabled) spatial slide to reveal it.
-          .opacity(reduceMotion ? (isShowingDrawer ? 1 : 0) : 1)
-          .animation(reduceMotion ? drawerAnimation : nil, value: isShowingDrawer)
+          .opacity(
+            appShellDrawerBasePlaneOpacity(
+              isShowingDrawer: isShowingDrawer,
+              drawerDragOffset: drawerDragOffset
+            )
+          )
+          .animation(drawerAnimation, value: isShowingDrawer)
+          .animation(reduceMotion ? nil : drawerAnimation, value: drawerDragOffset)
+          .accessibilityHidden(!isDrawerBasePlaneVisible)
 
           shellContent
+            // Full-bleed elevated card so the base plane cannot peek at bottom
+            // or trailing edges when closed (post–bottom-bar safeAreaInset removal).
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .offset(x: reduceMotion ? 0 : contentOffset(openOffset: openOffset))
             .opacity(reduceMotion && isShowingDrawer ? 0 : 1)
             .animation(drawerAnimation, value: isShowingDrawer)
@@ -268,8 +289,17 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
           .accessibilityHidden(true)
       }
     }
+    // Opaque full-size card. Clip first when elevated (rounded card). When
+    // closed, paint an unclipped bottom-safe-area underlay after clip so the
+    // home-indicator band cannot expose the recessed drawer (GH-12949).
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(JovieColor.backgroundBase)
     .clipShape(shellContentClipShape(isElevated: isElevated))
+    .background {
+      if !isElevated {
+        JovieColor.backgroundBase.ignoresSafeArea(edges: .bottom)
+      }
+    }
     .overlay(alignment: .leading) {
       if isElevated {
         Rectangle()

--- a/apps/ios/JovieTests/AppShellDrawerThreadsFilterTests.swift
+++ b/apps/ios/JovieTests/AppShellDrawerThreadsFilterTests.swift
@@ -71,3 +71,31 @@ struct AppShellDrawerSurfaceLayoutTests {
     #expect(AppShellDrawerSurfaceLayout.maxSingleLineSurfaceButtonHeight == 56)
   }
 }
+
+// GH-12949: recessed drawer base plane must be fully occluded when closed so
+// translucent composer/toolbar chrome cannot reveal thread rows underneath.
+struct AppShellDrawerBasePlaneOcclusionTests {
+  @Test func closedIdleStateHidesBasePlane() {
+    #expect(
+      appShellDrawerBasePlaneOpacity(isShowingDrawer: false, drawerDragOffset: 0) == 0
+    )
+  }
+
+  @Test func openStateShowsBasePlane() {
+    #expect(
+      appShellDrawerBasePlaneOpacity(isShowingDrawer: true, drawerDragOffset: 0) == 1
+    )
+  }
+
+  @Test func edgeDragRevealShowsBasePlaneWhileStillClosed() {
+    #expect(
+      appShellDrawerBasePlaneOpacity(isShowingDrawer: false, drawerDragOffset: 48) == 1
+    )
+  }
+
+  @Test func closingDragKeepsBasePlaneVisibleUntilSettled() {
+    #expect(
+      appShellDrawerBasePlaneOpacity(isShowingDrawer: true, drawerDragOffset: -32) == 1
+    )
+  }
+}

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -165,6 +165,39 @@ final class JovieUITests: XCTestCase {
     )
   }
 
+  // GH-12949: with the drawer closed, the recessed base plane must be fully
+  // occluded — no drawer chrome hittable under the composer/content card.
+  func testDrawerBasePlaneOccludedWhenClosed() {
+    let app = launchMockApp(launchArgument: "-ui-testing-chat", expectedElementDescription: "\"Ask Jovie\"") {
+      $0.textFields["Ask Jovie"]
+    }
+
+    let composer = app.textFields["Ask Jovie"]
+    XCTAssertTrue(
+      waitForHittable(composer, timeout: 3),
+      "Chat composer did not become hittable with drawer closed.\n\(app.debugDescription)"
+    )
+
+    let drawer = app.descendants(matching: .any)["shell-drawer"]
+    XCTAssertFalse(
+      drawer.isHittable,
+      "Drawer base plane stayed hittable with drawer closed — content card must fully occlude it.\n\(app.debugDescription)"
+    )
+    XCTAssertFalse(
+      app.buttons["shell-drawer-new-chat"].isHittable,
+      "Drawer New chat control is hittable with drawer closed.\n\(app.debugDescription)"
+    )
+    XCTAssertFalse(
+      app.buttons["shell-drawer-surface-shell-tab-profile"].isHittable,
+      "Drawer surface switcher is hittable with drawer closed.\n\(app.debugDescription)"
+    )
+    XCTAssertFalse(
+      app.staticTexts["Start a conversation to see recent conversations here."].isHittable,
+      "Drawer empty-threads copy is hittable under content with drawer closed.\n\(app.debugDescription)"
+    )
+    attachScreenshot(named: "drawer-base-plane-occluded-closed", app: app)
+  }
+
   // JOV-3670 evidence (a): the drawer is the SOLE surface switcher. The former
   // bottom QR/sparkle pill (shell-tab-* buttons, no drawer prefix) must not
   // exist anywhere in the shell, whether the drawer is closed or open.


### PR DESCRIPTION
## Summary
- Hide the recessed `AppShellLeftDrawer` base plane (`opacity 0`) while the drawer is fully closed so translucent composer/toolbar chrome cannot reveal thread rows underneath (GH-12949 / JOV-3869).
- Ensure the elevated content card is full-bleed (max frame + unclipped bottom safe-area underlay when closed) so home-indicator / trailing edges cannot expose the base plane after #12304 pill removal.
- Base plane stays visible during open state and mid-drag (`drawerDragOffset != 0`) so open/close gestures still work.

## Test plan
- [x] `pnpm run ios:lint` — clean
- [x] Scoped unit tests: `AppShellDrawerBasePlaneOcclusionTests` + drawer filter/layout suites — all passed
- [x] Added UI guard `testDrawerBasePlaneOccludedWhenClosed` (drawer chrome not hittable when closed)
- [ ] Simulator visual: Chat/Profile/Audience with drawer closed — no thread titles under composer; no dark trailing strip

## Bug-to-test
- Unit: `appShellDrawerBasePlaneOpacity` closed/open/drag cases
- UI: closed-state drawer controls not hittable under content

Fixes #12949