### PR TITLE
feat(shell): 6-item nav IA with Inbox as named home

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -36,13 +36,8 @@ import { useChatConversationsQuery } from '@/lib/queries/useChatConversationsQue
 import { useTaskStatsQuery } from '@/lib/queries/useTasksQuery';
 import {
   adminNavigationSections,
-  artistProfileNavItem,
   artistSettingsNavigation,
-  inboxNavItem,
-  newThreadNavItem,
   primaryNavigation,
-  releasesNavItem,
-  touringNavItem,
   userSettingsNavigation,
 } from './config';
 import { NavMenuItem } from './NavMenuItem';
@@ -78,6 +73,13 @@ function isReleasesRoute(pathname: string): boolean {
 }
 
 function isItemActive(pathname: string, item: NavItem): boolean {
+  if (item.id === 'inbox') {
+    // Inbox is the named home at exactly `/app` — it must not stay active
+    // on every `/app/*` subroute the generic prefix-match below would
+    // otherwise catch (GH #12634).
+    return normalizeTrailingSlash(pathname) === APP_ROUTES.DASHBOARD;
+  }
+
   if (item.id === 'releases') {
     return isReleasesRoute(pathname);
   }
@@ -230,7 +232,17 @@ export function DashboardNav(_: DashboardNavProps) {
   const artistSettingsLabel =
     shellChatV1Enabled || isInSettings ? 'Artist' : artistName || 'Artist';
 
-  // Memoize nav sections for dashboard (non-settings) mode
+  // Memoize nav sections for dashboard (non-settings) mode.
+  //
+  // Canonical 6-item nav IA (GH #12634 taste decision / #12640): Inbox,
+  // Chat, Library, Contacts, Calendar, Tasks. `primaryNavigation` in
+  // config.ts is the single source of truth for order/labels/routes; Inbox
+  // is filtered out here (rather than in config.ts) while the `INBOX_HOME`
+  // rollout flag is off, so nav and the /app page title/copy
+  // (OpportunityInboxPageClient) never drift out of sync mid-rollout.
+  // Search is a command-palette trigger, not a nav destination, so it isn't
+  // part of the canonical 6 — it renders alongside them, immediately after
+  // Chat, matching its previous position.
   const navSections = useMemo<readonly DashboardNavSection[]>(() => {
     const decorateItem = (item: NavItem): NavItem => {
       if (item.id === 'tasks') {
@@ -249,61 +261,30 @@ export function DashboardNav(_: DashboardNavProps) {
         };
       }
 
-      if (shellChatV1Enabled && !isInSettings && item.id === 'artist-profile') {
-        return {
-          ...item,
-          name: artistName || item.name,
-          href: APP_ROUTES.CHAT_PROFILE_PANEL,
-        };
-      }
-
       return item;
     };
 
-    const audienceItem = primaryNavigation.find(item => item.id === 'audience');
-    const tasksItem = primaryNavigation.find(item => item.id === 'tasks');
+    const canonicalItems = (
+      inboxHomeEnabled
+        ? primaryNavigation
+        : primaryNavigation.filter(item => item.id !== 'inbox')
+    ).map(decorateItem);
 
-    if (shellChatV1Enabled) {
-      return [
-        {
-          key: 'top',
-          items: [
-            ...(inboxHomeEnabled ? [decorateItem(inboxNavItem)] : []),
-            decorateItem(newThreadNavItem),
+    const chatIndex = canonicalItems.findIndex(item => item.id === 'chat');
+    const items =
+      chatIndex === -1
+        ? [...canonicalItems, searchNavItem]
+        : [
+            ...canonicalItems.slice(0, chatIndex + 1),
             searchNavItem,
-            decorateItem(releasesNavItem),
-          ],
-        },
-        {
-          key: 'artist',
-          label: artistSettingsLabel,
-          items: [
-            decorateItem(artistProfileNavItem),
-            decorateItem(touringNavItem),
-            ...(audienceItem ? [decorateItem(audienceItem)] : []),
-            ...(tasksItem ? [decorateItem(tasksItem)] : []),
-          ],
-        },
-      ];
-    }
+            ...canonicalItems.slice(chatIndex + 1),
+          ];
 
-    return [
-      {
-        key: 'primary',
-        items: [
-          ...(inboxHomeEnabled ? [decorateItem(inboxNavItem)] : []),
-          ...primaryNavigation.map(decorateItem),
-        ],
-      },
-    ];
+    return [{ key: 'primary', items }];
   }, [
     canAccessTasksWorkspace,
     isPlanGateLoading,
-    artistName,
-    artistSettingsLabel,
     inboxHomeEnabled,
-    isInSettings,
-    shellChatV1Enabled,
     taskStats,
     tasksSeenAt,
   ]);

--- a/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
@@ -66,27 +66,27 @@ describe('nav IA snapshot', () => {
     expect(toSnapshotProjection(primaryNavigation)).toMatchInlineSnapshot(`
       [
         {
+          "href": "/app",
+          "id": "inbox",
+          "label": "Inbox",
+          "order": 0,
+        },
+        {
           "href": "/app/chat",
           "id": "chat",
-          "label": "New Chat",
-          "order": 0,
+          "label": "Chat",
+          "order": 1,
         },
         {
           "href": "/app/library?view=releases",
           "id": "releases",
-          "label": "Releases",
-          "order": 1,
-        },
-        {
-          "href": "/app/settings/artist-profile",
-          "id": "artist-profile",
-          "label": "Artist Profile",
+          "label": "Library",
           "order": 2,
         },
         {
-          "href": "/app/settings/touring",
-          "id": "touring",
-          "label": "Touring",
+          "href": "/app/contacts",
+          "id": "contacts",
+          "label": "Contacts",
           "order": 3,
         },
         {
@@ -101,12 +101,6 @@ describe('nav IA snapshot', () => {
           "label": "Tasks",
           "order": 5,
         },
-        {
-          "href": "/app/audience",
-          "id": "audience",
-          "label": "Audience",
-          "order": 6,
-        },
       ]
     `);
   });
@@ -119,19 +113,19 @@ describe('nav IA snapshot', () => {
         {
           "href": "/app/chat",
           "id": "chat",
-          "label": "New Chat",
+          "label": "Chat",
           "order": 0,
         },
         {
           "href": "/app/library?view=releases",
           "id": "releases",
-          "label": "Releases",
+          "label": "Library",
           "order": 1,
         },
         {
-          "href": "/app/audience",
-          "id": "audience",
-          "label": "Audience",
+          "href": "/app/tasks",
+          "id": "tasks",
+          "label": "Tasks",
           "order": 2,
         },
       ]
@@ -156,15 +150,15 @@ describe('nav IA snapshot', () => {
           "order": 1,
         },
         {
-          "href": "/app/calendar",
-          "id": "calendar",
-          "label": "Calendar",
+          "href": "/app/contacts",
+          "id": "contacts",
+          "label": "Contacts",
           "order": 2,
         },
         {
-          "href": "/app/tasks",
-          "id": "tasks",
-          "label": "Tasks",
+          "href": "/app/calendar",
+          "id": "calendar",
+          "label": "Calendar",
           "order": 3,
         },
         {

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -64,7 +64,7 @@ export const inboxNavItem: NavItem = {
 };
 
 export const newThreadNavItem: NavItem = {
-  name: 'New Chat',
+  name: 'Chat',
   href: APP_ROUTES.CHAT,
   id: 'chat',
   icon: SquarePen,
@@ -80,7 +80,7 @@ export const profileNavItem: NavItem = {
 };
 
 export const releasesNavItem: NavItem = {
-  name: 'Releases',
+  name: 'Library',
   href: buildLibraryViewRoute('releases'),
   id: 'releases',
   icon: Music,
@@ -107,37 +107,45 @@ export const touringNavItem: NavItem = {
   description: 'Manage tour dates and touring settings',
 };
 
+export const contactsNavItem: NavItem = {
+  name: 'Contacts',
+  href: APP_ROUTES.CONTACTS,
+  id: 'contacts',
+  icon: IdCard,
+  description: 'Manage contacts, collaborators, and press relationships',
+};
+
+export const calendarNavItem: NavItem = {
+  name: 'Calendar',
+  href: APP_ROUTES.CALENDAR,
+  id: 'calendar',
+  icon: CalendarDays,
+  description: 'See release dates, events, and calendar moments',
+};
+
+export const tasksNavItem: NavItem = {
+  name: 'Tasks',
+  href: APP_ROUTES.TASKS,
+  id: 'tasks',
+  icon: CheckSquare,
+  description: 'Track release work and general artist operations',
+};
+
+/**
+ * Canonical 6-item nav IA (GH #12634 taste decision / #12640): Inbox is the
+ * named home and appears first. Consumers gate Inbox's presence on the
+ * `INBOX_HOME` rollout flag (see DashboardNav) rather than filtering it out
+ * of this array, so this list stays the single source of truth for the
+ * target IA order even while Inbox is mid-rollout.
+ */
 export const primaryNavigation: NavItem[] = [
+  inboxNavItem,
   newThreadNavItem,
   releasesNavItem,
-  artistProfileNavItem,
-  touringNavItem,
-  {
-    name: 'Calendar',
-    href: APP_ROUTES.CALENDAR,
-    id: 'calendar',
-    icon: CalendarDays,
-    description: 'See release dates, events, and calendar moments',
-  },
-  {
-    name: 'Tasks',
-    href: APP_ROUTES.TASKS,
-    id: 'tasks',
-    icon: CheckSquare,
-    description: 'Track release work and general artist operations',
-  },
-  {
-    name: 'Audience',
-    href: APP_ROUTES.AUDIENCE,
-    id: 'audience',
-    icon: Users,
-    description: 'Understand your audience demographics',
-  },
+  contactsNavItem,
+  calendarNavItem,
+  tasksNavItem,
 ];
-
-export const calendarNavItem = primaryNavigation.find(
-  item => item.id === 'calendar'
-)!;
 
 export const settingsNavItem: NavItem = {
   name: 'Settings',
@@ -309,15 +317,23 @@ export const adminNavigationSections: AdminNavSection[] = [
  */
 export const mobilePrimaryNavigation: NavItem[] = [
   newThreadNavItem,
-  primaryNavigation.find(i => i.id === 'releases')!,
-  primaryNavigation.find(i => i.id === 'audience')!,
+  releasesNavItem,
+  tasksNavItem,
 ];
 
-/** Items shown in the expanded "more" menu on mobile. */
+/**
+ * Items shown in the expanded "more" menu on mobile.
+ *
+ * Inbox is intentionally excluded from both mobile lists for now — the
+ * bottom bar is computed once at module load (no flag read), so it cannot
+ * mirror desktop's `INBOX_HOME` rollout gating yet. Wiring Inbox into mobile
+ * is deeper mobile work tracked separately (chunk 1.5 of the One App Shell
+ * program, GH #12633).
+ */
 export const mobileExpandedNavigation: NavItem[] = [
   artistProfileNavItem,
   touringNavItem,
+  contactsNavItem,
   calendarNavItem,
-  primaryNavigation.find(i => i.id === 'tasks')!,
   settingsNavItem,
 ];

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -7,8 +7,6 @@ import { OPEN_COMMAND_PALETTE_EVENT } from '@/components/organisms/command-palet
 import { APP_ROUTES, buildLibraryViewRoute } from '@/constants/routes';
 import {
   mockClearPendingShell,
-  mockOpenPreviewPanel,
-  mockRouterPush,
   mockShowPendingShell,
   mockToastInfo,
   mockUseChatConversationsQuery,
@@ -49,44 +47,48 @@ describe('DashboardNav interactions', () => {
     resetDashboardNavTestMocks();
   });
 
-  it('renders the full primary navigation config', () => {
+  it('renders the canonical 6-item primary nav config', () => {
     renderDashboardNav({ renderFn: render });
 
-    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Chat' })).toHaveAttribute(
       'href',
       APP_ROUTES.CHAT
     );
-    expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Library' })).toHaveAttribute(
       'href',
       buildLibraryViewRoute('releases')
     );
-    expect(
-      screen.getByRole('button', { name: 'Artist Profile' })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Contacts' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.CONTACTS
+    );
+    expect(screen.getByRole('link', { name: 'Calendar' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.CALENDAR
+    );
+    expect(screen.getByRole('link', { name: 'Tasks' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.TASKS
+    );
+    // Demoted from the primary 6-item IA (GH #12634) — no longer nav rows.
+    expect(screen.queryByRole('button', { name: 'Artist Profile' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Artist Profile' })).toBeNull();
-    expect(screen.getByRole('link', { name: 'Touring' })).toHaveAttribute(
-      'href',
-      APP_ROUTES.SETTINGS_TOURING
-    );
-    expect(screen.getByRole('link', { name: 'Audience' })).toHaveAttribute(
-      'href',
-      APP_ROUTES.AUDIENCE
-    );
+    expect(screen.queryByRole('link', { name: 'Touring' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Audience' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Profile' })).toBeNull();
-    expect(screen.queryByRole('link', { name: 'Library' })).toBeNull();
   });
 
-  it('keeps Releases in the grouped top navigation when the design flag is enabled', () => {
+  it('keeps Library in the grouped top navigation when the design flag is enabled', () => {
     renderDashboardNav({
       renderFn: render,
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Library' })).toHaveAttribute(
       'href',
       buildLibraryViewRoute('releases')
     );
-    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Chat' })).toHaveAttribute(
       'href',
       APP_ROUTES.CHAT
     );
@@ -114,22 +116,7 @@ describe('DashboardNav interactions', () => {
 
     renderDashboardNav({ renderFn: render });
 
-    expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
-      'aria-current',
-      'page'
-    );
-  });
-
-  it('highlights the canonical Audience nav item from the legacy dashboard path', () => {
-    mockUsePathname.mockReturnValueOnce(APP_ROUTES.DASHBOARD_AUDIENCE);
-
-    renderDashboardNav({ renderFn: render });
-
-    expect(screen.getByRole('link', { name: 'Audience' })).toHaveAttribute(
-      'href',
-      APP_ROUTES.AUDIENCE
-    );
-    expect(screen.getByRole('link', { name: 'Audience' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Library' })).toHaveAttribute(
       'aria-current',
       'page'
     );
@@ -138,37 +125,15 @@ describe('DashboardNav interactions', () => {
   it('exposes icon and label content for each navigation item', () => {
     renderDashboardNav({ renderFn: render });
 
-    const releasesLink = screen.getByRole('link', { name: 'Releases' });
+    const releasesLink = screen.getByRole('link', { name: 'Library' });
     // In the new shell nav design (DESIGN_V1 on by default), the icon is rendered
     // directly as an SVG element rather than inside a data-sidebar-icon wrapper span.
     const iconNode = releasesLink.querySelector('svg');
     const labelNode = releasesLink.querySelector('span.truncate');
 
     expect(iconNode).toBeTruthy();
-    expect(labelNode).toHaveTextContent('Releases');
+    expect(labelNode).toHaveTextContent('Library');
     expect(labelNode).toHaveClass('group-data-[collapsible=icon]:hidden');
-  });
-
-  it('opens the in-chat profile rail from the artist name on chat routes', async () => {
-    const user = userEvent.setup();
-    mockUsePathname.mockReturnValueOnce(APP_ROUTES.CHAT);
-    renderDashboardNav({
-      renderFn: render,
-      appFlags: { DESIGN_V1: true },
-      overrides: {
-        selectedProfile: {
-          id: 'profile_123',
-          displayName: 'Tim White',
-          username: 'tim',
-          usernameNormalized: 'tim',
-        } as DashboardData['selectedProfile'],
-      },
-    });
-
-    await user.click(screen.getByRole('button', { name: 'Tim White' }));
-
-    expect(mockOpenPreviewPanel).toHaveBeenCalledTimes(1);
-    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
   it('opens command search from the Design V1 sidebar search row', async () => {
@@ -201,7 +166,7 @@ describe('DashboardNav interactions', () => {
     expect(screen.getByLabelText('Command palette search')).toBeInTheDocument();
   });
 
-  it('groups the Design V1 shell into top nav and artist sections without duplicate Settings', () => {
+  it('renders the flat Design V1 primary nav section without duplicate Settings', () => {
     const { container } = renderDashboardNav({
       renderFn: render,
       appFlags: { DESIGN_V1: true },
@@ -222,27 +187,16 @@ describe('DashboardNav interactions', () => {
     expect(screen.queryByRole('button', { name: 'Growth' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'More' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Settings' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Artist' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Releases' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Artist' })).toHaveAttribute(
-      'aria-expanded',
-      'true'
-    );
-    expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Library' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Library' })).toHaveAttribute(
       'href',
       buildLibraryViewRoute('releases')
     );
-    expect(
-      screen.getByRole('button', { name: 'Tim White' })
-    ).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'Tim White' })).toBeNull();
-    expect(screen.getByRole('link', { name: 'Touring' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Contacts' })).toHaveAttribute(
       'href',
-      APP_ROUTES.SETTINGS_TOURING
-    );
-    expect(screen.getByRole('link', { name: 'Audience' })).toHaveAttribute(
-      'href',
-      APP_ROUTES.AUDIENCE
+      APP_ROUTES.CONTACTS
     );
     expect(container.querySelector('[data-nav-section="more"]')).toBeNull();
   });
@@ -313,30 +267,8 @@ describe('DashboardNav interactions', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(screen.getAllByRole('link', { name: 'New Chat' })).toHaveLength(1);
-    expect(screen.queryByRole('button', { name: 'New Chat' })).toBeNull();
-  });
-
-  it('navigates to chat and opens the profile rail from artist name off chat routes', async () => {
-    const user = userEvent.setup();
-    mockUsePathname.mockReturnValueOnce(APP_ROUTES.AUDIENCE);
-    renderDashboardNav({
-      renderFn: render,
-      appFlags: { DESIGN_V1: true },
-      overrides: {
-        selectedProfile: {
-          id: 'profile_123',
-          displayName: 'Tim White',
-          username: 'tim',
-          usernameNormalized: 'tim',
-        } as DashboardData['selectedProfile'],
-      },
-    });
-
-    await user.click(screen.getByRole('button', { name: 'Tim White' }));
-
-    expect(mockRouterPush).toHaveBeenCalledWith(APP_ROUTES.CHAT);
-    expect(mockOpenPreviewPanel).toHaveBeenCalledTimes(1);
+    expect(screen.getAllByRole('link', { name: 'Chat' })).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: 'Chat' })).toBeNull();
   });
 
   it('shows the releases pending shell once for a pointer click', async () => {
@@ -344,7 +276,7 @@ describe('DashboardNav interactions', () => {
 
     renderDashboardNav({ renderFn: render });
 
-    const releasesLink = screen.getByRole('link', { name: 'Releases' });
+    const releasesLink = screen.getByRole('link', { name: 'Library' });
     releasesLink.addEventListener('click', event => event.preventDefault());
 
     await user.click(releasesLink);
@@ -359,7 +291,7 @@ describe('DashboardNav interactions', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.RELEASES);
     renderDashboardNav({ renderFn: render });
 
-    const releasesLink = screen.getByRole('link', { name: 'Releases' });
+    const releasesLink = screen.getByRole('link', { name: 'Library' });
     releasesLink.addEventListener('click', event => event.preventDefault());
 
     await user.click(releasesLink);
@@ -371,7 +303,7 @@ describe('DashboardNav interactions', () => {
   it('does not hijack modified releases link clicks', async () => {
     renderDashboardNav({ renderFn: render });
 
-    const releasesLink = screen.getByRole('link', { name: 'Releases' });
+    const releasesLink = screen.getByRole('link', { name: 'Library' });
     releasesLink.addEventListener('click', event => event.preventDefault());
     fireEvent.pointerDown(releasesLink, {
       button: 0,

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -19,79 +19,74 @@ describe('DashboardNav', () => {
     resetDashboardNavTestMocks();
   });
 
-  it('renders primary navigation items', () => {
+  it('renders the canonical 6-item nav IA (GH #12634)', () => {
     const { getByRole, queryByRole } = renderDashboardNav({
       renderFn: fastRender,
     });
 
-    expect(getByRole('link', { name: 'New Chat' }).getAttribute('href')).toBe(
+    expect(getByRole('link', { name: 'Chat' }).getAttribute('href')).toBe(
       APP_ROUTES.CHAT
     );
     expect(getByRole('button', { name: 'Search' })).toBeDefined();
-    expect(getByRole('link', { name: 'Releases' }).getAttribute('href')).toBe(
+    expect(getByRole('link', { name: 'Library' }).getAttribute('href')).toBe(
       buildLibraryViewRoute('releases')
     );
-    expect(getByRole('button', { name: 'Artist Profile' })).toBeDefined();
-    expect(getByRole('link', { name: 'Touring' }).getAttribute('href')).toBe(
-      APP_ROUTES.SETTINGS_TOURING
+    expect(getByRole('link', { name: 'Contacts' }).getAttribute('href')).toBe(
+      APP_ROUTES.CONTACTS
+    );
+    expect(getByRole('link', { name: 'Calendar' }).getAttribute('href')).toBe(
+      APP_ROUTES.CALENDAR
     );
     expect(getByRole('link', { name: 'Tasks' }).getAttribute('href')).toBe(
       APP_ROUTES.TASKS
     );
-    expect(getByRole('link', { name: 'Audience' })).toBeDefined();
-    expect(queryByRole('link', { name: 'Calendar' })).toBeNull();
-    expect(queryByRole('link', { name: 'Library' })).toBeNull();
+    // Inbox is behind the INBOX_HOME rollout flag (default off) — not
+    // rendered without it.
+    expect(queryByRole('link', { name: 'Inbox' })).toBeNull();
+    // Demoted from the primary 6-item IA — no longer primary nav rows.
+    expect(queryByRole('link', { name: 'Audience' })).toBeNull();
+    expect(queryByRole('button', { name: 'Artist Profile' })).toBeNull();
+    expect(queryByRole('link', { name: 'Touring' })).toBeNull();
     expect(queryByRole('link', { name: 'Earnings' })).toBeNull();
   });
 
-  it('renders Releases in the grouped shell top nav', () => {
+  it('renders Inbox first when INBOX_HOME is enabled', () => {
+    const { getByRole, getAllByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      appFlags: { INBOX_HOME: true },
+    });
+
+    expect(getByRole('link', { name: 'Inbox' }).getAttribute('href')).toBe(
+      APP_ROUTES.DASHBOARD
+    );
+
+    const links = getAllByRole('link');
+    const primaryLabels = links
+      .map(link => link.textContent)
+      .filter((label): label is string =>
+        ['Inbox', 'Chat', 'Library', 'Contacts', 'Calendar', 'Tasks'].some(
+          canonical => label?.includes(canonical)
+        )
+      );
+    expect(primaryLabels[0]).toContain('Inbox');
+  });
+
+  it('keeps Library in the shell top nav', () => {
     const { getByRole } = renderDashboardNav({
       renderFn: fastRender,
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(getByRole('link', { name: 'Releases' }).getAttribute('href')).toBe(
+    expect(getByRole('link', { name: 'Library' }).getAttribute('href')).toBe(
       buildLibraryViewRoute('releases')
     );
-  });
-
-  it('renders artist work under the artist group in Design V1', () => {
-    const { getByRole, queryByRole } = renderDashboardNav({
-      renderFn: fastRender,
-      appFlags: { DESIGN_V1: true },
-      overrides: {
-        selectedProfile: {
-          id: 'profile_123',
-          displayName: 'Tim White',
-          username: 'tim',
-          usernameNormalized: 'tim',
-        } as DashboardData['selectedProfile'],
-      },
-    });
-
-    expect(getByRole('button', { name: 'Artist' })).toHaveAttribute(
-      'aria-expanded',
-      'true'
-    );
-    expect(getByRole('button', { name: 'Tim White' })).toBeDefined();
-    const releasesLink = getByRole('link', { name: 'Releases' });
-    expect(releasesLink.getAttribute('href')).toBe(
-      buildLibraryViewRoute('releases')
-    );
-    expect(releasesLink.className).toContain(
-      'grid-cols-[22px_minmax(0,1fr)_34px]'
-    );
-    expect(getByRole('link', { name: 'Touring' }).getAttribute('href')).toBe(
-      APP_ROUTES.SETTINGS_TOURING
-    );
-    expect(queryByRole('link', { name: 'Calendar' })).toBeNull();
   });
 
   it('applies active state to current page', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.LIBRARY);
     const { getByRole } = renderDashboardNav({ renderFn: fastRender });
 
-    const activeLink = getByRole('link', { name: 'Releases' });
+    const activeLink = getByRole('link', { name: 'Library' });
     expect(activeLink.getAttribute('aria-current')).toBe('page');
   });
 
@@ -99,14 +94,40 @@ describe('DashboardNav', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.DASHBOARD_RELEASES);
     const { getByRole } = renderDashboardNav({ renderFn: fastRender });
 
-    const releasesLink = getByRole('link', { name: 'Releases' });
+    const releasesLink = getByRole('link', { name: 'Library' });
     expect(releasesLink.getAttribute('href')).toBe(
       buildLibraryViewRoute('releases')
     );
     expect(releasesLink.getAttribute('aria-current')).toBe('page');
   });
 
-  it('only marks New Conversation active on the chat root', () => {
+  it('marks Inbox active only on exactly /app, not /app/* subroutes', () => {
+    mockUsePathname.mockReturnValueOnce(`${APP_ROUTES.DASHBOARD}/anything`);
+
+    const { getByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      appFlags: { INBOX_HOME: true },
+    });
+
+    expect(
+      getByRole('link', { name: 'Inbox' }).getAttribute('aria-current')
+    ).toBeNull();
+  });
+
+  it('marks Inbox active on exactly /app', () => {
+    mockUsePathname.mockReturnValueOnce(APP_ROUTES.DASHBOARD);
+
+    const { getByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      appFlags: { INBOX_HOME: true },
+    });
+
+    expect(
+      getByRole('link', { name: 'Inbox' }).getAttribute('aria-current')
+    ).toBe('page');
+  });
+
+  it('only marks Chat active on the chat root', () => {
     mockUsePathname.mockReturnValueOnce(`${APP_ROUTES.CHAT}/thread-123`);
 
     const { getByRole } = renderDashboardNav({
@@ -115,11 +136,11 @@ describe('DashboardNav', () => {
     });
 
     expect(
-      getByRole('link', { name: 'New Chat' }).getAttribute('aria-current')
+      getByRole('link', { name: 'Chat' }).getAttribute('aria-current')
     ).toBeNull();
   });
 
-  it('keeps New Conversation on the default shell tone when it is inactive', () => {
+  it('keeps Chat on the default shell tone when it is inactive', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.RELEASES);
 
     const { getByRole } = renderDashboardNav({
@@ -127,20 +148,20 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    const newThreadLink = getByRole('link', { name: 'New Chat' });
+    const newThreadLink = getByRole('link', { name: 'Chat' });
     expect(newThreadLink.className).toContain('text-sidebar-muted/80');
     expect(newThreadLink.className).not.toContain(
       'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)]'
     );
   });
 
-  it('renders one canonical New Conversation nav row in Design V1', () => {
+  it('renders one canonical Chat nav row in Design V1', () => {
     const { getAllByRole } = renderDashboardNav({
       renderFn: fastRender,
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(getAllByRole('link', { name: 'New Chat' })).toHaveLength(1);
+    expect(getAllByRole('link', { name: 'Chat' })).toHaveLength(1);
   });
 
   it('opens the global command palette from Search instead of navigating', () => {
@@ -219,7 +240,7 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    const newThreadLink = getByRole('link', { name: 'New Chat' });
+    const newThreadLink = getByRole('link', { name: 'Chat' });
     expect(newThreadLink.className).toContain(
       'group-data-[collapsible=icon]:justify-center'
     );
@@ -229,29 +250,29 @@ describe('DashboardNav', () => {
     });
   });
 
-  it('renders the grouped top nav and artist group without a duplicate Settings row', () => {
+  it('renders the flat 6-item primary nav without a duplicate Settings row', () => {
     const { getByRole, queryByRole } = renderDashboardNav({
       renderFn: fastRender,
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(getByRole('link', { name: 'New Chat' })).toHaveAttribute(
+    expect(getByRole('link', { name: 'Chat' })).toHaveAttribute(
       'href',
       APP_ROUTES.CHAT
     );
-    expect(getByRole('link', { name: 'Releases' })).toHaveAttribute(
+    expect(getByRole('link', { name: 'Library' })).toHaveAttribute(
       'href',
       buildLibraryViewRoute('releases')
     );
-    expect(getByRole('button', { name: 'Artist Profile' })).toBeDefined();
-    expect(getByRole('link', { name: 'Touring' })).toHaveAttribute(
+    expect(getByRole('link', { name: 'Contacts' })).toHaveAttribute(
       'href',
-      APP_ROUTES.SETTINGS_TOURING
+      APP_ROUTES.CONTACTS
     );
-    expect(getByRole('button', { name: 'Artist' })).toHaveAttribute(
-      'aria-expanded',
-      'true'
+    expect(getByRole('link', { name: 'Calendar' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.CALENDAR
     );
+    expect(queryByRole('button', { name: 'Artist' })).toBeNull();
     expect(queryByRole('button', { name: 'More' })).toBeNull();
     expect(queryByRole('link', { name: 'Settings' })).toBeNull();
     expect(queryByRole('button', { name: 'Work' })).toBeNull();
@@ -296,16 +317,7 @@ describe('DashboardNav', () => {
     );
   });
 
-  it('renders with different pathname', () => {
-    mockUsePathname.mockReturnValueOnce('/app/audience');
-
-    const { getByRole } = renderDashboardNav({ renderFn: fastRender });
-
-    const audienceLink = getByRole('link', { name: 'Audience' });
-    expect(audienceLink.getAttribute('aria-current')).toBe('page');
-  });
-
-  it('highlights Releases when the legacy library route is current', () => {
+  it('highlights Library when the legacy library route is current', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.DASHBOARD_LIBRARY);
 
     const { getByRole } = renderDashboardNav({
@@ -313,7 +325,7 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(getByRole('link', { name: 'Releases' })).toHaveAttribute(
+    expect(getByRole('link', { name: 'Library' })).toHaveAttribute(
       'aria-current',
       'page'
     );

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -39,6 +39,8 @@ const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
   '/app/settings/admin': 'Legacy admin settings route redirected to Ops',
   '/app/dashboard/release-plan':
     'Release plan demo page (gated by RELEASE_PLAN_DEMO flag)',
+  '/app/audience':
+    'Demoted from the primary nav by the 6-item IA (GH #12634); still reachable by direct link until a Settings/panel placement lands',
   '/app/insights':
     'AI insights workspace is reachable from dashboard widgets and direct app links until nav placement is finalised',
   '/app/jovie-work':


### PR DESCRIPTION
## What / why

Implements the approved target nav IA (GH #12634 taste decision): exactly 6 primary items — **Inbox, Chat, Library, Contacts, Calendar, Tasks** — with Inbox as the named home (`/app`).

- `primaryNavigation` in `dashboard-nav/config.ts` is rewritten to this canonical 6-item list/order and is now the single source of truth for both of `DashboardNav.tsx`'s previously-divergent render branches (the "flat" list and the "top nav + artist-name-labeled group" split, which are now unified into one flat section).
- Inbox is filtered in/out of the *rendered* list at the existing `INBOX_HOME` rollout flag boundary (default off in prod) rather than hardcoded unconditionally into the canonical array's render path — this keeps the sidebar and the `/app` page title/copy (`OpportunityInboxPageClient`, which already branches "Inbox" vs the legacy "Home — the inbox" string on the same flag) from drifting out of sync mid-rollout.
- Fixed an active-state bug: Inbox's href is `/app`, and the existing generic prefix-match (`pathname.startsWith(itemPathname + '/')`) would have kept Inbox highlighted on literally every `/app/*` route. Added an exact-match special case, matching the pattern already used for `releases`/`artist-profile`/`touring`.
- Renamed `New Chat` → `Chat` and `Releases` → `Library` to match the approved labels (routes unchanged).
- Added `Contacts` as a new primary nav item pointing at the existing `APP_ROUTES.CONTACTS` route.
- Demoted Artist Profile, Touring, and Audience out of the primary nav per the decision ("Artist row opens profile RAIL; Settings via user menu"). Routes are **not** deleted — `/app/audience` is still directly reachable and added to the `shell-nav-coverage` test's intentional-internal-routes allowlist. Artist Profile/Touring remain reachable via `artistSettingsNavigation` (Settings > Artist). Settings itself was never part of this component's primary nav — it's already served by the persistent user-menu button in `UnifiedSidebar.tsx`'s footer (untouched, out of this chunk's HOT ZONE), so there's no regression there.
- Search (command-palette trigger, not a page destination) stays rendered but outside the canonical 6-item array, immediately after Chat — same relative position as before.
- Mobile: `mobilePrimaryNavigation` now = Chat, Library, Tasks (Audience item removed, replaced with Tasks since it already ships a live badge); `mobileExpandedNavigation` gained Contacts, dropped Tasks (moved to primary). Inbox is intentionally **not** added to mobile in this chunk — `DashboardMobileTabs.tsx` computes its item list once at module load with no flag read, so it can't mirror desktop's `INBOX_HOME` gating without deeper changes; tracked as follow-up (see below).
- Updated the nav IA snapshot test (`config.test.ts`, added in chunk 0.1) intentionally to reflect the new canonical lists.

## Before / after nav table

| Slot | Before | After |
|---|---|---|
| 1 | New Chat (`/app/chat`) | **Inbox** (`/app`, behind `INBOX_HOME` flag) |
| 2 | Releases (`/app/library?view=releases`) | **Chat** (`/app/chat`) |
| 3 | Artist Profile (`/app/settings/artist-profile`) | **Library** (`/app/library?view=releases`) |
| 4 | Touring (`/app/settings/touring`) | **Contacts** (`/app/contacts`, new) |
| 5 | Calendar (`/app/calendar`) | **Calendar** (`/app/calendar`) |
| 6 | Tasks (`/app/tasks`) | **Tasks** (`/app/tasks`) |
| 7 | Audience (`/app/audience`) | *(removed — routes stay reachable by URL)* |

Search remains a persistent utility button immediately after Chat (unchanged position, not counted in the canonical 6).

## Follow-up (tracked, not in this PR)

Filed **#14206** for two deliberately deferred pieces of the #12634 decision:
1. Wiring a dedicated "artist row" (profile rail trigger) now that Artist Profile is out of the primary nav — `SidebarProfileButton.tsx`/`ProfileMenuActions.tsx` already exist unwired for this.
2. Making mobile's bottom tab bar `INBOX_HOME`-aware so Inbox can roll out to mobile too.

## Verification

```
pnpm --filter @jovie/web run typecheck -- --pretty false   # clean
pnpm biome check apps/web/components/features/dashboard/dashboard-nav apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx apps/web/tests/unit/dashboard/DashboardNav.test.tsx apps/web/tests/unit/routes/shell-nav-coverage.test.ts   # clean
pnpm --filter web exec vitest run components/features/dashboard/dashboard-nav/config.test.ts tests/unit/dashboard/DashboardNav.test.tsx tests/components/dashboard/DashboardNav.interaction.test.tsx tests/unit/routes/shell-nav-coverage.test.ts
# 4 files, 50/50 tests passing
pnpm --filter web exec vitest run components/features/dashboard tests/unit/dashboard tests/components/dashboard tests/unit/routes/shell-nav-coverage.test.ts
# 141 files, 745/746 passing (1 pre-existing skip, unrelated)
```

Layout-shift audit: nav item count changes from 7→6 (or 6→5 with the Inbox flag off); sidebar rows use fixed-height `SidebarMenuButton` rows with no reserved-space dependency on count, so no reflow/skeleton-mismatch risk. `AppShellSkeleton` was checked — it does not render a fixed nav item count, so no skeleton parity fix was needed.

Fixes #12634. Part of #12633 / #12640.