### PR TITLE
test(admin): approve-gate short-circuit + ingest partial-failure coverage (JOV-4220)

### DIFF
--- a/apps/web/tests/unit/actions/admin-actions.test.ts
+++ b/apps/web/tests/unit/actions/admin-actions.test.ts
@@ -418,6 +418,49 @@ describe('admin/actions.ts', () => {
       expect(mockRevalidatePath).toHaveBeenCalledWith('/admin');
     });
 
+    it('skips profiles missing both spotifyId and spotifyUrl without failing the batch', async () => {
+      const profiles = [
+        {
+          id: 'p1',
+          spotifyId: 'spotify-1',
+          spotifyUrl: null,
+        },
+        {
+          id: 'p2',
+          spotifyId: null,
+          spotifyUrl: null,
+        },
+      ];
+
+      createMultiSelectChain([
+        [{ userStatus: 'active', deletedAt: null }], // requireAdmin lookup
+        profiles, // action's select
+      ]);
+
+      mockEnqueueMusicFetchEnrichmentJob.mockResolvedValue('job-id');
+      mockEnqueueDspArtistDiscoveryJob.mockResolvedValue('discovery-job-id');
+
+      const { bulkRerunCreatorIngestionAction } = await import(
+        '@/app/app/(shell)/admin/actions'
+      );
+
+      const fd = makeFormData({
+        profileIds: JSON.stringify(['p1', 'p2']),
+      });
+
+      await expect(bulkRerunCreatorIngestionAction(fd)).resolves.toEqual({
+        queuedCount: 1,
+      });
+      expect(mockEnqueueMusicFetchEnrichmentJob).toHaveBeenCalledTimes(1);
+      expect(mockEnqueueMusicFetchEnrichmentJob).toHaveBeenCalledWith({
+        creatorProfileId: 'p1',
+        spotifyUrl: 'https://open.spotify.com/artist/spotify-1',
+      });
+      // p2 is skipped entirely -- no DSP discovery fired for the bad record.
+      expect(mockEnqueueDspArtistDiscoveryJob).toHaveBeenCalledTimes(1);
+      expect(mockRevalidatePath).toHaveBeenCalledWith('/admin');
+    });
+
     it('rejects more than 200 profileIds', async () => {
       const { bulkRerunCreatorIngestionAction } = await import(
         '@/app/app/(shell)/admin/actions'

--- a/apps/web/tests/unit/api/admin/waitlist-approve.test.ts
+++ b/apps/web/tests/unit/api/admin/waitlist-approve.test.ts
@@ -60,6 +60,64 @@ describe('Admin Waitlist Approve API', () => {
     mockEnqueueWaitlistApprovalInviteEmail.mockResolvedValue('job-1');
   });
 
+  it('returns 401 when the caller is not authenticated', async () => {
+    mockGetCurrentUserEntitlements.mockResolvedValue({
+      userId: null,
+      email: null,
+      isAuthenticated: false,
+      isAdmin: false,
+      isPro: false,
+      hasAdvancedFeatures: false,
+      canRemoveBranding: false,
+    });
+
+    const response = await POST(
+      new Request('http://localhost/app/admin/waitlist/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          entryId: '11111111-1111-4111-8111-111111111111',
+        }),
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toEqual({ success: false, error: 'Unauthorized' });
+    expect(mockWithSystemIngestionSession).not.toHaveBeenCalled();
+    expect(mockApproveWaitlistEntryInTx).not.toHaveBeenCalled();
+    expect(mockEnqueueWaitlistApprovalInviteEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the caller is authenticated but not an admin', async () => {
+    mockGetCurrentUserEntitlements.mockResolvedValue({
+      userId: 'user_123',
+      email: 'user@example.com',
+      isAuthenticated: true,
+      isAdmin: false,
+      isPro: false,
+      hasAdvancedFeatures: false,
+      canRemoveBranding: false,
+    });
+
+    const response = await POST(
+      new Request('http://localhost/app/admin/waitlist/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          entryId: '22222222-2222-4222-8222-222222222222',
+        }),
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data).toEqual({ success: false, error: 'Forbidden' });
+    expect(mockWithSystemIngestionSession).not.toHaveBeenCalled();
+    expect(mockApproveWaitlistEntryInTx).not.toHaveBeenCalled();
+    expect(mockEnqueueWaitlistApprovalInviteEmail).not.toHaveBeenCalled();
+  });
+
   it('rejects concurrent approvals after the entry is processed', async () => {
     const entryId = '11111111-1111-4111-8111-111111111111';
 


### PR DESCRIPTION
## Summary

Batch 13B of the coverage loop — two admin-surface gaps, both re-verified real against current main and the open sibling PRs:

- **waitlist-approve route**: the 401/403 gates now have tests with never-called guards on `withSystemIngestionSession`/approve/email. The frontier gate proved these load-bearing via a mutant that ran the side effects *before* returning the correct gate status — status-only tests would have shipped that hole.
- **`bulkRerunCreatorIngestionAction`**: a profile missing both `spotifyId` and `spotifyUrl` is silently skipped — the batch resolves, `queuedCount` counts only real jobs, enrichment fires exactly once with the derived URL, and no DSP-discovery side effect runs for the skipped profile.

## Verification
- 56/56 across both suites; typecheck + biome clean
- **Frontier gate 4/4 killed**: swapped gates, side-effects-before-gate, abort-on-missing-fields, count-skipped-jobs

## Notes
- Per loop policy, no CHANGELOG entry. bug-to-test: N/A — tests-only. Cost impact: none. No UI change.