### PR TITLE
feat: gstack: move auto-upgrade out-of-band (nightly cron) + pin tooling version per run

### DIFF
--- a/.agents/skills/gstack/.agents/skills/gstack-design-canonical/SKILL.md
+++ b/.agents/skills/gstack/.agents/skills/gstack-design-canonical/SKILL.md
@@ -18,8 +18,10 @@ GSTACK_ROOT="$HOME/.codex/skills/gstack"
 GSTACK_BIN="$GSTACK_ROOT/bin"
 GSTACK_BROWSE="$GSTACK_ROOT/browse/dist"
 GSTACK_DESIGN="$GSTACK_ROOT/design/dist"
-_UPD=$($GSTACK_BIN/gstack-update-check 2>/dev/null || .agents/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$GSTACK_BIN")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($GSTACK_BIN/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -90,7 +92,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `$GSTACK_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/.factory/skills/gstack-design-canonical/SKILL.md
+++ b/.agents/skills/gstack/.factory/skills/gstack-design-canonical/SKILL.md
@@ -19,8 +19,10 @@ GSTACK_ROOT="$HOME/.factory/skills/gstack"
 GSTACK_BIN="$GSTACK_ROOT/bin"
 GSTACK_BROWSE="$GSTACK_ROOT/browse/dist"
 GSTACK_DESIGN="$GSTACK_ROOT/design/dist"
-_UPD=$($GSTACK_BIN/gstack-update-check 2>/dev/null || .factory/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$GSTACK_BIN")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($GSTACK_BIN/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -91,7 +93,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `$GSTACK_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/SKILL.md
+++ b/.agents/skills/gstack/SKILL.md
@@ -19,8 +19,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -91,7 +93,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/autoplan/SKILL.md
+++ b/.agents/skills/gstack/autoplan/SKILL.md
@@ -28,8 +28,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -100,7 +102,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/benchmark/SKILL.md
+++ b/.agents/skills/gstack/benchmark/SKILL.md
@@ -21,8 +21,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -93,7 +95,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/bin/gstack-config
+++ b/.agents/skills/gstack/bin/gstack-config
@@ -31,7 +31,8 @@ CONFIG_HEADER='# gstack configuration — edit freely, changes take effect on ne
 #                           #   community — usage data + stable device ID
 #
 # ─── Updates ─────────────────────────────────────────────────────────
-# auto_upgrade: false       # true = silently upgrade on session start
+# auto_upgrade: false       # upgrades run only in the Hermes nightly refresh
+# upgrade_policy: pinned    # every agent run uses its starting version
 # update_check: true        # false = suppress version check notifications
 #
 # ─── Skill naming ────────────────────────────────────────────────────

--- a/.agents/skills/gstack/browse/SKILL.md
+++ b/.agents/skills/gstack/browse/SKILL.md
@@ -21,8 +21,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -93,7 +95,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/canary/SKILL.md
+++ b/.agents/skills/gstack/canary/SKILL.md
@@ -21,8 +21,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -93,7 +95,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/codex/SKILL.md
+++ b/.agents/skills/gstack/codex/SKILL.md
@@ -22,8 +22,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -94,7 +96,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/connect-chrome/SKILL.md
+++ b/.agents/skills/gstack/connect-chrome/SKILL.md
@@ -19,8 +19,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -91,7 +93,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/cso/SKILL.md
+++ b/.agents/skills/gstack/cso/SKILL.md
@@ -25,8 +25,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -97,7 +99,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/design-canonical/SKILL.md
+++ b/.agents/skills/gstack/design-canonical/SKILL.md
@@ -23,8 +23,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -95,7 +97,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/design-consultation/SKILL.md
+++ b/.agents/skills/gstack/design-consultation/SKILL.md
@@ -26,8 +26,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -98,7 +100,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/design-html/SKILL.md
+++ b/.agents/skills/gstack/design-html/SKILL.md
@@ -26,8 +26,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -98,7 +100,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/design-review/SKILL.md
+++ b/.agents/skills/gstack/design-review/SKILL.md
@@ -26,8 +26,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -98,7 +100,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/design-shotgun/SKILL.md
+++ b/.agents/skills/gstack/design-shotgun/SKILL.md
@@ -23,8 +23,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -95,7 +97,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/document-release/SKILL.md
+++ b/.agents/skills/gstack/document-release/SKILL.md
@@ -23,8 +23,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -95,7 +97,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/investigate/SKILL.md
+++ b/.agents/skills/gstack/investigate/SKILL.md
@@ -38,8 +38,10 @@ hooks:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -110,7 +112,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/land-and-deploy/SKILL.md
+++ b/.agents/skills/gstack/land-and-deploy/SKILL.md
@@ -20,8 +20,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -92,7 +94,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/learn/SKILL.md
+++ b/.agents/skills/gstack/learn/SKILL.md
@@ -23,8 +23,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -95,7 +97,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/office-hours/SKILL.md
+++ b/.agents/skills/gstack/office-hours/SKILL.md
@@ -30,8 +30,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -102,7 +104,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/plan-ceo-review/SKILL.md
+++ b/.agents/skills/gstack/plan-ceo-review/SKILL.md
@@ -26,8 +26,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -98,7 +100,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/plan-design-review/SKILL.md
+++ b/.agents/skills/gstack/plan-design-review/SKILL.md
@@ -24,8 +24,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -96,7 +98,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/plan-eng-review/SKILL.md
+++ b/.agents/skills/gstack/plan-eng-review/SKILL.md
@@ -25,8 +25,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -97,7 +99,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/qa-only/SKILL.md
+++ b/.agents/skills/gstack/qa-only/SKILL.md
@@ -21,8 +21,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -93,7 +95,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/qa/SKILL.md
+++ b/.agents/skills/gstack/qa/SKILL.md
@@ -27,8 +27,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -99,7 +101,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/retro/SKILL.md
+++ b/.agents/skills/gstack/retro/SKILL.md
@@ -21,8 +21,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -93,7 +95,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/review/SKILL.md
+++ b/.agents/skills/gstack/review/SKILL.md
@@ -24,8 +24,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -96,7 +98,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/scripts/resolvers/preamble.ts
+++ b/.agents/skills/gstack/scripts/resolvers/preamble.ts
@@ -8,7 +8,7 @@ function isNonInteractiveSkill(ctx: TemplateContext): boolean {
  * Preamble architecture — why every skill needs this
  *
  * Each skill runs independently via `claude -p`. There is no shared loader.
- * The preamble provides: update checks, session tracking, user preferences,
+ * The preamble provides: pinned-version reporting, session tracking, user preferences,
  * repo mode detection, and telemetry.
  *
  * Telemetry data flow:
@@ -33,8 +33,10 @@ GSTACK_DESIGN="$GSTACK_ROOT/design/dist"
   return `## Preamble (run first)
 
 \`\`\`bash
-${runtimeRoot}_UPD=$(${binDir}/gstack-update-check 2>/dev/null || ${ctx.paths.localSkillRoot}/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+${runtimeRoot}_GSTACK_VERSION=$(cat "$(dirname "${binDir}")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$(${binDir}/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: \${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -107,7 +109,9 @@ or invoking other gstack skills, use the \`/gstack-\` prefix (e.g., \`/gstack-qa
 of \`/qa\`, \`/gstack-ship\` instead of \`/ship\`). Disk paths are unaffected — always use
 \`${ctx.paths.skillRoot}/[skill-name]/SKILL.md\` for reading skill files.
 
-If output shows \`UPGRADE_AVAILABLE <old> <new>\`: read \`${ctx.paths.skillRoot}/gstack-upgrade/SKILL.md\` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If \`JUST_UPGRADED <from> <to>\`: tell user "Running gstack v{to} (just updated!)" and continue.`;
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded \`GSTACK_VERSION\`.`;
 }
 
 function generateLakeIntro(): string {

--- a/.agents/skills/gstack/setup-browser-cookies/SKILL.md
+++ b/.agents/skills/gstack/setup-browser-cookies/SKILL.md
@@ -18,8 +18,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -90,7 +92,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/setup-deploy/SKILL.md
+++ b/.agents/skills/gstack/setup-deploy/SKILL.md
@@ -24,8 +24,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -96,7 +98,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.agents/skills/gstack/ship/SKILL.md
+++ b/.agents/skills/gstack/ship/SKILL.md
@@ -25,8 +25,10 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$($HOME/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat "$(dirname "$HOME/.claude/skills/gstack/bin")/VERSION" 2>/dev/null || echo "unknown")
+_GSTACK_POLICY=$($HOME/.claude/skills/gstack/bin/gstack-config get upgrade_policy 2>/dev/null || echo "pinned")
+echo "GSTACK_VERSION: $_GSTACK_VERSION"
+echo "GSTACK_POLICY: ${_GSTACK_POLICY:-pinned}"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -97,7 +99,9 @@ or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` i
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
 `~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+gstack is pinned for the full run. Do not run an update check or upgrade gstack
+from this skill; the Hermes nightly refresh owns upgrades. Continue with the
+recorded `GSTACK_VERSION`.
 
 If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
 Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete

--- a/.claude/skills/autoplan/SKILL.md
+++ b/.claude/skills/autoplan/SKILL.md
@@ -43,7 +43,7 @@ to the legacy multi-step preamble in the upstream skill:
 
 1. worktree go/no-go  
 2. ownership (gbrain)  
-3. gstack version/policy **read only** (never auto-upgrade on blocked runs)  
+3. pinned gstack version/policy **read only** (never update or upgrade in a run)  
 4. goal state  
 
 ## 1. Full autoplan reviews
@@ -55,8 +55,8 @@ taste gate, and restore artifacts.
 Skip any preamble steps already covered by the receipt:
 
 - Worktree cleanliness / branch name → `receipt.worktree`
-- gstack update-check / version → `receipt.gstack` (still allow intentional
-  upgrade later only if `verdict == "go"` and the user/policy requires it)
+- gstack version/policy → `receipt.gstack` (the nightly Hermes refresh is the
+  only upgrade path)
 - GBrain ownership / org-chart probe → `receipt.ownership`
 - Active goal → `receipt.goal`
 

--- a/.claude/skills/setup-gbrain/SKILL.md
+++ b/.claude/skills/setup-gbrain/SKILL.md
@@ -29,8 +29,8 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat ~/.claude/skills/gstack/VERSION 2>/dev/null || echo "unknown")
+echo "GSTACK_VERSION: $_GSTACK_VERSION (pinned)"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -118,9 +118,8 @@ If `PROACTIVE` is `"false"`, do not auto-invoke or proactively suggest skills. I
 
 If `SKILL_PREFIX` is `"true"`, suggest/invoke `/gstack-*` names. Disk paths stay `~/.claude/skills/gstack/[skill-name]/SKILL.md`.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
-
-If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
+gstack is pinned for this run. Do not check for or install updates here; the
+Hermes nightly refresh owns upgrades.
 
 Feature discovery, max one prompt per session:
 - Missing `~/.claude/skills/gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `~/.claude/skills/gstack/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.

--- a/.claude/skills/sync-gbrain/SKILL.md
+++ b/.claude/skills/sync-gbrain/SKILL.md
@@ -29,8 +29,8 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
-_UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
-[ -n "$_UPD" ] && echo "$_UPD" || true
+_GSTACK_VERSION=$(cat ~/.claude/skills/gstack/VERSION 2>/dev/null || echo "unknown")
+echo "GSTACK_VERSION: $_GSTACK_VERSION (pinned)"
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"
 _SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -118,9 +118,8 @@ If `PROACTIVE` is `"false"`, do not auto-invoke or proactively suggest skills. I
 
 If `SKILL_PREFIX` is `"true"`, suggest/invoke `/gstack-*` names. Disk paths stay `~/.claude/skills/gstack/[skill-name]/SKILL.md`.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
-
-If output shows `JUST_UPGRADED <from> <to>`: print "Running gstack v{to} (just updated!)". If `SPAWNED_SESSION` is true, skip feature discovery.
+gstack is pinned for this run. Do not check for or install updates here; the
+Hermes nightly refresh owns upgrades.
 
 Feature discovery, max one prompt per session:
 - Missing `~/.claude/skills/gstack/.feature-prompted-continuous-checkpoint`: AskUserQuestion for Continuous checkpoint auto-commits. If accepted, run `~/.claude/skills/gstack/bin/gstack-config set checkpoint_mode continuous`. Always touch marker.

--- a/docs/CRON_REGISTRY.md
+++ b/docs/CRON_REGISTRY.md
@@ -33,6 +33,7 @@ These are machine-local Hermes jobs, not Vercel production crons. They run from 
 |------|----------|---------|--------|
 | `co.jovie.hermes.cron-pipeline-scoreboard` | every 60 min | Computes the daily codex shipping funnel, writes `pipeline-scoreboard-latest.json` + gbrain `ops/pipeline-scoreboard/latest`, and alerts on 12h shipper stalls. | `scripts/hermes/jobs/pipeline-scoreboard.ts` |
 | `co.jovie.hermes.cron-gbrain-health-summary` | 07:15 local daily | Runs bounded gbrain doctor/search probes, writes `ops/gbrain-health/latest`, and posts the summary to Telegram/Slack through existing ops notification helpers. | `scripts/hermes/jobs/gbrain-health-summary.ts` |
+| `co.jovie.hermes.cron-gstack-nightly-refresh` | 03:30 local daily | Refreshes gstack outside agent runs using backup/restore; failures go through the existing #product ops alert webhook. | `scripts/hermes/jobs/gstack-nightly-refresh.ts` |
 
 ## Production Schedule
 

--- a/scripts/agent/PREFLIGHT.md
+++ b/scripts/agent/PREFLIGHT.md
@@ -13,10 +13,11 @@ emits one JSON receipt; the skill makes **one** Bash call and branches on
 
 1. **worktree** — dirty/not-a-repo hard-blocks before tooling
 2. **ownership** — gbrain coordination probe (optional hard-block via env)
-3. **gstack** — version/policy **read only** (never auto-upgrade here)
+3. **gstack** — pinned version/policy **read only** (never checks or upgrades here)
 4. **goal** — active goal marker if present
 
-A blocked ownership/worktree run never pays the gstack upgrade tax.
+A job always consumes the recorded gstack version. The Hermes nightly refresh
+is the only path that checks for or installs a newer version.
 
 ## Implementation
 
@@ -62,7 +63,7 @@ Exit `0` = `verdict: go`. Exit `1` = `verdict: blocked`. Exit `2` = script error
     "installed": true,
     "version": "…",
     "latest": null,
-    "policy": "unknown",
+    "policy": "pinned",
     "path": "…/gstack/bin",
     "ms": 40
   },

--- a/scripts/agent/preflight.mjs
+++ b/scripts/agent/preflight.mjs
@@ -207,24 +207,13 @@ function collectGstack(repoRoot) {
     }
   }
 
-  let latest = null;
-  const check = join(binPath, 'gstack-update-check');
-  if (existsSync(check)) {
-    const upd = run(check, [], { timeout: 5000 });
-    const line = (upd.stdout || '').trim();
-    if (
-      line.startsWith('UPGRADE_AVAILABLE') ||
-      line.startsWith('JUST_UPGRADED')
-    ) {
-      latest = line.split(/\s+/)[2] || null;
-    }
-  }
-
   return evaluateGstack({
     binPath,
     version,
-    latest,
-    policy,
+    // A job must use the version it started with. Network update checks (and
+    // their cache/marker writes) belong to the nightly refresh job, never
+    // preflight.
+    policy: policy || 'pinned',
     requireGstack,
     ms: nowMs() - start,
   });

--- a/scripts/agent/preflight.test.mjs
+++ b/scripts/agent/preflight.test.mjs
@@ -141,6 +141,17 @@ test('evaluateGstack: installed carries version fields', () => {
   assert.deepEqual(r.blockers, []);
 });
 
+test('evaluateGstack: callers can record the pinned policy', () => {
+  const r = evaluateGstack({
+    binPath: '/x/bin',
+    version: '1.2.3',
+    policy: 'pinned',
+  });
+  assert.equal(r.gstack.version, '1.2.3');
+  assert.equal(r.gstack.policy, 'pinned');
+  assert.equal(r.gstack.latest, null);
+});
+
 test('evaluateGoal: inactive when no path', () => {
   const r = evaluateGoal({ goalPath: null });
   assert.equal(r.goal.active, false);

--- a/scripts/hermes/jobs/gstack-nightly-refresh.ts
+++ b/scripts/hermes/jobs/gstack-nightly-refresh.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env tsx
+/**
+ * gstack Nightly Refresh — Hermes/MBP
+ *
+ * Keeps agent runs reproducible: jobs only read their pinned local version;
+ * this out-of-band job is the sole automatic upgrade path. A replacement is
+ * staged beside the current install and restored from backup if setup fails.
+ */
+
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { sendOpsAlert } from '../lib/ops-notify';
+
+const JOB = 'gstack-nightly-refresh';
+const GSTACK_REPOSITORY = 'https://github.com/garrytan/gstack.git';
+
+export type RefreshResult =
+  | { readonly status: 'up-to-date'; readonly version: string }
+  | {
+      readonly status: 'upgraded';
+      readonly from: string;
+      readonly to: string;
+    };
+
+function gstackDirectory(): string | null {
+  const configured = process.env.GSTACK_UPGRADE_DIR?.trim();
+  const candidates = [
+    configured,
+    join(homedir(), '.gstack', 'repos', 'gstack'),
+    join(homedir(), '.claude', 'skills', 'gstack'),
+  ].filter((path): path is string => Boolean(path));
+
+  return candidates.find(path => existsSync(join(path, 'bin', 'gstack-config'))) ?? null;
+}
+
+function versionAt(dir: string): string {
+  try {
+    return readFileSync(join(dir, 'VERSION'), 'utf8').trim() || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function command(dir: string, file: string, args: readonly string[]): string {
+  return execFileSync(file, [...args], {
+    cwd: dir,
+    encoding: 'utf8',
+    timeout: 120_000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+}
+
+export function latestFromCheck(output: string): string | null {
+  const match = output.match(/^UPGRADE_AVAILABLE\s+\S+\s+(\S+)$/m);
+  return match?.[1] ?? null;
+}
+
+/** Upgrade the configured gstack install, retaining its pre-upgrade backup. */
+export function refreshGstack(options?: {
+  readonly dir?: string;
+  readonly run?: typeof command;
+}): RefreshResult {
+  const dir = options?.dir ?? gstackDirectory();
+  if (!dir) throw new Error('gstack install not found; set GSTACK_UPGRADE_DIR');
+  const run = options?.run ?? command;
+  const config = join(dir, 'bin', 'gstack-config');
+
+  // Persist the policy before checking: agent jobs cannot opt back into an
+  // inline upgrade between this refresh and their next preflight receipt.
+  run(dir, config, ['set', 'auto_upgrade', 'false']);
+  run(dir, config, ['set', 'upgrade_policy', 'pinned']);
+
+  const current = versionAt(dir);
+  const latest = latestFromCheck(
+    run(dir, join(dir, 'bin', 'gstack-update-check'), ['--force'])
+  );
+  if (!latest || latest === current) return { status: 'up-to-date', version: current };
+
+  const staging = mkdtempSync(join(tmpdir(), 'jovie-gstack-refresh-'));
+  const replacement = join(staging, 'gstack');
+  const backup = `${dir}.bak`;
+  try {
+    run(dir, 'git', ['clone', '--depth', '1', GSTACK_REPOSITORY, replacement]);
+    if (existsSync(backup)) rmSync(backup, { recursive: true, force: true });
+    renameSync(dir, backup);
+    try {
+      renameSync(replacement, dir);
+      run(dir, join(dir, 'setup'), []);
+    } catch (error) {
+      rmSync(dir, { recursive: true, force: true });
+      renameSync(backup, dir);
+      throw error;
+    }
+    rmSync(backup, { recursive: true, force: true });
+    return { status: 'upgraded', from: current, to: versionAt(dir) };
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    try {
+      const result = refreshGstack();
+      logJobEvent({ job: JOB, event: result.status, ...result });
+      process.stdout.write(`gstack refresh: ${JSON.stringify(result)}\n`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logJobEvent({ job: JOB, event: 'failed', error: message });
+      // SLACK_WEBHOOK_URL/HERMES_SLACK_WEBHOOK_URL is the existing #product
+      // incoming webhook for Hermes alerts.
+      await sendOpsAlert(`gstack nightly refresh failed\n\n${message}`);
+      throw error;
+    }
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().catch(error => {
+    console.error(`[${JOB}] fatal:`, error);
+    process.exit(1);
+  });
+}

--- a/scripts/hermes/launchd/README.md
+++ b/scripts/hermes/launchd/README.md
@@ -26,6 +26,7 @@ The Hermes gateway itself is managed by the installed Hermes CLI as `ai.hermes.g
 | `co.jovie.hermes.cron-daily-briefing.plist.template` | 07:00 daily | Morning briefing to Telegram |
 | `co.jovie.hermes.cron-deterministic-tracker.plist.template` | 03:00 daily | Self-improvement clustering |
 | `co.jovie.hermes.cron-free-model-health.plist.template` | 02:00 daily | Free-model rankings refresh |
+| `co.jovie.hermes.cron-gstack-nightly-refresh.plist.template` | 03:30 daily | Refresh gstack out of band; restore the prior install and alert #product on failure |
 
 ## Houston (MacBook Pro) units
 

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-gstack-nightly-refresh.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-gstack-nightly-refresh.plist.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-gstack-nightly-refresh</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/gstack-nightly-refresh.ts</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.bun/bin:{{HOME}}/.hermes/bin:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-gstack-nightly-refresh.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-gstack-nightly-refresh.err.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
Autonomous ship by **Gem** (OpenClaw + Codex CLI gpt-5.6-terra) for pre-scoped issue.

Closes #13915

## Implementation
- Scope was authored by frontier planning agents (Fable 5 / fleet)
- Gem + Codex CLI implemented the changes
- Draft until CI is green

## Verification
- [ ] CI passes
- [ ] Changes match issue scope