### PR TITLE
test(waitlist): mutation-verified invite-token issuance coverage (JOV-4220)

### DIFF
--- a/apps/web/tests/unit/lib/waitlist/email-jobs.test.ts
+++ b/apps/web/tests/unit/lib/waitlist/email-jobs.test.ts
@@ -1,6 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { encryptPII } from '@/lib/utils/pii-encryption';
-import { processWaitlistEmailJob } from '@/lib/waitlist/email-jobs';
+import crypto from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { decryptPII, encryptPII } from '@/lib/utils/pii-encryption';
+import {
+  enqueueWaitlistApprovalInviteEmail,
+  processWaitlistEmailJob,
+} from '@/lib/waitlist/email-jobs';
 import { hashWaitlistInviteToken } from '@/lib/waitlist/tokens';
 
 const mockSendNotification = vi.hoisted(() => vi.fn());
@@ -8,6 +12,20 @@ const mockSendNotification = vi.hoisted(() => vi.fn());
 vi.mock('@/lib/notifications/service', () => ({
   sendNotification: mockSendNotification,
 }));
+
+// PII encryption derives its key via scrypt with a deliberately expensive
+// work factor (N=2^17). Pre-derive it once and stub scryptSync so the
+// real-encryption tests below exercise real AES-256-GCM encrypt/decrypt
+// without paying the key-derivation cost on every call (mirrors
+// tests/lib/analytics/pii-encryption.test.ts).
+const FAST_TEST_KEY = crypto.randomBytes(32);
+const originalScryptSync = crypto.scryptSync.bind(crypto);
+vi.spyOn(crypto, 'scryptSync').mockImplementation((...args: unknown[]) => {
+  if (args[1] === 'jovie-pii-salt' && args[2] === 32) {
+    return FAST_TEST_KEY;
+  }
+  return originalScryptSync(...(args as Parameters<typeof crypto.scryptSync>));
+});
 
 function createTxMock(entryRows: Array<Record<string, unknown>>) {
   const updateSet = vi.fn(() => ({
@@ -112,5 +130,292 @@ describe('processWaitlistEmailJob', () => {
       })
     ).rejects.toThrow('Approval invite token already issued');
     expect(mockSendNotification).not.toHaveBeenCalled();
+  });
+});
+
+// -----------------------------------------------------------------------
+// issueWaitlistInviteToken (private) via enqueueWaitlistApprovalInviteEmail
+// -----------------------------------------------------------------------
+//
+// This is the *issuance* path (admin approves an entry / resends an invite),
+// as opposed to `processWaitlistEmailJob` above which is the *consumer* path
+// (the queued job actually sending the email). Every real call site
+// (admin approve route, admin resend-invite route, auto-accept) mocks
+// `enqueueWaitlistApprovalInviteEmail` away entirely, so the token
+// generation / reissuance / persistence / encryption logic here has zero
+// real coverage without these tests.
+
+const ENTRY_ID = '22222222-2222-4222-8222-222222222222';
+const TEST_ENCRYPTION_KEY = 'test-key-for-encryption-32-chars!';
+
+interface FakeEntryRow {
+  id: string;
+  status: string;
+  inviteTokenHash: string | null;
+  inviteTokenExpiresAt: Date | null;
+}
+
+function createIssueTokenTxMock(entryRow: FakeEntryRow | undefined) {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
+
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        for: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue(entryRow ? [entryRow] : []),
+        })),
+      })),
+    })),
+  }));
+
+  const update = vi.fn(() => ({
+    set: vi.fn((values: Record<string, unknown>) => {
+      updateCalls.push(values);
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    }),
+  }));
+
+  const insert = vi.fn(() => ({
+    values: vi.fn((values: Record<string, unknown>) => {
+      insertCalls.push(values);
+      return {
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([{ id: 'job-abc123' }]),
+        })),
+      };
+    }),
+  }));
+
+  const tx = { select, update, insert } as unknown as Parameters<
+    typeof enqueueWaitlistApprovalInviteEmail
+  >[0];
+
+  return { tx, updateCalls, insertCalls };
+}
+
+describe('enqueueWaitlistApprovalInviteEmail (issueWaitlistInviteToken)', () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.PII_ENCRYPTION_KEY;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.PII_ENCRYPTION_KEY;
+    } else {
+      process.env.PII_ENCRYPTION_KEY = originalKey;
+    }
+    vi.useRealTimers();
+  });
+
+  it.each([
+    'new',
+    'chat_started',
+    'qualified',
+    'waitlisted',
+    'claimed',
+    'signed_up',
+    'rejected',
+    'expired',
+    'blocked',
+  ])('does not issue a token or enqueue an email for non-redeemable status %s', async status => {
+    const { tx, updateCalls, insertCalls } = createIssueTokenTxMock({
+      id: ENTRY_ID,
+      status,
+      inviteTokenHash: null,
+      inviteTokenExpiresAt: null,
+    });
+
+    const result = await enqueueWaitlistApprovalInviteEmail(tx, ENTRY_ID);
+
+    expect(result).toBeNull();
+    expect(updateCalls).toHaveLength(0);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('returns null and writes nothing when the entry does not exist', async () => {
+    const { tx, updateCalls, insertCalls } = createIssueTokenTxMock(undefined);
+
+    const result = await enqueueWaitlistApprovalInviteEmail(tx, ENTRY_ID);
+
+    expect(result).toBeNull();
+    expect(updateCalls).toHaveLength(0);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('skips re-issuance when a still-valid unexpired token exists and force is not set', async () => {
+    const now = new Date('2026-01-01T00:00:00.000Z');
+    const stillValidExpiry = new Date(now.getTime() + 1); // 1ms in the future
+    const { tx, updateCalls, insertCalls } = createIssueTokenTxMock({
+      id: ENTRY_ID,
+      status: 'invited',
+      inviteTokenHash: 'existing-hash',
+      inviteTokenExpiresAt: stillValidExpiry,
+    });
+
+    const result = await enqueueWaitlistApprovalInviteEmail(tx, ENTRY_ID, {
+      now,
+    });
+
+    expect(result).toBeNull();
+    expect(updateCalls).toHaveLength(0);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('reissues and enqueues when force=true even though a valid unexpired token exists', async () => {
+    process.env.PII_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    const now = new Date('2026-01-01T00:00:00.000Z');
+    const stillValidExpiry = new Date(now.getTime() + 1);
+    const { tx, updateCalls, insertCalls } = createIssueTokenTxMock({
+      id: ENTRY_ID,
+      status: 'invited',
+      inviteTokenHash: 'existing-hash',
+      inviteTokenExpiresAt: stillValidExpiry,
+    });
+
+    const result = await enqueueWaitlistApprovalInviteEmail(tx, ENTRY_ID, {
+      now,
+      force: true,
+    });
+
+    expect(result).toBe('job-abc123');
+    expect(updateCalls).toHaveLength(1);
+    const updatePayload = updateCalls[0] as {
+      inviteTokenHash: string;
+      inviteTokenExpiresAt: Date;
+      inviteTokenRedeemedAt: null;
+      updatedAt: Date;
+    };
+    expect(updatePayload.inviteTokenHash).not.toBe('existing-hash');
+    expect(updatePayload.inviteTokenExpiresAt).toEqual(
+      new Date('2026-01-15T00:00:00.000Z')
+    );
+    expect(updatePayload.inviteTokenRedeemedAt).toBeNull();
+    expect(updatePayload.updatedAt).toEqual(now);
+
+    expect(insertCalls).toHaveLength(1);
+    const jobPayload = insertCalls[0]?.payload as {
+      entryId: string;
+      type: string;
+      encryptedInviteToken: string;
+    };
+    expect(jobPayload.entryId).toBe(ENTRY_ID);
+    expect(jobPayload.type).toBe('approval_invite');
+
+    // The token handed to the email job must be encrypted, not plaintext,
+    // and must decrypt back to the raw token whose hash was just persisted.
+    expect(jobPayload.encryptedInviteToken).not.toBe(
+      updatePayload.inviteTokenHash
+    );
+    const decryptedToken = decryptPII(jobPayload.encryptedInviteToken);
+    expect(decryptedToken).toBeTruthy();
+    expect(jobPayload.encryptedInviteToken).not.toBe(decryptedToken);
+    expect(hashWaitlistInviteToken(decryptedToken as string)).toBe(
+      updatePayload.inviteTokenHash
+    );
+  });
+
+  it('issues a new token and persists only the hash when none exists yet', async () => {
+    process.env.PII_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    const now = new Date('2026-02-01T00:00:00.000Z');
+    const { tx, updateCalls, insertCalls } = createIssueTokenTxMock({
+      id: ENTRY_ID,
+      status: 'approved',
+      inviteTokenHash: null,
+      inviteTokenExpiresAt: null,
+    });
+
+    const result = await enqueueWaitlistApprovalInviteEmail(tx, ENTRY_ID, {
+      now,
+    });
+
+    expect(result).toBe('job-abc123');
+    expect(updateCalls).toHaveLength(1);
+    const updatePayload = updateCalls[0] as {
+      inviteTokenHash: string;
+      inviteTokenExpiresAt: Date;
+    };
+    expect(updatePayload.inviteTokenExpiresAt).toEqual(
+      new Date('2026-02-15T00:00:00.000Z')
+    );
+
+    const jobPayload = insertCalls[0]?.payload as {
+      encryptedInviteToken: string;
+    };
+    const decryptedToken = decryptPII(
+      jobPayload.encryptedInviteToken
+    ) as string;
+    expect(decryptedToken).toBeTruthy();
+
+    // Persisted DB value must be the hash, never the raw token.
+    expect(updatePayload.inviteTokenHash).not.toBe(decryptedToken);
+    expect(updatePayload.inviteTokenHash).toBe(
+      hashWaitlistInviteToken(decryptedToken)
+    );
+
+    // dedupKey embeds the new token's hash, tying the enqueue to this issuance.
+    expect(insertCalls[0]?.dedupKey).toBe(
+      `waitlist_email:approval_invite:${ENTRY_ID}:token:${updatePayload.inviteTokenHash}`
+    );
+  });
+
+  it('treats a token exactly at its expiry as expired and reissues', async () => {
+    const now = new Date('2026-03-01T00:00:00.000Z');
+    const { tx, updateCalls, insertCalls } = createIssueTokenTxMock({
+      id: ENTRY_ID,
+      status: 'invited',
+      inviteTokenHash: 'old-hash',
+      inviteTokenExpiresAt: new Date(now.getTime()), // exactly equal, not strictly greater
+    });
+
+    const result = await enqueueWaitlistApprovalInviteEmail(tx, ENTRY_ID, {
+      now,
+    });
+
+    expect(result).toBe('job-abc123');
+    expect(updateCalls).toHaveLength(1);
+    expect(insertCalls).toHaveLength(1);
+    const updatePayload = updateCalls[0] as { inviteTokenHash: string };
+    expect(updatePayload.inviteTokenHash).not.toBe('old-hash');
+  });
+
+  it('treats a token past its expiry as expired and reissues', async () => {
+    const now = new Date('2026-03-01T00:00:00.000Z');
+    const { tx, updateCalls, insertCalls } = createIssueTokenTxMock({
+      id: ENTRY_ID,
+      status: 'invited',
+      inviteTokenHash: 'old-hash',
+      inviteTokenExpiresAt: new Date(now.getTime() - 1), // 1ms in the past
+    });
+
+    const result = await enqueueWaitlistApprovalInviteEmail(tx, ENTRY_ID, {
+      now,
+    });
+
+    expect(result).toBe('job-abc123');
+    expect(updateCalls).toHaveLength(1);
+    expect(insertCalls).toHaveLength(1);
+  });
+
+  it('uses the current time when no now override is provided', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-01T00:00:00.000Z'));
+
+    const { tx, updateCalls } = createIssueTokenTxMock({
+      id: ENTRY_ID,
+      status: 'invited',
+      inviteTokenHash: null,
+      inviteTokenExpiresAt: null,
+    });
+
+    await enqueueWaitlistApprovalInviteEmail(tx, ENTRY_ID);
+
+    const updatePayload = updateCalls[0] as { inviteTokenExpiresAt: Date };
+    expect(updatePayload.inviteTokenExpiresAt).toEqual(
+      new Date('2026-04-15T00:00:00.000Z')
+    );
   });
 });


### PR DESCRIPTION
## Summary

`issueWaitlistInviteToken` (private; reachable only via `enqueueWaitlistApprovalInviteEmail`, which every call site mocks away) had **zero direct coverage** — adversarially confirmed. 16 new tests extend `apps/web/tests/unit/lib/waitlist/email-jobs.test.ts`:

- Redeemable-status gate: all 9 non-redeemable statuses produce no token, no writes, no job
- Skip re-issuance while a valid unexpired token exists; `force=true` rotates the hash, resets `inviteTokenRedeemedAt`, sets the +14-day expiry
- Persisted value is the token **hash**, never the raw token — proven by round-trip: `decryptPII(job payload)` → `hashWaitlistInviteToken` equals the persisted hash (real AES-256-GCM with a fast pre-derived key, mirroring the existing pii-encryption test pattern)
- Expiry boundary: exactly-at-expiry counts as expired (strict `>`), 1ms-past reissues, default-`now` path via fake timers
- `dedupKey` format pins `entryId` + token hash

Part of JOV-4220 (test-coverage loop batch 4 — confirmed-uncovered priority-5 path).

## Verification

- New/extended suite: **18/18 pass** (~130ms); `tests/unit/api/waitlist/` regression: green
- typecheck (cache-cleared) + biome clean
- **Frontier-model mutation verification: 10/10 cumulative mutants killed** — 4 coder self-check (dropped status guard, ignored force, raw-token persistence, inverted expiry) + 6 independent (old-hash persistence on reissue, 14d→1d window, missing redeemed-at reset, dedupKey without hash, enqueue-on-skip, hash-encrypted-instead-of-token). The enqueue-on-skip mutant failed exactly one test — the skip test is precisely scoped.

## Notes

- No production bugs found; issuance logic is correct as written.
- bug-to-test: N/A — tests-only change. Cost impact: none. No UI change.