### PR TITLE
fix(ci): install Storybook browser on self-hosted runners

### DIFF
--- a/.github/workflows/visual-a11y.yml
+++ b/.github/workflows/visual-a11y.yml
@@ -63,7 +63,9 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter web exec playwright install chromium --with-deps
+      # Self-hosted runners already provide the system libraries; --with-deps
+      # invokes sudo and fails on the locked-down OrbStack runner.
+      - run: pnpm --filter web exec playwright install chromium
       - name: Run Storybook A11y Tests
         id: a11y-test
         run: pnpm --filter web test:a11y
@@ -71,15 +73,19 @@ jobs:
         if: always()
         run: |
           if [ "${{ steps.a11y-test.outcome }}" == "failure" ]; then
-            echo "## A11y Check Results" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "FAIL: Accessibility violations detected - blocking this PR." >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "To run locally: pnpm --filter web test:a11y" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## A11y Check Results"
+              echo ""
+              echo "FAIL: Accessibility violations detected - blocking this PR."
+              echo ""
+              echo "To run locally: pnpm --filter web test:a11y"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "## A11y Check Results" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "PASS: All Storybook components passed accessibility checks." >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## A11y Check Results"
+              echo ""
+              echo "PASS: All Storybook components passed accessibility checks."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
   playwright-visual:
@@ -117,14 +123,18 @@ jobs:
         if: always()
         run: |
           if [ "${{ steps.visual-test.outcome }}" == "failure" ]; then
-            echo "## Visual Regression Results" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "FAIL: Visual differences detected - blocking this PR." >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "If changes are intentional, update snapshots:" >> "$GITHUB_STEP_SUMMARY"
-            echo "pnpm --filter web e2e:visual:update" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## Visual Regression Results"
+              echo ""
+              echo "FAIL: Visual differences detected - blocking this PR."
+              echo ""
+              echo "If changes are intentional, update snapshots:"
+              echo "pnpm --filter web e2e:visual:update"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "## Visual Regression Results" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "PASS: All visual tests passed - no unexpected changes detected." >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## Visual Regression Results"
+              echo ""
+              echo "PASS: All visual tests passed - no unexpected changes detected."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/visual-a11y.yml
+++ b/.github/workflows/visual-a11y.yml
@@ -63,9 +63,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      # Self-hosted runners already provide the system libraries; --with-deps
-      # invokes sudo and fails on the locked-down OrbStack runner.
-      - run: pnpm --filter web exec playwright install chromium
+      - uses: ./.github/actions/setup-playwright
       - name: Run Storybook A11y Tests
         id: a11y-test
         run: pnpm --filter web test:a11y


### PR DESCRIPTION
## Summary
- Fixes the repo-owned Storybook A11y workflow failure on locked-down self-hosted OrbStack runners.
- Installs Chromium without `--with-deps`, which otherwise invokes `sudo` and fails before tests start.
- Keeps the Storybook A11y job and required blocking behavior intact.
- Removes existing ShellCheck SC2129 warnings in the workflow summaries so `actionlint` is clean.

## Evidence
- Failing run: https://github.com/JovieInc/Jovie/actions/runs/29142070464/job/86518355030
- First causal error: `sudo: a terminal is required ... sudo: a password is required` from `playwright install chromium --with-deps`.
- Runner: `orbstack-runner-4`.

## Verification
- `actionlint .github/workflows/visual-a11y.yml` ✅
- `git diff --check` ✅
- `pnpm --filter web test:a11y` ⚠️ local run reached Vitest but exposed 15 pre-existing Storybook/module failures (519 passed, 22 failed); unrelated to this workflow-only change.
- staged gitleaks + TruffleHog pre-commit scan ✅
- repository pre-push proxy guard, Tailwind guard, and TypeScript check ✅

## Trigger.dev status
No repo-owned Trigger.dev package, workflow, or integration dependency exists in `.github`, package manifests, scripts, or app runtime paths. The failing `Trigger.dev deployment` check is an external `trigger-dev-app` GitHub App check and requires removal/disablement by a repository admin in GitHub settings.
