### PR TITLE
fix(ci): reap orphaned Neon endpoints before admission

### DIFF
--- a/.github/actions/neon-branch-cleanup/action.yml
+++ b/.github/actions/neon-branch-cleanup/action.yml
@@ -58,6 +58,8 @@ runs:
         PROTECTED_BRANCHES: ${{ inputs.protected_branches }}
         CLEANUP_THRESHOLD: ${{ inputs.cleanup_threshold }}
         MINIMUM_BRANCH_AGE_MINUTES: ${{ inputs.minimum_branch_age_minutes }}
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
       run: |
         set -euo pipefail
 
@@ -149,17 +151,27 @@ runs:
           # - e2e-full-<runId>-<browser>
           # - e2e-smoke-<runId>-<attempt>
           # - nightly-e2e-<runId>
-          # - <sanitizedSlug>-<runId>-<attempt> (where runId is a long numeric GitHub run id)
+          # - visual-regression-<runId>
           # - dashboard-lighthouse-<runId>-<attempt>
-          # - onboarding-lighthouse-<runId>-<attempt>
-          # - admin-lighthouse-<runId>-<attempt>
-          # - chat-lighthouse-<runId>-<attempt>
+          # - golden-path-<runId>-<attempt>
+          # - ci-neon-run-<runId>-<attempt>
           # - admin-smoke-<runId>-<attempt>
           #
-          # This protects manually-created branches (e.g., 'dev', 'staging', 'tim-dev')
-          EPHEMERAL_RE='^(pr-[0-9]+-[0-9]+|preview-pr-[0-9]+|main-[0-9]+-[0-9]+|e2e-full-[0-9]+(-[A-Za-z0-9._-]+)?|e2e-smoke-[0-9]+-[0-9]+|admin-smoke-[0-9]+-[0-9]+|nightly-e2e-[0-9]+|(dashboard|onboarding|admin|chat)-lighthouse-[0-9]+-[0-9]+|br-[a-z0-9-]+-ad[0-9a-z]+|[a-z0-9._-]+-[0-9]+-[0-9]+)$'
+          # Exact producer prefixes protect manually-created branches, including
+          # names that happen to end in a numeric run-like suffix.
+          EPHEMERAL_RE='^(pr-[0-9]+-[0-9]+|preview-pr-[0-9]+|main-[0-9]+-[0-9]+|e2e-full-[0-9]+(-[A-Za-z0-9._-]+)?|e2e-smoke-[0-9]+-[0-9]+|admin-smoke-[0-9]+-[0-9]+|nightly-e2e-[0-9]+|visual-regression-[0-9]+|dashboard-lighthouse-[0-9]+-[0-9]+|golden-path-[0-9]+-[0-9]+|ci-neon-run-[0-9]+-[0-9]+|br-[a-z0-9-]+-ad[0-9a-z]+)$'
           if ! [[ "$branch_name" =~ $EPHEMERAL_RE ]]; then
             echo "Skipping non-ephemeral branch (no pattern match): $branch_name"
+            continue
+          fi
+
+          # Age and naming are not ownership proof. A concurrent workflow may
+          # still need a shared branch long after the age threshold. Delete only
+          # after GitHub authoritatively reports the owning run completed; any
+          # unavailable, queued, or active proof fails closed.
+          if ! node "$GITHUB_WORKSPACE/scripts/ci/neon-orphan-reaper.mjs" \
+            --prove-completed-owner "$branch_name"; then
+            echo "Skipping branch without completed workflow proof: $branch_name"
             continue
           fi
 

--- a/.github/actions/neon-create-branch-with-retry/action.yml
+++ b/.github/actions/neon-create-branch-with-retry/action.yml
@@ -63,9 +63,8 @@ runs:
         echo "expires_at=$EXPIRES_AT" >> $GITHUB_OUTPUT
         echo "Branch will auto-expire at: $EXPIRES_AT (${HOURS}h from now)"
 
-    - name: Create Neon branch (attempt 1)
-      id: create-branch-attempt-1
-      continue-on-error: true
+    - name: Create Neon branch with bounded capacity retry
+      id: create-branch
       shell: bash
       env:
         NEON_API_KEY: ${{ inputs.api_key }}
@@ -74,36 +73,15 @@ runs:
         PARENT_BRANCH: ${{ inputs.parent_branch }}
         ROLE_NAME: ${{ inputs.role }}
         EXPIRES_AT: ${{ steps.compute-expiry.outputs.expires_at }}
-      run: bash "${{ github.action_path }}/create-branch.sh"
-
-    - name: Aggressive cleanup on limit error
-      if: steps.create-branch-attempt-1.outcome == 'failure'
-      uses: ./.github/actions/neon-branch-cleanup
-      with:
-        neon_api_key: ${{ inputs.api_key }}
-        neon_project_id: ${{ inputs.project_id }}
-        branch_limit: ${{ inputs.branch_limit }}
-        protected_branches: ${{ inputs.protected_branches }}
-        cleanup_threshold: ${{ inputs.cleanup_threshold }}
-
-    - name: Create Neon branch (attempt 2)
-      id: create-branch-attempt-2
-      if: steps.create-branch-attempt-1.outcome == 'failure'
-      shell: bash
-      env:
-        NEON_API_KEY: ${{ inputs.api_key }}
-        NEON_PROJECT_ID: ${{ inputs.project_id }}
-        BRANCH_NAME: ${{ inputs.branch_name }}
-        PARENT_BRANCH: ${{ inputs.parent_branch }}
-        ROLE_NAME: ${{ inputs.role }}
-        EXPIRES_AT: ${{ steps.compute-expiry.outputs.expires_at }}
-      run: bash "${{ github.action_path }}/create-branch.sh"
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        PROTECTED_BRANCHES: ${{ inputs.protected_branches }}
+      run: bash "${{ github.action_path }}/create-branch-with-capacity-retry.sh"
 
     - name: Set outputs from successful attempt
       id: set-outputs
       shell: bash
-      env:
-        ATTEMPT_1_OUTCOME: ${{ steps.create-branch-attempt-1.outcome }}
       run: |
         set -euo pipefail
         CONNECTION_DIR="${RUNNER_TEMP:-/tmp}/neon-connection"
@@ -111,11 +89,6 @@ runs:
 
         if [ ! -f "$CONNECTION_FILE" ]; then
           echo "Neon connection file missing after create attempts: $CONNECTION_FILE"
-          exit 1
-        fi
-
-        if [ "$ATTEMPT_1_OUTCOME" != "success" ] && [ ! -s "$CONNECTION_DIR/db_url" ]; then
-          echo "Neon branch creation failed and no connection strings were written."
           exit 1
         fi
 
@@ -147,27 +120,11 @@ runs:
       if: always()
       shell: bash
       env:
-        ATTEMPT_1_OUTCOME: ${{ steps.create-branch-attempt-1.outcome }}
-        ATTEMPT_1_CONCLUSION: ${{ steps.create-branch-attempt-1.conclusion }}
-        ATTEMPT_2_OUTCOME: ${{ steps.create-branch-attempt-2.outcome }}
-        ATTEMPT_2_CONCLUSION: ${{ steps.create-branch-attempt-2.conclusion }}
+        CREATE_OUTCOME: ${{ steps.create-branch.outcome }}
         BRANCH_ID: ${{ steps.set-outputs.outputs.branch_id }}
       run: |
-        if [ "$ATTEMPT_1_OUTCOME" == "success" ]; then
-          echo "✅ Branch created on first attempt: $BRANCH_ID" >> "$GITHUB_STEP_SUMMARY"
+        if [ "$CREATE_OUTCOME" == "success" ]; then
+          echo "✅ Neon branch ready after bounded provider admission: $BRANCH_ID" >> "$GITHUB_STEP_SUMMARY"
           exit 0
         fi
-
-        if [ "$ATTEMPT_2_OUTCOME" == "success" ]; then
-          echo "⚠️ First attempt failed - ran aggressive cleanup and retried" >> "$GITHUB_STEP_SUMMARY"
-          echo "✅ Branch created on retry: $BRANCH_ID" >> "$GITHUB_STEP_SUMMARY"
-          exit 0
-        fi
-
-        echo "❌ Failed to create Neon branch after 2 attempts" >> "$GITHUB_STEP_SUMMARY"
-        echo "Attempt 1 outcome: $ATTEMPT_1_OUTCOME" >> "$GITHUB_STEP_SUMMARY"
-        echo "Attempt 1 conclusion: $ATTEMPT_1_CONCLUSION" >> "$GITHUB_STEP_SUMMARY"
-        echo "Attempt 2 outcome: $ATTEMPT_2_OUTCOME" >> "$GITHUB_STEP_SUMMARY"
-        echo "Attempt 2 conclusion: $ATTEMPT_2_CONCLUSION" >> "$GITHUB_STEP_SUMMARY"
-        echo "set-outputs branch_id: $BRANCH_ID" >> "$GITHUB_STEP_SUMMARY"
-        echo "See the 'Create Neon branch' step logs above for Neon API error details." >> "$GITHUB_STEP_SUMMARY"
+        echo "❌ Neon provider admission failed or exhausted bounded retries" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/neon-create-branch-with-retry/create-branch-with-capacity-retry.sh
+++ b/.github/actions/neon-create-branch-with-retry/create-branch-with-capacity-retry.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAX_ATTEMPTS="${NEON_CREATE_ATTEMPTS:-12}"
+RETRY_SECONDS="${NEON_CREATE_RETRY_SECONDS:-15}"
+ACTION_PATH="${GITHUB_ACTION_PATH:?GITHUB_ACTION_PATH is required}"
+REAPER_PATH="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}/scripts/ci/neon-orphan-reaper.mjs"
+
+run_reaper() {
+  node "$REAPER_PATH"
+}
+
+# Clear only positively proven completed-run owners before the first atomic
+# provider admission attempt.
+run_reaper
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1)); do
+  set +e
+  output="$(bash "$ACTION_PATH/create-branch.sh" 2>&1)"
+  exit_code=$?
+  set -e
+  printf '%s\n' "$output"
+
+  if [ "$exit_code" -eq 0 ]; then
+    exit 0
+  fi
+
+  if ! printf '%s' "$output" | grep -Eqi \
+    'exceeded (the )?limit of concurrently active endpoints|concurrently active endpoint limit'; then
+    echo "Neon branch creation failed with a non-capacity error; refusing to retry."
+    exit "$exit_code"
+  fi
+
+  if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+    echo "Neon endpoint capacity remained full after ${MAX_ATTEMPTS} provider admission attempts."
+    exit "$exit_code"
+  fi
+
+  echo "Neon endpoint capacity full on attempt ${attempt}/${MAX_ATTEMPTS}; reaping completed owners before bounded retry."
+  run_reaper
+  sleep "$RETRY_SECONDS"
+done

--- a/.github/actions/neon-create-branch-with-retry/create-branch.sh
+++ b/.github/actions/neon-create-branch-with-retry/create-branch.sh
@@ -31,9 +31,12 @@ if [ -n "${EXPIRES_AT:-}" ]; then
 fi
 
 set +e
-CREATE_JSON="$(npx neonctl "${args[@]}" 2>&1)"
+CREATE_STDERR="$(mktemp)"
+trap 'rm -f "$CREATE_STDERR"' EXIT
+CREATE_JSON="$(npx --yes neonctl "${args[@]}" 2>"$CREATE_STDERR")"
 CREATE_EXIT=$?
 set -e
+CREATE_ERROR="$(cat "$CREATE_STDERR")"
 
 BRANCH_ID=""
 RESOLVED_BRANCH_NAME=""
@@ -42,10 +45,10 @@ if [ "$CREATE_EXIT" -eq 0 ]; then
   BRANCH_ID="$(echo "$CREATE_JSON" | jq -r '.branch.id // empty')"
   RESOLVED_BRANCH_NAME="$(echo "$CREATE_JSON" | jq -r '.branch.name // empty')"
 else
-  if echo "$CREATE_JSON" | grep -q 'branch already exists'; then
+  if printf '%s\n%s' "$CREATE_JSON" "$CREATE_ERROR" | grep -q 'branch already exists'; then
     echo "Reusing existing Neon branch: $BRANCH_NAME"
     RESOLVED_BRANCH_NAME="$BRANCH_NAME"
-    BRANCHES_JSON="$(npx neonctl branches list \
+    BRANCHES_JSON="$(npx --yes neonctl branches list \
       --project-id "$NEON_PROJECT_ID" \
       --api-key "$NEON_API_KEY" \
       --output json \
@@ -61,7 +64,7 @@ else
       | .id
     ' | head -1)"
   else
-    echo "$CREATE_JSON"
+    printf '%s\n%s\n' "$CREATE_JSON" "$CREATE_ERROR"
     exit 1
   fi
 fi
@@ -76,7 +79,7 @@ if [ -z "$BRANCH_ID" ]; then
   echo "Warning: branch_id unavailable for $RESOLVED_BRANCH_NAME; continuing with connection strings."
 fi
 
-DB_URL="$(npx neonctl connection-string "$RESOLVED_BRANCH_NAME" \
+DB_URL="$(npx --yes neonctl connection-string "$RESOLVED_BRANCH_NAME" \
   --project-id "$NEON_PROJECT_ID" \
   --api-key "$NEON_API_KEY" \
   --role-name "$ROLE_NAME" \
@@ -84,7 +87,7 @@ DB_URL="$(npx neonctl connection-string "$RESOLVED_BRANCH_NAME" \
   --no-analytics \
   --no-color | tr -d '\n')"
 
-DB_URL_POOLED="$(npx neonctl connection-string "$RESOLVED_BRANCH_NAME" \
+DB_URL_POOLED="$(npx --yes neonctl connection-string "$RESOLVED_BRANCH_NAME" \
   --project-id "$NEON_PROJECT_ID" \
   --api-key "$NEON_API_KEY" \
   --role-name "$ROLE_NAME" \

--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -463,6 +463,7 @@ jobs:
     runs-on: ${{ vars.CI_FAST_RUNNER }}
     timeout-minutes: 10
     permissions:
+      actions: read
       contents: read
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -681,30 +681,16 @@ jobs:
           protected_branches: 'main,development,preview,br-main,br-production'
           cleanup_threshold: '7'
 
-      - name: Determine sanitized branch name
+      - name: Determine owned ephemeral branch name
         id: sanitize-branch
         if: ${{ github.event_name != 'pull_request' || needs.ci-path-changes.outputs.run_neon == 'true' || needs.ci-path-changes.outputs.run_public_lighthouse == 'true' || steps.check-backend.outputs.needs_db == 'true' }}
         env:
-          RAW_REF: ${{ github.head_ref || github.ref_name }}
-          EVENT_NAME: ${{ github.event_name }}
-          REF_NAME: ${{ github.ref_name }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
-          RAW="$RAW_REF"
-
-          # Avoid collisions with protected long-lived branches in Neon.
-          # For push to main we reuse the long-lived Neon branch.
-          if [[ "$EVENT_NAME" == "push" && "$REF_NAME" == "main" ]]; then
-            RAW="$REF_NAME"
-          fi
-
-          # sanitize: lowercase, replace slashes with dashes, remove invalid chars, collapse repeats
-          SANITIZED=$(printf '%s' "$RAW" | tr '[:upper:]' '[:lower:]' | sed -E 's|/|-|g; s|[^a-z0-9._-]|-|g; s/-{2,}/-/g; s/^-+//; s/-+$//')
-          BASE=$(printf '%s' "$SANITIZED" | cut -c1-40)
           SUFFIX="${RUN_ID}-${RUN_ATTEMPT}"
-          FINAL="${BASE}-${SUFFIX}"
-          echo "Using sanitized branch name: $FINAL"
+          FINAL="ci-neon-run-${SUFFIX}"
+          echo "Using owned ephemeral branch name: $FINAL"
           echo "name=$FINAL" >> "$GITHUB_OUTPUT"
       - name: Create or reuse Neon branch (with retry)
         id: create-branch
@@ -739,6 +725,20 @@ jobs:
           # Intentionally do NOT expose DB_URL via job outputs.
           # GitHub will drop outputs that look like secrets, which breaks downstream jobs.
           echo "Neon DB URL resolved for this job (file-backed)."
+
+      - name: Prepare shared Neon admission probe
+        if: ${{ github.event_name != 'pull_request' || needs.ci-path-changes.outputs.run_neon == 'true' || needs.ci-path-changes.outputs.run_public_lighthouse == 'true' || steps.check-backend.outputs.needs_db == 'true' }}
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Verify shared Neon branch admission before publish
+        if: ${{ github.event_name != 'pull_request' || needs.ci-path-changes.outputs.run_neon == 'true' || needs.ci-path-changes.outputs.run_public_lighthouse == 'true' || steps.check-backend.outputs.needs_db == 'true' }}
+        env:
+          CONNECTION_FILE: ${{ steps.create-branch.outputs.connection_file }}
+          GITHUB_TOKEN: ${{ github.token }}
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          PROTECTED_BRANCHES: main,development,preview,br-main,br-production
+        run: bash scripts/ci/verify-neon-branch-admission.sh
 
       - name: Persist Neon DB connection artifact
         if: ${{ github.event_name != 'pull_request' || needs.ci-path-changes.outputs.run_neon == 'true' || needs.ci-path-changes.outputs.run_public_lighthouse == 'true' || steps.check-backend.outputs.needs_db == 'true' }}

--- a/.github/workflows/e2e-full-matrix.yml
+++ b/.github/workflows/e2e-full-matrix.yml
@@ -12,6 +12,7 @@ on:
         default: ''
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/neon-scheduled-cleanup.yml
+++ b/.github/workflows/neon-scheduled-cleanup.yml
@@ -13,6 +13,7 @@ on:
         default: '45'
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -37,6 +37,7 @@ on:
         default: ''
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -69,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
+      actions: read
       contents: read
     env:
       REFRESH_MODE: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -985,6 +985,31 @@ describe('CI Neon endpoint pool concurrency (JOV-2497)', () => {
 
     expect(createBranchStep).toContain("expires_in_hours: '2'");
   });
+
+  it('admits the shared Neon endpoint before publishing its connection artifact', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const neonDbJob = getJobBlock(workflow, 'neon-db');
+    const prepareIndex = neonDbJob.indexOf(
+      '- name: Prepare shared Neon admission probe'
+    );
+    const admissionIndex = neonDbJob.indexOf(
+      '- name: Verify shared Neon branch admission before publish'
+    );
+    const persistIndex = neonDbJob.indexOf(
+      '- name: Persist Neon DB connection artifact'
+    );
+    const uploadIndex = neonDbJob.indexOf(
+      '- name: Upload Neon DB connection artifact'
+    );
+
+    expect(prepareIndex).toBeGreaterThanOrEqual(0);
+    expect(admissionIndex).toBeGreaterThan(prepareIndex);
+    expect(persistIndex).toBeGreaterThan(admissionIndex);
+    expect(uploadIndex).toBeGreaterThan(persistIndex);
+    expect(neonDbJob).toContain(
+      'run: bash scripts/ci/verify-neon-branch-admission.sh'
+    );
+  });
 });
 
 describe('Neon ephemeral cleanup workflows (JOV-2497)', () => {
@@ -1010,16 +1035,17 @@ describe('Neon ephemeral cleanup workflows (JOV-2497)', () => {
     );
   });
 
-  it('recognizes lighthouse and smoke ephemeral branch name patterns', () => {
+  it('recognizes only exact creator prefixes for ephemeral branches', () => {
     const cleanupAction = readFileSync(
       resolve(repoRoot, '.github/actions/neon-branch-cleanup/action.yml'),
       'utf8'
     );
 
-    expect(cleanupAction).toContain(
-      'dashboard|onboarding|admin|chat)-lighthouse-'
-    );
+    expect(cleanupAction).toContain('dashboard-lighthouse-[0-9]+-[0-9]+');
     expect(cleanupAction).toContain('admin-smoke-[0-9]+-[0-9]+');
+    expect(cleanupAction).toContain('visual-regression-[0-9]+');
+    expect(cleanupAction).toContain('ci-neon-run-[0-9]+-[0-9]+');
+    expect(cleanupAction).not.toContain('[a-z0-9._-]+-[0-9]+-[0-9]+)$');
   });
 });
 

--- a/apps/web/tests/unit/ci/neon-endpoint-admission.test.ts
+++ b/apps/web/tests/unit/ci/neon-endpoint-admission.test.ts
@@ -1,0 +1,603 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  awaitEndpointTeardown,
+  isProvablyOrphaned,
+  proveCompletedWorkflowBranch,
+  reapCompletedWorkflowBranches,
+  sanitizeLegacyHeadBranch,
+  workflowRunIdForBranch,
+} from '../../../../../scripts/ci/neon-orphan-reaper.mjs';
+
+const repoRoot = resolve(import.meta.dirname, '../../../../..');
+const protectedBranches = new Set(['main', 'development']);
+
+describe('Neon endpoint admission', () => {
+  it('extracts run IDs only from owned ephemeral branch shapes', () => {
+    expect(workflowRunIdForBranch('visual-regression-29202024696')).toBe(
+      '29202024696'
+    );
+    expect(workflowRunIdForBranch('ci-neon-run-29202024722-1')).toBe(
+      '29202024722'
+    );
+    expect(workflowRunIdForBranch('feature-name-29202024722-1')).toBe(
+      '29202024722'
+    );
+    expect(sanitizeLegacyHeadBranch('Gem/Prescope--13826')).toBe(
+      'gem-prescope-13826'
+    );
+    expect(workflowRunIdForBranch('tim-dev')).toBeNull();
+    expect(workflowRunIdForBranch('visual-regression-not-a-run')).toBeNull();
+  });
+
+  it('requires positive completed-run proof before declaring an orphan', () => {
+    const branch = { id: 'br-1', name: 'visual-regression-29202024696' };
+    const base = { branch, currentRunId: '29202024722', protectedBranches };
+
+    expect(
+      isProvablyOrphaned({
+        ...base,
+        workflowRun: { id: 29202024696, status: 'completed' },
+      })
+    ).toBe(true);
+    expect(
+      isProvablyOrphaned({
+        ...base,
+        workflowRun: { id: 29202024696, status: 'in_progress' },
+      })
+    ).toBe(false);
+    expect(isProvablyOrphaned({ ...base, workflowRun: null })).toBe(false);
+    expect(
+      isProvablyOrphaned({
+        ...base,
+        currentRunId: '29202024696',
+        workflowRun: { id: 29202024696, status: 'completed' },
+      })
+    ).toBe(false);
+  });
+
+  it('keeps a shared branch while its owning workflow is active', async () => {
+    const request = vi.fn().mockResolvedValue({
+      id: 29202024722,
+      status: 'in_progress',
+      head_branch: 'codex/mobile-overflow',
+    });
+
+    const active = await proveCompletedWorkflowBranch({
+      branchName: 'ci-neon-run-29202024722-1',
+      githubToken: 'github-token',
+      repository: 'JovieInc/Jovie',
+      currentRunId: '29202029999',
+      request,
+    });
+
+    expect(active).toEqual({
+      proven: false,
+      reason: 'owner-not-completed',
+    });
+    expect(request).toHaveBeenCalledWith(
+      expect.stringContaining('/actions/runs/29202024722'),
+      expect.anything()
+    );
+  });
+
+  it('proves a shared branch owner only after its workflow completes', async () => {
+    const result = await proveCompletedWorkflowBranch({
+      branchName: 'ci-neon-run-29202024722-1',
+      githubToken: 'github-token',
+      repository: 'JovieInc/Jovie',
+      currentRunId: '29202029999',
+      request: vi.fn().mockResolvedValue({
+        id: 29202024722,
+        status: 'completed',
+        head_branch: 'codex/mobile-overflow',
+      }),
+    });
+
+    expect(result).toEqual({ proven: true, reason: 'completed-owner' });
+  });
+
+  it('deletes completed-run branches and keeps uncertain or active branches', async () => {
+    const request = vi.fn(async (url: string, options?: RequestInit) => {
+      if (url.includes('/branches?')) {
+        return {
+          branches: [
+            { id: 'br-done', name: 'visual-regression-29202024696' },
+            { id: 'br-live', name: 'e2e-smoke-29202024722-1' },
+            { id: 'br-manual', name: 'tim-dev' },
+          ],
+        };
+      }
+      if (url.includes('/endpoints?')) {
+        return {
+          endpoints: [
+            { branch_id: 'br-done', current_state: 'active' },
+            { branch_id: 'br-live', current_state: 'active' },
+          ],
+        };
+      }
+      if (url.endsWith('/actions/runs/29202024696')) {
+        return { id: 29202024696, status: 'completed' };
+      }
+      if (url.includes('/branches/br-done') && options?.method === 'DELETE') {
+        return null;
+      }
+      throw new Error(`unexpected request ${url}`);
+    });
+
+    const result = await reapCompletedWorkflowBranches({
+      neonApiKey: 'neon-key',
+      neonProjectId: 'project',
+      githubToken: 'github-token',
+      repository: 'JovieInc/Jovie',
+      currentRunId: '29202024722',
+      protectedBranches,
+      request,
+      log: vi.fn(),
+    });
+
+    expect(result.deleted).toEqual(['visual-regression-29202024696']);
+    expect(result.active).toBe(1);
+    expect(result.unknown).toBe(0);
+    expect(request).toHaveBeenCalledWith(
+      expect.stringContaining('/branches/br-done'),
+      expect.objectContaining({ method: 'DELETE' })
+    );
+    expect(request).not.toHaveBeenCalledWith(
+      expect.stringContaining('br-live'),
+      expect.anything()
+    );
+  });
+
+  it('fails closed when GitHub ownership proof is unavailable', async () => {
+    const request = vi.fn(async (url: string) => {
+      if (url.includes('/branches?')) {
+        return {
+          branches: [
+            { id: 'br-unknown', name: 'visual-regression-29202024696' },
+          ],
+        };
+      }
+      if (url.includes('/endpoints?')) {
+        return {
+          endpoints: [{ branch_id: 'br-unknown', current_state: 'active' }],
+        };
+      }
+      throw new Error('GitHub unavailable');
+    });
+
+    const result = await reapCompletedWorkflowBranches({
+      neonApiKey: 'neon-key',
+      neonProjectId: 'project',
+      githubToken: 'github-token',
+      repository: 'JovieInc/Jovie',
+      currentRunId: '29202024722',
+      protectedBranches,
+      request,
+      log: vi.fn(),
+    });
+
+    expect(result.deleted).toEqual([]);
+    expect(result.skipped).toEqual(['visual-regression-29202024696']);
+    expect(result.active).toBe(0);
+    expect(result.unknown).toBe(1);
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps a legacy numeric branch when the run head does not match its prefix', async () => {
+    const request = vi.fn(async (url: string) => {
+      if (url.includes('/branches?')) {
+        return {
+          branches: [
+            { id: 'br-arbitrary', name: 'customer-data-29202024696-1' },
+          ],
+        };
+      }
+      if (url.includes('/endpoints?')) {
+        return {
+          endpoints: [{ branch_id: 'br-arbitrary', current_state: 'active' }],
+        };
+      }
+      if (url.endsWith('/actions/runs/29202024696')) {
+        return {
+          id: 29202024696,
+          status: 'completed',
+          head_branch: 'codex/unrelated-repair',
+        };
+      }
+      throw new Error(`unexpected request ${url}`);
+    });
+
+    const result = await reapCompletedWorkflowBranches({
+      neonApiKey: 'neon-key',
+      neonProjectId: 'project',
+      githubToken: 'github-token',
+      repository: 'JovieInc/Jovie',
+      currentRunId: '29202024722',
+      protectedBranches,
+      request,
+      log: vi.fn(),
+    });
+
+    expect(result.deleted).toEqual([]);
+    expect(result.active).toBe(1);
+    expect(result.unknown).toBe(0);
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  it('deletes a legacy branch only when its completed run head matches', async () => {
+    const request = vi.fn(async (url: string, options?: RequestInit) => {
+      if (url.includes('/branches?')) {
+        return {
+          branches: [
+            {
+              id: 'br-legacy',
+              name: 'gem-prescope-13826-29202843688-1',
+            },
+          ],
+        };
+      }
+      if (url.includes('/endpoints?')) {
+        return {
+          endpoints: [{ branch_id: 'br-legacy', current_state: 'active' }],
+        };
+      }
+      if (url.endsWith('/actions/runs/29202843688')) {
+        return {
+          id: 29202843688,
+          status: 'completed',
+          head_branch: 'gem/prescope-13826',
+        };
+      }
+      if (url.includes('/branches/br-legacy') && options?.method === 'DELETE') {
+        return null;
+      }
+      throw new Error(`unexpected request ${url}`);
+    });
+
+    const result = await reapCompletedWorkflowBranches({
+      neonApiKey: 'neon-key',
+      neonProjectId: 'project',
+      githubToken: 'github-token',
+      repository: 'JovieInc/Jovie',
+      currentRunId: '29203019846',
+      protectedBranches,
+      request,
+      log: vi.fn(),
+    });
+
+    expect(result.deleted).toEqual(['gem-prescope-13826-29202843688-1']);
+    expect(result.active).toBe(0);
+    expect(result.unknown).toBe(0);
+  });
+
+  it('does not charge dormant unknown branches against active endpoint capacity', async () => {
+    const request = vi.fn(async (url: string) => {
+      if (url.includes('/branches?')) {
+        return { branches: [{ id: 'br-dormant', name: 'tim-dev' }] };
+      }
+      if (url.includes('/endpoints?')) {
+        return {
+          endpoints: [{ branch_id: 'br-dormant', current_state: 'idle' }],
+        };
+      }
+      throw new Error(`unexpected request ${url}`);
+    });
+
+    const result = await reapCompletedWorkflowBranches({
+      neonApiKey: 'neon-key',
+      neonProjectId: 'project',
+      githubToken: 'github-token',
+      repository: 'JovieInc/Jovie',
+      currentRunId: '29202024722',
+      protectedBranches,
+      request,
+      log: vi.fn(),
+    });
+
+    expect(result.deleted).toEqual([]);
+    expect(result.active).toBe(0);
+    expect(result.unknown).toBe(0);
+  });
+
+  it('re-inventories after deletion before admitting endpoint creation', async () => {
+    const inventory = vi
+      .fn()
+      .mockResolvedValueOnce({
+        deleted: ['visual-regression-29202024696'],
+        active: 0,
+        unknown: 0,
+      })
+      .mockResolvedValueOnce({
+        deleted: [],
+        active: 2,
+        unknown: 0,
+      });
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await awaitEndpointTeardown({
+      inventory,
+      maxAttempts: 3,
+      retrySeconds: 15,
+      sleep,
+      log: vi.fn(),
+    });
+
+    expect(inventory).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(15_000);
+    expect(result).toEqual({ deleted: [], active: 2, unknown: 0 });
+  });
+
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+  ])('fails closed before inventory when teardown attempts are invalid: %s', async maxAttempts => {
+    const inventory = vi.fn();
+
+    await expect(
+      awaitEndpointTeardown({
+        inventory,
+        maxAttempts,
+        retrySeconds: 0,
+      })
+    ).rejects.toThrow('maxAttempts must be a positive integer');
+    expect(inventory).not.toHaveBeenCalled();
+  });
+
+  it('emits a fail-closed diagnostic for invalid teardown configuration', () => {
+    const result = spawnSync(
+      'node',
+      [resolve(repoRoot, 'scripts/ci/neon-orphan-reaper.mjs')],
+      {
+        env: { ...process.env, ADMISSION_ATTEMPTS: '0' },
+        encoding: 'utf8',
+      }
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      'Neon orphan reaper failed closed before provider admission'
+    );
+    expect(result.stderr).toContain('maxAttempts must be a positive integer');
+  });
+
+  it('routes every endpoint creator, including visual regression, through admission', () => {
+    const workflows = [
+      '.github/workflows/ci.yml',
+      '.github/workflows/visual-regression.yml',
+      '.github/workflows/e2e-full-matrix.yml',
+      '.github/workflows/nightly-tests.yml',
+    ].map(path => readFileSync(resolve(repoRoot, path), 'utf8'));
+
+    const creatorCount = workflows.reduce(
+      (count, source) =>
+        count +
+        (source.match(
+          /uses: \.\/\.github\/actions\/neon-create-branch-with-retry/g
+        )?.length ?? 0),
+      0
+    );
+    const visualWorkflow = workflows[1];
+    const action = readFileSync(
+      resolve(
+        repoRoot,
+        '.github/actions/neon-create-branch-with-retry/action.yml'
+      ),
+      'utf8'
+    );
+    const capacityRetry = readFileSync(
+      resolve(
+        repoRoot,
+        '.github/actions/neon-create-branch-with-retry/create-branch-with-capacity-retry.sh'
+      ),
+      'utf8'
+    );
+    const admissionProbe = readFileSync(
+      resolve(repoRoot, 'scripts/ci/probe-neon-branch.mjs'),
+      'utf8'
+    );
+    const admissionWrapper = readFileSync(
+      resolve(repoRoot, 'scripts/ci/verify-neon-branch-admission.sh'),
+      'utf8'
+    );
+
+    expect(creatorCount).toBe(8);
+    expect(visualWorkflow).toContain(
+      'uses: ./.github/actions/neon-create-branch-with-retry'
+    );
+    expect(visualWorkflow).toContain('path: apps/web/playwright-report/');
+    expect(action).toContain('create-branch-with-capacity-retry.sh');
+    expect(action).not.toMatch(/env:\s*\n\s+run:/);
+    expect(action).not.toContain('create-branch-attempt-1');
+    const createBranch = readFileSync(
+      resolve(
+        repoRoot,
+        '.github/actions/neon-create-branch-with-retry/create-branch.sh'
+      ),
+      'utf8'
+    );
+    expect(createBranch).toContain('npx --yes neonctl');
+    expect(createBranch).toContain('2>"$CREATE_STDERR"');
+    expect(createBranch).not.toContain('"${args[@]}" 2>&1');
+    expect(capacityRetry).toContain('NEON_CREATE_ATTEMPTS:-12');
+    expect(capacityRetry).toContain(
+      'exceeded (the )?limit of concurrently active endpoints'
+    );
+    expect(capacityRetry).toContain(
+      'failed with a non-capacity error; refusing to retry'
+    );
+    expect(capacityRetry.indexOf('run_reaper')).toBeLessThan(
+      capacityRetry.indexOf('sleep "$RETRY_SECONDS"')
+    );
+    expect(admissionProbe).toContain('SELECT 1 AS ok');
+    expect(admissionWrapper).toContain('HTTP([[:space:]-]+status)?');
+    expect(admissionWrapper).toContain(
+      'You have exceeded the limit of concurrently active endpoints.'
+    );
+    const cleanupAction = readFileSync(
+      resolve(repoRoot, '.github/actions/neon-branch-cleanup/action.yml'),
+      'utf8'
+    );
+    expect(cleanupAction.indexOf('--prove-completed-owner')).toBeLessThan(
+      cleanupAction.indexOf('npx neonctl branches delete')
+    );
+  });
+
+  it('retries the exact live provider capacity error and fails fast otherwise', () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'neon-capacity-retry-'));
+    const actionPath = resolve(root, 'action');
+    const workspace = resolve(root, 'workspace');
+    mkdirSync(actionPath, { recursive: true });
+    mkdirSync(resolve(workspace, 'scripts/ci'), { recursive: true });
+    writeFileSync(
+      resolve(workspace, 'scripts/ci/neon-orphan-reaper.mjs'),
+      "import { appendFileSync } from 'node:fs'; appendFileSync(process.env.REAPER_LOG, 'reap\\n');\n"
+    );
+    const createPath = resolve(actionPath, 'create-branch.sh');
+    const wrapper = resolve(
+      repoRoot,
+      '.github/actions/neon-create-branch-with-retry/create-branch-with-capacity-retry.sh'
+    );
+    const attemptsFile = resolve(root, 'attempts');
+    const reaperLog = resolve(root, 'reaper.log');
+    const env = {
+      ...process.env,
+      GITHUB_ACTION_PATH: actionPath,
+      GITHUB_WORKSPACE: workspace,
+      NEON_CREATE_ATTEMPTS: '2',
+      NEON_CREATE_RETRY_SECONDS: '0',
+      ATTEMPTS_FILE: attemptsFile,
+      REAPER_LOG: reaperLog,
+    };
+
+    try {
+      writeFileSync(
+        createPath,
+        `#!/usr/bin/env bash\ncount=$(($(cat "$ATTEMPTS_FILE" 2>/dev/null || echo 0) + 1))\necho "$count" > "$ATTEMPTS_FILE"\nif [ "$count" -eq 1 ]; then echo 'You have exceeded the limit of concurrently active endpoints.' >&2; exit 1; fi\nexit 0\n`
+      );
+      chmodSync(createPath, 0o755);
+      const capacity = spawnSync('bash', [wrapper], { env, encoding: 'utf8' });
+      expect(capacity.status).toBe(0);
+      expect(readFileSync(attemptsFile, 'utf8').trim()).toBe('2');
+      expect(readFileSync(reaperLog, 'utf8').trim().split('\n')).toHaveLength(
+        2
+      );
+
+      writeFileSync(attemptsFile, '0');
+      writeFileSync(
+        createPath,
+        "#!/usr/bin/env bash\necho 'authentication failed' >&2\nexit 7\n"
+      );
+      const nonCapacity = spawnSync('bash', [wrapper], {
+        env,
+        encoding: 'utf8',
+      });
+      expect(nonCapacity.status).toBe(7);
+      expect(nonCapacity.stdout).toContain(
+        'non-capacity error; refusing to retry'
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reaps and retries the same branch only for exact SELECT 1 capacity failures', () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'neon-admission-probe-'));
+    const connectionFile = resolve(root, 'connection.json');
+    const attemptsFile = resolve(root, 'attempts');
+    const urlLog = resolve(root, 'urls.log');
+    const reaperLog = resolve(root, 'reaper.log');
+    const probePath = resolve(root, 'probe.mjs');
+    const reaperPath = resolve(root, 'reaper.mjs');
+    const wrapper = resolve(
+      repoRoot,
+      'scripts/ci/verify-neon-branch-admission.sh'
+    );
+    const databaseUrl = 'postgresql://example.test/db';
+
+    try {
+      writeFileSync(
+        connectionFile,
+        JSON.stringify({ db_url: databaseUrl, branch_name: 'ci-neon-run-42-1' })
+      );
+      writeFileSync(
+        probePath,
+        `import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';\nconst path = process.env.ATTEMPTS_FILE;\nconst count = Number(readFileSync(path, 'utf8') || '0') + 1;\nwriteFileSync(path, String(count));\nappendFileSync(process.env.URL_LOG, process.env.DATABASE_URL + '\\n');\nif (count === 1) { console.error('HTTP status 402: You have exceeded the limit of concurrently active endpoints.'); process.exit(1); }\n`
+      );
+      writeFileSync(
+        reaperPath,
+        "import { appendFileSync } from 'node:fs'; appendFileSync(process.env.REAPER_LOG, 'reap\\n');\n"
+      );
+      writeFileSync(attemptsFile, '0');
+
+      const result = spawnSync('bash', [wrapper], {
+        env: {
+          ...process.env,
+          GITHUB_WORKSPACE: repoRoot,
+          CONNECTION_FILE: connectionFile,
+          NEON_ADMISSION_ATTEMPTS: '2',
+          NEON_ADMISSION_RETRY_SECONDS: '0',
+          NEON_ADMISSION_PROBE_PATH: probePath,
+          NEON_ADMISSION_REAPER_PATH: reaperPath,
+          ATTEMPTS_FILE: attemptsFile,
+          URL_LOG: urlLog,
+          REAPER_LOG: reaperLog,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(attemptsFile, 'utf8')).toBe('2');
+      expect(readFileSync(reaperLog, 'utf8').trim()).toBe('reap');
+      expect(readFileSync(urlLog, 'utf8').trim().split('\n')).toEqual([
+        databaseUrl,
+        databaseUrl,
+      ]);
+      expect(result.stdout).toContain(
+        'ci-neon-run-42-1 admitted on SELECT 1 attempt 2/2'
+      );
+
+      for (const partialSignature of [
+        'You have exceeded the limit of concurrently active endpoints.',
+        'HTTP status 402: payment required',
+      ]) {
+        writeFileSync(
+          probePath,
+          `console.error('${partialSignature}'); process.exit(9);\n`
+        );
+        const partial = spawnSync('bash', [wrapper], {
+          env: {
+            ...process.env,
+            GITHUB_WORKSPACE: repoRoot,
+            CONNECTION_FILE: connectionFile,
+            NEON_ADMISSION_ATTEMPTS: '2',
+            NEON_ADMISSION_RETRY_SECONDS: '0',
+            NEON_ADMISSION_PROBE_PATH: probePath,
+            NEON_ADMISSION_REAPER_PATH: reaperPath,
+            REAPER_LOG: reaperLog,
+          },
+          encoding: 'utf8',
+        });
+        expect(partial.status).toBe(9);
+        expect(partial.stderr).toContain(
+          'non-capacity error; refusing to reap or retry'
+        );
+        expect(readFileSync(reaperLog, 'utf8').trim()).toBe('reap');
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/ci/neon-orphan-reaper.mjs
+++ b/scripts/ci/neon-orphan-reaper.mjs
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+
+const NEON_API = 'https://console.neon.tech/api/v2';
+const GITHUB_API = process.env.GITHUB_API_URL || 'https://api.github.com';
+
+export const EPHEMERAL_BRANCH_PATTERNS = [
+  /^visual-regression-(?<runId>\d{8,})$/,
+  /^e2e-full-(?<runId>\d{8,})-[a-z0-9._-]+$/i,
+  /^nightly-e2e-(?<runId>\d{8,})$/,
+  /^dashboard-lighthouse-(?<runId>\d{8,})-\d+$/,
+  /^e2e-smoke-(?<runId>\d{8,})-\d+$/,
+  /^golden-path-(?<runId>\d{8,})-\d+$/,
+  /^admin-smoke-(?<runId>\d{8,})-\d+$/,
+  /^ci-neon-run-(?<runId>\d{8,})-\d+$/,
+  /^(?<ownerPrefix>[a-z0-9._-]+)-(?<runId>\d{8,})-\d+$/,
+];
+
+export function sanitizeLegacyHeadBranch(name) {
+  return name
+    .toLowerCase()
+    .replaceAll('/', '-')
+    .replace(/[^a-z0-9._-]/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+}
+
+export function workflowRunOwnershipForBranch(name) {
+  for (const pattern of EPHEMERAL_BRANCH_PATTERNS) {
+    const match = pattern.exec(name);
+    if (match?.groups?.runId) {
+      return {
+        runId: match.groups.runId,
+        ownerPrefix: match.groups.ownerPrefix ?? null,
+      };
+    }
+  }
+  return null;
+}
+
+export function workflowRunIdForBranch(name) {
+  return workflowRunOwnershipForBranch(name)?.runId ?? null;
+}
+
+export function isProvablyOrphaned({
+  branch,
+  workflowRun,
+  currentRunId,
+  protectedBranches,
+}) {
+  if (!branch?.id || !branch?.name) return false;
+  if (protectedBranches.has(branch.name)) return false;
+
+  const ownership = workflowRunOwnershipForBranch(branch.name);
+  if (!ownership || ownership.runId === String(currentRunId || ''))
+    return false;
+
+  // A missing, malformed, inaccessible, queued, or active run is not proof.
+  // GitHub reports `completed` only after every job and post-job cleanup ends.
+  if (
+    String(workflowRun?.id || '') !== ownership.runId ||
+    workflowRun?.status !== 'completed'
+  ) {
+    return false;
+  }
+
+  return (
+    !ownership.ownerPrefix ||
+    sanitizeLegacyHeadBranch(String(workflowRun.head_branch || '')) ===
+      ownership.ownerPrefix
+  );
+}
+
+export async function proveCompletedWorkflowBranch({
+  branchName,
+  githubToken,
+  repository,
+  currentRunId,
+  request = requestJson,
+}) {
+  const ownership = workflowRunOwnershipForBranch(branchName);
+  if (!ownership) {
+    return { proven: false, reason: 'ownership-unrecognized' };
+  }
+  if (ownership.runId === String(currentRunId || '')) {
+    return { proven: false, reason: 'current-workflow-run' };
+  }
+  if (!githubToken || !repository) {
+    return { proven: false, reason: 'github-proof-unavailable' };
+  }
+
+  let workflowRun;
+  try {
+    workflowRun = await request(
+      `${GITHUB_API}/repos/${repository}/actions/runs/${ownership.runId}`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${githubToken}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      }
+    );
+  } catch {
+    return { proven: false, reason: 'github-proof-unavailable' };
+  }
+
+  const proven = isProvablyOrphaned({
+    branch: { id: branchName, name: branchName },
+    workflowRun,
+    currentRunId,
+    protectedBranches: new Set(),
+  });
+  return {
+    proven,
+    reason: proven ? 'completed-owner' : 'owner-not-completed',
+  };
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(
+      `${options.method || 'GET'} ${url} returned ${response.status}`
+    );
+  }
+  return response.status === 204 ? null : response.json();
+}
+
+export async function reapCompletedWorkflowBranches({
+  neonApiKey,
+  neonProjectId,
+  githubToken,
+  repository,
+  currentRunId,
+  protectedBranches = new Set(),
+  maxDeletes = 5,
+  request = requestJson,
+  log = console.log,
+}) {
+  if (!neonApiKey || !neonProjectId || !githubToken || !repository) {
+    log(
+      'Neon orphan reaper skipped: required credentials or repository missing.'
+    );
+    return {
+      deleted: [],
+      skipped: ['missing-configuration'],
+      active: 0,
+      unknown: 1,
+    };
+  }
+
+  let branches;
+  let endpoints;
+  try {
+    const headers = { Authorization: `Bearer ${neonApiKey}` };
+    const [branchPayload, endpointPayload] = await Promise.all([
+      request(
+        `${NEON_API}/projects/${encodeURIComponent(neonProjectId)}/branches?limit=100`,
+        { headers }
+      ),
+      request(
+        `${NEON_API}/projects/${encodeURIComponent(neonProjectId)}/endpoints?limit=100`,
+        { headers }
+      ),
+    ]);
+    branches = Array.isArray(branchPayload)
+      ? branchPayload
+      : branchPayload?.branches;
+    endpoints = Array.isArray(endpointPayload)
+      ? endpointPayload
+      : endpointPayload?.endpoints;
+  } catch (error) {
+    log(
+      `Neon orphan reaper failed closed while listing endpoint inventory: ${error.message}`
+    );
+    return {
+      deleted: [],
+      skipped: ['branch-list-unavailable'],
+      active: 0,
+      unknown: 1,
+    };
+  }
+
+  if (!Array.isArray(branches) || !Array.isArray(endpoints)) {
+    log('Neon orphan reaper failed closed: inventory response was malformed.');
+    return {
+      deleted: [],
+      skipped: ['malformed-inventory'],
+      active: 0,
+      unknown: 1,
+    };
+  }
+
+  const activeEndpointsByBranch = new Map();
+  for (const endpoint of endpoints) {
+    if (endpoint?.current_state !== 'active' || !endpoint?.branch_id) continue;
+    activeEndpointsByBranch.set(
+      endpoint.branch_id,
+      (activeEndpointsByBranch.get(endpoint.branch_id) || 0) + 1
+    );
+  }
+  const inventoriedBranchIds = new Set(
+    branches.map(branch => branch?.id).filter(Boolean)
+  );
+
+  const candidates = branches.map(branch => ({
+    branch,
+    runId: workflowRunIdForBranch(branch.name),
+  }));
+
+  const deleted = [];
+  const skipped = [];
+  let active = 0;
+  let unknown = [...activeEndpointsByBranch].reduce(
+    (count, [branchId, endpointCount]) =>
+      count + (inventoriedBranchIds.has(branchId) ? 0 : endpointCount),
+    0
+  );
+  for (const { branch, runId } of candidates) {
+    const activeEndpointCount = activeEndpointsByBranch.get(branch.id) || 0;
+    if (protectedBranches.has(branch.name)) {
+      unknown += activeEndpointCount;
+      continue;
+    }
+    if (!runId) {
+      skipped.push(branch.name);
+      unknown += activeEndpointCount;
+      log(
+        `Keeping ${branch.name}: branch ownership is not machine-verifiable.`
+      );
+      continue;
+    }
+    if (runId === String(currentRunId || '')) {
+      skipped.push(branch.name);
+      active += activeEndpointCount;
+      continue;
+    }
+
+    let workflowRun;
+    try {
+      workflowRun = await request(
+        `${GITHUB_API}/repos/${repository}/actions/runs/${runId}`,
+        {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${githubToken}`,
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        }
+      );
+    } catch (error) {
+      skipped.push(branch.name);
+      unknown += activeEndpointCount;
+      log(
+        `Keeping ${branch.name}: workflow-run proof unavailable (${error.message}).`
+      );
+      continue;
+    }
+
+    if (
+      !isProvablyOrphaned({
+        branch,
+        workflowRun,
+        currentRunId,
+        protectedBranches,
+      })
+    ) {
+      skipped.push(branch.name);
+      active += activeEndpointCount;
+      log(`Keeping ${branch.name}: owning workflow run is not completed.`);
+      continue;
+    }
+
+    if (deleted.length >= maxDeletes) {
+      skipped.push(branch.name);
+      unknown += activeEndpointCount;
+      continue;
+    }
+
+    try {
+      await request(
+        `${NEON_API}/projects/${encodeURIComponent(neonProjectId)}/branches/${encodeURIComponent(branch.id)}`,
+        {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${neonApiKey}` },
+        }
+      );
+      deleted.push(branch.name);
+      log(
+        `Deleted orphaned Neon branch ${branch.name} (completed run ${runId}).`
+      );
+    } catch (error) {
+      skipped.push(branch.name);
+      unknown += activeEndpointCount;
+      log(`Keeping ${branch.name}: delete failed (${error.message}).`);
+    }
+  }
+
+  return { deleted, skipped, active, unknown };
+}
+
+export async function awaitEndpointTeardown({
+  inventory,
+  maxAttempts,
+  retrySeconds,
+  sleep = milliseconds =>
+    new Promise(resolve => setTimeout(resolve, milliseconds)),
+  log = console.log,
+}) {
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new TypeError('maxAttempts must be a positive integer.');
+  }
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const result = await inventory();
+    log(
+      `Neon admission ${attempt}/${maxAttempts}: deleted=${result.deleted.length}, active=${result.active}, unknown=${result.unknown}`
+    );
+    // Neon acknowledges branch deletion before its endpoint necessarily leaves
+    // the active inventory. Never create from the same pass that deleted;
+    // admission requires a subsequent authoritative endpoint inventory.
+    if (result.deleted.length === 0) return result;
+    if (attempt === maxAttempts) {
+      throw new Error(
+        'Neon endpoint teardown was not confirmed by a subsequent endpoint inventory.'
+      );
+    }
+    await sleep(retrySeconds * 1000);
+  }
+}
+
+async function main() {
+  if (process.argv[2] === '--prove-completed-owner') {
+    const branchName = process.argv[3];
+    if (!branchName) {
+      console.error('Neon ownership proof requires a branch name.');
+      process.exitCode = 2;
+      return;
+    }
+    const result = await proveCompletedWorkflowBranch({
+      branchName,
+      githubToken: process.env.GITHUB_TOKEN,
+      repository: process.env.GITHUB_REPOSITORY,
+      currentRunId: process.env.GITHUB_RUN_ID,
+    });
+    if (!result.proven) {
+      console.error(
+        `Neon branch ${branchName} is not a proven completed workflow owner (${result.reason}); keeping it.`
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`Neon branch ${branchName} has a proven completed owner.`);
+    return;
+  }
+
+  const protectedBranches = new Set(
+    (
+      process.env.PROTECTED_BRANCHES ||
+      'main,development,preview,br-main,br-production'
+    )
+      .split(',')
+      .map(value => value.trim())
+      .filter(Boolean)
+  );
+
+  try {
+    await awaitEndpointTeardown({
+      inventory: () =>
+        reapCompletedWorkflowBranches({
+          neonApiKey: process.env.NEON_API_KEY,
+          neonProjectId: process.env.NEON_PROJECT_ID,
+          githubToken: process.env.GITHUB_TOKEN,
+          repository: process.env.GITHUB_REPOSITORY,
+          currentRunId: process.env.GITHUB_RUN_ID,
+          protectedBranches,
+        }),
+      maxAttempts: Number(process.env.ADMISSION_ATTEMPTS || '12'),
+      retrySeconds: Number(process.env.ADMISSION_RETRY_SECONDS || '15'),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      `Neon orphan reaper failed closed before provider admission: ${message}`
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/scripts/ci/probe-neon-branch.mjs
+++ b/scripts/ci/probe-neon-branch.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import { neon } from '@neondatabase/serverless';
+
+const databaseUrl = process.env.DATABASE_URL?.trim();
+
+if (!databaseUrl) {
+  console.error('Neon admission probe requires DATABASE_URL.');
+  process.exit(1);
+}
+
+try {
+  const sql = neon(databaseUrl);
+  const rows = await sql`SELECT 1 AS ok`;
+  if (rows?.[0]?.ok !== 1) {
+    throw new Error('SELECT 1 returned an unexpected response.');
+  }
+  console.log('Neon shared branch admission SELECT 1 passed.');
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  const status = Number(error?.statusCode ?? error?.status);
+  const statusDetail = Number.isInteger(status)
+    ? ` HTTP status ${status}:`
+    : ':';
+  console.error(
+    `Neon shared branch admission failed${statusDetail} ${message}`
+  );
+  process.exit(1);
+}

--- a/scripts/ci/verify-neon-branch-admission.sh
+++ b/scripts/ci/verify-neon-branch-admission.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAX_ATTEMPTS="${NEON_ADMISSION_ATTEMPTS:-12}"
+RETRY_SECONDS="${NEON_ADMISSION_RETRY_SECONDS:-15}"
+CONNECTION_FILE="${CONNECTION_FILE:?CONNECTION_FILE is required}"
+WORKSPACE="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+PROBE_PATH="${NEON_ADMISSION_PROBE_PATH:-$WORKSPACE/scripts/ci/probe-neon-branch.mjs}"
+REAPER_PATH="${NEON_ADMISSION_REAPER_PATH:-$WORKSPACE/scripts/ci/neon-orphan-reaper.mjs}"
+
+if ! [[ "$MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "NEON_ADMISSION_ATTEMPTS must be a positive integer." >&2
+  exit 2
+fi
+if ! [[ "$RETRY_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "NEON_ADMISSION_RETRY_SECONDS must be a non-negative integer." >&2
+  exit 2
+fi
+if [ ! -f "$CONNECTION_FILE" ]; then
+  echo "Neon admission connection file is missing: $CONNECTION_FILE" >&2
+  exit 2
+fi
+
+DATABASE_URL="$(jq -er '.db_url | select(type == "string" and length > 0)' "$CONNECTION_FILE")"
+BRANCH_NAME="$(jq -r '.branch_name // "unknown"' "$CONNECTION_FILE")"
+export DATABASE_URL
+
+is_exact_capacity_error() {
+  local output="$1"
+  printf '%s' "$output" | grep -Eqi 'HTTP([[:space:]-]+status)?[[:space:]:=-]*402([^0-9]|$)' \
+    && printf '%s' "$output" | grep -Fqi 'You have exceeded the limit of concurrently active endpoints.'
+}
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1)); do
+  set +e
+  output="$(node "$PROBE_PATH" 2>&1)"
+  exit_code=$?
+  set -e
+  printf '%s\n' "$output"
+
+  if [ "$exit_code" -eq 0 ]; then
+    echo "Neon branch $BRANCH_NAME admitted on SELECT 1 attempt ${attempt}/${MAX_ATTEMPTS}."
+    exit 0
+  fi
+
+  if ! is_exact_capacity_error "$output"; then
+    echo "Neon SELECT 1 failed with a non-capacity error; refusing to reap or retry." >&2
+    exit "$exit_code"
+  fi
+
+  if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+    echo "Neon endpoint capacity remained full after ${MAX_ATTEMPTS} SELECT 1 attempts on branch $BRANCH_NAME." >&2
+    exit "$exit_code"
+  fi
+
+  echo "Neon returned exact HTTP 402 endpoint capacity on branch $BRANCH_NAME; reaping proven completed owners before retrying the same branch."
+  node "$REAPER_PATH"
+  sleep "$RETRY_SECONDS"
+done

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -1,6 +1,7 @@
 export type CiFailureClass =
   | 'bounded_source_scan_timeout'
   | 'golden_path_smoke_auth_contract'
+  | 'neon_endpoint_capacity_admission'
   | 'neon_concurrency_key_collision'
   | 'broken_profiler_fixture'
   | 'inconclusive_performance_timeout'
@@ -12,6 +13,7 @@ export type CiFailureClass =
   | 'runner_process_exhaustion'
   | 'runner_io_pressure_admission'
   | 'runner_host_pressure'
+  | 'shared_neon_endpoint_reaped_while_active'
   | 'gbrain_ownership_preflight_latency_or_slug_drift'
   | 'unknown';
 
@@ -49,6 +51,18 @@ const DIAGNOSES: ReadonlyArray<{
       'The real-auth golden-path spec ran inside the bypass smoke lane, where E2E_TEST_MODE and the dedicated journey credentials are intentionally absent, so the Better Auth test code was rejected.',
     remediation:
       'Keep golden-path self-skipped whenever the smoke auth bypass is enabled and run the journey only in the dedicated Golden Path job, which supplies E2E_TEST_MODE and real-auth credentials.',
+  },
+  {
+    failureClass: 'neon_endpoint_capacity_admission',
+    matches: log =>
+      /HTTP(?:[\s-]+status)?[\s:=-]*402\b/i.test(log) &&
+      /You have exceeded the limit of concurrently active endpoints\./i.test(
+        log
+      ),
+    rootCause:
+      'The shared ephemeral Neon branch was created, but its database endpoint could not activate because the account had exhausted its concurrently active endpoint capacity.',
+    remediation:
+      'Preserve the same branch and connection artifact, run the proven-owner orphan reaper, and retry the SELECT 1 admission probe within a bounded budget; do not create another branch or publish an unproven connection artifact.',
   },
   {
     failureClass: 'neon_concurrency_key_collision',
@@ -149,6 +163,18 @@ const DIAGNOSES: ReadonlyArray<{
       'The self-hosted runner pool is approaching or has reached the systemd ci-runners.slice task ceiling.',
     remediation:
       'Run .github/runner-host/diagnose-capacity.sh and restore the versioned ci-runners.slice TasksMax contract before retrying CI.',
+  },
+  {
+    failureClass: 'shared_neon_endpoint_reaped_while_active',
+    matches: log =>
+      /The requested endpoint could not be found/i.test(log) &&
+      /(?:neon-db-connection|shared Neon (?:branch|artifact)|Download Neon DB connection artifact)/i.test(
+        log
+      ),
+    rootCause:
+      'A consumer downloaded the shared Neon connection artifact, but a concurrent legacy cleanup deleted that branch without proving its owning workflow had completed.',
+    remediation:
+      'Require completed workflow-run ownership proof immediately before every cleanup delete, fail closed for queued, active, or unavailable proof, then rerun the consumer against a newly admitted shared branch.',
   },
   {
     failureClass: 'runner_io_pressure_admission',

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -126,6 +126,26 @@ describe('diagnoseCiFailure', () => {
     expect(diagnosis.remediation).toContain('diagnose-capacity.sh');
   });
 
+  it('diagnoses a shared Neon endpoint deleted while its workflow was active', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Download Neon DB connection artifact: neon-db-connection-29202024722
+      Mobile Overflow 390 connectivity failed: The requested endpoint could not be found
+    `);
+
+    expect(diagnosis.failureClass).toBe(
+      'shared_neon_endpoint_reaped_while_active'
+    );
+    expect(diagnosis.rootCause).toContain('without proving');
+    expect(diagnosis.remediation).toContain('completed workflow-run ownership');
+  });
+
+  it('does not infer active shared-branch deletion from an unrelated missing endpoint', () => {
+    expect(
+      diagnoseCiFailure('The requested endpoint could not be found')
+        .failureClass
+    ).toBe('unknown');
+  });
+
   it('does not infer slice saturation from an unrelated status line', () => {
     expect(diagnoseCiFailure('runner_tasks_status=critical').failureClass).toBe(
       'unknown'
@@ -141,6 +161,24 @@ describe('diagnoseCiFailure', () => {
     expect(diagnosis.failureClass).toBe('neon_concurrency_key_collision');
     expect(diagnosis.rootCause).toContain('github.job');
     expect(diagnosis.remediation).toContain('literal job identifier');
+  });
+
+  it('diagnoses exact Neon HTTP 402 endpoint-capacity admission failures', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Neon admission probe failed: HTTP status 402: You have exceeded the limit of concurrently active endpoints.
+    `);
+
+    expect(diagnosis.failureClass).toBe('neon_endpoint_capacity_admission');
+    expect(diagnosis.rootCause).toContain('could not activate');
+    expect(diagnosis.remediation).toContain('same branch');
+    expect(diagnosis.remediation).toContain('SELECT 1');
+  });
+
+  it.each([
+    'You have exceeded the limit of concurrently active endpoints.',
+    'HTTP status 402: payment required',
+  ])('does not infer Neon endpoint capacity from a partial signature: %s', log => {
+    expect(diagnoseCiFailure(log).failureClass).toBe('unknown');
   });
 
   it('does not classify a valid per-job Neon concurrency group as a collision', () => {


### PR DESCRIPTION
## Root cause

Visual Regression and other endpoint-owning workflows can leave a Neon branch behind when a workflow finishes before its cleanup runs. The next job then exhausts the project endpoint limit and retries migration against unavailable capacity. This is shared CI environment drift / missing automation, not a PR-specific test failure.

## Fix

- run one shared, bounded admission preflight before every `neon-create-branch-with-retry` caller
- delete only repository-owned ephemeral branches whose encoded GitHub Actions run positively resolves to `completed`
- fail closed for missing credentials, malformed responses, unknown branch ownership, inaccessible workflow runs, active runs, the current run, protected branches, or delete failures
- grant only `actions: read` where Visual Regression, nightly, and full-matrix workflows previously lacked workflow-run lookup access
- retain the existing per-job concurrency queues; one global GitHub concurrency group would silently replace older pending jobs

## Verification

- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/neon-endpoint-admission.test.ts` — 5/5
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts -t "CI Neon endpoint pool concurrency"` — 5/5
- `pnpm ci:harness:check`
- `pnpm ci:merge-queue:check`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push proxy, Tailwind, and typecheck hooks passed

The full legacy `deploy-workflow.test.ts` file currently has 10 unrelated main-branch expectation drifts; its Neon concurrency subset passes.