### PR TITLE
feat(admin): revenue-lift dashboard from canonical metrics (JOV-3619)

### DIFF
--- a/apps/web/app/app/(shell)/admin/revenue-lift/RevenueLiftDashboardView.tsx
+++ b/apps/web/app/app/(shell)/admin/revenue-lift/RevenueLiftDashboardView.tsx
@@ -1,0 +1,340 @@
+import { formatUsd } from '@/lib/admin/format';
+import { formatSourceFreshness, isSourceStale } from '@/lib/hud/source-trust';
+import type { RevenueLiftDashboardData } from '@/lib/metrics/revenue-lift-dashboard';
+import { formatAmount } from '@/lib/utils/format-number';
+
+interface RevenueLiftDashboardViewProps {
+  readonly data: RevenueLiftDashboardData;
+}
+
+function SourceLine({
+  source,
+}: Readonly<{
+  source: RevenueLiftDashboardData['irpaaSource'];
+}>) {
+  const stale = isSourceStale(source.fetchedAtIso);
+  return (
+    <p className='mt-2 min-h-5 text-2xs leading-4 text-tertiary-token'>
+      <span className='font-medium text-secondary-token'>{source.label}</span>
+      {' · '}
+      {source.state === 'unavailable'
+        ? (source.errorMessage ?? 'Unavailable')
+        : source.state === 'no_data'
+          ? 'No data'
+          : stale
+            ? `Stale · updated ${formatSourceFreshness(source.fetchedAtIso)}`
+            : `Updated ${formatSourceFreshness(source.fetchedAtIso)}`}
+      <span className='block truncate' title={source.source}>
+        Source: {source.source}
+      </span>
+    </p>
+  );
+}
+
+function KpiTile({
+  tile,
+}: Readonly<{
+  tile: RevenueLiftDashboardData['kpiTree'][number];
+}>) {
+  return (
+    <div
+      className='rounded-md border border-subtle bg-surface-1 p-4'
+      data-testid={`revenue-lift-kpi-${tile.id}`}
+    >
+      <div className='flex items-start justify-between gap-2'>
+        <p className='text-xs font-medium text-secondary-token'>{tile.label}</p>
+        <span className='rounded bg-surface-0 px-1.5 py-0.5 text-2xs font-medium text-tertiary-token'>
+          Tier {tile.tier}
+        </span>
+      </div>
+      <p className='mt-2 min-h-8 text-2xl font-semibold tracking-tight text-primary-token'>
+        {tile.valueLabel}
+      </p>
+      <p className='mt-1 min-h-8 text-xs text-secondary-token'>{tile.signal}</p>
+      <SourceLine source={tile.source} />
+    </div>
+  );
+}
+
+export function RevenueLiftDashboardView({
+  data,
+}: RevenueLiftDashboardViewProps) {
+  const irpaa = data.irpaa;
+  const prior = data.irpaaPrior;
+  const deltaCents =
+    irpaa && prior ? irpaa.irpaaCents - prior.irpaaCents : null;
+  const deltaLabel =
+    deltaCents == null
+      ? null
+      : `${deltaCents >= 0 ? '+' : ''}${formatAmount(deltaCents)} vs prior 30d`;
+
+  return (
+    <div className='space-y-6' data-testid='revenue-lift-dashboard'>
+      {/* North Star hero */}
+      <section
+        className='rounded-md border border-subtle bg-surface-1 p-5'
+        data-testid='revenue-lift-irpaa-hero'
+        aria-labelledby='revenue-lift-irpaa-heading'
+      >
+        <p className='text-xs font-medium text-secondary-token'>
+          North Star · Tier A
+        </p>
+        <h2
+          id='revenue-lift-irpaa-heading'
+          className='mt-1 text-sm font-medium text-primary-token'
+        >
+          Incremental Revenue per Active Artist (IRPAA)
+        </h2>
+        <p className='mt-3 min-h-10 text-4xl font-semibold tracking-tight text-primary-token'>
+          {irpaa ? formatAmount(irpaa.irpaaCents) : '—'}
+        </p>
+        <p className='mt-1 min-h-5 text-sm text-secondary-token'>
+          {deltaLabel ?? 'Prior-window comparison unavailable'}
+          {irpaa
+            ? ` · ${irpaa.activeArtists} active artists · ${irpaa.runCount} automation runs`
+            : null}
+        </p>
+        <p className='mt-2 text-xs text-secondary-token'>
+          Total lift {irpaa ? formatAmount(irpaa.totalRevenueLiftCents) : '—'}{' '}
+          over the rolling 30-day window. Weights{' '}
+          {irpaa?.weights.version ?? '—'}
+          {irpaa?.weights.lastValidatedAt
+            ? ` (validated ${irpaa.weights.lastValidatedAt})`
+            : ''}
+          .
+        </p>
+        <SourceLine source={data.irpaaSource} />
+      </section>
+
+      {/* KPI tree */}
+      <section aria-labelledby='revenue-lift-kpi-heading'>
+        <h2
+          id='revenue-lift-kpi-heading'
+          className='mb-3 text-sm font-medium text-primary-token'
+        >
+          KPI Tree
+        </h2>
+        <div className='grid gap-3 sm:grid-cols-2 xl:grid-cols-4'>
+          {data.kpiTree
+            .filter(t => t.id !== 'irpaa')
+            .map(tile => (
+              <KpiTile key={tile.id} tile={tile} />
+            ))}
+        </div>
+      </section>
+
+      {/* Metric → Signal → VC Interpretation */}
+      <section aria-labelledby='revenue-lift-map-heading'>
+        <h2
+          id='revenue-lift-map-heading'
+          className='mb-3 text-sm font-medium text-primary-token'
+        >
+          Metric → Signal → VC Interpretation
+        </h2>
+        <div className='overflow-x-auto rounded-md border border-subtle bg-surface-1'>
+          <table className='w-full min-w-[40rem] text-left text-sm'>
+            <thead className='border-b border-subtle bg-(--linear-app-content-surface) text-xs text-secondary-token'>
+              <tr>
+                <th className='px-3 py-2 font-medium'>Metric</th>
+                <th className='px-3 py-2 font-medium'>Value</th>
+                <th className='px-3 py-2 font-medium'>Signal</th>
+                <th className='px-3 py-2 font-medium'>VC Interpretation</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.interpretationTable.map(row => (
+                <tr
+                  key={row.id}
+                  className='border-b border-subtle last:border-0'
+                  data-testid={`revenue-lift-map-${row.id}`}
+                >
+                  <td className='px-3 py-2 align-top font-medium text-primary-token'>
+                    {row.label}
+                    <span className='mt-0.5 block text-2xs font-normal text-tertiary-token'>
+                      Tier {row.tier}
+                    </span>
+                  </td>
+                  <td className='px-3 py-2 align-top text-primary-token'>
+                    {row.valueLabel}
+                  </td>
+                  <td className='px-3 py-2 align-top text-secondary-token'>
+                    {row.signal}
+                    <span className='mt-0.5 block text-2xs text-tertiary-token'>
+                      {row.source.source}
+                    </span>
+                  </td>
+                  <td className='px-3 py-2 align-top text-secondary-token'>
+                    {row.vcInterpretation}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Cohort strip */}
+      <section aria-labelledby='revenue-lift-cohort-heading'>
+        <h2
+          id='revenue-lift-cohort-heading'
+          className='mb-3 text-sm font-medium text-primary-token'
+        >
+          Per-Artist Cohort
+        </h2>
+        <div className='mb-3 grid gap-3 sm:grid-cols-2'>
+          <div className='rounded-md border border-subtle bg-surface-1 p-4'>
+            <p className='text-xs font-medium text-secondary-token'>
+              Jovie Active
+            </p>
+            <p className='mt-1 text-2xl font-semibold text-primary-token'>
+              {data.cohorts.activeCount}
+            </p>
+            <p className='mt-1 text-xs text-secondary-token'>
+              Median lift{' '}
+              {data.cohorts.activeMedianLiftCents != null
+                ? formatAmount(data.cohorts.activeMedianLiftCents)
+                : '—'}
+            </p>
+          </div>
+          <div className='rounded-md border border-subtle bg-surface-1 p-4'>
+            <p className='text-xs font-medium text-secondary-token'>Control</p>
+            <p className='mt-1 text-2xl font-semibold text-primary-token'>
+              {data.cohorts.controlCount}
+            </p>
+            <p className='mt-1 text-xs text-secondary-token'>
+              Median lift{' '}
+              {data.cohorts.controlMedianLiftCents != null
+                ? formatAmount(data.cohorts.controlMedianLiftCents)
+                : '—'}
+            </p>
+          </div>
+        </div>
+        <SourceLine source={data.cohorts.source} />
+        <div className='mt-3 overflow-x-auto rounded-md border border-subtle bg-surface-1'>
+          <table className='w-full min-w-[32rem] text-left text-sm'>
+            <thead className='border-b border-subtle bg-(--linear-app-content-surface) text-xs text-secondary-token'>
+              <tr>
+                <th className='px-3 py-2 font-medium'>User</th>
+                <th className='px-3 py-2 font-medium'>Cohort</th>
+                <th className='px-3 py-2 font-medium'>Signal</th>
+                <th className='px-3 py-2 font-medium'>Baseline</th>
+                <th className='px-3 py-2 font-medium'>Lift</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.cohorts.rows.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className='px-3 py-6 text-center text-secondary-token'
+                  >
+                    No cohort rows yet. Artists are tagged when automation
+                    outcomes land.
+                  </td>
+                </tr>
+              ) : (
+                data.cohorts.rows.map(row => (
+                  <tr
+                    key={row.userId}
+                    className='border-b border-subtle last:border-0'
+                  >
+                    <td className='px-3 py-2 font-mono text-xs text-primary-token'>
+                      {row.userId.slice(0, 12)}…
+                    </td>
+                    <td className='px-3 py-2 text-secondary-token'>
+                      {row.cohort === 'jovie_active' ? 'Active' : 'Control'}
+                    </td>
+                    <td className='px-3 py-2 text-primary-token'>
+                      {row.signal
+                        ? formatAmount(row.signal.revenueSignalCents)
+                        : '—'}
+                    </td>
+                    <td className='px-3 py-2 text-secondary-token'>
+                      {formatAmount(row.baselineRevenueSignalCents)}
+                    </td>
+                    <td className='px-3 py-2 text-primary-token'>
+                      {row.liftCents != null
+                        ? formatAmount(row.liftCents)
+                        : '—'}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Multi-agent contribution */}
+      <section aria-labelledby='revenue-lift-agents-heading'>
+        <h2
+          id='revenue-lift-agents-heading'
+          className='mb-3 text-sm font-medium text-primary-token'
+        >
+          Multi-Agent Contribution
+        </h2>
+        <div className='overflow-x-auto rounded-md border border-subtle bg-surface-1'>
+          <table className='w-full min-w-[36rem] text-left text-sm'>
+            <thead className='border-b border-subtle bg-(--linear-app-content-surface) text-xs text-secondary-token'>
+              <tr>
+                <th className='px-3 py-2 font-medium'>Agent</th>
+                <th className='px-3 py-2 font-medium'>Tasks</th>
+                <th className='px-3 py-2 font-medium'>Success</th>
+                <th className='px-3 py-2 font-medium'>Override</th>
+                <th className='px-3 py-2 font-medium'>Cost / Opp</th>
+                <th className='px-3 py-2 font-medium'>Total Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.agents.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className='px-3 py-6 text-center text-secondary-token'
+                  >
+                    No workflow_step_results in the last 30 days.
+                  </td>
+                </tr>
+              ) : (
+                data.agents.map(agent => (
+                  <tr
+                    key={agent.agent}
+                    className='border-b border-subtle last:border-0'
+                    data-testid={`revenue-lift-agent-${agent.agent}`}
+                  >
+                    <td className='px-3 py-2 font-medium text-primary-token'>
+                      {agent.agent}
+                    </td>
+                    <td className='px-3 py-2 text-secondary-token'>
+                      {agent.totalTasks}
+                    </td>
+                    <td className='px-3 py-2 text-secondary-token'>
+                      {(agent.successRate * 100).toFixed(1)}%
+                    </td>
+                    <td className='px-3 py-2 text-secondary-token'>
+                      {(agent.humanOverrideRate * 100).toFixed(1)}%
+                    </td>
+                    <td className='px-3 py-2 text-secondary-token'>
+                      {agent.costPerOpportunityUsd != null
+                        ? formatUsd(agent.costPerOpportunityUsd)
+                        : '—'}
+                    </td>
+                    <td className='px-3 py-2 text-secondary-token'>
+                      {formatUsd(agent.totalCostUsd)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+        <SourceLine source={data.agentsSource} />
+      </section>
+
+      <p className='text-2xs text-tertiary-token'>
+        Generated {formatSourceFreshness(data.generatedAtIso)}. Proxy terms
+        always carry the weights version; see docs/REVENUE_LIFT_METRICS.md.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/app/(shell)/admin/revenue-lift/RevenueLiftDashboardView.tsx
+++ b/apps/web/app/app/(shell)/admin/revenue-lift/RevenueLiftDashboardView.tsx
@@ -83,7 +83,7 @@ export function RevenueLiftDashboardView({
           id='revenue-lift-irpaa-heading'
           className='mt-1 text-sm font-medium text-primary-token'
         >
-          Incremental Revenue per Active Artist (IRPAA)
+          Incremental Revenue Per Active Artist (IRPAA)
         </h2>
         <p className='mt-3 min-h-10 text-4xl font-semibold tracking-tight text-primary-token'>
           {irpaa ? formatAmount(irpaa.irpaaCents) : '—'}
@@ -133,7 +133,7 @@ export function RevenueLiftDashboardView({
         </h2>
         <div className='overflow-x-auto rounded-md border border-subtle bg-surface-1'>
           <table className='w-full min-w-[40rem] text-left text-sm'>
-            <thead className='border-b border-subtle bg-(--linear-app-content-surface) text-xs text-secondary-token'>
+            <thead className='border-b border-subtle bg-surface-0 text-xs text-secondary-token'>
               <tr>
                 <th className='px-3 py-2 font-medium'>Metric</th>
                 <th className='px-3 py-2 font-medium'>Value</th>
@@ -179,7 +179,7 @@ export function RevenueLiftDashboardView({
           id='revenue-lift-cohort-heading'
           className='mb-3 text-sm font-medium text-primary-token'
         >
-          Per-Artist Cohort
+          Per Artist Cohort
         </h2>
         <div className='mb-3 grid gap-3 sm:grid-cols-2'>
           <div className='rounded-md border border-subtle bg-surface-1 p-4'>
@@ -212,7 +212,7 @@ export function RevenueLiftDashboardView({
         <SourceLine source={data.cohorts.source} />
         <div className='mt-3 overflow-x-auto rounded-md border border-subtle bg-surface-1'>
           <table className='w-full min-w-[32rem] text-left text-sm'>
-            <thead className='border-b border-subtle bg-(--linear-app-content-surface) text-xs text-secondary-token'>
+            <thead className='border-b border-subtle bg-surface-0 text-xs text-secondary-token'>
               <tr>
                 <th className='px-3 py-2 font-medium'>User</th>
                 <th className='px-3 py-2 font-medium'>Cohort</th>
@@ -265,17 +265,17 @@ export function RevenueLiftDashboardView({
         </div>
       </section>
 
-      {/* Multi-agent contribution */}
+      {/* Multi agent contribution */}
       <section aria-labelledby='revenue-lift-agents-heading'>
         <h2
           id='revenue-lift-agents-heading'
           className='mb-3 text-sm font-medium text-primary-token'
         >
-          Multi-Agent Contribution
+          Multi Agent Contribution
         </h2>
         <div className='overflow-x-auto rounded-md border border-subtle bg-surface-1'>
           <table className='w-full min-w-[36rem] text-left text-sm'>
-            <thead className='border-b border-subtle bg-(--linear-app-content-surface) text-xs text-secondary-token'>
+            <thead className='border-b border-subtle bg-surface-0 text-xs text-secondary-token'>
               <tr>
                 <th className='px-3 py-2 font-medium'>Agent</th>
                 <th className='px-3 py-2 font-medium'>Tasks</th>

--- a/apps/web/app/app/(shell)/admin/revenue-lift/page.tsx
+++ b/apps/web/app/app/(shell)/admin/revenue-lift/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from 'next';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
+import { captureError } from '@/lib/error-tracking';
+import { loadRevenueLiftDashboard } from '@/lib/metrics/revenue-lift-dashboard';
+import { NOINDEX_ROBOTS } from '@/lib/seo/noindex-metadata';
+import { RevenueLiftDashboardView } from './RevenueLiftDashboardView';
+
+export const metadata: Metadata = {
+  title: 'Revenue Lift | Admin',
+  description:
+    'North Star IRPAA + KPI tree from the canonical metrics layer (ops/VC).',
+  robots: NOINDEX_ROBOTS,
+};
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export default async function AdminRevenueLiftPage() {
+  let data: Awaited<ReturnType<typeof loadRevenueLiftDashboard>> | null = null;
+
+  try {
+    data = await loadRevenueLiftDashboard();
+  } catch (error) {
+    await captureError('Admin revenue-lift dashboard failed to load', error, {
+      route: 'admin/revenue-lift',
+    });
+  }
+
+  return (
+    <AdminPage
+      title='Revenue Lift'
+      description='North Star IRPAA and KPI tree from the canonical metrics layer. Internal ops / VC surface — every tile names its source.'
+      testId='admin-revenue-lift-page'
+      viewTestId='admin-revenue-lift-content'
+    >
+      {data ? (
+        <RevenueLiftDashboardView data={data} />
+      ) : (
+        <div
+          className='rounded-md border border-subtle bg-surface-1 px-4 py-6 text-sm text-secondary-token'
+          data-testid='admin-revenue-lift-error'
+        >
+          Could not load revenue-lift metrics. Check server logs and
+          workflow_run_outcomes availability.
+        </div>
+      )}
+    </AdminPage>
+  );
+}

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -23,6 +23,7 @@ import {
   Share2,
   ShieldCheck,
   SquarePen,
+  TrendingUp,
   UserCircle,
   Users,
 } from 'lucide-react';
@@ -232,6 +233,7 @@ const adminIconById: Record<AdminWorkspaceId, LucideIcon> = {
   investors: Briefcase,
   screenshots: ImageIcon,
   costs: Banknote,
+  revenue_lift: TrendingUp,
   share_studio: Share2,
   system_map: Map,
   features: Flag,

--- a/apps/web/constants/admin-navigation.ts
+++ b/apps/web/constants/admin-navigation.ts
@@ -38,6 +38,7 @@ export type AdminWorkspaceId =
   | 'investors'
   | 'screenshots'
   | 'costs'
+  | 'revenue_lift'
   | 'share_studio'
   | 'system_map'
   | 'features';
@@ -66,6 +67,7 @@ export const ADMIN_SETTINGS_TOOL_IDS = [
   'screenshots',
   'share_studio',
   'costs',
+  'revenue_lift',
   'system_map',
   'features',
 ] as const satisfies readonly AdminWorkspaceId[];
@@ -133,6 +135,14 @@ export const ADMIN_NAV_REGISTRY: readonly AdminNavRegistryItem[] = [
     href: APP_ROUTES.ADMIN_COSTS,
     description:
       'Company infra, AI gateway, Neon, and vendor spend (30-day view)',
+    section: 'utilities',
+  },
+  {
+    id: 'revenue_lift',
+    label: 'Revenue Lift',
+    href: APP_ROUTES.ADMIN_REVENUE_LIFT,
+    description:
+      'IRPAA North Star, KPI tree, cohort lift, multi-agent contribution',
     section: 'utilities',
   },
   {

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -114,6 +114,8 @@ export const APP_ROUTES = {
   ADMIN_AGENT_RUN: '/app/admin/agent-runs',
   ADMIN_AGENT_RUN_DETAIL: '/app/admin/agent-runs/[id]',
   ADMIN_COSTS: '/app/admin/costs',
+  /** VC/ops revenue-lift dashboard (IRPAA North Star + KPI tree). */
+  ADMIN_REVENUE_LIFT: '/app/admin/revenue-lift',
   ADMIN_SYSTEM: '/app/admin/system',
   ADMIN_FEATURES: '/app/admin/features',
   FEATURE_FLAGS: '/app/feature-flags',

--- a/apps/web/lib/metrics/revenue-lift-dashboard.test.ts
+++ b/apps/web/lib/metrics/revenue-lift-dashboard.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Pure presentation helpers for the revenue-lift dashboard.
+ * Loader integration is covered via mocked DB tests on irpaa / cohorts.
+ */
+
+function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return Math.round((sorted[mid - 1]! + sorted[mid]!) / 2);
+  }
+  return sorted[mid]!;
+}
+
+describe('revenue-lift dashboard helpers', () => {
+  it('computes median for odd and even lengths', () => {
+    expect(median([])).toBeNull();
+    expect(median([10])).toBe(10);
+    expect(median([10, 30, 20])).toBe(20);
+    expect(median([10, 20, 30, 40])).toBe(25);
+  });
+
+  it('keeps IRPAA as the sole Tier A id in the interpretation map shape', () => {
+    const ids = [
+      'irpaa',
+      'gmv-lift',
+      'dsp-clicks',
+      'new-fans',
+      'cohort-lift',
+      'cycle-time',
+      'agent-success',
+      'human-override',
+    ] as const;
+    expect(ids.filter(id => id === 'irpaa')).toHaveLength(1);
+    expect(ids[0]).toBe('irpaa');
+  });
+});

--- a/apps/web/lib/metrics/revenue-lift-dashboard.ts
+++ b/apps/web/lib/metrics/revenue-lift-dashboard.ts
@@ -1,0 +1,392 @@
+/**
+ * VC/ops revenue-lift dashboard loader (JOV-3619).
+ *
+ * Aggregates the North Star (IRPAA) + KPI tree + cohort strip + multi-agent
+ * contribution from the canonical metrics modules — zero inline formula
+ * duplication. Every tile carries a data-source label + fetch timestamp.
+ */
+
+import 'server-only';
+
+import { getAgentTaskMetrics } from '@/lib/analytics/agent-task-metrics';
+import { getOpportunityCycleTime } from '@/lib/analytics/opportunity-cycle-time';
+import {
+  type ArtistCohortRevenueRow,
+  listArtistCohortRevenueRows,
+} from '@/lib/metrics/artist-revenue-cohorts';
+import {
+  getIRPAA,
+  getRolling30DayIRPAA,
+  type IrpaaResult,
+} from '@/lib/metrics/irpaa';
+import { getRevenueLiftWeightsSnapshot } from '@/lib/metrics/revenue-lift-weights';
+import { logger } from '@/lib/utils/logger';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface MetricSourceMeta {
+  readonly label: string;
+  readonly source: string;
+  readonly fetchedAtIso: string;
+  readonly state: 'ok' | 'no_data' | 'unavailable';
+  readonly errorMessage: string | null;
+}
+
+export interface RevenueLiftKpiTile {
+  readonly id: string;
+  readonly tier: 'A' | 'B' | 'C';
+  readonly label: string;
+  readonly valueLabel: string;
+  readonly signal: string;
+  readonly vcInterpretation: string;
+  readonly source: MetricSourceMeta;
+}
+
+export interface CohortSummary {
+  readonly activeCount: number;
+  readonly controlCount: number;
+  readonly activeMedianLiftCents: number | null;
+  readonly controlMedianLiftCents: number | null;
+  readonly rows: readonly ArtistCohortRevenueRow[];
+  readonly source: MetricSourceMeta;
+}
+
+export interface AgentContributionRow {
+  readonly agent: string;
+  readonly totalTasks: number;
+  readonly successRate: number;
+  readonly humanOverrideRate: number;
+  readonly costPerOpportunityUsd: number | null;
+  readonly totalCostUsd: number;
+}
+
+export interface RevenueLiftDashboardData {
+  readonly generatedAtIso: string;
+  readonly irpaa: IrpaaResult | null;
+  readonly irpaaPrior: IrpaaResult | null;
+  readonly irpaaSource: MetricSourceMeta;
+  readonly kpiTree: readonly RevenueLiftKpiTile[];
+  readonly interpretationTable: readonly RevenueLiftKpiTile[];
+  readonly cohorts: CohortSummary;
+  readonly agents: readonly AgentContributionRow[];
+  readonly agentsSource: MetricSourceMeta;
+}
+
+function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return Math.round((sorted[mid - 1]! + sorted[mid]!) / 2);
+  }
+  return sorted[mid]!;
+}
+
+function sourceOk(
+  label: string,
+  source: string,
+  fetchedAtIso: string,
+  hasData: boolean
+): MetricSourceMeta {
+  return {
+    label,
+    source,
+    fetchedAtIso,
+    state: hasData ? 'ok' : 'no_data',
+    errorMessage: null,
+  };
+}
+
+function sourceUnavailable(
+  label: string,
+  source: string,
+  fetchedAtIso: string,
+  error: unknown
+): MetricSourceMeta {
+  return {
+    label,
+    source,
+    fetchedAtIso,
+    state: 'unavailable',
+    errorMessage: error instanceof Error ? error.message : String(error),
+  };
+}
+
+function formatCents(cents: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: cents >= 100_00 ? 0 : 2,
+  }).format(cents / 100);
+}
+
+function formatRate(rate: number): string {
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+function formatMs(ms: number | null): string {
+  if (ms == null) return '—';
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
+/**
+ * Load the full revenue-lift dashboard snapshot for a rolling window.
+ * Failures on secondary tiles degrade to empty + unavailable source meta;
+ * IRPAA remains the hero path.
+ */
+export async function loadRevenueLiftDashboard(
+  now: Date = new Date()
+): Promise<RevenueLiftDashboardData> {
+  const fetchedAtIso = now.toISOString();
+  const window30 = {
+    start: new Date(now.getTime() - 30 * MS_PER_DAY),
+    end: now,
+  };
+  const windowPrior = {
+    start: new Date(now.getTime() - 60 * MS_PER_DAY),
+    end: new Date(now.getTime() - 30 * MS_PER_DAY),
+  };
+
+  let irpaa: IrpaaResult | null = null;
+  let irpaaPrior: IrpaaResult | null = null;
+  let irpaaSource: MetricSourceMeta;
+
+  try {
+    [irpaa, irpaaPrior] = await Promise.all([
+      getRolling30DayIRPAA(now),
+      getIRPAA(windowPrior),
+    ]);
+    irpaaSource = sourceOk(
+      'IRPAA',
+      'getRolling30DayIRPAA → workflow_run_outcomes + revenue-lift-weights',
+      fetchedAtIso,
+      irpaa.activeArtists > 0 || irpaa.runCount > 0
+    );
+  } catch (error) {
+    logger.error('[revenue-lift-dashboard] IRPAA load failed', error);
+    irpaaSource = sourceUnavailable(
+      'IRPAA',
+      'getRolling30DayIRPAA → workflow_run_outcomes + revenue-lift-weights',
+      fetchedAtIso,
+      error
+    );
+  }
+
+  let cohortRows: ArtistCohortRevenueRow[] = [];
+  let cohortSource: MetricSourceMeta;
+  try {
+    cohortRows = await listArtistCohortRevenueRows({ window: window30 });
+    cohortSource = sourceOk(
+      'Artist cohorts',
+      'listArtistCohortRevenueRows → artist_revenue_cohorts + revenue signals',
+      fetchedAtIso,
+      cohortRows.length > 0
+    );
+  } catch (error) {
+    logger.error('[revenue-lift-dashboard] cohort load failed', error);
+    cohortSource = sourceUnavailable(
+      'Artist cohorts',
+      'listArtistCohortRevenueRows → artist_revenue_cohorts + revenue signals',
+      fetchedAtIso,
+      error
+    );
+  }
+
+  const activeRows = cohortRows.filter(r => r.cohort === 'jovie_active');
+  const controlRows = cohortRows.filter(r => r.cohort === 'control');
+  const activeLifts = activeRows
+    .map(r => r.liftCents)
+    .filter((v): v is number => v != null);
+  const controlLifts = controlRows
+    .map(r => r.liftCents)
+    .filter((v): v is number => v != null);
+
+  const cohorts: CohortSummary = {
+    activeCount: activeRows.length,
+    controlCount: controlRows.length,
+    activeMedianLiftCents: median(activeLifts),
+    controlMedianLiftCents: median(controlLifts),
+    rows: cohortRows.slice(0, 50),
+    source: cohortSource,
+  };
+
+  let agents: AgentContributionRow[] = [];
+  let agentsSource: MetricSourceMeta;
+  try {
+    const metrics = await getAgentTaskMetrics({
+      since: window30.start,
+      until: window30.end,
+    });
+    agents = metrics.map(m => ({
+      agent: m.agent,
+      totalTasks: m.totalTasks,
+      successRate: m.successRate,
+      humanOverrideRate: m.humanOverrideRate,
+      costPerOpportunityUsd: m.costPerOpportunityUsd,
+      totalCostUsd: m.totalCostUsd,
+    }));
+    agentsSource = sourceOk(
+      'Multi-agent contribution',
+      'getAgentTaskMetrics → workflow_step_results',
+      fetchedAtIso,
+      agents.length > 0
+    );
+  } catch (error) {
+    logger.error('[revenue-lift-dashboard] agent metrics failed', error);
+    agentsSource = sourceUnavailable(
+      'Multi-agent contribution',
+      'getAgentTaskMetrics → workflow_step_results',
+      fetchedAtIso,
+      error
+    );
+  }
+
+  let medianCycleMs: number | null = null;
+  let cycleSource: MetricSourceMeta;
+  try {
+    const cycleRows = await getOpportunityCycleTime({
+      since: window30.start,
+      until: window30.end,
+    });
+    const allMedians = cycleRows.map(r => r.medianCycleTimeMs);
+    medianCycleMs = median(allMedians);
+    cycleSource = sourceOk(
+      'Opportunity cycle time',
+      'getOpportunityCycleTime → suggested_actions × workflow_runs',
+      fetchedAtIso,
+      cycleRows.length > 0
+    );
+  } catch (error) {
+    logger.error('[revenue-lift-dashboard] cycle time failed', error);
+    cycleSource = sourceUnavailable(
+      'Opportunity cycle time',
+      'getOpportunityCycleTime → suggested_actions × workflow_runs',
+      fetchedAtIso,
+      error
+    );
+  }
+
+  const weights = getRevenueLiftWeightsSnapshot();
+  const totalOverrideRate =
+    agents.length > 0
+      ? agents.reduce((s, a) => s + a.humanOverrideRate * a.totalTasks, 0) /
+        Math.max(
+          1,
+          agents.reduce((s, a) => s + a.totalTasks, 0)
+        )
+      : 0;
+  const totalSuccessRate =
+    agents.length > 0
+      ? agents.reduce((s, a) => s + a.successRate * a.totalTasks, 0) /
+        Math.max(
+          1,
+          agents.reduce((s, a) => s + a.totalTasks, 0)
+        )
+      : 0;
+
+  const kpiTree: RevenueLiftKpiTile[] = [
+    {
+      id: 'irpaa',
+      tier: 'A',
+      label: 'IRPAA (30d)',
+      valueLabel: irpaa ? formatCents(irpaa.irpaaCents) : '—',
+      signal: irpaa
+        ? `${irpaa.activeArtists} active artists · ${irpaa.runCount} runs · weights ${weights.version}`
+        : 'No IRPAA snapshot',
+      vcInterpretation:
+        'North Star: incremental revenue per active artist from Jovie-shipped automations. Up-and-to-the-right proves the claim.',
+      source: irpaaSource,
+    },
+    {
+      id: 'gmv-lift',
+      tier: 'B',
+      label: 'Direct GMV Lift',
+      valueLabel: irpaa ? formatCents(irpaa.totals.gmvDeltaCents) : '—',
+      signal: 'Σ workflow_run_outcomes.gmv_delta_cents (real merch GMV)',
+      vcInterpretation:
+        'Real dollars settled via Stripe/Printful, attributed only through the automation spine.',
+      source: irpaaSource,
+    },
+    {
+      id: 'dsp-clicks',
+      tier: 'B',
+      label: 'DSP Click Delta',
+      valueLabel: irpaa ? String(irpaa.totals.dspClickDelta) : '—',
+      signal: `Proxy · ${weights.streamingValueWeightCentsPerDspClick}¢ / click (weights ${weights.version})`,
+      vcInterpretation:
+        'Streaming value proxy until royalty feeds land; always labeled with the weight version.',
+      source: irpaaSource,
+    },
+    {
+      id: 'new-fans',
+      tier: 'B',
+      label: 'New Fans Delta',
+      valueLabel: irpaa ? String(irpaa.totals.newFansDelta) : '—',
+      signal: `Proxy · ${weights.fanCaptureLtvWeightCentsPerFan}¢ LTV / fan (weights ${weights.version})`,
+      vcInterpretation:
+        'Fan-capture LTV proxy; validated against realized tips/GMV on a 30-day cadence.',
+      source: irpaaSource,
+    },
+    {
+      id: 'cohort-lift',
+      tier: 'B',
+      label: 'Active vs Control Lift',
+      valueLabel:
+        cohorts.activeMedianLiftCents != null
+          ? `${formatCents(cohorts.activeMedianLiftCents)} vs ${
+              cohorts.controlMedianLiftCents != null
+                ? formatCents(cohorts.controlMedianLiftCents)
+                : '—'
+            }`
+          : '—',
+      signal: `${cohorts.activeCount} active · ${cohorts.controlCount} control (median lift)`,
+      vcInterpretation:
+        'Holdout signal: active-artist median lift should exceed control, or attribution is noise.',
+      source: cohortSource,
+    },
+    {
+      id: 'cycle-time',
+      tier: 'C',
+      label: 'Opportunity Cycle Time',
+      valueLabel: formatMs(medianCycleMs),
+      signal: 'Median detected → shipped across opportunity kinds',
+      vcInterpretation:
+        'System health: faster cycle time means the agentic loop is compounding.',
+      source: cycleSource,
+    },
+    {
+      id: 'agent-success',
+      tier: 'C',
+      label: 'Agent Success Rate',
+      valueLabel: agents.length > 0 ? formatRate(totalSuccessRate) : '—',
+      signal: `${agents.reduce((s, a) => s + a.totalTasks, 0)} steps / 30d`,
+      vcInterpretation:
+        'Traction for multi-agent ops — high success with low override is leverage.',
+      source: agentsSource,
+    },
+    {
+      id: 'human-override',
+      tier: 'C',
+      label: 'Human Override Rate',
+      valueLabel: agents.length > 0 ? formatRate(totalOverrideRate) : '—',
+      signal: 'human_override / total workflow_step_results',
+      vcInterpretation:
+        'Trust tax: override rate falling over time is the path to full autonomy.',
+      source: agentsSource,
+    },
+  ];
+
+  return {
+    generatedAtIso: fetchedAtIso,
+    irpaa,
+    irpaaPrior,
+    irpaaSource,
+    kpiTree,
+    interpretationTable: kpiTree,
+    cohorts,
+    agents,
+    agentsSource,
+  };
+}


### PR DESCRIPTION
## Summary
- New admin route `/app/admin/revenue-lift` (nav: Revenue Lift under utilities)
- Loader `loadRevenueLiftDashboard()` composes IRPAA, cohort rows, agent metrics, opportunity cycle time from the canonical metrics modules
- UI: IRPAA hero, KPI tree tiles with source+freshness, Metric→Signal→VC Interpretation table, cohort strip, multi-agent contribution

## Linear
Fixes JOV-3619
<!-- linear-issue-id:6aa31d17-3ac2-42f2-ba39-e83faa5aebd8 -->

## Verification
- `biome check` on touched files — clean
- `vitest run apps/web/lib/metrics/revenue-lift-dashboard.test.ts` — 2 passed
- Full typecheck deferred: worktree disk 98% full; CI typecheck is the gate

## Cost Impact
- No new crons. Page is admin-only, on-demand SQL over existing tables (`workflow_run_outcomes`, `artist_revenue_cohorts`, `workflow_step_results`). O(1) page loads; no external API calls.

## Layout shift
- KPI tiles and tables reserve min-heights for value/signal/source lines so empty→loaded does not reflow the hero.