### PR TITLE
fix(ci): let Vercel archive upload finalize

### DIFF
--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -67,9 +67,9 @@ run_deploy() {
 
   # One realistically budgeted archive attempt plus the source fallback must
   # leave a full minute beneath the workflow step's 10-minute ceiling.
-  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-180}"
+  local timeout_seconds="${VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS:-480}"
   if [ "$mode" = "source" ]; then
-    timeout_seconds="${VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS:-340}"
+    timeout_seconds="${VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS:-30}"
   fi
   local kill_grace_seconds="${VERCEL_DEPLOY_KILL_GRACE_SECONDS:-5}"
 
@@ -119,7 +119,7 @@ try_mode() {
     echo "Deploy attempt $attempt with ${mode} upload exceeded its time budget" >&2
     local accepted_deployment_url=""
     accepted_deployment_url="$(parse_deployment_url "$deploy_output")"
-    if [ -n "$accepted_deployment_url" ]; then
+    if [ "$mode" = "source" ] && [ -n "$accepted_deployment_url" ]; then
       write_deployment_url "$accepted_deployment_url"
       echo "Vercel accepted ${accepted_deployment_url}; downstream health gates will verify readiness"
       return 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3828,9 +3828,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ALLOW_SOURCE_FALLBACK: '1'
-          # The closed staging artifact contains more than Vercel's 15k plain
-          # upload limit. Give the archive path the full prebuilt budget.
-          VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'false'
+          VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'true'
           # Use main secrets - no Neon dependency for fast deployments
           DATABASE_URL_MAIN: ${{ secrets.DATABASE_URL_MAIN }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
@@ -4833,7 +4831,9 @@ jobs:
             if [ $i -eq 3 ]; then exit 1; fi
           done
         env:
-          VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'true'
+          # The closed staging artifact contains more than Vercel's 15k plain
+          # upload limit. Give the archive path the full prebuilt budget.
+          VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'false'
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
 

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -18,6 +18,7 @@ def test_timed_out_prebuilt_uploads_fall_back_to_source(tmp_path: Path) -> None:
         """#!/usr/bin/env bash
 set -euo pipefail
 if [[ " $* " == *" --prebuilt "* ]]; then
+  echo "https://jovie-incomplete-prebuilt.vercel.app"
   trap '' TERM
   sleep 5
   exit 1


### PR DESCRIPTION
## Summary
- give the single closed archive upload eight minutes to finalize
- prevent a timed-out prebuilt URL from being handed to readiness as an incomplete deployment
- keep a short source fallback within the ten-minute step budget
- disable impossible plain upload on the actual staging deploy step

## Verification
- `python3 -m pytest scripts/tests/test_vercel_prebuilt_deploy.py -q` (9 passed)
- regression proves a timed-out prebuilt URL is not handed downstream
- shellcheck + bash syntax check
- actionlint on CI and canary workflows
- `git diff --check`

## Bug-to-test
Bug-to-test: waived — covered by the focused Python behavioral and structural regression suite.