### PR TITLE
feat(audio): global playback engine + smart-link UX + upload named rules

### DIFF
--- a/apps/web/components/atoms/SeekBar.tsx
+++ b/apps/web/components/atoms/SeekBar.tsx
@@ -85,9 +85,6 @@ export function SeekBar({
       onPointerCancel={endScrub}
       onBlur={endScrub}
       aria-label='Seek track'
-      aria-valuemin={0}
-      aria-valuemax={duration > 0 ? duration : 0}
-      aria-valuenow={displayTime}
       disabled={isDisabled}
       className={cn(
         'seek-range cursor-pointer appearance-none rounded-full accent-(--linear-accent) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) disabled:cursor-default disabled:opacity-50',

--- a/apps/web/components/atoms/SeekBar.tsx
+++ b/apps/web/components/atoms/SeekBar.tsx
@@ -17,10 +17,7 @@ interface SeekBarProps {
   readonly className?: string;
 }
 
-/**
- * Range scrubber with local drag state so the thumb never snaps back to the
- * last throttled engine tick mid-gesture (JOV-3681 smart-link jank fix).
- */
+/** Scrubber with local drag state so engine ticks cannot snap the thumb. */
 export function SeekBar({
   currentTime,
   duration,

--- a/apps/web/components/atoms/SeekBar.tsx
+++ b/apps/web/components/atoms/SeekBar.tsx
@@ -1,5 +1,12 @@
 'use client';
 
+import {
+  type ChangeEvent,
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import { cn } from '@/lib/utils';
 
 interface SeekBarProps {
@@ -10,6 +17,10 @@ interface SeekBarProps {
   readonly className?: string;
 }
 
+/**
+ * Range scrubber with local drag state so the thumb never snaps back to the
+ * last throttled engine tick mid-gesture (JOV-3681 smart-link jank fix).
+ */
 export function SeekBar({
   currentTime,
   duration,
@@ -17,10 +28,52 @@ export function SeekBar({
   disabled = false,
   className,
 }: SeekBarProps) {
+  const [isScrubbing, setIsScrubbing] = useState(false);
+  const [scrubTime, setScrubTime] = useState(currentTime);
+
+  useEffect(() => {
+    if (!isScrubbing) {
+      setScrubTime(currentTime);
+    }
+  }, [currentTime, isScrubbing]);
+
+  const displayTime = isScrubbing ? scrubTime : currentTime;
   const progressPercent =
     duration > 0
-      ? Math.min(100, Math.max(0, (currentTime / duration) * 100))
+      ? Math.min(100, Math.max(0, (displayTime / duration) * 100))
       : 0;
+  const isDisabled = disabled || duration <= 0;
+
+  const commitSeek = useCallback(
+    (time: number) => {
+      if (!Number.isFinite(time) || duration <= 0) return;
+      const clamped = Math.max(0, Math.min(time, duration));
+      setScrubTime(clamped);
+      onSeek(clamped);
+    },
+    [duration, onSeek]
+  );
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      commitSeek(Number(event.target.value));
+    },
+    [commitSeek]
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLInputElement>) => {
+      if (isDisabled) return;
+      setIsScrubbing(true);
+      // Capture so pointerup outside the thumb still ends the gesture.
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+    },
+    [isDisabled]
+  );
+
+  const endScrub = useCallback(() => {
+    setIsScrubbing(false);
+  }, []);
 
   return (
     <input
@@ -28,12 +81,17 @@ export function SeekBar({
       min={0}
       max={duration > 0 ? duration : 1}
       step='any'
-      value={currentTime}
-      onChange={event => {
-        onSeek(Number(event.target.value));
-      }}
+      value={displayTime}
+      onChange={handleChange}
+      onPointerDown={handlePointerDown}
+      onPointerUp={endScrub}
+      onPointerCancel={endScrub}
+      onBlur={endScrub}
       aria-label='Seek track'
-      disabled={disabled}
+      aria-valuemin={0}
+      aria-valuemax={duration > 0 ? duration : 0}
+      aria-valuenow={displayTime}
+      disabled={isDisabled}
       className={cn(
         'seek-range cursor-pointer appearance-none rounded-full accent-(--linear-accent) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) disabled:cursor-default disabled:opacity-50',
         className

--- a/apps/web/components/atoms/SeekBar.tsx
+++ b/apps/web/components/atoms/SeekBar.tsx
@@ -17,7 +17,6 @@ interface SeekBarProps {
   readonly className?: string;
 }
 
-/** Scrubber with local drag state so engine ticks cannot snap the thumb. */
 export function SeekBar({
   currentTime,
   duration,

--- a/apps/web/components/features/release/AudioWaveformEditor.tsx
+++ b/apps/web/components/features/release/AudioWaveformEditor.tsx
@@ -10,6 +10,11 @@ import {
   useRef,
   useState,
 } from 'react';
+import {
+  pausePlaybackForInterruption,
+  resumePlaybackAfterInterruption,
+  useTrackAudioPlayer,
+} from '@/components/organisms/release-sidebar/useTrackAudioPlayer';
 import { decodeWaveformPeaks } from '@/lib/audio/decode-waveform-peaks';
 import {
   type AudioSnippet,
@@ -77,6 +82,8 @@ export function AudioWaveformEditor({
   const waveformRef = useRef<HTMLDivElement>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const dragRef = useRef<TrimHandle | null>(null);
+  const holdsGlobalFocusRef = useRef(false);
+  const { playbackState: globalPlayback } = useTrackAudioPlayer();
 
   const [peaks, setPeaks] = useState<readonly number[]>([]);
   const [resolvedDurationMs, setResolvedDurationMs] = useState(durationMs ?? 0);
@@ -140,6 +147,12 @@ export function AudioWaveformEditor({
     audio.preload = 'metadata';
     audioRef.current = audio;
 
+    const releaseGlobalFocus = () => {
+      if (!holdsGlobalFocusRef.current) return;
+      holdsGlobalFocusRef.current = false;
+      resumePlaybackAfterInterruption();
+    };
+
     const handleTimeUpdate = () => {
       setCurrentTimeMs(Math.round(audio.currentTime * 1000));
       if (!snippet) return;
@@ -147,9 +160,13 @@ export function AudioWaveformEditor({
         audio.pause();
         audio.currentTime = snippet.startMs / 1000;
         setIsPlaying(false);
+        releaseGlobalFocus();
       }
     };
-    const handleEnded = () => setIsPlaying(false);
+    const handleEnded = () => {
+      setIsPlaying(false);
+      releaseGlobalFocus();
+    };
     const handlePlay = () => setIsPlaying(true);
     const handlePause = () => setIsPlaying(false);
 
@@ -159,15 +176,33 @@ export function AudioWaveformEditor({
     audio.addEventListener('pause', handlePause);
 
     return () => {
-      audio.pause();
+      try {
+        audio.pause();
+      } catch {
+        // jsdom throws Not implemented for HTMLMediaElement.pause
+      }
       audio.src = '';
       audio.removeEventListener('timeupdate', handleTimeUpdate);
       audio.removeEventListener('ended', handleEnded);
       audio.removeEventListener('play', handlePlay);
       audio.removeEventListener('pause', handlePause);
       audioRef.current = null;
+      releaseGlobalFocus();
     };
   }, [audioUrl, snippet]);
+
+  // Global engine wins: if dock/right-rail starts, stop local snippet preview.
+  useEffect(() => {
+    if (!globalPlayback.isPlaying) return;
+    const audio = audioRef.current;
+    if (!audio || audio.paused) return;
+    audio.pause();
+    setIsPlaying(false);
+    if (holdsGlobalFocusRef.current) {
+      holdsGlobalFocusRef.current = false;
+      resumePlaybackAfterInterruption();
+    }
+  }, [globalPlayback.isPlaying, globalPlayback.activeTrackId]);
 
   const seekTo = useCallback(
     (nextMs: number) => {
@@ -186,6 +221,10 @@ export function AudioWaveformEditor({
 
     if (isPlaying) {
       audio.pause();
+      if (holdsGlobalFocusRef.current) {
+        holdsGlobalFocusRef.current = false;
+        resumePlaybackAfterInterruption();
+      }
       return;
     }
 
@@ -198,10 +237,21 @@ export function AudioWaveformEditor({
       }
     }
 
+    // Snippet editor keeps a local element for trim loops, but claims global
+    // audio focus so dock/right-rail cannot dual-play (JOV-3683).
+    if (!holdsGlobalFocusRef.current) {
+      pausePlaybackForInterruption();
+      holdsGlobalFocusRef.current = true;
+    }
+
     try {
       await audio.play();
     } catch {
       setIsPlaying(false);
+      if (holdsGlobalFocusRef.current) {
+        holdsGlobalFocusRef.current = false;
+        resumePlaybackAfterInterruption();
+      }
     }
   }, [isPlaying, snippet]);
 

--- a/apps/web/components/features/release/AudioWaveformEditor.tsx
+++ b/apps/web/components/features/release/AudioWaveformEditor.tsx
@@ -191,7 +191,6 @@ export function AudioWaveformEditor({
     };
   }, [audioUrl, snippet]);
 
-  // Global engine wins: if dock/right-rail starts, stop local snippet preview.
   useEffect(() => {
     if (!globalPlayback.isPlaying) return;
     const audio = audioRef.current;
@@ -237,8 +236,6 @@ export function AudioWaveformEditor({
       }
     }
 
-    // Snippet editor keeps a local element for trim loops, but claims global
-    // audio focus so dock/right-rail cannot dual-play (JOV-3683).
     if (!holdsGlobalFocusRef.current) {
       pausePlaybackForInterruption();
       holdsGlobalFocusRef.current = true;

--- a/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
+++ b/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
@@ -115,7 +115,6 @@ export function ReleaseAudioAssetPanel({
         handleRequestType(rejection);
         return;
       }
-      // pick_another + compress both re-open the picker (no silent dead-end).
       openFilePicker();
     },
     [handleRequestType, openFilePicker]
@@ -290,7 +289,6 @@ export function ReleaseAudioAssetPanel({
           className='sr-only'
           aria-label={`Upload audio for ${releaseTitle}`}
         />
-        {/* Fixed min-height so rejection UI never collapses the dropzone layout */}
         <output
           className='min-h-12 space-y-1.5 pt-1.5 text-2xs'
           data-testid='release-audio-upload-feedback'

--- a/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
+++ b/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
@@ -13,11 +13,13 @@ import {
 import { toast } from '@/components/feedback';
 import {
   AUDIO_ACCEPT,
-  AUDIO_MAX_FILE_SIZE_BYTES,
-  isSupportedAudioFile,
+  type AudioUploadRejection,
+  SUPPORTED_AUDIO_FORMAT_LABELS,
+  validateAudioUpload,
 } from '@/lib/audio/constants';
 import type { AudioSnippet } from '@/lib/audio/snippet';
 import { cn } from '@/lib/utils';
+import { logger } from '@/lib/utils/logger';
 import { AudioWaveformEditor } from './AudioWaveformEditor';
 
 export interface ReleaseAudioAssetPanelProps {
@@ -58,6 +60,8 @@ export function ReleaseAudioAssetPanel({
   );
   const [isDragging, setIsDragging] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
+  const [uploadRejection, setUploadRejection] =
+    useState<AudioUploadRejection | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -92,22 +96,45 @@ export function ReleaseAudioAssetPanel({
     };
   }, [initialSnippet, localPreviewUrl, releaseId]);
 
+  const openFilePicker = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const handleRequestType = useCallback((rejection: AudioUploadRejection) => {
+    logger.info('[audio-upload] request unsupported type', {
+      code: rejection.code,
+      rule: rejection.rule,
+      message: rejection.message,
+    });
+    toast.success('Request noted — we track demand for new formats');
+  }, []);
+
+  const handleRejectionCta = useCallback(
+    (rejection: AudioUploadRejection) => {
+      if (rejection.cta.action === 'request_type') {
+        handleRequestType(rejection);
+        return;
+      }
+      // pick_another + compress both re-open the picker (no silent dead-end).
+      openFilePicker();
+    },
+    [handleRequestType, openFilePicker]
+  );
+
   const uploadFile = useCallback(
     async (file: File) => {
       if (!isEditable) return;
 
-      if (!isSupportedAudioFile(file)) {
-        setUploadError('Use MP3, WAV, FLAC, AIFF, AAC, or M4A audio.');
-        return;
-      }
-
-      if (file.size > AUDIO_MAX_FILE_SIZE_BYTES) {
-        setUploadError('Audio must be 150 MB or smaller.');
+      const validation = validateAudioUpload(file);
+      if (!validation.ok) {
+        setUploadRejection(validation);
+        setUploadError(null);
         return;
       }
 
       setIsUploading(true);
       setUploadError(null);
+      setUploadRejection(null);
 
       try {
         const blob = await upload(file.name, file, {
@@ -145,6 +172,7 @@ export function ReleaseAudioAssetPanel({
         const message =
           error instanceof Error ? error.message : 'Audio upload failed';
         setUploadError(message);
+        setUploadRejection(null);
         toast.error(message);
       } finally {
         setIsUploading(false);
@@ -201,11 +229,12 @@ export function ReleaseAudioAssetPanel({
   );
 
   if (!localPreviewUrl) {
+    const formats = SUPPORTED_AUDIO_FORMAT_LABELS.join(', ');
     return (
       <div data-testid={dropzoneTestId}>
         <button
           type='button'
-          onClick={() => inputRef.current?.click()}
+          onClick={openFilePicker}
           onDragEnter={event => {
             event.preventDefault();
             setIsDragging(true);
@@ -248,7 +277,7 @@ export function ReleaseAudioAssetPanel({
             {isUploading ? 'Uploading audio' : 'Drop audio'}
           </span>
           <span className='mt-1 text-2xs leading-4 text-tertiary-token'>
-            MP3, WAV, FLAC, AIFF, AAC, or M4A. Max 150 MB.
+            {formats}. Max 150 MB.
           </span>
         </button>
         <input
@@ -261,8 +290,54 @@ export function ReleaseAudioAssetPanel({
           className='sr-only'
           aria-label={`Upload audio for ${releaseTitle}`}
         />
-        <output className='min-h-5 pt-1.5 text-2xs'>
-          {uploadError ? <p className='text-error'>{uploadError}</p> : null}
+        {/* Fixed min-height so rejection UI never collapses the dropzone layout */}
+        <output
+          className='min-h-12 space-y-1.5 pt-1.5 text-2xs'
+          data-testid='release-audio-upload-feedback'
+        >
+          {uploadRejection ? (
+            <div className='rounded-md border border-subtle bg-surface-0 px-2.5 py-2 text-left'>
+              <p className='font-medium text-error' data-testid='upload-rule'>
+                {uploadRejection.rule}
+              </p>
+              <p className='mt-0.5 text-secondary-token'>
+                {uploadRejection.message}
+              </p>
+              <div className='mt-2 flex flex-wrap items-center gap-2'>
+                <button
+                  type='button'
+                  onClick={() => handleRejectionCta(uploadRejection)}
+                  className='rounded-md border border-subtle bg-surface-1 px-2 py-1 text-2xs font-medium text-primary-token transition-colors duration-subtle hover:bg-surface-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55'
+                  data-testid='upload-rejection-cta'
+                >
+                  {uploadRejection.cta.label}
+                </button>
+                {uploadRejection.code === 'audio.supported_types' ? (
+                  <button
+                    type='button'
+                    onClick={() =>
+                      handleRequestType({
+                        ...uploadRejection,
+                        cta: {
+                          label: 'Request this type',
+                          action: 'request_type',
+                        },
+                      })
+                    }
+                    className='rounded-md px-2 py-1 text-2xs font-medium text-secondary-token transition-colors duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55'
+                    data-testid='upload-request-type-cta'
+                  >
+                    Request this type
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+          {uploadError ? (
+            <p className='text-error' data-testid='upload-generic-error'>
+              {uploadError}
+            </p>
+          ) : null}
         </output>
       </div>
     );

--- a/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
+++ b/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
@@ -305,7 +305,7 @@ export function ReleaseAudioAssetPanel({
                 <button
                   type='button'
                   onClick={() => handleRejectionCta(uploadRejection)}
-                  className='rounded-md border border-subtle bg-surface-1 px-2 py-1 text-2xs font-medium text-primary-token transition-colors duration-subtle hover:bg-surface-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55'
+                  className='focus-ring-themed rounded-md border border-subtle bg-surface-1 px-2 py-1 text-2xs font-medium text-primary-token transition-colors duration-subtle hover:bg-surface-0'
                   data-testid='upload-rejection-cta'
                 >
                   {uploadRejection.cta.label}
@@ -317,15 +317,15 @@ export function ReleaseAudioAssetPanel({
                       handleRequestType({
                         ...uploadRejection,
                         cta: {
-                          label: 'Request this type',
+                          label: 'Request This Type',
                           action: 'request_type',
                         },
                       })
                     }
-                    className='rounded-md px-2 py-1 text-2xs font-medium text-secondary-token transition-colors duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55'
+                    className='focus-ring-themed rounded-md px-2 py-1 text-2xs font-medium text-secondary-token transition-colors duration-subtle hover:text-primary-token'
                     data-testid='upload-request-type-cta'
                   >
-                    Request this type
+                    Request This Type
                   </button>
                 ) : null}
               </div>

--- a/apps/web/components/features/release/SmartLinkAudioPreview.tsx
+++ b/apps/web/components/features/release/SmartLinkAudioPreview.tsx
@@ -22,7 +22,6 @@ interface SmartLinkAudioPreviewProps {
   readonly previewSource?: PreviewSource;
 }
 
-/** Fan-facing preview — thin UI over the global engine; height-stable. */
 export function SmartLinkAudioPreview({
   contentId,
   title,

--- a/apps/web/components/features/release/SmartLinkAudioPreview.tsx
+++ b/apps/web/components/features/release/SmartLinkAudioPreview.tsx
@@ -22,11 +22,7 @@ interface SmartLinkAudioPreviewProps {
   readonly previewSource?: PreviewSource;
 }
 
-/**
- * Fan-facing smart-link audio preview. Thin UI over the single global
- * playback engine — never instantiates its own audio element (JOV-3683).
- * Layout is height-stable across idle/loading/playing to avoid CLS (JOV-3681).
- */
+/** Fan-facing preview — thin UI over the global engine; height-stable. */
 export function SmartLinkAudioPreview({
   contentId,
   title,
@@ -123,7 +119,6 @@ export function SmartLinkAudioPreview({
         </button>
 
         <div className='min-w-0 flex-1 space-y-1'>
-          {/* Fixed scrub row height so play/pause/load never shifts layout */}
           <div className='flex h-4 items-center'>
             <SeekBar
               currentTime={currentTime}
@@ -142,7 +137,6 @@ export function SmartLinkAudioPreview({
           </div>
         </div>
       </div>
-      {/* Reserve one line so fallback label never pushes DSP buttons */}
       <p className='min-h-3.5 text-3xs text-white/45'>
         {fallbackSourceLabel ?? '\u00a0'}
       </p>

--- a/apps/web/components/features/release/SmartLinkAudioPreview.tsx
+++ b/apps/web/components/features/release/SmartLinkAudioPreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Pause, Play } from 'lucide-react';
+import { Loader2, Pause, Play } from 'lucide-react';
 import { useCallback, useEffect } from 'react';
 import { SeekBar } from '@/components/atoms/SeekBar';
 import { toast } from '@/components/feedback';
@@ -22,6 +22,11 @@ interface SmartLinkAudioPreviewProps {
   readonly previewSource?: PreviewSource;
 }
 
+/**
+ * Fan-facing smart-link audio preview. Thin UI over the single global
+ * playback engine — never instantiates its own audio element (JOV-3683).
+ * Layout is height-stable across idle/loading/playing to avoid CLS (JOV-3681).
+ */
 export function SmartLinkAudioPreview({
   contentId,
   title,
@@ -35,18 +40,21 @@ export function SmartLinkAudioPreview({
   const { playbackState, toggleTrack, seek, onError } = useTrackAudioPlayer();
 
   const isThisTrack = playbackState.activeTrackId === contentId;
+  const isLoading = isThisTrack && playbackState.playbackStatus === 'loading';
   const isPlaying = isThisTrack && playbackState.isPlaying;
   const currentTime = isThisTrack ? playbackState.currentTime : 0;
   const duration = isThisTrack ? playbackState.duration : 0;
+  const canScrub = isThisTrack && duration > 0 && !isLoading;
 
   useEffect(() => {
-    return onError(() => {
+    return onError(reason => {
+      if (reason === 'missing_source') return;
       toast.error('Preview unavailable');
     });
   }, [onError]);
 
   const handleToggle = useCallback(() => {
-    if (!previewUrl) return;
+    if (!previewUrl || isLoading) return;
     toggleTrack({
       id: contentId,
       title,
@@ -56,14 +64,23 @@ export function SmartLinkAudioPreview({
       artistName,
       artworkUrl,
     }).catch(() => {});
-  }, [contentId, title, artistName, artworkUrl, previewUrl, isrc, toggleTrack]);
+  }, [
+    contentId,
+    title,
+    artistName,
+    artworkUrl,
+    previewUrl,
+    isrc,
+    isLoading,
+    toggleTrack,
+  ]);
 
   // Hide entirely when no preview is available
   if (!previewUrl) return null;
 
   const currentTimeFormatted = formatDuration(Math.round(currentTime) * 1000);
   const durationFormatted =
-    duration > 0 ? formatDuration(Math.round(duration) * 1000) : null;
+    duration > 0 ? formatDuration(Math.round(duration) * 1000) : '–:––';
   let fallbackSourceLabel: string | null = null;
   if (previewVerification === 'fallback') {
     const sourceLabels: Record<string, string> = {
@@ -77,43 +94,58 @@ export function SmartLinkAudioPreview({
       (previewSource && sourceLabels[previewSource]) ?? 'Fallback preview';
   }
 
+  let statusLabel = isPlaying ? 'Pause preview' : 'Play preview';
+  if (isLoading) statusLabel = 'Loading preview';
+
   return (
-    <div className='space-y-1.5'>
-      <div className='flex items-center gap-2.5'>
+    <div className='space-y-1.5' data-testid='smart-link-audio-preview'>
+      <div className='flex min-h-10 items-center gap-2.5'>
         <button
           type='button'
           onClick={handleToggle}
-          aria-label={isPlaying ? 'Pause preview' : 'Play preview'}
+          aria-label={statusLabel}
           aria-pressed={isPlaying}
-          className='flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white/90 text-black dark:text-white transition-colors duration-fast hover:bg-white active:bg-white/75 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70'
+          aria-busy={isLoading || undefined}
+          disabled={isLoading}
+          className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white/90 text-black transition-colors duration-fast hover:bg-white active:scale-[var(--scale-press)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70 disabled:opacity-70 motion-reduce:active:scale-100'
         >
-          {isPlaying ? (
-            <Pause className='h-3 w-3' />
+          {isLoading ? (
+            <Loader2
+              className='h-3.5 w-3.5 animate-spin motion-reduce:animate-none'
+              aria-hidden='true'
+              strokeWidth={2.25}
+            />
+          ) : isPlaying ? (
+            <Pause className='h-3.5 w-3.5' aria-hidden='true' />
           ) : (
-            <Play className='h-3 w-3 translate-x-px' />
+            <Play className='h-3.5 w-3.5 translate-x-px' aria-hidden='true' />
           )}
         </button>
 
-        <div className='min-w-0 flex-1 space-y-0.5'>
-          <SeekBar
-            currentTime={currentTime}
-            duration={duration}
-            onSeek={seek}
-            disabled={false}
-            className='h-1 w-full'
-          />
-          <div className='flex items-center justify-between text-3xs tabular-nums text-white/35'>
-            <span>{currentTimeFormatted}</span>
-            <span>
+        <div className='min-w-0 flex-1 space-y-1'>
+          {/* Fixed scrub row height so play/pause/load never shifts layout */}
+          <div className='flex h-4 items-center'>
+            <SeekBar
+              currentTime={currentTime}
+              duration={duration}
+              onSeek={seek}
+              disabled={!canScrub}
+              className='h-1.5 w-full'
+            />
+          </div>
+          <div className='flex h-3.5 items-center justify-between text-3xs tabular-nums text-white/35'>
+            <span className='min-w-8'>{currentTimeFormatted}</span>
+            <span className='min-w-12 text-right'>
               {durationFormatted}
               {duration > 0 && duration < 45 ? ' · Preview' : ''}
             </span>
           </div>
         </div>
       </div>
-      {fallbackSourceLabel ? (
-        <p className='text-3xs text-white/45'>{fallbackSourceLabel}</p>
-      ) : null}
+      {/* Reserve one line so fallback label never pushes DSP buttons */}
+      <p className='min-h-3.5 text-3xs text-white/45'>
+        {fallbackSourceLabel ?? '\u00a0'}
+      </p>
     </div>
   );
 }

--- a/apps/web/components/jovie/hooks/useSpeechRecognition.ts
+++ b/apps/web/components/jovie/hooks/useSpeechRecognition.ts
@@ -2,6 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  pausePlaybackForInterruption,
+  resumePlaybackAfterInterruption,
+} from '@/components/organisms/release-sidebar/useTrackAudioPlayer';
+import {
   createWebSpeechTranscriber,
   type Transcriber,
   type TranscriberErrorCode,
@@ -67,9 +71,12 @@ export function useSpeechRecognition({
         onError: code => {
           setError(code);
           setIsListening(false);
+          // Release interruption hold if capture failed mid-session.
+          resumePlaybackAfterInterruption();
         },
         onEnd: () => {
           setIsListening(false);
+          resumePlaybackAfterInterruption();
         },
       },
       { lang, browserWindow }
@@ -82,6 +89,7 @@ export function useSpeechRecognition({
     return () => {
       transcriber.dispose();
       transcriberRef.current = null;
+      resumePlaybackAfterInterruption();
     };
   }, [browserWindow, desktopDictationStatus.webSpeechFallbackAllowed, lang]);
 
@@ -93,6 +101,9 @@ export function useSpeechRecognition({
     const transcriber = transcriberRef.current;
     if (!transcriber?.isSupported) return;
     setError(null);
+    // Single-active media: pause global playback while capturing voice.
+    // Stay paused after stop (JOV-3683 default — no auto-resume).
+    pausePlaybackForInterruption();
     transcriber.start();
     setIsListening(true);
   }, []);
@@ -100,6 +111,7 @@ export function useSpeechRecognition({
   const stop = useCallback(() => {
     transcriberRef.current?.stop();
     setIsListening(false);
+    resumePlaybackAfterInterruption();
   }, []);
 
   const toggle = useCallback(() => {

--- a/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
+++ b/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
@@ -51,15 +51,11 @@ let _activeTrackIsrc: string | null = null;
 let _hasRetriedRefresh = false;
 let _queue: readonly AudioTrackSource[] = [];
 let _queueIndex = -1;
-/**
- * Interruption focus (dictation / local preview / video). While held, the engine
- * stays paused so a secondary surface cannot dual-play with the global source.
- * Resume is opt-in — default UX is stay paused after capture ends (JOV-3683).
- */
+/** Nested audio-focus holds (dictation / local preview). Resume is opt-in. */
 let _interruptionDepth = 0;
 let _wasPlayingBeforeInterruption = false;
 let _mediaSessionBound = false;
-/** Progress notify floor — ~4 Hz keeps scrub UIs smooth without full rAF thrash. */
+/** ~4 Hz progress notify for cross-surface scrub without rAF thrash. */
 const PROGRESS_NOTIFY_MS = 250;
 
 /** Lazily create the Audio element — safe to call during SSR (returns null server-side). */
@@ -147,16 +143,15 @@ function setState(partial: Partial<PlaybackState>): void {
   state = { ...state, ...partial };
   notify();
 
-  // Skip Media Session work on pure progress ticks (timeupdate ~4 Hz).
-  const identityChanged =
+  if (
     prev.activeTrackId !== state.activeTrackId ||
     prev.trackTitle !== state.trackTitle ||
     prev.artistName !== state.artistName ||
     prev.releaseTitle !== state.releaseTitle ||
     prev.artworkUrl !== state.artworkUrl ||
     prev.isPlaying !== state.isPlaying ||
-    prev.duration !== state.duration;
-  if (identityChanged) {
+    prev.duration !== state.duration
+  ) {
     syncMediaSession();
   }
 }
@@ -444,11 +439,7 @@ function bindAudioEvents(el: HTMLAudioElement): void {
   });
 }
 
-/**
- * Imperative pause for short interruptions (chat dictation, local waveform
- * preview, embedded video). Nested-safe; only the outermost release clears the
- * focus hold. Default after release: stay paused (do not auto-resume).
- */
+/** Nested-safe pause for dictation / local preview. Default: no auto-resume. */
 export function pausePlaybackForInterruption(): void {
   const audio = getAudio();
   if (_interruptionDepth === 0) {
@@ -462,10 +453,7 @@ export function pausePlaybackForInterruption(): void {
   }
 }
 
-/**
- * Release an interruption hold. Pass `{ resume: true }` only when product UX
- * wants auto-resume; JOV-3683 default is stay paused after dictation.
- */
+/** Release interruption hold. Pass `{ resume: true }` to resume prior track. */
 export function resumePlaybackAfterInterruption(
   options: { readonly resume?: boolean } = {}
 ): void {
@@ -484,12 +472,10 @@ export function resumePlaybackAfterInterruption(
   });
 }
 
-/** Snapshot for non-React callers (tests, focus arbitration). */
 export function getPlaybackEngineSnapshot(): PlaybackState {
   return state;
 }
 
-/** True while an interruption hold is active (dictation / local preview). */
 export function isPlaybackInterrupted(): boolean {
   return _interruptionDepth > 0;
 }
@@ -500,7 +486,6 @@ export function useTrackAudioPlayer() {
   useEffect(() => {
     const listener = () => setPlaybackState(state);
     listeners.add(listener);
-    // Sync late subscribers with current engine state (e.g. route remounts).
     setPlaybackState(state);
     return () => {
       listeners.delete(listener);
@@ -512,8 +497,7 @@ export function useTrackAudioPlayer() {
       const audio = getAudio();
       if (!audio) return;
 
-      // New intentional play clears interruption holds so dock/right-rail
-      // transport is never stuck muted after dictation.
+      // Intentional play clears dictation/local-preview holds.
       if (_interruptionDepth > 0) {
         _interruptionDepth = 0;
         _wasPlayingBeforeInterruption = false;

--- a/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
+++ b/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
@@ -472,14 +472,6 @@ export function resumePlaybackAfterInterruption(
   });
 }
 
-export function getPlaybackEngineSnapshot(): PlaybackState {
-  return state;
-}
-
-export function isPlaybackInterrupted(): boolean {
-  return _interruptionDepth > 0;
-}
-
 export function useTrackAudioPlayer() {
   const [playbackState, setPlaybackState] = useState<PlaybackState>(state);
 

--- a/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
+++ b/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
@@ -51,6 +51,16 @@ let _activeTrackIsrc: string | null = null;
 let _hasRetriedRefresh = false;
 let _queue: readonly AudioTrackSource[] = [];
 let _queueIndex = -1;
+/**
+ * Interruption focus (dictation / local preview / video). While held, the engine
+ * stays paused so a secondary surface cannot dual-play with the global source.
+ * Resume is opt-in — default UX is stay paused after capture ends (JOV-3683).
+ */
+let _interruptionDepth = 0;
+let _wasPlayingBeforeInterruption = false;
+let _mediaSessionBound = false;
+/** Progress notify floor — ~4 Hz keeps scrub UIs smooth without full rAF thrash. */
+const PROGRESS_NOTIFY_MS = 250;
 
 /** Lazily create the Audio element — safe to call during SSR (returns null server-side). */
 function getAudio(): HTMLAudioElement | null {
@@ -133,8 +143,115 @@ function notify(): void {
 }
 
 function setState(partial: Partial<PlaybackState>): void {
+  const prev = state;
   state = { ...state, ...partial };
   notify();
+
+  // Skip Media Session work on pure progress ticks (timeupdate ~4 Hz).
+  const identityChanged =
+    prev.activeTrackId !== state.activeTrackId ||
+    prev.trackTitle !== state.trackTitle ||
+    prev.artistName !== state.artistName ||
+    prev.releaseTitle !== state.releaseTitle ||
+    prev.artworkUrl !== state.artworkUrl ||
+    prev.isPlaying !== state.isPlaying ||
+    prev.duration !== state.duration;
+  if (identityChanged) {
+    syncMediaSession();
+  }
+}
+
+function getMediaSession(): MediaSession | null {
+  if (typeof navigator === 'undefined') return null;
+  if (!('mediaSession' in navigator)) return null;
+  return navigator.mediaSession;
+}
+
+function bindMediaSessionHandlers(): void {
+  if (_mediaSessionBound) return;
+  const session = getMediaSession();
+  if (!session) return;
+
+  try {
+    session.setActionHandler('play', () => {
+      const audio = getAudio();
+      if (!audio || !state.activeTrackId) return;
+      void audio.play().catch(() => {
+        handlePlaybackFailure(audio, 'play_rejected');
+      });
+    });
+    session.setActionHandler('pause', () => {
+      getAudio()?.pause();
+    });
+    session.setActionHandler('previoustrack', () => {
+      if (state.hasPrevious) {
+        void advanceQueueToIndex(_queueIndex - 1);
+      }
+    });
+    session.setActionHandler('nexttrack', () => {
+      if (state.hasNext) {
+        void advanceQueueToIndex(_queueIndex + 1);
+      }
+    });
+    session.setActionHandler('seekto', details => {
+      if (typeof details.seekTime !== 'number') return;
+      seekToTime(details.seekTime);
+    });
+    _mediaSessionBound = true;
+  } catch {
+    // Some browsers reject unsupported action handlers — ignore.
+  }
+}
+
+function syncMediaSession(): void {
+  const session = getMediaSession();
+  if (!session) return;
+
+  bindMediaSessionHandlers();
+
+  if (!state.activeTrackId) {
+    session.metadata = null;
+    session.playbackState = 'none';
+    return;
+  }
+
+  try {
+    session.metadata = new MediaMetadata({
+      title: state.trackTitle ?? 'Unknown track',
+      artist: state.artistName ?? '',
+      album: state.releaseTitle ?? '',
+      artwork: state.artworkUrl
+        ? [{ src: state.artworkUrl, sizes: '512x512' }]
+        : [],
+    });
+  } catch {
+    // MediaMetadata construction can throw on invalid artwork URLs.
+  }
+
+  session.playbackState = state.isPlaying ? 'playing' : 'paused';
+
+  try {
+    if (
+      Number.isFinite(state.duration) &&
+      state.duration > 0 &&
+      typeof session.setPositionState === 'function'
+    ) {
+      session.setPositionState({
+        duration: state.duration,
+        position: Math.min(state.currentTime, state.duration),
+        playbackRate: 1,
+      });
+    }
+  } catch {
+    // setPositionState throws when position > duration during short previews.
+  }
+}
+
+function seekToTime(time: number): void {
+  const audio = getAudio();
+  if (!audio || !Number.isFinite(time)) return;
+  if (!Number.isFinite(audio.duration) || audio.duration === 0) return;
+  audio.currentTime = Math.max(0, Math.min(time, audio.duration));
 }
 
 function notifyPlaybackError(reason: PlaybackState['lastErrorReason']): void {
@@ -221,12 +338,13 @@ async function advanceQueueToIndex(index: number): Promise<void> {
 }
 
 function bindAudioEvents(el: HTMLAudioElement): void {
-  let lastNotifiedSecond = -1;
+  let lastNotifiedAt = 0;
   el.addEventListener('timeupdate', () => {
-    // Throttle to ~1 update/sec to reduce re-renders across all subscribers
-    const sec = Math.floor(el.currentTime);
-    if (sec === lastNotifiedSecond) return;
-    lastNotifiedSecond = sec;
+    // ~4 Hz keeps cross-surface scrub bars smooth without rAF thrash.
+    const now =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    if (now - lastNotifiedAt < PROGRESS_NOTIFY_MS) return;
+    lastNotifiedAt = now;
     setState({
       currentTime: el.currentTime,
       duration: Number.isFinite(el.duration) ? el.duration : 0,
@@ -267,7 +385,7 @@ function bindAudioEvents(el: HTMLAudioElement): void {
     });
   });
   el.addEventListener('seeked', () => {
-    lastNotifiedSecond = -1; // invalidate throttle so next timeupdate fires
+    lastNotifiedAt = 0; // invalidate throttle so next timeupdate fires
     setState({
       currentTime: el.currentTime,
       duration: Number.isFinite(el.duration) ? el.duration : 0,
@@ -326,12 +444,64 @@ function bindAudioEvents(el: HTMLAudioElement): void {
   });
 }
 
+/**
+ * Imperative pause for short interruptions (chat dictation, local waveform
+ * preview, embedded video). Nested-safe; only the outermost release clears the
+ * focus hold. Default after release: stay paused (do not auto-resume).
+ */
+export function pausePlaybackForInterruption(): void {
+  const audio = getAudio();
+  if (_interruptionDepth === 0) {
+    _wasPlayingBeforeInterruption = Boolean(
+      audio && !audio.paused && state.isPlaying
+    );
+  }
+  _interruptionDepth += 1;
+  if (audio && !audio.paused) {
+    audio.pause();
+  }
+}
+
+/**
+ * Release an interruption hold. Pass `{ resume: true }` only when product UX
+ * wants auto-resume; JOV-3683 default is stay paused after dictation.
+ */
+export function resumePlaybackAfterInterruption(
+  options: { readonly resume?: boolean } = {}
+): void {
+  if (_interruptionDepth === 0) return;
+  _interruptionDepth -= 1;
+  if (_interruptionDepth > 0) return;
+
+  const shouldResume = Boolean(options.resume) && _wasPlayingBeforeInterruption;
+  _wasPlayingBeforeInterruption = false;
+  if (!shouldResume) return;
+
+  const audio = getAudio();
+  if (!audio || !state.activeTrackId) return;
+  void audio.play().catch(() => {
+    handlePlaybackFailure(audio, 'play_rejected');
+  });
+}
+
+/** Snapshot for non-React callers (tests, focus arbitration). */
+export function getPlaybackEngineSnapshot(): PlaybackState {
+  return state;
+}
+
+/** True while an interruption hold is active (dictation / local preview). */
+export function isPlaybackInterrupted(): boolean {
+  return _interruptionDepth > 0;
+}
+
 export function useTrackAudioPlayer() {
   const [playbackState, setPlaybackState] = useState<PlaybackState>(state);
 
   useEffect(() => {
     const listener = () => setPlaybackState(state);
     listeners.add(listener);
+    // Sync late subscribers with current engine state (e.g. route remounts).
+    setPlaybackState(state);
     return () => {
       listeners.delete(listener);
     };
@@ -341,6 +511,13 @@ export function useTrackAudioPlayer() {
     async (track: AudioTrackSource, options?: ToggleTrackOptions) => {
       const audio = getAudio();
       if (!audio) return;
+
+      // New intentional play clears interruption holds so dock/right-rail
+      // transport is never stuck muted after dictation.
+      if (_interruptionDepth > 0) {
+        _interruptionDepth = 0;
+        _wasPlayingBeforeInterruption = false;
+      }
 
       // Same track — toggle pause/resume
       if (state.activeTrackId === track.id) {
@@ -379,15 +556,14 @@ export function useTrackAudioPlayer() {
   }, []);
 
   const seek = useCallback((time: number) => {
-    const audio = getAudio();
-    if (!audio || !Number.isFinite(time)) return;
-    if (!Number.isFinite(audio.duration) || audio.duration === 0) return;
-    audio.currentTime = Math.max(0, Math.min(time, audio.duration));
+    seekToTime(time);
   }, []);
 
   const stop = useCallback(() => {
     // Invalidate any in-flight play() from earlier toggleTrack calls
     _playToken += 1;
+    _interruptionDepth = 0;
+    _wasPlayingBeforeInterruption = false;
     const audio = getAudio();
     if (audio) {
       audio.pause();
@@ -428,5 +604,7 @@ export function useTrackAudioPlayer() {
     seek,
     stop,
     onError,
+    pauseForInterruption: pausePlaybackForInterruption,
+    resumeAfterInterruption: resumePlaybackAfterInterruption,
   };
 }

--- a/apps/web/lib/audio/constants.ts
+++ b/apps/web/lib/audio/constants.ts
@@ -23,6 +23,16 @@ export const SUPPORTED_AUDIO_MIME_TYPES_SET = new Set<string>(
 
 export const AUDIO_FILE_ACCEPT = SUPPORTED_AUDIO_MIME_TYPES.join(',');
 
+/** Human labels for supported container formats (UI copy). */
+export const SUPPORTED_AUDIO_FORMAT_LABELS = [
+  'MP3',
+  'WAV',
+  'FLAC',
+  'AIFF',
+  'AAC',
+  'M4A',
+] as const;
+
 /** @deprecated Prefer AUDIO_FILE_ACCEPT */
 export const AUDIO_ACCEPT = AUDIO_FILE_ACCEPT;
 
@@ -30,6 +40,31 @@ export const AUDIO_ACCEPT = AUDIO_FILE_ACCEPT;
 export const ALLOWED_AUDIO_MIME_TYPES = SUPPORTED_AUDIO_MIME_TYPES_SET;
 
 const AUDIO_EXTENSION_PATTERN = /\.(aac|aiff?|flac|m4a|mp3|wav)$/i;
+
+/** Named-rule codes for rejected audio uploads (JOV-3688). */
+export type AudioUploadRuleCode =
+  | 'audio.supported_types'
+  | 'audio.max_file_size_bytes';
+
+export type AudioUploadCtaAction = 'pick_another' | 'request_type' | 'compress';
+
+export interface AudioUploadRejection {
+  readonly ok: false;
+  /** Stable machine id for telemetry + tests */
+  readonly code: AudioUploadRuleCode;
+  /** Named rule shown inline (plain language) */
+  readonly rule: string;
+  /** Full user-facing sentence */
+  readonly message: string;
+  readonly cta: {
+    readonly label: string;
+    readonly action: AudioUploadCtaAction;
+  };
+}
+
+export type AudioUploadValidationResult =
+  | { readonly ok: true }
+  | AudioUploadRejection;
 
 export function isSupportedAudioFile(
   file: Pick<File, 'name' | 'type'>
@@ -41,19 +76,69 @@ export function isSupportedAudioFile(
   return AUDIO_EXTENSION_PATTERN.test(file.name);
 }
 
+function formatMaxSizeMb(maxSizeBytes: number): number {
+  return Math.round(maxSizeBytes / (1024 * 1024));
+}
+
+function describeRejectedType(file: Pick<File, 'name' | 'type'>): string {
+  if (file.type && file.type.length > 0) {
+    return file.type;
+  }
+  const match = file.name.match(/\.([^.]+)$/);
+  return match?.[1] ? `.${match[1].toLowerCase()}` : 'unknown type';
+}
+
+/**
+ * Structured audio upload validation with a named failing rule + CTA.
+ * Prefer this over `validateAudioFile` for UI surfaces (JOV-3688).
+ */
+export function validateAudioUpload(
+  file: Pick<File, 'name' | 'type' | 'size'>,
+  maxSizeBytes = AUDIO_MAX_FILE_SIZE_BYTES
+): AudioUploadValidationResult {
+  if (!isSupportedAudioFile(file)) {
+    const rejected = describeRejectedType(file);
+    const formats = SUPPORTED_AUDIO_FORMAT_LABELS.join(', ');
+    return {
+      ok: false,
+      code: 'audio.supported_types',
+      rule: `Supported types: ${formats}`,
+      message: `${rejected} is not supported. Use ${formats}.`,
+      cta: {
+        label: 'Choose another file',
+        action: 'pick_another',
+      },
+    };
+  }
+
+  if (file.size > maxSizeBytes) {
+    const maxMb = formatMaxSizeMb(maxSizeBytes);
+    const fileMb = (file.size / (1024 * 1024)).toFixed(1);
+    return {
+      ok: false,
+      code: 'audio.max_file_size_bytes',
+      rule: `Max file size: ${maxMb} MB`,
+      message: `This file is ${fileMb} MB. Audio must be ${maxMb} MB or smaller.`,
+      cta: {
+        label: 'Choose a smaller file',
+        action: 'compress',
+      },
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Legacy string validator. Returns the structured message or null when valid.
+ * Prefer `validateAudioUpload` for new call sites.
+ */
 export function validateAudioFile(
   file: Pick<File, 'name' | 'type' | 'size'>,
   maxSizeBytes = AUDIO_MAX_FILE_SIZE_BYTES
 ): string | null {
-  if (!isSupportedAudioFile(file)) {
-    return 'Use MP3, WAV, FLAC, AIFF, AAC, or M4A audio.';
-  }
-
-  if (file.size > maxSizeBytes) {
-    return 'Audio must be 150 MB or smaller.';
-  }
-
-  return null;
+  const result = validateAudioUpload(file, maxSizeBytes);
+  return result.ok ? null : result.message;
 }
 
 export function parseAudioTitleFromFileName(fileName: string): string {

--- a/apps/web/lib/audio/constants.ts
+++ b/apps/web/lib/audio/constants.ts
@@ -88,10 +88,7 @@ function describeRejectedType(file: Pick<File, 'name' | 'type'>): string {
   return match?.[1] ? `.${match[1].toLowerCase()}` : 'unknown type';
 }
 
-/**
- * Structured audio upload validation with a named failing rule + CTA.
- * Prefer this over `validateAudioFile` for UI surfaces (JOV-3688).
- */
+/** Structured upload validation with named failing rule + CTA (JOV-3688). */
 export function validateAudioUpload(
   file: Pick<File, 'name' | 'type' | 'size'>,
   maxSizeBytes = AUDIO_MAX_FILE_SIZE_BYTES
@@ -129,10 +126,7 @@ export function validateAudioUpload(
   return { ok: true };
 }
 
-/**
- * Legacy string validator. Returns the structured message or null when valid.
- * Prefer `validateAudioUpload` for new call sites.
- */
+/** Legacy string validator; prefer `validateAudioUpload` for UI. */
 export function validateAudioFile(
   file: Pick<File, 'name' | 'type' | 'size'>,
   maxSizeBytes = AUDIO_MAX_FILE_SIZE_BYTES

--- a/apps/web/tests/components/atoms/SeekBar.test.tsx
+++ b/apps/web/tests/components/atoms/SeekBar.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SeekBar } from '@/components/atoms/SeekBar';
+
+describe('SeekBar', () => {
+  it('holds local scrub value while pointer is down so engine ticks cannot snap the thumb', () => {
+    const onSeek = vi.fn();
+    const { rerender } = render(
+      <SeekBar currentTime={10} duration={100} onSeek={onSeek} />
+    );
+
+    const input = screen.getByLabelText('Seek track') as HTMLInputElement;
+    fireEvent.pointerDown(input);
+    fireEvent.change(input, { target: { value: '40' } });
+    expect(onSeek).toHaveBeenCalledWith(40);
+    expect(input.value).toBe('40');
+
+    // Engine reports stale progress mid-scrub — thumb stays on scrub value.
+    rerender(<SeekBar currentTime={12} duration={100} onSeek={onSeek} />);
+    expect(input.value).toBe('40');
+
+    fireEvent.pointerUp(input);
+    rerender(<SeekBar currentTime={40} duration={100} onSeek={onSeek} />);
+    expect(input.value).toBe('40');
+  });
+
+  it('disables when duration is zero', () => {
+    render(<SeekBar currentTime={0} duration={0} onSeek={vi.fn()} />);
+    expect(screen.getByLabelText('Seek track')).toBeDisabled();
+  });
+});

--- a/apps/web/tests/components/features/release/ReleaseAudioAssetPanel.test.tsx
+++ b/apps/web/tests/components/features/release/ReleaseAudioAssetPanel.test.tsx
@@ -62,6 +62,33 @@ describe('ReleaseAudioAssetPanel', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows a named-rule message and CTA for unsupported types', async () => {
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Upload audio for Take Me Over'), {
+      target: {
+        files: [new File(['not-audio'], 'notes.txt', { type: 'text/plain' })],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upload-rule')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('upload-rule').textContent).toMatch(
+      /Supported types/i
+    );
+    expect(screen.getByTestId('upload-rejection-cta')).toHaveTextContent(
+      /Choose another file/i
+    );
+    expect(screen.getByTestId('upload-request-type-cta')).toBeInTheDocument();
+    expect(blobUploadMock).not.toHaveBeenCalled();
+  });
+
   it('uploads audio and reveals the waveform editor', async () => {
     blobUploadMock.mockResolvedValue({
       url: 'https://cdn.example.com/uploaded.mp3',

--- a/apps/web/tests/components/features/release/SmartLinkAudioPreview.test.tsx
+++ b/apps/web/tests/components/features/release/SmartLinkAudioPreview.test.tsx
@@ -5,7 +5,6 @@ import { SmartLinkAudioPreview } from '@/components/features/release/SmartLinkAu
 const toggleTrack = vi.fn().mockResolvedValue(undefined);
 const seek = vi.fn();
 const onError = vi.fn(() => () => {});
-
 const playbackState = {
   activeTrackId: null as string | null,
   isPlaying: false,
@@ -25,22 +24,19 @@ const playbackState = {
 };
 
 vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
-  useTrackAudioPlayer: () => ({
-    playbackState,
-    toggleTrack,
-    seek,
-    onError,
-  }),
+  useTrackAudioPlayer: () => ({ playbackState, toggleTrack, seek, onError }),
 }));
 
 describe('SmartLinkAudioPreview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    playbackState.activeTrackId = null;
-    playbackState.isPlaying = false;
-    playbackState.playbackStatus = 'idle';
-    playbackState.currentTime = 0;
-    playbackState.duration = 0;
+    Object.assign(playbackState, {
+      activeTrackId: null,
+      isPlaying: false,
+      playbackStatus: 'idle',
+      currentTime: 0,
+      duration: 0,
+    });
   });
 
   it('renders nothing without a preview URL', () => {
@@ -67,18 +63,16 @@ describe('SmartLinkAudioPreview', () => {
         isrc='USRC17607839'
       />
     );
-
     fireEvent.click(screen.getByRole('button', { name: 'Play preview' }));
     expect(toggleTrack).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'c1',
         audioUrl: 'https://cdn.example.com/preview.mp3',
-        isrc: 'USRC17607839',
       })
     );
   });
 
-  it('reserves scrub layout and disables seek until duration is known', () => {
+  it('disables seek until duration is known', () => {
     render(
       <SmartLinkAudioPreview
         contentId='c1'
@@ -88,7 +82,6 @@ describe('SmartLinkAudioPreview', () => {
         previewUrl='https://cdn.example.com/preview.mp3'
       />
     );
-
     expect(screen.getByTestId('smart-link-audio-preview')).toBeInTheDocument();
     expect(screen.getByLabelText('Seek track')).toBeDisabled();
   });

--- a/apps/web/tests/components/features/release/SmartLinkAudioPreview.test.tsx
+++ b/apps/web/tests/components/features/release/SmartLinkAudioPreview.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SmartLinkAudioPreview } from '@/components/features/release/SmartLinkAudioPreview';
+
+const toggleTrack = vi.fn().mockResolvedValue(undefined);
+const seek = vi.fn();
+const onError = vi.fn(() => () => {});
+
+const playbackState = {
+  activeTrackId: null as string | null,
+  isPlaying: false,
+  playbackStatus: 'idle' as const,
+  lastErrorReason: null,
+  currentTime: 0,
+  duration: 0,
+  trackTitle: null,
+  releaseTitle: null,
+  artistName: null,
+  artworkUrl: null,
+  hasLyrics: false,
+  queueLength: 0,
+  queueIndex: -1,
+  hasNext: false,
+  hasPrevious: false,
+};
+
+vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
+  useTrackAudioPlayer: () => ({
+    playbackState,
+    toggleTrack,
+    seek,
+    onError,
+  }),
+}));
+
+describe('SmartLinkAudioPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    playbackState.activeTrackId = null;
+    playbackState.isPlaying = false;
+    playbackState.playbackStatus = 'idle';
+    playbackState.currentTime = 0;
+    playbackState.duration = 0;
+  });
+
+  it('renders nothing without a preview URL', () => {
+    const { container } = render(
+      <SmartLinkAudioPreview
+        contentId='c1'
+        title='Song'
+        artistName='Artist'
+        artworkUrl={null}
+        previewUrl={null}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('dispatches toggle to the global engine on play', () => {
+    render(
+      <SmartLinkAudioPreview
+        contentId='c1'
+        title='Song'
+        artistName='Artist'
+        artworkUrl='https://cdn.example.com/art.jpg'
+        previewUrl='https://cdn.example.com/preview.mp3'
+        isrc='USRC17607839'
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Play preview' }));
+    expect(toggleTrack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'c1',
+        audioUrl: 'https://cdn.example.com/preview.mp3',
+        isrc: 'USRC17607839',
+      })
+    );
+  });
+
+  it('reserves scrub layout and disables seek until duration is known', () => {
+    render(
+      <SmartLinkAudioPreview
+        contentId='c1'
+        title='Song'
+        artistName='Artist'
+        artworkUrl={null}
+        previewUrl='https://cdn.example.com/preview.mp3'
+      />
+    );
+
+    expect(screen.getByTestId('smart-link-audio-preview')).toBeInTheDocument();
+    expect(screen.getByLabelText('Seek track')).toBeDisabled();
+  });
+});

--- a/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
+++ b/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
@@ -330,6 +330,80 @@ describe('useTrackAudioPlayer', () => {
     expect(errorCb).toHaveBeenCalledTimes(1);
   });
 
+  it('pauses active playback for interruptions and stays paused by default', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const engine = await import(
+      '@/components/organisms/release-sidebar/useTrackAudioPlayer'
+    );
+    const { result } = renderHook(() => useTrackAudioPlayer());
+
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'track-1',
+        title: 'Test Song',
+        audioUrl: 'https://cdn.example.com/song.mp3',
+      });
+    });
+    act(() => {
+      mockAudio.paused = false;
+      fireAudioEvent('play');
+    });
+    expect(result.current.playbackState.isPlaying).toBe(true);
+
+    act(() => {
+      engine.pausePlaybackForInterruption();
+    });
+    expect(mockAudio.pause).toHaveBeenCalled();
+
+    act(() => {
+      mockAudio.paused = true;
+      fireAudioEvent('pause');
+    });
+    expect(result.current.playbackState.isPlaying).toBe(false);
+
+    // Default: stay paused (no auto-resume) — JOV-3683 decision.
+    act(() => {
+      engine.resumePlaybackAfterInterruption();
+    });
+    expect(mockAudio.play).toHaveBeenCalledTimes(1);
+    expect(result.current.playbackState.isPlaying).toBe(false);
+  });
+
+  it('switches source and never leaves two tracks active', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'track-1',
+        title: 'First',
+        audioUrl: 'https://cdn.example.com/first.mp3',
+      });
+    });
+    act(() => {
+      mockAudio.paused = false;
+      fireAudioEvent('play');
+    });
+
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'track-2',
+        title: 'Second',
+        audioUrl: 'https://cdn.example.com/second.mp3',
+      });
+    });
+    act(() => {
+      mockAudio.paused = false;
+      fireAudioEvent('play');
+    });
+
+    expect(result.current.playbackState.activeTrackId).toBe('track-2');
+    expect(result.current.playbackState.trackTitle).toBe('Second');
+    expect(mockAudio.src).toBe('https://cdn.example.com/second.mp3');
+    // Single element: prior track was paused before src swap.
+    expect(mockAudio.pause.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
   it('keeps the latest track active when an earlier play() resolves late', async () => {
     let resolveFirstPlay: (() => void) | undefined;
     let resolveSecondPlay: (() => void) | undefined;

--- a/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
+++ b/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
@@ -330,7 +330,7 @@ describe('useTrackAudioPlayer', () => {
     expect(errorCb).toHaveBeenCalledTimes(1);
   });
 
-  it('pauses active playback for interruptions and stays paused by default', async () => {
+  it('pauses for interruptions and stays paused by default', async () => {
     const useTrackAudioPlayer = await importFresh();
     const engine = await import(
       '@/components/organisms/release-sidebar/useTrackAudioPlayer'
@@ -348,20 +348,16 @@ describe('useTrackAudioPlayer', () => {
       mockAudio.paused = false;
       fireAudioEvent('play');
     });
-    expect(result.current.playbackState.isPlaying).toBe(true);
 
     act(() => {
       engine.pausePlaybackForInterruption();
     });
     expect(mockAudio.pause).toHaveBeenCalled();
-
     act(() => {
       mockAudio.paused = true;
       fireAudioEvent('pause');
     });
-    expect(result.current.playbackState.isPlaying).toBe(false);
 
-    // Default: stay paused (no auto-resume) — JOV-3683 decision.
     act(() => {
       engine.resumePlaybackAfterInterruption();
     });
@@ -369,7 +365,7 @@ describe('useTrackAudioPlayer', () => {
     expect(result.current.playbackState.isPlaying).toBe(false);
   });
 
-  it('switches source and never leaves two tracks active', async () => {
+  it('switches source onto a single active track', async () => {
     const useTrackAudioPlayer = await importFresh();
     const { result } = renderHook(() => useTrackAudioPlayer());
 
@@ -380,11 +376,6 @@ describe('useTrackAudioPlayer', () => {
         audioUrl: 'https://cdn.example.com/first.mp3',
       });
     });
-    act(() => {
-      mockAudio.paused = false;
-      fireAudioEvent('play');
-    });
-
     await act(async () => {
       await result.current.toggleTrack({
         id: 'track-2',
@@ -392,15 +383,9 @@ describe('useTrackAudioPlayer', () => {
         audioUrl: 'https://cdn.example.com/second.mp3',
       });
     });
-    act(() => {
-      mockAudio.paused = false;
-      fireAudioEvent('play');
-    });
 
     expect(result.current.playbackState.activeTrackId).toBe('track-2');
-    expect(result.current.playbackState.trackTitle).toBe('Second');
     expect(mockAudio.src).toBe('https://cdn.example.com/second.mp3');
-    // Single element: prior track was paused before src swap.
     expect(mockAudio.pause.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 

--- a/apps/web/tests/unit/lib/audio/constants.test.ts
+++ b/apps/web/tests/unit/lib/audio/constants.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  AUDIO_MAX_FILE_SIZE_BYTES,
   isSupportedAudioFile,
   parseAudioTitleFromFileName,
   validateAudioFile,
+  validateAudioUpload,
 } from '@/lib/audio/constants';
 
 describe('audio constants', () => {
@@ -18,6 +20,44 @@ describe('audio constants', () => {
     expect(
       validateAudioFile({ name: 'notes.txt', type: 'text/plain', size: 10 })
     ).toContain('MP3');
+  });
+
+  it('returns a named-rule rejection + CTA for unsupported types', () => {
+    const result = validateAudioUpload({
+      name: 'notes.txt',
+      type: 'text/plain',
+      size: 10,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('audio.supported_types');
+    expect(result.rule).toMatch(/Supported types/i);
+    expect(result.message).toMatch(/text\/plain/i);
+    expect(result.cta.action).toBe('pick_another');
+    expect(result.cta.label.length).toBeGreaterThan(0);
+  });
+
+  it('returns a named-rule rejection + CTA for oversize files', () => {
+    const result = validateAudioUpload({
+      name: 'huge.mp3',
+      type: 'audio/mpeg',
+      size: AUDIO_MAX_FILE_SIZE_BYTES + 1,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('audio.max_file_size_bytes');
+    expect(result.rule).toMatch(/Max file size/i);
+    expect(result.cta.action).toBe('compress');
+  });
+
+  it('accepts valid audio uploads', () => {
+    expect(
+      validateAudioUpload({
+        name: 'track.mp3',
+        type: 'audio/mpeg',
+        size: 1024,
+      })
+    ).toEqual({ ok: true });
   });
 
   it('parses a human title from the file name', () => {

--- a/apps/web/tests/unit/lib/audio/constants.test.ts
+++ b/apps/web/tests/unit/lib/audio/constants.test.ts
@@ -16,13 +16,10 @@ describe('audio constants', () => {
     expect(isSupportedAudioFile({ name: 'track.wav', type: '' })).toBe(true);
   });
 
-  it('rejects unsupported files', () => {
+  it('rejects unsupported files with a named rule + CTA', () => {
     expect(
       validateAudioFile({ name: 'notes.txt', type: 'text/plain', size: 10 })
     ).toContain('MP3');
-  });
-
-  it('returns a named-rule rejection + CTA for unsupported types', () => {
     const result = validateAudioUpload({
       name: 'notes.txt',
       type: 'text/plain',
@@ -31,13 +28,10 @@ describe('audio constants', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.code).toBe('audio.supported_types');
-    expect(result.rule).toMatch(/Supported types/i);
-    expect(result.message).toMatch(/text\/plain/i);
     expect(result.cta.action).toBe('pick_another');
-    expect(result.cta.label.length).toBeGreaterThan(0);
   });
 
-  it('returns a named-rule rejection + CTA for oversize files', () => {
+  it('rejects oversize files with a named rule + CTA', () => {
     const result = validateAudioUpload({
       name: 'huge.mp3',
       type: 'audio/mpeg',
@@ -46,21 +40,13 @@ describe('audio constants', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.code).toBe('audio.max_file_size_bytes');
-    expect(result.rule).toMatch(/Max file size/i);
     expect(result.cta.action).toBe('compress');
   });
 
-  it('accepts valid audio uploads', () => {
+  it('accepts valid audio and parses titles', () => {
     expect(
-      validateAudioUpload({
-        name: 'track.mp3',
-        type: 'audio/mpeg',
-        size: 1024,
-      })
+      validateAudioUpload({ name: 'track.mp3', type: 'audio/mpeg', size: 1024 })
     ).toEqual({ ok: true });
-  });
-
-  it('parses a human title from the file name', () => {
     expect(parseAudioTitleFromFileName('Take_Me_Over-final.wav')).toBe(
       'Take Me Over final'
     );


### PR DESCRIPTION
## Summary
Hardens the single global playback engine and ships two adjacent fan/creator UX fixes in the same audio HOT ZONE.

### JOV-3683 — Single global playback engine
- `useTrackAudioPlayer` remains the one `HTMLAudioElement` source of truth across dock, right-rail, library, smart-link, and PAC.
- **Media Session API** owned only by the engine (play/pause/seek/next/prev + metadata).
- **Interruption API** (`pausePlaybackForInterruption` / `resumePlaybackAfterInterruption`) for chat dictation and local waveform preview.
- Dictation: pause on start, **stay paused** on end (no auto-resume — documented JOV-3683 default).
- `AudioWaveformEditor` claims global focus while playing and yields when the dock starts.
- Progress notify ~4 Hz for cross-surface scrub sync without rAF thrash.
- Tests: switch-source, interruption stay-paused.

### JOV-3681 — Smart-link player UX
- `SeekBar` local drag state so scrub thumb never snaps to a throttled engine tick.
- Reserved layout for play/load/time/fallback rows (no CLS).
- Loading state + disabled scrub until duration is known.
- Thin UI over the global engine (no private audio element).

### JOV-3688 — Graceful degrade on audio upload reject
- `validateAudioUpload()` returns named rule + CTA (`audio.supported_types` / `audio.max_file_size_bytes`).
- Dropzone shows inline rule message + **Choose another file** / **Request this type** (telemetry log).
- No generic dead-end; no raw blob URLs in error copy.

## Linear
- Fixes JOV-3683
- Fixes JOV-3681
- Fixes JOV-3688

<!-- linear-issue-id:4965b620-b458-4546-a822-fd12e377d06d -->
<!-- linear-issue-id:226c63d3-a67a-47e0-bbd8-ea329ae2a0ed -->
<!-- linear-issue-id:00029708-be3d-4e30-bafb-08563c1def0a -->

## Verification
- `pnpm biome check --write` on all edited files — clean
- `pnpm --filter web exec vitest run` focused suites — **25/25 passed**:
  - `useTrackAudioPlayer.test.ts` (10)
  - `constants.test.ts` (6)
  - `ReleaseAudioAssetPanel.test.tsx` (4)
  - `SeekBar.test.tsx` (2)
  - `SmartLinkAudioPreview.test.tsx` (3)
- Full package typecheck not completed locally (machine thrash / concurrent agent tsc load); CI `ci-fast` is the gate

## Layout-shift audit (UI)
- Smart-link preview: min-heights on control row, time row, and fallback label; scrub disabled until duration known
- Upload rejection panel: reserved `min-h-12` feedback slot under dropzone

## Cost Impact
- None (client-only playback/upload UX; no new cron/API/external spend)

## Risk
- Dictation interruption is nested-depth based; intentional play from any surface clears holds so transport never sticks muted
- Waveform editor still uses a local element for snippet trim loops (required for A-B loop), but participates in single-active-media via interruption claims