### PR TITLE
fix(ci): package complete Next server trace root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1050,21 +1050,20 @@ jobs:
             sleep 10
             if [ $i -eq 3 ]; then exit 1; fi
           done
-          # Next/Vercel edge functions keep file-trace references to generated
-          # WASM/font chunks under .next/server/edge. Preserve those 16 MB of
-          # targets with the reusable output so a later runner can deploy the
-          # prebuilt artifact without the full ~384 MB .next archive.
-          test -d apps/web/.next/server/edge
+          # Generated function configs reference chunks across the complete
+          # Next server tree, not only edge assets. Preserve that trace root so
+          # the prebuilt upload is closed over every generated server file.
+          test -d apps/web/.next/server/chunks
           rm -rf apps/web/.next/node_modules
           tar -xzf /tmp/vercel-runtime-node-modules.tar.gz -C apps/web/.next
           find apps/web/.next/node_modules -maxdepth 1 -type d \
             -name 'import-in-the-middle-*' -print -quit | grep -q .
           tar -czf /tmp/vercel-build-output.tar.gz -C . \
             .vercel/output \
-            apps/web/.next/server/edge \
+            apps/web/.next/server \
             apps/web/.next/node_modules
           tar -tzf /tmp/vercel-build-output.tar.gz \
-            apps/web/.next/server/edge >/dev/null
+            apps/web/.next/server/chunks >/dev/null
           tar -tzf /tmp/vercel-build-output.tar.gz \
             apps/web/.next/node_modules >/dev/null
           echo "vercel_artifact=true" >> "$GITHUB_OUTPUT"

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -201,6 +201,9 @@ def test_reusable_vercel_artifact_contains_traced_runtime_dependencies() -> None
     assert snapshot_index < build_index < restore_index
     assert "apps/web/.next/node_modules" in producer
     assert "import-in-the-middle-*" in producer
+    assert "apps/web/.next/server/chunks" in producer
+    assert "apps/web/.next/server \\" in producer
+    assert "apps/web/.next/server/edge \\" not in producer
 
 
 def test_staging_clerk_secrets_are_exposed_to_vercel_builds() -> None:


### PR DESCRIPTION
## Summary
- package the complete generated Next server tree used by Vercel function traces
- validate server chunks are present in the reusable deployment artifact
- retain the already-verified runtime dependency snapshot

## Verification
- `python3 -m pytest scripts/tests/test_vercel_prebuilt_deploy.py -q` (9 passed)
- actionlint on CI and canary workflows
- `git diff --check`

## Bug-to-test
Bug-to-test: waived — covered by the focused Python structural regression suite.