### PR TITLE
fix(profile): escapes, platform remove, claim footer, unpublished alerts

### DIFF
--- a/.github/workflows/pr-size-guard-label-override.yml
+++ b/.github/workflows/pr-size-guard-label-override.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   override:
     name: PR Size Guard Label Override
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 2
     if: >-
       github.event.pull_request.user.login != 'dependabot[bot]' &&

--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -12,8 +12,9 @@ name: PR Size Guard
 # merge loop does this constantly) cancels the in-flight run via
 # cancel-in-progress, leaving a CANCELLED/QUEUED run as the latest for a
 # required context → GitHub pins the PR BLOCKED even though it's green
-# (JOV-3580). The big-pr/codemod opt-out is still honored on push via
-# `gh pr view` at run time. When the label lands after a failing run,
+# (JOV-3580). The big-pr/codemod opt-out is honored on push via the webhook
+# payload (no GraphQL — avoids rate-limit flakes on bypass). When the label
+# lands after a failing run,
 # pr-size-guard-label-override.yml posts a passing check-run override.
 on:
   pull_request:
@@ -42,6 +43,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           MAX_LINES: ${{ vars.PR_MAX_LINES || '800' }}
           MAX_FILES: ${{ vars.PR_MAX_FILES || '40' }}
         run: |
@@ -51,13 +54,13 @@ jobs:
           # `big-pr`-bypassed member would fail size guard on the synthetic draft and
           # abort the whole merge group. Members were already size-checked individually.
           # Exit 0 (not skip) so the required "PR Size Guard" context reports success.
-          title=$(gh pr view "$PR" -R "$REPO" --json title -q '.title')
+          title="$PR_TITLE"
           case "$title" in
             '[Graphite MQ]'*)
               echo "✅ Graphite merge-queue group draft — size guard not applicable (members checked individually)"; exit 0;;
           esac
 
-          labels=$(gh pr view "$PR" -R "$REPO" --json labels -q '[.labels[].name]|join(",")')
+          labels="$PR_LABELS"
           case ",$labels," in
             *,big-pr,*|*,codemod,*)
               echo "✅ opt-out label present — PR Size Guard skipped"; exit 0;;

--- a/apps/web/app/[username]/[slug]/_lib/data.ts
+++ b/apps/web/app/[username]/[slug]/_lib/data.ts
@@ -5,7 +5,7 @@
  * Used by both the main smart link page and the /sounds page.
  */
 
-import { and, sql as drizzleSql, eq, isNotNull } from 'drizzle-orm';
+import { and, sql as drizzleSql, eq, isNotNull, isNull } from 'drizzle-orm';
 import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 import { sanitizeCacheTags } from '@/lib/cache/tags';
@@ -653,6 +653,49 @@ function rehydrateContent(
     releaseDate: cached.releaseDate ? new Date(cached.releaseDate) : null,
     revealDate: cached.revealDate ? new Date(cached.revealDate) : null,
   };
+}
+
+/**
+ * Soft presence check for an entity that exists but is not public-eligible yet.
+ * Used to convert 404s into alerts opt-in (JOV-3682). Does not leak draft
+ * status beyond title + existence; deleted rows still resolve to null.
+ */
+export async function getUnpublishedReleasePresence(
+  creatorProfileId: string,
+  slug: string
+): Promise<{ readonly title: string } | null> {
+  try {
+    const [row] = await db
+      .select({
+        title: discogReleases.title,
+        status: discogReleases.status,
+      })
+      .from(discogReleases)
+      .where(
+        and(
+          eq(discogReleases.creatorProfileId, creatorProfileId),
+          eq(discogReleases.slug, slug),
+          isNull(discogReleases.deletedAt)
+        )
+      )
+      .limit(1);
+
+    if (!row) return null;
+    return { title: row.title };
+  } catch (error) {
+    logger.error(
+      'Failed unpublished release presence check',
+      {
+        creatorProfileId,
+        error,
+        helper: 'getUnpublishedReleasePresence',
+        route: '/[username]/[slug]',
+        slug,
+      },
+      'public-smart-link'
+    );
+    return null;
+  }
 }
 
 /**

--- a/apps/web/app/[username]/[slug]/page.tsx
+++ b/apps/web/app/[username]/[slug]/page.tsx
@@ -10,12 +10,14 @@
 import { Metadata } from 'next';
 import { notFound, permanentRedirect } from 'next/navigation';
 import type React from 'react';
+import { Suspense } from 'react';
 import { PreferredDspRedirect } from '@/app/[username]/[slug]/PreferredDspRedirect';
 import { PreserveSearchRedirect } from '@/app/[username]/[slug]/PreserveSearchRedirect';
 import {
   type FeaturedArtist,
   ReleaseLandingPage,
 } from '@/app/r/[slug]/ReleaseLandingPage';
+import { UnpublishedEntityAlerts } from '@/components/features/alerts/UnpublishedEntityAlerts';
 import { BASE_URL } from '@/constants/app';
 import {
   MysteryReleasePage,
@@ -39,12 +41,14 @@ import { getCreatorEntitlements } from '@/lib/entitlements/creator-plan';
 import { getArtistEntitySameAs } from '@/lib/entity/queries';
 import { toDateOnlySafe, toISOStringOrNull } from '@/lib/utils/date';
 import { safeJsonLdStringify } from '@/lib/utils/json-ld';
+import type { Artist } from '@/types/db';
 import {
   checkPromoDownloads,
   getContentBySlug,
   getCreatorByUsername,
   getFeaturedSmartLinkStaticParams,
   getReleaseTrackList,
+  getUnpublishedReleasePresence,
 } from './_lib/data';
 import { generateMusicStructuredData } from './_lib/structured-data';
 
@@ -69,7 +73,7 @@ type Content = NonNullable<Awaited<ReturnType<typeof getContentBySlug>>>;
 async function resolveContentOrRedirect(
   creator: Creator,
   slug: string
-): Promise<Content> {
+): Promise<Content | null> {
   const content = await getContentBySlug(creator.id, slug);
   if (content) return content;
 
@@ -79,7 +83,23 @@ async function resolveContentOrRedirect(
       `/${creator.usernameNormalized}/${redirectInfo.currentSlug}`
     );
   }
-  notFound();
+  return null;
+}
+
+function creatorToArtist(creator: Creator): Artist {
+  return {
+    id: creator.id,
+    owner_user_id: creator.userId ?? '',
+    handle: creator.usernameNormalized,
+    spotify_id: '',
+    name: creator.displayName ?? creator.username,
+    image_url: creator.avatarUrl ?? undefined,
+    published: true,
+    is_verified: false,
+    is_featured: false,
+    marketing_opt_out: false,
+    created_at: new Date().toISOString(),
+  };
 }
 
 export default async function ContentSmartLinkPage({
@@ -99,6 +119,21 @@ export default async function ContentSmartLinkPage({
   }
 
   const content = await resolveContentOrRedirect(creator, slug);
+  if (!content) {
+    // Real-but-unpublished entity → alerts opt-in instead of 404 (JOV-3682).
+    const unpublished = await getUnpublishedReleasePresence(creator.id, slug);
+    if (!unpublished) {
+      notFound();
+    }
+    return (
+      <Suspense fallback={null}>
+        <UnpublishedEntityAlerts
+          artist={creatorToArtist(creator)}
+          entityTitle={unpublished.title}
+        />
+      </Suspense>
+    );
+  }
 
   // Tracks use a client redirect here to preserve query params like dsp/UTM
   // while keeping this route prerendered. Metadata points crawlers at the
@@ -587,6 +622,15 @@ export async function generateMetadata({
 
   const content = await getContentBySlug(creator.id, slug);
   if (!content) {
+    const unpublished = await getUnpublishedReleasePresence(creator.id, slug);
+    if (unpublished) {
+      const artistName = creator.displayName ?? creator.username;
+      return {
+        title: `Coming soon · ${artistName}`,
+        description: `Something new from ${artistName} is still in the works. Get alerts the moment it drops.`,
+        robots: { index: false, follow: false },
+      };
+    }
     return { title: 'Not Found' };
   }
 

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -354,6 +354,8 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
         visitTrackingToken={visitTrackingToken}
         showSubscriptionConfirmedBanner={!isPublicNoAuthSmoke}
         showShopButton={isShopEnabled(profileSettings)}
+        showClaimFooter={!profile.is_claimed}
+        claimFooterHref={`/${encodeURIComponent(artist.handle)}/claim?next=auth`}
         profileSettings={{
           showOldReleases: profileSettings.showOldReleases === true,
         }}

--- a/apps/web/app/a/[handle]/[slug]/page.tsx
+++ b/apps/web/app/a/[handle]/[slug]/page.tsx
@@ -1,14 +1,39 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+import { UnpublishedEntityAlerts } from '@/components/features/alerts/UnpublishedEntityAlerts';
 import { LibraryAssetShareSurface } from '@/components/features/library-asset-share/LibraryAssetShareSurface';
 import { PublicPageShell } from '@/components/site/PublicPageShell';
-import { buildLibraryAssetSharePublicViewBySlug } from '@/lib/library/asset-share-public.server';
+import {
+  buildLibraryAssetSharePendingViewBySlug,
+  buildLibraryAssetSharePublicViewBySlug,
+} from '@/lib/library/asset-share-public.server';
+import type { Artist } from '@/types/db';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 interface PublicAssetPageProps {
   readonly params: Promise<{ handle: string; slug: string }>;
+}
+
+function toArtistFromShareView(view: {
+  readonly artistName: string;
+  readonly artistHandle: string;
+  readonly assetId: string;
+}): Artist {
+  return {
+    id: view.assetId,
+    owner_user_id: '',
+    handle: view.artistHandle,
+    spotify_id: '',
+    name: view.artistName,
+    published: true,
+    is_verified: false,
+    is_featured: false,
+    marketing_opt_out: false,
+    created_at: new Date().toISOString(),
+  };
 }
 
 export async function generateMetadata({
@@ -20,32 +45,43 @@ export async function generateMetadata({
     shareSlug: slug,
   });
 
-  if (!view) {
+  if (view) {
+    const title = `${view.title} · ${view.artistName} · Jovie`;
     return {
-      title: 'Asset not found · Jovie',
+      title,
+      description: `Public asset page for ${view.title} by ${view.artistName}.`,
+      robots: { index: true, follow: true },
+      openGraph: {
+        title,
+        description: `Public asset page for ${view.title} by ${view.artistName}.`,
+        type: 'website',
+        siteName: 'Jovie',
+        images: view.artworkUrl ? [{ url: view.artworkUrl }] : undefined,
+      },
+      twitter: {
+        card: view.artworkUrl ? 'summary_large_image' : 'summary',
+        title,
+        description: `Public asset page for ${view.title} by ${view.artistName}.`,
+        images: view.artworkUrl ? [view.artworkUrl] : undefined,
+      },
+    };
+  }
+
+  const pending = await buildLibraryAssetSharePendingViewBySlug({
+    artistHandle: handle,
+    shareSlug: slug,
+  });
+  if (pending) {
+    return {
+      title: `Coming soon · ${pending.artistName} · Jovie`,
+      description: `Something new from ${pending.artistName} is still in the works. Get alerts the moment it drops.`,
       robots: { index: false, follow: false },
     };
   }
 
-  const title = `${view.title} · ${view.artistName} · Jovie`;
-
   return {
-    title,
-    description: `Public asset page for ${view.title} by ${view.artistName}.`,
-    robots: { index: true, follow: true },
-    openGraph: {
-      title,
-      description: `Public asset page for ${view.title} by ${view.artistName}.`,
-      type: 'website',
-      siteName: 'Jovie',
-      images: view.artworkUrl ? [{ url: view.artworkUrl }] : undefined,
-    },
-    twitter: {
-      card: view.artworkUrl ? 'summary_large_image' : 'summary',
-      title,
-      description: `Public asset page for ${view.title} by ${view.artistName}.`,
-      images: view.artworkUrl ? [view.artworkUrl] : undefined,
-    },
+    title: 'Asset not found · Jovie',
+    robots: { index: false, follow: false },
   };
 }
 
@@ -58,17 +94,34 @@ export default async function LibraryAssetPublicSharePage({
     shareSlug: slug,
   });
 
-  if (!view) {
+  if (view) {
+    return (
+      <PublicPageShell
+        headerVariant='landing'
+        logoSize='xs'
+        mainClassName='bg-(--linear-bg-page)'
+      >
+        <LibraryAssetShareSurface view={view} />
+      </PublicPageShell>
+    );
+  }
+
+  // Real entity exists but is not public yet — convert 404 into alerts opt-in.
+  // Secret /p/[token] links still render the full private surface.
+  const pending = await buildLibraryAssetSharePendingViewBySlug({
+    artistHandle: handle,
+    shareSlug: slug,
+  });
+  if (!pending) {
     notFound();
   }
 
   return (
-    <PublicPageShell
-      headerVariant='landing'
-      logoSize='xs'
-      mainClassName='bg-(--linear-bg-page)'
-    >
-      <LibraryAssetShareSurface view={view} />
-    </PublicPageShell>
+    <Suspense fallback={null}>
+      <UnpublishedEntityAlerts
+        artist={toArtistFromShareView(pending)}
+        entityTitle={pending.title}
+      />
+    </Suspense>
   );
 }

--- a/apps/web/components/features/alerts/AlertGrowthLanding.tsx
+++ b/apps/web/components/features/alerts/AlertGrowthLanding.tsx
@@ -241,7 +241,7 @@ export function AlertGrowthLanding({
         <div className='mb-4 flex items-center justify-between gap-3'>
           <Link
             href={profileHref}
-            className='inline-flex h-10 items-center gap-1.5 rounded-full px-1 text-sm font-medium text-secondary-token transition-colors duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)'
+            className='inline-flex h-10 items-center gap-1.5 rounded-full px-1 text-sm font-medium text-secondary-token transition-colors duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
             data-testid='alerts-landing-back'
             aria-label={`Back To ${artistName}`}
           >
@@ -250,7 +250,7 @@ export function AlertGrowthLanding({
           </Link>
           <Link
             href={profileHref}
-            className='inline-flex h-10 w-10 items-center justify-center rounded-full text-secondary-token transition-colors duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)'
+            className='inline-flex h-10 w-10 items-center justify-center rounded-full text-secondary-token transition-colors duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
             data-testid='alerts-landing-close'
             aria-label='Close Alerts Capture'
           >

--- a/apps/web/components/features/alerts/AlertGrowthLanding.tsx
+++ b/apps/web/components/features/alerts/AlertGrowthLanding.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ArrowLeft, X } from 'lucide-react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useCallback, useId, useMemo, useState } from 'react';
@@ -25,6 +26,11 @@ interface AlertGrowthLandingProps {
    * `useSearchParams`, which lets the page render statically.
    */
   readonly sourceCode?: string;
+  /**
+   * In-page exit target. Defaults to the artist profile so visitors always
+   * have a non-browser-chrome way out of the capture surface (JOV-3513).
+   */
+  readonly exitHref?: string;
 }
 
 type SubmitState =
@@ -112,6 +118,7 @@ function getInputValidationError(
 export function AlertGrowthLanding({
   artist,
   sourceCode: sourceCodeProp,
+  exitHref,
 }: AlertGrowthLandingProps) {
   const [channel, setChannel] = useState<NotificationChannel>('sms');
   const [phoneInput, setPhoneInput] = useState('');
@@ -136,6 +143,8 @@ export function AlertGrowthLanding({
   );
 
   const artistName = artist.name?.trim() || artist.handle;
+  const profileHref =
+    exitHref ?? `/${encodeURIComponent(artist.handle.trim().toLowerCase())}`;
 
   const handleChannelChange = useCallback((next: NotificationChannel) => {
     setChannel(next);
@@ -228,7 +237,27 @@ export function AlertGrowthLanding({
 
   return (
     <main className='min-h-dvh bg-(--linear-app-content-surface) text-primary-token'>
-      <div className='mx-auto flex min-h-dvh max-w-108 flex-col px-5 py-10 sm:py-12'>
+      <div className='mx-auto flex min-h-dvh max-w-108 flex-col px-5 py-6 sm:py-10'>
+        <div className='mb-4 flex items-center justify-between gap-3'>
+          <Link
+            href={profileHref}
+            className='inline-flex h-10 items-center gap-1.5 rounded-full px-1 text-sm font-medium text-secondary-token transition-colors duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)'
+            data-testid='alerts-landing-back'
+            aria-label={`Back To ${artistName}`}
+          >
+            <ArrowLeft className='h-4 w-4' aria-hidden='true' />
+            <span>Back</span>
+          </Link>
+          <Link
+            href={profileHref}
+            className='inline-flex h-10 w-10 items-center justify-center rounded-full text-secondary-token transition-colors duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)'
+            data-testid='alerts-landing-close'
+            aria-label='Close Alerts Capture'
+          >
+            <X className='h-4 w-4' aria-hidden='true' />
+          </Link>
+        </div>
+
         <header className='mb-6'>
           <p className='text-secondary-token text-app'>{APP_LABEL}</p>
           <h1 className='mt-2 text-2xl font-semibold leading-[1.08] tracking-normal'>
@@ -358,6 +387,16 @@ export function AlertGrowthLanding({
             </li>
           ))}
         </ul>
+
+        <div className='mt-6 text-center'>
+          <Link
+            href={profileHref}
+            className='text-secondary-token text-sm underline-offset-4 transition-colors duration-subtle hover:text-primary-token hover:underline'
+            data-testid='alerts-landing-maybe-later'
+          >
+            Maybe Later
+          </Link>
+        </div>
 
         <footer className='text-secondary-token mt-auto pt-10 text-xs'>
           Powered by{' '}

--- a/apps/web/components/features/alerts/UnpublishedEntityAlerts.tsx
+++ b/apps/web/components/features/alerts/UnpublishedEntityAlerts.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Link from 'next/link';
+import { AlertGrowthLanding } from '@/components/features/alerts/AlertGrowthLanding';
+import type { Artist } from '@/types/db';
+
+export interface UnpublishedEntityAlertsProps {
+  readonly artist: Artist;
+  /** Optional release/entity title for copy; never required. */
+  readonly entityTitle?: string | null;
+}
+
+/**
+ * Public-facing opt-in when a real entity exists but is not live yet.
+ * Reuses the alerts capture surface so fan intent is owned (JOV-3682).
+ */
+export function UnpublishedEntityAlerts({
+  artist,
+  entityTitle,
+}: UnpublishedEntityAlertsProps) {
+  const artistName = artist.name?.trim() || artist.handle;
+  const profileHref = `/${encodeURIComponent(artist.handle.trim().toLowerCase())}`;
+
+  return (
+    <div data-testid='unpublished-entity-alerts'>
+      <div className='mx-auto max-w-108 px-5 pt-8 sm:pt-10'>
+        <p className='text-secondary-token text-sm leading-6'>
+          Looks like this is still in the works from{' '}
+          <Link
+            href={profileHref}
+            className='text-primary-token font-medium underline-offset-4 hover:underline'
+          >
+            {artistName}
+          </Link>
+          {entityTitle ? (
+            <>
+              {' '}
+              — <span className='text-primary-token'>{entityTitle}</span>
+            </>
+          ) : null}
+          . Want alerts the moment it drops?
+        </p>
+      </div>
+      <AlertGrowthLanding artist={artist} exitHref={profileHref} />
+    </div>
+  );
+}

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceSidebar.tsx
@@ -3,9 +3,12 @@
 import { Button } from '@jovie/ui';
 
 import Image from 'next/image';
+import { useCallback, useState } from 'react';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import type { DspPresenceItem } from '@/app/app/(shell)/dashboard/presence/actions';
 import { Icon } from '@/components/atoms/Icon';
+import { toast } from '@/components/feedback';
+import { ConfirmDialog } from '@/components/molecules/ConfirmDialog';
 import { DrawerSection } from '@/components/molecules/drawer/DrawerSection';
 import { DrawerSurfaceCard } from '@/components/molecules/drawer/DrawerSurfaceCard';
 import { EntitySidebarShell } from '@/components/molecules/drawer/EntitySidebarShell';
@@ -92,7 +95,7 @@ function SidebarEntityHeader({
               <div
                 className='absolute -bottom-0.5 -right-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/60'
                 role='img'
-                aria-label='Profile image missing'
+                aria-label='Profile Image Missing'
               >
                 <Icon
                   name='Camera'
@@ -133,6 +136,10 @@ function getMatchSourceLabel(matchSource: string | null): string {
 
 function SidebarContent({ item }: { readonly item: DspPresenceItem }) {
   const isSuggested = item.status === 'suggested';
+  const isLinked =
+    item.status === 'confirmed' ||
+    item.status === 'auto_confirmed' ||
+    item.matchSource === 'manual';
   const label = PROVIDER_LABELS[item.providerId];
 
   return (
@@ -188,12 +195,18 @@ function SidebarContent({ item }: { readonly item: DspPresenceItem }) {
                 className='h-8 w-full justify-start rounded-full border-subtle bg-surface-0 px-3 text-xs font-caption'
               >
                 <Icon name='ExternalLink' className='mr-1.5 h-3.5 w-3.5' />
-                View on {label}
+                View On {label}
               </Button>
             </a>
           )}
 
           {isSuggested && <SuggestedMatchActions matchId={item.matchId} />}
+          {isLinked && !isSuggested && (
+            <RemovePlatformAction
+              matchId={item.matchId}
+              providerLabel={label}
+            />
+          )}
         </div>
       </DrawerSection>
     </div>
@@ -234,5 +247,68 @@ function SuggestedMatchActions({ matchId }: { readonly matchId: string }) {
         {isConfirming ? 'Confirming...' : 'Confirm Match'}
       </Button>
     </div>
+  );
+}
+
+function RemovePlatformAction({
+  matchId,
+  providerLabel,
+}: {
+  readonly matchId: string;
+  readonly providerLabel: string;
+}) {
+  const dashboardData = useDashboardData();
+  const profileId = dashboardData.selectedProfile?.id;
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const { rejectMatch, isRejecting } = useDspMatchActions({
+    profileId: profileId ?? '',
+    onRejectSuccess: () => {
+      toast.success(`${providerLabel} removed`);
+      setConfirmOpen(false);
+    },
+    onError: () => {
+      toast.error(`Failed to remove ${providerLabel}. Please try again.`);
+    },
+  });
+
+  const handleConfirm = useCallback(() => {
+    if (!profileId) return;
+    rejectMatch(matchId, 'user_disconnected');
+  }, [matchId, profileId, rejectMatch]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (isRejecting) return;
+      setConfirmOpen(open);
+    },
+    [isRejecting]
+  );
+
+  if (!profileId) return null;
+
+  return (
+    <>
+      <Button
+        variant='ghost'
+        size='sm'
+        onClick={() => setConfirmOpen(true)}
+        disabled={isRejecting}
+        className='h-8 w-full justify-start rounded-full border border-subtle bg-surface-0 px-3 text-xs font-caption text-error-token'
+        data-testid='presence-remove-platform'
+      >
+        <Icon name='Trash2' className='mr-1.5 h-3.5 w-3.5' />
+        {isRejecting ? 'Removing...' : 'Remove Platform'}
+      </Button>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={handleOpenChange}
+        title={`Remove ${providerLabel}?`}
+        description='Removing this platform link stops sync updates until you add it again.'
+        confirmLabel='Remove'
+        variant='destructive'
+        onConfirm={handleConfirm}
+      />
+    </>
   );
 }

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceSidebar.tsx
@@ -135,6 +135,8 @@ function getMatchSourceLabel(matchSource: string | null): string {
 }
 
 function SidebarContent({ item }: { readonly item: DspPresenceItem }) {
+  const dashboardData = useDashboardData();
+  const profileId = dashboardData.selectedProfile?.id;
   const isSuggested = item.status === 'suggested';
   const isLinked =
     item.status === 'confirmed' ||
@@ -201,12 +203,13 @@ function SidebarContent({ item }: { readonly item: DspPresenceItem }) {
           )}
 
           {isSuggested && <SuggestedMatchActions matchId={item.matchId} />}
-          {isLinked && !isSuggested && (
+          {isLinked && !isSuggested && profileId ? (
             <RemovePlatformAction
               matchId={item.matchId}
               providerLabel={label}
+              profileId={profileId}
             />
-          )}
+          ) : null}
         </div>
       </DrawerSection>
     </div>
@@ -253,16 +256,16 @@ function SuggestedMatchActions({ matchId }: { readonly matchId: string }) {
 function RemovePlatformAction({
   matchId,
   providerLabel,
+  profileId,
 }: {
   readonly matchId: string;
   readonly providerLabel: string;
+  readonly profileId: string;
 }) {
-  const dashboardData = useDashboardData();
-  const profileId = dashboardData.selectedProfile?.id;
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const { rejectMatch, isRejecting } = useDspMatchActions({
-    profileId: profileId ?? '',
+    profileId,
     onRejectSuccess: () => {
       toast.success(`${providerLabel} removed`);
       setConfirmOpen(false);
@@ -273,9 +276,8 @@ function RemovePlatformAction({
   });
 
   const handleConfirm = useCallback(() => {
-    if (!profileId) return;
     rejectMatch(matchId, 'user_disconnected');
-  }, [matchId, profileId, rejectMatch]);
+  }, [matchId, rejectMatch]);
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -284,8 +286,6 @@ function RemovePlatformAction({
     },
     [isRejecting]
   );
-
-  if (!profileId) return null;
 
   return (
     <>

--- a/apps/web/components/features/profile/ProfileClaimFooter.tsx
+++ b/apps/web/components/features/profile/ProfileClaimFooter.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { useIsAuthenticated } from '@/hooks/useIsAuthenticated';
+import { track } from '@/lib/analytics';
+import { cn } from '@/lib/utils';
+
+export interface ProfileClaimFooterProps {
+  readonly href: string;
+  readonly className?: string;
+  /** When false, hide for owners / claimed-by-viewer surfaces. Default true. */
+  readonly enabled?: boolean;
+}
+
+/**
+ * Desktop spare-space growth footer under the public profile card.
+ * Hidden on mobile and for authenticated viewers (JOV-3544).
+ */
+export function ProfileClaimFooter({
+  href,
+  className,
+  enabled = true,
+}: ProfileClaimFooterProps) {
+  const isAuthenticated = useIsAuthenticated();
+
+  if (!enabled || isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn('hidden w-full justify-center pt-4 md:flex', className)}
+      data-testid='profile-claim-footer'
+    >
+      <Link
+        href={href}
+        className='inline-flex items-center gap-2 text-sm font-medium tracking-normal text-white/55 transition-colors duration-subtle hover:text-white/88 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
+        data-testid='profile-claim-footer-cta'
+        onClick={() => {
+          track('profile_claim_footer_click', {
+            destination: href,
+          });
+        }}
+      >
+        <span className='text-white/70' aria-hidden='true'>
+          Jovie
+        </span>
+        <span className='text-white/30' aria-hidden='true'>
+          ·
+        </span>
+        <span>Claim Your Profile</span>
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/components/features/profile/StaticArtistPage.tsx
+++ b/apps/web/components/features/profile/StaticArtistPage.tsx
@@ -48,6 +48,8 @@ export interface StaticArtistPageProps {
   readonly merchCards?: readonly PublicMerchCard[];
   readonly hideJovieBranding?: boolean;
   readonly hideMoreMenu?: boolean;
+  readonly showClaimFooter?: boolean;
+  readonly claimFooterHref?: string | null;
 }
 
 export function StaticArtistPage({
@@ -81,6 +83,8 @@ export function StaticArtistPage({
   merchCards,
   hideJovieBranding = false,
   hideMoreMenu = false,
+  showClaimFooter = false,
+  claimFooterHref = null,
 }: StaticArtistPageProps) {
   const viewModel = buildProfilePublicViewModel({
     mode,
@@ -142,6 +146,8 @@ export function StaticArtistPage({
       merchCards={viewModel.merchCards}
       hideJovieBranding={hideJovieBranding}
       hideMoreMenu={hideMoreMenu}
+      showClaimFooter={showClaimFooter}
+      claimFooterHref={claimFooterHref}
     />
   );
 }

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -88,6 +88,9 @@ interface ProfileCompactTemplateProps {
   readonly hideJovieBranding?: boolean;
   readonly hideMoreMenu?: boolean;
   readonly visualVariant?: 'default';
+  /** Desktop spare-space claim footer (JOV-3544). */
+  readonly showClaimFooter?: boolean;
+  readonly claimFooterHref?: string | null;
 }
 
 function resolveDrawerView(
@@ -227,6 +230,8 @@ export function ProfileCompactTemplate({
   hideJovieBranding = false,
   hideMoreMenu = false,
   visualVariant = 'default',
+  showClaimFooter = false,
+  claimFooterHref = null,
 }: ProfileCompactTemplateProps) {
   // alertOptInVariant starts as the ISR-rendered default ('button').
   // AnonCookieBootstrap resolves the per-user Statsig variant on mount and
@@ -720,6 +725,8 @@ export function ProfileCompactTemplate({
         isDesktopLayout={isDesktopLayout}
         shouldRenderHeading={shouldRenderTemplateHeading}
         profileAccentStyle={profileAccentStyle}
+        showClaimFooter={showClaimFooter}
+        claimFooterHref={claimFooterHref}
         compactSurface={
           <div
             className='public-profile-compact-shell relative flex h-full min-w-0 w-full flex-col overflow-hidden bg-(--profile-content-bg) md:mx-auto md:rounded-(--profile-shell-card-radius) md:border md:border-(--profile-panel-border) md:shadow-(--profile-panel-shadow)'

--- a/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { CSSProperties, ReactNode } from 'react';
+import { ProfileClaimFooter } from '@/features/profile/ProfileClaimFooter';
 import { cn } from '@/lib/utils';
 
 interface PublicProfileLayoutShellProps {
@@ -14,6 +15,9 @@ interface PublicProfileLayoutShellProps {
   readonly shouldRenderHeading: boolean;
   readonly profileAccentStyle: CSSProperties;
   readonly compactSurface: ReactNode;
+  /** Desktop spare-space growth CTA (JOV-3544). */
+  readonly claimFooterHref?: string | null;
+  readonly showClaimFooter?: boolean;
 }
 
 export function PublicProfileLayoutShell({
@@ -24,6 +28,8 @@ export function PublicProfileLayoutShell({
   shouldRenderHeading,
   profileAccentStyle,
   compactSurface,
+  claimFooterHref = null,
+  showClaimFooter = false,
 }: Readonly<PublicProfileLayoutShellProps>) {
   // The background blur stage is 84px blurred and 28% opaque — a CSS radial
   // gradient using the artist accent color is visually identical and eliminates
@@ -32,18 +38,12 @@ export function PublicProfileLayoutShell({
   const hasAmbientBg = Boolean(heroImageUrl && !heroImageError);
   return (
     <div
-      className='profile-viewport relative overflow-hidden bg-(--profile-stage-bg) text-primary-token'
-      style={{
-        ...profileAccentStyle,
-        height: 'calc(100dvh - var(--cookie-banner-h, 0px))',
-      }}
+      className='profile-viewport relative h-[calc(100dvh-var(--cookie-banner-h,0px))] overflow-hidden bg-(--profile-stage-bg) text-primary-token md:h-auto md:min-h-[calc(100dvh-var(--cookie-banner-h,0px))] md:overflow-x-hidden md:overflow-y-auto'
+      style={profileAccentStyle}
       data-testid='public-profile-layout-shell'
     >
       <div className='absolute inset-0' aria-hidden='true'>
         <div className='absolute inset-0 sm:inset-[-10%]'>
-          {/* CSS-only ambient glow — replaces the blurred full-res image.
-              At blur-[84px] + opacity-28 the image is visually indistinguishable
-              from a solid radial gradient, saving ~96KB per page load (JOV-2263). */}
           <div
             className={cn(
               'h-full w-full',
@@ -58,20 +58,25 @@ export function PublicProfileLayoutShell({
 
       <div
         className={cn(
-          'public-profile-layout-frame relative mx-auto flex w-full items-stretch justify-center',
+          'public-profile-layout-frame relative mx-auto flex w-full justify-center',
+          // Center the stable stage container (not per-content height) so
+          // mode/tab switches do not reflow vertical position (JOV-1369).
           isDesktopLayout
-            ? 'public-profile-layout-frame--desktop'
-            : 'public-profile-layout-frame--compact md:items-center'
+            ? 'public-profile-layout-frame--desktop min-h-[calc(100dvh-var(--cookie-banner-h,0px))] items-center'
+            : 'public-profile-layout-frame--compact min-h-[calc(100dvh-var(--cookie-banner-h,0px))] items-stretch md:items-center'
         )}
         data-layout={isDesktopLayout ? 'desktop' : 'compact'}
       >
-        <main className='relative flex h-full min-w-0 w-full items-stretch md:items-center'>
+        <main className='relative flex min-h-0 min-w-0 w-full flex-col items-center justify-center'>
           {shouldRenderHeading ? (
             <h1 className='sr-only'>{artistName}</h1>
           ) : null}
           <div className='public-profile-layout-compact-slot'>
             {compactSurface}
           </div>
+          {showClaimFooter && claimFooterHref ? (
+            <ProfileClaimFooter href={claimFooterHref} enabled />
+          ) : null}
         </main>
       </div>
     </div>

--- a/apps/web/components/organisms/public-surface/PublicSurfaceStage.tsx
+++ b/apps/web/components/organisms/public-surface/PublicSurfaceStage.tsx
@@ -6,30 +6,37 @@ export interface PublicSurfaceStageProps {
   readonly children: React.ReactNode;
   readonly className?: string;
   readonly panelClassName?: string;
+  /** Optional content rendered below the stage card (desktop growth footer). */
+  readonly afterPanel?: React.ReactNode;
 }
 
 export function PublicSurfaceStage({
   children,
   className,
   panelClassName,
+  afterPanel,
 }: Readonly<PublicSurfaceStageProps>) {
   return (
     <div
       className={cn(
-        'relative mx-auto flex h-dvh w-full max-w-170 items-stretch justify-center md:h-auto md:min-h-dvh md:items-center md:px-6 md:py-8',
+        // min-h-dvh (not fixed h) so md:items-center has spare room when the
+        // card is shorter than the viewport; natural scroll when content is taller.
+        'relative mx-auto flex min-h-dvh w-full max-w-170 items-stretch justify-center md:items-center md:px-6 md:py-8',
         className
       )}
     >
-      <main className='relative flex w-full items-stretch md:items-center'>
+      <main className='relative flex w-full flex-col items-stretch justify-center md:items-center'>
         <div
           className={cn(
-            'relative flex h-full w-full max-w-(--profile-shell-max-width) flex-col overflow-clip bg-(--profile-content-bg) md:mx-auto md:min-h-[min(920px,calc(100dvh-64px))] md:overflow-hidden md:rounded-(--profile-card-radius) md:border md:border-(--profile-panel-border) md:shadow-(--profile-panel-shadow)',
+            // Do not stretch the phone-frame to full viewport height (JOV-3544).
+            'relative flex h-full w-full max-w-(--profile-shell-max-width) flex-col overflow-clip bg-(--profile-content-bg) md:mx-auto md:h-auto md:max-h-[min(920px,calc(100dvh-64px))] md:min-h-0 md:overflow-hidden md:rounded-(--profile-card-radius) md:border md:border-(--profile-panel-border) md:shadow-(--profile-panel-shadow)',
             panelClassName
           )}
         >
           <div className='pointer-events-none absolute inset-0 bg-(--profile-panel-gradient)' />
           {children}
         </div>
+        {afterPanel}
       </main>
     </div>
   );

--- a/apps/web/lib/library/asset-share-public.server.ts
+++ b/apps/web/lib/library/asset-share-public.server.ts
@@ -154,3 +154,35 @@ export async function buildLibraryAssetSharePublicViewBySlug(input: {
     visibility: 'public',
   });
 }
+
+/**
+ * Resolve a public-slug entity even when visibility is still private.
+ * Used to turn "not live yet" into an alerts opt-in instead of a 404.
+ */
+export async function buildLibraryAssetSharePendingViewBySlug(input: {
+  readonly artistHandle: string;
+  readonly shareSlug: string;
+}): Promise<LibraryAssetSharePublicView | null> {
+  const resolved = await resolveLibraryAssetShareByPublicSlug({
+    ...input,
+    publicOnly: false,
+  });
+  if (!resolved) return null;
+  if (resolved.settings.visibility === 'public') {
+    return buildPublicViewForSettings({
+      creatorProfileId: resolved.settings.creatorProfileId,
+      assetId: resolved.settings.assetId,
+      itemKind: resolved.settings.itemKind,
+      artistHandle: resolved.artistHandle,
+      visibility: 'public',
+    });
+  }
+
+  return buildPublicViewForSettings({
+    creatorProfileId: resolved.settings.creatorProfileId,
+    assetId: resolved.settings.assetId,
+    itemKind: resolved.settings.itemKind,
+    artistHandle: resolved.artistHandle,
+    visibility: 'private',
+  });
+}

--- a/apps/web/lib/library/asset-share.server.ts
+++ b/apps/web/lib/library/asset-share.server.ts
@@ -339,11 +339,25 @@ export async function resolveLibraryAssetShareByToken(
 export async function resolveLibraryAssetShareByPublicSlug(input: {
   readonly artistHandle: string;
   readonly shareSlug: string;
+  /**
+   * When true (default), only public share rows resolve — private rows 404
+   * at the call site so they can render an alerts opt-in instead (JOV-3682).
+   */
+  readonly publicOnly?: boolean;
 }): Promise<{
   readonly settings: typeof libraryAssetShareSettings.$inferSelect;
   readonly artistHandle: string;
 } | null> {
   const normalizedHandle = input.artistHandle.trim().toLowerCase();
+  const publicOnly = input.publicOnly !== false;
+
+  const filters = [
+    eq(creatorProfiles.usernameNormalized, normalizedHandle),
+    eq(libraryAssetShareSettings.shareSlug, input.shareSlug),
+  ];
+  if (publicOnly) {
+    filters.push(eq(libraryAssetShareSettings.visibility, 'public'));
+  }
 
   const [row] = await db
     .select({
@@ -355,13 +369,7 @@ export async function resolveLibraryAssetShareByPublicSlug(input: {
       creatorProfiles,
       eq(libraryAssetShareSettings.creatorProfileId, creatorProfiles.id)
     )
-    .where(
-      and(
-        eq(creatorProfiles.usernameNormalized, normalizedHandle),
-        eq(libraryAssetShareSettings.shareSlug, input.shareSlug),
-        eq(libraryAssetShareSettings.visibility, 'public')
-      )
-    )
+    .where(and(...filters))
     .limit(1);
 
   if (!row?.settings || !row.artistHandle) return null;

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -168,7 +168,6 @@
 }
 
 .public-profile-layout-frame {
-  height: 100%;
   max-width: min(100%, var(--content-max));
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
@@ -186,14 +185,35 @@
 
 .public-profile-layout-frame--compact {
   max-width: min(100%, calc(var(--content-max) + (var(--page-pad) * 2)));
+  /* Mobile: fill viewport so the phone-frame surface can stretch. */
+  height: 100%;
+  min-height: calc(100dvh - var(--cookie-banner-h, 0px));
 }
 
 .public-profile-layout-compact-slot {
   display: flex;
-  height: 100%;
   min-width: 0;
   width: 100%;
   flex-direction: column;
+}
+
+/* Mobile: slot fills frame so the card can use full height. */
+.public-profile-layout-frame--compact .public-profile-layout-compact-slot {
+  height: 100%;
+  flex: 1 1 auto;
+}
+
+/* Desktop: slot sizes to the card so vertical centering has spare space. */
+@media (min-width: 768px) {
+  .public-profile-layout-frame--compact {
+    height: auto;
+  }
+
+  .public-profile-layout-frame--compact .public-profile-layout-compact-slot,
+  .public-profile-layout-frame--desktop .public-profile-layout-compact-slot {
+    height: auto;
+    flex: 0 0 auto;
+  }
 }
 
 .public-profile-layout-desktop-shell {

--- a/apps/web/tests/unit/components/alerts/AlertGrowthLanding.test.tsx
+++ b/apps/web/tests/unit/components/alerts/AlertGrowthLanding.test.tsx
@@ -38,6 +38,17 @@ describe('<AlertGrowthLanding>', () => {
     expect(screen.getByText(/Get alerts first/i)).toBeDefined();
   });
 
+  it('always exposes in-page escape hatches back to the profile', () => {
+    render(<AlertGrowthLanding artist={ARTIST} />);
+    const back = screen.getByTestId('alerts-landing-back');
+    const close = screen.getByTestId('alerts-landing-close');
+    const later = screen.getByTestId('alerts-landing-maybe-later');
+    expect(back).toHaveAttribute('href', '/tim');
+    expect(close).toHaveAttribute('href', '/tim');
+    expect(later).toHaveAttribute('href', '/tim');
+    expect(screen.getByText(/Maybe later/i)).toBeDefined();
+  });
+
   it('defaults to SMS, submits with E.164 phone + US country code', async () => {
     render(<AlertGrowthLanding artist={ARTIST} />);
 

--- a/apps/web/tests/unit/components/alerts/UnpublishedEntityAlerts.test.tsx
+++ b/apps/web/tests/unit/components/alerts/UnpublishedEntityAlerts.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/queries/useNotificationStatusQuery', () => ({
+  useSubscribeNotificationsMutation: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('@/lib/error-tracking', () => ({ captureError: vi.fn() }));
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import { UnpublishedEntityAlerts } from '@/components/features/alerts/UnpublishedEntityAlerts';
+import type { Artist } from '@/types/db';
+
+const ARTIST: Artist = {
+  id: 'artist-1',
+  owner_user_id: 'user-1',
+  handle: 'tim',
+  spotify_id: '4u',
+  name: 'Tim White',
+} as Artist;
+
+describe('<UnpublishedEntityAlerts>', () => {
+  it('renders still-in-the-works copy and alerts capture', () => {
+    render(
+      <UnpublishedEntityAlerts artist={ARTIST} entityTitle='Midnight Drive' />
+    );
+    expect(screen.getByTestId('unpublished-entity-alerts')).toBeInTheDocument();
+    expect(screen.getByText(/still in the works/i)).toBeInTheDocument();
+    expect(screen.getByText(/Midnight Drive/)).toBeInTheDocument();
+    expect(screen.getByText(/Get alerts first/i)).toBeInTheDocument();
+    expect(screen.getByTestId('alerts-landing-back')).toHaveAttribute(
+      'href',
+      '/tim'
+    );
+  });
+});

--- a/apps/web/tests/unit/dashboard/DspPresenceSidebar.test.tsx
+++ b/apps/web/tests/unit/dashboard/DspPresenceSidebar.test.tsx
@@ -142,7 +142,7 @@ describe('DspPresenceSidebar', () => {
       screen.getByRole('button', { name: 'Confirm Match' })
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument();
-    expect(screen.getByText('View on Spotify')).toBeInTheDocument();
+    expect(screen.getByText('View On Spotify')).toBeInTheDocument();
   });
 
   it('hides suggested actions for manually linked platforms', () => {
@@ -172,7 +172,7 @@ describe('DspPresenceSidebar', () => {
     expect(
       screen.queryByRole('button', { name: 'Reject' })
     ).not.toBeInTheDocument();
-    expect(screen.getByText('View on Apple Music')).toBeInTheDocument();
+    expect(screen.getByText('View On Apple Music')).toBeInTheDocument();
   });
 
   it('calls confirm and reject match actions', async () => {

--- a/apps/web/tests/unit/dashboard/drawer-chrome.test.tsx
+++ b/apps/web/tests/unit/dashboard/drawer-chrome.test.tsx
@@ -5,6 +5,16 @@ import { AudienceMemberSidebar } from '@/features/dashboard/organisms/audience-m
 import { DspPresenceSidebar } from '@/features/dashboard/organisms/dsp-presence/DspPresenceSidebar';
 import type { AudienceMember } from '@/types';
 
+const { mockUseDashboardData, mockUseDspMatchActions } = vi.hoisted(() => ({
+  mockUseDashboardData: vi.fn(() => ({ selectedProfile: null })),
+  mockUseDspMatchActions: vi.fn(() => ({
+    confirmMatch: vi.fn(),
+    rejectMatch: vi.fn(),
+    isConfirming: false,
+    isRejecting: false,
+  })),
+}));
+
 vi.mock('@jovie/ui', async () => {
   const actual = await vi.importActual<object>('@jovie/ui');
   return {
@@ -16,6 +26,14 @@ vi.mock('@jovie/ui', async () => {
     ),
   };
 });
+
+vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
+  useDashboardData: mockUseDashboardData,
+}));
+
+vi.mock('@/features/dashboard/organisms/dsp-matches/hooks', () => ({
+  useDspMatchActions: mockUseDspMatchActions,
+}));
 
 const audienceMember: AudienceMember = {
   id: 'aud-1',
@@ -110,7 +128,7 @@ describe('dashboard drawer chrome', () => {
     expect(screen.queryByText('DSP profile')).not.toBeInTheDocument();
     expect(screen.getByText('Discovered via Spotify')).toBeInTheDocument();
     expect(screen.getByText('Tracks Verified')).toBeInTheDocument();
-    expect(screen.getByLabelText('Profile image missing')).toBeInTheDocument();
+    expect(screen.getByLabelText('Profile Image Missing')).toBeInTheDocument();
     expect(screen.queryByText('Confidence Breakdown')).not.toBeInTheDocument();
   });
 

--- a/apps/web/tests/unit/dashboard/dsp-presence-sidebar-remove.test.tsx
+++ b/apps/web/tests/unit/dashboard/dsp-presence-sidebar-remove.test.tsx
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sidebarPath = path.resolve(
+  process.cwd(),
+  'components/features/dashboard/organisms/dsp-presence/DspPresenceSidebar.tsx'
+);
+
+describe('DspPresenceSidebar remove platform source contract', () => {
+  const source = readFileSync(sidebarPath, 'utf8');
+
+  it('exposes a confirmed-platform remove action with confirmation', () => {
+    expect(source).toContain('RemovePlatformAction');
+    expect(source).toContain('presence-remove-platform');
+    expect(source).toContain('ConfirmDialog');
+    expect(source).toContain('user_disconnected');
+    expect(source).toContain('Remove Platform');
+  });
+
+  it('only offers remove for linked (non-suggested) matches', () => {
+    expect(source).toContain('isLinked');
+    expect(source).toContain('!isSuggested');
+    expect(source).toContain('SuggestedMatchActions');
+  });
+});

--- a/apps/web/tests/unit/profile/profile-claim-footer.test.tsx
+++ b/apps/web/tests/unit/profile/profile-claim-footer.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useIsAuthenticated = vi.fn(() => false);
+
+vi.mock('@/hooks/useIsAuthenticated', () => ({
+  useIsAuthenticated: () => useIsAuthenticated(),
+}));
+
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
+
+import { ProfileClaimFooter } from '@/features/profile/ProfileClaimFooter';
+
+describe('ProfileClaimFooter', () => {
+  beforeEach(() => {
+    useIsAuthenticated.mockReturnValue(false);
+  });
+
+  it('renders claim CTA for logged-out visitors', () => {
+    render(<ProfileClaimFooter href='/tim/claim?next=auth' enabled />);
+    const cta = screen.getByTestId('profile-claim-footer-cta');
+    expect(cta).toHaveAttribute('href', '/tim/claim?next=auth');
+    expect(screen.getByText(/Claim your profile/i)).toBeInTheDocument();
+  });
+
+  it('hides for authenticated viewers', () => {
+    useIsAuthenticated.mockReturnValue(true);
+    render(<ProfileClaimFooter href='/tim/claim?next=auth' enabled />);
+    expect(screen.queryByTestId('profile-claim-footer')).toBeNull();
+  });
+
+  it('hides when disabled', () => {
+    render(<ProfileClaimFooter href='/tim/claim?next=auth' enabled={false} />);
+    expect(screen.queryByTestId('profile-claim-footer')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Batch profile-escape fixes for public capture/presence surfaces.

- **JOV-3884**: Presence DSP sidebar now has Remove Platform + ConfirmDialog for linked platforms (not only suggested reject).
- **JOV-3513**: Email/SMS Alerts capture page gets Back, Close, and Maybe Later exits to the artist profile (no browser-chrome-only trap).
- **JOV-3544**: Desktop public profile stage vertically centers the stable card container; spare-space Claim Your Profile footer for unclaimed profiles (desktop, logged-out).
- **JOV-3682**: Real-but-unpublished smart links and private `/a/{handle}/{slug}` assets render alerts opt-in instead of 404; secret `/p/{token}` still works.

## Verification
- `pnpm --filter web exec vitest run` focused unit tests (23 passed): AlertGrowthLanding, UnpublishedEntityAlerts, presence-remove source contract, ProfileClaimFooter
- `pnpm --filter @jovie/web run typecheck` green (local)
- biome + eslint via pre-commit/lint-staged green

## Layout-shift notes (UI)
- Centering applies to the stable stage frame, not per-content height (JOV-1369 guard).
- Mobile profile remains full-viewport height; desktop uses min-height + center + natural scroll when content exceeds viewport.

## Cost Impact
None (UI/route presentation only; reuses existing subscribe mutation).

Fixes JOV-3884
Fixes JOV-3513
Fixes JOV-3544
Fixes JOV-3682

<!-- linear-issue-id:JOV-3884 -->
<!-- linear-issue-id:JOV-3513 -->
<!-- linear-issue-id:JOV-3544 -->
<!-- linear-issue-id:JOV-3682 -->