### PR TITLE
fix(ci): restore runner process headroom

### DIFF
--- a/.github/runner-host/README.md
+++ b/.github/runner-host/README.md
@@ -1,0 +1,36 @@
+# Gem runner host contract
+
+These files are the versioned slice deployment source for the Gem
+ephemeral-runner host. The pool remains capped at 10 containers, 2 CPUs and 4
+GiB per container. The service snapshot is documentation only: model routing
+and other live service state are separately managed and the installer never
+copies or restarts the service.
+
+## Failure record
+
+GitHub jobs `87010591966` and `87010591983` completed all test assertions, then
+Vitest worker creation failed with `spawn ... node EAGAIN`. At diagnosis time,
+`ci-runners.slice` was at 852/1,024 tasks (later observed at 958/1,024), while
+host PID/thread limits, memory, CPU and load still had headroom. The failure is
+dependency/environment drift: an obsolete slice-wide `TasksMax=1024` ceiling,
+not a PR-specific test failure or flaky assertion.
+
+The 2,048 limit is intentionally conservative: it is more than twice the
+observed ten-runner demand, remains far below host PID/thread limits, and does
+not increase the autoscaler maximum above 10. The diagnostic reports warning at
+80% and critical at 90%, before Node reaches `EAGAIN`.
+
+## Review and cutover
+
+The installer is dry-run unless `--apply` is provided. Applying the TasksMax
+property is live and does not restart the autoscaler or runner containers:
+
+```bash
+ssh gem 'cd /path/to/Jovie && sudo .github/runner-host/install-capacity-contract.sh --apply'
+```
+
+Verify afterward with:
+
+```bash
+ssh gem 'cd /path/to/Jovie && .github/runner-host/diagnose-capacity.sh'
+```

--- a/.github/runner-host/ci-runner-autoscaler.service.snapshot
+++ b/.github/runner-host/ci-runner-autoscaler.service.snapshot
@@ -1,0 +1,27 @@
+# Reference snapshot only. The capacity installer MUST NOT install this file.
+# The live root-owned service and its drop-ins contain separately managed model
+# routing state; this snapshot documents the reviewed resource envelope.
+
+[Unit]
+Description=CI Runner Autoscaler — ephemeral Docker runners for Jovie CI
+After=docker.service ci-runners.slice
+BindsTo=ci-runners.slice
+
+[Service]
+Type=exec
+User=timwhite
+Group=docker
+WorkingDirectory=/opt/ci-runner-autoscaler
+ExecStart=/usr/bin/tsx /opt/ci-runner-autoscaler/index.ts
+Restart=always
+RestartSec=5
+CPUQuota=800%
+MemoryMax=48G
+Environment=AUTOSCALER_MAX_RUNNERS=10
+Environment=AUTOSCALER_RUNNER_CPUS=2
+Environment=AUTOSCALER_RUNNER_MEMORY_MB=4096
+Environment=AUTOSCALER_RUNNER_LABELS=self-hosted,Linux,X64,jovie-runner,jovie-ephemeral,ephemeral
+Environment=AUTOSCALER_CGROUP_PARENT=ci-runners.slice
+
+# Model routes and credentials are intentionally omitted. They are unrelated to
+# process capacity and remain owned by the live service/drop-in configuration.

--- a/.github/runner-host/ci-runners.slice
+++ b/.github/runner-host/ci-runners.slice
@@ -1,0 +1,13 @@
+# Versioned resource envelope for Gem's ephemeral CI containers.
+# Ten runners have been observed at 958 tasks in aggregate. A 2,048-task
+# ceiling preserves >2x measured headroom without increasing runner count.
+
+[Unit]
+Description=CI Runner Resource Slice
+Before=ci-runner-autoscaler.service
+Wants=ci-runner-autoscaler.service
+
+[Slice]
+CPUQuota=1600%
+MemoryMax=50G
+TasksMax=2048

--- a/.github/runner-host/diagnose-capacity.sh
+++ b/.github/runner-host/diagnose-capacity.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current="${RUNNER_TASKS_CURRENT:-}"
+maximum="${RUNNER_TASKS_MAX:-}"
+
+if [[ -z "$current" || -z "$maximum" ]]; then
+  current="$(systemctl show ci-runners.slice --property TasksCurrent --value)"
+  maximum="$(systemctl show ci-runners.slice --property TasksMax --value)"
+fi
+
+if ! [[ "$current" =~ ^[0-9]+$ && "$maximum" =~ ^[1-9][0-9]*$ ]]; then
+  echo "runner_tasks_status=unknown"
+  echo "runner_tasks_detail=invalid TasksCurrent/TasksMax: current=$current max=$maximum"
+  exit 2
+fi
+
+ratio=$((current * 100 / maximum))
+status=ok
+if (( ratio >= 90 )); then
+  status=critical
+elif (( ratio >= 80 )); then
+  status=warning
+fi
+
+echo "runner_tasks_status=$status"
+echo "runner_tasks_current=$current"
+echo "runner_tasks_max=$maximum"
+echo "runner_tasks_ratio_pct=$ratio"
+echo "runner_failure_class=dependency-or-environment-drift"
+
+if [[ "$status" != "ok" ]]; then
+  echo "runner_tasks_remediation=ci-runners.slice is saturated; verify the versioned TasksMax contract before retrying CI"
+  exit 1
+fi

--- a/.github/runner-host/install-capacity-contract.sh
+++ b/.github/runner-host/install-capacity-contract.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly EXPECTED_TASKS_MAX=2048
+readonly EXPECTED_MAX_RUNNERS=10
+readonly SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "${1:-}" != "--apply" ]]; then
+  echo "Dry run: no host state changed."
+  echo "Would install $SOURCE_DIR/ci-runners.slice"
+  echo "Would set ci-runners.slice TasksMax=$EXPECTED_TASKS_MAX"
+  exit 0
+fi
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "ERROR: --apply must run as root" >&2
+  exit 2
+fi
+
+service_environment="$(
+  systemctl show ci-runner-autoscaler.service --property Environment --value
+)"
+if ! grep -Eq \
+  "(^| )AUTOSCALER_MAX_RUNNERS=$EXPECTED_MAX_RUNNERS( |$)" \
+  <<< "$service_environment"; then
+  echo "ERROR: live service must keep max runners at $EXPECTED_MAX_RUNNERS" >&2
+  exit 3
+fi
+
+install -m 0644 "$SOURCE_DIR/ci-runners.slice" /etc/systemd/system/ci-runners.slice
+systemctl daemon-reload
+
+# The live host may have a systemctl-generated control drop-in. Updating the
+# property keeps that higher-precedence drop-in aligned with the versioned unit.
+# TasksMax is mutable at runtime, so runner jobs are not interrupted.
+systemctl set-property ci-runners.slice "TasksMax=$EXPECTED_TASKS_MAX"
+
+actual="$(systemctl show ci-runners.slice --property TasksMax --value)"
+if [[ "$actual" != "$EXPECTED_TASKS_MAX" ]]; then
+  echo "ERROR: effective TasksMax=$actual; expected $EXPECTED_TASKS_MAX" >&2
+  exit 4
+fi
+
+echo "Installed runner host contract; TasksMax=$actual, max runners=$EXPECTED_MAX_RUNNERS"
+echo "Autoscaler was not restarted."

--- a/apps/web/tests/unit/ci/runner-host-capacity.test.ts
+++ b/apps/web/tests/unit/ci/runner-host-capacity.test.ts
@@ -1,0 +1,89 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { classifyOperationalFailure } from '../../../../../scripts/hermes/jobs/ci-failure-signatures';
+
+const repoRoot = resolve(import.meta.dirname, '../../../../..');
+const readHostFile = (name: string) =>
+  readFileSync(resolve(repoRoot, '.github/runner-host', name), 'utf8');
+
+describe('Gem runner process-capacity contract', () => {
+  it('keeps ten runners while providing measured task headroom', () => {
+    expect(readHostFile('ci-runners.slice')).toContain('TasksMax=2048');
+    const service = readHostFile('ci-runner-autoscaler.service.snapshot');
+    expect(service).toContain('Environment=AUTOSCALER_MAX_RUNNERS=10');
+    expect(service).toContain('Environment=AUTOSCALER_RUNNER_CPUS=2');
+    expect(service).toContain('Environment=AUTOSCALER_RUNNER_MEMORY_MB=4096');
+  });
+
+  it('changes only the slice and preserves the live autoscaler service', () => {
+    const installer = readHostFile('install-capacity-contract.sh');
+    expect(installer).toContain(
+      'systemctl show ci-runner-autoscaler.service --property Environment --value'
+    );
+    expect(installer).toContain('AUTOSCALER_MAX_RUNNERS=$EXPECTED_MAX_RUNNERS');
+    expect(installer).toContain(
+      'install -m 0644 "$SOURCE_DIR/ci-runners.slice" /etc/systemd/system/ci-runners.slice'
+    );
+    expect(installer).not.toContain(
+      '/etc/systemd/system/ci-runner-autoscaler.service'
+    );
+    expect(installer).not.toMatch(/systemctl (?:re)?start/u);
+  });
+
+  it('diagnoses saturation before the kernel rejects worker creation', () => {
+    const diagnostic = resolve(
+      repoRoot,
+      '.github/runner-host/diagnose-capacity.sh'
+    );
+    const saturated = spawnSync(diagnostic, [], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        RUNNER_TASKS_CURRENT: '958',
+        RUNNER_TASKS_MAX: '1024',
+      },
+    });
+    expect(saturated.status).toBe(1);
+    expect(saturated.stdout).toContain('runner_tasks_status=critical');
+    expect(saturated.stdout).toContain('runner_tasks_ratio_pct=93');
+    expect(saturated.stdout).toContain(
+      'runner_failure_class=dependency-or-environment-drift'
+    );
+
+    const repaired = spawnSync(diagnostic, [], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        RUNNER_TASKS_CURRENT: '958',
+        RUNNER_TASKS_MAX: '2048',
+      },
+    });
+    expect(repaired.status).toBe(0);
+    expect(repaired.stdout).toContain('runner_tasks_status=ok');
+    expect(repaired.stdout).toContain('runner_tasks_ratio_pct=46');
+  });
+
+  it('classifies Node EAGAIN as runner capacity, not a test assertion', () => {
+    expect(
+      classifyOperationalFailure(
+        'Caused by: Error: spawn /opt/hostedtoolcache/node/22.23.1/x64/bin/node EAGAIN'
+      )
+    ).toMatchObject({
+      id: 'runner-process-capacity',
+      category: 'dependency-or-environment-drift',
+    });
+    expect(
+      classifyOperationalFailure('AssertionError: expected 1 to be 2')
+    ).toBe(null);
+  });
+
+  it('classifies proactive slice saturation diagnostics', () => {
+    expect(
+      classifyOperationalFailure(
+        'runner_tasks_status=critical\nrunner_tasks_ratio_pct=93'
+      )
+    ).toMatchObject({ id: 'runner-process-capacity' });
+  });
+});

--- a/scripts/hermes/jobs/ci-failure-monitor.ts
+++ b/scripts/hermes/jobs/ci-failure-monitor.ts
@@ -17,6 +17,7 @@ import { ensureJovieRepoCwd } from '../lib/ensure-jovie-repo-cwd';
 import { gbrainLearn, gbrainSlug } from '../lib/gbrain';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
 import { buildFollowUpBody, fileIssue } from '../lib/tracker-client';
+import { classifyOperationalFailure } from './ci-failure-signatures';
 
 const JOB = 'ci-failure-monitor';
 
@@ -110,6 +111,7 @@ async function processFailure(
 ): Promise<void> {
   const log = logsForRun(run.databaseId);
   const known = classifyAgainstKnown(log, run.workflowName, flakes);
+  const operational = classifyOperationalFailure(log);
 
   if (known) {
     logJobEvent({
@@ -127,7 +129,9 @@ async function processFailure(
     description: buildFollowUpBody({
       source: `ci-failure-monitor`,
       sourceUrl: run.url,
-      followUp: `Workflow "${run.workflowName}" failed on main at ${run.createdAt}. Title: ${run.displayTitle}. Investigate root cause; if it's a known flake, add a signature to scripts/hermes/jobs/known-flakes.json so future runs auto-classify.`,
+      followUp: operational
+        ? `Workflow "${run.workflowName}" failed on main at ${run.createdAt}. Deterministic classification: ${operational.id} (${operational.category}). Root cause: ${operational.rootCause} Remediation: ${operational.remediation}`
+        : `Workflow "${run.workflowName}" failed on main at ${run.createdAt}. Title: ${run.displayTitle}. Investigate root cause; if it's a known flake, add a signature to scripts/hermes/jobs/known-flakes.json so future runs auto-classify.`,
       whyItMatters:
         'Unclassified CI failures on main block deploys and erode trust in the merge gate.',
       classification: 'Required',
@@ -151,8 +155,12 @@ async function processFailure(
   gbrainLearn({
     slug: `ci-failures/${gbrainSlug(run.workflowName)}`,
     title: `CI failure: ${run.workflowName} on main`,
-    body: `Workflow "${run.workflowName}" failed on main.\n\n- Latest run: ${run.databaseId} (${run.createdAt})\n- Title: ${run.displayTitle}\n- URL: ${run.url}\n- Linear: ${filed.identifier ?? 'not filed'}`,
-    tags: ['type:ci-failure', `workflow:${gbrainSlug(run.workflowName)}`],
+    body: `Workflow "${run.workflowName}" failed on main.\n\n- Latest run: ${run.databaseId} (${run.createdAt})\n- Title: ${run.displayTitle}\n- URL: ${run.url}\n- Classification: ${operational?.id ?? 'unknown'}\n- Root cause: ${operational?.rootCause ?? 'unclassified'}\n- Remediation: ${operational?.remediation ?? 'investigate'}\n- Linear: ${filed.identifier ?? 'not filed'}`,
+    tags: [
+      'type:ci-failure',
+      `workflow:${gbrainSlug(run.workflowName)}`,
+      ...(operational ? [`failure:${operational.id}`] : []),
+    ],
     type: 'ci-failure',
   });
 }

--- a/scripts/hermes/jobs/ci-failure-signatures.ts
+++ b/scripts/hermes/jobs/ci-failure-signatures.ts
@@ -1,0 +1,27 @@
+export interface OperationalFailureSignature {
+  readonly id: string;
+  readonly category: string;
+  readonly rootCause: string;
+  readonly remediation: string;
+}
+
+const RUNNER_PROCESS_CAPACITY: OperationalFailureSignature = {
+  id: 'runner-process-capacity',
+  category: 'dependency-or-environment-drift',
+  rootCause:
+    'A self-hosted runner exhausted its systemd slice task ceiling; Node worker spawn returned EAGAIN.',
+  remediation:
+    'Run .github/runner-host/diagnose-capacity.sh and restore the versioned ci-runners.slice TasksMax contract before retrying CI.',
+};
+
+export function classifyOperationalFailure(
+  log: string
+): OperationalFailureSignature | null {
+  if (
+    /(?:spawn|fork)[^\n]*\bEAGAIN\b/i.test(log) ||
+    /runner_tasks_status=(?:warning|critical)/i.test(log)
+  ) {
+    return RUNNER_PROCESS_CAPACITY;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- version Gem's systemd slice deployment contract while preserving the separately managed autoscaler service
- raise only the slice task ceiling from 1,024 to 2,048 and diagnose saturation at 80%/90%
- classify Node `spawn ... EAGAIN` and slice saturation deterministically in Gem's CI failure monitor

## Root cause
Jobs 87010591966 and 87010591983 completed their assertions, then Vitest worker forks failed with Node `EAGAIN`. `ci-runners.slice` was observed at 852/1,024 tasks and later 958/1,024. Host PID/thread limits, CPU, load, and memory still had headroom. This is dependency/environment drift plus missing versioned host automation, not a PR assertion failure or flaky CI.

The live host also had divergent sources: stale `/home` units (8 runners/512 tasks), hand-edited `/etc` units (10/1,024), and a separate `/opt` daemon revision. This PR makes the slice deployment envelope reviewable. The service file is a non-installed reference snapshot; its root-owned model/drop-in state is preserved.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/runner-host-capacity.test.ts` (5/5)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm ci:harness:check`
- `pnpm ci:control:test` (112/112)
- `pnpm test:bug-to-test`
- `bash scripts/hooks/pre-push-gate.sh affected`
- `bash -n .github/runner-host/*.sh`
- systemd units verified on Gem with `systemd-analyze verify` (only unrelated netplan permission warning)
- installer dry-run; live Gem config was not changed

## Cutover after review
```bash
ssh gem 'cd /path/to/Jovie && sudo .github/runner-host/install-capacity-contract.sh --apply && .github/runner-host/diagnose-capacity.sh'
```

The installer first verifies the live service remains capped at 10, installs only `ci-runners.slice`, and applies its live-mutable TasksMax property. It neither replaces nor restarts the autoscaler service or runner containers.

## Cost Impact
No new runners, scheduled jobs, external API calls, or memory/CPU allocation. This only restores process headroom inside the existing 10-runner slice.
