### PR TITLE
feat(pitch): ship personalized investor portal

### DIFF
--- a/apps/web/app/investor-portal/_components/InvestorStickyBar.tsx
+++ b/apps/web/app/investor-portal/_components/InvestorStickyBar.tsx
@@ -50,6 +50,7 @@ export function InvestorStickyBar({
         <div className='flex w-full gap-3 sm:w-auto'>
           {investUrl && (
             <a
+              data-pitch-event='invest_cta_clicked'
               href={investUrl}
               target='_blank'
               rel='noopener noreferrer'
@@ -65,6 +66,7 @@ export function InvestorStickyBar({
           )}
           {bookCallUrl && (
             <a
+              data-pitch-event='meeting_cta_clicked'
               href={bookCallUrl}
               target='_blank'
               rel='noopener noreferrer'

--- a/apps/web/app/investor-portal/events/route.ts
+++ b/apps/web/app/investor-portal/events/route.ts
@@ -1,0 +1,85 @@
+import { and, eq } from 'drizzle-orm';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import { db } from '@/lib/db';
+import { investorLinks, investorViews } from '@/lib/db/schema/investors';
+import { captureError } from '@/lib/error-tracking';
+import {
+  buildInvestorEventPath,
+  INVESTOR_PORTAL_EVENT_NAMES,
+} from '@/lib/investors/portal-events';
+import { apiLimiter } from '@/lib/rate-limit';
+
+export const runtime = 'nodejs';
+
+const eventSchema = z
+  .object({
+    event: z.enum(INVESTOR_PORTAL_EVENT_NAMES),
+    slideId: z
+      .string()
+      .regex(/^[a-z0-9-]+$/u)
+      .max(64)
+      .optional(),
+  })
+  .strict();
+
+function isSameOrigin(request: Request): boolean {
+  const origin = request.headers.get('origin');
+  return origin !== null && origin === new URL(request.url).origin;
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!isSameOrigin(request)) {
+    return new Response(null, { status: 403 });
+  }
+
+  const parsed = eventSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return new Response(null, { status: 400 });
+  }
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get('__investor_token')?.value;
+  if (!token) {
+    return new Response(null, { status: 404 });
+  }
+
+  try {
+    const clientIp =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+      'unknown';
+    const rateLimit = await apiLimiter.limit(
+      `investor-portal:event:${clientIp}`
+    );
+    if (!rateLimit.success) {
+      return new Response(null, { status: 429 });
+    }
+
+    const [link] = await db
+      .select({ id: investorLinks.id, expiresAt: investorLinks.expiresAt })
+      .from(investorLinks)
+      .where(
+        and(eq(investorLinks.token, token), eq(investorLinks.isActive, true))
+      )
+      .limit(1);
+
+    if (!link || (link.expiresAt && link.expiresAt <= new Date())) {
+      return new Response(null, { status: 404 });
+    }
+
+    await db.insert(investorViews).values({
+      investorLinkId: link.id,
+      pagePath: buildInvestorEventPath(parsed.data.event, parsed.data.slideId),
+      userAgent: request.headers.get('user-agent') ?? undefined,
+      referrer: request.headers.get('referer') ?? undefined,
+    });
+  } catch (error) {
+    await captureError('Investor portal event persistence failed', error, {
+      context: 'investor_portal_event',
+      event: parsed.data.event,
+    });
+  }
+
+  // Never expose the token, investor identity, or database identifier.
+  return new Response(null, { status: 204 });
+}

--- a/apps/web/app/investor-portal/page.tsx
+++ b/apps/web/app/investor-portal/page.tsx
@@ -1,25 +1,21 @@
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
+import { InvestorBrief } from '@/components/features/pitch/InvestorBrief';
 import { db } from '@/lib/db';
 import { investorLinks } from '@/lib/db/schema/investors';
+import { captureError } from '@/lib/error-tracking';
 import { NOINDEX_ROBOTS } from '@/lib/seo/noindex-metadata';
 
 export const metadata: Metadata = {
   robots: NOINDEX_ROBOTS,
 };
 
-const DECK_SRC = '/pitch/index.html';
-
 /**
  * Investor portal landing page. Token-gated via the `__investor_token`
- * cookie validated by proxy.ts. Shows a personalized greeting (when the
- * cookie maps to a known investor record) above the canonical HTML deck
- * embedded as a same-origin iframe.
- *
- * The deck source lives at apps/web/public/pitch/ — same artifact used by
- * the public /pitch route. JOV-2357 unified both routes on the canonical
- * deck-stage.js HTML and retired the markdown DeckViewer.
+ * cookie validated by proxy.ts. The cookie lookup remains server-only and is
+ * used solely for the optional greeting; engagement events never receive the
+ * token or investor identity.
  */
 export default async function InvestorLandingPage() {
   const cookieStore = await cookies();
@@ -27,31 +23,27 @@ export default async function InvestorLandingPage() {
 
   let investorName: string | null = null;
   if (token) {
-    const [link] = await db
-      .select({ investorName: investorLinks.investorName })
-      .from(investorLinks)
-      .where(eq(investorLinks.token, token))
-      .limit(1);
-    investorName = link?.investorName ?? null;
+    try {
+      const [link] = await db
+        .select({
+          investorName: investorLinks.investorName,
+          expiresAt: investorLinks.expiresAt,
+        })
+        .from(investorLinks)
+        .where(
+          and(eq(investorLinks.token, token), eq(investorLinks.isActive, true))
+        )
+        .limit(1);
+      investorName =
+        link && (!link.expiresAt || link.expiresAt > new Date())
+          ? link.investorName
+          : null;
+    } catch (error) {
+      await captureError('Investor portal greeting lookup failed', error, {
+        context: 'investor_portal_greeting',
+      });
+    }
   }
 
-  return (
-    <div className='flex flex-col'>
-      {investorName && (
-        <p
-          className='px-4 pt-12 pb-2 text-center text-[length:var(--text-2xl)] font-(--font-weight-medium) text-secondary-token sm:px-6 sm:pt-16 lg:pt-20'
-          style={{ letterSpacing: 'var(--tracking-normal)' }}
-        >
-          Hi {investorName}
-        </p>
-      )}
-      <iframe
-        src={DECK_SRC}
-        title='Jovie Pitch Deck'
-        className='block h-[calc(100svh-var(--marketing-header-height,72px))] w-full border-0'
-        allow='fullscreen'
-        loading='eager'
-      />
-    </div>
-  );
+  return <InvestorBrief embedded investorName={investorName} />;
 }

--- a/apps/web/app/pitch/page.tsx
+++ b/apps/web/app/pitch/page.tsx
@@ -1,114 +1,15 @@
-import { Download, Mail, Maximize2 } from 'lucide-react';
 import type { Metadata } from 'next';
-import Link from 'next/link';
-import { Logo } from '@/components/atoms/Logo';
+import { InvestorBrief } from '@/components/features/pitch/InvestorBrief';
 import { NOINDEX_ROBOTS } from '@/lib/seo/noindex-metadata';
 
 export const revalidate = false;
 
 export const metadata: Metadata = {
-  title: 'Jovie Pitch Deck',
+  title: 'Jovie — Investor Brief',
+  description: 'Jovie investor brief and product walkthrough.',
   robots: NOINDEX_ROBOTS,
 };
 
-const DECK_SRC = '/pitch/index.html';
-const PDF_HREF = '/Jovie-Pitch-Deck.pdf';
-const PDF_FILENAME = 'Jovie-Pitch-Deck.pdf';
-const CONTACT_EMAIL = 't@meetjovie.com';
-
-const CHROME_LINK_CLASS =
-  'group inline-flex items-center gap-1.5 -mx-2 -my-1 px-2 py-1 text-2xs font-medium uppercase tracking-[0.04em] text-white/45 transition-colors duration-subtle hover:text-white focus-visible:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/40 rounded';
-
 export default function PitchPage() {
-  return (
-    <>
-      <h1 className='sr-only'>Jovie Pitch Deck</h1>
-
-      {/* Desktop / tablet: full-bleed deck stage */}
-      <div className='hidden h-svh w-full flex-col bg-black dark:bg-black sm:flex'>
-        <header className='flex h-11 shrink-0 items-center justify-between border-b border-white/[0.04] px-5'>
-          <Link
-            href='/'
-            className='inline-flex items-center opacity-80 transition-opacity duration-subtle hover:opacity-100'
-            aria-label='Jovie Home'
-          >
-            <Logo variant='word' tone='white' size='xs' />
-          </Link>
-          <nav className='flex items-center gap-5'>
-            <a
-              href={DECK_SRC}
-              target='_blank'
-              rel='noreferrer'
-              className={CHROME_LINK_CLASS}
-              aria-label='Open Deck In New Tab For Fullscreen Presentation'
-            >
-              <Maximize2
-                className='size-3 opacity-80 group-hover:opacity-100'
-                aria-hidden='true'
-              />
-              <span>Present</span>
-            </a>
-            <a
-              href={PDF_HREF}
-              download={PDF_FILENAME}
-              className={CHROME_LINK_CLASS}
-              aria-label='Download Pitch Deck As PDF'
-            >
-              <Download
-                className='size-3 opacity-80 group-hover:opacity-100'
-                aria-hidden='true'
-              />
-              <span>PDF</span>
-            </a>
-          </nav>
-        </header>
-
-        <div className='relative min-h-0 flex-1'>
-          <iframe
-            src={DECK_SRC}
-            title='Jovie Pitch Deck'
-            className='block h-full w-full border-0'
-            allow='fullscreen'
-            loading='eager'
-          />
-          <p
-            aria-hidden='true'
-            className='pointer-events-none absolute bottom-3 right-4 font-mono text-3xs tracking-[0.08em] text-white/15'
-          >
-            Jovie · Seed · 2026
-          </p>
-        </div>
-      </div>
-
-      {/* Mobile: minimal fallback */}
-      <div className='flex min-h-svh w-full flex-col items-center justify-center gap-10 bg-black dark:bg-black px-6 py-16 sm:hidden'>
-        <Logo variant='word' tone='white' size='sm' />
-        <div className='flex flex-col items-center gap-3 text-center'>
-          <p className='font-mono text-3xs uppercase tracking-[0.18em] text-white/35'>
-            Pitch Deck
-          </p>
-          <p className='max-w-72 text-balance text-base leading-snug text-white/70'>
-            Designed for desktop. Open on a larger screen or download the PDF.
-          </p>
-        </div>
-        <div className='flex flex-col items-stretch gap-3'>
-          <a
-            href={PDF_HREF}
-            download={PDF_FILENAME}
-            className='inline-flex items-center justify-center gap-2 rounded-full border border-white/15 px-5 py-2.5 text-sm font-medium text-white dark:text-white transition-colors duration-subtle hover:border-white/40 hover:bg-white/[0.04]'
-          >
-            <Download className='size-4' aria-hidden='true' />
-            Download PDF
-          </a>
-          <a
-            href={`mailto:${CONTACT_EMAIL}`}
-            className='inline-flex items-center justify-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-white/60 transition-colors duration-subtle hover:text-white'
-          >
-            <Mail className='size-4' aria-hidden='true' />
-            {CONTACT_EMAIL}
-          </a>
-        </div>
-      </div>
-    </>
-  );
+  return <InvestorBrief />;
 }

--- a/apps/web/components/features/pitch/InvestorBrief.tsx
+++ b/apps/web/components/features/pitch/InvestorBrief.tsx
@@ -1,0 +1,288 @@
+import { Button } from '@jovie/ui';
+import { ArrowRight, Mail } from 'lucide-react';
+import Link from 'next/link';
+import { Logo } from '@/components/atoms/Logo';
+import { fundraisingRegistry } from '@/lib/investors/fundraising-registry';
+import { PitchEngagement } from './PitchEngagement';
+
+const CONTACT_EMAIL = 't@meetjovie.com';
+
+const statusTone = {
+  LIVE: 'text-accent-blue',
+  DEMO: 'text-accent-purple',
+  MANUAL: 'text-accent-pink',
+  PLANNED: 'text-tertiary-token',
+} as const;
+
+interface InvestorBriefProps {
+  readonly embedded?: boolean;
+  readonly investorName?: string | null;
+}
+
+export function InvestorBrief({
+  embedded = false,
+  investorName = null,
+}: InvestorBriefProps) {
+  const registry = fundraisingRegistry;
+  const Root = embedded ? 'div' : 'main';
+
+  return (
+    <Root className='min-h-svh bg-base text-primary-token'>
+      <PitchEngagement />
+
+      <nav className='sticky top-0 z-40 border-b border-subtle bg-base/90 backdrop-blur-md'>
+        <div className='mx-auto flex h-14 max-w-6xl items-center justify-between px-5 sm:px-8'>
+          <Link href='/' aria-label='Jovie Home'>
+            <Logo variant='word' tone='white' size='xs' />
+          </Link>
+          <Button asChild variant='primary' size='sm'>
+            <a
+              href={`mailto:${CONTACT_EMAIL}?subject=Jovie%20Investor%20Meeting`}
+              data-pitch-event='meeting_cta_clicked'
+            >
+              Request A Meeting
+            </a>
+          </Button>
+        </div>
+      </nav>
+
+      <header className='mx-auto flex min-h-svh max-w-6xl flex-col justify-center px-5 py-20 sm:px-8 lg:py-28'>
+        {investorName ? (
+          <p className='mb-3 text-sm text-tertiary-token'>For {investorName}</p>
+        ) : null}
+        <p className='mb-6 text-sm font-medium text-secondary-token'>
+          Investor Brief · {registry.asOf}
+        </p>
+        <h1 className='max-w-5xl text-balance font-display text-5xl font-semibold leading-none tracking-tight sm:text-7xl lg:text-8xl'>
+          {registry.thesis}
+        </h1>
+        <p className='mt-8 max-w-2xl text-balance text-lg leading-relaxed text-secondary-token sm:text-xl'>
+          {registry.companyDefinition} This brief separates what is live, shown,
+          manual, and planned.
+        </p>
+        <div className='mt-10 flex flex-wrap gap-3'>
+          <Button asChild variant='primary'>
+            <a href='#demo'>Watch The Product</a>
+          </Button>
+          <Button asChild variant='secondary'>
+            <a href='#brief'>Read The Brief</a>
+          </Button>
+        </div>
+      </header>
+
+      <section id='demo' className='border-y border-subtle bg-surface-0'>
+        <div className='mx-auto max-w-6xl px-5 py-20 sm:px-8 lg:py-28'>
+          <div className='mb-10 max-w-3xl'>
+            <p className={`mb-3 text-sm font-semibold ${statusTone.DEMO}`}>
+              {registry.demo.status}
+            </p>
+            <h2 className='font-display text-3xl font-semibold tracking-tight sm:text-5xl'>
+              {registry.demo.title}
+            </h2>
+            <p className='mt-4 text-balance text-base leading-relaxed text-secondary-token sm:text-lg'>
+              {registry.demo.description}
+            </p>
+          </div>
+          <div className='overflow-hidden rounded-xl border border-subtle bg-black shadow-card dark:bg-black'>
+            <video
+              aria-label='Jovie Product Walkthrough'
+              className='aspect-video w-full object-contain'
+              controls
+              data-pitch-demo-video
+              playsInline
+              poster={registry.demo.posterPath}
+              preload='metadata'
+              src={registry.demo.videoPath}
+            >
+              <track
+                default
+                kind='captions'
+                label='English'
+                src={registry.demo.captionsPath}
+                srcLang='en'
+              />
+            </video>
+          </div>
+        </div>
+      </section>
+
+      <section
+        id='brief'
+        className='mx-auto max-w-6xl px-5 py-20 sm:px-8 lg:py-28'
+      >
+        <div className='mb-12 flex items-end justify-between gap-6'>
+          <h2 className='font-display text-3xl font-semibold tracking-tight sm:text-5xl'>
+            The Brief
+          </h2>
+          <p className='hidden text-sm text-tertiary-token sm:block'>
+            Seven sentences · About two minutes
+          </p>
+        </div>
+        <ol className='divide-y divide-subtle border-y border-subtle'>
+          {registry.coreSlides.map((slide, index) => (
+            <li
+              className='grid gap-5 py-10 sm:grid-cols-[3rem_1fr] sm:py-14'
+              data-pitch-slide={slide.id}
+              key={slide.id}
+            >
+              <span className='font-mono text-sm text-tertiary-token'>
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <div className='max-w-4xl'>
+                <h3 className='text-balance font-display text-2xl font-semibold leading-tight tracking-tight sm:text-4xl'>
+                  {slide.dominantSentence}
+                </h3>
+                {slide.support.map(line => (
+                  <p
+                    className='mt-4 max-w-2xl text-base leading-relaxed text-secondary-token'
+                    key={line}
+                  >
+                    {line}
+                  </p>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section className='border-y border-subtle bg-surface-0'>
+        <div className='mx-auto max-w-6xl px-5 py-20 sm:px-8 lg:py-28'>
+          <div className='mb-12 max-w-3xl'>
+            <h2 className='font-display text-3xl font-semibold tracking-tight sm:text-5xl'>
+              The Operating Loop, Honestly
+            </h2>
+            <p className='mt-4 text-base leading-relaxed text-secondary-token sm:text-lg'>
+              The workflow is the thesis. The labels are the current evidence
+              boundary.
+            </p>
+          </div>
+          <ol className='grid gap-px overflow-hidden rounded-xl border border-subtle bg-subtle sm:grid-cols-2 lg:grid-cols-4'>
+            {registry.operatingLoop.map((step, index) => (
+              <li className='bg-surface-1 p-6' key={step.id}>
+                <div className='mb-8 flex items-center justify-between'>
+                  <span
+                    className={`text-xs font-semibold ${statusTone[step.status]}`}
+                  >
+                    {step.status}
+                  </span>
+                  <span className='font-mono text-xs text-tertiary-token'>
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                </div>
+                <h3 className='text-lg font-semibold'>{step.title}</h3>
+                <p className='mt-3 text-sm leading-relaxed text-secondary-token'>
+                  {step.description}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section className='mx-auto max-w-4xl px-5 py-20 sm:px-8 lg:py-28'>
+        <details
+          data-pitch-section='founder-letter'
+          className='group border-y border-subtle py-8'
+        >
+          <summary className='flex cursor-pointer list-none items-center justify-between gap-6 text-xl font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/30'>
+            Read The Founder Letter
+            <ArrowRight
+              className='size-5 transition-transform group-open:rotate-90'
+              aria-hidden='true'
+            />
+          </summary>
+          <div className='mt-10 space-y-6 text-base leading-relaxed text-secondary-token sm:text-lg'>
+            {registry.founderLetter.map(paragraph => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+            <p className='font-medium text-primary-token'>
+              — Tim White, Founder
+            </p>
+          </div>
+        </details>
+      </section>
+
+      <section className='border-y border-subtle bg-surface-0'>
+        <div className='mx-auto max-w-4xl px-5 py-20 sm:px-8 lg:py-28'>
+          <h2 className='font-display text-3xl font-semibold tracking-tight sm:text-5xl'>
+            The Questions That Matter
+          </h2>
+          <div className='mt-10 divide-y divide-subtle border-y border-subtle'>
+            {registry.risks.map(risk => (
+              <details className='group py-6' key={risk.id}>
+                <summary className='flex cursor-pointer list-none items-center justify-between gap-6 font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/30'>
+                  {risk.question}
+                  <ArrowRight
+                    className='size-4 shrink-0 transition-transform group-open:rotate-90'
+                    aria-hidden='true'
+                  />
+                </summary>
+                <p className='mt-4 max-w-2xl text-sm leading-relaxed text-secondary-token'>
+                  {risk.answer}
+                </p>
+                {risk.evidenceGap ? (
+                  <p className='mt-3 text-xs text-tertiary-token'>
+                    Evidence needed: {risk.evidenceGap}
+                  </p>
+                ) : null}
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className='mx-auto max-w-4xl px-5 py-20 sm:px-8'>
+        <details
+          className='group border-y border-subtle py-8'
+          data-testid='pitch-appendix'
+        >
+          <summary className='flex cursor-pointer list-none items-center justify-between gap-6 text-xl font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/30'>
+            Open The Appendix
+            <ArrowRight
+              className='size-5 transition-transform group-open:rotate-90'
+              aria-hidden='true'
+            />
+          </summary>
+          <div className='mt-8 divide-y divide-subtle'>
+            {registry.appendix.map(item => (
+              <div className='py-5' key={item.id}>
+                <h3 className='font-semibold'>{item.title}</h3>
+                <p className='mt-2 text-sm leading-relaxed text-secondary-token'>
+                  {item.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </details>
+      </section>
+
+      <footer className='border-t border-subtle'>
+        <div className='mx-auto flex max-w-4xl flex-col items-start justify-between gap-8 px-5 py-20 sm:flex-row sm:items-center sm:px-8'>
+          <div>
+            <h2 className='font-display text-3xl font-semibold tracking-tight'>
+              Continue The Conversation
+            </h2>
+            <p className='mt-3 text-secondary-token'>
+              Ask about the product, the evidence gaps, or the next proof point.
+            </p>
+          </div>
+          <div className='flex flex-wrap gap-3'>
+            <Button asChild variant='primary'>
+              <a
+                href={`mailto:${CONTACT_EMAIL}?subject=Jovie%20Investor%20Meeting`}
+                data-pitch-event='meeting_cta_clicked'
+              >
+                <Mail className='size-4' aria-hidden='true' />
+                Request A Meeting
+              </a>
+            </Button>
+            <Button asChild variant='secondary'>
+              <a href={`mailto:${CONTACT_EMAIL}`}>Email Tim</a>
+            </Button>
+          </div>
+        </div>
+      </footer>
+    </Root>
+  );
+}

--- a/apps/web/components/features/pitch/PitchEngagement.tsx
+++ b/apps/web/components/features/pitch/PitchEngagement.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect } from 'react';
+import { track } from '@/lib/analytics';
+import {
+  type InvestorPortalEventName,
+  isInvestorPortalEventName,
+} from '@/lib/investors/portal-events';
+import { postJsonBeacon } from '@/lib/tracking/json-beacon';
+
+function trackPitchEvent(event: InvestorPortalEventName, slideId?: string) {
+  const properties = slideId
+    ? { surface: 'pitch', slideId }
+    : { surface: 'pitch' };
+  track(event, properties);
+  if (globalThis.location.pathname.startsWith('/investor-portal')) {
+    postJsonBeacon('/investor-portal/events', { event, slideId });
+  }
+}
+
+export function PitchEngagement() {
+  useEffect(() => {
+    const progressedSlides = new Set<string>();
+    trackPitchEvent('portal_opened');
+
+    const onClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const action = target.closest<HTMLElement>('[data-pitch-event]');
+      const eventName = action?.dataset.pitchEvent;
+      if (isInvestorPortalEventName(eventName)) trackPitchEvent(eventName);
+    };
+
+    const onToggle = (event: Event) => {
+      const details = event.target;
+      if (
+        details instanceof HTMLDetailsElement &&
+        details.open &&
+        details.dataset.pitchSection === 'founder-letter'
+      ) {
+        trackPitchEvent('founder_letter_opened');
+      }
+    };
+
+    const video = document.querySelector<HTMLVideoElement>(
+      '[data-pitch-demo-video]'
+    );
+    let demoStarted = false;
+    const onPlay = () => {
+      if (demoStarted) return;
+      demoStarted = true;
+      trackPitchEvent('demo_started');
+    };
+    const onEnded = () => trackPitchEvent('demo_completed');
+    video?.addEventListener('play', onPlay);
+    video?.addEventListener('ended', onEnded);
+
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          const slideId = (entry.target as HTMLElement).dataset.pitchSlide;
+          if (!slideId || progressedSlides.has(slideId)) continue;
+          progressedSlides.add(slideId);
+          trackPitchEvent('deck_progressed', slideId);
+        }
+      },
+      { threshold: 0.6 }
+    );
+    const slides = document.querySelectorAll<HTMLElement>('[data-pitch-slide]');
+    for (const slide of slides) observer.observe(slide);
+
+    document.addEventListener('click', onClick);
+    document.addEventListener('toggle', onToggle, true);
+    return () => {
+      document.removeEventListener('click', onClick);
+      document.removeEventListener('toggle', onToggle, true);
+      video?.removeEventListener('play', onPlay);
+      video?.removeEventListener('ended', onEnded);
+      observer.disconnect();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/lib/auth/investor-portal.ts
+++ b/apps/web/lib/auth/investor-portal.ts
@@ -117,7 +117,7 @@ export async function handleInvestorRequest(
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       maxAge: 60 * 60 * 24 * 30, // 30 days
-      path: '/',
+      path: '/investor-portal',
     });
 
     return res;

--- a/apps/web/lib/investors/portal-events.ts
+++ b/apps/web/lib/investors/portal-events.ts
@@ -1,0 +1,26 @@
+export const INVESTOR_PORTAL_EVENT_NAMES = [
+  'portal_opened',
+  'demo_started',
+  'demo_completed',
+  'deck_progressed',
+  'founder_letter_opened',
+  'meeting_cta_clicked',
+  'invest_cta_clicked',
+] as const;
+
+export type InvestorPortalEventName =
+  (typeof INVESTOR_PORTAL_EVENT_NAMES)[number];
+
+export function isInvestorPortalEventName(
+  value: string | undefined
+): value is InvestorPortalEventName {
+  return INVESTOR_PORTAL_EVENT_NAMES.some(eventName => eventName === value);
+}
+
+export function buildInvestorEventPath(
+  event: InvestorPortalEventName,
+  slideId?: string
+): string {
+  const suffix = slideId ? `/${slideId}` : '';
+  return `/investor-portal#event/${event}${suffix}`;
+}

--- a/apps/web/tests/e2e/pitch.spec.ts
+++ b/apps/web/tests/e2e/pitch.spec.ts
@@ -2,73 +2,48 @@ import { expect, test } from './setup';
 
 test.use({ storageState: { cookies: [], origins: [] } });
 
-test.describe('public /pitch route', () => {
-  test('renders the deck iframe, is NOINDEX', async ({ page }) => {
-    const consoleErrors: string[] = [];
-    page.on('console', msg => {
-      if (msg.type() === 'error') {
-        consoleErrors.push(msg.text());
-      }
-    });
-
+test.describe('public investor brief', () => {
+  test('renders the canonical brief, demo, CTA, and closed appendix', async ({
+    page,
+  }) => {
     const response = await page.goto('/pitch', {
       waitUntil: 'domcontentloaded',
     });
     expect(response?.status()).toBe(200);
 
-    // NOINDEX contract — both the wrapper page AND the deck HTML must be noindex.
     const robotsMeta = await page
       .locator('meta[name="robots"]')
       .getAttribute('content');
-    expect(robotsMeta).toMatch(/noindex/i);
-    expect(robotsMeta).toMatch(/nofollow/i);
+    expect(robotsMeta).toMatch(/noindex/iu);
+    expect(robotsMeta).toMatch(/nofollow/iu);
 
-    // Iframe is present and points at the canonical static deck.
-    const iframeEl = page.locator('iframe[title="Jovie Pitch Deck"]');
-    await expect(iframeEl).toHaveAttribute('src', '/pitch/index.html');
-
-    // Deck content renders inside the iframe.
-    const deck = page.frameLocator('iframe[title="Jovie Pitch Deck"]');
-    await expect(deck.locator('deck-stage')).toBeAttached();
+    await expect(page.getByRole('heading', { level: 1 })).toContainText(
+      'operating layer'
+    );
+    await expect(page.locator('[data-pitch-demo-video]')).toBeVisible();
+    await expect(page.locator('[data-pitch-slide]')).toHaveCount(7);
     await expect(
-      deck.locator('section[data-label="Meet Jovie"]')
-    ).toBeAttached();
+      page.getByRole('link', { name: 'Request A Meeting' }).first()
+    ).toHaveAttribute('href', /mailto:t@meetjovie\.com/iu);
 
-    // PDF download button (one-click static asset, replaces print flow)
-    const pdfLink = page.locator('a[download="Jovie-Pitch-Deck.pdf"]');
-    await expect(pdfLink).toBeVisible();
-    await expect(pdfLink).toHaveAttribute('href', '/Jovie-Pitch-Deck.pdf');
-
-    expect(consoleErrors, consoleErrors.join('\n')).toHaveLength(0);
+    const appendix = page.getByTestId('pitch-appendix');
+    await expect(appendix).not.toHaveAttribute('open', '');
+    await expect(appendix).toContainText('Narrative Boundary');
+    await expect(appendix).toContainText('Risk Register');
+    await expect(appendix).toContainText('Evidence Boundary');
+    await expect(appendix).not.toContainText('Legacy Pitch Deck');
+    await expect(appendix).not.toContainText('Downloadable Deck');
+    await expect(appendix.locator('a')).toHaveCount(0);
   });
 
-  test('canonical deck HTML serves directly with NOINDEX', async ({ page }) => {
-    const response = await page.goto('/pitch/index.html', {
-      waitUntil: 'domcontentloaded',
-    });
-    expect(response?.status()).toBe(200);
-
-    const robotsMeta = await page
-      .locator('meta[name="robots"]')
-      .getAttribute('content');
-    expect(robotsMeta).toMatch(/noindex/i);
-
-    // The custom element registers and the first slide is mounted.
-    await expect(page.locator('deck-stage')).toBeAttached();
-    await expect(
-      page.locator('section[data-label="Meet Jovie"]')
-    ).toBeAttached();
-  });
-
-  test('deck-stage.js is reachable', async ({ request }) => {
-    const res = await request.head('/pitch/deck-stage.js');
-    expect(res.status()).toBe(200);
-  });
-
-  test('static PDF asset serves with 200 (pre-generated once from deck)', async ({
+  test('preserves the legacy deck and PDF as appendix assets', async ({
     request,
   }) => {
-    const res = await request.head('/Jovie-Pitch-Deck.pdf');
-    expect(res.status()).toBe(200);
+    const [deck, pdf] = await Promise.all([
+      request.head('/pitch/index.html'),
+      request.head('/Jovie-Pitch-Deck.pdf'),
+    ]);
+    expect(deck.status()).toBe(200);
+    expect(pdf.status()).toBe(200);
   });
 });

--- a/apps/web/tests/unit/app/investor-portal/events-route.test.ts
+++ b/apps/web/tests/unit/app/investor-portal/events-route.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  cookieGet: vi.fn(),
+  limit: vi.fn(),
+  select: vi.fn(),
+  insert: vi.fn(),
+  captureError: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({ get: mocks.cookieGet })),
+}));
+vi.mock('@/lib/rate-limit', () => ({ apiLimiter: { limit: mocks.limit } }));
+vi.mock('@/lib/error-tracking', () => ({ captureError: mocks.captureError }));
+vi.mock('@/lib/db', () => ({
+  db: { select: mocks.select, insert: mocks.insert },
+}));
+
+import { POST } from '@/app/investor-portal/events/route';
+
+function request(body: unknown, origin = 'https://jov.ie') {
+  return new Request('https://jov.ie/investor-portal/events', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Origin: origin },
+    body: JSON.stringify(body),
+  });
+}
+
+function selectRows(rows: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  mocks.select.mockReturnValue({ from });
+}
+
+describe('investor portal event route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cookieGet.mockReturnValue({ value: 'secret-token' });
+    mocks.limit.mockResolvedValue({ success: true });
+    selectRows([{ id: 'link-1', expiresAt: null }]);
+    mocks.insert.mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it('persists an allowlisted event path without returning identity', async () => {
+    const values = vi.fn().mockResolvedValue(undefined);
+    mocks.insert.mockReturnValue({ values });
+
+    const response = await POST(
+      request({ event: 'deck_progressed', slideId: 'product' })
+    );
+
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe('');
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        investorLinkId: 'link-1',
+        pagePath: '/investor-portal#event/deck_progressed/product',
+      })
+    );
+    expect(JSON.stringify(values.mock.calls)).not.toContain('secret-token');
+  });
+
+  it('rejects cross-origin and non-allowlisted payloads', async () => {
+    expect(
+      (await POST(request({ event: 'portal_opened' }, 'https://evil.test')))
+        .status
+    ).toBe(403);
+    expect((await POST(request({ event: 'arbitrary' }))).status).toBe(400);
+    expect(
+      (await POST(request({ event: 'deck_progressed', slideId: '../token' })))
+        .status
+    ).toBe(400);
+  });
+
+  it('rejects inactive, missing, and expired links', async () => {
+    selectRows([]);
+    expect((await POST(request({ event: 'portal_opened' }))).status).toBe(404);
+
+    selectRows([{ id: 'link-1', expiresAt: new Date('2020-01-01') }]);
+    expect((await POST(request({ event: 'portal_opened' }))).status).toBe(404);
+
+    mocks.cookieGet.mockReturnValue(undefined);
+    expect((await POST(request({ event: 'portal_opened' }))).status).toBe(404);
+  });
+
+  it('fails open after a persistence error without leaking details', async () => {
+    mocks.insert.mockImplementation(() => {
+      throw new Error('database unavailable');
+    });
+    const response = await POST(request({ event: 'demo_completed' }));
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe('');
+    expect(mocks.captureError).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/tests/unit/investors/shared-investor-brief.test.ts
+++ b/apps/web/tests/unit/investors/shared-investor-brief.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const appRoot = join(process.cwd(), 'app');
+
+describe('shared investor brief routing', () => {
+  it('uses the canonical brief for the public and tokenized landings', () => {
+    const publicPage = readFileSync(join(appRoot, 'pitch/page.tsx'), 'utf8');
+    const tokenizedPage = readFileSync(
+      join(appRoot, 'investor-portal/page.tsx'),
+      'utf8'
+    );
+
+    expect(publicPage).toContain('import { InvestorBrief }');
+    expect(publicPage).toContain('<InvestorBrief />');
+    expect(tokenizedPage).toContain('import { InvestorBrief }');
+    expect(tokenizedPage).toContain(
+      '<InvestorBrief embedded investorName={investorName} />'
+    );
+    expect(tokenizedPage).toContain("cookieStore.get('__investor_token')");
+  });
+
+  it('does not pass token or investor identity into engagement tracking', () => {
+    const engagement = readFileSync(
+      join(process.cwd(), 'components/features/pitch/PitchEngagement.tsx'),
+      'utf8'
+    );
+
+    expect(engagement).not.toMatch(/investorName|investor_name|token/u);
+    expect(engagement.indexOf('new Set<string>()')).toBeGreaterThan(
+      engagement.indexOf('useEffect(() =>')
+    );
+  });
+
+  it('attributes both sticky investor actions through document delegation', () => {
+    const stickyBar = readFileSync(
+      join(appRoot, 'investor-portal/_components/InvestorStickyBar.tsx'),
+      'utf8'
+    );
+
+    expect(stickyBar).toContain("data-pitch-event='invest_cta_clicked'");
+    expect(stickyBar).toContain("data-pitch-event='meeting_cta_clicked'");
+  });
+});

--- a/apps/web/tests/unit/lib/auth/investor-portal.test.ts
+++ b/apps/web/tests/unit/lib/auth/investor-portal.test.ts
@@ -109,6 +109,7 @@ describe('investor portal proxy helper', () => {
       'https://jov.ie/investor-portal?utm=x'
     );
     expect(res?.cookies.get('__investor_token')?.value).toBe('token-123');
+    expect(res?.cookies.get('__investor_token')?.path).toBe('/investor-portal');
     expect(mocks.select).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3538 -->

Supersedes closed #14008. GitHub permanently refused reopening that PR after its stacked base branch was deleted and the head was semantically replanted onto landed main. This replacement contains only #14008's child delta on #14007 as landed in `main`; stale root commits and merge commits are excluded.

## Summary

Builds the public and personalized investor portal on the canonical registry from #14007. The shared memo-native brief renders seven one-sentence slides, the existing 92-second demo with captions and poster, a concise founder letter, the labeled `LIVE`/`DEMO`/`MANUAL`/`PLANNED` loop, risk answers, a safe collapsed appendix, and direct meeting actions.

Existing unique investor links keep their proxy, HttpOnly cookie, database, settings, nav, and sticky CTA behavior. A strict same-origin event route attributes only allowlisted engagement through the server-resolved cookie, never exposing investor identity or token to JavaScript and requiring no migration or new auth system.

## Replant verification

- Parent is exact landed main `91e1df80a6ad43d36e781414ff17f34bbeb122e1` (#14007).
- Signed child commit `37a72b6035e10b5d0cae4ff6eae13ea4b35c25b9` preserves the original stable patch ID `39ccc5984c892e8887203b410c3ce3c6c9a4752a` exactly.
- Focused investor portal tests: 3 files, 10/10 passed on Node 22.22.1.
- Web typecheck, Biome, proxy guard, Tailwind guard, and pre-push checks passed.

## Original stack context

1. #14007 — Canonical fundraising registry, landed on `main`.
2. #14008 — Personalized investor portal, closed and superseded by this PR.
3. #14009 — QA proof and documentation; remains untouched pending this replacement landing.

## Linear follow-ups

- **JOV-3739:** closed-loop fundraising story and ingestion automation.
- **JOV-2016:** fundraising department agent.

Generated with OpenAI Codex.
