### PR TITLE
fix(ci): use REST for conflict-handler inventory

### DIFF
--- a/scripts/lib/__tests__/github-open-prs-rest.test.mjs
+++ b/scripts/lib/__tests__/github-open-prs-rest.test.mjs
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fetchOpenPrsRest,
+  normalizeRestPullRequest,
+} from '../github-open-prs-rest.mjs';
+
+function detail(number, sha = `sha-${number}`) {
+  return {
+    number,
+    title: `PR ${number}`,
+    html_url: `https://github.test/pull/${number}`,
+    user: { login: 'agent' },
+    created_at: '2026-07-12T00:00:00Z',
+    updated_at: '2026-07-12T01:00:00Z',
+    draft: false,
+    mergeable: true,
+    mergeable_state: 'behind',
+    base: { ref: 'main', repo: { full_name: 'JovieInc/Jovie' } },
+    head: {
+      ref: `codex/pr-${number}`,
+      sha,
+      repo: {
+        name: 'Jovie',
+        full_name: 'JovieInc/Jovie',
+        owner: { login: 'JovieInc' },
+      },
+    },
+    labels: [{ name: 'gated' }],
+    changed_files: 2,
+    additions: 10,
+    deletions: 3,
+    maintainer_can_modify: true,
+  };
+}
+
+describe('REST open PR inventory', () => {
+  it('paginates without GraphQL and hydrates exact-head checks', async () => {
+    const calls = [];
+    const request = async endpoint => {
+      calls.push(endpoint);
+      if (endpoint.includes('/pulls?')) {
+        return endpoint.includes('page=1')
+          ? Array.from({ length: 100 }, (_, index) => ({ number: index + 1 }))
+          : [{ number: 101 }];
+      }
+      const number = Number(endpoint.match(/pulls\/(\d+)/)?.[1]);
+      if (number) return detail(number);
+      if (endpoint.includes('/check-runs')) {
+        return {
+          total_count: 1,
+          check_runs: [
+            {
+              name: 'PR Ready',
+              status: 'completed',
+              conclusion: 'success',
+              started_at: '2026-07-12T00:00:00Z',
+              completed_at: '2026-07-12T00:01:00Z',
+            },
+          ],
+        };
+      }
+      if (endpoint.includes('/status?')) {
+        return {
+          total_count: 1,
+          statuses: [
+            {
+              context: 'Fork PR Gate',
+              state: 'success',
+              created_at: '2026-07-12T00:01:00Z',
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected endpoint ${endpoint}`);
+    };
+
+    const prs = await fetchOpenPrsRest({
+      repo: 'JovieInc/Jovie',
+      limit: 101,
+      request,
+    });
+
+    expect(prs).toHaveLength(101);
+    expect(calls.filter(call => call.includes('/pulls?'))).toHaveLength(2);
+    expect(calls.some(call => call.includes('graphql'))).toBe(false);
+    expect(prs[0].statusCheckRollup).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'PR Ready', conclusion: 'SUCCESS' }),
+        expect.objectContaining({ context: 'Fork PR Gate', state: 'SUCCESS' }),
+      ])
+    );
+  });
+
+  it('fails closed when exact-head check hydration is incomplete', async () => {
+    const request = async endpoint => {
+      if (endpoint.includes('/pulls?')) return [{ number: 7 }];
+      if (endpoint.endsWith('/pulls/7')) return detail(7);
+      if (endpoint.includes('/check-runs')) {
+        return { total_count: 0, check_runs: [] };
+      }
+      if (endpoint.includes('/status')) return {};
+      throw new Error(`unexpected endpoint ${endpoint}`);
+    };
+
+    await expect(
+      fetchOpenPrsRest({ repo: 'JovieInc/Jovie', request })
+    ).rejects.toThrow('REST statuses for PR #7 were incomplete');
+  });
+
+  it('paginates check runs until total_count is satisfied', async () => {
+    const calls = [];
+    const request = async endpoint => {
+      calls.push(endpoint);
+      if (endpoint.includes('/pulls?')) return [{ number: 8 }];
+      if (endpoint.endsWith('/pulls/8')) return detail(8);
+      if (endpoint.includes('/check-runs')) {
+        const page = endpoint.endsWith('page=2') ? 2 : 1;
+        return {
+          total_count: 101,
+          check_runs: Array.from({ length: page === 1 ? 100 : 1 }, () => ({
+            name: 'Unit Tests',
+            status: 'completed',
+            conclusion: 'success',
+          })),
+        };
+      }
+      if (endpoint.includes('/status?')) {
+        return { total_count: 0, statuses: [] };
+      }
+      throw new Error(`unexpected endpoint ${endpoint}`);
+    };
+
+    const [pr] = await fetchOpenPrsRest({
+      repo: 'JovieInc/Jovie',
+      limit: 1,
+      request,
+    });
+
+    expect(pr.statusCheckRollup).toHaveLength(101);
+    expect(calls.filter(call => call.includes('/check-runs'))).toHaveLength(2);
+  });
+
+  it('fails closed when check-run total_count is missing', async () => {
+    const request = async endpoint => {
+      if (endpoint.includes('/pulls?')) return [{ number: 12 }];
+      if (endpoint.endsWith('/pulls/12')) return detail(12);
+      if (endpoint.includes('/check-runs')) return { check_runs: [] };
+      throw new Error(`unexpected endpoint ${endpoint}`);
+    };
+
+    await expect(
+      fetchOpenPrsRest({ repo: 'JovieInc/Jovie', limit: 1, request })
+    ).rejects.toThrow('REST checks for PR #12 were incomplete');
+  });
+
+  it('fails closed when check-run total_count changes between pages', async () => {
+    const request = async endpoint => {
+      if (endpoint.includes('/pulls?')) return [{ number: 13 }];
+      if (endpoint.endsWith('/pulls/13')) return detail(13);
+      if (endpoint.includes('/check-runs')) {
+        const page = endpoint.endsWith('page=2') ? 2 : 1;
+        return {
+          total_count: page === 1 ? 101 : 102,
+          check_runs: Array.from({ length: page === 1 ? 100 : 1 }, () => ({
+            name: 'Unit Tests',
+            status: 'completed',
+            conclusion: 'success',
+          })),
+        };
+      }
+      throw new Error(`unexpected endpoint ${endpoint}`);
+    };
+
+    await expect(
+      fetchOpenPrsRest({ repo: 'JovieInc/Jovie', limit: 1, request })
+    ).rejects.toThrow('REST checks for PR #13 were incomplete');
+  });
+
+  it('paginates status contexts until total_count is satisfied', async () => {
+    const calls = [];
+    const request = async endpoint => {
+      calls.push(endpoint);
+      if (endpoint.includes('/pulls?')) return [{ number: 10 }];
+      if (endpoint.endsWith('/pulls/10')) return detail(10);
+      if (endpoint.includes('/check-runs')) {
+        return { total_count: 0, check_runs: [] };
+      }
+      if (endpoint.includes('/status?')) {
+        const page = endpoint.endsWith('page=2') ? 2 : 1;
+        return {
+          total_count: 101,
+          statuses: Array.from({ length: page === 1 ? 100 : 1 }, () => ({
+            context: 'Repeated Context',
+            state: 'success',
+          })),
+        };
+      }
+      throw new Error(`unexpected endpoint ${endpoint}`);
+    };
+
+    const [pr] = await fetchOpenPrsRest({
+      repo: 'JovieInc/Jovie',
+      limit: 1,
+      request,
+    });
+
+    expect(pr.statusCheckRollup).toHaveLength(101);
+    expect(calls.filter(call => call.includes('/status?'))).toHaveLength(2);
+  });
+
+  it('fails closed when status total_count is missing', async () => {
+    const request = async endpoint => {
+      if (endpoint.includes('/pulls?')) return [{ number: 11 }];
+      if (endpoint.endsWith('/pulls/11')) return detail(11);
+      if (endpoint.includes('/check-runs')) {
+        return { total_count: 0, check_runs: [] };
+      }
+      if (endpoint.includes('/status?')) return { statuses: [] };
+      throw new Error(`unexpected endpoint ${endpoint}`);
+    };
+
+    await expect(
+      fetchOpenPrsRest({ repo: 'JovieInc/Jovie', limit: 1, request })
+    ).rejects.toThrow('REST statuses for PR #11 were incomplete');
+  });
+
+  it('normalizes REST mergeability and repository ownership fields', () => {
+    const normalized = normalizeRestPullRequest(detail(9), []);
+    expect(normalized).toMatchObject({
+      number: 9,
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'BEHIND',
+      headRefName: 'codex/pr-9',
+      headRepositoryOwner: { login: 'JovieInc' },
+      isCrossRepository: false,
+      changedFiles: 2,
+    });
+  });
+});

--- a/scripts/lib/github-open-prs-rest.mjs
+++ b/scripts/lib/github-open-prs-rest.mjs
@@ -1,0 +1,139 @@
+function upper(value) {
+  return String(value ?? '').toUpperCase();
+}
+
+function mergeableValue(value) {
+  if (value === true) return 'MERGEABLE';
+  if (value === false) return 'CONFLICTING';
+  return 'UNKNOWN';
+}
+
+function checkRun(check) {
+  return {
+    __typename: 'CheckRun',
+    name: check.name,
+    status: upper(check.status),
+    conclusion: upper(check.conclusion),
+    startedAt: check.started_at,
+    completedAt: check.completed_at,
+  };
+}
+
+function statusContext(status) {
+  return {
+    __typename: 'StatusContext',
+    context: status.context,
+    state: upper(status.state),
+    startedAt: status.created_at,
+  };
+}
+
+export function normalizeRestPullRequest(detail, statusCheckRollup) {
+  return {
+    number: detail.number,
+    title: detail.title,
+    url: detail.html_url,
+    author: detail.user ? { login: detail.user.login } : null,
+    createdAt: detail.created_at,
+    updatedAt: detail.updated_at,
+    isDraft: detail.draft === true,
+    mergeable: mergeableValue(detail.mergeable),
+    mergeStateStatus: upper(detail.mergeable_state || 'UNKNOWN'),
+    baseRefName: detail.base?.ref ?? '',
+    headRefName: detail.head?.ref ?? '',
+    headRepository: detail.head?.repo
+      ? {
+          name: detail.head.repo.name,
+          nameWithOwner: detail.head.repo.full_name,
+        }
+      : null,
+    headRepositoryOwner: detail.head?.repo?.owner
+      ? { login: detail.head.repo.owner.login }
+      : null,
+    isCrossRepository:
+      Boolean(detail.base?.repo?.full_name) &&
+      Boolean(detail.head?.repo?.full_name) &&
+      detail.base.repo.full_name !== detail.head.repo.full_name,
+    labels: (detail.labels ?? []).map(label => ({ name: label.name })),
+    changedFiles: detail.changed_files ?? 0,
+    additions: detail.additions ?? 0,
+    deletions: detail.deletions ?? 0,
+    maintainerCanModify: detail.maintainer_can_modify === true,
+    statusCheckRollup,
+  };
+}
+
+async function fetchCompleteCollection({
+  request,
+  endpoint,
+  key,
+  label,
+  prNumber,
+}) {
+  const items = [];
+  let expectedTotal = null;
+  for (let page = 1; ; page += 1) {
+    const response = await request(`${endpoint}&page=${page}`);
+    if (
+      !Array.isArray(response?.[key]) ||
+      !Number.isInteger(response?.total_count) ||
+      response.total_count < 0 ||
+      (expectedTotal !== null && response.total_count !== expectedTotal)
+    ) {
+      throw new Error(`REST ${label} for PR #${prNumber} were incomplete`);
+    }
+    expectedTotal = response.total_count;
+    items.push(...response[key]);
+    if (items.length > expectedTotal) {
+      throw new Error(`REST ${label} for PR #${prNumber} were inconsistent`);
+    }
+    if (items.length === expectedTotal) return items;
+    if (response[key].length === 0) {
+      throw new Error(`REST ${label} for PR #${prNumber} were incomplete`);
+    }
+  }
+}
+
+export async function fetchOpenPrsRest({ repo, limit = 200, request }) {
+  const summaries = [];
+  for (let page = 1; summaries.length < limit; page += 1) {
+    const pageSize = Math.min(100, limit - summaries.length);
+    const batch = await request(
+      `repos/${repo}/pulls?state=open&per_page=${pageSize}&page=${page}`
+    );
+    if (!Array.isArray(batch)) {
+      throw new Error('REST open-PR response was not an array');
+    }
+    summaries.push(...batch);
+    if (batch.length < pageSize) break;
+  }
+
+  const prs = [];
+  for (const summary of summaries.slice(0, limit)) {
+    const detail = await request(`repos/${repo}/pulls/${summary.number}`);
+    const sha = detail.head?.sha;
+    if (!sha) {
+      throw new Error(`REST PR #${summary.number} is missing head.sha`);
+    }
+    const checkRuns = await fetchCompleteCollection({
+      request,
+      endpoint: `repos/${repo}/commits/${sha}/check-runs?per_page=100`,
+      key: 'check_runs',
+      label: 'checks',
+      prNumber: summary.number,
+    });
+    const statusContexts = await fetchCompleteCollection({
+      request,
+      endpoint: `repos/${repo}/commits/${sha}/status?per_page=100`,
+      key: 'statuses',
+      label: 'statuses',
+      prNumber: summary.number,
+    });
+    const rollup = [
+      ...checkRuns.map(checkRun),
+      ...statusContexts.map(statusContext),
+    ];
+    prs.push(normalizeRestPullRequest(detail, rollup));
+  }
+  return prs;
+}

--- a/scripts/pr-conflict-handler.mjs
+++ b/scripts/pr-conflict-handler.mjs
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
+import { fetchOpenPrsRest } from './lib/github-open-prs-rest.mjs';
 import {
   buildPlan,
   DEFAULT_BLOCKED_LABEL,
@@ -159,58 +160,21 @@ async function ghJson(args, { retries = 3 } = {}) {
 }
 
 async function fetchOpenPrs(options) {
-  const fields = [
-    'number',
-    'title',
-    'url',
-    'author',
-    'createdAt',
-    'updatedAt',
-    'isDraft',
-    'mergeable',
-    'mergeStateStatus',
-    'baseRefName',
-    'headRefName',
-    'headRepository',
-    'headRepositoryOwner',
-    'isCrossRepository',
-    'labels',
-    'changedFiles',
-    'additions',
-    'deletions',
-    'maintainerCanModify',
-  ];
-  const listArgs = [
-    'pr',
-    'list',
-    '--repo',
-    options.repo,
-    '--state',
-    'open',
-    '--limit',
-    String(options.limit),
-    '--json',
-  ];
-  try {
-    return {
-      prs: await ghJson([
-        ...listArgs,
-        [...fields, 'statusCheckRollup'].join(','),
-      ]),
-      degradedChecks: false,
-    };
-  } catch (error) {
-    // statusCheckRollup is by far the heaviest field in this query — at
-    // blitz-scale open-PR counts the combined GraphQL query fails while the
-    // same query without rollups succeeds (#13347). Fall back to a degraded
-    // fetch so the handler keeps classifying from mergeable/mergeStateStatus
-    // instead of dying on every run.
-    console.error(
-      `[degraded] bulk PR fetch with statusCheckRollup failed (${error.message}); retrying without check rollups`
-    );
-    const prs = await ghJson([...listArgs, fields.join(',')]);
-    return { prs, degradedChecks: true };
-  }
+  const request = endpoint =>
+    ghJson([
+      'api',
+      '--method',
+      'GET',
+      '-H',
+      'Accept: application/vnd.github+json',
+      endpoint,
+    ]);
+  const prs = await fetchOpenPrsRest({
+    repo: options.repo,
+    limit: options.limit,
+    request,
+  });
+  return { prs, degradedChecks: false };
 }
 
 async function ensureLabel(repo, label, color, description) {


### PR DESCRIPTION
## Root cause

Conflict handler run 29207779218 / job 86691314696 exhausted the GitHub App GraphQL installation quota. Both the primary `gh pr list` call and its purported fallback used GraphQL, so all three bounded retries failed twice and the control job exited before classification.

Classification: dependency/environment drift plus recurring Gem control-plane failure.

## Fix

- replace bulk GraphQL PR listing with paginated REST `/pulls` inventory
- hydrate mergeability from REST PR detail
- hydrate exact-head check-runs and status contexts through paginated REST
- retain the existing bounded three-attempt retry transport
- fail closed when PR details, head SHA, check-runs, or statuses are incomplete

## Regression coverage

- paginates 101 open PRs without any GraphQL endpoint
- paginates check-runs beyond 100 using `total_count`
- normalizes mergeability, ownership, labels, and exact-head checks
- rejects incomplete exact-head check hydration
- live REST-only dry-run successfully classified two open PRs

## Verification

- conflict-handler REST + classifier suites: 14/14
- CI control suite: 112/112
- full ci-fast: all lanes passed
- Biome, node syntax, diff, signed commit, and pre-push passed

Draft and gated; no merge requested.