### PR TITLE
fix(ci): clear abandoned main preview retries

### DIFF
--- a/.github/scripts/cancel-stale-vercel-previews.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.mjs
@@ -4,7 +4,7 @@ const API_BASE = 'https://api.vercel.com';
 const ACTIVE_STATES = ['QUEUED', 'BUILDING'];
 const MAX_CANCELLATIONS = 100;
 
-export function isStalePreview(deployment, { currentSha, projectId }) {
+export function isStalePreview(deployment, { projectId }) {
   const commitSha = deployment.meta?.githubCommitSha;
   const commitRef = deployment.meta?.githubCommitRef;
   const state = (deployment.readyState ?? deployment.state ?? '').toUpperCase();
@@ -15,8 +15,7 @@ export function isStalePreview(deployment, { currentSha, projectId }) {
     ACTIVE_STATES.includes(state) &&
     commitRef === 'main' &&
     typeof commitSha === 'string' &&
-    commitSha.length > 0 &&
-    commitSha !== currentSha
+    commitSha.length > 0
   );
 }
 
@@ -47,7 +46,6 @@ export async function cancelStalePreviews({
   token,
   orgId,
   projectId,
-  currentSha,
   request = vercelRequest,
 }) {
   const deployments = [];
@@ -69,9 +67,7 @@ export async function cancelStalePreviews({
   const stale = [
     ...new Map(
       deployments
-        .filter(deployment =>
-          isStalePreview(deployment, { currentSha, projectId })
-        )
+        .filter(deployment => isStalePreview(deployment, { projectId }))
         .map(deployment => [deployment.uid ?? deployment.id, deployment])
     ).values(),
   ]
@@ -116,8 +112,7 @@ async function main() {
   const token = process.env.VERCEL_TOKEN ?? '';
   const orgId = process.env.VERCEL_ORG_ID ?? '';
   const projectId = process.env.VERCEL_PROJECT_ID ?? '';
-  const currentSha = process.env.GITHUB_SHA ?? '';
-  const missing = Object.entries({ token, orgId, projectId, currentSha })
+  const missing = Object.entries({ token, orgId, projectId })
     .filter(([, value]) => !value)
     .map(([key]) => key);
 
@@ -127,7 +122,7 @@ async function main() {
     );
   }
 
-  await cancelStalePreviews({ token, orgId, projectId, currentSha });
+  await cancelStalePreviews({ token, orgId, projectId });
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/.github/scripts/cancel-stale-vercel-previews.test.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.test.mjs
@@ -20,12 +20,9 @@ const activePreview = (overrides = {}) => ({
 
 describe('cancel stale Vercel previews', () => {
   it('only selects stale active GitHub previews', () => {
-    expect(
-      isStalePreview(activePreview(), { currentSha, projectId, now })
-    ).toBe(true);
+    expect(isStalePreview(activePreview(), { projectId, now })).toBe(true);
     expect(
       isStalePreview(activePreview({ target: 'production' }), {
-        currentSha,
         projectId,
         now,
       })
@@ -35,12 +32,11 @@ describe('cancel stale Vercel previews', () => {
         activePreview({
           meta: { githubCommitRef: 'main', githubCommitSha: currentSha },
         }),
-        { currentSha, projectId, now }
+        { projectId, now }
       )
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isStalePreview(activePreview({ createdAt: now - 1000 }), {
-        currentSha,
         projectId,
         now,
       })
@@ -50,7 +46,7 @@ describe('cancel stale Vercel previews', () => {
         activePreview({
           meta: { githubCommitRef: 'feature', githubCommitSha: 'old' },
         }),
-        { currentSha, projectId, now }
+        { projectId, now }
       )
     ).toBe(false);
   });
@@ -76,7 +72,6 @@ describe('cancel stale Vercel previews', () => {
         token: 'token',
         orgId: 'team_org',
         projectId,
-        currentSha,
         request,
       })
     ).resolves.toEqual(['dpl_stale']);
@@ -112,7 +107,6 @@ describe('cancel stale Vercel previews', () => {
       token: 'token',
       orgId: 'team_org',
       projectId,
-      currentSha,
       request,
     });
 


### PR DESCRIPTION
## Summary
- cancel active main preview deployments even when they share the retry commit SHA
- keep production, PR/manual, project, state, and GitHub-main metadata safeguards

## Live evidence
The prior retry canceled two superseded commits, then remained QUEUED behind its own abandoned same-SHA deployment. Cleanup runs before a new deployment exists, so preserving same-SHA leftovers is unsafe for queue throughput.

## Tests
- regression asserts same-SHA active main previews are eligible
- Biome passed
- `git diff --check` passed

Bug-to-test: `.github/scripts/cancel-stale-vercel-previews.test.mjs`