### PR TITLE
fix(ci): count PR size through REST

### DIFF
--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -68,7 +68,28 @@ jobs:
 
           # Exclude generated / lock / snapshot / vendored noise from the count.
           EXCLUDE='pnpm-lock\.yaml|package-lock\.json|yarn\.lock|\.lock$|/generated/|\.gen\.|__snapshots__/|\.snap$|\.svg$|\.po$|/dist/|/build/|\.min\.|drizzle/migrations/meta/'
-          rows=$(gh pr view "$PR" -R "$REPO" --json files -q '.files[] | "\(.additions+.deletions)\t\(.path)"')
+          # The GraphQL-backed `gh pr view --json files` shares an installation
+          # quota with the rest of the fleet and can fail before counting a
+          # two-file PR. Use the paginated REST endpoint and retry only
+          # transient quota/server failures; every other error fails closed.
+          api_error="$RUNNER_TEMP/pr-size-guard-api.err"
+          rows=''
+          for attempt in 1 2 3; do
+            if rows=$(gh api --paginate \
+              "repos/$REPO/pulls/$PR/files?per_page=100" \
+              --jq '.[] | "\(.additions+.deletions)\t\(.filename)"' \
+              2>"$api_error"); then
+              break
+            fi
+            if [[ "$attempt" -eq 3 ]] || ! grep -qiE \
+              'rate limit|HTTP 403|HTTP 429|HTTP 5[0-9][0-9]' "$api_error"; then
+              cat "$api_error" >&2
+              exit 1
+            fi
+            delay=$((attempt * 5))
+            echo "Transient GitHub REST failure (attempt $attempt/3); retrying in ${delay}s"
+            sleep "$delay"
+          done
           counted=$(printf '%s\n' "$rows" | grep -vE "$EXCLUDE" || true)
           lines=$(printf '%s\n' "$counted" | awk -F'\t' '{s+=$1} END{print s+0}')
           files=$(printf '%s\n' "$counted" | grep -c . || true)

--- a/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
+++ b/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
@@ -63,6 +63,16 @@ describe('pr-size-guard label override helpers', () => {
 });
 
 describe('pr-size-guard workflow invariants (JOV-3580 + label override)', () => {
+  it('counts files through paginated REST with bounded transient retry', () => {
+    const workflow = readFileSync(SIZE_GUARD_WORKFLOW, 'utf8');
+
+    expect(workflow).toContain('gh api --paginate \\');
+    expect(workflow).toContain('"repos/$REPO/pulls/$PR/files?per_page=100"');
+    expect(workflow).toContain('for attempt in 1 2 3; do');
+    expect(workflow).toContain('HTTP 403|HTTP 429|HTTP 5[0-9][0-9]');
+    expect(workflow).not.toContain('gh pr view "$PR" -R "$REPO" --json files');
+  });
+
   it('keeps the primary size guard off labeled events', () => {
     const workflow = readFileSync(SIZE_GUARD_WORKFLOW, 'utf8');
 


### PR DESCRIPTION
## Summary
- replace GraphQL-backed `gh pr view --json files` with the paginated REST pull-files endpoint
- retry only bounded transient 403/429/5xx or rate-limit responses
- fail closed immediately for non-transient API errors
- lock the REST pagination, retry bound, and GraphQL removal with a workflow regression

## Root cause
Missing automation / recurring Gem failure. PR Size Guard used GitHub GraphQL to enumerate changed files even though file metadata is available from REST. The shared GitHub App installation GraphQL quota was exhausted, so a two-file PR failed before its size could be counted.

Incident evidence: PR #14003, run 29202362460 attempts 1 and 2 both failed with `GraphQL: API rate limit already exceeded for site ID installation.`

## Verification
- `pnpm exec vitest run scripts/lib/__tests__/pr-size-guard-label-override.test.mjs` — 6 passed
- `actionlint .github/workflows/pr-size-guard.yml` — passed
- `pnpm biome check scripts/lib/__tests__/pr-size-guard-label-override.test.mjs` — passed
- `pnpm turbo typecheck --output-logs=errors-only` — 10/10 passed
- repository commit and pre-push hooks — passed

## Safety
Pagination remains complete for PRs over 100 files. API failures never produce a zero-sized success; non-transient errors fail immediately and transient failures exhaust after three bounded attempts. This PR remains draft and gated pending exact CI/evidence.

## Linear follow-ups
Linear follow-ups: none.