### PR TITLE
fix(ci): fail closed on zero-task deploy contracts

### DIFF
--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -6,9 +6,14 @@ import { describe, expect, it } from 'vitest';
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
 const workflowPath = resolve(repoRoot, '.github/workflows/ci.yml');
+const ciFastLanesPath = resolve(repoRoot, 'scripts/ci-fast-lanes.mjs');
 const canaryWorkflowPath = resolve(
   repoRoot,
   '.github/workflows/canary-health-gate.yml'
+);
+const agentTickWorkflowPath = resolve(
+  repoRoot,
+  '.github/workflows/agent-tick.yml'
 );
 
 function getStepBlock(workflow: string, stepName: string): string {
@@ -62,14 +67,6 @@ describe('deploy workflow Vercel env resolution', () => {
         command: 'vercel build',
         name: 'Build (PR preview)',
       },
-      {
-        command: 'vercel pull',
-        name: 'Pull env (production)',
-      },
-      {
-        command: 'vercel build',
-        name: 'Build (preview target for staging verification)',
-      },
     ];
 
     for (const { command, name } of steps) {
@@ -86,6 +83,41 @@ describe('deploy workflow Vercel env resolution', () => {
       expect(step).toContain('scope_args=(--scope "$VERCEL_ORG_ID")');
       expect(step).toContain('"${scope_args[@]}"');
       expect(step).not.toContain('--scope ${{ secrets.VERCEL_ORG_ID }}');
+    }
+
+    const stagingJob = getJobBlock(workflow, 'deploy-staging');
+    const configureStep = getStepBlock(
+      stagingJob,
+      'Configure staging deployment credentials'
+    );
+    const stagingSteps = [
+      {
+        command: 'vercel pull',
+        name: 'Pull env (staging preview)',
+      },
+      {
+        command: 'vercel build',
+        name: 'Build (preview target for staging verification)',
+      },
+    ];
+
+    expect(configureStep).toContain(
+      'VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}'
+    );
+    expect(configureStep).toContain(
+      'VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}'
+    );
+    expect(configureStep).toContain(
+      'VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}'
+    );
+    expect(configureStep).toContain('>> "$GITHUB_ENV"');
+
+    for (const { command, name } of stagingSteps) {
+      const step = getStepBlock(stagingJob, name);
+      expect(step).toContain(command);
+      expect(step).toContain('scope_args=()');
+      expect(step).toContain('scope_args=(--scope "$VERCEL_ORG_ID")');
+      expect(step).toContain('"${scope_args[@]}"');
     }
   });
 
@@ -129,62 +161,29 @@ describe('deploy workflow Vercel env resolution', () => {
     }
   });
 
-  it('syncs required signup readiness keys into the configured production Vercel project before pulling env', () => {
-    const workflow = readFileSync(workflowPath, 'utf8');
-    const syncStep = getStepBlock(
-      workflow,
-      'Sync required production env to Vercel project'
-    );
-    const pullStep = getStepBlock(workflow, 'Pull env (production)');
-    const syncIndex = workflow.indexOf(
-      '- name: Sync required production env to Vercel project'
-    );
-    const pullIndex = workflow.indexOf('- name: Pull env (production)');
-    const requiredKeys = [
-      'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
-      'CLERK_SECRET_KEY',
-      'CLERK_PUBLISHABLE_KEY_STAGING',
-      'CLERK_SECRET_KEY_STAGING',
-      'DATABASE_URL',
-      'SESSION_SECRET',
-      'AI_GATEWAY_API_KEY',
-      'NEXT_PUBLIC_TURNSTILE_SITE_KEY',
-      'TURNSTILE_SECRET_KEY',
-    ];
-
-    expect(syncIndex).toBeGreaterThanOrEqual(0);
-    expect(pullIndex).toBeGreaterThan(syncIndex);
-    expect(syncStep).toContain('required_vercel_env=(');
-    expect(syncStep).toContain('vercel env rm "$key" production');
-    expect(syncStep).toContain('vercel env add "$key" production');
-    expect(syncStep).toContain('--value "${!key}"');
-    expect(syncStep).toContain('>/dev/null');
-    expect(syncStep).toContain('>/dev/null 2>&1 || true');
-    expect(syncStep).toContain('set +x');
-    expect(syncStep).toContain(
-      'VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}'
-    );
-    expect(pullStep).toContain(
-      'VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}'
-    );
-
-    for (const key of requiredKeys) {
-      expect(syncStep).toContain(key);
-      expect(syncStep).toContain(`${key}: \${{ secrets.${key} }}`);
-    }
-  });
-
-  it('checks production signup readiness against the deploy env instead of the pulled Vercel file', () => {
+  it('checks staging signup readiness against the deploy env before building the promotion artifact', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const readinessStep = getStepBlock(
       workflow,
-      'Check signup readiness (production deploy env)'
+      'Check signup readiness (staging deploy env)'
+    );
+    const buildStep = getStepBlock(
+      workflow,
+      'Build (preview target for staging verification)'
+    );
+    const readinessIndex = workflow.indexOf(
+      '- name: Check signup readiness (staging deploy env)'
+    );
+    const buildIndex = workflow.indexOf(
+      '- name: Build (preview target for staging verification)'
     );
 
-    expect(readinessStep).toContain('--target=prd');
+    expect(readinessIndex).toBeGreaterThanOrEqual(0);
+    expect(buildIndex).toBeGreaterThan(readinessIndex);
+    expect(readinessStep).toContain('--target=stg');
     expect(readinessStep).toContain('--source=env');
     expect(readinessStep).not.toContain('--source=vercel-file');
-    expect(readinessStep).not.toContain('.vercel/.env.production.local');
+    expect(buildStep).toContain('vercel build');
   });
 
   it('verifies production promotion through the canonical public alias', () => {
@@ -223,7 +222,7 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(promoteStep).toContain('"https://jov.ie/api/health/build-info"');
     expect(promoteStep).toContain('probe_labels=(');
     expect(promoteStep).toContain('"production-alias"');
-    expect(promoteStep).toContain('max_attempts=30');
+    expect(promoteStep).toContain('max_attempts=15');
     expect(promoteStep).toContain('URLs can return 401');
   });
 
@@ -291,7 +290,7 @@ describe('canary health gate workflow', () => {
       'value: ${{ jobs.canary-health-gate.outputs.verified_deployment_url }}'
     );
     expect(canaryStep).toContain('/api/health/build-info');
-    expect(canaryStep).toContain('local max_attempts=30');
+    expect(canaryStep).toContain('local max_attempts=15');
     expect(canaryStep).toContain(
       'CURL_TIMEOUT_ARGS=(--connect-timeout 5 --max-time 15)'
     );
@@ -364,7 +363,13 @@ describe('CI E2E smoke workflow', () => {
     expect(seedStep).toContain(
       "if: steps.check_changes.outputs.run_full_ci == 'true'"
     );
-    expect(seedStep).toContain('tests/seed-test-data.ts');
+    expect(seedStep).toContain('run seed:test-data');
+    const packageJson = JSON.parse(
+      readFileSync(resolve(repoRoot, 'apps/web/package.json'), 'utf8')
+    ) as { scripts: Record<string, string> };
+    expect(packageJson.scripts['seed:test-data']).toContain(
+      'tests/seed-test-data.ts'
+    );
     expect(smokeJob).not.toContain('Export DATABASE_URL (main');
   });
 });
@@ -421,7 +426,7 @@ describe('CI public lighthouse workflow', () => {
     expect(seedStep).toContain('matrix.shard == 0');
     expect(waitStep).toContain('matrix.shard != 0');
     expect(waitStep).toContain('tests/wait-for-public-qa-seed.ts');
-    expect(seedStep).toContain('tests/seed-test-data.ts');
+    expect(seedStep).toContain('run seed:test-data');
     expect(exportStep).toContain(
       'steps.resolve-lighthouse-neon-db-url.outputs.database_url'
     );
@@ -443,26 +448,21 @@ describe('CI public lighthouse workflow', () => {
     const config = JSON.parse(readFileSync(configPath, 'utf8')) as {
       ci: {
         collect: {
-          puppeteerLaunchOptions?: {
-            args?: string[];
-            protocolTimeout?: number;
-          };
           settings?: {
+            chromeFlags?: string;
             skipAudits?: string[];
           };
         };
       };
     };
 
-    const launchOptions = config.ci.collect.puppeteerLaunchOptions;
-    expect(launchOptions?.args).toEqual(
-      expect.arrayContaining([
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage',
-      ])
+    expect(config.ci.collect.settings?.chromeFlags).toContain('--no-sandbox');
+    expect(config.ci.collect.settings?.chromeFlags).toContain(
+      '--disable-setuid-sandbox'
     );
-    expect(launchOptions?.protocolTimeout).toBeGreaterThanOrEqual(120_000);
+    expect(config.ci.collect.settings?.chromeFlags).toContain(
+      '--disable-dev-shm-usage'
+    );
     expect(config.ci.collect.settings?.skipAudits).toContain('font-size');
   });
 });
@@ -519,7 +519,7 @@ describe('CI mobile overflow workflow', () => {
     expect(seedStep).toContain('matrix.width == 320');
     expect(waitStep).toContain('matrix.width != 320');
     expect(waitStep).toContain('tests/wait-for-public-qa-seed.ts');
-    expect(seedStep).toContain('tests/seed-test-data.ts');
+    expect(seedStep).toContain('run seed:test-data');
     expect(exportStep).toContain(
       'steps.resolve-mobile-overflow-neon-db-url.outputs.database_url'
     );
@@ -626,15 +626,15 @@ describe('Neon ephemeral cleanup workflows (JOV-2497)', () => {
     expect(cleanupWorkflow).toContain('startswith($base + "-")');
   });
 
-  it('runs scheduled branch cleanup every 30 minutes', () => {
-    const scheduledWorkflow = readFileSync(
-      resolve(repoRoot, '.github/workflows/neon-scheduled-cleanup.yml'),
-      'utf8'
-    );
+  it('runs Neon branch cleanup from the consolidated ten-minute agent tick', () => {
+    const agentTickWorkflow = readFileSync(agentTickWorkflowPath, 'utf8');
+    const cleanupJob = getJobBlock(agentTickWorkflow, 'neon-cleanup');
 
-    expect(scheduledWorkflow).toContain("cron: '*/30 * * * *'");
-    expect(scheduledWorkflow).toContain(
-      "minimum_branch_age_minutes: ${{ github.event.inputs.minimum_branch_age_minutes || '45' }}"
+    expect(agentTickWorkflow).toContain("cron: '*/10 * * * *'");
+    expect(cleanupJob).toContain('uses: ./.github/actions/neon-branch-cleanup');
+    expect(cleanupJob).toContain("minimum_branch_age_minutes: '45'");
+    expect(cleanupJob).toContain(
+      "protected_branches: 'main,development,preview,br-main,br-production'"
     );
   });
 
@@ -648,6 +648,19 @@ describe('Neon ephemeral cleanup workflows (JOV-2497)', () => {
       'dashboard|onboarding|admin|chat)-lighthouse-'
     );
     expect(cleanupAction).toContain('admin-smoke-[0-9]+-[0-9]+');
+  });
+});
+
+describe('ci-fast critical deploy contract', () => {
+  it('targets the web test directly so a zero-task Turbo run cannot pass', () => {
+    const ciFastLanes = readFileSync(ciFastLanesPath, 'utf8');
+    const command =
+      'pnpm --filter @jovie/web exec vitest run --config=vitest.config.mts tests/unit/ci/deploy-workflow.test.ts';
+
+    expect(ciFastLanes).toContain(command);
+    expect(command).not.toContain('turbo');
+    expect(command).not.toContain('--affected');
+    expect(command).not.toContain('--passWithNoTests');
   });
 });
 

--- a/scripts/ci-fast-lanes.mjs
+++ b/scripts/ci-fast-lanes.mjs
@@ -215,6 +215,11 @@ function runStructural() {
     'pnpm --filter=@jovie/web run lint:contrast-ratchet',
     'pnpm doc:freshness:check',
     'node .github/scripts/quarantine-ledger.mjs validate',
+    // CI workflow changes live at the repo root, so Turbo --affected can select
+    // only the root package and return success after running zero web tests.
+    // Target Vitest directly so the deploy contract always executes and fails
+    // closed when the file cannot be resolved or contains no tests.
+    'pnpm --filter @jovie/web exec vitest run --config=vitest.config.mts tests/unit/ci/deploy-workflow.test.ts',
     'pnpm --filter @jovie/web run test:reliability-detectors',
     // Optional: structural regression tests need pytest; soft-skip if unavailable.
     'if command -v pytest >/dev/null 2>&1; then pytest scripts/tests/test_gh_retry.py scripts/tests/test_vercel_prebuilt_deploy.py -v; elif python3 -c "import pytest" 2>/dev/null; then python3 -m pytest scripts/tests/test_gh_retry.py scripts/tests/test_vercel_prebuilt_deploy.py -v; else echo "pytest not installed — skip structural regressions"; fi',


### PR DESCRIPTION
## Summary
- run the deploy workflow contract directly in the blocking ci-fast structural lane
- fail closed when Vitest resolves zero tests instead of trusting Turbo's zero-task exit 0
- repair 10 stale deploy-contract assertions exposed by the direct lane

## Root cause
PR #14088 changed only root CI files. Unit Tests (4/5), job 86674435171, ran pnpm turbo test:fast --affected with TURBO_SCM_BASE=origin/main. Turbo selected only the root package (//), executed 0 tasks twice, and returned success. The explicit quarantined deploy contract therefore never ran. A direct invocation exposed 10 broken/stale workflow assertions.

Classification: recurring Gem failure + broken test fixture + missing fail-closed automation.

## Verification
- direct deploy workflow Vitest: 23/23 pass
- nonexistent direct test selection exits 1 with "No test files found"
- full scripts/ci-fast-lanes.mjs: biome, server boundaries, typecheck, guardrails, structural all pass
- pre-push hooks: pass
- git diff --check: pass

## Risk
The added blocking test is deterministic and completed in about 2 seconds locally. No production workflow behavior changes.

bug-to-test: regression included in deploy-workflow.test.ts

No Linear issue - ad-hoc PR queue repair.