### PR TITLE
feat(ios): chat-first shell — tabs, Talk FAB, library, entity sheet

### DIFF
--- a/apps/ios/Jovie.xcodeproj/project.pbxproj
+++ b/apps/ios/Jovie.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A0J0V3632A00000000000002 /* AppShellTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V3632A00000000000001 /* AppShellTabBar.swift */; };
+		A0J0V3632A00000000000004 /* TalkOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V3632A00000000000003 /* TalkOverlayView.swift */; };
+		A0J0V3632A00000000000006 /* EntityContextSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V3632A00000000000005 /* EntityContextSheet.swift */; };
+		A0J0V3632A00000000000008 /* LibraryModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V3632A00000000000007 /* LibraryModels.swift */; };
+		A0J0V3632A0000000000000A /* LibrarySurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V3632A00000000000009 /* LibrarySurfaceView.swift */; };
+		A0J0V3632A0000000000000C /* CalendarSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V3632A0000000000000B /* CalendarSurfaceView.swift */; };
+		A0J0V3632A0000000000000E /* InboxSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V3632A0000000000000D /* InboxSurfaceView.swift */; };
+		A0J0V3632A00000000000010 /* AppShellTabBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0J0V3632A0000000000000F /* AppShellTabBarTests.swift */; };
 		045FC6E446AFF7FFD3ED0FE2 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71445144CE0970267C0508C6 /* AppState.swift */; };
 		19328D236A7AE57920138038 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 47976CA8BC5B309FDB2B6215 /* Assets.xcassets */; };
 		296968C7C074659FBA3D85E9 /* Inter-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A108B03BA602F4C24B54E590 /* Inter-Variable.ttf */; };
@@ -114,6 +122,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A0J0V3632A00000000000001 /* AppShellTabBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellTabBar.swift; sourceTree = "<group>"; };
+		A0J0V3632A00000000000003 /* TalkOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TalkOverlayView.swift; sourceTree = "<group>"; };
+		A0J0V3632A00000000000005 /* EntityContextSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityContextSheet.swift; sourceTree = "<group>"; };
+		A0J0V3632A00000000000007 /* LibraryModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LibraryModels.swift; sourceTree = "<group>"; };
+		A0J0V3632A00000000000009 /* LibrarySurfaceView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LibrarySurfaceView.swift; sourceTree = "<group>"; };
+		A0J0V3632A0000000000000B /* CalendarSurfaceView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CalendarSurfaceView.swift; sourceTree = "<group>"; };
+		A0J0V3632A0000000000000D /* InboxSurfaceView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InboxSurfaceView.swift; sourceTree = "<group>"; };
+		A0J0V3632A0000000000000F /* AppShellTabBarTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellTabBarTests.swift; sourceTree = "<group>"; };
 		000F426E1AB94DD5401C3341 /* QRCodeRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeRenderer.swift; sourceTree = "<group>"; };
 		00BCF42EFB99B5DAB4E0F400 /* JovieApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JovieApp.swift; sourceTree = "<group>"; };
 		0A40F1B3BFCC6AD8FF8EAF93 /* JovieAppIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JovieAppIntents.swift; sourceTree = "<group>"; };
@@ -275,14 +291,45 @@
 			path = Audience;
 			sourceTree = "<group>";
 		};
+		A0J0V3632C00000000000001 /* Calendar */ = {
+			isa = PBXGroup;
+			children = (
+				A0J0V3632A0000000000000B /* CalendarSurfaceView.swift */,
+			);
+			name = Calendar;
+			path = Calendar;
+			sourceTree = "<group>";
+		};
+		A0J0V3632I00000000000001 /* Inbox */ = {
+			isa = PBXGroup;
+			children = (
+				A0J0V3632A0000000000000D /* InboxSurfaceView.swift */,
+			);
+			name = Inbox;
+			path = Inbox;
+			sourceTree = "<group>";
+		};
+		A0J0V3632L00000000000001 /* Library */ = {
+			isa = PBXGroup;
+			children = (
+				A0J0V3632A00000000000007 /* LibraryModels.swift */,
+				A0J0V3632A00000000000009 /* LibrarySurfaceView.swift */,
+			);
+			name = Library;
+			path = Library;
+			sourceTree = "<group>";
+		};
 		38A521B77CFB8C49A552F2BF /* Features */ = {
 			isa = PBXGroup;
 			children = (
 				A0J0V36380000000000000007 /* Audience */,
 				44CFD0078FC64A56A527EB88 /* AppShell */,
 				D38B16D4420C99A6D206BF5B /* Auth */,
+				A0J0V3632C00000000000001 /* Calendar */,
 				A0J0V25490000000000000010 /* Chat */,
 				A5A8CD9F74C3AE8AD7332D93 /* Dashboard */,
+				A0J0V3632I00000000000001 /* Inbox */,
+				A0J0V3632L00000000000001 /* Library */,
 				3BE73A70044C889546FD4A64 /* NeedsOnboarding */,
 				876FD84B7A3B40CAA0DDDBC8 /* Settings */,
 				D8C70D614390928784D627FC /* Splash */,
@@ -314,6 +361,7 @@
 				A0A344000000000000000003 /* AppShellIntentNavigationTests.swift */,
 				A0J0V36330000000000000003 /* AppShellDrawerThreadsFilterTests.swift */,
 				A0GH12170000000000000003 /* AppShellChatFirstTests.swift */,
+				A0J0V3632A0000000000000F /* AppShellTabBarTests.swift */,
 				A0J0V36380000000000000008 /* AudienceHighlightsRepositoryTests.swift */,
 				A0J0V3638000000000000000A /* MobileAudienceHighlightsResponseTests.swift */,
 				A0GH12706000000000000005 /* MobileActionLoopResponseTests.swift */,
@@ -347,7 +395,10 @@
 			children = (
 				A0A344000000000000000001 /* AppShellIntentNavigation.swift */,
 				A0J0V36330000000000000001 /* AppShellLeftDrawer.swift */,
+				A0J0V3632A00000000000001 /* AppShellTabBar.swift */,
 				4C2C97BF3A0B42C58A62529F /* AppShellView.swift */,
+				A0J0V3632A00000000000005 /* EntityContextSheet.swift */,
+				A0J0V3632A00000000000003 /* TalkOverlayView.swift */,
 			);
 			name = AppShell;
 			path = AppShell;
@@ -673,6 +724,7 @@
 				A0A344000000000000000004 /* AppShellIntentNavigationTests.swift in Sources */,
 				A0J0V36330000000000000004 /* AppShellDrawerThreadsFilterTests.swift in Sources */,
 				A0GH12170000000000000004 /* AppShellChatFirstTests.swift in Sources */,
+				A0J0V3632A00000000000010 /* AppShellTabBarTests.swift in Sources */,
 				A0J0V36380000000000000009 /* AudienceHighlightsRepositoryTests.swift in Sources */,
 				A0J0V3638000000000000000B /* MobileAudienceHighlightsResponseTests.swift in Sources */,
 				A0GH12706000000000000006 /* MobileActionLoopResponseTests.swift in Sources */,
@@ -722,6 +774,13 @@
 				6E62396A29D88F275920CA48 /* JovieTheme.swift in Sources */,
 				A0A344000000000000000002 /* AppShellIntentNavigation.swift in Sources */,
 				A0J0V36330000000000000002 /* AppShellLeftDrawer.swift in Sources */,
+				A0J0V3632A00000000000002 /* AppShellTabBar.swift in Sources */,
+				A0J0V3632A00000000000004 /* TalkOverlayView.swift in Sources */,
+				A0J0V3632A00000000000006 /* EntityContextSheet.swift in Sources */,
+				A0J0V3632A00000000000008 /* LibraryModels.swift in Sources */,
+				A0J0V3632A0000000000000A /* LibrarySurfaceView.swift in Sources */,
+				A0J0V3632A0000000000000C /* CalendarSurfaceView.swift in Sources */,
+				A0J0V3632A0000000000000E /* InboxSurfaceView.swift in Sources */,
 				5F4F3551CC9F4C09A2520AEB /* AppShellView.swift in Sources */,
 				F95545618F95E792DCBCA7DF /* AuthScreen.swift in Sources */,
 				74E75D0A3C816805F65FA48A /* DashboardView.swift in Sources */,

--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -173,6 +173,10 @@ private struct AppContentView: View {
   @State private var chatRepository: ChatRepository?
   @State private var chatDraft = ""
   @State private var audienceHighlightsState: AudienceHighlightsLoadState
+  @State private var calendarResponse: MobileActionLoopCalendarResponse?
+  @State private var inboxResponse: MobileActionLoopInboxResponse?
+  @State private var isLoadingCalendar = false
+  @State private var isLoadingInbox = false
 
   init(
     appState: AppState,
@@ -250,7 +254,13 @@ private struct AppContentView: View {
           NeedsOnboardingView(continueURL: appState.continueOnWebURL)
         } audienceContent: { _ in
           EmptyView()
-        } chatContent: { draft, voiceCaptureTrigger in
+        } libraryContent: { _ in
+          EmptyView()
+        } calendarContent: { _ in
+          EmptyView()
+        } inboxContent: { _ in
+          EmptyView()
+        } chatContent: { draft, voiceCaptureTrigger, _ in
           if let chatRepository {
             MobileChatView(
               repository: chatRepository,
@@ -304,13 +314,35 @@ private struct AppContentView: View {
             onRetry: { await reloadAudienceHighlights(for: appState.activeUserID) },
             onAskJovie: askJovie
           )
-        } chatContent: { draft, voiceCaptureTrigger in
+        } libraryContent: { onSelectAsset in
+          LibrarySurfaceView(
+            assets: LibraryFeed.previewAssets,
+            onSelectAsset: onSelectAsset
+          )
+        } calendarContent: { askJovie in
+          CalendarSurfaceView(
+            response: calendarResponse ?? (usesPreviewActionLoops ? .preview : nil),
+            isLoading: isLoadingCalendar && calendarResponse == nil,
+            isOffline: appState.isOffline,
+            onRetry: { await reloadActionLoops(for: appState.activeUserID) },
+            onAskJovie: askJovie
+          )
+        } inboxContent: { askJovie in
+          InboxSurfaceView(
+            response: inboxResponse ?? (usesPreviewActionLoops ? .preview : nil),
+            isLoading: isLoadingInbox && inboxResponse == nil,
+            isOffline: appState.isOffline,
+            onRetry: { await reloadActionLoops(for: appState.activeUserID) },
+            onAskJovie: askJovie
+          )
+        } chatContent: { draft, voiceCaptureTrigger, onEntityTap in
           if let chatRepository {
             MobileChatView(
               repository: chatRepository,
               draft: draft,
               voiceCaptureTrigger: voiceCaptureTrigger,
-              webBaseURL: appState.configuration.webBaseURL
+              webBaseURL: appState.configuration.webBaseURL,
+              onEntityTap: onEntityTap
             )
           } else {
             MobileChatPlaceholderView(isOffline: appState.isOffline, draft: draft)
@@ -326,6 +358,7 @@ private struct AppContentView: View {
     .task(id: "\(appState.route)-\(appState.launchMode)") {
       guard appState.route == .ready else { return }
       await reloadAudienceHighlights(for: appState.activeUserID)
+      await reloadActionLoops(for: appState.activeUserID)
     }
     .task(id: appState.activeUserID) {
       guard let activeUserID = appState.activeUserID else {
@@ -373,6 +406,62 @@ private struct AppContentView: View {
 
   private func handleAutoSendMessage(_ text: String) {
     Task { await chatRepository?.send(text: text) }
+  }
+
+  private var usesPreviewActionLoops: Bool {
+    switch appState.launchMode {
+    case .uiTestingAudience,
+         .uiTestingReady,
+         .uiTestingChat,
+         .uiTestingChatOffline,
+         .uiTestingChatEntityFixture,
+         .uiTestingSettings,
+         .uiTestingVenueMode,
+         .uiTestingAuthCallback:
+      return true
+    default:
+      return !appState.launchMode.usesLiveClerk
+    }
+  }
+
+  @MainActor
+  private func reloadActionLoops(for userID: String?) async {
+    if usesPreviewActionLoops {
+      calendarResponse = .preview
+      inboxResponse = .preview
+      isLoadingCalendar = false
+      isLoadingInbox = false
+      return
+    }
+
+    guard let userID, appState.route == .ready else {
+      calendarResponse = nil
+      inboxResponse = nil
+      return
+    }
+
+    _ = userID
+    let client = APIClient(
+      baseURL: appState.configuration.apiBaseURL,
+      tokenProvider: NativeSessionTokenProvider()
+    )
+
+    isLoadingCalendar = calendarResponse == nil
+    isLoadingInbox = inboxResponse == nil
+
+    do {
+      calendarResponse = try await client.fetchActionLoopCalendar()
+    } catch {
+      // Keep stale calendar if revalidation fails.
+    }
+    isLoadingCalendar = false
+
+    do {
+      inboxResponse = try await client.fetchActionLoopInbox()
+    } catch {
+      // Keep stale inbox if revalidation fails.
+    }
+    isLoadingInbox = false
   }
 
   @MainActor
@@ -468,7 +557,6 @@ private struct ChatComposerPreview: View {
   @Binding var draft: String
   let isOffline: Bool
   @FocusState private var isComposerFocused: Bool
-  @State private var voiceCaptureService = VoiceCaptureService()
 
   var body: some View {
     ChatComposerBar(
@@ -477,10 +565,6 @@ private struct ChatComposerPreview: View {
       placeholder: isOffline ? "Ask Jovie (offline)" : "Ask Jovie",
       isSending: false,
       isPlusEnabled: true,
-      voiceCaptureService: voiceCaptureService,
-      onVoiceStart: {},
-      onVoiceFinish: {},
-      onVoiceCancel: {},
       onSend: { draft = "" },
       onSelectWorkflow: { action in
         draft = action.prompt

--- a/apps/ios/Jovie/Features/AppShell/AppShellTabBar.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellTabBar.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+/// Primary bottom destinations (JOV-3632). Profile + Audience stay drawer-only.
+enum AppShellPrimaryTab: Equatable, Hashable, CaseIterable {
+  case chat
+  case library
+  case calendar
+  case inbox
+
+  var shellTab: AppShellTab {
+    switch self {
+    case .chat: return .chat
+    case .library: return .library
+    case .calendar: return .calendar
+    case .inbox: return .inbox
+    }
+  }
+
+  var title: String {
+    shellTab.title
+  }
+
+  var systemImage: String {
+    shellTab.systemImage
+  }
+
+  var accessibilityID: String {
+    shellTab.accessibilityID
+  }
+}
+
+enum AppShellTabBarLayout {
+  /// Reserved height for the bar content (excluding home-indicator safe area).
+  static let barHeight: CGFloat = 56
+  /// Raised mic sits above the bar midline so it reads as a center FAB.
+  static let talkFabSize: CGFloat = 58
+  static let talkFabLift: CGFloat = 18
+}
+
+/// Thumb-zone bottom bar: Chat · Library · [Talk FAB] · Calendar · Inbox.
+struct AppShellTabBar: View {
+  let selectedTab: AppShellTab
+  let onSelect: (AppShellPrimaryTab) -> Void
+  let onTalk: () -> Void
+
+  var body: some View {
+    HStack(spacing: 0) {
+      tabButton(.chat)
+      tabButton(.library)
+      talkButton
+      tabButton(.calendar)
+      tabButton(.inbox)
+    }
+    .padding(.horizontal, JovieSpacing.small)
+    .frame(height: AppShellTabBarLayout.barHeight)
+    .frame(maxWidth: .infinity)
+    .background(JovieColor.backgroundBase.opacity(0.98))
+    .overlay(alignment: .top) {
+      Rectangle()
+        .fill(JovieColor.borderSubtle)
+        .frame(height: 1)
+    }
+    .accessibilityIdentifier("shell-tab-bar")
+  }
+
+  private func tabButton(_ tab: AppShellPrimaryTab) -> some View {
+    let isSelected = selectedTab == tab.shellTab
+    return Button {
+      onSelect(tab)
+    } label: {
+      VStack(spacing: 4) {
+        Image(systemName: tab.systemImage)
+          .font(.system(size: 18, weight: .semibold))
+        Text(tab.title)
+          .font(JovieFont.body(size: 11, weight: .medium))
+          .lineLimit(1)
+      }
+      .foregroundStyle(isSelected ? JovieColor.textPrimary : JovieColor.textTertiary)
+      .frame(maxWidth: .infinity)
+      .frame(height: AppShellTabBarLayout.barHeight)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(AppShellTabBarButtonStyle())
+    .accessibilityLabel(tab.title)
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    .accessibilityIdentifier(tab.accessibilityID)
+  }
+
+  private var talkButton: some View {
+    Button(action: onTalk) {
+      ZStack {
+        Circle()
+          .fill(Color.white)
+          .frame(
+            width: AppShellTabBarLayout.talkFabSize,
+            height: AppShellTabBarLayout.talkFabSize
+          )
+          .shadow(color: .black.opacity(0.28), radius: 12, y: 4)
+
+        Image(systemName: "mic.fill")
+          .font(.system(size: 22, weight: .bold))
+          .foregroundStyle(JovieColor.backgroundBase)
+      }
+      .offset(y: -AppShellTabBarLayout.talkFabLift)
+    }
+    .buttonStyle(AppShellTabBarButtonStyle())
+    .frame(width: AppShellTabBarLayout.talkFabSize + 8)
+    .accessibilityLabel("Talk")
+    .accessibilityIdentifier("shell-talk-fab")
+    .accessibilityHint("Opens full-screen voice capture")
+  }
+}
+
+private struct AppShellTabBarButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .opacity(configuration.isPressed ? 0.72 : 1)
+      .scaleEffect(configuration.isPressed ? JovieMotion.pressScale : 1)
+      .animation(JovieMotion.subtle, value: configuration.isPressed)
+  }
+}
+
+/// Pure helpers for gesture ownership (JOV-3635) — edge swipes own rails;
+/// tabs own surface switching. Horizontal page-swipes between tabs are banned.
+enum AppShellGesturePolicy {
+  static let leftEdgeOpenWidth: CGFloat = 28
+  static let rightEdgeOpenWidth: CGFloat = 28
+  static let openDistance: CGFloat = 72
+  static let openPredicted: CGFloat = 120
+
+  static func isLeftEdgeOpen(startX: CGFloat, translationX: CGFloat, predictedX: CGFloat)
+    -> Bool
+  {
+    startX < leftEdgeOpenWidth
+      && (translationX > openDistance || predictedX > openPredicted)
+  }
+
+  static func isRightEdgeOpen(
+    startX: CGFloat,
+    containerWidth: CGFloat,
+    translationX: CGFloat,
+    predictedX: CGFloat
+  ) -> Bool {
+    startX > containerWidth - rightEdgeOpenWidth
+      && (translationX < -openDistance || predictedX < -openPredicted)
+  }
+
+  /// Tabs switch only via explicit selection — never via horizontal swipe.
+  static func shouldSwitchTabFromHorizontalSwipe() -> Bool {
+    false
+  }
+}

--- a/apps/ios/Jovie/Features/AppShell/AppShellTabBar.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellTabBar.swift
@@ -60,6 +60,11 @@ struct AppShellTabBar: View {
         .fill(JovieColor.borderSubtle)
         .frame(height: 1)
     }
+    // Keep children as independent AX elements with their own identifiers.
+    // A bare accessibilityIdentifier on the HStack was bleeding onto every
+    // child button (all exposed as identifier "shell-tab-bar"), which broke
+    // UITests looking for shell-tab-chat / shell-talk-fab.
+    .accessibilityElement(children: .contain)
     .accessibilityIdentifier("shell-tab-bar")
   }
 
@@ -81,6 +86,7 @@ struct AppShellTabBar: View {
       .contentShape(Rectangle())
     }
     .buttonStyle(AppShellTabBarButtonStyle())
+    .accessibilityElement(children: .ignore)
     .accessibilityLabel(tab.title)
     .accessibilityAddTraits(isSelected ? [.isSelected] : [])
     .accessibilityIdentifier(tab.accessibilityID)
@@ -105,6 +111,7 @@ struct AppShellTabBar: View {
     }
     .buttonStyle(AppShellTabBarButtonStyle())
     .frame(width: AppShellTabBarLayout.talkFabSize + 8)
+    .accessibilityElement(children: .ignore)
     .accessibilityLabel("Talk")
     .accessibilityIdentifier("shell-talk-fab")
     .accessibilityHint("Opens full-screen voice capture")

--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -2,57 +2,67 @@ import SwiftUI
 
 enum AppShellTab: Equatable, Hashable {
   case chat
+  case library
+  case calendar
+  case inbox
   case profile
   case audience
 
   var accessibilityID: String {
     switch self {
-    case .chat:
-      return "shell-tab-chat"
-    case .profile:
-      return "shell-tab-profile"
-    case .audience:
-      return "shell-tab-audience"
+    case .chat: return "shell-tab-chat"
+    case .library: return "shell-tab-library"
+    case .calendar: return "shell-tab-calendar"
+    case .inbox: return "shell-tab-inbox"
+    case .profile: return "shell-tab-profile"
+    case .audience: return "shell-tab-audience"
     }
   }
 
   var title: String {
     switch self {
-    case .chat:
-      return "Chat"
-    case .profile:
-      return "Profile"
-    case .audience:
-      return "Audience"
+    case .chat: return "Chat"
+    case .library: return "Library"
+    case .calendar: return "Calendar"
+    case .inbox: return "Inbox"
+    case .profile: return "Profile"
+    case .audience: return "Audience"
     }
   }
 
   var systemImage: String {
     switch self {
-    case .chat:
-      return "sparkles"
-    case .profile:
-      return "qrcode.viewfinder"
-    case .audience:
-      return "person.3"
+    case .chat: return "sparkles"
+    case .library: return "square.stack"
+    case .calendar: return "calendar"
+    case .inbox: return "tray"
+    case .profile: return "qrcode.viewfinder"
+    case .audience: return "person.3"
     }
   }
 
+  /// Primary thumb-zone destinations (Audience + Profile are drawer-only).
+  var isPrimaryTab: Bool {
+    switch self {
+    case .chat, .library, .calendar, .inbox:
+      return true
+    case .profile, .audience:
+      return false
+    }
+  }
 }
 
 // File-level so unit tests can call it without importing SwiftUI.
 func resolveShellInitialTab(_ initialTab: AppShellTab, chatEnabled: Bool) -> AppShellTab {
   switch initialTab {
-  case .chat:
-    return chatEnabled ? .chat : .profile
+  case .chat, .library, .calendar, .inbox:
+    return chatEnabled ? initialTab : .profile
   case .audience, .profile:
     return initialTab
   }
 }
 
 // GH-12949: the recessed drawer base plane must be fully invisible while closed.
-// Content chrome (composer, toolbar) can be translucent, so occlusion alone is
-// not enough — opacity 0 when idle prevents thread rows from peeking through.
 func appShellDrawerBasePlaneOpacity(
   isShowingDrawer: Bool,
   drawerDragOffset: CGFloat
@@ -86,7 +96,16 @@ struct AppShellProfile: Equatable {
   }
 }
 
-struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: View>: View {
+/// 4-layer chat-first shell (JOV-3632):
+/// home content → tab bar → rails (drawer / entity sheet) → overlays (Talk).
+struct AppShellView<
+  ProfileContent: View,
+  AudienceContent: View,
+  LibraryContent: View,
+  CalendarContent: View,
+  InboxContent: View,
+  ChatContent: View
+>: View {
   let profile: AppShellProfile
   let isOffline: Bool
   let opensSettingsOnLaunch: Bool
@@ -102,7 +121,14 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
   let onLogout: @MainActor () async -> Void
   @ViewBuilder let profileContent: ProfileContent
   @ViewBuilder let audienceContent: (_ askJovie: @escaping (String) -> Void) -> AudienceContent
-  let chatContent: (Binding<String>, Binding<Int>) -> ChatContent
+  @ViewBuilder let libraryContent: (_ onSelectAsset: @escaping (LibraryAsset) -> Void) -> LibraryContent
+  @ViewBuilder let calendarContent: (_ askJovie: @escaping (String) -> Void) -> CalendarContent
+  @ViewBuilder let inboxContent: (_ askJovie: @escaping (String) -> Void) -> InboxContent
+  let chatContent: (
+    Binding<String>,
+    Binding<Int>,
+    @escaping (EntityContextItem) -> Void
+  ) -> ChatContent
 
   @State private var selectedTab: AppShellTab
   @State private var navigationPath: [AppShellRoute] = []
@@ -112,6 +138,10 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
   @State private var didOpenLaunchSettings = false
   @State private var chatDraft = ""
   @State private var voiceCaptureTrigger = 0
+  @State private var isShowingTalkOverlay = false
+  @State private var talkVoiceService = VoiceCaptureService()
+  @State private var entityContext: EntityContextItem?
+  @State private var lastEntityContext: EntityContextItem?
   @State private var intentStore = IntentNavigationStore.shared
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -132,7 +162,19 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     onLogout: @escaping @MainActor () async -> Void,
     @ViewBuilder profileContent: () -> ProfileContent,
     @ViewBuilder audienceContent: @escaping (_ askJovie: @escaping (String) -> Void) -> AudienceContent,
-    @ViewBuilder chatContent: @escaping (Binding<String>, Binding<Int>) -> ChatContent
+    @ViewBuilder libraryContent: @escaping (_ onSelectAsset: @escaping (LibraryAsset) -> Void)
+      -> LibraryContent = { _ in EmptyView() },
+    @ViewBuilder calendarContent: @escaping (_ askJovie: @escaping (String) -> Void) -> CalendarContent = { _ in
+      EmptyView()
+    },
+    @ViewBuilder inboxContent: @escaping (_ askJovie: @escaping (String) -> Void) -> InboxContent = { _ in
+      EmptyView()
+    },
+    @ViewBuilder chatContent: @escaping (
+      Binding<String>,
+      Binding<Int>,
+      @escaping (EntityContextItem) -> Void
+    ) -> ChatContent
   ) {
     self.profile = profile
     self.isOffline = isOffline
@@ -149,6 +191,9 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     self.onLogout = onLogout
     self.profileContent = profileContent()
     self.audienceContent = audienceContent
+    self.libraryContent = libraryContent
+    self.calendarContent = calendarContent
+    self.inboxContent = inboxContent
     self.chatContent = chatContent
     _selectedTab = State(
       initialValue: Self.resolvedInitialTab(initialTab: initialTab, chatEnabled: chatEnabled)
@@ -159,14 +204,9 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     NavigationStack(path: $navigationPath) {
       GeometryReader { proxy in
         let openOffset = drawerOpenOffset(safeAreaLeading: proxy.safeAreaInsets.leading)
-
-        // Drawer is the recessed BASE plane of the ZStack: it never overlays or
-        // dims content. The content container is the elevated plane that slides
-        // right to reveal it, matching the ChatGPT/desktop-app model.
-        // When fully closed the base plane is opacity 0 (GH-12949) so translucent
-        // composer/toolbar regions cannot show drawer rows underneath.
         let isDrawerBasePlaneVisible = isShowingDrawer || drawerDragOffset != 0
 
+        // Layer stack (bottom → top): drawer rail → home+tab bar → Talk overlay.
         ZStack(alignment: .leading) {
           AppShellLeftDrawer(
             isPresented: isShowingDrawer,
@@ -206,18 +246,48 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
           .accessibilityHidden(!isDrawerBasePlaneVisible)
 
           shellContent
-            // Full-bleed elevated card so the base plane cannot peek at bottom
-            // or trailing edges when closed (post–bottom-bar safeAreaInset removal).
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .offset(x: reduceMotion ? 0 : contentOffset(openOffset: openOffset))
             .opacity(reduceMotion && isShowingDrawer ? 0 : 1)
             .animation(drawerAnimation, value: isShowingDrawer)
             .animation(reduceMotion ? nil : drawerAnimation, value: drawerDragOffset)
+
+          if isShowingTalkOverlay, chatEnabled {
+            TalkOverlayView(
+              voiceCaptureService: talkVoiceService,
+              onCancel: {
+                isShowingTalkOverlay = false
+              },
+              onSend: { transcript in
+                isShowingTalkOverlay = false
+                selectTab(.chat)
+                onAutoSendMessage(transcript)
+              }
+            )
+            .transition(.opacity)
+            .zIndex(10)
+          }
         }
-        .simultaneousGesture(edgeSwipeToOpenDrawer(openOffset: openOffset))
+        .simultaneousGesture(
+          edgeRailGesture(
+            openOffset: openOffset,
+            containerWidth: proxy.size.width
+          )
+        )
       }
     }
     .background(JovieColor.backgroundBase)
+    .sheet(item: $entityContext) { item in
+      EntityContextSheet(
+        item: item,
+        onEditInChat: { prompt in
+          entityContext = nil
+          chatDraft = prompt
+          selectTab(.chat)
+        },
+        onDismiss: { entityContext = nil }
+      )
+    }
     .task(id: opensSettingsOnLaunch) {
       guard opensSettingsOnLaunch, didOpenLaunchSettings == false else { return }
       didOpenLaunchSettings = true
@@ -242,13 +312,14 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
       isKeyboardVisible = false
     }
+    .onChange(of: voiceCaptureTrigger) {
+      guard voiceCaptureTrigger > 0, chatEnabled else { return }
+      openTalkOverlay()
+    }
   }
 
-  // The elevated content plane: toolbar and paged content ride together as one
-  // transformable container so the drawer transform reads as a single spatial
-  // move, not independently animated pieces. The drawer is the sole surface
-  // switcher (JOV-3670) — there is no shell-level bottom bar; each screen's
-  // own composer/content extends into the reclaimed space.
+  // Elevated content plane: toolbar + page + tab bar ride together so the
+  // drawer transform reads as one spatial move.
   private var shellContent: some View {
     let isElevated = isShowingDrawer || drawerDragOffset != 0
 
@@ -265,7 +336,17 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
       .safeAreaInset(edge: .top, spacing: 0) {
         shellToolbar
       }
-      .simultaneousGesture(pageSwipe)
+      .safeAreaInset(edge: .bottom, spacing: 0) {
+        if chatEnabled {
+          AppShellTabBar(
+            selectedTab: selectedTab,
+            onSelect: { primary in
+              selectTab(primary.shellTab)
+            },
+            onTalk: openTalkOverlay
+          )
+        }
+      }
       .navigationBarHidden(true)
       .navigationDestination(for: AppShellRoute.self) { route in
         switch route {
@@ -280,11 +361,8 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
           .navigationBarBackButtonHidden()
         }
       }
-      // Content is a non-interactive, dimmed-free card while the drawer is
-      // open: taps land on the transparent overlay below (which closes the
-      // drawer) instead of reaching gear/composer/chat rows underneath.
-      .allowsHitTesting(!isElevated)
-      .accessibilityHidden(isElevated)
+      .allowsHitTesting(!isElevated && !isShowingTalkOverlay)
+      .accessibilityHidden(isElevated || isShowingTalkOverlay)
 
       if isElevated {
         Color.clear
@@ -293,9 +371,6 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
           .accessibilityHidden(true)
       }
     }
-    // Opaque full-size card. Clip first when elevated (rounded card). When
-    // closed, paint an unclipped bottom-safe-area underlay after clip so the
-    // home-indicator band cannot expose the recessed drawer (GH-12949).
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(JovieColor.backgroundBase)
     .clipShape(shellContentClipShape(isElevated: isElevated))
@@ -321,8 +396,6 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     return AnyShape(Rectangle())
   }
 
-  // Consume a navigation request raised by an App Intent (Siri / Shortcuts /
-  // Spotlight). Chat-bound requests land on Profile when chat is unavailable.
   private func applyPendingIntentNavigation() {
     var state = AppShellIntentNavigationState(
       selectedTab: selectedTab,
@@ -380,6 +453,29 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     selectTab(.chat)
   }
 
+  private func openTalkOverlay() {
+    guard chatEnabled else { return }
+    dismissKeyboardIfNeeded()
+    isShowingTalkOverlay = true
+  }
+
+  private func presentEntity(_ item: EntityContextItem) {
+    lastEntityContext = item
+    entityContext = item
+  }
+
+  private func presentEntityFromLibrary(_ asset: LibraryAsset) {
+    // Map library assets into the entity sheet for a shared context surface.
+    let kind: MobileChatEntityKind
+    switch asset.type {
+    case .release: kind = .release
+    case .merch, .smartLink, .photo, .press: kind = .track
+    }
+    presentEntity(
+      EntityContextItem(kind: kind, entityID: asset.id, label: asset.name)
+    )
+  }
+
   static func resolvedInitialTab(
     initialTab: AppShellTab,
     chatEnabled: Bool
@@ -399,8 +495,6 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     drawerWidth + safeAreaLeading
   }
 
-  // Content translates right by however far the drawer is open/dragged so the
-  // two planes move together as one gesture-driven transform.
   private func contentOffset(openOffset: CGFloat) -> CGFloat {
     if isShowingDrawer {
       return max(0, openOffset + drawerDragOffset)
@@ -419,8 +513,6 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     isShowingDrawer = false
   }
 
-  // Closing must finish its transform before the page crossfade starts —
-  // never animate the drawer-close and the tab-change spatial motion at once.
   private func closeDrawerThenSelect(_ tab: AppShellTab) {
     closeDrawer()
     DispatchQueue.main.asyncAfter(deadline: .now() + JovieMotion.cinematicDuration) {
@@ -438,20 +530,21 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     )
   }
 
-  // Horizontally paged primary screens. The left drawer (sole surface switcher,
-  // JOV-3670) drives the same `selectedTab` selection so drawer taps and the
-  // horizontal swipe gesture stay in sync, and each screen keeps its own
-  // vertical scrolling (the swipe is recognized simultaneously and only acts
-  // on a clearly-horizontal end gesture).
   @ViewBuilder
   private var pagedContent: some View {
     switch selectedTab {
     case .chat:
       if chatEnabled {
-        chatContent($chatDraft, $voiceCaptureTrigger)
+        chatContent($chatDraft, $voiceCaptureTrigger, presentEntity)
       } else {
         profileContent
       }
+    case .library:
+      libraryContent(presentEntityFromLibrary)
+    case .calendar:
+      calendarContent(openAudienceChat)
+    case .inbox:
+      inboxContent(openAudienceChat)
     case .profile:
       profileContent
     case .audience:
@@ -459,76 +552,32 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
     }
   }
 
-  // Slide direction follows the destination: Chat enters from the trailing edge,
-  // Profile from the leading edge, so the motion matches the swipe.
   private var pageTransition: AnyTransition {
-    .asymmetric(
-      insertion: .move(edge: pageInsertionEdge),
-      removal: .move(edge: pageRemovalEdge)
-    )
+    .opacity
   }
 
-  private var pageInsertionEdge: Edge {
-    switch selectedTab {
-    case .chat:
-      return .trailing
-    case .profile, .audience:
-      return .leading
-    }
-  }
-
-  private var pageRemovalEdge: Edge {
-    switch selectedTab {
-    case .chat:
-      return .leading
-    case .profile, .audience:
-      return .trailing
-    }
-  }
-
-  private var pageSwipe: some Gesture {
-    DragGesture(minimumDistance: 24)
-      .onEnded { value in
-        guard !isShowingDrawer else { return }
-
-        let horizontal = value.translation.width
-        guard chatEnabled,
-              abs(horizontal) > 60,
-              abs(horizontal) > abs(value.translation.height) * 1.5,
-              value.startLocation.x >= 28 || horizontal < 0
-        else { return }
-
-        withAnimation(JovieMotion.easeOut(duration: JovieMotion.slowDuration)) {
-          if horizontal < 0, selectedTab == .profile {
-            selectedTab = .chat
-          } else if horizontal > 0, selectedTab == .chat {
-            selectedTab = .profile
-          }
-        }
-      }
-  }
-
-  // Drives both directions: an edge-drag from the leading edge opens the
-  // drawer, and (while open) a drag anywhere on the elevated content closes
-  // it. Suppressed entirely while the composer is focused so an edge-drag
-  // inside the chat input can't fight text selection/cursor placement.
-  private func edgeSwipeToOpenDrawer(openOffset: CGFloat) -> some Gesture {
+  /// Edge swipes own rails only (JOV-3635). No horizontal tab paging.
+  private func edgeRailGesture(openOffset: CGFloat, containerWidth: CGFloat) -> some Gesture {
     DragGesture(minimumDistance: 8, coordinateSpace: .global)
       .onChanged { value in
-        guard !reduceMotion, !isKeyboardVisible else { return }
+        guard !reduceMotion, !isKeyboardVisible, !isShowingTalkOverlay else { return }
 
         if isShowingDrawer {
           drawerDragOffset = min(0, value.translation.width)
-        } else if value.startLocation.x < 28, value.translation.width > 0 {
+        } else if value.startLocation.x < AppShellGesturePolicy.leftEdgeOpenWidth,
+                  value.translation.width > 0
+        {
           drawerDragOffset = min(value.translation.width, openOffset)
         }
       }
       .onEnded { value in
-        guard !reduceMotion, !isKeyboardVisible else { return }
+        guard !reduceMotion, !isKeyboardVisible, !isShowingTalkOverlay else { return }
 
         let predicted = value.predictedEndTranslation.width
         if isShowingDrawer {
-          if value.translation.width < -72 || predicted < -120 {
+          if value.translation.width < -AppShellGesturePolicy.openDistance
+            || predicted < -AppShellGesturePolicy.openPredicted
+          {
             closeDrawer()
           } else {
             drawerDragOffset = 0
@@ -536,10 +585,23 @@ struct AppShellView<ProfileContent: View, AudienceContent: View, ChatContent: Vi
           return
         }
 
-        if value.startLocation.x < 28,
-           value.translation.width > 72 || predicted > 120
-        {
+        if AppShellGesturePolicy.isLeftEdgeOpen(
+          startX: value.startLocation.x,
+          translationX: value.translation.width,
+          predictedX: predicted
+        ) {
           openDrawer()
+          drawerDragOffset = 0
+          return
+        }
+
+        if AppShellGesturePolicy.isRightEdgeOpen(
+          startX: value.startLocation.x,
+          containerWidth: containerWidth,
+          translationX: value.translation.width,
+          predictedX: predicted
+        ), let lastEntityContext {
+          presentEntity(lastEntityContext)
         }
         drawerDragOffset = 0
       }

--- a/apps/ios/Jovie/Features/AppShell/EntityContextSheet.swift
+++ b/apps/ios/Jovie/Features/AppShell/EntityContextSheet.swift
@@ -1,0 +1,222 @@
+import SwiftUI
+import UIKit
+
+/// Mini landing page for a referenced entity (JOV-3634). Opens from chip tap
+/// or right-edge swipe when a recent entity is available.
+struct EntityContextItem: Identifiable, Equatable, Hashable, Sendable {
+  let kind: MobileChatEntityKind
+  let entityID: String
+  let label: String
+
+  var id: String { "\(kind.rawValue):\(entityID)" }
+
+  var title: String { label }
+
+  var kindTitle: String {
+    switch kind {
+    case .release: return "Release"
+    case .artist: return "Artist"
+    case .track: return "Track"
+    case .event: return "Event"
+    }
+  }
+
+  var publicURL: String {
+    "https://jov.ie/e/\(kind.rawValue)/\(entityID)"
+  }
+
+  var coverURL: URL? {
+    MobileChatEntityThumbnailResolver.thumbnailURL(kind: kind, id: entityID)
+  }
+}
+
+enum EntityContextStats {
+  struct Snapshot: Equatable, Sendable {
+    let visits: String
+    let attachedMerch: String
+    let retargeting: String
+    let topPlatform: String
+  }
+
+  /// Stable placeholder stats until asset-graph pages are wired to mobile.
+  static func snapshot(for item: EntityContextItem) -> Snapshot {
+    // Deterministic pseudo-stats from id so the sheet never layout-shifts on
+    // open and unit tests can assert stable strings.
+    let seed = abs(item.entityID.hashValue)
+    let visits = (seed % 900) + 100
+    let merch = seed % 5
+    return Snapshot(
+      visits: "\(visits)",
+      attachedMerch: "\(merch)",
+      retargeting: merch > 0 ? "On" : "Off",
+      topPlatform: ["Spotify", "Instagram", "TikTok", "YouTube"][seed % 4]
+    )
+  }
+}
+
+struct EntityContextSheet: View {
+  let item: EntityContextItem
+  let onEditInChat: (String) -> Void
+  let onDismiss: () -> Void
+
+  @State private var isPublic: Bool
+  @State private var didCopyLink = false
+
+  init(
+    item: EntityContextItem,
+    isPublicInitially: Bool = true,
+    onEditInChat: @escaping (String) -> Void,
+    onDismiss: @escaping () -> Void
+  ) {
+    self.item = item
+    self.onEditInChat = onEditInChat
+    self.onDismiss = onDismiss
+    _isPublic = State(initialValue: isPublicInitially)
+  }
+
+  private var stats: EntityContextStats.Snapshot {
+    EntityContextStats.snapshot(for: item)
+  }
+
+  var body: some View {
+    NavigationStack {
+      ScrollView {
+        VStack(alignment: .leading, spacing: JovieSpacing.xLarge) {
+          header
+          visibilityRow
+          statsGrid
+          actions
+        }
+        .padding(JovieSpacing.xLarge)
+      }
+      .background(JovieColor.backgroundBase)
+      .navigationTitle(item.kindTitle)
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .topBarTrailing) {
+          Button("Done", action: onDismiss)
+            .font(JovieFont.body(size: 16, weight: .semibold))
+            .accessibilityIdentifier("entity-sheet-done")
+        }
+      }
+    }
+    .presentationDetents([.medium, .large])
+    .presentationDragIndicator(.visible)
+    .presentationBackground(JovieColor.backgroundBase)
+    .accessibilityIdentifier("entity-context-sheet")
+  }
+
+  private var header: some View {
+    HStack(spacing: JovieSpacing.medium) {
+      ZStack {
+        RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
+          .fill(JovieColor.surface1)
+        if let coverURL = item.coverURL {
+          CachedRemoteImageView(imageURL: coverURL, size: 72) {
+            accentDot
+          }
+          .clipShape(RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous))
+        } else {
+          accentDot
+        }
+      }
+      .frame(width: 72, height: 72)
+
+      VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
+        Text(item.title)
+          .font(JovieFont.display(size: 22))
+          .foregroundStyle(JovieColor.textPrimary)
+          .lineLimit(2)
+          .accessibilityIdentifier("entity-sheet-title")
+
+        Text(item.kindTitle)
+          .font(JovieFont.body(size: 14, weight: .medium))
+          .foregroundStyle(JovieColor.EntityAccent.color(for: item.kind))
+      }
+      Spacer(minLength: 0)
+    }
+  }
+
+  private var accentDot: some View {
+    Circle()
+      .fill(JovieColor.EntityAccent.color(for: item.kind).opacity(0.35))
+      .padding(18)
+  }
+
+  private var visibilityRow: some View {
+    HStack {
+      VStack(alignment: .leading, spacing: 4) {
+        Text(isPublic ? "Public" : "Private")
+          .font(JovieFont.body(size: 16, weight: .semibold))
+          .foregroundStyle(JovieColor.textPrimary)
+        Text(isPublic ? item.publicURL : "Only you can see this.")
+          .font(JovieFont.body(size: 13))
+          .foregroundStyle(JovieColor.textTertiary)
+          .lineLimit(1)
+      }
+      Spacer()
+      Toggle("", isOn: $isPublic)
+        .labelsHidden()
+        .tint(JovieColor.accent)
+        .accessibilityIdentifier("entity-sheet-public-toggle")
+        .accessibilityLabel(isPublic ? "Public" : "Private")
+    }
+    .padding(JovieSpacing.medium)
+    .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous))
+  }
+
+  private var statsGrid: some View {
+    LazyVGrid(
+      columns: [
+        GridItem(.flexible(), spacing: JovieSpacing.medium),
+        GridItem(.flexible(), spacing: JovieSpacing.medium),
+      ],
+      spacing: JovieSpacing.medium
+    ) {
+      statTile(title: "Visits", value: stats.visits)
+      statTile(title: "Merch", value: stats.attachedMerch)
+      statTile(title: "Retargeting", value: stats.retargeting)
+      statTile(title: "Top Platform", value: stats.topPlatform)
+    }
+    .accessibilityIdentifier("entity-sheet-stats")
+  }
+
+  private func statTile(title: String, value: String) -> some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
+      Text(title)
+        .font(JovieFont.body(size: 12, weight: .medium))
+        .foregroundStyle(JovieColor.textTertiary)
+      Text(value)
+        .font(JovieFont.body(size: 18, weight: .semibold))
+        .foregroundStyle(JovieColor.textPrimary)
+        .lineLimit(1)
+        .minimumScaleFactor(0.8)
+    }
+    .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
+    .padding(JovieSpacing.medium)
+    .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous))
+  }
+
+  private var actions: some View {
+    VStack(spacing: JovieSpacing.medium) {
+      Button {
+        onEditInChat("Edit \(item.title) in chat")
+      } label: {
+        Text("Edit In Chat")
+          .frame(maxWidth: .infinity)
+      }
+      .buttonStyle(JoviePillButtonStyle(filled: true))
+      .accessibilityIdentifier("entity-sheet-edit-in-chat")
+
+      Button {
+        UIPasteboard.general.string = item.publicURL
+        didCopyLink = true
+      } label: {
+        Text(didCopyLink ? "Copied" : "Copy Link")
+          .frame(maxWidth: .infinity)
+      }
+      .buttonStyle(JoviePillButtonStyle(filled: false))
+      .accessibilityIdentifier("entity-sheet-copy-link")
+    }
+  }
+}

--- a/apps/ios/Jovie/Features/AppShell/TalkOverlayView.swift
+++ b/apps/ios/Jovie/Features/AppShell/TalkOverlayView.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+/// Full-screen Talk overlay (JOV-3636). Single global voice entry from the
+/// shell Talk FAB — composer has no mic. Routes transcript into the active
+/// chat thread via `onSend`.
+struct TalkOverlayView: View {
+  @Bindable var voiceCaptureService: VoiceCaptureService
+  let onCancel: () -> Void
+  let onSend: (String) -> Void
+
+  @State private var isStarting = false
+  @State private var localError: String?
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  var body: some View {
+    ZStack {
+      JovieColor.backgroundBase.opacity(0.96)
+        .ignoresSafeArea()
+
+      VStack(spacing: JovieSpacing.xLarge) {
+        HStack {
+          Button("Cancel", action: handleCancel)
+            .font(JovieFont.body(size: 16, weight: .semibold))
+            .foregroundStyle(JovieColor.textSecondary)
+            .accessibilityIdentifier("talk-overlay-cancel")
+
+          Spacer()
+
+          Text("Talk")
+            .font(JovieFont.body(size: 17, weight: .semibold))
+            .foregroundStyle(JovieColor.textPrimary)
+
+          Spacer()
+
+          // Mirror cancel width so the title stays centered (no layout jump).
+          Text("Cancel")
+            .font(JovieFont.body(size: 16, weight: .semibold))
+            .opacity(0)
+            .accessibilityHidden(true)
+        }
+        .padding(.horizontal, JovieSpacing.large)
+        .padding(.top, JovieSpacing.large)
+
+        Spacer(minLength: JovieSpacing.xLarge)
+
+        pulsingOrb
+          .accessibilityLabel(
+            voiceCaptureService.isRecording ? "Listening" : "Starting microphone"
+          )
+
+        VStack(spacing: JovieSpacing.medium) {
+          Text(voiceCaptureService.isRecording ? "Listening…" : "Starting…")
+            .font(JovieFont.body(size: 15, weight: .medium))
+            .foregroundStyle(JovieColor.textTertiary)
+
+          Text(transcriptDisplay)
+            .font(JovieFont.display(size: 22))
+            .foregroundStyle(JovieColor.textPrimary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 320, minHeight: 72, alignment: .top)
+            .padding(.horizontal, JovieSpacing.xLarge)
+            .accessibilityIdentifier("talk-overlay-transcript")
+
+          if let localError {
+            Text(localError)
+              .font(JovieFont.body(size: 14))
+              .foregroundStyle(JovieColor.errorText)
+              .multilineTextAlignment(.center)
+              .padding(.horizontal, JovieSpacing.large)
+          }
+        }
+
+        Spacer(minLength: JovieSpacing.xLarge)
+
+        HStack(spacing: JovieSpacing.large) {
+          Button(action: handleCancel) {
+            Text("Cancel")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(JoviePillButtonStyle(filled: false))
+          .accessibilityIdentifier("talk-overlay-cancel-pill")
+
+          Button {
+            Task { await handleSend() }
+          } label: {
+            Text("Send")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(JoviePillButtonStyle(filled: true))
+          .disabled(!canSend)
+          .accessibilityIdentifier("talk-overlay-send")
+        }
+        .padding(.horizontal, JovieSpacing.xLarge)
+        .padding(.bottom, JovieSpacing.xxLarge)
+      }
+    }
+    .accessibilityIdentifier("talk-overlay")
+    .task {
+      await startIfNeeded()
+    }
+  }
+
+  private var canSend: Bool {
+    !transcriptDisplay.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      && !isStarting
+  }
+
+  private var transcriptDisplay: String {
+    let preview = voiceCaptureService.transcriptPreview
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    if preview.isEmpty {
+      return "Say something…"
+    }
+    return preview
+  }
+
+  private var pulsingOrb: some View {
+    let level = voiceCaptureService.audioLevel
+    let base: CGFloat = 120
+    let scale = reduceMotion ? 1 : 1 + CGFloat(level) * 0.18
+
+    return ZStack {
+      Circle()
+        .fill(JovieColor.accent.opacity(0.18))
+        .frame(width: base + 48, height: base + 48)
+        .scaleEffect(scale)
+      Circle()
+        .fill(JovieColor.accent.opacity(0.35))
+        .frame(width: base + 16, height: base + 16)
+        .scaleEffect(scale)
+      Circle()
+        .fill(Color.white)
+        .frame(width: base, height: base)
+      Image(systemName: "mic.fill")
+        .font(.system(size: 36, weight: .bold))
+        .foregroundStyle(JovieColor.backgroundBase)
+    }
+    .animation(
+      reduceMotion ? nil : JovieMotion.easeOut(duration: JovieMotion.fastDuration),
+      value: level
+    )
+  }
+
+  private func startIfNeeded() async {
+    guard !voiceCaptureService.isRecording, !isStarting else { return }
+    isStarting = true
+    localError = nil
+    do {
+      try await voiceCaptureService.start()
+    } catch {
+      localError = (error as? LocalizedError)?.errorDescription
+        ?? "Voice is unavailable."
+      voiceCaptureService.cancel()
+    }
+    isStarting = false
+  }
+
+  private func handleCancel() {
+    voiceCaptureService.cancel()
+    onCancel()
+  }
+
+  private func handleSend() async {
+    do {
+      let result = try await voiceCaptureService.finish()
+      onSend(result.transcript)
+    } catch {
+      localError = (error as? LocalizedError)?.errorDescription
+        ?? "Nothing heard."
+      // Stay open so the user can retry; restart capture after a clean cancel.
+      voiceCaptureService.cancel()
+      await startIfNeeded()
+    }
+  }
+}

--- a/apps/ios/Jovie/Features/Calendar/CalendarSurfaceView.swift
+++ b/apps/ios/Jovie/Features/Calendar/CalendarSurfaceView.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+
+/// Calendar surface for the primary tab bar (JOV-3632). Consumes the mobile
+/// action-loop calendar payload when loaded; otherwise shows a stable skeleton.
+struct CalendarSurfaceView: View {
+  let response: MobileActionLoopCalendarResponse?
+  let isLoading: Bool
+  let isOffline: Bool
+  let onRetry: () async -> Void
+  let onAskJovie: (String) -> Void
+
+  var body: some View {
+    ZStack {
+      JovieColor.backgroundBase.ignoresSafeArea()
+
+      ScrollView {
+        VStack(alignment: .leading, spacing: JovieSpacing.xLarge) {
+          header
+          content
+        }
+        .padding(JovieSpacing.large)
+      }
+    }
+    .accessibilityIdentifier("calendar-surface")
+  }
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.small) {
+      Text(response?.rangeLabel ?? "Calendar")
+        .font(JovieFont.display(size: 22))
+        .foregroundStyle(JovieColor.textPrimary)
+
+      if isOffline {
+        Text("Offline — showing cached calendar when available.")
+          .font(JovieFont.body(size: 13))
+          .foregroundStyle(JovieColor.textTertiary)
+      } else if let pending = response?.pendingReviewCount, pending > 0 {
+        Text("\(pending) pending review")
+          .font(JovieFont.body(size: 13, weight: .medium))
+          .foregroundStyle(JovieColor.textSecondary)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    if let response {
+      if response.upcomingEvents.isEmpty,
+         response.pendingEvents.isEmpty,
+         response.upcomingReleases.isEmpty
+      {
+        emptyState(prompt: response.chatPrompt)
+      } else {
+        if !response.upcomingEvents.isEmpty {
+          section(title: "Upcoming Events") {
+            ForEach(response.upcomingEvents) { event in
+              CalendarEventRow(event: event)
+            }
+          }
+        }
+        if !response.pendingEvents.isEmpty {
+          section(title: "Needs Confirmation") {
+            ForEach(response.pendingEvents) { event in
+              CalendarEventRow(event: event)
+            }
+          }
+        }
+        if !response.upcomingReleases.isEmpty {
+          section(title: "Releases") {
+            ForEach(response.upcomingReleases) { release in
+              CalendarReleaseRow(release: release)
+            }
+          }
+        }
+
+        Button {
+          onAskJovie(response.chatPrompt)
+        } label: {
+          Text("Ask Jovie")
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(JoviePillButtonStyle(filled: false))
+        .accessibilityIdentifier("calendar-ask-jovie")
+      }
+    } else if isLoading {
+      skeleton
+    } else {
+      VStack(spacing: JovieSpacing.large) {
+        Text("Could not load calendar.")
+          .font(JovieFont.body(size: 16, weight: .medium))
+          .foregroundStyle(JovieColor.textPrimary)
+        Button("Retry") {
+          Task { await onRetry() }
+        }
+        .buttonStyle(JoviePillButtonStyle(filled: true))
+        .accessibilityIdentifier("calendar-retry")
+      }
+      .frame(maxWidth: .infinity, minHeight: 220)
+    }
+  }
+
+  private func emptyState(prompt: String) -> some View {
+    VStack(spacing: JovieSpacing.large) {
+      Text("Nothing on the calendar yet.")
+        .font(JovieFont.body(size: 16, weight: .medium))
+        .foregroundStyle(JovieColor.textSecondary)
+      Button {
+        onAskJovie(prompt)
+      } label: {
+        Text("Plan With Jovie")
+          .frame(maxWidth: .infinity)
+      }
+      .buttonStyle(JoviePillButtonStyle(filled: true))
+    }
+    .frame(maxWidth: .infinity, minHeight: 200)
+  }
+
+  private var skeleton: some View {
+    VStack(spacing: JovieSpacing.medium) {
+      ForEach(0..<4, id: \.self) { _ in
+        RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
+          .fill(JovieColor.surface1)
+          .frame(height: 72)
+      }
+    }
+    .redacted(reason: .placeholder)
+    .accessibilityHidden(true)
+  }
+
+  private func section<Content: View>(
+    title: String,
+    @ViewBuilder content: () -> Content
+  ) -> some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.small) {
+      Text(title)
+        .font(JovieFont.body(size: 13, weight: .semibold))
+        .foregroundStyle(JovieColor.textTertiary)
+      content()
+    }
+  }
+}
+
+private struct CalendarEventRow: View {
+  let event: MobileActionLoopCalendarEventItem
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
+      Text(event.title)
+        .font(JovieFont.body(size: 16, weight: .semibold))
+        .foregroundStyle(JovieColor.textPrimary)
+        .lineLimit(1)
+      Text(event.subtitle)
+        .font(JovieFont.body(size: 13))
+        .foregroundStyle(JovieColor.textTertiary)
+        .lineLimit(2)
+      HStack(spacing: JovieSpacing.small) {
+        Text(event.eventType.capitalized)
+          .font(JovieFont.body(size: 11, weight: .semibold))
+          .foregroundStyle(JovieColor.textSecondary)
+        if let badge = event.statusBadge {
+          Text(badge)
+            .font(JovieFont.body(size: 11, weight: .semibold))
+            .foregroundStyle(JovieColor.textSecondary)
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(JovieSpacing.medium)
+    .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous))
+    .accessibilityIdentifier("calendar-event-\(event.id)")
+  }
+}
+
+private struct CalendarReleaseRow: View {
+  let release: MobileActionLoopCalendarReleaseItem
+
+  var body: some View {
+    HStack(spacing: JovieSpacing.medium) {
+      RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous)
+        .fill(JovieColor.surface2)
+        .frame(width: 48, height: 48)
+        .overlay {
+          Image(systemName: "opticaldisc")
+            .foregroundStyle(JovieColor.textTertiary)
+        }
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text(release.title)
+          .font(JovieFont.body(size: 16, weight: .semibold))
+          .foregroundStyle(JovieColor.textPrimary)
+          .lineLimit(1)
+        Text(release.status.capitalized)
+          .font(JovieFont.body(size: 13))
+          .foregroundStyle(JovieColor.textTertiary)
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(JovieSpacing.medium)
+    .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous))
+    .accessibilityIdentifier("calendar-release-\(release.id)")
+  }
+}

--- a/apps/ios/Jovie/Features/Chat/ComposerWorkflowSheet.swift
+++ b/apps/ios/Jovie/Features/Chat/ComposerWorkflowSheet.swift
@@ -143,17 +143,11 @@ struct ChatComposerBar: View {
   let placeholder: String
   let isSending: Bool
   let isPlusEnabled: Bool
-  @Bindable var voiceCaptureService: VoiceCaptureService
-  let onVoiceStart: () async -> Void
-  let onVoiceFinish: () async -> Void
-  let onVoiceCancel: () -> Void
   let onSend: () -> Void
   let onSelectWorkflow: (ComposerWorkflowAction) -> Void
   let onDraftEdited: () -> Void
 
   @State private var isShowingWorkflowSheet = false
-  @State private var didStartVoiceDrag = false
-  @State private var isVoiceDragCancelled = false
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   var body: some View {
@@ -164,44 +158,44 @@ struct ChatComposerBar: View {
     } ?? []
     let isSlashPaletteVisible = slashQuery != nil && !slashItems.isEmpty
 
-    VStack(spacing: 0) {
-      waveformStrip
+    // JOV-3636: composer is text-only. Voice is shell Talk FAB → full-screen
+    // overlay. OS keyboard mic still handles dictate-to-text.
+    HStack(spacing: JovieSpacing.medium) {
+      Button {
+        isShowingWorkflowSheet = true
+      } label: {
+        Image(systemName: "plus")
+          .font(.system(size: 18, weight: .semibold))
+          .foregroundStyle(
+            isPlusEnabled ? JovieColor.textPrimary : JovieColor.textTertiary
+          )
+          .frame(width: 36, height: 36)
+          .background(JovieColor.surface2, in: Circle())
+      }
+      .buttonStyle(.plain)
+      .disabled(!isPlusEnabled)
+      .accessibilityLabel("Open workflow sheet")
+      .accessibilityIdentifier("chat-composer-plus")
+      .accessibilityElement(children: .ignore)
 
-      HStack(spacing: JovieSpacing.medium) {
-        Button {
-          isShowingWorkflowSheet = true
-        } label: {
-          Image(systemName: "plus")
-            .font(.system(size: 18, weight: .semibold))
-            .foregroundStyle(
-              isPlusEnabled ? JovieColor.textPrimary : JovieColor.textTertiary
-            )
-            .frame(width: 36, height: 36)
-            .background(JovieColor.surface2, in: Circle())
+      TextField(placeholder, text: $draft)
+        .focused($isFocused)
+        .textInputAutocapitalization(.sentences)
+        .disableAutocorrection(false)
+        .font(JovieFont.body(size: 16))
+        .foregroundStyle(JovieColor.textPrimary)
+        .frame(height: 52)
+        .onChange(of: draft) {
+          onDraftEdited()
         }
-        .buttonStyle(.plain)
-        .disabled(!isPlusEnabled)
-        .accessibilityLabel("Open workflow sheet")
-        .accessibilityIdentifier("chat-composer-plus")
-        .accessibilityElement(children: .ignore)
 
-        TextField(placeholder, text: $draft)
-          .focused($isFocused)
-          .textInputAutocapitalization(.sentences)
-          .disableAutocorrection(false)
-          .font(JovieFont.body(size: 16))
-          .foregroundStyle(JovieColor.textPrimary)
-          .frame(height: 52)
-          .onChange(of: draft) {
-            onDraftEdited()
-          }
-
-        if trimmedDraft.isEmpty {
-          voiceButton
-        } else {
+      // Reserve a stable trailing 52pt slot so empty → typed never shifts layout.
+      ZStack {
+        if !trimmedDraft.isEmpty {
           sendButton(trimmedDraft: trimmedDraft)
         }
       }
+      .frame(width: 52, height: 52)
     }
     .padding(.horizontal, JovieSpacing.large)
     .frame(height: 76)
@@ -270,72 +264,6 @@ struct ChatComposerBar: View {
     }
   }
 
-  @ViewBuilder
-  private var waveformStrip: some View {
-    HStack(spacing: 3) {
-      ForEach(0..<14, id: \.self) { index in
-        RoundedRectangle(cornerRadius: 2, style: .continuous)
-          .fill(isVoiceDragCancelled ? JovieColor.textTertiary : JovieColor.textPrimary)
-          .frame(width: 3, height: waveformHeight(at: index))
-          .opacity(voiceCaptureService.isRecording ? 0.9 : 0)
-      }
-    }
-    .frame(height: 12)
-    .frame(maxWidth: .infinity)
-    .accessibilityHidden(true)
-  }
-
-  private var voiceButton: some View {
-    Button(action: {}) {
-      ZStack {
-        Circle()
-          .fill(voiceCaptureService.isRecording ? Color.white : JovieColor.surface2)
-        Image(systemName: isVoiceDragCancelled ? "xmark" : "mic.fill")
-          .font(.system(size: 16, weight: .bold))
-          .foregroundStyle(
-            voiceCaptureService.isRecording ? JovieColor.backgroundBase : JovieColor.textPrimary
-          )
-      }
-      .frame(width: 52, height: 52)
-    }
-    .buttonStyle(.plain)
-    .disabled(isSending)
-    .contentShape(Circle())
-    .gesture(voiceDragGesture)
-    .accessibilityLabel(voiceCaptureService.isRecording ? "Release to send" : "Hold to talk")
-    .accessibilityIdentifier("chat-voice-button")
-    .accessibilityHint("Slide away to cancel")
-    .accessibilityElement(children: .ignore)
-  }
-
-  private var voiceDragGesture: some Gesture {
-    DragGesture(minimumDistance: 0)
-      .onChanged { value in
-        if !didStartVoiceDrag {
-          didStartVoiceDrag = true
-          isVoiceDragCancelled = false
-          UIImpactFeedbackGenerator(style: .light).impactOccurred()
-          Task { await onVoiceStart() }
-        }
-
-        isVoiceDragCancelled = abs(value.translation.width) > 72 || value.translation.height < -72
-      }
-      .onEnded { _ in
-        guard didStartVoiceDrag else { return }
-        didStartVoiceDrag = false
-
-        if isVoiceDragCancelled {
-          UINotificationFeedbackGenerator().notificationOccurred(.warning)
-          onVoiceCancel()
-          isVoiceDragCancelled = false
-          return
-        }
-
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
-        Task { await onVoiceFinish() }
-      }
-  }
-
   private func sendButton(trimmedDraft: String) -> some View {
     Button(action: onSend) {
       Image(systemName: isSending ? "ellipsis" : "arrow.up")
@@ -354,13 +282,6 @@ struct ChatComposerBar: View {
     .buttonStyle(.plain)
     .disabled(trimmedDraft.isEmpty || isSending)
     .accessibilityLabel("Send")
-  }
-
-  private func waveformHeight(at index: Int) -> CGFloat {
-    let base = [4, 7, 10, 6, 12, 8, 5, 11, 7, 10, 6, 12, 8, 5][index]
-    guard voiceCaptureService.isRecording else { return CGFloat(base) }
-    let boosted = Double(base) + voiceCaptureService.audioLevel * Double((index % 4) + 5)
-    return CGFloat(min(14, max(4, boosted)))
   }
 }
 

--- a/apps/ios/Jovie/Features/Chat/MobileChatView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 enum MobileChatKeyboardPolicy {
   /// Dismiss when the assistant starts streaming only if the user has not typed since send.
@@ -12,11 +13,25 @@ struct MobileChatView: View {
   @Binding var draft: String
   @Binding var voiceCaptureTrigger: Int
   let webBaseURL: URL
+  let onEntityTap: (EntityContextItem) -> Void
 
   @FocusState private var isComposerFocused: Bool
   @State private var isAtBottom = true
   @State private var userEditedSinceSend = false
-  @State private var voiceCaptureService = VoiceCaptureService()
+
+  init(
+    repository: ChatRepository,
+    draft: Binding<String>,
+    voiceCaptureTrigger: Binding<Int>,
+    webBaseURL: URL,
+    onEntityTap: @escaping (EntityContextItem) -> Void = { _ in }
+  ) {
+    self.repository = repository
+    _draft = draft
+    _voiceCaptureTrigger = voiceCaptureTrigger
+    self.webBaseURL = webBaseURL
+    self.onEntityTap = onEntityTap
+  }
 
   var body: some View {
     ZStack {
@@ -37,10 +52,9 @@ struct MobileChatView: View {
     .task {
       await repository.refreshConversations()
     }
-    .task(id: voiceCaptureTrigger) {
-      guard voiceCaptureTrigger > 0 else { return }
-      await startVoiceCapture()
-    }
+    // voiceCaptureTrigger is owned by the shell Talk FAB / App Intents path
+    // (JOV-3636). Chat no longer starts capture itself — the shell opens
+    // TalkOverlayView when the trigger increments.
   }
 
   @ViewBuilder
@@ -58,7 +72,8 @@ struct MobileChatView: View {
               },
               onSubmitPrompt: { prompt in
                 Task { await repository.send(text: prompt) }
-              }
+              },
+              onEntityTap: onEntityTap
             )
             .transition(.opacity.combined(with: .offset(y: 6)))
           }
@@ -103,8 +118,6 @@ struct MobileChatView: View {
       .onChange(of: isComposerFocused) {
         scrollToBottomIfPinned(using: proxy, animated: true)
       }
-      // Bottom-center, above the composer: the shell-level Talk FAB now owns
-      // bottom-trailing (JOV-3670), so this button relocates to avoid overlap.
       .overlay(alignment: .bottom) {
         if !isAtBottom {
           Button {
@@ -141,7 +154,6 @@ struct MobileChatView: View {
         isComposerFocused: $isComposerFocused,
         isSending: repository.isSending,
         isOffline: repository.isOffline,
-        voiceCaptureService: voiceCaptureService,
         onSend: {
           let text = draft
           draft = ""
@@ -154,15 +166,6 @@ struct MobileChatView: View {
         },
         onDraftEdited: {
           userEditedSinceSend = true
-        },
-        onVoiceStart: {
-          await startVoiceCapture()
-        },
-        onVoiceFinish: {
-          await finishVoiceCapture()
-        },
-        onVoiceCancel: {
-          voiceCaptureService.cancel()
         }
       )
       .padding(.horizontal, JovieSpacing.large)
@@ -216,26 +219,6 @@ struct MobileChatView: View {
     }
   }
 
-  private func startVoiceCapture() async {
-    guard !repository.isSending else { return }
-    isComposerFocused = false
-    do {
-      try await voiceCaptureService.start()
-    } catch {
-      voiceCaptureService.cancel()
-    }
-  }
-
-  private func finishVoiceCapture() async {
-    do {
-      let result = try await voiceCaptureService.finish()
-      userEditedSinceSend = false
-      draft = ""
-      await repository.send(text: result.transcript)
-    } catch {
-      voiceCaptureService.cancel()
-    }
-  }
 }
 
 private struct MobileChatMessageRow: View {
@@ -243,6 +226,7 @@ private struct MobileChatMessageRow: View {
   let webBaseURL: URL
   let onRetry: () -> Void
   let onSubmitPrompt: (String) -> Void
+  let onEntityTap: (EntityContextItem) -> Void
 
   private var isStreamingAssistant: Bool {
     item.role == .assistant && item.status == .streaming
@@ -282,7 +266,8 @@ private struct MobileChatMessageRow: View {
   private var userMessageBubble: some View {
     MobileChatProseText(
       runs: MobileChatProseTokenizer.tokenize(item.content, isStreaming: false),
-      tone: .onLight
+      tone: .onLight,
+      onEntityTap: onEntityTap
     )
     .font(JovieFont.body(size: 16))
     .padding(.horizontal, JovieSpacing.large)
@@ -317,12 +302,21 @@ private struct MobileChatMessageRow: View {
       VStack(alignment: .leading, spacing: JovieSpacing.small) {
         let proseRuns = assistantProseRuns(from: segments)
         if !proseRuns.isEmpty {
-          MobileChatProseText(runs: proseRuns, tone: .onDark)
+          MobileChatProseText(runs: proseRuns, tone: .onDark, onEntityTap: onEntityTap)
             .font(JovieFont.body(size: 16))
             .padding(.horizontal, JovieSpacing.large)
             .padding(.vertical, JovieSpacing.medium)
             .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
             .frame(maxWidth: 320, alignment: .leading)
+            .contextMenu {
+              Button("Copy") {
+                UIPasteboard.general.string = item.content
+              }
+              Button("Share") {
+                // Share sheet is host-level; copy keeps this menu discoverable.
+                UIPasteboard.general.string = item.content
+              }
+            }
         }
 
         ForEach(segments) { segment in
@@ -411,13 +405,9 @@ private struct ChatComposerView: View {
   @FocusState.Binding var isComposerFocused: Bool
   let isSending: Bool
   let isOffline: Bool
-  @Bindable var voiceCaptureService: VoiceCaptureService
   let onSend: () -> Void
   let onSelectWorkflow: (ComposerWorkflowAction) -> Void
   let onDraftEdited: () -> Void
-  let onVoiceStart: () async -> Void
-  let onVoiceFinish: () async -> Void
-  let onVoiceCancel: () -> Void
 
   var body: some View {
     ChatComposerBar(
@@ -426,10 +416,6 @@ private struct ChatComposerView: View {
       placeholder: isOffline ? "Ask Jovie (offline)" : "Ask Jovie",
       isSending: isSending,
       isPlusEnabled: !isSending,
-      voiceCaptureService: voiceCaptureService,
-      onVoiceStart: onVoiceStart,
-      onVoiceFinish: onVoiceFinish,
-      onVoiceCancel: onVoiceCancel,
       onSend: onSend,
       onSelectWorkflow: onSelectWorkflow,
       onDraftEdited: onDraftEdited
@@ -520,27 +506,44 @@ private struct MobileChatEntityChipView: View {
   let id: String
   let label: String
   let tone: MobileChatProseTone
+  let onTap: (EntityContextItem) -> Void
 
   private static let mediaSize: CGFloat = 16
   private static let maxChipWidth: CGFloat = 220
 
+  private var entityItem: EntityContextItem {
+    EntityContextItem(kind: kind, entityID: id, label: label)
+  }
+
   var body: some View {
-    HStack(spacing: 6) {
-      mediaSlot
-      Text(label)
-        .lineLimit(1)
-        .truncationMode(.tail)
+    Button {
+      onTap(entityItem)
+    } label: {
+      HStack(spacing: 6) {
+        mediaSlot
+        Text(label)
+          .lineLimit(1)
+          .truncationMode(.tail)
+      }
+      .font(JovieFont.body(size: 16))
+      .foregroundStyle(chipTextColor)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 4)
+      .frame(maxWidth: Self.maxChipWidth)
+      .background(chipBackground, in: Capsule())
+      .overlay(
+        Capsule().stroke(chipBorderColor, lineWidth: 1)
+      )
     }
-    .font(JovieFont.body(size: 16))
-    .foregroundStyle(chipTextColor)
-    .padding(.horizontal, 8)
-    .padding(.vertical, 4)
-    .frame(maxWidth: Self.maxChipWidth)
-    .background(chipBackground, in: Capsule())
-    .overlay(
-      Capsule().stroke(chipBorderColor, lineWidth: 1)
-    )
+    .buttonStyle(.plain)
+    .contextMenu {
+      // Long-press peek (JOV-3635): quick open into the entity sheet.
+      Button("Open") { onTap(entityItem) }
+      Button("Copy Label") { UIPasteboard.general.string = label }
+    }
     .accessibilityLabel("\(kindPrefix): \(label)")
+    .accessibilityHint("Opens entity context")
+    .accessibilityIdentifier("entity-chip-\(kind.rawValue)-\(id)")
   }
 
   @ViewBuilder
@@ -607,6 +610,7 @@ private struct MobileChatEntityChipView: View {
 struct MobileChatProseText: View {
   let runs: [MobileChatProseRun]
   let tone: MobileChatProseTone
+  var onEntityTap: (EntityContextItem) -> Void = { _ in }
 
   var body: some View {
     let tokens = Self.flowTokens(from: runs)
@@ -624,7 +628,13 @@ struct MobileChatProseText: View {
       Text(verbatim: value)
         .foregroundStyle(primaryTextColor)
     case let .entity(kind, id, label):
-      MobileChatEntityChipView(kind: kind, id: id, label: label, tone: tone)
+      MobileChatEntityChipView(
+        kind: kind,
+        id: id,
+        label: label,
+        tone: tone,
+        onTap: onEntityTap
+      )
     case let .skill(_, label):
       Text(label)
         .foregroundStyle(skillLabelColor)

--- a/apps/ios/Jovie/Features/Inbox/InboxSurfaceView.swift
+++ b/apps/ios/Jovie/Features/Inbox/InboxSurfaceView.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+
+/// Inbox action-loop surface (JOV-3632) with swipe-to-triage (JOV-3635).
+struct InboxSurfaceView: View {
+  let response: MobileActionLoopInboxResponse?
+  let isLoading: Bool
+  let isOffline: Bool
+  let onRetry: () async -> Void
+  let onAskJovie: (String) -> Void
+
+  /// Local triage state (thumbs) — not persisted in v1; keeps swipe discoverable.
+  @State private var triageByID: [String: InboxTriage] = [:]
+  @State private var dismissedIDs: Set<String> = []
+
+  var body: some View {
+    ZStack {
+      JovieColor.backgroundBase.ignoresSafeArea()
+
+      ScrollView {
+        VStack(alignment: .leading, spacing: JovieSpacing.xLarge) {
+          header
+          content
+        }
+        .padding(JovieSpacing.large)
+      }
+    }
+    .accessibilityIdentifier("inbox-surface")
+  }
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.small) {
+      Text("Inbox")
+        .font(JovieFont.display(size: 22))
+        .foregroundStyle(JovieColor.textPrimary)
+
+      if isOffline {
+        Text("Offline — showing cached actions when available.")
+          .font(JovieFont.body(size: 13))
+          .foregroundStyle(JovieColor.textTertiary)
+      } else if let count = response?.pendingCount {
+        Text(count == 1 ? "1 pending action" : "\(count) pending actions")
+          .font(JovieFont.body(size: 13, weight: .medium))
+          .foregroundStyle(JovieColor.textSecondary)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    if let response {
+      let visibleItems = response.items.filter { !dismissedIDs.contains($0.id) }
+
+      if visibleItems.isEmpty {
+        emptyState(response: response)
+      } else {
+        VStack(spacing: JovieSpacing.medium) {
+          ForEach(visibleItems) { item in
+            InboxActionCard(
+              item: item,
+              triage: triageByID[item.id],
+              onTriage: { triage in
+                triageByID[item.id] = triage
+                if triage != .none {
+                  withAnimation(JovieMotion.easeOut()) {
+                    _ = dismissedIDs.insert(item.id)
+                  }
+                }
+              }
+            )
+          }
+        }
+
+        Button {
+          onAskJovie(response.chatPrompt)
+        } label: {
+          Text("Ask Jovie")
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(JoviePillButtonStyle(filled: false))
+        .accessibilityIdentifier("inbox-ask-jovie")
+      }
+    } else if isLoading {
+      skeleton
+    } else {
+      VStack(spacing: JovieSpacing.large) {
+        Text("Could not load inbox.")
+          .font(JovieFont.body(size: 16, weight: .medium))
+          .foregroundStyle(JovieColor.textPrimary)
+        Button("Retry") {
+          Task { await onRetry() }
+        }
+        .buttonStyle(JoviePillButtonStyle(filled: true))
+        .accessibilityIdentifier("inbox-retry")
+      }
+      .frame(maxWidth: .infinity, minHeight: 220)
+    }
+  }
+
+  private func emptyState(response: MobileActionLoopInboxResponse) -> some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.medium) {
+      Text("You're caught up.")
+        .font(JovieFont.body(size: 16, weight: .medium))
+        .foregroundStyle(JovieColor.textSecondary)
+
+      if !response.emptyActionCards.isEmpty {
+        ForEach(response.emptyActionCards) { card in
+          VStack(alignment: .leading, spacing: JovieSpacing.small) {
+            Text(card.title)
+              .font(JovieFont.body(size: 16, weight: .semibold))
+              .foregroundStyle(JovieColor.textPrimary)
+            Text(card.body)
+              .font(JovieFont.body(size: 14))
+              .foregroundStyle(JovieColor.textTertiary)
+          }
+          .padding(JovieSpacing.medium)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous))
+        }
+      }
+
+      Button {
+        onAskJovie(response.chatPrompt)
+      } label: {
+        Text("Ask Jovie")
+          .frame(maxWidth: .infinity)
+      }
+      .buttonStyle(JoviePillButtonStyle(filled: true))
+    }
+  }
+
+  private var skeleton: some View {
+    VStack(spacing: JovieSpacing.medium) {
+      ForEach(0..<3, id: \.self) { _ in
+        RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
+          .fill(JovieColor.surface1)
+          .frame(height: 110)
+      }
+    }
+    .redacted(reason: .placeholder)
+    .accessibilityHidden(true)
+  }
+}
+
+enum InboxTriage: Equatable, Sendable {
+  case none
+  case up
+  case down
+}
+
+private struct InboxActionCard: View {
+  let item: MobileActionLoopInboxItem
+  let triage: InboxTriage?
+  let onTriage: (InboxTriage) -> Void
+
+  @State private var dragOffset: CGFloat = 0
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  var body: some View {
+    ZStack {
+      HStack {
+        triageGlyph(systemName: "hand.thumbsup.fill", color: JovieColor.accent)
+          .opacity(dragOffset > 20 ? 1 : 0)
+        Spacer()
+        triageGlyph(systemName: "hand.thumbsdown.fill", color: JovieColor.errorText)
+          .opacity(dragOffset < -20 ? 1 : 0)
+      }
+      .padding(.horizontal, JovieSpacing.large)
+
+      cardBody
+        .offset(x: reduceMotion ? 0 : dragOffset)
+        .gesture(swipeGesture)
+        .contextMenu {
+          Button("Thumbs Up") { onTriage(.up) }
+          Button("Thumbs Down") { onTriage(.down) }
+        }
+    }
+    .accessibilityIdentifier("inbox-item-\(item.id)")
+    .accessibilityHint("Swipe right to approve, left to dismiss")
+  }
+
+  private var cardBody: some View {
+    VStack(alignment: .leading, spacing: JovieSpacing.small) {
+      HStack {
+        Text(item.typeLabel)
+          .font(JovieFont.body(size: 12, weight: .semibold))
+          .foregroundStyle(JovieColor.textTertiary)
+        Spacer()
+        Text(item.status.capitalized)
+          .font(JovieFont.body(size: 12, weight: .medium))
+          .foregroundStyle(JovieColor.textSecondary)
+      }
+      Text(item.title)
+        .font(JovieFont.body(size: 16, weight: .semibold))
+        .foregroundStyle(JovieColor.textPrimary)
+        .fixedSize(horizontal: false, vertical: true)
+      Text(item.why)
+        .font(JovieFont.body(size: 14))
+        .foregroundStyle(JovieColor.textTertiary)
+        .fixedSize(horizontal: false, vertical: true)
+      Text(item.primaryActionLabel)
+        .font(JovieFont.body(size: 14, weight: .semibold))
+        .foregroundStyle(JovieColor.accent)
+    }
+    .padding(JovieSpacing.medium)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
+        .stroke(JovieColor.borderSubtle, lineWidth: 1)
+    }
+  }
+
+  private func triageGlyph(systemName: String, color: Color) -> some View {
+    Image(systemName: systemName)
+      .font(.system(size: 22, weight: .bold))
+      .foregroundStyle(color)
+      .frame(width: 40, height: 40)
+  }
+
+  private var swipeGesture: some Gesture {
+    DragGesture(minimumDistance: 16)
+      .onChanged { value in
+        guard !reduceMotion else { return }
+        let horizontal = value.translation.width
+        guard abs(horizontal) > abs(value.translation.height) else { return }
+        dragOffset = max(-120, min(120, horizontal))
+      }
+      .onEnded { value in
+        defer { dragOffset = 0 }
+        let horizontal = value.translation.width
+        guard abs(horizontal) > abs(value.translation.height) * 1.2 else { return }
+        if horizontal > 80 {
+          onTriage(.up)
+        } else if horizontal < -80 {
+          onTriage(.down)
+        }
+      }
+  }
+}

--- a/apps/ios/Jovie/Features/Library/LibraryModels.swift
+++ b/apps/ios/Jovie/Features/Library/LibraryModels.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+enum LibraryAssetType: String, CaseIterable, Identifiable, Sendable {
+  case release
+  case merch
+  case smartLink
+  case photo
+  case press
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .release: return "Releases"
+    case .merch: return "Merch"
+    case .smartLink: return "Smart Links"
+    case .photo: return "Photos"
+    case .press: return "Press"
+    }
+  }
+
+  var filterLabel: String {
+    switch self {
+    case .release: return "Releases"
+    case .merch: return "Merch"
+    case .smartLink: return "Smart Links"
+    case .photo: return "Photos"
+    case .press: return "Press"
+    }
+  }
+
+  var singularTitle: String {
+    switch self {
+    case .release: return "Release"
+    case .merch: return "Merch"
+    case .smartLink: return "Smart Link"
+    case .photo: return "Photo"
+    case .press: return "Press"
+    }
+  }
+}
+
+enum LibraryFilter: Equatable, Hashable, Identifiable, Sendable {
+  case all
+  case type(LibraryAssetType)
+
+  var id: String {
+    switch self {
+    case .all: return "all"
+    case let .type(type): return type.rawValue
+    }
+  }
+
+  var title: String {
+    switch self {
+    case .all: return "All"
+    case let .type(type): return type.filterLabel
+    }
+  }
+
+  static let chips: [LibraryFilter] =
+    [.all] + LibraryAssetType.allCases.map(LibraryFilter.type)
+}
+
+struct LibraryAsset: Identifiable, Equatable, Sendable {
+  let id: String
+  let name: String
+  let type: LibraryAssetType
+  let isPublic: Bool
+  let coverURL: URL?
+  let liveStatLabel: String
+  let publicURL: String?
+
+  var typeBadge: String { type.singularTitle }
+  var visibilityBadge: String { isPublic ? "Public" : "Private" }
+}
+
+enum LibraryFeed {
+  /// Filters assets for the vertical feed (JOV-3637).
+  static func filtered(assets: [LibraryAsset], filter: LibraryFilter) -> [LibraryAsset] {
+    switch filter {
+    case .all:
+      return assets
+    case let .type(type):
+      return assets.filter { $0.type == type }
+    }
+  }
+
+  /// Preview storefront feed used until a dedicated mobile library API ships.
+  static let previewAssets: [LibraryAsset] = [
+    LibraryAsset(
+      id: "lib-release-midnight",
+      name: "Midnight Drive",
+      type: .release,
+      isPublic: true,
+      coverURL: nil,
+      liveStatLabel: "1.2k visits",
+      publicURL: "https://jov.ie/a/midnight-drive"
+    ),
+    LibraryAsset(
+      id: "lib-merch-tee",
+      name: "Tour Tee",
+      type: .merch,
+      isPublic: true,
+      coverURL: nil,
+      liveStatLabel: "84 orders",
+      publicURL: "https://jov.ie/a/tour-tee"
+    ),
+    LibraryAsset(
+      id: "lib-link-epk",
+      name: "EPK Smart Link",
+      type: .smartLink,
+      isPublic: true,
+      coverURL: nil,
+      liveStatLabel: "312 clicks",
+      publicURL: "https://jov.ie/l/epk"
+    ),
+    LibraryAsset(
+      id: "lib-photo-stage",
+      name: "Stage Still",
+      type: .photo,
+      isPublic: false,
+      coverURL: nil,
+      liveStatLabel: "Private",
+      publicURL: nil
+    ),
+    LibraryAsset(
+      id: "lib-press-kit",
+      name: "Press Kit 2026",
+      type: .press,
+      isPublic: false,
+      coverURL: nil,
+      liveStatLabel: "3 assets",
+      publicURL: nil
+    ),
+  ]
+}

--- a/apps/ios/Jovie/Features/Library/LibrarySurfaceView.swift
+++ b/apps/ios/Jovie/Features/Library/LibrarySurfaceView.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+/// Mobile Library storefront (JOV-3637): vertical rich asset cards + filter chips.
+struct LibrarySurfaceView: View {
+  let assets: [LibraryAsset]
+  let onSelectAsset: (LibraryAsset) -> Void
+
+  @State private var filter: LibraryFilter = .all
+
+  private var filteredAssets: [LibraryAsset] {
+    LibraryFeed.filtered(assets: assets, filter: filter)
+  }
+
+  var body: some View {
+    ZStack {
+      JovieColor.backgroundBase.ignoresSafeArea()
+
+      VStack(alignment: .leading, spacing: 0) {
+        filterChips
+          .padding(.horizontal, JovieSpacing.large)
+          .padding(.top, JovieSpacing.medium)
+          .padding(.bottom, JovieSpacing.small)
+
+        if filteredAssets.isEmpty {
+          emptyState
+        } else {
+          ScrollView {
+            LazyVStack(spacing: JovieSpacing.medium) {
+              ForEach(filteredAssets) { asset in
+                LibraryAssetCard(asset: asset) {
+                  onSelectAsset(asset)
+                }
+              }
+            }
+            .padding(.horizontal, JovieSpacing.large)
+            .padding(.bottom, JovieSpacing.xxLarge)
+          }
+        }
+      }
+    }
+    .accessibilityIdentifier("library-surface")
+  }
+
+  private var filterChips: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: JovieSpacing.small) {
+        ForEach(LibraryFilter.chips) { chip in
+          Button {
+            filter = chip
+          } label: {
+            Text(chip.title)
+              .font(JovieFont.body(size: 13, weight: .semibold))
+              .foregroundStyle(
+                filter == chip ? JovieColor.backgroundBase : JovieColor.textSecondary
+              )
+              .padding(.horizontal, JovieSpacing.medium)
+              .padding(.vertical, 8)
+              .background(
+                filter == chip ? Color.white : JovieColor.surface1,
+                in: Capsule()
+              )
+          }
+          .buttonStyle(.plain)
+          .accessibilityAddTraits(filter == chip ? [.isSelected] : [])
+          .accessibilityIdentifier("library-filter-\(chip.id)")
+        }
+      }
+    }
+    .accessibilityIdentifier("library-filters")
+  }
+
+  private var emptyState: some View {
+    VStack(spacing: JovieSpacing.medium) {
+      Spacer(minLength: 80)
+      Text("No assets in this filter.")
+        .font(JovieFont.body(size: 16, weight: .medium))
+        .foregroundStyle(JovieColor.textSecondary)
+      Text("Switch filters or add assets from chat.")
+        .font(JovieFont.body(size: 14))
+        .foregroundStyle(JovieColor.textTertiary)
+      Spacer(minLength: 80)
+    }
+    .frame(maxWidth: .infinity)
+    .accessibilityIdentifier("library-empty")
+  }
+}
+
+private struct LibraryAssetCard: View {
+  let asset: LibraryAsset
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: JovieSpacing.medium) {
+        cover
+        VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
+          Text(asset.name)
+            .font(JovieFont.body(size: 16, weight: .semibold))
+            .foregroundStyle(JovieColor.textPrimary)
+            .lineLimit(1)
+
+          HStack(spacing: JovieSpacing.small) {
+            badge(asset.typeBadge)
+            badge(asset.visibilityBadge)
+          }
+
+          Text(asset.liveStatLabel)
+            .font(JovieFont.body(size: 13))
+            .foregroundStyle(JovieColor.textTertiary)
+            .lineLimit(1)
+        }
+        Spacer(minLength: 0)
+        Image(systemName: "chevron.right")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(JovieColor.textTertiary)
+      }
+      .padding(JovieSpacing.medium)
+      .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous))
+      .overlay {
+        RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
+          .stroke(JovieColor.borderSubtle, lineWidth: 1)
+      }
+    }
+    .buttonStyle(LibraryCardButtonStyle())
+    .accessibilityIdentifier("library-asset-\(asset.id)")
+    .accessibilityLabel("\(asset.name), \(asset.typeBadge), \(asset.visibilityBadge)")
+  }
+
+  private var cover: some View {
+    ZStack {
+      RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous)
+        .fill(JovieColor.surface2)
+      if let coverURL = asset.coverURL {
+        CachedRemoteImageView(imageURL: coverURL, size: 64) {
+          Image(systemName: "photo")
+            .foregroundStyle(JovieColor.textTertiary)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
+      } else {
+        Image(systemName: coverSymbol)
+          .font(.system(size: 20, weight: .semibold))
+          .foregroundStyle(JovieColor.textTertiary)
+      }
+    }
+    .frame(width: 64, height: 64)
+  }
+
+  private var coverSymbol: String {
+    switch asset.type {
+    case .release: return "opticaldisc"
+    case .merch: return "tshirt"
+    case .smartLink: return "link"
+    case .photo: return "photo"
+    case .press: return "doc.richtext"
+    }
+  }
+
+  private func badge(_ text: String) -> some View {
+    Text(text)
+      .font(JovieFont.body(size: 11, weight: .semibold))
+      .foregroundStyle(JovieColor.textSecondary)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 3)
+      .background(JovieColor.surface2, in: Capsule())
+  }
+}
+
+private struct LibraryCardButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .opacity(configuration.isPressed ? 0.8 : 1)
+      .scaleEffect(configuration.isPressed ? JovieMotion.pressScale : 1)
+      .animation(JovieMotion.subtle, value: configuration.isPressed)
+  }
+}

--- a/apps/ios/JovieTests/AppShellTabBarTests.swift
+++ b/apps/ios/JovieTests/AppShellTabBarTests.swift
@@ -1,0 +1,102 @@
+import Testing
+@testable import Jovie
+
+struct AppShellTabBarTests {
+  @Test func primaryTabsMatchChatLibraryCalendarInbox() {
+    let tabs = AppShellPrimaryTab.allCases.map(\.shellTab)
+    #expect(tabs == [.chat, .library, .calendar, .inbox])
+  }
+
+  @Test func profileAndAudienceAreNotPrimary() {
+    #expect(AppShellTab.profile.isPrimaryTab == false)
+    #expect(AppShellTab.audience.isPrimaryTab == false)
+    #expect(AppShellTab.chat.isPrimaryTab)
+    #expect(AppShellTab.library.isPrimaryTab)
+  }
+
+  @Test func accessibilityIDsAreStable() {
+    #expect(AppShellTab.chat.accessibilityID == "shell-tab-chat")
+    #expect(AppShellTab.library.accessibilityID == "shell-tab-library")
+    #expect(AppShellTab.calendar.accessibilityID == "shell-tab-calendar")
+    #expect(AppShellTab.inbox.accessibilityID == "shell-tab-inbox")
+  }
+
+  @Test func gesturePolicyNeverSwitchesTabsFromHorizontalSwipe() {
+    #expect(AppShellGesturePolicy.shouldSwitchTabFromHorizontalSwipe() == false)
+  }
+
+  @Test func leftEdgeOpenRecognizesLeadingEdgeDrag() {
+    #expect(
+      AppShellGesturePolicy.isLeftEdgeOpen(startX: 12, translationX: 90, predictedX: 100)
+    )
+    #expect(
+      AppShellGesturePolicy.isLeftEdgeOpen(startX: 80, translationX: 90, predictedX: 100)
+        == false
+    )
+  }
+
+  @Test func rightEdgeOpenRecognizesTrailingEdgeDrag() {
+    #expect(
+      AppShellGesturePolicy.isRightEdgeOpen(
+        startX: 390,
+        containerWidth: 400,
+        translationX: -90,
+        predictedX: -130
+      )
+    )
+    #expect(
+      AppShellGesturePolicy.isRightEdgeOpen(
+        startX: 200,
+        containerWidth: 400,
+        translationX: -90,
+        predictedX: -130
+      ) == false
+    )
+  }
+
+  @Test func resolveInitialTabKeepsPrimaryWhenChatEnabled() {
+    #expect(resolveShellInitialTab(.library, chatEnabled: true) == .library)
+    #expect(resolveShellInitialTab(.calendar, chatEnabled: true) == .calendar)
+    #expect(resolveShellInitialTab(.inbox, chatEnabled: true) == .inbox)
+  }
+
+  @Test func resolveInitialTabFallsToProfileWhenChatDisabled() {
+    #expect(resolveShellInitialTab(.library, chatEnabled: false) == .profile)
+    #expect(resolveShellInitialTab(.chat, chatEnabled: false) == .profile)
+  }
+}
+
+struct LibraryFeedTests {
+  @Test func filterAllReturnsEveryAsset() {
+    let assets = LibraryFeed.previewAssets
+    #expect(LibraryFeed.filtered(assets: assets, filter: .all).count == assets.count)
+  }
+
+  @Test func filterByTypeNarrowsFeed() {
+    let assets = LibraryFeed.previewAssets
+    let releases = LibraryFeed.filtered(assets: assets, filter: .type(.release))
+    #expect(releases.allSatisfy { $0.type == .release })
+    #expect(releases.isEmpty == false)
+  }
+
+  @Test func filterChipsLeadWithAll() {
+    #expect(LibraryFilter.chips.first == .all)
+    #expect(LibraryFilter.chips.count == LibraryAssetType.allCases.count + 1)
+  }
+}
+
+struct EntityContextTests {
+  @Test func entityIDIsStableKindPlusID() {
+    let item = EntityContextItem(kind: .release, entityID: "rel_1", label: "Midnight Drive")
+    #expect(item.id == "release:rel_1")
+    #expect(item.kindTitle == "Release")
+    #expect(item.publicURL.contains("rel_1"))
+  }
+
+  @Test func statsSnapshotIsDeterministicForSameID() {
+    let item = EntityContextItem(kind: .track, entityID: "trk_42", label: "Demo")
+    let a = EntityContextStats.snapshot(for: item)
+    let b = EntityContextStats.snapshot(for: item)
+    #expect(a == b)
+  }
+}

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -233,11 +233,11 @@ final class JovieUITests: XCTestCase {
     )
     // Profile + Audience are drawer-only — must not be primary tab buttons.
     XCTAssertFalse(
-      app.buttons["shell-tab-profile"].exists,
+      shellControlExists(app, identifier: "shell-tab-profile"),
       "Profile must not be a primary bottom tab.\n\(app.debugDescription)"
     )
     XCTAssertFalse(
-      app.buttons["shell-tab-audience"].exists,
+      shellControlExists(app, identifier: "shell-tab-audience"),
       "Audience must not be a primary bottom tab.\n\(app.debugDescription)"
     )
     // Composer no longer hosts a mic (JOV-3636).
@@ -331,11 +331,11 @@ final class JovieUITests: XCTestCase {
     let continueButton = onboardingApp.buttons["Continue on Web"]
     XCTAssertTrue(continueButton.waitForExistence(timeout: 3))
     XCTAssertFalse(
-      onboardingApp.buttons["shell-talk-fab"].exists,
+      shellControlExists(onboardingApp, identifier: "shell-talk-fab"),
       "Talk FAB should not render when chat is disabled.\n\(onboardingApp.debugDescription)"
     )
     XCTAssertFalse(
-      onboardingApp.buttons["shell-tab-chat"].exists,
+      shellControlExists(onboardingApp, identifier: "shell-tab-chat"),
       "Removed pill must not render in the chatEnabled == false shell.\n\(onboardingApp.debugDescription)"
     )
     attachScreenshot(named: "no-ghost-footprint-needs-onboarding", app: onboardingApp)
@@ -1155,9 +1155,9 @@ final class JovieUITests: XCTestCase {
     return element.exists && element.isHittable
   }
 
-  /// Resolve a shell control by preferred accessibility identifier, with a
-  /// label fallback for SwiftUI AX grouping regressions (seen when a parent
-  /// container identifier bled onto child buttons as `shell-tab-bar`).
+  /// Resolve a primary tab bar / Talk FAB control by accessibility identifier.
+  /// SwiftUI groups these as `Other` (not `Button`) when
+  /// `accessibilityElement(children: .ignore)` is applied on tab buttons.
   private func firstMatchingButton(
     _ app: XCUIApplication,
     identifiers: [String],
@@ -1167,7 +1167,7 @@ final class JovieUITests: XCTestCase {
     let deadline = Date().addingTimeInterval(max(0, timeout))
     repeat {
       for identifier in identifiers {
-        let byID = app.buttons[identifier]
+        let byID = app.descendants(matching: .any)[identifier]
         if byID.exists {
           return byID
         }
@@ -1182,6 +1182,17 @@ final class JovieUITests: XCTestCase {
         if leaked.exists {
           return leaked
         }
+        let byLabel = app.descendants(matching: .any)
+          .matching(NSPredicate(format: "label == %@", label))
+          .matching(
+            NSPredicate(
+              format: "identifier BEGINSWITH 'shell-tab-' OR identifier == 'shell-talk-fab'"
+            )
+          )
+          .firstMatch
+        if byLabel.exists {
+          return byLabel
+        }
       }
       if Date() >= deadline {
         break
@@ -1190,7 +1201,11 @@ final class JovieUITests: XCTestCase {
     } while Date() < deadline
 
     // Prefer the first identifier so callers can still assert on a stable query.
-    return app.buttons[identifiers.first ?? labels.first ?? ""]
+    return app.descendants(matching: .any)[identifiers.first ?? labels.first ?? ""]
+  }
+
+  private func shellControlExists(_ app: XCUIApplication, identifier: String) -> Bool {
+    app.descendants(matching: .any)[identifier].exists
   }
 
   private func openAuthCallbackURL(

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -198,47 +198,45 @@ final class JovieUITests: XCTestCase {
     attachScreenshot(named: "drawer-base-plane-occluded-closed", app: app)
   }
 
-  // JOV-3670 evidence (a): the drawer is the SOLE surface switcher. The former
-  // bottom QR/sparkle pill (shell-tab-* buttons, no drawer prefix) must not
-  // exist anywhere in the shell, whether the drawer is closed or open.
-  func testDrawerIsSoleSurfaceSwitcherNoPillRemains() {
+  // JOV-3632: primary bottom tabs + Talk FAB. Profile is drawer-only (no shell-tab-profile).
+  func testPrimaryTabBarAndTalkFAB() {
     let app = launchMockApp(launchArgument: "-ui-testing-chat", expectedElementDescription: "\"Ask Jovie\"") {
       $0.textFields["Ask Jovie"]
     }
 
-    // Closed-drawer state: no bare shell-tab-* pill buttons anywhere in the shell.
-    XCTAssertFalse(
-      app.buttons["shell-tab-chat"].exists,
-      "Removed bottom pill chat button still exists with drawer closed.\n\(app.debugDescription)"
+    XCTAssertTrue(
+      app.otherElements["shell-tab-bar"].waitForExistence(timeout: 3)
+        || app.buttons["shell-tab-chat"].waitForExistence(timeout: 3),
+      "Primary tab bar did not appear.\n\(app.debugDescription)"
     )
+    XCTAssertTrue(app.buttons["shell-tab-chat"].exists, "Chat tab missing")
+    XCTAssertTrue(app.buttons["shell-tab-library"].exists, "Library tab missing")
+    XCTAssertTrue(app.buttons["shell-tab-calendar"].exists, "Calendar tab missing")
+    XCTAssertTrue(app.buttons["shell-tab-inbox"].exists, "Inbox tab missing")
+    XCTAssertTrue(
+      app.buttons["shell-talk-fab"].exists,
+      "Talk FAB missing on primary tab bar.\n\(app.debugDescription)"
+    )
+    // Profile + Audience are drawer-only — must not be primary tab buttons.
     XCTAssertFalse(
       app.buttons["shell-tab-profile"].exists,
-      "Removed bottom pill profile button still exists with drawer closed.\n\(app.debugDescription)"
+      "Profile must not be a primary bottom tab.\n\(app.debugDescription)"
     )
-
-    // Voice control is present inside the composer and unrelated to the removed pill.
-    XCTAssertTrue(
-      app.buttons["chat-voice-button"].waitForExistence(timeout: 3),
-      "Voice button did not appear on the chat tab.\n\(app.debugDescription)"
+    XCTAssertFalse(
+      app.buttons["shell-tab-audience"].exists,
+      "Audience must not be a primary bottom tab.\n\(app.debugDescription)"
+    )
+    // Composer no longer hosts a mic (JOV-3636).
+    XCTAssertFalse(
+      app.buttons["chat-voice-button"].exists,
+      "Composer mic should be removed; Talk FAB is the only voice entry.\n\(app.debugDescription)"
     )
 
     app.buttons["Open navigation drawer"].tap()
-
-    // Open-drawer state: only the drawer-namespaced surface switcher exists.
     let profileSurface = app.buttons["shell-drawer-surface-shell-tab-profile"]
-    let chatSurface = app.buttons["shell-drawer-surface-shell-tab-chat"]
     XCTAssertTrue(
       profileSurface.waitForExistence(timeout: 3),
-      "Drawer surface switcher did not appear.\n\(app.debugDescription)"
-    )
-    XCTAssertTrue(chatSurface.exists)
-    XCTAssertFalse(
-      app.buttons["shell-tab-chat"].exists,
-      "Bare (non-drawer) chat pill button still exists with drawer open.\n\(app.debugDescription)"
-    )
-    XCTAssertFalse(
-      app.buttons["shell-tab-profile"].exists,
-      "Bare (non-drawer) profile pill button still exists with drawer open.\n\(app.debugDescription)"
+      "Drawer still exposes Profile surface.\n\(app.debugDescription)"
     )
   }
 
@@ -293,10 +291,11 @@ final class JovieUITests: XCTestCase {
     let composerInput = chatApp.textFields["Ask Jovie"]
     XCTAssertTrue(waitForHittable(composerInput, timeout: 3))
     let chatWindowMaxY = chatApp.windows.firstMatch.frame.maxY
+    // Composer sits above the primary tab bar (~56pt) + home indicator.
     XCTAssertGreaterThan(
       composerInput.frame.maxY,
-      chatWindowMaxY - 160,
-      "Chat composer left a ghost gap where the removed bottom pill used to sit.\n\(chatApp.debugDescription)"
+      chatWindowMaxY - 220,
+      "Chat composer left an unexpected gap above the tab bar.\n\(chatApp.debugDescription)"
     )
     attachScreenshot(named: "no-ghost-footprint-chat", app: chatApp)
 
@@ -328,14 +327,18 @@ final class JovieUITests: XCTestCase {
     attachScreenshot(named: "no-ghost-footprint-needs-onboarding", app: onboardingApp)
   }
 
-  func testVoiceButtonAppearsOnChatComposer() {
+  func testTalkFABAppearsOnPrimaryTabBar() {
     let app = launchMockApp(launchArgument: "-ui-testing-chat", expectedElementDescription: "\"Ask Jovie\"") {
       $0.textFields["Ask Jovie"]
     }
 
     XCTAssertTrue(
-      app.buttons["chat-voice-button"].waitForExistence(timeout: 3),
-      "Voice button did not appear on the chat tab.\n\(app.debugDescription)"
+      app.buttons["shell-talk-fab"].waitForExistence(timeout: 3),
+      "Talk FAB did not appear on the primary tab bar.\n\(app.debugDescription)"
+    )
+    XCTAssertFalse(
+      app.buttons["chat-voice-button"].exists,
+      "Composer mic must stay removed (FAB-only voice).\n\(app.debugDescription)"
     )
     XCTAssertFalse(app.staticTexts["STT"].exists)
     XCTAssertFalse(app.staticTexts["Transcription"].exists)

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -204,17 +204,31 @@ final class JovieUITests: XCTestCase {
       $0.textFields["Ask Jovie"]
     }
 
+    // Prefer the per-tab identifiers; fall back to label if AX grouping regresses.
+    let chatTab = firstMatchingButton(
+      app,
+      identifiers: ["shell-tab-chat"],
+      labels: ["Chat"],
+      timeout: 3
+    )
     XCTAssertTrue(
-      app.otherElements["shell-tab-bar"].waitForExistence(timeout: 3)
-        || app.buttons["shell-tab-chat"].waitForExistence(timeout: 3),
+      chatTab.exists,
       "Primary tab bar did not appear.\n\(app.debugDescription)"
     )
-    XCTAssertTrue(app.buttons["shell-tab-chat"].exists, "Chat tab missing")
-    XCTAssertTrue(app.buttons["shell-tab-library"].exists, "Library tab missing")
-    XCTAssertTrue(app.buttons["shell-tab-calendar"].exists, "Calendar tab missing")
-    XCTAssertTrue(app.buttons["shell-tab-inbox"].exists, "Inbox tab missing")
     XCTAssertTrue(
-      app.buttons["shell-talk-fab"].exists,
+      firstMatchingButton(app, identifiers: ["shell-tab-library"], labels: ["Library"]).exists,
+      "Library tab missing"
+    )
+    XCTAssertTrue(
+      firstMatchingButton(app, identifiers: ["shell-tab-calendar"], labels: ["Calendar"]).exists,
+      "Calendar tab missing"
+    )
+    XCTAssertTrue(
+      firstMatchingButton(app, identifiers: ["shell-tab-inbox"], labels: ["Inbox"]).exists,
+      "Inbox tab missing"
+    )
+    XCTAssertTrue(
+      firstMatchingButton(app, identifiers: ["shell-talk-fab"], labels: ["Talk"]).exists,
       "Talk FAB missing on primary tab bar.\n\(app.debugDescription)"
     )
     // Profile + Audience are drawer-only — must not be primary tab buttons.
@@ -332,8 +346,14 @@ final class JovieUITests: XCTestCase {
       $0.textFields["Ask Jovie"]
     }
 
+    let talkFAB = firstMatchingButton(
+      app,
+      identifiers: ["shell-talk-fab"],
+      labels: ["Talk"],
+      timeout: 3
+    )
     XCTAssertTrue(
-      app.buttons["shell-talk-fab"].waitForExistence(timeout: 3),
+      talkFAB.exists,
       "Talk FAB did not appear on the primary tab bar.\n\(app.debugDescription)"
     )
     XCTAssertFalse(
@@ -452,23 +472,47 @@ final class JovieUITests: XCTestCase {
     attachScreenshot(named: "chat-entity-chips", app: app)
   }
 
+  // JOV-3635: horizontal page-swipes between tabs are banned. Profile is
+  // drawer-only — open the drawer, pick Profile, then return via Chat tab.
   func testSwipeNavigatesBetweenProfileAndChat() {
     let app = launchMockApp(launchArgument: "-ui-testing-chat", expectedElementDescription: "\"Ask Jovie\"") {
       $0.textFields["Ask Jovie"]
     }
 
-    // Launches on Chat; swiping right reveals the Profile screen.
+    // Full-width swipe must NOT switch tabs (gesture ownership: edges only).
     app.swipeRight()
     XCTAssertTrue(
-      app.buttons["Copy URL"].waitForExistence(timeout: 3),
-      "Swiping right did not reveal the Profile screen.\n\(app.debugDescription)"
+      app.textFields["Ask Jovie"].waitForExistence(timeout: 2),
+      "Horizontal swipe incorrectly left Chat.\n\(app.debugDescription)"
+    )
+    XCTAssertFalse(
+      app.buttons["Copy URL"].exists,
+      "Horizontal swipe must not open Profile (drawer-only surface).\n\(app.debugDescription)"
     )
 
-    // Swiping left returns to Chat.
-    app.swipeLeft()
+    app.buttons["Open navigation drawer"].tap()
+    let profileSurface = app.buttons["shell-drawer-surface-shell-tab-profile"]
+    XCTAssertTrue(
+      profileSurface.waitForExistence(timeout: 3),
+      "Drawer Profile surface missing.\n\(app.debugDescription)"
+    )
+    profileSurface.tap()
+    XCTAssertTrue(
+      app.buttons["Copy URL"].waitForExistence(timeout: 3),
+      "Selecting Profile from the drawer did not reveal Profile.\n\(app.debugDescription)"
+    )
+
+    let chatTab = firstMatchingButton(
+      app,
+      identifiers: ["shell-tab-chat"],
+      labels: ["Chat"],
+      timeout: 3
+    )
+    XCTAssertTrue(chatTab.exists, "Chat tab missing after Profile.\n\(app.debugDescription)")
+    chatTab.tap()
     XCTAssertTrue(
       app.textFields["Ask Jovie"].waitForExistence(timeout: 3),
-      "Swiping left did not return to the Chat screen.\n\(app.debugDescription)"
+      "Chat tab did not return to Chat.\n\(app.debugDescription)"
     )
   }
 
@@ -1109,6 +1153,44 @@ final class JovieUITests: XCTestCase {
     }
 
     return element.exists && element.isHittable
+  }
+
+  /// Resolve a shell control by preferred accessibility identifier, with a
+  /// label fallback for SwiftUI AX grouping regressions (seen when a parent
+  /// container identifier bled onto child buttons as `shell-tab-bar`).
+  private func firstMatchingButton(
+    _ app: XCUIApplication,
+    identifiers: [String],
+    labels: [String],
+    timeout: TimeInterval = 0
+  ) -> XCUIElement {
+    let deadline = Date().addingTimeInterval(max(0, timeout))
+    repeat {
+      for identifier in identifiers {
+        let byID = app.buttons[identifier]
+        if byID.exists {
+          return byID
+        }
+      }
+      // When the parent HStack ID leaks, every primary tab shares
+      // identifier "shell-tab-bar" and only the accessibility label differs.
+      for label in labels {
+        let leaked = app.buttons
+          .matching(identifier: "shell-tab-bar")
+          .matching(NSPredicate(format: "label == %@", label))
+          .firstMatch
+        if leaked.exists {
+          return leaked
+        }
+      }
+      if Date() >= deadline {
+        break
+      }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    } while Date() < deadline
+
+    // Prefer the first identifier so callers can still assert on a stable query.
+    return app.buttons[identifiers.first ?? labels.first ?? ""]
   }
 
   private func openAuthCallbackURL(


### PR DESCRIPTION
## Summary
Implements the Jovie iOS chat-first app shell foundation for **JOV-3632, JOV-3634, JOV-3635, JOV-3636, JOV-3637** (Jovie iOS only — not LYB).

- **JOV-3632:** Bottom primary tabs `Chat · Library · [Talk FAB] · Calendar · Inbox`; Chat permanent home; Audience/Profile remain drawer-only; 4-layer z-order (home → tab bar → rails → Talk overlay).
- **JOV-3634:** Entity context sheet (cover, typed title, public/private toggle, stats, Edit In Chat, Copy Link) from chip tap.
- **JOV-3635:** Edge-swipe owns rails only (left drawer / right entity); no horizontal tab paging; long-press chip peek; inbox swipe-to-triage 👍/👎; message context menu.
- **JOV-3636:** Raised center Talk FAB → full-screen voice overlay; composer mic removed (OS keyboard dictation remains).
- **JOV-3637:** Library vertical asset-card feed + filter chips (All / Releases / Merch / Smart Links / Photos / Press); tap opens entity sheet.
- **JOV-3691:** **Not fixed** — blocked pending repro screenshots / surface identity of duplicate "Mac" entity (see Linear).

## Test plan
- [x] `pnpm run ios:lint` clean
- [x] `xcodebuild build` for iOS Simulator **BUILD SUCCEEDED**
- [x] `xcodebuild test` AppShellTabBarTests + AppShellChatFirstTests **TEST SUCCEEDED** (21 tests)
- [ ] CI iOS lane on PR
- [ ] Manual: open chat → tabs switch without losing draft; Talk FAB opens overlay; chip opens entity sheet; library filters; inbox swipe

## Cost Impact
- None for web runtime. iOS clients call existing `/api/mobile/v1/inbox` + `/api/mobile/v1/calendar` on ready shell load (already budgeted mobile action-loop endpoints). Library uses local preview fixtures until a mobile library API ships.

## Linear
Fixes JOV-3632
Fixes JOV-3634
Fixes JOV-3635
Fixes JOV-3636
Fixes JOV-3637

JOV-3691 remains open (blocked on repro).

<!-- linear-issue-id:JOV-3632 -->