### PR TITLE
fix(ci): route main builds to hosted capacity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -884,7 +884,9 @@ jobs:
     # On main push: always runs for full coverage + JOV-4087 vercel deploy artifact.
     # Fork PRs are excluded (no secrets) — skipped via fork-pr-gate.
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false) || github.event_name == 'workflow_dispatch') }}
-    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
+    # Production deploy artifacts must not wait behind the saturated fixed PR
+    # runner. Keep PR builds on jovie-fixed; route main to hosted capacity.
+    runs-on: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'ubuntu-latest' || vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     outputs:
       has_artifact: ${{ steps.check_changes.outputs.run_full_ci }}

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -56,6 +56,15 @@ function getJobBlock(workflow: string, jobKey: string): string {
 }
 
 describe('deploy workflow Vercel env resolution', () => {
+  it('routes main deploy artifact builds to hosted capacity', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const buildJob = getJobBlock(workflow, 'ci-build-public');
+
+    expect(buildJob).toContain("github.ref == 'refs/heads/main'");
+    expect(buildJob).toContain("&& 'ubuntu-latest'");
+    expect(buildJob).toContain("|| vars.CI_FAST_RUNNER");
+  });
+
   it('pins Vercel pull and build commands to the configured project', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const steps = [


### PR DESCRIPTION
## Summary
- route only main public builds to ubuntu-latest
- keep PR builds on the configured fixed runner

## Live evidence
The current main build has remained queued on jovie-fixed for more than 15 minutes after obsolete main runs were canceled.

## Cost
Hosted minutes increase only for post-merge main public builds; PR build routing is unchanged.

## Tests
- structural runner-routing assertion
- `git diff --check` passed

Bug-to-test: `apps/web/tests/unit/ci/deploy-workflow.test.ts`