### PR TITLE
feat(shell): instrument route-transition latency + soft INP budget

### DIFF
--- a/apps/web/.lighthouserc.dashboard.pr.json
+++ b/apps/web/.lighthouserc.dashboard.pr.json
@@ -60,6 +60,12 @@
               {
                 "maxNumericValue": 850
               }
+            ],
+            "interaction-to-next-paint": [
+              "warn",
+              {
+                "maxNumericValue": 200
+              }
             ]
           }
         }

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -41,6 +41,7 @@ import { useDashboardShortcuts } from '@/hooks/useDashboardShortcuts';
 import { useGlobalShortcutActions } from '@/hooks/useGlobalShortcutActions';
 import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
 import { useAppFlag } from '@/lib/flags/client';
+import { useRouteTransitionTelemetry } from '@/lib/perf/route-transition';
 import { AuthShell } from './AuthShell';
 import { CommandPalette } from './CommandPalette';
 import { KeyboardShortcutsSheet } from './keyboard-shortcuts-sheet';
@@ -85,6 +86,7 @@ function AuthShellWrapperInner({
 }>) {
   const config = useAuthRouteConfig();
   const pathname = usePathname();
+  useRouteTransitionTelemetry();
   const headerActions = useHeaderActions();
   const isElectron = useIsElectronRuntime();
   const shellChatV1Enabled = useAppFlag('DESIGN_V1');

--- a/apps/web/lib/perf/route-transition.test.ts
+++ b/apps/web/lib/perf/route-transition.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/analytics', () => ({
+  track: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+  },
+}));
+
+import { track } from '@/lib/analytics';
+import {
+  __resetRouteTransitionStateForTests,
+  completeRouteTransition,
+  markRouteTransitionIntent,
+  toRouteId,
+} from '@/lib/perf/route-transition';
+
+async function flushDoubleRaf() {
+  // completeRouteTransition schedules work via two nested rAF calls.
+  await new Promise(resolve => requestAnimationFrame(resolve));
+  await new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+describe('route-transition', () => {
+  beforeEach(() => {
+    __resetRouteTransitionStateForTests();
+    vi.clearAllMocks();
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
+
+  afterEach(() => {
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
+
+  describe('toRouteId', () => {
+    it('keeps static segments as-is', () => {
+      expect(toRouteId('/app/dashboard/releases')).toBe(
+        '/app/dashboard/releases'
+      );
+    });
+
+    it('redacts numeric id segments', () => {
+      expect(toRouteId('/app/library/12345')).toBe('/app/library/:id');
+    });
+
+    it('redacts UUID segments', () => {
+      expect(
+        toRouteId('/app/releases/550e8400-e29b-41d4-a716-446655440000')
+      ).toBe('/app/releases/:id');
+    });
+
+    it('redacts long opaque tokens that contain a digit', () => {
+      expect(toRouteId('/app/chat/cjld2cyuq0000t3rmniod1foy')).toBe(
+        '/app/chat/:id'
+      );
+    });
+
+    it('does not redact ordinary route words', () => {
+      expect(toRouteId('/app/dashboard/notifications')).toBe(
+        '/app/dashboard/notifications'
+      );
+    });
+
+    it('normalizes the root path', () => {
+      expect(toRouteId('/')).toBe('/');
+      expect(toRouteId('')).toBe('/');
+    });
+  });
+
+  describe('markRouteTransitionIntent + completeRouteTransition', () => {
+    it('reports a route_transition measure when the pathname changes', async () => {
+      markRouteTransitionIntent('/app/dashboard/releases');
+      completeRouteTransition('/app/dashboard/audience');
+
+      await flushDoubleRaf();
+
+      expect(track).toHaveBeenCalledWith(
+        'route_transition',
+        expect.objectContaining({
+          fromRoute: '/app/dashboard/releases',
+          toRoute: '/app/dashboard/audience',
+          durationMs: expect.any(Number),
+        })
+      );
+    });
+
+    it('redacts dynamic segments in the reported payload', async () => {
+      markRouteTransitionIntent('/app/library/12345');
+      completeRouteTransition('/app/library/67890');
+
+      await flushDoubleRaf();
+
+      // Same route id after redaction (:id -> :id) means no real route
+      // change occurred, so nothing should be reported.
+      expect(track).not.toHaveBeenCalled();
+    });
+
+    it('does not report when there is no pending intent', async () => {
+      completeRouteTransition('/app/dashboard/releases');
+      await flushDoubleRaf();
+
+      expect(track).not.toHaveBeenCalled();
+    });
+
+    it('does not report a same-route transition (e.g. hash-only nav)', async () => {
+      markRouteTransitionIntent('/app/dashboard/releases');
+      completeRouteTransition('/app/dashboard/releases');
+
+      await flushDoubleRaf();
+
+      expect(track).not.toHaveBeenCalled();
+    });
+
+    it('clears the pending transition after completing so a stale intent is not reused', async () => {
+      markRouteTransitionIntent('/app/dashboard/releases');
+      completeRouteTransition('/app/dashboard/audience');
+      await flushDoubleRaf();
+
+      vi.mocked(track).mockClear();
+
+      // No new markRouteTransitionIntent call — completing again should be a no-op.
+      completeRouteTransition('/app/dashboard/library');
+      await flushDoubleRaf();
+
+      expect(track).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/lib/perf/route-transition.ts
+++ b/apps/web/lib/perf/route-transition.ts
@@ -1,0 +1,251 @@
+'use client';
+
+// Route-transition latency instrumentation for the authenticated shell.
+//
+// Captures perceived route-transition latency: the time from a nav-intent
+// click on an internal `<a>` link to the next route's first painted frame
+// (double `requestAnimationFrame` after the pathname changes). This is the
+// metric every later One App Shell perf chunk is judged against.
+//
+// Privacy: only route IDs are emitted (dynamic segments like ids/uuids are
+// redacted to `:id`), never raw pathnames with user data, and never query
+// strings (Next's `usePathname()` already excludes the query string).
+
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { track } from '@/lib/analytics';
+import { logger } from '@/lib/utils/logger';
+
+const MEASURE_NAME = 'route_transition';
+const MARK_PREFIX = 'route-transition:intent';
+
+export interface RouteTransitionPayload {
+  readonly fromRoute: string;
+  readonly toRoute: string;
+  readonly durationMs: number;
+}
+
+interface PendingRouteTransition {
+  readonly fromRoute: string;
+  readonly markName: string;
+}
+
+let pendingTransition: PendingRouteTransition | null = null;
+let markSequence = 0;
+
+function canUsePerformanceApi(): boolean {
+  return (
+    typeof performance !== 'undefined' &&
+    typeof performance.mark === 'function' &&
+    typeof performance.measure === 'function'
+  );
+}
+
+/**
+ * Redact dynamic path segments (numeric ids, UUIDs, long opaque tokens) so
+ * the emitted route id never carries user-identifying data.
+ */
+export function toRouteId(pathname: string): string {
+  if (!pathname) {
+    return '/';
+  }
+
+  const segments = pathname.split('/').map(segment => {
+    if (segment.length === 0) {
+      return segment;
+    }
+    return isDynamicSegment(segment) ? ':id' : segment;
+  });
+
+  const routeId = segments.join('/');
+  return routeId.length > 0 ? routeId : '/';
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const NUMERIC_ID_PATTERN = /^\d+$/;
+const OPAQUE_TOKEN_PATTERN = /^[a-zA-Z0-9_-]{16,}$/;
+
+function isDynamicSegment(segment: string): boolean {
+  if (UUID_PATTERN.test(segment)) {
+    return true;
+  }
+  if (NUMERIC_ID_PATTERN.test(segment)) {
+    return true;
+  }
+  // Long opaque alphanumeric tokens (cuid/nanoid/etc). Require at least one
+  // digit so ordinary route words (e.g. "dashboard", "notifications") are
+  // never mistaken for an id.
+  return OPAQUE_TOKEN_PATTERN.test(segment) && /\d/.test(segment);
+}
+
+/**
+ * Mark the start of a route-transition interaction. Call this at nav
+ * intent (e.g. an internal link click) with the CURRENT pathname.
+ */
+export function markRouteTransitionIntent(currentPathname: string): void {
+  if (!canUsePerformanceApi()) {
+    return;
+  }
+
+  markSequence += 1;
+  const markName = `${MARK_PREFIX}:${markSequence}`;
+
+  try {
+    performance.mark(markName);
+  } catch {
+    return;
+  }
+
+  pendingTransition = {
+    fromRoute: toRouteId(currentPathname),
+    markName,
+  };
+}
+
+/**
+ * Complete a pending route transition once the pathname has changed. Waits
+ * two animation frames (the standard "next paint has committed" signal) past
+ * the pathname change before measuring, so the duration reflects perceived
+ * paint latency rather than just the pathname commit.
+ */
+export function completeRouteTransition(nextPathname: string): void {
+  if (!pendingTransition) {
+    return;
+  }
+
+  const toRoute = toRouteId(nextPathname);
+  if (toRoute === pendingTransition.fromRoute) {
+    // Pathname didn't actually change (e.g. hash-only navigation) — keep
+    // waiting for a real route change instead of reporting a zero-length
+    // transition.
+    return;
+  }
+
+  const { fromRoute, markName } = pendingTransition;
+  pendingTransition = null;
+
+  if (!canUsePerformanceApi() || typeof requestAnimationFrame !== 'function') {
+    return;
+  }
+
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      finishMeasurement({ fromRoute, toRoute, markName });
+    });
+  });
+}
+
+function finishMeasurement({
+  fromRoute,
+  toRoute,
+  markName,
+}: {
+  fromRoute: string;
+  toRoute: string;
+  markName: string;
+}): void {
+  if (!canUsePerformanceApi()) {
+    return;
+  }
+
+  try {
+    const measure = performance.measure(
+      `${MEASURE_NAME}:${fromRoute}->${toRoute}`,
+      markName
+    );
+    reportRouteTransition({
+      fromRoute,
+      toRoute,
+      durationMs: Math.round(measure.duration),
+    });
+  } catch {
+    // The mark may already have been cleared (e.g. StrictMode double-invoke
+    // or an unrelated performance buffer reset). Never throw from telemetry.
+  } finally {
+    try {
+      performance.clearMarks(markName);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function reportRouteTransition(payload: RouteTransitionPayload): void {
+  logger.debug(`[${MEASURE_NAME}]`, payload);
+  track(MEASURE_NAME, {
+    fromRoute: payload.fromRoute,
+    toRoute: payload.toRoute,
+    durationMs: payload.durationMs,
+  });
+}
+
+function isInternalNavClick(event: MouseEvent): boolean {
+  if (event.defaultPrevented || event.button !== 0) {
+    return false;
+  }
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+    return false;
+  }
+
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  const anchor = target.closest('a[href]');
+  if (!(anchor instanceof HTMLAnchorElement)) {
+    return false;
+  }
+  if (anchor.target === '_blank' || anchor.hasAttribute('download')) {
+    return false;
+  }
+
+  const href = anchor.getAttribute('href');
+  if (!href || href.startsWith('#') || href.startsWith('mailto:')) {
+    return false;
+  }
+
+  // Only same-origin, app-relative links count as an in-shell route
+  // transition. External/absolute links leave the app entirely.
+  return href.startsWith('/');
+}
+
+/**
+ * Mount once inside the authenticated shell root. Listens for internal link
+ * clicks (nav intent) and measures perceived latency to the next route's
+ * committed paint whenever `usePathname()` changes.
+ *
+ * Zero overhead when idle: a single delegated click listener plus one
+ * `useEffect` comparing the previous pathname; no layout reads.
+ */
+export function useRouteTransitionTelemetry(): void {
+  const pathname = usePathname() ?? '/';
+  const pathnameRef = useRef(pathname);
+
+  useEffect(() => {
+    if (pathnameRef.current !== pathname) {
+      pathnameRef.current = pathname;
+      completeRouteTransition(pathname);
+    }
+  }, [pathname]);
+
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      if (isInternalNavClick(event)) {
+        markRouteTransitionIntent(pathnameRef.current);
+      }
+    }
+
+    document.addEventListener('click', handleClick, true);
+    return () => {
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, []);
+}
+
+/** Test-only: reset module state between test cases. */
+export function __resetRouteTransitionStateForTests(): void {
+  pendingTransition = null;
+  markSequence = 0;
+}


### PR DESCRIPTION
## What
- New `apps/web/lib/perf/route-transition.ts`: client-only instrumentation for the authenticated shell. `useRouteTransitionTelemetry()` marks nav intent on internal `<a>` link clicks and measures duration to the next route's committed paint (double `requestAnimationFrame` after `usePathname()` changes), reported through the existing `track()` sink (same convention as `lib/monitoring/web-vitals.ts`) plus `logger.debug` in dev.
- Route ids are redacted (numeric ids, UUIDs, and long opaque tokens containing a digit become `:id`) so no raw pathnames or user data are emitted. `usePathname()` already excludes the query string.
- Mounted once in `AuthShellWrapper.tsx` (`AuthShellWrapperInner`), which only covers the authed `/app` shell — not marketing/public routes.
- `lib/monitoring/web-vitals.ts` already reports INP via `onINP` (web-vitals 5.3, `inp` already has a rating threshold) — no changes needed there.
- Added a **warn-severity** `interaction-to-next-paint` assertion to `apps/web/.lighthouserc.dashboard.pr.json` (maxNumericValue 200ms) as a soft INP budget. Non-blocking by design; a later phase can flip it to `error`.

## Why
Web slice of #13009 — makes route-transition latency measurable inside the shell so every later One App Shell perf chunk has a real metric to be judged against.

## Cost Impact
None — no new external API calls, no new services. Reporting reuses the existing `track()` analytics sink (gtag), same as web-vitals.

## Verification
```
pnpm --filter web exec vitest run lib/perf/route-transition.test.ts
✓ lib/perf/route-transition.test.ts (11 tests) 248ms

pnpm --filter @jovie/web run typecheck -- --pretty false
(no errors)

pnpm biome check --write apps/web/lib/perf/route-transition.ts apps/web/lib/perf/route-transition.test.ts apps/web/components/organisms/AuthShellWrapper.tsx apps/web/.lighthouserc.dashboard.pr.json
Checked 4 files. No fixes applied.
```

Acceptance criteria from the manifest:
- Navigating between two dashboard routes in dev logs a `route_transition` measure with duration (verified via unit tests exercising `markRouteTransitionIntent` → `completeRouteTransition`; manual dev verification is straightforward via the same click→pathname-change path).
- INP appears in web-vitals reporting — already present (`onINP` in `lib/monitoring/web-vitals.ts`).
- Lighthouse config change is warn-only; CI stays green.

Closes web slice of #13009. Part of #12633.