### PR TITLE
fix(ui): dedupe admin page titles + guard composer radius tokens

### DIFF
--- a/apps/web/components/features/admin/layout/AdminPage.tsx
+++ b/apps/web/components/features/admin/layout/AdminPage.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { PageContent, PageShell } from '@/components/organisms/PageShell';
 import {
   type WorkspaceTabOption,
@@ -24,6 +23,11 @@ export interface AdminPageProps<
   TPrimary extends string = string,
   TSecondary extends string = never,
 > {
+  /**
+   * Route title. Used for tab aria labels and as a semantic page name for
+   * callers — **not** rendered as a visible page heading. The shell
+   * `DashboardHeader` breadcrumb is the single visible title source (JOV-3527).
+   */
   readonly title: string;
   readonly description?: string;
   /**
@@ -45,11 +49,12 @@ export interface AdminPageProps<
  *
  * Replaces the legacy `AdminToolPage` (header-in-card) and `AdminWorkspacePage`
  * (always-on tabs) wrappers. Provides:
- * - Flat page header (title + description + actions), no `ContentSurfaceCard`
- *   wrapper — the route already lives inside the dashboard shell.
- * - Optional `hero` slot directly under the header for primary metrics.
+ * - Description + actions only when needed. Route title lives in the shell
+ *   breadcrumb (`DashboardHeader`) — never re-rendered here (avoids the
+ *   double-"Ops" regression class).
+ * - Optional `hero` slot for primary metrics.
  * - Optional `tabs` slot that delegates to `WorkspaceTabsSurface`. The parent
- *   header owns the route title/description, so the tabs surface renders
+ *   owns the route title in the shell breadcrumb, so the tabs surface renders
  *   headerless to avoid duplicate page titles.
  * - `space-y-6` outer rhythm matching the canonical dashboard.
  *
@@ -71,6 +76,8 @@ export function AdminPage<
   className,
 }: Readonly<AdminPageProps<TPrimary, TSecondary>>) {
   const tabsHeaderless = Boolean(tabs);
+  // Breadcrumb owns the page title; only surface description + actions here.
+  const showMetaHeader = Boolean(description || actions);
 
   return (
     <PageShell>
@@ -82,15 +89,25 @@ export function AdminPage<
           )}
           data-testid={testId}
         >
-          <ContentSectionHeader
-            title={title}
-            subtitle={description}
-            actions={actions}
-            variant='plain'
-            density='compact'
-            className='min-h-0'
-            actionsClassName='shrink-0'
-          />
+          {showMetaHeader ? (
+            <div
+              className='flex min-w-0 items-start justify-between gap-2'
+              data-testid='admin-page-meta'
+            >
+              {description ? (
+                <p className='min-w-0 flex-1 text-2xs leading-[15px] text-tertiary-token'>
+                  {description}
+                </p>
+              ) : (
+                <span className='min-w-0 flex-1' aria-hidden='true' />
+              )}
+              {actions ? (
+                <div className='ml-auto flex shrink-0 items-center justify-end gap-1'>
+                  {actions}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
 
           {hero ? <div data-testid='admin-page-hero'>{hero}</div> : null}
 

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/lib/chat/large-text-paste';
 import { serializeEntity, serializeSkill } from '@/lib/chat/tokens';
 import type { TranscriberErrorCode } from '@/lib/chat/transcriber';
+import { SYSTEM_B_RADIUS_PX } from '@/lib/design/system-b-radius';
 import { useEntityRecents } from '@/lib/queries/useEntityRecents';
 import { cn } from '@/lib/utils';
 
@@ -109,13 +110,20 @@ function geometryFor(
 ): SurfaceGeometry {
   const width = '100%';
   const maxWidth = `min(calc(100vw - 32px), ${CHAT_COMPOSER_MAX_WIDTH})`;
-  if (stacked) return { width, maxWidth, borderRadius: 28 };
-  if (mode === 'entity') return { width, maxWidth, borderRadius: 24 };
-  if (variant === 'hero' && usePillLayout) {
-    return { width, maxWidth, borderRadius: 9999 };
+  // Radius values come only from SYSTEM_B_RADIUS_PX (JOV-3532).
+  if (stacked) {
+    return { width, maxWidth, borderRadius: SYSTEM_B_RADIUS_PX['3xl'] };
   }
-  if (variant === 'hero') return { width, maxWidth, borderRadius: 24 };
-  return { width, maxWidth, borderRadius: 28 };
+  if (mode === 'entity') {
+    return { width, maxWidth, borderRadius: SYSTEM_B_RADIUS_PX['3xl'] };
+  }
+  if (variant === 'hero' && usePillLayout) {
+    return { width, maxWidth, borderRadius: SYSTEM_B_RADIUS_PX.pill };
+  }
+  if (variant === 'hero') {
+    return { width, maxWidth, borderRadius: SYSTEM_B_RADIUS_PX['3xl'] };
+  }
+  return { width, maxWidth, borderRadius: SYSTEM_B_RADIUS_PX['3xl'] };
 }
 
 function pickerKindNoun(kind: import('@/lib/chat/tokens').EntityKind): string {

--- a/apps/web/components/marketing/HomeComposerHero.tsx
+++ b/apps/web/components/marketing/HomeComposerHero.tsx
@@ -28,6 +28,7 @@ import {
   TYPEWRITER_CHAR_INTERVAL,
   TYPEWRITER_QUERY,
 } from '@/data/homeComposerHeroData';
+import { SYSTEM_B_RADIUS_PX } from '@/lib/design/system-b-radius';
 import { cn } from '@/lib/utils';
 
 // ─── Design constants (match in-app composer exactly) ─────────────────────
@@ -85,9 +86,10 @@ function demoReducer(state: DemoState, action: DemoAction): DemoState {
 type SurfaceMode = 'empty' | 'typing' | 'entity';
 
 function geometryFor(mode: SurfaceMode) {
-  if (mode === 'empty') return { borderRadius: 999 };
-  if (mode === 'typing') return { borderRadius: 24 };
-  return { borderRadius: 20 };
+  // Mirror ChatInput geometryFor — System B radius tokens only (JOV-3532).
+  if (mode === 'empty') return { borderRadius: SYSTEM_B_RADIUS_PX.pill };
+  if (mode === 'typing') return { borderRadius: SYSTEM_B_RADIUS_PX['3xl'] };
+  return { borderRadius: SYSTEM_B_RADIUS_PX['2xl'] };
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────

--- a/apps/web/components/shell/ThreadView.tsx
+++ b/apps/web/components/shell/ThreadView.tsx
@@ -95,7 +95,7 @@ export function ThreadView({
         onScroll={checkAtBottom}
         className='absolute inset-0 overflow-y-auto'
       >
-        <div className='mx-auto w-full max-w-[44rem] px-(--linear-app-header-padding-x) pb-[9rem] pt-5 sm:pt-6'>
+        <div className='mx-auto w-full max-w-[44rem] px-(--linear-app-header-padding-x) pb-(--system-b-chat-composer-thread-scroll-padding) pt-5 sm:pt-6'>
           <header>
             <h1 className='text-2xl font-semibold leading-tight text-primary-token'>
               {thread.title}
@@ -119,6 +119,7 @@ export function ThreadView({
         className='pointer-events-none absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-(--linear-app-content-surface) via-(--linear-app-content-surface)/80 to-transparent'
       />
       <div className='absolute inset-x-0 bottom-0'>
+        {/* system-b-allow: safe-area inset requires calc(); no spacing token covers env() (JOV-3532) */}
         <div className='relative mx-auto w-full max-w-[44rem] px-(--linear-app-header-padding-x) pb-[calc(1rem+env(safe-area-inset-bottom))]'>
           {!atBottom && (
             <button

--- a/apps/web/lib/design/system-b-radius.ts
+++ b/apps/web/lib/design/system-b-radius.ts
@@ -1,0 +1,26 @@
+/**
+ * Pixel values of System B radius tokens from `styles/design-system.css`.
+ *
+ * Prefer CSS vars (`var(--radius-3xl)`) in stylesheets and Tailwind named
+ * utilities (`rounded-3xl`, `rounded-full`). Use these numeric constants only
+ * when a runtime animation API (Motion/WAAPI) requires a number or when a
+ * shared geometry helper must return a resolved px value.
+ *
+ * Do **not** invent off-scale magic numbers (e.g. 28). Snap to the nearest
+ * token and extend this map only when the CSS token scale itself changes.
+ */
+export const SYSTEM_B_RADIUS_PX = {
+  none: 0,
+  xs: 2,
+  default: 4,
+  sm: 8,
+  md: 10,
+  lg: 12,
+  xl: 16,
+  '2xl': 20,
+  '3xl': 24,
+  pill: 9999,
+  full: 9999,
+} as const;
+
+export type SystemBRadiusToken = keyof typeof SYSTEM_B_RADIUS_PX;

--- a/apps/web/tests/unit/app/admin-page-header-dedupe.test.ts
+++ b/apps/web/tests/unit/app/admin-page-header-dedupe.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * JOV-3527 — AdminPage must not re-render the route title. The shell
+ * DashboardHeader breadcrumb is the single visible page-title source.
+ *
+ * Also locks section-heading scale on the shared admin chrome primitives so
+ * oversized `text-2xl`/`text-3xl` / uppercase-tracking drift cannot regress
+ * without a deliberate token decision.
+ */
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+function read(rel: string): string {
+  return readFileSync(resolve(appRoot, rel), 'utf8');
+}
+
+const ADMIN_PAGE = 'components/features/admin/layout/AdminPage.tsx';
+const CONTENT_SECTION_HEADER = 'components/molecules/ContentSectionHeader.tsx';
+const SETTINGS_PANEL = 'components/molecules/settings/SettingsPanel.tsx';
+const OPERATIONAL_CONTROLS =
+  'components/features/admin/OperationalControlPanel.tsx';
+const OPS_PAGE = 'app/app/(shell)/admin/ops/page.tsx';
+
+describe('admin page header dedupe (JOV-3527)', () => {
+  it('does not render the route title via ContentSectionHeader', () => {
+    const source = read(ADMIN_PAGE);
+
+    expect(source).not.toContain('ContentSectionHeader');
+    expect(source).toContain("data-testid='admin-page-meta'");
+    expect(source).toContain('showMetaHeader');
+    // Title prop is retained for tabs/aria, not for a visible h2.
+    expect(source).toMatch(/readonly title: string/);
+    expect(source).toContain('DashboardHeader');
+  });
+
+  it('keeps ops inside AdminPage without a second page-title block', () => {
+    const source = read(OPS_PAGE);
+
+    expect(source).toContain('<AdminPage');
+    expect(source).toContain("title='Ops'");
+    // Page must not mount its own ContentSectionHeader page chrome.
+    expect(source).not.toMatch(
+      /ContentSectionHeader[\s\S]{0,120}title=['"]Ops['"]/
+    );
+  });
+
+  it('keeps ContentSectionHeader on the quiet app scale', () => {
+    const source = read(CONTENT_SECTION_HEADER);
+
+    expect(source).toContain('text-xs font-semibold');
+    expect(source).not.toMatch(/\btext-(lg|xl|2xl|3xl)\b/);
+    expect(source).not.toMatch(/uppercase/);
+  });
+
+  it('keeps SettingsPanel section titles on the quiet app scale', () => {
+    const source = read(SETTINGS_PANEL);
+
+    expect(source).toContain('text-app font-[540]');
+    expect(source).not.toMatch(/\btext-(lg|xl|2xl|3xl)\b/);
+    expect(source).not.toMatch(/uppercase/);
+  });
+
+  it('does not introduce oversized section headings on operational controls', () => {
+    const source = read(OPERATIONAL_CONTROLS);
+
+    expect(source).not.toMatch(/\btext-(lg|xl|2xl|3xl)\b/);
+    expect(source).not.toMatch(/uppercase\s+tracking-/);
+    expect(source).toContain('SettingsPanel');
+    expect(source).toContain('ContentSectionHeader');
+  });
+});

--- a/apps/web/tests/unit/chat/composer-header-radius-padding-source-guard.test.ts
+++ b/apps/web/tests/unit/chat/composer-header-radius-padding-source-guard.test.ts
@@ -1,0 +1,162 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * JOV-3532 — Source guard: ban off-token radius/padding magic numbers on
+ * composer + header surfaces.
+ *
+ * Fail when scoped files introduce:
+ * - numeric `borderRadius: N` literals (must use SYSTEM_B_RADIUS_PX / CSS vars)
+ * - arbitrary Tailwind radius `rounded-[…]`
+ * - arbitrary spacing `p-[…]` / `px-[…]` / `py-[…]` / `pt|pb|pl|pr-[…]`
+ *
+ * Escape hatch (same line or previous line):
+ *   // system-b-allow: <reason> (JOV-XXXX)
+ * or JSX `{/* system-b-allow: <reason> *\/}`
+ *
+ * Extend the scoped globs carefully — widen only when a surface has already
+ * been cleaned of un-allowlisted violations.
+ */
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const EXPLICIT_FILES = [
+  'components/jovie/components/ChatInput.tsx',
+  'components/jovie/components/ChatComposerToolbar.tsx',
+  'components/jovie/components/chat-motion.ts',
+  'components/marketing/HomeComposerHero.tsx',
+  'lib/design/system-b-radius.ts',
+] as const;
+
+const SHELL_DIR = resolve(appRoot, 'components/shell');
+
+const FORBIDDEN = [
+  {
+    id: 'numeric-borderRadius',
+    pattern: /borderRadius\s*:\s*\d+/,
+    message:
+      'numeric borderRadius literal — use SYSTEM_B_RADIUS_PX.<token> or var(--radius-*)',
+  },
+  {
+    id: 'arbitrary-rounded',
+    pattern: /\brounded-\[[^\]]+\]/,
+    message:
+      'arbitrary rounded-[…] — use named System B radius utilities (rounded-md, rounded-3xl, rounded-full, …)',
+  },
+  {
+    id: 'arbitrary-padding',
+    pattern: /\b(?:p|px|py|pt|pb|pl|pr)-\[[^\]]+\]/,
+    message:
+      'arbitrary padding-[…] — use spacing-scale utilities or CSS vars (e.g. pb-(--system-b-chat-composer-thread-scroll-padding))',
+  },
+] as const;
+
+const ALLOW_RE = /system-b-allow\s*:/;
+
+function listShellTsx(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry === '__tests__' || entry === 'node_modules') continue;
+    const full = join(dir, entry);
+    let stats: ReturnType<typeof statSync>;
+    try {
+      stats = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stats.isDirectory()) {
+      out.push(...listShellTsx(full));
+    } else if (
+      stats.isFile() &&
+      (entry.endsWith('.tsx') || entry.endsWith('.ts')) &&
+      !entry.endsWith('.test.tsx') &&
+      !entry.endsWith('.test.ts')
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function isAllowed(line: string, prevLine: string | undefined): boolean {
+  if (ALLOW_RE.test(line)) return true;
+  if (prevLine && ALLOW_RE.test(prevLine)) return true;
+  return false;
+}
+
+function scanFile(absPath: string): string[] {
+  const rel = relative(appRoot, absPath);
+  const source = readFileSync(absPath, 'utf8');
+  const lines = source.split('\n');
+  const offenders: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const prev = i > 0 ? lines[i - 1] : undefined;
+    // Skip pure allowlist comment lines themselves.
+    if (ALLOW_RE.test(line) && !FORBIDDEN.some(f => f.pattern.test(line))) {
+      continue;
+    }
+    for (const rule of FORBIDDEN) {
+      if (!rule.pattern.test(line)) continue;
+      if (isAllowed(line, prev)) continue;
+      offenders.push(
+        `${rel}:${i + 1} [${rule.id}] ${rule.message}\n  ${line.trim()}`
+      );
+    }
+  }
+
+  return offenders;
+}
+
+describe('composer + header radius/padding source guard (JOV-3532)', () => {
+  const files = [
+    ...EXPLICIT_FILES.map(rel => resolve(appRoot, rel)),
+    ...listShellTsx(SHELL_DIR),
+  ];
+
+  it('has scoped files to scan', () => {
+    expect(files.length).toBeGreaterThan(EXPLICIT_FILES.length);
+  });
+
+  it('bans off-token radius/padding magic numbers without system-b-allow', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      offenders.push(...scanFile(file));
+    }
+
+    expect(
+      offenders,
+      `Off-token radius/padding on composer/header surfaces:\n${offenders.join('\n')}\n\nFix by using SYSTEM_B_RADIUS_PX / spacing tokens, or add // system-b-allow: <reason> (JOV-XXXX) on the previous line.`
+    ).toEqual([]);
+  });
+
+  it('exports the System B radius pixel map for geometry helpers', () => {
+    const source = readFileSync(
+      resolve(appRoot, 'lib/design/system-b-radius.ts'),
+      'utf8'
+    );
+    expect(source).toContain('SYSTEM_B_RADIUS_PX');
+    expect(source).toContain("'3xl': 24");
+    expect(source).toContain('pill: 9999');
+  });
+
+  it('keeps ChatInput + HomeComposerHero geometry on SYSTEM_B_RADIUS_PX', () => {
+    for (const rel of [
+      'components/jovie/components/ChatInput.tsx',
+      'components/marketing/HomeComposerHero.tsx',
+    ] as const) {
+      const source = readFileSync(resolve(appRoot, rel), 'utf8');
+      expect(source).toContain('SYSTEM_B_RADIUS_PX');
+      expect(source).not.toMatch(/borderRadius\s*:\s*\d+/);
+    }
+  });
+});

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -187,6 +187,35 @@ these, not redefine them.
 - **Canonical button sizes** — `sm` = 28px, `md` = 36px, `lg` = 44px; `icon`
   uses the `md` control height with equal width.
 
+## Source guards (composer + header radius/padding)
+
+Composer and app-shell header surfaces must not reintroduce off-token corner
+radius or padding magic numbers. Enforced by:
+
+- `apps/web/tests/unit/chat/composer-header-radius-padding-source-guard.test.ts` (JOV-3532)
+- Numeric px map: `apps/web/lib/design/system-b-radius.ts` (`SYSTEM_B_RADIUS_PX`)
+
+**Forbidden in scoped files** (`ChatInput.tsx`, `ChatComposerToolbar.tsx`,
+`chat-motion.ts`, `HomeComposerHero.tsx`, `components/shell/*`):
+
+- `borderRadius: 28` (or any bare number) — use `SYSTEM_B_RADIUS_PX['3xl']` etc.
+- `rounded-[…]` arbitrary Tailwind radius
+- `p-[…]` / `px-[…]` / `py-[…]` (and `pt|pb|pl|pr-[…]`) arbitrary padding
+
+**Escape hatch** (previous line or same line, with reason + Linear ID):
+
+```ts
+// system-b-allow: safe-area inset requires calc(); no spacing token covers env() (JOV-3532)
+className='… pb-[calc(1rem+env(safe-area-inset-bottom))]'
+```
+
+To widen the guard: clean the new surface of un-allowlisted violations first,
+then add its path to the test's scoped file list.
+
+Admin page titles are owned by the shell breadcrumb — `AdminPage` must not
+re-render the route title (JOV-3527;
+`apps/web/tests/unit/app/admin-page-header-dedupe.test.ts`).
+
 ## Common Failure Modes
 
 - Defining the same token in multiple CSS files
@@ -195,3 +224,5 @@ these, not redefine them.
   `components/marketing/*`
 - Treating `/artist-profiles` as the public profile canonical surface
 - Treating `/ai` or `/investors` as design surfaces instead of redirects
+- Adding bare `borderRadius: N` or `rounded-[Npx]` on composer/header surfaces
+  (use `SYSTEM_B_RADIUS_PX` / named utilities; see source guards above)


### PR DESCRIPTION
## Summary
- **JOV-3527:** `AdminPage` no longer re-renders the route title. Shell `DashboardHeader` breadcrumb is the single visible title (fixes double “Ops”). Description + actions remain in a meta row.
- **JOV-3527 guard:** Source lock that ContentSectionHeader / SettingsPanel / OperationalControlPanel stay on the quiet heading scale (no `text-2xl/3xl`, no uppercase tracking).
- **JOV-3532:** Composer geometry uses `SYSTEM_B_RADIUS_PX` (snap off-scale 28→24 / pill). ThreadView scroll padding uses the design-system token.
- **JOV-3532 guard:** Vitest source-scan bans bare `borderRadius: N`, `rounded-[…]`, and arbitrary `p/px/py-[…]` on composer + `components/shell/*`, with `// system-b-allow:` escape hatch. Documented in `docs/DESIGN_TOKENS.md`.

## Linear
Fixes JOV-3527
Fixes JOV-3532
<!-- linear-issue-id:JOV-3527 -->
<!-- linear-issue-id:JOV-3532 -->

## Layout-shift audit
- Admin pages: title row removed only when it duplicated the breadcrumb; description/actions row preserves vertical space when present; no title→null height jump for title-only pages (meta header absent in both “before” states was title+desc; now desc-only or actions-only — reserved via flex min-w-0).
- Composer: radius token snap is visual geometry only (same element, no layout reflow of siblings).

## Verification
- `pnpm --filter @jovie/web run typecheck` — pass (local + pre-push)
- `biome check` on edited files — pass
- `vitest run tests/unit/app/admin-page-header-dedupe.test.ts tests/unit/chat/composer-header-radius-padding-source-guard.test.ts` — 9/9 pass
- Pre-commit hooks (eslint, a11y staged, typecheck) — pass

## Cost Impact
None (UI source + unit guards only).

## Test plan
- [ ] `/app/admin/ops` shows “Ops” once (breadcrumb only)
- [ ] Ops description + TV view action still render
- [ ] Composer empty/typing/entity morph radii look System B (no over-round 28px)
- [ ] Source guards fail if a bare `borderRadius: 28` is reintroduced in ChatInput