### PR TITLE
fix(library): rail status axes, chat System B rail, file chips, archive-only delete

### DIFF
--- a/.agent-status.json
+++ b/.agent-status.json
@@ -1,0 +1,8 @@
+{
+  "batch": "library-rail-bugs",
+  "branch": "tim/todo-library-rail-bugs",
+  "issues": ["JOV-3333", "JOV-3493", "JOV-3492", "JOV-3885"],
+  "status": "implementing",
+  "updatedAt": "2026-07-09T19:30:00Z",
+  "notes": "Implemented all four issues. Lightweight unit tests green (17). Full ChatMessage/LibrarySurface RTL blocked by worktree node_modules thrash; CI will re-verify."
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 - **Public artist profiles now feel native at every size (JOV-2018)**: Square artwork stays square, portraits keep a face-safe crop, profile rails use one consistent card size, scrollbars stay out of sight, and sparse or subscription states no longer leave awkward gaps.
 - **Unclaimed artist profiles now include a concise claim card (JOV-2018)**: Desktop AEO pages end with an editorial Jovie prompt and a single Spotify-verified claim action.
+- **Library status badges no longer call released items "Draft" (JOV-3333)**: Grid cards and the release rail hero show Release Status only; Approval Status stays as a single editable control in Details.
+- **Chat release right-rail System B polish (JOV-3493)**: Section cards use Library elevation, DSP rows show provider icons, and typography drops oversized/all-caps chrome.
+- **Chat file attachments render as rich chips (JOV-3492)**: Uploaded audio/docs show a filetype icon + clean filename instead of raw Vercel blob URLs.
+- **Provider-ingested released music can only be archived (JOV-3885)**: Soft-hide via `deleted_at` for ingested published releases; Jovie-created releases still hard-delete.
+
 
 - [internal] **Single machine-readable design-token source, wave 1 (GH-12009, GH-10158)**: New `apps/web/design/tokens.json` compiled by `scripts/build-design-tokens.mjs` (`pnpm tokens:build` / `tokens:check`) into generated CSS (`--gray1..12` now resolve app-wide), a typed TS export, and an agent manifest. `--linear-*` namespace is now shrink-only ratcheted (`linear-namespace-ratchet.test.ts`, baseline 2242), and a source-vs-emitter divergence guard locks tokens.json to the live accent palette. No visual changes.
 - [internal] **One EmptyState primitive (GH-12638)**: Canonical molecule at `components/molecules/EmptyState` (greyscale icon + Title Case heading + one sentence + primary CTA + optional text-link secondary). Migrated DSP presence/matches, insights, release tasks, and table empty surfaces onto it; deleted 5 bespoke `*EmptyState` components; component-family ratchet emptyState 14→9.

--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -28,8 +28,10 @@ import {
   useState,
 } from 'react';
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
+import { ProviderIcon } from '@/components/atoms/ProviderIcon';
 import { ReleaseTaskChecklist } from '@/components/features/dashboard/release-tasks/ReleaseTaskChecklist';
 import { CompactReleasePlanUpgradeCard } from '@/components/features/dashboard/tasks/TasksUpgradeInterstitial';
+import { DrawerSurfaceCard } from '@/components/molecules/drawer/DrawerSurfaceCard';
 import type { DrawerHeaderAction } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import { DrawerHeaderActions } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import type { EntityCardModel } from '@/components/organisms/entity-card';
@@ -48,13 +50,14 @@ import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
 import { buildReleaseTasksRoute } from '@/constants/routes';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { resolveChatRailContextLabel } from '@/lib/chat/context-label';
-import type { ReleaseViewModel } from '@/lib/discography/types';
+import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
 import { usePlanGate } from '@/lib/queries';
 import { prefetchChatEntityPanelData } from '@/lib/queries/prefetch-dashboard';
 import { useContactsQuery } from '@/lib/queries/useContactsQuery';
 import { type EventRecord, useEventsQuery } from '@/lib/queries/useEventsQuery';
 import { useReleaseEntityQuery } from '@/lib/queries/useReleaseEntityQuery';
 import { cn } from '@/lib/utils';
+import { capitalizeFirst } from '@/lib/utils/string-utils';
 import type { DashboardContact } from '@/types/contacts';
 import {
   type ChatEntityTarget,
@@ -543,11 +546,16 @@ function ChatEntityPanelSection({
 }>) {
   return (
     <section className='system-b-chat-entity-panel-section'>
-      <div className='system-b-chat-entity-section-heading'>
-        {icon}
-        <h3>{title}</h3>
-      </div>
-      {children}
+      <DrawerSurfaceCard
+        variant='card'
+        className='system-b-chat-entity-panel-card'
+      >
+        <div className='system-b-chat-entity-section-heading'>
+          {icon}
+          <h3>{title}</h3>
+        </div>
+        {children}
+      </DrawerSurfaceCard>
     </section>
   );
 }
@@ -688,7 +696,7 @@ function ChatReleaseEntityPanel({
                       </span>
                     ) : null}
                     <span className='system-b-chat-entity-meta-pill'>
-                      {release.status}
+                      {capitalizeFirst(release.status)}
                     </span>
                   </div>
                 </div>
@@ -751,7 +759,11 @@ function ChatReleaseEntityPanel({
                           rel='noreferrer'
                           className='system-b-chat-entity-provider-link'
                         >
-                          <LinkIcon className='h-3.5 w-3.5 shrink-0 text-tertiary-token' />
+                          <ProviderIcon
+                            provider={provider.key as ProviderKey}
+                            className='h-3.5 w-3.5 shrink-0'
+                            aria-label={provider.label}
+                          />
                           <span className='min-w-0 flex-1 truncate'>
                             {provider.label}
                           </span>

--- a/apps/web/app/app/(shell)/dashboard/releases/actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { and, eq, inArray, isNotNull, ne } from 'drizzle-orm';
+import { and, eq, inArray, ne } from 'drizzle-orm';
 import {
   unstable_noStore as noStore,
   revalidatePath,
@@ -15,7 +15,6 @@ import { isUniqueViolation } from '@/lib/db/errors';
 import {
   discogRecordings,
   discogReleases,
-  discogReleaseTracks,
   discogTracks,
 } from '@/lib/db/schema/content';
 import { dspArtistMatches } from '@/lib/db/schema/dsp-enrichment';
@@ -67,6 +66,7 @@ import {
   checkReleaseRefreshRateLimit,
   formatTimeRemaining,
 } from '@/lib/rate-limit';
+import { shouldArchiveOnlyRelease } from '@/lib/releases/release-archive-policy';
 import {
   loadReleaseEntity as loadReleaseEntityFromLoader,
   loadReleaseMatrixForProfile as loadReleaseMatrixForProfileFromLoader,
@@ -1878,12 +1878,17 @@ interface DeleteReleaseParams {
 }
 
 /**
- * Soft-delete a release (sets deleted_at instead of removing the row).
- * Blocks deletion of actively distributed releases (ISRC + past release date).
+ * Delete or archive a release (JOV-3885).
+ *
+ * - Provider-ingested + already released → archive only (soft-hide via deleted_at).
+ *   Provider data is the canonical source; we never hard-delete it.
+ * - Jovie-created / manual (or not-yet-released) → hard delete the row.
  */
-export async function deleteRelease(
-  params: DeleteReleaseParams
-): Promise<{ success: boolean; message?: string }> {
+export async function deleteRelease(params: DeleteReleaseParams): Promise<{
+  success: boolean;
+  message?: string;
+  mode?: 'archive' | 'delete';
+}> {
   noStore();
 
   const { userId } = await getCachedAuth();
@@ -1899,37 +1904,22 @@ export async function deleteRelease(
     throw new TypeError('Release not found');
   }
 
-  // Distribution gate: block if release has ISRC and is past release date
-  if (release.releaseDate && new Date(release.releaseDate) <= new Date()) {
-    const [hasIsrc] = await db
-      .select({ id: discogRecordings.id })
-      .from(discogRecordings)
-      .innerJoin(
-        discogReleaseTracks,
-        eq(discogReleaseTracks.recordingId, discogRecordings.id)
-      )
-      .where(
-        and(
-          eq(discogReleaseTracks.releaseId, params.releaseId),
-          isNotNull(discogRecordings.isrc)
-        )
-      )
-      .limit(1);
+  const archiveOnly = shouldArchiveOnlyRelease({
+    status: (release.status as ReleaseViewModel['status']) ?? 'released',
+    sourceType: release.sourceType,
+    releaseDate: release.releaseDate,
+  });
 
-    if (hasIsrc) {
-      return {
-        success: false,
-        message:
-          'This release appears to be distributed. Remove it from distribution first.',
-      };
-    }
+  if (archiveOnly) {
+    await db
+      .update(discogReleases)
+      .set({ deletedAt: new Date() })
+      .where(eq(discogReleases.id, params.releaseId));
+  } else {
+    await db
+      .delete(discogReleases)
+      .where(eq(discogReleases.id, params.releaseId));
   }
-
-  // Soft delete: set deleted_at instead of removing the row
-  await db
-    .update(discogReleases)
-    .set({ deletedAt: new Date() })
-    .where(eq(discogReleases.id, params.releaseId));
 
   // Invalidate cache and revalidate path
   revalidateTag(`releases:${userId}:${profile.id}`, 'max');
@@ -1937,13 +1927,19 @@ export async function deleteRelease(
   revalidateTag(createSmartLinkContentTag(profile.id), 'max');
   revalidatePath(APP_ROUTES.RELEASES);
 
-  void trackServerEvent('release_deleted', {
+  void trackServerEvent(archiveOnly ? 'release_archived' : 'release_deleted', {
     profileId: profile.id,
     releaseId: params.releaseId,
     releaseTitle: release.title,
   });
 
-  return { success: true };
+  return {
+    success: true,
+    mode: archiveOnly ? 'archive' : 'delete',
+    message: archiveOnly
+      ? 'Release archived. Provider-ingested catalog is soft-hidden only.'
+      : undefined,
+  };
 }
 
 /**

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -491,10 +491,13 @@ const StatusCell = memo(function StatusCell({
 }) {
   return (
     <span
+      role='status'
       className={cn(
         'system-b-library-status-pill inline-flex h-6 w-fit items-center border px-2 leading-4',
         releaseStatusClasses(asset.status)
       )}
+      data-testid={`library-release-status-${asset.id}`}
+      aria-label={`Release Status: ${formatLibraryStatus(asset)}`}
     >
       {formatLibraryStatus(asset)}
     </span>
@@ -508,11 +511,13 @@ const ApprovalStatusCell = memo(function ApprovalStatusCell({
 }) {
   return (
     <span
+      role='status'
       className={cn(
         'system-b-library-status-pill inline-flex h-6 w-fit items-center border px-2 leading-4',
         libraryApprovalStatusClasses(asset.approvalStatus)
       )}
       data-testid={`library-approval-status-${asset.id}`}
+      aria-label={`Approval Status: ${formatLibraryApprovalStatus(asset.approvalStatus)}`}
     >
       {formatLibraryApprovalStatus(asset.approvalStatus)}
     </span>
@@ -557,7 +562,7 @@ const ProvidersCell = memo(function ProvidersCell({
     return (
       <span
         role='img'
-        aria-label='No providers'
+        aria-label='No Providers'
         className='system-b-library-meta-text text-quaternary-token'
       >
         &mdash;
@@ -1393,13 +1398,15 @@ const AssetCard = memo(function AssetCard({
           >
             <LibraryMediaThumbnail asset={asset} size='card' />
             <span
+              role='status'
               className={cn(
                 'system-b-library-card-status absolute left-2 top-2 border px-1.5 py-0.5 leading-4',
-                libraryApprovalStatusClasses(asset.approvalStatus)
+                releaseStatusClasses(asset.status)
               )}
-              data-testid={`library-approval-status-${asset.id}`}
+              data-testid={`library-release-status-${asset.id}`}
+              aria-label={`Release Status: ${formatLibraryStatus(asset)}`}
             >
-              {formatLibraryApprovalStatus(asset.approvalStatus)}
+              {formatLibraryStatus(asset)}
             </span>
           </div>
           <div className='min-w-0 p-3'>
@@ -2045,20 +2052,19 @@ function AssetDrawer({
                   </div>
 
                   <div className='flex flex-wrap gap-1.5'>
+                    {/*
+                      Release Status only in the hero pills. Approval Status is
+                      editable once in Details (ApprovalStatusEditor) — never
+                      duplicate the axes side-by-side (JOV-3333).
+                    */}
                     <span
-                      className={cn(
-                        'system-b-library-status-pill inline-flex h-6 items-center border px-2',
-                        libraryApprovalStatusClasses(current.approvalStatus)
-                      )}
-                      data-testid={`library-approval-status-${current.id}`}
-                    >
-                      {formatLibraryApprovalStatus(current.approvalStatus)}
-                    </span>
-                    <span
+                      role='status'
                       className={cn(
                         'system-b-library-status-pill inline-flex h-6 items-center border px-2',
                         releaseStatusClasses(current.status)
                       )}
+                      data-testid={`library-release-status-${current.id}`}
+                      aria-label={`Release Status: ${formatLibraryStatus(current)}`}
                     >
                       {formatLibraryStatus(current)}
                     </span>

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -40,6 +40,7 @@ import { captureError } from '@/lib/error-tracking';
 import { useAppFlag } from '@/lib/flags/client';
 import { QueryErrorBoundary, usePlanGate } from '@/lib/queries';
 import type { ReleaseContext } from '@/lib/release-tasks/applicability';
+import { shouldArchiveOnlyRelease } from '@/lib/releases/release-archive-policy';
 import { buildReleasePitchChatPrompt } from '@/lib/services/pitch/targets';
 import { cn } from '@/lib/utils';
 import { useImportPolling } from './hooks/useImportPolling';
@@ -193,11 +194,14 @@ function buildReleaseLockState(
 }
 
 function isDistributedRelease(release: ReleaseViewModel) {
-  if (!release.primaryIsrc || !release.releaseDate) {
-    return false;
-  }
-
-  return new Date(release.releaseDate) <= new Date();
+  // Shared policy: provider-ingested + published → archive-only (JOV-3885).
+  return (
+    shouldArchiveOnlyRelease(release) ||
+    (release.sourceType == null &&
+      Boolean(release.primaryIsrc) &&
+      Boolean(release.releaseDate) &&
+      new Date(release.releaseDate as string) <= new Date())
+  );
 }
 
 function ReleaseImportProgressNotice({
@@ -484,11 +488,11 @@ function DeleteReleaseConfirmation({
 
   const isDistributed = isDistributedRelease(target);
   const title = isDistributed
-    ? 'Release is distributed'
+    ? `Archive "${target.title}"?`
     : `Delete "${target.title}"?`;
   const description = isDistributed
-    ? 'Remove this release from distribution before deleting it.'
-    : 'This will remove the release from your dashboard and public profile.';
+    ? 'This release was ingested from a provider and is already released. It will be archived (hidden from your dashboard and public profile), not permanently deleted.'
+    : 'This will permanently remove the release from your dashboard and public profile.';
 
   return (
     <ConfirmDialog
@@ -498,10 +502,10 @@ function DeleteReleaseConfirmation({
       }}
       title={title}
       description={description}
-      confirmLabel={isDistributed ? 'OK' : 'Delete'}
+      confirmLabel={isDistributed ? 'Archive' : 'Delete'}
       variant={isDistributed ? 'default' : 'destructive'}
       isLoading={isDeleting}
-      onConfirm={isDistributed ? onClose : onConfirm}
+      onConfirm={onConfirm}
     />
   );
 }
@@ -587,17 +591,29 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!deleteTarget) return;
+    const archiveOnly = isDistributedRelease(deleteTarget);
     setIsDeleting(true);
     try {
       const result = await deleteRelease({ releaseId: deleteTarget.id });
       if (result.success) {
         setRows(prev => prev.filter(r => r.id !== deleteTarget.id));
-        toast.success(`"${deleteTarget.title}" deleted.`);
+        toast.success(
+          archiveOnly || result.mode === 'archive'
+            ? `"${deleteTarget.title}" archived.`
+            : `"${deleteTarget.title}" deleted.`
+        );
       } else {
-        toast.error(result.message ?? 'Failed to delete release.');
+        toast.error(
+          result.message ??
+            (archiveOnly
+              ? 'Failed to archive release.'
+              : 'Failed to delete release.')
+        );
       }
     } catch {
-      toast.error('Failed to delete release.');
+      toast.error(
+        archiveOnly ? 'Failed to archive release.' : 'Failed to delete release.'
+      );
     } finally {
       setIsDeleting(false);
       setDeleteTarget(null);

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseWorkflowOverlays.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseWorkflowOverlays.tsx
@@ -138,24 +138,22 @@ export function ReleaseWorkflowOverlays({
           }}
           title={
             isDistributedRelease(deleteTarget)
-              ? 'Release is distributed'
+              ? `Archive "${deleteTarget.title}"?`
               : `Delete "${deleteTarget.title}"?`
           }
           description={
             isDistributedRelease(deleteTarget)
-              ? 'Remove this release from distribution before deleting it.'
-              : 'This will remove the release from your dashboard and public profile.'
+              ? 'This release was ingested from a provider and is already released. It will be archived (hidden from your dashboard and public profile), not permanently deleted.'
+              : 'This will permanently remove the release from your dashboard and public profile.'
           }
-          confirmLabel={isDistributedRelease(deleteTarget) ? 'OK' : 'Delete'}
+          confirmLabel={
+            isDistributedRelease(deleteTarget) ? 'Archive' : 'Delete'
+          }
           variant={
             isDistributedRelease(deleteTarget) ? 'default' : 'destructive'
           }
           isLoading={isDeleting}
-          onConfirm={
-            isDistributedRelease(deleteTarget)
-              ? closeDeleteDialog
-              : onDeleteConfirm
-          }
+          onConfirm={onDeleteConfirm}
         />
       )}
     </>

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/release-deletion.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/release-deletion.ts
@@ -9,11 +9,12 @@ import {
 import { deleteRelease } from '@/app/app/(shell)/dashboard/releases/actions';
 import { toast } from '@/components/feedback';
 import type { ReleaseViewModel } from '@/lib/discography/types';
+import {
+  isDistributedRelease,
+  shouldArchiveOnlyRelease,
+} from '@/lib/releases/release-archive-policy';
 
-export function isDistributedRelease(release: ReleaseViewModel): boolean {
-  if (!release.primaryIsrc || !release.releaseDate) return false;
-  return new Date(release.releaseDate) <= new Date();
-}
+export { isDistributedRelease, shouldArchiveOnlyRelease };
 
 interface UseReleaseDeletionOptions {
   readonly rows: readonly ReleaseViewModel[];
@@ -46,17 +47,29 @@ export function useReleaseDeletion({
   const confirmReleaseDelete = useCallback(async () => {
     if (!deleteTarget) return;
 
+    const archiveOnly = shouldArchiveOnlyRelease(deleteTarget);
     setIsDeleting(true);
     try {
       const result = await deleteRelease({ releaseId: deleteTarget.id });
       if (result.success) {
         setRows(prev => prev.filter(r => r.id !== deleteTarget.id));
-        toast.success(`"${deleteTarget.title}" deleted.`);
+        toast.success(
+          archiveOnly || result.mode === 'archive'
+            ? `"${deleteTarget.title}" archived.`
+            : `"${deleteTarget.title}" deleted.`
+        );
       } else {
-        toast.error(result.message ?? 'Failed to delete release.');
+        toast.error(
+          result.message ??
+            (archiveOnly
+              ? 'Failed to archive release.'
+              : 'Failed to delete release.')
+        );
       }
     } catch {
-      toast.error('Failed to delete release.');
+      toast.error(
+        archiveOnly ? 'Failed to archive release.' : 'Failed to delete release.'
+      );
     } finally {
       setIsDeleting(false);
       setDeleteTarget(null);

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -13,6 +13,7 @@ import { getMessageText } from '../utils';
 import { AssistantMessageText } from './AssistantMessageText';
 import { ChatFeedbackControl } from './ChatFeedbackControl';
 import { ChatStepLimitAffordance } from './ChatStepLimitAffordance';
+import { FileAttachmentChip } from './FileAttachmentChip';
 import { ImageAttachmentChip } from './ImageAttachmentChip';
 import { TokenizedText } from './TokenizedText';
 
@@ -119,20 +120,28 @@ export const ChatMessage = memo(function ChatMessage({
   const shouldReduceMotion = useReducedMotion();
   const toolEvents = getRenderableToolEvents(parts);
   const fileParts = parts.filter(
-    (p): p is MessagePart & { url: string; mediaType: string; name?: string } =>
-      p.type === 'file' &&
-      typeof p.url === 'string' &&
-      typeof p.mediaType === 'string' &&
-      p.mediaType.startsWith('image/')
+    (
+      p
+    ): p is MessagePart & { url: string; mediaType?: string; name?: string } =>
+      p.type === 'file' && typeof p.url === 'string'
   );
-  const imageChips = (() => {
+  const attachmentChips = (() => {
     const seenFileKeys = new Map<string, number>();
     return fileParts.map(file => {
       const seenCount = seenFileKeys.get(file.url) ?? 0;
       seenFileKeys.set(file.url, seenCount + 1);
       const dedupeKey =
         seenCount === 0 ? file.url : `${file.url}-${seenCount + 1}`;
-      return { dedupeKey, url: file.url, name: file.name };
+      const mediaType =
+        typeof file.mediaType === 'string' ? file.mediaType : '';
+      const isImage = mediaType.startsWith('image/');
+      return {
+        dedupeKey,
+        url: file.url,
+        name: file.name,
+        mediaType,
+        isImage,
+      };
     });
   })();
   const hasAssistantContent =
@@ -145,7 +154,7 @@ export const ChatMessage = memo(function ChatMessage({
     (!isUser && Boolean(isStreaming) && !hasAssistantContent);
   const useUserPillBubble =
     isUser &&
-    imageChips.length === 0 &&
+    attachmentChips.length === 0 &&
     !messageText.includes('\n') &&
     messageText.length <= 44;
 
@@ -167,19 +176,29 @@ export const ChatMessage = memo(function ChatMessage({
           data-bubble-shape={useUserPillBubble ? 'pill' : 'rectangle'}
           className='system-b-chat-user-bubble'
         >
-          {imageChips.length > 0 && (
+          {attachmentChips.length > 0 && (
             <div
               className='system-b-chat-user-attachments'
               data-has-message={messageText ? 'true' : 'false'}
             >
-              {imageChips.map(chip => (
-                <ImageAttachmentChip
-                  key={chip.dedupeKey}
-                  url={chip.url}
-                  name={chip.name}
-                  tone='onLight'
-                />
-              ))}
+              {attachmentChips.map(chip =>
+                chip.isImage ? (
+                  <ImageAttachmentChip
+                    key={chip.dedupeKey}
+                    url={chip.url}
+                    name={chip.name}
+                    tone='onLight'
+                  />
+                ) : (
+                  <FileAttachmentChip
+                    key={chip.dedupeKey}
+                    url={chip.url}
+                    name={chip.name}
+                    mediaType={chip.mediaType}
+                    tone='onLight'
+                  />
+                )
+              )}
             </div>
           )}
           {messageText && (

--- a/apps/web/components/jovie/components/FileAttachmentChip.tsx
+++ b/apps/web/components/jovie/components/FileAttachmentChip.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { ExternalLink } from 'lucide-react';
+import {
+  fileDisplayName,
+  fileKindFromMediaType,
+  type TranscriptFileKind,
+} from '@/lib/chat/file-display-name';
+import { cn } from '@/lib/utils';
+import { fileKindIcon } from './file-kind-icons';
+
+interface FileAttachmentChipProps {
+  readonly url: string;
+  readonly name?: string;
+  readonly mediaType?: string;
+  readonly tone?: 'onLight' | 'onDark';
+}
+
+function toComposerKind(
+  kind: TranscriptFileKind
+): 'image' | 'audio' | 'video' | 'archive' | 'document' | 'other' {
+  return kind;
+}
+
+/**
+ * Compact rich chip for non-image file attachments in the chat transcript.
+ * Mirrors ImageAttachmentChip / EntityChip height and System B chrome so the
+ * attachment strip reads as one coherent row (JOV-3492).
+ */
+export function FileAttachmentChip({
+  url,
+  name,
+  mediaType,
+  tone = 'onLight',
+}: FileAttachmentChipProps) {
+  const label = fileDisplayName(url, name);
+  const kind = fileKindFromMediaType(mediaType, name ?? label);
+
+  const chipClass = cn(
+    'system-b-image-attachment-chip',
+    tone === 'onLight'
+      ? 'system-b-image-attachment-chip-light'
+      : 'system-b-image-attachment-chip-dark'
+  );
+
+  return (
+    <a
+      href={url}
+      target='_blank'
+      rel='noreferrer'
+      className='system-b-image-attachment-trigger'
+      data-testid='file-attachment-chip-trigger'
+      aria-label={`File attachment: ${label}`}
+    >
+      <span className={chipClass} data-testid='file-attachment-chip'>
+        <span
+          className='system-b-file-attachment-icon'
+          aria-hidden
+          data-kind={kind}
+        >
+          {fileKindIcon(toComposerKind(kind), 'h-3.5 w-3.5')}
+        </span>
+        <span className='system-b-image-attachment-label'>{label}</span>
+        <ExternalLink className='h-3 w-3 shrink-0 opacity-60' aria-hidden />
+      </span>
+    </a>
+  );
+}

--- a/apps/web/components/jovie/components/ImageAttachmentChip.tsx
+++ b/apps/web/components/jovie/components/ImageAttachmentChip.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { fileDisplayName } from '@/lib/chat/file-display-name';
 import { cn } from '@/lib/utils';
 
 const HOVER_OPEN_DELAY_MS = 200;
@@ -84,7 +85,8 @@ export function ImageAttachmentChip({
     [clearTimers]
   );
 
-  const label = name && name.trim().length > 0 ? name : 'Image';
+  const derived = fileDisplayName(url, name?.trim() || null);
+  const label = derived === 'File' ? 'Image' : derived;
 
   const chipClass = cn(
     'system-b-image-attachment-chip',

--- a/apps/web/lib/chat/file-display-name.ts
+++ b/apps/web/lib/chat/file-display-name.ts
@@ -1,0 +1,115 @@
+/**
+ * Normalize a file attachment URL or name into a human-readable label.
+ * Strips blob hosts, query/hash, URL-decodes, and middle-ellipsizes long names.
+ * JOV-3492.
+ */
+
+const BLOB_HOST_PATTERN = /\.blob\.vercel-storage\.com$/i;
+const MAX_DISPLAY_LENGTH = 40;
+
+export function isVercelBlobUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname;
+    return BLOB_HOST_PATTERN.test(host) || host === 'blob.vercel-storage.com';
+  } catch {
+    return url.includes('blob.vercel-storage.com');
+  }
+}
+
+export function filenameFromUrlOrName(
+  url: string,
+  name?: string | null
+): string {
+  const raw = name?.trim() || extractPathBasename(url) || 'File';
+  let decoded = raw;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    decoded = raw;
+  }
+  // Collapse leftover percent-encoding noise and path separators.
+  decoded = decoded
+    .replaceAll('+', ' ')
+    .replaceAll(/[\\/]+/g, ' ')
+    .trim();
+  return decoded.length > 0 ? decoded : 'File';
+}
+
+function extractPathBasename(url: string): string | null {
+  try {
+    const pathname = new URL(url).pathname;
+    const segment = pathname.split('/').filter(Boolean).at(-1);
+    return segment ?? null;
+  } catch {
+    const withoutQuery = url.split(/[?#]/u)[0] ?? url;
+    const segment = withoutQuery.split('/').filter(Boolean).at(-1);
+    return segment ?? null;
+  }
+}
+
+export function middleEllipsis(
+  value: string,
+  maxLength: number = MAX_DISPLAY_LENGTH
+): string {
+  if (value.length <= maxLength) return value;
+  const keep = Math.max(4, Math.floor((maxLength - 1) / 2));
+  return `${value.slice(0, keep)}…${value.slice(-keep)}`;
+}
+
+export function fileDisplayName(
+  url: string,
+  name?: string | null,
+  maxLength: number = MAX_DISPLAY_LENGTH
+): string {
+  return middleEllipsis(filenameFromUrlOrName(url, name), maxLength);
+}
+
+export type TranscriptFileKind =
+  | 'image'
+  | 'audio'
+  | 'video'
+  | 'archive'
+  | 'document'
+  | 'other';
+
+export function fileKindFromMediaType(
+  mediaType: string | null | undefined,
+  filename?: string | null
+): TranscriptFileKind {
+  const type = (mediaType ?? '').toLowerCase();
+  if (type.startsWith('image/')) return 'image';
+  if (type.startsWith('audio/')) return 'audio';
+  if (type.startsWith('video/')) return 'video';
+  if (
+    type.includes('zip') ||
+    type.includes('rar') ||
+    type.includes('7z') ||
+    type.includes('tar') ||
+    type.includes('gzip')
+  ) {
+    return 'archive';
+  }
+  if (
+    type.includes('pdf') ||
+    type.startsWith('text/') ||
+    type.includes('document') ||
+    type.includes('msword') ||
+    type.includes('officedocument')
+  ) {
+    return 'document';
+  }
+
+  const ext = (filename ?? '').split('.').pop()?.toLowerCase() ?? '';
+  if (
+    ['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'heic', 'heif'].includes(ext)
+  ) {
+    return 'image';
+  }
+  if (['mp3', 'wav', 'flac', 'aac', 'aiff', 'm4a', 'ogg'].includes(ext)) {
+    return 'audio';
+  }
+  if (['mp4', 'mov', 'webm', 'avi', 'mkv'].includes(ext)) return 'video';
+  if (['zip', 'rar', '7z', 'tar', 'gz'].includes(ext)) return 'archive';
+  if (['pdf', 'txt', 'md', 'doc', 'docx'].includes(ext)) return 'document';
+  return 'other';
+}

--- a/apps/web/lib/discography/types.ts
+++ b/apps/web/lib/discography/types.ts
@@ -132,6 +132,8 @@ export interface ReleaseViewModel {
   artistNames?: string[];
   releaseDate?: string;
   status: 'draft' | 'scheduled' | 'released';
+  /** Origin of the release row: manual (Jovie-created) vs provider-ingested. */
+  sourceType?: 'manual' | 'admin' | 'ingested';
   revealDate?: string;
   deletedAt?: string;
   artworkUrl?: string;

--- a/apps/web/lib/releases/release-archive-policy.ts
+++ b/apps/web/lib/releases/release-archive-policy.ts
@@ -1,0 +1,49 @@
+export type ReleaseSourceType = 'manual' | 'admin' | 'ingested';
+
+/**
+ * Provider-ingested (or admin-seeded) releases that are already out are
+ * archive-only: soft-hide via deleted_at. Jovie-created / manual drafts may
+ * be hard-deleted. JOV-3885.
+ */
+export type ReleaseArchivePolicyInput = {
+  readonly status?: string | null;
+  readonly sourceType?: string | null;
+  readonly releaseDate?: string | Date | null;
+  readonly primaryIsrc?: string | null;
+};
+
+export function isProviderIngestedSource(
+  sourceType: string | null | undefined
+): boolean {
+  // Only explicit provider/admin origins are archive-only. Missing/manual stay
+  // hard-deletable (schema default is `manual`).
+  return sourceType === 'ingested' || sourceType === 'admin';
+}
+
+export function isReleasePublished(
+  release: ReleaseArchivePolicyInput
+): boolean {
+  if (release.status === 'released') return true;
+  if (!release.releaseDate) return false;
+  return new Date(release.releaseDate) <= new Date();
+}
+
+export function shouldArchiveOnlyRelease(
+  release: ReleaseArchivePolicyInput
+): boolean {
+  return (
+    isProviderIngestedSource(release.sourceType) && isReleasePublished(release)
+  );
+}
+
+/** Legacy name kept for call-site migration — prefer shouldArchiveOnlyRelease. */
+export function isDistributedRelease(
+  release: ReleaseArchivePolicyInput
+): boolean {
+  if (release.sourceType != null) {
+    return shouldArchiveOnlyRelease(release);
+  }
+  // Legacy heuristic when sourceType is not on the view model yet.
+  if (!release.primaryIsrc || !release.releaseDate) return false;
+  return new Date(release.releaseDate) <= new Date();
+}

--- a/apps/web/lib/releases/release-view-models.ts
+++ b/apps/web/lib/releases/release-view-models.ts
@@ -43,6 +43,12 @@ export function mapReleaseToViewModel(
     artistNames: release.artistNames,
     releaseDate: toISOStringOrNull(release.releaseDate) ?? undefined,
     status: (release.status as ReleaseStatusValue) ?? 'released',
+    sourceType:
+      release.sourceType === 'manual' ||
+      release.sourceType === 'admin' ||
+      release.sourceType === 'ingested'
+        ? release.sourceType
+        : 'ingested',
     revealDate: toISOStringOrNull(release.revealDate) ?? undefined,
     deletedAt: toISOStringOrNull(release.deletedAt) ?? undefined,
     artworkUrl: release.artworkUrl ?? undefined,

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -4231,9 +4231,15 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(.system-b-chat-entity-panel-section) {
-  padding: var(--space-4);
-  border-top: 1px solid
-    color-mix(in oklab, var(--system-b-app-frame-seam) 58%, transparent);
+  padding: var(--space-3) var(--space-3) 0;
+}
+
+:where(.system-b-chat-entity-panel-section:last-child) {
+  padding-bottom: var(--space-3);
+}
+
+:where(.system-b-chat-entity-panel-card) {
+  padding: var(--space-3);
 }
 
 :where(.system-b-chat-entity-panel-header-copy) {
@@ -4242,17 +4248,20 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 
 :where(.system-b-chat-entity-panel-eyebrow) {
   color: var(--color-text-tertiary-token);
-  font-size: var(--text-3xs);
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: 0.08em;
+  font-family: var(--font-body, inherit);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.01em;
   line-height: 1rem;
-  text-transform: uppercase;
+  /* Title Case via content; no all-caps (System B / ui.md). */
+  text-transform: none;
 }
 
 :where(.system-b-chat-entity-panel-title) {
   overflow: hidden;
   color: var(--color-text-primary-token);
-  font-size: var(--text-app);
+  font-family: var(--font-body, inherit);
+  font-size: var(--text-nav);
   font-weight: var(--font-weight-semibold);
   line-height: 1.25rem;
   text-overflow: ellipsis;
@@ -4280,10 +4289,18 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  margin-bottom: var(--space-3);
+  margin-bottom: var(--space-2-5);
   color: var(--color-text-secondary-token);
-  font-size: var(--text-nav);
+  font-family: var(--font-body, inherit);
+  font-size: var(--text-2xs);
   font-weight: var(--font-weight-semibold);
+  line-height: 1rem;
+}
+
+:where(.system-b-chat-entity-section-heading h3) {
+  margin: 0;
+  font: inherit;
+  color: inherit;
 }
 
 :where(.system-b-chat-entity-context-card) {
@@ -4393,7 +4410,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 
 :where(.system-b-chat-release-title) {
   color: var(--color-text-primary-token);
-  font-size: 0.9375rem;
+  font-family: var(--font-body, inherit);
+  font-size: var(--text-nav);
   font-weight: var(--font-weight-semibold);
   line-height: 1.25rem;
 }
@@ -4417,10 +4435,11 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   background: var(--color-bg-surface-0);
   padding: var(--space-0-5) var(--space-2);
   color: var(--color-text-secondary-token);
-  font-size: var(--text-3xs);
+  font-family: var(--font-body, inherit);
+  font-size: var(--text-2xs);
   font-weight: var(--font-weight-medium);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  text-transform: none;
 }
 
 :where(.system-b-chat-entity-action-link) {
@@ -9486,6 +9505,16 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   flex-shrink: 0;
   border-radius: var(--radius-sm);
   object-fit: cover;
+}
+
+:where(.system-b-file-attachment-icon) {
+  display: inline-flex;
+  width: var(--space-4);
+  height: var(--space-4);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-tertiary-token);
 }
 
 :where(.system-b-image-attachment-label) {

--- a/apps/web/tests/unit/actions/releases-actions.update.nightly.test.ts
+++ b/apps/web/tests/unit/actions/releases-actions.update.nightly.test.ts
@@ -309,7 +309,7 @@ function setupDbUpdateChain() {
   });
 }
 
-function setupDbSelectJoinChain(result: unknown[]) {
+function _setupDbSelectJoinChain(result: unknown[]) {
   mockDbSelect.mockReturnValueOnce({
     from: vi.fn().mockReturnValue({
       innerJoin: vi.fn().mockReturnValue({
@@ -585,9 +585,34 @@ describe('@critical releases/actions.ts — update/edit operations', () => {
   // deleteRelease
   // =========================================================================
   describe('deleteRelease', () => {
-    it('deletes a release owned by the user', async () => {
-      mockGetReleaseById.mockResolvedValue(makeRelease());
-      setupDbSelectJoinChain([]);
+    it('hard-deletes a manual Jovie-created release', async () => {
+      mockGetReleaseById.mockResolvedValue(
+        makeRelease({ sourceType: 'manual', status: 'draft' })
+      );
+      const deleteWhere = vi.fn().mockResolvedValue(undefined);
+      mockDbDelete.mockReturnValue({ where: deleteWhere });
+
+      const { deleteRelease } = await import(
+        '@/app/app/(shell)/dashboard/releases/actions'
+      );
+      const result = await deleteRelease({ releaseId: 'rel_001' });
+
+      expect(result.success).toBe(true);
+      expect(result.mode).toBe('delete');
+      expect(mockDbDelete).toHaveBeenCalled();
+      expect(mockDbUpdate).not.toHaveBeenCalled();
+      expect(mockRevalidateTag).toHaveBeenCalled();
+      expect(mockRevalidatePath).toHaveBeenCalledWith('/dashboard/releases');
+    });
+
+    it('archives provider-ingested released music instead of hard-deleting', async () => {
+      mockGetReleaseById.mockResolvedValue(
+        makeRelease({
+          sourceType: 'ingested',
+          status: 'released',
+          releaseDate: new Date('2020-01-01'),
+        })
+      );
       setupDbUpdateChain();
 
       const { deleteRelease } = await import(
@@ -596,9 +621,9 @@ describe('@critical releases/actions.ts — update/edit operations', () => {
       const result = await deleteRelease({ releaseId: 'rel_001' });
 
       expect(result.success).toBe(true);
+      expect(result.mode).toBe('archive');
       expect(mockDbUpdate).toHaveBeenCalled();
-      expect(mockRevalidateTag).toHaveBeenCalled();
-      expect(mockRevalidatePath).toHaveBeenCalledWith('/dashboard/releases');
+      expect(mockDbDelete).not.toHaveBeenCalled();
     });
 
     it('rejects unauthenticated calls', async () => {

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -163,6 +163,35 @@ describe('ChatMessage', () => {
     ).toHaveAttribute('data-has-message', 'true');
   });
 
+  it('renders non-image file parts as rich file chips without raw blob URLs (JOV-3492)', () => {
+    const blobUrl =
+      'https://egojgbuon2z2yahy.public.blob.vercel-storage.com/Never%20Say%20A%20Word_Instrumental.wav';
+    const messageProps = {
+      id: 'user-file-chip',
+      role: 'user' as const,
+      parts: [
+        {
+          type: 'file' as const,
+          mediaType: 'audio/wav',
+          url: blobUrl,
+        },
+        { type: 'text' as const, text: 'Here is the instrumental' },
+      ],
+    };
+
+    fastRender(<ChatMessage {...messageProps} />);
+
+    const bubble = screen.getByTestId('chat-user-bubble');
+    const chip = within(bubble).getByTestId('file-attachment-chip');
+    expect(chip).toHaveTextContent('Never Say A Word_Instrumental.wav');
+    expect(chip.textContent).not.toContain('blob.vercel-storage.com');
+    expect(chip.textContent).not.toContain('%20');
+    expect(
+      within(bubble).getByTestId('file-attachment-chip-trigger')
+    ).toHaveAttribute('href', blobUrl);
+    expect(bubble.textContent).not.toContain('blob.vercel-storage.com');
+  });
+
   it('renders thinking with stable System B loading hooks', () => {
     const messageProps = {
       id: 'assistant-thinking',

--- a/apps/web/tests/unit/chat/file-attachment-chip-source-guard.test.ts
+++ b/apps/web/tests/unit/chat/file-attachment-chip-source-guard.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const readSource = (path: string) => readFileSync(join(repoRoot, path), 'utf8');
+
+describe('chat file attachment chip source guards (JOV-3492)', () => {
+  const message = readSource('components/jovie/components/ChatMessage.tsx');
+  const chip = readSource('components/jovie/components/FileAttachmentChip.tsx');
+  const display = readSource('lib/chat/file-display-name.ts');
+
+  it('renders non-image file parts via FileAttachmentChip', () => {
+    expect(message).toContain("from './FileAttachmentChip'");
+    expect(message).toContain('<FileAttachmentChip');
+    expect(message).toContain("p.type === 'file'");
+  });
+
+  it('normalizes filenames and never shows raw blob hosts in the chip label', () => {
+    expect(chip).toContain('fileDisplayName');
+    expect(chip).toContain("data-testid='file-attachment-chip'");
+    expect(display).toContain('blob.vercel-storage.com');
+    expect(display).toContain('decodeURIComponent');
+    expect(display).toContain('middleEllipsis');
+  });
+});

--- a/apps/web/tests/unit/chat/file-display-name.test.ts
+++ b/apps/web/tests/unit/chat/file-display-name.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fileDisplayName,
+  fileKindFromMediaType,
+  filenameFromUrlOrName,
+  isVercelBlobUrl,
+  middleEllipsis,
+} from '@/lib/chat/file-display-name';
+
+describe('file-display-name (JOV-3492)', () => {
+  it('detects Vercel blob hosts', () => {
+    expect(
+      isVercelBlobUrl(
+        'https://egojgbuon2z2yahy.public.blob.vercel-storage.com/Never%20Say%20A%20Word_Instrumental.wav'
+      )
+    ).toBe(true);
+    expect(isVercelBlobUrl('https://example.com/file.wav')).toBe(false);
+  });
+
+  it('URL-decodes and strips blob host path noise', () => {
+    const url =
+      'https://egojgbuon2z2yahy.public.blob.vercel-storage.com/Never%20Say%20A%20Word_Instrumental.wav';
+    expect(filenameFromUrlOrName(url)).toBe(
+      'Never Say A Word_Instrumental.wav'
+    );
+    expect(fileDisplayName(url)).not.toContain('blob.vercel-storage.com');
+    expect(fileDisplayName(url)).not.toContain('%20');
+  });
+
+  it('prefers an explicit name over the URL basename', () => {
+    expect(
+      filenameFromUrlOrName('https://cdn.example.com/x.wav', 'Mix Final.wav')
+    ).toBe('Mix Final.wav');
+  });
+
+  it('middle-ellipsizes long names', () => {
+    const long = 'a'.repeat(60) + '.wav';
+    const display = middleEllipsis(long, 20);
+    expect(display.length).toBeLessThanOrEqual(21);
+    expect(display).toContain('…');
+    expect(display.endsWith('.wav')).toBe(true);
+  });
+
+  it('maps media types and extensions to file kinds', () => {
+    expect(fileKindFromMediaType('audio/wav')).toBe('audio');
+    expect(fileKindFromMediaType('image/png')).toBe('image');
+    expect(fileKindFromMediaType('application/pdf')).toBe('document');
+    expect(fileKindFromMediaType('application/zip')).toBe('archive');
+    expect(fileKindFromMediaType(undefined, 'master.wav')).toBe('audio');
+  });
+});

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -351,35 +351,77 @@ describe('LibrarySurface', () => {
     expect(portraitCard?.className).toContain('aspect-[9/16]');
   });
 
-  it('renders approval status badges and supports filtering by approval status', async () => {
+  it('shows release status on cards/rows and never conflates approval Draft with release state', async () => {
     renderLibraryWithSidebarOverride([
-      buildAsset({ approvalStatus: 'needs_review' }),
+      buildAsset({
+        status: 'released',
+        approvalStatus: 'draft',
+      }),
       buildAsset({
         id: 'release-2',
         title: 'Second Track',
+        status: 'released',
+        approvalStatus: 'needs_review',
+      }),
+      buildAsset({
+        id: 'release-3',
+        title: 'Third Track',
+        status: 'released',
         approvalStatus: 'approved',
       }),
     ]);
     clickGridView();
 
+    // Grid cards surface Release Status (not Approval) so a Released item never
+    // reads as a bare "Draft" (JOV-3333).
     expect(
-      screen.getByTestId('library-approval-status-release-1')
-    ).toHaveTextContent('Needs Review');
+      screen.getByTestId('library-release-status-release-1')
+    ).toHaveTextContent('Released');
     expect(
-      screen.getByTestId('library-approval-status-release-2')
-    ).toHaveTextContent('Approved');
+      screen.getByTestId('library-release-status-release-1')
+    ).toHaveAccessibleName('Release Status: Released');
+    expect(
+      screen.queryByTestId('library-approval-status-release-1')
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Show filters' }));
     fireEvent.click(screen.getByRole('button', { name: /Needs Review/u }));
 
     await waitFor(() => {
       expect(
-        screen.getByTestId('library-approval-status-release-1')
+        screen.getByTestId('library-release-status-release-2')
       ).toBeInTheDocument();
       expect(
-        screen.queryByTestId('library-approval-status-release-2')
+        screen.queryByTestId('library-release-status-release-1')
+      ).toBeNull();
+      expect(
+        screen.queryByTestId('library-release-status-release-3')
       ).toBeNull();
     });
+  });
+
+  it('keeps Approval Status once in the detail rail editor only', () => {
+    renderLibrary([
+      buildAsset({ status: 'released', approvalStatus: 'draft' }),
+    ]);
+
+    fireEvent.click(screen.getByTestId('library-release-row-release-1'));
+
+    const drawer = within(screen.getByTestId('library-asset-drawer'));
+    // Hero shows release status only — no duplicate approval pill.
+    expect(
+      drawer.getByTestId('library-release-status-release-1')
+    ).toHaveTextContent('Released');
+    expect(
+      drawer.queryByTestId('library-approval-status-release-1')
+    ).not.toBeInTheDocument();
+    // Editable approval lives exactly once under Details.
+    expect(
+      drawer.getByRole('button', { name: 'Approval Status' })
+    ).toBeInTheDocument();
+    expect(
+      drawer.getAllByRole('button', { name: 'Approval Status' })
+    ).toHaveLength(1);
   });
 
   it('keeps the approval status inline control labelled after the details refactor', () => {

--- a/apps/web/tests/unit/library/library-system-b-compliance.test.ts
+++ b/apps/web/tests/unit/library/library-system-b-compliance.test.ts
@@ -71,4 +71,15 @@ describe('library right-rail System B structural compliance', () => {
     expect(surface).not.toMatch(/<select[^>]*library-approval-status-select/);
     expect(surface).toContain('TOOLBAR_MENU_CONTENT_CLASS');
   });
+
+  it('surfaces Release Status on cards/hero and Approval Status once in Details (JOV-3333)', () => {
+    // Grid card badge must use release status classes, not approval.
+    expect(surface).toContain('library-release-status-');
+    expect(surface).toContain('Release Status: ${formatLibraryStatus');
+    // Drawer hero must not render a second approval pill next to release.
+    // Approval lives only in ApprovalStatusEditor under Details.
+    expect(surface).toContain('ApprovalStatusEditor');
+    // Card status data-testid is release, not approval.
+    expect(surface).toContain('library-release-status-${asset.id}');
+  });
 });

--- a/apps/web/tests/unit/releases/release-archive-policy.test.ts
+++ b/apps/web/tests/unit/releases/release-archive-policy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isProviderIngestedSource,
+  isReleasePublished,
+  shouldArchiveOnlyRelease,
+} from '@/lib/releases/release-archive-policy';
+
+describe('release-archive-policy (JOV-3885)', () => {
+  it('treats only ingested/admin source types as provider-ingested', () => {
+    expect(isProviderIngestedSource('ingested')).toBe(true);
+    expect(isProviderIngestedSource('admin')).toBe(true);
+    expect(isProviderIngestedSource('manual')).toBe(false);
+    expect(isProviderIngestedSource(null)).toBe(false);
+    expect(isProviderIngestedSource(undefined)).toBe(false);
+  });
+
+  it('treats released status or past release date as published', () => {
+    expect(
+      isReleasePublished({ status: 'released', releaseDate: undefined })
+    ).toBe(true);
+    expect(
+      isReleasePublished({
+        status: 'draft',
+        releaseDate: '2020-01-01T00:00:00.000Z',
+      })
+    ).toBe(true);
+    expect(
+      isReleasePublished({
+        status: 'draft',
+        releaseDate: '2099-01-01T00:00:00.000Z',
+      })
+    ).toBe(false);
+    expect(
+      isReleasePublished({ status: 'scheduled', releaseDate: undefined })
+    ).toBe(false);
+  });
+
+  it('archives only provider-ingested published releases', () => {
+    expect(
+      shouldArchiveOnlyRelease({
+        status: 'released',
+        sourceType: 'ingested',
+        releaseDate: '2020-01-01T00:00:00.000Z',
+      })
+    ).toBe(true);
+    expect(
+      shouldArchiveOnlyRelease({
+        status: 'released',
+        sourceType: 'manual',
+        releaseDate: '2020-01-01T00:00:00.000Z',
+      })
+    ).toBe(false);
+    expect(
+      shouldArchiveOnlyRelease({
+        status: 'draft',
+        sourceType: 'ingested',
+        releaseDate: '2099-01-01T00:00:00.000Z',
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes library/chat rail bugs in one batch:

- **JOV-3333** — Released items no longer show bare “Draft” (approval). Cards/hero use **Release Status**; Approval Status is editable **once** in Details.
- **JOV-3493** — Chat release right-rail: Library-style card elevation, `ProviderIcon` on DSP rows, System B type scale (no all-caps/oversized chrome).
- **JOV-3492** — Non-image chat attachments render as rich file chips (icon + decoded filename); no raw `*.blob.vercel-storage.com` text.
- **JOV-3885** — Provider-ingested + published releases **archive** (`deleted_at`); Jovie-created/manual releases **hard-delete**.

## Linear
- Fixes JOV-3333
- Fixes JOV-3493
- Fixes JOV-3492
- Fixes JOV-3885

<!-- linear-issue-id:JOV-3333 -->
<!-- linear-issue-id:JOV-3493 -->
<!-- linear-issue-id:JOV-3492 -->
<!-- linear-issue-id:JOV-3885 -->

## Test plan
- [x] `biome check` on edited paths
- [x] eslint on staged TS (Title Case aria-label fixed)
- [x] unit: `file-display-name`, `release-archive-policy`, `library-system-b-compliance`, file-attachment source guard (17 tests)
- [x] Direct `tsc` scan: **no errors in changed files** (worktree deps were thrashing; CI is source of truth)
- [ ] CI: typecheck / unit / PR Ready

## Risk notes
- Delete semantics change: ingested published → archive (soft hide), not block / hard delete.
- Library grid badge now shows release status (not approval); approval still filterable + editable.

## Escape hatch
Local pre-push typecheck skipped via `JOVIE_SKIP_PRE_PUSH_GATE=1` because this machine’s worktree `node_modules` graph was corrupted under parallel agents (false-positive missing `better-auth` / `drizzle-zod` / drizzle version skew). Changed files typecheck clean; CI gate owns merge correctness.