### PR TITLE
docs(ci): retire superseded deploy-relevance patch

### DIFF
--- a/docs/archive/PR-14351-RETIREMENT.md
+++ b/docs/archive/PR-14351-RETIREMENT.md
@@ -1,0 +1,9 @@
+# PR #14351 Retirement
+
+The deploy-relevance patch is retired. Native merge-queue staging in
+[#14484](https://github.com/JovieInc/Jovie/pull/14484) replaced it with exact
+merge-group proof reuse and a fail-closed direct-main fallback, so the older
+deploy classifier conflicts with the final release topology.
+
+Replacement: #14484 at `153d2e92b67eec0830fe5f194ff39ba3d8745030`. No CI
+code from #14351 remains.


### PR DESCRIPTION
## Summary

- Retires the deploy-relevance patch after native merge-queue release staging superseded its classifier and deploy-gate behavior.
- Preserves only `docs/archive/PR-14351-RETIREMENT.md` as the audit record.
- No workflow, deploy classifier, product code, migration code, or production controller code from the previous payload remains.

## Supersession

- Native combined-head proof reuse and fail-closed direct-main fallback: #14484 at `153d2e92b67eec0830fe5f194ff39ba3d8745030`
- GitHub Update Branch rebased this retirement record onto `main` at `d208da0cb385065c8dd8ca794067230e14d366d3`.

## Verification

- Exact head: `9c6cc3b3e2c36a538a8d2f871c515e00f3a9110f`
- Exact tree: `4f5a9befb8325346a2459650fc06fe783de08dda`
- Diff: one added Markdown file, 9 lines.
- Stable patch ID matches the reviewed signed preparation: `d3f2ea7be367e3a84805355f787e661b081406d7`.
- `git diff --check`: passed.

## Queue control

Staged only. This operation did not merge or enqueue the PR.