### PR TITLE
test(email): mutation-verified campaign suppression + advancement coverage (JOV-4220)

### DIFF
--- a/apps/web/tests/unit/lib/email/campaigns/processor.test.ts
+++ b/apps/web/tests/unit/lib/email/campaigns/processor.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Hoist mocks before module resolution
 const {
@@ -329,6 +329,34 @@ function setupProcessingMocks(options: {
   mockDbUpdate.mockReturnValue({ set: mockUpdateSet });
 }
 
+/**
+ * Retrieves the shared `.set()` / `.where()` spies for the current test's
+ * `db.update()` mock chain (configured by `setupProcessingMocks`).
+ *
+ * `mockDbUpdate.mockReturnValue({ set: mockUpdateSet })` returns the SAME
+ * object for every `db.update()` call within a test, so `.mock.results[n]`
+ * always points at the same `set`/`where` spies — this lets us assert on the
+ * exact payload written for a specific enrollment (by pairing `set` call
+ * index N with `where` call index N, since each processed enrollment issues
+ * at most one `db.update().set().where()` chain in enrollment order).
+ */
+function getUpdateSpies() {
+  const lastCall = mockDbUpdate.mock.results.at(-1)?.value as
+    | { set: ReturnType<typeof vi.fn> }
+    | undefined;
+  if (!lastCall) {
+    throw new Error('db.update() was never called in this test');
+  }
+  const setSpy = lastCall.set;
+  const setResult = setSpy.mock.results.at(-1)?.value as
+    | { where: ReturnType<typeof vi.fn> }
+    | undefined;
+  if (!setResult) {
+    throw new Error('db.update().set() was never called in this test');
+  }
+  return { setSpy, whereSpy: setResult.where };
+}
+
 // --- Tests ---
 
 describe('email/campaigns/processor.ts', () => {
@@ -507,6 +535,13 @@ describe('email/campaigns/processor.ts', () => {
 
       expect(result.stopped).toBe(1);
       expect(result.sent).toBe(0);
+      expect(mockEnqueueBulkClaimInviteJobs).not.toHaveBeenCalled();
+      const { setSpy } = getUpdateSpies();
+      expect(setSpy).toHaveBeenCalledWith({
+        status: 'stopped',
+        stopReason: 'unsubscribed',
+        updatedAt: expect.any(Date),
+      });
     });
 
     it('stops enrollment when recipient has bounced (hard_bounce)', async () => {
@@ -539,6 +574,60 @@ describe('email/campaigns/processor.ts', () => {
       const result = await processCampaigns();
 
       expect(result.stopped).toBe(1);
+      expect(result.sent).toBe(0);
+      expect(mockEnqueueBulkClaimInviteJobs).not.toHaveBeenCalled();
+      // The DB stopReason is the literal condition name ('bounced'), not the
+      // underlying suppression reason string — lock in the exact value so a
+      // mutant that leaks `suppression.reason` instead fails loudly.
+      const { setSpy } = getUpdateSpies();
+      expect(setSpy).toHaveBeenCalledWith({
+        status: 'stopped',
+        stopReason: 'bounced',
+        updatedAt: expect.any(Date),
+      });
+    });
+
+    it('stops enrollment when recipient has soft-bounced (identical gating + stopReason as hard_bounce)', async () => {
+      // processor.ts treats hard_bounce and soft_bounce identically for the
+      // 'bounced' stop condition — this test locks in that there is NO special
+      // "still send on soft bounce" carve-out in the current implementation.
+      setupProcessingMocks({
+        suppressionRows: [{ emailHash: 'rechash-1', reason: 'soft_bounce' }],
+        sequences: [
+          createMockSequence({
+            steps: [
+              {
+                stepNumber: 1,
+                delayHours: 0,
+                templateKey: 't1',
+                subject: 's1',
+              },
+              {
+                stepNumber: 2,
+                delayHours: 24,
+                templateKey: 't2',
+                subject: 's2',
+                stopConditions: [{ type: 'bounced' }],
+              },
+            ],
+          }),
+        ],
+      });
+
+      const { processCampaigns } = await import(
+        '@/lib/email/campaigns/processor'
+      );
+      const result = await processCampaigns();
+
+      expect(result.stopped).toBe(1);
+      expect(result.sent).toBe(0);
+      expect(mockEnqueueBulkClaimInviteJobs).not.toHaveBeenCalled();
+      const { setSpy } = getUpdateSpies();
+      expect(setSpy).toHaveBeenCalledWith({
+        status: 'stopped',
+        stopReason: 'bounced',
+        updatedAt: expect.any(Date),
+      });
     });
 
     it('stops enrollment when recipient has opened the email', async () => {
@@ -692,6 +781,59 @@ describe('email/campaigns/processor.ts', () => {
       expect(result.stopped).toBe(1);
       expect(result.sent).toBe(0);
       expect(mockEnqueueBulkClaimInviteJobs).not.toHaveBeenCalled();
+      const { setSpy } = getUpdateSpies();
+      expect(setSpy).toHaveBeenCalledWith({
+        status: 'stopped',
+        stopReason: 'suppressed:hard_bounce',
+        updatedAt: expect.any(Date),
+      });
+    });
+
+    it('blocks send via the unconditional email-suppression safety net even when the step defines no unsubscribed/bounced stopCondition', async () => {
+      // This is the regression this suite exists to prevent: the final
+      // email-hash suppression check in processEnrollment() runs regardless
+      // of the step's configured stopConditions. A step author who forgets to
+      // add `stopConditions: [{ type: 'unsubscribed' }]` must still be
+      // protected from emailing a suppressed recipient.
+      setupProcessingMocks({
+        emailSuppressionRows: [
+          { emailHash: 'hash_artist@example.com', reason: 'user_request' },
+        ],
+        sequences: [
+          createMockSequence({
+            steps: [
+              {
+                stepNumber: 1,
+                delayHours: 0,
+                templateKey: 't1',
+                subject: 's1',
+              },
+              {
+                // Deliberately no stopConditions / skipConditions at all.
+                stepNumber: 2,
+                delayHours: 24,
+                templateKey: 't2',
+                subject: 's2',
+              },
+            ],
+          }),
+        ],
+      });
+
+      const { processCampaigns } = await import(
+        '@/lib/email/campaigns/processor'
+      );
+      const result = await processCampaigns();
+
+      expect(result.stopped).toBe(1);
+      expect(result.sent).toBe(0);
+      expect(mockEnqueueBulkClaimInviteJobs).not.toHaveBeenCalled();
+      const { setSpy } = getUpdateSpies();
+      expect(setSpy).toHaveBeenCalledWith({
+        status: 'stopped',
+        stopReason: 'suppressed:user_request',
+        updatedAt: expect.any(Date),
+      });
     });
   });
 
@@ -843,6 +985,10 @@ describe('email/campaigns/processor.ts', () => {
   });
 
   describe('enrollment advancement', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('updates enrollment to next step after sending', async () => {
       setupProcessingMocks({});
 
@@ -853,6 +999,358 @@ describe('email/campaigns/processor.ts', () => {
 
       // db.update should have been called to advance the enrollment
       expect(mockDbUpdate).toHaveBeenCalled();
+    });
+
+    it('writes the exact advancement payload for a clean recipient when no further step exists', async () => {
+      const fixedNow = new Date('2026-02-01T00:00:00.000Z');
+      vi.useFakeTimers();
+      vi.setSystemTime(fixedNow);
+
+      setupProcessingMocks({
+        sequences: [
+          createMockSequence({
+            steps: [
+              {
+                stepNumber: 1,
+                delayHours: 0,
+                templateKey: 't1',
+                subject: 's1',
+              },
+              {
+                stepNumber: 2,
+                delayHours: 24,
+                templateKey: 't2',
+                subject: 's2',
+              },
+            ],
+          }),
+        ],
+      });
+
+      const { processCampaigns } = await import(
+        '@/lib/email/campaigns/processor'
+      );
+      const result = await processCampaigns();
+
+      expect(result.sent).toBe(1);
+      expect(mockEnqueueBulkClaimInviteJobs).toHaveBeenCalledWith(
+        expect.anything(),
+        [{ inviteId: 'invite-1', creatorProfileId: 'subject-1' }],
+        { minDelayMs: 0, maxDelayMs: 60000 }
+      );
+
+      const { setSpy } = getUpdateSpies();
+      expect(setSpy).toHaveBeenCalledWith({
+        currentStep: '2',
+        stepCompletedAt: {
+          1: '2026-01-01T00:00:00Z',
+          2: fixedNow.toISOString(),
+        },
+        nextStepAt: null,
+        status: 'completed',
+        updatedAt: fixedNow,
+      });
+    });
+
+    it('writes a computed nextStepAt (based on the following step delayHours) when a further step exists', async () => {
+      const fixedNow = new Date('2026-02-01T00:00:00.000Z');
+      vi.useFakeTimers();
+      vi.setSystemTime(fixedNow);
+
+      // Default 3-step sequence: enrollment is at step 1, sends step 2
+      // (delayHours 48, unused for scheduling here), and the NEXT step (3)
+      // has delayHours 72 — nextStepAt must be derived from step 3's delay,
+      // not step 2's, since it represents "when step 3 becomes due".
+      setupProcessingMocks({});
+
+      const { processCampaigns } = await import(
+        '@/lib/email/campaigns/processor'
+      );
+      const result = await processCampaigns();
+
+      expect(result.sent).toBe(1);
+
+      const { setSpy } = getUpdateSpies();
+      const expectedNextStepAt = new Date(
+        fixedNow.getTime() + 72 * 60 * 60 * 1000
+      );
+      expect(setSpy).toHaveBeenCalledWith({
+        currentStep: '2',
+        stepCompletedAt: {
+          1: '2026-01-01T00:00:00Z',
+          2: fixedNow.toISOString(),
+        },
+        nextStepAt: expectedNextStepAt,
+        status: 'active',
+        updatedAt: fixedNow,
+      });
+    });
+  });
+
+  describe('batch isolation (multiple enrollments in one processCampaigns() run)', () => {
+    it('consults the suppression source exactly once for the whole batch, not once per enrollment', async () => {
+      const enrollments = [
+        createMockEnrollment({
+          id: 'e-1',
+          subjectId: 'sub-1',
+          recipientHash: 'rh-1',
+        }),
+        createMockEnrollment({
+          id: 'e-2',
+          subjectId: 'sub-2',
+          recipientHash: 'rh-2',
+        }),
+      ];
+      const claimInviteRows = [
+        {
+          inviteId: 'inv-1',
+          email: 'a@example.com',
+          creatorProfileId: 'sub-1',
+          sentAt: new Date(),
+          profileId: 'sub-1',
+          username: 'a',
+          displayName: 'A',
+          avatarUrl: null,
+          meta: { claimToken: 'tok-1' },
+        },
+        {
+          inviteId: 'inv-2',
+          email: 'b@example.com',
+          creatorProfileId: 'sub-2',
+          sentAt: new Date(),
+          profileId: 'sub-2',
+          username: 'b',
+          displayName: 'B',
+          avatarUrl: null,
+          meta: { claimToken: 'tok-2' },
+        },
+      ];
+
+      setupProcessingMocks({ enrollments, claimInviteRows });
+
+      const { processCampaigns } = await import(
+        '@/lib/email/campaigns/processor'
+      );
+      const result = await processCampaigns();
+
+      expect(result.processed).toBe(2);
+      expect(result.sent).toBe(2);
+      // A mutant that removes the batch lookup (or re-queries per enrollment)
+      // must fail here: the suppression source is queried exactly once for
+      // the entire pending batch.
+      expect(mockDbQuery.emailSuppressions.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses only the flagged recipient in a batch while still sending to the clean recipient', async () => {
+      const enrollments = [
+        createMockEnrollment({
+          id: 'e-1',
+          subjectId: 'sub-1',
+          recipientHash: 'rh-1',
+        }),
+        createMockEnrollment({
+          id: 'e-2',
+          subjectId: 'sub-2',
+          recipientHash: 'rh-2',
+        }),
+      ];
+      const claimInviteRows = [
+        {
+          inviteId: 'inv-1',
+          email: 'a@example.com',
+          creatorProfileId: 'sub-1',
+          sentAt: new Date(),
+          profileId: 'sub-1',
+          username: 'a',
+          displayName: 'A',
+          avatarUrl: null,
+          meta: { claimToken: 'tok-1' },
+        },
+        {
+          inviteId: 'inv-2',
+          email: 'b@example.com',
+          creatorProfileId: 'sub-2',
+          sentAt: new Date(),
+          profileId: 'sub-2',
+          username: 'b',
+          displayName: 'B',
+          avatarUrl: null,
+          meta: { claimToken: 'tok-2' },
+        },
+      ];
+
+      setupProcessingMocks({
+        enrollments,
+        claimInviteRows,
+        // Only rh-2 (e-2's recipient) is unsubscribed.
+        suppressionRows: [{ emailHash: 'rh-2', reason: 'user_request' }],
+        sequences: [
+          createMockSequence({
+            steps: [
+              {
+                stepNumber: 1,
+                delayHours: 0,
+                templateKey: 't1',
+                subject: 's1',
+              },
+              {
+                stepNumber: 2,
+                delayHours: 24,
+                templateKey: 't2',
+                subject: 's2',
+                stopConditions: [{ type: 'unsubscribed' }],
+              },
+            ],
+          }),
+        ],
+      });
+
+      const { processCampaigns } = await import(
+        '@/lib/email/campaigns/processor'
+      );
+      const result = await processCampaigns();
+
+      expect(result.processed).toBe(2);
+      expect(result.sent).toBe(1);
+      expect(result.stopped).toBe(1);
+
+      // Only the clean recipient's invite is dispatched — the suppressed
+      // recipient's invite (inv-2) must never reach the send call.
+      expect(mockEnqueueBulkClaimInviteJobs).toHaveBeenCalledTimes(1);
+      expect(mockEnqueueBulkClaimInviteJobs).toHaveBeenCalledWith(
+        expect.anything(),
+        [{ inviteId: 'inv-1', creatorProfileId: 'sub-1' }],
+        { minDelayMs: 0, maxDelayMs: 60000 }
+      );
+
+      // db.update() is called once per enrollment, in processing order:
+      // call 0 -> e-1 (advance/sent), call 1 -> e-2 (stop/suppressed).
+      const { setSpy, whereSpy } = getUpdateSpies();
+      expect(setSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          status: 'stopped',
+          stopReason: 'unsubscribed',
+        })
+      );
+      expect(whereSpy).toHaveBeenNthCalledWith(2, {
+        type: 'eq',
+        a: 'id',
+        b: 'e-2',
+      });
+      expect(whereSpy).toHaveBeenNthCalledWith(1, {
+        type: 'eq',
+        a: 'id',
+        b: 'e-1',
+      });
+    });
+
+    it('a send failure for one enrollment does not block or corrupt processing of the next enrollment in the batch', async () => {
+      const enrollments = [
+        createMockEnrollment({
+          id: 'e-1',
+          subjectId: 'sub-1',
+          recipientHash: 'rh-1',
+        }),
+        createMockEnrollment({
+          id: 'e-2',
+          subjectId: 'sub-2',
+          recipientHash: 'rh-2',
+        }),
+      ];
+      const claimInviteRows = [
+        {
+          inviteId: 'inv-1',
+          email: 'a@example.com',
+          creatorProfileId: 'sub-1',
+          sentAt: new Date(),
+          profileId: 'sub-1',
+          username: 'a',
+          displayName: 'A',
+          avatarUrl: null,
+          meta: { claimToken: 'tok-1' },
+        },
+        {
+          inviteId: 'inv-2',
+          email: 'b@example.com',
+          creatorProfileId: 'sub-2',
+          sentAt: new Date(),
+          profileId: 'sub-2',
+          username: 'b',
+          displayName: 'B',
+          avatarUrl: null,
+          meta: { claimToken: 'tok-2' },
+        },
+      ];
+
+      setupProcessingMocks({
+        enrollments,
+        claimInviteRows,
+        sequences: [
+          createMockSequence({
+            steps: [
+              {
+                stepNumber: 1,
+                delayHours: 0,
+                templateKey: 't1',
+                subject: 's1',
+              },
+              {
+                stepNumber: 2,
+                delayHours: 24,
+                templateKey: 't2',
+                subject: 's2',
+              },
+            ],
+          }),
+        ],
+      });
+      // The FIRST send (e-1 / inv-1) fails; the second (e-2 / inv-2) succeeds.
+      mockEnqueueBulkClaimInviteJobs.mockRejectedValueOnce(
+        new Error('Provider down')
+      );
+
+      const { processCampaigns } = await import(
+        '@/lib/email/campaigns/processor'
+      );
+      const result = await processCampaigns();
+
+      expect(result.processed).toBe(2);
+      expect(result.errors).toBe(1);
+      expect(result.sent).toBe(1);
+
+      // Both sends were attempted — the failure of the first did not skip
+      // the second.
+      expect(mockEnqueueBulkClaimInviteJobs).toHaveBeenCalledTimes(2);
+      expect(mockEnqueueBulkClaimInviteJobs).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        [{ inviteId: 'inv-1', creatorProfileId: 'sub-1' }],
+        { minDelayMs: 0, maxDelayMs: 60000 }
+      );
+      expect(mockEnqueueBulkClaimInviteJobs).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        [{ inviteId: 'inv-2', creatorProfileId: 'sub-2' }],
+        { minDelayMs: 0, maxDelayMs: 60000 }
+      );
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        '[Campaign Processor] Failed to process enrollment',
+        expect.objectContaining({
+          enrollmentId: 'e-1',
+          error: 'Provider down',
+        })
+      );
+
+      // The failed enrollment (e-1) must NOT be advanced/marked sent — only
+      // the successful one (e-2) gets a db.update() call. A mutant that
+      // advances the enrollment before/regardless of the send result would
+      // leave a duplicate-send risk on the next cron tick undetected without
+      // this assertion.
+      expect(mockDbUpdate).toHaveBeenCalledTimes(1);
+      const { whereSpy } = getUpdateSpies();
+      expect(whereSpy).toHaveBeenCalledWith({ type: 'eq', a: 'id', b: 'e-2' });
     });
   });
 });


### PR DESCRIPTION
## Summary

Extends the campaign processor suite (`apps/web/tests/unit/lib/email/campaigns/processor.test.ts`, 20 → 27 tests) with the mutation-coverage gaps the audit flagged on the suppression/send pipeline:

- Exact `stopReason` payloads for unsubscribed / hard-bounce / **soft-bounce** gating (soft bounces gate identically to hard — now locked in)
- The **unconditional email-suppression safety net** fires even when a campaign step defines no `stopCondition` at all — the exact "sends ignore suppression" regression the audit described
- Advancement payloads: final step → `completed`/`nextStepAt: null`; further step → `nextStepAt = now + delayHours` (unit pinned against a minutes-for-hours mutant)
- Batch suppression lookup consulted **exactly once per batch** (N+1 guard)
- Per-enrollment failure isolation: a failed send gets **no** `db.update` (no false sent-marking), neighbors still send, `errors` counter accurate

Part of JOV-4220 (test-coverage loop batch 6B). Note: the audit's "zero tests on 646 lines" was stale — a base suite landed on main since; this PR closes the specific gaps that suite left.

## Verification

- 27/27 green + cron regression suite green; typecheck + biome clean
- **Frontier mutation gate: 10/10 cumulative mutants killed** — 4 coder self-check (leaked raw reason, removed safety net, empty suppression map, batch-wide break-on-failure) + 6 independent (swapped stopReason literals, every-step-final, hours→minutes unit, swallowed send failure, N+1 lookup, uncounted errors). The N+1 mutant was behavior-preserving except query cardinality — only the call-count assertion could catch it, and it did.

## Notes
- Per loop policy, no CHANGELOG entry (consolidated changelog PR at loop wind-down).
- bug-to-test: N/A — tests-only. Cost impact: none. No UI change.