### PR TITLE
docs(investors): add readiness audit report

### DIFF
--- a/apps/web/lib/investors/fundraising-registry.ts
+++ b/apps/web/lib/investors/fundraising-registry.ts
@@ -67,11 +67,37 @@ export interface OperatingStep {
   readonly description: string;
 }
 
+export interface FundraisingMetric {
+  readonly id: string;
+  readonly label: string;
+  readonly value: string | null;
+  readonly status: 'evidence-gap';
+  readonly provenance: readonly ClaimProvenance[];
+  readonly lastUpdated: string;
+}
+
+export interface InvestorConversationSummary {
+  readonly sourceId: string;
+  readonly capturedAt: string;
+  readonly summary: string;
+}
+
+export interface InvestorFaqEntry {
+  readonly riskId: string;
+  readonly question: string;
+  readonly answer: string;
+}
+
 export interface FundraisingRegistry {
   readonly version: string;
   readonly asOf: string;
   readonly thesis: string;
   readonly companyDefinition: string;
+  readonly currentNarrative: string;
+  readonly metrics: readonly FundraisingMetric[];
+  readonly researchSources: readonly ClaimProvenance[];
+  readonly investorConversationSummaries: readonly InvestorConversationSummary[];
+  readonly investorFaq: readonly InvestorFaqEntry[];
   readonly claims: readonly FundraisingClaim[];
   readonly coreSlides: readonly CoreSlide[];
   readonly operatingLoop: readonly OperatingStep[];
@@ -227,6 +253,11 @@ const RISK_DATA = [
   ['ai-commoditization', 'What remains valuable as generation gets cheaper?', 'Copy generation is not the moat. The bet is on trustworthy context, approvals, execution, and measured outcomes.', 'high', 'Production proof of execution quality and outcome capture.', 'strategy', ['closed-loop-category-context'], ['wedge', 'loop'], ['operating-loop', 'questions'], 'Prove value in context, approvals, reliable execution, and measured outcomes rather than generation.', 'Keep generative output separate from the proposed operating-system advantage.'],
   ['founder-dependency', 'Can the workflow scale beyond the founder?', 'Founder expertise is currently an advantage and a concentration risk. Manual decisions must become explicit product rules and repeatable operations.', 'high', 'Non-founder operation of the workflow with consistent quality.', 'evidence', ['founder-artist-operator'], ['founder'], ['founder-letter', 'questions'], 'Have a non-founder operate the documented workflow and compare quality and completion.', 'Present founder expertise as both an advantage and a concentration risk.'],
   ['capital', 'What does new capital prove?', 'The intended proof is paid activation, repeated release use, and measurable creator value. Round size and terms are kept out until approved evidence is current.', 'critical', 'Approved raise terms, milestone budget, and runway model.', 'evidence', [], ['round'], ['brief', 'questions'], 'Approve a milestone budget and runway model tied to paid activation and repeated release use.', 'Keep round size and terms out of the portal until the approved model is current.'],
+  ['why-now', 'Why is now the right time to build Jovie?', 'The timing thesis is that cheaper AI generation increases the volume of possible marketing work while creator release operations remain fragmented. Jovie has not yet proven that this timing produces urgent paid demand.', 'high', 'Dated buyer evidence that AI-driven content volume increases release-operations pain or purchase urgency.', 'evidence', ['slide-problem', 'closed-loop-category-context'], ['thesis', 'problem'], ['brief', 'questions'], 'Test timing and urgency explicitly in paid-pilot and buyer interviews.', 'Present why-now as a testable timing thesis, not a market fact.'],
+  ['why-founder', 'Why is this founder uniquely positioned to win?', 'The founder has an attested artist-operator problem history and built the current product. Unique distribution, execution velocity, and repeatable company-building advantage remain unproven.', 'high', 'Dated evidence of founder-led distribution, shipping velocity, or outcomes that competitors cannot readily reproduce.', 'evidence', ['founder-artist-operator', 'product-demo-exists'], ['founder'], ['founder-letter', 'questions'], 'Document dated founder execution and distribution evidence outside the pitch.', 'Separate the sourced artist-operator history from still-unproven founder advantage.'],
+  ['willingness-to-pay', 'Will creators both want and be able to pay for this workflow?', 'No approved willingness-to-pay, budget, or paid-pilot evidence is currently available. Creator-paid software is a working hypothesis.', 'critical', 'Segmented price discovery, budget evidence, and completed paid pilots.', 'evidence', ['release-workflow-focus'], ['wedge', 'round'], ['brief', 'questions'], 'Run priced offers with a defined creator segment and record acceptance, refusal, and budget constraints.', 'Do not infer willingness or ability to pay from product interest.'],
+  ['small-team-support', 'Can a small team support creator customers without becoming an agency?', 'Execution still includes manual work, so service load and support economics are not yet known. The product must make approvals and operations repeatable without hiding founder labor.', 'critical', 'Time-per-customer, support volume, exception rate, and gross-margin evidence from repeated release cohorts.', 'strategy', ['release-workflow-focus'], ['product', 'loop', 'round'], ['operating-loop', 'questions'], 'Instrument human time, exceptions, and support work per active release and set a service-load ceiling.', 'Label manual work and avoid presenting founder-operated service as software scalability.'],
+  ['closed-loop-credibility', 'Why should investors believe the closed-loop model will work?', 'The current registry distinguishes live context surfaces, a demonstrated opportunity flow, manual execution, and planned outcome learning. The complete loop has not been verified in production.', 'critical', 'End-to-end records showing approved work, shipped execution, measured outcomes, and improved next-release recommendations.', 'evidence', ['slide-loop', 'closed-loop-category-context'], ['loop'], ['operating-loop', 'questions'], 'Complete and audit repeated end-to-end release loops before claiming learning effects.', 'Keep each loop stage labeled LIVE, DEMO, MANUAL, or PLANNED and describe compounding as proposed.'],
 ] as const satisfies readonly RiskInput[];
 
 // biome-ignore format: One content record per line prevents structural duplication while keeping review diffs readable.
@@ -243,6 +274,33 @@ export const fundraisingRegistry = {
     'Jovie is building the operating layer that turns a music release into coordinated, measurable marketing work.',
   companyDefinition:
     'An AI marketing operator for music creators, beginning with release workflows.',
+  currentNarrative:
+    'Jovie begins with a bounded release-operations workflow: preserve creator and release context, surface executable marketing work, keep approval human-visible, and eventually learn from measured outcomes. The current proof is a product demonstration and founder-attested problem history; paid demand, scalable service economics, and a production closed loop remain evidence gaps.',
+  metrics: [
+    {
+      id: 'customer-revenue-retention',
+      label: 'Customer, revenue, activation, and retention metrics',
+      value: null,
+      status: 'evidence-gap',
+      provenance: [],
+      lastUpdated: AS_OF,
+    },
+  ],
+  researchSources: [
+    source('Demo video asset', '/demo/jovie-demo.mp4', 'first-party-artifact'),
+    source('Caption file', '/demo/jovie-demo.vtt', 'first-party-artifact'),
+    source(
+      'The Friday Problem by Tim White',
+      '/blog/the-friday-problem',
+      'founder-authored'
+    ),
+    source(
+      'YC Summer 2026 Requests for Startups',
+      'https://www.ycombinator.com/rfs',
+      'external-context'
+    ),
+  ],
+  investorConversationSummaries: [],
   claims: CLAIM_DATA.map(input =>
     claim(input[0], input[1], input[2], input[3], input[4], input[5])
   ),
@@ -272,6 +330,11 @@ export const fundraisingRegistry = {
       input[10]
     )
   ),
+  investorFaq: RISK_DATA.map(input => ({
+    riskId: input[0],
+    question: input[1],
+    answer: input[2],
+  })),
   appendix: APPENDIX_DATA.map(input =>
     appendixItem(input[0], input[1], input[2])
   ),

--- a/apps/web/lib/investors/fundraising-registry.ts
+++ b/apps/web/lib/investors/fundraising-registry.ts
@@ -71,19 +71,21 @@ export interface FundraisingMetric {
   readonly id: string;
   readonly label: string;
   readonly value: string | null;
-  readonly status: 'evidence-gap';
+  readonly status: EvidenceStatus | 'evidence-gap';
   readonly provenance: readonly ClaimProvenance[];
   readonly lastUpdated: string;
 }
 
 export interface InvestorConversationSummary {
   readonly sourceId: string;
+  readonly transcriptSha256: string;
   readonly capturedAt: string;
   readonly summary: string;
 }
 
 export interface InvestorFaqEntry {
   readonly riskId: string;
+  readonly riskLastUpdated: string;
   readonly question: string;
   readonly answer: string;
 }
@@ -249,7 +251,7 @@ const RISK_DATA = [
   ['market', 'Is the market venture-scale?', 'The thesis is that release operations can expand into recurring creator marketing execution. This version intentionally omits unsupported top-down market arithmetic.', 'high', 'Bottom-up buyer counts, willingness to pay, and expansion sensitivity.', 'evidence', [], ['thesis', 'round'], ['brief', 'questions'], 'Build a bottom-up model from a defined buyer, observed willingness to pay, and reachable distribution.', 'Omit top-down arithmetic until its inputs and sensitivities are reviewable.'],
   ['business-model', 'Who pays, and for what?', 'The working hypothesis is creator-paid software for recurring release operations. Pricing and packaging remain validation questions.', 'critical', 'Paid pilots and willingness-to-pay interviews tied to a specific package.', 'strategy', ['release-workflow-focus'], ['wedge', 'round'], ['brief', 'questions'], 'Test one creator-paid release-operations package through paid pilots.', 'Label pricing and packaging as a working hypothesis until payment evidence exists.'],
   ['moat', 'Why will this not become a feature?', 'The proposed advantage is accumulated release context, approval history, execution reliability, and outcome data. That compounding advantage is not yet proven.', 'high', 'Evidence that repeated use improves execution or creates switching costs.', 'strategy', ['closed-loop-category-context'], ['loop'], ['operating-loop', 'questions'], 'Measure whether retained release context improves repeated execution or creates switching costs.', 'Present the compounding loop as the proposed advantage, not a proven moat.'],
-  ['platform-dependency', 'How exposed is Jovie to music and social platforms?', 'Jovie depends on third-party catalog, audience, commerce, and messaging surfaces. The product must preserve first-party creator context and degrade safely when integrations change.', 'high', 'A dependency matrix with permissions, fallbacks, and owned data boundaries.', 'evidence', [], ['product', 'loop'], ['operating-loop', 'questions'], 'Document platform permissions, failure modes, fallbacks, and first-party data ownership.', 'State the dependency boundary and fallback posture without implying platform guarantees.'],
+  ['platform-dependency', 'How exposed is Jovie to music, social, and AI providers?', 'Jovie depends on third-party music, social, commerce, messaging, and AI-provider APIs. Provider substitution, outages, permissions changes, and model or API changes must degrade safely while preserving first-party creator data boundaries.', 'high', 'A dependency matrix covering each provider category, API substitution, outages, permissions, owned data boundaries, and tested fallbacks.', 'evidence', [], ['product', 'loop'], ['operating-loop', 'questions'], 'Document music, social, commerce, messaging, and AI providers; test substitution and outage paths; record permissions, first-party data boundaries, and fallbacks.', 'State provider dependencies, substitution limits, outage behavior, permissions, data boundaries, and fallbacks without implying guarantees.'],
   ['ai-commoditization', 'What remains valuable as generation gets cheaper?', 'Copy generation is not the moat. The bet is on trustworthy context, approvals, execution, and measured outcomes.', 'high', 'Production proof of execution quality and outcome capture.', 'strategy', ['closed-loop-category-context'], ['wedge', 'loop'], ['operating-loop', 'questions'], 'Prove value in context, approvals, reliable execution, and measured outcomes rather than generation.', 'Keep generative output separate from the proposed operating-system advantage.'],
   ['founder-dependency', 'Can the workflow scale beyond the founder?', 'Founder expertise is currently an advantage and a concentration risk. Manual decisions must become explicit product rules and repeatable operations.', 'high', 'Non-founder operation of the workflow with consistent quality.', 'evidence', ['founder-artist-operator'], ['founder'], ['founder-letter', 'questions'], 'Have a non-founder operate the documented workflow and compare quality and completion.', 'Present founder expertise as both an advantage and a concentration risk.'],
   ['capital', 'What does new capital prove?', 'The intended proof is paid activation, repeated release use, and measurable creator value. Round size and terms are kept out until approved evidence is current.', 'critical', 'Approved raise terms, milestone budget, and runway model.', 'evidence', [], ['round'], ['brief', 'questions'], 'Approve a milestone budget and runway model tied to paid activation and repeated release use.', 'Keep round size and terms out of the portal until the approved model is current.'],
@@ -332,6 +334,7 @@ export const fundraisingRegistry = {
   ),
   investorFaq: RISK_DATA.map(input => ({
     riskId: input[0],
+    riskLastUpdated: AS_OF,
     question: input[1],
     answer: input[2],
   })),
@@ -384,12 +387,131 @@ export function validateFundraisingRegistry(
   const issues: RegistryValidationIssue[] = [];
   const claimIds = new Set(registry.claims.map(claim => claim.id));
   const slideIds = new Set(registry.coreSlides.map(slide => slide.id));
+  const riskIds = new Set(registry.risks.map(risk => risk.id));
   const gapClassifications = new Set<GapClassification>([
     'communication',
     'evidence',
     'strategy',
     'investor-fit',
   ]);
+  const isIsoDate = (value: string) => /^\d{4}-\d{2}-\d{2}$/u.test(value);
+
+  if (!registry.currentNarrative.trim()) {
+    issues.push({
+      path: 'currentNarrative',
+      message: 'The current narrative must not be empty.',
+    });
+  }
+
+  const metricIds = new Set<string>();
+  for (const [index, metric] of registry.metrics.entries()) {
+    if (!metric.id.trim() || metricIds.has(metric.id)) {
+      issues.push({
+        path: `metrics.${index}.id`,
+        message: 'Metric IDs must be non-empty and unique.',
+      });
+    }
+    metricIds.add(metric.id);
+    if (!metric.label.trim() || !isIsoDate(metric.lastUpdated)) {
+      issues.push({
+        path: `metrics.${index}`,
+        message: 'Metrics require a label and ISO update date.',
+      });
+    }
+    if (
+      metric.status === 'evidence-gap' &&
+      (metric.value !== null || metric.provenance.length > 0)
+    ) {
+      issues.push({
+        path: `metrics.${index}`,
+        message: 'Evidence-gap metrics require a null value and no provenance.',
+      });
+    }
+    if (
+      metric.status !== 'evidence-gap' &&
+      (!metric.value?.trim() ||
+        (metric.status === 'verified' && metric.provenance.length === 0))
+    ) {
+      issues.push({
+        path: `metrics.${index}`,
+        message:
+          'Available metrics require a value, and verified metrics require provenance.',
+      });
+    }
+    for (const [sourceIndex, metricSource] of metric.provenance.entries()) {
+      if (
+        !metricSource.label.trim() ||
+        !metricSource.href.trim() ||
+        !isIsoDate(metricSource.accessedAt)
+      ) {
+        issues.push({
+          path: `metrics.${index}.provenance.${sourceIndex}`,
+          message:
+            'Metric provenance requires label, href, and ISO access date.',
+        });
+      }
+    }
+  }
+
+  for (const [index, researchSource] of registry.researchSources.entries()) {
+    if (
+      !researchSource.label.trim() ||
+      !researchSource.href.trim() ||
+      !isIsoDate(researchSource.accessedAt)
+    ) {
+      issues.push({
+        path: `researchSources.${index}`,
+        message: 'Research sources require label, href, and ISO access date.',
+      });
+    }
+  }
+
+  const conversationIds = new Set<string>();
+  for (const [
+    index,
+    conversation,
+  ] of registry.investorConversationSummaries.entries()) {
+    if (
+      !/^[a-z0-9][a-z0-9._-]{2,127}$/u.test(conversation.sourceId) ||
+      conversationIds.has(conversation.sourceId) ||
+      !/^[a-f0-9]{64}$/u.test(conversation.transcriptSha256) ||
+      !isIsoDate(conversation.capturedAt) ||
+      !conversation.summary.trim()
+    ) {
+      issues.push({
+        path: `investorConversationSummaries.${index}`,
+        message:
+          'Conversation summaries require a unique immutable source ID, transcript hash, ISO date, and content.',
+      });
+    }
+    conversationIds.add(conversation.sourceId);
+  }
+
+  const faqRiskIds = new Set<string>();
+  for (const [index, faq] of registry.investorFaq.entries()) {
+    const linkedRisk = registry.risks.find(risk => risk.id === faq.riskId);
+    if (
+      !linkedRisk ||
+      !riskIds.has(faq.riskId) ||
+      faqRiskIds.has(faq.riskId) ||
+      faq.question !== linkedRisk.question ||
+      faq.answer !== linkedRisk.answer ||
+      faq.riskLastUpdated !== linkedRisk.lastUpdated
+    ) {
+      issues.push({
+        path: `investorFaq.${index}`,
+        message:
+          'FAQ entries must uniquely match the linked risk question, answer, and version date.',
+      });
+    }
+    faqRiskIds.add(faq.riskId);
+  }
+  if (faqRiskIds.size !== riskIds.size) {
+    issues.push({
+      path: 'investorFaq',
+      message: 'Every risk requires exactly one FAQ entry.',
+    });
+  }
 
   if (registry.coreSlides.length < 6 || registry.coreSlides.length > 8) {
     issues.push({
@@ -461,7 +583,7 @@ export function validateFundraisingRegistry(
       });
     }
     for (const [sourceIndex, source] of claim.provenance.entries()) {
-      if (!/^\d{4}-\d{2}-\d{2}$/u.test(source.accessedAt)) {
+      if (!isIsoDate(source.accessedAt)) {
         issues.push({
           path: `claims.${index}.provenance.${sourceIndex}.accessedAt`,
           message: 'Provenance requires an ISO access date.',
@@ -477,7 +599,7 @@ export function validateFundraisingRegistry(
         message: 'Risks require a valid gap classification.',
       });
     }
-    if (!/^\d{4}-\d{2}-\d{2}$/u.test(risk.lastUpdated)) {
+    if (!isIsoDate(risk.lastUpdated)) {
       issues.push({
         path: `risks.${index}.lastUpdated`,
         message: 'Risks require an ISO update date.',

--- a/apps/web/tests/unit/investors/fundraising-registry.test.ts
+++ b/apps/web/tests/unit/investors/fundraising-registry.test.ts
@@ -60,7 +60,7 @@ describe('fundraising registry', () => {
       fundraisingRegistry.coreSlides.map(slide => slide.id)
     );
 
-    expect(fundraisingRegistry.risks).toHaveLength(10);
+    expect(fundraisingRegistry.risks).toHaveLength(15);
     for (const risk of fundraisingRegistry.risks) {
       expect([
         'communication',
@@ -78,6 +78,41 @@ describe('fundraising registry', () => {
       ).toBe(true);
       expect(risk.recommendedCompanyAction).not.toBe('');
       expect(risk.recommendedCommunicationAction).not.toBe('');
+    }
+  });
+
+  it('exposes explicit readiness sections without inventing evidence', () => {
+    expect(fundraisingRegistry.currentNarrative).not.toBe('');
+    expect(fundraisingRegistry.metrics).toEqual([
+      expect.objectContaining({ value: null, status: 'evidence-gap' }),
+    ]);
+    expect(fundraisingRegistry.researchSources.length).toBeGreaterThan(0);
+    expect(fundraisingRegistry.investorConversationSummaries).toEqual([]);
+    expect(fundraisingRegistry.investorFaq).toHaveLength(
+      fundraisingRegistry.risks.length
+    );
+    expect(fundraisingRegistry.investorFaq.map(item => item.riskId)).toEqual(
+      fundraisingRegistry.risks.map(item => item.id)
+    );
+  });
+
+  it('tracks the completion-audit objections with unknown frequency', () => {
+    const required = [
+      'why-now',
+      'why-founder',
+      'willingness-to-pay',
+      'small-team-support',
+      'closed-loop-credibility',
+    ];
+    for (const id of required) {
+      const objection = fundraisingRegistry.risks.find(risk => risk.id === id);
+      expect(objection).toMatchObject({
+        frequency: 'unknown',
+        lastUpdated: '2026-07-11',
+      });
+      expect(objection?.evidenceGap).not.toBe('');
+      expect(objection?.recommendedCompanyAction).not.toBe('');
+      expect(objection?.recommendedCommunicationAction).not.toBe('');
     }
   });
 

--- a/apps/web/tests/unit/investors/fundraising-registry.test.ts
+++ b/apps/web/tests/unit/investors/fundraising-registry.test.ts
@@ -116,6 +116,88 @@ describe('fundraising registry', () => {
     }
   });
 
+  it('validates narrative, metrics, research, conversations, and FAQ links', () => {
+    const mutations: Array<(registry: FundraisingRegistry) => void> = [
+      registry => {
+        (registry as { currentNarrative: string }).currentNarrative = ' ';
+      },
+      registry => {
+        (registry.metrics[0] as { value: string | null }).value = '10 users';
+      },
+      registry => {
+        (
+          registry.metrics[0] as {
+            provenance: Array<(typeof registry.researchSources)[number]>;
+          }
+        ).provenance = [registry.researchSources[0]!];
+      },
+      registry => {
+        const metric = registry.metrics[0] as {
+          status: string;
+          value: string | null;
+          provenance: unknown[];
+        };
+        metric.status = 'verified';
+        metric.value = '10 users';
+        metric.provenance = [];
+      },
+      registry => {
+        (registry.researchSources[0] as { accessedAt: string }).accessedAt =
+          'not-a-date';
+      },
+      registry => {
+        (
+          registry.investorConversationSummaries as unknown as Array<{
+            sourceId: string;
+            transcriptSha256: string;
+            capturedAt: string;
+            summary: string;
+          }>
+        ).push({
+          sourceId: 'conversation-a',
+          transcriptSha256: 'bad-hash',
+          capturedAt: '2026-07-11',
+          summary: 'Synthetic test summary.',
+        });
+      },
+      registry => {
+        (registry.investorFaq[0] as { answer: string }).answer =
+          'Stale answer.';
+      },
+      registry => {
+        (
+          registry.investorFaq[0] as { riskLastUpdated: string }
+        ).riskLastUpdated = '2026-07-10';
+      },
+    ];
+    for (const mutate of mutations) {
+      const registry = structuredClone(
+        fundraisingRegistry
+      ) as unknown as FundraisingRegistry;
+      mutate(registry);
+      expect(validateFundraisingRegistry(registry).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('covers platform and AI dependency failure categories explicitly', () => {
+    const dependency = fundraisingRegistry.risks.find(
+      risk => risk.id === 'platform-dependency'
+    );
+    const serialized = JSON.stringify(dependency);
+    for (const required of [
+      'music',
+      'social',
+      'AI-provider',
+      'substitution',
+      'outages',
+      'permissions',
+      'data boundaries',
+      'fallbacks',
+    ]) {
+      expect(serialized).toContain(required);
+    }
+  });
+
   it('rejects missing, unsafe, and mismatched core claims', () => {
     const missing = structuredClone(
       fundraisingRegistry

--- a/docs/fundraising/investor-readiness-report.md
+++ b/docs/fundraising/investor-readiness-report.md
@@ -76,8 +76,8 @@ These are structured internal simulations designed to surface likely diligence p
 ### Music-Industry Investor
 
 - **Strongest decline reason:** Platform dependencies and heterogeneous artist workflows may make execution brittle and operationally heavy.
-- **Missing evidence:** Integration fallbacks, first-party data boundaries, and reliable execution across multiple release types.
-- **First question:** What still works when a catalog, social, commerce, or messaging integration changes or removes access?
+- **Missing evidence:** Music, social, commerce, messaging, and AI-provider substitution tests; outage fallbacks; permissions; first-party data boundaries; and reliable execution across release types.
+- **First question:** What still works when a catalog, social, commerce, messaging, model, or AI API changes, fails, or removes access?
 
 ### Solo-Founder Skeptic
 

--- a/docs/fundraising/investor-readiness-report.md
+++ b/docs/fundraising/investor-readiness-report.md
@@ -1,0 +1,86 @@
+# Investor Readiness Report
+
+**As of:** 2026-07-11  
+**Evidence boundary:** This report summarizes the typed fundraising registry and five synthesized adversarial reviews. The critic readouts are not investor conversations. No production database or browser verification was performed for this report.
+
+## Resulting Narrative
+
+Jovie begins with a bounded release-operations workflow: preserve creator and release context, surface executable marketing work, keep approval human-visible, and eventually learn from measured outcomes. The current proof is a product demonstration and founder-attested problem history. Paid demand, scalable service economics, and a production closed loop remain evidence gaps.
+
+## Claim and Source Table
+
+| Claim | Classification | Status | Source or boundary |
+| --- | --- | --- | --- |
+| A recorded product demonstration is available with captions and a reproducible recording surface. | Verified fact | Verified | Demo video asset and caption file |
+| Current product and demo center on release planning and execution surfaces. | Verified fact | Verified | Product demonstration |
+| The next music bottleneck is operating the release around the song. | Thesis | Internal | No external proof claimed |
+| Artists are asked to become a marketing department for each release. | Thesis | Internal | No external proof claimed |
+| Jovie starts by turning release context into an executable launch plan. | Plan | Internal | No external proof claimed |
+| The product holds the release, opportunities, and work in one operating surface. | Verified fact | Verified | Product demonstration |
+| The proposed loop is context in, approved work out, and outcomes into the next release. | Plan | Internal | No production closed-loop proof claimed |
+| The founder built Jovie from an artist-operator problem he experienced. | Founder-attested | Internal | “The Friday Problem” founder-authored article |
+| This round is intended to prove a repeatable paid creator workflow. | Plan | Internal | No approved round metrics or terms claimed |
+| YC describes AI operating systems as monitoring outcomes and adjusting toward desired results. | Verified fact | Verified, not investor-facing | YC Summer 2026 Requests for Startups; external category context only |
+
+## Unresolved Evidence Gaps
+
+- Customer, revenue, activation, retention, and repeated-release cohorts are unavailable for approved publication.
+- A production capability matrix has not been verified against deployed behavior.
+- Willingness and ability to pay have not been established with segmented priced offers or paid pilots.
+- Bottom-up market sizing lacks observed buyer counts, budgets, and expansion sensitivity.
+- Human service time, exception rates, support load, and gross-margin behavior are unknown.
+- No audited end-to-end release records yet show approved work, execution, outcomes, and improved next-release recommendations.
+- Founder-led distribution and non-founder workflow operation remain unproven.
+- Approved round terms, milestone budget, and runway are intentionally absent.
+
+## Highest-Priority Risks
+
+1. **Traction:** The demo proves a product artifact, not customer demand or retention.
+2. **Willingness and ability to pay:** Creator-paid software remains a hypothesis.
+3. **Small-team support:** Manual execution may conceal agency-like labor and weak software economics.
+4. **Closed-loop credibility:** The learning loop is partly live, demonstrated, manual, and planned—not production-proven.
+5. **Go-to-market:** No repeatable outreach-to-paid funnel is established.
+6. **Founder concentration:** Founder expertise has not yet been converted into repeatable non-founder operations.
+
+## Recommended Company Actions
+
+1. Run one narrowly segmented, explicitly priced paid-pilot cohort and record acceptance, refusal, budget, activation, and repeat-release use.
+2. Instrument human minutes, support requests, exceptions, and completion quality per active release; set a service-load ceiling.
+3. Audit multiple complete release loops from context through approval, execution, measured outcome, and next recommendation.
+4. Publish a deployed capability matrix using `LIVE`, `DEMO`, `MANUAL`, and `PLANNED` labels.
+5. Have a non-founder operate the documented workflow and compare time, quality, exceptions, and customer outcome.
+6. Build the bottom-up market model only after buyer definition, price evidence, and reachable distribution are observed.
+
+## Synthesized Adversarial Critic Readouts
+
+These are structured internal simulations designed to surface likely diligence pressure. They must not be counted as investor conversations or objection frequency evidence.
+
+### Skeptical Seed Investor
+
+- **Strongest decline reason:** The company has a coherent product thesis but no approved evidence of paid demand, repeat use, or an efficient acquisition path.
+- **Missing evidence:** A dated outreach-to-paid funnel and repeated-release retention cohort.
+- **First question:** Which creators paid, used Jovie for a second release, and would be materially worse off without it?
+
+### Consumer-Market Investor
+
+- **Strongest decline reason:** Creator software can face fragmented willingness to pay, high churn, and expensive audience acquisition.
+- **Missing evidence:** A sharply defined buyer segment with budget, purchase urgency, retention, and reachable distribution.
+- **First question:** Who is the first narrow buyer, what budget already exists, and why does this purchase outrank their other release expenses?
+
+### Technical AI Investor
+
+- **Strongest decline reason:** The claimed closed loop may be workflow orchestration around commodity models rather than a defensible learning system.
+- **Missing evidence:** End-to-end outcome capture showing recommendations improve from proprietary context and feedback.
+- **First question:** What specific state does Jovie retain, what outcome signal updates it, and how has that changed a subsequent recommendation?
+
+### Music-Industry Investor
+
+- **Strongest decline reason:** Platform dependencies and heterogeneous artist workflows may make execution brittle and operationally heavy.
+- **Missing evidence:** Integration fallbacks, first-party data boundaries, and reliable execution across multiple release types.
+- **First question:** What still works when a catalog, social, commerce, or messaging integration changes or removes access?
+
+### Solo-Founder Skeptic
+
+- **Strongest decline reason:** Founder expertise and manual execution may create a service business that cannot support customers or sell without the founder.
+- **Missing evidence:** Non-founder operation, measured support load, and repeatable founder-independent distribution.
+- **First question:** What part of the workflow can another operator run today at the same quality and unit cost?

--- a/docs/fundraising/pitch-v1-qa-report.md
+++ b/docs/fundraising/pitch-v1-qa-report.md
@@ -2,11 +2,13 @@
 
 **Date:** 2026-07-11
 
-**Branch:** `codex/jov-3538-investor-portal-v1`
+**Current registry/report branch:** `codex/jov-3739-investor-readiness-report`
 
-**Implementation commits:** `1ec5dbb4db3d426302ca952149ee7b85054f89f1`, `02ef3aed2eb290dee73b96031323972162c75be8`
+**Browser evidence origin:** `codex/jov-3538-investor-portal-v1` at implementation commits `1ec5dbb4db3d426302ca952149ee7b85054f89f1`, `02ef3aed2eb290dee73b96031323972162c75be8`
 
 ## Verified Behavior
+
+The browser observations below were captured on the browser-evidence origin above. The current registry/report branch has not been re-verified against a production database or browser; its authoritative checks are the registry unit tests and TypeScript validation listed below.
 
 - Public `/pitch` returned 200 and emitted `noindex, nofollow` metadata.
 - The canonical brief rendered all 7 core slides.
@@ -23,9 +25,8 @@
 
 | Check | Result |
 | --- | --- |
-| Final Pitch Playwright after safe-appendix review | 3/3 passed |
-| Focused Vitest run | 19/19 passed |
-| Fundraising registry tests | 6/6 passed |
+| Historical Final Pitch Playwright after safe-appendix review | 3/3 passed |
+| Current fundraising registry tests | 10/10 passed |
 | Web TypeScript check | Passed |
 
 The responsive and slide screenshots below were refreshed from the reviewed public `/pitch` implementation after the safe-appendix and claim-contract fixes.

--- a/docs/fundraising/pitch-v1-qa-report.md
+++ b/docs/fundraising/pitch-v1-qa-report.md
@@ -26,7 +26,7 @@ The browser observations below were captured on the browser-evidence origin abov
 | Check | Result |
 | --- | --- |
 | Historical Final Pitch Playwright after safe-appendix review | 3/3 passed |
-| Current fundraising registry tests | 10/10 passed |
+| Current fundraising registry tests | 12/12 passed |
 | Web TypeScript check | Passed |
 
 The responsive and slide screenshots below were refreshed from the reviewed public `/pitch` implementation after the safe-appendix and claim-contract fixes.


### PR DESCRIPTION
## Summary
- add explicit typed narrative, unavailable metrics boundary, research sources, empty conversation summaries, and risk-derived investor FAQ
- add five missing structured objections with unknown frequency, evidence gaps, and company/communication actions
- publish a source-bounded readiness report with claim mapping, evidence gaps, priority risks, company actions, and five clearly synthesized adversarial critics
- correct QA provenance so historical browser evidence is not presented as current production verification

## Evidence boundary
- no customer, revenue, retention, willingness-to-pay, or production-loop evidence is invented
- critic readouts are explicitly synthesized reviews, not investor conversations
- no production database or new browser verification is claimed

## Verification
- fundraising registry Vitest: 12/12 passed
- web TypeScript check passed
- Biome and `git diff --check` passed
- commit and pre-push hooks passed

Stacked on #14014.

<!-- linear-issue-id:JOV-3739 -->