### PR TITLE
fix(ci): use Vercel source build cache

### DIFF
--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -138,6 +138,7 @@ try_mode() {
 
 plain_prebuilt_limit=15000
 plain_prebuilt_requested="${VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK:-false}"
+force_source_deploy="${VERCEL_FORCE_SOURCE_DEPLOY:-false}"
 prebuilt_file_count="$(count_prebuilt_files)"
 has_prebuilt_output=true
 can_use_plain_prebuilt=true
@@ -162,14 +163,15 @@ resolve_vercel_cmd
 echo "Using Vercel CLI command: ${VERCEL_CMD[*]}"
 echo "Plain prebuilt fallback requested: $plain_prebuilt_requested"
 echo "Plain prebuilt fallback enabled: $can_use_plain_prebuilt"
+echo "Force source deploy: $force_source_deploy"
 
 deploy_modes=()
 
-if [ "$has_prebuilt_output" = true ]; then
+if [ "$has_prebuilt_output" = true ] && [ "$force_source_deploy" != "true" ]; then
   deploy_modes+=(tgz)
 fi
 
-if [ "$can_use_plain_prebuilt" = true ]; then
+if [ "$can_use_plain_prebuilt" = true ] && [ "$force_source_deploy" != "true" ]; then
   deploy_modes+=(plain)
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4845,6 +4845,10 @@ jobs:
             if [ $i -eq 3 ]; then exit 1; fi
           done
         env:
+          # The restored prebuilt artifact uploads but its function runtime is
+          # not healthy. Use Vercel's source-build cache until the artifact is
+          # proven runtime-closed by canary.
+          VERCEL_FORCE_SOURCE_DEPLOY: 'true'
           # The closed staging artifact contains more than Vercel's 15k plain
           # upload limit. Give the archive path the full prebuilt budget.
           VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'false'

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -142,6 +142,17 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(deployScript).toContain('"${VERCEL_SCOPE_ARGS[@]}"');
     expect(deployScript).toContain('.vercel/jovie-generated-public-files');
     expect(deployScript).toContain('rm -f -- "$generated_file"');
+    expect(deployScript).toContain('VERCEL_FORCE_SOURCE_DEPLOY');
+  });
+
+  it('uses the Vercel source cache while prebuilt runtime closure is unhealthy', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const deployStep = getStepBlock(
+      workflow,
+      'Deploy (staging preview, prebuilt)'
+    );
+
+    expect(deployStep).toContain("VERCEL_FORCE_SOURCE_DEPLOY: 'true'");
   });
 
   it('packages generated public trace files and budgets remote fallback readiness', () => {


### PR DESCRIPTION
## Summary
- bypass the unhealthy prebuilt runtime for staging deployments
- deploy source directly after clearing preview capacity
- retain Vercel remote build caching and the 12-minute readiness budget

## Live evidence
The prebuilt deployment reached READY but returned HTTP 500 for `/api/health` through all canary retries. Source deployments previously reached BUILDING cleanly once the preview queue was drained.

## Tests
- structural assertions for the source-cache mode
- Biome passed
- `git diff --check` passed

Bug-to-test: `apps/web/tests/unit/ci/deploy-workflow.test.ts`