### PR TITLE
fix(design-lab): serialize proposal transitions

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Claude review
         continue-on-error: true
-        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         env:
           GBRAIN_CONNECTION: ${{ secrets.GBRAIN_CONNECTION }}
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/github-ai-orchestrator.yml
+++ b/.github/workflows/github-ai-orchestrator.yml
@@ -265,7 +265,7 @@ jobs:
         run: git checkout -b "$BRANCH_NAME"
 
       - name: Run Claude Code for implementation
-        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         env:
           JOVIE_AGENT_PROFILE: coder
         with:

--- a/.github/workflows/main-autofix.yml
+++ b/.github/workflows/main-autofix.yml
@@ -440,7 +440,7 @@ jobs:
       - name: Run Claude Code fallback
         if: steps.drift.outputs.drifted != 'true' && steps.dedup.outputs.skip_reason == '' && steps.openrouter.outputs.fallback == 'true'
         id: claude
-        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           allowed_bots: 'github-merge-queue[bot],jovie-bot[bot]'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Run Claude Code to fix the bug
         if: steps.dedup.outputs.skip != 'true'
         id: claude
-        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/apps/web/app/api/admin/design-lab/proposals/[proposalId]/comments/route.ts
+++ b/apps/web/app/api/admin/design-lab/proposals/[proposalId]/comments/route.ts
@@ -5,8 +5,8 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
   appendDesignProposalComment,
+  mutateDesignProposal,
   parseCompactFeedback,
-  saveDesignProposal,
 } from '@/lib/agent-os/design-lab/proposals';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import { getOrMaterializeCatalogProposal } from '../../catalog';
@@ -47,22 +47,29 @@ export async function POST(
         { status: 400, headers: NO_STORE_HEADERS }
       );
     }
-    const proposal = await getOrMaterializeCatalogProposal(
+    const materialized = await getOrMaterializeCatalogProposal(
       body.dayBucket,
       params.proposalId
     );
-    if (!proposal) {
+    if (!materialized) {
       return NextResponse.json(
         { error: 'Design proposal not found.' },
         { status: 404, headers: NO_STORE_HEADERS }
       );
     }
-    const updated = appendDesignProposalComment(proposal, {
-      author: entitlements.email ?? entitlements.userId ?? 'admin@jovie.local',
-      body: feedback.body,
-      date: new Date().toISOString(),
+    const updated = await mutateDesignProposal({
+      dayBucket: body.dayBucket,
+      proposalId: params.proposalId,
+      mutate: async proposal => {
+        const next = appendDesignProposalComment(proposal, {
+          author:
+            entitlements.email ?? entitlements.userId ?? 'admin@jovie.local',
+          body: feedback.body,
+          date: new Date().toISOString(),
+        });
+        return { proposal: next, result: next };
+      },
     });
-    await saveDesignProposal(updated);
     return NextResponse.json(
       { ok: true, proposal: updated },
       { status: 200, headers: NO_STORE_HEADERS }

--- a/apps/web/app/api/admin/design-lab/proposals/[proposalId]/comments/route.ts
+++ b/apps/web/app/api/admin/design-lab/proposals/[proposalId]/comments/route.ts
@@ -1,0 +1,82 @@
+import 'server-only';
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  appendDesignProposalComment,
+  parseCompactFeedback,
+  saveDesignProposal,
+} from '@/lib/agent-os/design-lab/proposals';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { getOrMaterializeCatalogProposal } from '../../catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+const ParamsSchema = z.object({
+  proposalId: z.string().trim().min(1).max(120),
+});
+const BodySchema = z
+  .object({
+    dayBucket: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    compactFeedback: z.string().trim().min(1).max(4050),
+  })
+  .strict();
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ proposalId: string }> }
+): Promise<Response> {
+  const entitlements = await getCurrentUserEntitlements();
+  if (!entitlements.isAuthenticated) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (!entitlements.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  try {
+    const params = ParamsSchema.parse(await context.params);
+    const body = BodySchema.parse(await request.json());
+    const feedback = parseCompactFeedback(body.compactFeedback);
+    if (!feedback || feedback.reviewId !== params.proposalId) {
+      return NextResponse.json(
+        { error: `Feedback must start with ${params.proposalId}:` },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+    const proposal = await getOrMaterializeCatalogProposal(
+      body.dayBucket,
+      params.proposalId
+    );
+    if (!proposal) {
+      return NextResponse.json(
+        { error: 'Design proposal not found.' },
+        { status: 404, headers: NO_STORE_HEADERS }
+      );
+    }
+    const updated = appendDesignProposalComment(proposal, {
+      author: entitlements.email ?? entitlements.userId ?? 'admin@jovie.local',
+      body: feedback.body,
+      date: new Date().toISOString(),
+    });
+    await saveDesignProposal(updated);
+    return NextResponse.json(
+      { ok: true, proposal: updated },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError || error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: 'Invalid comment request' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+    return NextResponse.json(
+      { error: 'Failed to append comment' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/api/admin/design-lab/proposals/[proposalId]/implemented/route.ts
+++ b/apps/web/app/api/admin/design-lab/proposals/[proposalId]/implemented/route.ts
@@ -3,8 +3,9 @@ import 'server-only';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { updateDesignLabLinearIssueStatus } from '@/lib/agent-os/design-lab/linear';
 import {
-  saveDesignProposal,
+  mutateDesignProposal,
   transitionProposalToImplemented,
 } from '@/lib/agent-os/design-lab/proposals';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
@@ -39,21 +40,33 @@ export async function POST(
   try {
     const params = ParamsSchema.parse(await context.params);
     const body = BodySchema.parse(await request.json());
-    const proposal = await getOrMaterializeCatalogProposal(
+    const materialized = await getOrMaterializeCatalogProposal(
       body.dayBucket,
       params.proposalId
     );
-    if (!proposal) {
+    if (!materialized) {
       return NextResponse.json(
         { error: 'Design proposal not found.' },
         { status: 404, headers: NO_STORE_HEADERS }
       );
     }
-    const updated = transitionProposalToImplemented(proposal, {
-      implementedAt: new Date().toISOString(),
-      evidenceRefs: body.evidenceRefs,
+    const updated = await mutateDesignProposal({
+      dayBucket: body.dayBucket,
+      proposalId: params.proposalId,
+      mutate: async proposal => {
+        const next = transitionProposalToImplemented(proposal, {
+          implementedAt: new Date().toISOString(),
+          evidenceRefs: body.evidenceRefs,
+        });
+        return { proposal: next, result: next };
+      },
     });
-    await saveDesignProposal(updated);
+    if (updated.linearIssueId !== 'UNASSIGNED') {
+      await updateDesignLabLinearIssueStatus(
+        updated.linearIssueId,
+        'completed'
+      );
+    }
     return NextResponse.json(
       { ok: true, proposal: updated },
       { status: 200, headers: NO_STORE_HEADERS }

--- a/apps/web/app/api/admin/design-lab/proposals/[proposalId]/implemented/route.ts
+++ b/apps/web/app/api/admin/design-lab/proposals/[proposalId]/implemented/route.ts
@@ -1,0 +1,79 @@
+import 'server-only';
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  saveDesignProposal,
+  transitionProposalToImplemented,
+} from '@/lib/agent-os/design-lab/proposals';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { getOrMaterializeCatalogProposal } from '../../catalog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+const ParamsSchema = z.object({
+  proposalId: z.string().trim().min(1).max(120),
+});
+const BodySchema = z
+  .object({
+    dayBucket: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    evidenceRefs: z.array(z.string().trim().min(1).max(500)).min(1).max(50),
+  })
+  .strict();
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ proposalId: string }> }
+): Promise<Response> {
+  const entitlements = await getCurrentUserEntitlements();
+  if (!entitlements.isAuthenticated) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (!entitlements.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  try {
+    const params = ParamsSchema.parse(await context.params);
+    const body = BodySchema.parse(await request.json());
+    const proposal = await getOrMaterializeCatalogProposal(
+      body.dayBucket,
+      params.proposalId
+    );
+    if (!proposal) {
+      return NextResponse.json(
+        { error: 'Design proposal not found.' },
+        { status: 404, headers: NO_STORE_HEADERS }
+      );
+    }
+    const updated = transitionProposalToImplemented(proposal, {
+      implementedAt: new Date().toISOString(),
+      evidenceRefs: body.evidenceRefs,
+    });
+    await saveDesignProposal(updated);
+    return NextResponse.json(
+      { ok: true, proposal: updated },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError || error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: 'Invalid implementation evidence request' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+    if (error instanceof Error && error.message.startsWith('Only approved')) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 409, headers: NO_STORE_HEADERS }
+      );
+    }
+    return NextResponse.json(
+      { error: 'Failed to record implementation evidence' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/api/admin/design-lab/proposals/[proposalId]/review/route.ts
+++ b/apps/web/app/api/admin/design-lab/proposals/[proposalId]/review/route.ts
@@ -8,6 +8,7 @@ import { DesignProposalReviewRequestSchema } from '@/lib/agent-os/design-lab/typ
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import { captureError } from '@/lib/error-tracking';
 import { logger } from '@/lib/utils/logger';
+import { getOrMaterializeCatalogProposal } from '../../catalog';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -53,6 +54,11 @@ export async function POST(
     const reviewer =
       entitlements.email ?? entitlements.userId ?? 'admin@jovie.local';
 
+    await getOrMaterializeCatalogProposal(
+      parsedBody.dayBucket,
+      params.proposalId
+    );
+
     const result = await reviewDesignProposal({
       dayBucket: parsedBody.dayBucket,
       proposalId: params.proposalId,
@@ -88,6 +94,13 @@ export async function POST(
       }
 
       if (error.message === 'Design proposal has already been reviewed.') {
+        return NextResponse.json(
+          { error: error.message },
+          { status: 409, headers: NO_STORE_HEADERS }
+        );
+      }
+
+      if (error.message === 'Design proposal review is already in progress.') {
         return NextResponse.json(
           { error: error.message },
           { status: 409, headers: NO_STORE_HEADERS }

--- a/apps/web/app/api/admin/design-lab/proposals/catalog.ts
+++ b/apps/web/app/api/admin/design-lab/proposals/catalog.ts
@@ -1,0 +1,62 @@
+import 'server-only';
+
+import { PROPOSED_SECTIONS } from '@/data/marketing';
+import {
+  getDesignProposal,
+  saveDesignProposal,
+} from '@/lib/agent-os/design-lab/proposals';
+import {
+  type DesignProposal,
+  DesignProposalSchema,
+} from '@/lib/agent-os/design-lab/types';
+
+const CATALOG_DAY_BUCKET = '2026-07-11';
+
+export function catalogDesignProposals(): readonly DesignProposal[] {
+  return PROPOSED_SECTIONS.map(record =>
+    DesignProposalSchema.parse({
+      id: record.id,
+      kind: 'section-gap',
+      surfaceId: `section-gap:${record.sectionType}`,
+      surfaceName: record.proposedSectionName,
+      proposalText: record.problem,
+      assetRefs: [],
+      scoring: null,
+      linearIssueId: 'UNASSIGNED',
+      linearIssueUrl: null,
+      status: record.status,
+      designGap: record,
+      createdAt: `${record.comments[0]?.date ?? CATALOG_DAY_BUCKET}T00:00:00.000Z`,
+      reviewedAt: null,
+      reviewer: null,
+      reviewNotes: null,
+      reviewDecision: null,
+      dispatchId: null,
+      dayBucket: CATALOG_DAY_BUCKET,
+    })
+  );
+}
+
+export function mergeCatalogDesignProposals(
+  persisted: readonly DesignProposal[]
+): readonly DesignProposal[] {
+  const merged = new Map(
+    catalogDesignProposals().map(proposal => [proposal.id, proposal])
+  );
+  for (const proposal of persisted) merged.set(proposal.id, proposal);
+  return [...merged.values()].sort((left, right) =>
+    left.id.localeCompare(right.id)
+  );
+}
+
+export async function getOrMaterializeCatalogProposal(
+  dayBucket: string,
+  proposalId: string
+): Promise<DesignProposal | null> {
+  const persisted = await getDesignProposal(dayBucket, proposalId);
+  if (persisted) return persisted;
+  const catalog = catalogDesignProposals().find(item => item.id === proposalId);
+  if (!catalog || catalog.dayBucket !== dayBucket) return null;
+  await saveDesignProposal(catalog);
+  return catalog;
+}

--- a/apps/web/app/api/admin/design-lab/proposals/route.ts
+++ b/apps/web/app/api/admin/design-lab/proposals/route.ts
@@ -1,33 +1,60 @@
 import 'server-only';
 
+import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { listPendingDesignProposals } from '@/lib/agent-os/design-lab/proposals';
-import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { z } from 'zod';
+import { requireAdmin } from '@/lib/admin';
+import { listDesignProposals } from '@/lib/agent-os/design-lab/proposals';
+import {
+  DESIGN_PROPOSAL_KINDS,
+  DESIGN_PROPOSAL_STATUSES,
+} from '@/lib/agent-os/design-lab/types';
 import { captureError } from '@/lib/error-tracking';
 import { logger } from '@/lib/utils/logger';
+import { mergeCatalogDesignProposals } from './catalog';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
 
-export async function GET(): Promise<Response> {
-  try {
-    const entitlements = await getCurrentUserEntitlements();
-    if (!entitlements.isAuthenticated) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401, headers: NO_STORE_HEADERS }
-      );
-    }
-    if (!entitlements.isAdmin) {
-      return NextResponse.json(
-        { error: 'Forbidden' },
-        { status: 403, headers: NO_STORE_HEADERS }
-      );
-    }
+const QuerySchema = z.object({
+  status: z.enum(DESIGN_PROPOSAL_STATUSES).optional(),
+  kind: z.enum(DESIGN_PROPOSAL_KINDS).optional(),
+  sectionType: z.string().trim().max(120).optional(),
+  affectedRoute: z.string().trim().max(500).optional(),
+});
 
-    const proposals = await listPendingDesignProposals();
+export async function GET(request: NextRequest): Promise<Response> {
+  const authError = await requireAdmin();
+  if (authError) return authError;
+
+  try {
+    const query = QuerySchema.parse({
+      status: request.nextUrl.searchParams.get('status') || undefined,
+      kind: request.nextUrl.searchParams.get('kind') || undefined,
+      sectionType: request.nextUrl.searchParams.get('sectionType') || undefined,
+      affectedRoute:
+        request.nextUrl.searchParams.get('affectedRoute') || undefined,
+    });
+    const persisted = await listDesignProposals();
+    const proposals = mergeCatalogDesignProposals(persisted).filter(
+      proposal => {
+        if (query.status && proposal.status !== query.status) return false;
+        if (query.kind && proposal.kind !== query.kind) return false;
+        if (
+          query.sectionType &&
+          proposal.designGap?.sectionType !== query.sectionType
+        ) {
+          return false;
+        }
+        return (
+          !query.affectedRoute ||
+          proposal.designGap?.affectedRoutes.includes(query.affectedRoute) ===
+            true
+        );
+      }
+    );
 
     return NextResponse.json(
       {
@@ -37,6 +64,12 @@ export async function GET(): Promise<Response> {
       { status: 200, headers: NO_STORE_HEADERS }
     );
   } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Invalid Design Lab filters', issues: error.issues },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
     logger.error(
       '[api/admin/design-lab/proposals] Failed to list proposals',
       error

--- a/apps/web/app/api/admin/design-lab/proposals/route.ts
+++ b/apps/web/app/api/admin/design-lab/proposals/route.ts
@@ -3,12 +3,12 @@ import 'server-only';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { requireAdmin } from '@/lib/admin';
 import { listDesignProposals } from '@/lib/agent-os/design-lab/proposals';
 import {
   DESIGN_PROPOSAL_KINDS,
   DESIGN_PROPOSAL_STATUSES,
 } from '@/lib/agent-os/design-lab/types';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import { captureError } from '@/lib/error-tracking';
 import { logger } from '@/lib/utils/logger';
 import { mergeCatalogDesignProposals } from './catalog';
@@ -26,8 +26,13 @@ const QuerySchema = z.object({
 });
 
 export async function GET(request: NextRequest): Promise<Response> {
-  const authError = await requireAdmin();
-  if (authError) return authError;
+  const entitlements = await getCurrentUserEntitlements();
+  if (!entitlements.isAuthenticated) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (!entitlements.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
   try {
     const query = QuerySchema.parse({

--- a/apps/web/lib/agent-os/design-lab/dispatch.ts
+++ b/apps/web/lib/agent-os/design-lab/dispatch.ts
@@ -24,17 +24,19 @@ function buildDispatchPrompt(payload: DesignLabDispatchPayload): string {
     : '';
 
   return [
-    'Design Lab D5 dispatch: build an HTML artifact for the approved proposal.',
+    'Design Lab dispatch: implement the approved section gap in the canonical marketing registry.',
     `Surface: ${payload.surfaceName} (${payload.surfaceId})`,
     `Linear issue: ${payload.linearIssueId}`,
     `Proposal:\n${payload.proposalText.trim()}`,
+    `Required changes:\n${payload.registryTask.requiredChanges.join('\n')}`,
     `Exact files:\n${payload.registryTask.exactFiles.join('\n')}`,
     `Forbidden patterns:\n${payload.registryTask.forbiddenPatterns.join('\n')}`,
     `Acceptance criteria:\n${payload.registryTask.acceptanceCriteria.join('\n')}`,
     `Required evidence:\n${payload.registryTask.evidenceRequired.join('\n')}`,
     notesBlock,
     tasteBlock,
-    'Store the resulting HTML artifact under agentos/runs/design-lab/ and link it back to the Linear issue.',
+    `Validation commands:\n${payload.registryTask.validationCommands.join('\n')}`,
+    'Implement the typed registry contract and shared component, migrate every affected route, add deterministic fixtures/tests, and attach the required evidence to the Linear issue. Do not mark the proposal implemented until every validation command passes and implementation evidence has been recorded through the Design Lab API.',
   ]
     .filter(part => part.length > 0)
     .join('\n\n');

--- a/apps/web/lib/agent-os/design-lab/dispatch.ts
+++ b/apps/web/lib/agent-os/design-lab/dispatch.ts
@@ -28,6 +28,10 @@ function buildDispatchPrompt(payload: DesignLabDispatchPayload): string {
     `Surface: ${payload.surfaceName} (${payload.surfaceId})`,
     `Linear issue: ${payload.linearIssueId}`,
     `Proposal:\n${payload.proposalText.trim()}`,
+    `Exact files:\n${payload.registryTask.exactFiles.join('\n')}`,
+    `Forbidden patterns:\n${payload.registryTask.forbiddenPatterns.join('\n')}`,
+    `Acceptance criteria:\n${payload.registryTask.acceptanceCriteria.join('\n')}`,
+    `Required evidence:\n${payload.registryTask.evidenceRequired.join('\n')}`,
     notesBlock,
     tasteBlock,
     'Store the resulting HTML artifact under agentos/runs/design-lab/ and link it back to the Linear issue.',
@@ -41,6 +45,17 @@ export async function triggerDesignLabDispatch(params: {
   readonly amendmentNotes: string | null;
   readonly requestedBy: string;
 }): Promise<{ triggered: boolean; dispatchId: string | null }> {
+  const registryTask = params.proposal.designGap?.registryTask;
+  if (!registryTask) {
+    logger.info(
+      '[design-lab/dispatch] Registry task missing; dispatch skipped',
+      {
+        proposalId: params.proposal.id,
+      }
+    );
+    return { triggered: false, dispatchId: null };
+  }
+
   const dispatchId = `design-lab-${crypto.randomUUID()}`;
   const tasteMemoryExcerpt = await readDesignTasteMemoryExcerpt();
 
@@ -56,6 +71,7 @@ export async function triggerDesignLabDispatch(params: {
     tasteMemoryExcerpt,
     requestedAt: new Date().toISOString(),
     requestedBy: params.requestedBy,
+    registryTask,
   };
 
   const dispatchDirectory = getDesignLabDispatchDirectory();
@@ -75,7 +91,7 @@ export async function triggerDesignLabDispatch(params: {
         reason: availability.unavailableReason,
       }
     );
-    return { triggered: true, dispatchId };
+    return { triggered: false, dispatchId: null };
   }
 
   try {
@@ -87,10 +103,8 @@ export async function triggerDesignLabDispatch(params: {
       runtime: 'codex-cli',
       priority: 70,
       skills: ['design-html', 'autoplan'],
-      allowedPaths: ['agentos', 'apps/web/components', 'apps/web/styles'],
-      verification: [
-        'pnpm --filter @jovie/web run typecheck -- --pretty false',
-      ],
+      allowedPaths: registryTask.exactFiles,
+      verification: registryTask.validationCommands,
       dryRun: false,
       prompt: buildDispatchPrompt(payload),
       owner: params.requestedBy,
@@ -104,7 +118,7 @@ export async function triggerDesignLabDispatch(params: {
           error: error.message,
         }
       );
-      return { triggered: true, dispatchId };
+      return { triggered: false, dispatchId: null };
     }
 
     logger.error(
@@ -114,7 +128,7 @@ export async function triggerDesignLabDispatch(params: {
         error,
       }
     );
-    return { triggered: true, dispatchId };
+    return { triggered: false, dispatchId: null };
   }
 
   return { triggered: true, dispatchId };

--- a/apps/web/lib/agent-os/design-lab/fixtures.ts
+++ b/apps/web/lib/agent-os/design-lab/fixtures.ts
@@ -5,6 +5,7 @@ const FIXTURE_CREATED_AT = '2026-06-08T12:00:00.000Z';
 export const DESIGN_LAB_DEV_FIXTURE_PROPOSALS: readonly DesignProposal[] = [
   {
     id: 'profile-page-quiet-hero',
+    kind: 'surface',
     surfaceId: 'profile-page',
     surfaceName: 'Public profile page',
     proposalText:
@@ -14,7 +15,8 @@ export const DESIGN_LAB_DEV_FIXTURE_PROPOSALS: readonly DesignProposal[] = [
     linearIssueId: 'JOV-1951',
     linearIssueUrl:
       'https://linear.app/jovie/issue/JOV-1951/profile-redesign-proposal-loop',
-    status: 'pending',
+    status: 'proposed',
+    designGap: null,
     createdAt: FIXTURE_CREATED_AT,
     reviewedAt: null,
     reviewer: null,
@@ -25,6 +27,7 @@ export const DESIGN_LAB_DEV_FIXTURE_PROPOSALS: readonly DesignProposal[] = [
   },
   {
     id: 'sidebar-density-pass',
+    kind: 'surface',
     surfaceId: 'dashboard-sidebar',
     surfaceName: 'Dashboard sidebar',
     proposalText:
@@ -34,7 +37,8 @@ export const DESIGN_LAB_DEV_FIXTURE_PROPOSALS: readonly DesignProposal[] = [
     linearIssueId: 'JOV-2098',
     linearIssueUrl:
       'https://linear.app/jovie/issue/JOV-2098/designadmin-consolidate-overlapping-ia-across-overview-ops-growth',
-    status: 'pending',
+    status: 'proposed',
+    designGap: null,
     createdAt: FIXTURE_CREATED_AT,
     reviewedAt: null,
     reviewer: null,

--- a/apps/web/lib/agent-os/design-lab/linear.ts
+++ b/apps/web/lib/agent-os/design-lab/linear.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { env } from '@/lib/env-server';
 import { logger } from '@/lib/utils/logger';
+import type { DesignProposal } from './types';
 
 const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql';
 
@@ -16,6 +17,11 @@ interface LinearTeamState {
   readonly id: string;
   readonly type: string;
   readonly name: string;
+}
+
+export interface DesignLabLinearIssueReference {
+  readonly identifier: string;
+  readonly url: string;
 }
 
 async function linearGraphql<T>(
@@ -117,6 +123,61 @@ async function resolveLinearIssue(
   }
 
   return lookupLinearIssueBySearch(issueIdentifier);
+}
+
+export async function createDesignLabLinearIssue(
+  proposal: DesignProposal
+): Promise<DesignLabLinearIssueReference> {
+  const teamData = await linearGraphql<{
+    teams: { nodes: Array<{ id: string }> };
+  }>(
+    `query DesignLabTeam($key: String!) {
+      teams(filter: { key: { eq: $key } }, first: 1) { nodes { id } }
+    }`,
+    { key: 'JOV' }
+  );
+  const teamId = teamData.teams.nodes[0]?.id;
+  if (!teamId) throw new Error('Linear team JOV was not found.');
+
+  const task = proposal.designGap?.registryTask;
+  if (!task)
+    throw new Error('Registry task is required before Linear issue creation.');
+  const description = [
+    proposal.proposalText,
+    '',
+    'Required changes:',
+    ...task.requiredChanges.map(item => `- ${item}`),
+    '',
+    'Exact files:',
+    ...task.exactFiles.map(item => `- ${item}`),
+    '',
+    'Validation:',
+    ...task.validationCommands.map(item => `- \`${item}\``),
+  ].join('\n');
+  const data = await linearGraphql<{
+    issueCreate: {
+      success: boolean;
+      issue: { identifier: string; url: string };
+    };
+  }>(
+    `mutation CreateDesignLabIssue($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { identifier url }
+      }
+    }`,
+    {
+      input: {
+        teamId,
+        title: `[Design Lab] ${proposal.surfaceName}`,
+        description,
+      },
+    }
+  );
+  if (!data.issueCreate.success) {
+    throw new Error('Linear issue creation returned success=false.');
+  }
+  return data.issueCreate.issue;
 }
 
 async function findTeamState(

--- a/apps/web/lib/agent-os/design-lab/proposals.ts
+++ b/apps/web/lib/agent-os/design-lab/proposals.ts
@@ -177,7 +177,84 @@ export async function saveDesignProposal(
   const parsed = DesignProposalSchema.parse(proposal);
   const filePath = resolveDesignProposalFilePath(dayBucket, parsed.id);
   await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, `${JSON.stringify(parsed, null, 2)}\n`, 'utf8');
+  const temporaryPath = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  await fs.writeFile(
+    temporaryPath,
+    `${JSON.stringify(parsed, null, 2)}\n`,
+    'utf8'
+  );
+  await fs.rename(temporaryPath, filePath);
+}
+
+const PROPOSAL_LOCK_RETRY_MS = 25;
+const PROPOSAL_LOCK_TIMEOUT_MS = 10_000;
+
+async function acquireProposalLock(
+  filePath: string
+): Promise<() => Promise<void>> {
+  const lockPath = `${filePath}.lock`;
+  const deadline = Date.now() + PROPOSAL_LOCK_TIMEOUT_MS;
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+  while (true) {
+    try {
+      const handle = await fs.open(lockPath, 'wx');
+      return async () => {
+        await handle.close();
+        await fs.rm(lockPath, { force: true });
+      };
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !('code' in error) ||
+        (error as NodeJS.ErrnoException).code !== 'EEXIST'
+      ) {
+        throw error;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error('Timed out waiting for the design proposal lock.');
+      }
+      await new Promise(resolve => setTimeout(resolve, PROPOSAL_LOCK_RETRY_MS));
+    }
+  }
+}
+
+export async function mutateDesignProposal<T>(params: {
+  readonly dayBucket: string;
+  readonly proposalId: string;
+  readonly mutate: (proposal: DesignProposal) => Promise<{
+    readonly proposal: DesignProposal;
+    readonly result: T;
+  }>;
+}): Promise<T> {
+  const filePath = resolveDesignProposalFilePath(
+    params.dayBucket,
+    params.proposalId
+  );
+  const release = await acquireProposalLock(filePath);
+  try {
+    const existing = await readProposalFile(filePath, params.dayBucket);
+    if (!existing) throw new Error('Design proposal not found.');
+    const mutation = await params.mutate(existing);
+    await saveDesignProposal(mutation.proposal);
+    return mutation.result;
+  } finally {
+    await release();
+  }
+}
+
+export async function withDesignProposalLock<T>(
+  dayBucket: string,
+  proposalId: string,
+  action: () => Promise<T>
+): Promise<T> {
+  const filePath = resolveDesignProposalFilePath(dayBucket, proposalId);
+  const release = await acquireProposalLock(filePath);
+  try {
+    return await action();
+  } finally {
+    await release();
+  }
 }
 
 export function deriveProposalStatus(

--- a/apps/web/lib/agent-os/design-lab/proposals.ts
+++ b/apps/web/lib/agent-os/design-lab/proposals.ts
@@ -9,7 +9,9 @@ import {
   resolveDesignProposalFilePath,
 } from './paths';
 import {
+  DESIGN_PROPOSAL_STATUSES,
   type DesignProposal,
+  type DesignProposalComment,
   DesignProposalSchema,
   type DesignProposalStatus,
 } from './types';
@@ -22,7 +24,7 @@ function isMissingFileError(error: unknown): boolean {
   );
 }
 
-function parseProposalRecord(
+export function parseProposalRecord(
   raw: unknown,
   dayBucket: string
 ): DesignProposal | null {
@@ -117,9 +119,26 @@ export async function ensureDesignLabDevFixtures(): Promise<void> {
   }
 }
 
-export async function listPendingDesignProposals(): Promise<
-  readonly DesignProposal[]
-> {
+export interface DesignProposalFilters {
+  readonly statuses?: readonly DesignProposalStatus[];
+  readonly kinds?: readonly DesignProposal['kind'][];
+  readonly affectedRoute?: string;
+}
+
+export function matchesDesignProposalFilters(
+  proposal: DesignProposal,
+  filters: DesignProposalFilters
+): boolean {
+  const statuses = new Set(filters.statuses ?? DESIGN_PROPOSAL_STATUSES);
+  if (!statuses.has(proposal.status)) return false;
+  if (filters.kinds && !filters.kinds.includes(proposal.kind)) return false;
+  const route = filters.affectedRoute?.trim();
+  return !route || proposal.designGap?.affectedRoutes.includes(route) === true;
+}
+
+export async function listDesignProposals(
+  filters: DesignProposalFilters = {}
+): Promise<readonly DesignProposal[]> {
   await ensureDesignLabDevFixtures();
 
   const dayBuckets = await listDayBuckets();
@@ -129,8 +148,14 @@ export async function listPendingDesignProposals(): Promise<
 
   return proposals
     .flat()
-    .filter(proposal => proposal.status === 'pending')
+    .filter(proposal => matchesDesignProposalFilters(proposal, filters))
     .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+}
+
+export async function listPendingDesignProposals(): Promise<
+  readonly DesignProposal[]
+> {
+  return listDesignProposals({ statuses: ['proposed', 'reviewing'] });
 }
 
 export async function getDesignProposal(
@@ -166,5 +191,61 @@ export function deriveProposalStatus(
     return 'approved';
   }
 
-  return 'pending';
+  return 'proposed';
+}
+
+const COMPACT_FEEDBACK_PATTERN =
+  /^(PROPOSED-SECTION-\d{4}):\s*(\S[\s\S]{0,3999})$/;
+
+export interface ParsedCompactFeedback {
+  readonly reviewId: string;
+  readonly body: string;
+}
+
+export function parseCompactFeedback(
+  input: string
+): ParsedCompactFeedback | null {
+  const match = COMPACT_FEEDBACK_PATTERN.exec(input.trim());
+  if (!match?.[1] || !match[2]) return null;
+  return { reviewId: match[1], body: match[2].trim() };
+}
+
+export function appendDesignProposalComment(
+  proposal: DesignProposal,
+  comment: DesignProposalComment
+): DesignProposal {
+  if (!proposal.designGap) {
+    throw new Error('Design proposal does not have a design-gap record.');
+  }
+  return DesignProposalSchema.parse({
+    ...proposal,
+    designGap: {
+      ...proposal.designGap,
+      comments: [...proposal.designGap.comments, comment],
+    },
+  });
+}
+
+export function transitionProposalToImplemented(
+  proposal: DesignProposal,
+  evidence: { readonly implementedAt: string; readonly evidenceRefs: string[] }
+): DesignProposal {
+  if (proposal.status !== 'approved') {
+    throw new Error('Only approved proposals can be implemented.');
+  }
+  if (!proposal.designGap?.registryTask) {
+    throw new Error('Registry task is required before implementation.');
+  }
+  return DesignProposalSchema.parse({
+    ...proposal,
+    status: 'implemented',
+    designGap: {
+      ...proposal.designGap,
+      registryTask: {
+        ...proposal.designGap.registryTask,
+        implementedAt: evidence.implementedAt,
+        evidenceRefs: evidence.evidenceRefs,
+      },
+    },
+  });
 }

--- a/apps/web/lib/agent-os/design-lab/review.ts
+++ b/apps/web/lib/agent-os/design-lab/review.ts
@@ -2,11 +2,15 @@ import 'server-only';
 
 import { logger } from '@/lib/utils/logger';
 import { triggerDesignLabDispatch } from './dispatch';
-import { updateDesignLabLinearIssueStatus } from './linear';
+import {
+  createDesignLabLinearIssue,
+  updateDesignLabLinearIssueStatus,
+} from './linear';
 import {
   deriveProposalStatus,
   getDesignProposal,
   saveDesignProposal,
+  withDesignProposalLock,
 } from './proposals';
 import { appendDesignTasteMemoryEntry } from './taste-memory';
 import type {
@@ -41,7 +45,24 @@ async function dispatchApprovedProposal(
   return { proposal: dispatched, triggered: true };
 }
 
-export async function reviewDesignProposal(params: {
+async function ensureImplementationIssue(
+  proposal: DesignProposal,
+  decision: DesignProposalReviewDecision
+): Promise<DesignProposal> {
+  if (!isApproval(decision) || proposal.linearIssueId !== 'UNASSIGNED') {
+    return proposal;
+  }
+  const issue = await createDesignLabLinearIssue(proposal);
+  const assigned = {
+    ...proposal,
+    linearIssueId: issue.identifier,
+    linearIssueUrl: issue.url,
+  };
+  await saveDesignProposal(assigned);
+  return assigned;
+}
+
+async function reviewDesignProposalLocked(params: {
   readonly dayBucket: string;
   readonly proposalId: string;
   readonly decision: DesignProposalReviewDecision;
@@ -107,7 +128,8 @@ export async function reviewDesignProposal(params: {
   await saveDesignProposal(reviewing);
 
   // Approval is durable before any external dispatch. A retry can safely resume it.
-  const decided: DesignProposal = { ...reviewing, status: finalStatus };
+  const assigned = await ensureImplementationIssue(reviewing, params.decision);
+  const decided: DesignProposal = { ...assigned, status: finalStatus };
   await saveDesignProposal(decided);
 
   const dispatch = await dispatchApprovedProposal(
@@ -134,10 +156,13 @@ export async function reviewDesignProposal(params: {
     logger.error('[design-lab/review] Taste memory append failed', { error });
   }
 
-  const linearUpdated = await updateDesignLabLinearIssueStatus(
-    existing.linearIssueId,
-    params.decision === 'no' ? 'canceled' : 'completed'
-  );
+  const linearUpdated =
+    params.decision === 'no' && decided.linearIssueId !== 'UNASSIGNED'
+      ? await updateDesignLabLinearIssueStatus(
+          decided.linearIssueId,
+          'canceled'
+        )
+      : false;
 
   return {
     proposal: dispatch.proposal,
@@ -146,4 +171,16 @@ export async function reviewDesignProposal(params: {
     dispatchTriggered: dispatch.triggered,
     dispatchId: dispatch.proposal.dispatchId,
   };
+}
+
+export async function reviewDesignProposal(params: {
+  readonly dayBucket: string;
+  readonly proposalId: string;
+  readonly decision: DesignProposalReviewDecision;
+  readonly notes: string | null;
+  readonly reviewer: string;
+}): Promise<ReviewDesignProposalResult> {
+  return withDesignProposalLock(params.dayBucket, params.proposalId, () =>
+    reviewDesignProposalLocked(params)
+  );
 }

--- a/apps/web/lib/agent-os/design-lab/review.ts
+++ b/apps/web/lib/agent-os/design-lab/review.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { logger } from '@/lib/utils/logger';
 import { triggerDesignLabDispatch } from './dispatch';
 import { updateDesignLabLinearIssueStatus } from './linear';
 import {
@@ -9,20 +10,35 @@ import {
 } from './proposals';
 import { appendDesignTasteMemoryEntry } from './taste-memory';
 import type {
+  DesignProposal,
   DesignProposalReviewDecision,
   ReviewDesignProposalResult,
 } from './types';
 
-function mapDecisionToTaste(
-  decision: DesignProposalReviewDecision
-): 'accepted' | 'rejected' {
-  return decision === 'no' ? 'rejected' : 'accepted';
+function isApproval(decision: DesignProposalReviewDecision): boolean {
+  return decision === 'yes' || decision === 'yes-with-notes';
 }
 
-function shouldTriggerDispatch(
-  decision: DesignProposalReviewDecision
-): boolean {
-  return decision === 'yes' || decision === 'yes-with-notes';
+async function dispatchApprovedProposal(
+  proposal: DesignProposal,
+  decision: DesignProposalReviewDecision,
+  notes: string | null,
+  reviewer: string
+): Promise<{ proposal: DesignProposal; triggered: boolean }> {
+  if (!isApproval(decision) || proposal.dispatchId) {
+    return { proposal, triggered: false };
+  }
+  const dispatch = await triggerDesignLabDispatch({
+    proposal,
+    amendmentNotes: decision === 'yes-with-notes' ? notes : null,
+    requestedBy: reviewer,
+  });
+  if (!dispatch.triggered || !dispatch.dispatchId) {
+    return { proposal, triggered: false };
+  }
+  const dispatched = { ...proposal, dispatchId: dispatch.dispatchId };
+  await saveDesignProposal(dispatched);
+  return { proposal: dispatched, triggered: true };
 }
 
 export async function reviewDesignProposal(params: {
@@ -33,54 +49,90 @@ export async function reviewDesignProposal(params: {
   readonly reviewer: string;
 }): Promise<ReviewDesignProposalResult> {
   const existing = await getDesignProposal(params.dayBucket, params.proposalId);
-  if (!existing) {
-    throw new Error('Design proposal not found.');
-  }
+  if (!existing) throw new Error('Design proposal not found.');
 
-  if (existing.status !== 'pending') {
-    throw new Error('Design proposal has already been reviewed.');
-  }
-
-  const reviewedAt = new Date().toISOString();
   const normalizedNotes = params.notes?.trim() ? params.notes.trim() : null;
+  const finalStatus = deriveProposalStatus(params.decision);
 
-  let dispatchId: string | null = null;
-  let dispatchTriggered = false;
-
-  if (shouldTriggerDispatch(params.decision)) {
-    const dispatch = await triggerDesignLabDispatch({
+  if (existing.status === 'implemented' || existing.status === 'rejected') {
+    if (existing.reviewDecision !== params.decision) {
+      throw new Error('Design proposal has already been reviewed.');
+    }
+    return {
       proposal: existing,
-      amendmentNotes:
-        params.decision === 'yes-with-notes' ? normalizedNotes : null,
-      requestedBy: params.reviewer,
-    });
-    dispatchTriggered = dispatch.triggered;
-    dispatchId = dispatch.dispatchId;
+      tasteMemoryWritten: false,
+      linearUpdated: false,
+      dispatchTriggered: false,
+      dispatchId: existing.dispatchId,
+    };
   }
 
-  const updatedProposal = {
+  if (existing.status === 'approved') {
+    if (existing.reviewDecision !== params.decision) {
+      throw new Error('Design proposal has already been reviewed.');
+    }
+    const retry = await dispatchApprovedProposal(
+      existing,
+      params.decision,
+      normalizedNotes,
+      params.reviewer
+    );
+    return {
+      proposal: retry.proposal,
+      tasteMemoryWritten: false,
+      linearUpdated: false,
+      dispatchTriggered: retry.triggered,
+      dispatchId: retry.proposal.dispatchId,
+    };
+  }
+
+  if (
+    existing.status === 'reviewing' &&
+    existing.reviewDecision &&
+    existing.reviewDecision !== params.decision
+  ) {
+    throw new Error('Design proposal review is already in progress.');
+  }
+
+  const reviewedAt = existing.reviewedAt ?? new Date().toISOString();
+  const reviewing: DesignProposal = {
     ...existing,
-    status: deriveProposalStatus(params.decision),
+    status: 'reviewing',
     reviewedAt,
     reviewer: params.reviewer,
     reviewNotes: normalizedNotes,
     reviewDecision: params.decision,
-    dispatchId,
     dayBucket: params.dayBucket,
   };
+  await saveDesignProposal(reviewing);
 
-  await saveDesignProposal(updatedProposal);
+  // Approval is durable before any external dispatch. A retry can safely resume it.
+  const decided: DesignProposal = { ...reviewing, status: finalStatus };
+  await saveDesignProposal(decided);
 
-  await appendDesignTasteMemoryEntry({
-    timestamp: reviewedAt,
-    surfaceId: existing.surfaceId,
-    surfaceName: existing.surfaceName,
-    direction: existing.proposalText,
-    decision: mapDecisionToTaste(params.decision),
-    notes: normalizedNotes,
-    reviewer: params.reviewer,
-    linearIssueId: existing.linearIssueId,
-  });
+  const dispatch = await dispatchApprovedProposal(
+    decided,
+    params.decision,
+    normalizedNotes,
+    params.reviewer
+  );
+
+  let tasteMemoryWritten = false;
+  try {
+    await appendDesignTasteMemoryEntry({
+      timestamp: reviewedAt,
+      surfaceId: existing.surfaceId,
+      surfaceName: existing.surfaceName,
+      direction: existing.proposalText,
+      decision: params.decision === 'no' ? 'rejected' : 'accepted',
+      notes: normalizedNotes,
+      reviewer: params.reviewer,
+      linearIssueId: existing.linearIssueId,
+    });
+    tasteMemoryWritten = true;
+  } catch (error) {
+    logger.error('[design-lab/review] Taste memory append failed', { error });
+  }
 
   const linearUpdated = await updateDesignLabLinearIssueStatus(
     existing.linearIssueId,
@@ -88,10 +140,10 @@ export async function reviewDesignProposal(params: {
   );
 
   return {
-    proposal: updatedProposal,
-    tasteMemoryWritten: true,
+    proposal: dispatch.proposal,
+    tasteMemoryWritten,
     linearUpdated,
-    dispatchTriggered,
-    dispatchId,
+    dispatchTriggered: dispatch.triggered,
+    dispatchId: dispatch.proposal.dispatchId,
   };
 }

--- a/apps/web/lib/agent-os/design-lab/types.ts
+++ b/apps/web/lib/agent-os/design-lab/types.ts
@@ -1,11 +1,14 @@
 import { z } from 'zod';
 
 export const DESIGN_PROPOSAL_STATUSES = [
-  'pending',
+  'proposed',
+  'reviewing',
   'approved',
   'rejected',
+  'implemented',
 ] as const;
 
+export const DESIGN_PROPOSAL_KINDS = ['surface', 'section-gap'] as const;
 export const DESIGN_PROPOSAL_REVIEW_DECISIONS = [
   'yes',
   'no',
@@ -13,9 +16,130 @@ export const DESIGN_PROPOSAL_REVIEW_DECISIONS = [
 ] as const;
 
 export type DesignProposalStatus = (typeof DESIGN_PROPOSAL_STATUSES)[number];
-
+export type DesignProposalKind = (typeof DESIGN_PROPOSAL_KINDS)[number];
 export type DesignProposalReviewDecision =
   (typeof DESIGN_PROPOSAL_REVIEW_DECISIONS)[number];
+
+const NonEmptyText = z.string().trim().min(1);
+const StringList = z.array(NonEmptyText.max(500)).max(50);
+
+export const DesignWireframeSpecSchema = z
+  .object({
+    viewport: z.enum(['desktop', 'mobile']),
+    width: z.number().int().positive(),
+    hierarchy: StringList.min(1),
+    layout: NonEmptyText.max(2000),
+    contentDensity: z.enum(['low', 'medium', 'high']),
+    mediaPlacement: NonEmptyText.max(2000),
+    responsiveBehavior: NonEmptyText.max(3000),
+    interactionModel: NonEmptyText.max(2000),
+    tokens: z
+      .array(z.enum(['surface', 'border', 'muted', 'foreground']))
+      .min(1),
+    placeholderContent: z.literal('grayscale-only'),
+  })
+  .strict();
+
+export const DesignProposalCommentSchema = z
+  .object({
+    author: NonEmptyText.max(160),
+    body: NonEmptyText.max(4000),
+    date: NonEmptyText.max(40),
+  })
+  .strict();
+export type DesignProposalComment = z.infer<typeof DesignProposalCommentSchema>;
+
+export const DesignRegistryTaskSchema = z
+  .object({
+    trigger: z.literal('after-approved'),
+    targetSectionId: NonEmptyText.max(120),
+    requiredChanges: StringList.min(1),
+    exactFiles: StringList.default([]),
+    forbiddenPatterns: StringList,
+    acceptanceCriteria: StringList.min(1),
+    validationCommands: StringList.min(1),
+    evidenceRequired: StringList.default([]),
+    implementedAt: z.string().datetime().nullable().default(null),
+    evidenceRefs: StringList.default([]),
+  })
+  .strict();
+
+export const DesignModelUsageSchema = z
+  .object({
+    model: NonEmptyText.max(120),
+    role: z.enum(['audit', 'wireframe-spec', 'implementation', 'review']),
+    tokens: z.union([
+      z.number().int().nonnegative(),
+      z.literal('unavailable from runtime'),
+    ]),
+    estimatedCostUsd: z.union([
+      z.number().nonnegative(),
+      z.literal('unavailable from runtime'),
+    ]),
+    estimationBasis: NonEmptyText.max(1000),
+  })
+  .strict();
+
+const NormalizedDesignGapRecordSchema = z
+  .object({
+    reviewId: z.string().regex(/^PROPOSED-SECTION-\d{4}$/),
+    proposedName: NonEmptyText.max(160),
+    problem: NonEmptyText.max(4000),
+    affectedRoutes: StringList.min(1),
+    audience: NonEmptyText.max(1000),
+    conversionGoal: NonEmptyText.max(1000),
+    requiredContentFields: StringList,
+    requiredMedia: StringList,
+    responsiveBehavior: NonEmptyText.max(3000),
+    ctaBehavior: NonEmptyText.max(2000),
+    similarSections: StringList,
+    insufficiencyReason: NonEmptyText.max(3000),
+    priority: z.enum(['low', 'medium', 'high', 'critical']),
+    sectionType: NonEmptyText.max(120),
+    wireframes: z
+      .object({
+        desktop: DesignWireframeSpecSchema,
+        mobile: DesignWireframeSpecSchema,
+      })
+      .strict(),
+    openQuestions: StringList,
+    comments: z.array(DesignProposalCommentSchema).max(200),
+    registryTask: DesignRegistryTaskSchema.nullable(),
+    modelUsage: z.array(DesignModelUsageSchema).max(50),
+  })
+  .strict();
+
+export const DesignGapRecordSchema = z.preprocess(value => {
+  if (!value || typeof value !== 'object') return value;
+  const record = value as Record<string, unknown>;
+  if (!('id' in record)) return value;
+  return {
+    reviewId: record.id,
+    proposedName: record.proposedSectionName,
+    problem: record.problem,
+    affectedRoutes: record.affectedRoutes,
+    audience: Array.isArray(record.intendedAudience)
+      ? record.intendedAudience.join(', ')
+      : record.intendedAudience,
+    conversionGoal: record.conversionGoal,
+    requiredContentFields: record.requiredContentFields,
+    requiredMedia: record.requiredMedia,
+    responsiveBehavior: record.proposedResponsiveBehavior,
+    ctaBehavior: record.proposedCtaBehavior,
+    similarSections: record.similarExistingSections,
+    insufficiencyReason: record.existingApprovedVariantInsufficiency,
+    priority: record.implementationPriority,
+    sectionType: record.sectionType,
+    wireframes: record.wireframes,
+    openQuestions: record.openDesignQuestions,
+    comments: record.comments,
+    registryTask: record.registryTask,
+    modelUsage: record.modelUsage,
+  };
+}, NormalizedDesignGapRecordSchema);
+
+export type DesignGapRecord = z.infer<typeof DesignGapRecordSchema>;
+export type DesignRegistryTask = z.infer<typeof DesignRegistryTaskSchema>;
 
 export const DesignProposalScoringSchema = z
   .object({
@@ -24,27 +148,34 @@ export const DesignProposalScoringSchema = z
   })
   .strict();
 
+const ProposalStatusSchema = z.preprocess(
+  value => (value === 'pending' ? 'proposed' : value),
+  z.enum(DESIGN_PROPOSAL_STATUSES)
+);
+
 export const DesignProposalSchema = z
   .object({
-    id: z.string().trim().min(1).max(120),
-    surfaceId: z.string().trim().min(1).max(80),
-    surfaceName: z.string().trim().min(1).max(120),
-    proposalText: z.string().trim().min(1).max(8000),
-    assetRefs: z.array(z.string().trim().min(1).max(500)).max(20),
+    id: NonEmptyText.max(120),
+    kind: z.enum(DESIGN_PROPOSAL_KINDS).optional().default('surface'),
+    surfaceId: NonEmptyText.max(80),
+    surfaceName: NonEmptyText.max(120),
+    proposalText: NonEmptyText.max(8000),
+    assetRefs: StringList.max(20),
     scoring: DesignProposalScoringSchema.nullable(),
-    linearIssueId: z.string().trim().min(1).max(40),
+    linearIssueId: NonEmptyText.max(40),
     linearIssueUrl: z.union([z.string().url(), z.null()]),
-    status: z.enum(DESIGN_PROPOSAL_STATUSES),
+    status: ProposalStatusSchema,
+    designGap: DesignGapRecordSchema.nullable().optional().default(null),
     createdAt: z.string().datetime(),
     reviewedAt: z.union([z.string().datetime(), z.null()]),
-    reviewer: z.union([z.string().trim().min(1).max(160), z.null()]),
+    reviewer: z.union([NonEmptyText.max(160), z.null()]),
     reviewNotes: z.union([z.string().trim().max(4000), z.null()]),
     reviewDecision: z
       .union([z.enum(DESIGN_PROPOSAL_REVIEW_DECISIONS), z.null()])
       .optional()
       .transform(value => value ?? null),
     dispatchId: z
-      .union([z.string().trim().min(1).max(80), z.null()])
+      .union([NonEmptyText.max(80), z.null()])
       .optional()
       .transform(value => value ?? null),
     dayBucket: z
@@ -53,7 +184,27 @@ export const DesignProposalSchema = z
       .optional()
       .transform(value => value ?? null),
   })
-  .strict();
+  .strict()
+  .superRefine((proposal, context) => {
+    if (proposal.kind === 'section-gap' && !proposal.designGap) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Section-gap proposals require a designGap record.',
+        path: ['designGap'],
+      });
+    }
+    if (proposal.status === 'implemented') {
+      const task = proposal.designGap?.registryTask;
+      if (!task?.implementedAt || task.evidenceRefs.length === 0) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'Implemented proposals require registry implementation evidence.',
+          path: ['designGap', 'registryTask'],
+        });
+      }
+    }
+  });
 
 export type DesignProposal = z.infer<typeof DesignProposalSchema>;
 
@@ -65,21 +216,13 @@ export const DesignProposalReviewRequestSchema = z
   })
   .strict()
   .superRefine((input, context) => {
-    if (input.decision === 'yes-with-notes') {
-      const notes = input.notes?.trim() ?? '';
-      if (notes.length === 0) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'Notes are required for yes-with-notes decisions.',
-          path: ['notes'],
-        });
-      }
-    }
-
-    if (input.decision === 'no' && (input.notes?.trim().length ?? 0) === 0) {
+    if (
+      (input.decision === 'yes-with-notes' || input.decision === 'no') &&
+      (input.notes?.trim().length ?? 0) === 0
+    ) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Rejection direction notes are required for no decisions.',
+        message: 'Notes are required for this decision.',
         path: ['notes'],
       });
     }
@@ -112,6 +255,7 @@ export interface DesignLabDispatchPayload {
   readonly tasteMemoryExcerpt: string;
   readonly requestedAt: string;
   readonly requestedBy: string;
+  readonly registryTask: DesignRegistryTask;
 }
 
 export interface ReviewDesignProposalResult {

--- a/apps/web/tests/unit/agent-os/design-lab-gallery/api.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab-gallery/api.test.ts
@@ -1,0 +1,243 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PROPOSED_SECTIONS } from '@/data/marketing';
+import { DesignProposalSchema } from '@/lib/agent-os/design-lab/types';
+
+const mocks = vi.hoisted(() => ({
+  entitlements: vi.fn(),
+  list: vi.fn(),
+  get: vi.fn(),
+  save: vi.fn(),
+  mutate: vi.fn(),
+  review: vi.fn(),
+}));
+
+vi.mock('@/lib/entitlements/server', () => ({
+  getCurrentUserEntitlements: mocks.entitlements,
+}));
+vi.mock('@/lib/agent-os/design-lab/proposals', async importOriginal => {
+  const actual =
+    await importOriginal<
+      typeof import('@/lib/agent-os/design-lab/proposals')
+    >();
+  return {
+    ...actual,
+    listDesignProposals: mocks.list,
+    getDesignProposal: mocks.get,
+    saveDesignProposal: mocks.save,
+    mutateDesignProposal: mocks.mutate,
+  };
+});
+vi.mock('@/lib/agent-os/design-lab/review', () => ({
+  reviewDesignProposal: mocks.review,
+}));
+vi.mock('@/lib/error-tracking', () => ({ captureError: vi.fn() }));
+
+const admin = {
+  isAuthenticated: true,
+  isAdmin: true,
+  email: 'reviewer@jovie.test',
+  userId: 'user_1',
+};
+
+const approvedProposal = DesignProposalSchema.parse({
+  id: PROPOSED_SECTIONS[0].id,
+  kind: 'section-gap',
+  surfaceId: 'section-gap:feature-split',
+  surfaceName: PROPOSED_SECTIONS[0].proposedSectionName,
+  proposalText: PROPOSED_SECTIONS[0].problem,
+  assetRefs: [],
+  scoring: null,
+  linearIssueId: 'UNASSIGNED',
+  linearIssueUrl: null,
+  status: 'approved',
+  designGap: PROPOSED_SECTIONS[0],
+  createdAt: '2026-07-11T00:00:00.000Z',
+  reviewedAt: '2026-07-11T01:00:00.000Z',
+  reviewer: 'reviewer@jovie.test',
+  reviewNotes: null,
+  reviewDecision: 'yes',
+  dayBucket: '2026-07-11',
+});
+const proposedProposal = DesignProposalSchema.parse({
+  ...approvedProposal,
+  status: 'proposed',
+  reviewedAt: null,
+  reviewer: null,
+  reviewDecision: null,
+});
+
+describe('Design Lab gallery API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.entitlements.mockResolvedValue(admin);
+    mocks.list.mockResolvedValue([]);
+    mocks.get.mockResolvedValue(null);
+    mocks.save.mockResolvedValue(undefined);
+    mocks.mutate.mockImplementation(async input => {
+      const source = (await mocks.get()) ?? proposedProposal;
+      const mutation = await input.mutate(source);
+      await mocks.save(mutation.proposal);
+      return mutation.result;
+    });
+  });
+
+  it('returns the canonical role-gate denial for gallery requests', async () => {
+    mocks.entitlements.mockResolvedValue({
+      isAuthenticated: true,
+      isAdmin: false,
+    });
+    const { GET } = await import('@/app/api/admin/design-lab/proposals/route');
+    const response = await GET(
+      new NextRequest('http://localhost/api/admin/design-lab/proposals')
+    );
+    expect(response.status).toBe(403);
+    expect(mocks.list).not.toHaveBeenCalled();
+  });
+
+  it('merges committed records and filters by status, type, and route', async () => {
+    const { GET } = await import('@/app/api/admin/design-lab/proposals/route');
+    const response = await GET(
+      new NextRequest(
+        'http://localhost/api/admin/design-lab/proposals?status=reviewing&sectionType=feature-grid&affectedRoute=%2Fdownload'
+      )
+    );
+    const payload = (await response.json()) as {
+      proposals: Array<{ id: string }>;
+    };
+    expect(response.status).toBe(200);
+    expect(mocks.entitlements).toHaveBeenCalledOnce();
+    expect(payload.proposals.map(item => item.id)).toEqual([
+      'PROPOSED-SECTION-0004',
+    ]);
+  });
+
+  it('limits the dedicated gallery query to section-gap records', async () => {
+    const { GET } = await import('@/app/api/admin/design-lab/proposals/route');
+    const response = await GET(
+      new NextRequest(
+        'http://localhost/api/admin/design-lab/proposals?kind=section-gap'
+      )
+    );
+    const payload = (await response.json()) as {
+      proposals: Array<{ id: string; kind: string; designGap: unknown }>;
+    };
+    expect(response.status).toBe(200);
+    expect(payload.proposals).toHaveLength(PROPOSED_SECTIONS.length);
+    expect(
+      payload.proposals.every(
+        item =>
+          item.kind === 'section-gap' &&
+          item.id.startsWith('PROPOSED-SECTION-') &&
+          item.designGap !== null
+      )
+    ).toBe(true);
+  });
+
+  it('validates compact feedback before persisting a comment', async () => {
+    const { POST } = await import(
+      '@/app/api/admin/design-lab/proposals/[proposalId]/comments/route'
+    );
+    const response = await POST(
+      new NextRequest('http://localhost/comments', {
+        method: 'POST',
+        body: JSON.stringify({
+          dayBucket: '2026-07-11',
+          compactFeedback: 'WRONG-ID: tighten the mobile hierarchy',
+        }),
+      }),
+      { params: Promise.resolve({ proposalId: 'PROPOSED-SECTION-0001' }) }
+    );
+    expect(response.status).toBe(400);
+    expect(mocks.save).not.toHaveBeenCalled();
+  });
+
+  it('appends valid compact feedback with the authenticated reviewer', async () => {
+    const { POST } = await import(
+      '@/app/api/admin/design-lab/proposals/[proposalId]/comments/route'
+    );
+    const response = await POST(
+      new NextRequest('http://localhost/comments', {
+        method: 'POST',
+        body: JSON.stringify({
+          dayBucket: '2026-07-11',
+          compactFeedback:
+            'PROPOSED-SECTION-0001: tighten the mobile hierarchy',
+        }),
+      }),
+      { params: Promise.resolve({ proposalId: 'PROPOSED-SECTION-0001' }) }
+    );
+    expect(response.status).toBe(200);
+    const saved =
+      mocks.save.mock.calls[1]?.[0] ?? mocks.save.mock.calls[0]?.[0];
+    expect(saved.designGap.comments.at(-1)).toMatchObject({
+      author: 'reviewer@jovie.test',
+      body: 'tighten the mobile hierarchy',
+    });
+  });
+
+  it('requires approved status and evidence before implementation', async () => {
+    const { POST } = await import(
+      '@/app/api/admin/design-lab/proposals/[proposalId]/implemented/route'
+    );
+    const response = await POST(
+      new NextRequest('http://localhost/implemented', {
+        method: 'POST',
+        body: JSON.stringify({
+          dayBucket: '2026-07-11',
+          evidenceRefs: ['tests/design-lab.png'],
+        }),
+      }),
+      { params: Promise.resolve({ proposalId: 'PROPOSED-SECTION-0001' }) }
+    );
+    expect(response.status).toBe(409);
+  });
+
+  it('records implementation evidence only on an approved proposal', async () => {
+    mocks.get.mockResolvedValue(approvedProposal);
+    const { POST } = await import(
+      '@/app/api/admin/design-lab/proposals/[proposalId]/implemented/route'
+    );
+    const response = await POST(
+      new NextRequest('http://localhost/implemented', {
+        method: 'POST',
+        body: JSON.stringify({
+          dayBucket: '2026-07-11',
+          evidenceRefs: ['tests/design-lab-desktop.png'],
+        }),
+      }),
+      { params: Promise.resolve({ proposalId: 'PROPOSED-SECTION-0001' }) }
+    );
+    expect(response.status).toBe(200);
+    expect(mocks.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'implemented',
+        designGap: expect.objectContaining({
+          registryTask: expect.objectContaining({
+            evidenceRefs: ['tests/design-lab-desktop.png'],
+          }),
+        }),
+      })
+    );
+  });
+
+  it('maps reviewing conflicts to 409', async () => {
+    mocks.review.mockRejectedValue(
+      new Error('Design proposal review is already in progress.')
+    );
+    const { POST } = await import(
+      '@/app/api/admin/design-lab/proposals/[proposalId]/review/route'
+    );
+    const response = await POST(
+      new NextRequest('http://localhost/review', {
+        method: 'POST',
+        body: JSON.stringify({
+          dayBucket: '2026-07-11',
+          decision: 'yes',
+        }),
+      }),
+      { params: Promise.resolve({ proposalId: 'PROPOSED-SECTION-0004' }) }
+    );
+    expect(response.status).toBe(409);
+  });
+});

--- a/apps/web/tests/unit/agent-os/design-lab/dispatch.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/dispatch.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DesignProposal } from '@/lib/agent-os/design-lab/types';
+
+vi.mock('server-only', () => ({}));
+
+const dispatchHermesWorker = vi.fn();
+const getHermesDispatchAvailability = vi.fn();
+const writeFile = vi.fn();
+const mkdir = vi.fn();
+
+vi.mock('node:fs', () => ({
+  default: { promises: { writeFile, mkdir } },
+  promises: { writeFile, mkdir },
+}));
+vi.mock('@/lib/hermes/dispatch', () => ({
+  dispatchHermesWorker,
+  getHermesDispatchAvailability,
+  HermesDispatchConfigurationError: class extends Error {},
+}));
+vi.mock('@/lib/agent-os/design-lab/paths', () => ({
+  getDesignLabDispatchDirectory: () => '/tmp/design-lab',
+  resolveDesignDispatchFilePath: (id: string) => `/tmp/${id}.json`,
+}));
+vi.mock('@/lib/agent-os/design-lab/taste-memory', () => ({
+  readDesignTasteMemoryExcerpt: vi.fn().mockResolvedValue(''),
+}));
+
+const proposal = {
+  id: 'gap',
+  kind: 'section-gap',
+  surfaceId: 'home',
+  surfaceName: 'Home',
+  proposalText: 'Add section',
+  assetRefs: [],
+  scoring: null,
+  linearIssueId: 'JOV-1',
+  linearIssueUrl: null,
+  status: 'approved',
+  createdAt: '2026-06-08T12:00:00.000Z',
+  reviewedAt: '2026-06-08T13:00:00.000Z',
+  reviewer: 'reviewer',
+  reviewNotes: null,
+  reviewDecision: 'yes',
+  dispatchId: null,
+  dayBucket: '2026-06-08',
+  designGap: {
+    reviewId: 'PROPOSED-SECTION-0001',
+    proposedName: 'Section',
+    problem: 'Missing section',
+    affectedRoutes: ['/'],
+    audience: 'Artists',
+    conversionGoal: 'Signups',
+    requiredContentFields: ['title'],
+    requiredMedia: [],
+    responsiveBehavior: 'Stacks',
+    ctaBehavior: 'Primary CTA',
+    similarSections: [],
+    insufficiencyReason: 'No match',
+    priority: 'high',
+    sectionType: 'hero',
+    wireframes: {
+      desktop: {
+        viewport: 'desktop',
+        width: 1440,
+        hierarchy: ['title'],
+        layout: 'split',
+        contentDensity: 'medium',
+        mediaPlacement: 'right',
+        responsiveBehavior: 'stack',
+        interactionModel: 'static',
+        tokens: ['surface'],
+        placeholderContent: 'grayscale-only',
+      },
+      mobile: {
+        viewport: 'mobile',
+        width: 390,
+        hierarchy: ['title'],
+        layout: 'stack',
+        contentDensity: 'medium',
+        mediaPlacement: 'below',
+        responsiveBehavior: 'stack',
+        interactionModel: 'static',
+        tokens: ['surface'],
+        placeholderContent: 'grayscale-only',
+      },
+    },
+    openQuestions: [],
+    comments: [],
+    registryTask: {
+      trigger: 'after-approved',
+      targetSectionId: 'hero',
+      requiredChanges: ['Implement registry variant'],
+      exactFiles: ['apps/web/components/sections/Hero.tsx'],
+      forbiddenPatterns: ['route-local JSX'],
+      acceptanceCriteria: ['Typed registry entry'],
+      validationCommands: [
+        'pnpm --filter @jovie/web run typecheck -- --pretty false',
+      ],
+      evidenceRequired: ['desktop screenshot'],
+      implementedAt: null,
+      evidenceRefs: [],
+    },
+    modelUsage: [],
+  },
+} satisfies DesignProposal;
+
+describe('triggerDesignLabDispatch', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reports unavailable Hermes honestly as not triggered', async () => {
+    getHermesDispatchAvailability.mockReturnValue({
+      available: false,
+      unavailableReason: 'not configured',
+    });
+    const { triggerDesignLabDispatch } = await import(
+      '@/lib/agent-os/design-lab/dispatch'
+    );
+    const result = await triggerDesignLabDispatch({
+      proposal,
+      amendmentNotes: null,
+      requestedBy: 'reviewer',
+    });
+    expect(result).toEqual({ triggered: false, dispatchId: null });
+    expect(dispatchHermesWorker).not.toHaveBeenCalled();
+  });
+
+  it('uses registry task boundaries and validation when dispatched', async () => {
+    getHermesDispatchAvailability.mockReturnValue({ available: true });
+    dispatchHermesWorker.mockResolvedValue({});
+    const { triggerDesignLabDispatch } = await import(
+      '@/lib/agent-os/design-lab/dispatch'
+    );
+    const result = await triggerDesignLabDispatch({
+      proposal,
+      amendmentNotes: null,
+      requestedBy: 'reviewer',
+    });
+    expect(result.triggered).toBe(true);
+    expect(dispatchHermesWorker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedPaths: proposal.designGap.registryTask?.exactFiles,
+        verification: proposal.designGap.registryTask?.validationCommands,
+      })
+    );
+  });
+});

--- a/apps/web/tests/unit/agent-os/design-lab/proposals.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/proposals.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  appendDesignProposalComment,
+  matchesDesignProposalFilters,
+  parseCompactFeedback,
+  parseProposalRecord,
+} from '@/lib/agent-os/design-lab/proposals';
+
+vi.mock('server-only', () => ({}));
+
+describe('proposal compatibility and feedback', () => {
+  it('parses compact proposed-section feedback', () => {
+    expect(
+      parseCompactFeedback('PROPOSED-SECTION-0042: Make the CTA quieter')
+    ).toEqual({
+      reviewId: 'PROPOSED-SECTION-0042',
+      body: 'Make the CTA quieter',
+    });
+    expect(parseCompactFeedback('section 42: nope')).toBeNull();
+  });
+
+  it('parses legacy pending records as proposed', () => {
+    const result = parseProposalRecord(
+      {
+        id: 'legacy',
+        surfaceId: 'home',
+        surfaceName: 'Home',
+        proposalText: 'Proposal',
+        assetRefs: [],
+        scoring: null,
+        linearIssueId: 'JOV-1',
+        linearIssueUrl: null,
+        status: 'pending',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        reviewedAt: null,
+        reviewer: null,
+        reviewNotes: null,
+      },
+      '2026-06-08'
+    );
+    expect(result?.status).toBe('proposed');
+  });
+
+  it('refuses comments on proposals without design-gap records', () => {
+    const proposal = parseProposalRecord(
+      {
+        id: 'surface',
+        surfaceId: 'home',
+        surfaceName: 'Home',
+        proposalText: 'Proposal',
+        assetRefs: [],
+        scoring: null,
+        linearIssueId: 'JOV-1',
+        linearIssueUrl: null,
+        status: 'proposed',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        reviewedAt: null,
+        reviewer: null,
+        reviewNotes: null,
+      },
+      '2026-06-08'
+    );
+    expect(() =>
+      appendDesignProposalComment(proposal!, {
+        author: 'reviewer',
+        body: 'Feedback',
+        date: '2026-06-08',
+      })
+    ).toThrow('does not have a design-gap record');
+    expect(
+      matchesDesignProposalFilters(proposal!, { statuses: ['approved'] })
+    ).toBe(false);
+    expect(
+      matchesDesignProposalFilters(proposal!, {
+        statuses: ['proposed'],
+        kinds: ['surface'],
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/agent-os/design-lab/review.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/review.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/lib/agent-os/design-lab/proposals', () => ({
   deriveProposalStatus: (decision: string | null) => {
     if (decision === 'no') return 'rejected';
     if (decision === 'yes' || decision === 'yes-with-notes') return 'approved';
-    return 'pending';
+    return 'proposed';
   },
 }));
 
@@ -33,6 +33,7 @@ vi.mock('@/lib/agent-os/design-lab/dispatch', () => ({
 
 const baseProposal: DesignProposal = {
   id: 'profile-page-quiet-hero',
+  kind: 'section-gap',
   surfaceId: 'profile-page',
   surfaceName: 'Public profile page',
   proposalText: 'Use a restrained surface-1 header band.',
@@ -40,7 +41,66 @@ const baseProposal: DesignProposal = {
   scoring: { weight: 0.9, score: 0.82 },
   linearIssueId: 'JOV-1951',
   linearIssueUrl: 'https://linear.app/jovie/issue/JOV-1951',
-  status: 'pending',
+  status: 'proposed',
+  designGap: {
+    reviewId: 'PROPOSED-SECTION-0001',
+    proposedName: 'Quiet hero',
+    problem: 'The current hero is too loud.',
+    affectedRoutes: ['/'],
+    audience: 'Artists',
+    conversionGoal: 'Profile visits',
+    requiredContentFields: ['title'],
+    requiredMedia: [],
+    responsiveBehavior: 'Stack on mobile.',
+    ctaBehavior: 'One primary CTA.',
+    similarSections: [],
+    insufficiencyReason: 'No canonical section matches.',
+    priority: 'high',
+    sectionType: 'hero',
+    wireframes: {
+      desktop: {
+        viewport: 'desktop',
+        width: 1440,
+        hierarchy: ['title'],
+        layout: 'split',
+        contentDensity: 'medium',
+        mediaPlacement: 'right',
+        responsiveBehavior: 'stack',
+        interactionModel: 'static',
+        tokens: ['surface'],
+        placeholderContent: 'grayscale-only',
+      },
+      mobile: {
+        viewport: 'mobile',
+        width: 390,
+        hierarchy: ['title'],
+        layout: 'stack',
+        contentDensity: 'medium',
+        mediaPlacement: 'below',
+        responsiveBehavior: 'stack',
+        interactionModel: 'static',
+        tokens: ['surface'],
+        placeholderContent: 'grayscale-only',
+      },
+    },
+    openQuestions: [],
+    comments: [],
+    registryTask: {
+      trigger: 'after-approved',
+      targetSectionId: 'quiet-hero',
+      requiredChanges: ['Implement registry variant'],
+      exactFiles: ['apps/web/components/sections/QuietHero.tsx'],
+      forbiddenPatterns: ['one-off route JSX'],
+      acceptanceCriteria: ['Typed registry component'],
+      validationCommands: [
+        'pnpm --filter @jovie/web run typecheck -- --pretty false',
+      ],
+      evidenceRequired: ['desktop screenshot'],
+      implementedAt: null,
+      evidenceRefs: [],
+    },
+    modelUsage: [],
+  },
   createdAt: '2026-06-08T12:00:00.000Z',
   reviewedAt: null,
   reviewer: null,
@@ -77,7 +137,11 @@ describe('reviewDesignProposal', () => {
     });
 
     expect(triggerDesignLabDispatch).toHaveBeenCalledWith({
-      proposal: baseProposal,
+      proposal: expect.objectContaining({
+        id: baseProposal.id,
+        status: 'approved',
+        reviewDecision: 'yes',
+      }),
       amendmentNotes: null,
       requestedBy: 'tim@jovie.com',
     });
@@ -149,7 +213,11 @@ describe('reviewDesignProposal', () => {
     });
 
     expect(triggerDesignLabDispatch).toHaveBeenCalledWith({
-      proposal: baseProposal,
+      proposal: expect.objectContaining({
+        id: baseProposal.id,
+        status: 'approved',
+        reviewDecision: 'yes-with-notes',
+      }),
       amendmentNotes: 'Keep the underline but reduce accent saturation.',
       requestedBy: 'tim@jovie.com',
     });
@@ -162,7 +230,7 @@ describe('reviewDesignProposal', () => {
     );
   });
 
-  it('throws when proposal was already reviewed', async () => {
+  it('rejects a conflicting decision after review', async () => {
     getDesignProposal.mockResolvedValue({
       ...baseProposal,
       status: 'approved',
@@ -176,10 +244,57 @@ describe('reviewDesignProposal', () => {
       reviewDesignProposal({
         dayBucket: '2026-06-08',
         proposalId: baseProposal.id,
-        decision: 'yes',
+        decision: 'no',
         notes: null,
         reviewer: 'tim@jovie.com',
       })
     ).rejects.toThrow('Design proposal has already been reviewed.');
+  });
+
+  it('persists approval before dispatch and resumes dispatch idempotently', async () => {
+    getDesignProposal.mockResolvedValue({
+      ...baseProposal,
+      status: 'approved',
+      reviewDecision: 'yes',
+    });
+    const { reviewDesignProposal } = await import(
+      '@/lib/agent-os/design-lab/review'
+    );
+    const result = await reviewDesignProposal({
+      dayBucket: '2026-06-08',
+      proposalId: baseProposal.id,
+      decision: 'yes',
+      notes: null,
+      reviewer: 'tim@jovie.com',
+    });
+    expect(triggerDesignLabDispatch).toHaveBeenCalledOnce();
+    expect(appendDesignTasteMemoryEntry).not.toHaveBeenCalled();
+    expect(result.dispatchTriggered).toBe(true);
+  });
+
+  it('keeps approval durable when dispatch is unavailable', async () => {
+    triggerDesignLabDispatch.mockResolvedValue({
+      triggered: false,
+      dispatchId: null,
+    });
+    const { reviewDesignProposal } = await import(
+      '@/lib/agent-os/design-lab/review'
+    );
+    const result = await reviewDesignProposal({
+      dayBucket: '2026-06-08',
+      proposalId: baseProposal.id,
+      decision: 'yes',
+      notes: null,
+      reviewer: 'tim@jovie.com',
+    });
+    expect(saveDesignProposal.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ status: 'reviewing' })
+    );
+    expect(saveDesignProposal.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({ status: 'approved' })
+    );
+    expect(result.proposal.status).toBe('approved');
+    expect(result.dispatchTriggered).toBe(false);
+    expect(result.dispatchId).toBeNull();
   });
 });

--- a/apps/web/tests/unit/agent-os/design-lab/review.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/review.test.ts
@@ -7,11 +7,17 @@ const getDesignProposal = vi.fn();
 const saveDesignProposal = vi.fn();
 const appendDesignTasteMemoryEntry = vi.fn();
 const updateDesignLabLinearIssueStatus = vi.fn();
+const createDesignLabLinearIssue = vi.fn();
 const triggerDesignLabDispatch = vi.fn();
 
 vi.mock('@/lib/agent-os/design-lab/proposals', () => ({
   getDesignProposal,
   saveDesignProposal,
+  withDesignProposalLock: async (
+    _dayBucket: string,
+    _proposalId: string,
+    action: () => Promise<unknown>
+  ) => action(),
   deriveProposalStatus: (decision: string | null) => {
     if (decision === 'no') return 'rejected';
     if (decision === 'yes' || decision === 'yes-with-notes') return 'approved';
@@ -24,6 +30,7 @@ vi.mock('@/lib/agent-os/design-lab/taste-memory', () => ({
 }));
 
 vi.mock('@/lib/agent-os/design-lab/linear', () => ({
+  createDesignLabLinearIssue,
   updateDesignLabLinearIssueStatus,
 }));
 
@@ -117,13 +124,17 @@ describe('reviewDesignProposal', () => {
     saveDesignProposal.mockResolvedValue(undefined);
     appendDesignTasteMemoryEntry.mockResolvedValue(undefined);
     updateDesignLabLinearIssueStatus.mockResolvedValue(true);
+    createDesignLabLinearIssue.mockResolvedValue({
+      identifier: 'JOV-9999',
+      url: 'https://linear.app/jovie/issue/JOV-9999',
+    });
     triggerDesignLabDispatch.mockResolvedValue({
       triggered: true,
       dispatchId: 'design-lab-test',
     });
   });
 
-  it('approves with yes, dispatches D5, and completes Linear issue', async () => {
+  it('approves with yes, dispatches D5, and leaves implementation issue open', async () => {
     const { reviewDesignProposal } = await import(
       '@/lib/agent-os/design-lab/review'
     );
@@ -151,10 +162,7 @@ describe('reviewDesignProposal', () => {
         reviewer: 'tim@jovie.com',
       })
     );
-    expect(updateDesignLabLinearIssueStatus).toHaveBeenCalledWith(
-      'JOV-1951',
-      'completed'
-    );
+    expect(updateDesignLabLinearIssueStatus).not.toHaveBeenCalled();
     expect(saveDesignProposal).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'approved',
@@ -226,6 +234,35 @@ describe('reviewDesignProposal', () => {
         status: 'approved',
         reviewDecision: 'yes-with-notes',
         reviewNotes: 'Keep the underline but reduce accent saturation.',
+      })
+    );
+  });
+
+  it('creates and persists an implementation issue before dispatch', async () => {
+    getDesignProposal.mockResolvedValue({
+      ...baseProposal,
+      linearIssueId: 'UNASSIGNED',
+      linearIssueUrl: null,
+    });
+    const { reviewDesignProposal } = await import(
+      '@/lib/agent-os/design-lab/review'
+    );
+
+    await reviewDesignProposal({
+      dayBucket: '2026-06-08',
+      proposalId: baseProposal.id,
+      decision: 'yes',
+      notes: null,
+      reviewer: 'tim@jovie.com',
+    });
+
+    expect(createDesignLabLinearIssue).toHaveBeenCalledOnce();
+    expect(triggerDesignLabDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proposal: expect.objectContaining({
+          linearIssueId: 'JOV-9999',
+          linearIssueUrl: 'https://linear.app/jovie/issue/JOV-9999',
+        }),
       })
     );
   });

--- a/apps/web/tests/unit/agent-os/design-lab/types.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/types.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { DesignProposalReviewRequestSchema } from '@/lib/agent-os/design-lab/types';
+import { PROPOSED_SECTIONS } from '@/data/marketing';
+import {
+  DesignGapRecordSchema,
+  DesignProposalReviewRequestSchema,
+  DesignProposalSchema,
+} from '@/lib/agent-os/design-lab/types';
 
 describe('DesignProposalReviewRequestSchema', () => {
   it('accepts yes without notes', () => {
@@ -37,5 +42,53 @@ describe('DesignProposalReviewRequestSchema', () => {
     });
 
     expect(parsed.success).toBe(true);
+  });
+});
+
+describe('DesignProposalSchema', () => {
+  const legacy = {
+    id: 'legacy',
+    surfaceId: 'home',
+    surfaceName: 'Home',
+    proposalText: 'Legacy proposal',
+    assetRefs: [],
+    scoring: null,
+    linearIssueId: 'JOV-1',
+    linearIssueUrl: null,
+    status: 'pending',
+    createdAt: '2026-06-08T12:00:00.000Z',
+    reviewedAt: null,
+    reviewer: null,
+    reviewNotes: null,
+  };
+
+  it('normalizes legacy pending surface records to proposed', () => {
+    const parsed = DesignProposalSchema.parse(legacy);
+    expect(parsed.status).toBe('proposed');
+    expect(parsed.kind).toBe('surface');
+    expect(parsed.designGap).toBeNull();
+  });
+
+  it('requires a design-gap record for section-gap proposals', () => {
+    expect(
+      DesignProposalSchema.safeParse({ ...legacy, kind: 'section-gap' }).success
+    ).toBe(false);
+  });
+
+  it('rejects implemented status without registry evidence', () => {
+    expect(
+      DesignProposalSchema.safeParse({ ...legacy, status: 'implemented' })
+        .success
+    ).toBe(false);
+  });
+});
+
+describe('DesignGapRecordSchema', () => {
+  it('consumes the canonical marketing design-gap catalog shape', () => {
+    const parsed = DesignGapRecordSchema.parse(PROPOSED_SECTIONS[0]);
+    expect(parsed.reviewId).toBe('PROPOSED-SECTION-0001');
+    expect(parsed.proposedName).toBeTruthy();
+    expect(parsed.wireframes.desktop.placeholderContent).toBe('grayscale-only');
+    expect(parsed.registryTask?.trigger).toBe('after-approved');
   });
 });


### PR DESCRIPTION
## Summary\n- serialize proposal mutations with per-proposal file locks and atomic writes\n- create a real Linear implementation issue before approved dispatch\n- keep implementation issues open until verified evidence is recorded\n- restore canonical entitlement checks and correct the worker implementation prompt\n\n## Verification\n- 73 focused tests passed across Design Lab and marketing manifests\n- bug-to-test gate passed\n- monorepo typecheck passed\n- production web build passed\n\n## Review\nAdversarial review findings were fixed before submission: concurrency, entitlement enforcement, placeholder issue dispatch, and artifact-only worker instructions.\n\n## Stack\nPart 6 of the governed proposed-section workflow.