### PR TITLE
feat(macos): MenuMonitor menu bar shipping counts (JOV-3593)

### DIFF
--- a/apps/macos/MenuMonitor/.gitignore
+++ b/apps/macos/MenuMonitor/.gitignore
@@ -1,0 +1,3 @@
+.build/
+*.xcodeproj/
+DerivedData/

--- a/apps/macos/MenuMonitor/Package.swift
+++ b/apps/macos/MenuMonitor/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+  name: "MenuMonitor",
+  platforms: [
+    .macOS(.v14),
+  ],
+  products: [
+    .executable(name: "MenuMonitor", targets: ["MenuMonitor"]),
+  ],
+  targets: [
+    .executableTarget(
+      name: "MenuMonitor",
+      path: "Sources/MenuMonitor"
+    ),
+  ]
+)

--- a/apps/macos/MenuMonitor/README.md
+++ b/apps/macos/MenuMonitor/README.md
@@ -1,0 +1,35 @@
+# MenuMonitor
+
+macOS menu bar app for live shipping counts + Hermes gateway controls (JOV-3593).
+
+## Behavior
+
+- Menu bar icon (shipping box SF Symbol) with badge = in-progress kanban cards
+- Polls every 30s via `hermes kanban --board jovie-product list --json`
+- Falls back to `gh issue list … --label status:in-progress` if kanban fails
+- Menu actions: restart gateway, restart daemons, status check, open Linear, quit
+
+## Build
+
+Requires macOS 14+ and Xcode / Swift 5.10+.
+
+```bash
+cd apps/macos/MenuMonitor
+swift build -c release
+# binary: .build/release/MenuMonitor
+open .build/release/MenuMonitor   # or copy to /Applications
+```
+
+## Run at login (optional)
+
+```bash
+# After release build:
+cp .build/release/MenuMonitor /Applications/MenuMonitor.app/Contents/MacOS/  # if wrapped
+# Or: use a simple LaunchAgent pointing at the binary
+```
+
+## Notes
+
+- Pure SwiftUI `MenuBarExtra` — no Electron, no webview
+- Idle footprint should stay well under 50MB
+- Sleep/wake: `Task.sleep` loop resumes after wake and re-polls

--- a/apps/macos/MenuMonitor/Sources/MenuMonitor/MenuMonitorApp.swift
+++ b/apps/macos/MenuMonitor/Sources/MenuMonitor/MenuMonitorApp.swift
@@ -1,0 +1,101 @@
+import AppKit
+import SwiftUI
+
+@main
+struct MenuMonitorApp: App {
+  @StateObject private var store = ShippingStatusStore()
+
+  init() {
+    // Menu-bar-only agent: hide Dock icon.
+    NSApplication.shared.setActivationPolicy(.accessory)
+  }
+
+  var body: some Scene {
+    MenuBarExtra {
+      MenuMonitorMenu(store: store)
+    } label: {
+      MenuBarLabel(count: store.inProgressCount)
+    }
+    .menuBarExtraStyle(.menu)
+  }
+}
+
+/// Menu bar icon + optional red badge with shipping count.
+struct MenuBarLabel: View {
+  let count: Int
+
+  var body: some View {
+    // Template image so macOS renders correctly in light/dark menu bar.
+    Label {
+      if count > 0 {
+        Text(badgeText)
+      }
+    } icon: {
+      Image(systemName: "shippingbox.fill")
+    }
+    .labelStyle(.titleAndIcon)
+    .help(count == 0 ? "No issues shipping" : "\(count) issues shipping")
+  }
+
+  private var badgeText: String {
+    count > 99 ? "99+" : "\(count)"
+  }
+}
+
+struct MenuMonitorMenu: View {
+  @ObservedObject var store: ShippingStatusStore
+
+  var body: some View {
+    Group {
+      Text("In Progress: \(store.inProgressCount) issues shipping")
+      Text("Ready: \(store.readyCount) cards waiting")
+      Text("Blocked: \(store.blockedCount) cards blocked")
+
+      if let refreshed = store.lastRefreshDescription {
+        Text("Updated \(refreshed)")
+          .foregroundStyle(.secondary)
+      }
+
+      if let error = store.lastError {
+        Text(error)
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+      }
+
+      Divider()
+
+      Button("Restart Hermes Gateway") {
+        Task { await store.restartGateway() }
+      }
+      Button("Restart All Daemons") {
+        Task { await store.restartDaemons() }
+      }
+      Button("Status Check") {
+        Task { await store.runStatusCheck() }
+      }
+
+      if let status = store.statusOutput, !status.isEmpty {
+        Divider()
+        Text(status)
+          .font(.system(.caption, design: .monospaced))
+          .lineLimit(12)
+          .foregroundStyle(.secondary)
+      }
+
+      Divider()
+
+      Button("Open Dashboard") {
+        store.openDashboard()
+      }
+      Button("Refresh Now") {
+        Task { await store.refresh() }
+      }
+      Button("Quit") {
+        NSApplication.shared.terminate(nil)
+      }
+    }
+    .task {
+      await store.start()
+    }
+  }
+}

--- a/apps/macos/MenuMonitor/Sources/MenuMonitor/ShippingStatusStore.swift
+++ b/apps/macos/MenuMonitor/Sources/MenuMonitor/ShippingStatusStore.swift
@@ -1,0 +1,203 @@
+import AppKit
+import Foundation
+
+/// Polls Hermes kanban (or GitHub fallback) for shipping counts and runs ops actions.
+@MainActor
+final class ShippingStatusStore: ObservableObject {
+  @Published private(set) var inProgressCount: Int = 0
+  @Published private(set) var readyCount: Int = 0
+  @Published private(set) var blockedCount: Int = 0
+  @Published private(set) var lastError: String?
+  @Published private(set) var lastRefresh: Date?
+  @Published private(set) var statusOutput: String?
+  @Published private(set) var actionMessage: String?
+
+  private var pollTask: Task<Void, Never>?
+  private let boardSlug = "jovie-product"
+  private let dashboardURL = URL(string: "https://linear.app/jovie")!
+  private let pollIntervalNanoseconds: UInt64 = 30 * 1_000_000_000
+
+  var lastRefreshDescription: String? {
+    guard let lastRefresh else { return nil }
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .abbreviated
+    return formatter.localizedString(for: lastRefresh, relativeTo: Date())
+  }
+
+  func start() async {
+    await refresh()
+    pollTask?.cancel()
+    pollTask = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(nanoseconds: self?.pollIntervalNanoseconds ?? 30_000_000_000)
+        guard !Task.isCancelled else { break }
+        await self?.refresh()
+      }
+    }
+  }
+
+  func refresh() async {
+    do {
+      let counts = try await Self.fetchKanbanCounts(board: boardSlug)
+      inProgressCount = counts.inProgress
+      readyCount = counts.ready
+      blockedCount = counts.blocked
+      lastError = nil
+      lastRefresh = Date()
+    } catch {
+      // GitHub fallback when hermes kanban is unavailable
+      do {
+        let ghCount = try await Self.fetchGitHubInProgressCount()
+        inProgressCount = ghCount
+        readyCount = 0
+        blockedCount = 0
+        lastError = "Kanban unavailable — GitHub fallback (\(error.localizedDescription))"
+        lastRefresh = Date()
+      } catch {
+        lastError = error.localizedDescription
+      }
+    }
+  }
+
+  func restartGateway() async {
+    actionMessage = "Restarting Hermes gateway…"
+    let result = await Self.runShell(
+      "/bin/zsh",
+      args: ["-lc", "command -v hermes >/dev/null && hermes gateway restart || echo 'hermes not found'"]
+    )
+    statusOutput = result
+    actionMessage = "Gateway restart finished"
+    await refresh()
+  }
+
+  func restartDaemons() async {
+    actionMessage = "Restarting orchestrator + webhook…"
+    let script = """
+    set -e
+    if command -v launchctl >/dev/null 2>&1; then
+      launchctl kickstart -k "gui/$(id -u)/ai.hermes.gateway" 2>/dev/null || true
+      launchctl kickstart -k "gui/$(id -u)/ai.hermes.orchestrator" 2>/dev/null || true
+      launchctl kickstart -k "gui/$(id -u)/ai.hermes.webhook" 2>/dev/null || true
+    fi
+    if command -v hermes >/dev/null 2>&1; then
+      hermes gateway restart 2>/dev/null || true
+    fi
+    echo "daemon restart attempted"
+    """
+    let result = await Self.runShell("/bin/zsh", args: ["-lc", script])
+    statusOutput = result
+    actionMessage = "Daemons restart finished"
+    await refresh()
+  }
+
+  func runStatusCheck() async {
+    actionMessage = "Running status check…"
+    let script = """
+    if [ -x "$HOME/.hermes/scripts/status-check.py" ]; then
+      python3 "$HOME/.hermes/scripts/status-check.py" 2>&1 | tail -40
+    elif command -v hermes >/dev/null 2>&1; then
+      hermes status 2>&1 | tail -40
+    else
+      echo "No status-check.py or hermes CLI found"
+    fi
+    """
+    let result = await Self.runShell("/bin/zsh", args: ["-lc", script])
+    statusOutput = result
+    actionMessage = nil
+  }
+
+  func openDashboard() {
+    NSWorkspace.shared.open(dashboardURL)
+  }
+
+  // MARK: - Fetchers
+
+  struct Counts: Sendable {
+    var inProgress: Int
+    var ready: Int
+    var blocked: Int
+  }
+
+  nonisolated static func fetchKanbanCounts(board: String) async throws -> Counts {
+    try await Task.detached(priority: .utility) {
+      let json = try runProcess(
+        "/bin/zsh",
+        args: [
+          "-lc",
+          "hermes kanban --board \(board) list --json 2>/dev/null",
+        ]
+      )
+      guard let data = json.data(using: .utf8),
+            let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+      else {
+        throw NSError(
+          domain: "MenuMonitor",
+          code: 1,
+          userInfo: [NSLocalizedDescriptionKey: "Invalid kanban JSON"]
+        )
+      }
+      var inProgress = 0
+      var ready = 0
+      var blocked = 0
+      for row in rows {
+        let status = ((row["status"] as? String) ?? "").lowercased()
+        switch status {
+        case "in_progress", "in-progress", "running", "shipping":
+          inProgress += 1
+        case "ready", "todo", "queued":
+          ready += 1
+        case "blocked":
+          blocked += 1
+        default:
+          break
+        }
+      }
+      return Counts(inProgress: inProgress, ready: ready, blocked: blocked)
+    }.value
+  }
+
+  nonisolated static func fetchGitHubInProgressCount() async throws -> Int {
+    try await Task.detached(priority: .utility) {
+      let json = try runProcess(
+        "/bin/zsh",
+        args: [
+          "-lc",
+          "gh issue list -R JovieInc/Jovie --state open --label 'status:in-progress' --json number --limit 100 2>/dev/null",
+        ]
+      )
+      guard let data = json.data(using: .utf8),
+            let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+      else {
+        return 0
+      }
+      return rows.count
+    }.value
+  }
+
+  nonisolated static func runShell(_ launchPath: String, args: [String]) async -> String {
+    await Task.detached(priority: .utility) {
+      (try? runProcess(launchPath, args: args)) ?? "Command failed"
+    }.value
+  }
+
+  nonisolated static func runProcess(_ launchPath: String, args: [String]) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: launchPath)
+    process.arguments = args
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try process.run()
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    if process.terminationStatus != 0, output.isEmpty {
+      throw NSError(
+        domain: "MenuMonitor",
+        code: Int(process.terminationStatus),
+        userInfo: [NSLocalizedDescriptionKey: "Process exited \(process.terminationStatus)"]
+      )
+    }
+    return output
+  }
+}


### PR DESCRIPTION
## Summary
- New `apps/macos/MenuMonitor` Swift Package: menu-bar-only agent app
- Polls hermes kanban every 30s for in_progress / ready / blocked counts
- GitHub label fallback when kanban is down
- Actions: restart Hermes gateway, restart daemons, status check, open Linear, quit
- Verified: `swift build` succeeds

## Linear
Fixes JOV-3593
<!-- linear-issue-id:6759cafc-9326-4196-864b-cdb355dd94f6 -->

## Verification
- `cd apps/macos/MenuMonitor && swift build` — Build complete

## Cost Impact
- None (local operator tooling)