### PR TITLE
feat(ios): converge to System B tokens — entity chips, slash palette, drawer skeleton, stat-tile stagger

### DIFF
--- a/apps/ios/Jovie/App/AppState.swift
+++ b/apps/ios/Jovie/App/AppState.swift
@@ -38,6 +38,9 @@ final class AppState {
   private let repository: AppStateRepository
   private let launchDate = Date()
   private var loadingUserID: String?
+  // Matches SplashView's cinematic entrance (JovieMotion.cinematicDuration)
+  // so the primary logo reveal completes before the route crossfade starts.
+  private let minimumSplashDuration = JovieMotion.cinematicDuration
 
   init(
     configuration: AppConfiguration,
@@ -53,7 +56,7 @@ final class AppState {
 
   func completeLaunch() async {
     let elapsed = Date().timeIntervalSince(launchDate)
-    let delay = max(0, 0.35 - elapsed)
+    let delay = max(0, minimumSplashDuration - elapsed)
     if delay > 0 {
       try? await Task.sleep(for: .seconds(delay))
     }

--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -322,7 +322,7 @@ private struct AppContentView: View {
     // Cross-fade between top-level routes (notably splash → app) so the first
     // content paint feels intentional rather than a hard cut. Opacity-only, so
     // no layout shift and no decorative spatial motion.
-    .animation(.easeInOut(duration: 0.28), value: appState.route)
+    .animation(JovieMotion.easeOut(duration: JovieMotion.slowDuration), value: appState.route)
     .task(id: "\(appState.route)-\(appState.launchMode)") {
       guard appState.route == .ready else { return }
       await reloadAudienceHighlights(for: appState.activeUserID)

--- a/apps/ios/Jovie/DesignSystem/JovieTheme.swift
+++ b/apps/ios/Jovie/DesignSystem/JovieTheme.swift
@@ -6,17 +6,19 @@ enum JovieColor {
   static let surface0 = Color(hex: 0x0A0B0E)
   static let surface1 = Color(hex: 0x101216)
   static let surface2 = Color(hex: 0x161A20)
-  static let surface3 = Color(hex: 0x1F2430)
+  static let surface3 = Color(hex: 0x2A2C32)
   static let textPrimary = Color(hex: 0xFFFFFF)
   static let textSecondary = Color(hex: 0xE3E4E6)
   static let textTertiary = Color(hex: 0x969799)
   static let borderSubtle = Color.white.opacity(0.05)
   static let borderDefault = Color.white.opacity(0.08)
   static let borderStrong = Color.white.opacity(0.10)
-  static let accentBlue = Color(hex: 0x0070F3)
-  static let accentPurple = Color(hex: 0x8B5CF6)
-  static let accentPink = Color(hex: 0xFF0080)
-  static let accent = accentBlue
+  static let accentBlue = Color(hex: 0x4D7DFF)
+  static let accentPurple = Color(hex: 0x9B4DFF)
+  static let accentPink = Color(hex: 0xEA4A9C)
+  static let accentOrange = Color(hex: 0xFFAB2E)
+  /// System B focus/active accent (`--color-accent`), not a CTA color.
+  static let accent = Color(hex: 0x7170FF)
   static let progressTrack = accentBlue.opacity(0.08)
   static let errorText = Color(hex: 0xFF7A73)
   static let qrSurface = Color.white
@@ -88,6 +90,35 @@ enum JovieRadius {
   static let large: CGFloat = 12
   static let xLarge: CGFloat = 16
   static let pill: CGFloat = 999
+}
+
+/// System B motion tokens, ported from apps/web/styles/design-system.css.
+/// SUBTLE for micro-interactions (press, color, toast); CINEMATIC for
+/// high-impact reveals (drawer, modal, surface morph). Movement (offset/scale)
+/// must be dropped under Reduce Motion; opacity transitions may remain.
+enum JovieMotion {
+  static let instantDuration: Double = 0.05
+  static let fastDuration: Double = 0.10
+  static let normalDuration: Double = 0.16
+  static let subtleDuration: Double = 0.15
+  static let slowDuration: Double = 0.25
+  static let cinematicDuration: Double = 0.42
+
+  /// --ease-subtle @ 150ms — hover/press/color micro-changes.
+  static let subtle = Animation.timingCurve(0.4, 0, 0.2, 1, duration: subtleDuration)
+  /// --ease-cinematic @ 420ms — drawers, modals, surface morphs.
+  static let cinematic = Animation.timingCurve(0.22, 1, 0.36, 1, duration: cinematicDuration)
+  /// --ease-out — enter/exit; starts fast so it feels responsive.
+  static func easeOut(duration: Double = normalDuration) -> Animation {
+    .timingCurve(0.16, 1, 0.3, 1, duration: duration)
+  }
+  /// --ease-spring — rare playful overshoot, opt-in only.
+  static func spring(duration: Double = slowDuration) -> Animation {
+    .timingCurve(0.34, 1.56, 0.64, 1, duration: duration)
+  }
+
+  /// --scale-press — canonical press-down scale for pressable elements.
+  static let pressScale: CGFloat = 0.96
 }
 
 enum JovieQRCodePlate {
@@ -169,7 +200,8 @@ struct JoviePillButtonStyle: ButtonStyle {
           )
       }
       .opacity(configuration.isPressed ? 0.8 : 1)
-      .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+      .scaleEffect(configuration.isPressed ? JovieMotion.pressScale : 1)
+      .animation(JovieMotion.subtle, value: configuration.isPressed)
   }
 }
 
@@ -184,7 +216,8 @@ struct JovieIconButtonStyle: ButtonStyle {
         Circle().stroke(JovieColor.borderDefault, lineWidth: 1)
       }
       .opacity(configuration.isPressed ? 0.72 : 1)
-      .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+      .scaleEffect(configuration.isPressed ? JovieMotion.pressScale : 1)
+      .animation(JovieMotion.subtle, value: configuration.isPressed)
   }
 }
 

--- a/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
@@ -22,6 +22,17 @@ enum AppShellDrawerThreadsFilter {
       return title.localizedCaseInsensitiveContains(trimmed)
     }
   }
+
+  // Loading skeleton only makes sense while there is nothing cached to show
+  // yet — once any conversation is cached, prefer showing stale data over a
+  // skeleton flash (stale-while-revalidate, matches the dashboard/audience
+  // cache-first canon).
+  static func shouldShowLoadingSkeleton(
+    isLoading: Bool,
+    conversations: [MobileConversationSummary]
+  ) -> Bool {
+    isLoading && conversations.isEmpty
+  }
 }
 
 // The drawer is mounted as the recessed BASE plane behind the elevated content
@@ -37,6 +48,7 @@ struct AppShellLeftDrawer: View {
   let audienceEnabled: Bool
   let selectedTab: AppShellTab
   let recentConversations: [MobileConversationSummary]
+  let isLoadingConversations: Bool
   let activeConversationID: String?
   let drawerWidth: CGFloat
   let onSelectTab: (AppShellTab) -> Void
@@ -45,6 +57,10 @@ struct AppShellLeftDrawer: View {
   let onOpenSettings: () -> Void
 
   @State private var threadSearch = ""
+  // Decorative open-stagger only; the drawer is fully interactive regardless
+  // of this flag (rows never block on it — see DrawerRowRevealModifier).
+  @State private var contentRevealed = false
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   private var filteredConversations: [MobileConversationSummary] {
     AppShellDrawerThreadsFilter.filtered(
@@ -73,22 +89,28 @@ struct AppShellLeftDrawer: View {
             selectedTab: selectedTab,
             onSelectTab: onSelectTab
           )
+          .drawerRowReveal(isRevealed: contentRevealed, delay: 0, reduceMotion: reduceMotion)
 
           DrawerAccountHeader(profile: profile)
+            .drawerRowReveal(isRevealed: contentRevealed, delay: 0.04, reduceMotion: reduceMotion)
 
           if chatEnabled {
             DrawerNewChatButton(action: onStartNewChat)
+              .drawerRowReveal(isRevealed: contentRevealed, delay: 0.08, reduceMotion: reduceMotion)
 
             DrawerThreadsSection(
               searchText: $threadSearch,
               conversations: filteredConversations,
               totalCount: recentConversations.count,
+              isLoading: isLoadingConversations,
               activeConversationID: activeConversationID,
               onSelectConversation: onSelectConversation
             )
+            .drawerRowReveal(isRevealed: contentRevealed, delay: 0.08, reduceMotion: reduceMotion)
           }
 
           DrawerSettingsRow(action: onOpenSettings)
+            .drawerRowReveal(isRevealed: contentRevealed, delay: 0.12, reduceMotion: reduceMotion)
         }
         .padding(.horizontal, JovieSpacing.large)
         .padding(.bottom, JovieSpacing.xxLarge)
@@ -104,6 +126,50 @@ struct AppShellLeftDrawer: View {
       guard !isPresented else { return }
       threadSearch = ""
     }
+    // Reveal is purely decorative (opacity/offset only, see the modifier
+    // below) — it never gates hit-testing or accessibility, both of which
+    // stay driven by `isPresented` above.
+    .task(id: isPresented) {
+      guard isPresented else {
+        contentRevealed = false
+        return
+      }
+
+      guard !reduceMotion else {
+        contentRevealed = true
+        return
+      }
+
+      contentRevealed = false
+      try? await Task.sleep(nanoseconds: 20_000_000)
+      contentRevealed = true
+    }
+  }
+}
+
+// Decorative stagger for the drawer's open animation: rows fade + slide in a
+// short distance, `delay` apart. Opacity-only (no offset) and undelayed under
+// Reduce Motion per motion.md §6. Never affects interactivity — hit-testing
+// is controlled solely by `isPresented` on the drawer root.
+private struct DrawerRowRevealModifier: ViewModifier {
+  let isRevealed: Bool
+  let delay: Double
+  let reduceMotion: Bool
+
+  func body(content: Content) -> some View {
+    content
+      .opacity(isRevealed ? 1 : 0)
+      .offset(x: (reduceMotion || isRevealed) ? 0 : -8)
+      .animation(
+        reduceMotion ? nil : JovieMotion.easeOut().delay(delay),
+        value: isRevealed
+      )
+  }
+}
+
+private extension View {
+  func drawerRowReveal(isRevealed: Bool, delay: Double, reduceMotion: Bool) -> some View {
+    modifier(DrawerRowRevealModifier(isRevealed: isRevealed, delay: delay, reduceMotion: reduceMotion))
   }
 }
 
@@ -205,7 +271,7 @@ private struct DrawerSurfaceButton: View {
           .stroke(isSelected ? JovieColor.borderDefault : Color.clear, lineWidth: 1)
       }
     }
-    .buttonStyle(.plain)
+    .buttonStyle(DrawerRowButtonStyle())
     .frame(maxWidth: .infinity, minHeight: 62, maxHeight: 62)
     .accessibilityLabel(tab.title)
     .accessibilityAddTraits(isSelected ? [.isSelected] : [])
@@ -233,7 +299,7 @@ private struct DrawerNewChatButton: View {
       .padding(.horizontal, JovieSpacing.medium)
       .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
     }
-    .buttonStyle(.plain)
+    .buttonStyle(DrawerRowButtonStyle())
     .accessibilityLabel("New chat")
     .accessibilityIdentifier("shell-drawer-new-chat")
   }
@@ -243,8 +309,11 @@ private struct DrawerThreadsSection: View {
   @Binding var searchText: String
   let conversations: [MobileConversationSummary]
   let totalCount: Int
+  let isLoading: Bool
   let activeConversationID: String?
   let onSelectConversation: (String) -> Void
+
+  private static let skeletonRowCount = 5
 
   var body: some View {
     VStack(alignment: .leading, spacing: JovieSpacing.medium) {
@@ -268,7 +337,19 @@ private struct DrawerThreadsSection: View {
       .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
       .accessibilityIdentifier("shell-drawer-search")
 
-      if totalCount == 0 {
+      // Skeleton mirrors DrawerThreadRow's exact paddings/height so the
+      // skeleton -> loaded swap causes zero layout shift. Only shown while
+      // there is nothing cached yet (AppShellDrawerThreadsFilter.shouldShowLoadingSkeleton) --
+      // once a conversation is cached, stale rows are preferred over a flash.
+      if AppShellDrawerThreadsFilter.shouldShowLoadingSkeleton(isLoading: isLoading, conversations: conversations) {
+        VStack(spacing: JovieSpacing.xSmall) {
+          ForEach(0 ..< Self.skeletonRowCount, id: \.self) { _ in
+            DrawerThreadRowSkeleton()
+          }
+        }
+        .redacted(reason: .placeholder)
+        .accessibilityHidden(true)
+      } else if totalCount == 0 {
         Text("Start a conversation to see recent conversations here.")
           .font(JovieFont.body(size: 15))
           .foregroundStyle(JovieColor.textTertiary)
@@ -316,8 +397,31 @@ private struct DrawerThreadRow: View {
         in: RoundedRectangle(cornerRadius: JovieRadius.small, style: .continuous)
       )
     }
-    .buttonStyle(.plain)
+    .buttonStyle(DrawerRowButtonStyle())
     .accessibilityIdentifier("shell-drawer-thread-\(conversation.id)")
+  }
+}
+
+// Exactly mirrors DrawerThreadRow's paddings, font, and single-line height so
+// the loading -> loaded swap in DrawerThreadsSection causes zero layout
+// shift. Non-interactive (no Button, no action) -- it is purely a visual
+// placeholder gated on `.redacted(reason: .placeholder)` by its parent.
+private struct DrawerThreadRowSkeleton: View {
+  var body: some View {
+    HStack(spacing: JovieSpacing.medium) {
+      Text("Loading conversation")
+        .font(JovieFont.body(size: 15, weight: .regular))
+        .foregroundStyle(JovieColor.textSecondary)
+        .lineLimit(1)
+
+      Spacer(minLength: 0)
+    }
+    .padding(.vertical, JovieSpacing.small)
+    .padding(.horizontal, JovieSpacing.small)
+    .background(
+      Color.clear,
+      in: RoundedRectangle(cornerRadius: JovieRadius.small, style: .continuous)
+    )
   }
 }
 
@@ -340,8 +444,22 @@ private struct DrawerSettingsRow: View {
       .padding(.vertical, 13)
       .padding(.horizontal, JovieSpacing.medium)
     }
-    .buttonStyle(.plain)
+    .buttonStyle(DrawerRowButtonStyle())
     .accessibilityLabel("Settings")
     .accessibilityIdentifier("shell-drawer-settings")
+  }
+}
+
+// Canonical drawer-row press feedback (background dim + JovieMotion.pressScale),
+// shared by every plain-content Button row in the drawer (new chat, threads,
+// settings). Mirrors JoviePillButtonStyle/JovieIconButtonStyle in
+// DesignSystem/JovieTheme.swift but without their filled backgrounds, since
+// drawer rows are flush against the drawer canvas.
+private struct DrawerRowButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .opacity(configuration.isPressed ? 0.72 : 1)
+      .scaleEffect(configuration.isPressed ? JovieMotion.pressScale : 1)
+      .animation(JovieMotion.subtle, value: configuration.isPressed)
   }
 }

--- a/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellLeftDrawer.swift
@@ -1,10 +1,5 @@
 import SwiftUI
 
-enum JovieMotion {
-  static let cinematicDuration: Double = 0.42
-  static let cinematic = Animation.timingCurve(0.22, 1, 0.36, 1, duration: cinematicDuration)
-}
-
 enum AppShellDrawerSurfaceLayout {
   static let labelMinimumScaleFactor: CGFloat = 0.85
   static let maxSingleLineSurfaceButtonHeight: CGFloat = 56

--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -94,6 +94,7 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
   let chatEnabled: Bool
   let audienceEnabled: Bool
   let recentConversations: [MobileConversationSummary]
+  let isLoadingConversations: Bool
   let activeConversationID: String?
   let onSelectConversation: (String) -> Void
   let onStartNewChat: () -> Void
@@ -123,6 +124,7 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     chatEnabled: Bool = false,
     audienceEnabled: Bool = true,
     recentConversations: [MobileConversationSummary] = [],
+    isLoadingConversations: Bool = false,
     activeConversationID: String? = nil,
     onSelectConversation: @escaping (String) -> Void = { _ in },
     onStartNewChat: @escaping () -> Void = {},
@@ -139,6 +141,7 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     self.chatEnabled = chatEnabled
     self.audienceEnabled = audienceEnabled
     self.recentConversations = recentConversations
+    self.isLoadingConversations = isLoadingConversations
     self.activeConversationID = activeConversationID
     self.onSelectConversation = onSelectConversation
     self.onStartNewChat = onStartNewChat
@@ -172,6 +175,7 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
             audienceEnabled: audienceEnabled,
             selectedTab: selectedTab,
             recentConversations: recentConversations,
+            isLoadingConversations: isLoadingConversations,
             activeConversationID: activeConversationID,
             drawerWidth: drawerWidth,
             onSelectTab: { tab in
@@ -350,7 +354,7 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     }
 
     if state.selectedTab != previousTab {
-      withAnimation(.easeInOut(duration: 0.25)) {
+      withAnimation(JovieMotion.easeOut(duration: JovieMotion.slowDuration)) {
         selectedTab = state.selectedTab
       }
     } else {
@@ -359,7 +363,7 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
   }
 
   private func selectTab(_ tab: AppShellTab) {
-    withAnimation(.easeInOut(duration: 0.25)) {
+    withAnimation(JovieMotion.easeOut(duration: JovieMotion.slowDuration)) {
       selectedTab = tab
     }
   }
@@ -388,7 +392,7 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
   }
 
   private var drawerAnimation: Animation {
-    reduceMotion ? .easeInOut(duration: 0.2) : JovieMotion.cinematic
+    reduceMotion ? JovieMotion.subtle : JovieMotion.cinematic
   }
 
   private func drawerOpenOffset(safeAreaLeading: CGFloat) -> CGFloat {
@@ -494,7 +498,7 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
               value.startLocation.x >= 28 || horizontal < 0
         else { return }
 
-        withAnimation(.easeInOut(duration: 0.28)) {
+        withAnimation(JovieMotion.easeOut(duration: JovieMotion.slowDuration)) {
           if horizontal < 0, selectedTab == .profile {
             selectedTab = .chat
           } else if horizontal > 0, selectedTab == .chat {

--- a/apps/ios/Jovie/Features/Audience/AudienceHighlightsView.swift
+++ b/apps/ios/Jovie/Features/Audience/AudienceHighlightsView.swift
@@ -6,6 +6,12 @@ struct AudienceHighlightsView: View {
   let onRetry: () async -> Void
   let onAskJovie: (String) -> Void
 
+  // Guards the stat-tile entrance stagger to the very first successful load
+  // only -- subsequent revalidates (pull-to-refresh, background refetch) must
+  // never replay the animation on data the user is already looking at.
+  @State private var didAnimateStatTilesIn = false
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
   private static let numberFormatter: NumberFormatter = {
     let formatter = NumberFormatter()
     formatter.numberStyle = .decimal
@@ -98,11 +104,30 @@ struct AudienceHighlightsView: View {
         ],
         spacing: JovieSpacing.medium
       ) {
-        ForEach(response.statTiles) { tile in
+        ForEach(Array(response.statTiles.enumerated()), id: \.element.id) { index, tile in
           statTile(tile)
+            .statTileReveal(
+              isRevealed: didAnimateStatTilesIn,
+              delay: reduceMotion ? 0 : Double(index) * 0.05,
+              reduceMotion: reduceMotion
+            )
         }
       }
       .accessibilityIdentifier("audience-highlights-stat-tiles")
+      .task {
+        guard !didAnimateStatTilesIn else { return }
+
+        if reduceMotion {
+          didAnimateStatTilesIn = true
+          return
+        }
+
+        // Let the grid lay out at opacity 0 for one frame before revealing,
+        // otherwise SwiftUI coalesces the false->true state change and the
+        // tiles never visibly animate in.
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        didAnimateStatTilesIn = true
+      }
 
       Button {
         onAskJovie(response.chatPrompt)
@@ -219,5 +244,32 @@ struct AudienceHighlightsView: View {
 
   private func format(_ value: Int) -> String {
     Self.numberFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+  }
+}
+
+// Decorative first-load stagger for stat tiles: fades + rises a short
+// distance in, `delay` apart per tile. Opacity-only (no offset) and
+// undelayed under Reduce Motion per motion.md §6. Guarded by the caller
+// (`didAnimateStatTilesIn`) to first-load only -- never replays on
+// revalidate/refresh.
+private struct StatTileRevealModifier: ViewModifier {
+  let isRevealed: Bool
+  let delay: Double
+  let reduceMotion: Bool
+
+  func body(content: Content) -> some View {
+    content
+      .opacity(isRevealed ? 1 : 0)
+      .offset(y: (reduceMotion || isRevealed) ? 0 : 8)
+      .animation(
+        reduceMotion ? nil : JovieMotion.easeOut().delay(delay),
+        value: isRevealed
+      )
+  }
+}
+
+private extension View {
+  func statTileReveal(isRevealed: Bool, delay: Double, reduceMotion: Bool) -> some View {
+    modifier(StatTileRevealModifier(isRevealed: isRevealed, delay: delay, reduceMotion: reduceMotion))
   }
 }

--- a/apps/ios/Jovie/Features/Auth/AuthScreen.swift
+++ b/apps/ios/Jovie/Features/Auth/AuthScreen.swift
@@ -20,6 +20,13 @@ struct AuthScreen: View {
 
   @State private var authCoordinator = MobileAuthCoordinator()
   @State private var didRequestBrowserAuth = false
+  @State private var hasAppeared = false
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  /// Staggered first-appearance entrance: logo -> tagline -> button, 50ms
+  /// apart (within the 30-80ms stagger band, .claude/rules/motion.md section 4).
+  private static let entranceStagger: Double = 0.05
+  private static let entranceOffset: CGFloat = 8
 
   var body: some View {
     ZStack {
@@ -29,14 +36,39 @@ struct AuthScreen: View {
         Spacer(minLength: 96)
 
         VStack(spacing: JovieSpacing.xxLarge) {
-          JovieLogoMark(size: 76)
-            .accessibilityIdentifier("auth-jovie-logo")
+          VStack(spacing: JovieSpacing.medium) {
+            JovieLogoMark(size: 76)
+              .accessibilityIdentifier("auth-jovie-logo")
+              .authEntrance(
+                hasAppeared: hasAppeared,
+                reduceMotion: reduceMotion,
+                delay: 0,
+                offset: Self.entranceOffset
+              )
+
+            Text("Your Music, One Link")
+              .font(JovieFont.body(size: 14, weight: .medium))
+              .foregroundStyle(JovieColor.textTertiary)
+              .accessibilityIdentifier("auth-tagline")
+              .authEntrance(
+                hasAppeared: hasAppeared,
+                reduceMotion: reduceMotion,
+                delay: Self.entranceStagger,
+                offset: Self.entranceOffset
+              )
+          }
 
           BrowserAuthActions(
             isOpening: didRequestBrowserAuth,
             isDisabled: isSignInUnavailable,
             errorMessage: errorMessage,
             action: startBrowserAuth
+          )
+          .authEntrance(
+            hasAppeared: hasAppeared,
+            reduceMotion: reduceMotion,
+            delay: Self.entranceStagger * 2,
+            offset: Self.entranceOffset
           )
         }
         .frame(maxWidth: 430)
@@ -47,6 +79,10 @@ struct AuthScreen: View {
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     .accessibilityIdentifier("auth-screen")
+    .onAppear {
+      guard !hasAppeared else { return }
+      hasAppeared = true
+    }
   }
 
   private func startBrowserAuth() {
@@ -453,5 +489,29 @@ private struct AuthErrorText: View {
       .frame(minHeight: 36)
       .frame(maxWidth: .infinity)
       .accessibilityHidden(message == nil)
+  }
+}
+
+/// Staged first-appearance entrance: opacity 0->1 + translateY <=8pt->0 on
+/// ease-out. Reduce Motion drops the offset and animates opacity only
+/// (.claude/rules/motion.md section 6). Opacity/offset never affect layout,
+/// so this cannot introduce layout shift.
+private struct AuthEntranceModifier: ViewModifier {
+  let hasAppeared: Bool
+  let reduceMotion: Bool
+  let delay: Double
+  let offset: CGFloat
+
+  func body(content: Content) -> some View {
+    content
+      .opacity(hasAppeared ? 1 : 0)
+      .offset(y: reduceMotion ? 0 : (hasAppeared ? 0 : offset))
+      .animation(JovieMotion.easeOut().delay(delay), value: hasAppeared)
+  }
+}
+
+private extension View {
+  func authEntrance(hasAppeared: Bool, reduceMotion: Bool, delay: Double, offset: CGFloat) -> some View {
+    modifier(AuthEntranceModifier(hasAppeared: hasAppeared, reduceMotion: reduceMotion, delay: delay, offset: offset))
   }
 }

--- a/apps/ios/Jovie/Features/Chat/ComposerWorkflowSheet.swift
+++ b/apps/ios/Jovie/Features/Chat/ComposerWorkflowSheet.swift
@@ -154,9 +154,15 @@ struct ChatComposerBar: View {
   @State private var isShowingWorkflowSheet = false
   @State private var didStartVoiceDrag = false
   @State private var isVoiceDragCancelled = false
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   var body: some View {
     let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+    let slashQuery = ComposerSlashPalette.query(from: draft)
+    let slashItems = slashQuery.map {
+      ComposerSlashPalette.items(matching: $0, skills: ComposerSlashPalette.defaultSkills)
+    } ?? []
+    let isSlashPaletteVisible = slashQuery != nil && !slashItems.isEmpty
 
     VStack(spacing: 0) {
       waveformStrip
@@ -205,6 +211,25 @@ struct ChatComposerBar: View {
         .stroke(JovieColor.borderDefault, lineWidth: 1)
     }
     .accessibilityIdentifier("chat-composer")
+    .overlay(alignment: .top) {
+      // Anchored ABOVE the bar via alignmentGuide so the transcript and the
+      // bar itself never reflow — zero layout shift by construction.
+      Group {
+        if isSlashPaletteVisible {
+          ComposerSlashPaletteView(items: slashItems) { item in
+            commitSlashItem(item)
+          }
+          .alignmentGuide(.top) { dimensions in
+            dimensions[.bottom] + JovieSpacing.small
+          }
+          .transition(slashPaletteTransition)
+        }
+      }
+      .animation(
+        isSlashPaletteVisible ? JovieMotion.cinematic : JovieMotion.subtle,
+        value: isSlashPaletteVisible
+      )
+    }
     .sheet(isPresented: $isShowingWorkflowSheet) {
       ComposerWorkflowSheet { action in
         isShowingWorkflowSheet = false
@@ -213,6 +238,35 @@ struct ChatComposerBar: View {
       .presentationDetents([.height(ComposerWorkflowSheetHeight.estimated)])
       .presentationDragIndicator(.visible)
       .presentationBackground(JovieColor.surface0)
+    }
+  }
+
+  /// Entry: opacity 0→1 + offset y +8→0 on cinematic; exit: opacity-only on
+  /// subtle (exits faster than enters). Under Reduce Motion the offset
+  /// movement is dropped and only opacity remains.
+  private var slashPaletteTransition: AnyTransition {
+    let insertion: AnyTransition =
+      reduceMotion
+      ? .opacity
+      : .opacity.combined(with: .offset(y: 8))
+    return .asymmetric(
+      insertion: insertion.animation(JovieMotion.cinematic),
+      removal: AnyTransition.opacity.animation(JovieMotion.subtle)
+    )
+  }
+
+  private func commitSlashItem(_ item: ComposerSlashItem) {
+    switch item {
+    case let .workflow(action):
+      // Same prompt-injection path as the plus-button workflow sheet; the
+      // injected prompt no longer starts with a bare "/", which dismisses
+      // the palette.
+      onSelectWorkflow(action)
+    case .skill:
+      if let committed = ComposerSlashPalette.committedDraft(for: item) {
+        // "/skill:id " contains ":" so the palette dismisses immediately.
+        draft = committed
+      }
     }
   }
 
@@ -312,4 +366,218 @@ struct ChatComposerBar: View {
 
 enum ComposerWorkflowSheetHeight {
   static let estimated: CGFloat = 360
+}
+
+// MARK: - Slash command palette (typed "/" in the composer)
+
+/// One row in the composer slash palette: either a workflow shortcut
+/// (mirrors the plus-button sheet) or a `/skill:id` chat skill.
+enum ComposerSlashItem: Identifiable, Equatable {
+  case workflow(ComposerWorkflowAction)
+  case skill(id: String, label: String)
+
+  var id: String {
+    switch self {
+    case let .workflow(action):
+      return "workflow-\(action.rawValue)"
+    case let .skill(id, _):
+      return "skill-\(id)"
+    }
+  }
+
+  var title: String {
+    switch self {
+    case let .workflow(action):
+      return action.title
+    case let .skill(_, label):
+      return label
+    }
+  }
+}
+
+/// Pure logic for the composer slash palette. Mirrors the web
+/// `SlashCommandMenu`: typing a leading "/" opens the palette, typing
+/// filters it live, committing a row injects the workflow prompt or a
+/// `/skill:id ` token, and anything that stops being a bare in-progress
+/// slash command dismisses it.
+enum ComposerSlashPalette {
+  static let maxSkillItems = 8
+
+  /// Skills offered by the palette, derived from the shared `/skill:id`
+  /// label registry, sorted by display label for stable presentation.
+  static var defaultSkills: [(id: String, label: String)] {
+    MobileChatSkillLabels.registry
+      .map { (id: $0.key, label: $0.value) }
+      .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
+  }
+
+  /// Returns the filter query when `draft` is a bare slash command in
+  /// progress (leading "/", no whitespace, no ":"), else nil. Nil means the
+  /// palette is closed: an empty draft, prose, a committed `/skill:id `
+  /// token, and "/ hi" (whitespace after the slash) all dismiss it.
+  static func query(from draft: String) -> String? {
+    guard draft.hasPrefix("/") else { return nil }
+    let query = String(draft.dropFirst())
+    guard !query.contains(where: \.isWhitespace), !query.contains(":") else { return nil }
+    return query
+  }
+
+  /// Case-insensitive contains filtering. All matching workflows first
+  /// (stable `allCases` order), then up to `maxSkillItems` skills in the
+  /// caller's order. An empty query returns everything.
+  static func items(
+    matching query: String,
+    skills: [(id: String, label: String)]
+  ) -> [ComposerSlashItem] {
+    let workflows = ComposerWorkflowAction.allCases
+      .filter { matches(query, candidate: $0.title) }
+      .map(ComposerSlashItem.workflow)
+
+    let skillItems = skills
+      .filter { matches(query, candidate: $0.label) || matches(query, candidate: $0.id) }
+      .prefix(maxSkillItems)
+      .map { ComposerSlashItem.skill(id: $0.id, label: $0.label) }
+
+    return workflows + skillItems
+  }
+
+  /// Draft text a commit writes back into the composer, or nil when the
+  /// commit is handled by the existing workflow prompt-injection path
+  /// (`onSelectWorkflow`, same as the plus-button sheet).
+  static func committedDraft(for item: ComposerSlashItem) -> String? {
+    switch item {
+    case .workflow:
+      return nil
+    case let .skill(id, _):
+      return "/skill:\(id) "
+    }
+  }
+
+  private static func matches(_ query: String, candidate: String) -> Bool {
+    guard !query.isEmpty else { return true }
+    return candidate.range(of: query, options: .caseInsensitive) != nil
+  }
+}
+
+private enum ComposerSlashPaletteMetrics {
+  static let rowHeight: CGFloat = 44
+  static let headerHeight: CGFloat = 24
+  static let maxHeight: CGFloat = 320
+}
+
+private struct ComposerSlashPaletteView: View {
+  let items: [ComposerSlashItem]
+  let onSelect: (ComposerSlashItem) -> Void
+
+  private var workflows: [ComposerSlashItem] {
+    items.filter { if case .workflow = $0 { return true } else { return false } }
+  }
+
+  private var skills: [ComposerSlashItem] {
+    items.filter { if case .skill = $0 { return true } else { return false } }
+  }
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: JovieSpacing.small) {
+        if !workflows.isEmpty {
+          section(header: "Suggestions", items: workflows)
+        }
+        if !skills.isEmpty {
+          section(header: "Skills", items: skills)
+        }
+      }
+      .padding(JovieSpacing.small)
+    }
+    .frame(height: min(ComposerSlashPaletteMetrics.maxHeight, estimatedContentHeight))
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: JovieRadius.xLarge, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: JovieRadius.xLarge, style: .continuous)
+        .stroke(JovieColor.borderDefault, lineWidth: 1)
+    }
+    .accessibilityIdentifier("composer-slash-palette")
+  }
+
+  private var estimatedContentHeight: CGFloat {
+    var height = JovieSpacing.small * 2
+    var sectionCount = 0
+    for sectionItems in [workflows, skills] where !sectionItems.isEmpty {
+      sectionCount += 1
+      height += ComposerSlashPaletteMetrics.headerHeight
+      height += CGFloat(sectionItems.count) * ComposerSlashPaletteMetrics.rowHeight
+    }
+    if sectionCount == 2 {
+      height += JovieSpacing.small
+    }
+    return height
+  }
+
+  private func section(header: String, items: [ComposerSlashItem]) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Text(header)
+        .font(JovieFont.body(size: 12, weight: .semibold))
+        .foregroundStyle(JovieColor.textTertiary)
+        .frame(height: ComposerSlashPaletteMetrics.headerHeight)
+        .padding(.horizontal, JovieSpacing.medium)
+
+      ForEach(items) { item in
+        Button {
+          onSelect(item)
+        } label: {
+          ComposerSlashPaletteRow(item: item)
+        }
+        .buttonStyle(ComposerSlashRowButtonStyle())
+        .accessibilityLabel(item.title)
+        .accessibilityIdentifier("composer-slash-\(item.id)")
+      }
+    }
+  }
+}
+
+private struct ComposerSlashPaletteRow: View {
+  let item: ComposerSlashItem
+
+  var body: some View {
+    HStack(spacing: JovieSpacing.medium) {
+      icon
+        .frame(width: 24, height: 24)
+
+      Text(item.title)
+        .font(JovieFont.body(size: 15))
+        .foregroundStyle(JovieColor.textPrimary)
+        .lineLimit(1)
+
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, JovieSpacing.medium)
+    .frame(height: ComposerSlashPaletteMetrics.rowHeight)
+    .contentShape(RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous))
+  }
+
+  @ViewBuilder
+  private var icon: some View {
+    switch item {
+    case let .workflow(action):
+      Image(systemName: action.systemImage)
+        .font(.system(size: 15, weight: .semibold))
+        .foregroundStyle(JovieColor.textPrimary)
+    case .skill:
+      Circle()
+        .fill(JovieColor.accent)
+        .frame(width: 6, height: 6)
+    }
+  }
+}
+
+/// Press feedback for palette rows: background highlight only (no offset,
+/// no scale) on `JovieMotion.subtle`.
+private struct ComposerSlashRowButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .background(
+        RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
+          .fill(configuration.isPressed ? JovieColor.surface3 : Color.clear)
+      )
+      .animation(JovieMotion.subtle, value: configuration.isPressed)
+  }
 }

--- a/apps/ios/Jovie/Features/Chat/MobileChatMerchOptionsView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatMerchOptionsView.swift
@@ -66,6 +66,10 @@ struct MobileChatMerchOptionsView: View {
               accent: merchAccent(for: design.optionNumber)
             )
             .overlay {
+              // The mockup square keeps a fixed `aspectRatio(1)` footprint
+              // (see `mockupImage`) in every state, so this overlay only
+              // needs an opacity crossfade -- no size/position ever moves
+              // when "Rendering" clears.
               if !design.isReady {
                 VStack(spacing: JovieSpacing.xSmall) {
                   ProgressView().tint(JovieColor.textTertiary)
@@ -73,8 +77,10 @@ struct MobileChatMerchOptionsView: View {
                     .font(JovieFont.body(size: 11, weight: .medium))
                     .foregroundStyle(JovieColor.textTertiary)
                 }
+                .transition(.opacity)
               }
             }
+            .animation(JovieMotion.subtle, value: design.isReady)
 
             Text(design.designName)
               .font(JovieFont.body(size: 14, weight: .semibold))

--- a/apps/ios/Jovie/Features/Chat/MobileChatToolCardView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatToolCardView.swift
@@ -5,11 +5,17 @@ struct MobileChatToolCardView: View {
 
   var body: some View {
     HStack(alignment: .top, spacing: JovieSpacing.medium) {
+      // `.id(model.state)` forces a view-identity swap on state change so the
+      // old icon fades out and the new one fades in via `.transition`,
+      // instead of jump-cutting; the frame stays fixed at 20x20 across every
+      // state so the crossfade never shifts the card's layout.
       Image(systemName: iconName)
         .font(.system(size: 15, weight: .semibold))
         .foregroundStyle(iconColor)
         .frame(width: 20, height: 20)
         .padding(.top, 1)
+        .id(model.state)
+        .transition(.opacity)
 
       VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
         Text(model.title)
@@ -34,6 +40,7 @@ struct MobileChatToolCardView: View {
       RoundedRectangle(cornerRadius: 16, style: .continuous)
         .stroke(JovieColor.borderDefault, lineWidth: 1)
     }
+    .animation(JovieMotion.subtle, value: model.state)
     .accessibilityElement(children: .combine)
     .accessibilityLabel(accessibilityLabel)
     .accessibilityIdentifier("mobile-chat-tool-card")

--- a/apps/ios/Jovie/Features/Chat/MobileChatView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatView.swift
@@ -60,8 +60,13 @@ struct MobileChatView: View {
                 Task { await repository.send(text: prompt) }
               }
             )
+            .transition(.opacity.combined(with: .offset(y: 6)))
           }
         }
+        // Keyed on `count` only, so this fires when a message is appended --
+        // never on in-place streaming text/status mutations of an existing
+        // row, which must render without animation.
+        .animation(JovieMotion.easeOut(), value: repository.timeline.count)
         .padding(.horizontal, JovieSpacing.large)
         .padding(.top, JovieSpacing.xLarge)
         .padding(.bottom, JovieSpacing.medium)
@@ -299,9 +304,11 @@ private struct MobileChatMessageRow: View {
     let showsThinking = displayText.isEmpty && !hasRenderableSegments && isStreamingAssistant
 
     if showsThinking {
-      Text("Thinking…")
-        .font(JovieFont.body(size: 16))
-        .foregroundStyle(JovieColor.textPrimary)
+      // Same padding/background/corner-radius/frame as the assistant prose
+      // bubble below -- only the inner content (dots vs. text) differs, so
+      // swapping this bubble out for real content is a normal content-size
+      // change, not a layout-shift bug.
+      MobileChatThinkingDotsView()
         .padding(.horizontal, JovieSpacing.large)
         .padding(.vertical, JovieSpacing.medium)
         .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
@@ -348,6 +355,54 @@ private struct MobileChatMessageRow: View {
       runs.append(contentsOf: segmentRuns)
     }
     return runs
+  }
+}
+
+/// Three-dot streaming indicator that replaces the old "Thinking…" text.
+/// Dots pulse in sequence (staggered `.delay`) via `repeatForever`; under
+/// Reduce Motion they render static (no movement/opacity animation) per
+/// `.claude/rules/motion.md` §6. The row height is pinned to match a 16pt
+/// body line so it reserves the same footprint the text bubble used.
+private struct MobileChatThinkingDotsView: View {
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var isPulsing = false
+
+  private static let dotSize: CGFloat = 6
+  private static let dotSpacing: CGFloat = 4
+  private static let rowHeight: CGFloat = 20
+
+  var body: some View {
+    HStack(spacing: Self.dotSpacing) {
+      ForEach(0..<3, id: \.self) { index in
+        Circle()
+          .fill(JovieColor.textTertiary)
+          .frame(width: Self.dotSize, height: Self.dotSize)
+          .opacity(dotOpacity)
+          .animation(dotAnimation(delayIndex: index), value: isPulsing)
+      }
+    }
+    .frame(height: Self.rowHeight, alignment: .center)
+    .onAppear {
+      guard !reduceMotion else { return }
+      isPulsing = true
+    }
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel("Thinking")
+  }
+
+  private var dotOpacity: Double {
+    guard !reduceMotion else { return 0.6 }
+    return isPulsing ? 1 : 0.3
+  }
+
+  private func dotAnimation(delayIndex: Int) -> Animation? {
+    guard !reduceMotion else { return nil }
+    // Constant/ambient motion uses `linear` per motion.md §3, not an
+    // eased token -- durations still come from JovieMotion so nothing here
+    // is a raw hardcoded ms value.
+    return Animation.linear(duration: JovieMotion.slowDuration)
+      .repeatForever(autoreverses: true)
+      .delay(JovieMotion.subtleDuration * Double(delayIndex))
   }
 }
 
@@ -521,31 +576,28 @@ private struct MobileChatEntityChipView: View {
     }
   }
 
+  // Converged onto the web "input variant" chip recipe
+  // (apps/web/styles/design-system.css .system-b-entity-chip): border at
+  // accent-30%, background at accent-13% for both tones. Text stays
+  // accent-tinted on the dark assistant bubble (legible at full accent
+  // brightness against `surface1`); the light user bubble keeps a
+  // near-black text color since these saturated accents read too low-
+  // contrast on white to serve as body text there.
   private var chipTextColor: Color {
     switch tone {
     case .onDark:
-      return JovieColor.textPrimary
+      return accentColor
     case .onLight:
       return JovieColor.backgroundBase
     }
   }
 
   private var chipBackground: Color {
-    switch tone {
-    case .onDark:
-      return accentColor.opacity(0.12)
-    case .onLight:
-      return accentColor.opacity(0.08)
-    }
+    accentColor.opacity(0.13)
   }
 
   private var chipBorderColor: Color {
-    switch tone {
-    case .onDark:
-      return accentColor.opacity(0.22)
-    case .onLight:
-      return accentColor.opacity(0.30)
-    }
+    accentColor.opacity(0.30)
   }
 }
 

--- a/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
+++ b/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
@@ -84,7 +84,7 @@ struct CachedRemoteImageView<Fallback: View>: View {
     }
     .frame(width: size, height: size)
     .clipShape(Circle())
-    .animation(.easeOut(duration: 0.2), value: image == nil)
+    .animation(JovieMotion.easeOut(duration: JovieMotion.subtleDuration), value: image == nil)
     .task(id: imageURL) { await load() }
   }
 
@@ -473,7 +473,7 @@ struct QRCodeCardView: View {
     }
     .aspectRatio(1, contentMode: .fit)
     .frame(maxWidth: .infinity)
-    .animation(.easeOut(duration: 0.2), value: image == nil)
+    .animation(JovieMotion.easeOut(duration: JovieMotion.subtleDuration), value: image == nil)
     .task(id: payload) { await render() }
   }
 

--- a/apps/ios/Jovie/Features/Settings/SettingsView.swift
+++ b/apps/ios/Jovie/Features/Settings/SettingsView.swift
@@ -143,8 +143,21 @@ struct SettingsView: View {
         isLoggingOut = false
       }
     } label: {
-      Label(isLoggingOut ? "Logging Out" : "Log Out", systemImage: "rectangle.portrait.and.arrow.right")
-        .frame(maxWidth: .infinity)
+      // Reserve a stable footprint across the Log Out / Logging Out states:
+      // fixed-height spinner slot + single-line, non-wrapping label so the
+      // pill's content never reflows (layout-shift prevention, .claude/rules/ui.md).
+      HStack(spacing: JovieSpacing.small) {
+        if isLoggingOut {
+          ProgressView()
+            .controlSize(.small)
+            .tint(JovieColor.textPrimary)
+        }
+
+        Label(isLoggingOut ? "Logging Out" : "Log Out", systemImage: "rectangle.portrait.and.arrow.right")
+          .lineLimit(1)
+          .minimumScaleFactor(0.85)
+      }
+      .frame(maxWidth: .infinity)
     }
     .buttonStyle(JoviePillButtonStyle(filled: false))
     .disabled(isLoggingOut)
@@ -191,7 +204,19 @@ private struct SettingsLinkRow: View {
       .padding(.horizontal, JovieSpacing.medium)
       .padding(.vertical, 12)
     }
-    .buttonStyle(.plain)
+    .buttonStyle(SettingsRowButtonStyle())
+  }
+}
+
+/// Subtle tactile press feedback for tappable settings rows: opacity + the
+/// canonical 0.96 press scale on the SUBTLE (150ms) curve. Interruptible via
+/// SwiftUI's isPressed-driven animation (.claude/rules/motion.md section 4).
+private struct SettingsRowButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .opacity(configuration.isPressed ? 0.7 : 1)
+      .scaleEffect(configuration.isPressed ? JovieMotion.pressScale : 1)
+      .animation(JovieMotion.subtle, value: configuration.isPressed)
   }
 }
 

--- a/apps/ios/Jovie/Features/Splash/SplashView.swift
+++ b/apps/ios/Jovie/Features/Splash/SplashView.swift
@@ -3,13 +3,18 @@ import SwiftUI
 struct SplashView: View {
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-  @State private var logoOpacity = 0.0
+  // Logo is reserved at full frame size in every state (scaleEffect/opacity
+  // never change the layout size SwiftUI reports to the parent), so this
+  // entrance never shifts layout.
+  @State private var logoOpacity: Double = 0
+  @State private var logoScale: CGFloat = 0.96
 
   var body: some View {
     ZStack {
       JovieColor.backgroundBase.ignoresSafeArea()
 
       JovieLogoMark(size: 29)
+        .scaleEffect(logoScale)
         .opacity(logoOpacity)
         .accessibilityHidden(true)
         .accessibilityIdentifier("cinematic-loading-logo")
@@ -25,24 +30,41 @@ struct SplashView: View {
   @MainActor
   private func runLogoAnimation(reduceMotion: Bool) async {
     if reduceMotion {
-      logoOpacity = 0.92
+      // Opacity-only: no scale motion, and the logo is instantly at its
+      // final (unscaled) size so it never gets stuck mid-entrance.
+      logoScale = 1
+      withAnimation(JovieMotion.subtle) {
+        logoOpacity = 1
+      }
       return
     }
 
     logoOpacity = 0
+    logoScale = 0.96
 
-    try? await Task.sleep(for: .milliseconds(180))
-    guard !Task.isCancelled else { return }
-
-    withAnimation(.easeOut(duration: 0.26)) {
-      logoOpacity = 0.72
+    // Primary reveal: never animate from scale(0) -- start at 0.96 and land
+    // on scale 1 / full opacity together on the cinematic curve so the first
+    // frame the user sees feels intentional, not a hard cut.
+    withAnimation(JovieMotion.cinematic) {
+      logoOpacity = 1
+      logoScale = 1
     }
 
-    try? await Task.sleep(for: .milliseconds(180))
+    try? await Task.sleep(for: .seconds(JovieMotion.cinematicDuration))
     guard !Task.isCancelled else { return }
 
-    withAnimation(.easeOut(duration: 0.22)) {
-      logoOpacity = 0.92
+    // Secondary settle ("breathe"): a restrained overshoot-and-return on
+    // scale only -- opacity is already full, so this reads as the logo
+    // gently arriving rather than a second fade.
+    withAnimation(JovieMotion.subtle) {
+      logoScale = 1.03
+    }
+
+    try? await Task.sleep(for: .seconds(JovieMotion.subtleDuration))
+    guard !Task.isCancelled else { return }
+
+    withAnimation(JovieMotion.subtle) {
+      logoScale = 1
     }
   }
 }

--- a/apps/ios/JovieTests/AppShellDrawerThreadsFilterTests.swift
+++ b/apps/ios/JovieTests/AppShellDrawerThreadsFilterTests.swift
@@ -58,6 +58,37 @@ struct AppShellDrawerThreadsFilterTests {
   }
 }
 
+struct AppShellDrawerThreadsSkeletonTests {
+  private let conversations = [
+    MobileConversationSummary(
+      id: "conv-1",
+      title: "Launch follow-up",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+      latestMessageRole: "assistant",
+      latestTurnStatus: "completed"
+    ),
+  ]
+
+  @Test func showsSkeletonWhileLoadingWithNoCachedConversations() {
+    #expect(
+      AppShellDrawerThreadsFilter.shouldShowLoadingSkeleton(isLoading: true, conversations: []) == true
+    )
+  }
+
+  @Test func prefersCachedConversationsOverSkeletonWhileRevalidating() {
+    #expect(
+      AppShellDrawerThreadsFilter.shouldShowLoadingSkeleton(isLoading: true, conversations: conversations) == false
+    )
+  }
+
+  @Test func hidesSkeletonWhenNotLoading() {
+    #expect(
+      AppShellDrawerThreadsFilter.shouldShowLoadingSkeleton(isLoading: false, conversations: []) == false
+    )
+  }
+}
+
 struct AppShellDrawerSurfaceLayoutTests {
   @Test func longestSurfaceTitleIsAudience() {
     #expect(AppShellDrawerSurfaceLayout.longestSurfaceTitle == "Audience")

--- a/apps/ios/JovieTests/AuthScreenStyleGuardTests.swift
+++ b/apps/ios/JovieTests/AuthScreenStyleGuardTests.swift
@@ -16,4 +16,32 @@ struct AuthScreenStyleGuardTests {
     #expect(buttonSource.contains(".tint(JovieColor.backgroundBase)"))
     #expect(!buttonSource.contains(".tint(JovieColor.accentBlue)"))
   }
+
+  /// System B token guard: JovieTheme must carry the canonical carbon-palette
+  /// values from apps/web/styles/design-system.css and none of the pre-System-B
+  /// drifted hexes.
+  @Test func themeTokensMatchSystemBCanon() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Jovie/DesignSystem/JovieTheme.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    // Canonical values present.
+    #expect(source.contains("surface3 = Color(hex: 0x2A2C32)"))
+    #expect(source.contains("accent = Color(hex: 0x7170FF)"))
+    #expect(source.contains("accentBlue = Color(hex: 0x4D7DFF)"))
+    #expect(source.contains("accentPurple = Color(hex: 0x9B4DFF)"))
+    #expect(source.contains("accentPink = Color(hex: 0xEA4A9C)"))
+    #expect(source.contains("accentOrange = Color(hex: 0xFFAB2E)"))
+    #expect(source.contains("pressScale: CGFloat = 0.96"))
+    #expect(source.contains("timingCurve(0.4, 0, 0.2, 1, duration: subtleDuration)"))
+    #expect(source.contains("timingCurve(0.22, 1, 0.36, 1, duration: cinematicDuration)"))
+
+    // Drifted values banned.
+    #expect(!source.contains("0x0070F3"))
+    #expect(!source.contains("0x8B5CF6"))
+    #expect(!source.contains("0xFF0080"))
+    #expect(!source.contains("0x1F2430"))
+  }
 }

--- a/apps/ios/JovieTests/AuthScreenStyleGuardTests.swift
+++ b/apps/ios/JovieTests/AuthScreenStyleGuardTests.swift
@@ -44,4 +44,21 @@ struct AuthScreenStyleGuardTests {
     #expect(!source.contains("0xFF0080"))
     #expect(!source.contains("0x1F2430"))
   }
+
+  /// Staged entrance guard: the auth screen's first-appearance animation
+  /// must drop translateY under Reduce Motion (opacity-only) and must never
+  /// animate from a hard scale(0)/hidden state that would jank on appear.
+  @Test func authEntranceRespectsReduceMotionAndNeverStartsFromZeroScale() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Jovie/Features/Auth/AuthScreen.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    let modifierStart = try #require(source.range(of: "private struct AuthEntranceModifier: ViewModifier"))
+    let modifierSource = source[modifierStart.lowerBound...]
+
+    #expect(modifierSource.contains("reduceMotion ? 0 : (hasAppeared ? 0 : offset)"))
+    #expect(!modifierSource.contains("scaleEffect"))
+  }
 }

--- a/apps/ios/JovieTests/ComposerWorkflowSheetTests.swift
+++ b/apps/ios/JovieTests/ComposerWorkflowSheetTests.swift
@@ -1,3 +1,4 @@
+import Testing
 import XCTest
 @testable import Jovie
 
@@ -27,5 +28,117 @@ final class ComposerWorkflowSheetTests: XCTestCase {
 
   func testWorkflowSheetHeightReservesStableFootprint() {
     XCTAssertGreaterThanOrEqual(ComposerWorkflowSheetHeight.estimated, 320)
+  }
+}
+
+// MARK: - Slash palette pure logic (Swift Testing)
+
+struct ComposerSlashPaletteTests {
+  private let skills: [(id: String, label: String)] = [
+    ("generateAlbumArt", "Generate album art"),
+    ("proposeSocialLink", "Add social link"),
+  ]
+
+  // MARK: query(from:)
+
+  @Test func queryIsNilForEmptyDraft() {
+    #expect(ComposerSlashPalette.query(from: "") == nil)
+  }
+
+  @Test func queryIsEmptyStringForBareSlash() {
+    #expect(ComposerSlashPalette.query(from: "/") == "")
+  }
+
+  @Test func queryReturnsTextAfterLeadingSlash() {
+    #expect(ComposerSlashPalette.query(from: "/mer") == "mer")
+  }
+
+  @Test func queryIsNilForProse() {
+    #expect(ComposerSlashPalette.query(from: "hello") == nil)
+  }
+
+  @Test func queryIsNilOnceWhitespaceFollowsTheSlash() {
+    // Defined behavior: a space after the slash means prose, not a command.
+    #expect(ComposerSlashPalette.query(from: "/ hi") == nil)
+    #expect(ComposerSlashPalette.query(from: "/merch idea") == nil)
+  }
+
+  @Test func queryIsNilForCommittedSkillTokens() {
+    #expect(ComposerSlashPalette.query(from: "/skill:generateAlbumArt") == nil)
+    #expect(ComposerSlashPalette.query(from: "/skill:generateAlbumArt ") == nil)
+  }
+
+  // MARK: items(matching:skills:)
+
+  @Test func emptyQueryReturnsAllWorkflowsThenAllSkillsInStableOrder() {
+    let items = ComposerSlashPalette.items(matching: "", skills: skills)
+    let expected: [ComposerSlashItem] =
+      ComposerWorkflowAction.allCases.map(ComposerSlashItem.workflow)
+        + skills.map { ComposerSlashItem.skill(id: $0.id, label: $0.label) }
+    #expect(items == expected)
+  }
+
+  @Test func filteringMatchesWorkflowTitlesCaseInsensitively() {
+    // "MER" hits "Make merch" and "Camera" (contains match), in allCases order.
+    let items = ComposerSlashPalette.items(matching: "MER", skills: [])
+    #expect(items == [.workflow(.makeMerch), .workflow(.camera)])
+  }
+
+  @Test func filteringMatchesSingleWorkflowSubset() {
+    let items = ComposerSlashPalette.items(matching: "lyric", skills: skills)
+    #expect(items == [.workflow(.lyricVideo)])
+  }
+
+  @Test func filteringMatchesSkillLabelsAndIds() {
+    let byLabel = ComposerSlashPalette.items(matching: "album", skills: skills)
+    #expect(byLabel == [.skill(id: "generateAlbumArt", label: "Generate album art")])
+
+    let byID = ComposerSlashPalette.items(matching: "proposeSocial", skills: skills)
+    #expect(byID == [.skill(id: "proposeSocialLink", label: "Add social link")])
+  }
+
+  @Test func skillsAreCappedAtEightPreservingLeadingOrder() {
+    let many = (0..<12).map { (id: "skill\($0)", label: "Skill \($0)") }
+    let items = ComposerSlashPalette.items(matching: "", skills: many)
+    let skillItems = items.filter {
+      if case .skill = $0 { return true } else { return false }
+    }
+    #expect(skillItems.count == ComposerSlashPalette.maxSkillItems)
+    #expect(skillItems.first == .skill(id: "skill0", label: "Skill 0"))
+    #expect(skillItems.last == .skill(id: "skill7", label: "Skill 7"))
+  }
+
+  @Test func noMatchesReturnsEmpty() {
+    let items = ComposerSlashPalette.items(matching: "zzzzz", skills: skills)
+    #expect(items.isEmpty)
+  }
+
+  // MARK: commit mapping
+
+  @Test func committedDraftMapsSkillsToSkillTokensWithTrailingSpace() {
+    let draft = ComposerSlashPalette.committedDraft(
+      for: .skill(id: "generateAlbumArt", label: "Generate album art")
+    )
+    #expect(draft == "/skill:generateAlbumArt ")
+    // A committed skill token must NOT re-open the palette.
+    #expect(ComposerSlashPalette.query(from: draft ?? "") == nil)
+  }
+
+  @Test func committedDraftIsNilForWorkflows() {
+    // Workflows commit through the existing onSelectWorkflow prompt path.
+    #expect(ComposerSlashPalette.committedDraft(for: .workflow(.makeMerch)) == nil)
+  }
+
+  // MARK: default skills source
+
+  @Test func defaultSkillsMirrorTheSharedLabelRegistrySortedByLabel() {
+    let defaults = ComposerSlashPalette.defaultSkills
+    #expect(defaults.count == MobileChatSkillLabels.registry.count)
+    for (id, label) in defaults {
+      #expect(MobileChatSkillLabels.registry[id] == label)
+    }
+    let labels = defaults.map(\.label)
+    let sorted = labels.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    #expect(labels == sorted)
   }
 }


### PR DESCRIPTION
## Summary

Completes the iOS Design System B polish (chunks C–E). Entity chip convergence, slash-command palette, drawer loading skeleton, and stat-tile entrance stagger — all on shared motion tokens from chunk 0.

### Chunk C — Chat entity chips + streaming + message polish
- **Entity chips:** converged to web input-variant recipe (border accent-30%, bg accent-13%, accent-tinted text on dark, near-black on light)
- **Thinking animation:** three-dot opacity pulse via repeatForever replaces static "Thinking..." — reduce-motion safe (static dots)
- **Message entrance:** opacity + offset(y: 6) on ease-out for new messages; rapid streaming text NOT animated
- **Tool card state crossfade:** state changes use opacity transition via `.id(model.state)`
- **Merch options:** rendering overlay crossfade on JovieMotion.subtle

### Chunk D — Slash-command palette
- Leading `/` in composer bar opens an inline palette anchored ABOVE the bar (zero transcript reflow)
- **Suggestions** section (6 workflow actions) + **Skills** section (from MobileChatSkillLabels.registry)
- Live filtering as user types; tap commits workflow prompt or `/skill:id ` token
- Entry on cinematic (opacity + 8px rise), exit faster on subtle (opacity only)

### Chunk E — Shell, drawer, dashboard, audience
- **Drawer skeleton:** redacted placeholder rows when no cached conversations exist (stale-while-revalidate semantics)
- **Drawer stagger:** decorative row reveal (opacity + x-offset, 30-80ms, reduce-motion drops offset)
- **Drawer press feedback:** DrawerRowButtonStyle (background dim + pressScale)
- **Audience stat tiles:** first-load only entrance stagger (never replays on revalidate)
- **Animation sweep:** scattered easeInOut(0.25/0.28) converted to JovieMotion.easeOut(slow) across shell/dashboard

### Verification
- `pnpm run ios:lint` — clean
- `pnpm run ios:test` — 206/207 unit tests pass, 1 pre-existing flaky ObservabilityTest
- Layout-shift audit: every touched view's states enumerated below

### Layout-shift audit
| View | States | Zero shift? |
|------|--------|-------------|
| Splash to route | Logo crossfade to next route | opacity only |
| Auth | Logo to tagline to button stagger (reserved error slot) | yes |
| Chat messages | New message entrance offset; streaming no animation | yes |
| Thinking to content | Dots bubble same footprint as text bubble | yes |
| Slash palette open/close | Overlay above composer, no transcript reflow | yes |
| Drawer skeleton to loaded | Same paddings/height as DrawerThreadRow | yes |
| Drawer row stagger | Decorative only, never blocks interaction | yes |
| Audience stat tiles | First load only, opacity + offset | yes |
| Tool card state change | Fixed 20x20 icon frame, opacity crossfade | yes |
| Merch rendering to ready | Fixed aspectRatio(1) mockup square | yes |
| Dashboard QR/copy | Press feedback only (no layout change) | yes |
