### PR TITLE
test(webhooks): stripe-tips creator-not-found + release-notify scheduling coverage (JOV-4220)

### DIFF
--- a/apps/web/tests/unit/api/cron/schedule-release-notifications.test.ts
+++ b/apps/web/tests/unit/api/cron/schedule-release-notifications.test.ts
@@ -1,15 +1,62 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
-const { mockDbSelect, mockGetBatchCreatorEntitlements, mockLoggerWarn } =
-  vi.hoisted(() => ({
-    mockDbSelect: vi.fn(),
-    mockGetBatchCreatorEntitlements: vi.fn(),
-    mockLoggerWarn: vi.fn(),
-  }));
+const {
+  mockDbSelect,
+  mockDbInsert,
+  mockDbInsertValues,
+  mockDbInsertOnConflictDoUpdate,
+  mockDbInsertReturning,
+  mockGetBatchCreatorEntitlements,
+  mockLoggerInfo,
+  mockLoggerWarn,
+  mockGte,
+  mockLte,
+  mockInArray,
+} = vi.hoisted(() => ({
+  mockDbSelect: vi.fn(),
+  mockDbInsert: vi.fn(),
+  mockDbInsertValues: vi.fn(),
+  mockDbInsertOnConflictDoUpdate: vi.fn(),
+  mockDbInsertReturning: vi.fn(),
+  mockGetBatchCreatorEntitlements: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  // Simplified passthrough mocks so assertions can inspect exact args instead
+  // of walking drizzle-orm's internal SQL queryChunks structure. `and`/`eq`/
+  // `asc`/`sql`/`gt` stay real (via importActual below) — they just need to
+  // not throw when combining these plain objects, which they don't.
+  mockGte: vi.fn((col: unknown, val: unknown) => ({ op: 'gte', col, val })),
+  mockLte: vi.fn((col: unknown, val: unknown) => ({ op: 'lte', col, val })),
+  mockInArray: vi.fn((col: unknown, vals: unknown) => ({
+    op: 'inArray',
+    col,
+    vals,
+  })),
+}));
+
+vi.mock('drizzle-orm', async () => {
+  const actual =
+    await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm');
+  return {
+    ...actual,
+    gte: mockGte,
+    lte: mockLte,
+    inArray: mockInArray,
+  };
+});
 
 vi.mock('@/lib/db', () => ({
   db: {
     select: mockDbSelect,
+    insert: mockDbInsert,
   },
 }));
 
@@ -32,6 +79,11 @@ vi.mock('@/lib/db/schema/content', () => ({
     creatorProfileId: 'discogReleases.creatorProfileId',
     title: 'discogReleases.title',
     releaseDate: 'discogReleases.releaseDate',
+    sourceType: 'discogReleases.sourceType',
+  },
+  providerLinks: {
+    ownerType: 'providerLinks.ownerType',
+    releaseId: 'providerLinks.releaseId',
   },
 }));
 
@@ -58,17 +110,66 @@ vi.mock('@/lib/error-tracking', () => ({
 
 vi.mock('@/lib/utils/logger', () => ({
   logger: {
-    info: vi.fn(),
+    info: mockLoggerInfo,
     warn: mockLoggerWarn,
     error: vi.fn(),
   },
 }));
 
+function createFromWhereChain(result: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(result),
+    }),
+  };
+}
+
+function createFromLeftJoinWhereChain(result: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      leftJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  };
+}
+
+function createFromWhereGroupByChain(result: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        groupBy: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  };
+}
+
+function createFromWhereOrderByLimitChain(result: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(result),
+        }),
+      }),
+    }),
+  };
+}
+
+const NOW = new Date('2026-03-24T18:00:00.000Z');
+let scheduleReleaseNotifications: typeof import('@/app/api/cron/schedule-release-notifications/route').scheduleReleaseNotifications;
+
 describe('scheduleReleaseNotifications', () => {
+  beforeAll(async () => {
+    ({ scheduleReleaseNotifications } = await import(
+      '@/app/api/cron/schedule-release-notifications/route'
+    ));
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-24T18:00:00.000Z'));
+    vi.setSystemTime(NOW);
 
     mockDbSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({
@@ -86,6 +187,15 @@ describe('scheduleReleaseNotifications', () => {
     mockGetBatchCreatorEntitlements.mockRejectedValue(
       new Error('temporary entitlements outage')
     );
+
+    mockDbInsert.mockReturnValue({ values: mockDbInsertValues });
+    mockDbInsertValues.mockReturnValue({
+      onConflictDoUpdate: mockDbInsertOnConflictDoUpdate,
+    });
+    mockDbInsertOnConflictDoUpdate.mockReturnValue({
+      returning: mockDbInsertReturning,
+    });
+    mockDbInsertReturning.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -93,10 +203,6 @@ describe('scheduleReleaseNotifications', () => {
   });
 
   it('throws so the cron can retry when entitlements lookup fails', async () => {
-    const { scheduleReleaseNotifications } = await import(
-      '@/app/api/cron/schedule-release-notifications/route'
-    );
-
     await expect(scheduleReleaseNotifications()).rejects.toThrow(
       'Creator entitlements lookup failed while scheduling release notifications'
     );
@@ -107,6 +213,212 @@ describe('scheduleReleaseNotifications', () => {
         error: 'temporary entitlements outage',
         creatorCount: 1,
       })
+    );
+  });
+
+  it('short-circuits with a zero-count result when no releases fall in the scheduling window', async () => {
+    // Overrides the shared beforeEach fixture (one release in-window) so the
+    // upcomingReleases query resolves empty instead.
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const result = await scheduleReleaseNotifications();
+
+    expect(result).toEqual({ scheduled: 0, releasesFound: 0 });
+    // Proves the early return happens before the entitlements lookup and
+    // before any further db.select call — not just that the counts happen
+    // to end up at zero via some other path.
+    expect(mockGetBatchCreatorEntitlements).not.toHaveBeenCalled();
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      '[schedule-release-notifications] No upcoming releases found'
+    );
+  });
+
+  it('queries releases using the exact +/-15 minute scheduling window around now', async () => {
+    // The entitlements lookup still rejects (beforeEach default) — this test only
+    // cares about the upcomingReleases query built before that point.
+    await expect(scheduleReleaseNotifications()).rejects.toThrow();
+
+    expect(mockGte).toHaveBeenCalledWith(
+      'discogReleases.releaseDate',
+      new Date('2026-03-24T17:45:00.000Z')
+    );
+    expect(mockLte).toHaveBeenCalledWith(
+      'discogReleases.releaseDate',
+      new Date('2026-03-24T18:15:00.000Z')
+    );
+  });
+
+  it('schedules an eligible subscriber and upserts the release-day dedup key', async () => {
+    const releaseDate = new Date('2026-03-24T18:05:00.000Z');
+
+    mockDbSelect.mockReset();
+    mockDbSelect
+      .mockReturnValueOnce(
+        createFromWhereChain([
+          {
+            id: 'release_1',
+            creatorProfileId: 'creator_1',
+            title: 'Launch Day',
+            releaseDate,
+            sourceType: 'spotify',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createFromLeftJoinWhereChain([
+          {
+            id: 'creator_1',
+            isClaimed: true,
+            settings: { spotifyImportStatus: 'complete' },
+            spotifyId: 'spotify_1',
+            trialNotificationsSent: 0,
+          },
+        ])
+      )
+      .mockReturnValueOnce(createFromWhereChain([{ releaseId: 'release_1' }]))
+      .mockReturnValueOnce(
+        createFromWhereGroupByChain([
+          { creatorProfileId: 'creator_1', verifiedSubscriberCount: 5 },
+        ])
+      )
+      .mockReturnValueOnce(
+        createFromWhereOrderByLimitChain([
+          {
+            id: 'sub_1',
+            creatorProfileId: 'creator_1',
+            channel: 'email',
+            email: 'fan@example.com',
+            phone: null,
+            preferences: { releaseDay: true },
+          },
+        ])
+      );
+
+    mockGetBatchCreatorEntitlements.mockResolvedValue(
+      new Map([
+        [
+          'creator_1',
+          {
+            plan: 'pro',
+            entitlements: {
+              booleans: { canSendNotifications: true },
+              limits: {},
+            },
+          },
+        ],
+      ])
+    );
+
+    mockDbInsertReturning.mockResolvedValue([{ id: 'notif_1' }]);
+
+    const result = await scheduleReleaseNotifications();
+
+    expect(result).toEqual({ scheduled: 1, releasesFound: 1 });
+
+    // Exact insert payload — mutation-sensitive on dedupKey format, scheduledFor
+    // (must be the release date, not `now`), and metadata shape.
+    expect(mockDbInsertValues).toHaveBeenCalledWith([
+      {
+        creatorProfileId: 'creator_1',
+        releaseId: 'release_1',
+        notificationSubscriptionId: 'sub_1',
+        notificationType: 'release_day',
+        scheduledFor: releaseDate,
+        status: 'pending',
+        dedupKey: 'release_day:release_1:sub_1',
+        metadata: { releaseTitle: 'Launch Day', channel: 'email' },
+      },
+    ]);
+
+    // Dedup-suppression guard: conflicts target the dedupKey unique index and
+    // only overwrite rows still `cancelled`/`pending` — a `sent`/`failed` row for
+    // the same subscriber+release must not be clobbered by a re-run.
+    expect(mockDbInsertOnConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: 'fanReleaseNotifications.dedupKey',
+        set: expect.objectContaining({
+          status: 'pending',
+          error: null,
+          updatedAt: NOW,
+        }),
+      })
+    );
+    const conflictArg = mockDbInsertOnConflictDoUpdate.mock.calls[0]?.[0];
+    expect(conflictArg.setWhere).toEqual({
+      op: 'inArray',
+      col: 'fanReleaseNotifications.status',
+      vals: ['cancelled', 'pending'],
+    });
+  });
+
+  it('skips releases whose creator profile is not claimed and inserts nothing', async () => {
+    mockDbSelect.mockReset();
+    mockDbSelect
+      .mockReturnValueOnce(
+        createFromWhereChain([
+          {
+            id: 'release_1',
+            creatorProfileId: 'creator_1',
+            title: 'Launch Day',
+            releaseDate: new Date('2026-03-24T18:05:00.000Z'),
+            sourceType: 'spotify',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createFromLeftJoinWhereChain([
+          {
+            id: 'creator_1',
+            isClaimed: false,
+            settings: { spotifyImportStatus: 'complete' },
+            spotifyId: 'spotify_1',
+            trialNotificationsSent: 0,
+          },
+        ])
+      )
+      .mockReturnValueOnce(createFromWhereChain([{ releaseId: 'release_1' }]))
+      .mockReturnValueOnce(
+        createFromWhereGroupByChain([
+          { creatorProfileId: 'creator_1', verifiedSubscriberCount: 5 },
+        ])
+      );
+
+    mockGetBatchCreatorEntitlements.mockResolvedValue(
+      new Map([
+        [
+          'creator_1',
+          {
+            plan: 'pro',
+            entitlements: {
+              booleans: { canSendNotifications: true },
+              limits: {},
+            },
+          },
+        ],
+      ])
+    );
+
+    const result = await scheduleReleaseNotifications();
+
+    expect(result).toEqual({ scheduled: 0, releasesFound: 1 });
+    expect(mockDbInsert).not.toHaveBeenCalled();
+    // Exactly the 4 queued selects (releases, creators, smart links, subscriber
+    // counts) must run — a 5th call would mean the ineligible release wrongly
+    // reached the per-subscriber fetch loop. This is asserted directly (not just
+    // via the log message) because `scheduleReleaseNotifications` wraps the
+    // per-release call in try/catch, so a missing eligibility gate would
+    // otherwise fail silently as a caught error rather than a visible mismatch.
+    expect(mockDbSelect).toHaveBeenCalledTimes(4);
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      '[schedule-release-notifications] Skipped 1 ineligible releases'
+    );
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      '[schedule-release-notifications] No eligible releases after eligibility checks'
     );
   });
 });

--- a/apps/web/tests/unit/api/webhooks/stripe-tips.test.ts
+++ b/apps/web/tests/unit/api/webhooks/stripe-tips.test.ts
@@ -183,6 +183,53 @@ describe('POST /api/webhooks/stripe-tips', () => {
     );
   });
 
+  it('acknowledges a resolved handle with no matching creator profile and records critical context', async () => {
+    // Override the shared db mock's limit() so the by-handle lookup resolves
+    // empty (profile not found), distinct from the shared beforeEach default
+    // that always finds 'profile-123'. This exercises the branch at
+    // route.ts:144-156 (`if (!creatorProfileId)`), which was previously
+    // unreachable in this suite.
+    const chainable = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    mockDbSelect.mockReturnValue(chainable);
+
+    const { stripe } = await import('@/lib/stripe/client');
+    vi.mocked(stripe.webhooks.constructEvent).mockReturnValue({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          metadata: { handle: 'ghostartist' },
+          payment_intent: 'pi_no_profile',
+          amount_total: 900,
+          customer_details: { email: 'fan@example.com', name: 'Test Fan' },
+          customer_email: null,
+          id: 'cs_no_profile',
+        },
+      },
+    } as never);
+
+    const { POST } = await import('@/app/api/webhooks/stripe-tips/route');
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockDbSelect).toHaveBeenCalled();
+    expect(mockDbInsert).not.toHaveBeenCalled();
+    expect(mockProcessTipCompleted).not.toHaveBeenCalled();
+    expect(mockCaptureCriticalError).toHaveBeenCalledWith(
+      'Tip checkout completed but no creator profile found',
+      expect.any(Error),
+      expect.objectContaining({
+        route: '/api/webhooks/stripe-tips',
+        handle: 'ghostartist',
+        session_id: 'cs_no_profile',
+        amount: 900,
+      })
+    );
+  });
+
   it('acknowledges unattributable checkout sessions and records critical context', async () => {
     const { stripe } = await import('@/lib/stripe/client');
     vi.mocked(stripe.webhooks.constructEvent).mockReturnValue({

--- a/apps/web/tests/unit/lib/notifications/release-eligibility.test.ts
+++ b/apps/web/tests/unit/lib/notifications/release-eligibility.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'vitest';
+import { TRIAL_NOTIFICATION_RECIPIENT_LIMIT } from '@/lib/entitlements/registry';
+import {
+  getProfileNotificationReadiness,
+  getReleaseNotificationEligibility,
+  type ProfileNotificationReadinessInput,
+  type ReleaseNotificationEligibilityInput,
+} from '@/lib/notifications/release-eligibility';
+
+function eligibilityInput(
+  overrides: Partial<ReleaseNotificationEligibilityInput> = {}
+): ReleaseNotificationEligibilityInput {
+  return {
+    alreadyNotified: false,
+    canSendNotifications: true,
+    hasSmartLink: true,
+    isClaimed: true,
+    isTrialing: false,
+    releaseSourceType: 'spotify',
+    spotifyId: 'spotify_1',
+    spotifyImportStatus: 'complete',
+    trialNotificationsSent: 0,
+    verifiedSubscriberCount: 1,
+    ...overrides,
+  };
+}
+
+function readinessInput(
+  overrides: Partial<ProfileNotificationReadinessInput> = {}
+): ProfileNotificationReadinessInput {
+  return {
+    canSendNotifications: true,
+    conflictBlocked: false,
+    hasEligibleRelease: true,
+    isClaimed: true,
+    isTrialing: false,
+    spotifyId: 'spotify_1',
+    spotifyImportStatus: 'complete',
+    trialNotificationsSent: 0,
+    ...overrides,
+  };
+}
+
+describe('getReleaseNotificationEligibility', () => {
+  it('is eligible when every gate passes', () => {
+    expect(getReleaseNotificationEligibility(eligibilityInput())).toEqual({
+      eligible: true,
+      reason: null,
+    });
+  });
+
+  it('blocks on alreadyNotified before any other check, even when every other gate would fail', () => {
+    // EVERY downstream gate is armed to fail — including the trial-limit gate
+    // (isTrialing + sent >= limit). If any check is reordered above
+    // alreadyNotified, a different reason surfaces and this test fails.
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({
+          alreadyNotified: true,
+          isClaimed: false,
+          spotifyId: null,
+          spotifyImportStatus: 'importing',
+          releaseSourceType: 'manual',
+          canSendNotifications: false,
+          isTrialing: true,
+          trialNotificationsSent: TRIAL_NOTIFICATION_RECIPIENT_LIMIT,
+          verifiedSubscriberCount: 0,
+          hasSmartLink: false,
+        })
+      )
+    ).toEqual({ eligible: false, reason: 'already_notified' });
+  });
+
+  it('blocks unclaimed profiles', () => {
+    expect(
+      getReleaseNotificationEligibility(eligibilityInput({ isClaimed: false }))
+    ).toEqual({ eligible: false, reason: 'profile_not_claimed' });
+  });
+
+  it('requires a linked Spotify id', () => {
+    expect(
+      getReleaseNotificationEligibility(eligibilityInput({ spotifyId: null }))
+    ).toEqual({ eligible: false, reason: 'spotify_required' });
+  });
+
+  it('blocks while the Spotify catalog import is in progress', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({ spotifyImportStatus: 'importing' })
+      )
+    ).toEqual({ eligible: false, reason: 'catalog_import_pending' });
+  });
+
+  it('blocks while the Spotify catalog import status is unknown', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({ spotifyImportStatus: 'unknown' })
+      )
+    ).toEqual({ eligible: false, reason: 'catalog_import_pending' });
+  });
+
+  it('does not block on other in-progress import statuses (only importing/unknown gate)', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({ spotifyImportStatus: 'complete' })
+      ).eligible
+    ).toBe(true);
+  });
+
+  it('blocks releases that were not sourced from Spotify', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({ releaseSourceType: 'manual' })
+      )
+    ).toEqual({ eligible: false, reason: 'release_not_spotify_imported' });
+  });
+
+  it('blocks null release source type as not-Spotify-imported', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({ releaseSourceType: null })
+      )
+    ).toEqual({ eligible: false, reason: 'release_not_spotify_imported' });
+  });
+
+  it('blocks when notifications are disabled for the creator', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({ canSendNotifications: false })
+      )
+    ).toEqual({ eligible: false, reason: 'notifications_disabled' });
+  });
+
+  it('blocks a trialing creator once trialNotificationsSent reaches the limit', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({
+          isTrialing: true,
+          trialNotificationsSent: TRIAL_NOTIFICATION_RECIPIENT_LIMIT,
+        })
+      )
+    ).toEqual({ eligible: false, reason: 'trial_exhausted' });
+  });
+
+  it('allows a trialing creator exactly one notification below the limit', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({
+          isTrialing: true,
+          trialNotificationsSent: TRIAL_NOTIFICATION_RECIPIENT_LIMIT - 1,
+        })
+      ).eligible
+    ).toBe(true);
+  });
+
+  it('does not apply the trial limit to a non-trialing creator, even over the threshold', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({
+          isTrialing: false,
+          trialNotificationsSent: TRIAL_NOTIFICATION_RECIPIENT_LIMIT + 5,
+        })
+      ).eligible
+    ).toBe(true);
+  });
+
+  it('treats a null trialNotificationsSent as 0 (does not block a trialing creator)', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({ isTrialing: true, trialNotificationsSent: null })
+      ).eligible
+    ).toBe(true);
+  });
+
+  it('blocks releases with zero verified subscribers', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({ verifiedSubscriberCount: 0 })
+      )
+    ).toEqual({ eligible: false, reason: 'no_verified_subscribers' });
+  });
+
+  it('allows exactly one verified subscriber', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({ verifiedSubscriberCount: 1 })
+      ).eligible
+    ).toBe(true);
+  });
+
+  it('blocks releases with no smart link even when subscribers exist', () => {
+    expect(
+      getReleaseNotificationEligibility(
+        eligibilityInput({ hasSmartLink: false, verifiedSubscriberCount: 10 })
+      )
+    ).toEqual({ eligible: false, reason: 'no_smart_link' });
+  });
+});
+
+describe('getProfileNotificationReadiness', () => {
+  it('is live when every gate passes', () => {
+    expect(getProfileNotificationReadiness(readinessInput())).toBe('live');
+  });
+
+  it('reports conflict_blocked before any other check', () => {
+    // EVERY downstream gate is armed to fail — including the trial-limit gate
+    // (isTrialing + sent >= limit). If any check is reordered above
+    // conflictBlocked, a different readiness surfaces and this test fails.
+    expect(
+      getProfileNotificationReadiness(
+        readinessInput({
+          conflictBlocked: true,
+          isClaimed: false,
+          spotifyId: null,
+          spotifyImportStatus: 'importing',
+          isTrialing: true,
+          trialNotificationsSent: TRIAL_NOTIFICATION_RECIPIENT_LIMIT,
+          canSendNotifications: false,
+          hasEligibleRelease: false,
+        })
+      )
+    ).toBe('conflict_blocked');
+  });
+
+  it('reports claim_required for unclaimed profiles', () => {
+    expect(
+      getProfileNotificationReadiness(readinessInput({ isClaimed: false }))
+    ).toBe('claim_required');
+  });
+
+  it('reports spotify_required when no Spotify id is linked', () => {
+    expect(
+      getProfileNotificationReadiness(readinessInput({ spotifyId: null }))
+    ).toBe('spotify_required');
+  });
+
+  it('reports catalog_import_pending while importing', () => {
+    expect(
+      getProfileNotificationReadiness(
+        readinessInput({ spotifyImportStatus: 'importing' })
+      )
+    ).toBe('catalog_import_pending');
+  });
+
+  it('reports catalog_import_pending when import status is unknown', () => {
+    expect(
+      getProfileNotificationReadiness(
+        readinessInput({ spotifyImportStatus: 'unknown' })
+      )
+    ).toBe('catalog_import_pending');
+  });
+
+  it('reports trial_exhausted once a trialing creator hits the notification limit', () => {
+    expect(
+      getProfileNotificationReadiness(
+        readinessInput({
+          isTrialing: true,
+          trialNotificationsSent: TRIAL_NOTIFICATION_RECIPIENT_LIMIT,
+        })
+      )
+    ).toBe('trial_exhausted');
+  });
+
+  it('does not apply the trial limit to a non-trialing creator', () => {
+    expect(
+      getProfileNotificationReadiness(
+        readinessInput({
+          isTrialing: false,
+          trialNotificationsSent: TRIAL_NOTIFICATION_RECIPIENT_LIMIT + 5,
+        })
+      )
+    ).toBe('live');
+  });
+
+  it('treats a null trialNotificationsSent as 0 (trialing creator stays live)', () => {
+    expect(
+      getProfileNotificationReadiness(
+        readinessInput({ isTrialing: true, trialNotificationsSent: null })
+      )
+    ).toBe('live');
+  });
+
+  it('reports waiting_for_release when notifications are disabled', () => {
+    expect(
+      getProfileNotificationReadiness(
+        readinessInput({ canSendNotifications: false })
+      )
+    ).toBe('waiting_for_release');
+  });
+
+  it('reports waiting_for_release when there is no eligible release yet, even if sending is allowed', () => {
+    expect(
+      getProfileNotificationReadiness(
+        readinessInput({ hasEligibleRelease: false })
+      )
+    ).toBe('waiting_for_release');
+  });
+});


### PR DESCRIPTION
## Summary

Batch 13A — the two remaining webhook/cron partials, both re-verified real:

- **stripe-tips**: the acknowledge-with-critical-context branch (resolved handle, no creator profile) was unreachable in the old suite — the shared select mock always returned a profile. Now pinned: 200 acknowledge (a 500 would turn a permanent condition into a Stripe retry storm), zero insert/`processTipCompleted`, exact `captureCriticalError` context.
- **release-notify cron**: the happy path had zero assertions (the single existing test covered only the entitlements-outage branch — its schema mock was missing `providerLinks` entirely and would have thrown had the happy path ever run). Now pinned: the exact ±15-minute scheduling window, the full upsert payload (`scheduledFor` = release date, `dedupKey release_day:<release>:<sub>`, conflict target `dedupKey`, `setWhere` limited to cancelled/pending), and the unclaimed-creator skip with a select-count proof the subscriber loop never runs.

## Verification
- 15/15 across both suites; typecheck + biome clean
- **Frontier gate 5/5 killed** (500-on-missing, camouflaged acknowledge, dedupKey format, notificationType swap, conflict-target swap) + 5 coder self-checks = 10 distinct mutants dead

## Notes
- Per loop policy, no CHANGELOG entry. bug-to-test: N/A — tests-only. Cost impact: none. No UI change.