### PR TITLE
fix(ci): budget Vercel source build readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4621,7 +4621,7 @@ jobs:
     # saturate the production-deploy concurrency slot.
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !failure() && !cancelled() && needs.deploy-gate.outputs.is_head == 'true' }}
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     # Deploy concurrency: serialize main deploys instead of cancelling them.
     # Cancelling in-progress main deploys during merge bursts can starve
     # production promotion and leave main without a completed deploy run.
@@ -4856,13 +4856,13 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
 
       - name: Wait for staging deployment readiness
-        timeout-minutes: 13
+        timeout-minutes: 21
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deploy_url }}
         run: |
           ./node_modules/.bin/vercel inspect "$DEPLOYMENT_URL" \
             --wait \
-            --timeout 12m \
+            --timeout 20m \
             --token "$VERCEL_TOKEN" \
             --scope "$VERCEL_ORG_ID"
           deployment_json="$(./node_modules/.bin/vercel inspect "$DEPLOYMENT_URL" \

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -168,7 +168,7 @@ describe('deploy workflow Vercel env resolution', () => {
       'cp apps/web/.next/server/app/robots.txt.body apps/web/public/robots.txt'
     );
     expect(buildJob).toContain('.vercel/jovie-generated-public-files');
-    expect(readinessStep).toContain('--timeout 12m');
+    expect(readinessStep).toContain('--timeout 20m');
   });
 
   it('passes signup readiness keys into the staging preview runtime', () => {


### PR DESCRIPTION
## Summary
- allow 20 minutes for the Vercel source build to reach READY
- expand the enclosing staging job to 40 minutes

## Live evidence
After deterministic queue cleanup, the source deployment started immediately and remained BUILDING at the 12-minute cutoff. Repeatedly restarting it guarantees starvation.

## Tests
- structural deploy-budget regression updated
- `git diff --check` passed

Bug-to-test: `apps/web/tests/unit/ci/deploy-workflow.test.ts`