### PR TITLE
fix(ci): gate runner scale-up on I/O pressure

### DIFF
--- a/.github/runner-host/README.md
+++ b/.github/runner-host/README.md
@@ -20,6 +20,23 @@ observed ten-runner demand, remains far below host PID/thread limits, and does
 not increase the autoscaler maximum above 10. The diagnostic reports warning at
 80% and critical at 90%, before Node reaches `EAGAIN`.
 
+## I/O-pressure scale-up admission
+
+The ten-runner process envelope remains the hard maximum, but a single NVMe
+device and Docker overlay2 are the measured bottleneck before CPU or memory.
+At 9–10 runners, `/proc/pressure/io` reported `full avg10` between 19% and 29%
+while memory PSI remained near zero and jobs blocked in `jbd2`. The autoscaler
+therefore stops admitting only new runners when I/O `full avg10` reaches 20%.
+
+Admission is latched until `full avg10` is at or below 10% for three consecutive
+15-second polls (45 seconds). The lower recovery threshold prevents runner
+spawn oscillation around 20%. Missing or malformed PSI fails closed for scale-up
+only. Existing containers keep running; the guard never stops a runner, cancels
+a job, reduces the configured ten-runner maximum, or changes the existing idle
+reaper. Diagnostics use `runner-io-pressure` (or
+`runner-io-pressure-unavailable`) and explicitly distinguish I/O admission from
+CPU, memory, EAGAIN process capacity, and GitHub scheduler starvation.
+
 ## Review and cutover
 
 The installer is dry-run unless `--apply` is provided. Applying the TasksMax
@@ -33,4 +50,13 @@ Verify afterward with:
 
 ```bash
 ssh gem 'cd /path/to/Jovie && .github/runner-host/diagnose-capacity.sh'
+```
+
+The I/O guard has its own dry-run-default installer. `--apply` checksum-gates
+the reviewed live controller and installs source only; it does not restart the
+autoscaler or touch runner containers. Activation requires a separate restart
+approved after primary review:
+
+```bash
+ssh gem 'cd /path/to/Jovie && sudo .github/runner-host/install-io-pressure-guard.sh'
 ```

--- a/.github/runner-host/autoscaler/controller-io-pressure.patch
+++ b/.github/runner-host/autoscaler/controller-io-pressure.patch
@@ -1,0 +1,83 @@
+--- a/controller.ts
++++ b/controller.ts
+@@ -18 +18 @@
+-import { appendFileSync } from "node:fs";
++import { appendFileSync, readFileSync } from "node:fs";
+@@ -28,0 +29,7 @@
++import {
++  evaluateIoPressureAdmission,
++  INITIAL_IO_PRESSURE_STATE,
++  type IoPressureAdmissionConfig,
++  type IoPressureAdmissionState,
++  ioPressureConfigFromEnv,
++} from "./io-pressure";
+@@ -63,0 +71 @@
++  readonly readIoPressure: () => string;
+@@ -87,0 +96 @@
++  private readonly readIoPressure: AutoscalerDependencies["readIoPressure"];
+@@ -88,0 +98 @@
++  private readonly ioPressureConfig: IoPressureAdmissionConfig;
+@@ -90,0 +101 @@
++  private ioPressureState: IoPressureAdmissionState = INITIAL_IO_PRESSURE_STATE;
+@@ -96,0 +108 @@
++    this.ioPressureConfig = ioPressureConfigFromEnv(process.env);
+@@ -108,0 +121,3 @@
++    this.readIoPressure =
++      dependencies.readIoPressure ??
++      (() => readFileSync("/proc/pressure/io", "utf8"));
+@@ -171,0 +187,46 @@
++      let admittedDeficit = deficit;
++      if (deficit > 0) {
++        let pressure: string | null = null;
++        try {
++          pressure = this.readIoPressure();
++        } catch {
++          // Admission fails closed below; current runners remain untouched.
++        }
++        const admission = evaluateIoPressureAdmission(
++          pressure,
++          this.ioPressureState,
++          this.ioPressureConfig,
++        );
++        this.ioPressureState = admission.state;
++        if (!admission.admitScaleUp) {
++          admittedDeficit = 0;
++          const avg10 = admission.fullAvg10Pct?.toFixed(2) ?? "unavailable";
++          this.log(
++            `runner_spawn_admission=blocked runner_failure_class=${admission.classification} io_full_avg10_pct=${avg10} distinct_from=cpu,memory,eagain,github-scheduler-starvation reason=${admission.reason}`,
++          );
++          try {
++            this.gbrain.recordScalingDecision(
++              activeContainers,
++              admission.reason,
++              "high",
++              {
++                tick: tickNum,
++                queuedJobs,
++                activeContainers,
++                requestedDeficit: deficit,
++                ioFullAvg10Pct: admission.fullAvg10Pct,
++                failureClass: admission.classification,
++              },
++            );
++          } catch {
++            // Admission safety never depends on telemetry availability.
++          }
++        } else if (
++          admission.classification === "runner-io-pressure-recovered"
++        ) {
++          this.log(
++            `runner_spawn_admission=recovered runner_failure_class=${admission.classification} io_full_avg10_pct=${admission.fullAvg10Pct?.toFixed(2)}`,
++          );
++        }
++      }
++
+@@ -173 +234 @@
+-      if (this.consecutiveFailures > 0 && deficit > 0) {
++      if (this.consecutiveFailures > 0 && admittedDeficit > 0) {
+@@ -202 +263 @@
+-      if (deficit > 0 && !this.config.dryRun) {
++      if (admittedDeficit > 0 && !this.config.dryRun) {
+@@ -204 +265 @@
+-        for (let i = 0; i < deficit; i++) {
++        for (let i = 0; i < admittedDeficit; i++) {

--- a/.github/runner-host/autoscaler/io-pressure.ts
+++ b/.github/runner-host/autoscaler/io-pressure.ts
@@ -1,0 +1,140 @@
+export const DEFAULT_IO_FULL_BLOCK_AVG10_PCT = 20;
+export const DEFAULT_IO_FULL_RECOVERY_AVG10_PCT = 10;
+export const DEFAULT_IO_RECOVERY_SAMPLES = 3;
+
+export interface IoPressureAdmissionState {
+  readonly blocked: boolean;
+  readonly recoverySamples: number;
+}
+
+export interface IoPressureAdmissionConfig {
+  readonly blockAvg10Pct: number;
+  readonly recoveryAvg10Pct: number;
+  readonly recoverySamples: number;
+}
+
+export interface IoPressureAdmissionDecision {
+  readonly admitScaleUp: boolean;
+  readonly classification:
+    | 'runner-io-pressure'
+    | 'runner-io-pressure-unavailable'
+    | 'runner-io-pressure-recovered'
+    | 'runner-io-pressure-ok';
+  readonly fullAvg10Pct: number | null;
+  readonly state: IoPressureAdmissionState;
+  readonly reason: string;
+}
+
+export const INITIAL_IO_PRESSURE_STATE: IoPressureAdmissionState = {
+  blocked: false,
+  recoverySamples: 0,
+};
+
+export const DEFAULT_IO_PRESSURE_CONFIG: IoPressureAdmissionConfig = {
+  blockAvg10Pct: DEFAULT_IO_FULL_BLOCK_AVG10_PCT,
+  recoveryAvg10Pct: DEFAULT_IO_FULL_RECOVERY_AVG10_PCT,
+  recoverySamples: DEFAULT_IO_RECOVERY_SAMPLES,
+};
+
+function finitePercent(value: string | undefined): number | null {
+  const parsed = Number.parseFloat(value ?? '');
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 100
+    ? parsed
+    : null;
+}
+
+export function ioPressureConfigFromEnv(
+  env: NodeJS.ProcessEnv
+): IoPressureAdmissionConfig {
+  const blockAvg10Pct = finitePercent(env.AUTOSCALER_IO_FULL_BLOCK_AVG10_PCT);
+  const recoveryAvg10Pct = finitePercent(
+    env.AUTOSCALER_IO_FULL_RECOVERY_AVG10_PCT
+  );
+  const recoverySamples = Number.parseInt(
+    env.AUTOSCALER_IO_RECOVERY_SAMPLES ?? '',
+    10
+  );
+
+  if (
+    blockAvg10Pct === null ||
+    recoveryAvg10Pct === null ||
+    recoveryAvg10Pct >= blockAvg10Pct ||
+    !Number.isInteger(recoverySamples) ||
+    recoverySamples < 1
+  ) {
+    return DEFAULT_IO_PRESSURE_CONFIG;
+  }
+
+  return { blockAvg10Pct, recoveryAvg10Pct, recoverySamples };
+}
+
+export function parseIoFullAvg10(pressure: string): number | null {
+  const fullLine = pressure
+    .split(/\r?\n/u)
+    .find(line => line.trimStart().startsWith('full '));
+  const match = fullLine?.match(/(?:^|\s)avg10=([0-9]+(?:\.[0-9]+)?)(?:\s|$)/u);
+  if (!match) return null;
+
+  const value = Number.parseFloat(match[1]);
+  return Number.isFinite(value) && value >= 0 && value <= 100 ? value : null;
+}
+
+export function evaluateIoPressureAdmission(
+  pressure: string | null,
+  previous: IoPressureAdmissionState = INITIAL_IO_PRESSURE_STATE,
+  config: IoPressureAdmissionConfig = DEFAULT_IO_PRESSURE_CONFIG
+): IoPressureAdmissionDecision {
+  const fullAvg10Pct = pressure === null ? null : parseIoFullAvg10(pressure);
+  if (fullAvg10Pct === null) {
+    return {
+      admitScaleUp: false,
+      classification: 'runner-io-pressure-unavailable',
+      fullAvg10Pct: null,
+      state: { blocked: true, recoverySamples: 0 },
+      reason:
+        'I/O pressure is unavailable or malformed; scale-up admission fails closed.',
+    };
+  }
+
+  if (!previous.blocked && fullAvg10Pct >= config.blockAvg10Pct) {
+    return {
+      admitScaleUp: false,
+      classification: 'runner-io-pressure',
+      fullAvg10Pct,
+      state: { blocked: true, recoverySamples: 0 },
+      reason: `I/O full avg10 ${fullAvg10Pct.toFixed(2)}% reached the ${config.blockAvg10Pct.toFixed(2)}% admission threshold.`,
+    };
+  }
+
+  if (previous.blocked) {
+    const recoverySamples =
+      fullAvg10Pct <= config.recoveryAvg10Pct
+        ? previous.recoverySamples + 1
+        : 0;
+    if (recoverySamples >= config.recoverySamples) {
+      return {
+        admitScaleUp: true,
+        classification: 'runner-io-pressure-recovered',
+        fullAvg10Pct,
+        state: { blocked: false, recoverySamples: 0 },
+        reason: `I/O full avg10 stayed at or below ${config.recoveryAvg10Pct.toFixed(2)}% for ${config.recoverySamples} samples.`,
+      };
+    }
+
+    return {
+      admitScaleUp: false,
+      classification: 'runner-io-pressure',
+      fullAvg10Pct,
+      state: { blocked: true, recoverySamples },
+      reason: `I/O scale-up admission remains latched; recovery ${recoverySamples}/${config.recoverySamples}.`,
+    };
+  }
+
+  return {
+    admitScaleUp: true,
+    classification: 'runner-io-pressure-ok',
+    fullAvg10Pct,
+    state: INITIAL_IO_PRESSURE_STATE,
+    reason: `I/O full avg10 ${fullAvg10Pct.toFixed(2)}% is below the admission threshold.`,
+  };
+}

--- a/.github/runner-host/ci-runner-autoscaler.service.snapshot
+++ b/.github/runner-host/ci-runner-autoscaler.service.snapshot
@@ -22,6 +22,9 @@ Environment=AUTOSCALER_RUNNER_CPUS=2
 Environment=AUTOSCALER_RUNNER_MEMORY_MB=4096
 Environment=AUTOSCALER_RUNNER_LABELS=self-hosted,Linux,X64,jovie-runner,jovie-ephemeral,ephemeral
 Environment=AUTOSCALER_CGROUP_PARENT=ci-runners.slice
+Environment=AUTOSCALER_IO_FULL_BLOCK_AVG10_PCT=20
+Environment=AUTOSCALER_IO_FULL_RECOVERY_AVG10_PCT=10
+Environment=AUTOSCALER_IO_RECOVERY_SAMPLES=3
 
 # Model routes and credentials are intentionally omitted. They are unrelated to
 # process capacity and remain owned by the live service/drop-in configuration.

--- a/.github/runner-host/install-io-pressure-guard.sh
+++ b/.github/runner-host/install-io-pressure-guard.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly EXPECTED_MAX_RUNNERS=10
+readonly EXPECTED_LIVE_CONTROLLER_SHA256=d41f50b6f5b1b969d1612b2e16e8b52c2a440a110b2f17c84841f609c1e3336b
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SOURCE_DIR
+readonly LIVE_DIR=/opt/ci-runner-autoscaler/lib
+
+source_patch="$SOURCE_DIR/autoscaler/controller-io-pressure.patch"
+source_guard="$SOURCE_DIR/autoscaler/io-pressure.ts"
+live_controller="$LIVE_DIR/controller.ts"
+live_guard="$LIVE_DIR/io-pressure.ts"
+
+if [[ "${1:-}" != "--apply" ]]; then
+  echo "Dry run: no host state changed."
+  echo "Would install the reviewed I/O admission guard into $LIVE_DIR"
+  echo "Would preserve max runners at $EXPECTED_MAX_RUNNERS"
+  echo "Would not restart the autoscaler or touch runner containers"
+  exit 0
+fi
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "ERROR: --apply must run as root" >&2
+  exit 2
+fi
+
+service_environment="$(
+  systemctl show ci-runner-autoscaler.service --property Environment --value
+)"
+if ! grep -Eq \
+  "(^| )AUTOSCALER_MAX_RUNNERS=$EXPECTED_MAX_RUNNERS( |$)" \
+  <<< "$service_environment"; then
+  echo "ERROR: live service must keep max runners at $EXPECTED_MAX_RUNNERS" >&2
+  exit 3
+fi
+
+live_sha="$(sha256sum "$live_controller" | awk '{print $1}')"
+if grep -Fq 'runner_spawn_admission=blocked runner_failure_class=' "$live_controller" && \
+  cmp -s "$source_guard" "$live_guard"; then
+  echo "I/O admission guard is already installed; no host state changed."
+  exit 0
+fi
+if [[ "$live_sha" != "$EXPECTED_LIVE_CONTROLLER_SHA256" ]]; then
+  echo "ERROR: live controller drifted: sha256=$live_sha" >&2
+  echo "Expected reviewed base $EXPECTED_LIVE_CONTROLLER_SHA256" >&2
+  exit 4
+fi
+
+patched_controller="$(mktemp)"
+trap 'rm -f "$patched_controller"' EXIT
+cp "$live_controller" "$patched_controller"
+patch --silent "$patched_controller" "$source_patch"
+
+install -o timwhite -g timwhite -m 0600 "$source_guard" "$live_guard"
+install -o timwhite -g timwhite -m 0600 "$patched_controller" "$live_controller"
+
+echo "Installed I/O admission source with max runners unchanged at $EXPECTED_MAX_RUNNERS."
+echo "Autoscaler was not restarted; no runner containers were stopped or removed."
+echo "Primary review must authorize a separate autoscaler restart to activate the guard."

--- a/apps/web/tests/unit/ci/runner-io-pressure.test.ts
+++ b/apps/web/tests/unit/ci/runner-io-pressure.test.ts
@@ -1,0 +1,158 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_IO_PRESSURE_CONFIG,
+  evaluateIoPressureAdmission,
+  INITIAL_IO_PRESSURE_STATE,
+  ioPressureConfigFromEnv,
+  parseIoFullAvg10,
+} from '../../../../../.github/runner-host/autoscaler/io-pressure';
+import { classifyOperationalFailure } from '../../../../../scripts/hermes/jobs/ci-failure-signatures';
+
+const repoRoot = resolve(import.meta.dirname, '../../../../..');
+const pressure = (fullAvg10: string) =>
+  `some avg10=31.00 avg60=12.00 avg300=4.00 total=1\nfull avg10=${fullAvg10} avg60=8.00 avg300=2.00 total=2\n`;
+
+describe('Gem runner I/O-pressure admission', () => {
+  it('parses Linux full pressure without confusing it with some pressure', () => {
+    expect(parseIoFullAvg10(pressure('19.75'))).toBe(19.75);
+    expect(parseIoFullAvg10('some avg10=99.00 total=1\n')).toBe(null);
+  });
+
+  it('blocks only scale-up at the measured 20% full avg10 threshold', () => {
+    expect(
+      evaluateIoPressureAdmission(pressure('19.99'), INITIAL_IO_PRESSURE_STATE)
+    ).toMatchObject({
+      admitScaleUp: true,
+      classification: 'runner-io-pressure-ok',
+    });
+    expect(
+      evaluateIoPressureAdmission(pressure('20.00'), INITIAL_IO_PRESSURE_STATE)
+    ).toMatchObject({
+      admitScaleUp: false,
+      classification: 'runner-io-pressure',
+      state: { blocked: true, recoverySamples: 0 },
+    });
+  });
+
+  it('requires three low-pressure samples before reopening admission', () => {
+    const blocked = evaluateIoPressureAdmission(
+      pressure('29.00'),
+      INITIAL_IO_PRESSURE_STATE
+    );
+    const midBand = evaluateIoPressureAdmission(
+      pressure('15.00'),
+      blocked.state
+    );
+    const recovery1 = evaluateIoPressureAdmission(
+      pressure('10.00'),
+      midBand.state
+    );
+    const recovery2 = evaluateIoPressureAdmission(
+      pressure('9.00'),
+      recovery1.state
+    );
+    const recovered = evaluateIoPressureAdmission(
+      pressure('8.00'),
+      recovery2.state
+    );
+
+    expect(midBand).toMatchObject({
+      admitScaleUp: false,
+      state: { blocked: true, recoverySamples: 0 },
+    });
+    expect(recovery1.admitScaleUp).toBe(false);
+    expect(recovery2.admitScaleUp).toBe(false);
+    expect(recovered).toMatchObject({
+      admitScaleUp: true,
+      classification: 'runner-io-pressure-recovered',
+      state: { blocked: false, recoverySamples: 0 },
+    });
+  });
+
+  it('fails scale-up admission closed when PSI is unavailable', () => {
+    expect(evaluateIoPressureAdmission(null)).toMatchObject({
+      admitScaleUp: false,
+      classification: 'runner-io-pressure-unavailable',
+      fullAvg10Pct: null,
+    });
+    expect(evaluateIoPressureAdmission('malformed')).toMatchObject({
+      admitScaleUp: false,
+      classification: 'runner-io-pressure-unavailable',
+    });
+  });
+
+  it('accepts a valid tuned hysteresis and rejects unsafe configuration', () => {
+    expect(
+      ioPressureConfigFromEnv({
+        AUTOSCALER_IO_FULL_BLOCK_AVG10_PCT: '25',
+        AUTOSCALER_IO_FULL_RECOVERY_AVG10_PCT: '12',
+        AUTOSCALER_IO_RECOVERY_SAMPLES: '4',
+      })
+    ).toEqual({
+      blockAvg10Pct: 25,
+      recoveryAvg10Pct: 12,
+      recoverySamples: 4,
+    });
+    expect(
+      ioPressureConfigFromEnv({
+        AUTOSCALER_IO_FULL_BLOCK_AVG10_PCT: '10',
+        AUTOSCALER_IO_FULL_RECOVERY_AVG10_PCT: '20',
+        AUTOSCALER_IO_RECOVERY_SAMPLES: '0',
+      })
+    ).toBe(DEFAULT_IO_PRESSURE_CONFIG);
+  });
+
+  it('wires admission before spawn without adding a runner mutation path', () => {
+    const controllerPatch = readFileSync(
+      resolve(
+        repoRoot,
+        '.github/runner-host/autoscaler/controller-io-pressure.patch'
+      ),
+      'utf8'
+    );
+    const admissionStart = controllerPatch.indexOf(
+      'evaluateIoPressureAdmission('
+    );
+
+    expect(admissionStart).toBeGreaterThan(0);
+    expect(controllerPatch).toContain('admittedDeficit = 0');
+    expect(controllerPatch).toContain(
+      'runner_spawn_admission=blocked runner_failure_class='
+    );
+    expect(controllerPatch).not.toContain(
+      '+            this.docker.stopContainer'
+    );
+    expect(controllerPatch).not.toContain('+            this.gh.removeRunner');
+    expect(controllerPatch).not.toContain('gh run');
+  });
+
+  it('keeps installation dry-run-only by default and preserves ten runners', () => {
+    const installer = resolve(
+      repoRoot,
+      '.github/runner-host/install-io-pressure-guard.sh'
+    );
+    const result = spawnSync('bash', [installer], { encoding: 'utf8' });
+    const source = readFileSync(installer, 'utf8');
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Dry run: no host state changed.');
+    expect(result.stdout).toContain('max runners at 10');
+    expect(source).not.toMatch(/systemctl (?:re)?start/u);
+    expect(source).not.toContain('docker stop');
+    expect(source).not.toContain('gh run cancel');
+  });
+
+  it('classifies I/O admission separately from EAGAIN capacity', () => {
+    expect(
+      classifyOperationalFailure(
+        'runner_spawn_admission=blocked runner_failure_class=runner-io-pressure io_full_avg10_pct=29.00 distinct_from=cpu,memory,eagain,github-scheduler-starvation'
+      )
+    ).toMatchObject({ id: 'runner-io-pressure' });
+    expect(
+      classifyOperationalFailure('spawn /usr/bin/node EAGAIN')
+    ).toMatchObject({ id: 'runner-process-capacity' });
+  });
+});

--- a/scripts/hermes/jobs/ci-failure-signatures.ts
+++ b/scripts/hermes/jobs/ci-failure-signatures.ts
@@ -14,9 +14,24 @@ const RUNNER_PROCESS_CAPACITY: OperationalFailureSignature = {
     'Run .github/runner-host/diagnose-capacity.sh and restore the versioned ci-runners.slice TasksMax contract before retrying CI.',
 };
 
+const RUNNER_IO_PRESSURE: OperationalFailureSignature = {
+  id: 'runner-io-pressure',
+  category: 'dependency-or-environment-drift',
+  rootCause:
+    'Gem runner scale-up was admission-blocked because Linux I/O full pressure reached the reviewed saturation threshold.',
+  remediation:
+    'Do not retry or add runners. Let existing jobs drain, then verify /proc/pressure/io full avg10 stays below the recovery threshold before admission resumes.',
+};
+
 export function classifyOperationalFailure(
   log: string
 ): OperationalFailureSignature | null {
+  if (
+    /runner_failure_class=runner-io-pressure(?:-unavailable)?\b/i.test(log) ||
+    /runner_spawn_admission=blocked[^\n]*\bio_full_avg10_pct=/i.test(log)
+  ) {
+    return RUNNER_IO_PRESSURE;
+  }
   if (
     /(?:spawn|fork)[^\n]*\bEAGAIN\b/i.test(log) ||
     /runner_tasks_status=(?:warning|critical)/i.test(log)

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -92,8 +92,40 @@ const GTMQ_SOURCE_GATE_REAPER_MANIFEST = [
   'scripts/run-affected-tests.mjs',
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const RUNNER_IO_PRESSURE_MANIFEST = [
+  '.github/runner-host/README.md',
+  '.github/runner-host/autoscaler/controller-io-pressure.patch',
+  '.github/runner-host/autoscaler/io-pressure.ts',
+  '.github/runner-host/ci-runner-autoscaler.service.snapshot',
+  '.github/runner-host/install-io-pressure-guard.sh',
+  'apps/web/tests/unit/ci/runner-io-pressure.test.ts',
+  'scripts/hermes/jobs/ci-failure-signatures.ts',
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+];
 
 describe('automation-verify affected scope', () => {
+  it('keeps runner I/O admission on focused controller regressions', () => {
+    const plan = buildAffectedTestPlan(RUNNER_IO_PRESSURE_MANIFEST);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/ci/runner-io-pressure.test.ts',
+    ]);
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+    ]);
+  });
+
+  it('fails closed when runner I/O admission includes an unknown peer', () => {
+    expect(
+      buildAffectedTestPlan([
+        ...RUNNER_IO_PRESSURE_MANIFEST,
+        '.github/runner-host/autoscaler/unknown-controller.ts',
+      ]).mode
+    ).toBe('full');
+  });
+
   it('selects related tests instead of the whole affected workspace package', () => {
     expect(script).toContain('node scripts/run-affected-tests.mjs');
     expect(script).not.toContain('turbo-local.mjs test --affected');

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -115,6 +115,20 @@ const GTMQ_SOURCE_GATE_REAPER_PYTHON_TESTS = ['scripts/tests/test_gh_retry.py'];
 const GTMQ_SOURCE_GATE_REAPER_SCRIPT_TESTS = [
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const RUNNER_IO_PRESSURE_MANIFEST = new Set([
+  '.github/runner-host/README.md',
+  '.github/runner-host/autoscaler/controller-io-pressure.patch',
+  '.github/runner-host/autoscaler/io-pressure.ts',
+  '.github/runner-host/ci-runner-autoscaler.service.snapshot',
+  '.github/runner-host/install-io-pressure-guard.sh',
+  'apps/web/tests/unit/ci/runner-io-pressure.test.ts',
+  'scripts/hermes/jobs/ci-failure-signatures.ts',
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+]);
+const RUNNER_IO_PRESSURE_SCRIPT_TESTS = [
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+];
 
 function isInvestorNoteIngestionInput(file) {
   return (
@@ -168,6 +182,12 @@ export function buildAffectedTestPlan(changedFiles) {
   const isExactGtmqSourceGateReaper =
     gtmqSourceGateReaperInputCount === GTMQ_SOURCE_GATE_REAPER_MANIFEST.size &&
     files.length === GTMQ_SOURCE_GATE_REAPER_MANIFEST.size;
+  const runnerIoPressureInputCount = files.filter(file =>
+    RUNNER_IO_PRESSURE_MANIFEST.has(file)
+  ).length;
+  const isExactRunnerIoPressure =
+    runnerIoPressureInputCount === RUNNER_IO_PRESSURE_MANIFEST.size &&
+    files.length === RUNNER_IO_PRESSURE_MANIFEST.size;
   const relatedFiles = files.filter(
     file =>
       TESTABLE_FILE.test(file) &&
@@ -264,6 +284,7 @@ export function buildAffectedTestPlan(changedFiles) {
     ...(isExactGtmqSourceGateReaper
       ? GTMQ_SOURCE_GATE_REAPER_SCRIPT_TESTS
       : []),
+    ...(isExactRunnerIoPressure ? RUNNER_IO_PRESSURE_SCRIPT_TESTS : []),
   ]);
   const isCoveredSource = file => {
     if (/\.(?:test|spec)\.[cm]?[jt]sx?$/.test(file)) return true;
@@ -275,6 +296,8 @@ export function buildAffectedTestPlan(changedFiles) {
     if (file.startsWith('apps/web/tests/eval/promptfoo/')) return true;
     if (isInvestorNoteIngestionInput(file)) return true;
     if (isCiCancellationHealerInput(file)) return true;
+    if (isExactRunnerIoPressure && RUNNER_IO_PRESSURE_MANIFEST.has(file))
+      return true;
     if (isExactPrerequisiteTrain && PREREQUISITE_TRAIN_MANIFEST.has(file))
       return true;
     if (
@@ -312,11 +335,18 @@ export function buildAffectedTestPlan(changedFiles) {
   const hasIncompleteAffectedTestSelector =
     affectedTestSelectorInputCount > 0 &&
     !isExactAffectedTestSelector &&
-    !isExactGtmqSourceGateReaper;
+    !isExactGtmqSourceGateReaper &&
+    !isExactRunnerIoPressure;
   const hasIncompleteGtmqSourceGateReaper =
     gtmqSourceGateReaperInputCount > 0 &&
     !isExactGtmqSourceGateReaper &&
-    !isExactAffectedTestSelector;
+    !isExactAffectedTestSelector &&
+    !isExactRunnerIoPressure;
+  const hasIncompleteRunnerIoPressure =
+    runnerIoPressureInputCount > 0 &&
+    !isExactRunnerIoPressure &&
+    !isExactAffectedTestSelector &&
+    !isExactGtmqSourceGateReaper;
   const hasUncoveredSource =
     relatedFiles.some(file => !isCoveredSource(file)) ||
     hasUnknownCiCancellationHealerPeer ||
@@ -326,7 +356,8 @@ export function buildAffectedTestPlan(changedFiles) {
     hasUnknownPrerequisiteTrainPeer ||
     hasIncompleteVercelCongestionControl ||
     hasIncompleteAffectedTestSelector ||
-    hasIncompleteGtmqSourceGateReaper;
+    hasIncompleteGtmqSourceGateReaper ||
+    hasIncompleteRunnerIoPressure;
   const hasSelectedTests =
     selectedTests.length > 0 ||
     rootVitestTests.length > 0 ||
@@ -341,7 +372,8 @@ export function buildAffectedTestPlan(changedFiles) {
             isExactPrerequisiteTrain ||
             isExactVercelCongestionControl ||
             isExactAffectedTestSelector ||
-            isExactGtmqSourceGateReaper)
+            isExactGtmqSourceGateReaper ||
+            isExactRunnerIoPressure)
         ? 'selected'
         : relatedFiles.length === 0
           ? 'none'


### PR DESCRIPTION
## Summary

- gate only *new* ephemeral runner scale-up when Linux I/O PSI `full avg10` reaches the measured saturation band
- latch admission closed at 20% and require three consecutive samples at or below 10% before recovery
- classify unavailable/malformed PSI fail-safe and separately from CPU, memory, EAGAIN, and GitHub scheduler starvation
- preserve all running jobs and existing runner capacity; this change never kills, cancels, or scales down a runner

## Root cause

The self-hosted Ubuntu host has one NVMe/overlay2 path. During the backlog it reached 100% utilization while `/proc/pressure/io` `full avg10` was 19–29%; memory PSI remained near zero. Raising the runner ceiling alone therefore admitted more write-heavy containers into an already saturated block device and lengthened every job.

This is dependency/environment capacity drift, not a PR-specific failure. The durable fix is an admission guard in Gem's autoscaler rather than another fixed runner limit.

## Thresholds

- block: `full avg10 >= 20%` (the lower edge of the observed critical 19–29% band)
- recover: `full avg10 <= 10%` for 3 consecutive 15-second samples (45 seconds of demonstrated headroom)
- between thresholds: retain the prior latch state to prevent oscillation
- PSI unavailable/malformed: fail closed for *new scale-up only*

## Safe rollout

This stacks on #14363 and keeps its 10-runner ceiling. The installer is dry-run by default, checksum-gates the exact reviewed live controller, verifies max runners remains 10, and intentionally does not restart the service. No live controller change has been applied; activation requires separate primary review.

## Verification

- Node 22 affected gate: Biome, proxy guard, Tailwind guard, web typecheck, Turbo typecheck/lint passed
- affected Vitest shards: 774 files and 6,090 tests passed before one unrelated DevToolbar async-render timing flake; the exact failed test passed on immediate isolated rerun
- PSI guard/capacity tests: 13/13
- CI control tests: 112/112
- affected-selector tests: 69/69
- CI harness current; bug-to-test satisfied; shellcheck clean
- installer dry-run and controller patch dry-run against the read-only live source passed

## Known unrelated flake

`DevToolbar > loads and displays the active persona when opened` used a synchronous assertion after an asynchronous persona fetch. It failed once in shard 4/8 and passed 1/1 on isolated rerun. Classified as flaky test timing, not PR-specific; its deterministic fix belongs in a separate PR and is not mixed into this runner guard.

No added external API usage or recurring cost.
