### PR TITLE
feat(chat): own-graph artists seed entity picker (JOV-3717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- **Tagging knows your world (JOV-3717)**: Artist picker cold-starts with your claimed Spotify artist and catalog collaborators (with ids) above Spotify search.
+
+
 - [internal] **Single machine-readable design-token source, wave 1 (GH-12009, GH-10158)**: New `apps/web/design/tokens.json` compiled by `scripts/build-design-tokens.mjs` (`pnpm tokens:build` / `tokens:check`) into generated CSS (`--gray1..12` now resolve app-wide), a typed TS export, and an agent manifest. `--linear-*` namespace is now shrink-only ratcheted (`linear-namespace-ratchet.test.ts`, baseline 2242), and a source-vs-emitter divergence guard locks tokens.json to the live accent palette. No visual changes.
 - [internal] **One EmptyState primitive (GH-12638)**: Canonical molecule at `components/molecules/EmptyState` (greyscale icon + Title Case heading + one sentence + primary CTA + optional text-link secondary). Migrated DSP presence/matches, insights, release tasks, and table empty surfaces onto it; deleted 5 bespoke `*EmptyState` components; component-family ratchet emptyState 14→9.
 - Toasts and banners now share one canonical feedback system: confirmations and errors appear bottom-right and dismiss on their own, while system status stays pinned at the top until you dismiss it. (GH-12885)

--- a/apps/web/components/jovie/components/SlashCommandMenu.tsx
+++ b/apps/web/components/jovie/components/SlashCommandMenu.tsx
@@ -40,9 +40,11 @@ import { useArtistSearchQuery } from '@/lib/queries/useArtistSearchQuery';
 import { useChatCapabilitiesQuery } from '@/lib/queries/useChatCapabilitiesQuery';
 import { useEntityRecents } from '@/lib/queries/useEntityRecents';
 import { useEventsQuery } from '@/lib/queries/useEventsQuery';
+import { useOwnGraphArtistsQuery } from '@/lib/queries/useOwnGraphArtistsQuery';
 import { useReleasesQuery } from '@/lib/queries/useReleasesQuery';
 import {
   artistResultToEntityRef,
+  ownGraphArtistToEntityRef,
   type ReleaseLikeRow,
   rankRecentsFirst,
   releaseRowMatches,
@@ -171,6 +173,13 @@ export function useSlashItems(
   // opens populated with the creator's world even before Spotify responds.
   const { recents } = useEntityRecents(profileId);
 
+  // Claimed-self + catalog collaborators with Spotify ids (JOV-3717).
+  // Cold-start: empty artist menu still shows "You" + credits before recents.
+  const { data: ownGraphArtists } = useOwnGraphArtistsQuery(profileId, {
+    enabled:
+      Boolean(profileId) && (isRoot || (isEntity && state.kind === 'artist')),
+  });
+
   return useMemo<UseSlashItemsResult>(() => {
     if (state.status === 'closed') {
       return { items: [], sections: [], isLoading: false };
@@ -201,7 +210,15 @@ export function useSlashItems(
       limit
     );
 
-    const artistRecents = recents.filter(r => r.kind === 'artist');
+    // Own-graph artists (self first, then collaborators) seed the recents
+    // tier so they win over Spotify fallback and de-dupe by id.
+    const ownGraphRefs = (ownGraphArtists ?? []).map(ownGraphArtistToEntityRef);
+    const artistRecents = [
+      ...ownGraphRefs,
+      ...recents.filter(
+        r => r.kind === 'artist' && !ownGraphRefs.some(own => own.id === r.id)
+      ),
+    ];
     const artistEntities: EntityRef[] = rankRecentsFirst(
       artistRecents,
       artistSearch.results
@@ -296,6 +313,7 @@ export function useSlashItems(
     query,
     isEntity,
     recents,
+    ownGraphArtists,
     releaseData,
     releaseLoading,
     eventData,

--- a/apps/web/components/jovie/components/entity-mappers.test.ts
+++ b/apps/web/components/jovie/components/entity-mappers.test.ts
@@ -108,7 +108,8 @@ describe('rankRecentsFirst', () => {
       'spotify-hit',
     ]);
     expect(result[0]?.meta?.subtitle).toBe('You');
-    expect(result[0]?.meta?.isYou).toBe(true);
+    // Narrow the EntityRefMeta discriminated union before reading isYou.
+    expect(result[0]?.meta).toMatchObject({ kind: 'artist', isYou: true });
   });
 });
 

--- a/apps/web/components/jovie/components/entity-mappers.test.ts
+++ b/apps/web/components/jovie/components/entity-mappers.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { EntityRef } from '@/lib/commands/entities';
 import {
   formatLongDate,
+  ownGraphArtistToEntityRef,
   rankRecentsFirst,
   shortMonthDay,
 } from './entity-mappers';
@@ -85,6 +86,48 @@ describe('rankRecentsFirst', () => {
   it('returns only source when there are no recents (Spotify fallback)', () => {
     const source = [artist('a1', 'One')];
     expect(rankRecentsFirst([], source, 'whatever', 8)).toEqual(source);
+  });
+
+  it('seeds claimed-self ahead of Spotify on cold start (JOV-3717)', () => {
+    const self = ownGraphArtistToEntityRef({
+      id: 'me-spotify',
+      name: 'Tim White',
+      imageUrl: 'https://example.com/a.jpg',
+      isClaimedSelf: true,
+    });
+    const collab = ownGraphArtistToEntityRef({
+      id: 'collab-1',
+      name: 'Feature Artist',
+      isClaimedSelf: false,
+    });
+    const spotify = [artist('spotify-hit', 'Random Spotify')];
+    const result = rankRecentsFirst([self, collab], spotify, '', 8);
+    expect(result.map(r => r.id)).toEqual([
+      'me-spotify',
+      'collab-1',
+      'spotify-hit',
+    ]);
+    expect(result[0]?.meta?.subtitle).toBe('You');
+    expect(result[0]?.meta?.isYou).toBe(true);
+  });
+});
+
+describe('ownGraphArtistToEntityRef', () => {
+  it('marks claimed self as You and collaborators as Catalog', () => {
+    expect(
+      ownGraphArtistToEntityRef({
+        id: '1',
+        name: 'Me',
+        isClaimedSelf: true,
+      }).meta
+    ).toMatchObject({ subtitle: 'You', isYou: true });
+    expect(
+      ownGraphArtistToEntityRef({
+        id: '2',
+        name: 'Collab',
+        isClaimedSelf: false,
+      }).meta
+    ).toMatchObject({ subtitle: 'Catalog', isYou: false });
   });
 });
 

--- a/apps/web/components/jovie/components/entity-mappers.ts
+++ b/apps/web/components/jovie/components/entity-mappers.ts
@@ -164,3 +164,27 @@ export function artistResultToEntityRef(r: SpotifyArtistResult): EntityRef {
     },
   };
 }
+
+/**
+ * Map own-graph artists (claimed self + catalog collaborators) into picker
+ * EntityRefs (JOV-3717). Claimed self always reads "You"; collaborators are
+ * attributed as catalog so they rank with the recents/own-graph tier.
+ */
+export function ownGraphArtistToEntityRef(artist: {
+  readonly id: string;
+  readonly name: string;
+  readonly imageUrl?: string | null;
+  readonly isClaimedSelf: boolean;
+}): EntityRef {
+  return {
+    kind: 'artist',
+    id: artist.id,
+    label: artist.name,
+    thumbnail: artist.imageUrl ?? undefined,
+    meta: {
+      kind: 'artist',
+      subtitle: artist.isClaimedSelf ? 'You' : 'Catalog',
+      isYou: artist.isClaimedSelf,
+    },
+  };
+}

--- a/apps/web/lib/chat/own-graph-artists.ts
+++ b/apps/web/lib/chat/own-graph-artists.ts
@@ -1,0 +1,89 @@
+'use server';
+
+/**
+ * Own-graph artist sources for the entity picker (JOV-3717).
+ *
+ * Returns the claimed-self Spotify identity (when linked) plus catalog
+ * collaborators that have a Spotify id — enough to tag without a Spotify
+ * search round-trip on cold start.
+ */
+
+import { and, eq, isNotNull, isNull, ne } from 'drizzle-orm';
+import { getDashboardDataEssential } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
+import { db } from '@/lib/db';
+import {
+  artists,
+  discogReleases,
+  releaseArtists,
+} from '@/lib/db/schema/content';
+
+export interface OwnGraphArtist {
+  readonly id: string;
+  readonly name: string;
+  readonly imageUrl: string | null;
+  /** True when this is the current profile's linked Spotify artist. */
+  readonly isClaimedSelf: boolean;
+}
+
+export async function loadOwnGraphArtists(
+  profileId: string
+): Promise<readonly OwnGraphArtist[]> {
+  if (!profileId) return [];
+
+  const data = await getDashboardDataEssential();
+  const profile =
+    data.selectedProfile?.id === profileId
+      ? data.selectedProfile
+      : (data.creatorProfiles.find(p => p.id === profileId) ?? null);
+
+  if (!profile) return [];
+
+  const out: OwnGraphArtist[] = [];
+  const seen = new Set<string>();
+  const selfSpotifyId = profile.spotifyId?.trim() || null;
+
+  if (selfSpotifyId) {
+    seen.add(selfSpotifyId);
+    out.push({
+      id: selfSpotifyId,
+      name: profile.displayName?.trim() || profile.username || 'You',
+      imageUrl: profile.avatarUrl ?? null,
+      isClaimedSelf: true,
+    });
+  }
+
+  const collaboratorWhere = [
+    eq(discogReleases.creatorProfileId, profileId),
+    isNull(discogReleases.deletedAt),
+    isNotNull(artists.spotifyId),
+  ];
+  if (selfSpotifyId) {
+    collaboratorWhere.push(ne(artists.spotifyId, selfSpotifyId));
+  }
+
+  const collaboratorRows = await db
+    .select({
+      id: artists.spotifyId,
+      name: artists.name,
+      imageUrl: artists.imageUrl,
+    })
+    .from(releaseArtists)
+    .innerJoin(artists, eq(releaseArtists.artistId, artists.id))
+    .innerJoin(discogReleases, eq(releaseArtists.releaseId, discogReleases.id))
+    .where(and(...collaboratorWhere))
+    .limit(48);
+
+  for (const row of collaboratorRows) {
+    if (!row.id || seen.has(row.id)) continue;
+    seen.add(row.id);
+    out.push({
+      id: row.id,
+      name: row.name,
+      imageUrl: row.imageUrl,
+      isClaimedSelf: false,
+    });
+    if (out.length >= 20) break;
+  }
+
+  return out;
+}

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -340,6 +340,9 @@ export const queryKeys = {
     usage: () => [...queryKeys.chat.all, 'usage'] as const,
     capabilities: (profileId: string | null | undefined) =>
       [...queryKeys.chat.all, 'capabilities', profileId ?? 'active'] as const,
+    /** Claimed-self + catalog collaborators for the entity picker (JOV-3717). */
+    ownGraphArtists: (profileId: string) =>
+      [...queryKeys.chat.all, 'own-graph-artists', profileId] as const,
   },
 
   // Opportunity inbox (suggested_actions)

--- a/apps/web/lib/queries/useOwnGraphArtistsQuery.ts
+++ b/apps/web/lib/queries/useOwnGraphArtistsQuery.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { loadOwnGraphArtists } from '@/lib/chat/own-graph-artists';
+import { STABLE_CACHE } from '@/lib/queries/cache-strategies';
+import { queryKeys } from '@/lib/queries/keys';
+
+/**
+ * Claimed-self + catalog collaborator artists for the entity picker own-graph
+ * tier (JOV-3717). Stable cache — identity and credits change rarely.
+ */
+export function useOwnGraphArtistsQuery(
+  profileId: string,
+  { enabled = true }: { readonly enabled?: boolean } = {}
+) {
+  return useQuery({
+    queryKey: queryKeys.chat.ownGraphArtists(profileId),
+    // eslint-disable-next-line @jovie/require-abort-signal -- server action; AbortSignal not passable
+    queryFn: () => loadOwnGraphArtists(profileId),
+    ...STABLE_CACHE,
+    enabled: enabled && Boolean(profileId),
+  });
+}

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -423,7 +423,7 @@ describe('surface elevation guardrails', () => {
 
     expect(shellFrame).toContain('lg:shadow-(--linear-app-shell-shadow)');
     expect(shellFrame).toContain(
-      'lg:gap-[var(--linear-app-shell-gap)] lg:p-[var(--linear-app-shell-gap)]'
+      'lg:gap-(--linear-app-shell-gap) lg:p-(--linear-app-shell-gap)'
     );
     expect(linearTokens).toContain('--linear-app-sidebar-shadow:');
     expect(sidebar).not.toContain(

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -26,7 +26,7 @@ describe('AppShellFrame', () => {
     // strips the top corners now that the header lives inside the card.
     expect(mainContent).toHaveClass('lg:rounded-(--linear-app-shell-radius)');
     expect(mainContent.querySelector('div.flex.flex-1')).toHaveClass(
-      'lg:gap-[var(--linear-app-shell-gap)]'
+      'lg:gap-(--linear-app-shell-gap)'
     );
     expect(screen.getByText('Sidebar')).toBeInTheDocument();
     expect(screen.getByText('Main Content')).toBeInTheDocument();
@@ -71,7 +71,7 @@ describe('AppShellFrame', () => {
       'lg:shadow-[var(--linear-app-shell-shadow)]'
     );
     expect(mainContent.querySelector('div.flex.flex-1')).not.toHaveClass(
-      'lg:gap-[var(--linear-app-shell-gap)]'
+      'lg:gap-(--linear-app-shell-gap)'
     );
   });
 


### PR DESCRIPTION
## Summary
- Server action `loadOwnGraphArtists` returns claimed-self + catalog collaborators with Spotify ids
- Seeds entity picker artist tier ahead of recents + Spotify via rankRecentsFirst
- Contact picker kind deferred (wire-format change)

Fixes JOV-3717
<!-- linear-issue-id:d73c8eab-46ce-41d1-aa6f-ebbdae60d0a7 -->

## Verification
- vitest entity-mappers.test.ts 18/18

## Cost Impact
- One cached server-action read per profile when picker opens; max 20 collaborator rows