### PR TITLE
fix(ci): run Claude review on hosted runner

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,7 +30,9 @@ concurrency:
 jobs:
   review:
     name: Claude Review
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    # setup-bun requires archive tooling (including unzip). The heterogeneous
+    # self-hosted fast pool does not guarantee those image prerequisites.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     # Real PRs only: skip drafts, dependabot, and mechanical codemods.
     if: >-

--- a/scripts/tests/test_agent_workflow_hygiene.py
+++ b/scripts/tests/test_agent_workflow_hygiene.py
@@ -105,3 +105,11 @@ def test_auto_pr_compares_trigger_branch_without_executing_its_checkout() -> Non
     assert 'git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"' in block
     assert 'git diff --name-only "origin/main...origin/$BRANCH"' in block
     assert "origin/main...HEAD" not in block
+
+
+def test_claude_review_uses_hosted_bun_prerequisites() -> None:
+    """setup-bun must not land on self-hosted images missing unzip."""
+    block = _job_block("claude-review.yml", "review")
+    assert "runs-on: ubuntu-latest" in block
+    assert "runs-on: ${{ vars.CI_FAST_RUNNER }}" not in block
+    assert "uses: oven-sh/setup-bun@" in block


### PR DESCRIPTION
## Summary

- route the Claude/gbrain PR review job to `ubuntu-latest`
- lock the hosted Bun prerequisite contract with workflow-hygiene regression coverage

## Root cause

Claude review uses `oven-sh/setup-bun`, which extracts a downloaded Bun archive with `unzip`. `CI_FAST_RUNNER` spans heterogeneous self-hosted images and some do not provide `unzip`, causing setup to fail before review on #13999/#13997 and historically #13944/#13964. The review has no self-host-only hardware or network requirement.

Classification: **environment drift / recurring Gem review failure**.

GitHub-hosted Ubuntu provides the archive tooling expected by setup-bun and starts from a clean image, making the prerequisite deterministic without adding mutable package installation to the job.

## Verification

- `python3 -m pytest scripts/tests/test_agent_workflow_hygiene.py -q` — 9 passed
- canonical actionlint on `claude-review.yml` — passed
- `git diff --check` — passed

## Bug-to-Test

bug-to-test: satisfied
Regression test: scripts/tests/test_agent_workflow_hygiene.py