### PR TITLE
feat(chat): empty state opportunity cards instead of pills (GH-13177)

### DIFF
--- a/apps/web/app/api/connectors/suggested-actions/route.ts
+++ b/apps/web/app/api/connectors/suggested-actions/route.ts
@@ -1,0 +1,60 @@
+/**
+ * GET /api/connectors/suggested-actions
+ *
+ * Returns pending opportunity cards for the authenticated user (suggested_actions
+ * rows with status=pending). Used by empty-chat opportunity cards (GH #13177).
+ */
+
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth/require-auth';
+import { loadOpportunityInboxData } from '@/lib/connectors/opportunity-inbox-data';
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
+import { captureError } from '@/lib/error-tracking';
+import { logger } from '@/lib/utils/logger';
+
+export const runtime = 'nodejs';
+
+const NO_STORE_HEADERS = {
+  'Cache-Control': 'no-store, no-cache, must-revalidate',
+  Pragma: 'no-cache',
+} as const;
+
+/** Chat empty-state surfaces at most 3 cards. */
+const CHAT_EMPTY_STATE_CARD_LIMIT = 3;
+
+export interface PendingSuggestedActionsResponse {
+  readonly cards: readonly OpportunityInboxCardViewModel[];
+}
+
+export async function GET() {
+  const { userId, error } = await requireAuth();
+  if (error) return error;
+
+  try {
+    const inbox = await loadOpportunityInboxData(userId);
+    if (!inbox) {
+      return NextResponse.json(
+        { error: 'User not found' },
+        { status: 404, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const cards = inbox.cards.slice(0, CHAT_EMPTY_STATE_CARD_LIMIT);
+    const payload: PendingSuggestedActionsResponse = { cards };
+
+    return NextResponse.json(payload, {
+      status: 200,
+      headers: NO_STORE_HEADERS,
+    });
+  } catch (err) {
+    logger.error('[suggested-actions] list pending failed', err);
+    await captureError('List pending suggested actions failed', err, {
+      route: '/api/connectors/suggested-actions',
+      method: 'GET',
+    });
+    return NextResponse.json(
+      { error: 'Internal error' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -11,11 +11,14 @@ import {
 } from 'react';
 import { useOptionalChatEntityPanel } from '@/app/app/(shell)/chat/ChatEntityPanelContext';
 import { ChatThreadNavigationRail } from '@/components/features/chat/navigation-rail';
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
 import { useAppFlag } from '@/lib/flags/client';
-import { usePlanGate } from '@/lib/queries';
+import { usePendingOpportunityCardsQuery, usePlanGate } from '@/lib/queries';
 import { cn } from '@/lib/utils';
 import { deriveChatRailContextTargets } from './chat-context-rail';
 import { ChatDropZoneOverlay } from './components/ChatDropZoneOverlay';
+import { ChatEmptyStateOpportunityCards } from './components/ChatEmptyStateOpportunityCards';
+import { ChatPinnedOpportunityHeader } from './components/ChatPinnedOpportunityHeader';
 import { ChatProvidersRegistrar } from './components/ChatProvidersRegistrar';
 import { EntityResolutionProvider } from './components/EntityResolutionProvider';
 import {
@@ -67,6 +70,9 @@ export function JovieChat({
   const initialSkillApplied = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [composerPickerOpen, setComposerPickerOpen] = useState(false);
+  /** Pinned opportunity card for empty-thread → card-open mode (GH #13177 / #13174). */
+  const [pinnedOpportunity, setPinnedOpportunity] =
+    useState<OpportunityInboxCardViewModel | null>(null);
   // Track message IDs that were loaded from persistence to skip entrance animation
   const knownMessageIdsRef = useRef<Set<string>>(new Set());
   const initialConversationScrollRef = useRef<string | null>(null);
@@ -390,7 +396,39 @@ export function JovieChat({
   const lastAssistantIndex = findLastAssistantIndex(messages);
 
   const isStreaming = status === 'streaming';
-  const showThreadView = hasMessages;
+  // Empty-thread opportunity cards (GH #13177): only when there is no active
+  // conversation content yet. Zero pending → leave empty state as-is (no pills).
+  const shouldLoadOpportunityCards =
+    !hasMessages && !conversationId && !isLoadingConversation;
+  const { data: pendingOpportunityCards = [] } =
+    usePendingOpportunityCardsQuery({
+      enabled: shouldLoadOpportunityCards && !pinnedOpportunity,
+    });
+  const showEmptyOpportunityCards =
+    shouldLoadOpportunityCards &&
+    !pinnedOpportunity &&
+    pendingOpportunityCards.length > 0;
+
+  const handleSelectOpportunityCard = useCallback(
+    (card: OpportunityInboxCardViewModel) => {
+      setPinnedOpportunity(card);
+    },
+    []
+  );
+  const handleUnpinOpportunity = useCallback(() => {
+    setPinnedOpportunity(null);
+  }, []);
+
+  // Clear pin when navigating to a different conversation.
+  useEffect(() => {
+    if (conversationId) {
+      setPinnedOpportunity(null);
+    }
+  }, [conversationId]);
+
+  // Pin mode uses the thread chrome (docked composer + header) so the card
+  // stays above the transcript, matching inbox → pinned-card behavior.
+  const showThreadView = hasMessages || pinnedOpportunity !== null;
   const showBottomComposer = showThreadView;
   const shouldReservePickerClearance = showBottomComposer && composerPickerOpen;
   const messageViewportPaddingBottom = shouldReservePickerClearance
@@ -616,6 +654,14 @@ export function JovieChat({
               >
                 <ChatEmptyStateComposerRegion
                   greetingName={displayName ?? username ?? null}
+                  above={
+                    showEmptyOpportunityCards ? (
+                      <ChatEmptyStateOpportunityCards
+                        cards={pendingOpportunityCards}
+                        onSelect={handleSelectOpportunityCard}
+                      />
+                    ) : undefined
+                  }
                 >
                   {composerSurface}
                   {inlineChatError ? (
@@ -624,27 +670,35 @@ export function JovieChat({
                 </ChatEmptyStateComposerRegion>
               </div>
             ) : (
-              <ChatThreadMessages
-                messages={messages}
-                shouldVirtualizeMessages={shouldVirtualizeMessages}
-                virtualizer={virtualizer}
-                virtualizedMessageViewportHeight={
-                  virtualizedMessageViewportHeight
-                }
-                virtualizedMinHeight={virtualizedMinHeight}
-                messageViewportPaddingBottom={messageViewportPaddingBottom}
-                totalSizeRef={totalSizeRef}
-                bottomSentinelRef={bottomSentinelRef}
-                isStreaming={isStreaming}
-                lastAssistantIndex={lastAssistantIndex}
-                avatarUrl={avatarUrl}
-                profileId={profileId}
-                knownMessageIds={knownMessageIdsRef.current}
-                inlineChatError={inlineChatError}
-                isStuckToBottom={isStuckToBottom}
-                onScrollToBottom={() => scrollToBottom()}
-                conversationId={activeConversationId ?? conversationId}
-              />
+              <>
+                {pinnedOpportunity ? (
+                  <ChatPinnedOpportunityHeader
+                    card={pinnedOpportunity}
+                    onUnpin={handleUnpinOpportunity}
+                  />
+                ) : null}
+                <ChatThreadMessages
+                  messages={messages}
+                  shouldVirtualizeMessages={shouldVirtualizeMessages}
+                  virtualizer={virtualizer}
+                  virtualizedMessageViewportHeight={
+                    virtualizedMessageViewportHeight
+                  }
+                  virtualizedMinHeight={virtualizedMinHeight}
+                  messageViewportPaddingBottom={messageViewportPaddingBottom}
+                  totalSizeRef={totalSizeRef}
+                  bottomSentinelRef={bottomSentinelRef}
+                  isStreaming={isStreaming}
+                  lastAssistantIndex={lastAssistantIndex}
+                  avatarUrl={avatarUrl}
+                  profileId={profileId}
+                  knownMessageIds={knownMessageIdsRef.current}
+                  inlineChatError={inlineChatError}
+                  isStuckToBottom={isStuckToBottom}
+                  onScrollToBottom={() => scrollToBottom()}
+                  conversationId={activeConversationId ?? conversationId}
+                />
+              </>
             )}
           </div>
 

--- a/apps/web/components/jovie/components/ChatEmptyStateOpportunityCards.test.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateOpportunityCards.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
+
+import { ChatEmptyStateOpportunityCards } from './ChatEmptyStateOpportunityCards';
+
+const cards: readonly OpportunityInboxCardViewModel[] = [
+  {
+    id: 'card-1',
+    typeLabel: 'Suggestion',
+    createdAt: '2026-07-01T12:00:00.000Z',
+    title: 'Detroit listeners up 340%',
+    why: 'Promoter at Magic Stick reached out.',
+    primaryActionLabel: 'Review pitch',
+    status: 'pending',
+    category: 'suggestion',
+  },
+  {
+    id: 'card-2',
+    typeLabel: 'Suggestion',
+    createdAt: '2026-07-02T12:00:00.000Z',
+    title: 'Playlist window this week',
+    why: 'Your latest single is peaking.',
+    primaryActionLabel: 'Draft pitch',
+    status: 'pending',
+    category: 'suggestion',
+  },
+  {
+    id: 'card-3',
+    typeLabel: 'Report',
+    createdAt: '2026-07-03T12:00:00.000Z',
+    title: 'Campaign results',
+    why: 'Streams rose 12%.',
+    primaryActionLabel: 'Plan next step',
+    status: 'pending',
+    category: 'report',
+  },
+  {
+    id: 'card-4',
+    typeLabel: 'Suggestion',
+    createdAt: '2026-07-04T12:00:00.000Z',
+    title: 'Should not render',
+    why: 'Fourth card is capped.',
+    primaryActionLabel: 'Approve',
+    status: 'pending',
+    category: 'suggestion',
+  },
+];
+
+describe('ChatEmptyStateOpportunityCards', () => {
+  it('renders up to 3 compact cards and ignores extras', () => {
+    render(<ChatEmptyStateOpportunityCards cards={cards} onSelect={vi.fn()} />);
+
+    expect(
+      screen.getByTestId('chat-empty-state-opportunity-cards')
+    ).toBeTruthy();
+    expect(screen.getByText('Detroit listeners up 340%')).toBeTruthy();
+    expect(screen.getByText('Playlist window this week')).toBeTruthy();
+    expect(screen.getByText('Campaign results')).toBeTruthy();
+    expect(screen.queryByText('Should not render')).toBeNull();
+  });
+
+  it('calls onSelect when a card is activated', () => {
+    const onSelect = vi.fn();
+    render(
+      <ChatEmptyStateOpportunityCards cards={cards} onSelect={onSelect} />
+    );
+
+    fireEvent.click(screen.getByTestId('chat-empty-opportunity-card-card-1'));
+    expect(onSelect).toHaveBeenCalledWith(cards[0]);
+  });
+
+  it('renders nothing when there are zero cards', () => {
+    const { container } = render(
+      <ChatEmptyStateOpportunityCards cards={[]} onSelect={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/components/jovie/components/ChatEmptyStateOpportunityCards.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateOpportunityCards.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import { formatOpportunityInboxRelativeTime } from '@/lib/connectors/opportunity-inbox-time';
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
+import { cn } from '@/lib/utils';
+
+/**
+ * Compact opportunity cards for empty-chat (GH #13177).
+ * Renders up to 3 pending suggested_actions; tap enters pinned-card mode.
+ *
+ * Layout: fixed min-height slot per card so loading → data does not reflow
+ * the centered composer stack (opacity-only reveal when ready).
+ */
+export interface ChatEmptyStateOpportunityCardsProps {
+  readonly cards: readonly OpportunityInboxCardViewModel[];
+  readonly onSelect: (card: OpportunityInboxCardViewModel) => void;
+  readonly className?: string;
+}
+
+const MAX_CARDS = 3;
+/** Reserved height per compact card + gap — keeps empty-state geometry stable. */
+const CARD_SLOT_MIN_HEIGHT_CLASS = 'min-h-[4.5rem]';
+
+export function ChatEmptyStateOpportunityCards({
+  cards,
+  onSelect,
+  className,
+}: ChatEmptyStateOpportunityCardsProps) {
+  const visible = cards.slice(0, MAX_CARDS);
+  if (visible.length === 0) return null;
+
+  return (
+    <ul
+      className={cn(
+        'mx-auto flex w-full max-w-[28rem] list-none flex-col gap-2 p-0',
+        className
+      )}
+      data-testid='chat-empty-state-opportunity-cards'
+      aria-label='Pending Opportunities'
+    >
+      {visible.map(card => (
+        <li key={card.id} className='list-none'>
+          <button
+            type='button'
+            data-testid={`chat-empty-opportunity-card-${card.id}`}
+            onClick={() => onSelect(card)}
+            className={cn(
+              CARD_SLOT_MIN_HEIGHT_CLASS,
+              'group flex w-full flex-col gap-1 rounded-2xl border border-subtle bg-surface-1 px-3.5 py-2.5 text-left',
+              'transition-colors duration-subtle hover:border-focus/30 hover:bg-surface-0',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40'
+            )}
+          >
+            <header className='flex items-center gap-1.5 text-2xs font-medium tracking-wide text-quaternary-token'>
+              <span className='uppercase'>{card.typeLabel}</span>
+              <span aria-hidden='true'>·</span>
+              <time dateTime={card.createdAt}>
+                {formatOpportunityInboxRelativeTime(card.createdAt)}
+              </time>
+            </header>
+            <div className='flex items-start justify-between gap-2'>
+              <div className='min-w-0 flex-1'>
+                <p className='truncate text-sm font-semibold leading-snug text-primary-token'>
+                  {card.title}
+                </p>
+                <p className='mt-0.5 line-clamp-1 text-xs leading-snug text-tertiary-token'>
+                  {card.why}
+                </p>
+              </div>
+              <span
+                className='mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-tertiary-token transition-colors duration-fast group-hover:text-primary-token'
+                aria-hidden='true'
+              >
+                <ArrowRight className='h-3.5 w-3.5' strokeWidth={2.25} />
+              </span>
+            </div>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/components/jovie/components/ChatPinnedOpportunityHeader.test.tsx
+++ b/apps/web/components/jovie/components/ChatPinnedOpportunityHeader.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
+
+import { ChatPinnedOpportunityHeader } from './ChatPinnedOpportunityHeader';
+
+const card: OpportunityInboxCardViewModel = {
+  id: 'pin-1',
+  typeLabel: 'Suggestion',
+  createdAt: '2026-07-01T12:00:00.000Z',
+  title: 'Detroit listeners up 340%',
+  why: 'Promoter at Magic Stick reached out.',
+  primaryActionLabel: 'Review pitch',
+  status: 'pending',
+  category: 'suggestion',
+};
+
+describe('ChatPinnedOpportunityHeader', () => {
+  it('renders the pinned card summary', () => {
+    render(<ChatPinnedOpportunityHeader card={card} onUnpin={vi.fn()} />);
+
+    expect(screen.getByTestId('chat-pinned-opportunity-header')).toBeTruthy();
+    expect(screen.getByText('Detroit listeners up 340%')).toBeTruthy();
+    expect(
+      screen.getByText('Promoter at Magic Stick reached out.')
+    ).toBeTruthy();
+  });
+
+  it('calls onUnpin from the dismiss control', () => {
+    const onUnpin = vi.fn();
+    render(<ChatPinnedOpportunityHeader card={card} onUnpin={onUnpin} />);
+
+    fireEvent.click(screen.getByTestId('chat-pinned-opportunity-unpin'));
+    expect(onUnpin).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/components/jovie/components/ChatPinnedOpportunityHeader.tsx
+++ b/apps/web/components/jovie/components/ChatPinnedOpportunityHeader.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { X } from 'lucide-react';
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
+import { cn } from '@/lib/utils';
+import { CHAT_MESSAGE_CONTENT_SHELL_CLASSNAME } from '../chat-layout';
+
+/**
+ * Pinned opportunity header for card-opened chat mode (GH #13177 / #13174).
+ * Sits above the transcript; composer stays at the bottom.
+ */
+export interface ChatPinnedOpportunityHeaderProps {
+  readonly card: OpportunityInboxCardViewModel;
+  readonly onUnpin: () => void;
+  readonly className?: string;
+}
+
+export function ChatPinnedOpportunityHeader({
+  card,
+  onUnpin,
+  className,
+}: ChatPinnedOpportunityHeaderProps) {
+  return (
+    <div
+      className={cn(
+        CHAT_MESSAGE_CONTENT_SHELL_CLASSNAME,
+        'sticky top-0 z-10 mb-4',
+        className
+      )}
+      data-testid='chat-pinned-opportunity-header'
+    >
+      <div className='flex items-start gap-3 rounded-2xl border border-subtle bg-surface-1 px-3.5 py-2.5'>
+        <div className='min-w-0 flex-1'>
+          <p className='text-2xs font-medium uppercase tracking-wide text-quaternary-token'>
+            {card.typeLabel}
+          </p>
+          <p className='mt-0.5 truncate text-sm font-semibold text-primary-token'>
+            {card.title}
+          </p>
+          <p className='mt-0.5 line-clamp-2 text-xs text-tertiary-token'>
+            {card.why}
+          </p>
+        </div>
+        <button
+          type='button'
+          onClick={onUnpin}
+          className='flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-tertiary-token transition-colors duration-fast hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40'
+          aria-label='Unpin Opportunity'
+          data-testid='chat-pinned-opportunity-unpin'
+        >
+          <X className='h-3.5 w-3.5' strokeWidth={2.25} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/jovie/components/index.ts
+++ b/apps/web/components/jovie/components/index.ts
@@ -1,6 +1,7 @@
 export { ChatAvatarUploadCard } from './ChatAvatarUploadCard';
 export { ChatDropZoneOverlay } from './ChatDropZoneOverlay';
 export { ChatEmptyStateComposerRegion } from './ChatEmptyStateComposerRegion';
+export { ChatEmptyStateOpportunityCards } from './ChatEmptyStateOpportunityCards';
 export { ChatFileChips } from './ChatFileChips';
 export { ChatInput } from './ChatInput';
 export { ChatLinkConfirmationCard } from './ChatLinkConfirmationCard';
@@ -10,6 +11,7 @@ export {
   ChatConversationComposerSkeleton,
   ChatMessageSkeleton,
 } from './ChatMessageSkeleton';
+export { ChatPinnedOpportunityHeader } from './ChatPinnedOpportunityHeader';
 export { ChatPitchCard } from './ChatPitchCard';
 export { ChatUploadManifest } from './ChatUploadManifest';
 export { EntityChip, type EntityChipData } from './EntityChip';

--- a/apps/web/lib/queries/index.ts
+++ b/apps/web/lib/queries/index.ts
@@ -413,6 +413,8 @@ export {
   useUpdateSubscriberNameMutation,
   useVerifyEmailOtpMutation,
 } from './useNotificationStatusQuery';
+// Pending opportunity cards (empty chat)
+export { usePendingOpportunityCardsQuery } from './usePendingOpportunityCardsQuery';
 // Pixel health query
 export {
   type PixelHealthData,

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -342,6 +342,13 @@ export const queryKeys = {
       [...queryKeys.chat.all, 'capabilities', profileId ?? 'active'] as const,
   },
 
+  // Opportunity inbox (suggested_actions)
+  opportunityInbox: {
+    all: ['opportunity-inbox'] as const,
+    pendingCards: () =>
+      [...queryKeys.opportunityInbox.all, 'pending-cards'] as const,
+  },
+
   // Audience infinite scroll
   audience: {
     all: ['audience'] as const,

--- a/apps/web/lib/queries/usePendingOpportunityCardsQuery.ts
+++ b/apps/web/lib/queries/usePendingOpportunityCardsQuery.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { OpportunityInboxCardViewModel } from '@/lib/connectors/opportunity-inbox-types';
+import { FREQUENT_CACHE } from './cache-strategies';
+import { fetchWithTimeout } from './fetch';
+import { queryKeys } from './keys';
+
+interface PendingSuggestedActionsResponse {
+  readonly cards: readonly OpportunityInboxCardViewModel[];
+}
+
+/**
+ * Pending opportunity cards for empty-chat (GH #13177).
+ * Disabled when a conversation is already open — empty-state only.
+ */
+export function usePendingOpportunityCardsQuery({
+  enabled = true,
+}: {
+  readonly enabled?: boolean;
+} = {}) {
+  return useQuery({
+    queryKey: queryKeys.opportunityInbox.pendingCards(),
+    queryFn: ({ signal }) =>
+      fetchWithTimeout<PendingSuggestedActionsResponse>(
+        '/api/connectors/suggested-actions',
+        { signal }
+      ),
+    enabled,
+    ...FREQUENT_CACHE,
+    select: (data): readonly OpportunityInboxCardViewModel[] =>
+      data.cards.slice(0, 3),
+  });
+}

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { JovieChat } from '@/components/jovie/JovieChat';
@@ -100,6 +100,17 @@ vi.mock('@/components/jovie/hooks', () => ({
   }),
 }));
 
+const mockPendingOpportunityCards: Array<{
+  readonly id: string;
+  readonly typeLabel: string;
+  readonly createdAt: string;
+  readonly title: string;
+  readonly why: string;
+  readonly primaryActionLabel: string;
+  readonly status: 'pending';
+  readonly category: 'suggestion';
+}> = [];
+
 vi.mock('@/lib/queries', () => ({
   queryKeys: {
     releases: {
@@ -112,6 +123,11 @@ vi.mock('@/lib/queries', () => ({
   usePlanGate: () => ({
     isPro: true,
     chatFileUploadLimit: null,
+    isLoading: false,
+    isError: false,
+  }),
+  usePendingOpportunityCardsQuery: () => ({
+    data: mockPendingOpportunityCards,
     isLoading: false,
     isError: false,
   }),
@@ -154,6 +170,7 @@ vi.mock('@/components/jovie/components/ChatUsageAlert', () => ({
 describe('JovieChat empty state', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPendingOpportunityCards.length = 0;
     mockChatState.input = '';
     mockChatState.messages = [];
     mockChatState.hasMessages = false;
@@ -339,5 +356,61 @@ describe('JovieChat empty state', () => {
     expect(
       screen.getByTestId('chat-input').getAttribute('data-quick-actions')
     ).toBeNull();
+  });
+
+  it('renders compact opportunity cards instead of suggestion pills when pending', () => {
+    mockPendingOpportunityCards.push({
+      id: 'opp-1',
+      typeLabel: 'Suggestion',
+      createdAt: '2026-07-01T12:00:00.000Z',
+      title: 'Detroit listeners up 340%',
+      why: 'Promoter at Magic Stick reached out.',
+      primaryActionLabel: 'Review pitch',
+      status: 'pending',
+      category: 'suggestion',
+    });
+
+    const { getByTestId, queryByTestId, getByText } = renderWithQueryClient(
+      <JovieChat profileId='profile-1' />
+    );
+
+    expect(getByTestId('chat-empty-state-opportunity-cards')).toBeTruthy();
+    expect(getByText('Detroit listeners up 340%')).toBeTruthy();
+    // Pills stay hidden when opportunities are present.
+    expect(queryByTestId('suggested-prompts-rail')).toBeNull();
+    expect(queryByTestId('chat-empty-state-soft-suggestions-slot')).toBeNull();
+  });
+
+  it('enters pinned-card mode when an opportunity card is tapped', () => {
+    mockPendingOpportunityCards.push({
+      id: 'opp-pin',
+      typeLabel: 'Suggestion',
+      createdAt: '2026-07-01T12:00:00.000Z',
+      title: 'Playlist window this week',
+      why: 'Your latest single is peaking.',
+      primaryActionLabel: 'Draft pitch',
+      status: 'pending',
+      category: 'suggestion',
+    });
+
+    const { getByTestId, queryByTestId } = renderWithQueryClient(
+      <JovieChat profileId='profile-1' />
+    );
+
+    fireEvent.click(getByTestId('chat-empty-opportunity-card-opp-pin'));
+
+    expect(getByTestId('chat-pinned-opportunity-header')).toBeTruthy();
+    expect(getByTestId('chat-composer-dock')).toBeTruthy();
+    expect(queryByTestId('chat-empty-state-opportunity-cards')).toBeNull();
+    expect(queryByTestId('chat-empty-state-viewport')).toBeNull();
+  });
+
+  it('does not render opportunity cards when there are none pending', () => {
+    const { queryByTestId } = renderWithQueryClient(
+      <JovieChat profileId='profile-1' />
+    );
+
+    expect(queryByTestId('chat-empty-state-opportunity-cards')).toBeNull();
+    expect(queryByTestId('suggested-prompts-rail')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Empty chat threads with pending `suggested_actions` now surface **up to 3 compact opportunity cards** instead of generic suggestion pills. Tapping a card enters **pinned-card mode** in the current thread (composer docked; card pinned above the transcript). Zero pending opportunities keeps the current empty-state behavior (logo + greeting + composer; no pills).

**Fixes #13177**

## Changes

- `GET /api/connectors/suggested-actions` — lists pending opportunity cards for the authenticated user (limit 3 for empty chat)
- `usePendingOpportunityCardsQuery` + query key `opportunityInbox.pendingCards`
- `ChatEmptyStateOpportunityCards` — compact, fixed min-height slots (layout-stable)
- `ChatPinnedOpportunityHeader` — sticky pin chrome with unpin
- `JovieChat` wires empty-state cards + pin mode

## Design-read

Reading this as: **product empty-chat** for **creators**, with a **quiet Linear-like** language, leaning toward **System B / opportunity-inbox** tokens.

## Acceptance

- [x] With pending opportunities: cards render, pills do not
- [x] Card tap enters pinned-card mode (UI pin header + docked composer; server context injection remains #13174)
- [x] Without opportunities: pills unchanged (still absent); no layout-shift regressions (reserved card min-height + `above` slot)

## Verification

```text
pnpm biome check --write <touched paths>  # clean
pnpm --filter @jovie/web run typecheck -- --pretty false  # pass
pnpm --filter web exec vitest run \
  components/jovie/components/ChatEmptyStateOpportunityCards.test.tsx \
  components/jovie/components/ChatPinnedOpportunityHeader.test.tsx \
  tests/unit/chat/JovieChat.empty-state.test.tsx
# Test Files  3 passed (3) · Tests  15 passed (15)
```

## Notes

- Server-side “Pinned opportunity” system-context injection is owned by **#13174** (not in this PR).
- Canonical inbox row component (**#13170** / OpportunityRow) is still open; this PR uses a chat-local compact card that maps the existing inbox view model.