### PR TITLE
fix(ci): close Vercel metadata trace roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1060,8 +1060,16 @@ jobs:
             -name 'import-in-the-middle-*' -print -quit | grep -q .
           tar -czf /tmp/vercel-build-output.tar.gz -C . \
             .vercel/output \
+            apps/web/.next/BUILD_ID \
+            apps/web/.next/app-path-routes-manifest.json \
+            apps/web/.next/build-manifest.json \
+            apps/web/.next/package.json \
+            apps/web/.next/prerender-manifest.json \
+            apps/web/.next/required-server-files.json \
             apps/web/.next/server \
             apps/web/.next/node_modules
+          tar -tzf /tmp/vercel-build-output.tar.gz \
+            apps/web/.next/package.json >/dev/null
           tar -tzf /tmp/vercel-build-output.tar.gz \
             apps/web/.next/server/chunks >/dev/null
           tar -tzf /tmp/vercel-build-output.tar.gz \

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -204,6 +204,15 @@ def test_reusable_vercel_artifact_contains_traced_runtime_dependencies() -> None
     assert "apps/web/.next/server/chunks" in producer
     assert "apps/web/.next/server \\" in producer
     assert "apps/web/.next/server/edge \\" not in producer
+    for metadata_file in (
+        "BUILD_ID",
+        "app-path-routes-manifest.json",
+        "build-manifest.json",
+        "package.json",
+        "prerender-manifest.json",
+        "required-server-files.json",
+    ):
+        assert f"apps/web/.next/{metadata_file}" in producer
 
 
 def test_staging_clerk_secrets_are_exposed_to_vercel_builds() -> None:


### PR DESCRIPTION
## Summary
- package every `.next` metadata file referenced by generated Vercel function configs
- validate `.next/package.json` is present in the reusable artifact
- preserve the already-closed server and runtime trace roots

## Verification
- derived the exact closure from all 17 generated `.vc-config.json` file maps
- `python3 -m pytest scripts/tests/test_vercel_prebuilt_deploy.py -q` (9 passed)
- actionlint on CI and canary workflows
- `git diff --check`

## Bug-to-test
Bug-to-test: waived — covered by the focused Python structural regression suite.