### PR TITLE
fix(ci): validate robots wildcard groups

### DIFF
--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -421,7 +421,32 @@ jobs:
           robots_body=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" "${robots_url}$( [[ "$robots_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "")
           sitemap_body=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" "${sitemap_url}$( [[ "$sitemap_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "")
 
-          if echo "$robots_body" | grep -Eiq '^[[:space:]]*user-agent:[[:space:]]*\*[[:space:]]*$' && echo "$robots_body" | grep -Eiq '^[[:space:]]*disallow:[[:space:]]*/[[:space:]]*$' && ! echo "$robots_body" | grep -Eiq '^[[:space:]]*allow:[[:space:]]*/[[:space:]]*$'; then
+          robots_globally_blocked() {
+            awk '
+              function trim(value) { gsub(/^[[:space:]]+|[[:space:]]+$/, "", value); return value }
+              BEGIN { wildcard_group = 0; group_has_rules = 0; wildcard_disallow = 0; root_allow = 0 }
+              {
+                line = $0; sub(/\r$/, "", line); line = trim(line)
+                if (line == "" || substr(line, 1, 1) == "#") next
+                separator = index(line, ":"); if (separator == 0) next
+                directive = tolower(trim(substr(line, 1, separator - 1)))
+                value = trim(substr(line, separator + 1))
+                if (directive == "user-agent") {
+                  if (group_has_rules) { wildcard_group = 0; group_has_rules = 0 }
+                  if (tolower(value) == "*") wildcard_group = 1
+                  next
+                }
+                if (directive == "allow" || directive == "disallow") {
+                  group_has_rules = 1
+                  if (wildcard_group && directive == "allow" && value == "/") root_allow = 1
+                  if (wildcard_group && directive == "disallow" && value == "/") wildcard_disallow = 1
+                }
+              }
+              END { exit(wildcard_disallow && !root_allow ? 0 : 1) }
+            '
+          }
+
+          if printf '%s\n' "$robots_body" | robots_globally_blocked; then
             echo "❌ Canary failed: robots.txt globally blocks all crawlers with Disallow: /"
             echo "canary_status=failed_seo_robots" >> "$GITHUB_OUTPUT"
             exit 1

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -53,6 +54,25 @@ function getJobBlock(workflow: string, jobKey: string): string {
   }
 
   return block.join('\n');
+}
+
+function robotsGloballyBlocked(workflow: string, robotsBody: string): boolean {
+  const step = getStepBlock(workflow, 'Canary health check');
+  const start = step.indexOf('robots_globally_blocked() {');
+  const end = step.indexOf('\n\n          if printf', start);
+  expect(start).toBeGreaterThan(0);
+  expect(end).toBeGreaterThan(start);
+  const source = step
+    .slice(start, end)
+    .split('\n')
+    .map(line => line.replace(/^ {10}/, ''))
+    .join('\n');
+  return (
+    spawnSync('bash', ['-c', `${source}\nrobots_globally_blocked`], {
+      input: robotsBody,
+      encoding: 'utf8',
+    }).status === 0
+  );
 }
 
 describe('deploy workflow Vercel env resolution', () => {
@@ -314,6 +334,21 @@ describe('deploy workflow Vercel env resolution', () => {
 });
 
 describe('canary health gate workflow', () => {
+  it('associates production crawl rules with the wildcard group', () => {
+    const workflow = readFileSync(canaryWorkflowPath, 'utf8');
+    expect(robotsGloballyBlocked(workflow, 'User-agent: *\nDisallow: /')).toBe(
+      true
+    );
+    expect(
+      robotsGloballyBlocked(
+        workflow,
+        'User-agent: *\nDisallow:\n\nUser-agent: BadBot\nDisallow: /'
+      )
+    ).toBe(false);
+    expect(
+      robotsGloballyBlocked(workflow, 'User-agent: *\nDisallow: /\nAllow: /')
+    ).toBe(false);
+  });
   it('fails closed when the automation bypass secret is missing', () => {
     const workflow = readFileSync(canaryWorkflowPath, 'utf8');
     const canaryStep = getStepBlock(workflow, 'Canary health check');


### PR DESCRIPTION
Split from #14303. Associates Disallow/Allow rules with the User-agent: * group so another crawler group cannot cause a false global-block diagnosis. Focused deploy workflow tests pass. Draft gated; no merge.