### PR TITLE
fix(chat): fail-open degraded rate limits + fail-soft turns (JOV-3956)

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -2512,18 +2512,38 @@ export async function POST(req: Request) {
       );
     }
 
-    const reservation = await reserveChatTurn({
-      conversationId: resolvedConversationId,
-      clientTurnId,
-      clientMessageId,
-      source,
-      toolIntent,
-      userMessage: userText || '(image attachment)',
-      userId: sessionContext.user.id,
-      creatorProfileId: resolvedProfileId,
-    });
+    // Turn reservation is durable bookkeeping. If it fails (DB blip,
+    // migration drift on optional columns), still answer the user —
+    // do not convert every web chat turn into CHAT_STREAM_FAILED.
+    let reservation: Awaited<ReturnType<typeof reserveChatTurn>> | null = null;
+    try {
+      reservation = await reserveChatTurn({
+        conversationId: resolvedConversationId,
+        clientTurnId,
+        clientMessageId,
+        source,
+        toolIntent,
+        userMessage: userText || '(image attachment)',
+        userId: sessionContext.user.id,
+        creatorProfileId: resolvedProfileId,
+      });
+    } catch (error) {
+      await captureError(
+        'Chat turn reserve failed; continuing without durable turn',
+        error,
+        {
+          feature: 'ai-chat',
+          mode: 'reserve-fail-soft',
+          requestId,
+          userId,
+          profileId: resolvedProfileId,
+          clientTurnId,
+        }
+      );
+      reservation = null;
+    }
 
-    if (reservation.outcome === 'duplicate_in_progress') {
+    if (reservation?.outcome === 'duplicate_in_progress') {
       return NextResponse.json(
         {
           error: TURN_IN_PROGRESS_ERROR_CODE,
@@ -2545,7 +2565,7 @@ export async function POST(req: Request) {
       );
     }
 
-    if (reservation.outcome === 'duplicate_completed') {
+    if (reservation?.outcome === 'duplicate_completed') {
       const assistantMessage = [...reservation.messages]
         .reverse()
         .find(message => message.role === 'assistant');
@@ -2582,20 +2602,23 @@ export async function POST(req: Request) {
       });
     }
 
-    reservedTurn = {
-      conversationId: reservation.conversationId,
-      turnId: reservation.turn.id,
-    };
+    if (reservation?.outcome === 'reserved') {
+      reservedTurn = {
+        conversationId: reservation.conversationId,
+        turnId: reservation.turn.id,
+      };
+    }
 
     if (
+      reservedTurn &&
       albumArtCapability.availability !== 'available' &&
       detectAlbumArtGenerationIntent({ text: userText, toolIntent })
     ) {
       const replyText =
         buildAlbumArtUnavailableAssistantMessage(albumArtCapability);
       await persistTerminalAssistantMessage({
-        conversationId: reservation.conversationId,
-        turnId: reservation.turn.id,
+        conversationId: reservedTurn.conversationId,
+        turnId: reservedTurn.turnId,
         status: 'failed_tool_unavailable',
         content: replyText,
         errorCode: albumArtCapability.reasonCode ?? 'TOOL_UNAVAILABLE',
@@ -2608,26 +2631,27 @@ export async function POST(req: Request) {
         corsHeaders,
         headers: {
           'x-chat-preflight': 'album-art-unavailable',
-          'x-conversation-id': reservation.conversationId,
-          'x-chat-turn-id': reservation.turn.id,
+          'x-conversation-id': reservedTurn.conversationId,
+          'x-chat-turn-id': reservedTurn.turnId,
         },
         metadata: buildChatTurnMetadata({
-          conversationId: reservation.conversationId,
-          turnId: reservation.turn.id,
+          conversationId: reservedTurn.conversationId,
+          turnId: reservedTurn.turnId,
           requestId,
         }),
       });
     }
 
     if (
+      reservedTurn &&
       retouchCapability.availability !== 'available' &&
       detectRetouchIntent({ text: userText, toolIntent })
     ) {
       const replyText =
         buildRetouchUnavailableAssistantMessage(retouchCapability);
       await persistTerminalAssistantMessage({
-        conversationId: reservation.conversationId,
-        turnId: reservation.turn.id,
+        conversationId: reservedTurn.conversationId,
+        turnId: reservedTurn.turnId,
         status: 'failed_tool_unavailable',
         content: replyText,
         errorCode: retouchCapability.reasonCode ?? 'TOOL_UNAVAILABLE',
@@ -2640,14 +2664,50 @@ export async function POST(req: Request) {
         corsHeaders,
         headers: {
           'x-chat-preflight': 'retouch-unavailable',
-          'x-conversation-id': reservation.conversationId,
-          'x-chat-turn-id': reservation.turn.id,
+          'x-conversation-id': reservedTurn.conversationId,
+          'x-chat-turn-id': reservedTurn.turnId,
         },
         metadata: buildChatTurnMetadata({
-          conversationId: reservation.conversationId,
-          turnId: reservation.turn.id,
+          conversationId: reservedTurn.conversationId,
+          turnId: reservedTurn.turnId,
           requestId,
         }),
+      });
+    }
+
+    // Preflight unavailability when reservation failed soft: still answer
+    // without durable turn headers so the client gets a clear stream.
+    if (
+      !reservedTurn &&
+      albumArtCapability.availability !== 'available' &&
+      detectAlbumArtGenerationIntent({ text: userText, toolIntent })
+    ) {
+      const replyText =
+        buildAlbumArtUnavailableAssistantMessage(albumArtCapability);
+      return createAssistantTextStreamResponse({
+        text: replyText,
+        requestId,
+        corsHeaders,
+        headers: {
+          'x-chat-preflight': 'album-art-unavailable',
+        },
+      });
+    }
+
+    if (
+      !reservedTurn &&
+      retouchCapability.availability !== 'available' &&
+      detectRetouchIntent({ text: userText, toolIntent })
+    ) {
+      const replyText =
+        buildRetouchUnavailableAssistantMessage(retouchCapability);
+      return createAssistantTextStreamResponse({
+        text: replyText,
+        requestId,
+        corsHeaders,
+        headers: {
+          'x-chat-preflight': 'retouch-unavailable',
+        },
       });
     }
   }

--- a/apps/web/lib/chat/turns.ts
+++ b/apps/web/lib/chat/turns.ts
@@ -7,6 +7,7 @@ import {
   chatMessages,
   chatTurns,
 } from '@/lib/db/schema/chat';
+import { logger } from '@/lib/utils/logger';
 import { sanitizeConversationTitle } from './title';
 import type { PersistedToolEvent } from './tool-events';
 
@@ -28,16 +29,119 @@ const IN_FLIGHT_STATUSES = new Set<ChatTurn['status']>([
   'streaming',
 ]);
 
+/**
+ * Stable chat_turns columns that predate optional attribution fields
+ * (`model` from 0069). Explicit select/returning keeps turn reservation
+ * working when prod Neon lags a migration (migration-drift class that
+ * previously surfaced as CHAT_STREAM_FAILED on every web turn).
+ */
+const chatTurnCoreColumns = {
+  id: chatTurns.id,
+  userId: chatTurns.userId,
+  creatorProfileId: chatTurns.creatorProfileId,
+  conversationId: chatTurns.conversationId,
+  clientTurnId: chatTurns.clientTurnId,
+  status: chatTurns.status,
+  source: chatTurns.source,
+  toolIntent: chatTurns.toolIntent,
+  errorCode: chatTurns.errorCode,
+  errorMessage: chatTurns.errorMessage,
+  createdAt: chatTurns.createdAt,
+  updatedAt: chatTurns.updatedAt,
+  startedAt: chatTurns.startedAt,
+  completedAt: chatTurns.completedAt,
+} as const;
+
+/**
+ * Stable chat_messages columns that predate script/source attribution
+ * (`assistant_source` / `script_line_key` from 0067).
+ */
+const chatMessageCoreColumns = {
+  id: chatMessages.id,
+  conversationId: chatMessages.conversationId,
+  turnId: chatMessages.turnId,
+  clientMessageId: chatMessages.clientMessageId,
+  role: chatMessages.role,
+  content: chatMessages.content,
+  toolCalls: chatMessages.toolCalls,
+  createdAt: chatMessages.createdAt,
+} as const;
+
+type ChatTurnCoreRow = {
+  readonly id: string;
+  readonly userId: string;
+  readonly creatorProfileId: string;
+  readonly conversationId: string;
+  readonly clientTurnId: string;
+  readonly status: ChatTurn['status'];
+  readonly source: string;
+  readonly toolIntent: string | null;
+  readonly errorCode: string | null;
+  readonly errorMessage: string | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly startedAt: Date | null;
+  readonly completedAt: Date | null;
+};
+
+type ChatMessageCoreRow = {
+  readonly id: string;
+  readonly conversationId: string;
+  readonly turnId: string | null;
+  readonly clientMessageId: string | null;
+  readonly role: ChatMessage['role'];
+  readonly content: string;
+  readonly toolCalls: ChatMessage['toolCalls'];
+  readonly createdAt: Date;
+};
+
+function toChatTurn(row: ChatTurnCoreRow): ChatTurn {
+  return {
+    ...row,
+    model: null,
+  };
+}
+
+function toChatMessage(row: ChatMessageCoreRow): ChatMessage {
+  return {
+    ...row,
+    assistantSource: null,
+    scriptLineKey: null,
+  };
+}
+
 function toConversationTitle(text: string): string | null {
   return sanitizeConversationTitle(text, 50);
 }
 
+function ephemeralAssistantMessage(input: {
+  readonly conversationId: string;
+  readonly turnId: string;
+  readonly content: string;
+  readonly toolCalls?: PersistedToolEvent[] | null;
+}): ChatMessage {
+  return {
+    id: `ephemeral-${input.turnId}`,
+    conversationId: input.conversationId,
+    turnId: input.turnId,
+    clientMessageId: null,
+    role: 'assistant',
+    content: input.content,
+    toolCalls:
+      input.toolCalls && input.toolCalls.length > 0 ? input.toolCalls : null,
+    assistantSource: null,
+    scriptLineKey: null,
+    createdAt: new Date(),
+  };
+}
+
 async function fetchTurnMessages(turnId: string): Promise<ChatMessage[]> {
-  return db
-    .select()
+  const rows = await db
+    .select(chatMessageCoreColumns)
     .from(chatMessages)
     .where(eq(chatMessages.turnId, turnId))
     .orderBy(asc(chatMessages.createdAt));
+  return rows.map(toChatMessage);
 }
 
 async function fetchExistingTurn(
@@ -45,7 +149,7 @@ async function fetchExistingTurn(
   clientTurnId: string
 ): Promise<ChatTurn | null> {
   const [turn] = await db
-    .select()
+    .select(chatTurnCoreColumns)
     .from(chatTurns)
     .where(
       and(
@@ -55,7 +159,7 @@ async function fetchExistingTurn(
     )
     .limit(1);
 
-  return turn ?? null;
+  return turn ? toChatTurn(turn) : null;
 }
 
 async function fetchExistingClientTurn(input: {
@@ -64,7 +168,7 @@ async function fetchExistingClientTurn(input: {
   readonly clientTurnId: string;
 }): Promise<ChatTurn | null> {
   const [turn] = await db
-    .select()
+    .select(chatTurnCoreColumns)
     .from(chatTurns)
     .where(
       and(
@@ -75,7 +179,7 @@ async function fetchExistingClientTurn(input: {
     )
     .limit(1);
 
-  return turn ?? null;
+  return turn ? toChatTurn(turn) : null;
 }
 
 async function toDuplicateReservationResult(
@@ -176,7 +280,7 @@ export async function reserveChatTurn(input: {
     createdConversationId = conversation.id;
   }
 
-  const [insertedTurn] = await db
+  const [insertedTurnRow] = await db
     .insert(chatTurns)
     .values({
       userId: input.userId,
@@ -196,9 +300,9 @@ export async function reserveChatTurn(input: {
         chatTurns.clientTurnId,
       ],
     })
-    .returning();
+    .returning(chatTurnCoreColumns);
 
-  if (!insertedTurn) {
+  if (!insertedTurnRow) {
     if (createdConversationId) {
       await db
         .delete(chatConversations)
@@ -217,6 +321,8 @@ export async function reserveChatTurn(input: {
 
     return toDuplicateReservationResult(existingTurn);
   }
+
+  const insertedTurn = toChatTurn(insertedTurnRow);
 
   // Insert the user message paired to the new turn. We always pass a
   // `clientMessageId` (falling back to the `clientTurnId` when the caller
@@ -257,27 +363,59 @@ export async function reserveChatTurn(input: {
  * turn's assistant output. Fire-and-forget from the chat route right after
  * model selection so 👍/👎 feedback rows can attribute votes to the
  * producing model even when the stream later fails (JOV #11460).
+ *
+ * Fail-soft: never throws. The `model` column may be missing when prod
+ * migrations lag (0069). Attribution is best-effort.
  */
 export async function recordChatTurnModel(
   turnId: string,
   model: string
 ): Promise<void> {
-  await db
-    .update(chatTurns)
-    .set({ model, updatedAt: new Date() })
-    .where(eq(chatTurns.id, turnId));
+  try {
+    await db
+      .update(chatTurns)
+      .set({ model, updatedAt: new Date() })
+      .where(eq(chatTurns.id, turnId));
+  } catch (error) {
+    // Fail-soft: model attribution must never break the stream (JOV-3956).
+    logger.warn(
+      'Chat turn model record failed',
+      {
+        turnId,
+        model,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'chat/turns'
+    );
+  }
 }
 
+/**
+ * Mark a reserved turn as streaming. Fail-soft: never throws so a status
+ * write cannot abort the user-visible stream (JOV-3956).
+ */
 export async function markChatTurnStreaming(turnId: string): Promise<void> {
   const now = new Date();
-  await db
-    .update(chatTurns)
-    .set({
-      status: 'streaming',
-      startedAt: now,
-      updatedAt: now,
-    })
-    .where(eq(chatTurns.id, turnId));
+  try {
+    await db
+      .update(chatTurns)
+      .set({
+        status: 'streaming',
+        startedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(chatTurns.id, turnId));
+  } catch (error) {
+    // Fail-soft: status write must never abort the user-visible stream.
+    logger.warn(
+      'Chat turn streaming mark failed',
+      {
+        turnId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'chat/turns'
+    );
+  }
 }
 
 /**
@@ -299,19 +437,23 @@ export async function markChatTurnStreaming(turnId: string): Promise<void> {
  * persisted one. The turn-status `UPDATE` is left in place so any later
  * status transition (e.g. completed-after-cancel) still lands, but it's
  * idempotent by construction.
+ *
+ * Fail-soft (JOV-3956): persistence errors are logged and an ephemeral
+ * in-memory assistant row is returned so the stream path never dies with
+ * CHAT_STREAM_FAILED solely because a durable write failed.
  */
 async function fetchTerminalAssistantMessage(
   turnId: string
 ): Promise<ChatMessage | null> {
   const [message] = await db
-    .select()
+    .select(chatMessageCoreColumns)
     .from(chatMessages)
     .where(
       and(eq(chatMessages.turnId, turnId), eq(chatMessages.role, 'assistant'))
     )
     .orderBy(asc(chatMessages.createdAt))
     .limit(1);
-  return message ?? null;
+  return message ? toChatMessage(message) : null;
 }
 
 export async function persistTerminalAssistantMessage(input: {
@@ -323,14 +465,63 @@ export async function persistTerminalAssistantMessage(input: {
   readonly errorCode?: string | null;
   readonly errorMessage?: string | null;
 }): Promise<ChatMessage> {
-  const now = new Date();
+  try {
+    const now = new Date();
 
-  const existing = await fetchTerminalAssistantMessage(input.turnId);
-  if (existing) {
-    // Another terminal path already persisted an assistant message for
-    // this turn. Do not insert a second row. We still allow the turn
-    // status to advance (e.g. a slower error handler arrives after a
-    // successful onFinish) but never duplicate the message row.
+    const existing = await fetchTerminalAssistantMessage(input.turnId);
+    if (existing) {
+      // Another terminal path already persisted an assistant message for
+      // this turn. Do not insert a second row. We still allow the turn
+      // status to advance (e.g. a slower error handler arrives after a
+      // successful onFinish) but never duplicate the message row.
+      await db
+        .update(chatTurns)
+        .set({
+          status: input.status,
+          errorCode: input.errorCode ?? null,
+          errorMessage: input.errorMessage ?? null,
+          completedAt: now,
+          updatedAt: now,
+        })
+        .where(eq(chatTurns.id, input.turnId));
+
+      await db
+        .update(chatConversations)
+        .set({ updatedAt: now })
+        .where(eq(chatConversations.id, input.conversationId));
+
+      return existing;
+    }
+
+    const [messageRow] = await db
+      .insert(chatMessages)
+      .values({
+        conversationId: input.conversationId,
+        turnId: input.turnId,
+        role: 'assistant',
+        content: input.content,
+        toolCalls:
+          input.toolCalls && input.toolCalls.length > 0
+            ? input.toolCalls
+            : null,
+        createdAt: now,
+      })
+      .returning(chatMessageCoreColumns);
+
+    // Defensive: if the race fell through (parallel inserts between the
+    // SELECT and INSERT — possible under serverless concurrency), re-fetch
+    // and prefer the earliest assistant row so the rest of the system
+    // keeps a single terminal message per turn.
+    if (!messageRow) {
+      const racedExisting = await fetchTerminalAssistantMessage(input.turnId);
+      if (racedExisting) {
+        return racedExisting;
+      }
+      throw new Error('Failed to persist terminal assistant message');
+    }
+
+    const message = toChatMessage(messageRow);
+
     await db
       .update(chatTurns)
       .set({
@@ -347,51 +538,23 @@ export async function persistTerminalAssistantMessage(input: {
       .set({ updatedAt: now })
       .where(eq(chatConversations.id, input.conversationId));
 
-    return existing;
+    return message;
+  } catch (error) {
+    // Fail-soft: durable write failures must not kill the stream with
+    // CHAT_STREAM_FAILED (migration drift / transient DB — JOV-3956).
+    logger.error(
+      'Chat terminal assistant persist failed',
+      {
+        conversationId: input.conversationId,
+        turnId: input.turnId,
+        status: input.status,
+        errorCode: input.errorCode ?? null,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'chat/turns'
+    );
+    return ephemeralAssistantMessage(input);
   }
-
-  const [message] = await db
-    .insert(chatMessages)
-    .values({
-      conversationId: input.conversationId,
-      turnId: input.turnId,
-      role: 'assistant',
-      content: input.content,
-      toolCalls:
-        input.toolCalls && input.toolCalls.length > 0 ? input.toolCalls : null,
-      createdAt: now,
-    })
-    .returning();
-
-  // Defensive: if the race fell through (parallel inserts between the
-  // SELECT and INSERT — possible under serverless concurrency), re-fetch
-  // and prefer the earliest assistant row so the rest of the system
-  // keeps a single terminal message per turn.
-  if (!message) {
-    const racedExisting = await fetchTerminalAssistantMessage(input.turnId);
-    if (racedExisting) {
-      return racedExisting;
-    }
-    throw new Error('Failed to persist terminal assistant message');
-  }
-
-  await db
-    .update(chatTurns)
-    .set({
-      status: input.status,
-      errorCode: input.errorCode ?? null,
-      errorMessage: input.errorMessage ?? null,
-      completedAt: now,
-      updatedAt: now,
-    })
-    .where(eq(chatTurns.id, input.turnId));
-
-  await db
-    .update(chatConversations)
-    .set({ updatedAt: now })
-    .where(eq(chatConversations.id, input.conversationId));
-
-  return message;
 }
 
 export function isInFlightChatTurn(turn: ChatTurn): boolean {

--- a/apps/web/lib/rate-limit/index.ts
+++ b/apps/web/lib/rate-limit/index.ts
@@ -149,6 +149,7 @@ export type {
 } from './types';
 // Utilities
 export {
+  allowIfRateLimitBackendDegraded,
   createRateLimitHeaders,
   createRateLimitHeadersFromStatus,
   createRateLimitKey,

--- a/apps/web/lib/rate-limit/limiters.ts
+++ b/apps/web/lib/rate-limit/limiters.ts
@@ -10,6 +10,7 @@ import { RATE_LIMITERS } from './config';
 import { createPlanAwareRateLimiter } from './plan-aware-limiter';
 import { createRateLimiter, RateLimiter } from './rate-limiter';
 import type { PlanAwareRateLimiter, RateLimitResult } from './types';
+import { allowIfRateLimitBackendDegraded } from './utils';
 
 // ============================================================================
 // Authentication & User Operations
@@ -594,24 +595,50 @@ export async function checkAiChatRateLimit(
  * Check AI chat rate limits for a specific plan.
  * Applies both the hourly burst limiter (all plans) and the daily plan quota.
  * Returns the first failure or success if all pass.
+ *
+ * Fail-open when the durable rate-limit backend is degraded/unavailable
+ * (archived Upstash, circuit open → per-instance memory). A healthy Redis
+ * denial still blocks. Never throws — chat must not die with CHAT_STREAM_FAILED
+ * because the limiter path blew up (JOV-3956 / JOV-3929).
  */
 export async function checkAiChatRateLimitForPlan(
   userId: string,
   plan: string | null
 ): Promise<RateLimitResult> {
-  // 1. Check hourly burst limiter (applies to all plans)
-  const burstResult = await checkRateLimit(
-    aiChatLimiter,
-    userId,
-    'Too many messages in a short time. Please wait a moment.'
-  );
-  if (!burstResult.success) {
-    return burstResult;
-  }
+  try {
+    // 1. Check hourly burst limiter (applies to all plans)
+    const burstResult = await checkRateLimit(
+      aiChatLimiter,
+      userId,
+      'Too many messages in a short time. Please wait a moment.'
+    );
+    const burstAllowed = allowIfRateLimitBackendDegraded(burstResult, {
+      limiter: 'ai-chat-burst',
+      userId,
+      plan,
+    });
+    if (!burstAllowed.success) {
+      return burstAllowed;
+    }
 
-  // 2. Check daily plan-specific quota using the plan-aware limiter
-  const dailyResult = await aiChatDailyPlanAwareLimiter.limit(userId, plan);
-  return dailyResult;
+    // 2. Check daily plan-specific quota using the plan-aware limiter
+    const dailyResult = await aiChatDailyPlanAwareLimiter.limit(userId, plan);
+    return allowIfRateLimitBackendDegraded(dailyResult, {
+      limiter: 'ai-chat-daily',
+      userId,
+      plan,
+    });
+  } catch {
+    // Unexpected limiter failure (should be rare — RateLimiter already
+    // catches Redis errors). Fail open so chat stays available.
+    return {
+      success: true,
+      limit: 0,
+      remaining: 0,
+      reset: new Date(),
+      degraded: true,
+    };
+  }
 }
 
 // ============================================================================

--- a/apps/web/lib/rate-limit/utils.ts
+++ b/apps/web/lib/rate-limit/utils.ts
@@ -4,7 +4,50 @@
  * Shared utilities for rate limiting including IP extraction and header generation.
  */
 
+import * as Sentry from '@sentry/nextjs';
 import type { RateLimitResult, RateLimitStatus } from './types';
+
+/**
+ * Treat a denied rate-limit result as allowed when the durable backend was
+ * degraded or unavailable (Redis down / circuit open → per-instance memory).
+ *
+ * User-critical paths (auth, chat) must not hard-block on an advisory
+ * in-memory bucket during an Upstash outage (JOV-3929 / JOV-3956). Healthy
+ * Redis denials still enforce the limit.
+ */
+export function allowIfRateLimitBackendDegraded(
+  result: RateLimitResult,
+  context?: Readonly<Record<string, string | null | undefined>>
+): RateLimitResult {
+  if (result.success) {
+    return result;
+  }
+
+  const backendDegraded =
+    result.unavailable === true || result.degraded === true;
+  if (!backendDegraded) {
+    return result;
+  }
+
+  Sentry.addBreadcrumb({
+    category: 'rate-limit',
+    message: 'Rate-limit backend degraded — treating limit as advisory',
+    level: 'warning',
+    data: {
+      ...context,
+      limit: result.limit,
+      remaining: result.remaining,
+      unavailable: result.unavailable === true,
+      degraded: result.degraded === true,
+    },
+  });
+
+  return {
+    ...result,
+    success: true,
+    reason: undefined,
+  };
+}
 
 /**
  * Extract client IP address from request headers

--- a/apps/web/tests/unit/chat/turns.test.ts
+++ b/apps/web/tests/unit/chat/turns.test.ts
@@ -65,6 +65,15 @@ vi.mock('@/lib/db', () => ({
   },
 }));
 
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 vi.mock('@/lib/db/schema/chat', () => ({
   chatConversations: {
     id: 'conversationId',
@@ -83,6 +92,8 @@ vi.mock('@/lib/db/schema/chat', () => ({
     content: 'content',
     toolCalls: 'toolCalls',
     createdAt: 'createdAt',
+    assistantSource: 'assistantSource',
+    scriptLineKey: 'scriptLineKey',
   },
   chatTurns: {
     id: 'turnId',
@@ -99,6 +110,7 @@ vi.mock('@/lib/db/schema/chat', () => ({
     updatedAt: 'updatedAt',
     startedAt: 'startedAt',
     completedAt: 'completedAt',
+    model: 'model',
   },
 }));
 
@@ -262,6 +274,7 @@ describe('chat turn service', () => {
       id: 'msg-existing',
       conversationId: 'conv-1',
       turnId: 'turn-1',
+      clientMessageId: null,
       role: 'assistant',
       content: 'Already saved.',
       toolCalls: null,
@@ -285,8 +298,13 @@ describe('chat turn service', () => {
       content: 'A second terminal write attempt',
     });
 
-    // Returns the existing row instead of inserting a duplicate.
-    expect(result).toEqual(existingAssistant);
+    // Returns the existing row (with core-column null attribution fields)
+    // instead of inserting a duplicate.
+    expect(result).toEqual({
+      ...existingAssistant,
+      assistantSource: null,
+      scriptLineKey: null,
+    });
     // Critical JOV-2275 invariant: no chatMessages insert is issued when
     // a terminal assistant row already exists for this turn.
     expect(hoisted.insertMock).not.toHaveBeenCalled();
@@ -308,6 +326,7 @@ describe('chat turn service', () => {
         id: 'msg-new',
         conversationId: 'conv-1',
         turnId: 'turn-1',
+        clientMessageId: null,
         role: 'assistant',
         content: 'Hello!',
         toolCalls: null,
@@ -326,7 +345,57 @@ describe('chat turn service', () => {
     });
 
     expect(result.id).toBe('msg-new');
+    expect(result.assistantSource).toBeNull();
+    expect(result.scriptLineKey).toBeNull();
     expect(hoisted.insertMock).toHaveBeenCalled();
     expect(hoisted.updateMock).toHaveBeenCalled();
+  });
+
+  it('persistTerminalAssistantMessage fails soft when the DB write throws', async () => {
+    hoisted.selectOrderByMock.mockReturnValueOnce({
+      limit: vi.fn().mockRejectedValueOnce(new Error('column does not exist')),
+      then: (onFulfilled: (value: unknown) => unknown, onRejected) =>
+        Promise.reject(new Error('column does not exist')).then(
+          onFulfilled,
+          onRejected
+        ),
+    });
+
+    const { logger } = await import('@/lib/utils/logger');
+    const { persistTerminalAssistantMessage } = await import(
+      '@/lib/chat/turns'
+    );
+    const result = await persistTerminalAssistantMessage({
+      conversationId: 'conv-1',
+      turnId: 'turn-1',
+      status: 'failed_model_error',
+      content: 'Stream text still delivered.',
+      errorCode: 'CHAT_STREAM_FAILED',
+    });
+
+    // Ephemeral row so callers never throw and kill the stream.
+    expect(result.id).toBe('ephemeral-turn-1');
+    expect(result.content).toBe('Stream text still delivered.');
+    expect(logger.error).toHaveBeenCalledWith(
+      'Chat terminal assistant persist failed',
+      expect.objectContaining({ turnId: 'turn-1' }),
+      'chat/turns'
+    );
+  });
+
+  it('markChatTurnStreaming fails soft when the update throws', async () => {
+    hoisted.updateMock.mockImplementationOnce(() => {
+      throw new Error('db unavailable');
+    });
+
+    const { logger } = await import('@/lib/utils/logger');
+    const { markChatTurnStreaming } = await import('@/lib/chat/turns');
+
+    await expect(markChatTurnStreaming('turn-1')).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Chat turn streaming mark failed',
+      expect.objectContaining({ turnId: 'turn-1' }),
+      'chat/turns'
+    );
   });
 });

--- a/apps/web/tests/unit/lib/rate-limit/limiters.test.ts
+++ b/apps/web/tests/unit/lib/rate-limit/limiters.test.ts
@@ -682,6 +682,46 @@ describe('limiters.ts', () => {
         'You have reached your daily AI message limit. Your quota resets tomorrow.'
       );
     });
+
+    it('fails open when the burst limit is denied by a degraded backend', async () => {
+      mockLimit
+        .mockResolvedValueOnce(makeDeniedResult({ degraded: true }))
+        .mockResolvedValueOnce(makeAllowedResult());
+
+      const { checkAiChatRateLimitForPlan } = await import(
+        '@/lib/rate-limit/limiters'
+      );
+      const result = await checkAiChatRateLimitForPlan('user-1', 'pro');
+
+      expect(result.success).toBe(true);
+      // burst (degraded → allow) + daily
+      expect(mockLimit).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails open when the daily limit is denied by an unavailable backend', async () => {
+      mockLimit
+        .mockResolvedValueOnce(makeAllowedResult())
+        .mockResolvedValueOnce(makeDeniedResult({ unavailable: true }));
+
+      const { checkAiChatRateLimitForPlan } = await import(
+        '@/lib/rate-limit/limiters'
+      );
+      const result = await checkAiChatRateLimitForPlan('user-1', 'free');
+
+      expect(result.success).toBe(true);
+    });
+
+    it('fails open when the limiter throws unexpectedly', async () => {
+      mockLimit.mockRejectedValue(new Error('redis circuit exploded'));
+
+      const { checkAiChatRateLimitForPlan } = await import(
+        '@/lib/rate-limit/limiters'
+      );
+      const result = await checkAiChatRateLimitForPlan('user-1', 'pro');
+
+      expect(result.success).toBe(true);
+      expect(result.degraded).toBe(true);
+    });
   });
 
   // =========================================================================

--- a/apps/web/tests/unit/lib/rate-limit/utils-degraded.test.ts
+++ b/apps/web/tests/unit/lib/rate-limit/utils-degraded.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@sentry/nextjs', () => ({
+  addBreadcrumb: vi.fn(),
+}));
+
+import * as Sentry from '@sentry/nextjs';
+import type { RateLimitResult } from '@/lib/rate-limit/types';
+import { allowIfRateLimitBackendDegraded } from '@/lib/rate-limit/utils';
+
+function denied(overrides?: Partial<RateLimitResult>): RateLimitResult {
+  return {
+    success: false,
+    limit: 10,
+    remaining: 0,
+    reset: new Date(Date.now() + 60_000),
+    reason: 'blocked',
+    ...overrides,
+  };
+}
+
+describe('allowIfRateLimitBackendDegraded', () => {
+  it('passes through successful results unchanged', () => {
+    const allowed: RateLimitResult = {
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: new Date(),
+    };
+    expect(allowIfRateLimitBackendDegraded(allowed)).toBe(allowed);
+  });
+
+  it('enforces denials from a healthy backend', () => {
+    const result = denied();
+    expect(allowIfRateLimitBackendDegraded(result)).toEqual(result);
+  });
+
+  it('allows degraded memory-fallback denials and breadcrumbs', () => {
+    const result = allowIfRateLimitBackendDegraded(denied({ degraded: true }), {
+      limiter: 'ai-chat',
+    });
+    expect(result.success).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(result.degraded).toBe(true);
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'rate-limit',
+        level: 'warning',
+      })
+    );
+  });
+
+  it('allows unavailable-backend denials', () => {
+    const result = allowIfRateLimitBackendDegraded(
+      denied({ unavailable: true })
+    );
+    expect(result.success).toBe(true);
+    expect(result.unavailable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Rate limits fail-open when Redis backend is degraded/unavailable (no throw → CHAT_STREAM_FAILED)
- Chat turn reserve/persist fail-soft so the stream can continue
- Core-column selects for turn rows (migration-drift safety)
- Unit coverage for degraded rate-limit + turns paths

## Linear
Fixes JOV-3956  
JOV-3986 canceled as duplicate  
JOV-3929 remains human Upstash provision

## Verification
- `vitest` turns + rate-limit (64 tests) pass
- Biome clean on touched files
- Typecheck green (singleflight)

## Cost Impact
- None (fewer hard failures; may slightly increase chat load when Redis is down)