### PR TITLE
fix(ci): package Vercel edge runtime targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1009,7 +1009,16 @@ jobs:
             sleep 10
             if [ $i -eq 3 ]; then exit 1; fi
           done
-          tar -czf /tmp/vercel-build-output.tar.gz -C . .vercel/output
+          # Next/Vercel edge functions keep file-trace references to generated
+          # WASM/font chunks under .next/server/edge. Preserve those 16 MB of
+          # targets with the reusable output so a later runner can deploy the
+          # prebuilt artifact without the full ~384 MB .next archive.
+          test -d apps/web/.next/server/edge
+          tar -czf /tmp/vercel-build-output.tar.gz -C . \
+            .vercel/output \
+            apps/web/.next/server/edge
+          tar -tzf /tmp/vercel-build-output.tar.gz \
+            apps/web/.next/server/edge >/dev/null
           echo "vercel_artifact=true" >> "$GITHUB_OUTPUT"
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0


### PR DESCRIPTION
## Summary
- package `.next/server/edge` with the reusable `.vercel/output` artifact
- preserve generated `@vercel/og` WASM/font targets referenced by edge functions
- keep the deploy artifact compact instead of shipping the full Next build

## Root cause
The reusable 59 MB Vercel artifact preserved generated function references to `apps/web/.next/server/edge`, but omitted those targets. Archive and plain prebuilt uploads failed on the missing Yoga WASM, then source fallback timed out.

## Verification
- inspected failed run 29115569313 artifact and confirmed the missing file trace
- extracted the existing Next artifact and measured `.next/server/edge` at 16 MB
- simulated the revised artifact: 61 MB compressed, both Yoga and Resvg WASM targets present
- actionlint parses the workflow; existing informational ShellCheck findings are unchanged
- Node 22 proxy/Tailwind/typecheck pre-push checks passed
- secret scans and `git diff --check` passed