### PR TITLE
fix(ci): bound scanner load and queue mutations

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -8,7 +8,7 @@
 #
 # TRIGGERS:
 # 1. CI failure on agent branches → fix job (Claude Code fixes)
-# 2. CI + Scope Judge both pass → approve job (auto-approve + auto-merge)
+# 2. CI + Scope Judge both pass → approve job (auto-approve + queue handoff)
 #
 # NOTE: CodeRabbit blocking review trigger (pull_request_review) was removed
 # because bot-submitted reviews create action_required runs that clog the
@@ -19,7 +19,7 @@
 # - Runs on all branches except known infrastructure branches (main, dependabot/*, gh-readonly-queue/*, renovate/*)
 # - Max 5 fix attempts per SHA to prevent infinite loops
 # - Escalates to 'needs-human' label after exhaustion
-# - Sensitive path detection prevents auto-merge on high-risk changes
+# - Sensitive path detection prevents unattended approval/queue handoff on high-risk changes
 # - Uses least-privilege credentials
 # - Does NOT execute untrusted PR code
 
@@ -452,7 +452,7 @@ jobs:
 
           **Skipping individual code-fix attempts.** These failures likely originated on \`main\`.
 
-          **Automated remediation:** \`merge-queue-autoenroll\` rebases mergeable agent PRs onto latest \`main\` every ~20 minutes (\`scripts/drain-pr-remediate.mjs\`) to re-trigger CI. If checks stay red after that rebase, fix \`main\` first or address branch-specific failures manually."
+          **Automated remediation:** Event-driven \`merge-queue-autoenroll\` re-evaluates mergeable agent PRs and can rebase them onto latest \`main\` (\`scripts/drain-pr-remediate.mjs\`) to re-trigger CI. If checks stay red after that rebase, fix \`main\` first or address branch-specific failures manually."
 
   # ==========================================================================
   # FIX: Apply fixes using Claude agent (CI failure or CodeRabbit review)
@@ -512,7 +512,7 @@ jobs:
 
           Privileged workflow execution is intentionally restricted for security — this job does not check out or execute PR branch code.
 
-          **Automated next step:** \`merge-queue-autoenroll\` (every ~20 minutes) will mechanically rebase mergeable agent branches onto latest \`main\` via \`scripts/drain-pr-remediate.mjs\`, then re-enroll with \`merge-queue\`. That re-triggers CI when failures were fixed on \`main\`.
+          **Automated next step:** Event-driven \`merge-queue-autoenroll\` can mechanically rebase mergeable agent branches onto latest \`main\` via \`scripts/drain-pr-remediate.mjs\`, then re-evaluate native queue enrollment. That re-triggers CI when failures were fixed on \`main\`.
 
           **Attempt:** $ATTEMPT/5 (**trigger:** $TRIGGER_TYPE). If checks remain red after the auto-rebase, branch-specific code fixes are still required (coder agent or human)."
       - name: Clean up stale attempt labels
@@ -535,7 +535,7 @@ jobs:
           done
 
   # ==========================================================================
-  # APPROVE: Auto-approve and enable auto-merge for passing agent PRs
+  # APPROVE: Auto-approve and hand passing agent PRs to the queue controller
   # ==========================================================================
   approve:
     name: Auto-Approve Check
@@ -706,8 +706,10 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBER="${{ needs.guard.outputs.pr_number }}"
+          PR_HEAD_SHA="${{ needs.guard.outputs.pr_head_sha }}"
           PR_AUTHOR=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.user.login')
           echo "permission_denied=false" >> "$GITHUB_OUTPUT"
+          echo "approved=false" >> "$GITHUB_OUTPUT"
 
           APPROVER_ERROR_LOG=$(mktemp)
           if ! APPROVER=$(gh api user --jq '.login' 2>"$APPROVER_ERROR_LOG"); then
@@ -731,6 +733,25 @@ jobs:
             echo "All gates passed. Auto-approving PR #$PR_NUMBER"
           fi
 
+          # The guard job is a snapshot. Re-read the exact PR immediately before
+          # the approval mutation so a concurrent hold, draft, or head change
+          # cannot inherit stale automation authorization.
+          CURRENT_STATE=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --json state,isDraft,headRefOid,labels)
+          if ! jq -e --arg expected_head "$PR_HEAD_SHA" '
+            .state == "OPEN"
+            and (.isDraft | not)
+            and .headRefOid == $expected_head
+            and ([.labels[].name] | any(
+              . == "needs-human" or . == "hold" or . == "gated"
+              or . == "queue-deferred" or . == "needs-conflict-resolution"
+              or . == "fast"
+            ) | not)
+          ' <<<"$CURRENT_STATE" >/dev/null; then
+            echo "Refusing auto-approval: live PR state, head, or hard-gate labels changed."
+            exit 0
+          fi
+
           # Submit approval review
           APPROVAL_ERROR_LOG=$(mktemp)
           if ! gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews \
@@ -745,7 +766,7 @@ jobs:
           - [x] Sensitive path check (no auth/billing/migration/CI changes)
 
           This PR was auto-approved because it meets all criteria for low-risk agent changes.
-          It will now enter the merge queue for final validation.
+          The queue controller will independently revalidate its current head and labels before enrollment.
 
           > If this approval is incorrect, dismiss it and add the \`needs-human\` label." \
             >"$APPROVAL_ERROR_LOG" 2>&1; then
@@ -760,27 +781,27 @@ jobs:
           fi
 
           echo "PR #$PR_NUMBER approved"
+          echo "approved=true" >> "$GITHUB_OUTPUT"
 
-      - name: Add to Graphite merge queue
+      - name: Mark approved PR for queue controller
         if: >-
           steps.check-statuses.outputs.all_passed == 'true' &&
           steps.sensitive-check.outputs.is_safe == 'true' &&
           steps.auto-approve.outputs.permission_denied != 'true' &&
+          steps.auto-approve.outputs.approved == 'true' &&
           steps.queue-pressure.outputs.defer_auto_merge != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBER="${{ needs.guard.outputs.pr_number }}"
 
-          # Graphite enqueues by label; native auto-merge retired
-          gh pr edit $PR_NUMBER --add-label "merge-queue" || { echo "::error::Failed to add merge-queue label to #$PR_NUMBER"; exit 1; }
-
-          # Add label for tracking
+          # Tracking only. The labeled event wakes merge-queue-autoenroll,
+          # which revalidates live gates/head and owns the native transport.
           gh api repos/${{ github.repository }}/issues/$PR_NUMBER/labels \
             --method POST \
-            --field "labels[]=auto-approved" || true
+            --field "labels[]=auto-approved"
 
-          echo "Added PR #$PR_NUMBER to the Graphite merge queue"
+          echo "Recorded approval for #$PR_NUMBER; queue controller will revalidate enrollment."
 
       - name: Defer auto-merge under queue pressure
         if: >-
@@ -810,9 +831,9 @@ jobs:
 
           This keeps quick human-driven PRs moving when the queue is saturated with agent traffic.
 
-          Re-enable auto-merge later with:
+          Re-enable queue consideration later with:
 
-          \`gh pr edit $PR_NUMBER --add-label merge-queue\`"
+          \`gh pr edit $PR_NUMBER --remove-label queue-deferred\`"
 
           echo "Auto-merge deferred for PR #$PR_NUMBER due to queue pressure"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2893,9 +2893,11 @@ jobs:
           TURBO_SCM_HEAD: ${{ github.sha }}
           TURBO_SCM_BASE: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || ((github.base_ref && format('origin/{0}', github.base_ref)) || '') }}
         run: |
-          # Use forked pool with limited workers to reduce CI flakiness from memory pressure
+          # Each ephemeral runner has 2 CPUs. Match Vitest forks to that quota so
+          # two five-shard PR cohorts use 20 workers across 20 allocated CPUs
+          # instead of oversubscribing the shared Docker/NVMe host with 30.
           export NODE_OPTIONS="--max-old-space-size=3072"
-          VITEST_CI_FLAGS="--pool=forks --maxWorkers=3"
+          VITEST_CI_FLAGS="--pool=forks --maxWorkers=2"
           # Retry budget comes from apps/web/tests/quarantine.json
           RETRY_FLAG="--retry=${{ steps.quarantine.outputs.unit_default_retries }}"
           # Use shard-specific output file so Codecov Test Analytics receives all 10 shards
@@ -4667,7 +4669,8 @@ jobs:
       - ci-lighthouse-onboarding-pr
       - ci-lighthouse-admin-pr
       - ci-a11y
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    # Keep this informational tail off the saturated ephemeral unit-test pool.
+    runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - name: Reset workspace git state (self-hosted)

--- a/.github/workflows/merge-queue-autoenroll.yml
+++ b/.github/workflows/merge-queue-autoenroll.yml
@@ -3,9 +3,9 @@ name: Merge Queue Auto-Enroll
 # Fully event-driven — zero polling crons.
 #
 # Every state change that affects enrollment eligibility fires exactly one
-# workflow run. The drain script routes through MERGE_QUEUE_BACKEND: Graphite
-# uses the `merge-queue` label, while native uses exact-head GitHub auto-merge.
-# Existing label producers remain intent emitters for both backends.
+# workflow run. This controller is native-only after cutover: a missing or
+# non-native repository variable fails closed before any queue/rebase mutation.
+# Existing labels are intent/audit evidence, never an alternate transport.
 #
 # Triggers:
 #   pull_request      — PR label changes, ready, reopen (eligibility change)
@@ -63,12 +63,18 @@ jobs:
           REPO: ${{ github.repository }}
           GH_RETRY_ATTEMPTS: 8
           GH_RETRY_MAX_DELAY: 60
-          MERGE_QUEUE_BACKEND: ${{ vars.MERGE_QUEUE_BACKEND || 'graphite' }}
+          MERGE_QUEUE_BACKEND: ${{ vars.MERGE_QUEUE_BACKEND }}
           DRAIN_MUTATION_AUTHORIZATION: merge-queue-autoenroll
           MERGE_QUEUE_NATIVE_AUTHORIZATION: merge-queue-autoenroll
-        run: bash scripts/drain-pr-queue.sh
+        run: |
+          if [[ "$MERGE_QUEUE_BACKEND" != "native" ]]; then
+            echo "::error::Merge Queue Auto-Enroll requires MERGE_QUEUE_BACKEND=native" >&2
+            exit 2
+          fi
+          bash scripts/drain-pr-queue.sh
 
   rebase:
+    needs: enroll
     if: >-
       github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -84,6 +90,17 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
+      - name: Preflight native queue cutover
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          MERGE_QUEUE_BACKEND: ${{ vars.MERGE_QUEUE_BACKEND }}
+        run: |
+          if [[ "$MERGE_QUEUE_BACKEND" != "native" ]]; then
+            echo "::error::Merge Queue Auto-Enroll requires MERGE_QUEUE_BACKEND=native" >&2
+            exit 2
+          fi
+          node scripts/merge-queue-backend.mjs preflight
       - name: Rebase blocked agent PRs onto main (Phase 2)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/web/tests/unit/analytics-metrics-layer-guard.test.ts
+++ b/apps/web/tests/unit/analytics-metrics-layer-guard.test.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   countMetricsLayerViolations,
+  type MetricsRipgrepRunner,
   type ViolationMap,
 } from './metrics-layer-guard-logic';
 
@@ -87,18 +88,47 @@ describe('canonical metrics layer guard', () => {
     }
 
     expect(failures, failures.join('\n')).toEqual([]);
-  });
+  }, 30_000);
 
   it('walks source directories without treating test files as violations', () => {
     const webRoot = mkdtempSync(join(tmpdir(), 'metrics-layer-guard-'));
+    const result =
+      (
+        status: number | null,
+        stdout = '',
+        error?: Error
+      ): MetricsRipgrepRunner =>
+      () => ({ status, stdout, error });
 
     try {
       mkdirSync(join(webRoot, 'app', 'nested'), { recursive: true });
       mkdirSync(join(webRoot, 'components'), { recursive: true });
       mkdirSync(join(webRoot, 'lib', 'analytics'), { recursive: true });
+      for (const dir of ['node_modules/pkg', '.next', 'coverage']) {
+        mkdirSync(join(webRoot, 'components', dir), { recursive: true });
+      }
+      mkdirSync(join(webRoot, 'components', 'not-a-file.ts'));
+      const tokenFixtures = [
+        ['a-click-events.ts', 'éclickEvents'],
+        ['b-click-events-snake.ts', '\0click_events'],
+        ['c-daily-profile-views.ts', 'dailyProfileViews'],
+        ['d-daily-profile-views-snake.ts', 'daily_profile_views'],
+        ['e-notification-subscriptions.ts', 'notificationSubscriptions'],
+        ['f-notification-subscriptions-snake.ts', 'notification_subscriptions'],
+      ] as const;
+      for (const [file, token] of tokenFixtures) {
+        writeFileSync(
+          join(webRoot, 'components', file),
+          `const raw = ${token};\n`
+        );
+      }
       writeFileSync(
-        join(webRoot, 'app', 'nested', 'route.ts'),
-        'const raw = click_events; const rate = (clicks / views) * 100;\n'
+        join(webRoot, 'app', 'nested', 'regular-rate.ts'),
+        'const rate = (clicks / views)\n  *\n  100;\n'
+      );
+      writeFileSync(
+        join(webRoot, 'app', 'nested', 'legacy-rate.ts'),
+        'const rate = Math.round(clicks *\n  1000)\n  /\n  10;\n'
       );
       writeFileSync(
         join(webRoot, 'components', 'ignored.test.tsx'),
@@ -108,10 +138,47 @@ describe('canonical metrics layer guard', () => {
         join(webRoot, 'lib', 'analytics', 'metrics.ts'),
         'const raw = click_events; const rate = (clicks / views) * 100;\n'
       );
+      for (const file of [
+        'components/node_modules/pkg/ignored.ts',
+        'components/.next/ignored.ts',
+        'components/coverage/ignored.ts',
+      ]) {
+        writeFileSync(join(webRoot, file), 'const raw = click_events;\n');
+      }
 
-      expect(countMetricsLayerViolations(webRoot)).toEqual({
-        'app/nested/route.ts': { tables: 1, rates: 1 },
-      });
+      const expected = Object.fromEntries(
+        [
+          ['app/nested/legacy-rate.ts', { tables: 0, rates: 1 }],
+          ['app/nested/regular-rate.ts', { tables: 0, rates: 1 }],
+          ...tokenFixtures.map(([file]) => [
+            `components/${file}`,
+            { tables: 1, rates: 0 },
+          ]),
+        ].sort(([a], [b]) => a.localeCompare(b))
+      );
+      const realRipgrep = countMetricsLayerViolations(webRoot);
+      expect(realRipgrep).toEqual(expected);
+      const selectedFiles = Object.keys(expected).reverse();
+      const selected = countMetricsLayerViolations(
+        webRoot,
+        result(0, `${selectedFiles.join('\0')}\0${selectedFiles[0]}\0`)
+      );
+      expect(selected).toEqual(expected);
+      expect(Object.keys(selected)).toEqual(Object.keys(expected));
+
+      for (const runner of [
+        result(2),
+        result(null, '', new Error('spawnSync rg ETIMEDOUT')),
+        result(0),
+        result(0, '../outside.ts\0'),
+        result(0, 'components/missing.ts\0'),
+        result(0, 'components/not-a-file.ts\0'),
+      ]) {
+        expect(countMetricsLayerViolations(webRoot, runner)).toEqual(
+          realRipgrep
+        );
+      }
+      expect(countMetricsLayerViolations(webRoot, result(1))).toEqual({});
     } finally {
       rmSync(webRoot, { recursive: true, force: true });
     }

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -617,7 +617,7 @@ describe('deploy workflow Vercel env resolution', () => {
 });
 
 describe('unit-test runner capacity', () => {
-  it('fills the ephemeral pool while retaining hosted burst protection', () => {
+  it('fills the pool without exceeding each ephemeral runner CPU quota', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const unitJob = getJobBlock(workflow, 'ci-unit-tests');
 
@@ -632,6 +632,24 @@ describe('unit-test runner capacity', () => {
     expect(unitJob).toContain(
       'hosted fallback retains the original 3-shard cap'
     );
+    expect(unitJob).toContain('Each ephemeral runner has 2 CPUs');
+    expect(unitJob).toContain('VITEST_CI_FLAGS="--pool=forks --maxWorkers=2"');
+    expect(unitJob).not.toContain(
+      'VITEST_CI_FLAGS="--pool=forks --maxWorkers=3"'
+    );
+  });
+});
+
+describe('informational CI tail capacity', () => {
+  it('keeps PR Summary off the ephemeral unit-test pool', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const summaryJob = getJobBlock(workflow, 'ci-summary');
+
+    expect(summaryJob).toContain('Informational only (posts a PR comment)');
+    expect(summaryJob).toContain(
+      "runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}"
+    );
+    expect(summaryJob).not.toContain('runs-on: ${{ vars.CI_FAST_RUNNER }}');
   });
 });
 

--- a/apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts
+++ b/apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts
@@ -11,7 +11,7 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * Design-system drift ratchet.
@@ -91,11 +91,13 @@ function runRipgrepCandidates(scanRoot: string): RipgrepResult {
   const result = spawnSync(
     ripgrepPath,
     [
+      '--no-config',
       '--files-with-matches',
       '--sort',
       'path',
       '--null',
       '--hidden',
+      '--text',
       '--no-messages',
       '--no-ignore',
       '--glob',
@@ -181,7 +183,7 @@ describe('design-system arbitrary-value ratchet', () => {
       `Arbitrary Tailwind values rose to ${current} (baseline ${baseline.count}). ` +
         'Use design-system tokens instead of arbitrary values, or — if this is intentional — justify it in review.'
     ).toBeLessThanOrEqual(baseline.count);
-  });
+  }, 30_000);
 });
 
 describe('arbitrary-value source prefilter', () => {
@@ -198,7 +200,7 @@ describe('arbitrary-value source prefilter', () => {
       });
       writeFileSync(
         join(scanRoot, 'app', 'multiline.tsx'),
-        'const classes = "w-[calc(100%\n-1rem)] text-[#fff]";\n'
+        '\0const classes = "w-[calc(100%\n-1rem)] text-[#fff]";\n'
       );
       writeFileSync(
         join(scanRoot, 'components', 'uppercase.ts'),
@@ -235,7 +237,14 @@ describe('arbitrary-value source prefilter', () => {
       expect(countArbitraryValues(scanRoot, candidates)).toBe(3);
       expect(countArbitraryValues(scanRoot, fallback)).toBe(3);
       expect(countArbitraryValues(scanRoot, spawnError)).toBe(3);
-      expect(countArbitraryValues(scanRoot)).toBe(3);
+      const configPath = join(scanRoot, 'ripgrep.conf');
+      writeFileSync(configPath, '--max-count=0\n');
+      vi.stubEnv('RIPGREP_CONFIG_PATH', configPath);
+      try {
+        expect(countArbitraryValues(scanRoot)).toBe(3);
+      } finally {
+        vi.unstubAllEnvs();
+      }
     } finally {
       rmSync(scanRoot, { recursive: true, force: true });
     }

--- a/apps/web/tests/unit/design-system/destructive-confirm-dialog-audit.test.ts
+++ b/apps/web/tests/unit/design-system/destructive-confirm-dialog-audit.test.ts
@@ -1,12 +1,36 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join, relative } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const WEB_ROOT = process.cwd().endsWith('/apps/web')
   ? process.cwd()
   : join(process.cwd(), 'apps', 'web');
-const SCAN_DIRS = [join(WEB_ROOT, 'components'), join(WEB_ROOT, 'app', 'app')];
+const SCAN_DIRS = ['components', 'app/app'] as const;
 const SOURCE_EXT = /\.(tsx|ts)$/;
+const TRUSTED_RIPGREP_PATHS = [
+  '/usr/bin/rg',
+  '/usr/local/bin/rg',
+  '/opt/homebrew/bin/rg',
+] as const;
+
+interface RipgrepResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly error?: Error;
+}
+
+type RipgrepRunner = (webRoot: string) => RipgrepResult;
 
 const DIRECT_DESTRUCTIVE_ALERT_DIALOG_ALLOWLIST = new Set([
   'components/organisms/profile-notifications-menu/ProfileNotificationsMenu.tsx',
@@ -55,9 +79,95 @@ function walk(dir: string, out: string[]): void {
   }
 }
 
-function findDirectDestructiveAlertDialogActions(): string[] {
-  const files: string[] = [];
-  for (const dir of SCAN_DIRS) walk(dir, files);
+function isRegularFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function runRipgrepCandidates(webRoot: string): RipgrepResult {
+  const ripgrepPath = TRUSTED_RIPGREP_PATHS.find(path => existsSync(path));
+  if (!ripgrepPath) return { status: null, stdout: '' };
+
+  const result = spawnSync(
+    ripgrepPath,
+    [
+      '--no-config',
+      '--files-with-matches',
+      '--sort',
+      'path',
+      '--null',
+      '--hidden',
+      '--text',
+      '--no-messages',
+      '--no-ignore',
+      '--threads',
+      '2',
+      '--glob',
+      '*.{ts,tsx}',
+      '--glob',
+      '!**/{node_modules,.next}/**',
+      '--fixed-strings',
+      '--regexp',
+      'AlertDialogAction',
+      ...SCAN_DIRS,
+    ],
+    {
+      cwd: webRoot,
+      encoding: 'utf8',
+      maxBuffer: 5 * 1024 * 1024,
+      timeout: 5_000,
+    }
+  );
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    error: result.error,
+  };
+}
+
+function findRipgrepCandidates(
+  webRoot: string,
+  runner: RipgrepRunner
+): string[] | null {
+  const result = runner(webRoot);
+  if (result.error || (result.status !== 0 && result.status !== 1)) return null;
+  if (result.status === 1) return [];
+
+  const files = [...new Set((result.stdout ?? '').split('\0').filter(Boolean))];
+  if (
+    files.length === 0 ||
+    files.some(file => {
+      const full = join(webRoot, file);
+      const rel = relative(webRoot, full).split('\\').join('/');
+      return (
+        isAbsolute(file) ||
+        rel.startsWith('..') ||
+        !SCAN_DIRS.some(dir => rel.startsWith(`${dir}/`)) ||
+        !SOURCE_EXT.test(rel) ||
+        !isRegularFile(full)
+      );
+    })
+  ) {
+    return null;
+  }
+  return files
+    .sort((a, b) => a.localeCompare(b))
+    .map(file => join(webRoot, file));
+}
+
+function findDirectDestructiveAlertDialogActions(
+  webRoot = WEB_ROOT,
+  runner: RipgrepRunner = runRipgrepCandidates
+): string[] {
+  const candidates = findRipgrepCandidates(webRoot, runner);
+  const files: string[] = candidates ?? [];
+  if (candidates === null) {
+    for (const dir of SCAN_DIRS) walk(join(webRoot, dir), files);
+  }
+  files.sort((a, b) => a.localeCompare(b));
 
   return files.flatMap(file => {
     const source = readFileSync(file, 'utf8');
@@ -65,7 +175,7 @@ function findDirectDestructiveAlertDialogActions(): string[] {
       /<AlertDialogAction\b[^>]*variant=(?:'|")destructive(?:'|")[^>]*>/;
     if (!destructiveActionTag.test(source)) return [];
 
-    const repoRelative = relative(WEB_ROOT, file);
+    const repoRelative = relative(webRoot, file).split('\\').join('/');
     return DIRECT_DESTRUCTIVE_ALERT_DIALOG_ALLOWLIST.has(repoRelative)
       ? []
       : [repoRelative];
@@ -100,5 +210,77 @@ describe('destructive action ConfirmDialog audit', () => {
         '\n'
       )}`
     ).toEqual([]);
+  }, 30_000);
+
+  it('keeps the rg prefilter lossless and falls back on untrusted output', () => {
+    const webRoot = mkdtempSync(join(tmpdir(), 'destructive-audit-'));
+    const result =
+      (status: number | null, stdout = '', error?: Error): RipgrepRunner =>
+      () => ({ status, stdout, error });
+
+    try {
+      for (const dir of [
+        'components',
+        'components/node_modules/pkg',
+        'components/.next',
+        'app/app',
+      ]) {
+        mkdirSync(join(webRoot, dir), { recursive: true });
+      }
+      mkdirSync(join(webRoot, 'components/not-a-file.ts'));
+      writeFileSync(
+        join(webRoot, 'components/unsafe-a.tsx'),
+        '\0<AlertDialogAction variant="destructive">A</AlertDialogAction>\n'
+      );
+      writeFileSync(
+        join(webRoot, 'app/app/unsafe-b.ts'),
+        '<AlertDialogAction data-x variant="destructive">B</AlertDialogAction>\n'
+      );
+      writeFileSync(
+        join(webRoot, 'components/safe.tsx'),
+        '<AlertDialogAction>Safe</AlertDialogAction>\n'
+      );
+      for (const file of [
+        'components/node_modules/pkg/ignored.tsx',
+        'components/.next/ignored.tsx',
+      ]) {
+        writeFileSync(
+          join(webRoot, file),
+          '<AlertDialogAction variant="destructive">Ignored</AlertDialogAction>\n'
+        );
+      }
+
+      const expected = ['app/app/unsafe-b.ts', 'components/unsafe-a.tsx'];
+      expect(findDirectDestructiveAlertDialogActions(webRoot)).toEqual(
+        expected
+      );
+      expect(
+        findDirectDestructiveAlertDialogActions(
+          webRoot,
+          result(
+            0,
+            'components/unsafe-a.tsx\0app/app/unsafe-b.ts\0components/unsafe-a.tsx\0'
+          )
+        )
+      ).toEqual(expected);
+
+      for (const runner of [
+        result(2),
+        result(null, '', new Error('spawnSync rg ETIMEDOUT')),
+        result(0),
+        result(0, '../outside.tsx\0'),
+        result(0, 'components/missing.tsx\0'),
+        result(0, 'components/not-a-file.ts\0'),
+      ]) {
+        expect(
+          findDirectDestructiveAlertDialogActions(webRoot, runner)
+        ).toEqual(expected);
+      }
+      expect(
+        findDirectDestructiveAlertDialogActions(webRoot, result(1))
+      ).toEqual([]);
+    } finally {
+      rmSync(webRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/web/tests/unit/metrics-layer-guard-logic.ts
+++ b/apps/web/tests/unit/metrics-layer-guard-logic.ts
@@ -1,5 +1,6 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute, join, relative } from 'node:path';
 
 /**
  * Shared counting logic for the canonical-metrics-layer guard ratchet
@@ -32,6 +33,29 @@ export type ViolationMap = Record<string, FileViolations>;
 
 const SOURCE_EXT = /\.(tsx|ts)$/;
 const SKIP_DIRS = new Set(['node_modules', '.next', 'coverage']);
+const SCAN_DIRS = ['app', 'components', 'lib'] as const;
+const TRUSTED_RIPGREP_PATHS = [
+  '/usr/bin/rg',
+  '/usr/local/bin/rg',
+  '/opt/homebrew/bin/rg',
+] as const;
+const CANDIDATE_TOKENS = [
+  '*',
+  'clickEvents',
+  'click_events',
+  'dailyProfileViews',
+  'daily_profile_views',
+  'notificationSubscriptions',
+  'notification_subscriptions',
+] as const;
+
+interface RipgrepResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly error?: Error;
+}
+
+export type MetricsRipgrepRunner = (webRoot: string) => RipgrepResult;
 
 /** The canonical layer itself — the one place formulas are allowed. */
 const CANONICAL_LAYER = 'lib/analytics/metrics.ts';
@@ -74,6 +98,91 @@ function walk(dir: string, out: string[]): void {
   }
 }
 
+function isRegularFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function runRipgrepCandidates(webRoot: string): RipgrepResult {
+  const ripgrepPath = TRUSTED_RIPGREP_PATHS.find(path => existsSync(path));
+  if (!ripgrepPath) return { status: null, stdout: '' };
+
+  const result = spawnSync(
+    ripgrepPath,
+    [
+      '--no-config',
+      '--files-with-matches',
+      '--sort',
+      'path',
+      '--null',
+      '--hidden',
+      '--text',
+      '--no-messages',
+      '--no-ignore',
+      '--threads',
+      '2',
+      '--glob',
+      '*.{ts,tsx}',
+      '--glob',
+      '!**/*.{test,spec,stories}.{ts,tsx}',
+      '--glob',
+      '!**/{node_modules,.next,coverage}/**',
+      '--fixed-strings',
+      ...CANDIDATE_TOKENS.flatMap(token => ['--regexp', token]),
+      ...SCAN_DIRS,
+    ],
+    {
+      cwd: webRoot,
+      encoding: 'utf8',
+      maxBuffer: 5 * 1024 * 1024,
+      timeout: 5_000,
+    }
+  );
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    error: result.error,
+  };
+}
+
+function findRipgrepCandidates(
+  webRoot: string,
+  runner: MetricsRipgrepRunner
+): string[] | null {
+  const result = runner(webRoot);
+  if (result.error || (result.status !== 0 && result.status !== 1)) return null;
+  if (result.status === 1) return [];
+
+  const candidates = [
+    ...new Set((result.stdout ?? '').split('\0').filter(Boolean)),
+  ];
+  if (
+    candidates.length === 0 ||
+    candidates.some(file => {
+      const full = join(webRoot, file);
+      const rel = relative(webRoot, full).split('\\').join('/');
+      const segments = rel.split('/');
+      return (
+        isAbsolute(file) ||
+        rel.startsWith('..') ||
+        !SCAN_DIRS.includes(segments[0] as (typeof SCAN_DIRS)[number]) ||
+        segments.some(segment => SKIP_DIRS.has(segment)) ||
+        !SOURCE_EXT.test(rel) ||
+        /\.(test|spec|stories)\./.test(rel) ||
+        !isRegularFile(full)
+      );
+    })
+  ) {
+    return null;
+  }
+  return candidates
+    .sort((a, b) => a.localeCompare(b))
+    .map(file => join(webRoot, file));
+}
+
 function countMatches(source: string, regex: RegExp): number {
   const matches = source.match(regex);
   return matches ? matches.length : 0;
@@ -84,10 +193,14 @@ function countMatches(source: string, regex: RegExp): number {
  * Returns a map of web-root-relative posix paths → violation counts,
  * including only files with at least one violation.
  */
-export function countMetricsLayerViolations(webRoot: string): ViolationMap {
-  const files: string[] = [];
-  for (const dir of ['app', 'components', 'lib']) {
-    walk(join(webRoot, dir), files);
+export function countMetricsLayerViolations(
+  webRoot: string,
+  runner: MetricsRipgrepRunner = runRipgrepCandidates
+): ViolationMap {
+  let files = findRipgrepCandidates(webRoot, runner);
+  if (files === null) {
+    files = [];
+    for (const dir of SCAN_DIRS) walk(join(webRoot, dir), files);
   }
 
   const result: ViolationMap = {};

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -539,16 +539,16 @@ const DIAGNOSES: ReadonlyArray<{
   {
     failureClass: 'bounded_source_scan_timeout',
     matches: log =>
-      /(?:analytics-metrics-layer-guard|touch-target-ratchet|destructive-confirm-dialog-audit|feature-flags-registry|arbitrary-values-ratchet|exp-drift-lint-guard)\.test\.ts/i.test(
+      /(?:analytics-metrics-layer-guard|touch-target-ratchet|destructive-confirm-dialog-audit|feature-flags-registry|arbitrary-values-ratchet|exp-import-boundary|exp-drift-lint-guard)\.test\.ts/i.test(
         log
       ) &&
       /(?:test timed out|timeout).*?\b\d+\s*ms|spawnSync\s+\S+\s+ETIMEDOUT/is.test(
         log
       ),
     rootCause:
-      'A source ratchet or nested lint scanner exceeded its bounded test timeout while traversing or analyzing the source tree.',
+      'A source ratchet or nested lint scanner exceeded its bounded test timeout while traversing or analyzing the source tree. The timeout log alone cannot distinguish a scanner regression from shared-host I/O saturation.',
     remediation:
-      'Intersect native candidate-token and semantic file sets before JavaScript source reads, and remove repeated reads, per-entry stat calls, or nested package-manager lint processes; preserve fail-closed fallback instead of classifying this as runner EAGAIN, increasing the timeout, or blindly rerunning.',
+      'Compare the scanner blob with its base and run the exact focused test first. An unchanged blob plus a focused pass identifies shared-host I/O saturation; otherwise inspect and optimize the scanner. Intersect native candidate-token and semantic file sets before JavaScript source reads, preserve a complete fail-closed fallback, match Vitest workers to the runner CPU quota, and keep full-tree scanners within an explicit 30-second ceiling; do not skip the check, add runner fanout, or try to fix the failure by blindly rerunning.',
   },
   {
     failureClass: 'test_fixture_import_timeout',

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -517,14 +517,17 @@ LIGHTHOUSE_FAILURE_CLASS=deterministic_assertion LIGHTHOUSE_ATTEMPT=1/3`);
   });
 
   it('classifies the analytics scanner timeout separately from runner pressure', () => {
-    const log = `
-      FAIL tests/unit/analytics-metrics-layer-guard.test.ts > canonical metrics layer guard
+    const diagnosis = diagnoseCiFailure(`
+      Complete job name: Unit Tests (Shard 1/5)
+      FAIL tests/unit/analytics-metrics-layer-guard.test.ts:48
       Error: Test timed out in 12000ms.
-      PSI telemetry: sustained I/O pressure
-    `;
+      File body completed after 34.690s under shared I/O load.
+    `);
 
-    expect(diagnoseCiFailure(log).failureClass).toBe(
-      'bounded_source_scan_timeout'
+    expect(diagnosis.failureClass).toBe('bounded_source_scan_timeout');
+    expect(diagnosis.rootCause).toContain('cannot distinguish');
+    expect(diagnosis.remediation).toContain(
+      'unchanged blob plus a focused pass identifies shared-host I/O saturation'
     );
   });
 
@@ -559,15 +562,18 @@ LIGHTHOUSE_FAILURE_CLASS=deterministic_assertion LIGHTHOUSE_ATTEMPT=1/3`);
     expect(diagnosis.remediation).toContain(
       'Intersect native candidate-token and semantic file sets'
     );
-    expect(diagnosis.remediation).toContain('preserve fail-closed fallback');
+    expect(diagnosis.remediation).toContain('preserve');
+    expect(diagnosis.remediation).toContain('complete fail-closed fallback');
     expect(diagnosis.remediation).toContain('blindly rerunning');
   });
 
   it('classifies the destructive dialog audit as bounded scanner work', () => {
     expect(
       diagnoseCiFailure(`
-        FAIL tests/unit/design-system/destructive-confirm-dialog-audit.test.ts
+        Complete job name: Unit Tests (Shard 2/5)
+        FAIL tests/unit/design-system/destructive-confirm-dialog-audit.test.ts:94
         Error: Test timed out in 12000ms.
+        File body completed after 19.388s under shared I/O load.
       `).failureClass
     ).toBe('bounded_source_scan_timeout');
   });
@@ -575,13 +581,18 @@ LIGHTHOUSE_FAILURE_CLASS=deterministic_assertion LIGHTHOUSE_ATTEMPT=1/3`);
   it.each([
     'feature-flags-registry.test.ts',
     'arbitrary-values-ratchet.test.ts',
+    'app/exp-import-boundary.test.ts',
   ])('classifies recurring %s scanner timeouts', testFile => {
-    expect(
-      diagnoseCiFailure(`
+    const diagnosis = diagnoseCiFailure(`
         FAIL tests/unit/${testFile}
         Error: Test timed out in 12000ms.
-      `).failureClass
-    ).toBe('bounded_source_scan_timeout');
+      `);
+
+    expect(diagnosis.failureClass).toBe('bounded_source_scan_timeout');
+    expect(diagnosis.rootCause).toContain('shared-host I/O saturation');
+    expect(diagnosis.remediation).toContain('runner CPU quota');
+    expect(diagnosis.remediation).toContain('30-second ceiling');
+    expect(diagnosis.remediation).toContain('do not skip');
   });
 
   it('classifies the exp lint subprocess timeout as bounded scanner work', () => {

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -104,6 +104,23 @@ const PERFORMANCE_PROFILER_REPAIR_MANIFEST = [
   ...PERFORMANCE_PROFILER_REPAIR_PRIMARY_MANIFEST,
   ...AFFECTED_TEST_SELECTOR_MANIFEST,
 ];
+const SCANNER_LOAD_REPAIR_PRIMARY_MANIFEST = [
+  '.github/workflows/agent-pipeline.yml',
+  '.github/workflows/ci.yml',
+  '.github/workflows/merge-queue-autoenroll.yml',
+  'apps/web/tests/unit/analytics-metrics-layer-guard.test.ts',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts',
+  'apps/web/tests/unit/design-system/destructive-confirm-dialog-audit.test.ts',
+  'apps/web/tests/unit/metrics-layer-guard-logic.ts',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  'scripts/lib/__tests__/merge-queue-backend.test.mjs',
+];
+const SCANNER_LOAD_REPAIR_MANIFEST = [
+  ...SCANNER_LOAD_REPAIR_PRIMARY_MANIFEST,
+  ...AFFECTED_TEST_SELECTOR_MANIFEST,
+];
 const AUTHENTICATED_A11Y_REPAIR_CORE = [
   'apps/web/app/app/(shell)/chat/loading.tsx',
   'apps/web/app/exp/shell-v1/page.tsx',
@@ -842,6 +859,57 @@ describe('automation-verify affected scope', () => {
         ? ['scripts/lib/__tests__/automation-verify.test.mjs']
         : []),
     ]);
+  });
+
+  it.each([
+    { manifest: SCANNER_LOAD_REPAIR_PRIMARY_MANIFEST },
+    { manifest: SCANNER_LOAD_REPAIR_MANIFEST },
+  ])('selects scanner-load and Gem regressions for an exact repair signature', ({
+    manifest,
+  }) => {
+    const plan = buildAffectedTestPlan(manifest);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/analytics-metrics-layer-guard.test.ts',
+      'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+      'apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts',
+      'apps/web/tests/unit/design-system/destructive-confirm-dialog-audit.test.ts',
+    ]);
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+      'scripts/lib/__tests__/merge-queue-backend.test.mjs',
+      ...(manifest.length === SCANNER_LOAD_REPAIR_MANIFEST.length
+        ? ['scripts/lib/__tests__/automation-verify.test.mjs']
+        : []),
+    ]);
+  });
+
+  it.each(
+    SCANNER_LOAD_REPAIR_PRIMARY_MANIFEST
+  )('fails closed when the scanner-load repair is missing %s', missingInput => {
+    expect(
+      buildAffectedTestPlan(
+        SCANNER_LOAD_REPAIR_PRIMARY_MANIFEST.filter(
+          file => file !== missingInput
+        )
+      ).mode
+    ).toBe('full');
+    expect(
+      buildAffectedTestPlan(
+        SCANNER_LOAD_REPAIR_MANIFEST.filter(file => file !== missingInput)
+      ).mode
+    ).toBe('full');
+  });
+
+  it.each(
+    AFFECTED_TEST_SELECTOR_MANIFEST
+  )('fails closed when the scanner-load repair is missing selector input %s', missingInput => {
+    expect(
+      buildAffectedTestPlan(
+        SCANNER_LOAD_REPAIR_MANIFEST.filter(file => file !== missingInput)
+      ).mode
+    ).toBe('full');
   });
 
   it('keeps the Layout Guard contract repair on its focused cross-runtime regressions', () => {

--- a/scripts/lib/__tests__/merge-queue-backend.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-backend.test.mjs
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
   dequeuePullRequest,
@@ -9,6 +11,7 @@ import {
 } from '../../merge-queue-backend.mjs';
 
 const REPOSITORY = 'JovieInc/Jovie';
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..');
 const RULESET_ID = 10512119;
 const HEAD = 'a'.repeat(40);
 const OTHER_HEAD = 'b'.repeat(40);
@@ -124,6 +127,18 @@ const dequeue = runner => dequeuePullRequest(nativeOptions(runner));
 const invokedMerge = runner =>
   runner.mock.calls.some(([args]) => args[0] === 'pr' && args[1] === 'merge');
 
+function readRepoFile(path) {
+  return readFileSync(resolve(REPO_ROOT, path), 'utf8');
+}
+
+function workflowStep(workflow, name) {
+  const marker = `      - name: ${name}`;
+  const start = workflow.indexOf(marker);
+  if (start === -1) throw new Error(`Workflow step not found: ${name}`);
+  const end = workflow.indexOf('\n      - name:', start + marker.length);
+  return workflow.slice(start, end === -1 ? undefined : end);
+}
+
 describe('merge queue backend resolution', () => {
   it('fails unknown backends before any command can run', async () => {
     const runner = vi.fn();
@@ -143,6 +158,77 @@ describe('merge queue backend resolution', () => {
       })
     ).rejects.toMatchObject({ code: 'native_mutation_unauthorized' });
     expect(runner).not.toHaveBeenCalled();
+  });
+});
+
+describe('queue workflow mutation safety', () => {
+  it('revalidates the live head and hard gates before approval, then delegates enrollment', () => {
+    const workflow = readRepoFile('.github/workflows/agent-pipeline.yml');
+    const approval = workflowStep(workflow, 'Auto-approve PR');
+    const handoff = workflowStep(
+      workflow,
+      'Mark approved PR for queue controller'
+    );
+
+    expect(approval).toContain(
+      'PR_HEAD_SHA="${{ needs.guard.outputs.pr_head_sha }}"'
+    );
+    expect(approval).toContain('--json state,isDraft,headRefOid,labels');
+    expect(approval).toContain('.headRefOid == $expected_head');
+    for (const label of [
+      'needs-human',
+      'hold',
+      'gated',
+      'queue-deferred',
+      'needs-conflict-resolution',
+      'fast',
+    ]) {
+      expect(approval).toContain(`. == "${label}"`);
+    }
+    expect(approval.indexOf('CURRENT_STATE=$(gh pr view')).toBeLessThan(
+      approval.indexOf('-f event="APPROVE"')
+    );
+    expect(approval).toContain('echo "approved=false"');
+    expect(approval).toContain('echo "approved=true"');
+
+    expect(handoff).toContain("steps.auto-approve.outputs.approved == 'true'");
+    expect(handoff).toContain('--field "labels[]=auto-approved"');
+    expect(handoff).toContain('merge-queue-autoenroll');
+    expect(workflow).not.toContain('name: Add to Graphite merge queue');
+    expect(workflow).not.toMatch(
+      /gh pr edit[^\n]*--add-label[^\n]*merge-queue/
+    );
+  });
+
+  it('requires native configuration and ruleset preflight before autoenroll mutations', () => {
+    const workflow = readRepoFile(
+      '.github/workflows/merge-queue-autoenroll.yml'
+    );
+    const enroll = workflowStep(workflow, 'Enroll clean PRs');
+    const rebasePreflight = workflowStep(
+      workflow,
+      'Preflight native queue cutover'
+    );
+    const drain = readRepoFile('scripts/drain-pr-queue.sh');
+
+    expect(workflow).toContain(
+      'MERGE_QUEUE_BACKEND: ${{ vars.MERGE_QUEUE_BACKEND }}'
+    );
+    expect(workflow).not.toContain("MERGE_QUEUE_BACKEND || 'graphite'");
+    expect(workflow).toContain('  rebase:\n    needs: enroll\n');
+    expect(enroll).toContain('if [[ "$MERGE_QUEUE_BACKEND" != "native" ]]');
+    expect(enroll).toContain('bash scripts/drain-pr-queue.sh');
+    expect(rebasePreflight).toContain(
+      'if [[ "$MERGE_QUEUE_BACKEND" != "native" ]]'
+    );
+    expect(rebasePreflight).toContain(
+      'node scripts/merge-queue-backend.mjs preflight'
+    );
+    expect(
+      drain.indexOf('node scripts/merge-queue-backend.mjs preflight')
+    ).toBeLessThan(
+      drain.indexOf('node scripts/merge-queue-backend.mjs list-state')
+    );
   });
 });
 

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -176,6 +176,33 @@ const PERFORMANCE_PROFILER_REPAIR_MANIFEST = new Set([
   ...PERFORMANCE_PROFILER_REPAIR_PRIMARY_MANIFEST,
   ...AFFECTED_TEST_SELECTOR_MANIFEST,
 ]);
+const SCANNER_LOAD_REPAIR_PRIMARY_MANIFEST = new Set([
+  '.github/workflows/agent-pipeline.yml',
+  '.github/workflows/ci.yml',
+  '.github/workflows/merge-queue-autoenroll.yml',
+  'apps/web/tests/unit/analytics-metrics-layer-guard.test.ts',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts',
+  'apps/web/tests/unit/design-system/destructive-confirm-dialog-audit.test.ts',
+  'apps/web/tests/unit/metrics-layer-guard-logic.ts',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  'scripts/lib/__tests__/merge-queue-backend.test.mjs',
+]);
+const SCANNER_LOAD_REPAIR_MANIFEST = new Set([
+  ...SCANNER_LOAD_REPAIR_PRIMARY_MANIFEST,
+  ...AFFECTED_TEST_SELECTOR_MANIFEST,
+]);
+const SCANNER_LOAD_REPAIR_WEB_TESTS = [
+  'apps/web/tests/unit/analytics-metrics-layer-guard.test.ts',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts',
+  'apps/web/tests/unit/design-system/destructive-confirm-dialog-audit.test.ts',
+];
+const SCANNER_LOAD_REPAIR_SCRIPT_TESTS = [
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  'scripts/lib/__tests__/merge-queue-backend.test.mjs',
+];
 const PERFORMANCE_PROFILER_REPAIR_WEB_TESTS = [
   'apps/web/scripts/test-performance-profiler.test.ts',
 ];
@@ -393,12 +420,26 @@ export function buildAffectedTestPlan(changedFiles) {
   const isExactPerformanceProfilerRepairPrimary =
     files.length === PERFORMANCE_PROFILER_REPAIR_PRIMARY_MANIFEST.size &&
     files.every(file => PERFORMANCE_PROFILER_REPAIR_PRIMARY_MANIFEST.has(file));
-  const isExactPerformanceProfilerRepairWithSelector =
+  const isExactPerformanceProfilerRepairWithSelectorLegacy =
     files.length === PERFORMANCE_PROFILER_REPAIR_MANIFEST.size &&
     files.every(file => PERFORMANCE_PROFILER_REPAIR_MANIFEST.has(file));
+  const isExactScannerLoadRepairPrimary =
+    files.length === SCANNER_LOAD_REPAIR_PRIMARY_MANIFEST.size &&
+    files.every(file => SCANNER_LOAD_REPAIR_PRIMARY_MANIFEST.has(file));
+  const isExactScannerLoadRepairWithSelector =
+    files.length === SCANNER_LOAD_REPAIR_MANIFEST.size &&
+    files.every(file => SCANNER_LOAD_REPAIR_MANIFEST.has(file));
+  const scannerLoadRepairInputCount = files.filter(file =>
+    SCANNER_LOAD_REPAIR_MANIFEST.has(file)
+  ).length;
+  const isExactPerformanceProfilerRepairWithSelector =
+    isExactPerformanceProfilerRepairWithSelectorLegacy ||
+    isExactScannerLoadRepairWithSelector;
   const isExactPerformanceProfilerRepair =
     isExactPerformanceProfilerRepairPrimary ||
-    isExactPerformanceProfilerRepairWithSelector;
+    isExactPerformanceProfilerRepairWithSelectorLegacy ||
+    isExactScannerLoadRepairPrimary ||
+    isExactScannerLoadRepairWithSelector;
   const persistedAuthFixtureInputCount = files.filter(file =>
     PERSISTED_AUTH_FIXTURE_REPAIR_CORE.has(file)
   ).length;
@@ -553,8 +594,14 @@ export function buildAffectedTestPlan(changedFiles) {
   if (isExactNeonAttemptArtifactRepair) {
     mandatoryTests.push(...NEON_ATTEMPT_ARTIFACT_TESTS);
   }
-  if (isExactPerformanceProfilerRepair) {
+  if (
+    isExactPerformanceProfilerRepairPrimary ||
+    isExactPerformanceProfilerRepairWithSelectorLegacy
+  ) {
     mandatoryTests.push(...PERFORMANCE_PROFILER_REPAIR_WEB_TESTS);
+  }
+  if (isExactScannerLoadRepairPrimary || isExactScannerLoadRepairWithSelector) {
+    mandatoryTests.push(...SCANNER_LOAD_REPAIR_WEB_TESTS);
   }
   if (isExactRunnerPrerequisiteRepair) {
     mandatoryTests.push(...RUNNER_PREREQUISITE_CONTRACT_TESTS);
@@ -576,8 +623,12 @@ export function buildAffectedTestPlan(changedFiles) {
       : []),
   ]);
   const scriptVitestTests = unique([
-    ...(isExactPerformanceProfilerRepair
+    ...(isExactPerformanceProfilerRepairPrimary ||
+    isExactPerformanceProfilerRepairWithSelectorLegacy
       ? PERFORMANCE_PROFILER_REPAIR_SCRIPT_TESTS
+      : []),
+    ...(isExactScannerLoadRepairPrimary || isExactScannerLoadRepairWithSelector
+      ? SCANNER_LOAD_REPAIR_SCRIPT_TESTS
       : []),
     ...(isExactAffectedTestSelector ||
     (isExactAuthenticatedA11yRepair && affectedTestSelectorInputCount > 0) ||
@@ -644,7 +695,8 @@ export function buildAffectedTestPlan(changedFiles) {
       return true;
     if (
       isExactPerformanceProfilerRepair &&
-      PERFORMANCE_PROFILER_REPAIR_MANIFEST.has(file)
+      (PERFORMANCE_PROFILER_REPAIR_MANIFEST.has(file) ||
+        SCANNER_LOAD_REPAIR_MANIFEST.has(file))
     )
       return true;
     if (
@@ -708,6 +760,22 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactLayoutGuardContract;
+  const hasIncompleteScannerLoadRepair =
+    scannerLoadRepairInputCount > 0 &&
+    !isExactScannerLoadRepairPrimary &&
+    !isExactScannerLoadRepairWithSelector &&
+    !isExactAffectedTestSelector &&
+    !isExactAuthenticatedA11yRepair &&
+    !isExactPrerequisiteTrain &&
+    !isExactGoldenPathSmokeContractRepair &&
+    !isExactNeonAttemptArtifactRepair &&
+    !isExactPerformanceProfilerRepair &&
+    !isExactPersistedAuthFixtureRepair &&
+    !isExactVisualQaSelectorRepair &&
+    !isExactGtmqSourceGateReaper &&
+    !isExactRunnerIoPressure &&
+    !isExactRunnerPrerequisiteRepair &&
+    !isExactLayoutGuardContract;
   const hasIncompleteGtmqSourceGateReaper =
     gtmqSourceGateReaperInputCount > 0 &&
     !isExactGtmqSourceGateReaper &&
@@ -716,6 +784,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactNeonAttemptArtifactRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactAffectedTestSelector &&
+    !isExactScannerLoadRepairPrimary &&
     !isExactVisualQaSelectorRepair &&
     !isExactPerformanceProfilerRepairWithSelector &&
     !isExactRunnerIoPressure &&
@@ -787,6 +856,7 @@ export function buildAffectedTestPlan(changedFiles) {
     hasIncompleteVercelCongestionControl ||
     hasIncompleteAffectedTestSelector ||
     hasIncompletePerformanceProfilerRepair ||
+    hasIncompleteScannerLoadRepair ||
     hasIncompleteGtmqSourceGateReaper ||
     hasIncompleteRunnerIoPressure ||
     hasIncompleteRunnerPrerequisiteContract ||


### PR DESCRIPTION
## Root cause

Two independent CI recovery defects were blocking the queue:

1. Each ephemeral runner has 2 vCPUs, but every unit shard launched 3 Vitest forks. Reducing the pool to 2 removed CPU oversubscription but did not fix repository scanners by itself: exact head `850844c` still failed only `analytics-metrics-layer-guard.test.ts:48` after 27.7 seconds while the other 3,509 tests passed.
2. Analytics, destructive-dialog, and arbitrary-value ratchets could traverse the full tree under shared I/O pressure. Their native prefilters also needed fail-closed parity for multiline formulas, Unicode-adjacent identifiers, NUL-containing source, ripgrep config injection, malformed output, and missing paths.

Separately, Agent Pipeline could approve or hand a PR to Graphite from stale event state, and native enrollment lacked a fail-closed backend/ruleset preflight.

## Smallest durable fix

- match Vitest forks to the 2-vCPU runner quota and move the informational PR Summary off the ephemeral pool
- use trusted absolute ripgrep only as a coarse candidate selector; keep the JavaScript semantic scanners authoritative
- force `--no-config --text`, validate candidate paths, preserve deterministic ordering, and fall back to the complete walker on any failure or untrusted output
- give bounded repository scanners explicit 30-second ceilings
- teach Gem to classify this failure without claiming shared-host I/O until unchanged-blob and focused-pass evidence exists
- revalidate live PR head/state/gates immediately before approval
- remove direct Graphite enrollment and require an explicit native backend plus a live zero-bypass merge-queue ruleset before mutation

## Exact verification

- signed head: `e8086313197968712ae971a76fdd85c4149304c0`
- size: 13 files, 799 counted lines (canonical cap: 800/40)
- Node 22.23.1 / pnpm 9.15.4
- web: 57/57
- Gem/scripts: 262/262
- CI control: 118/118
- repeated scanner pair: 5/5 green; final scanner trio: 7/7 in 1.07s
- web typecheck, Biome, canonical actionlint, diff integrity, CI harness, native queue contract, commit hooks, and normal pre-push hook: green
- independent exact-diff review: no findings

GStack evidence is intentionally waived for this CI-recovery PR under the user-approved temporary recovery policy. Required remote CI remains authoritative; no required check, branch protection rule, or size policy is bypassed.