### PR TITLE
fix(ci): isolate golden path from bypass smoke

### DIFF
--- a/apps/web/tests/e2e/golden-path.spec.ts
+++ b/apps/web/tests/e2e/golden-path.spec.ts
@@ -32,6 +32,11 @@ const REQUIRED_ENV = {
   DATABASE_URL: process.env.DATABASE_URL,
 } as const;
 
+const IS_LOCAL_AUTH_BYPASS =
+  process.env.E2E_USE_TEST_AUTH_BYPASS === '1' ||
+  process.env.NEXT_PUBLIC_CLERK_MOCK === '1' ||
+  process.env.NEXT_PUBLIC_CLERK_PROXY_DISABLED === '1';
+
 function hasRealEnv(): boolean {
   return Object.values(REQUIRED_ENV).every(
     v => v && !v.includes('mock') && !v.includes('dummy')
@@ -319,6 +324,13 @@ test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Live Profile'
   test.use({ storageState: { cookies: [], origins: [] } });
 
   test.beforeEach(async ({ page }) => {
+    if (IS_LOCAL_AUTH_BYPASS) {
+      test.skip(
+        true,
+        'Golden path requires the dedicated real-auth lane, not the smoke auth bypass'
+      );
+    }
+
     if (!hasRealEnv()) {
       test.skip(true, 'Better Auth/DB env vars not configured');
     }

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -514,6 +514,38 @@ describe('canary health gate workflow', () => {
 });
 
 describe('CI E2E smoke workflow', () => {
+  it('keeps the real-auth golden path inert in the bypass smoke lane', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const smokeStep = getStepBlock(
+      getJobBlock(workflow, 'ci-e2e-smoke'),
+      'Run E2E Smoke (Chromium)'
+    );
+    const goldenPathStep = getStepBlock(
+      getJobBlock(workflow, 'ci-golden-path'),
+      'Run Golden Path (Chromium, Better Auth)'
+    );
+    const goldenPathSpec = readFileSync(
+      resolve(repoRoot, 'apps/web/tests/e2e/golden-path.spec.ts'),
+      'utf8'
+    );
+    const smokeManifest = readFileSync(
+      resolve(repoRoot, 'apps/web/tests/e2e/smoke-manifest.ts'),
+      'utf8'
+    );
+
+    expect(smokeManifest).toContain("'golden-path.spec.ts'");
+    expect(smokeStep).toContain('export E2E_USE_TEST_AUTH_BYPASS=1');
+    expect(smokeStep).not.toContain('export E2E_TEST_MODE=1');
+    expect(goldenPathStep).toContain('export E2E_TEST_MODE=1');
+    expect(goldenPathStep).not.toContain('E2E_USE_TEST_AUTH_BYPASS');
+    expect(goldenPathSpec).toContain(
+      "process.env.E2E_USE_TEST_AUTH_BYPASS === '1'"
+    );
+    expect(goldenPathSpec).toContain(
+      'Golden path requires the dedicated real-auth lane'
+    );
+  });
+
   it('seeds public QA fixtures on ephemeral Neon before PR smoke runs', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const smokeJob = getJobBlock(workflow, 'ci-e2e-smoke');

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -1,5 +1,6 @@
 export type CiFailureClass =
   | 'bounded_source_scan_timeout'
+  | 'golden_path_smoke_auth_contract'
   | 'neon_concurrency_key_collision'
   | 'test_fixture_import_timeout'
   | 'runner_process_exhaustion'
@@ -18,6 +19,20 @@ const DIAGNOSES: ReadonlyArray<{
   readonly rootCause: string;
   readonly remediation: string;
 }> = [
+  {
+    failureClass: 'golden_path_smoke_auth_contract',
+    matches: log =>
+      /E2E Smoke \(PR Fast Feedback\)/i.test(log) &&
+      /export E2E_USE_TEST_AUTH_BYPASS=1/i.test(log) &&
+      /golden-path\.spec\.ts/i.test(log) &&
+      /(?:That code is incorrect|createFreshUserOnce|page\.waitForURL)/i.test(
+        log
+      ),
+    rootCause:
+      'The real-auth golden-path spec ran inside the bypass smoke lane, where E2E_TEST_MODE and the dedicated journey credentials are intentionally absent, so the Better Auth test code was rejected.',
+    remediation:
+      'Keep golden-path self-skipped whenever the smoke auth bypass is enabled and run the journey only in the dedicated Golden Path job, which supplies E2E_TEST_MODE and real-auth credentials.',
+  },
   {
     failureClass: 'neon_concurrency_key_collision',
     matches: log => /neon-endpoint-pool--[0-3]\b/i.test(log),

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -2,6 +2,31 @@ import { describe, expect, it } from 'vitest';
 import { diagnoseCiFailure } from '../../jobs/ci-failure-diagnosis';
 
 describe('diagnoseCiFailure', () => {
+  it('diagnoses deterministic Better Auth OTP rejection in the bypass smoke lane', () => {
+    const diagnosis = diagnoseCiFailure(`
+      E2E Smoke (PR Fast Feedback)
+      export E2E_USE_TEST_AUTH_BYPASS=1
+      [chromium] tests/e2e/golden-path.spec.ts
+      TimeoutError: page.waitForURL: Timeout 30000ms exceeded.
+      at createFreshUserOnce (tests/e2e/golden-path.spec.ts:252:14)
+    `);
+
+    expect(diagnosis.failureClass).toBe('golden_path_smoke_auth_contract');
+    expect(diagnosis.rootCause).toContain('E2E_TEST_MODE');
+    expect(diagnosis.remediation).toContain('dedicated Golden Path job');
+  });
+
+  it('does not misclassify the authoritative real-auth golden-path lane', () => {
+    expect(
+      diagnoseCiFailure(`
+        Golden Path (PR)
+        export E2E_TEST_MODE=1
+        [chromium] tests/e2e/golden-path.spec.ts
+        TimeoutError: page.waitForURL: Timeout 30000ms exceeded.
+      `).failureClass
+    ).toBe('unknown');
+  });
+
   it('classifies the analytics scanner timeout separately from runner pressure', () => {
     const log = `
       FAIL tests/unit/analytics-metrics-layer-guard.test.ts > canonical metrics layer guard

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -81,6 +81,13 @@ const AFFECTED_TEST_SELECTOR_MANIFEST = [
   'scripts/run-affected-tests.mjs',
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const GOLDEN_PATH_SMOKE_CONTRACT_REPAIR_DIFF = [
+  'apps/web/tests/e2e/golden-path.spec.ts',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  ...AFFECTED_TEST_SELECTOR_MANIFEST,
+];
 const PERSISTED_AUTH_FIXTURE_REPAIR_CORE = [
   'apps/web/app/api/dev/test-auth/session/route.ts',
   'apps/web/lib/auth/dev-test-auth-identity.ts',
@@ -484,6 +491,22 @@ describe('automation-verify affected scope', () => {
         ],
       ],
     ]);
+  });
+
+  it('keeps the golden-path smoke contract repair on focused coverage', () => {
+    const plan = buildAffectedTestPlan(GOLDEN_PATH_SMOKE_CONTRACT_REPAIR_DIFF);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+    ]);
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+      'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+    ]);
+    expect(plan.selectedTests).not.toContain(
+      'apps/web/tests/e2e/golden-path.spec.ts'
+    );
   });
 
   it('keeps persisted auth fixture repairs on focused non-retryable coverage', () => {

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -100,6 +100,18 @@ const AFFECTED_TEST_SELECTOR_MANIFEST = new Set([
 const AFFECTED_TEST_SELECTOR_TESTS = [
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const GOLDEN_PATH_SMOKE_CONTRACT_CORE = new Set([
+  'apps/web/tests/e2e/golden-path.spec.ts',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+]);
+const GOLDEN_PATH_SMOKE_CONTRACT_TESTS = [
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+];
+const GOLDEN_PATH_SMOKE_CONTRACT_SCRIPT_TESTS = [
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+];
 const PERSISTED_AUTH_FIXTURE_REPAIR_CORE = new Set([
   'apps/web/app/api/dev/test-auth/session/route.ts',
   'apps/web/lib/auth/dev-test-auth-identity.ts',
@@ -185,6 +197,18 @@ export function buildAffectedTestPlan(changedFiles) {
   const isExactAffectedTestSelector =
     affectedTestSelectorInputCount === AFFECTED_TEST_SELECTOR_MANIFEST.size &&
     files.length === AFFECTED_TEST_SELECTOR_MANIFEST.size;
+  const goldenPathSmokeContractInputCount = files.filter(file =>
+    GOLDEN_PATH_SMOKE_CONTRACT_CORE.has(file)
+  ).length;
+  const isExactGoldenPathSmokeContractRepair =
+    goldenPathSmokeContractInputCount ===
+      GOLDEN_PATH_SMOKE_CONTRACT_CORE.size &&
+    files.every(
+      file =>
+        GOLDEN_PATH_SMOKE_CONTRACT_CORE.has(file) ||
+        AFFECTED_TEST_SELECTOR_MANIFEST.has(file)
+    ) &&
+    affectedTestSelectorInputCount === AFFECTED_TEST_SELECTOR_MANIFEST.size;
   const persistedAuthFixtureInputCount = files.filter(file =>
     PERSISTED_AUTH_FIXTURE_REPAIR_CORE.has(file)
   ).length;
@@ -215,6 +239,10 @@ export function buildAffectedTestPlan(changedFiles) {
       !(
         isExactPrerequisiteTrain &&
         PREREQUISITE_TRAIN_PLAYWRIGHT_SPECS.has(file)
+      ) &&
+      !(
+        isExactGoldenPathSmokeContractRepair &&
+        file === 'apps/web/tests/e2e/golden-path.spec.ts'
       )
   );
   const mandatoryTests = [];
@@ -282,6 +310,9 @@ export function buildAffectedTestPlan(changedFiles) {
   if (isExactPrerequisiteTrain) {
     mandatoryTests.push(...PREREQUISITE_TRAIN_TESTS);
   }
+  if (isExactGoldenPathSmokeContractRepair) {
+    mandatoryTests.push(...GOLDEN_PATH_SMOKE_CONTRACT_TESTS);
+  }
 
   const selectedTests = unique([...directTests, ...mandatoryTests]);
   const rootVitestTests = isExactVercelCongestionControl
@@ -297,8 +328,12 @@ export function buildAffectedTestPlan(changedFiles) {
   ]);
   const scriptVitestTests = unique([
     ...(isExactAffectedTestSelector ||
+    isExactGoldenPathSmokeContractRepair ||
     (isExactPersistedAuthFixtureRepair && affectedTestSelectorInputCount > 0)
       ? AFFECTED_TEST_SELECTOR_TESTS
+      : []),
+    ...(isExactGoldenPathSmokeContractRepair
+      ? GOLDEN_PATH_SMOKE_CONTRACT_SCRIPT_TESTS
       : []),
     ...(isExactPersistedAuthFixtureRepair
       ? PERSISTED_AUTH_FIXTURE_SCRIPT_TESTS
@@ -317,6 +352,11 @@ export function buildAffectedTestPlan(changedFiles) {
     if (file.startsWith('apps/web/tests/eval/promptfoo/')) return true;
     if (isInvestorNoteIngestionInput(file)) return true;
     if (isCiCancellationHealerInput(file)) return true;
+    if (
+      isExactGoldenPathSmokeContractRepair &&
+      GOLDEN_PATH_SMOKE_CONTRACT_CORE.has(file)
+    )
+      return true;
     if (
       isExactPersistedAuthFixtureRepair &&
       PERSISTED_AUTH_FIXTURE_REPAIR_CORE.has(file)
@@ -359,11 +399,13 @@ export function buildAffectedTestPlan(changedFiles) {
   const hasIncompleteAffectedTestSelector =
     affectedTestSelectorInputCount > 0 &&
     !isExactAffectedTestSelector &&
+    !isExactGoldenPathSmokeContractRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactGtmqSourceGateReaper;
   const hasIncompleteGtmqSourceGateReaper =
     gtmqSourceGateReaperInputCount > 0 &&
     !isExactGtmqSourceGateReaper &&
+    !isExactGoldenPathSmokeContractRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactAffectedTestSelector;
   const hasUncoveredSource =
@@ -390,6 +432,7 @@ export function buildAffectedTestPlan(changedFiles) {
             isExactPrerequisiteTrain ||
             isExactVercelCongestionControl ||
             isExactAffectedTestSelector ||
+            isExactGoldenPathSmokeContractRepair ||
             isExactPersistedAuthFixtureRepair ||
             isExactGtmqSourceGateReaper)
         ? 'selected'


### PR DESCRIPTION
## Root cause

Current-main E2E Smoke run 29376291612, job 87231775294, ran `golden-path.spec.ts` inside the smoke auth-bypass lane. The spec's former bypass guard was removed during the Clerk-to-Better-Auth conversion, but it remained in the desktop smoke manifest.

That lane intentionally exports `E2E_USE_TEST_AUTH_BYPASS=1` and omits `E2E_TEST_MODE` plus the dedicated journey credentials. The real Better Auth signup therefore generated a non-deterministic OTP and rejected the spec's `424242` code. This is deterministic broken test/fixture and CI contract drift, not flaky CI, runner pressure, or #14369's persisted-actor repair.

## Smallest safe fix

- Restore the golden-path self-skip whenever the local smoke auth bypass/mock is active.
- Keep the dedicated `Golden Path (PR)` job authoritative for the real journey; it still supplies `E2E_TEST_MODE=1` and real-auth credentials.
- Lock the smoke-vs-dedicated lane contract with a regression test.
- Teach Gem to diagnose this exact failure as `golden_path_smoke_auth_contract` and recommend the dedicated lane instead of a blind rerun.
- Keep this exact six-file repair on focused affected-test coverage.

No product auth, workflow, or chat implementation changed.

## Verification

- CI workflow contract: 34/34 passed.
- Gem diagnosis + affected selector: 77/77 passed.
- Exact affected pre-push bundle: passed (111 assertions total).
- Web typecheck: passed.
- Biome on all six files: passed.
- Tailwind guard, proxy guard, CI harness, secret scans, diff check, and bug-to-test: passed.
- Normal signed push and repository hooks: passed.
- Direct actionlint reports only pre-existing shellcheck findings in unchanged `.github/workflows/ci.yml` blocks; this PR does not modify the workflow.

bug-to-test: satisfied

## Test plan

- [x] Bypass smoke includes the golden spec but self-skips it before real-auth work.
- [x] Dedicated Golden Path exports `E2E_TEST_MODE=1` and does not enable the bypass.
- [x] Gem matches the exact failed smoke signature.
- [x] Gem does not misclassify a dedicated-lane navigation failure.
- [ ] Required remote CI on exact signed head.

Linear issue: none — ad-hoc current-main repair coordinated in GBrain.
