### PR TITLE
test(admin): mutation-verified investor-token CRUD + rate-limit coverage (JOV-4220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- [internal] Mutation-verified tests for investor-token admin CRUD + portal rate limit — PATCH allowlist (token not writable), soft-delete-only DELETE, 429 anti-enumeration with floored Retry-After (JOV-4220)
 - **Homepage labels now meet WCAG AA contrast:** the distributor trust-strip and closed-loop labels use the readable tertiary text token instead of the low-contrast quaternary token.
 - [internal] **Design-system drift ratchet tightened 3044→2609 (JOV-4211)**: converted 29 exact-match typography arbitraries to tokens across 18 dashboard/admin/organism/molecule files (`leading-[16px]`→`leading-4`, `tracking-[-0.01em]`→`tracking-tight`, `tracking-[-0.02em]`→`tracking-tighter`, `tracking-[0.01em]`→`tracking-wide`) and re-measured the baseline to the true count, removing ~406 counts of stale regression headroom.
 - [internal] **Desktop renderer recovery (JOV-3595)**: recover from hosted loads that return HTTP 200 but never boot React, and route crashed or unresponsive renderers to the visible recovery shell instead of a permanent black window.

--- a/apps/web/tests/unit/api/admin/investors-links-id.test.ts
+++ b/apps/web/tests/unit/api/admin/investors-links-id.test.ts
@@ -1,0 +1,284 @@
+import { NextResponse } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireAdmin = vi.hoisted(() => vi.fn());
+const mockEq = vi.hoisted(() => vi.fn(() => 'eq-clause'));
+
+const { mockDb, mockUpdate, mockSet, mockReturning, mockDelete } = vi.hoisted(
+  () => {
+    const mockReturning = vi.fn();
+    const mockWhere = vi.fn(() => ({ returning: mockReturning }));
+    const mockSet = vi.fn(() => ({ where: mockWhere }));
+    const mockUpdate = vi.fn(() => ({ set: mockSet }));
+    // Tracked separately so a test can assert DELETE never calls a hard
+    // row-delete method (the route only ever calls db.update()).
+    const mockDelete = vi.fn();
+
+    return {
+      mockDb: { update: mockUpdate, delete: mockDelete },
+      mockUpdate,
+      mockSet,
+      mockReturning,
+      mockDelete,
+    };
+  }
+);
+
+vi.mock('@/lib/admin/middleware', () => ({
+  requireAdmin: mockRequireAdmin,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: mockDb,
+}));
+
+vi.mock('@/lib/db/schema/investors', () => ({
+  investorLinks: {
+    id: 'investor_links.id',
+    label: 'investor_links.label',
+    investorName: 'investor_links.investor_name',
+    email: 'investor_links.email',
+    stage: 'investor_links.stage',
+    notes: 'investor_links.notes',
+    isActive: 'investor_links.is_active',
+    expiresAt: 'investor_links.expires_at',
+    token: 'investor_links.token',
+    updatedAt: 'investor_links.updated_at',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: mockEq,
+}));
+
+import { DELETE, PATCH } from '@/app/api/admin/investors/links/[id]/route';
+
+function patchRequest(body: unknown) {
+  return new Request('http://localhost/api/admin/investors/links/link-1', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('PATCH /api/admin/investors/links/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(null); // authorized by default
+    mockReturning.mockResolvedValue([
+      { id: 'link-1', label: 'Updated Label', stage: 'engaged' },
+    ]);
+  });
+
+  it('rejects the request before touching the database when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    );
+
+    const res = await PATCH(
+      patchRequest({ label: 'New Label' }),
+      paramsFor('link-1')
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(data.error).toBe('Forbidden');
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('passes allowlisted fields through to the update payload', async () => {
+    const expiresAt = '2027-01-01T00:00:00.000Z';
+
+    await PATCH(
+      patchRequest({
+        label: 'New Label',
+        investorName: 'Jane Doe',
+        email: 'jane@example.com',
+        stage: 'engaged',
+        notes: 'Follow up next week',
+        isActive: false,
+        expiresAt,
+      }),
+      paramsFor('link-1')
+    );
+
+    expect(mockSet).toHaveBeenCalledTimes(1);
+    const updatePayload = mockSet.mock.calls[0][0];
+
+    expect(updatePayload).toMatchObject({
+      label: 'New Label',
+      investorName: 'Jane Doe',
+      email: 'jane@example.com',
+      stage: 'engaged',
+      notes: 'Follow up next week',
+      isActive: false,
+      expiresAt,
+    });
+    expect(updatePayload.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('ignores a `token` field in the body — it is not in the update payload', async () => {
+    await PATCH(
+      patchRequest({
+        label: 'New Label',
+        token: 'attacker-supplied-token',
+      }),
+      paramsFor('link-1')
+    );
+
+    const updatePayload = mockSet.mock.calls[0][0];
+
+    expect(updatePayload).not.toHaveProperty('token');
+    expect(Object.keys(updatePayload).sort()).toEqual(
+      ['label', 'updatedAt'].sort()
+    );
+  });
+
+  it('ignores any other unlisted field in the body', async () => {
+    await PATCH(
+      patchRequest({
+        label: 'New Label',
+        id: 'attacker-supplied-id',
+        engagementScore: 999999,
+        createdAt: '2000-01-01T00:00:00.000Z',
+      }),
+      paramsFor('link-1')
+    );
+
+    const updatePayload = mockSet.mock.calls[0][0];
+
+    expect(updatePayload).not.toHaveProperty('id');
+    expect(updatePayload).not.toHaveProperty('engagementScore');
+    expect(updatePayload).not.toHaveProperty('createdAt');
+    expect(Object.keys(updatePayload).sort()).toEqual(
+      ['label', 'updatedAt'].sort()
+    );
+  });
+
+  it('only writes updatedAt when the body has no allowlisted fields', async () => {
+    await PATCH(patchRequest({ token: 'nope' }), paramsFor('link-1'));
+
+    const updatePayload = mockSet.mock.calls[0][0];
+    expect(Object.keys(updatePayload)).toEqual(['updatedAt']);
+  });
+
+  it('returns 404 when the link id does not exist and does not leak an update body', async () => {
+    mockReturning.mockResolvedValue([]);
+
+    const res = await PATCH(
+      patchRequest({ label: 'New Label' }),
+      paramsFor('missing-id')
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.error).toBe('Link not found');
+  });
+
+  it('returns the updated row as { link } with 200 on success', async () => {
+    const updatedRow = { id: 'link-1', label: 'New Label', stage: 'engaged' };
+    mockReturning.mockResolvedValue([updatedRow]);
+
+    const res = await PATCH(
+      patchRequest({ label: 'New Label' }),
+      paramsFor('link-1')
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ link: updatedRow });
+  });
+});
+
+describe('DELETE /api/admin/investors/links/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(null); // authorized by default
+    mockReturning.mockResolvedValue([
+      { id: 'link-1', isActive: false, label: 'Acme Ventures' },
+    ]);
+  });
+
+  it('rejects the request before touching the database when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    );
+
+    const res = await DELETE(
+      new Request('http://localhost/api/admin/investors/links/link-1', {
+        method: 'DELETE',
+      }),
+      paramsFor('link-1')
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('soft-deletes via db.update({ isActive: false }) — never a hard db.delete()', async () => {
+    await DELETE(
+      new Request('http://localhost/api/admin/investors/links/link-1', {
+        method: 'DELETE',
+      }),
+      paramsFor('link-1')
+    );
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockDelete).not.toHaveBeenCalled();
+
+    const updatePayload = mockSet.mock.calls[0][0];
+    expect(updatePayload.isActive).toBe(false);
+    expect(updatePayload.updatedAt).toBeInstanceOf(Date);
+    // Exactly these two keys — no accidental extra field wipe.
+    expect(Object.keys(updatePayload).sort()).toEqual(
+      ['isActive', 'updatedAt'].sort()
+    );
+  });
+
+  it('scopes the update to the requested id via eq()', async () => {
+    await DELETE(
+      new Request('http://localhost/api/admin/investors/links/link-1', {
+        method: 'DELETE',
+      }),
+      paramsFor('link-1')
+    );
+
+    expect(mockEq).toHaveBeenCalledWith('investor_links.id', 'link-1');
+  });
+
+  it('returns 404 when the link id does not exist', async () => {
+    mockReturning.mockResolvedValue([]);
+
+    const res = await DELETE(
+      new Request('http://localhost/api/admin/investors/links/missing-id', {
+        method: 'DELETE',
+      }),
+      paramsFor('missing-id')
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.error).toBe('Link not found');
+  });
+
+  it('returns the deactivated row as { link } with 200 on success', async () => {
+    const deactivatedRow = { id: 'link-1', isActive: false };
+    mockReturning.mockResolvedValue([deactivatedRow]);
+
+    const res = await DELETE(
+      new Request('http://localhost/api/admin/investors/links/link-1', {
+        method: 'DELETE',
+      }),
+      paramsFor('link-1')
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ link: deactivatedRow });
+  });
+});

--- a/apps/web/tests/unit/api/admin/investors-links.test.ts
+++ b/apps/web/tests/unit/api/admin/investors-links.test.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireAdmin = vi.hoisted(() => vi.fn());
+const mockDesc = vi.hoisted(() => vi.fn(() => 'desc-clause'));
+
+const { mockDb, mockInsert, mockValues, mockReturning } = vi.hoisted(() => {
+  const mockReturning = vi.fn();
+  const mockValues = vi.fn(() => ({ returning: mockReturning }));
+  const mockInsert = vi.fn(() => ({ values: mockValues }));
+
+  const mockOrderBy = vi.fn();
+  const mockFrom = vi.fn(() => ({ orderBy: mockOrderBy }));
+  const mockSelect = vi.fn(() => ({ from: mockFrom }));
+
+  return {
+    mockDb: { insert: mockInsert, select: mockSelect },
+    mockInsert,
+    mockValues,
+    mockReturning,
+  };
+});
+
+vi.mock('@/lib/admin/middleware', () => ({
+  requireAdmin: mockRequireAdmin,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: mockDb,
+}));
+
+vi.mock('@/lib/db/schema/investors', () => ({
+  investorLinks: {
+    id: 'investor_links.id',
+    token: 'investor_links.token',
+    label: 'investor_links.label',
+    investorName: 'investor_links.investor_name',
+    email: 'investor_links.email',
+    createdAt: 'investor_links.created_at',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  desc: mockDesc,
+}));
+
+import { POST } from '@/app/api/admin/investors/links/route';
+
+function postRequest(body: unknown) {
+  return new Request('http://localhost/api/admin/investors/links', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/admin/investors/links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(null); // authorized by default
+    mockReturning.mockResolvedValue([
+      {
+        id: 'link-1',
+        token: 'placeholder-token',
+        label: 'Acme Ventures',
+        investorName: null,
+        email: null,
+      },
+    ]);
+  });
+
+  it('rejects the request before touching the database when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    );
+
+    const res = await POST(postRequest({ label: 'Acme Ventures' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(data.error).toBe('Forbidden');
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing label with 400 and does not insert', async () => {
+    const res = await POST(postRequest({ investorName: 'Jane' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBe('Label is required');
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string label with 400 and does not insert', async () => {
+    const res = await POST(postRequest({ label: 42 }));
+
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('generates a non-trivial token, trims the label, and nulls empty optional fields', async () => {
+    const res = await POST(
+      postRequest({
+        label: '  Acme Ventures  ',
+        investorName: '   ',
+        email: '',
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockValues).toHaveBeenCalledTimes(1);
+
+    const insertPayload = mockValues.mock.calls[0][0];
+
+    // Token must be present, non-trivial, and URL-safe (base-36 alphabet).
+    expect(typeof insertPayload.token).toBe('string');
+    expect(insertPayload.token.length).toBeGreaterThan(0);
+    expect(insertPayload.token).toMatch(/^[0-9a-z]+$/);
+
+    expect(insertPayload.label).toBe('Acme Ventures'); // trimmed
+    expect(insertPayload.investorName).toBeNull(); // whitespace-only -> null
+    expect(insertPayload.email).toBeNull(); // empty string -> null
+  });
+
+  it('preserves a real investorName/email instead of nulling them', async () => {
+    await POST(
+      postRequest({
+        label: 'Acme Ventures',
+        investorName: '  Jane Doe  ',
+        email: '  jane@example.com  ',
+      })
+    );
+
+    const insertPayload = mockValues.mock.calls[0][0];
+
+    expect(insertPayload.investorName).toBe('Jane Doe');
+    expect(insertPayload.email).toBe('jane@example.com');
+  });
+
+  it('generates a different token on each call (not a hardcoded/predictable value)', async () => {
+    await POST(postRequest({ label: 'Acme Ventures' }));
+    const firstToken = mockValues.mock.calls[0][0].token;
+
+    await POST(postRequest({ label: 'Acme Ventures' }));
+    const secondToken = mockValues.mock.calls[1][0].token;
+
+    expect(firstToken).not.toBe(secondToken);
+  });
+
+  it('returns the inserted row from .returning() as { link } with 201', async () => {
+    const insertedRow = {
+      id: 'link-42',
+      token: 'abc123',
+      label: 'Acme Ventures',
+      investorName: null,
+      email: null,
+    };
+    mockReturning.mockResolvedValue([insertedRow]);
+
+    const res = await POST(postRequest({ label: 'Acme Ventures' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data).toEqual({ link: insertedRow });
+  });
+});

--- a/apps/web/tests/unit/lib/auth/investor-portal.test.ts
+++ b/apps/web/tests/unit/lib/auth/investor-portal.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   captureError: vi.fn(),
   releaseInvestorViewDedup: vi.fn(),
   shouldRecordInvestorView: vi.fn(),
+  apiLimiterLimit: vi.fn(),
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -51,6 +52,12 @@ vi.mock('@/lib/error-tracking', () => ({
   captureError: mocks.captureError,
 }));
 
+vi.mock('@/lib/rate-limit', () => ({
+  apiLimiter: {
+    limit: mocks.apiLimiterLimit,
+  },
+}));
+
 import { handleInvestorRequest } from '@/lib/auth/investor-portal';
 
 function createInvestorRequest(path: string) {
@@ -71,6 +78,12 @@ describe('investor portal proxy helper', () => {
     vi.clearAllMocks();
     mocks.select.mockReset();
     mocks.shouldRecordInvestorView.mockResolvedValue(true);
+    mocks.apiLimiterLimit.mockResolvedValue({
+      success: true,
+      limit: 20,
+      remaining: 19,
+      reset: new Date(Date.now() + 60_000),
+    });
   });
 
   it('lets response action links reach the page with token and action intact before DB validation', async () => {
@@ -110,5 +123,95 @@ describe('investor portal proxy helper', () => {
     );
     expect(res?.cookies.get('__investor_token')?.value).toBe('token-123');
     expect(mocks.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the rate limiter keyed by client IP before validating the token', async () => {
+    mockSelectRows([{ id: 'link-1', isActive: true, expiresAt: null }]);
+
+    const req = new NextRequest('https://jov.ie/investor-portal?t=token-123', {
+      headers: { 'x-forwarded-for': '203.0.113.7, 10.0.0.1' },
+    });
+    await handleInvestorRequest(req);
+
+    expect(mocks.apiLimiterLimit).toHaveBeenCalledTimes(1);
+    expect(mocks.apiLimiterLimit).toHaveBeenCalledWith(
+      'investor-portal:token:203.0.113.7'
+    );
+  });
+
+  it('returns 429 with a numeric Retry-After header when the rate limiter rejects the request, without touching the database', async () => {
+    const resetInMs = 12_000;
+    mocks.apiLimiterLimit.mockResolvedValue({
+      success: false,
+      limit: 20,
+      remaining: 0,
+      reset: new Date(Date.now() + resetInMs),
+    });
+
+    const res = await handleInvestorRequest(
+      createInvestorRequest('/investor-portal?t=token-123')
+    );
+
+    expect(res?.status).toBe(429);
+
+    const retryAfter = res?.headers.get('Retry-After');
+    expect(retryAfter).not.toBeNull();
+    const retryAfterSeconds = Number(retryAfter);
+    expect(Number.isNaN(retryAfterSeconds)).toBe(false);
+    expect(retryAfterSeconds).toBeGreaterThan(0);
+    expect(retryAfterSeconds).toBeLessThanOrEqual(12);
+
+    // Anti-enumeration: the DB must never be consulted once the limiter
+    // has rejected the request, and no cookie should be set.
+    expect(mocks.select).not.toHaveBeenCalled();
+    expect(res?.cookies.get('__investor_token')).toBeUndefined();
+  });
+
+  it('floors Retry-After at 1 second even when the reset window has already elapsed', async () => {
+    mocks.apiLimiterLimit.mockResolvedValue({
+      success: false,
+      limit: 20,
+      remaining: 0,
+      reset: new Date(Date.now() - 5_000), // already in the past
+    });
+
+    const res = await handleInvestorRequest(
+      createInvestorRequest('/investor-portal?t=token-123')
+    );
+
+    expect(res?.status).toBe(429);
+    expect(res?.headers.get('Retry-After')).toBe('1');
+  });
+
+  it('still validates the token normally once the rate limiter allows the request (limiter pass -> normal flow)', async () => {
+    mocks.apiLimiterLimit.mockResolvedValue({
+      success: true,
+      limit: 20,
+      remaining: 19,
+      reset: new Date(Date.now() + 60_000),
+    });
+    mockSelectRows([{ id: 'link-1', isActive: true, expiresAt: null }]);
+
+    const res = await handleInvestorRequest(
+      createInvestorRequest('/investor-portal?t=token-123&utm=x')
+    );
+
+    expect(mocks.apiLimiterLimit).toHaveBeenCalledTimes(1);
+    expect(res?.status).toBe(307);
+    expect(res?.cookies.get('__investor_token')?.value).toBe('token-123');
+    expect(mocks.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not rate-limit cookie-based revisits (no ?t= param)', async () => {
+    const req = new NextRequest('https://jov.ie/investor-portal', {
+      headers: { Cookie: '__investor_token=token-123' },
+    });
+
+    mockSelectRows([{ id: 'link-1', stage: 'shared' }]);
+    mocks.shouldRecordInvestorView.mockResolvedValue(false);
+
+    await handleInvestorRequest(req);
+
+    expect(mocks.apiLimiterLimit).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

The investor-token surface had **zero tests** (adversarially confirmed twice): the admin links routes (`apps/web/app/api/admin/investors/links/**`) and the anti-enumeration rate-limit branch in `apps/web/lib/auth/investor-portal.ts`. 24 new/extended tests across three files:

- **POST**: 403 short-circuits before insert; label trimmed; empty `investorName`/`email` → `null`; token non-constant across calls; 201 `{ link }` from `.returning()`
- **PATCH**: exact `.set()` key-set assertions — allowlisted fields pass through; **`token` and other unlisted fields (`id`, `engagementScore`, `createdAt`) are not writable**; body of only-disallowed fields yields exactly `['updatedAt']`; 404 on missing id
- **DELETE**: `.set()` is exactly `{ isActive: false, updatedAt }` — **soft-delete only, `db.delete` never called**; WHERE targets the real schema `id` column; 404 branch
- **Rate limit**: limiter keyed `investor-portal:token:<ip>` fires **only** on the token-param path (not cookie revisits or `/respond` links); failure → 429 with numeric `Retry-After` **floored at 1s**; DB never touched when limited

Part of JOV-4220 (test-coverage loop batch 5B — confirmed-uncovered security surface).

## Verification

- 27/27 tests green (7 + 12 + 8); typecheck + biome clean
- **Frontier mutation gate: 9/9 cumulative mutants killed** — 4 coder self-check (un-trimmed label, token in allowlist, stray token-null in DELETE, disabled 429) + 5 independent (constant token, widened allowlist, 200-instead-of-404, limiter-on-cookie-path, unfloored Retry-After). Each killed by exactly its targeted test; the verifier confirmed the dedicated Retry-After floor test is load-bearing (the generic 429 test alone would have missed it).

## Notes
- Production verified correct: `token` is not PATCHable and DELETE is already soft-only — the two suspected vulnerabilities are guarded; tests now pin that.
- bug-to-test: N/A — tests-only. Cost impact: none. No UI change.