### PR TITLE
fix(ci): retry cancelled PR gate jobs

### DIFF
--- a/.github/workflows/ci-cancelled-rerun.yml
+++ b/.github/workflows/ci-cancelled-rerun.yml
@@ -1,0 +1,53 @@
+name: CI Cancelled DAG Retry
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: ci-cancelled-rerun-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  rerun-cancelled:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.run_attempt <= 2 &&
+      (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main retry policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Classify cancelled DAG
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+          jobs="$(gh api --paginate --slurp "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --jq '[.[].jobs[]]')"
+          decision="$(printf '%s' "$jobs" | node scripts/lib/ci-cancelled-retry.mjs)"
+          echo "decision=$decision"
+          echo "should_rerun=$(jq -r '.shouldRerun' <<<"$decision")" >> "$GITHUB_OUTPUT"
+          echo "reason=$(jq -r '.reason' <<<"$decision")" >> "$GITHUB_OUTPUT"
+
+      - name: Rerun failed and cancelled jobs once
+        if: steps.classify.outputs.should_rerun == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          echo "${{ steps.classify.outputs.reason }}"
+          gh api --method POST "repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3678,6 +3678,7 @@ jobs:
           RISK_BLOCKS_UNATTENDED="${{ needs.ci-risk-classifier.outputs.blocks_unattended_auto_merge }}"
           RISK_RULES="${{ needs.ci-risk-classifier.outputs.matched_rule_ids }}"
           PREVIEW_RESULT="${{ needs.ci-pr-vercel-preview.result }}"
+          PREVIEW_URL="${{ needs.ci-pr-vercel-preview.outputs.deployment_url }}"
           IS_DEPENDABOT="${{ github.event.pull_request.user.login == 'dependabot[bot]' }}"
           HAS_CODE_CHANGES="${{ needs.ci-path-changes.outputs.has_code_changes }}"
           echo "ci-path-changes: $PATH_RESULT (has_code_changes=$HAS_CODE_CHANGES)"
@@ -3744,6 +3745,13 @@ jobs:
           if [[ "$BUILD_RESULT" != "success" && "$BUILD_RESULT" != "skipped" ]]; then
             echo "::warning::ci-build-public did not pass (result: $BUILD_RESULT) — non-blocking per throughput policy"
             echo "Build failure will be corrected post-merge or in a follow-up PR."
+          fi
+
+          # A hosted deployment URL is substantive preview evidence. Preserve
+          # it when only action post-cleanup changed the aggregate to cancelled.
+          if [[ "$PREVIEW_RESULT" == "cancelled" && -n "$PREVIEW_URL" ]]; then
+            echo "Preview deploy completed (${PREVIEW_URL}); only runner cleanup was cancelled — accepting deployment evidence."
+            PREVIEW_RESULT="success"
           fi
 
           if [[ "$RISK_REQUIRES_PREVIEW" == "true" && "$PREVIEW_RESULT" != "success" && "$IS_DEPENDABOT" != "true" ]]; then

--- a/scripts/lib/__tests__/ci-cancelled-retry.test.mjs
+++ b/scripts/lib/__tests__/ci-cancelled-retry.test.mjs
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { cancelledDagRetryDecision } from '../ci-cancelled-retry.mjs';
+
+describe('cancelledDagRetryDecision', () => {
+  it('reruns once when cancelled preview/build makes PR Ready false-red', () => {
+    const result = cancelledDagRetryDecision([
+      { name: 'Path Changes', conclusion: 'success' },
+      { name: 'CI Risk Classifier', conclusion: 'success' },
+      { name: 'ci-fast', conclusion: 'success' },
+      { name: 'Unit Tests (1/5)', conclusion: 'success' },
+      { name: 'Build (public routes)', conclusion: 'cancelled' },
+      { name: 'Preview Deploy (PR)', conclusion: 'cancelled' },
+      { name: 'PR Ready', conclusion: 'failure' },
+    ]);
+
+    expect(result.shouldRerun).toBe(true);
+    expect(result.reason).toContain('Preview Deploy (PR)');
+  });
+
+  it('does not rerun a real preview failure', () => {
+    const result = cancelledDagRetryDecision([
+      { name: 'Path Changes', conclusion: 'success' },
+      { name: 'Preview Deploy (PR)', conclusion: 'failure' },
+      { name: 'PR Ready', conclusion: 'failure' },
+    ]);
+
+    expect(result).toEqual({
+      shouldRerun: false,
+      reason: 'no cancelled aggregate false-red',
+    });
+  });
+
+  it('does not mask terminal core failures or retry more than once', () => {
+    expect(
+      cancelledDagRetryDecision([
+        { name: 'ci-fast', conclusion: 'failure' },
+        { name: 'Preview Deploy (PR)', conclusion: 'cancelled' },
+        { name: 'PR Ready', conclusion: 'failure' },
+      ]).shouldRerun
+    ).toBe(false);
+
+    expect(
+      cancelledDagRetryDecision(
+        [
+          { name: 'Preview Deploy (PR)', conclusion: 'cancelled' },
+          { name: 'PR Ready', conclusion: 'failure' },
+        ],
+        2
+      ).reason
+    ).toBe('automatic retry already consumed');
+  });
+});

--- a/scripts/lib/ci-cancelled-retry.mjs
+++ b/scripts/lib/ci-cancelled-retry.mjs
@@ -1,0 +1,66 @@
+const TERMINAL_CONCLUSIONS = new Set([
+  'failure',
+  'timed_out',
+  'action_required',
+  'startup_failure',
+]);
+
+const CORE_JOB_PATTERNS = [
+  /^Path Changes$/,
+  /^CI Risk Classifier$/,
+  /^ci-fast$/,
+  /^Unit Tests \(/,
+];
+
+const RETRYABLE_JOB_NAMES = new Set([
+  'Build (public routes)',
+  'Preview Deploy (PR)',
+]);
+
+export function cancelledDagRetryDecision(jobs = [], runAttempt = 1) {
+  const coreFailure = jobs.find(
+    job =>
+      CORE_JOB_PATTERNS.some(pattern => pattern.test(job.name ?? '')) &&
+      TERMINAL_CONCLUSIONS.has(job.conclusion ?? '')
+  );
+  if (coreFailure) {
+    return {
+      shouldRerun: false,
+      reason: `terminal core failure: ${coreFailure.name}`,
+    };
+  }
+
+  const prReadyFailed = jobs.some(
+    job => job.name === 'PR Ready' && job.conclusion === 'failure'
+  );
+  const cancelledJobs = jobs
+    .filter(
+      job =>
+        RETRYABLE_JOB_NAMES.has(job.name ?? '') &&
+        job.conclusion === 'cancelled'
+    )
+    .map(job => job.name);
+
+  if (!prReadyFailed || cancelledJobs.length === 0) {
+    return { shouldRerun: false, reason: 'no cancelled aggregate false-red' };
+  }
+  if (runAttempt !== 1) {
+    return { shouldRerun: false, reason: 'automatic retry already consumed' };
+  }
+
+  return {
+    shouldRerun: true,
+    reason: `retry cancelled jobs: ${cancelledJobs.join(', ')}`,
+  };
+}
+
+if (process.argv[1]?.endsWith('ci-cancelled-retry.mjs')) {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const jobs = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  const decision = cancelledDagRetryDecision(
+    jobs,
+    Number.parseInt(process.env.RUN_ATTEMPT ?? '1', 10)
+  );
+  process.stdout.write(`${JSON.stringify(decision)}\n`);
+}


### PR DESCRIPTION
## Summary

- accept a cancelled Preview aggregate only when the deploy step produced a concrete deployment URL
- automatically rerun failed/cancelled jobs once when PR Ready is false-red solely because Build or Preview was cancelled
- keep real preview/core failures terminal and cap automated retries at one

## Root cause

PR #13886 run `29140312425` passed path detection, risk classification, ci-fast, migration, and all unit shards. Preview successfully built and deployed, but its post `setup-node-pnpm` cleanup was cancelled, changing the aggregate result to `cancelled`. Build was separately cancelled during runner setup. PR Ready consumed those aggregate conclusions and failed the required preview gate even though substantive preview evidence existed.

Classification: **runner/action cleanup cancellation + missing Gem retry state**.

## Fail-closed behavior

- A cancelled preview is accepted only when `deployment_url` is non-empty.
- Cancellation before deployment remains blocking.
- A workflow-run controller reruns failed/cancelled jobs only when PR Ready failed, Build/Preview was cancelled, core gates have no terminal failure, and `run_attempt == 1`.
- Real failures and second-attempt cancellations are never auto-retried or waived.

## Verification

- `pnpm exec vitest run scripts/lib/__tests__/ci-cancelled-retry.test.mjs` — 3 passed
- canonical actionlint on `ci.yml` and `ci-cancelled-rerun.yml` — passed
- `git diff --check` — passed
- pre-commit and pre-push security/format/proxy gates — passed