### PR TITLE
fix(ci): preserve authenticated a11y failure artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2822,7 +2822,7 @@ jobs:
           pnpm exec playwright test \
             tests/e2e/a11y.spec.ts \
             tests/e2e/chat-axe.spec.ts \
-            --config=playwright.config.ts --project=chromium --reporter=line
+            --config=playwright.config.ts --project=chromium
         env:
           BASE_URL: http://localhost:3100
           CI: true
@@ -2845,8 +2845,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: a11y-authed-report-${{ github.run_id }}-${{ github.run_attempt }}
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 7
+          if-no-files-found: error
 
   ci-e2e-smoke:
     name: E2E Smoke (PR Fast Feedback)

--- a/apps/web/tests/unit/ci/visual-a11y-workflow.test.ts
+++ b/apps/web/tests/unit/ci/visual-a11y-workflow.test.ts
@@ -62,4 +62,15 @@ describe('CI accessibility and visual gate contracts (JOV-4060)', () => {
     expect(visualJob).toContain('- name: Cleanup Neon branch');
     expect(visualJob).toContain('if: always()');
   });
+
+  it('preserves authenticated axe diagnostics when Playwright fails', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const authenticatedA11yJob = getJobBlock(workflow, 'ci-a11y-authed');
+
+    expect(authenticatedA11yJob).not.toContain('--reporter=line');
+    expect(authenticatedA11yJob).toContain('path: |');
+    expect(authenticatedA11yJob).toContain('apps/web/playwright-report/');
+    expect(authenticatedA11yJob).toContain('apps/web/test-results/');
+    expect(authenticatedA11yJob).toContain('if-no-files-found: error');
+  });
 });


### PR DESCRIPTION
## Summary

- let authenticated Playwright a11y use the configured CI reporters instead of overriding them with line-only output
- upload both the HTML report and raw test-results diagnostics on failure
- fail closed when a failed run produces neither artifact path
- add a workflow contract regression test

## Root cause

PR #13859 failed authenticated axe, but the workflow passed `--reporter=line`, which overrides `playwright.config.ts` and never creates `apps/web/playwright-report/`. The upload step targeted only that nonexistent directory and used the action default `if-no-files-found: warn`, so the failed check published no diagnostic artifact.

## Verification

- `pnpm --filter web exec vitest run tests/unit/ci/visual-a11y-workflow.test.ts` — 3/3 passed
- `pnpm biome check .github/workflows/ci.yml apps/web/tests/unit/ci/visual-a11y-workflow.test.ts` — passed
- `actionlint .github/workflows/ci.yml` — no new errors (existing repository-wide shellcheck notices remain)
- pre-commit and pre-push hooks passed

## Bug-to-Test

Regression contract added in `apps/web/tests/unit/ci/visual-a11y-workflow.test.ts`.