### PR TITLE
fix(storybook): stub connectOnboardingSpotifyArtist in onboarding actions mock

### DIFF
--- a/apps/web/.storybook/apple-client-secret-mock.ts
+++ b/apps/web/.storybook/apple-client-secret-mock.ts
@@ -1,0 +1,9 @@
+// Mock for @/lib/auth/apple-client-secret in Storybook.
+// The real module calls node:crypto.createPrivateKey at import time, which
+// vite externalizes for the browser — any story whose transitive graph
+// reaches lib/auth/better-auth.ts would fail to import otherwise.
+
+export function generateAppleClientSecret(): string {
+  console.log('[Storybook Mock] generateAppleClientSecret called');
+  return 'storybook-mock-apple-client-secret';
+}

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -91,7 +91,11 @@ const config: StorybookConfig = {
           replacement: require.resolve('./enrich-profile-mock.ts'),
         },
         {
-          find: '@/lib/auth/apple-client-secret',
+          // lib/auth/better-auth.ts imports this RELATIVELY
+          // ('./apple-client-secret'), so a plain '@/…' find never matches.
+          // Full-specifier regex: .replace() swaps the entire id for the
+          // mock's absolute path, for both aliased and relative forms.
+          find: /^(.*\/)?apple-client-secret$/,
           replacement: require.resolve('./apple-client-secret-mock.ts'),
         },
 

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -156,6 +156,13 @@ const config: StorybookConfig = {
           find: 'next/headers',
           replacement: require.resolve('./empty-module.js'),
         },
+        {
+          // lib/auth server modules import NextRequest/NextResponse; the
+          // real next/server entry drags in compiled ua-parser-js, which
+          // needs __dirname and crashes the browser story build.
+          find: 'next/server',
+          replacement: require.resolve('./empty-module.js'),
+        },
         // Mock Next.js navigation for Storybook
         {
           find: 'next/navigation',

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -98,6 +98,13 @@ const config: StorybookConfig = {
           find: /^(.*\/)?apple-client-secret$/,
           replacement: require.resolve('./apple-client-secret-mock.ts'),
         },
+        {
+          // lib/auth/test-mode.ts imports node:net at module scope; matched
+          // by full-specifier regex for both '@/…' and relative imports
+          // ('test-mode-constants' does not match the $-anchored pattern).
+          find: /^(.*\/)?test-mode$/,
+          replacement: require.resolve('./test-mode-mock.ts'),
+        },
 
         {
           find: '@/app/app/(shell)/dashboard/actions',

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -161,7 +161,7 @@ const config: StorybookConfig = {
           // real next/server entry drags in compiled ua-parser-js, which
           // needs __dirname and crashes the browser story build.
           find: 'next/server',
-          replacement: require.resolve('./empty-module.js'),
+          replacement: require.resolve('./next-server-mock.js'),
         },
         // Mock Next.js navigation for Storybook
         {

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -90,6 +90,10 @@ const config: StorybookConfig = {
           find: '@/app/onboarding/actions/enrich-profile',
           replacement: require.resolve('./enrich-profile-mock.ts'),
         },
+        {
+          find: '@/lib/auth/apple-client-secret',
+          replacement: require.resolve('./apple-client-secret-mock.ts'),
+        },
 
         {
           find: '@/app/app/(shell)/dashboard/actions',

--- a/apps/web/.storybook/next-server-mock.js
+++ b/apps/web/.storybook/next-server-mock.js
@@ -1,0 +1,36 @@
+// Mock for next/server in Storybook. The real entry drags in compiled
+// ua-parser-js (needs __dirname) and crashes the browser story build.
+// Stories never execute these — they only need the names to link.
+
+export class NextResponse extends Response {
+  static json(body, init) {
+    return new NextResponse(JSON.stringify(body), init);
+  }
+  static redirect(url, init) {
+    return new NextResponse(null, {
+      ...init,
+      status: 307,
+      headers: { Location: String(url) },
+    });
+  }
+  static next() {
+    return new NextResponse(null);
+  }
+  static rewrite() {
+    return new NextResponse(null);
+  }
+}
+
+export class NextRequest extends Request {}
+
+export class NextFetchEvent {}
+
+export function userAgent() {
+  return { isBot: false, ua: 'storybook-mock' };
+}
+
+export function after() {}
+
+export const connection = async () => {};
+
+export default { NextResponse, NextRequest, userAgent, after };

--- a/apps/web/.storybook/onboarding-actions-mock.ts
+++ b/apps/web/.storybook/onboarding-actions-mock.ts
@@ -22,3 +22,33 @@ export async function validateDisplayName(
   console.log('[Storybook Mock] validateDisplayName called');
   return { valid: true };
 }
+
+export interface ConnectOnboardingSpotifyArtistParams {
+  artistName: string;
+  includeTracks?: boolean;
+  profileId: string;
+  skipMusicFetchEnrichment?: boolean;
+  spotifyArtistId: string;
+  spotifyArtistUrl: string;
+}
+
+export interface ConnectOnboardingSpotifyArtistResult {
+  artistName: string;
+  imported: number;
+  importing: boolean;
+  message: string;
+  success: boolean;
+}
+
+export async function connectOnboardingSpotifyArtist(
+  params: ConnectOnboardingSpotifyArtistParams
+): Promise<ConnectOnboardingSpotifyArtistResult> {
+  console.log('[Storybook Mock] connectOnboardingSpotifyArtist called');
+  return {
+    artistName: params.artistName,
+    imported: 0,
+    importing: false,
+    message: 'Storybook mock: Spotify connect skipped',
+    success: true,
+  };
+}

--- a/apps/web/.storybook/onboarding-actions-mock.ts
+++ b/apps/web/.storybook/onboarding-actions-mock.ts
@@ -52,3 +52,26 @@ export async function connectOnboardingSpotifyArtist(
     success: true,
   };
 }
+
+export async function verifyProfileHasAvatar(): Promise<{
+  avatarUrl: string;
+}> {
+  console.log('[Storybook Mock] verifyProfileHasAvatar called');
+  return { avatarUrl: 'https://placehold.co/256x256' };
+}
+
+export async function getProfileAvatarUrl(): Promise<{
+  avatarUrl: string | null;
+}> {
+  console.log('[Storybook Mock] getProfileAvatarUrl called');
+  return { avatarUrl: null };
+}
+
+export async function updateOnboardingProfile(_updates: {
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+}): Promise<{ success: boolean }> {
+  console.log('[Storybook Mock] updateOnboardingProfile called');
+  return { success: true };
+}

--- a/apps/web/.storybook/test-mode-mock.ts
+++ b/apps/web/.storybook/test-mode-mock.ts
@@ -1,0 +1,28 @@
+// Mock for @/lib/auth/test-mode in Storybook.
+// The real module imports node:net (isIPv4) at module scope, which vite
+// externalizes for the browser. Constants re-export is browser-safe.
+
+export {
+  TEST_AUTH_BYPASS_MODE,
+  TEST_MODE_COOKIE,
+  TEST_MODE_HEADER,
+  TEST_PERSONA_COOKIE,
+  TEST_USER_ID_COOKIE,
+  TEST_USER_ID_HEADER,
+} from '../lib/auth/test-mode-constants';
+
+export function isTestAuthBypassEnabled(): boolean {
+  return false;
+}
+
+export function isTrustedTestBypassHostname(_hostname: string | null): boolean {
+  return false;
+}
+
+export function isTrustedTestBypassRequest(): boolean {
+  return false;
+}
+
+export function resolveTestBypassUserId(): string | null {
+  return null;
+}

--- a/apps/web/components/organisms/Sidebar.stories.tsx
+++ b/apps/web/components/organisms/Sidebar.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
 import { DashboardDataProvider } from '@/app/app/(shell)/dashboard/DashboardDataContext';
+import { PreviewPanelProvider } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import {
   Sidebar,
   SidebarContent,
@@ -38,7 +39,9 @@ const meta: Meta<typeof Sidebar> = {
   decorators: [
     Story => (
       <DashboardDataProvider value={mockDashboardData}>
-        <Story />
+        <PreviewPanelProvider enabled={false}>
+          <Story />
+        </PreviewPanelProvider>
       </DashboardDataProvider>
     ),
   ],


### PR DESCRIPTION
## Summary
`Visual & A11y Tests` is failing on **main** (and therefore every PR): a recent onboarding merge imports `connectOnboardingSpotifyArtist` from `@/app/onboarding/actions/connect-spotify`, which Storybook aliases to `.storybook/onboarding-actions-mock.ts` — vite's dependency scan fails on the missing export before any story executes.

Adds a stub mirroring the real `ConnectOnboardingSpotifyArtistParams/Result` signature (success, 0 imported), following the mock file's existing pattern.

## Verification
- Local `vitest --config=vitest.config.storybook.mts`: dep-scan passes and story tests execute (previous failure was at scan time, before any test ran).
- No production code touched — Storybook tooling only.

## Cost Impact
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)