### PR TITLE
docs(ci): align PR flow docs to post-#13610 reality (JOV-4168)

### DIFF
--- a/.claude/rules/ci-branching.md
+++ b/.claude/rules/ci-branching.md
@@ -43,7 +43,9 @@ After a train merges to `main`, reset the integration branch from `main` before 
 
 ## Hard rules for agents
 
-1. **Never open a routine Linear PR to `main`** — target `integration/loop-{domain}` first.
+1. **Default is a small sibling PR straight to `main`** (see header note +
+   `docs/PR_FLOW.md`). Target `integration/loop-{domain}` only inside a
+   coordinated multi-agent wave (>3 agents, one domain, same window).
 2. **One PR = one Linear issue** — no drive-by refactors.
 3. **No `testing` label** unless touching: auth, billing, DB/migrations, proxy, env, agent control plane.
 4. **Local verify before integration merge:** `typecheck`, `biome`, focused `vitest`.
@@ -86,4 +88,8 @@ After a train merges to `main`, reset the integration branch from `main` before 
 - **Local:** `pnpm ci:branching-guard --head <branch> --base main` before opening agent PRs.
 - **Harness:** `pnpm ci:branching-guard:validate` in Structural Contract lane.
 
-**Ship now:** warn mode for agent PRs → `main`. **Re-evaluate when:** 2026-06-17. **Then:** escalate to error mode unless false-positive rate >10% (hotfix path blocked).
+**Ship now:** warn mode for agent PRs → `main` — kept past the original
+2026-06-17 trigger because direct-to-`main` sibling PRs became the documented
+default (`docs/PR_FLOW.md`, 2026-06-22 post-mortem); error mode would fight the
+canonical flow. **Re-evaluate when:** integration-branch waves become the
+default again. **Then:** escalate to error mode.

--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -6,9 +6,11 @@ PR discipline, ship validation, branch strategy, deploy flow, bot-review blockin
 
 ### Size Limits
 
-- Max 10 files changed per PR (excluding lockfiles and generated files)
-- Max 400 lines of diff (additions + deletions)
-- If a task requires more, split into sequential PRs with clear dependencies
+- Max 40 files changed per PR (excluding lockfiles, generated files, snapshots, svg)
+- Max 800 lines of diff (additions + deletions) — enforced by `pr-size-guard.yml`
+  (repo vars `PR_MAX_LINES`/`PR_MAX_FILES`); approved mechanical codemods use `big-pr`
+- If a task requires more, split into a `gt` stack with clear dependencies
+  (see [`.claude/rules/pr-stacking.md`](pr-stacking.md))
 
 ### Pre-Push Gate
 

--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -16,7 +16,7 @@ gh api repos/JovieInc/Jovie/rulesets/10512119 \
   --jq '.rules[]|select(.type=="required_status_checks")|.parameters.required_status_checks[].context'
 ```
 
-1. **PR Ready** - Aggregate fast lane (`ci-fast`: typecheck + biome lint + server boundaries + guardrails)
+1. **PR Ready** - The single aggregate merge gate (`ci-pr-ready` job in `ci.yml`): fans in typecheck, biome, guardrails, structural contract, unit tests, risk classifier + risk-triggered preview evidence (build is advisory)
 2. **Migration Guard** - Database migration validation (path-gated to DB/schema changes)
 3. **Fork PR Gate** - Blocks unreviewed external fork PRs; auto-passes for agents + team
 4. **PR Size Guard** - Caps PR size (800 lines / 40 files) to force small, reviewable PRs; `big-pr` label opts out

--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -46,11 +46,12 @@ Graphite and branch protection must wait on **aggregate** contexts only — neve
 
 | Context | Role |
 | --- | --- |
-| `CI / PR Ready` | Single merge gate — aggregates ci-fast, unit tests, build, Lighthouse, risk-triggered smoke/preview |
+| `CI / PR Ready` | Single merge gate — fans in typecheck, biome, guardrails, structural contract, unit tests, risk classifier, and risk-triggered preview evidence (build is advisory) |
 | `CI / Migration Guard` | Path-gated schema/migration safety (independent aggregate) |
 | `Fork PR Gate` | Blocks unreviewed fork PRs (auto-passes for agents + team) |
+| `PR Size Guard` | Caps PR size (800 lines / 40 files); `big-pr` label opts out |
 
-**Queue CI runs the same workflow file and trigger as PR CI, with a reduced job set on `gtmq_*` batches.** Graphite does not use GitHub `merge_group` events. Speculative queue runs trigger the same `pull_request` workflow (`ci.yml`). `gtmq_*`-based PRs still get the real merge gates (`PR Ready`'s fast/unit/build checks, `Migration Guard`), but job-level `if:` conditions skip informational/preview-evidence lanes (Lighthouse, A11y, Mobile Overflow, Layout Guard, E2E Smoke, Golden Path, `DB Migrate (PR main)`, Preview Deploy, `PR Summary`) that never gated `PR Ready` and whose evidence was already produced on the source PR pre-enqueue. See `docs/PR_FLOW.md` §2 for the full rationale. There is no separate slim merge-queue *workflow file* — the reduction happens via existing job conditions in `ci.yml`.
+**Queue CI is the PR's own CI.** Graphite runs on every PR directly (not draft-batch mode), so `gtmq_*` batch branches are never created and the former slim-lane `if:` conditions were removed from `ci.yml` (#13610). Graphite does not use GitHub `merge_group` events. If batching mode is ever re-enabled, the slim-lane conditions must be restored with it — see `docs/PR_FLOW.md` §2 and the 2026-06-22 post-mortem.
 
 ### Graphite dashboard (`app.graphite.com/settings/merge-queue`) — OWL/human verify
 
@@ -74,7 +75,7 @@ Bisection behavior is also unit-tested in `scripts/lib/__tests__/merge-queue-gua
 
 ### GitHub (ruleset `Main Branch Protection`, id `10512119`) — `gh`-configurable
 
-- Required status checks: `CI / PR Ready`, `CI / Migration Guard`, `Fork PR Gate` (strict / up-to-date).
+- Required status checks: `PR Ready`, `Migration Guard`, `Fork PR Gate`, `PR Size Guard` (strict / up-to-date). Verify live: `gh api repos/JovieInc/Jovie/rulesets/10512119 --jq '.rules[]|select(.type=="required_status_checks")|.parameters.required_status_checks[].context'`
 - `required_linear_history`, `required_signatures`, `non_fast_forward`, `deletion`, `pull_request` (0 approvals).
 - **No `merge_queue` rule** (retired).
 - **Bypass actor: `graphite-app` (App ID `158384`), `bypass_mode: always`** — required so Graphite can merge through the protected branch. Source-of-record: `.github/rulesets/branch-protection.yml`.

--- a/docs/PR_FLOW.md
+++ b/docs/PR_FLOW.md
@@ -19,8 +19,9 @@ If you are an agent about to open a PR, read [Agent checklist](#agent-checklist)
 
 ## 1. Unit of work: one small PR → `main`
 
-- **Default: a small, focused PR targeting `main`.** ≤ 400 lines / 10 files
-  (`pr-size-guard`). Independent changes are **sibling PRs off `main`** — parallel,
+- **Default: a small, focused PR targeting `main`.** ≤ 800 lines / 40 files
+  (`pr-size-guard`, repo vars `PR_MAX_LINES`/`PR_MAX_FILES`; mechanical codemods
+  use `big-pr`). Independent changes are **sibling PRs off `main`** — parallel,
   never based on each other.
 - **Dependent work → a real `gt` stack** (`gt create` per step; restacks once;
   children auto-retarget to `main` as bases land). **Never** hand-create N
@@ -58,16 +59,13 @@ Rules:
   isn't required for correctness of *this* diff, path-gate it or move it off-PR.
 - Remaining lever: turbo `--affected` + remote cache on the PR gate so cache-hit
   jobs finish in seconds (tracked in JOV-3461).
-- **`gtmq_*` batch branches run a slim lane.** Graphite's merge queue re-runs the
-  full `ci.yml` `pull_request` workflow on each batch branch. Batches keep `PR
-  Ready`'s fast/unit/build checks plus `Migration Guard` — the actual merge
-  gates — but skip Lighthouse (all four surfaces), A11y, Mobile Overflow, Layout
-  Guard, E2E Smoke, Golden Path, `DB Migrate (PR main)`, Preview Deploy, and the
-  `PR Summary` comment. None of those lanes ever gated `PR Ready`; the evidence
-  they produce was already generated on the source PR before it entered the
-  queue, so re-running them per-batch is redundant compute, not redundant
-  safety. Layout Guard also moved off PRs entirely to run once post-merge
-  (`push: main`) instead of once per PR and once per gtmq batch.
+- **There is no separate merge-queue lane.** Graphite is configured to run on
+  every PR directly (not draft-batch mode), so `gtmq_*` batch branches are never
+  created and the gtmq slim-lane job conditions were removed from `ci.yml`
+  (#13610). The `pull_request` workflow on the PR itself is the only CI a change
+  pays for pre-merge. If Graphite's batching mode is ever re-enabled, the
+  slim-lane conditions must come back with it — see the 2026-06-22 post-mortem
+  below for why batches must never run the informational lanes.
 
 ### Does my change need the heavy lane, a preview, or taste approval?
 
@@ -184,8 +182,10 @@ Before you open a PR:
    one `big-pr` PR. Never base-on-base micro-PRs.
 2. **Don't add heavy CI to the PR path.** New scan/security/perf job → post-merge
    or nightly, not `pull_request`.
-3. **Taste-touching?** Add a screenshot to the body and let the 👍 gate handle it.
-   Otherwise expect it to auto-merge — don't add `needs-human`.
+3. **Taste-touching?** Add a screenshot to the body. The classifier applies
+   `llm-review` and the PR ships autonomously — there is no taste gate to wait
+   on (the old 👍 `taste-approve` workflow was removed 2026-07-06). Don't add
+   `needs-human`.
 4. **Verify locally** (typecheck, lint, affected tests), push, open a draft PR,
    let the fast gate run. Don't hand-merge; the queue does it.
 5. If a PR's base branch was deleted, **retarget to `main`** before debugging a


### PR DESCRIPTION
Stacked on #13838 → queue-hardening PR.

Doc/guardrail contradiction sweep (agent-audited, all claims verified against live workflows + ruleset):

- **PR_FLOW.md**: size caps 400/10 → actual 800/40; gtmq slim-lane section replaced with 'no separate merge-queue lane' (Graphite run-on-every-PR; batch branches never created; slim-lane conditions removed in #13610); agent checklist no longer points to the removed 👍 taste-approve gate.
- **release.md**: size caps corrected; gt-stack pointer.
- **ci-branching.md**: hard rule 1 no longer contradicts its own header + PR_FLOW.md (sibling PRs to main are the default); stale 2026-06-17 decision trigger resolved with rationale.
- **MERGE_QUEUE.md + BRANCH_PROTECTION.md**: one identical required-check set (PR Ready, Migration Guard, Fork PR Gate, PR Size Guard) + accurate description of what PR Ready fans in; dead gtmq claims removed.

Verified: `doc:freshness:check`, `ci:harness:check`, `ci:merge-queue:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)