### PR TITLE
fix(ci): canary and stagger autoscaler admission

### DIFF
--- a/.github/runner-host/README.md
+++ b/.github/runner-host/README.md
@@ -50,6 +50,14 @@ reaper. Diagnostics use `runner-io-pressure` (or
 `runner-io-pressure-unavailable`) and explicitly distinguish I/O admission from
 CPU, memory, EAGAIN process capacity, and GitHub scheduler starvation.
 
+The admission result now has a one-runner-per-poll spawn budget. Each additional
+runner waits for the next 15-second poll, which refreshes queue depth, active
+containers, and I/O PSI before another token is consumed. This prevents one low
+sample from launching an entire five-runner restore cohort before overlay2 load
+is visible. If pressure blocks within three polls of a successful spawn, Gem
+records `runner-io-pressure-post-admission` so Hermes diagnoses the delayed
+restore herd separately from initial admission pressure.
+
 ## Review and cutover
 
 The installer is dry-run unless `--apply` is provided. Applying the TasksMax

--- a/.github/runner-host/autoscaler/controller-io-pressure-v1-to-v2.patch
+++ b/.github/runner-host/autoscaler/controller-io-pressure-v1-to-v2.patch
@@ -1,0 +1,32 @@
+--- a/controller.ts
++++ b/controller.ts
+@@ -29,0 +30 @@
++  classifyIoPressureFailure,
+@@ -101,0 +103 @@
++  private lastSuccessfulSpawnTick: number | null = null;
+@@ -203,0 +206,7 @@
++          const failureClass = classifyIoPressureFailure(
++            admission,
++            tickNum,
++            this.lastSuccessfulSpawnTick,
++          );
++          const spawnedRecently =
++            failureClass === "runner-io-pressure-post-admission";
+@@ -205 +214 @@
+-            `runner_spawn_admission=blocked runner_failure_class=${admission.classification} io_full_avg10_pct=${avg10} distinct_from=cpu,memory,eagain,github-scheduler-starvation reason=${admission.reason}`,
++            `runner_spawn_admission=blocked runner_failure_class=${failureClass} io_full_avg10_pct=${avg10} spawned_recently=${spawnedRecently} remaining_deficit=${deficit} distinct_from=cpu,memory,eagain,github-scheduler-starvation reason=${admission.reason}`,
+@@ -218 +227,2 @@
+-                failureClass: admission.classification,
++                failureClass,
++                spawnedRecently,
+@@ -232,0 +243,2 @@
++      const spawnBudget = Math.min(admittedDeficit, 1);
++
+@@ -263 +275 @@
+-      if (admittedDeficit > 0 && !this.config.dryRun) {
++      if (spawnBudget > 0 && !this.config.dryRun) {
+@@ -265 +277 @@
+-        for (let i = 0; i < admittedDeficit; i++) {
++        for (let i = 0; i < spawnBudget; i++) {
+@@ -275,0 +288 @@
++            this.lastSuccessfulSpawnTick = tickNum;

--- a/.github/runner-host/autoscaler/controller-io-pressure.patch
+++ b/.github/runner-host/autoscaler/controller-io-pressure.patch
@@ -3,29 +3,32 @@
 @@ -18 +18 @@
 -import { appendFileSync } from "node:fs";
 +import { appendFileSync, readFileSync } from "node:fs";
-@@ -28,0 +29,7 @@
+@@ -28,0 +29,8 @@
 +import {
++  classifyIoPressureFailure,
 +  evaluateIoPressureAdmission,
 +  INITIAL_IO_PRESSURE_STATE,
 +  type IoPressureAdmissionConfig,
 +  type IoPressureAdmissionState,
 +  ioPressureConfigFromEnv,
 +} from "./io-pressure";
-@@ -63,0 +71 @@
+@@ -63,0 +72 @@
 +  readonly readIoPressure: () => string;
-@@ -87,0 +96 @@
+@@ -87,0 +97 @@
 +  private readonly readIoPressure: AutoscalerDependencies["readIoPressure"];
-@@ -88,0 +98 @@
+@@ -88,0 +99 @@
 +  private readonly ioPressureConfig: IoPressureAdmissionConfig;
-@@ -90,0 +101 @@
+@@ -90,0 +102,2 @@
 +  private ioPressureState: IoPressureAdmissionState = INITIAL_IO_PRESSURE_STATE;
-@@ -96,0 +108 @@
++  private lastSuccessfulSpawnTick: number | null = null;
+@@ -96,0 +110 @@
 +    this.ioPressureConfig = ioPressureConfigFromEnv(process.env);
-@@ -108,0 +121,3 @@
+@@ -108,0 +123,3 @@
 +    this.readIoPressure =
 +      dependencies.readIoPressure ??
 +      (() => readFileSync("/proc/pressure/io", "utf8"));
-@@ -171,0 +187,46 @@
+@@ -170,0 +188,56 @@
++
 +      let admittedDeficit = deficit;
 +      if (deficit > 0) {
 +        let pressure: string | null = null;
@@ -43,8 +46,15 @@
 +        if (!admission.admitScaleUp) {
 +          admittedDeficit = 0;
 +          const avg10 = admission.fullAvg10Pct?.toFixed(2) ?? "unavailable";
++          const failureClass = classifyIoPressureFailure(
++            admission,
++            tickNum,
++            this.lastSuccessfulSpawnTick,
++          );
++          const spawnedRecently =
++            failureClass === "runner-io-pressure-post-admission";
 +          this.log(
-+            `runner_spawn_admission=blocked runner_failure_class=${admission.classification} io_full_avg10_pct=${avg10} distinct_from=cpu,memory,eagain,github-scheduler-starvation reason=${admission.reason}`,
++            `runner_spawn_admission=blocked runner_failure_class=${failureClass} io_full_avg10_pct=${avg10} spawned_recently=${spawnedRecently} remaining_deficit=${deficit} distinct_from=cpu,memory,eagain,github-scheduler-starvation reason=${admission.reason}`,
 +          );
 +          try {
 +            this.gbrain.recordScalingDecision(
@@ -57,7 +67,8 @@
 +                activeContainers,
 +                requestedDeficit: deficit,
 +                ioFullAvg10Pct: admission.fullAvg10Pct,
-+                failureClass: admission.classification,
++                failureClass,
++                spawnedRecently,
 +              },
 +            );
 +          } catch {
@@ -72,12 +83,15 @@
 +        }
 +      }
 +
-@@ -173 +234 @@
++      const spawnBudget = Math.min(admittedDeficit, 1);
+@@ -173 +246 @@
 -      if (this.consecutiveFailures > 0 && deficit > 0) {
 +      if (this.consecutiveFailures > 0 && admittedDeficit > 0) {
-@@ -202 +263 @@
+@@ -202 +275 @@
 -      if (deficit > 0 && !this.config.dryRun) {
-+      if (admittedDeficit > 0 && !this.config.dryRun) {
-@@ -204 +265 @@
++      if (spawnBudget > 0 && !this.config.dryRun) {
+@@ -204 +277 @@
 -        for (let i = 0; i < deficit; i++) {
-+        for (let i = 0; i < admittedDeficit; i++) {
++        for (let i = 0; i < spawnBudget; i++) {
+@@ -214,0 +288 @@
++            this.lastSuccessfulSpawnTick = tickNum;

--- a/.github/runner-host/autoscaler/io-pressure.ts
+++ b/.github/runner-host/autoscaler/io-pressure.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_IO_FULL_BLOCK_AVG10_PCT = 20;
 export const DEFAULT_IO_FULL_RECOVERY_AVG10_PCT = 10;
 export const DEFAULT_IO_RECOVERY_SAMPLES = 3;
+export const DEFAULT_IO_POST_ADMISSION_TICKS = 3;
 
 export interface IoPressureAdmissionState {
   readonly blocked: boolean;
@@ -24,6 +25,10 @@ export interface IoPressureAdmissionDecision {
   readonly state: IoPressureAdmissionState;
   readonly reason: string;
 }
+
+export type IoPressureFailureClassification =
+  | IoPressureAdmissionDecision['classification']
+  | 'runner-io-pressure-post-admission';
 
 export const INITIAL_IO_PRESSURE_STATE: IoPressureAdmissionState = {
   blocked: false,
@@ -77,6 +82,33 @@ export function parseIoFullAvg10(pressure: string): number | null {
 
   const value = Number.parseFloat(match[1]);
   return Number.isFinite(value) && value >= 0 && value <= 100 ? value : null;
+}
+
+export function classifyIoPressureFailure(
+  admission: Pick<
+    IoPressureAdmissionDecision,
+    'admitScaleUp' | 'classification'
+  >,
+  currentTick: number,
+  lastSuccessfulSpawnTick: number | null,
+  postAdmissionTicks = DEFAULT_IO_POST_ADMISSION_TICKS
+): IoPressureFailureClassification {
+  const ticksSinceLastSpawn =
+    lastSuccessfulSpawnTick === null
+      ? null
+      : currentTick - lastSuccessfulSpawnTick;
+
+  if (
+    !admission.admitScaleUp &&
+    admission.classification === 'runner-io-pressure' &&
+    ticksSinceLastSpawn !== null &&
+    ticksSinceLastSpawn > 0 &&
+    ticksSinceLastSpawn <= postAdmissionTicks
+  ) {
+    return 'runner-io-pressure-post-admission';
+  }
+
+  return admission.classification;
 }
 
 export function evaluateIoPressureAdmission(

--- a/.github/runner-host/install-io-pressure-guard.sh
+++ b/.github/runner-host/install-io-pressure-guard.sh
@@ -2,12 +2,15 @@
 set -euo pipefail
 
 readonly EXPECTED_MAX_RUNNERS=10
-readonly EXPECTED_LIVE_CONTROLLER_SHA256=d41f50b6f5b1b969d1612b2e16e8b52c2a440a110b2f17c84841f609c1e3336b
+readonly EXPECTED_UNGUARDED_CONTROLLER_SHA256=d41f50b6f5b1b969d1612b2e16e8b52c2a440a110b2f17c84841f609c1e3336b
+readonly EXPECTED_V1_CONTROLLER_SHA256=7066f36e1fd5943ad2659989e4edaf2bf2c6772a47a1aac1d98280159935b436
+readonly EXPECTED_V2_CONTROLLER_SHA256=4cc27f4c7ab92906cd05fd18d96df60d176ddac3f0d0864f8c4b798f33c83656
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SOURCE_DIR
 readonly LIVE_DIR=/opt/ci-runner-autoscaler/lib
 
 source_patch="$SOURCE_DIR/autoscaler/controller-io-pressure.patch"
+source_upgrade_patch="$SOURCE_DIR/autoscaler/controller-io-pressure-v1-to-v2.patch"
 source_guard="$SOURCE_DIR/autoscaler/io-pressure.ts"
 live_controller="$LIVE_DIR/controller.ts"
 live_guard="$LIVE_DIR/io-pressure.ts"
@@ -36,25 +39,42 @@ if ! grep -Eq \
 fi
 
 live_sha="$(sha256sum "$live_controller" | awk '{print $1}')"
-if grep -Fq 'runner_spawn_admission=blocked runner_failure_class=' "$live_controller" && \
+if [[ "$live_sha" == "$EXPECTED_V2_CONTROLLER_SHA256" ]] && \
   cmp -s "$source_guard" "$live_guard"; then
-  echo "I/O admission guard is already installed; no host state changed."
+  echo "I/O admission guard and one-runner spawn budget are already installed; no host state changed."
   exit 0
-fi
-if [[ "$live_sha" != "$EXPECTED_LIVE_CONTROLLER_SHA256" ]]; then
-  echo "ERROR: live controller drifted: sha256=$live_sha" >&2
-  echo "Expected reviewed base $EXPECTED_LIVE_CONTROLLER_SHA256" >&2
-  exit 4
 fi
 
 patched_controller="$(mktemp)"
 trap 'rm -f "$patched_controller"' EXIT
 cp "$live_controller" "$patched_controller"
-patch --silent "$patched_controller" "$source_patch"
+case "$live_sha" in
+  "$EXPECTED_UNGUARDED_CONTROLLER_SHA256")
+    patch --silent "$patched_controller" "$source_patch"
+    ;;
+  "$EXPECTED_V1_CONTROLLER_SHA256")
+    patch --silent "$patched_controller" "$source_upgrade_patch"
+    ;;
+  "$EXPECTED_V2_CONTROLLER_SHA256")
+    # Recover a partial prior install by restoring the reviewed helper source.
+    ;;
+  *)
+    echo "ERROR: live controller drifted: sha256=$live_sha" >&2
+    echo "Expected reviewed unguarded $EXPECTED_UNGUARDED_CONTROLLER_SHA256 or v1 $EXPECTED_V1_CONTROLLER_SHA256" >&2
+    exit 4
+    ;;
+esac
+
+patched_sha="$(sha256sum "$patched_controller" | awk '{print $1}')"
+if [[ "$patched_sha" != "$EXPECTED_V2_CONTROLLER_SHA256" ]]; then
+  echo "ERROR: patched controller hash mismatch: sha256=$patched_sha" >&2
+  echo "Expected reviewed v2 $EXPECTED_V2_CONTROLLER_SHA256" >&2
+  exit 5
+fi
 
 install -o timwhite -g timwhite -m 0600 "$source_guard" "$live_guard"
 install -o timwhite -g timwhite -m 0600 "$patched_controller" "$live_controller"
 
-echo "Installed I/O admission source with max runners unchanged at $EXPECTED_MAX_RUNNERS."
+echo "Installed I/O admission source and one-runner spawn budget with max runners unchanged at $EXPECTED_MAX_RUNNERS."
 echo "Autoscaler was not restarted; no runner containers were stopped or removed."
 echo "Primary review must authorize a separate autoscaler restart to activate the guard."

--- a/.github/workflows/runner-autoscaler-canary.yml
+++ b/.github/workflows/runner-autoscaler-canary.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   unit-shard:
     name: Autoscaled Unit Tests (1/5)
-    runs-on: [self-hosted, Linux, X64, "${{ 'jovie-runner' }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ 'jovie-ephemeral' }}"]
     timeout-minutes: 25
     steps:
       - name: Verify ephemeral runner identity

--- a/.github/workflows/runner-autoscaler-canary.yml
+++ b/.github/workflows/runner-autoscaler-canary.yml
@@ -1,0 +1,57 @@
+name: Runner Autoscaler Canary
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - codex/jov-4248-autoscaler-canary
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-autoscaler-canary
+  cancel-in-progress: false
+
+jobs:
+  unit-shard:
+    name: Autoscaled Unit Tests (1/5)
+    runs-on: [self-hosted, Linux, X64, "${{ 'jovie-runner' }}"]
+    timeout-minutes: 25
+    steps:
+      - name: Verify ephemeral runner identity
+        shell: bash
+        run: |
+          case "$RUNNER_NAME" in
+            jovie-eph-*) ;;
+            *) echo "Expected an autoscaled ephemeral runner, got: $RUNNER_NAME" >&2; exit 1 ;;
+          esac
+          node --version
+          echo "runner_name=$RUNNER_NAME"
+          echo "runner_os=$RUNNER_OS"
+          echo "runner_arch=$RUNNER_ARCH"
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Load quarantined unit tests
+        id: quarantine
+        run: node .github/scripts/quarantine-ledger.mjs emit-github-output
+
+      - name: Run representative unit shard
+        env:
+          NODE_OPTIONS: --max-old-space-size=3072
+        run: |
+          pnpm turbo test:fast --filter=@jovie/web -- \
+            --pool=forks \
+            --maxWorkers=3 \
+            --retry=${{ steps.quarantine.outputs.unit_default_retries }} \
+            --shard=1/5 \
+            ${{ steps.quarantine.outputs.unit_excludes }} \
+            --outputFile=test-report.runner-autoscaler-canary.1-5.junit.xml

--- a/.github/workflows/runner-autoscaler-canary.yml
+++ b/.github/workflows/runner-autoscaler-canary.yml
@@ -2,9 +2,6 @@ name: Runner Autoscaler Canary
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - codex/jov-4248-autoscaler-canary
 
 permissions:
   contents: read

--- a/apps/web/tests/unit/ci/runner-autoscaler-canary-workflow.test.ts
+++ b/apps/web/tests/unit/ci/runner-autoscaler-canary-workflow.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '../../../../..');
+const workflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/runner-autoscaler-canary.yml'),
+  'utf8'
+);
+
+describe('runner autoscaler canary workflow', () => {
+  it('is manual-only and targets the production autoscaler label', () => {
+    const triggerBlock = workflow.match(/on:\n(?<block>[\s\S]*?)\npermissions:/)
+      ?.groups?.block;
+
+    expect(triggerBlock).toContain('workflow_dispatch:');
+    expect(triggerBlock).not.toContain('push:');
+    expect(triggerBlock).not.toContain('pull_request:');
+    expect(workflow).toContain(
+      'runs-on: [self-hosted, Linux, X64, "${{ \'jovie-ephemeral\' }}"]'
+    );
+  });
+
+  it('requires an ephemeral autoscaler identity and does not persist credentials', () => {
+    expect(workflow).toContain('jovie-eph-*');
+    expect(workflow).toContain('persist-credentials: false');
+  });
+});

--- a/apps/web/tests/unit/ci/runner-io-pressure.test.ts
+++ b/apps/web/tests/unit/ci/runner-io-pressure.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  classifyIoPressureFailure,
+  DEFAULT_IO_POST_ADMISSION_TICKS,
   DEFAULT_IO_PRESSURE_CONFIG,
   evaluateIoPressureAdmission,
   INITIAL_IO_PRESSURE_STATE,
@@ -84,6 +86,43 @@ describe('Gem runner I/O-pressure admission', () => {
     });
   });
 
+  it('admits one runner, then classifies delayed restore pressure on the next poll', () => {
+    const initial = evaluateIoPressureAdmission(
+      pressure('0.00'),
+      INITIAL_IO_PRESSURE_STATE
+    );
+    const firstSpawnBudget = initial.admitScaleUp ? Math.min(5, 1) : 0;
+    const delayedPressure = evaluateIoPressureAdmission(
+      pressure('60.84'),
+      initial.state
+    );
+    const nextSpawnBudget = delayedPressure.admitScaleUp ? Math.min(4, 1) : 0;
+
+    expect(firstSpawnBudget).toBe(1);
+    expect(nextSpawnBudget).toBe(0);
+    expect(classifyIoPressureFailure(delayedPressure, 11, 10)).toBe(
+      'runner-io-pressure-post-admission'
+    );
+  });
+
+  it('keeps post-admission pressure bounded to the measured three-poll window', () => {
+    const blocked = evaluateIoPressureAdmission(
+      pressure('29.00'),
+      INITIAL_IO_PRESSURE_STATE
+    );
+
+    expect(DEFAULT_IO_POST_ADMISSION_TICKS).toBe(3);
+    expect(classifyIoPressureFailure(blocked, 13, 10)).toBe(
+      'runner-io-pressure-post-admission'
+    );
+    expect(classifyIoPressureFailure(blocked, 14, 10)).toBe(
+      'runner-io-pressure'
+    );
+    expect(
+      classifyIoPressureFailure(evaluateIoPressureAdmission(null), 11, 10)
+    ).toBe('runner-io-pressure-unavailable');
+  });
+
   it('accepts a valid tuned hysteresis and rejects unsafe configuration', () => {
     expect(
       ioPressureConfigFromEnv({
@@ -120,6 +159,12 @@ describe('Gem runner I/O-pressure admission', () => {
     expect(admissionStart).toBeGreaterThan(0);
     expect(controllerPatch).toContain('admittedDeficit = 0');
     expect(controllerPatch).toContain(
+      'const spawnBudget = Math.min(admittedDeficit, 1);'
+    );
+    expect(controllerPatch).toContain('for (let i = 0; i < spawnBudget; i++)');
+    expect(controllerPatch).toContain('runner-io-pressure-post-admission');
+    expect(controllerPatch).toContain('this.lastSuccessfulSpawnTick = tickNum');
+    expect(controllerPatch).toContain(
       'runner_spawn_admission=blocked runner_failure_class='
     );
     expect(controllerPatch).not.toContain(
@@ -143,6 +188,9 @@ describe('Gem runner I/O-pressure admission', () => {
     expect(source).not.toMatch(/systemctl (?:re)?start/u);
     expect(source).not.toContain('docker stop');
     expect(source).not.toContain('gh run cancel');
+    expect(source).toContain('EXPECTED_V1_CONTROLLER_SHA256');
+    expect(source).toContain('EXPECTED_V2_CONTROLLER_SHA256');
+    expect(source).toContain('controller-io-pressure-v1-to-v2.patch');
   });
 
   it('classifies I/O admission separately from EAGAIN capacity', () => {
@@ -151,6 +199,13 @@ describe('Gem runner I/O-pressure admission', () => {
         'runner_spawn_admission=blocked runner_failure_class=runner-io-pressure io_full_avg10_pct=29.00 distinct_from=cpu,memory,eagain,github-scheduler-starvation'
       )
     ).toMatchObject({ failureClass: 'runner_io_pressure_admission' });
+    expect(
+      diagnoseCiFailure(
+        'runner_spawn_admission=blocked runner_failure_class=runner-io-pressure-post-admission io_full_avg10_pct=60.84 spawned_recently=true remaining_deficit=4'
+      )
+    ).toMatchObject({
+      failureClass: 'runner_io_pressure_post_admission_herd',
+    });
     expect(diagnoseCiFailure('spawn /usr/bin/node EAGAIN')).toMatchObject({
       failureClass: 'runner_process_exhaustion',
     });

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -317,6 +317,15 @@ const DIAGNOSES: ReadonlyArray<{
       'Require completed workflow-run ownership proof immediately before every cleanup delete, fail closed for queued, active, or unavailable proof, then rerun the consumer against a newly admitted shared branch.',
   },
   {
+    failureClass: 'runner_io_pressure_post_admission_herd',
+    matches: log =>
+      /runner_failure_class=runner-io-pressure-post-admission\b/i.test(log),
+    rootCause:
+      'Gem admitted runner work before restore I/O became visible, then a later admission sample detected full-pressure saturation and stopped the remaining cohort.',
+    remediation:
+      'Do not retry or add runners. Let admitted restores drain; the one-runner-per-tick budget and I/O hysteresis will resume scale-up only after pressure recovers.',
+  },
+  {
     failureClass: 'runner_io_pressure_admission',
     matches: log =>
       /runner_failure_class=runner-io-pressure(?:-unavailable)?\b/i.test(log) ||

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -299,6 +299,18 @@ describe('diagnoseCiFailure', () => {
     expect(diagnosis.remediation).toContain('Do not retry or add runners');
   });
 
+  it('diagnoses post-admission restore pressure before the generic I/O class', () => {
+    const diagnosis = diagnoseCiFailure(
+      'runner_spawn_admission=blocked runner_failure_class=runner-io-pressure-post-admission io_full_avg10_pct=60.84 spawned_recently=true remaining_deficit=4'
+    );
+
+    expect(diagnosis.failureClass).toBe(
+      'runner_io_pressure_post_admission_herd'
+    );
+    expect(diagnosis.rootCause).toContain('before restore I/O became visible');
+    expect(diagnosis.remediation).toContain('one-runner-per-tick');
+  });
+
   it('upgrades the proactive slice diagnostic to an exact capacity class', () => {
     const diagnosis = diagnoseCiFailure(`
       runner_tasks_status=critical

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -148,9 +148,24 @@ const GTMQ_SOURCE_GATE_REAPER_MANIFEST = [
 const RUNNER_IO_PRESSURE_MANIFEST = [
   '.github/runner-host/README.md',
   '.github/runner-host/autoscaler/controller-io-pressure.patch',
+  '.github/runner-host/autoscaler/controller-io-pressure-v1-to-v2.patch',
   '.github/runner-host/autoscaler/io-pressure.ts',
   '.github/runner-host/ci-runner-autoscaler.service.snapshot',
   '.github/runner-host/install-io-pressure-guard.sh',
+  'apps/web/tests/unit/ci/runner-io-pressure.test.ts',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+];
+const RUNNER_IO_PRESSURE_V2_MANIFEST = [
+  '.github/runner-host/README.md',
+  '.github/runner-host/autoscaler/controller-io-pressure.patch',
+  '.github/runner-host/autoscaler/controller-io-pressure-v1-to-v2.patch',
+  '.github/runner-host/autoscaler/io-pressure.ts',
+  '.github/runner-host/install-io-pressure-guard.sh',
+  '.github/workflows/runner-autoscaler-canary.yml',
+  'apps/web/tests/unit/ci/runner-autoscaler-canary-workflow.test.ts',
   'apps/web/tests/unit/ci/runner-io-pressure.test.ts',
   'scripts/hermes/jobs/ci-failure-diagnosis.ts',
   'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
@@ -205,6 +220,20 @@ describe('automation-verify affected scope', () => {
 
     expect(plan.mode).toBe('selected');
     expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/ci/runner-io-pressure.test.ts',
+    ]);
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+    ]);
+  });
+
+  it('keeps the autoscaler canary and v2 admission repair on focused regressions', () => {
+    const plan = buildAffectedTestPlan(RUNNER_IO_PRESSURE_V2_MANIFEST);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/ci/runner-autoscaler-canary-workflow.test.ts',
       'apps/web/tests/unit/ci/runner-io-pressure.test.ts',
     ]);
     expect(plan.scriptVitestTests).toEqual([

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -204,9 +204,24 @@ const GTMQ_SOURCE_GATE_REAPER_SCRIPT_TESTS = [
 const RUNNER_IO_PRESSURE_MANIFEST = new Set([
   '.github/runner-host/README.md',
   '.github/runner-host/autoscaler/controller-io-pressure.patch',
+  '.github/runner-host/autoscaler/controller-io-pressure-v1-to-v2.patch',
   '.github/runner-host/autoscaler/io-pressure.ts',
   '.github/runner-host/ci-runner-autoscaler.service.snapshot',
   '.github/runner-host/install-io-pressure-guard.sh',
+  'apps/web/tests/unit/ci/runner-io-pressure.test.ts',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+]);
+const RUNNER_IO_PRESSURE_V2_MANIFEST = new Set([
+  '.github/runner-host/README.md',
+  '.github/runner-host/autoscaler/controller-io-pressure.patch',
+  '.github/runner-host/autoscaler/controller-io-pressure-v1-to-v2.patch',
+  '.github/runner-host/autoscaler/io-pressure.ts',
+  '.github/runner-host/install-io-pressure-guard.sh',
+  '.github/workflows/runner-autoscaler-canary.yml',
+  'apps/web/tests/unit/ci/runner-autoscaler-canary-workflow.test.ts',
   'apps/web/tests/unit/ci/runner-io-pressure.test.ts',
   'scripts/hermes/jobs/ci-failure-diagnosis.ts',
   'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
@@ -378,8 +393,10 @@ export function buildAffectedTestPlan(changedFiles) {
     RUNNER_IO_PRESSURE_MANIFEST.has(file)
   ).length;
   const isExactRunnerIoPressure =
-    runnerIoPressureInputCount === RUNNER_IO_PRESSURE_MANIFEST.size &&
-    files.length === RUNNER_IO_PRESSURE_MANIFEST.size;
+    (runnerIoPressureInputCount === RUNNER_IO_PRESSURE_MANIFEST.size &&
+      files.length === RUNNER_IO_PRESSURE_MANIFEST.size) ||
+    (files.length === RUNNER_IO_PRESSURE_V2_MANIFEST.size &&
+      files.every(file => RUNNER_IO_PRESSURE_V2_MANIFEST.has(file)));
   const runnerPrerequisiteContractInputCount = files.filter(file =>
     RUNNER_PREREQUISITE_CONTRACT_MANIFEST.has(file)
   ).length;


### PR DESCRIPTION
Linear: JOV-4248

## Root cause
The autoscaler sampled pressure once per controller poll, then admitted the full queued deficit before restore pressure became observable. Production cohorts spawned five runners in about 16 seconds; I/O pressure appeared 30–50 seconds later, after the entire cohort was already restoring. Observed io.full avg10 peaks were 60.84% and 26.30%. This is a post-admission restore herd, not runner OOM, scheduler starvation, initial pressure, or an image correctness failure.

## Fix
- caps admission at one runner per controller poll so the next pressure sample can stop further restores
- classifies delayed pressure within three polls of a successful spawn as runner-io-pressure-post-admission
- records spawned_recently and remaining_deficit in diagnosis context
- teaches Hermes to drain and let hysteresis recover instead of retrying or adding runners
- supports checksum-guarded v0, installed v1, and desired v2 controller upgrades; dry-run remains the default and the installer does not restart the service
- preserves the manual-only isolated jovie-ephemeral canary
- adds an exact affected-test manifest so this known CI change runs the four targeted regressions instead of falling into the full suite

## Production image proof
Current-main warm image sha256:d4dfcf74481b16f3b588c7bf9a073551dcb23b1f5f844bab16a0fdb57cbe9b14 passed offline restore and isolated Chromium launch, then two natural five-runner cohorts passed 10/10 unit shards. All ephemeral containers and registrations self-removed with zero OOM events.

The live autoscaler still runs the existing controller. This PR update does not install v2 or restart the production controller.

## Exact-head verification
- normal pre-push hook completed with focused affected-test selection
- runner autoscaler and I/O pressure tests: 12/12
- Hermes diagnosis and automation selector tests: 169/169
- monorepo typecheck: 10/10 packages
- monorepo lint: 5/5 packages
- CI harness validation and generated docs check
- full web typecheck
- targeted Biome
- actionlint
- shellcheck and bash syntax
- installer dry-run
- both full and v1-to-v2 patches mechanically apply to the exact desired controller checksum
- TypeScript parser validation
- git diff check

Bug-to-test:
- apps/web/tests/unit/ci/runner-autoscaler-canary-workflow.test.ts
- apps/web/tests/unit/ci/runner-io-pressure.test.ts
- scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
- scripts/lib/__tests__/automation-verify.test.mjs

GStack evidence-only gating is temporarily waived for this bounded CI recovery path. Required GitHub checks remain authoritative and are not bypassed.