### PR TITLE
perf(shell): flip authed-shell link prefetch + lock in server/client query key parity

### DIFF
--- a/apps/web/components/organisms/WorkspaceTabsSurface.tsx
+++ b/apps/web/components/organisms/WorkspaceTabsSurface.tsx
@@ -213,7 +213,6 @@ function LinkedTabBar<T extends string>({
               <Link
                 key={option.value}
                 href={href}
-                prefetch={false}
                 role='tab'
                 data-testid={`drawer-tab-${option.value}`}
                 aria-selected={selected}

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -94,6 +94,9 @@ function EntityCtaControl({
 
   if (cta.href?.startsWith('/')) {
     return (
+      // Justified suppression: EntityCard renders in carousels/lists (release
+      // matrix, profile rails) where dozens of cards can be in the viewport
+      // at once — default prefetch would stampede on scroll.
       <Link
         href={cta.href}
         prefetch={false}
@@ -145,6 +148,8 @@ function CardShell({
 }>) {
   if (href?.startsWith('/')) {
     return (
+      // Justified suppression: same carousel/list stampede risk as the CTA
+      // link above — CardShell wraps the whole card in release/profile rails.
       <Link
         href={href}
         prefetch={false}

--- a/apps/web/tests/unit/queries/server-prefetch-key-equality.test.ts
+++ b/apps/web/tests/unit/queries/server-prefetch-key-equality.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_TASK_WORKSPACE_FILTERS } from '@/lib/tasks/query-defaults';
+import { queryKeys } from '../../../lib/queries/keys';
+
+/**
+ * Regression guard for JOV one-app-shell chunk 1.6.
+ *
+ * Server `page.tsx` route wrappers call `queryClient.fetchQuery({ queryKey })`
+ * to dehydrate data ahead of the client hooks that read it. If either side
+ * ever hardcodes its own key array instead of importing `queryKeys` from the
+ * shared module, the client hook silently misses the server-primed cache
+ * entry and falls back to a loading skeleton -> fetch waterfall (the exact
+ * hydration bug this chunk exists to fix). This test locks in both:
+ *  1. Every route's server prefetch call site and its matching client hook
+ *     source literally reference the same `queryKeys.<domain>.<method>(...)`
+ *     call (static usage check).
+ *  2. The key factory itself produces byte-identical arrays for both call
+ *     shapes (runtime equality check).
+ */
+
+const repoRoot = resolve(__dirname, '../../..');
+const read = (relativePath: string) =>
+  readFileSync(resolve(repoRoot, relativePath), 'utf8');
+
+describe('server prefetch / client hook query key equality', () => {
+  describe('releases matrix (library route)', () => {
+    const serverSource = read('app/app/(shell)/library/page.tsx');
+    const hookSource = read('lib/queries/useReleasesQuery.ts');
+
+    it('server prefetch and client hook both call queryKeys.releases.matrix(...)', () => {
+      expect(serverSource).toContain('queryKeys.releases.matrix(profileId)');
+      expect(hookSource).toContain('queryKeys.releases.matrix(profileId)');
+    });
+
+    it('resolves to the identical key for the same profileId', () => {
+      const profileId = 'profile-abc';
+      expect(queryKeys.releases.matrix(profileId)).toEqual(
+        queryKeys.releases.matrix(profileId)
+      );
+      expect(queryKeys.releases.matrix(profileId)).toMatchInlineSnapshot(`
+        [
+          "releases",
+          "matrix",
+          "profile-abc",
+        ]
+      `);
+    });
+  });
+
+  describe('tasks list + board (tasks route)', () => {
+    const serverSource = read('app/app/(shell)/tasks/TasksRoute.tsx');
+    const hookSource = read('lib/queries/useTasksQuery.ts');
+
+    it('server prefetch and client hook both call queryKeys.tasks.list(...)', () => {
+      expect(serverSource).toMatch(
+        /queryKeys\.tasks\.list\(\s*profileId,\s*DEFAULT_TASK_WORKSPACE_FILTERS\s*\)/
+      );
+      expect(hookSource).toContain('queryKeys.tasks.list(profileId,');
+    });
+
+    it('server prefetch and client hook both call queryKeys.tasks.board(...)', () => {
+      expect(serverSource).toMatch(
+        /queryKeys\.tasks\.board\(\s*profileId,\s*DEFAULT_TASK_WORKSPACE_FILTERS\s*\)/
+      );
+      expect(hookSource).toContain('queryKeys.tasks.board(profileId,');
+    });
+
+    it('resolves to the identical key for list and board given the same filters', () => {
+      const profileId = 'profile-abc';
+      expect(
+        queryKeys.tasks.list(profileId, DEFAULT_TASK_WORKSPACE_FILTERS)
+      ).toEqual(
+        queryKeys.tasks.list(profileId, DEFAULT_TASK_WORKSPACE_FILTERS)
+      );
+      expect(
+        queryKeys.tasks.board(profileId, DEFAULT_TASK_WORKSPACE_FILTERS)
+      ).toEqual(
+        queryKeys.tasks.board(profileId, DEFAULT_TASK_WORKSPACE_FILTERS)
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

Chunk 1.6 of the One App Shell program (#12633): link prefetch audit + server `prefetchQuery` dehydration for the top-3 dashboard routes.

### 1. Prefetch audit (`prefetch={false}` across apps/web)

Audited all 29 occurrences:

| Classification | Count | Action |
|---|---|---|
| Marketing / public-profile page | 27 | Left as-is — out of scope (footers, pricing, investors page, all `[username]` profile CTAs) |
| Justified suppression | 2 | Kept, documented with a one-line comment — `EntityCard.tsx`'s CTA link and `CardShell` wrapper render inside release-matrix / profile-rail carousels where many cards can be in the viewport at once; default prefetch would stampede on scroll |
| Authenticated shell link | 1 | **Flipped** — `WorkspaceTabsSurface.tsx` (admin workspace tab bar): a small, bounded tab set with no stampede risk, so it now gets Next's default viewport prefetch |

### 2. Server `prefetchQuery` dehydration for the top-3 routes

Investigated `/app` (home), `/app/releases`, `/app/tasks`:

- **`/app/releases`** redirects to `/app/library?view=releases`. `library/page.tsx` **already** runs `queryClient.fetchQuery({ queryKey: queryKeys.releases.matrix(profileId), queryFn: () => loadReleaseMatrix(profileId) })` and passes real dehydrated state through `HydrateClient` — matching `useReleasesQuery.ts` exactly (same key, same fetcher). Pre-existing, verified correct.
- **`/app/tasks`** (`TasksRoute.tsx`) **already** prefetches both `queryKeys.tasks.list(...)` and `queryKeys.tasks.board(...)` via `Promise.all` + `fetchQuery`, dehydrated through `HydrateClient` — matching `useTasksQuery.ts`'s `useTasksQuery`/`useTaskBoardQuery` exactly. Pre-existing, verified correct.
- **`/app` (home / Opportunity Inbox)**: `OpportunityInboxRoute.tsx` loads `inbox` data via a plain server action (`loadOpportunityInboxData`) and passes it as props to `OpportunityInboxPageClient` — there is **no TanStack Query usage anywhere in the opportunity-inbox feature** (confirmed via grep for `useQuery`/`useSuspenseQuery`/`useInfiniteQuery`). Its `HydrateClient state={getDehydratedState()}` wrapper is therefore legitimately empty: there is no client-side query to prefetch, and no fetch waterfall exists on this route today. No code change needed here — documenting per the manifest's "adjust the trio if the inbox route differs, justify in PR body" clause. No substitute third route was needed since the acceptance criterion ("warm nav renders data without a client fetch waterfall") already holds trivially for this route.

### 3. Key-equality regression test

Added `apps/web/tests/unit/queries/server-prefetch-key-equality.test.ts`: asserts (a) both the server `page.tsx`/`TasksRoute.tsx` prefetch call sites and their corresponding client hooks (`useReleasesQuery.ts`, `useTasksQuery.ts`) literally reference `queryKeys.releases.matrix(...)` / `queryKeys.tasks.list(...)` / `queryKeys.tasks.board(...)` from the shared module (static usage check), and (b) the key factory produces identical arrays for identical inputs (runtime check). This guards against the exact regression called out in the manifest: a hardcoded/divergent key on either side silently breaking hydration and falling back to skeleton → fetch.

## Verification

```
pnpm --filter @jovie/web run typecheck -- --pretty false   # PASS (exit 0)
pnpm biome check --write <touched files>                    # PASS, 1 file auto-formatted
pnpm --filter web exec vitest run tests/unit/queries/server-prefetch-key-equality.test.ts
  # ✓ 5 tests passed
pnpm --filter web exec vitest run components/organisms/entity-card/EntityCard.test.tsx \
  tests/unit/app/admin-overview-shell-normalization.test.ts
  # ✓ 12 tests passed (no regressions from the prefetch/comment changes)
```

Pre-commit hooks (gitleaks, trufflehog, biome, eslint, a11y:check:staged, typecheck) all passed on commit.

## HOT ZONE

Touched only: `WorkspaceTabsSurface.tsx`, `EntityCard.tsx` (both explicitly in the enumerated `prefetch={false}` callsite list), and a new colocated test. Did not touch `DashboardShellContent.tsx` / `dashboard-data.ts` (chunk 1.2), `AppShellFrame`/`AuthShell*`, or nav config. `apps/web/lib/queries/server.ts` and `prefetch-dashboard.ts` were read but not modified — their existing `prefetchQuery`/`HydrateClient` wiring for the releases and tasks routes was already correct.

Part of #12633