### PR TITLE
feat(links,merch): social shortcuts + Printful cost hydration (JOV-3924, JOV-3393)

### DIFF
--- a/apps/web/app/[username]/s/[platform]/route.ts
+++ b/apps/web/app/[username]/s/[platform]/route.ts
@@ -1,0 +1,199 @@
+/**
+ * Social shortcut redirects: jov.ie/{username}/s/{platform}
+ *
+ * Found social link → 301 to the artist's URL.
+ * Profile exists but platform missing/unknown → 302 to /{username} (no 404s for fans).
+ * Unknown username → 404.
+ *
+ * Click demand is recorded best-effort (does not block the redirect).
+ *
+ * @see JOV-3924
+ */
+
+import { and, sql as drizzleSql, eq, inArray } from 'drizzle-orm';
+import { after, type NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { recordClickEvent } from '@/lib/db/queries/analytics';
+import { socialLinks } from '@/lib/db/schema/links';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { captureError } from '@/lib/error-tracking';
+import { publicClickLimiter } from '@/lib/rate-limit';
+import { resolveSocialShortcutPlatforms } from '@/lib/social/shortcut-platforms';
+import { detectBot } from '@/lib/utils/bot-detection';
+import { extractClientIP } from '@/lib/utils/ip-extraction';
+import { validateSocialLinkUrl } from '@/lib/utils/url-validation';
+
+export const runtime = 'nodejs';
+
+const NO_STORE = {
+  'Cache-Control': 'no-cache, no-store, must-revalidate',
+  Pragma: 'no-cache',
+  Expires: '0',
+  'X-Robots-Tag': 'noindex, nofollow, nosnippet, noarchive',
+  'Referrer-Policy': 'no-referrer',
+} as const;
+
+function isSafeRedirectDestination(url: string): boolean {
+  const validation = validateSocialLinkUrl(url);
+  if (!validation.valid) return false;
+  try {
+    const parsed = new URL(url);
+    if (!['http:', 'https:'].includes(parsed.protocol)) return false;
+    return !url.toLowerCase().includes('javascript:');
+  } catch {
+    return false;
+  }
+}
+
+function profileRedirect(request: NextRequest, username: string): NextResponse {
+  const dest = new URL(`/${username}`, request.url);
+  return NextResponse.redirect(dest, { status: 302, headers: NO_STORE });
+}
+
+function notFoundResponse(): NextResponse {
+  return new NextResponse('Not Found', {
+    status: 404,
+    headers: NO_STORE,
+  });
+}
+
+async function recordShortcutAnalytics(input: {
+  readonly creatorProfileId: string;
+  readonly socialLinkId: string;
+  readonly platform: string;
+  readonly slug: string;
+  readonly destinationUrl: string;
+  readonly isBot: boolean;
+  readonly clientIP: string;
+  readonly userAgent: string | null;
+  readonly referrer: string | null;
+}): Promise<void> {
+  await Promise.all([
+    db
+      .update(socialLinks)
+      .set({
+        clicks: drizzleSql`${socialLinks.clicks} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(eq(socialLinks.id, input.socialLinkId)),
+    recordClickEvent(input.creatorProfileId, 'social', input.socialLinkId, {
+      isBot: input.isBot,
+      ipAddress: input.clientIP,
+      userAgent: input.userAgent,
+      referrer: input.referrer,
+      metadata: {
+        source: 'social_shortcut',
+        slug: input.slug,
+        platform: input.platform,
+        destinationUrl: input.destinationUrl,
+      },
+    }),
+  ]);
+}
+
+export async function GET(
+  request: NextRequest,
+  {
+    params,
+  }: {
+    readonly params: Promise<{
+      readonly username: string;
+      readonly platform: string;
+    }>;
+  }
+) {
+  const { username: rawUsername, platform: rawPlatform } = await params;
+  const username = rawUsername?.trim() ?? '';
+  if (!username) return notFoundResponse();
+
+  const usernameNormalized = username.toLowerCase();
+  const platformKey = rawPlatform?.trim() ?? '';
+  const platforms = resolveSocialShortcutPlatforms(platformKey);
+
+  try {
+    const [profile] = await db
+      .select({
+        id: creatorProfiles.id,
+        username: creatorProfiles.username,
+        usernameNormalized: creatorProfiles.usernameNormalized,
+      })
+      .from(creatorProfiles)
+      .where(eq(creatorProfiles.usernameNormalized, usernameNormalized))
+      .limit(1);
+
+    if (!profile) {
+      return notFoundResponse();
+    }
+
+    // Soft-degrade: unknown slug or missing configured link → profile page.
+    if (!platforms || platforms.length === 0) {
+      return profileRedirect(request, profile.username);
+    }
+
+    const [link] = await db
+      .select({
+        id: socialLinks.id,
+        platform: socialLinks.platform,
+        url: socialLinks.url,
+      })
+      .from(socialLinks)
+      .where(
+        and(
+          eq(socialLinks.creatorProfileId, profile.id),
+          inArray(socialLinks.platform, [...platforms]),
+          eq(socialLinks.isActive, true),
+          eq(socialLinks.state, 'active')
+        )
+      )
+      .limit(1);
+
+    if (!link || !isSafeRedirectDestination(link.url)) {
+      return profileRedirect(request, profile.username);
+    }
+
+    const clientIP = extractClientIP(request.headers);
+    const userAgent = request.headers.get('user-agent');
+    const referrer = request.headers.get('referer');
+    const botDetection = detectBot(
+      request,
+      `/${profile.usernameNormalized}/s/${platformKey}`
+    );
+
+    const rateLimitResult = await publicClickLimiter.limit(clientIP);
+    if (rateLimitResult.success) {
+      after(() =>
+        recordShortcutAnalytics({
+          creatorProfileId: profile.id,
+          socialLinkId: link.id,
+          platform: link.platform,
+          slug: platformKey.toLowerCase(),
+          destinationUrl: link.url,
+          isBot: botDetection.isBot,
+          clientIP,
+          userAgent,
+          referrer,
+        }).catch(error =>
+          captureError('Social shortcut analytics failed', error, {
+            route: '/[username]/s/[platform]',
+            username: profile.usernameNormalized,
+            platform: platformKey,
+            socialLinkId: link.id,
+          })
+        )
+      );
+    }
+
+    return NextResponse.redirect(link.url, {
+      status: 301,
+      headers: NO_STORE,
+    });
+  } catch (error) {
+    await captureError('Social shortcut redirect failed', error, {
+      route: '/[username]/s/[platform]',
+      username: usernameNormalized,
+      platform: platformKey,
+    });
+    // Prefer soft degrade over 500 for fans.
+    return profileRedirect(request, username);
+  }
+}

--- a/apps/web/lib/merch/design-generation.ts
+++ b/apps/web/lib/merch/design-generation.ts
@@ -29,6 +29,7 @@ import {
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { env } from '@/lib/env-server';
 import { logger } from '@/lib/utils/logger';
+import { resolveMerchCatalogSelection } from './catalog';
 import { MERCH_DEFAULT_PRINTFUL_PRODUCT } from './default-catalog';
 import { generatePrintGraphic } from './graphic-engine';
 import { attachMockupsToDesignOption, generateProductMockups } from './mockups';
@@ -115,7 +116,7 @@ function buildImagePrompt(
   ].join(' ');
 }
 
-function defaultPricing() {
+function fallbackPricing() {
   return buildMerchPricingSnapshot({
     retailPriceCents: calculateRecommendedSalePriceCents(
       MERCH_DEFAULT_PRINTFUL_PRODUCT_COST_CENTS,
@@ -126,6 +127,45 @@ function defaultPricing() {
     printfulCostSource: 'jovie_default',
     printfulCostUpdatedAt: null,
   });
+}
+
+/**
+ * Prefer live Printful catalog economics so generated options can publish.
+ * Falls back to jovie_default (draft-only) when Printful is unavailable.
+ */
+async function resolveGenerationPricing(prompt: string) {
+  try {
+    const catalog = await resolveMerchCatalogSelection(prompt);
+    return {
+      pricing: catalog.pricing,
+      productionWarnings: catalog.providerWarnings,
+      productType: catalog.productType,
+      productName: catalog.productName,
+      catalogProductId: catalog.catalogProductId,
+      catalogVariantIds: catalog.catalogVariantIds,
+      variantMap: catalog.variantMap,
+      colorway: catalog.colorway,
+      sizes: catalog.sizes,
+      placements: catalog.placements,
+      technique: catalog.technique,
+    };
+  } catch {
+    return {
+      pricing: fallbackPricing(),
+      productionWarnings: [] as string[],
+      productType: MERCH_DEFAULT_PRINTFUL_PRODUCT.productType,
+      productName: MERCH_DEFAULT_PRINTFUL_PRODUCT.productName,
+      catalogProductId: MERCH_DEFAULT_PRINTFUL_PRODUCT.catalogProductId,
+      catalogVariantIds: Object.values(
+        MERCH_DEFAULT_PRINTFUL_PRODUCT.variantMap
+      ),
+      variantMap: MERCH_DEFAULT_PRINTFUL_PRODUCT.variantMap,
+      colorway: MERCH_DEFAULT_PRINTFUL_PRODUCT.colorway,
+      sizes: MERCH_DEFAULT_PRINTFUL_PRODUCT.sizes,
+      placements: MERCH_DEFAULT_PRINTFUL_PRODUCT.placements,
+      technique: MERCH_DEFAULT_PRINTFUL_PRODUCT.technique,
+    };
+  }
 }
 
 /**
@@ -234,7 +274,10 @@ export async function generateMerchDesigns(params: {
   const name = await artistName(params.profileId);
   const generationId = randomUUID();
   const count = Math.min(Math.max(params.count ?? DEFAULT_DESIGN_COUNT, 1), 4);
-  const pricing = defaultPricing();
+  // Resolve live Printful economics up front so selected designs can go live
+  // without a separate cost-hydration step (JOV-3393 demo path).
+  const catalog = await resolveGenerationPricing(params.prompt);
+  const pricing = catalog.pricing;
 
   await db.insert(merchGenerationBatches).values({
     id: generationId,
@@ -282,18 +325,15 @@ export async function generateMerchDesigns(params: {
             status: 'candidate',
             designLane: 'fashion_graphic_item',
             designName,
-            productType: MERCH_DEFAULT_PRINTFUL_PRODUCT.productType,
-            printfulProductName: MERCH_DEFAULT_PRINTFUL_PRODUCT.productName,
-            printfulCatalogProductId:
-              MERCH_DEFAULT_PRINTFUL_PRODUCT.catalogProductId,
-            printfulCatalogVariantIds: Object.values(
-              MERCH_DEFAULT_PRINTFUL_PRODUCT.variantMap
-            ),
-            variantMap: MERCH_DEFAULT_PRINTFUL_PRODUCT.variantMap,
-            colorway: MERCH_DEFAULT_PRINTFUL_PRODUCT.colorway,
-            availableSizes: MERCH_DEFAULT_PRINTFUL_PRODUCT.sizes,
-            placements: MERCH_DEFAULT_PRINTFUL_PRODUCT.placements,
-            technique: MERCH_DEFAULT_PRINTFUL_PRODUCT.technique,
+            productType: catalog.productType,
+            printfulProductName: catalog.productName,
+            printfulCatalogProductId: catalog.catalogProductId,
+            printfulCatalogVariantIds: catalog.catalogVariantIds,
+            variantMap: catalog.variantMap,
+            colorway: catalog.colorway,
+            availableSizes: catalog.sizes,
+            placements: catalog.placements,
+            technique: catalog.technique,
             retailPriceCents: pricing.retailPriceCents,
             estimatedPrintfulProductCostCents:
               pricing.estimatedPrintfulProductCostCents,
@@ -306,7 +346,13 @@ export async function generateMerchDesigns(params: {
             whyItFits: 'Illustrated graphic generated for this artist.',
             mockupUrls: [previewUrl],
             printFileUrls: [previewUrl],
-            productionWarnings: [],
+            // Catalog warnings about unavailability stay; cost-source warnings
+            // that mark draft-only should not block when Printful is healthy.
+            productionWarnings: catalog.productionWarnings.filter(
+              warning =>
+                !warning.toLowerCase().includes('printful is not configured') &&
+                !warning.toLowerCase().includes('catalog pricing unavailable')
+            ),
             qualityReview: {
               copyrightRisk: 'low',
               typography: 'generated',
@@ -316,7 +362,7 @@ export async function generateMerchDesigns(params: {
               styleLane: 'fashion_graphic_item',
               typographyStyle: direction.label,
               graphicDensity: 'medium',
-              garmentColor: MERCH_DEFAULT_PRINTFUL_PRODUCT.colorway,
+              garmentColor: catalog.colorway,
               motifs: [direction.label],
               selectedOverOptionIds: [],
               rejectedAttributes: [],

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -726,6 +726,127 @@ async function getOptionForSelection(params: {
   return option;
 }
 
+/**
+ * Ensure a design option carries live Printful economics before card create /
+ * publish. Phase-A carousel used to stamp jovie_default costs, which hard-blocks
+ * sellability forever (JOV-3393). Idempotent when already printful-sourced.
+ */
+async function hydrateOptionPrintfulEconomics(
+  option: MerchDesignOption
+): Promise<MerchDesignOption> {
+  if (option.pricing.printfulCostSource === 'printful') {
+    return option;
+  }
+
+  const catalog = await resolveMerchCatalogSelection(
+    option.productType || option.printfulProductName || option.designName
+  );
+  if (catalog.pricing.printfulCostSource !== 'printful') {
+    return option;
+  }
+
+  const pricing = catalog.pricing;
+  const grossMargin =
+    pricing.retailPriceCents -
+    pricing.estimatedPrintfulProductCostCents -
+    pricing.stripeFeeEstimateCents -
+    pricing.refundReserveCents;
+
+  const [updated] = await db
+    .update(merchDesignOptions)
+    .set({
+      productType: catalog.productType,
+      printfulProductName: catalog.productName,
+      printfulCatalogProductId: catalog.catalogProductId,
+      printfulCatalogVariantIds: catalog.catalogVariantIds,
+      variantMap: catalog.variantMap,
+      colorway: catalog.colorway,
+      availableSizes: catalog.sizes,
+      placements: catalog.placements,
+      technique: catalog.technique,
+      retailPriceCents: pricing.retailPriceCents,
+      estimatedPrintfulProductCostCents:
+        pricing.estimatedPrintfulProductCostCents,
+      estimatedShippingCostCents: pricing.estimatedShippingCostCents,
+      estimatedGrossMarginCents: grossMargin,
+      artistShareCents: pricing.artistPayoutPerUnitEstimateCents,
+      jovieShareCents: pricing.jovieMarginPerUnitEstimateCents,
+      pricing,
+      // Drop draft-only cost warnings once real Printful costs land.
+      productionWarnings: option.productionWarnings.filter(
+        warning =>
+          !warning.toLowerCase().includes('printful is not configured') &&
+          !warning.toLowerCase().includes('catalog pricing unavailable') &&
+          !warning.toLowerCase().includes('draft-only')
+      ),
+      updatedAt: new Date(),
+    })
+    .where(eq(merchDesignOptions.id, option.id))
+    .returning();
+
+  return updated ?? option;
+}
+
+/**
+ * Refresh merch card economics from Printful when still on jovie_default so
+ * publish / checkout sellability can pass (JOV-3393).
+ */
+async function hydrateMerchCardPrintfulEconomics(
+  card: MerchCard
+): Promise<MerchCard> {
+  if (card.printful.catalogCostSource === 'printful') {
+    return card;
+  }
+
+  const catalog = await resolveMerchCatalogSelection(
+    card.productType || card.title
+  );
+  if (catalog.pricing.printfulCostSource !== 'printful') {
+    return card;
+  }
+
+  const pricing = catalog.pricing;
+  const printful: MerchPrintfulSnapshot = {
+    ...card.printful,
+    catalogProductId: catalog.catalogProductId,
+    catalogVariantIds: catalog.catalogVariantIds,
+    variantMap: catalog.variantMap,
+    placements: catalog.placements,
+    techniques: [catalog.technique],
+    catalogCostSource: 'printful',
+    catalogCostUpdatedAt:
+      pricing.printfulCostUpdatedAt ?? new Date().toISOString(),
+    catalogProductName: catalog.productName,
+    providerWarnings: (card.printful.providerWarnings ?? []).filter(
+      warning =>
+        !warning.toLowerCase().includes('printful is not configured') &&
+        !warning.toLowerCase().includes('catalog pricing unavailable') &&
+        !warning.toLowerCase().includes('draft-only')
+    ),
+  };
+
+  const [updated] = await db
+    .update(merchCards)
+    .set({
+      productType: catalog.productType,
+      printful,
+      retailPriceCents: pricing.retailPriceCents,
+      estimatedPrintfulProductCostCents:
+        pricing.estimatedPrintfulProductCostCents,
+      estimatedShippingCostCents: pricing.estimatedShippingCostCents,
+      artistRoyaltyRateBps: pricing.artistRoyaltyRateBps,
+      artistPayoutPerUnitEstimateCents:
+        pricing.artistPayoutPerUnitEstimateCents,
+      jovieMarginPerUnitEstimateCents: pricing.jovieMarginPerUnitEstimateCents,
+      pricing,
+      updatedAt: new Date(),
+    })
+    .where(eq(merchCards.id, card.id))
+    .returning();
+
+  return updated ?? card;
+}
+
 export async function selectMerchDesign(params: {
   readonly generationId: string;
   readonly clerkUserId: string;
@@ -733,11 +854,12 @@ export async function selectMerchDesign(params: {
   readonly optionNumber?: number | null;
   readonly publish?: boolean;
 }): Promise<MerchSelectionResult> {
-  const selected = await getOptionForSelection(params);
+  const rawSelected = await getOptionForSelection(params);
   await assertCanManageMerchProfile(
-    selected.creatorProfileId,
+    rawSelected.creatorProfileId,
     params.clerkUserId
   );
+  const selected = await hydrateOptionPrintfulEconomics(rawSelected);
   const profile = await getCreatorProfileForMerch(selected.creatorProfileId);
   const publishSellability = getDesignOptionSellability(selected);
   const shouldPublish = params.publish === true && publishSellability.sellable;
@@ -1083,7 +1205,9 @@ export async function publishMerchCard(params: {
     )
     .limit(1);
   if (!current) throw new Error('Merch card not found');
-  validateMerchCardForPublishing(current);
+  // Cards generated before Printful cost hydration can still publish once costs refresh.
+  const hydrated = await hydrateMerchCardPrintfulEconomics(current);
+  validateMerchCardForPublishing(hydrated);
 
   const [card] = await db
     .update(merchCards)

--- a/apps/web/lib/social/shortcut-platforms.test.ts
+++ b/apps/web/lib/social/shortcut-platforms.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveSocialShortcutPlatforms,
+  SOCIAL_SHORTCUT_SLUG_MAP,
+  SOCIAL_SHORTCUT_SLUGS,
+} from './shortcut-platforms';
+
+describe('resolveSocialShortcutPlatforms', () => {
+  it('maps all six short slugs to canonical platform ids', () => {
+    expect(resolveSocialShortcutPlatforms('ig')).toEqual(['instagram']);
+    expect(resolveSocialShortcutPlatforms('tt')).toEqual(['tiktok']);
+    expect(resolveSocialShortcutPlatforms('x')).toEqual(['x', 'twitter']);
+    expect(resolveSocialShortcutPlatforms('yt')).toEqual(['youtube']);
+    expect(resolveSocialShortcutPlatforms('sp')).toEqual(['spotify']);
+    expect(resolveSocialShortcutPlatforms('web')).toEqual(['website']);
+  });
+
+  it('accepts full platform name aliases', () => {
+    expect(resolveSocialShortcutPlatforms('instagram')).toEqual(['instagram']);
+    expect(resolveSocialShortcutPlatforms('TikTok')).toEqual(['tiktok']);
+    expect(resolveSocialShortcutPlatforms('twitter')).toEqual(['x', 'twitter']);
+    expect(resolveSocialShortcutPlatforms('YOUTUBE')).toEqual(['youtube']);
+    expect(resolveSocialShortcutPlatforms('spotify')).toEqual(['spotify']);
+    expect(resolveSocialShortcutPlatforms('website')).toEqual(['website']);
+  });
+
+  it('trims and lowercases input', () => {
+    expect(resolveSocialShortcutPlatforms('  IG  ')).toEqual(['instagram']);
+  });
+
+  it('returns null for empty or unknown slugs', () => {
+    expect(resolveSocialShortcutPlatforms(null)).toBeNull();
+    expect(resolveSocialShortcutPlatforms(undefined)).toBeNull();
+    expect(resolveSocialShortcutPlatforms('')).toBeNull();
+    expect(resolveSocialShortcutPlatforms('   ')).toBeNull();
+    expect(resolveSocialShortcutPlatforms('fb')).toBeNull();
+    expect(resolveSocialShortcutPlatforms('linkedin')).toBeNull();
+  });
+
+  it('exports the six short slugs as a stable list', () => {
+    expect(SOCIAL_SHORTCUT_SLUGS).toEqual(['ig', 'tt', 'x', 'yt', 'sp', 'web']);
+    expect(Object.keys(SOCIAL_SHORTCUT_SLUG_MAP)).toEqual(
+      SOCIAL_SHORTCUT_SLUGS
+    );
+  });
+});

--- a/apps/web/lib/social/shortcut-platforms.ts
+++ b/apps/web/lib/social/shortcut-platforms.ts
@@ -1,0 +1,58 @@
+/**
+ * Social shortcut slug map for jov.ie/{username}/s/{platform}.
+ *
+ * Short memorable slugs (ig, tt, x, …) resolve to one or more canonical
+ * `social_links.platform` ids. Full platform names are accepted as aliases.
+ *
+ * @see JOV-3924
+ */
+
+/** Canonical short slugs → social_links.platform ids to try (first match wins). */
+export const SOCIAL_SHORTCUT_SLUG_MAP = {
+  ig: ['instagram'],
+  tt: ['tiktok'],
+  x: ['x', 'twitter'],
+  yt: ['youtube'],
+  sp: ['spotify'],
+  web: ['website'],
+} as const satisfies Record<string, readonly string[]>;
+
+export type SocialShortcutSlug = keyof typeof SOCIAL_SHORTCUT_SLUG_MAP;
+
+/** Full platform name aliases accepted in addition to short slugs. */
+const PLATFORM_NAME_ALIASES: Readonly<Record<string, readonly string[]>> = {
+  instagram: SOCIAL_SHORTCUT_SLUG_MAP.ig,
+  tiktok: SOCIAL_SHORTCUT_SLUG_MAP.tt,
+  twitter: SOCIAL_SHORTCUT_SLUG_MAP.x,
+  youtube: SOCIAL_SHORTCUT_SLUG_MAP.yt,
+  spotify: SOCIAL_SHORTCUT_SLUG_MAP.sp,
+  website: SOCIAL_SHORTCUT_SLUG_MAP.web,
+};
+
+/**
+ * Normalize a path segment and resolve it to social_links.platform ids.
+ * Returns null for unknown / empty segments (caller should soft-redirect).
+ */
+export function resolveSocialShortcutPlatforms(
+  raw: string | null | undefined
+): readonly string[] | null {
+  if (!raw) return null;
+  const key = raw.trim().toLowerCase();
+  if (!key) return null;
+
+  if (Object.hasOwn(SOCIAL_SHORTCUT_SLUG_MAP, key)) {
+    return SOCIAL_SHORTCUT_SLUG_MAP[key as SocialShortcutSlug];
+  }
+
+  if (Object.hasOwn(PLATFORM_NAME_ALIASES, key)) {
+    return PLATFORM_NAME_ALIASES[key] ?? null;
+  }
+
+  // Unknown short/long slug — treat as soft miss (302 to profile), not hard 404.
+  return null;
+}
+
+/** All short slugs for docs / generators. */
+export const SOCIAL_SHORTCUT_SLUGS = Object.keys(
+  SOCIAL_SHORTCUT_SLUG_MAP
+) as SocialShortcutSlug[];

--- a/apps/web/tests/unit/app/username-s-platform-route.test.ts
+++ b/apps/web/tests/unit/app/username-s-platform-route.test.ts
@@ -1,0 +1,205 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const profile = {
+    id: 'profile_123',
+    username: 'tim',
+    usernameNormalized: 'tim',
+  };
+  const link = {
+    id: 'link_ig',
+    platform: 'instagram',
+    url: 'https://instagram.com/timwhite',
+  };
+
+  const profileLimit = vi.fn().mockResolvedValue([profile]);
+  const profileWhere = vi.fn().mockReturnValue({ limit: profileLimit });
+  const profileFrom = vi.fn().mockReturnValue({ where: profileWhere });
+
+  const linkLimit = vi.fn().mockResolvedValue([link]);
+  const linkWhere = vi.fn().mockReturnValue({ limit: linkLimit });
+  const linkFrom = vi.fn().mockReturnValue({ where: linkWhere });
+
+  let selectCall = 0;
+  const selectMock = vi.fn().mockImplementation(() => {
+    selectCall += 1;
+    return selectCall % 2 === 1 ? { from: profileFrom } : { from: linkFrom };
+  });
+
+  const updateWhere = vi.fn().mockResolvedValue(undefined);
+  const updateSet = vi.fn().mockReturnValue({ where: updateWhere });
+  const updateMock = vi.fn().mockReturnValue({ set: updateSet });
+
+  return {
+    profile,
+    link,
+    selectMock,
+    profileLimit,
+    linkLimit,
+    updateMock,
+    resetSelectCall: () => {
+      selectCall = 0;
+    },
+    after: vi.fn((fn: () => void) => {
+      void Promise.resolve().then(fn);
+    }),
+    publicClickLimiter: {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    },
+    detectBot: vi.fn().mockReturnValue({ isBot: false, reason: 'ok' }),
+    extractClientIP: vi.fn().mockReturnValue('1.2.3.4'),
+    captureError: vi.fn().mockResolvedValue(undefined),
+    validateSocialLinkUrl: vi.fn().mockReturnValue({ valid: true }),
+    recordClickEvent: vi.fn().mockResolvedValue({ id: 'click_1' }),
+  };
+});
+
+vi.mock('next/server', async () => {
+  const actual =
+    await vi.importActual<typeof import('next/server')>('next/server');
+  return {
+    ...actual,
+    after: mocks.after,
+  };
+});
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mocks.selectMock,
+    update: mocks.updateMock,
+  },
+}));
+
+vi.mock('@/lib/db/schema/links', () => ({
+  socialLinks: {
+    id: 'id',
+    creatorProfileId: 'creatorProfileId',
+    platform: 'platform',
+    url: 'url',
+    isActive: 'isActive',
+    state: 'state',
+    clicks: 'clicks',
+    updatedAt: 'updatedAt',
+  },
+}));
+
+vi.mock('@/lib/db/schema/profiles', () => ({
+  creatorProfiles: {
+    id: 'id',
+    username: 'username',
+    usernameNormalized: 'usernameNormalized',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => args),
+  eq: vi.fn((...args: unknown[]) => args),
+  inArray: vi.fn((...args: unknown[]) => args),
+  sql: vi.fn().mockReturnValue('sql'),
+}));
+
+vi.mock('@/lib/db/queries/analytics', () => ({
+  recordClickEvent: mocks.recordClickEvent,
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  publicClickLimiter: mocks.publicClickLimiter,
+}));
+
+vi.mock('@/lib/utils/bot-detection', () => ({
+  detectBot: mocks.detectBot,
+}));
+
+vi.mock('@/lib/utils/ip-extraction', () => ({
+  extractClientIP: mocks.extractClientIP,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mocks.captureError,
+}));
+
+vi.mock('@/lib/utils/url-validation', () => ({
+  validateSocialLinkUrl: mocks.validateSocialLinkUrl,
+}));
+
+import { GET } from '@/app/[username]/s/[platform]/route';
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(`https://jov.ie${path}`, {
+    headers: { 'user-agent': 'vitest' },
+  });
+}
+
+describe('GET /[username]/s/[platform]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resetSelectCall();
+    mocks.profileLimit.mockResolvedValue([mocks.profile]);
+    mocks.linkLimit.mockResolvedValue([mocks.link]);
+    mocks.publicClickLimiter.limit.mockResolvedValue({ success: true });
+    mocks.detectBot.mockReturnValue({ isBot: false, reason: 'ok' });
+    mocks.validateSocialLinkUrl.mockReturnValue({ valid: true });
+  });
+
+  it('301s to the artist social URL when the link exists', async () => {
+    const res = await GET(makeRequest('/tim/s/ig'), {
+      params: Promise.resolve({ username: 'tim', platform: 'ig' }),
+    });
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('https://instagram.com/timwhite');
+  });
+
+  it('302s to the profile when the platform link is missing', async () => {
+    mocks.linkLimit.mockResolvedValueOnce([]);
+
+    const res = await GET(makeRequest('/tim/s/ig'), {
+      params: Promise.resolve({ username: 'tim', platform: 'ig' }),
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://jov.ie/tim');
+  });
+
+  it('302s to the profile for unknown platform slugs (never 404 a fan)', async () => {
+    mocks.selectMock.mockImplementationOnce(() => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mocks.profileLimit,
+        }),
+      }),
+    }));
+
+    const res = await GET(makeRequest('/tim/s/fb'), {
+      params: Promise.resolve({ username: 'tim', platform: 'fb' }),
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://jov.ie/tim');
+  });
+
+  it('404s for unknown usernames', async () => {
+    mocks.profileLimit.mockResolvedValueOnce([]);
+
+    const res = await GET(makeRequest('/nobody/s/ig'), {
+      params: Promise.resolve({ username: 'nobody', platform: 'ig' }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('302s to the profile when destination URL fails safety validation', async () => {
+    mocks.validateSocialLinkUrl.mockReturnValueOnce({
+      valid: false,
+      error: 'bad',
+    });
+
+    const res = await GET(makeRequest('/tim/s/ig'), {
+      params: Promise.resolve({ username: 'tim', platform: 'ig' }),
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://jov.ie/tim');
+  });
+});


### PR DESCRIPTION
## Summary
- **JOV-3924:** New route `/{username}/s/{platform}` (ig/tt/x/yt/sp/web + full-name aliases) 301s to the artist's `social_links` URL; missing platform → 302 to profile (never 404 a fan); unknown username → 404. Best-effort click analytics (`social_links.clicks` + `click_events`).
- **JOV-3393:** Merch design generation resolves live Printful catalog economics instead of permanently stamping `jovie_default` costs. Select/publish hydrate draft cards so sellability can pass and the ask → design → publish → buyable path is no longer hard-blocked.

## Linear
Fixes JOV-3924  
Fixes JOV-3393  

<!-- linear-issue-id:JOV-3924 -->
<!-- linear-issue-id:JOV-3393 -->

## Verification
- `biome check` clean on touched files
- `vitest` `lib/social/shortcut-platforms.test.ts` — 5 passed
- `vitest` `tests/unit/app/username-s-platform-route.test.ts` — 5 passed
- `vitest` `lib/merch/design-generation.test.ts` — 4 passed
- Pre-commit typecheck green (turbo cache)

## Cost Impact
- **External API calls:** Social shortcut is DB-only (+ rate-limited click write). Merch generation now awaits Printful catalog pricing once per batch (same as the older `createMerchGeneration` path); select/publish may call catalog once when hydrating legacy `jovie_default` cards.
- **Monthly projection:** O(generations + publish actions), not O(users).
- **Scaling factor:** O(1) per merch generation/publish; O(1) per social shortcut click write.
- **Monthly cost estimate:** negligible vs existing Printful catalog traffic on merch create.

## Remaining risks
- Full prod demo still depends on Printful + image-gen credentials, MERCH_MVP gate, and one-click publish confirm (intentional JOV-3009 fence) — not removed.
- Compositing/blank-garment quality (JOV-2894) is separate; this PR unblocks **cost-source sellability**, not visual mockup polish.