### PR TITLE
fix(profile): replace birthday native selects with on-system dropdown (GH-13389)

### DIFF
--- a/apps/web/components/features/profile/artist-notifications-cta/BirthdayInput.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/BirthdayInput.tsx
@@ -18,7 +18,12 @@ interface BirthdayInputProps {
   readonly error?: boolean;
 }
 
-const GROUP_LABELS = ['Month', 'Day', 'Year'];
+const GROUP_LABELS = ['Month', 'Day', 'Year'] as const;
+const GROUP_TEST_IDS = [
+  'mobile-birthday-month',
+  'mobile-birthday-day',
+  'mobile-birthday-year',
+] as const;
 
 export function BirthdayInput({
   value: controlledValue,
@@ -78,12 +83,16 @@ export function BirthdayInput({
     <div className='relative' ref={containerRef}>
       <fieldset
         className='flex items-center justify-center gap-1 border-0 p-0 m-0'
-        aria-label='Birthday month, day, and year'
+        aria-label='Birthday Month, Day, And Year'
         onPaste={handlePaste}
       >
         <legend className='sr-only'>Birthday (MM/DD/YYYY)</legend>
         {groups.map((group, gIdx) => (
-          <div key={group.label} className='flex items-center gap-1'>
+          <div
+            key={group.label}
+            className='flex items-center gap-1'
+            data-testid={GROUP_TEST_IDS[group.groupIdx]}
+          >
             {gIdx > 0 && (
               <span
                 className='px-0.5 text-mid text-secondary-token/40 select-none'

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
@@ -1,13 +1,6 @@
 'use client';
 
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  Switch,
-} from '@jovie/ui';
+import { Switch } from '@jovie/ui';
 import {
   CalendarDays,
   Check,
@@ -20,13 +13,7 @@ import {
   X,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import {
-  type CSSProperties,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { type CSSProperties, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { OtpInput } from '@/features/auth/atoms/otp-input';
 import {
@@ -36,6 +23,7 @@ import {
 import { PROFILE_Z } from '@/lib/profile/z-index-constants';
 import { cn } from '@/lib/utils';
 import type { NotificationContentType } from '@/types/notifications';
+import { BirthdayInput } from './BirthdayInput';
 
 export type ProfileMobileNotificationsFlowStep =
   | 'email'
@@ -106,23 +94,6 @@ const FLOW_TRANSITION = {
 const CAPTURE_CONSENT_COPY =
   'By submitting, you agree to receive updates from this artist and Jovie. Reply STOP to opt out. Message and data rates may apply.';
 
-const MONTH_OPTIONS = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-] as const;
-
-const CURRENT_YEAR = new Date().getFullYear();
-
 const PREFERENCE_META: Record<
   Extract<NotificationContentType, 'newMusic' | 'tourDates' | 'merch'>,
   {
@@ -145,22 +116,6 @@ const PREFERENCE_META: Record<
 };
 
 const JOVIE_ALERT_KEYS = ['newMusic', 'tourDates', 'merch'] as const;
-
-function extractBirthdayParts(value: string) {
-  return {
-    month: value.slice(0, 2),
-    day: value.slice(2, 4),
-    year: value.slice(4, 8),
-  };
-}
-
-function combineBirthdayParts(params: {
-  month: string;
-  day: string;
-  year: string;
-}) {
-  return `${params.month}${params.day}${params.year}`.slice(0, 8);
-}
 
 function formatCountdown(endTime: number) {
   const remainingMs = endTime - Date.now();
@@ -402,122 +357,6 @@ function InlineCaptureField({
           <Send className='size-4' />
         </button>
       </div>
-    </div>
-  );
-}
-
-const BIRTHDAY_SELECT_TRIGGER_CLASSNAME =
-  'h-12 touch-manipulation rounded-3xl border-white/10 bg-white/[0.03] px-3 text-base font-medium tracking-[-0.005em] text-white hover:border-white/18 focus-visible:border-white/18 focus-visible:ring-0 data-[placeholder]:text-white/42';
-
-/**
- * The flow overlay renders at PROFILE_Z.FULLSCREEN_FLOW (z-[140]); the Radix
- * Select content portals to document.body at z-50 by default, so it must be
- * raised above the takeover to stay visible.
- */
-const BIRTHDAY_SELECT_CONTENT_CLASSNAME = 'z-[150]';
-
-function BirthdayPartSelect({
-  label,
-  value,
-  options,
-  onValueChange,
-  testId,
-}: Readonly<{
-  label: string;
-  value: string;
-  options: readonly { readonly value: string; readonly label: string }[];
-  onValueChange: (value: string) => void;
-  testId: string;
-}>) {
-  return (
-    <div className='space-y-2'>
-      <span className='block text-app font-medium tracking-[-0.01em] text-white/42'>
-        {label}
-      </span>
-      <Select value={value || undefined} onValueChange={onValueChange}>
-        <SelectTrigger
-          data-testid={testId}
-          aria-label={label}
-          className={BIRTHDAY_SELECT_TRIGGER_CLASSNAME}
-        >
-          <SelectValue placeholder={label} />
-        </SelectTrigger>
-        <SelectContent className={BIRTHDAY_SELECT_CONTENT_CLASSNAME}>
-          {options.map(option => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
-
-const BIRTHDAY_MONTH_SELECT_OPTIONS = MONTH_OPTIONS.map((month, index) => ({
-  value: String(index + 1).padStart(2, '0'),
-  label: month,
-}));
-
-const BIRTHDAY_DAY_SELECT_OPTIONS = Array.from(
-  { length: 31 },
-  (_, index) => index + 1
-).map(day => ({
-  value: String(day).padStart(2, '0'),
-  label: String(day),
-}));
-
-function BirthdaySelectors({
-  value,
-  onChange,
-}: Readonly<{
-  value: string;
-  onChange: (value: string) => void;
-}>) {
-  const parts = extractBirthdayParts(value);
-  const yearOptions = useMemo(
-    () =>
-      Array.from({ length: 100 }, (_, index) => {
-        const year = String(CURRENT_YEAR - index);
-        return { value: year, label: year };
-      }),
-    []
-  );
-
-  const updatePart = (key: 'month' | 'day' | 'year', nextValue: string) => {
-    const nextParts = { ...parts, [key]: nextValue };
-    onChange(
-      combineBirthdayParts({
-        month: nextParts.month,
-        day: nextParts.day,
-        year: nextParts.year,
-      })
-    );
-  };
-
-  return (
-    <div className='grid grid-cols-3 gap-3'>
-      <BirthdayPartSelect
-        label='Month'
-        value={parts.month}
-        options={BIRTHDAY_MONTH_SELECT_OPTIONS}
-        onValueChange={next => updatePart('month', next)}
-        testId='mobile-birthday-month'
-      />
-      <BirthdayPartSelect
-        label='Day'
-        value={parts.day}
-        options={BIRTHDAY_DAY_SELECT_OPTIONS}
-        onValueChange={next => updatePart('day', next)}
-        testId='mobile-birthday-day'
-      />
-      <BirthdayPartSelect
-        label='Year'
-        value={parts.year}
-        options={yearOptions}
-        onValueChange={next => updatePart('year', next)}
-        testId='mobile-birthday-year'
-      />
     </div>
   );
 }
@@ -852,9 +691,18 @@ export function ProfileMobileNotificationsFlow({
             </div>
           }
         >
-          <BirthdaySelectors
+          {/*
+            Segmented BirthdayInput (not native/Radix selects): avoids OS listbox
+            overflow on desktop and reuses the existing on-system MM/DD/YYYY primitive
+            (GH-13389). Testids live on each digit group for keyboard + e2e parity.
+          */}
+          <BirthdayInput
             value={birthdayInput}
             onChange={onBirthdayChange}
+            onSubmit={() => onBirthdaySubmit()}
+            disabled={isBirthdaySaving}
+            error={birthdayHintShown}
+            autoFocus
           />
         </ScreenShell>
       );

--- a/apps/web/scripts/profile-review-matrix.ts
+++ b/apps/web/scripts/profile-review-matrix.ts
@@ -148,9 +148,7 @@ const SCREENSHOT_CASES: readonly CaptureCase[] = [
       await page.getByTestId('mobile-name-input').fill('Alex');
       await clickStepButton(page, 'name', /^continue$/i);
       await waitForStep(page, 'birthday');
-      await pickBirthdayOption(page, 'mobile-birthday-month', 'April');
-      await pickBirthdayOption(page, 'mobile-birthday-day', '5');
-      await pickBirthdayOption(page, 'mobile-birthday-year', '1992');
+      await fillBirthdayDigits(page, '04051992');
     },
   },
   {
@@ -177,9 +175,7 @@ const SCREENSHOT_CASES: readonly CaptureCase[] = [
       await page.getByTestId('mobile-name-input').fill('Alex');
       await clickStepButton(page, 'name', /^continue$/i);
       await waitForStep(page, 'birthday');
-      await pickBirthdayOption(page, 'mobile-birthday-month', 'April');
-      await pickBirthdayOption(page, 'mobile-birthday-day', '24');
-      await pickBirthdayOption(page, 'mobile-birthday-year', '1994');
+      await fillBirthdayDigits(page, '04241994');
       await clickStepButton(page, 'birthday', /^continue$/i);
       await waitForStep(page, 'preferences');
       await clickStepButton(page, 'preferences', /save & finish/i);
@@ -468,17 +464,14 @@ async function clickStepButton(
   await button.click({ timeout: 20_000, force: true });
 }
 
-async function pickBirthdayOption(
-  page: Page,
-  testId: string,
-  optionName: string
-) {
-  // Birthday selects are Radix Selects (portal to document.body), not native
-  // <select> elements — open each trigger, then click the option by name.
-  await page.getByTestId(testId).click({ timeout: 20_000 });
-  await page
-    .getByRole('option', { name: optionName, exact: true })
-    .click({ timeout: 20_000 });
+/** Fill segmented BirthdayInput via MMDDYYYY digits (GH-13389). */
+async function fillBirthdayDigits(page: Page, digits: string) {
+  const firstDigit = page
+    .getByTestId('mobile-birthday-month')
+    .locator('input')
+    .first();
+  await firstDigit.click({ timeout: 20_000 });
+  await firstDigit.pressSequentially(digits, { delay: 20 });
 }
 
 async function continueFromAlertsEntry(page: Page) {

--- a/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
+++ b/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
@@ -857,6 +857,8 @@ test.describe('Public Profile Mobile Viewport Stability @smoke @critical', () =>
           .getByRole('button', { name: /^continue$/i })
           .click();
 
+        // Birthday uses segmented digit groups (GH-13389); focus the first
+        // numeric input inside each group rather than a select trigger.
         for (const [id, label] of [
           ['mobile-birthday-month', 'birthday month'],
           ['mobile-birthday-day', 'birthday day'],
@@ -864,7 +866,7 @@ test.describe('Public Profile Mobile Viewport Stability @smoke @critical', () =>
         ] as const) {
           await focusAndAssertNoShift(
             flowPage,
-            activeFlow.getByTestId(id),
+            activeFlow.getByTestId(id).locator('input').first(),
             rootSelector,
             `${viewport.label} ${label}`
           );

--- a/apps/web/tests/e2e/profile-subscribe-e2e.spec.ts
+++ b/apps/web/tests/e2e/profile-subscribe-e2e.spec.ts
@@ -181,16 +181,19 @@ async function completeNameStep(page: Page, name: string) {
   await continueButton.click();
 }
 
-async function pickBirthdayOption(
-  page: Page,
-  flow: Locator,
-  testId: string,
-  optionName: string
-) {
-  await flow.locator(`[data-testid="${testId}"]`).click();
-  await page
-    .getByRole('option', { name: optionName, exact: true })
-    .click({ timeout: SMOKE_TIMEOUTS.VISIBILITY });
+/**
+ * Fill the segmented BirthdayInput (MMDDYYYY digits). No dropdown — typing
+ * into the first month digit auto-advances through the remaining boxes.
+ */
+async function fillBirthdayDigits(flow: Locator, digits: string) {
+  const firstDigit = flow
+    .getByTestId('mobile-birthday-month')
+    .locator('input')
+    .first();
+  await firstDigit.click();
+  await firstDigit.pressSequentially(digits, {
+    delay: 20,
+  });
 }
 
 async function completeBirthdayStep(page: Page) {
@@ -202,11 +205,8 @@ async function completeBirthdayStep(page: Page) {
     state: 'visible',
     timeout: SMOKE_TIMEOUTS.VISIBILITY,
   });
-  // Birthday selects are Radix Selects (portal to document.body), not native
-  // <select> elements — open each trigger, then click the option by name.
-  await pickBirthdayOption(page, flow, 'mobile-birthday-month', 'April');
-  await pickBirthdayOption(page, flow, 'mobile-birthday-day', '24');
-  await pickBirthdayOption(page, flow, 'mobile-birthday-year', '1994');
+  // Birthday uses segmented BirthdayInput (GH-13389) — type MMDDYYYY digits.
+  await fillBirthdayDigits(flow, '04241994');
   const continueButton = birthdayStep.getByRole('button', {
     name: /^continue$/i,
   });

--- a/apps/web/tests/unit/profile/inline-notifications-cta.test.tsx
+++ b/apps/web/tests/unit/profile/inline-notifications-cta.test.tsx
@@ -331,16 +331,24 @@ describe('ProfileInlineNotificationsCTA flow', () => {
     expect(await screen.findByTestId('mobile-name-input')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
 
-    // Regression #13391: birthday inputs are themed Radix Select triggers, not
-    // native <select> elements that pop an unstyled OS listbox.
+    // Regression GH-13389 / #13391: birthday uses segmented BirthdayInput
+    // digit groups (not native <select> or portaled listboxes that escape the
+    // dark card on desktop). Groups keep mobile-birthday-* testids.
     for (const testId of [
       'mobile-birthday-month',
       'mobile-birthday-day',
       'mobile-birthday-year',
     ]) {
-      const trigger = await screen.findByTestId(testId);
-      expect(trigger.tagName).toBe('BUTTON');
+      const group = await screen.findByTestId(testId);
+      expect(group.querySelectorAll('input[inputmode="numeric"]').length).toBe(
+        testId === 'mobile-birthday-year' ? 4 : 2
+      );
+      expect(group.querySelector('select')).toBeNull();
     }
+
+    expect(
+      screen.getByRole('group', { name: /birthday/i })
+    ).toBeInTheDocument();
   });
 
   it('renders nothing while notification hydration is checking', async () => {


### PR DESCRIPTION
## Summary
- Replaces the Birthday step Month/Day/Year controls with the existing segmented `BirthdayInput` primitive (MM/DD/YYYY digit boxes) so desktop never opens a native or portaled listbox that escapes the dark profile card (white column overflow).
- Removes the third birthday-input pattern (`BirthdaySelectors` + Radix Select) and reuses the folder-local primitive already designed for this flow.
- Keeps `mobile-birthday-month|day|year` testids on each digit group for keyboard, a11y, and e2e parity; SegmentedDigitBox tokens stay on-system (no `rounded-3xl` / raw white-alpha select chrome).

## Context
#13391 / #13407 already moved off native `<select>` to Radix Select. Residual #13389 acceptance still preferred consolidating onto `BirthdayInput` (no open-dropdown surface) and eliminating token-drift select triggers.

## Fixes
Fixes #13389

## Validation
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write` on edited files
- `pnpm --filter web exec vitest run tests/unit/profile/inline-notifications-cta.test.tsx` (10/10 pass)
- Pre-commit: eslint, a11y staged, turbo typecheck
- Pre-push: biome, proxy-guard, tailwind-guard, typecheck

## Cost Impact
- None (UI-only; no new API/cron/external calls)

## Residual risks
- E2E helpers now type MMDDYYYY via `pressSequentially` instead of selecting list options; smoke may need a green CI pass to confirm auto-advance timing under load.
- Viewport-stability birthday focus targets the first digit input inside each group (div wrappers are not focusable).