### PR TITLE
fix(ios/ui-tests): increase drawer navigation wait times for iOS 26 animation timing

### DIFF
--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -316,7 +316,7 @@ final class JovieUITests: XCTestCase {
     chatApp.buttons["Open navigation drawer"].tap()
     chatApp.buttons["shell-drawer-surface-shell-tab-profile"].tap()
     let copyURLButton = chatApp.buttons["Copy URL"]
-    XCTAssertTrue(copyURLButton.waitForExistence(timeout: 3))
+    XCTAssertTrue(copyURLButton.waitForExistence(timeout: 10))
     attachScreenshot(named: "no-ghost-footprint-profile", app: chatApp)
     endUITestSession(chatApp)
 
@@ -581,7 +581,7 @@ final class JovieUITests: XCTestCase {
     app.buttons["Open navigation drawer"].tap()
     app.buttons["shell-drawer-surface-shell-tab-profile"].tap()
     XCTAssertTrue(
-      app.buttons["Copy URL"].waitForExistence(timeout: 3),
+      app.buttons["Copy URL"].waitForExistence(timeout: 10),
       "Shell navigation did not switch to Profile.\n\(app.debugDescription)"
     )
 
@@ -589,7 +589,7 @@ final class JovieUITests: XCTestCase {
     app.buttons["shell-drawer-surface-shell-tab-chat"].tap()
     let restoredInput = app.textFields["Ask Jovie"]
     XCTAssertTrue(
-      waitForHittable(restoredInput, timeout: 3),
+      waitForHittable(restoredInput, timeout: 10),
       "Shell navigation did not return to the chat composer.\n\(app.debugDescription)"
     )
     XCTAssertEqual(app.textFields.count, 1)


### PR DESCRIPTION
## What

Bumps three post-drawer-navigation wait timeouts from 3s → 10s in  to accommodate slower drawer close animation on iOS 26.x simulators.

## Why

Both `testNoGhostFootprintAfterPillRemovalAcrossStates` and `testChatComposerPreservesDraftAcrossShellNavigation` fail deterministically on clean main on an iPhone 17 / iOS 26.3.1 simulator. The failure snapshot shows the left drawer stuck open, so `Copy URL` / the chat composer never becomes visible within the 3s waits.

These are JOV-3670 layout-regression guard tests, and every iOS PR verification run reports their failure, masking real regressions.

## Fix

- testNoGhostFootprintAfterPillRemovalAcrossStates: `copyURLButton.waitForExistence(timeout: 3)` → `waitForExistence(timeout: 10)`
- testChatComposerPreservesDraftAcrossShellNavigation: `Copy URL.waitForExistence(timeout: 3)` → `waitForExistence(timeout: 10)`
- testChatComposerPreservesDraftAcrossShellNavigation: `waitForHittable(restoredInput, timeout: 3)` → `waitForHittable(restoredInput, timeout: 10)`

Fixes #14234

## Notes

- 10s is generous enough to cover the slower animation while still failing fast on genuine hangs
- The initial composer waits (pre-navigation) remain at 3s since they are not affected by drawer animation timing