### PR TITLE
fix(design-system): heal raw-button + touch-target ratchets via Button conversions (JOV-4157)

### DIFF
--- a/apps/web/app/investor-portal/_components/InvestorNav.tsx
+++ b/apps/web/app/investor-portal/_components/InvestorNav.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { Menu, X } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -86,23 +87,22 @@ export function InvestorNav({ investorName, pages }: InvestorNavProps) {
 
       {/* Mobile header bar */}
       <header className='fixed left-0 right-0 top-0 z-40 flex items-center justify-between border-b border-subtle bg-base px-4 py-3 lg:hidden'>
-        <span className='text-[length:var(--text-base)] font-bold text-primary-token'>
-          Jovie
-        </span>
+        <span className='text-base font-bold text-primary-token'>Jovie</span>
         <div className='flex items-center gap-3'>
           {investorName && (
             <span className='text-[length:var(--text-xs)] text-tertiary-token'>
               For {investorName}
             </span>
           )}
-          <button
-            type='button'
+          <Button
+            variant='ghost'
+            size='icon'
             onClick={toggleSheet}
             aria-expanded={isOpen}
             aria-controls='mobile-nav'
             aria-label={isOpen ? 'Close Navigation' : 'Open Navigation'}
             className={cn(
-              'flex h-8 w-8 items-center justify-center rounded',
+              'h-8 w-8 rounded',
               'text-secondary-token hover:bg-interactive-hover',
               'focus-ring-themed transition-colors'
             )}
@@ -112,7 +112,7 @@ export function InvestorNav({ investorName, pages }: InvestorNavProps) {
             ) : (
               <Menu className='h-4 w-4' aria-hidden='true' />
             )}
-          </button>
+          </Button>
         </div>
       </header>
 
@@ -147,18 +147,19 @@ export function InvestorNav({ investorName, pages }: InvestorNavProps) {
                   </p>
                 )}
               </div>
-              <button
-                type='button'
+              <Button
+                variant='ghost'
+                size='icon'
                 onClick={() => setIsOpen(false)}
                 aria-label='Close Navigation'
                 className={cn(
-                  'flex h-8 w-8 items-center justify-center rounded',
+                  'h-8 w-8 rounded',
                   'text-secondary-token hover:bg-interactive-hover',
                   'focus-ring-themed transition-colors'
                 )}
               >
                 <X className='h-4 w-4' aria-hidden='true' />
-              </button>
+              </Button>
             </div>
 
             {navLinks}
@@ -183,7 +184,7 @@ function NavItem({
       <Link
         href={href}
         aria-current={isActive ? 'page' : undefined}
-        className={`block rounded-(--radius-sm) px-2 py-1.5 text-[length:var(--text-app)] font-medium transition-colors ${
+        className={`block rounded-(--radius-sm) px-2 py-1.5 text-app font-medium transition-colors ${
           isActive
             ? 'bg-interactive-hover text-primary-token'
             : 'text-tertiary-token hover:bg-interactive-hover hover:text-secondary-token'

--- a/apps/web/app/investor-portal/_components/InvestorThemeToggle.tsx
+++ b/apps/web/app/investor-portal/_components/InvestorThemeToggle.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { MoonStar, SunMedium } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { cn } from '@/lib/utils';
@@ -24,16 +25,17 @@ export function InvestorThemeToggle({
   const Icon = isLight ? MoonStar : SunMedium;
 
   return (
-    <button
-      type='button'
+    <Button
+      variant='ghost'
+      size='icon'
       onClick={handleToggle}
       aria-label={isLight ? 'Switch to dark mode' : 'Switch to light mode'}
       className={cn(
-        'focus-ring-themed flex h-8 w-8 items-center justify-center rounded-full border border-subtle text-secondary-token transition-colors hover:border-default hover:bg-surface-1 hover:text-primary-token',
+        'focus-ring-themed h-8 w-8 rounded-full border border-subtle text-secondary-token transition-colors hover:border-default hover:bg-surface-1 hover:text-primary-token',
         isLight && 'bg-surface-1 text-primary-token'
       )}
     >
       <Icon className='h-4 w-4' aria-hidden='true' />
-    </button>
+    </Button>
   );
 }

--- a/apps/web/components/features/admin/OperatorBanner.tsx
+++ b/apps/web/components/features/admin/OperatorBanner.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { QueryClient, QueryClientContext } from '@tanstack/react-query';
 import { AlertTriangle, X } from 'lucide-react';
 import { useContext, useEffect, useMemo, useState } from 'react';
@@ -101,14 +102,15 @@ export function OperatorBanner({
             )}
           </span>
         </div>
-        <button
+        <Button
           type='button'
+          variant='ghost'
           onClick={handleDismiss}
-          className='rounded p-1 transition-colors hover:bg-amber-600/20'
-          aria-label='Dismiss environment warning'
+          className='h-auto w-auto rounded p-1 text-amber-950 transition-colors hover:bg-amber-600/20'
+          aria-label='Dismiss Environment Warning'
         >
           <X className='size-3.5' />
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/components/features/admin/TimActionRequiredSection.tsx
+++ b/apps/web/components/features/admin/TimActionRequiredSection.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { Check, ExternalLink } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from '@/components/feedback';
@@ -34,7 +35,7 @@ const PRIORITY_CONFIG: Record<number, { label: string; className: string }> = {
 };
 
 const DEFAULT_PRIORITY_CONFIG = {
-  label: 'No priority',
+  label: 'No Priority',
   className: 'bg-zinc-500/15 text-zinc-400 border border-zinc-500/20',
 };
 
@@ -101,15 +102,16 @@ function ActionRow({ issue, onClose, isClosing }: Readonly<ActionRowProps>) {
       <DaysOldBadge daysOld={issue.daysOld} />
 
       {/* Quick-mark-done */}
-      <button
+      <Button
         type='button'
+        variant='secondary'
         onClick={() => void onClose(issue.id)}
         disabled={isClosing}
         aria-label={`Mark "${issue.title}" as done`}
-        className='shrink-0 rounded-lg border border-subtle bg-surface-1 p-1.5 text-tertiary-token transition-colors hover:border-warning/30 hover:bg-warning/10 hover:text-warning disabled:cursor-not-allowed disabled:opacity-40'
+        className='h-auto w-auto shrink-0 rounded-lg border border-subtle bg-surface-1 p-1.5 text-tertiary-token transition-colors hover:border-warning/30 hover:bg-warning/10 hover:text-warning disabled:cursor-not-allowed disabled:opacity-40'
       >
         <Check className='h-3.5 w-3.5' aria-hidden='true' />
-      </button>
+      </Button>
     </ShellListRowFrame>
   );
 }

--- a/apps/web/components/features/dev/DevToolbar.tsx
+++ b/apps/web/components/features/dev/DevToolbar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import * as Switch from '@radix-ui/react-switch';
 import {
   type QueryClient,
@@ -723,17 +724,18 @@ export function DevToolbar({
 
   if (hidden) {
     return (
-      <button
+      <Button
         type='button'
+        variant='ghost'
         onClick={show}
         data-testid='dev-toolbar'
-        className='fixed bottom-3 right-3 z-[9999] flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-default bg-surface-1 text-(--color-text-tertiary) hover:text-(--color-text-primary) hover:border-default shadow-md font-mono text-3xs transition-colors'
+        className='fixed bottom-3 right-3 z-[9999] h-auto gap-1.5 px-2.5 py-1.5 rounded-lg border border-default bg-surface-1 text-(--color-text-tertiary) hover:text-(--color-text-primary) hover:border-default shadow-md font-mono text-3xs transition-colors'
         aria-label='Show Dev Toolbar'
         title='Show Dev Toolbar (⌘⇧D)'
       >
         <Wrench size={11} />
         Dev
-      </button>
+      </Button>
     );
   }
 
@@ -768,14 +770,15 @@ export function DevToolbar({
               aria-label='Search Flags'
             />
             {search && (
-              <button
+              <Button
                 type='button'
+                variant='ghost'
                 onClick={() => setSearch('')}
-                className='shrink-0 text-quaternary-token hover:text-(--color-text-primary) transition-colors'
+                className='h-auto w-auto shrink-0 p-0 text-quaternary-token hover:bg-transparent hover:text-(--color-text-primary) transition-colors'
                 aria-label='Clear Search'
               >
                 <X size={11} />
-              </button>
+              </Button>
             )}
             <span className='shrink-0 text-3xs text-quaternary-token'>
               {matchCount} of {filteredFlags.total}
@@ -791,13 +794,14 @@ export function DevToolbar({
                   <span className='text-3xs font-semibold uppercase tracking-wide text-accent'>
                     Overrides ({filteredFlags.overridden.length})
                   </span>
-                  <button
+                  <Button
                     type='button'
+                    variant='link'
                     onClick={overridesCtx.clearOverrides}
                     className='text-3xs text-(--color-text-tertiary) hover:text-(--color-text-primary) underline transition-colors'
                   >
-                    clear all
-                  </button>
+                    Clear All
+                  </Button>
                 </div>
                 <div className='flex flex-col gap-0.5'>
                   {filteredFlags.overridden.map(flag => (
@@ -882,28 +886,30 @@ export function DevToolbar({
 
         {/* Override badge */}
         {overrideCount > 0 && (
-          <button
+          <Button
             type='button'
+            variant='ghost'
             onClick={() => {
               if (!open) toggleOpen();
             }}
-            className='px-2 py-0.5 rounded-full text-3xs font-medium bg-accent/10 text-accent border border-accent/30 shrink-0 hover:bg-accent/20 transition-colors cursor-pointer'
+            className='h-auto px-2 py-0.5 rounded-full text-3xs font-medium bg-accent/10 text-accent border border-accent/30 shrink-0 hover:bg-accent/20 transition-colors cursor-pointer'
             title='View overrides'
           >
             {overrideCount} {overrideCount === 1 ? 'override' : 'overrides'}
-          </button>
+          </Button>
         )}
 
         <span className='max-md:hidden md:inline px-1.5 py-0.5 rounded text-3xs text-quaternary-token bg-surface-2 shrink-0'>
           {breakpoint}
         </span>
 
-        <button
+        <Button
           type='button'
+          variant='ghost'
           aria-pressed={designV1Enabled}
           title='Toggle New Design (DESIGN_V1)'
           onClick={toggleDesignV1}
-          className={`inline-flex shrink-0 items-center gap-1 px-1.5 py-1 rounded text-3xs transition-colors ${
+          className={`h-auto shrink-0 gap-1 px-1.5 py-1 rounded text-3xs transition-colors ${
             designV1Enabled
               ? 'text-accent bg-accent/10 hover:bg-accent/15'
               : 'text-quaternary-token hover:text-(--color-text-primary) hover:bg-surface-2'
@@ -913,18 +919,19 @@ export function DevToolbar({
           {designV1Overridden && (
             <span className='text-3xs opacity-70'>(override)</span>
           )}
-        </button>
+        </Button>
 
         <div className='flex-1' />
 
         {/* Quick actions */}
         <div className='flex items-center gap-0.5'>
           {/* Flag badges toggle */}
-          <button
+          <Button
             type='button'
+            variant='ghost'
             onClick={() => flagBadgeCtx?.toggleBadges()}
             title={`${flagBadgeCtx?.showBadges ? 'Hide' : 'Show'} flag badges (⌘⇧F)`}
-            className={`p-1.5 rounded transition-colors ${
+            className={`h-auto w-auto p-1.5 rounded transition-colors ${
               flagBadgeCtx?.showBadges
                 ? 'text-accent bg-accent/10'
                 : 'text-quaternary-token hover:text-(--color-text-primary) hover:bg-surface-2'
@@ -932,7 +939,7 @@ export function DevToolbar({
             aria-label='Toggle Flag Badges'
           >
             <Flag size={12} />
-          </button>
+          </Button>
 
           <div className='w-px h-4 mx-1 bg-subtle' />
 
@@ -961,30 +968,32 @@ export function DevToolbar({
           <div className='w-px h-4 mx-1 bg-subtle' />
 
           {sha && (
-            <button
+            <Button
               type='button'
+              variant='ghost'
               onClick={() => copyToClipboard(sha, 'sha')}
               title={`Copy SHA: ${sha}`}
-              className='flex items-center gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-(--color-text-primary) hover:bg-surface-2 transition-colors'
+              className='h-auto gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-(--color-text-primary) hover:bg-surface-2 transition-colors'
               aria-label='Copy SHA'
             >
               <CopyFieldIcon copied={copiedField === 'sha'} icon={Copy} />
               <span className='max-sm:hidden sm:inline text-3xs'>SHA</span>
-            </button>
+            </Button>
           )}
 
-          <button
+          <Button
             type='button'
+            variant='ghost'
             onClick={() =>
               copyToClipboard(globalThis.location.pathname, 'route')
             }
             title={`Copy Route: ${globalThis.window === undefined ? '' : globalThis.location.pathname}`}
-            className='flex items-center gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-(--color-text-primary) hover:bg-surface-2 transition-colors'
+            className='h-auto gap-1 px-1.5 py-1 rounded text-quaternary-token hover:text-(--color-text-primary) hover:bg-surface-2 transition-colors'
             aria-label='Copy Route'
           >
             <CopyFieldIcon copied={copiedField === 'route'} icon={Route} />
             <span className='max-sm:hidden sm:inline text-3xs'>Route</span>
-          </button>
+          </Button>
 
           {designV1Enabled && (
             <Link

--- a/apps/web/eslint-rules/canonical-ui-label-casing-utils.js
+++ b/apps/web/eslint-rules/canonical-ui-label-casing-utils.js
@@ -40,6 +40,7 @@ const BRAND_WORDS = new Set([
   'Instagram',
   'iOS',
   'Jovie',
+  'Linear',
   'LinkedIn',
   'SoundCloud',
   'Spotify',

--- a/apps/web/tests/unit/design-system/raw-button.baseline.json
+++ b/apps/web/tests/unit/design-system/raw-button.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 722,
-  "note": "Raw <button> tags in apps/web/{components,app}. Ratchet only goes down — lower this when a PR converts raw buttons to the canonical Button. 725→722 on 2026-07-09 (fix/main-green-neon-visual): convert Banner action/dismiss + CookieSettingsFooterButton raw <button>s to @jovie/ui Button."
+  "count": 713,
+  "note": "Raw <button> tags in apps/web/{components,app}. Ratchet only goes down \u2014 lower this when a PR converts raw buttons to the canonical Button. 722\u2192713 on 2026-07-09 (JOV-4157/JOV-3479): NOTE main actually counted 726 (the 722 stamp from #13814 predated 4 racing merges); this wave converted 13 (DevToolbar\u00d78, OperatorBanner, TimActionRequiredSection, InvestorNav\u00d72, InvestorThemeToggle) landing at 713."
 }

--- a/apps/web/tests/unit/dev/DevToolbar.test.tsx
+++ b/apps/web/tests/unit/dev/DevToolbar.test.tsx
@@ -517,7 +517,7 @@ describe('DevToolbar', () => {
       localStorage.setItem(TOOLBAR_OPEN_KEY, '1');
       renderToolbar();
 
-      expect(screen.getByText('clear all')).toBeInTheDocument();
+      expect(screen.getByText('Clear All')).toBeInTheDocument();
     });
 
     it('clears all overrides when clear all is clicked', () => {
@@ -525,7 +525,7 @@ describe('DevToolbar', () => {
       localStorage.setItem(TOOLBAR_OPEN_KEY, '1');
       renderToolbar();
 
-      fireEvent.click(screen.getByText('clear all'));
+      fireEvent.click(screen.getByText('Clear All'));
       expect(localStorage.getItem(FF_OVERRIDES_KEY)).toBeNull();
     });
 

--- a/apps/web/touch-target-ratchet.baseline.json
+++ b/apps/web/touch-target-ratchet.baseline.json
@@ -1,4 +1,4 @@
 {
-  "_comment": "Touch-target ratchet baseline \u2014 interactive elements with explicit sub-44px heights (scripts/lint-touch-target.mjs). Ratchet only goes down: fix elements (min 44px hit area, WCAG 2.5.5), then run `node scripts/lint-touch-target.mjs --update`.",
-  "count": 226
+  "_comment": "Touch-target ratchet baseline — interactive elements with explicit sub-44px heights (scripts/lint-touch-target.ts). Ratchet only goes down: fix elements (min 44px hit area, WCAG 2.5.5), then run `pnpm --filter web run lint:touch-target -- --update`.",
+  "count": 225
 }


### PR DESCRIPTION
## Summary
Heals **main's red Unit Tests lane**: two design-system ratchets regressed via a merge race today — raw-button count on main is actually **726 vs baseline 722** (the 722 stamp from #13814 predated 4 racing merges), and touch-target is **228 vs 226**.

- Convert **13 raw `<button>` → canonical `Button`** (`@jovie/ui`): DevToolbar ×8, OperatorBanner, TimActionRequiredSection, InvestorNav ×2, InvestorThemeToggle — all internal/investor surfaces, visuals preserved via `className` overrides; Button's built-in pseudo-element hit area resolves the WCAG 2.5.5 targets.
- Lower baselines: raw-button **722→713**, touch-target **226→225**.
- Add `Linear` to the casing rule's `BRAND_WORDS` (rule flagged "Marked as done in Linear" with Found==Expected — unsatisfiable without the brand entry) + 3 Title Case label fixes the conversions exposed.

Part of JOV-4157; progresses JOV-3479.

## Verification
- `vitest run tests/unit/design-system` — 14/14 files, 47/47 tests pass (both previously-failing ratchets green)
- `pnpm --filter @jovie/web run typecheck` — clean
- Biome clean; adversarial behavior-preservation review (Opus lens) found zero prop/handler/a11y regressions

bug-to-test: the ratchet tests themselves are the regression guard (they fail on the pre-PR state, pass after).

## Cost Impact
None — no external API calls, no scheduled work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
