### PR TITLE
fix(ci): harden Claude review action wiring

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,7 +10,7 @@ name: Claude Review (gbrain-aware)
 # REQUIRED SECRETS (Tim to set — workflow runs without gbrain context until then,
 # and just notes gbrain was unavailable):
 #   CLAUDE_CODE_OAUTH_TOKEN  (already set — used by main-autofix)
-#   JOVIE_BOT_PRIVATE_KEY    (already set) + vars.JOVIE_BOT_APP_ID
+#   JOVIE_BOT_PRIVATE_KEY    (already set) + vars.JOVIE_BOT_CLIENT_ID
 #   GBRAIN_CONNECTION        (NEW — the connection string/token your gbrain CLI
 #                             reads to reach your brain backend; confirm the exact
 #                             env var name your `gbrain` build expects)
@@ -44,7 +44,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.JOVIE_BOT_APP_ID }}
+          client-id: ${{ vars.JOVIE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
 
       - name: Checkout
@@ -76,8 +76,34 @@ jobs:
             echo "::warning::gbrain unreachable — review will run WITHOUT collective context."
           fi
 
+      - name: Prepare Claude review context
+        env:
+          GBRAIN_CONNECTION: ${{ secrets.GBRAIN_CONNECTION }}
+        run: |
+          set -euo pipefail
+          canonical_skill='.agents/skills/gstack/office-hours/SKILL.md'
+          test -f "$canonical_skill"
+
+          # Claude discovers repo-local skills under .claude/skills. Rebuild the
+          # compatibility link on every run so persistent runners cannot retain
+          # the old broken ../gstack/office-hours target.
+          rm -rf .claude/skills/office-hours
+          mkdir -p .claude/skills/office-hours
+          ln -s ../../../$canonical_skill .claude/skills/office-hours/SKILL.md
+          test -f .claude/skills/office-hours/SKILL.md
+
+          jq -n --arg connection "$GBRAIN_CONNECTION" '{
+            mcpServers: {
+              gbrain: {
+                type: "stdio",
+                command: "bunx",
+                args: ["gbrain", "serve"],
+                env: { GBRAIN_CONNECTION: $connection }
+              }
+            }
+          }' > "$RUNNER_TEMP/claude-review-mcp.json"
+
       - name: Claude review
-        continue-on-error: true
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
         env:
           GBRAIN_CONNECTION: ${{ secrets.GBRAIN_CONNECTION }}
@@ -85,16 +111,8 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'jovie-bot[bot],github-merge-queue[bot]'
-          mcp_config: |
-            {
-              "mcpServers": {
-                "gbrain": {
-                  "command": "bunx",
-                  "args": ["gbrain", "serve"],
-                  "env": { "GBRAIN_CONNECTION": "${{ secrets.GBRAIN_CONNECTION }}" }
-                }
-              }
-            }
+          claude_args: >-
+            --mcp-config ${{ runner.temp }}/claude-review-mcp.json
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} in JovieInc/Jovie. Review as jovie-bot.
 

--- a/scripts/lib/__tests__/claude-review-workflow.test.mjs
+++ b/scripts/lib/__tests__/claude-review-workflow.test.mjs
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..');
+const WORKFLOW_PATH = resolve(REPO_ROOT, '.github/workflows/claude-review.yml');
+const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+
+describe('Claude review workflow hygiene', () => {
+  it('uses supported action inputs', () => {
+    expect(workflow).toContain('client-id: ${{ vars.JOVIE_BOT_CLIENT_ID }}');
+    expect(workflow).not.toMatch(/^\s+app-id:/m);
+    expect(workflow).not.toMatch(/^\s+mcp_config:/m);
+    expect(workflow).toContain(
+      '--mcp-config ${{ runner.temp }}/claude-review-mcp.json'
+    );
+  });
+
+  it('repairs skill discovery using the canonical tracked skill', () => {
+    expect(workflow).toContain(
+      "canonical_skill='.agents/skills/gstack/office-hours/SKILL.md'"
+    );
+    expect(workflow).toContain('test -f "$canonical_skill"');
+    expect(workflow).toContain(
+      'ln -s ../../../$canonical_skill .claude/skills/office-hours/SKILL.md'
+    );
+    expect(workflow).toContain('test -f .claude/skills/office-hours/SKILL.md');
+  });
+
+  it('keeps gbrain context and high-signal review requirements enabled', () => {
+    const reviewStep = workflow.slice(
+      workflow.indexOf('- name: Claude review')
+    );
+
+    expect(reviewStep).not.toContain('continue-on-error: true');
+    expect(workflow).toContain('command: "bunx"');
+    expect(workflow).toContain('args: ["gbrain", "serve"]');
+    expect(workflow).toContain('COLLECTIVE CONTEXT FIRST');
+    expect(workflow).toContain('BE HIGH-SIGNAL');
+    expect(workflow).toContain('Post ONE concise PR review');
+  });
+});


### PR DESCRIPTION
## Summary
- replace deprecated GitHub App `app-id` and removed Claude Action `mcp_config` inputs with supported `client-id` and `claude_args --mcp-config` wiring
- rebuild the Claude skill compatibility link from the tracked `.agents/skills/gstack/office-hours/SKILL.md` on every run
- make Claude review action failures visible instead of silently succeeding
- add workflow hygiene regression coverage

## Root cause
The successful #13964 workflow still annotated an internal failure because persistent runner skill discovery resolved a stale broken office-hours link, while the pinned action versions warned on deprecated/unknown inputs. The Claude step was `continue-on-error`, hiding that failure from the check conclusion.

## Verification
- `actionlint .github/workflows/claude-review.yml`
- `pnpm vitest --root scripts --config vitest.config.mts run lib/__tests__/claude-review-workflow.test.mjs` (3 tests)
- `pnpm biome check scripts/lib/__tests__/claude-review-workflow.test.mjs`
- `git diff --check`

## Configuration
Added repository variable `JOVIE_BOT_CLIENT_ID=Iv23liqeCEveSE3t5Rdt`, matching GitHub App ID 2934433 (`jovie-bot`).