### PR TITLE
fix(auth): BA identity resolution + rate-limit TTL self-heal (dashboard redirect-loop P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- **Signing in is more reliable**: fixed a bug that could bounce signed-in artists between the sign-in page and the dashboard forever, and another that could permanently lock an address out of receiving sign-in codes.
+- [internal] **Better Auth identity resolution + rate-limit TTL self-heal**: `userIdentityFilter` matches clerk_id / better_auth_user_id / app UUID in shared user queries (fixes the /app ↔ /signin streamed-redirect loop and a uuid-cast throw in `getUserByIdentity`); secondary-storage `increment` applies `EXPIRE NX` so TTL-less rate-limit counters self-heal; op timeout env-tunable via `AUTH_SECONDARY_STORAGE_TIMEOUT_MS`.
+
 - [internal] Agent preflight: one-shot JSON bootstrap for /autoplan (JOV-4183)
 - **[internal] Critical auth, activation, and billing identity hardening (JOV-4181)**: Stripe billing updates, trial activation, billing-status reads, and profile ownership checks now resolve Better Auth application users safely across the legacy Clerk-ID transition; deterministic regression tests cover the identity and compare-and-set predicates. CI now classifies onboarding, ingestion, memory, AI/workflow, enrichment, chat, and cron changes as high risk.
 - **Jovie now presents one focused, dark career operating system from hero to conversion:** the homepage leads with “Jovie runs your music career,” shows one release workspace, replaces the profile carousel with three static artist outcomes, and connects release, fan capture, routing, learning, and next actions in one closed-loop story. The floating header, CTAs, chat bubbles, motion, reduced-motion behavior, and responsive alignment now follow the same compact System B rules.

--- a/apps/web/lib/auth/secondary-storage.ts
+++ b/apps/web/lib/auth/secondary-storage.ts
@@ -25,25 +25,37 @@ import { logger } from '@/lib/utils/logger';
  *   controls in production).
  */
 
-const OP_TIMEOUT_MS = 500;
+const DEFAULT_OP_TIMEOUT_MS = 500;
 const MEMORY_FALLBACK_MAX_ENTRIES = 1000;
 
+/**
+ * Env-tunable so local dev (where Upstash REST RTT can sit at ~500ms and race
+ * the default) can raise headroom without touching deployed behavior. Read at
+ * call time to stay test-mutable, mirroring env-server's dynamic proxy.
+ */
+function getOpTimeoutMs(): number {
+  const raw = env.AUTH_SECONDARY_STORAGE_TIMEOUT_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_OP_TIMEOUT_MS;
+}
+
 class SecondaryStorageTimeoutError extends Error {
-  constructor() {
-    super(`Secondary storage operation timed out after ${OP_TIMEOUT_MS}ms`);
+  constructor(timeoutMs: number) {
+    super(`Secondary storage operation timed out after ${timeoutMs}ms`);
     this.name = 'SecondaryStorageTimeoutError';
   }
 }
 
 async function withTimeout<T>(operation: Promise<T>): Promise<T> {
+  const timeoutMs = getOpTimeoutMs();
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
       operation,
       new Promise<never>((_resolve, reject) => {
         timer = setTimeout(
-          () => reject(new SecondaryStorageTimeoutError()),
-          OP_TIMEOUT_MS
+          () => reject(new SecondaryStorageTimeoutError(timeoutMs)),
+          timeoutMs
         );
       }),
     ]);
@@ -186,8 +198,11 @@ export const secondaryStorage: SecondaryStorage = {
     }
     try {
       const count = await withTimeout(redis.incr(key));
-      if (count === 1 && ttl > 0) {
-        await withTimeout(redis.expire(key, ttl));
+      if (ttl > 0) {
+        // NX: set expiry only when the key has none. Covers both the fresh
+        // key (count===1) and self-heals keys whose first expire call failed
+        // — a TTL-less counter never resets and 429s that bucket forever.
+        await withTimeout(redis.expire(key, ttl, 'NX'));
       }
       return count;
     } catch (error) {

--- a/apps/web/lib/db/queries/shared.ts
+++ b/apps/web/lib/db/queries/shared.ts
@@ -10,11 +10,36 @@
 
 import 'server-only';
 
-import { and, eq, isNotNull, or } from 'drizzle-orm';
+import { and, eq, isNotNull, or, type SQL } from 'drizzle-orm';
 import type { DbOrTransaction } from '@/lib/db';
 import { users } from '@/lib/db/schema/auth';
 import { socialLinks } from '@/lib/db/schema/links';
 import { creatorProfiles, userProfileClaims } from '@/lib/db/schema/profiles';
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Match a users row by any live identity shape (Clerk → Better Auth
+ * migration): legacy Clerk id (`user_…` in `clerk_id`), bridge value
+ * (`ba:<baId>` in `clerk_id`), raw Better Auth id, or the app `users.id`
+ * UUID that `getCachedAuth()` returns. Matching only `clerk_id` sent every
+ * BA-session dashboard request into the /app ↔ /signin redirect loop
+ * (OpportunityInboxRoute streamed redirect).
+ *
+ * The `users.id` clause is only added for UUID-shaped input — comparing a
+ * uuid column against a non-UUID string throws a Postgres cast error.
+ */
+export function userIdentityFilter(authUserId: string): SQL {
+  const clauses: SQL[] = [
+    eq(users.clerkId, authUserId) as SQL,
+    eq(users.betterAuthUserId, authUserId) as SQL,
+  ];
+  if (UUID_PATTERN.test(authUserId)) {
+    clauses.push(eq(users.id, authUserId) as SQL);
+  }
+  return or(...clauses) as SQL;
+}
 
 /**
  * Result type for authenticated profile queries.
@@ -65,7 +90,7 @@ export async function getAuthenticatedProfile(
       displayNameLocked: creatorProfiles.displayNameLocked,
     })
     .from(creatorProfiles)
-    .innerJoin(users, eq(users.id, appUserId))
+    .innerJoin(users, userIdentityFilter(appUserId))
     .leftJoin(
       userProfileClaims,
       and(
@@ -225,28 +250,14 @@ export async function getUserByIdentity(
       deletedAt: users.deletedAt,
     })
     .from(users)
-    .where(eq(users.clerkId, userIdentity))
+    // Single OR query replaces the prior clerkId-then-uuid two-step: it also
+    // matches raw better_auth_user_id, and the uuid clause is shape-guarded —
+    // the two-step fallback threw a Postgres cast error whenever a non-UUID
+    // identity (stale legacy clerk id) missed on clerk_id.
+    .where(userIdentityFilter(userIdentity))
     .limit(1);
 
-  if (user) {
-    return user;
-  }
-
-  const [appUser] = await tx
-    .select({
-      id: users.id,
-      clerkId: users.clerkId,
-      email: users.email,
-      isAdmin: users.isAdmin,
-      isPro: users.isPro,
-      userStatus: users.userStatus,
-      deletedAt: users.deletedAt,
-    })
-    .from(users)
-    .where(eq(users.id, userIdentity))
-    .limit(1);
-
-  return appUser ?? null;
+  return user ?? null;
 }
 
 /**
@@ -280,7 +291,7 @@ export async function verifyProfileOwnership(
   const [profile] = await tx
     .select({ id: creatorProfiles.id })
     .from(creatorProfiles)
-    .innerJoin(users, eq(users.id, appUserId))
+    .innerJoin(users, userIdentityFilter(appUserId))
     .leftJoin(
       userProfileClaims,
       and(

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -216,6 +216,9 @@ export const ServerEnvSchema = z.object({
   // Upstash Redis
   UPSTASH_REDIS_REST_URL: z.string().trim().url().optional(),
   UPSTASH_REDIS_REST_TOKEN: z.string().trim().optional(),
+  // Better Auth secondary-storage op timeout (ms). Local machines can sit at
+  // ~500ms RTT to Upstash REST, racing the default; raise locally only.
+  AUTH_SECONDARY_STORAGE_TIMEOUT_MS: z.string().trim().optional(),
 
   // Onboarding chat (anonymous session signing + bot challenge — JOV-2132)
   SESSION_SECRET: z.string().min(32).optional(),
@@ -498,6 +501,7 @@ export const ENV_KEYS = [
   'MERCURY_ACCOUNT_ID',
   'UPSTASH_REDIS_REST_URL',
   'UPSTASH_REDIS_REST_TOKEN',
+  'AUTH_SECONDARY_STORAGE_TIMEOUT_MS',
   'SESSION_SECRET',
   'TURNSTILE_SECRET_KEY',
   'E2E_PROD_SIGNUP_EMAIL_BASE',

--- a/apps/web/tests/unit/lib/auth/secondary-storage.test.ts
+++ b/apps/web/tests/unit/lib/auth/secondary-storage.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getRedisMock } = vi.hoisted(() => ({ getRedisMock: vi.fn() }));
+
+vi.mock('@/lib/redis', () => ({ getRedis: getRedisMock }));
+vi.mock('@/lib/error-tracking', () => ({ captureError: vi.fn() }));
+vi.mock('server-only', () => ({}));
+
+import {
+  resetSecondaryStorageMemoryForTests,
+  secondaryStorage,
+} from '@/lib/auth/secondary-storage';
+
+describe('secondaryStorage.increment', () => {
+  beforeEach(() => {
+    resetSecondaryStorageMemoryForTests();
+    getRedisMock.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.AUTH_SECONDARY_STORAGE_TIMEOUT_MS;
+  });
+
+  it('always applies TTL with NX so TTL-less counters self-heal', async () => {
+    // Regression: a rate-limit key whose first expire call failed kept
+    // count>1 with TTL=-1 forever -> permanent 429 for that IP+path bucket
+    // (observed live: counts 14/17 with ttl -1 on shared dev Redis).
+    const expire = vi.fn().mockResolvedValue(1);
+    getRedisMock.mockReturnValue({
+      incr: vi.fn().mockResolvedValue(14),
+      expire,
+    });
+
+    const count = await secondaryStorage.increment?.('ip|/send-otp', 60);
+
+    expect(count).toBe(14);
+    expect(expire).toHaveBeenCalledWith('ip|/send-otp', 60, 'NX');
+  });
+
+  it('applies NX TTL on first increment too', async () => {
+    const expire = vi.fn().mockResolvedValue(1);
+    getRedisMock.mockReturnValue({
+      incr: vi.fn().mockResolvedValue(1),
+      expire,
+    });
+
+    await secondaryStorage.increment?.('ip|/send-otp', 60);
+
+    expect(expire).toHaveBeenCalledWith('ip|/send-otp', 60, 'NX');
+  });
+
+  it('skips TTL when rule has no window', async () => {
+    const expire = vi.fn().mockResolvedValue(1);
+    getRedisMock.mockReturnValue({
+      incr: vi.fn().mockResolvedValue(2),
+      expire,
+    });
+
+    await secondaryStorage.increment?.('key', 0);
+
+    expect(expire).not.toHaveBeenCalled();
+  });
+
+  it('honors AUTH_SECONDARY_STORAGE_TIMEOUT_MS for slow ops', async () => {
+    process.env.AUTH_SECONDARY_STORAGE_TIMEOUT_MS = '1500';
+    const slowIncr = vi
+      .fn()
+      .mockImplementation(
+        () => new Promise(resolve => setTimeout(() => resolve(3), 900))
+      );
+    getRedisMock.mockReturnValue({
+      incr: slowIncr,
+      expire: vi.fn().mockResolvedValue(1),
+    });
+
+    // 900ms would exceed the 500ms default and degrade to 1; with the env
+    // raised to 1500ms the real count survives.
+    const count = await secondaryStorage.increment?.('key', 60);
+    expect(count).toBe(3);
+  });
+});

--- a/apps/web/tests/unit/lib/db/queries/shared.test.ts
+++ b/apps/web/tests/unit/lib/db/queries/shared.test.ts
@@ -7,6 +7,8 @@ import {
 } from '@/lib/db/queries/shared';
 import { users } from '@/lib/db/schema/auth';
 
+const APP_UUID = '912cfbb0-a2f6-494d-a880-da3e581c4b3a';
+
 function createQueryChain<T>(rows: T[]) {
   const limit = vi.fn().mockResolvedValue(rows);
   const where = vi.fn(() => ({ limit }));
@@ -27,13 +29,26 @@ function createQueryChain<T>(rows: T[]) {
   };
 }
 
+function createUserQueryChain<T>(rows: T[]) {
+  const limit = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  return {
+    tx: { select } as unknown as Parameters<typeof getUserByIdentity>[0],
+    mocks: { from, limit, select, where },
+  };
+}
+
 describe('shared ownership queries', () => {
-  it('resolves Better Auth app ids after the legacy Clerk lookup misses', async () => {
-    const firstLimit = vi.fn().mockResolvedValue([]);
-    const secondLimit = vi.fn().mockResolvedValue([
+  it('resolves every live identity shape in a single dual-read query', async () => {
+    // One query matches clerk_id OR better_auth_user_id (OR users.id when the
+    // input is UUID-shaped) — the two-step fallback threw a Postgres uuid
+    // cast error whenever a non-UUID identity missed the clerk_id match.
+    const { mocks, tx } = createUserQueryChain([
       {
-        id: 'user_123',
-        clerkId: 'user_legacy',
+        id: APP_UUID,
+        clerkId: 'ba:3PrEc2kJI1rknuVLVD5VstQ7IxsjyIkP',
         email: 'user@example.com',
         isAdmin: false,
         isPro: true,
@@ -41,29 +56,29 @@ describe('shared ownership queries', () => {
         deletedAt: null,
       },
     ]);
-    const firstWhere = vi.fn(() => ({ limit: firstLimit }));
-    const secondWhere = vi.fn(() => ({ limit: secondLimit }));
-    const firstFrom = vi.fn(() => ({ where: firstWhere }));
-    const secondFrom = vi.fn(() => ({ where: secondWhere }));
-    const select = vi
-      .fn()
-      .mockReturnValueOnce({ from: firstFrom })
-      .mockReturnValueOnce({ from: secondFrom });
 
-    const result = await getUserByIdentity(
-      { select } as unknown as Parameters<typeof getUserByIdentity>[0],
-      'user_123'
-    );
+    const result = await getUserByIdentity(tx, APP_UUID);
 
     const dialect = new PgDialect();
-    expect(result?.id).toBe('user_123');
-    expect(select).toHaveBeenCalledTimes(2);
-    expect(dialect.sqlToQuery(firstWhere.mock.calls[0][0]).sql).toContain(
-      '"users"."clerk_id" ='
-    );
-    expect(dialect.sqlToQuery(secondWhere.mock.calls[0][0]).sql).toContain(
-      '"users"."id" ='
-    );
+    const whereSql = dialect.sqlToQuery(mocks.where.mock.calls[0][0]).sql;
+    expect(result?.id).toBe(APP_UUID);
+    expect(mocks.select).toHaveBeenCalledTimes(1);
+    expect(whereSql).toContain('"users"."clerk_id" =');
+    expect(whereSql).toContain('"users"."better_auth_user_id" =');
+    expect(whereSql).toContain('"users"."id" =');
+  });
+
+  it('omits the uuid clause for non-UUID identities (postgres cast safety)', async () => {
+    const { mocks, tx } = createUserQueryChain([]);
+
+    const result = await getUserByIdentity(tx, 'user_legacy_clerk');
+
+    const dialect = new PgDialect();
+    const whereSql = dialect.sqlToQuery(mocks.where.mock.calls[0][0]).sql;
+    expect(result).toBeNull();
+    expect(whereSql).toContain('"users"."clerk_id" =');
+    expect(whereSql).toContain('"users"."better_auth_user_id" =');
+    expect(whereSql).not.toContain('"users"."id" =');
   });
 
   it('checks canonical and legacy ownership in getAuthenticatedProfile', async () => {
@@ -78,7 +93,7 @@ describe('shared ownership queries', () => {
       },
     ]);
 
-    const result = await getAuthenticatedProfile(tx, 'profile_123', 'user_abc');
+    const result = await getAuthenticatedProfile(tx, 'profile_123', APP_UUID);
 
     const dialect = new PgDialect();
     const selectArgs = mocks.select.mock.calls[0][0];
@@ -90,8 +105,11 @@ describe('shared ownership queries', () => {
 
     expect(result?.id).toBe('profile_123');
     expect(selectArgs.userId).toBe(users.id);
+    // Dual-read identity join: app UUID matches users.id, and migration-era
+    // clerk_id / better_auth_user_id shapes still resolve.
     expect(innerJoinSql).toContain('"users"."id" =');
-    expect(innerJoinSql).not.toContain('"users"."clerk_id"');
+    expect(innerJoinSql).toContain('"users"."clerk_id" =');
+    expect(innerJoinSql).toContain('"users"."better_auth_user_id" =');
     expect(leftJoinSql).toContain('"user_profile_claims"."creator_profile_id"');
     expect(leftJoinSql).toContain('"user_profile_claims"."user_id"');
     expect(whereSql).toContain('"user_profile_claims"."id" is not null');
@@ -102,7 +120,7 @@ describe('shared ownership queries', () => {
   it('checks canonical and legacy ownership in verifyProfileOwnership', async () => {
     const { mocks, tx } = createQueryChain([{ id: 'profile_123' }]);
 
-    const result = await verifyProfileOwnership(tx, 'profile_123', 'user_abc');
+    const result = await verifyProfileOwnership(tx, 'profile_123', APP_UUID);
 
     const dialect = new PgDialect();
     const innerJoinSql = dialect.sqlToQuery(
@@ -113,7 +131,7 @@ describe('shared ownership queries', () => {
 
     expect(result?.id).toBe('profile_123');
     expect(innerJoinSql).toContain('"users"."id" =');
-    expect(innerJoinSql).not.toContain('"users"."clerk_id"');
+    expect(innerJoinSql).toContain('"users"."clerk_id" =');
     expect(leftJoinSql).toContain('"user_profile_claims"."creator_profile_id"');
     expect(whereSql).toContain('"user_profile_claims"."id" is not null');
     expect(whereSql).toContain('"creator_profiles"."user_id" = "users"."id"');


### PR DESCRIPTION
## Summary
Slim P0 split from #13958 (which parks the QA evidence tooling and desktop gates).

- **P0: /app ↔ /signin redirect loop for every Better Auth session** — `getUserByClerkId`/joins matched only legacy `users.clerk_id`, but BA sessions resolve the app `users.id` UUID and new signups carry `ba:<id>` bridges. `OpportunityInboxRoute` then streamed a `redirect()` to `/signin?redirect_url=%2Fapp` whose server saw the session and bounced back — infinite loop, **reproduced live on staging.jov.ie** (60-nav ping-pong, 397 console errors). Also fixes `getUserByIdentity`'s uuid-cast throw on non-UUID misses. Likely root cause of the desktop black-screen P0 (#13939 / JOV-3835) for signed-in users.
- **Permanent 429 sign-in lockout** — `secondary-storage.increment` set TTL only when `count === 1`; a failed first expire left eternal counters (live keys at 14/17, `ttl=-1`, including the `::` bucket for proxied traffic). Now `EXPIRE NX` on every increment (self-healing).
- Local OTP verify died on Upstash RTT racing the hard 500ms op timeout — env-tunable via `AUTH_SECONDARY_STORAGE_TIMEOUT_MS` (deployed default unchanged).

## Evidence (frontier-reviewed screenshots in `artifacts/auth-qa/live-loop-2026-07-10T18-42Z` on the tooling branch)
- web-local signup+login → dashboard → Settings shows signed-in email: PASS after fix (loop reproduced before fix)
- web-staging signup+login via real OTP email: PASS; deployed (pre-fix) dashboard loops — this PR is the fix
- desktop-local: full native PKCE handoff → shell signed in → Settings shows user: PASS
- Regression tests: `apps/web/tests/unit/lib/auth/secondary-storage.test.ts` (4 passing)

## Verification
- `pnpm --filter @jovie/web run typecheck` ✓ (on source branch)
- `pnpm --filter @jovie/web exec vitest run tests/unit/lib/auth/secondary-storage.test.ts` ✓
- Live Playwright drivers: signin → OTP → /app (no loop) → /app/settings/account shows the signed-in email ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)