### PR TITLE
fix(ops): bound and dedupe shipping drain

### DIFF
--- a/.claude/commands/drain.md
+++ b/.claude/commands/drain.md
@@ -30,9 +30,14 @@ queue, not this command, is what keeps `main` green.
 ## Phase 0 — Classify + enroll the clean bucket
 
 ```bash
-DRY_RUN=1 bash scripts/drain-pr-queue.sh   # preview the buckets
-bash scripts/drain-pr-queue.sh             # apply: -merge-queue on hard gates, +merge-queue on clean PRs, +needs-conflict-resolution on conflicts
+DRY_RUN=1 DRAIN_MAX_SECONDS=900 bash scripts/drain-pr-queue.sh   # preview for at most 15 minutes
+DRAIN_MAX_SECONDS=900 bash scripts/drain-pr-queue.sh             # apply; defer remainder at the budget
 ```
+
+`DRAIN_MAX_SECONDS` defaults to `900` (15 minutes). The script checks the budget
+before each per-PR GitHub operation, so a scheduled drain cannot expand without
+bound as the backlog grows. A single in-flight API call may finish after the
+budget; the next operation is deferred to the next tick.
 
 The script enrolls every non-draft, `MERGEABLE`, green, non-opted-out PR and
 prints five work buckets: **DEQUEUE**, **CONFLICT**, **BLOCKED**, **SURFACE**,

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -17,6 +17,7 @@
 #
 # Env:
 #   DRY_RUN=1   classify and print only; apply no labels
+#   DRAIN_MAX_SECONDS  hard wall-clock budget between GitHub calls (default 900)
 set -euo pipefail
 
 # shellcheck source=./scripts/lib/gh-retry.sh
@@ -24,6 +25,18 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/gh-retry.sh"
 
 REPO="${REPO:-JovieInc/Jovie}"
 DRY_RUN="${DRY_RUN:-0}"
+DRAIN_MAX_SECONDS="${DRAIN_MAX_SECONDS:-900}"
+DRAIN_STARTED_AT="$SECONDS"
+
+# Keep one scheduled tick bounded. A single in-flight GitHub call may finish
+# after the deadline, but no subsequent per-PR operation is started.
+stop_if_budget_exhausted() {
+  if (( SECONDS - DRAIN_STARTED_AT >= DRAIN_MAX_SECONDS )); then
+    echo "=== drain budget exhausted after ${DRAIN_MAX_SECONDS}s; deferring remaining PRs ==="
+    return 0
+  fi
+  return 1
+}
 # Branches that are agent-owned (safe to rebase/force-push in a fix agent).
 AGENT_RE='^(tim/|codex/|agent/|claude/|linear/|feat/|dependabot/)'
 
@@ -114,6 +127,7 @@ SNAP="$(gh_retry pr list -R "$REPO" --state open --limit 200 \
 
 ENRICHED="[]"
 while IFS= read -r pr; do
+  stop_if_budget_exhausted && break
   n="$(jq -r '.n' <<<"$pr")"
   fail="[]"
   if jq -e '
@@ -202,74 +216,32 @@ echo "$SNAP" | jq -c '.[]
 # CLEAN meant those PRs never entered the queue. Enrolling a not-yet-green PR is
 # safe — Graphite re-validates and the dequeue step above removes any that truly
 # fail. `.fail` only counts terminal failing checks, not pending/queued ones.
-echo "=== ENROLL (mergeable + not failing → +merge-queue + auto-merge) ==="
-# Honor GRAPHITE_QUEUE_POLICY.maxQueueDepth: this is the primary enrollment
-# path, and until 2026-07-09 it was the only one that ignored the cap the
-# agent-pipeline/landing-sweep/tick paths all enforce — a mass-green event
-# (CI outage recovery, post-rebase wave) could enqueue an unbounded batch and
-# saturate Graphite + the runner pool in one pass.
+echo "=== ENROLL (mergeable + not failing → +merge-queue) ==="
+# Honor GRAPHITE_QUEUE_POLICY.maxQueueDepth. Use process substitution rather
+# than a pipe so ENROLLED_THIS_RUN remains in the parent shell and the cap is
+# actually enforced.
 MAX_QUEUE_DEPTH=$(node scripts/ci-merge-queue-check.mjs max-queue-depth 2>/dev/null || echo 16)
 QUEUED_NOW=$(echo "$SNAP" | jq '[.[] | select([.L[]] | index("merge-queue"))] | length')
 ENROLL_SLOTS=$((MAX_QUEUE_DEPTH - QUEUED_NOW))
 [[ "$ENROLL_SLOTS" -lt 0 ]] && ENROLL_SLOTS=0
 echo "  queue depth: $QUEUED_NOW/$MAX_QUEUE_DEPTH ($ENROLL_SLOTS slots)"
 ENROLLED_THIS_RUN=0
-echo "$SNAP" | jq -c '.[]
+while read -r pr; do
+  stop_if_budget_exhausted && break
+  n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
+  if [[ "$ENROLLED_THIS_RUN" -ge "$ENROLL_SLOTS" ]]; then
+    echo "  #$n  $t  ⏸ deferred (queue at depth cap; next drain pass enrolls)"
+    continue
+  fi
+  ENROLLED_THIS_RUN=$((ENROLLED_THIS_RUN + 1))
+  echo "  #$n  $t"
+  label "$n" merge-queue
+done < <(echo "$SNAP" | jq -c '.[]
   | select(.draft|not)
   | select(.m=="MERGEABLE")
   | select(.fail|length==0)
   | select((.head|startswith("gtmq_"))|not)
-  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="needs-conflict-resolution" or .=="merge-queue" or .=="fast") | not)' \
-| while read -r pr; do
-    n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
-    if [[ "$ENROLLED_THIS_RUN" -ge "$ENROLL_SLOTS" ]]; then
-      echo "  #$n  $t  ⏸ deferred (queue at depth cap; next drain pass enrolls)"
-      continue
-    fi
-    ENROLLED_THIS_RUN=$((ENROLLED_THIS_RUN + 1))
-    echo "  #$n  $t"
-    label "$n" merge-queue
-    # Enable GitHub native auto-merge (squash) so the PR merges as soon as
-    # CI goes green. The `merge-queue` label alone is a status marker, not a
-    # merge trigger — the old mq-guard.sh cron controlled actual auto-merge.
-    # Since that cron was disabled during CI consolidation (2026-07-08),
-    # this step closes the pipeline gap inline.
-    if [[ "$DRY_RUN" == "1" ]]; then
-      echo "    [dry-run] would enable auto-merge on #$n"
-    else
-      gh_retry pr merge "$n" -R "$REPO" --auto --squash >/dev/null 2>&1 \
-        && echo "    +auto-merge on #$n" \
-        || echo "    !! failed to enable auto-merge on #$n"
-    fi
-  done
-
-# --- CATCH-UP: labeled but no auto-merge ---
-# PRs that got the `merge-queue` label from an earlier drain run (before this
-# auto-merge step existed) or from manual labeling need auto-merge enabled too.
-echo "=== CATCH-UP (+auto-merge on labeled PRs missing it) ==="
-echo "$SNAP" | jq -c '.[]
-  | select(.draft|not)
-  | select(.m=="MERGEABLE")
-  | select(.fail|length==0)
-  | select(.head|startswith("gtmq_")|not)
-  | select([.L[]] | index("merge-queue"))
-  | select(.ms == "CLEAN" or .ms == "UNSTABLE")' \
-| while read -r pr; do
-    n=$(jq -r '.n' <<<"$pr")
-    t=$(jq -r '.t' <<<"$pr")
-    if [[ "$DRY_RUN" == "1" ]]; then
-      echo "    [dry-run] would check auto-merge on #$n $t"
-    else
-      if gh pr view "$n" -R "$REPO" --json autoMergeRequest --jq '.autoMergeRequest' 2>/dev/null | grep -q 'mergeMethod'; then
-        echo "  #$n  $t  auto-merge already enabled"
-      else
-        echo "  #$n  $t  enabling auto-merge (catch-up)"
-        gh_retry pr merge "$n" -R "$REPO" --auto --squash >/dev/null 2>&1 \
-          && echo "    +auto-merge on #$n" \
-          || echo "    !! failed to enable auto-merge on #$n"
-      fi
-    fi
-  done
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="needs-conflict-resolution" or .=="merge-queue" or .=="fast") | not)')
 
 # --- CONFLICT: needs rebase (agent branches only) → label + hand to fix agent ---
 echo "=== CONFLICT (needs rebase → fix agent) ==="

--- a/scripts/drain-pr-remediate.mjs
+++ b/scripts/drain-pr-remediate.mjs
@@ -3,7 +3,7 @@
 import { execFile, execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { listBlockedAgentPrs } from './lib/pr-check-failures.mjs';
@@ -171,9 +171,21 @@ async function labelPr(repo, prNumber, labelName) {
 
 async function commentPr(repo, prNumber, body) {
   await execFileAsync(
-    'gh',
-    ['pr', 'comment', String(prNumber), '-R', repo, '--body', body],
-    { encoding: 'utf8' }
+    'bash',
+    [
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        'lib',
+        'upsert-pr-comment.sh'
+      ),
+      String(prNumber),
+      'drain-auto-rebase',
+      body,
+    ],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, GITHUB_REPOSITORY: repo },
+    }
   );
 }
 

--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -52,6 +52,7 @@ import {
   gbrainContextBlocker,
   HUMAN_REVIEW_LABEL,
   type IssueComment,
+  isAlreadyClaimedOrBlocked,
   labelNames,
   loadShipperConfig,
   NO_AUTO_LABEL,
@@ -714,7 +715,54 @@ function commentIssue(
   );
 }
 
-function claimIssue(config: ShipperConfig, plan: DispatchPlan): void {
+function claimIssue(config: ShipperConfig, plan: DispatchPlan): boolean {
+  // Re-read the issue immediately before claiming. The planner snapshot can be
+  // stale while another shipper tick (or a human) claims the same issue.
+  let current: { state?: string; labels?: ReadonlyArray<{ name: string }> };
+  try {
+    current = JSON.parse(
+      run(
+        [
+          'gh',
+          'issue',
+          'view',
+          String(plan.issue.number),
+          '--repo',
+          config.repo,
+          '--json',
+          'state,labels',
+        ],
+        config
+      )
+    ) as typeof current;
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'claim_revalidation_failed',
+      issue: plan.issue.number,
+      error: shortError(err),
+    });
+    return false;
+  }
+
+  const currentIssue: GithubIssue = {
+    ...plan.issue,
+    labels: current.labels ?? [],
+  };
+  if (
+    current.state?.toUpperCase() !== 'OPEN' ||
+    isAlreadyClaimedOrBlocked(currentIssue)
+  ) {
+    logJobEvent({
+      job: JOB,
+      event: 'claim_deduped',
+      issue: plan.issue.number,
+      state: current.state,
+      labels: labelNames(currentIssue),
+    });
+    return false;
+  }
+
   run(
     [
       'gh',
@@ -729,20 +777,57 @@ function claimIssue(config: ShipperConfig, plan: DispatchPlan): void {
     config
   );
 
+  // Confirm the shared claim signal landed before starting an agent. This
+  // avoids a false local claim when GitHub accepted neither the edit nor the
+  // token's permission to mutate labels.
+  const confirmed = JSON.parse(
+    run(
+      [
+        'gh',
+        'issue',
+        'view',
+        String(plan.issue.number),
+        '--repo',
+        config.repo,
+        '--json',
+        'state,labels',
+      ],
+      config
+    )
+  ) as typeof current;
+  const confirmedIssue: GithubIssue = {
+    ...plan.issue,
+    labels: confirmed.labels ?? [],
+  };
+  if (
+    confirmed.state?.toUpperCase() !== 'OPEN' ||
+    !labelNames(confirmedIssue).includes(CODEX_CLAIM_LABEL)
+  ) {
+    logJobEvent({
+      job: JOB,
+      event: 'claim_confirmation_failed',
+      issue: plan.issue.number,
+      state: confirmed.state,
+      labels: labelNames(confirmedIssue),
+    });
+    return false;
+  }
+
   commentIssue(
     config,
     plan.issue.number,
     [
       `Jovie agent (codex issue shipper) claimed this issue.`,
       '',
-      `Branch: \`${plan.branchName}\``,
-      `Risk: \`${plan.route.riskLevel}\``,
-      `Model route: \`${plan.route.modelProfile}\` using \`${plan.route.sessionModel}\``,
+      `Branch: ${plan.branchName}`,
+      `Risk: ${plan.route.riskLevel}`,
+      `Model route: ${plan.route.modelProfile} using ${plan.route.sessionModel}`,
       plan.integrationBranch
-        ? `Integration branch: \`${plan.integrationBranch}\``
+        ? `Integration branch: ${plan.integrationBranch}`
         : 'Integration branch: not used for this issue',
     ].join('\n')
   );
+  return true;
 }
 
 function markBlocked(
@@ -1164,7 +1249,12 @@ async function dispatchPlan(
   const prepared = prepareWorktree(config, plan);
   const dispatch = prepared.plan;
   try {
-    claimIssue(config, dispatch);
+    if (!claimIssue(config, dispatch)) {
+      // Another active shipper/human won the race, or GitHub did not confirm
+      // our label mutation. Do not mark the issue blocked or release a claim
+      // we do not own; the next tick will re-evaluate it.
+      return;
+    }
     journalStart({
       job: JOB,
       repo: config.repo,


### PR DESCRIPTION
## Summary
- Bound each drain tick to a 15-minute default budget via `DRAIN_MAX_SECONDS`.
- Fix queue-depth enforcement: the enrollment loop now uses process substitution, so the per-run enrollment counter is not lost in a subshell.
- Remove forbidden `gh pr merge --auto` behavior from the Graphite-native drain; enrollment is label-only.
- Make drain rebase remediation comments idempotent through the shared upsert helper.
- Revalidate issue state/claim labels immediately before and after claim mutation; deduped claims exit without marking or releasing another worker's issue.

## Audit outcome
Existing code already provided isolated worktrees, a machine-global shipper lock, deterministic no-agent finisher, PR evidence artifacts, merge-queue labeling, and terminal-failure-only dequeue logic. This PR only hardens the gaps found in the execution contract. Independent post-agent verification remains the CI/PR gate and is not replaced by the coding agent.

## Verification
- `pnpm exec vitest run scripts/lib/__tests__/codex-issue-shipper.test.mjs scripts/lib/__tests__/merge-queue-guard.test.mjs` — 81 passed
- `pnpm exec tsc --noEmit --pretty false --incremental false` — passed
- `bash -n scripts/drain-pr-queue.sh` — passed
- `node --check scripts/drain-pr-remediate.mjs` — passed
- `git diff --check` — passed
- pre-push: Biome, proxy guard, Tailwind guard, web typecheck — passed

Do not merge manually; Graphite owns enrollment/landing via the `merge-queue` label.
