### PR TITLE
fix(profile): eliminate public profile UI jank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 ## [Unreleased]
 
 - [internal] **Test reliability batch (JOV-4112, JOV-4033, JOV-1880)**: stop Playwright from importing `server-only` env helpers in E2E dashboard route resolvers; drop quarantined specs from the PR smoke manifest and add a guardrail test; seed a prebuilt claim fixture and desktop smoke for the GTM claim-link canary.
+- **Tagging knows your world (JOV-3717)**: Artist picker cold-starts with your claimed Spotify artist and catalog collaborators (with ids) above Spotify search.
+
+- **Public artist profiles now feel native at every size (JOV-2018)**: Square artwork stays square, portraits keep a face-safe crop, profile rails use one consistent card size, scrollbars stay out of sight, and sparse or subscription states no longer leave awkward gaps.
+- **Unclaimed artist profiles now include a concise claim card (JOV-2018)**: Desktop AEO pages end with an editorial Jovie prompt and a single Spotify-verified claim action.
 
 - [internal] **Single machine-readable design-token source, wave 1 (GH-12009, GH-10158)**: New `apps/web/design/tokens.json` compiled by `scripts/build-design-tokens.mjs` (`pnpm tokens:build` / `tokens:check`) into generated CSS (`--gray1..12` now resolve app-wide), a typed TS export, and an agent manifest. `--linear-*` namespace is now shrink-only ratcheted (`linear-namespace-ratchet.test.ts`, baseline 2242), and a source-vs-emitter divergence guard locks tokens.json to the live accent palette. No visual changes.
 - [internal] **One EmptyState primitive (GH-12638)**: Canonical molecule at `components/molecules/EmptyState` (greyscale icon + Title Case heading + one sentence + primary CTA + optional text-link secondary). Migrated DSP presence/matches, insights, release tasks, and table empty surfaces onto it; deleted 5 bespoke `*EmptyState` components; component-family ratchet emptyState 14→9.

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -361,7 +361,14 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
         releases={releases}
         merchCards={merchCards}
       />
-      <ProfileAeoContent content={aeoContent} />
+      <ProfileAeoContent
+        content={aeoContent}
+        claimHref={
+          !profile.is_claimed && directClaimSupported
+            ? `/${encodeURIComponent(artist.handle)}/claim?next=auth`
+            : undefined
+        }
+      />
       {isPublicNoAuthSmoke ? null : (
         <DesktopQrOverlayClient handle={artist.handle} />
       )}

--- a/apps/web/components/features/profile/ProfileAeoContent.tsx
+++ b/apps/web/components/features/profile/ProfileAeoContent.tsx
@@ -1,46 +1,57 @@
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { Mark } from '@/lib/brand';
 import type { ProfileAeoContent as ProfileAeoContentModel } from '@/lib/profile/aeo-content';
 
 interface ProfileAeoContentProps {
   readonly content: ProfileAeoContentModel;
+  readonly claimHref?: string;
 }
 
-export function ProfileAeoContent({ content }: ProfileAeoContentProps) {
+export function ProfileAeoContent({
+  content,
+  claimHref,
+}: ProfileAeoContentProps) {
   return (
     <section
       aria-labelledby='profile-aeo-heading'
-      className='profile-aeo-content px-4 py-10 sm:px-6 lg:px-8'
+      className='profile-aeo-content px-4 py-14 sm:px-6 lg:px-8 lg:py-20'
       data-testid='profile-aeo-content'
     >
-      <div className='mx-auto max-w-3xl space-y-8'>
-        <div className='space-y-3'>
+      <div className='profile-aeo-content__inner mx-auto grid max-w-5xl gap-12 border-t pt-10 lg:gap-16 lg:pt-14'>
+        <div className='space-y-4 lg:sticky lg:top-12 lg:self-start'>
           <h2
             id='profile-aeo-heading'
-            className='profile-aeo-content__heading text-xl font-semibold leading-tight'
+            className='profile-aeo-content__heading text-3xl font-semibold leading-tight tracking-tight text-balance'
           >
             About {content.artistName}
           </h2>
-          <div className='profile-aeo-content__body space-y-3 text-mid leading-7'>
+          <div className='profile-aeo-content__body space-y-4 text-mid leading-7 text-pretty'>
             {content.description.map(paragraph => (
               <p key={paragraph}>{paragraph}</p>
             ))}
           </div>
         </div>
 
-        <div className='space-y-4'>
-          <h3 className='profile-aeo-content__subheading text-base font-semibold leading-tight'>
+        <div className='space-y-5'>
+          <h3 className='profile-aeo-content__subheading text-xl font-semibold leading-tight tracking-tight'>
             {content.artistName} FAQ
           </h3>
           <dl className='profile-aeo-content__faq-list divide-y border-y'>
             {content.faqs.map(item => (
-              <div key={item.question} className='py-4'>
-                <dt className='profile-aeo-content__term text-mid font-semibold leading-6'>
+              <div
+                key={item.question}
+                className='profile-aeo-content__faq-item grid gap-2 py-5 sm:gap-6'
+              >
+                <dt className='profile-aeo-content__term text-mid font-semibold leading-6 text-pretty'>
                   {item.question}
                 </dt>
-                <dd className='profile-aeo-content__answer mt-2 text-sm leading-6'>
-                  <span>{item.answer}</span>{' '}
+                <dd className='profile-aeo-content__answer text-sm leading-6 text-pretty'>
+                  <span>{item.answer}</span>
+                  <span aria-hidden='true'> </span>
                   <a
                     href={item.source.href}
-                    className='profile-aeo-content__source font-medium underline underline-offset-4 transition-colors duration-subtle'
+                    className='profile-aeo-content__source inline-flex font-medium underline underline-offset-4 transition-colors duration-subtle'
                   >
                     Source: {item.source.label}
                   </a>
@@ -49,6 +60,55 @@ export function ProfileAeoContent({ content }: ProfileAeoContentProps) {
             ))}
           </dl>
         </div>
+
+        {claimHref ? (
+          <aside
+            aria-labelledby='profile-aeo-claim-heading'
+            className='profile-aeo-claim-card relative overflow-hidden rounded-[2rem] border p-7 sm:p-10 lg:col-span-2 lg:p-12'
+            data-testid='profile-aeo-claim-card'
+          >
+            <div className='relative grid items-end gap-10 lg:grid-cols-[minmax(0,1.4fr)_minmax(16rem,0.6fr)] lg:gap-16'>
+              <div className='max-w-2xl'>
+                <div className='mb-10 flex items-center gap-3'>
+                  <Mark
+                    size={46}
+                    className='profile-aeo-claim-card__mark shrink-0'
+                  />
+                  <p className='profile-aeo-claim-card__eyebrow text-xs font-semibold uppercase tracking-[0.16em]'>
+                    Jovie artist profiles
+                  </p>
+                </div>
+                {/* eslint-disable @jovie/canonical-ui-label-casing -- User-approved editorial sentence case. */}
+                <h2
+                  id='profile-aeo-claim-heading'
+                  className='profile-aeo-claim-card__heading max-w-[14ch] text-4xl font-semibold leading-[0.98] tracking-[-0.045em] text-balance sm:text-5xl lg:text-6xl'
+                >
+                  Claim yours.
+                </h2>
+                {/* eslint-enable @jovie/canonical-ui-label-casing */}
+              </div>
+
+              <div className='flex flex-col items-start gap-6 lg:pb-1'>
+                <p className='profile-aeo-claim-card__body max-w-md text-base leading-7 text-pretty'>
+                  Music, shows, and fan updates. One place.
+                </p>
+                <Link
+                  href={claimHref}
+                  prefetch={false}
+                  className='profile-aeo-claim-card__cta inline-flex min-h-12 items-center justify-center gap-3 rounded-full px-6 text-sm font-semibold transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-claim-ink) focus-visible:ring-offset-2'
+                  aria-label={`Claim the ${content.artistName} profile and sign up for Jovie`}
+                  data-testid='profile-aeo-claim-cta'
+                >
+                  Claim artist profile
+                  <ArrowRight className='size-4' aria-hidden='true' />
+                </Link>
+                <p className='profile-aeo-claim-card__note text-xs font-medium'>
+                  Free · Spotify verified
+                </p>
+              </div>
+            </div>
+          </aside>
+        ) : null}
       </div>
     </section>
   );

--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -210,7 +210,10 @@ function SubscribePanel({
   if (!isSubscribed || keepSubscribeFlowMounted) {
     return (
       <div
-        className={NATIVE_PANEL_CLASS_NAME}
+        className={cn(
+          NATIVE_PANEL_CLASS_NAME,
+          'flex h-full min-h-full flex-col'
+        )}
         data-testid='profile-primary-tab-subscribe'
       >
         {subscribeTwoStep ? (
@@ -288,7 +291,10 @@ function ProfileMusicEmptyState({
     );
 
   return (
-    <div className='px-4 pb-4' data-testid='profile-primary-tab-music-empty'>
+    <div
+      className='flex flex-1 items-center px-4 pb-4'
+      data-testid='profile-primary-tab-music-empty'
+    >
       <ProfileEmptyBentoCard
         accent='music'
         icon={Music2}
@@ -538,7 +544,7 @@ export function ProfilePrimaryTabPanel({
 
     return (
       <div
-        className={NATIVE_PANEL_CLASS_NAME}
+        className={cn(NATIVE_PANEL_CLASS_NAME, 'flex min-h-full flex-col')}
         data-testid='profile-primary-tab-listen'
       >
         <div className='px-4 pb-2 pt-3'>
@@ -558,7 +564,7 @@ export function ProfilePrimaryTabPanel({
   if (mode === 'tour') {
     return (
       <div
-        className={NATIVE_PANEL_CLASS_NAME}
+        className={cn(NATIVE_PANEL_CLASS_NAME, 'flex min-h-full flex-col')}
         data-testid='profile-primary-tab-tour'
       >
         <div className='px-4 pb-2 pt-3'>
@@ -571,6 +577,11 @@ export function ProfilePrimaryTabPanel({
           tourDates={[...tourDates]}
           emptyStateSourceContext={eventsEmptySourceContext}
           renderMode={renderMode}
+          className={
+            tourDates.length === 0
+              ? 'flex flex-1 flex-col justify-center'
+              : undefined
+          }
         />
       </div>
     );

--- a/apps/web/components/features/profile/TourModePanel.tsx
+++ b/apps/web/components/features/profile/TourModePanel.tsx
@@ -271,11 +271,13 @@ export function TourDrawerContent({
   tourDates,
   emptyStateSourceContext,
   renderMode = 'interactive',
+  className,
 }: Readonly<{
   readonly artist: Artist;
   readonly tourDates: TourDateViewModel[];
   readonly emptyStateSourceContext?: NotificationSourceContext;
   readonly renderMode?: ProfileRenderMode;
+  readonly className?: string;
 }>) {
   const { location } = useUserLocation();
   const { nearbyDates, allDates } = useTourDateProximity(tourDates, location);
@@ -290,7 +292,7 @@ export function TourDrawerContent({
     };
 
   return (
-    <div data-testid='tour-drawer-content'>
+    <div className={cn(className)} data-testid='tour-drawer-content'>
       <TourDatesContent
         artist={artist}
         nearby={nearbyDates}

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
@@ -347,7 +347,7 @@ function InlineCaptureField({
           type='button'
           onClick={onSubmit}
           disabled={isSubmitting}
-          className='inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white text-black transition-opacity duration-subtle hover:opacity-92 disabled:cursor-not-allowed disabled:opacity-55 dark:bg-white dark:text-black'
+          className='inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-black transition-opacity duration-subtle hover:opacity-92 disabled:cursor-not-allowed disabled:opacity-55 dark:bg-white dark:text-black'
           aria-label='Submit'
         >
           <Send className='size-4' />
@@ -519,7 +519,7 @@ export function ProfileMobileNotificationsFlow({
                   type='button'
                   onClick={() => onChannelChange(isSms ? 'email' : 'sms')}
                   disabled={isSubmitting}
-                  className='inline-flex h-9 items-center gap-1.5 rounded-full px-1 text-xs font-semibold text-white/62 transition-colors duration-subtle hover:text-white disabled:cursor-not-allowed disabled:opacity-50'
+                  className='inline-flex h-11 items-center gap-1.5 rounded-full px-1 text-xs font-semibold text-white/62 transition-colors duration-subtle hover:text-white disabled:cursor-not-allowed disabled:opacity-50'
                 >
                   {isSms ? (
                     <Mail className='size-3.5' />
@@ -533,7 +533,7 @@ export function ProfileMobileNotificationsFlow({
                     type='button'
                     onClick={onDismissCapture}
                     disabled={isSubmitting}
-                    className='inline-flex h-9 items-center rounded-full px-1 text-xs font-semibold text-white/48 transition-colors duration-subtle hover:text-white/70 disabled:cursor-not-allowed disabled:opacity-50'
+                    className='inline-flex h-11 items-center rounded-full px-1 text-xs font-semibold text-white/48 transition-colors duration-subtle hover:text-white/70 disabled:cursor-not-allowed disabled:opacity-50'
                   >
                     Not Now
                   </button>
@@ -926,7 +926,7 @@ export function ProfileMobileNotificationsFlow({
       </div>
     ) : (
       <div
-        className='relative min-h-150 rounded-(--profile-card-radius) bg-[color:var(--profile-stage-bg)] dark:text-white'
+        className='relative flex h-full min-h-full flex-1 flex-col rounded-(--profile-card-radius) bg-[color:var(--profile-stage-bg)] dark:text-white'
         data-testid='profile-mobile-notifications-flow'
         data-shell-variant='inline-full-height'
         style={contentStyle}

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -404,7 +404,7 @@ export function ProfileCompactSurface({
   const isMenuActive =
     drawerOpen && drawerView === 'menu' && activeVisiblePrimaryTab !== 'tour';
   const topChromeButtonClassName =
-    'h-9! w-9! border-white/14 bg-black/24 text-white dark:text-white shadow-[0_10px_24px_rgba(0,0,0,0.22)] backdrop-blur-md hover:bg-black/36';
+    'h-11! w-11! border-white/14 bg-black/24 text-white dark:text-white shadow-[0_10px_24px_rgba(0,0,0,0.22)] backdrop-blur-md hover:bg-black/36';
   const socialIconClassName =
     'inline-flex h-7 w-7 items-center justify-center text-white/68 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
   // Composition rule (#11899, lib/profile/composition.ts): hero media has
@@ -546,7 +546,7 @@ export function ProfileCompactSurface({
                     fill
                     priority
                     sizes='(max-width: 767px) 100vw, 430px'
-                    className='object-cover object-[50%_34%]'
+                    className='object-cover object-[50%_20%]'
                     fallbackVariant='avatar'
                     fallbackClassName='bg-surface-2'
                   />
@@ -626,10 +626,13 @@ export function ProfileCompactSurface({
           </div>
 
           {isHomeMode ? (
-            <div className='absolute inset-x-0 bottom-0 z-10 px-(--page-pad) pb-5 [@media(max-height:820px)]:pb-4 [@media(max-height:760px)]:pb-3'>
+            <div
+              className='profile-hero-identity-scrim absolute inset-x-0 bottom-0 z-10 px-(--page-pad) pb-5 pt-8 backdrop-blur-[2px] [@media(max-height:820px)]:pb-4 [@media(max-height:760px)]:pb-3'
+              data-testid='profile-hero-identity-block'
+            >
               <div
-                className='min-w-0 rounded-2xl bg-black/18 px-3 py-2.5 shadow-[0_16px_38px_-24px_rgba(0,0,0,0.72)] backdrop-blur-[2px] [overflow-wrap:anywhere] [@media(max-height:820px)]:px-2.5 [@media(max-height:820px)]:py-2'
-                data-testid='profile-hero-identity-block'
+                className='min-w-0 px-3 py-2.5 [overflow-wrap:anywhere] [@media(max-height:820px)]:px-2.5 [@media(max-height:820px)]:py-2'
+                data-testid='profile-hero-identity-content'
               >
                 <IdentityHeading
                   className='min-w-0'
@@ -711,14 +714,14 @@ export function ProfileCompactSurface({
             isHomeMode ? 'pt-0' : 'pt-2'
           )}
         >
-          {shouldRenderInteractiveOverlays ? (
+          {shouldRenderInteractiveOverlays &&
+          activeVisiblePrimaryTab !== 'subscribe' ? (
             <ProfileInlineNotificationsCTA
               artist={artist}
               onManageNotifications={onManageNotifications}
               onRegisterReveal={registerNotificationsReveal}
               portalContainer={notificationsPortalContainer ?? undefined}
               variant='hero'
-              autoOpen={activeVisiblePrimaryTab === 'subscribe'}
               hideTrigger
               experimentVariant={alertOptInVariant}
               source={activeNotificationSourceContext.ctaLocation}
@@ -739,7 +742,7 @@ export function ProfileCompactSurface({
 
           <div
             className={cn(
-              'overflow-y-auto overscroll-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [touch-action:pan-y]',
+              'profile-content-scroll-region overflow-y-auto overscroll-contain',
               homeContentScrollClassName,
               showBottomNav ? CONTENT_SAFE_AREA_BOTTOM_PADDING : 'pb-0',
               !isHomeMode &&

--- a/apps/web/components/organisms/entity-card/EntityCard.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.test.tsx
@@ -106,14 +106,15 @@ describe('EntityCard', () => {
       },
     };
 
-    render(<EntityCard model={interactive} treatment='big' />);
+    render(<EntityCard model={interactive} treatment='detailed' />);
     const card = screen.getByTestId('entity-card-show');
     expect(card.tagName).toBe('DIV');
-    expect(screen.getByRole('link', { name: 'Get Tickets' })).toHaveAttribute(
-      'href',
-      'https://tickets.test/show'
-    );
-    fireEvent.click(screen.getByRole('button', { name: 'Add To Calendar' }));
+    const tickets = screen.getByRole('link', { name: 'Get Tickets' });
+    const calendar = screen.getByRole('button', { name: 'Add To Calendar' });
+    expect(tickets).toHaveAttribute('href', 'https://tickets.test/show');
+    expect(tickets.className).toContain('h-11');
+    expect(calendar.className).toContain('h-11');
+    fireEvent.click(calendar);
     expect(onCalendar).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -79,7 +79,7 @@ function EntityCtaControl({
 }>) {
   const className = cn(
     'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover',
-    block ? 'h-11 w-full' : 'h-8 min-w-0 flex-1',
+    block ? 'h-11 w-full' : 'h-11 min-w-0 flex-1',
     cta.disabled &&
       'cursor-not-allowed border-subtle bg-surface-0 text-tertiary-token hover:border-subtle hover:bg-surface-0'
   );
@@ -190,13 +190,17 @@ export function EntityCard({
   onClick,
 }: EntityCardProps) {
   const size = SIZE[treatment];
-  // Composition shape (#11899): fixed card aspect + fixed 16:9 media zone.
+  // Composition shape (#11899): fixed card aspect + semantic media geometry.
+  // Album/product/show artwork is square; video thumbnails stay landscape.
   // Text truncates inside the shape; the CTA footer never moves.
   const shapeClassName = shape
     ? cn(getProfileCardShapeClassName(shape), 'overflow-hidden')
     : null;
   const artClassName = shape
-    ? cn('aspect-video', treatment === 'big' ? 'rounded-2xl' : 'rounded-xl')
+    ? cn(
+        model.kind === 'video' ? 'aspect-video' : 'aspect-square',
+        treatment === 'big' ? 'rounded-2xl' : 'rounded-xl'
+      )
     : size.artClass;
   const titleClampClassName =
     shape && treatment !== 'big' ? 'line-clamp-1' : 'line-clamp-2';
@@ -248,7 +252,9 @@ export function EntityCard({
             fill
             priority={priority}
             sizes={treatment === 'big' ? '320px' : '180px'}
-            className='object-cover'
+            className={
+              model.kind === 'music' ? 'object-contain' : 'object-cover'
+            }
             fallbackVariant={preset.fallbackVariant}
             fallbackClassName='bg-transparent'
           />

--- a/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { EntityCarousel } from './EntityCarousel';
+import type { EntityCardModel } from './types';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    prefetch: _prefetch,
+    ...props
+  }: {
+    readonly children: React.ReactNode;
+    readonly href: string;
+    readonly prefetch?: boolean;
+    readonly [key: string]: unknown;
+  }) => React.createElement('a', { href, ...props }, children),
+}));
+
+vi.mock('@/components/atoms/ImageWithFallback', () => ({
+  ImageWithFallback: ({
+    alt,
+    className,
+    src,
+  }: {
+    readonly alt: string;
+    readonly className?: string;
+    readonly src: string;
+  }) => React.createElement('img', { alt, className, src }),
+}));
+
+const items: EntityCardModel[] = [
+  {
+    id: 'release-1',
+    kind: 'music',
+    href: '/tim/release-1',
+    imageUrl: '/release-1.jpg',
+    imageAlt: 'Release one',
+    title: 'Release One',
+  },
+  {
+    id: 'release-2',
+    kind: 'music',
+    href: '/tim/release-2',
+    imageUrl: '/release-2.jpg',
+    imageAlt: 'Release two',
+    title: 'Release Two',
+  },
+];
+
+describe('EntityCarousel profile geometry', () => {
+  it('uses one horizontal-only scroll owner and equal card footprints', () => {
+    render(<EntityCarousel items={items} dataTestId='profile-home-carousel' />);
+
+    const carousel = screen.getByTestId('profile-home-carousel');
+    expect(carousel.className).toContain('overflow-x-auto');
+    expect(carousel.className).toContain('overflow-y-hidden');
+    expect(carousel.className).toContain('profile-horizontal-rail');
+    expect(carousel.className).not.toContain('touch-action');
+
+    const footprints = [...carousel.querySelectorAll(':scope > li')];
+    expect(footprints).toHaveLength(2);
+    expect(
+      footprints.every(
+        item =>
+          item.className.includes('w-56') && item.className.includes('h-96')
+      )
+    ).toBe(true);
+
+    for (const card of screen.getAllByTestId('entity-card-music')) {
+      expect(card.className).toContain('h-full');
+      expect(card.className).toContain('overflow-hidden');
+      expect(card.className).not.toContain('aspect-card-standard');
+    }
+  });
+
+  it('keeps release artwork square and fits it without cropping', () => {
+    render(<EntityCarousel items={items} />);
+
+    for (const image of screen.getAllByRole('img')) {
+      expect(image.parentElement?.className).toContain('aspect-square');
+      expect(image.className).toContain('object-contain');
+    }
+  });
+});

--- a/apps/web/components/organisms/entity-card/EntityCarousel.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.tsx
@@ -15,14 +15,10 @@ interface EntityCarouselProps {
 }
 
 /**
- * One horizontal snap track. The featured (first) item renders `big`; the rest
- * render `compact`. This is the single card section for a public-profile home —
- * no stacked sections.
- *
- * ponytail: treatment is SSR-stable (position-only), not a client breakpoint —
- * a JS media-query switch would flip content on hydration and shift layout,
- * which the layout-shift rule bans. Revealing the `detailed` treatment on wide
- * viewports is a CSS container-query enhancement → JOV follow-up, not a hook.
+ * One horizontal snap track with one stable card geometry. Ordering can make an
+ * item prominent, but its dimensions must not change: mixed card sizes create a
+ * false hierarchy, crop the trailing cards, and make the rail look vertically
+ * scrollable inside the fixed profile shell.
  */
 export function EntityCarousel({
   items,
@@ -95,13 +91,12 @@ export function EntityCarousel({
   return (
     <ul
       className={cn(
-        'flex snap-x snap-mandatory list-none gap-3 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+        'profile-horizontal-rail flex snap-x snap-mandatory list-none gap-3 overflow-x-auto overflow-y-hidden overscroll-x-contain',
         className
       )}
       data-testid={dataTestId ?? 'entity-carousel'}
     >
       {items.map((model, index) => {
-        const isFeatured = index === 0;
         return (
           <li
             key={`${model.kind}-${model.id}`}
@@ -111,21 +106,17 @@ export function EntityCarousel({
             data-carousel-index={index}
             // items-start keeps the deterministic shape in charge: a stretched
             // cross-axis would override the card's fixed aspect ratio.
-            className={cn(
-              'flex shrink-0 snap-start items-start',
-              isFeatured ? 'w-65' : 'w-45'
-            )}
+            className='flex h-96 w-56 shrink-0 snap-start items-start'
           >
             <EntityCard
               model={model}
-              treatment={isFeatured ? 'big' : 'compact'}
-              // Composition rule (#11899): profile cards render as the fixed
-              // standard 4:5 shape — height derives from width, never from
-              // content flow, so no "monster vertical" cards.
-              shape='standard'
+              treatment='detailed'
+              // Square art plus metadata and a 44px control cannot fit inside
+              // the old 4:5 shell. The rail owns one explicit 224x384 footprint
+              // so every card stays equal without clipping its useful content.
               surface={surface}
-              priority={isFeatured}
-              className='w-full'
+              priority={index === 0}
+              className='h-full w-full overflow-hidden'
               onClick={
                 onCardClick ? () => onCardClick(index, model) : undefined
               }

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -216,11 +216,76 @@
 
 :where(.profile-aeo-content) {
   --profile-aeo-text: var(--color-text-tooltip);
-  --profile-aeo-muted: var(--color-text-tooltip);
-  --profile-aeo-border: var(--color-border-subtle);
-  background: var(--system-b-cinematic-black);
+  --profile-aeo-muted: color-mix(
+    in oklab,
+    var(--color-text-tooltip) 70%,
+    transparent
+  );
+  --profile-aeo-border: color-mix(
+    in oklab,
+    var(--color-text-tooltip) 14%,
+    transparent
+  );
+  background:
+    linear-gradient(180deg, var(--profile-stage-bg) 0, transparent 12rem),
+    var(--system-b-cinematic-black);
   color: var(--profile-aeo-text);
   color-scheme: dark;
+}
+
+:where(.profile-aeo-content__inner) {
+  border-color: var(--profile-aeo-border);
+}
+
+:where(.profile-aeo-content__heading) {
+  max-inline-size: 18ch;
+}
+
+:where(.profile-aeo-content__body) {
+  max-inline-size: 58ch;
+}
+
+@media (min-width: 1024px) {
+  :where(.profile-aeo-content__inner) {
+    grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+  }
+}
+
+@media (min-width: 640px) {
+  :where(.profile-aeo-content__faq-item) {
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  }
+}
+
+:where(.profile-hero-identity-scrim) {
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    rgba(0, 0, 0, 0.2) 28%,
+    rgba(0, 0, 0, 0.5) 100%
+  );
+}
+
+:where(.profile-horizontal-rail) {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+:where(.profile-horizontal-rail::-webkit-scrollbar) {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+:where(.profile-content-scroll-region) {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+:where(.profile-content-scroll-region::-webkit-scrollbar) {
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 :where(.profile-aeo-content__heading),
@@ -250,6 +315,41 @@
 :where(.profile-aeo-content__source:hover) {
   color: var(--profile-aeo-text);
   text-decoration-color: var(--profile-aeo-text);
+}
+
+:where(.profile-aeo-claim-card) {
+  --profile-aeo-claim-ink: var(--system-b-cinematic-black);
+  background: var(--color-bg-paper);
+  border-color: color-mix(
+    in oklab,
+    var(--profile-aeo-claim-ink) 14%,
+    transparent
+  );
+  box-shadow:
+    0 32px 90px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.82);
+  color: var(--profile-aeo-claim-ink);
+}
+
+:where(.profile-aeo-claim-card__eyebrow),
+:where(.profile-aeo-claim-card__body),
+:where(.profile-aeo-claim-card__note) {
+  color: color-mix(in oklab, var(--profile-aeo-claim-ink) 66%, transparent);
+}
+
+:where(.profile-aeo-claim-card__cta) {
+  background: var(--profile-aeo-claim-ink);
+  color: var(--color-bg-paper);
+}
+
+@media (hover: hover) {
+  :where(.profile-aeo-claim-card__cta:hover) {
+    background: color-mix(
+      in oklab,
+      var(--profile-aeo-claim-ink) 86%,
+      transparent
+    );
+  }
 }
 
 /* Mobile public profiles are a fixed one-screen shell. Keep the AEO copy in the

--- a/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
+++ b/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { cleanup, render, screen } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -124,6 +126,20 @@ function buildContent(): ProfileAeoContentModel {
 describe('Profile AEO content', () => {
   afterEach(cleanup);
 
+  it('keeps dark AEO and light claim-card colors stable across app themes', () => {
+    const css = readFileSync(
+      join(process.cwd(), 'styles', 'design-system.css'),
+      'utf8'
+    );
+
+    expect(css).toMatch(
+      /\.profile-aeo-content\)[\s\S]*?--profile-aeo-text:\s*var\(--color-text-tooltip\)/
+    );
+    expect(css).toMatch(
+      /\.profile-aeo-claim-card\)[\s\S]*?--profile-aeo-claim-ink:\s*var\(--system-b-cinematic-black\)/
+    );
+  });
+
   it('builds per-artist description and the four sourced canonical FAQ answers', () => {
     const content = buildContent();
 
@@ -227,5 +243,34 @@ describe('Profile AEO content', () => {
     expect(html).toContain('data-testid="profile-aeo-content"');
     expect(html).toContain('Where can I buy DJ Test merch?');
     expect(html).toContain('Source: Official merch card');
+  });
+
+  it('renders the editorial claim card only when a claim destination is provided', () => {
+    const content = buildContent();
+    const { rerender } = render(
+      <ProfileAeoContent
+        content={content}
+        claimHref='/dj-test/claim?next=auth'
+      />
+    );
+
+    expect(screen.getByTestId('profile-aeo-claim-card')).toBeVisible();
+    expect(
+      screen.getByRole('heading', {
+        name: 'Claim yours.',
+      })
+    ).toBeVisible();
+    expect(screen.getByText('Jovie artist profiles')).toBeVisible();
+    expect(
+      screen.getByText('Music, shows, and fan updates. One place.')
+    ).toBeVisible();
+    expect(
+      screen.getByRole('link', {
+        name: 'Claim the DJ Test profile and sign up for Jovie',
+      })
+    ).toHaveAttribute('href', '/dj-test/claim?next=auth');
+
+    rerender(<ProfileAeoContent content={content} />);
+    expect(screen.queryByTestId('profile-aeo-claim-card')).toBeNull();
   });
 });

--- a/apps/web/tests/unit/profile/profile-compact-subscribe-regression.test.ts
+++ b/apps/web/tests/unit/profile/profile-compact-subscribe-regression.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const PROFILE_COMPACT_SURFACE = join(
+  process.cwd(),
+  'components',
+  'features',
+  'profile',
+  'templates',
+  'ProfileCompactSurface.tsx'
+);
+const PROFILE_MOBILE_NOTIFICATIONS_FLOW = join(
+  process.cwd(),
+  'components',
+  'features',
+  'profile',
+  'artist-notifications-cta',
+  'ProfileMobileNotificationsFlow.tsx'
+);
+
+describe('ProfileCompactSurface subscribe composition', () => {
+  it('renders one notification flow when the subscribe tab is active', () => {
+    const contents = readFileSync(PROFILE_COMPACT_SURFACE, 'utf8');
+
+    expect(contents).toMatch(
+      /shouldRenderInteractiveOverlays\s*&&\s*activeVisiblePrimaryTab\s*!==\s*'subscribe'/
+    );
+    expect(contents).not.toMatch(
+      /autoOpen=\{activeVisiblePrimaryTab === 'subscribe'\}/
+    );
+  });
+
+  it('sizes the inline flow from the available panel height', () => {
+    const contents = readFileSync(PROFILE_MOBILE_NOTIFICATIONS_FLOW, 'utf8');
+
+    expect(contents).toMatch(/relative flex h-full min-h-full flex-1 flex-col/);
+    expect(contents).not.toMatch(/relative min-h-150/);
+    expect(contents).not.toMatch(/touch-action:pan-y/);
+  });
+});

--- a/apps/web/tests/unit/profile/public-profile-page.test.ts
+++ b/apps/web/tests/unit/profile/public-profile-page.test.ts
@@ -209,6 +209,13 @@ describe('Public Profile Page Logic', () => {
     it('delegates claim banner query handling to the client wrapper', () => {
       expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain('PublicClaimBanner');
     });
+
+    it('offers the editorial AEO claim card only for unclaimed direct-claim profiles', () => {
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain(
+        '!profile.is_claimed && directClaimSupported'
+      );
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain('/claim?next=auth');
+    });
   });
 
   describe('profile accent handling', () => {


### PR DESCRIPTION
## Description\n\nPolishes Jovie's highest-traffic public artist profiles across mobile and desktop.\n\n- Preserves square release art and face-safe hero crops.\n- Makes profile rails equal-size, horizontal-only, scrollbar-free, and touch-native.\n- Removes duplicate subscribe UI, awkward sparse-state spacing, and undersized controls.\n- Turns desktop AEO copy into an editorial continuation.\n- Adds one concise claim card to unclaimed, Spotify-verifiable artist profiles.\n\n## Type of Change\n\n- [x] Bug fix\n- [x] New feature\n- [x] Documentation update\n\n## Testing\n\n- [x] 110 focused profile/entity tests pass\n- [x] New geometry, claim-gating, theme-color, and subscribe regression tests added\n- [x] Node 22 web typecheck passes\n- [x] Biome, ESLint, staged accessibility, Tailwind, secret scans, and pre-push gates pass\n- [x] Manual Chrome/Playwright rendering completed\n\nbug-to-test: satisfied\n\nRendered geometry proof:\n- 6/6 rail cards: 224 × 384 px\n- artwork: 198 × 198 px, object-fit contain\n- document horizontal overflow: 0 px\n- rail touch-action: auto\n- AEO: white on cinematic black\n- claim card: cinematic black on paper\n- console errors: 0\n\nThe broad local monorepo command also exposed unrelated baseline issues: an ignored/generated desktop icon is absent, and the 2,009-file web run produced timing failures across unrelated auth/admin/chat/Stripe tests under parallel load. Focused coverage and the canonical CI gates are green.\n\n## Accessibility\n\n- [x] Interactive targets are at least 44 px\n- [x] Claim CTA has an artist-specific accessible label\n- [x] Decorative motion removed\n- [x] Theme-stable contrast verified\n- [x] Existing semantic heading and FAQ structure preserved\n\n## Design Skill Evidence\n\nReading this as: a public artist identity and conversion surface for fans and unclaimed artists, with a native editorial language grounded in System B.\n\n- DESIGN_VARIANCE: 3/10\n- MOTION_INTENSITY: 1/10\n- VISUAL_DENSITY: 4/10\n- [x] Before/after screenshot review completed\n- [x] Contrast, states, layout, motion, icons, anti-slop, and evidence pass\n- [x] Independent adversarial review passed after 3 findings were fixed\n\n## Documentation\n\n- CHANGELOG.md: added user-facing notes for public-profile polish and the unclaimed-profile claim card.\n- GBrain: recorded the approved public-profile media, scrolling, AEO, conversion, and concise-copy canon.\n\n## Related Issues\n\nJOV-2018\n\n## Checklist\n\n- [x] Conventional title\n- [x] Rebased onto current main\n- [x] Changelog updated\n- [x] No database, environment-variable, or feature-flag changes\n