### PR TITLE
docs(ci): retire fixed-runner cancellation healer

### DIFF
--- a/docs/archive/PR-14299-RETIREMENT.md
+++ b/docs/archive/PR-14299-RETIREMENT.md
@@ -1,0 +1,13 @@
+# PR #14299 Retirement
+
+The fixed-runner cancellation healer is retired. Native merge-queue staging in
+[#14484](https://github.com/JovieInc/Jovie/pull/14484) moved source-PR unit
+evidence to the exact combined head and routes those shards through
+`CI_UNIT_RUNNER`; the deterministic source `ci-fast` lane now uses hosted
+capacity. Reintroducing a `workflow_run` job with `actions: write` would add a
+second cancellation mutation controller beside the native queue and runner
+routing controls.
+
+Replacement: #14484 at `153d2e92b67eec0830fe5f194ff39ba3d8745030`
+and #14485 at `4182a46470b5344234969ad375b00207a8fe5dd5`. No healer
+workflow or classifier from #14299 remains.


### PR DESCRIPTION
## Summary

- Retires the fixed-runner cancellation healer after native merge-queue staging and conservative heartbeat routing superseded it.
- Preserves only `docs/archive/PR-14299-RETIREMENT.md` as the audit record.
- No workflow, classifier, cancellation mutator, product code, or deploy code from the previous payload remains.

## Supersession

- Native queue topology: #14484 at `153d2e92b67eec0830fe5f194ff39ba3d8745030`
- Native queue unblock: #14485 at `4182a46470b5344234969ad375b00207a8fe5dd5`
- GitHub Update Branch rebased this retirement record onto `main` at `d208da0cb385065c8dd8ca794067230e14d366d3`.

## Verification

- Exact head: `36fa106bec6f318186771fc3a6598fadcaeaa256`
- Exact tree: `8cbd2bb813f773ce86e611229f643328c57089ec`
- Diff: one added Markdown file, 13 lines.
- Stable patch ID matches the reviewed signed preparation: `80db4c5f60096a30468fac2cd1f33b37df0393b8`.
- `git diff --check`: passed.

## Queue control

Staged only. This operation did not merge or enqueue the PR.