### PR TITLE
feat(marketing): audit route recipe parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] **Governed marketing section proposals:** the marketing registry now records route-recipe evidence and explicit design gaps, while the admin Design Lab provides desktop/mobile proposal review, comments, approval states, implementation evidence, and auditable model-usage metadata.
 - **Homepage labels now meet WCAG AA contrast:** the distributor trust-strip and closed-loop labels use the readable tertiary text token instead of the low-contrast quaternary token.
 - [internal] **Desktop renderer recovery (JOV-3595)**: recover from hosted loads that return HTTP 200 but never boot React, and route crashed or unresponsive renderers to the visible recovery shell instead of a permanent black window.
 - [internal] Agent preflight: one-shot JSON bootstrap for /autoplan (JOV-4183)

--- a/apps/web/data/marketing/composition.ts
+++ b/apps/web/data/marketing/composition.ts
@@ -80,14 +80,14 @@ export const MarketingBriefSchema = z.object({
       phoneProfileAsset: z.boolean().default(false),
       videoAsset: z.boolean().default(false),
     })
-    .default({}),
+    .prefault({}),
   brandConstraints: z
     .object({
       darkOnly: z.literal(true).default(true), // charter delta #9 — always dark
       fullyStatic: z.literal(true).default(true), // .claude/rules/ui.md — always static
       waitlistEnabled: z.boolean().default(false), // gates waitlist recipe + homepage CTAs
     })
-    .default({}),
+    .prefault({}),
 });
 export type MarketingBrief = z.infer<typeof MarketingBriefSchema>;
 

--- a/apps/web/data/marketing/designGaps.ts
+++ b/apps/web/data/marketing/designGaps.ts
@@ -1,0 +1,452 @@
+import type { MarketingAudience, MarketingSectionId } from './sections';
+
+export type ProposedSectionId = `PROPOSED-SECTION-${number}`;
+export type ProposedSectionStatus =
+  | 'proposed'
+  | 'reviewing'
+  | 'approved'
+  | 'rejected'
+  | 'implemented';
+
+export interface GrayscaleWireframeSpec {
+  readonly viewport: 'desktop' | 'mobile';
+  readonly width: number;
+  readonly hierarchy: readonly string[];
+  readonly layout: string;
+  readonly contentDensity: 'low' | 'medium' | 'high';
+  readonly mediaPlacement: string;
+  readonly responsiveBehavior: string;
+  readonly interactionModel: string;
+  readonly tokens: readonly ('surface' | 'border' | 'muted' | 'foreground')[];
+  readonly placeholderContent: 'grayscale-only';
+}
+
+export interface ProposedSectionComment {
+  readonly author: string;
+  readonly date: string;
+  readonly body: string;
+}
+
+export interface RegistryTaskContract {
+  readonly trigger: 'after-approved';
+  readonly targetSectionId: MarketingSectionId;
+  readonly requiredChanges: readonly string[];
+  readonly exactFiles: readonly string[];
+  readonly forbiddenPatterns: readonly string[];
+  readonly acceptanceCriteria: readonly string[];
+  readonly validationCommands: readonly string[];
+  readonly evidenceRequired: readonly string[];
+  readonly implementedAt: string | null;
+  readonly evidenceRefs: readonly string[];
+}
+
+export interface ModelUsageEstimate {
+  readonly role: 'audit' | 'wireframe-spec' | 'implementation' | 'review';
+  readonly model: string | 'unavailable from runtime';
+  readonly tokens: number | 'unavailable from runtime';
+  readonly estimatedCostUsd: number | 'unavailable from runtime';
+  readonly estimationBasis: string;
+}
+
+export interface ProposedSectionRecord {
+  readonly id: ProposedSectionId;
+  readonly proposedSectionName: string;
+  readonly status: ProposedSectionStatus;
+  readonly problem: string;
+  readonly affectedRoutes: readonly string[];
+  readonly intendedAudience: readonly MarketingAudience[];
+  readonly conversionGoal: string;
+  readonly requiredContentFields: readonly string[];
+  readonly requiredMedia: readonly string[];
+  readonly proposedResponsiveBehavior: string;
+  readonly proposedCtaBehavior: string;
+  readonly sectionType: MarketingSectionId;
+  readonly similarExistingSections: readonly MarketingSectionId[];
+  readonly existingApprovedVariantInsufficiency: string;
+  readonly wireframes: {
+    readonly desktop: GrayscaleWireframeSpec;
+    readonly mobile: GrayscaleWireframeSpec;
+  };
+  readonly openDesignQuestions: readonly string[];
+  readonly implementationPriority: 'low' | 'medium' | 'high';
+  readonly comments: readonly ProposedSectionComment[];
+  readonly registryTask: RegistryTaskContract;
+  readonly modelUsage: readonly ModelUsageEstimate[];
+}
+
+const unavailableUsage: readonly ModelUsageEstimate[] = [
+  {
+    role: 'audit',
+    model: 'unavailable from runtime',
+    tokens: 'unavailable from runtime',
+    estimatedCostUsd: 'unavailable from runtime',
+    estimationBasis:
+      'The delegated agent runtime does not expose model billing.',
+  },
+];
+
+const task = (
+  targetSectionId: MarketingSectionId,
+  componentPath: string
+): RegistryTaskContract => ({
+  trigger: 'after-approved',
+  targetSectionId,
+  requiredChanges: [
+    'Finalize the approved typed variant contract in sections.ts.',
+    'Implement with existing design-system primitives and copy-in-data.',
+    'Add a deterministic fixture and desktop/mobile screenshot evidence.',
+    'Migrate every affected route and mark this proposal implemented.',
+  ],
+  exactFiles: [
+    'apps/web/data/marketing/sections.ts',
+    'apps/web/data/marketing/composition.ts',
+    componentPath,
+    'apps/web/tests/unit/marketing/recipe-manifest.test.ts',
+    'docs/marketing/DESIGN_GAPS.md',
+  ],
+  forbiddenPatterns: [
+    'No one-off route-local section implementation.',
+    'No new dependency, schema, renderer, or design-system primitive.',
+    'No production binding while proposal status is proposed, reviewing, or rejected.',
+  ],
+  acceptanceCriteria: [
+    'Implementation matches both approved grayscale wireframes.',
+    'Responsive and interaction contracts are covered by tests.',
+    'Every production binding resolves to an approved canonical section.',
+  ],
+  validationCommands: [
+    'pnpm --filter web exec vitest run apps/web/tests/unit/marketing/recipe-manifest.test.ts',
+    'pnpm biome check apps/web/data/marketing apps/web/tests/unit/marketing/recipe-manifest.test.ts',
+  ],
+  evidenceRequired: [
+    'Focused manifest test output',
+    '1440×900 approved-wireframe comparison screenshot',
+    '390×844 approved-wireframe comparison screenshot',
+    'Affected-route parity report after migration',
+  ],
+  implementedAt: null,
+  evidenceRefs: [],
+});
+
+export const PROPOSED_SECTIONS: readonly ProposedSectionRecord[] = [
+  {
+    id: 'PROPOSED-SECTION-0001',
+    proposedSectionName: 'Artist notification mode switcher',
+    status: 'proposed',
+    problem:
+      'Explain and switch between release, catalog, and fan-notification modes without presenting them as unrelated cards.',
+    affectedRoutes: ['/artist-notifications'],
+    intendedAudience: ['artist'],
+    conversionGoal: 'Start an artist notification workflow',
+    requiredContentFields: [
+      'mode label',
+      'mode summary',
+      'mode details',
+      'active mode',
+    ],
+    requiredMedia: ['one product screenshot per mode'],
+    proposedResponsiveBehavior:
+      'Desktop uses a left mode rail and right media panel; mobile uses a horizontal selector above stacked content.',
+    proposedCtaBehavior:
+      'One unchanged page-primary CTA below the active mode summary.',
+    sectionType: 'feature-split',
+    similarExistingSections: ['feature-split', 'feature-grid'],
+    existingApprovedVariantInsufficiency:
+      'Approved feature-split variants present one static capability and feature-grid variants do not define mutually exclusive mode interaction.',
+    wireframes: {
+      desktop: {
+        viewport: 'desktop',
+        width: 1440,
+        hierarchy: [
+          'heading',
+          'mode rail',
+          'active summary',
+          'media',
+          'primary CTA',
+        ],
+        layout: '4/12 selector rail + 8/12 active panel',
+        contentDensity: 'medium',
+        mediaPlacement: 'right panel',
+        responsiveBehavior: 'Rail becomes horizontal selector below 768px',
+        interactionModel: 'Single-select tabs with keyboard arrow navigation',
+        tokens: ['surface', 'border', 'muted', 'foreground'],
+        placeholderContent: 'grayscale-only',
+      },
+      mobile: {
+        viewport: 'mobile',
+        width: 390,
+        hierarchy: [
+          'heading',
+          'mode selector',
+          'active summary',
+          'media',
+          'primary CTA',
+        ],
+        layout: 'single stack',
+        contentDensity: 'medium',
+        mediaPlacement: 'full-width below copy',
+        responsiveBehavior:
+          'Selector scrolls horizontally without changing section height',
+        interactionModel: 'Single-select tabs with 44px targets',
+        tokens: ['surface', 'border', 'muted', 'foreground'],
+        placeholderContent: 'grayscale-only',
+      },
+    },
+    openDesignQuestions: [
+      'Should mode state be URL-addressable?',
+      'Does media cross-fade or swap without animation?',
+    ],
+    implementationPriority: 'medium',
+    comments: [
+      {
+        author: 'registry-audit',
+        date: '2026-07-11',
+        body: 'Awaiting design review; continue using approved static feature-split sections.',
+      },
+    ],
+    registryTask: task(
+      'feature-split',
+      'apps/web/components/marketing/artist-notifications/ArtistNotificationModeSwitcher.tsx'
+    ),
+    modelUsage: unavailableUsage,
+  },
+  {
+    id: 'PROPOSED-SECTION-0002',
+    proposedSectionName: 'Two-rung proof carousel',
+    status: 'proposed',
+    problem:
+      'Show recognizable and peer artist proof as one navigable sequence while preserving attribution.',
+    affectedRoutes: ['/artist-profiles', '/artist-profile'],
+    intendedAudience: ['artist'],
+    conversionGoal: 'Claim an artist profile',
+    requiredContentFields: [
+      'artist name',
+      'proof tier',
+      'attributed statement',
+      'profile link',
+    ],
+    requiredMedia: ['consenting artist portrait or live profile capture'],
+    proposedResponsiveBehavior:
+      'Desktop previews adjacent proof cards; mobile shows one card with stable-height navigation.',
+    proposedCtaBehavior:
+      'No CTA inside cards; page-primary CTA follows the proof section.',
+    sectionType: 'social-proof',
+    similarExistingSections: ['social-proof'],
+    existingApprovedVariantInsufficiency:
+      'The approved artist-carousel exemplar does not encode the required two-rung ordering, stable-height mobile behavior, or tier attribution contract.',
+    wireframes: {
+      desktop: {
+        viewport: 'desktop',
+        width: 1440,
+        hierarchy: [
+          'heading',
+          'tier label',
+          'active proof',
+          'adjacent previews',
+          'navigation',
+        ],
+        layout: 'center card with clipped side previews',
+        contentDensity: 'medium',
+        mediaPlacement: 'portrait left inside card',
+        responsiveBehavior: 'Side previews collapse below 768px',
+        interactionModel: 'Previous/next buttons and labeled pagination',
+        tokens: ['surface', 'border', 'muted', 'foreground'],
+        placeholderContent: 'grayscale-only',
+      },
+      mobile: {
+        viewport: 'mobile',
+        width: 390,
+        hierarchy: ['heading', 'tier label', 'proof card', 'navigation'],
+        layout: 'single stable-height card',
+        contentDensity: 'medium',
+        mediaPlacement: 'full-width card header',
+        responsiveBehavior:
+          'Reserve maximum copy height to prevent layout shift',
+        interactionModel:
+          'Buttons plus optional swipe; keyboard remains supported',
+        tokens: ['surface', 'border', 'muted', 'foreground'],
+        placeholderContent: 'grayscale-only',
+      },
+    },
+    openDesignQuestions: ['How visibly should the two proof tiers be labeled?'],
+    implementationPriority: 'high',
+    comments: [
+      {
+        author: 'registry-audit',
+        date: '2026-07-11',
+        body: 'Proof must remain verified; use approved artist-carousel until review.',
+      },
+    ],
+    registryTask: task(
+      'social-proof',
+      'apps/web/components/marketing/artist-profile/TwoRungProofCarousel.tsx'
+    ),
+    modelUsage: unavailableUsage,
+  },
+  {
+    id: 'PROPOSED-SECTION-0003',
+    proposedSectionName: 'Pay-flow video split',
+    status: 'proposed',
+    problem:
+      'Demonstrate the payment flow beside conversion copy without turning video into a second hero.',
+    affectedRoutes: ['/pay'],
+    intendedAudience: ['artist'],
+    conversionGoal: 'Start accepting fan payments',
+    requiredContentFields: [
+      'outcome heading',
+      'flow summary',
+      'step captions',
+      'poster alt text',
+    ],
+    requiredMedia: ['captioned product-flow video', 'static poster fallback'],
+    proposedResponsiveBehavior:
+      'Desktop copy/video split; mobile stacks copy then full-width video with fixed aspect ratio.',
+    proposedCtaBehavior:
+      'One primary CTA in copy; video controls are not conversion CTAs.',
+    sectionType: 'feature-split',
+    similarExistingSections: ['feature-split'],
+    existingApprovedVariantInsufficiency:
+      'Approved feature-split variants cover screenshots; the video-background variant is unproven and too cinematic for an instructional pay flow.',
+    wireframes: {
+      desktop: {
+        viewport: 'desktop',
+        width: 1440,
+        hierarchy: [
+          'heading',
+          'summary',
+          'primary CTA',
+          'video frame',
+          'captions',
+        ],
+        layout: '5/12 copy + 7/12 media',
+        contentDensity: 'low',
+        mediaPlacement: 'right fixed-ratio frame',
+        responsiveBehavior: 'Stacks media below copy under 768px',
+        interactionModel:
+          'User-initiated playback with native controls and poster fallback',
+        tokens: ['surface', 'border', 'muted', 'foreground'],
+        placeholderContent: 'grayscale-only',
+      },
+      mobile: {
+        viewport: 'mobile',
+        width: 390,
+        hierarchy: [
+          'heading',
+          'summary',
+          'primary CTA',
+          'video frame',
+          'captions',
+        ],
+        layout: 'single stack',
+        contentDensity: 'low',
+        mediaPlacement: 'full-width below CTA',
+        responsiveBehavior: 'Fixed aspect ratio reserves playback height',
+        interactionModel: 'User-initiated playback; no autoplay',
+        tokens: ['surface', 'border', 'muted', 'foreground'],
+        placeholderContent: 'grayscale-only',
+      },
+    },
+    openDesignQuestions: [
+      'Should step captions sit below the player or use an external transcript?',
+    ],
+    implementationPriority: 'medium',
+    comments: [
+      {
+        author: 'registry-audit',
+        date: '2026-07-11',
+        body: 'Keep the current approved screenshot split until captioned video assets exist.',
+      },
+    ],
+    registryTask: task(
+      'feature-split',
+      'apps/web/features/pay/PayFlowVideoSplit.tsx'
+    ),
+    modelUsage: unavailableUsage,
+  },
+  {
+    id: 'PROPOSED-SECTION-0004',
+    proposedSectionName: 'Download platform selector',
+    status: 'reviewing',
+    problem:
+      'Let visitors choose an available desktop platform while clearly distinguishing unavailable platforms.',
+    affectedRoutes: ['/download'],
+    intendedAudience: ['artist', 'general'],
+    conversionGoal: 'Download the desktop application',
+    requiredContentFields: [
+      'platform',
+      'availability',
+      'system requirement',
+      'download label',
+    ],
+    requiredMedia: ['platform icon from existing icon set'],
+    proposedResponsiveBehavior:
+      'Desktop uses equal selector cards; mobile uses a stacked radio-card list with the selected action below.',
+    proposedCtaBehavior:
+      'Only the selected available platform exposes the page-primary download CTA.',
+    sectionType: 'feature-grid',
+    similarExistingSections: ['feature-grid', 'capture'],
+    existingApprovedVariantInsufficiency:
+      'Approved feature-grid variants are informational card grids and do not define selection, availability, or a single conditional download action.',
+    wireframes: {
+      desktop: {
+        viewport: 'desktop',
+        width: 1440,
+        hierarchy: [
+          'heading',
+          'platform cards',
+          'availability detail',
+          'download CTA',
+        ],
+        layout: 'three equal cards over one detail/action row',
+        contentDensity: 'medium',
+        mediaPlacement: 'small icon at card top',
+        responsiveBehavior: 'Cards become a vertical list under 640px',
+        interactionModel:
+          'Single-select radio cards; unavailable choices are labeled, not disabled without explanation',
+        tokens: ['surface', 'border', 'muted', 'foreground'],
+        placeholderContent: 'grayscale-only',
+      },
+      mobile: {
+        viewport: 'mobile',
+        width: 390,
+        hierarchy: [
+          'heading',
+          'platform list',
+          'availability detail',
+          'download CTA',
+        ],
+        layout: 'single stack',
+        contentDensity: 'medium',
+        mediaPlacement: 'leading icon in each row',
+        responsiveBehavior:
+          'Action remains in normal flow below the stable list',
+        interactionModel:
+          'Radio-card list with 44px targets and announced availability',
+        tokens: ['surface', 'border', 'muted', 'foreground'],
+        placeholderContent: 'grayscale-only',
+      },
+    },
+    openDesignQuestions: [
+      'Should unavailable platforms accept waitlist intent?',
+    ],
+    implementationPriority: 'high',
+    comments: [
+      {
+        author: 'registry-audit',
+        date: '2026-07-11',
+        body: 'Reviewing interaction contract; production remains mapped to approved feature-grid.',
+      },
+    ],
+    registryTask: task(
+      'feature-grid',
+      'apps/web/components/marketing/download/DownloadPlatformSelector.tsx'
+    ),
+    modelUsage: unavailableUsage,
+  },
+] as const;
+
+export function getProposedSection(
+  id: ProposedSectionId
+): ProposedSectionRecord | null {
+  return PROPOSED_SECTIONS.find(proposal => proposal.id === id) ?? null;
+}

--- a/apps/web/data/marketing/index.ts
+++ b/apps/web/data/marketing/index.ts
@@ -35,6 +35,16 @@ export {
   resolveComposition,
 } from './composition';
 export type {
+  GrayscaleWireframeSpec,
+  ModelUsageEstimate,
+  ProposedSectionComment,
+  ProposedSectionId,
+  ProposedSectionRecord,
+  ProposedSectionStatus,
+  RegistryTaskContract,
+} from './designGaps';
+export { getProposedSection, PROPOSED_SECTIONS } from './designGaps';
+export type {
   ArcBeat,
   CtaCadence,
   MarketingRecipe,
@@ -49,11 +59,15 @@ export {
   MARKETING_RECIPE_IDS,
   MARKETING_RECIPES,
 } from './recipes';
-export type { RouteManifestEntry } from './routeManifest';
+export type {
+  RouteManifestEntry,
+  RouteRecipeParityReport,
+} from './routeManifest';
 export {
   DEPRECATION_RATCHET_BASELINE,
   EXEMPTION_RATCHET_BASELINE,
   getRouteManifestEntry,
+  getRouteRecipeParity,
   isExempt,
   isRecipeRoute,
   MARKETING_ROUTE_MANIFEST,

--- a/apps/web/data/marketing/routeManifest.ts
+++ b/apps/web/data/marketing/routeManifest.ts
@@ -14,7 +14,40 @@
  * waitlist recipe (currently stub tier).
  */
 
+import type { ProposedSectionId } from './designGaps';
 import type { RecipeId } from './recipes';
+import { getMarketingRecipe } from './recipes';
+import type { MarketingSectionId } from './sections';
+import { getMarketingSection } from './sections';
+
+export type RenderedSectionBinding =
+  | {
+      readonly kind: 'approved-section';
+      readonly sectionId: MarketingSectionId;
+      readonly componentPath: string;
+    }
+  | {
+      readonly kind: 'proposal';
+      readonly proposalId: ProposedSectionId;
+    };
+
+const approvedBindings = (
+  componentPath: string,
+  ...sectionIds: readonly MarketingSectionId[]
+): readonly RenderedSectionBinding[] =>
+  sectionIds.map(sectionId => {
+    const section = getMarketingSection(sectionId);
+    if (section.status !== 'approved') {
+      throw new Error(
+        `Route manifest cannot bind non-approved section ${sectionId}`
+      );
+    }
+    return {
+      kind: 'approved-section' as const,
+      sectionId,
+      componentPath,
+    };
+  });
 
 /** A route entry — either bound to a recipe or exempt with a sanctioned reason. */
 export interface RouteManifestEntry {
@@ -22,6 +55,13 @@ export interface RouteManifestEntry {
   readonly glob: string;
   /** Recipe this route implements — required unless `exempt`. */
   readonly recipeId?: RecipeId;
+  /** Ordered production bindings. Repeated section ids are legal recipe beats. */
+  readonly renderedSections: readonly RenderedSectionBinding[];
+  readonly bindingEvidence: {
+    readonly status: 'verified' | 'unverified' | 'exempt';
+    readonly source: string;
+    readonly notes?: string;
+  };
   /**
    * Exemption — when present, the route is NOT a recipe-composable page.
    * DX2 escape hatch: requires Linear ID + approvedBy + prUrl + optional expires.
@@ -69,6 +109,13 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(home)/page.tsx',
     recipeId: 'homepage',
+    renderedSections: approvedBindings('apps/web/app/(home)/page.tsx', 'hero'),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+      notes:
+        'Live route audit; feature-flagged story variants are not certified as recipe parity.',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/',
@@ -76,6 +123,22 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/new/page.tsx',
     recipeId: 'homepage',
+    renderedSections: approvedBindings(
+      'components/marketing/homepage-v2/HomepageV2Route.tsx',
+      'hero',
+      'logo-cloud',
+      'feature-split',
+      'feature-split',
+      'feature-split',
+      'spec-wall',
+      'social-proof',
+      'pricing',
+      'cta'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/new',
@@ -84,6 +147,19 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/pricing/page.tsx',
     recipeId: 'pricing',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/pricing/page.tsx',
+      'hero',
+      'pricing',
+      'social-proof',
+      'comparison',
+      'cta'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+      notes: 'FAQ recipe beat is not rendered.',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/pricing',
@@ -91,6 +167,16 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/launch/pricing/page.tsx',
     recipeId: 'pricing',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/launch/pricing/page.tsx',
+      'hero',
+      'pricing'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+      notes: 'Hand-built plan cards; later pricing recipe beats are absent.',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/launch/pricing',
@@ -98,6 +184,25 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/artist-profiles/page.tsx',
     recipeId: 'artist-lp',
+    renderedSections: approvedBindings(
+      'components/marketing/artist-profile/ArtistProfileLandingRoute.tsx',
+      'hero',
+      'logo-cloud',
+      'feature-split',
+      'social-proof',
+      'capture',
+      'feature-split',
+      'monetization',
+      'spec-wall',
+      'how-it-works',
+      'social-proof',
+      'faq',
+      'cta'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/artist-profiles',
@@ -105,6 +210,26 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/artist-profile/page.tsx',
     recipeId: 'artist-lp',
+    renderedSections: approvedBindings(
+      'components/marketing/artist-profile/ArtistProfileLandingRoute.tsx',
+      'hero',
+      'logo-cloud',
+      'feature-split',
+      'social-proof',
+      'capture',
+      'feature-split',
+      'monetization',
+      'spec-wall',
+      'how-it-works',
+      'social-proof',
+      'faq',
+      'cta'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+      notes: 'Alias renders the same route component as /artist-profiles.',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/artist-profile',
@@ -113,6 +238,21 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/artist-notifications/page.tsx',
     recipeId: 'feature',
+    renderedSections: approvedBindings(
+      'components/marketing/artist-notifications/ArtistNotificationsLanding.tsx',
+      'hero',
+      'logo-cloud',
+      'capture',
+      'feature-split',
+      'feature-grid',
+      'spec-wall',
+      'faq',
+      'cta'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/artist-notifications',
@@ -120,6 +260,19 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/download/page.tsx',
     recipeId: 'feature',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/download/page.tsx',
+      'hero',
+      'feature-grid',
+      'how-it-works',
+      'feature-grid',
+      'faq',
+      'cta'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/download',
@@ -127,6 +280,13 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/pay/page.tsx',
     recipeId: 'feature',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'unverified',
+      source: 'route audit 2026-07-11',
+      notes:
+        'PayLanding body was outside the bounded route audit; no parity is asserted.',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/pay',
@@ -134,6 +294,17 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/voice/page.tsx',
     recipeId: 'feature',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/voice/page.tsx',
+      'hero',
+      'feature-grid',
+      'feature-split',
+      'cta'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/voice',
@@ -142,6 +313,24 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/launch/page.tsx',
     recipeId: 'launch',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/launch/page.tsx',
+      'hero',
+      'logo-cloud',
+      'feature-split',
+      'feature-split',
+      'feature-split',
+      'feature-split',
+      'feature-split',
+      'feature-split',
+      'content-prose',
+      'comparison',
+      'cta'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/launch',
@@ -149,6 +338,17 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/about/page.tsx',
     recipeId: 'seo',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/about/page.tsx',
+      'hero',
+      'content-prose',
+      'content-prose',
+      'faq'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/about',
@@ -156,6 +356,19 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/support/page.tsx',
     recipeId: 'seo',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/support/page.tsx',
+      'hero',
+      'content-prose',
+      'faq',
+      'cta'
+    ),
+    bindingEvidence: {
+      status: 'unverified',
+      source: 'route audit 2026-07-11',
+      notes:
+        'SupportChannels maps conceptually to content-prose or feature-grid; exact section type requires migration review.',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/support',
@@ -163,6 +376,17 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/compare/[slug]/page.tsx',
     recipeId: 'comparison',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/compare/[slug]/page.tsx',
+      'hero',
+      'comparison',
+      'cta',
+      'faq'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/compare/*',
@@ -170,6 +394,18 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/alternatives/[slug]/page.tsx',
     recipeId: 'comparison',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/alternatives/[slug]/page.tsx',
+      'hero',
+      'content-prose',
+      'feature-grid',
+      'cta',
+      'faq'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/alternatives/*',
@@ -177,6 +413,15 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/blog/page.tsx',
     recipeId: 'blog-landing',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/blog/page.tsx',
+      'hero',
+      'blog-feed'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/blog',
@@ -184,6 +429,15 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: '(marketing)/blog/category/[slug]/page.tsx',
     recipeId: 'blog-landing',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/blog/category/[slug]/page.tsx',
+      'hero',
+      'blog-feed'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-07-11',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/blog/category/*',
@@ -192,6 +446,13 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   {
     glob: 'waitlist/page.tsx',
     recipeId: 'waitlist',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'unverified',
+      source: 'route audit 2026-07-11',
+      notes:
+        'Route renders an authenticated success view or redirects; canonical recipe mapping is not verified.',
+    },
     status: 'active',
     specVersion: '1.0.0',
     url: '/waitlist',
@@ -200,6 +461,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   // ── Exemptions (sanctioned per DX2 — linearId + approvedBy + prUrl required) ──
   {
     glob: '(marketing)/ai/page.tsx',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'exempt',
+      source: 'sanctioned route manifest exemption',
+    },
     exempt: {
       reason:
         'noindex public brief — hand-rolled <main> layout, no marketing shell; not recipe-composable',
@@ -214,6 +480,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   },
   {
     glob: '(marketing)/blog/[slug]/page.tsx',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'exempt',
+      source: 'sanctioned route manifest exemption',
+    },
     exempt: {
       reason:
         'dynamic content page — article body via BlogPostPage organism; not section-composed',
@@ -227,6 +498,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   },
   {
     glob: '(marketing)/blog/authors/[username]/page.tsx',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'exempt',
+      source: 'sanctioned route manifest exemption',
+    },
     exempt: {
       reason:
         'dynamic content page — author card + post list; not section-composed',
@@ -240,6 +516,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   },
   {
     glob: '(marketing)/changelog/page.tsx',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'exempt',
+      source: 'sanctioned route manifest exemption',
+    },
     exempt: {
       reason:
         'generated content page — rendered from repo CHANGELOG.md via lib/changelog-parser.ts; not recipe-composable',
@@ -253,6 +534,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   },
   {
     glob: '(marketing)/demo/video/page.tsx',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'exempt',
+      source: 'sanctioned route manifest exemption',
+    },
     exempt: {
       reason:
         'noindex demo surface — renders features/demo/DemoVideoPage; not section-composed',
@@ -267,6 +553,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   },
   {
     glob: '(marketing)/demovideo/page.tsx',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'exempt',
+      source: 'sanctioned route manifest exemption',
+    },
     exempt: {
       reason: 'noindex duplicate of /demo/video — identical body; legacy route',
       linearId: 'JOV-4063',
@@ -280,6 +571,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   },
   {
     glob: '(marketing)/investors/page.tsx',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'exempt',
+      source: 'sanctioned route manifest exemption',
+    },
     exempt: {
       reason:
         'noindex investor brief — hand-rolled layout; not recipe-composable',
@@ -294,6 +590,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   },
   {
     glob: '(marketing)/renders/page.tsx',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'exempt',
+      source: 'sanctioned route manifest exemption',
+    },
     exempt: {
       reason:
         'internal render surface — screenshot-capture index for marketing renders',
@@ -307,6 +608,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   },
   {
     glob: '(marketing)/renders/[state]/page.tsx',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'exempt',
+      source: 'sanctioned route manifest exemption',
+    },
     exempt: {
       reason:
         'internal render surface — profile showcase states; dynamicParams = false',
@@ -320,6 +626,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
   },
   {
     glob: '(marketing)/renders/surfaces/[surface]/page.tsx',
+    renderedSections: [],
+    bindingEvidence: {
+      status: 'exempt',
+      source: 'sanctioned route manifest exemption',
+    },
     exempt: {
       reason:
         'internal render surface — MarketingRenderSurface capture targets',
@@ -352,6 +663,39 @@ export function isExempt(glob: string): boolean {
 
 export function isRecipeRoute(glob: string): boolean {
   return MANIFEST_BY_GLOB[glob]?.recipeId !== undefined;
+}
+
+export interface RouteRecipeParityReport {
+  readonly url: string;
+  readonly evidenceStatus: RouteManifestEntry['bindingEvidence']['status'];
+  readonly expectedSectionIds: readonly MarketingSectionId[];
+  readonly actualSectionIds: readonly MarketingSectionId[];
+  readonly matches: boolean | null;
+}
+
+export function getRouteRecipeParity(
+  entry: RouteManifestEntry
+): RouteRecipeParityReport {
+  const expectedSectionIds = entry.recipeId
+    ? getMarketingRecipe(entry.recipeId).sectionOrder
+    : [];
+  const actualSectionIds = entry.renderedSections.flatMap(binding =>
+    binding.kind === 'approved-section' ? [binding.sectionId] : []
+  );
+  const canCompare =
+    entry.bindingEvidence.status === 'verified' && entry.recipeId !== undefined;
+  return {
+    url: entry.url,
+    evidenceStatus: entry.bindingEvidence.status,
+    expectedSectionIds,
+    actualSectionIds,
+    matches: canCompare
+      ? expectedSectionIds.length === actualSectionIds.length &&
+        expectedSectionIds.every((sectionId, index) =>
+          Object.is(sectionId, actualSectionIds[index])
+        )
+      : null,
+  };
 }
 
 /**

--- a/apps/web/data/marketing/sections.ts
+++ b/apps/web/data/marketing/sections.ts
@@ -256,7 +256,7 @@ export interface MarketingSection {
    * as hard legality failures.
    */
   readonly neverUse: readonly string[];
-  readonly status: 'active' | 'deprecated' | 'removed';
+  readonly status: 'approved' | 'deprecated' | 'removed';
   readonly deprecatedSince?: string;
   readonly replacedBy?: MarketingSectionId;
 }
@@ -523,7 +523,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'As anything other than the first section (composition rule)',
       'With fabricated metrics in the logos/media slot (zero-proof law)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── logo-cloud ──────────────────────────────────────────────────────────────
@@ -602,7 +602,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'As the closing beat (illegalAfter pricing/cta)',
       'On artist-recipes with customer-company logos (use platform-reach-row variant instead)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── feature-grid ────────────────────────────────────────────────────────────
@@ -713,7 +713,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
     neverUse: [
       'With fabricated feature claims (copy must describe real capability)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── feature-split ───────────────────────────────────────────────────────────
@@ -812,7 +812,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
     neverUse: [
       'As a problem-agitation section for audience=artist (creator R9: no problem beat in artist arc)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── how-it-works ────────────────────────────────────────────────────────────
@@ -891,7 +891,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
     neverUse: [
       'After pricing/cta/faq (terminal-section proximity illegalAfter)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── social-proof ────────────────────────────────────────────────────────────
@@ -998,7 +998,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'Immediately after hero (illegalAfter hero — proof is a gradient)',
       'For audience=artist with quotes from famous artists (creator R5: famous=profiles, quotes=small/relatable)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── stats ───────────────────────────────────────────────────────────────────
@@ -1078,7 +1078,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'Immediately after hero (illegalAfter)',
       'With more than 4 stats (cognitive overload)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── pricing ──────────────────────────────────────────────────────────────────
@@ -1178,7 +1178,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'Immediately after hero (illegalAfter hero; requires feature-grid first)',
       'On artist LP as a full table (use one-liner-link variant; cost-objection in CTA string)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── comparison ──────────────────────────────────────────────────────────────
@@ -1256,7 +1256,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'Above the fold when audience=artist (audienceLegality)',
       'Immediately after hero or cta (illegalAfter)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── faq ────────────────────────────────────────────────────────────────────
@@ -1326,7 +1326,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'Immediately after hero (illegalAfter)',
       'Without real question sourcing (zero-proof law)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── cta ────────────────────────────────────────────────────────────────────
@@ -1412,7 +1412,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'Before any proof beat (mid-page CTAs only after proof — B2B C6)',
       'With multiple distinct primary CTA verbs on one page (one primary label repeated — B2B C6 invariant)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── spec-wall (Jovie delta) ────────────────────────────────────────────────
@@ -1484,7 +1484,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'Immediately after hero or cta (illegalAfter)',
       'Without a screenshot or icon per tile (use feature-grid instead)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── capture (Jovie delta) ───────────────────────────────────────────────────
@@ -1562,7 +1562,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'As a demo-gate on audience=artist (creator R10 — self-serve only on creator paths)',
       'Without interaction states (submitting/success/error/already-subscribed — Design F2)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── monetization (Jovie delta) ─────────────────────────────────────────────
@@ -1646,7 +1646,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'Without a real take-rate (zero-proof law; omit the section instead)',
       'With projected personal earnings calculators (creator R3 — banned)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── ownership (Jovie delta) ─────────────────────────────────────────────────
@@ -1711,7 +1711,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'For audience=fan (audienceLegality)',
       'Without the music object (use music-native nouns: releases, drops, shows, payouts — creator R5)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── content-prose ───────────────────────────────────────────────────────────
@@ -1778,7 +1778,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
     neverUse: [
       'On a conversion-page recipe as the primary body (conversion pages use feature-grid/feature-split, not prose)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 
   // ── blog-feed ───────────────────────────────────────────────────────────────
@@ -1849,7 +1849,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
       'Immediately after hero (illegalAfter — hero is for the page promise, not the feed)',
       'With <3 posts (omit the section)',
     ],
-    status: 'active',
+    status: 'approved',
   },
 ] as const;
 

--- a/apps/web/tests/unit/marketing/recipe-manifest.test.ts
+++ b/apps/web/tests/unit/marketing/recipe-manifest.test.ts
@@ -26,6 +26,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   EXEMPTION_RATCHET_BASELINE,
+  getRouteRecipeParity,
   MARKETING_RECIPE_IDS,
   MARKETING_RECIPES,
   MARKETING_ROUTE_MANIFEST,
@@ -35,6 +36,7 @@ import {
   MarketingBriefSchema,
   MarketingCompositionSchema,
   type MarketingSectionId,
+  PROPOSED_SECTIONS,
   type RecipeId,
   resolveComposition,
 } from '@/data/marketing';
@@ -388,6 +390,151 @@ describe('marketing route manifest integrity', () => {
       }
     }
   });
+
+  it('every rendered binding resolves to an approved section or approved proposal', () => {
+    for (const entry of MARKETING_ROUTE_MANIFEST) {
+      for (const binding of entry.renderedSections) {
+        if (binding.kind === 'approved-section') {
+          const section = MARKETING_SECTIONS.find(
+            candidate => candidate.id === binding.sectionId
+          );
+          expect(section?.status, `${entry.url}: ${binding.sectionId}`).toBe(
+            'approved'
+          );
+          expect(binding.componentPath.trim()).toBeTruthy();
+          continue;
+        }
+
+        const proposal = PROPOSED_SECTIONS.find(
+          candidate => candidate.id === binding.proposalId
+        );
+        expect(proposal, `${entry.url}: ${binding.proposalId}`).toBeDefined();
+        expect(
+          proposal && ['approved', 'implemented'].includes(proposal.status),
+          `${entry.url} cannot ship proposal ${binding.proposalId} with status ${proposal?.status}`
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('every route has bindings or an explicit non-composable exemption', () => {
+    for (const entry of MARKETING_ROUTE_MANIFEST) {
+      if (entry.renderedSections.length === 0) {
+        const hasExemption = Boolean(entry.exempt?.reason.trim());
+        const isExplicitlyUnverified =
+          entry.bindingEvidence.status === 'unverified' &&
+          Boolean(entry.bindingEvidence.notes?.trim());
+        expect(hasExemption || isExplicitlyUnverified, entry.url).toBe(true);
+      } else {
+        expect(entry.recipeId, entry.url).toBeDefined();
+      }
+    }
+  });
+
+  it('keeps audited route-to-recipe parity gaps visible', () => {
+    const launchPricing = MARKETING_ROUTE_MANIFEST.find(
+      entry => entry.url === '/launch/pricing'
+    );
+    const artistProfiles = MARKETING_ROUTE_MANIFEST.find(
+      entry => entry.url === '/artist-profiles'
+    );
+    expect(launchPricing).toBeDefined();
+    expect(artistProfiles).toBeDefined();
+
+    const launchReport = getRouteRecipeParity(launchPricing!);
+    expect(launchReport.actualSectionIds).toEqual(['hero', 'pricing']);
+    expect(launchReport.expectedSectionIds).toEqual([
+      'hero',
+      'pricing',
+      'social-proof',
+      'comparison',
+      'faq',
+      'cta',
+    ]);
+    expect(launchReport.matches).toBe(false);
+
+    const artistReport = getRouteRecipeParity(artistProfiles!);
+    expect(artistReport.actualSectionIds).toEqual([
+      'hero',
+      'logo-cloud',
+      'feature-split',
+      'social-proof',
+      'capture',
+      'feature-split',
+      'monetization',
+      'spec-wall',
+      'how-it-works',
+      'social-proof',
+      'faq',
+      'cta',
+    ]);
+    expect(artistReport.evidenceStatus).toBe('verified');
+    expect(artistReport.matches).toBe(false);
+  });
+
+  it('does not claim parity for unaudited route bodies', () => {
+    const pay = MARKETING_ROUTE_MANIFEST.find(entry => entry.url === '/pay');
+    expect(pay).toBeDefined();
+    expect(getRouteRecipeParity(pay!).matches).toBeNull();
+  });
+});
+
+describe('proposed section governance', () => {
+  it('uses unique stable proposal ids and complete review records', () => {
+    const ids = PROPOSED_SECTIONS.map(proposal => proposal.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    for (const proposal of PROPOSED_SECTIONS) {
+      expect(proposal.id).toMatch(/^PROPOSED-SECTION-\d{4}$/);
+      expect(proposal.proposedSectionName.trim()).toBeTruthy();
+      expect(proposal.problem.trim()).toBeTruthy();
+      expect(proposal.affectedRoutes.length).toBeGreaterThan(0);
+      expect(proposal.intendedAudience.length).toBeGreaterThan(0);
+      expect(proposal.conversionGoal.trim()).toBeTruthy();
+      expect(proposal.requiredContentFields.length).toBeGreaterThan(0);
+      expect(proposal.requiredMedia.length).toBeGreaterThan(0);
+      expect(proposal.proposedResponsiveBehavior.trim()).toBeTruthy();
+      expect(proposal.proposedCtaBehavior.trim()).toBeTruthy();
+      expect(proposal.similarExistingSections.length).toBeGreaterThan(0);
+      expect(proposal.existingApprovedVariantInsufficiency.trim()).toBeTruthy();
+      expect(proposal.openDesignQuestions.length).toBeGreaterThan(0);
+      expect(proposal.comments.length).toBeGreaterThan(0);
+      expect(proposal.registryTask.trigger).toBe('after-approved');
+      expect(proposal.registryTask.requiredChanges.length).toBeGreaterThan(0);
+      expect(proposal.registryTask.exactFiles.length).toBeGreaterThan(0);
+      expect(proposal.registryTask.forbiddenPatterns.length).toBeGreaterThan(0);
+      expect(proposal.registryTask.acceptanceCriteria.length).toBeGreaterThan(
+        0
+      );
+      expect(proposal.registryTask.validationCommands.length).toBeGreaterThan(
+        0
+      );
+      expect(proposal.registryTask.evidenceRequired.length).toBeGreaterThan(0);
+      expect(proposal.registryTask.implementedAt).toBeNull();
+      expect(proposal.registryTask.evidenceRefs).toEqual([]);
+
+      for (const wireframe of [
+        proposal.wireframes.desktop,
+        proposal.wireframes.mobile,
+      ]) {
+        expect(wireframe.hierarchy.length).toBeGreaterThan(0);
+        expect(wireframe.layout.trim()).toBeTruthy();
+        expect(wireframe.mediaPlacement.trim()).toBeTruthy();
+        expect(wireframe.responsiveBehavior.trim()).toBeTruthy();
+        expect(wireframe.interactionModel.trim()).toBeTruthy();
+        expect(wireframe.placeholderContent).toBe('grayscale-only');
+      }
+    }
+  });
+
+  it('seeds only the four audited variant-level design gaps', () => {
+    expect(PROPOSED_SECTIONS.map(proposal => proposal.id)).toEqual([
+      'PROPOSED-SECTION-0001',
+      'PROPOSED-SECTION-0002',
+      'PROPOSED-SECTION-0003',
+      'PROPOSED-SECTION-0004',
+    ]);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -395,6 +542,32 @@ describe('marketing route manifest integrity', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('marketing decision engine determinism (golden fixtures)', () => {
+  it('applies nested brief defaults when asset and brand objects are omitted', () => {
+    const parsed = MarketingBriefSchema.parse({
+      businessObjective: 'Exercise Zod input defaults',
+      targetAudience: 'general',
+      desiredConversion: 'start',
+      intent: 'category',
+    });
+
+    expect(parsed.availableAssets).toEqual({
+      socialProofVerified: false,
+      statsVerified: false,
+      logoCloudVerified: false,
+      productScreenshots: true,
+      artistFaces: false,
+      artistFacesTwoRung: false,
+      takeRateReal: false,
+      phoneProfileAsset: false,
+      videoAsset: false,
+    });
+    expect(parsed.brandConstraints).toEqual({
+      darkOnly: true,
+      fullyStatic: true,
+      waitlistEnabled: false,
+    });
+  });
+
   const briefFiles = [
     'brief-01-artist-claim.json',
     'brief-02-homepage-general.json',

--- a/docs/marketing/AGENT_GUIDE.md
+++ b/docs/marketing/AGENT_GUIDE.md
@@ -207,7 +207,9 @@ humanOptIn: { prUrl: string, date: string }
 ```
 The PR URL is the approval artifact (per post-2026-07-06 autonomy doctrine —
 approval artifact = PR/Linear, not a pre-merge human). First use goes through
-taste feedback, then the variant/section can promote to `status: 'active'`.
+taste feedback, then a variant can promote to `status: 'active'`. Missing
+section types follow `DESIGN_GAPS.md` and enter production only as approved
+registry sections.
 
 ## When the spec version bumps
 
@@ -233,4 +235,6 @@ are reverse-engineered FROM code, not the reverse.
 - `SECTION_CATALOG.md` — per-section rationale + exemplar.
 - `RECIPE_CATALOG.md` — per-recipe rationale + arc + decision tree.
 - `COMPOSITION_RULES.md` — composition-rule rationale (7 laws + page-class rules).
+- `DESIGN_GAPS.md` — proposed-section review, conversion workflow, migration matrix.
+- `MODEL_USAGE.md` — model-role and cost evidence ledger.
 - `AGENT_GUIDE.md` (this file) — sole entrypoint.

--- a/docs/marketing/ARCHITECTURE.md
+++ b/docs/marketing/ARCHITECTURE.md
@@ -207,9 +207,10 @@ Spec-doc version drift fails Structural Contract doc-freshness (E13).
 | **minor** | Add a section, recipe, or variant; add a route mapping. Backward-compatible. |
 | **major** | Remove or deprecate a section/recipe/variant; change a chooseWhen predicate; reorder a recipe's sectionOrder. Requires lifecycle fields (`status: 'deprecated'`, `deprecatedSince`, `replacedBy`) + canon precedence update. |
 
-Section/variant lifecycle: `status: 'active' | 'deprecated' | 'removed'`.
-`deprecated` requires `deprecatedSince` + `replacedBy` (must reference an active
-id, test-asserted). `removed` usage = hard fail naming `replacedBy`.
+Production section lifecycle: `status: 'approved' | 'deprecated' | 'removed'`.
+Variant maturity remains `active | unproven | deprecated | removed`.
+`deprecated` requires `deprecatedSince` + `replacedBy` (the replacement must be
+approved for sections or active for variants). `removed` usage is a hard fail.
 
 Two ratchets (decrease-only baselines):
 - **Exemption ratchet**: unsanctioned exemptions (missing `linearId`/`approvedBy`/`prUrl`) must not increase. Baseline: 0.
@@ -247,7 +248,9 @@ and ui.md. Stays-rows are referenced, not duplicated.
 
 Adding a new section/recipe/variant:
 1. Add to the registry (`sections.ts` or `recipes.ts`) with a kebab-case id.
-2. Declare `status: 'unproven'` if no shipped exemplar; first use requires `humanOptIn` (DX2).
+2. New production sections enter through a `ProposedSectionRecord`; only add the
+   section registry entry after approval. New variants without a shipped
+   exemplar use `status: 'unproven'` and require `humanOptIn` (DX2).
 3. Add a golden-fixture brief that exercises the new path (determinism regression-tested forever).
 4. Bump `MARKETING_SPEC_VERSION` (minor for addition).
 5. Add the docs anchor (`#section-{id}` or `#recipe-{id}`) — manifest gate asserts parity.
@@ -256,6 +259,8 @@ Adding a new section/recipe/variant:
 Adding a new route:
 1. Add to `routeManifest.ts` with `recipeId` or sanctioned `exempt` (DX2: `linearId` + `approvedBy` + `prUrl`).
 2. If exempt and unsanctioned, the exemption ratchet fails — must carry all three fields.
+3. Add ordered `renderedSections`. Production bindings must resolve to approved
+   sections; a non-composable exemption records an empty list and its reason.
 
 ## 13. Migration strategy
 

--- a/docs/marketing/DESIGN_GAPS.md
+++ b/docs/marketing/DESIGN_GAPS.md
@@ -1,0 +1,69 @@
+<!--
+spec-version: 1.0.0
+doc-freshness: docs/marketing/DESIGN_GAPS.md
+-->
+# Missing-section governance
+
+The normative catalog is `apps/web/data/marketing/designGaps.ts`. This document
+explains the repeatable review and conversion workflow; it does not duplicate
+proposal records.
+
+## State model
+
+- `approved` production sections live in `MARKETING_SECTIONS` and may be bound
+  by production routes.
+- `proposed` and `reviewing` records contain grayscale desktop/mobile
+  wireframes and may not be production bindings.
+- `approved` proposals are review decisions, not components. Their
+  `registryTask` must be completed before the proposal becomes `implemented`.
+- `rejected` proposals remain in the catalog to prevent repeated proposals.
+- `deprecated` and `removed` production sections remain governed by the section
+  lifecycle and deprecation ratchet.
+
+Variant status is a separate maturity axis. An `unproven` variant still needs
+the existing `humanOptIn` artifact; it does not create a new section type.
+
+## Gap to registry workflow
+
+1. Search `MARKETING_SECTIONS` and recipes for an approved section or approved
+   composition that satisfies the need.
+2. If none does, add one complete `ProposedSectionRecord` with the next stable
+   `PROPOSED-SECTION-NNNN` ID. Identify all affected routes and explain why the
+   approved variants are insufficient.
+3. Specify both grayscale wireframes using only `surface`, `border`, `muted`,
+   and `foreground`. Record hierarchy, density, media placement, responsive
+   behavior, and interaction behavior.
+4. Review through status/comments. Compact feedback is stored verbatim, for
+   example: `PROPOSED-SECTION-0012: approve layout, remove secondary CTA`.
+5. Production continues with the closest approved section. The manifest gate
+   rejects production bindings to proposed, reviewing, or rejected records.
+6. After approval, execute the committed `registryTask`: finalize the typed
+   variant contract, assign bounded implementation, add fixture/screenshots,
+   migrate all affected routes, verify, then mark `implemented`.
+
+## Current migration matrix
+
+| Routes | Audited actual binding / parity | Open design gap |
+|---|---|---|
+| `/` | verified `hero` only; homepage recipe mismatch | none |
+| `/new` | verified homepage recipe parity | none |
+| `/pricing` | verified `hero → pricing → social-proof → comparison → cta`; FAQ missing | none |
+| `/launch/pricing` | verified `hero → pricing`; later pricing beats missing | none |
+| `/artist-profiles`, `/artist-profile` | verified 12-beat actual order; differs from the 11-beat artist recipe | `PROPOSED-SECTION-0002` proof carousel |
+| `/artist-notifications` | verified feature recipe parity | `PROPOSED-SECTION-0001` mode switcher |
+| `/pay` | unverified `PayLanding` body; parity intentionally unknown | `PROPOSED-SECTION-0003` pay-flow video split |
+| `/download` | verified `hero → feature-grid → how-it-works → feature-grid → faq → cta`; feature recipe mismatch | `PROPOSED-SECTION-0004` platform selector |
+| `/voice` | verified `hero → feature-grid → feature-split → cta`; feature recipe mismatch | none |
+| `/launch` | verified launch recipe parity | none |
+| `/about` | verified `hero → content-prose ×2 → faq`; SEO recipe mismatch | none |
+| `/support` | unverified section-type ambiguity in `SupportChannels` | none |
+| `/compare/*`, `/alternatives/*` | verified actual sequences; both differ from comparison recipe | none |
+| `/blog`, `/blog/category/*` | verified `hero → blog-feed`; capture/CTA recipe beats missing | none |
+| `/waitlist` | unverified authenticated success view or redirect | none |
+| `/ai`, `/blog/*` articles, `/blog/authors/*`, `/changelog`, `/demo/video`, `/demovideo`, `/investors`, `/renders*` | sanctioned non-composable exemption with empty bindings | none |
+
+Every manifest route carries audited `renderedSections` plus evidence status.
+Repeated section IDs are intentional; aliases carry their own explicit list.
+`getRouteRecipeParity` compares verified actual order with recipe order. It
+returns `null` for unverified/exempt bodies so unknown evidence cannot pass as
+parity.

--- a/docs/marketing/MODEL_USAGE.md
+++ b/docs/marketing/MODEL_USAGE.md
@@ -1,0 +1,22 @@
+<!--
+spec-version: 1.0.0
+doc-freshness: docs/marketing/MODEL_USAGE.md
+-->
+# Model usage ledger
+
+Runtime model names, token counts, durations, and billing were not exposed to
+delegated agents. Those values are recorded as unavailable rather than guessed.
+
+| Task ID | Role | Agent/model | Frontier or escalation reason | Duration | Tokens | Estimated cost |
+|---|---|---|---|---|---|---|
+| AUDIT-REGISTRY | bounded audit: registries, recipes, route manifest | unavailable from runtime | orchestration assigned a read-only architecture inventory | unavailable from runtime | unavailable from runtime | unavailable from runtime |
+| AUDIT-ROUTES-UI | bounded audit: routes and review surfaces | unavailable from runtime | orchestration assigned independent evidence gathering | unavailable from runtime | unavailable from runtime | unavailable from runtime |
+| AUDIT-GATES | bounded audit: tests and enforcement | unavailable from runtime | orchestration assigned independent gate inventory | unavailable from runtime | unavailable from runtime | unavailable from runtime |
+| IMPLEMENT-GOVERNANCE | implementation: data contract, bindings, tests, docs | unavailable from runtime | bounded economical implementation; no frontier escalation reported | unavailable from runtime | unavailable from runtime | unavailable from runtime |
+| IMPLEMENT-GALLERY | implementation: review gallery | unavailable from runtime | bounded economical implementation; owned by a separate task | unavailable from runtime | unavailable from runtime | unavailable from runtime |
+| IMPLEMENT-GUARD | implementation: production one-off guard | unavailable from runtime | bounded economical implementation; owned by a separate task | unavailable from runtime | unavailable from runtime | unavailable from runtime |
+| ORCHESTRATOR-REVIEW | architecture and diff review | unavailable from runtime | frontier role reserved for architecture conflict resolution and review | unavailable from runtime | unavailable from runtime | unavailable from runtime |
+| ORCHESTRATOR-VERIFY | final integration and exhaustive verification | unavailable from runtime | frontier role reserved for final verification | unavailable from runtime | unavailable from runtime | unavailable from runtime |
+
+Update this ledger when the orchestrator can observe actual usage. Never infer
+cost from wall time or prose output.


### PR DESCRIPTION
## Summary\n- audit marketing route recipes against the canonical section registry\n- expose explicit parity and evidence status for every route\n- add regression coverage for exemptions and mismatches\n\n## Verification\n- recipe manifest unit tests\n- monorepo typecheck\n- production web build\n\n## Stack\nPart 1 of the governed proposed-section workflow.