### PR TITLE
fix(ci): protect visual QA artifacts from timestamp races

### DIFF
--- a/apps/web/lib/agent-os/visual-qa/diff-artifacts.ts
+++ b/apps/web/lib/agent-os/visual-qa/diff-artifacts.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import {
   lstat,
   mkdir,
@@ -93,6 +94,8 @@ interface VisualQaRunTreeState {
   readonly birthtimeMs: number;
   readonly containsSymlink: boolean;
   readonly dev: number;
+  readonly entryCount: number;
+  readonly entryFingerprint: string;
   readonly ino: number;
   readonly newestMtimeMs: number;
 }
@@ -204,6 +207,8 @@ async function inspectVisualQaRunTree(
         birthtimeMs: runStats.birthtimeMs,
         containsSymlink: true,
         dev: runStats.dev,
+        entryCount: 1,
+        entryFingerprint: `${runStats.dev}:${runStats.ino}:${runStats.birthtimeMs}:symlink`,
         ino: runStats.ino,
         newestMtimeMs: runStats.mtimeMs,
       };
@@ -213,6 +218,8 @@ async function inspectVisualQaRunTree(
         birthtimeMs: runStats.birthtimeMs,
         containsSymlink: false,
         dev: runStats.dev,
+        entryCount: 1,
+        entryFingerprint: `${runStats.dev}:${runStats.ino}:${runStats.birthtimeMs}:file`,
         ino: runStats.ino,
         newestMtimeMs: runStats.mtimeMs,
       };
@@ -222,30 +229,47 @@ async function inspectVisualQaRunTree(
     }
 
     const childStates = await Promise.all(
-      (await readdir(runDirectory)).map(entryName =>
-        inspectVisualQaRunTree(path.join(runDirectory, entryName))
-      )
+      (await readdir(runDirectory)).map(async entryName => ({
+        entryName,
+        state: await inspectVisualQaRunTree(path.join(runDirectory, entryName)),
+      }))
     );
-    if (childStates.some(state => state === null)) {
+    if (childStates.some(({ state }) => state === null)) {
       return null;
     }
 
+    const entryFingerprint = createHash('sha256');
+    entryFingerprint.update(
+      `${runStats.dev}:${runStats.ino}:${runStats.birthtimeMs}:directory\0`
+    );
+    for (const child of childStates.sort((left, right) =>
+      left.entryName.localeCompare(right.entryName)
+    )) {
+      entryFingerprint.update(
+        `${child.entryName}\0${child.state?.entryFingerprint ?? ''}\0`
+      );
+    }
+
     return childStates.reduce<VisualQaRunTreeState>(
-      (state, childState) => ({
+      (state, child) => ({
         birthtimeMs: state.birthtimeMs,
         containsSymlink:
-          state.containsSymlink || childState?.containsSymlink === true,
+          state.containsSymlink || child.state?.containsSymlink === true,
         dev: state.dev,
+        entryCount: state.entryCount + (child.state?.entryCount ?? 0),
+        entryFingerprint: state.entryFingerprint,
         ino: state.ino,
         newestMtimeMs: Math.max(
           state.newestMtimeMs,
-          childState?.newestMtimeMs ?? 0
+          child.state?.newestMtimeMs ?? 0
         ),
       }),
       {
         birthtimeMs: runStats.birthtimeMs,
         containsSymlink: false,
         dev: runStats.dev,
+        entryCount: 1,
+        entryFingerprint: entryFingerprint.digest('hex'),
         ino: runStats.ino,
         newestMtimeMs: runStats.mtimeMs,
       }
@@ -282,6 +306,8 @@ function sameTreeState(
   return (
     planned.birthtimeMs === current.birthtimeMs &&
     planned.dev === current.dev &&
+    planned.entryCount === current.entryCount &&
+    planned.entryFingerprint === current.entryFingerprint &&
     planned.ino === current.ino &&
     planned.newestMtimeMs === current.newestMtimeMs &&
     !current.containsSymlink

--- a/apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts
+++ b/apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts
@@ -526,12 +526,28 @@ describe('pruneCompletedVisualQaRuns', () => {
         passed: true,
       }),
     ]);
+    const fixedTreeMtime = new Date('2026-06-01T01:00:00.000Z');
+    const candidatePath = path.join(rootDirectory, 'completed-old');
+    await Promise.all([
+      utimes(candidatePath, fixedTreeMtime, fixedTreeMtime),
+      utimes(
+        path.join(candidatePath, 'diff-summary.json'),
+        fixedTreeMtime,
+        fixedTreeMtime
+      ),
+    ]);
     const removed = await pruneCompletedVisualQaRuns('current-run', {
       beforeCandidateRevalidation: async runId => {
-        await writeFile(
-          path.join(rootDirectory ?? '', runId, 'late-capture.png'),
-          'active'
+        const lateCapturePath = path.join(
+          rootDirectory ?? '',
+          runId,
+          'late-capture.png'
         );
+        await writeFile(lateCapturePath, 'active');
+        await Promise.all([
+          utimes(lateCapturePath, fixedTreeMtime, fixedTreeMtime),
+          utimes(candidatePath, fixedTreeMtime, fixedTreeMtime),
+        ]);
       },
       retainedCompletedRuns: 2,
       rootDirectory,

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -182,6 +182,39 @@ describe('automation-verify affected scope', () => {
     ]);
   });
 
+  it('maps Visual QA diff-artifact changes to the focused TOCTOU regression', () => {
+    const plan = buildAffectedTestPlan([
+      'apps/web/lib/agent-os/visual-qa/diff-artifacts.ts',
+      'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
+    ]);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.relatedFiles).toHaveLength(2);
+    expect(plan.mandatoryTests).toEqual([
+      'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
+    ]);
+    expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
+    ]);
+  });
+
+  it('keeps the selector plus Visual QA repair manifest on focused suites', () => {
+    const plan = buildAffectedTestPlan([
+      'scripts/run-affected-tests.mjs',
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+      'apps/web/lib/agent-os/visual-qa/diff-artifacts.ts',
+      'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
+    ]);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
+    ]);
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+    ]);
+  });
+
   it('maps deterministic Promptfoo changes to their contract tests', () => {
     const plan = buildAffectedTestPlan([
       'apps/web/scripts/run-deterministic-promptfoo-evals.sh',

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -135,6 +135,14 @@ const PERSISTED_AUTH_FIXTURE_SCRIPT_TESTS = [
   'scripts/hermes/lib/__tests__/ci-failure-classifier.test.ts',
   'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
 ];
+const VISUAL_QA_DIFF_ARTIFACTS_SOURCE =
+  'apps/web/lib/agent-os/visual-qa/diff-artifacts.ts';
+const VISUAL_QA_DIFF_ARTIFACTS_TEST =
+  'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts';
+const VISUAL_QA_DIFF_ARTIFACTS_MANIFEST = new Set([
+  VISUAL_QA_DIFF_ARTIFACTS_SOURCE,
+  VISUAL_QA_DIFF_ARTIFACTS_TEST,
+]);
 const GTMQ_SOURCE_GATE_REAPER_MANIFEST = new Set([
   '.github/actions/setup-node-pnpm/action.yml',
   '.github/workflows/gtmq-source-authorization.yml',
@@ -222,6 +230,16 @@ export function buildAffectedTestPlan(changedFiles) {
     ) &&
     (affectedTestSelectorInputCount === 0 ||
       affectedTestSelectorInputCount === AFFECTED_TEST_SELECTOR_MANIFEST.size);
+  const visualQaDiffArtifactsInputCount = files.filter(file =>
+    VISUAL_QA_DIFF_ARTIFACTS_MANIFEST.has(file)
+  ).length;
+  const isExactVisualQaSelectorRepair =
+    affectedTestSelectorInputCount === AFFECTED_TEST_SELECTOR_MANIFEST.size &&
+    visualQaDiffArtifactsInputCount ===
+      VISUAL_QA_DIFF_ARTIFACTS_MANIFEST.size &&
+    files.length ===
+      AFFECTED_TEST_SELECTOR_MANIFEST.size +
+        VISUAL_QA_DIFF_ARTIFACTS_MANIFEST.size;
   const gtmqSourceGateReaperInputCount = files.filter(file =>
     GTMQ_SOURCE_GATE_REAPER_MANIFEST.has(file)
   ).length;
@@ -307,6 +325,9 @@ export function buildAffectedTestPlan(changedFiles) {
   if (hasCiCancellationHealerChange) {
     mandatoryTests.push(...CI_CANCELLATION_HEALER_TESTS);
   }
+  if (files.includes(VISUAL_QA_DIFF_ARTIFACTS_SOURCE)) {
+    mandatoryTests.push(VISUAL_QA_DIFF_ARTIFACTS_TEST);
+  }
   if (isExactPrerequisiteTrain) {
     mandatoryTests.push(...PREREQUISITE_TRAIN_TESTS);
   }
@@ -329,6 +350,7 @@ export function buildAffectedTestPlan(changedFiles) {
   const scriptVitestTests = unique([
     ...(isExactAffectedTestSelector ||
     isExactGoldenPathSmokeContractRepair ||
+    isExactVisualQaSelectorRepair ||
     (isExactPersistedAuthFixtureRepair && affectedTestSelectorInputCount > 0)
       ? AFFECTED_TEST_SELECTOR_TESTS
       : []),
@@ -362,6 +384,7 @@ export function buildAffectedTestPlan(changedFiles) {
       PERSISTED_AUTH_FIXTURE_REPAIR_CORE.has(file)
     )
       return true;
+    if (file === VISUAL_QA_DIFF_ARTIFACTS_SOURCE) return true;
     if (isExactPrerequisiteTrain && PREREQUISITE_TRAIN_MANIFEST.has(file))
       return true;
     if (
@@ -401,13 +424,15 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactAffectedTestSelector &&
     !isExactGoldenPathSmokeContractRepair &&
     !isExactPersistedAuthFixtureRepair &&
+    !isExactVisualQaSelectorRepair &&
     !isExactGtmqSourceGateReaper;
   const hasIncompleteGtmqSourceGateReaper =
     gtmqSourceGateReaperInputCount > 0 &&
     !isExactGtmqSourceGateReaper &&
     !isExactGoldenPathSmokeContractRepair &&
     !isExactPersistedAuthFixtureRepair &&
-    !isExactAffectedTestSelector;
+    !isExactAffectedTestSelector &&
+    !isExactVisualQaSelectorRepair;
   const hasUncoveredSource =
     relatedFiles.some(file => !isCoveredSource(file)) ||
     hasUnknownCiCancellationHealerPeer ||


### PR DESCRIPTION
## Summary
- fingerprint the sorted recursive Visual-QA artifact tree before pruning
- compare entry count and fingerprint during candidate revalidation so same-mtime activity is preserved
- keep the exact four-file repair on focused affected-test suites

## Root cause
The prune revalidation compared only directory identity, birth time, and newest mtime. A late artifact could be created and then receive the same mtime as the candidate tree, leaving those signals unchanged and allowing an active run to be pruned. This is a broken test/fixture plus missing automation class, not a PR-specific product failure.

## Verification
- focused diff-artifacts: 11/11
- full Visual-QA unit directory: 28/28
- selector suite: 70/70
- exact affected plan: selected, 11/11 + 70/70
- web typecheck: passed
- Biome (four changed files): passed
- bug-to-test: satisfied
- diff check: passed

## Replacement
Replants stale/conflicting #14355 on current main. Close #14355 only after this PR lands.