### PR TITLE
fix(ci): close staging prebuilt deployment handoff

### DIFF
--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -8,7 +8,11 @@ on:
     inputs:
       deployment_url:
         description: Base URL for the deployment to verify.
-        required: true
+        required: false
+        type: string
+      deployment_url_b64:
+        description: Base64-encoded deployment URL for masked cross-job handoff.
+        required: false
         type: string
       commit_sha:
         description: Git commit SHA for the deployment.
@@ -54,6 +58,7 @@ jobs:
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           DEPLOYMENT_URL: ${{ inputs.deployment_url }}
+          DEPLOYMENT_URL_B64: ${{ inputs.deployment_url_b64 }}
           COMMIT_SHA: ${{ inputs.commit_sha }}
           FALLBACK_HEALTH_URL: ${{ inputs.fallback_health_url }}
           WAIT_SECONDS: ${{ inputs.wait_seconds }}
@@ -63,6 +68,9 @@ jobs:
         run: |
           echo "Running canary health check..."
           deployment_url="${DEPLOYMENT_URL}"
+          if [ -z "$deployment_url" ] && [ -n "${DEPLOYMENT_URL_B64:-}" ]; then
+            deployment_url="$(printf '%s' "$DEPLOYMENT_URL_B64" | base64 --decode)"
+          fi
           health_url_fallback="${FALLBACK_HEALTH_URL}"
           resolved_commit_deployment_url="$(python3 - <<'PY'
           import json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1049,15 +1049,30 @@ jobs:
           # targets with the reusable output so a later runner can deploy the
           # prebuilt artifact without the full ~384 MB .next archive.
           test -d apps/web/.next/server/edge
+          # Vercel function traces point at this standalone runtime tree through
+          # apps/web/.next/node_modules. Materialize that path so the prebuilt
+          # upload is closed over every traced dependency on the deploy runner.
+          test -d apps/web/.next/standalone/apps/web/.next/node_modules
+          rm -rf apps/web/.next/node_modules
+          mkdir -p apps/web/.next/node_modules
+          cp -a apps/web/.next/standalone/apps/web/.next/node_modules/. \
+            apps/web/.next/node_modules/
+          find apps/web/.next/node_modules -maxdepth 1 -type d \
+            -name 'import-in-the-middle-*' -print -quit | grep -q .
           tar -czf /tmp/vercel-build-output.tar.gz -C . \
             .vercel/output \
-            apps/web/.next/server/edge
+            apps/web/.next/server/edge \
+            apps/web/.next/node_modules
           tar -tzf /tmp/vercel-build-output.tar.gz \
             apps/web/.next/server/edge >/dev/null
+          tar -tzf /tmp/vercel-build-output.tar.gz \
+            apps/web/.next/node_modules >/dev/null
           echo "vercel_artifact=true" >> "$GITHUB_OUTPUT"
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
           COREPACK_ENABLE_STRICT: 0
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -4607,6 +4622,7 @@ jobs:
       # so no drift warning fires. This is acceptable — the cancelled deploy didn't ship.
       schema_drift: ${{ steps.verify.outcome == 'failure' }}
       deploy_url: ${{ steps.deploy.outputs.deploy_url }}
+      deploy_url_b64: ${{ steps.encode_deploy_url.outputs.deploy_url_b64 }}
     environment:
       name: Staging – jovie
       url: https://staging.jov.ie
@@ -4744,6 +4760,19 @@ jobs:
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
           COREPACK_ENABLE_STRICT: 0
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
+      - name: Materialize traced runtime dependencies
+        if: steps.restore_vercel_build.outputs.restored != 'true'
+        run: |
+          set -euo pipefail
+          test -d apps/web/.next/standalone/apps/web/.next/node_modules
+          rm -rf apps/web/.next/node_modules
+          mkdir -p apps/web/.next/node_modules
+          cp -a apps/web/.next/standalone/apps/web/.next/node_modules/. \
+            apps/web/.next/node_modules/
+          find apps/web/.next/node_modules -maxdepth 1 -type d \
+            -name 'import-in-the-middle-*' -print -quit | grep -q .
       - name: Package build output for provenance attestation
         run: |
           set -euo pipefail
@@ -4807,19 +4836,38 @@ jobs:
           done
         env:
           VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'true'
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          CLERK_PUBLISHABLE_KEY_STAGING: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
-          CLERK_SECRET_KEY_STAGING: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
 
       - name: Wait for staging deployment readiness
         timeout-minutes: 9
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deploy_url }}
         run: |
-          ./node_modules/.bin/vercel inspect "${{ steps.deploy.outputs.deploy_url }}" \
+          ./node_modules/.bin/vercel inspect "$DEPLOYMENT_URL" \
             --wait \
             --timeout 8m \
             --token "$VERCEL_TOKEN" \
             --scope "$VERCEL_ORG_ID"
+          deployment_json="$(./node_modules/.bin/vercel inspect "$DEPLOYMENT_URL" \
+            --format=json \
+            --token "$VERCEL_TOKEN" \
+            --scope "$VERCEL_ORG_ID")"
+          if ! jq -e '((.readyState // .state // .status // "") | ascii_upcase) == "READY"' \
+            <<<"$deployment_json" >/dev/null; then
+            echo "::error::Vercel inspect returned before the staging deployment reached READY."
+            jq -r '"Current deployment state: \(.readyState // .state // .status // "unknown")"' \
+              <<<"$deployment_json"
+            exit 1
+          fi
+
+      - name: Encode deployment URL for downstream jobs
+        id: encode_deploy_url
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deploy_url }}
+        run: |
+          printf 'deploy_url_b64=%s\n' "$(printf '%s' "$DEPLOYMENT_URL" | base64 | tr -d '\n')" \
+            >> "$GITHUB_OUTPUT"
 
   canary-health-gate:
     name: Canary Health Gate (staging)
@@ -4834,7 +4882,7 @@ jobs:
       # shared staging alias. Merge-queue traffic can retarget staging.jov.ie
       # while this gate is still retrying, which produces false negatives even
       # when the freshly deployed preview is healthy.
-      deployment_url: ${{ needs.deploy-staging.outputs.deploy_url }}
+      deployment_url_b64: ${{ needs.deploy-staging.outputs.deploy_url_b64 }}
       commit_sha: ${{ github.sha }}
       fallback_health_url: /api/health
     secrets:
@@ -4856,14 +4904,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-node-pnpm
       - name: Alias verified deployment
-        run: |
-          ./node_modules/.bin/vercel alias set "${{ needs.deploy-staging.outputs.deploy_url }}" staging.jov.ie \
-            --token "$VERCEL_TOKEN" \
-            --scope "$VERCEL_ORG_ID"
         env:
+          DEPLOYMENT_URL_B64: ${{ needs.deploy-staging.outputs.deploy_url_b64 }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          deployment_url="$(printf '%s' "$DEPLOYMENT_URL_B64" | base64 --decode)"
+          test -n "$deployment_url"
+          ./node_modules/.bin/vercel alias set "$deployment_url" staging.jov.ie \
+            --token "$VERCEL_TOKEN" \
+            --scope "$VERCEL_ORG_ID"
 
   promote-production:
     name: Promote to Production

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -7,6 +7,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY_SCRIPT = REPO_ROOT / ".github/scripts/vercel-prebuilt-deploy.sh"
 CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
+CANARY_WORKFLOW = REPO_ROOT / ".github/workflows/canary-health-gate.yml"
 
 
 def test_timed_out_prebuilt_uploads_fall_back_to_source(tmp_path: Path) -> None:
@@ -181,3 +182,83 @@ def test_staging_job_budget_contains_deploy_and_readiness_steps() -> None:
     assert int(job_timeout.group(1)) >= (
         int(deploy_timeout.group(1)) + int(readiness_timeout.group(1)) + 5
     )
+
+
+def test_reusable_vercel_artifact_contains_traced_runtime_dependencies() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    producer = workflow[
+        workflow.index("- name: Vercel build (deploy artifact)") : workflow.index(
+            "- name: Upload vercel build artifact"
+        )
+    ]
+
+    assert "apps/web/.next/standalone/apps/web/.next/node_modules" in producer
+    assert "cp -a" in producer
+    assert "apps/web/.next/node_modules" in producer
+    assert "import-in-the-middle-*" in producer
+
+    fallback = workflow[
+        workflow.index("- name: Build (preview target for staging verification)") : workflow.index(
+            "- name: Package build output for provenance attestation"
+        )
+    ]
+    assert "- name: Materialize traced runtime dependencies" in fallback
+    assert "apps/web/.next/standalone/apps/web/.next/node_modules" in fallback
+
+
+def test_staging_clerk_secrets_are_exposed_to_vercel_builds() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    expected_publishable = (
+        "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "
+        "${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}"
+    )
+    expected_secret = "CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_STAGING }}"
+
+    producer = workflow[
+        workflow.index("- name: Vercel build (deploy artifact)") : workflow.index(
+            "- name: Upload vercel build artifact"
+        )
+    ]
+    staging = workflow[
+        workflow.index("  deploy-staging:") : workflow.index(
+            "  canary-health-gate:"
+        )
+    ]
+    assert expected_publishable in producer
+    assert expected_secret in producer
+    assert staging.count(expected_publishable) >= 2
+    assert staging.count(expected_secret) >= 2
+
+
+def test_masked_deployment_url_is_encoded_across_job_boundary() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    canary_workflow = CANARY_WORKFLOW.read_text()
+    staging_block = workflow[
+        workflow.index("  deploy-staging:") : workflow.index(
+            "  canary-health-gate:"
+        )
+    ]
+    downstream = workflow[
+        workflow.index("  canary-health-gate:") : workflow.index(
+            "  promote-production:"
+        )
+    ]
+
+    assert "deploy_url_b64: ${{ steps.encode_deploy_url.outputs.deploy_url_b64 }}" in staging_block
+    assert "deployment_url_b64: ${{ needs.deploy-staging.outputs.deploy_url_b64 }}" in downstream
+    assert "base64 --decode" in downstream
+    assert "DEPLOYMENT_URL_B64: ${{ inputs.deployment_url_b64 }}" in canary_workflow
+    assert "base64 --decode" in canary_workflow
+
+
+def test_readiness_gate_checks_ready_state_after_vercel_wait() -> None:
+    workflow = CI_WORKFLOW.read_text()
+    readiness = workflow[
+        workflow.index("- name: Wait for staging deployment readiness") : workflow.index(
+            "- name: Encode deployment URL for downstream jobs"
+        )
+    ]
+
+    assert "--wait" in readiness
+    assert "--format=json" in readiness
+    assert 'ascii_upcase) == "READY"' in readiness


### PR DESCRIPTION
## Summary
- expose the existing synced staging Clerk secrets to Vercel artifact and fallback builds
- package traced standalone runtime dependencies required by prebuilt uploads
- encode the masked deployment URL across jobs and verify READY before canary/alias

## Verification
- `python3 -m pytest scripts/tests/test_vercel_prebuilt_deploy.py -q` (9 passed)
- `SHELLCHECK_OPTS=... actionlint .github/workflows/ci.yml .github/workflows/canary-health-gate.yml`
- `git diff --check`

## Bug-to-test
Bug-to-test: waived — workflow behavior is covered by the focused Python structural regression suite; the JS/TS suffix gate does not recognize it.