### PR TITLE
ci(perf): blobless clones on hot jobs + var-switchable runners (JOV-4171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: steps.graphite.outputs.skip != 'true'
         with:
+          # Blobless partial clone: full commit graph for merge-base/diff
+          # (names only), no historical file contents. Cuts the clone from
+          # ~30-40s (worse under runner throttling) to seconds on this repo;
+          # any blob that is actually needed is lazy-fetched on demand.
           fetch-depth: 0
+          filter: blob:none
       - name: Detect path changes for all job types
         if: steps.graphite.outputs.skip != 'true'
         id: detect
@@ -663,15 +668,23 @@ jobs:
     # Draft PRs skip; ready PRs + pushes + merge queue run typecheck
     # Note: Runs in parallel with lint for speed (no dependency on cache-warm)
     needs: [ci-path-changes]
-    # Runs on GitHub-hosted runners (typecheck --force means no turbo cache benefit).
-    runs-on: ubuntu-latest
+    # Runner is var-switchable: CI_FAST_RUNNER=jovie-runner offloads typecheck
+    # to the self-hosted pool when hosted concurrency is the bottleneck
+    # (free-plan orgs get ~20 concurrent hosted jobs + fair-use throttling —
+    # see gbrain jovie-ci-actions-budget-stall-2026-07-10). Typecheck uploads
+    # no artifacts, so the pool's slow egress doesn't bite.
+    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name != 'pull_request' || needs.ci-path-changes.outputs.has_code_changes == 'true') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Full history needed for turbo --affected merge-base detection
+          # Full history needed for turbo --affected merge-base detection.
+          # Blobless: --affected only needs the commit graph + changed-file
+          # names; HEAD blobs are materialized at checkout, historical blobs
+          # lazy-fetch if ever needed.
           fetch-depth: 0
+          filter: blob:none
       - uses: ./.github/actions/setup-node-pnpm
       - name: Cache Turbo
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -2456,8 +2469,11 @@ jobs:
     # Parallel with typecheck/build for faster CI.
     # Path-gated: skips test execution when no test-relevant files changed.
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') }}
-    # 5-shard unit tests on GitHub-hosted runners for reliability (turbo remote cache works on any runner).
-    runs-on: ubuntu-latest
+    # 5-shard unit tests; runner is var-switchable (CI_UNIT_RUNNER=jovie-runner
+    # offloads all shards to the self-hosted pool when hosted concurrency is
+    # the bottleneck). Defaults to GitHub-hosted. Shards upload no artifacts on
+    # the PR path (coverage is nightly-only), so pool egress is not a concern.
+    runs-on: ${{ vars.CI_UNIT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -2470,7 +2486,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0  # Full history for vitest --changed
+          fetch-depth: 0 # Full history for vitest --changed (names via commit graph)
+          filter: blob:none # historical blobs lazy-fetch; saves ~30s × 5 shards/run
 
       - name: Check for relevant changes
         id: check_changes


### PR DESCRIPTION
## Why
Org is on the GitHub free plan: ~20 concurrent hosted jobs with fair-use throttling (observed 2–5 effective during today's stall, JOV-4174). Per-run hosted demand is the binding constraint until the plan is upgraded — and cheap to cut regardless.

## What
1. **`filter: blob:none`** on the three `fetch-depth: 0` checkouts that run on every PR (`ci-path-changes`, `ci-typecheck`, `ci-unit-tests` ×5 shards). Commit graph retained — `merge-base`, `turbo --affected`, `vitest --changed` all work on names; historical blobs lazy-fetch on demand. Saves ~30–40s × 7 job instances/run, and shortens every PR's critical path since Path Changes gates all other jobs.
2. **Var-switchable runners**: `ci-typecheck` → `vars.CI_FAST_RUNNER` (currently `jovie-runner` → offloads to the 10 idle self-hosted machines now), `ci-unit-tests` → `vars.CI_UNIT_RUNNER` (defaults hosted; one-var flip in a crunch). Neither uploads artifacts on the PR path, so pool egress (364KB/s, #13444) doesn't bite.

## Verification
- actionlint: no new findings vs base
- `pnpm ci:harness:check` + `pnpm ci:merge-queue:check`: pass
- pre-push hook (proxy-guard, tailwind:check, full typecheck): pass

## Cost Impact
- **Hosted minutes**: −3–5 min per CI run; typecheck minutes move to self-hosted ($0)
- **Scaling factor**: O(runs) — multiplies across every PR and push
- No new external API calls or crons

Related: JOV-4174 (plan upgrade, tim-action-required), JOV-4171 (remaining levers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)