### PR TITLE
feat(search): full-viewport Cmd+K search surface (JOV-2982)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 - **Chat release right-rail System B polish (JOV-3493)**: Section cards use Library elevation, DSP rows show provider icons, and typography drops oversized/all-caps chrome.
 - **Chat file attachments render as rich chips (JOV-3492)**: Uploaded audio/docs show a filetype icon + clean filename instead of raw Vercel blob URLs.
 - **Provider-ingested released music can only be archived (JOV-3885)**: Soft-hide via `deleted_at` for ingested published releases; Jovie-created releases still hard-delete.
-
+- **Search fills the whole screen (JOV-2982)**: Cmd+K opens a full-viewport search surface with the same clean input; results scroll the remaining height instead of a cramped centered card.
 
 
 - [internal] **Single machine-readable design-token source, wave 1 (GH-12009, GH-10158)**: New `apps/web/design/tokens.json` compiled by `scripts/build-design-tokens.mjs` (`pnpm tokens:build` / `tokens:check`) into generated CSS (`--gray1..12` now resolve app-wide), a typed TS export, and an agent manifest. `--linear-*` namespace is now shrink-only ratcheted (`linear-namespace-ratchet.test.ts`, baseline 2242), and a source-vs-emitter divergence guard locks tokens.json to the live accent palette. No visual changes.

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -31,6 +31,7 @@ import {
 import { useArtistSearchQuery } from '@/lib/queries/useArtistSearchQuery';
 import { useChatCapabilitiesQuery } from '@/lib/queries/useChatCapabilitiesQuery';
 import { useReleasesQuery } from '@/lib/queries/useReleasesQuery';
+import { cn } from '@/lib/utils';
 import {
   artistResultToEntityRef,
   type ReleaseLikeRow,
@@ -251,8 +252,21 @@ export function CmdKPalette({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className='overflow-hidden rounded-xl border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-0 shadow-popover sm:max-w-140'
+        // JOV-2982: full-viewport search takeover (not a centered card).
+        // Overrides DialogContent centered defaults via tailwind-merge.
+        className={cn(
+          'left-0 top-0 h-dvh w-screen max-w-none [translate:0_0]',
+          'grid gap-0 overflow-hidden rounded-none border-0 p-0 shadow-none',
+          'bg-(--linear-app-content-surface)',
+          'sm:max-w-none',
+          // Full-page: fade only (no zoom — zoom reads as a modal card)
+          'data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100'
+        )}
         hideClose
+        overlayProps={{
+          className: 'bg-(--linear-app-content-surface)',
+        }}
+        testId='cmdk-full-page'
       >
         <DialogPrimitive.Title className='sr-only'>
           Command palette
@@ -261,11 +275,11 @@ export function CmdKPalette({
           Search routes, skills, releases, artists, and recent conversations.
         </DialogPrimitive.Description>
         <div
-          className='flex flex-col'
+          className='mx-auto flex h-full w-full max-w-3xl flex-col'
           data-testid='shared-command-palette'
           data-surface='cmdk'
         >
-          <div className='flex items-center gap-2 border-b border-(--linear-app-frame-seam) px-3.5 py-2.5'>
+          <div className='flex shrink-0 items-center gap-2 border-b border-(--linear-app-frame-seam) px-3.5 py-2.5'>
             <Search
               className='size-4 shrink-0 text-tertiary-token'
               aria-hidden='true'
@@ -287,7 +301,7 @@ export function CmdKPalette({
             </span>
           </div>
           <div
-            className='max-h-105 overflow-y-auto px-2 pb-2 pt-1.5'
+            className='min-h-0 flex-1 overflow-y-auto px-2 pb-2 pt-1.5'
             role='listbox'
             aria-label='Command Palette Results'
           >

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -29,8 +29,18 @@ vi.mock('next/image', () => ({
 vi.mock('@jovie/ui', () => ({
   Dialog: ({ children, open }: { children: ReactNode; open: boolean }) =>
     open ? <div role='dialog'>{children}</div> : null,
-  DialogContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
+  DialogContent: ({
+    children,
+    className,
+    testId,
+  }: {
+    children: ReactNode;
+    className?: string;
+    testId?: string;
+  }) => (
+    <div data-testid={testId ?? 'dialog-content'} className={className}>
+      {children}
+    </div>
   ),
 }));
 
@@ -178,6 +188,21 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
     expect(sectionLabels).toContain('Skills');
     expect(sectionLabels).toContain('Releases');
     expect(screen.getByText('Midnight Run')).toBeInTheDocument();
+  });
+
+  it('opens as a full-viewport search surface (JOV-2982)', () => {
+    render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
+    const shell = screen.getByTestId('cmdk-full-page');
+    expect(shell.className).toContain('h-dvh');
+    expect(shell.className).toContain('w-screen');
+    expect(shell.className).toContain('max-w-none');
+    expect(shell.className).not.toContain('sm:max-w-140');
+    // Results region fills remaining height (not a fixed max-h card)
+    const listbox = screen.getByRole('listbox', {
+      name: 'Command Palette Results',
+    });
+    expect(listbox.className).toContain('flex-1');
+    expect(listbox.className).not.toContain('max-h-105');
   });
 
   it('shows aligned numbered shortcuts for the first three visible rows', () => {


### PR DESCRIPTION
## Summary
- Cmd+K search expands to a full-viewport takeover (no centered card / dim void)
- Search input treatment preserved (icon, placeholder, Esc hint)
- Results list uses `flex-1` + scroll so it fills available height
- Overlay uses app content surface so shell chrome is fully covered

Fixes JOV-2982
<!-- linear-issue-id:db653816-5576-48d9-bef2-4b42b848d736 -->

## Verification
- biome clean on edited files
- vitest `SharedCommandPalette.test.tsx`: new full-viewport assertion passes; 16/17 pass (1 pre-existing slow suite timeout under constrained env)

## Cost Impact
- None (UI layout only)

## Test plan
- [ ] Cmd+K / click search opens full-screen surface
- [ ] Escape closes; ↑/↓/Enter still navigate
- [ ] Mobile viewport full takeover