### PR TITLE
fix(shell): repair train CI — defer seed-test-data import, lock ratchet baseline

### DIFF
--- a/apps/web/tests/global-setup.ts
+++ b/apps/web/tests/global-setup.ts
@@ -7,7 +7,16 @@ import {
   ensureDevTestAuthPersona,
   resolveDevTestAuthPersona,
 } from './helpers/dev-test-auth-personas';
-import { seedTestData } from './seed-test-data';
+
+// Lazy import (below, at call site) keeps `@/lib/db` — and its `server-only`
+// env module — out of this file's eager module graph. `seed-test-data.ts`
+// transitively imports `@/lib/db` (via `@/lib/events/insert`), and a
+// top-level static import here would load that whole chain unconditionally,
+// even on the `isCI && BASE_URL` early-return path below where seeding never
+// runs. `server-only` throws unconditionally outside a Next.js bundler
+// context, so eagerly loading it here trips the guard before this function
+// ever gets a chance to skip seeding. See the identical lazy-import pattern
+// (and rationale) in `lib/testing/test-user-provision.server.ts`.
 
 // Load environment variables in priority order (first-loaded wins with override: false)
 const webRoot = path.resolve(__dirname, '..');
@@ -84,6 +93,7 @@ async function globalSetup() {
   } else if (process.env.DATABASE_URL) {
     try {
       console.log('🌱 Seeding test data...');
+      const { seedTestData } = await import('./seed-test-data');
       await seedTestData();
       console.log('✓ Test data seeded successfully');
     } catch (error) {

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 2200
+  "count": 2194
 }


### PR DESCRIPTION
## What / Why

Repairs the `testing`-label CI lanes failing on train PR #14214 (integration/loop-ui → main, aggregating 10 One App Shell chunks). All were failing for one of two independent, pre-existing root causes exposed by that train batch's CI run — neither is a regression in the nav IA / shell chunks themselves.

## Disposition table

| Check | Root cause | Fix |
|---|---|---|
| Golden Path (PR) | `tests/global-setup.ts` eagerly imported `seedTestData` from `./seed-test-data` at module scope. `seed-test-data.ts` transitively imports `@/lib/db` (via `@/lib/events/insert.ts`), which imports the `server-only`-guarded `lib/env-server.ts`. Outside a Next.js bundler context, the `server-only` package throws unconditionally on import. Every Playwright run that loads `global-setup.ts` crashed at import time — **before** the `isCI && process.env.BASE_URL` early-return (which is supposed to skip seeding entirely on standalone-server/preview lanes) ever got a chance to run. | Deferred the import to the call site (`const { seedTestData } = await import('./seed-test-data')`), matching the existing lazy-import pattern already used for the identical constraint in `lib/testing/test-user-provision.server.ts`'s `ensureBetterAuthTestUser` (see the comment there). No functional change to *when* seeding runs — only *when* the module graph loads. |
| Mobile Overflow Guard (320px/390px/430px) | Same `server-only` crash — all three widths use the standalone server + `BASE_URL`. | Same fix. |
| A11y (axe) | Same `server-only` crash (via `playwright.config.ts`'s shared `global-setup.ts`). | Same fix. |
| A11y (authenticated, informational) | Same `server-only` crash. | Same fix. |
| Extended Smoke (Preview) | Same `server-only` crash (`playwright.config.smoke.ts`). | Same fix. |
| Full E2E (Preview) (1) / (2) | Same `server-only` crash. | Same fix. |
| Unit Tests (3/5) | `tests/unit/design-system/linear-namespace-ratchet.test.ts` failed: `--linear-*` usage dropped to 2194 (frozen baseline 2200). The ratchet is shrink-only and the test's own assertion message instructs lowering the baseline to lock in the improvement. | Lowered `tests/unit/design-system/linear-namespace.baseline.json` `count` from 2200 → 2194. |
| PR Size Guard | The train PR (#14214) itself aggregates 10 chunk PRs and exceeds the 800-line/40-file cap. Not fixable from a repair PR — it's a property of the train aggregation, not this diff. | **Not fixed here** — flagging as a blocker for the orchestrator: apply the `big-pr` label to #14214 (per `.claude/rules/pr-stacking.md`, mechanical/aggregation trains are the documented exemption path) or split the train. |

## Verification

- `pnpm --filter @jovie/web run typecheck -- --pretty false` — pass
- `pnpm biome check --write apps/web/tests/global-setup.ts apps/web/tests/unit/design-system/linear-namespace.baseline.json` — pass (1 formatting fix applied)
- `pnpm --filter web exec vitest run tests/unit/design-system/linear-namespace-ratchet.test.ts` — pass
- Built `.next/standalone` locally and reproduced the exact CI invocation (`BASE_URL=http://localhost:3100`, standalone server, `doppler run --project jovie-web --config dev --`) for:
  - `axe-audit.spec.ts` (a11y-axe lane config): **before fix** — 100% crash at global-setup import, zero tests execute. **After fix** — global setup completes, 63/81 axe checks pass. The remaining local failures (profile-mode-pay drawer, notifications drawer, a couple of public-surface selectors) reproduce against my personal Doppler dev DB/Redis state, which isn't a fresh ephemeral Neon branch like CI provisions per-PR, and were never part of the original failure signal (the original CI run never got past the crash to execute any assertion). Flagging as a **known local-repro gap**, not a claimed fix — worth a second look if these specific surfaces still fail in CI once the crash is cleared, but out of scope for this repair (not caused by the shell chunks).
  - `golden-path.spec.ts` (golden-path lane config): **before fix** — same crash. **After fix** — global setup completes (`✅ E2E global setup complete`), the actual signup flow runs; failed later on an unrelated OTP-code-visibility timeout most likely caused by local rate-limiting/shared dev-DB state from repeated local runs, not the shell chunks.
  - `mobile-overflow.spec.ts` config (390px/430px CI logs): confirmed the *only* error present in both raw job logs was the identical `server-only` crash — no other failure signature.

## Blockers / follow-ups for the orchestrator

- **PR Size Guard** on #14214 needs a `big-pr` label or a split — not something a test-file repair PR can address.
- The handful of a11y surfaces that still fail against my local (non-ephemeral) dev DB after the crash fix (`profile-mode-pay`, `profile-notifications`, `public-release`) should be watched on the next CI run of the train with a fresh ephemeral Neon branch + real secrets. If they fail there too, that's a separate, pre-existing issue unrelated to nav IA and should get its own Linear ticket rather than being folded into this repair.

Part of #12633, unblocks train #14214.