### PR TITLE
fix(ci): bound repository-wide ratchet scans

### DIFF
--- a/apps/web/lib/a11y-gates/touch-target-engine.ts
+++ b/apps/web/lib/a11y-gates/touch-target-engine.ts
@@ -11,8 +11,9 @@
  *   - tests/unit/design-system/touch-target-ratchet.test.ts (merge gate)
  */
 
+import { spawnSync } from 'node:child_process';
 import type { Dirent } from 'node:fs';
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 export interface TouchTargetViolation {
@@ -24,6 +25,20 @@ export interface TouchTargetViolation {
 export const SCAN_DIRS = ['components', 'app'] as const;
 const EXTENSIONS = ['.tsx'];
 const SKIP_FRAGMENTS = ['.stories.', '.spec.', '.test.', '.storybook/'];
+const CANDIDATE_PATTERN = String.raw`(?:h|size)-(?:10(?:\.5)?|[0-9](?:\.5)?|\[(?:\d+(?:\.\d+)?)px\])`;
+const TRUSTED_RIPGREP_PATHS = [
+  '/usr/bin/rg',
+  '/usr/local/bin/rg',
+  '/opt/homebrew/bin/rg',
+] as const;
+
+export interface RipgrepResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly error?: Error;
+}
+
+export type RipgrepRunner = (scanRoot: string) => RipgrepResult;
 
 // Tailwind heights below 44px (h-11 = 2.75rem = 44px is the floor).
 const SUB_44_SCALE =
@@ -72,6 +87,92 @@ export function walkDir(dir: string, files: string[] = []): string[] {
     }
   }
   return files;
+}
+
+function walkAllSourceFiles(scanRoot: string): string[] {
+  const files: string[] = [];
+  for (const dir of SCAN_DIRS) walkDir(join(scanRoot, dir), files);
+  return files.sort((a, b) => a.localeCompare(b));
+}
+
+export function resolveTrustedRipgrepPath(
+  pathExists: (path: string) => boolean = existsSync
+): string | null {
+  return TRUSTED_RIPGREP_PATHS.find(pathExists) ?? null;
+}
+
+export function runRipgrep(
+  scanRoot: string,
+  resolveRipgrep: () => string | null = resolveTrustedRipgrepPath
+): RipgrepResult {
+  const ripgrepPath = resolveRipgrep();
+  if (!ripgrepPath) {
+    return {
+      status: null,
+      stdout: '',
+      error: new Error('No trusted ripgrep binary found'),
+    };
+  }
+
+  const result = spawnSync(
+    ripgrepPath,
+    [
+      '--files-with-matches',
+      '--sort',
+      'path',
+      '--no-messages',
+      '--no-ignore',
+      '--glob',
+      '*.tsx',
+      '--glob',
+      '!*.stories.*',
+      '--glob',
+      '!*.spec.*',
+      '--glob',
+      '!*.test.*',
+      '--glob',
+      '!**/.storybook/**',
+      '--glob',
+      '!**/node_modules/**',
+      '--glob',
+      '!**/.next/**',
+      '--regexp',
+      CANDIDATE_PATTERN,
+      ...SCAN_DIRS,
+    ],
+    {
+      cwd: scanRoot,
+      encoding: 'utf8',
+      maxBuffer: 5 * 1024 * 1024,
+      timeout: 10_000,
+    }
+  );
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    error: result.error,
+  };
+}
+
+/**
+ * Use ripgrep to avoid opening every TSX file from JavaScript on a cold
+ * checkout. Exit 1 is ripgrep's successful "no matches" result. A missing or
+ * failed binary falls back to the complete Dirent walker so correctness never
+ * depends on the optimization being available.
+ */
+export function findTouchTargetSourceFiles(
+  scanRoot: string,
+  runner: RipgrepRunner = runRipgrep
+): string[] {
+  const result = runner(scanRoot);
+  if (result.status === 1) return [];
+  if (result.status !== 0) return walkAllSourceFiles(scanRoot);
+
+  return result.stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(file => join(scanRoot, file))
+    .sort((a, b) => a.localeCompare(b));
 }
 
 // ── JSX opening-tag extraction ──────────────────────────────────────────────
@@ -152,9 +253,11 @@ export function findViolationsInSource(
   return violations;
 }
 
-export function countViolations(scanRoot: string): TouchTargetViolation[] {
-  const files: string[] = [];
-  for (const dir of SCAN_DIRS) walkDir(join(scanRoot, dir), files);
+export function countViolations(
+  scanRoot: string,
+  runner?: RipgrepRunner
+): TouchTargetViolation[] {
+  const files = findTouchTargetSourceFiles(scanRoot, runner);
   const violations: TouchTargetViolation[] = [];
   for (const filePath of files) {
     let content: string;

--- a/apps/web/tests/unit/analytics-metrics-layer-guard.test.ts
+++ b/apps/web/tests/unit/analytics-metrics-layer-guard.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -79,5 +87,33 @@ describe('canonical metrics layer guard', () => {
     }
 
     expect(failures, failures.join('\n')).toEqual([]);
+  });
+
+  it('walks source directories without treating test files as violations', () => {
+    const webRoot = mkdtempSync(join(tmpdir(), 'metrics-layer-guard-'));
+
+    try {
+      mkdirSync(join(webRoot, 'app', 'nested'), { recursive: true });
+      mkdirSync(join(webRoot, 'components'), { recursive: true });
+      mkdirSync(join(webRoot, 'lib', 'analytics'), { recursive: true });
+      writeFileSync(
+        join(webRoot, 'app', 'nested', 'route.ts'),
+        'const raw = click_events; const rate = (clicks / views) * 100;\n'
+      );
+      writeFileSync(
+        join(webRoot, 'components', 'ignored.test.tsx'),
+        'const raw = click_events;\n'
+      );
+      writeFileSync(
+        join(webRoot, 'lib', 'analytics', 'metrics.ts'),
+        'const raw = click_events; const rate = (clicks / views) * 100;\n'
+      );
+
+      expect(countMetricsLayerViolations(webRoot)).toEqual({
+        'app/nested/route.ts': { tables: 1, rates: 1 },
+      });
+    } finally {
+      rmSync(webRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/web/tests/unit/design-system/touch-target-ratchet.test.ts
+++ b/apps/web/tests/unit/design-system/touch-target-ratchet.test.ts
@@ -1,10 +1,22 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   countViolations,
+  findTouchTargetSourceFiles,
   findViolationsInSource,
+  type RipgrepRunner,
+  resolveTrustedRipgrepPath,
+  runRipgrep,
   tagHasSub44Height,
 } from '../../../lib/a11y-gates/touch-target-engine';
 
@@ -75,6 +87,94 @@ describe('touch-target ratchet', () => {
 });
 
 describe('touch-target detection — violations are caught (red→green proof)', () => {
+  it('prefilters candidates deterministically and falls back only on rg errors', () => {
+    const scanRoot = mkdtempSync(join(tmpdir(), 'touch-target-ratchet-'));
+    const result =
+      (status: number | null, stdout = '', error?: Error): RipgrepRunner =>
+      () => ({ status, stdout, error });
+
+    try {
+      mkdirSync(join(scanRoot, 'app'), { recursive: true });
+      mkdirSync(join(scanRoot, 'components'), { recursive: true });
+      writeFileSync(join(scanRoot, 'app', 'a.tsx'), '<button />');
+      writeFileSync(join(scanRoot, 'components', 'z.tsx'), '<button />');
+
+      const expected = [
+        join(scanRoot, 'app', 'a.tsx'),
+        join(scanRoot, 'components', 'z.tsx'),
+      ];
+      expect(
+        findTouchTargetSourceFiles(
+          scanRoot,
+          result(0, 'components/z.tsx\napp/a.tsx\n')
+        )
+      ).toEqual(expected);
+      expect(
+        findTouchTargetSourceFiles(
+          scanRoot,
+          result(0, 'app/a.tsx\ncomponents/z.tsx\n')
+        )
+      ).toEqual(expected);
+      expect(findTouchTargetSourceFiles(scanRoot, result(1))).toEqual([]);
+      expect(findTouchTargetSourceFiles(scanRoot, result(2))).toEqual(expected);
+      expect(
+        findTouchTargetSourceFiles(
+          scanRoot,
+          result(null, '', new Error('spawnSync rg ENOENT'))
+        )
+      ).toEqual(expected);
+    } finally {
+      rmSync(scanRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('uses only trusted absolute rg paths and falls back when none exist', () => {
+    const scanRoot = mkdtempSync(join(tmpdir(), 'touch-target-no-rg-'));
+
+    try {
+      mkdirSync(join(scanRoot, 'app'), { recursive: true });
+      writeFileSync(join(scanRoot, 'app', 'fallback.tsx'), '<button />');
+
+      expect(resolveTrustedRipgrepPath(() => false)).toBeNull();
+      expect(
+        findTouchTargetSourceFiles(scanRoot, root =>
+          runRipgrep(root, () => null)
+        )
+      ).toEqual([join(scanRoot, 'app', 'fallback.tsx')]);
+    } finally {
+      rmSync(scanRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('ripgrep candidates preserve multiline and arbitrary-token violations', () => {
+    const scanRoot = mkdtempSync(join(tmpdir(), 'touch-target-parity-'));
+
+    try {
+      mkdirSync(join(scanRoot, 'app'), { recursive: true });
+      mkdirSync(join(scanRoot, 'components'), { recursive: true });
+      writeFileSync(
+        join(scanRoot, 'app', 'multiline.tsx'),
+        '<button\n className="h-8 w-8"\n>compact</button>\n'
+      );
+      writeFileSync(
+        join(scanRoot, 'components', 'arbitrary.tsx'),
+        '<a className="size-[43.5px]">compact</a>\n'
+      );
+      writeFileSync(
+        join(scanRoot, 'components', 'safe.tsx'),
+        '<button className="h-11">safe</button>\n'
+      );
+
+      const fallback: RipgrepRunner = () => ({ status: 2, stdout: '' });
+      expect(countViolations(scanRoot)).toEqual(
+        countViolations(scanRoot, fallback)
+      );
+      expect(countViolations(scanRoot)).toHaveLength(2);
+    } finally {
+      rmSync(scanRoot, { recursive: true, force: true });
+    }
+  });
+
   it('RED: flags a sub-44px icon button', () => {
     const violations = findViolationsInSource(
       '<button className="h-8 w-8 rounded-full" onClick={fn}>x</button>'

--- a/apps/web/tests/unit/metrics-layer-guard-logic.ts
+++ b/apps/web/tests/unit/metrics-layer-guard-logic.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 /**
@@ -56,15 +56,18 @@ const RATE_DERIVATION_LEGACY = /\*\s*1000\s*\)\s*\/\s*10\b/g;
 
 function walk(dir: string, out: string[]): void {
   if (!existsSync(dir)) return;
-  for (const entry of readdirSync(dir)) {
-    if (SKIP_DIRS.has(entry)) continue;
-    const full = join(dir, entry);
-    const s = statSync(full);
-    if (s.isDirectory()) {
+  // Dirent already carries the file type from the directory read. Avoiding a
+  // separate statSync for every entry keeps this repository-wide guard bounded
+  // when the shared runner's filesystem is under load.
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
       walk(full, out);
     } else if (
-      SOURCE_EXT.test(entry) &&
-      !/\.(test|spec|stories)\./.test(entry)
+      entry.isFile() &&
+      SOURCE_EXT.test(entry.name) &&
+      !/\.(test|spec|stories)\./.test(entry.name)
     ) {
       out.push(full);
     }

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -1,0 +1,64 @@
+export type CiFailureClass =
+  | 'bounded_source_scan_timeout'
+  | 'runner_process_exhaustion'
+  | 'runner_host_pressure'
+  | 'unknown';
+
+export interface CiFailureDiagnosis {
+  readonly failureClass: CiFailureClass;
+  readonly rootCause: string;
+  readonly remediation: string;
+}
+
+const DIAGNOSES: ReadonlyArray<{
+  readonly failureClass: Exclude<CiFailureClass, 'unknown'>;
+  readonly matches: (log: string) => boolean;
+  readonly rootCause: string;
+  readonly remediation: string;
+}> = [
+  {
+    failureClass: 'bounded_source_scan_timeout',
+    matches: log =>
+      /(?:analytics-metrics-layer-guard|touch-target-ratchet)\.test\.ts/i.test(
+        log
+      ) && /(?:test timed out|timeout).*?\b\d+\s*ms/is.test(log),
+    rootCause:
+      'A repository-wide source ratchet exceeded its bounded test timeout while scanning the source tree.',
+    remediation:
+      'Inspect the ratchet scanner for unbounded per-file filesystem work; do not classify this as runner EAGAIN or increase the test timeout.',
+  },
+  {
+    failureClass: 'runner_process_exhaustion',
+    matches: log =>
+      /\bEAGAIN\b|ERR_WORKER_INIT_FAILED|resource temporarily unavailable/i.test(
+        log
+      ),
+    rootCause:
+      'The runner could not create a process or worker because process resources were exhausted.',
+    remediation:
+      'Reduce runner process pressure or retry on a healthy runner; do not modify the failing test based on this signature alone.',
+  },
+  {
+    failureClass: 'runner_host_pressure',
+    matches: log =>
+      /pressure stall information|\bPSI\b|sustained (?:cpu|memory|i\/o) pressure/i.test(
+        log
+      ),
+    rootCause:
+      'Runner pressure telemetry shows sustained host-level resource contention.',
+    remediation:
+      'Inspect runner capacity and workload concurrency before changing application or test code.',
+  },
+];
+
+export function diagnoseCiFailure(log: string): CiFailureDiagnosis {
+  const diagnosis = DIAGNOSES.find(candidate => candidate.matches(log));
+  if (diagnosis) return diagnosis;
+
+  return {
+    failureClass: 'unknown',
+    rootCause: 'No deterministic CI failure signature matched the failed log.',
+    remediation:
+      'Inspect the failed check and add a narrow diagnosis if it recurs.',
+  };
+}

--- a/scripts/hermes/jobs/ci-failure-monitor.ts
+++ b/scripts/hermes/jobs/ci-failure-monitor.ts
@@ -17,6 +17,7 @@ import { ensureJovieRepoCwd } from '../lib/ensure-jovie-repo-cwd';
 import { gbrainLearn, gbrainSlug } from '../lib/gbrain';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
 import { buildFollowUpBody, fileIssue } from '../lib/tracker-client';
+import { diagnoseCiFailure } from './ci-failure-diagnosis';
 
 const JOB = 'ci-failure-monitor';
 
@@ -110,6 +111,7 @@ async function processFailure(
 ): Promise<void> {
   const log = logsForRun(run.databaseId);
   const known = classifyAgainstKnown(log, run.workflowName, flakes);
+  const diagnosis = diagnoseCiFailure(log);
 
   if (known) {
     logJobEvent({
@@ -127,7 +129,7 @@ async function processFailure(
     description: buildFollowUpBody({
       source: `ci-failure-monitor`,
       sourceUrl: run.url,
-      followUp: `Workflow "${run.workflowName}" failed on main at ${run.createdAt}. Title: ${run.displayTitle}. Investigate root cause; if it's a known flake, add a signature to scripts/hermes/jobs/known-flakes.json so future runs auto-classify.`,
+      followUp: `Workflow "${run.workflowName}" failed on main at ${run.createdAt}. Title: ${run.displayTitle}. Deterministic diagnosis: ${diagnosis.failureClass}. ${diagnosis.rootCause} Recommended remediation: ${diagnosis.remediation}`,
       whyItMatters:
         'Unclassified CI failures on main block deploys and erode trust in the merge gate.',
       classification: 'Required',
@@ -141,6 +143,7 @@ async function processFailure(
     job: JOB,
     event: filed.success ? 'issue_filed' : 'file_failed',
     runId: run.databaseId,
+    failureClass: diagnosis.failureClass,
     identifier: filed.identifier,
     error: filed.error,
   });
@@ -151,8 +154,12 @@ async function processFailure(
   gbrainLearn({
     slug: `ci-failures/${gbrainSlug(run.workflowName)}`,
     title: `CI failure: ${run.workflowName} on main`,
-    body: `Workflow "${run.workflowName}" failed on main.\n\n- Latest run: ${run.databaseId} (${run.createdAt})\n- Title: ${run.displayTitle}\n- URL: ${run.url}\n- Linear: ${filed.identifier ?? 'not filed'}`,
-    tags: ['type:ci-failure', `workflow:${gbrainSlug(run.workflowName)}`],
+    body: `Workflow "${run.workflowName}" failed on main.\n\n- Latest run: ${run.databaseId} (${run.createdAt})\n- Title: ${run.displayTitle}\n- Failure class: ${diagnosis.failureClass}\n- Root cause: ${diagnosis.rootCause}\n- Remediation: ${diagnosis.remediation}\n- URL: ${run.url}\n- Linear: ${filed.identifier ?? 'not filed'}`,
+    tags: [
+      'type:ci-failure',
+      `workflow:${gbrainSlug(run.workflowName)}`,
+      `failure-class:${diagnosis.failureClass}`,
+    ],
     type: 'ci-failure',
   });
 }

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { diagnoseCiFailure } from '../../jobs/ci-failure-diagnosis';
+
+describe('diagnoseCiFailure', () => {
+  it('classifies the analytics scanner timeout separately from runner pressure', () => {
+    const log = `
+      FAIL tests/unit/analytics-metrics-layer-guard.test.ts > canonical metrics layer guard
+      Error: Test timed out in 12000ms.
+      PSI telemetry: sustained I/O pressure
+    `;
+
+    expect(diagnoseCiFailure(log).failureClass).toBe(
+      'bounded_source_scan_timeout'
+    );
+  });
+
+  it('classifies the touch-target ratchet as the same bounded scanner class', () => {
+    expect(
+      diagnoseCiFailure(`
+        FAIL tests/unit/design-system/touch-target-ratchet.test.ts
+        Error: Test timed out in 12000ms.
+      `).failureClass
+    ).toBe('bounded_source_scan_timeout');
+  });
+
+  it('keeps process exhaustion and host pressure as distinct failure classes', () => {
+    expect(
+      diagnoseCiFailure('ERR_WORKER_INIT_FAILED: spawnSync node EAGAIN')
+        .failureClass
+    ).toBe('runner_process_exhaustion');
+    expect(
+      diagnoseCiFailure('PSI: sustained memory pressure on runner').failureClass
+    ).toBe('runner_host_pressure');
+  });
+});


### PR DESCRIPTION
## Root cause

Two repository-wide Vitest ratchets amplified cold/shared-runner filesystem contention:

- analytics metrics guard performed a statSync for every tree entry before reading roughly 4,200 source files; PR #14361 observed 24.178s against a 12s timeout.
- touch-target ratchet synchronously opened every app/components TSX file; PR #14369 observed 12.180s against a 12s timeout.

These are bounded-source-scan failures, distinct from runner EAGAIN/process exhaustion and PSI host pressure.

## Fix

- use Dirent metadata in the analytics walker, eliminating per-entry statSync calls
- prefilter touch-target candidates with ripgrep while treating exit 1 as a valid empty set and falling back to the complete walker on missing/error exits
- preserve sorted deterministic paths and parser parity for multiline/arbitrary tokens
- add deterministic Gem diagnoses for bounded scanner timeout, process exhaustion, and host pressure

## Verification

- analytics guard: 2/2 passed; full scan 0.77-2.47s in focused/full runs
- touch-target guard: 14/14 passed; optimized/fallback parity 222 violations; full scan 0.42-2.11s
- Gem diagnosis: 3/3 passed
- web typecheck and Biome passed
- normal pre-push affected gate: all 10 test batches passed; CI harness validation passed

## Risk

Draft and gated. No timeout inflation, known-flake suppression, or affected-PR rerun.