### PR TITLE
refactor(dev): extract DevToolbar row components to DevToolbarRows

### DIFF
--- a/apps/web/components/features/dev/DevToolbar.tsx
+++ b/apps/web/components/features/dev/DevToolbar.tsx
@@ -1,11 +1,6 @@
 'use client';
 
 import { Button } from '@jovie/ui';
-import * as Switch from '@radix-ui/react-switch';
-import {
-  type QueryClient,
-  useQueryClient as useQueryClientBase,
-} from '@tanstack/react-query';
 import {
   ArrowUpCircle,
   Check,
@@ -40,23 +35,12 @@ import {
   APP_FLAG_OVERRIDE_KEYS,
   DESIGN_V1_ALIAS_FLAGS,
 } from '@/lib/flags/contracts';
-import { queryKeys } from '@/lib/queries/keys';
-import { useBillingStatusQuery } from '@/lib/queries/useBillingStatusQuery';
-
-/** Safe query client — returns null outside QueryClientProvider (root layout). */
-function useSafeQueryClient(): QueryClient | null {
-  try {
-    return useQueryClientBase();
-  } catch {
-    return null;
-  }
-}
-
 import {
   registerServiceWorker,
   SW_ENABLED_KEY,
   unregisterServiceWorker,
 } from '@/lib/service-worker/control';
+import { FlagRow, OrphanOverrides, PlanToggle } from './DevToolbarRows';
 import { useFlagBadges } from './FlagBadgeContext';
 
 type FlagEntry = {
@@ -1293,173 +1277,3 @@ export function DevToolbar({
 }
 
 /** Plan toggle gate — only renders inner component when QueryClientProvider exists. */
-function PlanToggle() {
-  const queryClient = useSafeQueryClient();
-  if (!queryClient) return null;
-  return <PlanToggleInner queryClient={queryClient} />;
-}
-
-/** Plan toggle for admin users. Uses billing query to show/switch plans. */
-function PlanToggleInner({
-  queryClient,
-}: {
-  readonly queryClient: QueryClient;
-}) {
-  const { data: billing } = useBillingStatusQuery();
-  const [switching, setSwitching] = useState(false);
-  const currentPlan = billing?.plan ?? 'free';
-
-  return (
-    <>
-      <div className='w-px h-4 mx-1 bg-subtle' />
-      <div className='flex items-center gap-0.5'>
-        <span className='text-3xs text-quaternary-token mr-0.5'>Plan</span>
-        {(['free', 'pro', 'max'] as const).map(plan => (
-          <button
-            key={plan}
-            type='button'
-            disabled={switching}
-            onClick={async () => {
-              if (plan === currentPlan || switching) return;
-              setSwitching(true);
-              try {
-                const res = await fetch('/api/admin/set-plan', {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ plan }),
-                });
-                if (res.ok) {
-                  await queryClient.invalidateQueries({
-                    queryKey: queryKeys.billing.all,
-                  });
-                }
-              } finally {
-                setSwitching(false);
-              }
-            }}
-            className={`px-1.5 py-0.5 rounded text-3xs transition-colors ${
-              plan === currentPlan
-                ? 'font-semibold text-accent bg-accent/10'
-                : 'text-quaternary-token hover:text-(--color-text-primary) hover:bg-surface-2'
-            } ${switching ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-            title={`Switch to ${plan} plan`}
-            aria-label={`Switch to ${plan} plan`}
-          >
-            {plan}
-          </button>
-        ))}
-      </div>
-    </>
-  );
-}
-
-function OrphanOverrides({
-  keys,
-  onPurge,
-}: Readonly<{ keys: string[]; onPurge: () => void }>) {
-  const [expanded, setExpanded] = useState(false);
-  return (
-    <div className='mb-2 mt-1 border-l-2 border-yellow-500/50 pl-3'>
-      <div className='flex items-center justify-between mb-1'>
-        <span
-          className='text-3xs font-semibold uppercase tracking-wide text-yellow-400'
-          title='Override keys in localStorage that no longer match any flag in APP_FLAG_OVERRIDE_KEYS. Likely from renamed or removed flags.'
-        >
-          Orphans ({keys.length})
-        </span>
-        <div className='flex items-center gap-2'>
-          <button
-            type='button'
-            onClick={() => setExpanded(prev => !prev)}
-            className='text-3xs text-(--color-text-tertiary) hover:text-(--color-text-primary) underline transition-colors'
-          >
-            {expanded ? 'hide' : 'inspect'}
-          </button>
-          <button
-            type='button'
-            onClick={onPurge}
-            className='text-3xs text-yellow-400 hover:text-yellow-300 underline transition-colors'
-          >
-            purge
-          </button>
-        </div>
-      </div>
-      {expanded && (
-        <div className='flex flex-col gap-0.5 pb-1'>
-          {keys.map(k => (
-            <span
-              key={k}
-              className='truncate text-3xs text-quaternary-token font-mono'
-            >
-              {k}
-            </span>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function FlagRow({
-  label,
-  isOverridden,
-  checked,
-  flashing = false,
-  serverDefault,
-  onCheckedChange,
-  onClear,
-  source = 'statsig',
-}: Readonly<{
-  label: string;
-  isOverridden: boolean;
-  checked: boolean;
-  /** Parent-driven flash highlight — survives row re-categorization. */
-  flashing?: boolean;
-  serverDefault?: boolean;
-  onCheckedChange: (v: boolean) => void;
-  onClear: () => void;
-  source?: 'statsig' | 'code';
-}>) {
-  return (
-    <div
-      className={`flex items-center gap-2 py-0.5 rounded-sm transition-colors duration-subtle ${
-        flashing ? 'bg-accent/10' : ''
-      }`}
-    >
-      <Switch.Root
-        checked={checked}
-        onCheckedChange={onCheckedChange}
-        className={`relative w-7 h-4 rounded-full transition-colors outline-none cursor-pointer shrink-0 ${
-          checked ? 'bg-accent' : 'bg-surface-3'
-        }`}
-      >
-        <Switch.Thumb className='block w-3 h-3 bg-white rounded-full transition-transform translate-x-0.5 data-[state=checked]:translate-x-3.5 shadow-sm dark:bg-white' />
-      </Switch.Root>
-      <span
-        className={`flex-1 truncate ${isOverridden ? 'text-(--color-text-primary)' : 'text-(--color-text-tertiary)'}`}
-      >
-        {label}
-      </span>
-      {isOverridden && serverDefault !== undefined && (
-        <span className='shrink-0 text-3xs text-quaternary-token'>
-          server: {serverDefault ? 'on' : 'off'}
-        </span>
-      )}
-      {isOverridden && (
-        <button
-          type='button'
-          onClick={onClear}
-          title='Remove override'
-          className='shrink-0 text-quaternary-token hover:text-(--color-text-secondary) transition-colors'
-        >
-          <X size={10} />
-        </button>
-      )}
-      {!isOverridden && (
-        <span className='shrink-0 text-3xs text-quaternary-token'>
-          {source}
-        </span>
-      )}
-    </div>
-  );
-}

--- a/apps/web/components/features/dev/DevToolbarRows.tsx
+++ b/apps/web/components/features/dev/DevToolbarRows.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import * as Switch from '@radix-ui/react-switch';
+import {
+  type QueryClient,
+  useQueryClient as useQueryClientBase,
+} from '@tanstack/react-query';
+import { X } from 'lucide-react';
+import { useState } from 'react';
+import { queryKeys } from '@/lib/queries/keys';
+import { useBillingStatusQuery } from '@/lib/queries/useBillingStatusQuery';
+
+/** Safe query client — returns null outside QueryClientProvider (root layout). */
+function useSafeQueryClient(): QueryClient | null {
+  try {
+    return useQueryClientBase();
+  } catch {
+    return null;
+  }
+}
+
+export function PlanToggle() {
+  const queryClient = useSafeQueryClient();
+  if (!queryClient) return null;
+  return <PlanToggleInner queryClient={queryClient} />;
+}
+
+/** Plan toggle for admin users. Uses billing query to show/switch plans. */
+function PlanToggleInner({
+  queryClient,
+}: {
+  readonly queryClient: QueryClient;
+}) {
+  const { data: billing } = useBillingStatusQuery();
+  const [switching, setSwitching] = useState(false);
+  const currentPlan = billing?.plan ?? 'free';
+
+  return (
+    <>
+      <div className='w-px h-4 mx-1 bg-subtle' />
+      <div className='flex items-center gap-0.5'>
+        <span className='text-3xs text-quaternary-token mr-0.5'>Plan</span>
+        {(['free', 'pro', 'max'] as const).map(plan => (
+          <button
+            key={plan}
+            type='button'
+            disabled={switching}
+            onClick={async () => {
+              if (plan === currentPlan || switching) return;
+              setSwitching(true);
+              try {
+                const res = await fetch('/api/admin/set-plan', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ plan }),
+                });
+                if (res.ok) {
+                  await queryClient.invalidateQueries({
+                    queryKey: queryKeys.billing.all,
+                  });
+                }
+              } finally {
+                setSwitching(false);
+              }
+            }}
+            className={`px-1.5 py-0.5 rounded text-3xs transition-colors ${
+              plan === currentPlan
+                ? 'font-semibold text-accent bg-accent/10'
+                : 'text-quaternary-token hover:text-(--color-text-primary) hover:bg-surface-2'
+            } ${switching ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+            title={`Switch to ${plan} plan`}
+            aria-label={`Switch to ${plan} plan`}
+          >
+            {plan}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}
+
+export function OrphanOverrides({
+  keys,
+  onPurge,
+}: Readonly<{ keys: string[]; onPurge: () => void }>) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className='mb-2 mt-1 border-l-2 border-yellow-500/50 pl-3'>
+      <div className='flex items-center justify-between mb-1'>
+        <span
+          className='text-3xs font-semibold uppercase tracking-wide text-yellow-400'
+          title='Override keys in localStorage that no longer match any flag in APP_FLAG_OVERRIDE_KEYS. Likely from renamed or removed flags.'
+        >
+          Orphans ({keys.length})
+        </span>
+        <div className='flex items-center gap-2'>
+          <button
+            type='button'
+            onClick={() => setExpanded(prev => !prev)}
+            className='text-3xs text-(--color-text-tertiary) hover:text-(--color-text-primary) underline transition-colors'
+          >
+            {expanded ? 'hide' : 'inspect'}
+          </button>
+          <button
+            type='button'
+            onClick={onPurge}
+            className='text-3xs text-yellow-400 hover:text-yellow-300 underline transition-colors'
+          >
+            purge
+          </button>
+        </div>
+      </div>
+      {expanded && (
+        <div className='flex flex-col gap-0.5 pb-1'>
+          {keys.map(k => (
+            <span
+              key={k}
+              className='truncate text-3xs text-quaternary-token font-mono'
+            >
+              {k}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function FlagRow({
+  label,
+  isOverridden,
+  checked,
+  flashing = false,
+  serverDefault,
+  onCheckedChange,
+  onClear,
+  source = 'statsig',
+}: Readonly<{
+  label: string;
+  isOverridden: boolean;
+  checked: boolean;
+  /** Parent-driven flash highlight — survives row re-categorization. */
+  flashing?: boolean;
+  serverDefault?: boolean;
+  onCheckedChange: (v: boolean) => void;
+  onClear: () => void;
+  source?: 'statsig' | 'code';
+}>) {
+  return (
+    <div
+      className={`flex items-center gap-2 py-0.5 rounded-sm transition-colors duration-subtle ${
+        flashing ? 'bg-accent/10' : ''
+      }`}
+    >
+      <Switch.Root
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        className={`relative w-7 h-4 rounded-full transition-colors outline-none cursor-pointer shrink-0 ${
+          checked ? 'bg-accent' : 'bg-surface-3'
+        }`}
+      >
+        <Switch.Thumb className='block w-3 h-3 bg-white rounded-full transition-transform translate-x-0.5 data-[state=checked]:translate-x-3.5 shadow-sm dark:bg-white' />
+      </Switch.Root>
+      <span
+        className={`flex-1 truncate ${isOverridden ? 'text-(--color-text-primary)' : 'text-(--color-text-tertiary)'}`}
+      >
+        {label}
+      </span>
+      {isOverridden && serverDefault !== undefined && (
+        <span className='shrink-0 text-3xs text-quaternary-token'>
+          server: {serverDefault ? 'on' : 'off'}
+        </span>
+      )}
+      {isOverridden && (
+        <button
+          type='button'
+          onClick={onClear}
+          title='Remove override'
+          className='shrink-0 text-quaternary-token hover:text-(--color-text-secondary) transition-colors'
+        >
+          <X size={10} />
+        </button>
+      )}
+      {!isOverridden && (
+        <span className='shrink-0 text-3xs text-quaternary-token'>
+          {source}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Repo-quality loop, iteration 3 (no Linear issue — ad-hoc loop) — the first web chunk, deliberately starting with the **dev-only, lowest-blast-radius** file. Behavior-preserving split of `DevToolbar.tsx` (**1465 → 1280 lines**).

- The prop-driven row/toggle components (`PlanToggle`, `PlanToggleInner`, `OrphanOverrides`, `FlagRow`) + the `useSafeQueryClient` helper → new `DevToolbarRows.tsx` (same feature dir, so eslint-boundaries safe). They're self-contained — the only shared dependency (`useSafeQueryClient`) moved with them (verified the main body doesn't use it).
- Now-unused imports (`Switch`, `queryKeys`, `useBillingStatusQuery`, `useQueryClient`, `QueryClient` type) dropped from `DevToolbar.tsx` and relocated to the new file. Component bodies verbatim.

Note: `DevToolbar` itself is a single ~1030-line component; its body can't be split without decomposing the component (structural change, out of scope for a behavior-preserving move). This extracts the cleanly-separable periphery.

## Verification

- `pnpm biome check` → **clean ✓**
- `pnpm --filter @jovie/web run typecheck` → **pass ✓** (0 errors)
- `vitest tests/unit/dev/DevToolbar.test.tsx` → **70/70 pass ✓**
- Pre-commit gate (eslint custom rules, a11y, typecheck) passed.

## Risks

- Very low: dev-only component (`components/features/dev/`), same-directory move, no logic changes, typecheck + full test coverage green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)