### PR TITLE
fix(test): disable waitlist gate in E2E seed (train 1 repair round 2)

### DIFF
--- a/apps/web/tests/seed-test-data.ts
+++ b/apps/web/tests/seed-test-data.ts
@@ -44,6 +44,7 @@ const {
   providerLinks,
   tourDates,
   users,
+  waitlistSettings,
 } = schema;
 
 export function buildPublicReleaseApprovalSeedRow(
@@ -1540,6 +1541,58 @@ export async function seedTestData(options: SeedTestDataOptions = {}) {
           }
         }
       }
+    }, seedRetryOptions);
+
+    await withSeedDatabaseRetry(async () => {
+      // Fresh ephemeral CI databases default `waitlist_settings.gate_enabled`
+      // to `true` (see lib/waitlist/settings.ts `ensureSettingsRow`). That
+      // blocks brand-new signups at account creation (lib/auth/gate.ts
+      // `checkWaitlistAccessInternal`) before they ever reach onboarding,
+      // which breaks E2E specs that drive the real signup flow
+      // (golden-path.spec.ts, shell-chat-v1*.spec.ts). Force the gate off
+      // for E2E runs. golden-path-waitlist-local.spec.ts is unaffected: it
+      // provisions its user via the test-auth-bypass session path (skips
+      // gate.ts entirely) and drives waitlist state via direct
+      // waitlist_entries writes, not this flag.
+      console.log('  Disabling waitlist gate for E2E...');
+      const nextDayUtc = new Date();
+      nextDayUtc.setUTCDate(nextDayUtc.getUTCDate() + 1);
+      nextDayUtc.setUTCHours(0, 0, 0, 0);
+
+      await db
+        .insert(waitlistSettings)
+        .values({
+          id: 1,
+          gateEnabled: false,
+          autoAcceptResetsAt: nextDayUtc,
+        })
+        .onConflictDoUpdate({
+          target: waitlistSettings.id,
+          set: { gateEnabled: false, updatedAt: new Date() },
+        });
+
+      // `isWaitlistGateEnabled()` layers a 30s Redis cache on top of the DB
+      // row (see lib/waitlist/settings.ts GATE_CACHE_KEY); invalidate it so
+      // a stale `true` value from a prior run against a shared Redis
+      // instance can't outlive this seed.
+      const { UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN } = getSeedEnv();
+      if (UPSTASH_REDIS_REST_URL && UPSTASH_REDIS_REST_TOKEN) {
+        try {
+          const redis = new Redis({
+            url: UPSTASH_REDIS_REST_URL,
+            token: UPSTASH_REDIS_REST_TOKEN,
+          });
+          await redis.del('waitlist:gate:enabled');
+          console.log('    ✓ Invalidated waitlist gate Redis cache');
+        } catch (error) {
+          console.warn(
+            '    ⚠ Failed to invalidate waitlist gate Redis cache:',
+            error
+          );
+        }
+      }
+
+      console.log('    ✓ Waitlist gate disabled for E2E');
     }, seedRetryOptions);
 
     console.log('✅ Test data seeding complete');


### PR DESCRIPTION
## What
Fresh ephemeral CI databases default `waitlist_settings.gate_enabled=true` (schema default, `lib/db/schema/waitlist.ts:155`). That blocks brand-new signups at account creation (`lib/auth/gate.ts`) before they reach onboarding — breaking every E2E spec that drives the real signup flow. The seed now forces the gate off and invalidates the 30s Redis gate cache (`GATE_CACHE_KEY = 'waitlist:gate:enabled'`).

## Disposition (train #14214 failures)
| Check | Root cause | This PR |
|---|---|---|
| Golden Path (PR) | signup blocked by waitlist gate → /onboarding redirects to /waitlist | **Fixed** — seed disables gate |
| Extended Smoke (Preview) — signup-funnel/welcome-chat/claim | same gate blocks signup flow | **Fixed** (expected) |
| Extended Smoke — shell-chat-v1 specs (bypass persona) | bypass skips the gate; if these still fail after this lands, it's a separate authed-render issue — evaluate on CI | **Watch** |
| Mobile Overflow Guard (320/390/430) | authed routes assert `auth bootstrap should not server-error`; if gate-related, fixed; if real overflow, separate | **Watch** — CI re-evaluates |
| Lighthouse (public routes) (0) | **pre-existing on main** (run 29215286408, commit e049e54) — tracked in #14233 | Out of scope |
| A11y (authenticated, informational) | crash-masked until #14219; tracked in #14225 | Out of scope (informational) |

## Verification
- Typecheck: pass (exit 0). Biome: clean. Pre-commit hooks (gitleaks, trufflehog, eslint, typecheck): pass.
- Static verification: `GATE_CACHE_KEY` matches, `waitlistSettings` schema fields (`gateEnabled`, `autoAcceptResetsAt`) confirmed, imports (`Redis`, `getSeedEnv`) present.
- Live E2E deferred to CI (build-machine constraints).

Part of #12633, unblocks train #14214.