### PR TITLE
feat(profile): wire pac events and cold-visitor experiments

### DIFF
--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Pause, Play } from 'lucide-react';
+import { Pause, Play, X } from 'lucide-react';
 import Link from 'next/link';
 import {
   type FormEvent,
@@ -16,7 +16,6 @@ import { ImageWithFallback } from '@/components/atoms/ImageWithFallback';
 import { SeekBar } from '@/components/atoms/SeekBar';
 import { useTrackAudioPlayer } from '@/components/organisms/release-sidebar/useTrackAudioPlayer';
 import type { ProfileRenderMode } from '@/features/profile/contracts';
-import { track } from '@/lib/analytics';
 import type {
   ProfilePacAssignment,
   ProfilePacCopyArm,
@@ -25,10 +24,12 @@ import type { PublicMerchCard } from '@/lib/merch/types';
 import { subscribeToNotifications } from '@/lib/notifications/client';
 import { normalizeSubscriptionEmail } from '@/lib/notifications/validation';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
+import type { PacState as PacEventState } from '@/lib/tracking/pac-events-contract';
 import { cn } from '@/lib/utils';
 import { formatAmount } from '@/lib/utils/format-number';
 import { formatDuration } from '@/lib/utils/formatDuration';
 import type { Artist } from '@/types/db';
+import { usePacEvents } from '../usePacEvents';
 import {
   hasReachedListenThreshold,
   type PacContext,
@@ -264,6 +265,19 @@ export function ProfilePacCard({
     setState(prev => pacReducer(prev, event, ctxRef.current));
   }, []);
 
+  // PAC instrumentation (JOV-3905 / spec §8): consent-aware, variant-keyed.
+  const eventState = state.kind as PacEventState;
+  const { exposureRef, emit, createPlayTracker } = usePacEvents({
+    profileId: artist.id,
+    assignment,
+    state: eventState,
+    enabled: isInteractive,
+  });
+  const playTrackerRef = useRef(createPlayTracker());
+  useEffect(() => {
+    playTrackerRef.current = createPlayTracker();
+  }, [createPlayTracker, pacTrackId]);
+
   // Re-resolve when visitor context lands/changes (jv_aid bootstrap flips
   // the assignment prop upstream; subscription state flips isSubscribed).
   useEffect(() => {
@@ -301,9 +315,35 @@ export function ProfilePacCard({
   // surface started playback, the track ended, an error fired).
   useEffect(() => {
     if (state.kind === 'playing' && !isPacPlaying) {
+      playTrackerRef.current.onPause();
       dispatch({ type: 'PAUSE' });
     }
   }, [dispatch, isPacPlaying, state.kind]);
+
+  // Play milestone ticks while the PAC track is active (pac_play_30s).
+  useEffect(() => {
+    if (!isPacTrackActive || !isPacPlaying) return;
+    playTrackerRef.current.onTick();
+  }, [isPacPlaying, isPacTrackActive, playbackState.currentTime]);
+
+  // Track completion → pac_play_complete + machine pause.
+  const lastDurationRef = useRef(0);
+  useEffect(() => {
+    if (!isPacTrackActive || playbackState.duration <= 0) return;
+    lastDurationRef.current = playbackState.duration;
+    if (
+      playbackState.currentTime > 0 &&
+      playbackState.currentTime >= playbackState.duration - 0.25 &&
+      !playbackState.isPlaying
+    ) {
+      playTrackerRef.current.onComplete();
+    }
+  }, [
+    isPacTrackActive,
+    playbackState.currentTime,
+    playbackState.duration,
+    playbackState.isPlaying,
+  ]);
 
   // Capture moment trigger: listen threshold per experiment arm.
   const thresholdFiredRef = useRef(false);
@@ -318,13 +358,8 @@ export function ProfilePacCard({
     ) {
       thresholdFiredRef.current = true;
       dispatch({ type: 'LISTEN_THRESHOLD' });
-      track('profile_pac_capture_moment', {
-        artist_id: artist.id,
-        trigger: assignment.triggerThreshold,
-      });
     }
   }, [
-    artist.id,
     assignment.triggerThreshold,
     dispatch,
     isPacTrackActive,
@@ -332,20 +367,28 @@ export function ProfilePacCard({
     playbackState.duration,
   ]);
 
-  // Exposure analytics — once per stage.
-  const lastTrackedStageRef = useRef<string | null>(null);
+  // capture_prompt_shown once per entry into the prompt state.
+  const lastPromptShownRef = useRef(false);
   useEffect(() => {
-    if (!isInteractive) return;
-    if (lastTrackedStageRef.current === state.stage) return;
-    lastTrackedStageRef.current = state.stage;
-    track('profile_pac_exposure', {
-      artist_id: artist.id,
-      state: state.kind,
-      stage: state.stage,
-      copy_arm: assignment.copyArm,
-      degraded: state.degraded,
-    });
-  }, [artist.id, assignment.copyArm, isInteractive, state]);
+    if (state.kind === 'prompt') {
+      if (!lastPromptShownRef.current) {
+        lastPromptShownRef.current = true;
+        emit('capture_prompt_shown', {
+          trigger: assignment.triggerThreshold,
+          dismiss_affordance: assignment.dismissAffordance,
+        });
+      }
+      return;
+    }
+    if (state.kind !== 'submitting' && state.kind !== 'error') {
+      lastPromptShownRef.current = false;
+    }
+  }, [
+    assignment.dismissAffordance,
+    assignment.triggerThreshold,
+    emit,
+    state.kind,
+  ]);
 
   const handlePlayClick = useCallback(
     (event: MouseEvent<HTMLElement>) => {
@@ -359,13 +402,15 @@ export function ProfilePacCard({
         artistName: artist.name,
         artworkUrl: release.artworkUrl,
       });
-      dispatch({ type: isPacPlaying ? 'PAUSE' : 'PLAY' });
-      if (!isPacPlaying) {
-        track('profile_pac_play', { artist_id: artist.id });
+      if (isPacPlaying) {
+        playTrackerRef.current.onPause();
+        dispatch({ type: 'PAUSE' });
+      } else {
+        playTrackerRef.current.onPlay();
+        dispatch({ type: 'PLAY' });
       }
     },
     [
-      artist.id,
       artist.name,
       dispatch,
       isInteractive,
@@ -390,14 +435,16 @@ export function ProfilePacCard({
       if (!email) {
         setFieldError('Enter a valid email address.');
         emailRef.current?.focus();
+        emit(
+          'capture_error',
+          { rule: 'invalid_email', channel: 'email' },
+          'error'
+        );
         return;
       }
       setFieldError(null);
       dispatch({ type: 'CAPTURE_SUBMIT' });
-      track('profile_pac_capture_submitted', {
-        artist_id: artist.id,
-        copy_arm: assignment.copyArm,
-      });
+      emit('capture_submit', { channel: 'email' }, 'submitting');
       subscribeToNotifications({
         artistId: artist.id,
         channel: 'email',
@@ -411,13 +458,15 @@ export function ProfilePacCard({
       })
         .then(() => {
           dispatch({ type: 'CAPTURE_SUCCESS' });
-          track('profile_pac_capture_success', {
-            artist_id: artist.id,
-            copy_arm: assignment.copyArm,
-          });
+          emit('capture_success', { channel: 'email' }, 'success');
         })
         .catch(() => {
           dispatch({ type: 'CAPTURE_FAILURE' });
+          emit(
+            'capture_error',
+            { rule: 'subscribe_failed', channel: 'email' },
+            'error'
+          );
         });
     },
     [
@@ -426,6 +475,7 @@ export function ProfilePacCard({
       assignment.triggerThreshold,
       dispatch,
       emailInput,
+      emit,
       isInteractive,
     ]
   );
@@ -433,10 +483,11 @@ export function ProfilePacCard({
   const handleDismiss = useCallback(() => {
     dispatch({ type: 'DISMISS' });
     setCaptureSuppressed(true);
-    track('profile_pac_capture_dismissed', {
-      artist_id: artist.id,
-      copy_arm: assignment.copyArm,
-    });
+    emit(
+      'capture_dismiss',
+      { dismiss_affordance: assignment.dismissAffordance },
+      'dismissed'
+    );
     void fetch('/api/profile/capture-dismissal', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -445,7 +496,14 @@ export function ProfilePacCard({
     }).catch(() => {
       // Best-effort — suppression is also held in memory for this session.
     });
-  }, [artist.id, assignment.copyArm, dispatch]);
+  }, [artist.id, assignment.dismissAffordance, dispatch, emit]);
+
+  const handleSecondaryClick = useCallback(
+    (slot: string) => {
+      emit('pac_secondary_click', { slot }, state.kind as PacEventState);
+    },
+    [emit, state.kind]
+  );
 
   // --- Zero-CLS height reservation + 420ms self-height animation.
   const innerRef = useRef<HTMLDivElement>(null);
@@ -536,15 +594,30 @@ export function ProfilePacCard({
     case 'submitting':
     case 'error': {
       contextLabel = 'Stay In The Loop';
-      contextAside = (
-        <button
-          type='button'
-          onClick={handleDismiss}
-          className='shrink-0 text-xs font-medium text-white/50 transition-colors duration-subtle hover:text-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70'
-        >
-          Not now
-        </button>
-      );
+      // JOV-3908: text "Not now" (control) vs borderless icon-X (candidate).
+      contextAside =
+        assignment.dismissAffordance === 'icon' ? (
+          <button
+            type='button'
+            onClick={handleDismiss}
+            aria-label='Dismiss'
+            data-testid='pac-capture-dismiss'
+            data-affordance='icon'
+            className='-mr-1.5 -mt-1.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-white/50 transition-colors duration-subtle hover:bg-white/10 hover:text-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70'
+          >
+            <X className='h-4 w-4' aria-hidden='true' />
+          </button>
+        ) : (
+          <button
+            type='button'
+            onClick={handleDismiss}
+            data-testid='pac-capture-dismiss'
+            data-affordance='text'
+            className='shrink-0 text-xs font-medium text-white/50 transition-colors duration-subtle hover:text-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70'
+          >
+            Not now
+          </button>
+        );
       subject = (
         <div className='min-w-0 flex-1'>
           <p className='truncate text-sm font-semibold leading-tight text-white dark:text-white'>
@@ -622,7 +695,14 @@ export function ProfilePacCard({
           }
         />
       );
-      action = <PrimaryPill href={`/${artist.handle}/shop`}>Shop</PrimaryPill>;
+      action = (
+        <PrimaryPill
+          href={`/${artist.handle}/shop`}
+          onClick={() => handleSecondaryClick('merch')}
+        >
+          Shop
+        </PrimaryPill>
+      );
       break;
     }
 
@@ -638,7 +718,14 @@ export function ProfilePacCard({
           </p>
         </div>
       );
-      action = <PrimaryPill href={`/${artist.handle}/tip`}>Tip</PrimaryPill>;
+      action = (
+        <PrimaryPill
+          href={`/${artist.handle}/tip`}
+          onClick={() => handleSecondaryClick('tip')}
+        >
+          Tip
+        </PrimaryPill>
+      );
       break;
     }
 
@@ -660,11 +747,20 @@ export function ProfilePacCard({
       );
       action =
         state.kind === 'tickets' && nextShow?.ticketUrl ? (
-          <PrimaryPill href={nextShow.ticketUrl} external>
+          <PrimaryPill
+            href={nextShow.ticketUrl}
+            external
+            onClick={() => handleSecondaryClick('tickets')}
+          >
             Tickets
           </PrimaryPill>
         ) : (
-          <PrimaryPill href={`/${artist.handle}/tour`}>RSVP</PrimaryPill>
+          <PrimaryPill
+            href={`/${artist.handle}/tour`}
+            onClick={() => handleSecondaryClick('rsvp')}
+          >
+            RSVP
+          </PrimaryPill>
         );
       break;
     }
@@ -682,7 +778,10 @@ export function ProfilePacCard({
         </div>
       );
       action = (
-        <PrimaryPill href={`/${artist.handle}?mode=subscribe`}>
+        <PrimaryPill
+          href={`/${artist.handle}?mode=subscribe`}
+          onClick={() => handleSecondaryClick('following')}
+        >
           Manage
         </PrimaryPill>
       );
@@ -690,13 +789,24 @@ export function ProfilePacCard({
     }
   }
 
+  // Merge exposure + height refs on the outer section (callback refs).
+  const sectionRef = useCallback(
+    (node: HTMLElement | null) => {
+      exposureRef(node);
+      // height measurement lives on the inner content node, not the section.
+    },
+    [exposureRef]
+  );
+
   return (
     <section
+      ref={sectionRef}
       aria-label={`${artist.name} primary action`}
       data-testid='profile-pac'
       data-state={state.kind}
       data-stage={state.stage}
       data-degraded={state.degraded ? 'true' : undefined}
+      data-dismiss-affordance={assignment.dismissAffordance}
       className={cn(
         'w-full overflow-hidden border border-white/10 bg-white/5 backdrop-blur-2xl',
         className

--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -595,29 +595,30 @@ export function ProfilePacCard({
     case 'error': {
       contextLabel = 'Stay In The Loop';
       // JOV-3908: text "Not now" (control) vs borderless icon-X (candidate).
-      contextAside =
-        assignment.dismissAffordance === 'icon' ? (
-          <button
-            type='button'
-            onClick={handleDismiss}
-            aria-label='Dismiss'
-            data-testid='pac-capture-dismiss'
-            data-affordance='icon'
-            className='-mr-1.5 -mt-1.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-white/50 transition-colors duration-subtle hover:bg-white/10 hover:text-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70'
-          >
+      // One control element keeps the raw-button ratchet flat; min-h/w-11 keeps
+      // the icon arm at the 44px WCAG touch-target floor.
+      const isIconDismiss = assignment.dismissAffordance === 'icon';
+      contextAside = (
+        <button
+          type='button'
+          onClick={handleDismiss}
+          aria-label={isIconDismiss ? 'Dismiss' : undefined}
+          data-testid='pac-capture-dismiss'
+          data-affordance={isIconDismiss ? 'icon' : 'text'}
+          className={cn(
+            'shrink-0 text-white/50 transition-colors duration-subtle hover:text-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70',
+            isIconDismiss
+              ? '-mr-1.5 -mt-1.5 flex min-h-11 min-w-11 items-center justify-center rounded-full hover:bg-white/10'
+              : 'text-xs font-medium'
+          )}
+        >
+          {isIconDismiss ? (
             <X className='h-4 w-4' aria-hidden='true' />
-          </button>
-        ) : (
-          <button
-            type='button'
-            onClick={handleDismiss}
-            data-testid='pac-capture-dismiss'
-            data-affordance='text'
-            className='shrink-0 text-xs font-medium text-white/50 transition-colors duration-subtle hover:text-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70'
-          >
-            Not now
-          </button>
-        );
+          ) : (
+            'Not now'
+          )}
+        </button>
+      );
       subject = (
         <div className='min-w-0 flex-1'>
           <p className='truncate text-sm font-semibold leading-tight text-white dark:text-white'>

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -36,6 +36,11 @@ import {
 import type { PublicMerchCard } from '@/lib/merch/types';
 import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import { CONTENT_SAFE_AREA_BOTTOM_PADDING } from '@/lib/profile/nav-constants';
+import {
+  markPacTabBarReturnVisit,
+  readPacTabBarReturnVisit,
+  shouldShowColdVisitorTabBar,
+} from '@/lib/profile/pac-tab-bar-experiment';
 import { getCanonicalProfileDSPs } from '@/lib/profile-dsps';
 import { buildProfileShareContext } from '@/lib/share/context';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
@@ -342,7 +347,26 @@ export function ProfileCompactSurface({
   const activeNotificationSourceContext =
     notificationSourceContext ?? defaultNotificationSourceContext;
   const isHomeMode = activeVisiblePrimaryTab === 'profile';
-  const showBottomNav = true;
+  // JOV-3907: cold-visitor tab bar experiment — hide vs visible 50/50.
+  // Tab bar always restored after first interaction or on return visits.
+  const [tabBarRestoredThisSession, setTabBarRestoredThisSession] =
+    useState(false);
+  const [isTabBarReturnVisit, setIsTabBarReturnVisit] = useState(false);
+  useEffect(() => {
+    setIsTabBarReturnVisit(readPacTabBarReturnVisit(globalThis.localStorage));
+  }, []);
+  const restoreTabBar = useCallback(() => {
+    setTabBarRestoredThisSession(true);
+    markPacTabBarReturnVisit(globalThis.localStorage);
+    setIsTabBarReturnVisit(true);
+  }, []);
+  const showBottomNav = shouldShowColdVisitorTabBar({
+    tabBarArm: profilePacAssignment.tabBar,
+    isSubscribed,
+    restoredThisSession: tabBarRestoredThisSession,
+    isReturnVisit: isTabBarReturnVisit,
+    isInteractive: renderMode === 'interactive',
+  });
   const isPreviewEmbedded =
     renderMode === 'preview' && presentation === 'embedded';
   const surfaceState = useMemo(
@@ -470,6 +494,7 @@ export function ProfileCompactSurface({
   );
   const handleTabSelect = useCallback(
     (tab: ProfilePrimaryTab) => {
+      restoreTabBar();
       const nextTab = mapPrimaryTabToAnalyticsTab(tab);
       track('profile_tab_click', {
         artist_id: artist.id,
@@ -482,7 +507,7 @@ export function ProfileCompactSurface({
       });
       onModeSelect(tab);
     },
-    [artist.handle, artist.id, currentAnalyticsTab, onModeSelect]
+    [artist.handle, artist.id, currentAnalyticsTab, onModeSelect, restoreTabBar]
   );
   const handleSocialClick = useCallback(
     (link: LegacySocialLink) => {
@@ -513,6 +538,15 @@ export function ProfileCompactSurface({
       data-testid={dataTestId}
       data-render-mode={renderMode}
       data-profile-mode={activeMode}
+      data-tab-bar-arm={profilePacAssignment.tabBar}
+      data-tab-bar-visible={showBottomNav ? 'true' : 'false'}
+      onPointerDownCapture={
+        showBottomNav
+          ? undefined
+          : () => {
+              restoreTabBar();
+            }
+      }
     >
       <div
         ref={setNotificationsPortalContainer}

--- a/apps/web/components/features/profile/usePacEvents.ts
+++ b/apps/web/components/features/profile/usePacEvents.ts
@@ -89,9 +89,19 @@ export function usePacEvents({
   const variantId = useMemo(() => buildPacVariantId(assignment), [assignment]);
 
   const stateRef = useRef<PacState>(state);
+  const isVisibleRef = useRef(false);
   useEffect(() => {
     stateRef.current = state;
-  }, [state]);
+    // When the PAC state machine advances while already ≥50% visible,
+    // re-emit exposure for the new state (once-per-state dedup still applies).
+    if (enabled && isVisibleRef.current) {
+      trackPacExposure({
+        profileId,
+        variantId,
+        pacState: state,
+      });
+    }
+  }, [enabled, profileId, state, variantId]);
 
   const emit = useCallback(
     (
@@ -119,6 +129,7 @@ export function usePacEvents({
     (node: Element | null) => {
       observerRef.current?.disconnect();
       observerRef.current = null;
+      isVisibleRef.current = false;
 
       if (!node || !enabled) return;
       if (typeof IntersectionObserver === 'undefined') return;
@@ -126,7 +137,9 @@ export function usePacEvents({
       const observer = new IntersectionObserver(
         entries => {
           for (const entry of entries) {
-            if (isPacExposureVisible(entry)) {
+            const visible = isPacExposureVisible(entry);
+            isVisibleRef.current = visible;
+            if (visible) {
               // Once-per-state-per-session dedup lives in trackPacExposure.
               trackPacExposure({
                 profileId,

--- a/apps/web/lib/flags/profile-pac.test.ts
+++ b/apps/web/lib/flags/profile-pac.test.ts
@@ -6,18 +6,22 @@ import {
 } from './profile-pac';
 
 describe('parseProfilePacAssignment', () => {
-  it('accepts only the three locked PAC slots from Statsig config', () => {
+  it('accepts the five PAC experiment slots from Statsig config', () => {
     expect(
       parseProfilePacAssignment({
         copy_arm: 'alternate',
         trigger_threshold: 'track_complete',
         s2_slot: 'tickets',
+        tab_bar: 'hidden',
+        dismiss_affordance: 'icon',
         rendering: 'not-allowed',
       })
     ).toEqual({
       copyArm: 'alternate',
       triggerThreshold: 'track_complete',
       s2Slot: 'tickets',
+      tabBar: 'hidden',
+      dismissAffordance: 'icon',
     });
   });
 
@@ -27,8 +31,26 @@ describe('parseProfilePacAssignment', () => {
         copyArm: 'icon-x',
         triggerThreshold: '5s',
         s2Slot: 'video',
+        tabBar: 'maybe',
+        dismissAffordance: 'ghost',
       })
     ).toEqual(DEFAULT_PROFILE_PAC_ASSIGNMENT);
+  });
+
+  it('defaults component arms when only the original three slots are set', () => {
+    expect(
+      parseProfilePacAssignment({
+        copyArm: 'alternate',
+        triggerThreshold: '30s',
+        s2Slot: 'merch',
+      })
+    ).toEqual({
+      copyArm: 'alternate',
+      triggerThreshold: '30s',
+      s2Slot: 'merch',
+      tabBar: 'visible',
+      dismissAffordance: 'text',
+    });
   });
 });
 
@@ -140,6 +162,98 @@ describe('evaluateProfilePacPromotion', () => {
           revenueCents: 20_100,
         },
         minRewardLiftCents: 1,
+      })
+    ).toBeNull();
+  });
+
+  it('promotes tab-bar arm only when play + capture both win and engagement holds', () => {
+    expect(
+      evaluateProfilePacPromotion({
+        slot: 'tabBar',
+        control: {
+          arm: 'visible',
+          exposures: 1000,
+          captures: 100,
+          dismissals: 90,
+          plays: 200,
+          engagements: 600,
+        },
+        candidate: {
+          arm: 'hidden',
+          exposures: 1000,
+          captures: 150,
+          dismissals: 80,
+          plays: 280,
+          engagements: 620,
+        },
+      })
+    ).toMatchObject({
+      reason: 'play_and_capture_rate_significant',
+      configPatch: { tabBar: 'hidden' },
+    });
+
+    // Engagement floor violated → no promote.
+    expect(
+      evaluateProfilePacPromotion({
+        slot: 'tabBar',
+        control: {
+          arm: 'visible',
+          exposures: 1000,
+          captures: 100,
+          dismissals: 90,
+          plays: 200,
+          engagements: 600,
+        },
+        candidate: {
+          arm: 'hidden',
+          exposures: 1000,
+          captures: 150,
+          dismissals: 80,
+          plays: 280,
+          engagements: 500,
+        },
+      })
+    ).toBeNull();
+  });
+
+  it('promotes dismiss affordance on capture lift without raising dismissals', () => {
+    expect(
+      evaluateProfilePacPromotion({
+        slot: 'dismissAffordance',
+        control: {
+          arm: 'text',
+          exposures: 1000,
+          captures: 100,
+          dismissals: 90,
+        },
+        candidate: {
+          arm: 'icon',
+          exposures: 1000,
+          captures: 150,
+          dismissals: 80,
+        },
+      })
+    ).toMatchObject({
+      reason: 'capture_rate_significant',
+      configPatch: { dismissAffordance: 'icon' },
+    });
+
+    // Dark pattern: capture up but dismissals up → blocked.
+    expect(
+      evaluateProfilePacPromotion({
+        slot: 'dismissAffordance',
+        control: {
+          arm: 'text',
+          exposures: 1000,
+          captures: 100,
+          dismissals: 90,
+        },
+        candidate: {
+          arm: 'icon',
+          exposures: 1000,
+          captures: 150,
+          dismissals: 120,
+        },
       })
     ).toBeNull();
   });

--- a/apps/web/lib/flags/profile-pac.ts
+++ b/apps/web/lib/flags/profile-pac.ts
@@ -1,12 +1,39 @@
+/**
+ * Public profile PAC (Primary Action Card) experiment assignment +
+ * auto-promotion rules.
+ *
+ * Slots (JOV-3906 base + JOV-3907/3908 component arms):
+ * - copyArm — S1 capture copy
+ * - triggerThreshold — S1 listen threshold before capture prompt
+ * - s2Slot — S2 monetization slot
+ * - tabBar — cold-visitor bottom tab bar visibility (JOV-3907)
+ * - dismissAffordance — capture prompt dismiss control (JOV-3908)
+ */
+
 export type ProfilePacCopyArm = 'default' | 'alternate';
 export type ProfilePacTriggerThreshold = '30s' | 'track_complete';
 export type ProfilePacS2Slot = 'merch' | 'tip' | 'tickets' | 'rsvp';
-export type ProfilePacSlotKey = 'copyArm' | 'triggerThreshold' | 's2Slot';
+/** Cold-visitor tab bar experiment (JOV-3907). Default ships `visible`. */
+export type ProfilePacTabBar = 'hidden' | 'visible';
+/**
+ * Capture dismiss affordance experiment (JOV-3908).
+ * Default ships text "Not now"; candidate is borderless icon-X.
+ */
+export type ProfilePacDismissAffordance = 'text' | 'icon';
+
+export type ProfilePacSlotKey =
+  | 'copyArm'
+  | 'triggerThreshold'
+  | 's2Slot'
+  | 'tabBar'
+  | 'dismissAffordance';
 
 export interface ProfilePacAssignment {
   readonly copyArm: ProfilePacCopyArm;
   readonly triggerThreshold: ProfilePacTriggerThreshold;
   readonly s2Slot: ProfilePacS2Slot;
+  readonly tabBar: ProfilePacTabBar;
+  readonly dismissAffordance: ProfilePacDismissAffordance;
 }
 
 export interface ProfilePacArmMetrics {
@@ -14,6 +41,13 @@ export interface ProfilePacArmMetrics {
   readonly exposures: number;
   readonly captures: number;
   readonly dismissals: number;
+  /** Play starts (pac_play_start) — used by the tab-bar experiment. */
+  readonly plays?: number;
+  /**
+   * Any-interaction / engagement count (scroll depth or interaction rate
+   * proxy) — do-no-harm floor for the tab-bar experiment.
+   */
+  readonly engagements?: number;
   readonly revenueCents?: number;
 }
 
@@ -30,11 +64,15 @@ export interface ProfilePacPromotionRecommendation {
   readonly slot: ProfilePacSlotKey;
   readonly winningArm: string;
   readonly previousArm: string;
-  readonly reason: 'capture_rate_significant' | 'revenue_reward_significant';
+  readonly reason:
+    | 'capture_rate_significant'
+    | 'revenue_reward_significant'
+    | 'play_and_capture_rate_significant';
   readonly zScore: number;
   readonly doNoHarm: {
     readonly captureRateDelta: number;
     readonly dismissalRateDelta: number;
+    readonly engagementRateDelta?: number;
   };
   readonly configPatch: Partial<ProfilePacAssignment>;
   readonly reversible: true;
@@ -44,6 +82,9 @@ export const DEFAULT_PROFILE_PAC_ASSIGNMENT: ProfilePacAssignment = {
   copyArm: 'default',
   triggerThreshold: '30s',
   s2Slot: 'merch',
+  // Control arms for component experiments — Statsig 50/50 overrides.
+  tabBar: 'visible',
+  dismissAffordance: 'text',
 };
 
 const COPY_ARMS = new Set<ProfilePacCopyArm>(['default', 'alternate']);
@@ -52,6 +93,11 @@ const TRIGGER_THRESHOLDS = new Set<ProfilePacTriggerThreshold>([
   'track_complete',
 ]);
 const S2_SLOTS = new Set<ProfilePacS2Slot>(['merch', 'tip', 'tickets', 'rsvp']);
+const TAB_BARS = new Set<ProfilePacTabBar>(['hidden', 'visible']);
+const DISMISS_AFFORDANCES = new Set<ProfilePacDismissAffordance>([
+  'text',
+  'icon',
+]);
 
 function readString(config: Record<string, unknown>, keys: readonly string[]) {
   for (const key of keys) {
@@ -72,6 +118,11 @@ export function parseProfilePacAssignment(
     'trigger_threshold',
   ]);
   const s2Slot = readString(config, ['s2Slot', 's2_slot']);
+  const tabBar = readString(config, ['tabBar', 'tab_bar']);
+  const dismissAffordance = readString(config, [
+    'dismissAffordance',
+    'dismiss_affordance',
+  ]);
 
   return {
     copyArm: COPY_ARMS.has(copyArm as ProfilePacCopyArm)
@@ -85,6 +136,14 @@ export function parseProfilePacAssignment(
     s2Slot: S2_SLOTS.has(s2Slot as ProfilePacS2Slot)
       ? (s2Slot as ProfilePacS2Slot)
       : DEFAULT_PROFILE_PAC_ASSIGNMENT.s2Slot,
+    tabBar: TAB_BARS.has(tabBar as ProfilePacTabBar)
+      ? (tabBar as ProfilePacTabBar)
+      : DEFAULT_PROFILE_PAC_ASSIGNMENT.tabBar,
+    dismissAffordance: DISMISS_AFFORDANCES.has(
+      dismissAffordance as ProfilePacDismissAffordance
+    )
+      ? (dismissAffordance as ProfilePacDismissAffordance)
+      : DEFAULT_PROFILE_PAC_ASSIGNMENT.dismissAffordance,
   };
 }
 
@@ -135,6 +194,15 @@ function buildPatch(
   if (slot === 's2Slot' && S2_SLOTS.has(winningArm as ProfilePacS2Slot)) {
     return { s2Slot: winningArm as ProfilePacS2Slot };
   }
+  if (slot === 'tabBar' && TAB_BARS.has(winningArm as ProfilePacTabBar)) {
+    return { tabBar: winningArm as ProfilePacTabBar };
+  }
+  if (
+    slot === 'dismissAffordance' &&
+    DISMISS_AFFORDANCES.has(winningArm as ProfilePacDismissAffordance)
+  ) {
+    return { dismissAffordance: winningArm as ProfilePacDismissAffordance };
+  }
   return {};
 }
 
@@ -165,12 +233,38 @@ export function evaluateProfilePacPromotion(
     input.candidate.dismissals,
     input.candidate.exposures
   );
+  const controlEngagementRate = rate(
+    input.control.engagements ?? 0,
+    input.control.exposures
+  );
+  const candidateEngagementRate = rate(
+    input.candidate.engagements ?? 0,
+    input.candidate.exposures
+  );
   const doNoHarm = {
     captureRateDelta: candidateCaptureRate - controlCaptureRate,
     dismissalRateDelta: candidateDismissalRate - controlDismissalRate,
+    engagementRateDelta: candidateEngagementRate - controlEngagementRate,
   };
 
-  if (doNoHarm.captureRateDelta < 0 || doNoHarm.dismissalRateDelta > 0) {
+  // Shared capture floor — never promote an arm that hurts captures.
+  if (doNoHarm.captureRateDelta < 0) {
+    return null;
+  }
+
+  // Dismissal-rate guardrail (JOV-3908 / shared): never promote an arm that
+  // raises dismissals — including dark-pattern dismiss affordances.
+  if (doNoHarm.dismissalRateDelta > 0) {
+    return null;
+  }
+
+  // Tab-bar do-no-harm floor (JOV-3907): session engagement must not degrade.
+  if (
+    input.slot === 'tabBar' &&
+    (input.control.engagements !== undefined ||
+      input.candidate.engagements !== undefined) &&
+    doNoHarm.engagementRateDelta < 0
+  ) {
     return null;
   }
 
@@ -197,6 +291,26 @@ export function evaluateProfilePacPromotion(
       candidateTotal: input.candidate.exposures,
     });
     reason = 'revenue_reward_significant';
+  } else if (input.slot === 'tabBar') {
+    // Promote on play-start rate AND capture-rate joint evidence.
+    const playZ = twoProportionZScore({
+      controlSuccesses: input.control.plays ?? 0,
+      controlTotal: input.control.exposures,
+      candidateSuccesses: input.candidate.plays ?? 0,
+      candidateTotal: input.candidate.exposures,
+    });
+    const captureZ = twoProportionZScore({
+      controlSuccesses: input.control.captures,
+      controlTotal: input.control.exposures,
+      candidateSuccesses: input.candidate.captures,
+      candidateTotal: input.candidate.exposures,
+    });
+    // Both metrics must clear the threshold (joint win, not cherry-picked).
+    if (playZ < zScoreThreshold || captureZ < zScoreThreshold) {
+      return null;
+    }
+    zScore = Math.min(playZ, captureZ);
+    reason = 'play_and_capture_rate_significant';
   } else {
     zScore = twoProportionZScore({
       controlSuccesses: input.control.captures,
@@ -207,7 +321,7 @@ export function evaluateProfilePacPromotion(
     reason = 'capture_rate_significant';
   }
 
-  if (zScore < zScoreThreshold) {
+  if (input.slot !== 'tabBar' && zScore < zScoreThreshold) {
     return null;
   }
 

--- a/apps/web/lib/flags/registry.ts
+++ b/apps/web/lib/flags/registry.ts
@@ -105,7 +105,7 @@ export const PROFILE_PAC_VARIANT_SLOTS_FLAG = flag<
     ...DEFAULT_PROFILE_PAC_ASSIGNMENT,
   },
   description:
-    'Public profile Primary Action Card variant slots: S1 copy arm, S1 trigger threshold, S2 monetization slot',
+    'Public profile Primary Action Card variant slots: S1 copy/trigger, S2 monetization, cold-visitor tab bar, capture dismiss affordance',
   options: [{ label: 'Default', value: DEFAULT_PROFILE_PAC_ASSIGNMENT }],
   async decide({ entities }) {
     return getProfilePacAssignmentValue(entities?.userId ?? null);

--- a/apps/web/lib/profile/pac-tab-bar-experiment.test.ts
+++ b/apps/web/lib/profile/pac-tab-bar-experiment.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  markPacTabBarReturnVisit,
+  PAC_TAB_BAR_RETURN_VISIT_KEY,
+  readPacTabBarReturnVisit,
+  shouldShowColdVisitorTabBar,
+} from './pac-tab-bar-experiment';
+
+describe('shouldShowColdVisitorTabBar', () => {
+  it('shows the bar for the visible arm', () => {
+    expect(
+      shouldShowColdVisitorTabBar({
+        tabBarArm: 'visible',
+        isSubscribed: false,
+        restoredThisSession: false,
+        isReturnVisit: false,
+      })
+    ).toBe(true);
+  });
+
+  it('hides the bar only for cold first-visit visitors on the hidden arm', () => {
+    expect(
+      shouldShowColdVisitorTabBar({
+        tabBarArm: 'hidden',
+        isSubscribed: false,
+        restoredThisSession: false,
+        isReturnVisit: false,
+      })
+    ).toBe(false);
+  });
+
+  it('always restores after first interaction, on return visits, or when subscribed', () => {
+    expect(
+      shouldShowColdVisitorTabBar({
+        tabBarArm: 'hidden',
+        isSubscribed: false,
+        restoredThisSession: true,
+        isReturnVisit: false,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldShowColdVisitorTabBar({
+        tabBarArm: 'hidden',
+        isSubscribed: false,
+        restoredThisSession: false,
+        isReturnVisit: true,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldShowColdVisitorTabBar({
+        tabBarArm: 'hidden',
+        isSubscribed: true,
+        restoredThisSession: false,
+        isReturnVisit: false,
+      })
+    ).toBe(true);
+  });
+
+  it('keeps the bar in non-interactive/preview renders', () => {
+    expect(
+      shouldShowColdVisitorTabBar({
+        tabBarArm: 'hidden',
+        isSubscribed: false,
+        restoredThisSession: false,
+        isReturnVisit: false,
+        isInteractive: false,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('return-visit storage helpers', () => {
+  it('reads and marks the durable return-visit flag', () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+    };
+
+    expect(readPacTabBarReturnVisit(storage)).toBe(false);
+    markPacTabBarReturnVisit(storage);
+    expect(store.get(PAC_TAB_BAR_RETURN_VISIT_KEY)).toBe('1');
+    expect(readPacTabBarReturnVisit(storage)).toBe(true);
+  });
+});

--- a/apps/web/lib/profile/pac-tab-bar-experiment.ts
+++ b/apps/web/lib/profile/pac-tab-bar-experiment.ts
@@ -1,0 +1,63 @@
+/**
+ * Cold-visitor tab bar experiment helpers (JOV-3907).
+ *
+ * Hypothesis: hiding the bottom tab bar for cold (S0) visitors reduces choice
+ * surface and raises play-rate → capture-rate.
+ *
+ * Rules:
+ * - Only cold, unsubscribed visitors on the `hidden` arm start without the bar.
+ * - First interaction restores the bar for the rest of the session.
+ * - Return visits always see the bar (localStorage-marked), regardless of arm.
+ */
+
+export const PAC_TAB_BAR_RETURN_VISIT_KEY = 'jv_pac_tab_bar_return';
+
+export interface ColdTabBarVisibilityInput {
+  /** Statsig-assigned arm (`hidden` | `visible`). */
+  readonly tabBarArm: 'hidden' | 'visible';
+  /** True when the visitor is already subscribed / captured. */
+  readonly isSubscribed: boolean;
+  /** True once any interaction restored the bar this session. */
+  readonly restoredThisSession: boolean;
+  /** True when localStorage marks a prior visit that already interacted. */
+  readonly isReturnVisit: boolean;
+  /** Preview / non-interactive renders always keep the bar. */
+  readonly isInteractive?: boolean;
+}
+
+/**
+ * Whether the bottom tab bar should render for this visitor state.
+ * Pure — storage reads happen at the call site.
+ */
+export function shouldShowColdVisitorTabBar(
+  input: ColdTabBarVisibilityInput
+): boolean {
+  if (input.isInteractive === false) return true;
+  if (input.isSubscribed) return true;
+  if (input.restoredThisSession) return true;
+  if (input.isReturnVisit) return true;
+  if (input.tabBarArm === 'visible') return true;
+  return false;
+}
+
+export function readPacTabBarReturnVisit(
+  storage: Pick<Storage, 'getItem'> | null | undefined
+): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(PAC_TAB_BAR_RETURN_VISIT_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function markPacTabBarReturnVisit(
+  storage: Pick<Storage, 'setItem'> | null | undefined
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(PAC_TAB_BAR_RETURN_VISIT_KEY, '1');
+  } catch {
+    // Best-effort — return-visit restore degrades to per-session only.
+  }
+}

--- a/apps/web/lib/tracking/pac-events-contract.ts
+++ b/apps/web/lib/tracking/pac-events-contract.ts
@@ -125,12 +125,14 @@ export interface PacEventPayload {
 
 /**
  * Builds the combined variant key for the visitor's PAC assignment.
- * Keys every event to all three experiment slots so any slot's arms can be
- * compared without re-deriving assignment server-side.
+ * Keys every event to all experiment slots (S1 copy/trigger, S2, plus
+ * component arms for tab-bar + dismiss) so any slot's arms can be compared
+ * without re-deriving assignment server-side.
  */
 export function buildPacVariantId(assignment: ProfilePacAssignment): string {
-  const { copyArm, triggerThreshold, s2Slot } = assignment;
-  return `copy:${copyArm}|trigger:${triggerThreshold}|s2:${s2Slot}`;
+  const { copyArm, triggerThreshold, s2Slot, tabBar, dismissAffordance } =
+    assignment;
+  return `copy:${copyArm}|trigger:${triggerThreshold}|s2:${s2Slot}|tab:${tabBar}|dismiss:${dismissAffordance}`;
 }
 
 /**

--- a/apps/web/tests/e2e/pac-instrumentation.spec.ts
+++ b/apps/web/tests/e2e/pac-instrumentation.spec.ts
@@ -21,7 +21,7 @@ test.use({ storageState: { cookies: [], origins: [] } });
 
 const PROFILE_HANDLE = process.env.SMOKE_PROFILE_HANDLE ?? 'timwhite';
 
-const VARIANT_ID = 'copy:default|trigger:30s|s2:merch';
+const VARIANT_ID = 'copy:default|trigger:30s|s2:merch|tab:visible|dismiss:text';
 
 type ScriptedEvent = {
   readonly event: string;

--- a/apps/web/tests/unit/api/profile/pac-event.test.ts
+++ b/apps/web/tests/unit/api/profile/pac-event.test.ts
@@ -72,7 +72,7 @@ function buildPayload(overrides: Record<string, unknown> = {}) {
     jv_aid: null,
     profile_id: PROFILE_ID,
     pac_state: 'idle',
-    variant_id: 'copy:default|trigger:30s|s2:merch',
+    variant_id: 'copy:default|trigger:30s|s2:merch|tab:visible|dismiss:text',
     session_id: SESSION_ID,
     consent: 'undecided',
     ts: 1_751_000_000_000,
@@ -116,7 +116,7 @@ describe('POST /api/profile/pac-event', () => {
     expect(mockLogStatsigEvent).toHaveBeenCalledWith(
       JV_AID,
       'pac_exposure',
-      'copy:default|trigger:30s|s2:merch',
+      'copy:default|trigger:30s|s2:merch|tab:visible|dismiss:text',
       expect.objectContaining({
         profile_id: PROFILE_ID,
         pac_state: 'idle',

--- a/apps/web/tests/unit/tracking/pac-events.test.ts
+++ b/apps/web/tests/unit/tracking/pac-events.test.ts
@@ -44,7 +44,7 @@ const PROFILE_ID = '3f9c2f6a-8f1e-4b6a-9a44-1c2d3e4f5a6b';
 
 const CONTEXT = {
   profileId: PROFILE_ID,
-  variantId: 'copy:default|trigger:30s|s2:merch',
+  variantId: 'copy:default|trigger:30s|s2:merch|tab:visible|dismiss:text',
   pacState: 'idle',
 } as const;
 
@@ -73,14 +73,18 @@ describe('PAC event schema (spec §8)', () => {
     expect(PAC_SERVER_EVENTS).toEqual(['pac_s2_convert']);
   });
 
-  it('builds the combined variant key from all three assignment slots', () => {
+  it('builds the combined variant key from all five assignment slots', () => {
     expect(
       buildPacVariantId({
         copyArm: 'alternate',
         triggerThreshold: 'track_complete',
         s2Slot: 'tip',
+        tabBar: 'hidden',
+        dismissAffordance: 'icon',
       })
-    ).toBe('copy:alternate|trigger:track_complete|s2:tip');
+    ).toBe(
+      'copy:alternate|trigger:track_complete|s2:tip|tab:hidden|dismiss:icon'
+    );
   });
 
   it('emits every client event with the full payload contract', () => {

--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -74,7 +74,7 @@ This document is the canonical feature list for Jovie. It is designed for onboar
 | Integrations | Spotify OAuth sign-in method | Shipped (internal v1 default-on) | Free+ | Former key: `feature_spotify_oauth` | Available in auth method selector |
 | Billing | Direct upgrade checkout flow | Shipped (internal v1 default-on) | Free+ | Former key: `billing.upgradeDirect` | Billing UX experiment |
 | Conversion | Subscribe CTA variant experiment | In rollout | Flag-gated | `experiment_subscribe_cta_variant` | Variant defaults to `inline` |
-| Conversion | Public profile PAC variant slots | In rollout | Flag-gated | `profile_pac_variant_slots` | Three-slot Statsig experiment: S1 copy arm, S1 trigger threshold, S2 monetization slot |
+| Conversion | Public profile PAC variant slots | In rollout | Flag-gated | `profile_pac_variant_slots` | Five-slot Statsig experiment: S1 copy arm, S1 trigger threshold, S2 monetization slot, cold-visitor tab bar, capture dismiss affordance |
 | Creator recording | Teleprompter recording proposals + showcase interstitial | In rollout | Flag-gated | `teleprompter_recording` + `experiment_teleprompter_showcase` | A/B measures interstitial lift into recorder use |
 | Mobile UX | iOS Apple Music destination prioritization | Shipped (internal v1 default-on) | Free+ | Former key: `feature_ios_apple_music_priority` | Listen interface optimization |
 | Marketing Site | Modular homepage sections | Shipped (internal v1 default-on) | Internal v1 default-on flags | `homepage_*` flags | Static flags default visible |

--- a/docs/STATSIG_FEATURE_GATES.md
+++ b/docs/STATSIG_FEATURE_GATES.md
@@ -38,7 +38,7 @@ historical console cleanup.
 |---|---|---|---|---|
 | `experiment_subscribe_cta_variant` | `LEGACY_STATSIG_GATE_KEYS.SUBSCRIBE_CTA_EXPERIMENT` | `'two_step'` | Subscription CTA experiment | Setup |
 | `profile_alert_optin_cta_variant` | `LEGACY_STATSIG_GATE_KEYS.PROFILE_ALERT_OPTIN_EXPERIMENT` | `'button'` | Public profile alert opt-in CTA variant | Setup |
-| `profile_pac_variant_slots` | `LEGACY_STATSIG_GATE_KEYS.PROFILE_PAC_VARIANT_SLOTS_EXPERIMENT` | `{ copyArm: 'default', triggerThreshold: '30s', s2Slot: 'merch' }` | Public profile Primary Action Card slot assignment: S1 copy, S1 trigger threshold, S2 monetization slot | Setup |
+| `profile_pac_variant_slots` | `LEGACY_STATSIG_GATE_KEYS.PROFILE_PAC_VARIANT_SLOTS_EXPERIMENT` | `{ copyArm: 'default', triggerThreshold: '30s', s2Slot: 'merch', tabBar: 'visible', dismissAffordance: 'text' }` | Public profile Primary Action Card slot assignment: S1 copy, S1 trigger threshold, S2 monetization slot, cold-visitor tab bar (JOV-3907), capture dismiss affordance (JOV-3908) | Setup |
 | `experiment_teleprompter_showcase` | `LEGACY_STATSIG_GATE_KEYS.TELEPROMPTER_SHOWCASE_EXPERIMENT` | `'direct'` | Teleprompter showcase interstitial vs direct recorder | Setup |
 
 ## Operational Notes


### PR DESCRIPTION
## Summary
Completes the PAC experiment batch for public profiles:

- **JOV-3905** — Wire `ProfilePacCard` to the consent-aware, variant-keyed PAC event schema (`usePacEvents` / `trackPacClientEvent`): `pac_play_*`, `capture_prompt_shown`, `capture_submit`/`success`/`error`, `capture_dismiss`, `pac_secondary_click`. Exposure re-fires once per state while ≥50% visible.
- **JOV-3907** — Cold-visitor tab bar experiment (`tabBar: hidden | visible`). Hidden only for cold first-visit visitors; restored on first interaction and always on return visits (`localStorage`).
- **JOV-3908** — Capture dismiss affordance experiment (`dismissAffordance: text | icon`). Control ships text “Not now”; candidate is borderless icon-X with hover circle.

Extends `profile_pac_variant_slots` assignment + `variant_id` + auto-promotion rules (play+capture for tab bar; capture with dismissal-rate guardrail for dismiss).

## Linear
- Fixes JOV-3905
- Fixes JOV-3907
- Fixes JOV-3908
<!-- linear-issue-id:118400de-5bac-4857-869e-70fe1ad76e7f -->

## Verification
- `pnpm --filter @jovie/web run typecheck -- --pretty false` ✅
- `pnpm biome check --write` on edited paths ✅
- Unit tests ✅:
  - `lib/flags/profile-pac.test.ts` (8)
  - `lib/profile/pac-tab-bar-experiment.test.ts` (5)
  - `tests/unit/tracking/pac-events.test.ts` (12)
  - `tests/unit/api/profile/pac-event.test.ts` (11)
- Pre-commit lint-staged typecheck + eslint + a11y ✅
- Pre-push biome + tailwind guard + typecheck ✅

## Layout shift
- PAC height remains reserved (`PAC_RESERVED_HEIGHT_PX`) with cinematic self-height animation.
- Tab bar hide/show is experiment-driven for cold first visits only; padding follows `showBottomNav`. Return visits / interaction restore keep the bar stable.

## Cost Impact
- No new cron, external API loops, or third-party analytics.
- Events continue through existing `track()` + first-party `/api/profile/pac-event` sink → Statsig arm metrics only.

## Statsig config note
Ensure experiment `profile_pac_variant_slots` can emit:
```json
{
  "copyArm": "default",
  "triggerThreshold": "30s",
  "s2Slot": "merch",
  "tabBar": "hidden|visible",
  "dismissAffordance": "text|icon"
}
```
Defaults remain `tabBar: visible`, `dismissAffordance: text` when config is missing.