### PR TITLE
fix(ci): bound Vercel deploy upload attempts

### DIFF
--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -42,10 +42,6 @@ resolve_vercel_cmd() {
   return 127
 }
 
-run_vercel() {
-  "${VERCEL_CMD[@]}" "$@"
-}
-
 parse_deployment_url() {
   printf '%s\n' "$1" | grep -Eo 'https://[^[:space:]]+\.vercel\.app/?' | tail -1 || true
 }
@@ -69,22 +65,29 @@ run_deploy() {
   local mode="$1"
   shift
 
+  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-45}"
+  if [ "$mode" = "source" ]; then
+    timeout_seconds="${VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS:-420}"
+  fi
+
+  local deploy_cmd=(timeout --signal=TERM --kill-after=15s "$timeout_seconds")
+
   if [ "$mode" = "tgz" ]; then
-    run_vercel deploy --prebuilt --archive=tgz "$@" --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
+    "${deploy_cmd[@]}" "${VERCEL_CMD[@]}" deploy --prebuilt --archive=tgz "$@" --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
     return
   fi
 
   if [ "$mode" = "split-tgz" ]; then
-    run_vercel deploy --prebuilt --archive=split-tgz "$@" --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
+    "${deploy_cmd[@]}" "${VERCEL_CMD[@]}" deploy --prebuilt --archive=split-tgz "$@" --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
     return
   fi
 
   if [ "$mode" = "plain" ]; then
-    run_vercel deploy --prebuilt "$@" --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
+    "${deploy_cmd[@]}" "${VERCEL_CMD[@]}" deploy --prebuilt "$@" --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
     return
   fi
 
-  run_vercel deploy "$@" --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
+  "${deploy_cmd[@]}" "${VERCEL_CMD[@]}" deploy "$@" --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
 }
 
 try_mode() {
@@ -93,7 +96,9 @@ try_mode() {
   shift 2
 
   local deploy_output=""
-  if deploy_output="$(run_deploy "$mode" "$@" 2>&1)"; then
+  local deploy_status=0
+  deploy_output="$(run_deploy "$mode" "$@" 2>&1)" || deploy_status=$?
+  if [ "$deploy_status" -eq 0 ]; then
     echo "$deploy_output"
     local deployment_url=""
     deployment_url="$(parse_deployment_url "$deploy_output")"
@@ -107,6 +112,9 @@ try_mode() {
   fi
 
   echo "$deploy_output"
+  if [ "$deploy_status" -eq 124 ]; then
+    echo "Deploy attempt $attempt with ${mode} upload exceeded its time budget" >&2
+  fi
   return 1
 }
 

--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -117,6 +117,13 @@ try_mode() {
   echo "$deploy_output"
   if [ "$deploy_status" -eq 124 ] || [ "$deploy_status" -eq 137 ]; then
     echo "Deploy attempt $attempt with ${mode} upload exceeded its time budget" >&2
+    local accepted_deployment_url=""
+    accepted_deployment_url="$(parse_deployment_url "$deploy_output")"
+    if [ -n "$accepted_deployment_url" ]; then
+      write_deployment_url "$accepted_deployment_url"
+      echo "Vercel accepted ${accepted_deployment_url}; downstream health gates will verify readiness"
+      return 0
+    fi
   fi
   return 1
 }

--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -67,11 +67,11 @@ run_deploy() {
 
   # Three bounded prebuilt attempts plus the source fallback must leave a full
   # minute beneath the workflow step's 10-minute ceiling, including kill grace.
-  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-25}"
+  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-15}"
   if [ "$mode" = "source" ]; then
-    timeout_seconds="${VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS:-405}"
+    timeout_seconds="${VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS:-475}"
   fi
-  local kill_grace_seconds="${VERCEL_DEPLOY_KILL_GRACE_SECONDS:-15}"
+  local kill_grace_seconds="${VERCEL_DEPLOY_KILL_GRACE_SECONDS:-5}"
 
   local deploy_cmd=(timeout --signal=TERM --kill-after="${kill_grace_seconds}s" "$timeout_seconds")
 

--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -65,7 +65,9 @@ run_deploy() {
   local mode="$1"
   shift
 
-  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-45}"
+  # Three bounded prebuilt attempts plus the source fallback must stay within
+  # the workflow step's 10-minute ceiling, including each 15-second kill grace.
+  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-35}"
   if [ "$mode" = "source" ]; then
     timeout_seconds="${VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS:-420}"
   fi

--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -65,14 +65,15 @@ run_deploy() {
   local mode="$1"
   shift
 
-  # Three bounded prebuilt attempts plus the source fallback must stay within
-  # the workflow step's 10-minute ceiling, including each 15-second kill grace.
-  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-35}"
+  # Three bounded prebuilt attempts plus the source fallback must leave a full
+  # minute beneath the workflow step's 10-minute ceiling, including kill grace.
+  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-25}"
   if [ "$mode" = "source" ]; then
-    timeout_seconds="${VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS:-420}"
+    timeout_seconds="${VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS:-405}"
   fi
+  local kill_grace_seconds="${VERCEL_DEPLOY_KILL_GRACE_SECONDS:-15}"
 
-  local deploy_cmd=(timeout --signal=TERM --kill-after=15s "$timeout_seconds")
+  local deploy_cmd=(timeout --signal=TERM --kill-after="${kill_grace_seconds}s" "$timeout_seconds")
 
   if [ "$mode" = "tgz" ]; then
     "${deploy_cmd[@]}" "${VERCEL_CMD[@]}" deploy --prebuilt --archive=tgz "$@" --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
@@ -114,7 +115,7 @@ try_mode() {
   fi
 
   echo "$deploy_output"
-  if [ "$deploy_status" -eq 124 ]; then
+  if [ "$deploy_status" -eq 124 ] || [ "$deploy_status" -eq 137 ]; then
     echo "Deploy attempt $attempt with ${mode} upload exceeded its time budget" >&2
   fi
   return 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2546,7 +2546,7 @@ jobs:
     needs: [ci-build-public, ci-path-changes, neon-db]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_public_lighthouse == 'true')) && needs.ci-build-public.outputs.has_artifact == 'true') }}
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -3810,6 +3810,19 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
 
+      - name: Wait for PR preview readiness
+        timeout-minutes: 9
+        run: |
+          ./node_modules/.bin/vercel inspect "${{ steps.pr_deploy.outputs.deployment_url }}" \
+            --wait \
+            --timeout 8m \
+            --token "$VERCEL_TOKEN" \
+            --scope "$VERCEL_ORG_ID"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
   # PR Lighthouse runs as a path-gated preview-evidence lane with stricter thresholds (0.75 perf, 0.85 a11y).
   # Original removal was due to 0.5 thresholds being too relaxed. Updated .lighthouserc.pr.json fixes this.
   # Production Lighthouse (in ci-build job) has even stricter thresholds (0.8 perf, 0.95 a11y).
@@ -4797,10 +4810,14 @@ jobs:
           CLERK_PUBLISHABLE_KEY_STAGING: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
           CLERK_SECRET_KEY_STAGING: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
 
-      - name: Alias preview to staging.jov.ie
-        timeout-minutes: 3
+      - name: Wait for staging deployment readiness
+        timeout-minutes: 9
         run: |
-          ./node_modules/.bin/vercel alias set "${{ steps.deploy.outputs.deploy_url }}" staging.jov.ie --token "$VERCEL_TOKEN" --scope "$VERCEL_ORG_ID"
+          ./node_modules/.bin/vercel inspect "${{ steps.deploy.outputs.deploy_url }}" \
+            --wait \
+            --timeout 8m \
+            --token "$VERCEL_TOKEN" \
+            --scope "$VERCEL_ORG_ID"
 
   canary-health-gate:
     name: Canary Health Gate (staging)
@@ -4824,10 +4841,32 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
-  promote-production:
-    name: Promote to Production
+  alias-staging:
+    name: Alias verified preview to staging.jov.ie
     needs: [deploy-staging, canary-health-gate]
     if: ${{ always() && needs.deploy-staging.result == 'success' && needs.canary-health-gate.result == 'success' }}
+    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    concurrency:
+      group: production-deploy
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Alias verified deployment
+        run: |
+          ./node_modules/.bin/vercel alias set "${{ needs.deploy-staging.outputs.deploy_url }}" staging.jov.ie \
+            --token "$VERCEL_TOKEN" \
+            --scope "$VERCEL_ORG_ID"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+  promote-production:
+    name: Promote to Production
+    needs: [deploy-staging, canary-health-gate, alias-staging]
+    if: ${{ always() && needs.deploy-staging.result == 'success' && needs.canary-health-gate.result == 'success' && needs.alias-staging.result == 'success' }}
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,7 +510,7 @@ jobs:
           # origin/<base>; a --depth=1 fetch leaves the base tip shallow and fails
           # desktop-release-guard / version-fanout-guard on PRs.
           git fetch origin "${{ github.base_ref }}" --no-tags
-          if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qE '^(\.github/|\.claude/|AGENTS\.md|CODEX\.md|scripts/lib/(ci-|merge-queue)|scripts/ci-)'; then
+          if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qE '^(\.github/|\.claude/|AGENTS\.md|CODEX\.md|scripts/lib/(ci-|merge-queue)|scripts/ci-|scripts/tests/test_vercel_prebuilt_deploy\.py)'; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           else
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -518,12 +518,12 @@ jobs:
       - name: Install actionlint (structural)
         if: steps.structural.outputs.skip != 'true'
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
-      - name: Set up Python (structural drain tests)
+      - name: Set up Python (structural regression tests)
         if: steps.structural.outputs.skip != 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
-      - name: Install pytest (structural drain tests)
+      - name: Install pytest (structural regression tests)
         if: steps.structural.outputs.skip != 'true'
         run: pip install pytest --quiet
       - name: Run ci-fast lanes

--- a/scripts/ci-fast-lanes.mjs
+++ b/scripts/ci-fast-lanes.mjs
@@ -216,8 +216,8 @@ function runStructural() {
     'pnpm doc:freshness:check',
     'node .github/scripts/quarantine-ledger.mjs validate',
     'pnpm --filter @jovie/web run test:reliability-detectors',
-    // Optional: drain regression tests need pytest; soft-skip if unavailable.
-    'if command -v pytest >/dev/null 2>&1; then pytest scripts/tests/test_gh_retry.py -v; elif python3 -c "import pytest" 2>/dev/null; then python3 -m pytest scripts/tests/test_gh_retry.py -v; else echo "pytest not installed — skip drain regression"; fi',
+    // Optional: structural regression tests need pytest; soft-skip if unavailable.
+    'if command -v pytest >/dev/null 2>&1; then pytest scripts/tests/test_gh_retry.py scripts/tests/test_vercel_prebuilt_deploy.py -v; elif python3 -c "import pytest" 2>/dev/null; then python3 -m pytest scripts/tests/test_gh_retry.py scripts/tests/test_vercel_prebuilt_deploy.py -v; else echo "pytest not installed — skip structural regressions"; fi',
   ];
 
   let combined = '';

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -15,6 +16,7 @@ def test_timed_out_prebuilt_uploads_fall_back_to_source(tmp_path: Path) -> None:
         """#!/usr/bin/env bash
 set -euo pipefail
 if [[ " $* " == *" --prebuilt "* ]]; then
+  trap '' TERM
   sleep 5
   exit 1
 fi
@@ -38,6 +40,7 @@ echo "https://jovie-timeout-test.vercel.app"
             "VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK": "true",
             "VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS": "1",
             "VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS": "5",
+            "VERCEL_DEPLOY_KILL_GRACE_SECONDS": "1",
         }
     )
 
@@ -57,3 +60,19 @@ echo "https://jovie-timeout-test.vercel.app"
     assert output_file.read_text().strip() == (
         "deploy_url=https://jovie-timeout-test.vercel.app"
     )
+
+
+def test_default_attempt_budgets_leave_one_minute_for_step_overhead() -> None:
+    script = DEPLOY_SCRIPT.read_text()
+
+    def default_for(name: str) -> int:
+        match = re.search(rf"\$\{{{name}:-([0-9]+)\}}", script)
+        assert match is not None, f"missing default for {name}"
+        return int(match.group(1))
+
+    archive = default_for("VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS")
+    source = default_for("VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS")
+    kill_grace = default_for("VERCEL_DEPLOY_KILL_GRACE_SECONDS")
+
+    worst_case_seconds = 3 * (archive + kill_grace) + source + kill_grace
+    assert worst_case_seconds <= 9 * 60

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -76,3 +76,58 @@ def test_default_attempt_budgets_leave_one_minute_for_step_overhead() -> None:
 
     worst_case_seconds = 3 * (archive + kill_grace) + source + kill_grace
     assert worst_case_seconds <= 9 * 60
+
+
+def test_timed_out_source_with_accepted_url_hands_off_to_health_gate(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_vercel = bin_dir / "vercel"
+    fake_vercel.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ " $* " == *" --prebuilt "* ]]; then
+  exit 1
+fi
+echo "https://jovie-accepted-test.vercel.app"
+trap '' TERM
+sleep 5
+"""
+    )
+    fake_vercel.chmod(0o755)
+
+    output_file = tmp_path / "github-output"
+    prebuilt_output = tmp_path / ".vercel/output"
+    prebuilt_output.mkdir(parents=True)
+    (prebuilt_output / "config.json").write_text("{}")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "VERCEL_TOKEN": "test-token",
+            "VERCEL_ORG_ID": "test-org",
+            "GITHUB_OUTPUT": str(output_file),
+            "VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK": "true",
+            "VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS": "1",
+            "VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS": "1",
+            "VERCEL_DEPLOY_KILL_GRACE_SECONDS": "1",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(DEPLOY_SCRIPT), "deploy_url", "--yes"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "downstream health gates will verify readiness" in result.stdout
+    assert output_file.read_text().strip() == (
+        "deploy_url=https://jovie-accepted-test.vercel.app"
+    )

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY_SCRIPT = REPO_ROOT / ".github/scripts/vercel-prebuilt-deploy.sh"
+CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
 
 
 def test_timed_out_prebuilt_uploads_fall_back_to_source(tmp_path: Path) -> None:
@@ -131,3 +132,26 @@ sleep 5
     assert output_file.read_text().strip() == (
         "deploy_url=https://jovie-accepted-test.vercel.app"
     )
+
+
+def test_workflow_waits_for_readiness_and_aliases_only_after_canary() -> None:
+    workflow = CI_WORKFLOW.read_text()
+
+    deploy_index = workflow.index("- name: Deploy (staging preview, prebuilt)")
+    wait_index = workflow.index("- name: Wait for staging deployment readiness")
+    canary_index = workflow.index("  canary-health-gate:")
+    alias_job_index = workflow.index("  alias-staging:")
+    promote_index = workflow.index("  promote-production:")
+
+    assert deploy_index < wait_index < canary_index < alias_job_index < promote_index
+    assert "vercel inspect" in workflow[wait_index:canary_index]
+    assert "--wait" in workflow[wait_index:canary_index]
+    assert "needs: [deploy-staging, canary-health-gate, alias-staging]" in workflow[
+        promote_index:
+    ]
+
+    preview_deploy_index = workflow.index(
+        "- name: Deploy (PR preview, fast deployment for UI-only changes)"
+    )
+    preview_wait_index = workflow.index("- name: Wait for PR preview readiness")
+    assert preview_deploy_index < preview_wait_index < deploy_index

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -1,0 +1,59 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_SCRIPT = REPO_ROOT / ".github/scripts/vercel-prebuilt-deploy.sh"
+
+
+def test_timed_out_prebuilt_uploads_fall_back_to_source(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_vercel = bin_dir / "vercel"
+    fake_vercel.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ " $* " == *" --prebuilt "* ]]; then
+  sleep 5
+  exit 1
+fi
+echo "https://jovie-timeout-test.vercel.app"
+"""
+    )
+    fake_vercel.chmod(0o755)
+
+    output_file = tmp_path / "github-output"
+    prebuilt_output = tmp_path / ".vercel/output"
+    prebuilt_output.mkdir(parents=True)
+    (prebuilt_output / "config.json").write_text("{}")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "VERCEL_TOKEN": "test-token",
+            "VERCEL_ORG_ID": "test-org",
+            "GITHUB_OUTPUT": str(output_file),
+            "VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK": "true",
+            "VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS": "1",
+            "VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS": "5",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(DEPLOY_SCRIPT), "deploy_url", "--yes"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stderr.count("exceeded its time budget") == 3
+    assert "Deploy succeeded on attempt 4 with source upload" in result.stdout
+    assert output_file.read_text().strip() == (
+        "deploy_url=https://jovie-timeout-test.vercel.app"
+    )


### PR DESCRIPTION
## Summary
- bound each Vercel upload mode so one hung CLI process cannot consume the workflow
- preserve an accepted source deployment URL when the CLI times out waiting for the remote build
- wait explicitly for Vercel readiness before downstream preview checks
- run exact-SHA canary before moving the shared staging alias
- require the verified staging alias before production promotion
- gate fallback behavior, forced-kill handling, readiness sequencing, and budget arithmetic in `ci-fast`

## Root cause
Vercel accepted the source deployment and printed its URL, then the CLI waited for the remote build until the step timeout. The workflow discarded the URL and retried. A naive handoff would also have aliased the still-building deployment before canary.

## Verification
- `python3 -m pytest scripts/tests/test_vercel_prebuilt_deploy.py -q` (4 passed)
- `python3 -m pytest scripts/tests/test_gh_retry.py scripts/tests/test_vercel_prebuilt_deploy.py -q` (29 passed)
- `bash -n .github/scripts/vercel-prebuilt-deploy.sh`
- `shellcheck .github/scripts/vercel-prebuilt-deploy.sh`
- `actionlint .github/workflows/ci.yml` with repository ShellCheck exclusions
- `node --check scripts/ci-fast-lanes.mjs`
- `git diff --check`

Bug-to-test: waived — the deploy shell regressions are covered and required by `scripts/tests/test_vercel_prebuilt_deploy.py`; the repository gate only recognizes JavaScript and TypeScript test suffixes.