### PR TITLE
test(ci): validate ephemeral runner in isolation

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -54,7 +54,13 @@ runs:
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
     - name: Setup pnpm cache
-      if: runner.environment != 'github-hosted'
+      # Static self-hosted runners reuse this store across jobs. Ephemeral
+      # containers do not, so actions/cache would upload the whole store during
+      # teardown and can keep an otherwise-finished job occupied until timeout.
+      if: >-
+        runner.environment != 'github-hosted' &&
+        !startsWith(runner.name, 'jovie-eph-') &&
+        !startsWith(runner.name, 'jovie-iso-')
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}

--- a/.github/workflows/runner-isolation-smoke.yml
+++ b/.github/workflows/runner-isolation-smoke.yml
@@ -1,6 +1,7 @@
 name: Runner Isolation Smoke
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - codex/jov-4248-isolated-runner-validation

--- a/.github/workflows/runner-isolation-smoke.yml
+++ b/.github/workflows/runner-isolation-smoke.yml
@@ -1,0 +1,43 @@
+name: Runner Isolation Smoke
+
+on:
+  push:
+    branches:
+      - codex/jov-4248-isolated-runner-validation
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-isolation-smoke
+  cancel-in-progress: false
+
+jobs:
+  unit-shard:
+    name: Isolated Unit Tests (1/5)
+    runs-on: [self-hosted, Linux, X64, "${{ 'jovie-eph-isolation' }}"]
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Load quarantined unit tests
+        id: quarantine
+        run: node .github/scripts/quarantine-ledger.mjs emit-github-output
+
+      - name: Run representative unit shard
+        env:
+          NODE_OPTIONS: --max-old-space-size=3072
+        run: |
+          pnpm turbo test:fast --filter=@jovie/web -- \
+            --pool=forks \
+            --maxWorkers=3 \
+            --retry=${{ steps.quarantine.outputs.unit_default_retries }} \
+            --shard=1/5 \
+            ${{ steps.quarantine.outputs.unit_excludes }} \
+            --outputFile=test-report.runner-isolation.1-5.junit.xml

--- a/apps/web/tests/unit/ci/runner-setup-action.test.ts
+++ b/apps/web/tests/unit/ci/runner-setup-action.test.ts
@@ -11,7 +11,12 @@ describe('self-hosted runner setup action', () => {
       'utf8'
     );
 
-    expect(action).toContain("!startsWith(runner.name, 'jovie-eph-')");
-    expect(action).toContain("!startsWith(runner.name, 'jovie-iso-')");
+    const cacheStep = action.match(
+      /- name: Setup pnpm cache\n(?<step>[\s\S]*?)(?=\n    - name:)/
+    )?.groups?.step;
+
+    expect(cacheStep).toContain('uses: actions/cache@');
+    expect(cacheStep).toContain("!startsWith(runner.name, 'jovie-eph-')");
+    expect(cacheStep).toContain("!startsWith(runner.name, 'jovie-iso-')");
   });
 });

--- a/apps/web/tests/unit/ci/runner-setup-action.test.ts
+++ b/apps/web/tests/unit/ci/runner-setup-action.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '../../../../..');
+
+describe('self-hosted runner setup action', () => {
+  it('does not save pnpm caches from ephemeral runners', () => {
+    const action = readFileSync(
+      resolve(repoRoot, '.github/actions/setup-node-pnpm/action.yml'),
+      'utf8',
+    );
+
+    expect(action).toContain("!startsWith(runner.name, 'jovie-eph-')");
+    expect(action).toContain("!startsWith(runner.name, 'jovie-iso-')");
+  });
+});

--- a/apps/web/tests/unit/ci/runner-setup-action.test.ts
+++ b/apps/web/tests/unit/ci/runner-setup-action.test.ts
@@ -8,7 +8,7 @@ describe('self-hosted runner setup action', () => {
   it('does not save pnpm caches from ephemeral runners', () => {
     const action = readFileSync(
       resolve(repoRoot, '.github/actions/setup-node-pnpm/action.yml'),
-      'utf8',
+      'utf8'
     );
 
     expect(action).toContain("!startsWith(runner.name, 'jovie-eph-')");


### PR DESCRIPTION
Linear: JOV-4248

## Summary
- adds a reusable isolation smoke workflow targeting a unique ephemeral-runner label
- exercises checkout, canonical Node/pnpm setup, quarantine loading, and web unit shard 1/5
- skips pnpm cache upload for `jovie-eph-*` and `jovie-iso-*` runners, whose filesystems terminate after one job
- adds a regression contract for the cache condition
- keeps production runner variables on `ubuntu-latest`

## Confirmed root causes
1. Rolled-back image embedded Actions Runner 2.322.0; GitHub rejected it as deprecated. Candidate uses 2.335.1.
2. Base image exposed `/usr/bin/node` 10.19.0; `pnpm/action-setup` failed on `node:path`. Candidate exposes runner-bundled Node 24 for bootstrap, then canonical setup installs Node 22.
3. After tests finished, `actions/cache` post-save kept the ephemeral job occupied. Ephemeral runners now skip that pointless upload.

## Isolated verification
- failed version reproduction: https://github.com/JovieInc/Jovie/actions/runs/29214752267
- first successful full shard: https://github.com/JovieInc/Jovie/actions/runs/29215256149 (job 86709791673, 8m36s)
- repeat successful full shard: https://github.com/JovieInc/Jovie/actions/runs/29215256149 (job 86710705151, 8m50s)
- merged-main success: https://github.com/JovieInc/Jovie/actions/runs/29216005332 (job 86711909969, 10m08s)
- pre-review final-commit success: https://github.com/JovieInc/Jovie/actions/runs/29216603361 (job 86713644502, 9m06s)
- reviewed final-commit success: https://github.com/JovieInc/Jovie/actions/runs/29217111739 (job 86715020622, 8m55s, commit `ef64cc976813cdbf69f20aa5637fb5a06862e35b`)
- all successes completed checkout, setup, quarantine loading, shard 1/5, post-job actions, and cleanup
- final post-setup completed in 1s; zero remaining isolation containers and zero registered `jovie-iso-*` runners
- peak observed memory during setup was about 3.0 GiB; the rolled-back 2 GiB limit is unsafe
- `CI_FAST_RUNNER` and `CI_UNIT_RUNNER` remained `ubuntu-latest` throughout

## Verification
- `git diff --check` passed
- `actionlint` passed locally and in GitHub Actions
- Biome formatting passed in `ci-fast`
- typecheck, structural checks, server boundaries, and guardrails passed in `ci-fast`
- full isolated unit shard passed on the candidate runner

Bug-to-test: `apps/web/tests/unit/ci/runner-setup-action.test.ts` plus the isolated workflow.

<!-- agent-run-artifact
{
  "id": "pr-ef64cc976813cdbf69f20aa5637fb5a06862e35b",
  "source": "github",
  "sourceRunId": "ef64cc976813cdbf69f20aa5637fb5a06862e35b",
  "kind": "code_review",
  "status": "done",
  "title": "Agent PR",
  "summary": "Isolated runner QA, adversarial review, and ship readiness completed on the final commit.",
  "modelRoute": "deterministic",
  "allowedActions": ["open_pr", "ready_pr"],
  "forbiddenActions": ["merge", "deploy"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-4248",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-4248/fix-deprecated-ephemeral-runner-image-and-prove-isolated-job",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/14211",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/actions/runs/29217111739",
      "summary": "Five isolated full-shard successes, final teardown, deregistration, and zero-orphan checks recorded.",
      "checkedAt": "2026-07-13T01:27:27Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/14211",
      "summary": "Adversarial review completed; the sole test-scoping issue was fixed and re-reviewed clean.",
      "checkedAt": "2026-07-13T01:27:27Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/14211/checks",
      "summary": "Final commit passed actionlint, ci-fast, hosted checks, and the isolated candidate workflow.",
      "checkedAt": "2026-07-13T01:27:27Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-07-13T01:27:27Z",
  "updatedAt": "2026-07-13T01:27:27Z",
  "metadata": {}
}
-->
