### PR TITLE
fix(design-system): clear bareTextBlack ratchet regression blocking merge queue

### DIFF
--- a/apps/web/components/features/release/SmartLinkAudioPreview.tsx
+++ b/apps/web/components/features/release/SmartLinkAudioPreview.tsx
@@ -102,7 +102,7 @@ export function SmartLinkAudioPreview({
           aria-pressed={isPlaying}
           aria-busy={isLoading || undefined}
           disabled={isLoading}
-          className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white/90 text-black transition-colors duration-fast hover:bg-white active:scale-[var(--scale-press)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70 disabled:opacity-70 motion-reduce:active:scale-100'
+          className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white/90 text-black dark:text-black transition-colors duration-fast hover:bg-white active:scale-[var(--scale-press)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70 disabled:opacity-70 motion-reduce:active:scale-100'
         >
           {isLoading ? (
             <Loader2


### PR DESCRIPTION
## Systemic CI unblock

On current \`main\`, the contrast ratchet reports \`bareTextBlack: 2 > baseline 1\`. This fails the **Structural Contract** lane of \`ci-fast\` on **every PR rebased onto main**, silently blocking the entire Graphite merge queue — agents' local typecheck/biome pass while CI stays red on `ci-fast`.

### Root cause
The SmartLink audio-preview play button added in #13876 (\`SmartLinkAudioPreview.tsx\`) introduced a bare \`text-black\` with no \`dark:\` counterpart. The ratchet baseline (1) was not updated, so the second violation trips the regression guard.

### Fix
The button is a fixed white circle (\`bg-white/90\`) overlaid on album artwork — always white background, always black icon in both themes. A theme-flipping semantic foreground token would make the icon invisible in dark mode, so the correct fix is an explicit \`dark:text-black\` that documents the intended theme-independence and satisfies both the ratchet and the \`no-hardcoded-theme-colors\` eslint rule. Count returns to baseline 1.

### Verification
- \`node apps/web/scripts/lint-contrast-ratchet.mjs\` → exit 0, \`bareTextBlack: 1 (baseline: 1)\`
- \`biome check\` clean on the file
- No visual change (identical black icon on white button in both themes)

Unblocks: #13853, #14003, #13979, and every other PR failing \`ci-fast\` → Structural Contract → contrast-ratchet after rebasing onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)