### PR TITLE
test(shell): freeze nav IA snapshot and add header/toolbar lint guardrail

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   artistProfileNavItem,
+  artistSettingsNavigation,
   mobileExpandedNavigation,
   mobilePrimaryNavigation,
   newThreadNavItem,
   primaryNavigation,
   settingsNavItem,
   touringNavItem,
+  userSettingsNavigation,
 } from './config';
+import type { NavItem } from './types';
 
 // Canonical nav items that mobile is allowed to reference. Anything mobile
 // renders must come from this set (or the shared exports above) so desktop
@@ -31,5 +34,216 @@ describe('mobile nav derivation', () => {
 
   it('uses the shared chat entry point instead of a redefined "home" item', () => {
     expect(mobilePrimaryNavigation[0]).toBe(newThreadNavItem);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nav IA snapshot — freezes labels, hrefs, and order for every canonical nav
+// list before the One App Shell refactor swarm starts. Any change to a nav
+// item's id/label/href, or its position within a list, must show up as an
+// explicit snapshot diff in review rather than a silent drift. See
+// .context/one-shell/manifests/0-1-nav-guardrails.md (GH #12633 / #12645).
+// ---------------------------------------------------------------------------
+
+interface NavSnapshotEntry {
+  id: string;
+  label: string;
+  href: string;
+  order: number;
+}
+
+function toSnapshotProjection(items: NavItem[]): NavSnapshotEntry[] {
+  return items.map((item, order) => ({
+    id: item.id,
+    label: item.name,
+    href: item.href,
+    order,
+  }));
+}
+
+describe('nav IA snapshot', () => {
+  it('freezes desktop primary navigation', () => {
+    expect(toSnapshotProjection(primaryNavigation)).toMatchInlineSnapshot(`
+      [
+        {
+          "href": "/app/chat",
+          "id": "chat",
+          "label": "New Chat",
+          "order": 0,
+        },
+        {
+          "href": "/app/library?view=releases",
+          "id": "releases",
+          "label": "Releases",
+          "order": 1,
+        },
+        {
+          "href": "/app/settings/artist-profile",
+          "id": "artist-profile",
+          "label": "Artist Profile",
+          "order": 2,
+        },
+        {
+          "href": "/app/settings/touring",
+          "id": "touring",
+          "label": "Touring",
+          "order": 3,
+        },
+        {
+          "href": "/app/calendar",
+          "id": "calendar",
+          "label": "Calendar",
+          "order": 4,
+        },
+        {
+          "href": "/app/tasks",
+          "id": "tasks",
+          "label": "Tasks",
+          "order": 5,
+        },
+        {
+          "href": "/app/audience",
+          "id": "audience",
+          "label": "Audience",
+          "order": 6,
+        },
+      ]
+    `);
+  });
+
+  it('freezes mobile primary (bottom-bar) navigation', () => {
+    expect(
+      toSnapshotProjection(mobilePrimaryNavigation)
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "href": "/app/chat",
+          "id": "chat",
+          "label": "New Chat",
+          "order": 0,
+        },
+        {
+          "href": "/app/library?view=releases",
+          "id": "releases",
+          "label": "Releases",
+          "order": 1,
+        },
+        {
+          "href": "/app/audience",
+          "id": "audience",
+          "label": "Audience",
+          "order": 2,
+        },
+      ]
+    `);
+  });
+
+  it('freezes mobile expanded ("more") navigation', () => {
+    expect(
+      toSnapshotProjection(mobileExpandedNavigation)
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "href": "/app/settings/artist-profile",
+          "id": "artist-profile",
+          "label": "Artist Profile",
+          "order": 0,
+        },
+        {
+          "href": "/app/settings/touring",
+          "id": "touring",
+          "label": "Touring",
+          "order": 1,
+        },
+        {
+          "href": "/app/calendar",
+          "id": "calendar",
+          "label": "Calendar",
+          "order": 2,
+        },
+        {
+          "href": "/app/tasks",
+          "id": "tasks",
+          "label": "Tasks",
+          "order": 3,
+        },
+        {
+          "href": "/app/settings",
+          "id": "settings",
+          "label": "Settings",
+          "order": 4,
+        },
+      ]
+    `);
+  });
+
+  it('freezes user settings navigation', () => {
+    expect(toSnapshotProjection(userSettingsNavigation)).toMatchInlineSnapshot(`
+      [
+        {
+          "href": "/app/settings/account",
+          "id": "account",
+          "label": "Account",
+          "order": 0,
+        },
+        {
+          "href": "/app/settings/usage",
+          "id": "usage",
+          "label": "Usage Stats",
+          "order": 1,
+        },
+        {
+          "href": "/app/settings/billing",
+          "id": "billing",
+          "label": "Billing & Subscription",
+          "order": 2,
+        },
+        {
+          "href": "/app/settings/data-privacy",
+          "id": "data-privacy",
+          "label": "Data & Privacy",
+          "order": 3,
+        },
+      ]
+    `);
+  });
+
+  it('freezes artist settings navigation', () => {
+    expect(
+      toSnapshotProjection(artistSettingsNavigation)
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "href": "/app/settings/artist-profile",
+          "id": "artist-profile",
+          "label": "Profile",
+          "order": 0,
+        },
+        {
+          "href": "/app/settings/contacts",
+          "id": "contacts",
+          "label": "Contacts",
+          "order": 1,
+        },
+        {
+          "href": "/app/settings/touring",
+          "id": "touring",
+          "label": "Touring",
+          "order": 2,
+        },
+        {
+          "href": "/app/settings/analytics",
+          "id": "analytics",
+          "label": "Analytics",
+          "order": 3,
+        },
+        {
+          "href": "/app/settings/audience",
+          "id": "audience-tracking",
+          "label": "Audience & Tracking",
+          "order": 4,
+        },
+      ]
+    `);
   });
 });

--- a/apps/web/eslint-rules/no-new-header-toolbar-components.js
+++ b/apps/web/eslint-rules/no-new-header-toolbar-components.js
@@ -1,0 +1,126 @@
+/**
+ * ESLint rule: no-new-header-toolbar-components
+ *
+ * The header/toolbar "component zoo" has grown to ~28 distinct `*Header.tsx`
+ * and `*Toolbar.tsx` files under `apps/web/components/**` with no shared
+ * contract. Before the One App Shell refactor consolidates these into a
+ * canonical set, this rule freezes the count: any NEW file matching
+ * `(Header|Toolbar).tsx` under `apps/web/components/**` that isn't already on
+ * the allowlist below gets a warning pointing back at the existing systems.
+ *
+ * This is a warn-level guardrail, not a build-breaker — the point is to make
+ * new additions to the zoo a visible, reviewable choice instead of a silent
+ * default. Existing files are allowlisted so authoring/re-exporting them
+ * never triggers the rule.
+ *
+ * @see .context/one-shell/manifests/0-1-nav-guardrails.md
+ * @see GitHub #12633 (One App Shell) / #12645
+ */
+
+// Snapshot of every *Header.tsx / *Toolbar.tsx under apps/web/components as of
+// the One App Shell guardrail chunk (JOV one-shell 0.1). Paths are relative to
+// `apps/web/`. Add to this list only alongside an explicit decision to grow
+// the header/toolbar surface — the refactor swarm should be shrinking it.
+const ALLOWLISTED_COMPONENT_PATHS = [
+  'components/features/admin/table/AdminCreatorsTableHeader.tsx',
+  'components/features/admin/table/AdminTableHeader.tsx',
+  'components/features/dashboard/atoms/AudienceMemberHeader.tsx',
+  'components/features/dashboard/audience/table/molecules/AudienceTableHeader.tsx',
+  'components/features/dashboard/molecules/SectionHeader.tsx',
+  'components/features/dashboard/organisms/DashboardHeader.tsx',
+  'components/features/dashboard/organisms/contacts-table/ContactDetailHeader.tsx',
+  'components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactHeader.tsx',
+  'components/features/dashboard/organisms/profile-contact-sidebar/ProfileSidebarHeader.tsx',
+  'components/features/dashboard/organisms/table/TableToolbar.tsx',
+  'components/features/dev/DevToolbar.tsx',
+  'components/features/library-share/LibraryShareDropHeader.tsx',
+  'components/features/profile/ProfileHeader.tsx',
+  'components/jovie/components/ChatComposerToolbar.tsx',
+  'components/jovie/components/ChatPinnedOpportunityHeader.tsx',
+  'components/marketing/artist-profile/ArtistProfileSectionHeader.tsx',
+  'components/molecules/ContentSectionHeader.tsx',
+  'components/molecules/DocToolbar.tsx',
+  'components/molecules/drawer/DrawerHeader.tsx',
+  'components/organisms/billing/BillingHeader.tsx',
+  'components/organisms/profile-sidebar/ProfileSidebarHeader.tsx',
+  'components/organisms/public-surface/PublicSurfaceHeader.tsx',
+  'components/organisms/release-sidebar/ReleaseSidebarHeader.tsx',
+  'components/organisms/table/atoms/GroupHeader.tsx',
+  'components/organisms/table/molecules/PageToolbar.tsx',
+  'components/organisms/table/molecules/TableBulkActionsToolbar.tsx',
+  'components/organisms/table/molecules/TableStandardToolbar.tsx',
+  'components/organisms/table/organisms/UnifiedTableHeader.tsx',
+  'components/shell/LyricsHeader.tsx',
+  'components/site/Header.tsx',
+  'components/site/MarketingHeader.tsx',
+];
+
+const HEADER_TOOLBAR_FILENAME_PATTERN = /(Header|Toolbar)\.tsx$/;
+const COMPONENTS_DIR_PATTERN = /\/components\//;
+
+function normalize(filePath) {
+  return filePath.replaceAll('\\', '/');
+}
+
+/**
+ * Returns the path relative to `apps/web/` when the file lives under
+ * `apps/web/components/`, or null when it doesn't (e.g. a different app,
+ * or a path outside the components tree).
+ */
+function toWebRelativePath(filename) {
+  const normalized = normalize(filename);
+  const marker = '/apps/web/';
+  const index = normalized.lastIndexOf(marker);
+  if (index === -1) return null;
+  return normalized.slice(index + marker.length);
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Warn when a new *Header.tsx/*Toolbar.tsx component is added under apps/web/components without being added to the allowlist — freezes the header/toolbar component zoo ahead of the One App Shell refactor',
+      recommended: false,
+    },
+    messages: {
+      notAllowlisted:
+        'New header/toolbar component "{{relativePath}}" is not on the allowlist in ' +
+        'eslint-rules/no-new-header-toolbar-components.js. There are already ~28 ' +
+        '*Header.tsx/*Toolbar.tsx components under apps/web/components — check whether ' +
+        'an existing one (DashboardHeader, PageToolbar, UnifiedTableHeader, etc.) can be ' +
+        'reused or extended before adding another. If this is an intentional new system, ' +
+        'add it to the allowlist array. See .context/one-shell/manifests/0-1-nav-guardrails.md.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const filename = context.filename ?? context.getFilename?.() ?? '';
+    const normalized = normalize(filename);
+
+    if (
+      !HEADER_TOOLBAR_FILENAME_PATTERN.test(normalized) ||
+      !COMPONENTS_DIR_PATTERN.test(normalized)
+    ) {
+      return {};
+    }
+
+    const relativePath = toWebRelativePath(normalized);
+    if (relativePath === null) return {};
+
+    if (ALLOWLISTED_COMPONENT_PATHS.includes(relativePath)) {
+      return {};
+    }
+
+    return {
+      Program(node) {
+        context.report({
+          node,
+          messageId: 'notAllowlisted',
+          data: { relativePath },
+        });
+      },
+    };
+  },
+};

--- a/apps/web/eslint-rules/no-new-header-toolbar-components.test.ts
+++ b/apps/web/eslint-rules/no-new-header-toolbar-components.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for the no-new-header-toolbar-components ESLint rule.
+ *
+ * Warns (does not error) when a *Header.tsx / *Toolbar.tsx file under
+ * apps/web/components/** is not on the frozen allowlist. Existing files
+ * must stay silent; a new, non-allowlisted file must warn.
+ */
+
+import { createRequire } from 'node:module';
+import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const rule = require('./no-new-header-toolbar-components.js');
+
+RuleTester.describe = describe as typeof RuleTester.describe;
+RuleTester.it = it as typeof RuleTester.it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+ruleTester.run('no-new-header-toolbar-components', rule, {
+  valid: [
+    // Allowlisted existing file — silent
+    {
+      code: `export function DashboardHeader() { return null; }`,
+      filename:
+        '/repo/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx',
+    },
+    {
+      code: `export function PageToolbar() { return null; }`,
+      filename:
+        '/repo/apps/web/components/organisms/table/molecules/PageToolbar.tsx',
+    },
+    // Not a Header/Toolbar filename — never checked
+    {
+      code: `export function DashboardNav() { return null; }`,
+      filename:
+        '/repo/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx',
+    },
+    // Header/Toolbar filename outside apps/web/components — not checked
+    {
+      code: `export function SomeHeader() { return null; }`,
+      filename: '/repo/apps/web/lib/SomeHeader.tsx',
+    },
+    // Header/Toolbar filename outside apps/web entirely — not checked
+    {
+      code: `export function OtherHeader() { return null; }`,
+      filename: '/repo/apps/ios/components/OtherHeader.tsx',
+    },
+  ],
+
+  invalid: [
+    // New, non-allowlisted Header component
+    {
+      code: `export function BrandNewHeader() { return null; }`,
+      filename:
+        '/repo/apps/web/components/features/dashboard/organisms/BrandNewHeader.tsx',
+      errors: [{ messageId: 'notAllowlisted' }],
+    },
+    // New, non-allowlisted Toolbar component
+    {
+      code: `export function BrandNewToolbar() { return null; }`,
+      filename: '/repo/apps/web/components/molecules/BrandNewToolbar.tsx',
+      errors: [{ messageId: 'notAllowlisted' }],
+    },
+  ],
+});

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -22,6 +22,7 @@ const clerkOauthOptionsMustIncludePromptRule = require('./eslint-rules/clerk-oau
 const chatToolSchemaStrictRule = require('./eslint-rules/chat-tool-schema-strict');
 const canonicalUiLabelCasingRule = require('./eslint-rules/canonical-ui-label-casing');
 const noHardcodedThemeColorsRule = require('./eslint-rules/no-hardcoded-theme-colors');
+const noNewHeaderToolbarComponentsRule = require('./eslint-rules/no-new-header-toolbar-components');
 
 const [nextBase, nextTypescript, nextIgnores] = nextConfig;
 
@@ -52,6 +53,7 @@ const baseConfig = {
         'chat-tool-schema-strict': chatToolSchemaStrictRule,
         'canonical-ui-label-casing': canonicalUiLabelCasingRule,
         'no-hardcoded-theme-colors': noHardcodedThemeColorsRule,
+        'no-new-header-toolbar-components': noNewHeaderToolbarComponentsRule,
       },
     },
   },
@@ -215,6 +217,9 @@ const baseConfig = {
     // Contrast guardrail — bare text-black/bg-white without dark: counterpart (JOV-11038)
     // error at author time; contrast-ratchet counts legacy debt in CI (JOV-3572)
     '@jovie/no-hardcoded-theme-colors': 'error',
+    // Freeze the header/toolbar component zoo ahead of the One App Shell
+    // refactor — warn only, see eslint-rules/no-new-header-toolbar-components.js
+    '@jovie/no-new-header-toolbar-components': 'warn',
   },
 };
 


### PR DESCRIPTION
## What
Guardrail chunk ahead of the One App Shell refactor swarm — no behavior changes.

1. **Nav IA snapshot test** (`config.test.ts`): inline-snapshot projection of `{ id, label, href, order }` for `primaryNavigation`, `mobilePrimaryNavigation`, `mobileExpandedNavigation`, `userSettingsNavigation`, and `artistSettingsNavigation`. Any label/href/order change now surfaces as an explicit snapshot diff in review instead of a silent drift.
2. **Header/toolbar lint guardrail** (`eslint-rules/no-new-header-toolbar-components.js`, registered as `@jovie/no-new-header-toolbar-components: 'warn'`): warns when a new `*Header.tsx`/`*Toolbar.tsx` file is added under `apps/web/components/**` and isn't on the seeded allowlist. Allowlist was seeded from a full grep of the current tree (28 existing files, not the ~9 the manifest estimated) so the count is frozen, not broken.

## Why
Freezes both the nav IA and the header/toolbar component count *before* the refactor swarm starts touching these surfaces, so drift during the swarm becomes a reviewable diff instead of an invisible regression. Part of #12633 (One App Shell), closes partial #12645.

## Verification
```
pnpm --filter web exec vitest run components/features/dashboard/dashboard-nav/config.test.ts eslint-rules/no-new-header-toolbar-components.test.ts
# Test Files  2 passed (2) / Tests  14 passed (14)

pnpm --filter @jovie/web run typecheck -- --pretty false
# exit 0, no errors

pnpm biome check --write <touched files>
# clean

# pre-commit hook ran: eslint --config apps/web/eslint.config.js --max-warnings=0 ...
# COMPLETED — confirms the new warn rule fires zero false positives on the
# staged files (including the allowlisted existing dashboard-nav files it scoped).
```

Note: the full-repo `pnpm --filter web lint:eslint` run was attempted twice locally but exceeded 30 minutes and was killed — this worktree is one of ~7 concurrent worktrees on the same machine competing for CPU during a parallel swarm, not a regression from this change. Scoped eslint runs against the touched files and a spot-check of 4 real allowlisted `*Header.tsx`/`*Toolbar.tsx` files (`AdminCreatorsTableHeader.tsx`, `Header.tsx`, `PageToolbar.tsx`, `DashboardHeader.tsx`) confirm the new rule produces zero warnings on existing code. CI will run the full lint on a clean runner.

## HOT ZONE
Stayed entirely within the assigned zone:
- `apps/web/components/features/dashboard/dashboard-nav/config.test.ts`
- `apps/web/eslint-rules/no-new-header-toolbar-components.{js,test.ts}` (new)
- `apps/web/eslint.config.js` (rule registration only)

No `.claude/rules/*` HOT ZONE escapes or blockers.