### PR TITLE
fix(ci): preserve Vercel artifact dependency closure

### DIFF
--- a/.github/scripts/package-vercel-build-output.sh
+++ b/.github/scripts/package-vercel-build-output.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_path="${1:-/tmp/vercel-build-output.tar.gz}"
+archive_path="${output_path%.gz}"
+closure_list="$(mktemp)"
+trap 'rm -f "$closure_list" "$archive_path"' EXIT
+
+node .github/scripts/vercel-artifact-closure.mjs verify
+node .github/scripts/vercel-artifact-closure.mjs list-null > "$closure_list"
+
+# Preserve the generated Vercel output as-is, then materialize every external
+# .next runtime path referenced by its .vc-config.json file maps. Dereferencing
+# only the appended closure prevents pnpm symlinks from dangling on the deploy
+# runner without duplicating all function output dependencies.
+tar -cf "$archive_path" .vercel/output
+tar --append --file "$archive_path" --dereference --null --files-from="$closure_list"
+gzip -f "$archive_path"
+
+tar -tzf "$output_path" .vercel/output >/dev/null
+echo "Packaged Vercel build output with generated runtime dependency closure"
+

--- a/.github/scripts/vercel-artifact-closure.mjs
+++ b/.github/scripts/vercel-artifact-closure.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+import { lstat, readdir, readFile, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const EXTERNAL_NEXT_PREFIX = 'apps/web/.next/';
+
+async function* walk(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(path);
+    } else if (entry.isFile() && entry.name === '.vc-config.json') {
+      yield path;
+    }
+  }
+}
+
+function assertSafeBuildPath(path) {
+  if (!path.startsWith(EXTERNAL_NEXT_PREFIX)) return false;
+  if (path.includes('\0') || path.split('/').includes('..')) {
+    throw new Error(`Unsafe Vercel build dependency path: ${path}`);
+  }
+  return true;
+}
+
+export async function collectVercelArtifactClosure(repoRoot) {
+  const functionsDir = resolve(repoRoot, '.vercel/output/functions');
+  const paths = new Set();
+
+  for await (const configPath of walk(functionsDir)) {
+    const config = JSON.parse(await readFile(configPath, 'utf8'));
+    for (const path of Object.keys(config.filePathMap ?? {})) {
+      if (assertSafeBuildPath(path)) paths.add(path);
+    }
+  }
+
+  return [...paths].sort();
+}
+
+export async function verifyVercelArtifactClosure(repoRoot) {
+  const paths = await collectVercelArtifactClosure(repoRoot);
+  const missing = [];
+
+  for (const path of paths) {
+    const absolutePath = resolve(repoRoot, path);
+    try {
+      await lstat(absolutePath);
+      // stat follows symlinks, so this also rejects a present-but-dangling entry.
+      await stat(absolutePath);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+      missing.push(path);
+    }
+  }
+
+  return { missing, paths };
+}
+
+async function main() {
+  const [command = 'verify', rootArg = process.cwd()] = process.argv.slice(2);
+  const repoRoot = resolve(rootArg);
+
+  if (command === 'list-null') {
+    const paths = await collectVercelArtifactClosure(repoRoot);
+    process.stdout.write(paths.map(path => `${path}\0`).join(''));
+    return;
+  }
+
+  if (command !== 'verify') {
+    throw new Error(`Unknown command: ${command}`);
+  }
+
+  const { missing, paths } = await verifyVercelArtifactClosure(repoRoot);
+  if (missing.length > 0) {
+    const preview = missing.slice(0, 10).join(', ');
+    console.error(
+      `::error title=Vercel artifact dependency closure missing::${missing.length} generated runtime path(s) are missing or dangling before deploy: ${preview}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Verified Vercel artifact dependency closure: ${paths.length} path(s)`
+  );
+}
+
+const isEntryPoint =
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isEntryPoint) {
+  main().catch(error => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1044,16 +1044,7 @@ jobs:
             sleep 10
             if [ $i -eq 3 ]; then exit 1; fi
           done
-          # Next/Vercel edge functions keep file-trace references to generated
-          # WASM/font chunks under .next/server/edge. Preserve those 16 MB of
-          # targets with the reusable output so a later runner can deploy the
-          # prebuilt artifact without the full ~384 MB .next archive.
-          test -d apps/web/.next/server/edge
-          tar -czf /tmp/vercel-build-output.tar.gz -C . \
-            .vercel/output \
-            apps/web/.next/server/edge
-          tar -tzf /tmp/vercel-build-output.tar.gz \
-            apps/web/.next/server/edge >/dev/null
+          bash .github/scripts/package-vercel-build-output.sh
           echo "vercel_artifact=true" >> "$GITHUB_OUTPUT"
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
@@ -4686,6 +4677,7 @@ jobs:
             mkdir -p .vercel
             tar -xzf /tmp/vercel-build-output.tar.gz -C .
             if [ -d .vercel/output ]; then
+              node .github/scripts/vercel-artifact-closure.mjs verify
               echo "restored=true" >> "$GITHUB_OUTPUT"
               echo "Restored .vercel/output from ci-build-public artifact (JOV-4087)"
             else

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -134,6 +134,15 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(deployScript).toContain('"${VERCEL_SCOPE_ARGS[@]}"');
   });
 
+  it('fails before upload when the restored Vercel artifact closure is incomplete', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const restoreStep = getStepBlock(
+      workflow,
+      'Restore vercel build output from artifact'
+    );
+    expect(restoreStep).toContain('vercel-artifact-closure.mjs verify');
+  });
+
   it('passes signup readiness keys into the staging preview runtime', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const deployStep = getStepBlock(

--- a/apps/web/tests/unit/ci/supply-chain-provenance.test.ts
+++ b/apps/web/tests/unit/ci/supply-chain-provenance.test.ts
@@ -97,8 +97,10 @@ describe('supply chain provenance guardrails', () => {
     expect(deployIndex).toBeGreaterThan(attestIndex);
 
     expect(buildStep).toContain('vercel build');
-    expect(packageStep).toContain('tar -czf /tmp/vercel-build-output.tar.gz');
-    expect(packageStep).toContain('.vercel/output');
+    expect(workflow).toContain(
+      'bash .github/scripts/package-vercel-build-output.sh'
+    );
+    expect(packageStep).toContain('/tmp/vercel-build-output.tar.gz');
     // Assert the action is pinned to a full 40-char commit SHA (the security
     // property this guardrail protects) without hardcoding a specific SHA, so
     // dependabot pin bumps don't deterministically redden the merge gate (#12425).

--- a/apps/web/tests/unit/ci/vercel-artifact-closure.test.ts
+++ b/apps/web/tests/unit/ci/vercel-artifact-closure.test.ts
@@ -1,0 +1,120 @@
+import { execFile } from 'node:child_process';
+import { copyFile, lstat, mkdir, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  collectVercelArtifactClosure,
+  verifyVercelArtifactClosure,
+} from '../../../../../.github/scripts/vercel-artifact-closure.mjs';
+
+const roots: string[] = [];
+const execFileAsync = promisify(execFile);
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
+
+async function fixture(filePathMap: Record<string, string>) {
+  const root = join(tmpdir(), `vercel-closure-${crypto.randomUUID()}`);
+  roots.push(root);
+  const functionDir = join(root, '.vercel/output/functions/example.func');
+  await mkdir(functionDir, { recursive: true });
+  await writeFile(
+    join(functionDir, '.vc-config.json'),
+    JSON.stringify({ filePathMap })
+  );
+  return root;
+}
+
+afterEach(async () => {
+  const { rm } = await import('node:fs/promises');
+  await Promise.all(
+    roots.splice(0).map(root => rm(root, { force: true, recursive: true }))
+  );
+});
+
+describe('Vercel artifact dependency closure', () => {
+  it('collects only generated .next paths referenced outside the Vercel output', async () => {
+    const root = await fixture({
+      'apps/web/.next/node_modules/runtime-hash': 'runtime-hash',
+      'apps/web/.next/server/chunks/123.js': '123.js',
+      'node_modules/package/index.js': 'index.js',
+    });
+
+    await expect(collectVercelArtifactClosure(root)).resolves.toEqual([
+      'apps/web/.next/node_modules/runtime-hash',
+      'apps/web/.next/server/chunks/123.js',
+    ]);
+  });
+
+  it('classifies missing and dangling generated dependencies before upload', async () => {
+    const missingPath = 'apps/web/.next/node_modules/missing-hash';
+    const danglingPath = 'apps/web/.next/node_modules/dangling-hash';
+    const root = await fixture({
+      [danglingPath]: danglingPath,
+      [missingPath]: missingPath,
+    });
+    const danglingAbsolute = join(root, danglingPath);
+    await mkdir(join(root, 'apps/web/.next/node_modules'), { recursive: true });
+    await symlink('does-not-exist', danglingAbsolute);
+
+    await expect(verifyVercelArtifactClosure(root)).resolves.toEqual({
+      missing: [danglingPath, missingPath],
+      paths: [danglingPath, missingPath],
+    });
+  });
+
+  it('accepts a complete generated runtime dependency closure', async () => {
+    const runtimePath = 'apps/web/.next/node_modules/runtime-hash';
+    const root = await fixture({ [runtimePath]: runtimePath });
+    const absolutePath = join(root, runtimePath);
+    await mkdir(absolutePath, { recursive: true });
+    await writeFile(join(absolutePath, 'index.js'), 'export {};');
+
+    await expect(verifyVercelArtifactClosure(root)).resolves.toEqual({
+      missing: [],
+      paths: [runtimePath],
+    });
+  });
+
+  it('packages symlinked runtime dependencies as self-contained files', async () => {
+    const runtimePath = 'apps/web/.next/node_modules/runtime-hash';
+    const root = await fixture({ [runtimePath]: runtimePath });
+    const scriptsDir = join(root, '.github/scripts');
+    const packageDir = join(root, 'runtime-package');
+    const archivePath = join(root, 'vercel-build-output.tar.gz');
+    const restoredRoot = join(root, 'restored');
+    await mkdir(scriptsDir, { recursive: true });
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(join(packageDir, 'index.js'), 'export {};');
+    await mkdir(join(root, 'apps/web/.next/node_modules'), { recursive: true });
+    await symlink('../../../../runtime-package', join(root, runtimePath));
+    await copyFile(
+      join(repoRoot, '.github/scripts/vercel-artifact-closure.mjs'),
+      join(scriptsDir, 'vercel-artifact-closure.mjs')
+    );
+    await copyFile(
+      join(repoRoot, '.github/scripts/package-vercel-build-output.sh'),
+      join(scriptsDir, 'package-vercel-build-output.sh')
+    );
+
+    await execFileAsync(
+      'bash',
+      ['.github/scripts/package-vercel-build-output.sh', archivePath],
+      { cwd: root }
+    );
+    await mkdir(restoredRoot);
+    await execFileAsync('tar', ['-xzf', archivePath, '-C', restoredRoot]);
+
+    const restoredRuntime = join(restoredRoot, runtimePath);
+    expect((await lstat(restoredRuntime)).isSymbolicLink()).toBe(false);
+    await expect(
+      lstat(join(restoredRuntime, 'index.js'))
+    ).resolves.toBeDefined();
+    await expect(verifyVercelArtifactClosure(restoredRoot)).resolves.toEqual({
+      missing: [],
+      paths: [runtimePath],
+    });
+  });
+});


### PR DESCRIPTION
## Root cause
Vercel's generated `.vc-config.json` file maps reference runtime paths outside `.vercel/output`. The reusable deploy artifact preserved only `.vercel/output` and `.next/server/edge`, so the staging runner received 4,944 missing generated paths. All prebuilt modes failed on the first missing hashed dependency (`apps/web/.next/node_modules/import-in-the-middle-9c133c96fa52e8eb`), then the source fallback hid the classification until the 10-minute timeout.

Classification: dependency/environment drift plus recurring Gem artifact-closure gap.

## Fix
- derive the exact external `.next` dependency closure from generated Vercel file maps
- fail with an actionable `Vercel artifact dependency closure missing` annotation when any path is absent or dangling
- materialize symlink targets into the reusable tarball so the deploy runner gets a self-contained closure
- verify the closure again immediately after artifact restore
- disable source fallback when staging has a prebuilt artifact, preventing a deterministic artifact failure from turning into a 10-minute opaque timeout

## Regression coverage
- validator collects only generated `.next` dependencies
- missing and dangling hashed dependencies fail closed
- complete closures pass
- deploy workflow requires post-restore validation and fail-closed prebuilt behavior

## Verification
- 6/6 focused closure + provenance tests pass
- targeted deploy workflow regression passes
- synthetic package/extract validates dereferenced symlink materialization
- historical run 29165623945 artifact reproduces 4,944 missing paths including the exact observed dependency
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Biome, shellcheck, and bash syntax checks pass

Draft pending live CI artifact/deploy evidence. No merge requested.
