### PR TITLE
perf(ci): reuse .vercel/output from ci-build-public in deploy-staging (JOV-4087)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -972,11 +972,11 @@ jobs:
     # Shared Next.js build for a11y + layout-guard — build once, test twice.
     # On PRs to main: always runs (non-fork) for build validation. Part of the merge gate.
     # Merge queue intentionally skips build (already validated on the PR).
-    # On main push: always runs for full coverage.
+    # On main push: always runs for full coverage + JOV-4087 vercel deploy artifact.
     # Fork PRs are excluded (no secrets) — skipped via fork-pr-gate.
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false) || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     outputs:
       has_artifact: ${{ steps.check_changes.outputs.run_full_ci }}
     steps:
@@ -1046,6 +1046,66 @@ jobs:
           path: /tmp/nextjs-build.tar
           retention-days: 1
           if-no-files-found: error
+
+      # JOV-4087: produce .vercel/output once on main so deploy-staging can skip
+      # its own vercel build (~3–5 min). Keep turbo `.next` artifact untouched for
+      # downstream test jobs. Soft-fail so a Vercel CLI blip cannot red the merge gate.
+      - name: Pull Vercel env (preview) for deploy artifact
+        id: vercel_pull
+        if: ${{ steps.check_changes.outputs.run_full_ci == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          scope_args=()
+          if [ -n "${VERCEL_ORG_ID:-}" ]; then
+            scope_args=(--scope "$VERCEL_ORG_ID")
+          fi
+          ./node_modules/.bin/vercel pull --yes --environment=preview --token "$VERCEL_TOKEN" "${scope_args[@]}"
+          for env_file in .vercel/.env.preview.local .vercel/.env.local; do
+            if [ -f "$env_file" ]; then
+              grep -v '^TURBO_REMOTE_ONLY=' "$env_file" > "${env_file}.tmp" || true
+              mv "${env_file}.tmp" "$env_file"
+            fi
+          done
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Vercel build (deploy artifact)
+        id: vercel_build
+        if: ${{ steps.check_changes.outputs.run_full_ci == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.vercel_pull.outcome == 'success' }}
+        continue-on-error: true
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          scope_args=()
+          if [ -n "${VERCEL_ORG_ID:-}" ]; then
+            scope_args=(--scope "$VERCEL_ORG_ID")
+          fi
+          # Do NOT inherit NEXT_PUBLIC_CLERK_MOCK from the turbo build step —
+          # deploy artifact must match staging preview compile flags.
+          env -u TURBO_REMOTE_ONLY -u NEXT_PUBLIC_CLERK_MOCK -u NEXT_PUBLIC_CLERK_PROXY_DISABLED \
+            ./node_modules/.bin/vercel build --token "$VERCEL_TOKEN" "${scope_args[@]}"
+          tar -czf /tmp/vercel-build-output.tar.gz -C . .vercel/output
+          echo "vercel_artifact=true" >> "$GITHUB_OUTPUT"
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
+          COREPACK_ENABLE_STRICT: 0
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Upload vercel build artifact
+        if: ${{ steps.vercel_build.outputs.vercel_artifact == 'true' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vercel-build-output-${{ github.run_id }}
+          path: /tmp/vercel-build-output.tar.gz
+          retention-days: 1
+          if-no-files-found: warn
 
   ci-layout-guard:
     name: Layout Guard (informational)
@@ -4276,6 +4336,7 @@ jobs:
           fi
 
   deploy-staging:
+    # deploy-gate already needs ci-build-public (JOV-4087 vercel artifact producer).
     needs: [deploy-gate]
     # Fast main path: merge on deterministic checks, deploy a production build to
     # a preview URL, verify it on staging, then promote only if it passes.
@@ -4335,7 +4396,39 @@ jobs:
         # merge commit message. The Slack drift notification in deploy-notify
         # fires when verify fails but deploy proceeds (bypass alert).
         continue-on-error: ${{ contains(github.event.head_commit.message, '[skip-schema-verify]') }}
+      # JOV-4087: reuse vercel build from ci-build-public when available.
+      - name: Download vercel build artifact
+        id: download_vercel_build
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vercel-build-output-${{ github.run_id }}
+          path: /tmp
+
+      - name: Restore vercel build output from artifact
+        id: restore_vercel_build
+        if: steps.download_vercel_build.outcome == 'success'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          if [ -f /tmp/vercel-build-output.tar.gz ]; then
+            mkdir -p .vercel
+            tar -xzf /tmp/vercel-build-output.tar.gz -C .
+            if [ -d .vercel/output ]; then
+              echo "restored=true" >> "$GITHUB_OUTPUT"
+              echo "Restored .vercel/output from ci-build-public artifact (JOV-4087)"
+            else
+              echo "restored=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::vercel artifact missing .vercel/output after extract"
+            fi
+          else
+            echo "restored=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::vercel-build-output tar not found after download"
+          fi
+
       - name: Pull env (staging preview)
+        # Always pull project metadata/env; needed even when prebuilt output is restored
+        # (deploy CLI reads .vercel/project.json).
         timeout-minutes: 5
         run: |
           scope_args=()
@@ -4354,6 +4447,8 @@ jobs:
       - name: Check signup readiness (staging deploy env)
         run: pnpm --filter=@jovie/web exec tsx scripts/check-signup-readiness.ts --target=stg --source=env
       - name: Build (preview target for staging verification)
+        # Skip when JOV-4087 artifact restored successfully.
+        if: steps.restore_vercel_build.outputs.restored != 'true'
         timeout-minutes: 10
         run: |
           scope_args=()
@@ -4365,7 +4460,13 @@ jobs:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
           COREPACK_ENABLE_STRICT: 0
       - name: Package build output for provenance attestation
-        run: tar -czf /tmp/vercel-build-output.tar.gz -C . .vercel/output
+        run: |
+          set -euo pipefail
+          if [ -f /tmp/vercel-build-output.tar.gz ] && [ "${{ steps.restore_vercel_build.outputs.restored }}" = "true" ]; then
+            echo "Using downloaded vercel-build-output.tar.gz for attestation"
+          else
+            tar -czf /tmp/vercel-build-output.tar.gz -C . .vercel/output
+          fi
       - name: Attest build provenance (SLSA Level 2)
         id: attest
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1


### PR DESCRIPTION
## Summary
- `ci-build-public` (main push only) runs `vercel pull --environment=preview` + `vercel build` after the turbo `.next` build and uploads `vercel-build-output-${{ github.run_id }}`
- `deploy-staging` downloads that artifact, restores `.vercel/output`, and **skips** its own `vercel build` when restore succeeds
- Local `vercel build` remains as fallback if the artifact is missing
- Turbo `nextjs-build-*` artifact and all downstream test jobs are unchanged

## Savings
~3–5 min per main deploy on the critical path (compilation paid once instead of twice).

## Cost Impact
- **External API calls**: none new (same Vercel build, moved earlier on main)
- **CI time**: net decrease on deploy path; main `ci-build-public` timeout raised 10→20m to cover dual build

## Verification
- Workflow YAML only; `nextjs-build` path untouched
- Soft-fail on vercel artifact steps so PR merge gate / test consumers cannot red on Vercel CLI blips

Fixes JOV-4087
<!-- linear-issue-id:JOV-4087 -->