### PR TITLE
chore(design-system): lower arbitrary-value ratchet baseline 3044→2651 (JOV-4157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] Design-system drift sweep (JOV-4157/JOV-3479): 393 arbitrary Tailwind values converged to exact tokens across marketing/home/profile/dashboard/admin/shell/app surfaces; 13 raw buttons converted to canonical Button (healing the raw-button ratchet main regression 726→713); motion doctrine fixes (transition-all, raw cubic-bezier→ease tokens, raw durations→intent tokens); touch-target count 228→225; ratchet baselines lowered (arbitrary 3044→2651, raw-button 722→713, touch-target 226→225).
+
 - [internal] **Single machine-readable design-token source, wave 1 (GH-12009, GH-10158)**: New `apps/web/design/tokens.json` compiled by `scripts/build-design-tokens.mjs` (`pnpm tokens:build` / `tokens:check`) into generated CSS (`--gray1..12` now resolve app-wide), a typed TS export, and an agent manifest. `--linear-*` namespace is now shrink-only ratcheted (`linear-namespace-ratchet.test.ts`, baseline 2242), and a source-vs-emitter divergence guard locks tokens.json to the live accent palette. No visual changes.
 - [internal] **One EmptyState primitive (GH-12638)**: Canonical molecule at `components/molecules/EmptyState` (greyscale icon + Title Case heading + one sentence + primary CTA + optional text-link secondary). Migrated DSP presence/matches, insights, release tasks, and table empty surfaces onto it; deleted 5 bespoke `*EmptyState` components; component-family ratchet emptyState 14→9.
 - Toasts and banners now share one canonical feedback system: confirmations and errors appear bottom-right and dismiss on their own, while system status stays pinned at the top until you dismiss it. (GH-12885)

--- a/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
+++ b/apps/web/tests/unit/design-system/arbitrary-values.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 3044,
-  "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down — lower this when a PR reduces the count. Corrected 3057→3061 on 2026-06-23: #11689 set the baseline 4 below the true post-sweep count and was admin-merged past its own red ratchet, leaving main RED and failing every PR's Unit Tests. Drive back down via JOV-3466 (tokenize the 4 stragglers). 3061→3059 on 2026-06-23 (JOV-3484): TaskListRow dropped grid-cols-[…] + leading-[17px] arbitrary values when converging to a flex layout. 3059→3058 on 2026-06-27 (JOV-3490): TaskLoadingState dropped grid-cols-[…] when matching TaskListRow flex layout. 3058→3056 on 2026-07-04 (#12890): canonical MarketingHero migration removed the home hero's arbitrary values. 3056→3044 on 2026-07-04 (#11899): profile composition layer replaced dvh hero heights, aspect-[4/5], and carousel w-[260px]/w-[180px] with aspect-hero/aspect-card-standard tokens and scale utilities."
+  "count": 2651,
+  "note": "Arbitrary Tailwind values in apps/web/{components,app}. Ratchet only goes down \u2014 lower this when a PR reduces the count. 3044\u21922651 on 2026-07-09 (JOV-4157 sweep): exact-equivalence codemod (px-grid/percent/var()\u2192paren/z/vh) + 7-zone agent wave converging named tokens."
 }


### PR DESCRIPTION
## Summary
Stack top of the JOV-4157 sweep: lower the arbitrary-value drift ratchet baseline **3044 → 2651** (−393) now that all sweep members beneath have landed, plus the CHANGELOG `[Unreleased]` entry.

Motion-doctrine fixes are distributed through the stack (transition-all → named properties, raw `cubic-bezier` → `--ease-*` tokens where exactly equal, raw durations → intent tokens, decorative hover motion removed per ui.md).

Jank findings that need real design work were filed instead of hacked: JOV-4158…JOV-4162 (skeleton mismatches, unreserved banner slots, late-insert layout shifts).

## Verification
- Full design-system suite 14/14 green at this baseline
- Ratchet direction: shrink-only preserved (arbitrary 3044→2651, raw-button 722→713, touch-target 226→225 in the stack base)

## Cost Impact
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
