### PR TITLE
fix(ci): route main deploy jobs to hosted capacity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4589,7 +4589,7 @@ jobs:
     name: Deploy Gate (HEAD-only)
     needs: [ci-path-changes, ci-build-public]
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !failure() && !cancelled() }}
-    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       is_head: ${{ steps.check.outputs.is_head }}
@@ -4622,7 +4622,7 @@ jobs:
     # Intermediate commits (not main HEAD at gate time) skip so they don't
     # saturate the production-deploy concurrency slot.
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !failure() && !cancelled() && needs.deploy-gate.outputs.is_head == 'true' }}
-    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     # Deploy concurrency: serialize main deploys instead of cancelling them.
     # Cancelling in-progress main deploys during merge bursts can starve

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -65,6 +65,17 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(buildJob).toContain("|| vars.CI_FAST_RUNNER");
   });
 
+  it('runs main deploy control jobs on hosted capacity', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+
+    expect(getJobBlock(workflow, 'deploy-gate')).toContain(
+      'runs-on: ubuntu-latest'
+    );
+    expect(getJobBlock(workflow, 'deploy-staging')).toContain(
+      'runs-on: ubuntu-latest'
+    );
+  });
+
   it('pins Vercel pull and build commands to the configured project', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const steps = [


### PR DESCRIPTION
## Summary
- run the main-only HEAD deploy gate on ubuntu-latest
- run main staging deploy on ubuntu-latest
- leave PR routing unchanged

## Live evidence
The hosted main build completed in four minutes, then its tiny HEAD gate remained queued on jovie-fixed.

## Cost
Hosted usage applies only to main deploy control jobs, not PR lanes.

## Tests
- structural runner-routing assertions
- `git diff --check` passed

Bug-to-test: `apps/web/tests/unit/ci/deploy-workflow.test.ts`