### PR TITLE
fix(desktop): recover permanent black screen on hung/crashed renderer (JOV-3595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] **Desktop renderer recovery (JOV-3595)**: recover from hosted loads that return HTTP 200 but never boot React, and route crashed or unresponsive renderers to the visible recovery shell instead of a permanent black window.
 - [internal] Agent preflight: one-shot JSON bootstrap for /autoplan (JOV-4183)
 - **[internal] Critical auth, activation, and billing identity hardening (JOV-4181)**: Stripe billing updates, trial activation, billing-status reads, and profile ownership checks now resolve Better Auth application users safely across the legacy Clerk-ID transition; deterministic regression tests cover the identity and compare-and-set predicates. CI now classifies onboarding, ingestion, memory, AI/workflow, enrichment, chat, and cron changes as high risk.
 - **Jovie now presents one focused, dark career operating system from hero to conversion:** the homepage leads with “Jovie runs your music career,” shows one release workspace, replaces the profile carousel with three static artist outcomes, and connects release, fan capture, routing, learning, and next actions in one closed-loop story. The floating header, CTAs, chat bubbles, motion, reduced-motion behavior, and responsive alignment now follow the same compact System B rules.

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -125,6 +125,19 @@ test('desktop window fails into a branded Jovie recovery surface', async () => {
     /maybeShowDesktopAuthHandoff\(resolveNavigationUrl\(validatedURL\)\)/
   );
   assert.match(mainSource, /showDesktopLoadFailure\(win\)/);
+  // JOV-3595: blank/crashed-renderer recovery (beyond network did-fail-load).
+  assert.match(mainSource, /APP_BOOTED_CHANNEL/);
+  assert.match(mainSource, /RENDERER_BOOT_WATCHDOG_MS/);
+  assert.match(mainSource, /shouldArmRendererBootWatchdog/);
+  assert.match(mainSource, /armBootWatchdog/);
+  assert.match(mainSource, /Renderer boot watchdog expired/);
+  assert.match(mainSource, /render-process-gone/);
+  assert.match(mainSource, /win\.webContents\.on\('unresponsive'/);
+  assert.match(
+    mainSource,
+    /win\.webContents\.on\('unresponsive'[\s\S]*showDesktopLoadFailure\(win\)/
+  );
+  assert.match(mainSource, /ipcMain\.on\(APP_BOOTED_CHANNEL/);
   assert.match(mainSource, /viewBox="0 0 353\.68 347\.97"/);
   assert.match(mainSource, /START_DESKTOP_AUTH_HANDOFF_CHANNEL/);
   assert.match(mainSource, /OPEN_DESKTOP_AUTH_URL_CHANNEL/);
@@ -333,6 +346,9 @@ test('preload marks the hosted app as Electron after the document root is ready'
   assert.match(preloadSource, /startDesktopAuthHandoff/);
   assert.match(preloadSource, /openDesktopAuthUrl/);
   assert.match(preloadSource, /closeDesktopAuthWindow/);
+  assert.match(preloadSource, /const APP_BOOTED_CHANNEL = 'app-booted'/);
+  assert.match(preloadSource, /notifyAppBooted:/);
+  assert.match(preloadSource, /ipcRenderer\.send\(APP_BOOTED_CHANNEL\)/);
 });
 
 test('desktop bridge exposes bounded dictation support', async () => {
@@ -560,9 +576,7 @@ test('hosted web app has an early Electron runtime marker before first paint', a
     titlebarSource,
     /data-testid='electron-traffic-light-safe-area'/
   );
-  assert.match(
-    titlebarSource,
-    /w-\[var\(--electron-traffic-light-safe-width\)\]/
-  );
+  // Tailwind v4 CSS-var utility form (not arbitrary w-[var(...)]).
+  assert.match(titlebarSource, /w-\(--electron-traffic-light-safe-width\)/);
   assert.doesNotMatch(titlebarSource, /w-\[72px\]/);
 });

--- a/apps/desktop/scripts/renderer-recovery.test.ts
+++ b/apps/desktop/scripts/renderer-recovery.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest';
-import { decideRendererRecovery } from '../src/renderer-recovery.ts';
+import {
+  decideRendererRecovery,
+  RENDERER_BOOT_WATCHDOG_MS,
+  shouldArmRendererBootWatchdog,
+} from '../src/renderer-recovery.ts';
 
 const MAX = 2;
 
@@ -45,4 +49,23 @@ test('a crash loop falls back to the failure page instead of black', () => {
       maxReloads: MAX,
     })
   ).toBe('failure-page');
+});
+
+test('boot watchdog arms only for real hosted http(s) navigations', () => {
+  expect(RENDERER_BOOT_WATCHDOG_MS).toBeGreaterThanOrEqual(12_000);
+  expect(RENDERER_BOOT_WATCHDOG_MS).toBeLessThanOrEqual(15_000);
+
+  expect(
+    shouldArmRendererBootWatchdog('https://jov.ie/app/chat?runtime=electron')
+  ).toBe(true);
+  expect(shouldArmRendererBootWatchdog('http://localhost:3112/app')).toBe(true);
+
+  expect(shouldArmRendererBootWatchdog('')).toBe(false);
+  expect(shouldArmRendererBootWatchdog('about:blank')).toBe(false);
+  expect(shouldArmRendererBootWatchdog('data:text/html,failure')).toBe(false);
+  expect(shouldArmRendererBootWatchdog('devtools://devtools/bundled')).toBe(
+    false
+  );
+  expect(shouldArmRendererBootWatchdog('file:///tmp/x.html')).toBe(false);
+  expect(shouldArmRendererBootWatchdog('not a url')).toBe(false);
 });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -45,7 +45,11 @@ import {
   type UrlDisposition,
 } from './navigation';
 import { evaluateRemoteDebuggingGuard } from './remote-debugging-guard';
-import { decideRendererRecovery } from './renderer-recovery';
+import {
+  decideRendererRecovery,
+  RENDERER_BOOT_WATCHDOG_MS,
+  shouldArmRendererBootWatchdog,
+} from './renderer-recovery';
 import { SYSTEM_B_DESKTOP_TOKENS } from './system-b-tokens';
 import { sanitizeWindowState, type WindowState } from './window-state';
 
@@ -110,6 +114,8 @@ const LEGACY_AUTH_RETURN_HOST = 'auth-return';
 const DICTATION_STATUS_CHANNEL = 'dictation-status';
 const TRAY_SET_STATE_CHANNEL = 'tray-set-state';
 const TRAY_ACTION_CHANNEL = 'tray-action';
+/** Renderer → main: first successful React paint of the hosted app (JOV-3595). */
+const APP_BOOTED_CHANNEL = 'app-booted';
 const DESKTOP_RUNTIME_LABEL_BY_PLATFORM: Partial<
   Record<NodeJS.Platform, string>
 > = {
@@ -170,6 +176,19 @@ let pendingLegacyAuthReturnRoute: string | null = null;
 let pendingDesktopAuthPkce: PendingDesktopAuthPkce | null = null;
 let mainWindowHiddenForAuthHandoff = false;
 let currentHudBuildFingerprint: string | null = null;
+
+/**
+ * Per-webContents boot-watchdog controllers (JOV-3595). The hosted web app
+ * must call `notifyAppBooted` after first successful paint; otherwise the
+ * shell shows the recovery page instead of a permanent black window.
+ */
+const rendererBootControllers = new Map<
+  number,
+  {
+    readonly markBooted: () => void;
+    readonly dispose: () => void;
+  }
+>();
 
 function getDesktopAppDisplayName(): string {
   if (APP_ENV === 'staging') return 'Jovie Staging';
@@ -1026,11 +1045,73 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   // blank black window with no recovery, which strands the user. Reload the
   // view on a crash, capped to avoid a crash loop, then fall back to the
   // visible load-failure page (Retry) instead of black.
+  //
+  // JOV-3595 also covers the "HTTP 200 but never interactive" path: after a
+  // real hosted load finishes, the web app must ping APP_BOOTED_CHANNEL within
+  // RENDERER_BOOT_WATCHDOG_MS. If it never does (React crash / hung hydrate),
+  // show the recovery shell instead of a permanent black canvas.
   let rendererCrashReloadCount = 0;
+  let rendererBooted = false;
+  let bootWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
+  const webContentsId = win.webContents.id;
+
+  const clearBootWatchdog = (): void => {
+    if (bootWatchdogTimer !== null) {
+      clearTimeout(bootWatchdogTimer);
+      bootWatchdogTimer = null;
+    }
+  };
+
+  const markRendererBooted = (): void => {
+    rendererBooted = true;
+    clearBootWatchdog();
+  };
+
+  const armBootWatchdog = (): void => {
+    clearBootWatchdog();
+    rendererBooted = false;
+    if (win.isDestroyed()) return;
+    const url = win.webContents.getURL();
+    if (!shouldArmRendererBootWatchdog(url)) return;
+
+    bootWatchdogTimer = setTimeout(() => {
+      bootWatchdogTimer = null;
+      if (win.isDestroyed() || rendererBooted) return;
+      // Main window may sit on a transitional URL while the dedicated auth
+      // handoff window is the interactive surface — do not false-alarm.
+      if (win === mainWindow && isAuthHandoffOpen()) return;
+
+      console.error('[Jovie Desktop] Renderer boot watchdog expired', {
+        url: url.split('?')[0],
+        timeoutMs: RENDERER_BOOT_WATCHDOG_MS,
+      });
+      showDesktopLoadFailure(win);
+    }, RENDERER_BOOT_WATCHDOG_MS);
+  };
+
+  rendererBootControllers.set(webContentsId, {
+    markBooted: markRendererBooted,
+    dispose: () => {
+      clearBootWatchdog();
+      rendererBootControllers.delete(webContentsId);
+    },
+  });
+
+  win.on('closed', () => {
+    rendererBootControllers.get(webContentsId)?.dispose();
+  });
+
+  win.webContents.on('did-start-loading', () => {
+    clearBootWatchdog();
+    rendererBooted = false;
+  });
+
   win.webContents.on('did-finish-load', () => {
     rendererCrashReloadCount = 0;
+    armBootWatchdog();
   });
   win.webContents.on('render-process-gone', (_event, details) => {
+    clearBootWatchdog();
     const action = decideRendererRecovery({
       reason: details.reason,
       reloadCount: rendererCrashReloadCount,
@@ -1053,6 +1134,10 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
     console.warn('[Jovie Desktop] Renderer unresponsive', {
       url: win.webContents.getURL().split('?')[0],
     });
+    if (win.isDestroyed()) return;
+    if (win === mainWindow && isAuthHandoffOpen()) return;
+    clearBootWatchdog();
+    showDesktopLoadFailure(win);
   });
 
   win.webContents.session.setPermissionRequestHandler(
@@ -1396,6 +1481,14 @@ ipcMain.handle(
     return { ok: true };
   }
 );
+
+// Hosted app first-paint heartbeat (JOV-3595). Uses send (not invoke) so a
+// missing main handler on a stale binary cannot reject the renderer promise.
+ipcMain.on(APP_BOOTED_CHANNEL, event => {
+  const parsed = parseUrl(event.senderFrame?.url ?? event.sender.getURL());
+  if (parsed?.origin !== APP_ORIGIN) return;
+  rendererBootControllers.get(event.sender.id)?.markBooted();
+});
 
 ipcMain.handle(GO_BACK_CHANNEL, (event: IpcMainInvokeEvent) => {
   if (!isTrustedIpcSender(event)) return;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -13,6 +13,7 @@ const CONSUME_DESKTOP_AUTH_COMPLETION_CHANNEL =
 const DICTATION_STATUS_CHANNEL = 'dictation-status';
 const TRAY_SET_STATE_CHANNEL = 'tray-set-state';
 const TRAY_ACTION_CHANNEL = 'tray-action';
+const APP_BOOTED_CHANNEL = 'app-booted';
 
 interface MinimalDocument {
   readonly documentElement?: {
@@ -171,5 +172,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
       const listener = (_: unknown, action: string) => cb(action);
       ipcRenderer.on(TRAY_ACTION_CHANNEL, listener);
       return () => ipcRenderer.removeListener(TRAY_ACTION_CHANNEL, listener);
+    },
+
+    /**
+     * First successful hosted-app paint (JOV-3595). Cancels the main-process
+     * boot watchdog so a 200-but-never-interactive load surfaces recovery UI
+     * instead of a permanent black window. Fire-and-forget (send, not invoke).
+     */
+    notifyAppBooted: () => {
+      ipcRenderer.send(APP_BOOTED_CHANNEL);
     },
 });

--- a/apps/desktop/src/renderer-recovery.ts
+++ b/apps/desktop/src/renderer-recovery.ts
@@ -6,6 +6,13 @@
 // renderer on a crash, and — once a small reload budget is exhausted (crash
 // loop) — fall back to the visible load-failure page so the user gets a Retry
 // affordance instead of staring at black.
+//
+// A second failure mode (JOV-3595): the main-frame load can succeed (HTTP 200)
+// while React never hydrates / throws before first paint. Network-level
+// `did-fail-load` does not fire, so the shell stays on the near-black
+// backgroundColor forever. The boot watchdog covers that path: after a real
+// app navigation finishes, the hosted web app must ping `app-booted` within
+// RENDERER_BOOT_WATCHDOG_MS or we show the recovery shell.
 
 export type RendererRecoveryAction = 'ignore' | 'reload' | 'failure-page';
 
@@ -14,6 +21,9 @@ export type RendererRecoveryAction = 'ignore' | 'reload' | 'failure-page';
 // not trigger a reload. Every other reason (crashed, oom, killed,
 // abnormal-exit, launch-failed, integrity-failure) is a real loss of the view.
 const NON_CRASH_REASONS = new Set(['clean-exit']);
+
+/** How long to wait after did-finish-load for the renderer app-booted ping. */
+export const RENDERER_BOOT_WATCHDOG_MS = 14_000;
 
 export function decideRendererRecovery(input: {
   readonly reason: string;
@@ -29,4 +39,23 @@ export function decideRendererRecovery(input: {
   }
 
   return 'failure-page';
+}
+
+/**
+ * Only arm the boot watchdog for real hosted navigations.
+ * Skip data: recovery pages, about:blank, and non-http(s) schemes so the
+ * failure shell cannot re-trigger itself and auth blanks don't false-alarm.
+ */
+export function shouldArmRendererBootWatchdog(url: string): boolean {
+  if (!url) return false;
+  if (url === 'about:blank') return false;
+  if (url.startsWith('data:')) return false;
+  if (url.startsWith('devtools:')) return false;
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
 }

--- a/apps/web/app/desktop-auth/DesktopAuthClient.tsx
+++ b/apps/web/app/desktop-auth/DesktopAuthClient.tsx
@@ -6,6 +6,7 @@ import { sanitizeDesktopAuthUrl } from '@/lib/desktop/auth-return';
 import {
   closeDesktopAuthWindow,
   openDesktopAuthUrl,
+  useDesktopAppBootSignal,
 } from '@/lib/desktop/electron-bridge';
 
 type BrowserOpenState = 'idle' | 'opening' | 'opened' | 'error';
@@ -61,6 +62,9 @@ function getAppOrigin(): string {
 }
 
 export function DesktopAuthClient({ authUrlParam }: DesktopAuthClientProps) {
+  // Auth handoff is a dedicated BrowserWindow outside ClientProviders.
+  // Still clear any shell boot watchdog if this surface owns the view.
+  useDesktopAppBootSignal();
   const [openState, setOpenState] = useState<BrowserOpenState>('idle');
   const [openError, setOpenError] = useState<string | null>(null);
   const appOrigin = getAppOrigin();

--- a/apps/web/components/providers/ClientProviders.tsx
+++ b/apps/web/components/providers/ClientProviders.tsx
@@ -7,9 +7,16 @@ import {
   ClerkSafeValuesProvider,
 } from '@/hooks/useClerkSafe';
 import type { ClientAuthBootstrap } from '@/lib/auth/dev-test-auth-types';
+import { useDesktopAppBootSignal } from '@/lib/desktop/electron-bridge';
 import type { ThemeMode } from '@/types';
 import { CoreProviders } from './CoreProviders';
 import { QueryProvider } from './QueryProvider';
+
+/** Cancels the Electron shell boot watchdog after React mounts (JOV-3595). */
+function DesktopAppBootSignal() {
+  useDesktopAppBootSignal();
+  return null;
+}
 
 interface ClientProvidersProps {
   readonly children: React.ReactNode;
@@ -87,9 +94,17 @@ export function ClientProviders({
   // BA session cookie that `authClient.useSession()` observes directly.
   if (forceBypassClerk && !authBootstrap?.isAuthenticated) {
     return (
-      <ClerkSafeDefaultsProvider>{wrappedChildren}</ClerkSafeDefaultsProvider>
+      <ClerkSafeDefaultsProvider>
+        <DesktopAppBootSignal />
+        {wrappedChildren}
+      </ClerkSafeDefaultsProvider>
     );
   }
 
-  return <ClerkSafeValuesProvider>{wrappedChildren}</ClerkSafeValuesProvider>;
+  return (
+    <ClerkSafeValuesProvider>
+      <DesktopAppBootSignal />
+      {wrappedChildren}
+    </ClerkSafeValuesProvider>
+  );
 }

--- a/apps/web/lib/desktop/electron-bridge.test.ts
+++ b/apps/web/lib/desktop/electron-bridge.test.ts
@@ -70,6 +70,23 @@ describe('electron-bridge — defensive guards', () => {
     expect(isDesktopEnvironment()).toBe(true);
   });
 
+  it('notifyDesktopAppBooted no-ops without a bridge and does not warn', () => {
+    document.documentElement.dataset.desktopRuntime = 'electron';
+    __testing.notifyDesktopAppBooted();
+    expect(captureWarningMock).not.toHaveBeenCalled();
+    Reflect.deleteProperty(document.documentElement.dataset, 'desktopRuntime');
+  });
+
+  it('notifyDesktopAppBooted sends once when bridge method exists', () => {
+    const notifyAppBooted = vi.fn();
+    setElectronAPI({ notifyAppBooted });
+    document.documentElement.dataset.desktopRuntime = 'electron';
+    __testing.notifyDesktopAppBooted();
+    __testing.notifyDesktopAppBooted();
+    expect(notifyAppBooted).toHaveBeenCalledTimes(1);
+    Reflect.deleteProperty(document.documentElement.dataset, 'desktopRuntime');
+  });
+
   it('safeOnUpdateAvailable does NOT throw when bridge is missing the method (stale binary)', () => {
     setElectronAPI({
       versions: { app: '0.1.0' },

--- a/apps/web/lib/desktop/electron-bridge.ts
+++ b/apps/web/lib/desktop/electron-bridge.ts
@@ -67,6 +67,11 @@ export interface ElectronAPI {
    * Returns an unsubscribe function.
    */
   readonly onTrayAction?: (cb: (action: string) => void) => () => void;
+  /**
+   * Signal first successful React paint so the desktop shell can cancel its
+   * boot watchdog (JOV-3595). Optional — older binaries ignore the channel.
+   */
+  readonly notifyAppBooted?: () => void;
 }
 
 export interface DesktopAuthCompletion {
@@ -282,6 +287,41 @@ export function useIsElectronRuntime(): boolean {
   }, []);
 
   return isElectron;
+}
+
+let desktopAppBootedSent = false;
+
+/**
+ * Notify the Electron main process that the hosted web app painted successfully.
+ * Idempotent per full document load. No-ops in the browser and on stale binaries
+ * that predate the app-booted channel (those builds also lack the watchdog).
+ */
+export function notifyDesktopAppBooted(): void {
+  if (desktopAppBootedSent) return;
+  if (!isElectronRuntime()) return;
+
+  const api = getRawElectronAPI();
+  if (!api || typeof api.notifyAppBooted !== 'function') {
+    // Stale binary: no watchdog on that main process either. Do not Sentry-spam.
+    return;
+  }
+
+  try {
+    api.notifyAppBooted();
+    desktopAppBootedSent = true;
+  } catch {
+    // Non-fatal — the watchdog remains armed if send fails.
+  }
+}
+
+/**
+ * Fire the desktop boot heartbeat once React has mounted this tree.
+ * Mount near the top of any client provider that wraps desktop routes.
+ */
+export function useDesktopAppBootSignal(): void {
+  useEffect(() => {
+    notifyDesktopAppBooted();
+  }, []);
 }
 
 // ---------------------------------------------------------------------------
@@ -583,7 +623,10 @@ export function onDesktopTrayAction(cb: (action: string) => void): () => void {
 
 // Exported for tests only — do not call directly from product code.
 export const __testing = {
-  reset: () => reportedMissing.clear(),
+  reset: () => {
+    reportedMissing.clear();
+    desktopAppBootedSent = false;
+  },
   safeInstallUpdateAndRestart,
   safeGetDictationStatus,
   safeOnUpdateAvailable,
@@ -594,5 +637,6 @@ export const __testing = {
   consumeDesktopAuthCompletion,
   setDesktopTrayState,
   onDesktopTrayAction,
+  notifyDesktopAppBooted,
   RELEASE_DOWNLOAD_URL,
 };

--- a/apps/web/tests/unit/app/desktop-auth-page.test.tsx
+++ b/apps/web/tests/unit/app/desktop-auth-page.test.tsx
@@ -20,6 +20,9 @@ vi.mock('@/lib/desktop/electron-bridge', () => ({
   closeDesktopAuthWindow: () => closeDesktopAuthWindowMock(),
   isElectronRuntime: () => isElectronRuntimeMock(),
   openDesktopAuthUrl: (authUrl: string) => openDesktopAuthUrlMock(authUrl),
+  // JOV-3595: DesktopAuthClient clears the shell boot watchdog on mount
+  useDesktopAppBootSignal: vi.fn(),
+  notifyDesktopAppBooted: vi.fn(),
 }));
 
 function getAuthUrlParam(): string | null {


### PR DESCRIPTION
## Summary
- Desktop shell no longer stays permanently black when the hosted app returns HTTP 200 but never becomes interactive (React crash / hung hydrate).
- After `did-finish-load`, a 14s boot watchdog waits for an `app-booted` IPC ping from the web app; on timeout, show the existing recovery shell (Retry / Open Jovie).
- `render-process-gone` already reloads with budget; `unresponsive` now also routes to the recovery shell.
- Web bridge exposes `notifyAppBooted`; ClientProviders + DesktopAuthClient fire it on first successful React mount.

Fixes JOV-3595
<!-- linear-issue-id:9deadd90-7120-4252-9ded-7373027f3df3 -->

## Root cause
The shell only recovered on network-level `did-fail-load`. A successful navigation whose renderer never painted left only `backgroundColor` (near-black) with no recovery path.

## Changes
| Area | Change |
|------|--------|
| `apps/desktop/src/renderer-recovery.ts` | `RENDERER_BOOT_WATCHDOG_MS` + `shouldArmRendererBootWatchdog` |
| `apps/desktop/src/main.ts` | Boot watchdog, `app-booted` IPC, unresponsive → failure page |
| `apps/desktop/src/preload.ts` | `notifyAppBooted` bridge method |
| `apps/web/lib/desktop/electron-bridge.ts` | `notifyDesktopAppBooted` / `useDesktopAppBootSignal` |
| Providers / desktop-auth | Fire heartbeat on first paint |

## Verification
- `pnpm --filter @jovie/desktop run typecheck` — pass
- `pnpm --filter @jovie/desktop run test:desktop-renderer-recovery` — 4 pass
- `pnpm --filter @jovie/desktop run test:desktop-shell` — 11 pass
- `vitest run lib/desktop/electron-bridge.test.ts` — 31 pass
- `pnpm biome check --write` on edited files — clean

## Cost Impact
- None (local IPC + one timer per window load; no new external API calls)

## Risk
Low — recovery path is fail-safe and additive. False-positive watchdog only if the app takes >14s to first React mount without network fail; auth-handoff open skips the timeout on the main window.