### PR TITLE
feat(shell): flag-aware config-driven mobile nav + demoted-route continuity

### DIFF
--- a/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.test.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.test.tsx
@@ -1,0 +1,119 @@
+import { render, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  inboxNavItem,
+  mobileExpandedNavigation,
+  mobilePrimaryNavigation,
+} from '@/features/dashboard/dashboard-nav';
+import { AppFlagProvider } from '@/lib/flags/client';
+import { APP_FLAG_DEFAULTS, type AppFlagSnapshot } from '@/lib/flags/contracts';
+import { DashboardMobileTabs } from './DashboardMobileTabs';
+
+const { mockUsePathname, mockSignOut } = vi.hoisted(() => ({
+  mockUsePathname: vi.fn<() => string>(() => '/app/chat'),
+  mockSignOut: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
+  useDashboardData: () => ({ isAdmin: false }),
+}));
+
+vi.mock('@/hooks/useClerkSafe', () => ({
+  useAuthSafe: () => ({ signOut: mockSignOut }),
+}));
+
+function renderMobileTabs(appFlags: Partial<AppFlagSnapshot> = {}) {
+  return render(
+    <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, ...appFlags }}>
+      <DashboardMobileTabs />
+    </AppFlagProvider>
+  );
+}
+
+function bottomBar(container: HTMLElement) {
+  return within(container).getByRole('navigation', {
+    name: 'Dashboard Tabs',
+  });
+}
+
+function expandedMenu(container: HTMLElement) {
+  return within(container).getByRole('navigation', {
+    name: 'Expanded Navigation Menu',
+  });
+}
+
+afterEach(() => {
+  mockUsePathname.mockReset();
+  mockUsePathname.mockReturnValue('/app/chat');
+});
+
+describe('DashboardMobileTabs', () => {
+  it('renders the bottom tab bar from the canonical mobilePrimaryNavigation config (flag off)', () => {
+    const { baseElement } = renderMobileTabs();
+
+    const links = within(bottomBar(baseElement)).getAllByRole('link');
+    expect(links.map(link => link.getAttribute('href'))).toEqual(
+      mobilePrimaryNavigation.map(item => item.href)
+    );
+    expect(links.map(link => link.textContent)).toEqual(
+      mobilePrimaryNavigation.map(item => item.name)
+    );
+  });
+
+  it('prepends the config Inbox item to the bottom bar when INBOX_HOME is on', () => {
+    const { baseElement } = renderMobileTabs({ INBOX_HOME: true });
+
+    const links = within(bottomBar(baseElement)).getAllByRole('link');
+    expect(links.map(link => link.getAttribute('href'))).toEqual(
+      [inboxNavItem, ...mobilePrimaryNavigation].map(item => item.href)
+    );
+    expect(links[0].textContent).toBe(inboxNavItem.name);
+  });
+
+  it('renders the expanded menu from the canonical config lists only', () => {
+    const { baseElement } = renderMobileTabs();
+
+    const links = within(expandedMenu(baseElement)).getAllByRole('link');
+    // Expanded overlay lists primary + expanded items (then admin/sign-out,
+    // which are not config nav links).
+    expect(links.map(link => link.getAttribute('href'))).toEqual(
+      [...mobilePrimaryNavigation, ...mobileExpandedNavigation].map(
+        item => item.href
+      )
+    );
+  });
+
+  it('marks Inbox active on exactly /app (desktop parity)', () => {
+    mockUsePathname.mockReturnValue('/app');
+    const { baseElement } = renderMobileTabs({ INBOX_HOME: true });
+
+    const inboxLink = within(bottomBar(baseElement)).getByRole('link', {
+      name: inboxNavItem.name,
+    });
+    expect(inboxLink.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('does not mark Inbox active on /app/* subroutes (exact match only)', () => {
+    mockUsePathname.mockReturnValue('/app/calendar');
+    const { baseElement } = renderMobileTabs({ INBOX_HOME: true });
+
+    const inboxLink = within(bottomBar(baseElement)).getByRole('link', {
+      name: inboxNavItem.name,
+    });
+    expect(inboxLink.getAttribute('aria-current')).toBeNull();
+  });
+
+  it('keeps the bottom bar at four slots max even with Inbox enabled', () => {
+    const { baseElement } = renderMobileTabs({ INBOX_HOME: true });
+
+    const links = within(bottomBar(baseElement)).getAllByRole('link');
+    // Layout-shift guard: the bar renders `slice(0, 4)` fixed-height rows, so
+    // the flag flipping on must not push any config item out of the bar.
+    expect(links.length).toBeLessThanOrEqual(4);
+    expect(links.length).toBe(1 + mobilePrimaryNavigation.length);
+  });
+});

--- a/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.tsx
@@ -4,11 +4,13 @@ import { useCallback, useMemo } from 'react';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import {
   adminNavigation,
+  inboxNavItem,
   mobileExpandedNavigation,
   mobilePrimaryNavigation,
 } from '@/features/dashboard/dashboard-nav';
 import type { NavItem } from '@/features/dashboard/dashboard-nav/types';
 import { useAuthSafe } from '@/hooks/useClerkSafe';
+import { useAppFlag } from '@/lib/flags/client';
 import { cn } from '@/lib/utils';
 
 import { LiquidGlassMenu, type LiquidGlassMenuItem } from './LiquidGlassMenu';
@@ -17,7 +19,6 @@ function toMenuItem(item: NavItem): LiquidGlassMenuItem {
   return { id: item.id, label: item.name, href: item.href, icon: item.icon };
 }
 
-const PRIMARY_ITEMS = mobilePrimaryNavigation.map(toMenuItem);
 const ADMIN_ITEMS = adminNavigation.map(toMenuItem);
 
 export interface DashboardMobileTabsProps {
@@ -29,6 +30,18 @@ export function DashboardMobileTabs({
 }: DashboardMobileTabsProps): React.JSX.Element {
   const { isAdmin } = useDashboardData();
   const { signOut } = useAuthSafe();
+  const inboxHomeEnabled = useAppFlag('INBOX_HOME');
+
+  // Mirrors DashboardNav's INBOX_HOME gating (GH #12634 / #14206 follow-up):
+  // computed inside the component (not at module scope) so the bottom bar
+  // reacts to the flag instead of freezing Inbox out at first import.
+  const primaryItems = useMemo(() => {
+    const items = inboxHomeEnabled
+      ? [inboxNavItem, ...mobilePrimaryNavigation]
+      : mobilePrimaryNavigation;
+    return items.map(toMenuItem);
+  }, [inboxHomeEnabled]);
+
   const expandedItems = useMemo(
     () => mobileExpandedNavigation.map(toMenuItem),
     []
@@ -40,7 +53,7 @@ export function DashboardMobileTabs({
 
   return (
     <LiquidGlassMenu
-      primaryItems={PRIMARY_ITEMS}
+      primaryItems={primaryItems}
       expandedItems={expandedItems}
       adminItems={isAdmin ? ADMIN_ITEMS : undefined}
       onSignOut={handleSignOut}

--- a/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
@@ -225,8 +225,14 @@ export function LiquidGlassMenu({
     setIsExpanded(false);
   }, [pathname]);
 
-  const isActive = (href: string) =>
-    pathname === href || pathname.startsWith(`${href}/`);
+  // Inbox is the named home at exactly `/app` — the generic prefix-match
+  // below would otherwise keep it active on every `/app/*` route. Mirrors
+  // the exact-match special case in DashboardNav's `isItemActive` (GH
+  // #12634 / #14206) so desktop and mobile agree on when Inbox is current.
+  const isActive = (item: LiquidGlassMenuItem) =>
+    item.id === 'inbox'
+      ? pathname === item.href
+      : pathname === item.href || pathname.startsWith(`${item.href}/`);
 
   const allMenuItems = [...primaryItems, ...expandedItems];
   const hasAdminItems = adminItems && adminItems.length > 0;
@@ -280,7 +286,7 @@ export function LiquidGlassMenu({
                 <MenuItemLink
                   key={item.id}
                   item={item}
-                  active={isActive(item.href)}
+                  active={isActive(item)}
                 />
               ))}
 
@@ -295,7 +301,7 @@ export function LiquidGlassMenu({
                     <MenuItemLink
                       key={item.id}
                       item={item}
-                      active={isActive(item.href)}
+                      active={isActive(item)}
                     />
                   ))}
                 </>
@@ -340,7 +346,7 @@ export function LiquidGlassMenu({
           {/* Primary nav items with labels */}
           {primaryItems.slice(0, 4).map(item => {
             const Icon = item.icon;
-            const active = isActive(item.href);
+            const active = isActive(item);
 
             return (
               <Link

--- a/apps/web/tests/unit/routes/legacy-dashboard-redirect-stubs.test.ts
+++ b/apps/web/tests/unit/routes/legacy-dashboard-redirect-stubs.test.ts
@@ -45,4 +45,48 @@ describe('legacy dashboard redirect stubs', () => {
       `${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`
     );
   });
+
+  // Demoted-route continuity (6-item nav IA, GH #12634 / #12633 chunk 1.5):
+  // routes that lost their primary nav slot must keep working via redirect.
+  it('sends legacy audience traffic to the canonical audience route', async () => {
+    const { default: LegacyAudienceRedirect } = await import(
+      '../../../app/app/(shell)/dashboard/audience/page'
+    );
+
+    LegacyAudienceRedirect();
+
+    expect(redirectMock).toHaveBeenCalledWith(APP_ROUTES.AUDIENCE);
+  });
+
+  it('sends legacy tasks traffic to the canonical tasks route', async () => {
+    const { default: LegacyTasksRedirect } = await import(
+      '../../../app/app/(shell)/dashboard/tasks/page'
+    );
+
+    LegacyTasksRedirect();
+
+    expect(redirectMock).toHaveBeenCalledWith(APP_ROUTES.TASKS);
+  });
+
+  it('sends the demoted releases route to the Library releases view', async () => {
+    const { default: ReleasesRedirect } = await import(
+      '../../../app/app/(shell)/releases/page'
+    );
+
+    await ReleasesRedirect();
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      `${APP_ROUTES.LIBRARY}?view=releases`
+    );
+  });
+
+  it('sends legacy threads traffic to the canonical chats route', async () => {
+    const { default: ThreadsRedirect } = await import(
+      '../../../app/app/(shell)/threads/page'
+    );
+
+    await ThreadsRedirect();
+
+    expect(redirectMock).toHaveBeenCalledWith(APP_ROUTES.CHATS);
+  });
 });


### PR DESCRIPTION
## What / why

Chunk 1.5 of the One App Shell program: the two continuity jobs after the 6-item nav IA merged in chunk 1.4 (#14208), so the IA change never strands a user.

**Mobile nav single source (closes the mobile half of #14206):**
- `DashboardMobileTabs` no longer freezes its bottom-bar item list at module load. It now computes items inside the component from the canonical `config.ts` lists and gates Inbox on the same `INBOX_HOME` rollout flag desktop's `DashboardNav` reads. With the flag on, the bar is Inbox / Chat / Library / Tasks — exactly 4 items, so nothing falls off the `slice(0, 4)` bar.
- `LiquidGlassMenu` active-state parity with desktop: Inbox (`/app`) is exact-match only — the previous generic prefix-match would have kept it highlighted on every `/app/*` route. Mirrors `DashboardNav.isItemActive`.
- Verified `DashboardMobileTabs` is the **only** consumer of the mobile lists and contains no hardcoded item list (`rg "mobilePrimaryNavigation|mobileExpandedNavigation"` → config.ts, index.ts, this component, tests only).
- New colocated test asserts the rendered mobile item set (bottom bar + expanded menu) always equals the config-derived set, so future IA changes cannot fork mobile.

**Demoted-route continuity (audit result):** every route demoted by the 6-item IA already redirects or remains reachable — no new redirect shims were needed. Added behavior tests pinning each redirect target so they can't silently regress.

## Continuity table

| Route | Old nav slot | New access path | Action taken |
|---|---|---|---|
| `/app/releases` | Releases (primary, pre-1.4) | Library nav item → `/app/library?view=releases`; route redirects there | Redirect test added |
| `/app/dashboard/releases` | legacy | Retained for old bookmarks (matrix ownership, per shell-nav-coverage) | None (already covered) |
| `/app/settings/artist-profile` | Artist Profile (primary) | Mobile expanded menu item + Settings → Artist → Profile | None (already in expanded nav) |
| `/app/settings/touring` | Touring (primary) | Mobile expanded menu item + Settings → Artist → Touring | None (already in expanded nav) |
| `/app/audience` | Audience (primary) | Direct URL only (allowlisted in shell-nav-coverage) | **Kept as-is — genuinely ambiguous** (see below) |
| `/app/dashboard/audience` | legacy | Redirects → `/app/audience` | Redirect test added |
| `/app/dashboard/tasks` | legacy | Redirects → `/app/tasks` (Tasks is still primary) | Redirect test added |
| `/app/earnings`, `/app/dashboard/earnings` | (demoted pre-1.4, #12634 item 3) | Redirect → `/app/settings/artist-profile?tab=earn#pay` | None (existing, covered by shell-nav-coverage) |
| `/app/threads` | legacy | Redirects → `/app/chats` | Redirect test added |
| `/app/insights` | (never primary; #12634 demotes to panels) | Direct link + dashboard widgets; legacy `/app/dashboard/insights` redirects with params | None (pre-existing state) |
| `/app/jovie-work` | — | Direct link; #12640 merges it into Inbox as a filter — that is Inbox-epic work, not this chunk | None |

**Ambiguous, kept as-is:** `/app/audience` lost its primary slot in 1.4 and has no secondary nav grouping. Adding it to `mobileExpandedNavigation` would change `config.ts` (frozen — 1.4 owns its shape; the 0.1 nav snapshot must not change this chunk). #12634 does not name a canonical panel/Settings placement for Audience, so per the manifest it stays reachable by direct URL (already allowlisted in `shell-nav-coverage.test.ts` with this exact rationale).

## Layout-shift audit

- Bottom tab bar: fixed-height rows (`py-1.5`, fixed icon size, `sr-only` labels); flag flip changes item count 3→4 within the same `justify-around` bar — no height change, no reflow of surrounding content (bar is `fixed bottom-0`).
- Expanded overlay: opacity-only transitions (existing); adding Inbox to `allMenuItems` when the flag is on only lengthens the scrollable overlay (max-h capped), zero shift of the bar or page.
- Active-state change is color + a 1px absolute-positioned dot — no layout impact.
- All states enumerated: flag on/off × admin on/off × expanded open/closed × active/inactive per item.

## Verification

```
pnpm --filter @jovie/web run typecheck -- --pretty false        # exit 0
pnpm biome check --write <4 touched files>                      # clean (1 format fix applied)
pnpm --filter web exec vitest run \
  components/features/dashboard/organisms/DashboardMobileTabs.test.tsx \
  tests/unit/routes/legacy-dashboard-redirect-stubs.test.ts \
  components/features/dashboard/dashboard-nav/config.test.ts \
  tests/unit/routes/shell-nav-coverage.test.ts                  # 4 files, 25/25 passed
pnpm --filter web exec vitest run \
  tests/unit/dashboard/DashboardNav.test.tsx \
  tests/components/dashboard/DashboardNav.interaction.test.tsx  # 38/38 passed
pnpm --filter web exec vitest run \
  tests/unit/shell/shell-variant-parity.test.tsx \
  tests/unit/components/organisms/AuthShell.flag.test.tsx \
  tests/unit/dashboard/liquid-glass-menu-system-b-style-guard.test.ts  # 7/7 passed
```

Nav IA snapshot from chunk 0.1: **unchanged** (`config.ts` untouched; `config.test.ts` inline snapshots pass as-is).

Part of #12633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)