### PR TITLE
test(admin): mutation-verified investor-token CRUD + rate-limit coverage (JOV-4220)

### DIFF
--- a/apps/web/app/api/admin/investors/links/[id]/route.ts
+++ b/apps/web/app/api/admin/investors/links/[id]/route.ts
@@ -27,13 +27,32 @@ export async function PATCH(
     'stage',
     'notes',
     'isActive',
-    'expiresAt',
   ] as const;
 
   const updates: Record<string, unknown> = { updatedAt: new Date() };
   for (const field of allowedFields) {
     if (field in body) {
       updates[field] = body[field];
+    }
+  }
+
+  if ('expiresAt' in body) {
+    if (body.expiresAt === null) {
+      updates.expiresAt = null;
+    } else if (typeof body.expiresAt === 'string') {
+      const expiresAt = new Date(body.expiresAt);
+      if (Number.isNaN(expiresAt.getTime())) {
+        return NextResponse.json(
+          { error: 'expiresAt must be a valid date' },
+          { status: 400 }
+        );
+      }
+      updates.expiresAt = expiresAt;
+    } else {
+      return NextResponse.json(
+        { error: 'expiresAt must be a valid date' },
+        { status: 400 }
+      );
     }
   }
 

--- a/apps/web/app/api/admin/investors/links/route.ts
+++ b/apps/web/app/api/admin/investors/links/route.ts
@@ -43,8 +43,9 @@ export async function POST(request: Request) {
 
   const body = await request.json();
   const { label, investorName, email } = body;
+  const trimmedLabel = typeof label === 'string' ? label.trim() : '';
 
-  if (!label || typeof label !== 'string') {
+  if (!trimmedLabel) {
     return NextResponse.json({ error: 'Label is required' }, { status: 400 });
   }
 
@@ -54,7 +55,7 @@ export async function POST(request: Request) {
     .insert(investorLinks)
     .values({
       token,
-      label: label.trim(),
+      label: trimmedLabel,
       investorName: investorName?.trim() || null,
       email: email?.trim() || null,
     })

--- a/apps/web/tests/unit/api/admin/investors-links-id.test.ts
+++ b/apps/web/tests/unit/api/admin/investors-links-id.test.ts
@@ -1,0 +1,306 @@
+import { NextResponse } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireAdmin = vi.hoisted(() => vi.fn());
+const mockEq = vi.hoisted(() => vi.fn(() => 'eq-clause'));
+
+const { mockDb, mockUpdate, mockSet, mockReturning, mockDelete } = vi.hoisted(
+  () => {
+    const mockReturning = vi.fn();
+    const mockWhere = vi.fn(() => ({ returning: mockReturning }));
+    const mockSet = vi.fn(() => ({ where: mockWhere }));
+    const mockUpdate = vi.fn(() => ({ set: mockSet }));
+    // Tracked separately so a test can assert DELETE never calls a hard
+    // row-delete method (the route only ever calls db.update()).
+    const mockDelete = vi.fn();
+
+    return {
+      mockDb: { update: mockUpdate, delete: mockDelete },
+      mockUpdate,
+      mockSet,
+      mockReturning,
+      mockDelete,
+    };
+  }
+);
+
+vi.mock('@/lib/admin/middleware', () => ({
+  requireAdmin: mockRequireAdmin,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: mockDb,
+}));
+
+vi.mock('@/lib/db/schema/investors', () => ({
+  investorLinks: {
+    id: 'investor_links.id',
+    label: 'investor_links.label',
+    investorName: 'investor_links.investor_name',
+    email: 'investor_links.email',
+    stage: 'investor_links.stage',
+    notes: 'investor_links.notes',
+    isActive: 'investor_links.is_active',
+    expiresAt: 'investor_links.expires_at',
+    token: 'investor_links.token',
+    updatedAt: 'investor_links.updated_at',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: mockEq,
+}));
+
+import { DELETE, PATCH } from '@/app/api/admin/investors/links/[id]/route';
+
+function patchRequest(body: unknown) {
+  return new Request('http://localhost/api/admin/investors/links/link-1', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('PATCH /api/admin/investors/links/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(null); // authorized by default
+    mockReturning.mockResolvedValue([
+      { id: 'link-1', label: 'Updated Label', stage: 'engaged' },
+    ]);
+  });
+
+  it('rejects the request before touching the database when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    );
+
+    const res = await PATCH(
+      patchRequest({ label: 'New Label' }),
+      paramsFor('link-1')
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(data.error).toBe('Forbidden');
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('passes allowlisted fields through to the update payload', async () => {
+    const expiresAt = '2027-01-01T00:00:00.000Z';
+
+    await PATCH(
+      patchRequest({
+        label: 'New Label',
+        investorName: 'Jane Doe',
+        email: 'jane@example.com',
+        stage: 'engaged',
+        notes: 'Follow up next week',
+        isActive: false,
+        expiresAt,
+      }),
+      paramsFor('link-1')
+    );
+
+    expect(mockSet).toHaveBeenCalledTimes(1);
+    const updatePayload = mockSet.mock.calls[0][0];
+
+    expect(updatePayload).toMatchObject({
+      label: 'New Label',
+      investorName: 'Jane Doe',
+      email: 'jane@example.com',
+      stage: 'engaged',
+      notes: 'Follow up next week',
+      isActive: false,
+    });
+    expect(updatePayload.expiresAt).toEqual(new Date(expiresAt));
+    expect(updatePayload.updatedAt).toBeInstanceOf(Date);
+    expect(mockEq).toHaveBeenCalledWith('investor_links.id', 'link-1');
+  });
+
+  it('allows clearing expiresAt with null', async () => {
+    await PATCH(patchRequest({ expiresAt: null }), paramsFor('link-1'));
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresAt: null })
+    );
+  });
+
+  it.each([
+    'not-a-date',
+    123,
+  ])('rejects invalid expiresAt %j before touching the database', async expiresAt => {
+    const res = await PATCH(patchRequest({ expiresAt }), paramsFor('link-1'));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: 'expiresAt must be a valid date',
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('ignores a `token` field in the body — it is not in the update payload', async () => {
+    await PATCH(
+      patchRequest({
+        label: 'New Label',
+        token: 'attacker-supplied-token',
+      }),
+      paramsFor('link-1')
+    );
+
+    const updatePayload = mockSet.mock.calls[0][0];
+
+    expect(updatePayload).not.toHaveProperty('token');
+    expect(Object.keys(updatePayload).sort()).toEqual(
+      ['label', 'updatedAt'].sort()
+    );
+  });
+
+  it('ignores any other unlisted field in the body', async () => {
+    await PATCH(
+      patchRequest({
+        label: 'New Label',
+        id: 'attacker-supplied-id',
+        engagementScore: 999999,
+        createdAt: '2000-01-01T00:00:00.000Z',
+      }),
+      paramsFor('link-1')
+    );
+
+    const updatePayload = mockSet.mock.calls[0][0];
+
+    expect(updatePayload).not.toHaveProperty('id');
+    expect(updatePayload).not.toHaveProperty('engagementScore');
+    expect(updatePayload).not.toHaveProperty('createdAt');
+    expect(Object.keys(updatePayload).sort()).toEqual(
+      ['label', 'updatedAt'].sort()
+    );
+  });
+
+  it('only writes updatedAt when the body has no allowlisted fields', async () => {
+    await PATCH(patchRequest({ token: 'nope' }), paramsFor('link-1'));
+
+    const updatePayload = mockSet.mock.calls[0][0];
+    expect(Object.keys(updatePayload)).toEqual(['updatedAt']);
+  });
+
+  it('returns 404 when the link id does not exist and does not leak an update body', async () => {
+    mockReturning.mockResolvedValue([]);
+
+    const res = await PATCH(
+      patchRequest({ label: 'New Label' }),
+      paramsFor('missing-id')
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.error).toBe('Link not found');
+  });
+
+  it('returns the updated row as { link } with 200 on success', async () => {
+    const updatedRow = { id: 'link-1', label: 'New Label', stage: 'engaged' };
+    mockReturning.mockResolvedValue([updatedRow]);
+
+    const res = await PATCH(
+      patchRequest({ label: 'New Label' }),
+      paramsFor('link-1')
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ link: updatedRow });
+  });
+});
+
+describe('DELETE /api/admin/investors/links/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(null); // authorized by default
+    mockReturning.mockResolvedValue([
+      { id: 'link-1', isActive: false, label: 'Acme Ventures' },
+    ]);
+  });
+
+  it('rejects the request before touching the database when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    );
+
+    const res = await DELETE(
+      new Request('http://localhost/api/admin/investors/links/link-1', {
+        method: 'DELETE',
+      }),
+      paramsFor('link-1')
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('soft-deletes via db.update({ isActive: false }) — never a hard db.delete()', async () => {
+    await DELETE(
+      new Request('http://localhost/api/admin/investors/links/link-1', {
+        method: 'DELETE',
+      }),
+      paramsFor('link-1')
+    );
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockDelete).not.toHaveBeenCalled();
+
+    const updatePayload = mockSet.mock.calls[0][0];
+    expect(updatePayload.isActive).toBe(false);
+    expect(updatePayload.updatedAt).toBeInstanceOf(Date);
+    // Exactly these two keys — no accidental extra field wipe.
+    expect(Object.keys(updatePayload).sort()).toEqual(
+      ['isActive', 'updatedAt'].sort()
+    );
+  });
+
+  it('scopes the update to the requested id via eq()', async () => {
+    await DELETE(
+      new Request('http://localhost/api/admin/investors/links/link-1', {
+        method: 'DELETE',
+      }),
+      paramsFor('link-1')
+    );
+
+    expect(mockEq).toHaveBeenCalledWith('investor_links.id', 'link-1');
+  });
+
+  it('returns 404 when the link id does not exist', async () => {
+    mockReturning.mockResolvedValue([]);
+
+    const res = await DELETE(
+      new Request('http://localhost/api/admin/investors/links/missing-id', {
+        method: 'DELETE',
+      }),
+      paramsFor('missing-id')
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.error).toBe('Link not found');
+  });
+
+  it('returns the deactivated row as { link } with 200 on success', async () => {
+    const deactivatedRow = { id: 'link-1', isActive: false };
+    mockReturning.mockResolvedValue([deactivatedRow]);
+
+    const res = await DELETE(
+      new Request('http://localhost/api/admin/investors/links/link-1', {
+        method: 'DELETE',
+      }),
+      paramsFor('link-1')
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ link: deactivatedRow });
+  });
+});

--- a/apps/web/tests/unit/api/admin/investors-links.test.ts
+++ b/apps/web/tests/unit/api/admin/investors-links.test.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireAdmin = vi.hoisted(() => vi.fn());
+const mockDesc = vi.hoisted(() => vi.fn(() => 'desc-clause'));
+
+const { mockDb, mockInsert, mockValues, mockReturning } = vi.hoisted(() => {
+  const mockReturning = vi.fn();
+  const mockValues = vi.fn(() => ({ returning: mockReturning }));
+  const mockInsert = vi.fn(() => ({ values: mockValues }));
+
+  const mockOrderBy = vi.fn();
+  const mockFrom = vi.fn(() => ({ orderBy: mockOrderBy }));
+  const mockSelect = vi.fn(() => ({ from: mockFrom }));
+
+  return {
+    mockDb: { insert: mockInsert, select: mockSelect },
+    mockInsert,
+    mockValues,
+    mockReturning,
+  };
+});
+
+vi.mock('@/lib/admin/middleware', () => ({
+  requireAdmin: mockRequireAdmin,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: mockDb,
+}));
+
+vi.mock('@/lib/db/schema/investors', () => ({
+  investorLinks: {
+    id: 'investor_links.id',
+    token: 'investor_links.token',
+    label: 'investor_links.label',
+    investorName: 'investor_links.investor_name',
+    email: 'investor_links.email',
+    createdAt: 'investor_links.created_at',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  desc: mockDesc,
+}));
+
+import { POST } from '@/app/api/admin/investors/links/route';
+
+function postRequest(body: unknown) {
+  return new Request('http://localhost/api/admin/investors/links', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/admin/investors/links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(null); // authorized by default
+    mockReturning.mockResolvedValue([
+      {
+        id: 'link-1',
+        token: 'placeholder-token',
+        label: 'Acme Ventures',
+        investorName: null,
+        email: null,
+      },
+    ]);
+  });
+
+  it('rejects the request before touching the database when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue(
+      NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    );
+
+    const res = await POST(postRequest({ label: 'Acme Ventures' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(data.error).toBe('Forbidden');
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing label with 400 and does not insert', async () => {
+    const res = await POST(postRequest({ investorName: 'Jane' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBe('Label is required');
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string label with 400 and does not insert', async () => {
+    const res = await POST(postRequest({ label: 42 }));
+
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a whitespace-only label with 400 and does not insert', async () => {
+    const res = await POST(postRequest({ label: '   ' }));
+
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('generates a non-trivial token, trims the label, and nulls empty optional fields', async () => {
+    const res = await POST(
+      postRequest({
+        label: '  Acme Ventures  ',
+        investorName: '   ',
+        email: '',
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockValues).toHaveBeenCalledTimes(1);
+
+    const insertPayload = mockValues.mock.calls[0][0];
+
+    // Token must be present, non-trivial, and URL-safe (base-36 alphabet).
+    expect(typeof insertPayload.token).toBe('string');
+    expect(insertPayload.token.length).toBeGreaterThan(0);
+    expect(insertPayload.token).toMatch(/^[0-9a-z]+$/);
+
+    expect(insertPayload.label).toBe('Acme Ventures'); // trimmed
+    expect(insertPayload.investorName).toBeNull(); // whitespace-only -> null
+    expect(insertPayload.email).toBeNull(); // empty string -> null
+  });
+
+  it('preserves a real investorName/email instead of nulling them', async () => {
+    await POST(
+      postRequest({
+        label: 'Acme Ventures',
+        investorName: '  Jane Doe  ',
+        email: '  jane@example.com  ',
+      })
+    );
+
+    const insertPayload = mockValues.mock.calls[0][0];
+
+    expect(insertPayload.investorName).toBe('Jane Doe');
+    expect(insertPayload.email).toBe('jane@example.com');
+  });
+
+  it('generates a different token on each call (not a hardcoded/predictable value)', async () => {
+    await POST(postRequest({ label: 'Acme Ventures' }));
+    const firstToken = mockValues.mock.calls[0][0].token;
+
+    await POST(postRequest({ label: 'Acme Ventures' }));
+    const secondToken = mockValues.mock.calls[1][0].token;
+
+    expect(firstToken).not.toBe(secondToken);
+  });
+
+  it('returns the inserted row from .returning() as { link } with 201', async () => {
+    const insertedRow = {
+      id: 'link-42',
+      token: 'abc123',
+      label: 'Acme Ventures',
+      investorName: null,
+      email: null,
+    };
+    mockReturning.mockResolvedValue([insertedRow]);
+
+    const res = await POST(postRequest({ label: 'Acme Ventures' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data).toEqual({ link: insertedRow });
+  });
+});

--- a/apps/web/tests/unit/lib/auth/investor-portal.test.ts
+++ b/apps/web/tests/unit/lib/auth/investor-portal.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   captureError: vi.fn(),
   releaseInvestorViewDedup: vi.fn(),
   shouldRecordInvestorView: vi.fn(),
+  apiLimiterLimit: vi.fn(),
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -51,6 +52,12 @@ vi.mock('@/lib/error-tracking', () => ({
   captureError: mocks.captureError,
 }));
 
+vi.mock('@/lib/rate-limit', () => ({
+  apiLimiter: {
+    limit: mocks.apiLimiterLimit,
+  },
+}));
+
 import { handleInvestorRequest } from '@/lib/auth/investor-portal';
 
 function createInvestorRequest(path: string) {
@@ -71,6 +78,12 @@ describe('investor portal proxy helper', () => {
     vi.clearAllMocks();
     mocks.select.mockReset();
     mocks.shouldRecordInvestorView.mockResolvedValue(true);
+    mocks.apiLimiterLimit.mockResolvedValue({
+      success: true,
+      limit: 20,
+      remaining: 19,
+      reset: new Date(Date.now() + 60_000),
+    });
   });
 
   it('lets response action links reach the page with token and action intact before DB validation', async () => {
@@ -111,5 +124,95 @@ describe('investor portal proxy helper', () => {
     expect(res?.cookies.get('__investor_token')?.value).toBe('token-123');
     expect(res?.cookies.get('__investor_token')?.path).toBe('/investor-portal');
     expect(mocks.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the rate limiter keyed by client IP before validating the token', async () => {
+    mockSelectRows([{ id: 'link-1', isActive: true, expiresAt: null }]);
+
+    const req = new NextRequest('https://jov.ie/investor-portal?t=token-123', {
+      headers: { 'x-forwarded-for': '203.0.113.7, 10.0.0.1' },
+    });
+    await handleInvestorRequest(req);
+
+    expect(mocks.apiLimiterLimit).toHaveBeenCalledTimes(1);
+    expect(mocks.apiLimiterLimit).toHaveBeenCalledWith(
+      'investor-portal:token:203.0.113.7'
+    );
+  });
+
+  it('returns 429 with a numeric Retry-After header when the rate limiter rejects the request, without touching the database', async () => {
+    const resetInMs = 12_000;
+    mocks.apiLimiterLimit.mockResolvedValue({
+      success: false,
+      limit: 20,
+      remaining: 0,
+      reset: new Date(Date.now() + resetInMs),
+    });
+
+    const res = await handleInvestorRequest(
+      createInvestorRequest('/investor-portal?t=token-123')
+    );
+
+    expect(res?.status).toBe(429);
+
+    const retryAfter = res?.headers.get('Retry-After');
+    expect(retryAfter).not.toBeNull();
+    const retryAfterSeconds = Number(retryAfter);
+    expect(Number.isNaN(retryAfterSeconds)).toBe(false);
+    expect(retryAfterSeconds).toBeGreaterThan(0);
+    expect(retryAfterSeconds).toBeLessThanOrEqual(12);
+
+    // Anti-enumeration: the DB must never be consulted once the limiter
+    // has rejected the request, and no cookie should be set.
+    expect(mocks.select).not.toHaveBeenCalled();
+    expect(res?.cookies.get('__investor_token')).toBeUndefined();
+  });
+
+  it('floors Retry-After at 1 second even when the reset window has already elapsed', async () => {
+    mocks.apiLimiterLimit.mockResolvedValue({
+      success: false,
+      limit: 20,
+      remaining: 0,
+      reset: new Date(Date.now() - 5_000), // already in the past
+    });
+
+    const res = await handleInvestorRequest(
+      createInvestorRequest('/investor-portal?t=token-123')
+    );
+
+    expect(res?.status).toBe(429);
+    expect(res?.headers.get('Retry-After')).toBe('1');
+  });
+
+  it('still validates the token normally once the rate limiter allows the request (limiter pass -> normal flow)', async () => {
+    mocks.apiLimiterLimit.mockResolvedValue({
+      success: true,
+      limit: 20,
+      remaining: 19,
+      reset: new Date(Date.now() + 60_000),
+    });
+    mockSelectRows([{ id: 'link-1', isActive: true, expiresAt: null }]);
+
+    const res = await handleInvestorRequest(
+      createInvestorRequest('/investor-portal?t=token-123&utm=x')
+    );
+
+    expect(mocks.apiLimiterLimit).toHaveBeenCalledTimes(1);
+    expect(res?.status).toBe(307);
+    expect(res?.cookies.get('__investor_token')?.value).toBe('token-123');
+    expect(mocks.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not rate-limit cookie-based revisits (no ?t= param)', async () => {
+    const req = new NextRequest('https://jov.ie/investor-portal', {
+      headers: { Cookie: '__investor_token=token-123' },
+    });
+
+    mockSelectRows([{ id: 'link-1', stage: 'shared' }]);
+    mocks.shouldRecordInvestorView.mockResolvedValue(false);
+
+    await handleInvestorRequest(req);
+
+    expect(mocks.apiLimiterLimit).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Replants #14062 onto current `main` and preserves its mutation-verified investor-token coverage:

- POST authorization, validation, trimming/null normalization, token generation, and response shape
- PATCH allowlist protection, exact ID scoping, 404 behavior, and response shape
- DELETE soft-delete-only behavior, exact ID scoping, 404 behavior, and response shape
- investor-portal token-path rate limiting, anti-enumeration 429 behavior, Retry-After floor, and cookie-path bypass

Independent review found that the original PATCH test pinned a raw JSON string for `expiresAt`, while the Drizzle timestamp column uses Date mode. This replacement fixes the real route contract by converting valid date strings to `Date`, preserving nullable expiry clearing, and returning 400 for invalid/non-string expiry values before any database write.

## Root cause and classification

- Stale PR conflict: additive `CHANGELOG.md` anchor plus both branches changed the investor-portal test.
- Semantic drift: current `main` added a narrower `/investor-portal` cookie-path assertion; this replant retains it.
- Failure class: **PR-specific broken test exposing a real route bug**.
- Durable regression coverage: exact timestamp normalization/rejection and exact PATCH `eq(investorLinks.id, id)` assertions.

## Preservation evidence

- Both new admin route test files initially replanted byte-for-byte from #14062.
- The investor-portal test differed from the original head only by current main's cookie-path assertion.
- The independent reviewer verified the final route normalization and predicate coverage with no remaining findings.

## Verification

- Focused suites: 30/30 tests passed after the route fix; the original 27/27 set passed three consecutive runs.
- Updated PATCH suite: 15/15 passed independently.
- Biome: clean.
- Web typecheck: passed.
- Full non-bypassed pre-push gate: passed (proxy guard, Tailwind guard, affected typecheck/lint, 31/31 affected tests, CI harness manifest/docs).
- Commits are SSH-signed.

## Merge controls

Draft and `gated`. Do not ready, enqueue, or merge until required GitHub CI is green and the queue coordinator approves.

Supersedes #14062 after preservation review.

<!-- linear-issue-id:JOV-4220 -->