### PR TITLE
fix(e2e): synchronize mobile auth redirect

### DIFF
--- a/apps/web/tests/e2e/mobile-overflow.spec.ts
+++ b/apps/web/tests/e2e/mobile-overflow.spec.ts
@@ -7,7 +7,10 @@ import {
 } from '@playwright/test';
 import { APP_ROUTES } from '@/constants/routes';
 import { setTestAuthBypassSession } from '../helpers/clerk-auth';
-import { expectNoDocumentOverflow } from './utils/mobile-overflow';
+import {
+  expectNoDocumentOverflow,
+  waitForPendingNextRedirect,
+} from './utils/mobile-overflow';
 import {
   type ResolvedPublicSurfaceSpec,
   resolvePublicSurfaceManifestSync,
@@ -265,6 +268,13 @@ async function navigateToPublicSurface(
     `${surface.id} should not server-error`
   ).toBeLessThan(500);
 
+  if (surface.family === 'auth-entry') {
+    await waitForPendingNextRedirect(
+      page,
+      response,
+      surface.readyVisibleTimeoutMs ?? SMOKE_TIMEOUTS.VISIBILITY
+    );
+  }
   await waitForHydration(page, {
     timeout: surface.readyVisibleTimeoutMs ?? SMOKE_TIMEOUTS.VISIBILITY,
   });

--- a/apps/web/tests/e2e/utils/mobile-overflow.ts
+++ b/apps/web/tests/e2e/utils/mobile-overflow.ts
@@ -1,4 +1,9 @@
-import { expect, type Page, type TestInfo } from '@playwright/test';
+import {
+  expect,
+  type Page,
+  type Response,
+  type TestInfo,
+} from '@playwright/test';
 
 export interface MobileOverflowMetrics {
   readonly documentScrollWidth: number;
@@ -22,12 +27,39 @@ export interface OverflowingElement {
   readonly text: string;
 }
 
+type RedirectPage = Pick<Page, 'waitForURL'>;
+type RedirectResponse = Pick<Response, 'text' | 'url'>;
+
 function normalizeAttachmentName(label: string): string {
   return label
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '')
     .slice(0, 80);
+}
+
+export async function waitForPendingNextRedirect(
+  page: RedirectPage,
+  response: RedirectResponse | null,
+  timeout: number
+): Promise<void> {
+  if (!response) return;
+
+  const html = await response.text();
+  const digest = html.match(
+    /NEXT_REDIRECT;(?:replace|push);.*?;(?:303|307|308);(?=["'<>\\]|$)/s
+  )?.[0];
+  const target = digest?.split(';').slice(2, -2).join(';').trim();
+  if (!target) return;
+
+  const expectedUrl = new URL(target, response.url());
+  await page.waitForURL(
+    url =>
+      url.origin === expectedUrl.origin &&
+      url.pathname === expectedUrl.pathname &&
+      url.search === expectedUrl.search,
+    { waitUntil: 'domcontentloaded', timeout }
+  );
 }
 
 export async function getMobileOverflowMetrics(

--- a/apps/web/tests/unit/e2e/mobile-overflow-navigation.test.ts
+++ b/apps/web/tests/unit/e2e/mobile-overflow-navigation.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import { waitForPendingNextRedirect } from '../../e2e/utils/mobile-overflow';
+
+describe('waitForPendingNextRedirect', () => {
+  it('waits for the exact server-rendered Next redirect target', async () => {
+    const waitForURL = vi.fn().mockResolvedValue(undefined);
+    const page = { waitForURL };
+    const response = {
+      text: vi
+        .fn()
+        .mockResolvedValue(
+          '<template data-dgst="NEXT_REDIRECT;replace;/app?source=signin;307;"></template>'
+        ),
+      url: vi.fn().mockReturnValue('https://jov.ie/signin'),
+    };
+
+    await waitForPendingNextRedirect(page, response, 9_000);
+
+    expect(waitForURL).toHaveBeenCalledOnce();
+    const [matchesUrl, options] = waitForURL.mock.calls[0] as [
+      (url: URL) => boolean,
+      Record<string, unknown>,
+    ];
+    expect(matchesUrl(new URL('https://jov.ie/app?source=signin'))).toBe(true);
+    expect(matchesUrl(new URL('https://jov.ie/app?source=other'))).toBe(false);
+    expect(options).toEqual({
+      waitUntil: 'domcontentloaded',
+      timeout: 9_000,
+    });
+  });
+
+  it('waits when the raw streamed response carries the redirect digest', async () => {
+    const waitForURL = vi.fn().mockResolvedValue(undefined);
+    const page = { waitForURL };
+    const response = {
+      text: vi
+        .fn()
+        .mockResolvedValue(
+          '<script>self.__next_f.push([1,"c:E{\\"digest\\":\\"NEXT_REDIRECT;replace;/app;307;\\"}\\n"])</script>'
+        ),
+      url: vi.fn().mockReturnValue('https://jov.ie/signin'),
+    };
+
+    await waitForPendingNextRedirect(page, response, 9_000);
+
+    expect(waitForURL).toHaveBeenCalledOnce();
+    const [matchesUrl] = waitForURL.mock.calls[0] as [(url: URL) => boolean];
+    expect(matchesUrl(new URL('https://jov.ie/app'))).toBe(true);
+    expect(matchesUrl(new URL('https://jov.ie/signin'))).toBe(false);
+  });
+
+  it('preserves semicolons in the redirect destination', async () => {
+    const waitForURL = vi.fn().mockResolvedValue(undefined);
+    const page = { waitForURL };
+    const response = {
+      text: vi
+        .fn()
+        .mockResolvedValue(
+          '<template data-dgst="NEXT_REDIRECT;push;/app;mode=compact?source=signin;303;"></template>'
+        ),
+      url: vi.fn().mockReturnValue('https://jov.ie/signin'),
+    };
+
+    await waitForPendingNextRedirect(page, response, 9_000);
+
+    expect(waitForURL).toHaveBeenCalledOnce();
+    const [matchesUrl] = waitForURL.mock.calls[0] as [(url: URL) => boolean];
+    expect(
+      matchesUrl(new URL('https://jov.ie/app;mode=compact?source=signin'))
+    ).toBe(true);
+    expect(matchesUrl(new URL('https://jov.ie/app'))).toBe(false);
+  });
+
+  it('does not wait when the response has no redirect digest', async () => {
+    const waitForURL = vi.fn();
+    const page = { waitForURL };
+    const response = {
+      text: vi.fn().mockResolvedValue('<main>Sign in</main>'),
+      url: vi.fn().mockReturnValue('https://jov.ie/signin'),
+    };
+
+    await waitForPendingNextRedirect(page, response, 9_000);
+
+    expect(waitForURL).not.toHaveBeenCalled();
+  });
+
+  it('does not treat unsupported redirect statuses as a Next redirect', async () => {
+    const waitForURL = vi.fn();
+    const page = { waitForURL };
+    const response = {
+      text: vi
+        .fn()
+        .mockResolvedValue(
+          '<template data-dgst="NEXT_REDIRECT;replace;/legacy;301;"></template>'
+        ),
+      url: vi.fn().mockReturnValue('https://jov.ie/signin'),
+    };
+
+    await waitForPendingNextRedirect(page, response, 9_000);
+
+    expect(waitForURL).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -37,6 +37,7 @@ export type CiFailureClass =
   | 'broad_test_performance_regression'
   | 'isolated_stuck_test_regression'
   | 'test_fixture_import_timeout'
+  | 'mobile_overflow_navigation_race'
   | 'runner_slice_task_saturation'
   | 'runner_process_exhaustion'
   | 'runner_io_pressure_admission'
@@ -573,6 +574,20 @@ const DIAGNOSES: ReadonlyArray<{
       'The HUD page test counted its cold dynamic module transform and import against the per-test timeout after resetting the module graph.',
     remediation:
       'Hoist the mocked HUD page import outside the timed test bodies and avoid resetting modules when the assertions do not require a fresh module graph.',
+  },
+  {
+    failureClass: 'mobile_overflow_navigation_race',
+    matches: log =>
+      /Mobile Overflow/i.test(log) &&
+      /auth-signin/i.test(log) &&
+      /page\.evaluate: Execution context was destroyed, most likely because of a navigation/i.test(
+        log
+      ) &&
+      /utils\/mobile-overflow\.ts/i.test(log),
+    rootCause:
+      'The no-auth mobile overflow lane only recognized a DOM data-dgst redirect marker, but the raw Next.js response carries the digest in its streamed Flight script, so DOM measurement began before navigation completed and invalidated the evaluation context.',
+    remediation:
+      'Parse the NEXT_REDIRECT digest from the raw response and wait for its exact target to finish loading before hydration and overflow measurement; do not retry page.evaluate.',
   },
   {
     failureClass: 'runner_slice_task_saturation',

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -642,6 +642,38 @@ LIGHTHOUSE_FAILURE_CLASS=deterministic_assertion LIGHTHOUSE_ATTEMPT=1/3`);
     ).toBe('test_fixture_import_timeout');
   });
 
+  it('classifies the mobile overflow sign-in navigation race', () => {
+    const diagnosis = diagnoseCiFailure(`
+        Mobile Overflow Release Guard > 320px > public auth-signin has no horizontal overflow @ 320px
+        page.evaluate: Execution context was destroyed, most likely because of a navigation
+        at getOverflowingElements (tests/e2e/utils/mobile-overflow.ts:61:15)
+      `);
+
+    expect(diagnosis.failureClass).toBe('mobile_overflow_navigation_race');
+    expect(diagnosis.rootCause).toContain('streamed Flight script');
+    expect(diagnosis.remediation).toContain('raw response');
+  });
+
+  it('does not classify a generic destroyed execution context as mobile overflow', () => {
+    expect(
+      diagnoseCiFailure(`
+        Checkout flow
+        page.evaluate: Execution context was destroyed, most likely because of a navigation
+        at tests/e2e/checkout.spec.ts:42:9
+      `).failureClass
+    ).toBe('unknown');
+  });
+
+  it('does not apply the sign-in diagnosis to another mobile overflow surface', () => {
+    expect(
+      diagnoseCiFailure(`
+        Mobile Overflow Release Guard > 320px > public marketing-pricing has no horizontal overflow @ 320px
+        page.evaluate: Execution context was destroyed, most likely because of a navigation
+        at getOverflowingElements (tests/e2e/utils/mobile-overflow.ts:61:15)
+      `).failureClass
+    ).toBe('unknown');
+  });
+
   it('keeps process exhaustion and host pressure as distinct failure classes', () => {
     expect(
       diagnoseCiFailure('ERR_WORKER_INIT_FAILED: spawnSync node EAGAIN')

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -198,6 +198,15 @@ const GTMQ_SOURCE_GATE_REAPER_MANIFEST = [
   'scripts/run-affected-tests.mjs',
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST = [
+  'apps/web/tests/e2e/mobile-overflow.spec.ts',
+  'apps/web/tests/e2e/utils/mobile-overflow.ts',
+  'apps/web/tests/unit/e2e/mobile-overflow-navigation.test.ts',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+];
 const RUNNER_IO_PRESSURE_MANIFEST = [
   '.github/runner-host/README.md',
   '.github/runner-host/autoscaler/controller-io-pressure.patch',
@@ -907,6 +916,53 @@ describe('automation-verify affected scope', () => {
     ]);
   });
 
+  it('keeps Playwright deep and selects deterministic mobile overflow regressions', () => {
+    const plan = buildAffectedTestPlan(
+      MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST
+    );
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/e2e/mobile-overflow-navigation.test.ts',
+    ]);
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+      'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+    ]);
+    expect(buildSelectedTestCommands(plan, '2')).toEqual([
+      [
+        'pnpm',
+        [
+          'exec',
+          'vitest',
+          '--root',
+          'scripts',
+          '--config',
+          'vitest.config.mts',
+          'run',
+          'lib/__tests__/automation-verify.test.mjs',
+          'hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+          '--maxWorkers',
+          '2',
+        ],
+      ],
+      [
+        'pnpm',
+        [
+          '--filter',
+          '@jovie/web',
+          'exec',
+          'vitest',
+          'run',
+          'tests/unit/e2e/mobile-overflow-navigation.test.ts',
+          '--passWithNoTests',
+          '--maxWorkers',
+          '2',
+        ],
+      ],
+    ]);
+  });
+
   it.each([
     { manifest: PERFORMANCE_PROFILER_REPAIR_PRIMARY_MANIFEST },
     { manifest: PERFORMANCE_PROFILER_REPAIR_MANIFEST },
@@ -1044,6 +1100,27 @@ describe('automation-verify affected scope', () => {
       buildAffectedTestPlan(
         GTMQ_SOURCE_GATE_REAPER_MANIFEST.filter(file => file !== missingInput)
       ).mode
+    ).toBe('full');
+  });
+
+  it.each(
+    MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST
+  )('fails closed when the mobile overflow navigation repair is missing %s', missingInput => {
+    expect(
+      buildAffectedTestPlan(
+        MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST.filter(
+          file => file !== missingInput
+        )
+      ).mode
+    ).toBe('full');
+  });
+
+  it('fails closed when the mobile overflow navigation repair includes an unknown peer', () => {
+    expect(
+      buildAffectedTestPlan([
+        ...MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST,
+        'scripts/hermes/lib/unknown-mobile-overflow-helper.ts',
+      ]).mode
     ).toBe('full');
   });
 

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -263,6 +263,19 @@ const GTMQ_SOURCE_GATE_REAPER_PYTHON_TESTS = ['scripts/tests/test_gh_retry.py'];
 const GTMQ_SOURCE_GATE_REAPER_SCRIPT_TESTS = [
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST = new Set([
+  'apps/web/tests/e2e/mobile-overflow.spec.ts',
+  'apps/web/tests/e2e/utils/mobile-overflow.ts',
+  'apps/web/tests/unit/e2e/mobile-overflow-navigation.test.ts',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+]);
+const MOBILE_OVERFLOW_NAVIGATION_RACE_SCRIPT_TESTS = [
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+];
 const RUNNER_IO_PRESSURE_MANIFEST = new Set([
   '.github/runner-host/README.md',
   '.github/runner-host/autoscaler/controller-io-pressure.patch',
@@ -488,6 +501,13 @@ export function buildAffectedTestPlan(changedFiles) {
   const isExactGtmqSourceGateReaper =
     gtmqSourceGateReaperInputCount === GTMQ_SOURCE_GATE_REAPER_MANIFEST.size &&
     files.length === GTMQ_SOURCE_GATE_REAPER_MANIFEST.size;
+  const mobileOverflowNavigationRaceInputCount = files.filter(file =>
+    MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST.has(file)
+  ).length;
+  const isExactMobileOverflowNavigationRace =
+    mobileOverflowNavigationRaceInputCount ===
+      MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST.size &&
+    files.length === MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST.size;
   const runnerIoPressureInputCount = files.filter(file =>
     RUNNER_IO_PRESSURE_MANIFEST.has(file)
   ).length;
@@ -537,7 +557,9 @@ export function buildAffectedTestPlan(changedFiles) {
       !(
         isExactGoldenPathSmokeContractRepair &&
         file === 'apps/web/tests/e2e/golden-path.spec.ts'
-      )
+      ) &&
+      // Per docs/PR_FLOW.md, Playwright remains in hosted manual/deep lanes.
+      !(isExactMobileOverflowNavigationRace && file.endsWith('.spec.ts'))
   );
   const mandatoryTests = [];
   const hasSeedConfirmationChange = files.some(
@@ -675,6 +697,9 @@ export function buildAffectedTestPlan(changedFiles) {
     ...(isExactGtmqSourceGateReaper
       ? GTMQ_SOURCE_GATE_REAPER_SCRIPT_TESTS
       : []),
+    ...(isExactMobileOverflowNavigationRace
+      ? MOBILE_OVERFLOW_NAVIGATION_RACE_SCRIPT_TESTS
+      : []),
     ...(isExactRunnerIoPressure ? RUNNER_IO_PRESSURE_SCRIPT_TESTS : []),
     ...(isExactRunnerPrerequisiteRepair
       ? RUNNER_PREREQUISITE_CONTROL_TESTS
@@ -709,6 +734,11 @@ export function buildAffectedTestPlan(changedFiles) {
     if (
       isExactPersistedAuthFixtureRepair &&
       PERSISTED_AUTH_FIXTURE_REPAIR_CORE.has(file)
+    )
+      return true;
+    if (
+      isExactMobileOverflowNavigationRace &&
+      MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST.has(file)
     )
       return true;
     if (isExactRunnerIoPressure && RUNNER_IO_PRESSURE_MANIFEST.has(file))
@@ -771,6 +801,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactPersistedAuthFixtureRepair &&
     !isExactVisualQaSelectorRepair &&
     !isExactGtmqSourceGateReaper &&
+    !isExactMobileOverflowNavigationRace &&
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactLayoutGuardContract &&
@@ -785,6 +816,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactGoldenPathSmokeContractRepair &&
     !isExactNeonAttemptArtifactRepair &&
     !isExactPersistedAuthFixtureRepair &&
+    !isExactMobileOverflowNavigationRace &&
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactLayoutGuardContract;
@@ -801,6 +833,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactPersistedAuthFixtureRepair &&
     !isExactVisualQaSelectorRepair &&
     !isExactGtmqSourceGateReaper &&
+    !isExactMobileOverflowNavigationRace &&
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactLayoutGuardContract &&
@@ -816,6 +849,22 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactScannerLoadRepairPrimary &&
     !isExactVisualQaSelectorRepair &&
     !isExactPerformanceProfilerRepairWithSelector &&
+    !isExactMobileOverflowNavigationRace &&
+    !isExactRunnerIoPressure &&
+    !isExactRunnerPrerequisiteRepair &&
+    !isExactLayoutGuardContract &&
+    !isExactPrSizeGuardWithSelector;
+  const hasIncompleteMobileOverflowNavigationRace =
+    mobileOverflowNavigationRaceInputCount > 0 &&
+    !isExactMobileOverflowNavigationRace &&
+    !isExactAuthenticatedA11yRepair &&
+    !isExactAffectedTestSelector &&
+    !isExactGoldenPathSmokeContractRepair &&
+    !isExactNeonAttemptArtifactRepair &&
+    !isExactPerformanceProfilerRepair &&
+    !isExactPersistedAuthFixtureRepair &&
+    !isExactVisualQaSelectorRepair &&
+    !isExactGtmqSourceGateReaper &&
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactLayoutGuardContract &&
@@ -831,6 +880,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactVisualQaSelectorRepair &&
     !isExactGtmqSourceGateReaper &&
     !isExactPerformanceProfilerRepair &&
+    !isExactMobileOverflowNavigationRace &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactLayoutGuardContract &&
     !isExactPrSizeGuardWithSelector;
@@ -847,6 +897,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactPersistedAuthFixtureRepair &&
     !isExactLayoutGuardContract &&
     !isExactPerformanceProfilerRepair &&
+    !isExactMobileOverflowNavigationRace &&
     !isExactRunnerIoPressure &&
     !isExactPrSizeGuardWithSelector;
   const hasIncompleteLayoutGuardContract =
@@ -862,6 +913,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactVisualQaSelectorRepair &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactPerformanceProfilerRepair &&
+    !isExactMobileOverflowNavigationRace &&
     !isExactRunnerIoPressure &&
     !isExactPrSizeGuardWithSelector;
   const hasIncompleteNeonAttemptArtifactRepair =
@@ -876,6 +928,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactPersistedAuthFixtureRepair &&
     !isExactVisualQaSelectorRepair &&
     !isExactGtmqSourceGateReaper &&
+    !isExactMobileOverflowNavigationRace &&
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactLayoutGuardContract &&
@@ -893,6 +946,7 @@ export function buildAffectedTestPlan(changedFiles) {
     hasIncompletePerformanceProfilerRepair ||
     hasIncompleteScannerLoadRepair ||
     hasIncompleteGtmqSourceGateReaper ||
+    hasIncompleteMobileOverflowNavigationRace ||
     hasIncompleteRunnerIoPressure ||
     hasIncompleteRunnerPrerequisiteContract ||
     hasIncompleteLayoutGuardContract ||
@@ -920,6 +974,7 @@ export function buildAffectedTestPlan(changedFiles) {
             isExactPersistedAuthFixtureRepair ||
             isExactVisualQaSelectorRepair ||
             isExactGtmqSourceGateReaper ||
+            isExactMobileOverflowNavigationRace ||
             isExactRunnerIoPressure ||
             isExactRunnerPrerequisiteRepair ||
             isExactLayoutGuardContract)


### PR DESCRIPTION
## Summary
- wait for the exact server-rendered Next.js `NEXT_REDIRECT` target before Mobile Overflow hydration and DOM measurement
- classify the exact auth-signin execution-context race in Gem without matching unrelated navigation failures
- keep this seven-file repair on focused behavioral, diagnosis, and selector coverage

## Root cause
PR #14402 job 87232583874 loaded `/signin` with the no-auth bypass. The initial document rendered a transitional auth shell plus `NEXT_REDIRECT;replace;/app;307`; broad readiness matched the shell and overflow `page.evaluate` began while the redirect committed, destroying the execution context. This is a broken test synchronization/fixture lifecycle, not product overflow, runner pressure, or a blind-retry case.

## Verification
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/automation-verify.test.mjs hermes/lib/__tests__/ci-failure-diagnosis.test.ts --maxWorkers 2` (84/84)
- `pnpm --filter @jovie/web exec vitest run tests/unit/e2e/mobile-overflow-navigation.test.ts --maxWorkers 2` (2/2)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write apps/web`
- Playwright no-auth discovery: 996 tests listed
- `pnpm --filter @jovie/web run test:bug-to-test`
- `git diff --check`

## Regression contract
The behavioral test proves a response carrying `NEXT_REDIRECT` waits for the exact path and query before measurement, while a response without the digest performs no wait.

Draft pending required remote CI and the planned current-main rebase after #14401 lands.