### PR TITLE
fix(ci): pin fleet controllers to main

### DIFF
--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -181,7 +181,7 @@ jobs:
   # --------------------------------------------------------------------------
   auto-ready:
     name: Auto-Ready Agent Drafts
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       pull-requests: write
@@ -189,7 +189,14 @@ jobs:
       checks: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Checkout main policy code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Verify GitHub CLI
+        run: gh --version
 
       - name: Auto-ready green agent drafts
         env:

--- a/.github/workflows/auto-pr-on-push.yml
+++ b/.github/workflows/auto-pr-on-push.yml
@@ -34,7 +34,9 @@ concurrency:
 jobs:
   open-pr:
     name: Open PR
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    # Fleet controller: use the hosted image contract so `gh` is always
+    # available and persistent runner workspaces cannot supply stale helpers.
+    runs-on: ubuntu-latest
     timeout-minutes: 12
     permissions:
       contents: read
@@ -57,18 +59,29 @@ jobs:
           app-id: ${{ vars.JOVIE_BOT_APP_ID }}
           private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
 
-      - name: Checkout
+      - name: Checkout main policy code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # The pushed branch is data for this controller, not its source code.
+          # Older agent branches may not contain current workflow helpers.
+          ref: main
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify GitHub CLI
+        run: gh --version
 
       - name: Check for code changes
         id: diff
         env:
           BRANCH: ${{ github.ref_name }}
         run: |
+          # Materialize the triggering branch explicitly while keeping current
+          # main checked out as the fleet controller source of truth.
+          git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+
           # Compare this branch against main to get all changed files
-          CHANGED=$(git diff --name-only origin/main...HEAD)
+          CHANGED=$(git diff --name-only "origin/main...origin/$BRANCH")
 
           if [[ -z "$CHANGED" ]]; then
             echo "No files changed vs main. Skipping PR."

--- a/.github/workflows/auto-ready-agent-drafts.yml
+++ b/.github/workflows/auto-ready-agent-drafts.yml
@@ -30,9 +30,20 @@ permissions:
 
 jobs:
   auto-ready:
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    # Fleet controller: use the hosted image contract so `gh` is always
+    # available. Some self-hosted fast runners intentionally lack it.
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Checkout main policy code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # pull_request events otherwise checkout the triggering merge ref,
+          # which may not contain the current fleet scripts or tests.
+          ref: main
+          persist-credentials: false
+
+      - name: Verify GitHub CLI
+        run: gh --version
 
       - name: Auto-ready green agent drafts
         env:

--- a/.github/workflows/merge-queue-autoenroll.yml
+++ b/.github/workflows/merge-queue-autoenroll.yml
@@ -46,9 +46,17 @@ jobs:
   enroll:
     if: >-
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion != 'cancelled')
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    # API-only fleet controller. ubuntu-latest deterministically includes gh;
+    # the heterogeneous self-hosted fast pool does not.
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Checkout main policy code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+      - name: Verify GitHub CLI
+        run: gh --version
       - name: Enroll clean PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,9 +68,15 @@ jobs:
   rebase:
     if: >-
       github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Checkout main policy code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+      - name: Verify GitHub CLI
+        run: gh --version
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/scripts/tests/test_agent_workflow_hygiene.py
+++ b/scripts/tests/test_agent_workflow_hygiene.py
@@ -18,6 +18,13 @@ FULL_CHECKOUT_JOBS = (
     ("ci.yml", "ci-summary"),
 )
 
+FLEET_CONTROLLER_JOBS = (
+    ("auto-ready-agent-drafts.yml", "auto-ready"),
+    ("merge-queue-autoenroll.yml", "enroll"),
+    ("merge-queue-autoenroll.yml", "rebase"),
+    ("agent-tick.yml", "auto-ready"),
+)
+
 
 def _job_block(workflow: str, job_name: str) -> str:
     """Return one top-level workflow job using its two-space YAML boundary."""
@@ -72,3 +79,20 @@ def test_merge_gated_secret_scans_use_clean_hosted_runners() -> None:
         block = _job_block("security.yml", job_name)
         assert "runs-on: ubuntu-latest" in block, job_name
         assert "runs-on: ${{ vars.CI_FAST_RUNNER }}" not in block, job_name
+
+
+def test_fleet_controllers_checkout_main_policy_code() -> None:
+    """PR events must not replace fleet scripts with the triggering merge ref."""
+    for workflow, job_name in FLEET_CONTROLLER_JOBS:
+        block = _job_block(workflow, job_name)
+        assert "uses: actions/checkout@" in block, (workflow, job_name)
+        assert "ref: main" in block, (workflow, job_name)
+        assert "persist-credentials: false" in block, (workflow, job_name)
+
+
+def test_gh_fleet_controllers_use_hosted_cli_contract() -> None:
+    """Controller jobs invoking gh must not depend on heterogeneous runners."""
+    for workflow, job_name in FLEET_CONTROLLER_JOBS:
+        block = _job_block(workflow, job_name)
+        assert "runs-on: ubuntu-latest" in block, (workflow, job_name)
+        assert "run: gh --version" in block, (workflow, job_name)

--- a/scripts/tests/test_agent_workflow_hygiene.py
+++ b/scripts/tests/test_agent_workflow_hygiene.py
@@ -19,6 +19,7 @@ FULL_CHECKOUT_JOBS = (
 )
 
 FLEET_CONTROLLER_JOBS = (
+    ("auto-pr-on-push.yml", "open-pr"),
     ("auto-ready-agent-drafts.yml", "auto-ready"),
     ("merge-queue-autoenroll.yml", "enroll"),
     ("merge-queue-autoenroll.yml", "rebase"),
@@ -96,3 +97,11 @@ def test_gh_fleet_controllers_use_hosted_cli_contract() -> None:
         block = _job_block(workflow, job_name)
         assert "runs-on: ubuntu-latest" in block, (workflow, job_name)
         assert "run: gh --version" in block, (workflow, job_name)
+
+
+def test_auto_pr_compares_trigger_branch_without_executing_its_checkout() -> None:
+    """The pushed branch is controller input; current main supplies helpers."""
+    block = _job_block("auto-pr-on-push.yml", "open-pr")
+    assert 'git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"' in block
+    assert 'git diff --name-only "origin/main...origin/$BRANCH"' in block
+    assert "origin/main...HEAD" not in block


### PR DESCRIPTION
## Summary

- pin fleet-wide auto-ready and merge-queue controller checkouts to `main`
- run `gh`-dependent controller jobs on `ubuntu-latest` and verify the CLI before execution
- add workflow-hygiene regression assertions for both invariants

## Root cause

The control-plane workflows are triggered by `pull_request` events, but their checkouts did not specify a ref. Actions therefore checked out the triggering PR merge ref instead of the fleet controller source of truth on `main`. Older PR branches could omit current scripts/tests or carry stale workflow content. Separately, `CI_FAST_RUNNER` resolves across heterogeneous self-hosted runners, and some images do not install GitHub CLI.

Exact run evidence:

- run `29160577064`: auto-ready executed merge-ref content that invoked `scripts/tests/test_gh_retry.py`; the file was absent in that PR checkout
- run `29160650463`: `scripts/auto-ready-agent-drafts.sh` failed with `gh: command not found`
- run `29160650458`: enrollment failed with `scripts/drain-pr-queue.sh: No such file or directory`

Classification: **missing automation / environment drift / recurring Gem control-plane failure**.

## Fix

Affected controller jobs now explicitly checkout `ref: main` with persisted checkout credentials disabled. API-only jobs run on GitHub-hosted Ubuntu, whose runner image contract includes `gh`, and execute `gh --version` as an early deterministic preflight. Active PR code is still inspected through GitHub APIs; it is never used as controller code.

## Regression evidence

- `SHELLCHECK_OPTS="--exclude=SC2001,SC2016,SC2028,SC2034,SC2086,SC2126,SC2129,SC2329" actionlint .github/workflows/auto-ready-agent-drafts.yml .github/workflows/merge-queue-autoenroll.yml .github/workflows/agent-tick.yml`
- `python3 -m pytest scripts/tests/test_agent_workflow_hygiene.py -q` — 6 passed
- `git diff --check`

Unfiltered actionlint reports only two pre-existing SC2034 warnings elsewhere in `agent-tick`; the repository workflow lint configuration canonically excludes SC2034.