### PR TITLE
fix(ci): prevent Neon concurrency key collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ env:
   # Only jobs that call neon-create-branch-with-retry use the pool — artifact consumers
   # (Lighthouse/A11y/Mobile Overflow) reuse neon-db and must NOT share the pool or
   # sibling matrix jobs cancel each other within the same workflow run.
-  # Pool groups include github.job so branch-creator siblings in one workflow (neon-db,
-  # dashboard Lighthouse, E2E smoke fallback, admin smoke) do not queue-cancel each other.
+  # Pool groups use literal job IDs because github.job is only populated inside runner
+  # steps. Job-level concurrency is evaluated before assignment, where github.job is null.
 
 jobs:
   # ── CI Optimizer + Centralized path-change detection (merged) ──────────
@@ -611,7 +611,7 @@ jobs:
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     concurrency:
-      group: neon-endpoint-pool-${{ github.job }}-${{ (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '0') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '4') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '8')) && '0' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '1') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '5') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '9')) && '1' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '2') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '6')) && '2' || '3' }}
+      group: neon-endpoint-pool-neon-db-${{ (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '0') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '4') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '8')) && '0' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '1') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '5') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '9')) && '1' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '2') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '6')) && '2' || '3' }}
       cancel-in-progress: false
     outputs:
       branch_name: ${{ steps.sanitize-branch.outputs.name }}
@@ -1599,7 +1599,7 @@ jobs:
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     concurrency:
-      group: neon-endpoint-pool-${{ github.job }}-${{ (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '0') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '4') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '8')) && '0' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '1') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '5') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '9')) && '1' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '2') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '6')) && '2' || '3' }}
+      group: neon-endpoint-pool-ci-lighthouse-dashboard-pr-${{ (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '0') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '4') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '8')) && '0' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '1') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '5') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '9')) && '1' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '2') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '6')) && '2' || '3' }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -2933,7 +2933,7 @@ jobs:
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     concurrency:
-      group: neon-endpoint-pool-${{ github.job }}-${{ (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '0') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '4') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '8')) && '0' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '1') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '5') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '9')) && '1' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '2') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '6')) && '2' || '3' }}
+      group: neon-endpoint-pool-ci-e2e-smoke-${{ (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '0') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '4') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '8')) && '0' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '1') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '5') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '9')) && '1' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '2') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '6')) && '2' || '3' }}
       cancel-in-progress: false
     outputs:
       run_full_ci: ${{ steps.check_changes.outputs.run_full_ci }}
@@ -3343,7 +3343,7 @@ jobs:
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
     concurrency:
-      group: neon-endpoint-pool-${{ github.job }}-${{ (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '0') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '4') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '8')) && '0' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '1') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '5') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '9')) && '1' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '2') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '6')) && '2' || '3' }}
+      group: neon-endpoint-pool-ci-admin-smoke-${{ (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '0') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '4') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '8')) && '0' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '1') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '5') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '9')) && '1' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '2') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '6')) && '2' || '3' }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -761,12 +761,13 @@ describe('CI mobile overflow workflow', () => {
 });
 
 describe('CI Neon endpoint pool concurrency (JOV-2497)', () => {
-  const neonBranchCreateJobs = [
-    'neon-db',
-    'ci-lighthouse-dashboard-pr',
-    'ci-e2e-smoke',
-    'ci-admin-smoke',
-  ] as const;
+  const neonBranchCreateJobs = {
+    'neon-db': 'neon-endpoint-pool-neon-db-',
+    'ci-lighthouse-dashboard-pr':
+      'neon-endpoint-pool-ci-lighthouse-dashboard-pr-',
+    'ci-e2e-smoke': 'neon-endpoint-pool-ci-e2e-smoke-',
+    'ci-admin-smoke': 'neon-endpoint-pool-ci-admin-smoke-',
+  } as const;
 
   const neonArtifactConsumerJobs = [
     'ci-lighthouse-pr',
@@ -780,12 +781,27 @@ describe('CI Neon endpoint pool concurrency (JOV-2497)', () => {
   it('caps cross-PR Neon branch creation with a four-slot queue', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
 
-    for (const jobKey of neonBranchCreateJobs) {
+    for (const [jobKey, expectedGroupPrefix] of Object.entries(
+      neonBranchCreateJobs
+    )) {
       const job = getJobBlock(workflow, jobKey);
       expect(job).toContain('concurrency:');
-      expect(job).toContain('group: neon-endpoint-pool-${{ github.job }}-');
+      expect(job).toContain(`group: ${expectedGroupPrefix}`);
+      expect(job).not.toContain('group: neon-endpoint-pool-${{ github.job }}-');
       expect(job).toContain('cancel-in-progress: false');
+
+      // Preserve the four-slot hash: decimal endings 0/4/8 -> 0,
+      // 1/5/9 -> 1, 2/6 -> 2, and 3/7 -> the fallback slot 3.
+      for (const suffix of ['0', '4', '8', '1', '5', '9', '2', '6']) {
+        expect(job).toContain(`, '${suffix}')`);
+      }
+      expect(job).toContain("&& '0'");
+      expect(job).toContain("&& '1'");
+      expect(job).toContain("&& '2'");
+      expect(job).toContain("|| '3'");
     }
+
+    expect(new Set(Object.values(neonBranchCreateJobs)).size).toBe(4);
   });
 
   // ci-golden-path deliberately uses ONE constant repo-wide group: it must
@@ -798,7 +814,7 @@ describe('CI Neon endpoint pool concurrency (JOV-2497)', () => {
     'group: neon-endpoint-pool-ci-golden-path',
   ] as const;
 
-  it('scopes branch-creation pool per job so siblings in one workflow are not cancelled', () => {
+  it('uses literal job prefixes because github.job is unavailable before a runner starts', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const poolGroups =
       workflow.match(/group: neon-endpoint-pool-[^\n]+/g) ?? [];
@@ -812,7 +828,8 @@ describe('CI Neon endpoint pool concurrency (JOV-2497)', () => {
       ) {
         continue;
       }
-      expect(group).toContain('${{ github.job }}');
+      expect(group).not.toContain('${{ github.job }}');
+      expect(group).not.toMatch(/neon-endpoint-pool--[0-3]/);
     }
   });
 

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -1,5 +1,6 @@
 export type CiFailureClass =
   | 'bounded_source_scan_timeout'
+  | 'neon_concurrency_key_collision'
   | 'test_fixture_import_timeout'
   | 'runner_process_exhaustion'
   | 'runner_host_pressure'
@@ -17,6 +18,14 @@ const DIAGNOSES: ReadonlyArray<{
   readonly rootCause: string;
   readonly remediation: string;
 }> = [
+  {
+    failureClass: 'neon_concurrency_key_collision',
+    matches: log => /neon-endpoint-pool--[0-3]\b/i.test(log),
+    rootCause:
+      'A job-level Neon concurrency key used github.job before runner assignment, where that property is null, collapsing distinct jobs into one empty-prefix pool group.',
+    remediation:
+      'Replace github.job in job-level concurrency with a stable literal job identifier and preserve the four-slot suffix hash.',
+  },
   {
     failureClass: 'bounded_source_scan_timeout',
     matches: log =>

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -41,4 +41,23 @@ describe('diagnoseCiFailure', () => {
       diagnoseCiFailure('PSI: sustained memory pressure on runner').failureClass
     ).toBe('runner_host_pressure');
   });
+
+  it('diagnoses a cancelled pending job whose Neon concurrency key lost its job prefix', () => {
+    const diagnosis = diagnoseCiFailure(`
+      E2E Smoke (PR Fast Feedback) was cancelled before runner assignment.
+      A newer pending job replaced it in concurrency group neon-endpoint-pool--0.
+    `);
+
+    expect(diagnosis.failureClass).toBe('neon_concurrency_key_collision');
+    expect(diagnosis.rootCause).toContain('github.job');
+    expect(diagnosis.remediation).toContain('literal job identifier');
+  });
+
+  it('does not classify a valid per-job Neon concurrency group as a collision', () => {
+    expect(
+      diagnoseCiFailure(
+        'waiting in concurrency group neon-endpoint-pool-ci-e2e-smoke-0'
+      ).failureClass
+    ).toBe('unknown');
+  });
 });


### PR DESCRIPTION
## Summary

- replace the four job-level Neon pool keys that used runner-only `github.job` with stable literal job identifiers
- preserve the existing four-slot PR/run hash and `cancel-in-progress: false`
- preserve Golden Path's intentional repo-wide serialization
- teach Gem to diagnose the empty-prefix concurrency collision deterministically
- harden the workflow regression to require four distinct literal prefixes and reject dynamic or empty job keys

## Root cause

PR #14400 CI run [29373783324](https://github.com/JovieInc/Jovie/actions/runs/29373783324) cancelled `E2E Smoke (PR Fast Feedback)` job [87223357647](https://github.com/JovieInc/Jovie/actions/runs/29373783324/job/87223357647) before runner assignment (`runner_id=0`, no runner name, no steps). Its evaluated group was `neon-endpoint-pool--0`.

The four job-level concurrency expressions used `${{ github.job }}`. GitHub documents that `github.job` is populated by the runner and is null outside execution steps, while job-level concurrency is evaluated before runner assignment. The intended per-job groups therefore collapsed into the same empty-prefix slot. GitHub keeps only one pending member in a concurrency group by default, so a newer sibling replaced and cancelled the queued E2E job even though `cancel-in-progress` was false.

Classification: missing automation / recurring Gem failure in the CI control plane. Not PR-specific, not a test failure, and not runner-capacity starvation.

Prior art inspected: #14112 and #14139. This PR deliberately excludes their artifact-attempt and orphan-reaper changes.

## Bug-to-Test

bug-to-test: satisfied

## Verification

- red proof on prior workflow: Neon concurrency subset 2 failed / 3 passed
- `deploy-workflow.test.ts`: 33/33 passed
- `ci-failure-diagnosis.test.ts`: 6/6 passed after merging current main
- CI harness manifest/docs: passed
- Biome on all changed TypeScript: passed
- structural actionlint (YAML + expressions): passed
- `git diff --check`: passed
- bug-to-test after commit: passed
- normal signed pushes: passed, hooks unchanged
- merged current main `fc5c7c009d` without force; preserved #14369's `test_fixture_import_timeout` classification and all persisted-auth changes
- exact PR diff remains four files, 61 insertions / 16 deletions
- full local actionlint reports only pre-existing shellcheck findings in untouched script blocks; no new workflow finding
- app typecheck was attempted once but interrupted after 15 minutes of host I/O pressure when the shared volume reached 2 GiB free; required remote CI remains authoritative for this draft

## Pre-Landing Review

No issues found. The change is limited to four literal prefixes, exact regression coverage, and one deterministic Gem diagnosis signature.

## Test plan

- [x] Verify all four branch-creator jobs retain the same four-slot suffix hash
- [x] Verify each job has a distinct literal prefix
- [x] Verify no Neon group uses `${{ github.job }}` or can evaluate to `neon-endpoint-pool--N`
- [x] Verify Golden Path remains intentionally serialized
- [x] Verify valid literal groups do not trigger the Gem collision diagnosis
- [x] Verify #14369's fixture-import diagnosis remains classified after the main merge
- [ ] Required remote CI on exact signed head

## Linear follow-ups

Linear follow-ups: none.