### PR TITLE
test(profile): remove cold import timeout flake

### DIFF
--- a/apps/web/tests/unit/profile/profile-layout-shift.test.tsx
+++ b/apps/web/tests/unit/profile/profile-layout-shift.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProfileNotificationsContextValue } from '@/components/organisms/profile-shell/types';
+import { ArtistNotificationsCTA } from '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA';
+import { ProfileInlineNotificationsCTA } from '@/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA';
 import type { Artist } from '@/types/db';
 
 const mockUseSubscriptionForm = vi.fn();
@@ -142,10 +144,6 @@ describe('notification flow shell sizing', () => {
       buildFormState({ hydrationStatus: 'checking' })
     );
 
-    const { ArtistNotificationsCTA } = await import(
-      '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA'
-    );
-
     const { container } = render(
       <ArtistNotificationsCTA artist={artist} autoOpen />
     );
@@ -155,10 +153,6 @@ describe('notification flow shell sizing', () => {
 
   it('ArtistNotificationsCTA uses the full-height inline flow shell when expanded', async () => {
     mockUseSubscriptionForm.mockReturnValue(buildFormState());
-
-    const { ArtistNotificationsCTA } = await import(
-      '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA'
-    );
 
     render(<ArtistNotificationsCTA artist={artist} autoOpen />);
 
@@ -170,10 +164,6 @@ describe('notification flow shell sizing', () => {
 
   it('ProfileInlineNotificationsCTA reuses the same full-height inline shell', async () => {
     mockUseSubscriptionForm.mockReturnValue(buildFormState());
-
-    const { ProfileInlineNotificationsCTA } = await import(
-      '@/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA'
-    );
 
     render(
       <ProfileInlineNotificationsCTA artist={artist} presentation='inline' />


### PR DESCRIPTION
## Root cause

`profile-layout-shift.test.tsx` charged each test's 5-second budget for a dynamic import of the large `ArtistNotificationsCTA` graph. On a cold worker the transform/import takes 6-9 seconds, so two unchanged layout assertions timed out before execution. This reproduced on pristine `main` (`66c82de710`) with 2/3 tests failing. The repair is rebased onto exact current `main` (`0e8725a05a`).

Classification: broken/under-budget test fixture; deterministic cold-run failure, not product behavior and not PR-specific.

## Fix

- Load the two CTA components once at module scope, outside per-test timeout accounting.
- Preserve Vitest's hoisted mocks, all three assertions, and production code unchanged.
- Add no retry, global timeout, or bypass.

## QA artifact

- Before fix on pristine `66c82de710`: 2/3 failed at 5,000 ms.
- After fix: three separate serial processes passed 3/3 each; actual test time was 89 ms, 181 ms, and 204 ms, including a run whose import phase took 8.44 seconds.
- Post-commit affected run: 3/3 passed in 80 ms.

## Review artifact

- Scope: one test fixture, 2 insertions / 12 deletions.
- Assertions unchanged; no production behavior or timeout policy changed.
- Signed commit: `4aa3619f7a`.

## Ship validation

- `pnpm biome check --write apps/web/tests/unit/profile/profile-layout-shift.test.tsx` — pass
- web typecheck — pass
- normal `.husky/pre-push` with no bypass — pass
- affected typecheck, lint, test, and CI harness bundle — pass

Urgent unblocker for #14044. Keep draft and `gated` until primary review and exact-head CI are green.

<!-- agent-run-artifact
{
  "id": "pr-14236-4aa3619f7ae01e3cc92def77f1de3813227bd842",
  "source": "github",
  "sourceRunId": "4aa3619f7ae01e3cc92def77f1de3813227bd842",
  "kind": "code_review",
  "status": "done",
  "title": "Profile layout cold-import fixture control",
  "summary": "Removed avoidable per-test dynamic import overhead after reproducing deterministic cold-worker timeouts on pristine main; assertions and production behavior are unchanged.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "classify", "write_code", "open_pr"],
  "forbiddenActions": ["ready_pr", "merge", "deploy"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "Draft fixture-only unblocker remains gated for primary review.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": null,
  "linearIssueUrl": null,
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/14236",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/14236",
      "summary": "Pristine main failed 2/3; three separate serial fixed runs passed 3/3, with assertions unchanged.",
      "checkedAt": "2026-07-13T03:41:13Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/14236/files",
      "summary": "Fixture-only review found no production changes, timeout increases, retries, assertion weakening, or unresolved findings.",
      "checkedAt": "2026-07-13T03:41:13Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/14236/checks",
      "summary": "Exact-base Biome, web typecheck, affected lint/test bundle, CI harness, and normal no-bypass pre-push passed; exact-head GitHub CI remains separately gated.",
      "checkedAt": "2026-07-13T03:41:13Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-07-13T03:41:13Z",
  "updatedAt": "2026-07-13T03:41:13Z",
  "metadata": {
    "baseSha": "0e8725a05ae457f368c0cb68826339607291710c",
    "draft": true,
    "gated": true,
    "pristineFailure": "2 of 3 tests timed out at 5000ms",
    "serialFixedRuns": 3
  }
}
-->
