### PR TITLE
test(waitlist): mutation-verified 503 fail-closed + admin gate coverage (JOV-4220)

### DIFF
--- a/apps/web/tests/unit/api/admin/waitlist.test.ts
+++ b/apps/web/tests/unit/api/admin/waitlist.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetCurrentUserEntitlements = vi.hoisted(() => vi.fn());
+const mockGetAdminWaitlistEntries = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/entitlements/server', () => ({
+  getCurrentUserEntitlements: mockGetCurrentUserEntitlements,
+}));
+
+vi.mock('@/lib/admin/waitlist', () => ({
+  getAdminWaitlistEntries: mockGetAdminWaitlistEntries,
+}));
+
+describe('GET /api/admin/waitlist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetCurrentUserEntitlements.mockResolvedValue({
+      userId: null,
+      email: null,
+      isAuthenticated: false,
+      isAdmin: false,
+      isPro: false,
+      hasAdvancedFeatures: false,
+      canRemoveBranding: false,
+    });
+
+    const { GET } = await import('@/app/api/admin/waitlist/route');
+    const request = new Request('http://localhost/api/admin/waitlist');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
+    expect(mockGetAdminWaitlistEntries).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when authenticated user is not admin', async () => {
+    mockGetCurrentUserEntitlements.mockResolvedValue({
+      userId: 'user_123',
+      email: 'user@example.com',
+      isAuthenticated: true,
+      isAdmin: false,
+      isPro: false,
+      hasAdvancedFeatures: false,
+      canRemoveBranding: false,
+    });
+
+    const { GET } = await import('@/app/api/admin/waitlist/route');
+    const request = new Request('http://localhost/api/admin/waitlist');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe('Forbidden');
+    expect(mockGetAdminWaitlistEntries).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with entries for admins', async () => {
+    mockGetCurrentUserEntitlements.mockResolvedValue({
+      userId: 'admin_123',
+      email: 'admin@example.com',
+      isAuthenticated: true,
+      isAdmin: true,
+      isPro: true,
+      hasAdvancedFeatures: true,
+      canRemoveBranding: true,
+    });
+
+    const createdAt = new Date('2026-01-01T00:00:00.000Z');
+    const updatedAt = new Date('2026-01-02T00:00:00.000Z');
+    mockGetAdminWaitlistEntries.mockResolvedValue({
+      entries: [
+        {
+          id: 'entry_1',
+          fullName: 'Test User',
+          email: 'test@example.com',
+          primaryGoal: 'streams',
+          primarySocialUrl: 'https://instagram.com/test',
+          primarySocialPlatform: 'instagram',
+          primarySocialUrlNormalized: 'instagram.com/test',
+          spotifyUrl: null,
+          spotifyUrlNormalized: null,
+          spotifyArtistName: null,
+          heardAbout: null,
+          status: 'new',
+          primarySocialFollowerCount: null,
+          createdAt,
+          updatedAt,
+        },
+      ],
+      page: 1,
+      pageSize: 20,
+      total: 1,
+    });
+
+    const { GET } = await import('@/app/api/admin/waitlist/route');
+    const request = new Request(
+      'http://localhost/api/admin/waitlist?page=2&pageSize=10'
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGetAdminWaitlistEntries).toHaveBeenCalledWith({
+      page: 2,
+      pageSize: 10,
+    });
+    expect(data.total).toBe(1);
+    expect(data.rows).toEqual([
+      expect.objectContaining({
+        id: 'entry_1',
+        createdAt: createdAt.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+      }),
+    ]);
+  });
+});

--- a/apps/web/tests/unit/api/waitlist/waitlist.test.ts
+++ b/apps/web/tests/unit/api/waitlist/waitlist.test.ts
@@ -380,6 +380,60 @@ describe('Waitlist API', { timeout: 20_000 }, () => {
       expect(mockDbTransaction).not.toHaveBeenCalled();
     });
 
+    it('returns 503 with Retry-After when the waitlist table does not exist', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' });
+      mockDoesTableExist.mockResolvedValue(false);
+
+      const { POST } = await routeModulePromise;
+      const request = new Request('http://localhost/api/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          primaryGoal: 'streams',
+          primarySocialUrl: 'https://instagram.com/test',
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get('Retry-After')).toBeTruthy();
+      expect(data.success).toBe(false);
+      expect(data.code).toBe('waitlist_table_missing');
+      expect(mockCurrentUser).not.toHaveBeenCalled();
+      expect(mockDbTransaction).not.toHaveBeenCalled();
+      expect(mockDbInsert).not.toHaveBeenCalled();
+    });
+
+    it('fails closed with 503 when checking waitlist table existence throws', async () => {
+      mockAuth.mockResolvedValue({ userId: 'user_123' });
+      mockDoesTableExist.mockRejectedValue(
+        new Error('connection terminated unexpectedly')
+      );
+
+      const { POST } = await routeModulePromise;
+      const request = new Request('http://localhost/api/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          primaryGoal: 'streams',
+          primarySocialUrl: 'https://instagram.com/test',
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get('Retry-After')).toBeTruthy();
+      expect(data.success).toBe(false);
+      expect(data.code).toBe('waitlist_table_missing');
+      expect(mockCurrentUser).not.toHaveBeenCalled();
+      expect(mockDbTransaction).not.toHaveBeenCalled();
+      expect(mockDbInsert).not.toHaveBeenCalled();
+    });
+
     it('rejects submissions when Better Auth user has no primary email', async () => {
       mockAuth.mockResolvedValue({ userId: 'user_123' });
       mockCurrentUser.mockResolvedValue({


### PR DESCRIPTION
## Summary

Two confirmed-uncovered waitlist API branches (batch 8B of the coverage loop):

- **POST `/api/waitlist` fails closed** when `waitlist_entries` is missing or the existence check throws: 503 + `Retry-After`, no `currentUser` lookup, no transaction/insert attempted (`route.ts:70-77` catch + `:169-176`). Every prior test defaulted the table check to `true`, so the fail-closed path had never executed in CI.
- **GET `/api/admin/waitlist` gates**: 401 unauthenticated / 403 non-admin short-circuit **before** any data fetch; admin 200 honors `page`/`pageSize` and ISO-serializes timestamps.

## Verification

- 17 pass / 2 pre-existing skips across both suites; sibling admin waitlist suites (35 tests) green; typecheck + biome clean
- **Frontier mutation gate 6/6 killed**: fail-open proceed, fail-open catch (`return true` on error), dropped `Retry-After`, swapped 401/403, fetch-before-gate, ignored pagination — each killed by exactly its targeted assertion
- Production verified correct: both branches already fail closed per `.claude/rules/security.md`; the tests now pin it.

## Notes
- Per loop policy, no CHANGELOG entry. bug-to-test: N/A — tests-only. Cost impact: none. No UI change.