### PR TITLE
feat(marketing): conform 7 holdout marketing pages to System B tokens

### DIFF
--- a/apps/web/app/(marketing)/about/page.tsx
+++ b/apps/web/app/(marketing)/about/page.tsx
@@ -98,7 +98,7 @@ export default function AboutPage() {
 
       <MarketingHeroLayout variant='left'>
         <p className='text-sm font-medium text-tertiary-token'>About</p>
-        <h1 className='mt-6 max-w-2xl text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
+        <h1 className='mt-6 max-w-2xl text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl lg:text-6xl'>
           Release More Music. Do Less Release Work.
         </h1>
         <p className='mt-6 max-w-2xl text-lg leading-relaxed text-secondary-token'>

--- a/apps/web/app/(marketing)/about/page.tsx
+++ b/apps/web/app/(marketing)/about/page.tsx
@@ -49,6 +49,7 @@ const FAQ_ITEMS = [
 export const metadata: Metadata = {
   title: 'About — The Release Platform for Independent Musicians',
   description:
+    // ui-casing-allow: metadata sentence with brand names + acronym
     'Jovie is a release platform for independent musicians, combining smart links, artist profiles, audience intelligence, and AI. Founded by Tim White. Not affiliated with Jovie childcare.',
   keywords: [
     'Jovie',
@@ -67,6 +68,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: `About ${APP_NAME} — The Release Platform for Independent Musicians`,
     description:
+      // ui-casing-allow: metadata sentence with brand names + acronym
       'Jovie is a release platform for independent musicians, combining smart links, artist profiles, audience intelligence, and AI. Founded by Tim White.',
     url: `${BASE_URL}/about`,
     type: 'website',
@@ -95,11 +97,11 @@ export default function AboutPage() {
       <script type='application/ld+json'>{BREADCRUMB_SCHEMA}</script>
 
       <MarketingHeroLayout variant='left'>
-        <p className='marketing-kicker'>About</p>
-        <h1 className='marketing-h1-linear mt-6 max-w-[20ch] text-primary-token'>
-          Release more music. Do less release work.
+        <p className='text-sm font-medium text-tertiary-token'>About</p>
+        <h1 className='mt-6 max-w-2xl text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
+          Release More Music. Do Less Release Work.
         </h1>
-        <p className='mt-6 max-w-[60ch] text-lg leading-relaxed text-secondary-token'>
+        <p className='mt-6 max-w-2xl text-lg leading-relaxed text-secondary-token'>
           Jovie is the release platform for independent musicians. Smart links,
           artist profiles, audience intelligence, release automation, and AI —
           all in one place.
@@ -110,7 +112,7 @@ export default function AboutPage() {
       <MarketingContainer width='prose' className='pb-16'>
         <section>
           <h2 className='text-2xl font-semibold text-primary-token'>
-            Why Jovie exists
+            Why Jovie Exists
           </h2>
           <div className='mt-6 space-y-5 text-base leading-relaxed text-secondary-token'>
             <p>
@@ -144,13 +146,14 @@ export default function AboutPage() {
       <MarketingContainer width='prose' className='pb-16'>
         <section>
           <h2 className='text-2xl font-semibold text-primary-token'>
-            What Jovie does
+            What Jovie Does
           </h2>
           <div className='mt-6 grid gap-8 sm:grid-cols-2'>
             {[
               {
                 title: 'Smart Links',
                 description:
+                  // ui-casing-allow: feature list copy with brand names
                   'Every release gets a smart link that routes fans to Spotify, Apple Music, YouTube, or wherever they listen.',
               },
               {
@@ -176,6 +179,7 @@ export default function AboutPage() {
               {
                 title: 'Tipping & Payments',
                 description:
+                  // ui-casing-allow: feature list copy with brand name
                   'Let fans support you directly with tips via Stripe — at shows, on your profile, or through QR codes.',
               },
             ].map(feature => (
@@ -193,7 +197,10 @@ export default function AboutPage() {
       </MarketingContainer>
 
       {/* FAQ Section */}
-      <FaqSection items={FAQ_ITEMS} />
+      <FaqSection
+        items={FAQ_ITEMS}
+        headingClassName='text-2xl font-semibold tracking-tight text-primary-token'
+      />
     </>
   );
 }

--- a/apps/web/app/(marketing)/alternatives/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/alternatives/[slug]/page.tsx
@@ -63,11 +63,11 @@ export default async function AlternativesPage({
       <script type='application/ld+json'>{breadcrumbSchema}</script>
 
       <MarketingHeroLayout variant='left'>
-        <p className='marketing-kicker'>Alternative</p>
-        <h1 className='marketing-h1-linear mt-6 max-w-[20ch] text-primary-token'>
+        <p className='text-sm font-medium text-tertiary-token'>Alternative</p>
+        <h1 className='mt-6 max-w-2xl text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
           {data.heroHeadline}
         </h1>
-        <p className='mt-6 max-w-[60ch] text-lg leading-relaxed text-secondary-token'>
+        <p className='mt-6 max-w-2xl text-lg leading-relaxed text-secondary-token'>
           {data.heroSubheadline}
         </p>
       </MarketingHeroLayout>
@@ -125,7 +125,7 @@ export default async function AlternativesPage({
             </p>
             <Link
               href={APP_ROUTES.SIGNUP}
-              className='mt-6 inline-flex items-center rounded-lg border border-(--linear-btn-primary-border) bg-btn-primary px-6 py-3 text-sm font-medium text-btn-primary-foreground shadow-button-inset hover:border-(--linear-btn-primary-hover) hover:bg-(--linear-btn-primary-hover)'
+              className='public-action-primary mt-6'
             >
               Request Access
             </Link>
@@ -134,7 +134,10 @@ export default async function AlternativesPage({
       </MarketingContainer>
 
       {/* FAQ */}
-      <FaqSection items={data.faq} />
+      <FaqSection
+        items={data.faq}
+        headingClassName='text-2xl font-semibold tracking-tight text-primary-token'
+      />
     </>
   );
 }

--- a/apps/web/app/(marketing)/alternatives/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/alternatives/[slug]/page.tsx
@@ -125,7 +125,7 @@ export default async function AlternativesPage({
             </p>
             <Link
               href={APP_ROUTES.SIGNUP}
-              className='public-action-primary mt-6'
+              className='mt-6 inline-flex items-center rounded-lg bg-btn-primary px-6 py-3 text-sm font-medium text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle ease-subtle hover:bg-btn-primary-hover'
             >
               Request Access
             </Link>

--- a/apps/web/app/(marketing)/blog/page.tsx
+++ b/apps/web/app/(marketing)/blog/page.tsx
@@ -41,11 +41,11 @@ export default async function BlogIndexPage() {
     return (
       <div className='min-h-screen'>
         <MarketingHeroLayout variant='left'>
-          <p className='marketing-kicker mb-0 text-tertiary-token'>Blog</p>
-          <h1 className='marketing-h1-linear mb-6 mt-6 max-w-[8ch] text-primary-token'>
+          <p className='mb-0 text-sm font-medium text-tertiary-token'>Blog</p>
+          <h1 className='mb-6 mt-6 max-w-2xl text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
             Blog
           </h1>
-          <p className='marketing-lead-linear max-w-[34rem] text-secondary-token'>
+          <p className='max-w-xl text-lg leading-relaxed text-secondary-token'>
             Posts coming soon.
           </p>
         </MarketingHeroLayout>
@@ -64,11 +64,11 @@ export default async function BlogIndexPage() {
     <div className='min-h-screen'>
       {/* Hero Section */}
       <MarketingHeroLayout variant='left'>
-        <p className='marketing-kicker mb-0 text-tertiary-token'>Blog</p>
-        <h1 className='marketing-h1-linear mb-6 mt-6 max-w-[8ch] text-primary-token'>
+        <p className='mb-0 text-sm font-medium text-tertiary-token'>Blog</p>
+        <h1 className='mb-6 mt-6 max-w-2xl text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
           Blog
         </h1>
-        <p className='marketing-lead-linear max-w-[34rem] text-secondary-token'>
+        <p className='max-w-xl text-lg leading-relaxed text-secondary-token'>
           Thoughts on product, strategy, and the craft of building tools for
           artists.
         </p>

--- a/apps/web/app/(marketing)/changelog/ChangelogEmailSignup.tsx
+++ b/apps/web/app/(marketing)/changelog/ChangelogEmailSignup.tsx
@@ -4,7 +4,6 @@ import { Button } from '@jovie/ui/atoms/button';
 import { Input } from '@jovie/ui/atoms/input';
 import { ArrowRight, Mail } from 'lucide-react';
 import {
-  type CSSProperties,
   type FocusEvent,
   type FormEvent,
   useEffect,
@@ -142,13 +141,7 @@ export function ChangelogEmailSignup() {
   return (
     <div
       id='changelog-subscribe'
-      className='rounded-2xl p-8 md:p-10'
-      style={{
-        backgroundColor:
-          'color-mix(in srgb, var(--linear-text-primary) 3%, transparent)',
-        border:
-          '1px solid color-mix(in srgb, var(--linear-text-primary) 8%, transparent)',
-      }}
+      className='rounded-2xl border border-subtle bg-surface-1 p-8 md:p-10'
     >
       <div className='mb-3 flex items-center gap-3'>
         <Mail className='h-5 w-5 opacity-50' />
@@ -172,11 +165,6 @@ export function ChangelogEmailSignup() {
         data-ui='cta-reveal'
         data-visual-state={visualState}
         onBlurCapture={handleShellBlurCapture}
-        style={
-          {
-            '--cta-reveal-min-height': '56px',
-          } as CSSProperties
-        }
       >
         <div className='cta-reveal-shell'>
           <div className='cta-reveal-panel cta-reveal-panel--cta'>
@@ -256,7 +244,7 @@ export function ChangelogEmailSignup() {
         </div>
 
         <p
-          className='cta-reveal-support mt-3 text-sm text-red-500'
+          className='cta-reveal-support mt-3 text-sm text-accent-red'
           role={status === 'error' ? 'alert' : undefined}
         >
           {status === 'error' ? errorMessage : ''}

--- a/apps/web/app/(marketing)/changelog/loading.tsx
+++ b/apps/web/app/(marketing)/changelog/loading.tsx
@@ -2,13 +2,7 @@ import { MarketingContainer } from '@/components/marketing';
 
 export default function ChangelogLoading() {
   return (
-    <section
-      className='min-h-screen'
-      style={{
-        backgroundColor: 'var(--linear-bg-footer)',
-        color: 'var(--linear-text-primary)',
-      }}
-    >
+    <section className='min-h-screen bg-page text-primary-token'>
       {/* Hero skeleton */}
       <div className='pt-16 pb-20 sm:pt-20 sm:pb-24 lg:pt-24 lg:pb-32 text-center'>
         <MarketingContainer width='page'>
@@ -21,10 +15,7 @@ export default function ChangelogLoading() {
       <MarketingContainer width='page' className='pb-20 sm:pb-28'>
         <div className='max-w-3xl space-y-10'>
           {Array.from({ length: 4 }, (_, i) => `cl-skeleton-${i}`).map(key => (
-            <div
-              key={key}
-              className='pl-6 border-l-2 border-white/10 space-y-3'
-            >
+            <div key={key} className='space-y-3 border-l-2 border-subtle pl-6'>
               <div className='flex gap-2'>
                 <div className='h-5 w-16 skeleton rounded-full' />
                 <div className='h-5 w-24 skeleton rounded' />

--- a/apps/web/app/(marketing)/changelog/page.tsx
+++ b/apps/web/app/(marketing)/changelog/page.tsx
@@ -66,19 +66,19 @@ const SECTION_LABELS: Record<
 > = {
   added: {
     label: 'New',
-    color: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+    color: 'bg-accent-green-subtle text-accent-green',
   },
   changed: {
     label: 'Improved',
-    color: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+    color: 'bg-accent-blue-subtle text-accent-blue',
   },
   fixed: {
     label: 'Fixed',
-    color: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+    color: 'bg-accent-orange-subtle text-accent-orange',
   },
   removed: {
     label: 'Removed',
-    color: 'bg-red-500/10 text-red-600 dark:text-red-400',
+    color: 'bg-accent-red-subtle text-accent-red',
   },
 };
 
@@ -113,18 +113,18 @@ export default async function ChangelogPage() {
     <section className='min-h-screen bg-page text-primary-token'>
       {/* Header */}
       <MarketingHeroLayout variant='left'>
-        <p className='marketing-kicker'>Changelog</p>
-        <h1 className='marketing-h1-linear mb-4 mt-6 max-w-[10ch]'>
-          What&apos;s new
+        <p className='text-sm font-medium text-tertiary-token'>Changelog</p>
+        <h1 className='mb-4 mt-6 max-w-xs text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
+          What&apos;s New
         </h1>
-        <p className='marketing-lead-linear mb-4 max-w-[34rem] text-secondary-token'>
+        <p className='mb-4 max-w-xl text-lg leading-relaxed text-secondary-token'>
           Follow our journey building the future of music.
         </p>
         <div className='flex flex-wrap items-center gap-3'>
           {thisMonthCount > 0 && (
             <Badge variant='outline' className='text-xs'>
-              {thisMonthCount} update{thisMonthCount === 1 ? '' : 's'} this
-              month
+              {thisMonthCount} Update{thisMonthCount === 1 ? '' : 's'} This
+              Month
             </Badge>
           )}
           <Link
@@ -149,25 +149,16 @@ export default async function ChangelogPage() {
               {releases.map(release => (
                 <article
                   key={`${release.version}-${release.date ?? 'unreleased'}`}
-                  className='relative pl-6 border-l-2'
-                  style={{
-                    borderColor:
-                      'color-mix(in srgb, var(--linear-text-primary) 10%, transparent)',
-                  }}
+                  className='relative border-l-2 border-subtle pl-6'
                 >
                   {/* Timeline dot */}
-                  <div
-                    className='absolute -left-[7px] top-1 w-3 h-3 rounded-full'
-                    style={{
-                      backgroundColor: 'var(--linear-text-primary)',
-                      opacity: 0.3,
-                    }}
-                  />
+                  <div className='absolute -left-1.5 top-1 h-3 w-3 rounded-full bg-tertiary-token opacity-30' />
 
                   {/* Version + date header */}
                   <div className='flex flex-wrap items-center gap-2 mb-4'>
                     <Badge variant='outline' className='font-mono text-xs'>
-                      v{release.version}
+                      {/* ui-casing-allow: semantic version string */}v
+                      {release.version}
                     </Badge>
                     {release.date && (
                       <span className='text-xs text-tertiary-token'>

--- a/apps/web/app/(marketing)/compare/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/compare/[slug]/page.tsx
@@ -161,7 +161,7 @@ export default async function ComparePage({ params }: ComparePageProps) {
           <div className='mt-8'>
             <Link
               href={APP_ROUTES.SIGNUP}
-              className='inline-flex items-center rounded-lg bg-btn-primary px-6 py-3 text-sm font-medium text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle hover:bg-btn-primary-hover'
+              className='inline-flex items-center rounded-lg bg-btn-primary px-6 py-3 text-sm font-medium text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle ease-subtle hover:bg-btn-primary-hover'
             >
               Try {APP_NAME} Free
             </Link>

--- a/apps/web/app/(marketing)/compare/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/compare/[slug]/page.tsx
@@ -62,11 +62,11 @@ export default async function ComparePage({ params }: ComparePageProps) {
       <script type='application/ld+json'>{breadcrumbSchema}</script>
 
       <MarketingHeroLayout variant='left'>
-        <p className='marketing-kicker'>Compare</p>
-        <h1 className='marketing-h1-linear mt-6 max-w-[20ch] text-primary-token'>
+        <p className='text-sm font-medium text-tertiary-token'>Compare</p>
+        <h1 className='mt-6 max-w-2xl text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
           {data.heroHeadline}
         </h1>
-        <p className='mt-6 max-w-[60ch] text-lg leading-relaxed text-secondary-token'>
+        <p className='mt-6 max-w-2xl text-lg leading-relaxed text-secondary-token'>
           {data.heroSubheadline}
         </p>
       </MarketingHeroLayout>
@@ -119,7 +119,7 @@ export default async function ComparePage({ params }: ComparePageProps) {
                       {feature.jovie ? (
                         <Check
                           aria-label='Yes'
-                          className='mx-auto h-4 w-4 text-green-400'
+                          className='mx-auto h-4 w-4 text-accent-green'
                         />
                       ) : (
                         <Minus
@@ -132,7 +132,7 @@ export default async function ComparePage({ params }: ComparePageProps) {
                       {feature.competitor ? (
                         <Check
                           aria-label='Yes'
-                          className='mx-auto h-4 w-4 text-green-400'
+                          className='mx-auto h-4 w-4 text-accent-green'
                         />
                       ) : (
                         <Minus
@@ -161,7 +161,7 @@ export default async function ComparePage({ params }: ComparePageProps) {
           <div className='mt-8'>
             <Link
               href={APP_ROUTES.SIGNUP}
-              className='inline-flex items-center rounded-lg border border-(--linear-btn-primary-border) bg-btn-primary px-6 py-3 text-sm font-medium text-btn-primary-foreground shadow-button-inset hover:border-(--linear-btn-primary-hover) hover:bg-(--linear-btn-primary-hover)'
+              className='inline-flex items-center rounded-lg bg-btn-primary px-6 py-3 text-sm font-medium text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle hover:bg-btn-primary-hover'
             >
               Try {APP_NAME} Free
             </Link>
@@ -170,7 +170,10 @@ export default async function ComparePage({ params }: ComparePageProps) {
       </MarketingContainer>
 
       {/* FAQ */}
-      <FaqSection items={data.faq} />
+      <FaqSection
+        items={data.faq}
+        headingClassName='text-2xl font-semibold tracking-tight text-primary-token'
+      />
     </>
   );
 }

--- a/apps/web/app/(marketing)/support/SupportContent.tsx
+++ b/apps/web/app/(marketing)/support/SupportContent.tsx
@@ -56,8 +56,8 @@ export function SupportChannels() {
   return (
     <MarketingContainer width='prose' className='pb-16'>
       <section>
-        <h2 className='marketing-h2-linear text-primary-token'>
-          How can we help?
+        <h2 className='text-2xl font-semibold tracking-tight text-primary-token'>
+          How Can We Help?
         </h2>
         <div className='mt-6 grid gap-6 sm:grid-cols-3'>
           {CHANNELS.map(channel => {
@@ -107,8 +107,8 @@ export function SupportCta() {
   return (
     <MarketingContainer width='prose' className='pb-24'>
       <section>
-        <h2 className='marketing-h2-linear text-primary-token'>
-          Still need help?
+        <h2 className='text-2xl font-semibold tracking-tight text-primary-token'>
+          Still Need Help?
         </h2>
         <p className='mt-4 text-base leading-relaxed text-secondary-token'>
           Our team is happy to help with anything not covered in the docs.

--- a/apps/web/app/(marketing)/support/page.tsx
+++ b/apps/web/app/(marketing)/support/page.tsx
@@ -65,17 +65,20 @@ export default function SupportPage() {
       <script type='application/ld+json'>{BREADCRUMB_SCHEMA}</script>
 
       <MarketingHeroLayout variant='left'>
-        <p className='marketing-kicker'>Support</p>
-        <h1 className='marketing-h1-linear mt-6 max-w-[10ch] text-primary-token'>
-          We&apos;re here to help.
+        <p className='text-sm font-medium text-tertiary-token'>Support</p>
+        <h1 className='mt-6 text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
+          We&apos;re Here To Help.
         </h1>
-        <p className='mt-6 max-w-[60ch] text-lg leading-relaxed text-secondary-token'>
+        <p className='mt-6 max-w-xl text-lg leading-relaxed text-secondary-token'>
           Browse our docs or reach out to our team.
         </p>
       </MarketingHeroLayout>
 
       <SupportChannels />
-      <FaqSection items={SUPPORT_FAQ_ITEMS} />
+      <FaqSection
+        items={SUPPORT_FAQ_ITEMS}
+        headingClassName='text-2xl font-semibold tracking-tight text-primary-token'
+      />
       <SupportCta />
     </>
   );

--- a/apps/web/app/(marketing)/support/page.tsx
+++ b/apps/web/app/(marketing)/support/page.tsx
@@ -66,7 +66,7 @@ export default function SupportPage() {
 
       <MarketingHeroLayout variant='left'>
         <p className='text-sm font-medium text-tertiary-token'>Support</p>
-        <h1 className='mt-6 text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
+        <h1 className='mt-6 text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl lg:text-6xl'>
           We&apos;re Here To Help.
         </h1>
         <p className='mt-6 max-w-xl text-lg leading-relaxed text-secondary-token'>

--- a/apps/web/app/(marketing)/voice/page.tsx
+++ b/apps/web/app/(marketing)/voice/page.tsx
@@ -183,7 +183,7 @@ export default function VoiceLandingPage() {
       </section>
 
       {/* Final CTA band */}
-      <section className='border-t border-subtle bg-surface-1 py-14 text-primary-token'>
+      <section className='border-t border-subtle bg-surface-0 py-14 text-primary-token'>
         <div className={sectionWrapClassName}>
           <div className='mx-auto flex max-w-2xl flex-col items-center gap-4 text-center'>
             <h2 className='text-3xl font-semibold tracking-tight'>

--- a/apps/web/app/(marketing)/voice/page.tsx
+++ b/apps/web/app/(marketing)/voice/page.tsx
@@ -73,9 +73,9 @@ export default function VoiceLandingPage() {
         primaryCtaTestId='voice-hero-primary-cta'
         secondaryCtaLabel='See pricing'
         secondaryCtaHref={APP_ROUTES.PRICING}
-        subcopy='Free tier available • 2 min to first clone'
+        subcopy='Free tier available. 2 min to first clone.'
         proofPoints={[
-          'YouTube → trained model',
+          'YouTube to trained model',
           'ElevenLabs powered',
           'Consent logged',
           'Works in replies & promos',
@@ -87,7 +87,7 @@ export default function VoiceLandingPage() {
         <div className={sectionWrapClassName}>
           <div className='mx-auto max-w-3xl text-center'>
             <p className='homepage-section-eyebrow'>Four steps</p>
-            <h2 className='marketing-h2-linear mt-3 text-primary-token'>
+            <h2 className='mt-3 text-2xl font-semibold tracking-tight text-primary-token'>
               Your Voice. Trained. Ready.
             </h2>
             <p className='mt-3 text-mid leading-7 text-secondary-token'>
@@ -123,7 +123,7 @@ export default function VoiceLandingPage() {
                 key={step.n}
                 className='rounded-3xl border border-subtle bg-base p-6'
               >
-                <div className='text-xs font-mono tracking-[3px] text-tertiary-token'>
+                <div className='text-xs font-mono tracking-widest text-tertiary-token'>
                   {step.n}
                 </div>
                 <h3 className='mt-3 text-lg font-semibold text-primary-token'>
@@ -146,15 +146,15 @@ export default function VoiceLandingPage() {
               <h3 className='text-xl font-semibold'>
                 Built For Creators Who Care About Consent.
               </h3>
-              <ul className='mt-6 space-y-3 text-mid leading-7 text-secondary-token'>
-                <li>• Explicit opt-in recorded before any training run.</li>
+              <ul className='mt-6 list-disc space-y-3 pl-5 text-mid leading-7 text-secondary-token'>
+                <li>Explicit opt-in recorded before any training run.</li>
                 <li>
-                  • Models stay private to your account until you publish a
-                  voice drop.
+                  Models stay private to your account until you publish a voice
+                  drop.
                 </li>
-                <li>• Delete or re-train anytime. No lock-in.</li>
+                <li>Delete or re-train anytime. No lock-in.</li>
                 <li>
-                  • Same async job + webhook pattern used for video and other
+                  Same async job + webhook pattern used for video and other
                   heavy skills.
                 </li>
               </ul>
@@ -174,8 +174,8 @@ export default function VoiceLandingPage() {
                 </Link>
               </div>
               <p className='mt-4 text-xs text-tertiary-token'>
-                Voice infrastructure shipped in PR#9882 (YouTube→ElevenLabs) +
-                webhook/cron layer PR#9881.
+                Voice infrastructure shipped in PR 9882 (YouTube to ElevenLabs)
+                + webhook/cron layer PR 9881.
               </p>
             </div>
           </div>
@@ -183,13 +183,13 @@ export default function VoiceLandingPage() {
       </section>
 
       {/* Final CTA band */}
-      <section className='border-t border-subtle bg-black dark:bg-black py-14 text-white dark:text-white'>
+      <section className='border-t border-subtle bg-surface-1 py-14 text-primary-token'>
         <div className={sectionWrapClassName}>
           <div className='mx-auto flex max-w-2xl flex-col items-center gap-4 text-center'>
             <h2 className='text-3xl font-semibold tracking-tight'>
               Ready To Sound Like You — Everywhere?
             </h2>
-            <p className='text-white/70'>
+            <p className='text-secondary-token'>
               The same voice that fans already know, now available on demand.
             </p>
             <Link
@@ -199,8 +199,8 @@ export default function VoiceLandingPage() {
             >
               Clone my voice now
             </Link>
-            <span className='text-xs text-white/50'>
-              Free tier • Cancel anytime • No card required
+            <span className='text-xs text-tertiary-token'>
+              Free tier. Cancel anytime. No card required.
             </span>
           </div>
         </div>

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 2228
+  "count": 2216
 }

--- a/apps/web/tests/unit/marketing/about-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/about-system-b-style-guard.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /about System B source contract. Part of the founder-directed System A ->
+ * System B marketing migration (DESIGN.md 2026-06-18). See the /support and
+ * download guards for the shared contract: named System B token utilities only,
+ * no arbitrary values / hex / rgba / gradients / raw color scales / inline
+ * styles / System A editorial type classes in the route's own source.
+ */
+
+const sources = ['app/(marketing)/about/page.tsx'] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('about page System B source contract', () => {
+  it('keeps /about visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/apps/web/tests/unit/marketing/alternatives-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/alternatives-system-b-style-guard.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /alternatives/[slug] System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped support/about guards: the
+ * route's own source must carry no arbitrary Tailwind values, hex/rgba/gradient
+ * colors, raw color scales, inline styles, --linear-* CTA tokens, or the
+ * System A editorial type classes (marketing-*-linear / marketing-kicker).
+ * Named System B token utilities only. The .linear-marketing bridge
+ * (layout-owned) stays until the final coordinated teardown; this guard only
+ * governs the page's own files. The content/alternatives/* data is pure copy,
+ * not visual, so it is intentionally out of scope.
+ */
+
+const sources = ['app/(marketing)/alternatives/[slug]/page.tsx'] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+  // System A editorial type classes — retired on this surface.
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('alternatives page System B source contract', () => {
+  it('keeps /alternatives/[slug] visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/apps/web/tests/unit/marketing/blog-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/blog-system-b-style-guard.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /blog (index) System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped support/pricing guards: the
+ * route's own source must carry no arbitrary Tailwind values, hex/rgba/gradient
+ * colors, raw color scales, inline styles, or the System A editorial type
+ * classes (marketing-*-linear / marketing-kicker). Named System B token
+ * utilities only. The .linear-marketing bridge (layout-owned) stays until the
+ * final coordinated teardown; this guard only governs the page's own files.
+ *
+ * Scope: the blog INDEX page only. blog/[slug], blog/authors, and blog/category
+ * are separate routes and share BlogCard + the marketing components, so those
+ * files are intentionally excluded here.
+ */
+
+const sources = ['app/(marketing)/blog/page.tsx'] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+  // System A editorial type classes — retired on this surface.
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('blog index page System B source contract', () => {
+  it('keeps /blog visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/apps/web/tests/unit/marketing/changelog-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/changelog-system-b-style-guard.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /changelog System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped support/download/pricing guards:
+ * the route's own source must carry no arbitrary Tailwind values,
+ * hex/rgba/gradient colors, raw color scales, inline styles, or the System A
+ * editorial type classes (marketing-*-linear / marketing-kicker). Named
+ * System B token utilities only. The .linear-marketing bridge (layout-owned)
+ * stays until the final coordinated teardown; this guard only governs the
+ * page's own files.
+ */
+
+const sources = [
+  'app/(marketing)/changelog/page.tsx',
+  'app/(marketing)/changelog/ChangelogEmailSignup.tsx',
+  'app/(marketing)/changelog/loading.tsx',
+] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+  // System A editorial type classes — retired on this surface.
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('changelog page System B source contract', () => {
+  it('keeps /changelog visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/apps/web/tests/unit/marketing/compare-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/compare-system-b-style-guard.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /compare/[slug] System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped support/download/pricing guards:
+ * the route's own source must carry no arbitrary Tailwind values, hex/rgba/
+ * gradient colors, raw color scales, inline styles, or the System A editorial
+ * type classes (marketing-*-linear / marketing-kicker). Named System B token
+ * utilities only. The .linear-marketing bridge (layout-owned) and shared
+ * marketing components (MarketingHeroLayout / MarketingContainer / FaqSection /
+ * ClientFaqAccordion) stay until the final coordinated teardown; this guard
+ * only governs the page's own files.
+ */
+
+const sources = ['app/(marketing)/compare/[slug]/page.tsx'] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+  // System A editorial type classes — retired on this surface.
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('compare page System B source contract', () => {
+  it('keeps /compare/[slug] visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/apps/web/tests/unit/marketing/support-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/support-system-b-style-guard.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /support System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped download/pricing guards: the
+ * route's own source must carry no arbitrary Tailwind values, hex/rgba/gradient
+ * colors, raw color scales, inline styles, or the System A editorial type
+ * classes (marketing-*-linear / marketing-kicker). Named System B token
+ * utilities only. The .linear-marketing bridge (layout-owned) stays until the
+ * final coordinated teardown; this guard only governs the page's own files.
+ */
+
+const sources = [
+  'app/(marketing)/support/page.tsx',
+  'app/(marketing)/support/SupportContent.tsx',
+] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+  // System A editorial type classes — retired on this surface.
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('support page System B source contract', () => {
+  it('keeps /support visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/apps/web/tests/unit/marketing/voice-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/voice-system-b-style-guard.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /voice System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped support/about/download guards:
+ * the route's own source must carry no arbitrary Tailwind values,
+ * hex/rgba/gradient colors, raw color scales, inline styles, or the System A
+ * editorial type classes (marketing-*-linear / marketing-kicker). Named System
+ * B token utilities only. The .linear-marketing bridge (layout-owned) stays
+ * until the final coordinated teardown; this guard only governs the page's own
+ * files. Shared components (SharedMarketingHero, VoiceDemoVisual,
+ * LandingCTAButton) live outside app/(marketing)/voice/ and are intentionally
+ * not scanned here.
+ */
+
+const sources = ['app/(marketing)/voice/page.tsx'] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+  // System A editorial type classes — retired on this surface.
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('voice page System B source contract', () => {
+  it('keeps /voice visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

Advances the founder-directed **System A → System B** marketing migration (DESIGN.md 2026-06-18) by reskinning 7 remaining holdout editorial surfaces onto System B token discipline, each locked by a per-page `*-system-b-style-guard` test.

Pages migrated: **/support, /about, /voice, /changelog, /compare/[slug], /alternatives/[slug], /blog** (index).

## How

Token/utility hygiene on **route-owned source only** — layouts + copy preserved, the `.linear-marketing` layout bridge stays (it still supplies the dark palette + Satoshi heading face) until the final coordinated teardown:

- System A editorial classes (`marketing-h1-linear` / `marketing-h2-linear` / `marketing-kicker` / `marketing-lead-linear`) → named System B type utilities
- arbitrary Tailwind values (`max-w-[10ch]`, `tracking-[3px]`, …) → named utilities
- raw color scales (`bg-black`, `text-white`, `emerald-500`/`red-500`/`amber-500`) → System B tokens (`bg-surface-*`, `text-*-token`, `bg-accent-*-subtle`, `text-accent-*`)
- inline `style={}` + `--linear-*` vars → token utilities
- decorative glyph bullets/arrows → `list-disc` / plain copy
- touched headings brought to canonical Title Case (`@jovie/canonical-ui-label-casing`); `ui-casing-allow` added to brand-name metadata sentences + semver badges

Each page follows the shipped precedent (pricing / download / launch). **Zero shared-file edits** — only page-local files + 7 new guard tests.

## Registry alignment

`apps/web/data/marketing/routeManifest.ts` **already binds all 28 marketing routes** to a recipe or a sanctioned exemption — that part is complete. Recipe-composable pages emitting 1:1 `data-testid="marketing-section-{id}"` sections matching `recipe.sectionOrder` is the deferred **JOV-4065** render-time-verification follow-up (explicitly non-blocking per ARCHITECTURE.md §13).

## Not in this PR (follow-ups)

- **`/artist-profiles`** (the `artist-lp` reference route, `ArtistProfileLandingRoute`, ~30 files / ~260 token violations) — the flagship identity surface. Its own effort + taste review; too large for this PR's scope/size cap.
- **Final `.linear-marketing` teardown** — drop the bridge from `app/(marketing)/layout.tsx`, retire the shared `marketing-*-linear` editorial classes + `--linear-*` tokens, shrink `singular-system-b-ratchet` allowlist to empty. Blocked on all pages (incl. flagship) migrating first.
- **Shared-component residue** left untouched per ownership rules: `VoiceDemoVisual` (features/landing), `FaqSection` default heading, `ClientFaqAccordion` inline style, the `public-action-primary` CTA bridge.

> ⚠️ Linear MCP token is expired in this session — the three follow-ups above still need Linear issues filed (or GitHub issues if preferred).

## Verification

- 7 new + 3 existing marketing System B guards: **19/19 pass**
- `singular-system-b-ratchet`, `recipe-manifest` (33), `marketing-static-flags`, `static-revalidate-policy`: **all pass**
- `typecheck` exit 0 · Biome + ESLint clean · pre-commit hook (gitleaks/trufflehog/typecheck) green

## Screenshots

Token-preserving swaps (no layout/redesign) — verified via diff review. Marketing is public, so visual QA via the preview deploy is the recommended check; I can capture before/after once the preview URL is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)