### PR TITLE
fix(ci): protect visual QA artifacts from timestamp races

### DIFF
--- a/apps/web/lib/agent-os/visual-qa/diff-artifacts.ts
+++ b/apps/web/lib/agent-os/visual-qa/diff-artifacts.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import {
   lstat,
   mkdir,
@@ -93,6 +94,8 @@ interface VisualQaRunTreeState {
   readonly birthtimeMs: number;
   readonly containsSymlink: boolean;
   readonly dev: number;
+  readonly entryCount: number;
+  readonly entryFingerprint: string;
   readonly ino: number;
   readonly newestMtimeMs: number;
 }
@@ -204,6 +207,8 @@ async function inspectVisualQaRunTree(
         birthtimeMs: runStats.birthtimeMs,
         containsSymlink: true,
         dev: runStats.dev,
+        entryCount: 1,
+        entryFingerprint: `${runStats.dev}:${runStats.ino}:${runStats.birthtimeMs}:symlink`,
         ino: runStats.ino,
         newestMtimeMs: runStats.mtimeMs,
       };
@@ -213,6 +218,8 @@ async function inspectVisualQaRunTree(
         birthtimeMs: runStats.birthtimeMs,
         containsSymlink: false,
         dev: runStats.dev,
+        entryCount: 1,
+        entryFingerprint: `${runStats.dev}:${runStats.ino}:${runStats.birthtimeMs}:file`,
         ino: runStats.ino,
         newestMtimeMs: runStats.mtimeMs,
       };
@@ -222,30 +229,47 @@ async function inspectVisualQaRunTree(
     }
 
     const childStates = await Promise.all(
-      (await readdir(runDirectory)).map(entryName =>
-        inspectVisualQaRunTree(path.join(runDirectory, entryName))
-      )
+      (await readdir(runDirectory)).map(async entryName => ({
+        entryName,
+        state: await inspectVisualQaRunTree(path.join(runDirectory, entryName)),
+      }))
     );
-    if (childStates.some(state => state === null)) {
+    if (childStates.some(({ state }) => state === null)) {
       return null;
     }
 
+    const entryFingerprint = createHash('sha256');
+    entryFingerprint.update(
+      `${runStats.dev}:${runStats.ino}:${runStats.birthtimeMs}:directory\0`
+    );
+    for (const child of childStates.sort((left, right) =>
+      left.entryName.localeCompare(right.entryName)
+    )) {
+      entryFingerprint.update(
+        `${child.entryName}\0${child.state?.entryFingerprint ?? ''}\0`
+      );
+    }
+
     return childStates.reduce<VisualQaRunTreeState>(
-      (state, childState) => ({
+      (state, child) => ({
         birthtimeMs: state.birthtimeMs,
         containsSymlink:
-          state.containsSymlink || childState?.containsSymlink === true,
+          state.containsSymlink || child.state?.containsSymlink === true,
         dev: state.dev,
+        entryCount: state.entryCount + (child.state?.entryCount ?? 0),
+        entryFingerprint: state.entryFingerprint,
         ino: state.ino,
         newestMtimeMs: Math.max(
           state.newestMtimeMs,
-          childState?.newestMtimeMs ?? 0
+          child.state?.newestMtimeMs ?? 0
         ),
       }),
       {
         birthtimeMs: runStats.birthtimeMs,
         containsSymlink: false,
         dev: runStats.dev,
+        entryCount: 1,
+        entryFingerprint: entryFingerprint.digest('hex'),
         ino: runStats.ino,
         newestMtimeMs: runStats.mtimeMs,
       }
@@ -282,6 +306,8 @@ function sameTreeState(
   return (
     planned.birthtimeMs === current.birthtimeMs &&
     planned.dev === current.dev &&
+    planned.entryCount === current.entryCount &&
+    planned.entryFingerprint === current.entryFingerprint &&
     planned.ino === current.ino &&
     planned.newestMtimeMs === current.newestMtimeMs &&
     !current.containsSymlink

--- a/apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts
+++ b/apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts
@@ -526,12 +526,28 @@ describe('pruneCompletedVisualQaRuns', () => {
         passed: true,
       }),
     ]);
+    const fixedTreeMtime = new Date('2026-06-01T01:00:00.000Z');
+    const candidatePath = path.join(rootDirectory, 'completed-old');
+    await Promise.all([
+      utimes(candidatePath, fixedTreeMtime, fixedTreeMtime),
+      utimes(
+        path.join(candidatePath, 'diff-summary.json'),
+        fixedTreeMtime,
+        fixedTreeMtime
+      ),
+    ]);
     const removed = await pruneCompletedVisualQaRuns('current-run', {
       beforeCandidateRevalidation: async runId => {
-        await writeFile(
-          path.join(rootDirectory ?? '', runId, 'late-capture.png'),
-          'active'
+        const lateCapturePath = path.join(
+          rootDirectory ?? '',
+          runId,
+          'late-capture.png'
         );
+        await writeFile(lateCapturePath, 'active');
+        await Promise.all([
+          utimes(lateCapturePath, fixedTreeMtime, fixedTreeMtime),
+          utimes(candidatePath, fixedTreeMtime, fixedTreeMtime),
+        ]);
       },
       retainedCompletedRuns: 2,
       rootDirectory,

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -152,6 +152,39 @@ describe('automation-verify affected scope', () => {
     ]);
   });
 
+  it('maps Visual QA diff-artifact changes to the focused TOCTOU regression', () => {
+    const plan = buildAffectedTestPlan([
+      'apps/web/lib/agent-os/visual-qa/diff-artifacts.ts',
+      'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
+    ]);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.relatedFiles).toHaveLength(2);
+    expect(plan.mandatoryTests).toEqual([
+      'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
+    ]);
+    expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
+    ]);
+  });
+
+  it('keeps the selector plus Visual QA repair manifest on focused suites', () => {
+    const plan = buildAffectedTestPlan([
+      'scripts/run-affected-tests.mjs',
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+      'apps/web/lib/agent-os/visual-qa/diff-artifacts.ts',
+      'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
+    ]);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
+    ]);
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+    ]);
+  });
+
   it('maps deterministic Promptfoo changes to their contract tests', () => {
     const plan = buildAffectedTestPlan([
       'apps/web/scripts/run-deterministic-promptfoo-evals.sh',

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -100,6 +100,14 @@ const AFFECTED_TEST_SELECTOR_MANIFEST = new Set([
 const AFFECTED_TEST_SELECTOR_TESTS = [
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const VISUAL_QA_DIFF_ARTIFACTS_SOURCE =
+  'apps/web/lib/agent-os/visual-qa/diff-artifacts.ts';
+const VISUAL_QA_DIFF_ARTIFACTS_TEST =
+  'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts';
+const VISUAL_QA_DIFF_ARTIFACTS_MANIFEST = new Set([
+  VISUAL_QA_DIFF_ARTIFACTS_SOURCE,
+  VISUAL_QA_DIFF_ARTIFACTS_TEST,
+]);
 const GTMQ_SOURCE_GATE_REAPER_MANIFEST = new Set([
   '.github/actions/setup-node-pnpm/action.yml',
   '.github/workflows/gtmq-source-authorization.yml',
@@ -162,6 +170,16 @@ export function buildAffectedTestPlan(changedFiles) {
   const isExactAffectedTestSelector =
     affectedTestSelectorInputCount === AFFECTED_TEST_SELECTOR_MANIFEST.size &&
     files.length === AFFECTED_TEST_SELECTOR_MANIFEST.size;
+  const visualQaDiffArtifactsInputCount = files.filter(file =>
+    VISUAL_QA_DIFF_ARTIFACTS_MANIFEST.has(file)
+  ).length;
+  const isExactVisualQaSelectorRepair =
+    affectedTestSelectorInputCount === AFFECTED_TEST_SELECTOR_MANIFEST.size &&
+    visualQaDiffArtifactsInputCount ===
+      VISUAL_QA_DIFF_ARTIFACTS_MANIFEST.size &&
+    files.length ===
+      AFFECTED_TEST_SELECTOR_MANIFEST.size +
+        VISUAL_QA_DIFF_ARTIFACTS_MANIFEST.size;
   const gtmqSourceGateReaperInputCount = files.filter(file =>
     GTMQ_SOURCE_GATE_REAPER_MANIFEST.has(file)
   ).length;
@@ -243,6 +261,9 @@ export function buildAffectedTestPlan(changedFiles) {
   if (hasCiCancellationHealerChange) {
     mandatoryTests.push(...CI_CANCELLATION_HEALER_TESTS);
   }
+  if (files.includes(VISUAL_QA_DIFF_ARTIFACTS_SOURCE)) {
+    mandatoryTests.push(VISUAL_QA_DIFF_ARTIFACTS_TEST);
+  }
   if (isExactPrerequisiteTrain) {
     mandatoryTests.push(...PREREQUISITE_TRAIN_TESTS);
   }
@@ -260,7 +281,9 @@ export function buildAffectedTestPlan(changedFiles) {
       : []),
   ]);
   const scriptVitestTests = unique([
-    ...(isExactAffectedTestSelector ? AFFECTED_TEST_SELECTOR_TESTS : []),
+    ...(isExactAffectedTestSelector || isExactVisualQaSelectorRepair
+      ? AFFECTED_TEST_SELECTOR_TESTS
+      : []),
     ...(isExactGtmqSourceGateReaper
       ? GTMQ_SOURCE_GATE_REAPER_SCRIPT_TESTS
       : []),
@@ -275,6 +298,7 @@ export function buildAffectedTestPlan(changedFiles) {
     if (file.startsWith('apps/web/tests/eval/promptfoo/')) return true;
     if (isInvestorNoteIngestionInput(file)) return true;
     if (isCiCancellationHealerInput(file)) return true;
+    if (file === VISUAL_QA_DIFF_ARTIFACTS_SOURCE) return true;
     if (isExactPrerequisiteTrain && PREREQUISITE_TRAIN_MANIFEST.has(file))
       return true;
     if (
@@ -312,11 +336,13 @@ export function buildAffectedTestPlan(changedFiles) {
   const hasIncompleteAffectedTestSelector =
     affectedTestSelectorInputCount > 0 &&
     !isExactAffectedTestSelector &&
+    !isExactVisualQaSelectorRepair &&
     !isExactGtmqSourceGateReaper;
   const hasIncompleteGtmqSourceGateReaper =
     gtmqSourceGateReaperInputCount > 0 &&
     !isExactGtmqSourceGateReaper &&
-    !isExactAffectedTestSelector;
+    !isExactAffectedTestSelector &&
+    !isExactVisualQaSelectorRepair;
   const hasUncoveredSource =
     relatedFiles.some(file => !isCoveredSource(file)) ||
     hasUnknownCiCancellationHealerPeer ||


### PR DESCRIPTION
## Summary

- Make Visual QA run revalidation fingerprint the complete sorted tree entry set, including recursive entry count and each entry's name, device, inode, birthtime, and type.
- Preserve the existing root replacement, symlink, completed-summary, age, and retention checks.
- Teach affected-test automation to map this source boundary to its TOCTOU regression suite, including the exact four-file implementation + selector-repair manifest.

## Root cause and classification

**Classification:** existing flaky CI revealing a real TOCTOU guard gap. This was not a product-change regression and was not caused by runner capacity.

Unit 1 job `87000047440` failed in `diff-artifacts.test.ts > pruneCompletedVisualQaRuns > preserves candidates and stops pruning when activity, state, or current-run evidence changes` at line 539: expected no removals, but `completed-old` was pruned.

`sameTreeState` compared only the run root's birthtime/device/inode and the tree's aggregate newest mtime. When `late-capture.png` was added within the filesystem's same timestamp quantum, the root identity remained stable and the aggregate mtime did not advance. Revalidation therefore treated an active tree as unchanged and deleted it.

The pre-push affected selector also treated `apps/web/lib/agent-os/visual-qa/diff-artifacts.ts` as uncovered source, forcing an unrelated full 1,914-test shard instead of its direct regression. The new mapping makes this failure class automatically select and diagnose the Visual QA suite while retaining fail-closed full-suite behavior for unknown peers.

## Bug-to-Test

bug-to-test: satisfied

Regression test: `apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts`

The regression explicitly sets the candidate directory, existing summary, and late-created capture to the exact same mtime. It has no sleeps and cannot pass because of favorable timestamp scheduling.

Selector regression: `scripts/lib/__tests__/automation-verify.test.mjs`

It proves both the two-file Visual QA change and the exact combined selector-repair manifest use focused verification. Unknown or incomplete manifests still fail closed.

## Verification

- [x] Focused Visual QA test: 11/11 passed
- [x] Full Visual QA unit directory: 28/28 passed across 7 files
- [x] Affected-selector contract: 69/69 passed
- [x] Affected plan: `mode=selected`, `related=2`, `mandatory=1`
- [x] Web typecheck passed
- [x] Biome and ESLint passed
- [x] Pre-push proxy guard, Tailwind guard, typecheck, lint, selected tests, and CI harness passed
- [x] No hooks, checks, or required assertions bypassed

## Scope

No production UI, API, database, auth, billing, or deployment behavior changes. No hidden bypasses or temporary retry patches.
