### PR TITLE
fix(ci): scope Neon credentials to rerun attempts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1013,7 +1013,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || needs.ci-path-changes.outputs.run_neon == 'true' || needs.ci-path-changes.outputs.run_public_lighthouse == 'true' || steps.check-backend.outputs.needs_db == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-artifact/connection.json
           retention-days: 1
 
@@ -1086,7 +1086,7 @@ jobs:
         if: steps.check_changes.outputs.run_full_ci == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -1531,7 +1531,7 @@ jobs:
         # Screenshot/UI-only PRs still need seeded profile fixtures for Playwright.
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -1737,7 +1737,7 @@ jobs:
         # Screenshot/UI-only PRs still need seeded profile fixtures for shard-0 Playwright.
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -2072,7 +2072,7 @@ jobs:
         if: needs.ci-path-changes.outputs.run_neon == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -2205,7 +2205,7 @@ jobs:
         if: needs.ci-path-changes.outputs.run_neon == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -2340,7 +2340,7 @@ jobs:
         if: needs.ci-path-changes.outputs.run_neon == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -2480,7 +2480,7 @@ jobs:
         if: steps.check_changes.outputs.run_full_ci == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -2952,7 +2952,7 @@ jobs:
         if: steps.check_changes.outputs.run_full_ci == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -3091,7 +3091,7 @@ jobs:
       - name: Download Neon DB connection artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
         continue-on-error: true
 
@@ -3257,7 +3257,7 @@ jobs:
         if: steps.check_changes.outputs.run_full_ci == 'true' && needs.neon-db.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -3471,7 +3471,7 @@ jobs:
         if: needs.neon-db.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -3796,7 +3796,7 @@ jobs:
         if: steps.check_changes.outputs.run_full_ci == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -3872,7 +3872,7 @@ jobs:
       - name: Download Neon DB connection artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
@@ -4821,7 +4821,7 @@ jobs:
       - name: Download Neon DB connection artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: neon-db-connection-${{ github.run_id }}
+          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -56,6 +56,32 @@ function getJobBlock(workflow: string, jobKey: string): string {
   return block.join('\n');
 }
 
+describe('CI Neon connection artifact contract', () => {
+  it('binds every producer and consumer to the current run attempt', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const artifactLines = workflow
+      .split('\n')
+      .filter(line => line.includes('name: neon-db-connection-'));
+
+    expect(artifactLines.length).toBeGreaterThan(1);
+    expect(artifactLines).toEqual(
+      artifactLines.map(
+        () =>
+          '          name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
+      )
+    );
+    expect(workflow).not.toMatch(
+      /name: neon-db-connection-\$\{\{ github\.run_id \}\}\s*$/m
+    );
+
+    const neonJob = getJobBlock(workflow, 'neon-db');
+    expect(neonJob).toContain('SUFFIX="${RUN_ID}-${RUN_ATTEMPT}"');
+    expect(neonJob).toContain(
+      'name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
+    );
+  });
+});
+
 describe('CI test-performance path gate', () => {
   it('runs the budget job only for its exact internal-PR inputs or main', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
@@ -784,7 +810,7 @@ describe('CI public lighthouse workflow', () => {
     );
 
     expect(downloadArtifactStep).toContain(
-      'name: neon-db-connection-${{ github.run_id }}'
+      'name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
     );
     expect(resolveDbStep).toContain(
       'connection_file: /tmp/neon-db-connection/connection.json'
@@ -880,7 +906,7 @@ describe('CI mobile overflow workflow', () => {
     );
 
     expect(downloadArtifactStep).toContain(
-      'name: neon-db-connection-${{ github.run_id }}'
+      'name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
     );
     expect(resolveDbStep).toContain(
       'connection_file: /tmp/neon-db-connection/connection.json'
@@ -1115,7 +1141,7 @@ describe('CI public a11y workflow', () => {
       "if: steps.check_changes.outputs.run_full_ci == 'true'"
     );
     expect(downloadArtifactStep).toContain(
-      'name: neon-db-connection-${{ github.run_id }}'
+      'name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
     );
     expect(resolveDbStep).toContain(
       "if: steps.check_changes.outputs.run_full_ci == 'true'"
@@ -1173,7 +1199,7 @@ describe('CI PR neon migrate workflow', () => {
     );
 
     expect(downloadArtifactStep).toContain(
-      'name: neon-db-connection-${{ github.run_id }}'
+      'name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
     );
     expect(resolveDbStep).toContain(
       'connection_file: /tmp/neon-db-connection/connection.json'

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -8,6 +8,7 @@ export type CiFailureClass =
   | 'standalone_runtime_launcher_mismatch'
   | 'neon_endpoint_capacity_admission'
   | 'neon_probe_workspace_dependency_resolution'
+  | 'neon_shared_artifact_credential_mismatch'
   | 'neon_concurrency_key_collision'
   | 'broken_profiler_fixture'
   | 'inconclusive_performance_timeout'
@@ -141,6 +142,28 @@ const DIAGNOSES: ReadonlyArray<{
       'The repo-root Neon admission probe imported a dependency declared only by the apps/web workspace. Under the strict pnpm layout, Node resolved from the script directory and could not see the web workspace dependency.',
     remediation:
       'Load @neondatabase/serverless through createRequire anchored to apps/web/package.json, then run the real probe without DATABASE_URL and require it to reach its own environment validation instead of hoisting or reinstalling dependencies.',
+  },
+  {
+    failureClass: 'neon_shared_artifact_credential_mismatch',
+    matches: log => {
+      const attemptBlindArtifact =
+        /Download Neon DB connection artifact/i.test(log) &&
+        /name:\s*neon-db-connection-\d+\b(?!-\d+)/i.test(log);
+      const exhaustedConsumerMigration =
+        /Run migrations \(ephemeral Neon\)/i.test(log) &&
+        /Database connection attempt 11\/12 failed/i.test(log);
+
+      return (
+        (attemptBlindArtifact || exhaustedConsumerMigration) &&
+        /password authentication failed for user ['"]neondb_owner['"]/i.test(
+          log
+        )
+      );
+    },
+    rootCause:
+      'A downstream migration exhausted its Neon connectivity retries because the shared connection artifact carried credentials that no longer authenticated; run-id-only artifact selection permits this drift on reruns.',
+    remediation:
+      'Bind the Neon connection artifact producer and every consumer to both github.run_id and github.run_attempt, then fail closed when the exact-attempt artifact is absent instead of retrying stale credentials.',
   },
   {
     failureClass: 'neon_concurrency_key_collision',

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -293,6 +293,39 @@ describe('diagnoseCiFailure', () => {
     ).toBe('unknown');
   });
 
+  it('diagnoses attempt-blind Neon credentials selected by a rerun consumer', () => {
+    const diagnosis = diagnoseCiFailure(`
+      E2E Smoke (PR Fast Feedback) Run migrations (ephemeral Neon)
+      Database connection attempt 11/12 failed with a transient Neon endpoint error. Retrying in 5s...
+      Failed to connect to database: error: password authentication failed for user 'neondb_owner'
+    `);
+
+    expect(diagnosis.failureClass).toBe(
+      'neon_shared_artifact_credential_mismatch'
+    );
+    expect(diagnosis.rootCause).toContain('run-id-only');
+    expect(diagnosis.remediation).toContain('github.run_attempt');
+    expect(diagnosis.remediation).toContain('fail closed');
+  });
+
+  it('does not infer rerun artifact drift from an attempt-bound artifact', () => {
+    expect(
+      diagnoseCiFailure(`
+        Download Neon DB connection artifact
+        name: neon-db-connection-29184792705-2
+        password authentication failed for user 'neondb_owner'
+      `).failureClass
+    ).toBe('unknown');
+  });
+
+  it('does not infer shared-artifact drift from an unrelated password failure', () => {
+    expect(
+      diagnoseCiFailure(
+        "password authentication failed for user 'neondb_owner'"
+      ).failureClass
+    ).toBe('unknown');
+  });
+
   it('does not infer slice saturation from an unrelated status line', () => {
     expect(diagnoseCiFailure('runner_tasks_status=critical').failureClass).toBe(
       'unknown'

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -190,6 +190,14 @@ const LAYOUT_GUARD_CONTRACT_MANIFEST = [
   'scripts/run-affected-tests.mjs',
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const NEON_ATTEMPT_ARTIFACT_MANIFEST = [
+  '.github/workflows/ci.yml',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+];
 
 describe('automation-verify affected scope', () => {
   it('keeps runner I/O admission on focused controller regressions', () => {
@@ -744,6 +752,38 @@ describe('automation-verify affected scope', () => {
       'scripts/lib/__tests__/automation-verify.test.mjs',
       'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
     ]);
+  });
+
+  it('keeps the Neon rerun artifact repair on focused workflow and Gem regressions', () => {
+    const plan = buildAffectedTestPlan(NEON_ATTEMPT_ARTIFACT_MANIFEST);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.mandatoryTests).toEqual([
+      'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+    ]);
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+      'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+    ]);
+  });
+
+  it.each(
+    NEON_ATTEMPT_ARTIFACT_MANIFEST
+  )('fails closed when the Neon rerun artifact repair is missing %s', missingInput => {
+    expect(
+      buildAffectedTestPlan(
+        NEON_ATTEMPT_ARTIFACT_MANIFEST.filter(file => file !== missingInput)
+      ).mode
+    ).toBe('full');
+  });
+
+  it('fails closed when the Neon rerun artifact repair includes an unknown peer', () => {
+    expect(
+      buildAffectedTestPlan([
+        ...NEON_ATTEMPT_ARTIFACT_MANIFEST,
+        'scripts/hermes/lib/unknown-neon-artifact-helper.ts',
+      ]).mode
+    ).toBe('full');
   });
 
   it.each(

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -106,6 +106,20 @@ const GOLDEN_PATH_SMOKE_CONTRACT_CORE = new Set([
   'scripts/hermes/jobs/ci-failure-diagnosis.ts',
   'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
 ]);
+const NEON_ATTEMPT_ARTIFACT_MANIFEST = new Set([
+  '.github/workflows/ci.yml',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  ...AFFECTED_TEST_SELECTOR_MANIFEST,
+]);
+const NEON_ATTEMPT_ARTIFACT_TESTS = [
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+];
+const NEON_ATTEMPT_ARTIFACT_SCRIPT_TESTS = [
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+];
 const PERFORMANCE_PROFILER_REPAIR_PRIMARY_MANIFEST = new Set([
   '.github/workflows/ci.yml',
   'apps/web/scripts/test-performance-guard.ts',
@@ -313,6 +327,12 @@ export function buildAffectedTestPlan(changedFiles) {
         AFFECTED_TEST_SELECTOR_MANIFEST.has(file)
     ) &&
     affectedTestSelectorInputCount === AFFECTED_TEST_SELECTOR_MANIFEST.size;
+  const neonAttemptArtifactInputCount = files.filter(file =>
+    NEON_ATTEMPT_ARTIFACT_MANIFEST.has(file)
+  ).length;
+  const isExactNeonAttemptArtifactRepair =
+    neonAttemptArtifactInputCount === NEON_ATTEMPT_ARTIFACT_MANIFEST.size &&
+    files.length === NEON_ATTEMPT_ARTIFACT_MANIFEST.size;
   const performanceProfilerRepairInputCount = files.filter(file =>
     PERFORMANCE_PROFILER_REPAIR_ANCHORS.has(file)
   ).length;
@@ -469,6 +489,9 @@ export function buildAffectedTestPlan(changedFiles) {
   if (isExactGoldenPathSmokeContractRepair) {
     mandatoryTests.push(...GOLDEN_PATH_SMOKE_CONTRACT_TESTS);
   }
+  if (isExactNeonAttemptArtifactRepair) {
+    mandatoryTests.push(...NEON_ATTEMPT_ARTIFACT_TESTS);
+  }
   if (isExactPerformanceProfilerRepair) {
     mandatoryTests.push(...PERFORMANCE_PROFILER_REPAIR_WEB_TESTS);
   }
@@ -497,6 +520,7 @@ export function buildAffectedTestPlan(changedFiles) {
       : []),
     ...(isExactAffectedTestSelector ||
     isExactGoldenPathSmokeContractRepair ||
+    isExactNeonAttemptArtifactRepair ||
     isExactPerformanceProfilerRepairWithSelector ||
     isExactVisualQaSelectorRepair ||
     isExactRunnerPrerequisiteVisualQaRepair ||
@@ -505,6 +529,9 @@ export function buildAffectedTestPlan(changedFiles) {
       : []),
     ...(isExactGoldenPathSmokeContractRepair
       ? GOLDEN_PATH_SMOKE_CONTRACT_SCRIPT_TESTS
+      : []),
+    ...(isExactNeonAttemptArtifactRepair
+      ? NEON_ATTEMPT_ARTIFACT_SCRIPT_TESTS
       : []),
     ...(isExactPersistedAuthFixtureRepair
       ? PERSISTED_AUTH_FIXTURE_SCRIPT_TESTS
@@ -531,6 +558,11 @@ export function buildAffectedTestPlan(changedFiles) {
     if (
       isExactGoldenPathSmokeContractRepair &&
       GOLDEN_PATH_SMOKE_CONTRACT_CORE.has(file)
+    )
+      return true;
+    if (
+      isExactNeonAttemptArtifactRepair &&
+      NEON_ATTEMPT_ARTIFACT_MANIFEST.has(file)
     )
       return true;
     if (
@@ -589,6 +621,7 @@ export function buildAffectedTestPlan(changedFiles) {
     affectedTestSelectorInputCount > 0 &&
     !isExactAffectedTestSelector &&
     !isExactGoldenPathSmokeContractRepair &&
+    !isExactNeonAttemptArtifactRepair &&
     !isExactPerformanceProfilerRepairWithSelector &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactVisualQaSelectorRepair &&
@@ -600,6 +633,7 @@ export function buildAffectedTestPlan(changedFiles) {
     performanceProfilerRepairInputCount > 0 &&
     !isExactPerformanceProfilerRepair &&
     !isExactGoldenPathSmokeContractRepair &&
+    !isExactNeonAttemptArtifactRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
@@ -608,6 +642,7 @@ export function buildAffectedTestPlan(changedFiles) {
     gtmqSourceGateReaperInputCount > 0 &&
     !isExactGtmqSourceGateReaper &&
     !isExactGoldenPathSmokeContractRepair &&
+    !isExactNeonAttemptArtifactRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactAffectedTestSelector &&
     !isExactVisualQaSelectorRepair &&
@@ -619,6 +654,7 @@ export function buildAffectedTestPlan(changedFiles) {
     runnerIoPressureInputCount > 0 &&
     !isExactRunnerIoPressure &&
     !isExactGoldenPathSmokeContractRepair &&
+    !isExactNeonAttemptArtifactRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactAffectedTestSelector &&
     !isExactVisualQaSelectorRepair &&
@@ -634,6 +670,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactGtmqSourceGateReaper &&
     !isExactPrerequisiteTrain &&
     !isExactGoldenPathSmokeContractRepair &&
+    !isExactNeonAttemptArtifactRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactLayoutGuardContract &&
     !isExactPerformanceProfilerRepair &&
@@ -644,12 +681,27 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactPrerequisiteTrain &&
     !isExactAffectedTestSelector &&
     !isExactGoldenPathSmokeContractRepair &&
+    !isExactNeonAttemptArtifactRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactGtmqSourceGateReaper &&
     !isExactVisualQaSelectorRepair &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactPerformanceProfilerRepair &&
     !isExactRunnerIoPressure;
+  const hasIncompleteNeonAttemptArtifactRepair =
+    neonAttemptArtifactInputCount > 0 &&
+    !isExactNeonAttemptArtifactRepair &&
+    !isExactPrerequisiteTrain &&
+    !isExactVercelCongestionControl &&
+    !isExactAffectedTestSelector &&
+    !isExactGoldenPathSmokeContractRepair &&
+    !isExactPerformanceProfilerRepair &&
+    !isExactPersistedAuthFixtureRepair &&
+    !isExactVisualQaSelectorRepair &&
+    !isExactGtmqSourceGateReaper &&
+    !isExactRunnerIoPressure &&
+    !isExactRunnerPrerequisiteRepair &&
+    !isExactLayoutGuardContract;
   const hasUncoveredSource =
     relatedFiles.some(file => !isCoveredSource(file)) ||
     hasUnknownCiCancellationHealerPeer ||
@@ -663,7 +715,8 @@ export function buildAffectedTestPlan(changedFiles) {
     hasIncompleteGtmqSourceGateReaper ||
     hasIncompleteRunnerIoPressure ||
     hasIncompleteRunnerPrerequisiteContract ||
-    hasIncompleteLayoutGuardContract;
+    hasIncompleteLayoutGuardContract ||
+    hasIncompleteNeonAttemptArtifactRepair;
   const hasSelectedTests =
     selectedTests.length > 0 ||
     rootVitestTests.length > 0 ||
@@ -679,6 +732,7 @@ export function buildAffectedTestPlan(changedFiles) {
             isExactVercelCongestionControl ||
             isExactAffectedTestSelector ||
             isExactGoldenPathSmokeContractRepair ||
+            isExactNeonAttemptArtifactRepair ||
             isExactPerformanceProfilerRepair ||
             isExactPersistedAuthFixtureRepair ||
             isExactVisualQaSelectorRepair ||


### PR DESCRIPTION
## Root cause
GitHub Actions reruns keep the same `run_id` but increment `run_attempt`. The Neon producer already creates a fresh branch named with both values, while its credential artifact and all 14 consumers used only `run_id`. A rerun could therefore resolve attempt-1 credentials for an attempt-2 branch. PR #14022 reproduced this exactly: job `86637864382` retried database connectivity 12 times, then failed `password authentication failed for user neondb_owner` before Playwright started.

Classification: dependency/environment drift plus missing CI automation.

## Fix
- name the Neon credential artifact `neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}`
- update every producer/consumer reference in the canonical CI workflow to the same attempt-bound contract
- fail closed through exact `download-artifact` selection; there is no fallback to main or staging credentials
- add a structural regression that inventories every Neon artifact name and rejects any attempt-blind producer or consumer

## Verification
- new producer/consumer contract regression: 1/1 pass
- actionlint: pass
- CI harness manifest/docs: pass
- Biome and diff check: pass
- typecheck, proxy guard, Tailwind guard, secret scans, pre-push hooks: pass
- full legacy `deploy-workflow.test.ts` currently has 10 unrelated failures already present on main (removed Vercel steps, changed seed script entry point, removed cleanup schedule); the new focused contract passes independently

## Safety
First-attempt behavior remains identical except for the `-1` artifact suffix. Reruns cannot select a prior attempt artifact, and missing exact-attempt artifacts fail before any database command.

<!-- bug-to-test: regression coverage in apps/web/tests/unit/ci/deploy-workflow.test.ts -->