### PR TITLE
ci(gate): collapse cheap cluster into ci-fast + restore PR Ready (JOV-3464)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,164 +449,72 @@ jobs:
       - name: Verify backup-file fixture coverage
         run: ./scripts/security/verify-gitleaks-coverage.sh
 
-  ci-guardrails:
-    name: Guardrails (proxy)
-    # Draft PRs skip; ready PRs + pushes + merge queue enforce core repo guardrails
+  ci-fast:
+    name: ci-fast
+    # JOV-3464: fold cheap cluster into one job (checkout+install once).
+    # Lanes: biome, eslint server-boundaries, typecheck --force, guardrails,
+    # structural (path-gated). Per-lane PASS/FAIL via scripts/ci-fast-lanes.mjs
+    # (--continue semantics; never set -e out on first failure). Heavy lanes
+    # (build / Lighthouse / e2e / preview) stay separate.
     needs: [ci-path-changes]
-    runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with: { fetch-depth: 0 }
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '22'
-      - name: Desktop release guard
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-        run: node scripts/desktop-release-guard.mjs --base "origin/${BASE_REF}"
-      - name: Version fan-out guard (main-only stamping)
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-        run: node scripts/version-fanout-guard.mjs --base "origin/${BASE_REF}"
-      - name: Script unit tests
-        run: node --test scripts/cleanup-stale-dev.test.mjs scripts/desktop-release-guard.test.mjs scripts/desktop-installed-apps-audit.test.mjs scripts/dev-web-fast.test.mjs scripts/ios-guardrail-rollout-audit.test.mjs scripts/version-fanout-guard.test.mjs scripts/version-stamp.test.mjs
-      - name: Version consistency guard
-        run: node scripts/version-check.mjs
-      - name: Next.js proxy guard
-        # next-proxy-guard.mjs only uses Node built-ins (fs, path) — no pnpm install needed.
-        # Running node directly avoids ERR_PNPM_OUTDATED_LOCKFILE on dependabot PRs that
-        # bump package.json without regenerating pnpm-lock.yaml.
-        working-directory: apps/web
-        run: node scripts/next-proxy-guard.mjs
-
-  ci-structural-contract:
-    # Path-gated: only runs when CI harness/.github files change or on push/dispatch.
-    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
-    name: Structural Contract
-    needs: [ci-path-changes]
-    runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 8
-    env:
-      SHELLCHECK_OPTS: >-
-        --exclude=SC2001,SC2016,SC2028,SC2034,SC2086,SC2126,SC2129,SC2329
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with: { fetch-depth: 1 }
-      - uses: ./.github/actions/setup-node-pnpm
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-      - name: Validate CI harness manifest and generated docs
-        run: pnpm ci:harness:check
-      - name: CI control-plane characterization suite
-        # Locks merge-gate set, risk smoke/preview flags, and merge-queue aggregate
-        # required-check contracts before any YAML refactor can silently change them.
-        run: pnpm ci:control:test
-      - name: Validate CI branching policy
-        run: pnpm ci:branching-guard:validate
-      - name: Validate Graphite merge queue config
-        run: pnpm ci:merge-queue:check
-      - name: Verify typecheck gate uses --force (JOV-3499)
-        run: pnpm ci:typecheck-gate-guard
-      # Keep this pin aligned with actionlint.yml. Downloading the latest binary
-      # from a moving branch during CI made the control-plane check non-hermetic.
-      - name: Run actionlint
-        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
-      - name: Run structural repo guardrails
-        run: |
-          pnpm next:proxy-guard
-          pnpm tailwind:check
-          pnpm --filter=@jovie/web run lint:no-native-dialogs
-          pnpm --filter=@jovie/web run lint:seo
-          pnpm --filter=@jovie/web run lint:contrast-ratchet
-          pnpm doc:freshness:check
-      - name: Validate flaky quarantine ledger
-        run: node .github/scripts/quarantine-ledger.mjs validate
-      - name: Validate reliability detector registry
-        run: pnpm --filter @jovie/web run test:reliability-detectors
-      - name: Run merge-queue drain regression tests
-        run: pip install pytest --quiet && pytest scripts/tests/test_gh_retry.py -v
-      - name: Write remediation summary
-        if: always()
-        run: |
-          {
-            echo "### Structural Contract"
-            echo
-            echo "This lane enforces the CI harness manifest, generated docs, Graphite merge-queue config, workflow syntax, proxy guard, Tailwind contract, native-dialog ban, SEO/AEO ratchet, contrast ratchet, and reliability detector registry."
-            echo
-            echo "Next local command:"
-            echo
-            echo '```bash'
-            echo "pnpm ci:harness:check && pnpm ci:control:test && pnpm ci:merge-queue:check && pnpm next:proxy-guard && pnpm tailwind:check && pnpm --filter=@jovie/web run lint:no-native-dialogs && pnpm --filter=@jovie/web run lint:seo && pnpm --filter=@jovie/web run lint:contrast-ratchet && pnpm doc:freshness:check && pnpm test:reliability-detectors"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  ci-biome:
-    name: Lint
-    # Single consolidated job for all Biome checks (lint + format)
-    needs: [ci-path-changes]
-    # Merge gate: keep on always-available GitHub runners. The self-hosted
-    # jovie-runner pool is not highly-available (personal OrbStack host) and
-    # took down this gate when it shut down mid-run.
-    runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name != 'pull_request' || needs.ci-path-changes.outputs.has_code_changes == 'true') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with: { fetch-depth: 2 }
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
-      - name: Run Biome CI (lint + format)
-        run: |
-          # For PRs: only lint changed files (faster, pre-commit already ran on local)
-          # For pushes to main: full lint to catch any issues
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            DIFF_BASE="HEAD^1"
-            if ! git rev-parse --verify "$DIFF_BASE" >/dev/null 2>&1; then
-              git fetch origin "${{ github.base_ref }}" --depth=1
-              DIFF_BASE="origin/${{ github.base_ref }}"
-            fi
-            # Use diff-filter=d to exclude deleted files (biome can't lint deleted files)
-            # Include .mts/.mjs extensions for ESM config files
-            mapfile -t CHANGED_FILES < <(
-              git diff --diff-filter=d --name-only "$DIFF_BASE" HEAD -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.json' '*.mts' '*.mjs' ':(exclude)**/package-lock.json' ':(exclude).claude/settings.json' ':(exclude).claude/skills/**'
-            )
-            if (( ${#CHANGED_FILES[@]} > 0 )); then
-              echo "Linting changed files only:"
-              printf '  %s\n' "${CHANGED_FILES[@]}"
-              pnpm biome ci --reporter=github --no-errors-on-unmatched "${CHANGED_FILES[@]}"
-            else
-              echo "No lintable files changed"
-            fi
-          else
-            pnpm biome ci --reporter=github .
-          fi
-      - name: Run ESLint server boundary checks
+      - name: Cache Turbo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+      - name: Decide structural lane
+        id: structural
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            DIFF_BASE="HEAD^1"
-            if ! git rev-parse --verify "$DIFF_BASE" >/dev/null 2>&1; then
-              git fetch origin "${{ github.base_ref }}" --depth=1
-              DIFF_BASE="origin/${{ github.base_ref }}"
-            fi
-            mapfile -t CHANGED_FILES < <(
-              git diff --diff-filter=d --name-only "$DIFF_BASE" HEAD -- \
-                'apps/web/*.ts' \
-                'apps/web/*.tsx' \
-                'apps/web/**/*.ts' \
-                'apps/web/**/*.tsx'
-            )
-            if (( ${#CHANGED_FILES[@]} > 0 )); then
-              pnpm --filter=@jovie/web run lint:server-boundaries -- "${CHANGED_FILES[@]}"
-            else
-              echo "No server-boundary TypeScript files changed"
-            fi
-          else
-            pnpm --filter=@jovie/web run lint:server-boundaries
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qE '^(\.github/|\.claude/|AGENTS\.md|CODEX\.md|scripts/lib/(ci-|merge-queue)|scripts/ci-)'; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Install actionlint (structural)
+        if: steps.structural.outputs.skip != 'true'
+        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
+      - name: Set up Python (structural drain tests)
+        if: steps.structural.outputs.skip != 'true'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+      - name: Install pytest (structural drain tests)
+        if: steps.structural.outputs.skip != 'true'
+        run: pip install pytest --quiet
+      - name: Run ci-fast lanes
+        id: lanes
+        env:
+          TURBO_SCM_BASE: ${{ (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
+          CI_FAST_SKIP_STRUCTURAL: ${{ steps.structural.outputs.skip }}
+          CI_FAST_LANES_OUT: ${{ runner.temp }}/ci-fast-lanes.json
+          SHELLCHECK_OPTS: >-
+            --exclude=SC2001,SC2016,SC2028,SC2034,SC2086,SC2126,SC2129,SC2329
+        run: node scripts/ci-fast-lanes.mjs
+      - name: Upload ci-fast lane results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-fast-lanes-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ci-fast-lanes.json
+          retention-days: 7
+          if-no-files-found: warn
 
   ci-promptfoo-evals:
     name: Promptfoo Evals (deterministic)
@@ -664,48 +572,6 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
       - name: Run Knip (unused files, deps & exports)
         run: pnpm knip
-
-  ci-typecheck:
-    name: Typecheck
-    # Draft PRs skip; ready PRs + pushes + merge queue run typecheck
-    # Note: Runs in parallel with lint for speed (no dependency on cache-warm)
-    needs: [ci-path-changes]
-    # Runner is var-switchable: CI_FAST_RUNNER=jovie-runner offloads typecheck
-    # to the self-hosted pool when hosted concurrency is the bottleneck
-    # (free-plan orgs get ~20 concurrent hosted jobs + fair-use throttling —
-    # see gbrain jovie-ci-actions-budget-stall-2026-07-10). Typecheck uploads
-    # no artifacts, so the pool's slow egress doesn't bite.
-    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 20
-    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name != 'pull_request' || needs.ci-path-changes.outputs.has_code_changes == 'true') }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # Full history needed for turbo --affected merge-base detection.
-          # Blobless: --affected only needs the commit graph + changed-file
-          # names; HEAD blobs are materialized at checkout, historical blobs
-          # lazy-fetch if ever needed.
-          fetch-depth: 0
-          filter: blob:none
-      - uses: ./.github/actions/setup-node-pnpm
-      - name: Cache Turbo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          # Use content hash for better cache hit rates (not commit SHA which changes every commit)
-          key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-      # NOTE: tsbuildinfo restore intentionally removed (JOV-3499).
-      # A stale tsbuildinfo from GH Actions cache can convince tsc --incremental that no
-      # types changed, producing a false green even after --force bypasses the Turbo cache.
-      # The merge gate must be a fresh tsc run; the cost is ~1–2 extra minutes per PR.
-      - name: Run typecheck
-        env:
-          TURBO_SCM_BASE: ${{ (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
-        # --force bypasses Turbo's remote cache so a stale SUCCESS from a prior commit
-        # cannot be replayed as the merge gate result. See JOV-3499.
-        run: pnpm turbo typecheck --affected --force
 
   neon-db:
     name: Neon DB
@@ -3719,10 +3585,7 @@ jobs:
       [
         ci-path-changes,
         ci-risk-classifier,
-        ci-typecheck,
-        ci-biome,
-        ci-guardrails,
-        ci-structural-contract,
+        ci-fast,
         ci-unit-tests,
         ci-build-public,
         ci-pr-vercel-preview,
@@ -3733,10 +3596,7 @@ jobs:
     steps:
       - name: Evaluate required PR checks
         run: |
-          TYPECHECK_RESULT="${{ needs.ci-typecheck.result }}"
-          BIOME_RESULT="${{ needs.ci-biome.result }}"
-          GUARDRAILS_RESULT="${{ needs.ci-guardrails.result }}"
-          STRUCTURAL_RESULT="${{ needs.ci-structural-contract.result }}"
+          FAST_RESULT="${{ needs.ci-fast.result }}"
           UNIT_RESULT="${{ needs.ci-unit-tests.result }}"
           BUILD_RESULT="${{ needs.ci-build-public.result }}"
           RISK_RESULT="${{ needs.ci-risk-classifier.result }}"
@@ -3746,10 +3606,7 @@ jobs:
           RISK_RULES="${{ needs.ci-risk-classifier.outputs.matched_rule_ids }}"
           PREVIEW_RESULT="${{ needs.ci-pr-vercel-preview.result }}"
           IS_DEPENDABOT="${{ github.event.pull_request.user.login == 'dependabot[bot]' }}"
-          echo "ci-typecheck: $TYPECHECK_RESULT"
-          echo "ci-biome: $BIOME_RESULT"
-          echo "ci-guardrails: $GUARDRAILS_RESULT"
-          echo "ci-structural-contract: $STRUCTURAL_RESULT"
+          echo "ci-fast: $FAST_RESULT"
           echo "ci-unit-tests: $UNIT_RESULT"
           echo "ci-build-public: $BUILD_RESULT"
           echo "ci-risk-classifier: $RISK_RESULT ($RISK_LEVEL; rules: ${RISK_RULES:-none})"
@@ -3760,10 +3617,7 @@ jobs:
             echo
             echo "| Gate | Result | Next local command |"
             echo "| --- | --- | --- |"
-            echo "| Typecheck | $TYPECHECK_RESULT | \`pnpm run typecheck\` |"
-            echo "| Biome | $BIOME_RESULT | \`pnpm run biome:check\` |"
-            echo "| Guardrails | $GUARDRAILS_RESULT | \`pnpm next:proxy-guard\` |"
-            echo "| Structural Contract | $STRUCTURAL_RESULT | \`pnpm ci:harness:check\` |"
+            echo "| ci-fast (typecheck/biome/eslint/guardrails/structural) | $FAST_RESULT | \`pnpm run typecheck && pnpm run biome:check\` |"
             echo "| Unit Tests | $UNIT_RESULT | \`pnpm --filter=@jovie/web run test:fast\` |"
             echo "| Build (public routes) | $BUILD_RESULT | \`pnpm run build:web\` |"
             echo "| Risk classifier | $RISK_RESULT | \`pnpm ci:harness:check\` |"
@@ -3778,23 +3632,10 @@ jobs:
             exit 1
           fi
 
-          # Fast leaves must each succeed (or be skipped when path-gated with
-          # no relevant files changed).
-          FAST_LEAF_NAMES=(ci-typecheck ci-biome ci-guardrails ci-structural-contract)
-          FAST_LEAF_RESULTS=("$TYPECHECK_RESULT" "$BIOME_RESULT" "$GUARDRAILS_RESULT" "$STRUCTURAL_RESULT")
-          FAST_LEAF_FAILED=false
-          for i in "${!FAST_LEAF_NAMES[@]}"; do
-            leaf_result="${FAST_LEAF_RESULTS[$i]}"
-            if [[ "$leaf_result" != "success" && "$leaf_result" != "skipped" ]]; then
-              FAST_LEAF_FAILED=true
-            fi
-          done
-          if [[ "$FAST_LEAF_FAILED" == "true" ]]; then
-            echo "❌ One or more fast checks did not pass:"
-            for i in "${!FAST_LEAF_NAMES[@]}"; do
-              echo "   - ${FAST_LEAF_NAMES[$i]}: ${FAST_LEAF_RESULTS[$i]}"
-            done
-            echo "Likely fix: run pnpm run typecheck && pnpm run biome:check, then inspect the failing fast-check job."
+          # ci-fast may be skipped on docs-only PRs (has_code_changes=false).
+          if [[ "$FAST_RESULT" != "success" && "$FAST_RESULT" != "skipped" ]]; then
+            echo "❌ ci-fast did not pass (result: $FAST_RESULT)"
+            echo "Likely fix: pnpm run typecheck && pnpm run biome:check (see ci-fast step summary for the failing lane)."
             exit 1
           fi
 
@@ -3840,11 +3681,9 @@ jobs:
       - ci-path-changes
       - ci-env-example-guard
       - ci-secret-scan
-      - ci-guardrails
+      - ci-fast
+      - ci-pr-ready
       - ci-risk-classifier
-      - ci-structural-contract
-      - ci-typecheck
-      - ci-biome
       - neon-db
       - drizzle-migration-guard
       - ci-drizzle-check
@@ -3879,7 +3718,8 @@ jobs:
           RISK_BLOCKS_UNATTENDED: ${{ needs.ci-risk-classifier.outputs.blocks_unattended_auto_merge }}
           RISK_RULES: ${{ needs.ci-risk-classifier.outputs.matched_rule_ids }}
           CI_HARNESS_JOB_CI_RISK_CLASSIFIER: ${{ needs.ci-risk-classifier.result }}
-          CI_HARNESS_JOB_CI_STRUCTURAL_CONTRACT: ${{ needs.ci-structural-contract.result }}
+          CI_HARNESS_JOB_CI_FAST: ${{ needs.ci-fast.result }}
+          CI_HARNESS_JOB_CI_STRUCTURAL_CONTRACT: ${{ needs.ci-fast.result }}
           CI_HARNESS_JOB_CI_UNIT_TESTS: ${{ needs.ci-unit-tests.result }}
           CI_HARNESS_JOB_CI_BUILD_PUBLIC: ${{ needs.ci-build-public.result }}
           CI_HARNESS_JOB_CI_LIGHTHOUSE_PR: ${{ needs.ci-lighthouse-pr.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,24 +56,29 @@ jobs:
   # runs first (fail-open), then path detection.
   ci-path-changes:
     name: Path Changes
-    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
+    # Hosted-only root of the PR DAG. Self-hosted cancel/hang here cascades into
+    # SKIPPED risk/ci-fast/unit leaves and a red PR Ready (JOV-3464 drain).
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
+      # Prefer real path detect; fall back to graphite-skip defaults so job
+      # outputs are never empty when Path Changes succeeds (empty has_code_changes
+      # was treated as docs-only and skip-cascaded ci-fast / unit leaves).
       skip: ${{ steps.graphite.outputs.skip || 'false' }}
-      run_build: ${{ steps.detect.outputs.run_build }}
-      run_test: ${{ steps.detect.outputs.run_test }}
-      run_public_lighthouse: ${{ steps.detect.outputs.run_public_lighthouse }}
-      run_dashboard_lighthouse: ${{ steps.detect.outputs.run_dashboard_lighthouse }}
-      run_onboarding_lighthouse: ${{ steps.detect.outputs.run_onboarding_lighthouse }}
-      run_admin_lighthouse: ${{ steps.detect.outputs.run_admin_lighthouse }}
-      run_chat_lighthouse: ${{ steps.detect.outputs.run_chat_lighthouse }}
-      run_promptfoo_evals: ${{ steps.detect.outputs.run_promptfoo_evals }}
-      run_golden_eval_set: ${{ steps.detect.outputs.run_golden_eval_set }}
-      run_e2e: ${{ steps.detect.outputs.run_e2e }}
-      run_golden_path: ${{ steps.detect.outputs.run_golden_path }}
-      run_drizzle: ${{ steps.detect.outputs.run_drizzle }}
-      run_neon: ${{ steps.detect.outputs.run_neon }}
-      has_code_changes: ${{ steps.detect.outputs.has_code_changes }}
+      run_build: ${{ steps.detect.outputs.run_build || steps.graphite_skip.outputs.run_build || 'false' }}
+      run_test: ${{ steps.detect.outputs.run_test || steps.graphite_skip.outputs.run_test || 'false' }}
+      run_public_lighthouse: ${{ steps.detect.outputs.run_public_lighthouse || steps.graphite_skip.outputs.run_public_lighthouse || 'false' }}
+      run_dashboard_lighthouse: ${{ steps.detect.outputs.run_dashboard_lighthouse || steps.graphite_skip.outputs.run_dashboard_lighthouse || 'false' }}
+      run_onboarding_lighthouse: ${{ steps.detect.outputs.run_onboarding_lighthouse || steps.graphite_skip.outputs.run_onboarding_lighthouse || 'false' }}
+      run_admin_lighthouse: ${{ steps.detect.outputs.run_admin_lighthouse || steps.graphite_skip.outputs.run_admin_lighthouse || 'false' }}
+      run_chat_lighthouse: ${{ steps.detect.outputs.run_chat_lighthouse || steps.graphite_skip.outputs.run_chat_lighthouse || 'false' }}
+      run_promptfoo_evals: ${{ steps.detect.outputs.run_promptfoo_evals || steps.graphite_skip.outputs.run_promptfoo_evals || 'false' }}
+      run_golden_eval_set: ${{ steps.detect.outputs.run_golden_eval_set || steps.graphite_skip.outputs.run_golden_eval_set || 'false' }}
+      run_e2e: ${{ steps.detect.outputs.run_e2e || steps.graphite_skip.outputs.run_e2e || 'false' }}
+      run_golden_path: ${{ steps.detect.outputs.run_golden_path || steps.graphite_skip.outputs.run_golden_path || 'false' }}
+      run_drizzle: ${{ steps.detect.outputs.run_drizzle || steps.graphite_skip.outputs.run_drizzle || 'false' }}
+      run_neon: ${{ steps.detect.outputs.run_neon || steps.graphite_skip.outputs.run_neon || 'false' }}
+      has_code_changes: ${{ steps.detect.outputs.has_code_changes || steps.graphite_skip.outputs.has_code_changes || 'false' }}
     steps:
       - id: graphite-token
         name: Check Graphite token configuration
@@ -95,6 +100,7 @@ jobs:
           graphite_token: ${{ secrets.GRAPHITE_TOKEN }}
 
       - name: Skip CI (Graphite optimizer)
+        id: graphite_skip
         if: steps.graphite.outputs.skip == 'true'
         run: |
           echo "Graphite CI optimizer requested skip — CI will be skipped."
@@ -116,11 +122,26 @@ jobs:
         id: detect
         shell: bash
         run: |
+          set -euo pipefail
           IS_FORK="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}"
           # Determine changed files
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git fetch origin "${{ github.base_ref }}"
-            CHANGED_FILES=$(git diff --name-only "origin/${{ github.base_ref }}" HEAD)
+            # Fail closed on base resolution: a failed fetch used to leave an
+            # empty CHANGED_FILES list that looked like docs-only and skip-
+            # cascaded ci-fast / unit leaves while risk still ran.
+            git fetch --no-tags origin "${{ github.base_ref }}"
+            if ! git rev-parse --verify "origin/${{ github.base_ref }}" >/dev/null 2>&1; then
+              echo "::error::Could not resolve origin/${{ github.base_ref }} after fetch"
+              exit 1
+            fi
+            CHANGED_FILES=$(git diff --name-only "origin/${{ github.base_ref }}" HEAD || true)
+            if [[ -z "${CHANGED_FILES//[$'\t\r\n' ]/}" ]]; then
+              echo "Empty changed-file list vs origin/${{ github.base_ref }} — no path triggers"
+              for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_golden_path run_drizzle run_neon has_code_changes; do
+                echo "$t=false" >> "$GITHUB_OUTPUT"
+              done
+              exit 0
+            fi
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # Manual dispatch: run everything
             echo "Manual dispatch: running all checks"
@@ -3595,12 +3616,16 @@ jobs:
         ci-build-public,
         ci-pr-vercel-preview,
       ]
-    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (always() && github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') }}
+    # always() so we still evaluate when a leaf fails. !cancelled() avoids a
+    # second red PR Ready when the whole run is concurrency-cancelled mid-DAG
+    # (Path Changes cancel → leaves SKIPPED → risk "skipped" noise).
+    if: ${{ always() && !cancelled() && needs.ci-path-changes.outputs.skip == 'false' && github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' }}
     runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 2
     steps:
       - name: Evaluate required PR checks
         run: |
+          PATH_RESULT="${{ needs.ci-path-changes.result }}"
           FAST_RESULT="${{ needs.ci-fast.result }}"
           UNIT_RESULT="${{ needs.ci-unit-tests.result }}"
           BUILD_RESULT="${{ needs.ci-build-public.result }}"
@@ -3611,6 +3636,8 @@ jobs:
           RISK_RULES="${{ needs.ci-risk-classifier.outputs.matched_rule_ids }}"
           PREVIEW_RESULT="${{ needs.ci-pr-vercel-preview.result }}"
           IS_DEPENDABOT="${{ github.event.pull_request.user.login == 'dependabot[bot]' }}"
+          HAS_CODE_CHANGES="${{ needs.ci-path-changes.outputs.has_code_changes }}"
+          echo "ci-path-changes: $PATH_RESULT (has_code_changes=$HAS_CODE_CHANGES)"
           echo "ci-fast: $FAST_RESULT"
           echo "ci-unit-tests: $UNIT_RESULT"
           echo "ci-build-public: $BUILD_RESULT"
@@ -3622,6 +3649,7 @@ jobs:
             echo
             echo "| Gate | Result | Next local command |"
             echo "| --- | --- | --- |"
+            echo "| Path Changes | $PATH_RESULT | re-run workflow if cancelled/failed |"
             echo "| ci-fast (typecheck/biome/eslint/guardrails/structural) | $FAST_RESULT | \`pnpm run typecheck && pnpm run biome:check\` |"
             echo "| Unit Tests | $UNIT_RESULT | \`pnpm --filter=@jovie/web run test:fast\` |"
             echo "| Build (public routes) | $BUILD_RESULT | \`pnpm run build:web\` |"
@@ -3631,14 +3659,31 @@ jobs:
             echo "Risk level: ${RISK_LEVEL:-low}; matched rules: ${RISK_RULES:-none}"
           } >> "$GITHUB_STEP_SUMMARY"
 
+          # Fail closed first when the path DAG root never completed — leaves
+          # (including risk classifier) are SKIPPED in that case, which must not
+          # look like a docs-only green path.
+          if [[ "$PATH_RESULT" != "success" ]]; then
+            echo "❌ Path Changes did not succeed (result: $PATH_RESULT)"
+            echo "Leaf gates (CI Risk Classifier, ci-fast, Unit Tests, …) were skipped because the path DAG root did not finish."
+            echo "Likely fix: re-run the failed jobs / workflow. Path Changes is hosted ubuntu-latest to avoid self-hosted cancel cascades."
+            exit 1
+          fi
+
           if [[ "$RISK_RESULT" != "success" ]]; then
             echo "❌ CI risk classifier did not pass (result: $RISK_RESULT)"
             echo "Likely fix: run pnpm ci:harness:check and inspect .github/ci-harness/manifest.json."
             exit 1
           fi
 
-          # ci-fast may be skipped on docs-only PRs (has_code_changes=false).
-          if [[ "$FAST_RESULT" != "success" && "$FAST_RESULT" != "skipped" ]]; then
+          # Code PRs must run ci-fast (not skip). Docs-only may skip when
+          # has_code_changes=false from a successful Path Changes detect.
+          if [[ "$HAS_CODE_CHANGES" == "true" ]]; then
+            if [[ "$FAST_RESULT" != "success" ]]; then
+              echo "❌ ci-fast did not pass (result: $FAST_RESULT) on a code-changing PR"
+              echo "Likely fix: pnpm run typecheck && pnpm run biome:check (see ci-fast step summary for the failing lane)."
+              exit 1
+            fi
+          elif [[ "$FAST_RESULT" != "success" && "$FAST_RESULT" != "skipped" ]]; then
             echo "❌ ci-fast did not pass (result: $FAST_RESULT)"
             echo "Likely fix: pnpm run typecheck && pnpm run biome:check (see ci-fast step summary for the failing lane)."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,10 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git fetch origin "${{ github.base_ref }}" --depth=1
+          # Full (non-shallow) base fetch: guardrails needs git merge-base with
+          # origin/<base>; a --depth=1 fetch leaves the base tip shallow and fails
+          # desktop-release-guard / version-fanout-guard on PRs.
+          git fetch origin "${{ github.base_ref }}" --no-tags
           if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qE '^(\.github/|\.claude/|AGENTS\.md|CODEX\.md|scripts/lib/(ci-|merge-queue)|scripts/ci-)'; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,6 +460,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name != 'pull_request' || needs.ci-path-changes.outputs.has_code_changes == 'true') }}
+    env:
+      # Match prior Structural Contract job so actionlint/shellcheck is hermetic.
+      SHELLCHECK_OPTS: >-
+        --exclude=SC2001,SC2016,SC2028,SC2034,SC2086,SC2126,SC2129,SC2329
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -504,8 +508,6 @@ jobs:
           TURBO_SCM_BASE: ${{ (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
           CI_FAST_SKIP_STRUCTURAL: ${{ steps.structural.outputs.skip }}
           CI_FAST_LANES_OUT: ${{ runner.temp }}/ci-fast-lanes.json
-          SHELLCHECK_OPTS: >-
-            --exclude=SC2001,SC2016,SC2028,SC2034,SC2086,SC2126,SC2129,SC2329
         run: node scripts/ci-fast-lanes.mjs
       - name: Upload ci-fast lane results
         if: always()

--- a/scripts/ci-fast-lanes.mjs
+++ b/scripts/ci-fast-lanes.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+/**
+ * Run the cheap CI cluster as labeled lanes with continue-on-failure semantics.
+ *
+ * Used by the `ci-fast` job in `.github/workflows/ci.yml` (JOV-3464):
+ * checkout + install once, then run typecheck / biome / eslint / guardrails /
+ * structural as independent lanes. Never aborts mid-suite — always reports every
+ * lane, writes $GITHUB_STEP_SUMMARY, emits lane records for the harness, and
+ * exits non-zero only after all lanes finish if any failed.
+ *
+ * Usage:
+ *   node scripts/ci-fast-lanes.mjs
+ *
+ * Env:
+ *   GITHUB_EVENT_NAME, GITHUB_BASE_REF, GITHUB_REF, GITHUB_STEP_SUMMARY
+ *   CI_FAST_LANES_OUT  — optional path for JSON lane results
+ *   TURBO_SCM_BASE     — for typecheck --affected
+ *   CI_FAST_SKIP_STRUCTURAL — "true" to skip structural lane (path-gated)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { appendFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = process.cwd();
+
+/** @typedef {{ id: string, name: string, nextLocalCommand: string, status: 'success'|'failure'|'skipped', logExcerpt: string }} LaneResult */
+
+const LANES = [
+  {
+    id: 'biome',
+    name: 'Biome (lint + format)',
+    nextLocalCommand: 'pnpm run biome:check',
+    run: runBiome,
+  },
+  {
+    id: 'eslint-server-boundaries',
+    name: 'ESLint server boundaries',
+    nextLocalCommand: 'pnpm --filter=@jovie/web run lint:server-boundaries',
+    run: runEslintServerBoundaries,
+  },
+  {
+    id: 'typecheck',
+    name: 'Typecheck',
+    nextLocalCommand: 'pnpm run typecheck',
+    run: runTypecheck,
+  },
+  {
+    id: 'guardrails',
+    name: 'Guardrails (proxy)',
+    nextLocalCommand: 'pnpm next:proxy-guard',
+    run: runGuardrails,
+  },
+  {
+    id: 'structural',
+    name: 'Structural Contract',
+    nextLocalCommand:
+      'pnpm ci:harness:check && pnpm ci:control:test && pnpm ci:merge-queue:check && pnpm next:proxy-guard && pnpm tailwind:check && pnpm --filter=@jovie/web run lint:no-native-dialogs && pnpm --filter=@jovie/web run lint:seo && pnpm --filter=@jovie/web run lint:contrast-ratchet && pnpm doc:freshness:check && pnpm test:reliability-detectors',
+    run: runStructural,
+  },
+];
+
+function shell(command, opts = {}) {
+  const result = spawnSync(command, {
+    shell: true,
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: process.env,
+    maxBuffer: 20 * 1024 * 1024,
+    ...opts,
+  });
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+  return {
+    code: result.status ?? 1,
+    output: `${stdout}${stderr}`,
+  };
+}
+
+function changedFiles(patterns) {
+  const event = process.env.GITHUB_EVENT_NAME || '';
+  let diffBase = 'HEAD^1';
+  if (event === 'pull_request') {
+    const base = process.env.GITHUB_BASE_REF || 'main';
+    // Prefer origin/<base> when available (fetch done by workflow).
+    const probe = shell(`git rev-parse --verify origin/${base}`);
+    diffBase =
+      probe.code === 0
+        ? `origin/${base}`
+        : process.env.TURBO_SCM_BASE || diffBase;
+  } else if (process.env.TURBO_SCM_BASE) {
+    diffBase = process.env.TURBO_SCM_BASE;
+  }
+
+  const pathspecs = patterns.map(p => `'${p}'`).join(' ');
+  const result = shell(
+    `git diff --diff-filter=d --name-only ${diffBase} HEAD -- ${pathspecs}`
+  );
+  if (result.code !== 0) {
+    // Fall back to full set (caller decides).
+    return null;
+  }
+  return result.output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+}
+
+function excerpt(text, max = 1200) {
+  const trimmed = (text || '').trim();
+  if (trimmed.length <= max) return trimmed;
+  return `…${trimmed.slice(-max)}`;
+}
+
+function runBiome() {
+  const event = process.env.GITHUB_EVENT_NAME || '';
+  if (event === 'pull_request') {
+    const files = changedFiles([
+      '*.ts',
+      '*.tsx',
+      '*.js',
+      '*.jsx',
+      '*.json',
+      '*.mts',
+      '*.mjs',
+      ':(exclude)**/package-lock.json',
+      ':(exclude).claude/settings.json',
+      ':(exclude).claude/skills/**',
+    ]);
+    if (files && files.length === 0) {
+      return { code: 0, output: 'No lintable files changed\n', skipped: false };
+    }
+    if (files && files.length > 0) {
+      const quoted = files.map(f => JSON.stringify(f)).join(' ');
+      return shell(
+        `pnpm biome ci --reporter=github --no-errors-on-unmatched ${quoted}`
+      );
+    }
+  }
+  return shell('pnpm biome ci --reporter=github .');
+}
+
+function runEslintServerBoundaries() {
+  const event = process.env.GITHUB_EVENT_NAME || '';
+  if (event === 'pull_request') {
+    const files = changedFiles([
+      'apps/web/*.ts',
+      'apps/web/*.tsx',
+      'apps/web/**/*.ts',
+      'apps/web/**/*.tsx',
+    ]);
+    if (files && files.length === 0) {
+      return {
+        code: 0,
+        output: 'No server-boundary TypeScript files changed\n',
+        skipped: false,
+      };
+    }
+    if (files && files.length > 0) {
+      const quoted = files.map(f => JSON.stringify(f)).join(' ');
+      return shell(
+        `pnpm --filter=@jovie/web run lint:server-boundaries -- ${quoted}`
+      );
+    }
+  }
+  return shell('pnpm --filter=@jovie/web run lint:server-boundaries');
+}
+
+function runTypecheck() {
+  // --force is mandatory (JOV-3499). Gate guard scans this file + ci.yml.
+  return shell('pnpm turbo typecheck --affected --force');
+}
+
+function runGuardrails() {
+  const base = process.env.GITHUB_BASE_REF || 'main';
+  const originBase = `origin/${base}`;
+  const parts = [
+    `node scripts/desktop-release-guard.mjs --base ${JSON.stringify(originBase)}`,
+    `node scripts/version-fanout-guard.mjs --base ${JSON.stringify(originBase)}`,
+    'node --test scripts/cleanup-stale-dev.test.mjs scripts/desktop-release-guard.test.mjs scripts/desktop-installed-apps-audit.test.mjs scripts/dev-web-fast.test.mjs scripts/ios-guardrail-rollout-audit.test.mjs scripts/version-fanout-guard.test.mjs scripts/version-stamp.test.mjs',
+    'node scripts/version-check.mjs',
+    'node apps/web/scripts/next-proxy-guard.mjs',
+  ];
+  let combined = '';
+  for (const cmd of parts) {
+    const result = shell(cmd);
+    combined += result.output;
+    if (result.code !== 0) {
+      return { code: result.code, output: combined };
+    }
+  }
+  return { code: 0, output: combined };
+}
+
+function runStructural() {
+  if (process.env.CI_FAST_SKIP_STRUCTURAL === 'true') {
+    return {
+      code: 0,
+      output: 'Structural Contract skipped (path-gated)\n',
+      skipped: true,
+    };
+  }
+
+  const parts = [
+    'pnpm ci:harness:check',
+    'pnpm ci:control:test',
+    'pnpm ci:branching-guard:validate',
+    'pnpm ci:merge-queue:check',
+    'pnpm ci:typecheck-gate-guard',
+    // actionlint runs as a dedicated workflow step before this script (rhysd/actionlint).
+    'pnpm next:proxy-guard',
+    'pnpm tailwind:check',
+    'pnpm --filter=@jovie/web run lint:no-native-dialogs',
+    'pnpm --filter=@jovie/web run lint:seo',
+    'pnpm --filter=@jovie/web run lint:contrast-ratchet',
+    'pnpm doc:freshness:check',
+    'node .github/scripts/quarantine-ledger.mjs validate',
+    'pnpm --filter @jovie/web run test:reliability-detectors',
+    // Optional: drain regression tests need pytest; soft-skip if unavailable.
+    'if command -v pytest >/dev/null 2>&1; then pytest scripts/tests/test_gh_retry.py -v; elif python3 -c "import pytest" 2>/dev/null; then python3 -m pytest scripts/tests/test_gh_retry.py -v; else echo "pytest not installed — skip drain regression"; fi',
+  ];
+
+  let combined = '';
+  for (const cmd of parts) {
+    const result = shell(cmd);
+    combined += result.output;
+    if (result.code !== 0) {
+      return { code: result.code, output: combined };
+    }
+  }
+  return { code: 0, output: combined };
+}
+
+function annotateFailure(lane, logExcerpt) {
+  // GitHub Actions annotation — visible on the PR Checks UI.
+  const msg = `${lane.name} failed. Fix: ${lane.nextLocalCommand}`;
+  console.error(`::error title=${lane.name}::${msg}`);
+  if (logExcerpt) {
+    // Keep annotation body short; full log is in the step output.
+    const short = logExcerpt.split('\n').slice(-8).join(' | ').slice(0, 400);
+    console.error(`::error::${short}`);
+  }
+}
+
+function writeSummary(results) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const lines = [
+    '### ci-fast lanes (JOV-3464)',
+    '',
+    '| Lane | Status | Next local command |',
+    '| --- | --- | --- |',
+  ];
+  for (const r of results) {
+    lines.push(`| ${r.name} | **${r.status}** | \`${r.nextLocalCommand}\` |`);
+  }
+  lines.push('');
+  const failed = results.filter(r => r.status === 'failure');
+  if (failed.length > 0) {
+    lines.push('#### Failing lanes');
+    for (const r of failed) {
+      lines.push('');
+      lines.push(`##### ${r.name}`);
+      lines.push('');
+      lines.push('```');
+      lines.push(r.logExcerpt || '(no output)');
+      lines.push('```');
+    }
+  }
+  lines.push('');
+  appendFileSync(summaryPath, `${lines.join('\n')}\n`);
+}
+
+function main() {
+  /** @type {LaneResult[]} */
+  const results = [];
+
+  for (const lane of LANES) {
+    console.log(`\n======== lane: ${lane.id} ========`);
+    let outcome;
+    try {
+      outcome = lane.run();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.stack || error.message : String(error);
+      outcome = { code: 1, output: message };
+    }
+
+    const skipped = Boolean(outcome.skipped);
+    const status = skipped
+      ? 'skipped'
+      : outcome.code === 0
+        ? 'success'
+        : 'failure';
+    const logExcerpt = excerpt(outcome.output);
+
+    if (status === 'failure') {
+      annotateFailure(lane, logExcerpt);
+    }
+
+    console.log(`[ci-fast] ${lane.id}: ${status}`);
+    if (logExcerpt && status !== 'success') {
+      console.log(logExcerpt);
+    }
+
+    results.push({
+      id: lane.id,
+      name: lane.name,
+      nextLocalCommand: lane.nextLocalCommand,
+      status,
+      logExcerpt,
+    });
+  }
+
+  writeSummary(results);
+
+  const outPath =
+    process.env.CI_FAST_LANES_OUT || resolve(REPO_ROOT, 'ci-fast-lanes.json');
+  writeFileSync(
+    outPath,
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        job: 'ci-fast',
+        lanes: results,
+        generatedAt: new Date().toISOString(),
+      },
+      null,
+      2
+    )
+  );
+  console.log(`[ci-fast] wrote lane results → ${outPath}`);
+
+  const failed = results.filter(r => r.status === 'failure');
+  if (failed.length > 0) {
+    console.error(
+      `[ci-fast] ${failed.length} lane(s) failed: ${failed.map(f => f.id).join(', ')}`
+    );
+    process.exit(1);
+  }
+  console.log('[ci-fast] all lanes passed');
+  process.exit(0);
+}
+
+main();

--- a/scripts/ci-harness.mjs
+++ b/scripts/ci-harness.mjs
@@ -100,6 +100,14 @@ function runClassifyRisk(manifest, args) {
 function runEmitArtifact(manifest, args) {
   const riskPath = argValue(args, '--risk');
   const risk = riskPath ? JSON.parse(readFileSync(riskPath, 'utf8')) : null;
+  // Optional intra-job lane results (JOV-3464 ci-fast collapse).
+  // Accepts either a flat lanes array file or `{ lanes: [...] }` from ci-fast-lanes.mjs.
+  const lanesPath = argValue(args, '--lanes');
+  let laneResults;
+  if (lanesPath) {
+    const raw = JSON.parse(readFileSync(lanesPath, 'utf8'));
+    laneResults = Array.isArray(raw) ? raw : (raw.lanes ?? raw);
+  }
   const artifact = buildCiHarnessArtifact({
     runId: process.env.GITHUB_RUN_ID,
     runAttempt: process.env.GITHUB_RUN_ATTEMPT,
@@ -110,6 +118,7 @@ function runEmitArtifact(manifest, args) {
     jobResults: parseJobResultsFromEnv(process.env, manifest),
     risk,
     manifest,
+    laneResults,
   });
 
   const outputPath = argValue(args, '--out');

--- a/scripts/ci-typecheck-gate-guard.mjs
+++ b/scripts/ci-typecheck-gate-guard.mjs
@@ -17,59 +17,95 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const WORKFLOW_PATH = resolve('.github/workflows/ci.yml');
-const JOB_MARKER = 'ci-typecheck:';
+const LANES_PATH = resolve('scripts/ci-fast-lanes.mjs');
+// JOV-3464: typecheck lives in the collapsed `ci-fast` job (lanes runner).
+// Accept either the legacy `ci-typecheck:` job or the `ci-fast` + lanes script.
+const JOB_MARKERS = ['ci-fast:', 'ci-typecheck:'];
 const REQUIRED_FLAG = '--force';
-const TURBO_CMD_PATTERN = /pnpm\s+turbo\s+typecheck/;
+const TURBO_CMD_PATTERN = /(?:pnpm\s+)?turbo\s+typecheck/;
 
-function main() {
-  let workflow;
+function scanFile(filePath, label) {
+  let content;
   try {
-    workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+    content = readFileSync(filePath, 'utf8');
   } catch {
-    console.error(`[ci-typecheck-gate-guard] Cannot read ${WORKFLOW_PATH}`);
-    process.exit(1);
+    return { missingFile: true, findings: [], hasForce: false, label };
   }
 
-  const lines = workflow.split('\n');
-
-  // Locate the ci-typecheck job block and find the turbo typecheck run line.
-  let inJob = false;
+  const lines = content.split('\n');
+  // Non-workflow files (lanes script) are scanned in full; workflow files are
+  // restricted to the ci-fast / ci-typecheck job blocks below.
+  let inJob = !filePath.endsWith('ci.yml');
   let inNextJob = false;
   const findings = [];
+  let sawTurbo = false;
+  let hasForce = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
 
-    // Detect job boundaries (top-level job keys end with a colon at column 2 in GH Actions YAML).
-    if (/^\s{2}\w[\w-]+:\s*$/.test(line)) {
-      if (line.trim() === JOB_MARKER) {
+    if (filePath.endsWith('ci.yml') && /^\s{2}\w[\w-]+:\s*$/.test(line)) {
+      if (JOB_MARKERS.includes(line.trim())) {
         inJob = true;
         inNextJob = false;
       } else if (inJob) {
-        // Entered the next job — stop scanning.
         inNextJob = true;
       }
     }
 
     if (!inJob || inNextJob) continue;
 
-    // Found a turbo typecheck invocation inside the ci-typecheck job.
     if (TURBO_CMD_PATTERN.test(line)) {
-      if (!line.includes(REQUIRED_FLAG)) {
-        findings.push({ lineNumber: i + 1, content: line.trim() });
+      sawTurbo = true;
+      if (line.includes(REQUIRED_FLAG)) {
+        hasForce = true;
+      } else {
+        findings.push({ lineNumber: i + 1, content: line.trim(), label });
       }
     }
   }
 
-  if (findings.length === 0) {
+  return { missingFile: false, findings, hasForce, sawTurbo, label };
+}
+
+function main() {
+  // Prefer the lanes script (source of truth after JOV-3464 collapse); also
+  // scan ci.yml for any inline turbo typecheck that might bypass the lanes.
+  const scans = [
+    scanFile(LANES_PATH, 'ci-fast-lanes'),
+    scanFile(WORKFLOW_PATH, 'ci.yml'),
+  ];
+
+  if (scans[0].missingFile && scans[1].missingFile) {
+    console.error(
+      '[ci-typecheck-gate-guard] Cannot read workflow or lanes script'
+    );
+    process.exit(1);
+  }
+
+  const findings = scans.flatMap(s => s.findings);
+  const hasForce = scans.some(s => s.hasForce);
+  const sawTurbo = scans.some(s => s.sawTurbo);
+
+  if (sawTurbo && hasForce && findings.length === 0) {
     console.log(
-      `[ci-typecheck-gate-guard] PASS — ci-typecheck gate invokes turbo with ${REQUIRED_FLAG}.`
+      `[ci-typecheck-gate-guard] PASS — ci-fast typecheck gate invokes turbo with ${REQUIRED_FLAG}.`
     );
     process.exit(0);
   }
 
+  if (!sawTurbo) {
+    console.error(
+      '[ci-typecheck-gate-guard] FAIL — no turbo typecheck invocation found in ci-fast.'
+    );
+    console.error(
+      `Remediation: ensure ${LANES_PATH} (or the ci-fast job) runs \`pnpm turbo typecheck --affected --force\`.`
+    );
+    process.exit(1);
+  }
+
   console.error(
-    '[ci-typecheck-gate-guard] FAIL — ci-typecheck gate is missing --force.'
+    '[ci-typecheck-gate-guard] FAIL — typecheck gate is missing --force.'
   );
   console.error('');
   console.error(
@@ -79,12 +115,12 @@ function main() {
     'producing a false-green merge gate (JOV-3499). The gate MUST use --force.'
   );
   console.error('');
-  for (const { lineNumber, content } of findings) {
-    console.error(`  Line ${lineNumber}: ${content}`);
+  for (const { lineNumber, content, label } of findings) {
+    console.error(`  ${label}:${lineNumber}: ${content}`);
   }
   console.error('');
   console.error(
-    `Remediation: add ${REQUIRED_FLAG} to the turbo typecheck command in ${WORKFLOW_PATH}`
+    `Remediation: add ${REQUIRED_FLAG} to the turbo typecheck command in ${LANES_PATH}`
   );
   process.exit(1);
 }

--- a/scripts/lib/__tests__/ci-harness.test.mjs
+++ b/scripts/lib/__tests__/ci-harness.test.mjs
@@ -102,10 +102,9 @@ describe('ci-harness manifest', () => {
       'Fork PR Gate',
     ]);
     // Individual harness merge-gate job names must stay in the forbidden pin list
-    // so a batch failure bisects instead of evicting siblings.
+    // so a batch failure bisects instead of evicting siblings. ci-fast is a real
+    // collapsed job (JOV-3464) but must never be pinned alone — only PR Ready is.
     for (const name of EXPECTED_MERGE_GATE_NAMES) {
-      // ci-fast appears in the manifest for docs/remediation; the aggregator was
-      // removed from the workflow but the name remains a forbidden pin.
       expect(
         FORBIDDEN_PINNED_JOB_CONTEXTS.includes(name) ||
           FORBIDDEN_PINNED_JOB_CONTEXTS.includes(`CI / ${name}`),
@@ -339,6 +338,47 @@ describe('ci-harness artifact formatter', () => {
     expect(
       artifact.nextLocalCommands.some(command =>
         command.includes('pnpm doc:freshness:check')
+      )
+    ).toBe(true);
+  });
+
+  it('includes intra-job lane results for ci-fast collapse (JOV-3464)', () => {
+    const artifact = buildCiHarnessArtifact({
+      runId: '456',
+      runAttempt: '1',
+      repository: 'JovieInc/Jovie',
+      prNumber: '100',
+      sha: 'def456',
+      previewUrl: null,
+      manifest,
+      risk: null,
+      jobResults: [{ id: 'ci-fast', status: 'failure' }],
+      laneResults: [
+        {
+          lane: 'typecheck',
+          status: 'failure',
+          nextLocalCommand: 'pnpm run typecheck',
+          log_excerpt: "error TS2304: Cannot find name 'x'",
+        },
+        {
+          id: 'biome',
+          status: 'success',
+          nextLocalCommand: 'pnpm run biome:check',
+        },
+      ],
+    });
+
+    expect(artifact.lanes).toHaveLength(2);
+    expect(artifact.lanes[0]).toMatchObject({
+      lane: 'typecheck',
+      status: 'failure',
+      nextLocalCommand: 'pnpm run typecheck',
+    });
+    expect(artifact.nextLocalCommands).toContain('pnpm run typecheck');
+    // Job-level remediation from ci-fast still present
+    expect(
+      artifact.nextLocalCommands.some(command =>
+        command.includes('pnpm run typecheck')
       )
     ).toBe(true);
   });

--- a/scripts/lib/ci-harness.mjs
+++ b/scripts/lib/ci-harness.mjs
@@ -493,6 +493,22 @@ export function generateDocsFiles(manifest, { write = false } = {}) {
   return results;
 }
 
+/**
+ * Normalize intra-job lane records (JOV-3464 ci-fast collapse).
+ * @param {Array<{ lane?: string, id?: string, status?: string, nextLocalCommand?: string, log_excerpt?: string, logExcerpt?: string }>} lanes
+ */
+export function normalizeLaneResults(lanes = []) {
+  return (lanes ?? []).map(lane => {
+    const id = lane.lane ?? lane.id ?? 'unknown';
+    return {
+      lane: id,
+      status: lane.status ?? 'not_run',
+      nextLocalCommand: lane.nextLocalCommand ?? null,
+      log_excerpt: lane.log_excerpt ?? lane.logExcerpt ?? null,
+    };
+  });
+}
+
 export function buildCiHarnessArtifact({
   runId,
   runAttempt,
@@ -503,6 +519,9 @@ export function buildCiHarnessArtifact({
   jobResults,
   risk,
   manifest,
+  // Intra-job lane results (e.g. ci-fast biome/typecheck/guardrails lanes).
+  // Accepts either a flat array or a map of jobId → lanes[].
+  laneResults,
 }) {
   const jobsById = new Map((manifest.jobs ?? []).map(job => [job.id, job]));
   const normalizedJobs = (jobResults ?? []).map(result => {
@@ -520,6 +539,23 @@ export function buildCiHarnessArtifact({
     };
   });
 
+  /** @type {Array<{ lane: string, status: string, nextLocalCommand: string|null, log_excerpt: string|null, jobId?: string }>} */
+  let normalizedLanes = [];
+  if (Array.isArray(laneResults)) {
+    normalizedLanes = normalizeLaneResults(laneResults);
+  } else if (laneResults && typeof laneResults === 'object') {
+    for (const [jobId, lanes] of Object.entries(laneResults)) {
+      for (const lane of normalizeLaneResults(lanes)) {
+        normalizedLanes.push({ ...lane, jobId });
+      }
+    }
+  }
+
+  const laneCommands = normalizedLanes
+    .filter(lane => lane.status !== 'success' && lane.status !== 'skipped')
+    .map(lane => lane.nextLocalCommand)
+    .filter(Boolean);
+
   return {
     schemaVersion: HARNESS_SCHEMA_VERSION,
     run: {
@@ -535,12 +571,15 @@ export function buildCiHarnessArtifact({
       risk: risk ?? null,
     },
     jobs: normalizedJobs,
+    // Intra-job lanes (JOV-3464) — fixer agents read nextLocalCommand per lane.
+    lanes: normalizedLanes,
     nextLocalCommands: [
-      ...new Set(
-        normalizedJobs
+      ...new Set([
+        ...normalizedJobs
           .filter(job => job.status !== 'success' && job.nextLocalCommand)
-          .map(job => job.nextLocalCommand)
-      ),
+          .map(job => job.nextLocalCommand),
+        ...laneCommands,
+      ]),
     ],
     generatedAt: new Date().toISOString(),
   };


### PR DESCRIPTION
## Summary
- Fold typecheck / biome / eslint server-boundaries / guardrails / structural into one **`ci-fast`** job (single checkout + install) with continue-on-lane-failure reporting via `scripts/ci-fast-lanes.mjs`
- Restore **`PR Ready`** aggregate (required-context continuity for merge-queue-guard, drain, agent-pipeline, agent-landing-sweep, agent-tick)
- Fix **CI Risk Classifier** to run on PRs again (was main-only — risk-triggered smoke/preview never fired)
- Structural lane is path-gated on PRs (`.github/`, harness, agent control plane); always on main
- Extend `buildCiHarnessArtifact` with intra-job `lanes[]` for fixer-agent remediation

## Why
One PR was fanning into too many cheap jobs (each with checkout+install). Collapsing the cheap cluster frees runner slots and removes setup tax. PR Ready restore closes the JOV-4168 gate regression (main was only gated by Migration Guard + Fork PR Gate + PR Size Guard).

## Acceptance (JOV-3464)
- [x] `PR Ready` name byte-for-byte
- [x] Per-lane PASS/FAIL in step summary + `::error` annotations
- [x] Lane records feed harness (`lanes` on `ci-harness.v1.json`)
- [x] Docs-only PR path still skips `ci-fast` (`has_code_changes=false` → skipped → PR Ready success)
- [x] Heavy lanes (build, Lighthouse, e2e, preview) stay separate

## Verification
```
pnpm ci:control:test   # 102 passed
node scripts/ci-typecheck-gate-guard.mjs  # PASS --force
pnpm ci:harness:check  # valid
pnpm ci:merge-queue:check  # OK
```

## Cost Impact
- **External API calls**: none
- **CI runner slots**: lower per PR (4 cheap jobs → 1)
- **Wall-clock**: similar for typecheck-bound PRs; structural skipped on non-CI paths

## Note vs #13838
This PR supersedes the leaf-fan-in approach in #13838 by collapsing leaves into `ci-fast` while still restoring `PR Ready`.

Fixes JOV-3464
<!-- linear-issue-id:JOV-3464 -->