### PR TITLE
test(profile): lock social hero icons (JOV-4103 missed-merge recovery)

### DIFF
--- a/apps/web/components/features/profile/profile-surface-state.test.ts
+++ b/apps/web/components/features/profile/profile-surface-state.test.ts
@@ -166,4 +166,45 @@ describe('resolveProfileSurfaceState', () => {
       }).hasTip
     ).toBe(false);
   });
+
+  // Regression: JOV-4103 — header social icons must surface when profile has
+  // Instagram/Twitter/etc. links (not only when the sparse empty case applies).
+  it('surfaces high-priority social platforms in the hero social row', () => {
+    const instagramLink = {
+      id: 'instagram',
+      artist_id: artist.id,
+      platform: 'instagram',
+      url: 'https://instagram.com/test',
+      clicks: 0,
+      created_at: '2026-01-01T00:00:00.000Z',
+    } satisfies LegacySocialLink;
+    const twitterLink = {
+      id: 'twitter',
+      artist_id: artist.id,
+      platform: 'twitter',
+      url: 'https://x.com/test',
+      clicks: 0,
+      created_at: '2026-01-01T00:00:00.000Z',
+    } satisfies LegacySocialLink;
+    const bandcampLink = {
+      id: 'bandcamp',
+      artist_id: artist.id,
+      platform: 'bandcamp',
+      url: 'https://test.bandcamp.com',
+      clicks: 0,
+      created_at: '2026-01-01T00:00:00.000Z',
+    } satisfies LegacySocialLink;
+
+    const state = resolveProfileSurfaceState({
+      artist,
+      socialLinks: [bandcampLink, twitterLink, instagramLink, spotifyLink],
+      hasPlayableDestinations: true,
+      activeSubtitle: 'Artist profile',
+    });
+
+    expect(state.visibleSocialLinks.map(link => link.platform)).toEqual([
+      'instagram',
+      'twitter',
+    ]);
+  });
 });

--- a/apps/web/components/features/profile/templates/ProfileDesktopSurface.test.tsx
+++ b/apps/web/components/features/profile/templates/ProfileDesktopSurface.test.tsx
@@ -208,4 +208,55 @@ describe('ProfileDesktopSurface', () => {
     expect(screen.getByTestId('mock-static-listen-interface')).toBeVisible();
     expect(screen.getByRole('button', { name: 'Spotify' })).toBeVisible();
   });
+
+  // Regression: JOV-4103 — desktop hero must render social media icons.
+  it('renders hero social icons when Instagram and Twitter links are present', () => {
+    render(
+      <ProfileDesktopSurface
+        artist={artist}
+        socialLinks={[
+          {
+            id: 'ig-1',
+            artist_id: artist.id,
+            platform: 'instagram',
+            url: 'https://instagram.com/timwhite',
+            clicks: 0,
+            created_at: '2026-01-01T00:00:00.000Z',
+          },
+          {
+            id: 'tw-1',
+            artist_id: artist.id,
+            platform: 'twitter',
+            url: 'https://x.com/timwhite',
+            clicks: 0,
+            created_at: '2026-01-01T00:00:00.000Z',
+          },
+        ]}
+        contacts={contacts}
+        photoDownloadSizes={[]}
+        drawerOpen={false}
+        drawerView='menu'
+        activeMode='profile'
+        onModeSelect={vi.fn()}
+        onDrawerOpenChange={vi.fn()}
+        onDrawerViewChange={vi.fn()}
+        onOpenMenu={vi.fn()}
+        onPlayClick={vi.fn()}
+        profileHref='/timwhite'
+        isSubscribed={false}
+        contentPrefs={contentPrefs}
+        onTogglePref={vi.fn()}
+        onUnsubscribe={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('link', { name: 'instagram' })).toHaveAttribute(
+      'href',
+      'https://instagram.com/timwhite'
+    );
+    expect(screen.getByRole('link', { name: 'twitter' })).toHaveAttribute(
+      'href',
+      'https://x.com/timwhite'
+    );
+  });
 });

--- a/apps/web/tests/unit/profile/profile-compact-template.test.tsx
+++ b/apps/web/tests/unit/profile/profile-compact-template.test.tsx
@@ -335,6 +335,49 @@ describe('ProfileCompactTemplate', () => {
     expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
   });
 
+  // Regression: JOV-4103 — public profile hero must show social media icons
+  // when the artist has Instagram/Twitter links (missed-ship recovery).
+  it('renders hero social icons for Instagram and Twitter profile links', async () => {
+    render(
+      <ProfileCompactTemplate
+        mode='profile'
+        artist={mockArtist}
+        socialLinks={[
+          {
+            id: 'ig-1',
+            artist_id: mockArtist.id,
+            platform: 'instagram',
+            url: 'https://instagram.com/test-artist',
+            clicks: 0,
+            created_at: '2026-01-01T00:00:00.000Z',
+          },
+          {
+            id: 'tw-1',
+            artist_id: mockArtist.id,
+            platform: 'twitter',
+            url: 'https://x.com/test-artist',
+            clicks: 0,
+            created_at: '2026-01-01T00:00:00.000Z',
+          },
+        ]}
+        contacts={[]}
+      />
+    );
+
+    const socialRow = await screen.findByTestId('profile-hero-social-row');
+    expect(socialRow).toBeInTheDocument();
+
+    const instagram = within(socialRow).getByRole('link', {
+      name: 'instagram',
+    });
+    const twitter = within(socialRow).getByRole('link', { name: 'twitter' });
+    expect(instagram).toHaveAttribute(
+      'href',
+      'https://instagram.com/test-artist'
+    );
+    expect(twitter).toHaveAttribute('href', 'https://x.com/test-artist');
+  });
+
   it('links the artist name back to the canonical profile route', async () => {
     render(
       <ProfileCompactTemplate


### PR DESCRIPTION
## Summary
- Confirms public profile social media icons already render via `SocialIcon` in compact + desktop heroes when high-priority social links exist
- Adds regression tests so the missed-ship gap (built locally, never pushed) cannot recur silently
- **JOV-4102** closed separately: profile image download `q=90→100` already shipped in **#10836** / JOV-2163

## Investigation
| Issue | Finding |
|---|---|
| JOV-4102 (PR #8512) | Closed PR body claimed q=90→100, but diff was only ChatInput styling. Real fix landed as #10836 on 2026-06-13. |
| JOV-4103 social icons | Already implemented in `ProfileCompactSurface` (`profile-hero-social-row`) and `ProfileDesktopSurface` using `getHeaderSocialLinks` + `SocialIcon`. |

## Test plan
- [x] `avatar-sizes.test.ts` (JOV-4102 evidence) — 7/7 pass
- [x] `profile-surface-state.test.ts` — 5/5 pass (includes new hero social prioritization case)
- [ ] CI: compact + desktop surface tests (local monorepo thrash blocked full React suite)

## Verification
```
pnpm --filter @jovie/web exec vitest run \
  components/features/profile/profile-surface-state.test.ts \
  tests/unit/lib/utils/avatar-sizes.test.ts
```

Fixes JOV-4103
<!-- linear-issue-id:818b47d8-e63b-4b81-8c85-ef04d0248c45 -->

## Cost Impact
- None (tests only)