### PR TITLE
feat(ci): add metrics schema v2

### DIFF
--- a/scripts/hermes/jobs/ci-metrics.ts
+++ b/scripts/hermes/jobs/ci-metrics.ts
@@ -15,10 +15,22 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 
-import { summarizeCiMetrics } from '../../lib/ci-metrics-compute.mjs';
+import {
+  createApiRequestBudget,
+  hasGreenRequiredChecks,
+  shouldReuseJobCache,
+  shouldReuseRequiredChecksCache,
+  summarizeCiMetrics,
+} from '../../lib/ci-metrics-compute.mjs';
 import { parseMergeQueueTimeline } from '../../lib/merge-queue-guard.mjs';
 import { gbrainLearn } from '../lib/gbrain';
 import { HERMES_PATHS } from '../lib/hermes-paths';
@@ -29,6 +41,12 @@ const RUN_SAMPLE = 100;
 const PR_SAMPLE = 50;
 const METRICS_JSONL = join(HERMES_PATHS.stateDir, 'ci-metrics.jsonl');
 const METRICS_LATEST = join(HERMES_PATHS.stateDir, 'ci-metrics-latest.json');
+const METRICS_API_CACHE = join(
+  HERMES_PATHS.stateDir,
+  'ci-metrics-api-cache.json'
+);
+const API_CACHE_SCHEMA_VERSION = 2;
+const TIMELINE_REQUEST_RESERVE = 6;
 
 interface WorkflowRun {
   readonly id: number;
@@ -37,6 +55,62 @@ interface WorkflowRun {
   readonly run_attempt: number;
   readonly status: string;
   readonly conclusion: string | null;
+  readonly head_sha: string;
+}
+
+interface WorkflowJob {
+  readonly id: number;
+  readonly name: string;
+  readonly started_at: string | null;
+  readonly completed_at: string | null;
+  readonly conclusion: string | null;
+  readonly runner_name: string | null;
+  readonly labels: readonly string[];
+}
+
+interface RequiredCheck {
+  readonly id: number;
+  readonly name: string;
+  readonly started_at: string | null;
+  readonly completed_at: string | null;
+  readonly conclusion: string | null;
+}
+
+interface RunJobSample {
+  readonly runId: number;
+  readonly runCreatedAt: string;
+  readonly runConclusion: string | null;
+  readonly jobs: readonly WorkflowJob[];
+}
+
+interface JobCacheEntry {
+  readonly updatedAt: string;
+  readonly sample: RunJobSample;
+}
+
+interface CheckCacheEntry {
+  readonly fetchedAt: string;
+  readonly green: boolean;
+  readonly checks: readonly RequiredCheck[];
+}
+
+type MergeQueueTimeline = ReturnType<typeof parseMergeQueueTimeline>;
+
+interface TimelineCacheEntry {
+  readonly mergedAt: string | null;
+  readonly timeline: MergeQueueTimeline;
+}
+
+interface MetricsApiCache {
+  readonly schemaVersion: number;
+  readonly jobs: Record<string, JobCacheEntry>;
+  readonly checks: Record<string, CheckCacheEntry>;
+  readonly timelines: Record<string, TimelineCacheEntry>;
+}
+
+interface ApiRequestBudget {
+  tryConsume(reservedRequests?: number): boolean;
+  readonly used: number;
 }
 
 interface MergedPr {
@@ -68,6 +142,163 @@ function fetchCiRuns(repo: string): WorkflowRun[] {
   );
 }
 
+function emptyApiCache(): MetricsApiCache {
+  return {
+    schemaVersion: API_CACHE_SCHEMA_VERSION,
+    jobs: {},
+    checks: {},
+    timelines: {},
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isJobCacheEntry(value: unknown): value is JobCacheEntry {
+  if (!isRecord(value) || !isRecord(value.sample)) return false;
+  return (
+    typeof value.updatedAt === 'string' &&
+    typeof value.sample.runId === 'number' &&
+    typeof value.sample.runCreatedAt === 'string' &&
+    Array.isArray(value.sample.jobs)
+  );
+}
+
+function isCheckCacheEntry(value: unknown): value is CheckCacheEntry {
+  return (
+    isRecord(value) &&
+    typeof value.fetchedAt === 'string' &&
+    typeof value.green === 'boolean' &&
+    Array.isArray(value.checks)
+  );
+}
+
+function isTimelineCacheEntry(value: unknown): value is TimelineCacheEntry {
+  return (
+    isRecord(value) &&
+    (value.mergedAt === null || typeof value.mergedAt === 'string') &&
+    isRecord(value.timeline)
+  );
+}
+
+function isCacheEntryRecord<T>(
+  value: unknown,
+  isEntry: (entry: unknown) => entry is T
+): value is Record<string, T> {
+  return isRecord(value) && Object.values(value).every(isEntry);
+}
+
+function readApiCache(): MetricsApiCache {
+  if (!existsSync(METRICS_API_CACHE)) return emptyApiCache();
+  try {
+    const parsed = JSON.parse(
+      readFileSync(METRICS_API_CACHE, 'utf8')
+    ) as unknown;
+    if (
+      isRecord(parsed) &&
+      parsed.schemaVersion === API_CACHE_SCHEMA_VERSION &&
+      isCacheEntryRecord(parsed.jobs, isJobCacheEntry) &&
+      isCacheEntryRecord(parsed.checks, isCheckCacheEntry) &&
+      isCacheEntryRecord(parsed.timelines, isTimelineCacheEntry)
+    ) {
+      return parsed;
+    }
+  } catch {
+    // A corrupt cache only costs one bounded refill; metric history is separate.
+  }
+  return emptyApiCache();
+}
+
+function fetchRunSamples(
+  repo: string,
+  runs: readonly WorkflowRun[],
+  cache: MetricsApiCache,
+  now: Date,
+  budget: ApiRequestBudget
+) {
+  // Stable completed runs are reused by id/updated_at and SHA. On a cold cache,
+  // job/check hydration stops before the global ceiling so timeline hydration
+  // always retains a small slice of the same request budget.
+  const next = emptyApiCache();
+  const samples = runs.map(run => {
+    const runKey = String(run.id);
+    let jobEntry = cache.jobs[runKey];
+    const reuseJobs = shouldReuseJobCache(run, jobEntry);
+    let jobSample: RunJobSample =
+      reuseJobs && jobEntry
+        ? jobEntry.sample
+        : {
+            runId: run.id,
+            runCreatedAt: run.created_at,
+            runConclusion: run.conclusion,
+            jobs: [],
+          };
+    let jobsHydrated = reuseJobs;
+
+    if (!reuseJobs && budget.tryConsume(TIMELINE_REQUEST_RESERVE)) {
+      try {
+        const out = gh(
+          ['api', `repos/${repo}/actions/runs/${run.id}/jobs?per_page=100`],
+          20_000
+        );
+        jobSample = {
+          runId: run.id,
+          runCreatedAt: run.created_at,
+          runConclusion: run.conclusion,
+          jobs: (JSON.parse(out) as { jobs?: WorkflowJob[] }).jobs ?? [],
+        };
+        jobEntry = { updatedAt: run.updated_at, sample: jobSample };
+        jobsHydrated = true;
+      } catch {
+        // Keep the old entry only so the changed run is retried next tick. Do
+        // not measure the changed run with stale job timestamps.
+      }
+    }
+    if (jobEntry) next.jobs[runKey] = jobEntry;
+
+    let checkEntry = next.checks[run.head_sha] ?? cache.checks[run.head_sha];
+    const reuseChecks = shouldReuseRequiredChecksCache(run, checkEntry, now);
+    let requiredChecks = reuseChecks ? (checkEntry?.checks ?? []) : [];
+    let requiredChecksHydrated = reuseChecks;
+    if (!reuseChecks && budget.tryConsume(TIMELINE_REQUEST_RESERVE)) {
+      try {
+        const out = gh(
+          [
+            'api',
+            `repos/${repo}/commits/${run.head_sha}/check-runs?per_page=100`,
+          ],
+          20_000
+        );
+        const checks =
+          (JSON.parse(out) as { check_runs?: RequiredCheck[] }).check_runs ??
+          [];
+        checkEntry = {
+          fetchedAt: now.toISOString(),
+          green: hasGreenRequiredChecks(checks),
+          checks,
+        };
+        requiredChecks = checks;
+        requiredChecksHydrated = true;
+      } catch {
+        // Keep the old entry only so the next tick retries. Do not measure a
+        // changed run with stale required-check results.
+      }
+    }
+    if (checkEntry) next.checks[run.head_sha] = checkEntry;
+
+    return {
+      ...jobSample,
+      headSha: run.head_sha,
+      jobsHydrated,
+      requiredChecks,
+      requiredChecksHydrated,
+    };
+  });
+
+  return { samples, cache: next };
+}
+
 function fetchMergedPrs(): MergedPr[] {
   const out = gh([
     'pr',
@@ -82,37 +313,70 @@ function fetchMergedPrs(): MergedPr[] {
   return JSON.parse(out) as MergedPr[];
 }
 
-function fetchTimeline(repo: string, pr: MergedPr) {
-  // ponytail: first 100 timeline events captures the merge-queue label,
-  // ready_for_review, and merge events for nearly all PRs; skip --paginate to
-  // bound per-tick API cost.
-  try {
-    const out = gh(
-      ['api', `repos/${repo}/issues/${pr.number}/timeline?per_page=100`],
-      20_000
-    );
-    return parseMergeQueueTimeline(JSON.parse(out), {
-      prCreatedAt: pr.createdAt,
-    });
-  } catch {
-    return null;
+function fetchTimelineSamples(
+  repo: string,
+  prs: readonly MergedPr[],
+  cache: MetricsApiCache,
+  nextCache: MetricsApiCache,
+  budget: ApiRequestBudget
+): MergeQueueTimeline[] {
+  const timelines: MergeQueueTimeline[] = [];
+  for (const pr of prs) {
+    const key = String(pr.number);
+    let entry = cache.timelines[key];
+    if (entry?.mergedAt !== pr.mergedAt) entry = undefined;
+
+    if (!entry && budget.tryConsume()) {
+      // ponytail: first 100 timeline events captures the merge-queue label,
+      // ready_for_review, and merge events for nearly all PRs; skip --paginate
+      // to keep each request bounded.
+      try {
+        const out = gh(
+          ['api', `repos/${repo}/issues/${pr.number}/timeline?per_page=100`],
+          20_000
+        );
+        entry = {
+          mergedAt: pr.mergedAt,
+          timeline: parseMergeQueueTimeline(JSON.parse(out), {
+            prCreatedAt: pr.createdAt,
+          }),
+        };
+      } catch {
+        // Leave uncached so the next tick retries within its fresh budget.
+      }
+    }
+
+    if (entry) {
+      nextCache.timelines[key] = entry;
+      timelines.push(entry.timeline);
+    }
   }
+  return timelines;
 }
 
 function fmtMin(seconds: number): string {
   return `${Math.round(seconds / 60)}m`;
 }
 
+function fmtSampledMin(seconds: number, samples: number): string {
+  return samples > 0 ? fmtMin(seconds) : '?';
+}
+
 function renderBody(m: ReturnType<typeof summarizeCiMetrics>): string {
   const t = m.throughput;
   const l = m.latency;
   const v = m.throughputVerdict;
+  const h = m.hydration;
   return [
+    `Snapshot: ${h.complete ? 'COMPLETE' : 'PARTIAL (non-authoritative)'} · jobs ${h.runJobs.covered}/${h.runJobs.total} · required-check SHAs ${h.requiredChecks.covered}/${h.requiredChecks.total} · timelines ${h.timelines.covered}/${h.timelines.total}`,
     `Window: ${m.window.mergedPrs} merged PRs · ${m.window.ciRuns} CI runs · ${m.window.spanDays}d span`,
-    `Throughput (primary): ${t.mergedPrsPerDay}/day · ${t.ciRunHoursPerMergedPr ?? '?'} runner-h/PR · flaky ${(t.flakyRerunRate * 100).toFixed(1)}% · queue-wait p50 ${fmtMin(t.queueWaitSeconds.p50)} / p95 ${fmtMin(t.queueWaitSeconds.p95)}`,
-    `Latency (secondary): gate p50 ${fmtMin(l.gateWallclockSeconds.p50)} / p75 ${fmtMin(l.gateWallclockSeconds.p75)} / p95 ${fmtMin(l.gateWallclockSeconds.p95)} · full-merge p50 ${fmtMin(l.fullMergeTimeSeconds.p50)} / p95 ${fmtMin(l.fullMergeTimeSeconds.p95)}`,
-    `Ready→merged (target p50<10m / p95<15m): p50 ${fmtMin(l.readyToMergeSeconds.p50)} / p75 ${fmtMin(l.readyToMergeSeconds.p75)} / p95 ${fmtMin(l.readyToMergeSeconds.p95)}`,
-    `Samples: gate ${m.sampleSizes.gate} · full-merge ${m.sampleSizes.fullMerge} · queue-wait ${m.sampleSizes.queueWait} · ready-to-merge ${m.sampleSizes.readyToMerge}`,
+    `Throughput (primary): ${t.mergedPrsPerDay}/day · ${t.ciRunHoursPerMergedPr ?? '?'} legacy CI wall-clock h/PR · flaky ${(t.flakyRerunRate * 100).toFixed(1)}% · queue-wait p50 ${fmtSampledMin(t.queueWaitSeconds.p50, m.sampleSizes.queueWait)} / p95 ${fmtSampledMin(t.queueWaitSeconds.p95, m.sampleSizes.queueWait)}`,
+    `Latency (secondary): gate p50 ${fmtSampledMin(l.gateWallclockSeconds.p50, m.sampleSizes.gate)} / p75 ${fmtSampledMin(l.gateWallclockSeconds.p75, m.sampleSizes.gate)} / p95 ${fmtSampledMin(l.gateWallclockSeconds.p95, m.sampleSizes.gate)} · full-merge p50 ${fmtSampledMin(l.fullMergeTimeSeconds.p50, m.sampleSizes.fullMerge)} / p95 ${fmtSampledMin(l.fullMergeTimeSeconds.p95, m.sampleSizes.fullMerge)}`,
+    `Fleet lead time (target p50<10m / p95<15m): p50 ${fmtSampledMin(l.fleetLeadTimeSeconds.p50, m.sampleSizes.fleetLeadTime)} / p75 ${fmtSampledMin(l.fleetLeadTimeSeconds.p75, m.sampleSizes.fleetLeadTime)} / p95 ${fmtSampledMin(l.fleetLeadTimeSeconds.p95, m.sampleSizes.fleetLeadTime)}`,
+    `Queue decomposition: first-enqueue lead p50 ${fmtSampledMin(l.firstEnqueueLeadSeconds.p50, m.sampleSizes.firstEnqueueLead)} / p95 ${fmtSampledMin(l.firstEnqueueLeadSeconds.p95, m.sampleSizes.firstEnqueueLead)} · last-enqueue→merge p50 ${fmtSampledMin(l.lastEnqueueToMergeSeconds.p50, m.sampleSizes.lastEnqueueToMerge)} / p95 ${fmtSampledMin(l.lastEnqueueToMergeSeconds.p95, m.sampleSizes.lastEnqueueToMerge)} · active queued p50 ${fmtSampledMin(l.activeQueuedSeconds.p50, m.sampleSizes.activeQueued)} / p95 ${fmtSampledMin(l.activeQueuedSeconds.p95, m.sampleSizes.activeQueued)}`,
+    `Runner use: hosted ${fmtSampledMin(t.runnerJobSeconds.hosted, m.sampleSizes.jobs)} · self-hosted ${fmtSampledMin(t.runnerJobSeconds.selfHosted, m.sampleSizes.jobs)} · cancellation waste ${fmtSampledMin(t.cancellationWasteSeconds, m.sampleSizes.jobs)}`,
+    `Gate diagnostics: job-start p50 ${fmtSampledMin(l.jobStartDelaySeconds.p50, m.sampleSizes.jobStartDelay)} / p95 ${fmtSampledMin(l.jobStartDelaySeconds.p95, m.sampleSizes.jobStartDelay)} · first terminal failure p50 ${fmtSampledMin(l.timeToFirstTerminalFailureSeconds.p50, m.sampleSizes.firstTerminalFailure)} / p95 ${fmtSampledMin(l.timeToFirstTerminalFailureSeconds.p95, m.sampleSizes.firstTerminalFailure)} · required green p50 ${fmtSampledMin(l.timeToRequiredGreenSeconds.p50, m.sampleSizes.requiredGreen)} / p95 ${fmtSampledMin(l.timeToRequiredGreenSeconds.p95, m.sampleSizes.requiredGreen)}`,
+    `Samples: gate ${m.sampleSizes.gate} · full-merge ${m.sampleSizes.fullMerge} · fleet-lead ${m.sampleSizes.fleetLeadTime} · active-queued ${m.sampleSizes.activeQueued} · jobs ${m.sampleSizes.jobs}`,
     `Throughput verdict: ${v.status} — ${v.reason} (action: ${v.action})`,
   ].join('\n');
 }
@@ -121,19 +385,57 @@ async function main(): Promise<void> {
   await withJobLogging(JOB, async () => {
     const repo = resolveRepo();
     const runs = fetchCiRuns(repo);
+    const apiCache = readApiCache();
+    const apiBudget = createApiRequestBudget();
+    const { samples: runJobs, cache: nextApiCache } = fetchRunSamples(
+      repo,
+      runs,
+      apiCache,
+      new Date(),
+      apiBudget
+    );
     const prs = fetchMergedPrs();
-    const timelineResults = prs
-      .map(pr => fetchTimeline(repo, pr))
-      .filter((t): t is NonNullable<typeof t> => t !== null);
+    const timelineResults = fetchTimelineSamples(
+      repo,
+      prs,
+      apiCache,
+      nextApiCache,
+      apiBudget
+    );
+    const uniqueHeadShas = new Set(runs.map(run => run.head_sha));
+    const hydratedCheckShas = new Set(
+      runJobs
+        .filter(sample => sample.requiredChecksHydrated)
+        .map(sample => sample.headSha)
+    );
 
     const metrics = summarizeCiMetrics({
       ts: new Date().toISOString(),
       runs,
       prs,
       timelineResults,
+      runJobs,
+      hydration: {
+        runJobs: {
+          covered: runJobs.filter(sample => sample.jobsHydrated).length,
+          total: runs.length,
+        },
+        requiredChecks: {
+          covered: hydratedCheckShas.size,
+          total: uniqueHeadShas.size,
+        },
+        timelines: {
+          covered: timelineResults.length,
+          total: prs.length,
+        },
+      },
     });
 
     mkdirSync(HERMES_PATHS.stateDir, { recursive: true });
+    writeFileSync(
+      METRICS_API_CACHE,
+      `${JSON.stringify(nextApiCache, null, 2)}\n`
+    );
     appendFileSync(METRICS_JSONL, `${JSON.stringify(metrics)}\n`);
     writeFileSync(METRICS_LATEST, `${JSON.stringify(metrics, null, 2)}\n`);
 
@@ -156,8 +458,15 @@ async function main(): Promise<void> {
       queueWaitP95: metrics.throughput.queueWaitSeconds.p95,
       gateP95: metrics.latency.gateWallclockSeconds.p95,
       fullMergeP95: metrics.latency.fullMergeTimeSeconds.p95,
+      fleetLeadTimeP50: metrics.latency.fleetLeadTimeSeconds.p50,
+      fleetLeadTimeP95: metrics.latency.fleetLeadTimeSeconds.p95,
+      // Schema-v1 log compatibility for one transition window.
       readyToMergeP50: metrics.latency.readyToMergeSeconds.p50,
       readyToMergeP95: metrics.latency.readyToMergeSeconds.p95,
+      activeQueuedP95: metrics.latency.activeQueuedSeconds.p95,
+      hostedRunnerSeconds: metrics.throughput.runnerJobSeconds.hosted,
+      selfHostedRunnerSeconds: metrics.throughput.runnerJobSeconds.selfHosted,
+      cancellationWasteSeconds: metrics.throughput.cancellationWasteSeconds,
       throughputVerdictStatus: metrics.throughputVerdict.status,
       throughputVerdictAction: metrics.throughputVerdict.action,
       samples: metrics.sampleSizes,

--- a/scripts/hermes/lib/pipeline-scoreboard.ts
+++ b/scripts/hermes/lib/pipeline-scoreboard.ts
@@ -49,6 +49,11 @@ export interface PipelineScoreboard {
       readonly p50: number;
       readonly p95: number;
     };
+    readonly timeToMergeAvailable?: boolean;
+    readonly timeToMergeUnavailableReason?:
+      | 'partial_hydration'
+      | 'no_samples'
+      | 'unavailable';
   };
   readonly gates: {
     readonly tasteLabeledPrsWeek: number;
@@ -79,6 +84,12 @@ export interface PipelineScoreboardInput {
   readonly previous?: PipelineScoreboard | null;
   readonly jobLogEntries?: ReadonlyArray<JobLogEntry>;
   readonly ciMetrics?: {
+    readonly hydration?: {
+      readonly complete?: boolean;
+    };
+    readonly sampleSizes?: {
+      readonly fleetLeadTime?: number;
+    };
     readonly throughput?: {
       readonly queueWaitSeconds?: {
         readonly p50?: number;
@@ -86,6 +97,10 @@ export interface PipelineScoreboardInput {
       };
     };
     readonly latency?: {
+      readonly fleetLeadTimeSeconds?: {
+        readonly p50?: number;
+        readonly p95?: number;
+      };
       readonly readyToMergeSeconds?: {
         readonly p50?: number;
         readonly p95?: number;
@@ -201,13 +216,25 @@ function isCiMetricsSnapshot(
   if (!isRecord(value)) return false;
   const throughput = value.throughput;
   const latency = value.latency;
+  const hydration = value.hydration;
+  const sampleSizes = value.sampleSizes;
   return (
+    (hydration === undefined ||
+      (isRecord(hydration) &&
+        (hydration.complete === undefined ||
+          typeof hydration.complete === 'boolean'))) &&
+    (sampleSizes === undefined ||
+      (isRecord(sampleSizes) &&
+        (sampleSizes.fleetLeadTime === undefined ||
+          typeof sampleSizes.fleetLeadTime === 'number'))) &&
     (throughput === undefined ||
       (isRecord(throughput) &&
         (throughput.queueWaitSeconds === undefined ||
           isPercentileRecord(throughput.queueWaitSeconds)))) &&
     (latency === undefined ||
       (isRecord(latency) &&
+        (latency.fleetLeadTimeSeconds === undefined ||
+          isPercentileRecord(latency.fleetLeadTimeSeconds)) &&
         (latency.readyToMergeSeconds === undefined ||
           isPercentileRecord(latency.readyToMergeSeconds))))
   );
@@ -346,7 +373,22 @@ export function buildPipelineScoreboard(
   const mqAttempts = input.mergedPrs?.filter(pr =>
     labelList(pr.labels).includes('merge-queue')
   ).length;
-  const readyToMerge = input.ciMetrics?.latency?.readyToMergeSeconds;
+  const schemaV2FleetLeadTime = input.ciMetrics?.latency?.fleetLeadTimeSeconds;
+  const fleetLeadTime =
+    schemaV2FleetLeadTime ?? input.ciMetrics?.latency?.readyToMergeSeconds;
+  const timeToMergeAvailable =
+    input.ciMetrics?.hydration?.complete !== false &&
+    fleetLeadTime !== undefined &&
+    (schemaV2FleetLeadTime === undefined ||
+      (input.ciMetrics?.sampleSizes?.fleetLeadTime ?? 0) > 0);
+  const timeToMergeUnavailableReason = timeToMergeAvailable
+    ? undefined
+    : input.ciMetrics?.hydration?.complete === false
+      ? 'partial_hydration'
+      : schemaV2FleetLeadTime !== undefined &&
+          (input.ciMetrics?.sampleSizes?.fleetLeadTime ?? 0) <= 0
+        ? 'no_samples'
+        : 'unavailable';
   const gateEntries = shipperEntries;
 
   const scoreboard: PipelineScoreboard = {
@@ -377,9 +419,11 @@ export function buildPipelineScoreboard(
           ? Number((mqAttempts / merges).toFixed(2))
           : null,
       timeToMergeSeconds: {
-        p50: readyToMerge?.p50 ?? 0,
-        p95: readyToMerge?.p95 ?? 0,
+        p50: timeToMergeAvailable ? (fleetLeadTime.p50 ?? 0) : 0,
+        p95: timeToMergeAvailable ? (fleetLeadTime.p95 ?? 0) : 0,
       },
+      timeToMergeAvailable,
+      timeToMergeUnavailableReason,
     },
     gates: {
       tasteLabeledPrsWeek:
@@ -433,12 +477,20 @@ export function renderPipelineScoreboard(
   const failureText = Object.entries(scoreboard.shipper.failuresByCategory)
     .map(([key, value]) => `${key}:${value}`)
     .join(', ');
+  const timeToMergeText =
+    scoreboard.queue.timeToMergeAvailable !== false
+      ? `p50 ${fmtSeconds(scoreboard.queue.timeToMergeSeconds.p50)} / p95 ${fmtSeconds(scoreboard.queue.timeToMergeSeconds.p95)}`
+      : scoreboard.queue.timeToMergeUnavailableReason === 'partial_hydration'
+        ? 'n/a (partial hydration)'
+        : scoreboard.queue.timeToMergeUnavailableReason === 'no_samples'
+          ? 'n/a (no samples)'
+          : 'n/a';
   return [
     `Pipeline scoreboard (${scoreboard.window.since.slice(0, 10)} UTC)`,
     `Funnel: ready ${scoreboard.funnel.ready} (${signed(scoreboard.funnel.deltas.ready)}) · claimed ${scoreboard.funnel.claimed} (${signed(scoreboard.funnel.deltas.claimed)}) · in-progress ${scoreboard.funnel.inProgress} (${signed(scoreboard.funnel.deltas.inProgress)}) · blocked ${scoreboard.funnel.blocked} (${signed(scoreboard.funnel.deltas.blocked)})`,
     `Shipper: claims ${scoreboard.shipper.claims} · ships ${scoreboard.shipper.ships} · retries ${scoreboard.shipper.retriesUsed} · cost/ship $${scoreboard.shipper.costPerShippedIssueUsd ?? 0}`,
     `Failures: ${failureText || 'none'}`,
-    `Queue: merges ${scoreboard.queue.merges} · MQ attempts/merge ${scoreboard.queue.mqAttemptsPerMerge ?? 'n/a'} · time-to-merge p50 ${fmtSeconds(scoreboard.queue.timeToMergeSeconds.p50)} / p95 ${fmtSeconds(scoreboard.queue.timeToMergeSeconds.p95)}`,
+    `Queue: merges ${scoreboard.queue.merges} · MQ attempts/merge ${scoreboard.queue.mqAttemptsPerMerge ?? 'n/a'} · time-to-merge ${timeToMergeText}`,
     `Gates: taste-labeled PRs/week ${scoreboard.gates.tasteLabeledPrsWeek} · autofix interventions ${scoreboard.gates.autofixInterventions}`,
     scoreboard.alarms.length
       ? `Alarms: ${scoreboard.alarms.map(alarm => alarm.message).join(' ')}`

--- a/scripts/lib/__tests__/ci-metrics-compute.test.mjs
+++ b/scripts/lib/__tests__/ci-metrics-compute.test.mjs
@@ -1,12 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
+  activeQueuedSeconds,
+  CI_METRICS_REQUIRED_STATUSES,
   CI_METRICS_SCHEMA_VERSION,
   ciRunHours,
   completedDurationsSeconds,
+  createApiRequestBudget,
   evaluateMergeQueueThroughput,
   flakyRerunRate,
+  fleetLeadTimeSeconds,
   fullMergeTimesSeconds,
   gateDurationsSeconds,
+  hasCompleteRequiredChecks,
+  hasGreenRequiredChecks,
+  lastEnqueueToMergeSeconds,
   MIN_READY_TO_MERGE_SAMPLES,
   mergedThroughput,
   percentilesOf,
@@ -14,7 +21,10 @@ import {
   READY_TO_MERGE_P50_TARGET_SECONDS,
   READY_TO_MERGE_P95_TARGET_SECONDS,
   readyToMergeSeconds,
+  shouldReuseJobCache,
+  shouldReuseRequiredChecksCache,
   summarizeCiMetrics,
+  summarizeJobMetrics,
 } from '../ci-metrics-compute.mjs';
 
 const run = (
@@ -155,18 +165,376 @@ describe('queueWaitSeconds', () => {
 });
 
 describe('readyToMergeSeconds', () => {
-  it('extracts positive readyToMergedSeconds', () => {
+  it('keeps the v1 helper as an alias for fleet lead time', () => {
     const tl = [
       { readyToMergedSeconds: 300 },
       { readyToMergedSeconds: null },
       { readyToMergedSeconds: 0 },
       { readyToMergedSeconds: 900 },
     ];
+    expect(fleetLeadTimeSeconds(tl)).toEqual([300, 900]);
     expect(readyToMergeSeconds(tl)).toEqual([300, 900]);
   });
 
   it('returns [] for nullish input', () => {
     expect(readyToMergeSeconds(undefined)).toEqual([]);
+  });
+});
+
+describe('queue interval metrics', () => {
+  it('extracts first, last, and active queue durations independently', () => {
+    const timelines = [
+      {
+        firstEnqueueToMergedSeconds: 5400,
+        lastEnqueueToMergedSeconds: 1800,
+        activeQueuedSeconds: 3660,
+      },
+      {
+        firstEnqueueToMergedSeconds: null,
+        lastEnqueueToMergedSeconds: null,
+        activeQueuedSeconds: null,
+      },
+    ];
+
+    expect(queueWaitSeconds(timelines)).toEqual([5400]);
+    expect(lastEnqueueToMergeSeconds(timelines)).toEqual([1800]);
+    expect(activeQueuedSeconds(timelines)).toEqual([3660]);
+  });
+});
+
+const greenChecks = completedAt =>
+  CI_METRICS_REQUIRED_STATUSES.map(name => ({
+    name,
+    completed_at: completedAt,
+    conclusion: 'success',
+  }));
+
+describe('summarizeJobMetrics', () => {
+  it('reports runner classes, waste, failures, required green, and skips', () => {
+    const out = summarizeJobMetrics([
+      {
+        runCreatedAt: '2026-07-10T10:00:00Z',
+        runConclusion: 'failure',
+        requiredChecks: greenChecks('2026-07-10T10:07:00Z'),
+        jobs: [
+          {
+            labels: ['ubuntu-latest'],
+            started_at: '2026-07-10T10:00:20Z',
+            completed_at: '2026-07-10T10:05:20Z',
+            conclusion: 'cancelled',
+          },
+          {
+            labels: ['self-hosted'],
+            started_at: '2026-07-10T10:00:40Z',
+            completed_at: '2026-07-10T10:02:40Z',
+            conclusion: 'failure',
+          },
+          {
+            labels: ['ubuntu-latest'],
+            started_at: '2026-07-10T10:05:20Z',
+            completed_at: '2026-07-10T10:06:00Z',
+            conclusion: 'success',
+          },
+          {
+            labels: ['ubuntu-latest'],
+            started_at: '2026-07-10T10:05:00Z',
+            completed_at: '2026-07-10T10:05:30Z',
+            conclusion: 'skipped',
+          },
+        ],
+      },
+      {
+        runCreatedAt: '2026-07-10T12:00:00Z',
+        runConclusion: 'cancelled',
+        jobs: [
+          {
+            labels: ['self-hosted'],
+            started_at: '2026-07-10T12:01:00Z',
+            completed_at: '2026-07-10T12:02:00Z',
+            conclusion: 'success',
+          },
+        ],
+      },
+    ]);
+
+    expect(out.runnerSeconds).toEqual({ hosted: 340, selfHosted: 180 });
+    expect(out.cancellationWasteSeconds).toBe(360);
+    expect(out.timeToFirstTerminalFailureSeconds.p50).toBe(160);
+    expect(out.timeToRequiredGreenSeconds.p50).toBe(420);
+    expect(out.sampleSizes.jobs).toBe(4);
+  });
+
+  it('ignores missing and negative timestamps', () => {
+    const out = summarizeJobMetrics([
+      {
+        runCreatedAt: '2026-07-10T11:00:00Z',
+        jobs: [
+          { conclusion: 'skipped', started_at: null, completed_at: null },
+          {
+            labels: ['self-hosted'],
+            started_at: '2026-07-10T10:59:00Z',
+            completed_at: '2026-07-10T10:58:00Z',
+            conclusion: 'success',
+          },
+        ],
+      },
+    ]);
+    expect(out.runnerSeconds).toEqual({ hosted: 0, selfHosted: 0 });
+    expect(out.sampleSizes.jobStartDelay).toBe(0);
+  });
+
+  it('counts an immediate job start as a zero-second delay sample', () => {
+    const out = summarizeJobMetrics([
+      {
+        runCreatedAt: '2026-07-10T11:00:00Z',
+        jobs: [
+          {
+            labels: ['ubuntu-latest'],
+            started_at: '2026-07-10T11:00:00Z',
+            completed_at: '2026-07-10T11:01:00Z',
+            conclusion: 'success',
+          },
+        ],
+      },
+    ]);
+
+    expect(out.jobStartDelaySeconds.p50).toBe(0);
+    expect(out.sampleSizes.jobStartDelay).toBe(1);
+  });
+});
+
+describe('CI metrics API cache policy', () => {
+  const now = new Date('2026-07-11T12:00:00Z');
+  const run = {
+    created_at: '2026-07-11T10:00:00Z',
+    updated_at: '2026-07-11T11:00:00Z',
+  };
+  const cache = (green, fetchedAt) => ({
+    green,
+    fetchedAt,
+  });
+
+  it('keys jobs by updated_at and bounds required-check refreshes', () => {
+    expect(shouldReuseJobCache(run, { updatedAt: run.updated_at })).toBe(true);
+    expect(shouldReuseJobCache(run, { updatedAt: 'changed' })).toBe(false);
+    expect(
+      shouldReuseRequiredChecksCache(
+        run,
+        cache(true, '2026-07-11T11:00:00Z'),
+        now
+      )
+    ).toBe(true);
+    expect(
+      shouldReuseRequiredChecksCache(
+        run,
+        cache(false, '2026-07-11T08:00:00Z'),
+        now
+      )
+    ).toBe(true);
+    expect(
+      shouldReuseRequiredChecksCache(
+        run,
+        cache(false, '2026-07-11T05:00:00Z'),
+        now
+      )
+    ).toBe(false);
+    expect(
+      shouldReuseRequiredChecksCache(
+        { ...run, created_at: '2026-07-09T10:00:00Z' },
+        cache(false, '2026-07-09T11:00:00Z'),
+        now
+      )
+    ).toBe(false);
+  });
+
+  it('refreshes green and old non-green caches at the 24-hour boundary', () => {
+    const oldRun = { ...run, created_at: '2026-07-09T10:00:00Z' };
+    for (const green of [true, false]) {
+      expect(
+        shouldReuseRequiredChecksCache(
+          oldRun,
+          cache(green, '2026-07-10T12:00:01Z'),
+          now
+        )
+      ).toBe(true);
+      expect(
+        shouldReuseRequiredChecksCache(
+          oldRun,
+          cache(green, '2026-07-10T12:00:00Z'),
+          now
+        )
+      ).toBe(false);
+    }
+  });
+
+  it('refreshes terminal red and then reuses rerun-success checks', () => {
+    const failed = greenChecks(now.toISOString());
+    failed[0] = { ...failed[0], conclusion: 'failure' };
+    expect(hasCompleteRequiredChecks(failed)).toBe(true);
+    expect(hasGreenRequiredChecks(failed)).toBe(false);
+    expect(
+      shouldReuseRequiredChecksCache(
+        run,
+        cache(false, '2026-07-11T04:00:00Z'),
+        now
+      )
+    ).toBe(false);
+    expect(hasGreenRequiredChecks(greenChecks(now.toISOString()))).toBe(true);
+    expect(
+      shouldReuseRequiredChecksCache(run, cache(true, now.toISOString()), now)
+    ).toBe(true);
+  });
+
+  it.each([
+    'missing',
+    'pending',
+    'failed',
+  ])('does not report required green when PR Size Guard is %s', state => {
+    const checks = greenChecks(now.toISOString()).filter(
+      check => !(state === 'missing' && check.name === 'PR Size Guard')
+    );
+    if (state !== 'missing') {
+      const index = checks.findIndex(check => check.name === 'PR Size Guard');
+      checks[index] = {
+        ...checks[index],
+        conclusion: state === 'pending' ? null : 'failure',
+      };
+    }
+
+    expect(hasCompleteRequiredChecks(checks)).toBe(state === 'failed');
+    expect(hasGreenRequiredChecks(checks)).toBe(false);
+    expect(
+      summarizeJobMetrics([
+        {
+          runCreatedAt: '2026-07-11T10:00:00Z',
+          requiredChecks: checks,
+          jobs: [],
+        },
+      ]).sampleSizes.requiredGreen
+    ).toBe(0);
+  });
+
+  it('reuses one SHA-scoped check fetch across runs with different updated_at values', () => {
+    const fetched = cache(true, now.toISOString());
+    expect(
+      shouldReuseRequiredChecksCache(
+        { ...run, updated_at: '2026-07-11T11:30:00Z' },
+        fetched,
+        now
+      )
+    ).toBe(true);
+  });
+
+  it('treats a newer skipped execution as authoritative over older success', () => {
+    const checks = greenChecks('2026-07-11T10:00:00Z');
+    checks.push({
+      name: 'PR Ready',
+      completed_at: '2026-07-11T11:00:00Z',
+      conclusion: 'skipped',
+    });
+
+    expect(hasCompleteRequiredChecks(checks)).toBe(false);
+    expect(hasGreenRequiredChecks(checks)).toBe(false);
+  });
+
+  it('keeps a newer pending execution authoritative when an older success finishes later', () => {
+    const checks = greenChecks('2026-07-11T11:10:00Z');
+    const ready = checks.findIndex(check => check.name === 'PR Ready');
+    checks[ready] = {
+      ...checks[ready],
+      id: 100,
+      started_at: '2026-07-11T10:00:00Z',
+      completed_at: '2026-07-11T11:10:00Z',
+    };
+    checks.push({
+      id: 101,
+      name: 'PR Ready',
+      started_at: '2026-07-11T11:00:00Z',
+      completed_at: null,
+      conclusion: null,
+    });
+
+    expect(hasCompleteRequiredChecks(checks)).toBe(false);
+    expect(hasGreenRequiredChecks(checks)).toBe(false);
+  });
+
+  it('uses check-run id over start time when executions overlap', () => {
+    const checks = greenChecks('2026-07-11T11:20:00Z');
+    const ready = checks.findIndex(check => check.name === 'PR Ready');
+    checks[ready] = {
+      ...checks[ready],
+      id: 100,
+      started_at: '2026-07-11T11:00:00Z',
+      completed_at: '2026-07-11T11:20:00Z',
+    };
+    checks.push({
+      id: 101,
+      name: 'PR Ready',
+      started_at: '2026-07-11T10:55:00Z',
+      completed_at: null,
+      conclusion: null,
+    });
+
+    expect(hasCompleteRequiredChecks(checks)).toBe(false);
+    expect(hasGreenRequiredChecks(checks)).toBe(false);
+  });
+
+  it('uses check-run id when the newer queued execution has no timestamps', () => {
+    const checks = greenChecks('2026-07-11T11:20:00Z');
+    const ready = checks.findIndex(check => check.name === 'PR Ready');
+    checks[ready] = { ...checks[ready], id: 100 };
+    checks.push({
+      id: 101,
+      name: 'PR Ready',
+      started_at: null,
+      completed_at: null,
+      conclusion: null,
+    });
+
+    expect(hasCompleteRequiredChecks(checks)).toBe(false);
+    expect(hasGreenRequiredChecks(checks)).toBe(false);
+  });
+});
+
+describe('CI metrics API request budget', () => {
+  it('caps cold-cache request fanout and stops at the elapsed deadline', () => {
+    let nowMs = 1_000;
+    const byCount = createApiRequestBudget({
+      maxRequests: 2,
+      maxElapsedMs: 10_000,
+      now: () => nowMs,
+    });
+    expect(byCount.tryConsume()).toBe(true);
+    expect(byCount.tryConsume()).toBe(true);
+    expect(byCount.tryConsume()).toBe(false);
+    expect(byCount.used).toBe(2);
+
+    const byTime = createApiRequestBudget({
+      maxRequests: 10,
+      maxElapsedMs: 500,
+      now: () => nowMs,
+    });
+    expect(byTime.tryConsume()).toBe(true);
+    nowMs += 500;
+    expect(byTime.tryConsume()).toBe(false);
+    expect(byTime.used).toBe(1);
+  });
+
+  it('reserves requests for later hydration without exceeding the global cap', () => {
+    const budget = createApiRequestBudget({
+      maxRequests: 4,
+      maxElapsedMs: 10_000,
+    });
+
+    expect(budget.tryConsume(2)).toBe(true);
+    expect(budget.tryConsume(2)).toBe(true);
+    expect(budget.tryConsume(2)).toBe(false);
+    expect(budget.used).toBe(2);
+
+    expect(budget.tryConsume()).toBe(true);
+    expect(budget.tryConsume()).toBe(true);
+    expect(budget.tryConsume()).toBe(false);
+    expect(budget.used).toBe(4);
   });
 });
 
@@ -228,7 +596,7 @@ describe('evaluateMergeQueueThroughput', () => {
     expect(verdict.action).toBe('close_follow_up');
   });
 
-  it('recommends raising max queue depth when p95 is off target', () => {
+  it('does not recommend a queue depth that is already active', () => {
     const verdict = evaluateMergeQueueThroughput(
       metricsFixture({
         latency: {
@@ -242,7 +610,11 @@ describe('evaluateMergeQueueThroughput', () => {
       { now: afterEvalWindow }
     );
     expect(verdict.status).toBe('off_target');
-    expect(verdict.action).toContain('raise_max_queue_depth_12_to_16');
+    expect(verdict.action).toContain(
+      'investigate_runner_capacity_and_queue_churn'
+    );
+    expect(verdict.action).not.toContain('raise_max_queue_depth_12_to_16');
+    expect(verdict.queuePolicy.maxQueueDepth).toBe(16);
   });
 });
 
@@ -257,8 +629,18 @@ describe('summarizeCiMetrics', () => {
       { createdAt: '2026-06-19T10:00:00Z', mergedAt: '2026-06-19T12:00:00Z' }, // 7200
     ];
     const timelineResults = [
-      { queuedToMergedSeconds: 240, readyToMergedSeconds: 500 },
-      { queuedToMergedSeconds: 480, readyToMergedSeconds: 700 },
+      {
+        queuedToMergedSeconds: 240,
+        lastEnqueueToMergedSeconds: 180,
+        activeQueuedSeconds: 200,
+        readyToMergedSeconds: 500,
+      },
+      {
+        queuedToMergedSeconds: 480,
+        lastEnqueueToMergedSeconds: 300,
+        activeQueuedSeconds: 420,
+        readyToMergedSeconds: 700,
+      },
     ];
     const out = summarizeCiMetrics({
       ts: '2026-06-19T13:00:00Z',
@@ -267,7 +649,9 @@ describe('summarizeCiMetrics', () => {
       timelineResults,
     });
 
+    expect(CI_METRICS_SCHEMA_VERSION).toBe(2);
     expect(out.schemaVersion).toBe(CI_METRICS_SCHEMA_VERSION);
+    expect(out.hydration.complete).toBe(true);
     expect(out.ts).toBe('2026-06-19T13:00:00Z');
     // span = 25h = 1.042d; p50 of two values is the lower (nearest-rank).
     expect(out.window).toEqual({ mergedPrs: 2, ciRuns: 2, spanDays: 1.042 });
@@ -290,13 +674,72 @@ describe('summarizeCiMetrics', () => {
       p75: 700,
       p95: 700,
     });
-    expect(out.sampleSizes).toEqual({
+    expect(out.latency.fleetLeadTimeSeconds).toEqual(
+      out.latency.readyToMergeSeconds
+    );
+    expect(out.latency.lastEnqueueToMergeSeconds.p95).toBe(300);
+    expect(out.latency.activeQueuedSeconds.p95).toBe(420);
+    expect(out.sampleSizes).toMatchObject({
       gate: 2,
       fullMerge: 2,
       queueWait: 2,
       readyToMerge: 2,
+      fleetLeadTime: 2,
+      firstEnqueueLead: 2,
+      lastEnqueueToMerge: 2,
+      activeQueued: 2,
     });
     expect(out.throughputVerdict.status).toBe('defer');
     expect(out.throughputVerdict.action).toBe('wait_for_evaluation_window');
+  });
+
+  it('marks a cold snapshot partial and prevents an authoritative verdict', () => {
+    const out = summarizeCiMetrics({
+      ts: '2026-07-10T12:00:00Z',
+      runs: [],
+      prs: [],
+      timelineResults: [],
+      hydration: {
+        runJobs: { covered: 0, total: 100 },
+        requiredChecks: { covered: 0, total: 90 },
+        timelines: { covered: 0, total: 50 },
+      },
+    });
+
+    expect(out.hydration.complete).toBe(false);
+    expect(out.hydration.timelines).toEqual({ covered: 0, total: 50 });
+    expect(out.throughputVerdict.status).toBe('insufficient_data');
+    expect(out.throughputVerdict.action).toBe('hydrate_remaining_api_samples');
+  });
+
+  it('keeps a data-rich partial snapshot non-authoritative until coverage is complete', () => {
+    const timelineResults = Array.from({ length: 10 }, () => ({
+      readyToMergedSeconds: 300,
+    }));
+    const base = {
+      ts: '2026-07-10T12:00:00Z',
+      runs: [],
+      prs: [],
+      timelineResults,
+      hydration: {
+        runJobs: { covered: 0, total: 0 },
+        requiredChecks: { covered: 0, total: 0 },
+        timelines: { covered: 9, total: 10 },
+      },
+    };
+
+    const partial = summarizeCiMetrics(base);
+    expect(partial.throughputVerdict.status).toBe('insufficient_data');
+
+    const complete = summarizeCiMetrics({
+      ...base,
+      hydration: {
+        ...base.hydration,
+        timelines: { covered: 10, total: 10 },
+      },
+    });
+    expect(complete.hydration.complete).toBe(true);
+    expect(complete.throughputVerdict.status).toBe('on_target');
+    expect(complete.throughputVerdict.action).toBe('close_follow_up');
   });
 });

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -496,6 +496,9 @@ describe('merge queue telemetry parser', () => {
     ]);
 
     expect(metrics.queuedToMergedSeconds).toBe(5400);
+    expect(metrics.firstEnqueueToMergedSeconds).toBe(5400);
+    expect(metrics.lastEnqueueToMergedSeconds).toBe(1800);
+    expect(metrics.activeQueuedSeconds).toBe(3660);
     expect(metrics.requeueCount).toBe(1);
     expect(metrics.conflictEvictions).toBe(1);
     expect(metrics.ciEvictions).toBe(1);
@@ -521,6 +524,7 @@ describe('merge queue telemetry parser', () => {
     ]);
 
     expect(metrics.readyForReviewAt).toEqual(['2026-06-20T01:00:00Z']);
+    expect(metrics.fleetLeadTimeSeconds).toBe(600);
     expect(metrics.readyToMergedSeconds).toBe(600);
   });
 
@@ -548,5 +552,35 @@ describe('merge queue telemetry parser', () => {
     ]);
 
     expect(metrics.readyToMergedSeconds).toBeNull();
+  });
+
+  it('reports no queue duration for a PR that was never queued', () => {
+    const metrics = parseMergeQueueTimeline(
+      [{ event: 'merged', created_at: '2026-06-20T01:10:00Z' }],
+      { prCreatedAt: '2026-06-20T01:00:00Z' }
+    );
+
+    expect(metrics.firstEnqueueToMergedSeconds).toBeNull();
+    expect(metrics.lastEnqueueToMergedSeconds).toBeNull();
+    expect(metrics.activeQueuedSeconds).toBeNull();
+    expect(metrics.fleetLeadTimeSeconds).toBe(600);
+  });
+
+  it('caps active queue time at merge when cleanup unlabeled arrives later', () => {
+    const metrics = parseMergeQueueTimeline([
+      {
+        event: 'labeled',
+        label: { name: 'merge-queue' },
+        created_at: '2026-06-20T01:00:00Z',
+      },
+      { event: 'merged', created_at: '2026-06-20T01:10:00Z' },
+      {
+        event: 'unlabeled',
+        label: { name: 'merge-queue' },
+        created_at: '2026-06-20T01:15:00Z',
+      },
+    ]);
+
+    expect(metrics.activeQueuedSeconds).toBe(600);
   });
 });

--- a/scripts/lib/__tests__/pipeline-scoreboard.test.mjs
+++ b/scripts/lib/__tests__/pipeline-scoreboard.test.mjs
@@ -325,6 +325,66 @@ describe('pipeline scoreboard compute', () => {
     expect(body).toContain('Queue: merges 1');
     expect(body).toContain('time-to-merge p50 10m / p95 15m');
   });
+
+  it('prefers schema-v2 fleet lead time over the schema-v1 fallback', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T00:00:00.000Z',
+      window,
+      issues: [],
+      ciMetrics: {
+        hydration: { complete: true },
+        sampleSizes: { fleetLeadTime: 2 },
+        latency: {
+          fleetLeadTimeSeconds: { p50: 120, p95: 240 },
+          readyToMergeSeconds: { p50: 600, p95: 900 },
+        },
+      },
+    });
+
+    expect(scoreboard.queue.timeToMergeSeconds).toEqual({ p50: 120, p95: 240 });
+    expect(scoreboard.queue.timeToMergeAvailable).toBe(true);
+  });
+
+  it('marks schema-v2 fleet lead time unavailable when no samples exist', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T00:00:00.000Z',
+      window,
+      issues: [],
+      ciMetrics: {
+        hydration: { complete: true },
+        sampleSizes: { fleetLeadTime: 0 },
+        latency: { fleetLeadTimeSeconds: { p50: 120, p95: 240 } },
+      },
+    });
+
+    expect(scoreboard.queue.timeToMergeSeconds).toEqual({ p50: 0, p95: 0 });
+    expect(scoreboard.queue.timeToMergeAvailable).toBe(false);
+    expect(scoreboard.queue.timeToMergeUnavailableReason).toBe('no_samples');
+    expect(renderPipelineScoreboard(scoreboard)).toContain(
+      'time-to-merge n/a (no samples)'
+    );
+  });
+
+  it('suppresses queue latency from a partially hydrated snapshot', () => {
+    const scoreboard = buildPipelineScoreboard({
+      ts: '2026-07-03T00:00:00.000Z',
+      window,
+      issues: [],
+      ciMetrics: {
+        hydration: { complete: false },
+        latency: { fleetLeadTimeSeconds: { p50: 120, p95: 240 } },
+      },
+    });
+
+    expect(scoreboard.queue.timeToMergeSeconds).toEqual({ p50: 0, p95: 0 });
+    expect(scoreboard.queue.timeToMergeAvailable).toBe(false);
+    expect(scoreboard.queue.timeToMergeUnavailableReason).toBe(
+      'partial_hydration'
+    );
+    expect(renderPipelineScoreboard(scoreboard)).toContain(
+      'time-to-merge n/a (partial hydration)'
+    );
+  });
 });
 
 describe('pipeline scoreboard digest and schedule wiring', () => {

--- a/scripts/lib/ci-metrics-compute.mjs
+++ b/scripts/lib/ci-metrics-compute.mjs
@@ -16,14 +16,31 @@ import {
   computeElapsedSeconds,
   computePercentile,
 } from './ci-duration-ratchet.mjs';
+import {
+  GRAPHITE_QUEUE_POLICY,
+  REQUIRED_MERGE_STATUSES,
+} from './merge-queue-guard.mjs';
 
-export const CI_METRICS_SCHEMA_VERSION = 1;
+// The merge-queue hot path intentionally tracks only the statuses Graphite
+// waits on directly. CI metrics must mirror the complete active main ruleset,
+// which also requires the independent PR Size Guard workflow.
+export const CI_METRICS_REQUIRED_STATUSES = Object.freeze([
+  ...REQUIRED_MERGE_STATUSES,
+  'PR Size Guard',
+]);
 
-/** Ready→merged merge-time targets (docs/PR_FLOW.md, gbrain ci-metrics/latest). */
-export const READY_TO_MERGE_P50_TARGET_SECONDS = 600; // 10m
-export const READY_TO_MERGE_P95_TARGET_SECONDS = 900; // 15m
-/** Minimum ready→merged samples before a throughput verdict is actionable. */
-export const MIN_READY_TO_MERGE_SAMPLES = 10;
+export const CI_METRICS_SCHEMA_VERSION = 2;
+
+/** Fleet lead-time targets (ready-for-review/open → merged). */
+export const FLEET_LEAD_TIME_P50_TARGET_SECONDS = 600; // 10m
+export const FLEET_LEAD_TIME_P95_TARGET_SECONDS = 900; // 15m
+export const MIN_FLEET_LEAD_TIME_SAMPLES = 10;
+// Schema-v1 compatibility aliases. Keep for one metrics transition window.
+export const READY_TO_MERGE_P50_TARGET_SECONDS =
+  FLEET_LEAD_TIME_P50_TARGET_SECONDS;
+export const READY_TO_MERGE_P95_TARGET_SECONDS =
+  FLEET_LEAD_TIME_P95_TARGET_SECONDS;
+export const MIN_READY_TO_MERGE_SAMPLES = MIN_FLEET_LEAD_TIME_SAMPLES;
 
 /** {p50,p75,p95} of an array (0s when empty). */
 export function percentilesOf(values) {
@@ -35,8 +52,8 @@ export function percentilesOf(values) {
 }
 
 /**
- * Wall-clock seconds for every completed run (any conclusion). This is the
- * slot-hours basis: failed/cancelled runs still burn runner slots.
+ * Legacy workflow wall-clock seconds for every completed run (any conclusion).
+ * This is retained for schema-v1 compatibility; runner job time is authoritative.
  */
 export function completedDurationsSeconds(runs) {
   return (runs ?? [])
@@ -78,7 +95,7 @@ export function flakyRerunRate(runs) {
   return reran / list.length;
 }
 
-/** Total CI runner wall-clock hours across all completed runs (a slot-hours proxy). */
+/** Legacy workflow wall-clock hours; retained for schema-v1 compatibility. */
 export function ciRunHours(runs) {
   const totalSeconds = completedDurationsSeconds(runs).reduce(
     (a, b) => a + b,
@@ -114,20 +131,283 @@ export function mergedThroughput(prs) {
 /** Queue-wait seconds from parseMergeQueueTimeline results (queuedToMergedSeconds). */
 export function queueWaitSeconds(timelineResults) {
   return (timelineResults ?? [])
-    .map(t => t && t.queuedToMergedSeconds)
+    .map(t => t && (t.firstEnqueueToMergedSeconds ?? t.queuedToMergedSeconds))
+    .filter(s => Number.isFinite(s) && s > 0);
+}
+
+export function lastEnqueueToMergeSeconds(timelineResults) {
+  return (timelineResults ?? [])
+    .map(
+      t => t && (t.lastEnqueueToMergedSeconds ?? t.lastQueuedToMergedSeconds)
+    )
+    .filter(s => Number.isFinite(s) && s > 0);
+}
+
+export function activeQueuedSeconds(timelineResults) {
+  return (timelineResults ?? [])
+    .map(t => t && t.activeQueuedSeconds)
     .filter(s => Number.isFinite(s) && s > 0);
 }
 
 /**
- * Ready→merged seconds from parseMergeQueueTimeline results
- * (readyToMergedSeconds). Tracks the ready→merged p50<10m / p95<15m target —
+ * Fleet lead-time seconds from parseMergeQueueTimeline results, preferring the
+ * schema-v2 field with the schema-v1 readyToMergedSeconds fallback. Tracks the
+ * ready→merged p50<10m / p95<15m target —
  * separate from queueWaitSeconds (merge-queue-label→merged), since a PR can
  * sit ready-for-review for a while before ever being queued.
  */
-export function readyToMergeSeconds(timelineResults) {
+export function fleetLeadTimeSeconds(timelineResults) {
   return (timelineResults ?? [])
-    .map(t => t && t.readyToMergedSeconds)
+    .map(t => t && (t.fleetLeadTimeSeconds ?? t.readyToMergedSeconds))
     .filter(s => Number.isFinite(s) && s > 0);
+}
+
+/** Schema-v1 compatibility alias for fleetLeadTimeSeconds. */
+export function readyToMergeSeconds(timelineResults) {
+  return fleetLeadTimeSeconds(timelineResults);
+}
+
+const TERMINAL_FAILURE_CONCLUSIONS = new Set([
+  'failure',
+  'error',
+  'timed_out',
+  'action_required',
+  'startup_failure',
+]);
+const REQUIRED_CHECK_TERMINAL_CONCLUSIONS = new Set([
+  'success',
+  'failure',
+  'cancelled',
+  'timed_out',
+  'action_required',
+  'startup_failure',
+  'neutral',
+]);
+const INCOMPLETE_CHECK_CACHE_HOURS = 24;
+const NON_GREEN_CHECK_RETRY_HOURS = 6;
+const GREEN_CHECK_REFRESH_HOURS = 24;
+
+function positiveElapsedSeconds(start, end) {
+  if (!start || !end) return null;
+  const seconds = computeElapsedSeconds(start, end);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+}
+
+function nonNegativeElapsedSeconds(start, end) {
+  if (!start || !end) return null;
+  const startMs = new Date(start).getTime();
+  const endMs = new Date(end).getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return null;
+  }
+  return (endMs - startMs) / 1000;
+}
+
+function isSelfHostedJob(job) {
+  const labels = (job?.labels ?? []).map(label => String(label).toLowerCase());
+  return labels.includes('self-hosted') || labels.includes('jovie-runner');
+}
+
+export function latestRequiredChecks(checks) {
+  const latest = new Map();
+  for (const check of checks ?? []) {
+    if (!CI_METRICS_REQUIRED_STATUSES.includes(check?.name)) continue;
+    const previous = latest.get(check.name);
+    // GitHub's monotonic check-run id is authoritative when both executions
+    // expose one. Timestamps are only a fallback for missing/equal ids; an
+    // older execution may start or finish after a newer pending check exists.
+    const id = typeof check?.id === 'number' ? check.id : null;
+    const previousId = typeof previous?.id === 'number' ? previous.id : null;
+    const idsDecide =
+      Number.isFinite(id) && Number.isFinite(previousId) && id !== previousId;
+    const timestamp = Date.parse(
+      check?.started_at ?? check?.completed_at ?? ''
+    );
+    const previousTimestamp = Date.parse(
+      previous?.started_at ?? previous?.completed_at ?? ''
+    );
+    const timestampDecides =
+      !Number.isFinite(previousTimestamp) || timestamp >= previousTimestamp;
+    if (!previous || (idsDecide ? id > previousId : timestampDecides)) {
+      latest.set(check.name, check);
+    }
+  }
+  return CI_METRICS_REQUIRED_STATUSES.map(name => latest.get(name)).filter(
+    Boolean
+  );
+}
+
+export function hasCompleteRequiredChecks(checks) {
+  const latest = latestRequiredChecks(checks);
+  return (
+    latest.length === CI_METRICS_REQUIRED_STATUSES.length &&
+    latest.every(check =>
+      REQUIRED_CHECK_TERMINAL_CONCLUSIONS.has(check?.conclusion)
+    )
+  );
+}
+
+export function hasGreenRequiredChecks(checks) {
+  const latest = latestRequiredChecks(checks);
+  return (
+    latest.length === CI_METRICS_REQUIRED_STATUSES.length &&
+    latest.every(check => check?.conclusion === 'success')
+  );
+}
+
+export function shouldReuseJobCache(run, cached) {
+  return Boolean(cached && cached.updatedAt === run?.updated_at);
+}
+
+export function shouldReuseRequiredChecksCache(run, cached, now = new Date()) {
+  if (!cached) return false;
+  // Check runs are scoped to the commit SHA, not to one ci.yml workflow run.
+  // Several PR events can produce runs for the same SHA with different
+  // updated_at values; tying this cache to run.updated_at causes every sibling
+  // run to invalidate and refetch the same commit checks.
+  const fetchedAt = new Date(cached.fetchedAt).getTime();
+  const sinceFetchHours = (now.getTime() - fetchedAt) / 3_600_000;
+  if (cached.green) {
+    return (
+      Number.isFinite(sinceFetchHours) &&
+      sinceFetchHours >= 0 &&
+      sinceFetchHours < GREEN_CHECK_REFRESH_HOURS
+    );
+  }
+  // Terminal red is not stable: Fork PR Gate is a separate workflow and may
+  // rerun without changing the sampled ci.yml run's updated_at.
+  const createdAt = new Date(run?.created_at).getTime();
+  const ageHours = (now.getTime() - createdAt) / 3_600_000;
+  const retryHours =
+    Number.isFinite(ageHours) && ageHours >= INCOMPLETE_CHECK_CACHE_HOURS
+      ? GREEN_CHECK_REFRESH_HOURS
+      : NON_GREEN_CHECK_RETRY_HOURS;
+  return (
+    Number.isFinite(sinceFetchHours) &&
+    sinceFetchHours >= 0 &&
+    sinceFetchHours < retryHours
+  );
+}
+
+/**
+ * Shared budget for bounded GitHub detail hydration. `tryConsume` is checked
+ * immediately before each request, so a cold cache makes incremental progress
+ * without turning one Hermes tick into hundreds of sequential API calls.
+ */
+export function createApiRequestBudget({
+  maxRequests = 24,
+  maxElapsedMs = 4 * 60 * 1000,
+  now = () => Date.now(),
+} = {}) {
+  const startedAt = now();
+  let used = 0;
+  return {
+    tryConsume(reservedRequests = 0) {
+      const reserve = Math.max(
+        0,
+        Math.min(maxRequests, Number(reservedRequests) || 0)
+      );
+      if (used >= maxRequests - reserve || now() - startedAt >= maxElapsedMs)
+        return false;
+      used += 1;
+      return true;
+    },
+    get used() {
+      return used;
+    },
+  };
+}
+
+/** Aggregate job-level runner consumption and gate diagnostics per sampled run. */
+export function summarizeJobMetrics(runJobs) {
+  let hostedSeconds = 0;
+  let selfHostedSeconds = 0;
+  let cancellationWasteSeconds = 0;
+  const jobStartDelays = [];
+  const firstTerminalFailures = [];
+  const requiredGreen = [];
+
+  for (const sample of runJobs ?? []) {
+    const jobs = (sample?.jobs ?? []).filter(
+      job => job?.conclusion !== 'skipped'
+    );
+    const terminalFailureCompletions = [];
+
+    for (const job of jobs) {
+      const duration = positiveElapsedSeconds(
+        job?.started_at,
+        job?.completed_at
+      );
+      if (duration !== null) {
+        if (isSelfHostedJob(job)) selfHostedSeconds += duration;
+        else hostedSeconds += duration;
+        if (
+          sample?.runConclusion === 'cancelled' ||
+          job?.conclusion === 'cancelled'
+        ) {
+          cancellationWasteSeconds += duration;
+        }
+      }
+
+      const startDelay = nonNegativeElapsedSeconds(
+        sample?.runCreatedAt,
+        job?.started_at
+      );
+      if (startDelay !== null) jobStartDelays.push(startDelay);
+
+      if (
+        TERMINAL_FAILURE_CONCLUSIONS.has(job?.conclusion) &&
+        job?.completed_at
+      ) {
+        terminalFailureCompletions.push(job.completed_at);
+      }
+    }
+
+    const firstFailureAt = terminalFailureCompletions.sort()[0];
+    const firstFailure = positiveElapsedSeconds(
+      sample?.runCreatedAt,
+      firstFailureAt
+    );
+    if (firstFailure !== null) firstTerminalFailures.push(firstFailure);
+
+    const requiredChecks = latestRequiredChecks(sample?.requiredChecks);
+    if (
+      hasCompleteRequiredChecks(requiredChecks) &&
+      requiredChecks.every(
+        check => check?.conclusion === 'success' && check?.completed_at
+      )
+    ) {
+      const requiredGreenAt = requiredChecks
+        .map(check => check.completed_at)
+        .sort()
+        .at(-1);
+      const elapsed = positiveElapsedSeconds(
+        sample?.runCreatedAt,
+        requiredGreenAt
+      );
+      if (elapsed !== null) requiredGreen.push(elapsed);
+    }
+  }
+
+  return {
+    runnerSeconds: { hosted: hostedSeconds, selfHosted: selfHostedSeconds },
+    cancellationWasteSeconds,
+    jobStartDelaySeconds: percentilesOf(jobStartDelays),
+    timeToFirstTerminalFailureSeconds: percentilesOf(firstTerminalFailures),
+    timeToRequiredGreenSeconds: percentilesOf(requiredGreen),
+    sampleSizes: {
+      jobs: (runJobs ?? []).reduce(
+        (count, sample) =>
+          count +
+          (sample?.jobs ?? []).filter(job => job?.conclusion !== 'skipped')
+            .length,
+        0
+      ),
+      jobStartDelay: jobStartDelays.length,
+      firstTerminalFailure: firstTerminalFailures.length,
+      requiredGreen: requiredGreen.length,
+    },
+  };
 }
 
 /**
@@ -142,9 +422,19 @@ export function evaluateMergeQueueThroughput(metrics, options = {}) {
   const now = options.now ?? new Date();
   const eligibleAfter =
     options.eligibleAfter ?? new Date('2026-07-09T00:00:00Z');
-  const sampleCount = metrics?.sampleSizes?.readyToMerge ?? 0;
-  const p50 = metrics?.latency?.readyToMergeSeconds?.p50 ?? 0;
-  const p95 = metrics?.latency?.readyToMergeSeconds?.p95 ?? 0;
+  const sampleCount =
+    metrics?.sampleSizes?.fleetLeadTime ??
+    metrics?.sampleSizes?.readyToMerge ??
+    0;
+  const fleetLead =
+    metrics?.latency?.fleetLeadTimeSeconds ??
+    metrics?.latency?.readyToMergeSeconds;
+  const p50 = fleetLead?.p50 ?? 0;
+  const p95 = fleetLead?.p95 ?? 0;
+  const queuePolicy = {
+    maxQueueDepth: GRAPHITE_QUEUE_POLICY.maxQueueDepth,
+    parallelBatchSize: GRAPHITE_QUEUE_POLICY.parallelBatchSize,
+  };
 
   if (now < eligibleAfter) {
     return {
@@ -158,13 +448,14 @@ export function evaluateMergeQueueThroughput(metrics, options = {}) {
         p95Seconds: READY_TO_MERGE_P95_TARGET_SECONDS,
       },
       action: 'wait_for_evaluation_window',
+      queuePolicy,
     };
   }
 
   if (sampleCount < MIN_READY_TO_MERGE_SAMPLES) {
     return {
       status: 'insufficient_data',
-      reason: `Need >=${MIN_READY_TO_MERGE_SAMPLES} ready→merged samples (have ${sampleCount})`,
+      reason: `Need >=${MIN_READY_TO_MERGE_SAMPLES} fleet lead-time samples (have ${sampleCount})`,
       sampleCount,
       p50Seconds: p50,
       p95Seconds: p95,
@@ -173,6 +464,7 @@ export function evaluateMergeQueueThroughput(metrics, options = {}) {
         p95Seconds: READY_TO_MERGE_P95_TARGET_SECONDS,
       },
       action: 'collect_more_samples',
+      queuePolicy,
     };
   }
 
@@ -182,7 +474,7 @@ export function evaluateMergeQueueThroughput(metrics, options = {}) {
   if (p50OnTarget && p95OnTarget) {
     return {
       status: 'on_target',
-      reason: 'Ready→merged p50 and p95 are within targets',
+      reason: 'Fleet lead-time p50 and p95 are within targets',
       sampleCount,
       p50Seconds: p50,
       p95Seconds: p95,
@@ -191,12 +483,19 @@ export function evaluateMergeQueueThroughput(metrics, options = {}) {
         p95Seconds: READY_TO_MERGE_P95_TARGET_SECONDS,
       },
       action: 'close_follow_up',
+      queuePolicy,
     };
   }
 
   const actions = [];
   if (!p95OnTarget) {
-    actions.push('raise_max_queue_depth_12_to_16');
+    if (GRAPHITE_QUEUE_POLICY.maxQueueDepth < 16) {
+      actions.push(
+        `raise_max_queue_depth_${GRAPHITE_QUEUE_POLICY.maxQueueDepth}_to_16`
+      );
+    } else {
+      actions.push('investigate_runner_capacity_and_queue_churn');
+    }
   }
   if (!p50OnTarget) {
     actions.push('tune_unit_test_shards');
@@ -206,8 +505,8 @@ export function evaluateMergeQueueThroughput(metrics, options = {}) {
     status: 'off_target',
     reason:
       p95 > READY_TO_MERGE_P95_TARGET_SECONDS
-        ? `Ready→merged p95 ${Math.round(p95 / 60)}m exceeds ${READY_TO_MERGE_P95_TARGET_SECONDS / 60}m target`
-        : `Ready→merged p50 ${Math.round(p50 / 60)}m exceeds ${READY_TO_MERGE_P50_TARGET_SECONDS / 60}m target`,
+        ? `Fleet lead-time p95 ${Math.round(p95 / 60)}m exceeds ${READY_TO_MERGE_P95_TARGET_SECONDS / 60}m target`
+        : `Fleet lead-time p50 ${Math.round(p50 / 60)}m exceeds ${READY_TO_MERGE_P50_TARGET_SECONDS / 60}m target`,
     sampleCount,
     p50Seconds: p50,
     p95Seconds: p95,
@@ -216,19 +515,62 @@ export function evaluateMergeQueueThroughput(metrics, options = {}) {
       p95Seconds: READY_TO_MERGE_P95_TARGET_SECONDS,
     },
     action: actions.join(';'),
+    queuePolicy,
   };
 }
 
-export function summarizeCiMetrics({ ts, runs, prs, timelineResults }) {
+export function summarizeCiMetrics({
+  ts,
+  runs,
+  prs,
+  timelineResults,
+  runJobs = [],
+  hydration,
+}) {
   const gate = gateDurationsSeconds(runs);
   const fullMerge = fullMergeTimesSeconds(prs);
   const queueWaits = queueWaitSeconds(timelineResults);
-  const readyToMerge = readyToMergeSeconds(timelineResults);
+  const lastEnqueueToMerge = lastEnqueueToMergeSeconds(timelineResults);
+  const activeQueued = activeQueuedSeconds(timelineResults);
+  const fleetLeadTime = fleetLeadTimeSeconds(timelineResults);
+  const jobMetrics = summarizeJobMetrics(runJobs);
   const { mergedPrsPerDay, spanDays, mergedCount } = mergedThroughput(prs);
+  const hydrationCoverage = {
+    runJobs: {
+      covered: hydration?.runJobs?.covered ?? runJobs.length,
+      total: hydration?.runJobs?.total ?? runJobs.length,
+    },
+    requiredChecks: {
+      covered: hydration?.requiredChecks?.covered ?? runJobs.length,
+      total: hydration?.requiredChecks?.total ?? runJobs.length,
+    },
+    timelines: {
+      covered: hydration?.timelines?.covered ?? timelineResults?.length ?? 0,
+      total: hydration?.timelines?.total ?? timelineResults?.length ?? 0,
+    },
+  };
+  const hydrationComplete = Object.values(hydrationCoverage).every(
+    coverage => coverage.covered >= coverage.total
+  );
+  const evaluatedVerdict = evaluateMergeQueueThroughput(
+    {
+      latency: {
+        fleetLeadTimeSeconds: percentilesOf(fleetLeadTime),
+      },
+      sampleSizes: { fleetLeadTime: fleetLeadTime.length },
+    },
+    // Keep verdict deterministic: callers pass `ts` so wall-clock Date.now
+    // cannot flip evaluation-window status between test and job runs.
+    { now: ts ? new Date(ts) : new Date() }
+  );
 
   return {
     schemaVersion: CI_METRICS_SCHEMA_VERSION,
     ts,
+    hydration: {
+      complete: hydrationComplete,
+      ...hydrationCoverage,
+    },
     window: {
       mergedPrs: (prs ?? []).length,
       ciRuns: (runs ?? []).length,
@@ -243,30 +585,42 @@ export function summarizeCiMetrics({ ts, runs, prs, timelineResults }) {
           : null,
       flakyRerunRate: Number(flakyRerunRate(runs).toFixed(4)),
       queueWaitSeconds: percentilesOf(queueWaits),
+      runnerJobSeconds: jobMetrics.runnerSeconds,
+      cancellationWasteSeconds: jobMetrics.cancellationWasteSeconds,
     },
     // SECONDARY: latency diagnostics.
     latency: {
       gateWallclockSeconds: percentilesOf(gate),
       fullMergeTimeSeconds: percentilesOf(fullMerge),
       // Tracks the ready→merged p50<10m / p95<15m target.
-      readyToMergeSeconds: percentilesOf(readyToMerge),
+      readyToMergeSeconds: percentilesOf(fleetLeadTime),
+      fleetLeadTimeSeconds: percentilesOf(fleetLeadTime),
+      firstEnqueueLeadSeconds: percentilesOf(queueWaits),
+      lastEnqueueToMergeSeconds: percentilesOf(lastEnqueueToMerge),
+      activeQueuedSeconds: percentilesOf(activeQueued),
+      jobStartDelaySeconds: jobMetrics.jobStartDelaySeconds,
+      timeToFirstTerminalFailureSeconds:
+        jobMetrics.timeToFirstTerminalFailureSeconds,
+      timeToRequiredGreenSeconds: jobMetrics.timeToRequiredGreenSeconds,
     },
     sampleSizes: {
       gate: gate.length,
       fullMerge: fullMerge.length,
       queueWait: queueWaits.length,
-      readyToMerge: readyToMerge.length,
+      readyToMerge: fleetLeadTime.length,
+      fleetLeadTime: fleetLeadTime.length,
+      firstEnqueueLead: queueWaits.length,
+      lastEnqueueToMerge: lastEnqueueToMerge.length,
+      activeQueued: activeQueued.length,
+      ...jobMetrics.sampleSizes,
     },
-    throughputVerdict: evaluateMergeQueueThroughput(
-      {
-        latency: {
-          readyToMergeSeconds: percentilesOf(readyToMerge),
+    throughputVerdict: hydrationComplete
+      ? evaluatedVerdict
+      : {
+          ...evaluatedVerdict,
+          status: 'insufficient_data',
+          reason: 'API hydration incomplete; snapshot is non-authoritative',
+          action: 'hydrate_remaining_api_samples',
         },
-        sampleSizes: { readyToMerge: readyToMerge.length },
-      },
-      // Keep verdict deterministic: callers pass `ts` so wall-clock Date.now
-      // cannot flip evaluation-window status between test and job runs.
-      { now: ts ? new Date(ts) : new Date() }
-    ),
   };
 }

--- a/scripts/lib/merge-queue-guard.mjs
+++ b/scripts/lib/merge-queue-guard.mjs
@@ -1068,6 +1068,7 @@ function secondsBetween(start, end) {
 export function parseMergeQueueTimeline(events, options = {}) {
   const queuedAt = [];
   const dequeued = [];
+  const queueTransitions = [];
   const telemetry = [];
   const conflictComments = [];
   const ciComments = [];
@@ -1077,6 +1078,7 @@ export function parseMergeQueueTimeline(events, options = {}) {
   for (const event of events ?? []) {
     if (event.event === 'labeled' && event.label?.name === MERGE_QUEUE_LABEL) {
       queuedAt.push(event.created_at);
+      queueTransitions.push({ type: 'queued', at: event.created_at });
     }
     if (
       event.event === 'unlabeled' &&
@@ -1086,6 +1088,7 @@ export function parseMergeQueueTimeline(events, options = {}) {
         at: event.created_at,
         actor: event.actor?.login ?? null,
       });
+      queueTransitions.push({ type: 'dequeued', at: event.created_at });
     }
     if (event.event === 'ready_for_review') {
       readyForReviewAt.push(event.created_at);
@@ -1130,13 +1133,50 @@ export function parseMergeQueueTimeline(events, options = {}) {
   const lastReadyForReviewAt =
     readyForReviewAt.at(-1) ?? options.prCreatedAt ?? null;
 
+  // Sum only intervals where the merge-queue label was actually present. This
+  // keeps dequeue/requeue gaps out of runner-fleet queue pressure telemetry.
+  let activeQueueStart = null;
+  let activeQueuedSeconds = 0;
+  for (const transition of queueTransitions) {
+    if (
+      mergedAt &&
+      new Date(transition.at).getTime() >= new Date(mergedAt).getTime()
+    ) {
+      continue;
+    }
+    if (transition.type === 'queued' && activeQueueStart === null) {
+      activeQueueStart = transition.at;
+    } else if (transition.type === 'dequeued' && activeQueueStart !== null) {
+      const interval = secondsBetween(activeQueueStart, transition.at);
+      if (Number.isFinite(interval) && interval > 0) {
+        activeQueuedSeconds += interval;
+      }
+      activeQueueStart = null;
+    }
+  }
+  if (activeQueueStart !== null && mergedAt) {
+    const interval = secondsBetween(activeQueueStart, mergedAt);
+    if (Number.isFinite(interval) && interval > 0) {
+      activeQueuedSeconds += interval;
+    }
+  }
+
+  const firstEnqueueToMergedSeconds = secondsBetween(firstQueuedAt, mergedAt);
+  const lastEnqueueToMergedSeconds = secondsBetween(lastQueuedAt, mergedAt);
+  const fleetLeadTimeSeconds = secondsBetween(lastReadyForReviewAt, mergedAt);
+
   return {
     queuedAt,
     mergedAt,
     readyForReviewAt,
-    queuedToMergedSeconds: secondsBetween(firstQueuedAt, mergedAt),
-    lastQueuedToMergedSeconds: secondsBetween(lastQueuedAt, mergedAt),
-    readyToMergedSeconds: secondsBetween(lastReadyForReviewAt, mergedAt),
+    firstEnqueueToMergedSeconds,
+    lastEnqueueToMergedSeconds,
+    activeQueuedSeconds: firstQueuedAt ? activeQueuedSeconds : null,
+    fleetLeadTimeSeconds,
+    // Schema-v1 compatibility aliases. Keep for one metrics transition window.
+    queuedToMergedSeconds: firstEnqueueToMergedSeconds,
+    lastQueuedToMergedSeconds: lastEnqueueToMergedSeconds,
+    readyToMergedSeconds: fleetLeadTimeSeconds,
     requeueCount: Math.max(0, queuedAt.length - 1),
     conflictEvictions: conflictComments.length,
     ciEvictions: ciComments.length,


### PR DESCRIPTION
Fixes JOV-3461

<!-- linear-issue-id:JOV-3461 -->

## Summary

- Upgrades the append-only CI metrics record and latest snapshot to schema v2 while preserving schema-v1 field paths and helper/constants aliases for one transition window.
- Decomposes fleet lead time into first-enqueue lead, last-enqueue-to-merge, and active queued time that excludes dequeue gaps and caps at merge.
- Measures positive job runtime by hosted versus self-hosted runner, cancellation waste, job start delay, first terminal failure, and actual required-green time across PR Ready, Migration Guard, and Fork PR Gate.
- Derives throughput recommendations from the current GRAPHITE_QUEUE_POLICY, so the verdict cannot recommend the already-active maxQueueDepth=16.
- Persists sampled job/check responses by run id, updated_at, and head SHA; green checks reuse immediately, non-green checks retry on a 6h cadence for 24h, and no new schedule is added.

## Schema-v1 compatibility window

For one transition window, v2 retains throughput.queueWaitSeconds, latency.readyToMergeSeconds, sampleSizes.queueWait, sampleSizes.readyToMerge, the READY_TO_MERGE target constants, readyToMergeSeconds(), queuedToMergedSeconds, lastQueuedToMergedSeconds, readyToMergedSeconds, and the legacy readyToMerge log fields. Existing JSONL remains append-only and ci-metrics-latest.json keeps its path and snapshot contract.

## Verification

- Node 22.22.1
- pnpm ci:control:test — 5 files, 119 tests passed
- pnpm biome check --write on all five changed files — clean
- esbuild bundle check for scripts/hermes/jobs/ci-metrics.ts — passed
- node --check scripts/lib/ci-metrics-compute.mjs — passed
- node --check scripts/lib/merge-queue-guard.mjs — passed
- git diff --check — passed

Full pnpm turbo typecheck could not complete in this isolated worktree for unrelated dependency-state failures:

- @jovie/observability-ingest: TS2688 Cannot find type definition file for @cloudflare/workers-types; local package node_modules is missing.
- @jovie/desktop: TS5107 moduleResolution=node10 is deprecated under the shared TypeScript 6 dependency tree and requires ignoreDeprecations=6.0.

A direct TypeScript command was also unavailable because the isolated root lacks linked Node type declarations; the bundled TypeScript entrypoint check above passed.

## API cost disclosure

- Direct dollar charge: none; these are GitHub REST API calls within the repository quota.
- Cold start: at most 200 added calls, comprising up to 100 sampled-run job requests and 100 commit check-run requests.
- Endpoint payload ceiling: 100 records per non-paginated request.
- Normal steady state: approximately two calls per new or changed sampled run, plus non-green required-check retries no more often than every 6h during the first 24h.
- Stable all-red 100-run upper bound: at most 12,000 required-check refreshes per 30-day month.
- Existing 50 merge-timeline calls per hourly tick are unchanged.
- No new workflow, launchd job, or schedule is introduced.

This PR remains draft. Do not ready or merge it until the parent CI optimization sequence approves the observation window.