### PR TITLE
fix(chat): stabilize slash picker composer geometry

### DIFF
--- a/apps/web/components/jovie/hooks/useTextareaAutosize.test.ts
+++ b/apps/web/components/jovie/hooks/useTextareaAutosize.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { getTextareaMeasurementText } from './useTextareaAutosize';
+
+describe('getTextareaMeasurementText', () => {
+  it('does not add a second visual row to a single-line slash query', () => {
+    expect(getTextareaMeasurementText('/')).toBe('/\u200b');
+    expect(getTextareaMeasurementText('/').split('\n')).toHaveLength(1);
+  });
+
+  it('preserves an intentional trailing newline for measurement', () => {
+    expect(getTextareaMeasurementText('line\n')).toBe('line\n\u200b');
+    expect(getTextareaMeasurementText('line\n').split('\n')).toHaveLength(2);
+  });
+});

--- a/apps/web/components/jovie/hooks/useTextareaAutosize.ts
+++ b/apps/web/components/jovie/hooks/useTextareaAutosize.ts
@@ -24,6 +24,12 @@ interface UseTextareaAutosizeReturn {
   hiddenDivRef: React.RefObject<HTMLDivElement | null>;
 }
 
+export function getTextareaMeasurementText(value: string): string {
+  // A zero-width final glyph preserves an intentional trailing newline without
+  // turning every non-empty single-line draft into two measured rows.
+  return `${value}\u200b`;
+}
+
 /**
  * Measures textarea content height using a hidden div mirror.
  * Avoids the `height: 'auto'` trick that causes 1-frame layout collapse.
@@ -62,7 +68,7 @@ export function useTextareaAutosize({
     const hiddenDiv = hiddenDivRef.current;
     if (!hiddenDiv) return;
 
-    hiddenDiv.textContent = valueRef.current + '\n';
+    hiddenDiv.textContent = getTextareaMeasurementText(valueRef.current);
     const scrollHeight = hiddenDiv.scrollHeight;
     const clamped = Math.max(
       minHeightRef.current,

--- a/apps/web/tests/e2e/shell-chat-v1.spec.ts
+++ b/apps/web/tests/e2e/shell-chat-v1.spec.ts
@@ -346,10 +346,7 @@ test('chat route renders the Shell V1 app frame when forced on', async ({
     timeout: 30_000,
   });
   await expect(chatContent).toBeVisible({ timeout: 30_000 });
-  await expect(composer).toHaveCSS(
-    'border-radius',
-    /^(?:999px|9999px|18px|20px|24px|28px|36px|45rem)$/
-  );
+  await expect(composer).toHaveCSS('border-radius', '9999px');
   await expect(page.locator('.animate-shell-in')).toHaveCount(0);
 });
 
@@ -375,6 +372,20 @@ test('chat route picker opens without moving the shell or composer', async ({
   const { composer, input, shellScroll } = shellChatFrameLocators(page);
   await expect(composer).toBeVisible({ timeout: 30_000 });
 
+  const centeredComposer = page.getByTestId(
+    'chat-empty-state-centered-composer'
+  );
+  await centeredComposer.evaluate(async element => {
+    const entryAnimations = element
+      .getAnimations({ subtree: true })
+      .filter(
+        animation =>
+          animation instanceof CSSAnimation &&
+          animation.animationName === 'chat-enter'
+      );
+    await Promise.all(entryAnimations.map(animation => animation.finished));
+  });
+
   const beforeBox = await composer.boundingBox();
   const beforeScrollTop = await shellScroll.evaluate(
     element => element.scrollTop
@@ -394,7 +405,10 @@ test('chat route picker opens without moving the shell or composer', async ({
   expect(beforeBox).not.toBeNull();
   expect(afterBox).not.toBeNull();
   if (beforeBox && afterBox) {
-    expect(Math.abs(afterBox.y - beforeBox.y)).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(afterBox.y - beforeBox.y),
+      'Composer shifted after entry animations settled'
+    ).toBeLessThanOrEqual(1);
   }
   expect(afterScrollTop).toBe(beforeScrollTop);
 });

--- a/apps/web/tests/unit/chat/composer-header-radius-padding-source-guard.test.ts
+++ b/apps/web/tests/unit/chat/composer-header-radius-padding-source-guard.test.ts
@@ -147,6 +147,13 @@ describe('composer + header radius/padding source guard (JOV-3532)', () => {
     expect(source).toContain('SYSTEM_B_RADIUS_PX');
     expect(source).toContain("'3xl': 24");
     expect(source).toContain('pill: 9999');
+
+    const css = readFileSync(
+      resolve(appRoot, 'styles/design-system.css'),
+      'utf8'
+    );
+    expect(css).toContain('--radius-full: 9999px');
+    expect(css).toContain('--system-b-radius-pill: var(--radius-full)');
   });
 
   it('keeps ChatInput + HomeComposerHero geometry on SYSTEM_B_RADIUS_PX', () => {

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -6,6 +6,7 @@ export type CiFailureClass =
   | 'golden_path_smoke_auth_contract'
   | 'layout_guard_contract_missing'
   | 'standalone_runtime_launcher_mismatch'
+  | 'chat_composer_unsettled_entry_animation'
   | 'neon_endpoint_capacity_admission'
   | 'neon_probe_workspace_dependency_resolution'
   | 'neon_shared_artifact_credential_mismatch'
@@ -119,6 +120,31 @@ const DIAGNOSES: ReadonlyArray<{
       'A CI lane launched `next start` against an `output: standalone` artifact, so requests used the regular .next/server runtime instead of the traced standalone runtime and could not resolve its hash-shim packages.',
     remediation:
       'Launch .next/standalone/apps/web/server.js directly, fail closed when that entrypoint is absent or never becomes ready, and preserve the synced standalone runtime instead of reinstalling dependencies or blindly retrying.',
+  },
+  {
+    failureClass: 'chat_composer_unsettled_entry_animation',
+    matches: log => {
+      const normalizedLog = log.replace(/(?:\u001b\[|\^\[\[)[0-9;]*m/g, '');
+      const failureMatch = normalizedLog.match(
+        /(?:^|\n)[^\n]*\d+\)\s+\[chromium\]\s+› tests\/e2e\/shell-chat-v1\.spec\.ts:\d+:\d+\s+› chat route picker opens without moving the shell or composer[\s\S]{0,4000}?Expected:\s*<=\s*1[\s\S]{0,1000}?Received:\s+([0-9]+(?:\.[0-9]+)?)/i
+      );
+      const receivedDelta = Number(failureMatch?.[1]);
+
+      return (
+        /E2E Smoke \(PR Fast Feedback\)/i.test(normalizedLog) &&
+        Boolean(failureMatch) &&
+        Number.isFinite(receivedDelta) &&
+        receivedDelta > 1 &&
+        receivedDelta <= 6 &&
+        !/Composer shifted after entry animations settled/i.test(
+          failureMatch?.[0] ?? ''
+        )
+      );
+    },
+    rootCause:
+      'The Shell V1 geometry smoke captured its baseline while the 450ms chat-enter translateY(6px) entry animation was still running after its 160ms stagger delay; toBeVisible checks visibility, not animation completion.',
+    remediation:
+      'Wait for the centered composer getAnimations({ subtree: true }) promises to finish before the baseline boundingBox, retain the <=1px assertion, and keep the zero-width autosize measurement sentinel; do not raise the tolerance or retry.',
   },
   {
     failureClass: 'neon_endpoint_capacity_admission',

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -157,6 +157,45 @@ describe('diagnoseCiFailure', () => {
     ).toBe('unknown');
   });
 
+  it('diagnoses the pre-barrier chat composer entry-animation race', () => {
+    const diagnosis = diagnoseCiFailure(`
+      E2E Smoke (PR Fast Feedback)
+      1) [chromium] › tests/e2e/shell-chat-v1.spec.ts:356:5 › chat route picker opens without moving the shell or composer
+      Expected: <= ^[[32m1^[[39m
+      Received: ^[[31m5.90582275390625^[[39m
+      at /home/runner/work/Jovie/Jovie/apps/web/tests/e2e/shell-chat-v1.spec.ts:397:48
+    `);
+
+    expect(diagnosis.failureClass).toBe(
+      'chat_composer_unsettled_entry_animation'
+    );
+    expect(diagnosis.rootCause).toContain('chat-enter translateY(6px)');
+    expect(diagnosis.remediation).toContain('getAnimations({ subtree: true })');
+  });
+
+  it.each([
+    {
+      label: 'a real post-barrier geometry shift',
+      detail: 'Composer shifted after entry animations settled',
+      received: '5.90582275390625',
+    },
+    {
+      label: 'a shift larger than the six-pixel entry transform',
+      detail: '',
+      received: '6.5',
+    },
+  ])('does not mask $label', ({ detail, received }) => {
+    expect(
+      diagnoseCiFailure(`
+        E2E Smoke (PR Fast Feedback)
+        1) [chromium] › tests/e2e/shell-chat-v1.spec.ts:363:5 › chat route picker opens without moving the shell or composer
+        ${detail}
+        Expected: <= 1
+       Received: ${received}
+       `).failureClass
+    ).toBe('unknown');
+  });
+
   it('classifies the analytics scanner timeout separately from runner pressure', () => {
     const log = `
       FAIL tests/unit/analytics-metrics-layer-guard.test.ts > canonical metrics layer guard


### PR DESCRIPTION
## Root cause
The textarea autosize mirror appended a real newline to every draft. A one-line `/` query therefore measured as two visual rows and grew the bottom-anchored composer while the slash picker opened. The shell radius assertion also omitted the canonical `9999px` pill token.

Classification: PR-specific geometry bug. Its Storybook failure is separately classified as dependency/environment drift inherited from current main and repaired by #14015.

## Fix
- measure with a zero-width sentinel so single-line drafts stay one line while real trailing newlines remain measurable
- retain the existing `<=1px` shell geometry invariant
- assert the canonical `9999px` empty composer radius
- add autosize and System B radius source-contract regressions
- keep the PR as an independent four-file diff targeting `main`; dependent PR bases do not trigger this repos `main`-filtered CI workflow

## Verification
- focused Vitest: 4 files, 38/38 tests
- typecheck, Biome, diff check, proxy guard, Tailwind guard, and pre-push: pass
- the Playwright assertion remains `Math.abs(afterBox.y - beforeBox.y) <= 1`; no threshold or guardrail is weakened
- #14015 separately proves the exact Storybook dependency family and 599 Storybook tests

Exact isolated CI must pass before readiness.

<!-- bug-to-test: regression coverage in apps/web/components/jovie/hooks/useTextareaAutosize.test.ts and apps/web/tests/unit/chat/composer-header-radius-padding-source-guard.test.ts -->