### PR TITLE
docs(hermes): define private voice shadow architecture

### DIFF
--- a/.claude/rules/hermes-air.md
+++ b/.claude/rules/hermes-air.md
@@ -6,8 +6,9 @@ Operating contract for the always-on Hermes gateway running on the dedicated 16 
 
 A dedicated orchestration node that:
 
-- Ingests brain dumps (Telegram typed messages + macOS Voice Memos transcripts via iCloud).
-- Persists every dump to gbrain (Air-as-server, PGLite backend, exposed over Tailscale as a remote-MCP HTTP server).
+- Ingests Telegram brain dumps into the shared company workflows.
+- Retains a selected, private macOS Voice Memos shadow architecture for later activation. The watcher is disabled and must not process real memos until the activation gate below passes.
+- Persists shared company context to gbrain (Air-as-server, PGLite backend, exposed over Tailscale as a remote-MCP HTTP server). Raw Voice Memo audio and transcripts are excluded from that shared store.
 - Segments dumps into `memory` (gbrain only), `issue` (GitHub Issues), and `task` (sub-agent dispatch).
 - Files GitHub issues for engineering/product/ops work using the canonical follow-up shape from `.claude/rules/linear.md` via `scripts/hermes/lib/tracker-client.ts` (`gh issue create`). Linear mirrors behind `TRACKER_GITHUB_ONLY` during the parallel-run window.
 - Routes non-engineering tasks (calendar moves, Airtable updates, emails) to the right sub-agent which calls the appropriate MCP.
@@ -25,10 +26,13 @@ A dedicated orchestration node that:
 | Invariant | Enforced by |
 |---|---|
 | Hermes-Air never edits code or merges PRs | Profile gate (`JOVIE_AGENT_PROFILE!=coder`); `orchestrator-boundary-check.sh` hook on any Claude Code session that ever runs on Air (should be zero) |
-| All engineering follow-ups go through GitHub Issues | `voice-memo-ingest.ts` and Telegram intake handlers file via `tracker-client.ts` (`gh issue create`); no `repository_dispatch` from Air |
+| All admitted engineering follow-ups go through GitHub Issues | Telegram intake handlers file via `tracker-client.ts` (`gh issue create`); no `repository_dispatch` from Air. Private voice proposals require Summer admission and sanitization first. |
 | Inference cost is $0 unless user explicitly opts in | `free-model-router.ts` only selects `:free` OpenRouter variants; `cost-monitor.ts` kills non-watchdog jobs if any paid spend exceeds $0 in 24h |
 | gbrain stays local (Air-hosted, Tailscale-bound) | `gbrain serve --http --bind <tailscale-ip>` binds to the Tailscale interface only; no public exposure |
-| Voice memo transcripts never leave the Air | Stored only in gbrain PGLite; embedding API calls use free providers; no Supabase sync in v1 |
+| Voice memo source material stays private on the Air | Audio, raw transcripts, classifications, and proposals live only under non-symlinked `~/.hermes/private/` roots with `0700` directories and `0600` files. No raw shared gbrain, GitHub, Telegram, dispatch log, or repository write. |
+| Voice storage is isolated from company gbrain | A dedicated no-embedding PGLite store lives at `~/.hermes/private/voice-brain/`. The adapter scrubs ambient database, Supabase, repository, sync, provider, and source variables, runs from a neutral private working directory, and requires gbrain repo write-through to report `no_repo_configured`. |
+| Voice analysis is local by default | Apple transcripts are accepted only after exact database binding. Missing transcripts fall back to local Whisper. Classification uses literal-loopback Ollama. Groq transcription is disabled unless the operator explicitly sets `HERMES_VOICE_ENABLE_GROQ=1` and provides its key. |
+| Voice activation fails closed | No launchd watcher or cron may run until synthetic canaries and a manual shadow review pass, a production local Whisper model is installed, and the user separately authorizes activation. A maintenance window alone does not authorize activation or processing a real memo. |
 | Single heavy-job semaphore | Ollama inference and `whisper-cli` cannot run concurrently; protected by `~/.hermes/state/heavy-job.lock` |
 | Telegram bot token never logged | `~/.hermes/.env` only; `bootstrap-air.sh` verifies `.env` is `chmod 600` and never copied into logs |
 
@@ -43,15 +47,28 @@ Profiles are defined in `~/.hermes/config.yaml` (template at `scripts/hermes/con
 | `founder-os` | fundraising, GTM, company-state, warm network recall | Airtable (fundraising base), Gmail (read+draft, not send), Calendar, gbrain | edit code, send emails without confirmation |
 | `code-orchestrator` | PR triage, CI failure classification, file GitHub repair issues | GitHub (read/write issues), gbrain | edit code, merge PRs, push branches |
 
+## Private Voice Shadow Architecture (Selected, Disabled)
+
+This is the selected architecture, not an active service contract:
+
+1. Wait for the Apple recording to remain unchanged across two observations, then copy it into a content-addressed inbox under `~/.hermes/private/voice-ingest/` with restrictive permissions.
+2. Read `CloudRecordings.db` in read-only/query-only mode from the recordings directory, then its parent, unless `HERMES_VOICE_MEMOS_DB` supplies the reviewed path. Query `ZCLOUDRECORDING` by exact `ZPATH` filename and read `ZUNIQUEID` plus `ZTRANSCRIPTION`. Accept exactly one row only when the resolved recording stays inside Apple's recordings root and the source audio SHA-256 equals the staged object's SHA-256. Missing database, schema, transcript, or row means transcription fallback; duplicate rows, path escape, or hash mismatch fail closed.
+3. Validate the stable private copy with `ffprobe`. If Apple did not supply a verified transcript, split audio into resumable 8–12 minute chunks (10 minutes by default) and transcribe with a per-chunk timeout. Local Whisper is the default. Groq is explicit opt-in only.
+4. Run extraction and classification through Ollama on a literal loopback endpoint (`http://127.0.0.1:11434/api/chat` by default), using `gemma3:4b` by default. Analysis failure defaults to `mixed` and `highly_sensitive` with zero outward proposals.
+5. Write raw artifacts and private proposals only to the dedicated no-embedding PGLite store and private object root. Run the adapter with ambient database and sync variables scrubbed, from a neutral private working directory, while holding `~/.hermes/state/heavy-job.lock`.
+6. Summer may later admit a constraint-relevant, sanitized company work packet. The raw audio, transcript, private classification, and unadmitted proposal never enter shared gbrain, GitHub, Telegram, or an executor prompt.
+
+The legacy `scripts/hermes/jobs/voice-memo-ingest.ts` watcher is not the activation source for this architecture and must remain unloaded.
+
 ## Engineering Work Handoff (the only contract with the Pro)
 
-1. Voice memo or Telegram intake → classified as `issue` span.
-2. Hermes-Air files a GitHub issue using the canonical follow-up shape from `.claude/rules/linear.md` (Source / Follow-up / Why it matters / Classification / Acceptance criteria). `Source` references the gbrain entry permalink.
+1. Telegram intake, or a sanitized voice proposal explicitly admitted by Summer, is classified as an `issue` span.
+2. Hermes-Air files a GitHub issue using the canonical follow-up shape from `.claude/rules/linear.md` (Source / Follow-up / Why it matters / Classification / Acceptance criteria). A voice-derived issue references only the sanitized private proposal receipt, never the raw memo or transcript.
 3. Optional: add the `agent-ready` label when the issue should enter the GitHub-native orchestrator immediately.
 4. The Pro codex issue shipper or `.github/workflows/github-ai-orchestrator.yml` discovers labeled/ready work — no Air-side `repository_dispatch`, no SSH.
 5. PR opens with `Fixes #N` in the body; merge to `main` closes the GitHub issue (Graphite queue-land safe). `linear-sync-on-merge.yml` still mirrors to Linear until `TRACKER_GITHUB_ONLY=1`.
 
-If the Air cannot file the GitHub issue (network down, `gh` outage), queue the intent in `~/.hermes/state/linear-queue.jsonl` for operator inspection and keep the source memo un-seen so the next scan retries from the durable voice memo + gbrain source.
+If the Air cannot file the GitHub issue (network down, `gh` outage), queue a Telegram-derived or already-sanitized intent in `~/.hermes/state/linear-queue.jsonl` for operator inspection. A voice-derived proposal remains only in the private voice store and may be retried after service recovery without copying its raw memo or transcript into shared gbrain or the queue.
 
 ## Self-Improvement Loop
 
@@ -67,7 +84,7 @@ This is how Hermes-Air keeps trending toward $0 model calls over time.
 ## Cost Contract
 
 - **Hermes inference**: $0/mo. `free-model-router.ts` only selects `:free` OpenRouter models. Local Ollama Qwen 3 4B as fallback.
-- **Hermes embeddings**: $0/mo. Free OpenRouter embedding models or local `sentence-transformers` (~80 MB).
+- **Hermes embeddings**: $0/mo for shared company context. The private voice store disables embeddings entirely.
 - **Telegram bot**: $0/mo.
 - **Tailscale**: $0/mo (free tier, 2 devices under 100-device limit).
 - **gbrain**: $0/mo (local PGLite).
@@ -81,7 +98,7 @@ Per `CLAUDE.md` → Workspace Topology: this Air is the **third workspace** alon
 
 - `scripts/hermes/bootstrap-air.sh` — installer
 - `scripts/hermes/config.air.template.yaml` — Hermes config template
-- `scripts/hermes/launchd/*.plist.template` — launchd unit templates (bootstrap renders to `~/Library/LaunchAgents/`)
+- `scripts/hermes/launchd/*.plist.template` — launchd unit templates (the legacy voice-memo watcher must remain unloaded)
 - `scripts/hermes/jobs/*.ts` — cron handlers
 - `scripts/hermes/lib/free-model-router.ts` — cost-safe model selection
 - `docs/HERMES_AIR.md` — operator runbook

--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -4,35 +4,38 @@ Day-to-day operations for the always-on Hermes gateway running on the dedicated 
 
 ## What This Machine Is
 
-A single-purpose orchestration node. It listens for brain dumps (Telegram + Voice Memos), persists them to gbrain, routes engineering work to **GitHub Issues** (Linear mirror optional via `TRACKER_GITHUB_ONLY`), and routes ops tasks to sub-agents. The Hermes scanner code does **zero coding** itself. The opt-in codex issue shipper can start a separate `JOVIE_AGENT_PROFILE=coder` child session for eligible open GitHub issues.
+A single-purpose orchestration node. It accepts Telegram brain dumps, persists shared company context to gbrain, routes admitted engineering work to **GitHub Issues** (Linear mirror optional via `TRACKER_GITHUB_ONLY`), and routes ops tasks to sub-agents. The selected Voice Memos path is a disabled private shadow architecture: raw audio, transcripts, classifications, and proposals do not enter shared gbrain or any outbound system. The Hermes scanner code does **zero coding** itself. The opt-in codex issue shipper can start a separate `JOVIE_AGENT_PROFILE=coder` child session for eligible open GitHub issues.
+
+> **Voice activation state: disabled.** Do not load the legacy voice-memo launchd unit, process a real memo, or treat this maintenance window as activation approval. Activation requires synthetic canaries, a reviewed manual shadow run, a production local Whisper model, and separate user authorization.
 
 ## First-Time Setup
 
+The current `scripts/hermes/bootstrap-air.sh` bootstraps every rendered Hermes launchd unit, including the legacy voice-memo watcher. Therefore the all-in-one bootstrap is blocked while private voice activation is disabled. Do not run it unless the legacy unit has first been excluded from the rendered launchd set. If the unit exists from an earlier installation, keep it unloaded:
+
 ```bash
-# On the Air, from a clone of this repo:
-./scripts/hermes/bootstrap-air.sh
+launchctl bootout gui/$(id -u)/co.jovie.hermes.voice-memo-watcher 2>/dev/null || true
 ```
 
-The bootstrap script is idempotent. It will:
+Once that exclusion is verified, the bootstrap script is idempotent. It will:
 
 1. Verify Node 22 / pnpm 9.15.4.
 2. Install (if missing): Hermes (`hermes-agent-rs`), gbrain CLI, Doppler, Tailscale, Ollama.
 3. Pull the Ollama fallback model (`qwen3:4b-q4_K_M`).
 4. Render `~/.hermes/config.yaml` from `scripts/hermes/config.air.template.yaml` + Doppler secrets.
 5. Render `~/.hermes/.env` from Doppler (and `chmod 600`).
-6. Install all launchd plists into `~/Library/LaunchAgents/` and bootstrap them.
-7. Pause for the manual GUI step (see below).
+6. Install and bootstrap the remaining Hermes launchd plists into `~/Library/LaunchAgents/`. The legacy `co.jovie.hermes.voice-memo-watcher` must be absent from this set.
+7. Pause for the non-voice manual GUI steps (see below).
 8. Run a verification checklist and print results.
 
 ## Manual GUI Steps Required
 
 These cannot be scripted; bootstrap will pause and instruct.
 
-### 1. Full Disk Access for Voice Memo watcher
+### 1. Full Disk Access for Voice Memo shadow review (deferred)
 
-System Settings → Privacy & Security → Full Disk Access → enable the `tsx` binary at `~/.hermes/bin/tsx` (or whichever interpreter the launchd plist references).
+Do not grant a watcher Full Disk Access while voice activation is disabled. During a separately authorized manual shadow review, grant access only to the exact reviewed private adapter/interpreter, then revoke it if activation is not approved.
 
-Without this, the voice-memo watcher cannot read `~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/`.
+The reviewed adapter may read `~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/` and the Apple Voice Memos database only for the selected synthetic fixture or explicitly approved shadow input.
 
 ### 2. Tailscale auth
 
@@ -86,6 +89,8 @@ doppler secrets set HERMES_TELEGRAM_CHAT_ID="<telegram-chat-id>" \
 | `AIRTABLE_API_KEY` | Founder-OS profile (fundraising base) | already provisioned |
 | `SENTRY_AUTH_TOKEN` | Optional: ship Hermes errors to Sentry `hermes-air` env | already provisioned |
 | `HERMES_TELEGRAM_CHAT_ID` | Optional: Telegram private-chat allowlist + outbound target | manual after first bot message |
+| `HERMES_VOICE_ENABLE_GROQ` | Voice transcription opt-in; absent or not `1` keeps Groq disabled | manual, only after explicit approval |
+| `GROQ_API_KEY` | Used only when `HERMES_VOICE_ENABLE_GROQ=1` | optional; must not be exposed to local-only voice runs |
 
 The bootstrap script verifies every required secret is present before continuing.
 
@@ -95,8 +100,8 @@ Once installed, you should never need to interact with the Air directly. All con
 
 | To do this | Do this |
 |---|---|
-| Brain-dump an idea | Telegram the bot, or record a Voice Memo on iPhone |
-| File a bug | Voice-memo "Hermes, file a GitHub issue for ..." or type it |
+| Brain-dump an idea | Telegram the bot. You may record a Voice Memo on iPhone, but it remains in Apple Voice Memos while ingest is disabled. |
+| File a bug | Type it to the Telegram bot. Voice memos cannot directly create issues. |
 | Queue CI agent dispatch | Add the GitHub issue label `agent-ready` |
 | Queue local coding work | Leave issue open for the codex issue shipper (or add `codex` for explicit routing) |
 | Ask a strategic question | Telegram the bot; the chief profile routes |
@@ -138,6 +143,13 @@ tail -50 ~/.hermes/logs/launchd/cron-gbrain-health-summary.log \
 
 # Free-model rankings
 cat ~/.hermes/state/model-router-rankings.json | jq .
+
+# Voice watcher must remain absent while activation is disabled
+if launchctl print gui/$(id -u)/co.jovie.hermes.voice-memo-watcher >/dev/null 2>&1; then
+  echo "STOP_VOICE_WATCHER"
+else
+  echo "VOICE_DISABLED"
+fi
 ```
 
 ## Common Operations
@@ -162,6 +174,7 @@ done
 ```bash
 hermes gateway start --all
 for plist in ~/Library/LaunchAgents/co.jovie.hermes.*.plist; do
+  [[ "$plist" == *voice-memo-watcher* ]] && continue
   launchctl bootstrap gui/$(id -u) "$plist"
 done
 ```
@@ -178,18 +191,13 @@ tail -f ~/.hermes/logs/gateway.error.log
 # All cron job runs
 tail -f ~/.hermes/logs/jobs.jsonl
 
-# Voice memo ingest events
-tail -f ~/.hermes/logs/voice-memo.jsonl
+# Private voice shadow receipts (only after an authorized synthetic/manual run)
+find ~/.hermes/private/voice-ingest -maxdepth 2 -type f -print 2>/dev/null
 ```
 
 ### Re-render config from updated Doppler
 
-```bash
-./scripts/hermes/bootstrap-air.sh --reconfigure
-# then:
-hermes gateway restart --all
-launchctl kickstart -k gui/$(id -u)/co.jovie.hermes.gbrain-server
-```
+The current `--reconfigure` path can load every rendered plist, including the legacy voice watcher. Do not use it while voice activation is disabled. Update only the intended rendered non-voice configuration, then restart that explicit service. Before and after the restart, run the voice-disabled status check above.
 
 ### Run the codex issue shipper once
 
@@ -218,13 +226,13 @@ Config variables:
 
 | Variable | Default | Purpose | Update path |
 |---|---:|---|---|
-| `HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN` | `3` | Max Codex issues selected per drain batch; also caps parallel agent fan-out | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
-| `HERMES_CODEX_SHIPPER_MAX_PARALLEL_AGENTS` | `3` | Absolute cap for concurrent coder agents inside the singleton shipper run | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
-| `HERMES_CODEX_SHIPPER_MIN_FREE_MEMORY_MB` | `4096` | Below this free-memory floor, launch at most one new coder; below half this floor, launch none | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
-| `HERMES_CODEX_SHIPPER_MAX_LOAD_PER_CPU` | `1.5` | Above this one-minute load-per-CPU threshold, launch at most one new coder; above 1.5x this threshold, launch none | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
-| `HERMES_CODEX_SHIPPER_SINGLETON_LOCK_STALE_MS` | `28800000` | Long-running shipper lock TTL; new crons skip while the owning process is alive | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
-| `HERMES_CODEX_SHIPPER_INTEGRATION_THRESHOLD` | `4` | Eligible queue depth that routes trainable issues through `integration/codex-queue` | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
-| `HERMES_CODEX_SHIPPER_AGENT` | `claude` | Local coding agent binary; `claude` keeps subagent support, `codex` is available as an explicit override | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
+| `HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN` | `3` | Max Codex issues selected per drain batch; also caps parallel agent fan-out | Rendered non-voice plist env, then restart only `co.jovie.hermes.cron-codex-issue-shipper` |
+| `HERMES_CODEX_SHIPPER_MAX_PARALLEL_AGENTS` | `3` | Absolute cap for concurrent coder agents inside the singleton shipper run | Rendered non-voice plist env, then restart only `co.jovie.hermes.cron-codex-issue-shipper` |
+| `HERMES_CODEX_SHIPPER_MIN_FREE_MEMORY_MB` | `4096` | Below this free-memory floor, launch at most one new coder; below half this floor, launch none | Rendered non-voice plist env, then restart only `co.jovie.hermes.cron-codex-issue-shipper` |
+| `HERMES_CODEX_SHIPPER_MAX_LOAD_PER_CPU` | `1.5` | Above this one-minute load-per-CPU threshold, launch at most one new coder; above 1.5x this threshold, launch none | Rendered non-voice plist env, then restart only `co.jovie.hermes.cron-codex-issue-shipper` |
+| `HERMES_CODEX_SHIPPER_SINGLETON_LOCK_STALE_MS` | `28800000` | Long-running shipper lock TTL; new crons skip while the owning process is alive | Rendered non-voice plist env, then restart only `co.jovie.hermes.cron-codex-issue-shipper` |
+| `HERMES_CODEX_SHIPPER_INTEGRATION_THRESHOLD` | `4` | Eligible queue depth that routes trainable issues through `integration/codex-queue` | Rendered non-voice plist env, then restart only `co.jovie.hermes.cron-codex-issue-shipper` |
+| `HERMES_CODEX_SHIPPER_AGENT` | `claude` | Local coding agent binary; `claude` keeps subagent support, `codex` is available as an explicit override | Rendered non-voice plist env, then restart only `co.jovie.hermes.cron-codex-issue-shipper` |
 
 Control labels:
 
@@ -253,8 +261,8 @@ Ship now / Re-evaluate when / Then:
 2. Tail gateway log: `tail -100 ~/.hermes/logs/gateway.error.log`
 3. Run the config sentinel: `tsx scripts/hermes/jobs/agent-config-health.ts`
 4. Confirm the supported Hermes gateway command works: `hermes gateway status`
-5. Re-run bootstrap: `./scripts/hermes/bootstrap-air.sh` (idempotent)
-6. If config is corrupt: `mv ~/.hermes/config.yaml ~/.hermes/config.yaml.bak && ./scripts/hermes/bootstrap-air.sh --reconfigure`
+5. Restart the gateway with `hermes gateway restart --all`.
+6. Do not use bootstrap or `--reconfigure` as recovery while voice activation is disabled; both can load the legacy watcher. Restore a known-good `~/.hermes/config.yaml`, then start only the explicit non-voice units using the guarded loop under "Re-enable after stop."
 
 ### Agents keep failing after Telegram dispatch
 
@@ -270,9 +278,18 @@ schema-clobbered `memorySearch` blocks in `~/.openclaw/openclaw.json`, Vercel AI
 
 ### Voice memo ingest stopped working
 
-1. Verify Full Disk Access in System Settings → Privacy & Security (re-grant if you upgraded macOS).
-2. Check the dedupe ledger isn't claiming the file: `grep <uuid> ~/.hermes/state/voice-memos-seen.json`.
-3. Run the handler manually with the file: `tsx scripts/hermes/jobs/voice-memo-ingest.ts --file <path>`.
+Voice ingest is intentionally disabled. Do not restart the legacy watcher or run `scripts/hermes/jobs/voice-memo-ingest.ts` manually.
+
+Before activation can be considered:
+
+1. Confirm all private roots resolve beneath a non-symlinked `~/.hermes/private/`, with `0700` directories and `0600` files.
+2. Confirm the dedicated store is `~/.hermes/private/voice-brain/`, embeddings are disabled, and the adapter runs from a neutral private working directory. Its gbrain subprocess environment must remove `GBRAIN_DATABASE_URL`, `DATABASE_URL`, `SUPABASE_DB_URL`, `SUPABASE_DATABASE_URL`, `GBRAIN_SOURCE`, `GBRAIN_REPO`, `GBRAIN_REPO_PATH`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `VOYAGE_API_KEY`, `ZEROENTROPY_API_KEY`, `COHERE_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, and `GROQ_API_KEY` before adding only the dedicated private configuration.
+3. Confirm the pre-write gbrain repo-path check is empty and the post-write receipt is exactly `written: false, skipped: no_repo_configured`.
+4. Confirm the read-only/query-only Apple database chain checks `CloudRecordings.db` in the recordings directory and then its parent, unless `HERMES_VOICE_MEMOS_DB` supplies the reviewed path. It must query `ZCLOUDRECORDING` by exact `ZPATH`, read `ZUNIQUEID` and `ZTRANSCRIPTION`, accept one row only, confine the source to the recordings root, and require source-to-staged SHA-256 equality. Missing database, schema, transcript, or row may fall back; ambiguity, path escape, or hash mismatch must fail closed.
+5. Confirm local Ollama classification uses a literal loopback endpoint (`http://127.0.0.1:11434/api/chat` by default) and the locally installed `gemma3:4b` model by default. Failure must produce `mixed`, `highly_sensitive`, and zero proposals.
+6. Confirm local Whisper is installed and is the default fallback. Groq must remain unavailable unless both `HERMES_VOICE_ENABLE_GROQ=1` and its key are deliberately supplied.
+7. Run synthetic canaries, then one explicitly approved manual shadow input. Verify no raw shared gbrain, GitHub, Telegram, dispatch, repository, or executor output.
+8. Present the receipts for user review. Only separate activation authorization may install or load a watcher.
 
 ### Cost monitor killed everything
 
@@ -282,10 +299,14 @@ This is intentional. Something escalated to a paid model. Investigate:
 cat ~/.hermes/logs/cost.jsonl | jq 'select(.cost > 0)' | tail -20
 ```
 
-Once you understand the cause, fix it (likely in `free-model-router.ts` rankings), then resume:
+Once you understand the cause, fix it (likely in `free-model-router.ts` rankings), then resume only the non-voice services:
 
 ```bash
-./scripts/hermes/bootstrap-air.sh --resume-after-cost-kill
+hermes gateway start --all
+for plist in ~/Library/LaunchAgents/co.jovie.hermes.*.plist; do
+  [[ "$plist" == *voice-memo-watcher* ]] && continue
+  launchctl bootstrap gui/$(id -u) "$plist"
+done
 ```
 
 ### gbrain unreachable from Pro
@@ -338,10 +359,11 @@ Removes all launchd plists, drops `~/.hermes/`, leaves Doppler and Tailscale alo
 | `~/.hermes/.env` | Secrets (chmod 600) | regenerable |
 | `~/.hermes/logs/` | All Hermes logs | rotate weekly via launchd |
 | `~/.hermes/logs/codex-issue-shipper/` | Coder prompts and run logs for `codex` issue dispatches | operator-managed; prune if large |
-| `~/.hermes/state/voice-memos-seen.json` | Dedupe ledger | rebuildable (worst case: re-ingest 1 day) |
+| `~/.hermes/private/voice-ingest/` | Content-addressed audio, chunks, transcripts, classifications, proposals, and receipts | private backup only; never shared gbrain or repo |
+| `~/.hermes/private/voice-brain/` | Dedicated no-embedding PGlite store for private voice records | private backup only; never shared gbrain or repo |
 | `~/.hermes/state/heavy-job.lock` | Semaphore for Ollama vs whisper | ephemeral |
 | `~/.hermes/state/model-router-rankings.json` | Free-model rankings | regenerable nightly |
 | `~/.gbrain/data/*.pglite` | gbrain durable store | **back up nightly** (rsync to Pro) |
 | `~/Library/LaunchAgents/co.jovie.hermes.*.plist` | launchd units | regenerable via bootstrap |
 
-The only thing worth backing up is gbrain. Everything else is regenerable from this repo + Doppler.
+Back up shared gbrain and, only under the user's private-data policy, the private voice roots. Never copy private voice backups into the repository, shared gbrain, GitHub, Telegram, or general company backup paths.


### PR DESCRIPTION
## Summary

- Make the selected Voice Memos architecture explicitly private, isolated, and disabled.
- Document exact Apple `CloudRecordings.db` row binding and fail-closed fallback behavior.
- Require a dedicated no-embedding PGlite store under `~/.hermes/private`, scrubbed ambient database/provider variables, and no repository write-through.
- Set local Whisper and loopback Ollama as defaults; keep Groq behind explicit opt-in.
- Prohibit raw voice material in shared gbrain, GitHub, Telegram, dispatch logs, repository state, or executor prompts.
- Keep the legacy watcher unloaded until synthetic canaries, an approved manual shadow review, a production local Whisper model, and separate user activation authorization.

Kanban child: `t_902878ae` under maintenance task `t_87a81b35`.

## Bug-to-Test

bug-to-test: not applicable (docs-only architecture update, not a bug fix PR).

## Test Coverage

No application code paths changed.

## Pre-Landing Review

Adversarial review found and fixed two unsafe documentation contradictions: legacy bootstrap/recovery commands could load the watcher, and a retry path implied raw voice in shared gbrain. No unresolved findings.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN. Only `.claude/rules/hermes-air.md` and `docs/HERMES_AIR.md` changed.

## Plan Completion

No plan file detected. The bounded Kanban child requirements are fully represented in the two canonical docs.

## Linear follow-ups

Linear follow-ups: none.

## Verification Results

- `pnpm doc:freshness:check` passed: 33 cross-link files and 120 AGENTS map lines.
- `pnpm --filter @jovie/web run test:bug-to-test` passed as not applicable.
- `git diff --check origin/main...HEAD` passed.
- Changed-file scope assertion passed for exactly the two authorized docs.
- Node `v22.23.1`; pnpm `9.15.4`.
- Generic `pnpm biome check --write apps/web` was unavailable because this isolated worktree has no `node_modules`; no app files changed, and the exact docs checks above passed.

## Test plan

- [x] Verify canonical rule and operator runbook agree that voice activation is disabled.
- [x] Verify no raw shared gbrain, GitHub, Telegram, dispatch, repository, or executor path remains documented.
- [x] Verify legacy bootstrap and recovery instructions cannot silently authorize the watcher.

No merge, deployment, service activation, or real memo processing is part of this PR.
