### PR TITLE
fix(ci): hand active Vercel build to canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4860,22 +4860,30 @@ jobs:
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deploy_url }}
         run: |
+          inspect_wait_status=0
           ./node_modules/.bin/vercel inspect "$DEPLOYMENT_URL" \
             --wait \
             --timeout 20m \
             --token "$VERCEL_TOKEN" \
-            --scope "$VERCEL_ORG_ID"
+            --scope "$VERCEL_ORG_ID" || inspect_wait_status=$?
           deployment_json="$(./node_modules/.bin/vercel inspect "$DEPLOYMENT_URL" \
             --format=json \
             --token "$VERCEL_TOKEN" \
             --scope "$VERCEL_ORG_ID")"
-          if ! jq -e '((.readyState // .state // .status // "") | ascii_upcase) == "READY"' \
-            <<<"$deployment_json" >/dev/null; then
-            echo "::error::Vercel inspect returned before the staging deployment reached READY."
-            jq -r '"Current deployment state: \(.readyState // .state // .status // "unknown")"' \
-              <<<"$deployment_json"
-            exit 1
-          fi
+          deployment_state="$(jq -r '(.readyState // .state // .status // "unknown") | ascii_upcase' \
+            <<<"$deployment_json")"
+          echo "Current deployment state: $deployment_state"
+          case "$deployment_state" in
+            READY)
+              ;;
+            BUILDING|QUEUED|INITIALIZING)
+              echo "::warning::Vercel is still $deployment_state after readiness wait (status $inspect_wait_status); handing off to retrying canary."
+              ;;
+            *)
+              echo "::error::Vercel deployment entered terminal state $deployment_state."
+              exit 1
+              ;;
+          esac
 
       - name: Encode deployment URL for downstream jobs
         id: encode_deploy_url

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -169,6 +169,8 @@ describe('deploy workflow Vercel env resolution', () => {
     );
     expect(buildJob).toContain('.vercel/jovie-generated-public-files');
     expect(readinessStep).toContain('--timeout 20m');
+    expect(readinessStep).toContain('BUILDING|QUEUED|INITIALIZING)');
+    expect(readinessStep).toContain('handing off to retrying canary');
   });
 
   it('passes signup readiness keys into the staging preview runtime', () => {

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -261,7 +261,7 @@ def test_masked_deployment_url_is_encoded_across_job_boundary() -> None:
     assert "base64 --decode" in canary_workflow
 
 
-def test_readiness_gate_checks_ready_state_after_vercel_wait() -> None:
+def test_readiness_gate_hands_active_deployment_to_retrying_canary() -> None:
     workflow = CI_WORKFLOW.read_text()
     readiness = workflow[
         workflow.index("- name: Wait for staging deployment readiness") : workflow.index(
@@ -271,4 +271,6 @@ def test_readiness_gate_checks_ready_state_after_vercel_wait() -> None:
 
     assert "--wait" in readiness
     assert "--format=json" in readiness
-    assert 'ascii_upcase) == "READY"' in readiness
+    assert "BUILDING|QUEUED|INITIALIZING)" in readiness
+    assert "handing off to retrying canary" in readiness
+    assert "terminal state" in readiness


### PR DESCRIPTION
## Summary
- hand BUILDING, QUEUED, or INITIALIZING deployments to the retrying canary after readiness timeout
- keep terminal Vercel states blocking
- avoid abandoning and restarting healthy long-running builds

## Live evidence
Queue cleanup succeeded and the source deployment remained BUILDING after 20 minutes. The downstream canary already owns retrying HTTP health verification and promotion safety.

## Tests
- `python3 -m pytest scripts/tests/test_vercel_prebuilt_deploy.py -q`
- `git diff --check`

Bug-to-test: `scripts/tests/test_vercel_prebuilt_deploy.py`