### PR TITLE
feat(design-lab): extend proposal contracts

### DIFF
--- a/apps/web/lib/agent-os/design-lab/fixtures.ts
+++ b/apps/web/lib/agent-os/design-lab/fixtures.ts
@@ -5,6 +5,7 @@ const FIXTURE_CREATED_AT = '2026-06-08T12:00:00.000Z';
 export const DESIGN_LAB_DEV_FIXTURE_PROPOSALS: readonly DesignProposal[] = [
   {
     id: 'profile-page-quiet-hero',
+    kind: 'surface',
     surfaceId: 'profile-page',
     surfaceName: 'Public profile page',
     proposalText:
@@ -14,7 +15,8 @@ export const DESIGN_LAB_DEV_FIXTURE_PROPOSALS: readonly DesignProposal[] = [
     linearIssueId: 'JOV-1951',
     linearIssueUrl:
       'https://linear.app/jovie/issue/JOV-1951/profile-redesign-proposal-loop',
-    status: 'pending',
+    status: 'proposed',
+    designGap: null,
     createdAt: FIXTURE_CREATED_AT,
     reviewedAt: null,
     reviewer: null,
@@ -25,6 +27,7 @@ export const DESIGN_LAB_DEV_FIXTURE_PROPOSALS: readonly DesignProposal[] = [
   },
   {
     id: 'sidebar-density-pass',
+    kind: 'surface',
     surfaceId: 'dashboard-sidebar',
     surfaceName: 'Dashboard sidebar',
     proposalText:
@@ -34,7 +37,8 @@ export const DESIGN_LAB_DEV_FIXTURE_PROPOSALS: readonly DesignProposal[] = [
     linearIssueId: 'JOV-2098',
     linearIssueUrl:
       'https://linear.app/jovie/issue/JOV-2098/designadmin-consolidate-overlapping-ia-across-overview-ops-growth',
-    status: 'pending',
+    status: 'proposed',
+    designGap: null,
     createdAt: FIXTURE_CREATED_AT,
     reviewedAt: null,
     reviewer: null,

--- a/apps/web/lib/agent-os/design-lab/proposals.ts
+++ b/apps/web/lib/agent-os/design-lab/proposals.ts
@@ -9,7 +9,9 @@ import {
   resolveDesignProposalFilePath,
 } from './paths';
 import {
+  DESIGN_PROPOSAL_STATUSES,
   type DesignProposal,
+  type DesignProposalComment,
   DesignProposalSchema,
   type DesignProposalStatus,
 } from './types';
@@ -22,7 +24,7 @@ function isMissingFileError(error: unknown): boolean {
   );
 }
 
-function parseProposalRecord(
+export function parseProposalRecord(
   raw: unknown,
   dayBucket: string
 ): DesignProposal | null {
@@ -117,9 +119,26 @@ export async function ensureDesignLabDevFixtures(): Promise<void> {
   }
 }
 
-export async function listPendingDesignProposals(): Promise<
-  readonly DesignProposal[]
-> {
+export interface DesignProposalFilters {
+  readonly statuses?: readonly DesignProposalStatus[];
+  readonly kinds?: readonly DesignProposal['kind'][];
+  readonly affectedRoute?: string;
+}
+
+export function matchesDesignProposalFilters(
+  proposal: DesignProposal,
+  filters: DesignProposalFilters
+): boolean {
+  const statuses = new Set(filters.statuses ?? DESIGN_PROPOSAL_STATUSES);
+  if (!statuses.has(proposal.status)) return false;
+  if (filters.kinds && !filters.kinds.includes(proposal.kind)) return false;
+  const route = filters.affectedRoute?.trim();
+  return !route || proposal.designGap?.affectedRoutes.includes(route) === true;
+}
+
+export async function listDesignProposals(
+  filters: DesignProposalFilters = {}
+): Promise<readonly DesignProposal[]> {
   await ensureDesignLabDevFixtures();
 
   const dayBuckets = await listDayBuckets();
@@ -129,8 +148,14 @@ export async function listPendingDesignProposals(): Promise<
 
   return proposals
     .flat()
-    .filter(proposal => proposal.status === 'pending')
+    .filter(proposal => matchesDesignProposalFilters(proposal, filters))
     .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+}
+
+export async function listPendingDesignProposals(): Promise<
+  readonly DesignProposal[]
+> {
+  return listDesignProposals({ statuses: ['proposed', 'reviewing'] });
 }
 
 export async function getDesignProposal(
@@ -166,5 +191,61 @@ export function deriveProposalStatus(
     return 'approved';
   }
 
-  return 'pending';
+  return 'proposed';
+}
+
+const COMPACT_FEEDBACK_PATTERN =
+  /^(PROPOSED-SECTION-\d{4}):\s*(\S[\s\S]{0,3999})$/;
+
+export interface ParsedCompactFeedback {
+  readonly reviewId: string;
+  readonly body: string;
+}
+
+export function parseCompactFeedback(
+  input: string
+): ParsedCompactFeedback | null {
+  const match = COMPACT_FEEDBACK_PATTERN.exec(input.trim());
+  if (!match?.[1] || !match[2]) return null;
+  return { reviewId: match[1], body: match[2].trim() };
+}
+
+export function appendDesignProposalComment(
+  proposal: DesignProposal,
+  comment: DesignProposalComment
+): DesignProposal {
+  if (!proposal.designGap) {
+    throw new Error('Design proposal does not have a design-gap record.');
+  }
+  return DesignProposalSchema.parse({
+    ...proposal,
+    designGap: {
+      ...proposal.designGap,
+      comments: [...proposal.designGap.comments, comment],
+    },
+  });
+}
+
+export function transitionProposalToImplemented(
+  proposal: DesignProposal,
+  evidence: { readonly implementedAt: string; readonly evidenceRefs: string[] }
+): DesignProposal {
+  if (proposal.status !== 'approved') {
+    throw new Error('Only approved proposals can be implemented.');
+  }
+  if (!proposal.designGap?.registryTask) {
+    throw new Error('Registry task is required before implementation.');
+  }
+  return DesignProposalSchema.parse({
+    ...proposal,
+    status: 'implemented',
+    designGap: {
+      ...proposal.designGap,
+      registryTask: {
+        ...proposal.designGap.registryTask,
+        implementedAt: evidence.implementedAt,
+        evidenceRefs: evidence.evidenceRefs,
+      },
+    },
+  });
 }

--- a/apps/web/lib/agent-os/design-lab/review.ts
+++ b/apps/web/lib/agent-os/design-lab/review.ts
@@ -37,7 +37,10 @@ export async function reviewDesignProposal(params: {
     throw new Error('Design proposal not found.');
   }
 
-  if (existing.status !== 'pending') {
+  // Persisted legacy records and test fixtures may still expose `pending`,
+  // while the expanded schema normalizes that state to `proposed`.
+  const existingStatus: string = existing.status;
+  if (existingStatus !== 'pending' && existingStatus !== 'proposed') {
     throw new Error('Design proposal has already been reviewed.');
   }
 

--- a/apps/web/lib/agent-os/design-lab/types.ts
+++ b/apps/web/lib/agent-os/design-lab/types.ts
@@ -255,7 +255,9 @@ export interface DesignLabDispatchPayload {
   readonly tasteMemoryExcerpt: string;
   readonly requestedAt: string;
   readonly requestedBy: string;
-  readonly registryTask: DesignRegistryTask;
+  // Older surface proposals do not carry a governed registry task. The review
+  // workflow makes this required before dispatching section-gap proposals.
+  readonly registryTask?: DesignRegistryTask;
 }
 
 export interface ReviewDesignProposalResult {

--- a/apps/web/lib/agent-os/design-lab/types.ts
+++ b/apps/web/lib/agent-os/design-lab/types.ts
@@ -1,11 +1,14 @@
 import { z } from 'zod';
 
 export const DESIGN_PROPOSAL_STATUSES = [
-  'pending',
+  'proposed',
+  'reviewing',
   'approved',
   'rejected',
+  'implemented',
 ] as const;
 
+export const DESIGN_PROPOSAL_KINDS = ['surface', 'section-gap'] as const;
 export const DESIGN_PROPOSAL_REVIEW_DECISIONS = [
   'yes',
   'no',
@@ -13,9 +16,130 @@ export const DESIGN_PROPOSAL_REVIEW_DECISIONS = [
 ] as const;
 
 export type DesignProposalStatus = (typeof DESIGN_PROPOSAL_STATUSES)[number];
-
+export type DesignProposalKind = (typeof DESIGN_PROPOSAL_KINDS)[number];
 export type DesignProposalReviewDecision =
   (typeof DESIGN_PROPOSAL_REVIEW_DECISIONS)[number];
+
+const NonEmptyText = z.string().trim().min(1);
+const StringList = z.array(NonEmptyText.max(500)).max(50);
+
+export const DesignWireframeSpecSchema = z
+  .object({
+    viewport: z.enum(['desktop', 'mobile']),
+    width: z.number().int().positive(),
+    hierarchy: StringList.min(1),
+    layout: NonEmptyText.max(2000),
+    contentDensity: z.enum(['low', 'medium', 'high']),
+    mediaPlacement: NonEmptyText.max(2000),
+    responsiveBehavior: NonEmptyText.max(3000),
+    interactionModel: NonEmptyText.max(2000),
+    tokens: z
+      .array(z.enum(['surface', 'border', 'muted', 'foreground']))
+      .min(1),
+    placeholderContent: z.literal('grayscale-only'),
+  })
+  .strict();
+
+export const DesignProposalCommentSchema = z
+  .object({
+    author: NonEmptyText.max(160),
+    body: NonEmptyText.max(4000),
+    date: NonEmptyText.max(40),
+  })
+  .strict();
+export type DesignProposalComment = z.infer<typeof DesignProposalCommentSchema>;
+
+export const DesignRegistryTaskSchema = z
+  .object({
+    trigger: z.literal('after-approved'),
+    targetSectionId: NonEmptyText.max(120),
+    requiredChanges: StringList.min(1),
+    exactFiles: StringList.default([]),
+    forbiddenPatterns: StringList,
+    acceptanceCriteria: StringList.min(1),
+    validationCommands: StringList.min(1),
+    evidenceRequired: StringList.default([]),
+    implementedAt: z.string().datetime().nullable().default(null),
+    evidenceRefs: StringList.default([]),
+  })
+  .strict();
+
+export const DesignModelUsageSchema = z
+  .object({
+    model: NonEmptyText.max(120),
+    role: z.enum(['audit', 'wireframe-spec', 'implementation', 'review']),
+    tokens: z.union([
+      z.number().int().nonnegative(),
+      z.literal('unavailable from runtime'),
+    ]),
+    estimatedCostUsd: z.union([
+      z.number().nonnegative(),
+      z.literal('unavailable from runtime'),
+    ]),
+    estimationBasis: NonEmptyText.max(1000),
+  })
+  .strict();
+
+const NormalizedDesignGapRecordSchema = z
+  .object({
+    reviewId: z.string().regex(/^PROPOSED-SECTION-\d{4}$/),
+    proposedName: NonEmptyText.max(160),
+    problem: NonEmptyText.max(4000),
+    affectedRoutes: StringList.min(1),
+    audience: NonEmptyText.max(1000),
+    conversionGoal: NonEmptyText.max(1000),
+    requiredContentFields: StringList,
+    requiredMedia: StringList,
+    responsiveBehavior: NonEmptyText.max(3000),
+    ctaBehavior: NonEmptyText.max(2000),
+    similarSections: StringList,
+    insufficiencyReason: NonEmptyText.max(3000),
+    priority: z.enum(['low', 'medium', 'high', 'critical']),
+    sectionType: NonEmptyText.max(120),
+    wireframes: z
+      .object({
+        desktop: DesignWireframeSpecSchema,
+        mobile: DesignWireframeSpecSchema,
+      })
+      .strict(),
+    openQuestions: StringList,
+    comments: z.array(DesignProposalCommentSchema).max(200),
+    registryTask: DesignRegistryTaskSchema.nullable(),
+    modelUsage: z.array(DesignModelUsageSchema).max(50),
+  })
+  .strict();
+
+export const DesignGapRecordSchema = z.preprocess(value => {
+  if (!value || typeof value !== 'object') return value;
+  const record = value as Record<string, unknown>;
+  if (!('id' in record)) return value;
+  return {
+    reviewId: record.id,
+    proposedName: record.proposedSectionName,
+    problem: record.problem,
+    affectedRoutes: record.affectedRoutes,
+    audience: Array.isArray(record.intendedAudience)
+      ? record.intendedAudience.join(', ')
+      : record.intendedAudience,
+    conversionGoal: record.conversionGoal,
+    requiredContentFields: record.requiredContentFields,
+    requiredMedia: record.requiredMedia,
+    responsiveBehavior: record.proposedResponsiveBehavior,
+    ctaBehavior: record.proposedCtaBehavior,
+    similarSections: record.similarExistingSections,
+    insufficiencyReason: record.existingApprovedVariantInsufficiency,
+    priority: record.implementationPriority,
+    sectionType: record.sectionType,
+    wireframes: record.wireframes,
+    openQuestions: record.openDesignQuestions,
+    comments: record.comments,
+    registryTask: record.registryTask,
+    modelUsage: record.modelUsage,
+  };
+}, NormalizedDesignGapRecordSchema);
+
+export type DesignGapRecord = z.infer<typeof DesignGapRecordSchema>;
+export type DesignRegistryTask = z.infer<typeof DesignRegistryTaskSchema>;
 
 export const DesignProposalScoringSchema = z
   .object({
@@ -24,27 +148,34 @@ export const DesignProposalScoringSchema = z
   })
   .strict();
 
+const ProposalStatusSchema = z.preprocess(
+  value => (value === 'pending' ? 'proposed' : value),
+  z.enum(DESIGN_PROPOSAL_STATUSES)
+);
+
 export const DesignProposalSchema = z
   .object({
-    id: z.string().trim().min(1).max(120),
-    surfaceId: z.string().trim().min(1).max(80),
-    surfaceName: z.string().trim().min(1).max(120),
-    proposalText: z.string().trim().min(1).max(8000),
-    assetRefs: z.array(z.string().trim().min(1).max(500)).max(20),
+    id: NonEmptyText.max(120),
+    kind: z.enum(DESIGN_PROPOSAL_KINDS).optional().default('surface'),
+    surfaceId: NonEmptyText.max(80),
+    surfaceName: NonEmptyText.max(120),
+    proposalText: NonEmptyText.max(8000),
+    assetRefs: StringList.max(20),
     scoring: DesignProposalScoringSchema.nullable(),
-    linearIssueId: z.string().trim().min(1).max(40),
+    linearIssueId: NonEmptyText.max(40),
     linearIssueUrl: z.union([z.string().url(), z.null()]),
-    status: z.enum(DESIGN_PROPOSAL_STATUSES),
+    status: ProposalStatusSchema,
+    designGap: DesignGapRecordSchema.nullable().optional().default(null),
     createdAt: z.string().datetime(),
     reviewedAt: z.union([z.string().datetime(), z.null()]),
-    reviewer: z.union([z.string().trim().min(1).max(160), z.null()]),
+    reviewer: z.union([NonEmptyText.max(160), z.null()]),
     reviewNotes: z.union([z.string().trim().max(4000), z.null()]),
     reviewDecision: z
       .union([z.enum(DESIGN_PROPOSAL_REVIEW_DECISIONS), z.null()])
       .optional()
       .transform(value => value ?? null),
     dispatchId: z
-      .union([z.string().trim().min(1).max(80), z.null()])
+      .union([NonEmptyText.max(80), z.null()])
       .optional()
       .transform(value => value ?? null),
     dayBucket: z
@@ -53,7 +184,27 @@ export const DesignProposalSchema = z
       .optional()
       .transform(value => value ?? null),
   })
-  .strict();
+  .strict()
+  .superRefine((proposal, context) => {
+    if (proposal.kind === 'section-gap' && !proposal.designGap) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Section-gap proposals require a designGap record.',
+        path: ['designGap'],
+      });
+    }
+    if (proposal.status === 'implemented') {
+      const task = proposal.designGap?.registryTask;
+      if (!task?.implementedAt || task.evidenceRefs.length === 0) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'Implemented proposals require registry implementation evidence.',
+          path: ['designGap', 'registryTask'],
+        });
+      }
+    }
+  });
 
 export type DesignProposal = z.infer<typeof DesignProposalSchema>;
 
@@ -65,21 +216,13 @@ export const DesignProposalReviewRequestSchema = z
   })
   .strict()
   .superRefine((input, context) => {
-    if (input.decision === 'yes-with-notes') {
-      const notes = input.notes?.trim() ?? '';
-      if (notes.length === 0) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'Notes are required for yes-with-notes decisions.',
-          path: ['notes'],
-        });
-      }
-    }
-
-    if (input.decision === 'no' && (input.notes?.trim().length ?? 0) === 0) {
+    if (
+      (input.decision === 'yes-with-notes' || input.decision === 'no') &&
+      (input.notes?.trim().length ?? 0) === 0
+    ) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Rejection direction notes are required for no decisions.',
+        message: 'Notes are required for this decision.',
         path: ['notes'],
       });
     }
@@ -112,6 +255,7 @@ export interface DesignLabDispatchPayload {
   readonly tasteMemoryExcerpt: string;
   readonly requestedAt: string;
   readonly requestedBy: string;
+  readonly registryTask: DesignRegistryTask;
 }
 
 export interface ReviewDesignProposalResult {

--- a/apps/web/tests/unit/agent-os/design-lab/proposals.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/proposals.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  appendDesignProposalComment,
+  matchesDesignProposalFilters,
+  parseCompactFeedback,
+  parseProposalRecord,
+} from '@/lib/agent-os/design-lab/proposals';
+
+vi.mock('server-only', () => ({}));
+
+describe('proposal compatibility and feedback', () => {
+  it('parses compact proposed-section feedback', () => {
+    expect(
+      parseCompactFeedback('PROPOSED-SECTION-0042: Make the CTA quieter')
+    ).toEqual({
+      reviewId: 'PROPOSED-SECTION-0042',
+      body: 'Make the CTA quieter',
+    });
+    expect(parseCompactFeedback('section 42: nope')).toBeNull();
+  });
+
+  it('parses legacy pending records as proposed', () => {
+    const result = parseProposalRecord(
+      {
+        id: 'legacy',
+        surfaceId: 'home',
+        surfaceName: 'Home',
+        proposalText: 'Proposal',
+        assetRefs: [],
+        scoring: null,
+        linearIssueId: 'JOV-1',
+        linearIssueUrl: null,
+        status: 'pending',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        reviewedAt: null,
+        reviewer: null,
+        reviewNotes: null,
+      },
+      '2026-06-08'
+    );
+    expect(result?.status).toBe('proposed');
+  });
+
+  it('refuses comments on proposals without design-gap records', () => {
+    const proposal = parseProposalRecord(
+      {
+        id: 'surface',
+        surfaceId: 'home',
+        surfaceName: 'Home',
+        proposalText: 'Proposal',
+        assetRefs: [],
+        scoring: null,
+        linearIssueId: 'JOV-1',
+        linearIssueUrl: null,
+        status: 'proposed',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        reviewedAt: null,
+        reviewer: null,
+        reviewNotes: null,
+      },
+      '2026-06-08'
+    );
+    expect(() =>
+      appendDesignProposalComment(proposal!, {
+        author: 'reviewer',
+        body: 'Feedback',
+        date: '2026-06-08',
+      })
+    ).toThrow('does not have a design-gap record');
+    expect(
+      matchesDesignProposalFilters(proposal!, { statuses: ['approved'] })
+    ).toBe(false);
+    expect(
+      matchesDesignProposalFilters(proposal!, {
+        statuses: ['proposed'],
+        kinds: ['surface'],
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/agent-os/design-lab/types.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/types.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { DesignProposalReviewRequestSchema } from '@/lib/agent-os/design-lab/types';
+import { PROPOSED_SECTIONS } from '@/data/marketing';
+import {
+  DesignGapRecordSchema,
+  DesignProposalReviewRequestSchema,
+  DesignProposalSchema,
+} from '@/lib/agent-os/design-lab/types';
 
 describe('DesignProposalReviewRequestSchema', () => {
   it('accepts yes without notes', () => {
@@ -37,5 +42,53 @@ describe('DesignProposalReviewRequestSchema', () => {
     });
 
     expect(parsed.success).toBe(true);
+  });
+});
+
+describe('DesignProposalSchema', () => {
+  const legacy = {
+    id: 'legacy',
+    surfaceId: 'home',
+    surfaceName: 'Home',
+    proposalText: 'Legacy proposal',
+    assetRefs: [],
+    scoring: null,
+    linearIssueId: 'JOV-1',
+    linearIssueUrl: null,
+    status: 'pending',
+    createdAt: '2026-06-08T12:00:00.000Z',
+    reviewedAt: null,
+    reviewer: null,
+    reviewNotes: null,
+  };
+
+  it('normalizes legacy pending surface records to proposed', () => {
+    const parsed = DesignProposalSchema.parse(legacy);
+    expect(parsed.status).toBe('proposed');
+    expect(parsed.kind).toBe('surface');
+    expect(parsed.designGap).toBeNull();
+  });
+
+  it('requires a design-gap record for section-gap proposals', () => {
+    expect(
+      DesignProposalSchema.safeParse({ ...legacy, kind: 'section-gap' }).success
+    ).toBe(false);
+  });
+
+  it('rejects implemented status without registry evidence', () => {
+    expect(
+      DesignProposalSchema.safeParse({ ...legacy, status: 'implemented' })
+        .success
+    ).toBe(false);
+  });
+});
+
+describe('DesignGapRecordSchema', () => {
+  it('consumes the canonical marketing design-gap catalog shape', () => {
+    const parsed = DesignGapRecordSchema.parse(PROPOSED_SECTIONS[0]);
+    expect(parsed.reviewId).toBe('PROPOSED-SECTION-0001');
+    expect(parsed.proposedName).toBeTruthy();
+    expect(parsed.wireframes.desktop.placeholderContent).toBe('grayscale-only');
+    expect(parsed.registryTask?.trigger).toBe('after-approved');
   });
 });


### PR DESCRIPTION
## Summary\n- extend Design Lab contracts with section-gap records and lifecycle states\n- preserve legacy pending-record compatibility\n- add proposal parsing and filtering tests\n\n## Verification\n- Design Lab contract and proposal unit tests\n- TypeScript typecheck\n\n## Stack\nPart 3 of the governed proposed-section workflow.