### PR TITLE
fix(library-share): preserve base64url token entropy (JOV-4220)

### DIFF
--- a/apps/web/lib/library-share/token.ts
+++ b/apps/web/lib/library-share/token.ts
@@ -1,11 +1,11 @@
 import { randomBytes } from 'node:crypto';
 
 const TOKEN_BYTES = 18;
+type RandomBytesSource = (size: number) => Buffer;
 
 /** URL-safe opaque token for public /drop/[token] links. */
-export function generateLibraryShareDropToken(): string {
-  return randomBytes(TOKEN_BYTES)
-    .toString('base64url')
-    .replace(/[^a-zA-Z0-9]/g, '')
-    .slice(0, 24);
+export function generateLibraryShareDropToken(
+  randomBytesSource: RandomBytesSource = randomBytes
+): string {
+  return randomBytesSource(TOKEN_BYTES).toString('base64url');
 }

--- a/apps/web/tests/unit/library-share/service.test.ts
+++ b/apps/web/tests/unit/library-share/service.test.ts
@@ -1,0 +1,244 @@
+import { getTableName } from 'drizzle-orm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BASE_URL } from '@/constants/app';
+import { LIBRARY_SHARE_DROP_ROUTE_PREFIX } from '@/lib/library-share/constants';
+import { verifyLibrarySharePassphrase } from '@/lib/library-share/passphrase';
+
+// All DB calls are mocked — no real Postgres connection required. Table
+// routing uses `getTableName` (matches the pattern in
+// lib/release-to-revenue/gmv-attribution.test.ts) rather than object
+// identity, so the mock stays robust to module re-instantiation.
+const ownedReleaseRows: Array<Array<{ id: string }>> = [];
+const selectSpy = vi.fn();
+const dropValuesSpy = vi.fn();
+const itemsValuesSpy = vi.fn();
+const dropIdToReturn = { value: 'drop-id-1' };
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: (...args: unknown[]) => {
+      selectSpy(...args);
+      return {
+        from: () => ({
+          where: () => Promise.resolve(ownedReleaseRows.shift() ?? []),
+        }),
+      };
+    },
+    insert: (table: unknown) => {
+      const tableName = getTableName(table as never);
+      if (tableName === 'library_share_drops') {
+        return {
+          values: (values: unknown) => {
+            dropValuesSpy(values);
+            const captured = values as Record<string, unknown>;
+            return {
+              returning: () =>
+                Promise.resolve([
+                  { id: dropIdToReturn.value, token: captured.token },
+                ]),
+            };
+          },
+        };
+      }
+      return {
+        values: (values: unknown) => {
+          itemsValuesSpy(values);
+          return Promise.resolve(undefined);
+        },
+      };
+    },
+  },
+}));
+
+import { createLibraryShareDrop } from '@/lib/library-share/service';
+
+const PROFILE_ID = 'creator-profile-1';
+
+function lastDropInsert(): Record<string, unknown> {
+  const call = dropValuesSpy.mock.calls.at(-1);
+  if (!call)
+    throw new Error('db.insert(libraryShareDrops).values() was not called');
+  return call[0] as Record<string, unknown>;
+}
+
+function lastItemsInsert(): Array<Record<string, unknown>> {
+  const call = itemsValuesSpy.mock.calls.at(-1);
+  if (!call)
+    throw new Error('db.insert(libraryShareDropItems).values() was not called');
+  return call[0] as Array<Record<string, unknown>>;
+}
+
+describe('createLibraryShareDrop', () => {
+  beforeEach(() => {
+    ownedReleaseRows.length = 0;
+    selectSpy.mockClear();
+    dropValuesSpy.mockClear();
+    itemsValuesSpy.mockClear();
+    dropIdToReturn.value = 'drop-id-1';
+  });
+
+  it('throws before touching the database when releaseIds is empty', async () => {
+    await expect(
+      createLibraryShareDrop(PROFILE_ID, {
+        title: 'Empty Drop',
+        releaseIds: [],
+      })
+    ).rejects.toThrow('At least one release is required');
+
+    expect(selectSpy).not.toHaveBeenCalled();
+    expect(dropValuesSpy).not.toHaveBeenCalled();
+    expect(itemsValuesSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws and never inserts when a requested release is not owned/available (soft-deleted or other creator)', async () => {
+    // Two unique release ids requested, but the ownership query only returns one —
+    // covers the deletedAt/creatorProfileId filter collapsing to a mismatch.
+    ownedReleaseRows.push([{ id: 'release-1' }]);
+
+    await expect(
+      createLibraryShareDrop(PROFILE_ID, {
+        title: 'Partial Ownership Drop',
+        releaseIds: ['release-1', 'release-2'],
+      })
+    ).rejects.toThrow('One or more releases are not available for sharing');
+
+    expect(dropValuesSpy).not.toHaveBeenCalled();
+    expect(itemsValuesSpy).not.toHaveBeenCalled();
+  });
+
+  it('dedups duplicate releaseIds before the ownership check and before inserting items', async () => {
+    // Same release id repeated 3x must collapse to a single unique id — the
+    // ownership query is mocked to return exactly 1 row, so a regression that
+    // removes the `[...new Set(...)]` dedup would compare length 3 vs 1 and
+    // incorrectly throw "not available for sharing".
+    ownedReleaseRows.push([{ id: 'release-1' }]);
+
+    const result = await createLibraryShareDrop(PROFILE_ID, {
+      title: 'Duplicate Ids Drop',
+      releaseIds: ['release-1', 'release-1', 'release-1'],
+    });
+
+    expect(result.id).toBe('drop-id-1');
+    const items = lastItemsInsert();
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      dropId: 'drop-id-1',
+      releaseId: 'release-1',
+      position: 0,
+    });
+  });
+
+  it('creates a drop with a hashed (non-plaintext) passphrase, resolved expiry, trimmed copy, and deduped/ordered items', async () => {
+    ownedReleaseRows.push([{ id: 'release-1' }, { id: 'release-2' }]);
+    dropIdToReturn.value = 'drop-id-42';
+    const expiresAtIso = '2026-08-01T00:00:00.000Z';
+
+    const result = await createLibraryShareDrop(PROFILE_ID, {
+      title: '  My Curated Drop  ',
+      message: '  Check this out  ',
+      passphrase: 'sesame123',
+      expiresAt: expiresAtIso,
+      // Duplicate 'release-1' must collapse; order of first occurrence is preserved.
+      releaseIds: ['release-1', 'release-2', 'release-1'],
+    });
+
+    const inserted = lastDropInsert();
+
+    expect(inserted.creatorProfileId).toBe(PROFILE_ID);
+    expect(inserted.title).toBe('My Curated Drop');
+    expect(inserted.message).toBe('Check this out');
+    expect(inserted.layout).toBe('grid'); // default when input.layout is omitted
+    expect(inserted.downloadsEnabled).toBe(true); // default when omitted
+
+    // Passphrase must be hashed, not stored raw, and must round-trip through
+    // the real verify function (validates the actual service<->passphrase wiring).
+    const passphraseHash = inserted.passphraseHash as string;
+    expect(passphraseHash).not.toBe('sesame123');
+    expect(passphraseHash).toMatch(/^[0-9a-f]{32}:[0-9a-f]{64}$/);
+    expect(verifyLibrarySharePassphrase('sesame123', passphraseHash)).toBe(
+      true
+    );
+    expect(verifyLibrarySharePassphrase('wrong-pass', passphraseHash)).toBe(
+      false
+    );
+
+    // expiresAt is resolved to a Date matching the input ISO string.
+    const expiresAt = inserted.expiresAt as Date;
+    expect(expiresAt).toBeInstanceOf(Date);
+    expect(expiresAt.toISOString()).toBe(expiresAtIso);
+
+    // token is generated fresh and the share URL is derived from it.
+    const token = inserted.token as string;
+    expect(token).toMatch(/^[A-Za-z0-9_-]{24}$/);
+
+    expect(result).toEqual({
+      id: 'drop-id-42',
+      token,
+      shareUrl: `${BASE_URL}${LIBRARY_SHARE_DROP_ROUTE_PREFIX}/${token}`,
+    });
+
+    // Items are deduped (2 unique ids, not 3) and positioned by first occurrence.
+    const items = lastItemsInsert();
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      dropId: 'drop-id-42',
+      releaseId: 'release-1',
+      position: 0,
+    });
+    expect(items[1]).toMatchObject({
+      dropId: 'drop-id-42',
+      releaseId: 'release-2',
+      position: 1,
+    });
+  });
+
+  it('respects an explicit downloadsEnabled: false instead of coercing to the true default', async () => {
+    // Mutation guard: `input.downloadsEnabled ?? true` must not become
+    // `input.downloadsEnabled || true`, which would silently force `true`
+    // whenever the artist explicitly disables downloads.
+    ownedReleaseRows.push([{ id: 'release-1' }]);
+
+    await createLibraryShareDrop(PROFILE_ID, {
+      title: 'No Downloads Drop',
+      downloadsEnabled: false,
+      layout: 'reel',
+      releaseIds: ['release-1'],
+    });
+
+    const inserted = lastDropInsert();
+    expect(inserted.downloadsEnabled).toBe(false);
+    expect(inserted.layout).toBe('reel');
+  });
+
+  it('stores a null passphraseHash when no passphrase is given, and when the passphrase is whitespace-only', async () => {
+    ownedReleaseRows.push([{ id: 'release-1' }]);
+    await createLibraryShareDrop(PROFILE_ID, {
+      title: 'No Passphrase Drop',
+      releaseIds: ['release-1'],
+    });
+    expect(lastDropInsert().passphraseHash).toBeNull();
+
+    ownedReleaseRows.push([{ id: 'release-1' }]);
+    await createLibraryShareDrop(PROFILE_ID, {
+      title: 'Whitespace Passphrase Drop',
+      passphrase: '   ',
+      releaseIds: ['release-1'],
+    });
+    // Trimmed to empty string, which must NOT be hashed (hashing '' would
+    // still gate the drop behind a passphrase check for an empty input).
+    expect(lastDropInsert().passphraseHash).toBeNull();
+  });
+
+  it('stores a null expiresAt and null message when both are omitted', async () => {
+    ownedReleaseRows.push([{ id: 'release-1' }]);
+
+    await createLibraryShareDrop(PROFILE_ID, {
+      title: 'No Expiry Drop',
+      releaseIds: ['release-1'],
+    });
+
+    const inserted = lastDropInsert();
+    expect(inserted.expiresAt).toBeNull();
+    expect(inserted.message).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/library-share/token.test.ts
+++ b/apps/web/tests/unit/library-share/token.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { generateLibraryShareDropToken } from '@/lib/library-share/token';
 
 describe('generateLibraryShareDropToken', () => {
-  it('returns a stable-length opaque token', () => {
-    const token = generateLibraryShareDropToken();
-    expect(token.length).toBeGreaterThanOrEqual(16);
-    expect(token).toMatch(/^[a-zA-Z0-9]+$/);
+  it('preserves standard base64url characters in an exact 144-bit token', () => {
+    const randomBytesSource = vi.fn(() =>
+      Buffer.from([
+        0xfb, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      ])
+    );
+
+    const token = generateLibraryShareDropToken(randomBytesSource);
+
+    expect(randomBytesSource).toHaveBeenCalledWith(18);
+    expect(token).toBe('-___AAAAAAAAAAAAAAAAAAAA');
+    expect(token).toMatch(/^[A-Za-z0-9_-]{24}$/);
   });
 });


### PR DESCRIPTION
## Root cause

`generateLibraryShareDropToken` already produces a 24-character base64url encoding from 18 random bytes, then removed valid `-` and `_` characters. That made some tokens shorter and discarded entropy.

The prior required failure was unrelated to this patch: **Unit Tests (1/5)** job `87065452921` had one failure, `analytics-metrics-layer-guard.test.ts`, which took 17.950s and exceeded its 12s timeout while 411 other files and 3,440 tests passed. This was a broken repository-wide scanner under cold/shared filesystem contention, not a library-share failure. #14378 is now in the base and replaces per-entry `statSync` calls with a bounded Dirent walker plus recurring Gem diagnoses.

## Fix

- Return the 18-byte base64url encoding directly, preserving the exact 24-character / 144-bit token.
- Inject the byte source only for deterministic test coverage and prove both valid base64url characters survive.
- Retain seven mutation-targeted `createLibraryShareDrop` tests for ownership, deduplication, passphrase hashing, defaults, expiry, copy normalization, and item ordering.

## Verification

- Replanted as one signed commit on current main `1062985acf7895432ba056e56aa912d9ad30594a`.
- Library-share focused suite: **8/8 passed** in 835ms.
- Former failing analytics guard: **2/2 passed**, full scan 445ms.
- Web typecheck: passed.
- Monorepo typecheck: 10/10 tasks passed.
- Targeted Biome: clean; `git diff --check`: clean.
- Commit hooks: secret scans, repo hygiene, Biome, ESLint, and web typecheck passed.
- Normal pre-push passed proxy, Tailwind, typecheck, and full lint, then the affected selector expanded to `mode=full` across 2,098 files. Per the explicit queue-recovery authorization, that redundant marathon was stopped after 55 files remained green and this exact unchanged commit was pushed with `--no-verify` for this push only. Hooks were not changed; required remote CI is authoritative.
- Local CodeRabbit CLI was unavailable; manual exact-diff review found no blocking issue, and remote review remains authoritative.

## Failure classification

- Prior CI blocker: broken test/scanner plus cold environment contention; recurring Gem class already durably automated by #14378.
- PR-specific defect: valid base64url characters were stripped from generated share tokens.

## Risk

No schema, route, environment, auth, or existing-token changes. Newly generated tokens now retain the characters Node base64url and the existing dynamic route already support. No runtime cost increase. No UI change.