### PR TITLE
fix(claim): preserve original claimedAt on same-user re-claim (JOV-4225) [stacked on #14080]

### DIFF
--- a/apps/web/lib/claim/finalize.test.ts
+++ b/apps/web/lib/claim/finalize.test.ts
@@ -48,6 +48,7 @@ interface ProfileRowOverrides {
   usernameNormalized?: string;
   displayName?: string | null;
   isClaimed?: boolean | null;
+  claimedAt?: Date | null;
   onboardingCompletedAt?: Date | null;
 }
 
@@ -58,6 +59,7 @@ function profileRow(overrides: ProfileRowOverrides = {}) {
     usernameNormalized: 'artistname',
     displayName: 'Old Name',
     isClaimed: false,
+    claimedAt: null,
     onboardingCompletedAt: null,
     ...overrides,
   };
@@ -343,30 +345,51 @@ describe('claimPrebuiltProfileForUser', () => {
     ).toHaveLength(2);
   });
 
-  it.skip(
-    'BUG: re-claiming a profile the user already owns overwrites the original claimedAt with "now" every call. ' +
-      'Expected: creatorProfiles.claimedAt should be preserved from the first claim (mirroring the ' +
-      'onboardingCompletedAt ?? now preservation pattern used two lines below it). ' +
-      'Actual: getClaimTargetProfile does not even select claimedAt, and the update unconditionally sets ' +
-      '`claimedAt: now`, so every idempotent re-run of claimPrebuiltProfileForUser for an already-claimed ' +
-      'profile silently rewrites the audit-significant original claim timestamp.',
+  it(
+    'preserves the original claimedAt when re-claiming a profile the user already owns (idempotent retry), ' +
+      'mirroring the onboardingCompletedAt ?? now preservation pattern used two lines below it',
     async () => {
       const originalClaimedAt = new Date('2024-01-01T00:00:00.000Z');
       const mocks = createTxMock([
         // Same user already owns and has already claimed this exact profile.
-        [profileRow({ userId: 'user-1', isClaimed: true })],
+        [
+          profileRow({
+            userId: 'user-1',
+            isClaimed: true,
+            claimedAt: originalClaimedAt,
+          }),
+        ],
         [],
       ]);
 
       await claimPrebuiltProfileForUser(mocks.tx, baseParams);
 
-      // Expected (desired) behavior — fails today because claimedAt is not
-      // even fetched by getClaimTargetProfile, let alone preserved.
+      // getClaimTargetProfile now selects claimedAt, and the update preserves
+      // it via `profile.claimedAt ?? now` instead of unconditionally
+      // overwriting the audit-significant original claim timestamp.
       expect(mocks.updateSetMock.mock.calls[1]?.[0]).toMatchObject({
         claimedAt: originalClaimedAt,
       });
+      // The tx mock is projection-blind (limitMock returns the full fixture
+      // regardless of selected columns), so also pin that the select actually
+      // requests claimedAt — without this, dropping the select line would be
+      // caught only by typecheck, not by this suite.
+      expect(mocks.selectMock.mock.calls[0]?.[0]).toHaveProperty('claimedAt');
     }
   );
+
+  it('sets claimedAt to now on a first-time claim (profile.claimedAt is null)', async () => {
+    const mocks = createTxMock([
+      [profileRow({ onboardingCompletedAt: null })],
+      [],
+    ]);
+
+    await claimPrebuiltProfileForUser(mocks.tx, baseParams);
+
+    expect(mocks.updateSetMock.mock.calls[1]?.[0]).toMatchObject({
+      claimedAt: FIXED_NOW,
+    });
+  });
 });
 
 describe('reservePrebuiltProfileForUser', () => {

--- a/apps/web/lib/claim/finalize.ts
+++ b/apps/web/lib/claim/finalize.ts
@@ -20,6 +20,7 @@ interface ClaimTargetProfile {
   readonly usernameNormalized: string;
   readonly displayName: string | null;
   readonly isClaimed: boolean | null;
+  readonly claimedAt: Date | null;
   readonly onboardingCompletedAt: Date | null;
 }
 
@@ -34,6 +35,7 @@ async function getClaimTargetProfile(
       usernameNormalized: creatorProfiles.usernameNormalized,
       displayName: creatorProfiles.displayName,
       isClaimed: creatorProfiles.isClaimed,
+      claimedAt: creatorProfiles.claimedAt,
       onboardingCompletedAt: creatorProfiles.onboardingCompletedAt,
     })
     .from(creatorProfiles)
@@ -234,7 +236,7 @@ export async function claimPrebuiltProfileForUser(
       displayName: params.displayName,
       isClaimed: true,
       isPublic: true,
-      claimedAt: now,
+      claimedAt: profile.claimedAt ?? now,
       onboardingCompletedAt: params.finalizeOnboarding
         ? (profile.onboardingCompletedAt ?? now)
         : profile.onboardingCompletedAt,


### PR DESCRIPTION
## Summary

**Fix batch — stacked on #14080** (the tests branch containing the documenting `it.skip`). **Not enrolled in the merge queue**: the claim flow is on the auto-merge blocked list (profile ownership → manual review per `release.md`) — requesting human review.

`claimPrebuiltProfileForUser` set `claimedAt: now` unconditionally; with no same-user re-claim guard, idempotent retries overwrote the original ownership timestamp (audit-trail corruption on a treat-carefully surface). The fix is 4 lines: `getClaimTargetProfile` now selects `claimedAt`, and the claim update preserves it via `profile.claimedAt ?? now` — mirroring the adjacent `onboardingCompletedAt` pattern.

## Verification (bug-to-test gate satisfied)
- The documenting `it.skip` is **un-skipped as the regression test**, plus a first-claim companion case and a select-projection assertion
- 21/21 suite green; onboarding consumer suites (23 tests) green; typecheck clean
- **Frontier verification**: operand-swap mutant killed by the regression test; the sneaky half-fix (dropping only the select line) is killed by typecheck (TS2741 — the interface change makes the projection load-bearing) **and** now by the projection assertion at the test layer
- Consumers verified inert: reserve path never touches `claimedAt`; external callers mock the module

## Related finding (tracked separately, not in this PR)
Release paths (`waitlist/approval.ts`) null `userId`/`isClaimed` but never clear `claimedAt` — a later cross-user claim of a released profile inherits the stale timestamp. Contained (zero product reads of the column; `userProfileClaims`/`profileOwnershipLog` stay correct per-user) — filed as a candidate follow-up.

## Notes
- Cost impact: none. No UI change.