### PR TITLE
fix(ci): prioritize production over active previews

### DIFF
--- a/.github/scripts/cancel-stale-vercel-previews.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.mjs
@@ -5,17 +5,12 @@ const ACTIVE_STATES = ['QUEUED', 'BUILDING'];
 const MAX_CANCELLATIONS = 100;
 
 export function isStalePreview(deployment, { projectId }) {
-  const commitSha = deployment.meta?.githubCommitSha;
-  const commitRef = deployment.meta?.githubCommitRef;
   const state = (deployment.readyState ?? deployment.state ?? '').toUpperCase();
 
   return (
     deployment.projectId === projectId &&
     deployment.target !== 'production' &&
-    ACTIVE_STATES.includes(state) &&
-    commitRef === 'main' &&
-    typeof commitSha === 'string' &&
-    commitSha.length > 0
+    ACTIVE_STATES.includes(state)
   );
 }
 
@@ -76,9 +71,8 @@ export async function cancelStalePreviews({
 
   for (const deployment of stale) {
     const id = deployment.uid ?? deployment.id;
-    const commitSha = deployment.meta.githubCommitSha;
     const state = deployment.readyState ?? deployment.state;
-    console.log(`Canceling stale preview ${id} (${state}, ${commitSha})`);
+    console.log(`Canceling active preview ${id} (${state})`);
 
     const url = scopedUrl(
       `/v12/deployments/${encodeURIComponent(id)}/cancel`,

--- a/.github/scripts/cancel-stale-vercel-previews.test.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.test.mjs
@@ -19,7 +19,7 @@ const activePreview = (overrides = {}) => ({
 });
 
 describe('cancel stale Vercel previews', () => {
-  it('only selects stale active GitHub previews', () => {
+  it('selects every active project preview while preserving production', () => {
     expect(isStalePreview(activePreview(), { projectId, now })).toBe(true);
     expect(
       isStalePreview(activePreview({ target: 'production' }), {
@@ -48,6 +48,15 @@ describe('cancel stale Vercel previews', () => {
         }),
         { projectId, now }
       )
+    ).toBe(true);
+    expect(
+      isStalePreview(activePreview({ meta: undefined }), { projectId, now })
+    ).toBe(true);
+    expect(
+      isStalePreview(activePreview({ projectId: 'prj_other' }), {
+        projectId,
+        now,
+      })
     ).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- cancel every QUEUED or BUILDING preview for the Vercel project before main deploys
- preserve production deployments and other projects unconditionally

## Live evidence
Main-only cleanup repeatedly left the production candidate QUEUED after all eligible main previews were canceled. Remaining capacity is therefore held by PR/manual previews. Main deployment now has explicit priority over all preview work.

## Tests
- branch and manual previews are eligible
- production and cross-project deployments remain protected
- Biome passed
- `git diff --check` passed

Bug-to-test: `.github/scripts/cancel-stale-vercel-previews.test.mjs`