### PR TITLE
fix(ci): route promotion chain to hosted capacity

### DIFF
--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   canary-health-gate:
     name: Canary health gate
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
       canary_status: ${{ steps.canary-status.outputs.canary_status || steps.canary-check.outputs.canary_status }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4921,7 +4921,7 @@ jobs:
     name: Alias verified preview to staging.jov.ie
     needs: [deploy-staging, canary-health-gate]
     if: ${{ always() && needs.deploy-staging.result == 'success' && needs.canary-health-gate.result == 'success' }}
-    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
       group: production-deploy
@@ -4946,7 +4946,7 @@ jobs:
     name: Promote to Production
     needs: [deploy-staging, canary-health-gate, alias-staging]
     if: ${{ always() && needs.deploy-staging.result == 'success' && needs.canary-health-gate.result == 'success' && needs.alias-staging.result == 'success' }}
-    runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
       group: production-deploy

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -74,6 +74,15 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(getJobBlock(workflow, 'deploy-staging')).toContain(
       'runs-on: ubuntu-latest'
     );
+    expect(getJobBlock(workflow, 'alias-staging')).toContain(
+      'runs-on: ubuntu-latest'
+    );
+    expect(getJobBlock(workflow, 'promote-production')).toContain(
+      'runs-on: ubuntu-latest'
+    );
+    expect(readFileSync(canaryWorkflowPath, 'utf8')).toContain(
+      'runs-on: ubuntu-latest'
+    );
   });
 
   it('pins Vercel pull and build commands to the configured project', () => {


### PR DESCRIPTION
## Summary
- run staging canary on ubuntu-latest
- run staging alias and production promotion on ubuntu-latest
- leave PR lanes on the fixed runner

## Live evidence
A healthy staging deployment waited more than 12 minutes for the fixed-runner canary.

## Cost
Hosted usage applies only to the main promotion chain.

## Tests
- structural hosted-runner assertions
- `git diff --check` passed

Bug-to-test: `apps/web/tests/unit/ci/deploy-workflow.test.ts`