### PR TITLE
fix(ci): strip pytest from merge-queue enroll hot path

### DIFF
--- a/.github/workflows/merge-queue-autoenroll.yml
+++ b/.github/workflows/merge-queue-autoenroll.yml
@@ -15,8 +15,12 @@ name: Merge Queue Auto-Enroll
 #
 # Two jobs run (not at the same time — concurrency group serializes):
 #   enroll    — classify open PRs, enroll green ones, dequeue broken ones,
-#               flag conflicts for the fix agent
+#               flag conflicts for the fix agent (no pytest/Python setup;
+#               drain regression tests run in CI Structural Contract instead)
 #   rebase    — mechanically rebase blocked agent PRs onto latest main
+#
+# GH-13630 scope boundary: pr-conflict-handler debounce + lighter model are
+# follow-ups — handler lacks a durable "recently resolved" marker contract.
 #
 # No schedule. No watchdog label-cycling. No polling.
 

--- a/scripts/ci-merge-queue-check.mjs
+++ b/scripts/ci-merge-queue-check.mjs
@@ -6,6 +6,7 @@ import {
   GRAPHITE_QUEUE_POLICY,
   MERGE_QUEUE_REPO_PATHS,
   validateLiveMergeQueueRuleset,
+  validateMergeQueueEnrollHotPath,
   validateMergeQueueRepoConfig,
 } from './lib/merge-queue-guard.mjs';
 
@@ -52,10 +53,14 @@ function runValidate({ checkLive = false } = {}) {
     MERGE_QUEUE_REPO_PATHS.branchProtection
   );
   const ciWorkflowYaml = readRepoFile(MERGE_QUEUE_REPO_PATHS.ciWorkflow);
+  const autoenrollWorkflowYaml = readRepoFile(
+    MERGE_QUEUE_REPO_PATHS.autoenrollWorkflow
+  );
   const repoValidation = validateMergeQueueRepoConfig({
     branchProtectionYaml,
     ciWorkflowYaml,
   });
+  const enrollHotPath = validateMergeQueueEnrollHotPath(autoenrollWorkflowYaml);
 
   if (repoValidation.warnings.length > 0) {
     console.warn('Merge queue repo-config warnings:');
@@ -64,10 +69,18 @@ function runValidate({ checkLive = false } = {}) {
     }
   }
 
-  if (!repoValidation.ok) {
-    console.error('Merge queue repo-config validation failed:');
-    for (const error of repoValidation.errors) {
-      console.error(`- ${error}`);
+  if (!repoValidation.ok || !enrollHotPath.ok) {
+    if (!repoValidation.ok) {
+      console.error('Merge queue repo-config validation failed:');
+      for (const error of repoValidation.errors) {
+        console.error(`- ${error}`);
+      }
+    }
+    if (!enrollHotPath.ok) {
+      console.error('Merge queue enroll hot-path validation failed:');
+      for (const error of enrollHotPath.errors) {
+        console.error(`- ${error}`);
+      }
     }
     process.exitCode = 1;
     return;
@@ -76,6 +89,7 @@ function runValidate({ checkLive = false } = {}) {
   console.log(
     `Repo config OK — required aggregates: ${repoValidation.contexts.join(', ')}`
   );
+  console.log('Enroll hot path OK — no test-only dependency bootstrap');
 
   if (!checkLive) {
     return;

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -6,8 +6,10 @@ import {
   compareRatchetCounts,
   detectChangedFileOverlap,
   detectIssueOverlap,
+  extractWorkflowJobBlock,
   fastTrackPolicy,
   isAutonomousBranch,
+  MERGE_QUEUE_ENROLL_HOT_PATH_FORBIDDEN,
   MERGE_QUEUE_REPO_PATHS,
   parseMergeQueueTimeline,
   parseRequiredStatusChecksFromYaml,
@@ -16,6 +18,7 @@ import {
   uiFastTrackPolicy,
   validateAggregateRequiredChecks,
   validateLiveMergeQueueRuleset,
+  validateMergeQueueEnrollHotPath,
   validateMergeQueueRepoConfig,
 } from '../merge-queue-guard.mjs';
 
@@ -379,6 +382,23 @@ describe('aggregate required checks', () => {
       'Fork PR Gate',
       'PR Size Guard',
     ]);
+  });
+
+  it('keeps merge-queue enroll hot path free of pytest/Python bootstrap (GH-13630)', () => {
+    const autoenrollYaml = readFileSync(
+      resolve(REPO_ROOT, MERGE_QUEUE_REPO_PATHS.autoenrollWorkflow),
+      'utf8'
+    );
+    const enrollBlock = extractWorkflowJobBlock(autoenrollYaml, 'enroll');
+
+    expect(enrollBlock).toMatch(/drain-pr-queue\.sh/);
+    for (const rule of MERGE_QUEUE_ENROLL_HOT_PATH_FORBIDDEN) {
+      expect(rule.pattern.test(enrollBlock), rule.id).toBe(false);
+    }
+
+    const result = validateMergeQueueEnrollHotPath(autoenrollYaml);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
   });
 
   it('validates the live ruleset shape used by Graphite merge queue', () => {

--- a/scripts/lib/merge-queue-guard.mjs
+++ b/scripts/lib/merge-queue-guard.mjs
@@ -859,10 +859,83 @@ export function bisectBatchFailure(batch, batchPasses) {
   };
 }
 
+export const MERGE_QUEUE_AUTOENROLL_WORKFLOW_PATH =
+  '.github/workflows/merge-queue-autoenroll.yml';
+
+/** Test-only patterns forbidden on the merge-queue enroll hot path (GH-13630). */
+export const MERGE_QUEUE_ENROLL_HOT_PATH_FORBIDDEN = Object.freeze([
+  { id: 'setup-python', pattern: /uses:\s*actions\/setup-python@/i },
+  { id: 'pip-install-pytest', pattern: /pip install pytest/i },
+  { id: 'pytest-run', pattern: /\bpytest\s+scripts\//i },
+]);
+
 export const MERGE_QUEUE_REPO_PATHS = Object.freeze({
   branchProtection: BRANCH_PROTECTION_RULESET_PATH,
   ciWorkflow: CI_WORKFLOW_PATH,
+  autoenrollWorkflow: MERGE_QUEUE_AUTOENROLL_WORKFLOW_PATH,
 });
+
+/**
+ * Extract a `jobs.<name>` block from a workflow YAML file (indent-based).
+ *
+ * @param {string} workflowYaml
+ * @param {string} jobName
+ */
+export function extractWorkflowJobBlock(workflowYaml = '', jobName = '') {
+  const lines = workflowYaml.split('\n');
+  const jobHeader = `  ${jobName}:`;
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i] === jobHeader) {
+      start = i;
+      break;
+    }
+  }
+  if (start < 0) {
+    return '';
+  }
+
+  const block = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^  \S/.test(line) && !line.startsWith('    ')) {
+      break;
+    }
+    block.push(line);
+  }
+  return block.join('\n');
+}
+
+/**
+ * Enroll hot path must stay lean: no pytest/Python bootstrap before drain.
+ * Drain regression coverage lives in CI Structural Contract (ci-fast lanes).
+ *
+ * @param {string} workflowYaml
+ */
+export function validateMergeQueueEnrollHotPath(workflowYaml = '') {
+  const errors = [];
+  const enrollBlock = extractWorkflowJobBlock(workflowYaml, 'enroll');
+  if (!enrollBlock) {
+    errors.push(
+      `${MERGE_QUEUE_AUTOENROLL_WORKFLOW_PATH} is missing enroll job`
+    );
+    return { ok: false, errors };
+  }
+
+  for (const rule of MERGE_QUEUE_ENROLL_HOT_PATH_FORBIDDEN) {
+    if (rule.pattern.test(enrollBlock)) {
+      errors.push(
+        `enroll hot path must not include ${rule.id} (test-only; run in Structural Contract instead)`
+      );
+    }
+  }
+
+  if (!/drain-pr-queue\.sh/.test(enrollBlock)) {
+    errors.push('enroll hot path must invoke scripts/drain-pr-queue.sh');
+  }
+
+  return { ok: errors.length === 0, errors };
+}
 
 export function requiredStatusDecision(statuses) {
   const byName = new Map();


### PR DESCRIPTION
## Summary
- remove pytest/test-only dependency bootstrap from the merge-queue enrollment hot path (already absent on main; document boundary)
- add a deterministic guard (`validateMergeQueueEnrollHotPath`) and regression test so enrollment cannot reintroduce test-only installs
- leave full test lanes unchanged
- defer conflict-handler debounce because the current handler has no durable recently-resolved marker; no speculative behavior change

Closes #13630

Supersedes #13969 (stuck `refs/pull/*/head` after corrupted tip with accidental mass deletions).

## KPI
- Primary: reduce issue-open → PR-open time for CI maintenance and reduce PR-open → landed time by removing an unnecessary pytest bootstrap from the enroll hot path

## Test plan
- [x] `node scripts/ci-merge-queue-check.mjs validate`
- [x] `vitest run scripts/lib/__tests__/merge-queue-guard.test.mjs` (30 passed)
- [ ] CI Structural Contract / merge-queue guard lanes green

## Bug-to-Test
- Regression covered by `keeps merge-queue enroll hot path free of pytest/Python bootstrap (GH-13630)` in `scripts/lib/__tests__/merge-queue-guard.test.mjs`