### PR TITLE
fix(ci): restore staging Clerk deploy credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4518,6 +4518,10 @@ jobs:
           done
         env:
           VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'true'
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          CLERK_PUBLISHABLE_KEY_STAGING: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
+          CLERK_SECRET_KEY_STAGING: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
 
       - name: Alias preview to staging.jov.ie
         timeout-minutes: 3


### PR DESCRIPTION
## Summary
- source the four required Clerk deploy keys from existing GitHub Actions secrets
- preserve Doppler `stg` for database, app runtime, and non-Clerk staging secrets
- keep the staging fail-closed runtime credential guard intact

## Root cause
The Vercel credential restoration allowed staging through pull, migration, schema verification, readiness, and provenance, but the deploy contract then failed because Doppler `stg` does not contain the dedicated Clerk pairs already managed by GitHub Actions.

## Verification
- staging Clerk source contract passed for all four required keys
- actionlint parses the workflow; existing informational ShellCheck findings are unchanged
- pre-push proxy, Tailwind, and TypeScript checks passed on Node 22
- secret scans passed
- `git diff --check`