### PR TITLE
fix(testing): fail closed in performance profiler

### DIFF
--- a/apps/web/scripts/test-performance-profiler.test.ts
+++ b/apps/web/scripts/test-performance-profiler.test.ts
@@ -1,0 +1,282 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type ProfilerDependencies,
+  TestPerformanceProfiler,
+  TestRunError,
+} from './test-performance-profiler';
+
+const workspaces: string[] = [];
+
+function commandResult(
+  overrides: Partial<ReturnType<ProfilerDependencies['runCommand']>> = {}
+): ReturnType<ProfilerDependencies['runCommand']> {
+  return {
+    pid: 123,
+    output: [null, '', ''],
+    stdout: '',
+    stderr: '',
+    status: 0,
+    signal: null,
+    ...overrides,
+  };
+}
+
+function createWorkspace(): string {
+  const cwd = mkdtempSync(join(tmpdir(), 'jovie-profiler-'));
+  mkdirSync(join(cwd, '.cache'));
+  workspaces.push(cwd);
+  return cwd;
+}
+
+function createProfiler(
+  cwd: string,
+  runCommand: ProfilerDependencies['runCommand']
+): TestPerformanceProfiler {
+  return new TestPerformanceProfiler({ cwd, runCommand });
+}
+
+function seedBaseline(cwd: string): void {
+  writeFileSync(join(cwd, 'test-performance-baseline.json'), 'last-valid');
+}
+
+function expectBaselinePreserved(cwd: string): void {
+  expect(
+    readFileSync(join(cwd, 'test-performance-baseline.json'), 'utf8')
+  ).toBe('last-valid');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const workspace of workspaces.splice(0)) {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+describe('TestPerformanceProfiler fail-closed behavior', () => {
+  it('reports a missing Vitest executable and preserves the baseline', async () => {
+    const cwd = createWorkspace();
+    seedBaseline(cwd);
+    const missing = Object.assign(new Error('spawnSync pnpm ENOENT'), {
+      code: 'ENOENT',
+    });
+    const profiler = createProfiler(cwd, () =>
+      commandResult({
+        error: missing,
+        output: [null, undefined, undefined],
+        stdout: undefined,
+        stderr: undefined,
+        status: null,
+      })
+    );
+
+    await expect(profiler.runPerformanceAnalysis()).rejects.toMatchObject({
+      name: 'TestRunError',
+      details: expect.stringContaining('ENOENT'),
+    });
+    expectBaselinePreserved(cwd);
+  });
+
+  it('reports timeout signal details and preserves the baseline', async () => {
+    const cwd = createWorkspace();
+    seedBaseline(cwd);
+    let invocation = 0;
+    const profiler = createProfiler(cwd, () => {
+      invocation += 1;
+      if (invocation === 1) {
+        return commandResult({ stdout: 'Duration 1.0s (setup 0.2s)' });
+      }
+      const timeout = Object.assign(new Error('spawnSync pnpm ETIMEDOUT'), {
+        code: 'ETIMEDOUT',
+      });
+      return commandResult({
+        error: timeout,
+        status: null,
+        signal: 'SIGTERM',
+        stderr: 'suite exceeded 420000ms',
+      });
+    });
+
+    await expect(profiler.runPerformanceAnalysis()).rejects.toEqual(
+      expect.objectContaining<TestRunError>({
+        details: expect.stringMatching(/signal=SIGTERM[\s\S]*ETIMEDOUT/),
+      })
+    );
+    expectBaselinePreserved(cwd);
+  });
+
+  it('rejects partial or zero timing output and preserves the baseline', async () => {
+    const cwd = createWorkspace();
+    seedBaseline(cwd);
+    let invocation = 0;
+    const profiler = createProfiler(cwd, () => {
+      invocation += 1;
+      if (invocation === 1) {
+        return commandResult({ stdout: 'Duration 1.0s (setup 0.2s)' });
+      }
+      writeFileSync(
+        join(cwd, '.cache/vitest-performance-results.json'),
+        JSON.stringify({ numTotalTests: 0, testResults: [] })
+      );
+      return commandResult({ stdout: 'Duration 4.2s (tests 0.0s)' });
+    });
+
+    await expect(profiler.runPerformanceAnalysis()).rejects.toMatchObject({
+      details: expect.stringContaining('testResults'),
+    });
+    expectBaselinePreserved(cwd);
+  });
+
+  it('writes a baseline for valid Vitest 4 output without collect or prepare', async () => {
+    const cwd = createWorkspace();
+    seedBaseline(cwd);
+    let invocation = 0;
+    const profiler = createProfiler(cwd, () => {
+      invocation += 1;
+      if (invocation === 1) {
+        return commandResult({ stdout: 'Duration 1.0s (setup 0.2s)' });
+      }
+      writeFileSync(
+        join(cwd, '.cache/vitest-performance-results.json'),
+        JSON.stringify({
+          numTotalTests: 1,
+          testResults: [
+            {
+              assertionResults: [
+                { title: 'works', duration: 12, status: 'passed' },
+              ],
+            },
+          ],
+        })
+      );
+      return commandResult({
+        stdout:
+          'Duration 2.0s (transform 100ms, setup 200ms, import 300ms, tests 400ms, environment 500ms)',
+      });
+    });
+
+    const metrics = await profiler.runPerformanceAnalysis();
+
+    expect(metrics.testResults).toHaveLength(1);
+    expect(metrics.setupTime).toBe(200);
+    const baseline = JSON.parse(
+      readFileSync(join(cwd, 'test-performance-baseline.json'), 'utf8')
+    );
+    expect(baseline.metrics.totalDuration).toBe(2000);
+    expect(baseline.metrics.collectTime).toBe(0);
+    expect(baseline.metrics.prepareTime).toBe(0);
+    expect(baseline.metrics.testResults[0].name).toBe('works');
+  });
+
+  it('resets metrics between runs and preserves the valid baseline on a later partial run', async () => {
+    const cwd = createWorkspace();
+    let invocation = 0;
+    const profiler = createProfiler(cwd, () => {
+      invocation += 1;
+      if (invocation === 1 || invocation === 3) {
+        return commandResult({ stdout: 'Duration 1.0s (setup 0.2s)' });
+      }
+      if (invocation === 2) {
+        writeFileSync(
+          join(cwd, '.cache/vitest-performance-results.json'),
+          JSON.stringify({
+            numTotalTests: 1,
+            testResults: [
+              {
+                assertionResults: [
+                  { title: 'first run', duration: 12, status: 'passed' },
+                ],
+              },
+            ],
+          })
+        );
+        return commandResult({
+          stdout:
+            'Duration 2.0s (transform 100ms, tests 400ms, environment 500ms)',
+        });
+      }
+      writeFileSync(
+        join(cwd, '.cache/vitest-performance-results.json'),
+        JSON.stringify({ numTotalTests: 0, testResults: [] })
+      );
+      return commandResult({ stdout: 'Duration 3.0s' });
+    });
+
+    const first = await profiler.runPerformanceAnalysis();
+    expect(first.testResults.map(result => result.name)).toEqual(['first run']);
+    const validBaseline = readFileSync(
+      join(cwd, 'test-performance-baseline.json'),
+      'utf8'
+    );
+
+    await expect(profiler.runPerformanceAnalysis()).rejects.toMatchObject({
+      details: expect.stringContaining('testResults'),
+    });
+    expect(
+      readFileSync(join(cwd, 'test-performance-baseline.json'), 'utf8')
+    ).toBe(validBaseline);
+  });
+
+  it.each([
+    {
+      name: 'missing JSON',
+      writeJson: (_cwd: string) => {},
+      expected: 'vitestJson',
+    },
+    {
+      name: 'malformed JSON',
+      writeJson: (cwd: string) =>
+        writeFileSync(
+          join(cwd, '.cache/vitest-performance-results.json'),
+          '{"numTotalTests":1,"testResults":'
+        ),
+      expected: 'vitestJson',
+    },
+    {
+      name: 'truncated assertion set',
+      writeJson: (cwd: string) =>
+        writeFileSync(
+          join(cwd, '.cache/vitest-performance-results.json'),
+          JSON.stringify({
+            numTotalTests: 2,
+            testResults: [
+              {
+                assertionResults: [
+                  { title: 'only one', duration: 10, status: 'passed' },
+                ],
+              },
+            ],
+          })
+        ),
+      expected: 'vitestJsonCount(declared=2, assertions=1)',
+    },
+  ])('rejects $name even when console timings look complete', async scenario => {
+    const cwd = createWorkspace();
+    seedBaseline(cwd);
+    let invocation = 0;
+    const profiler = createProfiler(cwd, () => {
+      invocation += 1;
+      if (invocation === 1) {
+        return commandResult({ stdout: 'Duration 1.0s (setup 0.2s)' });
+      }
+      scenario.writeJson(cwd);
+      return commandResult({
+        stdout:
+          '✓ tests/unit/example.test.ts (1 test) 20ms\nDuration 2.0s (transform 100ms, tests 400ms, environment 500ms)',
+      });
+    });
+
+    await expect(profiler.runPerformanceAnalysis()).rejects.toMatchObject({
+      details: expect.stringContaining(scenario.expected),
+    });
+    expectBaselinePreserved(cwd);
+  });
+});

--- a/apps/web/scripts/test-performance-profiler.ts
+++ b/apps/web/scripts/test-performance-profiler.ts
@@ -6,7 +6,7 @@
  * Generates detailed reports on setup time, individual test performance, and overall metrics.
  */
 
-import { execSync } from 'child_process';
+import { type SpawnSyncReturns, spawnSync } from 'child_process';
 import { readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
@@ -36,8 +36,53 @@ interface PerformanceMetrics {
   };
 }
 
-class TestPerformanceProfiler {
-  private results: PerformanceMetrics = {
+interface JsonEvidence {
+  valid: boolean;
+  declaredTests: number | null;
+  assertionCount: number;
+  reason: string;
+}
+
+type CommandResult = Omit<
+  SpawnSyncReturns<string>,
+  'output' | 'stdout' | 'stderr'
+> & {
+  output?: Array<string | null | undefined>;
+  stdout?: string | null;
+  stderr?: string | null;
+};
+
+interface ProfilerDependencies {
+  runCommand: (args: string[], timeout: number) => CommandResult;
+  cwd: string;
+}
+
+const defaultDependencies: ProfilerDependencies = {
+  runCommand: (args, timeout) =>
+    spawnSync('pnpm', args, {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      maxBuffer: 20 * 1024 * 1024,
+      timeout,
+    }),
+  cwd: process.cwd(),
+};
+
+function parseTiming(output: string, label: string): number | undefined {
+  const match = output.match(
+    new RegExp(`${label}\\s+(\\d+(?:\\.\\d+)?)(ms|s)`, 'i')
+  );
+  if (!match) return undefined;
+  const value = Number.parseFloat(match[1]);
+  return match[2].toLowerCase() === 's' ? value * 1000 : value;
+}
+
+function commandOutput(output: string | null | undefined): string {
+  return typeof output === 'string' ? output : '';
+}
+
+function createEmptyMetrics(): PerformanceMetrics {
+  return {
     totalDuration: 0,
     setupTime: 0,
     testExecutionTime: 0,
@@ -55,8 +100,36 @@ class TestPerformanceProfiler {
       median: 0,
     },
   };
+}
+
+function createEmptyJsonEvidence(): JsonEvidence {
+  return {
+    valid: false,
+    declaredTests: null,
+    assertionCount: 0,
+    reason: 'Vitest JSON output was not parsed.',
+  };
+}
+
+class TestRunError extends Error {
+  constructor(
+    message: string,
+    readonly details: string
+  ) {
+    super(message);
+    this.name = 'TestRunError';
+  }
+}
+
+class TestPerformanceProfiler {
+  constructor(private readonly dependencies = defaultDependencies) {}
+
+  private results: PerformanceMetrics = createEmptyMetrics();
+  private jsonEvidence: JsonEvidence = createEmptyJsonEvidence();
 
   async runPerformanceAnalysis(): Promise<PerformanceMetrics> {
+    this.results = createEmptyMetrics();
+    this.jsonEvidence = createEmptyJsonEvidence();
     console.log('🔍 Starting test performance analysis...\n');
 
     // Measure wall-clock setup time using a single probe test file.
@@ -77,9 +150,9 @@ class TestPerformanceProfiler {
     // already captured by the probe above so we don't overwrite it with the
     // misleading aggregate value).
     this.parseTestOutput(testOutput, jsonOutput, { skipSetupTime: true });
-    if (!this.results.totalDuration) {
-      this.results.totalDuration = durationMs;
-    }
+    if (!this.results.totalDuration) this.results.totalDuration = durationMs;
+
+    this.assertCredibleResults();
 
     // Calculate performance statistics
     this.calculatePerformanceStats();
@@ -105,38 +178,29 @@ class TestPerformanceProfiler {
     const probeFile = 'tests/unit/atoms/BrandLogo.test.tsx';
     console.log(`⚡ Measuring per-file setup time via probe: ${probeFile}`);
     try {
-      const output = execSync(
-        `pnpm vitest run --config vitest.config.mts ${probeFile} --reporter=verbose`,
-        {
-          encoding: 'utf8',
-          stdio: 'pipe',
-          timeout: 60000,
-        }
+      const result = this.dependencies.runCommand(
+        [
+          'exec',
+          'vitest',
+          'run',
+          '--config=vitest.config.mts',
+          probeFile,
+          '--reporter=verbose',
+        ],
+        60000
       );
-      const setupMatch = output.match(/setup\s+(\d+\.?\d*)s/);
-      if (setupMatch) {
-        this.results.setupTime = parseFloat(setupMatch[1]) * 1000;
+      this.assertCommandSucceeded(result, 'Setup probe');
+      const setupTime = parseTiming(commandOutput(result.stdout), 'setup');
+      if (setupTime) {
+        this.results.setupTime = setupTime;
         console.log(
           `   ✓ Per-file setup time: ${this.results.setupTime.toFixed(0)}ms`
         );
       }
     } catch (error: unknown) {
-      // Still try to parse stdout on non-zero exit (e.g. test warning)
-      if (error && typeof error === 'object' && 'stdout' in error) {
-        const stdout = (error as { stdout?: string | Buffer }).stdout;
-        const text = Buffer.isBuffer(stdout)
-          ? stdout.toString('utf8')
-          : (stdout as string) || '';
-        const setupMatch = text.match(/setup\s+(\d+\.?\d*)s/);
-        if (setupMatch) {
-          this.results.setupTime = parseFloat(setupMatch[1]) * 1000;
-          console.log(
-            `   ✓ Per-file setup time: ${this.results.setupTime.toFixed(0)}ms`
-          );
-          return;
-        }
-      }
-      console.warn('   ⚠ Could not measure probe setup time; defaulting to 0');
+      throw error instanceof TestRunError
+        ? error
+        : new TestRunError('Setup probe failed', String(error));
     }
   }
 
@@ -148,72 +212,59 @@ class TestPerformanceProfiler {
     console.log('⏱️  Running test suite with timing analysis...');
     const startTime = Date.now();
     const jsonOutputFile = '.cache/vitest-performance-results.json';
+    this.removeStaleJsonOutput(jsonOutputFile);
+    const result = this.dependencies.runCommand(
+      [
+        'run',
+        'test:fast',
+        '--',
+        '--reporter=default',
+        '--reporter=json',
+        `--outputFile=${jsonOutputFile}`,
+      ],
+      420000
+    );
+    this.assertCommandSucceeded(result, 'Test suite');
 
+    return {
+      output: commandOutput(result.stdout),
+      durationMs: Date.now() - startTime,
+      jsonOutput: this.readVitestJsonOutput(jsonOutputFile),
+    };
+  }
+
+  private assertCommandSucceeded(result: CommandResult, label: string): void {
+    if (result.status === 0 && !result.error && !result.signal) return;
+
+    const details = [
+      `exit=${result.status ?? 'none'}`,
+      `signal=${result.signal ?? 'none'}`,
+      result.error ? `error=${result.error.message}` : '',
+      commandOutput(result.stderr).trim()
+        ? `stderr=${commandOutput(result.stderr).trim()}`
+        : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+    console.error(`${label} failed:\n${details}`);
+    throw new TestRunError(`${label} did not complete successfully`, details);
+  }
+
+  private removeStaleJsonOutput(outputFile: string): void {
     try {
-      const output = execSync(
-        `pnpm test:fast --reporter=default --reporter=json --outputFile=${jsonOutputFile}`,
-        {
-          encoding: 'utf8',
-          stdio: 'pipe',
-          maxBuffer: 20 * 1024 * 1024, // allow verbose output without truncation
-          timeout: 420000, // 7 minutes timeout to align with budget ceilings
-        }
-      );
-
-      return {
-        output,
-        durationMs: Date.now() - startTime,
-        jsonOutput: this.readVitestJsonOutput(jsonOutputFile),
-      };
+      unlinkSync(join(this.dependencies.cwd, outputFile));
     } catch (error: unknown) {
-      // Tests might fail but we still want the timing data
-      if (error && typeof error === 'object') {
-        const errorObj = error as {
-          stdout?: string | Buffer;
-          output?: Array<string | Buffer | null>;
-        };
-        const stdout = errorObj.stdout
-          ? Buffer.isBuffer(errorObj.stdout)
-            ? errorObj.stdout.toString('utf8')
-            : errorObj.stdout
-          : '';
-
-        if (stdout) {
-          return {
-            output: stdout,
-            durationMs: Date.now() - startTime,
-            jsonOutput: this.readVitestJsonOutput(jsonOutputFile),
-          };
-        }
-
-        if (Array.isArray(errorObj.output)) {
-          const output = errorObj.output
-            .filter(Boolean)
-            .map(chunk =>
-              Buffer.isBuffer(chunk)
-                ? chunk.toString('utf8')
-                : (chunk as string)
-            )
-            .join('');
-          return {
-            output,
-            durationMs: Date.now() - startTime,
-            jsonOutput: this.readVitestJsonOutput(jsonOutputFile),
-          };
-        }
-      }
-      return {
-        output: '',
-        durationMs: Date.now() - startTime,
-        jsonOutput: this.readVitestJsonOutput(jsonOutputFile),
-      };
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
     }
   }
 
   private readVitestJsonOutput(outputFile: string): string {
     try {
-      const content = readFileSync(join(process.cwd(), outputFile), 'utf8');
-      unlinkSync(join(process.cwd(), outputFile));
+      const content = readFileSync(
+        join(this.dependencies.cwd, outputFile),
+        'utf8'
+      );
+      unlinkSync(join(this.dependencies.cwd, outputFile));
       return content;
     } catch {
       return '';
@@ -226,44 +277,26 @@ class TestPerformanceProfiler {
     options: { skipSetupTime?: boolean } = {}
   ): void {
     // Extract overall timing information
-    const durationMatch = output.match(/Duration\s+(\d+\.?\d*)s/);
-    if (durationMatch) {
-      this.results.totalDuration = parseFloat(durationMatch[1]) * 1000; // Convert to ms
-    }
+    this.results.totalDuration =
+      parseTiming(output, 'Duration') ?? this.results.totalDuration;
 
     // setupTime is measured separately by measureProbeSetupTime() when
     // skipSetupTime is true, so we skip the misleading aggregate value here.
     if (!options.skipSetupTime) {
-      const setupMatch = output.match(/setup\s+(\d+\.?\d*)s/);
-      if (setupMatch) {
-        this.results.setupTime = parseFloat(setupMatch[1]) * 1000;
-      }
+      this.results.setupTime =
+        parseTiming(output, 'setup') ?? this.results.setupTime;
     }
 
-    const testsMatch = output.match(/tests\s+(\d+\.?\d*)s/);
-    if (testsMatch) {
-      this.results.testExecutionTime = parseFloat(testsMatch[1]) * 1000;
-    }
-
-    const environmentMatch = output.match(/environment\s+(\d+\.?\d*)s/);
-    if (environmentMatch) {
-      this.results.environmentTime = parseFloat(environmentMatch[1]) * 1000;
-    }
-
-    const transformMatch = output.match(/transform\s+(\d+\.?\d*)s/);
-    if (transformMatch) {
-      this.results.transformTime = parseFloat(transformMatch[1]) * 1000;
-    }
-
-    const collectMatch = output.match(/collect\s+(\d+\.?\d*)s/);
-    if (collectMatch) {
-      this.results.collectTime = parseFloat(collectMatch[1]) * 1000;
-    }
-
-    const prepareMatch = output.match(/prepare\s+(\d+\.?\d*)s/);
-    if (prepareMatch) {
-      this.results.prepareTime = parseFloat(prepareMatch[1]) * 1000;
-    }
+    this.results.testExecutionTime =
+      parseTiming(output, 'tests') ?? this.results.testExecutionTime;
+    this.results.environmentTime =
+      parseTiming(output, 'environment') ?? this.results.environmentTime;
+    this.results.transformTime =
+      parseTiming(output, 'transform') ?? this.results.transformTime;
+    this.results.collectTime =
+      parseTiming(output, 'collect') ?? this.results.collectTime;
+    this.results.prepareTime =
+      parseTiming(output, 'prepare') ?? this.results.prepareTime;
 
     if (jsonOutput) {
       this.parseVitestJsonOutput(jsonOutput);
@@ -304,6 +337,7 @@ class TestPerformanceProfiler {
   private parseVitestJsonOutput(jsonOutput: string): void {
     try {
       const parsed = JSON.parse(jsonOutput) as {
+        numTotalTests?: number;
         testResults?: Array<{
           assertionResults?: Array<{
             ancestorTitles?: string[];
@@ -317,6 +351,16 @@ class TestPerformanceProfiler {
       const assertionResults =
         parsed.testResults?.flatMap(suite => suite.assertionResults ?? []) ??
         [];
+
+      this.jsonEvidence = {
+        valid: true,
+        declaredTests:
+          typeof parsed.numTotalTests === 'number'
+            ? parsed.numTotalTests
+            : null,
+        assertionCount: assertionResults.length,
+        reason: '',
+      };
 
       this.results.testResults.push(
         ...assertionResults
@@ -336,7 +380,13 @@ class TestPerformanceProfiler {
               | 'skipped',
           }))
       );
-    } catch {
+    } catch (error: unknown) {
+      this.jsonEvidence = {
+        valid: false,
+        declaredTests: null,
+        assertionCount: 0,
+        reason: `Vitest JSON is missing or malformed: ${String(error)}`,
+      };
       // Fallback parsing from console output is still available when JSON parsing fails.
     }
   }
@@ -364,6 +414,45 @@ class TestPerformanceProfiler {
     this.results.slowTests = this.results.testResults
       .filter(test => test.duration > 200)
       .sort((a, b) => b.duration - a.duration);
+  }
+
+  private assertCredibleResults(): void {
+    const requiredTimings: Array<[string, number]> = [
+      ['totalDuration', this.results.totalDuration],
+      ['setupTime', this.results.setupTime],
+      ['testExecutionTime', this.results.testExecutionTime],
+      ['environmentTime', this.results.environmentTime],
+      ['transformTime', this.results.transformTime],
+    ];
+    const invalid = requiredTimings
+      .filter(([, value]) => !Number.isFinite(value) || value <= 0)
+      .map(([name]) => name);
+
+    for (const [name, value] of [
+      ['collectTime', this.results.collectTime],
+      ['prepareTime', this.results.prepareTime],
+    ] as Array<[string, number]>) {
+      if (!Number.isFinite(value) || value < 0) invalid.push(name);
+    }
+
+    if (this.results.testResults.length === 0) invalid.push('testResults');
+    if (!this.jsonEvidence.valid) {
+      invalid.push('vitestJson');
+    } else if (
+      this.jsonEvidence.declaredTests === null ||
+      this.jsonEvidence.declaredTests <= 0 ||
+      this.jsonEvidence.assertionCount !== this.jsonEvidence.declaredTests
+    ) {
+      invalid.push(
+        `vitestJsonCount(declared=${this.jsonEvidence.declaredTests ?? 'missing'}, assertions=${this.jsonEvidence.assertionCount})`
+      );
+    }
+    if (invalid.length > 0) {
+      throw new TestRunError(
+        'Profiler output is incomplete; baseline was not updated',
+        `invalid or empty fields: ${invalid.join(', ')}${this.jsonEvidence.reason ? `; ${this.jsonEvidence.reason}` : ''}`
+      );
+    }
   }
 
   private generateReport(): void {
@@ -477,7 +566,7 @@ class TestPerformanceProfiler {
     };
 
     writeFileSync(
-      join(process.cwd(), 'test-performance-baseline.json'),
+      join(this.dependencies.cwd, 'test-performance-baseline.json'),
       JSON.stringify(baseline, null, 2)
     );
 
@@ -490,7 +579,17 @@ class TestPerformanceProfiler {
 // Run the profiler if called directly
 if (require.main === module) {
   const profiler = new TestPerformanceProfiler();
-  profiler.runPerformanceAnalysis().catch(console.error);
+  profiler.runPerformanceAnalysis().catch((error: unknown) => {
+    const details =
+      error instanceof TestRunError ? error.details : String(error);
+    console.error(`Test performance profiling failed: ${details}`);
+    process.exitCode = 1;
+  });
 }
 
-export { type PerformanceMetrics, TestPerformanceProfiler };
+export {
+  type PerformanceMetrics,
+  type ProfilerDependencies,
+  TestPerformanceProfiler,
+  TestRunError,
+};


### PR DESCRIPTION
## Summary
- run Vitest through argument-safe process invocations and preserve exit/signal/timeout diagnostics
- normalize nullable spawnSync output and reset all metrics/results on every invocation
- require valid Vitest JSON before writing a baseline; console parsing remains diagnostic only
- verify `numTotalTests` is positive and exactly matches parsed assertion records, rejecting missing, malformed, or truncated JSON
- reject empty/partial timing output and preserve the last valid baseline
- parse mixed seconds/milliseconds while allowing Vitest 4 to omit collect/prepare

## Regression evidence
- real ENOENT-shaped undefined stdout/stderr retains diagnostics
- reused profiler instance cannot inherit prior-run metrics or overwrite its valid baseline after a partial run
- complete-looking default reporter output with missing JSON rejects
- malformed JSON rejects
- syntactically valid truncated JSON (`numTotalTests=2`, one assertion) rejects
- timeout, zero/partial metrics, and valid Vitest 4 output remain covered

## Verification
- focused profiler suite: 8/8 passed in 3.68s under Node 22
- targeted Biome and web typecheck passed
- pre-commit and pre-push web checks passed

Ad-hoc implementation during current Linear intake pause.