### PR TITLE
fix(ci): budget Vercel archive upload realistically

### DIFF
--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -65,11 +65,11 @@ run_deploy() {
   local mode="$1"
   shift
 
-  # Three bounded prebuilt attempts plus the source fallback must leave a full
-  # minute beneath the workflow step's 10-minute ceiling, including kill grace.
-  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-15}"
+  # One realistically budgeted archive attempt plus the source fallback must
+  # leave a full minute beneath the workflow step's 10-minute ceiling.
+  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-180}"
   if [ "$mode" = "source" ]; then
-    timeout_seconds="${VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS:-475}"
+    timeout_seconds="${VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS:-340}"
   fi
   local kill_grace_seconds="${VERCEL_DEPLOY_KILL_GRACE_SECONDS:-5}"
 
@@ -158,7 +158,7 @@ echo "Plain prebuilt fallback enabled: $can_use_plain_prebuilt"
 deploy_modes=()
 
 if [ "$has_prebuilt_output" = true ]; then
-  deploy_modes+=(tgz split-tgz)
+  deploy_modes+=(tgz)
 fi
 
 if [ "$can_use_plain_prebuilt" = true ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3828,7 +3828,9 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ALLOW_SOURCE_FALLBACK: '1'
-          VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'true'
+          # The closed staging artifact contains more than Vercel's 15k plain
+          # upload limit. Give the archive path the full prebuilt budget.
+          VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'false'
           # Use main secrets - no Neon dependency for fast deployments
           DATABASE_URL_MAIN: ${{ secrets.DATABASE_URL_MAIN }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -39,7 +39,7 @@ echo "https://jovie-timeout-test.vercel.app"
             "VERCEL_TOKEN": "test-token",
             "VERCEL_ORG_ID": "test-org",
             "GITHUB_OUTPUT": str(output_file),
-            "VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK": "true",
+            "VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK": "false",
             "VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS": "1",
             "VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS": "5",
             "VERCEL_DEPLOY_KILL_GRACE_SECONDS": "1",
@@ -57,8 +57,8 @@ echo "https://jovie-timeout-test.vercel.app"
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert result.stderr.count("exceeded its time budget") == 3
-    assert "Deploy succeeded on attempt 4 with source upload" in result.stdout
+    assert result.stderr.count("exceeded its time budget") == 1
+    assert "Deploy succeeded on attempt 2 with source upload" in result.stdout
     assert output_file.read_text().strip() == (
         "deploy_url=https://jovie-timeout-test.vercel.app"
     )
@@ -76,7 +76,7 @@ def test_default_attempt_budgets_leave_one_minute_for_step_overhead() -> None:
     source = default_for("VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS")
     kill_grace = default_for("VERCEL_DEPLOY_KILL_GRACE_SECONDS")
 
-    worst_case_seconds = 3 * (archive + kill_grace) + source + kill_grace
+    worst_case_seconds = archive + kill_grace + source + kill_grace
     assert worst_case_seconds <= 9 * 60
 
 
@@ -111,7 +111,7 @@ sleep 5
             "VERCEL_TOKEN": "test-token",
             "VERCEL_ORG_ID": "test-org",
             "GITHUB_OUTPUT": str(output_file),
-            "VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK": "true",
+            "VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK": "false",
             "VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS": "1",
             "VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS": "1",
             "VERCEL_DEPLOY_KILL_GRACE_SECONDS": "1",


### PR DESCRIPTION
## Summary
- give the closed 185 MB prebuilt archive three minutes instead of 15 seconds
- remove the redundant split-tgz attempt from the active deploy modes
- disable the staging plain upload path that Vercel rejects above 15,000 files
- retain a bounded source fallback within the ten-minute step budget

## Verification
- `python3 -m pytest scripts/tests/test_vercel_prebuilt_deploy.py -q` (9 passed)
- shellcheck + bash syntax check
- actionlint on CI and canary workflows
- `git diff --check`

## Bug-to-test
Bug-to-test: waived — covered by the focused Python behavioral and structural regression suite.