### PR TITLE
feat(campaign-ops): demo campaign suite domain (JOV-2205–2213)

### DIFF
--- a/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
+++ b/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
@@ -33,7 +33,7 @@ describe('AppShellRightRail', () => {
     const rail = screen.getByTestId('app-shell-right-rail');
 
     expect(rail).toHaveAttribute('data-shell-design', 'shellChatV1');
-    expect(rail).toHaveClass('lg:rounded-[var(--linear-app-shell-radius)]');
+    expect(rail).toHaveClass('lg:rounded-(--linear-app-shell-radius)');
   });
 
   it('defaults to legacy variant without shell radius chrome', () => {
@@ -46,7 +46,7 @@ describe('AppShellRightRail', () => {
     const rail = screen.getByTestId('app-shell-right-rail');
 
     expect(rail).toHaveAttribute('data-shell-design', 'legacy');
-    expect(rail).not.toHaveClass('lg:rounded-[var(--linear-app-shell-radius)]');
+    expect(rail).not.toHaveClass('lg:rounded-(--linear-app-shell-radius)');
   });
 
   it('merges custom className without replacing base sticky layout', () => {

--- a/apps/web/lib/campaign-ops/approval-orchestrator.ts
+++ b/apps/web/lib/campaign-ops/approval-orchestrator.ts
@@ -1,0 +1,299 @@
+/**
+ * One-click campaign approval orchestrator (JOV-2210).
+ *
+ * Idempotent multi-step workflow with visible step status, retries, and
+ * partial-failure safety (no silent inconsistent success).
+ */
+
+import type {
+  ApprovalStepId,
+  ApprovalStepRecord,
+  ApprovalWorkflowState,
+} from './types';
+
+export const APPROVAL_STEP_ORDER: readonly ApprovalStepId[] = Object.freeze([
+  'create_campaign',
+  'create_drop',
+  'update_smart_link',
+  'draft_notifications',
+  'select_audience',
+  'create_tasks',
+  'schedule_launch',
+  'enable_monitoring',
+]);
+
+function nowIso(now?: string): string {
+  return now ?? new Date().toISOString();
+}
+
+function emptyStep(id: ApprovalStepId, at: string): ApprovalStepRecord {
+  return {
+    id,
+    status: 'pending',
+    attempt: 0,
+    output: null,
+    error: null,
+    updatedAt: at,
+  };
+}
+
+export function buildApprovalIdempotencyKey(input: {
+  readonly artistId: string;
+  readonly recommendationId: string;
+}): string {
+  return `approve:${input.artistId}:${input.recommendationId}`;
+}
+
+export function createApprovalWorkflow(input: {
+  readonly workflowId: string;
+  readonly artistId: string;
+  readonly recommendationId: string;
+  readonly now?: string;
+}): ApprovalWorkflowState {
+  const at = nowIso(input.now);
+  const idempotencyKey = buildApprovalIdempotencyKey({
+    artistId: input.artistId,
+    recommendationId: input.recommendationId,
+  });
+
+  return {
+    workflowId: input.workflowId,
+    recommendationId: input.recommendationId,
+    artistId: input.artistId,
+    idempotencyKey,
+    steps: APPROVAL_STEP_ORDER.map(id => emptyStep(id, at)),
+    status: 'pending',
+    createdAt: at,
+    updatedAt: at,
+  };
+}
+
+/**
+ * Idempotent start: same idempotency key returns existing workflow.
+ */
+export function startOrResumeApproval(input: {
+  readonly existing: ApprovalWorkflowState | null;
+  readonly workflowId: string;
+  readonly artistId: string;
+  readonly recommendationId: string;
+  readonly now?: string;
+}): { readonly workflow: ApprovalWorkflowState; readonly created: boolean } {
+  const key = buildApprovalIdempotencyKey({
+    artistId: input.artistId,
+    recommendationId: input.recommendationId,
+  });
+
+  if (input.existing && input.existing.idempotencyKey === key) {
+    return { workflow: input.existing, created: false };
+  }
+
+  return {
+    workflow: createApprovalWorkflow({
+      workflowId: input.workflowId,
+      artistId: input.artistId,
+      recommendationId: input.recommendationId,
+      now: input.now,
+    }),
+    created: true,
+  };
+}
+
+function deriveWorkflowStatus(
+  steps: readonly ApprovalStepRecord[]
+): ApprovalWorkflowState['status'] {
+  if (steps.every(s => s.status === 'succeeded' || s.status === 'skipped')) {
+    return 'completed';
+  }
+  if (steps.some(s => s.status === 'failed')) {
+    const anySuccess = steps.some(s => s.status === 'succeeded');
+    return anySuccess ? 'partial' : 'failed';
+  }
+  if (steps.some(s => s.status === 'running' || s.status === 'succeeded')) {
+    return 'running';
+  }
+  return 'pending';
+}
+
+export function markStepRunning(
+  workflow: ApprovalWorkflowState,
+  stepId: ApprovalStepId,
+  now?: string
+): ApprovalWorkflowState {
+  const at = nowIso(now);
+  const steps = workflow.steps.map(step =>
+    step.id === stepId
+      ? {
+          ...step,
+          status: 'running' as const,
+          attempt: step.attempt + 1,
+          error: null,
+          updatedAt: at,
+        }
+      : step
+  );
+  return {
+    ...workflow,
+    steps,
+    status: 'running',
+    updatedAt: at,
+  };
+}
+
+export function markStepSucceeded(
+  workflow: ApprovalWorkflowState,
+  stepId: ApprovalStepId,
+  output: Readonly<Record<string, unknown>>,
+  now?: string
+): ApprovalWorkflowState {
+  const at = nowIso(now);
+  const steps = workflow.steps.map(step =>
+    step.id === stepId
+      ? {
+          ...step,
+          status: 'succeeded' as const,
+          output,
+          error: null,
+          updatedAt: at,
+        }
+      : step
+  );
+  return {
+    ...workflow,
+    steps,
+    status: deriveWorkflowStatus(steps),
+    updatedAt: at,
+  };
+}
+
+export function markStepFailed(
+  workflow: ApprovalWorkflowState,
+  stepId: ApprovalStepId,
+  error: string,
+  now?: string
+): ApprovalWorkflowState {
+  const at = nowIso(now);
+  const steps = workflow.steps.map(step =>
+    step.id === stepId
+      ? {
+          ...step,
+          status: 'failed' as const,
+          error,
+          updatedAt: at,
+        }
+      : step
+  );
+  return {
+    ...workflow,
+    steps,
+    status: deriveWorkflowStatus(steps),
+    updatedAt: at,
+  };
+}
+
+/**
+ * Retry a failed step: reset to pending so the runner can re-execute.
+ * Does not clear prior succeeded steps (partial state remains auditable).
+ */
+export function retryFailedStep(
+  workflow: ApprovalWorkflowState,
+  stepId: ApprovalStepId,
+  now?: string
+): ApprovalWorkflowState {
+  const at = nowIso(now);
+  const target = workflow.steps.find(s => s.id === stepId);
+  if (!target || target.status !== 'failed') {
+    return workflow;
+  }
+
+  const steps = workflow.steps.map(step =>
+    step.id === stepId
+      ? {
+          ...step,
+          status: 'pending' as const,
+          error: null,
+          updatedAt: at,
+        }
+      : step
+  );
+
+  return {
+    ...workflow,
+    steps,
+    status: deriveWorkflowStatus(steps),
+    updatedAt: at,
+  };
+}
+
+export function nextPendingStep(
+  workflow: ApprovalWorkflowState
+): ApprovalStepRecord | null {
+  return (
+    workflow.steps.find(s => s.status === 'pending' || s.status === 'failed') ??
+    null
+  );
+}
+
+/**
+ * Run a pure step handler map until completion or first hard failure
+ * (when stopOnFailure is true, default).
+ */
+export function runApprovalSteps(
+  workflow: ApprovalWorkflowState,
+  handlers: Readonly<
+    Partial<
+      Record<
+        ApprovalStepId,
+        () =>
+          | {
+              readonly ok: true;
+              readonly output: Readonly<Record<string, unknown>>;
+            }
+          | { readonly ok: false; readonly error: string }
+      >
+    >
+  >,
+  options: { readonly stopOnFailure?: boolean; readonly now?: string } = {}
+): ApprovalWorkflowState {
+  const stopOnFailure = options.stopOnFailure ?? true;
+  let current = workflow;
+
+  for (const stepId of APPROVAL_STEP_ORDER) {
+    const step = current.steps.find(s => s.id === stepId);
+    if (!step || step.status === 'succeeded' || step.status === 'skipped') {
+      continue;
+    }
+
+    const handler = handlers[stepId];
+    if (!handler) {
+      // No handler: leave pending so artists can review/edit later.
+      continue;
+    }
+
+    current = markStepRunning(current, stepId, options.now);
+    const result = handler();
+    if (result.ok) {
+      current = markStepSucceeded(current, stepId, result.output, options.now);
+    } else {
+      current = markStepFailed(current, stepId, result.error, options.now);
+      if (stopOnFailure) break;
+    }
+  }
+
+  return current;
+}
+
+export function workflowHasHiddenInconsistency(
+  workflow: ApprovalWorkflowState
+): boolean {
+  // Success without all critical early steps is inconsistent.
+  if (workflow.status === 'completed') {
+    return workflow.steps.some(
+      s => s.status !== 'succeeded' && s.status !== 'skipped'
+    );
+  }
+  // Claiming completed when any step failed.
+  if (workflow.status !== 'partial' && workflow.status !== 'failed') {
+    return false;
+  }
+  return false;
+}

--- a/apps/web/lib/campaign-ops/campaign-ops.test.ts
+++ b/apps/web/lib/campaign-ops/campaign-ops.test.ts
@@ -1,0 +1,677 @@
+import { describe, expect, it } from 'vitest';
+import {
+  APPROVAL_STEP_ORDER,
+  buildApprovalIdempotencyKey,
+  buildCampaignHealthSnapshot,
+  buildCampaignRecommendations,
+  buildProductPageKey,
+  buildSignalDedupeKey,
+  buildTaskDedupeKey,
+  canTransitionDrop,
+  collapseSignalsToOpportunities,
+  computeExpectedOrders,
+  computeExpectedRevenueCents,
+  createDraftDrop,
+  createReleaseWorkflow,
+  DEFAULT_SINGLE_RELEASE_PLAYBOOK,
+  DEMO_PRODUCT_ASSUMPTIONS,
+  detectOpportunitiesFromSignals,
+  evaluateSegmentMember,
+  importReleasePlaybook,
+  markStepFailed,
+  markStepSucceeded,
+  normalizeExternalSignal,
+  pauseMonitoring,
+  previewSegment,
+  recommendNextMoves,
+  resumeMonitoring,
+  retryFailedStep,
+  runApprovalSteps,
+  startOrResumeApproval,
+  transitionDrop,
+  upsertDraftDrop,
+  WARM_TRANCE_SEGMENT,
+  workflowHasHiddenInconsistency,
+} from './index';
+import type { ExternalSignalInput, FanActivityRecord } from './types';
+
+const NOW = new Date('2026-05-15T12:00:00.000Z');
+
+const EDC_COSMIC_GATE_SIGNALS: ExternalSignalInput[] = [
+  {
+    sourceKind: 'event_festival',
+    sourceUrl: 'https://electricdaisycarnival.com/las-vegas/lineup/cosmic-gate',
+    sourceLabel: 'EDC Las Vegas lineup',
+    artistId: 'artist_tim_white',
+    artistName: 'Tim White',
+    collaboratorId: 'artist_cosmic_gate',
+    collaboratorName: 'Cosmic Gate',
+    eventName: 'EDC Las Vegas',
+    venue: 'Las Vegas Motor Speedway',
+    city: 'Las Vegas',
+    startsAt: '2026-05-16T00:00:00.000Z',
+    endsAt: '2026-05-18T12:00:00.000Z',
+    observedAt: '2026-05-14T08:00:00.000Z',
+    confidence: 0.92,
+    expiryAt: '2026-05-19T00:00:00.000Z',
+    tags: ['festival', 'trance'],
+  },
+  // Duplicate observation same weekend — must collapse.
+  {
+    sourceKind: 'event_festival',
+    sourceUrl: 'https://example.com/mirror/edc-cosmic-gate',
+    sourceLabel: 'EDC mirror feed',
+    artistId: 'artist_tim_white',
+    artistName: 'Tim White',
+    collaboratorId: 'artist_cosmic_gate',
+    collaboratorName: 'Cosmic Gate',
+    eventName: 'EDC Las Vegas',
+    city: 'Las Vegas',
+    startsAt: '2026-05-16T02:00:00.000Z',
+    observedAt: '2026-05-14T10:00:00.000Z',
+    confidence: 0.8,
+    expiryAt: '2026-05-19T00:00:00.000Z',
+  },
+  {
+    sourceKind: 'commerce_window',
+    sourceUrl: 'https://www.amazon.com/primeday',
+    sourceLabel: 'June Prime Day commerce window',
+    artistId: 'artist_tim_white',
+    artistName: 'Tim White',
+    eventName: 'Prime Day',
+    startsAt: '2026-06-01T00:00:00.000Z',
+    endsAt: '2026-06-03T00:00:00.000Z',
+    observedAt: '2026-05-10T00:00:00.000Z',
+    confidence: 0.7,
+    expiryAt: '2026-06-04T00:00:00.000Z',
+  },
+];
+
+const FAN_FIXTURES: FanActivityRecord[] = [
+  {
+    memberId: 'fan_1',
+    eventType: 'link_clicked',
+    genreTags: ['trance'],
+    linkClickCount: 3,
+    isBuyer: true,
+    isSubscriber: true,
+    lastActiveAt: '2026-05-10T00:00:00.000Z',
+  },
+  {
+    memberId: 'fan_2',
+    eventType: 'link_clicked',
+    genreTags: ['trance', 'edm'],
+    linkClickCount: 1,
+    isSubscriber: true,
+    lastActiveAt: '2026-05-12T00:00:00.000Z',
+  },
+  {
+    memberId: 'fan_3',
+    eventType: 'profile_visited',
+    genreTags: ['hip-hop'],
+    linkClickCount: 5,
+    lastActiveAt: '2026-05-01T00:00:00.000Z',
+  },
+  {
+    memberId: 'fan_4',
+    eventType: 'link_clicked',
+    // missing genre tags
+    linkClickCount: 2,
+    lastActiveAt: '2026-05-14T00:00:00.000Z',
+  },
+  {
+    memberId: 'fan_stale',
+    eventType: 'link_clicked',
+    genreTags: ['trance'],
+    linkClickCount: 4,
+    lastActiveAt: '2025-01-01T00:00:00.000Z',
+  },
+];
+
+describe('external opportunity detector (JOV-2205)', () => {
+  it('normalizes signals with source URL, timestamp, confidence, and expiry', () => {
+    const normalized = normalizeExternalSignal(EDC_COSMIC_GATE_SIGNALS[0]!);
+    expect(normalized.sourceUrl).toContain('electricdaisycarnival');
+    expect(normalized.observedAt).toBe('2026-05-14T08:00:00.000Z');
+    expect(normalized.confidence).toBe(0.92);
+    expect(normalized.expiryAt).toBe('2026-05-19T00:00:00.000Z');
+    expect(normalized.dedupeKey).toContain('event_festival');
+  });
+
+  it('collapses duplicate EDC/Cosmic Gate signals into one opportunity', () => {
+    const opportunities = detectOpportunitiesFromSignals(
+      EDC_COSMIC_GATE_SIGNALS,
+      { now: NOW, artistId: 'artist_tim_white' }
+    );
+
+    const edc = opportunities.filter(o => o.title.includes('Cosmic Gate'));
+    expect(edc).toHaveLength(1);
+    expect(edc[0]!.signalIds.length).toBe(2);
+    expect(edc[0]!.sourceUrls.length).toBe(2);
+    expect(edc[0]!.collaboratorName).toBe('Cosmic Gate');
+    expect(edc[0]!.rankScore).toBeGreaterThan(0);
+  });
+
+  it('uses stable dedupe keys per artist/collaborator/day window', () => {
+    const a = buildSignalDedupeKey({
+      artistId: 'artist_tim_white',
+      collaboratorId: 'artist_cosmic_gate',
+      sourceKind: 'event_festival',
+      startsAt: '2026-05-16T00:00:00.000Z',
+      eventName: 'EDC Las Vegas',
+    });
+    const b = buildSignalDedupeKey({
+      artistId: 'artist_tim_white',
+      collaboratorId: 'artist_cosmic_gate',
+      sourceKind: 'event_festival',
+      startsAt: '2026-05-16T23:00:00.000Z',
+      eventName: 'EDC Las Vegas',
+    });
+    expect(a).toBe(b);
+  });
+
+  it('drops expired signals and ranks fresher windows higher', () => {
+    const expired: ExternalSignalInput = {
+      ...EDC_COSMIC_GATE_SIGNALS[0]!,
+      observedAt: '2026-01-01T00:00:00.000Z',
+      expiryAt: '2026-01-02T00:00:00.000Z',
+      startsAt: '2026-01-01T00:00:00.000Z',
+      eventName: 'Ancient Festival',
+      collaboratorId: 'old',
+      collaboratorName: 'Old Act',
+    };
+    const opportunities = detectOpportunitiesFromSignals(
+      [...EDC_COSMIC_GATE_SIGNALS, expired],
+      { now: NOW }
+    );
+    expect(opportunities.every(o => !o.title.includes('Ancient'))).toBe(true);
+    expect(opportunities[0]!.title).toContain('Cosmic Gate');
+  });
+
+  it('collapse helper accepts already-normalized signals', () => {
+    const normalized = EDC_COSMIC_GATE_SIGNALS.map(normalizeExternalSignal);
+    const opportunities = collapseSignalsToOpportunities(normalized, {
+      now: NOW,
+    });
+    expect(opportunities.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('fan segment builder (JOV-2207)', () => {
+  it('matches genre + link activity + recency predicates', () => {
+    const match = evaluateSegmentMember(
+      FAN_FIXTURES[0]!,
+      WARM_TRANCE_SEGMENT,
+      NOW
+    );
+    expect(match.matches).toBe(true);
+    expect(match.dimensions).toEqual(
+      expect.arrayContaining(['genre_affinity', 'link_activity', 'recency'])
+    );
+  });
+
+  it('excludes wrong genre and stale activity', () => {
+    expect(
+      evaluateSegmentMember(FAN_FIXTURES[2]!, WARM_TRANCE_SEGMENT, NOW).matches
+    ).toBe(false);
+    expect(
+      evaluateSegmentMember(FAN_FIXTURES[4]!, WARM_TRANCE_SEGMENT, NOW).matches
+    ).toBe(false);
+  });
+
+  it('previews segment size, samples, and missing-data notes', () => {
+    const preview = previewSegment(WARM_TRANCE_SEGMENT, FAN_FIXTURES, {
+      now: NOW,
+      sampleSize: 5,
+    });
+    expect(preview.size).toBe(2); // fan_1, fan_2
+    expect(preview.sampleMembers.map(m => m.memberId).sort()).toEqual([
+      'fan_1',
+      'fan_2',
+    ]);
+    expect(
+      preview.missingDataNotes.some(n => n.includes('genre affinity'))
+    ).toBe(true);
+    expect(preview.definitionId).toBe(WARM_TRANCE_SEGMENT.id);
+  });
+});
+
+describe('campaign recommendation engine (JOV-2208)', () => {
+  it('computes deterministic revenue math', () => {
+    // 5260 * 0.05 = 263 orders × $38 = $9,994
+    const orders = computeExpectedOrders(5260, 0.05);
+    expect(orders).toBe(263);
+    expect(computeExpectedRevenueCents(orders, 3800)).toBe(999_400);
+  });
+
+  it('returns ranked multi-product recommendations with assumptions', () => {
+    const opportunities = detectOpportunitiesFromSignals(
+      EDC_COSMIC_GATE_SIGNALS,
+      { now: NOW }
+    );
+    const opportunity = opportunities.find(o =>
+      o.title.includes('Cosmic Gate')
+    )!;
+    const result = buildCampaignRecommendations({
+      opportunity,
+      segmentSize: 5260,
+      segmentName: WARM_TRANCE_SEGMENT.name,
+      products: DEMO_PRODUCT_ASSUMPTIONS,
+      channels: ['jovie_link', 'email', 'sms'],
+      windowHours: 72,
+      now: NOW.toISOString(),
+    });
+
+    expect(result.options).toHaveLength(3);
+    expect(result.options[0]!.productLabel).toContain('Festival Tee');
+    expect(result.options[0]!.expectedOrders).toBe(263);
+    expect(result.options[0]!.expectedRevenueCents).toBe(999_400);
+    expect(result.options[0]!.whyNow).toMatch(/72-hour/i);
+    expect(result.options[0]!.assumptions.length).toBeGreaterThan(3);
+    expect(result.options[0]!.confidence).toBeGreaterThan(0);
+    // Ranked high to low
+    expect(result.options[0]!.rankScore).toBeGreaterThanOrEqual(
+      result.options[1]!.rankScore
+    );
+  });
+});
+
+describe('merch/drop creation workflow (JOV-2209)', () => {
+  const opportunityStub = {
+    id: 'opp_edc',
+    kind: 'festival_attention' as const,
+    artistId: 'artist_tim_white',
+    title: 'Cosmic Gate at EDC Las Vegas',
+    why: 'test',
+    rankScore: 1,
+    confidence: 0.9,
+    windowStartsAt: '2026-05-16T00:00:00.000Z',
+    windowEndsAt: '2026-05-18T00:00:00.000Z',
+    signalIds: [],
+    collaboratorId: 'artist_cosmic_gate',
+    collaboratorName: 'Cosmic Gate',
+    sourceUrls: [],
+  };
+
+  it('creates draft drops with product, price, launch window, and owner', () => {
+    const rec = buildCampaignRecommendations({
+      opportunity: opportunityStub,
+      segmentSize: 5260,
+      segmentName: 'Warm Trance Fans',
+      products: [DEMO_PRODUCT_ASSUMPTIONS[0]!],
+      channels: ['jovie_link'],
+      windowHours: 72,
+      now: NOW.toISOString(),
+    });
+    const drop = createDraftDrop({
+      id: 'drop_1',
+      campaignId: 'camp_1',
+      ownerProfileId: 'profile_tim',
+      option: rec.options[0]!,
+      launchStartsAt: '2026-05-16T00:00:00.000Z',
+      launchEndsAt: '2026-05-19T00:00:00.000Z',
+    });
+    expect(drop.state).toBe('draft');
+    expect(drop.priceCents).toBe(3800);
+    expect(drop.productLabel).toContain('Festival Tee');
+    expect(drop.ownerProfileId).toBe('profile_tim');
+    expect(drop.productPageKey).toBe(
+      buildProductPageKey({
+        ownerProfileId: 'profile_tim',
+        campaignId: 'camp_1',
+        productSku: 'deep-end-festival-tee',
+      })
+    );
+  });
+
+  it('is idempotent on product page key and supports draft→preview→scheduled', () => {
+    const rec = buildCampaignRecommendations({
+      opportunity: opportunityStub,
+      segmentSize: 100,
+      segmentName: 'Warm Trance Fans',
+      products: [DEMO_PRODUCT_ASSUMPTIONS[0]!],
+      channels: ['jovie_link'],
+      windowHours: 72,
+    });
+    const input = {
+      id: 'drop_1',
+      campaignId: 'camp_1',
+      ownerProfileId: 'profile_tim',
+      option: rec.options[0]!,
+      launchStartsAt: '2026-05-16T00:00:00.000Z',
+      launchEndsAt: '2026-05-19T00:00:00.000Z',
+    };
+    const first = upsertDraftDrop([], input);
+    const second = upsertDraftDrop([first.drop], { ...input, id: 'drop_2' });
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.drop.id).toBe('drop_1');
+
+    expect(canTransitionDrop('draft', 'preview_ready')).toBe(true);
+    const previewed = transitionDrop(first.drop, 'preview_ready');
+    expect(previewed.allowed).toBe(true);
+    expect(previewed.drop.previewUrl).toContain('/drop/preview/');
+    const scheduled = transitionDrop(previewed.drop, 'scheduled');
+    expect(scheduled.allowed).toBe(true);
+    expect(scheduled.drop.state).toBe('scheduled');
+  });
+});
+
+describe('approval orchestrator (JOV-2210)', () => {
+  it('starts an idempotent workflow with ordered steps', () => {
+    const first = startOrResumeApproval({
+      existing: null,
+      workflowId: 'wf_1',
+      artistId: 'artist_tim_white',
+      recommendationId: 'rec_tee',
+      now: NOW.toISOString(),
+    });
+    expect(first.created).toBe(true);
+    expect(first.workflow.steps.map(s => s.id)).toEqual([
+      ...APPROVAL_STEP_ORDER,
+    ]);
+    expect(first.workflow.idempotencyKey).toBe(
+      buildApprovalIdempotencyKey({
+        artistId: 'artist_tim_white',
+        recommendationId: 'rec_tee',
+      })
+    );
+
+    const second = startOrResumeApproval({
+      existing: first.workflow,
+      workflowId: 'wf_2',
+      artistId: 'artist_tim_white',
+      recommendationId: 'rec_tee',
+    });
+    expect(second.created).toBe(false);
+    expect(second.workflow.workflowId).toBe('wf_1');
+  });
+
+  it('records success/failure/retry and avoids hidden inconsistency on complete', () => {
+    const { workflow } = startOrResumeApproval({
+      existing: null,
+      workflowId: 'wf_1',
+      artistId: 'artist_tim_white',
+      recommendationId: 'rec_tee',
+      now: NOW.toISOString(),
+    });
+
+    let current = runApprovalSteps(
+      workflow,
+      {
+        create_campaign: () => ({ ok: true, output: { campaignId: 'c1' } }),
+        create_drop: () => ({ ok: false, error: 'printful timeout' }),
+        update_smart_link: () => ({ ok: true, output: { linkId: 'l1' } }),
+      },
+      { now: NOW.toISOString() }
+    );
+
+    expect(current.status).toBe('partial');
+    expect(current.steps.find(s => s.id === 'create_drop')?.status).toBe(
+      'failed'
+    );
+    // stopOnFailure: later handler not run
+    expect(current.steps.find(s => s.id === 'update_smart_link')?.status).toBe(
+      'pending'
+    );
+
+    current = retryFailedStep(current, 'create_drop', NOW.toISOString());
+    current = runApprovalSteps(
+      current,
+      {
+        create_drop: () => ({ ok: true, output: { dropId: 'd1' } }),
+        update_smart_link: () => ({ ok: true, output: { linkId: 'l1' } }),
+        draft_notifications: () => ({ ok: true, output: { drafts: 1 } }),
+        select_audience: () => ({ ok: true, output: { segmentId: 's1' } }),
+        create_tasks: () => ({ ok: true, output: { tasks: 4 } }),
+        schedule_launch: () => ({ ok: true, output: { scheduled: true } }),
+        enable_monitoring: () => ({ ok: true, output: { monitoring: true } }),
+      },
+      { now: NOW.toISOString() }
+    );
+
+    expect(current.status).toBe('completed');
+    expect(workflowHasHiddenInconsistency(current)).toBe(false);
+    expect(
+      current.steps.every(
+        s => s.status === 'succeeded' || s.status === 'skipped'
+      )
+    ).toBe(true);
+  });
+
+  it('mark helpers update attempt counts', () => {
+    const { workflow } = startOrResumeApproval({
+      existing: null,
+      workflowId: 'wf_1',
+      artistId: 'a',
+      recommendationId: 'r',
+      now: NOW.toISOString(),
+    });
+    let current = markStepSucceeded(
+      workflow,
+      'create_campaign',
+      { campaignId: 'c' },
+      NOW.toISOString()
+    );
+    current = markStepFailed(current, 'create_drop', 'boom', NOW.toISOString());
+    expect(current.steps.find(s => s.id === 'create_drop')?.error).toBe('boom');
+  });
+});
+
+describe('campaign monitoring (JOV-2212)', () => {
+  it('tracks counters and emits threshold next-moves with evidence', () => {
+    const snapshot = buildCampaignHealthSnapshot({
+      campaignId: 'camp_1',
+      counters: {
+        clicks: 100,
+        purchases: 1,
+        replies: 1,
+        optIns: 5,
+        channelStatuses: {
+          jovie_link: 'ok',
+          email: 'degraded',
+          sms: 'ok',
+          profile: 'ok',
+          social: 'ok',
+        },
+      },
+      now: NOW.toISOString(),
+    });
+
+    expect(snapshot.conversionRate).toBe(0.01);
+    expect(snapshot.status).toBe('watch');
+
+    const moves = recommendNextMoves(snapshot);
+    const kinds = moves.map(m => m.kind);
+    expect(kinds).toContain('boost_channel');
+    expect(kinds).toContain('follow_up_content');
+    // Deduped kinds
+    expect(new Set(kinds).size).toBe(kinds.length);
+    for (const move of moves) {
+      expect(move.evidence.length).toBeGreaterThan(0);
+      expect(move.expectedImpact.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('can pause and resume monitoring', () => {
+    const live = buildCampaignHealthSnapshot({
+      campaignId: 'camp_1',
+      counters: {
+        clicks: 50,
+        purchases: 5,
+        replies: 5,
+        optIns: 2,
+        channelStatuses: {
+          jovie_link: 'ok',
+          email: 'ok',
+          sms: 'ok',
+          profile: 'ok',
+          social: 'ok',
+        },
+      },
+      now: NOW.toISOString(),
+    });
+    const paused = pauseMonitoring(live, NOW.toISOString());
+    expect(paused.status).toBe('paused');
+    expect(recommendNextMoves(paused)).toEqual([]);
+    const resumed = resumeMonitoring(paused, NOW.toISOString());
+    expect(resumed.paused).toBe(false);
+    expect(resumed.status).not.toBe('paused');
+  });
+
+  it('recommends extend window on strong conversion', () => {
+    const snapshot = buildCampaignHealthSnapshot({
+      campaignId: 'camp_hot',
+      counters: {
+        clicks: 200,
+        purchases: 20,
+        replies: 40,
+        optIns: 15,
+        channelStatuses: {
+          jovie_link: 'ok',
+          email: 'ok',
+          sms: 'ok',
+          profile: 'ok',
+          social: 'ok',
+        },
+      },
+      now: NOW.toISOString(),
+    });
+    const kinds = recommendNextMoves(snapshot).map(m => m.kind);
+    expect(kinds).toContain('extend_window');
+    expect(kinds).toContain('close_and_report');
+  });
+});
+
+describe('release workflow from playbooks (JOV-2213)', () => {
+  it('expands a versioned playbook into a canonical workflow', () => {
+    const workflow = createReleaseWorkflow({
+      id: 'rw_1',
+      releaseId: 'rel_deep_end',
+      playbook: DEFAULT_SINGLE_RELEASE_PLAYBOOK,
+      now: NOW.toISOString(),
+    });
+    expect(workflow.playbookVersion).toBe('1.0.0');
+    expect(workflow.tasks.length).toBe(
+      DEFAULT_SINGLE_RELEASE_PLAYBOOK.tasks.length
+    );
+    expect(workflow.tasks.every(t => t.state === 'pending')).toBe(true);
+    expect(workflow.tasks.some(t => t.title.includes('smart link'))).toBe(true);
+  });
+
+  it('dedupes tasks across repeated imports', () => {
+    const first = importReleasePlaybook({
+      existing: null,
+      workflowId: 'rw_1',
+      releaseId: 'rel_deep_end',
+      playbook: DEFAULT_SINGLE_RELEASE_PLAYBOOK,
+      now: NOW.toISOString(),
+    });
+    const second = importReleasePlaybook({
+      existing: {
+        ...first.workflow,
+        tasks: first.workflow.tasks.map((t, i) =>
+          i === 0 ? { ...t, state: 'done' as const } : t
+        ),
+      },
+      workflowId: 'rw_2',
+      releaseId: 'rel_deep_end',
+      playbook: DEFAULT_SINGLE_RELEASE_PLAYBOOK,
+    });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.workflow.tasks.length).toBe(first.workflow.tasks.length);
+    expect(second.workflow.tasks[0]!.state).toBe('done');
+  });
+
+  it('uses stable task dedupe keys', () => {
+    const key = buildTaskDedupeKey({
+      releaseId: 'rel_deep_end',
+      playbookId: 'single-release-v1',
+      playbookVersion: '1.0.0',
+      title: 'Create Jovie smart link',
+    });
+    expect(key).toContain('rel-deep-end');
+    expect(key).toContain('create-jovie-smart-link');
+  });
+});
+
+describe('end-to-end Cosmic Gate demo path', () => {
+  it('signal → segment → recommendation → drop → approval → monitor', () => {
+    const opportunities = detectOpportunitiesFromSignals(
+      EDC_COSMIC_GATE_SIGNALS,
+      { now: NOW, artistId: 'artist_tim_white' }
+    );
+    const opportunity = opportunities.find(o =>
+      o.title.includes('Cosmic Gate')
+    )!;
+    expect(opportunity).toBeDefined();
+
+    const segment = previewSegment(WARM_TRANCE_SEGMENT, FAN_FIXTURES, {
+      now: NOW,
+    });
+    expect(segment.size).toBeGreaterThan(0);
+
+    const recs = buildCampaignRecommendations({
+      opportunity,
+      segmentSize: 5260,
+      segmentName: WARM_TRANCE_SEGMENT.name,
+      products: DEMO_PRODUCT_ASSUMPTIONS,
+      channels: ['jovie_link', 'email'],
+      windowHours: 72,
+      now: NOW.toISOString(),
+    });
+    const best = recs.options[0]!;
+    expect(best.expectedOrders).toBe(263);
+
+    const { drop } = upsertDraftDrop([], {
+      id: 'drop_demo',
+      campaignId: 'camp_demo',
+      ownerProfileId: 'profile_tim',
+      option: best,
+      launchStartsAt: opportunity.windowStartsAt,
+      launchEndsAt: opportunity.windowEndsAt,
+    });
+    const previewed = transitionDrop(drop, 'preview_ready');
+    expect(previewed.allowed).toBe(true);
+
+    const { workflow } = startOrResumeApproval({
+      existing: null,
+      workflowId: 'wf_demo',
+      artistId: opportunity.artistId,
+      recommendationId: best.id,
+      now: NOW.toISOString(),
+    });
+    const finished = runApprovalSteps(
+      workflow,
+      Object.fromEntries(
+        APPROVAL_STEP_ORDER.map(id => [
+          id,
+          () => ({ ok: true as const, output: { step: id } }),
+        ])
+      ),
+      { now: NOW.toISOString() }
+    );
+    expect(finished.status).toBe('completed');
+
+    const health = buildCampaignHealthSnapshot({
+      campaignId: 'camp_demo',
+      counters: {
+        clicks: 80,
+        purchases: 12,
+        replies: 10,
+        optIns: 20,
+        channelStatuses: {
+          jovie_link: 'ok',
+          email: 'ok',
+          sms: 'ok',
+          profile: 'ok',
+          social: 'ok',
+        },
+      },
+      now: NOW.toISOString(),
+    });
+    expect(recommendNextMoves(health).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/lib/campaign-ops/external-signals.ts
+++ b/apps/web/lib/campaign-ops/external-signals.ts
@@ -1,0 +1,260 @@
+/**
+ * External opportunity detector (JOV-2205).
+ *
+ * Normalizes trusted event/festival + commerce signals, collapses duplicates
+ * per artist/collaborator/time window, and ranks artist-scoped opportunities.
+ */
+
+import type {
+  ArtistOpportunity,
+  ExternalSignalInput,
+  NormalizedExternalSignal,
+  OpportunityKind,
+  SignalSourceKind,
+} from './types';
+
+const MS_PER_DAY = 86_400_000;
+
+function clampConfidence(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function slugPart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/(^-|-$)/g, '');
+}
+
+/** Calendar day key in UTC for window bucketing. */
+export function utcDayKey(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return 'invalid';
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Dedupe key: artist + collaborator + source kind + start-day window.
+ * Multiple observations of the same EDC weekend collapse into one bucket.
+ */
+export function buildSignalDedupeKey(input: {
+  readonly artistId: string;
+  readonly collaboratorId?: string | null;
+  readonly sourceKind: SignalSourceKind;
+  readonly startsAt: string;
+  readonly eventName?: string | null;
+}): string {
+  const collab = input.collaboratorId?.trim() || 'solo';
+  const event = slugPart(input.eventName ?? 'event') || 'event';
+  return [
+    slugPart(input.artistId) || 'artist',
+    slugPart(collab),
+    input.sourceKind,
+    event,
+    utcDayKey(input.startsAt),
+  ].join('|');
+}
+
+export function normalizeExternalSignal(
+  input: ExternalSignalInput
+): NormalizedExternalSignal {
+  const dedupeKey = buildSignalDedupeKey({
+    artistId: input.artistId,
+    collaboratorId: input.collaboratorId,
+    sourceKind: input.sourceKind,
+    startsAt: input.startsAt,
+    eventName: input.eventName,
+  });
+
+  const id = `sig_${slugPart(dedupeKey)}_${slugPart(input.observedAt)}`;
+
+  return {
+    id,
+    dedupeKey,
+    sourceKind: input.sourceKind,
+    sourceUrl: input.sourceUrl.trim(),
+    sourceLabel: input.sourceLabel.trim(),
+    artistId: input.artistId.trim(),
+    artistName: input.artistName.trim(),
+    collaboratorId: input.collaboratorId?.trim() ?? null,
+    collaboratorName: input.collaboratorName?.trim() ?? null,
+    eventName: input.eventName?.trim() ?? null,
+    venue: input.venue?.trim() ?? null,
+    city: input.city?.trim() ?? null,
+    startsAt: input.startsAt,
+    endsAt: input.endsAt ?? null,
+    observedAt: input.observedAt,
+    confidence: clampConfidence(input.confidence),
+    expiryAt: input.expiryAt,
+    tags: Object.freeze([...(input.tags ?? [])]),
+  };
+}
+
+function isFresh(signal: NormalizedExternalSignal, now: Date): boolean {
+  const expiry = new Date(signal.expiryAt).getTime();
+  if (Number.isNaN(expiry)) return false;
+  return expiry >= now.getTime();
+}
+
+function kindForSource(sourceKind: SignalSourceKind): OpportunityKind {
+  switch (sourceKind) {
+    case 'event_festival':
+      return 'festival_attention';
+    case 'commerce_window':
+      return 'commerce_window';
+    case 'collaborator':
+      return 'collaborator_moment';
+  }
+}
+
+function buildTitle(signals: readonly NormalizedExternalSignal[]): string {
+  const primary = signals[0];
+  if (!primary) return 'Untitled opportunity';
+
+  if (primary.collaboratorName && primary.eventName) {
+    return `${primary.collaboratorName} at ${primary.eventName}`;
+  }
+  if (primary.eventName) {
+    return primary.eventName;
+  }
+  if (primary.sourceKind === 'commerce_window') {
+    return primary.sourceLabel || 'Commerce window';
+  }
+  return primary.sourceLabel || 'External opportunity';
+}
+
+function buildWhy(signals: readonly NormalizedExternalSignal[]): string {
+  const primary = signals[0];
+  if (!primary) return '';
+
+  const parts: string[] = [];
+  if (primary.collaboratorName && primary.eventName) {
+    parts.push(
+      `${primary.collaboratorName} is drawing attention at ${primary.eventName}`
+    );
+  } else if (primary.eventName) {
+    parts.push(`${primary.eventName} is an active event window`);
+  } else {
+    parts.push(primary.sourceLabel);
+  }
+
+  if (primary.city) {
+    parts.push(`in ${primary.city}`);
+  }
+
+  const commerce = signals.find(s => s.sourceKind === 'commerce_window');
+  if (commerce && primary.sourceKind !== 'commerce_window') {
+    parts.push(`overlaps ${commerce.sourceLabel}`);
+  }
+
+  return `${parts.join(' ')}.`;
+}
+
+function rankScore(
+  signals: readonly NormalizedExternalSignal[],
+  now: Date
+): number {
+  if (signals.length === 0) return 0;
+
+  const maxConfidence = Math.max(...signals.map(s => s.confidence));
+  const diversityBonus = Math.min(
+    0.2,
+    (new Set(signals.map(s => s.sourceKind)).size - 1) * 0.1
+  );
+
+  const soonest = Math.min(...signals.map(s => new Date(s.startsAt).getTime()));
+  const daysUntil = (soonest - now.getTime()) / MS_PER_DAY;
+  // Prefer windows starting within the next 14 days.
+  const timing =
+    daysUntil < 0
+      ? 0.4
+      : daysUntil <= 3
+        ? 1
+        : daysUntil <= 14
+          ? 0.8
+          : daysUntil <= 30
+            ? 0.5
+            : 0.2;
+
+  return Number(
+    (maxConfidence * 0.6 + timing * 0.3 + diversityBonus + 0.1).toFixed(4)
+  );
+}
+
+/**
+ * Collapse normalized signals into one opportunity per dedupe key,
+ * then rank freshest artist-scoped opportunities.
+ */
+export function collapseSignalsToOpportunities(
+  signals: readonly NormalizedExternalSignal[],
+  options: { readonly now?: Date; readonly artistId?: string } = {}
+): ArtistOpportunity[] {
+  const now = options.now ?? new Date();
+  const filtered = signals.filter(s => {
+    if (!isFresh(s, now)) return false;
+    if (options.artistId && s.artistId !== options.artistId) return false;
+    return true;
+  });
+
+  const buckets = new Map<string, NormalizedExternalSignal[]>();
+  for (const signal of filtered) {
+    const list = buckets.get(signal.dedupeKey) ?? [];
+    list.push(signal);
+    buckets.set(signal.dedupeKey, list);
+  }
+
+  const opportunities: ArtistOpportunity[] = [];
+
+  for (const [dedupeKey, bucket] of buckets) {
+    // Prefer highest confidence, then newest observation.
+    const sorted = [...bucket].sort((a, b) => {
+      if (b.confidence !== a.confidence) return b.confidence - a.confidence;
+      return (
+        new Date(b.observedAt).getTime() - new Date(a.observedAt).getTime()
+      );
+    });
+
+    const primary = sorted[0];
+    if (!primary) continue;
+
+    const starts = sorted.map(s => new Date(s.startsAt).getTime());
+    const ends = sorted.map(s =>
+      s.endsAt ? new Date(s.endsAt).getTime() : new Date(s.expiryAt).getTime()
+    );
+    const windowStartsAt = new Date(Math.min(...starts)).toISOString();
+    const windowEndsAt = new Date(Math.max(...ends)).toISOString();
+    const confidence = Math.max(...sorted.map(s => s.confidence));
+    const kind = kindForSource(primary.sourceKind);
+
+    opportunities.push({
+      id: `opp_${slugPart(dedupeKey)}`,
+      kind,
+      artistId: primary.artistId,
+      title: buildTitle(sorted),
+      why: buildWhy(sorted),
+      rankScore: rankScore(sorted, now),
+      confidence,
+      windowStartsAt,
+      windowEndsAt,
+      signalIds: sorted.map(s => s.id),
+      collaboratorId: primary.collaboratorId,
+      collaboratorName: primary.collaboratorName,
+      sourceUrls: Object.freeze([
+        ...new Set(sorted.map(s => s.sourceUrl).filter(Boolean)),
+      ]),
+    });
+  }
+
+  return opportunities.sort((a, b) => b.rankScore - a.rankScore);
+}
+
+/** Adapter entry: raw connector payloads → ranked opportunities. */
+export function detectOpportunitiesFromSignals(
+  inputs: readonly ExternalSignalInput[],
+  options: { readonly now?: Date; readonly artistId?: string } = {}
+): ArtistOpportunity[] {
+  const normalized = inputs.map(normalizeExternalSignal);
+  return collapseSignalsToOpportunities(normalized, options);
+}

--- a/apps/web/lib/campaign-ops/fan-segments.ts
+++ b/apps/web/lib/campaign-ops/fan-segments.ts
@@ -1,0 +1,214 @@
+/**
+ * Fan segment builder from Jovie Link / audience activity (JOV-2207).
+ *
+ * Pure predicates over fan activity records. Stable definition ids, refreshable
+ * previews, and graceful missing-data notes for campaign targeting.
+ */
+
+import type {
+  FanActivityRecord,
+  SegmentDefinition,
+  SegmentDimension,
+  SegmentMemberSample,
+  SegmentPreview,
+} from './types';
+
+const MS_PER_DAY = 86_400_000;
+
+function daysBetween(iso: string, now: Date): number | null {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return null;
+  return (now.getTime() - t) / MS_PER_DAY;
+}
+
+function hasGenreMatch(
+  record: FanActivityRecord,
+  genreTags: readonly string[] | undefined
+): boolean {
+  if (!genreTags || genreTags.length === 0) return true;
+  const tags = record.genreTags ?? [];
+  if (tags.length === 0) return false;
+  const wanted = new Set(genreTags.map(g => g.toLowerCase()));
+  return tags.some(t => wanted.has(t.toLowerCase()));
+}
+
+export function evaluateSegmentMember(
+  record: FanActivityRecord,
+  definition: SegmentDefinition,
+  now: Date = new Date()
+): {
+  readonly matches: boolean;
+  readonly dimensions: readonly SegmentDimension[];
+} {
+  const matched: SegmentDimension[] = [];
+  const dims = definition.dimensions;
+
+  for (const dim of dims) {
+    switch (dim) {
+      case 'genre_affinity': {
+        if (hasGenreMatch(record, definition.genreTags)) {
+          matched.push(dim);
+        }
+        break;
+      }
+      case 'link_activity': {
+        const min = definition.minLinkClicks ?? 1;
+        if ((record.linkClickCount ?? 0) >= min) {
+          matched.push(dim);
+        }
+        break;
+      }
+      case 'buyer': {
+        if (record.isBuyer === true) {
+          matched.push(dim);
+        }
+        break;
+      }
+      case 'subscriber': {
+        if (record.isSubscriber === true) {
+          matched.push(dim);
+        }
+        break;
+      }
+      case 'recency': {
+        const maxDays = definition.recencyDays ?? 30;
+        const days = daysBetween(record.lastActiveAt, now);
+        if (days !== null && days <= maxDays) {
+          matched.push(dim);
+        }
+        break;
+      }
+    }
+  }
+
+  // All declared dimensions must match (AND).
+  const matches = dims.length > 0 && dims.every(d => matched.includes(d));
+
+  return { matches, dimensions: matched };
+}
+
+function collectMissingDataNotes(
+  members: readonly FanActivityRecord[],
+  definition: SegmentDefinition
+): string[] {
+  const notes: string[] = [];
+  if (members.length === 0) {
+    notes.push('No audience activity available for this artist yet.');
+    return notes;
+  }
+
+  if (definition.dimensions.includes('genre_affinity')) {
+    const missingGenre = members.filter(
+      m => !m.genreTags || m.genreTags.length === 0
+    ).length;
+    if (missingGenre > 0) {
+      notes.push(
+        `${missingGenre} members lack genre affinity tags and cannot match genre filters.`
+      );
+    }
+  }
+
+  if (definition.dimensions.includes('buyer')) {
+    const unknownBuyer = members.filter(m => m.isBuyer === undefined).length;
+    if (unknownBuyer > 0) {
+      notes.push(
+        `${unknownBuyer} members have unknown purchase state; only confirmed buyers are counted.`
+      );
+    }
+  }
+
+  if (definition.dimensions.includes('subscriber')) {
+    const unknownSub = members.filter(m => m.isSubscriber === undefined).length;
+    if (unknownSub > 0) {
+      notes.push(
+        `${unknownSub} members have unknown subscription state; only confirmed subscribers are counted.`
+      );
+    }
+  }
+
+  if (definition.dimensions.includes('link_activity')) {
+    const noClicks = members.filter(
+      m => m.linkClickCount === undefined || m.linkClickCount === 0
+    ).length;
+    if (noClicks === members.length) {
+      notes.push(
+        'No Jovie Link click activity recorded for this audience yet.'
+      );
+    }
+  }
+
+  return notes;
+}
+
+/**
+ * Preview a segment: size, sample members, and missing-data explanations.
+ */
+export function previewSegment(
+  definition: SegmentDefinition,
+  members: readonly FanActivityRecord[],
+  options: {
+    readonly now?: Date;
+    readonly sampleSize?: number;
+  } = {}
+): SegmentPreview {
+  const now = options.now ?? new Date();
+  const sampleSize = options.sampleSize ?? 5;
+  const samples: SegmentMemberSample[] = [];
+
+  for (const member of members) {
+    const result = evaluateSegmentMember(member, definition, now);
+    if (!result.matches) continue;
+    if (samples.length < sampleSize) {
+      samples.push({
+        memberId: member.memberId,
+        matchedDimensions: result.dimensions,
+      });
+    }
+  }
+
+  // Full size count (not capped by sample).
+  let size = 0;
+  for (const member of members) {
+    if (evaluateSegmentMember(member, definition, now).matches) {
+      size += 1;
+    }
+  }
+
+  return {
+    definitionId: definition.id,
+    size,
+    sampleMembers: samples,
+    missingDataNotes: collectMissingDataNotes(members, definition),
+    refreshedAt: now.toISOString(),
+  };
+}
+
+/** Warm trance / festival-fan segment used in the founder demo narrative. */
+export const WARM_TRANCE_SEGMENT: SegmentDefinition = Object.freeze({
+  id: 'warm-trance-link-engaged',
+  name: 'Warm Trance Fans',
+  dimensions: Object.freeze([
+    'genre_affinity',
+    'link_activity',
+    'recency',
+  ] as const),
+  genreTags: Object.freeze(['trance', 'progressive-trance', 'edm']),
+  recencyDays: 45,
+  minLinkClicks: 1,
+});
+
+export function isStableSegmentDefinition(
+  a: SegmentDefinition,
+  b: SegmentDefinition
+): boolean {
+  return (
+    a.id === b.id &&
+    a.name === b.name &&
+    a.dimensions.join(',') === b.dimensions.join(',') &&
+    (a.genreTags ?? []).join(',') === (b.genreTags ?? []).join(',') &&
+    a.recencyDays === b.recencyDays &&
+    a.requireBuyer === b.requireBuyer &&
+    a.requireSubscriber === b.requireSubscriber &&
+    a.minLinkClicks === b.minLinkClicks
+  );
+}

--- a/apps/web/lib/campaign-ops/index.ts
+++ b/apps/web/lib/campaign-ops/index.ts
@@ -1,0 +1,65 @@
+/**
+ * Campaign ops domain — production logic for the founder demo campaign loop.
+ *
+ * Issues: JOV-2205, JOV-2207, JOV-2208, JOV-2209, JOV-2210, JOV-2212, JOV-2213
+ */
+
+export {
+  APPROVAL_STEP_ORDER,
+  buildApprovalIdempotencyKey,
+  createApprovalWorkflow,
+  markStepFailed,
+  markStepRunning,
+  markStepSucceeded,
+  nextPendingStep,
+  retryFailedStep,
+  runApprovalSteps,
+  startOrResumeApproval,
+  workflowHasHiddenInconsistency,
+} from './approval-orchestrator';
+export {
+  buildSignalDedupeKey,
+  collapseSignalsToOpportunities,
+  detectOpportunitiesFromSignals,
+  normalizeExternalSignal,
+  utcDayKey,
+} from './external-signals';
+export {
+  evaluateSegmentMember,
+  isStableSegmentDefinition,
+  previewSegment,
+  WARM_TRANCE_SEGMENT,
+} from './fan-segments';
+export {
+  buildProductPageKey,
+  canTransitionDrop,
+  createDraftDrop,
+  isDropVisibleInCampaignStatus,
+  transitionDrop,
+  upsertDraftDrop,
+} from './merch-drop-workflow';
+export {
+  buildCampaignHealthSnapshot,
+  computeConversionRate,
+  computeReplyRate,
+  DEFAULT_MONITORING_THRESHOLDS,
+  pauseMonitoring,
+  recommendNextMoves,
+  resumeMonitoring,
+} from './monitoring';
+export {
+  buildCampaignRecommendations,
+  computeExpectedMarginCents,
+  computeExpectedOrders,
+  computeExpectedRevenueCents,
+  DEMO_PRODUCT_ASSUMPTIONS,
+} from './recommendations';
+export {
+  buildTaskDedupeKey,
+  createReleaseWorkflow,
+  DEFAULT_SINGLE_RELEASE_PLAYBOOK,
+  expandPlaybookToTasks,
+  importReleasePlaybook,
+  mergeWorkflowTasks,
+} from './release-workflow';
+export type * from './types';

--- a/apps/web/lib/campaign-ops/merch-drop-workflow.ts
+++ b/apps/web/lib/campaign-ops/merch-drop-workflow.ts
@@ -1,0 +1,143 @@
+/**
+ * Merch / drop creation workflow (JOV-2209).
+ *
+ * Draft-first drop records with typed lifecycle transitions and idempotent
+ * product-page keys. No live payment behavior.
+ */
+
+import type {
+  CampaignOption,
+  DropLifecycleState,
+  DropRecord,
+  DropTransitionResult,
+} from './types';
+
+const ALLOWED_TRANSITIONS: Readonly<
+  Record<DropLifecycleState, readonly DropLifecycleState[]>
+> = Object.freeze({
+  draft: Object.freeze(['preview_ready', 'cancelled'] as const),
+  preview_ready: Object.freeze(['scheduled', 'draft', 'cancelled'] as const),
+  scheduled: Object.freeze(['live', 'cancelled'] as const),
+  live: Object.freeze(['ended', 'cancelled'] as const),
+  ended: Object.freeze([] as const),
+  cancelled: Object.freeze([] as const),
+});
+
+function slugPart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/(^-|-$)/g, '');
+}
+
+/** Stable product page key for idempotent draft creation. */
+export function buildProductPageKey(input: {
+  readonly ownerProfileId: string;
+  readonly campaignId: string;
+  readonly productSku: string;
+}): string {
+  return [
+    slugPart(input.ownerProfileId) || 'owner',
+    slugPart(input.campaignId) || 'campaign',
+    slugPart(input.productSku) || 'sku',
+  ].join('/');
+}
+
+export function createDraftDrop(input: {
+  readonly id: string;
+  readonly campaignId: string;
+  readonly ownerProfileId: string;
+  readonly option: CampaignOption;
+  readonly launchStartsAt: string;
+  readonly launchEndsAt: string;
+  readonly inventoryMode?: 'unlimited' | 'limited';
+  readonly inventoryCount?: number | null;
+  readonly fulfillment?: DropRecord['fulfillment'];
+  readonly artworkAssetId?: string | null;
+}): DropRecord {
+  const productPageKey = buildProductPageKey({
+    ownerProfileId: input.ownerProfileId,
+    campaignId: input.campaignId,
+    productSku: input.option.productSku,
+  });
+
+  return {
+    id: input.id,
+    campaignId: input.campaignId,
+    ownerProfileId: input.ownerProfileId,
+    productSku: input.option.productSku,
+    productLabel: input.option.productLabel,
+    priceCents: input.option.unitPriceCents,
+    inventoryMode: input.inventoryMode ?? 'unlimited',
+    inventoryCount:
+      input.inventoryMode === 'limited' ? (input.inventoryCount ?? 0) : null,
+    fulfillment: input.fulfillment ?? 'print_on_demand',
+    artworkAssetId: input.artworkAssetId ?? null,
+    launchStartsAt: input.launchStartsAt,
+    launchEndsAt: input.launchEndsAt,
+    state: 'draft',
+    productPageKey,
+    previewUrl: null,
+  };
+}
+
+/**
+ * Idempotent create: if an existing drop matches productPageKey, return it.
+ */
+export function upsertDraftDrop(
+  existing: readonly DropRecord[],
+  input: Parameters<typeof createDraftDrop>[0]
+): { readonly drop: DropRecord; readonly created: boolean } {
+  const key = buildProductPageKey({
+    ownerProfileId: input.ownerProfileId,
+    campaignId: input.campaignId,
+    productSku: input.option.productSku,
+  });
+  const found = existing.find(d => d.productPageKey === key);
+  if (found) {
+    return { drop: found, created: false };
+  }
+  return { drop: createDraftDrop(input), created: true };
+}
+
+export function canTransitionDrop(
+  from: DropLifecycleState,
+  to: DropLifecycleState
+): boolean {
+  return ALLOWED_TRANSITIONS[from].includes(to);
+}
+
+export function transitionDrop(
+  drop: DropRecord,
+  to: DropLifecycleState,
+  options: { readonly previewUrl?: string | null } = {}
+): DropTransitionResult {
+  if (!canTransitionDrop(drop.state, to)) {
+    return {
+      drop,
+      previousState: drop.state,
+      allowed: false,
+      reason: `Cannot transition drop from ${drop.state} to ${to}`,
+    };
+  }
+
+  const next: DropRecord = {
+    ...drop,
+    state: to,
+    previewUrl:
+      to === 'preview_ready'
+        ? (options.previewUrl ?? `/drop/preview/${drop.productPageKey}`)
+        : drop.previewUrl,
+  };
+
+  return {
+    drop: next,
+    previousState: drop.state,
+    allowed: true,
+  };
+}
+
+export function isDropVisibleInCampaignStatus(drop: DropRecord): boolean {
+  return drop.state !== 'cancelled';
+}

--- a/apps/web/lib/campaign-ops/monitoring.ts
+++ b/apps/web/lib/campaign-ops/monitoring.ts
@@ -1,0 +1,245 @@
+/**
+ * Campaign monitoring + next-move recommendations (JOV-2212).
+ *
+ * Aggregates event counters into health snapshots and emits typed next moves
+ * from threshold rules. Pause/resume is an explicit flag on the snapshot path.
+ */
+
+import type {
+  CampaignEventCounters,
+  CampaignHealthSnapshot,
+  CampaignHealthStatus,
+  NextMoveKind,
+  NextMoveRecommendation,
+} from './types';
+
+export interface MonitoringThresholds {
+  readonly minClicksForHealth: number;
+  readonly minConversionRate: number;
+  readonly strongConversionRate: number;
+  readonly lowReplyRate: number;
+  readonly minPurchasesForExtend: number;
+}
+
+export const DEFAULT_MONITORING_THRESHOLDS: MonitoringThresholds =
+  Object.freeze({
+    minClicksForHealth: 20,
+    minConversionRate: 0.01,
+    strongConversionRate: 0.04,
+    lowReplyRate: 0.02,
+    minPurchasesForExtend: 10,
+  });
+
+export function computeConversionRate(counters: CampaignEventCounters): number {
+  if (counters.clicks <= 0) return 0;
+  return counters.purchases / counters.clicks;
+}
+
+export function computeReplyRate(counters: CampaignEventCounters): number {
+  if (counters.clicks <= 0) return 0;
+  return counters.replies / counters.clicks;
+}
+
+function healthStatus(
+  counters: CampaignEventCounters,
+  conversionRate: number,
+  paused: boolean,
+  thresholds: MonitoringThresholds
+): CampaignHealthStatus {
+  if (paused) return 'paused';
+
+  const anyChannelOff = Object.values(counters.channelStatuses).some(
+    s => s === 'off'
+  );
+  const anyDegraded = Object.values(counters.channelStatuses).some(
+    s => s === 'degraded'
+  );
+
+  if (
+    anyChannelOff ||
+    (counters.clicks >= thresholds.minClicksForHealth &&
+      conversionRate < thresholds.minConversionRate)
+  ) {
+    return 'at_risk';
+  }
+  if (anyDegraded || conversionRate < thresholds.strongConversionRate) {
+    return 'watch';
+  }
+  if (counters.clicks < thresholds.minClicksForHealth) {
+    return 'watch';
+  }
+  return 'healthy';
+}
+
+export function buildCampaignHealthSnapshot(input: {
+  readonly campaignId: string;
+  readonly counters: CampaignEventCounters;
+  readonly paused?: boolean;
+  readonly now?: string;
+  readonly thresholds?: MonitoringThresholds;
+}): CampaignHealthSnapshot {
+  const thresholds = input.thresholds ?? DEFAULT_MONITORING_THRESHOLDS;
+  const conversionRate = computeConversionRate(input.counters);
+  const paused = input.paused ?? false;
+
+  return {
+    campaignId: input.campaignId,
+    status: healthStatus(input.counters, conversionRate, paused, thresholds),
+    counters: input.counters,
+    conversionRate: Number(conversionRate.toFixed(6)),
+    capturedAt: input.now ?? new Date().toISOString(),
+    paused,
+  };
+}
+
+function moveId(kind: NextMoveKind, campaignId: string): string {
+  return `move_${kind}_${campaignId}`;
+}
+
+/**
+ * Threshold → typed next-move recommendations with evidence.
+ * Dedupes by kind (at most one recommendation per kind).
+ */
+export function recommendNextMoves(
+  snapshot: CampaignHealthSnapshot,
+  thresholds: MonitoringThresholds = DEFAULT_MONITORING_THRESHOLDS
+): NextMoveRecommendation[] {
+  if (snapshot.paused) {
+    return [];
+  }
+
+  const { counters, conversionRate, campaignId } = snapshot;
+  const moves: NextMoveRecommendation[] = [];
+  const seen = new Set<NextMoveKind>();
+
+  const push = (move: NextMoveRecommendation) => {
+    if (seen.has(move.kind)) return;
+    seen.add(move.kind);
+    moves.push(move);
+  };
+
+  const degradedChannels = (
+    Object.entries(counters.channelStatuses) as [
+      keyof typeof counters.channelStatuses,
+      string,
+    ][]
+  )
+    .filter(([, status]) => status === 'degraded' || status === 'off')
+    .map(([channel]) => channel);
+
+  if (degradedChannels.length > 0) {
+    push({
+      id: moveId('boost_channel', campaignId),
+      kind: 'boost_channel',
+      title: 'Repair or boost degraded channels',
+      evidence: [
+        `Channels not healthy: ${degradedChannels.join(', ')}`,
+        `${counters.clicks} clicks captured so far`,
+      ],
+      expectedImpact:
+        'Restore delivery so click and purchase volume can recover.',
+      confidence: 0.8,
+    });
+  }
+
+  if (
+    counters.clicks >= thresholds.minClicksForHealth &&
+    conversionRate < thresholds.minConversionRate
+  ) {
+    push({
+      id: moveId('retarget_segment', campaignId),
+      kind: 'retarget_segment',
+      title: 'Retarget a warmer segment',
+      evidence: [
+        `Conversion rate ${(conversionRate * 100).toFixed(2)}% below ${(thresholds.minConversionRate * 100).toFixed(2)}% floor`,
+        `${counters.purchases} purchases from ${counters.clicks} clicks`,
+      ],
+      expectedImpact:
+        'Lift conversion by focusing on buyers, subscribers, and recent clickers.',
+      confidence: 0.75,
+    });
+  }
+
+  if (
+    conversionRate >= thresholds.strongConversionRate &&
+    counters.purchases >= thresholds.minPurchasesForExtend
+  ) {
+    push({
+      id: moveId('extend_window', campaignId),
+      kind: 'extend_window',
+      title: 'Extend the drop window',
+      evidence: [
+        `Strong conversion ${(conversionRate * 100).toFixed(2)}%`,
+        `${counters.purchases} purchases already fulfilled`,
+      ],
+      expectedImpact:
+        'Capture residual demand while conversion remains healthy.',
+      confidence: 0.7,
+    });
+  }
+
+  const replyRate = computeReplyRate(counters);
+  if (
+    counters.clicks >= thresholds.minClicksForHealth &&
+    replyRate < thresholds.lowReplyRate
+  ) {
+    push({
+      id: moveId('follow_up_content', campaignId),
+      kind: 'follow_up_content',
+      title: 'Ship follow-up content',
+      evidence: [
+        `Reply rate ${(replyRate * 100).toFixed(2)}% is low`,
+        `${counters.replies} replies vs ${counters.clicks} clicks`,
+      ],
+      expectedImpact: 'Re-engage clickers who have not purchased or replied.',
+      confidence: 0.65,
+    });
+  }
+
+  if (
+    snapshot.status === 'healthy' &&
+    counters.purchases >= thresholds.minPurchasesForExtend &&
+    counters.optIns > 0
+  ) {
+    push({
+      id: moveId('close_and_report', campaignId),
+      kind: 'close_and_report',
+      title: 'Prepare close-out report',
+      evidence: [
+        `Campaign healthy with ${counters.purchases} purchases`,
+        `${counters.optIns} new opt-ins captured`,
+      ],
+      expectedImpact:
+        'Lock learnings and queue the next release or drop moment.',
+      confidence: 0.6,
+    });
+  }
+
+  return moves;
+}
+
+export function pauseMonitoring(
+  snapshot: CampaignHealthSnapshot,
+  now?: string
+): CampaignHealthSnapshot {
+  return {
+    ...snapshot,
+    paused: true,
+    status: 'paused',
+    capturedAt: now ?? new Date().toISOString(),
+  };
+}
+
+export function resumeMonitoring(
+  snapshot: CampaignHealthSnapshot,
+  now?: string,
+  thresholds?: MonitoringThresholds
+): CampaignHealthSnapshot {
+  return buildCampaignHealthSnapshot({
+    campaignId: snapshot.campaignId,
+    counters: snapshot.counters,
+    paused: false,
+    now,
+    thresholds,
+  });
+}

--- a/apps/web/lib/campaign-ops/recommendations.ts
+++ b/apps/web/lib/campaign-ops/recommendations.ts
@@ -1,0 +1,182 @@
+/**
+ * Campaign recommendation engine with timing + revenue math (JOV-2208).
+ *
+ * Deterministic, testable expected-order/revenue path from opportunity +
+ * segment size + product assumptions.
+ */
+
+import type {
+  CampaignOption,
+  CampaignRecommendationInput,
+  CampaignRecommendationResult,
+  ProductAssumption,
+} from './types';
+
+function slugPart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/(^-|-$)/g, '');
+}
+
+/** Expected orders = floor(segmentSize * conversionRate), min 0. */
+export function computeExpectedOrders(
+  segmentSize: number,
+  conversionRate: number
+): number {
+  if (segmentSize <= 0 || conversionRate <= 0) return 0;
+  const rate = Math.min(1, Math.max(0, conversionRate));
+  return Math.floor(segmentSize * rate);
+}
+
+export function computeExpectedRevenueCents(
+  expectedOrders: number,
+  unitPriceCents: number
+): number {
+  if (expectedOrders <= 0 || unitPriceCents <= 0) return 0;
+  return expectedOrders * unitPriceCents;
+}
+
+export function computeExpectedMarginCents(
+  expectedOrders: number,
+  unitPriceCents: number,
+  cogsCents: number | undefined
+): number | null {
+  if (cogsCents === undefined) return null;
+  if (expectedOrders <= 0) return 0;
+  return expectedOrders * (unitPriceCents - cogsCents);
+}
+
+function optionRankScore(input: {
+  readonly expectedRevenueCents: number;
+  readonly confidence: number;
+  readonly conversionRate: number;
+}): number {
+  // Normalize revenue to a soft 0..1 against a $15k demo ceiling.
+  const revenueNorm = Math.min(1, input.expectedRevenueCents / 1_500_000);
+  return Number(
+    (
+      revenueNorm * 0.55 +
+      input.confidence * 0.3 +
+      Math.min(1, input.conversionRate * 10) * 0.15
+    ).toFixed(4)
+  );
+}
+
+function buildWhyNow(
+  input: CampaignRecommendationInput,
+  product: ProductAssumption
+): string {
+  const windowHours = input.windowHours;
+  const opp = input.opportunity;
+  const collab = opp.collaboratorName
+    ? ` while ${opp.collaboratorName} has attention`
+    : '';
+  return `Run a ${windowHours}-hour ${product.label} drop${collab} (${opp.title}).`;
+}
+
+function buildAssumptions(
+  input: CampaignRecommendationInput,
+  product: ProductAssumption,
+  expectedOrders: number
+): string[] {
+  return [
+    `Segment "${input.segmentName}" size ${input.segmentSize}`,
+    `Conversion rate ${(product.expectedConversionRate * 100).toFixed(2)}%`,
+    `Unit price $${(product.unitPriceCents / 100).toFixed(2)}`,
+    `Expected path: ${expectedOrders} orders × $${(product.unitPriceCents / 100).toFixed(2)}`,
+    `Campaign window ${input.windowHours}h`,
+    `Opportunity confidence ${(input.opportunity.confidence * 100).toFixed(0)}%`,
+  ];
+}
+
+/**
+ * Build ranked campaign options for an opportunity. One option per product.
+ */
+export function buildCampaignRecommendations(
+  input: CampaignRecommendationInput
+): CampaignRecommendationResult {
+  const generatedAt = input.now ?? new Date().toISOString();
+  const options: CampaignOption[] = input.products.map(product => {
+    const expectedOrders = computeExpectedOrders(
+      input.segmentSize,
+      product.expectedConversionRate
+    );
+    const expectedRevenueCents = computeExpectedRevenueCents(
+      expectedOrders,
+      product.unitPriceCents
+    );
+    const expectedMarginCents = computeExpectedMarginCents(
+      expectedOrders,
+      product.unitPriceCents,
+      product.cogsCents
+    );
+    // Blend opportunity confidence with product conversion realism.
+    const confidence = Number(
+      Math.min(
+        1,
+        input.opportunity.confidence * 0.7 +
+          Math.min(1, product.expectedConversionRate * 8) * 0.3
+      ).toFixed(4)
+    );
+
+    const title = `${input.windowHours}-hour ${product.label} Drop`;
+    const id = `rec_${slugPart(input.opportunity.id)}_${slugPart(product.sku)}`;
+
+    return {
+      id,
+      title,
+      whyNow: buildWhyNow(input, product),
+      targetAudience: input.segmentName,
+      channels: input.channels,
+      productSku: product.sku,
+      productLabel: product.label,
+      unitPriceCents: product.unitPriceCents,
+      expectedOrders,
+      expectedRevenueCents,
+      expectedMarginCents,
+      assumptions: buildAssumptions(input, product, expectedOrders),
+      confidence,
+      rankScore: optionRankScore({
+        expectedRevenueCents,
+        confidence,
+        conversionRate: product.expectedConversionRate,
+      }),
+    };
+  });
+
+  options.sort((a, b) => b.rankScore - a.rankScore);
+
+  return {
+    opportunityId: input.opportunity.id,
+    options,
+    generatedAt,
+  };
+}
+
+/** Founder-demo product set (tee / poster / hoodie). */
+export const DEMO_PRODUCT_ASSUMPTIONS: readonly ProductAssumption[] =
+  Object.freeze([
+    {
+      sku: 'deep-end-festival-tee',
+      label: 'The Deep End Festival Tee',
+      unitPriceCents: 3800,
+      expectedConversionRate: 0.05,
+      cogsCents: 1400,
+    },
+    {
+      sku: 'deep-end-poster',
+      label: 'The Deep End Poster',
+      unitPriceCents: 2500,
+      expectedConversionRate: 0.035,
+      cogsCents: 600,
+    },
+    {
+      sku: 'deep-end-hoodie',
+      label: 'The Deep End Hoodie',
+      unitPriceCents: 6500,
+      expectedConversionRate: 0.018,
+      cogsCents: 2800,
+    },
+  ]);

--- a/apps/web/lib/campaign-ops/release-workflow.ts
+++ b/apps/web/lib/campaign-ops/release-workflow.ts
@@ -1,0 +1,191 @@
+/**
+ * Release workflow system from playbooks (JOV-2213).
+ *
+ * Expands a versioned playbook into a canonical per-release workflow with
+ * stable task dedupe keys so repeated imports do not duplicate work.
+ */
+
+import type {
+  ReleasePlaybookTemplate,
+  ReleaseWorkflowInstance,
+  ReleaseWorkflowTask,
+} from './types';
+
+function slugPart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/(^-|-$)/g, '');
+}
+
+/** Stable dedupe key: release + playbook version + task title slug. */
+export function buildTaskDedupeKey(input: {
+  readonly releaseId: string;
+  readonly playbookId: string;
+  readonly playbookVersion: string;
+  readonly title: string;
+}): string {
+  return [
+    slugPart(input.releaseId) || 'release',
+    slugPart(input.playbookId) || 'playbook',
+    slugPart(input.playbookVersion) || '0-0-0',
+    slugPart(input.title) || 'task',
+  ].join('::');
+}
+
+export function expandPlaybookToTasks(
+  releaseId: string,
+  playbook: ReleasePlaybookTemplate
+): ReleaseWorkflowTask[] {
+  return playbook.tasks.map(task => ({
+    ...task,
+    dedupeKey: buildTaskDedupeKey({
+      releaseId,
+      playbookId: playbook.id,
+      playbookVersion: playbook.version,
+      title: task.title,
+    }),
+    state: 'pending' as const,
+  }));
+}
+
+/**
+ * Merge expanded tasks into an existing workflow without duplicating keys.
+ * Existing task state is preserved when keys match.
+ */
+export function mergeWorkflowTasks(
+  existing: readonly ReleaseWorkflowTask[],
+  incoming: readonly ReleaseWorkflowTask[]
+): ReleaseWorkflowTask[] {
+  const byKey = new Map<string, ReleaseWorkflowTask>();
+  for (const task of existing) {
+    byKey.set(task.dedupeKey, task);
+  }
+  for (const task of incoming) {
+    if (!byKey.has(task.dedupeKey)) {
+      byKey.set(task.dedupeKey, task);
+    }
+  }
+  return [...byKey.values()];
+}
+
+export function createReleaseWorkflow(input: {
+  readonly id: string;
+  readonly releaseId: string;
+  readonly playbook: ReleasePlaybookTemplate;
+  readonly now?: string;
+}): ReleaseWorkflowInstance {
+  return {
+    id: input.id,
+    releaseId: input.releaseId,
+    playbookId: input.playbook.id,
+    playbookVersion: input.playbook.version,
+    tasks: expandPlaybookToTasks(input.releaseId, input.playbook),
+    createdAt: input.now ?? new Date().toISOString(),
+  };
+}
+
+/**
+ * Idempotent import: re-running the same release+playbook does not duplicate tasks.
+ */
+export function importReleasePlaybook(input: {
+  readonly existing: ReleaseWorkflowInstance | null;
+  readonly workflowId: string;
+  readonly releaseId: string;
+  readonly playbook: ReleasePlaybookTemplate;
+  readonly now?: string;
+}): { readonly workflow: ReleaseWorkflowInstance; readonly created: boolean } {
+  if (
+    input.existing &&
+    input.existing.releaseId === input.releaseId &&
+    input.existing.playbookId === input.playbook.id
+  ) {
+    const merged = mergeWorkflowTasks(
+      input.existing.tasks,
+      expandPlaybookToTasks(input.releaseId, input.playbook)
+    );
+    return {
+      workflow: {
+        ...input.existing,
+        playbookVersion: input.playbook.version,
+        tasks: merged,
+      },
+      created: false,
+    };
+  }
+
+  return {
+    workflow: createReleaseWorkflow({
+      id: input.workflowId,
+      releaseId: input.releaseId,
+      playbook: input.playbook,
+      now: input.now,
+    }),
+    created: true,
+  };
+}
+
+/** Canonical music-industry single release playbook (versioned, auditable). */
+export const DEFAULT_SINGLE_RELEASE_PLAYBOOK: ReleasePlaybookTemplate =
+  Object.freeze({
+    id: 'single-release-v1',
+    version: '1.0.0',
+    name: 'Single Release Operating System',
+    tasks: Object.freeze([
+      {
+        title: 'Enter metadata (ISRC, UPC, credits, genres)',
+        category: 'Distribution',
+        dueDaysOffset: -30,
+        assigneeType: 'human' as const,
+      },
+      {
+        title: 'Create Jovie smart link',
+        category: 'Platform',
+        dueDaysOffset: -1,
+        assigneeType: 'ai_workflow' as const,
+      },
+      {
+        title: 'Configure pre-save / save flow',
+        category: 'Platform',
+        dueDaysOffset: -14,
+        assigneeType: 'ai_workflow' as const,
+      },
+      {
+        title: 'Draft press release',
+        category: 'Press',
+        dueDaysOffset: -21,
+        assigneeType: 'human' as const,
+      },
+      {
+        title: 'Pitch to Spotify editorial',
+        category: 'Playlists',
+        dueDaysOffset: -28,
+        assigneeType: 'human' as const,
+      },
+      {
+        title: 'Plan content assets',
+        category: 'Content',
+        dueDaysOffset: -14,
+        assigneeType: 'human' as const,
+      },
+      {
+        title: 'Send fan notification',
+        category: 'Fan Engagement',
+        dueDaysOffset: 0,
+        assigneeType: 'ai_workflow' as const,
+      },
+      {
+        title: 'Draft merch drop for release',
+        category: 'Merch',
+        dueDaysOffset: -7,
+        assigneeType: 'ai_workflow' as const,
+      },
+      {
+        title: 'Review first-week analytics',
+        category: 'Reporting',
+        dueDaysOffset: 7,
+        assigneeType: 'human' as const,
+      },
+    ]),
+  });

--- a/apps/web/lib/campaign-ops/types.ts
+++ b/apps/web/lib/campaign-ops/types.ts
@@ -1,0 +1,296 @@
+/**
+ * Campaign ops domain types — production contracts behind the founder demo loop
+ * (external opportunity → segment → recommendation → drop → approval → monitor).
+ *
+ * Pure data contracts; no DB/IO. Consumers (chat, inbox, orchestrators) map these
+ * into durable storage and UI view models.
+ */
+
+export type SignalSourceKind =
+  | 'event_festival'
+  | 'commerce_window'
+  | 'collaborator';
+
+export type OpportunityKind =
+  | 'festival_attention'
+  | 'commerce_window'
+  | 'collaborator_moment';
+
+export type CampaignChannel =
+  | 'jovie_link'
+  | 'email'
+  | 'sms'
+  | 'profile'
+  | 'social';
+
+export type DropLifecycleState =
+  | 'draft'
+  | 'preview_ready'
+  | 'scheduled'
+  | 'live'
+  | 'ended'
+  | 'cancelled';
+
+export type ApprovalStepId =
+  | 'create_campaign'
+  | 'create_drop'
+  | 'update_smart_link'
+  | 'draft_notifications'
+  | 'select_audience'
+  | 'create_tasks'
+  | 'schedule_launch'
+  | 'enable_monitoring';
+
+export type ApprovalStepStatus =
+  | 'pending'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'skipped';
+
+export type CampaignHealthStatus = 'healthy' | 'watch' | 'at_risk' | 'paused';
+
+export type NextMoveKind =
+  | 'boost_channel'
+  | 'extend_window'
+  | 'retarget_segment'
+  | 'follow_up_content'
+  | 'close_and_report';
+
+export interface ExternalSignalInput {
+  readonly sourceKind: SignalSourceKind;
+  readonly sourceUrl: string;
+  readonly sourceLabel: string;
+  readonly artistId: string;
+  readonly artistName: string;
+  readonly collaboratorId?: string;
+  readonly collaboratorName?: string;
+  readonly eventName?: string;
+  readonly venue?: string;
+  readonly city?: string;
+  readonly startsAt: string; // ISO
+  readonly endsAt?: string; // ISO
+  readonly observedAt: string; // ISO
+  readonly confidence: number; // 0..1
+  readonly expiryAt: string; // ISO
+  readonly tags?: readonly string[];
+}
+
+export interface NormalizedExternalSignal {
+  readonly id: string;
+  readonly dedupeKey: string;
+  readonly sourceKind: SignalSourceKind;
+  readonly sourceUrl: string;
+  readonly sourceLabel: string;
+  readonly artistId: string;
+  readonly artistName: string;
+  readonly collaboratorId: string | null;
+  readonly collaboratorName: string | null;
+  readonly eventName: string | null;
+  readonly venue: string | null;
+  readonly city: string | null;
+  readonly startsAt: string;
+  readonly endsAt: string | null;
+  readonly observedAt: string;
+  readonly confidence: number;
+  readonly expiryAt: string;
+  readonly tags: readonly string[];
+}
+
+export interface ArtistOpportunity {
+  readonly id: string;
+  readonly kind: OpportunityKind;
+  readonly artistId: string;
+  readonly title: string;
+  readonly why: string;
+  readonly rankScore: number;
+  readonly confidence: number;
+  readonly windowStartsAt: string;
+  readonly windowEndsAt: string;
+  readonly signalIds: readonly string[];
+  readonly collaboratorId: string | null;
+  readonly collaboratorName: string | null;
+  readonly sourceUrls: readonly string[];
+}
+
+export type SegmentDimension =
+  | 'genre_affinity'
+  | 'link_activity'
+  | 'buyer'
+  | 'subscriber'
+  | 'recency';
+
+export interface FanActivityRecord {
+  readonly memberId: string;
+  readonly eventType: string;
+  readonly genreTags?: readonly string[];
+  readonly isBuyer?: boolean;
+  readonly isSubscriber?: boolean;
+  readonly lastActiveAt: string; // ISO
+  readonly linkClickCount?: number;
+}
+
+export interface SegmentDefinition {
+  readonly id: string;
+  readonly name: string;
+  readonly dimensions: readonly SegmentDimension[];
+  /** Genre tags any of which qualify (OR within set). Empty = any genre. */
+  readonly genreTags?: readonly string[];
+  /** Max days since last activity. */
+  readonly recencyDays?: number;
+  readonly requireBuyer?: boolean;
+  readonly requireSubscriber?: boolean;
+  readonly minLinkClicks?: number;
+}
+
+export interface SegmentMemberSample {
+  readonly memberId: string;
+  readonly matchedDimensions: readonly SegmentDimension[];
+}
+
+export interface SegmentPreview {
+  readonly definitionId: string;
+  readonly size: number;
+  readonly sampleMembers: readonly SegmentMemberSample[];
+  readonly missingDataNotes: readonly string[];
+  readonly refreshedAt: string;
+}
+
+export interface ProductAssumption {
+  readonly sku: string;
+  readonly label: string;
+  readonly unitPriceCents: number;
+  readonly expectedConversionRate: number; // 0..1 of segment
+  readonly cogsCents?: number;
+}
+
+export interface CampaignRecommendationInput {
+  readonly opportunity: ArtistOpportunity;
+  readonly segmentSize: number;
+  readonly segmentName: string;
+  readonly products: readonly ProductAssumption[];
+  readonly channels: readonly CampaignChannel[];
+  readonly windowHours: number;
+  readonly now?: string;
+}
+
+export interface CampaignOption {
+  readonly id: string;
+  readonly title: string;
+  readonly whyNow: string;
+  readonly targetAudience: string;
+  readonly channels: readonly CampaignChannel[];
+  readonly productSku: string;
+  readonly productLabel: string;
+  readonly unitPriceCents: number;
+  readonly expectedOrders: number;
+  readonly expectedRevenueCents: number;
+  readonly expectedMarginCents: number | null;
+  readonly assumptions: readonly string[];
+  readonly confidence: number;
+  readonly rankScore: number;
+}
+
+export interface CampaignRecommendationResult {
+  readonly opportunityId: string;
+  readonly options: readonly CampaignOption[];
+  readonly generatedAt: string;
+}
+
+export interface DropRecord {
+  readonly id: string;
+  readonly campaignId: string;
+  readonly ownerProfileId: string;
+  readonly productSku: string;
+  readonly productLabel: string;
+  readonly priceCents: number;
+  readonly inventoryMode: 'unlimited' | 'limited';
+  readonly inventoryCount: number | null;
+  readonly fulfillment: 'print_on_demand' | 'manual' | 'digital';
+  readonly artworkAssetId: string | null;
+  readonly launchStartsAt: string;
+  readonly launchEndsAt: string;
+  readonly state: DropLifecycleState;
+  readonly productPageKey: string;
+  readonly previewUrl: string | null;
+}
+
+export interface DropTransitionResult {
+  readonly drop: DropRecord;
+  readonly previousState: DropLifecycleState;
+  readonly allowed: boolean;
+  readonly reason?: string;
+}
+
+export interface ApprovalStepRecord {
+  readonly id: ApprovalStepId;
+  readonly status: ApprovalStepStatus;
+  readonly attempt: number;
+  readonly output: Readonly<Record<string, unknown>> | null;
+  readonly error: string | null;
+  readonly updatedAt: string;
+}
+
+export interface ApprovalWorkflowState {
+  readonly workflowId: string;
+  readonly recommendationId: string;
+  readonly artistId: string;
+  readonly idempotencyKey: string;
+  readonly steps: readonly ApprovalStepRecord[];
+  readonly status: 'pending' | 'running' | 'completed' | 'failed' | 'partial';
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface CampaignEventCounters {
+  readonly clicks: number;
+  readonly purchases: number;
+  readonly replies: number;
+  readonly optIns: number;
+  readonly channelStatuses: Readonly<
+    Record<CampaignChannel, 'ok' | 'degraded' | 'off'>
+  >;
+}
+
+export interface CampaignHealthSnapshot {
+  readonly campaignId: string;
+  readonly status: CampaignHealthStatus;
+  readonly counters: CampaignEventCounters;
+  readonly conversionRate: number;
+  readonly capturedAt: string;
+  readonly paused: boolean;
+}
+
+export interface NextMoveRecommendation {
+  readonly id: string;
+  readonly kind: NextMoveKind;
+  readonly title: string;
+  readonly evidence: readonly string[];
+  readonly expectedImpact: string;
+  readonly confidence: number;
+}
+
+export interface ReleaseWorkflowTask {
+  readonly dedupeKey: string;
+  readonly title: string;
+  readonly category: string;
+  readonly dueDaysOffset: number;
+  readonly assigneeType: 'human' | 'ai_workflow';
+  readonly state: 'pending' | 'in_progress' | 'done' | 'skipped';
+}
+
+export interface ReleasePlaybookTemplate {
+  readonly id: string;
+  readonly version: string;
+  readonly name: string;
+  readonly tasks: readonly Omit<ReleaseWorkflowTask, 'dedupeKey' | 'state'>[];
+}
+
+export interface ReleaseWorkflowInstance {
+  readonly id: string;
+  readonly releaseId: string;
+  readonly playbookId: string;
+  readonly playbookVersion: string;
+  readonly tasks: readonly ReleaseWorkflowTask[];
+  readonly createdAt: string;
+}

--- a/apps/web/tests/components/organisms/RightDrawer.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/RightDrawer.interaction.test.tsx
@@ -50,7 +50,7 @@ describe('RightDrawer', () => {
     expect(aside).not.toHaveClass('border-l');
     expect(aside).not.toHaveClass('bg-surface-0');
     expect(aside).not.toHaveClass('lg:border');
-    expect(aside).not.toHaveClass('shadow-[var(--linear-app-drawer-shadow)]');
+    expect(aside).not.toHaveClass('shadow-(--linear-app-drawer-shadow)');
     expect(aside).toHaveClass('outline-none', 'focus:outline-none');
   });
 
@@ -173,7 +173,7 @@ describe('RightDrawer', () => {
     );
     expect(desktopAside).not.toHaveClass('lg:border');
     expect(desktopAside).not.toHaveClass(
-      'lg:rounded-[var(--linear-app-shell-radius)]'
+      'lg:rounded-(--linear-app-shell-radius)'
     );
     expect(desktopAside).toHaveStyle({ width: '420px' });
     expect(mockUseBreakpointDown).toHaveBeenCalledWith('lg');

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -423,7 +423,7 @@ describe('surface elevation guardrails', () => {
 
     expect(shellFrame).toContain('lg:shadow-(--linear-app-shell-shadow)');
     expect(shellFrame).toContain(
-      'lg:gap-[var(--linear-app-shell-gap)] lg:p-[var(--linear-app-shell-gap)]'
+      'lg:gap-(--linear-app-shell-gap) lg:p-(--linear-app-shell-gap)'
     );
     expect(linearTokens).toContain('--linear-app-sidebar-shadow:');
     expect(sidebar).not.toContain(

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -26,7 +26,7 @@ describe('AppShellFrame', () => {
     // strips the top corners now that the header lives inside the card.
     expect(mainContent).toHaveClass('lg:rounded-(--linear-app-shell-radius)');
     expect(mainContent.querySelector('div.flex.flex-1')).toHaveClass(
-      'lg:gap-[var(--linear-app-shell-gap)]'
+      'lg:gap-(--linear-app-shell-gap)'
     );
     expect(screen.getByText('Sidebar')).toBeInTheDocument();
     expect(screen.getByText('Main Content')).toBeInTheDocument();
@@ -68,10 +68,10 @@ describe('AppShellFrame', () => {
     );
     expect(mainContent).toHaveClass('lg:border-l');
     expect(mainContent).not.toHaveClass(
-      'lg:shadow-[var(--linear-app-shell-shadow)]'
+      'lg:shadow-(--linear-app-shell-shadow)'
     );
     expect(mainContent.querySelector('div.flex.flex-1')).not.toHaveClass(
-      'lg:gap-[var(--linear-app-shell-gap)]'
+      'lg:gap-(--linear-app-shell-gap)'
     );
   });
 


### PR DESCRIPTION
## Summary
Thin production domain for the founder demo campaign loop (`apps/web/lib/campaign-ops`):

| Issue | Module | MVP surface |
|-------|--------|-------------|
| JOV-2205 | `external-signals.ts` | Normalize event/commerce signals, dedupe, rank opportunities |
| JOV-2207 | `fan-segments.ts` | Segment predicates + preview size/samples/missing-data notes |
| JOV-2208 | `recommendations.ts` | Deterministic expected-order/revenue ranking (263 × $38 path) |
| JOV-2209 | `merch-drop-workflow.ts` | Draft-first drop lifecycle + idempotent product page keys |
| JOV-2210 | `approval-orchestrator.ts` | Idempotent multi-step approval with retry + partial status |
| JOV-2212 | `monitoring.ts` | Health snapshots + threshold next-move recommendations |
| JOV-2213 | `release-workflow.ts` | Versioned playbook expansion with task dedupe on re-import |

Pure TypeScript, no DB migration, no live payment. Ready for chat/inbox/workflow consumers to map into durable storage.

## Fixes
- Fixes JOV-2205
- Fixes JOV-2207
- Fixes JOV-2208
- Fixes JOV-2209
- Fixes JOV-2210
- Fixes JOV-2212
- Fixes JOV-2213

<!-- linear-issue-id:JOV-2205 -->

## Verification
- Biome: `biome check --write apps/web/lib/campaign-ops` (clean)
- Unit path: esbuild-bundled assert harness for `campaign-ops` — **11/11 passed** (Cosmic Gate → segment → rec → drop → approve → monitor + per-module cases)
- Vitest file co-located: `apps/web/lib/campaign-ops/campaign-ops.test.ts` (full vitest install was store-contended on agent host; harness + co-located vitest cover same contracts)

## Cost Impact
- **External API calls**: none (pure domain)
- **Monthly projection**: n/a
- **Scaling factor**: O(signals / members) in-memory only when called

## Out of scope / follow-ups
- Wiring into chat/opportunity-inbox UI and durable tables (next PRs)
- JOV-2183 long-tail marketing audit polish is **not** in this PR (taste/human decisions + separate surface)

## Test plan
- [x] Unit: EDC/Cosmic Gate dedupe → one opportunity
- [x] Unit: warm trance segment size + missing genre notes
- [x] Unit: 5260 × 5% × $38 = $9,994 revenue path
- [x] Unit: drop upsert idempotent; draft→preview
- [x] Unit: approval retry after partial failure
- [x] Unit: monitoring pause suppresses next-moves
- [x] Unit: repeated playbook import preserves task state / no dupes