### PR TITLE
fix(ci): run supported size label overrides

### DIFF
--- a/.github/workflows/pr-size-guard-label-override.yml
+++ b/.github/workflows/pr-size-guard-label-override.yml
@@ -28,16 +28,16 @@ jobs:
     name: PR Size Guard Label Override
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 2
-    if: >-
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      github.event.pull_request.head.ref != 'screenshots/auto-update' &&
-      (
-        github.event.label.name == 'big-pr' ||
-        github.event.label.name == 'codemod' ||
-        github.event.label.name == 'integration-train'
-      )
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: >-
+          github.event.pull_request.user.login != 'dependabot[bot]' &&
+          github.event.pull_request.head.ref != 'screenshots/auto-update' &&
+          (
+            github.event.label.name == 'big-pr' ||
+            github.event.label.name == 'codemod' ||
+            github.event.label.name == 'integration-train'
+          )
         with:
           # This job has checks:write. Execute policy code only from the
           # immutable base commit, never from a PR-controlled head.
@@ -46,7 +46,10 @@ jobs:
           persist-credentials: false
 
       - name: Recompute and validate bounded integration train
-        if: ${{ github.event.label.name == 'integration-train' }}
+        if: >-
+          github.event.pull_request.user.login != 'dependabot[bot]' &&
+          github.event.pull_request.head.ref != 'screenshots/auto-update' &&
+          github.event.label.name == 'integration-train'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -81,6 +84,14 @@ jobs:
             node scripts/lib/pr-size-guard-policy.mjs
 
       - name: Post passing PR Size Guard check
+        if: >-
+          github.event.pull_request.user.login != 'dependabot[bot]' &&
+          github.event.pull_request.head.ref != 'screenshots/auto-update' &&
+          (
+            github.event.label.name == 'big-pr' ||
+            github.event.label.name == 'codemod' ||
+            github.event.label.name == 'integration-train'
+          )
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
+++ b/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
@@ -131,4 +131,30 @@ describe('pr-size-guard workflow invariants (JOV-3580 + label override)', () => 
     expect(workflow).toContain('node scripts/pr-size-guard-label-override.mjs');
     expect(workflow).toContain('JOV-3580');
   });
+
+  it('does not skip the job before supported-label step conditions can run', () => {
+    const workflow = readFileSync(OVERRIDE_WORKFLOW, 'utf8');
+    const jobHeader = workflow.slice(
+      workflow.indexOf('  override:'),
+      workflow.indexOf('    steps:')
+    );
+    const privilegedSteps = workflow.slice(workflow.indexOf('    steps:'));
+
+    // GitHub skipped the entire job for an integration-train labeled event in
+    // runs 29210018465 and 29210083985. Keep the job schedulable, then gate
+    // every privileged step on the exact supported labels instead.
+    expect(jobHeader).not.toMatch(/^\s+if:/m);
+    expect(
+      privilegedSteps.match(/github\.event\.label\.name == 'big-pr'/g)
+    ).toHaveLength(2);
+    expect(
+      privilegedSteps.match(/github\.event\.label\.name == 'codemod'/g)
+    ).toHaveLength(2);
+    expect(
+      privilegedSteps.match(
+        /github\.event\.label\.name == 'integration-train'/g
+      )
+    ).toHaveLength(4);
+    expect(privilegedSteps.match(/^\s+if:/gm)).toHaveLength(3);
+  });
 });


### PR DESCRIPTION
## Summary

- keep the label-override job schedulable for every `labeled` event
- move the exact supported-label, bot, and screenshot predicates onto all three privileged steps
- preserve immutable base-SHA checkout and disabled persisted credentials
- ensure unsupported labels execute zero steps and cannot mint a required check

## Root cause

#14004 received `integration-train` twice on exact head `cbb63eb4`, after the bounded policy had landed on main. Runs [29210018465](https://github.com/JovieInc/Jovie/actions/runs/29210018465) and [29210083985](https://github.com/JovieInc/Jovie/actions/runs/29210083985) both skipped the whole job with zero steps. The compound job-level predicate prevented the supported label from reaching the recomputation step.

This change leaves the job schedulable, then gates checkout, recomputation, and check-run creation independently. Unsupported labels perform no privileged work.

## Verification

- focused policy/override tests: 14/14 passed
- actionlint: passed
- CI harness and generated docs check: passed
- Biome: passed
- Node 22 pre-push proxy, Tailwind, and typecheck guards: passed
