### PR TITLE
fix(shell): eliminate skeleton layout-shift bugs, add skeleton-parity guard

### DIFF
--- a/apps/web/app/app/(shell)/calendar/LazyCalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/LazyCalendarPageClient.tsx
@@ -52,7 +52,7 @@ const CALENDAR_GRID_CELL_KEYS = [
   'calendar-cell-35',
 ] as const;
 
-function CalendarRouteSkeleton() {
+export function CalendarRouteSkeleton() {
   return (
     <PageShell
       aria-busy='true'

--- a/apps/web/app/app/(shell)/loading.tsx
+++ b/apps/web/app/app/(shell)/loading.tsx
@@ -1,15 +1,27 @@
 import { headers } from 'next/headers';
+import { AudienceTableLoadingShell } from '@/components/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell';
 import { DashboardSegmentSkeleton } from '@/components/shell/DashboardSegmentSkeleton';
 import { LyricsRouteSkeleton } from '@/components/shell/LyricsRouteSkeleton';
 import { TasksRouteSkeleton } from '@/components/shell/TasksRouteSkeleton';
+import AdminLoading from './admin/loading';
+import { CalendarRouteSkeleton } from './calendar/LazyCalendarPageClient';
 import ChatLoading from './chat/loading';
+import PresenceLoading from './dashboard/presence/loading';
 import { ReleaseTableSkeleton } from './dashboard/releases/loading';
+import InsightsLoading from './insights/loading';
 import { LibraryLoadingState } from './library/LibrarySurface';
+import SettingsLoading from './settings/loading';
 import {
+  isAdminShellRoute,
+  isAudienceShellRoute,
+  isCalendarShellRoute,
   isChatShellRoute,
+  isInsightsShellRoute,
   isLibraryShellRoute,
   isLyricsShellRoute,
+  isPresenceShellRoute,
   isReleasesShellRoute,
+  isSettingsShellRoute,
   isTasksShellRoute,
   resolveAppShellRequestPath,
 } from './shell-route-matches';
@@ -48,6 +60,30 @@ export default async function ShellLoading() {
 
   if (isTasksShellRoute(pathname)) {
     return <TasksRouteSkeleton />;
+  }
+
+  if (isSettingsShellRoute(pathname)) {
+    return <SettingsLoading />;
+  }
+
+  if (isPresenceShellRoute(pathname)) {
+    return <PresenceLoading />;
+  }
+
+  if (isAudienceShellRoute(pathname)) {
+    return <AudienceTableLoadingShell />;
+  }
+
+  if (isCalendarShellRoute(pathname)) {
+    return <CalendarRouteSkeleton />;
+  }
+
+  if (isInsightsShellRoute(pathname)) {
+    return <InsightsLoading />;
+  }
+
+  if (isAdminShellRoute(pathname)) {
+    return <AdminLoading />;
   }
 
   return <DashboardSegmentSkeleton rowKeyPrefix='shell-loading-row' />;

--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -135,8 +135,12 @@ function isDashboardSubRoute(pathname: string | null): boolean {
   return matchesNestedRoute(pathname, APP_ROUTES.LEGACY_DASHBOARD);
 }
 
-function isShellOptimizedSettingsRoute(pathname: string | null): boolean {
+export function isSettingsShellRoute(pathname: string | null): boolean {
   return matchesRoutePrefix(pathname, APP_ROUTES.SETTINGS);
+}
+
+export function isAdminShellRoute(pathname: string | null): boolean {
+  return matchesRoutePrefix(pathname, APP_ROUTES.ADMIN);
 }
 
 function isLightweightShellRoute(pathname: string | null): boolean {
@@ -152,7 +156,7 @@ function isLightweightShellRoute(pathname: string | null): boolean {
     isAudienceShellRoute(pathname) ||
     isCalendarShellRoute(pathname) ||
     isDashboardSubRoute(pathname) ||
-    isShellOptimizedSettingsRoute(pathname)
+    isSettingsShellRoute(pathname)
   );
 }
 

--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.test.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { AnalyticsSidebar, calculateConversionRate } from './AnalyticsSidebar';
+import {
+  AnalyticsSidebar,
+  calculateConversionRate,
+  FunnelStage,
+} from './AnalyticsSidebar';
 
 vi.mock('@/lib/queries', () => ({
   useDashboardAnalyticsQuery: () => ({
@@ -147,5 +151,30 @@ describe('AnalyticsSidebar', () => {
     );
     expect(screen.getByText('Audience funnel')).toBeInTheDocument();
     expect(screen.getByText('Link Clicks')).toBeInTheDocument();
+  });
+});
+
+describe('FunnelStage (regression: #13819 skeleton padding parity)', () => {
+  const stageProps = {
+    label: 'Profile Views',
+    value: 120,
+    rate: null,
+    barPercent: 50,
+    barIndex: 0,
+  };
+
+  it('uses identical outer padding in loading and loaded states', () => {
+    const { container: loadingContainer } = render(
+      <FunnelStage {...stageProps} loading />
+    );
+    const { container: loadedContainer } = render(
+      <FunnelStage {...stageProps} loading={false} />
+    );
+
+    const loadingRow = loadingContainer.firstElementChild;
+    const loadedRow = loadedContainer.firstElementChild;
+
+    expect(loadingRow).toHaveClass('px-3.5', 'py-2.5');
+    expect(loadedRow).toHaveClass('px-3.5', 'py-2.5');
   });
 });

--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
@@ -73,7 +73,7 @@ function formatRankedLabel(label: string): string {
 }
 
 /** Single stage in the vertical funnel waterfall */
-function FunnelStage({
+export function FunnelStage({
   label,
   value,
   rate,
@@ -90,7 +90,7 @@ function FunnelStage({
 }) {
   if (loading) {
     return (
-      <div className='space-y-1.5 px-3 py-2'>
+      <div className='space-y-1.5 px-3.5 py-2.5'>
         <div className='flex items-center justify-between'>
           <LoadingSkeleton height='h-3' width='w-20' rounded='sm' />
           <LoadingSkeleton height='h-3' width='w-12' rounded='sm' />

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SuggestedDspMatches.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SuggestedDspMatches.tsx
@@ -55,21 +55,12 @@ export function SuggestedDspMatches({ profileId }: SuggestedDspMatchesProps) {
   const visible = expanded ? sorted : sorted.slice(0, MAX_VISIBLE);
   const hiddenCount = sorted.length - MAX_VISIBLE;
 
+  // Zero matches is the common resolution for this query, so a skeleton
+  // that renders during `isLoading` and then collapses to `null` produces a
+  // visible flash-then-shift for most users (#13821). Stay collapsed while
+  // loading and only occupy space once we know there is something to show.
   if (isLoading) {
-    return (
-      <div className='mt-3 space-y-1.5'>
-        <SectionHeading count={0} />
-        {[1, 2, 3].map(i => (
-          <div
-            key={i}
-            className='flex items-center gap-2.5 rounded-md px-2 py-1'
-          >
-            <div className='h-4 w-4 rounded skeleton' />
-            <div className='h-3.5 flex-1 rounded skeleton' />
-          </div>
-        ))}
-      </div>
-    );
+    return null;
   }
 
   if (error) {

--- a/apps/web/components/molecules/SettingsLoadingSkeleton.tsx
+++ b/apps/web/components/molecules/SettingsLoadingSkeleton.tsx
@@ -21,7 +21,7 @@ export function SettingsLoadingSkeleton({
   children,
 }: Readonly<SettingsLoadingSkeletonProps>) {
   return (
-    <div className='mx-auto max-w-3xl'>
+    <div className='mx-auto max-w-3xl' data-testid='settings-loading-skeleton'>
       <div className='space-y-6 pb-8'>
         <section className='scroll-mt-4'>
           <div className='mb-4 space-y-2'>

--- a/apps/web/components/shell/TasksRouteSkeleton.tsx
+++ b/apps/web/components/shell/TasksRouteSkeleton.tsx
@@ -18,6 +18,7 @@ export function TasksRouteSkeleton() {
       aria-label='Loading Tasks'
       aria-busy='true'
       aria-live='polite'
+      data-testid='tasks-route-skeleton'
       className='absolute inset-0 overflow-hidden'
       toolbar={
         <PageToolbar

--- a/apps/web/tests/e2e/layout/skeleton-parity.spec.ts
+++ b/apps/web/tests/e2e/layout/skeleton-parity.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * Skeleton -> hydrated shell-chrome parity guard.
+ *
+ * Regression guard for #13819, #13821, #13823 (JOV-4157 UI drift wave) and a
+ * standing guard for every future shell chunk in the One App Shell program
+ * (#12633): the persistent shell chrome (sidebar mount + header) must not
+ * shift position or size while a route's loading skeleton is swapped for its
+ * hydrated content during a client-side navigation. `DashboardShellContent`
+ * (sidebar, header, `AppShellFrame`) stays mounted across in-shell route
+ * changes — only the inner route segment (dispatched by
+ * `apps/web/app/app/(shell)/loading.tsx` / `shell-route-matches.ts`) swaps
+ * between its skeleton and hydrated content. A skeleton whose structure
+ * doesn't match the loaded layout can leak into the persistent frame (e.g.
+ * via a horizontal scrollbar or a reflowed content-container height); this
+ * spec asserts it never does.
+ *
+ * How it works, per route:
+ * 1. Auth via the dev bypass to a creator-ready session and land on
+ *    `/app/dashboard` (the persistent shell mounts here).
+ * 2. Capture the sidebar + header bounding boxes as a baseline.
+ * 3. Click the sidebar nav link for the target route (client-side
+ *    navigation — the same transition a real user triggers).
+ * 4. Capture the sidebar + header bounding boxes immediately after the
+ *    click (the route's skeleton may still be visible at this point).
+ * 5. Wait for the route's hydrated content testid to appear.
+ * 6. Capture the sidebar + header bounding boxes once more and assert all
+ *    three snapshots are equal within 1px.
+ *
+ * Run:
+ *   pnpm run test:web:e2e -- skeleton-parity --project=chromium
+ *
+ * @stability
+ */
+
+import { expect, type Page, test } from '@playwright/test';
+import { APP_ROUTES } from '@/constants/routes';
+
+const BYPASS_URL =
+  '/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/dashboard';
+
+const SIDEBAR_SELECTOR = '[data-testid="app-shell-sidebar-mount"]';
+const HEADER_SELECTOR = '[data-testid="dashboard-header"]';
+
+interface RouteCase {
+  readonly name: string;
+  readonly path: string;
+  /** Hydrated content that replaces the route's loading skeleton. */
+  readonly contentSelector?: string;
+  /** Loading skeleton to wait for disappearance of, when there is no single
+   * stable "hydrated" content testid to assert visible instead. */
+  readonly skeletonSelector?: string;
+}
+
+async function waitForRouteReady(
+  page: Page,
+  routeCase: RouteCase
+): Promise<void> {
+  if (routeCase.contentSelector) {
+    await expect(page.locator(routeCase.contentSelector).first()).toBeVisible({
+      timeout: 45_000,
+    });
+    return;
+  }
+
+  if (routeCase.skeletonSelector) {
+    await expect(page.locator(routeCase.skeletonSelector)).toHaveCount(0, {
+      timeout: 45_000,
+    });
+    return;
+  }
+
+  throw new Error(`Route case ${routeCase.name} has no readiness condition.`);
+}
+
+// Routes reachable via a direct sidebar nav link so the transition is a real
+// client-side navigation (not a hard reload that would instead hit the
+// layout-level cold-boot skeleton). Covers both a pre-existing dedicated
+// skeleton (tasks, audience) and the new dispatch branch added for #13823
+// (settings, previously fell through to the generic DashboardSegmentSkeleton).
+const ROUTE_CASES: readonly RouteCase[] = [
+  {
+    name: 'tasks',
+    path: APP_ROUTES.TASKS,
+    contentSelector:
+      '[data-testid="tasks-workspace"], [data-testid="tasks-upgrade-interstitial"]',
+  },
+  {
+    name: 'audience',
+    path: APP_ROUTES.AUDIENCE,
+    contentSelector: '[data-testid="dashboard-audience-table"]',
+  },
+  {
+    name: 'settings',
+    path: APP_ROUTES.SETTINGS,
+    skeletonSelector: '[data-testid="settings-loading-skeleton"]',
+  },
+];
+
+interface ChromeBoxes {
+  readonly sidebar: { x: number; y: number; width: number; height: number };
+  readonly header: { x: number; y: number; width: number; height: number };
+}
+
+async function captureChromeBoxes(page: Page): Promise<ChromeBoxes> {
+  const sidebar = page.locator(SIDEBAR_SELECTOR);
+  const header = page.locator(HEADER_SELECTOR);
+
+  await expect(sidebar).toBeVisible({ timeout: 30_000 });
+  await expect(header).toBeVisible({ timeout: 30_000 });
+
+  const [sidebarBox, headerBox] = await Promise.all([
+    sidebar.boundingBox(),
+    header.boundingBox(),
+  ]);
+
+  if (!sidebarBox || !headerBox) {
+    throw new Error('Shell chrome bounding boxes were not measurable.');
+  }
+
+  return { sidebar: sidebarBox, header: headerBox };
+}
+
+function assertBoxesMatch(
+  before: ChromeBoxes,
+  after: ChromeBoxes,
+  label: string
+): void {
+  const tolerancePx = 1;
+
+  for (const key of ['sidebar', 'header'] as const) {
+    const beforeBox = before[key];
+    const afterBox = after[key];
+
+    expect(
+      Math.abs(beforeBox.x - afterBox.x),
+      `${label}: ${key} x shifted`
+    ).toBeLessThanOrEqual(tolerancePx);
+    expect(
+      Math.abs(beforeBox.y - afterBox.y),
+      `${label}: ${key} y shifted`
+    ).toBeLessThanOrEqual(tolerancePx);
+    expect(
+      Math.abs(beforeBox.width - afterBox.width),
+      `${label}: ${key} width shifted`
+    ).toBeLessThanOrEqual(tolerancePx);
+    expect(
+      Math.abs(beforeBox.height - afterBox.height),
+      `${label}: ${key} height shifted`
+    ).toBeLessThanOrEqual(tolerancePx);
+  }
+}
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('Skeleton parity across shell routes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto(BYPASS_URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForURL(/\/app\/dashboard/, { timeout: 60_000 });
+    await captureChromeBoxes(page); // shell fully mounted before we start clicking
+  });
+
+  for (const routeCase of ROUTE_CASES) {
+    test(`${routeCase.name} shell chrome does not shift between skeleton and hydrated states`, async ({
+      page,
+    }) => {
+      test.setTimeout(60_000);
+
+      const baselineBoxes = await captureChromeBoxes(page);
+
+      const navLink = page.locator(`a[href="${routeCase.path}"]`).first();
+      await expect(navLink).toBeVisible({ timeout: 30_000 });
+      await navLink.click();
+      await page.waitForURL(url => url.pathname.startsWith(routeCase.path), {
+        timeout: 30_000,
+      });
+
+      // Captured immediately after the client-side transition starts — the
+      // route's loading skeleton may still be visible here.
+      const duringTransitionBoxes = await captureChromeBoxes(page);
+      assertBoxesMatch(
+        baselineBoxes,
+        duringTransitionBoxes,
+        `${routeCase.name} (baseline -> during transition)`
+      );
+
+      await waitForRouteReady(page, routeCase);
+
+      const hydratedBoxes = await captureChromeBoxes(page);
+      assertBoxesMatch(
+        duringTransitionBoxes,
+        hydratedBoxes,
+        `${routeCase.name} (during transition -> hydrated)`
+      );
+    });
+  }
+});

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isAdminShellRoute,
   isAudienceShellRoute,
   isCalendarShellRoute,
   isChatShellRoute,
@@ -8,6 +9,7 @@ import {
   isLyricsShellRoute,
   isPresenceShellRoute,
   isReleasesShellRoute,
+  isSettingsShellRoute,
   isTasksShellRoute,
   isThreadsShellRoute,
   resolveAppShellRequestPath,
@@ -191,6 +193,30 @@ describe('isCalendarShellRoute', () => {
     expect(isCalendarShellRoute(`${APP_ROUTES.CALENDAR}/week/2026-05-15`)).toBe(
       true
     );
+  });
+});
+
+describe('isSettingsShellRoute', () => {
+  it('matches the settings root and nested settings subroutes', () => {
+    expect(isSettingsShellRoute(APP_ROUTES.SETTINGS)).toBe(true);
+    expect(isSettingsShellRoute(APP_ROUTES.SETTINGS_ACCOUNT)).toBe(true);
+  });
+
+  it('returns false for non-settings routes', () => {
+    expect(isSettingsShellRoute(APP_ROUTES.AUDIENCE)).toBe(false);
+    expect(isSettingsShellRoute(null)).toBe(false);
+  });
+});
+
+describe('isAdminShellRoute', () => {
+  it('matches the admin root and nested admin subroutes', () => {
+    expect(isAdminShellRoute(APP_ROUTES.ADMIN)).toBe(true);
+    expect(isAdminShellRoute(`${APP_ROUTES.ADMIN}/activity`)).toBe(true);
+  });
+
+  it('returns false for non-admin routes', () => {
+    expect(isAdminShellRoute(APP_ROUTES.SETTINGS)).toBe(false);
+    expect(isAdminShellRoute(null)).toBe(false);
   });
 });
 

--- a/apps/web/tests/unit/dashboard/SuggestedDspMatches.test.tsx
+++ b/apps/web/tests/unit/dashboard/SuggestedDspMatches.test.tsx
@@ -172,7 +172,12 @@ describe('SuggestedDspMatches', () => {
     ).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders skeleton rows while loading', () => {
+  it('renders nothing while loading (regression: #13821 flash-then-collapse)', () => {
+    // Zero matches is the common resolution, so rendering a skeleton during
+    // `isLoading` that later collapses to `null` shifts sibling sections.
+    // The component must stay collapsed while loading and only occupy space
+    // once resolved with real matches — matching the eventual `null` render
+    // for the empty case exactly, with no intermediate skeleton frame.
     mockUseDspMatchesQuery.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -182,10 +187,8 @@ describe('SuggestedDspMatches', () => {
 
     const { container } = render(<SuggestedDspMatches profileId='profile-1' />);
 
-    expect(screen.getByText('Suggested')).toBeInTheDocument();
-    // Skeleton rows have the skeleton class (at least 2 per row: icon + text)
-    const skeletons = container.querySelectorAll('.skeleton');
-    expect(skeletons.length).toBeGreaterThanOrEqual(2);
+    expect(container.innerHTML).toBe('');
+    expect(screen.queryByText('Suggested')).not.toBeInTheDocument();
   });
 
   it('returns null when no suggestions exist', () => {


### PR DESCRIPTION
## What / Why

Chunk 0.4 of the One App Shell program (#12633): fix three known skeleton/layout-shift bugs and add a Playwright guard so future shell chunks can't regress skeleton parity.

- **Fixes #13819** — `AnalyticsSidebar` `FunnelStage` skeleton used `px-3 py-2` while the loaded row used `px-3.5 py-2.5`, so every funnel row micro-shifted the instant loading resolved. Padding now matches in both branches (`apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx`).
- **Fixes #13821** — `SuggestedDspMatches` rendered a 3-row skeleton while loading, then collapsed to `null` on the common zero-matches result, shifting sibling profile-sidebar sections upward. The component now stays collapsed (`return null`) while loading and only occupies space once resolved with real matches (`apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SuggestedDspMatches.tsx`).
- **Fixes #13823** — the shell-level `loading.tsx` dispatch (`apps/web/app/app/(shell)/loading.tsx` + `shell-route-matches.ts`) fell through to the generic table-shaped `DashboardSegmentSkeleton` for settings, presence, audience, calendar, insights, and admin routes — even though each of those routes already ships a dedicated, correctly-shaped skeleton (form, card-grid, table, calendar-grid). Wired those six routes into the dispatch (mirroring the existing chat/releases/library/lyrics/tasks pattern) so each now uses its matching skeleton instead of a mismatched table skeleton, eliminating pop-in reflow on cross-section nav. Exported `isSettingsShellRoute`/added `isAdminShellRoute` in `shell-route-matches.ts`, and exported the previously-private `CalendarRouteSkeleton`.

## New test

`apps/web/tests/e2e/layout/skeleton-parity.spec.ts` — for `tasks`, `audience`, and `settings` (the three routes reachable via a direct sidebar nav link, so the transition is a real client-side navigation rather than a hard reload hitting the unrelated cold-boot shell skeleton), the spec:
1. Captures the persistent shell chrome (sidebar mount + header) bounding box before the nav.
2. Clicks the sidebar nav link.
3. Captures chrome bounding boxes immediately after the transition starts (route skeleton may still be visible).
4. Waits for the route's hydrated content (or the skeleton to clear, for settings).
5. Captures chrome bounding boxes again.
6. Asserts all snapshots are equal within 1px.

This is a standing guard: it doesn't test the specific #13819/#13821/#13823 symptoms directly (those have colocated unit regression tests below) — it guards the coarser invariant that a mismatched inner-route skeleton never leaks into a shift of the persistent shell frame, for every future shell chunk.

Added `data-testid="tasks-route-skeleton"` to `TasksRouteSkeleton` and `data-testid="settings-loading-skeleton"` to `SettingsLoadingSkeleton` (both previously untestable) to support the spec.

## State enumeration (layout-shift audit)

- `AnalyticsSidebar` `FunnelStage`: loading → loaded — padding now identical, verified in `AnalyticsSidebar.test.tsx`.
- `SuggestedDspMatches`: loading → zero matches (`null`) → matches found (rows) → error. Loading and zero-matches now render the same `null` output, so there is no longer an intermediate skeleton frame to shift away from.
- Shell-level `loading.tsx` dispatch: settings / presence / audience / calendar / insights / admin routes now render their own matching skeleton instead of the generic table skeleton — each already had layout-shift coverage for its own route-level `loading.tsx` (unchanged), this PR only changes *which* skeleton renders during the shell-level cross-section transition, not the app-shell chrome or route sizing itself.

## Verification

```
pnpm --filter @jovie/web run typecheck -- --pretty false   # pass
pnpm biome check <touched files>                            # clean, no fixes needed
pnpm --filter web exec vitest run \
  tests/unit/dashboard/SuggestedDspMatches.test.tsx \
  components/features/dashboard/organisms/AnalyticsSidebar.test.tsx \
  tests/unit/dashboard/AnalyticsSidebar.test.ts \
  tests/unit/app/shell-route-matches.test.ts               # 82/82 pass
```

`skeleton-parity.spec.ts` was written and reviewed against the repo's e2e stability-spec conventions (`presence-page-stability.spec.ts`, `shell-route-persistence.spec.ts`) but has not been run against a live dev server in this session (no local server bootstrap was needed for the unit/typecheck verification above). Recommend running it once via `pnpm run test:web:e2e -- skeleton-parity --project=chromium` before merge to catch any selector drift.

Part of #12633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)