### PR TITLE
test(connectors): mutation-verified Google OAuth route coverage (JOV-4220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] Mutation-verified tests for the Google OAuth connector routes — real HMAC state signing/verification, AES-256-GCM token encryption at rest, no-partial-write on provider failure, disconnect token-residue nulling (JOV-4220)
 - **Homepage labels now meet WCAG AA contrast:** the distributor trust-strip and closed-loop labels use the readable tertiary text token instead of the low-contrast quaternary token.
 - [internal] **Design-system drift ratchet tightened 3044→2609 (JOV-4211)**: converted 29 exact-match typography arbitraries to tokens across 18 dashboard/admin/organism/molecule files (`leading-[16px]`→`leading-4`, `tracking-[-0.01em]`→`tracking-tight`, `tracking-[-0.02em]`→`tracking-tighter`, `tracking-[0.01em]`→`tracking-wide`) and re-measured the baseline to the true count, removing ~406 counts of stale regression headroom.
 - [internal] **Desktop renderer recovery (JOV-3595)**: recover from hosted loads that return HTTP 200 but never boot React, and route crashed or unresponsive renderers to the visible recovery shell instead of a permanent black window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
-- [internal] Mutation-verified tests for the Google OAuth connector routes — real HMAC state signing/verification, AES-256-GCM token encryption at rest, no-partial-write on provider failure, disconnect token-residue nulling (JOV-4220)
 - **Homepage labels now meet WCAG AA contrast:** the distributor trust-strip and closed-loop labels use the readable tertiary text token instead of the low-contrast quaternary token.
 - [internal] **Design-system drift ratchet tightened 3044→2609 (JOV-4211)**: converted 29 exact-match typography arbitraries to tokens across 18 dashboard/admin/organism/molecule files (`leading-[16px]`→`leading-4`, `tracking-[-0.01em]`→`tracking-tight`, `tracking-[-0.02em]`→`tracking-tighter`, `tracking-[0.01em]`→`tracking-wide`) and re-measured the baseline to the true count, removing ~406 counts of stale regression headroom.
 - [internal] **Desktop renderer recovery (JOV-3595)**: recover from hosted loads that return HTTP 200 but never boot React, and route crashed or unresponsive renderers to the visible recovery shell instead of a permanent black window.

--- a/apps/web/tests/unit/api/connectors/google/authorize.test.ts
+++ b/apps/web/tests/unit/api/connectors/google/authorize.test.ts
@@ -1,0 +1,226 @@
+/**
+ * GET /api/connectors/google/authorize
+ *
+ * Uses the REAL `signGoogleOAuthState`/`verifyGoogleOAuthState` helpers (only
+ * `@/lib/env-server`, `@/lib/auth/cached`, `@/lib/db`, and `@/lib/error-tracking`
+ * are mocked) so the state token produced by the route is verified through the
+ * actual HMAC signing code, not a stand-in.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
+import { verifyGoogleOAuthState } from '@/lib/connectors/google-calendar/oauth-state';
+
+const hoisted = vi.hoisted(() => ({
+  getCachedAuthMock: vi.fn(),
+  dbSelectMock: vi.fn(),
+  captureErrorMock: vi.fn().mockResolvedValue(undefined),
+  mockEnv: {
+    GOOGLE_OAUTH_CLIENT_ID: 'test-client-id.apps.googleusercontent.com' as
+      | string
+      | undefined,
+    GOOGLE_OAUTH_CLIENT_SECRET: 'test-client-secret' as string | undefined,
+    GOOGLE_OAUTH_REDIRECT_URI_BASE: undefined as string | undefined,
+    TRACKING_TOKEN_SECRET: 'test-oauth-state-secret' as string | undefined,
+    CRON_SECRET: undefined as string | undefined,
+  },
+}));
+
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: hoisted.getCachedAuthMock,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: { select: hoisted.dbSelectMock },
+}));
+
+vi.mock('@/lib/db/schema/auth', () => ({
+  users: { id: 'users.id', clerkId: 'users.clerk_id' },
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: hoisted.captureErrorMock,
+}));
+
+vi.mock('@/lib/env-server', () => ({
+  env: hoisted.mockEnv,
+  isTestEnv: () => true,
+}));
+
+function selectReturns(rows: Array<{ id: string }>) {
+  hoisted.dbSelectMock.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  });
+}
+
+function selectThrows(error: Error) {
+  hoisted.dbSelectMock.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockRejectedValue(error),
+      }),
+    }),
+  });
+}
+
+describe('GET /api/connectors/google/authorize', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.mockEnv.GOOGLE_OAUTH_CLIENT_ID =
+      'test-client-id.apps.googleusercontent.com';
+    hoisted.mockEnv.GOOGLE_OAUTH_CLIENT_SECRET = 'test-client-secret';
+    hoisted.mockEnv.GOOGLE_OAUTH_REDIRECT_URI_BASE = undefined;
+    hoisted.mockEnv.TRACKING_TOKEN_SECRET = 'test-oauth-state-secret';
+    hoisted.mockEnv.CRON_SECRET = undefined;
+    selectReturns([{ id: 'db-user-1' }]);
+    hoisted.getCachedAuthMock.mockResolvedValue({ userId: 'clerk_1' });
+  });
+
+  it('falls back to the dev fixture seed route when GOOGLE_OAUTH_CLIENT_ID is missing (non-production)', async () => {
+    hoisted.mockEnv.GOOGLE_OAUTH_CLIENT_ID = undefined;
+
+    const { GET } = await import('@/app/api/connectors/google/authorize/route');
+    const response = await GET(
+      new Request('http://localhost/api/connectors/google/authorize')
+    );
+
+    expect(response.status).toBe(302);
+    const location = response.headers.get('location');
+    expect(location).toBe(
+      'http://localhost/api/dev/connectors/seed-fixtures?returnTo=%2Fapp%2Fsettings%2Fconnectors'
+    );
+    // The mock-mode short-circuit happens before the auth check runs at all.
+    expect(hoisted.getCachedAuthMock).not.toHaveBeenCalled();
+    expect(hoisted.dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects to sign-in when unauthenticated', async () => {
+    hoisted.getCachedAuthMock.mockResolvedValue({ userId: null });
+
+    const { GET } = await import('@/app/api/connectors/google/authorize/route');
+    const response = await GET(
+      new Request('http://localhost/api/connectors/google/authorize')
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('http://localhost/sign-in');
+    // No DB lookup or state signing should occur pre-auth.
+    expect(hoisted.dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects with ?error=auth when the Clerk user has no DB row', async () => {
+    selectReturns([]);
+
+    const { GET } = await import('@/app/api/connectors/google/authorize/route');
+    const response = await GET(
+      new Request('http://localhost/api/connectors/google/authorize')
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      `http://localhost${APP_ROUTES.SETTINGS_CONNECTORS}?error=auth`
+    );
+  });
+
+  it('builds a Google authorize URL with client_id, redirect_uri, readonly scopes, and a real verifiable state', async () => {
+    const { GET } = await import('@/app/api/connectors/google/authorize/route');
+    const response = await GET(
+      new Request(
+        'http://localhost/api/connectors/google/authorize?returnTo=%2Fapp%2Fcustom'
+      )
+    );
+
+    expect(response.status).toBe(302);
+    const location = response.headers.get('location');
+    expect(location).toBeTruthy();
+    const url = new URL(location as string);
+
+    expect(url.origin + url.pathname).toBe(
+      'https://accounts.google.com/o/oauth2/v2/auth'
+    );
+    expect(url.searchParams.get('client_id')).toBe(
+      'test-client-id.apps.googleusercontent.com'
+    );
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'http://localhost/api/connectors/google/callback'
+    );
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('access_type')).toBe('offline');
+    expect(url.searchParams.get('prompt')).toBe('consent');
+
+    const scope = url.searchParams.get('scope');
+    expect(scope).toBeTruthy();
+    const scopes = (scope as string).split(' ');
+    expect(scopes).toEqual(
+      expect.arrayContaining([
+        'https://www.googleapis.com/auth/calendar.events.readonly',
+        'https://www.googleapis.com/auth/calendar.events',
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/userinfo.email',
+      ])
+    );
+
+    // The state must verify through the REAL signing/verification helper and
+    // carry the resolved DB user id + the requested returnTo — not the Clerk id.
+    const state = url.searchParams.get('state');
+    expect(state).toBeTruthy();
+    const decoded = verifyGoogleOAuthState(state as string);
+    expect(decoded.userId).toBe('db-user-1');
+    expect(decoded.returnTo).toBe('/app/custom');
+  });
+
+  it('uses GOOGLE_OAUTH_REDIRECT_URI_BASE when configured instead of request origin', async () => {
+    hoisted.mockEnv.GOOGLE_OAUTH_REDIRECT_URI_BASE =
+      'https://redirect.example.com/api/connectors/google';
+
+    const { GET } = await import('@/app/api/connectors/google/authorize/route');
+    const response = await GET(
+      new Request('http://localhost/api/connectors/google/authorize')
+    );
+
+    const location = response.headers.get('location');
+    const url = new URL(location as string);
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://redirect.example.com/api/connectors/google/callback'
+    );
+  });
+
+  it('produces a state that a tampered signature fails to verify', async () => {
+    const { GET } = await import('@/app/api/connectors/google/authorize/route');
+    const response = await GET(
+      new Request('http://localhost/api/connectors/google/authorize')
+    );
+    const url = new URL(response.headers.get('location') as string);
+    const state = url.searchParams.get('state') as string;
+
+    // Flip the last character of the signature portion to simulate tampering.
+    const tampered = state.slice(0, -1) + (state.at(-1) === 'a' ? 'b' : 'a');
+
+    expect(() => verifyGoogleOAuthState(tampered)).toThrow(
+      /Invalid Google OAuth state signature/
+    );
+  });
+
+  it('redirects with ?error=oauth_start and captures the error on unexpected failure', async () => {
+    selectThrows(new Error('db unreachable'));
+
+    const { GET } = await import('@/app/api/connectors/google/authorize/route');
+    const response = await GET(
+      new Request('http://localhost/api/connectors/google/authorize')
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      `http://localhost${APP_ROUTES.SETTINGS_CONNECTORS}?error=oauth_start`
+    );
+    expect(hoisted.captureErrorMock).toHaveBeenCalledWith(
+      'Google OAuth authorize failed',
+      expect.any(Error),
+      expect.objectContaining({ route: '/api/connectors/google/authorize' })
+    );
+  });
+});

--- a/apps/web/tests/unit/api/connectors/google/callback.test.ts
+++ b/apps/web/tests/unit/api/connectors/google/callback.test.ts
@@ -1,0 +1,421 @@
+/**
+ * GET /api/connectors/google/callback
+ *
+ * Mocks only `@/lib/db`, `@/lib/http/server-fetch`, `@/lib/env-server`, and
+ * `@/lib/error-tracking`. State verification (`verifyGoogleOAuthState`) and
+ * token persistence (`storeTokens` → real `encryptPII`/`decryptPII`) run for
+ * real, so a dropped signature check or a dropped encryption call is caught
+ * by these assertions rather than by an inspected mock call.
+ *
+ * `PII_ENCRYPTION_KEY` is left unset for most tests (real `encryptPII` then
+ * takes its cheap dev/test plaintext-passthrough branch — no `scryptSync`
+ * cost). Exactly one test ("persists AES-256-GCM encrypted tokens...") sets a
+ * real key to exercise the full AES-256-GCM path; that test is intentionally
+ * isolated and slower (~2 real KDF-backed encrypt/decrypt round trips).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
+
+const hoisted = vi.hoisted(() => ({
+  dbInsertMock: vi.fn(),
+  dbUpdateMock: vi.fn(),
+  serverFetchMock: vi.fn(),
+  captureErrorMock: vi.fn().mockResolvedValue(undefined),
+  captureWarningMock: vi.fn().mockResolvedValue(undefined),
+  mockEnv: {
+    GOOGLE_OAUTH_CLIENT_ID: 'test-client-id.apps.googleusercontent.com' as
+      | string
+      | undefined,
+    GOOGLE_OAUTH_CLIENT_SECRET: 'test-client-secret' as string | undefined,
+    GOOGLE_OAUTH_REDIRECT_URI_BASE: undefined as string | undefined,
+    TRACKING_TOKEN_SECRET: 'test-oauth-state-secret' as string | undefined,
+    CRON_SECRET: undefined as string | undefined,
+    PII_ENCRYPTION_KEY: undefined as string | undefined,
+    VERCEL_ENV: undefined as string | undefined,
+    NODE_ENV: 'test',
+  },
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: { insert: hoisted.dbInsertMock, update: hoisted.dbUpdateMock },
+}));
+
+vi.mock('@/lib/http/server-fetch', () => ({
+  serverFetch: hoisted.serverFetchMock,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: hoisted.captureErrorMock,
+  captureWarning: hoisted.captureWarningMock,
+}));
+
+vi.mock('@/lib/env-server', () => ({
+  env: hoisted.mockEnv,
+  isTestEnv: () => true,
+}));
+
+import { signGoogleOAuthState } from '@/lib/connectors/google-calendar/oauth-state';
+import { decryptPII } from '@/lib/utils/pii-encryption';
+
+interface InsertCall {
+  readonly values: Record<string, unknown>;
+  readonly conflict: unknown;
+}
+
+interface UpdateCall {
+  readonly set: Record<string, unknown>;
+  readonly where: unknown;
+}
+
+function trackInserts(returnIds: string[]): InsertCall[] {
+  const calls: InsertCall[] = [];
+  let n = 0;
+  hoisted.dbInsertMock.mockImplementation(() => ({
+    values: (valuesArg: Record<string, unknown>) => ({
+      onConflictDoUpdate: (conflictArg: unknown) => {
+        calls.push({ values: valuesArg, conflict: conflictArg });
+        const id = returnIds[n] ?? `mock-id-${n}`;
+        n += 1;
+        return { returning: () => Promise.resolve([{ id }]) };
+      },
+    }),
+  }));
+  return calls;
+}
+
+function trackUpdates(): UpdateCall[] {
+  const calls: UpdateCall[] = [];
+  hoisted.dbUpdateMock.mockImplementation(() => ({
+    set: (setArg: Record<string, unknown>) => ({
+      where: (whereArg: unknown) => {
+        calls.push({ set: setArg, where: whereArg });
+        return { returning: () => Promise.resolve([{ id: 'updated' }]) };
+      },
+    }),
+  }));
+  return calls;
+}
+
+function tokenResponse(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => 'unused',
+    json: async () => ({
+      access_token: 'ya29.real-access-token',
+      refresh_token: 'refresh-token-value',
+      expires_in: 3600,
+      token_type: 'Bearer',
+      scope: [
+        'https://www.googleapis.com/auth/calendar.events.readonly',
+        'https://www.googleapis.com/auth/calendar.events',
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/userinfo.email',
+      ].join(' '),
+      ...overrides,
+    }),
+  };
+}
+
+function userInfoResponse(email = 'dj@example.com') {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ email, sub: 'google-sub-123' }),
+  };
+}
+
+function callbackRequest(params: Record<string, string>) {
+  const url = new URL('http://localhost/api/connectors/google/callback');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new Request(url.toString());
+}
+
+describe('GET /api/connectors/google/callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.mockEnv.GOOGLE_OAUTH_CLIENT_ID =
+      'test-client-id.apps.googleusercontent.com';
+    hoisted.mockEnv.GOOGLE_OAUTH_CLIENT_SECRET = 'test-client-secret';
+    hoisted.mockEnv.GOOGLE_OAUTH_REDIRECT_URI_BASE = undefined;
+    hoisted.mockEnv.TRACKING_TOKEN_SECRET = 'test-oauth-state-secret';
+    hoisted.mockEnv.CRON_SECRET = undefined;
+    // Unset by default so encryptPII/decryptPII take the cheap dev/test
+    // plaintext-passthrough branch (no scryptSync). One test below opts in.
+    hoisted.mockEnv.PII_ENCRYPTION_KEY = undefined;
+  });
+
+  it('redirects with ?error=oauth_denied when Google reports a provider error, without exchanging anything', async () => {
+    const { GET } = await import('@/app/api/connectors/google/callback/route');
+    const response = await GET(
+      callbackRequest({ error: 'access_denied', code: 'x', state: 'y' })
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      `http://localhost${APP_ROUTES.SETTINGS_CONNECTORS}?error=oauth_denied`
+    );
+    expect(hoisted.serverFetchMock).not.toHaveBeenCalled();
+    expect(hoisted.dbInsertMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects with ?error=oauth_missing_params when code or state is absent', async () => {
+    const { GET } = await import('@/app/api/connectors/google/callback/route');
+
+    const missingCode = await GET(callbackRequest({ state: 'some-state' }));
+    expect(missingCode.headers.get('location')).toBe(
+      `http://localhost${APP_ROUTES.SETTINGS_CONNECTORS}?error=oauth_missing_params`
+    );
+
+    const missingState = await GET(callbackRequest({ code: 'some-code' }));
+    expect(missingState.headers.get('location')).toBe(
+      `http://localhost${APP_ROUTES.SETTINGS_CONNECTORS}?error=oauth_missing_params`
+    );
+    expect(hoisted.serverFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a tampered state signature without exchanging the code or writing to the DB', async () => {
+    const validState = signGoogleOAuthState({
+      userId: 'db-user-1',
+      returnTo: '/app/settings/connectors',
+    });
+    const tampered =
+      validState.slice(0, -1) + (validState.at(-1) === 'a' ? 'b' : 'a');
+
+    const { GET } = await import('@/app/api/connectors/google/callback/route');
+    const response = await GET(
+      callbackRequest({ code: 'auth-code-123', state: tampered })
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      `http://localhost${APP_ROUTES.SETTINGS_CONNECTORS}?error=oauth_callback`
+    );
+    expect(hoisted.serverFetchMock).not.toHaveBeenCalled();
+    expect(hoisted.dbInsertMock).not.toHaveBeenCalled();
+    expect(hoisted.captureErrorMock).toHaveBeenCalledWith(
+      'Google OAuth callback failed',
+      expect.any(Error),
+      expect.objectContaining({ route: '/api/connectors/google/callback' })
+    );
+  });
+
+  it('rejects an expired (>15 min old) state without exchanging the code', async () => {
+    const now = Date.now();
+    const validState = signGoogleOAuthState({
+      userId: 'db-user-1',
+      returnTo: '/app/settings/connectors',
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now + 16 * 60 * 1000);
+    try {
+      const { GET } = await import(
+        '@/app/api/connectors/google/callback/route'
+      );
+      const response = await GET(
+        callbackRequest({ code: 'auth-code-123', state: validState })
+      );
+
+      expect(response.headers.get('location')).toBe(
+        `http://localhost${APP_ROUTES.SETTINGS_CONNECTORS}?error=oauth_callback`
+      );
+      expect(hoisted.serverFetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not write any connector rows when token exchange fails', async () => {
+    const validState = signGoogleOAuthState({
+      userId: 'db-user-1',
+      returnTo: '/app/settings/connectors',
+    });
+    hoisted.serverFetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => 'invalid_grant',
+    });
+
+    const { GET } = await import('@/app/api/connectors/google/callback/route');
+    const response = await GET(
+      callbackRequest({ code: 'auth-code-123', state: validState })
+    );
+
+    expect(response.headers.get('location')).toBe(
+      `http://localhost${APP_ROUTES.SETTINGS_CONNECTORS}?error=token_exchange`
+    );
+    expect(hoisted.serverFetchMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.dbInsertMock).not.toHaveBeenCalled();
+  });
+
+  it('does not write any connector rows when the userinfo fetch fails', async () => {
+    const validState = signGoogleOAuthState({
+      userId: 'db-user-1',
+      returnTo: '/app/settings/connectors',
+    });
+    hoisted.serverFetchMock
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce({ ok: false, status: 401 });
+
+    const { GET } = await import('@/app/api/connectors/google/callback/route');
+    const response = await GET(
+      callbackRequest({ code: 'auth-code-123', state: validState })
+    );
+
+    expect(response.headers.get('location')).toBe(
+      `http://localhost${APP_ROUTES.SETTINGS_CONNECTORS}?error=userinfo`
+    );
+    expect(hoisted.serverFetchMock).toHaveBeenCalledTimes(2);
+    expect(hoisted.dbInsertMock).not.toHaveBeenCalled();
+  });
+
+  it('exchanges the code with the correct payload and persists gmail + google_calendar rows', async () => {
+    const validState = signGoogleOAuthState({
+      userId: 'db-user-1',
+      returnTo: '/app/custom-return',
+    });
+    hoisted.serverFetchMock
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(userInfoResponse('dj@example.com'));
+    const inserts = trackInserts(['gmail-acct-id', 'calendar-acct-id']);
+    trackUpdates();
+
+    const { GET } = await import('@/app/api/connectors/google/callback/route');
+    const response = await GET(
+      callbackRequest({ code: 'auth-code-123', state: validState })
+    );
+
+    // --- Exchange request payload ---
+    expect(hoisted.serverFetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://oauth2.googleapis.com/token',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      })
+    );
+    const exchangeBody = new URLSearchParams(
+      (hoisted.serverFetchMock.mock.calls[0][1] as { body: string }).body
+    );
+    expect(exchangeBody.get('code')).toBe('auth-code-123');
+    expect(exchangeBody.get('client_id')).toBe(
+      'test-client-id.apps.googleusercontent.com'
+    );
+    expect(exchangeBody.get('client_secret')).toBe('test-client-secret');
+    expect(exchangeBody.get('redirect_uri')).toBe(
+      'http://localhost/api/connectors/google/callback'
+    );
+    expect(exchangeBody.get('grant_type')).toBe('authorization_code');
+
+    // --- Userinfo request uses the exchanged access token ---
+    expect(hoisted.serverFetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://www.googleapis.com/oauth2/v3/userinfo',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer ya29.real-access-token' },
+      })
+    );
+
+    // --- Both connector rows written, correctly identified ---
+    expect(inserts).toHaveLength(2);
+    expect(inserts[0].values).toMatchObject({
+      provider: 'gmail',
+      providerAccountId: 'dj@example.com',
+      capabilities: { canRead: true },
+    });
+    expect(inserts[1].values).toMatchObject({
+      provider: 'google_calendar',
+      providerAccountId: 'dj@example.com',
+      // calendar.events (write) scope was granted in tokenResponse() defaults.
+      capabilities: { canRead: true, canWrite: true },
+    });
+
+    // --- Redirect honors returnTo from the signed state ---
+    expect(response.headers.get('location')).toBe(
+      'http://localhost/app/custom-return?connected=google'
+    );
+  });
+
+  it('does not grant canWrite capability when the calendar.events (write) scope was not granted', async () => {
+    const validState = signGoogleOAuthState({
+      userId: 'db-user-1',
+      returnTo: '/app/settings/connectors',
+    });
+    hoisted.serverFetchMock
+      .mockResolvedValueOnce(
+        tokenResponse({
+          scope: [
+            'https://www.googleapis.com/auth/calendar.events.readonly',
+            'https://www.googleapis.com/auth/gmail.readonly',
+            'https://www.googleapis.com/auth/userinfo.email',
+          ].join(' '),
+        })
+      )
+      .mockResolvedValueOnce(userInfoResponse('readonly-dj@example.com'));
+    const inserts = trackInserts(['gmail-acct-id', 'calendar-acct-id']);
+    trackUpdates();
+
+    const { GET } = await import('@/app/api/connectors/google/callback/route');
+    await GET(callbackRequest({ code: 'auth-code-123', state: validState }));
+
+    expect(inserts).toHaveLength(2);
+    expect(inserts[1].values).toMatchObject({
+      provider: 'google_calendar',
+      capabilities: { canRead: true, canWrite: false },
+    });
+  });
+
+  it('persists AES-256-GCM encrypted tokens that are not plaintext and decrypt back to the original values', async () => {
+    hoisted.mockEnv.PII_ENCRYPTION_KEY =
+      'a-real-32-byte-plus-test-key-for-gcm-checks';
+    const validState = signGoogleOAuthState({
+      userId: 'db-user-1',
+      returnTo: '/app/settings/connectors',
+    });
+    hoisted.serverFetchMock
+      .mockResolvedValueOnce(
+        tokenResponse({
+          access_token: 'ya29.super-secret-access-token',
+          refresh_token: undefined, // keep this test to 2 real KDF calls
+        })
+      )
+      .mockResolvedValueOnce(userInfoResponse('encrypted-dj@example.com'));
+    trackInserts(['gmail-acct-id', 'calendar-acct-id']);
+    const updates = trackUpdates();
+
+    const { GET } = await import('@/app/api/connectors/google/callback/route');
+    const response = await GET(
+      callbackRequest({ code: 'auth-code-123', state: validState })
+    );
+
+    expect(response.headers.get('location')).toBe(
+      'http://localhost/app/settings/connectors?connected=google'
+    );
+    expect(updates).toHaveLength(2);
+
+    for (const update of updates) {
+      const encrypted = update.set.encryptedAccessToken as string;
+      expect(encrypted).toBeTruthy();
+      expect(encrypted).not.toBe('ya29.super-secret-access-token');
+      // AES-256-GCM combined format: iv:authTag:ciphertext.
+      expect(encrypted.split(':')).toHaveLength(3);
+    }
+
+    // The two stored ciphertexts must differ (random IV per encryption) even
+    // though both accounts were granted the identical access token.
+    expect(updates[0].set.encryptedAccessToken).not.toBe(
+      updates[1].set.encryptedAccessToken
+    );
+
+    // Round-trip through the REAL decryptPII to prove this is genuine
+    // AES-256-GCM, not a base64/no-op stand-in.
+    expect(decryptPII(updates[0].set.encryptedAccessToken as string)).toBe(
+      'ya29.super-secret-access-token'
+    );
+    expect(updates[0].set.encryptedRefreshToken).toBeNull();
+  }, 15_000);
+});

--- a/apps/web/tests/unit/api/connectors/google/disconnect.test.ts
+++ b/apps/web/tests/unit/api/connectors/google/disconnect.test.ts
@@ -1,0 +1,214 @@
+/**
+ * POST /api/connectors/google/disconnect
+ *
+ * Only `@/lib/auth/cached`, `@/lib/db`, and `@/lib/error-tracking` are mocked.
+ * `eq`/`and` from `drizzle-orm` are wrapped (not stubbed) with `vi.fn(actual)` so
+ * assertions can inspect the exact WHERE-clause targeting while the real
+ * schema/column objects and real SQL-builder logic still run underneath.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  getCachedAuthMock: vi.fn(),
+  dbSelectMock: vi.fn(),
+  dbUpdateMock: vi.fn(),
+  captureErrorMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: hoisted.getCachedAuthMock,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: { select: hoisted.dbSelectMock, update: hoisted.dbUpdateMock },
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: hoisted.captureErrorMock,
+}));
+
+vi.mock('drizzle-orm', async importOriginal => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...actual,
+    eq: vi.fn(actual.eq),
+    and: vi.fn(actual.and),
+  };
+});
+
+import { and, eq } from 'drizzle-orm';
+import { GOOGLE_CONNECTOR_PROVIDERS } from '@/lib/connectors/registry';
+import { connectorAccounts } from '@/lib/db/schema/connectors';
+
+interface UpdateCall {
+  readonly set: unknown;
+  readonly where: unknown;
+}
+
+function selectReturns(rows: Array<{ id: string }>) {
+  hoisted.dbSelectMock.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  });
+}
+
+function trackUpdates(): UpdateCall[] {
+  const calls: UpdateCall[] = [];
+  hoisted.dbUpdateMock.mockImplementation(() => ({
+    set: (setArg: unknown) => ({
+      where: (whereArg: unknown) => {
+        calls.push({ set: setArg, where: whereArg });
+        return Promise.resolve(undefined);
+      },
+    }),
+  }));
+  return calls;
+}
+
+function postRequest(body: unknown) {
+  return new Request('http://localhost/api/connectors/google/disconnect', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/connectors/google/disconnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getCachedAuthMock.mockResolvedValue({ userId: 'clerk_1' });
+    selectReturns([{ id: 'db-user-1' }]);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    hoisted.getCachedAuthMock.mockResolvedValue({ userId: null });
+
+    const { POST } = await import(
+      '@/app/api/connectors/google/disconnect/route'
+    );
+    const response = await POST(postRequest({}));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: 'Unauthorized' });
+    expect(hoisted.dbSelectMock).not.toHaveBeenCalled();
+    expect(hoisted.dbUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an invalid provider value', async () => {
+    const { POST } = await import(
+      '@/app/api/connectors/google/disconnect/route'
+    );
+    const response = await POST(postRequest({ provider: 'not_a_provider' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: 'Invalid payload' });
+    expect(hoisted.dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when no DB user row exists for the Clerk id', async () => {
+    selectReturns([]);
+    const updateCalls = trackUpdates();
+
+    const { POST } = await import(
+      '@/app/api/connectors/google/disconnect/route'
+    );
+    const response = await POST(postRequest({}));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({ error: 'User not found' });
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it('disconnects only the requested provider when body.provider is set', async () => {
+    const updateCalls = trackUpdates();
+
+    const { POST } = await import(
+      '@/app/api/connectors/google/disconnect/route'
+    );
+    const response = await POST(postRequest({ provider: 'gmail' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    expect(updateCalls).toHaveLength(1);
+
+    // WHERE must target this user's row AND the 'gmail' provider specifically —
+    // not 'google_calendar', and not an unscoped update.
+    expect(eq).toHaveBeenCalledWith(connectorAccounts.userId, 'db-user-1');
+    expect(eq).toHaveBeenCalledWith(connectorAccounts.provider, 'gmail');
+    expect(eq).not.toHaveBeenCalledWith(
+      connectorAccounts.provider,
+      'google_calendar'
+    );
+    expect(and).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnects both Google providers when body.provider is omitted', async () => {
+    const updateCalls = trackUpdates();
+    expect(GOOGLE_CONNECTOR_PROVIDERS).toEqual(['gmail', 'google_calendar']);
+
+    const { POST } = await import(
+      '@/app/api/connectors/google/disconnect/route'
+    );
+    const response = await POST(postRequest({}));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    // One update per provider in the shared Google OAuth bundle.
+    expect(updateCalls).toHaveLength(2);
+    expect(eq).toHaveBeenCalledWith(connectorAccounts.provider, 'gmail');
+    expect(eq).toHaveBeenCalledWith(
+      connectorAccounts.provider,
+      'google_calendar'
+    );
+  });
+
+  it('nulls the encrypted token columns and expiry on every disconnect update', async () => {
+    const updateCalls = trackUpdates();
+
+    const { POST } = await import(
+      '@/app/api/connectors/google/disconnect/route'
+    );
+    await POST(postRequest({ provider: 'google_calendar' }));
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].set).toEqual(
+      expect.objectContaining({
+        encryptedAccessToken: null,
+        encryptedRefreshToken: null,
+        tokenExpiresAt: null,
+        updatedAt: expect.any(Date),
+      })
+    );
+  });
+
+  it('returns 500 and captures the error when the update throws', async () => {
+    hoisted.dbUpdateMock.mockImplementation(() => ({
+      set: () => ({
+        where: () => Promise.reject(new Error('db write failed')),
+      }),
+    }));
+
+    const { POST } = await import(
+      '@/app/api/connectors/google/disconnect/route'
+    );
+    const response = await POST(postRequest({ provider: 'gmail' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({ error: 'Internal error' });
+    expect(hoisted.captureErrorMock).toHaveBeenCalledWith(
+      'Google connector disconnect failed',
+      expect.any(Error),
+      expect.objectContaining({ route: '/api/connectors/google/disconnect' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The Google OAuth connector control plane (`apps/web/app/api/connectors/google/{authorize,callback,disconnect}/route.ts`) had **zero tests** — adversarially confirmed by two independent verification passes. These routes handle signed OAuth state, token exchange, and encrypted token storage; a regression here (skipped state verification, plaintext tokens, token residue after disconnect) would ship silently.

23 tests across three files (`apps/web/tests/unit/api/connectors/google/`), exercising the **real** helpers — HMAC state signing/verification, AES-256-GCM `encryptPII`/`decryptPII`, real drizzle `eq`/`and` WHERE construction. Only `db`, `server-fetch`, `error-tracking`, and env are mocked:

- **authorize**: sign-in redirect when unauthenticated; full OAuth URL assertions (client_id, redirect_uri, `access_type=offline`, all 4 readonly scopes); state signed for the **DB user id** and decoded via the real verifier; dev seed-fixtures fallback when `GOOGLE_OAUTH_CLIENT_ID` is missing
- **callback**: tampered and expired (>15 min, fake timers) state rejected **before** any token exchange; exact exchange POST payload; both `gmail` + `google_calendar` rows persisted; `canWrite` scope gating; encrypted-at-rest round-trip (ciphertext ≠ plaintext, random IVs, decrypts back); **no partial DB writes** on token-exchange or userinfo failure
- **disconnect**: 401/400/404 branches; provider WHERE targeting (single vs both); `encryptedAccessToken`/`encryptedRefreshToken`/`tokenExpiresAt` actually nulled (token-residue check)

Part of JOV-4220 (test-coverage loop batch 3 — confirmed-uncovered priority-5 security surface).

## Verification

- `pnpm --filter web exec vitest run tests/unit/api/connectors/` → **23/23 pass**
- typecheck + biome clean (pre-commit hooks)
- **Frontier-model mutation verification: 11/11 cumulative mutants killed** — 4 by the coder's self-check (dropped auth check, skipped state verification, missing token nulls, unencrypted storage) + 7 independent (wrong-identity state signing, dropped scope, removed expiry check, missing calendar row, hardcoded canWrite, unfiltered disconnect WHERE, and a camouflaged partial-write that preserved the error redirect — killed purely by the no-partial-state assertion)

## Notes

- No production bugs found: state verification, encryption at rest, and failure paths all behave as documented.
- bug-to-test: N/A — tests-only change. Cost impact: none. No UI change.