### PR TITLE
testing: run tests/integration in a real-DB CI lane, revive rls-access-control, add dead-test detector (JOV-4195)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -67,6 +67,7 @@
     "test:reliability-detectors": "tsx scripts/check-reliability-detectors.ts",
     "test:watch": "vitest --config=vitest.config.mts",
     "test:fast": "vitest run --config=vitest.config.mts",
+    "test:integration": "vitest run --config=vitest.config.integration.mts",
     "test:seo": "vitest run --config=vitest.config.mts tests/app/robots.test.ts tests/app/sitemap.test.ts tests/unit/ci/seo-ratchet.test.ts tests/unit/seo/guardrail-check.test.ts",
     "seo:guardrail-check": "tsx scripts/seo-guardrail-check.ts",
     "test:profile": "tsx scripts/test-performance-profiler.ts",

--- a/apps/web/scripts/test-truth-guard.mjs
+++ b/apps/web/scripts/test-truth-guard.mjs
@@ -50,6 +50,135 @@ function walk(dir) {
 
 walk(testsRoot);
 
+/**
+ * Dead-test detector (JOV-4195 / GH #13931).
+ *
+ * Fails when a tests/** vitest file is excluded by every CI-executed vitest
+ * config — i.e. it counts as coverage on the heatmap but never runs anywhere.
+ * (This is exactly how tests/integration/** sat structurally dead: the fast
+ * config backing the merge gate excluded it, and no other CI lane ran it.)
+ *
+ * CI-executed vitest lanes modeled here:
+ *   - vitest.config.fast.mts  -> "Unit Tests" merge gate (excludes parsed
+ *     live from the config so drift is caught automatically)
+ *   - vitest.config.integration.mts -> "Integration Tests (DB)" lane
+ *   - vitest.config.golden-eval.mts -> evals:golden gate (tests/eval/golden
+ *     *.ci.test.ts only)
+ *
+ * Non-vitest / opt-in lanes (allowlisted): *.nightly.test.ts (nightly agent),
+ * *.real.test.ts (live real-model lane), tests/e2e (Playwright).
+ */
+function globToRegExp(glob) {
+  let re = '';
+  let i = 0;
+  while (i < glob.length) {
+    const ch = glob[i];
+    if (ch === '*') {
+      if (glob.startsWith('**/', i)) {
+        re += '(?:.*/)?';
+        i += 3;
+        continue;
+      }
+      if (glob.startsWith('**', i)) {
+        re += '.*';
+        i += 2;
+        continue;
+      }
+      re += '[^/]*';
+      i += 1;
+      continue;
+    }
+    if (ch === '?') {
+      re += '[^/]';
+      i += 1;
+      continue;
+    }
+    if (ch === '{') {
+      const end = glob.indexOf('}', i);
+      if (end !== -1) {
+        const alts = glob
+          .slice(i + 1, end)
+          .split(',')
+          .map(alt => alt.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+          .join('|');
+        re += `(?:${alts})`;
+        i = end + 1;
+        continue;
+      }
+    }
+    re += ch.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    i += 1;
+  }
+  return new RegExp(`^${re}$`);
+}
+
+function parseGlobArray(configText, key) {
+  const match = configText.match(new RegExp(`${key}:\\s*\\[([^\\]]*)\\]`, 'm'));
+  if (!match) return [];
+  return [...match[1].matchAll(/'([^']+)'/g)].map(m => m[1]);
+}
+
+function checkDeadTests() {
+  const fastConfig = fs.readFileSync(
+    path.join(appRoot, 'vitest.config.fast.mts'),
+    'utf8'
+  );
+  const integrationConfig = fs.readFileSync(
+    path.join(appRoot, 'vitest.config.integration.mts'),
+    'utf8'
+  );
+
+  const fastExcludes = parseGlobArray(fastConfig, 'exclude')
+    .filter(glob => glob.startsWith('tests/'))
+    .map(globToRegExp);
+  const integrationIncludes = parseGlobArray(integrationConfig, 'include').map(
+    globToRegExp
+  );
+  const goldenIncludes = [globToRegExp('tests/eval/golden/**/*.ci.test.ts')];
+
+  const allowlistedLanes = [
+    globToRegExp('tests/e2e/**'), // Playwright
+    globToRegExp('tests/**/*.nightly.test.ts'), // nightly agent lane
+    globToRegExp('tests/**/*.real.test.ts'), // opt-in live real-model lane
+  ];
+
+  const deadFiles = [];
+
+  function walkForDead(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walkForDead(fullPath);
+        continue;
+      }
+      if (!/\.test\.(ts|tsx)$/.test(entry.name)) continue;
+
+      const rel = path.relative(appRoot, fullPath).split(path.sep).join('/');
+      if (allowlistedLanes.some(re => re.test(rel))) continue;
+
+      const coveredByFast = !fastExcludes.some(re => re.test(rel));
+      const coveredByIntegration = integrationIncludes.some(re =>
+        re.test(rel)
+      );
+      const coveredByGolden = goldenIncludes.some(re => re.test(rel));
+
+      if (!coveredByFast && !coveredByIntegration && !coveredByGolden) {
+        deadFiles.push(rel);
+      }
+    }
+  }
+
+  walkForDead(testsRoot);
+
+  for (const file of deadFiles) {
+    violations.push(
+      `${file} is excluded by every CI-executed vitest config (dead test — wire it into a CI lane or move it to an allowlisted lane)`
+    );
+  }
+}
+
+checkDeadTests();
+
 for (const setupFile of setupFiles) {
   const content = fs.readFileSync(setupFile, 'utf8');
   const lines = content.split('\n');

--- a/apps/web/tests/integration/rls-access-control.test.ts
+++ b/apps/web/tests/integration/rls-access-control.test.ts
@@ -2,198 +2,267 @@ import { sql as drizzleSql } from 'drizzle-orm';
 /* eslint-disable no-restricted-imports -- Test requires full schema access */
 import type { NeonDatabase } from 'drizzle-orm/neon-serverless';
 import { beforeAll, describe, expect, it } from 'vitest';
-import * as schema from '@/lib/db/schema';
+import type * as schema from '@/lib/db/schema';
 import { users } from '@/lib/db/schema/auth';
 import { creatorProfiles, profilePhotos } from '@/lib/db/schema/profiles';
-import { withRlsAnonymous, withRlsUser } from '../setup-db';
+import {
+  setupDatabaseBeforeAll,
+  withRlsAnonymous,
+  withRlsUser,
+} from '../setup-db';
 
 /**
- * RLS Access Control Tests
+ * RLS Access Control Tests (JOV-4194 / JOV-4195)
  *
- * These tests verify that Row Level Security (RLS) policies are properly enforced.
- * They use a test role without BYPASSRLS privilege and helper functions to simulate
- * authenticated and anonymous access patterns.
+ * Verifies the RLS policies shipped by the real Drizzle migrations
+ * (0001 + 0036 + 0075) — NOT test-authored policy copies. Enforcement is
+ * exercised through the NOBYPASSRLS `test_app_user` role via withRlsUser /
+ * withRlsAnonymous, with the `app.clerk_user_id` session variable carrying
+ * the app `users.id` UUID exactly as lib/auth/session.ts writes it.
  *
- * The RLS policies enforce:
- * - Public profiles can be read by anyone
- * - Private profiles can only be read by their owners
- * - Profiles can only be updated/deleted by their owners
+ * Policies under test:
+ * - users: self-only select/update/insert keyed on users.id
+ * - creator_profiles: public read; owner-only otherwise
+ * - profile_photos: public read via public profile; owner-only otherwise
  */
 
-// Use the global test database connection provisioned in tests/setup.ts
-const db = (
-  globalThis as typeof globalThis & { db?: NeonDatabase<typeof schema> }
-).db;
+type TestDb = NeonDatabase<typeof schema>;
 
-if (!db) {
-  describe.skip('RLS access control (database)', () => {
-    it.todo('skips because no database connection is configured');
+setupDatabaseBeforeAll();
+
+const hasDatabase = Boolean(process.env.DATABASE_URL);
+
+describe.skipIf(!hasDatabase)('RLS access control (database)', () => {
+  let db: TestDb;
+  let userAId: string;
+  let userBId: string;
+  let publicProfileId: string;
+  let privateProfileId: string;
+  let publicPhotoId: string;
+  let privatePhotoId: string;
+
+  beforeAll(async () => {
+    const connection = (globalThis as typeof globalThis & { db?: TestDb }).db;
+    if (!connection) {
+      throw new Error(
+        'Database connection not initialized for RLS integration tests'
+      );
+    }
+    db = connection;
+
+    const now = Date.now();
+
+    const [userA, userB] = await db
+      .insert(users)
+      .values([
+        { clerkId: `rls_user_a_${now}`, userStatus: 'active' },
+        { clerkId: `rls_user_b_${now}`, userStatus: 'active' },
+      ])
+      .returning({ id: users.id });
+
+    userAId = userA.id;
+    userBId = userB.id;
+
+    const [publicProfile, privateProfile] = await db
+      .insert(creatorProfiles)
+      .values([
+        {
+          userId: userAId,
+          creatorType: 'artist',
+          username: `rls-public-${now}`,
+          usernameNormalized: `rls-public-${now}`,
+          isPublic: true,
+        },
+        {
+          userId: userBId,
+          creatorType: 'artist',
+          username: `rls-private-${now}`,
+          usernameNormalized: `rls-private-${now}`,
+          isPublic: false,
+        },
+      ])
+      .returning({ id: creatorProfiles.id });
+
+    publicProfileId = publicProfile.id;
+    privateProfileId = privateProfile.id;
+
+    const [publicPhoto, privatePhoto] = await db
+      .insert(profilePhotos)
+      .values([
+        {
+          userId: userAId,
+          creatorProfileId: publicProfileId,
+          status: 'ready',
+          blobUrl: 'https://public-avatar.test/original.webp',
+        },
+        {
+          userId: userBId,
+          creatorProfileId: privateProfileId,
+          status: 'ready',
+          blobUrl: 'https://private-avatar.test/original.webp',
+        },
+      ])
+      .returning({ id: profilePhotos.id });
+
+    publicPhotoId = publicPhoto.id;
+    privatePhotoId = privatePhoto.id;
   });
-} else {
-  describe('RLS access control (database)', () => {
-    let userAClerkId: string;
-    let userBClerkId: string;
-    let publicProfileId: string;
-    let privateProfileId: string;
-    let publicPhotoId: string;
-    let privatePhotoId: string;
 
-    beforeAll(async () => {
-      const now = Date.now();
-      userAClerkId = `rls_user_a_${now}`;
-      userBClerkId = `rls_user_b_${now}`;
-
-      const [userA, userB] = await db
-        .insert(users)
-        .values([
-          { clerkId: userAClerkId, userStatus: 'active' },
-          { clerkId: userBClerkId, userStatus: 'active' },
-        ])
-        .returning({ id: users.id });
-
-      const [publicProfile, privateProfile] = await db
-        .insert(creatorProfiles)
-        .values([
-          {
-            userId: userA.id,
-            creatorType: 'artist',
-            username: `rls-public-${now}`,
-            usernameNormalized: `rls-public-${now}`,
-            isPublic: true,
-          },
-          {
-            userId: userB.id,
-            creatorType: 'artist',
-            username: `rls-private-${now}`,
-            usernameNormalized: `rls-private-${now}`,
-            isPublic: false,
-          },
-        ])
-        .returning({ id: creatorProfiles.id });
-
-      publicProfileId = publicProfile.id;
-      privateProfileId = privateProfile.id;
-
-      const [publicPhoto, privatePhoto] = await db
-        .insert(profilePhotos)
-        .values([
-          {
-            userId: userA.id,
-            creatorProfileId: publicProfile.id,
-            status: 'ready',
-            blobUrl: 'https://public-avatar.test/original.webp',
-            smallUrl: 'https://public-avatar.test/s.webp',
-            mediumUrl: 'https://public-avatar.test/m.webp',
-            largeUrl: 'https://public-avatar.test/l.webp',
-          },
-          {
-            userId: userB.id,
-            creatorProfileId: privateProfile.id,
-            status: 'ready',
-            blobUrl: 'https://private-avatar.test/original.webp',
-            smallUrl: 'https://private-avatar.test/s.webp',
-            mediumUrl: 'https://private-avatar.test/m.webp',
-            largeUrl: 'https://private-avatar.test/l.webp',
-          },
-        ])
-        .returning({ id: profilePhotos.id });
-
-      publicPhotoId = publicPhoto.id;
-      privatePhotoId = privatePhoto.id;
+  describe('users table', () => {
+    it('allows a user to read their own row', async () => {
+      const rows = await withRlsUser(userAId, async tx =>
+        tx.execute(
+          drizzleSql.raw(`SELECT id FROM users WHERE id = '${userAId}'`)
+        )
+      );
+      expect(rows.rows.length).toBe(1);
+      expect(rows.rows[0]?.id).toBe(userAId);
     });
 
-    it("prevents a user from reading another user's private profile", async () => {
-      const rows = await withRlsUser(userAClerkId, async tx => {
-        return tx.execute(
+    it("denies reading another user's row", async () => {
+      const rows = await withRlsUser(userAId, async tx =>
+        tx.execute(
+          drizzleSql.raw(`SELECT id FROM users WHERE id = '${userBId}'`)
+        )
+      );
+      expect(rows.rows.length).toBe(0);
+    });
+
+    it("denies updating another user's row", async () => {
+      const updated = await withRlsUser(userAId, async tx =>
+        tx.execute(
+          drizzleSql.raw(
+            `UPDATE users SET email = 'stolen@rls.test' WHERE id = '${userBId}' RETURNING id`
+          )
+        )
+      );
+      expect(updated.rows.length).toBe(0);
+    });
+
+    it('denies anonymous reads of users', async () => {
+      const rows = await withRlsAnonymous(async tx =>
+        tx.execute(
+          drizzleSql.raw(`SELECT id FROM users WHERE id = '${userAId}'`)
+        )
+      );
+      expect(rows.rows.length).toBe(0);
+    });
+  });
+
+  describe('creator_profiles table', () => {
+    it("denies reading another user's private profile", async () => {
+      const rows = await withRlsUser(userAId, async tx =>
+        tx.execute(
           drizzleSql.raw(
             `SELECT id FROM creator_profiles WHERE id = '${privateProfileId}'`
           )
-        );
-      });
-
-      // With proper RLS, user A should not see user B's private profile
+        )
+      );
       expect(rows.rows.length).toBe(0);
     });
 
     it('allows the owner to read their own private profile', async () => {
-      const rows = await withRlsUser(userBClerkId, async tx => {
-        return tx.execute(
+      const rows = await withRlsUser(userBId, async tx =>
+        tx.execute(
           drizzleSql.raw(
             `SELECT id FROM creator_profiles WHERE id = '${privateProfileId}'`
           )
-        );
-      });
-
-      // User B should be able to see their own private profile
+        )
+      );
       expect(rows.rows.length).toBe(1);
       expect(rows.rows[0]?.id).toBe(privateProfileId);
     });
 
-    it("prevents a user from updating another user's profile", async () => {
-      const updated = await withRlsUser(userAClerkId, async tx => {
-        return tx.execute(
+    it("denies updating another user's profile", async () => {
+      const updated = await withRlsUser(userAId, async tx =>
+        tx.execute(
           drizzleSql.raw(
             `UPDATE creator_profiles SET display_name = 'unauthorized-update' WHERE id = '${privateProfileId}' RETURNING id`
           )
-        );
-      });
-
-      // With proper RLS, user A should not be able to update user B's profile
+        )
+      );
       expect(updated.rows.length).toBe(0);
     });
 
-    it('allows reads of public profiles', async () => {
-      // Even anonymous users should be able to read public profiles
-      const publicRows = await withRlsAnonymous(async tx => {
-        return tx.execute(
+    it('allows the owner to update their own profile', async () => {
+      const updated = await withRlsUser(userAId, async tx =>
+        tx.execute(
+          drizzleSql.raw(
+            `UPDATE creator_profiles SET display_name = 'owner-update' WHERE id = '${publicProfileId}' RETURNING id`
+          )
+        )
+      );
+      expect(updated.rows.length).toBe(1);
+    });
+
+    it('allows anonymous reads of public profiles', async () => {
+      const rows = await withRlsAnonymous(async tx =>
+        tx.execute(
           drizzleSql.raw(
             `SELECT id FROM creator_profiles WHERE id = '${publicProfileId}'`
           )
-        );
-      });
-
-      expect(publicRows.rows.length).toBe(1);
-      expect(publicRows.rows[0]?.id).toBe(publicProfileId);
+        )
+      );
+      expect(rows.rows.length).toBe(1);
+      expect(rows.rows[0]?.id).toBe(publicProfileId);
     });
 
-    it('prevents anonymous reads of private profiles', async () => {
-      const privateRows = await withRlsAnonymous(async tx => {
-        return tx.execute(
+    it('denies anonymous reads of private profiles', async () => {
+      const rows = await withRlsAnonymous(async tx =>
+        tx.execute(
           drizzleSql.raw(
             `SELECT id FROM creator_profiles WHERE id = '${privateProfileId}'`
           )
-        );
-      });
-
-      // Anonymous users should not see private profiles
-      expect(privateRows.rows.length).toBe(0);
+        )
+      );
+      expect(rows.rows.length).toBe(0);
     });
+  });
 
-    it('allows reads of public profile photos', async () => {
-      // Even anonymous users should be able to read photos for public profiles
-      const publicRows = await withRlsAnonymous(async tx => {
-        return tx.execute(
+  describe('profile_photos table', () => {
+    it('allows anonymous reads of photos on public profiles', async () => {
+      const rows = await withRlsAnonymous(async tx =>
+        tx.execute(
           drizzleSql.raw(
             `SELECT id FROM profile_photos WHERE id = '${publicPhotoId}'`
           )
-        );
-      });
-
-      expect(publicRows.rows.length).toBe(1);
-      expect(publicRows.rows[0]?.id).toBe(publicPhotoId);
+        )
+      );
+      expect(rows.rows.length).toBe(1);
+      expect(rows.rows[0]?.id).toBe(publicPhotoId);
     });
 
-    it('prevents anonymous reads of private profile photos', async () => {
-      const privateRows = await withRlsAnonymous(async tx => {
-        return tx.execute(
+    it('denies anonymous reads of photos on private profiles', async () => {
+      const rows = await withRlsAnonymous(async tx =>
+        tx.execute(
           drizzleSql.raw(
             `SELECT id FROM profile_photos WHERE id = '${privatePhotoId}'`
           )
-        );
-      });
+        )
+      );
+      expect(rows.rows.length).toBe(0);
+    });
 
-      // Anonymous users should not see photos for private profiles
-      expect(privateRows.rows.length).toBe(0);
+    it('allows the owner to read their private-profile photo', async () => {
+      const rows = await withRlsUser(userBId, async tx =>
+        tx.execute(
+          drizzleSql.raw(
+            `SELECT id FROM profile_photos WHERE id = '${privatePhotoId}'`
+          )
+        )
+      );
+      expect(rows.rows.length).toBe(1);
+    });
+
+    it("denies updating another user's photo", async () => {
+      const updated = await withRlsUser(userAId, async tx =>
+        tx.execute(
+          drizzleSql.raw(
+            `UPDATE profile_photos SET blob_url = 'https://hijacked.test/x.webp' WHERE id = '${privatePhotoId}' RETURNING id`
+          )
+        )
+      );
+      expect(updated.rows.length).toBe(0);
     });
   });
-}
+});

--- a/apps/web/vitest.config.integration.mts
+++ b/apps/web/vitest.config.integration.mts
@@ -1,0 +1,91 @@
+import react from '@vitejs/plugin-react';
+import dotenv from 'dotenv';
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+// Load environment variables from .env.test if it exists
+dotenv.config({ path: '.env.test' });
+
+/**
+ * Integration test config (JOV-4195 / GH #13931).
+ *
+ * Runs `tests/integration/**` against a real database (DATABASE_URL —
+ * a Neon ephemeral branch in CI). This is the ONLY config that executes
+ * the integration suites: vitest.config.fast.mts (merge gate) excludes
+ * them, and vitest.config.ci.mts runs without a DATABASE_URL in the
+ * nightly sonarcloud lane. Suites use describe.skipIf(!DATABASE_URL) so
+ * the run degrades to skips rather than hard failures when no DB is
+ * provisioned.
+ *
+ * CI lane: "Integration Tests (DB)" in .github/workflows/ci.yml —
+ * risk-triggered on DB-relevant path changes, reusing the shared
+ * neon-db ephemeral branch artifact.
+ */
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./tests/setup.ts'],
+    include: ['tests/integration/**/*.test.{ts,tsx}'],
+    exclude: ['node_modules/**', '.next/**'],
+    pool: 'forks',
+    // DB integration suites share one ephemeral branch — run serially to
+    // avoid cross-file fixture interference.
+    singleFork: true,
+    fileParallelism: false,
+    maxWorkers: 1,
+    minWorkers: 1,
+    isolate: true,
+    // Real DB round-trips + drizzle migrate() in beforeAll need generous
+    // budgets compared to the 5s unit-test defaults.
+    testTimeout: 30_000,
+    hookTimeout: 120_000,
+    teardownTimeout: 30_000,
+    globals: true,
+    maxConcurrency: 1,
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@\/app\/app\//,
+        replacement: `${path.resolve(__dirname, './app/app')}/`,
+      },
+      {
+        find: /^@\/app\/api\//,
+        replacement: `${path.resolve(__dirname, './app/api')}/`,
+      },
+      {
+        find: /^@\/app\/\(marketing\)\//,
+        replacement: `${path.resolve(__dirname, './app/(marketing)')}/`,
+      },
+      {
+        find: /^@\/app\/\(shell\)\//,
+        replacement: `${path.resolve(__dirname, './app/app/(shell)')}/`,
+      },
+      {
+        find: /^@\/app\//,
+        replacement: `${path.resolve(__dirname, './app')}/`,
+      },
+      {
+        find: /^@\/features\//,
+        replacement: `${path.resolve(__dirname, './components/features')}/`,
+      },
+      {
+        find: /^@\//,
+        replacement: `${path.resolve(__dirname, './')}/`,
+      },
+      {
+        find: /^@jovie\/ui\//,
+        replacement: `${path.resolve(__dirname, '../../packages/ui')}/`,
+      },
+      {
+        find: /^@jovie\/ui$/,
+        replacement: path.resolve(__dirname, '../../packages/ui'),
+      },
+    ],
+  },
+  build: {
+    target: 'esnext',
+    minify: false,
+  },
+});

--- a/scripts/ci-fast-lanes.mjs
+++ b/scripts/ci-fast-lanes.mjs
@@ -52,6 +52,12 @@ const LANES = [
     run: runGuardrails,
   },
   {
+    id: 'test-truth',
+    name: 'Test Truth Guard (dead-test detector)',
+    nextLocalCommand: 'pnpm --filter=@jovie/web run test:truth',
+    run: runTestTruth,
+  },
+  {
     id: 'structural',
     name: 'Structural Contract',
     nextLocalCommand:
@@ -190,6 +196,13 @@ function runGuardrails() {
     }
   }
   return { code: 0, output: combined };
+}
+
+function runTestTruth() {
+  // Banned-phrase scan + dead-test detector (fails when a tests/** vitest
+  // file is excluded by every CI-executed vitest config). Cheap fs walk —
+  // runs unconditionally (JOV-4195).
+  return shell('pnpm --filter=@jovie/web run test:truth');
 }
 
 function runStructural() {


### PR DESCRIPTION
## Problem
`tests/integration/**` executes in NO CI lane: `vitest.config.fast.mts` (merge gate + nightly coverage) excludes it, and the only config including it (`vitest.config.ci.mts`) runs solely in nightly sonarcloud with no `DATABASE_URL`. On top of that, `rls-access-control.test.ts` read `globalThis.db` at module-eval time before any `beforeAll` could assign it, so its `describe.skip` branch was ALWAYS taken — structurally dead coverage that the heatmap counted as protection.

## What changed
- **`tests/integration/rls-access-control.test.ts`**: revived using the `setupDatabaseBeforeAll()` pattern (from `onboarding-completion.test.ts`) + `describe.skipIf(!DATABASE_URL)`. Now asserts against the REAL migration policies (0001/0036/0075), keyed on `users.id` session identity, via the NOBYPASSRLS `test_app_user` role: users self-read/cross-read-deny/cross-update-deny/anon-deny; creator_profiles public-read/private-owner-only/update ownership; profile_photos public-via-public-profile/owner-only.
- **`vitest.config.integration.mts`** (new) + `test:integration` script: the dedicated integration config (serial, real-DB timeouts).
- **`scripts/test-truth-guard.mjs`**: dead-test detector — fails when a `tests/**` vitest file is excluded by every CI-executed vitest config (parses fast-config excludes live; allowlists Playwright/e2e, `*.nightly.test.ts`, `*.real.test.ts` lanes). Verified it fires on a planted orphan and passes on the current tree.
- **`scripts/ci-fast-lanes.mjs`**: wires `test:truth` (banned phrases + dead-test detector) into the ci-fast merge gate as its own lane.

## ⚠️ Human step required (token lacks `workflows` permission)
The new **`Integration Tests (DB)`** job for `.github/workflows/ci.yml` could NOT be pushed — the GitHub App token returned `403 Resource not accessible by integration` on any tree touching workflow files. The exact job (risk-triggered on `run_neon`, reuses the shared `neon-db` ephemeral-branch artifact, informational/non-merge-gate) needs to be committed to this branch by someone with workflow-write (Tim or the local shipper). Apply this hunk immediately before the `ci-integration-ready:` job:

```yaml
  ci-integration-tests:
    name: Integration Tests (DB)
    needs: [neon-db, ci-path-changes]
    # Risk-triggered DB integration lane (JOV-4195 / GH #13931): executes
    # tests/integration/** (vitest.config.integration.mts) against the shared
    # Neon ephemeral branch created by the neon-db job. Runs on push to main
    # and on PRs touching DB-relevant paths (run_neon). Informational lane —
    # intentionally NOT part of the PR Ready merge-gate aggregate.
    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.ci-path-changes.outputs.run_neon == 'true')) }}
    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
    timeout-minutes: 15
    steps:
      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
        with:
          fetch-depth: 1

      - name: Download Neon DB connection artifact
        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
        with:
          name: neon-db-connection-${{ github.run_id }}
          path: /tmp/neon-db-connection

      - name: Resolve DATABASE_URL from Neon artifact
        id: resolve-integration-neon-db-url
        uses: ./.github/actions/resolve-neon-database-url
        with:
          connection_file: /tmp/neon-db-connection/connection.json
          candidate_json_key: db_url
          fallback_json_key: db_url_pooled
          credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
          credential_fallback_url: ${{ secrets.DATABASE_URL }}

      - name: Export DATABASE_URL
        run: echo "DATABASE_URL=${{ steps.resolve-integration-neon-db-url.outputs.database_url }}" >> "$GITHUB_ENV"

      - name: Fail if Neon DB URL is missing
        run: |
          if [[ -z "$DATABASE_URL" ]]; then
            echo "No Neon ephemeral DATABASE_URL available. Refusing to run integration tests against staging/production DBs."
            exit 1
          fi

      - name: Setup Node.js and pnpm
        uses: ./.github/actions/setup-node-pnpm

      - name: Run integration tests (real DB)
        env:
          DATABASE_URL: ${{ env.DATABASE_URL }}
          NODE_ENV: test
        run: pnpm --filter=@jovie/web run test:integration
```

## Assumptions
- Lane is **informational** (not in the PR Ready merge-gate aggregate) — matches the issue's "risk-triggered is fine" and avoids expanding the merge gate without a human call.
- `.nightly.test.ts` / `.real.test.ts` / `tests/e2e` are treated as legitimately-covered non-vitest-gate lanes by the detector.

## Verification
- Sandbox npm registry egress denied (403; access request pending) → `pnpm turbo lint typecheck test:fast` / `build:web` delegated to CI; PR stays DRAFT until green.
- Ran locally: `node --check` on both modified scripts (pass); `node apps/web/scripts/test-truth-guard.mjs` → `no violations found`; planted `tests/audit/tmp-dead-check.test.ts` → guard exits 1 with the dead-test violation, removed → clean again.
- CI-log evidence of `rls-access-control.test.ts` executing will come from the new lane once the workflow hunk lands (acceptance criterion for this issue).

## Stack
Part 2/2 — stacked on #13966 (`agent/jov-4194-rls-realign`). The revived RLS assertions require migration 0075; land part 1 first.

Dispatch: Summer issue-drain requeue 2026-07-10 (RLS/CI hardening workstream). Linear: JOV-4195.

Fixes #13931

🤖 Generated with [Claude Code](https://claude.com/claude-code)
