### PR TITLE
test(auth): close HUD admin positive-path + proxy dashboard-redirect gate gaps (JOV-4220)

### DIFF
--- a/apps/web/tests/unit/app/hud-page.test.ts
+++ b/apps/web/tests/unit/app/hud-page.test.ts
@@ -11,8 +11,17 @@ const {
   redirectMock: vi.fn((url: string) => {
     throw new Error(`NEXT_REDIRECT:${url}`);
   }),
-  unauthorizedMock: vi.fn(),
-  forbiddenMock: vi.fn(),
+  // Real next/navigation `unauthorized()`/`forbidden()` always throw (they
+  // never return to the caller) -- mirror that here so a mutation that lets
+  // execution continue past the gate (e.g. `getHudMetrics` firing before or
+  // regardless of the gate check) fails the suite instead of silently
+  // passing, the same way `redirectMock` above already does for `redirect()`.
+  unauthorizedMock: vi.fn(() => {
+    throw new Error('NEXT_UNAUTHORIZED');
+  }),
+  forbiddenMock: vi.fn(() => {
+    throw new Error('NEXT_FORBIDDEN');
+  }),
   getCurrentAdminPageAccessMock: vi.fn(),
   getHudMetricsMock: vi.fn(),
 }));
@@ -37,6 +46,41 @@ vi.mock('@/lib/env-server', () => ({
   },
 }));
 
+type ReactElementLike = {
+  readonly type: unknown;
+  readonly props?: {
+    readonly children?: unknown;
+    readonly [key: string]: unknown;
+  };
+};
+
+/**
+ * Depth-first search for the first element whose component function/tag is
+ * named `name`. Matching by component name keeps this focused gate test from
+ * importing and mocking the nested client dashboard solely to compare its
+ * function reference.
+ */
+function findElementByName(
+  node: unknown,
+  name: string
+): ReactElementLike | null {
+  if (!node || typeof node !== 'object') return null;
+  const element = node as ReactElementLike;
+  const type = element.type as { name?: string } | string | undefined;
+  const typeName = typeof type === 'string' ? type : type?.name;
+  if (typeName === name) return element;
+
+  const children = element.props?.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const found = findElementByName(child, name);
+      if (found) return found;
+    }
+    return null;
+  }
+  return findElementByName(children, name);
+}
+
 describe('/hud page auth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,9 +103,13 @@ describe('/hud page auth', () => {
       userId: null,
     });
 
-    await HudPage({ searchParams: Promise.resolve({}) });
+    await expect(
+      HudPage({ searchParams: Promise.resolve({}) })
+    ).rejects.toThrow('NEXT_UNAUTHORIZED');
 
     expect(unauthorizedMock).toHaveBeenCalled();
+    expect(forbiddenMock).not.toHaveBeenCalled();
+    expect(getHudMetricsMock).not.toHaveBeenCalled();
   });
 
   it('calls forbidden for signed-in non-admin users', async () => {
@@ -71,8 +119,41 @@ describe('/hud page auth', () => {
       userId: 'user_123',
     });
 
-    await HudPage({ searchParams: Promise.resolve({}) });
+    await expect(
+      HudPage({ searchParams: Promise.resolve({}) })
+    ).rejects.toThrow('NEXT_FORBIDDEN');
 
     expect(forbiddenMock).toHaveBeenCalled();
+    expect(unauthorizedMock).not.toHaveBeenCalled();
+    expect(getHudMetricsMock).not.toHaveBeenCalled();
+  });
+
+  it('renders the metrics dashboard for signed-in admins', async () => {
+    getCurrentAdminPageAccessMock.mockResolvedValue({
+      isAuthenticated: true,
+      hasAdminRole: true,
+      userId: 'admin_1',
+    });
+    const metrics = { accessMode: 'admin' as const, generatedAt: 'now' };
+    getHudMetricsMock.mockResolvedValue(metrics);
+
+    const result = await HudPage({ searchParams: Promise.resolve({}) });
+
+    // The gate passed cleanly -- neither escape hatch fired, and the real
+    // admin data fetch happened. A mutation that makes the admin gate
+    // unconditionally call forbidden()/unauthorized() (breaking all real
+    // admin access) would fail these assertions.
+    expect(unauthorizedMock).not.toHaveBeenCalled();
+    expect(forbiddenMock).not.toHaveBeenCalled();
+    expect(getHudMetricsMock).toHaveBeenCalledWith('admin');
+
+    // Full DOM rendering of HudDashboardClient would require a QueryClient
+    // provider and mocks for a dozen nested admin panels/charts -- assert
+    // directly on the returned React element tree instead so this stays a
+    // fast, focused test of the auth-gate wiring (metrics reach the
+    // dashboard) rather than an integration test of dashboard internals.
+    const dashboardElement = findElementByName(result, 'HudDashboardClient');
+    expect(dashboardElement).not.toBeNull();
+    expect(dashboardElement?.props?.initialMetrics).toEqual(metrics);
   });
 });

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -53,6 +53,14 @@ const mocks = vi.hoisted(() => ({
   getAudienceBlockIpFromHeaders: vi.fn().mockReturnValue('masked-ip'),
   createBotResponse: vi.fn(),
   clerkMiddleware: vi.fn(),
+  // Better Auth cookie helpers. `getSessionCookie` backs the proxy's
+  // top-level signed-in marker (apps/web/proxy.ts); `getCookieCache` backs
+  // the live `/` -> dashboard convenience redirect inside
+  // `handleProxyRequest` (apps/web/lib/auth/proxy-request-handler.ts).
+  // Both default to "no session" so existing unauthenticated/bypass-based
+  // tests keep their current behavior unless a test explicitly opts in.
+  getSessionCookie: vi.fn().mockReturnValue(null),
+  getCookieCache: vi.fn().mockResolvedValue(null),
   buildProtectedAuthRedirectUrl: vi.fn(
     (authPage: string, pathname: string, search: string) =>
       `${authPage}?redirect_url=${encodeURIComponent(pathname + search)}`
@@ -117,6 +125,10 @@ vi.mock('@/lib/auth/constants', () => ({
 }));
 vi.mock('@clerk/nextjs/server', () => ({
   clerkMiddleware: mocks.clerkMiddleware,
+}));
+vi.mock('better-auth/cookies', () => ({
+  getSessionCookie: mocks.getSessionCookie,
+  getCookieCache: mocks.getCookieCache,
 }));
 vi.mock('@/constants/app', () => ({
   AUDIENCE_ANON_COOKIE: 'audience_anon',
@@ -192,6 +204,8 @@ function resetMocks() {
   mocks.checkProfileVisitorBlocked.mockResolvedValue(false);
   mocks.getAudienceBlockIpFromHeaders.mockReturnValue('masked-ip');
   mocks.createBotResponse.mockReturnValue(undefined);
+  mocks.getSessionCookie.mockReturnValue(null);
+  mocks.getCookieCache.mockResolvedValue(null);
   mocks.fetch.mockResolvedValue(
     new Response('ok', {
       status: 200,
@@ -1068,6 +1082,69 @@ describe('proxy.ts middleware', () => {
       expect(locationUrl.searchParams.get('tab')).toBe('earn');
       expect(locationUrl.hash).toBe('#pay');
       expect(mocks.getUserState).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // Signed-in `/` -> dashboard convenience redirect (audit row 16)
+  //
+  // Live branch in handleProxyRequest
+  // (apps/web/lib/auth/proxy-request-handler.ts ~line 311): a signed-in
+  // session cookie at `/` bounces straight to the dashboard via a cheap
+  // cookie-cache read (no DB hit). This is distinct from the retired
+  // getUserState-based `/` -> /start redirect skipped above -- this branch
+  // is still live and previously had no active test coverage.
+  // ==========================================================================
+  describe('signed-in / -> dashboard redirect (audit row 16)', () => {
+    it('redirects to the dashboard when the signed-in session cookie cache is valid', async () => {
+      mocks.getCookieCache.mockResolvedValue({
+        session: { id: 'session_1' },
+        user: { id: 'user_1' },
+      });
+
+      const req = createAuthenticatedRequest('clerk_user_1', {
+        pathname: '/',
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+      expect(isRedirectTo(res, APP_ROUTES.DASHBOARD)).toBe(true);
+      expect(mocks.getCookieCache).toHaveBeenCalled();
+      // Purely cookie-cache based -- no DB user-state lookup on this path.
+      expect(mocks.getUserState).not.toHaveBeenCalled();
+    });
+
+    it('falls through to the homepage when there is no valid session cache (stale/tampered cookie)', async () => {
+      mocks.getCookieCache.mockResolvedValue(null);
+
+      const req = createAuthenticatedRequest('clerk_user_1', {
+        pathname: '/',
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBeLessThan(300);
+      expect(isRedirectTo(res, APP_ROUTES.DASHBOARD)).toBe(false);
+      expect(mocks.getCookieCache).toHaveBeenCalled();
+    });
+
+    it('does not redirect non-navigation methods even with a valid session cache', async () => {
+      mocks.getCookieCache.mockResolvedValue({
+        session: { id: 'session_1' },
+        user: { id: 'user_1' },
+      });
+
+      const req = createAuthenticatedRequest('clerk_user_1', {
+        pathname: '/',
+        method: 'POST',
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBeLessThan(300);
+      expect(isRedirectTo(res, APP_ROUTES.DASHBOARD)).toBe(false);
+      // The isNavigationMethod gate must short-circuit before the cache is
+      // even consulted.
+      expect(mocks.getCookieCache).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Two access gates whose live/positive path was untested — mutations breaking them passed the suite (adversarially proven):

- **`/hud` admin gate**: no test ever set `hasAdminRole: true`, and the `forbidden`/`unauthorized` mocks didn't throw (real `next/navigation` always throws), so `getHudMetrics` fired in every test regardless of authorization. Now: mocks throw with digest errors, existing negative tests strengthened with cross-checks, and a positive-path test pins admin → no gate escape, `getHudMetrics('admin')`, metrics delivered to `HudDashboardClient` props.
- **Signed-in `/` → `/app` proxy redirect** (`proxy-request-handler.ts:311-325`): the only related test was `it.skip`'d and targeted a retired DB-based path. Now: `better-auth/cookies` mocked in the suite; new tests pin the redirect target, cookie-cache-only resolution (no `getUserState` DB hit), null-cache fall-through, and the `isNavigationMethod` short-circuit (POST never consults the cache).

Part of JOV-4220 (test-coverage loop batch 7A — covered-weak gate gaps from the adversarial re-verification).

## Verification

- 60 passed / 31 skipped across both suites; typecheck + biome clean
- **Frontier mutation gate 5/5 killed** (gate swap unauthorized↔forbidden, viewer-scope metrics call, `/start` redirect target, inserted DB hit, POST-as-navigation) + 4 coder self-checks — each killed by its attributed assertion, verified not incidental

## Notes
- Per loop policy, no CHANGELOG entry (consolidated PR at loop wind-down). bug-to-test: N/A — tests-only. Cost impact: none. No UI change.