### PR TITLE
fix(ci): repair authenticated-lane seeding + actionable axe output

### DIFF
--- a/apps/web/tests/e2e/a11y.spec.ts
+++ b/apps/web/tests/e2e/a11y.spec.ts
@@ -39,6 +39,7 @@ interface AxeViolationSummary {
   readonly impact: string | null;
   readonly help: string;
   readonly nodes: number;
+  readonly sampleNodes: readonly string[];
 }
 
 function summarizeViolations(
@@ -49,6 +50,14 @@ function summarizeViolations(
     impact: v.impact ?? null,
     help: v.help,
     nodes: v.nodes.length,
+    // First offending selectors + failure text so a red CI log is actionable
+    // without downloading artifacts.
+    sampleNodes: v.nodes
+      .slice(0, 5)
+      .map(
+        n =>
+          `${n.target.join(' ')} — ${(n.failureSummary ?? '').split('\n').slice(0, 2).join(' ')}`
+      ),
   }));
 }
 

--- a/apps/web/tests/e2e/chat-axe.spec.ts
+++ b/apps/web/tests/e2e/chat-axe.spec.ts
@@ -46,6 +46,7 @@ interface AxeViolationSummary {
   readonly impact: string | null;
   readonly help: string;
   readonly nodes: number;
+  readonly sampleNodes: readonly string[];
 }
 
 function summarizeViolations(
@@ -56,6 +57,14 @@ function summarizeViolations(
     impact: violation.impact ?? null,
     help: violation.help,
     nodes: violation.nodes.length,
+    // First offending selectors + failure text so a red CI log is actionable
+    // without downloading artifacts.
+    sampleNodes: violation.nodes
+      .slice(0, 5)
+      .map(
+        node =>
+          `${node.target.join(' ')} — ${(node.failureSummary ?? '').split('\n').slice(0, 2).join(' ')}`
+      ),
   }));
 }
 

--- a/apps/web/tests/seed-test-data.ts
+++ b/apps/web/tests/seed-test-data.ts
@@ -14,6 +14,7 @@ import { Redis } from '@upstash/redis';
 import { and, eq, not } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/neon-http';
 import * as schema from '@/lib/db/schema';
+import { deriveConfirmationStatus } from '@/lib/events/insert';
 import { hashClaimToken } from '@/lib/security/claim-token';
 import {
   E2E_PREBUILT_CLAIM_TOKEN,
@@ -733,6 +734,9 @@ async function seedTourDatesForProfile(
   const values = TEST_TOUR_DATES.map(td => ({
     profileId,
     externalId: td.externalId,
+    // confirmation_status is NOT NULL with no default (trust gate) — derive
+    // it the same way the app's insertEvent helper does.
+    confirmationStatus: deriveConfirmationStatus(td.provider),
     title: td.title,
     venueName: td.venueName,
     city: td.city,


### PR DESCRIPTION
Two tightly-coupled fixes for the failing authenticated CI lanes (diagnosis trail on #13994):

## 1. Seed: tour_dates NOT NULL violation
`tour_dates.confirmation_status` is **NOT NULL with no default** (trust gate; schema says inserts must set it explicitly via `insertEvent`). `tests/seed-test-data.ts` predates that migration and omitted the column — every tour-dates insert on ephemeral Neon branches failed, leaving authenticated lanes (A11y, E2E smoke) running against incompletely seeded data. Now derives per item exactly like the app: `deriveConfirmationStatus(td.provider)`.

## 2. Axe logs: name the failing elements
The A11y lane fails with only `{id: color-contrast, impact: serious, nodes: 7}` and uploads no artifacts — unactionable. Both axe specs now print the first five node target selectors + failure summaries per violation, so the next red run identifies the exact dashboard/chat elements to fix.

## Verification
- Typecheck ✅ across both changes
- Seed value set satisfies every NOT NULL column in `lib/db/schema/tour.ts`
- Logging change is output-only (assertions untouched)

## Cost Impact
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)