### PR TITLE
fix(ci): keep held verified drafts from promotion

### DIFF
--- a/.github/workflows/agent-pr-verify-ready.yml
+++ b/.github/workflows/agent-pr-verify-ready.yml
@@ -84,8 +84,50 @@ jobs:
           app-id: ${{ vars.JOVIE_BOT_APP_ID }}
           private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
 
-      - name: Mark PR ready
+      - name: Mark PR ready if the live state is still eligible
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr ready "$PR_NUMBER"
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          HOLD_LABEL_RE='^(needs-human|hold|gated|queue-deferred|fast)$'
+
+          read_state() {
+            gh pr view "$PR_NUMBER" --json isDraft,headRefOid,labels
+          }
+
+          before="$(read_state)"
+          live_head="$(jq -r '.headRefOid' <<<"$before")"
+          if [[ "$live_head" != "$EXPECTED_HEAD_SHA" ]]; then
+            echo "::error::PR head changed during verification ($live_head != $EXPECTED_HEAD_SHA)"
+            exit 1
+          fi
+          if [[ "$(jq -r '.isDraft' <<<"$before")" != "true" ]]; then
+            echo "PR is no longer draft; nothing to promote."
+            exit 0
+          fi
+          if jq -e --arg re "$HOLD_LABEL_RE" \
+            '[.labels[].name] | any(test($re))' <<<"$before" >/dev/null; then
+            echo "PR gained a hold label during verification; leaving it draft."
+            exit 0
+          fi
+
+          gh pr ready "$PR_NUMBER"
+
+          after="$(read_state)"
+          after_head="$(jq -r '.headRefOid' <<<"$after")"
+          held_after=false
+          if jq -e --arg re "$HOLD_LABEL_RE" \
+            '[.labels[].name] | any(test($re))' <<<"$after" >/dev/null; then
+            held_after=true
+          fi
+          if [[ "$after_head" != "$EXPECTED_HEAD_SHA" || "$held_after" == "true" ]]; then
+            gh pr ready "$PR_NUMBER" --undo
+            echo "::error::PR eligibility changed during promotion; restored draft state"
+            exit 1
+          fi
+          if [[ "$(jq -r '.isDraft' <<<"$after")" != "false" ]]; then
+            echo "::error::gh pr ready returned without promoting the PR"
+            exit 1
+          fi

--- a/scripts/lib/__tests__/agent-pr-verify-ready.test.mjs
+++ b/scripts/lib/__tests__/agent-pr-verify-ready.test.mjs
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '../../..');
+const workflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/agent-pr-verify-ready.yml'),
+  'utf8'
+);
+
+describe('Agent PR Verify Ready live-state guard', () => {
+  it('re-reads draft, head, and hold labels before promotion', () => {
+    expect(workflow).toContain(
+      'gh pr view "$PR_NUMBER" --json isDraft,headRefOid,labels'
+    );
+    expect(workflow).toContain(
+      "HOLD_LABEL_RE='^(needs-human|hold|gated|queue-deferred|fast)$'"
+    );
+    expect(workflow).toContain('live_head" != "$EXPECTED_HEAD_SHA');
+    expect(workflow.indexOf('before="$(read_state)"')).toBeLessThan(
+      workflow.indexOf('gh pr ready "$PR_NUMBER"')
+    );
+  });
+
+  it('compensates a concurrent hold or head change after promotion', () => {
+    expect(workflow).toContain('after="$(read_state)"');
+    expect(workflow).toContain('held_after');
+    expect(workflow).toContain('gh pr ready "$PR_NUMBER" --undo');
+    expect(workflow.indexOf('after="$(read_state)"')).toBeGreaterThan(
+      workflow.indexOf('gh pr ready "$PR_NUMBER"')
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- re-read the live PR draft, head SHA, and hold labels immediately before promotion
- leave `needs-human`, `hold`, `gated`, `queue-deferred`, and `fast` PRs draft
- compensate with `gh pr ready --undo` if the head or hold state changes during promotion
- verify the workflow contract with a focused source regression

## Root cause
Recurring Gem failure / missing automation. `Agent PR Verify Ready` validated exact-head GStack evidence and then unconditionally ran `gh pr ready`, without re-reading the live hold-label state. In run 29201636112 this promoted gated PR #13999 at 2026-07-12T17:18:15Z. The primary agent restored draft state 38 seconds later.

## Regression evidence
- Incident: #13999, run 29201636112
- `pnpm exec vitest run scripts/lib/__tests__/agent-pr-verify-ready.test.mjs` — 2 passed
- `actionlint .github/workflows/agent-pr-verify-ready.yml` — passed
- `pnpm biome check scripts/lib/__tests__/agent-pr-verify-ready.test.mjs` — passed
- `pnpm turbo typecheck --output-logs=errors-only` — passed
- repository commit and pre-push hooks — passed

## Safety
This PR changes only the dedicated verify-and-ready workflow and its regression. It does not enroll or merge any PR. It remains draft and gated pending exact CI/evidence.

## Linear follow-ups
Linear follow-ups: none.