### PR TITLE
feat(investors): add note ingestion review workflow

### DIFF
--- a/apps/web/lib/investors/note-ingestion.ts
+++ b/apps/web/lib/investors/note-ingestion.ts
@@ -1,17 +1,19 @@
+import { createHash } from 'node:crypto';
 import { z } from 'zod';
 
-const gapClassificationSchema = z.enum([
+const GAP_CLASSIFICATIONS = [
   'communication',
   'evidence',
   'strategy',
   'investor-fit',
-]);
+] as const;
+const gapClassificationSchema = z.enum(GAP_CLASSIFICATIONS);
 const severitySchema = z.enum(['medium', 'high', 'critical']);
 const signalKindSchema = z.enum(['question', 'objection']);
 
 export const investorNoteSignalSchema = z.object({
   kind: signalKindSchema,
-  text: z.string().trim().min(3).max(1000),
+  text: z.string().trim().min(1).max(1000),
   gapClassification: gapClassificationSchema,
   severity: severitySchema,
   line: z.number().int().positive().optional(),
@@ -19,6 +21,7 @@ export const investorNoteSignalSchema = z.object({
 
 export const investorNoteInputSchema = z.object({
   source: z.object({
+    id: z.string().regex(/^[a-z0-9][a-z0-9._-]{2,127}$/u),
     kind: z.enum(['local-note', 'granola-export']),
     label: z.string().trim().min(1).max(200),
     capturedAt: z.iso.date(),
@@ -29,31 +32,38 @@ export const investorNoteInputSchema = z.object({
 
 export type InvestorNoteInput = z.infer<typeof investorNoteInputSchema>;
 export type InvestorNoteSignal = z.infer<typeof investorNoteSignalSchema>;
+type GapClassification = InvestorNoteSignal['gapClassification'];
+
+interface CandidateSource {
+  readonly sourceId: string;
+  readonly label: string;
+  readonly capturedAt: string;
+  readonly transcriptSha256: string;
+  readonly line?: number;
+}
 
 export interface InvestorNoteCandidate {
   readonly key: string;
   readonly kind: InvestorNoteSignal['kind'];
   readonly text: string;
-  readonly gapClassification: InvestorNoteSignal['gapClassification'];
+  readonly gapClassifications: readonly GapClassification[];
   readonly severity: InvestorNoteSignal['severity'];
   readonly occurrenceCount: number;
+  readonly conversationCount: number;
   readonly frequency: 'occasional' | 'common' | 'frequent';
-  readonly sources: readonly {
-    readonly label: string;
-    readonly capturedAt: string;
-    readonly line?: number;
-  }[];
+  readonly sources: readonly CandidateSource[];
+  readonly proposedNextActions: readonly string[];
+  readonly proposedReviewTargets: readonly string[];
 }
 
 export interface InvestorNoteReviewArtifact {
-  readonly artifactVersion: '1.0.0';
+  readonly artifactVersion: '1.1.0';
   readonly reviewStatus: 'manual-review-required';
   readonly asOf: string;
   readonly sourceCount: number;
   readonly candidates: readonly InvestorNoteCandidate[];
-  readonly classificationCounts: Readonly<
-    Record<InvestorNoteSignal['gapClassification'], number>
-  >;
+  readonly classificationCounts: Readonly<Record<GapClassification, number>>;
+  readonly proposedReviewTargets: readonly string[];
   readonly guardrails: {
     readonly autoPublish: false;
     readonly protectedFields: readonly [
@@ -69,13 +79,37 @@ export interface InvestorNoteReviewArtifact {
 const ANNOTATED_LINE =
   /^(QUESTION|OBJECTION)\s*\|\s*(communication|evidence|strategy|investor-fit)\s*\|\s*(medium|high|critical)\s*\|\s*(.+)$/iu;
 const severityRank = { medium: 0, high: 1, critical: 2 } as const;
+const compareText = (left: string, right: string) =>
+  left < right ? -1 : left > right ? 1 : 0;
+const NEXT_ACTIONS: Readonly<Record<GapClassification, string>> = {
+  communication:
+    'Review whether the portal and deck explain the existing evidence clearly.',
+  evidence:
+    'Identify the missing source or measurement before changing investor-facing copy.',
+  strategy: 'Resolve the company decision before proposing a narrative change.',
+  'investor-fit':
+    'Review targeting and outreach context before changing the canonical company story.',
+};
+const REVIEW_TARGETS: Readonly<Record<GapClassification, readonly string[]>> = {
+  communication: ['portal', 'deck'],
+  evidence: ['fundraisingRegistry.claims', 'portal', 'deck'],
+  strategy: ['fundraisingRegistry.risks', 'portal', 'deck'],
+  'investor-fit': ['outreach-brief', 'portal'],
+};
 
-function normalizeSignalText(text: string): string {
-  return text
+export function normalizeSignalText(text: string): string {
+  const normalized = text
+    .normalize('NFKC')
     .toLocaleLowerCase('en-US')
-    .replace(/[^a-z0-9\s]/gu, ' ')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
     .replace(/\s+/gu, ' ')
     .trim();
+  if (!normalized) throw new Error('Signal text has no letters or numbers.');
+  return normalized;
+}
+
+function transcriptHash(transcript: string): string {
+  return createHash('sha256').update(transcript, 'utf8').digest('hex');
 }
 
 function frequencyFor(count: number): InvestorNoteCandidate['frequency'] {
@@ -84,123 +118,173 @@ function frequencyFor(count: number): InvestorNoteCandidate['frequency'] {
   return 'occasional';
 }
 
-/**
- * Deterministic manual-adapter format for plain-text exports:
- * QUESTION | evidence | high | What traction is proven?
- * OBJECTION | strategy | critical | The buyer is unclear.
- *
- * Unannotated transcript lines are retained as source context but never
- * interpreted as claims or objections.
- */
+function parseAnnotatedLine(
+  rawLine: string
+): Omit<InvestorNoteSignal, 'line'> | null {
+  const match = ANNOTATED_LINE.exec(rawLine.trim());
+  if (!match) return null;
+  const [, rawKind, gapClassification, severity, text] = match;
+  return investorNoteSignalSchema.omit({ line: true }).parse({
+    kind: rawKind?.toLocaleLowerCase('en-US'),
+    text,
+    gapClassification,
+    severity,
+  });
+}
+
 export function parseAnnotatedTranscript(
   transcript: string
 ): readonly InvestorNoteSignal[] {
   return transcript.split(/\r?\n/gu).flatMap((rawLine, index) => {
-    const match = ANNOTATED_LINE.exec(rawLine.trim());
-    if (!match) return [];
-    const [, rawKind, gapClassification, severity, text] = match;
-    return [
-      investorNoteSignalSchema.parse({
-        kind: rawKind?.toLocaleLowerCase('en-US'),
-        text,
-        gapClassification,
-        severity,
-        line: index + 1,
-      }),
-    ];
+    const signal = parseAnnotatedLine(rawLine);
+    return signal ? [{ ...signal, line: index + 1 }] : [];
   });
+}
+
+function validateLineProvenance(
+  input: InvestorNoteInput,
+  signal: InvestorNoteSignal
+): void {
+  if (!signal.line) return;
+  const rawLine = input.transcript.split(/\r?\n/gu)[signal.line - 1];
+  const annotated = rawLine ? parseAnnotatedLine(rawLine) : null;
+  if (
+    !annotated ||
+    annotated.kind !== signal.kind ||
+    annotated.text !== signal.text ||
+    annotated.gapClassification !== signal.gapClassification ||
+    annotated.severity !== signal.severity
+  ) {
+    throw new Error(
+      `Signal line ${signal.line} does not match annotated transcript content for source ${input.source.id}.`
+    );
+  }
 }
 
 export function buildInvestorNoteReviewArtifact(
   rawInputs: readonly unknown[]
 ): InvestorNoteReviewArtifact {
   const inputs = rawInputs.map(input => investorNoteInputSchema.parse(input));
-  if (inputs.length === 0) {
+  if (inputs.length === 0)
     throw new Error('At least one investor note is required.');
+  const sourceIds = new Set<string>();
+  for (const input of inputs) {
+    if (sourceIds.has(input.source.id)) {
+      throw new Error(`Duplicate investor note source ID: ${input.source.id}`);
+    }
+    sourceIds.add(input.source.id);
   }
 
   const merged = new Map<
     string,
     {
       kind: InvestorNoteSignal['kind'];
-      text: string;
-      gapClassification: InvestorNoteSignal['gapClassification'];
+      texts: Set<string>;
+      classifications: Set<GapClassification>;
       severity: InvestorNoteSignal['severity'];
-      sources: Array<InvestorNoteCandidate['sources'][number]>;
+      occurrenceCount: number;
+      conversationIds: Set<string>;
+      sources: Map<string, CandidateSource>;
     }
   >();
 
   for (const input of inputs) {
+    const sha256 = transcriptHash(input.transcript);
     for (const signal of input.signals) {
+      validateLineProvenance(input, signal);
       const key = `${signal.kind}:${normalizeSignalText(signal.text)}`;
-      const existing = merged.get(key);
-      const source = {
-        label: input.source.label,
-        capturedAt: input.source.capturedAt,
-        ...(signal.line ? { line: signal.line } : {}),
+      const existing = merged.get(key) ?? {
+        kind: signal.kind,
+        texts: new Set<string>(),
+        classifications: new Set<GapClassification>(),
+        severity: signal.severity,
+        occurrenceCount: 0,
+        conversationIds: new Set<string>(),
+        sources: new Map<string, CandidateSource>(),
       };
-      if (!existing) {
-        merged.set(key, {
-          kind: signal.kind,
-          text: signal.text,
-          gapClassification: signal.gapClassification,
-          severity: signal.severity,
-          sources: [source],
-        });
-        continue;
-      }
-
-      existing.sources.push(source);
+      existing.texts.add(signal.text);
+      existing.classifications.add(signal.gapClassification);
+      existing.occurrenceCount += 1;
+      existing.conversationIds.add(input.source.id);
       if (severityRank[signal.severity] > severityRank[existing.severity]) {
         existing.severity = signal.severity;
       }
+      const sourceKey = `${input.source.id}:${signal.line ?? 'manual'}`;
+      existing.sources.set(sourceKey, {
+        sourceId: input.source.id,
+        label: input.source.label,
+        capturedAt: input.source.capturedAt,
+        transcriptSha256: sha256,
+        ...(signal.line ? { line: signal.line } : {}),
+      });
+      merged.set(key, existing);
     }
   }
 
   const candidates = [...merged.entries()]
-    .map(
-      ([key, value]): InvestorNoteCandidate => ({
+    .map(([key, value]): InvestorNoteCandidate => {
+      const gapClassifications = GAP_CLASSIFICATIONS.filter(
+        value.classifications.has.bind(value.classifications)
+      );
+      const proposedNextActions = gapClassifications.map(
+        item => NEXT_ACTIONS[item]
+      );
+      const proposedReviewTargets = [
+        ...new Set(gapClassifications.flatMap(item => REVIEW_TARGETS[item])),
+      ].sort();
+      const conversationCount = value.conversationIds.size;
+      return {
         key,
         kind: value.kind,
-        text: value.text,
-        gapClassification: value.gapClassification,
+        text: [...value.texts].sort(compareText)[0]!,
+        gapClassifications,
         severity: value.severity,
-        occurrenceCount: value.sources.length,
-        frequency: frequencyFor(value.sources.length),
-        sources: value.sources,
-      })
-    )
-    .sort((left, right) =>
-      severityRank[right.severity] !== severityRank[left.severity]
-        ? severityRank[right.severity] - severityRank[left.severity]
-        : right.occurrenceCount - left.occurrenceCount ||
-          left.key.localeCompare(right.key)
+        occurrenceCount: value.occurrenceCount,
+        conversationCount,
+        frequency: frequencyFor(conversationCount),
+        sources: [...value.sources.values()].sort(
+          (left, right) =>
+            compareText(left.sourceId, right.sourceId) ||
+            (left.line ?? 0) - (right.line ?? 0)
+        ),
+        proposedNextActions,
+        proposedReviewTargets,
+      };
+    })
+    .sort(
+      (left, right) =>
+        severityRank[right.severity] - severityRank[left.severity] ||
+        right.conversationCount - left.conversationCount ||
+        compareText(left.key, right.key)
     );
 
-  const classificationCounts = {
-    communication: 0,
-    evidence: 0,
-    strategy: 0,
-    'investor-fit': 0,
-  };
-  for (const candidate of candidates) {
-    classificationCounts[candidate.gapClassification] += 1;
-  }
+  const classificationCounts = Object.fromEntries(
+    GAP_CLASSIFICATIONS.map(item => [
+      item,
+      candidates.filter(candidate =>
+        candidate.gapClassifications.includes(item)
+      ).length,
+    ])
+  ) as Record<GapClassification, number>;
 
   return {
-    artifactVersion: '1.0.0',
+    artifactVersion: '1.1.0',
     reviewStatus: 'manual-review-required',
     asOf: inputs
       .map(input => input.source.capturedAt)
-      .sort((left, right) => right.localeCompare(left))[0]!,
+      .sort()
+      .at(-1)!,
     sourceCount: inputs.length,
     candidates,
     classificationCounts,
+    proposedReviewTargets: [
+      ...new Set(candidates.flatMap(item => item.proposedReviewTargets)),
+    ].sort(),
     guardrails: {
       autoPublish: false,
       protectedFields: ['claims', 'numbers', 'ask', 'positioning'],
     },
     recommendedReviewPath:
-      'Review candidates, then manually update fundraisingRegistry.risks in a dedicated PR. Do not copy transcript text into claims.',
+      'Create codex/jov-3739-investor-note-review, update only source-backed registry risks or communication, run registry tests, and open a draft PR. Never copy transcript text into claims.',
   };
 }

--- a/apps/web/lib/investors/note-ingestion.ts
+++ b/apps/web/lib/investors/note-ingestion.ts
@@ -1,0 +1,206 @@
+import { z } from 'zod';
+
+const gapClassificationSchema = z.enum([
+  'communication',
+  'evidence',
+  'strategy',
+  'investor-fit',
+]);
+const severitySchema = z.enum(['medium', 'high', 'critical']);
+const signalKindSchema = z.enum(['question', 'objection']);
+
+export const investorNoteSignalSchema = z.object({
+  kind: signalKindSchema,
+  text: z.string().trim().min(3).max(1000),
+  gapClassification: gapClassificationSchema,
+  severity: severitySchema,
+  line: z.number().int().positive().optional(),
+});
+
+export const investorNoteInputSchema = z.object({
+  source: z.object({
+    kind: z.enum(['local-note', 'granola-export']),
+    label: z.string().trim().min(1).max(200),
+    capturedAt: z.iso.date(),
+  }),
+  transcript: z.string().max(100_000),
+  signals: z.array(investorNoteSignalSchema).max(200),
+});
+
+export type InvestorNoteInput = z.infer<typeof investorNoteInputSchema>;
+export type InvestorNoteSignal = z.infer<typeof investorNoteSignalSchema>;
+
+export interface InvestorNoteCandidate {
+  readonly key: string;
+  readonly kind: InvestorNoteSignal['kind'];
+  readonly text: string;
+  readonly gapClassification: InvestorNoteSignal['gapClassification'];
+  readonly severity: InvestorNoteSignal['severity'];
+  readonly occurrenceCount: number;
+  readonly frequency: 'occasional' | 'common' | 'frequent';
+  readonly sources: readonly {
+    readonly label: string;
+    readonly capturedAt: string;
+    readonly line?: number;
+  }[];
+}
+
+export interface InvestorNoteReviewArtifact {
+  readonly artifactVersion: '1.0.0';
+  readonly reviewStatus: 'manual-review-required';
+  readonly asOf: string;
+  readonly sourceCount: number;
+  readonly candidates: readonly InvestorNoteCandidate[];
+  readonly classificationCounts: Readonly<
+    Record<InvestorNoteSignal['gapClassification'], number>
+  >;
+  readonly guardrails: {
+    readonly autoPublish: false;
+    readonly protectedFields: readonly [
+      'claims',
+      'numbers',
+      'ask',
+      'positioning',
+    ];
+  };
+  readonly recommendedReviewPath: string;
+}
+
+const ANNOTATED_LINE =
+  /^(QUESTION|OBJECTION)\s*\|\s*(communication|evidence|strategy|investor-fit)\s*\|\s*(medium|high|critical)\s*\|\s*(.+)$/iu;
+const severityRank = { medium: 0, high: 1, critical: 2 } as const;
+
+function normalizeSignalText(text: string): string {
+  return text
+    .toLocaleLowerCase('en-US')
+    .replace(/[^a-z0-9\s]/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function frequencyFor(count: number): InvestorNoteCandidate['frequency'] {
+  if (count >= 4) return 'frequent';
+  if (count >= 2) return 'common';
+  return 'occasional';
+}
+
+/**
+ * Deterministic manual-adapter format for plain-text exports:
+ * QUESTION | evidence | high | What traction is proven?
+ * OBJECTION | strategy | critical | The buyer is unclear.
+ *
+ * Unannotated transcript lines are retained as source context but never
+ * interpreted as claims or objections.
+ */
+export function parseAnnotatedTranscript(
+  transcript: string
+): readonly InvestorNoteSignal[] {
+  return transcript.split(/\r?\n/gu).flatMap((rawLine, index) => {
+    const match = ANNOTATED_LINE.exec(rawLine.trim());
+    if (!match) return [];
+    const [, rawKind, gapClassification, severity, text] = match;
+    return [
+      investorNoteSignalSchema.parse({
+        kind: rawKind?.toLocaleLowerCase('en-US'),
+        text,
+        gapClassification,
+        severity,
+        line: index + 1,
+      }),
+    ];
+  });
+}
+
+export function buildInvestorNoteReviewArtifact(
+  rawInputs: readonly unknown[]
+): InvestorNoteReviewArtifact {
+  const inputs = rawInputs.map(input => investorNoteInputSchema.parse(input));
+  if (inputs.length === 0) {
+    throw new Error('At least one investor note is required.');
+  }
+
+  const merged = new Map<
+    string,
+    {
+      kind: InvestorNoteSignal['kind'];
+      text: string;
+      gapClassification: InvestorNoteSignal['gapClassification'];
+      severity: InvestorNoteSignal['severity'];
+      sources: Array<InvestorNoteCandidate['sources'][number]>;
+    }
+  >();
+
+  for (const input of inputs) {
+    for (const signal of input.signals) {
+      const key = `${signal.kind}:${normalizeSignalText(signal.text)}`;
+      const existing = merged.get(key);
+      const source = {
+        label: input.source.label,
+        capturedAt: input.source.capturedAt,
+        ...(signal.line ? { line: signal.line } : {}),
+      };
+      if (!existing) {
+        merged.set(key, {
+          kind: signal.kind,
+          text: signal.text,
+          gapClassification: signal.gapClassification,
+          severity: signal.severity,
+          sources: [source],
+        });
+        continue;
+      }
+
+      existing.sources.push(source);
+      if (severityRank[signal.severity] > severityRank[existing.severity]) {
+        existing.severity = signal.severity;
+      }
+    }
+  }
+
+  const candidates = [...merged.entries()]
+    .map(
+      ([key, value]): InvestorNoteCandidate => ({
+        key,
+        kind: value.kind,
+        text: value.text,
+        gapClassification: value.gapClassification,
+        severity: value.severity,
+        occurrenceCount: value.sources.length,
+        frequency: frequencyFor(value.sources.length),
+        sources: value.sources,
+      })
+    )
+    .sort((left, right) =>
+      severityRank[right.severity] !== severityRank[left.severity]
+        ? severityRank[right.severity] - severityRank[left.severity]
+        : right.occurrenceCount - left.occurrenceCount ||
+          left.key.localeCompare(right.key)
+    );
+
+  const classificationCounts = {
+    communication: 0,
+    evidence: 0,
+    strategy: 0,
+    'investor-fit': 0,
+  };
+  for (const candidate of candidates) {
+    classificationCounts[candidate.gapClassification] += 1;
+  }
+
+  return {
+    artifactVersion: '1.0.0',
+    reviewStatus: 'manual-review-required',
+    asOf: inputs
+      .map(input => input.source.capturedAt)
+      .sort((left, right) => right.localeCompare(left))[0]!,
+    sourceCount: inputs.length,
+    candidates,
+    classificationCounts,
+    guardrails: {
+      autoPublish: false,
+      protectedFields: ['claims', 'numbers', 'ask', 'positioning'],
+    },
+    recommendedReviewPath:
+      'Review candidates, then manually update fundraisingRegistry.risks in a dedicated PR. Do not copy transcript text into claims.',
+  };
+}

--- a/apps/web/lib/investors/note-ingestion.ts
+++ b/apps/web/lib/investors/note-ingestion.ts
@@ -80,7 +80,9 @@ const ANNOTATED_LINE =
   /^(QUESTION|OBJECTION)\s*\|\s*(communication|evidence|strategy|investor-fit)\s*\|\s*(medium|high|critical)\s*\|\s*(.+)$/iu;
 const severityRank = { medium: 0, high: 1, critical: 2 } as const;
 const compareText = (left: string, right: string) =>
-  left < right ? -1 : left > right ? 1 : 0;
+  left.localeCompare(right, 'en-US');
+const compareIsoDate = (left: string, right: string) =>
+  Date.parse(left) - Date.parse(right);
 const NEXT_ACTIONS: Readonly<Record<GapClassification, string>> = {
   communication:
     'Review whether the portal and deck explain the existing evidence clearly.',
@@ -231,7 +233,7 @@ export function buildInvestorNoteReviewArtifact(
       );
       const proposedReviewTargets = [
         ...new Set(gapClassifications.flatMap(item => REVIEW_TARGETS[item])),
-      ].sort();
+      ].sort(compareText);
       const conversationCount = value.conversationIds.size;
       return {
         key,
@@ -272,14 +274,14 @@ export function buildInvestorNoteReviewArtifact(
     reviewStatus: 'manual-review-required',
     asOf: inputs
       .map(input => input.source.capturedAt)
-      .sort()
+      .sort(compareIsoDate)
       .at(-1)!,
     sourceCount: inputs.length,
     candidates,
     classificationCounts,
     proposedReviewTargets: [
       ...new Set(candidates.flatMap(item => item.proposedReviewTargets)),
-    ].sort(),
+    ].sort(compareText),
     guardrails: {
       autoPublish: false,
       protectedFields: ['claims', 'numbers', 'ask', 'positioning'],

--- a/apps/web/scripts/ingest-investor-note.ts
+++ b/apps/web/scripts/ingest-investor-note.ts
@@ -1,0 +1,70 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import {
+  buildInvestorNoteReviewArtifact,
+  investorNoteInputSchema,
+  parseAnnotatedTranscript,
+} from '@/lib/investors/note-ingestion';
+
+interface CliOptions {
+  readonly inputs: readonly string[];
+  readonly output: string | null;
+  readonly capturedAt: string | null;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  const inputs: string[] = [];
+  let output: string | null = null;
+  let capturedAt: string | null = null;
+  for (const arg of argv) {
+    if (arg.startsWith('--out=')) output = arg.slice('--out='.length);
+    else if (arg.startsWith('--captured-at='))
+      capturedAt = arg.slice('--captured-at='.length);
+    else inputs.push(arg);
+  }
+  if (inputs.length === 0) {
+    throw new Error(
+      'Usage: pnpm --filter @jovie/web exec tsx scripts/ingest-investor-note.ts <note.json|note.txt> [more files] [--captured-at=YYYY-MM-DD] [--out=artifact.json]'
+    );
+  }
+  return { inputs, output, capturedAt };
+}
+
+async function readInput(filePath: string, capturedAt: string | null) {
+  const raw = await readFile(filePath, 'utf8');
+  if (path.extname(filePath).toLocaleLowerCase('en-US') === '.json') {
+    return investorNoteInputSchema.parse(JSON.parse(raw));
+  }
+  if (!capturedAt) {
+    throw new Error(`--captured-at=YYYY-MM-DD is required for ${filePath}`);
+  }
+  return investorNoteInputSchema.parse({
+    source: {
+      kind: 'local-note',
+      label: path.basename(filePath),
+      capturedAt,
+    },
+    transcript: raw,
+    signals: parseAnnotatedTranscript(raw),
+  });
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const inputs = await Promise.all(
+    options.inputs.map(input => readInput(input, options.capturedAt))
+  );
+  const artifact = buildInvestorNoteReviewArtifact(inputs);
+  const serialized = `${JSON.stringify(artifact, null, 2)}\n`;
+  if (options.output) {
+    await writeFile(options.output, serialized, 'utf8');
+  } else {
+    process.stdout.write(serialized);
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/apps/web/scripts/ingest-investor-note.ts
+++ b/apps/web/scripts/ingest-investor-note.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import {
   buildInvestorNoteReviewArtifact,
   investorNoteInputSchema,
@@ -11,39 +12,78 @@ interface CliOptions {
   readonly inputs: readonly string[];
   readonly output: string | null;
   readonly capturedAt: string | null;
+  readonly sourceId: string | null;
+  readonly overwrite: boolean;
 }
+
+const webRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..'
+);
 
 function parseArgs(argv: readonly string[]): CliOptions {
   const inputs: string[] = [];
   let output: string | null = null;
   let capturedAt: string | null = null;
+  let sourceId: string | null = null;
+  let overwrite = false;
   for (const arg of argv) {
     if (arg.startsWith('--out=')) output = arg.slice('--out='.length);
     else if (arg.startsWith('--captured-at='))
       capturedAt = arg.slice('--captured-at='.length);
+    else if (arg.startsWith('--source-id='))
+      sourceId = arg.slice('--source-id='.length);
+    else if (arg === '--overwrite') overwrite = true;
     else inputs.push(arg);
   }
   if (inputs.length === 0) {
     throw new Error(
-      'Usage: pnpm --filter @jovie/web exec tsx scripts/ingest-investor-note.ts <note.json|note.txt> [more files] [--captured-at=YYYY-MM-DD] [--out=artifact.json]'
+      'Usage: pnpm --filter @jovie/web exec tsx scripts/ingest-investor-note.ts <note.json|note.txt> [more JSON files] [--source-id=stable-id] [--captured-at=YYYY-MM-DD] [--out=artifact.json] [--overwrite]'
     );
   }
-  return { inputs, output, capturedAt };
+  return { inputs, output, capturedAt, sourceId, overwrite };
 }
 
-async function readInput(filePath: string, capturedAt: string | null) {
-  const raw = await readFile(filePath, 'utf8');
-  if (path.extname(filePath).toLocaleLowerCase('en-US') === '.json') {
+function resolveSafePath(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  const segments = resolved.split(path.sep);
+  const basename = path.basename(resolved).toLocaleLowerCase('en-US');
+  const canonicalRegistry = path.resolve(
+    webRoot,
+    'lib/investors/fundraising-registry.ts'
+  );
+  if (
+    segments.includes('.git') ||
+    segments.includes('node_modules') ||
+    basename.startsWith('.env') ||
+    basename === '.npmrc' ||
+    resolved === canonicalRegistry
+  ) {
+    throw new Error(`Protected path is not allowed: ${filePath}`);
+  }
+  return resolved;
+}
+
+async function readInput(
+  filePath: string,
+  options: Pick<CliOptions, 'capturedAt' | 'sourceId'>
+) {
+  const safePath = resolveSafePath(filePath);
+  const raw = await readFile(safePath, 'utf8');
+  if (path.extname(safePath).toLocaleLowerCase('en-US') === '.json') {
     return investorNoteInputSchema.parse(JSON.parse(raw));
   }
-  if (!capturedAt) {
-    throw new Error(`--captured-at=YYYY-MM-DD is required for ${filePath}`);
+  if (!options.capturedAt || !options.sourceId) {
+    throw new Error(
+      `--captured-at and --source-id are required for plain text input ${filePath}`
+    );
   }
   return investorNoteInputSchema.parse({
     source: {
+      id: options.sourceId,
       kind: 'local-note',
-      label: path.basename(filePath),
-      capturedAt,
+      label: path.basename(safePath),
+      capturedAt: options.capturedAt,
     },
     transcript: raw,
     signals: parseAnnotatedTranscript(raw),
@@ -52,19 +92,46 @@ async function readInput(filePath: string, capturedAt: string | null) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
+  const inputPaths = options.inputs.map(resolveSafePath);
+  if (new Set(inputPaths).size !== inputPaths.length) {
+    throw new Error('The same input path cannot be supplied more than once.');
+  }
+  const outputPath = options.output ? resolveSafePath(options.output) : null;
+  if (outputPath && inputPaths.includes(outputPath)) {
+    throw new Error('Output path must not equal an input path.');
+  }
+  if (
+    inputPaths.some(
+      file => path.extname(file).toLocaleLowerCase('en-US') !== '.json'
+    ) &&
+    inputPaths.length > 1
+  ) {
+    throw new Error('Plain text ingestion accepts exactly one input per run.');
+  }
+
   const inputs = await Promise.all(
-    options.inputs.map(input => readInput(input, options.capturedAt))
+    inputPaths.map(input => readInput(input, options))
   );
-  const artifact = buildInvestorNoteReviewArtifact(inputs);
-  const serialized = `${JSON.stringify(artifact, null, 2)}\n`;
-  if (options.output) {
-    await writeFile(options.output, serialized, 'utf8');
+  const serialized = `${JSON.stringify(
+    buildInvestorNoteReviewArtifact(inputs),
+    null,
+    2
+  )}\n`;
+  if (outputPath) {
+    await writeFile(outputPath, serialized, {
+      encoding: 'utf8',
+      flag: options.overwrite ? 'w' : 'wx',
+    });
   } else {
     process.stdout.write(serialized);
   }
 }
 
 main().catch(error => {
-  console.error(error instanceof Error ? error.message : error);
+  process.stderr.write(
+    `${JSON.stringify({
+      error: error instanceof Error ? error.message : String(error),
+    })}\n`
+  );
   process.exitCode = 1;
 });

--- a/apps/web/tests/fixtures/investors/note-a.json
+++ b/apps/web/tests/fixtures/investors/note-a.json
@@ -1,0 +1,22 @@
+{
+  "source": {
+    "kind": "granola-export",
+    "label": "Sample investor conversation A",
+    "capturedAt": "2026-07-10"
+  },
+  "transcript": "Synthetic fixture. No real investor or deal information.",
+  "signals": [
+    {
+      "kind": "question",
+      "text": "What customer traction is proven?",
+      "gapClassification": "evidence",
+      "severity": "high"
+    },
+    {
+      "kind": "objection",
+      "text": "The initial buyer is unclear.",
+      "gapClassification": "strategy",
+      "severity": "critical"
+    }
+  ]
+}

--- a/apps/web/tests/fixtures/investors/note-a.json
+++ b/apps/web/tests/fixtures/investors/note-a.json
@@ -1,5 +1,6 @@
 {
   "source": {
+    "id": "sample-conversation-a",
     "kind": "granola-export",
     "label": "Sample investor conversation A",
     "capturedAt": "2026-07-10"

--- a/apps/web/tests/fixtures/investors/note-b.json
+++ b/apps/web/tests/fixtures/investors/note-b.json
@@ -1,0 +1,22 @@
+{
+  "source": {
+    "kind": "local-note",
+    "label": "Sample investor conversation B",
+    "capturedAt": "2026-07-11"
+  },
+  "transcript": "Synthetic fixture. No real investor or deal information.",
+  "signals": [
+    {
+      "kind": "question",
+      "text": "What customer traction is proven?",
+      "gapClassification": "evidence",
+      "severity": "critical"
+    },
+    {
+      "kind": "question",
+      "text": "How will this reach the right investors?",
+      "gapClassification": "investor-fit",
+      "severity": "medium"
+    }
+  ]
+}

--- a/apps/web/tests/fixtures/investors/note-b.json
+++ b/apps/web/tests/fixtures/investors/note-b.json
@@ -1,5 +1,6 @@
 {
   "source": {
+    "id": "sample-conversation-b",
     "kind": "local-note",
     "label": "Sample investor conversation B",
     "capturedAt": "2026-07-11"

--- a/apps/web/tests/unit/investors/note-ingestion-cli.test.ts
+++ b/apps/web/tests/unit/investors/note-ingestion-cli.test.ts
@@ -1,0 +1,120 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const tempDirectories: string[] = [];
+const script = 'scripts/ingest-investor-note.ts';
+const CLI_TEST_TIMEOUT_MS = 20_000;
+
+function tempDirectory() {
+  const directory = mkdtempSync(path.join(tmpdir(), 'investor-note-cli-'));
+  tempDirectories.push(directory);
+  return directory;
+}
+
+function fixture(sourceId = 'conversation-cli') {
+  return {
+    source: {
+      id: sourceId,
+      kind: 'local-note',
+      label: 'CLI fixture',
+      capturedAt: '2026-07-11',
+    },
+    transcript: 'Synthetic CLI fixture.',
+    signals: [
+      {
+        kind: 'question',
+        text: 'What traction is proven?',
+        gapClassification: 'evidence',
+        severity: 'high',
+      },
+    ],
+  };
+}
+
+function run(args: readonly string[]) {
+  return spawnSync('pnpm', ['exec', 'tsx', script, ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('investor note ingestion CLI', () => {
+  it(
+    'writes JSON exclusively and refuses accidental overwrite',
+    () => {
+      const directory = tempDirectory();
+      const input = path.join(directory, 'note.json');
+      const output = path.join(directory, 'artifact.json');
+      writeFileSync(input, JSON.stringify(fixture()));
+
+      expect(run([input, `--out=${output}`]).status).toBe(0);
+      expect(JSON.parse(readFileSync(output, 'utf8'))).toMatchObject({
+        reviewStatus: 'manual-review-required',
+      });
+      const second = run([input, `--out=${output}`]);
+      expect(second.status).not.toBe(0);
+      expect(() => JSON.parse(second.stderr)).not.toThrow();
+      expect(JSON.parse(second.stderr).error).toMatch(/exist/iu);
+
+      expect(run([input, `--out=${output}`, '--overwrite']).status).toBe(0);
+    },
+    CLI_TEST_TIMEOUT_MS
+  );
+
+  it(
+    'refuses input/output collisions even with overwrite enabled',
+    () => {
+      const directory = tempDirectory();
+      const input = path.join(directory, 'note.json');
+      writeFileSync(input, JSON.stringify(fixture()));
+
+      const result = run([input, `--out=${input}`, '--overwrite']);
+      expect(result.status).not.toBe(0);
+      expect(JSON.parse(result.stderr).error).toContain(
+        'Output path must not equal an input path.'
+      );
+      expect(JSON.parse(readFileSync(input, 'utf8'))).toEqual(fixture());
+    },
+    CLI_TEST_TIMEOUT_MS
+  );
+
+  it(
+    'refuses protected source and output paths',
+    () => {
+      const directory = tempDirectory();
+      const protectedInput = path.join(directory, '.env.investor');
+      writeFileSync(protectedInput, 'secret=value');
+      const inputResult = run([
+        protectedInput,
+        '--source-id=conversation-protected',
+        '--captured-at=2026-07-11',
+      ]);
+      expect(inputResult.status).not.toBe(0);
+      expect(JSON.parse(inputResult.stderr).error).toContain(
+        'Protected path is not allowed'
+      );
+
+      const input = path.join(directory, 'note.json');
+      writeFileSync(input, JSON.stringify(fixture('conversation-safe')));
+      const outputResult = run([
+        input,
+        `--out=${path.join(directory, '.env.output')}`,
+        '--overwrite',
+      ]);
+      expect(outputResult.status).not.toBe(0);
+      expect(JSON.parse(outputResult.stderr).error).toContain(
+        'Protected path is not allowed'
+      );
+    },
+    CLI_TEST_TIMEOUT_MS
+  );
+});

--- a/apps/web/tests/unit/investors/note-ingestion.test.ts
+++ b/apps/web/tests/unit/investors/note-ingestion.test.ts
@@ -1,20 +1,34 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildInvestorNoteReviewArtifact,
+  normalizeSignalText,
   parseAnnotatedTranscript,
 } from '@/lib/investors/note-ingestion';
 
-function note(
-  label: string,
-  capturedAt: string,
-  signals: readonly Record<string, unknown>[]
-) {
+function note({
+  id,
+  capturedAt = '2026-07-11',
+  transcript = 'Synthetic test transcript.',
+  signals,
+}: {
+  id: string;
+  capturedAt?: string;
+  transcript?: string;
+  signals: readonly Record<string, unknown>[];
+}) {
   return {
-    source: { kind: 'local-note', label, capturedAt },
-    transcript: 'Synthetic test transcript.',
+    source: { id, kind: 'local-note', label: id, capturedAt },
+    transcript,
     signals,
   };
 }
+
+const tractionSignal = {
+  kind: 'question',
+  text: 'What traction is proven?',
+  gapClassification: 'evidence',
+  severity: 'high',
+};
 
 describe('investor note ingestion', () => {
   it('extracts only explicitly annotated text lines', () => {
@@ -23,13 +37,7 @@ describe('investor note ingestion', () => {
 QUESTION | evidence | high | What traction is proven?
 OBJECTION | strategy | critical | The buyer is unclear.`)
     ).toEqual([
-      {
-        kind: 'question',
-        text: 'What traction is proven?',
-        gapClassification: 'evidence',
-        severity: 'high',
-        line: 2,
-      },
+      { ...tractionSignal, line: 2 },
       {
         kind: 'objection',
         text: 'The buyer is unclear.',
@@ -40,56 +48,124 @@ OBJECTION | strategy | critical | The buyer is unclear.`)
     ]);
   });
 
-  it('merges duplicates and keeps the highest observed severity', () => {
-    const artifact = buildInvestorNoteReviewArtifact([
-      note('A', '2026-07-10', [
+  it('is input-order independent and preserves classification conflicts', () => {
+    const first = note({
+      id: 'conversation-a',
+      capturedAt: '2026-07-10',
+      signals: [tractionSignal],
+    });
+    const second = note({
+      id: 'conversation-b',
+      signals: [
         {
-          kind: 'question',
-          text: 'What traction is proven?',
-          gapClassification: 'evidence',
-          severity: 'medium',
-        },
-      ]),
-      note('B', '2026-07-11', [
-        {
-          kind: 'question',
+          ...tractionSignal,
           text: 'What traction is proven!',
-          gapClassification: 'evidence',
+          gapClassification: 'communication',
           severity: 'critical',
         },
-      ]),
-    ]);
+      ],
+    });
 
-    expect(artifact.asOf).toBe('2026-07-11');
-    expect(artifact.candidates).toHaveLength(1);
-    expect(artifact.candidates[0]).toMatchObject({
+    const forward = buildInvestorNoteReviewArtifact([first, second]);
+    const reverse = buildInvestorNoteReviewArtifact([second, first]);
+    expect(reverse).toEqual(forward);
+    expect(forward.candidates[0]).toMatchObject({
+      text: 'What traction is proven!',
+      gapClassifications: ['communication', 'evidence'],
       severity: 'critical',
       occurrenceCount: 2,
+      conversationCount: 2,
       frequency: 'common',
-      gapClassification: 'evidence',
     });
-    expect(artifact.candidates[0]?.sources).toHaveLength(2);
+    expect(
+      forward.candidates[0]?.sources.map(source => source.sourceId)
+    ).toEqual(['conversation-a', 'conversation-b']);
   });
 
-  it('classifies gaps and forbids automatic publishing', () => {
+  it('scores frequency from distinct conversations, not repeated mentions', () => {
     const artifact = buildInvestorNoteReviewArtifact([
-      note('A', '2026-07-11', [
-        {
-          kind: 'objection',
-          text: 'The investor fit is unclear.',
-          gapClassification: 'investor-fit',
-          severity: 'high',
-        },
-      ]),
+      note({
+        id: 'conversation-a',
+        signals: [tractionSignal, tractionSignal, tractionSignal],
+      }),
     ]);
-
-    expect(artifact.classificationCounts['investor-fit']).toBe(1);
-    expect(artifact.reviewStatus).toBe('manual-review-required');
-    expect(artifact.guardrails).toEqual({
-      autoPublish: false,
-      protectedFields: ['claims', 'numbers', 'ask', 'positioning'],
+    expect(artifact.candidates[0]).toMatchObject({
+      occurrenceCount: 3,
+      conversationCount: 1,
+      frequency: 'occasional',
     });
-    expect(artifact.recommendedReviewPath).toContain('dedicated PR');
+    expect(artifact.candidates[0]?.sources).toHaveLength(1);
+  });
+
+  it('rejects repeated source IDs instead of inflating frequency', () => {
+    const input = note({ id: 'conversation-a', signals: [tractionSignal] });
+    expect(() => buildInvestorNoteReviewArtifact([input, input])).toThrow(
+      'Duplicate investor note source ID: conversation-a'
+    );
+  });
+
+  it('normalizes Unicode with NFKC while retaining letters and numbers', () => {
+    expect(normalizeSignalText('Ｃafé № １２')).toBe('café no 12');
+    expect(normalizeSignalText('市場 规模 2026')).toBe('市場 规模 2026');
+    expect(() => normalizeSignalText('?! —')).toThrow(
+      'Signal text has no letters or numbers.'
+    );
+  });
+
+  it('validates annotated line provenance and emits transcript hashes', () => {
+    const transcript =
+      'Context\nQUESTION | evidence | high | What traction is proven?';
+    const artifact = buildInvestorNoteReviewArtifact([
+      note({
+        id: 'conversation-a',
+        transcript,
+        signals: [{ ...tractionSignal, line: 2 }],
+      }),
+    ]);
+    expect(artifact.candidates[0]?.sources[0]).toMatchObject({
+      sourceId: 'conversation-a',
+      line: 2,
+    });
+    expect(artifact.candidates[0]?.sources[0]?.transcriptSha256).toMatch(
+      /^[a-f0-9]{64}$/u
+    );
+
+    expect(() =>
+      buildInvestorNoteReviewArtifact([
+        note({
+          id: 'conversation-b',
+          transcript,
+          signals: [{ ...tractionSignal, line: 1 }],
+        }),
+      ])
+    ).toThrow('does not match annotated transcript content');
+  });
+
+  it('proposes bounded actions and review targets without publishing', () => {
+    const artifact = buildInvestorNoteReviewArtifact([
+      note({
+        id: 'conversation-a',
+        signals: [
+          {
+            kind: 'objection',
+            text: 'The investor fit is unclear.',
+            gapClassification: 'investor-fit',
+            severity: 'high',
+          },
+        ],
+      }),
+    ]);
+    expect(artifact.proposedReviewTargets).toEqual([
+      'outreach-brief',
+      'portal',
+    ]);
+    expect(artifact.candidates[0]?.proposedNextActions[0]).toContain(
+      'targeting'
+    );
+    expect(artifact.guardrails.autoPublish).toBe(false);
+    expect(artifact.recommendedReviewPath).toContain(
+      'codex/jov-3739-investor-note-review'
+    );
   });
 
   it('rejects invalid classifications and empty input sets', () => {
@@ -98,14 +174,15 @@ OBJECTION | strategy | critical | The buyer is unclear.`)
     );
     expect(() =>
       buildInvestorNoteReviewArtifact([
-        note('A', '2026-07-11', [
-          {
-            kind: 'question',
-            text: 'Is this valid?',
-            gapClassification: 'made-up',
-            severity: 'high',
-          },
-        ]),
+        note({
+          id: 'conversation-a',
+          signals: [
+            {
+              ...tractionSignal,
+              gapClassification: 'made-up',
+            },
+          ],
+        }),
       ])
     ).toThrow();
   });

--- a/apps/web/tests/unit/investors/note-ingestion.test.ts
+++ b/apps/web/tests/unit/investors/note-ingestion.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildInvestorNoteReviewArtifact,
+  parseAnnotatedTranscript,
+} from '@/lib/investors/note-ingestion';
+
+function note(
+  label: string,
+  capturedAt: string,
+  signals: readonly Record<string, unknown>[]
+) {
+  return {
+    source: { kind: 'local-note', label, capturedAt },
+    transcript: 'Synthetic test transcript.',
+    signals,
+  };
+}
+
+describe('investor note ingestion', () => {
+  it('extracts only explicitly annotated text lines', () => {
+    expect(
+      parseAnnotatedTranscript(`Unstructured context is not interpreted.
+QUESTION | evidence | high | What traction is proven?
+OBJECTION | strategy | critical | The buyer is unclear.`)
+    ).toEqual([
+      {
+        kind: 'question',
+        text: 'What traction is proven?',
+        gapClassification: 'evidence',
+        severity: 'high',
+        line: 2,
+      },
+      {
+        kind: 'objection',
+        text: 'The buyer is unclear.',
+        gapClassification: 'strategy',
+        severity: 'critical',
+        line: 3,
+      },
+    ]);
+  });
+
+  it('merges duplicates and keeps the highest observed severity', () => {
+    const artifact = buildInvestorNoteReviewArtifact([
+      note('A', '2026-07-10', [
+        {
+          kind: 'question',
+          text: 'What traction is proven?',
+          gapClassification: 'evidence',
+          severity: 'medium',
+        },
+      ]),
+      note('B', '2026-07-11', [
+        {
+          kind: 'question',
+          text: 'What traction is proven!',
+          gapClassification: 'evidence',
+          severity: 'critical',
+        },
+      ]),
+    ]);
+
+    expect(artifact.asOf).toBe('2026-07-11');
+    expect(artifact.candidates).toHaveLength(1);
+    expect(artifact.candidates[0]).toMatchObject({
+      severity: 'critical',
+      occurrenceCount: 2,
+      frequency: 'common',
+      gapClassification: 'evidence',
+    });
+    expect(artifact.candidates[0]?.sources).toHaveLength(2);
+  });
+
+  it('classifies gaps and forbids automatic publishing', () => {
+    const artifact = buildInvestorNoteReviewArtifact([
+      note('A', '2026-07-11', [
+        {
+          kind: 'objection',
+          text: 'The investor fit is unclear.',
+          gapClassification: 'investor-fit',
+          severity: 'high',
+        },
+      ]),
+    ]);
+
+    expect(artifact.classificationCounts['investor-fit']).toBe(1);
+    expect(artifact.reviewStatus).toBe('manual-review-required');
+    expect(artifact.guardrails).toEqual({
+      autoPublish: false,
+      protectedFields: ['claims', 'numbers', 'ask', 'positioning'],
+    });
+    expect(artifact.recommendedReviewPath).toContain('dedicated PR');
+  });
+
+  it('rejects invalid classifications and empty input sets', () => {
+    expect(() => buildInvestorNoteReviewArtifact([])).toThrow(
+      'At least one investor note is required.'
+    );
+    expect(() =>
+      buildInvestorNoteReviewArtifact([
+        note('A', '2026-07-11', [
+          {
+            kind: 'question',
+            text: 'Is this valid?',
+            gapClassification: 'made-up',
+            severity: 'high',
+          },
+        ]),
+      ])
+    ).toThrow();
+  });
+});

--- a/apps/web/tests/unit/investors/note-ingestion.test.ts
+++ b/apps/web/tests/unit/investors/note-ingestion.test.ts
@@ -69,6 +69,7 @@ OBJECTION | strategy | critical | The buyer is unclear.`)
     const forward = buildInvestorNoteReviewArtifact([first, second]);
     const reverse = buildInvestorNoteReviewArtifact([second, first]);
     expect(reverse).toEqual(forward);
+    expect(forward.asOf).toBe('2026-07-11');
     expect(forward.candidates[0]).toMatchObject({
       text: 'What traction is proven!',
       gapClassifications: ['communication', 'evidence'],

--- a/docs/fundraising/investor-note-ingestion.md
+++ b/docs/fundraising/investor-note-ingestion.md
@@ -1,0 +1,42 @@
+# Investor Note Ingestion
+
+This workflow converts local investor-note or transcript exports into a deterministic review artifact. It does not connect to Granola, call an LLM, or publish fundraising content.
+
+## Input Boundary
+
+Use one or more JSON files shaped like the synthetic fixtures in `apps/web/tests/fixtures/investors/`, or a plain-text file with explicit manual annotations:
+
+```text
+QUESTION | evidence | high | What customer traction is proven?
+OBJECTION | strategy | critical | The initial buyer is unclear.
+```
+
+The four allowed gap classes are `communication`, `evidence`, `strategy`, and `investor-fit`. Severity is `medium`, `high`, or `critical`. Unannotated transcript text remains source context and is never interpreted as a claim.
+
+A Granola export may use `source.kind: "granola-export"`, but it must already exist as a local file. Jovie has no Granola API integration or credentials.
+
+## Run
+
+From `apps/web`:
+
+```bash
+pnpm exec tsx scripts/ingest-investor-note.ts \
+  tests/fixtures/investors/note-a.json \
+  tests/fixtures/investors/note-b.json \
+  --out=/tmp/investor-note-review.json
+```
+
+For plain text, also provide the source date:
+
+```bash
+pnpm exec tsx scripts/ingest-investor-note.ts exported-note.txt \
+  --captured-at=2026-07-11 \
+  --out=/tmp/investor-note-review.json
+```
+
+## Review Contract
+
+The artifact normalizes and merges duplicate questions or objections, keeps the highest observed severity, scores frequency from occurrence count, and summarizes gaps by classification. Each candidate retains source labels and dates.
+
+Every artifact is `manual-review-required` and declares `autoPublish: false`. Claims, numbers, the ask, and positioning are protected fields. The next step is a dedicated human-reviewed PR that updates only supported registry entries; transcript text must never be copied into investor-facing claims without separate provenance review.
+

--- a/docs/fundraising/investor-note-ingestion.md
+++ b/docs/fundraising/investor-note-ingestion.md
@@ -15,6 +15,8 @@ The four allowed gap classes are `communication`, `evidence`, `strategy`, and `i
 
 A Granola export may use `source.kind: "granola-export"`, but it must already exist as a local file. Jovie has no Granola API integration or credentials.
 
+Every source requires a stable `source.id`. Reusing an ID is rejected so repeated imports cannot inflate frequency. Each artifact source reference includes that ID and a SHA-256 hash of the transcript. JSON signals normally omit `line`; when a line is supplied, it must point to an exact matching annotated transcript line.
+
 ## Run
 
 From `apps/web`:
@@ -30,13 +32,27 @@ For plain text, also provide the source date:
 
 ```bash
 pnpm exec tsx scripts/ingest-investor-note.ts exported-note.txt \
+  --source-id=conversation-2026-07-11-example \
   --captured-at=2026-07-11 \
   --out=/tmp/investor-note-review.json
 ```
 
 ## Review Contract
 
-The artifact normalizes and merges duplicate questions or objections, keeps the highest observed severity, scores frequency from occurrence count, and summarizes gaps by classification. Each candidate retains source labels and dates.
+The artifact normalizes Unicode with NFKC and merges duplicate questions or objections. It preserves every observed gap classification, chooses canonical text deterministically, keeps the highest observed severity, and sorts and deduplicates provenance. `occurrenceCount` counts mentions; frequency uses distinct conversation IDs so repetition inside one note cannot inflate it.
 
-Every artifact is `manual-review-required` and declares `autoPublish: false`. Claims, numbers, the ask, and positioning are protected fields. The next step is a dedicated human-reviewed PR that updates only supported registry entries; transcript text must never be copied into investor-facing claims without separate provenance review.
+The CLI refuses `.env*`, `.npmrc`, `.git`, `node_modules`, and the canonical fundraising registry as input or output. Output cannot equal any input. Files are created exclusively by default; `--overwrite` is explicit and never bypasses protected-path or input-collision checks. CLI stdout and stderr are JSON.
 
+Every artifact is `manual-review-required` and declares `autoPublish: false`. Claims, numbers, the ask, and positioning are protected fields. Candidates include deterministic next actions and proposed review targets for the portal, deck, outreach brief, or registry.
+
+To perform the manual review, create a dedicated branch and draft PR:
+
+```bash
+git switch -c codex/jov-3739-investor-note-review
+# Review the artifact; edit only source-backed risks or communication.
+pnpm --filter @jovie/web exec vitest run tests/unit/investors/fundraising-registry.test.ts
+gh pr create --draft --base codex/jov-3739-investor-note-ingestion \
+  --title "docs(investors): review investor note signals"
+```
+
+The command is deliberately manual. The ingestion script never creates branches, edits the registry, opens PRs, or copies transcript text into investor-facing claims.


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3739 -->

## Summary

Adds a deterministic local investor-note ingestion workflow stacked on the investor-portal proof PR. It accepts validated JSON exports or explicitly annotated plain-text notes, merges duplicate questions and objections, keeps the highest observed severity, scores frequency, classifies communication/evidence/strategy/investor-fit gaps, and emits a source-backed review artifact.

The workflow does not connect to Granola or invent API credentials. `granola-export` means an existing local export only. Unannotated transcript prose is retained as context but never interpreted as a signal.

## Safety boundary

- Every artifact is `manual-review-required` with `autoPublish: false`.
- Claims, numbers, the ask, and positioning are protected fields.
- Output recommends a dedicated reviewed PR for supported risk-registry changes.
- Transcript text must not become an investor-facing claim without separate provenance review.

## Files

- Typed parser, validator, duplicate merger, scoring, and artifact builder.
- Local CLI supporting JSON and annotated text files.
- Two synthetic fixtures with no real investor or deal information.
- Focused deterministic tests and operator documentation.

## Tests

- Note-ingestion Vitest: 4/4 passed.
- Web typecheck: passed.
- Biome and `git diff --check`: passed.
- Fixture CLI run produced the expected three review candidates, including one merged duplicate with critical severity and common frequency.
- Commit and push gates passed.

## Stack

Base: `codex/jov-3538-pitch-proof` / https://github.com/JovieInc/Jovie/pull/14009

## Follow-ups

- **JOV-3739:** extend the review loop only when real exported-note usage proves the next adapter is needed.
- **JOV-2016:** broader fundraising department agent remains separate.

Generated with OpenAI Codex.