### PR TITLE
fix(agent): reject issue scope contamination

### DIFF
--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -43,6 +43,7 @@ import {
   CODEX_TRUSTED_LABEL,
   countRetryReleases,
   type DispatchPlan,
+  describeIssueScopeMismatch,
   EPIC_LABEL,
   type FinisherRunner,
   finishDispatch,
@@ -64,6 +65,7 @@ import {
   type ShipperConfig,
   SpawnEagainError,
   shouldEscalateRetry,
+  validateIssueScopeOverlap,
   worktreeHasWork,
 } from '../lib/codex-issue-shipper';
 import { tryWithHeavyJobLock } from '../lib/heavy-job-lock';
@@ -1450,6 +1452,56 @@ async function dispatchPlan(
         event: 'missing_pr_release_claim',
         issue: plan.issue.number,
         branch: dispatch.branchName,
+      });
+      return;
+    }
+
+    const changedPaths = runInWorktree([
+      'git',
+      'diff',
+      '--name-only',
+      'origin/main...HEAD',
+    ])
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    const scopeVerdict = validateIssueScopeOverlap(
+      dispatch.issue,
+      changedPaths
+    );
+    if (!scopeVerdict.matches) {
+      const reason = describeIssueScopeMismatch(scopeVerdict);
+      try {
+        run(
+          [
+            'gh',
+            'pr',
+            'close',
+            String(pr.number),
+            '--repo',
+            config.repo,
+            '--comment',
+            reason,
+          ],
+          config
+        );
+      } catch (err) {
+        logJobEvent({
+          job: JOB,
+          event: 'scope_mismatch_pr_close_failed',
+          issue: dispatch.issue.number,
+          pr: pr.number,
+          error: shortError(err),
+        });
+      }
+      markBlocked(config, dispatch, reason);
+      logJobEvent({
+        job: JOB,
+        event: 'scope_mismatch_blocked',
+        issue: dispatch.issue.number,
+        pr: pr.number,
+        expectedPaths: scopeVerdict.expectedPaths,
+        changedPaths,
       });
       return;
     }

--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -41,6 +41,7 @@ import {
   CODEX_BLOCKED_LABEL,
   CODEX_CLAIM_LABEL,
   CODEX_TRUSTED_LABEL,
+  containContaminatedPr,
   countRetryReleases,
   type DispatchPlan,
   describeIssueScopeMismatch,
@@ -1472,27 +1473,32 @@ async function dispatchPlan(
     if (!scopeVerdict.matches) {
       const reason = describeIssueScopeMismatch(scopeVerdict);
       try {
-        run(
-          [
-            'gh',
-            'pr',
-            'close',
-            String(pr.number),
-            '--repo',
-            config.repo,
-            '--comment',
-            reason,
-          ],
-          config
-        );
+        const containment = containContaminatedPr(args => run(args, config), {
+          repo: config.repo,
+          prNumber: pr.number,
+          reason,
+        });
+        logJobEvent({
+          job: JOB,
+          event: 'scope_mismatch_pr_contained',
+          issue: dispatch.issue.number,
+          pr: pr.number,
+          containedBy: containment.containedBy,
+        });
       } catch (err) {
         logJobEvent({
           job: JOB,
-          event: 'scope_mismatch_pr_close_failed',
+          event: 'scope_mismatch_pr_containment_failed',
           issue: dispatch.issue.number,
           pr: pr.number,
           error: shortError(err),
         });
+        markBlocked(
+          config,
+          dispatch,
+          `${reason}\n\nAutomatic PR containment failed; manual closure is required for PR #${pr.number}.`
+        );
+        return;
       }
       markBlocked(config, dispatch, reason);
       logJobEvent({

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -787,6 +787,10 @@ export interface IssueScopeVerdict {
   readonly changedPaths: ReadonlyArray<string>;
 }
 
+export interface ContaminatedPrContainment {
+  readonly containedBy: 'closed' | 'drafted' | 'merge-eligibility-removed';
+}
+
 const PATH_TOKEN = /`([^`\n]+)`/g;
 const TITLE_PATH_TOKEN = /[\w.@-]+(?:\/[\w.@*?-]+)+/g;
 const PATHISH_EXTENSION = /\.[a-z0-9]+(?:\.[a-z0-9]+)*$/i;
@@ -885,6 +889,129 @@ export function describeIssueScopeMismatch(verdict: IssueScopeVerdict): string {
     `Expected: ${verdict.expectedPaths.join(', ') || '(none)'}`,
     `Changed: ${verdict.changedPaths.join(', ') || '(none)'}`,
   ].join('\n');
+}
+
+/**
+ * Close a contaminated PR, or fail closed by removing at least one merge path.
+ * Drafting and merge-queue label removal are attempted independently so a
+ * transient failure in one GitHub mutation cannot leave the PR mergeable.
+ */
+export function containContaminatedPr(
+  run: FinisherRunner,
+  input: {
+    readonly repo: string;
+    readonly prNumber: number;
+    readonly reason: string;
+  }
+): ContaminatedPrContainment {
+  try {
+    run([
+      'gh',
+      'pr',
+      'close',
+      String(input.prNumber),
+      '--repo',
+      input.repo,
+      '--comment',
+      input.reason,
+    ]);
+    return { containedBy: 'closed' };
+  } catch (closeError) {
+    try {
+      run([
+        'gh',
+        'pr',
+        'ready',
+        String(input.prNumber),
+        '--undo',
+        '--repo',
+        input.repo,
+      ]);
+    } catch {
+      // Independent merge-eligibility removal below may still contain it.
+    }
+    for (const label of ['merge-queue', 'fast']) {
+      try {
+        run([
+          'gh',
+          'pr',
+          'edit',
+          String(input.prNumber),
+          '--repo',
+          input.repo,
+          '--remove-label',
+          label,
+        ]);
+      } catch {
+        // A missing label is already safe; final state is verified below.
+      }
+    }
+    try {
+      run([
+        'gh',
+        'pr',
+        'merge',
+        String(input.prNumber),
+        '--repo',
+        input.repo,
+        '--disable-auto',
+      ]);
+    } catch {
+      // Auto-merge may already be disabled; final state is verified below.
+    }
+    try {
+      const state = JSON.parse(
+        run([
+          'gh',
+          'pr',
+          'view',
+          String(input.prNumber),
+          '--repo',
+          input.repo,
+          '--json',
+          'isDraft,labels,autoMergeRequest',
+        ])
+      ) as {
+        isDraft?: boolean;
+        labels?: ReadonlyArray<{ name?: string }>;
+        autoMergeRequest?: unknown;
+      };
+      if (state.isDraft === true) return { containedBy: 'drafted' };
+      const labels = new Set((state.labels ?? []).map(label => label.name));
+      if (
+        !labels.has('merge-queue') &&
+        !labels.has('fast') &&
+        state.autoMergeRequest == null
+      ) {
+        return { containedBy: 'merge-eligibility-removed' };
+      }
+    } catch {
+      // Unverifiable state is not containment.
+    }
+    throw closeError;
+  }
+}
+
+export function changedPathsForScope(
+  runInWorktree: FinisherRunner,
+  revision: string
+): readonly string[] {
+  const tracked = runInWorktree(['git', 'diff', '--name-only', revision]);
+  const untracked = runInWorktree([
+    'git',
+    'ls-files',
+    '--others',
+    '--exclude-standard',
+  ]);
+  return [
+    ...new Set(
+      `${tracked}\n${untracked}`
+        .trim()
+        .split('\n')
+        .map(path => path.trim())
+        .filter(Boolean)
+    ),
+  ];
 }
 
 /** Uncommitted changes or unpushed commits count as shippable work. */
@@ -1019,15 +1146,7 @@ export function finishDispatch(
     readonly statePath?: string;
   }
 ): void {
-  const changedPaths = runInWorktree([
-    'git',
-    'diff',
-    '--name-only',
-    'origin/main',
-  ])
-    .trim()
-    .split('\n')
-    .filter(Boolean);
+  const changedPaths = changedPathsForScope(runInWorktree, 'origin/main');
   const scopeVerdict = validateIssueScopeOverlap(input.issue, changedPaths);
   if (!scopeVerdict.matches) {
     throw new Error(describeIssueScopeMismatch(scopeVerdict));

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -780,6 +780,100 @@ export interface FinisherRunner {
   (args: ReadonlyArray<string>, opts?: { readonly timeoutMs?: number }): string;
 }
 
+export interface IssueScopeVerdict {
+  readonly enforce: boolean;
+  readonly matches: boolean;
+  readonly expectedPaths: ReadonlyArray<string>;
+  readonly changedPaths: ReadonlyArray<string>;
+}
+
+const PATH_TOKEN = /`([^`\n]+)`/g;
+const TITLE_PATH_TOKEN = /[\w.@-]+(?:\/[\w.@*?-]+)+/g;
+const PATHISH_EXTENSION = /\.[a-z0-9]+(?:\.[a-z0-9]+)*$/i;
+
+/**
+ * Extract only explicit, repository-path-shaped scope from an issue. This is
+ * deliberately not a title/keyword classifier: the gate activates only when
+ * the issue author supplied a concrete path manifest in backticks.
+ */
+export function extractIssueScopePaths(issue: GithubIssue): readonly string[] {
+  const text = `${issue.title}\n${issue.body ?? ''}`;
+  const explicitTokens = [
+    ...(issue.title.match(TITLE_PATH_TOKEN) ?? []),
+    ...[...text.matchAll(PATH_TOKEN)].map(match => match[1]?.trim() ?? ''),
+  ];
+  const paths = explicitTokens
+    .filter(token => {
+      if (!token || token.startsWith('-') || /\s/.test(token)) return false;
+      return (
+        token.includes('/') ||
+        token.includes('*') ||
+        PATHISH_EXTENSION.test(token)
+      );
+    })
+    .map(token =>
+      token
+        .replace(/^\.\//, '')
+        .replace(/\/\*\*.*$/, '')
+        .replace(/\/\*$/, '')
+        .replace(/\/+$/, '')
+    )
+    .filter(Boolean);
+  return [...new Set(paths)];
+}
+
+function pathSegmentsOverlap(
+  changedPath: string,
+  expectedPath: string
+): boolean {
+  if (
+    changedPath === expectedPath ||
+    changedPath.startsWith(`${expectedPath}/`) ||
+    expectedPath.startsWith(`${changedPath}/`)
+  ) {
+    return true;
+  }
+
+  // Issues often describe web-package paths relative to apps/web (for
+  // example tests/integration/**). Match complete path segments, never loose
+  // substrings, so `test` cannot accidentally match `contest`.
+  if (expectedPath.includes('/')) {
+    return (
+      changedPath.includes(`/${expectedPath}/`) ||
+      changedPath.endsWith(`/${expectedPath}`)
+    );
+  }
+  return changedPath.split('/').at(-1) === expectedPath;
+}
+
+export function validateIssueScopeOverlap(
+  issue: GithubIssue,
+  changedPaths: ReadonlyArray<string>
+): IssueScopeVerdict {
+  const expectedPaths = extractIssueScopePaths(issue);
+  if (expectedPaths.length === 0) {
+    return { enforce: false, matches: true, expectedPaths, changedPaths };
+  }
+  return {
+    enforce: true,
+    matches: changedPaths.some(changedPath =>
+      expectedPaths.some(expectedPath =>
+        pathSegmentsOverlap(changedPath, expectedPath)
+      )
+    ),
+    expectedPaths,
+    changedPaths,
+  };
+}
+
+export function describeIssueScopeMismatch(verdict: IssueScopeVerdict): string {
+  return [
+    'Issue scope contamination: changed paths do not overlap the explicit issue path manifest.',
+    `Expected: ${verdict.expectedPaths.join(', ') || '(none)'}`,
+    `Changed: ${verdict.changedPaths.join(', ') || '(none)'}`,
+  ].join('\n');
+}
+
 /** Uncommitted changes or unpushed commits count as shippable work. */
 export function worktreeHasWork(runInWorktree: FinisherRunner): boolean {
   const dirty = runInWorktree(['git', 'status', '--porcelain']).trim();
@@ -912,6 +1006,19 @@ export function finishDispatch(
     readonly statePath?: string;
   }
 ): void {
+  const changedPaths = runInWorktree([
+    'git',
+    'diff',
+    '--name-only',
+    'origin/main',
+  ])
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  const scopeVerdict = validateIssueScopeOverlap(input.issue, changedPaths);
+  if (!scopeVerdict.matches) {
+    throw new Error(describeIssueScopeMismatch(scopeVerdict));
+  }
   const dirty = runInWorktree(['git', 'status', '--porcelain']).trim();
   if (dirty.length > 0) {
     runInWorktree(['git', 'add', '-A']);

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -904,6 +904,7 @@ export function containContaminatedPr(
     readonly reason: string;
   }
 ): ContaminatedPrContainment {
+  let closeError: unknown;
   try {
     run([
       'gh',
@@ -915,8 +916,36 @@ export function containContaminatedPr(
       '--comment',
       input.reason,
     ]);
-    return { containedBy: 'closed' };
-  } catch (closeError) {
+  } catch (error) {
+    closeError = error;
+  }
+
+  const readState = () =>
+    JSON.parse(
+      run([
+        'gh',
+        'pr',
+        'view',
+        String(input.prNumber),
+        '--repo',
+        input.repo,
+        '--json',
+        'state,isDraft,labels,autoMergeRequest',
+      ])
+    ) as {
+      state?: string;
+      isDraft?: boolean;
+      labels?: ReadonlyArray<{ name?: string }>;
+      autoMergeRequest?: unknown;
+    };
+
+  try {
+    if (readState().state === 'CLOSED') return { containedBy: 'closed' };
+  } catch {
+    // A successful mutation without observable closed state is not containment.
+  }
+
+  try {
     try {
       run([
         'gh',
@@ -960,35 +989,25 @@ export function containContaminatedPr(
       // Auto-merge may already be disabled; final state is verified below.
     }
     try {
-      const state = JSON.parse(
-        run([
-          'gh',
-          'pr',
-          'view',
-          String(input.prNumber),
-          '--repo',
-          input.repo,
-          '--json',
-          'isDraft,labels,autoMergeRequest',
-        ])
-      ) as {
-        isDraft?: boolean;
-        labels?: ReadonlyArray<{ name?: string }>;
-        autoMergeRequest?: unknown;
-      };
-      if (state.isDraft === true) return { containedBy: 'drafted' };
+      const state = readState();
+      if (state.state === 'CLOSED') return { containedBy: 'closed' };
       const labels = new Set((state.labels ?? []).map(label => label.name));
       if (
         !labels.has('merge-queue') &&
         !labels.has('fast') &&
         state.autoMergeRequest == null
       ) {
-        return { containedBy: 'merge-eligibility-removed' };
+        return {
+          containedBy:
+            state.isDraft === true ? 'drafted' : 'merge-eligibility-removed',
+        };
       }
     } catch {
       // Unverifiable state is not containment.
     }
-    throw closeError;
+    throw closeError ?? new Error('Contaminated PR did not close');
+  } catch (containmentError) {
+    throw closeError ?? containmentError;
   }
 }
 

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -790,6 +790,7 @@ export interface IssueScopeVerdict {
 const PATH_TOKEN = /`([^`\n]+)`/g;
 const TITLE_PATH_TOKEN = /[\w.@-]+(?:\/[\w.@*?-]+)+/g;
 const PATHISH_EXTENSION = /\.[a-z0-9]+(?:\.[a-z0-9]+)*$/i;
+const URI_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
 
 /**
  * Extract only explicit, repository-path-shaped scope from an issue. This is
@@ -798,13 +799,25 @@ const PATHISH_EXTENSION = /\.[a-z0-9]+(?:\.[a-z0-9]+)*$/i;
  */
 export function extractIssueScopePaths(issue: GithubIssue): readonly string[] {
   const text = `${issue.title}\n${issue.body ?? ''}`;
+  const pathOnlyTitle = issue.title
+    .replace(/\b[a-z][a-z0-9+.-]*:\/\/\S+/gi, '')
+    .replace(/@[\w.-]+\/[\w.-]+/g, '');
   const explicitTokens = [
-    ...(issue.title.match(TITLE_PATH_TOKEN) ?? []),
+    ...(pathOnlyTitle.match(TITLE_PATH_TOKEN) ?? []),
     ...[...text.matchAll(PATH_TOKEN)].map(match => match[1]?.trim() ?? ''),
   ];
   const paths = explicitTokens
     .filter(token => {
-      if (!token || token.startsWith('-') || /\s/.test(token)) return false;
+      if (
+        !token ||
+        token.startsWith('-') ||
+        token.startsWith('@') ||
+        token.startsWith('$') ||
+        URI_SCHEME.test(token) ||
+        /\s/.test(token)
+      ) {
+        return false;
+      }
       return (
         token.includes('/') ||
         token.includes('*') ||

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -872,6 +872,26 @@ describe('contaminated PR containment', () => {
     reason: 'Issue scope contamination',
   };
 
+  it('verifies a successful close before reporting containment', () => {
+    const calls = [];
+    const result = containContaminatedPr(args => {
+      calls.push(args);
+      if (args[2] === 'view')
+        return JSON.stringify({
+          state: 'CLOSED',
+          isDraft: false,
+          labels: [],
+          autoMergeRequest: null,
+        });
+      return '';
+    }, input);
+    expect(result).toEqual({ containedBy: 'closed' });
+    expect(calls.map(args => `${args[1]} ${args[2]}`)).toEqual([
+      'pr close',
+      'pr view',
+    ]);
+  });
+
   it('drafts and removes every merge path when closing fails', () => {
     const calls = [];
     const result = containContaminatedPr(args => {
@@ -879,6 +899,7 @@ describe('contaminated PR containment', () => {
       if (args[2] === 'close') throw new Error('close failed');
       if (args[2] === 'view')
         return JSON.stringify({
+          state: 'OPEN',
           isDraft: true,
           labels: [],
           autoMergeRequest: null,
@@ -888,6 +909,7 @@ describe('contaminated PR containment', () => {
     expect(result).toEqual({ containedBy: 'drafted' });
     expect(calls.map(args => `${args[1]} ${args[2]}`)).toEqual([
       'pr close',
+      'pr view',
       'pr ready',
       'pr edit',
       'pr edit',
@@ -904,6 +926,7 @@ describe('contaminated PR containment', () => {
         throw new Error('label was already absent');
       if (args[2] === 'view')
         return JSON.stringify({
+          state: 'OPEN',
           isDraft: false,
           labels: [],
           autoMergeRequest: null,
@@ -911,6 +934,22 @@ describe('contaminated PR containment', () => {
       return '';
     }, input);
     expect(result).toEqual({ containedBy: 'merge-eligibility-removed' });
+  });
+
+  it('rejects draft state while a merge path remains active', () => {
+    expect(() =>
+      containContaminatedPr(args => {
+        if (args[2] === 'close') throw new Error('close failed');
+        if (args[2] === 'view')
+          return JSON.stringify({
+            state: 'OPEN',
+            isDraft: true,
+            labels: [{ name: 'merge-queue' }],
+            autoMergeRequest: null,
+          });
+        return '';
+      }, input)
+    ).toThrow('close failed');
   });
 
   it('escalates when close and both containment fallbacks fail', () => {

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -11,6 +11,7 @@ import {
   CODEX_CLAIM_LABEL,
   CODEX_TRUSTED_LABEL,
   classifyCheckout,
+  containContaminatedPr,
   countRetryReleases,
   describeCheckout,
   describeIssueScopeMismatch,
@@ -743,13 +744,14 @@ describe('deterministic finisher', () => {
     const cmds = calls.map(c => c.args.slice(0, 2).join(' '));
     expect(cmds).toEqual([
       'git diff',
+      'git ls-files',
       'git status',
       'git add',
       'git -c',
       'git push',
       'gh pr',
     ]);
-    const commit = calls[3].args;
+    const commit = calls[4].args;
     expect(commit).toContain('commit');
     const msg = commit[commit.indexOf('-m') + 1];
     expect(msg).toMatch(
@@ -757,8 +759,8 @@ describe('deterministic finisher', () => {
     );
     expect(msg).toContain('(#12721)');
     // hooks get a long timeout
-    expect(calls[3].opts?.timeoutMs).toBeGreaterThan(60_000);
-    const prCreate = calls[5].args;
+    expect(calls[4].opts?.timeoutMs).toBeGreaterThan(60_000);
+    const prCreate = calls[6].args;
     expect(prCreate).toContain('--head');
     expect(prCreate[prCreate.indexOf('--head') + 1]).toBe('codex/gh-12721-x');
     expect(prCreate[prCreate.indexOf('--body') + 1]).toContain('Fixes #12721');
@@ -788,7 +790,13 @@ describe('deterministic finisher', () => {
       logPath: '/tmp/agent.log',
     });
     const cmds = calls.map(c => c.args.slice(0, 2).join(' '));
-    expect(cmds).toEqual(['git diff', 'git status', 'git push', 'gh pr']);
+    expect(cmds).toEqual([
+      'git diff',
+      'git ls-files',
+      'git status',
+      'git push',
+      'gh pr',
+    ]);
   });
 
   it('finishDispatch propagates a failing step (caller releases the claim)', () => {
@@ -830,7 +838,87 @@ describe('deterministic finisher', () => {
     ).toThrow('Issue scope contamination');
     expect(calls.map(call => call.args.slice(0, 2).join(' '))).toEqual([
       'git diff',
+      'git ls-files',
     ]);
+  });
+
+  it('includes valid untracked files in the scope verdict', () => {
+    const scopedIssue = {
+      ...issue,
+      title: 'Add `apps/web/new-route.ts`',
+    };
+    const { run, calls } = fakeRunner({
+      'git diff --name-only': '',
+      'git ls-files --others': 'apps/web/new-route.ts\n',
+      'git status --porcelain': '?? apps/web/new-route.ts\n',
+    });
+
+    expect(() =>
+      finishDispatch(run, {
+        repo: 'JovieInc/Jovie',
+        branchName: 'codex/gh-12721-new-route',
+        issue: scopedIssue,
+        logPath: '/tmp/agent.log',
+      })
+    ).not.toThrow();
+    expect(calls.some(call => call.args[1] === 'add')).toBe(true);
+  });
+});
+
+describe('contaminated PR containment', () => {
+  const input = {
+    repo: 'JovieInc/Jovie',
+    prNumber: 13981,
+    reason: 'Issue scope contamination',
+  };
+
+  it('drafts and removes every merge path when closing fails', () => {
+    const calls = [];
+    const result = containContaminatedPr(args => {
+      calls.push(args);
+      if (args[2] === 'close') throw new Error('close failed');
+      if (args[2] === 'view')
+        return JSON.stringify({
+          isDraft: true,
+          labels: [],
+          autoMergeRequest: null,
+        });
+      return '';
+    }, input);
+    expect(result).toEqual({ containedBy: 'drafted' });
+    expect(calls.map(args => `${args[1]} ${args[2]}`)).toEqual([
+      'pr close',
+      'pr ready',
+      'pr edit',
+      'pr edit',
+      'pr merge',
+      'pr view',
+    ]);
+  });
+
+  it('accepts verified containment when draft and one label removal fail', () => {
+    const result = containContaminatedPr(args => {
+      if (args[2] === 'close' || args[2] === 'ready')
+        throw new Error('mutation failed');
+      if (args[2] === 'edit' && args.at(-1) === 'fast')
+        throw new Error('label was already absent');
+      if (args[2] === 'view')
+        return JSON.stringify({
+          isDraft: false,
+          labels: [],
+          autoMergeRequest: null,
+        });
+      return '';
+    }, input);
+    expect(result).toEqual({ containedBy: 'merge-eligibility-removed' });
+  });
+
+  it('escalates when close and both containment fallbacks fail', () => {
+    expect(() =>
+      containContaminatedPr(() => {
+        throw new Error('GitHub unavailable');
+      }, input)
+    ).toThrow('GitHub unavailable');
   });
 });
 
@@ -875,6 +963,14 @@ describe('issue scope overlap gate', () => {
     ]);
     expect(verdict.enforce).toBe(true);
     expect(verdict.matches).toBe(true);
+  });
+
+  it('allows bounded ancillary changes when one explicit path overlaps', () => {
+    const verdict = validateIssueScopeOverlap(integrationIssue, [
+      'apps/web/tests/integration/rls-access-control.test.ts',
+      'scripts/test-truth-guard.mjs',
+    ]);
+    expect(verdict).toMatchObject({ enforce: true, matches: true });
   });
 
   it('does not guess when an issue has no explicit path manifest', () => {

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -882,6 +882,27 @@ describe('issue scope overlap gate', () => {
       validateIssueScopeOverlap(issue(), ['apps/web/components/Foo.tsx'])
     ).toMatchObject({ enforce: false, matches: true });
   });
+
+  it('does not treat package specs, URLs, commands, or flags as repo scope', () => {
+    const verdict = validateIssueScopeOverlap(
+      issue({
+        title: 'Update @jovie/web docs from https://example.com/path/to/docs',
+        body: [
+          'Package: `@jovie/web`.',
+          'Reference: `https://example.com/path/to/docs`.',
+          'Run `pnpm --filter @jovie/web test` with `--force`.',
+          'Shell prompt: `$HOME/bin/tool`.',
+        ].join('\n'),
+      }),
+      ['apps/web/package.json']
+    );
+
+    expect(verdict).toMatchObject({
+      enforce: false,
+      matches: true,
+      expectedPaths: [],
+    });
+  });
 });
 
 describe('agent fallback chain', () => {

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -13,6 +13,7 @@ import {
   classifyCheckout,
   countRetryReleases,
   describeCheckout,
+  describeIssueScopeMismatch,
   dirtyPathsAreRecoverableDetritus,
   EPIC_LABEL,
   eligibleCodexIssues,
@@ -40,6 +41,7 @@ import {
   selectTaskRoute,
   shellQuote,
   shouldEscalateRetry,
+  validateIssueScopeOverlap,
   worktreeHasWork,
 } from '../../hermes/lib/codex-issue-shipper.ts';
 
@@ -740,13 +742,14 @@ describe('deterministic finisher', () => {
     });
     const cmds = calls.map(c => c.args.slice(0, 2).join(' '));
     expect(cmds).toEqual([
+      'git diff',
       'git status',
       'git add',
       'git -c',
       'git push',
       'gh pr',
     ]);
-    const commit = calls[2].args;
+    const commit = calls[3].args;
     expect(commit).toContain('commit');
     const msg = commit[commit.indexOf('-m') + 1];
     expect(msg).toMatch(
@@ -754,8 +757,8 @@ describe('deterministic finisher', () => {
     );
     expect(msg).toContain('(#12721)');
     // hooks get a long timeout
-    expect(calls[2].opts?.timeoutMs).toBeGreaterThan(60_000);
-    const prCreate = calls[4].args;
+    expect(calls[3].opts?.timeoutMs).toBeGreaterThan(60_000);
+    const prCreate = calls[5].args;
     expect(prCreate).toContain('--head');
     expect(prCreate[prCreate.indexOf('--head') + 1]).toBe('codex/gh-12721-x');
     expect(prCreate[prCreate.indexOf('--body') + 1]).toContain('Fixes #12721');
@@ -785,7 +788,7 @@ describe('deterministic finisher', () => {
       logPath: '/tmp/agent.log',
     });
     const cmds = calls.map(c => c.args.slice(0, 2).join(' '));
-    expect(cmds).toEqual(['git status', 'git push', 'gh pr']);
+    expect(cmds).toEqual(['git diff', 'git status', 'git push', 'gh pr']);
   });
 
   it('finishDispatch propagates a failing step (caller releases the claim)', () => {
@@ -802,6 +805,82 @@ describe('deterministic finisher', () => {
         logPath: '/tmp/agent.log',
       })
     ).toThrow('push rejected');
+  });
+
+  it('rejects a contaminated diff before commit, push, or PR creation', () => {
+    const scopedIssue = {
+      ...issue,
+      number: 13931,
+      title: 'tests/integration/** executes in no CI lane',
+      body: 'Fix `apps/web/tests/integration/rls-access-control.test.ts` and `apps/web/vitest.config.integration.mts`.',
+    };
+    const { run, calls } = fakeRunner({
+      'git diff --name-only':
+        'scripts/hermes/config/model-registry.json\nscripts/hermes/model-router.py\n',
+      'git status --porcelain': ' M scripts/hermes/model-router.py\n',
+    });
+
+    expect(() =>
+      finishDispatch(run, {
+        repo: 'JovieInc/Jovie',
+        branchName: 'gem/prescope-13931',
+        issue: scopedIssue,
+        logPath: '/tmp/agent.log',
+      })
+    ).toThrow('Issue scope contamination');
+    expect(calls.map(call => call.args.slice(0, 2).join(' '))).toEqual([
+      'git diff',
+    ]);
+  });
+});
+
+describe('issue scope overlap gate', () => {
+  const integrationIssue = issue({
+    title: 'tests/integration/** executes in NO CI lane',
+    body: [
+      'Fix `apps/web/tests/integration/rls-access-control.test.ts`.',
+      'Add `vitest.config.integration.mts` and update `scripts/test-truth-guard.mjs`.',
+    ].join('\n'),
+  });
+
+  it('rejects the #13981 model-router contamination', () => {
+    const verdict = validateIssueScopeOverlap(integrationIssue, [
+      'scripts/hermes/config/model-registry.json',
+      'scripts/hermes/model-router.py',
+    ]);
+    expect(verdict.enforce).toBe(true);
+    expect(verdict.matches).toBe(false);
+    expect(describeIssueScopeMismatch(verdict)).toContain(
+      'scripts/hermes/model-router.py'
+    );
+  });
+
+  it('uses an explicit path in the title even when the body has no manifest', () => {
+    const verdict = validateIssueScopeOverlap(
+      issue({
+        title: 'tests/integration/** executes in NO CI lane',
+        body: '',
+      }),
+      ['scripts/hermes/model-router.py']
+    );
+    expect(verdict).toMatchObject({ enforce: true, matches: false });
+    expect(verdict.expectedPaths).toContain('tests/integration');
+  });
+
+  it('accepts the valid #13967 integration implementation', () => {
+    const verdict = validateIssueScopeOverlap(integrationIssue, [
+      'apps/web/tests/integration/rls-access-control.test.ts',
+      'apps/web/vitest.config.integration.mts',
+      'apps/web/scripts/test-truth-guard.mjs',
+    ]);
+    expect(verdict.enforce).toBe(true);
+    expect(verdict.matches).toBe(true);
+  });
+
+  it('does not guess when an issue has no explicit path manifest', () => {
+    expect(
+      validateIssueScopeOverlap(issue(), ['apps/web/components/Foo.tsx'])
+    ).toMatchObject({ enforce: false, matches: true });
   });
 });
 


### PR DESCRIPTION
## Summary
- derive deterministic expected paths only from explicit path-shaped issue scope
- reject the deterministic finisher before push/PR creation when changed files have zero overlap
- close and block agent-opened PRs that fail the same scope gate
- cover the contaminated #13981 and valid #13967 file sets

## Root cause
The shipper trusted an agent exit/PR as evidence of scope alignment. Branch contamination could therefore attach an unrelated model-router diff to an integration-test issue with no deterministic comparison against the issue's explicit path manifest.

## Verification
- `pnpm exec vitest run scripts/lib/__tests__/codex-issue-shipper.test.mjs` — 57 passed
- `pnpm turbo typecheck` — passed (10 packages)
- `pnpm exec biome check` on changed files — passed
- `git diff --check` — passed

Regression: #13981
Valid reference: #13967