### PR TITLE
fix(ci): checkout trusted workflow commit for size override

### DIFF
--- a/.github/workflows/pr-size-guard-label-override.yml
+++ b/.github/workflows/pr-size-guard-label-override.yml
@@ -13,7 +13,7 @@ name: PR Size Guard Label Override
 on:
   # Use the default-branch workflow definition so old PR heads can receive a
   # newly shipped label policy. All executable code remains pinned to the
-  # immutable base SHA below; no PR-head code runs with checks:write.
+  # immutable workflow SHA below; no PR-head code runs with checks:write.
   pull_request_target:
     types: [labeled]
 
@@ -43,8 +43,9 @@ jobs:
           )
         with:
           # This job has checks:write. Execute policy code only from the
-          # immutable base commit, never from a PR-controlled head.
-          ref: ${{ github.event.pull_request.base.sha }}
+          # exact trusted commit that supplied this workflow, never from a
+          # stale PR base or PR-controlled head.
+          ref: ${{ github.workflow_sha }}
           fetch-depth: 1
           persist-credentials: false
 

--- a/scripts/tests/test_pr_size_guard_label_override_workflow.py
+++ b/scripts/tests/test_pr_size_guard_label_override_workflow.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/pr-size-guard-label-override.yml"
+
+
+def test_pull_request_target_checks_out_trusted_workflow_commit() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert "pull_request_target:" in workflow
+    assert "ref: ${{ github.workflow_sha }}" in workflow
+    assert "ref: ${{ github.event.pull_request.base.sha }}" not in workflow
+    assert "ref: ${{ github.event.pull_request.head.sha }}" not in workflow
+    assert "persist-credentials: false" in workflow
+
+
+def test_policy_runs_from_checked_out_trusted_commit() -> None:
+    workflow = WORKFLOW.read_text()
+
+    checkout = workflow.index("uses: actions/checkout@")
+    policy = workflow.index("node scripts/lib/pr-size-guard-policy.mjs")
+    check_writer = workflow.index("node scripts/pr-size-guard-label-override.mjs")
+
+    assert checkout < policy < check_writer


### PR DESCRIPTION
## Root cause

The `pull_request_target` size override checked out `github.event.pull_request.base.sha`. For old PRs, that immutable SHA predates newly shipped policy scripts, so #14004 failed with `MODULE_NOT_FOUND scripts/lib/pr-size-guard-policy.mjs`.

## Fix

Checkout immutable `github.workflow_sha`, the exact trusted default-branch commit that supplied the running workflow. The privileged job still uses `persist-credentials: false` and never executes PR-head code.

## Regression coverage

A structural test requires the trusted workflow SHA, rejects stale PR-base and PR-head refs, requires credential persistence to remain disabled, and verifies checkout precedes both policy execution and check publication.

## Verification

- Node v22.22.1 / pnpm 9.15.4
- `python3 -m pytest -q scripts/tests/test_pr_size_guard_label_override_workflow.py` (2 passed)
- `actionlint .github/workflows/pr-size-guard-label-override.yml`
- `pnpm run ci:harness:check`
- `git diff --check`