### PR TITLE
fix(ci): mask Doppler imports and preflight staging creds

### DIFF
--- a/.github/actions/setup-doppler/action.yml
+++ b/.github/actions/setup-doppler/action.yml
@@ -42,6 +42,17 @@ runs:
           decoded="$(printf '%s' "$entry" | base64 -d)"
           key="$(printf '%s' "$decoded" | jq -r '.key')"
           value="$(printf '%s' "$decoded" | jq -r '.value // ""')"
+
+          # Values downloaded at runtime are not registered GitHub secrets, so
+          # Actions will not redact them automatically when it prints a later
+          # step's environment. Register each value before writing GITHUB_ENV.
+          if [ -n "$value" ]; then
+            masked_value="${value//'%'/'%25'}"
+            masked_value="${masked_value//$'\r'/'%0D'}"
+            masked_value="${masked_value//$'\n'/'%0A'}"
+            printf '::add-mask::%s\n' "$masked_value"
+          fi
+
           marker="EOF_${RANDOM}_$(date +%s%N)"
           {
             echo "${key}<<${marker}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4327,6 +4327,19 @@ jobs:
       - uses: ./.github/actions/setup-doppler
         with:
           doppler-token: ${{ secrets.DOPPLER_TOKEN_STG }}
+      - name: Verify staging deploy control-plane credentials
+        shell: bash
+        run: |
+          missing=()
+          for key in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+            if [ -z "${!key:-}" ]; then
+              missing+=("$key")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Doppler stg is missing required deploy credentials: ${missing[*]}"
+            exit 1
+          fi
       - name: DB safety check (staging preflight)
         id: preflight
         run: pnpm --filter=@jovie/web exec tsx scripts/drizzle-migrate-preflight.ts


### PR DESCRIPTION
## Summary
- register every runtime Doppler value with GitHub Actions masking before exporting it
- fail staging immediately when the isolated `stg` config lacks Vercel control-plane credentials
- preserve the existing no-production-secret-fallback boundary

## Incident
Main deploy run 29088254916 failed because `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` are absent from Doppler `stg`. Runtime-imported values were not automatically redacted in later step environment output. No secret values are included in this PR.

## Verification
- composite shell parses with `bash -n`
- masking escape simulation covers percent and multiline values
- `actionlint` reports no findings in the changed workflow block (existing baseline warnings remain elsewhere)
- `git diff --check`

## Required external follow-up
Provision the three Vercel control-plane credentials in Doppler `stg`, then rotate staging values exposed by the affected Actions run before rerunning deployment.