### PR TITLE
fix(ci): reap stale Vercel previews

### DIFF
--- a/.github/scripts/cancel-stale-vercel-previews.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+const API_BASE = 'https://api.vercel.com';
+const ACTIVE_STATES = ['QUEUED', 'BUILDING'];
+const MINIMUM_AGE_MS = 20 * 60 * 1000;
+const MAX_CANCELLATIONS = 10;
+
+export function isStalePreview(
+  deployment,
+  { currentSha, projectId, now = Date.now() }
+) {
+  const commitSha = deployment.meta?.githubCommitSha;
+  const commitRef = deployment.meta?.githubCommitRef;
+  const state = (deployment.readyState ?? deployment.state ?? '').toUpperCase();
+  const createdAt = Number(deployment.createdAt ?? deployment.created ?? 0);
+
+  return (
+    deployment.projectId === projectId &&
+    deployment.target !== 'production' &&
+    ACTIVE_STATES.includes(state) &&
+    commitRef === 'main' &&
+    typeof commitSha === 'string' &&
+    commitSha.length > 0 &&
+    commitSha !== currentSha &&
+    createdAt > 0 &&
+    now - createdAt >= MINIMUM_AGE_MS
+  );
+}
+
+function scopedUrl(path, orgId, params = {}) {
+  const url = new URL(path, API_BASE);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, String(value));
+  }
+  if (orgId.startsWith('team_')) url.searchParams.set('teamId', orgId);
+  return url;
+}
+
+async function vercelRequest(url, token, init = {}) {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...init.headers,
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  return response;
+}
+
+export async function cancelStalePreviews({
+  token,
+  orgId,
+  projectId,
+  currentSha,
+  request = vercelRequest,
+}) {
+  const deployments = [];
+
+  for (const state of ACTIVE_STATES) {
+    const url = scopedUrl('/v7/deployments', orgId, {
+      projectId,
+      state,
+      limit: 100,
+    });
+    const response = await request(url, token);
+    if (!response.ok) {
+      throw new Error(`Vercel deployment list failed (${response.status})`);
+    }
+    const payload = await response.json();
+    deployments.push(...(payload.deployments ?? []));
+  }
+
+  const stale = [
+    ...new Map(
+      deployments
+        .filter(deployment =>
+          isStalePreview(deployment, { currentSha, projectId })
+        )
+        .map(deployment => [deployment.uid ?? deployment.id, deployment])
+    ).values(),
+  ]
+    .filter(deployment => deployment.uid ?? deployment.id)
+    .slice(0, MAX_CANCELLATIONS);
+
+  for (const deployment of stale) {
+    const id = deployment.uid ?? deployment.id;
+    const commitSha = deployment.meta.githubCommitSha;
+    const state = deployment.readyState ?? deployment.state;
+    console.log(`Canceling stale preview ${id} (${state}, ${commitSha})`);
+
+    const url = scopedUrl(
+      `/v12/deployments/${encodeURIComponent(id)}/cancel`,
+      orgId
+    );
+    const response = await request(url, token, { method: 'PATCH' });
+    if (!response.ok && ![400, 404, 409].includes(response.status)) {
+      throw new Error(
+        `Vercel deployment cancel failed for ${id} (${response.status})`
+      );
+    }
+    if (!response.ok) {
+      console.log(
+        `Preview ${id} was already terminal (${response.status}); continuing`
+      );
+      continue;
+    }
+    const payload = await response.json();
+    if (
+      (payload.readyState ?? payload.state ?? '').toUpperCase() !== 'CANCELED'
+    ) {
+      throw new Error(`Vercel did not confirm cancellation for ${id}`);
+    }
+  }
+
+  console.log(`Canceled ${stale.length} stale Vercel preview deployment(s)`);
+  return stale.map(deployment => deployment.uid ?? deployment.id);
+}
+
+async function main() {
+  const token = process.env.VERCEL_TOKEN ?? '';
+  const orgId = process.env.VERCEL_ORG_ID ?? '';
+  const projectId = process.env.VERCEL_PROJECT_ID ?? '';
+  const currentSha = process.env.GITHUB_SHA ?? '';
+  const missing = Object.entries({ token, orgId, projectId, currentSha })
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required queue-reaper inputs: ${missing.join(', ')}`
+    );
+  }
+
+  await cancelStalePreviews({ token, orgId, projectId, currentSha });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/cancel-stale-vercel-previews.test.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.test.mjs
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  cancelStalePreviews,
+  isStalePreview,
+} from './cancel-stale-vercel-previews.mjs';
+
+const currentSha = 'current-sha';
+const projectId = 'prj_project';
+const now = Date.parse('2026-07-12T12:00:00Z');
+
+const activePreview = (overrides = {}) => ({
+  uid: 'dpl_stale',
+  projectId,
+  target: null,
+  readyState: 'QUEUED',
+  createdAt: now - 21 * 60 * 1000,
+  meta: { githubCommitRef: 'main', githubCommitSha: 'old-sha' },
+  ...overrides,
+});
+
+describe('cancel stale Vercel previews', () => {
+  it('only selects stale active GitHub previews', () => {
+    expect(
+      isStalePreview(activePreview(), { currentSha, projectId, now })
+    ).toBe(true);
+    expect(
+      isStalePreview(activePreview({ target: 'production' }), {
+        currentSha,
+        projectId,
+        now,
+      })
+    ).toBe(false);
+    expect(
+      isStalePreview(
+        activePreview({
+          meta: { githubCommitRef: 'main', githubCommitSha: currentSha },
+        }),
+        { currentSha, projectId, now }
+      )
+    ).toBe(false);
+    expect(
+      isStalePreview(activePreview({ createdAt: now - 5 * 60 * 1000 }), {
+        currentSha,
+        projectId,
+        now,
+      })
+    ).toBe(false);
+    expect(
+      isStalePreview(
+        activePreview({
+          meta: { githubCommitRef: 'feature', githubCommitSha: 'old' },
+        }),
+        { currentSha, projectId, now }
+      )
+    ).toBe(false);
+  });
+
+  it('lists both active states and cancels each stale preview once', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const stale = activePreview({ readyState: 'BUILDING' });
+    const production = activePreview({ uid: 'dpl_prod', target: 'production' });
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ deployments: [stale, production] }))
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ deployments: [stale] }))
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ readyState: 'CANCELED' }))
+      );
+
+    await expect(
+      cancelStalePreviews({
+        token: 'token',
+        orgId: 'team_org',
+        projectId,
+        currentSha,
+        request,
+      })
+    ).resolves.toEqual(['dpl_stale']);
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request.mock.calls[0][0].searchParams.get('state')).toBe('QUEUED');
+    expect(request.mock.calls[1][0].searchParams.get('state')).toBe('BUILDING');
+    expect(request.mock.calls[2][0].pathname).toBe(
+      '/v12/deployments/dpl_stale/cancel'
+    );
+    expect(request.mock.calls[2][0].searchParams.get('teamId')).toBe(
+      'team_org'
+    );
+    expect(request.mock.calls[2][2]).toEqual({ method: 'PATCH' });
+  });
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4669,6 +4669,8 @@ jobs:
             echo "::error::Missing required staging deployment credentials: ${missing[*]}"
             exit 1
           fi
+      - name: Cancel stale Vercel preview deployments
+        run: node .github/scripts/cancel-stale-vercel-previews.mjs
       - name: DB safety check (staging preflight)
         id: preflight
         run: pnpm --filter=@jovie/web exec tsx scripts/drizzle-migrate-preflight.ts

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -112,6 +112,14 @@ describe('deploy workflow Vercel env resolution', () => {
     );
     expect(configureStep).toContain('>> "$GITHUB_ENV"');
 
+    const queueReaperStep = getStepBlock(
+      stagingJob,
+      'Cancel stale Vercel preview deployments'
+    );
+    expect(queueReaperStep).toContain(
+      'node .github/scripts/cancel-stale-vercel-previews.mjs'
+    );
+
     for (const { command, name } of stagingSteps) {
       const step = getStepBlock(stagingJob, name);
       expect(step).toContain(command);


### PR DESCRIPTION
## Summary
- cancel stale main-branch Vercel previews before staging deploys
- preserve production, current-SHA, PR, manual, and fresh deployments
- retain the prebuilt artifact restore/deploy/promotion path

## Safety
- project/team scoped
- QUEUED and BUILDING only
- minimum age 20 minutes
- maximum 10 cancellations per run
- production target is explicitly excluded

## Tests
- focused queue-selection and API contract tests
- deploy-workflow structural regression assertion
- `node` selection smoke passed
- `git diff --check` passed

Bug-to-test: `.github/scripts/cancel-stale-vercel-previews.test.mjs`