### PR TITLE
fix(ci): persist runner health routing state

### DIFF
--- a/.github/scripts/query-runner-heartbeat.sh
+++ b/.github/scripts/query-runner-heartbeat.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_REPO:?GH_REPO is required}"
+HEARTBEAT_WORKFLOW="${HEARTBEAT_WORKFLOW:-runner-heartbeat.yml}"
+HEARTBEAT_MAX_AGE_SECONDS="${HEARTBEAT_MAX_AGE_SECONDS:-1500}"
+
+if ! [[ "$HEARTBEAT_MAX_AGE_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "HEARTBEAT_MAX_AGE_SECONDS must be a positive integer" >&2
+  exit 2
+fi
+
+api_error="$(mktemp)"
+trap 'rm -f "$api_error"' EXIT
+if ! LATEST=$(gh api \
+  "repos/$GH_REPO/actions/workflows/$HEARTBEAT_WORKFLOW/runs?per_page=1" \
+  --jq '.workflow_runs[0] | [.status, (.conclusion // ""), .updated_at, .html_url] | @tsv' \
+  2>"$api_error"); then
+  if grep -Eqi 'HTTP (401|403)|bad credentials|resource not accessible' "$api_error"; then
+    echo "Runner heartbeat query failed with a credential/permission error (HTTP 401/403); routing was not changed. Verify the Jovie Bot installation can read Actions workflow runs." >&2
+  else
+    echo "Runner heartbeat query failed with an Actions API error; routing was not changed. This is not runner-health evidence." >&2
+  fi
+  cat "$api_error" >&2
+  exit 3
+fi
+
+if [[ -z "${LATEST//$'\t'/}" || "$LATEST" == "null"$'\t\t\t' ]]; then
+  HEALTH=down
+  EVIDENCE="no runner heartbeat run exists"
+else
+  IFS=$'\t' read -r STATUS CONCLUSION OBSERVED_AT URL <<< "$LATEST"
+  if [[ "$STATUS" == "completed" && "$CONCLUSION" == "success" ]]; then
+    AGE_SECONDS=$(python3 - "$OBSERVED_AT" <<'PY'
+import datetime
+import sys
+
+created = datetime.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+now = datetime.datetime.now(datetime.timezone.utc)
+print(max(0, int((now - created).total_seconds())))
+PY
+)
+    if [[ "$AGE_SECONDS" -le "$HEARTBEAT_MAX_AGE_SECONDS" ]]; then
+      HEALTH=up
+      EVIDENCE="latest heartbeat succeeded ${AGE_SECONDS}s ago at $OBSERVED_AT ($URL)"
+    else
+      HEALTH=down
+      EVIDENCE="latest successful heartbeat is stale (${AGE_SECONDS}s > ${HEARTBEAT_MAX_AGE_SECONDS}s) at $OBSERVED_AT ($URL)"
+    fi
+  else
+    HEALTH=down
+    EVIDENCE="latest heartbeat is status=$STATUS conclusion=${CONCLUSION:-none} observed=$OBSERVED_AT ($URL)"
+  fi
+fi
+
+echo "Runner health: $HEALTH — $EVIDENCE"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "health=$HEALTH" >> "$GITHUB_OUTPUT"
+  echo "evidence=$EVIDENCE" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/update-runner-routing.sh
+++ b/.github/scripts/update-runner-routing.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_REPO:?GH_REPO is required}"
+: "${RUNNER_HEALTH:?RUNNER_HEALTH must be up or down}"
+
+TARGET_VARIABLE="${TARGET_VARIABLE:-CI_FAST_RUNNER}"
+STATE_VARIABLE="${STATE_VARIABLE:-CI_FAST_RUNNER_HEALTH_STATE}"
+OFFLINE_TARGET="${OFFLINE_TARGET:-ubuntu-latest}"
+ONLINE_TARGET="${ONLINE_TARGET:-jovie-runner}"
+FLAP_THRESHOLD="${FLAP_THRESHOLD:-2}"
+
+if [[ "$RUNNER_HEALTH" != "up" && "$RUNNER_HEALTH" != "down" ]]; then
+  echo "RUNNER_HEALTH must be up or down" >&2
+  exit 2
+fi
+
+if ! [[ "$FLAP_THRESHOLD" =~ ^[1-9][0-9]*$ ]]; then
+  echo "FLAP_THRESHOLD must be a positive integer" >&2
+  exit 2
+fi
+
+target_for_health() {
+  if [[ "$1" == "up" ]]; then
+    printf '%s\n' "$ONLINE_TARGET"
+  else
+    printf '%s\n' "$OFFLINE_TARGET"
+  fi
+}
+
+api_error="$(mktemp)"
+trap 'rm -f "$api_error"' EXIT
+
+report_api_failure() {
+  local operation="$1"
+  local routing_disposition="$2"
+
+  if grep -Eqi 'HTTP (401|403)|bad credentials|resource not accessible' "$api_error"; then
+    echo "Runner routing credential/permission failure during $operation (HTTP 401/403). $routing_disposition Verify the Jovie Bot installation can read and write Actions variables." >&2
+  else
+    echo "Runner routing Actions API failure during $operation. $routing_disposition" >&2
+  fi
+  cat "$api_error" >&2
+  exit 3
+}
+
+is_not_found() {
+  grep -Eq 'HTTP 404|Not Found|not found' "$api_error"
+}
+
+put_variable() {
+  local name="$1"
+  local value="$2"
+  local routing_disposition="$3"
+
+  : > "$api_error"
+  if gh api "repos/$GH_REPO/actions/variables/$name" >/dev/null 2>"$api_error"; then
+    : > "$api_error"
+    if ! gh api -X PATCH "repos/$GH_REPO/actions/variables/$name" \
+      -f name="$name" -f value="$value" >/dev/null 2>"$api_error"; then
+      report_api_failure "updating repository variable '$name'" "$routing_disposition"
+    fi
+  elif is_not_found; then
+    : > "$api_error"
+    if ! gh api -X POST "repos/$GH_REPO/actions/variables" \
+      -f name="$name" -f value="$value" >/dev/null 2>"$api_error"; then
+      report_api_failure "creating repository variable '$name'" "$routing_disposition"
+    fi
+  else
+    report_api_failure "reading repository variable '$name'" "$routing_disposition"
+  fi
+}
+
+: > "$api_error"
+if ! CURRENT=$(gh api "repos/$GH_REPO/actions/variables/$TARGET_VARIABLE" --jq '.value' 2>"$api_error"); then
+  report_api_failure "reading repository variable '$TARGET_VARIABLE'" "The routing target was not changed."
+fi
+DESIRED=$(target_for_health "$RUNNER_HEALTH")
+
+if [[ "$CURRENT" == "$DESIRED" ]]; then
+  put_variable "$STATE_VARIABLE" "$RUNNER_HEALTH:0" "The routing target already matched; only the debounce-state reset failed."
+  echo "Runner routing already matches observed health ($RUNNER_HEALTH → $DESIRED)."
+  exit 0
+fi
+
+: > "$api_error"
+if ! STATE=$(gh api "repos/$GH_REPO/actions/variables/$STATE_VARIABLE" --jq '.value' 2>"$api_error"); then
+  if is_not_found; then
+    STATE=""
+  else
+    report_api_failure "reading repository variable '$STATE_VARIABLE'" "The routing target was not changed."
+  fi
+fi
+STATE_HEALTH="${STATE%%:*}"
+STATE_COUNT="${STATE#*:}"
+if [[ "$STATE" == "$STATE_HEALTH" ]] || ! [[ "$STATE_COUNT" =~ ^[0-9]+$ ]]; then
+  STATE_COUNT=0
+fi
+
+if [[ "$STATE_HEALTH" == "$RUNNER_HEALTH" ]]; then
+  COUNT=$((STATE_COUNT + 1))
+else
+  COUNT=1
+fi
+
+# Repository variables persist across scheduled jobs even when each run uses a
+# different GitHub-hosted VM. runner.temp cannot provide that guarantee.
+put_variable "$STATE_VARIABLE" "$RUNNER_HEALTH:$COUNT" "The routing target was not changed."
+
+if [[ "$COUNT" -lt "$FLAP_THRESHOLD" ]]; then
+  echo "Observed runner health '$RUNNER_HEALTH' $COUNT/$FLAP_THRESHOLD consecutive checks; routing unchanged."
+  exit 0
+fi
+
+echo "Observed runner health '$RUNNER_HEALTH' for $COUNT consecutive checks. Setting $TARGET_VARIABLE → $DESIRED."
+: > "$api_error"
+if ! gh api -X PATCH "repos/$GH_REPO/actions/variables/$TARGET_VARIABLE" \
+  -f name="$TARGET_VARIABLE" -f value="$DESIRED" >/dev/null 2>"$api_error"; then
+  report_api_failure "updating repository variable '$TARGET_VARIABLE'" "The routing target was not changed; persisted debounce state will make the next tick retry."
+fi
+put_variable "$STATE_VARIABLE" "$RUNNER_HEALTH:0" "The routing target changed successfully, but the debounce-state reset failed; the next tick will reconcile it."

--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -486,8 +486,12 @@ jobs:
   # --------------------------------------------------------------------------
   runner-health:
     name: Runner Health
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    # This monitor must remain runnable when the self-hosted pool is offline.
+    runs-on: ubuntu-latest
     timeout-minutes: 2
+    concurrency:
+      group: runner-health-routing
+      cancel-in-progress: false
     permissions:
       contents: read
       actions: write
@@ -496,61 +500,49 @@ jobs:
       TARGET_VARIABLE: CI_FAST_RUNNER
       OFFLINE_TARGET: ubuntu-latest
       ONLINE_TARGET: jovie-runner
+      # Two missed 10-minute heartbeats indicate either outage or saturation.
+      # The routing debounce requires that signal on two observer ticks.
+      HEARTBEAT_MAX_AGE_SECONDS: '1500'
 
     steps:
-      - name: Detect self-hosted runner label drift
-        run: |
-          set -euo pipefail
-          OFFENDERS=$(gh api repos/JovieInc/Jovie/actions/runners --jq \
-            '[.runners[] | select([.labels[].name] | any(. == "ubuntu-latest" or . == "macos-latest" or . == "windows-latest")) | {name: .name, labels: [.labels[].name]}]')
-          COUNT=$(echo "$OFFENDERS" | jq length)
-          if [ "$COUNT" -gt 0 ]; then
-            DETAIL=$(echo "$OFFENDERS" | jq -r '[.[] | "\(.name) [\(.labels | join(","))]"] | join("; ")')
-            echo "::error::Runner label drift: $COUNT runner(s) with forbidden labels: $DETAIL"
-            exit 1
-          fi
-          echo "OK: no runner label drift detected."
+      - name: Checkout main policy code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Mint Jovie Bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.JOVIE_BOT_APP_ID }}
+          private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
 
       - name: Query runner status
         id: runners
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          set -euo pipefail
-          RUNNERS=$(gh api repos/JovieInc/Jovie/actions/runners --jq \
-            '[.runners[] | select(.labels[].name == "jovie-runner") | {name: .name, status: .status, busy: .busy}]')
-          TOTAL=$(echo "$RUNNERS" | jq length)
-          ONLINE=$(echo "$RUNNERS" | jq '[.[] | select(.status == "online")] | length')
-          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "online=$ONLINE" >> "$GITHUB_OUTPUT"
-          if [ "$ONLINE" -eq 0 ]; then echo "health=down" >> "$GITHUB_OUTPUT"
-          elif [ "$ONLINE" -ge 1 ]; then echo "health=up" >> "$GITHUB_OUTPUT"; fi
+          .github/scripts/query-runner-heartbeat.sh
 
       - name: Flip to GitHub-hosted fallback if runners are down
         if: steps.runners.outputs.health == 'down'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RUNNER_HEALTH: down
         run: |
-          set -euo pipefail
-          CURRENT=$(gh api repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER --jq '.value' 2>/dev/null || echo "")
-          if [ "$CURRENT" = "ubuntu-latest" ]; then echo "Already on fallback."; exit 0; fi
-          CONSECUTIVE_FILE="${{ runner.temp }}/runner-down-count"
-          COUNT=0; [ -f "$CONSECUTIVE_FILE" ] && COUNT=$(cat "$CONSECUTIVE_FILE")
-          COUNT=$((COUNT + 1)); echo "$COUNT" > "$CONSECUTIVE_FILE"
-          FLAP_THRESHOLD=2
-          if [ "$COUNT" -lt "$FLAP_THRESHOLD" ]; then echo "First detection. Need $((FLAP_THRESHOLD - COUNT)) more."; exit 0; fi
-          echo "Runners offline for $COUNT consecutive checks. Flipping CI_FAST_RUNNER → ubuntu-latest..."
-          gh api -X PATCH repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER -f name=CI_FAST_RUNNER -f value=ubuntu-latest
+          .github/scripts/update-runner-routing.sh
 
       - name: Restore self-hosted runners when they come back
         if: steps.runners.outputs.health == 'up'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RUNNER_HEALTH: up
         run: |
-          set -euo pipefail
-          CURRENT=$(gh api repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER --jq '.value' 2>/dev/null || echo "")
-          if [ "$CURRENT" = "jovie-runner" ]; then echo "Already on self-hosted."; exit 0; fi
-          CONSECUTIVE_FILE="${{ runner.temp }}/runner-up-count"
-          COUNT=0; [ -f "$CONSECUTIVE_FILE" ] && COUNT=$(cat "$CONSECUTIVE_FILE")
-          COUNT=$((COUNT + 1)); echo "$COUNT" > "$CONSECUTIVE_FILE"
-          FLAP_THRESHOLD=2
-          if [ "$COUNT" -lt "$FLAP_THRESHOLD" ]; then echo "First recovery check. Need $((FLAP_THRESHOLD - COUNT)) more."; exit 0; fi
-          echo "Runners back for $COUNT consecutive checks. Restoring CI_FAST_RUNNER → jovie-runner..."
-          gh api -X PATCH repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER -f name=CI_FAST_RUNNER -f value=jovie-runner
+          .github/scripts/update-runner-routing.sh
 
   # --------------------------------------------------------------------------
   # JOB: synthetic-monitoring

--- a/.github/workflows/runner-health-monitor.yml
+++ b/.github/workflows/runner-health-monitor.yml
@@ -7,143 +7,73 @@ name: Runner Health Monitor
 # Detects 2+ consecutive lost heartbeats before flipping to avoid flapping
 # on brief network blips.
 #
-# Also guards against runner label drift: self-hosted runners must never carry
-# GitHub-hosted labels (`ubuntu-latest`, `macos-latest`, `windows-latest`). A
-# self-hosted runner labeled `ubuntu-latest` hijacks workflows intended for
-# GitHub-hosted runners onto an incomplete toolchain.
+# Health comes from the dedicated self-hosted heartbeat workflow. The monitor
+# itself always runs on GitHub-hosted capacity so an offline pool cannot prevent
+# its own fallback repair.
 
 on:
   workflow_dispatch:         # manual trigger (cron moved to agent-tick.yml)
 
 permissions:
   contents: read
-  actions: write             # needed to read runners + update repo variables
+  actions: write             # needed to read heartbeat runs + update repo variables
 
 jobs:
   monitor:
     name: Check runner health
-    runs-on: ${{ vars.CI_FAST_RUNNER }}
+    runs-on: ubuntu-latest
     timeout-minutes: 2
+    concurrency:
+      group: runner-health-routing
+      cancel-in-progress: false
     env:
       GH_TOKEN: ${{ github.token }}
       TARGET_VARIABLE: CI_FAST_RUNNER
       OFFLINE_TARGET: ubuntu-latest
       ONLINE_TARGET: jovie-runner
+      # Two missed 10-minute heartbeats indicate either outage or saturation.
+      # The routing debounce requires that signal on two observer ticks.
+      HEARTBEAT_MAX_AGE_SECONDS: '1500'
     steps:
+      - name: Checkout main policy code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Mint Jovie Bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.JOVIE_BOT_APP_ID }}
+          private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
+
       - name: Query runner status
         id: runners
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          set -euo pipefail
-
-          STATE_FILE="${{ runner.temp }}/runner-health-state"
-          PREV="${{ runner.temp }}/runner-health-prev"
-
-          # Fetch runners (online, offline — just not removed)
-          RUNNERS=$(gh api repos/JovieInc/Jovie/actions/runners --jq \
-            '[.runners[] | select(.labels[].name == "jovie-runner") | {name: .name, status: .status, busy: .busy}]')
-
-          TOTAL=$(echo "$RUNNERS" | jq length)
-          ONLINE=$(echo "$RUNNERS" | jq '[.[] | select(.status == "online")] | length')
-          OFFLINE=$(echo "$RUNNERS" | jq '[.[] | select(.status == "offline")] | length')
-
-          echo "total=$TOTAL"
-          echo "online=$ONLINE"
-          echo "offline=$OFFLINE"
-          echo "runner_list=$RUNNERS"
-
-          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "online=$ONLINE" >> "$GITHUB_OUTPUT"
-
-          # Determine current health state
-          if [ "$ONLINE" -eq 0 ]; then
-            echo "health=down" >> "$GITHUB_OUTPUT"
-          elif [ "$ONLINE" -ge 1 ]; then
-            echo "health=up" >> "$GITHUB_OUTPUT"
-          fi
+          .github/scripts/query-runner-heartbeat.sh
 
       - name: Flip to GitHub-hosted fallback if runners are down
         if: steps.runners.outputs.health == 'down'
         env:
-          PREV_FLIP_FILE: ${{ runner.temp }}/last-flipped
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RUNNER_HEALTH: down
         run: |
-          set -euo pipefail
-
-          CURRENT=$(gh api repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER --jq '.value' 2>/dev/null || echo "")
-
-          if [ "$CURRENT" = "ubuntu-latest" ]; then
-            echo "Already on fallback (ubuntu-latest). No action needed."
-            exit 0
-          fi
-
-          # Require 2+ consecutive detections before flipping (anti-flap)
-          CONSECUTIVE_FILE="${{ runner.temp }}/runner-down-count"
-          COUNT=0
-          if [ -f "$CONSECUTIVE_FILE" ]; then
-            COUNT=$(cat "$CONSECUTIVE_FILE")
-          fi
-          COUNT=$((COUNT + 1))
-          echo "$COUNT" > "$CONSECUTIVE_FILE"
-
-          FLAP_THRESHOLD=2  # require 2+ consecutive checks (~10 min) before flipping
-          if [ "$COUNT" -lt "$FLAP_THRESHOLD" ]; then
-            echo "First detection of runner outage. Need $((FLAP_THRESHOLD - COUNT)) more. (count=$COUNT)"
-            exit 0
-          fi
-
-          echo "Runners offline for $COUNT consecutive checks. Flipping CI_FAST_RUNNER → ubuntu-latest..."
-          gh api -X PATCH repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER \
-            -f name=CI_FAST_RUNNER -f value=ubuntu-latest 2>&1
-
-          echo "last_flip=down" > "$PREV_FLIP_FILE"
+          .github/scripts/update-runner-routing.sh
 
       - name: Restore self-hosted runners when they come back
         if: steps.runners.outputs.health == 'up'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RUNNER_HEALTH: up
         run: |
-          set -euo pipefail
-
-          CURRENT=$(gh api repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER --jq '.value' 2>/dev/null || echo "")
-
-          if [ "$CURRENT" = "jovie-runner" ]; then
-            echo "Already on self-hosted (jovie-runner). No action needed."
-            exit 0
-          fi
-
-          # Only restore if we were previously on fallback (debounce: 2 checks)
-          CONSECUTIVE_FILE="${{ runner.temp }}/runner-up-count"
-          COUNT=0
-          if [ -f "$CONSECUTIVE_FILE" ]; then
-            COUNT=$(cat "$CONSECUTIVE_FILE")
-          fi
-          COUNT=$((COUNT + 1))
-          echo "$COUNT" > "$CONSECUTIVE_FILE"
-
-          FLAP_THRESHOLD=2
-          if [ "$COUNT" -lt "$FLAP_THRESHOLD" ]; then
-            echo "First detection of runner recovery. Need $((FLAP_THRESHOLD - COUNT)) more. (count=$COUNT)"
-            exit 0
-          fi
-
-          echo "Runners back for $COUNT consecutive checks. Restoring CI_FAST_RUNNER → jovie-runner..."
-          gh api -X PATCH repos/JovieInc/Jovie/actions/variables/CI_FAST_RUNNER \
-            -f name=CI_FAST_RUNNER -f value=jovie-runner 2>&1
+          .github/scripts/update-runner-routing.sh
 
       - name: Log health state
         run: |
-          echo "::notice::Runner health: online=${{ steps.runners.outputs.online }}/${{ steps.runners.outputs.total }}"
-
-      - name: Detect self-hosted runner label drift
-        run: |
-          set -euo pipefail
-
-          OFFENDERS=$(gh api repos/JovieInc/Jovie/actions/runners --jq \
-            '[.runners[] | select([.labels[].name] | any(. == "ubuntu-latest" or . == "macos-latest" or . == "windows-latest")) | {name: .name, labels: [.labels[].name]}]')
-          COUNT=$(echo "$OFFENDERS" | jq length)
-
-          if [ "$COUNT" -gt 0 ]; then
-            DETAIL=$(echo "$OFFENDERS" | jq -r '[.[] | "\(.name) [\(.labels | join(","))]"] | join("; ")')
-            echo "::warning::Self-hosted runner label drift: $COUNT runner(s) carry forbidden GitHub-hosted labels (ubuntu-latest/macos-latest/windows-latest): $DETAIL. Remove those labels; self-hosted runners must use explicit labels such as jovie-runner."
-            echo "::notice::Drift detected; the auto-flip safety net still works independently."
-            echo "Drift found — $COUNT runner(s) with forbidden labels. No action taken; auto-flip remains intact."
-          else
-            echo "OK: no self-hosted runners carry GitHub-hosted labels."
-          fi
+          echo "::notice::${{ steps.runners.outputs.evidence }}"

--- a/.github/workflows/runner-heartbeat.yml
+++ b/.github/workflows/runner-heartbeat.yml
@@ -1,0 +1,25 @@
+name: Runner Heartbeat
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-heartbeat
+  # A saturated/offline pool retains only the newest queued probe. The hosted
+  # observer treats queued/in-progress or stale success as down; its separate
+  # two-check debounce prevents a single busy interval from flipping routing.
+  cancel-in-progress: true
+
+jobs:
+  heartbeat:
+    name: Self-hosted runner heartbeat
+    runs-on: jovie-runner
+    timeout-minutes: 2
+    steps:
+      - name: Record heartbeat
+        run: echo "Self-hosted heartbeat from $RUNNER_NAME"

--- a/scripts/tests/test_runner_routing.py
+++ b/scripts/tests/test_runner_routing.py
@@ -1,0 +1,353 @@
+"""Regression tests for durable runner-health routing state."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import textwrap
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / ".github" / "scripts" / "update-runner-routing.sh"
+_QUERY_SCRIPT = _REPO_ROOT / ".github" / "scripts" / "query-runner-heartbeat.sh"
+
+
+def _fake_gh(tmp_path: Path) -> Path:
+    fake = tmp_path / "gh"
+    fake.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            state="${FAKE_GH_STATE:?}"
+            endpoint=""
+            method=GET
+            name=""
+            value=""
+            jq_filter=""
+            while [[ $# -gt 0 ]]; do
+              case "$1" in
+                api) shift ;;
+                -X) method="$2"; shift 2 ;;
+                -f)
+                  case "$2" in
+                    name=*) name="${2#name=}" ;;
+                    value=*) value="${2#value=}" ;;
+                  esac
+                  shift 2
+                  ;;
+                --jq) jq_filter="$2"; shift 2 ;;
+                *) [[ -z "$endpoint" ]] && endpoint="$1"; shift ;;
+              esac
+            done
+            key="${endpoint##*/}"
+            if [[ "$endpoint" == */actions/variables && "$method" == POST ]]; then
+              key="$name"
+            fi
+            if [[ "$method" == GET ]]; then
+              if ! entry=$(awk -F= -v key="$key" '$1 == key {sub(/^[^=]*=/, ""); print; found=1} END {if (!found) exit 1}' "$state"); then
+                echo "gh: Variable not found (HTTP 404)" >&2
+                exit 1
+              fi
+              [[ "$jq_filter" == .value ]] && printf '%s\n' "$entry" || printf '{"value":"%s"}\n' "$entry"
+              exit 0
+            fi
+            if [[ "${FAKE_GH_FAIL_PATCH:-}" == "$name" && "$method" == PATCH ]]; then
+              echo "gh: Resource not accessible by integration (HTTP 403)" >&2
+              exit 1
+            fi
+            tmp="${state}.tmp"
+            awk -F= -v key="$name" '$1 != key' "$state" > "$tmp"
+            printf '%s=%s\n' "$name" "$value" >> "$tmp"
+            mv "$tmp" "$state"
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+    return fake
+
+
+def _run(
+    tmp_path: Path,
+    health: str,
+    *,
+    runner_temp: Optional[Path] = None,
+    extra_env: Optional[dict[str, str]] = None,
+) -> subprocess.CompletedProcess[str]:
+    if runner_temp is None:
+        runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}:{env['PATH']}",
+            "FAKE_GH_STATE": str(tmp_path / "state"),
+            "GH_REPO": "JovieInc/Jovie",
+            "RUNNER_HEALTH": health,
+            "RUNNER_TEMP": str(runner_temp),
+        }
+    )
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(_SCRIPT)],
+        cwd=_REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _state(tmp_path: Path) -> dict[str, str]:
+    return dict(
+        line.split("=", 1)
+        for line in (tmp_path / "state").read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_recovery_debounce_survives_distinct_runner_filesystems(tmp_path: Path) -> None:
+    _fake_gh(tmp_path)
+    (tmp_path / "state").write_text("CI_FAST_RUNNER=ubuntu-latest\n", encoding="utf-8")
+
+    first_temp = tmp_path / "first-runner-temp"
+    second_temp = tmp_path / "second-runner-temp"
+    first = _run(tmp_path, "up", runner_temp=first_temp)
+    assert first.returncode == 0, first.stderr
+    assert _state(tmp_path) == {
+        "CI_FAST_RUNNER": "ubuntu-latest",
+        "CI_FAST_RUNNER_HEALTH_STATE": "up:1",
+    }
+
+    # The second observation runs on a separate hosted VM filesystem. Only the
+    # repository variable is shared across ticks.
+    second = _run(tmp_path, "up", runner_temp=second_temp)
+    assert second.returncode == 0, second.stderr
+    assert _state(tmp_path) == {
+        "CI_FAST_RUNNER": "jovie-runner",
+        "CI_FAST_RUNNER_HEALTH_STATE": "up:0",
+    }
+    assert first_temp != second_temp
+    assert list(first_temp.iterdir()) == []
+    assert list(second_temp.iterdir()) == []
+
+
+def test_opposite_observation_resets_consecutive_count(tmp_path: Path) -> None:
+    _fake_gh(tmp_path)
+    (tmp_path / "state").write_text(
+        "CI_FAST_RUNNER=jovie-runner\nCI_FAST_RUNNER_HEALTH_STATE=down:1\n",
+        encoding="utf-8",
+    )
+
+    up = _run(tmp_path, "up")
+    assert up.returncode == 0, up.stderr
+    assert _state(tmp_path)["CI_FAST_RUNNER_HEALTH_STATE"] == "up:0"
+
+    down = _run(tmp_path, "down")
+    assert down.returncode == 0, down.stderr
+    assert _state(tmp_path)["CI_FAST_RUNNER_HEALTH_STATE"] == "down:1"
+
+
+def _run_heartbeat_query(
+    tmp_path: Path, latest: str, *, api_error: Optional[str] = None
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    fake = tmp_path / "gh"
+    fake.write_text(
+        (
+            f"#!/usr/bin/env bash\necho '{api_error}' >&2\nexit 1\n"
+            if api_error
+            else f"#!/usr/bin/env bash\nprintf '%s\\n' '{latest}'\n"
+        ),
+        encoding="utf-8",
+    )
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+    output = tmp_path / "output"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}:{env['PATH']}",
+            "GH_REPO": "JovieInc/Jovie",
+            "GITHUB_OUTPUT": str(output),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(_QUERY_SCRIPT)],
+        cwd=_REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, output.read_text(encoding="utf-8") if output.exists() else ""
+
+
+def test_fresh_successful_heartbeat_is_up(tmp_path: Path) -> None:
+    created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    result, output = _run_heartbeat_query(
+        tmp_path,
+        f"completed\tsuccess\t{created_at}\thttps://example.test/run",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "health=up" in output
+
+
+def test_no_heartbeat_run_is_down_without_parse_noise(tmp_path: Path) -> None:
+    result, output = _run_heartbeat_query(tmp_path, "\t\t\t")
+
+    assert result.returncode == 0, result.stderr
+    assert "health=down" in output
+    assert "no runner heartbeat run exists" in output
+
+
+def test_stale_successful_heartbeat_is_down(tmp_path: Path) -> None:
+    created_at = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat().replace(
+        "+00:00", "Z"
+    )
+    result, output = _run_heartbeat_query(
+        tmp_path,
+        f"completed\tsuccess\t{created_at}\thttps://example.test/stale",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "health=down" in output
+    assert "stale" in output
+
+
+def test_queued_heartbeat_is_down_for_routing_debounce(tmp_path: Path) -> None:
+    created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    result, output = _run_heartbeat_query(
+        tmp_path,
+        f"queued\t\t{created_at}\thttps://example.test/queued",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "health=down" in output
+    assert "status=queued" in output
+
+
+def test_heartbeat_api_auth_failure_is_not_reported_as_runner_down(tmp_path: Path) -> None:
+    result, output = _run_heartbeat_query(
+        tmp_path,
+        "",
+        api_error="HTTP 403: Resource not accessible by integration",
+    )
+
+    assert result.returncode == 3
+    assert "credential/permission error (HTTP 401/403)" in result.stderr
+    assert "routing was not changed" in result.stderr
+    assert "health=down" not in output
+
+
+def test_routing_api_403_is_not_misclassified_as_missing_state(tmp_path: Path) -> None:
+    fake = tmp_path / "gh"
+    fake.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            endpoint=""
+            while [[ $# -gt 0 ]]; do
+              case "$1" in
+                api) shift ;;
+                --jq) shift 2 ;;
+                *) [[ -z "$endpoint" ]] && endpoint="$1"; shift ;;
+              esac
+            done
+            if [[ "$endpoint" == */actions/variables/CI_FAST_RUNNER ]]; then
+              echo ubuntu-latest
+              exit 0
+            fi
+            echo 'gh: Resource not accessible by integration (HTTP 403)' >&2
+            exit 1
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+
+    result = _run(tmp_path, "up")
+
+    assert result.returncode == 3
+    assert "credential/permission failure" in result.stderr
+    assert "HTTP 401/403" in result.stderr
+    assert "routing target was not changed" in result.stderr
+    assert "CI_FAST_RUNNER_HEALTH_STATE" in result.stderr
+
+
+def test_target_mutation_403_fails_closed_and_retries_next_tick(tmp_path: Path) -> None:
+    _fake_gh(tmp_path)
+    (tmp_path / "state").write_text(
+        "CI_FAST_RUNNER=ubuntu-latest\nCI_FAST_RUNNER_HEALTH_STATE=up:1\n",
+        encoding="utf-8",
+    )
+
+    failed = _run(
+        tmp_path,
+        "up",
+        extra_env={"FAKE_GH_FAIL_PATCH": "CI_FAST_RUNNER"},
+    )
+
+    assert failed.returncode == 3
+    assert "credential/permission failure" in failed.stderr
+    assert "updating repository variable 'CI_FAST_RUNNER'" in failed.stderr
+    assert "persisted debounce state will make the next tick retry" in failed.stderr
+    assert _state(tmp_path) == {
+        "CI_FAST_RUNNER": "ubuntu-latest",
+        "CI_FAST_RUNNER_HEALTH_STATE": "up:2",
+    }
+
+    retried = _run(tmp_path, "up")
+    assert retried.returncode == 0, retried.stderr
+    assert _state(tmp_path) == {
+        "CI_FAST_RUNNER": "jovie-runner",
+        "CI_FAST_RUNNER_HEALTH_STATE": "up:0",
+    }
+
+
+def _agent_runner_health_block() -> str:
+    workflow = (_REPO_ROOT / ".github/workflows/agent-tick.yml").read_text(
+        encoding="utf-8"
+    )
+    return workflow.split("  runner-health:\n", 1)[1].split(
+        "  # JOB: synthetic-monitoring", 1
+    )[0]
+
+
+def test_health_workflows_are_independent_and_serialized() -> None:
+    agent_runner_health = _agent_runner_health_block()
+    standalone = (
+        _REPO_ROOT / ".github/workflows/runner-health-monitor.yml"
+    ).read_text(encoding="utf-8")
+    heartbeat = (_REPO_ROOT / ".github/workflows/runner-heartbeat.yml").read_text(
+        encoding="utf-8"
+    )
+
+    for observer in (agent_runner_health, standalone):
+        assert "runs-on: ubuntu-latest" in observer
+        assert "runs-on: ${{ vars.CI_FAST_RUNNER }}" not in observer
+        assert "group: runner-health-routing" in observer
+        assert "cancel-in-progress: false" in observer
+        assert "actions/runners" not in observer
+        assert "runner.temp" not in observer
+        assert ".github/scripts/query-runner-heartbeat.sh" in observer
+        assert ".github/scripts/update-runner-routing.sh" in observer
+
+    assert "runs-on: jovie-runner" in heartbeat
+    assert "group: runner-heartbeat" in heartbeat
+
+
+def test_health_workflows_use_jovie_bot_token_for_api_calls() -> None:
+    standalone = (
+        _REPO_ROOT / ".github/workflows/runner-health-monitor.yml"
+    ).read_text(encoding="utf-8")
+    for workflow in (_agent_runner_health_block(), standalone):
+        assert "actions/create-github-app-token@" in workflow
+        assert "app-id: ${{ vars.JOVIE_BOT_APP_ID }}" in workflow
+        assert "private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}" in workflow
+        assert "GH_TOKEN: ${{ steps.app-token.outputs.token }}" in workflow


### PR DESCRIPTION
## Summary

- run runner-health observers on GitHub-hosted capacity so an offline self-hosted pool cannot block its own fallback
- replace the unauthorized runner-admin API query with a dedicated self-hosted heartbeat
- persist two-observation anti-flap state in repository variables and serialize routing mutations across both observer entry points
- fail closed with explicit HTTP 401/403 diagnostics and retry-safe partial-state behavior

Supersedes the runner-routing portion of #14147. Graphite observer and unrelated documentation changes are intentionally excluded.

## Root cause

The existing monitor runs on `CI_FAST_RUNNER`, the same route it must repair, and queries the runner administration endpoint with a token that cannot reliably access it. Its debounce counters live in `runner.temp`, so separate scheduled jobs never observe the previous count. The standalone and consolidated observers also lacked a shared mutation lock.

Classification: recurring Gem failure caused by missing automation plus credential/environment mismatch.

## Verification

- `python3 -m pytest -q scripts/tests/test_runner_routing.py` (11 passed)
- `bash -n .github/scripts/query-runner-heartbeat.sh .github/scripts/update-runner-routing.sh`
- `shellcheck .github/scripts/query-runner-heartbeat.sh .github/scripts/update-runner-routing.sh`
- `actionlint .github/workflows/runner-health-monitor.yml .github/workflows/runner-heartbeat.yml .github/workflows/agent-tick.yml` with the repository CI ShellCheck exclusions
- `pnpm ci:harness:check`
- `git diff origin/main --check`

## Review

Manual adversarial review covered first-run behavior, distinct hosted-runner filesystems, recovery after the second healthy observation, opposite-observation reset, no-heartbeat/stale/queued classifications, 403 reads, 403 target mutation and next-tick retry, cross-workflow serialization, and exact runner/token workflow contracts. No unresolved findings.

## Risk

High-risk CI control-plane change. This PR remains draft and gated for required remote verification; no merge enrollment is requested.