### PR TITLE
fix(ci): require canonical production promotion

### DIFF
--- a/.github/scripts/promote-production-deployment.sh
+++ b/.github/scripts/promote-production-deployment.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+deploy_id="${PRODUCTION_DEPLOYMENT_ID:-}"
+vercel_cli="${VERCEL_CLI:-./node_modules/.bin/vercel}"
+poll_seconds="${PRODUCTION_PROMOTION_POLL_SECONDS:-5}"
+settle_attempts="${PRODUCTION_PROMOTION_SETTLE_ATTEMPTS:-36}"
+cleanup_attempts="${PRODUCTION_PROMOTION_CLEANUP_ATTEMPTS:-12}"
+promote_timeout="${PRODUCTION_PROMOTION_CLI_TIMEOUT:-3m}"
+
+write_failure() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf 'failure_subtype=%s\n' "$1" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+for required in deploy_id VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+  if [ -z "${!required:-}" ]; then
+    echo "${required} is required" >&2
+    write_failure production_promotion_state_invalid
+    exit 2
+  fi
+done
+
+if [[ "$deploy_id" != dpl_* ]] ||
+  ! [[ "$poll_seconds" =~ ^[0-9]+$ ]] ||
+  ! [[ "$settle_attempts" =~ ^[1-9][0-9]*$ ]] ||
+  ! [[ "$cleanup_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Promotion inputs are invalid." >&2
+  write_failure production_promotion_state_invalid
+  exit 2
+fi
+
+vercel() {
+  "$vercel_cli" "$@" \
+    --token "$VERCEL_TOKEN" \
+    --scope "$VERCEL_ORG_ID" \
+    --no-color
+}
+
+valid_current_json() {
+  jq -e '
+    type == "object" and
+    (.id | type == "string") and
+    (.readyState | type == "string") and
+    (.target | type == "string")
+  ' >/dev/null 2>&1
+}
+
+inspect_current() {
+  local result=""
+  if ! result="$(vercel inspect jov.ie --format=json 2>/dev/null)" ||
+    ! valid_current_json <<<"$result"; then
+    return 1
+  fi
+  printf '%s\n' "$result"
+}
+
+fetch_rollout() {
+  local result=""
+  if ! result="$(vercel rolling-release fetch 2>/dev/null)" ||
+    ! jq -e 'type == "object" or . == null' >/dev/null 2>&1 <<<"$result"; then
+    return 1
+  fi
+  printf '%s\n' "$result"
+}
+
+rollout_is_active() {
+  jq -e '. != null and .activeStage != null' >/dev/null 2>&1 <<<"$1"
+}
+
+rollout_target_id() {
+  jq -r '
+    if . == null then ""
+    else (
+      .canaryDeployment.id //
+      .canaryDeploymentId //
+      .default.targetDeploymentId //
+      .targetDeploymentId //
+      ""
+    )
+    end
+  ' <<<"$1"
+}
+
+current_json=""
+rollout_json=""
+if ! current_json="$(inspect_current)" || ! rollout_json="$(fetch_rollout)"; then
+  echo "Unable to establish canonical production state before promotion." >&2
+  write_failure production_promotion_state_invalid
+  exit 1
+fi
+
+previous_id="$(jq -r '.id' <<<"$current_json")"
+if [[ "$previous_id" != dpl_* ]]; then
+  echo "Current jov.ie deployment has an invalid deployment ID." >&2
+  write_failure production_promotion_state_invalid
+  exit 1
+fi
+
+echo "Current production deployment before promotion: $previous_id"
+
+promotion_requested=false
+promote_status=0
+complete_requested=false
+current_ready="$(jq -r '.readyState | ascii_upcase' <<<"$current_json")"
+current_target="$(jq -r '.target | ascii_downcase' <<<"$current_json")"
+if [ "$previous_id" = "$deploy_id" ] &&
+  [ "$current_ready" = "READY" ] &&
+  [ "$current_target" = "production" ] &&
+  ! rollout_is_active "$rollout_json"; then
+  echo "Production Current is already terminal on $deploy_id."
+  exit 0
+elif rollout_is_active "$rollout_json"; then
+  active_target="$(rollout_target_id "$rollout_json")"
+  if [ "$active_target" != "$deploy_id" ]; then
+    echo "A foreign rolling release is active for ${active_target:-<unknown>}; refusing to mutate production." >&2
+    write_failure production_promotion_foreign_rollout
+    exit 1
+  fi
+  echo "Resuming the already-active rolling release for $deploy_id."
+else
+  promotion_requested=true
+  promote_output="$(vercel promote "$deploy_id" --yes --timeout "$promote_timeout" 2>&1)" || promote_status=$?
+  printf '%s\n' "$promote_output"
+  if [ "$promote_status" -ne 0 ]; then
+    echo "Promotion command exited ${promote_status}; checking server state without resubmitting." >&2
+  fi
+fi
+
+abort_owned_rollout() {
+  local cleanup_rollout=""
+  local cleanup_target=""
+  local cleanup_current=""
+
+  if ! cleanup_rollout="$(fetch_rollout)"; then
+    echo "Cannot verify rollout ownership for cleanup." >&2
+    return 1
+  fi
+
+  if rollout_is_active "$cleanup_rollout"; then
+    cleanup_target="$(rollout_target_id "$cleanup_rollout")"
+    if [ "$cleanup_target" != "$deploy_id" ]; then
+      echo "Refusing cleanup because the active rollout is not owned by this deployment." >&2
+      return 1
+    fi
+    echo "Aborting the owned rolling release for $deploy_id." >&2
+    if ! vercel rolling-release abort --dpl "$deploy_id"; then
+      return 1
+    fi
+  fi
+
+  for cleanup_attempt in $(seq 1 "$cleanup_attempts"); do
+    if cleanup_current="$(inspect_current)" && cleanup_rollout="$(fetch_rollout)"; then
+      cleanup_current_id="$(jq -r '.id' <<<"$cleanup_current")"
+      cleanup_ready="$(jq -r '.readyState | ascii_upcase' <<<"$cleanup_current")"
+      cleanup_target_type="$(jq -r '.target | ascii_downcase' <<<"$cleanup_current")"
+
+      if [ "$cleanup_current_id" = "$deploy_id" ] &&
+        [ "$cleanup_ready" = "READY" ] &&
+        [ "$cleanup_target_type" = "production" ] &&
+        ! rollout_is_active "$cleanup_rollout"; then
+        echo "Production completed while cleanup was being evaluated."
+        return 2
+      fi
+
+      if [ "$cleanup_current_id" = "$previous_id" ] &&
+        [ "$cleanup_ready" = "READY" ] &&
+        [ "$cleanup_target_type" = "production" ] &&
+        ! rollout_is_active "$cleanup_rollout"; then
+        echo "Rollback verified: production Current remains $previous_id." >&2
+        return 0
+      fi
+    fi
+
+    if [ "$cleanup_attempt" -lt "$cleanup_attempts" ]; then
+      sleep "$poll_seconds"
+    fi
+  done
+
+  return 1
+}
+
+last_state_valid=false
+last_rollout_active=false
+last_rollout_target=""
+for attempt in $(seq 1 "$settle_attempts"); do
+  if current_json="$(inspect_current)" && rollout_json="$(fetch_rollout)"; then
+    last_state_valid=true
+    current_id="$(jq -r '.id' <<<"$current_json")"
+    current_ready="$(jq -r '.readyState | ascii_upcase' <<<"$current_json")"
+    current_target="$(jq -r '.target | ascii_downcase' <<<"$current_json")"
+    last_rollout_active=false
+    last_rollout_target=""
+    if rollout_is_active "$rollout_json"; then
+      last_rollout_active=true
+      last_rollout_target="$(rollout_target_id "$rollout_json")"
+    fi
+
+    echo "  promotion attempt ${attempt}/${settle_attempts}: current=${current_id} ready=${current_ready} rollout=${last_rollout_target:-none}"
+
+    if [ "$current_id" = "$deploy_id" ] &&
+      [ "$current_ready" = "READY" ] &&
+      [ "$current_target" = "production" ] &&
+      [ "$last_rollout_active" = "false" ]; then
+      echo "Production Current is terminal on $deploy_id."
+      exit 0
+    fi
+
+    if [ "$last_rollout_active" = "true" ]; then
+      if [ "$last_rollout_target" != "$deploy_id" ]; then
+        echo "A foreign rolling release became active for ${last_rollout_target:-<unknown>}; refusing further mutation." >&2
+        write_failure production_promotion_foreign_rollout
+        exit 1
+      fi
+
+      if [ "$complete_requested" != "true" ]; then
+        complete_requested=true
+        if ! vercel rolling-release complete --dpl "$deploy_id"; then
+          echo "Rolling-release completion request failed; observing terminal state without resubmitting." >&2
+        fi
+      fi
+    fi
+  else
+    last_state_valid=false
+    echo "  promotion attempt ${attempt}/${settle_attempts}: state unavailable or malformed" >&2
+  fi
+
+  if [ "$attempt" -lt "$settle_attempts" ]; then
+    sleep "$poll_seconds"
+  fi
+done
+
+if [ "$last_state_valid" != "true" ]; then
+  cleanup_status=0
+  abort_owned_rollout || cleanup_status=$?
+  if [ "$cleanup_status" -eq 2 ]; then
+    exit 0
+  fi
+  write_failure production_promotion_state_invalid
+  exit 1
+fi
+
+if [ "$last_rollout_active" = "true" ] && [ "$last_rollout_target" = "$deploy_id" ]; then
+  cleanup_status=0
+  abort_owned_rollout || cleanup_status=$?
+  if [ "$cleanup_status" -eq 2 ]; then
+    exit 0
+  fi
+  if [ "$cleanup_status" -ne 0 ]; then
+    write_failure production_promotion_rollback_failed
+    exit 1
+  fi
+fi
+
+if [ "$promote_status" -ne 0 ] || [ "$promotion_requested" = "true" ]; then
+  write_failure production_promotion_failed
+else
+  write_failure production_promotion_state_blocked
+fi
+exit 1

--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -149,6 +149,7 @@ try_mode() {
 
 plain_prebuilt_limit=15000
 plain_prebuilt_requested="${VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK:-false}"
+source_fallback_requested="${VERCEL_ENABLE_SOURCE_FALLBACK:-true}"
 force_source_deploy="${VERCEL_FORCE_SOURCE_DEPLOY:-false}"
 prebuilt_file_count="$(count_prebuilt_files)"
 has_prebuilt_output=true
@@ -174,7 +175,13 @@ resolve_vercel_cmd
 echo "Using Vercel CLI command: ${VERCEL_CMD[*]}"
 echo "Plain prebuilt fallback requested: $plain_prebuilt_requested"
 echo "Plain prebuilt fallback enabled: $can_use_plain_prebuilt"
+echo "Source fallback requested: $source_fallback_requested"
 echo "Force source deploy: $force_source_deploy"
+
+if [ "$force_source_deploy" = "true" ] && [ "$source_fallback_requested" != "true" ]; then
+  echo "Deploy failed: force-source and disabled source fallback are mutually exclusive." >&2
+  exit 1
+fi
 
 deploy_modes=()
 
@@ -186,7 +193,14 @@ if [ "$can_use_plain_prebuilt" = true ] && [ "$force_source_deploy" != "true" ];
   deploy_modes+=(plain)
 fi
 
-deploy_modes+=(source)
+if [ "$force_source_deploy" = "true" ] || [ "$source_fallback_requested" = "true" ]; then
+  deploy_modes+=(source)
+fi
+
+if [ "${#deploy_modes[@]}" -eq 0 ]; then
+  echo "Deploy failed: no prebuilt output is available and source fallback is disabled." >&2
+  exit 1
+fi
 total_attempts="${#deploy_modes[@]}"
 attempt=0
 

--- a/.github/scripts/verify-production-alias.sh
+++ b/.github/scripts/verify-production-alias.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_sha="${EXPECTED_COMMIT_SHA:-}"
+expected_deploy_id="${EXPECTED_PRODUCTION_DEPLOYMENT_ID:-}"
+canonical_domain="${PRODUCTION_DOMAIN:-jov.ie}"
+canonical_url="${PRODUCTION_BUILD_INFO_URL:-https://jov.ie/api/health/build-info}"
+vercel_cli="${VERCEL_CLI:-./node_modules/.bin/vercel}"
+max_attempts="${PRODUCTION_ALIAS_MAX_ATTEMPTS:-15}"
+retry_seconds="${PRODUCTION_ALIAS_RETRY_SECONDS:-10}"
+required_rounds="${PRODUCTION_ALIAS_REQUIRED_ROUNDS:-3}"
+
+write_failure() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf 'failure_subtype=production_alias_not_updated\n' >> "$GITHUB_OUTPUT"
+  fi
+}
+
+if [ -z "$expected_sha" ] || [ -z "$expected_deploy_id" ] ||
+  [ -z "${VERCEL_TOKEN:-}" ] || [ -z "${VERCEL_ORG_ID:-}" ]; then
+  echo "EXPECTED_COMMIT_SHA, EXPECTED_PRODUCTION_DEPLOYMENT_ID, VERCEL_TOKEN, and VERCEL_ORG_ID are required." >&2
+  write_failure
+  exit 2
+fi
+
+expected_sha="${expected_sha:0:7}"
+if [[ "$expected_deploy_id" != dpl_* ]] ||
+  ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]] ||
+  ! [[ "$retry_seconds" =~ ^[0-9]+$ ]] ||
+  ! [[ "$required_rounds" =~ ^[1-9][0-9]*$ ]] ||
+  [ "$required_rounds" -gt "$max_attempts" ]; then
+  echo "Production alias verifier inputs are invalid." >&2
+  write_failure
+  exit 2
+fi
+
+vercel() {
+  "$vercel_cli" "$@" \
+    --token "$VERCEL_TOKEN" \
+    --scope "$VERCEL_ORG_ID" \
+    --no-color
+}
+
+curl_args=(
+  -sS
+  -L
+  --connect-timeout 3
+  --max-time 5
+  -A "Mozilla/5.0 (compatible; JovieCI/1.0; +https://jov.ie)"
+  -H "Cache-Control: no-cache, no-store, must-revalidate"
+  -H "Pragma: no-cache"
+)
+
+last_status=""
+last_sha=""
+last_current_id=""
+consecutive_rounds=0
+for attempt in $(seq 1 "$max_attempts"); do
+  if [ "$attempt" -gt 1 ]; then
+    sleep "$retry_seconds"
+  fi
+
+  current_ok=false
+  current_json=""
+  if current_json="$(vercel inspect "$canonical_domain" --format=json 2>/dev/null)" &&
+    jq -e '
+      type == "object" and
+      (.id | type == "string") and
+      (.readyState | type == "string") and
+      (.target | type == "string")
+    ' >/dev/null 2>&1 <<<"$current_json"; then
+    last_current_id="$(jq -r '.id' <<<"$current_json")"
+    current_ready="$(jq -r '.readyState | ascii_upcase' <<<"$current_json")"
+    current_target="$(jq -r '.target | ascii_downcase' <<<"$current_json")"
+    if [ "$last_current_id" = "$expected_deploy_id" ] &&
+      [ "$current_ready" = "READY" ] &&
+      [ "$current_target" = "production" ]; then
+      current_ok=true
+    fi
+  fi
+
+  echo "  attempt ${attempt}/${max_attempts} production-current: id=${last_current_id:-<unknown>} expected=${expected_deploy_id}"
+
+  round_ok="$current_ok"
+  for routing in plain stable canary; do
+    routing_query=""
+    case "$routing" in
+      stable) routing_query="vcrrForceStable=true" ;;
+      canary) routing_query="vcrrForceCanary=true" ;;
+    esac
+
+    separator="?"
+    [[ "$canonical_url" == *"?"* ]] && separator="&"
+    probe_url="${canonical_url}${separator}_cb=$(date +%s%N)"
+    if [ -n "$routing_query" ]; then
+      probe_url="${probe_url}&${routing_query}"
+    fi
+
+    response="$(curl "${curl_args[@]}" -w "\n%{http_code}" "$probe_url" 2>/dev/null || printf '\n000')"
+    last_status="${response##*$'\n'}"
+    body="${response%$'\n'*}"
+    last_sha="$(printf '%s' "$body" | jq -r '.commitSha // ""' 2>/dev/null || echo "")"
+    environment="$(printf '%s' "$body" | jq -r '.environment // ""' 2>/dev/null || echo "")"
+
+    echo "  attempt ${attempt}/${max_attempts} production-alias/${routing}: HTTP ${last_status}, commitSha=${last_sha:-<empty>}, environment=${environment:-<empty>}"
+    if [ "$last_status" != "200" ] ||
+      [ "$last_sha" != "$expected_sha" ] ||
+      [ "$environment" != "production" ]; then
+      round_ok=false
+    fi
+  done
+
+  if [ "$round_ok" = "true" ]; then
+    consecutive_rounds=$((consecutive_rounds + 1))
+    if [ "$consecutive_rounds" -ge "$required_rounds" ]; then
+      echo "Canonical production is ${expected_deploy_id} and serves ${expected_sha} across ${required_rounds} consecutive routing rounds."
+      exit 0
+    fi
+  else
+    consecutive_rounds=0
+  fi
+done
+
+echo "Canonical production did not converge: current='${last_current_id:-<unknown>}', HTTP ${last_status:-<unknown>}, commitSha='${last_sha:-<empty>}', expected deployment '${expected_deploy_id}' and SHA '${expected_sha}'." >&2
+write_failure
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2564,10 +2564,17 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
-      - name: Wait for CDN propagation
-        run: |
-          echo "Waiting 30s for Vercel CDN propagation after deploy..."
-          sleep 30
+      - name: Verify exact production deployment before smoke
+        timeout-minutes: 2
+        env:
+          EXPECTED_COMMIT_SHA: ${{ github.sha }}
+          EXPECTED_PRODUCTION_DEPLOYMENT_ID: ${{ needs.promote-production.outputs.production_deployment_id }}
+          PRODUCTION_ALIAS_MAX_ATTEMPTS: '3'
+          PRODUCTION_ALIAS_REQUIRED_ROUNDS: '1'
+          PRODUCTION_ALIAS_RETRY_SECONDS: '5'
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+        run: bash .github/scripts/verify-production-alias.sh
 
       - name: Verify production endpoints are healthy
         env:
@@ -5365,14 +5372,13 @@ jobs:
             if [ $i -eq 3 ]; then exit 1; fi
           done
         env:
-          # The restored prebuilt artifact uploads but its function runtime is
-          # not healthy. Use Vercel's source-build cache until the artifact is
-          # proven runtime-closed by canary.
-          VERCEL_FORCE_SOURCE_DEPLOY: 'true'
           VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
           # The closed staging artifact contains more than Vercel's 15k plain
           # upload limit. Give the archive path the full prebuilt budget.
           VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'false'
+          # The restored artifact is the thing canary verifies. A source
+          # fallback would silently discard it and repeat the slow server build.
+          VERCEL_ENABLE_SOURCE_FALLBACK: 'false'
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
 
@@ -5466,7 +5472,7 @@ jobs:
     needs: [deploy-staging, canary-health-gate, alias-staging]
     if: ${{ always() && needs.deploy-staging.result == 'success' && needs.canary-health-gate.result == 'success' && needs.alias-staging.result == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
     concurrency:
       group: production-deploy
       cancel-in-progress: false
@@ -5476,11 +5482,10 @@ jobs:
     outputs:
       # Emitted when promote-production exits non-zero so deploy-notify can
       # distinguish silent-no-op regressions from generic promote failures.
-      # Values: "domain_project_mismatch" (public domains are not on the
-      # canonical Vercel project) | "no_match" (no Vercel deployment for
-      # github.sha) | "verify_mismatch" (production keeps serving the old
-      # commit after promote).
-      failure_subtype: ${{ steps.domain-guard.outputs.failure_subtype || steps.promote.outputs.failure_subtype }}
+      # Values distinguish production artifact, promotion state, and canonical
+      # alias convergence failures for deploy-notify and Gem diagnosis.
+      failure_subtype: ${{ steps.domain-guard.outputs.failure_subtype || steps.stage-production.outputs.failure_subtype || steps.promote.outputs.failure_subtype || steps.verify-production.outputs.failure_subtype }}
+      production_deployment_id: ${{ steps.stage-production.outputs.production_deployment_id }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-node-pnpm
@@ -5495,9 +5500,9 @@ jobs:
             echo "failure_subtype=domain_project_mismatch" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-      - name: Promote specific deployment for this SHA
-        timeout-minutes: 10
-        id: promote
+      - name: Build and stage production deployment
+        id: stage-production
+        timeout-minutes: 30
         env:
           GITHUB_SHA: ${{ github.sha }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -5505,211 +5510,166 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
-          # Resolve the exact deployment URL for github.sha via the Vercel API.
-          # We deliberately do NOT promote the staging.jov.ie alias: if staging
-          # drifts (silent `vercel alias set` failure, stale alias), promoting
-          # the alias hits "already the current production deployment" and
-          # silently no-ops. That regression kept production 7 days stale in
-          # 2026-04. Looking up by SHA means the only way to silently succeed
-          # is if we actually promote the right commit.
           set -euo pipefail
-          echo "Resolving deployment URL for SHA ${GITHUB_SHA}..."
-          deploy_url="$(python3 - <<'PY'
-          import json
-          import os
-          import sys
-          import urllib.parse
-          import urllib.request
 
-          token = os.environ.get("VERCEL_TOKEN", "")
-          org_id = os.environ.get("VERCEL_ORG_ID", "")
-          project_id = os.environ.get("VERCEL_PROJECT_ID", "")
-          commit_sha = os.environ.get("GITHUB_SHA", "")
-
-          # Distinguish missing-creds from genuine no-match so the shell can
-          # pick a different failure subtype. Without this, an unset secret
-          # silently triggers the `no_match` Slack alert.
-          if not token or not project_id or not commit_sha:
-              print("__MISSING_CREDS__", end="")
-              sys.exit(0)
-
-          # Paginate over READY deployments until we find the SHA or the
-          # Vercel API says there are no more pages. A hard page cap prevents
-          # runaway API calls on pathological account state.
-          #
-          # No target filter: the upstream deploy-staging job uses
-          # `vercel deploy --prebuilt` (via vercel-prebuilt-deploy.sh) without
-          # --prod, which creates PREVIEW deployments. Filtering by
-          # target=production would never match and every promote would fail
-          # with no_match. Preview-collision safety comes from (a) projectId
-          # scoping the query to this project, (b) exact 40-char SHA match,
-          # and (c) the `vercel promote` step itself, which only accepts URLs
-          # from the same project.
-          base_params = {
-              "projectId": project_id,
-              "state": "READY",
-              "limit": 100,
+          fail_stage() {
+            echo "::error::$1"
+            echo "failure_subtype=$2" >> "$GITHUB_OUTPUT"
+            exit 1
           }
-          if org_id.startswith("team_"):
-              base_params["teamId"] = org_id
 
-          next_cursor = None
-          found = False
-          for _page in range(10):  # hard cap: 1000 deployments searched
-              params = dict(base_params)
-              if next_cursor is not None:
-                  params["until"] = next_cursor
-              url = f"https://api.vercel.com/v6/deployments?{urllib.parse.urlencode(params)}"
-              req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
-              with urllib.request.urlopen(req, timeout=15) as response:
-                  payload = json.load(response)
-
-              deployments = payload.get("deployments", [])
-              for deployment in deployments:
-                  meta = deployment.get("meta") or {}
-                  if meta.get("githubCommitSha") == commit_sha:
-                      print(f"https://{deployment['url']}")
-                      found = True
-                      break
-              if found:
-                  break
-
-              pagination = payload.get("pagination") or {}
-              next_cursor = pagination.get("next")
-              if not next_cursor or not deployments:
-                  break
-          PY
-          )"
-
-          if [ "$deploy_url" = "__MISSING_CREDS__" ]; then
-            echo "❌ Missing Vercel credentials (VERCEL_TOKEN / VERCEL_PROJECT_ID / GITHUB_SHA)."
-            echo "   Cannot resolve deployment URL. Check repo secrets."
-            echo "failure_subtype=missing_creds" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
-          if [ -z "$deploy_url" ]; then
-            echo "❌ No READY Vercel deployment found for SHA ${GITHUB_SHA}."
-            echo "   Either the deploy-staging job never produced a READY deployment"
-            echo "   (build error, timeout) or it sits beyond the 1000-deployment"
-            echo "   search window. Failing loudly instead of silently no-opping."
-            echo "failure_subtype=no_match" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-          echo "Found deployment for SHA: promoting..."
-
-          set +e
-          promote_output=$(./node_modules/.bin/vercel promote "$deploy_url" --yes --token "$VERCEL_TOKEN" --scope "$VERCEL_ORG_ID" 2>&1)
-          promote_exit_code=$?
-          set -e
-          printf '%s\n' "$promote_output"
-
-          if [ "$promote_exit_code" -ne 0 ]; then
-            # Re-running ship on the same SHA is legitimately idempotent.
-            if printf '%s' "$promote_output" | grep -q "already the current production deployment"; then
-              echo "Deployment for SHA ${GITHUB_SHA} is already in production; continuing to verify."
-            else
-              exit "$promote_exit_code"
+          missing=()
+          for key in GITHUB_SHA VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+            if [ -z "${!key:-}" ]; then
+              missing+=("$key")
             fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            fail_stage "Missing production deployment inputs: ${missing[*]}" missing_creds
           fi
 
-          # Verify production actually serves github.sha. /api/health/build-info
-          # returns commitSha as a 7-char slice of VERCEL_GIT_COMMIT_SHA (see
-          # apps/web/app/api/health/build-info/route.ts:35).
           expected="${GITHUB_SHA:0:7}"
-          USER_AGENT="Mozilla/5.0 (compatible; JovieCI/1.0; +https://jov.ie)"
-          BYPASS_ARGS=()
-          if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
-            BYPASS_ARGS+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
+          scope_args=(--scope "$VERCEL_ORG_ID")
+          rm -rf .vercel/output .vercel/.env.preview.local .vercel/.env.production.local .vercel/.env.local
+
+          if ! ./node_modules/.bin/vercel pull --yes --environment=production \
+            --token "$VERCEL_TOKEN" "${scope_args[@]}"; then
+            fail_stage "Unable to pull the Production environment." production_artifact_failed
           fi
 
-          # Prefer the deployment URL when Vercel allows direct access, but
-          # also verify the canonical production alias. Protected deployment
-          # URLs can return 401 even after a successful promote; jov.ie is the
-          # user-facing surface and catches domain/project wiring regressions.
-          probe_urls=(
-            "${deploy_url}/api/health/build-info"
-            "https://jov.ie/api/health/build-info"
-          )
-          probe_labels=(
-            "deployment"
-            "production-alias"
-          )
-          echo "Verifying promoted deployment serves ${expected}..."
-          # Track confirmed_mismatch separately from saw_valid_probe so a
-          # late 500 can't overwrite an earlier confirmed mismatch. Once we
-          # see a 200 with a wrong SHA, it IS a mismatch — routing a
-          # subsequent edge hiccup to verify_probe_failed would send the
-          # wrong alert path.
-          actual=""
-          last_status=""
-          saw_valid_probe=false
-          confirmed_mismatch=false
-          # Vercel edge rollout can lag behind a successful `vercel promote`.
-          # Keep verification strict, but use a bounded 5-minute window to
-          # avoid false negatives on healthy deploys.
-          max_attempts=15
-          for attempt in $(seq 1 "$max_attempts"); do
-            # Skip sleep on the first attempt; wait between retries so we
-            # don't burn 10s after the final failing attempt.
-            if [ "$attempt" -gt 1 ]; then
-              sleep 10
+          for env_file in .vercel/.env.production.local .vercel/.env.local; do
+            if [ -f "$env_file" ]; then
+              grep -v '^TURBO_REMOTE_ONLY=' "$env_file" > "${env_file}.tmp" || true
+              mv "${env_file}.tmp" "$env_file"
             fi
-            for index in "${!probe_urls[@]}"; do
-              probe_url="${probe_urls[$index]}"
-              probe_label="${probe_labels[$index]}"
-              response=$(curl -sS -L \
-                --connect-timeout 5 \
-                --max-time 10 \
-                -A "$USER_AGENT" \
-                -H "Cache-Control: no-cache" \
-                "${BYPASS_ARGS[@]}" \
-                -w "\n%{http_code}" \
-                "${probe_url}?_cb=$(date +%s%N)" 2>/dev/null || printf '\n000')
-              last_status="${response##*$'\n'}"
-              body="${response%$'\n'*}"
-
-              if [ "$last_status" != "200" ]; then
-                echo "  attempt ${attempt} ${probe_label}: build-info returned HTTP ${last_status}"
-                continue
-              fi
-
-              actual=$(printf '%s' "$body" | jq -r '.commitSha // ""' 2>/dev/null || echo "")
-              if [ -z "$actual" ]; then
-                echo "  attempt ${attempt} ${probe_label}: build-info returned 200 without commitSha"
-                continue
-              fi
-
-              echo "  attempt ${attempt} ${probe_label}: build-info commitSha=${actual}"
-              saw_valid_probe=true
-              if [ "$actual" = "$expected" ]; then
-                echo "✅ ${probe_label} serves ${expected} — promote succeeded."
-                exit 0
-              fi
-              confirmed_mismatch=true
-            done
           done
 
-          if [ "$confirmed_mismatch" = "true" ]; then
-            echo "❌ Production verification returned commitSha='${actual:-<empty>}' but expected '${expected}'."
-            echo "   The promoted deployment or jov.ie alias is serving a different SHA."
-            echo "failure_subtype=verify_mismatch" >> "$GITHUB_OUTPUT"
-            exit 1
+          if ! pnpm --filter=@jovie/web exec tsx scripts/check-signup-readiness.ts \
+            --target=prd --source=vercel-file; then
+            fail_stage "Production signup configuration is incomplete." production_artifact_failed
           fi
 
-          if [ "$saw_valid_probe" != "true" ]; then
-            echo "❌ Production build-info probes failed across all attempts (last HTTP ${last_status})."
-            echo "   Cannot confirm whether production is serving ${expected}."
-            echo "failure_subtype=verify_probe_failed" >> "$GITHUB_OUTPUT"
-            exit 1
+          if ! env -u TURBO_REMOTE_ONLY \
+            VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA" \
+            NEXT_PUBLIC_BUILD_SHA="$expected" \
+            ./node_modules/.bin/vercel build --prod \
+              --token "$VERCEL_TOKEN" "${scope_args[@]}"; then
+            fail_stage "Production Vercel build failed." production_artifact_failed
+          fi
+          if [ ! -f .vercel/output/config.json ]; then
+            fail_stage "Production build did not create .vercel/output/config.json." production_artifact_failed
           fi
 
-          # Unreachable: the loop either exits 0 on match, or both
-          # confirmed_mismatch=false and saw_valid_probe=false can't both
-          # hold — if we got here, something broke the control flow.
-          echo "❌ Verification loop finished in an unexpected state."
-          echo "failure_subtype=verify_probe_failed" >> "$GITHUB_OUTPUT"
-          exit 1
+          deploy_json=""
+          if ! deploy_json="$(./node_modules/.bin/vercel deploy \
+            --prebuilt --archive=tgz --prod --skip-domain --format=json \
+            --env "VERCEL_GIT_COMMIT_SHA=${GITHUB_SHA}" \
+            --env "NEXT_PUBLIC_BUILD_SHA=${expected}" \
+            --meta "githubCommitSha=${GITHUB_SHA}" \
+            --token "$VERCEL_TOKEN" "${scope_args[@]}")"; then
+            fail_stage "Production prebuilt deployment failed." production_artifact_failed
+          fi
+          if ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$deploy_json"; then
+            fail_stage "Production deploy returned malformed JSON." production_artifact_failed
+          fi
+
+          production_deploy_id="$(jq -r '.id // .deployment.id // ""' <<<"$deploy_json")"
+          production_deploy_url="$(jq -r '.url // .deployment.url // ""' <<<"$deploy_json")"
+          if [[ "$production_deploy_url" != *://* && "$production_deploy_url" == *.vercel.app ]]; then
+            production_deploy_url="https://${production_deploy_url}"
+          fi
+          production_deploy_url="${production_deploy_url%/}"
+          if [[ "$production_deploy_id" != dpl_* ]] ||
+            [[ "$production_deploy_url" != https://*.vercel.app ]]; then
+            fail_stage "Production deploy returned an invalid deployment ID or URL." production_artifact_failed
+          fi
+          echo "Staged production deployment: ${production_deploy_id} (${production_deploy_url})"
+
+          inspect_wait_status=0
+          ./node_modules/.bin/vercel inspect "$production_deploy_id" \
+            --wait --timeout 15m --token "$VERCEL_TOKEN" "${scope_args[@]}" ||
+            inspect_wait_status=$?
+          if ! production_deploy_json="$(./node_modules/.bin/vercel inspect \
+            "$production_deploy_id" --format=json --token "$VERCEL_TOKEN" \
+            "${scope_args[@]}")" ||
+            ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$production_deploy_json"; then
+            fail_stage "Unable to inspect the staged production deployment." staged_production_not_ready
+          fi
+
+          inspected_id="$(jq -r '.id // ""' <<<"$production_deploy_json")"
+          production_deploy_state="$(jq -r \
+            '(.readyState // .state // .status // "unknown") | ascii_upcase' \
+            <<<"$production_deploy_json")"
+          production_deploy_target="$(jq -r '(.target // "") | ascii_downcase' \
+            <<<"$production_deploy_json")"
+          if [ "$inspected_id" != "$production_deploy_id" ] ||
+            [ "$production_deploy_state" != "READY" ] ||
+            [ "$production_deploy_target" != "production" ]; then
+            fail_stage "Staged production deployment is not the exact READY Production target (wait status ${inspect_wait_status})." staged_production_not_ready
+          fi
+
+          bypass_args=()
+          if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
+            bypass_args+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
+          fi
+          fetch_staged() {
+            local url="$1"
+            local separator="?"
+            [[ "$url" == *"?"* ]] && separator="&"
+            STAGED_RESPONSE="$(curl -sS -L --connect-timeout 5 --max-time 15 \
+              -A "Mozilla/5.0 (compatible; JovieCI/1.0; +https://jov.ie)" \
+              -H "Cache-Control: no-cache, no-store, must-revalidate" \
+              "${bypass_args[@]}" -w "\n%{http_code}" \
+              "${url}${separator}_cb=$(date +%s%N)" \
+              2>/dev/null || printf '\n000')"
+            STAGED_STATUS="${STAGED_RESPONSE##*$'\n'}"
+            STAGED_BODY="${STAGED_RESPONSE%$'\n'*}"
+          }
+
+          fetch_staged "${production_deploy_url}/api/health/build-info"
+          staged_sha="$(printf '%s' "$STAGED_BODY" | jq -r '.commitSha // ""' 2>/dev/null || echo "")"
+          staged_environment="$(printf '%s' "$STAGED_BODY" | jq -r '.environment // ""' 2>/dev/null || echo "")"
+          if [ "$STAGED_STATUS" != "200" ] ||
+            [ "$staged_sha" != "$expected" ] ||
+            [ "$staged_environment" != "production" ]; then
+            fail_stage "Staged production build-info canary failed (HTTP ${STAGED_STATUS}, SHA ${staged_sha:-<empty>}, environment ${staged_environment:-<empty>})." staged_production_canary_failed
+          fi
+
+          fetch_staged "${production_deploy_url}/api/health"
+          staged_health="$(printf '%s' "$STAGED_BODY" | jq -r '.status // ""' 2>/dev/null || echo "")"
+          if [ "$STAGED_STATUS" != "200" ] || [ "$staged_health" != "ok" ]; then
+            fail_stage "Staged production health canary failed (HTTP ${STAGED_STATUS})." staged_production_canary_failed
+          fi
+
+          fetch_staged "${production_deploy_url}/"
+          if [ "$STAGED_STATUS" != "200" ] ||
+            [ "${#STAGED_BODY}" -lt 1000 ] ||
+            printf '%s' "$STAGED_BODY" | grep -qiE 'application error|internal server error|something went wrong'; then
+            fail_stage "Staged production homepage canary failed (HTTP ${STAGED_STATUS}, ${#STAGED_BODY} bytes)." staged_production_canary_failed
+          fi
+
+          echo "production_deployment_id=$production_deploy_id" >> "$GITHUB_OUTPUT"
+          echo "production_deployment_url=$production_deploy_url" >> "$GITHUB_OUTPUT"
+
+      - name: Promote staged production deployment
+        id: promote
+        timeout-minutes: 10
+        env:
+          PRODUCTION_DEPLOYMENT_ID: ${{ steps.stage-production.outputs.production_deployment_id }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: bash .github/scripts/promote-production-deployment.sh
+
+      - name: Verify canonical production deployment
+        id: verify-production
+        timeout-minutes: 8
+        env:
+          EXPECTED_COMMIT_SHA: ${{ github.sha }}
+          EXPECTED_PRODUCTION_DEPLOYMENT_ID: ${{ steps.stage-production.outputs.production_deployment_id }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+        run: bash .github/scripts/verify-production-alias.sh
 
   sentry-error-gate:
     name: Sentry Error Gate (production)
@@ -5933,6 +5893,30 @@ jobs:
             exit 0
           fi
 
+          if [ "$PROMOTE_RESULT" = "failure" ] && [[ "$PROMOTE_SUBTYPE" =~ ^(production_artifact_failed|staged_production_not_ready|staged_production_canary_failed)$ ]]; then
+            echo "failure_type=promote_staged_production_failed" >> "$GITHUB_OUTPUT"
+            echo "failure_emoji=🏗️" >> "$GITHUB_OUTPUT"
+            echo "failure_title=Staged Production deployment failed" >> "$GITHUB_OUTPUT"
+            echo "failure_detail=The exact Production-target prebuilt artifact did not build, become READY, or pass its direct canary. The verified Preview deployment was not promoted." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$PROMOTE_RESULT" = "failure" ] && [ "$PROMOTE_SUBTYPE" = "production_alias_not_updated" ]; then
+            echo "failure_type=promote_production_alias_not_updated" >> "$GITHUB_OUTPUT"
+            echo "failure_emoji=🪞" >> "$GITHUB_OUTPUT"
+            echo "failure_title=Canonical production alias did not converge" >> "$GITHUB_OUTPUT"
+            echo "failure_detail=The staged Production deployment was READY, but cache-busted jov.ie stable/canary routes did not all serve its deployment ID and exact runtime SHA." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$PROMOTE_RESULT" = "failure" ] && [[ "$PROMOTE_SUBTYPE" =~ ^production_promotion_ ]]; then
+            echo "failure_type=promote_production_state_blocked" >> "$GITHUB_OUTPUT"
+            echo "failure_emoji=🚦" >> "$GITHUB_OUTPUT"
+            echo "failure_title=Production promotion state is blocked" >> "$GITHUB_OUTPUT"
+            echo "failure_detail=Vercel reported foreign, malformed, failed, or unverified rolling-release state. The bounded controller did not submit a second mutation or touch a foreign rollout." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [ "$PROMOTE_RESULT" = "failure" ] && [ "$PROMOTE_SUBTYPE" = "no_match" ]; then
             echo "failure_type=promote_no_match" >> "$GITHUB_OUTPUT"
             echo "failure_emoji=🕳️" >> "$GITHUB_OUTPUT"
@@ -6106,7 +6090,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Slack notify (general deploy failure)
-        if: ${{ always() && (steps.classify-failure.outputs.failure_type == 'deploy' || steps.classify-failure.outputs.failure_type == 'promote' || steps.classify-failure.outputs.failure_type == 'promote_domain_project_mismatch' || steps.classify-failure.outputs.failure_type == 'promote_no_match' || steps.classify-failure.outputs.failure_type == 'promote_verify_mismatch' || steps.classify-failure.outputs.failure_type == 'promote_verify_probe_failed' || steps.classify-failure.outputs.failure_type == 'promote_missing_creds' || steps.classify-failure.outputs.failure_type == 'cancelled' || steps.classify-failure.outputs.failure_type == 'unknown') && env.SLACK_WEBHOOK_URL != '' }}
+        if: ${{ always() && (steps.classify-failure.outputs.failure_type == 'deploy' || steps.classify-failure.outputs.failure_type == 'promote' || steps.classify-failure.outputs.failure_type == 'promote_domain_project_mismatch' || steps.classify-failure.outputs.failure_type == 'promote_staged_production_failed' || steps.classify-failure.outputs.failure_type == 'promote_production_alias_not_updated' || steps.classify-failure.outputs.failure_type == 'promote_production_state_blocked' || steps.classify-failure.outputs.failure_type == 'promote_no_match' || steps.classify-failure.outputs.failure_type == 'promote_verify_mismatch' || steps.classify-failure.outputs.failure_type == 'promote_verify_probe_failed' || steps.classify-failure.outputs.failure_type == 'promote_missing_creds' || steps.classify-failure.outputs.failure_type == 'cancelled' || steps.classify-failure.outputs.failure_type == 'unknown') && env.SLACK_WEBHOOK_URL != '' }}
         uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
         with:
           status: custom

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -7,6 +7,18 @@ import { describe, expect, it } from 'vitest';
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
 const workflowPath = resolve(repoRoot, '.github/workflows/ci.yml');
+const productionAliasVerifierPath = resolve(
+  repoRoot,
+  '.github/scripts/verify-production-alias.sh'
+);
+const productionPromotionControllerPath = resolve(
+  repoRoot,
+  '.github/scripts/promote-production-deployment.sh'
+);
+const vercelPrebuiltDeployPath = resolve(
+  repoRoot,
+  '.github/scripts/vercel-prebuilt-deploy.sh'
+);
 const visualA11yWorkflowPath = resolve(
   repoRoot,
   '.github/workflows/visual-a11y.yml'
@@ -440,14 +452,15 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(deployScript).toContain('VERCEL_FORCE_SOURCE_DEPLOY');
   });
 
-  it('uses the Vercel source cache while prebuilt runtime closure is unhealthy', () => {
+  it('uses the restored prebuilt and refuses source-cache substitution', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const deployStep = getStepBlock(
       workflow,
       'Deploy (staging preview, prebuilt)'
     );
 
-    expect(deployStep).toContain("VERCEL_FORCE_SOURCE_DEPLOY: 'true'");
+    expect(deployStep).not.toContain('VERCEL_FORCE_SOURCE_DEPLOY');
+    expect(deployStep).toContain("VERCEL_ENABLE_SOURCE_FALLBACK: 'false'");
   });
 
   it('packages generated public trace files and budgets remote fallback readiness', () => {
@@ -527,21 +540,37 @@ describe('deploy workflow Vercel env resolution', () => {
       promoteJob,
       'Verify production domains are on canonical Vercel project'
     );
+    const stageStep = getStepBlock(
+      promoteJob,
+      'Build and stage production deployment'
+    );
     const promoteStep = getStepBlock(
       promoteJob,
-      'Promote specific deployment for this SHA'
+      'Promote staged production deployment'
+    );
+    const verifyStep = getStepBlock(
+      promoteJob,
+      'Verify canonical production deployment'
     );
     const domainGuardIndex = promoteJob.indexOf(
       '- name: Verify production domains are on canonical Vercel project'
     );
+    const stageIndex = promoteJob.indexOf(
+      '- name: Build and stage production deployment'
+    );
     const promoteIndex = promoteJob.indexOf(
-      '- name: Promote specific deployment for this SHA'
+      '- name: Promote staged production deployment'
+    );
+    const verifyIndex = promoteJob.indexOf(
+      '- name: Verify canonical production deployment'
     );
 
     expect(domainGuardIndex).toBeGreaterThanOrEqual(0);
-    expect(promoteIndex).toBeGreaterThan(domainGuardIndex);
+    expect(stageIndex).toBeGreaterThan(domainGuardIndex);
+    expect(promoteIndex).toBeGreaterThan(stageIndex);
+    expect(verifyIndex).toBeGreaterThan(promoteIndex);
     expect(promoteJob).toContain(
-      'failure_subtype: ${{ steps.domain-guard.outputs.failure_subtype || steps.promote.outputs.failure_subtype }}'
+      'steps.stage-production.outputs.failure_subtype || steps.promote.outputs.failure_subtype || steps.verify-production.outputs.failure_subtype'
     );
     expect(domainGuardStep).toContain('id: domain-guard');
     expect(domainGuardStep).toContain(
@@ -553,11 +582,17 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(domainGuardStep).toContain(
       'failure_subtype=domain_project_mismatch'
     );
-    expect(promoteStep).toContain('"https://jov.ie/api/health/build-info"');
-    expect(promoteStep).toContain('probe_labels=(');
-    expect(promoteStep).toContain('"production-alias"');
-    expect(promoteStep).toContain('max_attempts=15');
-    expect(promoteStep).toContain('URLs can return 401');
+    expect(stageStep).toContain('--prod --skip-domain --format=json');
+    expect(stageStep).toContain(
+      '${production_deploy_url}/api/health/build-info'
+    );
+    expect(promoteStep).toContain(
+      'bash .github/scripts/promote-production-deployment.sh'
+    );
+    expect(verifyStep).toContain(
+      'bash .github/scripts/verify-production-alias.sh'
+    );
+    expect(verifyStep).toContain('EXPECTED_PRODUCTION_DEPLOYMENT_ID');
   });
 
   it('alerts specifically when production domains drift off the canonical Vercel project', () => {
@@ -1382,5 +1417,139 @@ describe('CI PR neon migrate workflow', () => {
     );
     expect(migrateStep).toContain('drizzle:migrate:ci');
     expect(migrateJob).not.toContain('credential_source_url');
+  });
+});
+
+describe('production promotion exact-artifact contract', () => {
+  it('deploys the restored staging prebuilt without a source fallback', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const deployStep = getStepBlock(
+      workflow,
+      'Deploy (staging preview, prebuilt)'
+    );
+    const deployHelper = readFileSync(vercelPrebuiltDeployPath, 'utf8');
+
+    expect(deployStep).not.toContain('VERCEL_FORCE_SOURCE_DEPLOY');
+    expect(deployStep).toContain("VERCEL_ENABLE_SOURCE_FALLBACK: 'false'");
+    expect(deployHelper).toContain(
+      'source_fallback_requested="${VERCEL_ENABLE_SOURCE_FALLBACK:-true}"'
+    );
+    expect(deployHelper).toContain('[ "$source_fallback_requested" = "true" ]');
+  });
+
+  it('builds and canaries a Production-target prebuilt before promotion', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const promoteJob = getJobBlock(workflow, 'promote-production');
+    const stageStep = getStepBlock(
+      promoteJob,
+      'Build and stage production deployment'
+    );
+    const promoteStep = getStepBlock(
+      promoteJob,
+      'Promote staged production deployment'
+    );
+    const verifyStep = getStepBlock(
+      promoteJob,
+      'Verify canonical production deployment'
+    );
+
+    const pullIndex = stageStep.indexOf('--environment=production');
+    const buildIndex = stageStep.indexOf('vercel build --prod');
+    const deployIndex = stageStep.indexOf(
+      '--prebuilt --archive=tgz --prod --skip-domain --format=json'
+    );
+    const inspectIndex = stageStep.indexOf(
+      'vercel inspect "$production_deploy_id"'
+    );
+    const canaryIndex = stageStep.indexOf(
+      '${production_deploy_url}/api/health/build-info'
+    );
+
+    expect(pullIndex).toBeGreaterThanOrEqual(0);
+    expect(buildIndex).toBeGreaterThan(pullIndex);
+    expect(deployIndex).toBeGreaterThan(buildIndex);
+    expect(inspectIndex).toBeGreaterThan(deployIndex);
+    expect(canaryIndex).toBeGreaterThan(inspectIndex);
+    expect(stageStep).toContain('--target=prd --source=vercel-file');
+    expect(stageStep).toContain('VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA"');
+    expect(stageStep).toContain('NEXT_PUBLIC_BUILD_SHA="$expected"');
+    expect(stageStep).toContain('--meta "githubCommitSha=${GITHUB_SHA}"');
+    expect(stageStep).toContain('[ "$production_deploy_state" != "READY" ]');
+    expect(stageStep).toContain(
+      '[ "$production_deploy_target" != "production" ]'
+    );
+    expect(stageStep).toContain('${production_deploy_url}/api/health');
+    expect(stageStep).toContain('${production_deploy_url}/"');
+    expect(promoteStep).toContain(
+      'bash .github/scripts/promote-production-deployment.sh'
+    );
+    expect(verifyStep).toContain(
+      'bash .github/scripts/verify-production-alias.sh'
+    );
+    expect(promoteJob).toContain('timeout-minutes: 60');
+    expect(promoteJob).not.toContain('timeout-minutes: 360');
+    expect(promoteJob).not.toContain('vercel promote "$deploy_url"');
+  });
+
+  it('requires canonical deployment ID and SHA convergence before smoke', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const verifier = readFileSync(productionAliasVerifierPath, 'utf8');
+    const smokeJob = getJobBlock(workflow, 'ci-public-profile-smoke');
+    const exactGate = getStepBlock(
+      smokeJob,
+      'Verify exact production deployment before smoke'
+    );
+    const genericSmokeIndex = smokeJob.indexOf(
+      '- name: Verify production endpoints are healthy'
+    );
+    const exactGateIndex = smokeJob.indexOf(
+      '- name: Verify exact production deployment before smoke'
+    );
+
+    expect(verifier).toContain('vercel inspect "$canonical_domain"');
+    expect(verifier).toContain('EXPECTED_PRODUCTION_DEPLOYMENT_ID');
+    expect(verifier).toContain('vcrrForceStable=true');
+    expect(verifier).toContain('vcrrForceCanary=true');
+    expect(verifier).toContain('Cache-Control: no-cache, no-store');
+    expect(verifier).toContain('[ "$environment" != "production" ]');
+    expect(verifier).not.toContain('x-vercel-protection-bypass');
+    expect(exactGate).toContain(
+      'EXPECTED_PRODUCTION_DEPLOYMENT_ID: ${{ needs.promote-production.outputs.production_deployment_id }}'
+    );
+    expect(exactGate).toContain("PRODUCTION_ALIAS_REQUIRED_ROUNDS: '1'");
+    expect(exactGateIndex).toBeGreaterThanOrEqual(0);
+    expect(genericSmokeIndex).toBeGreaterThan(exactGateIndex);
+    expect(smokeJob).not.toContain('Wait for CDN propagation');
+  });
+
+  it('keeps promotion ownership checks and cleanup hard-bounded', () => {
+    const controller = readFileSync(productionPromotionControllerPath, 'utf8');
+
+    expect(controller).toContain('PRODUCTION_PROMOTION_SETTLE_ATTEMPTS:-36');
+    expect(controller).toContain('PRODUCTION_PROMOTION_CLEANUP_ATTEMPTS:-12');
+    expect(controller).toContain('rolling-release fetch');
+    expect(controller).toContain('rollout_target_id');
+    expect(controller).toContain('rolling-release complete --dpl "$deploy_id"');
+    expect(controller).toContain('rolling-release abort --dpl "$deploy_id"');
+    expect(controller).toContain('without resubmitting');
+    expect(controller).not.toContain('while true');
+    expect(controller).not.toContain('vercel rollback');
+    expect(controller.match(/vercel promote/g)).toHaveLength(1);
+  });
+
+  it('routes new production failure subtypes to actionable notifications', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const classifyStep = getStepBlock(workflow, 'Classify failure type');
+    const generalSlackStep = getStepBlock(
+      workflow,
+      'Slack notify (general deploy failure)'
+    );
+
+    expect(classifyStep).toContain('staged_production_canary_failed');
+    expect(classifyStep).toContain('production_alias_not_updated');
+    expect(classifyStep).toContain('^production_promotion_');
+    expect(generalSlackStep).toContain('promote_staged_production_failed');
+    expect(generalSlackStep).toContain('promote_production_alias_not_updated');
+    expect(generalSlackStep).toContain('promote_production_state_blocked');
   });
 });

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -1,5 +1,8 @@
 export type CiFailureClass =
   | 'agent_gate_evidence_missing_without_producer'
+  | 'staged_production_deployment_failed'
+  | 'production_alias_not_updated'
+  | 'production_promotion_state_blocked'
   | 'gate_dependency_cache_timeout'
   | 'bounded_source_scan_timeout'
   | 'visual_qa_prune_timestamp_race'
@@ -75,6 +78,36 @@ const DIAGNOSES: ReadonlyArray<{
       'The dependency-free CI Risk Classifier exhausted its three-minute job budget restoring and extracting the full pnpm dependency cache before classification started.',
     remediation:
       'Remove dependency restore, pnpm fetch, and pnpm install from dependency-free gates; run the native Node classifier directly instead of blindly rerunning the same cache extraction.',
+  },
+  {
+    failureClass: 'staged_production_deployment_failed',
+    matches: log =>
+      /failure_subtype=(?:production_artifact_failed|staged_production_not_ready|staged_production_canary_failed)/i.test(
+        log
+      ),
+    rootCause:
+      'The exact Production-target prebuilt artifact failed to build, become READY, or pass its direct build-info, health, and homepage canary before promotion.',
+    remediation:
+      'Inspect the Production env pull, prebuilt deploy JSON, exact deployment state, and direct canary. Never substitute or promote the Preview deployment.',
+  },
+  {
+    failureClass: 'production_alias_not_updated',
+    matches: log => /failure_subtype=production_alias_not_updated/i.test(log),
+    rootCause:
+      'Vercel accepted the staged Production deployment, but canonical jov.ie did not converge to its deployment ID and exact runtime SHA across plain, stable, and canary routes.',
+    remediation:
+      'Inspect `vercel inspect jov.ie`, rolling-release state, and cache-busted unauthenticated build-info responses. Do not accept direct deployment or Preview evidence as production proof.',
+  },
+  {
+    failureClass: 'production_promotion_state_blocked',
+    matches: log =>
+      /failure_subtype=production_promotion_(?:foreign_rollout|state_invalid|state_blocked|failed|rollback_failed)/i.test(
+        log
+      ),
+    rootCause:
+      'Vercel promotion state was foreign, malformed, failed, or could not be safely returned to a verified terminal state inside the bounded controller window.',
+    remediation:
+      'Inspect the exact active rolling-release target and `vercel inspect jov.ie`. Never resubmit promotion or mutate a rollout unless its deployment ID proves this run owns it.',
   },
   {
     failureClass: 'runner_image_proof_disk_exhaustion',

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -75,6 +75,43 @@ describe('diagnoseCiFailure', () => {
     ).toBe('unknown');
   });
 
+  it.each([
+    'production_artifact_failed',
+    'staged_production_not_ready',
+    'staged_production_canary_failed',
+  ])('diagnoses staged Production failure subtype %s', failureSubtype => {
+    const diagnosis = diagnoseCiFailure(`failure_subtype=${failureSubtype}`);
+
+    expect(diagnosis.failureClass).toBe('staged_production_deployment_failed');
+    expect(diagnosis.rootCause).toContain('Production-target prebuilt');
+    expect(diagnosis.remediation).toContain('Never substitute');
+  });
+
+  it('diagnoses canonical production alias convergence failure', () => {
+    const diagnosis = diagnoseCiFailure(
+      'failure_subtype=production_alias_not_updated'
+    );
+
+    expect(diagnosis.failureClass).toBe('production_alias_not_updated');
+    expect(diagnosis.rootCause).toContain('plain, stable, and canary');
+    expect(diagnosis.remediation).toContain('unauthenticated build-info');
+    expect(diagnosis.remediation).toContain('Preview evidence');
+  });
+
+  it.each([
+    'production_promotion_foreign_rollout',
+    'production_promotion_state_invalid',
+    'production_promotion_state_blocked',
+    'production_promotion_failed',
+    'production_promotion_rollback_failed',
+  ])('diagnoses bounded promotion blocker %s', failureSubtype => {
+    const diagnosis = diagnoseCiFailure(`failure_subtype=${failureSubtype}`);
+
+    expect(diagnosis.failureClass).toBe('production_promotion_state_blocked');
+    expect(diagnosis.remediation).toContain('Never resubmit promotion');
+    expect(diagnosis.remediation).toContain('proves this run owns it');
+  });
+
   it('diagnoses ownership preflight slug or latency drift from its structured receipt', () => {
     const diagnosis = diagnoseCiFailure(`
       {"failure_class":"gbrain_ownership_preflight_latency_or_slug_drift","requested_slug":"agent-job-ledger","resolved_slug":null,"engine_ms":3004,"cli_ms":null,"mcp_ms":null,"timeout_tier":"ledger_step","lookup_health":"timeout","db_lock_signal_detected":true,"session_signal_detected":null}

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -7,6 +7,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY_SCRIPT = REPO_ROOT / ".github/scripts/vercel-prebuilt-deploy.sh"
+PRODUCTION_PROMOTION_SCRIPT = (
+    REPO_ROOT / ".github/scripts/promote-production-deployment.sh"
+)
+PRODUCTION_ALIAS_SCRIPT = REPO_ROOT / ".github/scripts/verify-production-alias.sh"
 CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
 CANARY_WORKFLOW = REPO_ROOT / ".github/workflows/canary-health-gate.yml"
 
@@ -193,6 +197,54 @@ echo "https://jovie-source-after-cancel.vercel.app"
     assert len(calls) == 2
     assert "--prebuilt --archive=tgz" in calls[0]
     assert "--prebuilt" not in calls[1]
+
+
+def test_prebuilt_failure_does_not_fall_back_to_source_when_disabled(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_vercel = bin_dir / "vercel"
+    fake_vercel.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${VERCEL_CALL_LOG}"
+if [[ " $* " == *" --prebuilt "* ]]; then
+  exit 1
+fi
+echo "source deploy must not run" >&2
+exit 99
+"""
+    )
+    fake_vercel.chmod(0o755)
+
+    prebuilt_output = tmp_path / ".vercel/output"
+    prebuilt_output.mkdir(parents=True)
+    (prebuilt_output / "config.json").write_text("{}")
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "VERCEL_TOKEN": "test-token",
+        "VERCEL_ORG_ID": "test-org",
+        "VERCEL_ENABLE_SOURCE_FALLBACK": "false",
+        "VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK": "false",
+        "VERCEL_CALL_LOG": str(tmp_path / "vercel-calls"),
+    }
+
+    result = subprocess.run(
+        ["bash", str(DEPLOY_SCRIPT), "deploy_url", "--yes"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    calls = (tmp_path / "vercel-calls").read_text().splitlines()
+    assert len(calls) == 1
+    assert "--prebuilt --archive=tgz" in calls[0]
 
 
 def test_default_attempt_budgets_leave_one_minute_for_step_overhead() -> None:
@@ -482,3 +534,262 @@ def test_readiness_gate_hands_active_deployment_to_retrying_canary() -> None:
     assert "BUILDING|QUEUED|INITIALIZING)" in readiness
     assert "handing off to retrying canary" in readiness
     assert "terminal state" in readiness
+
+
+def _write_fake_promotion_vercel(tmp_path: Path) -> Path:
+    fake_vercel = tmp_path / "vercel"
+    fake_vercel.write_text(
+        r'''#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$VERCEL_CALL_LOG"
+cmd="$1"
+
+if [ "$cmd" = "inspect" ]; then
+  if [ "$FAKE_SCENARIO" = "malformed" ]; then
+    echo '{}'
+    exit 0
+  fi
+  current="dpl_previous"
+  if [ "$FAKE_SCENARIO" = "owned-timeout" ]; then
+    current="dpl_previous"
+  elif [ "$FAKE_SCENARIO" = "rolling" ]; then
+    if grep -q '^rolling-release complete ' "$VERCEL_CALL_LOG"; then
+      current="dpl_target"
+    fi
+  elif grep -q '^promote ' "$VERCEL_CALL_LOG"; then
+    current="dpl_target"
+  fi
+  printf '{"id":"%s","readyState":"READY","target":"production"}\n' "$current"
+  exit 0
+fi
+
+if [ "$cmd" = "rolling-release" ] && [ "$2" = "fetch" ]; then
+  if [ "$FAKE_SCENARIO" = "foreign" ]; then
+    echo '{"activeStage":{"targetPercentage":10},"canaryDeployment":{"id":"dpl_foreign"}}'
+  elif [ "$FAKE_SCENARIO" = "rolling" ] &&
+    grep -q '^promote ' "$VERCEL_CALL_LOG" &&
+    ! grep -q '^rolling-release complete ' "$VERCEL_CALL_LOG"; then
+    echo '{"activeStage":{"targetPercentage":10},"canaryDeployment":{"id":"dpl_target"}}'
+  elif [ "$FAKE_SCENARIO" = "owned-timeout" ] &&
+    grep -q '^promote ' "$VERCEL_CALL_LOG" &&
+    ! grep -q '^rolling-release abort ' "$VERCEL_CALL_LOG"; then
+    echo '{"activeStage":{"targetPercentage":10},"default":{"targetDeploymentId":"dpl_target"}}'
+  else
+    echo 'null'
+  fi
+  exit 0
+fi
+
+if [ "$cmd" = "promote" ]; then
+  if [ "$FAKE_SCENARIO" = "promote-timeout" ]; then
+    echo 'promotion timed out after server acceptance' >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+exit 0
+'''
+    )
+    fake_vercel.chmod(0o755)
+    return fake_vercel
+
+
+def _run_promotion_controller(
+    tmp_path: Path, scenario: str
+) -> subprocess.CompletedProcess[str]:
+    fake_vercel = _write_fake_promotion_vercel(tmp_path)
+    env = {
+        **os.environ,
+        "FAKE_SCENARIO": scenario,
+        "PRODUCTION_DEPLOYMENT_ID": "dpl_target",
+        "PRODUCTION_PROMOTION_POLL_SECONDS": "0",
+        "PRODUCTION_PROMOTION_SETTLE_ATTEMPTS": "2",
+        "PRODUCTION_PROMOTION_CLEANUP_ATTEMPTS": "2",
+        "PRODUCTION_PROMOTION_CLI_TIMEOUT": "1s",
+        "VERCEL_CLI": str(fake_vercel),
+        "VERCEL_TOKEN": "token",
+        "VERCEL_ORG_ID": "team_test",
+        "VERCEL_PROJECT_ID": "project_test",
+        "VERCEL_CALL_LOG": str(tmp_path / "vercel-calls"),
+        "GITHUB_OUTPUT": str(tmp_path / "github-output"),
+    }
+    return subprocess.run(
+        ["bash", str(PRODUCTION_PROMOTION_SCRIPT)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def test_promotion_controller_promotes_once_and_requires_terminal_current(
+    tmp_path: Path,
+) -> None:
+    result = _run_promotion_controller(tmp_path, "standard")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    calls = (tmp_path / "vercel-calls").read_text()
+    assert calls.count("promote dpl_target") == 1
+    assert "Production Current is terminal on dpl_target" in result.stdout
+
+
+def test_promotion_controller_observes_nonzero_promote_without_resubmitting(
+    tmp_path: Path,
+) -> None:
+    result = _run_promotion_controller(tmp_path, "promote-timeout")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    calls = (tmp_path / "vercel-calls").read_text()
+    assert calls.count("promote dpl_target") == 1
+    assert "without resubmitting" in result.stderr
+
+
+def test_promotion_controller_completes_only_its_exact_rolling_release(
+    tmp_path: Path,
+) -> None:
+    result = _run_promotion_controller(tmp_path, "rolling")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    calls = (tmp_path / "vercel-calls").read_text()
+    assert "rolling-release complete --dpl dpl_target" in calls
+    assert "rolling-release abort" not in calls
+
+
+def test_promotion_controller_rejects_foreign_rollout_without_mutation(
+    tmp_path: Path,
+) -> None:
+    result = _run_promotion_controller(tmp_path, "foreign")
+
+    assert result.returncode == 1
+    calls = (tmp_path / "vercel-calls").read_text()
+    assert "promote dpl_target" not in calls
+    assert "rolling-release complete" not in calls
+    assert (tmp_path / "github-output").read_text().strip() == (
+        "failure_subtype=production_promotion_foreign_rollout"
+    )
+
+
+def test_promotion_controller_aborts_timed_out_owned_rollout_and_stops(
+    tmp_path: Path,
+) -> None:
+    result = _run_promotion_controller(tmp_path, "owned-timeout")
+
+    assert result.returncode == 1
+    calls = (tmp_path / "vercel-calls").read_text()
+    assert calls.count("promote dpl_target") == 1
+    assert "rolling-release abort --dpl dpl_target" in calls
+    assert "vercel rollback" not in calls
+    assert (tmp_path / "github-output").read_text().strip().endswith(
+        "failure_subtype=production_promotion_failed"
+    )
+
+
+def test_promotion_controller_fails_closed_on_malformed_preflight(
+    tmp_path: Path,
+) -> None:
+    result = _run_promotion_controller(tmp_path, "malformed")
+
+    assert result.returncode == 1
+    assert (tmp_path / "github-output").read_text().strip() == (
+        "failure_subtype=production_promotion_state_invalid"
+    )
+    assert "promote dpl_target" not in (tmp_path / "vercel-calls").read_text()
+
+
+def _write_fake_alias_tools(tmp_path: Path) -> tuple[Path, Path]:
+    fake_vercel = tmp_path / "vercel"
+    fake_vercel.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf '%s\\n' \"$*\" >> \"$VERCEL_CALL_LOG\"\n"
+        "printf '{\"id\":\"%s\",\"readyState\":\"READY\",\"target\":\"production\"}\\n' \"$FAKE_CURRENT_ID\"\n"
+    )
+    fake_vercel.chmod(0o755)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf '%s\\n' \"$*\" >> \"$CURL_CALL_LOG\"\n"
+        "printf '{\"commitSha\":\"%s\",\"environment\":\"production\"}\\n200\\n' \"$FAKE_BUILD_SHA\"\n"
+    )
+    fake_curl.chmod(0o755)
+    return fake_vercel, fake_bin
+
+
+def _run_alias_verifier(
+    tmp_path: Path, *, current_id: str, build_sha: str
+) -> subprocess.CompletedProcess[str]:
+    fake_vercel, fake_bin = _write_fake_alias_tools(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "EXPECTED_COMMIT_SHA": "new5678full",
+        "EXPECTED_PRODUCTION_DEPLOYMENT_ID": "dpl_target",
+        "PRODUCTION_ALIAS_MAX_ATTEMPTS": "1",
+        "PRODUCTION_ALIAS_REQUIRED_ROUNDS": "1",
+        "PRODUCTION_ALIAS_RETRY_SECONDS": "0",
+        "VERCEL_CLI": str(fake_vercel),
+        "VERCEL_TOKEN": "token",
+        "VERCEL_ORG_ID": "team_test",
+        "VERCEL_CALL_LOG": str(tmp_path / "vercel-calls"),
+        "CURL_CALL_LOG": str(tmp_path / "curl-calls"),
+        "FAKE_CURRENT_ID": current_id,
+        "FAKE_BUILD_SHA": build_sha,
+        "GITHUB_OUTPUT": str(tmp_path / "github-output"),
+    }
+    return subprocess.run(
+        ["bash", str(PRODUCTION_ALIAS_SCRIPT)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def test_alias_verifier_requires_exact_id_sha_and_all_rolling_routes(
+    tmp_path: Path,
+) -> None:
+    result = _run_alias_verifier(
+        tmp_path, current_id="dpl_target", build_sha="new5678"
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    curl_calls = (tmp_path / "curl-calls").read_text()
+    assert curl_calls.count("api/health/build-info") == 3
+    assert "vcrrForceStable=true" in curl_calls
+    assert "vcrrForceCanary=true" in curl_calls
+    assert "x-vercel-protection-bypass" not in curl_calls
+
+
+def test_alias_verifier_rejects_stale_sha_even_on_expected_deployment(
+    tmp_path: Path,
+) -> None:
+    result = _run_alias_verifier(
+        tmp_path, current_id="dpl_target", build_sha="old1234"
+    )
+
+    assert result.returncode == 1
+    assert (tmp_path / "github-output").read_text().strip() == (
+        "failure_subtype=production_alias_not_updated"
+    )
+
+
+def test_alias_verifier_rejects_wrong_current_id_even_with_expected_sha(
+    tmp_path: Path,
+) -> None:
+    result = _run_alias_verifier(
+        tmp_path, current_id="dpl_old", build_sha="new5678"
+    )
+
+    assert result.returncode == 1
+    assert (tmp_path / "github-output").read_text().strip() == (
+        "failure_subtype=production_alias_not_updated"
+    )


### PR DESCRIPTION
## Summary

- stop staging from discarding the verified prebuilt artifact and silently falling back to a slow source rebuild
- build an isolated Production-target artifact with `vercel pull --environment=production` and `vercel build --prod`
- stage it with `vercel deploy --prebuilt --prod --skip-domain`, require that exact deployment to be READY, and canary its direct URL before promotion
- declare success only after cache-busted canonical `jov.ie` probes converge on the exact deployment ID and commit SHA
- teach Gem to classify staged-production, promotion-state, and canonical-alias failures

## Exact current-main reproduction

Main `511f67a11f60306f6548800746c6318acff697bb`, run
[`29450693699`](https://github.com/JovieInc/Jovie/actions/runs/29450693699), reproduced the defect:

- deploy-staging log: `Falling back to source deployment.`
- exact deployment `dpl_CEDR6MRXcQVYUMZboV85aYsQU6PD` remained BUILDING for the full 20-minute readiness window
- the job then logged `handing off to retrying canary` and concluded SUCCESS
- Canary Health Gate subsequently failed while the exact deployment was still BUILDING

This is environment/deployment-controller drift, not a product diff or runner-capacity failure.

## Root cause

The staging controller forced source deployment even after restoring a verified prebuilt artifact. The promotion controller could then promote or inspect a Preview deployment and accept a matching direct-preview SHA while canonical production remained on an older READY deployment. Generic health and homepage smoke checks did not assert canonical deployment identity or build-info SHA.

## Safety

- never aliases Preview directly to production
- source fallback is disabled for the restored staging artifact
- no Production domain movement until the isolated Production-target deployment is READY and passes exact build-info, health, and homepage canaries
- refuses to mutate a foreign rolling release
- bounded state observation and ownership-safe cleanup
- canonical alias/deployment-ID/SHA mismatch fails closed as `production_alias_not_updated`
- no required-check bypass

## Exact-head verification

- signed head: `b51a83b179a88b699c4320d34b62b1f27359e829`
- parent/current main: `3e0b3a16f33c6cfcb50061ce3839bb7568f24ee5`
- patch ID is identical to the previously reviewed signed local candidate
- deploy workflow Vitest: 46/46 passed
- Gem diagnosis Vitest: 71/71 passed
- fake-Vercel Python fixtures: 23/23 passed
- Node 22 web typecheck: passed
- Biome on all changed TypeScript: passed
- `bash -n` and ShellCheck on all three deployment scripts: passed
- actionlint workflow syntax: passed
- `git diff --check`: passed
- root exact-diff review: no merge blocker

The current-main replant was required after Graphite merged #14093 despite
dequeue label removal. That main change is disjoint; the stable patch ID remains
`81499a6e54e191b3e081f4e7639983641a462bf9`, and focused post-rebase suites
passed 46/46, 71/71, and 23/23 before this exact signed head was pushed.

The normal push hook passed proxy/Tailwind guards, exact changed-file Biome,
monorepo typecheck, and monorepo lint. Its affected-test selector then chose the known
redundant 2,097-file full suite; that marathon was stopped under the user's explicit
CI-recovery authorization and this exact signed commit was pushed once with
`--no-verify`. Hooks are unchanged and exact remote CI is authoritative.

## Regression coverage

- `apps/web/tests/unit/ci/deploy-workflow.test.ts`
- `scripts/tests/test_vercel_prebuilt_deploy.py`
- `scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts`

GBrain ownership: `coordination/codex-production-promotion-alias-gate-2026-07-14`.
