### PR TITLE
fix(chat): consolidate tool cards onto ChatToolSurface (JOV-3551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] **Chat tool-card System B consolidation (JOV-3551)**: Shared `ChatToolSurface` primitive; one "Cancelled" dismiss verb; success accent uses `text-success` (no cyan-300); Make Live uses Play icon; album-art single title; nested merch action is flat (no card-in-card); analytics signal cards on surface tokens.
 - [internal] **Test reliability batch (JOV-4112, JOV-4033, JOV-1880)**: stop Playwright from importing `server-only` env helpers in E2E dashboard route resolvers; drop quarantined specs from the PR smoke manifest and add a guardrail test; seed a prebuilt claim fixture and desktop smoke for the GTM claim-link canary.
 - **Tagging knows your world (JOV-3717)**: Artist picker cold-starts with your claimed Spotify artist and catalog collaborators (with ids) above Spotify search.
 
 - **Public artist profiles now feel native at every size (JOV-2018)**: Square artwork stays square, portraits keep a face-safe crop, profile rails use one consistent card size, scrollbars stay out of sight, and sparse or subscription states no longer leave awkward gaps.
 - **Unclaimed artist profiles now include a concise claim card (JOV-2018)**: Desktop AEO pages end with an editorial Jovie prompt and a single Spotify-verified claim action.
+
 
 - [internal] **Single machine-readable design-token source, wave 1 (GH-12009, GH-10158)**: New `apps/web/design/tokens.json` compiled by `scripts/build-design-tokens.mjs` (`pnpm tokens:build` / `tokens:check`) into generated CSS (`--gray1..12` now resolve app-wide), a typed TS export, and an agent manifest. `--linear-*` namespace is now shrink-only ratcheted (`linear-namespace-ratchet.test.ts`, baseline 2242), and a source-vs-emitter divergence guard locks tokens.json to the live accent palette. No visual changes.
 - [internal] **One EmptyState primitive (GH-12638)**: Canonical molecule at `components/molecules/EmptyState` (greyscale icon + Title Case heading + one sentence + primary CTA + optional text-link secondary). Migrated DSP presence/matches, insights, release tasks, and table empty surfaces onto it; deleted 5 bespoke `*EmptyState` components; component-family ratchet emptyState 14→9.

--- a/apps/web/components/features/dashboard/organisms/ProfileEditPreviewCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/ProfileEditPreviewCard.tsx
@@ -132,7 +132,7 @@ export function ProfileEditPreviewCard({
     );
   }
 
-  // Show cancelled state
+  // Show cancelled state — single "Cancelled" verb (JOV-3551); keep field label + badge only
   if (cancelled) {
     return (
       <ContentSurfaceCard className='p-3 opacity-70'>
@@ -141,7 +141,6 @@ export function ProfileEditPreviewCard({
             <p className='truncate text-app font-semibold tracking-tight text-primary-token'>
               {preview.fieldLabel}
             </p>
-            <p className='text-xs text-secondary-token'>Edit cancelled</p>
           </div>
           <span className='inline-flex shrink-0 items-center gap-1 rounded-md bg-surface-0 px-1.5 py-0.5 text-2xs font-caption tracking-tight text-secondary-token'>
             <X className='h-3.5 w-3.5' />

--- a/apps/web/components/jovie/components/ChatAlbumArtCard.tsx
+++ b/apps/web/components/jovie/components/ChatAlbumArtCard.tsx
@@ -121,14 +121,8 @@ function ChatAlbumArtCardSuccess({
 
   if (result.state === 'needs_release_target') {
     return (
-      <ChatGenerationArtifactSurface
-        title='Album Art'
-        subtitle='Choose a release'
-      >
-        <div className='text-app font-medium text-primary-token'>
-          Choose Release
-        </div>
-        <div className='mt-2 flex flex-wrap gap-2'>
+      <ChatGenerationArtifactSurface title='Choose Release'>
+        <div className='flex flex-wrap gap-2'>
           {result.suggestedReleases.map(release => (
             <Button
               key={release.id}

--- a/apps/web/components/jovie/components/ChatAnalyticsCard.tsx
+++ b/apps/web/components/jovie/components/ChatAnalyticsCard.tsx
@@ -75,23 +75,23 @@ export function ChatAnalyticsCard({ result }: ChatAnalyticsCardProps) {
           <li
             key={insight.id}
             className={cn(
-              'flex min-h-34 min-w-[min(20rem,84vw)] snap-start flex-col justify-between rounded-lg border border-black/10 bg-white dark:bg-surface-1 p-4 text-black dark:text-white shadow-[0_18px_60px_-48px_rgba(0,0,0,0.7)] md:min-w-0'
+              'flex min-h-34 min-w-[min(20rem,84vw)] snap-start flex-col justify-between rounded-lg border border-subtle bg-surface-1 p-4 text-primary-token shadow-card md:min-w-0'
             )}
             data-testid='chat-analytics-signal-card'
           >
             <div className='flex items-center gap-2'>
-              <span className='flex h-4 w-4 shrink-0 items-center justify-center text-black/55'>
+              <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token'>
                 <InsightCategoryIcon category={insight.category} size='sm' />
               </span>
-              <span className='text-2xs font-medium capitalize leading-4 text-black/55'>
+              <span className='text-2xs font-medium capitalize leading-4 text-tertiary-token'>
                 {insight.category.replaceAll('_', ' ')}
               </span>
             </div>
             <div className='mt-4 min-w-0'>
-              <p className='text-pretty text-base font-semibold leading-[1.18] text-black dark:text-white'>
+              <p className='text-pretty text-base font-semibold leading-[1.18] text-primary-token'>
                 {insight.title}
               </p>
-              <p className='mt-3 line-clamp-2 text-xs leading-5 text-black/60'>
+              <p className='mt-3 line-clamp-2 text-xs leading-5 text-secondary-token'>
                 {insight.actionSuggestion ?? insight.description}
               </p>
             </div>

--- a/apps/web/components/jovie/components/ChatLinkConfirmationCard.tsx
+++ b/apps/web/components/jovie/components/ChatLinkConfirmationCard.tsx
@@ -4,9 +4,9 @@ import { Check, Loader2, X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { usePreviewPanelContext } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
-import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { useConfirmChatLinkMutation } from '@/lib/queries';
 import { cn } from '@/lib/utils';
+import { CHAT_TOOL_CANCELLED_LABEL, ChatToolSurface } from './ChatToolSurface';
 
 interface ChatLinkConfirmationCardProps {
   readonly profileId: string;
@@ -123,30 +123,30 @@ export function ChatLinkConfirmationCard({
 
   if (state === 'added') {
     return (
-      <ContentSurfaceCard className='border-subtle bg-surface-1 p-4'>
+      <ChatToolSurface tone='success'>
         <div className='flex items-center gap-2 text-success'>
           <Check className='h-4 w-4' />
           <span className='text-sm font-medium'>
             {platform.name} link added
           </span>
         </div>
-      </ContentSurfaceCard>
+      </ChatToolSurface>
     );
   }
 
   if (state === 'dismissed') {
     return (
-      <ContentSurfaceCard className='border-(--system-b-app-frame-seam) bg-(--system-b-app-content-surface) p-4 opacity-60'>
+      <ChatToolSurface tone='cancelled'>
         <div className='flex items-center gap-2 text-secondary-token'>
           <X className='h-4 w-4' />
-          <span className='text-sm'>Link dismissed</span>
+          <span className='text-sm'>{CHAT_TOOL_CANCELLED_LABEL}</span>
         </div>
-      </ContentSurfaceCard>
+      </ChatToolSurface>
     );
   }
 
   return (
-    <ContentSurfaceCard className='system-b-chat-link-card system-b-chat-link-card-add'>
+    <ChatToolSurface className='system-b-chat-link-card system-b-chat-link-card-add'>
       <div className='flex items-center gap-3'>
         <span className='system-b-chat-link-card-icon system-b-chat-link-card-icon-add'>
           <SocialIcon
@@ -201,6 +201,6 @@ export function ChatLinkConfirmationCard({
           </button>
         </div>
       </div>
-    </ContentSurfaceCard>
+    </ChatToolSurface>
   );
 }

--- a/apps/web/components/jovie/components/ChatLinkRemovalCard.tsx
+++ b/apps/web/components/jovie/components/ChatLinkRemovalCard.tsx
@@ -4,9 +4,9 @@ import { Check, Loader2, Trash2, X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { usePreviewPanelContext } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
-import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { useConfirmChatRemoveLinkMutation } from '@/lib/queries';
 import { cn } from '@/lib/utils';
+import { CHAT_TOOL_CANCELLED_LABEL, ChatToolSurface } from './ChatToolSurface';
 
 interface ChatLinkRemovalCardProps {
   readonly profileId: string;
@@ -96,28 +96,28 @@ export function ChatLinkRemovalCard({
 
   if (state === 'removed') {
     return (
-      <ContentSurfaceCard className='border-subtle bg-surface-1 p-4'>
+      <ChatToolSurface tone='success'>
         <div className='flex items-center gap-2 text-success'>
           <Check className='h-4 w-4' />
           <span className='text-sm font-medium'>{platform} link removed</span>
         </div>
-      </ContentSurfaceCard>
+      </ChatToolSurface>
     );
   }
 
   if (state === 'dismissed') {
     return (
-      <ContentSurfaceCard className='border-(--system-b-app-frame-seam) bg-(--system-b-app-content-surface) p-4 opacity-60'>
+      <ChatToolSurface tone='cancelled'>
         <div className='flex items-center gap-2 text-secondary-token'>
           <X className='h-4 w-4' />
-          <span className='text-sm'>Removal cancelled</span>
+          <span className='text-sm'>{CHAT_TOOL_CANCELLED_LABEL}</span>
         </div>
-      </ContentSurfaceCard>
+      </ChatToolSurface>
     );
   }
 
   return (
-    <ContentSurfaceCard className='system-b-chat-link-card system-b-chat-link-card-remove'>
+    <ChatToolSurface className='system-b-chat-link-card system-b-chat-link-card-remove'>
       <div className='flex items-center gap-3'>
         <span className='system-b-chat-link-card-icon system-b-chat-link-card-icon-remove'>
           <SocialIcon
@@ -170,6 +170,6 @@ export function ChatLinkRemovalCard({
           </button>
         </div>
       </div>
-    </ContentSurfaceCard>
+    </ChatToolSurface>
   );
 }

--- a/apps/web/components/jovie/components/ChatMerchActionCard.test.tsx
+++ b/apps/web/components/jovie/components/ChatMerchActionCard.test.tsx
@@ -35,4 +35,44 @@ describe('ChatMerchActionCard', () => {
       expect.any(Object)
     );
   });
+
+  it('uses Play icon for Make Live and Cancelled dismiss copy', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <ChatMerchActionCard
+        profileId='profile-1'
+        merchCardId='card-1'
+        action='unpause'
+        title='Tour Tee'
+        currentStatus='paused'
+        retailPrice='$25.00'
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /Make Live/i })).toBeTruthy();
+    // lucide Play renders a triangle path; Pause would be two rects — assert no Pause label
+    expect(container.querySelector('svg.lucide-pause')).toBeNull();
+    expect(container.querySelector('svg.lucide-play')).not.toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /Cancel Action/i }));
+    expect(screen.getByText('Cancelled')).toBeInTheDocument();
+  });
+
+  it('nested mode uses flat surface (no card-in-card)', () => {
+    render(
+      <ChatMerchActionCard
+        profileId='profile-1'
+        merchCardId='card-1'
+        action='publish'
+        title='Tour Tee'
+        currentStatus='draft'
+        retailPrice='$25.00'
+        nested
+      />
+    );
+
+    expect(screen.getByTestId('chat-tool-surface')).toHaveClass(
+      'system-b-chat-tool-surface-flat'
+    );
+  });
 });

--- a/apps/web/components/jovie/components/ChatMerchActionCard.tsx
+++ b/apps/web/components/jovie/components/ChatMerchActionCard.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { Archive, Check, Loader2, Pause, Rocket, X } from 'lucide-react';
+import { Archive, Check, Loader2, Play, Rocket, X } from 'lucide-react';
 import { useCallback, useState } from 'react';
-import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import {
   type ConfirmChatMerchActionType,
   useConfirmChatMerchActionMutation,
 } from '@/lib/queries';
 import { cn } from '@/lib/utils';
+import { CHAT_TOOL_CANCELLED_LABEL, ChatToolSurface } from './ChatToolSurface';
 
 interface ChatMerchActionCardProps {
   readonly profileId: string;
@@ -16,6 +16,11 @@ interface ChatMerchActionCardProps {
   readonly title: string;
   readonly currentStatus: string;
   readonly retailPrice: string;
+  /**
+   * When nested under ChatGenerationArtifactSurface (or another card),
+   * drop the outer card chrome to avoid card-in-card (JOV-3551).
+   */
+  readonly nested?: boolean;
 }
 
 type CardState = 'pending' | 'confirming' | 'confirmed' | 'dismissed';
@@ -40,7 +45,8 @@ const ACTION_CONFIG: Record<
     label: 'Make Merch Live',
     confirmLabel: 'Make Live',
     successLabel: 'Merch is live',
-    Icon: Pause,
+    // Play (not Pause) — "Make Live" is a resume action (JOV-3551)
+    Icon: Play,
   },
   archive: {
     label: 'Archive Merch',
@@ -58,12 +64,14 @@ export function ChatMerchActionCard({
   title,
   currentStatus,
   retailPrice,
+  nested = false,
 }: ChatMerchActionCardProps) {
   const [state, setState] = useState<CardState>('pending');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const confirmAction = useConfirmChatMerchActionMutation();
   const config = ACTION_CONFIG[action];
   const ActionIcon = config.Icon;
+  const surfaceTone = nested ? 'flat' : 'default';
 
   const handleConfirm = useCallback(() => {
     setErrorMessage(null);
@@ -86,28 +94,31 @@ export function ChatMerchActionCard({
 
   if (state === 'confirmed') {
     return (
-      <ContentSurfaceCard className='border-subtle bg-surface-1 p-4'>
+      <ChatToolSurface tone={nested ? 'flat' : 'success'}>
         <div className='flex items-center gap-2 text-success'>
           <Check className='h-4 w-4' />
           <span className='text-sm font-medium'>{config.successLabel}</span>
         </div>
-      </ContentSurfaceCard>
+      </ChatToolSurface>
     );
   }
 
   if (state === 'dismissed') {
     return (
-      <ContentSurfaceCard className='border-(--system-b-app-frame-seam) bg-(--system-b-app-content-surface) p-4 opacity-60'>
+      <ChatToolSurface tone={nested ? 'flat' : 'cancelled'}>
         <div className='flex items-center gap-2 text-secondary-token'>
           <X className='h-4 w-4' />
-          <span className='text-sm'>Action cancelled</span>
+          <span className='text-sm'>{CHAT_TOOL_CANCELLED_LABEL}</span>
         </div>
-      </ContentSurfaceCard>
+      </ChatToolSurface>
     );
   }
 
   return (
-    <ContentSurfaceCard className='system-b-chat-link-card'>
+    <ChatToolSurface
+      tone={surfaceTone}
+      className={nested ? undefined : 'system-b-chat-link-card'}
+    >
       <div className='flex items-center gap-3'>
         <span
           className={cn(
@@ -165,6 +176,6 @@ export function ChatMerchActionCard({
           </button>
         </div>
       </div>
-    </ContentSurfaceCard>
+    </ChatToolSurface>
   );
 }

--- a/apps/web/components/jovie/components/ChatMerchCard.tsx
+++ b/apps/web/components/jovie/components/ChatMerchCard.tsx
@@ -356,7 +356,7 @@ export function ChatMerchSelectionCard({
         data-testid='chat-merch-selection-card'
         className='flex items-start gap-3 rounded-lg border border-subtle bg-surface-0 p-3'
       >
-        <span className='grid h-9 w-9 shrink-0 place-items-center rounded-md bg-cyan-400/[0.08] text-cyan-300'>
+        <span className='grid h-9 w-9 shrink-0 place-items-center rounded-md bg-success-subtle text-success'>
           <CheckCircle2 className='h-4 w-4' strokeWidth={2.25} />
         </span>
         <div className='min-w-0 flex-1'>
@@ -429,6 +429,7 @@ export function ChatMerchSelectionCard({
             title={result.publishProposal.title}
             currentStatus={result.publishProposal.currentStatus}
             retailPrice={result.publishProposal.retailPrice}
+            nested
           />
         </div>
       ) : null}

--- a/apps/web/components/jovie/components/ChatToolSurface.test.tsx
+++ b/apps/web/components/jovie/components/ChatToolSurface.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CHAT_TOOL_CANCELLED_LABEL, ChatToolSurface } from './ChatToolSurface';
+
+describe('ChatToolSurface', () => {
+  it('exports a single cancelled label for all confirm cards', () => {
+    expect(CHAT_TOOL_CANCELLED_LABEL).toBe('Cancelled');
+  });
+
+  it('renders default tone on System B surface classes', () => {
+    render(
+      <ChatToolSurface>
+        <span>Pending action</span>
+      </ChatToolSurface>
+    );
+
+    expect(screen.getByTestId('chat-tool-surface')).toHaveClass(
+      'system-b-chat-tool-surface'
+    );
+    expect(screen.getByText('Pending action')).toBeInTheDocument();
+  });
+
+  it('renders success and cancelled tones', () => {
+    const { rerender } = render(
+      <ChatToolSurface tone='success'>
+        <span>Done</span>
+      </ChatToolSurface>
+    );
+    expect(screen.getByTestId('chat-tool-surface')).toHaveClass(
+      'system-b-chat-tool-surface-success'
+    );
+
+    rerender(
+      <ChatToolSurface tone='cancelled'>
+        <span>{CHAT_TOOL_CANCELLED_LABEL}</span>
+      </ChatToolSurface>
+    );
+    expect(screen.getByTestId('chat-tool-surface')).toHaveClass(
+      'system-b-chat-tool-surface-cancelled'
+    );
+    expect(screen.getByText('Cancelled')).toBeInTheDocument();
+  });
+
+  it('flat tone drops card chrome for nested use', () => {
+    render(
+      <ChatToolSurface tone='flat'>
+        <span>Nested</span>
+      </ChatToolSurface>
+    );
+    const surface = screen.getByTestId('chat-tool-surface');
+    expect(surface).toHaveClass('system-b-chat-tool-surface-flat');
+    expect(surface.tagName.toLowerCase()).toBe('div');
+  });
+});

--- a/apps/web/components/jovie/components/ChatToolSurface.tsx
+++ b/apps/web/components/jovie/components/ChatToolSurface.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+import { cn } from '@/lib/utils';
+
+/**
+ * Canonical dismiss copy for chat confirm/tool cards (JOV-3551).
+ * All confirm cards share this verb — no "Link dismissed" / "Removal cancelled" drift.
+ */
+export const CHAT_TOOL_CANCELLED_LABEL = 'Cancelled' as const;
+
+export type ChatToolSurfaceTone = 'default' | 'success' | 'cancelled' | 'flat';
+
+interface ChatToolSurfaceProps {
+  readonly children: ReactNode;
+  readonly tone?: ChatToolSurfaceTone;
+  /** Extra classes layered onto the surface (e.g. system-b-chat-link-card). */
+  readonly className?: string;
+  readonly 'data-testid'?: string;
+}
+
+/**
+ * Single System B surface for chat tool/confirm result cards.
+ * Replaces ad-hoc ContentSurfaceCard wrappers so success, cancel, and active
+ * confirm states share tokens and elevation (no card-in-card when nested).
+ */
+export function ChatToolSurface({
+  children,
+  tone = 'default',
+  className,
+  'data-testid': testId,
+}: ChatToolSurfaceProps) {
+  if (tone === 'flat') {
+    return (
+      <div
+        data-testid={testId ?? 'chat-tool-surface'}
+        data-tone={tone}
+        className={cn('system-b-chat-tool-surface-flat', className)}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <ContentSurfaceCard
+      data-testid={testId ?? 'chat-tool-surface'}
+      className={cn(
+        'system-b-chat-tool-surface',
+        tone === 'success' && 'system-b-chat-tool-surface-success',
+        tone === 'cancelled' && 'system-b-chat-tool-surface-cancelled',
+        className
+      )}
+    >
+      {children}
+    </ContentSurfaceCard>
+  );
+}

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -280,7 +280,7 @@ function ToolActivityRow({
           isRunning && 'text-secondary-token',
           isError && 'text-red-500',
           isLocked && 'text-secondary-token',
-          !isRunning && !isError && !isLocked && 'text-cyan-300'
+          !isRunning && !isError && !isLocked && 'text-success'
         )}
       >
         <Icon

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -9623,6 +9623,30 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   background: var(--surface-1);
 }
 
+/* JOV-3551: shared chat tool/confirm surface tones */
+:where(.system-b-chat-tool-surface) {
+  padding: var(--space-4);
+}
+
+:where(.system-b-chat-tool-surface-success) {
+  border-color: var(--color-border-subtle);
+  background: var(--surface-1);
+}
+
+:where(.system-b-chat-tool-surface-cancelled) {
+  border-color: var(--system-b-app-frame-seam);
+  background: var(--system-b-app-content-surface);
+  opacity: 0.6;
+}
+
+:where(.system-b-chat-tool-surface-flat) {
+  /* Nested inside ChatGenerationArtifactSurface — no second card chrome */
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+
 :where(.system-b-chat-link-card) {
   padding: var(--space-4);
 }

--- a/apps/web/tests/unit/chat/ProfileEditPreviewCard.test.tsx
+++ b/apps/web/tests/unit/chat/ProfileEditPreviewCard.test.tsx
@@ -121,7 +121,7 @@ describe('ProfileEditPreviewCard', () => {
     const cancelButton = screen.getByRole('button', { name: /cancel/i });
     fireEvent.click(cancelButton);
 
-    expect(screen.getByText('Edit cancelled')).toBeInTheDocument();
+    expect(screen.getByText('Cancelled')).toBeInTheDocument();
 
     // Apply button should no longer be present
     expect(screen.queryByRole('button', { name: /apply/i })).toBeNull();


### PR DESCRIPTION
## Summary
- Introduce shared `ChatToolSurface` + `CHAT_TOOL_CANCELLED_LABEL` for chat confirm/tool result cards
- Unify cancel copy to **Cancelled** across link add/remove, merch action, and profile edit preview
- Replace off-palette `text-cyan-300` success accent with `text-success` / success-subtle tokens
- **Make Live** uses `Play` (not Pause); album-art needs-release state has a single title
- Nested merch publish action is `nested`/flat to avoid card-in-card inside artifact surface
- Analytics signal cards use System B surface tokens (no white-on-dark island)

Fixes JOV-3551
<!-- linear-issue-id:e787c9fa-b918-447f-8f7d-1a3a20d30921 -->

## Verification
- `biome check --write` on edited files — clean
- `vitest` focused: ChatToolSurface (4), ChatMerchActionCard (3) — all pass
- Layout: cancel/success states keep reserved card footprint; nested flat removes double elevation only

## Cost Impact
- None (UI-only, no new API/cron/external calls)

## Test plan
- [ ] Chat link add confirm → dismiss shows Cancelled
- [ ] Merch Make Live shows Play icon; nested publish proposal has no double card border
- [ ] Album art needs-release shows one title
- [ ] Analytics tool result cards match dark chat surfaces