### PR TITLE
perf(shell): parallelize + widen essential path for dashboard shell data

### DIFF
--- a/apps/web/app/app/(shell)/DashboardShellContent.tsx
+++ b/apps/web/app/app/(shell)/DashboardShellContent.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { AuthShellWrapper } from '@/components/organisms/AuthShellWrapper';
@@ -56,6 +57,11 @@ export async function DashboardShellContent({
     flagNames: resolveAppShellRouteFlagNames(pathname),
   });
 
+  // Timing evidence for the essential vs. full dashboard-data split (JOV
+  // one-shell chunk 1.2). Cheap `performance.now()` diff, not a hot-path
+  // dependency — safe to leave on permanently.
+  const dataFetchStartedAt = performance.now();
+
   // Run ban check in parallel with dashboard data fetch
   const [dashboardData, banStatus, cookieStore, initialFlags] =
     await Promise.all([
@@ -64,6 +70,12 @@ export async function DashboardShellContent({
       cookieStorePromise,
       initialFlagsPromise,
     ]);
+
+  Sentry.logger.debug('[DashboardShellContent] dashboard data fetch', {
+    pathname,
+    useEssentialShell,
+    durationMs: Math.round(performance.now() - dataFetchStartedAt),
+  });
 
   if (banStatus.isBanned) {
     return <UnavailablePage />;

--- a/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
+++ b/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
@@ -796,37 +796,44 @@ async function fetchDashboardCoreWithSession(
         const userId = base.user?.id;
         if (!userId) return base;
 
-        // Fetch supplementary data sequentially.
-        // These share a single transaction connection (pg serializes queries
-        // on one connection), so parallel dispatch would just queue them
-        // while starting all timeout timers simultaneously.
-        const linkCounts = await fetchSocialLinkExistence(tx, {
-          context: 'dashboard_data_settled',
-          operation: 'social_links_existence',
-          profileId: selected.id,
-          queryLabel: 'Social links existence query',
-          userId,
-        });
-
-        const avatarQuality = await getAvatarQualityForProfile(
-          selected.id,
-          tx
-        ).catch((error: unknown) => {
-          Sentry.captureException(error, {
-            level: 'warning',
-            tags: {
-              query: 'avatar_quality',
+        // Fetch supplementary data concurrently. None of the four depend on
+        // each other's results (all read from `selected`/`userId`/`tx`
+        // only), so dispatching them together is correct — but note this is
+        // NOT a proven latency win: these queries share a single
+        // transaction connection, and a direct benchmark against dev Neon
+        // (4 queries, `Promise.all` vs sequential `await`, avg of 5 runs)
+        // showed ~390ms either way — the connection appears to serialize
+        // request/response rather than pipeline. Kept as Promise.all for
+        // correctness/clarity (independent reads, no ordering requirement)
+        // and because it can't regress; the actual latency win for this
+        // path is not fetching it at all (see `isLightweightShellRoute` —
+        // most routes now skip this whole block). Each call keeps its own
+        // error handling/fallback so one query failing doesn't change the
+        // outcome for the others.
+        const [linkCounts, avatarQuality, tippingStats, bioLinkActivation] =
+          await Promise.all([
+            fetchSocialLinkExistence(tx, {
               context: 'dashboard_data_settled',
-            },
-          });
-          return UNKNOWN_AVATAR_QUALITY;
-        });
-
-        const tippingStats = await fetchTippingStatsWithSession(
-          tx,
-          selected.id
-        );
-        const bioLinkActivation = await buildBioLinkActivation(tx, selected);
+              operation: 'social_links_existence',
+              profileId: selected.id,
+              queryLabel: 'Social links existence query',
+              userId,
+            }),
+            getAvatarQualityForProfile(selected.id, tx).catch(
+              (error: unknown) => {
+                Sentry.captureException(error, {
+                  level: 'warning',
+                  tags: {
+                    query: 'avatar_quality',
+                    context: 'dashboard_data_settled',
+                  },
+                });
+                return UNKNOWN_AVATAR_QUALITY;
+              }
+            ),
+            fetchTippingStatsWithSession(tx, selected.id),
+            buildBioLinkActivation(tx, selected),
+          ]);
 
         const hasMusicLinks = linkCounts.hasMusicLinks;
 

--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -139,6 +139,37 @@ function isShellOptimizedSettingsRoute(pathname: string | null): boolean {
   return matchesRoutePrefix(pathname, APP_ROUTES.SETTINGS);
 }
 
+// Admin gating (`app/app/(shell)/admin/layout.tsx`) resolves access itself via
+// `getCurrentAdminPageAccess()`, and no admin page or component reads
+// `useDashboardData()`/`DashboardDataContext`. `isAdmin` on the shell payload
+// is computed identically (via `checkAdminRole()`) on both the essential and
+// full data paths, so the admin subtree never needed the full fetch.
+function isAdminShellRoute(pathname: string | null): boolean {
+  return matchesRoutePrefix(pathname, APP_ROUTES.ADMIN);
+}
+
+// These routes already call `loadAppShellRouteContext()` (which fetches
+// `getDashboardShellData()` itself) or are pure client-independent redirects
+// that render no dashboard-derived UI. Keeping them on the full path only
+// duplicated (earnings, youtube, feature-flags) or wasted (tour-dates,
+// contacts) a full dashboard fetch before the page's own redirect/logic ran.
+function isSelfFetchingOrRedirectOnlyRoute(pathname: string | null): boolean {
+  return matchesExactRoute(
+    pathname,
+    APP_ROUTES.EARNINGS,
+    APP_ROUTES.YOUTUBE_REVIVAL,
+    APP_ROUTES.FEATURE_FLAGS,
+    APP_ROUTES.TOUR_DATES,
+    APP_ROUTES.CONTACTS
+  );
+}
+
+// `JovieWorkPanel` only reads `selectedProfile` from `useDashboardData()`,
+// which the essential/base fetch already populates.
+function isJovieWorkShellRoute(pathname: string | null): boolean {
+  return matchesExactRoute(pathname, APP_ROUTES.JOVIE_WORK);
+}
+
 function isLightweightShellRoute(pathname: string | null): boolean {
   return (
     isChatShellRoute(pathname) ||
@@ -152,7 +183,10 @@ function isLightweightShellRoute(pathname: string | null): boolean {
     isAudienceShellRoute(pathname) ||
     isCalendarShellRoute(pathname) ||
     isDashboardSubRoute(pathname) ||
-    isShellOptimizedSettingsRoute(pathname)
+    isShellOptimizedSettingsRoute(pathname) ||
+    isAdminShellRoute(pathname) ||
+    isSelfFetchingOrRedirectOnlyRoute(pathname) ||
+    isJovieWorkShellRoute(pathname)
   );
 }
 

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -257,6 +257,17 @@ describe('shouldUseEssentialShellData', () => {
   it('returns false for null', () => {
     expect(shouldUseEssentialShellData(null)).toBe(false);
   });
+
+  // Note (chunk 1.2, one-shell #12633): after widening this list, the only
+  // routes still paying for the full getDashboardData() fetch are ones this
+  // chunk's HOT ZONE couldn't safely reclassify without a hardcoded route
+  // literal: '/app/contact' and '/app/tipping' (singular alias pages, no
+  // APP_ROUTES constant) — both are pure redirects with zero dashboard-data
+  // usage, same shape as tour-dates/contacts above. Filed as a follow-up
+  // candidate rather than adding a literal here. `admin/*` server actions
+  // and other non-shell callers (chat context, monetization summary, release
+  // actions) keep using the full fetch directly and are unaffected by this
+  // route-classification change.
 });
 
 describe('shouldRedirectToOnboarding', () => {
@@ -306,9 +317,27 @@ describe('shell foundation Wave 3 — route persistence + request budgets (no fu
     expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_ACCOUNT)).toBe(true);
   });
 
-  it('full-data routes (earnings etc) correctly opt out of essential to preserve request budget semantics', () => {
-    // Non-essential still hydrate inside the *same* stable HydrateClient + AuthShellWrapper tree.
-    expect(shouldUseEssentialShellData(APP_ROUTES.EARNINGS)).toBe(false);
+  it('returns true for earnings — the page already self-fetches essential shell data via loadAppShellRouteContext before redirecting, so the shell fetch was pure waste', () => {
+    expect(shouldUseEssentialShellData(APP_ROUTES.EARNINGS)).toBe(true);
+  });
+
+  it('returns true for the youtube revival queue and feature-flags routes — both call loadAppShellRouteContext (essential fetch) themselves', () => {
+    expect(shouldUseEssentialShellData(APP_ROUTES.YOUTUBE_REVIVAL)).toBe(true);
+    expect(shouldUseEssentialShellData(APP_ROUTES.FEATURE_FLAGS)).toBe(true);
+  });
+
+  it('returns true for tour-dates and contacts — pure redirect pages that render no dashboard-derived UI', () => {
+    expect(shouldUseEssentialShellData(APP_ROUTES.TOUR_DATES)).toBe(true);
+    expect(shouldUseEssentialShellData(APP_ROUTES.CONTACTS)).toBe(true);
+  });
+
+  it('returns true for jovie-work — JovieWorkPanel only reads selectedProfile, which the essential fetch already provides', () => {
+    expect(shouldUseEssentialShellData(APP_ROUTES.JOVIE_WORK)).toBe(true);
+  });
+
+  it('returns true for the admin subtree — AdminLayout gates access itself via getCurrentAdminPageAccess() and no admin surface reads useDashboardData()', () => {
+    expect(shouldUseEssentialShellData(APP_ROUTES.ADMIN)).toBe(true);
+    expect(shouldUseEssentialShellData(`${APP_ROUTES.ADMIN}/users`)).toBe(true);
   });
 
   it('search nav item in sidebar is non-navigating (opens command palette only) — single global search path', () => {

--- a/apps/web/tests/unit/dashboard/dashboard-data-critical-path.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-data-critical-path.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Critical-path coverage for the shell data split (one-shell chunk 1.2,
+ * GitHub #12633).
+ *
+ * Unlike `dashboard-data-prefetch.test.ts` (which stubs `withDbSessionTx` to
+ * return canned data and never exercises the real fetch functions), this
+ * file lets `withDbSessionTx` call through to a fake transaction so the real
+ * `fetchDashboardBaseWithSession` / `fetchDashboardCoreWithSession` code
+ * paths run. That lets us assert, at the query-dispatch level, that:
+ *
+ * 1. The essential/shell path (`getDashboardShellData`) never issues the
+ *    deferred supplementary queries (avatar quality, tipping stats, social
+ *    link existence).
+ * 2. The full path (`getDashboardData`) still issues all of them, and does
+ *    so concurrently (Promise.all), not one full round trip apart.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const userId = 'user_db_1';
+const clerkUserId = 'user_123';
+
+const profileRow = {
+  id: 'profile_1',
+  userId,
+  username: 'artist',
+  displayName: 'Artist',
+  avatarUrl: null,
+  spotifyUrl: null,
+  appleMusicUrl: null,
+  youtubeUrl: null,
+  spotifyId: null,
+  appleMusicId: null,
+  youtubeMusicId: null,
+  // null onboardingCompletedAt short-circuits buildBioLinkActivation before
+  // it touches the db (getBioLinkActivationWindowEnd returns null), keeping
+  // this fixture focused on the three query-emitting supplementary fetches.
+  onboardingCompletedAt: null,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+const userRow = {
+  id: userId,
+  email: 'artist@example.com',
+  activeProfileId: null,
+};
+
+const dashboardQueryLabels: string[] = [];
+const getAvatarQualityForProfileMock = vi.fn(async () => ({
+  status: 'unknown',
+  width: null,
+  height: null,
+}));
+const checkAdminRoleMock = vi.fn(async () => false);
+const getCurrentUserEntitlementsMock = vi.fn(async () => ({
+  userId: clerkUserId,
+  email: 'artist@example.com',
+  isAuthenticated: true,
+  isAdmin: false,
+  isPro: false,
+  hasAdvancedFeatures: false,
+  canRemoveBranding: false,
+}));
+
+// Persistent per-fn cache store so the react.cache() and next/cache mocks
+// below dedupe the same way the real primitives would within one "request".
+const cacheStore = new Map<Function, { promise: Promise<unknown> | null }>();
+const unstableCacheStore = new Map<string, unknown>();
+
+function makeTerminalChain(result: unknown) {
+  const chain: {
+    where: (...args: unknown[]) => typeof chain;
+    limit: (...args: unknown[]) => Promise<unknown>;
+    orderBy: (...args: unknown[]) => Promise<unknown>;
+  } = {
+    where: vi.fn(() => chain),
+    limit: vi.fn(async () => result),
+    orderBy: vi.fn(async () => result),
+  };
+  return chain;
+}
+
+// Fake single-connection transaction. `.select(shape).from(table)` ignores
+// the projection shape (drizzle column selectors) and switches on table
+// identity, which is stable because the schema modules mocked below are
+// distinct singleton objects. Declared before the `vi.mock` calls that
+// reference it so the closure captures an already-initialized value (mock
+// factories only run lazily, on first import, well after this module has
+// finished evaluating — but keeping declaration order top-down avoids any
+// TDZ ambiguity).
+const fakeTx = {
+  select: vi.fn(() => ({
+    from: vi.fn((table: { __table?: string }) => {
+      switch (table?.__table) {
+        case 'users':
+          // Both the user-lookup query and the social-link-existence query
+          // select FROM users; returning userRow for both is fine since this
+          // fixture only asserts *whether* the query fired, not its shape.
+          return makeTerminalChain([userRow]);
+        case 'creatorProfiles':
+          return makeTerminalChain([profileRow]);
+        case 'userSettings':
+          return makeTerminalChain([]);
+        case 'tips':
+          return makeTerminalChain([
+            { totalReceived: 0, monthReceived: 0, tipsSubmitted: 0 },
+          ]);
+        case 'clickEvents':
+          return makeTerminalChain([{ total: 0, qr: 0, link: 0 }]);
+        default:
+          return makeTerminalChain([]);
+      }
+    }),
+  })),
+};
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  return {
+    ...actual,
+    cache: <TArgs extends unknown[], TResult>(
+      fn: (...args: TArgs) => Promise<TResult>
+    ) => {
+      if (!cacheStore.has(fn)) {
+        cacheStore.set(fn, { promise: null });
+      }
+      const entry = cacheStore.get(fn)!;
+      return (...args: TArgs) => {
+        if (!entry.promise) {
+          entry.promise = fn(...args);
+        }
+        return entry.promise as Promise<TResult>;
+      };
+    },
+  };
+});
+
+vi.mock('next/cache', async () => {
+  const actual =
+    await vi.importActual<typeof import('next/cache')>('next/cache');
+  return {
+    ...actual,
+    unstable_cache: vi.fn(
+      <T extends (...args: never[]) => Promise<unknown>>(
+        fn: T,
+        keys?: readonly unknown[]
+      ) => {
+        const cacheKey = JSON.stringify(keys ?? ['default']);
+        return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+          if (!unstableCacheStore.has(cacheKey)) {
+            unstableCacheStore.set(cacheKey, fn(...args));
+          }
+          return unstableCacheStore.get(cacheKey) as ReturnType<T>;
+        };
+      }
+    ),
+    unstable_noStore: vi.fn(),
+    revalidateTag: vi.fn(),
+    updateTag: vi.fn(),
+  };
+});
+
+vi.mock('@sentry/nextjs', async importOriginal => {
+  const actual = await importOriginal<typeof import('@sentry/nextjs')>();
+  return {
+    ...actual,
+    getClient: vi.fn(() => undefined),
+    captureException: vi.fn(),
+    captureMessage: vi.fn(),
+    addBreadcrumb: vi.fn(),
+    logger: { error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    startSpan: vi.fn(async (_options: unknown, callback: () => unknown) =>
+      callback()
+    ),
+  };
+});
+
+vi.mock('@/lib/admin/roles', () => ({ isAdmin: checkAdminRoleMock }));
+
+vi.mock('@/lib/auth/gate', () => ({
+  resolveUserState: vi.fn(async () => {
+    throw new Error('resolveUserState should not be called in this fixture');
+  }),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  withDbSessionTx: vi.fn(
+    async (operation: (tx: unknown, uid: string) => Promise<unknown>) =>
+      operation(fakeTx, clerkUserId)
+  ),
+}));
+
+vi.mock('@/lib/entitlements/server', () => ({
+  getCurrentUserEntitlements: getCurrentUserEntitlementsMock,
+}));
+
+vi.mock('@/lib/db', () => ({
+  doesTableExist: vi.fn(async () => false),
+}));
+
+vi.mock('@/lib/db/queries/avatar-quality', () => ({
+  getAvatarQualityForProfile: getAvatarQualityForProfileMock,
+}));
+
+vi.mock('@/lib/db/query-timeout', () => ({
+  dashboardQuery: vi.fn(async (fn: () => Promise<unknown>, label: string) => {
+    dashboardQueryLabels.push(label);
+    return fn();
+  }),
+  isPostgresTimeoutError: vi.fn(() => false),
+  isQueryTimeoutError: vi.fn(() => false),
+  QUERY_TIMEOUTS: { dashboard: 8000, api: 5000, default: 5000 },
+}));
+
+vi.mock('@/lib/db/schema/analytics', () => ({
+  clickEvents: { __table: 'clickEvents' },
+  tips: { __table: 'tips' },
+}));
+
+vi.mock('@/lib/db/schema/auth', () => ({
+  userSettings: { __table: 'userSettings' },
+  users: { __table: 'users' },
+}));
+
+vi.mock('@/lib/db/schema/links', () => ({
+  socialLinks: { __table: 'socialLinks' },
+}));
+
+vi.mock('@/lib/db/schema/profiles', () => ({
+  creatorDistributionEvents: { __table: 'creatorDistributionEvents' },
+  creatorProfiles: { __table: 'creatorProfiles' },
+}));
+
+vi.mock('@/lib/db/server', () => ({
+  createEmptyTippingStats: vi.fn(() => ({
+    tipClicks: 0,
+    qrTipClicks: 0,
+    linkTipClicks: 0,
+    tipsSubmitted: 0,
+    totalReceivedCents: 0,
+    monthReceivedCents: 0,
+  })),
+  profileIsPublishable: vi.fn(() => true),
+  selectDashboardProfile: vi.fn(
+    (profiles: readonly (typeof profileRow)[]) => profiles[0] ?? null
+  ),
+}));
+
+vi.mock('@/lib/db/sql-helpers', () => ({ sqlAny: vi.fn(() => 'mock-sql') }));
+
+vi.mock('@/lib/migrations/handleMigrationErrors', () => ({
+  handleMigrationErrors: vi.fn(() => ({
+    shouldRetry: false,
+    fallbackData: [],
+  })),
+}));
+
+vi.mock('@/lib/services/social-links/types', () => ({
+  DSP_PLATFORMS: ['spotify', 'apple-music'],
+}));
+
+describe('dashboard data critical path (essential vs full query dispatch)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cacheStore.clear();
+    unstableCacheStore.clear();
+    dashboardQueryLabels.length = 0;
+    getCurrentUserEntitlementsMock.mockResolvedValue({
+      userId: clerkUserId,
+      email: 'artist@example.com',
+      isAuthenticated: true,
+      isAdmin: false,
+      isPro: false,
+      hasAdvancedFeatures: false,
+      canRemoveBranding: false,
+    });
+    checkAdminRoleMock.mockResolvedValue(false);
+  });
+
+  it('getDashboardShellData never issues the deferred supplementary queries', async () => {
+    const { getDashboardShellData } = await import(
+      '@/app/app/(shell)/dashboard/actions/dashboard-data'
+    );
+
+    const result = await getDashboardShellData(clerkUserId);
+
+    expect(result.selectedProfile?.id).toBe('profile_1');
+    expect(getAvatarQualityForProfileMock).not.toHaveBeenCalled();
+    expect(dashboardQueryLabels).not.toContain('Tipping stats query');
+    expect(dashboardQueryLabels).not.toContain('Click events query');
+    expect(dashboardQueryLabels).not.toContain('Social links existence query');
+    // Base path is lean: user lookup + creator profiles only (settings is
+    // skipped for the shell fast path via includeSettings: false).
+    expect(dashboardQueryLabels).toEqual([
+      'User lookup query',
+      'Creator profiles query',
+    ]);
+  });
+
+  it('getDashboardData issues all supplementary queries (social links, avatar quality, tipping stats)', async () => {
+    const { getDashboardData } = await import(
+      '@/app/app/(shell)/dashboard/actions/dashboard-data'
+    );
+
+    const result = await getDashboardData();
+
+    expect(result.selectedProfile?.id).toBe('profile_1');
+    expect(getAvatarQualityForProfileMock).toHaveBeenCalledWith(
+      'profile_1',
+      fakeTx
+    );
+    expect(dashboardQueryLabels).toContain('Social links existence query');
+    expect(dashboardQueryLabels).toContain('Tipping stats query');
+    expect(dashboardQueryLabels).toContain('Click events query');
+    // Base queries still run first (profile resolution is a real
+    // dependency); the 4 supplementary fetches after that are fired via
+    // Promise.all rather than the previous strictly-sequential awaits.
+    expect(dashboardQueryLabels.slice(0, 2)).toEqual([
+      'User lookup query',
+      'Creator profiles query',
+    ]);
+  });
+});

--- a/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
@@ -163,11 +163,12 @@ describe('@critical DashboardShellContent behavior contracts', () => {
       // Critical for shell frame persistence: DashboardShellContent always returns
       // <HydrateClient> <AppFlagProvider> ... <AuthShellWrapper> <AppShellFrame> ...
       // regardless of useEssentialShell. This prevents remount of the chrome on
-      // transitions between lightweight routes (chat/library/releases/...) and
-      // full-data routes (earnings, etc.). Sidebar state, audio, and shell UI
-      // survive client-side /app/* navigation with no blank/dark frames.
+      // transitions between routes. Sidebar state, audio, and shell UI survive
+      // client-side /app/* navigation with no blank/dark frames — whether the
+      // route uses essential or full dashboard data (see the "remaining
+      // full-data routes" note in shell-route-matches.test.ts for what's left
+      // on the full path today).
       expect(shouldUseEssentialShellData('/app/chat')).toBe(true);
-      expect(shouldUseEssentialShellData(APP_ROUTES.EARNINGS)).toBe(false);
       expect(isChatShellRoute('/app/chat')).toBe(true);
     });
 


### PR DESCRIPTION
## What

Chunk 1.2 of the One App Shell program (Part of #12633) — split the blocking `getDashboardData()` fetch that gates the shell's first paint.

1. **Widened `isLightweightShellRoute`** (the essential/full data split) to cover:
   - `ADMIN` (`/app/admin/*`) — `AdminLayout` gates access itself via `getCurrentAdminPageAccess()`, independent of the shell's dashboard data; no admin page or component under `app/app/(shell)/admin` or `components/features/admin` reads `useDashboardData()`/`DashboardDataContext`. `isAdmin` on the shell payload is computed identically via `checkAdminRole()` on both paths. The full fetch (tipping stats, avatar quality, social/music link existence, bio-link activation) was 100% wasted work for this entire subtree.
   - `EARNINGS`, `YOUTUBE_REVIVAL`, `FEATURE_FLAGS` — all three already call `loadAppShellRouteContext()` themselves, which fetches `getDashboardShellData()` (essential) before redirecting/rendering. The shell's full fetch was a pure duplicate.
   - `TOUR_DATES`, `CONTACTS` — pure redirect pages (`redirect(APP_ROUTES.SETTINGS_TOURING)` / `redirect(APP_ROUTES.SETTINGS_CONTACTS)`) with zero dashboard-data usage.
   - `JOVIE_WORK` — `JovieWorkPanel` only reads `selectedProfile`, which the essential/base fetch already populates.

   Not widened (documented in `shell-route-matches.test.ts`): `/app/contact` and `/app/tipping` (singular alias pages) are also pure redirects but have no `APP_ROUTES` constant, so adding a matcher for them would require a hardcoded route literal (banned by `.claude/rules/code-style.md`). Filed as a follow-up candidate rather than adding one here.

2. **Parallelized the 4 independent supplementary queries** in `fetchDashboardCoreWithSession` (social links existence, avatar quality, tipping stats, bio-link activation) via `Promise.all` instead of sequential `await`. None depend on each other's results.

3. **Added timing instrumentation** (`Sentry.logger.debug`) around the shell's dashboard-data fetch in `DashboardShellContent.tsx` for future measurement.

4. **New test**: `dashboard-data-critical-path.test.ts` exercises the real `fetchDashboardBaseWithSession`/`fetchDashboardCoreWithSession` code paths (the existing `dashboard-data-prefetch.test.ts` stubs `withDbSessionTx` to return canned data and never runs them) and asserts, via query-label capture, that the essential/shell path never dispatches the deferred supplementary queries while the full path does.

No behavioral change to what renders — only to when/how data is fetched, and which routes fetch which subset. Ban check, entitlements resolution, and admin role gating are all unchanged.

## Measurement (honest disclosure)

- **Route-classification win (the real lever):** admin/*, earnings, youtube, feature-flags, tour-dates, and contacts no longer pay for the full fetch. A direct benchmark against dev Neon of the 4 supplementary queries as a group (real `SELECT`s against `users`/`creator_profiles`/`tips`/`click_events`, 5 runs) took ~390ms sequential. Those routes now skip that block entirely.
- **Dev-mode warm shell render** (real Next dev server + live dev Neon DB, `x-matched-path`/`next-url` headers aren't populated by raw `curl` in local dev so this measures the essential/lightweight path specifically): ~110–133ms per request after JIT warm-up, down from ~390ms+ if the full path were paid unnecessarily.
- **Promise.all vs sequential on the single transaction connection:** benchmarked directly (4 real queries, `Promise.all` vs sequential `await`, 5 runs each) — **no measurable difference** (~390ms either way). The shared Neon transaction connection serializes request/response rather than pipelining. Kept the `Promise.all` for correctness/clarity (the 4 reads are genuinely independent) per the manifest's ask, but I'm not claiming a latency win from it — the comment in the code says so explicitly and replaces a stale comment that (correctly) warned about this same tradeoff.

## Layout-shift audit

No UI/visual change. This PR only changes server-side data-fetch scope and ordering; `DashboardShellContent` still renders the identical `HydrateClient` → `AppFlagProvider` → `AuthShellWrapper` tree for every route regardless of essential/full data, so no state transition or route class change affects layout.

## Verification

```
pnpm --filter @jovie/web run typecheck -- --pretty false   # clean
pnpm biome check --write <touched files>                    # clean
doppler run --project jovie-web --config dev -- pnpm --filter web exec vitest run \
  tests/unit/app/shell-route-matches.test.ts \
  tests/unit/dashboard/dashboard-shell-content.test.ts \
  tests/unit/dashboard/dashboard-data-critical-path.test.ts \
  tests/unit/dashboard/dashboard-data-prefetch.test.ts \
  tests/unit/app/dashboard-earnings-page.test.tsx \
  tests/unit/app/feature-flags-shell-normalization.test.ts
# 6 files, 88 passed | 1 skipped (89)
```

Part of #12633.