### PR TITLE
fix(shell): thread DESIGN_V1 variant into app/app/loading.tsx skeleton

### DIFF
--- a/apps/web/app/app/loading.tsx
+++ b/apps/web/app/app/loading.tsx
@@ -1,10 +1,23 @@
 import { AppShellSkeleton } from '@/components/organisms/AppShellSkeleton';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { getAppFlagValue } from '@/lib/flags/server';
 
 /**
  * App root loading screen
  * Renders a skeleton of the full app shell (sidebar + header + content)
  * to prevent layout shift while the server layout and data resolve.
+ *
+ * This is the Suspense fallback Next.js renders while
+ * `app/app/(shell)/layout.tsx` is still resolving, so it must resolve the
+ * same `DESIGN_V1` variant that layout will land on — otherwise flag-on
+ * users flash the legacy skeleton before the shellChatV1 frame mounts.
+ * `getCachedAuth()` is request-memoized (React `cache()`), so this doesn't
+ * add a second auth round-trip on top of the layout's own call. See #14187.
  */
-export default function AppLoading() {
-  return <AppShellSkeleton />;
+export default async function AppLoading() {
+  const auth = await getCachedAuth();
+  const shellChatV1 = await getAppFlagValue('DESIGN_V1', {
+    userId: auth.userId,
+  });
+  return <AppShellSkeleton variant={shellChatV1 ? 'shellChatV1' : 'legacy'} />;
 }

--- a/apps/web/tests/unit/app/app-loading-shell-variant.test.tsx
+++ b/apps/web/tests/unit/app/app-loading-shell-variant.test.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const getCachedAuthMock = vi.fn();
+const getAppFlagValueMock = vi.fn();
+
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: () => getCachedAuthMock(),
+}));
+
+vi.mock('@/lib/flags/server', () => ({
+  getAppFlagValue: (...args: unknown[]) => getAppFlagValueMock(...args),
+}));
+
+/**
+ * Regression test for #14187: `app/app/loading.tsx` is the Suspense
+ * fallback Next.js renders while `app/app/(shell)/layout.tsx` resolves, so
+ * it must thread the same resolved `DESIGN_V1` variant into
+ * `AppShellSkeleton` that the layout will land on. Before this fix it
+ * always rendered the 'legacy' skeleton regardless of the flag.
+ */
+describe('AppLoading (app/app/loading.tsx)', () => {
+  it('renders the shellChatV1 skeleton frame when DESIGN_V1 is enabled', async () => {
+    getCachedAuthMock.mockResolvedValue({
+      userId: 'user_123',
+      sessionId: 'sess_123',
+      orgId: null,
+    });
+    getAppFlagValueMock.mockResolvedValue(true);
+
+    const { default: AppLoading } = await import('@/app/app/loading');
+    const element = await AppLoading();
+    const { container } = render(element);
+
+    const frame = container.querySelector('[data-app-shell-frame]');
+    expect(frame).toHaveAttribute('data-shell-design', 'shellChatV1');
+    expect(getAppFlagValueMock).toHaveBeenCalledWith('DESIGN_V1', {
+      userId: 'user_123',
+    });
+  });
+
+  it('renders the legacy skeleton frame when DESIGN_V1 is disabled', async () => {
+    getCachedAuthMock.mockResolvedValue({
+      userId: null,
+      sessionId: null,
+      orgId: null,
+    });
+    getAppFlagValueMock.mockResolvedValue(false);
+
+    const { default: AppLoading } = await import('@/app/app/loading');
+    const element = await AppLoading();
+    const { container } = render(element);
+
+    const frame = container.querySelector('[data-app-shell-frame]');
+    expect(frame).toHaveAttribute('data-shell-design', 'legacy');
+  });
+});


### PR DESCRIPTION
## What / Why

Chunk 1.3 of the One App Shell program (#12633 / #12636): flip `DESIGN_V1`'s default to `shellChatV1` for all users, keep the kill switch, and (if still real) fix #14187.

**Flag-flip status:** `APP_FLAG_DEFAULTS.DESIGN_V1` has been `true` (permanently enabled, no Statsig gate, `LOCAL_DEFAULT_ONLY_FLAGS`) since PR #8337/#8406, well before this program started. `buildBooleanFlag('DESIGN_V1').decide()` unconditionally returns that default, and every shell entry point (`(shell)/layout.tsx`, `AuthShell.tsx`, `AuthShellWrapper.tsx`) resolves `shellVariant` from `DESIGN_V1`. So **the default is already `shellChatV1` for every user with no override** — there was nothing left to flip in code. The per-user cookie override, admin override, and env-level override cell (the kill switch) are all still intact and unchanged.

**What this PR actually does:** fixes #14187, which is real and directly coupled to the flip being live. `apps/web/app/app/loading.tsx` — the Suspense fallback Next.js renders while `(shell)/layout.tsx` is still resolving — rendered `<AppShellSkeleton />` with no `variant`, so it always fell back to `'legacy'` regardless of `DESIGN_V1`. Since the flag already defaults to on for everyone, this was actively flashing the legacy-styled skeleton (58-width sidebar, `h-9` header) before snapping to the real `shellChatV1` frame on every cold `/app` load.

Fix: resolve the variant in `loading.tsx` the same way `(shell)/layout.tsx` does (`getCachedAuth()` + `getAppFlagValue('DESIGN_V1', { userId })`) and pass it into `AppShellSkeleton`. `getCachedAuth()` is request-memoized via React `cache()`, so this doesn't add a second auth round-trip.

## Rollback

One-line revert of this PR. No flag default changed, no schema/migration, no new gate — purely a Suspense-fallback prop fix.

## Bake plan

N/A for a new rollout (the `DESIGN_V1` default has been live in production since #8406) — this is a cosmetic parity fix, not a rollout. Standard 3–5 day Sentry/route-transition-telemetry (chunk 0.2) monitoring before the legacy-deletion chunk (2.1) still applies to the overall program, not specifically to this PR.

## Verification

```
pnpm --filter @jovie/web run typecheck -- --pretty false   # exit 0
pnpm biome check --write apps/web/app/app/loading.tsx apps/web/tests/unit/app/app-loading-shell-variant.test.tsx
  # Checked 2 files. No fixes applied.

doppler run --project jovie-web --config dev -- pnpm --filter web exec vitest run \
  tests/unit/app/app-loading-shell-variant.test.tsx \
  tests/unit/shell/shell-variant-parity.test.tsx \
  tests/unit/components/organisms/AuthShell.flag.test.tsx
  # Test Files  3 passed (3)
  # Tests  8 passed (8)
```

New regression test (`apps/web/tests/unit/app/app-loading-shell-variant.test.tsx`) asserts `AppLoading()` renders `data-shell-design="shellChatV1"` when `DESIGN_V1` resolves true and `"legacy"` when false, mocking `getCachedAuth`/`getAppFlagValue` the same way `(shell)/layout.tsx` consumes them.

Part of #12636/#12633.