### PR TITLE
fix(ci): drain stale Vercel preview queue

### DIFF
--- a/.github/scripts/cancel-stale-vercel-previews.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.mjs
@@ -3,7 +3,7 @@
 const API_BASE = 'https://api.vercel.com';
 const ACTIVE_STATES = ['QUEUED', 'BUILDING'];
 const MINIMUM_AGE_MS = 20 * 60 * 1000;
-const MAX_CANCELLATIONS = 10;
+const MAX_CANCELLATIONS = 100;
 
 export function isStalePreview(
   deployment,

--- a/.github/scripts/cancel-stale-vercel-previews.test.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.test.mjs
@@ -92,4 +92,31 @@ describe('cancel stale Vercel previews', () => {
     );
     expect(request.mock.calls[2][2]).toEqual({ method: 'PATCH' });
   });
+
+  it('drains a full Vercel result page instead of leaving stale work queued', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const deployments = Array.from({ length: 100 }, (_, index) =>
+      activePreview({ uid: `dpl_${index}` })
+    );
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ deployments })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ deployments: [] })));
+    for (let index = 0; index < deployments.length; index += 1) {
+      request.mockResolvedValueOnce(
+        new Response(JSON.stringify({ readyState: 'CANCELED' }))
+      );
+    }
+
+    const canceled = await cancelStalePreviews({
+      token: 'token',
+      orgId: 'team_org',
+      projectId,
+      currentSha,
+      request,
+    });
+
+    expect(canceled).toHaveLength(100);
+    expect(request).toHaveBeenCalledTimes(102);
+  });
 });


### PR DESCRIPTION
## Summary
- raise the guarded stale-preview drain from 10 to the full 100-deployment API page
- add regression coverage proving one run drains the full bounded page

## Live evidence
The first production workflow canceled exactly 10 eligible stale previews, then the current deploy remained QUEUED behind additional stale work. All project, branch, target, state, and age guards remain unchanged.

## Tests
- focused 100-deployment drain regression
- Biome passed
- `git diff --check` passed

Bug-to-test: `.github/scripts/cancel-stale-vercel-previews.test.mjs`