### PR TITLE
fix(ci): reap orphaned Graphite queue drafts

### DIFF
--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -114,7 +114,17 @@ Agent commit signing (each identity that authors merges):
 - **Stale Graphite draft after a downstack MQ draft closes:** resubmit the
   source PR with `gt submit --always --update-only --no-edit --no-interactive
   --no-verify`. If the stale `gtmq_*` draft remains, cancel/retry the queue
-  entry from the Graphite dashboard. Do not close `gtmq_*` PRs from GitHub.
+  entry from the Graphite dashboard. Do not close `gtmq_*` PRs manually from
+  GitHub.
+  - The only automated exception is the fail-closed orphan reaper in
+    `scripts/drain-pr-queue.sh`. It may close a `gtmq_*` PR only when the PR is
+    still a draft, its generated body contains explicit Graphite or GitHub
+    source-PR URLs, and every referenced source PR is confirmed `CLOSED` or
+    `MERGED`.
+  - Missing or malformed source metadata, an `OPEN` source, an unknown/failed
+    source lookup, or a failure to post the root-cause comment always preserves
+    the synthetic draft. The reaper records that comment before attempting to
+    close the draft.
 - **Batch failure stalled siblings:** confirm Graphite **bisect on batch failure** is enabled in the dashboard. Repo guardrails only allow aggregate required checks — pinned leaf jobs break bisection.
 - **Want to bypass for an emergency:** use Graphite's "merge now" in the dashboard; there is no GitHub-side bypass actor for humans.
 

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -9,7 +9,12 @@
 #   - run `gh pr merge` (branch protection lets only the Graphite app push to
 #     main; Graphite rebase-merges enrolled PRs server-side)
 #   - retarget to integration/loop-* (agents ship straight to main now)
-#   - close PRs (surfaced for a human instead — see the SURFACE bucket)
+#   - close ordinary PRs (surfaced for a human instead — see the SURFACE bucket)
+#
+# The sole close path is a Graphite synthetic-draft reaper. It closes a
+# `gtmq_*` draft only after every source PR named by Graphite's generated body
+# is confirmed closed or merged. Missing/malformed source metadata and GitHub
+# lookup failures always preserve the draft.
 #
 # Buckets that need code work (CONFLICT / BLOCKED) are printed for the
 # /drain command to fan out per-PR worktree agents (cheap model for mechanical
@@ -50,6 +55,48 @@ unlabel() {  # unlabel <num> <label>
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would -$2 on #$1"; return 0; }
   gh_retry pr edit "$1" -R "$REPO" --remove-label "$2" >/dev/null 2>&1 \
     && echo "    -$2 on #$1" || echo "    !! failed to remove $2 on #$1"
+}
+
+graphite_source_prs() {  # graphite_source_prs <generated-body>
+  # Graphite currently links sources through app.graphite.com. Accept GitHub
+  # pull URLs too so a harmless body-template change does not strand drafts.
+  # Do not fall back to arbitrary #123 references: generated bodies may gain
+  # issue links, and false positives would make closing unsafe.
+  grep -Eo '(app\.graphite\.com/github/pr/[^/[:space:])]+/[^/[:space:])]+/[0-9]+|github\.com/[^/[:space:])]+/[^/[:space:])]+/pull/[0-9]+)' <<<"$1" \
+    | grep -Eo '[0-9]+$' \
+    | sort -nu \
+    || true
+}
+
+graphite_source_state() {  # graphite_source_state <num>
+  local n="$1" state
+  state="$(gh_retry pr view "$n" -R "$REPO" --json state --jq '.state' 2>/dev/null || true)"
+  case "$state" in
+    CLOSED | MERGED) echo "$state" ;;
+    OPEN) echo "OPEN" ;;
+    *) echo "UNKNOWN" ;;
+  esac
+}
+
+reap_graphite_orphan() {  # reap_graphite_orphan <synthetic-num> <source-summary>
+  local n="$1" source_summary="$2"
+  local comment="Root cause: this Graphite merge-queue synthetic draft is orphaned because every source PR listed in its generated body is already closed or merged (${source_summary}). Closing the synthetic queue artifact; no source PR is being modified."
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    [dry-run] would comment root cause and close orphaned Graphite draft #$n"
+    return 0
+  fi
+
+  # Do not close without leaving the diagnostic trail requested by the queue
+  # drain contract. A comment failure therefore preserves the draft.
+  if ! gh_retry pr comment "$n" -R "$REPO" --body "$comment" >/dev/null; then
+    echo "    !! failed to record orphan root cause on #$n; preserving draft"
+    return 0
+  fi
+  if gh_retry pr close "$n" -R "$REPO" >/dev/null; then
+    echo "    closed orphaned Graphite draft #$n"
+  else
+    echo "    !! root cause recorded but failed to close #$n"
+  fi
 }
 
 check_failures_for_pr() {  # check_failures_for_pr <num>
@@ -113,7 +160,7 @@ check_failures_for_pr() {  # check_failures_for_pr <num>
 }
 
 SNAP="$(gh_retry pr list -R "$REPO" --state open --limit 200 \
-  --json number,title,isDraft,mergeable,mergeStateStatus,labels,headRefName --jq '
+  --json number,title,body,isDraft,mergeable,mergeStateStatus,labels,headRefName --jq '
   [ .[] | {
     n: .number,
     t: (.title[0:48]),
@@ -121,6 +168,7 @@ SNAP="$(gh_retry pr list -R "$REPO" --state open --limit 200 \
     m: .mergeable,
     ms: (.mergeStateStatus // "UNKNOWN"),
     head: .headRefName,
+    body: (.body // ""),
     L: [.labels[].name],
     fail: []
   } ]')"
@@ -271,8 +319,51 @@ echo "$SNAP" | jq -r '.[]
   | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated"))
   | "  #\(.n)  \(.t)  {\(.L|join(","))}"'
 
-# --- Graphite MQ working drafts (the queue itself; leave alone) ---
-echo "=== GRAPHITE MQ in-flight (leave) ==="
-echo "$SNAP" | jq -r '.[] | select(.head|startswith("gtmq_")) | "  #\(.n)  \(.t)"'
+# --- Graphite MQ synthetic drafts: reap only proven orphans ---
+echo "=== GRAPHITE MQ synthetic drafts ==="
+gtmq_orphans=0
+gtmq_active=0
+while IFS= read -r pr; do
+  stop_if_budget_exhausted && break
+  n="$(jq -r '.n' <<<"$pr")"
+  t="$(jq -r '.t' <<<"$pr")"
+  draft="$(jq -r '.draft' <<<"$pr")"
+  body="$(jq -r '.body' <<<"$pr")"
+
+  # A gtmq-named non-draft is unexpected and is never a safe reaper target.
+  if [[ "$draft" != "true" ]]; then
+    echo "  #$n  $t  ACTIVE/PRESERVE (synthetic branch is not a draft)"
+    gtmq_active=$((gtmq_active + 1))
+    continue
+  fi
+
+  sources="$(graphite_source_prs "$body")"
+  if [[ -z "$sources" ]]; then
+    echo "  #$n  $t  ACTIVE/PRESERVE (no parseable Graphite source PRs)"
+    gtmq_active=$((gtmq_active + 1))
+    continue
+  fi
+
+  all_terminal=1
+  source_summary=""
+  for source in $sources; do
+    state="$(graphite_source_state "$source")"
+    [[ -n "$source_summary" ]] && source_summary+=", "
+    source_summary+="#${source}=${state}"
+    if [[ "$state" != "CLOSED" && "$state" != "MERGED" ]]; then
+      all_terminal=0
+    fi
+  done
+
+  if [[ "$all_terminal" -eq 1 ]]; then
+    echo "  #$n  $t  ORPHAN ($source_summary)"
+    reap_graphite_orphan "$n" "$source_summary"
+    gtmq_orphans=$((gtmq_orphans + 1))
+  else
+    echo "  #$n  $t  ACTIVE/PRESERVE ($source_summary)"
+    gtmq_active=$((gtmq_active + 1))
+  fi
+done < <(echo "$SNAP" | jq -c '.[] | select(.head|startswith("gtmq_"))')
+echo "  Graphite orphans: $gtmq_orphans; active/preserved: $gtmq_active"
 
 echo "=== done (DRY_RUN=$DRY_RUN) ==="

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -469,10 +469,120 @@ JSON
 
         assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
         assert "gtmq: 1" in result.stdout
-        assert "=== GRAPHITE MQ in-flight (leave) ===" in result.stdout
+        assert "=== GRAPHITE MQ synthetic drafts ===" in result.stdout
         assert "#999" in result.stdout
+        assert "ACTIVE/PRESERVE (synthetic branch is not a draft)" in result.stdout
         assert "[dry-run] would -merge-queue on #999" not in result.stdout
         assert "[dry-run] would +needs-conflict-resolution on #999" not in result.stdout
+
+    def test_gtmq_orphan_dry_run_reports_without_mutation(self, tmp_path: Path) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                echo "$*" >> "{tmp_path}/calls.log"
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{{"n":1001,"t":"Graphite orphan","body":"Sources: https://app.graphite.com/github/pr/JovieInc/Jovie/41 and https://github.com/JovieInc/Jovie/pull/42","draft":true,"m":"CONFLICTING","ms":"DIRTY","head":"gtmq_spec_orphan","L":[],"fail":[]}}]
+JSON
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  [[ "$3" == "41" ]] && echo MERGED || echo CLOSED
+                  exit 0
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=1 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "#1001  Graphite orphan  ORPHAN (#41=MERGED, #42=CLOSED)" in result.stdout
+        assert "[dry-run] would comment root cause and close orphaned Graphite draft #1001" in result.stdout
+        calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
+        assert "pr comment" not in calls
+        assert "pr close" not in calls
+
+    def test_gtmq_active_source_preserves_draft(self, tmp_path: Path) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                echo "$*" >> "{tmp_path}/calls.log"
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{{"n":1002,"t":"Graphite active","body":"* https://app.graphite.com/github/pr/JovieInc/Jovie/51\\n* https://app.graphite.com/github/pr/JovieInc/Jovie/52","draft":true,"m":"MERGEABLE","ms":"CLEAN","head":"gtmq_spec_active","L":[],"fail":[]}}]
+JSON
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  [[ "$3" == "51" ]] && echo CLOSED || echo OPEN
+                  exit 0
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=0 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "ACTIVE/PRESERVE (#51=CLOSED, #52=OPEN)" in result.stdout
+        calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
+        assert "pr comment" not in calls
+        assert "pr close" not in calls
+
+    def test_gtmq_orphan_live_mode_comments_before_close(self, tmp_path: Path) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                echo "$*" >> "{tmp_path}/calls.log"
+                if [[ "$1 $2" == "pr list" ]]; then
+                  cat <<'JSON'
+                [{{"n":1003,"t":"Graphite orphan","body":"https://app.graphite.com/github/pr/JovieInc/Jovie/61","draft":true,"m":"CONFLICTING","ms":"DIRTY","head":"gtmq_spec_closed","L":[],"fail":[]}}]
+JSON
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then echo MERGED; exit 0; fi
+                if [[ "$1 $2" == "pr comment" || "$1 $2" == "pr close" ]]; then exit 0; fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=0 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "closed orphaned Graphite draft #1003" in result.stdout
+        calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
+        comment_index = next(i for i, call in enumerate(calls) if call.startswith("pr comment 1003"))
+        close_index = next(i for i, call in enumerate(calls) if call.startswith("pr close 1003"))
+        assert comment_index < close_index
+        assert "Root cause: this Graphite merge-queue synthetic draft is orphaned" in calls[comment_index]
 
 
 class TestMergeQueueWatchdog:

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -584,6 +584,20 @@ JSON
         assert comment_index < close_index
         assert "Root cause: this Graphite merge-queue synthetic draft is orphaned" in calls[comment_index]
 
+    def test_gtmq_orphan_policy_documents_fail_closed_contract(self) -> None:
+        policy = (_REPO_ROOT / ".github" / "MERGE_QUEUE.md").read_text(
+            encoding="utf-8"
+        )
+
+        assert "only automated exception is the fail-closed orphan reaper" in policy
+        assert "still a draft" in policy
+        assert "explicit Graphite or GitHub" in policy
+        assert "confirmed `CLOSED` or" in policy
+        assert "`MERGED`" in policy
+        assert "unknown/failed" in policy
+        assert "root-cause comment always preserves" in policy
+        assert "comment before attempting to" in policy
+
 
 class TestMergeQueueWatchdog:
     """


### PR DESCRIPTION
## Summary

- detect orphaned Graphite `gtmq_*` synthetic draft PRs during queue drain
- preserve active or ambiguous Graphite drafts fail-closed
- in live mode, record the root cause before closing a proven orphan

## Root cause

The queue drain treated every Graphite synthetic draft as permanently in-flight. When all source PRs had already closed or merged, stale artifacts such as #13105 remained open indefinitely because no automation correlated the generated body back to source PR state.

Classification: **missing automation / recurring Gem failure**.

The reaper acts only when the PR is a draft on a `gtmq_*` branch, at least one explicit Graphite or GitHub source-PR URL is present, and every source resolves to `CLOSED` or `MERGED`. Open sources, lookup failures, malformed bodies, and non-draft branches are preserved. Dry-run reports without mutation; live mode comments with the root cause before closing.

## Regression evidence

- `bash -n scripts/drain-pr-queue.sh`
- `python3 -m pytest scripts/tests/test_gh_retry.py -q` — 25 passed
- `git diff --check`
- Shellcheck: no new findings; existing informational SC1091 remains for the dynamic `gh-retry.sh` source

## Incident link

- Stale Graphite synthetic artifact: #13105