### PR TITLE
fix(ci): fit staging readiness inside job budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,8 @@ jobs:
     # (build / Lighthouse / e2e / preview) stay separate.
     needs: [ci-path-changes]
     runs-on: ubuntu-latest
+    # Setup/DB work (~2m) + accepted source deploy (up to 10m) + readiness
+    # verification (up to 9m) must fit without the job canceling a healthy build.
     timeout-minutes: 25
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name != 'pull_request' || needs.ci-path-changes.outputs.has_code_changes == 'true') }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2546,7 +2546,7 @@ jobs:
     needs: [ci-build-public, ci-path-changes, neon-db]
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_public_lighthouse == 'true')) && needs.ci-build-public.outputs.has_artifact == 'true') }}
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 20
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -4585,7 +4585,7 @@ jobs:
     # saturate the production-deploy concurrency slot.
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !failure() && !cancelled() && needs.deploy-gate.outputs.is_head == 'true' }}
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     # Deploy concurrency: serialize main deploys instead of cancelling them.
     # Cancelling in-progress main deploys during merge bursts can starve
     # production promotion and leave main without a completed deploy run.

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -155,3 +155,29 @@ def test_workflow_waits_for_readiness_and_aliases_only_after_canary() -> None:
     )
     preview_wait_index = workflow.index("- name: Wait for PR preview readiness")
     assert preview_deploy_index < preview_wait_index < deploy_index
+
+
+def test_staging_job_budget_contains_deploy_and_readiness_steps() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    staging_block = workflow[
+        workflow.index("  deploy-staging:") : workflow.index(
+            "  canary-health-gate:"
+        )
+    ]
+
+    job_timeout = re.search(r"^    timeout-minutes: ([0-9]+)$", staging_block, re.M)
+    deploy_timeout = re.search(
+        r"- name: Deploy \(staging preview, prebuilt\)\n        timeout-minutes: ([0-9]+)",
+        staging_block,
+    )
+    readiness_timeout = re.search(
+        r"- name: Wait for staging deployment readiness\n        timeout-minutes: ([0-9]+)",
+        staging_block,
+    )
+
+    assert job_timeout is not None
+    assert deploy_timeout is not None
+    assert readiness_timeout is not None
+    assert int(job_timeout.group(1)) >= (
+        int(deploy_timeout.group(1)) + int(readiness_timeout.group(1)) + 5
+    )


### PR DESCRIPTION
## Summary
- give `deploy-staging` 25 minutes so its 10-minute deploy and 9-minute readiness steps fit with setup overhead
- revert the accidental A11y timeout increase from the prior hotfix
- add a regression that scopes the budget assertion to the `deploy-staging` job by name

## Root cause
The staging job remained capped at 15 minutes. Setup and deploy consumed 9m34s, leaving only 5m26s for an 8-minute Vercel readiness wait, so GitHub canceled a healthy deployment before canary.

## Verification
- `python3 -m pytest scripts/tests/test_vercel_prebuilt_deploy.py -q` (5 passed)
- `actionlint .github/workflows/ci.yml` with repository ShellCheck exclusions
- `git diff --check`

Bug-to-test: waived — workflow budget regression is covered and required by `scripts/tests/test_vercel_prebuilt_deploy.py`; the gate only recognizes JS/TS suffixes.