### PR TITLE
ci: add fixed runner canary

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,7 @@
 self-hosted-runner:
   labels:
     - jovie-runner
+    - jovie-fixed
     - hermes
     - ubicloud-standard-2
     - ubicloud-standard-8

--- a/.github/workflows/fixed-runner-canary.yml
+++ b/.github/workflows/fixed-runner-canary.yml
@@ -1,0 +1,81 @@
+name: Fixed Runner Canary
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fixed-runner-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: Validate fixed runner
+    runs-on: [self-hosted, Linux, X64, jovie-fixed]
+    timeout-minutes: 20
+    steps:
+      - name: Record runner identity
+        run: |
+          echo "runner_name=$RUNNER_NAME"
+          echo "runner_os=$RUNNER_OS"
+          echo "runner_arch=$RUNNER_ARCH"
+
+      - name: Checkout main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate workspace and disk
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f .github/actions/setup-node-pnpm/action.yml
+          test -f .github/actions/resolve-neon-database-url/action.yml
+          test -f .github/scripts/quarantine-ledger.mjs
+
+          minimum_kb=$((15 * 1024 * 1024))
+          for path in "$RUNNER_TEMP" "$GITHUB_WORKSPACE"; do
+            available_kb=$(df -Pk "$path" | awk 'NR == 2 { print $4 }')
+            if [[ ! "$available_kb" =~ ^[0-9]+$ ]] || ((available_kb < minimum_kb)); then
+              echo "::error::Insufficient disk at $path: ${available_kb:-unknown} KiB available; ${minimum_kb} KiB required."
+              exit 1
+            fi
+            echo "Disk at $path: ${available_kb} KiB available."
+          done
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Validate toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major !== 22 || minor < 13) { throw new Error('Expected Node >=22.13 <23, got ' + process.versions.node); }"
+          test "$(pnpm --version)" = "9.15.4"
+          node --version
+          pnpm --version
+
+      - name: Load quarantined unit tests
+        id: quarantine
+        run: node .github/scripts/quarantine-ledger.mjs emit-github-output
+
+      - name: Run representative unit shard
+        env:
+          NODE_OPTIONS: --max-old-space-size=3072
+        run: |
+          pnpm turbo test:fast --filter=@jovie/web -- \
+            --pool=forks \
+            --maxWorkers=2 \
+            --retry=${{ steps.quarantine.outputs.unit_default_retries }} \
+            --shard=1/5 \
+            ${{ steps.quarantine.outputs.unit_excludes }}
+
+      - name: Record final disk
+        if: always()
+        run: |
+          df -h "$RUNNER_TEMP"
+          df -h "$GITHUB_WORKSPACE"

--- a/apps/web/tests/unit/ci/fixed-runner-canary-workflow.test.ts
+++ b/apps/web/tests/unit/ci/fixed-runner-canary-workflow.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
+const workflowPath = resolve(
+  repoRoot,
+  '.github/workflows/fixed-runner-canary.yml'
+);
+const actionlintConfigPath = resolve(repoRoot, '.github/actionlint.yaml');
+
+describe('fixed runner canary workflow', () => {
+  const workflow = readFileSync(workflowPath, 'utf8');
+
+  it('is manual-only and cannot mutate runner routing', () => {
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).not.toContain('pull_request:');
+    expect(workflow).not.toContain('push:');
+    expect(workflow).not.toContain('schedule:');
+    expect(workflow).not.toContain('CI_FAST_RUNNER');
+    expect(workflow).toContain('contents: read');
+  });
+
+  it('targets only the distinct fixed runner label', () => {
+    const actionlintConfig = readFileSync(actionlintConfigPath, 'utf8');
+
+    expect(workflow).toContain(
+      'runs-on: [self-hosted, Linux, X64, jovie-fixed]'
+    );
+    expect(workflow).not.toContain('jovie-eph-isolation');
+    expect(actionlintConfig).toContain('- jovie-fixed');
+  });
+
+  it('validates disk, toolchain, local actions, and a representative shard', () => {
+    expect(workflow).toContain('15 * 1024 * 1024');
+    expect(workflow).toContain('.github/actions/setup-node-pnpm/action.yml');
+    expect(workflow).toContain(
+      '.github/actions/resolve-neon-database-url/action.yml'
+    );
+    expect(workflow).toContain('uses: ./.github/actions/setup-node-pnpm');
+    expect(workflow).toContain('Expected Node >=22.13 <23');
+    expect(workflow).toContain('test "$(pnpm --version)" = "9.15.4"');
+    expect(workflow).toContain('--shard=1/5');
+    expect(workflow).toContain('--maxWorkers=2');
+  });
+
+  it('pins checkout and does not persist credentials', () => {
+    expect(workflow).toContain(
+      'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0'
+    );
+    expect(workflow).toContain('ref: main');
+    expect(workflow).toContain('persist-credentials: false');
+  });
+});


### PR DESCRIPTION
## Root cause

At approximately 00:12Z, repository runner IDs 53–57 (`gem-linux`, `gem-linux-1` through `gem-linux-4`) were all online and idle with labels `self-hosted,Linux,jovie-runner,X64`. They were unused because the repository variable `CI_FAST_RUNNER` has remained `ubuntu-latest` since 2026-07-11T18:40:37Z.

A generic ephemeral runner registered, went offline without taking a job, and exposed image drift during isolation testing: attempt 1 failed inside pnpm/action setup with `Cannot find module node:path` from stale bootstrap Node/PATH contamination. Attempt 2 succeeded only after setup established Node 22.23.1 and pnpm 9.15.4, then self-deregistered. Because the fixed Gem runners and generic ephemeral runners currently share `jovie-runner`, changing global routing blindly could send required checks to an unhealthy ephemeral node.

The existing runner health monitor cannot safely restore routing: the Actions runners API returns 403 under its `GITHUB_TOKEN`, and its debounce state lives in hosted `runner.temp`, which resets each tick.

Classification: **dependency/environment drift plus missing runner-routing automation**.

## Smallest safe change

- Add a manual-only `Fixed Runner Canary` workflow targeting a distinct `jovie-fixed` label.
- Validate identity, at least 15 GiB free workspace/temp disk, required local actions, Node >=22.13 <23, pnpm 9.15.4, quarantine configuration, and a representative bounded unit shard.
- Add `jovie-fixed` only to actionlint's known self-hosted labels.
- Add a 4-case structural regression that keeps the workflow manual-only, read-only, pinned, credential-safe, isolated from `jovie-runner`, and unable to mutate `CI_FAST_RUNNER`.

This PR does **not** add or remove any live runner label and does **not** change `CI_FAST_RUNNER` or any production job routing.

## Safety and rollout

1. Land this inert workflow while the PR remains draft/gated through review.
2. Add `jovie-fixed` to exactly one known-good fixed Gem runner.
3. Dispatch the canary and require a first-attempt pass with the expected runner identity and toolchain.
4. Only in a separately reviewed routing change, point selected CI at the proven fixed label or update `CI_FAST_RUNNER`.
5. Keep generic ephemeral runners excluded from the distinct label until their bootstrap image is repaired and independently canaried.

## Rollback

- Before routing changes: delete the `jovie-fixed` label from the runner; no CI job is affected.
- After a later routing change: immediately restore `CI_FAST_RUNNER=ubuntu-latest` (or revert the selected job selector), then delete `jovie-fixed`.
- The canary itself is manual-only and can be reverted independently; it has `contents: read` and persists no checkout credentials.

## Verification

- `actionlint -config-file .github/actionlint.yaml .github/workflows/fixed-runner-canary.yml` — pass
- focused workflow regression — 4/4 pass
- Biome on touched paths — pass, no fixes
- `pnpm ci:harness:check` — pass
- normal repaired pre-push hook, no bypass — pass: proxy guard, Tailwind guard, full typecheck, affected typecheck/lint, focused 4/4, CI harness
- exact signed head: `7a0f8e6f3b2638a07e871b0276810ef5d04d3789`

<!-- bug-to-test: apps/web/tests/unit/ci/fixed-runner-canary-workflow.test.ts -->
