### PR TITLE
fix(ci): make merge-queue watchdog label cycles fail-safe

### DIFF
--- a/scripts/merge-queue-watchdog.sh
+++ b/scripts/merge-queue-watchdog.sh
@@ -120,8 +120,37 @@ last_kick_age_hours() {  # last_kick_age_hours <num>
 record_kick() {  # record_kick <num> <body>
   local n="$1" body="$2"
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would record kick comment on #$n"; return 0; }
-  bash "$(dirname "${BASH_SOURCE[0]}")/lib/upsert-pr-comment.sh" "$n" "$KICK_MARKER" "$body" \
-    || echo "    !! failed to record kick comment on #$n"
+  if bash "$(dirname "${BASH_SOURCE[0]}")/lib/upsert-pr-comment.sh" "$n" "$KICK_MARKER" "$body"; then
+    echo "    recorded kick comment on #$n"
+    return 0
+  fi
+  echo "    !! failed to record kick comment on #$n" >&2
+  return 1
+}
+
+# A label cycle is a two-step mutation. Unlike the best-effort label helpers
+# used for one-way classifications above, these helpers preserve failure so a
+# removed queue label can always be compensated before the watchdog exits.
+add_queue_label_strict() {  # add_queue_label_strict <num>
+  local n="$1"
+  [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would +merge-queue on #$n"; return 0; }
+  if gh_retry pr edit "$n" -R "$REPO" --add-label merge-queue >/dev/null; then
+    echo "    +merge-queue on #$n"
+    return 0
+  fi
+  echo "    !! failed to add merge-queue on #$n" >&2
+  return 1
+}
+
+remove_queue_label_strict() {  # remove_queue_label_strict <num>
+  local n="$1"
+  [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would -merge-queue on #$n"; return 0; }
+  if gh_retry pr edit "$n" -R "$REPO" --remove-label merge-queue >/dev/null; then
+    echo "    -merge-queue on #$n"
+    return 0
+  fi
+  echo "    !! failed to remove merge-queue on #$n; queue membership is unchanged" >&2
+  return 1
 }
 
 # Kicks recorded today (UTC) for this PR, parsed from the marker comment body
@@ -213,6 +242,7 @@ conflicts=0
 dequeued=0
 skipped_fresh=0
 skipped_cooldown=0
+mutation_failures=0
 
 while IFS= read -r pr; do
   n="$(jq -r '.n' <<<"$pr")"
@@ -267,9 +297,26 @@ while IFS= read -r pr; do
   fi
 
   echo "  #$n  $t  STALLED (age=${age_min}m, clean+green) -> label-cycle merge-queue"
-  unlabel "$n" merge-queue
-  label "$n" merge-queue
-  record_kick "$n" "Merge-queue watchdog: label-cycled \`merge-queue\` after ${age_min}m stalled with no terminal check failures (kicked at $(date -u +%Y-%m-%dT%H:%M:%SZ)). Timestamp source: \`merge-queue\` labeled event at ${labeled_at} from the issue timeline. kicks ${today_utc}: $((kicks_today + 1))"
+  if ! remove_queue_label_strict "$n"; then
+    mutation_failures=$((mutation_failures + 1))
+    continue
+  fi
+  if ! add_queue_label_strict "$n"; then
+    echo "    !! re-add failed; compensating by restoring merge-queue on #$n" >&2
+    if ! add_queue_label_strict "$n"; then
+      echo "    !! CRITICAL: compensation failed; #$n may be missing merge-queue" >&2
+    fi
+    mutation_failures=$((mutation_failures + 1))
+    continue
+  fi
+  if ! record_kick "$n" "Merge-queue watchdog: label-cycled \`merge-queue\` after ${age_min}m stalled with no terminal check failures (kicked at $(date -u +%Y-%m-%dT%H:%M:%SZ)). Timestamp source: \`merge-queue\` labeled event at ${labeled_at} from the issue timeline. kicks ${today_utc}: $((kicks_today + 1))"; then
+    echo "    !! comment failed; confirming merge-queue remains restored on #$n" >&2
+    if ! add_queue_label_strict "$n"; then
+      echo "    !! CRITICAL: label confirmation failed; #$n may be missing merge-queue" >&2
+    fi
+    mutation_failures=$((mutation_failures + 1))
+    continue
+  fi
   kicked=$((kicked + 1))
 done < <(jq -c '.[]' <<<"$CANDIDATES")
 
@@ -279,4 +326,6 @@ echo "  conflicts flagged: ${conflicts}"
 echo "  dequeued (terminal red): ${dequeued}"
 echo "  skipped (fresh, <${STALL_MINUTES}m): ${skipped_fresh}"
 echo "  skipped (cooldown): ${skipped_cooldown}"
+echo "  mutation failures: ${mutation_failures}"
 echo "=== done (DRY_RUN=$DRY_RUN) ==="
+[[ "$mutation_failures" -eq 0 ]]

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -492,6 +492,8 @@ class TestMergeQueueWatchdog:
         timeline_by_pr: dict[int, str] | None = None,
         comments_by_pr: dict[int, str] | None = None,
         checks_by_pr: dict[int, tuple[str, int]] | None = None,
+        add_label_failures: int = 0,
+        comment_failures: int = 0,
     ) -> Path:
         """Write a fake `gh` that answers pr list / api timeline / api comments /
         pr checks / pr edit for the watchdog script's exact call shapes."""
@@ -558,10 +560,26 @@ JSON
             fi
             if [[ "$1 $2" == "pr edit" ]]; then
               echo "edit $*" >> "{tmp_path}/edits.log"
+              if [[ " $* " == *" --add-label merge-queue "* ]]; then
+                count=$(cat "{tmp_path}/add-label-count" 2>/dev/null || echo 0)
+                count=$((count + 1))
+                echo "$count" > "{tmp_path}/add-label-count"
+                if [[ "$count" -le {add_label_failures} ]]; then
+                  echo "simulated add-label failure" >&2
+                  exit 1
+                fi
+              fi
               exit 0
             fi
             if [[ "$1 $2" == "pr comment" ]]; then
               echo "comment $*" >> "{tmp_path}/edits.log"
+              count=$(cat "{tmp_path}/comment-count" 2>/dev/null || echo 0)
+              count=$((count + 1))
+              echo "$count" > "{tmp_path}/comment-count"
+              if [[ "$count" -le {comment_failures} ]]; then
+                echo "simulated comment failure" >&2
+                exit 1
+              fi
               exit 0
             fi
             echo "unexpected gh args: $*" >&2
@@ -622,6 +640,91 @@ JSON
         assert "[dry-run] would -merge-queue on #100" in result.stdout
         assert "[dry-run] would +merge-queue on #100" in result.stdout
         assert "kicked (label-cycled): 1" in result.stdout
+
+    def test_successful_real_cycle_removes_readds_and_records(self, tmp_path: Path) -> None:
+        stale_ts = self._stale_ts()
+        pr_list = (
+            '[{"n":108,"t":"Successful cycle","m":"MERGEABLE","ms":"CLEAN",'
+            '"head":"tim/jov-108","L":["merge-queue"]}]'
+        )
+        timeline = (
+            f'[{{"event":"labeled","label":{{"name":"merge-queue"}},'
+            f'"created_at":"{stale_ts}"}}]'
+        )
+        self._fake_gh(
+            tmp_path,
+            pr_list_json=pr_list,
+            timeline_by_pr={108: timeline},
+            comments_by_pr={108: "[]"},
+            checks_by_pr={108: ("[]", 0)},
+        )
+
+        result = self._run_watchdog(tmp_path, extra_env="STALL_MINUTES=45", dry_run=False)
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        edits = (tmp_path / "edits.log").read_text(encoding="utf-8")
+        assert edits.count("--remove-label merge-queue") == 1
+        assert edits.count("--add-label merge-queue") == 1
+        assert edits.count("comment pr comment 108") == 1
+        assert "kicked (label-cycled): 1" in result.stdout
+        assert "mutation failures: 0" in result.stdout
+
+    def test_readd_failure_restores_label_and_returns_failure(self, tmp_path: Path) -> None:
+        stale_ts = self._stale_ts()
+        pr_list = (
+            '[{"n":109,"t":"Re-add fails once","m":"MERGEABLE","ms":"CLEAN",'
+            '"head":"tim/jov-109","L":["merge-queue"]}]'
+        )
+        timeline = (
+            f'[{{"event":"labeled","label":{{"name":"merge-queue"}},'
+            f'"created_at":"{stale_ts}"}}]'
+        )
+        self._fake_gh(
+            tmp_path,
+            pr_list_json=pr_list,
+            timeline_by_pr={109: timeline},
+            comments_by_pr={109: "[]"},
+            checks_by_pr={109: ("[]", 0)},
+            add_label_failures=1,
+        )
+
+        result = self._run_watchdog(tmp_path, extra_env="STALL_MINUTES=45", dry_run=False)
+
+        assert result.returncode != 0
+        edits = (tmp_path / "edits.log").read_text(encoding="utf-8")
+        assert edits.count("--remove-label merge-queue") == 1
+        assert edits.count("--add-label merge-queue") == 2
+        assert "compensating by restoring merge-queue" in result.stderr
+        assert "mutation failures: 1" in result.stdout
+
+    def test_comment_failure_confirms_label_and_returns_failure(self, tmp_path: Path) -> None:
+        stale_ts = self._stale_ts()
+        pr_list = (
+            '[{"n":110,"t":"Comment fails","m":"MERGEABLE","ms":"CLEAN",'
+            '"head":"tim/jov-110","L":["merge-queue"]}]'
+        )
+        timeline = (
+            f'[{{"event":"labeled","label":{{"name":"merge-queue"}},'
+            f'"created_at":"{stale_ts}"}}]'
+        )
+        self._fake_gh(
+            tmp_path,
+            pr_list_json=pr_list,
+            timeline_by_pr={110: timeline},
+            comments_by_pr={110: "[]"},
+            checks_by_pr={110: ("[]", 0)},
+            comment_failures=1,
+        )
+
+        result = self._run_watchdog(tmp_path, extra_env="STALL_MINUTES=45", dry_run=False)
+
+        assert result.returncode != 0
+        edits = (tmp_path / "edits.log").read_text(encoding="utf-8")
+        assert edits.count("--remove-label merge-queue") == 1
+        assert edits.count("--add-label merge-queue") == 2
+        assert edits.count("comment pr comment 110") == 1
+        assert "confirming merge-queue remains restored" in result.stderr
+        assert "mutation failures: 1" in result.stdout
 
     def test_freshly_labeled_pr_is_skipped(self, tmp_path: Path) -> None:
         fresh_ts = subprocess.run(


### PR DESCRIPTION
## Summary
- preserve command failures for the watchdog label-cycle mutation
- compensate a failed re-add and confirm queue membership after comment failures
- return a clear nonzero result when any cycle is only partially completed

## Root cause
The generic `label`, `unlabel`, and `record_kick` helpers logged failures but returned success. The watchdog therefore continued after removing `merge-queue`, even when re-add or comment operations failed, and could silently leave the PR outside the queue.

## Regression coverage
- successful remove/re-add/comment cycle
- first re-add failure followed by compensating restoration and nonzero exit
- comment failure followed by idempotent label confirmation and nonzero exit

## Verification
- `python3 -m pytest scripts/tests/test_gh_retry.py -q` (25 passed)
- `shellcheck scripts/merge-queue-watchdog.sh`
- `bash -n scripts/merge-queue-watchdog.sh`
- `git diff --check`

Bug-to-test: `scripts/tests/test_gh_retry.py`