### PR TITLE
fix(billing): prevent duplicate subscription on cross-plan checkout (JOV-4196)

### DIFF
--- a/apps/web/app/api/stripe/checkout/route.ts
+++ b/apps/web/app/api/stripe/checkout/route.ts
@@ -201,6 +201,7 @@ export async function POST(request: NextRequest) {
             sessionId: subscriptionCheck.portalSession.id,
             url: subscriptionCheck.portalSession.url,
             alreadySubscribed: true,
+            planChangeRequired: subscriptionCheck.planChangeRequired,
           },
           { headers: NO_STORE_HEADERS }
         );

--- a/apps/web/lib/stripe/checkout-helpers.ts
+++ b/apps/web/lib/stripe/checkout-helpers.ts
@@ -25,6 +25,12 @@ interface ExistingSubscriptionResult {
 
 interface AlreadySubscribedResult {
   alreadySubscribed: true;
+  /**
+   * true when the active subscription is for a DIFFERENT plan than the one
+   * being checked out (i.e. an upgrade/downgrade that must go through the
+   * billing portal, not a brand-new second subscription).
+   */
+  planChangeRequired: boolean;
   portalSession: { id: string; url: string | null };
 }
 
@@ -33,8 +39,17 @@ type SubscriptionCheckResult =
   | AlreadySubscribedResult;
 
 /**
- * Check if customer already has an active subscription to the same plan.
- * If so, returns a billing portal session for managing the subscription.
+ * Guard against creating a second subscription for a customer who already has
+ * an active one.
+ *
+ * Stripe checkout always creates a NEW subscription — it never mutates an
+ * existing one. So if a customer with an active Pro subscription completes a
+ * Max checkout, they end up billed for BOTH plans. Plan changes must go
+ * through the billing portal (or plan-change flow) instead.
+ *
+ * Returns a portal session whenever ANY active subscription exists:
+ * - same plan  → `planChangeRequired: false` (manage current plan)
+ * - other plan → `planChangeRequired: true`  (upgrade/downgrade via portal)
  */
 export async function checkExistingPlanSubscription(
   customerId: string,
@@ -50,15 +65,20 @@ export async function checkExistingPlanSubscription(
     limit: 25,
   });
 
-  const alreadySubscribed = existingSubscriptions.data.some(
-    subscription =>
-      ACTIVE_SUBSCRIPTION_STATUSES.has(subscription.status) &&
-      hasMatchingPriceItem(subscription.items.data, planPriceIds)
+  const activeSubscriptions = existingSubscriptions.data.filter(subscription =>
+    ACTIVE_SUBSCRIPTION_STATUSES.has(subscription.status)
   );
 
-  if (!alreadySubscribed) {
+  if (activeSubscriptions.length === 0) {
     return { alreadySubscribed: false };
   }
+
+  // Any active subscription blocks a new checkout. Distinguish same-plan
+  // (manage) from cross-plan (upgrade/downgrade) purely for UI messaging —
+  // both route to the portal so no duplicate subscription is ever created.
+  const hasSamePlanSubscription = activeSubscriptions.some(subscription =>
+    hasMatchingPriceItem(subscription.items.data, planPriceIds)
+  );
 
   const baseUrl = publicEnv.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
   const returnUrl = `${baseUrl}/app/dashboard`;
@@ -69,6 +89,7 @@ export async function checkExistingPlanSubscription(
 
   return {
     alreadySubscribed: true,
+    planChangeRequired: !hasSamePlanSubscription,
     portalSession: { id: portalSession.id, url: portalSession.url },
   };
 }

--- a/apps/web/tests/unit/lib/stripe/checkout-helpers.test.ts
+++ b/apps/web/tests/unit/lib/stripe/checkout-helpers.test.ts
@@ -1,17 +1,19 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSubscriptionsList, mockCreatePortalSession } = vi.hoisted(() => ({
+  mockSubscriptionsList: vi.fn(),
+  mockCreatePortalSession: vi.fn(),
+}));
 
 vi.mock('@/lib/env-public', () => ({
   publicEnv: { NEXT_PUBLIC_APP_URL: 'http://localhost:3000' },
 }));
 
 vi.mock('@/lib/stripe/client', () => ({
-  createBillingPortalSession: vi.fn().mockResolvedValue({
-    id: 'bps_123',
-    url: 'https://billing.stripe.com/portal',
-  }),
+  createBillingPortalSession: mockCreatePortalSession,
   stripe: {
     subscriptions: {
-      list: vi.fn(),
+      list: mockSubscriptionsList,
     },
   },
 }));
@@ -33,9 +35,77 @@ vi.mock('@/lib/stripe/config', () => ({
   },
 }));
 
-import { getCheckoutErrorResponse } from '@/lib/stripe/checkout-helpers';
+import {
+  checkExistingPlanSubscription,
+  getCheckoutErrorResponse,
+} from '@/lib/stripe/checkout-helpers';
+
+function sub(status: string, priceId: string) {
+  return { status, items: { data: [{ price: { id: priceId } }] } };
+}
 
 describe('checkout-helpers', () => {
+  describe('checkExistingPlanSubscription (double-subscription guard)', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockCreatePortalSession.mockResolvedValue({
+        id: 'bps_123',
+        url: 'https://billing.stripe.com/portal',
+      });
+    });
+
+    it('allows checkout when the customer has no active subscription', async () => {
+      mockSubscriptionsList.mockResolvedValue({
+        data: [sub('canceled', 'price_pro_monthly')],
+      });
+
+      const result = await checkExistingPlanSubscription('cus_1', 'max');
+
+      expect(result).toEqual({ alreadySubscribed: false });
+      expect(mockCreatePortalSession).not.toHaveBeenCalled();
+    });
+
+    it('routes a same-plan active subscriber to the portal (manage current plan)', async () => {
+      mockSubscriptionsList.mockResolvedValue({
+        data: [sub('active', 'price_pro_monthly')],
+      });
+
+      const result = await checkExistingPlanSubscription('cus_1', 'pro');
+
+      expect(result).toMatchObject({
+        alreadySubscribed: true,
+        planChangeRequired: false,
+      });
+      expect(mockCreatePortalSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT create a second subscription when an active DIFFERENT-plan sub exists (Pro → Max)', async () => {
+      // Regression for JOV-4196: a Pro subscriber checking out Max previously
+      // fell through to a brand-new second subscription = double billing.
+      mockSubscriptionsList.mockResolvedValue({
+        data: [sub('active', 'price_pro_monthly')],
+      });
+
+      const result = await checkExistingPlanSubscription('cus_1', 'max');
+
+      expect(result).toMatchObject({
+        alreadySubscribed: true,
+        planChangeRequired: true,
+      });
+      expect(mockCreatePortalSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats trialing/past_due/unpaid as active blockers', async () => {
+      for (const status of ['trialing', 'past_due', 'unpaid']) {
+        mockSubscriptionsList.mockResolvedValue({
+          data: [sub(status, 'price_pro_monthly')],
+        });
+        const result = await checkExistingPlanSubscription('cus_1', 'max');
+        expect(result).toMatchObject({ alreadySubscribed: true });
+      }
+    });
+  });
+
   describe('getCheckoutErrorResponse', () => {
     it('should return customer error for customer-related messages', () => {
       const error = new Error('Failed to create customer');


### PR DESCRIPTION
## Summary

Fixes **JOV-4196** — a Stripe checkout double-billing bug.

Stripe checkout **always creates a new subscription**; it never mutates an existing one. `checkExistingPlanSubscription` (`apps/web/lib/stripe/checkout-helpers.ts`) only detected a **same-plan** active subscription and routed it to the billing portal. A customer with an active **Pro** subscription who completed a **Max** checkout fell through the guard → **a second active subscription was created → billed for both plans** until support intervened.

## Fix
- `checkExistingPlanSubscription` now treats **any** active subscription (`active`/`trialing`/`past_due`/`unpaid`) as a blocker and routes to the billing portal — Stripe's canonical plan-switch surface — so no duplicate subscription can be created.
- New `planChangeRequired` flag on the result (and in the checkout route response) distinguishes same-plan (manage current plan) from cross-plan (upgrade/downgrade), for UI messaging. Behavior is identical either way: route to portal.

## Tests
`apps/web/tests/unit/lib/stripe/checkout-helpers.test.ts` (+4):
- no active sub → checkout allowed
- same-plan active → portal, `planChangeRequired: false`
- **Pro → Max cross-plan active → portal, `planChangeRequired: true` (the regression)**
- trialing/past_due/unpaid all treated as active blockers

Negative-verified: reverting to the same-plan-only predicate makes the cross-plan and status tests fail (2 failures). All 15 tests in the file + the checkout route suite pass on the fix.

## Validation
- `vitest run` checkout-helpers + checkout route: 15 passed
- Pre-commit: gitleaks, trufflehog, next-proxy-guard, biome, eslint, full `@jovie/web` typecheck — green

## Cost Impact
None. Same single `stripe.subscriptions.list` call already made; no new API calls, no new cron. Prevents duplicate-subscription refunds/support load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)