### PR TITLE
ci(runners): per-job pnpm install dir — shared-HOME race on pool machines (JOV-4175)

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -21,15 +21,19 @@ runs:
             || git config --global --add safe.directory "$GITHUB_WORKSPACE"
         fi
 
-    # Version-scoped install dir: the default ~/setup-pnpm persists on
-    # self-hosted runners, and a pnpm v11 layout left there crashes the pinned
-    # pnpm 9.15.4 with "Worker pnpm exited with code 1" during `pnpm fetch`
-    # (JOV-4175, run 29070623310 on gem-linux). A pnpm-9-only dest can never be
-    # polluted by another major. No-op on hosted runners (fresh VM each job).
+    # Per-job pnpm install dir (JOV-4175). Two prior failure modes on the
+    # self-hosted pool, both from a shared persistent dest:
+    #   1. default ~/setup-pnpm carried a pnpm v11 layout that crashed pinned
+    #      9.15.4 ("Worker pnpm exited with code 1", run 29070623310)
+    #   2. version-scoped ~/setup-pnpm-v9 raced between CONCURRENT runner
+    #      processes on the same machine (shared $HOME) — ENOTEMPTY rmdir
+    #      during action-setup's reinstall (job 86298003824)
+    # runner.temp is per-job, so no sharing is possible; the pnpm tarball
+    # re-download costs seconds. The package store stays shared and safe.
     - name: Setup pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
-        dest: ~/setup-pnpm-v9
+        dest: ${{ runner.temp }}/setup-pnpm
 
     # Actions-cache-backed pnpm caching is GitHub-hosted only. Self-hosted
     # runners (jovie-runner) keep a persistent pnpm store on disk, so the


### PR DESCRIPTION
## Why
Pool canary after #13894 surfaced failure mode #2: the pool machines run **multiple runner processes sharing one $HOME**, so even the version-scoped `~/setup-pnpm-v9` races between concurrent jobs — `ENOTEMPTY: rmdir .../setup-pnpm-v9/node_modules/.bin/store` during pnpm/action-setup's reinstall (job 86298003824, gem-linux-4). `CI_GATE_RUNNER` reverted to `ubuntu-latest` in the meantime (≤15-min exposure; one Lint failure to rerun).

## What
`dest: ${{ runner.temp }}/setup-pnpm` — per-job dir, sharing impossible. Costs a ~10MB pnpm tarball download per job (seconds). The pnpm *package store* stays shared per-machine, which is concurrency-safe by design.

## After this lands
Re-canary: `CI_GATE_RUNNER=jovie-runner`, verify Lint/Structural pass on two concurrent pool jobs, then keep or revert. Acceptance criteria on JOV-4175.

## Verification
- actionlint clean; change is inert on hosted runners (fresh VM per job) — this PR's own CI exercises it

🤖 Generated with [Claude Code](https://claude.com/claude-code)