### PR TITLE
fix(ci): stop self-hosted pnpm cache uploads

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -35,38 +35,18 @@ runs:
       with:
         dest: ${{ runner.temp }}/setup-pnpm
 
-    # Actions-cache-backed pnpm caching is GitHub-hosted only. Self-hosted
-    # runners (jovie-runner) keep a persistent pnpm store on disk, so the
-    # restore is pointless and the post-run save uploads ~1.2 GB — observed
-    # stalling at 0 B/s and eating the whole job timeout (Typecheck cancelled
-    # at 10m during the "Post Run" cache save, 2026-07-06).
+    # setup-node's pnpm cache is GitHub-hosted only. Every self-hosted runner,
+    # fixed or ephemeral, skips Actions cache restore/save. Fixed runners reuse
+    # their persistent local pnpm store; ephemeral runners warm a fresh store
+    # below. Do not add a separate actions/cache step here: run 29220980115
+    # uploaded a 1.335 GB store at 1-1.5 MB/s until the 20-minute canary timed
+    # out after all tests had passed.
     - name: Setup Node.js with pnpm cache
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22'
         cache: ${{ runner.environment == 'github-hosted' && 'pnpm' || '' }}
         cache-dependency-path: '**/pnpm-lock.yaml'
-
-    - name: Get pnpm store directory
-      id: pnpm-cache
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-    - name: Setup pnpm cache
-      # Static self-hosted runners reuse this store across jobs. Ephemeral
-      # containers do not, so actions/cache would upload the whole store during
-      # teardown and can keep an otherwise-finished job occupied until timeout.
-      if: >-
-        runner.environment != 'github-hosted' &&
-        !startsWith(runner.name, 'jovie-eph-') &&
-        !startsWith(runner.name, 'jovie-iso-')
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ runner.name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-${{ runner.name }}-
 
     - name: Warm pnpm store
       shell: bash

--- a/apps/web/tests/unit/ci/runner-setup-action.test.ts
+++ b/apps/web/tests/unit/ci/runner-setup-action.test.ts
@@ -5,18 +5,30 @@ import { describe, expect, it } from 'vitest';
 const repoRoot = resolve(import.meta.dirname, '../../../../..');
 
 describe('self-hosted runner setup action', () => {
-  it('does not save pnpm caches from ephemeral runners', () => {
-    const action = readFileSync(
-      resolve(repoRoot, '.github/actions/setup-node-pnpm/action.yml'),
-      'utf8'
-    );
+  const action = readFileSync(
+    resolve(repoRoot, '.github/actions/setup-node-pnpm/action.yml'),
+    'utf8'
+  );
 
-    const cacheStep = action.match(
-      /- name: Setup pnpm cache\n(?<step>[\s\S]*?)(?=\n    - name:)/
+  it('never saves pnpm stores from fixed or ephemeral self-hosted runners', () => {
+    expect(action).not.toContain('uses: actions/cache@');
+    expect(action).not.toContain('STORE_PATH=');
+    expect(action).not.toContain('steps.pnpm-cache.outputs.STORE_PATH');
+    expect(action).toContain('run: pnpm fetch --frozen-lockfile');
+    expect(action).toContain('run: pnpm install --frozen-lockfile');
+  });
+
+  it('preserves setup-node caching only for GitHub-hosted runners', () => {
+    const setupNodeStep = action.match(
+      /- name: Setup Node\.js with pnpm cache\n(?<step>[\s\S]*?)(?=\n    - name:)/
     )?.groups?.step;
 
-    expect(cacheStep).toContain('uses: actions/cache@');
-    expect(cacheStep).toContain("!startsWith(runner.name, 'jovie-eph-')");
-    expect(cacheStep).toContain("!startsWith(runner.name, 'jovie-iso-')");
+    expect(setupNodeStep).toContain('uses: actions/setup-node@');
+    expect(setupNodeStep).toContain(
+      "cache: ${{ runner.environment == 'github-hosted' && 'pnpm' || '' }}"
+    );
+    expect(setupNodeStep).toContain(
+      "cache-dependency-path: '**/pnpm-lock.yaml'"
+    );
   });
 });


### PR DESCRIPTION
## Root cause

Fixed-runner canary run `29220980115`, job `86725864631`, proved the runner itself healthy on first attempt: `gem-linux-1` checked out exact main, had 782 GiB free, installed Node 22.23.1 and pnpm 9.15.4, and passed 409 files / 3,401 tests.

The job still timed out after all tests passed because the shared setup action ran a direct `actions/cache` post-save on the self-hosted pnpm store. It created a 1,334,751,981-byte archive and uploaded at roughly 1.0–1.5 MB/s. At the 20-minute job timeout it had reached only 1,073,741,824 bytes (80.4%), and GitHub canceled `Post Setup Node.js and pnpm`.

Classification: **recurring Gem failure caused by environment/network throughput plus missing shared cache automation**. PR #14211 excluded ephemeral runner names, but left fixed Gem runners on the same unsafe upload path.

## Smallest safe fix

- Remove the direct `actions/cache` store discovery, restore, and post-save path from the shared `setup-node-pnpm` action for every self-hosted runner.
- Keep `actions/setup-node` pnpm caching unchanged for GitHub-hosted runners only.
- Keep `pnpm fetch --frozen-lockfile` and `pnpm install --frozen-lockfile`; fixed runners reuse their persistent local store naturally, while ephemeral runners warm their fresh store without a teardown upload.
- Strengthen the #14211 regression contract to ban direct `actions/cache` and store-output plumbing while pinning the hosted cache expression and fetch/install behavior.

## Safety and rollback

This changes no runner labels, repository variables, or job routing. If persistent-store reuse regresses, revert this PR; GitHub-hosted caching is unaffected throughout. A later cache design must use a bounded artifact or explicit size/throughput policy rather than restoring the unbounded shared-store save.

## Verification

- focused runner setup contract: 2/2 passed
- actionlint workflow syntax/expression validation: passed
- Biome: passed, no fixes
- `pnpm ci:harness:check`: passed
- normal bounded pre-push, no bypass: passed; affected typecheck/lint, exact 2/2 test selection, CI harness
- exact signed head: `ed7de4dfcbbd398c967a5c36f4b267c8092dda1e`

<!-- bug-to-test: apps/web/tests/unit/ci/runner-setup-action.test.ts -->
