### PR TITLE
fix(ci): make Vercel function closures self-contained

### DIFF
--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -25,6 +25,7 @@ export type CiFailureClass =
   | 'vercel_concurrent_build_queue'
   | 'layout_guard_contract_missing'
   | 'standalone_runtime_launcher_mismatch'
+  | 'vercel_prebuilt_function_closure_missing'
   | 'chat_composer_unsettled_entry_animation'
   | 'neon_endpoint_capacity_admission'
   | 'neon_probe_workspace_dependency_resolution'
@@ -84,6 +85,19 @@ const DIAGNOSES: ReadonlyArray<{
       'The dependency-free CI Risk Classifier exhausted its three-minute job budget restoring and extracting the full pnpm dependency cache before classification started.',
     remediation:
       'Remove dependency restore, pnpm fetch, and pnpm install from dependency-free gates; run the native Node classifier directly instead of blindly rerunning the same cache extraction.',
+  },
+  {
+    failureClass: 'vercel_prebuilt_function_closure_missing',
+    matches: log =>
+      /\/var\/task\/apps\/web\/\.next\/server/i.test(log) &&
+      (/(?:Cannot find module|Failed to load external module) ['"]?(?:require|import)-in-the-middle-[a-z0-9]+['"]?/i.test(
+        log
+      ) ||
+        /Cannot find package ['"]@opentelemetry\/sdk-node['"]/i.test(log)),
+    rootCause:
+      'The prebuilt Vercel function was deployed without repo-relative files referenced by its Build Output filePathMap. Transferring only .vercel/output between jobs can omit those traced runtime sources, so middleware fails before the health handler boots.',
+    remediation:
+      'Do not rerun or promote the unchanged prebuilt. Build and deploy in the same job and workspace so every filePathMap source remains available; never restore .vercel/output alone. Require the exact deployment to pass /api/health before promotion.',
   },
   {
     failureClass: 'staged_production_deployment_failed',

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -469,11 +469,40 @@ LIGHTHOUSE_FAILURE_CLASS=deterministic_assertion LIGHTHOUSE_ATTEMPT=1/3`);
     expect(diagnosis.remediation).toContain('fail closed');
   });
 
+  it('diagnoses a Vercel prebuilt whose cross-job artifact omitted traced runtime files', () => {
+    const failures = [
+      `failure_subtype=staged_production_canary_failed
+       Cannot find module 'require-in-the-middle-a99415fa67232f7f'
+       at /var/task/apps/web/.next/server/middleware.js`,
+      `Cannot find package '@opentelemetry/sdk-node' imported from
+       /var/task/apps/web/.next/server/chunks/observability.js`,
+    ];
+
+    const diagnoses = failures.map(diagnoseCiFailure);
+    expect(diagnoses.map(({ failureClass }) => failureClass)).toEqual([
+      'vercel_prebuilt_function_closure_missing',
+      'vercel_prebuilt_function_closure_missing',
+    ]);
+    expect(diagnoses[0]).toMatchObject({
+      rootCause: expect.stringMatching(/filePathMap.*\.vercel\/output/),
+      remediation: expect.stringMatching(
+        /Do not rerun.*same job and workspace.*\/api\/health/
+      ),
+    });
+  });
+
   it('does not infer a launcher mismatch from an unrelated missing module', () => {
     expect(
       diagnoseCiFailure(
         'Error: Failed to load external module require-in-the-middle-deadbeef'
       ).failureClass
+    ).toBe('unknown');
+    expect(
+      diagnoseCiFailure(`
+        Cannot find module 'require-in-the-middle-deadbeef'
+        Require stack:
+        - /home/runner/work/Jovie/Jovie/apps/web/.next/server/middleware.js
+      `).failureClass
     ).toBe('unknown');
   });
 


### PR DESCRIPTION
## Summary

- Normalize every Vercel Build Output function closure before the prebuilt artifact crosses jobs.
- Expand directory-valued `filePathMap` references into individual regular files inside `.vercel/output`.
- Fail closed on missing, escaping, cyclic, colliding, or non-materializable function inputs.
- Keep the affected-test lane focused on the closure, deployment, and Hermes regressions for this exact repair signature.

## Exact production root cause

Main CI run `29469099122`, canary job `87529828265`, reached staging but returned HTTP 500 on all 8 health attempts. The prebuilt function closure omitted the generated `require-in-the-middle-*` external required by middleware and instrumentation. A Vercel deployment could become `READY` while remaining unbootable because Build Output configs retained repo-relative or whole-directory `FileFsRef` entries that the cross-job artifact did not materialize as Lambda files.

The normalizer now expands those refs, dereferences files into a self-contained store under `.vercel/output`, validates configured handlers and path boundaries, and rewrites each function config before archiving. The regression reproduces Vercel directory hydration, proves the unchanged closure fails, and then boots the normalized hydrated handler offline.

## Verification

- Vercel closure regression: 5/5 passed.
- Deploy workflow regression: 49/49 passed.
- Hermes diagnosis and affected-test selector: 236/236 passed.
- Python prebuilt-deploy regression: 23/23 passed.
- Exact changed-file Biome, actionlint YAML/expression validation, and `git diff --check`: passed.
- Node `22.23.1`; pnpm `9.15.4`.
- Exact signed head: `d94231023ba74f0c5db3aeee8f6637b0e7c217a4` on main base `98900f4f726abc259eeb8bac15d41bb840b5e300`.
- PR Size counted range: 891 lines across 9 files, below the 1500-line cap.
- Authoritative exact-head GitHub CI: running; every required check remains mandatory.

## Merge controls

This remains an existing CI-recovery PR. The user waived GStack evidence for CI-recovery work only; no required GitHub check is waived. The `testing` and `gated` labels remain, and there is no `merge-queue` enrollment. This update does not merge, deploy, mutate runner hosts or rulesets, or rerun a workflow.

<!-- linear-issue-id:JOV-3461 -->