### PR TITLE
test(notifications): release-day send path + failure isolation coverage (JOV-4220)

### DIFF
--- a/apps/web/tests/unit/api/cron/send-release-notifications.test.ts
+++ b/apps/web/tests/unit/api/cron/send-release-notifications.test.ts
@@ -8,6 +8,8 @@ const {
   mockDbUpdateReturning,
   mockGetBatchCreatorEntitlements,
   mockLoggerWarn,
+  mockGetReleaseDayNotificationEmail,
+  mockSendNotification,
 } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(),
   mockDbUpdate: vi.fn(),
@@ -16,6 +18,8 @@ const {
   mockDbUpdateReturning: vi.fn(),
   mockGetBatchCreatorEntitlements: vi.fn(),
   mockLoggerWarn: vi.fn(),
+  mockGetReleaseDayNotificationEmail: vi.fn(),
+  mockSendNotification: vi.fn(),
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -97,7 +101,7 @@ vi.mock('@/lib/db/schema/profiles', () => ({
 }));
 
 vi.mock('@/lib/email/templates/release-day-notification', () => ({
-  getReleaseDayNotificationEmail: vi.fn(),
+  getReleaseDayNotificationEmail: mockGetReleaseDayNotificationEmail,
 }));
 
 vi.mock('@/lib/entitlements/creator-plan', () => ({
@@ -113,7 +117,7 @@ vi.mock('@/lib/error-tracking', () => ({
 }));
 
 vi.mock('@/lib/notifications/service', () => ({
-  sendNotification: vi.fn(),
+  sendNotification: mockSendNotification,
 }));
 
 vi.mock('@/lib/utils/date', () => ({
@@ -274,6 +278,426 @@ describe('sendPendingNotifications', () => {
     expect(result.sent).toBe(0);
     expect(mockDbUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'cancelled' })
+    );
+  });
+
+  it('marks notification as sent when the email dispatch succeeds', async () => {
+    // Full happy-path chain: pending notification -> release -> creator ->
+    // email subscriber -> streaming link (required for eligibility's
+    // hasSmartLink check), then a successful sendNotification dispatch.
+    mockDbSelect.mockReset();
+    mockDbSelect
+      .mockReturnValueOnce(
+        createPendingNotificationsChain([
+          {
+            id: 'notif_1',
+            creatorProfileId: 'creator_1',
+            releaseId: 'release_1',
+            notificationSubscriptionId: 'sub_1',
+            notificationType: 'release_day',
+            metadata: {},
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            id: 'release_1',
+            title: 'New Album',
+            slug: 'new-album',
+            artworkUrl: null,
+            releaseDate: null,
+            sourceType: 'spotify',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            id: 'creator_1',
+            displayName: 'Creator One',
+            isClaimed: true,
+            ownerUserId: 'user_1',
+            settings: { spotifyImportStatus: 'complete' },
+            spotifyId: 'spotify_1',
+            trialNotificationsSent: 0,
+            username: 'creatorone',
+            usernameNormalized: 'creatorone',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            id: 'sub_1',
+            channel: 'email',
+            email: 'fan@example.com',
+            phone: null,
+            name: 'Fan Name',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            releaseId: 'release_1',
+            providerId: 'spotify',
+            url: 'https://open.spotify.com/track/xyz',
+          },
+        ])
+      );
+
+    mockGetBatchCreatorEntitlements.mockResolvedValue(
+      new Map([
+        [
+          'creator_1',
+          {
+            plan: 'pro',
+            entitlements: {
+              booleans: { canSendNotifications: true },
+              limits: {},
+            },
+          },
+        ],
+      ])
+    );
+
+    // First .returning() call is recoverStuckNotifications (no stuck rows);
+    // second is claimNotification (claim succeeds so processing proceeds).
+    mockDbUpdateReturning
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'notif_1' }]);
+
+    mockGetReleaseDayNotificationEmail.mockReturnValue({
+      subject: 'New release from Creator One',
+      text: 'plain text body',
+      html: '<p>html body</p>',
+    });
+    mockSendNotification.mockResolvedValue({
+      delivered: ['email'],
+      skipped: [],
+      errors: [],
+    });
+
+    const { sendPendingNotifications } = await import(
+      '@/app/api/cron/send-release-notifications/route'
+    );
+
+    const result = await sendPendingNotifications();
+
+    expect(result).toEqual({ sent: 1, failed: 0, skipped: 0, processed: 1 });
+    expect(mockSendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'notif_1',
+        channels: ['email'],
+        category: 'marketing',
+      }),
+      { email: 'fan@example.com' }
+    );
+    expect(mockDbUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'sent',
+        sentAt: expect.any(Date),
+        error: null,
+      })
+    );
+  });
+
+  it('marks notification as failed with the delivery error when the email dispatch fails', async () => {
+    mockDbSelect.mockReset();
+    mockDbSelect
+      .mockReturnValueOnce(
+        createPendingNotificationsChain([
+          {
+            id: 'notif_1',
+            creatorProfileId: 'creator_1',
+            releaseId: 'release_1',
+            notificationSubscriptionId: 'sub_1',
+            notificationType: 'release_day',
+            metadata: {},
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            id: 'release_1',
+            title: 'New Album',
+            slug: 'new-album',
+            artworkUrl: null,
+            releaseDate: null,
+            sourceType: 'spotify',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            id: 'creator_1',
+            displayName: 'Creator One',
+            isClaimed: true,
+            ownerUserId: 'user_1',
+            settings: { spotifyImportStatus: 'complete' },
+            spotifyId: 'spotify_1',
+            trialNotificationsSent: 0,
+            username: 'creatorone',
+            usernameNormalized: 'creatorone',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            id: 'sub_1',
+            channel: 'email',
+            email: 'fan@example.com',
+            phone: null,
+            name: 'Fan Name',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            releaseId: 'release_1',
+            providerId: 'spotify',
+            url: 'https://open.spotify.com/track/xyz',
+          },
+        ])
+      );
+
+    mockGetBatchCreatorEntitlements.mockResolvedValue(
+      new Map([
+        [
+          'creator_1',
+          {
+            plan: 'pro',
+            entitlements: {
+              booleans: { canSendNotifications: true },
+              limits: {},
+            },
+          },
+        ],
+      ])
+    );
+
+    mockDbUpdateReturning
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'notif_1' }]);
+
+    mockGetReleaseDayNotificationEmail.mockReturnValue({
+      subject: 'New release from Creator One',
+      text: 'plain text body',
+      html: '<p>html body</p>',
+    });
+    mockSendNotification.mockResolvedValue({
+      delivered: [],
+      skipped: [],
+      errors: [
+        {
+          channel: 'email',
+          status: 'error',
+          error: 'Resend API error: rate limited',
+        },
+      ],
+    });
+
+    const { sendPendingNotifications } = await import(
+      '@/app/api/cron/send-release-notifications/route'
+    );
+
+    const result = await sendPendingNotifications();
+
+    expect(result).toEqual({ sent: 0, failed: 1, skipped: 0, processed: 1 });
+    expect(mockDbUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        sentAt: null,
+        error: 'Resend API error: rate limited',
+      })
+    );
+  });
+
+  it('isolates per-notification failures so one bad row does not block a sibling send', async () => {
+    // notif_1 -> creator_1/release_1 will send successfully.
+    // notif_2 -> creator_2/release_missing has no matching release row, so
+    // processing throws "Release not found" and only that row is failed.
+    // notif_3 -> creator_1/release_1 (different subscriber) is scheduled AFTER
+    // the failing row and must still dispatch — this kills the abort-after-
+    // failure mutant (continue -> break in processNotificationBatches), which
+    // would be invisible if the failing notification were last in the batch.
+    mockDbSelect.mockReset();
+    mockDbSelect
+      .mockReturnValueOnce(
+        createPendingNotificationsChain([
+          {
+            id: 'notif_1',
+            creatorProfileId: 'creator_1',
+            releaseId: 'release_1',
+            notificationSubscriptionId: 'sub_1',
+            notificationType: 'release_day',
+            metadata: {},
+          },
+          {
+            id: 'notif_2',
+            creatorProfileId: 'creator_2',
+            releaseId: 'release_missing',
+            notificationSubscriptionId: 'sub_2',
+            notificationType: 'release_day',
+            metadata: {},
+          },
+          {
+            id: 'notif_3',
+            creatorProfileId: 'creator_1',
+            releaseId: 'release_1',
+            notificationSubscriptionId: 'sub_3',
+            notificationType: 'release_day',
+            metadata: {},
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        // Only release_1 is returned; release_missing is intentionally absent.
+        createWhereResolvedChain([
+          {
+            id: 'release_1',
+            title: 'New Album',
+            slug: 'new-album',
+            artworkUrl: null,
+            releaseDate: null,
+            sourceType: 'spotify',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            id: 'creator_1',
+            displayName: 'Creator One',
+            isClaimed: true,
+            ownerUserId: 'user_1',
+            settings: { spotifyImportStatus: 'complete' },
+            spotifyId: 'spotify_1',
+            trialNotificationsSent: 0,
+            username: 'creatorone',
+            usernameNormalized: 'creatorone',
+          },
+          {
+            id: 'creator_2',
+            displayName: 'Creator Two',
+            isClaimed: true,
+            ownerUserId: 'user_2',
+            settings: { spotifyImportStatus: 'complete' },
+            spotifyId: 'spotify_2',
+            trialNotificationsSent: 0,
+            username: 'creatortwo',
+            usernameNormalized: 'creatortwo',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            id: 'sub_1',
+            channel: 'email',
+            email: 'fan@example.com',
+            phone: null,
+            name: 'Fan Name',
+          },
+          {
+            id: 'sub_3',
+            channel: 'email',
+            email: 'otherfan@example.com',
+            phone: null,
+            name: 'Other Fan',
+          },
+        ])
+      )
+      .mockReturnValueOnce(
+        createWhereResolvedChain([
+          {
+            releaseId: 'release_1',
+            providerId: 'spotify',
+            url: 'https://open.spotify.com/track/xyz',
+          },
+        ])
+      );
+
+    mockGetBatchCreatorEntitlements.mockResolvedValue(
+      new Map([
+        [
+          'creator_1',
+          {
+            plan: 'pro',
+            entitlements: {
+              booleans: { canSendNotifications: true },
+              limits: {},
+            },
+          },
+        ],
+        [
+          'creator_2',
+          {
+            plan: 'pro',
+            entitlements: {
+              booleans: { canSendNotifications: true },
+              limits: {},
+            },
+          },
+        ],
+      ])
+    );
+
+    // recoverStuckNotifications, then claimNotification for notif_1 and
+    // notif_3 — notif_2 throws on the missing-release check before it ever
+    // claims, so it never consumes a .returning() result.
+    mockDbUpdateReturning
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'notif_1' }])
+      .mockResolvedValueOnce([{ id: 'notif_3' }]);
+
+    mockGetReleaseDayNotificationEmail.mockReturnValue({
+      subject: 'New release from Creator One',
+      text: 'plain text body',
+      html: '<p>html body</p>',
+    });
+    mockSendNotification.mockResolvedValue({
+      delivered: ['email'],
+      skipped: [],
+      errors: [],
+    });
+
+    const { sendPendingNotifications } = await import(
+      '@/app/api/cron/send-release-notifications/route'
+    );
+
+    const result = await sendPendingNotifications();
+
+    expect(result).toEqual({ sent: 2, failed: 1, skipped: 0, processed: 3 });
+    // notif_1 and notif_3 reach dispatch; notif_2 fails before send. notif_3
+    // dispatching AFTER the failure proves processing continues past a failed
+    // row instead of aborting the batch.
+    expect(mockSendNotification).toHaveBeenCalledTimes(2);
+    expect(mockSendNotification).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ id: 'notif_1' }),
+      { email: 'fan@example.com' }
+    );
+    expect(mockSendNotification).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ id: 'notif_3' }),
+      { email: 'otherfan@example.com' }
+    );
+    const sentWrites = mockDbUpdateSet.mock.calls.filter(
+      ([payload]) =>
+        (payload as { status?: string } | undefined)?.status === 'sent'
+    );
+    expect(sentWrites).toHaveLength(2);
+    expect(mockDbUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        error: 'Release not found: release_missing',
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary

Batch 14B — the send-side companion to #14092's scheduling coverage. The send cron suite covered only failure/skip/empty branches; the successful dispatch path had **zero assertions**. Three new tests:

- **Happy path**: exact `sendNotification` args (`channels: ['email']`, `category: 'marketing'`) and the sent-status write (`{status: 'sent', sentAt, error: null}`)
- **Failed delivery**: exact error-string propagation into the failed write
- **Per-notification isolation with a 3-row batch** (send → fail → send): one bad row neither blocks nor aborts siblings. Hardened mid-review: the frontier gate's extra probe showed the original 2-row fixture couldn't observe an abort-*after*-failure mutant (the failing row was last); the `continue`→`break` mutant now dies on the `sent: 2` assertion with fail-then-pass evidence.

## Verification
- 6/6 green; typecheck + biome clean
- **Frontier gate 4/4 killed** (error-null on failure, transactional category, throw-aborts-loop, double-send) + the coder's ternary self-check + the post-gate hardening kill

## Notes
- Per loop policy, no CHANGELOG entry. bug-to-test: N/A — tests-only. Cost impact: none. No UI change.