### PR TITLE
fix(ci): make preview congestion controls state-aware

### DIFF
--- a/.github/scripts/cancel-stale-vercel-previews.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.mjs
@@ -3,12 +3,25 @@
 const API_BASE = 'https://api.vercel.com';
 const ACTIVE_STATES = ['QUEUED', 'BUILDING'];
 const MAX_CANCELLATIONS = 100;
-export const DEFAULT_MIN_AGE_MS = 15 * 60 * 1000;
+export const DEFAULT_QUEUED_MIN_AGE_MS = 30 * 60 * 1000;
+export const DEFAULT_BUILDING_MIN_AGE_MS = 30 * 60 * 1000;
 
-function requireValidMinAge(minAgeMs) {
-  if (!Number.isFinite(minAgeMs) || minAgeMs < 0) {
-    throw new Error('Vercel preview minimum age must be a non-negative number');
+function requireValidMinAges(queuedMinAgeMs, buildingMinAgeMs) {
+  if (!Number.isFinite(queuedMinAgeMs) || queuedMinAgeMs < 0) {
+    throw new Error(
+      'Vercel queued preview minimum age must be a non-negative number'
+    );
   }
+  if (!Number.isFinite(buildingMinAgeMs) || buildingMinAgeMs < 0) {
+    throw new Error(
+      'Vercel building preview minimum age must be a non-negative number'
+    );
+  }
+}
+
+function validTimestamp(value) {
+  const timestamp = Number(value);
+  return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : null;
 }
 
 export function isStalePreview(
@@ -16,22 +29,25 @@ export function isStalePreview(
   {
     projectId,
     now = Date.now(),
-    minAgeMs = DEFAULT_MIN_AGE_MS,
+    queuedMinAgeMs = DEFAULT_QUEUED_MIN_AGE_MS,
+    buildingMinAgeMs = DEFAULT_BUILDING_MIN_AGE_MS,
     currentSha = '',
   }
 ) {
-  requireValidMinAge(minAgeMs);
+  requireValidMinAges(queuedMinAgeMs, buildingMinAgeMs);
   const state = (deployment.readyState ?? deployment.state ?? '').toUpperCase();
-  const createdAt = Number(deployment.createdAt ?? deployment.created);
+  const createdAt = validTimestamp(deployment.createdAt ?? deployment.created);
+  const buildingAt = validTimestamp(deployment.buildingAt);
+  const activeSince = state === 'BUILDING' ? buildingAt : createdAt;
+  const minAgeMs = state === 'BUILDING' ? buildingMinAgeMs : queuedMinAgeMs;
   const deploymentSha = deployment.meta?.githubCommitSha ?? '';
 
   return (
     deployment.projectId === projectId &&
     deployment.target !== 'production' &&
     ACTIVE_STATES.includes(state) &&
-    Number.isFinite(createdAt) &&
-    createdAt > 0 &&
-    now - createdAt >= minAgeMs &&
+    activeSince !== null &&
+    now - activeSince >= minAgeMs &&
     (!currentSha || deploymentSha !== currentSha)
   );
 }
@@ -63,12 +79,13 @@ export async function cancelStalePreviews({
   token,
   orgId,
   projectId,
-  minAgeMs = DEFAULT_MIN_AGE_MS,
+  queuedMinAgeMs = DEFAULT_QUEUED_MIN_AGE_MS,
+  buildingMinAgeMs = DEFAULT_BUILDING_MIN_AGE_MS,
   currentSha = '',
   now = Date.now(),
   request = vercelRequest,
 }) {
-  requireValidMinAge(minAgeMs);
+  requireValidMinAges(queuedMinAgeMs, buildingMinAgeMs);
   const deployments = [];
 
   for (const state of ACTIVE_STATES) {
@@ -91,7 +108,8 @@ export async function cancelStalePreviews({
         .filter(deployment =>
           isStalePreview(deployment, {
             projectId,
-            minAgeMs,
+            queuedMinAgeMs,
+            buildingMinAgeMs,
             currentSha,
             now,
           })
@@ -140,8 +158,11 @@ async function main() {
   const orgId = process.env.VERCEL_ORG_ID ?? '';
   const projectId = process.env.VERCEL_PROJECT_ID ?? '';
   const currentSha = process.env.GITHUB_SHA ?? '';
-  const minAgeMinutes = Number(
-    process.env.VERCEL_PREVIEW_MIN_AGE_MINUTES ?? '15'
+  const queuedMinAgeMinutes = Number(
+    process.env.VERCEL_PREVIEW_QUEUED_MIN_AGE_MINUTES ?? '30'
+  );
+  const buildingMinAgeMinutes = Number(
+    process.env.VERCEL_PREVIEW_BUILDING_MIN_AGE_MINUTES ?? '30'
   );
   const missing = Object.entries({ token, orgId, projectId })
     .filter(([, value]) => !value)
@@ -153,8 +174,15 @@ async function main() {
     );
   }
 
-  if (!Number.isFinite(minAgeMinutes) || minAgeMinutes < 0) {
-    throw new Error('VERCEL_PREVIEW_MIN_AGE_MINUTES must be non-negative');
+  if (!Number.isFinite(queuedMinAgeMinutes) || queuedMinAgeMinutes < 0) {
+    throw new Error(
+      'VERCEL_PREVIEW_QUEUED_MIN_AGE_MINUTES must be non-negative'
+    );
+  }
+  if (!Number.isFinite(buildingMinAgeMinutes) || buildingMinAgeMinutes < 0) {
+    throw new Error(
+      'VERCEL_PREVIEW_BUILDING_MIN_AGE_MINUTES must be non-negative'
+    );
   }
 
   await cancelStalePreviews({
@@ -162,7 +190,8 @@ async function main() {
     orgId,
     projectId,
     currentSha,
-    minAgeMs: minAgeMinutes * 60 * 1000,
+    queuedMinAgeMs: queuedMinAgeMinutes * 60 * 1000,
+    buildingMinAgeMs: buildingMinAgeMinutes * 60 * 1000,
   });
 }
 

--- a/.github/scripts/cancel-stale-vercel-previews.test.mjs
+++ b/.github/scripts/cancel-stale-vercel-previews.test.mjs
@@ -13,7 +13,7 @@ const activePreview = (overrides = {}) => ({
   projectId,
   target: null,
   readyState: 'QUEUED',
-  createdAt: now - 20 * 60 * 1000,
+  createdAt: now - 31 * 60 * 1000,
   meta: { githubCommitRef: 'main', githubCommitSha: 'old-sha' },
   ...overrides,
 });
@@ -60,6 +60,54 @@ describe('cancel stale Vercel previews', () => {
     ).toBe(false);
   });
 
+  it('uses independent 30-minute boundaries for queued and building previews', () => {
+    expect(
+      isStalePreview(activePreview({ createdAt: now - (30 * 60 * 1000 - 1) }), {
+        projectId,
+        now,
+      })
+    ).toBe(false);
+    expect(
+      isStalePreview(activePreview({ createdAt: now - 30 * 60 * 1000 }), {
+        projectId,
+        now,
+      })
+    ).toBe(true);
+
+    const building = activePreview({
+      readyState: 'BUILDING',
+      createdAt: now - 45 * 60 * 1000,
+      buildingAt: now - (30 * 60 * 1000 - 1),
+    });
+    expect(isStalePreview(building, { projectId, now })).toBe(false);
+    expect(
+      isStalePreview(
+        { ...building, buildingAt: now - 30 * 60 * 1000 },
+        { projectId, now }
+      )
+    ).toBe(true);
+  });
+
+  it('preserves building previews when the building timestamp is missing or invalid', () => {
+    const staleBuilding = activePreview({
+      readyState: 'BUILDING',
+      createdAt: now - 31 * 60 * 1000,
+    });
+    expect(isStalePreview(staleBuilding, { projectId, now })).toBe(false);
+    expect(
+      isStalePreview(
+        { ...staleBuilding, buildingAt: 'invalid' },
+        { projectId, now }
+      )
+    ).toBe(false);
+    expect(
+      isStalePreview(
+        { ...staleBuilding, createdAt: 'invalid', buildingAt: 'invalid' },
+        { projectId, now }
+      )
+    ).toBe(false);
+  });
+
   it('fails closed for invalid timestamps and minimum-age configuration', () => {
     expect(
       isStalePreview(activePreview({ createdAt: 'invalid' }), {
@@ -68,28 +116,47 @@ describe('cancel stale Vercel previews', () => {
       })
     ).toBe(false);
     expect(() =>
-      isStalePreview(activePreview(), { projectId, now, minAgeMs: Number.NaN })
-    ).toThrow(/minimum age/);
+      isStalePreview(activePreview(), {
+        projectId,
+        now,
+        queuedMinAgeMs: Number.NaN,
+      })
+    ).toThrow(/queued preview minimum age/);
+    expect(() =>
+      isStalePreview(activePreview(), {
+        projectId,
+        now,
+        buildingMinAgeMs: Number.NaN,
+      })
+    ).toThrow(/building preview minimum age/);
   });
 
   it('does not call Vercel when minimum-age configuration is invalid', async () => {
     const request = vi.fn();
 
-    await expect(
-      cancelStalePreviews({
-        token: 'token',
-        orgId: 'team_org',
-        projectId,
-        minAgeMs: Number.NaN,
-        request,
-      })
-    ).rejects.toThrow(/minimum age/);
+    for (const invalidConfig of [
+      { queuedMinAgeMs: Number.NaN },
+      { buildingMinAgeMs: Number.NaN },
+    ]) {
+      await expect(
+        cancelStalePreviews({
+          token: 'token',
+          orgId: 'team_org',
+          projectId,
+          ...invalidConfig,
+          request,
+        })
+      ).rejects.toThrow(/preview minimum age/);
+    }
     expect(request).not.toHaveBeenCalled();
   });
 
   it('lists both active states and cancels each stale preview once', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(now);
-    const stale = activePreview({ readyState: 'BUILDING' });
+    const stale = activePreview({
+      readyState: 'BUILDING',
+      buildingAt: now - 31 * 60 * 1000,
+    });
     const production = activePreview({ uid: 'dpl_prod', target: 'production' });
     const request = vi
       .fn()

--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -127,7 +127,7 @@ try_mode() {
     echo "Deploy attempt $attempt with ${mode} upload exceeded its time budget" >&2
     local accepted_deployment_url=""
     accepted_deployment_url="$(parse_deployment_url "$deploy_output")"
-    if [ "$mode" = "source" ] && [ -n "$accepted_deployment_url" ]; then
+    if [ -n "$accepted_deployment_url" ]; then
       write_deployment_url "$accepted_deployment_url"
       echo "Vercel accepted ${accepted_deployment_url}; downstream health gates will verify readiness"
       return 0

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -10,13 +10,16 @@ CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
 CANARY_WORKFLOW = REPO_ROOT / ".github/workflows/canary-health-gate.yml"
 
 
-def test_timed_out_prebuilt_uploads_fall_back_to_source(tmp_path: Path) -> None:
+def test_timed_out_prebuilt_with_accepted_url_hands_off_to_health_gate(
+    tmp_path: Path,
+) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     fake_vercel = bin_dir / "vercel"
     fake_vercel.write_text(
         """#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" >> "${VERCEL_CALL_LOG}"
 if [[ " $* " == *" --prebuilt "* ]]; then
   echo "https://jovie-incomplete-prebuilt.vercel.app"
   trap '' TERM
@@ -44,6 +47,68 @@ echo "https://jovie-timeout-test.vercel.app"
             "VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS": "1",
             "VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS": "5",
             "VERCEL_DEPLOY_KILL_GRACE_SECONDS": "1",
+            "VERCEL_CALL_LOG": str(tmp_path / "vercel-calls"),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(DEPLOY_SCRIPT), "deploy_url", "--yes"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stderr.count("exceeded its time budget") == 1
+    assert "downstream health gates will verify readiness" in result.stdout
+    assert output_file.read_text().strip() == (
+        "deploy_url=https://jovie-incomplete-prebuilt.vercel.app"
+    )
+    calls = (tmp_path / "vercel-calls").read_text().splitlines()
+    assert len(calls) == 1
+    assert "--prebuilt --archive=tgz" in calls[0]
+
+
+def test_timed_out_prebuilt_without_accepted_url_falls_back_to_source(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_vercel = bin_dir / "vercel"
+    fake_vercel.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${VERCEL_CALL_LOG}"
+if [[ " $* " == *" --prebuilt "* ]]; then
+  trap '' TERM
+  sleep 5
+  exit 1
+fi
+echo "https://jovie-source-fallback.vercel.app"
+"""
+    )
+    fake_vercel.chmod(0o755)
+
+    output_file = tmp_path / "github-output"
+    prebuilt_output = tmp_path / ".vercel/output"
+    prebuilt_output.mkdir(parents=True)
+    (prebuilt_output / "config.json").write_text("{}")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "VERCEL_TOKEN": "test-token",
+            "VERCEL_ORG_ID": "test-org",
+            "GITHUB_OUTPUT": str(output_file),
+            "VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK": "false",
+            "VERCEL_DEPLOY_ARCHIVE_TIMEOUT_SECONDS": "1",
+            "VERCEL_DEPLOY_SOURCE_TIMEOUT_SECONDS": "5",
+            "VERCEL_DEPLOY_KILL_GRACE_SECONDS": "1",
+            "VERCEL_CALL_LOG": str(tmp_path / "vercel-calls"),
         }
     )
 
@@ -61,8 +126,67 @@ echo "https://jovie-timeout-test.vercel.app"
     assert result.stderr.count("exceeded its time budget") == 1
     assert "Deploy succeeded on attempt 2 with source upload" in result.stdout
     assert output_file.read_text().strip() == (
-        "deploy_url=https://jovie-timeout-test.vercel.app"
+        "deploy_url=https://jovie-source-fallback.vercel.app"
     )
+    calls = (tmp_path / "vercel-calls").read_text().splitlines()
+    assert len(calls) == 2
+    assert "--prebuilt --archive=tgz" in calls[0]
+    assert "--prebuilt" not in calls[1]
+
+
+def test_failed_prebuilt_with_url_still_falls_back_to_source(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_vercel = bin_dir / "vercel"
+    fake_vercel.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${VERCEL_CALL_LOG}"
+if [[ " $* " == *" --prebuilt "* ]]; then
+  echo "https://jovie-canceled-archive.vercel.app"
+  exit 1
+fi
+echo "https://jovie-source-after-cancel.vercel.app"
+"""
+    )
+    fake_vercel.chmod(0o755)
+
+    output_file = tmp_path / "github-output"
+    prebuilt_output = tmp_path / ".vercel/output"
+    prebuilt_output.mkdir(parents=True)
+    (prebuilt_output / "config.json").write_text("{}")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "VERCEL_TOKEN": "test-token",
+            "VERCEL_ORG_ID": "test-org",
+            "GITHUB_OUTPUT": str(output_file),
+            "VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK": "false",
+            "VERCEL_CALL_LOG": str(tmp_path / "vercel-calls"),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(DEPLOY_SCRIPT), "deploy_url", "--yes"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Deploy succeeded on attempt 2 with source upload" in result.stdout
+    assert output_file.read_text().strip() == (
+        "deploy_url=https://jovie-source-after-cancel.vercel.app"
+    )
+    calls = (tmp_path / "vercel-calls").read_text().splitlines()
+    assert len(calls) == 2
+    assert "--prebuilt --archive=tgz" in calls[0]
+    assert "--prebuilt" not in calls[1]
 
 
 def test_default_attempt_budgets_leave_one_minute_for_step_overhead() -> None:


### PR DESCRIPTION
## Summary

- Treat a timed-out Vercel upload that already returned a deployment URL as an accepted handoff for both archive and source modes. The downstream readiness gate remains responsible for terminal health, so CI no longer creates a duplicate deployment solely because the CLI stayed attached after acceptance.
- Keep immediate non-timeout upload failures eligible for fallback, including the observed archive-cancellation case.
- Make the preview reaper state-aware: QUEUED age starts at `createdAt`, BUILDING age starts only at a valid `buildingAt`, and both thresholds default independently to 30 minutes. Missing or invalid timestamps preserve the deployment.
- Add regression coverage for accepted timeout handoff, fallback behavior, state-specific age boundaries, invalid timestamps, and invalid configuration.

## Root cause and classification

**Classification:** recurring Vercel/Gem automation failure caused by dependency/environment behavior under deployment congestion. It is not PR-specific.

The deploy helper treated every archive timeout as a failed upload even when Vercel had already accepted the archive and emitted its deployment URL. It then submitted a plain-prebuilt fallback and a source fallback, multiplying work in an already congested Vercel queue. Separately, the reaper measured BUILDING age from `createdAt`, so a deployment that queued for a long time could be canceled shortly after its actual build began.

This PR separates acceptance from readiness: once a timed-out command has emitted a valid deployment URL, exactly one downstream readiness control owns terminal verification. It also uses state-specific clocks and fails closed when the relevant timestamp is unavailable.

## Incident timing evidence

- **E6MA — immediate archive cancellation:** `dpl_E6MAh4tqqo3qSQGPB1Pwd4WpVzJp` was accepted/BUILDING at `07:10:34.798Z` and canceled at `07:11:28.502Z` (53.704 seconds). `canceledBy` was null and the API exposed no error code, message, or events. The repository reaper did not run until `07:18:36Z–07:18:37Z` and canceled zero deployments. This remains an immediate non-timeout failure, so fallback is correct.
- **A1K — accepted archive timeout:** the 188 MB tgz upload emitted inspect slug `A1KzC8TFPYE6HMmQbxDMyzL2sxAY` and a preview URL, then remained attached from `07:52:14.866Z` until the 480-second budget expired at `08:00:14.879Z` (480.013 seconds). The old helper discarded that accepted URL and created more deployments.
- **FMB — duplicate source handoff:** fallback deployment `dpl_FMB3pBx9RCPTUDRweAuCRfyLGDiX` emitted its URL at `08:00:49.774Z` after the 30-second source budget. The downstream readiness check waited a further eight minutes and observed `BUILDING` at `08:08:52.594Z`; PR #14268 correctly refused the false green. The deploy helper should hand an accepted URL to that terminal-state gate instead of creating another deployment.

Evidence: [PR #14268 preview job](https://github.com/JovieInc/Jovie/actions/runs/29233204686/job/86762119102).

## Bug-to-Test

bug-to-test: satisfied — `scripts/tests/test_vercel_prebuilt_deploy.py` and `.github/scripts/cancel-stale-vercel-previews.test.mjs`

## Verification

- Node `v22.22.1`, pnpm `9.15.4`
- `python3 -m pytest -q scripts/tests/test_vercel_prebuilt_deploy.py` — 11 passed
- focused Vitest reaper suite — 7 passed
- `pnpm ci:harness:check` — passed
- actionlint with repository ShellCheck exclusions — passed
- Biome, `bash -n`, `node --check`, and `git diff --check` — passed
- SSH signature verified for head `c4d62d8f02c136747bcbd96ff9c0ea8fa9497e3b`

## Scope and controls

- Base SHA: `710d6e08b518f6e07784cf57b67e6b71352c3e5a`
- Head SHA: `c4d62d8f02c136747bcbd96ff9c0ea8fa9497e3b`
- Ready but quarantined with `gated` only. Do not remove `gated`, enroll, or merge until exact-head CI passes and primary review approves landing.

<!-- agent-run-artifact
{
  "id": "run-vercel-congestion-control-c4d62d8f02",
  "source": "github",
  "sourceRunId": "c4d62d8f02c136747bcbd96ff9c0ea8fa9497e3b",
  "kind": "workflow",
  "status": "done",
  "title": "State-aware Vercel congestion controls",
  "summary": "Rebased the verified congestion-control patch directly onto current main after Graphite failed to materialize a valid synthetic.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "classify", "write_code", "open_pr"],
  "forbiddenActions": ["ready_pr", "merge", "deploy", "mutate_linear", "send_outbound", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": null,
  "linearIssueUrl": null,
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/14273",
  "adminSurface": "/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "11 deploy-helper cases and 7 reaper cases passed under Node 22.22.1.",
      "checkedAt": "2026-07-13T09:44:46.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Stable patch ID exactly matches the previously approved source patch.",
      "checkedAt": "2026-07-13T09:44:46.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Single SSH-signed commit on exact current main; actionlint, CI harness, Biome, syntax, typecheck, affected pre-push, and diff checks passed.",
      "checkedAt": "2026-07-13T09:44:46.000Z"
    },
    {
      "name": "github.ci",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/actions/runs/29240445343",
      "summary": "All 69 collapsed latest-name checks completed with no terminal failure on the exact rebased head.",
      "checkedAt": "2026-07-13T09:54:00.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Repository-local deterministic verification."
  },
  "blockedReason": null,
  "createdAt": "2026-07-13T09:44:46.000Z",
  "updatedAt": "2026-07-13T09:54:00.000Z",
  "metadata": {
    "draft": false,
    "gated": true,
    "testing": false,
    "productCodeChanged": false,
    "changedFiles": 4,
    "baseSha": "710d6e08b518f6e07784cf57b67e6b71352c3e5a",
    "headSha": "c4d62d8f02c136747bcbd96ff9c0ea8fa9497e3b",
    "treeSha": "e96d62be92d162fff5e2dbe0bb7d236abd436630",
    "stablePatchId": "3eac1796f6b21050245cebd964c62e7ccfd67645",
    "incidentPr": 14245,
    "readinessControlPr": 14268
  }
}
-->
