### PR TITLE
test(stripe): make webhook duplicate-suppression assertions real (JOV-4220)

### DIFF
--- a/apps/web/tests/unit/api/stripe/webhooks.idempotency.test.ts
+++ b/apps/web/tests/unit/api/stripe/webhooks.idempotency.test.ts
@@ -57,6 +57,18 @@ describe('/api/stripe/webhooks - Idempotency Handling', () => {
 
     mockConstructEvent.mockReturnValue(event);
 
+    // Register a REAL handler so the "handler not called" assertion below is
+    // meaningful. Without this, mockGetHandler stays null (per beforeEach)
+    // and the handler could never be invoked regardless of whether the
+    // processedAt skip-check exists — the assertion would pass trivially
+    // even if that skip-check were deleted from the route.
+    const mockHandler = {
+      eventTypes: ['checkout.session.completed'] as const,
+      handle: mockHandlerHandle,
+    };
+    mockGetHandler.mockReturnValue(mockHandler);
+    mockHandlerHandle.mockResolvedValue({ success: true });
+
     // Set up to return an already-processed event
     setSkipProcessing(true);
 
@@ -79,8 +91,51 @@ describe('/api/stripe/webhooks - Idempotency Handling', () => {
     expect(mockDbInsert).toHaveBeenCalled();
     // Select was called to check existing record
     expect(mockDbSelect).toHaveBeenCalled();
-    // Should not call handler for duplicate events
+    // Should not call the handler for an already-processed duplicate, even
+    // though a real handler IS registered and would run if the processedAt
+    // skip-check were removed from the route.
     expect(mockHandlerHandle).not.toHaveBeenCalled();
+  });
+
+  it('invokes the handler at most once when the same event is delivered twice (unprocessed then duplicate)', async () => {
+    const event = {
+      id: 'evt_dedup_once',
+      type: 'checkout.session.completed',
+      created: Math.floor(Date.now() / 1000),
+      data: { object: { id: 'cs_dedup_once' } },
+    } as any;
+
+    mockConstructEvent.mockReturnValue(event);
+
+    const mockHandler = {
+      eventTypes: ['checkout.session.completed'] as const,
+      handle: mockHandlerHandle,
+    };
+    mockGetHandler.mockReturnValue(mockHandler);
+    mockHandlerHandle.mockResolvedValue({ success: true });
+
+    const makeRequest = () =>
+      new NextRequest('http://localhost:3000/api/stripe/webhooks', {
+        method: 'POST',
+        body: 'test-body',
+        headers: { 'stripe-signature': 'sig_test' },
+      });
+
+    // First delivery: brand-new event — insert succeeds, handler runs once.
+    setSkipProcessing(false);
+    const firstResponse = await POST(makeRequest());
+    expect(firstResponse.status).toBe(200);
+    expect((await firstResponse.json()).received).toBe(true);
+    expect(mockHandlerHandle).toHaveBeenCalledTimes(1);
+
+    // Second delivery of the SAME event: now a duplicate with processedAt
+    // set — the handler must not be invoked again (at-most-once guarantee).
+    setSkipProcessing(true);
+    const secondResponse = await POST(makeRequest());
+    expect(secondResponse.status).toBe(200);
+    expect((await secondResponse.json()).received).toBe(true);
+
+    expect(mockHandlerHandle).toHaveBeenCalledTimes(1);
   });
 
   it('retries processing for existing unprocessed event (prior handler failure path)', async () => {


### PR DESCRIPTION
## Summary

The re-verification pass proved the webhook idempotency test **hollow**: `mockGetHandler` stayed `null` in the duplicate-events describe block, so `expect(mockHandlerHandle).not.toHaveBeenCalled()` passed trivially — **deleting the entire `processedAt` skip-check in `route.ts` kept the suite green**. The exact failure mode this loop exists to purge.

Changes to `apps/web/tests/unit/api/stripe/webhooks.idempotency.test.ts` (7 → 9 tests):
- Duplicate-events test now registers a real handler and asserts it is NOT invoked for an already-processed event (200 `received:true` pinned)
- New composite: the same event delivered twice → handler invoked **exactly once** across both deliveries

Part of JOV-4220 (test-coverage loop batch 5A — covered-weak strengthening).

## Verification

- Suite 9/9; full stripe API suite **55/55**, no collateral changes
- Coder self-check: deleting the `processedAt` skip-check fails exactly the 2 strengthened tests (previously: zero failures)
- **Frontier mutation gate 3/3 killed**: inverted skip condition (kills duplicate + retry tests), neutralized existing-event detection (composite catches `called 2 times`), 500-on-duplicate response mutant (shape assertion)

## Notes
- bug-to-test: N/A — tests-only. Cost impact: none. No UI change.