### PR TITLE
test(e2e): follow canonical onboarding activation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2987,6 +2987,10 @@ jobs:
           export SENTRY_ENVIRONMENT=ci-pr-e2e
           export SENTRY_RELEASE="${{ github.sha }}"
           export E2E_USE_TEST_AUTH_BYPASS=1
+          # golden-path.spec.ts is part of the smoke manifest. Its visible
+          # Better Auth signup requires the deterministic OTP contract, which
+          # is production-blocked and restricted to canonical +e2e addresses.
+          export E2E_TEST_MODE=1
           export VERCEL_ENV=development
           export E2E_TEST_AUTH_PERSONA=creator-ready
           export NEXT_PUBLIC_CLERK_MOCK=1
@@ -3176,6 +3180,9 @@ jobs:
           # Enables Better Auth's deterministic OTP only for the golden path's
           # canonical +e2e test address; production hard-blocks this switch.
           export E2E_TEST_MODE=1
+          # Makes the anonymous /start turn deterministic while preserving the
+          # real session cookie, persistence, signup, claim, and activation path.
+          export CHAT_LLM_FAILURE_INJECTION=1
           export NEXT_PUBLIC_APP_URL=http://localhost:3100
           # GHA HOSTNAME is the runner machine name; pin loopback so BA redirects
           # and form origin checks stay on localhost:3100.

--- a/apps/web/app/api/chat/onboarding-handler.ts
+++ b/apps/web/app/api/chat/onboarding-handler.ts
@@ -175,6 +175,10 @@ function shouldBypassTurnstileForLocalRuntime(req: Request): boolean {
     env.NODE_ENV === 'development' ||
     publicEnv.NEXT_PUBLIC_E2E_MODE === '1' ||
     publicEnv.NEXT_PUBLIC_CLERK_MOCK === '1' ||
+    // The fail-closed injection handshake is request-scoped, so the exact
+    // deterministic CI turn may bypass the challenge without opening the
+    // standalone server to unrelated anonymous requests.
+    isLlmFailureInjected(req) ||
     (env.PUBLIC_NOAUTH_SMOKE === '1' &&
       isLocalDevelopmentAutomationHostname(extractRequestHostname(req)))
   );
@@ -578,13 +582,13 @@ export async function tryHandleAnonymousOnboardingChat(
 
 /**
  * E2E-only LLM failure injection. Fails closed: the header is inert unless
- * the server was started with `CHAT_LLM_FAILURE_INJECTION=1`, and production
- * deploys ignore it unconditionally.
+ * the server was started with `CHAT_LLM_FAILURE_INJECTION=1`, and secure
+ * preview/production deploys ignore it unconditionally.
  */
 function isLlmFailureInjected(req: Request): boolean {
   return (
+    !isSecureTurnstileEnvironment(req) &&
     env.CHAT_LLM_FAILURE_INJECTION === '1' &&
-    env.VERCEL_ENV !== 'production' &&
     req.headers.get('x-jovie-e2e-llm-failure') === '1'
   );
 }

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -881,6 +881,7 @@ export function OnboardingChat({
   const isSubmitted = status === 'submitted';
   const isStreaming = status === 'streaming';
   const isBusy = isSubmitted || isStreaming;
+  const isComposerInitializing = localAutomationBypass === null;
   const requiresTurnstile =
     process.env.NODE_ENV !== 'development' && localAutomationBypass !== true;
   const isAwaitingFirstToken =
@@ -1146,7 +1147,10 @@ export function OnboardingChat({
     onChange: handleInputChange,
     onSubmit: handleSubmit,
     isLoading: isBusy,
-    isSubmitting: isSubmitted,
+    // Keep the action inert until runtime Turnstile/automation policy has
+    // resolved. submitText intentionally rejects turns in this window, so an
+    // enabled button would acknowledge a click without sending anything.
+    isSubmitting: isSubmitted || isComposerInitializing,
     isStreaming,
     onStop: stop,
     // Raw "Securing chat..." text is replaced in follow-up pass with
@@ -1172,6 +1176,14 @@ export function OnboardingChat({
       className='relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-(--linear-app-content-surface)'
       aria-label='Jovie Onboarding Chat'
       data-testid='onboarding-chat'
+      data-interaction-ready={isComposerInitializing ? 'false' : 'true'}
+      data-automation-bypass={
+        localAutomationBypass === null
+          ? 'pending'
+          : localAutomationBypass
+            ? 'true'
+            : 'false'
+      }
       data-picker-open={composerPickerOpen ? 'true' : undefined}
     >
       {/* Scroll area (flex-1) — upper content morphs on first message */}

--- a/apps/web/tests/e2e/golden-path.spec.ts
+++ b/apps/web/tests/e2e/golden-path.spec.ts
@@ -8,12 +8,15 @@ import {
 } from '../helpers/clerk-auth';
 
 /**
- * Golden Path E2E — Signup -> Onboarding -> Music Fetch -> Live Profile
+ * Golden Path E2E — Anonymous Chat -> Signup -> Claim -> Live Profile
  *
  * Tests the complete new-user journey end to end with REAL data:
- * - No mocks for music fetch
+ * - Real anonymous conversation persistence and Better Auth signup
+ * - Deterministic confirmed artist/handle tool-call fixtures
+ * - Real claim endpoint and public profile activation
  * - No pre-authenticated state
- * - Real Better Auth email-OTP signup (test environment)
+ *
+ * MusicFetch integration coverage remains in musicfetch-coverage.spec.ts.
  *
  * Jovie's pricing is a 14-day reverse trial with NO card required at signup
  * (see docs/PRICING-PHILOSOPHY.md), so the golden path's "first value" moment
@@ -308,11 +311,103 @@ async function createFreshUser(page: import('@playwright/test').Page) {
     : new Error('Failed to create Better Auth test user');
 }
 
+async function seedAnonymousOnboardingJourney(page: Page, handle: string) {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) throw new Error('DATABASE_URL required for onboarding seed');
+
+  // The real-Clerk artifact intentionally omits compile-time E2E flags. Mark
+  // only this browser as local automation before React initializes so the
+  // anonymous turn bypasses Turnstile without enabling auth bypass.
+  await page.addInitScript(() => {
+    document.documentElement.dataset.e2eMode = '1';
+  });
+  await page.route('**/api/chat', async route => {
+    await route.continue({
+      headers: {
+        ...route.request().headers(),
+        'x-jovie-e2e-llm-failure': '1',
+      },
+    });
+  });
+  await page.goto('/start', { waitUntil: 'domcontentloaded' });
+  await expect(
+    page.getByTestId('onboarding-chat'),
+    'Onboarding runtime policy did not finish initializing'
+  ).toHaveAttribute('data-interaction-ready', 'true', { timeout: 30_000 });
+  await expect(
+    page.getByTestId('onboarding-chat'),
+    'Golden path browser did not activate the local automation bypass'
+  ).toHaveAttribute('data-automation-bypass', 'true');
+  await expect(
+    page.locator('[aria-label="Chat message input" i]')
+  ).toBeVisible();
+
+  await page
+    .locator('[aria-label="Chat message input" i]')
+    .fill('I am Tim White');
+  const sendButton = page.getByRole('button', { name: 'Send message' });
+  await expect(sendButton).toBeEnabled();
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      response =>
+        response.request().method() === 'POST' &&
+        new URL(response.url()).pathname === '/api/chat'
+    ),
+    sendButton.click(),
+  ]);
+  expect(response.status()).toBe(200);
+  const conversationId = response.headers()['x-conversation-id'];
+  expect(
+    conversationId,
+    'Anonymous chat did not reserve a conversation'
+  ).toBeTruthy();
+
+  const sql = neon(dbUrl);
+  const toolCalls = [
+    {
+      schemaVersion: 2,
+      toolCallId: `golden-artist-${Date.now()}`,
+      toolName: 'confirmSpotifyArtist',
+      state: 'succeeded',
+      output: {
+        action: 'spotify_artist_confirmed',
+        spotifyArtistId: '4Uwpa6zW3zzCSQvooQNksm',
+        artist: {
+          id: '4Uwpa6zW3zzCSQvooQNksm',
+          name: 'Tim White',
+          url: 'https://open.spotify.com/artist/4Uwpa6zW3zzCSQvooQNksm',
+        },
+      },
+      uiHint: 'artifact',
+    },
+    {
+      schemaVersion: 2,
+      toolCallId: `golden-handle-${Date.now()}`,
+      toolName: 'checkHandle',
+      state: 'succeeded',
+      output: { action: 'check_handle', handle },
+      uiHint: 'artifact',
+    },
+  ];
+  const updated = await sql`
+    UPDATE chat_messages
+    SET tool_calls = ${JSON.stringify(toolCalls)}::jsonb
+    WHERE id = (
+      SELECT id FROM chat_messages
+      WHERE conversation_id = ${conversationId}
+      ORDER BY created_at DESC LIMIT 1
+    )
+    RETURNING id
+  `;
+  expect(updated.length, 'Anonymous chat message was not persisted').toBe(1);
+  return conversationId;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Test suite                                                          */
 /* ------------------------------------------------------------------ */
 
-test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Live Profile', () => {
+test.describe('Golden Path: Anonymous Chat -> Signup -> Claim -> Live Profile', () => {
   test.describe.configure({ mode: 'serial' });
 
   // Fresh browser — no inherited auth state
@@ -340,102 +435,44 @@ test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Live Profile'
       timeout: 30_000,
     });
 
-    // The collapsed homepage (#11988) is hero + minimal footer: no claim
-    // input, no signup links — the funnel routes through the hero command
-    // center into /start chat. Assert the hero rendered, then enter the
-    // classic signup path directly (this spec's scope is signup →
-    // onboarding → live profile, not the chat funnel).
+    // The collapsed homepage routes onboarding through /start chat.
     await expect(page.getByTestId('homepage-hero-command-center')).toBeVisible({
       timeout: 20_000,
     });
 
     // ──────────────────────────────────────────────────────────────────
-    // STEP 2: Initiate signup
+    // STEP 2: Start the canonical anonymous chat journey
     // ──────────────────────────────────────────────────────────────────
-    await page.goto('/signup', {
-      waitUntil: 'domcontentloaded',
-      timeout: 30_000,
-    });
-    await page.waitForURL(/\/(signup|onboarding)/, { timeout: 30_000 });
+    const randomSuffix = Math.random().toString(36).slice(2, 8);
+    const uniqueHandle = `t${Date.now().toString(36)}${randomSuffix}`;
+    const conversationId = await seedAnonymousOnboardingJourney(
+      page,
+      uniqueHandle
+    );
 
     // ──────────────────────────────────────────────────────────────────
     // STEP 3: Create account
     // ──────────────────────────────────────────────────────────────────
     const { betterAuthUserId } = await createFreshUser(page);
-
-    // ──────────────────────────────────────────────────────────────────
-    // STEP 4: Onboarding — Handle step
-    // ──────────────────────────────────────────────────────────────────
-    // Generate a unique handle and pass it via search param.
-    // When the handle is pre-filled via ?handle=, the validation hook's
-    // fast path marks it as available immediately (skips API check),
-    // avoiding the TanStack Pacer debouncer state race condition.
-    const randomSuffix = Math.random().toString(36).slice(2, 8);
-    const uniqueHandle = `t${Date.now().toString(36)}${randomSuffix}`;
-
-    // Navigate to onboarding with pre-filled handle, submit handle step,
-    // and advance to DSP step. Retry the whole sequence since the Neon
-    // WebSocket pool can fail during SSR or server action execution.
-    await expect(async () => {
-      await page.goto(`/onboarding?handle=${uniqueHandle}`, {
-        waitUntil: 'domcontentloaded',
-        timeout: 60_000,
-      });
-      await expect(
-        page.locator('[data-testid="onboarding-form-wrapper"]')
-      ).toBeVisible({ timeout: 10_000 });
-
-      // Handle input should be pre-filled
-      const handleEl = page.getByLabel('Claim Your Handle');
-      const handleVisible = await handleEl
-        .isVisible({ timeout: 3_000 })
-        .catch(() => false);
-
-      if (handleVisible) {
-        // Still on handle step — submit it through the icon-only claim button.
-        await expect
-          .poll(async () => (await handleEl.inputValue()).trim(), {
-            timeout: 20_000,
-          })
-          .toBe(uniqueHandle);
-
-        const claimHandleButton = page.getByTestId('onboarding-handle-submit');
-        await expect(claimHandleButton).toBeEnabled({ timeout: 30_000 });
-        await claimHandleButton.click();
-      }
-
-      // Must reach DSP step (artist search)
-      await expect(
-        page.getByPlaceholder(/search by artist name or paste a spotify link/i)
-      ).toBeVisible({ timeout: 60_000 });
-    }).toPass({
-      timeout: 180_000,
-      intervals: [3_000, 5_000, 10_000, 15_000],
-    });
-
-    // ──────────────────────────────────────────────────────────────────
-    // STEP 5: Onboarding — Artist search (Music Fetch)
-    // ──────────────────────────────────────────────────────────────────
-    const artistInput = page.getByPlaceholder(
-      /search by artist name or paste a spotify link/i
-    );
-    await expect(artistInput).toBeVisible({ timeout: 5_000 });
-
     const TEST_SPOTIFY_ID = '4Uwpa6zW3zzCSQvooQNksm';
     const testSpotifyUrl = `https://open.spotify.com/artist/${TEST_SPOTIFY_ID}`;
-    const capturedSpotifyUrl: string | null = testSpotifyUrl;
-    const capturedSpotifyId: string | null = TEST_SPOTIFY_ID;
 
-    await artistInput.fill(testSpotifyUrl);
-
-    // ──────────────────────────────────────────────────────────────────
-    // STEP 6: Current onboarding V2 — verify import and finish path
-    // ──────────────────────────────────────────────────────────────────
-
-    const importCompleteHeading = page.getByRole('heading', {
-      name: /^(Spotify connected|Your Link Is Live)$/i,
-    });
-    await expect(importCompleteHeading).toBeVisible({ timeout: 180_000 });
+    // Exercise the real activation endpoint. Signup may already have called it;
+    // the endpoint is intentionally idempotent, so assert its durable outcome.
+    const claim = await page.request.post('/api/onboarding/claim');
+    expect(claim.status()).toBe(200);
+    const sql = neon(process.env.DATABASE_URL!);
+    await expect
+      .poll(async () => {
+        const rows = await sql`
+          SELECT cp.id FROM creator_profiles cp
+          INNER JOIN users u ON u.id = cp.user_id
+          WHERE u.better_auth_user_id = ${betterAuthUserId}
+            AND cp.username_normalized = ${uniqueHandle}
+        `;
+        return rows.length;
+      })
+      .toBe(1);
 
     // Ensure Spotify URL is saved on the profile via direct DB write.
     // The fire-and-forget connectSpotifyArtist uses the flaky WebSocket pool
@@ -444,10 +481,10 @@ test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Live Profile'
     //
     // Fallback uses a known real Spotify artist ID for "Tim White" in case
     // the response interceptor didn't capture the URL (e.g. search cached).
-    const spotifyIdToSave = capturedSpotifyId || TEST_SPOTIFY_ID;
-    const spotifyUrlToSave = capturedSpotifyUrl || testSpotifyUrl;
+    const spotifyIdToSave = TEST_SPOTIFY_ID;
+    const spotifyUrlToSave = testSpotifyUrl;
     console.log(
-      `[golden-path] Setting spotify_url=${spotifyUrlToSave} spotify_id=${spotifyIdToSave} (captured=${capturedSpotifyUrl})`
+      `[golden-path] Activated conversation=${conversationId}; setting spotify_url=${spotifyUrlToSave}`
     );
     await ensureSpotifyUrlOnProfile(
       betterAuthUserId,

--- a/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
+++ b/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
@@ -278,7 +278,7 @@ describe('tryHandleAnonymousOnboardingChat', () => {
 
   it('honors LLM failure injection only when the server env enables it', async () => {
     vi.resetModules();
-    stubRuntimeEnv();
+    stubRuntimeEnv({ nodeEnv: 'test' });
     vi.stubEnv('CHAT_LLM_FAILURE_INJECTION', '1');
     const { tryHandleAnonymousOnboardingChat } = await import(
       '@/app/api/chat/onboarding-handler'
@@ -293,6 +293,8 @@ describe('tryHandleAnonymousOnboardingChat', () => {
     expect(result?.status).toBe(200);
     expect(result?.headers.get('x-fallback-reason')).toBe('injected');
     expect(hoisted.executeChatTurnMock).not.toHaveBeenCalled();
+    expect(hoisted.isTurnstileConfiguredMock).not.toHaveBeenCalled();
+    expect(hoisted.verifyTurnstileTokenMock).not.toHaveBeenCalled();
   });
 
   it('ignores the injection header when the env flag is not set', async () => {
@@ -362,6 +364,54 @@ describe('tryHandleAnonymousOnboardingChat', () => {
 
     expect(result?.status).toBe(200);
     expect(result?.headers.get('x-fallback-reason')).toBeNull();
+    expect(hoisted.executeChatTurnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores injection and dispatches normally on preview deploys', async () => {
+    vi.resetModules();
+    stubRuntimeEnv({ nodeEnv: 'test', vercelEnv: 'preview' });
+    vi.stubEnv('CHAT_LLM_FAILURE_INJECTION', '1');
+    hoisted.checkGateForUserMock.mockResolvedValue(false);
+    hoisted.isTurnstileConfiguredMock.mockReturnValue(true);
+    hoisted.verifyTurnstileTokenMock.mockResolvedValue({ success: true });
+    hoisted.executeChatTurnMock.mockResolvedValue({
+      streamResult: {
+        toUIMessageStreamResponse: ({
+          headers,
+        }: {
+          headers: Record<string, string>;
+        }) => new Response('normal-preview-response', { status: 200, headers }),
+      },
+      selectedModel: 'anthropic/claude-haiku-4-5-20251001',
+      systemPrompt: '',
+      toolNames: [],
+      modelMessages: [],
+    });
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest(
+      {
+        mode: 'onboarding',
+        turnstileToken: 'valid-preview-token',
+        messages: [userMessage('hi')],
+      },
+      '',
+      { 'x-jovie-e2e-llm-failure': '1' }
+    );
+    const result = await tryHandleAnonymousOnboardingChat(
+      req,
+      'req-preview-inject'
+    );
+
+    expect(result?.status).toBe(200);
+    expect(result?.headers.get('x-fallback-reason')).toBeNull();
+    expect(await result?.text()).toBe('normal-preview-response');
+    expect(hoisted.isTurnstileConfiguredMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.verifyTurnstileTokenMock).toHaveBeenCalledWith(
+      'valid-preview-token',
+      '203.0.113.5'
+    );
     expect(hoisted.executeChatTurnMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -55,6 +55,16 @@ function getJobBlock(workflow: string, jobKey: string): string {
   return block.join('\n');
 }
 
+describe('golden-path smoke OTP contract', () => {
+  it('enables deterministic OTP when the smoke manifest runs golden path', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const smokeStep = getStepBlock(workflow, 'Run E2E Smoke (Chromium)');
+
+    expect(smokeStep).toContain('export E2E_TEST_MODE=1');
+    expect(smokeStep).toContain('export E2E_USE_TEST_AUTH_BYPASS=1');
+  });
+});
+
 describe('deploy workflow Vercel env resolution', () => {
   it('pins Vercel pull and build commands to the configured project', () => {
     const workflow = readFileSync(workflowPath, 'utf8');

--- a/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { type FormEvent, type ReactNode, useState } from 'react';
+import { renderToString } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OnboardingChat } from '@/components/features/onboarding/OnboardingChat';
 import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
@@ -296,6 +297,30 @@ describe('OnboardingChat Turnstile gating', () => {
     expect(chatMocks.sendMessage).not.toHaveBeenCalled();
   });
 
+  it('keeps send disabled until runtime interaction policy resolves', async () => {
+    const serverMarkup = renderToString(
+      <OnboardingChat turnstileStatus='interactive' turnstileToken={null} />
+    );
+    expect(serverMarkup).toContain('data-interaction-ready="false"');
+    expect(serverMarkup).toMatch(
+      /<button[^>]*aria-label="Send message"[^>]*disabled=""/
+    );
+
+    render(
+      <OnboardingChat turnstileStatus='interactive' turnstileToken={null} />
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('onboarding-chat')).toHaveAttribute(
+        'data-interaction-ready',
+        'true'
+      )
+    );
+    expect(screen.getByTestId('onboarding-chat')).toHaveAttribute(
+      'data-automation-bypass',
+      'false'
+    );
+  });
+
   it('keeps the first message local and shows verification guidance until a token exists', () => {
     const onTurnstileRequired = vi.fn();
     render(
@@ -348,6 +373,10 @@ describe('OnboardingChat Turnstile gating', () => {
     );
 
     await waitFor(() => expect(chatMocks.sendMessage).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('onboarding-chat')).toHaveAttribute(
+      'data-automation-bypass',
+      'true'
+    );
     expect(chatMocks.sendMessage).toHaveBeenCalledWith({
       text: 'Hey, I want to get access to Jovie.',
     });


### PR DESCRIPTION
## Root cause

The removed classic `/onboarding` fixture was replaced with the canonical `/start` chat, but the real-Clerk Golden artifact intentionally has no compile-time E2E marker. The retry trace proves React handled the send click and opened the Turnstile slot; it emitted no `/api/chat` request. `data-interaction-ready=true` only proved that runtime policy had resolved, not that the local automation bypass was active.

Classification: PR-specific broken fixture contract. The concurrent `429` from `/api/auth/get-session` was environment/rate-limit noise and did not cause the failed send. Shared Storybook, mobile, authenticated-a11y, smoke, and deploy-test failures are tracked outside this PR.

## Fix

- establish the existing browser-scoped E2E marker with `page.addInitScript` before React initializes, without enabling auth bypass
- require `data-automation-bypass=true` before sending so missing setup fails immediately
- make the fail-closed LLM-injection env+header handshake bypass Turnstile only in non-secure local/test runtimes; preview and production remain fail-closed
- wait for the exact POST `/api/chat` response
- preserve the real Better Auth signup, durable anonymous conversation, claim endpoint, profile materialization, and live public profile assertions

## Regression coverage

- local injection bypasses Turnstile only when both env and request header are present
- preview rejects the same injection handshake and remains fail-closed
- UI diagnostics distinguish policy resolution from the resolved bypass value

## Verification

Exact head: `5f74140079ec9e1570112fba7deb683cb3862d02`

- Node `22.22.1`, pnpm `9.15.4`
- affected Vitest suites: 32/32 passed
- web typecheck passed
- Biome, proxy guard, Tailwind guard, actionlint, diff check, secret scan, and pre-push hook passed
- exact-head Golden Path CI is running

The PR remains draft and has no merge-queue label. No production or preview bypass is introduced.