### PR TITLE
feat(ci): universal gate-ladder skeleton for web + iOS (JOV-3210)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,16 @@
 #!/usr/bin/env sh
 set -e  # Required: ensures check-conflict-markers.sh failure actually blocks commits
+# Universal gate ladder (JOV-3210): conflict → secrets → proxy → lint/typecheck.
+# Source of truth: scripts/gate-ladder/ladder.json (`pnpm gate-ladder:validate`).
 
 bash scripts/check-conflict-markers.sh
 bash scripts/security/scan-secrets.sh pre-commit
 pnpm run next:proxy-guard
 node scripts/turbo-warm-precommit-cache.mjs
 pnpm exec lint-staged
+
+# iOS adapter: when Swift sources are staged, run the portable best-practices lint.
+if git diff --cached --name-only --diff-filter=ACM | grep -qE '^apps/ios/.*\.swift$'; then
+  echo "[gate-ladder] ios format-lint rung (staged Swift)"
+  pnpm run ios:lint
+fi

--- a/package.json
+++ b/package.json
@@ -196,7 +196,10 @@
     "ds:offscale": "node scripts/ds-offscale-report.mjs",
     "ds:llms-manifest": "node scripts/generate-llms-design-manifest.mjs",
     "ds:llms-manifest:check": "node scripts/generate-llms-design-manifest.mjs --check",
-    "ci:control:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__/ci-harness.test.mjs lib/__tests__/ci-duration-ratchet.test.mjs lib/__tests__/ci-branching-guard.test.mjs lib/__tests__/merge-queue-guard.test.mjs lib/__tests__/ci-metrics-compute.test.mjs"
+    "ci:control:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__/ci-harness.test.mjs lib/__tests__/ci-duration-ratchet.test.mjs lib/__tests__/ci-branching-guard.test.mjs lib/__tests__/merge-queue-guard.test.mjs lib/__tests__/ci-metrics-compute.test.mjs",
+    "gate-ladder:validate": "node scripts/gate-ladder/validate.mjs",
+    "gate-ladder:list": "node scripts/gate-ladder/run.mjs --list",
+    "gate-ladder:test": "node --test scripts/gate-ladder/gate-ladder.test.mjs"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.100.1",

--- a/scripts/gate-ladder/gate-ladder.test.mjs
+++ b/scripts/gate-ladder/gate-ladder.test.mjs
@@ -1,8 +1,8 @@
+import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..', '..');

--- a/scripts/gate-ladder/gate-ladder.test.mjs
+++ b/scripts/gate-ladder/gate-ladder.test.mjs
@@ -1,0 +1,45 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+function run(args) {
+  return spawnSync('node', args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+}
+
+describe('gate-ladder (JOV-3210)', () => {
+  it('validates the shared ladder against live hooks and workflows', () => {
+    const result = run(['scripts/gate-ladder/validate.mjs']);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /PASS/);
+  });
+
+  it('lists rungs including secrets and PR Ready aggregate', () => {
+    const result = run(['scripts/gate-ladder/run.mjs', '--list']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /secrets/);
+    assert.match(result.stdout, /aggregate/);
+    assert.match(result.stdout, /typecheck/);
+  });
+
+  it('skips PR-mapping prose without executing it', () => {
+    const result = run([
+      'scripts/gate-ladder/run.mjs',
+      '--rung',
+      'aggregate',
+      '--app',
+      'web',
+      '--phase',
+      'pr',
+    ]);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /documented mapping only|PR Ready/);
+  });
+});

--- a/scripts/gate-ladder/ladder.json
+++ b/scripts/gate-ladder/ladder.json
@@ -1,0 +1,150 @@
+{
+  "schemaVersion": 1,
+  "id": "jovie-universal-gate-ladder",
+  "description": "Shared pre-commit → pre-push → PR gate ladder for web + iOS (JOV-3210). Adapters map to husky hooks and GitHub Actions; do not fork intent per app.",
+  "rungs": [
+    {
+      "id": "conflict-markers",
+      "name": "Conflict markers",
+      "intent": "Block unresolved merge conflict markers from being committed.",
+      "hardBlock": true,
+      "preCommit": {
+        "web": "bash scripts/check-conflict-markers.sh",
+        "ios": "bash scripts/check-conflict-markers.sh"
+      },
+      "prePush": null,
+      "pr": null
+    },
+    {
+      "id": "secrets",
+      "name": "Secret scan (gitleaks + trufflehog)",
+      "intent": "Block staged secrets before they hit a public remote.",
+      "hardBlock": true,
+      "preCommit": {
+        "web": "bash scripts/security/scan-secrets.sh pre-commit",
+        "ios": "bash scripts/security/scan-secrets.sh pre-commit"
+      },
+      "prePush": null,
+      "pr": {
+        "web": "security.yml → Gitleaks Secret Scanning",
+        "ios": "security.yml → Gitleaks Secret Scanning"
+      }
+    },
+    {
+      "id": "proxy-guard",
+      "name": "Next.js proxy guard",
+      "intent": "Keep Clerk /__clerk proxy contract intact.",
+      "hardBlock": true,
+      "preCommit": {
+        "web": "pnpm run next:proxy-guard",
+        "ios": null
+      },
+      "prePush": null,
+      "pr": {
+        "web": "ci-fast guardrails lane (JOV-3464) / ci.yml",
+        "ios": null
+      }
+    },
+    {
+      "id": "format-lint",
+      "name": "Format + lint (Biome / ESLint / SwiftLint)",
+      "intent": "Deterministic style and server-boundary checks on changed files.",
+      "hardBlock": true,
+      "preCommit": {
+        "web": "pnpm exec lint-staged (biome + eslint server-boundaries)",
+        "ios": "pnpm run ios:lint (best-practices) + SwiftFormat/SwiftLint when available"
+      },
+      "prePush": {
+        "web": "bash scripts/hooks/pre-push-gate.sh lint",
+        "ios": "pnpm run ios:lint"
+      },
+      "pr": {
+        "web": "ci-fast biome + eslint lanes",
+        "ios": "ios-ci.yml best-practices lint"
+      }
+    },
+    {
+      "id": "typecheck",
+      "name": "Typecheck (tsc strict / affected)",
+      "intent": "Fail closed on TypeScript errors before push/merge.",
+      "hardBlock": true,
+      "preCommit": {
+        "web": "lint-staged → turbo typecheck --filter=@jovie/web (staged TS)",
+        "ios": null
+      },
+      "prePush": {
+        "web": "bash scripts/hooks/pre-push-gate.sh lint (includes type-adjacent checks)",
+        "ios": null
+      },
+      "pr": {
+        "web": "ci-fast typecheck lane (turbo typecheck --affected --force)",
+        "ios": null
+      }
+    },
+    {
+      "id": "unit",
+      "name": "Affected unit tests",
+      "intent": "Run focused unit tests before merge; full suite on main.",
+      "hardBlock": true,
+      "preCommit": null,
+      "prePush": {
+        "web": "bash scripts/hooks/pre-push-gate.sh test (optional mode)",
+        "ios": "pnpm run ios:test (when exercising native changes)"
+      },
+      "pr": {
+        "web": "Unit Tests (ci-unit-tests shards)",
+        "ios": "ios-ci.yml unit/UI tests"
+      }
+    },
+    {
+      "id": "size",
+      "name": "PR size limit",
+      "intent": "Keep PRs reviewable (800 lines / 40 files; big-pr for codemods).",
+      "hardBlock": true,
+      "preCommit": null,
+      "prePush": null,
+      "pr": {
+        "web": "pr-size-guard.yml",
+        "ios": "pr-size-guard.yml"
+      }
+    },
+    {
+      "id": "osv",
+      "name": "Dependency vulnerability scan",
+      "intent": "Surface known vulnerable deps on the PR/security path.",
+      "hardBlock": false,
+      "preCommit": null,
+      "prePush": null,
+      "pr": {
+        "web": "security.yml / CodeQL / Trivy (post-merge heavy; PR secret scans hard-block)",
+        "ios": "security.yml (shared)"
+      }
+    },
+    {
+      "id": "aggregate",
+      "name": "PR Ready aggregate",
+      "intent": "Single required check so red PRs cannot merge.",
+      "hardBlock": true,
+      "preCommit": null,
+      "prePush": null,
+      "pr": {
+        "web": "CI / PR Ready (ci-pr-ready)",
+        "ios": "ios-ci required checks"
+      }
+    }
+  ],
+  "adapters": {
+    "web": {
+      "preCommitHook": ".husky/pre-commit",
+      "prePushHook": ".husky/pre-push",
+      "prWorkflow": ".github/workflows/ci.yml",
+      "notes": "Husky + lint-staged is the local adapter. Lefthook is not required while husky covers the same rungs."
+    },
+    "ios": {
+      "preCommitHook": ".husky/pre-commit (shared secret + conflict rungs)",
+      "prePushHook": "pnpm run ios:lint via scripts/hooks when Swift files staged",
+      "prWorkflow": ".github/workflows/ios-ci.yml",
+      "notes": "SwiftFormat/SwiftLint run in ios-ci; local best-practices lint is scripts/ios-best-practices-lint.sh."
+    }
+  }
+}

--- a/scripts/gate-ladder/run.mjs
+++ b/scripts/gate-ladder/run.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Run a gate-ladder rung by id (JOV-3210).
+ *
+ * Usage:
+ *   node scripts/gate-ladder/run.mjs --rung secrets --app web --phase preCommit
+ *   node scripts/gate-ladder/run.mjs --list
+ *
+ * This is the shared entrypoint web + iOS adapters can call. Hard-block rungs
+ * exit non-zero; advisory rungs warn and exit 0 unless --strict.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const ladder = JSON.parse(
+  readFileSync(resolve(__dirname, 'ladder.json'), 'utf8')
+);
+
+function usage(code = 0) {
+  console.log(`Usage:
+  node scripts/gate-ladder/run.mjs --list
+  node scripts/gate-ladder/run.mjs --rung <id> --app web|ios --phase preCommit|prePush|pr [--strict]
+`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const out = { list: false, strict: false, rung: null, app: 'web', phase: 'preCommit' };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--list') out.list = true;
+    else if (a === '--strict') out.strict = true;
+    else if (a === '--rung') out.rung = argv[++i];
+    else if (a === '--app') out.app = argv[++i];
+    else if (a === '--phase') out.phase = argv[++i];
+    else if (a === '--help' || a === '-h') usage(0);
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.list) {
+    for (const rung of ladder.rungs) {
+      console.log(
+        `${rung.id.padEnd(18)} hard=${String(rung.hardBlock).padEnd(5)} ${rung.name}`
+      );
+    }
+    process.exit(0);
+  }
+
+  if (!args.rung) usage(2);
+  const rung = ladder.rungs.find(r => r.id === args.rung);
+  if (!rung) {
+    console.error(`[gate-ladder] unknown rung: ${args.rung}`);
+    process.exit(2);
+  }
+
+  const phase = rung[args.phase];
+  if (phase == null) {
+    console.log(
+      `[gate-ladder] rung ${rung.id} has no ${args.phase} command — skip`
+    );
+    process.exit(0);
+  }
+
+  const command = phase[args.app];
+  if (!command) {
+    console.log(
+      `[gate-ladder] rung ${rung.id} has no ${args.phase} adapter for ${args.app} — skip`
+    );
+    process.exit(0);
+  }
+
+  // Only execute real shell commands (not prose descriptions used for PR mapping).
+  const executable =
+    command.startsWith('bash ') ||
+    command.startsWith('pnpm ') ||
+    command.startsWith('node ');
+
+  if (!executable) {
+    console.log(
+      `[gate-ladder] ${rung.id}/${args.phase}/${args.app}: documented mapping only → ${command}`
+    );
+    process.exit(0);
+  }
+
+  console.log(`[gate-ladder] running ${rung.id}: ${command}`);
+  const result = spawnSync(command, {
+    shell: true,
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  const code = result.status ?? 1;
+  if (code !== 0 && !rung.hardBlock && !args.strict) {
+    console.warn(
+      `[gate-ladder] advisory rung ${rung.id} failed (exit ${code}) — not blocking`
+    );
+    process.exit(0);
+  }
+  process.exit(code);
+}
+
+main();

--- a/scripts/gate-ladder/run.mjs
+++ b/scripts/gate-ladder/run.mjs
@@ -30,7 +30,13 @@ function usage(code = 0) {
 }
 
 function parseArgs(argv) {
-  const out = { list: false, strict: false, rung: null, app: 'web', phase: 'preCommit' };
+  const out = {
+    list: false,
+    strict: false,
+    rung: null,
+    app: 'web',
+    phase: 'preCommit',
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--list') out.list = true;

--- a/scripts/gate-ladder/validate.mjs
+++ b/scripts/gate-ladder/validate.mjs
@@ -53,13 +53,19 @@ function main() {
     ? read('.husky/pre-commit')
     : '';
   if (!preCommit.includes('scan-secrets.sh')) {
-    errors.push('.husky/pre-commit must invoke scripts/security/scan-secrets.sh');
+    errors.push(
+      '.husky/pre-commit must invoke scripts/security/scan-secrets.sh'
+    );
   }
   if (!preCommit.includes('check-conflict-markers.sh')) {
-    errors.push('.husky/pre-commit must invoke scripts/check-conflict-markers.sh');
+    errors.push(
+      '.husky/pre-commit must invoke scripts/check-conflict-markers.sh'
+    );
   }
   if (!preCommit.includes('lint-staged')) {
-    errors.push('.husky/pre-commit must invoke lint-staged (format/lint/typecheck)');
+    errors.push(
+      '.husky/pre-commit must invoke lint-staged (format/lint/typecheck)'
+    );
   }
 
   const prePush = existsSync(resolve(REPO_ROOT, '.husky/pre-push'))
@@ -75,7 +81,9 @@ function main() {
   const ciYml = existsSync(resolve(REPO_ROOT, '.github/workflows/ci.yml'))
     ? read('.github/workflows/ci.yml')
     : '';
-  const mergeQueue = existsSync(resolve(REPO_ROOT, 'scripts/lib/merge-queue-guard.mjs'))
+  const mergeQueue = existsSync(
+    resolve(REPO_ROOT, 'scripts/lib/merge-queue-guard.mjs')
+  )
     ? read('scripts/lib/merge-queue-guard.mjs')
     : '';
   const hasPrReadyJob =
@@ -89,7 +97,9 @@ function main() {
 
   // iOS adapter surfaces
   if (!existsSync(resolve(REPO_ROOT, 'scripts/ios-best-practices-lint.sh'))) {
-    errors.push('missing scripts/ios-best-practices-lint.sh (ios lint adapter)');
+    errors.push(
+      'missing scripts/ios-best-practices-lint.sh (ios lint adapter)'
+    );
   }
   if (!existsSync(resolve(REPO_ROOT, '.github/workflows/ios-ci.yml'))) {
     errors.push('missing .github/workflows/ios-ci.yml');

--- a/scripts/gate-ladder/validate.mjs
+++ b/scripts/gate-ladder/validate.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Validate the universal gate ladder skeleton (JOV-3210).
+ *
+ * Checks:
+ * - ladder.json schema + unique rung ids
+ * - hard-block pre-commit rungs are referenced from .husky/pre-commit
+ * - PR aggregate rung references PR Ready / ios-ci
+ * - web + ios adapters declare hook/workflow paths that exist
+ *
+ * Exit 0 = pass. Exit 1 = fail.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const LADDER_PATH = resolve(__dirname, 'ladder.json');
+
+function read(rel) {
+  return readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+}
+
+function main() {
+  const errors = [];
+  const ladder = JSON.parse(readFileSync(LADDER_PATH, 'utf8'));
+
+  if (ladder.schemaVersion !== 1) {
+    errors.push(`expected schemaVersion 1, got ${ladder.schemaVersion}`);
+  }
+  if (!Array.isArray(ladder.rungs) || ladder.rungs.length < 5) {
+    errors.push('ladder must declare at least 5 rungs');
+  }
+
+  const ids = ladder.rungs.map(r => r.id);
+  if (new Set(ids).size !== ids.length) {
+    errors.push('rung ids must be unique');
+  }
+
+  for (const rung of ladder.rungs) {
+    if (!rung.id || !rung.name || !rung.intent) {
+      errors.push(`rung missing id/name/intent: ${JSON.stringify(rung)}`);
+    }
+    if (typeof rung.hardBlock !== 'boolean') {
+      errors.push(`rung ${rung.id}: hardBlock must be boolean`);
+    }
+  }
+
+  // Pre-commit hard blocks must be reachable from husky.
+  const preCommit = existsSync(resolve(REPO_ROOT, '.husky/pre-commit'))
+    ? read('.husky/pre-commit')
+    : '';
+  if (!preCommit.includes('scan-secrets.sh')) {
+    errors.push('.husky/pre-commit must invoke scripts/security/scan-secrets.sh');
+  }
+  if (!preCommit.includes('check-conflict-markers.sh')) {
+    errors.push('.husky/pre-commit must invoke scripts/check-conflict-markers.sh');
+  }
+  if (!preCommit.includes('lint-staged')) {
+    errors.push('.husky/pre-commit must invoke lint-staged (format/lint/typecheck)');
+  }
+
+  const prePush = existsSync(resolve(REPO_ROOT, '.husky/pre-push'))
+    ? read('.husky/pre-push')
+    : '';
+  if (!prePush.includes('pre-push-gate.sh')) {
+    errors.push('.husky/pre-push must invoke scripts/hooks/pre-push-gate.sh');
+  }
+
+  // PR aggregate: ci.yml must define PR Ready OR document the restore path.
+  // After JOV-3464 the job is `ci-pr-ready` / name: PR Ready. Tolerate either
+  // the restored job or the merge-queue required-status contract.
+  const ciYml = existsSync(resolve(REPO_ROOT, '.github/workflows/ci.yml'))
+    ? read('.github/workflows/ci.yml')
+    : '';
+  const mergeQueue = existsSync(resolve(REPO_ROOT, 'scripts/lib/merge-queue-guard.mjs'))
+    ? read('scripts/lib/merge-queue-guard.mjs')
+    : '';
+  const hasPrReadyJob =
+    /name:\s*PR Ready/.test(ciYml) || /ci-pr-ready:/.test(ciYml);
+  const hasPrReadyContract = /['"]PR Ready['"]/.test(mergeQueue);
+  if (!hasPrReadyJob && !hasPrReadyContract) {
+    errors.push(
+      'PR Ready must exist as a ci.yml job or as REQUIRED_MERGE_STATUSES in merge-queue-guard.mjs'
+    );
+  }
+
+  // iOS adapter surfaces
+  if (!existsSync(resolve(REPO_ROOT, 'scripts/ios-best-practices-lint.sh'))) {
+    errors.push('missing scripts/ios-best-practices-lint.sh (ios lint adapter)');
+  }
+  if (!existsSync(resolve(REPO_ROOT, '.github/workflows/ios-ci.yml'))) {
+    errors.push('missing .github/workflows/ios-ci.yml');
+  }
+  if (!existsSync(resolve(REPO_ROOT, '.github/workflows/security.yml'))) {
+    errors.push('missing .github/workflows/security.yml (PR secret scan)');
+  }
+  if (!existsSync(resolve(REPO_ROOT, '.github/workflows/pr-size-guard.yml'))) {
+    errors.push('missing .github/workflows/pr-size-guard.yml');
+  }
+
+  // Adapter path existence from ladder.json
+  for (const [app, adapter] of Object.entries(ladder.adapters ?? {})) {
+    for (const key of ['preCommitHook', 'prePushHook', 'prWorkflow']) {
+      const value = adapter[key];
+      if (typeof value !== 'string') continue;
+      // First path-like token only (hooks may include prose after the path).
+      const token = value.split(/\s+/)[0];
+      if (token.includes('/') && !existsSync(resolve(REPO_ROOT, token))) {
+        errors.push(`adapter ${app}.${key}: path not found: ${token}`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('[gate-ladder] FAIL');
+    for (const err of errors) console.error(`  - ${err}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `[gate-ladder] PASS — ${ladder.rungs.length} rungs, web+ios adapters wired (JOV-3210)`
+  );
+  process.exit(0);
+}
+
+main();

--- a/scripts/vitest.config.mts
+++ b/scripts/vitest.config.mts
@@ -10,6 +10,7 @@ export default defineConfig({
     environment: 'node',
     include: [
       'lib/__tests__/**/*.test.mjs',
+      'gate-ladder/**/*.test.mjs',
       'hermes/lib/__tests__/**/*.test.ts',
     ],
     name: 'workspace-scripts',


### PR DESCRIPTION
## Summary
- Add `scripts/gate-ladder/ladder.json` — shared rungs (secrets, lint, typecheck, unit, size, osv, PR Ready) for **web + iOS**
- `pnpm gate-ladder:validate` asserts hooks/workflows are wired; `pnpm gate-ladder:test` (node:test) locks it
- `pnpm gate-ladder:list` / `run.mjs` execute or document each rung
- Husky pre-commit comments map to the ladder; runs `ios:lint` when Swift files are staged
- Does **not** force a husky→lefthook migration (prior art: husky already covers hard-block rungs)

## Acceptance (JOV-3210 skeleton)
- [x] Shared ladder definition (web + iOS adapters)
- [x] Staged secrets blocked pre-commit (existing scan-secrets + validation)
- [x] Red PR merge path owned by PR Ready contract (merge-queue-guard / ci-pr-ready)
- [x] Hard-block rungs documented; pair with fixer agents via nextLocalCommand on CI lanes

## Verification
```
node scripts/gate-ladder/validate.mjs   # PASS
node --test scripts/gate-ladder/gate-ladder.test.mjs  # 3 pass
```

## Cost Impact
- None (local hooks + tiny validation script)

Fixes JOV-3210
<!-- linear-issue-id:JOV-3210 -->