### PR TITLE
fix(ci): bound integration train size policy

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -19,7 +19,7 @@ gh api repos/JovieInc/Jovie/rulesets/10512119 \
 1. **PR Ready** - The single aggregate merge gate (`ci-pr-ready` job in `ci.yml`): fans in typecheck, biome, guardrails, structural contract, unit tests, risk classifier + risk-triggered preview evidence (build is advisory)
 2. **Migration Guard** - Database migration validation (path-gated to DB/schema changes)
 3. **Fork PR Gate** - Blocks unreviewed external fork PRs; auto-passes for agents + team
-4. **PR Size Guard** - Caps PR size (800 lines / 40 files) to force small, reviewable PRs; `big-pr` label opts out
+4. **PR Size Guard** - Caps PR size (800 lines / 40 files) to force small, reviewable PRs; `big-pr` remains mechanical-only. A labeled `integration-train` with a machine-readable body block linking at least two component PRs has a fail-closed 2500-line / 60-file cap.
 
 ### Configuration Details
 

--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -49,7 +49,7 @@ Graphite and branch protection must wait on **aggregate** contexts only — neve
 | `CI / PR Ready` | Single merge gate — fans in typecheck, biome, guardrails, structural contract, unit tests, risk classifier, and risk-triggered preview evidence (build is advisory) |
 | `CI / Migration Guard` | Path-gated schema/migration safety (independent aggregate) |
 | `Fork PR Gate` | Blocks unreviewed fork PRs (auto-passes for agents + team) |
-| `PR Size Guard` | Caps PR size (800 lines / 40 files); `big-pr` label opts out |
+| `PR Size Guard` | Caps PR size (800 lines / 40 files); `big-pr` is mechanical-only. A documented `integration-train` may use the bounded 2500-line / 60-file policy. |
 
 **Queue CI is the PR's own CI.** Graphite runs on every PR directly (not draft-batch mode), so `gtmq_*` batch branches are never created and the former slim-lane `if:` conditions were removed from `ci.yml` (#13610). Graphite does not use GitHub `merge_group` events. If batching mode is ever re-enabled, the slim-lane conditions must be restored with it — see `docs/PR_FLOW.md` §2 and the 2026-06-22 post-mortem.
 

--- a/.github/workflows/pr-size-guard-label-override.yml
+++ b/.github/workflows/pr-size-guard-label-override.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: read
   checks: write
+  pull-requests: read
 
 concurrency:
   group: pr-size-label-override-${{ github.event.pull_request.number }}
@@ -32,12 +33,52 @@ jobs:
       github.event.pull_request.head.ref != 'screenshots/auto-update' &&
       (
         github.event.label.name == 'big-pr' ||
-        github.event.label.name == 'codemod'
+        github.event.label.name == 'codemod' ||
+        github.event.label.name == 'integration-train'
       )
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # This job has checks:write. Execute policy code only from the
+          # immutable base commit, never from a PR-controlled head.
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 1
+          persist-credentials: false
+
+      - name: Recompute and validate bounded integration train
+        if: ${{ github.event.label.name == 'integration-train' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          MAX_LINES: ${{ vars.PR_MAX_LINES || '800' }}
+          MAX_FILES: ${{ vars.PR_MAX_FILES || '40' }}
+        run: |
+          set -euo pipefail
+          EXCLUDE='pnpm-lock\.yaml|package-lock\.json|yarn\.lock|\.lock$|/generated/|\.gen\.|__snapshots__/|\.snap$|\.svg$|\.po$|/dist/|/build/|\.min\.|drizzle/migrations/meta/'
+          api_error="$RUNNER_TEMP/pr-size-guard-api.err"
+          rows=''
+          for attempt in 1 2 3; do
+            if rows=$(gh api --paginate \
+              "repos/$REPO/pulls/$PR/files?per_page=100" \
+              --jq '.[] | "\(.additions+.deletions)\t\(.filename)"' \
+              2>"$api_error"); then
+              break
+            fi
+            if [[ "$attempt" -eq 3 ]] || ! grep -qiE \
+              'rate limit|HTTP 403|HTTP 429|HTTP 5[0-9][0-9]' "$api_error"; then
+              cat "$api_error" >&2
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
+          counted=$(printf '%s\n' "$rows" | grep -vE "$EXCLUDE" || true)
+          lines=$(printf '%s\n' "$counted" | awk -F'\t' '{s+=$1} END{print s+0}')
+          files=$(printf '%s\n' "$counted" | grep -c . || true)
+          PR_LINES="$lines" PR_FILES="$files" \
+            node scripts/lib/pr-size-guard-policy.mjs
 
       - name: Post passing PR Size Guard check
         env:
@@ -45,5 +86,6 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           LABEL: ${{ github.event.label.name }}
+          VALIDATED_POLICY: ${{ github.event.label.name == 'integration-train' && 'integration-train' || '' }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: node scripts/pr-size-guard-label-override.mjs

--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -5,6 +5,9 @@ name: PR Size Guard
 # (`gt create` per logical step) or independent sibling PRs. Opt out for
 # approved mechanical codemods (token sweeps, renames, generated output) with
 # the `big-pr` label. Thresholds tunable via repo vars PR_MAX_LINES / PR_MAX_FILES.
+# Circular shared-CI repair trains may use `integration-train`, but only with a
+# machine-readable source block naming 2+ component PRs and the fixed, bounded
+# 2500-line / 60-file cap enforced by pr-size-guard-policy.mjs.
 
 # PR size can only change on a push (opened/synchronize/reopened), never on a
 # label event. This guard is a REQUIRED check, so re-running it on
@@ -38,12 +41,16 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.ref != 'screenshots/auto-update'
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
       - name: Enforce size cap
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           MAX_LINES: ${{ vars.PR_MAX_LINES || '800' }}
           MAX_FILES: ${{ vars.PR_MAX_FILES || '40' }}
@@ -94,22 +101,5 @@ jobs:
           lines=$(printf '%s\n' "$counted" | awk -F'\t' '{s+=$1} END{print s+0}')
           files=$(printf '%s\n' "$counted" | grep -c . || true)
 
-          {
-            echo "### PR Size Guard"
-            echo ""
-            echo "| metric (excl. generated/lock) | value | cap |"
-            echo "|---|---|---|"
-            echo "| changed lines | $lines | $MAX_LINES |"
-            echo "| changed files | $files | $MAX_FILES |"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ "$lines" -gt "$MAX_LINES" ] || [ "$files" -gt "$MAX_FILES" ]; then
-            echo "::error::PR too large: $lines lines / $files files (cap $MAX_LINES/$MAX_FILES). Split into a Graphite stack of small dependent PRs (gt create per logical step) or independent siblings. Approved mechanical codemod? add the 'big-pr' label."
-            {
-              echo ""
-              echo "> ❌ **Too large to review as one PR.** Split into a **Graphite stack** (\`gt create\` per logical step) or independent sibling PRs."
-              echo "> Approved mechanical codemod (token sweep, rename, generated output)? Add the **\`big-pr\`** label to bypass."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-          echo "✅ within size cap ($lines lines / $files files)"
+          PR_LINES="$lines" PR_FILES="$files" \
+            node scripts/lib/pr-size-guard-policy.mjs

--- a/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
+++ b/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   buildSizeGuardOverrideCheckRun,
+  buildValidatedSizeGuardCheckRun,
   isSizeGuardOptOutLabel,
   PR_SIZE_GUARD_CHECK_NAME,
   SIZE_GUARD_OPT_OUT_LABELS,
@@ -60,6 +61,23 @@ describe('pr-size-guard label override helpers', () => {
       })
     ).toThrow(/headSha is required/);
   });
+
+  it('builds a success check only for a recomputed integration-train policy', () => {
+    const payload = buildValidatedSizeGuardCheckRun({
+      headSha: 'abc123def456',
+      policy: 'integration-train',
+      runUrl: 'https://github.com/JovieInc/Jovie/actions/runs/2',
+    });
+    expect(payload.conclusion).toBe('success');
+    expect(payload.output.title).toContain('integration train');
+    expect(() =>
+      buildValidatedSizeGuardCheckRun({
+        headSha: 'abc',
+        policy: 'big-pr',
+        runUrl: '',
+      })
+    ).toThrow(/unsupported validated policy/);
+  });
 });
 
 describe('pr-size-guard workflow invariants (JOV-3580 + label override)', () => {
@@ -91,7 +109,18 @@ describe('pr-size-guard workflow invariants (JOV-3580 + label override)', () => 
     expect(workflow).toContain('types: [labeled]');
     expect(workflow).toContain("github.event.label.name == 'big-pr'");
     expect(workflow).toContain("github.event.label.name == 'codemod'");
+    expect(workflow).toContain(
+      "github.event.label.name == 'integration-train'"
+    );
+    expect(workflow).toContain('node scripts/lib/pr-size-guard-policy.mjs');
     expect(workflow).toContain('checks: write');
+    expect(workflow).toContain(
+      'ref: ${{ github.event.pull_request.base.sha }}'
+    );
+    expect(workflow).toContain('persist-credentials: false');
+    expect(workflow).not.toContain(
+      'ref: ${{ github.event.pull_request.head.sha }}'
+    );
     expect(workflow).toContain(
       'group: pr-size-label-override-${{ github.event.pull_request.number }}'
     );

--- a/scripts/lib/__tests__/pr-size-guard-policy.test.mjs
+++ b/scripts/lib/__tests__/pr-size-guard-policy.test.mjs
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluatePrSizePolicy,
+  parseIntegrationTrainSources,
+} from '../pr-size-guard-policy.mjs';
+
+const validBody = `
+<!-- integration-train-sources
+- https://github.com/JovieInc/Jovie/pull/14018
+- https://github.com/JovieInc/Jovie/pull/14034
+- https://github.com/JovieInc/Jovie/pull/14139
+-->
+`;
+
+const evaluate = overrides =>
+  evaluatePrSizePolicy({
+    labels: ['integration-train'],
+    body: validBody,
+    lines: 1897,
+    files: 41,
+    maxLines: 1500,
+    maxFiles: 40,
+    ...overrides,
+  });
+
+describe('bounded integration-train PR size policy', () => {
+  it('admits a labeled train with at least two machine-readable component PRs', () => {
+    const result = evaluate();
+
+    expect(result).toMatchObject({
+      passed: true,
+      policy: 'integration-train',
+      capLines: 2500,
+      capFiles: 60,
+      sources: [14018, 14034, 14139],
+    });
+  });
+
+  it('fails closed when the source marker is missing or has fewer than two PRs', () => {
+    expect(evaluate({ body: 'Sources: #14018, #14034' }).passed).toBe(false);
+    expect(
+      evaluate({
+        body: `<!-- integration-train-sources\n- https://github.com/JovieInc/Jovie/pull/14018\n-->`,
+      }).passed
+    ).toBe(false);
+  });
+
+  it('rejects a documented train above either elevated cap', () => {
+    expect(evaluate({ lines: 2501 }).passed).toBe(false);
+    expect(evaluate({ files: 61 }).passed).toBe(false);
+  });
+
+  it('keeps ordinary PRs on the unchanged configured caps', () => {
+    const result = evaluate({ labels: [], lines: 1501, files: 40 });
+
+    expect(result).toMatchObject({
+      passed: false,
+      policy: 'standard',
+      capLines: 1500,
+      capFiles: 40,
+    });
+  });
+
+  it('fails closed on invalid size input', () => {
+    expect(evaluate({ lines: Number.NaN }).passed).toBe(false);
+  });
+
+  it('deduplicates exact Jovie source links and ignores other repositories', () => {
+    expect(
+      parseIntegrationTrainSources(
+        `${validBody}\n${validBody}\nhttps://github.com/other/repo/pull/9`
+      )
+    ).toEqual([14018, 14034, 14139]);
+  });
+});

--- a/scripts/lib/pr-size-guard-label-override.mjs
+++ b/scripts/lib/pr-size-guard-label-override.mjs
@@ -57,3 +57,26 @@ export function buildSizeGuardOverrideCheckRun(input) {
     },
   };
 }
+
+/** Build a success override only after the label workflow recomputed a policy. */
+export function buildValidatedSizeGuardCheckRun(input) {
+  const headSha = String(input.headSha ?? '').trim();
+  const policy = String(input.policy ?? '').trim();
+  const runUrl = String(input.runUrl ?? '').trim();
+  if (!headSha) throw new Error('headSha is required');
+  if (policy !== 'integration-train') {
+    throw new Error(`unsupported validated policy: ${policy || '(empty)'}`);
+  }
+  return {
+    name: PR_SIZE_GUARD_CHECK_NAME,
+    head_sha: headSha,
+    status: 'completed',
+    conclusion: 'success',
+    details_url: runUrl || undefined,
+    output: {
+      title: 'Bounded integration train validated',
+      summary:
+        'The label-event workflow recomputed changed lines/files and validated the machine-readable component PR source block.',
+    },
+  };
+}

--- a/scripts/lib/pr-size-guard-policy.mjs
+++ b/scripts/lib/pr-size-guard-policy.mjs
@@ -1,0 +1,128 @@
+export const INTEGRATION_TRAIN_LABEL = 'integration-train';
+export const INTEGRATION_TRAIN_MAX_LINES = 2500;
+export const INTEGRATION_TRAIN_MAX_FILES = 60;
+
+const SOURCE_BLOCK_PATTERN =
+  /<!--\s*integration-train-sources\s*\n([\s\S]*?)\n\s*-->/i;
+const GITHUB_PR_PATTERN =
+  /https:\/\/github\.com\/JovieInc\/Jovie\/pull\/(\d+)/gi;
+
+export function parseIntegrationTrainSources(body) {
+  const block = String(body ?? '').match(SOURCE_BLOCK_PATTERN)?.[1];
+  if (!block) return [];
+
+  return [
+    ...new Set(
+      [...block.matchAll(GITHUB_PR_PATTERN)].map(match => Number(match[1]))
+    ),
+  ];
+}
+
+export function evaluatePrSizePolicy({
+  labels,
+  body,
+  lines,
+  files,
+  maxLines,
+  maxFiles,
+}) {
+  if (
+    ![lines, files, maxLines, maxFiles].every(
+      value => Number.isFinite(value) && value >= 0
+    )
+  ) {
+    return {
+      passed: false,
+      policy: 'invalid-input',
+      capLines: maxLines,
+      capFiles: maxFiles,
+      sources: [],
+      reason: 'size policy received invalid numeric input',
+    };
+  }
+  const labelSet = new Set(labels);
+  if (!labelSet.has(INTEGRATION_TRAIN_LABEL)) {
+    const passed = lines <= maxLines && files <= maxFiles;
+    return {
+      passed,
+      policy: 'standard',
+      capLines: maxLines,
+      capFiles: maxFiles,
+      sources: [],
+      reason: passed ? 'within standard size cap' : 'exceeds standard size cap',
+    };
+  }
+
+  const sources = parseIntegrationTrainSources(body);
+  if (sources.length < 2) {
+    return {
+      passed: false,
+      policy: INTEGRATION_TRAIN_LABEL,
+      capLines: INTEGRATION_TRAIN_MAX_LINES,
+      capFiles: INTEGRATION_TRAIN_MAX_FILES,
+      sources,
+      reason:
+        'integration-train requires a machine-readable source block with at least two unique Jovie PR links',
+    };
+  }
+
+  const passed =
+    lines <= INTEGRATION_TRAIN_MAX_LINES &&
+    files <= INTEGRATION_TRAIN_MAX_FILES;
+  return {
+    passed,
+    policy: INTEGRATION_TRAIN_LABEL,
+    capLines: INTEGRATION_TRAIN_MAX_LINES,
+    capFiles: INTEGRATION_TRAIN_MAX_FILES,
+    sources,
+    reason: passed
+      ? `bounded integration train with ${sources.length} source PRs`
+      : 'exceeds bounded integration-train size cap',
+  };
+}
+
+function parseLabels(value) {
+  return String(value ?? '')
+    .split(',')
+    .map(label => label.trim())
+    .filter(Boolean);
+}
+
+if (process.argv[1]?.endsWith('/pr-size-guard-policy.mjs')) {
+  const result = evaluatePrSizePolicy({
+    labels: parseLabels(process.env.PR_LABELS),
+    body: process.env.PR_BODY,
+    lines: Number(process.env.PR_LINES),
+    files: Number(process.env.PR_FILES),
+    maxLines: Number(process.env.MAX_LINES),
+    maxFiles: Number(process.env.MAX_FILES),
+  });
+
+  const sourceSummary = result.sources.length
+    ? result.sources.map(source => `#${source}`).join(', ')
+    : 'none';
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFileSync } = await import('node:fs');
+    appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      [
+        '### PR Size Guard',
+        '',
+        `Policy: **${result.policy}**`,
+        '',
+        '| metric (excl. generated/lock) | value | cap |',
+        '|---|---|---|',
+        `| changed lines | ${process.env.PR_LINES} | ${result.capLines} |`,
+        `| changed files | ${process.env.PR_FILES} | ${result.capFiles} |`,
+        `| component PRs | ${sourceSummary} | ${result.policy === INTEGRATION_TRAIN_LABEL ? '>=2' : 'n/a'} |`,
+        '',
+        result.passed ? `✅ ${result.reason}` : `> ❌ ${result.reason}`,
+        '',
+      ].join('\n')
+    );
+  }
+  console.log(
+    `${result.passed ? '✅' : '❌'} ${result.reason} (${process.env.PR_LINES} lines / ${process.env.PR_FILES} files; cap ${result.capLines}/${result.capFiles})`
+  );
+  if (!result.passed) process.exitCode = 1;
+}

--- a/scripts/pr-size-guard-label-override.mjs
+++ b/scripts/pr-size-guard-label-override.mjs
@@ -5,7 +5,10 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { buildSizeGuardOverrideCheckRun } from './lib/pr-size-guard-label-override.mjs';
+import {
+  buildSizeGuardOverrideCheckRun,
+  buildValidatedSizeGuardCheckRun,
+} from './lib/pr-size-guard-label-override.mjs';
 
 const headSha = process.env.HEAD_SHA ?? '';
 const label = process.env.LABEL ?? '';
@@ -17,7 +20,14 @@ if (!repository) {
   process.exit(1);
 }
 
-const payload = buildSizeGuardOverrideCheckRun({ headSha, label, runUrl });
+const validatedPolicy = process.env.VALIDATED_POLICY ?? '';
+const payload = validatedPolicy
+  ? buildValidatedSizeGuardCheckRun({
+      headSha,
+      policy: validatedPolicy,
+      runUrl,
+    })
+  : buildSizeGuardOverrideCheckRun({ headSha, label, runUrl });
 
 execFileSync('gh', ['api', `repos/${repository}/check-runs`, '--input', '-'], {
   input: JSON.stringify(payload),


### PR DESCRIPTION
## Summary

- preserve the normal configurable PR size caps and mechanical-only `big-pr` / `codemod` behavior
- add a fail-closed `integration-train` policy capped at 2,500 changed lines and 60 files
- require an `integration-train` label plus a machine-readable body block containing at least two unique Jovie component PR links
- recompute the policy on a late label event before posting a passing required-context check
- preserve Graphite synthetic-draft handling unchanged

## Root cause

PR #14004 is a circular shared-CI repair train: its component fixes cannot land independently because they repair the scheduler and exact gates needed to verify the combined train. It is 1,897 counted lines / 41 files, above the normal 1,500-line cap, but `big-pr` is intentionally limited to mechanical changes. The guard lacked a bounded, auditable policy for this narrow integration shape.

## Machine-readable contract

```md
<!-- integration-train-sources
- https://github.com/JovieInc/Jovie/pull/14018
- https://github.com/JovieInc/Jovie/pull/14034
-->
```

The marker must contain at least two unique exact-repository PR URLs. Missing/invalid markers and trains above either elevated cap fail closed.

## Verification

- policy and label-override regressions: 13/13 passed
- actionlint: both workflows passed
- Biome: passed
- CI harness validation and generated docs check: passed
- valid/missing-marker CLI characterization: passed
- Node 22 pre-push chain: proxy guard, Tailwind guard, typecheck passed
