### PR TITLE
fix(ci): keep held PRs out of auto-enroll

### DIFF
--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -52,6 +52,89 @@ unlabel() {  # unlabel <num> <label>
     && echo "    -$2 on #$1" || echo "    !! failed to remove $2 on #$1"
 }
 
+# The queue snapshot can be stale by the time enrollment begins. Re-read the
+# authoritative PR state immediately before mutation so a draft conversion or
+# a queue-deferred hold cannot be overwritten by this controller.
+enroll_if_still_eligible() {  # enroll_if_still_eligible <num>
+  local n="$1" current
+  if ! current="$(gh_retry pr view "$n" -R "$REPO" \
+    --json state,isDraft,mergeable,labels 2>/dev/null)"; then
+    echo "    !! could not refresh #$n eligibility; refusing enrollment" >&2
+    return 1
+  fi
+  if ! jq -e '
+    .state == "OPEN"
+    and (.isDraft | not)
+    and .mergeable == "MERGEABLE"
+    and ([.labels[].name] | any(
+      . == "needs-human" or . == "hold" or . == "gated"
+      or . == "queue-deferred" or . == "needs-conflict-resolution"
+      or . == "merge-queue" or . == "fast"
+    ) | not)
+  ' <<<"$current" >/dev/null; then
+    echo "    ⏸ eligibility changed; refusing enrollment for #$n"
+    return 2
+  fi
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    [dry-run] would +merge-queue on #$n"
+    return 0
+  fi
+  if ! gh_retry pr edit "$n" -R "$REPO" --add-label merge-queue >/dev/null; then
+    echo "    !! failed to add merge-queue on #$n" >&2
+    return 1
+  fi
+  if ! current="$(gh_retry pr view "$n" -R "$REPO" \
+    --json state,isDraft,mergeable,labels 2>/dev/null)"; then
+    echo "    !! could not verify #$n after enrollment" >&2
+    if ! remove_held_queue_label_strict "$n"; then
+      echo "    !! CRITICAL: could not prove failed enrollment was compensated for #$n" >&2
+    fi
+    return 1
+  fi
+  if jq -e '
+    .state == "OPEN"
+    and (.isDraft | not)
+    and .mergeable == "MERGEABLE"
+    and ([.labels[].name] | index("merge-queue"))
+    and ([.labels[].name] | any(
+      . == "needs-human" or . == "hold" or . == "gated"
+      or . == "queue-deferred" or . == "needs-conflict-resolution"
+      or . == "fast"
+    ) | not)
+  ' <<<"$current" >/dev/null; then
+    echo "    +merge-queue on #$n"
+    return 0
+  fi
+  echo "    !! enrollment verification failed for #$n" >&2
+  if ! remove_held_queue_label_strict "$n"; then
+    echo "    !! CRITICAL: could not prove failed enrollment was compensated for #$n" >&2
+  fi
+  return 1
+}
+
+remove_held_queue_label_strict() {  # remove_held_queue_label_strict <num>
+  local n="$1" current
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    [dry-run] would -merge-queue on #$n"
+    return 0
+  fi
+  if ! gh_retry pr edit "$n" -R "$REPO" --remove-label merge-queue >/dev/null; then
+    echo "    !! failed to remove merge-queue hold violation from #$n" >&2
+    return 1
+  fi
+  if ! current="$(gh_retry pr view "$n" -R "$REPO" --json labels 2>/dev/null)"; then
+    echo "    !! could not verify merge-queue removal for held PR #$n" >&2
+    return 1
+  fi
+  if jq -e '([.labels[].name] | index("merge-queue")) == null' \
+    <<<"$current" >/dev/null; then
+    echo "    -merge-queue on #$n"
+    return 0
+  fi
+  echo "    !! held PR #$n still has merge-queue after removal" >&2
+  return 1
+}
+
 check_failures_for_pr() {  # check_failures_for_pr <num>
   local n="$1"
   local attempts="${GH_RETRY_ATTEMPTS:-5}"
@@ -134,7 +217,7 @@ while IFS= read -r pr; do
     (.draft | not)
     and (.m == "MERGEABLE")
     and ((.head | startswith("gtmq_")) | not)
-    and (([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated" or . == "fast")) | not)
+    and (([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated" or . == "queue-deferred" or . == "fast")) | not)
   ' <<<"$pr" >/dev/null; then
     fail="$(check_failures_for_pr "$n")"
   fi
@@ -152,7 +235,7 @@ echo "=== QUEUE SUMMARY ==="
 echo "$SNAP" | jq -r '
   def labels: (.L // []);
   def queued: labels | index("merge-queue");
-  def hard_gated: labels | any(. == "needs-human" or . == "hold" or . == "gated");
+  def hard_gated: labels | any(. == "needs-human" or . == "hold" or . == "gated" or . == "queue-deferred");
   [
     "  CLEAN: " + ([.[] | select(queued and (.ms // "") == "CLEAN")] | length | tostring),
     "  UNSTABLE: " + ([.[] | select(queued and (.ms // "") == "UNSTABLE")] | length | tostring),
@@ -164,15 +247,17 @@ echo "$SNAP" | jq -r '
 
 # --- DEQUEUE: hard-gated PRs must not occupy Graphite queue slots ---
 echo "=== DEQUEUE (hard gates → -merge-queue) ==="
-echo "$SNAP" | jq -c '.[]
-  | select([.L[]] | index("merge-queue"))
-  | select((.head|startswith("gtmq_"))|not)
-  | select([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated"))' \
-| while read -r pr; do
+while read -r pr; do
     n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
     echo "  #$n  $t"
-    unlabel "$n" merge-queue
-  done
+    if ! remove_held_queue_label_strict "$n"; then
+      echo "::error::Failed to prove held PR #$n is outside merge queue" >&2
+      exit 1
+    fi
+  done < <(echo "$SNAP" | jq -c '.[]
+  | select([.L[]] | index("merge-queue"))
+  | select((.head|startswith("gtmq_"))|not)
+  | select(.draft or ([.L[]] | any(. == "needs-human" or . == "hold" or . == "gated" or . == "queue-deferred")))')
 
 # --- DEQUEUE: only GENUINELY un-mergeable PRs (conflict or real failing checks) ---
 # Do NOT dequeue on mergeStateStatus alone. A MERGEABLE PR flickers to BLOCKED
@@ -190,7 +275,7 @@ echo "=== DEQUEUE (conflict / failing → -merge-queue) ==="
 echo "$SNAP" | jq -c '.[]
   | select([.L[]] | index("merge-queue"))
   | select((.head|startswith("gtmq_"))|not)
-  | select(([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated")) | not)
+  | select(([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="queue-deferred")) | not)
   | select(
       ([.L[]] | any(.=="needs-conflict-resolution"))
       or (.m == "CONFLICTING")
@@ -235,13 +320,23 @@ while read -r pr; do
   fi
   ENROLLED_THIS_RUN=$((ENROLLED_THIS_RUN + 1))
   echo "  #$n  $t"
-  label "$n" merge-queue
+  if enroll_if_still_eligible "$n"; then
+    :
+  else
+    enroll_result=$?
+    ENROLLED_THIS_RUN=$((ENROLLED_THIS_RUN - 1))
+    if [[ "$enroll_result" -eq 2 ]]; then
+      continue
+    fi
+    echo "::error::Failed to prove enrollment for #$n" >&2
+    exit 1
+  fi
 done < <(echo "$SNAP" | jq -c '.[]
   | select(.draft|not)
   | select(.m=="MERGEABLE")
   | select(.fail|length==0)
   | select((.head|startswith("gtmq_"))|not)
-  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="needs-conflict-resolution" or .=="merge-queue" or .=="fast") | not)')
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="queue-deferred" or .=="needs-conflict-resolution" or .=="merge-queue" or .=="fast") | not)')
 
 # --- CONFLICT: needs rebase (agent branches only) → label + hand to fix agent ---
 echo "=== CONFLICT (needs rebase → fix agent) ==="
@@ -249,26 +344,26 @@ echo "$SNAP" | jq -r --arg re "$AGENT_RE" '.[]
   | select(.m=="CONFLICTING")
   | select((.head|startswith("gtmq_"))|not)
   | select(.head|test($re))
-  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated") | not)
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="queue-deferred") | not)
   | "  #\(.n)  \(.t)  [\(.head)]"'
 echo "$SNAP" | jq -r --arg re "$AGENT_RE" '.[]
   | select(.m=="CONFLICTING")
   | select((.head|startswith("gtmq_"))|not)
   | select(.head|test($re))
-  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated") | not) | .n' \
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="queue-deferred") | not) | .n' \
 | while read -r n; do [[ -n "$n" ]] && label "$n" needs-conflict-resolution; done
 
 # --- BLOCKED: mergeable but red checks → hand to fix agent ---
 echo "=== BLOCKED (red checks → fix agent) ==="
 echo "$SNAP" | jq -r '.[]
   | select(.draft|not) | select(.m=="MERGEABLE") | select(.fail|length>0)
-  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated") | not)
+  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="queue-deferred") | not)
   | "  #\(.n)  \(.t)  ✗ \(.fail|join(", "))"'
 
 # --- SURFACE: human-gated / superseded → report only, never auto-close ---
 echo "=== SURFACE (human decision; not touched) ==="
 echo "$SNAP" | jq -r '.[]
-  | select([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated"))
+  | select(.draft or ([.L[]] | any(.=="needs-human" or .=="hold" or .=="gated" or .=="queue-deferred")))
   | "  #\(.n)  \(.t)  {\(.L|join(","))}"'
 
 # --- Graphite MQ working drafts (the queue itself; leave alone) ---

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -220,13 +220,17 @@ JSON
                 set -euo pipefail
                 if [[ "$1 $2" == "pr list" ]]; then
                   cat <<'JSON'
-                [{"n":456,"t":"Taste approved PR","draft":false,"m":"MERGEABLE","head":"codex/jov-456-taste","L":["needs-human","approved:taste"],"fail":[]},{"n":789,"t":"Human gated PR","draft":false,"m":"MERGEABLE","head":"codex/jov-789-human","L":["needs-human","merge-queue"],"fail":[]},{"n":101,"t":"Clean PR","draft":false,"m":"MERGEABLE","head":"codex/jov-101-clean","L":[],"fail":[]}]
+                [{"n":456,"t":"Taste approved PR","draft":false,"m":"MERGEABLE","head":"codex/jov-456-taste","L":["needs-human","approved:taste"],"fail":[]},{"n":789,"t":"Human gated PR","draft":false,"m":"MERGEABLE","head":"codex/jov-789-human","L":["needs-human","merge-queue"],"fail":[]},{"n":102,"t":"Deferred PR","draft":false,"m":"MERGEABLE","head":"codex/jov-102-deferred","L":["queue-deferred","merge-queue"],"fail":[]},{"n":103,"t":"Draft PR","draft":true,"m":"MERGEABLE","head":"codex/jov-103-draft","L":["merge-queue"],"fail":[]},{"n":101,"t":"Clean PR","draft":false,"m":"MERGEABLE","head":"codex/jov-101-clean","L":[],"fail":[]}]
 JSON
                   exit 0
                 fi
                 if [[ "$1 $2" == "pr checks" ]]; then
                   [[ "$3" == "101" ]]
                   echo '[]'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  echo '{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","labels":[]}'
                   exit 0
                 fi
                 echo "unexpected gh args: $*" >&2
@@ -244,9 +248,13 @@ JSON
         assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
         assert "=== DEQUEUE (hard gates" in result.stdout
         assert "[dry-run] would -merge-queue on #789" in result.stdout
+        assert "[dry-run] would -merge-queue on #102" in result.stdout
+        assert "[dry-run] would -merge-queue on #103" in result.stdout
         assert "[dry-run] would +merge-queue on #101" in result.stdout
         assert "[dry-run] would +merge-queue on #456" not in result.stdout
         assert "[dry-run] would +merge-queue on #789" not in result.stdout
+        assert "[dry-run] would +merge-queue on #102" not in result.stdout
+        assert "[dry-run] would +merge-queue on #103" not in result.stdout
         assert "=== SURFACE (human decision; not touched) ===" in result.stdout
         assert "#456" in result.stdout
         assert "#789" in result.stdout
@@ -267,6 +275,10 @@ JSON
                 if [[ "$1 $2" == "pr checks" ]]; then
                   echo '[]'
                   exit 8
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  echo '{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","labels":[]}'
+                  exit 0
                 fi
                 echo "unexpected gh args: $*" >&2
                 exit 2
@@ -310,6 +322,10 @@ JSON
                   echo '[]'
                   exit 0
                 fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  echo '{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","labels":[]}'
+                  exit 0
+                fi
                 echo "unexpected gh args: $*" >&2
                 exit 2
                 """
@@ -326,6 +342,205 @@ JSON
         assert "[dry-run] would +merge-queue on #654" in result.stdout
         assert "gh-retry" in result.stderr
         assert counter.read_text(encoding="utf-8").strip() == "2"
+
+    @pytest.mark.parametrize(
+        "refreshed_state",
+        [
+            '{"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","labels":[]}',
+            '{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","labels":[{"name":"queue-deferred"}]}',
+        ],
+    )
+    def test_enroll_refuses_draft_or_deferred_state_from_fresh_read(
+        self, tmp_path: Path, refreshed_state: str
+    ) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  echo '[{{"n":655,"t":"Held after snapshot","draft":false,"m":"MERGEABLE","head":"codex/jov-655-held","L":[],"fail":[]}}]'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  echo '[]'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  echo '{refreshed_state}'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr edit" ]]; then
+                  echo "unexpected enrollment mutation: $*" >&2
+                  exit 9
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(
+            f'PATH="{tmp_path}:$PATH" DRY_RUN=1 bash "{_DRAIN_SCRIPT}"'
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+        assert "eligibility changed; refusing enrollment for #655" in result.stdout
+        assert "[dry-run] would +merge-queue on #655" not in result.stdout
+
+    @pytest.mark.parametrize("edit_exit", [0, 1])
+    def test_held_dequeue_fails_when_removal_is_not_proven(
+        self, tmp_path: Path, edit_exit: int
+    ) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  echo '[{{"n":656,"t":"Held and queued","draft":true,"m":"MERGEABLE","head":"codex/jov-656-held","L":["merge-queue"],"fail":[]}}]'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr edit" ]]; then
+                  exit {edit_exit}
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  echo '{{"labels":[{{"name":"merge-queue"}}]}}'
+                  exit 0
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(f'PATH="{tmp_path}:$PATH" bash "{_DRAIN_SCRIPT}"')
+
+        assert result.returncode != 0
+        assert "Failed to prove held PR #656 is outside merge queue" in result.stderr
+
+    def test_enrollment_mutation_failure_is_terminal(self, tmp_path: Path) -> None:
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  echo '[{"n":657,"t":"Clean candidate","draft":false,"m":"MERGEABLE","head":"codex/jov-657-clean","L":[],"fail":[]}]'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  echo '[]'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  echo '{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","labels":[]}'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr edit" ]]; then
+                  exit 1
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(f'PATH="{tmp_path}:$PATH" bash "{_DRAIN_SCRIPT}"')
+
+        assert result.returncode != 0
+        assert "Failed to prove enrollment for #657" in result.stderr
+
+    @pytest.mark.parametrize(
+        ("second_read", "removal_exit", "expected_message"),
+        [
+            (
+                '{"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","labels":[{"name":"merge-queue"}]}',
+                0,
+                "enrollment verification failed",
+            ),
+            (
+                '{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","labels":[{"name":"merge-queue"},{"name":"needs-conflict-resolution"}]}',
+                0,
+                "enrollment verification failed",
+            ),
+            ("READ_FAILURE", 0, "could not verify"),
+            (
+                "READ_FAILURE",
+                1,
+                "CRITICAL: could not prove failed enrollment was compensated",
+            ),
+        ],
+    )
+    def test_post_enrollment_failure_compensates_and_proves_absence(
+        self,
+        tmp_path: Path,
+        second_read: str,
+        removal_exit: int,
+        expected_message: str,
+    ) -> None:
+        read_count = tmp_path / "read-count"
+        edit_count = tmp_path / "edit-count"
+        read_count.write_text("0", encoding="utf-8")
+        edit_count.write_text("0", encoding="utf-8")
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "pr list" ]]; then
+                  echo '[{{"n":658,"t":"Racing candidate","draft":false,"m":"MERGEABLE","head":"codex/jov-658-race","L":[],"fail":[]}}]'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  echo '[]'
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  count=$(cat '{read_count}')
+                  count=$((count + 1))
+                  echo "$count" > '{read_count}'
+                  if [[ "$count" -eq 1 ]]; then
+                    echo '{{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","labels":[]}}'
+                  elif [[ "$count" -eq 2 && '{second_read}' == 'READ_FAILURE' ]]; then
+                    exit 1
+                  elif [[ "$count" -eq 2 ]]; then
+                    echo '{second_read}'
+                  else
+                    echo '{{"labels":[]}}'
+                  fi
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr edit" ]]; then
+                  count=$(cat '{edit_count}')
+                  count=$((count + 1))
+                  echo "$count" > '{edit_count}'
+                  if [[ "$count" -eq 2 ]]; then exit {removal_exit}; fi
+                  exit 0
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        result = _run_bash(f'PATH="{tmp_path}:$PATH" bash "{_DRAIN_SCRIPT}"')
+
+        assert result.returncode != 0
+        assert expected_message in result.stderr
+        assert edit_count.read_text(encoding="utf-8").strip() == "2"
 
     def test_queued_conflict_is_dequeued_and_labeled_for_resolution(self, tmp_path: Path) -> None:
         fake_gh = tmp_path / "gh"


### PR DESCRIPTION
## Summary
- treat `queue-deferred` and draft state as hard merge-queue holds
- re-read authoritative PR state immediately before enrollment mutation
- dequeue already-enrolled held PRs and refuse stale-snapshot enrollment

## Root cause
The drain selected candidates from one queue snapshot and mutated labels later without re-reading state. A PR converted to draft or labeled `queue-deferred` after the snapshot could therefore receive `merge-queue`; `queue-deferred` was also absent from the hard-gate policy. This reproduced on #13999 and #14003.

## Verification
- `shellcheck -x scripts/drain-pr-queue.sh`
- `bash -n scripts/drain-pr-queue.sh`
- `python3 -m pytest scripts/tests/test_gh_retry.py -q` (31 passed)
- `git diff --check`

<!-- bug-to-test: scripts/tests/test_gh_retry.py -->