### PR TITLE
feat(security): rate-limit public claim-token route

### DIFF
--- a/apps/web/app/claim/[token]/route.ts
+++ b/apps/web/app/claim/[token]/route.ts
@@ -6,6 +6,12 @@ import {
   markLeadClaimPageViewedFromToken,
   setLeadAttributionCookieFromToken,
 } from '@/lib/leads/funnel-events';
+import {
+  allowIfRateLimitBackendDegraded,
+  claimTokenAccessLimiter,
+  createRateLimitHeaders,
+  getClientIP,
+} from '@/lib/rate-limit';
 import { hashClaimToken } from '@/lib/security/claim-token';
 import { getProfileByUsername } from '@/lib/services/profile';
 import {
@@ -29,6 +35,22 @@ export async function GET(
 
   if (!token) {
     return NextResponse.redirect(buildAbsoluteUrl(request, '/'));
+  }
+
+  // Throttle this unauthenticated entry before any DB work: each hit runs
+  // several profile/lead reads plus lead/cookie writes. A degraded (Redis-down)
+  // backend is treated as advisory so an outage never blocks a legitimate
+  // creator following their claim link.
+  const clientIp = getClientIP(request);
+  const rateLimit = allowIfRateLimitBackendDegraded(
+    await claimTokenAccessLimiter.limit(clientIp),
+    { route: '/claim/[token]' }
+  );
+  if (!rateLimit.success) {
+    return new NextResponse('Too many requests', {
+      status: 429,
+      headers: createRateLimitHeaders(rateLimit),
+    });
   }
 
   const username = await lookupUsernameByClaimToken(token);

--- a/apps/web/lib/rate-limit/config.ts
+++ b/apps/web/lib/rate-limit/config.ts
@@ -322,6 +322,20 @@ export const RATE_LIMITERS = {
     analytics: false,
   } satisfies RateLimitConfig,
 
+  /**
+   * Claim-token link follow: 20 requests per minute per IP.
+   * Unauthenticated public entry (`/claim/[token]`) that runs several DB reads
+   * plus lead/cookie writes per hit — throttle abuse/DoS while staying generous
+   * for real humans (multi-tab / refresh).
+   */
+  claimTokenAccess: {
+    name: 'Claim Token Access',
+    limit: 20,
+    window: '1 m',
+    prefix: 'public:claim-token',
+    analytics: false,
+  } satisfies RateLimitConfig,
+
   // ---------------------------------------------------------------------------
   // Health & Monitoring
   // ---------------------------------------------------------------------------

--- a/apps/web/lib/rate-limit/index.ts
+++ b/apps/web/lib/rate-limit/index.ts
@@ -83,6 +83,7 @@ export {
   checkTrackingRateLimit,
   checkVerificationRequestRateLimit,
   checkWrapLinkRateLimit,
+  claimTokenAccessLimiter,
   dashboardLinksLimiter,
   deployPromoteLimiter,
   dspDiscoveryLimiter,

--- a/apps/web/lib/rate-limit/limiters.ts
+++ b/apps/web/lib/rate-limit/limiters.ts
@@ -256,6 +256,20 @@ export const publicProfileLimiter = createRateLimiter(
 );
 
 /**
+ * Rate limiter for the public claim-token entry route (`/claim/[token]`)
+ * Limit: 20 requests per minute per IP. Durable (Redis) so the throttle holds
+ * across serverless instances; callers treat a degraded backend as advisory
+ * (see allowIfRateLimitBackendDegraded) so a Redis outage never blocks a
+ * legitimate creator following their claim link.
+ */
+export const claimTokenAccessLimiter = createRateLimiter(
+  RATE_LIMITERS.claimTokenAccess,
+  {
+    requireRedis: true,
+  }
+);
+
+/**
  * Rate limiter for public click endpoint
  * Limit: 50 requests per minute per IP
  */
@@ -1065,6 +1079,7 @@ export function getAllLimiters(): Record<string, RateLimiter> {
     trackingIpClicks: trackingIpClicksLimiter,
     trackingIpVisits: trackingIpVisitsLimiter,
     publicProfile: publicProfileLimiter,
+    claimTokenAccess: claimTokenAccessLimiter,
     publicClick: publicClickLimiter,
     publicVisit: publicVisitLimiter,
     health: healthLimiter,

--- a/apps/web/tests/unit/app/claim-token-route.test.ts
+++ b/apps/web/tests/unit/app/claim-token-route.test.ts
@@ -11,6 +11,8 @@ const {
   mockMarkLeadClaimPageViewedFromToken,
   mockSetLeadAttributionCookieFromToken,
   mockWritePendingClaimContext,
+  mockClaimLimit,
+  mockGetClientIP,
 } = vi.hoisted(() => ({
   mockClearLeadAttributionCookie: vi.fn(),
   mockGetProfileByUsername: vi.fn(),
@@ -21,6 +23,26 @@ const {
   mockMarkLeadClaimPageViewedFromToken: vi.fn(),
   mockSetLeadAttributionCookieFromToken: vi.fn(),
   mockWritePendingClaimContext: vi.fn(),
+  mockClaimLimit: vi.fn(),
+  mockGetClientIP: vi.fn(),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  claimTokenAccessLimiter: { limit: mockClaimLimit },
+  getClientIP: mockGetClientIP,
+  createRateLimitHeaders: (result: { readonly reset?: number }) => ({
+    'retry-after': String(result.reset ?? 60),
+  }),
+  // Faithful mirror of the real helper's contract: a degraded/unavailable
+  // backend downgrades a hard block to an advisory allow (fail-open).
+  allowIfRateLimitBackendDegraded: (result: {
+    readonly success: boolean;
+    readonly degraded?: boolean;
+    readonly unavailable?: boolean;
+  }) =>
+    !result.success && (result.degraded === true || result.unavailable === true)
+      ? { ...result, success: true }
+      : result,
 }));
 
 vi.mock('@/lib/claim/context', () => ({
@@ -52,6 +74,13 @@ import { GET } from '../../../app/claim/[token]/route';
 describe('Claim token route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetClientIP.mockReturnValue('203.0.113.7');
+    mockClaimLimit.mockResolvedValue({
+      success: true,
+      limit: 20,
+      remaining: 19,
+      reset: 60,
+    });
     mockLookupLeadByClaimToken.mockResolvedValue(null);
     mockHashClaimToken.mockResolvedValue('hashed-token');
     mockGetProfileByUsername.mockResolvedValue({
@@ -155,5 +184,67 @@ describe('Claim token route', () => {
     expect(response.headers.get('location')).toBe('http://localhost/');
     expect(mockClearLeadAttributionCookie).toHaveBeenCalledTimes(1);
     expect(mockWritePendingClaimContext).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 without touching the database when the IP is over the limit', async () => {
+    mockClaimLimit.mockResolvedValue({
+      success: false,
+      limit: 20,
+      remaining: 0,
+      reset: 60,
+    });
+
+    const response = await GET(
+      new NextRequest('http://localhost/claim/valid-token'),
+      {
+        params: Promise.resolve({ token: 'valid-token' }),
+      }
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('retry-after')).toBe('60');
+    // Throttle short-circuits before any DB/lead/cookie work.
+    expect(mockLookupUsernameByClaimToken).not.toHaveBeenCalled();
+    expect(mockIsClaimTokenValid).not.toHaveBeenCalled();
+    expect(mockGetProfileByUsername).not.toHaveBeenCalled();
+    expect(mockLookupLeadByClaimToken).not.toHaveBeenCalled();
+    expect(mockSetLeadAttributionCookieFromToken).not.toHaveBeenCalled();
+    expect(mockWritePendingClaimContext).not.toHaveBeenCalled();
+  });
+
+  it('keys the limiter by the client IP', async () => {
+    mockLookupUsernameByClaimToken.mockResolvedValue('testartist');
+    mockIsClaimTokenValid.mockResolvedValue(true);
+
+    await GET(new NextRequest('http://localhost/claim/valid-token'), {
+      params: Promise.resolve({ token: 'valid-token' }),
+    });
+
+    expect(mockClaimLimit).toHaveBeenCalledWith('203.0.113.7');
+  });
+
+  it('fails open (proceeds) when the rate-limit backend is degraded', async () => {
+    mockClaimLimit.mockResolvedValue({
+      success: false,
+      degraded: true,
+      limit: 20,
+      remaining: 0,
+      reset: 60,
+    });
+    mockLookupUsernameByClaimToken.mockResolvedValue('testartist');
+    mockIsClaimTokenValid.mockResolvedValue(true);
+
+    const response = await GET(
+      new NextRequest('http://localhost/claim/valid-token'),
+      {
+        params: Promise.resolve({ token: 'valid-token' }),
+      }
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost/testartist?claim=1'
+    );
+    expect(mockWritePendingClaimContext).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/unit/lib/rate-limit/config.test.ts
+++ b/apps/web/tests/unit/lib/rate-limit/config.test.ts
@@ -148,6 +148,17 @@ describe('Rate Limit Config', () => {
         expect(RATE_LIMITERS.spotifyClaim.limit).toBeLessThanOrEqual(10);
         expect(RATE_LIMITERS.spotifyClaim.window).toContain('h');
       });
+
+      it('should throttle the public claim-token entry route per IP', () => {
+        // The unauthenticated /claim/[token] route runs several DB reads plus
+        // lead/cookie writes per hit — the throttle must not be silently dropped.
+        expect(RATE_LIMITERS.claimTokenAccess).toBeDefined();
+        expect(RATE_LIMITERS.claimTokenAccess.limit).toBe(20);
+        expect(RATE_LIMITERS.claimTokenAccess.window).toBe('1 m');
+        expect(RATE_LIMITERS.claimTokenAccess.prefix).toBe(
+          'public:claim-token'
+        );
+      });
     });
 
     describe('analytics configuration', () => {

--- a/apps/web/tests/unit/lib/rate-limit/limiters.test.ts
+++ b/apps/web/tests/unit/lib/rate-limit/limiters.test.ts
@@ -337,6 +337,7 @@ describe('limiters.ts', () => {
         'trackingIpClicks',
         'trackingIpVisits',
         'publicProfile',
+        'claimTokenAccess',
         'publicClick',
         'publicVisit',
         'health',


### PR DESCRIPTION
## Source
- No Linear issue — ad-hoc (Linear MCP unauthenticated this session). Iteration 1 of a "harden critical flows" loop.
- Sibling PR off `main` (kept separate from #13929, which owns the trial-lifecycle/claim-expiry concern — one PR = one concern).

## What
`GET /claim/[token]` is the **unauthenticated** entry handed to prospects in outreach ("claim your profile") links. Per hit it ran 4 sequential DB reads (`lookupUsernameByClaimToken`, `isClaimTokenValid`, `getProfileByUsername`, `lookupLeadByClaimToken`) + a token hash + 2 lead writes + cookie/context writes — with **no rate limiting**. That's a DoS/amplification surface on a trust-critical, auto-merge-blocked path.

This adds a durable, IP-keyed limiter checked **before any DB work**:
- New `claimTokenAccess` limiter — **20 req/min per IP** (generous for real humans, throttles abuse; tunable).
- Redis-backed via the existing `createRateLimiter` factory (`requireRedis: true`) — durable across serverless instances, no in-memory coordination (satisfies *Public/Webhook Coordination Must Be Durable*).
- **Fails open on a degraded backend**: wraps the result in `allowIfRateLimitBackendDegraded`, so a Redis outage downgrades the block to advisory and never locks out a legitimate creator following their claim link.

## Files
- `lib/rate-limit/config.ts` — `claimTokenAccess` config
- `lib/rate-limit/limiters.ts` — `claimTokenAccessLimiter` instance + registry entry
- `lib/rate-limit/index.ts` — export
- `app/claim/[token]/route.ts` — apply limiter before DB work

## Tests (bug-to-test: satisfied)
`tests/unit/app/claim-token-route.test.ts`:
- under-limit → proceeds to existing redirect
- over-limit → **429**, rate-limit headers, and **no** DB/lead/cookie calls (throttle short-circuits before DB)
- limiter keyed by client IP
- degraded backend → **fails open** (proceeds)

Plus config/registry guards (`config.test.ts`, `limiters.test.ts`) so the throttle can't be silently dropped.

Verification (local): focused vitest (87 passed), `typecheck` clean, `biome check`, `test:bug-to-test` satisfied.

## Cost Impact
None. Reuses the existing Upstash Redis limiter (one extra Redis op per claim-link hit, an already-throttled low-volume path). No new external services or cron.

## Follow-ups (subsequent loop iterations — to be filed in Linear on pickup)
`/p/[token]` share page (RSC, needs a different throttle mechanism); webhook signature branch coverage (heatmap #1 gap); proxy fail-open-on-error review; `activateTrial` error sentinel; brittle DB-error string matching; entitlements-registry coverage; public-profile DB query timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)