### PR TITLE
feat: P0: macOS desktop app launches to a permanently black screen — never loads (shell has no recovery for a 200-but-crashed renderer)

### DIFF
--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -333,6 +333,8 @@ test('preload marks the hosted app as Electron after the document root is ready'
   assert.match(preloadSource, /startDesktopAuthHandoff/);
   assert.match(preloadSource, /openDesktopAuthUrl/);
   assert.match(preloadSource, /closeDesktopAuthWindow/);
+  assert.match(preloadSource, /sendAppBooted/);
+  assert.match(preloadSource, /ipcRenderer\.send\(APP_BOOTED_CHANNEL\)/);
 });
 
 test('desktop bridge exposes bounded dictation support', async () => {
@@ -535,6 +537,12 @@ test('hosted web app has an early Electron runtime marker before first paint', a
   // runs before React hydration. next/script + nonce drift caused local E2E
   // console errors, so the runtime marker is injected this way intentionally.
   assert.match(rootLayout, /<script src='\/electron-runtime-init\.js' \/>/);
+  assert.match(rootLayout, /ElectronBootHeartbeat/);
+  const heartbeatSource = await readFile(
+    join(webRoot, 'components/desktop/ElectronBootHeartbeat.tsx'),
+    'utf8'
+  );
+  assert.match(heartbeatSource, /sendAppBooted/);
   assert.match(runtimeInit, /params\.get\('runtime'\) === 'electron'/);
   assert.match(runtimeInit, /JovieDesktop\\\//);
   assert.match(runtimeInit, /root\.dataset\.desktopRuntime = 'electron'/);
@@ -562,7 +570,99 @@ test('hosted web app has an early Electron runtime marker before first paint', a
   );
   assert.match(
     titlebarSource,
-    /w-\[var\(--electron-traffic-light-safe-width\)\]/
+    /w-\(--electron-traffic-light-safe-width\)/
   );
   assert.doesNotMatch(titlebarSource, /w-\[72px\]/);
+});
+
+test('desktop shell has a renderer heartbeat watchdog for 200-but-crashed pages', async () => {
+  const mainSource = await readFile(join(desktopRoot, 'src/main.ts'), 'utf8');
+  const preloadSource = await readFile(
+    join(desktopRoot, 'src/preload.ts'),
+    'utf8'
+  );
+
+  // Heartbeat channel constant
+  assert.match(
+    mainSource,
+    /const APP_BOOTED_CHANNEL = 'app-booted'/
+  );
+  assert.match(
+    preloadSource,
+    /const APP_BOOTED_CHANNEL = 'app-booted'/
+  );
+
+  // Watchdog timer map (per-window)
+  assert.match(
+    mainSource,
+    /const appBootedWatchdogTimers = new Map/
+  );
+
+  // did-finish-load starts the 14s watchdog and clears any existing one
+  assert.match(
+    mainSource,
+    /appBootedWatchdogTimers.get\(win\.id\)/
+  );
+  assert.match(
+    mainSource,
+    /clearTimeout\(existingTimer\)/
+  );
+  assert.match(
+    mainSource,
+    /14_000/
+  );
+
+  // Watchdog expiry shows the recovery shell
+  assert.match(
+    mainSource,
+    /showing recovery shell/
+  );
+  assert.match(
+    mainSource,
+    /showDesktopLoadFailure\(win\)/
+  );
+
+  // IPC handler cancels the watchdog when renderer sends app-booted
+  assert.match(
+    mainSource,
+    /ipcMain\.on\(APP_BOOTED_CHANNEL/
+  );
+  assert.match(
+    mainSource,
+    /clearTimeout\(timer\);\s*appBootedWatchdogTimers\.delete\(win\.id\)/
+  );
+
+  // Window close cleans up the watchdog
+  assert.match(
+    mainSource,
+    /appBootedWatchdogTimers\.get\(win\.id\)/
+  );
+  assert.match(
+    mainSource,
+    /appBootedWatchdogTimers\.delete\(win\.id\)/
+  );
+
+  // unresponsive handler now shows recovery shell after a grace period
+  assert.match(
+    mainSource,
+    /Renderer unresponsive for 10s/
+  );
+  assert.match(
+    mainSource,
+    /win\.webContents\.once\('responsive'/
+  );
+
+  // Preload exposes sendAppBooted
+  assert.match(
+    preloadSource,
+    /sendAppBooted:/
+  );
+  assert.match(
+    preloadSource,
+    /\) => \{/  
+  );
+  assert.match(
+    preloadSource,
+    /ipcRenderer\.send\(APP_BOOTED_CHANNEL\)/
+  );
 });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -107,6 +107,7 @@ const AUTH_RETURN_PROTOCOL = `${AUTH_RETURN_SCHEME}:`;
 const AUTH_RETURN_HOST = 'auth';
 const AUTH_RETURN_COMPLETE_PATH = '/complete';
 const LEGACY_AUTH_RETURN_HOST = 'auth-return';
+const APP_BOOTED_CHANNEL = 'app-booted';
 const DICTATION_STATUS_CHANNEL = 'dictation-status';
 const TRAY_SET_STATE_CHANNEL = 'tray-set-state';
 const TRAY_ACTION_CHANNEL = 'tray-action';
@@ -161,6 +162,13 @@ const AUTH_COMPLETION_REPLAY_TTL_MS = 60_000;
 const reportDesktopSecurityEvent = createDesktopSecurityReporter();
 
 let updateReadyToInstall = false;
+// Maps BrowserWindow.id to the heartbeat watchdog timer. When did-finish-load
+// fires for a main-frame navigation, a 14-second timer starts. If the renderer
+// sends 'app-booted' before the timer expires, the timer is cleared. Otherwise
+// the recovery shell is shown (the page 200'd but the renderer never became
+// interactive).
+const appBootedWatchdogTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
 let mainWindow: BrowserWindow | null = null;
 let authHandoffWindow: BrowserWindow | null = null;
 let menuBarTray: MenuBarTray | null = null;
@@ -1029,6 +1037,24 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   let rendererCrashReloadCount = 0;
   win.webContents.on('did-finish-load', () => {
     rendererCrashReloadCount = 0;
+
+    // Heartbeat watchdog: if the renderer loaded (200) but the React app never
+    // signals it booted successfully (app-booted), the page may have crashed
+    // client-side after a successful HTTP load. Show the recovery shell
+    // instead of leaving a permanently black window.
+    const existingTimer = appBootedWatchdogTimers.get(win.id);
+    if (existingTimer) clearTimeout(existingTimer);
+    appBootedWatchdogTimers.set(
+      win.id,
+      setTimeout(() => {
+        appBootedWatchdogTimers.delete(win.id);
+        if (win.isDestroyed()) return;
+        console.warn(
+          '[Jovie Desktop] Renderer loaded but never signaled app-booted — showing recovery shell'
+        );
+        showDesktopLoadFailure(win);
+      }, 14_000)
+    );
   });
   win.webContents.on('render-process-gone', (_event, details) => {
     const action = decideRendererRecovery({
@@ -1052,6 +1078,18 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   win.webContents.on('unresponsive', () => {
     console.warn('[Jovie Desktop] Renderer unresponsive', {
       url: win.webContents.getURL().split('?')[0],
+    });
+    // Give the renderer a short grace period to become responsive again.
+    // If it stays unresponsive, show the recovery shell.
+    const unresponsiveTimer = setTimeout(() => {
+      if (win.isDestroyed()) return;
+      console.warn(
+        '[Jovie Desktop] Renderer unresponsive for 10s — showing recovery shell'
+      );
+      showDesktopLoadFailure(win);
+    }, 10_000);
+    win.webContents.once('responsive', () => {
+      clearTimeout(unresponsiveTimer);
     });
   });
 
@@ -1153,6 +1191,11 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
 
   win.on('close', () => {
     saveWindowState(win);
+    const timer = appBootedWatchdogTimers.get(win.id);
+    if (timer) {
+      clearTimeout(timer);
+      appBootedWatchdogTimers.delete(win.id);
+    }
   });
 
   win.on('closed', () => {
@@ -1612,6 +1655,17 @@ app.whenReady().then(() => {
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
+  }
+});
+
+ipcMain.on(APP_BOOTED_CHANNEL, (event: IpcMainInvokeEvent) => {
+  if (!isTrustedIpcSender(event)) return;
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win || win.isDestroyed()) return;
+  const timer = appBootedWatchdogTimers.get(win.id);
+  if (timer) {
+    clearTimeout(timer);
+    appBootedWatchdogTimers.delete(win.id);
   }
 });
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -10,6 +10,7 @@ const OPEN_DESKTOP_AUTH_URL_CHANNEL = 'open-desktop-auth-url';
 const CLOSE_DESKTOP_AUTH_WINDOW_CHANNEL = 'close-desktop-auth-window';
 const CONSUME_DESKTOP_AUTH_COMPLETION_CHANNEL =
   'consume-desktop-auth-completion';
+const APP_BOOTED_CHANNEL = 'app-booted';
 const DICTATION_STATUS_CHANNEL = 'dictation-status';
 const TRAY_SET_STATE_CHANNEL = 'tray-set-state';
 const TRAY_ACTION_CHANNEL = 'tray-action';
@@ -149,6 +150,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     /** Probe desktop dictation support without exposing node/native APIs. */
     getDictationStatus: () => {
       return ipcRenderer.invoke(DICTATION_STATUS_CHANNEL);
+    },
+
+    sendAppBooted: () => {
+      ipcRenderer.send(APP_BOOTED_CHANNEL);
     },
 
     /**

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,6 +11,7 @@ import './globals.css';
 import '@/components/organisms/HeaderNav.css';
 import '@/components/site/MarketingFooter.css';
 import { CookieBannerMount } from '@/components/organisms/CookieBannerMount';
+import { ElectronBootHeartbeat } from '@/components/desktop/ElectronBootHeartbeat';
 import { GoogleAnalytics } from '@/components/providers/GoogleAnalytics';
 import { InstantlyPixel } from '@/components/providers/InstantlyPixel';
 import { getRootLayoutChromeState } from '@/lib/demo-recording';
@@ -224,6 +225,7 @@ export default async function RootLayout({
       {shouldRenderCookieBanner ? <CookieBannerMount /> : null}
       <GoogleAnalytics />
       <InstantlyPixel />
+      <ElectronBootHeartbeat />
     </>
   );
 

--- a/apps/web/components/desktop/ElectronBootHeartbeat.tsx
+++ b/apps/web/components/desktop/ElectronBootHeartbeat.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+import { sendAppBooted } from '@/lib/desktop/electron-bridge';
+
+/**
+ * Fires the Electron desktop `app-booted` heartbeat signal on first mount.
+ *
+ * This component must be mounted in every Electron-rendered route tree so the
+ * main process receives the signal and cancels the heartbeat watchdog. Without
+ * it, the watchdog timer fires 14s after did-finish-load and shows the
+ * recovery shell — a false positive in non-Electron contexts, but harmless
+ * because sendAppBooted is a silent no-op outside Electron.
+ */
+export function ElectronBootHeartbeat(): null {
+  useEffect(() => {
+    sendAppBooted();
+  }, []);
+
+  return null;
+}

--- a/apps/web/lib/desktop/electron-bridge.ts
+++ b/apps/web/lib/desktop/electron-bridge.ts
@@ -67,6 +67,12 @@ export interface ElectronAPI {
    * Returns an unsubscribe function.
    */
   readonly onTrayAction?: (cb: (action: string) => void) => () => void;
+  /**
+   * Signal to the Electron main process that the web app has successfully
+   * booted (React first render completed). Cancels the heartbeat watchdog
+   * timer and prevents the recovery shell from appearing.
+   */
+  readonly sendAppBooted?: () => void;
 }
 
 export interface DesktopAuthCompletion {
@@ -579,6 +585,17 @@ export function onDesktopTrayAction(cb: (action: string) => void): () => void {
   if (!api || typeof api.onTrayAction !== 'function') return noopUnsubscribe;
   const unsubscribe = api.onTrayAction(cb);
   return typeof unsubscribe === 'function' ? unsubscribe : noopUnsubscribe;
+}
+
+/**
+ * Signal that the web app has booted successfully. Call once on first render
+ * to cancel the Electron main process heartbeat watchdog.
+ * Silently no-ops when not in Electron or when the bridge is stale.
+ */
+export function sendAppBooted(): void {
+  const api = getRawElectronAPI();
+  if (!api || typeof api.sendAppBooted !== 'function') return;
+  api.sendAppBooted();
 }
 
 // Exported for tests only — do not call directly from product code.


### PR DESCRIPTION
## Summary
Autonomous ship by **Gem** (OpenClaw on gem box) for pre-scoped issue.

Closes #12044

## Notes
- Scope was authored by frontier planning agents (Fable 5 / fleet); Gem implemented and opened this draft.
- Draft until CI is green; agent-pipeline / auto-ready may promote.