### PR TITLE
feat(investors): guard note review proposals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ apps/extension/
 
 # marketing architecture loop state (JOV loop, 2026-07-06)
 .context/marketing-architecture/
+
+# Local fundraising review artifacts may contain source transcripts.
+.artifacts/

--- a/apps/web/lib/investors/investor-review-proposal.ts
+++ b/apps/web/lib/investors/investor-review-proposal.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { investorNotePriorArtifactSchema } from '@/lib/investors/note-ingestion';
+import {
+  buildInvestorNoteReviewArtifact,
+  inputsFromPriorArtifact,
+  investorNotePriorArtifactSchema,
+} from '@/lib/investors/note-ingestion';
 
 const protectedFieldSchema = z.enum([
   'claims',
@@ -54,25 +58,19 @@ export function renderInvestorReviewProposal(
   readonly markdown: string;
 } {
   const proposal = investorReviewProposalSchema.parse(rawProposal);
-  const artifact = investorNotePriorArtifactSchema
-    .and(
-      z.object({
-        candidates: z.array(
-          z.object({
-            key: z.string(),
-            proposedReviewTargets: z.array(z.string()),
-            sources: z.array(
-              z.object({
-                sourceId: z.string(),
-                transcriptSha256: z.string(),
-                line: z.number().int().positive().optional(),
-              })
-            ),
-          })
-        ),
-      })
-    )
+  const supplied = investorNotePriorArtifactSchema
+    .and(z.object({ candidates: z.array(z.unknown()) }))
     .parse(rawArtifact);
+  const artifact = buildInvestorNoteReviewArtifact(
+    inputsFromPriorArtifact(supplied)
+  );
+  if (
+    JSON.stringify(supplied.candidates) !== JSON.stringify(artifact.candidates)
+  ) {
+    throw new Error(
+      'Supplied derived candidates do not match the canonical corpus.'
+    );
+  }
   const candidates = new Map(
     artifact.candidates.map(candidate => [candidate.key, candidate])
   );

--- a/apps/web/lib/investors/investor-review-proposal.ts
+++ b/apps/web/lib/investors/investor-review-proposal.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod';
+import { investorNotePriorArtifactSchema } from '@/lib/investors/note-ingestion';
+
+const protectedFieldSchema = z.enum([
+  'claims',
+  'numbers',
+  'ask',
+  'positioning',
+]);
+const targetSchema = z.enum([
+  'portal',
+  'deck',
+  'outreach-brief',
+  'fundraisingRegistry.claims',
+  'fundraisingRegistry.risks',
+]);
+
+export const investorReviewProposalSchema = z.object({
+  proposalVersion: z.literal('1.0.0'),
+  slug: z.string().regex(/^[a-z0-9][a-z0-9-]{2,63}$/u),
+  title: z.string().trim().min(1).max(120),
+  approvedCandidates: z
+    .array(
+      z.object({
+        key: z.string().min(1),
+        proposedCopy: z.string().trim().min(1).max(2_000),
+        action: z.string().trim().min(1).max(500),
+        target: targetSchema,
+        protectedFields: z.array(protectedFieldSchema),
+        evidence: z
+          .array(
+            z.object({
+              sourceId: z.string().min(1),
+              transcriptSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+              line: z.number().int().positive().optional(),
+            })
+          )
+          .min(1),
+      })
+    )
+    .min(1),
+});
+
+export type InvestorReviewProposal = z.infer<
+  typeof investorReviewProposalSchema
+>;
+
+export function renderInvestorReviewProposal(
+  rawProposal: unknown,
+  rawArtifact: unknown
+): {
+  readonly slug: string;
+  readonly title: string;
+  readonly markdown: string;
+} {
+  const proposal = investorReviewProposalSchema.parse(rawProposal);
+  const artifact = investorNotePriorArtifactSchema
+    .and(
+      z.object({
+        candidates: z.array(
+          z.object({
+            key: z.string(),
+            proposedReviewTargets: z.array(z.string()),
+            sources: z.array(
+              z.object({
+                sourceId: z.string(),
+                transcriptSha256: z.string(),
+                line: z.number().int().positive().optional(),
+              })
+            ),
+          })
+        ),
+      })
+    )
+    .parse(rawArtifact);
+  const candidates = new Map(
+    artifact.candidates.map(candidate => [candidate.key, candidate])
+  );
+
+  const sections = [...proposal.approvedCandidates]
+    .sort((left, right) => left.key.localeCompare(right.key))
+    .map(item => {
+      const candidate = candidates.get(item.key);
+      if (!candidate)
+        throw new Error(`Unknown approved candidate key: ${item.key}`);
+      if (!candidate.proposedReviewTargets.includes(item.target)) {
+        throw new Error(
+          `Target ${item.target} is not allowed for ${item.key}.`
+        );
+      }
+      for (const evidence of item.evidence) {
+        const matches = candidate.sources.some(
+          source =>
+            source.sourceId === evidence.sourceId &&
+            source.transcriptSha256 === evidence.transcriptSha256 &&
+            source.line === evidence.line
+        );
+        if (!matches)
+          throw new Error(`Evidence does not match candidate ${item.key}.`);
+      }
+      const flags =
+        item.protectedFields.length > 0
+          ? item.protectedFields.sort().join(', ')
+          : 'none';
+      const evidence = [...item.evidence]
+        .sort((left, right) => left.sourceId.localeCompare(right.sourceId))
+        .map(
+          ref =>
+            `- \`${ref.sourceId}\` / \`${ref.transcriptSha256}\`${ref.line ? ` / line ${ref.line}` : ''}`
+        )
+        .join('\n');
+      return `## ${item.key}\n\n- Target: \`${item.target}\`\n- Action: ${item.action}\n- Protected-field review: ${flags}\n\n### Proposed copy\n\n${item.proposedCopy}\n\n### Evidence\n\n${evidence}`;
+    });
+
+  return {
+    slug: proposal.slug,
+    title: proposal.title,
+    markdown: `# ${proposal.title}\n\nStatus: **manual review required**\n\nThis artifact proposes copy only. It does not modify or approve investor-facing claims, numbers, the ask, or positioning.\n\n${sections.join('\n\n')}\n`,
+  };
+}

--- a/apps/web/lib/investors/investor-review-publisher.ts
+++ b/apps/web/lib/investors/investor-review-publisher.ts
@@ -142,6 +142,11 @@ export async function publishInvestorReviewDraft(
           `${failure(push, 'Draft branch push failed.').message} Recoverable state: remote branch ${branch} points to different SHA ${observedOid}; it was retained.`
         );
       }
+      if (observed.status !== 0 && observed.status !== 2) {
+        throw new Error(
+          `${failure(push, 'Draft branch push failed.').message} Recoverable state: remote branch ${branch} ownership at local SHA ${localCommitSha} is indeterminate; verify the remote ref manually before retrying. ${observed.stderr.trim()}`
+        );
+      }
       throw failure(push, 'Draft branch push failed.');
     }
     const pushedRemote = run('git', [

--- a/apps/web/lib/investors/investor-review-publisher.ts
+++ b/apps/web/lib/investors/investor-review-publisher.ts
@@ -90,6 +90,8 @@ export async function publishInvestorReviewDraft(
   let remoteOwned = false;
   let prCreateFailed = false;
   let primaryError: Error | null = null;
+  let draftPrUrl: string | null = null;
+  const cleanupErrors: string[] = [];
   try {
     const add = run('git', [
       'worktree',
@@ -188,7 +190,7 @@ export async function publishInvestorReviewDraft(
       prCreateFailed = true;
       throw failure(pr, 'Draft PR creation failed.');
     }
-    return pr.stdout.trim();
+    draftPrUrl = pr.stdout.trim();
   } catch (error) {
     primaryError = error instanceof Error ? error : new Error(String(error));
     if (remoteOwned && prCreateFailed) {
@@ -246,9 +248,7 @@ export async function publishInvestorReviewDraft(
         );
       }
     }
-    throw primaryError;
   } finally {
-    const cleanupErrors: string[] = [];
     const remove = run('git', [
       'worktree',
       'remove',
@@ -274,11 +274,14 @@ export async function publishInvestorReviewDraft(
       if (deleteBranch.status !== 0)
         cleanupErrors.push(deleteBranch.stderr.trim());
     }
-    if (cleanupErrors.length > 0) {
-      const prefix = primaryError
-        ? `${primaryError.message} Recoverable state: local cleanup failed:`
-        : 'Draft created but local cleanup failed:';
-      throw new Error(`${prefix} ${cleanupErrors.join(' ')}`);
-    }
   }
+  if (cleanupErrors.length > 0) {
+    const prefix = primaryError
+      ? `${primaryError.message} Recoverable state: local cleanup failed:`
+      : 'Draft created but local cleanup failed:';
+    throw new Error(`${prefix} ${cleanupErrors.join(' ')}`);
+  }
+  if (primaryError) throw primaryError;
+  if (!draftPrUrl) throw new Error('Draft PR URL was not returned.');
+  return draftPrUrl;
 }

--- a/apps/web/lib/investors/investor-review-publisher.ts
+++ b/apps/web/lib/investors/investor-review-publisher.ts
@@ -22,6 +22,7 @@ interface PublishOptions {
   readonly branch: string;
   readonly base: string;
   readonly title: string;
+  readonly repository: string;
   readonly relativeOutput: string;
   readonly markdown: string;
 }
@@ -34,7 +35,15 @@ export async function publishInvestorReviewDraft(
   options: PublishOptions,
   dependencies: InvestorReviewPublisherDependencies
 ): Promise<string> {
-  const { repoRoot, branch, base, title, relativeOutput, markdown } = options;
+  const {
+    repoRoot,
+    branch,
+    base,
+    title,
+    repository,
+    relativeOutput,
+    markdown,
+  } = options;
   const run = (
     command: 'git' | 'gh',
     args: readonly string[],
@@ -77,7 +86,9 @@ export async function publishInvestorReviewDraft(
   }
 
   const temporaryWorktree = await dependencies.createTempDirectory();
-  let remoteCreated = false;
+  let localCommitSha: string | null = null;
+  let remoteOwned = false;
+  let prCreateFailed = false;
   let primaryError: Error | null = null;
   try {
     const add = run('git', [
@@ -103,18 +114,54 @@ export async function publishInvestorReviewDraft(
       const result = run('git', args, temporaryWorktree);
       if (result.status !== 0) throw failure(result, `git ${args[0]} failed.`);
     }
+    const revision = run('git', ['rev-parse', 'HEAD'], temporaryWorktree);
+    if (
+      revision.status !== 0 ||
+      !/^[a-f0-9]{40}$/u.test(revision.stdout.trim())
+    ) {
+      throw failure(revision, 'Could not record the proposal commit SHA.');
+    }
+    localCommitSha = revision.stdout.trim();
     const push = run(
       'git',
       ['push', '-u', 'origin', `${branch}:${branch}`],
       temporaryWorktree
     );
     if (push.status !== 0) {
-      remoteCreated =
-        run('git', ['ls-remote', '--exit-code', '--heads', 'origin', branch])
-          .status === 0;
+      const observed = run('git', [
+        'ls-remote',
+        '--exit-code',
+        '--heads',
+        'origin',
+        branch,
+      ]);
+      const observedOid = observed.stdout.trim().split(/\s+/u)[0];
+      remoteOwned = observed.status === 0 && observedOid === localCommitSha;
+      if (observed.status === 0 && observedOid !== localCommitSha) {
+        throw new Error(
+          `${failure(push, 'Draft branch push failed.').message} Recoverable state: remote branch ${branch} points to different SHA ${observedOid}; it was retained.`
+        );
+      }
       throw failure(push, 'Draft branch push failed.');
     }
-    remoteCreated = true;
+    const pushedRemote = run('git', [
+      'ls-remote',
+      '--exit-code',
+      '--heads',
+      'origin',
+      branch,
+    ]);
+    const pushedOid = pushedRemote.stdout.trim().split(/\s+/u)[0];
+    remoteOwned = pushedRemote.status === 0 && pushedOid === localCommitSha;
+    if (!remoteOwned) {
+      const detail =
+        pushedRemote.status === 0
+          ? `points to different SHA ${pushedOid}`
+          : 'could not be read';
+      throw new Error(
+        `Recoverable state: pushed remote branch ${branch} ${detail}; ownership was not established and the branch was retained.`
+      );
+    }
     const pr = run(
       'gh',
       [
@@ -132,15 +179,65 @@ export async function publishInvestorReviewDraft(
       ],
       temporaryWorktree
     );
-    if (pr.status !== 0) throw failure(pr, 'Draft PR creation failed.');
+    if (pr.status !== 0) {
+      prCreateFailed = true;
+      throw failure(pr, 'Draft PR creation failed.');
+    }
     return pr.stdout.trim();
   } catch (error) {
     primaryError = error instanceof Error ? error : new Error(String(error));
-    if (remoteCreated) {
-      const rollback = run('git', ['push', 'origin', '--delete', branch]);
+    if (remoteOwned && prCreateFailed) {
+      const existingPr = run('gh', [
+        'pr',
+        'list',
+        '--repo',
+        repository,
+        '--head',
+        branch,
+        '--base',
+        base,
+        '--state',
+        'all',
+        '--json',
+        'url,state',
+      ]);
+      if (existingPr.status !== 0) {
+        primaryError = new Error(
+          `${primaryError.message} Recoverable state: PR existence for ${repository}:${branch}->${base} could not be determined; owned remote branch ${branch} at ${localCommitSha} was retained.`
+        );
+        remoteOwned = false;
+      } else {
+        try {
+          const matches = JSON.parse(existingPr.stdout) as Array<{
+            url: string;
+            state: string;
+          }>;
+          if (!Array.isArray(matches)) throw new Error('Expected PR list.');
+          if (matches.length > 0) {
+            const match = matches[0]!;
+            primaryError = new Error(
+              `${primaryError.message} Draft PR exists at ${match.url} (${match.state}); remote branch retained.`
+            );
+            remoteOwned = false;
+          }
+        } catch {
+          primaryError = new Error(
+            `${primaryError.message} Recoverable state: PR query returned invalid data; owned remote branch ${branch} at ${localCommitSha} was retained.`
+          );
+          remoteOwned = false;
+        }
+      }
+    }
+    if (remoteOwned && localCommitSha) {
+      const rollback = run('git', [
+        'push',
+        `--force-with-lease=refs/heads/${branch}:${localCommitSha}`,
+        'origin',
+        `:refs/heads/${branch}`,
+      ]);
       if (rollback.status !== 0) {
         primaryError = new Error(
-          `${primaryError.message} Recoverable state: remote branch ${branch} exists; delete it manually before retrying. ${rollback.stderr.trim()}`
+          `${primaryError.message} Recoverable state: leased deletion of remote branch ${branch} at expected SHA ${localCommitSha} failed; the branch was retained. ${rollback.stderr.trim()}`
         );
       }
     }

--- a/apps/web/lib/investors/investor-review-publisher.ts
+++ b/apps/web/lib/investors/investor-review-publisher.ts
@@ -1,0 +1,182 @@
+import path from 'node:path';
+
+export interface PublisherCommandResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface InvestorReviewPublisherDependencies {
+  readonly run: (
+    command: 'git' | 'gh',
+    args: readonly string[],
+    cwd: string
+  ) => PublisherCommandResult;
+  readonly createTempDirectory: () => Promise<string>;
+  readonly removeTempDirectory: (directory: string) => Promise<void>;
+  readonly writeArtifact: (filePath: string, content: string) => Promise<void>;
+}
+
+interface PublishOptions {
+  readonly repoRoot: string;
+  readonly branch: string;
+  readonly base: string;
+  readonly title: string;
+  readonly relativeOutput: string;
+  readonly markdown: string;
+}
+
+function failure(result: PublisherCommandResult, fallback: string): Error {
+  return new Error(result.stderr.trim() || fallback);
+}
+
+export async function publishInvestorReviewDraft(
+  options: PublishOptions,
+  dependencies: InvestorReviewPublisherDependencies
+): Promise<string> {
+  const { repoRoot, branch, base, title, relativeOutput, markdown } = options;
+  const run = (
+    command: 'git' | 'gh',
+    args: readonly string[],
+    cwd = repoRoot
+  ) => dependencies.run(command, args, cwd);
+  const status = run('git', ['status', '--porcelain']);
+  if (status.status !== 0) {
+    throw failure(status, 'Could not verify worktree cleanliness.');
+  }
+  if (status.stdout.trim()) {
+    throw new Error('Refusing a dirty worktree.');
+  }
+  const initialLocal = run('git', [
+    'show-ref',
+    '--verify',
+    '--quiet',
+    `refs/heads/${branch}`,
+  ]);
+  if (initialLocal.status === 0) {
+    throw new Error(`Branch already exists: ${branch}`);
+  }
+  if (initialLocal.status !== 1) {
+    throw failure(initialLocal, 'Could not verify local branch availability.');
+  }
+  const initialRemote = run('git', [
+    'ls-remote',
+    '--exit-code',
+    '--heads',
+    'origin',
+    branch,
+  ]);
+  if (initialRemote.status === 0) {
+    throw new Error(`Remote branch already exists: ${branch}`);
+  }
+  if (initialRemote.status !== 2) {
+    throw failure(
+      initialRemote,
+      'Could not verify remote branch availability.'
+    );
+  }
+
+  const temporaryWorktree = await dependencies.createTempDirectory();
+  let remoteCreated = false;
+  let primaryError: Error | null = null;
+  try {
+    const add = run('git', [
+      'worktree',
+      'add',
+      '-b',
+      branch,
+      temporaryWorktree,
+      base,
+    ]);
+    if (add.status !== 0)
+      throw failure(add, 'Temporary worktree creation failed.');
+    const output = path.join(temporaryWorktree, relativeOutput);
+    await dependencies.writeArtifact(output, markdown);
+    for (const args of [
+      ['add', '--', relativeOutput],
+      [
+        'commit',
+        '-m',
+        `docs(investors): add ${path.basename(relativeOutput, '.md')} review proposal`,
+      ],
+    ] as const) {
+      const result = run('git', args, temporaryWorktree);
+      if (result.status !== 0) throw failure(result, `git ${args[0]} failed.`);
+    }
+    const push = run(
+      'git',
+      ['push', '-u', 'origin', `${branch}:${branch}`],
+      temporaryWorktree
+    );
+    if (push.status !== 0) {
+      remoteCreated =
+        run('git', ['ls-remote', '--exit-code', '--heads', 'origin', branch])
+          .status === 0;
+      throw failure(push, 'Draft branch push failed.');
+    }
+    remoteCreated = true;
+    const pr = run(
+      'gh',
+      [
+        'pr',
+        'create',
+        '--draft',
+        '--base',
+        base,
+        '--head',
+        branch,
+        '--title',
+        title,
+        '--body',
+        'Manual investor-note review proposal only. No investor-facing content is changed.',
+      ],
+      temporaryWorktree
+    );
+    if (pr.status !== 0) throw failure(pr, 'Draft PR creation failed.');
+    return pr.stdout.trim();
+  } catch (error) {
+    primaryError = error instanceof Error ? error : new Error(String(error));
+    if (remoteCreated) {
+      const rollback = run('git', ['push', 'origin', '--delete', branch]);
+      if (rollback.status !== 0) {
+        primaryError = new Error(
+          `${primaryError.message} Recoverable state: remote branch ${branch} exists; delete it manually before retrying. ${rollback.stderr.trim()}`
+        );
+      }
+    }
+    throw primaryError;
+  } finally {
+    const cleanupErrors: string[] = [];
+    const remove = run('git', [
+      'worktree',
+      'remove',
+      '--force',
+      temporaryWorktree,
+    ]);
+    if (remove.status !== 0) cleanupErrors.push(remove.stderr.trim());
+    try {
+      await dependencies.removeTempDirectory(temporaryWorktree);
+    } catch (error) {
+      cleanupErrors.push(
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+    const local = run('git', [
+      'show-ref',
+      '--verify',
+      '--quiet',
+      `refs/heads/${branch}`,
+    ]);
+    if (local.status === 0) {
+      const deleteBranch = run('git', ['branch', '-D', branch]);
+      if (deleteBranch.status !== 0)
+        cleanupErrors.push(deleteBranch.stderr.trim());
+    }
+    if (cleanupErrors.length > 0) {
+      const prefix = primaryError
+        ? `${primaryError.message} Recoverable state: local cleanup failed:`
+        : 'Draft created but local cleanup failed:';
+      throw new Error(`${prefix} ${cleanupErrors.join(' ')}`);
+    }
+  }
+}

--- a/apps/web/lib/investors/note-ingestion.ts
+++ b/apps/web/lib/investors/note-ingestion.ts
@@ -34,12 +34,50 @@ export type InvestorNoteInput = z.infer<typeof investorNoteInputSchema>;
 export type InvestorNoteSignal = z.infer<typeof investorNoteSignalSchema>;
 type GapClassification = InvestorNoteSignal['gapClassification'];
 
+export const investorNotePriorArtifactSchema = z.object({
+  artifactVersion: z.literal('1.2.0'),
+  reviewStatus: z.literal('manual-review-required'),
+  corpus: z.array(
+    z.object({
+      source: investorNoteInputSchema.shape.source,
+      transcriptSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+      transcript: investorNoteInputSchema.shape.transcript,
+      signals: investorNoteInputSchema.shape.signals,
+    })
+  ),
+});
+
+export function inputsFromPriorArtifact(
+  raw: unknown
+): readonly InvestorNoteInput[] {
+  const artifact = investorNotePriorArtifactSchema.parse(raw);
+  return artifact.corpus.map(entry => {
+    if (transcriptHash(entry.transcript) !== entry.transcriptSha256) {
+      throw new Error(
+        `Prior artifact transcript hash mismatch for source ${entry.source.id}.`
+      );
+    }
+    return {
+      source: entry.source,
+      transcript: entry.transcript,
+      signals: entry.signals,
+    };
+  });
+}
+
 interface CandidateSource {
   readonly sourceId: string;
   readonly label: string;
   readonly capturedAt: string;
   readonly transcriptSha256: string;
   readonly line?: number;
+}
+
+export interface InvestorNoteCorpusEntry {
+  readonly source: InvestorNoteInput['source'];
+  readonly transcriptSha256: string;
+  readonly transcript: string;
+  readonly signals: readonly InvestorNoteSignal[];
 }
 
 export interface InvestorNoteCandidate {
@@ -57,11 +95,12 @@ export interface InvestorNoteCandidate {
 }
 
 export interface InvestorNoteReviewArtifact {
-  readonly artifactVersion: '1.1.0';
+  readonly artifactVersion: '1.2.0';
   readonly reviewStatus: 'manual-review-required';
   readonly asOf: string;
   readonly sourceCount: number;
   readonly candidates: readonly InvestorNoteCandidate[];
+  readonly corpus: readonly InvestorNoteCorpusEntry[];
   readonly classificationCounts: Readonly<Record<GapClassification, number>>;
   readonly proposedReviewTargets: readonly string[];
   readonly guardrails: {
@@ -164,16 +203,29 @@ function validateLineProvenance(
 export function buildInvestorNoteReviewArtifact(
   rawInputs: readonly unknown[]
 ): InvestorNoteReviewArtifact {
-  const inputs = rawInputs.map(input => investorNoteInputSchema.parse(input));
+  const parsedInputs = rawInputs.map(input =>
+    investorNoteInputSchema.parse(input)
+  );
+  const inputsById = new Map<string, InvestorNoteInput>();
+  for (const input of parsedInputs) {
+    const existing = inputsById.get(input.source.id);
+    if (existing) {
+      if (
+        transcriptHash(existing.transcript) !== transcriptHash(input.transcript)
+      ) {
+        throw new Error(
+          `Investor note source ID ${input.source.id} has a changed transcript hash.`
+        );
+      }
+      continue;
+    }
+    inputsById.set(input.source.id, input);
+  }
+  const inputs = [...inputsById.values()].sort((left, right) =>
+    compareText(left.source.id, right.source.id)
+  );
   if (inputs.length === 0)
     throw new Error('At least one investor note is required.');
-  const sourceIds = new Set<string>();
-  for (const input of inputs) {
-    if (sourceIds.has(input.source.id)) {
-      throw new Error(`Duplicate investor note source ID: ${input.source.id}`);
-    }
-    sourceIds.add(input.source.id);
-  }
 
   const merged = new Map<
     string,
@@ -268,7 +320,7 @@ export function buildInvestorNoteReviewArtifact(
   ) as Record<GapClassification, number>;
 
   return {
-    artifactVersion: '1.1.0',
+    artifactVersion: '1.2.0',
     reviewStatus: 'manual-review-required',
     asOf: inputs
       .map(input => input.source.capturedAt)
@@ -276,6 +328,12 @@ export function buildInvestorNoteReviewArtifact(
       .at(-1)!,
     sourceCount: inputs.length,
     candidates,
+    corpus: inputs.map(input => ({
+      source: input.source,
+      transcriptSha256: transcriptHash(input.transcript),
+      transcript: input.transcript,
+      signals: input.signals,
+    })),
     classificationCounts,
     proposedReviewTargets: [
       ...new Set(candidates.flatMap(item => item.proposedReviewTargets)),

--- a/apps/web/lib/investors/note-ingestion.ts
+++ b/apps/web/lib/investors/note-ingestion.ts
@@ -151,6 +151,12 @@ function transcriptHash(transcript: string): string {
   return createHash('sha256').update(transcript, 'utf8').digest('hex');
 }
 
+function sourceRecordHash(input: InvestorNoteInput): string {
+  return createHash('sha256')
+    .update(JSON.stringify(input), 'utf8')
+    .digest('hex');
+}
+
 function frequencyFor(count: number): InvestorNoteCandidate['frequency'] {
   if (count >= 4) return 'frequent';
   if (count >= 2) return 'common';
@@ -210,11 +216,9 @@ export function buildInvestorNoteReviewArtifact(
   for (const input of parsedInputs) {
     const existing = inputsById.get(input.source.id);
     if (existing) {
-      if (
-        transcriptHash(existing.transcript) !== transcriptHash(input.transcript)
-      ) {
+      if (sourceRecordHash(existing) !== sourceRecordHash(input)) {
         throw new Error(
-          `Investor note source ID ${input.source.id} has a changed transcript hash.`
+          `Investor note source ID ${input.source.id} has a changed source record.`
         );
       }
       continue;

--- a/apps/web/scripts/create-investor-review-draft.ts
+++ b/apps/web/scripts/create-investor-review-draft.ts
@@ -1,0 +1,123 @@
+import { spawnSync } from 'node:child_process';
+import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { renderInvestorReviewProposal } from '@/lib/investors/investor-review-proposal';
+
+const webRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..'
+);
+const repoRoot = path.resolve(webRoot, '../..');
+const reviewRoot = path.join(repoRoot, 'docs/fundraising/reviews');
+
+function argument(name: string): string {
+  const value = process.argv
+    .slice(2)
+    .find(item => item.startsWith(`--${name}=`));
+  if (!value) throw new Error(`--${name} is required.`);
+  return value.slice(name.length + 3);
+}
+
+function git(args: readonly string[]): string {
+  const result = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `git ${args.join(' ')} failed.`);
+  }
+  return result.stdout.trim();
+}
+
+async function regularRealPath(filePath: string): Promise<string> {
+  const resolved = path.resolve(filePath);
+  const stats = await lstat(resolved);
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new Error(`Input must be a regular non-symlink file: ${filePath}`);
+  }
+  return realpath(resolved);
+}
+
+async function main() {
+  const proposalPath = await regularRealPath(argument('proposal'));
+  const artifactPath = await regularRealPath(argument('artifact'));
+  const publish = process.argv.includes('--publish-draft');
+  const rendered = renderInvestorReviewProposal(
+    JSON.parse(await readFile(proposalPath, 'utf8')),
+    JSON.parse(await readFile(artifactPath, 'utf8'))
+  );
+  const output = path.join(reviewRoot, 'proposals', `${rendered.slug}.md`);
+  const branch = `codex/investor-review-${rendered.slug}`;
+  const base = git(['branch', '--show-current']);
+  const plan = {
+    mode: publish ? 'publish-draft' : 'dry-run',
+    branch,
+    base,
+    output,
+  };
+  if (!publish) {
+    process.stdout.write(
+      `${JSON.stringify({ ...plan, markdown: rendered.markdown })}\n`
+    );
+    return;
+  }
+  if (git(['status', '--porcelain']))
+    throw new Error('Refusing a dirty worktree.');
+  const localBranch = spawnSync(
+    'git',
+    ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
+    { cwd: repoRoot }
+  );
+  if (localBranch.status === 0) {
+    throw new Error(`Branch already exists: ${branch}`);
+  }
+  const remote = spawnSync(
+    'git',
+    ['ls-remote', '--exit-code', '--heads', 'origin', branch],
+    { cwd: repoRoot }
+  );
+  if (remote.status === 0)
+    throw new Error(`Remote branch already exists: ${branch}`);
+  if (remote.status !== 2) {
+    throw new Error(
+      remote.stderr?.toString().trim() ||
+        'Could not verify remote branch availability.'
+    );
+  }
+  await mkdir(path.dirname(output), { recursive: true });
+  await writeFile(output, rendered.markdown, { encoding: 'utf8', flag: 'wx' });
+  git(['switch', '-c', branch]);
+  git(['add', '--', path.relative(repoRoot, output)]);
+  git([
+    'commit',
+    '-m',
+    `docs(investors): add ${rendered.slug} review proposal`,
+  ]);
+  git(['push', '-u', 'origin', branch]);
+  const pr = spawnSync(
+    'gh',
+    [
+      'pr',
+      'create',
+      '--draft',
+      '--base',
+      base,
+      '--title',
+      rendered.title,
+      '--body',
+      'Manual investor-note review proposal only. No investor-facing content is changed.',
+    ],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+  if (pr.status !== 0)
+    throw new Error(pr.stderr.trim() || 'Draft PR creation failed.');
+  process.stdout.write(
+    `${JSON.stringify({ ...plan, draftPr: pr.stdout.trim() })}\n`
+  );
+}
+
+main().catch(error => {
+  process.stderr.write(
+    `${JSON.stringify({ error: error instanceof Error ? error.message : String(error) })}\n`
+  );
+  process.exitCode = 1;
+});

--- a/apps/web/scripts/create-investor-review-draft.ts
+++ b/apps/web/scripts/create-investor-review-draft.ts
@@ -78,12 +78,27 @@ async function main() {
     );
     return;
   }
+  const repositoryResult = run('gh', [
+    'repo',
+    'view',
+    '--json',
+    'nameWithOwner',
+    '--jq',
+    '.nameWithOwner',
+  ]);
+  if (repositoryResult.status !== 0 || !repositoryResult.stdout.trim()) {
+    throw new Error(
+      repositoryResult.stderr.trim() || 'GitHub repository is required.'
+    );
+  }
+  const repository = repositoryResult.stdout.trim();
   const draftPr = await publishInvestorReviewDraft(
     {
       repoRoot,
       branch,
       base,
       title: rendered.title,
+      repository,
       relativeOutput,
       markdown: rendered.markdown,
     },

--- a/apps/web/scripts/create-investor-review-draft.ts
+++ b/apps/web/scripts/create-investor-review-draft.ts
@@ -1,16 +1,26 @@
 import { spawnSync } from 'node:child_process';
-import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { renderInvestorReviewProposal } from '@/lib/investors/investor-review-proposal';
+import { publishInvestorReviewDraft } from '@/lib/investors/investor-review-publisher';
 
 const webRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '..'
 );
 const repoRoot = path.resolve(webRoot, '../..');
-const reviewRoot = path.join(repoRoot, 'docs/fundraising/reviews');
+const relativeReviewRoot = 'docs/fundraising/reviews/proposals';
 
 function argument(name: string): string {
   const value = process.argv
@@ -20,12 +30,13 @@ function argument(name: string): string {
   return value.slice(name.length + 3);
 }
 
-function git(args: readonly string[]): string {
-  const result = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' });
-  if (result.status !== 0) {
-    throw new Error(result.stderr.trim() || `git ${args.join(' ')} failed.`);
-  }
-  return result.stdout.trim();
+function run(command: 'git' | 'gh', args: readonly string[], cwd = repoRoot) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
 }
 
 async function regularRealPath(filePath: string): Promise<string> {
@@ -45,9 +56,16 @@ async function main() {
     JSON.parse(await readFile(proposalPath, 'utf8')),
     JSON.parse(await readFile(artifactPath, 'utf8'))
   );
-  const output = path.join(reviewRoot, 'proposals', `${rendered.slug}.md`);
+  const relativeOutput = path.join(relativeReviewRoot, `${rendered.slug}.md`);
+  const output = path.join(repoRoot, relativeOutput);
   const branch = `codex/investor-review-${rendered.slug}`;
-  const base = git(['branch', '--show-current']);
+  const currentBranch = run('git', ['branch', '--show-current']);
+  if (currentBranch.status !== 0 || !currentBranch.stdout.trim()) {
+    throw new Error(
+      currentBranch.stderr.trim() || 'Current branch is required.'
+    );
+  }
+  const base = currentBranch.stdout.trim();
   const plan = {
     mode: publish ? 'publish-draft' : 'dry-run',
     branch,
@@ -60,59 +78,28 @@ async function main() {
     );
     return;
   }
-  if (git(['status', '--porcelain']))
-    throw new Error('Refusing a dirty worktree.');
-  const localBranch = spawnSync(
-    'git',
-    ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
-    { cwd: repoRoot }
-  );
-  if (localBranch.status === 0) {
-    throw new Error(`Branch already exists: ${branch}`);
-  }
-  const remote = spawnSync(
-    'git',
-    ['ls-remote', '--exit-code', '--heads', 'origin', branch],
-    { cwd: repoRoot }
-  );
-  if (remote.status === 0)
-    throw new Error(`Remote branch already exists: ${branch}`);
-  if (remote.status !== 2) {
-    throw new Error(
-      remote.stderr?.toString().trim() ||
-        'Could not verify remote branch availability.'
-    );
-  }
-  await mkdir(path.dirname(output), { recursive: true });
-  await writeFile(output, rendered.markdown, { encoding: 'utf8', flag: 'wx' });
-  git(['switch', '-c', branch]);
-  git(['add', '--', path.relative(repoRoot, output)]);
-  git([
-    'commit',
-    '-m',
-    `docs(investors): add ${rendered.slug} review proposal`,
-  ]);
-  git(['push', '-u', 'origin', branch]);
-  const pr = spawnSync(
-    'gh',
-    [
-      'pr',
-      'create',
-      '--draft',
-      '--base',
+  const draftPr = await publishInvestorReviewDraft(
+    {
+      repoRoot,
+      branch,
       base,
-      '--title',
-      rendered.title,
-      '--body',
-      'Manual investor-note review proposal only. No investor-facing content is changed.',
-    ],
-    { cwd: repoRoot, encoding: 'utf8' }
+      title: rendered.title,
+      relativeOutput,
+      markdown: rendered.markdown,
+    },
+    {
+      run,
+      createTempDirectory: () =>
+        mkdtemp(path.join(tmpdir(), 'jovie-investor-review-')),
+      removeTempDirectory: directory =>
+        rm(directory, { recursive: true, force: true }),
+      writeArtifact: async (filePath, content) => {
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, content, { encoding: 'utf8', flag: 'wx' });
+      },
+    }
   );
-  if (pr.status !== 0)
-    throw new Error(pr.stderr.trim() || 'Draft PR creation failed.');
-  process.stdout.write(
-    `${JSON.stringify({ ...plan, draftPr: pr.stdout.trim() })}\n`
-  );
+  process.stdout.write(`${JSON.stringify({ ...plan, draftPr })}\n`);
 }
 
 main().catch(error => {

--- a/apps/web/scripts/ingest-investor-note.ts
+++ b/apps/web/scripts/ingest-investor-note.ts
@@ -1,9 +1,10 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import {
   buildInvestorNoteReviewArtifact,
+  inputsFromPriorArtifact,
   investorNoteInputSchema,
   parseAnnotatedTranscript,
 } from '@/lib/investors/note-ingestion';
@@ -14,12 +15,15 @@ interface CliOptions {
   readonly capturedAt: string | null;
   readonly sourceId: string | null;
   readonly overwrite: boolean;
+  readonly prior: string | null;
 }
 
 const webRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '..'
 );
+const repoRoot = path.resolve(webRoot, '../..');
+export const reviewArtifactRoot = path.join(repoRoot, '.artifacts/fundraising');
 
 function parseArgs(argv: readonly string[]): CliOptions {
   const inputs: string[] = [];
@@ -27,6 +31,7 @@ function parseArgs(argv: readonly string[]): CliOptions {
   let capturedAt: string | null = null;
   let sourceId: string | null = null;
   let overwrite = false;
+  let prior: string | null = null;
   for (const arg of argv) {
     if (arg.startsWith('--out=')) output = arg.slice('--out='.length);
     else if (arg.startsWith('--captured-at='))
@@ -34,32 +39,98 @@ function parseArgs(argv: readonly string[]): CliOptions {
     else if (arg.startsWith('--source-id='))
       sourceId = arg.slice('--source-id='.length);
     else if (arg === '--overwrite') overwrite = true;
+    else if (arg.startsWith('--prior=')) prior = arg.slice('--prior='.length);
     else inputs.push(arg);
   }
   if (inputs.length === 0) {
     throw new Error(
-      'Usage: pnpm --filter @jovie/web exec tsx scripts/ingest-investor-note.ts <note.json|note.txt> [more JSON files] [--source-id=stable-id] [--captured-at=YYYY-MM-DD] [--out=artifact.json] [--overwrite]'
+      'Usage: pnpm --filter @jovie/web exec tsx scripts/ingest-investor-note.ts <note.json|note.txt> [more JSON files] [--prior=prior-artifact.json] [--source-id=stable-id] [--captured-at=YYYY-MM-DD] --out=.artifacts/fundraising/artifact.json [--overwrite]'
     );
   }
-  return { inputs, output, capturedAt, sourceId, overwrite };
+  if (!output) throw new Error('--out is required.');
+  return { inputs, output, capturedAt, sourceId, overwrite, prior };
 }
 
-function resolveSafePath(filePath: string): string {
+async function resolveSafeInputPath(filePath: string): Promise<string> {
   const resolved = path.resolve(filePath);
-  const segments = resolved.split(path.sep);
   const basename = path.basename(resolved).toLocaleLowerCase('en-US');
   const canonicalRegistry = path.resolve(
     webRoot,
     'lib/investors/fundraising-registry.ts'
   );
   if (
-    segments.includes('.git') ||
-    segments.includes('node_modules') ||
+    resolved.split(path.sep).includes('.git') ||
+    resolved.split(path.sep).includes('node_modules') ||
     basename.startsWith('.env') ||
     basename === '.npmrc' ||
     resolved === canonicalRegistry
   ) {
     throw new Error(`Protected path is not allowed: ${filePath}`);
+  }
+  const stats = await lstat(resolved);
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Symbolic-link input is not allowed: ${filePath}`);
+  }
+  return realpath(resolved);
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative !== '' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    relative !== '..' &&
+    !path.isAbsolute(relative)
+  );
+}
+
+async function resolveSafeOutputPath(filePath: string): Promise<string> {
+  const resolved = path.resolve(filePath);
+  if (path.extname(resolved).toLocaleLowerCase('en-US') !== '.json') {
+    throw new Error('Review artifact output must use a .json extension.');
+  }
+  if (!isInside(reviewArtifactRoot, resolved)) {
+    throw new Error(`Output must be inside ${reviewArtifactRoot}.`);
+  }
+  await mkdir(reviewArtifactRoot, { recursive: true });
+  if ((await lstat(reviewArtifactRoot)).isSymbolicLink()) {
+    throw new Error(
+      `Symbolic-link artifact root is not allowed: ${reviewArtifactRoot}`
+    );
+  }
+  const realRoot = await realpath(reviewArtifactRoot);
+  if (realRoot !== reviewArtifactRoot) {
+    throw new Error(
+      `Artifact root resolves through a symbolic link: ${reviewArtifactRoot}`
+    );
+  }
+  let cursor = path.dirname(resolved);
+  while (isInside(reviewArtifactRoot, cursor)) {
+    try {
+      const stats = await lstat(cursor);
+      if (stats.isSymbolicLink()) {
+        throw new Error(
+          `Symbolic-link output path is not allowed: ${filePath}`
+        );
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    cursor = path.dirname(cursor);
+  }
+  const parent = path.dirname(resolved);
+  await mkdir(parent, { recursive: true });
+  const realParent = await realpath(parent);
+  if (!isInside(realRoot, realParent) && realParent !== realRoot) {
+    throw new Error(`Output resolves outside ${reviewArtifactRoot}.`);
+  }
+  try {
+    const outputStats = await lstat(resolved);
+    if (outputStats.isSymbolicLink()) {
+      throw new Error(`Symbolic-link output is not allowed: ${filePath}`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
   }
   return resolved;
 }
@@ -68,7 +139,7 @@ async function readInput(
   filePath: string,
   options: Pick<CliOptions, 'capturedAt' | 'sourceId'>
 ) {
-  const safePath = resolveSafePath(filePath);
+  const safePath = await resolveSafeInputPath(filePath);
   const raw = await readFile(safePath, 'utf8');
   if (path.extname(safePath).toLocaleLowerCase('en-US') === '.json') {
     return investorNoteInputSchema.parse(JSON.parse(raw));
@@ -92,12 +163,17 @@ async function readInput(
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const inputPaths = options.inputs.map(resolveSafePath);
+  const inputPaths = await Promise.all(
+    options.inputs.map(resolveSafeInputPath)
+  );
   if (new Set(inputPaths).size !== inputPaths.length) {
     throw new Error('The same input path cannot be supplied more than once.');
   }
-  const outputPath = options.output ? resolveSafePath(options.output) : null;
-  if (outputPath && inputPaths.includes(outputPath)) {
+  const outputPath = await resolveSafeOutputPath(options.output!);
+  const priorPath = options.prior
+    ? await resolveSafeInputPath(options.prior)
+    : null;
+  if (inputPaths.includes(outputPath) || priorPath === outputPath) {
     throw new Error('Output path must not equal an input path.');
   }
   if (
@@ -112,19 +188,19 @@ async function main() {
   const inputs = await Promise.all(
     inputPaths.map(input => readInput(input, options))
   );
+  const priorInputs = options.prior
+    ? inputsFromPriorArtifact(JSON.parse(await readFile(priorPath!, 'utf8')))
+    : [];
   const serialized = `${JSON.stringify(
-    buildInvestorNoteReviewArtifact(inputs),
+    buildInvestorNoteReviewArtifact([...priorInputs, ...inputs]),
     null,
     2
   )}\n`;
-  if (outputPath) {
-    await writeFile(outputPath, serialized, {
-      encoding: 'utf8',
-      flag: options.overwrite ? 'w' : 'wx',
-    });
-  } else {
-    process.stdout.write(serialized);
-  }
+  await writeFile(outputPath, serialized, {
+    encoding: 'utf8',
+    flag: options.overwrite ? 'w' : 'wx',
+  });
+  process.stdout.write(`${JSON.stringify({ output: outputPath })}\n`);
 }
 
 main().catch(error => {

--- a/apps/web/tests/unit/investors/investor-review-draft-cli.test.ts
+++ b/apps/web/tests/unit/investors/investor-review-draft-cli.test.ts
@@ -1,0 +1,83 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildInvestorNoteReviewArtifact } from '@/lib/investors/note-ingestion';
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('investor review draft CLI', () => {
+  it('defaults to a side-effect-free deterministic dry run', () => {
+    const directory = mkdtempSync(
+      path.join(tmpdir(), 'investor-review-draft-')
+    );
+    directories.push(directory);
+    const artifact = buildInvestorNoteReviewArtifact([
+      {
+        source: {
+          id: 'conversation-dry-run',
+          kind: 'local-note',
+          label: 'Dry run',
+          capturedAt: '2026-07-11',
+        },
+        transcript: 'Synthetic.',
+        signals: [
+          {
+            kind: 'question',
+            text: 'What traction is proven?',
+            gapClassification: 'evidence',
+            severity: 'high',
+          },
+        ],
+      },
+    ]);
+    const candidate = artifact.candidates[0]!;
+    const artifactPath = path.join(directory, 'artifact.json');
+    const proposalPath = path.join(directory, 'proposal.json');
+    writeFileSync(artifactPath, JSON.stringify(artifact));
+    writeFileSync(
+      proposalPath,
+      JSON.stringify({
+        proposalVersion: '1.0.0',
+        slug: 'dry-run-review',
+        title: 'Dry-run investor review',
+        approvedCandidates: [
+          {
+            key: candidate.key,
+            proposedCopy: 'Sourced copy for manual review.',
+            action: 'Review only.',
+            target: 'fundraisingRegistry.claims',
+            protectedFields: ['claims'],
+            evidence: [candidate.sources[0]],
+          },
+        ],
+      })
+    );
+    const result = spawnSync(
+      'pnpm',
+      [
+        'exec',
+        'tsx',
+        'scripts/create-investor-review-draft.ts',
+        `--proposal=${proposalPath}`,
+        `--artifact=${artifactPath}`,
+      ],
+      { cwd: process.cwd(), encoding: 'utf8' }
+    );
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      mode: 'dry-run',
+      branch: 'codex/investor-review-dry-run-review',
+    });
+    expect(JSON.parse(result.stdout).markdown).toContain(
+      'manual review required'
+    );
+  }, 20_000);
+});

--- a/apps/web/tests/unit/investors/investor-review-proposal.test.ts
+++ b/apps/web/tests/unit/investors/investor-review-proposal.test.ts
@@ -25,6 +25,15 @@ function setup() {
   return { artifact, candidate: artifact.candidates[0]! };
 }
 
+interface MutableArtifact {
+  candidates: Array<{
+    key: string;
+    text: string;
+    proposedReviewTargets: string[];
+    sources: Array<{ transcriptSha256: string }>;
+  }>;
+}
+
 describe('investor review proposal', () => {
   it('renders approved copy with matching evidence and protected-field flags', () => {
     const { artifact, candidate } = setup();
@@ -74,5 +83,56 @@ describe('investor review proposal', () => {
         artifact
       )
     ).toThrow('not allowed');
+  });
+
+  it.each([
+    [
+      'source hash',
+      (artifact: MutableArtifact) => {
+        artifact.candidates[0]!.sources[0]!.transcriptSha256 = '0'.repeat(64);
+      },
+    ],
+    [
+      'target',
+      (artifact: MutableArtifact) => {
+        artifact.candidates[0]!.proposedReviewTargets = ['outreach-brief'];
+      },
+    ],
+    [
+      'key',
+      (artifact: MutableArtifact) => {
+        artifact.candidates[0]!.key = 'question:forged';
+      },
+    ],
+    [
+      'text',
+      (artifact: MutableArtifact) => {
+        artifact.candidates[0]!.text = 'Forged derived text';
+      },
+    ],
+  ])('rejects a mutated derived candidate %s', (_label, mutate) => {
+    const { artifact, candidate } = setup();
+    const rawArtifact = structuredClone(artifact);
+    mutate(rawArtifact as unknown as MutableArtifact);
+    expect(() =>
+      renderInvestorReviewProposal(
+        {
+          proposalVersion: '1.0.0',
+          slug: 'traction-proof',
+          title: 'Review traction proof',
+          approvedCandidates: [
+            {
+              key: candidate.key,
+              proposedCopy: 'Copy',
+              action: 'Review',
+              target: 'fundraisingRegistry.claims',
+              protectedFields: ['claims'],
+              evidence: [candidate.sources[0]],
+            },
+          ],
+        },
+        rawArtifact
+      )
+    ).toThrow('do not match the canonical corpus');
   });
 });

--- a/apps/web/tests/unit/investors/investor-review-proposal.test.ts
+++ b/apps/web/tests/unit/investors/investor-review-proposal.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { renderInvestorReviewProposal } from '@/lib/investors/investor-review-proposal';
+import { buildInvestorNoteReviewArtifact } from '@/lib/investors/note-ingestion';
+
+function setup() {
+  const artifact = buildInvestorNoteReviewArtifact([
+    {
+      source: {
+        id: 'conversation-a',
+        kind: 'local-note',
+        label: 'A',
+        capturedAt: '2026-07-11',
+      },
+      transcript: 'Synthetic.',
+      signals: [
+        {
+          kind: 'question',
+          text: 'What traction is proven?',
+          gapClassification: 'evidence',
+          severity: 'high',
+        },
+      ],
+    },
+  ]);
+  return { artifact, candidate: artifact.candidates[0]! };
+}
+
+describe('investor review proposal', () => {
+  it('renders approved copy with matching evidence and protected-field flags', () => {
+    const { artifact, candidate } = setup();
+    const rendered = renderInvestorReviewProposal(
+      {
+        proposalVersion: '1.0.0',
+        slug: 'traction-proof',
+        title: 'Review traction proof',
+        approvedCandidates: [
+          {
+            key: candidate.key,
+            proposedCopy: 'Add a sourced traction explanation.',
+            action: 'Review copy before any investor-facing edit.',
+            target: 'fundraisingRegistry.claims',
+            protectedFields: ['claims', 'numbers'],
+            evidence: [candidate.sources[0]],
+          },
+        ],
+      },
+      artifact
+    );
+    expect(rendered.markdown).toContain(
+      'Protected-field review: claims, numbers'
+    );
+    expect(rendered.markdown).toContain(candidate.sources[0]!.transcriptSha256);
+  });
+
+  it('rejects targets not allowed for the candidate', () => {
+    const { artifact, candidate } = setup();
+    expect(() =>
+      renderInvestorReviewProposal(
+        {
+          proposalVersion: '1.0.0',
+          slug: 'traction-proof',
+          title: 'Review traction proof',
+          approvedCandidates: [
+            {
+              key: candidate.key,
+              proposedCopy: 'Copy',
+              action: 'Review',
+              target: 'outreach-brief',
+              protectedFields: ['claims'],
+              evidence: [candidate.sources[0]],
+            },
+          ],
+        },
+        artifact
+      )
+    ).toThrow('not allowed');
+  });
+});

--- a/apps/web/tests/unit/investors/investor-review-publisher.test.ts
+++ b/apps/web/tests/unit/investors/investor-review-publisher.test.ts
@@ -205,6 +205,28 @@ describe('investor review publisher', () => {
     expect(state.remoteSha).toBe(OTHER_SHA);
   });
 
+  it('reports indeterminate ownership when post-push remote lookup fails', async () => {
+    const { state, dependencies } = harness('push');
+    const originalRun = dependencies.run;
+    dependencies.run = (command, args) => {
+      if (
+        command === 'git' &&
+        args[0] === 'ls-remote' &&
+        state.artifactWritten &&
+        state.remoteSha
+      ) {
+        return { status: 128, stdout: '', stderr: 'remote unavailable' };
+      }
+      return originalRun(command, args);
+    };
+    await expect(
+      publishInvestorReviewDraft(options(), dependencies)
+    ).rejects.toThrow(
+      `remote branch codex/investor-review-test ownership at local SHA ${LOCAL_SHA} is indeterminate`
+    );
+    expect(state.remoteSha).toBe(LOCAL_SHA);
+  });
+
   it('never deletes a remote ref changed after ownership was established', async () => {
     const { state, dependencies } = harness('gh');
     const originalRun = dependencies.run;

--- a/apps/web/tests/unit/investors/investor-review-publisher.test.ts
+++ b/apps/web/tests/unit/investors/investor-review-publisher.test.ts
@@ -5,12 +5,26 @@ import {
 } from '@/lib/investors/investor-review-publisher';
 
 type FailurePhase = 'commit' | 'push' | 'gh';
+const LOCAL_SHA = '1'.repeat(40);
+const OTHER_SHA = '2'.repeat(40);
+
+function options() {
+  return {
+    repoRoot: '/repo',
+    branch: 'codex/investor-review-test',
+    base: 'codex/original',
+    title: 'Test proposal',
+    repository: 'JovieInc/Jovie',
+    relativeOutput: 'docs/fundraising/reviews/proposals/test.md',
+    markdown: '# Test',
+  };
+}
 
 function harness(failurePhase: FailurePhase) {
   const state = {
     callerBranch: 'codex/original',
     localBranch: false,
-    remoteBranch: false,
+    remoteSha: null as string | null,
     temporaryWorktree: false,
     artifactWritten: false,
   };
@@ -31,13 +45,20 @@ function harness(failurePhase: FailurePhase) {
       },
       run: (command: 'git' | 'gh', args: readonly string[]) => {
         if (command === 'gh') {
+          if (args[1] === 'list') return result(0, '[]');
           return failurePhase === 'gh'
             ? result(1, '', 'injected gh failure')
             : result(0, 'https://example.test/pr/1');
         }
         if (args[0] === 'status') return result();
         if (args[0] === 'show-ref') return result(state.localBranch ? 0 : 1);
-        if (args[0] === 'ls-remote') return result(state.remoteBranch ? 0 : 2);
+        if (args[0] === 'ls-remote')
+          return state.remoteSha
+            ? result(
+                0,
+                `${state.remoteSha}\trefs/heads/codex/investor-review-test\n`
+              )
+            : result(2);
         if (args[0] === 'worktree' && args[1] === 'add') {
           state.localBranch = true;
           state.temporaryWorktree = true;
@@ -53,12 +74,22 @@ function harness(failurePhase: FailurePhase) {
         }
         if (args[0] === 'commit' && failurePhase === 'commit')
           return result(1, '', 'injected commit failure');
-        if (args[0] === 'push' && args.includes('--delete')) {
-          state.remoteBranch = false;
+        if (args[0] === 'rev-parse') return result(0, `${LOCAL_SHA}\n`);
+        if (
+          args[0] === 'push' &&
+          args.some(arg => arg.startsWith('--force-with-lease='))
+        ) {
+          const expected = args
+            .find(arg => arg.startsWith('--force-with-lease='))
+            ?.split(':')
+            .at(-1);
+          if (state.remoteSha !== expected)
+            return result(1, '', 'lease rejected');
+          state.remoteSha = null;
           return result();
         }
         if (args[0] === 'push') {
-          state.remoteBranch = true;
+          state.remoteSha = LOCAL_SHA;
           return failurePhase === 'push'
             ? result(1, '', 'injected push failure')
             : result();
@@ -83,6 +114,7 @@ describe('investor review publisher', () => {
           branch: 'codex/investor-review-test',
           base: state.callerBranch,
           title: 'Test proposal',
+          repository: 'JovieInc/Jovie',
           relativeOutput: 'docs/fundraising/reviews/proposals/test.md',
           markdown: '# Test',
         },
@@ -92,7 +124,7 @@ describe('investor review publisher', () => {
     expect(state).toMatchObject({
       callerBranch: 'codex/original',
       localBranch: false,
-      remoteBranch: false,
+      remoteSha: null,
       temporaryWorktree: false,
       artifactWritten: true,
     });
@@ -108,6 +140,7 @@ describe('investor review publisher', () => {
           branch: 'codex/investor-review-test',
           base: state.callerBranch,
           title: 'Test proposal',
+          repository: 'JovieInc/Jovie',
           relativeOutput: 'docs/fundraising/reviews/proposals/test.md',
           markdown: '# Test',
         },
@@ -125,7 +158,7 @@ describe('investor review publisher', () => {
       if (
         command === 'git' &&
         args[0] === 'push' &&
-        args.includes('--delete')
+        args.some(arg => arg.startsWith('--force-with-lease='))
       ) {
         return { status: 1, stdout: '', stderr: 'injected delete failure' };
       }
@@ -138,16 +171,83 @@ describe('investor review publisher', () => {
           branch: 'codex/investor-review-test',
           base: state.callerBranch,
           title: 'Test proposal',
+          repository: 'JovieInc/Jovie',
           relativeOutput: 'docs/fundraising/reviews/proposals/test.md',
           markdown: '# Test',
         },
         dependencies
       )
     ).rejects.toThrow(
-      'Recoverable state: remote branch codex/investor-review-test exists'
+      'leased deletion of remote branch codex/investor-review-test'
     );
-    expect(state.remoteBranch).toBe(true);
+    expect(state.remoteSha).toBe(LOCAL_SHA);
     expect(state.localBranch).toBe(false);
     expect(state.temporaryWorktree).toBe(false);
+  });
+
+  it('retains a different remote SHA observed after a racing push', async () => {
+    const { state, dependencies } = harness('push');
+    const originalRun = dependencies.run;
+    dependencies.run = (command, args) => {
+      if (
+        command === 'git' &&
+        args[0] === 'push' &&
+        !args.some(arg => arg.startsWith('--force-with-lease='))
+      ) {
+        state.remoteSha = OTHER_SHA;
+        return { status: 1, stdout: '', stderr: 'racing push failure' };
+      }
+      return originalRun(command, args);
+    };
+    await expect(
+      publishInvestorReviewDraft(options(), dependencies)
+    ).rejects.toThrow(`points to different SHA ${OTHER_SHA}`);
+    expect(state.remoteSha).toBe(OTHER_SHA);
+  });
+
+  it('never deletes a remote ref changed after ownership was established', async () => {
+    const { state, dependencies } = harness('gh');
+    const originalRun = dependencies.run;
+    dependencies.run = (command, args) => {
+      if (command === 'gh' && args[1] === 'list') {
+        state.remoteSha = OTHER_SHA;
+        return { status: 0, stdout: '[]', stderr: '' };
+      }
+      return originalRun(command, args);
+    };
+    await expect(
+      publishInvestorReviewDraft(options(), dependencies)
+    ).rejects.toThrow('leased deletion');
+    expect(state.remoteSha).toBe(OTHER_SHA);
+  });
+
+  it('retains the owned branch when failed creation has an observable PR', async () => {
+    const { state, dependencies } = harness('gh');
+    const originalRun = dependencies.run;
+    dependencies.run = (command, args) =>
+      command === 'gh' && args[1] === 'list'
+        ? {
+            status: 0,
+            stdout: '[{"url":"https://example.test/pr/7","state":"OPEN"}]',
+            stderr: '',
+          }
+        : originalRun(command, args);
+    await expect(
+      publishInvestorReviewDraft(options(), dependencies)
+    ).rejects.toThrow('https://example.test/pr/7 (OPEN)');
+    expect(state.remoteSha).toBe(LOCAL_SHA);
+  });
+
+  it('retains the owned branch when exact PR existence is indeterminate', async () => {
+    const { state, dependencies } = harness('gh');
+    const originalRun = dependencies.run;
+    dependencies.run = (command, args) =>
+      command === 'gh' && args[1] === 'list'
+        ? { status: 1, stdout: '', stderr: 'query unavailable' }
+        : originalRun(command, args);
+    await expect(
+      publishInvestorReviewDraft(options(), dependencies)
+    ).rejects.toThrow('PR existence for JovieInc/Jovie');
+    expect(state.remoteSha).toBe(LOCAL_SHA);
   });
 });

--- a/apps/web/tests/unit/investors/investor-review-publisher.test.ts
+++ b/apps/web/tests/unit/investors/investor-review-publisher.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type PublisherCommandResult,
+  publishInvestorReviewDraft,
+} from '@/lib/investors/investor-review-publisher';
+
+type FailurePhase = 'commit' | 'push' | 'gh';
+
+function harness(failurePhase: FailurePhase) {
+  const state = {
+    callerBranch: 'codex/original',
+    localBranch: false,
+    remoteBranch: false,
+    temporaryWorktree: false,
+    artifactWritten: false,
+  };
+  const result = (
+    status = 0,
+    stdout = '',
+    stderr = ''
+  ): PublisherCommandResult => ({ status, stdout, stderr });
+  return {
+    state,
+    dependencies: {
+      createTempDirectory: async () => '/tmp/injected-review-worktree',
+      removeTempDirectory: async () => {
+        state.temporaryWorktree = false;
+      },
+      writeArtifact: async () => {
+        state.artifactWritten = true;
+      },
+      run: (command: 'git' | 'gh', args: readonly string[]) => {
+        if (command === 'gh') {
+          return failurePhase === 'gh'
+            ? result(1, '', 'injected gh failure')
+            : result(0, 'https://example.test/pr/1');
+        }
+        if (args[0] === 'status') return result();
+        if (args[0] === 'show-ref') return result(state.localBranch ? 0 : 1);
+        if (args[0] === 'ls-remote') return result(state.remoteBranch ? 0 : 2);
+        if (args[0] === 'worktree' && args[1] === 'add') {
+          state.localBranch = true;
+          state.temporaryWorktree = true;
+          return result();
+        }
+        if (args[0] === 'worktree' && args[1] === 'remove') {
+          state.temporaryWorktree = false;
+          return result();
+        }
+        if (args[0] === 'branch' && args[1] === '-D') {
+          state.localBranch = false;
+          return result();
+        }
+        if (args[0] === 'commit' && failurePhase === 'commit')
+          return result(1, '', 'injected commit failure');
+        if (args[0] === 'push' && args.includes('--delete')) {
+          state.remoteBranch = false;
+          return result();
+        }
+        if (args[0] === 'push') {
+          state.remoteBranch = true;
+          return failurePhase === 'push'
+            ? result(1, '', 'injected push failure')
+            : result();
+        }
+        return result();
+      },
+    },
+  };
+}
+
+describe('investor review publisher', () => {
+  it.each([
+    'commit',
+    'push',
+    'gh',
+  ] as const)('restores caller state after an injected %s failure', async failurePhase => {
+    const { state, dependencies } = harness(failurePhase);
+    await expect(
+      publishInvestorReviewDraft(
+        {
+          repoRoot: '/repo',
+          branch: 'codex/investor-review-test',
+          base: state.callerBranch,
+          title: 'Test proposal',
+          relativeOutput: 'docs/fundraising/reviews/proposals/test.md',
+          markdown: '# Test',
+        },
+        dependencies
+      )
+    ).rejects.toThrow(`injected ${failurePhase} failure`);
+    expect(state).toMatchObject({
+      callerBranch: 'codex/original',
+      localBranch: false,
+      remoteBranch: false,
+      temporaryWorktree: false,
+      artifactWritten: true,
+    });
+  });
+
+  it('never deletes a preexisting branch rejected during preflight', async () => {
+    const { state, dependencies } = harness('commit');
+    state.localBranch = true;
+    await expect(
+      publishInvestorReviewDraft(
+        {
+          repoRoot: '/repo',
+          branch: 'codex/investor-review-test',
+          base: state.callerBranch,
+          title: 'Test proposal',
+          relativeOutput: 'docs/fundraising/reviews/proposals/test.md',
+          markdown: '# Test',
+        },
+        dependencies
+      )
+    ).rejects.toThrow('Branch already exists');
+    expect(state.localBranch).toBe(true);
+    expect(state.temporaryWorktree).toBe(false);
+  });
+
+  it('reports recoverable remote state when rollback deletion fails', async () => {
+    const { state, dependencies } = harness('gh');
+    const originalRun = dependencies.run;
+    dependencies.run = (command, args) => {
+      if (
+        command === 'git' &&
+        args[0] === 'push' &&
+        args.includes('--delete')
+      ) {
+        return { status: 1, stdout: '', stderr: 'injected delete failure' };
+      }
+      return originalRun(command, args);
+    };
+    await expect(
+      publishInvestorReviewDraft(
+        {
+          repoRoot: '/repo',
+          branch: 'codex/investor-review-test',
+          base: state.callerBranch,
+          title: 'Test proposal',
+          relativeOutput: 'docs/fundraising/reviews/proposals/test.md',
+          markdown: '# Test',
+        },
+        dependencies
+      )
+    ).rejects.toThrow(
+      'Recoverable state: remote branch codex/investor-review-test exists'
+    );
+    expect(state.remoteBranch).toBe(true);
+    expect(state.localBranch).toBe(false);
+    expect(state.temporaryWorktree).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/investors/note-ingestion-cli.test.ts
+++ b/apps/web/tests/unit/investors/note-ingestion-cli.test.ts
@@ -1,5 +1,12 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -7,6 +14,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 const tempDirectories: string[] = [];
 const script = 'scripts/ingest-investor-note.ts';
 const CLI_TEST_TIMEOUT_MS = 20_000;
+const reviewRoot = path.resolve(process.cwd(), '../../.artifacts/fundraising');
 
 function tempDirectory() {
   const directory = mkdtempSync(path.join(tmpdir(), 'investor-note-cli-'));
@@ -53,7 +61,11 @@ describe('investor note ingestion CLI', () => {
     () => {
       const directory = tempDirectory();
       const input = path.join(directory, 'note.json');
-      const output = path.join(directory, 'artifact.json');
+      const output = path.join(
+        reviewRoot,
+        `cli-${path.basename(directory)}.json`
+      );
+      tempDirectories.push(output);
       writeFileSync(input, JSON.stringify(fixture()));
 
       expect(run([input, `--out=${output}`]).status).toBe(0);
@@ -80,7 +92,7 @@ describe('investor note ingestion CLI', () => {
       const result = run([input, `--out=${input}`, '--overwrite']);
       expect(result.status).not.toBe(0);
       expect(JSON.parse(result.stderr).error).toContain(
-        'Output path must not equal an input path.'
+        'Output must be inside'
       );
       expect(JSON.parse(readFileSync(input, 'utf8'))).toEqual(fixture());
     },
@@ -93,10 +105,16 @@ describe('investor note ingestion CLI', () => {
       const directory = tempDirectory();
       const protectedInput = path.join(directory, '.env.investor');
       writeFileSync(protectedInput, 'secret=value');
+      const protectedOutput = path.join(
+        reviewRoot,
+        `protected-${path.basename(directory)}.json`
+      );
+      tempDirectories.push(protectedOutput);
       const inputResult = run([
         protectedInput,
         '--source-id=conversation-protected',
         '--captured-at=2026-07-11',
+        `--out=${protectedOutput}`,
       ]);
       expect(inputResult.status).not.toBe(0);
       expect(JSON.parse(inputResult.stderr).error).toContain(
@@ -107,12 +125,49 @@ describe('investor note ingestion CLI', () => {
       writeFileSync(input, JSON.stringify(fixture('conversation-safe')));
       const outputResult = run([
         input,
-        `--out=${path.join(directory, '.env.output')}`,
+        `--out=${path.join(directory, 'outside.json')}`,
         '--overwrite',
       ]);
       expect(outputResult.status).not.toBe(0);
       expect(JSON.parse(outputResult.stderr).error).toContain(
-        'Protected path is not allowed'
+        'Output must be inside'
+      );
+    },
+    CLI_TEST_TIMEOUT_MS
+  );
+
+  it(
+    'accepts arbitrary regular sources but rejects symlink sources and outputs',
+    () => {
+      const directory = tempDirectory();
+      const input = path.join(directory, 'arbitrary.json');
+      const linkedInput = path.join(directory, 'linked.json');
+      const output = path.join(
+        reviewRoot,
+        `arbitrary-${path.basename(directory)}.json`
+      );
+      tempDirectories.push(output);
+      writeFileSync(input, JSON.stringify(fixture('conversation-arbitrary')));
+      symlinkSync(input, linkedInput);
+      expect(run([input, `--out=${output}`]).status).toBe(0);
+      const linked = run([linkedInput, `--out=${output}`, '--overwrite']);
+      expect(linked.status).not.toBe(0);
+      expect(JSON.parse(linked.stderr).error).toContain('Symbolic-link input');
+
+      mkdirSync(reviewRoot, { recursive: true });
+      const linkedDirectory = path.join(
+        reviewRoot,
+        `linked-${path.basename(directory)}`
+      );
+      tempDirectories.push(linkedDirectory);
+      symlinkSync(directory, linkedDirectory);
+      const linkedOutput = run([
+        input,
+        `--out=${path.join(linkedDirectory, 'escaped.json')}`,
+      ]);
+      expect(linkedOutput.status).not.toBe(0);
+      expect(JSON.parse(linkedOutput.stderr).error).toContain(
+        'Symbolic-link output path'
       );
     },
     CLI_TEST_TIMEOUT_MS

--- a/apps/web/tests/unit/investors/note-ingestion.test.ts
+++ b/apps/web/tests/unit/investors/note-ingestion.test.ts
@@ -103,7 +103,7 @@ OBJECTION | strategy | critical | The buyer is unclear.`)
     expect(buildInvestorNoteReviewArtifact([input, input]).sourceCount).toBe(1);
   });
 
-  it('makes sequential corpus ingestion equal batch and rejects changed sources', () => {
+  it('makes sequential corpus ingestion equal batch and rejects any changed source record', () => {
     const first = note({ id: 'conversation-a', signals: [tractionSignal] });
     const second = note({
       id: 'conversation-b',
@@ -117,12 +117,25 @@ OBJECTION | strategy | critical | The buyer is unclear.`)
     expect(sequential).toEqual(
       buildInvestorNoteReviewArtifact([first, second])
     );
-    expect(() =>
-      buildInvestorNoteReviewArtifact([
-        first,
-        { ...first, transcript: 'Changed transcript.' },
-      ])
-    ).toThrow('has a changed transcript hash');
+    const mutations = [
+      { ...first, transcript: 'Changed transcript.' },
+      { ...first, source: { ...first.source, label: 'Changed label' } },
+      {
+        ...first,
+        source: { ...first.source, capturedAt: '2026-07-10' },
+      },
+      { ...first, signals: [{ ...tractionSignal, severity: 'critical' }] },
+      {
+        ...first,
+        signals: [{ ...tractionSignal, gapClassification: 'communication' }],
+      },
+      { ...first, signals: [{ ...tractionSignal, line: 1 }] },
+    ];
+    for (const mutation of mutations) {
+      expect(() => buildInvestorNoteReviewArtifact([first, mutation])).toThrow(
+        'has a changed source record'
+      );
+    }
   });
 
   it('normalizes Unicode with NFKC while retaining letters and numbers', () => {

--- a/apps/web/tests/unit/investors/note-ingestion.test.ts
+++ b/apps/web/tests/unit/investors/note-ingestion.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildInvestorNoteReviewArtifact,
+  inputsFromPriorArtifact,
   normalizeSignalText,
   parseAnnotatedTranscript,
 } from '@/lib/investors/note-ingestion';
@@ -97,11 +98,31 @@ OBJECTION | strategy | critical | The buyer is unclear.`)
     expect(artifact.candidates[0]?.sources).toHaveLength(1);
   });
 
-  it('rejects repeated source IDs instead of inflating frequency', () => {
+  it('deduplicates repeated source IDs with identical transcript hashes', () => {
     const input = note({ id: 'conversation-a', signals: [tractionSignal] });
-    expect(() => buildInvestorNoteReviewArtifact([input, input])).toThrow(
-      'Duplicate investor note source ID: conversation-a'
+    expect(buildInvestorNoteReviewArtifact([input, input]).sourceCount).toBe(1);
+  });
+
+  it('makes sequential corpus ingestion equal batch and rejects changed sources', () => {
+    const first = note({ id: 'conversation-a', signals: [tractionSignal] });
+    const second = note({
+      id: 'conversation-b',
+      signals: [{ ...tractionSignal, severity: 'critical' }],
+    });
+    const initial = buildInvestorNoteReviewArtifact([first]);
+    const sequential = buildInvestorNoteReviewArtifact([
+      ...inputsFromPriorArtifact(initial),
+      second,
+    ]);
+    expect(sequential).toEqual(
+      buildInvestorNoteReviewArtifact([first, second])
     );
+    expect(() =>
+      buildInvestorNoteReviewArtifact([
+        first,
+        { ...first, transcript: 'Changed transcript.' },
+      ])
+    ).toThrow('has a changed transcript hash');
   });
 
   it('normalizes Unicode with NFKC while retaining letters and numbers', () => {

--- a/docs/fundraising/investor-note-ingestion.md
+++ b/docs/fundraising/investor-note-ingestion.md
@@ -25,7 +25,7 @@ From `apps/web`:
 pnpm exec tsx scripts/ingest-investor-note.ts \
   tests/fixtures/investors/note-a.json \
   tests/fixtures/investors/note-b.json \
-  --out=/tmp/investor-note-review.json
+  --out=../../.artifacts/fundraising/investor-note-review.json
 ```
 
 For plain text, also provide the source date:
@@ -34,25 +34,64 @@ For plain text, also provide the source date:
 pnpm exec tsx scripts/ingest-investor-note.ts exported-note.txt \
   --source-id=conversation-2026-07-11-example \
   --captured-at=2026-07-11 \
-  --out=/tmp/investor-note-review.json
+  --out=../../.artifacts/fundraising/investor-note-review.json
 ```
+
+Outputs are required to be `.json` files under the repository-local
+`.artifacts/fundraising/` directory. That directory is gitignored because the
+artifact retains source transcripts for deterministic incremental ingestion.
+The CLI resolves real paths, rejects symlink inputs and output components, and
+refuses every output outside that root, including with `--overwrite`.
+
+To add notes without losing prior frequency evidence, pass the previous artifact:
+
+```bash
+pnpm exec tsx scripts/ingest-investor-note.ts new-note.json \
+  --prior=../../.artifacts/fundraising/investor-note-review.json \
+  --out=../../.artifacts/fundraising/investor-note-review-next.json
+```
+
+The embedded corpus deduplicates an unchanged `source.id` plus transcript hash.
+Reusing a source ID with a changed transcript hash is rejected. Sequential
+ingestion therefore produces the same artifact as a single batch.
 
 ## Review Contract
 
 The artifact normalizes Unicode with NFKC and merges duplicate questions or objections. It preserves every observed gap classification, chooses canonical text deterministically, keeps the highest observed severity, and sorts and deduplicates provenance. `occurrenceCount` counts mentions; frequency uses distinct conversation IDs so repetition inside one note cannot inflate it.
 
-The CLI refuses `.env*`, `.npmrc`, `.git`, `node_modules`, and the canonical fundraising registry as input or output. Output cannot equal any input. Files are created exclusively by default; `--overwrite` is explicit and never bypasses protected-path or input-collision checks. CLI stdout and stderr are JSON.
+The CLI refuses `.env*`, `.npmrc`, `.git`, `node_modules`, and the canonical fundraising registry as input. Files are created exclusively by default; `--overwrite` is explicit and never bypasses containment, realpath, or symlink checks. CLI stdout and stderr are JSON.
 
 Every artifact is `manual-review-required` and declares `autoPublish: false`. Claims, numbers, the ask, and positioning are protected fields. Candidates include deterministic next actions and proposed review targets for the portal, deck, outreach brief, or registry.
 
-To perform the manual review, create a dedicated branch and draft PR:
+## Guarded Proposal and Draft PR
+
+Create a proposal JSON with `proposalVersion: "1.0.0"`, a stable `slug`, a
+title, and `approvedCandidates`. Each approved item must include an exact
+candidate key, concrete proposed copy, action, allowed target, protected-field
+review flags, and evidence references copied from that candidate's sources.
+Unknown candidates, non-allowed targets, missing evidence, and mismatched
+source IDs, hashes, or line references are rejected.
+
+Preview the deterministic Markdown and git plan without writing or calling a
+remote service (the default):
 
 ```bash
-git switch -c codex/jov-3739-investor-note-review
-# Review the artifact; edit only source-backed risks or communication.
-pnpm --filter @jovie/web exec vitest run tests/unit/investors/fundraising-registry.test.ts
-gh pr create --draft --base codex/jov-3739-investor-note-ingestion \
-  --title "docs(investors): review investor note signals"
+pnpm exec tsx scripts/create-investor-review-draft.ts \
+  --proposal=proposal.json \
+  --artifact=../../.artifacts/fundraising/investor-note-review.json
 ```
 
-The command is deliberately manual. The ingestion script never creates branches, edits the registry, opens PRs, or copies transcript text into investor-facing claims.
+After reviewing the dry-run JSON, explicitly request the external draft stage:
+
+```bash
+pnpm exec tsx scripts/create-investor-review-draft.ts \
+  --proposal=proposal.json \
+  --artifact=../../.artifacts/fundraising/investor-note-review.json \
+  --publish-draft
+```
+
+The opt-in command refuses dirty worktrees and local or remote branch
+collisions. It creates a new `codex/investor-review-*` branch, commits only the
+tracked proposal Markdown under `docs/fundraising/reviews/proposals/`, pushes
+that branch, and opens a GitHub **draft** PR. It never edits registry, portal,
+deck, claims, numbers, ask, or positioning; marks a PR ready; merges; or deploys.

--- a/docs/fundraising/investor-note-ingestion.md
+++ b/docs/fundraising/investor-note-ingestion.md
@@ -91,7 +91,13 @@ pnpm exec tsx scripts/create-investor-review-draft.ts \
 ```
 
 The opt-in command refuses dirty worktrees and local or remote branch
-collisions. It creates a new `codex/investor-review-*` branch, commits only the
-tracked proposal Markdown under `docs/fundraising/reviews/proposals/`, pushes
-that branch, and opens a GitHub **draft** PR. It never edits registry, portal,
-deck, claims, numbers, ask, or positioning; marks a PR ready; merges; or deploys.
+collisions. It creates the `codex/investor-review-*` branch in an isolated
+temporary git worktree, leaving the caller's checkout and branch untouched. It
+commits only the tracked proposal Markdown under
+`docs/fundraising/reviews/proposals/`, pushes that branch, and opens a GitHub
+**draft** PR. Pre-push failures remove the temporary worktree, artifact, and
+new local branch. If draft-PR creation fails after push, the newly-created
+remote branch is deleted; a failed deletion reports the exact recoverable
+remote state. The command never deletes a preexisting branch, edits registry,
+portal, deck, claims, numbers, ask, or positioning; marks a PR ready; merges;
+or deploys.

--- a/docs/fundraising/investor-note-ingestion.md
+++ b/docs/fundraising/investor-note-ingestion.md
@@ -96,8 +96,12 @@ temporary git worktree, leaving the caller's checkout and branch untouched. It
 commits only the tracked proposal Markdown under
 `docs/fundraising/reviews/proposals/`, pushes that branch, and opens a GitHub
 **draft** PR. Pre-push failures remove the temporary worktree, artifact, and
-new local branch. If draft-PR creation fails after push, the newly-created
-remote branch is deleted; a failed deletion reports the exact recoverable
-remote state. The command never deletes a preexisting branch, edits registry,
+new local branch. Remote ownership is bound to the exact locally-recorded
+commit SHA, and rollback deletion uses an expected-OID lease, so a ref changed
+by another actor is never deleted. If draft-PR creation reports failure, the
+command first queries the exact repository, head, and base: an observable PR
+is reported with its URL/state and the branch is retained; an indeterminate
+query also retains the branch with explicit recovery instructions. The command
+never deletes a preexisting or different-SHA branch, edits registry,
 portal, deck, claims, numbers, ask, or positioning; marks a PR ready; merges;
 or deploys.


### PR DESCRIPTION
## Summary
- confine transcript-bearing review JSON to gitignored `.artifacts/fundraising` with `.json`, realpath, lstat, and symlink protections
- persist an append-only normalized corpus so prior-artifact ingestion is batch-equivalent and changed source hashes are rejected
- validate approved candidate proposals and provide a default dry-run command whose explicit publish mode commits only proposal Markdown and opens a draft PR

## Safety contract
- arbitrary regular source files are accepted; symlink inputs and output paths are rejected
- publish mode refuses dirty worktrees, invalid candidates/targets/evidence, and local or remote branch collisions
- no registry, portal, deck, claims, numbers, ask, or positioning edits; never ready, merge, or deploy

## Verification
- `pnpm biome check --write <changed paths>`
- `pnpm --filter @jovie/web exec vitest run tests/unit/investors/note-ingestion.test.ts tests/unit/investors/note-ingestion-cli.test.ts tests/unit/investors/investor-review-proposal.test.ts tests/unit/investors/investor-review-draft-cli.test.ts` (25/25)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hooks and pre-push gates passed

Stacked on #14010.

<!-- linear-issue-id:JOV-3739 -->