### PR TITLE
ci(runners): version-scoped pnpm install dir to dodge v11 store pollution (JOV-4175)

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -21,9 +21,16 @@ runs:
             || git config --global --add safe.directory "$GITHUB_WORKSPACE"
         fi
 
+    # Version-scoped install dir: the default ~/setup-pnpm persists on
+    # self-hosted runners, and a pnpm v11 layout left there crashes the pinned
+    # pnpm 9.15.4 with "Worker pnpm exited with code 1" during `pnpm fetch`
+    # (JOV-4175, run 29070623310 on gem-linux). A pnpm-9-only dest can never be
+    # polluted by another major. No-op on hosted runners (fresh VM each job).
     - name: Setup pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      
+      with:
+        dest: ~/setup-pnpm-v9
+
     # Actions-cache-backed pnpm caching is GitHub-hosted only. Self-hosted
     # runners (jovie-runner) keep a persistent pnpm store on disk, so the
     # restore is pointless and the post-run save uploads ~1.2 GB — observed


### PR DESCRIPTION
## Why
The self-hosted pool offload (JOV-4171/#13891) failed because the pool machines have a pnpm v11 layout persisted at the default `~/setup-pnpm`, which crashes pinned pnpm 9.15.4 (`Worker pnpm exited with code 1` during `pnpm fetch` — run 29070623310, gem-linux). That forced reverting the runner vars to `ubuntu-latest`.

## What
One-line fix in `setup-node-pnpm`: `dest: ~/setup-pnpm-v9` — a pnpm-9-only install dir that another major version can never pollute. No-op on hosted runners (fresh VMs).

## After this lands
Canary the pool per JOV-4175's acceptance criteria (flip `CI_GATE_RUNNER=jovie-runner`, verify Lint + Structural Contract + Unit Tests pass on `jovie-runner`), then decide whether to re-offload now that the org is on the Team plan.

## Verification
- actionlint: clean
- Change is inert on hosted runners — current CI validates it directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)