### PR TITLE
docs: define one-codebase two-shell architecture

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -39,6 +39,14 @@ These registries are the **single source of truth** consumed by the CSP builder,
 
 ## Entitlements: Single Source of Truth
 
+### Private capability boundary
+
+Personal finance is a shared module, not a separate shell implementation.
+Keep raw Gmail/Amazon receipts local and encrypted; only normalized facts may
+cross into gbrain. Gate the module through the canonical entitlement chain and
+keep it out of consumer/public surfaces by default. Do not add account
+connections or money movement without a separate architecture decision.
+
 Entitlements behavior must stay centralized and predictable. Use these files as the canonical chain:
 
 1. `apps/web/lib/entitlements/registry.ts` — plan matrix (features, limits, marketing metadata)

--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -4,6 +4,15 @@ Design system, component hierarchy, surfaces, taste rules. Always read `DESIGN.m
 
 ## Component Architecture
 
+### Shared implementation, configured shells
+
+Jovie and Ovie use the same UI implementation. Jovie is the
+external/consumer shell; Ovie is the internal/personal/ops shell. Select
+shell, route, entitlement, and presentation mode through configuration. Do
+not fork components, create Ovie-only copies of shared UI, or define separate
+metric widgets for the same underlying metric. `/app/admin/ops` is canonical
+Ops; HUD/Ovie/TV are presentation modes.
+
 Components follow atomic design with feature-based grouping:
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,16 @@
 # Jovie — Agent Operating Manual
 
-Controller map for AI agents. `AGENTS.md` symlinks here. Read the scoped rule for your topic before editing. Detail lives in `.claude/rules/*` and `docs/`.
+Controller map for AI agents. `AGENTS.md` symlinks here. Read scoped rules before editing. Detail lives in `.claude/rules/*` and `docs/`.
 
 ## Operating Principles
 
+- **One codebase, two shells:** Jovie is external/consumer; Ovie is internal/personal/ops. Shared packages, components, contracts, clients, auth, ledger models, interaction patterns, and metrics are canonical; use shell/route/entitlement/presentation configuration, never forks or duplicate metrics. `/app/admin/ops` is canonical Ops; HUD/Ovie/TV are presentation modes.
 - Smallest correct change; inspect existing patterns first.
 - Server-side code, typed contracts, existing package boundaries.
 - Don't invent commands, env vars, routes, tables, services, or tokens.
 - Report exact check failures — don't hide them.
 - Ask before destructive ops (data deletion, irreversible migrations without CI guard, credential changes, prod scripts). Auth/payment edits do **not** need human merge approval — CI + Migration Guard own that.
 - **Decisions are systems, not events** when quantifiable: **Ship now / Re-evaluate when / Then** with unit-economics triggers; tag `EVENT:` for taste/identity/security permanence. No "later"/"future work" without a Linear ID → [`.claude/rules/code-style.md`](.claude/rules/code-style.md).
-
 Canon principles: [`docs/company/operating-principles.md`](docs/company/operating-principles.md) (supersede [`docs/company/core-values.md`](docs/company/core-values.md)).
 
 ## Agent Role Boundary

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -31,6 +31,23 @@ This replaces traditional ship cycles. The loop runs faster and more autonomousl
 
 ## Repository Structure
 
+### One Codebase, Two Shells
+
+Jovie and Ovie are two configured shells over the same implementation, not
+forked applications. Jovie is the external/consumer shell. Ovie is the
+internal/personal/ops shell. Shared packages, components, design-system
+primitives, data contracts, API clients, auth primitives, ledger models,
+interaction patterns, and metrics are canonical.
+
+Shell, route, entitlement, and presentation configuration may differ; UI
+components, business contracts, and metric definitions must not be duplicated.
+`/app/admin/ops` is the canonical Ops surface. HUD, Ovie, and TV are
+presentation modes over that shared surface.
+
+Personal finance is a shared module with a private capability boundary: raw
+Gmail/Amazon receipts remain local and encrypted, normalized facts may be
+stored in gbrain, and no account connections or money movement are enabled.
+
 ### Key Directories
 - `apps/web/`: Next.js web application (HUD, marketing, admin)
 - `apps/desktop/`: Electron desktop app

--- a/docs/AGENT_OS_ARCHITECTURE.md
+++ b/docs/AGENT_OS_ARCHITECTURE.md
@@ -6,6 +6,25 @@
 
 ## Decision
 
+### One Codebase, Two Shells
+
+Jovie and Ovie are shells over one shared codebase. Jovie is the
+external/consumer shell; Ovie is the internal/personal/ops shell. Shared
+packages and components are canonical, including the design system, data
+contracts, API clients, auth primitives, ledger models, interaction patterns,
+and metric definitions.
+
+Agents must express differences through shell, route, entitlement, and
+presentation configuration. Do not fork UI, create duplicate components or
+metrics, or introduce a second implementation of a shared contract. The
+`/app/admin/ops` route remains canonical Ops; Ovie/HUD/TV are presentation
+modes, not separate products.
+
+Personal finance follows the same shared-module rule with a strict private
+capability boundary: raw Gmail/Amazon receipts remain local and encrypted,
+only normalized facts may be sent to gbrain, and the module is private and
+entitlement-gated. Do not add account connections or money movement yet.
+
 Jovie AgentOS v1 uses Vercel Workflow/WDK as the first durable coordinator, not Trigger.dev. Trigger stays the fallback if WDK cannot satisfy local durability, retries, queues, or operator visibility after the dry-run proof.
 
 The control plane is intentionally Jovie-owned:

--- a/docs/OVIE.md
+++ b/docs/OVIE.md
@@ -11,6 +11,10 @@ mode. Do not create Ovie-specific copies of Jovie UI, data contracts, or
 metrics. `/app/admin/ops` remains the canonical Ops surface; Ovie, HUD, and TV
 are presentation modes over the shared implementation.
 
+Before pushing documentation changes, run the local brand-scrub and slopcheck
+guardrails on the changed files; keep these checks passing without weakening
+the scanners.
+
 ## Personal finance boundary
 
 The personal finance module belongs in shared code so its contracts and UI can

--- a/docs/OVIE.md
+++ b/docs/OVIE.md
@@ -1,7 +1,26 @@
 # Ovie
 
-**Ovie is the Jovie web app's `/hud` route.** The canonical Ovie surface is
-`apps/web/app/hud/` (admin Ops HUD), served by the production web app.
+Ovie and Jovie are one codebase with two shells, not two products with forked
+implementations. Jovie is the external/consumer shell; Ovie is the
+internal/personal/ops shell. Shared packages, components, design system,
+contracts, API clients, auth primitives, ledger models, interaction patterns,
+and metrics are canonical and must be reused by both shells.
+
+The difference is configuration: shell, route, entitlement, and presentation
+mode. Do not create Ovie-specific copies of Jovie UI, data contracts, or
+metrics. `/app/admin/ops` remains the canonical Ops surface; Ovie, HUD, and TV
+are presentation modes over the shared implementation.
+
+## Personal finance boundary
+
+The personal finance module belongs in shared code so its contracts and UI can
+be reused by either shell, but it has a strict private capability boundary:
+
+- Raw Gmail and Amazon receipts stay local and encrypted.
+- Only normalized facts may enter gbrain.
+- Access is private/entitlement-gated; never expose personal finance data to
+  the consumer shell or public APIs by default.
+- No account connections or money movement are part of this architecture yet.
 
 ## History
 
@@ -20,7 +39,9 @@ Swift app should be labeled "archived".
 
 | Concern | Location |
 |---|---|
-| Ovie UI | `apps/web/app/hud/` in this repo |
+| Shared UI and contracts | `packages/` and `apps/web/components/` in this repo |
+| Ovie/HUD presentation | `apps/web/app/hud/` in this repo |
+| Canonical private Ops | `/app/admin/ops` |
 | Shipper loop the old app monitored | `scripts/hermes/` in this repo |
 | Ship-ledger contract | `scripts/hermes/lib/ship-ledger.ts` |
 | Archived Swift launcher | `JovieInc/ovie` (read-only) |

--- a/docs/ovie-design-guardrails.md
+++ b/docs/ovie-design-guardrails.md
@@ -1,6 +1,11 @@
 # Ovie Design Guardrails
 
-Ovie is Jovie's local macOS ops cockpit. Treat Ovie UI work as product/admin UI, not marketing or landing-page work: dense but calm, fast, native-feeling, and stripped of AI-slop decoration.
+Ovie is Jovie's internal/personal/ops shell in the shared web codebase, not a
+separate UI implementation. Treat Ovie UI work as product/admin UI, not
+marketing or landing-page work: dense but calm, fast, and stripped of AI-slop
+decoration. Reuse shared components and metrics; vary only shell, route,
+entitlement, and presentation configuration. `/app/admin/ops` remains the
+canonical Ops surface, with HUD/Ovie/TV as presentation modes.
 
 ## Required Routing
 
@@ -9,7 +14,8 @@ Any Ovie UI or UX task must run through the existing make-interfaces-better guar
 - Load gstack `/design-review` before marking visual work complete.
 - Load `design-taste-frontend` where available and run its audit checklist.
 - Read `DESIGN.md` and this file before changing Ovie UI.
-- Preserve Ovie's local dirty state first. If `~/JovieInc/ovie` has uncommitted changes, inspect them and avoid overwriting unrelated work.
+- Preserve unrelated local work first. The archived `JovieInc/ovie` Swift
+  repository is not the current Ovie surface.
 
 ## Design Read
 


### PR DESCRIPTION
## Summary
- Encode Jovie/Ovie as one shared codebase with external/consumer and internal/personal/ops shells.
- Make shared packages, components, contracts, auth primitives, ledger models, interaction patterns, and metrics canonical; differences belong to configuration.
- Clarify `/app/admin/ops` as canonical Ops and HUD/Ovie/TV as presentation modes.
- Document the private personal-finance boundary: local encrypted raw receipts, normalized facts only in gbrain, and no account connections or money movement.
- Align agent, UI, security, and Ovie design guidance; remove the stale current-surface implication that Ovie is a separate macOS app.

## Checks
- `pnpm doc:freshness:check`
- `pnpm run doc:freshness:test`
- `pnpm format:check`
- Relative-link check across changed Markdown files
- `git diff --check`

Documentation-only. No implementation or finance integrations added.

Do not merge this PR as part of this task.
