### PR TITLE
fix(agents): diagnose invalid gate artifacts

### DIFF
--- a/apps/web/lib/agent-os/gate-evidence.ts
+++ b/apps/web/lib/agent-os/gate-evidence.ts
@@ -20,11 +20,24 @@ interface ArtifactCommentSlice {
   readonly rawJson: string;
 }
 
+export interface AgentRunArtifactIssue {
+  readonly artifactIndex: number;
+  readonly kind: 'malformed-json' | 'schema-invalid';
+  readonly sourceRunId?: string;
+  readonly details: readonly string[];
+}
+
+interface AgentRunArtifactExtraction {
+  readonly artifacts: readonly AgentRunArtifact[];
+  readonly issues: readonly AgentRunArtifactIssue[];
+}
+
 export interface GateEvidenceEvaluation {
   readonly passed: boolean;
   readonly missingGateNames: readonly AgentRunGateEvidenceName[];
   readonly passedGateNames: readonly AgentRunGateEvidenceName[];
   readonly artifacts: readonly AgentRunArtifact[];
+  readonly artifactIssues: readonly AgentRunArtifactIssue[];
 }
 
 export interface GateEvidenceEvaluationOptions {
@@ -41,9 +54,18 @@ function advanceSearchAfterMalformed(commentStart: number): number {
   return commentStart + 1;
 }
 
-function parseArtifactFromSlice(rawJson: string): AgentRunArtifact | null {
-  const parsed = safeParseAgentRunArtifact(JSON.parse(rawJson));
-  return parsed.success ? parsed.data : null;
+function readSourceRunId(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const sourceRunId = Reflect.get(value, 'sourceRunId');
+  return typeof sourceRunId === 'string' ? sourceRunId : undefined;
+}
+
+function formatSchemaIssue(issue: {
+  readonly path: PropertyKey[];
+  readonly message: string;
+}): string {
+  const path = issue.path.map(String).join('.');
+  return path ? `${path}: ${issue.message}` : issue.message;
 }
 
 function hasCompleteJsonSlice(rawJson: string): boolean {
@@ -96,14 +118,23 @@ function findCommentEndWithRecovery(
 export function extractAgentRunArtifactsFromMarkdown(
   markdown: string
 ): AgentRunArtifact[] {
+  return [...extractAgentRunArtifactReport(markdown).artifacts];
+}
+
+export function extractAgentRunArtifactReport(
+  markdown: string
+): AgentRunArtifactExtraction {
   const artifacts: AgentRunArtifact[] = [];
+  const issues: AgentRunArtifactIssue[] = [];
   let searchStart = 0;
+  let artifactIndex = 0;
 
   while (searchStart < markdown.length) {
     const commentStart = markdown.indexOf(ARTIFACT_COMMENT_START, searchStart);
     if (commentStart === -1) {
       break;
     }
+    artifactIndex += 1;
 
     const jsonStart = commentStart + ARTIFACT_COMMENT_START.length;
     const commentSlice = findCommentEndWithRecovery(
@@ -114,16 +145,31 @@ export function extractAgentRunArtifactsFromMarkdown(
     searchStart = commentSlice.nextSearchStart;
 
     if (commentSlice.aborted || !commentSlice.rawJson) {
+      issues.push({
+        artifactIndex,
+        kind: 'malformed-json',
+        details: [
+          'Artifact comment is unclosed, empty, or contains invalid JSON.',
+        ],
+      });
       continue;
     }
 
-    const artifact = parseArtifactFromSlice(commentSlice.rawJson);
-    if (artifact) {
-      artifacts.push(artifact);
+    const input = JSON.parse(commentSlice.rawJson) as unknown;
+    const parsed = safeParseAgentRunArtifact(input);
+    if (parsed.success) {
+      artifacts.push(parsed.data);
+    } else {
+      issues.push({
+        artifactIndex,
+        kind: 'schema-invalid',
+        sourceRunId: readSourceRunId(input),
+        details: parsed.error.issues.map(formatSchemaIssue),
+      });
     }
   }
 
-  return artifacts;
+  return { artifacts, issues };
 }
 
 function gateHasRecordedEvidence(gate: VerificationGate): boolean {
@@ -148,10 +194,17 @@ export function evaluateAgentRunGateEvidence(
   requiredGateNames: readonly AgentRunGateEvidenceName[] = REQUIRED_NON_DRY_RUN_GSTACK_GATES,
   options: GateEvidenceEvaluationOptions = {}
 ): GateEvidenceEvaluation {
-  const artifacts = extractAgentRunArtifactsFromMarkdown(markdown).filter(
+  const extraction = extractAgentRunArtifactReport(markdown);
+  const artifacts = extraction.artifacts.filter(
     artifact =>
       options.sourceRunId === undefined ||
       artifact.sourceRunId === options.sourceRunId
+  );
+  const artifactIssues = extraction.issues.filter(
+    issue =>
+      options.sourceRunId === undefined ||
+      issue.sourceRunId === undefined ||
+      issue.sourceRunId === options.sourceRunId
   );
   const requiredGateNameSet = new Set(requiredGateNames);
   const latestGateState = new Map<
@@ -194,10 +247,11 @@ export function evaluateAgentRunGateEvidence(
   );
 
   return {
-    passed: missingGateNames.length === 0,
+    passed: missingGateNames.length === 0 && artifactIssues.length === 0,
     missingGateNames,
     passedGateNames,
     artifacts,
+    artifactIssues,
   };
 }
 
@@ -208,5 +262,22 @@ export function buildGateEvidenceSummary(
     return `Recorded gate evidence found for: ${evaluation.passedGateNames.join(', ')}`;
   }
 
-  return `Missing recorded gate evidence for: ${evaluation.missingGateNames.join(', ')}`;
+  const lines: string[] = [];
+  if (evaluation.artifactIssues.length > 0) {
+    lines.push('Invalid agent-run artifact evidence:');
+    for (const issue of evaluation.artifactIssues) {
+      lines.push(
+        `- artifact #${issue.artifactIndex} (${issue.kind}): ${issue.details.join('; ')}`
+      );
+    }
+    lines.push(
+      'Preflight the replacement before commenting: pnpm --filter @jovie/web exec tsx scripts/prepare-agent-gate-evidence.ts <artifact.json>'
+    );
+  }
+  if (evaluation.missingGateNames.length > 0) {
+    lines.push(
+      `Missing recorded gate evidence for: ${evaluation.missingGateNames.join(', ')}`
+    );
+  }
+  return lines.join('\n');
 }

--- a/apps/web/scripts/prepare-agent-gate-evidence.ts
+++ b/apps/web/scripts/prepare-agent-gate-evidence.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env tsx
+
+import { readFileSync } from 'node:fs';
+import { safeParseAgentRunArtifact } from '../lib/agent-os/artifact';
+import { formatAgentRunArtifactComment } from '../lib/agent-os/gate-evidence';
+
+const artifactFile = process.argv[2];
+if (!artifactFile) {
+  console.error(
+    'Usage: prepare-agent-gate-evidence.ts <artifact.json>\nValidates JSON and prints comment-ready markdown to stdout.'
+  );
+  process.exit(2);
+}
+
+let input: unknown;
+try {
+  input = JSON.parse(readFileSync(artifactFile, 'utf8')) as unknown;
+} catch (error) {
+  console.error(
+    `Malformed artifact JSON: ${error instanceof Error ? error.message : String(error)}`
+  );
+  process.exit(1);
+}
+
+const parsed = safeParseAgentRunArtifact(input);
+if (!parsed.success) {
+  console.error('Schema-invalid agent-run artifact:');
+  for (const issue of parsed.error.issues) {
+    const path = issue.path.map(String).join('.');
+    console.error(`- ${path ? `${path}: ` : ''}${issue.message}`);
+  }
+  process.exit(1);
+}
+
+process.stdout.write(`${formatAgentRunArtifactComment(parsed.data)}\n`);

--- a/apps/web/tests/unit/agent-os/gate-evidence.test.ts
+++ b/apps/web/tests/unit/agent-os/gate-evidence.test.ts
@@ -115,6 +115,9 @@ describe('AgentOS gate evidence', () => {
 
     expect(evaluation.passed).toBe(false);
     expect(evaluation.artifacts).toEqual([]);
+    expect(evaluation.artifactIssues).toEqual([
+      expect.objectContaining({ kind: 'malformed-json' }),
+    ]);
   });
 
   it('continues after malformed artifact comments', () => {
@@ -127,8 +130,9 @@ describe('AgentOS gate evidence', () => {
       ].join('\n')
     );
 
-    expect(evaluation.passed).toBe(true);
+    expect(evaluation.passed).toBe(false);
     expect(evaluation.artifacts).toHaveLength(1);
+    expect(evaluation.artifactIssues).toHaveLength(1);
   });
 
   it('continues after schema-invalid artifact comments', () => {
@@ -141,8 +145,54 @@ describe('AgentOS gate evidence', () => {
       ].join('\n')
     );
 
-    expect(evaluation.passed).toBe(true);
+    expect(evaluation.passed).toBe(false);
     expect(evaluation.artifacts).toHaveLength(1);
+    expect(evaluation.artifactIssues).toEqual([
+      expect.objectContaining({ kind: 'schema-invalid' }),
+    ]);
+  });
+
+  it('reports exact invalid route and action paths instead of only missing gates', () => {
+    const invalid = JSON.stringify({
+      ...baseArtifact,
+      modelRoute: 'codex',
+      forbiddenActions: ['merge', 'mutate_ruleset'],
+    });
+    const evaluation = evaluateAgentRunGateEvidence(
+      `<!-- agent-run-artifact\n${invalid}\n-->`,
+      undefined,
+      { sourceRunId: '123' }
+    );
+
+    expect(evaluation.passed).toBe(false);
+    expect(evaluation.artifactIssues[0]?.details).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('modelRoute'),
+        expect.stringContaining('forbiddenActions.1'),
+      ])
+    );
+  });
+
+  it('does not let a stale invalid artifact block exact-head evidence', () => {
+    const stale = JSON.stringify({
+      ...baseArtifact,
+      sourceRunId: 'stale-sha',
+      modelRoute: 'codex',
+    });
+    const evaluation = evaluateAgentRunGateEvidence(
+      [
+        `<!-- agent-run-artifact\n${stale}\n-->`,
+        formatAgentRunArtifactComment({
+          ...baseArtifact,
+          sourceRunId: 'current-sha',
+        }),
+      ].join('\n'),
+      undefined,
+      { sourceRunId: 'current-sha' }
+    );
+
+    expect(evaluation.passed).toBe(true);
+    expect(evaluation.artifactIssues).toEqual([]);
   });
 
   it('continues after unclosed malformed artifact comments', () => {
@@ -154,8 +204,9 @@ describe('AgentOS gate evidence', () => {
       ].join('\n')
     );
 
-    expect(evaluation.passed).toBe(true);
+    expect(evaluation.passed).toBe(false);
     expect(evaluation.artifacts).toHaveLength(1);
+    expect(evaluation.artifactIssues).toHaveLength(1);
   });
 
   it('parses artifact comments when JSON strings contain comment terminators', () => {

--- a/scripts/lib/__tests__/merge-queue-backend.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-backend.test.mjs
@@ -23,7 +23,7 @@ const VALID_REPOSITORY = Object.freeze(
 );
 const VALID_RULESET = Object.freeze(
   JSON.parse(
-    `{"id":${RULESET_ID},"enforcement":"active","target":"branch","conditions":{"ref_name":{"include":["refs/heads/main"],"exclude":[]}},"bypass_actors":[{"actor_id":2934433,"actor_type":"Integration"}],"rules":[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false,"required_status_checks":[{"context":"PR Ready"},{"context":"Migration Guard"},{"context":"Fork PR Gate"},{"context":"PR Size Guard"}]}},{"type":"merge_queue","parameters":{"check_response_timeout_minutes":60,"grouping_strategy":"ALLGREEN","max_entries_to_build":2,"max_entries_to_merge":10,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":0}}]}`
+    `{"id":${RULESET_ID},"enforcement":"active","target":"branch","conditions":{"ref_name":{"include":["refs/heads/main"],"exclude":[]}},"bypass_actors":[],"rules":[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false,"required_status_checks":[{"context":"PR Ready"},{"context":"Migration Guard"},{"context":"Fork PR Gate"},{"context":"PR Size Guard"}]}},{"type":"merge_queue","parameters":{"check_response_timeout_minutes":60,"grouping_strategy":"ALLGREEN","max_entries_to_build":2,"max_entries_to_merge":10,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":0}}]}`
   )
 );
 const VALID_WORKFLOW = `name: CI
@@ -159,6 +159,22 @@ describe('native live preflight', () => {
     expect(result.errors).toContain('ruleset bypass_actors must be an array');
   });
 
+  it.each([
+    158384, 2934433,
+  ])('rejects non-empty bypass_actors including actor %s', actor_id => {
+    const result = validateNativePreflightEvidence({
+      ruleset: {
+        ...structuredClone(VALID_RULESET),
+        bypass_actors: [{ actor_id, actor_type: 'Integration' }],
+      },
+      repository: VALID_REPOSITORY,
+      workflowYaml: VALID_WORKFLOW,
+    });
+    expect(result.errors).toContain(
+      'ruleset bypass_actors must be empty before native enrollment'
+    );
+  });
+
   it('reports every unsafe activation condition instead of partially enabling native mode', () => {
     const invalidRuleset = structuredClone(VALID_RULESET);
     invalidRuleset.enforcement = 'evaluate';
@@ -185,7 +201,7 @@ describe('native live preflight', () => {
         'ruleset enforcement must be active',
         'ruleset must contain an active merge_queue rule',
         'ruleset is missing required checks: Migration Guard, Fork PR Gate, PR Size Guard',
-        'Graphite bypass actor must be absent before native enrollment',
+        'ruleset bypass_actors must be empty before native enrollment',
         'repository auto-merge must be enabled',
         'CI workflow must handle merge_group checks_requested',
       ])

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -387,6 +387,24 @@ describe('aggregate required checks', () => {
       'Fork PR Gate',
       'PR Size Guard',
     ]);
+
+    for (const bypass_actors of [
+      '{}',
+      '\n  - actor_id: 158384',
+      '\n  - actor_id: 2934433',
+    ]) {
+      const unsafe = validateMergeQueueRepoConfig({
+        backend: 'native',
+        branchProtectionYaml: branchProtectionYaml.replace(
+          'bypass_actors: []',
+          `bypass_actors: ${bypass_actors}`
+        ),
+        ciWorkflowYaml,
+      });
+      expect(unsafe.errors).toContain(
+        'branch-protection.yml native bypass_actors must be an empty array'
+      );
+    }
   });
 
   it('keeps Storybook A11y path-gated as a leaf and blocking through PR Ready', () => {
@@ -486,7 +504,7 @@ describe('aggregate required checks', () => {
       expect.arrayContaining([
         expect.stringContaining('must enable GitHub native merge_queue'),
         expect.stringContaining('must handle merge_group'),
-        expect.stringContaining('must remove the graphite-app bypass actor'),
+        expect.stringContaining('bypass_actors must be an empty array'),
       ])
     );
   });
@@ -533,6 +551,19 @@ describe('aggregate required checks', () => {
       );
     }
 
+    for (const actor_id of [158384, 2934433]) {
+      const unsafeBypass = validateLiveMergeQueueRuleset(
+        {
+          bypass_actors: [{ actor_id, actor_type: 'Integration' }],
+          rules: nativeRules,
+        },
+        { backend: 'native' }
+      );
+      expect(unsafeBypass.errors).toContain(
+        'live native ruleset bypass_actors must be empty'
+      );
+    }
+
     const unsafe = validateLiveMergeQueueRuleset(
       {
         bypass_actors: [{ actor_id: 158384, actor_type: 'Integration' }],
@@ -554,7 +585,7 @@ describe('aggregate required checks', () => {
       expect.arrayContaining([
         expect.stringContaining('SQUASH'),
         expect.stringContaining('max_entries_to_build'),
-        expect.stringContaining('still grants graphite-app bypass'),
+        expect.stringContaining('bypass_actors must be empty'),
       ])
     );
   });

--- a/scripts/lib/merge-queue-guard.mjs
+++ b/scripts/lib/merge-queue-guard.mjs
@@ -792,10 +792,12 @@ export function validateMergeQueueRepoConfig(input) {
   }
   if (
     backend === 'native' &&
-    /actor_id:\s*158384\b/i.test(input.branchProtectionYaml)
+    !/^\s*bypass_actors:\s*\[\s*\]\s*(?:#.*)?$/m.test(
+      input.branchProtectionYaml
+    )
   ) {
     errors.push(
-      'branch-protection.yml must remove the graphite-app bypass actor before native cutover'
+      'branch-protection.yml native bypass_actors must be an empty array'
     );
   }
 
@@ -886,10 +888,8 @@ export function validateLiveMergeQueueRuleset(ruleset, options = {}) {
       `live ruleset missing graphite-app bypass actor (id ${GRAPHITE_QUEUE_POLICY.graphiteBypassActorId})`
     );
   }
-  if (backend === 'native' && hasGraphiteBypass) {
-    errors.push(
-      `live ruleset still grants graphite-app bypass (id ${GRAPHITE_QUEUE_POLICY.graphiteBypassActorId})`
-    );
+  if (backend === 'native' && bypassActors.length > 0) {
+    errors.push('live native ruleset bypass_actors must be empty');
   }
 
   return {

--- a/scripts/merge-queue-backend.mjs
+++ b/scripts/merge-queue-backend.mjs
@@ -10,7 +10,6 @@ export const MERGE_QUEUE_BACKENDS = Object.freeze(['graphite', 'native']);
 const DEFAULT_REPOSITORY = 'JovieInc/Jovie';
 const DEFAULT_RULESET_ID = '10512119';
 const DEFAULT_BASE_BRANCH = 'main';
-const GRAPHITE_BYPASS_ACTOR_ID = '158384';
 const CI_WORKFLOW_PATH = '.github/workflows/ci.yml';
 const NATIVE_MUTATION_AUTHORIZATIONS = new Set([
   'merge-queue-autoenroll',
@@ -228,13 +227,6 @@ export function validateNativePreflightEvidence({
   );
   const bypassActors = ruleset?.bypass_actors;
   const hasValidBypassActors = Array.isArray(bypassActors);
-  const graphiteBypassPresent = hasValidBypassActors
-    ? bypassActors.some(
-        actor =>
-          actor?.actor_type === 'Integration' &&
-          String(actor?.actor_id) === GRAPHITE_BYPASS_ACTOR_ID
-      )
-    : false;
   const validations = {
     [`ruleset id must be ${rulesetId}`]:
       String(ruleset?.id ?? '') === String(rulesetId),
@@ -257,8 +249,8 @@ export function validateNativePreflightEvidence({
       ruleset?.rules?.find(rule => rule?.type === 'required_status_checks')
         ?.parameters?.strict_required_status_checks_policy === false,
     'ruleset bypass_actors must be an array': hasValidBypassActors,
-    'Graphite bypass actor must be absent before native enrollment':
-      !graphiteBypassPresent,
+    'ruleset bypass_actors must be empty before native enrollment':
+      !hasValidBypassActors || bypassActors.length === 0,
     [`repository default branch must be ${baseBranch}`]:
       repository?.default_branch === baseBranch,
     'repository auto-merge must be enabled':


### PR DESCRIPTION
## Summary
- report malformed JSON and exact Zod paths for schema-invalid agent-run artifacts instead of collapsing them to "missing gates"
- scope invalid-artifact diagnostics to the requested exact head so stale typo artifacts do not block valid current evidence
- add a deterministic preflight that validates artifact JSON and emits comment-ready markdown only when the schema passes

## Root cause
PRs #14358 and #14359 used `modelRoute: codex` instead of `codex-cli`; their forbidden-action metadata also included non-enum values. The evidence parser silently discarded schema-invalid artifacts, so Verify Draft misleadingly reported all three gates as missing. This is recurring missing automation, not missing test/review/ship evidence.

## Verification
- gate-evidence regression suite: 14/14
- valid preflight output revalidated against exact `AGENT_RUN_SOURCE_RUN_ID`
- invalid preflight reports exact `modelRoute` and `forbiddenActions.3` paths and exits non-zero
- web typecheck, Biome, bug-to-test, and non-bypassed pre-push gate passed

## Agent preflight
```bash
pnpm --filter @jovie/web exec tsx scripts/prepare-agent-gate-evidence.ts artifact.json > artifact-comment.md
AGENT_RUN_SOURCE_RUN_ID="$HEAD_SHA" pnpm --filter @jovie/web exec tsx scripts/check-agent-gate-evidence.ts artifact-comment.md
```
