### PR TITLE
fix(ci): close Vercel prebuilt public trace

### DIFF
--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -90,6 +90,14 @@ run_deploy() {
     return
   fi
 
+  if [ -f ".vercel/jovie-generated-public-files" ]; then
+    while IFS= read -r generated_file; do
+      if [ -n "$generated_file" ]; then
+        rm -f -- "$generated_file"
+      fi
+    done < ".vercel/jovie-generated-public-files"
+  fi
+
   "${deploy_cmd[@]}" "${VERCEL_CMD[@]}" deploy "$@" --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4621,7 +4621,7 @@ jobs:
     # saturate the production-deploy concurrency slot.
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !failure() && !cancelled() && needs.deploy-gate.outputs.is_head == 'true' }}
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 25
+    timeout-minutes: 30
     # Deploy concurrency: serialize main deploys instead of cancelling them.
     # Cancelling in-progress main deploys during merge bursts can starve
     # production promotion and leave main without a completed deploy run.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1058,8 +1058,18 @@ jobs:
           tar -xzf /tmp/vercel-runtime-node-modules.tar.gz -C apps/web/.next
           find apps/web/.next/node_modules -maxdepth 1 -type d \
             -name 'import-in-the-middle-*' -print -quit | grep -q .
+          # Vercel's function trace references the generated robots response at
+          # its public-file path even though the source route is app/robots.ts.
+          # Materialize it only inside the deploy artifact; the deploy helper
+          # removes generated public files before any source fallback.
+          test -f apps/web/.next/server/app/robots.txt.body
+          cp apps/web/.next/server/app/robots.txt.body apps/web/public/robots.txt
+          printf '%s\n' 'apps/web/public/robots.txt' \
+            > .vercel/jovie-generated-public-files
           tar -czf /tmp/vercel-build-output.tar.gz -C . \
             .vercel/output \
+            .vercel/jovie-generated-public-files \
+            apps/web/public/robots.txt \
             apps/web/.next/BUILD_ID \
             apps/web/.next/app-path-routes-manifest.json \
             apps/web/.next/build-manifest.json \
@@ -1074,6 +1084,8 @@ jobs:
             apps/web/.next/server/chunks >/dev/null
           tar -tzf /tmp/vercel-build-output.tar.gz \
             apps/web/.next/node_modules >/dev/null
+          tar -tzf /tmp/vercel-build-output.tar.gz \
+            apps/web/public/robots.txt >/dev/null
           echo "vercel_artifact=true" >> "$GITHUB_OUTPUT"
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
@@ -4840,13 +4852,13 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
 
       - name: Wait for staging deployment readiness
-        timeout-minutes: 9
+        timeout-minutes: 13
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deploy_url }}
         run: |
           ./node_modules/.bin/vercel inspect "$DEPLOYMENT_URL" \
             --wait \
-            --timeout 8m \
+            --timeout 12m \
             --token "$VERCEL_TOKEN" \
             --scope "$VERCEL_ORG_ID"
           deployment_json="$(./node_modules/.bin/vercel inspect "$DEPLOYMENT_URL" \

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -140,6 +140,24 @@ describe('deploy workflow Vercel env resolution', () => {
       'VERCEL_SCOPE_ARGS=(--scope "$VERCEL_ORG_ID")'
     );
     expect(deployScript).toContain('"${VERCEL_SCOPE_ARGS[@]}"');
+    expect(deployScript).toContain('.vercel/jovie-generated-public-files');
+    expect(deployScript).toContain('rm -f -- "$generated_file"');
+  });
+
+  it('packages generated public trace files and budgets remote fallback readiness', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const buildJob = getJobBlock(workflow, 'ci-build-public');
+    const stagingJob = getJobBlock(workflow, 'deploy-staging');
+    const readinessStep = getStepBlock(
+      stagingJob,
+      'Wait for staging deployment readiness'
+    );
+
+    expect(buildJob).toContain(
+      'cp apps/web/.next/server/app/robots.txt.body apps/web/public/robots.txt'
+    );
+    expect(buildJob).toContain('.vercel/jovie-generated-public-files');
+    expect(readinessStep).toContain('--timeout 12m');
   });
 
   it('passes signup readiness keys into the staging preview runtime', () => {


### PR DESCRIPTION
## Summary
- include the generated robots response required by Vercel function traces in the prebuilt artifact
- remove artifact-only generated public files before source fallback
- extend fallback readiness from 8 to 12 minutes

## Live evidence
After canceling 87 active previews, Vercel advanced the current deployment to BUILDING. The prebuilt upload had fallen back because `apps/web/public/robots.txt` was absent, and the remote build exceeded the 8-minute readiness budget.

## Tests
- structural assertions for generated trace closure, source cleanup, and readiness budget
- Biome passed
- `git diff --check` passed

Bug-to-test: `apps/web/tests/unit/ci/deploy-workflow.test.ts`