### PR TITLE
fix: route trigger guard to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
   # runs first (fail-open), then path detection.
   ci-path-changes:
     name: Path Changes
-    runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:
       skip: ${{ steps.graphite.outputs.skip || 'false' }}


### PR DESCRIPTION
Trigger Guard was hardcoded to ubuntu-latest, causing 47+ queued runs to bottleneck on GitHub-hosted runners. Routes to CI_FAST_RUNNER (self-hosted pool) instead.