### PR TITLE
test(proxy): real Better Auth session detection at middleware level (JOV-4220) [stacked on #14066]

### DIFF
--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -197,6 +197,11 @@ function resetMocks() {
     status: 'ok',
   });
   mocks.resolveTestBypassUserId.mockReturnValue(null);
+  // Some tests flip this to `false` to exercise the real (non-bypass)
+  // getSessionCookie detection path; restore the suite default here so
+  // that override never leaks into later tests via mockClear() (which
+  // clears call history but not a previously assigned return value).
+  mocks.isTestAuthBypassEnabled.mockReturnValue(true);
   mocks.isCookieBannerRequired.mockReturnValue(false);
   mocks.getUserState.mockResolvedValue(null);
   mocks.isKnownActiveUser.mockReturnValue(false);
@@ -1145,6 +1150,69 @@ describe('proxy.ts middleware', () => {
       // The isNavigationMethod gate must short-circuit before the cache is
       // even consulted.
       expect(mocks.getCookieCache).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // Real (non-bypass) session-cookie detection (audit row 16 follow-up)
+  //
+  // `detectBetterAuthSession` (apps/web/proxy.ts ~line 39) calls
+  // `getSessionCookie` from 'better-auth/cookies' to derive the truthy
+  // signed-in marker that flows into `handleProxyRequest` on every request
+  // that is NOT using the E2E test-bypass. Every other "authenticated" test
+  // in this suite goes through `resolveTestBypassUserId` instead, so this is
+  // the only place `getSessionCookie`'s actual return value (not just the
+  // test-bypass user id) drives auth-gated behavior. `isTestAuthBypassEnabled`
+  // is forced to `false` in each test here so there is no ambiguity about
+  // which path produced the observed behavior.
+  // ==========================================================================
+  describe('real session-cookie detection (getSessionCookie, non-bypass path)', () => {
+    it('treats a truthy Better Auth session cookie as signed-in and lets a protected path through', async () => {
+      mocks.isTestAuthBypassEnabled.mockReturnValue(false);
+      mocks.getSessionCookie.mockReturnValue('valid_session_cookie_value');
+
+      const req = createTestRequest({ pathname: '/app' });
+      const res = await callMiddleware(req);
+
+      expect(mocks.getSessionCookie).toHaveBeenCalledWith(req);
+      // Confirms this went through the real detection path, not the bypass.
+      expect(mocks.resolveTestBypassUserId).not.toHaveBeenCalled();
+      expect(res.status).toBeLessThan(300);
+      expect(isRedirectTo(res, '/signin')).toBe(false);
+    });
+
+    it('treats a thrown/malformed session cookie as signed-out (fails closed)', async () => {
+      mocks.isTestAuthBypassEnabled.mockReturnValue(false);
+      mocks.getSessionCookie.mockImplementation(() => {
+        throw new Error('malformed session cookie');
+      });
+
+      const req = createTestRequest({ pathname: '/app' });
+      const res = await callMiddleware(req);
+
+      expect(mocks.getSessionCookie).toHaveBeenCalledWith(req);
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+      expect(isRedirectTo(res, '/signin')).toBe(true);
+    });
+
+    it('does not redirect a signed-in Electron app-shell request to signin', async () => {
+      mocks.isTestAuthBypassEnabled.mockReturnValue(false);
+      mocks.getSessionCookie.mockReturnValue('valid_session_cookie_value');
+
+      const req = createTestRequest({
+        hostname: 'localhost:3112',
+        pathname: '/app/chat',
+        searchParams: { runtime: 'electron' },
+      });
+      const res = await callMiddleware(req);
+
+      expect(mocks.getSessionCookie).toHaveBeenCalledWith(req);
+      expect(res.status).toBeLessThan(300);
+      expect(isRedirectTo(res, '/signin')).toBe(false);
+      // The signed-out Electron redirect helper must not fire when a
+      // session cookie is present.
+      expect(mocks.buildProtectedAuthRedirectUrl).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Closes the **last priority-4 audit item** of the coverage loop. Stacked on #14066 (extends the same suite + its `better-auth/cookies` mocks).

#14066 pinned the `getCookieCache` call site; the **upstream** `getSessionCookie` path (`detectBetterAuthSession`, `proxy.ts:39-46`) — the real production sign-in detection for all non-bypass traffic — had never been exercised: every "authenticated" test used the E2E bypass, which returns from `middleware()` before detection runs. Three new tests with the bypass explicitly disabled and `handleProxyRequest` un-mocked:

- Truthy session cookie → protected path passes; `getSessionCookie` consulted, bypass resolver **not** consulted
- Thrown/malformed cookie **fails closed** to signed-out (`/signin` redirect)
- Signed-in Electron app-shell navigation not redirected (complement to the existing signed-out case)

Also fixes a dormant test-isolation bug: `resetMocks()` never restored the `isTestAuthBypassEnabled` default (`mockClear` doesn't reset return values) — a previously-unreachable leak these tests exposed.

## Verification
- 59 pass / 31 skip (56 inherited + 3 new); typecheck + biome clean
- **Frontier gate 3/3 killed**: hardcoded-signed-in-without-consulting-cookie (11 failures incl. all 3 new tests), fail-open-on-throw (single-test surgical kill), inverted Electron check

## Notes
- Per loop policy, no CHANGELOG entry. bug-to-test: N/A — tests-only (the resetMocks fix is test-infra). No UI change.