### PR TITLE
fix(ci): select Vercel congestion regressions

### DIFF
--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -3,7 +3,10 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { buildAffectedTestPlan } from '../../run-affected-tests.mjs';
+import {
+  buildAffectedTestPlan,
+  buildSelectedTestCommands,
+} from '../../run-affected-tests.mjs';
 
 const runner = readFileSync(
   resolve(import.meta.dirname, '../../run-affected-tests.mjs'),
@@ -66,6 +69,16 @@ const PREREQUISITE_TRAIN_TESTS = [
   'apps/web/tests/unit/e2e/seed-test-data.test.ts',
   'apps/web/tests/unit/lib/auth/dev-test-auth.server.test.ts',
   'apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx',
+];
+const VERCEL_CONGESTION_CONTROL_MANIFEST = [
+  '.github/scripts/cancel-stale-vercel-previews.mjs',
+  '.github/scripts/cancel-stale-vercel-previews.test.mjs',
+  '.github/scripts/vercel-prebuilt-deploy.sh',
+  'scripts/tests/test_vercel_prebuilt_deploy.py',
+];
+const AFFECTED_TEST_SELECTOR_MANIFEST = [
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
 
 describe('automation-verify affected scope', () => {
@@ -314,6 +327,107 @@ describe('automation-verify affected scope', () => {
   ])('fails closed when the prerequisite train includes unknown peer %s', peer => {
     expect(
       buildAffectedTestPlan([...PREREQUISITE_TRAIN_MANIFEST, peer]).mode
+    ).toBe('full');
+  });
+
+  it('keeps the Vercel congestion-control diff on its focused cross-runtime suites', () => {
+    const plan = buildAffectedTestPlan(VERCEL_CONGESTION_CONTROL_MANIFEST);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.relatedFiles).toEqual([]);
+    expect(plan.selectedTests).toEqual([]);
+    expect(plan.rootVitestTests).toEqual([
+      '.github/scripts/cancel-stale-vercel-previews.test.mjs',
+    ]);
+    expect(plan.pythonTests).toEqual([
+      'scripts/tests/test_vercel_prebuilt_deploy.py',
+    ]);
+    expect(buildSelectedTestCommands(plan, '2')).toEqual([
+      [
+        'pnpm',
+        [
+          'exec',
+          'vitest',
+          'run',
+          '--root',
+          '.',
+          '--config',
+          'apps/web/vitest.config.mts',
+          '.github/scripts/cancel-stale-vercel-previews.test.mjs',
+          '--maxWorkers',
+          '2',
+        ],
+      ],
+      [
+        'python3',
+        ['-m', 'pytest', 'scripts/tests/test_vercel_prebuilt_deploy.py', '-q'],
+      ],
+    ]);
+  });
+
+  it.each(
+    VERCEL_CONGESTION_CONTROL_MANIFEST
+  )('fails closed when the Vercel congestion-control input %s is standalone', input => {
+    expect(buildAffectedTestPlan([input]).mode).toBe('full');
+  });
+
+  it.each(
+    VERCEL_CONGESTION_CONTROL_MANIFEST
+  )('fails closed when the Vercel congestion-control diff is missing %s', missingInput => {
+    expect(
+      buildAffectedTestPlan(
+        VERCEL_CONGESTION_CONTROL_MANIFEST.filter(file => file !== missingInput)
+      ).mode
+    ).toBe('full');
+  });
+
+  it.each([
+    '.github/scripts/unknown-vercel-control.mjs',
+    'scripts/tests/test_unknown_vercel_control.py',
+  ])('fails closed when the Vercel congestion-control diff includes unknown peer %s', peer => {
+    expect(
+      buildAffectedTestPlan([...VERCEL_CONGESTION_CONTROL_MANIFEST, peer]).mode
+    ).toBe('full');
+  });
+
+  it('selects the selector regression for the exact selector implementation pair', () => {
+    const plan = buildAffectedTestPlan(AFFECTED_TEST_SELECTOR_MANIFEST);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+    ]);
+    expect(buildSelectedTestCommands(plan, '2')).toEqual([
+      [
+        'pnpm',
+        [
+          'exec',
+          'vitest',
+          '--root',
+          'scripts',
+          '--config',
+          'vitest.config.mts',
+          'run',
+          'lib/__tests__/automation-verify.test.mjs',
+          '--maxWorkers',
+          '2',
+        ],
+      ],
+    ]);
+  });
+
+  it.each(
+    AFFECTED_TEST_SELECTOR_MANIFEST
+  )('fails closed when the affected-test selector input %s is standalone', input => {
+    expect(buildAffectedTestPlan([input]).mode).toBe('full');
+  });
+
+  it('fails closed when the affected-test selector diff includes an unknown peer', () => {
+    expect(
+      buildAffectedTestPlan([
+        ...AFFECTED_TEST_SELECTOR_MANIFEST,
+        'scripts/lib/unknown-selector-helper.mjs',
+      ]).mode
     ).toBe('full');
   });
 

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -81,6 +81,25 @@ const PREREQUISITE_TRAIN_MANIFEST = new Set([
   ...PREREQUISITE_TRAIN_TESTS,
   'scripts/ci/neon-orphan-reaper.mjs',
 ]);
+const VERCEL_CONGESTION_CONTROL_MANIFEST = new Set([
+  '.github/scripts/cancel-stale-vercel-previews.mjs',
+  '.github/scripts/cancel-stale-vercel-previews.test.mjs',
+  '.github/scripts/vercel-prebuilt-deploy.sh',
+  'scripts/tests/test_vercel_prebuilt_deploy.py',
+]);
+const VERCEL_CONGESTION_CONTROL_ROOT_VITEST_TESTS = [
+  '.github/scripts/cancel-stale-vercel-previews.test.mjs',
+];
+const VERCEL_CONGESTION_CONTROL_PYTHON_TESTS = [
+  'scripts/tests/test_vercel_prebuilt_deploy.py',
+];
+const AFFECTED_TEST_SELECTOR_MANIFEST = new Set([
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+]);
+const AFFECTED_TEST_SELECTOR_TESTS = [
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+];
 
 function isInvestorNoteIngestionInput(file) {
   return (
@@ -115,6 +134,19 @@ export function buildAffectedTestPlan(changedFiles) {
   const isExactPrerequisiteTrain =
     hasPrerequisiteTrainCorners &&
     files.every(file => PREREQUISITE_TRAIN_MANIFEST.has(file));
+  const vercelCongestionControlInputCount = files.filter(file =>
+    VERCEL_CONGESTION_CONTROL_MANIFEST.has(file)
+  ).length;
+  const isExactVercelCongestionControl =
+    vercelCongestionControlInputCount ===
+      VERCEL_CONGESTION_CONTROL_MANIFEST.size &&
+    files.length === VERCEL_CONGESTION_CONTROL_MANIFEST.size;
+  const affectedTestSelectorInputCount = files.filter(file =>
+    AFFECTED_TEST_SELECTOR_MANIFEST.has(file)
+  ).length;
+  const isExactAffectedTestSelector =
+    affectedTestSelectorInputCount === AFFECTED_TEST_SELECTOR_MANIFEST.size &&
+    files.length === AFFECTED_TEST_SELECTOR_MANIFEST.size;
   const relatedFiles = files.filter(
     file =>
       TESTABLE_FILE.test(file) &&
@@ -195,6 +227,15 @@ export function buildAffectedTestPlan(changedFiles) {
   }
 
   const selectedTests = unique([...directTests, ...mandatoryTests]);
+  const rootVitestTests = isExactVercelCongestionControl
+    ? VERCEL_CONGESTION_CONTROL_ROOT_VITEST_TESTS
+    : [];
+  const pythonTests = isExactVercelCongestionControl
+    ? VERCEL_CONGESTION_CONTROL_PYTHON_TESTS
+    : [];
+  const scriptVitestTests = isExactAffectedTestSelector
+    ? AFFECTED_TEST_SELECTOR_TESTS
+    : [];
   const isCoveredSource = file => {
     if (/\.(?:test|spec)\.[cm]?[jt]sx?$/.test(file)) return true;
     if (file.startsWith('apps/web/components/features/profile/')) return true;
@@ -237,20 +278,33 @@ export function buildAffectedTestPlan(changedFiles) {
     files.length === 1 && PREREQUISITE_TRAIN_STANDALONE_GLOBALS.has(files[0]);
   const hasUnknownPrerequisiteTrainPeer =
     hasPrerequisiteTrainCorners && !isExactPrerequisiteTrain;
+  const hasIncompleteVercelCongestionControl =
+    vercelCongestionControlInputCount > 0 && !isExactVercelCongestionControl;
+  const hasIncompleteAffectedTestSelector =
+    affectedTestSelectorInputCount > 0 && !isExactAffectedTestSelector;
   const hasUncoveredSource =
     relatedFiles.some(file => !isCoveredSource(file)) ||
     hasUnknownCiCancellationHealerPeer ||
     hasStandaloneCiFastLanesChange ||
     hasIncompletePrerequisiteTrain ||
     hasStandalonePrerequisiteGlobal ||
-    hasUnknownPrerequisiteTrainPeer;
+    hasUnknownPrerequisiteTrainPeer ||
+    hasIncompleteVercelCongestionControl ||
+    hasIncompleteAffectedTestSelector;
+  const hasSelectedTests =
+    selectedTests.length > 0 ||
+    rootVitestTests.length > 0 ||
+    pythonTests.length > 0 ||
+    scriptVitestTests.length > 0;
   return {
     mode: hasUncoveredSource
       ? 'full'
-      : selectedTests.length > 0 &&
+      : hasSelectedTests &&
           (relatedFiles.length > 0 ||
             hasCiCancellationHealerChange ||
-            isExactPrerequisiteTrain)
+            isExactPrerequisiteTrain ||
+            isExactVercelCongestionControl ||
+            isExactAffectedTestSelector)
         ? 'selected'
         : relatedFiles.length === 0
           ? 'none'
@@ -258,6 +312,9 @@ export function buildAffectedTestPlan(changedFiles) {
     relatedFiles,
     mandatoryTests: unique(mandatoryTests),
     selectedTests,
+    rootVitestTests,
+    pythonTests,
+    scriptVitestTests,
   };
 }
 
@@ -280,7 +337,7 @@ function changedFiles(base) {
     .filter(Boolean);
 }
 
-export async function runCommand(command, args) {
+async function runCommandStatus(command, args) {
   const child = spawn(command, args, {
     cwd: REPO_ROOT,
     stdio: 'inherit',
@@ -304,7 +361,77 @@ export async function runCommand(command, args) {
   });
   process.removeListener('SIGINT', onInterrupt);
   process.removeListener('SIGTERM', onTerminate);
-  process.exit(status);
+  return status;
+}
+
+export async function runCommand(command, args) {
+  process.exit(await runCommandStatus(command, args));
+}
+
+async function runCommands(commands) {
+  for (const [command, args] of commands) {
+    const status = await runCommandStatus(command, args);
+    if (status !== 0) process.exit(status);
+  }
+  process.exit(0);
+}
+
+export function buildSelectedTestCommands(plan, maxWorkers) {
+  const commands = [];
+  if (plan.scriptVitestTests.length > 0) {
+    commands.push([
+      'pnpm',
+      [
+        'exec',
+        'vitest',
+        '--root',
+        'scripts',
+        '--config',
+        'vitest.config.mts',
+        'run',
+        ...plan.scriptVitestTests.map(file => file.replace(/^scripts\//, '')),
+        '--maxWorkers',
+        maxWorkers,
+      ],
+    ]);
+  }
+  if (plan.rootVitestTests.length > 0) {
+    commands.push([
+      'pnpm',
+      [
+        'exec',
+        'vitest',
+        'run',
+        '--root',
+        '.',
+        '--config',
+        'apps/web/vitest.config.mts',
+        ...plan.rootVitestTests,
+        '--maxWorkers',
+        maxWorkers,
+      ],
+    ]);
+  }
+  if (plan.pythonTests.length > 0) {
+    commands.push(['python3', ['-m', 'pytest', ...plan.pythonTests, '-q']]);
+  }
+  if (plan.selectedTests.length > 0) {
+    commands.push([
+      'pnpm',
+      [
+        '--filter',
+        '@jovie/web',
+        'exec',
+        'vitest',
+        'run',
+        ...plan.selectedTests.map(file => file.replace(/^apps\/web\//, '')),
+        '--passWithNoTests',
+        '--maxWorkers',
+        maxWorkers,
+      ],
+    ]);
+  }
+  return commands;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
@@ -325,15 +452,5 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     await runCommand('pnpm', ['--filter', '@jovie/web', 'run', 'test']);
   }
 
-  await runCommand('pnpm', [
-    '--filter',
-    '@jovie/web',
-    'exec',
-    'vitest',
-    'run',
-    ...plan.selectedTests.map(file => file.replace(/^apps\/web\//, '')),
-    '--passWithNoTests',
-    '--maxWorkers',
-    maxWorkers,
-  ]);
+  await runCommands(buildSelectedTestCommands(plan, maxWorkers));
 }


### PR DESCRIPTION
## Summary

- Bind the exact four-file Vercel congestion-control change to its root Vitest and pytest regression suites.
- Bind the exact selector implementation and regression pair to the selector regression itself.
- Fall back to the full suite for standalone, partial, or mixed unknown peers.

## Root cause

`buildAffectedTestPlan()` only treated testable files under `apps/web/` and `packages/` as related. The congestion-control implementation and tests live under `.github/scripts/` and `scripts/tests/`, so the exact PR #14273 diff returned `mode=none`. The selector implementation and its own regression had the same blind spot, which meant a selector repair could also skip its regression.

## Verification

- Node 22 selector regression: 55/55 passed.
- Exact four-file congestion plan: selected root Vitest first and pytest second.
- Actual congestion suites: root Vitest 7/7 and pytest 11/11 passed.
- Exact selector pair: pre-push reported `mode=selected` and ran automation-verify 55/55.
- Standalone, missing-input, and unknown-peer cases fall back to `mode=full`.
- Biome, Node syntax, CI harness validation/docs, and diff checks passed.
- Normal pre-push: proxy guard, Tailwind guard, typecheck, affected typecheck/lint, selected regression, and CI harness passed.
- Commit `5c70c9e726643d2112bc580239bbe9bab49a03dd` contains an SSH signature.

bug-to-test: satisfied - exact selector regressions added.

design-canonical: not applicable.

## Queue control

This repair remains draft and gated for primary final review. Do not ready, enroll, or merge.

<!-- agent-run-artifact
{
  "id": "codex-selector-vercel-congestion-5c70c9e726",
  "source": "github",
  "sourceRunId": "5c70c9e726643d2112bc580239bbe9bab49a03dd",
  "kind": "workflow",
  "status": "done",
  "title": "Select Vercel congestion regressions",
  "summary": "Added strict cross-runtime selector coverage for the exact Vercel congestion-control diff and durable self-selection for the affected-test selector.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["ready_pr", "merge", "deploy"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": null,
  "linearIssueUrl": null,
  "pullRequestUrl": null,
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Selector regression passed 55/55; congestion root Vitest passed 7/7 and pytest passed 11/11; incomplete and mixed signatures fail closed.",
      "checkedAt": "2026-07-13T10:10:00Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Primary approved the strict exact-four mapping, cross-runtime runner extension, and selector self-test mapping.",
      "checkedAt": "2026-07-13T10:10:00Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Node 22 Biome, syntax, CI harness, diff checks, SSH-signed commit, and normal pre-push passed.",
      "checkedAt": "2026-07-13T10:10:00Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Bounded CI selector repair."
  },
  "blockedReason": null,
  "createdAt": "2026-07-13T10:10:00Z",
  "updatedAt": "2026-07-13T10:10:00Z",
  "metadata": {
    "relatedPullRequest": 14273,
    "worktree": "/private/tmp/jovie-selector-vercel-congestion"
  }
}
-->
