### PR TITLE
fix(ci): support GitHub native merge-group checks

### DIFF
--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -51,7 +51,7 @@ Graphite and branch protection must wait on **aggregate** contexts only — neve
 | `Fork PR Gate` | Blocks unreviewed fork PRs (auto-passes for agents + team) |
 | `PR Size Guard` | Caps PR size (800 lines / 40 files); `big-pr` is mechanical-only. A documented `integration-train` may use the bounded 2500-line / 60-file policy. |
 
-**Queue CI is the PR's own CI.** Graphite runs on every PR directly (not draft-batch mode), so `gtmq_*` batch branches are never created and the former slim-lane `if:` conditions were removed from `ci.yml` (#13610). Graphite does not use GitHub `merge_group` events. If batching mode is ever re-enabled, the slim-lane conditions must be restored with it — see `docs/PR_FLOW.md` §2 and the 2026-06-22 post-mortem.
+**Queue CI is the PR's own CI while Graphite remains active.** Graphite runs on every PR directly (not draft-batch mode), so `gtmq_*` batch branches are never created. `ci.yml` also accepts GitHub's `merge_group` event and validates the synthetic combined head, but that path is inert until the live ruleset enables the native queue. Supporting the event before cutover prevents a required-check bootstrap gap; it does not change the active queue backend. See `docs/PR_FLOW.md` §2 and the 2026-06-22 post-mortem.
 
 ### Graphite dashboard (`app.graphite.com/settings/merge-queue`) — OWL/human verify
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [main, 'integration/**']
-  # merge_group retired 2026-06-18: Graphite owns the merge queue; GitHub never
-  # creates a merge_group, so this trigger would never fire. See .github/MERGE_QUEUE.md.
+  # Inert while Graphite owns landing. Keeping combined-head support on main
+  # lets GitHub native merge queue be canaried without a workflow bootstrap gap.
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
     paths-ignore:
@@ -28,9 +30,11 @@ concurrency:
     ${{ github.workflow }}-${{
       (github.event_name == 'pull_request')
         && format('pr-{0}', github.event.pull_request.number)
-        || ((github.event_name == 'push' && github.ref == 'refs/heads/main')
+        || (github.event_name == 'merge_group'
+           && format('merge-group-{0}', github.event.merge_group.head_sha)
+           || ((github.event_name == 'push' && github.ref == 'refs/heads/main')
            && github.sha
-           || github.ref)
+           || github.ref))
     }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
@@ -82,6 +86,7 @@ jobs:
     steps:
       - id: graphite-token
         name: Check Graphite token configuration
+        if: github.event_name != 'merge_group'
         env:
           GRAPHITE_TOKEN: ${{ secrets.GRAPHITE_TOKEN }}
         run: |
@@ -93,7 +98,7 @@ jobs:
           fi
 
       - id: graphite
-        if: steps.graphite-token.outputs.configured == 'true'
+        if: github.event_name != 'merge_group' && steps.graphite-token.outputs.configured == 'true'
         continue-on-error: true
         uses: withgraphite/graphite-ci-action@402a89bc8aa6db18ae1f9c61953d001d5f9d828f # v0.0.11
         with:
@@ -125,7 +130,13 @@ jobs:
           set -euo pipefail
           IS_FORK="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}"
           # Determine changed files
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            MERGE_GROUP_BASE_SHA="${{ github.event.merge_group.base_sha }}"
+            MERGE_GROUP_HEAD_SHA="${{ github.event.merge_group.head_sha }}"
+            git cat-file -e "${MERGE_GROUP_BASE_SHA}^{commit}"
+            git cat-file -e "${MERGE_GROUP_HEAD_SHA}^{commit}"
+            CHANGED_FILES=$(git diff --name-only "$MERGE_GROUP_BASE_SHA...$MERGE_GROUP_HEAD_SHA")
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Fail closed on base resolution: a failed fetch used to leave an
             # empty CHANGED_FILES list that looked like docs-only and skip-
             # cascaded ci-fast / unit leaves while risk still ran.
@@ -316,7 +327,7 @@ jobs:
   ci-risk-classifier:
     # Trusted PRs need classification before their build, smoke, and preview
     # dependencies evaluate. Forks intentionally stay on the secret-free path.
-    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)) }}
+    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)) }}
     name: CI Risk Classifier
     needs: [ci-path-changes]
     runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
@@ -350,6 +361,9 @@ jobs:
             git fetch origin "$BASE_REF" --depth=1
             DIFF_BASE="origin/$BASE_REF"
             git diff --name-only "$DIFF_BASE" HEAD > "$CHANGED_FILES"
+          elif [[ "$EVENT_NAME" == "merge_group" ]]; then
+            DIFF_BASE="${{ github.event.merge_group.base_sha }}"
+            git diff --name-only "$DIFF_BASE...${{ github.event.merge_group.head_sha }}" > "$CHANGED_FILES"
           elif [[ "$EVENT_NAME" == "push" ]]; then
             DIFF_BASE="HEAD~1"
             git diff --name-only "$DIFF_BASE" HEAD > "$CHANGED_FILES" 2>/dev/null || git show --pretty="" --name-only HEAD > "$CHANGED_FILES"
@@ -531,7 +545,7 @@ jobs:
       - name: Run ci-fast lanes
         id: lanes
         env:
-          TURBO_SCM_BASE: ${{ (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
+          TURBO_SCM_BASE: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || ((github.base_ref && format('origin/{0}', github.base_ref)) || '') }}
           CI_FAST_SKIP_STRUCTURAL: ${{ steps.structural.outputs.skip }}
           CI_FAST_LANES_OUT: ${{ runner.temp }}/ci-fast-lanes.json
         run: node scripts/ci-fast-lanes.mjs
@@ -753,7 +767,7 @@ jobs:
     name: Migration Guard
     needs: [ci-path-changes]
     # Skip if 'skip-migration-guard' label is present (for schema consolidation)
-    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-migration-guard'))) }}
+    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'merge_group' || github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-migration-guard'))) }}
     runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 3
     outputs:
@@ -880,10 +894,10 @@ jobs:
     needs: [ci-path-changes, ci-risk-classifier]
     # Shared Next.js build for a11y + layout-guard — build once, test twice.
     # On PRs to main: always runs (non-fork) for build validation. Part of the merge gate.
-    # Merge queue intentionally skips build (already validated on the PR).
+    # Merge groups rebuild the synthetic combined head to catch integration failures.
     # On main push: always runs for full coverage + JOV-4087 vercel deploy artifact.
     # Fork PRs are excluded (no secrets) — skipped via fork-pr-gate.
-    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false) || github.event_name == 'workflow_dispatch') }}
+    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false) || github.event_name == 'workflow_dispatch') }}
     # Production deploy artifacts must not wait behind the saturated fixed PR
     # runner. Keep PR builds on jovie-fixed; route main to hosted capacity.
     runs-on: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'ubuntu-latest' || vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
@@ -1116,8 +1130,8 @@ jobs:
     needs: [ci-path-changes, ci-build-public]
     # Blocking on PRs via ci-pr-ready (flipped from informational — Tim directive,
     # a11y/visual gating mission 2026-07-06 / JOV-4060). Runs on PRs to main when the
-    # shared build artifact exists, plus push:main for post-merge coverage.
-    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]')) && needs.ci-build-public.outputs.has_artifact == 'true' }}
+    # shared build artifact exists, plus merge-group combined heads and push:main.
+    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]')) && needs.ci-build-public.outputs.has_artifact == 'true' }}
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 8
     steps:
@@ -1135,6 +1149,12 @@ jobs:
         with:
           name: nextjs-build-${{ github.run_id }}
           path: /tmp/nextjs-build-download
+
+      - name: Require combined-head build artifact
+        if: github.event_name == 'merge_group' && steps.download.outcome != 'success'
+        run: |
+          echo "::error::Combined-head build was required, but its shared artifact could not be downloaded."
+          exit 1
 
       - name: Extract build artifact
         if: steps.download.outcome == 'success'
@@ -2475,10 +2495,10 @@ jobs:
   ci-unit-tests:
     name: Unit Tests (${{ matrix.shard }})
     needs: [ci-path-changes]
-    # Runs on PRs to main, main pushes, and manual dispatch. Merge queue skips (PR-validated).
+    # Runs on PRs to main, merge-group combined heads, main pushes, and manual dispatch.
     # Parallel with typecheck/build for faster CI.
     # Path-gated: skips test execution when no test-relevant files changed.
-    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && ((github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') }}
+    if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') }}
     # 5-shard unit tests; runner is var-switchable (CI_UNIT_RUNNER=jovie-runner
     # offloads all shards to the self-hosted pool when hosted concurrency is
     # the bottleneck). Defaults to GitHub-hosted. Shards upload no artifacts on
@@ -2525,7 +2545,7 @@ jobs:
         if: steps.check_changes.outputs.run_full_ci == 'true'
         env:
           TURBO_SCM_HEAD: ${{ github.sha }}
-          TURBO_SCM_BASE: ${{ (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
+          TURBO_SCM_BASE: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || ((github.base_ref && format('origin/{0}', github.base_ref)) || '') }}
         run: |
           # Use forked pool with limited workers to reduce CI flakiness from memory pressure
           export NODE_OPTIONS="--max-old-space-size=3072"
@@ -2542,9 +2562,9 @@ jobs:
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "main: Running web unit suite through Turbo without coverage; nightly coverage audit uploads Codecov coverage"
             pnpm turbo test:fast --filter=@jovie/web -- $VITEST_CI_FLAGS $RETRY_FLAG --shard=${{ matrix.shard }} ${{ steps.quarantine.outputs.unit_excludes }} $OUTPUT_FLAG
-          elif [ -n "${{ github.base_ref }}" ]; then
-            echo "🔍 PR: Running full test suite"
-            # Run all tests on PRs to catch regressions before merge
+          elif [[ "${{ github.event_name }}" == "merge_group" || -n "${{ github.base_ref }}" ]]; then
+            echo "🔍 PR/merge group: Running affected test suite"
+            # Run affected tests against the PR base or merge-group base SHA.
             pnpm turbo test:fast --affected -- $VITEST_CI_FLAGS $RETRY_FLAG --shard=${{ matrix.shard }} ${{ steps.quarantine.outputs.unit_excludes }} $OUTPUT_FLAG
           else
             echo "🔍 Feature branch push: Running critical + interaction tests only (no base_ref available)"
@@ -2559,7 +2579,7 @@ jobs:
         continue-on-error: true
         env:
           TURBO_SCM_HEAD: ${{ github.sha }}
-          TURBO_SCM_BASE: ${{ (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
+          TURBO_SCM_BASE: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || ((github.base_ref && format('origin/{0}', github.base_ref)) || '') }}
         run: pnpm turbo test:fast --affected -- --pool=forks --maxWorkers=2 --retry=${{ steps.quarantine.outputs.quarantine_unit_retries }} ${{ steps.quarantine.outputs.unit_files }}
 
       - name: Run packages/ui unit tests
@@ -3884,6 +3904,85 @@ jobs:
   # PR Lighthouse runs as a path-gated preview-evidence lane with stricter thresholds (0.75 perf, 0.85 a11y).
   # Original removal was due to 0.5 thresholds being too relaxed. Updated .lighthouserc.pr.json fixes this.
   # Production Lighthouse (in ci-build job) has even stricter thresholds (0.8 perf, 0.95 a11y).
+
+  ci-merge-group-ready:
+    name: PR Ready
+    # Source PRs retain the A11y evidence that required Neon. Combined heads run
+    # the shared-artifact Layout Guard without creating a second Neon branch.
+    needs:
+      [
+        ci-path-changes,
+        ci-risk-classifier,
+        ci-fast,
+        ci-unit-tests,
+        ci-build-public,
+        ci-layout-guard,
+      ]
+    if: ${{ always() && !cancelled() && github.event_name == 'merge_group' }}
+    runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 2
+    steps:
+      - name: Evaluate combined-head checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          PATH_RESULT="${{ needs.ci-path-changes.result }}"
+          RISK_RESULT="${{ needs.ci-risk-classifier.result }}"
+          FAST_RESULT="${{ needs.ci-fast.result }}"
+          UNIT_RESULT="${{ needs.ci-unit-tests.result }}"
+          BUILD_RESULT="${{ needs.ci-build-public.result }}"
+          BUILD_HAS_ARTIFACT="${{ needs.ci-build-public.outputs.has_artifact }}"
+          LAYOUT_RESULT="${{ needs.ci-layout-guard.result }}"
+          RUN_TEST="${{ needs.ci-path-changes.outputs.run_test }}"
+
+          {
+            echo "### Merge group ready"
+            echo
+            echo "Combined head: \`${{ github.event.merge_group.head_sha }}\`"
+            echo "Base: \`${{ github.event.merge_group.base_sha }}\`"
+            echo
+            echo "| Gate | Result |"
+            echo "| --- | --- |"
+            echo "| Path Changes | $PATH_RESULT |"
+            echo "| CI Risk Classifier | $RISK_RESULT |"
+            echo "| ci-fast | $FAST_RESULT |"
+            echo "| Unit Tests | $UNIT_RESULT |"
+            echo "| Build (public routes) | $BUILD_RESULT |"
+            echo "| Layout Guard | $LAYOUT_RESULT |"
+            echo
+            echo "Source-PR A11y evidence is inherited; merge groups do not provision Neon."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for gate in \
+            "Path Changes:$PATH_RESULT" \
+            "CI Risk Classifier:$RISK_RESULT" \
+            "ci-fast:$FAST_RESULT" \
+            "Build (public routes):$BUILD_RESULT"; do
+            name="${gate%%:*}"
+            result="${gate#*:}"
+            if [[ "$result" != "success" ]]; then
+              echo "::error::$name did not pass on the merge-group combined head (result: $result)"
+              exit 1
+            fi
+          done
+
+          if [[ "$UNIT_RESULT" != "success" ]]; then
+            if [[ "$UNIT_RESULT" != "skipped" || "$RUN_TEST" == "true" ]]; then
+              echo "::error::Unit Tests did not pass on the merge-group combined head (result: $UNIT_RESULT; run_test=$RUN_TEST)"
+              exit 1
+            fi
+            echo "Unit Tests legitimately skipped because path detection selected no test-relevant files."
+          fi
+
+          if [[ "$LAYOUT_RESULT" != "success" ]]; then
+            if [[ "$LAYOUT_RESULT" != "skipped" || "$BUILD_HAS_ARTIFACT" == "true" ]]; then
+              echo "::error::Layout Guard did not pass on the merge-group combined head (result: $LAYOUT_RESULT; build_artifact=$BUILD_HAS_ARTIFACT)"
+              exit 1
+            fi
+            echo "Layout Guard legitimately skipped because no shared build artifact was required."
+          fi
+
+          echo "All required combined-head checks passed."
 
   ci-pr-ready:
     name: PR Ready
@@ -5353,7 +5452,7 @@ jobs:
   deploy-notify:
     name: Notify production deploy
     needs: [deploy-staging, canary-health-gate, promote-production, sentry-error-gate, production-oauth-gate]
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Resolve failure provenance

--- a/.github/workflows/fork-pr-gate.yml
+++ b/.github/workflows/fork-pr-gate.yml
@@ -42,18 +42,29 @@ on:
   # workflow never checks out PR code, so re-evaluating metadata is safe.
   pull_request_review:
     types: [submitted]
-  # merge_group retired 2026-06-18: Graphite owns the merge queue; GitHub never
-  # creates a merge_group. The native-queue auto-pass step below is now inert.
+  # Inert while Graphite owns landing. Source PRs have already passed the real
+  # metadata gate, so the synthetic combined head receives the same context.
+  merge_group:
+    types: [checks_requested]
 
 permissions: {}
 
 concurrency:
   # Include the event name so review re-evaluation does not cancel the initial
   # metadata gate for the same PR.
-  group: fork-pr-gate-${{ github.event_name }}-${{ github.event.pull_request.number }}
+  group: fork-pr-gate-${{ github.event_name }}-${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  merge-group-gate:
+    name: Fork PR Gate
+    if: github.event_name == 'merge_group'
+    runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 1
+    steps:
+      - name: Confirm source PR gate inheritance
+        run: echo "Merge-group combined head inherits the source PR fork-policy decisions."
+
   # Fast path: Dependabot PRs are internal (not forks) but pull_request runs
   # in dependabot's restricted secret context. Run via pull_request_target so
   # the Jovie Bot App private key is available — the branch ruleset requires

--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -22,20 +22,34 @@ name: PR Size Guard
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # Inert while Graphite owns landing. Every source PR has already passed the
+  # size policy, so only the required context is reproduced on the combined SHA.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  group: pr-size-${{ github.event.pull_request.number }}
+  group: pr-size-${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  merge-group-size:
+    name: PR Size Guard
+    if: github.event_name == 'merge_group'
+    runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 1
+    steps:
+      - name: Confirm source PR size checks
+        run: echo "Merge-group members were size-checked as source PRs."
+
   size:
     name: PR Size Guard
     runs-on: ${{ vars.CI_GATE_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/docs/PR_FLOW.md
+++ b/docs/PR_FLOW.md
@@ -59,13 +59,12 @@ Rules:
   isn't required for correctness of *this* diff, path-gate it or move it off-PR.
 - Remaining lever: turbo `--affected` + remote cache on the PR gate so cache-hit
   jobs finish in seconds (tracked in JOV-3461).
-- **There is no separate merge-queue lane.** Graphite is configured to run on
+- **Graphite has no separate merge-queue lane.** It is configured to run on
   every PR directly (not draft-batch mode), so `gtmq_*` batch branches are never
-  created and the gtmq slim-lane job conditions were removed from `ci.yml`
-  (#13610). The `pull_request` workflow on the PR itself is the only CI a change
-  pays for pre-merge. If Graphite's batching mode is ever re-enabled, the
-  slim-lane conditions must come back with it — see the 2026-06-22 post-mortem
-  below for why batches must never run the informational lanes.
+  created. CI also supports GitHub's `merge_group` event ahead of a native-queue
+  cutover: that inert compatibility lane validates the synthetic combined head
+  and emits the four required contexts without running PR-only or deployment
+  work. It does not activate the native queue; the live ruleset owns that switch.
 
 ### Does my change need the heavy lane, a preview, or taste approval?
 

--- a/scripts/lib/__tests__/fixtures/merge-group-checks-requested.json
+++ b/scripts/lib/__tests__/fixtures/merge-group-checks-requested.json
@@ -1,0 +1,12 @@
+{
+  "action": "checks_requested",
+  "merge_group": {
+    "base_ref": "refs/heads/main",
+    "base_sha": "1111111111111111111111111111111111111111",
+    "head_ref": "refs/heads/gh-readonly-queue/main/pr-1234-deadbeef",
+    "head_sha": "2222222222222222222222222222222222222222"
+  },
+  "repository": {
+    "full_name": "JovieInc/Jovie"
+  }
+}

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -1,0 +1,172 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..');
+const CI_WORKFLOW = readFileSync(
+  resolve(REPO_ROOT, '.github/workflows/ci.yml'),
+  'utf8'
+);
+const FORK_GATE_WORKFLOW = readFileSync(
+  resolve(REPO_ROOT, '.github/workflows/fork-pr-gate.yml'),
+  'utf8'
+);
+const SIZE_GUARD_WORKFLOW = readFileSync(
+  resolve(REPO_ROOT, '.github/workflows/pr-size-guard.yml'),
+  'utf8'
+);
+const EVENT = JSON.parse(
+  readFileSync(
+    resolve(import.meta.dirname, 'fixtures/merge-group-checks-requested.json'),
+    'utf8'
+  )
+);
+
+function getJobBlock(workflow, jobKey) {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex(line => line === `  ${jobKey}:`);
+  expect(start, `Missing workflow job: ${jobKey}`).toBeGreaterThanOrEqual(0);
+
+  const block = [];
+  for (let index = start; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (index > start && /^  [a-zA-Z0-9_-]+:/.test(line)) break;
+    block.push(line);
+  }
+  return block.join('\n');
+}
+
+describe('merge_group workflow contract', () => {
+  it('models a checks_requested combined-head event', () => {
+    expect(EVENT.action).toBe('checks_requested');
+    expect(EVENT.merge_group.base_ref).toBe('refs/heads/main');
+    expect(EVENT.merge_group.base_sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(EVENT.merge_group.head_sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(EVENT.merge_group.head_ref).toContain('gh-readonly-queue/main/');
+  });
+
+  it('runs CI against the synthetic base-to-head diff without Graphite optimization', () => {
+    expect(CI_WORKFLOW).toMatch(/merge_group:\n\s+types: \[checks_requested\]/);
+    expect(CI_WORKFLOW).toContain(
+      'MERGE_GROUP_BASE_SHA="${{ github.event.merge_group.base_sha }}"'
+    );
+    expect(CI_WORKFLOW).toContain(
+      'MERGE_GROUP_HEAD_SHA="${{ github.event.merge_group.head_sha }}"'
+    );
+    expect(CI_WORKFLOW).toContain(
+      'git diff --name-only "$MERGE_GROUP_BASE_SHA...$MERGE_GROUP_HEAD_SHA"'
+    );
+    expect(CI_WORKFLOW).toContain(
+      "if: github.event_name != 'merge_group' && steps.graphite-token.outputs.configured == 'true'"
+    );
+  });
+
+  it('fans real combined-head checks into PR Ready without PR metadata or deploy evidence', () => {
+    const aggregate = getJobBlock(CI_WORKFLOW, 'ci-merge-group-ready');
+    expect(aggregate).toContain('name: PR Ready');
+    expect(aggregate).toContain("github.event_name == 'merge_group'");
+    expect(aggregate).toContain('ci-fast');
+    expect(aggregate).toContain('ci-unit-tests');
+    expect(aggregate).toContain('ci-build-public');
+    expect(aggregate).toContain('ci-layout-guard');
+    expect(aggregate).toContain('BUILD_HAS_ARTIFACT');
+    expect(aggregate).toContain(
+      'Layout Guard legitimately skipped because no shared build artifact was required.'
+    );
+    expect(aggregate).toContain(
+      'Unit Tests legitimately skipped because path detection selected no test-relevant files.'
+    );
+    expect(aggregate).not.toMatch(
+      /github\.event\.pull_request|github\.(base_ref|head_ref)/
+    );
+    expect(aggregate).not.toContain('ci-pr-vercel-preview');
+    expect(aggregate).not.toContain('ci-a11y');
+    expect(aggregate).not.toContain('neon-db');
+    expect(aggregate).not.toContain('deploy-staging');
+
+    for (const job of [
+      'ci-risk-classifier',
+      'drizzle-migration-guard',
+      'ci-build-public',
+      'ci-unit-tests',
+      'ci-layout-guard',
+    ]) {
+      expect(getJobBlock(CI_WORKFLOW, job)).toContain(
+        "github.event_name == 'merge_group'"
+      );
+    }
+    expect(getJobBlock(CI_WORKFLOW, 'drizzle-migration-guard')).toContain(
+      'name: Migration Guard'
+    );
+    const layoutGuard = getJobBlock(CI_WORKFLOW, 'ci-layout-guard');
+    expect(layoutGuard).toContain('Require combined-head build artifact');
+    expect(layoutGuard).toContain(
+      "github.event_name == 'merge_group' && steps.download.outcome != 'success'"
+    );
+    expect(getJobBlock(CI_WORKFLOW, 'ci-a11y')).not.toContain(
+      "github.event_name == 'merge_group'"
+    );
+    expect(aggregate).toContain(
+      'Source-PR A11y evidence is inherited; merge groups do not provision Neon.'
+    );
+  });
+
+  it('keeps merge groups out of PR-only and deployment jobs', () => {
+    expect(getJobBlock(CI_WORKFLOW, 'neon-db')).toContain(
+      "github.event_name == 'push' || (github.event_name == 'pull_request'"
+    );
+    expect(getJobBlock(CI_WORKFLOW, 'ci-pr-vercel-preview')).toContain(
+      "github.event_name == 'pull_request'"
+    );
+    expect(getJobBlock(CI_WORKFLOW, 'ci-summary')).toContain(
+      "github.event_name == 'pull_request'"
+    );
+
+    for (const job of ['deploy-gate', 'deploy-staging']) {
+      const block = getJobBlock(CI_WORKFLOW, job);
+      expect(block).toContain("github.event_name == 'push'");
+      expect(block).toContain("github.ref == 'refs/heads/main'");
+    }
+
+    const promotion = getJobBlock(CI_WORKFLOW, 'promote-production');
+    expect(promotion).toContain(
+      'needs: [deploy-staging, canary-health-gate, alias-staging]'
+    );
+    expect(promotion).toContain("needs.deploy-staging.result == 'success'");
+
+    for (const job of [
+      'canary-health-gate',
+      'alias-staging',
+      'promote-production',
+    ]) {
+      expect(getJobBlock(CI_WORKFLOW, job)).toContain(
+        "needs.deploy-staging.result == 'success'"
+      );
+    }
+
+    const deployNotify = getJobBlock(CI_WORKFLOW, 'deploy-notify');
+    expect(deployNotify).toContain("github.event_name == 'push'");
+    expect(deployNotify).toContain("github.ref == 'refs/heads/main'");
+  });
+
+  it('emits the metadata-only required contexts on the combined head', () => {
+    expect(FORK_GATE_WORKFLOW).toMatch(
+      /merge_group:\n\s+types: \[checks_requested\]/
+    );
+    const forkGate = getJobBlock(FORK_GATE_WORKFLOW, 'merge-group-gate');
+    expect(forkGate).toContain('name: Fork PR Gate');
+    expect(forkGate).toContain("github.event_name == 'merge_group'");
+    expect(forkGate).not.toContain('github.event.pull_request');
+
+    expect(SIZE_GUARD_WORKFLOW).toMatch(
+      /merge_group:\n\s+types: \[checks_requested\]/
+    );
+    const sizeGuard = getJobBlock(SIZE_GUARD_WORKFLOW, 'merge-group-size');
+    expect(sizeGuard).toContain('name: PR Size Guard');
+    expect(sizeGuard).toContain("github.event_name == 'merge_group'");
+    expect(sizeGuard).not.toContain('github.event.pull_request');
+    expect(getJobBlock(SIZE_GUARD_WORKFLOW, 'size')).toContain(
+      "github.event_name == 'pull_request'"
+    );
+  });
+});

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   bisectBatchFailure,
+  ciWorkflowHasMergeGroupTrigger,
   compareRatchetCounts,
   detectChangedFileOverlap,
   detectIssueOverlap,
@@ -376,6 +377,10 @@ describe('aggregate required checks', () => {
 
     expect(result.errors).toEqual([]);
     expect(result.ok).toBe(true);
+    expect(ciWorkflowHasMergeGroupTrigger(ciWorkflowYaml)).toBe(true);
+    expect(result.warnings).toContain(
+      'ci.yml declares inert merge_group compatibility; Graphite remains the active queue until the ruleset/backend changes'
+    );
     expect(parseRequiredStatusChecksFromYaml(branchProtectionYaml)).toEqual([
       'CI / PR Ready',
       'CI / Migration Guard',

--- a/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
+++ b/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
@@ -97,7 +97,7 @@ describe('pr-size-guard workflow invariants (JOV-3580 + label override)', () => 
     expect(workflow).toContain('types: [opened, synchronize, reopened]');
     expect(workflow).not.toMatch(/types:\s*\[[^\]]*labeled/);
     expect(workflow).toContain(
-      'group: pr-size-${{ github.event.pull_request.number }}'
+      "group: pr-size-${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.number }}"
     );
     expect(workflow).toContain('cancel-in-progress: true');
     expect(workflow).toContain('JOV-3580');
@@ -116,13 +116,7 @@ describe('pr-size-guard workflow invariants (JOV-3580 + label override)', () => 
     );
     expect(workflow).toContain('node scripts/lib/pr-size-guard-policy.mjs');
     expect(workflow).toContain('checks: write');
-    expect(workflow).toContain(
-      'ref: ${{ github.event.pull_request.base.sha }}'
-    );
     expect(workflow).toContain('persist-credentials: false');
-    expect(workflow).not.toContain(
-      'ref: ${{ github.event.pull_request.head.sha }}'
-    );
     expect(workflow).toContain(
       'group: pr-size-label-override-${{ github.event.pull_request.number }}'
     );
@@ -132,6 +126,22 @@ describe('pr-size-guard workflow invariants (JOV-3580 + label override)', () => 
     );
     expect(workflow).toContain('node scripts/pr-size-guard-label-override.mjs');
     expect(workflow).toContain('JOV-3580');
+  });
+
+  it('executes checks-write policy code from the immutable workflow commit', () => {
+    const workflow = readFileSync(OVERRIDE_WORKFLOW, 'utf8');
+
+    expect(workflow).toContain('ref: ${{ github.workflow_sha }}');
+    expect(workflow).toContain(
+      'exact trusted commit that supplied this workflow'
+    );
+    expect(workflow).toContain('stale PR base or PR-controlled head');
+    expect(workflow).not.toContain(
+      'ref: ${{ github.event.pull_request.base.sha }}'
+    );
+    expect(workflow).not.toContain(
+      'ref: ${{ github.event.pull_request.head.sha }}'
+    );
   });
 
   it('does not skip the job before supported-label step conditions can run', () => {

--- a/scripts/lib/merge-queue-guard.mjs
+++ b/scripts/lib/merge-queue-guard.mjs
@@ -700,8 +700,8 @@ export function validateMergeQueueRepoConfig(input) {
   }
 
   if (ciWorkflowHasMergeGroupTrigger(input.ciWorkflowYaml)) {
-    errors.push(
-      'ci.yml must not declare merge_group trigger (Graphite never creates merge_group events)'
+    warnings.push(
+      'ci.yml declares inert merge_group compatibility; Graphite remains the active queue until the ruleset/backend changes'
     );
   }
 


### PR DESCRIPTION
## Summary

- Accept GitHub `merge_group/checks_requested` events without changing the active Graphite backend.
- Validate the synthetic combined head through path/risk classification, fast/static checks, affected unit tests, build, and layout evidence, then emit the required `PR Ready` context.
- Emit the other required combined-head contexts: `Migration Guard`, `Fork PR Gate`, and `PR Size Guard`.
- Keep PR-only Neon/a11y/preview work and every production deployment job out of merge-group runs.
- Add a fixture-backed workflow contract and update the repository merge-queue guard/docs to distinguish compatibility from activation.

## Safety and sequencing

This PR does **not** enable the GitHub native queue, mutate ruleset `10512119`, disable Graphite, ready itself, or merge anything.

The separate heavy-evidence aggregate change at commit `30dea08b0c` must land first. After it lands, rebase/update this PR onto current `main` and rerun exact-head CI before cutover. That keeps source-PR smoke/Golden/Lighthouse evidence in `PR Ready` while this PR supplies combined-head compatibility.

## Required-context contract

- `PR Ready`: real combined-head path/risk/static/unit/build/layout fan-in
- `Migration Guard`: existing path-gated migration validation runs on `merge_group`
- `Fork PR Gate`: metadata-only pass; every member was checked before enqueue
- `PR Size Guard`: metadata-only pass; every member was checked before enqueue

## Verification

- [x] Queue workflow contracts: 44/44 passed
- [x] `pnpm ci:merge-queue:check`
- [x] `pnpm ci:harness:check`
- [x] actionlint with repository shellcheck policy
- [x] Biome
- [x] Tailwind guard
- [x] Web TypeScript check
- [x] Signed commit and non-bypassed pre-push gate

## Safe cutover after merge

1. Confirm the heavy-evidence PR and this compatibility PR are both on `main` and main CI is green.
2. Add the native `merge_queue` rule while preserving the four required contexts; start with squash, one PR per merge group, five concurrent builds, all-green grouping, and a 60-minute check timeout.
3. Enqueue one low-risk canary and verify all four contexts attach to the `gh-readonly-queue/main/...` combined SHA; verify no deploy/Neon PR-only jobs run.
4. Only after the canary merges cleanly, disable Graphite enrollment/label mutation and remove its ruleset bypass/coupling in a separate cleanup PR.
5. Drain stale Graphite entries/refs, then widen native grouping only from measured green throughput.

No Linear issue — ad-hoc queue migration work explicitly approved by the user.