### PR TITLE
fix(ci): cancel superseded main previews immediately

### DIFF
--- a/.github/scripts/cancel-stale-vercel-previews.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.mjs
@@ -2,17 +2,12 @@
 
 const API_BASE = 'https://api.vercel.com';
 const ACTIVE_STATES = ['QUEUED', 'BUILDING'];
-const MINIMUM_AGE_MS = 20 * 60 * 1000;
 const MAX_CANCELLATIONS = 100;
 
-export function isStalePreview(
-  deployment,
-  { currentSha, projectId, now = Date.now() }
-) {
+export function isStalePreview(deployment, { currentSha, projectId }) {
   const commitSha = deployment.meta?.githubCommitSha;
   const commitRef = deployment.meta?.githubCommitRef;
   const state = (deployment.readyState ?? deployment.state ?? '').toUpperCase();
-  const createdAt = Number(deployment.createdAt ?? deployment.created ?? 0);
 
   return (
     deployment.projectId === projectId &&
@@ -21,9 +16,7 @@ export function isStalePreview(
     commitRef === 'main' &&
     typeof commitSha === 'string' &&
     commitSha.length > 0 &&
-    commitSha !== currentSha &&
-    createdAt > 0 &&
-    now - createdAt >= MINIMUM_AGE_MS
+    commitSha !== currentSha
   );
 }
 

--- a/.github/scripts/cancel-stale-vercel-previews.test.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.test.mjs
@@ -13,7 +13,7 @@ const activePreview = (overrides = {}) => ({
   projectId,
   target: null,
   readyState: 'QUEUED',
-  createdAt: now - 21 * 60 * 1000,
+  createdAt: now - 60 * 1000,
   meta: { githubCommitRef: 'main', githubCommitSha: 'old-sha' },
   ...overrides,
 });
@@ -39,12 +39,12 @@ describe('cancel stale Vercel previews', () => {
       )
     ).toBe(false);
     expect(
-      isStalePreview(activePreview({ createdAt: now - 5 * 60 * 1000 }), {
+      isStalePreview(activePreview({ createdAt: now - 1000 }), {
         currentSha,
         projectId,
         now,
       })
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isStalePreview(
         activePreview({


### PR DESCRIPTION
## Summary
- cancel superseded main preview deployments immediately instead of waiting 20 minutes
- preserve project, preview target, active state, main branch, GitHub metadata, and current-SHA safeguards

## Live evidence
The full-page reaper found zero eligible records while a younger superseded main deployment continued blocking the current HEAD. The current deployment is not created until after cleanup, and current-SHA retries remain explicitly protected.

## Tests
- regression now asserts a one-second-old superseded main preview is eligible
- Biome passed
- `git diff --check` passed

Bug-to-test: `.github/scripts/cancel-stale-vercel-previews.test.mjs`