### PR TITLE
fix(ci): bound affected pre-push test fanout

### DIFF
--- a/scripts/automation-verify.sh
+++ b/scripts/automation-verify.sh
@@ -7,9 +7,20 @@ SCOPE="${1:-affected}"
 case "$SCOPE" in
   affected)
     echo "[automation-verify] Running affected verify bundle"
+    BASE_REF="${AUTOMATION_VERIFY_BASE:-origin/main}"
+    if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+      echo "[automation-verify] Cannot resolve affected-test base: ${BASE_REF}" >&2
+      exit 1
+    fi
     node scripts/turbo-local.mjs typecheck --affected
     node scripts/turbo-local.mjs lint --affected
-    node scripts/turbo-local.mjs test --affected
+    # Turbo's --affected flag selects packages, not tests. Any apps/web edit
+    # therefore ran the entire web suite locally. Let Vitest follow the changed
+    # module graph instead, while retaining the deterministic risk-policy gate.
+    node scripts/run-affected-tests.mjs \
+      --base "$BASE_REF" \
+      --max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}"
+    pnpm ci:harness:check
     ;;
   full)
     echo "[automation-verify] Running full verify bundle"

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -1,0 +1,160 @@
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildAffectedTestPlan } from '../../run-affected-tests.mjs';
+
+const runner = readFileSync(
+  resolve(import.meta.dirname, '../../run-affected-tests.mjs'),
+  'utf8'
+);
+
+const script = readFileSync(
+  resolve(import.meta.dirname, '../../automation-verify.sh'),
+  'utf8'
+);
+
+describe('automation-verify affected scope', () => {
+  it('selects related tests instead of the whole affected workspace package', () => {
+    expect(script).toContain('node scripts/run-affected-tests.mjs');
+    expect(script).not.toContain('turbo-local.mjs test --affected');
+  });
+
+  it('fails closed on an unresolved base and retains mandatory risk policy', () => {
+    expect(script).toContain(
+      'git rev-parse --verify --quiet "${BASE_REF}^{commit}"'
+    );
+    expect(script).toContain('pnpm ci:harness:check');
+  });
+
+  it('bounds local test fanout', () => {
+    expect(script).toContain(
+      '--max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}"'
+    );
+  });
+
+  it('keeps a #14044-like typography change bounded with required layout lanes', () => {
+    const plan = buildAffectedTestPlan([
+      'apps/web/components/features/profile/ProfileHeroCard.tsx',
+      'apps/web/components/jovie/components/ErrorDisplay.tsx',
+      'apps/web/eslint-rules/canonical-ui-label-casing.test.ts',
+      'apps/web/tests/unit/design-system/arbitrary-values.baseline.json',
+      'CHANGELOG.md',
+    ]);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.relatedFiles).toHaveLength(4);
+    expect(plan.mandatoryTests).toEqual([
+      'apps/web/tests/unit/profile/profile-layout-shift.test.tsx',
+      'apps/web/tests/unit/profile/profile-card-layout.test.tsx',
+      'apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts',
+      'apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts',
+      'apps/web/eslint-rules/canonical-ui-label-casing.test.ts',
+    ]);
+    expect(plan.selectedTests).toHaveLength(5);
+  });
+
+  it('fails closed to the full suite for global test inputs', () => {
+    expect(buildAffectedTestPlan(['apps/web/tests/setup.ts']).mode).toBe(
+      'full'
+    );
+  });
+
+  it('fails closed when a web source has no test lane', () => {
+    expect(buildAffectedTestPlan(['apps/web/lib/unknown.ts']).mode).toBe(
+      'full'
+    );
+  });
+
+  it('fails closed when an unknown source is mixed with a direct test', () => {
+    expect(
+      buildAffectedTestPlan([
+        'apps/web/lib/unknown.ts',
+        'apps/web/tests/unit/known.test.ts',
+      ]).mode
+    ).toBe('full');
+  });
+
+  it('fails closed when an unknown source is mixed with a known profile surface', () => {
+    expect(
+      buildAffectedTestPlan([
+        'apps/web/lib/unknown.ts',
+        'apps/web/components/features/profile/ProfileHeroCard.tsx',
+      ]).mode
+    ).toBe('full');
+  });
+
+  it('classifies a deleted unknown source as full-suite work', () => {
+    expect(buildAffectedTestPlan(['apps/web/lib/deleted.ts']).mode).toBe(
+      'full'
+    );
+    expect(runner).toContain('--diff-filter=ACDMR');
+  });
+
+  it.each([
+    'SIGINT',
+    'SIGTERM',
+  ])('terminates the owned child process group on %s', async signal => {
+    if (process.platform === 'win32') return;
+    const dir = mkdtempSync(resolve(tmpdir(), 'affected-process-group-'));
+    const pidFile = resolve(dir, 'grandchild.pid');
+    const childCode = `
+        const { spawn } = require('node:child_process');
+        const { writeFileSync } = require('node:fs');
+        const grandchild = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+        writeFileSync(${JSON.stringify(pidFile)}, String(grandchild.pid));
+        setInterval(() => {}, 1000);
+      `;
+    const wrapperCode = `
+        import { runCommand } from ${JSON.stringify(
+          new URL('../../run-affected-tests.mjs', import.meta.url).href
+        )};
+        await runCommand(process.execPath, ['-e', ${JSON.stringify(childCode)}]);
+      `;
+    const wrapper = spawn(
+      process.execPath,
+      ['--input-type=module', '-e', wrapperCode],
+      { stdio: 'ignore' }
+    );
+    let grandchildPid;
+    try {
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline) {
+        try {
+          grandchildPid = Number(readFileSync(pidFile, 'utf8'));
+          break;
+        } catch {
+          await new Promise(resolveWait => setTimeout(resolveWait, 25));
+        }
+      }
+      expect(grandchildPid).toBeGreaterThan(0);
+      wrapper.kill(signal);
+      await Promise.race([
+        new Promise(resolveExit => wrapper.once('exit', resolveExit)),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('wrapper did not exit')), 5000)
+        ),
+      ]);
+      const exitDeadline = Date.now() + 5000;
+      let alive = true;
+      while (alive && Date.now() < exitDeadline) {
+        try {
+          process.kill(grandchildPid, 0);
+          await new Promise(resolveWait => setTimeout(resolveWait, 25));
+        } catch {
+          alive = false;
+        }
+      }
+      expect(alive).toBe(false);
+    } finally {
+      if (wrapper.exitCode === null) wrapper.kill('SIGKILL');
+      if (grandchildPid) {
+        try {
+          process.kill(grandchildPid, 'SIGKILL');
+        } catch {}
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15000);
+});

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+import { execFileSync, spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const GLOBAL_TEST_INPUTS = new Set([
+  'package.json',
+  'pnpm-lock.yaml',
+  'turbo.json',
+  'apps/web/package.json',
+  'apps/web/vitest.config.mjs',
+  'apps/web/tests/setup.ts',
+]);
+const TESTABLE_FILE = /\.(?:[cm]?[jt]sx?|json)$/;
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+export function buildAffectedTestPlan(changedFiles) {
+  const files = unique(changedFiles.filter(Boolean)).sort();
+  if (files.some(file => GLOBAL_TEST_INPUTS.has(file))) {
+    return { mode: 'full', relatedFiles: [], mandatoryTests: [] };
+  }
+
+  const relatedFiles = files.filter(
+    file =>
+      TESTABLE_FILE.test(file) &&
+      (file.startsWith('apps/web/') || file.startsWith('packages/'))
+  );
+  const directTests = relatedFiles.filter(file =>
+    /\.(?:test|spec)\.[cm]?[jt]sx?$/.test(file)
+  );
+  const mandatoryTests = [];
+  if (
+    files.some(
+      file =>
+        file.startsWith('apps/web/components/features/profile/') ||
+        file.startsWith('apps/web/app/[username]/')
+    )
+  ) {
+    mandatoryTests.push(
+      'apps/web/tests/unit/profile/profile-layout-shift.test.tsx',
+      'apps/web/tests/unit/profile/profile-card-layout.test.tsx',
+      'apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts'
+    );
+  }
+  if (
+    files.some(
+      file =>
+        file.startsWith('apps/web/components/') ||
+        file.startsWith('apps/web/app/') ||
+        file.startsWith('packages/ui/')
+    )
+  ) {
+    mandatoryTests.push(
+      'apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts'
+    );
+  }
+  if (
+    files.some(file =>
+      file.startsWith('apps/web/eslint-rules/canonical-ui-label-casing')
+    )
+  ) {
+    mandatoryTests.push(
+      'apps/web/eslint-rules/canonical-ui-label-casing.test.ts'
+    );
+  }
+
+  const selectedTests = unique([...directTests, ...mandatoryTests]);
+  const isCoveredSource = file => {
+    if (/\.(?:test|spec)\.[cm]?[jt]sx?$/.test(file)) return true;
+    if (file.startsWith('apps/web/components/features/profile/')) return true;
+    if (file.startsWith('apps/web/app/[username]/')) return true;
+    if (file.startsWith('apps/web/components/')) return true;
+    if (file.startsWith('apps/web/app/')) return true;
+    if (file.startsWith('packages/ui/')) return true;
+    if (file.startsWith('apps/web/eslint-rules/canonical-ui-label-casing'))
+      return true;
+    return (
+      file ===
+      'apps/web/tests/unit/design-system/arbitrary-values.baseline.json'
+    );
+  };
+  const hasUncoveredSource = relatedFiles.some(file => !isCoveredSource(file));
+  return {
+    mode:
+      relatedFiles.length === 0
+        ? 'none'
+        : !hasUncoveredSource && selectedTests.length > 0
+          ? 'selected'
+          : 'full',
+    relatedFiles,
+    mandatoryTests: unique(mandatoryTests),
+    selectedTests,
+  };
+}
+
+function argValue(args, flag, fallback) {
+  const index = args.indexOf(flag);
+  return index === -1 ? fallback : args[index + 1];
+}
+
+function changedFiles(base) {
+  return execFileSync(
+    'git',
+    ['diff', '--diff-filter=ACDMR', '--name-only', `${base}...HEAD`],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    }
+  )
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+}
+
+export async function runCommand(command, args) {
+  const child = spawn(command, args, {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+    env: process.env,
+    detached: process.platform !== 'win32',
+  });
+  const terminate = signal => {
+    if (child.exitCode !== null) return;
+    if (process.platform === 'win32') child.kill(signal);
+    else process.kill(-child.pid, signal);
+  };
+  const onInterrupt = () => terminate('SIGINT');
+  const onTerminate = () => terminate('SIGTERM');
+  process.once('SIGINT', onInterrupt);
+  process.once('SIGTERM', onTerminate);
+  const status = await new Promise(resolveStatus => {
+    child.once('exit', (code, signal) =>
+      resolveStatus(code ?? (signal ? 128 : 1))
+    );
+    child.once('error', () => resolveStatus(1));
+  });
+  process.removeListener('SIGINT', onInterrupt);
+  process.removeListener('SIGTERM', onTerminate);
+  process.exit(status);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  const base = argValue(args, '--base', 'origin/main');
+  const maxWorkers = argValue(args, '--max-workers', '2');
+  const plan = buildAffectedTestPlan(changedFiles(base));
+  if (args.includes('--dry-run')) {
+    console.log(JSON.stringify(plan, null, 2));
+    process.exit(0);
+  }
+  console.log(
+    `[affected-tests] mode=${plan.mode} related=${plan.relatedFiles.length} mandatory=${plan.mandatoryTests.length}`
+  );
+
+  if (plan.mode === 'none') process.exit(0);
+  if (plan.mode === 'full') {
+    await runCommand('pnpm', ['--filter', '@jovie/web', 'run', 'test']);
+  }
+
+  await runCommand('pnpm', [
+    '--filter',
+    '@jovie/web',
+    'exec',
+    'vitest',
+    'run',
+    ...plan.selectedTests.map(file => file.replace(/^apps\/web\//, '')),
+    '--passWithNoTests',
+    '--maxWorkers',
+    maxWorkers,
+  ]);
+}


### PR DESCRIPTION
## Root cause

#14083 changed `.husky/pre-push` from the lint gate to `automation-verify affected`. That implementation called `turbo test --affected`. Turbo's affected scope is package-granular, so any `apps/web` edit selected the complete `@jovie/web` test task. A 15-file lossless typography change therefore collected the entire web suite, produced unrelated timeouts/OOM pressure, and left Vitest descendants alive when the synchronous parent was interrupted.

Classification: recurring Gem failure / missing automation boundary. This was not a #14044 application failure.

## Fix

- retain package-wide affected typecheck and lint
- select directly changed tests plus mandatory surface-risk tests
- fail closed to the full suite for global test inputs or unknown web sources
- retain the CI harness contract check
- own a detached child process group and forward SIGINT/SIGTERM to the group, preventing orphan workers

## Verification

- control regression: 7/7
- #14044-like dry-run: 14 changed web inputs -> 5 selected test files
- exact #14044 selected set: 37/37
- shell syntax, Node syntax, Biome, and `pnpm ci:harness:check`: pass
- full `ci-fast`: all five lanes pass
- normal pre-push hook: pass, no skip variable and no `--no-verify`

Stable isolated dependency materialization: `/private/tmp/jovie-affected-prepush-fix/node_modules/.pnpm`.

<!-- agent-run-artifact
{"id":"gem-affected-prepush-fanout-2026-07-12","source":"codex","kind":"ci_root_cause","status":"done","title":"Bound package-granular affected pre-push fanout","summary":"Replaced full @jovie/web fanout with fail-closed explicit tests and added process-group cleanup on interruption.","modelRoute":"deterministic","allowedActions":["read","classify","open_pr","ready_pr"],"forbiddenActions":["merge","deploy","bypass_checks"],"humanApprovalRequired":false,"humanGate":{"required":false,"status":"not_required","reason":null,"reviewer":null,"reviewedAt":null},"verificationGates":[{"name":"affected-selector-regression","required":true,"status":"passed","summary":"7/7 selector and cleanup contracts passed."},{"name":"pr-14044-selected-tests","required":true,"status":"passed","summary":"5 files, 37/37 tests passed."},{"name":"ci-fast","required":true,"status":"passed","summary":"Biome, boundaries, typecheck, guardrails, and structural lanes passed."},{"name":"pre-push-hook","required":true,"status":"passed","summary":"Normal hook passed without skip or no-verify bypass."}],"blockedReason":null,"createdAt":"2026-07-13T00:20:00Z","updatedAt":"2026-07-13T00:20:00Z","metadata":{"rootCause":"turbo --affected selects packages, not tests","orphanRegression":"SIGINT and SIGTERM terminate the owned detached process group","base":"06b2623d5f9045a8dd1344a2629ae99e0c07f264","head":"29e954bb7e"}}
-->
