### PR TITLE
fix(design-system): converge marketing + home surfaces to tokens (JOV-4157)

### DIFF
--- a/apps/web/components/features/home/ArtistProfileModesShowcase.tsx
+++ b/apps/web/components/features/home/ArtistProfileModesShowcase.tsx
@@ -11,7 +11,7 @@ export function ArtistProfileModesShowcase() {
 
   return (
     <div className='grid gap-6 lg:grid-cols-[10rem_15.5rem] lg:justify-end lg:gap-8 lg:items-center'>
-      <div className='order-2 lg:order-1 lg:w-[10rem]'>
+      <div className='order-2 lg:order-1 lg:w-40'>
         <div className='flex flex-wrap gap-2 lg:flex-col lg:items-start'>
           {PHONE_SHOWCASE_MODES.map((mode, index) => {
             const isActive = index === activeIndex;
@@ -35,13 +35,13 @@ export function ArtistProfileModesShowcase() {
           })}
         </div>
 
-        <p className='mt-3 max-w-[9rem] pl-1 text-2xs leading-5 text-tertiary-token'>
+        <p className='mt-3 max-w-36 pl-1 text-2xs leading-5 text-tertiary-token'>
           {activeMode?.summary}
         </p>
       </div>
 
       <div className='order-1 flex justify-center lg:order-2 lg:justify-end'>
-        <div className='w-[13.5rem] sm:w-[14rem] lg:w-[15.5rem]'>
+        <div className='w-54 sm:w-56 lg:w-62'>
           <PhoneShowcase
             activeIndex={activeIndex}
             onIndexChange={setActiveIndex}

--- a/apps/web/components/features/home/AudienceCRMSection.tsx
+++ b/apps/web/components/features/home/AudienceCRMSection.tsx
@@ -42,7 +42,7 @@ export function AudienceCRMSection() {
           title='Audience'
         />
         {/* Bottom gradient fade */}
-        <div className='pointer-events-none absolute inset-x-0 bottom-0 z-20 h-40 bg-linear-to-t from-[var(--linear-bg-surface-0)] to-transparent' />
+        <div className='pointer-events-none absolute inset-x-0 bottom-0 z-20 h-40 bg-linear-to-t from-(--linear-bg-surface-0) to-transparent' />
       </div>
     </NumberedSection>
   );

--- a/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
+++ b/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
@@ -100,7 +100,7 @@ export function AutomaticReleaseSmartlinksSection() {
                     <div className='w-3 h-3 rounded-full bg-(--color-accent-orange) border border-black/10' />
                     <div className='w-3 h-3 rounded-full bg-(--color-accent-green) border border-black/10' />
                   </div>
-                  <div className='flex-1 text-center text-[var(--linear-caption-size)] text-tertiary-token'>
+                  <div className='flex-1 text-center text-(--linear-caption-size) text-tertiary-token'>
                     Jovie Dashboard
                   </div>
                   <div className='w-13' />
@@ -179,7 +179,7 @@ export function AutomaticReleaseSmartlinksSection() {
 
                   {/* Release info */}
                   <div className='mt-4 w-full text-center'>
-                    <h3 className='text-lg font-[var(--linear-font-weight-semibold)] leading-snug tracking-tight'>
+                    <h3 className='text-lg font-(--linear-font-weight-semibold) leading-snug tracking-tight'>
                       The Deep End
                     </h3>
                     <p className='mt-1 text-sm text-secondary-token'>
@@ -213,7 +213,7 @@ export function AutomaticReleaseSmartlinksSection() {
                   <div className='mt-3 pt-3 text-center'>
                     <span className='inline-flex items-center gap-1 text-2xs uppercase tracking-widest text-secondary-token'>
                       <span>Powered by</span>
-                      <span className='font-[var(--linear-font-weight-semibold)]'>
+                      <span className='font-(--linear-font-weight-semibold)'>
                         Jovie
                       </span>
                     </span>

--- a/apps/web/components/features/home/DashboardMockup.tsx
+++ b/apps/web/components/features/home/DashboardMockup.tsx
@@ -22,7 +22,7 @@ export function DashboardMockup({
 
   return (
     <div
-      className='relative overflow-hidden rounded-[0.95rem] md:rounded-[1rem]'
+      className='relative overflow-hidden rounded-[0.95rem] md:rounded-xl'
       style={{
         border: '1px solid var(--linear-border-subtle)',
         backgroundColor: 'var(--linear-bg-surface-0)',

--- a/apps/web/components/features/home/DeeplinksGrid.tsx
+++ b/apps/web/components/features/home/DeeplinksGrid.tsx
@@ -94,7 +94,7 @@ function StickyPhone({ activeIndex }: { readonly activeIndex: number }) {
         {MODES.map((mode, i) => (
           <div
             key={mode.id}
-            className='rounded-full transition-colors duration-[var(--linear-duration-slow)] ease-subtle'
+            className='rounded-full transition-colors duration-(--linear-duration-slow) ease-subtle'
             style={{
               width: i === activeIndex ? 16 : 6,
               height: 6,
@@ -275,10 +275,10 @@ export function DeeplinksGrid() {
               }}
             />
 
-            <div className='relative mx-auto max-w-[var(--linear-content-max)]'>
+            <div className='relative mx-auto max-w-(--linear-content-max)'>
               <div className='grid items-center grid-cols-[1fr_auto_1fr] gap-8 xl:gap-16'>
                 <div className='flex flex-col gap-6'>
-                  <span className='inline-flex items-center gap-1.5 self-start rounded-full px-3 py-1 text-xs font-medium tracking-[-0.01em] text-tertiary-token border border-subtle'>
+                  <span className='inline-flex items-center gap-1.5 self-start rounded-full px-3 py-1 text-xs font-medium tracking-tight text-tertiary-token border border-subtle'>
                     One profile. Every way fans support you.
                   </span>
 
@@ -322,7 +322,7 @@ export function DeeplinksGrid() {
                     {MODES.map((mode, i) => (
                       <div
                         key={mode.id}
-                        className='h-1 rounded-full transition-colors duration-[var(--linear-duration-slow)] ease-subtle'
+                        className='h-1 rounded-full transition-colors duration-(--linear-duration-slow) ease-subtle'
                         style={{
                           width: i === activeIndex ? 32 : 8,
                           backgroundColor:
@@ -341,7 +341,7 @@ export function DeeplinksGrid() {
                     href='https://jov.ie/tim'
                     target='_blank'
                     rel='noopener noreferrer'
-                    className='inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-[var(--linear-duration-normal)]'
+                    className='inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-(--linear-duration-normal)'
                     style={{
                       color: 'var(--linear-text-tertiary)',
                       border: '1px solid var(--linear-border-subtle)',
@@ -379,7 +379,7 @@ export function DeeplinksGrid() {
                       }}
                     >
                       <p
-                        className='font-mono tracking-[-0.02em]'
+                        className='font-mono tracking-tighter'
                         style={{
                           fontSize: i === activeIndex ? '20px' : '15px',
                           fontWeight: i === activeIndex ? 590 : 400,
@@ -436,9 +436,9 @@ export function DeeplinksGrid() {
             }}
           />
 
-          <div className='mx-auto max-w-[var(--linear-content-max)]'>
+          <div className='mx-auto max-w-(--linear-content-max)'>
             <div className='flex flex-col items-center text-center gap-6 mb-12'>
-              <span className='inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium tracking-[-0.01em] text-tertiary-token border border-subtle'>
+              <span className='inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium tracking-tight text-tertiary-token border border-subtle'>
                 One profile. Every way fans support you.
               </span>
               <h2 className='marketing-h2-linear text-primary-token'>

--- a/apps/web/components/features/home/EmailNotificationMockup.tsx
+++ b/apps/web/components/features/home/EmailNotificationMockup.tsx
@@ -30,7 +30,7 @@ export function EmailNotificationMockup() {
         {/* Email body — flex-1 so it stretches */}
         <div className='flex flex-1 flex-col justify-between px-4 pb-4 pt-3'>
           <div>
-            <p className='text-xs font-semibold tracking-[-0.01em] text-white dark:text-white'>
+            <p className='text-xs font-semibold tracking-tight text-white dark:text-white'>
               New music from Tim White
             </p>
             <p className='mt-2 text-2xs leading-[1.6] text-white/45'>
@@ -41,7 +41,7 @@ export function EmailNotificationMockup() {
 
           {/* CTA button — white */}
           <div className='mt-4 text-center'>
-            <div className='inline-flex items-center rounded-full bg-white dark:bg-surface-1 px-5 py-2 text-2xs font-semibold tracking-[-0.01em] text-black dark:text-white shadow-[0_2px_8px_rgba(255,255,255,0.1)]'>
+            <div className='inline-flex items-center rounded-full bg-white dark:bg-surface-1 px-5 py-2 text-2xs font-semibold tracking-tight text-black dark:text-white shadow-[0_2px_8px_rgba(255,255,255,0.1)]'>
               Listen now
             </div>
           </div>

--- a/apps/web/components/features/home/FeatureRow.tsx
+++ b/apps/web/components/features/home/FeatureRow.tsx
@@ -53,7 +53,7 @@ export function FeatureRow({
             </div>
 
             {/* Right: screenshot */}
-            <div className='homepage-surface-card overflow-hidden rounded-[1rem] md:rounded-[1.1rem]'>
+            <div className='homepage-surface-card overflow-hidden rounded-xl md:rounded-[1.1rem]'>
               <ProductScreenshot
                 src={screenshotSrc}
                 alt={screenshotAlt}

--- a/apps/web/components/features/home/FinalCTASection.tsx
+++ b/apps/web/components/features/home/FinalCTASection.tsx
@@ -30,6 +30,7 @@ export function FinalCTASection() {
             data-testid='final-cta-headline'
             className='marketing-h2-linear text-primary-token'
           >
+            {/* ui-casing-allow: marketing sentence-style headline */}
             Claim your handle.
           </h2>
 
@@ -44,7 +45,7 @@ export function FinalCTASection() {
             <ClaimHandleForm submitButtonTestId='final-cta-action' />
           </div>
 
-          <p className='mt-5 text-2xs tracking-[0.01em] text-quaternary-token'>
+          <p className='mt-5 text-2xs tracking-wide text-quaternary-token'>
             Be one of the first artists on Jovie.
           </p>
         </div>

--- a/apps/web/components/features/home/HeroCinematic.tsx
+++ b/apps/web/components/features/home/HeroCinematic.tsx
@@ -54,7 +54,7 @@ export function HeroCinematic({
                     {heroPrimaryAction}
                   </div>
 
-                  <p className='mt-3.5 text-2xs tracking-[0.01em] text-quaternary-token md:mt-4 lg:text-left'>
+                  <p className='mt-3.5 text-2xs tracking-wide text-quaternary-token md:mt-4 lg:text-left'>
                     Private launch access with your artist page and next release
                     ready to go.
                   </p>
@@ -90,7 +90,7 @@ export function HeroCinematic({
       />
       <div className='hero-glow pointer-events-none absolute inset-0 max-lg:hidden' />
 
-      <div className='relative z-10 mx-auto w-full max-w-[var(--linear-content-max)] px-5 pb-10 pt-8 sm:px-6 sm:pb-12 sm:pt-10 lg:hidden'>
+      <div className='relative z-10 mx-auto w-full max-w-(--linear-content-max) px-5 pb-10 pt-8 sm:px-6 sm:pb-12 sm:pt-10 lg:hidden'>
         <div className='max-w-[30rem] text-left'>
           <p className='homepage-section-eyebrow'>
             Built for independent artists
@@ -113,7 +113,7 @@ export function HeroCinematic({
             {heroPrimaryAction}
           </div>
 
-          <p className='mt-2.5 text-2xs tracking-[0.01em] text-quaternary-token sm:mt-3'>
+          <p className='mt-2.5 text-2xs tracking-wide text-quaternary-token sm:mt-3'>
             Private launch access with your artist page and next release ready
             to go.
           </p>
@@ -121,7 +121,7 @@ export function HeroCinematic({
       </div>
 
       <div className='relative z-10 max-lg:hidden min-h-0 flex-1 items-center justify-center w-full lg:flex'>
-        <div className='mx-auto w-full max-w-[var(--linear-content-max)] px-5 sm:px-6 lg:px-0'>
+        <div className='mx-auto w-full max-w-(--linear-content-max) px-5 sm:px-6 lg:px-0'>
           <div className='grid grid-cols-2 items-center gap-0'>
             <div className='max-w-[31rem] text-left'>
               <p className='homepage-section-eyebrow'>
@@ -144,7 +144,7 @@ export function HeroCinematic({
                 {heroPrimaryAction}
               </div>
 
-              <p className='mt-2.5 text-2xs tracking-[0.01em] text-quaternary-token sm:mt-3'>
+              <p className='mt-2.5 text-2xs tracking-wide text-quaternary-token sm:mt-3'>
                 Private launch access with your artist page and next release
                 ready to go.
               </p>
@@ -171,7 +171,7 @@ export function HeroCinematic({
         {['/profile', '/tour', '/tip', '/listen'].map((label, i) => (
           <span
             key={label}
-            className='rounded-full px-3 py-1 text-2xs font-mono tracking-[-0.02em] transition-colors duration-slower'
+            className='rounded-full px-3 py-1 text-2xs font-mono tracking-tighter transition-colors duration-slower'
             style={{
               backgroundColor:
                 i === 0 ? 'var(--linear-bg-surface-2)' : 'transparent',

--- a/apps/web/components/features/home/HeroScrollSection.tsx
+++ b/apps/web/components/features/home/HeroScrollSection.tsx
@@ -21,6 +21,7 @@ export function HeroScrollSection() {
               </p>
 
               <h1 className='marketing-h1-linear mt-5 max-w-[12ch] text-primary-token lg:text-left'>
+                {/* ui-casing-allow: marketing sentence-style headline */}
                 The link your music deserves.
               </h1>
 
@@ -33,14 +34,14 @@ export function HeroScrollSection() {
                 <ClaimHandleForm size='hero' />
               </div>
 
-              <p className='mt-3.5 text-2xs tracking-[0.01em] text-quaternary-token md:mt-4 lg:text-left'>
+              <p className='mt-3.5 text-2xs tracking-wide text-quaternary-token md:mt-4 lg:text-left'>
                 Private launch access with your artist page and next release
                 ready to go.
               </p>
             </div>
 
             <div className='relative mt-10 w-full md:mt-13 lg:mt-15'>
-              <div className='homepage-surface-card relative overflow-hidden rounded-[1rem] md:rounded-[1.1rem]'>
+              <div className='homepage-surface-card relative overflow-hidden rounded-xl md:rounded-[1.1rem]'>
                 <MarketingScreenshot
                   scenarioId='dashboard-releases-desktop'
                   altOverride='Jovie release dashboard showing releases table with smart link details'

--- a/apps/web/components/features/home/HomeBentoPairs.tsx
+++ b/apps/web/components/features/home/HomeBentoPairs.tsx
@@ -55,10 +55,10 @@ export function HomeBentoPairs() {
       className='home-bento-pairs-section border-t border-black/[0.08] px-6 py-32 sm:py-36'
     >
       <div className='mx-auto max-w-300'>
-        <p className='mb-5 font-[var(--marketing-font-body)] text-sm font-medium text-black/55 dark:text-black/55'>
+        <p className='mb-5 font-(--marketing-font-body) text-sm font-medium text-black/55 dark:text-black/55'>
           What it does
         </p>
-        <h2 className='m-0 max-w-[20ch] font-[var(--marketing-font-display)] text-[clamp(2.25rem,5vw,3.5rem)] font-bold leading-[1.05] tracking-[-0.028em] text-black dark:text-black'>
+        <h2 className='m-0 max-w-[20ch] font-(--marketing-font-display) text-[clamp(2.25rem,5vw,3.5rem)] font-bold leading-[1.05] tracking-[-0.028em] text-black dark:text-black'>
           <span className='text-black/45 dark:text-black/45'>
             Turn attention
           </span>
@@ -92,10 +92,10 @@ function BentoCardView({ card }: { readonly card: BentoCard }) {
         {card.preview}
       </div>
       <div className='px-9 pt-9 pb-10 text-center'>
-        <h3 className='m-0 font-[var(--marketing-font-display)] text-xl font-semibold leading-[1.3] tracking-[-0.012em] text-black dark:text-black'>
+        <h3 className='m-0 font-(--marketing-font-display) text-xl font-semibold leading-[1.3] tracking-[-0.012em] text-black dark:text-black'>
           {card.title}
         </h3>
-        <p className='mx-auto mt-3 max-w-[46ch] font-[var(--marketing-font-body)] text-sm leading-[1.55] text-black/58 dark:text-black/58'>
+        <p className='mx-auto mt-3 max-w-[46ch] font-(--marketing-font-body) text-sm leading-[1.55] text-black/58 dark:text-black/58'>
           {card.body}
         </p>
       </div>
@@ -119,7 +119,7 @@ function SmartLinkPreview() {
   return (
     <div className='absolute inset-0 flex items-center justify-center'>
       <PreviewHalo color='var(--geist-purple-solid)' />
-      <div className='relative flex flex-col items-center gap-3 font-[var(--marketing-font-body)]'>
+      <div className='relative flex flex-col items-center gap-3 font-(--marketing-font-body)'>
         <div className='flex h-14 w-14 items-center justify-center rounded-lg border border-black/10 bg-white dark:bg-white text-lg font-bold text-black dark:text-black shadow-[0_12px_42px_-34px_rgba(0,0,0,0.55)]'>
           j
         </div>
@@ -144,7 +144,7 @@ function CountdownPreview() {
     <div className='absolute inset-0 flex items-center justify-center'>
       <PreviewHalo color='var(--geist-blue-solid)' />
       <div
-        className='relative font-[var(--marketing-font-display)] text-[64px] font-extrabold leading-none tracking-[-0.04em] text-black dark:text-black tabular-nums'
+        className='relative font-(--marketing-font-display) text-[64px] font-extrabold leading-none tracking-[-0.04em] text-black dark:text-black tabular-nums'
         style={{ fontVariantNumeric: 'tabular-nums' }}
       >
         02&nbsp;:&nbsp;14&nbsp;:&nbsp;57
@@ -166,7 +166,7 @@ function TourPreview() {
         {cities.map(c => (
           <li
             key={c.city}
-            className='flex items-center justify-between px-3 py-2 font-[var(--marketing-font-body)] text-xs text-black dark:text-black'
+            className='flex items-center justify-between px-3 py-2 font-(--marketing-font-body) text-xs text-black dark:text-black'
           >
             <span>{c.city}</span>
             <span className='text-black/45 dark:text-black/45'>{c.date}</span>
@@ -181,7 +181,7 @@ function TipPreview() {
   return (
     <div className='absolute inset-0 flex items-center justify-center'>
       <PreviewHalo color='var(--geist-green-solid)' />
-      <div className='relative flex items-baseline gap-1 font-[var(--marketing-font-display)] text-black dark:text-black'>
+      <div className='relative flex items-baseline gap-1 font-(--marketing-font-display) text-black dark:text-black'>
         <span
           className='text-3xl font-semibold'
           style={{ color: 'var(--geist-green-solid)' }}

--- a/apps/web/components/features/home/HomeHeroCTA.tsx
+++ b/apps/web/components/features/home/HomeHeroCTA.tsx
@@ -36,7 +36,7 @@ export function HomeHeroCTA() {
       <label className='flex h-11 flex-1 items-center rounded-full border border-white/8 bg-black/30 pl-4 pr-2'>
         <span
           aria-hidden='true'
-          className='shrink-0 font-mono text-sm tracking-[-0.02em] text-white/56'
+          className='shrink-0 font-mono text-sm tracking-tighter text-white/56'
         >
           jov.ie/
         </span>
@@ -45,12 +45,12 @@ export function HomeHeroCTA() {
           name='handle'
           value={handle}
           onChange={e => setHandle(e.target.value)}
-          placeholder='you'
-          aria-label='Choose your handle'
+          placeholder='you' // ui-casing-allow: literal lowercase handle preview
+          aria-label='Choose Your Handle'
           autoComplete='off'
           autoCapitalize='off'
           spellCheck={false}
-          className='w-full min-w-0 bg-transparent font-mono text-sm tracking-[-0.02em] text-primary-token placeholder:text-white/36 focus:outline-none'
+          className='w-full min-w-0 bg-transparent font-mono text-sm tracking-tighter text-primary-token placeholder:text-white/36 focus:outline-none'
         />
       </label>
       <button

--- a/apps/web/components/features/home/HomeHeroSurfaceCluster.tsx
+++ b/apps/web/components/features/home/HomeHeroSurfaceCluster.tsx
@@ -58,7 +58,7 @@ function HeroTaskPanel() {
   return (
     <div className='space-y-2'>
       <div className='flex items-center justify-between px-1'>
-        <p className='text-3xs font-medium tracking-[0.02em] text-white/42'>
+        <p className='text-3xs font-medium tracking-wider text-white/42'>
           Release Tasks
         </p>
         <span className='rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-3xs font-medium text-white/62'>
@@ -85,7 +85,7 @@ function HeroTaskPanel() {
                   icon={statusStyle.icon}
                   className={statusStyle.iconClassName}
                 />
-                <p className='text-xs font-semibold leading-5 tracking-[-0.01em] text-white dark:text-white truncate'>
+                <p className='text-xs font-semibold leading-5 tracking-tight text-white dark:text-white truncate'>
                   {task.title}
                 </p>
               </div>
@@ -153,13 +153,13 @@ export function HomeHeroSurfaceCluster() {
   return (
     <>
       {/* Mobile: profile dominant, release + tasks below */}
-      <div className='relative mx-auto w-full max-w-[34rem] lg:hidden'>
+      <div className='relative mx-auto w-full max-w-136 lg:hidden'>
         <div className='space-y-4'>
-          <div className='mx-auto max-w-[14rem]'>
+          <div className='mx-auto max-w-56'>
             <HeroProfilePanel />
           </div>
           <div className='grid grid-cols-2 gap-3'>
-            <div className='mx-auto w-full max-w-[10rem]'>
+            <div className='mx-auto w-full max-w-40'>
               <HeroSmartLinkPanel />
             </div>
             <div className='flex items-center'>
@@ -183,7 +183,7 @@ export function HomeHeroSurfaceCluster() {
         <div className='relative flex items-start justify-center gap-4 xl:gap-6'>
           {/* Left: release card, tilted + dropped */}
           <div
-            className='w-[9.5rem] shrink-0 pt-14 xl:w-[10.5rem]'
+            className='w-38 shrink-0 pt-14 xl:w-42'
             style={{
               transform: 'rotateY(6deg) rotateZ(-1deg)',
               transformStyle: 'preserve-3d',
@@ -193,13 +193,13 @@ export function HomeHeroSurfaceCluster() {
           </div>
 
           {/* Center: dominant profile phone, elevated */}
-          <div className='z-10 w-[12.5rem] shrink-0 xl:w-[14rem]'>
+          <div className='z-10 w-50 shrink-0 xl:w-56'>
             <HeroProfilePanel />
           </div>
 
           {/* Right: task panel, tilted opposite + dropped further */}
           <div
-            className='w-[11.5rem] shrink-0 pt-20 xl:w-[12.5rem]'
+            className='w-46 shrink-0 pt-20 xl:w-50'
             style={{
               transform: 'rotateY(-4deg) rotateZ(1deg)',
               transformStyle: 'preserve-3d',

--- a/apps/web/components/features/home/HomeLoopDiagramSection.tsx
+++ b/apps/web/components/features/home/HomeLoopDiagramSection.tsx
@@ -49,12 +49,12 @@ export function HomeLoopDiagramSection() {
     <section className='border-t border-white/[0.04] bg-black dark:bg-black px-6 py-32 sm:py-40'>
       <div className='mx-auto grid max-w-300 gap-16 lg:grid-cols-[320px_1fr] lg:items-center'>
         <div>
-          <h2 className='m-0 font-[var(--marketing-font-display)] text-[clamp(2rem,4.5vw,3rem)] font-extrabold leading-[1.05] tracking-[-0.03em] text-primary-token'>
+          <h2 className='m-0 font-(--marketing-font-display) text-[clamp(2rem,4.5vw,3rem)] font-extrabold leading-[1.05] tracking-[-0.03em] text-primary-token'>
             Stop Letting
             <br />
             Momentum Decay.
           </h2>
-          <p className='mt-5 mb-7 max-w-[32ch] font-[var(--marketing-font-body)] text-base leading-[1.5] text-tertiary-token'>
+          <p className='mt-5 mb-7 max-w-[32ch] font-(--marketing-font-body) text-base leading-[1.5] text-tertiary-token'>
             Jovie shortens the time between fan signal and next action.
           </p>
         </div>
@@ -62,7 +62,7 @@ export function HomeLoopDiagramSection() {
         <div className='grid items-center gap-4 sm:grid-cols-[1fr_auto_1fr]'>
           {/* Flatline card */}
           <article className='min-h-90 rounded-xl border border-white/[0.06] bg-(--color-bg-surface-0) p-5'>
-            <div className='font-[var(--marketing-font-body)] text-3xs font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
+            <div className='font-(--marketing-font-body) text-3xs font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
               Flatline marketing
             </div>
             <svg
@@ -93,7 +93,7 @@ export function HomeLoopDiagramSection() {
               {FLATLINE_ITEMS.map(item => (
                 <li
                   key={item}
-                  className='flex items-center gap-2 py-1 font-[var(--marketing-font-body)] text-xs text-tertiary-token'
+                  className='flex items-center gap-2 py-1 font-(--marketing-font-body) text-xs text-tertiary-token'
                 >
                   <span
                     aria-hidden='true'
@@ -108,7 +108,7 @@ export function HomeLoopDiagramSection() {
           {/* vs */}
           <div
             aria-hidden='true'
-            className='mx-auto flex h-8 w-8 items-center justify-center rounded-full border border-white/10 font-[var(--marketing-font-display)] text-sm font-bold text-tertiary-token'
+            className='mx-auto flex h-8 w-8 items-center justify-center rounded-full border border-white/10 font-(--marketing-font-display) text-sm font-bold text-tertiary-token'
           >
             vs
           </div>
@@ -116,7 +116,7 @@ export function HomeLoopDiagramSection() {
           {/* Loop card */}
           <article className='min-h-90 rounded-xl border border-white/[0.06] bg-(--color-bg-surface-0) p-5'>
             <div
-              className='font-[var(--marketing-font-body)] text-3xs font-semibold uppercase tracking-[0.12em]'
+              className='font-(--marketing-font-body) text-3xs font-semibold uppercase tracking-[0.12em]'
               style={{ color: ACCENT }}
             >
               The Jovie Loop
@@ -185,7 +185,7 @@ export function HomeLoopDiagramSection() {
               {LOOP_ITEMS.map(item => (
                 <li
                   key={item}
-                  className='flex items-center gap-2 py-1 font-[var(--marketing-font-body)] text-xs text-tertiary-token'
+                  className='flex items-center gap-2 py-1 font-(--marketing-font-body) text-xs text-tertiary-token'
                 >
                   <span
                     aria-hidden='true'

--- a/apps/web/components/features/home/HomePhoneFrame.tsx
+++ b/apps/web/components/features/home/HomePhoneFrame.tsx
@@ -31,7 +31,7 @@ export function HomePhoneFrame({
       <div className='homepage-phone-device relative w-full rounded-[2.65rem] p-2 shadow-[0_28px_84px_rgba(0,0,0,0.42)]'>
         <div
           aria-hidden='true'
-          className='pointer-events-none absolute inset-[1px] rounded-[2.55rem] border border-white/12'
+          className='pointer-events-none absolute inset-px rounded-[2.55rem] border border-white/12'
         />
         <div
           aria-hidden='true'

--- a/apps/web/components/features/home/HomeStatQuoteSection.tsx
+++ b/apps/web/components/features/home/HomeStatQuoteSection.tsx
@@ -47,11 +47,11 @@ export function HomeStatQuoteSection({
         ))}
       </svg>
       <div className='relative mx-auto max-w-300 text-left'>
-        <h3 className='m-0 max-w-[22ch] font-[var(--marketing-font-display)] text-[clamp(1.875rem,4vw,2.75rem)] font-bold leading-[1.12] tracking-[-0.025em] text-primary-token'>
+        <h3 className='m-0 max-w-[22ch] font-(--marketing-font-display) text-[clamp(1.875rem,4vw,2.75rem)] font-bold leading-[1.12] tracking-[-0.025em] text-primary-token'>
           <span>Jovie delivers {stat}</span>
           <span className='text-tertiary-token'> {body}</span>
         </h3>
-        <div className='mt-7 font-[var(--marketing-font-body)] text-sm italic text-tertiary-token'>
+        <div className='mt-7 font-(--marketing-font-body) text-sm italic text-tertiary-token'>
           {source}
         </div>
       </div>

--- a/apps/web/components/features/home/IGComparisonAside.tsx
+++ b/apps/web/components/features/home/IGComparisonAside.tsx
@@ -28,6 +28,7 @@ export function IGComparisonAside() {
               color: 'var(--linear-text-primary)',
             }}
           >
+            {/* ui-casing-allow: marketing sentence-style headline */}
             Stop sending fans through a maze.
           </h2>
           <p
@@ -42,7 +43,7 @@ export function IGComparisonAside() {
           </p>
         </div>
 
-        <div className='grid grid-cols-1 md:grid-cols-2 overflow-hidden bg-[var(--linear-border-subtle)] gap-px rounded-lg'>
+        <div className='grid grid-cols-1 md:grid-cols-2 overflow-hidden bg-(--linear-border-subtle) gap-px rounded-lg'>
           {/* Linktree side (dimmed) */}
           <div className='flex flex-col gap-3 p-4 bg-surface-0 opacity-50'>
             <span className='text-xs font-medium uppercase tracking-wider text-tertiary-token'>
@@ -53,7 +54,7 @@ export function IGComparisonAside() {
               linktr.ee/timwhite
             </div>
 
-            <p className='text-[length:var(--linear-body-sm-size)] leading-[var(--linear-body-sm-leading)] text-tertiary-token'>
+            <p className='text-[length:var(--linear-body-sm-size)] leading-(--linear-body-sm-leading) text-tertiary-token'>
               Fan taps → Linktree page → scrolls to find link → taps again
             </p>
 
@@ -91,7 +92,7 @@ export function IGComparisonAside() {
               ))}
             </div>
 
-            <p className='text-[length:var(--linear-body-sm-size)] leading-[var(--linear-body-sm-leading)] text-tertiary-token'>
+            <p className='text-[length:var(--linear-body-sm-size)] leading-(--linear-body-sm-leading) text-tertiary-token'>
               Fan taps → arrives exactly where they need to be
             </p>
 

--- a/apps/web/components/features/home/InputAuraFrame.tsx
+++ b/apps/web/components/features/home/InputAuraFrame.tsx
@@ -15,7 +15,7 @@ export function InputAuraFrame({
       <div
         aria-hidden='true'
         className={cn(
-          'pointer-events-none absolute -inset-[6px] overflow-hidden rounded-[1rem] opacity-40 blur-[5px]',
+          'pointer-events-none absolute -inset-1.5 overflow-hidden rounded-xl opacity-40 blur-[5px]',
           'transition-opacity duration-cinematic group-focus-within/aura:opacity-100',
           "before:absolute before:left-1/2 before:top-1/2 before:h-150 before:w-150 before:-translate-x-1/2 before:-translate-y-1/2 before:rotate-[82deg] before:content-['']",
           'before:bg-[conic-gradient(transparent,var(--color-accent-purple),transparent_10%,transparent_50%,var(--color-accent-pink),transparent_60%)]',

--- a/apps/web/components/features/home/MarketingRenderSurface.tsx
+++ b/apps/web/components/features/home/MarketingRenderSurface.tsx
@@ -107,7 +107,7 @@ export function MarketingRenderSurface({
     case 'profile':
       return (
         <RenderShell emphasize>
-          <div className='w-full max-w-[24rem]'>
+          <div className='w-full max-w-96'>
             <ShowcaseCrop stateId='streams-latest' hideChrome={hideChrome} />
           </div>
         </RenderShell>
@@ -115,7 +115,7 @@ export function MarketingRenderSurface({
     case 'notification':
       return (
         <RenderShell emphasize>
-          <div className='w-full max-w-[22rem]'>
+          <div className='w-full max-w-88'>
             <HomeNotificationCard />
           </div>
         </RenderShell>
@@ -123,7 +123,7 @@ export function MarketingRenderSurface({
     case 'tips':
       return (
         <RenderShell>
-          <div className='w-full max-w-[24rem]'>
+          <div className='w-full max-w-96'>
             <HomeProfileShowcase
               stateId='tips-apple-pay'
               presentation='drawer-crop'
@@ -139,7 +139,7 @@ export function MarketingRenderSurface({
     case 'countdown':
       return (
         <RenderShell>
-          <div className='grid w-full max-w-[24rem] gap-3'>
+          <div className='grid w-full max-w-96 gap-3'>
             <ShowcaseCrop stateId='streams-presave' hideChrome={hideChrome} />
             <ShowcaseCrop stateId='streams-latest' hideChrome={hideChrome} />
           </div>
@@ -148,7 +148,7 @@ export function MarketingRenderSurface({
     case 'fans':
       return (
         <RenderShell>
-          <div className='w-full max-w-[24rem] rounded-[1.25rem] bg-white/[0.03] p-3'>
+          <div className='w-full max-w-96 rounded-[1.25rem] bg-white/[0.03] p-3'>
             <HomeRelationshipPanel />
           </div>
         </RenderShell>
@@ -156,7 +156,7 @@ export function MarketingRenderSurface({
     case 'tour':
       return (
         <RenderShell>
-          <div className='w-full max-w-[24rem]'>
+          <div className='w-full max-w-96'>
             <ShowcaseCrop stateId='tour' hideChrome={hideChrome} />
           </div>
         </RenderShell>

--- a/apps/web/components/features/home/PricingSection.tsx
+++ b/apps/web/components/features/home/PricingSection.tsx
@@ -54,6 +54,7 @@ export function PricingSection() {
           <div className='homepage-section-intro reveal-on-scroll'>
             <div className='flex max-w-[22rem] flex-col gap-4 lg:max-w-none'>
               <h2 className='marketing-h2-linear max-w-[10ch] text-primary-token md:max-w-[12ch] lg:max-w-none'>
+                {/* ui-casing-allow: marketing sentence-style headline */}
                 Simple pricing.
               </h2>
             </div>
@@ -69,14 +70,14 @@ export function PricingSection() {
             data-delay='80'
           >
             <div
-              className='relative flex h-full flex-col rounded-[1rem] p-6 md:p-7'
+              className='relative flex h-full flex-col rounded-xl p-6 md:p-7'
               style={{
                 backgroundColor: 'var(--linear-bg-surface-0)',
                 border: '1px solid var(--linear-border-subtle)',
                 boxShadow: 'var(--linear-shadow-card)',
               }}
             >
-              <p className='text-sm font-medium tracking-[-0.01em] text-tertiary-token'>
+              <p className='text-sm font-medium tracking-tight text-tertiary-token'>
                 {freePlan.displayName}
               </p>
               <div className='mt-4 flex items-baseline gap-1'>
@@ -123,7 +124,7 @@ export function PricingSection() {
             </div>
 
             <div
-              className='relative flex h-full flex-col rounded-[1rem] p-6 md:p-7'
+              className='relative flex h-full flex-col rounded-xl p-6 md:p-7'
               style={{
                 backgroundColor: 'var(--linear-bg-surface-0)',
                 border: '1px solid var(--linear-border-subtle)',
@@ -131,11 +132,11 @@ export function PricingSection() {
               }}
             >
               <div className='flex items-center justify-between'>
-                <p className='text-sm font-medium tracking-[-0.01em] text-tertiary-token'>
+                <p className='text-sm font-medium tracking-tight text-tertiary-token'>
                   {proPlan.displayName}
                 </p>
                 <Badge variant='default' size='lg'>
-                  Limited time
+                  Limited Time
                 </Badge>
               </div>
               <div className='mt-4 flex items-baseline gap-1'>

--- a/apps/web/components/features/home/ProductScreenshotFrame.tsx
+++ b/apps/web/components/features/home/ProductScreenshotFrame.tsx
@@ -100,7 +100,7 @@ export function ProductScreenshotFrame({
       aria-label={isAvailable === true ? undefined : alt}
       data-testid={testId}
       className={[
-        'relative overflow-hidden rounded-[0.95rem] border border-subtle bg-surface-0 shadow-card-elevated md:rounded-[1rem]',
+        'relative overflow-hidden rounded-[0.95rem] border border-subtle bg-surface-0 shadow-card-elevated md:rounded-xl',
         className,
       ]
         .filter(Boolean)

--- a/apps/web/components/features/home/ReleaseNotificationsSection.tsx
+++ b/apps/web/components/features/home/ReleaseNotificationsSection.tsx
@@ -37,12 +37,12 @@ export function ReleaseNotificationsSection() {
       />
 
       <Container size='homepage'>
-        <div className='relative mx-auto max-w-[var(--linear-content-max)]'>
+        <div className='relative mx-auto max-w-(--linear-content-max)'>
           {/* ── Desktop: side-by-side · Mobile: stacked ── */}
           <div className='grid lg:grid-cols-[0.4fr_0.6fr] gap-12 lg:gap-16 lg:items-start'>
             {/* ─── Left column: copy + stat ─── */}
             <div className='flex flex-col reveal-on-scroll'>
-              <span className='inline-flex w-fit items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium tracking-[-0.01em] text-tertiary-token border border-subtle'>
+              <span className='inline-flex w-fit items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium tracking-tight text-tertiary-token border border-subtle'>
                 <Zap className='h-3 w-3' aria-hidden='true' />
                 Automatic
               </span>
@@ -75,10 +75,10 @@ export function ReleaseNotificationsSection() {
                   />
                 </div>
                 <div>
-                  <p className='text-[var(--linear-caption-size)] font-[number:var(--linear-font-weight-medium)] text-primary-token'>
+                  <p className='text-(--linear-caption-size) font-[number:var(--linear-font-weight-medium)] text-primary-token'>
                     4,218 fans notified
                   </p>
-                  <p className='text-[var(--linear-label-size)] text-tertiary-token'>
+                  <p className='text-(--linear-label-size) text-tertiary-token'>
                     Zero emails written
                   </p>
                 </div>
@@ -121,7 +121,7 @@ export function ReleaseNotificationsSection() {
                         <span className='flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-3xs font-medium text-quaternary-token bg-surface-2'>
                           {i + 1}
                         </span>
-                        <span className='text-app text-tertiary-token line-through decoration-[var(--linear-text-quaternary)]'>
+                        <span className='text-app text-tertiary-token line-through decoration-(--linear-text-quaternary)'>
                           {step}
                         </span>
                       </div>
@@ -205,7 +205,7 @@ export function ReleaseNotificationsSection() {
                       {/* Listen Now button */}
                       <button
                         type='button'
-                        className='mt-4 flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-app font-semibold transition-colors duration-[var(--linear-duration-normal)] ease-subtle'
+                        className='mt-4 flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-app font-semibold transition-colors duration-(--linear-duration-normal) ease-subtle'
                         style={{
                           background:
                             'linear-gradient(135deg, oklch(72% 0.16 75), oklch(68% 0.14 60))',

--- a/apps/web/components/features/home/ReleasesSection.tsx
+++ b/apps/web/components/features/home/ReleasesSection.tsx
@@ -46,7 +46,7 @@ export function ReleasesSection() {
       subItems={SUB_ITEMS}
       className='relative overflow-hidden bg-page'
     >
-      <div className='homepage-surface-card relative mt-4 overflow-hidden rounded-[1rem] p-3.5 sm:mt-5 sm:p-4 md:p-[1.15rem] lg:p-5'>
+      <div className='homepage-surface-card relative mt-4 overflow-hidden rounded-xl p-3.5 sm:mt-5 sm:p-4 md:p-[1.15rem] lg:p-5'>
         <div
           aria-hidden='true'
           className='pointer-events-none absolute inset-x-0 top-0 h-px'

--- a/apps/web/components/features/home/SeeItInActionCarousel.tsx
+++ b/apps/web/components/features/home/SeeItInActionCarousel.tsx
@@ -164,7 +164,7 @@ function ReleasePopoverContent({
 
       <Link
         href={`${releaseHref}?noredirect=1`}
-        className='mt-4 inline-flex text-sm font-medium text-secondary-token transition-colors duration-[var(--linear-duration-normal)] hover:text-primary-token'
+        className='mt-4 inline-flex text-sm font-medium text-secondary-token transition-colors duration-(--linear-duration-normal) hover:text-primary-token'
       >
         All platforms
       </Link>
@@ -207,7 +207,7 @@ function ReleaseCard({
                 onHoverEnd(release.id);
               }
             }}
-            className='group flex w-full flex-col rounded-xl p-6 text-left no-underline transition-colors duration-[var(--linear-duration-normal)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-text-secondary)'
+            className='group flex w-full flex-col rounded-xl p-6 text-left no-underline transition-colors duration-(--linear-duration-normal) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-text-secondary)'
             style={{
               backgroundColor: 'var(--linear-bg-surface-0)',
               border: '1px solid var(--linear-border-subtle)',
@@ -356,7 +356,7 @@ export function SeeItInActionCarousel({
                 </p>
                 <Link
                   href={PROFILE.profilePath}
-                  className='mt-4 inline-flex items-center gap-2 text-app font-mono text-secondary-token transition-colors duration-[var(--linear-duration-normal)] hover:text-primary-token'
+                  className='mt-4 inline-flex items-center gap-2 text-app font-mono text-secondary-token transition-colors duration-(--linear-duration-normal) hover:text-primary-token'
                 >
                   <span
                     aria-hidden='true'
@@ -366,7 +366,7 @@ export function SeeItInActionCarousel({
                 </Link>
                 <Link
                   href={PROFILE.profilePath}
-                  className='mt-5 inline-flex items-center rounded-lg border border-subtle bg-surface-1 px-4 py-2 text-sm font-medium text-primary-token transition-colors duration-[var(--linear-duration-normal)] hover:bg-hover'
+                  className='mt-5 inline-flex items-center rounded-lg border border-subtle bg-surface-1 px-4 py-2 text-sm font-medium text-primary-token transition-colors duration-(--linear-duration-normal) hover:bg-hover'
                 >
                   View Profile
                 </Link>

--- a/apps/web/components/features/home/SocialProofSection.tsx
+++ b/apps/web/components/features/home/SocialProofSection.tsx
@@ -1,10 +1,10 @@
 export function SocialProofSection() {
   return (
-    <section className='py-[var(--linear-section-pt-sm)] px-5 sm:px-6'>
+    <section className='py-(--linear-section-pt-sm) px-5 sm:px-6'>
       <div className='mx-auto flex max-w-linear-content flex-col items-center gap-8 text-center'>
         {/* Founder credibility */}
         <div className='flex flex-col items-center gap-3'>
-          <p className='text-[var(--linear-label-size)] font-medium uppercase tracking-[0.1em] text-tertiary-token'>
+          <p className='text-(--linear-label-size) font-medium uppercase tracking-[0.1em] text-tertiary-token'>
             Built by a musician
           </p>
           <p className='max-w-120 text-base leading-relaxed text-secondary-token'>

--- a/apps/web/components/features/home/StickyPhoneTourClient.tsx
+++ b/apps/web/components/features/home/StickyPhoneTourClient.tsx
@@ -130,7 +130,7 @@ export function StickyPhoneTourClient({
             <div className='relative'>
               <div className='grid items-center grid-cols-[1fr_auto_1fr] gap-8 xl:gap-16'>
                 <div className='relative min-h-80'>
-                  <span className='inline-flex items-center gap-1.5 self-start rounded-full border border-subtle px-3 py-1 text-xs font-medium tracking-[-0.01em] text-tertiary-token'>
+                  <span className='inline-flex items-center gap-1.5 self-start rounded-full border border-subtle px-3 py-1 text-xs font-medium tracking-tight text-tertiary-token'>
                     {introBadge}
                   </span>
 
@@ -182,7 +182,7 @@ export function StickyPhoneTourClient({
                         }}
                       >
                         <p
-                          className='font-mono tracking-[-0.02em]'
+                          className='font-mono tracking-tighter'
                           style={{
                             fontSize: isActive ? '20px' : '15px',
                             fontWeight: isActive ? 590 : 400,

--- a/apps/web/components/features/home/TestimonialCard.tsx
+++ b/apps/web/components/features/home/TestimonialCard.tsx
@@ -13,7 +13,7 @@ export function TestimonialCard({
 }: TestimonialCardProps) {
   return (
     <div
-      className='relative flex flex-col items-center rounded-xl p-8 text-center transition-colors duration-[var(--linear-duration-normal)]'
+      className='relative flex flex-col items-center rounded-xl p-8 text-center transition-colors duration-(--linear-duration-normal)'
       style={{
         backgroundColor: 'var(--linear-bg-surface-0)',
         border: '1px solid var(--linear-border-subtle)',

--- a/apps/web/components/features/home/phone-showcase-primitives.tsx
+++ b/apps/web/components/features/home/phone-showcase-primitives.tsx
@@ -40,7 +40,7 @@ export type ModeData = PhoneShowcaseModeData;
 export const MODES: readonly ModeData[] = PHONE_SHOWCASE_MODES;
 
 export const PHONE_TOUR_CONTAINER_CLASS =
-  'mx-auto w-full max-w-[var(--linear-content-max)] px-5 sm:px-6 lg:px-0';
+  'mx-auto w-full max-w-(--linear-content-max) px-5 sm:px-6 lg:px-0';
 
 export const PHONE_TOUR_SHOWCASE_SHADOW =
   'drop-shadow(0 25px 60px rgba(0,0,0,0.35)) drop-shadow(0 8px 30px rgba(94,106,210,0.15))';
@@ -66,7 +66,7 @@ export function PhoneTourMobileSection() {
 
         <div>
           <div className='mb-12 flex flex-col items-center gap-6 text-center'>
-            <span className='inline-flex items-center gap-1.5 rounded-full border border-subtle px-3 py-1 text-xs font-medium tracking-[-0.01em] text-tertiary-token'>
+            <span className='inline-flex items-center gap-1.5 rounded-full border border-subtle px-3 py-1 text-xs font-medium tracking-tight text-tertiary-token'>
               One profile. Every way fans support you.
             </span>
             <h2 className='marketing-h2-linear text-primary-token'>
@@ -403,10 +403,10 @@ export function PhoneShowcase({
               ref={node => {
                 tabRefs.current[i] = node;
               }}
-              className={`relative z-10 rounded-full px-3 py-1 text-2xs font-mono tracking-[-0.02em] transition-colors duration-cinematic ${
+              className={`relative z-10 rounded-full px-3 py-1 text-2xs font-mono tracking-tighter transition-colors duration-cinematic ${
                 i === activeIndex
-                  ? 'text-[var(--linear-text-primary)]'
-                  : 'text-[var(--linear-text-quaternary)] hover:text-[var(--linear-text-secondary)]'
+                  ? 'text-(--linear-text-primary)'
+                  : 'text-(--linear-text-quaternary) hover:text-(--linear-text-secondary)'
               }`}
             >
               {MODE_TAB_LABELS[mode.id] ?? `/${mode.id}`}

--- a/apps/web/components/homepage/HomepageReleaseVelocityReveal.tsx
+++ b/apps/web/components/homepage/HomepageReleaseVelocityReveal.tsx
@@ -43,7 +43,7 @@ export function HomepageReleaseVelocityReveal() {
   return (
     <section
       aria-labelledby='homepage-release-velocity-heading'
-      className='relative isolate overflow-hidden bg-(--color-bg-hover) px-[var(--homepage-page-gutter)] py-20 text-center sm:py-24 lg:py-28'
+      className='relative isolate overflow-hidden bg-(--color-bg-hover) px-(--homepage-page-gutter) py-20 text-center sm:py-24 lg:py-28'
       data-testid='homepage-release-velocity-reveal'
     >
       <div

--- a/apps/web/components/marketing/FigCard.tsx
+++ b/apps/web/components/marketing/FigCard.tsx
@@ -14,10 +14,7 @@ export interface FigCardProps {
 export function FigCard({ title, description, icon, className }: FigCardProps) {
   return (
     <div
-      className={cn(
-        'homepage-surface-card rounded-[1rem] p-6 md:p-7',
-        className
-      )}
+      className={cn('homepage-surface-card rounded-xl p-6 md:p-7', className)}
     >
       {icon && (
         <div className='mb-5 flex h-9 w-9 items-center justify-center rounded-xl border border-subtle bg-surface-1 text-secondary-token'>

--- a/apps/web/components/marketing/MarketingMetricCard.tsx
+++ b/apps/web/components/marketing/MarketingMetricCard.tsx
@@ -26,10 +26,7 @@ export function MarketingMetricCard({
   return (
     <div
       data-testid={testId}
-      className={cn(
-        'homepage-surface-card rounded-[1rem] px-4 py-3.5',
-        className
-      )}
+      className={cn('homepage-surface-card rounded-xl px-4 py-3.5', className)}
     >
       <div className='flex items-center gap-2 text-xs font-medium text-secondary-token'>
         {icon}

--- a/apps/web/components/marketing/MarketingStoryPrimitives.tsx
+++ b/apps/web/components/marketing/MarketingStoryPrimitives.tsx
@@ -206,7 +206,7 @@ export function ArtistProfileCaptureVisual({
     >
       <style>{CAPTURE_ANIMATION_STYLES}</style>
 
-      <div className='mx-auto flex max-w-[32rem] justify-center'>
+      <div className='mx-auto flex max-w-lg justify-center'>
         <CaptureActionPill capture={capture} phase={phase} />
       </div>
 

--- a/apps/web/components/marketing/MarketingSurfaceCard.tsx
+++ b/apps/web/components/marketing/MarketingSurfaceCard.tsx
@@ -83,7 +83,7 @@ export function MarketingSurfaceCard({
           />
           <div
             aria-hidden='true'
-            className='pointer-events-none absolute inset-[1px] rounded-[inherit] border border-white/6'
+            className='pointer-events-none absolute inset-px rounded-[inherit] border border-white/6'
           />
         </>
       ) : null}

--- a/apps/web/components/marketing/artist-notifications/ArtistNotificationsBenefitsSection.tsx
+++ b/apps/web/components/marketing/artist-notifications/ArtistNotificationsBenefitsSection.tsx
@@ -20,7 +20,7 @@ export function ArtistNotificationsBenefitsSection({
           align='left'
           headline={benefits.headline}
           body={benefits.body}
-          className='max-w-[42rem]'
+          className='max-w-2xl'
           headlineClassName='max-w-[11ch] text-[clamp(2.8rem,4.8vw,4.35rem)]'
           bodyClassName='max-w-[34rem]'
         />

--- a/apps/web/components/marketing/artist-profile/ArtistProfileHero.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileHero.tsx
@@ -24,9 +24,9 @@ export function ArtistProfileHero({ hero }: Readonly<ArtistProfileHeroProps>) {
 
       <MarketingContainer
         width='page'
-        className='relative !max-w-[var(--linear-content-max)] !px-5 sm:!px-6 lg:!px-0'
+        className='relative !max-w-(--linear-content-max) !px-5 sm:!px-6 lg:!px-0'
       >
-        <div className='mx-auto flex max-w-[48rem] flex-col items-center pb-10 pt-[calc(var(--linear-header-height)+3rem)] text-center sm:pb-12 sm:pt-[calc(var(--linear-header-height)+3.5rem)] lg:pb-14 lg:pt-[calc(var(--linear-header-height)+4rem)]'>
+        <div className='mx-auto flex max-w-3xl flex-col items-center pb-10 pt-[calc(var(--linear-header-height)+3rem)] text-center sm:pb-12 sm:pt-[calc(var(--linear-header-height)+3.5rem)] lg:pb-14 lg:pt-[calc(var(--linear-header-height)+4rem)]'>
           <h1
             id='artist-profile-hero-heading'
             className='max-w-[11ch] text-[clamp(3.125rem,7.15vw,5.625rem)] font-[660] leading-[0.95] tracking-[-0.055em] text-primary-token'

--- a/apps/web/components/marketing/artist-profile/ArtistProfileHeroAdaptiveIntro.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileHeroAdaptiveIntro.tsx
@@ -32,7 +32,7 @@ export function ArtistProfileHeroAdaptiveIntro({
       >
         <MarketingContainer
           width='page'
-          className='relative !max-w-[var(--linear-content-max)] !px-5 sm:!px-6 lg:!px-0'
+          className='relative !max-w-(--linear-content-max) !px-5 sm:!px-6 lg:!px-0'
         >
           <div className='artist-profile-intro-stage'>
             <div className='artist-profile-intro-rail'>

--- a/apps/web/components/marketing/artist-profile/ArtistProfileHowItWorks.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileHowItWorks.tsx
@@ -61,7 +61,7 @@ export function ArtistProfileHowItWorks({
         <div className='mt-10 grid gap-5 lg:grid-cols-3 lg:gap-5'>
           <article className='flex flex-col gap-3'>
             <StepNumber value={1} />
-            <div className='relative min-h-[10.5rem] space-y-3 pt-1'>
+            <div className='relative min-h-42 space-y-3 pt-1'>
               <div
                 aria-hidden='true'
                 className='pointer-events-none absolute inset-x-8 top-4 h-14 rounded-full bg-white/8 blur-3xl'
@@ -185,7 +185,7 @@ export function ArtistProfileHowItWorks({
 
           <article className='flex flex-col gap-3'>
             <StepNumber value={3} />
-            <div className='relative min-h-[10.5rem] space-y-3 pt-1'>
+            <div className='relative min-h-42 space-y-3 pt-1'>
               <div
                 aria-hidden='true'
                 className='pointer-events-none absolute inset-x-8 top-4 h-14 rounded-full bg-white/8 blur-3xl'
@@ -288,7 +288,7 @@ function HoverPopover({
         side='bottom'
         align='start'
         showArrow
-        className='w-auto rounded-[1rem] border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-3 shadow-[0_22px_54px_rgba(0,0,0,0.24)]'
+        className='w-auto rounded-xl border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-3 shadow-[0_22px_54px_rgba(0,0,0,0.24)]'
       >
         {content}
       </PopoverContent>

--- a/apps/web/components/marketing/artist-profile/ArtistProfileModeSwitcher.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileModeSwitcher.tsx
@@ -128,11 +128,11 @@ export function ArtistProfileModeSwitcher({
   return (
     <div
       ref={rootRef}
-      className='artist-profile-mode-switcher mx-auto flex w-full max-w-[32rem] flex-col items-center text-center'
+      className='artist-profile-mode-switcher mx-auto flex w-full max-w-lg flex-col items-center text-center'
     >
       {showIntroHeading ? (
         <motion.div
-          className='artist-profile-mode-switcher-heading mx-auto max-w-[24rem]'
+          className='artist-profile-mode-switcher-heading mx-auto max-w-sm'
           initial={false}
           animate={
             introVisible

--- a/apps/web/components/marketing/artist-profile/ArtistProfileMonetizationSection.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileMonetizationSection.tsx
@@ -214,7 +214,7 @@ export function ArtistProfileMonetizationSection({
       width='page'
     >
       <div>
-        <div className='mx-auto max-w-[var(--linear-content-max)] px-5 sm:px-6 lg:px-0'>
+        <div className='mx-auto max-w-(--linear-content-max) px-5 sm:px-6 lg:px-0'>
           <div className='max-w-[34rem]'>
             <h2 className={SHELL_H2_CLASS}>
               <span className='block'>Get paid.</span>
@@ -497,7 +497,7 @@ function ReengageVisual({
           <div
             key={output.id}
             className={cn(
-              'relative rounded-[1rem] bg-(--color-bg-input) px-3.5 py-3.5 text-white dark:text-white shadow-[0_14px_30px_rgba(0,0,0,0.18)]',
+              'relative rounded-xl bg-(--color-bg-input) px-3.5 py-3.5 text-white dark:text-white shadow-[0_14px_30px_rgba(0,0,0,0.18)]',
               getOutputTransformClass(index),
               index > 0 && 'mt-2.5'
             )}

--- a/apps/web/components/marketing/artist-profile/ArtistProfileOutcomesCarousel.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOutcomesCarousel.tsx
@@ -74,7 +74,7 @@ export function ArtistProfileOutcomesCarousel({
       width='page'
     >
       <div>
-        <div className='mx-auto max-w-[var(--linear-content-max)] px-5 sm:px-6 lg:px-0'>
+        <div className='mx-auto max-w-(--linear-content-max) px-5 sm:px-6 lg:px-0'>
           <ArtistProfileSectionHeader
             align='left'
             headline={outcomes.headline}
@@ -397,7 +397,7 @@ function ShareProof({
           {proof.title}
         </p>
 
-        <div className='mt-3.5 flex h-[9.75rem] w-[9.75rem] items-center justify-center rounded-[1rem] bg-white dark:bg-surface-1 shadow-[inset_0_0_0_1px_rgba(17,17,17,0.06)]'>
+        <div className='mt-3.5 flex h-39 w-39 items-center justify-center rounded-xl bg-white dark:bg-surface-1 shadow-[inset_0_0_0_1px_rgba(17,17,17,0.06)]'>
           <div className='grid grid-cols-7 gap-2'>
             {QR_CELLS.map(cell => (
               <span

--- a/apps/web/components/marketing/artist-profile/ArtistProfilePlaceholderShot.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfilePlaceholderShot.tsx
@@ -94,7 +94,7 @@ export function ArtistProfilePlaceholderShot({
     return (
       <div className={cn('flex h-full flex-col px-5 pb-5 pt-14', className)}>
         <div className='mx-auto grid h-40 w-40 place-items-center rounded-[1.8rem] border border-white/10 bg-white/[0.045]'>
-          <div className='h-24 w-24 rounded-[1rem] bg-white/8' />
+          <div className='h-24 w-24 rounded-xl bg-white/8' />
         </div>
         <div className='mt-6 grid grid-cols-3 gap-3'>
           <Panel className='h-14 border-white/10 bg-white/[0.08]' />

--- a/apps/web/components/marketing/artist-profile/ArtistProfileSectionHeader.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileSectionHeader.tsx
@@ -35,7 +35,7 @@ export function ArtistProfileSectionHeader({
   return (
     <div
       className={cn(
-        isCentered ? 'mx-auto max-w-[46rem] text-center' : 'max-w-[42rem]',
+        isCentered ? 'mx-auto max-w-[46rem] text-center' : 'max-w-2xl',
         className
       )}
     >
@@ -50,7 +50,7 @@ export function ArtistProfileSectionHeader({
           className={cn(
             SHELL_LEAD_CLASS,
             'mt-5 sm:mt-6',
-            isCentered ? 'mx-auto max-w-[38rem]' : 'max-w-[42rem]',
+            isCentered ? 'mx-auto max-w-[38rem]' : 'max-w-2xl',
             bodyClassName
           )}
         >

--- a/apps/web/components/marketing/artist-profile/ArtistProfileSocialProof.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileSocialProof.tsx
@@ -47,7 +47,7 @@ export function ArtistProfileSocialProof({
 
       {!proofData.hasRealQuotes && proofData.founderQuote ? (
         <article className='mx-auto mt-6 max-w-280 overflow-hidden rounded-[1.9rem] border border-black/10 bg-white dark:bg-surface-1 px-6 py-6 text-black dark:text-white shadow-[0_22px_60px_rgba(0,0,0,0.16)] sm:px-8 sm:py-7 lg:px-10 lg:py-8'>
-          <blockquote className='max-w-[48rem] text-pretty text-[clamp(1.375rem,2.4vw,2rem)] font-semibold leading-[1.18] tracking-[-0.025em] text-black dark:text-white'>
+          <blockquote className='max-w-3xl text-pretty text-[clamp(1.375rem,2.4vw,2rem)] font-semibold leading-[1.18] tracking-[-0.025em] text-black dark:text-white'>
             “{proofData.founderQuote.quote}”
           </blockquote>
           <div className='mt-6 flex flex-col gap-1 text-left'>

--- a/apps/web/components/marketing/artist-profile/ArtistProfileSpecWall.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileSpecWall.tsx
@@ -90,7 +90,7 @@ function ButtonChipVisual({
     <div
       role='img'
       aria-label={`${chipLabel} preview`}
-      className='flex h-full min-h-[9rem] items-center justify-center rounded-[0.9rem] bg-[radial-gradient(circle_at_50%_15%,rgba(255,255,255,0.08),transparent_38%),#070a0f]'
+      className='flex h-full min-h-36 items-center justify-center rounded-[0.9rem] bg-[radial-gradient(circle_at_50%_15%,rgba(255,255,255,0.08),transparent_38%),#070a0f]'
     >
       <div className='inline-flex items-center gap-2 rounded-full border border-white/10 bg-white dark:bg-surface-1 px-4 py-2.5 text-xs font-semibold text-black dark:text-white shadow-[0_14px_26px_rgba(0,0,0,0.22)]'>
         <Icon className='h-3.5 w-3.5' strokeWidth={2} />
@@ -120,7 +120,7 @@ function IconBadgeVisual({
     <div
       role='img'
       aria-label={`${badgeLabel} preview`}
-      className='flex h-full min-h-[9rem] items-center justify-center rounded-[0.9rem] bg-[radial-gradient(circle_at_50%_15%,rgba(255,255,255,0.08),transparent_38%),#070a0f]'
+      className='flex h-full min-h-36 items-center justify-center rounded-[0.9rem] bg-[radial-gradient(circle_at_50%_15%,rgba(255,255,255,0.08),transparent_38%),#070a0f]'
     >
       <div className='flex flex-col items-center gap-3 text-center'>
         <span className='inline-flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white dark:bg-surface-1 text-black dark:text-white shadow-[0_16px_28px_rgba(0,0,0,0.22)]'>
@@ -201,7 +201,7 @@ function AudienceQualityFilterVisual() {
       />
       <div
         aria-hidden='true'
-        className='absolute left-1/2 top-[42%] h-px w-[120%] -translate-x-1/2 rotate-[-18deg] bg-gradient-to-r from-transparent via-[var(--tile-accent)]/50 to-transparent opacity-70'
+        className='absolute left-1/2 top-[42%] h-px w-[120%] -translate-x-1/2 rotate-[-18deg] bg-gradient-to-r from-transparent via-(--tile-accent)/50 to-transparent opacity-70'
       />
       <div className='relative z-10 grid w-full grid-cols-[minmax(0,1fr)_3.25rem_minmax(0,1fr)] items-center gap-3'>
         <div className='space-y-2'>
@@ -226,10 +226,10 @@ function AudienceQualityFilterVisual() {
         </div>
 
         <div className='flex flex-col items-center gap-2 text-white/50'>
-          <span className='flex h-10 w-10 items-center justify-center rounded-full border border-[var(--tile-accent)]/30 bg-[var(--tile-accent)]/10 text-[var(--tile-accent)] shadow-[0_0_34px_rgba(94,106,210,0.18)]'>
+          <span className='flex h-10 w-10 items-center justify-center rounded-full border border-(--tile-accent)/30 bg-(--tile-accent)/10 text-(--tile-accent) shadow-[0_0_34px_rgba(94,106,210,0.18)]'>
             <Filter aria-hidden='true' className='h-4 w-4' />
           </span>
-          <span className='h-10 w-px bg-gradient-to-b from-[var(--tile-accent)]/45 to-transparent' />
+          <span className='h-10 w-px bg-gradient-to-b from-(--tile-accent)/45 to-transparent' />
         </div>
 
         <div className='rounded-[0.8rem] border border-emerald-300/18 bg-emerald-300/[0.07] p-3 text-left shadow-[0_18px_52px_rgba(16,185,129,0.12)]'>
@@ -273,11 +273,11 @@ function ArtistProfilePowerFeatureTile({
       <div className='relative flex h-full flex-col overflow-hidden rounded-[1.25rem] border border-white/8 bg-(--color-bg-base) p-4'>
         <div
           aria-hidden='true'
-          className='pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[var(--tile-accent)]/60 to-transparent opacity-80'
+          className='pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-(--tile-accent)/60 to-transparent opacity-80'
         />
         <div
           aria-hidden='true'
-          className='pointer-events-none absolute -right-16 -top-16 hidden h-44 w-44 rounded-full bg-[var(--tile-accent)]/12 blur-3xl sm:block'
+          className='pointer-events-none absolute -right-16 -top-16 hidden h-44 w-44 rounded-full bg-(--tile-accent)/12 blur-3xl sm:block'
         />
         <div className='relative flex-1'>
           {tile.visual === 'audience-quality-filter' ? (
@@ -328,7 +328,7 @@ function ArtistProfilePowerFeatureTile({
             />
           ) : null}
         </div>
-        <div className='relative z-10 mt-4 max-w-[24rem]'>
+        <div className='relative z-10 mt-4 max-w-sm'>
           <h3 className='max-w-[20ch] text-[1.08rem] font-semibold tracking-normal text-white dark:text-white sm:text-[1.16rem]'>
             {tile.title}
           </h3>
@@ -347,14 +347,14 @@ export function ArtistProfileSpecWall({
 }: Readonly<ArtistProfileSpecWallProps>) {
   return (
     <ArtistProfileSectionShell width='page' containerClassName='max-w-none'>
-      <div className='mx-auto max-w-[var(--linear-content-max)]'>
+      <div className='mx-auto max-w-(--linear-content-max)'>
         <ArtistProfileSectionHeader
           align='left'
           headline={specWall.headline}
           body={specWall.subhead}
           className='max-w-[44rem]'
           headlineClassName=''
-          bodyClassName='max-w-[36rem]'
+          bodyClassName='max-w-xl'
         />
 
         <div className='mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-12 xl:grid-rows-4 xl:gap-4'>

--- a/apps/web/components/marketing/friday-rhythm-section.tsx
+++ b/apps/web/components/marketing/friday-rhythm-section.tsx
@@ -254,7 +254,7 @@ function FridayRhythmContent({
   const graphSummary = `Jovie rhythm model showing ${activeFridays} of ${totalFridays} Fridays active`;
 
   return (
-    <div className='homepage-friday-rhythm-content mx-auto w-full max-w-[var(--homepage-section-max)] px-[var(--homepage-page-gutter)] py-20 sm:py-24 md:py-0'>
+    <div className='homepage-friday-rhythm-content mx-auto w-full max-w-(--homepage-section-max) px-(--homepage-page-gutter) py-20 sm:py-24 md:py-0'>
       <div className='homepage-friday-rhythm-copy max-w-[45rem] text-left'>
         <h2 className='homepage-friday-rhythm-title text-white dark:text-white'>
           <span className='block'>Make Every Friday</span>

--- a/apps/web/components/marketing/go-live-in-sixty-section.tsx
+++ b/apps/web/components/marketing/go-live-in-sixty-section.tsx
@@ -39,7 +39,7 @@ export function GoLiveInSixtySection() {
         className='absolute left-1/2 top-1/2 h-80 w-[80vw] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[radial-gradient(circle,rgba(94,106,210,0.13),transparent_64%)] blur-3xl'
       />
 
-      <div className='relative mx-auto grid w-full max-w-[var(--homepage-section-max)] gap-12 px-[var(--homepage-page-gutter)] lg:grid-cols-[minmax(24rem,0.95fr)_minmax(0,1.05fr)] lg:items-end lg:gap-14'>
+      <div className='relative mx-auto grid w-full max-w-(--homepage-section-max) gap-12 px-(--homepage-page-gutter) lg:grid-cols-[minmax(24rem,0.95fr)_minmax(0,1.05fr)] lg:items-end lg:gap-14'>
         <h2
           id='go-live-sixty-heading'
           className='max-w-[12.5ch] text-[3rem] font-semibold leading-[0.94] tracking-[-0.035em] text-white dark:text-white sm:text-[4.15rem] lg:text-[4.55rem] lg:leading-[0.92] xl:text-[4.95rem]'

--- a/apps/web/components/marketing/homepage-v2/HomepageV2Route.tsx
+++ b/apps/web/components/marketing/homepage-v2/HomepageV2Route.tsx
@@ -71,7 +71,7 @@ function HomepageV2Hero() {
   return (
     <section
       data-testid='homepage-v2-shell'
-      className='relative overflow-hidden pb-16 pt-[5.75rem] sm:pb-20 md:pt-[6.25rem] lg:pb-24'
+      className='relative overflow-hidden pb-16 pt-23 sm:pb-20 md:pt-25 lg:pb-24'
       aria-labelledby='homepage-v2-hero-heading'
     >
       <style>{`
@@ -192,7 +192,7 @@ function HomepageV2Hero() {
                 altOverride='Audience insights showing top cities and engagement signals'
                 title='Audience insight'
                 chrome='minimal'
-                className='rounded-[1rem]'
+                className='rounded-xl'
               />
             </div>
 
@@ -210,7 +210,7 @@ function HomepageV2Hero() {
                 altOverride='Tracked link share menu with campaign routing controls'
                 title='Share and route'
                 chrome='minimal'
-                className='rounded-[1rem]'
+                className='rounded-xl'
               />
             </div>
 
@@ -241,8 +241,8 @@ export function HomepageV2SystemOverview() {
           align='center'
           headline={HOMEPAGE_V2_COPY.systemOverview.headline}
           body={HOMEPAGE_V2_COPY.systemOverview.subhead}
-          className='max-w-[42rem]'
-          bodyClassName='max-w-[32rem]'
+          className='max-w-2xl'
+          bodyClassName='max-w-lg'
         />
 
         <div className='homepage-overview-grid'>
@@ -303,14 +303,14 @@ export function HomepageV2Spotlight() {
         }
       `}</style>
       <MarketingContainer width='page'>
-        <div className='mx-auto grid max-w-[72rem] gap-10 lg:grid-cols-[minmax(16rem,0.36fr)_minmax(0,0.64fr)] lg:items-center xl:gap-16'>
+        <div className='mx-auto grid max-w-6xl gap-10 lg:grid-cols-[minmax(16rem,0.36fr)_minmax(0,0.64fr)] lg:items-center xl:gap-16'>
           <div className='max-w-[23rem] lg:self-center'>
             <div className='max-w-[23rem]'>
               <h2 className='homepage-story-heading max-w-[11ch]'>
                 <span className='block'>One Link.</span>
                 <span className='block whitespace-nowrap'>Always In Sync.</span>
               </h2>
-              <p className='homepage-story-body max-w-[20rem]'>
+              <p className='homepage-story-body max-w-xs'>
                 {HOMEPAGE_V2_COPY.spotlight.body}
               </p>
             </div>
@@ -343,7 +343,7 @@ export function HomepageV2CaptureReactivate() {
           align='center'
           headline={HOMEPAGE_V2_COPY.captureReactivation.headline}
           body={HOMEPAGE_V2_COPY.captureReactivation.body}
-          className='max-w-[42rem]'
+          className='max-w-2xl'
           headlineClassName='whitespace-pre-line'
           bodyClassName='mx-auto max-w-[29rem]'
         />
@@ -404,14 +404,14 @@ function HomepageV2SocialProof() {
           headline={HOMEPAGE_V2_COPY.socialProof.headline}
           body={HOMEPAGE_V2_COPY.socialProof.body}
           className='max-w-[40rem]'
-          bodyClassName='mx-auto max-w-[28rem]'
+          bodyClassName='mx-auto max-w-md'
         />
 
         <div className='mt-8 grid gap-4 lg:grid-cols-3'>
           {ARTIST_PROFILE_SOCIAL_PROOF.profileCards.map(card => (
             <article
               key={card.id}
-              className='overflow-hidden rounded-[1.25rem] bg-white/[0.03]'
+              className='overflow-hidden rounded-2xl bg-white/[0.03]'
             >
               <div className='relative aspect-[4/3]'>
                 <Image

--- a/apps/web/components/site/public-shell.constants.ts
+++ b/apps/web/components/site/public-shell.constants.ts
@@ -7,4 +7,4 @@ export const PUBLIC_SHELL_FOOTER_LINKS = [
 ] as const;
 
 export const PUBLIC_SHELL_MAIN_OFFSET_CLASS =
-  'pt-[var(--public-shell-header-offset)]';
+  'pt-(--public-shell-header-offset)';

--- a/apps/web/eslint-rules/canonical-ui-label-casing-utils.js
+++ b/apps/web/eslint-rules/canonical-ui-label-casing-utils.js
@@ -42,6 +42,7 @@ const BRAND_WORDS = new Set([
   'Jovie',
   'Linear',
   'LinkedIn',
+  'Music',
   'SoundCloud',
   'Spotify',
   'TikTok',


### PR DESCRIPTION
## Summary
Wave 1 of the JOV-4157 UI-drift sweep: converge **marketing + home surfaces** onto design-system tokens. Mechanical, exact-equivalence-only conversions (px-on-4px-grid → scale steps, `-[var(--x)]` → `(--x)` paren shorthand, exact %→fraction, named radius/text/tracking/weight tokens verified against `globals.css @theme` + `design-system.css`).

Also: latent Title Case fixes + `ui-casing-allow` annotations for deliberate marketing sentence-style headlines (rule surfaced them on touched files); `Music` added to casing BRAND_WORDS (Apple Music/YouTube Music mid-sentence).

**No visual change intended.** Verified by an adversarial exactness review (Opus) against the theme cascade — including the repo-specific radius scale (xl=16px, 2xl=20px) where 12 initially-wrong `rounded-[1rem]→rounded-2xl` conversions were caught and corrected to `rounded-xl` before this PR.

`big-pr`: mechanical codemod sweep per `.claude/rules/pr-stacking.md` (one PR per sweep slice, not N micro-PRs). Stacked on the ratchet-heal PR; baselines ratchet down at the stack top.

## Verification
- `vitest run tests/unit/design-system` — 14/14 green (arbitrary count 3044 → well below baseline)
- typecheck clean, `pnpm tailwind:check` green, Biome clean

## Cost Impact
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
