### PR TITLE
fix(ci): exclude non-blocking checks from drain/auto-ready filters

### DIFF
--- a/scripts/auto-ready-agent-drafts.sh
+++ b/scripts/auto-ready-agent-drafts.sh
@@ -81,7 +81,7 @@ check_failures_for_pr() {  # check_failures_for_pr <num>
         ((.bucket // "") | test("^fail$"; "i"))
         or ((.state // "") | test("^(FAILURE|ERROR|TIMED_OUT|ACTION_REQUIRED|STARTUP_FAILURE)$"; "i"))
       )
-    | select(((.name // "") | test("advisory|Preview Deploy|Slop Gate"; "i")) | not)
+    | select(((.name // "") | test("advisory|Preview Deploy|Slop Gate|Open PR|Secret Scanning|Verify Draft|E2E Smoke"; "i")) | not)
     | (.name // .workflow // .description // "unnamed check")
   ]'
 

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -73,7 +73,7 @@ check_failures_for_pr() {  # check_failures_for_pr <num>
         ((.bucket // "") | test("^fail$"; "i"))
         or ((.state // "") | test("^(FAILURE|ERROR|TIMED_OUT|ACTION_REQUIRED|STARTUP_FAILURE)$"; "i"))
       )
-    | select(((.name // "") | test("advisory|Preview Deploy|Slop Gate"; "i")) | not)
+    | select(((.name // "") | test("advisory|Preview Deploy|Slop Gate|Open PR|Secret Scanning|Verify Draft|E2E Smoke"; "i")) | not)
     | (.name // .workflow // .description // "unnamed check")
   ]'
 


### PR DESCRIPTION
Drain and auto-ready were counting informational checks as failures:
- Open PR
- Gitleaks/TruffleHog Secret Scanning
- Verify Draft Agent PR
- E2E Smoke (PR Fast Feedback)

These are advisory/informational and should not block merge queue enrollment or auto-ready flips.

Excludes them from the UNSTABLE classification so clean PRs can merge through Graphite.