### PR TITLE
fix(tasks): sane due dates, release-task dedupe, Me/Jovie assignees

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/catalog-task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/catalog-task-actions.ts
@@ -22,6 +22,7 @@ import {
   type SelectionResult,
   selectTasks,
 } from '@/lib/release-tasks/select-tasks';
+import { computeTaskDueDate } from '@/lib/tasks/task-due-date';
 import { requireProfileId } from '../requireProfileId';
 import { getReleaseTasks } from './task-actions';
 
@@ -40,12 +41,6 @@ async function requireReleaseAccess(
     )
     .limit(1);
   if (!release) throw new Error('Release not found or access denied');
-}
-
-function computeDueDate(releaseDate: Date, offsetDays: number): Date {
-  const d = new Date(releaseDate);
-  d.setDate(d.getDate() + offsetDays);
-  return d;
 }
 
 async function loadCatalog(): Promise<CatalogRow[]> {
@@ -154,10 +149,7 @@ export async function instantiateReleaseTasksFromCatalog(
         agentStatus: 'idle' as const,
         releaseId,
         category: row.category,
-        dueAt:
-          releaseDate === null || row.flowStageDaysOffset === null
-            ? null
-            : computeDueDate(releaseDate, row.flowStageDaysOffset),
+        dueAt: computeTaskDueDate(releaseDate, row.flowStageDaysOffset),
         position: startPosition + index,
         sourceTemplateId: null,
         metadata: {
@@ -409,10 +401,7 @@ export async function addCatalogTaskToRelease(releaseId: string, slug: string) {
         agentStatus: 'idle' as const,
         releaseId,
         category: row.category,
-        dueAt:
-          releaseDate === null || row.flowStageDaysOffset === null
-            ? null
-            : computeDueDate(releaseDate, row.flowStageDaysOffset),
+        dueAt: computeTaskDueDate(releaseDate, row.flowStageDaysOffset),
         position,
         sourceTemplateId: null,
         metadata: {

--- a/apps/web/app/app/(shell)/dashboard/releases/task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/task-actions.ts
@@ -17,6 +17,7 @@ import {
   type DefaultTemplateItem,
 } from '@/lib/release-tasks/default-template';
 import type { ReleaseTaskView } from '@/lib/release-tasks/types';
+import { computeTaskDueDate } from '@/lib/tasks/task-due-date';
 import type { TaskView } from '@/lib/tasks/types';
 import { requireProfileId } from '../requireProfileId';
 import { createTask, deleteTask, updateTask } from '../tasks/task-actions';
@@ -84,12 +85,6 @@ function mapTaskToReleaseTaskView(task: TaskView): ReleaseTaskView {
   };
 }
 
-function computeDueDate(releaseDate: Date, offsetDays: number): Date {
-  const date = new Date(releaseDate);
-  date.setDate(date.getDate() + offsetDays);
-  return date;
-}
-
 export async function instantiateReleaseTasks(releaseId: string) {
   await requireReleasePlanGenerationAccess();
   const profileId = await requireProfileId();
@@ -110,7 +105,7 @@ export async function instantiateReleaseTasks(releaseId: string) {
     return getReleaseTasks(releaseId);
   }
 
-  const [release, positionRow, counterRow] = await Promise.all([
+  const [release, positionRow] = await Promise.all([
     db
       .select({ releaseDate: discogReleases.releaseDate })
       .from(discogReleases)
@@ -124,16 +119,34 @@ export async function instantiateReleaseTasks(releaseId: string) {
         and(eq(tasks.creatorProfileId, profileId), isNull(tasks.deletedAt))
       )
       .then(rows => rows[0]),
-    db
-      .update(creatorProfiles)
-      .set({
-        nextTaskNumber: drizzleSql`${creatorProfiles.nextTaskNumber} + ${DEFAULT_RELEASE_TASK_TEMPLATE.length}`,
-        updatedAt: new Date(),
-      })
-      .where(eq(creatorProfiles.id, profileId))
-      .returning({ nextTaskNumber: creatorProfiles.nextTaskNumber })
-      .then(rows => rows[0]),
   ]);
+
+  // Re-check immediately before allocating task numbers / inserting so a
+  // second concurrent call is less likely to double-seed the template.
+  // List-layer dedupe (dedupeReleaseTasks) is the hard guarantee for
+  // remaining races / historical duplicates (GH-12331).
+  const [freshExisting] = await db
+    .select({ taskCount: count() })
+    .from(tasks)
+    .where(
+      and(
+        eq(tasks.releaseId, releaseId),
+        eq(tasks.creatorProfileId, profileId),
+        isNull(tasks.deletedAt)
+      )
+    );
+  if (freshExisting && freshExisting.taskCount > 0) {
+    return getReleaseTasks(releaseId);
+  }
+
+  const [counterRow] = await db
+    .update(creatorProfiles)
+    .set({
+      nextTaskNumber: drizzleSql`${creatorProfiles.nextTaskNumber} + ${DEFAULT_RELEASE_TASK_TEMPLATE.length}`,
+      updatedAt: new Date(),
+    })
+    .where(eq(creatorProfiles.id, profileId))
+    .returning({ nextTaskNumber: creatorProfiles.nextTaskNumber });
 
   const firstTaskNumber =
     (counterRow?.nextTaskNumber ?? DEFAULT_RELEASE_TASK_TEMPLATE.length + 1) -
@@ -157,10 +170,7 @@ export async function instantiateReleaseTasks(releaseId: string) {
       agentStatus: 'idle' as const,
       releaseId,
       category: item.category,
-      dueAt:
-        releaseDate === null
-          ? null
-          : computeDueDate(releaseDate, item.dueDaysOffset),
+      dueAt: computeTaskDueDate(releaseDate, item.dueDaysOffset),
       position: startPosition + index,
       sourceTemplateId: null,
       metadata: {

--- a/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
@@ -27,7 +27,9 @@ import { discogReleases } from '@/lib/db/schema/content';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { tasks } from '@/lib/db/schema/tasks';
 import { requireTasksWorkspaceAccess } from '@/lib/entitlements/tasks-gate';
+import { dedupeReleaseTasks } from '@/lib/tasks/dedupe-release-tasks';
 import { isTaskStatus, TASK_BOARD_STATUSES } from '@/lib/tasks/task-board';
+import { sanitizeTaskDueAt } from '@/lib/tasks/task-due-date';
 import { buildTaskUpdateFieldPatch } from '@/lib/tasks/task-update';
 import type {
   CreateTaskInput,
@@ -162,7 +164,8 @@ function mapTaskRow(
     releaseTitle: row.releaseTitle ?? null,
     parentTaskId: row.parentTaskId ?? null,
     category: row.category ?? null,
-    dueAt: row.dueAt ?? null,
+    // Drop epoch / multi-year historical dues so the list never paints "12Y ago".
+    dueAt: sanitizeTaskDueAt(row.dueAt ?? null),
     scheduledFor: row.scheduledFor ?? null,
     startedAt: row.startedAt ?? null,
     completedAt: row.completedAt ?? null,
@@ -172,6 +175,14 @@ function mapTaskRow(
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
+}
+
+function mapAndDedupeTaskRows(
+  rows: ReadonlyArray<
+    Omit<TaskView, 'releaseTitle'> & { releaseTitle?: string | null }
+  >
+): TaskView[] {
+  return dedupeReleaseTasks(rows.map(mapTaskRow));
 }
 
 async function assertReleaseAccess(
@@ -485,7 +496,7 @@ export async function getTasks(filters?: TaskFilters): Promise<TaskListResult> {
   const pageRows = getPageRows(rows, limit);
 
   return {
-    tasks: pageRows.map(mapTaskRow),
+    tasks: mapAndDedupeTaskRows(pageRows),
     nextCursor: getNextCursor(rows, limit),
   };
 }
@@ -547,7 +558,7 @@ export async function getTaskBoard(
 
       return {
         status,
-        tasks: getPageRows(rows, limit).map(mapTaskRow),
+        tasks: mapAndDedupeTaskRows(getPageRows(rows, limit)),
         totalCount: Number(totalRow?.totalCount ?? 0),
         nextCursor: getNextCursor(rows, limit),
       };

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskAssigneeBadge.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskAssigneeBadge.tsx
@@ -22,7 +22,7 @@ export function ReleaseTaskAssigneeBadge({
 }: ReleaseTaskAssigneeBadgeProps) {
   return (
     <DotBadge
-      label={assigneeType === 'human' ? 'You' : 'AI'}
+      label={assigneeType === 'human' ? 'Me' : 'Jovie'}
       size='sm'
       variant={ASSIGNEE_VARIANTS[assigneeType]}
     />

--- a/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
@@ -5,6 +5,7 @@ import { Disc3, Sparkles, Tag } from 'lucide-react';
 import { memo, type ReactNode } from 'react';
 import { ShellListRowFrame } from '@/components/organisms/table';
 import { DueChip } from '@/components/shell/DueChip';
+import { toDueIso } from '@/lib/tasks/task-due-date';
 import type { TaskView } from '@/lib/tasks/types';
 import { getAccentCssVars } from '@/lib/ui/accent-palette';
 import { cn } from '@/lib/utils';
@@ -160,6 +161,7 @@ export const TaskListRow = memo(function TaskListRow({
   const isCancelled = task.status === 'cancelled';
   const isMuted = isDone || isCancelled;
   const categoryLabel = getTaskCategoryLabel(task.category);
+  const dueIso = hideDue ? null : toDueIso(task.dueAt);
   const agentWorking = isTaskAgentWorking(
     task.assigneeKind,
     task.status,
@@ -204,9 +206,7 @@ export const TaskListRow = memo(function TaskListRow({
             !hideTitle && 'mt-0.5'
           )}
         >
-          {task.dueAt && !hideDue ? (
-            <DueChip dueIso={task.dueAt.toISOString()} muted={isMuted} />
-          ) : null}
+          {dueIso ? <DueChip dueIso={dueIso} muted={isMuted} /> : null}
           <span className='shrink-0 truncate text-tertiary-token'>
             {stage.label}
           </span>

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -164,7 +164,7 @@ const TASK_PRIORITY_OPTIONS = [
 ] as const satisfies ReadonlyArray<readonly [TaskPriority, string]>;
 
 const TASK_ASSIGNEE_OPTIONS = [
-  ['human', 'You'],
+  ['human', 'Me'],
   ['jovie', 'Jovie'],
 ] as const satisfies ReadonlyArray<readonly [TaskAssigneeKind, string]>;
 
@@ -1314,7 +1314,7 @@ function useTaskActions({
           items: [
             {
               id: 'assignee-human',
-              label: 'You',
+              label: 'Me',
               icon: (
                 <span aria-hidden='true'>
                   <TaskAssigneeLeadingVisual

--- a/apps/web/components/features/dashboard/tasks/task-presentation.test.ts
+++ b/apps/web/components/features/dashboard/tasks/task-presentation.test.ts
@@ -73,9 +73,21 @@ describe('task-presentation', () => {
     });
 
     expect(getTaskAssigneeVisual('human', 'Tim White')).toMatchObject({
-      label: 'You',
-      avatarName: 'Tim White',
+      label: 'Me',
+      avatarName: 'Me',
       accent: 'blue',
+    });
+
+    // Release/song titles must never surface as the assignee chip (GH-12331).
+    expect(getTaskAssigneeVisual('human', 'Take Me Over')).toMatchObject({
+      label: 'Me',
+      avatarName: 'Me',
+    });
+    expect(
+      getTaskAssigneeVisual('jovie', "Love Don't Let Me Down")
+    ).toMatchObject({
+      label: 'Jovie',
+      avatarName: 'Jovie',
     });
   });
 

--- a/apps/web/components/features/dashboard/tasks/task-presentation.ts
+++ b/apps/web/components/features/dashboard/tasks/task-presentation.ts
@@ -148,9 +148,15 @@ export function getTaskPriorityVisual(
   return TASK_PRIORITY_META[priority];
 }
 
+/**
+ * Assignee chips always resolve from `assigneeKind` only.
+ * Never bind release/song titles (or display names) into the chip label —
+ * GH-12331: wrong field binding showed "Take Me Over" etc. as the assignee.
+ * The optional `artistName` arg is retained for call-site compatibility and ignored.
+ */
 export function getTaskAssigneeVisual(
   assigneeKind: TaskAssigneeKind,
-  artistName?: string | null
+  _artistName?: string | null
 ): TaskAssigneeMeta {
   if (assigneeKind === 'jovie') {
     return {
@@ -161,8 +167,8 @@ export function getTaskAssigneeVisual(
   }
 
   return {
-    label: 'You',
-    avatarName: artistName?.trim() || 'You',
+    label: 'Me',
+    avatarName: 'Me',
     accent: 'blue',
   };
 }

--- a/apps/web/components/shell/DueChip.test.tsx
+++ b/apps/web/components/shell/DueChip.test.tsx
@@ -30,10 +30,13 @@ describe('DueChip', () => {
     expect(screen.getByText('Due in 2w')).toBeInTheDocument();
   });
 
-  it('renders year counts instead of raw multi-year day counts', () => {
-    render(<DueChip dueIso='2020-04-25T12:00:00Z' now={NOW} />);
-    expect(screen.getByText('Due 6y ago')).toBeInTheDocument();
-    expect(screen.queryByText(/2192d/i)).not.toBeInTheDocument();
+  it('hides multi-year historical overdues instead of "12y ago" chips', () => {
+    const { container } = render(
+      <DueChip dueIso='2020-04-25T12:00:00Z' now={NOW} />
+    );
+    // Outside the actionable overdue window — no absurd relative chip.
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText(/y ago/i)).not.toBeInTheDocument();
   });
 
   it('tints amber for soon-due (<= 2 days)', () => {

--- a/apps/web/components/shell/DueChip.tsx
+++ b/apps/web/components/shell/DueChip.tsx
@@ -1,3 +1,7 @@
+import {
+  MAX_ACTIONABLE_OVERDUE_DAYS,
+  parseTaskDate,
+} from '@/lib/tasks/task-due-date';
 import { cn } from '@/lib/utils';
 import {
   ShellMetadataChip,
@@ -32,26 +36,27 @@ function resolveDueTone(days: number, muted: boolean): ShellMetadataChipTone {
   return 'neutral';
 }
 
-function formatDueLabel(days: number): string {
+function formatDueLabel(days: number, due: Date): string {
   if (days === 0) return 'Due today';
   if (days === 1) return 'Due tomorrow';
   if (days === -1) return 'Due yesterday';
+
+  // Multi-year relative chips ("12y ago") are never sane for planning —
+  // fall back to a short absolute date instead of year-scale relative text.
+  if (Math.abs(days) >= 365) {
+    return due.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
   if (days > 0) {
-    const text =
-      days >= 365
-        ? `${Math.round(days / 365)}y`
-        : days < 7
-          ? `${days}d`
-          : `${Math.round(days / 7)}w`;
+    const text = days < 7 ? `${days}d` : `${Math.round(days / 7)}w`;
     return `Due in ${text}`;
   }
   const abs = Math.abs(days);
-  const text =
-    abs >= 365
-      ? `${Math.round(abs / 365)}y`
-      : abs < 7
-        ? `${abs}d`
-        : `${Math.round(abs / 7)}w`;
+  const text = abs < 7 ? `${abs}d` : `${Math.round(abs / 7)}w`;
   return `Due ${text} ago`;
 }
 
@@ -69,19 +74,28 @@ function formatDueLabel(days: number): string {
  * ```
  */
 export function DueChip({ dueIso, now, muted, className }: DueChipProps) {
-  const due = new Date(dueIso).getTime();
-  if (!Number.isFinite(due)) {
+  const dueDate = parseTaskDate(dueIso);
+  if (!dueDate) {
     return null;
   }
-  const reference = (now ?? new Date()).getTime();
+  const due = dueDate.getTime();
+  const referenceDate = now ?? new Date();
+  const reference = referenceDate.getTime();
   const days = Math.round((due - reference) / MS_PER_DAY);
-  const label = formatDueLabel(days);
+
+  // Hide absurd historical overdues entirely (defense in depth for rows
+  // that bypassed sanitizeTaskDueAt at the data layer).
+  if (days < -MAX_ACTIONABLE_OVERDUE_DAYS) {
+    return null;
+  }
+
+  const label = formatDueLabel(days, dueDate);
   return (
     <ShellMetadataChip
       tone={resolveDueTone(days, Boolean(muted))}
       className={cn('tabular-nums', className)}
       contentClassName='uppercase tracking-[0.04em]'
-      title={new Date(due).toLocaleDateString()}
+      title={dueDate.toLocaleDateString()}
     >
       {label}
     </ShellMetadataChip>

--- a/apps/web/lib/tasks/dedupe-release-tasks.test.ts
+++ b/apps/web/lib/tasks/dedupe-release-tasks.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import {
+  dedupeReleaseTasks,
+  getReleaseTaskWorkKey,
+} from './dedupe-release-tasks';
+
+function task(partial: {
+  id: string;
+  taskNumber: number;
+  releaseId: string | null;
+  title: string;
+  catalogSlug?: string;
+}) {
+  return {
+    id: partial.id,
+    taskNumber: partial.taskNumber,
+    releaseId: partial.releaseId,
+    title: partial.title,
+    metadata: partial.catalogSlug ? { catalogSlug: partial.catalogSlug } : null,
+  };
+}
+
+describe('getReleaseTaskWorkKey', () => {
+  it('keys by catalogSlug when present, else normalized title', () => {
+    expect(
+      getReleaseTaskWorkKey(
+        task({
+          id: 'a',
+          taskNumber: 2,
+          releaseId: 'r1',
+          title: 'Enter metadata',
+          catalogSlug: 'enter-metadata',
+        })
+      )
+    ).toBe('release:r1:enter-metadata');
+
+    expect(
+      getReleaseTaskWorkKey(
+        task({
+          id: 'b',
+          taskNumber: 22,
+          releaseId: 'r1',
+          title: 'Enter metadata',
+        })
+      )
+    ).toBe('release:r1:enter metadata');
+  });
+
+  it('does not collapse standalone tasks by title', () => {
+    expect(
+      getReleaseTaskWorkKey(
+        task({
+          id: 'solo-1',
+          taskNumber: 1,
+          releaseId: null,
+          title: 'Custom',
+        })
+      )
+    ).toBe('id:solo-1');
+  });
+});
+
+describe('dedupeReleaseTasks', () => {
+  it('collapses duplicate rows for the same release work (J-2 & J-22 style)', () => {
+    const rows = [
+      task({
+        id: 't2',
+        taskNumber: 2,
+        releaseId: 'r1',
+        title: 'Enter metadata (ISRC, UPC, credits, genres)',
+      }),
+      task({
+        id: 't8',
+        taskNumber: 8,
+        releaseId: 'r1',
+        title: 'Pitch to Apple Music editorial',
+      }),
+      task({
+        id: 't22',
+        taskNumber: 22,
+        releaseId: 'r1',
+        title: 'Enter metadata (ISRC, UPC, credits, genres)',
+      }),
+      task({
+        id: 't28',
+        taskNumber: 28,
+        releaseId: 'r1',
+        title: 'Pitch to Apple Music editorial',
+      }),
+      task({
+        id: 't9',
+        taskNumber: 9,
+        releaseId: 'r1',
+        title: 'Pitch to Amazon Music editorial',
+      }),
+      task({
+        id: 't29',
+        taskNumber: 29,
+        releaseId: 'r1',
+        title: 'Pitch to Amazon Music editorial',
+      }),
+    ];
+
+    const deduped = dedupeReleaseTasks(rows);
+    expect(deduped.map(t => t.taskNumber)).toEqual([2, 8, 9]);
+    expect(deduped.map(t => t.id)).toEqual(['t2', 't8', 't9']);
+  });
+
+  it('keeps same title across different releases', () => {
+    const rows = [
+      task({
+        id: 'a',
+        taskNumber: 2,
+        releaseId: 'r1',
+        title: 'Enter metadata',
+      }),
+      task({
+        id: 'b',
+        taskNumber: 22,
+        releaseId: 'r2',
+        title: 'Enter metadata',
+      }),
+    ];
+    expect(dedupeReleaseTasks(rows)).toHaveLength(2);
+  });
+
+  it('prefers lowest task number when catalogSlug collides', () => {
+    const rows = [
+      task({
+        id: 'later',
+        taskNumber: 40,
+        releaseId: 'r1',
+        title: 'Different title',
+        catalogSlug: 'enter-metadata',
+      }),
+      task({
+        id: 'earlier',
+        taskNumber: 5,
+        releaseId: 'r1',
+        title: 'Enter metadata',
+        catalogSlug: 'enter-metadata',
+      }),
+    ];
+    const deduped = dedupeReleaseTasks(rows);
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0]?.id).toBe('earlier');
+  });
+});

--- a/apps/web/lib/tasks/dedupe-release-tasks.ts
+++ b/apps/web/lib/tasks/dedupe-release-tasks.ts
@@ -1,0 +1,56 @@
+/**
+ * Dedupe release-plan tasks that represent the same work item.
+ *
+ * Double-instantiation of the default template (or catalog) for the same
+ * release produces pairs like "Enter metadata" as J-2 and J-22. Identity is
+ * `releaseId + catalogSlug` when present, else `releaseId + normalized title`.
+ * Standalone (non-release) tasks are never collapsed.
+ */
+
+export interface DedupeTaskLike {
+  readonly id: string;
+  readonly taskNumber: number;
+  readonly releaseId: string | null;
+  readonly title: string;
+  readonly metadata?: Record<string, unknown> | null;
+}
+
+function readCatalogSlug(
+  metadata: Record<string, unknown> | null | undefined
+): string | null {
+  const value = metadata?.catalogSlug;
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+export function getReleaseTaskWorkKey(task: DedupeTaskLike): string {
+  if (!task.releaseId) {
+    return `id:${task.id}`;
+  }
+
+  const slug = readCatalogSlug(task.metadata ?? null);
+  const identity = slug ?? task.title.trim().toLowerCase();
+  return `release:${task.releaseId}:${identity}`;
+}
+
+/**
+ * Keep one row per release work identity. Prefer the lowest task number
+ * (earliest instantiation) when duplicates exist. Preserves relative order
+ * of the winning rows as they first appeared in the input.
+ */
+export function dedupeReleaseTasks<T extends DedupeTaskLike>(
+  tasks: readonly T[]
+): T[] {
+  if (tasks.length <= 1) return [...tasks];
+
+  const bestByKey = new Map<string, T>();
+  for (const task of tasks) {
+    const key = getReleaseTaskWorkKey(task);
+    const existing = bestByKey.get(key);
+    if (!existing || task.taskNumber < existing.taskNumber) {
+      bestByKey.set(key, task);
+    }
+  }
+
+  const winnerIds = new Set([...bestByKey.values()].map(task => task.id));
+  return tasks.filter(task => winnerIds.has(task.id));
+}

--- a/apps/web/lib/tasks/task-due-date.test.ts
+++ b/apps/web/lib/tasks/task-due-date.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeTaskDueDate,
+  parseTaskDate,
+  sanitizeTaskDueAt,
+  toDueIso,
+} from './task-due-date';
+
+describe('parseTaskDate', () => {
+  it('parses Date, ISO strings, and unix seconds vs ms', () => {
+    expect(
+      parseTaskDate(new Date('2026-04-15T00:00:00.000Z'))?.toISOString()
+    ).toBe('2026-04-15T00:00:00.000Z');
+    expect(parseTaskDate('2026-04-15T00:00:00.000Z')?.toISOString()).toBe(
+      '2026-04-15T00:00:00.000Z'
+    );
+    // 2014-05-13T16:53:20.000Z as seconds
+    expect(parseTaskDate(1_400_000_000)?.toISOString()).toBe(
+      '2014-05-13T16:53:20.000Z'
+    );
+    // same instant as ms
+    expect(parseTaskDate(1_400_000_000_000)?.toISOString()).toBe(
+      '2014-05-13T16:53:20.000Z'
+    );
+    expect(parseTaskDate('not-a-date')).toBeNull();
+    expect(parseTaskDate(null)).toBeNull();
+  });
+});
+
+describe('computeTaskDueDate', () => {
+  const now = new Date('2026-04-25T12:00:00.000Z');
+
+  it('applies negative and positive offsets from a valid release baseline', () => {
+    const releaseDate = new Date('2026-04-15T00:00:00.000Z');
+    expect(
+      computeTaskDueDate(releaseDate, -28, { now })?.toISOString().slice(0, 10)
+    ).toBe('2026-03-18');
+    expect(
+      computeTaskDueDate(releaseDate, 7, { now })?.toISOString().slice(0, 10)
+    ).toBe('2026-04-22');
+    expect(
+      computeTaskDueDate(releaseDate, 0, { now })?.toISOString().slice(0, 10)
+    ).toBe('2026-04-15');
+  });
+
+  it('returns null for missing offset, missing baseline, or pre-2000 epoch-like baselines', () => {
+    expect(
+      computeTaskDueDate(new Date('2026-04-15T00:00:00.000Z'), null, { now })
+    ).toBeNull();
+    expect(computeTaskDueDate(null, -30, { now })).toBeNull();
+    expect(
+      computeTaskDueDate(new Date('1970-01-01T00:00:00.000Z'), -30, { now })
+    ).toBeNull();
+  });
+
+  it('returns null when the computed due is a multi-year historical overdue', () => {
+    // 2014 release + -30d → ~12 years ago relative to 2026
+    expect(
+      computeTaskDueDate(new Date('2014-06-01T00:00:00.000Z'), -30, { now })
+    ).toBeNull();
+    expect(
+      computeTaskDueDate(new Date('2017-03-01T00:00:00.000Z'), -28, { now })
+    ).toBeNull();
+  });
+
+  it('keeps recently overdue and near-future dues', () => {
+    expect(
+      computeTaskDueDate(new Date('2026-04-20T00:00:00.000Z'), 0, { now })
+    ).not.toBeNull();
+    expect(
+      computeTaskDueDate(new Date('2026-05-01T00:00:00.000Z'), -7, { now })
+    ).not.toBeNull();
+  });
+});
+
+describe('sanitizeTaskDueAt', () => {
+  const now = new Date('2026-04-25T12:00:00.000Z');
+
+  it('drops absurd multi-year overdue values used by DueChip', () => {
+    expect(
+      sanitizeTaskDueAt(new Date('2014-04-25T12:00:00.000Z'), { now })
+    ).toBeNull();
+    expect(
+      sanitizeTaskDueAt(new Date('2026-04-20T12:00:00.000Z'), { now })
+    ).not.toBeNull();
+  });
+});
+
+describe('toDueIso', () => {
+  it('accepts Date and ISO string inputs', () => {
+    expect(toDueIso(new Date('2026-04-25T12:00:00.000Z'))).toBe(
+      '2026-04-25T12:00:00.000Z'
+    );
+    expect(toDueIso('2026-04-25T12:00:00.000Z')).toBe(
+      '2026-04-25T12:00:00.000Z'
+    );
+    expect(toDueIso(null)).toBeNull();
+  });
+});

--- a/apps/web/lib/tasks/task-due-date.ts
+++ b/apps/web/lib/tasks/task-due-date.ts
@@ -1,0 +1,104 @@
+/**
+ * Task due-date helpers.
+ *
+ * Release-plan tasks derive `dueAt` from `releaseDate + offsetDays`.
+ * Historical catalog releases (and bad epoch-like baselines) produced
+ * absurd chips like "Due 12y ago". These helpers:
+ *  - reject invalid / pre-2000 baselines
+ *  - coerce seconds vs ms unix timestamps
+ *  - omit dues that are too far in the past to be actionable
+ */
+
+const MS_PER_DAY = 86_400_000;
+
+/** Years before this are treated as bad seed / epoch baselines. */
+export const MIN_VALID_RELEASE_YEAR = 2000;
+
+/**
+ * Past due dates older than this many days are not actionable planning
+ * signals on the Tasks list (historical releases, re-imported catalogs).
+ */
+export const MAX_ACTIONABLE_OVERDUE_DAYS = 180;
+
+export function parseTaskDate(
+  value: Date | string | number | null | undefined
+): Date | null {
+  if (value == null) return null;
+
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value : null;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return null;
+    // Unix seconds are ~1e9; ms are ~1e12+. Treat smaller values as seconds.
+    const ms = Math.abs(value) < 1e12 ? value * 1000 : value;
+    const fromNumber = new Date(ms);
+    return Number.isFinite(fromNumber.getTime()) ? fromNumber : null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  // Pure integer strings (e.g. "1400000000") — parse as unix seconds/ms.
+  if (/^-?\d+$/.test(trimmed)) {
+    return parseTaskDate(Number(trimmed));
+  }
+
+  const fromString = new Date(trimmed);
+  return Number.isFinite(fromString.getTime()) ? fromString : null;
+}
+
+function isActionableDue(due: Date, now: Date): boolean {
+  if (due.getUTCFullYear() < MIN_VALID_RELEASE_YEAR) return false;
+  const daysPast = Math.round((now.getTime() - due.getTime()) / MS_PER_DAY);
+  return daysPast <= MAX_ACTIONABLE_OVERDUE_DAYS;
+}
+
+/**
+ * Compute a task due date from a release baseline + day offset.
+ * Returns null when the baseline is missing/invalid or the result would
+ * be an absurd multi-month historical overdue.
+ */
+export function computeTaskDueDate(
+  releaseDate: Date | string | number | null | undefined,
+  offsetDays: number | null | undefined,
+  options?: { readonly now?: Date }
+): Date | null {
+  if (offsetDays == null || !Number.isFinite(offsetDays)) return null;
+
+  const base = parseTaskDate(releaseDate);
+  if (!base) return null;
+  if (base.getUTCFullYear() < MIN_VALID_RELEASE_YEAR) return null;
+
+  const due = new Date(base.getTime());
+  due.setDate(due.getDate() + offsetDays);
+
+  const now = options?.now ?? new Date();
+  if (!isActionableDue(due, now)) return null;
+  return due;
+}
+
+/**
+ * Sanitize a stored dueAt for list/board display. Drops epoch-like and
+ * multi-month historical overdue values so existing bad rows do not
+ * paint the Tasks surface red with "12Y ago" chips.
+ */
+export function sanitizeTaskDueAt(
+  dueAt: Date | string | number | null | undefined,
+  options?: { readonly now?: Date }
+): Date | null {
+  const due = parseTaskDate(dueAt);
+  if (!due) return null;
+  const now = options?.now ?? new Date();
+  if (!isActionableDue(due, now)) return null;
+  return due;
+}
+
+/** Safe ISO string for DueChip — handles Date objects and ISO strings. */
+export function toDueIso(
+  dueAt: Date | string | number | null | undefined
+): string | null {
+  const due = parseTaskDate(dueAt);
+  return due ? due.toISOString() : null;
+}

--- a/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
@@ -136,7 +136,7 @@ describe('TaskListRow', () => {
       />
     );
 
-    expect(queryByText('You')).not.toBeInTheDocument();
+    expect(queryByText('Me')).not.toBeInTheDocument();
   });
 
   it('hides the title and due chip when the detail pane already shows them', () => {

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -914,7 +914,7 @@ describe('TasksPageClient', () => {
 
     expect(screen.getAllByText('In Progress').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Medium').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('You').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Me').length).toBeGreaterThan(0);
   });
 
   it('renders separate list and document scroll regions on desktop', () => {

--- a/apps/web/tests/unit/release-tasks/task-logic.test.ts
+++ b/apps/web/tests/unit/release-tasks/task-logic.test.ts
@@ -1,14 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_RELEASE_TASK_TEMPLATE } from '@/lib/release-tasks/default-template';
+import { computeTaskDueDate } from '@/lib/tasks/task-due-date';
 
 // Test the pure logic that the server actions use — date computation,
 // task row building, idempotency checks. These don't need DB mocking.
 
-function computeDueDate(releaseDate: Date, offsetDays: number): Date {
-  const date = new Date(releaseDate);
-  date.setDate(date.getDate() + offsetDays);
-  return date;
-}
+const NOW = new Date('2026-04-25T12:00:00.000Z');
 
 function buildTaskRows(
   releaseId: string,
@@ -38,41 +35,45 @@ function buildTaskRows(
     assigneeType: item.assigneeType,
     aiWorkflowId: item.aiWorkflowId ?? null,
     dueDaysOffset: item.dueDaysOffset,
-    dueDate: releaseDate
-      ? computeDueDate(releaseDate, item.dueDaysOffset)
-      : null,
+    dueDate: computeTaskDueDate(releaseDate, item.dueDaysOffset, { now: NOW }),
   }));
 }
 
-describe('computeDueDate', () => {
+describe('computeTaskDueDate', () => {
   it('computes correct date with negative offset', () => {
     const releaseDate = new Date('2026-04-15T00:00:00Z');
-    const result = computeDueDate(releaseDate, -28);
-    expect(result.toISOString().split('T')[0]).toBe('2026-03-18');
+    const result = computeTaskDueDate(releaseDate, -28, { now: NOW });
+    expect(result?.toISOString().split('T')[0]).toBe('2026-03-18');
   });
 
   it('computes correct date with positive offset', () => {
     const releaseDate = new Date('2026-04-15T00:00:00Z');
-    const result = computeDueDate(releaseDate, 7);
-    expect(result.toISOString().split('T')[0]).toBe('2026-04-22');
+    const result = computeTaskDueDate(releaseDate, 7, { now: NOW });
+    expect(result?.toISOString().split('T')[0]).toBe('2026-04-22');
   });
 
   it('computes correct date with zero offset (release day)', () => {
     const releaseDate = new Date('2026-04-15T00:00:00Z');
-    const result = computeDueDate(releaseDate, 0);
-    expect(result.toISOString().split('T')[0]).toBe('2026-04-15');
+    const result = computeTaskDueDate(releaseDate, 0, { now: NOW });
+    expect(result?.toISOString().split('T')[0]).toBe('2026-04-15');
   });
 
   it('handles month boundary crossing', () => {
     const releaseDate = new Date('2026-03-05T00:00:00Z');
-    const result = computeDueDate(releaseDate, -10);
-    expect(result.toISOString().split('T')[0]).toBe('2026-02-23');
+    const result = computeTaskDueDate(releaseDate, -10, { now: NOW });
+    expect(result?.toISOString().split('T')[0]).toBe('2026-02-23');
   });
 
   it('handles year boundary crossing', () => {
     const releaseDate = new Date('2026-01-10T00:00:00Z');
-    const result = computeDueDate(releaseDate, -30);
-    expect(result.toISOString().split('T')[0]).toBe('2025-12-11');
+    const result = computeTaskDueDate(releaseDate, -30, { now: NOW });
+    expect(result?.toISOString().split('T')[0]).toBe('2025-12-11');
+  });
+
+  it('returns null for historical multi-year baselines (no 12Y-ago dues)', () => {
+    expect(
+      computeTaskDueDate(new Date('2014-06-01T00:00:00Z'), -30, { now: NOW })
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes #12331 — Tasks list was rendering broken due dates, duplicate release-plan rows, and wrong assignee chips.

### Changes
1. **Due dates**
   - Shared `computeTaskDueDate` / `sanitizeTaskDueAt` rejects epoch-like baselines and multi-month historical overdues (no more "Due 12Y/9Y ago").
   - List/board mapping sanitizes stored dues; generation uses the shared helper.
   - `DueChip` hides absurd historical overdues as defense-in-depth.

2. **Duplicate task rows**
   - `dedupeReleaseTasks` collapses same-release work (title / `catalogSlug`) keeping the lowest `taskNumber` (J-2 & J-22 style pairs).
   - Applied on `getTasks` / `getTaskBoard` mapping; generation re-checks before insert.

3. **Assignee chips**
   - Chips bind only to `assigneeKind` → **Me** / **Jovie**.
   - Never uses display name / release / song titles (e.g. "Take Me Over").

## Test plan
- [x] `pnpm --filter web exec vitest run` focused suites (due-date, dedupe, DueChip, presentation, TaskListRow, task-logic, TasksPageClient) — **102 passed**
- [x] `pnpm biome check` on edited files
- [x] `pnpm --filter @jovie/web run typecheck`
- [ ] Visual: Tasks list shows sane dues, no same-release duplicates, assignee Me/Jovie only

## Design-read
Reading this as: product Tasks workspace for creators, with a quiet Linear-like language, leaning toward System B shell chips (DueChip / assignee meta).

## Risk
Low — app-layer mapping + presentation. No migrations. Existing historical due rows are sanitized at read time (null chip) rather than mutated in DB.