### PR TITLE
test(library): mutation-verified share/audio/approval guard coverage (JOV-4220)

### DIFF
--- a/apps/web/lib/library/asset-share-public.server.test.ts
+++ b/apps/web/lib/library/asset-share-public.server.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// All DB calls are mocked — no real Postgres connection required.
+const queuedRows: Array<unknown[]> = [];
+
+function makeSelectChain() {
+  const chain = {
+    from: () => chain,
+    innerJoin: () => chain,
+    where: () => chain,
+    limit: () => Promise.resolve(queuedRows.shift() ?? []),
+  };
+  return chain;
+}
+
+const selectMock = vi.fn(() => makeSelectChain());
+
+// Reference selectMock only inside a wrapper closure — the vi.mock factory
+// itself is hoisted above the `const selectMock` declaration, so calling
+// selectMock directly here would throw a TDZ ReferenceError.
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: () => selectMock(),
+  },
+}));
+
+const shareServerMocks = vi.hoisted(() => ({
+  resolveLibraryAssetShareByToken: vi.fn(),
+  resolveLibraryAssetShareByPublicSlug: vi.fn(),
+}));
+
+vi.mock('./asset-share.server', () => shareServerMocks);
+
+const merchServiceMocks = vi.hoisted(() => ({
+  getLibraryMerchCardsForProfile: vi.fn(),
+}));
+
+vi.mock('@/lib/merch/service', () => merchServiceMocks);
+
+import { buildLibraryAssetSharePublicViewByToken } from './asset-share-public.server';
+
+function releaseSettingsRow(overrides: Record<string, unknown> = {}) {
+  return {
+    settings: {
+      id: 'row-1',
+      creatorProfileId: 'creator-1',
+      assetId: 'release-1',
+      itemKind: 'release',
+      visibility: 'private',
+      shareSlug: 'midnight-city',
+      accessToken: 'valid-token',
+      tokenRevokedAt: null,
+      createdAt: new Date('2026-01-01'),
+      updatedAt: new Date('2026-01-01'),
+      ...overrides,
+    },
+    artistHandle: 'tim',
+  };
+}
+
+describe('buildLibraryAssetSharePublicViewByToken (private share access — deny without leaking)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queuedRows.length = 0;
+  });
+
+  it('returns null and never queries asset content when the token does not resolve (revoked/expired/unknown)', async () => {
+    shareServerMocks.resolveLibraryAssetShareByToken.mockResolvedValue(null);
+
+    const result =
+      await buildLibraryAssetSharePublicViewByToken('revoked-token');
+
+    expect(result).toBeNull();
+    // No asset content query should ever run for a token that failed to resolve —
+    // this is the "not leaked" guarantee: the denial path touches zero asset rows.
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the full public view for a release on a valid, non-revoked token (happy path)', async () => {
+    shareServerMocks.resolveLibraryAssetShareByToken.mockResolvedValue(
+      releaseSettingsRow()
+    );
+    queuedRows.push([
+      {
+        id: 'release-1',
+        title: 'Midnight City',
+        artworkUrl: 'https://cdn.example.com/art.jpg',
+        slug: 'midnight-city',
+        artistName: 'Tim White',
+        metadata: { previewUrl: 'https://cdn.example.com/preview.mp3' },
+      },
+    ]);
+
+    const result = await buildLibraryAssetSharePublicViewByToken('valid-token');
+
+    expect(result).toEqual({
+      assetId: 'release-1',
+      itemKind: 'release',
+      title: 'Midnight City',
+      artistName: 'Tim White',
+      artistHandle: 'tim',
+      artworkUrl: 'https://cdn.example.com/art.jpg',
+      previewUrl: 'https://cdn.example.com/preview.mp3',
+      smartLinkPath: '/tim/midnight-city',
+      visibility: 'private',
+    });
+  });
+
+  it('returns null when the resolved release row itself is missing (deleted asset, still no leak)', async () => {
+    shareServerMocks.resolveLibraryAssetShareByToken.mockResolvedValue(
+      releaseSettingsRow()
+    );
+    queuedRows.push([]); // release lookup miss
+
+    const result = await buildLibraryAssetSharePublicViewByToken('valid-token');
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/lib/library/asset-share.server.test.ts
+++ b/apps/web/lib/library/asset-share.server.test.ts
@@ -14,6 +14,7 @@ const eqValues: unknown[] = [];
 function makeSelectChain() {
   const chain = {
     from: () => chain,
+    innerJoin: () => chain,
     where: () => chain,
     // ensure() awaits `.limit(1)` for the read; pop the next queued result set.
     limit: () => Promise.resolve(selectRows.shift() ?? []),
@@ -78,6 +79,7 @@ vi.mock('@/lib/library/asset-share/token', () => ({
 
 import {
   ensureLibraryAssetShareSettings,
+  resolveLibraryAssetShareByToken,
   revokeLibraryAssetShareToken,
   updateLibraryAssetShareVisibility,
 } from './asset-share.server';
@@ -234,5 +236,54 @@ describe('updateLibraryAssetShareVisibility with a slug-collided assetId', () =>
 
     expect(result.assetId).toBe('release-OLD');
     expect(result.accessToken).toBe('fixed-token-000000000000');
+  });
+});
+
+describe('resolveLibraryAssetShareByToken (private share access)', () => {
+  beforeEach(() => {
+    selectRows.length = 0;
+    insertResult.value = [];
+    insertSpy.mockClear();
+    updatableRowsByAssetId.clear();
+    eqValues.length = 0;
+  });
+
+  it('resolves the settings and artist handle for a valid, non-revoked token', async () => {
+    // The real query filters with `isNull(tokenRevokedAt)` in the WHERE clause —
+    // a matching row here models a token that passed that predicate.
+    selectRows.push([
+      {
+        settings: shareRow({ accessToken: 'valid-token' }),
+        artistHandle: 'tim',
+      },
+    ]);
+
+    const result = await resolveLibraryAssetShareByToken('valid-token');
+
+    expect(result).toEqual({
+      settings: shareRow({ accessToken: 'valid-token' }),
+      artistHandle: 'tim',
+    });
+  });
+
+  it('returns null (no leaked settings) for a token that does not match any non-revoked row', async () => {
+    // Models a revoked or unknown token: the DB predicate excludes the row, so
+    // the query returns no rows at all — the caller cannot distinguish "revoked"
+    // from "never existed", which is the point (no information leak).
+    selectRows.push([]);
+
+    const result = await resolveLibraryAssetShareByToken(
+      'revoked-or-unknown-token'
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the joined artist handle is missing even though a settings row matched', async () => {
+    selectRows.push([{ settings: shareRow(), artistHandle: null }]);
+
+    const result = await resolveLibraryAssetShareByToken('valid-token');
+
+    expect(result).toBeNull();
   });
 });

--- a/apps/web/lib/library/asset-share/route-helpers.server.test.ts
+++ b/apps/web/lib/library/asset-share/route-helpers.server.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+const authMocks = vi.hoisted(() => ({
+  getSessionContext: vi.fn(),
+}));
+
+const shareServerMocks = vi.hoisted(() => ({
+  loadArtistHandleForProfile: vi.fn(),
+}));
+
+const captureErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionContext: authMocks.getSessionContext,
+}));
+
+vi.mock('@/lib/library/asset-share.server', () => ({
+  loadArtistHandleForProfile: shareServerMocks.loadArtistHandleForProfile,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: captureErrorMock,
+}));
+
+import {
+  parseLibraryAssetShareRequest,
+  resolveLibraryAssetShareActor,
+  runLibraryAssetShareMutation,
+} from './route-helpers.server';
+
+const OWNED_PROFILE_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('resolveLibraryAssetShareActor (asset-share auth boundary)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 without loading the artist handle when the caller has no creator profile', async () => {
+    authMocks.getSessionContext.mockResolvedValue({ profile: null });
+
+    const actor = await resolveLibraryAssetShareActor(
+      'clerk_user_1',
+      OWNED_PROFILE_ID
+    );
+
+    expect(actor.ok).toBe(false);
+    if (!actor.ok) {
+      expect(actor.response.status).toBe(403);
+      await expect(actor.response.json()).resolves.toEqual({
+        error: 'Creator profile not found',
+      });
+    }
+    expect(shareServerMocks.loadArtistHandleForProfile).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 without loading the artist handle when the session profile does not match the requested profileId', async () => {
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: 'someone-elses-profile-id' },
+    });
+
+    const actor = await resolveLibraryAssetShareActor(
+      'clerk_user_1',
+      OWNED_PROFILE_ID
+    );
+
+    expect(actor.ok).toBe(false);
+    if (!actor.ok) {
+      expect(actor.response.status).toBe(403);
+      await expect(actor.response.json()).resolves.toEqual({
+        error: 'Creator profile not found',
+      });
+    }
+    expect(shareServerMocks.loadArtistHandleForProfile).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the owning profile has no resolvable artist handle', async () => {
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: OWNED_PROFILE_ID },
+    });
+    shareServerMocks.loadArtistHandleForProfile.mockResolvedValue(null);
+
+    const actor = await resolveLibraryAssetShareActor(
+      'clerk_user_1',
+      OWNED_PROFILE_ID
+    );
+
+    expect(actor.ok).toBe(false);
+    if (!actor.ok) {
+      expect(actor.response.status).toBe(400);
+      await expect(actor.response.json()).resolves.toEqual({
+        error: 'Artist handle not found',
+      });
+    }
+  });
+
+  it('returns ok:true with the artist handle for the owning profile (happy path)', async () => {
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: OWNED_PROFILE_ID },
+    });
+    shareServerMocks.loadArtistHandleForProfile.mockResolvedValue('tim');
+
+    const actor = await resolveLibraryAssetShareActor(
+      'clerk_user_1',
+      OWNED_PROFILE_ID
+    );
+
+    expect(actor).toEqual({ ok: true, artistHandle: 'tim' });
+  });
+});
+
+describe('parseLibraryAssetShareRequest', () => {
+  const schema = z.object({ profileId: z.string().uuid() });
+
+  it('returns a 400 response for an invalid payload', async () => {
+    const result = await parseLibraryAssetShareRequest(
+      new Request('http://localhost/x', {
+        method: 'POST',
+        body: JSON.stringify({ profileId: 'not-a-uuid' }),
+      }),
+      schema
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(400);
+    }
+  });
+
+  it('returns the parsed data for a valid payload', async () => {
+    const result = await parseLibraryAssetShareRequest(
+      new Request('http://localhost/x', {
+        method: 'POST',
+        body: JSON.stringify({ profileId: OWNED_PROFILE_ID }),
+      }),
+      schema
+    );
+
+    expect(result).toEqual({ ok: true, data: { profileId: OWNED_PROFILE_ID } });
+  });
+});
+
+describe('runLibraryAssetShareMutation (unauthorized short-circuit)', () => {
+  const schema = z.object({ profileId: z.string().uuid() });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the actor response and never calls mutate when the actor is unauthorized', async () => {
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: 'someone-elses-profile-id' },
+    });
+    const mutate = vi.fn();
+
+    const response = await runLibraryAssetShareMutation({
+      request: new Request('http://localhost/api/library/asset-share', {
+        method: 'POST',
+        body: JSON.stringify({ profileId: OWNED_PROFILE_ID }),
+      }),
+      clerkUserId: 'clerk_user_1',
+      schema,
+      route: '/api/library/asset-share',
+      captureMessage: 'test capture message',
+      errorMessage: 'test error message',
+      mutate,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Creator profile not found',
+    });
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it('calls mutate and returns { ok: true, share } when the actor is authorized (happy path)', async () => {
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: OWNED_PROFILE_ID },
+    });
+    shareServerMocks.loadArtistHandleForProfile.mockResolvedValue('tim');
+    const share = { assetId: 'release-1', visibility: 'private' };
+    const mutate = vi.fn().mockResolvedValue(share);
+
+    const response = await runLibraryAssetShareMutation({
+      request: new Request('http://localhost/api/library/asset-share', {
+        method: 'POST',
+        body: JSON.stringify({ profileId: OWNED_PROFILE_ID }),
+      }),
+      clerkUserId: 'clerk_user_1',
+      schema,
+      route: '/api/library/asset-share',
+      captureMessage: 'test capture message',
+      errorMessage: 'test error message',
+      mutate,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, share });
+    expect(mutate).toHaveBeenCalledWith({ profileId: OWNED_PROFILE_ID }, 'tim');
+  });
+
+  it('captures the error and returns 500 without leaking internals when mutate throws', async () => {
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: OWNED_PROFILE_ID },
+    });
+    shareServerMocks.loadArtistHandleForProfile.mockResolvedValue('tim');
+    const mutate = vi.fn().mockRejectedValue(new Error('db exploded'));
+
+    const response = await runLibraryAssetShareMutation({
+      request: new Request('http://localhost/api/library/asset-share', {
+        method: 'POST',
+        body: JSON.stringify({ profileId: OWNED_PROFILE_ID }),
+      }),
+      clerkUserId: 'clerk_user_1',
+      schema,
+      route: '/api/library/asset-share',
+      captureMessage: 'test capture message',
+      errorMessage: 'test error message',
+      mutate,
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'test error message',
+    });
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      'test capture message',
+      expect.any(Error),
+      { route: '/api/library/asset-share' }
+    );
+  });
+});

--- a/apps/web/tests/unit/api/library-approval-status.test.ts
+++ b/apps/web/tests/unit/api/library-approval-status.test.ts
@@ -87,4 +87,91 @@ describe('/api/library/approval-status', () => {
       approvalStatus: 'approved',
     });
   });
+
+  it('PATCH returns 403 without calling the service when the profile is missing', async () => {
+    authMocks.getSessionContext.mockResolvedValue({ profile: null });
+
+    const { PATCH } = await import('@/app/api/library/approval-status/route');
+    const response = await PATCH(
+      new NextRequest('http://localhost/api/library/approval-status', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profileId: '11111111-1111-4111-8111-111111111111',
+          assetId: 'release_123',
+          itemKind: 'release',
+          approvalStatus: 'approved',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Creator profile not found',
+    });
+    expect(serviceMocks.upsertLibraryApprovalStatus).not.toHaveBeenCalled();
+  });
+
+  it('PATCH returns 403 without calling the service when the session profile does not own the requested profileId', async () => {
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: 'some-other-profile-id' },
+    });
+
+    const { PATCH } = await import('@/app/api/library/approval-status/route');
+    const response = await PATCH(
+      new NextRequest('http://localhost/api/library/approval-status', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profileId: '11111111-1111-4111-8111-111111111111',
+          assetId: 'release_123',
+          itemKind: 'release',
+          approvalStatus: 'approved',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Creator profile not found',
+    });
+    expect(serviceMocks.upsertLibraryApprovalStatus).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 403 without calling the service when the session profile does not own the requested profileId', async () => {
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: 'some-other-profile-id' },
+    });
+
+    const { GET } = await import('@/app/api/library/approval-status/route');
+    const response = await GET(
+      new NextRequest(
+        'http://localhost/api/library/approval-status?profileId=11111111-1111-4111-8111-111111111111&assetId=release_123'
+      )
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Creator profile not found',
+    });
+    expect(
+      serviceMocks.getLibraryApprovalStatusForAsset
+    ).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 403 without calling the service when the caller has no creator profile at all', async () => {
+    authMocks.getSessionContext.mockResolvedValue({ profile: null });
+
+    const { GET } = await import('@/app/api/library/approval-status/route');
+    const response = await GET(
+      new NextRequest(
+        'http://localhost/api/library/approval-status?profileId=11111111-1111-4111-8111-111111111111&assetId=release_123'
+      )
+    );
+
+    expect(response.status).toBe(403);
+    expect(
+      serviceMocks.getLibraryApprovalStatusForAsset
+    ).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/unit/api/library-asset-share.test.ts
+++ b/apps/web/tests/unit/api/library-asset-share.test.ts
@@ -1,0 +1,303 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMocks = vi.hoisted(() => ({
+  requireAuth: vi.fn(),
+  getSessionContext: vi.fn(),
+}));
+
+const serviceMocks = vi.hoisted(() => ({
+  ensureLibraryAssetShareSettings: vi.fn(),
+  updateLibraryAssetShareVisibility: vi.fn(),
+  getLibraryAssetShareForAsset: vi.fn(),
+  loadArtistHandleForProfile: vi.fn(),
+  revokeLibraryAssetShareToken: vi.fn(),
+}));
+
+const captureErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/require-auth', () => ({
+  requireAuth: authMocks.requireAuth,
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionContext: authMocks.getSessionContext,
+}));
+
+vi.mock('@/lib/library/asset-share.server', () => ({
+  ensureLibraryAssetShareSettings: serviceMocks.ensureLibraryAssetShareSettings,
+  updateLibraryAssetShareVisibility:
+    serviceMocks.updateLibraryAssetShareVisibility,
+  getLibraryAssetShareForAsset: serviceMocks.getLibraryAssetShareForAsset,
+  loadArtistHandleForProfile: serviceMocks.loadArtistHandleForProfile,
+  revokeLibraryAssetShareToken: serviceMocks.revokeLibraryAssetShareToken,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: captureErrorMock,
+}));
+
+const OWNED_PROFILE_ID = '11111111-1111-4111-8111-111111111111';
+
+const mutationBody = {
+  profileId: OWNED_PROFILE_ID,
+  assetId: 'release_123',
+  itemKind: 'release' as const,
+  title: 'Midnight City',
+  smartLinkPath: '/tim/midnight-city',
+};
+
+describe('/api/library/asset-share', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMocks.requireAuth.mockResolvedValue({
+      userId: 'clerk_user_1',
+      error: null,
+    });
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: OWNED_PROFILE_ID },
+    });
+    serviceMocks.loadArtistHandleForProfile.mockResolvedValue('tim');
+  });
+
+  describe('POST (ensure share link)', () => {
+    it('returns 403 and never calls ensureLibraryAssetShareSettings for a profile the caller does not own', async () => {
+      authMocks.getSessionContext.mockResolvedValue({
+        profile: { id: 'someone-elses-profile-id' },
+      });
+
+      const { POST } = await import('@/app/api/library/asset-share/route');
+      const response = await POST(
+        new NextRequest('http://localhost/api/library/asset-share', {
+          method: 'POST',
+          body: JSON.stringify(mutationBody),
+        })
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Creator profile not found',
+      });
+      expect(
+        serviceMocks.ensureLibraryAssetShareSettings
+      ).not.toHaveBeenCalled();
+    });
+
+    it('wires the request into ensureLibraryAssetShareSettings and returns { ok: true, share } (happy path)', async () => {
+      const share = {
+        assetId: 'release_123',
+        visibility: 'private',
+        shareSlug: 'midnight-city',
+        accessToken: 'token-abc',
+        shareUrl: 'https://jov.ie/p/token-abc',
+      };
+      serviceMocks.ensureLibraryAssetShareSettings.mockResolvedValue(share);
+
+      const { POST } = await import('@/app/api/library/asset-share/route');
+      const response = await POST(
+        new NextRequest('http://localhost/api/library/asset-share', {
+          method: 'POST',
+          body: JSON.stringify(mutationBody),
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true, share });
+      expect(serviceMocks.ensureLibraryAssetShareSettings).toHaveBeenCalledWith(
+        {
+          creatorProfileId: OWNED_PROFILE_ID,
+          assetId: 'release_123',
+          itemKind: 'release',
+          title: 'Midnight City',
+          artistHandle: 'tim',
+          smartLinkPath: '/tim/midnight-city',
+        }
+      );
+    });
+  });
+
+  describe('PATCH (update visibility)', () => {
+    const patchBody = { ...mutationBody, visibility: 'public' as const };
+
+    it('returns 403 and never calls updateLibraryAssetShareVisibility for a profile the caller does not own', async () => {
+      authMocks.getSessionContext.mockResolvedValue({
+        profile: { id: 'someone-elses-profile-id' },
+      });
+
+      const { PATCH } = await import('@/app/api/library/asset-share/route');
+      const response = await PATCH(
+        new NextRequest('http://localhost/api/library/asset-share', {
+          method: 'PATCH',
+          body: JSON.stringify(patchBody),
+        })
+      );
+
+      expect(response.status).toBe(403);
+      expect(
+        serviceMocks.updateLibraryAssetShareVisibility
+      ).not.toHaveBeenCalled();
+    });
+
+    it('wires the request into updateLibraryAssetShareVisibility and returns { ok: true, share } (happy path)', async () => {
+      const share = {
+        assetId: 'release_123',
+        visibility: 'public',
+        shareSlug: 'midnight-city',
+        accessToken: 'token-abc',
+        shareUrl: 'https://jov.ie/a/tim/midnight-city',
+      };
+      serviceMocks.updateLibraryAssetShareVisibility.mockResolvedValue(share);
+
+      const { PATCH } = await import('@/app/api/library/asset-share/route');
+      const response = await PATCH(
+        new NextRequest('http://localhost/api/library/asset-share', {
+          method: 'PATCH',
+          body: JSON.stringify(patchBody),
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true, share });
+      expect(
+        serviceMocks.updateLibraryAssetShareVisibility
+      ).toHaveBeenCalledWith({
+        creatorProfileId: OWNED_PROFILE_ID,
+        assetId: 'release_123',
+        itemKind: 'release',
+        title: 'Midnight City',
+        smartLinkPath: '/tim/midnight-city',
+        visibility: 'public',
+        artistHandle: 'tim',
+      });
+    });
+  });
+
+  describe('GET (fetch share settings)', () => {
+    it('returns 400 when profileId or assetId is missing', async () => {
+      const { GET } = await import('@/app/api/library/asset-share/route');
+      const response = await GET(
+        new NextRequest(
+          `http://localhost/api/library/asset-share?profileId=${OWNED_PROFILE_ID}`
+        )
+      );
+
+      expect(response.status).toBe(400);
+      expect(serviceMocks.getLibraryAssetShareForAsset).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 and never calls getLibraryAssetShareForAsset for a profile the caller does not own', async () => {
+      authMocks.getSessionContext.mockResolvedValue({
+        profile: { id: 'someone-elses-profile-id' },
+      });
+
+      const { GET } = await import('@/app/api/library/asset-share/route');
+      const response = await GET(
+        new NextRequest(
+          `http://localhost/api/library/asset-share?profileId=${OWNED_PROFILE_ID}&assetId=release_123`
+        )
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Creator profile not found',
+      });
+      expect(serviceMocks.getLibraryAssetShareForAsset).not.toHaveBeenCalled();
+    });
+
+    it('returns { ok: true, share: null } when no share settings exist yet', async () => {
+      serviceMocks.getLibraryAssetShareForAsset.mockResolvedValue(null);
+
+      const { GET } = await import('@/app/api/library/asset-share/route');
+      const response = await GET(
+        new NextRequest(
+          `http://localhost/api/library/asset-share?profileId=${OWNED_PROFILE_ID}&assetId=release_123`
+        )
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        ok: true,
+        share: null,
+      });
+    });
+
+    it('returns the share for an owned asset with an exact response shape (happy path)', async () => {
+      const share = {
+        assetId: 'release_123',
+        visibility: 'private',
+        shareSlug: 'midnight-city',
+        accessToken: 'token-abc',
+        shareUrl: 'https://jov.ie/p/token-abc',
+      };
+      serviceMocks.getLibraryAssetShareForAsset.mockResolvedValue(share);
+
+      const { GET } = await import('@/app/api/library/asset-share/route');
+      const response = await GET(
+        new NextRequest(
+          `http://localhost/api/library/asset-share?profileId=${OWNED_PROFILE_ID}&assetId=release_123`
+        )
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true, share });
+      expect(serviceMocks.getLibraryAssetShareForAsset).toHaveBeenCalledWith({
+        creatorProfileId: OWNED_PROFILE_ID,
+        assetId: 'release_123',
+        artistHandle: 'tim',
+      });
+    });
+
+    it('returns 500 without leaking data when the stored visibility is invalid', async () => {
+      serviceMocks.getLibraryAssetShareForAsset.mockResolvedValue({
+        assetId: 'release_123',
+        visibility: 'not-a-real-visibility',
+      });
+
+      const { GET } = await import('@/app/api/library/asset-share/route');
+      const response = await GET(
+        new NextRequest(
+          `http://localhost/api/library/asset-share?profileId=${OWNED_PROFILE_ID}&assetId=release_123`
+        )
+      );
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Invalid share visibility',
+      });
+    });
+  });
+});
+
+describe('/api/library/asset-share/revoke', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMocks.requireAuth.mockResolvedValue({
+      userId: 'clerk_user_1',
+      error: null,
+    });
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: OWNED_PROFILE_ID },
+    });
+    serviceMocks.loadArtistHandleForProfile.mockResolvedValue('tim');
+  });
+
+  it('returns 403 and never revokes a token for a profile the caller does not own', async () => {
+    authMocks.getSessionContext.mockResolvedValue({
+      profile: { id: 'someone-elses-profile-id' },
+    });
+    const { revokeLibraryAssetShareToken } = await import(
+      '@/lib/library/asset-share.server'
+    );
+
+    const { POST } = await import('@/app/api/library/asset-share/revoke/route');
+    const response = await POST(
+      new NextRequest('http://localhost/api/library/asset-share/revoke', {
+        method: 'POST',
+        body: JSON.stringify(mutationBody),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(revokeLibraryAssetShareToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/api/library-audio.test.ts
+++ b/apps/web/tests/unit/api/library-audio.test.ts
@@ -195,4 +195,60 @@ describe('library audio upload API', () => {
     expect(response.status).toBe(409);
     expect(hoisted.updateMock).not.toHaveBeenCalled();
   });
+
+  it('returns 403 without resolving or mutating a recording when the caller has no creator profile', async () => {
+    hoisted.getSessionContextMock.mockResolvedValue({ profile: null });
+
+    const { POST } = await import('@/app/api/library/audio/confirm/route');
+    const response = await POST(
+      new Request('http://localhost/api/library/audio/confirm', {
+        method: 'POST',
+        body: JSON.stringify({
+          releaseId: '00000000-0000-4000-8000-000000000001',
+          blobUrl: 'https://cdn.example.com/take-me-over.mp3',
+          blobPathname: 'library/audio/take-me-over.mp3',
+          fileName: 'take-me-over.mp3',
+          fileMimeType: 'audio/mpeg',
+          fileSizeBytes: 1024,
+        }),
+      }) as never
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Creator profile not found',
+    });
+    expect(
+      hoisted.resolvePrimaryRecordingForReleaseMock
+    ).not.toHaveBeenCalled();
+    expect(hoisted.updateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 without mutating when the release is not owned by the requesting profile', async () => {
+    // resolvePrimaryRecordingForRelease scopes its join by creatorProfileId, so a
+    // release owned by someone else resolves to no row — same as "not found".
+    hoisted.resolvePrimaryRecordingForReleaseMock.mockResolvedValue(null);
+
+    const { POST } = await import('@/app/api/library/audio/confirm/route');
+    const response = await POST(
+      new Request('http://localhost/api/library/audio/confirm', {
+        method: 'POST',
+        body: JSON.stringify({
+          releaseId: '00000000-0000-4000-8000-000000000002',
+          blobUrl: 'https://cdn.example.com/take-me-over.mp3',
+          blobPathname: 'library/audio/take-me-over.mp3',
+          fileName: 'take-me-over.mp3',
+          fileMimeType: 'audio/mpeg',
+          fileSizeBytes: 1024,
+        }),
+      }) as never
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Release recording not found',
+    });
+    expect(hoisted.updateMock).not.toHaveBeenCalled();
+    expect(hoisted.revalidateTagMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

The library surface's denial branches were uncovered (re-verified against current main; the one stale audit claim — `dashboard-sync-spotify` — was confirmed already covered and skipped). 31 new/extended tests across 6 files:

- **audio/confirm**: 403 no-profile and 404 unowned-release branches, with resolve/mutate never invoked
- **asset-share actor resolution**: 403 null-profile, 403 cross-profile mismatch, 400 missing handle; POST/PATCH/GET/revoke wiring asserts the service is never called on denial
- **Private/expired share token**: `null` with **zero `db.select`** — the no-leak proof at `buildLibraryAssetSharePublicViewByToken`, which had no test file at all (audit scope was too narrow)
- **approval-status** GET/PATCH denial without service invocation
- **Shared mutation wrapper**: 500 captures the error and returns a generic message (no internals leaked)

Part of JOV-4220 (test-coverage loop batch 9B).

## Verification

- 43/43 across the 6 suites; typecheck + biome clean
- **Frontier mutation gate 6/6 killed** — the standout: a revoke-despite-403 side-effect mutant that still returned the right status; only the `revokeLibraryAssetShareToken` not-called assertion caught it. Status-only tests would have shipped that hole.

## Notes
- Per loop policy, no CHANGELOG entry. bug-to-test: N/A — tests-only. Cost impact: none. No UI change.