### PR TITLE
fix(dev): fully activate session user via /api/dev/unwaitlist

### DIFF
--- a/apps/web/app/api/dev/unwaitlist/route.ts
+++ b/apps/web/app/api/dev/unwaitlist/route.ts
@@ -1,74 +1,54 @@
 import { NextResponse } from 'next/server';
-import { getWaitlistAccess } from '@/lib/auth/gate';
-import { invalidateProxyUserStateCache } from '@/lib/auth/proxy-state';
+import { devUnwaitlistSessionUser } from '@/lib/dev/dev-unwaitlist.server';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
-import { withSystemIngestionSession } from '@/lib/ingestion/session';
 import {
   developmentOnlyForbiddenJson,
   isExplicitDevelopmentEnvironment,
+  isVercelProductionDeployment,
 } from '@/lib/security/development-only';
-import {
-  approveWaitlistEntryInTx,
-  finalizeWaitlistApproval,
-} from '@/lib/waitlist/approval';
 
 export const runtime = 'nodejs';
 
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
 
 export async function POST() {
-  if (!isExplicitDevelopmentEnvironment()) {
+  if (isVercelProductionDeployment() || !isExplicitDevelopmentEnvironment()) {
     return developmentOnlyForbiddenJson(undefined, {
       headers: NO_STORE_HEADERS,
     });
   }
 
   const entitlements = await getCurrentUserEntitlements();
-  if (!entitlements.isAuthenticated || !entitlements.email) {
+  if (
+    !entitlements.isAuthenticated ||
+    !entitlements.email ||
+    !entitlements.userId
+  ) {
     return NextResponse.json(
       { success: false, error: 'Not authenticated' },
       { status: 401, headers: NO_STORE_HEADERS }
     );
   }
 
-  const waitlistAccess = await getWaitlistAccess(entitlements.email);
-  if (!waitlistAccess.entryId) {
+  const result = await devUnwaitlistSessionUser({
+    userId: entitlements.userId,
+    email: entitlements.email,
+    clerkId: null,
+  });
+
+  if (!result.ok) {
     return NextResponse.json(
-      { success: false, error: 'No waitlist entry found for this email' },
-      { status: 404, headers: NO_STORE_HEADERS }
+      { success: false, error: result.error },
+      { status: result.status, headers: NO_STORE_HEADERS }
     );
   }
-
-  const result = await withSystemIngestionSession(
-    async tx => approveWaitlistEntryInTx(tx, waitlistAccess.entryId!),
-    { isolationLevel: 'serializable' }
-  );
-
-  if (result.outcome === 'already_processed') {
-    // Still invalidate cache — previous approval may have cached stale state
-    if (entitlements.userId) {
-      await invalidateProxyUserStateCache(entitlements.userId);
-    }
-    return NextResponse.json(
-      { success: true, message: 'Already approved', status: result.status },
-      { status: 200, headers: NO_STORE_HEADERS }
-    );
-  }
-
-  if (result.outcome !== 'approved') {
-    return NextResponse.json(
-      { success: false, error: `Unexpected outcome: ${result.outcome}` },
-      { status: 422, headers: NO_STORE_HEADERS }
-    );
-  }
-
-  await finalizeWaitlistApproval(result);
 
   return NextResponse.json(
     {
       success: true,
-      message: 'Waitlist entry approved — reload to access the dashboard',
+      message: result.message,
       profileId: result.profileId,
+      waitlistStatus: result.waitlistStatus,
     },
     { status: 200, headers: NO_STORE_HEADERS }
   );

--- a/apps/web/lib/dev/dev-unwaitlist.server.ts
+++ b/apps/web/lib/dev/dev-unwaitlist.server.ts
@@ -1,0 +1,312 @@
+import 'server-only';
+
+import { and, eq } from 'drizzle-orm';
+import { getWaitlistAccess } from '@/lib/auth/gate';
+import { invalidateProxyUserStateCache } from '@/lib/auth/proxy-state';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema/auth';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { waitlistEntries } from '@/lib/db/schema/waitlist';
+import { withSystemIngestionSession } from '@/lib/ingestion/session';
+import {
+  DEFAULT_TEST_AVATAR_URL,
+  ensureCreatorProfileRecord,
+  ensureUserProfileClaim,
+  setActiveProfileForUser,
+} from '@/lib/testing/test-user-provision.server';
+import {
+  approveWaitlistEntryInTx,
+  finalizeWaitlistApproval,
+  type WaitlistApprovalResult,
+} from '@/lib/waitlist/approval';
+import { isWaitlistPendingStatus } from '@/lib/waitlist/state-machine';
+
+export type DevUnwaitlistResult =
+  | {
+      readonly ok: true;
+      readonly profileId: string | null;
+      readonly message: string;
+      readonly waitlistStatus: string | null;
+    }
+  | {
+      readonly ok: false;
+      readonly error: string;
+      readonly status: 404 | 422;
+    };
+
+function devUsernameFromEmail(email: string): string {
+  const local =
+    email
+      .split('@')[0]
+      ?.replaceAll(/[^a-z0-9]/gi, '')
+      .slice(0, 24) ?? 'user';
+  return `dev-${local || 'user'}`.toLowerCase();
+}
+
+function displayNameFromEmail(email: string): string {
+  const local = email.split('@')[0]?.trim();
+  if (!local) return 'Dev Artist';
+  return local.replaceAll(/[._+-]/g, ' ').trim() || 'Dev Artist';
+}
+
+async function resolveWaitlistEntryId(
+  email: string,
+  userWaitlistEntryId: string | null
+): Promise<string | null> {
+  const waitlistAccess = await getWaitlistAccess(email);
+  return waitlistAccess.entryId ?? userWaitlistEntryId;
+}
+
+async function resolveProfileId(params: {
+  readonly userId: string;
+  readonly activeProfileId: string | null;
+  readonly waitlistEntryId: string | null;
+}): Promise<string | null> {
+  if (params.activeProfileId) {
+    return params.activeProfileId;
+  }
+
+  if (params.waitlistEntryId) {
+    const [waitlistProfile] = await db
+      .select({ id: creatorProfiles.id })
+      .from(creatorProfiles)
+      .where(eq(creatorProfiles.waitlistEntryId, params.waitlistEntryId))
+      .limit(1);
+    if (waitlistProfile) {
+      return waitlistProfile.id;
+    }
+  }
+
+  const [claimedProfile] = await db
+    .select({ id: creatorProfiles.id })
+    .from(creatorProfiles)
+    .where(
+      and(
+        eq(creatorProfiles.userId, params.userId),
+        eq(creatorProfiles.isClaimed, true)
+      )
+    )
+    .limit(1);
+
+  return claimedProfile?.id ?? null;
+}
+
+async function approvePendingWaitlistEntry(
+  entryId: string,
+  waitlistStatus: string | null
+): Promise<WaitlistApprovalResult | null> {
+  if (!isWaitlistPendingStatus(waitlistStatus)) {
+    return null;
+  }
+
+  return withSystemIngestionSession(
+    async tx => approveWaitlistEntryInTx(tx, entryId),
+    { isolationLevel: 'serializable' }
+  );
+}
+
+async function finalizeDevSessionActivation(params: {
+  readonly userId: string;
+  readonly email: string;
+  readonly clerkId: string | null;
+  readonly userName: string | null;
+  readonly waitlistEntryId: string | null;
+  readonly activeProfileId: string | null;
+}): Promise<{ profileId: string | null }> {
+  const now = new Date();
+  let profileId = await resolveProfileId({
+    userId: params.userId,
+    activeProfileId: params.activeProfileId,
+    waitlistEntryId: params.waitlistEntryId,
+  });
+
+  const username = devUsernameFromEmail(params.email);
+  const displayName =
+    params.userName?.trim() || displayNameFromEmail(params.email);
+
+  if (!profileId) {
+    profileId = await ensureCreatorProfileRecord(db, {
+      userId: params.userId,
+      creatorType: 'artist',
+      username,
+      usernameNormalized: username.toLowerCase(),
+      displayName,
+      bio: null,
+      venmoHandle: null,
+      avatarUrl: DEFAULT_TEST_AVATAR_URL,
+      spotifyUrl: null,
+      appleMusicUrl: null,
+      appleMusicId: null,
+      youtubeMusicId: null,
+      deezerId: null,
+      tidalId: null,
+      soundcloudId: null,
+      isPublic: true,
+      isVerified: false,
+      isClaimed: true,
+      ingestionStatus: 'idle',
+      onboardingCompletedAt: now,
+    });
+  } else {
+    const [existingProfile] = await db
+      .select({
+        username: creatorProfiles.username,
+        usernameNormalized: creatorProfiles.usernameNormalized,
+        displayName: creatorProfiles.displayName,
+      })
+      .from(creatorProfiles)
+      .where(eq(creatorProfiles.id, profileId))
+      .limit(1);
+
+    await db
+      .update(creatorProfiles)
+      .set({
+        userId: params.userId,
+        username: existingProfile?.username?.trim() || username,
+        usernameNormalized:
+          existingProfile?.usernameNormalized?.trim() || username.toLowerCase(),
+        displayName: existingProfile?.displayName?.trim() || displayName,
+        isClaimed: true,
+        isPublic: true,
+        claimedAt: now,
+        onboardingCompletedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(creatorProfiles.id, profileId));
+  }
+
+  await ensureUserProfileClaim(db, params.userId, profileId);
+  await setActiveProfileForUser(db, params.userId, profileId);
+
+  await db
+    .update(users)
+    .set({
+      userStatus: 'active',
+      activeProfileId: profileId,
+      ...(params.waitlistEntryId
+        ? { waitlistEntryId: params.waitlistEntryId }
+        : {}),
+      updatedAt: now,
+    })
+    .where(eq(users.id, params.userId));
+
+  if (params.waitlistEntryId) {
+    await db
+      .update(waitlistEntries)
+      .set({
+        status: 'claimed',
+        updatedAt: now,
+      })
+      .where(eq(waitlistEntries.id, params.waitlistEntryId));
+  }
+
+  if (params.clerkId) {
+    await invalidateProxyUserStateCache(params.clerkId);
+  }
+
+  return { profileId };
+}
+
+/**
+ * Dev-only activation for the authenticated session user.
+ * Approves any pending waitlist entry, then marks the profile claimed/public
+ * with onboarding completed so native-auth smoke can proceed without manual DB edits.
+ */
+export async function devUnwaitlistSessionUser(params: {
+  readonly userId: string;
+  readonly email: string;
+  readonly clerkId: string | null;
+}): Promise<DevUnwaitlistResult> {
+  const [user] = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      userStatus: users.userStatus,
+      waitlistEntryId: users.waitlistEntryId,
+      activeProfileId: users.activeProfileId,
+      clerkId: users.clerkId,
+    })
+    .from(users)
+    .where(eq(users.id, params.userId))
+    .limit(1);
+
+  if (!user) {
+    return {
+      ok: false,
+      error: 'User record not found',
+      status: 404,
+    };
+  }
+
+  const waitlistAccess = await getWaitlistAccess(params.email);
+  const entryId = await resolveWaitlistEntryId(
+    params.email,
+    user.waitlistEntryId
+  );
+
+  if (user.userStatus === 'active') {
+    const { profileId } = await finalizeDevSessionActivation({
+      userId: user.id,
+      email: params.email,
+      clerkId: params.clerkId ?? user.clerkId,
+      userName: user.name,
+      waitlistEntryId: entryId,
+      activeProfileId: user.activeProfileId,
+    });
+
+    return {
+      ok: true,
+      profileId,
+      message: 'Session user already active — profile refreshed for dev QA',
+      waitlistStatus: waitlistAccess.status,
+    };
+  }
+
+  let approvalResult: WaitlistApprovalResult | null = null;
+  if (entryId) {
+    approvalResult = await approvePendingWaitlistEntry(
+      entryId,
+      waitlistAccess.status
+    );
+
+    if (approvalResult?.outcome === 'no_user') {
+      return {
+        ok: false,
+        error: 'Waitlist entry exists but no app user is linked yet',
+        status: 422,
+      };
+    }
+
+    if (
+      approvalResult &&
+      approvalResult.outcome !== 'approved' &&
+      approvalResult.outcome !== 'already_processed'
+    ) {
+      return {
+        ok: false,
+        error: `Unexpected waitlist outcome: ${approvalResult.outcome}`,
+        status: 422,
+      };
+    }
+
+    if (approvalResult) {
+      await finalizeWaitlistApproval(approvalResult);
+    }
+  }
+
+  const { profileId } = await finalizeDevSessionActivation({
+    userId: user.id,
+    email: params.email,
+    clerkId: params.clerkId ?? user.clerkId,
+    userName: user.name,
+    waitlistEntryId: entryId,
+    activeProfileId: user.activeProfileId,
+  });
+
+  return {
+    ok: true,
+    profileId,
+    message: 'Session user activated past waitlist for dev QA',
+    waitlistStatus: waitlistAccess.status,
+  };
+}

--- a/apps/web/tests/unit/api/dev/unwaitlist-route.test.ts
+++ b/apps/web/tests/unit/api/dev/unwaitlist-route.test.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDevUnwaitlistSessionUser, mockGetCurrentUserEntitlements } =
+  vi.hoisted(() => ({
+    mockDevUnwaitlistSessionUser: vi.fn(),
+    mockGetCurrentUserEntitlements: vi.fn(),
+  }));
+
+vi.mock('@/lib/dev/dev-unwaitlist.server', () => ({
+  devUnwaitlistSessionUser: mockDevUnwaitlistSessionUser,
+}));
+
+vi.mock('@/lib/entitlements/server', () => ({
+  getCurrentUserEntitlements: mockGetCurrentUserEntitlements,
+}));
+
+describe('POST /api/dev/unwaitlist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('VERCEL_ENV', 'development');
+
+    mockGetCurrentUserEntitlements.mockResolvedValue({
+      userId: 'user-db-1',
+      email: 'smoke@example.com',
+      isAuthenticated: true,
+    });
+    mockDevUnwaitlistSessionUser.mockResolvedValue({
+      ok: true,
+      profileId: 'profile-1',
+      message: 'Session user activated past waitlist for dev QA',
+      waitlistStatus: 'invited',
+    });
+  });
+
+  it('returns 403 outside explicit development environments', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('VERCEL_ENV', 'preview');
+
+    const { POST } = await import('@/app/api/dev/unwaitlist/route');
+    const response = await POST();
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'Not available outside development',
+    });
+    expect(mockDevUnwaitlistSessionUser).not.toHaveBeenCalled();
+  });
+
+  it('hard-blocks production Vercel deploys even when NODE_ENV is development', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('VERCEL_ENV', 'production');
+
+    const { POST } = await import('@/app/api/dev/unwaitlist/route');
+    const response = await POST();
+
+    expect(response.status).toBe(403);
+    expect(mockDevUnwaitlistSessionUser).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when the session is not authenticated', async () => {
+    mockGetCurrentUserEntitlements.mockResolvedValue({
+      userId: null,
+      email: null,
+      isAuthenticated: false,
+    });
+
+    const { POST } = await import('@/app/api/dev/unwaitlist/route');
+    const response = await POST();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'Not authenticated',
+    });
+    expect(mockDevUnwaitlistSessionUser).not.toHaveBeenCalled();
+  });
+
+  it('activates the current session user in development', async () => {
+    const { POST } = await import('@/app/api/dev/unwaitlist/route');
+    const response = await POST();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      message: 'Session user activated past waitlist for dev QA',
+      profileId: 'profile-1',
+      waitlistStatus: 'invited',
+    });
+    expect(mockDevUnwaitlistSessionUser).toHaveBeenCalledWith({
+      userId: 'user-db-1',
+      email: 'smoke@example.com',
+      clerkId: null,
+    });
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('forwards activation failures from the server helper', async () => {
+    mockDevUnwaitlistSessionUser.mockResolvedValue({
+      ok: false,
+      error: 'Waitlist entry exists but no app user is linked yet',
+      status: 422,
+    });
+
+    const { POST } = await import('@/app/api/dev/unwaitlist/route');
+    const response = await POST();
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'Waitlist entry exists but no app user is linked yet',
+    });
+  });
+
+  it('sets no-store cache headers on success responses', async () => {
+    const { POST } = await import('@/app/api/dev/unwaitlist/route');
+    const response = await POST();
+
+    expect(response).toBeInstanceOf(NextResponse);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+});

--- a/apps/web/tests/unit/lib/dev/dev-unwaitlist.server.test.ts
+++ b/apps/web/tests/unit/lib/dev/dev-unwaitlist.server.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockApproveWaitlistEntryInTx,
+  mockFinalizeWaitlistApproval,
+  mockGetWaitlistAccess,
+  mockInvalidateProxyUserStateCache,
+  mockWithSystemIngestionSession,
+  mockEnsureCreatorProfileRecord,
+  mockEnsureUserProfileClaim,
+  mockSetActiveProfileForUser,
+  mockDbSelect,
+  mockDbUpdate,
+} = vi.hoisted(() => ({
+  mockApproveWaitlistEntryInTx: vi.fn(),
+  mockFinalizeWaitlistApproval: vi.fn(),
+  mockGetWaitlistAccess: vi.fn(),
+  mockInvalidateProxyUserStateCache: vi.fn(),
+  mockWithSystemIngestionSession: vi.fn(),
+  mockEnsureCreatorProfileRecord: vi.fn(),
+  mockEnsureUserProfileClaim: vi.fn(),
+  mockSetActiveProfileForUser: vi.fn(),
+  mockDbSelect: vi.fn(),
+  mockDbUpdate: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/gate', () => ({
+  getWaitlistAccess: mockGetWaitlistAccess,
+}));
+
+vi.mock('@/lib/auth/proxy-state', () => ({
+  invalidateProxyUserStateCache: mockInvalidateProxyUserStateCache,
+}));
+
+vi.mock('@/lib/ingestion/session', () => ({
+  withSystemIngestionSession: mockWithSystemIngestionSession,
+}));
+
+vi.mock('@/lib/waitlist/approval', () => ({
+  approveWaitlistEntryInTx: mockApproveWaitlistEntryInTx,
+  finalizeWaitlistApproval: mockFinalizeWaitlistApproval,
+}));
+
+vi.mock('@/lib/testing/test-user-provision.server', () => ({
+  DEFAULT_TEST_AVATAR_URL: '/avatars/default-user.png',
+  ensureCreatorProfileRecord: mockEnsureCreatorProfileRecord,
+  ensureUserProfileClaim: mockEnsureUserProfileClaim,
+  setActiveProfileForUser: mockSetActiveProfileForUser,
+}));
+
+function createSelectChain(rows: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  return { from, where, limit };
+}
+
+function createUpdateChain() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn(() => ({ where }));
+  return { set, where };
+}
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mockDbSelect,
+    update: mockDbUpdate,
+  },
+}));
+
+describe('devUnwaitlistSessionUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    mockGetWaitlistAccess.mockResolvedValue({
+      entryId: 'entry-1',
+      status: 'waitlisted',
+    });
+    mockWithSystemIngestionSession.mockImplementation(async operation =>
+      operation({})
+    );
+    mockApproveWaitlistEntryInTx.mockResolvedValue({
+      outcome: 'approved',
+      entryId: 'entry-1',
+      profileId: 'profile-1',
+      email: 'smoke@example.com',
+      fullName: 'Smoke Artist',
+      clerkId: 'clerk_123',
+    });
+    mockEnsureCreatorProfileRecord.mockResolvedValue('profile-created');
+    mockEnsureUserProfileClaim.mockResolvedValue(undefined);
+    mockSetActiveProfileForUser.mockResolvedValue(undefined);
+    mockInvalidateProxyUserStateCache.mockResolvedValue(undefined);
+  });
+
+  it('approves pending waitlist entries and finalizes dev activation', async () => {
+    const userSelect = createSelectChain([
+      {
+        id: 'user-db-1',
+        name: 'Smoke Artist',
+        userStatus: 'waitlist_pending',
+        waitlistEntryId: 'entry-1',
+        activeProfileId: null,
+        clerkId: 'clerk_123',
+      },
+    ]);
+    const profileSelect = createSelectChain([{ id: 'profile-1' }]);
+    const profileDetailsSelect = createSelectChain([
+      {
+        username: 'smoke-artist',
+        usernameNormalized: 'smoke-artist',
+        displayName: 'Smoke Artist',
+      },
+    ]);
+    const userUpdate = createUpdateChain();
+    const profileUpdate = createUpdateChain();
+    const waitlistUpdate = createUpdateChain();
+
+    mockDbSelect
+      .mockReturnValueOnce(userSelect)
+      .mockReturnValueOnce(profileSelect)
+      .mockReturnValueOnce(profileDetailsSelect);
+    mockDbUpdate
+      .mockReturnValueOnce(profileUpdate)
+      .mockReturnValueOnce(userUpdate)
+      .mockReturnValueOnce(waitlistUpdate);
+
+    const { devUnwaitlistSessionUser } = await import(
+      '@/lib/dev/dev-unwaitlist.server'
+    );
+
+    const result = await devUnwaitlistSessionUser({
+      userId: 'user-db-1',
+      email: 'smoke@example.com',
+      clerkId: null,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      profileId: 'profile-1',
+      message: 'Session user activated past waitlist for dev QA',
+      waitlistStatus: 'waitlisted',
+    });
+    expect(mockApproveWaitlistEntryInTx).toHaveBeenCalledWith({}, 'entry-1');
+    expect(mockFinalizeWaitlistApproval).toHaveBeenCalled();
+    expect(profileUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isClaimed: true,
+        isPublic: true,
+        onboardingCompletedAt: expect.any(Date),
+      })
+    );
+    expect(userUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userStatus: 'active',
+        activeProfileId: 'profile-1',
+      })
+    );
+    expect(waitlistUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'claimed' })
+    );
+    expect(mockInvalidateProxyUserStateCache).toHaveBeenCalledWith('clerk_123');
+  });
+
+  it('activates waitlist_pending users without a waitlist entry row', async () => {
+    mockGetWaitlistAccess.mockResolvedValue({
+      entryId: null,
+      status: null,
+    });
+
+    const userSelect = createSelectChain([
+      {
+        id: 'user-db-1',
+        name: 'Smoke Artist',
+        userStatus: 'waitlist_pending',
+        waitlistEntryId: null,
+        activeProfileId: null,
+        clerkId: 'clerk_123',
+      },
+    ]);
+    const claimedProfileSelect = createSelectChain([]);
+    const userUpdate = createUpdateChain();
+
+    mockDbSelect
+      .mockReturnValueOnce(userSelect)
+      .mockReturnValueOnce(claimedProfileSelect);
+    mockDbUpdate.mockReturnValueOnce(userUpdate);
+
+    const { devUnwaitlistSessionUser } = await import(
+      '@/lib/dev/dev-unwaitlist.server'
+    );
+
+    const result = await devUnwaitlistSessionUser({
+      userId: 'user-db-1',
+      email: 'smoke@example.com',
+      clerkId: null,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockApproveWaitlistEntryInTx).not.toHaveBeenCalled();
+    expect(mockEnsureCreatorProfileRecord).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        userId: 'user-db-1',
+        isClaimed: true,
+        isPublic: true,
+        onboardingCompletedAt: expect.any(Date),
+      })
+    );
+    expect(result.profileId).toBe('profile-created');
+  });
+
+  it('returns 404 when the app user row is missing', async () => {
+    mockDbSelect.mockReturnValueOnce(createSelectChain([]));
+
+    const { devUnwaitlistSessionUser } = await import(
+      '@/lib/dev/dev-unwaitlist.server'
+    );
+
+    const result = await devUnwaitlistSessionUser({
+      userId: 'missing-user',
+      email: 'smoke@example.com',
+      clerkId: null,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'User record not found',
+      status: 404,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #13974

## Summary

Native-auth smoke (`apps/desktop/scripts/smoke-native-auth.mjs`) POSTs `/api/dev/unwaitlist` when a fresh signup lands on the waitlist screen. The route existed but only approved waitlist entries without completing dev QA activation (claimed/public profile, `onboardingCompletedAt`, `active` user status). Smoke tolerated 404 and then timed out while the account stayed `waitlist_pending`.

This PR extracts dev activation into `dev-unwaitlist.server.ts` and wires the route to:

1. Approve a pending waitlist entry when one exists for the session email
2. Claim/create the creator profile with dev-complete fields (`isClaimed`, `isPublic`, `onboardingCompletedAt`)
3. Set the session user to `active` and mark the waitlist entry `claimed` when present
4. Activate `waitlist_pending` users even when no waitlist row exists (smoke fallback)

## Security

- Hard-blocks `VERCEL_ENV=production` and non-explicit dev environments (`403`)
- Session-bound only: identity from `getCurrentUserEntitlements()`; no request body/target user params
- Covered by existing `/api/dev/` proxy production block

## Verification

```text
pnpm biome check --write apps/web/app/api/dev/unwaitlist/route.ts apps/web/lib/dev/dev-unwaitlist.server.ts apps/web/tests/unit/api/dev/unwaitlist-route.test.ts apps/web/tests/unit/lib/dev/dev-unwaitlist.server.test.ts
# Checked 4 files in 11ms. Fixed 4 files.

pnpm --filter @jovie/web run typecheck -- --pretty false
# PASS (tsc -p tsconfig.typecheck.json)

pnpm --filter web exec vitest run tests/unit/api/dev/unwaitlist-route.test.ts tests/unit/lib/dev/dev-unwaitlist.server.test.ts
# Test Files  2 passed (2)
# Tests       9 passed (9)

pnpm --filter @jovie/web run test:bug-to-test
# bug-to-test: not applicable (feature completion for missing dev route behavior)
```

Security subagent review: **PASS** (no blockers).

## Risk

Low — dev-only route under `/api/dev/`, no production deploy path, no schema migrations.

## Cost Impact

None — inline DB updates on manual dev/smoke invocation only.