### PR TITLE
fix(inbox): mock nextStepMutation in OpportunityInboxPageClient tests

### DIFF
--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
@@ -33,6 +33,11 @@ vi.mock('@/lib/queries/useOpportunityInboxMutations', () => ({
       variables: undefined,
       mutate: mutateMock,
     },
+    nextStepMutation: {
+      isPending: false,
+      variables: undefined,
+      mutate: mutateMock,
+    },
   }),
 }));
 

--- a/apps/web/contrast-ratchet.baseline.json
+++ b/apps/web/contrast-ratchet.baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Contrast ratchet baseline — counts of hardcoded raw-color violations (JOV-11026/11038). To reduce: fix violations then run `pnpm --filter web lint:contrast-ratchet --update`. CI fails if counts exceed these baselines.",
   "bareTextBlack": 1,
   "bareBgWhite": 5,
-  "bareTextWhite": 20,
+  "bareTextWhite": 19,
   "bareBgBlack": 5,
   "arbitraryHex": 2
 }


### PR DESCRIPTION
## Summary
Fixes Unit Tests (4/5) on main: `OpportunityInboxPageClient` reads `nextStepMutation.isPending` but the test mock omitted `nextStepMutation` (TypeError after GH-13408).

Also lowers contrast ratchet `bareTextWhite` baseline 20→19 (improvement from #13731).

## Test plan
- [x] vitest OpportunityInboxPageClient.test.tsx (7 passed)
- [x] lint:contrast-ratchet
- [ ] CI