### PR TITLE
fix(ci): restore runner task headroom

### DIFF
--- a/.github/runner-host/README.md
+++ b/.github/runner-host/README.md
@@ -1,0 +1,61 @@
+# Gem runner host contract
+
+These files are the versioned slice deployment source for the Gem
+ephemeral-runner host. The pool remains capped at 10 containers, 2 CPUs and 4
+GiB per container. The service snapshot is documentation only: model routing
+and other live service state are separately managed and the installer never
+copies or restarts the service.
+
+## Failure record
+
+GitHub jobs `87010591966` and `87010591983` completed all test assertions, then
+Vitest worker creation failed with `spawn ... node EAGAIN`. At diagnosis time,
+`ci-runners.slice` was at 852/1,024 tasks (later observed at 958/1,024), while
+host PID/thread limits, memory, CPU and load still had headroom. The failure is
+dependency/environment drift: an obsolete slice-wide `TasksMax=1024` ceiling,
+not a PR-specific test failure or flaky assertion.
+
+The 2,048 limit is intentionally conservative: it is more than twice the
+observed ten-runner demand, remains far below host PID/thread limits, and does
+not increase the autoscaler maximum above 10. The diagnostic reports warning at
+80% and critical at 90%, before Node reaches `EAGAIN`.
+
+## Automatic enforcement
+
+`ci-runner-capacity-reconcile.timer` runs once per minute as root. It checks the
+live autoscaler cap before changing anything. With exactly 10 runners, drifted
+slice limits are converged to the reviewed 2,048 ceiling and the diagnostic is
+rerun against effective state. A correct limit is a no-op. An autoscaler cap
+other than 10 or an invalid limit fails closed. Before lowering an unsafe
+higher limit, the reconciler also refuses to mutate the slice when live task
+usage is already at/above 80% of the reviewed ceiling. Saturation at the
+correct ceiling fails the immediate proof, but the installed timer remains
+active and retries once per minute. The reconciler never restarts the
+autoscaler or runners and never raises the limit beyond 2,048.
+
+## Review and cutover
+
+The installer is dry-run unless `--apply` is provided. Applying the TasksMax
+property is live and does not restart the autoscaler or runner containers:
+
+```bash
+ssh gem 'cd /path/to/Jovie && sudo .github/runner-host/install-capacity-contract.sh --apply'
+```
+
+Before its first mutation, the installer runs the reconciler in preflight mode
+to validate exactly one live `AUTOSCALER_MAX_RUNNERS=10` entry plus numeric
+`TasksMax` and `TasksCurrent` values. It then installs the root-owned
+one-shot/timer, enables the timer without starting it, runs reconciliation once
+immediately, and starts the timer even if that proof reports saturation.
+Setting `RUNNER_HOST_INSTALL_ROOT` stages files only and performs zero live
+`systemctl` or reconciliation calls. Verify afterward with:
+
+```bash
+ssh gem 'cd /path/to/Jovie && .github/runner-host/diagnose-capacity.sh'
+```
+
+Inspect automatic enforcement with:
+
+```bash
+ssh gem 'systemctl status ci-runner-capacity-reconcile.timer ci-runner-capacity-reconcile.service'
+```

--- a/.github/runner-host/ci-runner-autoscaler.service.snapshot
+++ b/.github/runner-host/ci-runner-autoscaler.service.snapshot
@@ -1,0 +1,27 @@
+# Reference snapshot only. The capacity installer MUST NOT install this file.
+# The live root-owned service and its drop-ins contain separately managed model
+# routing state; this snapshot documents the reviewed resource envelope.
+
+[Unit]
+Description=CI Runner Autoscaler — ephemeral Docker runners for Jovie CI
+After=docker.service ci-runners.slice
+BindsTo=ci-runners.slice
+
+[Service]
+Type=exec
+User=timwhite
+Group=docker
+WorkingDirectory=/opt/ci-runner-autoscaler
+ExecStart=/usr/bin/tsx /opt/ci-runner-autoscaler/index.ts
+Restart=always
+RestartSec=5
+CPUQuota=800%
+MemoryMax=48G
+Environment=AUTOSCALER_MAX_RUNNERS=10
+Environment=AUTOSCALER_RUNNER_CPUS=2
+Environment=AUTOSCALER_RUNNER_MEMORY_MB=4096
+Environment=AUTOSCALER_RUNNER_LABELS=self-hosted,Linux,X64,jovie-runner,jovie-ephemeral,ephemeral
+Environment=AUTOSCALER_CGROUP_PARENT=ci-runners.slice
+
+# Model routes and credentials are intentionally omitted. They are unrelated to
+# process capacity and remain owned by the live service/drop-in configuration.

--- a/.github/runner-host/ci-runner-capacity-reconcile.service
+++ b/.github/runner-host/ci-runner-capacity-reconcile.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Reconcile and diagnose Jovie CI runner process capacity
+After=ci-runner-autoscaler.service
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart=/usr/local/libexec/jovie-runner-host/reconcile-capacity.sh
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict

--- a/.github/runner-host/ci-runner-capacity-reconcile.timer
+++ b/.github/runner-host/ci-runner-capacity-reconcile.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Continuously enforce Jovie CI runner process capacity
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+AccuracySec=10s
+Persistent=true
+Unit=ci-runner-capacity-reconcile.service
+
+[Install]
+WantedBy=timers.target

--- a/.github/runner-host/ci-runners.slice
+++ b/.github/runner-host/ci-runners.slice
@@ -1,0 +1,13 @@
+# Versioned resource envelope for Gem's ephemeral CI containers.
+# Ten runners have been observed at 958 tasks in aggregate. A 2,048-task
+# ceiling preserves >2x measured headroom without increasing runner count.
+
+[Unit]
+Description=CI Runner Resource Slice
+Before=ci-runner-autoscaler.service
+Wants=ci-runner-autoscaler.service
+
+[Slice]
+CPUQuota=1600%
+MemoryMax=50G
+TasksMax=2048

--- a/.github/runner-host/diagnose-capacity.sh
+++ b/.github/runner-host/diagnose-capacity.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current="${RUNNER_TASKS_CURRENT:-}"
+maximum="${RUNNER_TASKS_MAX:-}"
+
+if [[ -z "$current" || -z "$maximum" ]]; then
+  current="$(systemctl show ci-runners.slice --property TasksCurrent --value)"
+  maximum="$(systemctl show ci-runners.slice --property TasksMax --value)"
+fi
+
+if ! [[ "$current" =~ ^[0-9]+$ && "$maximum" =~ ^[1-9][0-9]*$ ]]; then
+  echo "runner_tasks_status=unknown"
+  echo "runner_tasks_detail=invalid TasksCurrent/TasksMax: current=$current max=$maximum"
+  exit 2
+fi
+
+ratio=$((current * 100 / maximum))
+status=ok
+if (( ratio >= 90 )); then
+  status=critical
+elif (( ratio >= 80 )); then
+  status=warning
+fi
+
+echo "runner_tasks_status=$status"
+echo "runner_tasks_current=$current"
+echo "runner_tasks_max=$maximum"
+echo "runner_tasks_ratio_pct=$ratio"
+echo "runner_failure_class=dependency-or-environment-drift"
+
+if [[ "$status" != "ok" ]]; then
+  echo "runner_tasks_remediation=ci-runners.slice is saturated; verify the versioned TasksMax contract before retrying CI"
+  exit 1
+fi

--- a/.github/runner-host/install-capacity-contract.sh
+++ b/.github/runner-host/install-capacity-contract.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly EXPECTED_TASKS_MAX=2048
+readonly EXPECTED_MAX_RUNNERS=10
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SOURCE_DIR
+readonly INSTALL_ROOT="${RUNNER_HOST_INSTALL_ROOT:-}"
+
+install_contract_files() {
+  local install_root="$1"
+
+  install -d -m 0755 "$install_root/etc/systemd/system"
+  install -m 0644 \
+    "$SOURCE_DIR/ci-runners.slice" \
+    "$install_root/etc/systemd/system/ci-runners.slice"
+  install -d -m 0755 "$install_root/usr/local/libexec/jovie-runner-host"
+  install -m 0755 \
+    "$SOURCE_DIR/diagnose-capacity.sh" \
+    "$SOURCE_DIR/reconcile-capacity.sh" \
+    "$install_root/usr/local/libexec/jovie-runner-host/"
+  install -m 0644 \
+    "$SOURCE_DIR/ci-runner-capacity-reconcile.service" \
+    "$SOURCE_DIR/ci-runner-capacity-reconcile.timer" \
+    "$install_root/etc/systemd/system/"
+}
+
+apply_live_contract() {
+  local install_root="${1:-}"
+  local reconcile_status=0
+  local timer_status=0
+
+  # Validate the live host before the first file write or systemd mutation.
+  "$SOURCE_DIR/reconcile-capacity.sh" --preflight
+  install_contract_files "$install_root"
+  systemctl daemon-reload
+
+  # Enable without starting so the immediate proof and timer cannot reconcile
+  # concurrently. Start the timer even when the proof reports saturation, so
+  # the failed condition is retried and remains visible until it clears.
+  systemctl enable ci-runner-capacity-reconcile.timer
+  "$install_root/usr/local/libexec/jovie-runner-host/reconcile-capacity.sh" || reconcile_status=$?
+  systemctl start ci-runner-capacity-reconcile.timer || timer_status=$?
+
+  if [[ "$reconcile_status" -ne 0 ]]; then
+    return "$reconcile_status"
+  fi
+  if [[ "$timer_status" -ne 0 ]]; then
+    return "$timer_status"
+  fi
+
+  echo "Installed runner host contract; TasksMax=$EXPECTED_TASKS_MAX, max runners=$EXPECTED_MAX_RUNNERS"
+  echo "Autoscaler was not restarted."
+}
+
+main() {
+  if [[ "${1:-}" != "--apply" ]]; then
+    echo "Dry run: no host state changed."
+    echo "Would install $SOURCE_DIR/ci-runners.slice"
+    echo "Would install the root-owned capacity reconciler and timer"
+    echo "Would reconcile ci-runners.slice TasksMax=$EXPECTED_TASKS_MAX"
+    return 0
+  fi
+
+  # A staging root is packaging-only. It never reads or mutates live systemd
+  # state and is intentionally available to unprivileged verification.
+  if [[ -n "$INSTALL_ROOT" ]]; then
+    install_contract_files "$INSTALL_ROOT"
+    echo "Staged runner host contract at $INSTALL_ROOT; live host unchanged."
+    return 0
+  fi
+
+  if [[ "${EUID}" -ne 0 ]]; then
+    echo "ERROR: --apply must run as root" >&2
+    return 2
+  fi
+
+  apply_live_contract ""
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/runner-host/reconcile-capacity.sh
+++ b/.github/runner-host/reconcile-capacity.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly EXPECTED_TASKS_MAX=2048
+readonly EXPECTED_MAX_RUNNERS=10
+readonly TARGET_WARNING_PERCENT=80
+readonly TARGET_WARNING_TASKS=$((
+  (EXPECTED_TASKS_MAX * TARGET_WARNING_PERCENT + 99) / 100
+))
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SOURCE_DIR
+
+validate_live_contract() {
+  service_environment="$(
+    systemctl show ci-runner-autoscaler.service --property Environment --value
+  )"
+
+  max_runner_entries=0
+  actual_max_runners=""
+  for entry in $service_environment; do
+    entry="${entry#\"}"
+    entry="${entry%\"}"
+    if [[ "$entry" == AUTOSCALER_MAX_RUNNERS=* ]]; then
+      max_runner_entries=$((max_runner_entries + 1))
+      actual_max_runners="${entry#AUTOSCALER_MAX_RUNNERS=}"
+    fi
+  done
+
+  if [[ "$max_runner_entries" -ne 1 || "$actual_max_runners" != "$EXPECTED_MAX_RUNNERS" ]]; then
+    echo "runner_capacity_reconciliation=blocked"
+    echo "runner_failure_class=dependency-or-environment-drift"
+    echo "runner_capacity_detail=live AUTOSCALER_MAX_RUNNERS must be exactly $EXPECTED_MAX_RUNNERS; observed ${actual_max_runners:-missing} ($max_runner_entries entries)"
+    exit 3
+  fi
+
+  actual_tasks_max="$(
+    systemctl show ci-runners.slice --property TasksMax --value
+  )"
+  if ! [[ "$actual_tasks_max" =~ ^[1-9][0-9]*$ ]]; then
+    echo "runner_capacity_reconciliation=blocked"
+    echo "runner_failure_class=dependency-or-environment-drift"
+    echo "runner_capacity_detail=invalid live TasksMax: $actual_tasks_max"
+    exit 2
+  fi
+
+  actual_tasks_current="$(
+    systemctl show ci-runners.slice --property TasksCurrent --value
+  )"
+  if ! [[ "$actual_tasks_current" =~ ^[0-9]+$ ]]; then
+    echo "runner_capacity_reconciliation=blocked"
+    echo "runner_failure_class=dependency-or-environment-drift"
+    echo "runner_capacity_detail=invalid live TasksCurrent: $actual_tasks_current"
+    exit 2
+  fi
+
+  # Lowering pids.max beneath a busy slice can immediately prevent every
+  # runner from forking. Refuse the clamp before any file or systemd mutation
+  # when the reviewed target would already be warning/critical.
+  if (( actual_tasks_max > EXPECTED_TASKS_MAX && actual_tasks_current >= TARGET_WARNING_TASKS )); then
+    echo "runner_capacity_reconciliation=blocked"
+    echo "runner_failure_class=dependency-or-environment-drift"
+    echo "runner_capacity_detail=refusing to lower TasksMax from $actual_tasks_max to $EXPECTED_TASKS_MAX with TasksCurrent=$actual_tasks_current (target warning threshold=$TARGET_WARNING_TASKS)"
+    exit 5
+  fi
+}
+
+if [[ "${1:-}" != "" && "${1:-}" != "--preflight" ]]; then
+  echo "ERROR: usage: $0 [--preflight]" >&2
+  exit 64
+fi
+
+validate_live_contract
+
+if [[ "${1:-}" == "--preflight" ]]; then
+  echo "runner_capacity_preflight=passed"
+  echo "runner_capacity_preflight_tasks_max=$actual_tasks_max"
+  echo "runner_capacity_preflight_tasks_current=$actual_tasks_current"
+  echo "runner_capacity_preflight_max_runners=$actual_max_runners"
+  exit 0
+fi
+
+if [[ "$actual_tasks_max" == "$EXPECTED_TASKS_MAX" ]]; then
+  echo "runner_capacity_reconciliation=no-op"
+else
+  # Converge obsolete lower limits and unsafe higher limits to the reviewed
+  # envelope. This never raises TasksMax beyond the versioned value.
+  systemctl set-property ci-runners.slice "TasksMax=$EXPECTED_TASKS_MAX"
+  reconciled_tasks_max="$(
+    systemctl show ci-runners.slice --property TasksMax --value
+  )"
+  if [[ "$reconciled_tasks_max" != "$EXPECTED_TASKS_MAX" ]]; then
+    echo "runner_capacity_reconciliation=failed"
+    echo "runner_failure_class=dependency-or-environment-drift"
+    echo "runner_capacity_detail=effective TasksMax=$reconciled_tasks_max after reconciliation; expected $EXPECTED_TASKS_MAX"
+    exit 4
+  fi
+  echo "runner_capacity_reconciliation=repaired"
+  echo "runner_capacity_previous_tasks_max=$actual_tasks_max"
+fi
+
+# Always rerun the diagnostic against effective live state. At the reviewed
+# ceiling, >=80% usage is genuine saturation and must alert without mutation.
+exec "$SOURCE_DIR/diagnose-capacity.sh"

--- a/apps/web/tests/unit/ci/runner-host-capacity.test.ts
+++ b/apps/web/tests/unit/ci/runner-host-capacity.test.ts
@@ -1,0 +1,423 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { diagnoseCiFailure } from '../../../../../scripts/hermes/jobs/ci-failure-diagnosis';
+
+const repoRoot = resolve(import.meta.dirname, '../../../../..');
+const readHostFile = (name: string) =>
+  readFileSync(resolve(repoRoot, '.github/runner-host', name), 'utf8');
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+const runReconciler = ({
+  current,
+  maximum,
+  maxRunners = '10',
+}: {
+  current: string;
+  maximum: string;
+  maxRunners?: string;
+}) => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'runner-capacity-'));
+  temporaryDirectories.push(directory);
+  const systemctl = resolve(directory, 'systemctl');
+  const state = resolve(directory, 'tasks-max');
+  const mutations = resolve(directory, 'mutations');
+  writeFileSync(state, `${maximum}\n`);
+  writeFileSync(
+    systemctl,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "show" && "$2" == "ci-runner-autoscaler.service" ]]; then
+  echo "AUTOSCALER_MAX_RUNNERS=\${FAKE_MAX_RUNNERS} AUTOSCALER_RUNNER_CPUS=2"
+elif [[ "$1" == "show" && "$2" == "ci-runners.slice" && "$4" == "TasksMax" ]]; then
+  cat "\${FAKE_TASKS_MAX_STATE}"
+elif [[ "$1" == "show" && "$2" == "ci-runners.slice" && "$4" == "TasksCurrent" ]]; then
+  echo "\${FAKE_TASKS_CURRENT}"
+elif [[ "$1" == "set-property" && "$2" == "ci-runners.slice" ]]; then
+  printf '%s\\n' "$3" >> "\${FAKE_MUTATIONS}"
+  printf '%s\\n' "\${3#TasksMax=}" > "\${FAKE_TASKS_MAX_STATE}"
+else
+  printf 'unexpected systemctl call: %s\\n' "$*" >&2
+  exit 91
+fi
+`
+  );
+  chmodSync(systemctl, 0o755);
+  const result = spawnSync(
+    resolve(repoRoot, '.github/runner-host/reconcile-capacity.sh'),
+    [],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FAKE_MAX_RUNNERS: maxRunners,
+        FAKE_MUTATIONS: mutations,
+        FAKE_TASKS_CURRENT: current,
+        FAKE_TASKS_MAX_STATE: state,
+        PATH: `${directory}:${process.env.PATH ?? ''}`,
+      },
+    }
+  );
+  return {
+    ...result,
+    effectiveMaximum: readFileSync(state, 'utf8').trim(),
+    mutations: readFileSync(mutations, { encoding: 'utf8', flag: 'a+' }),
+  };
+};
+
+const runInstaller = ({
+  autoscalerEnvironment = 'AUTOSCALER_MAX_RUNNERS=10 AUTOSCALER_RUNNER_CPUS=2',
+  current = '958',
+  maximum = '1024',
+  mode = 'live',
+}: {
+  autoscalerEnvironment?: string;
+  current?: string;
+  maximum?: string;
+  mode?: 'live' | 'stage';
+}) => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'runner-installer-'));
+  temporaryDirectories.push(directory);
+  const binDirectory = resolve(directory, 'bin');
+  const installRoot = resolve(directory, 'root');
+  const events = resolve(directory, 'events');
+  const state = resolve(directory, 'tasks-max');
+  mkdirSync(binDirectory, { recursive: true });
+  mkdirSync(resolve(installRoot, 'etc/systemd/system'), { recursive: true });
+  writeFileSync(events, '');
+  writeFileSync(state, `${maximum}\n`);
+
+  const install = resolve(binDirectory, 'install');
+  writeFileSync(
+    install,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'install %s\\n' "$*" >> "\${FAKE_EVENTS}"
+exec /usr/bin/install "$@"
+`
+  );
+  chmodSync(install, 0o755);
+
+  const systemctl = resolve(binDirectory, 'systemctl');
+  writeFileSync(
+    systemctl,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'systemctl %s\\n' "$*" >> "\${FAKE_EVENTS}"
+if [[ "$1" == "show" && "$2" == "ci-runner-autoscaler.service" ]]; then
+  echo "\${FAKE_AUTOSCALER_ENVIRONMENT}"
+elif [[ "$1" == "show" && "$2" == "ci-runners.slice" && "$4" == "TasksMax" ]]; then
+  cat "\${FAKE_TASKS_MAX_STATE}"
+elif [[ "$1" == "show" && "$2" == "ci-runners.slice" && "$4" == "TasksCurrent" ]]; then
+  echo "\${FAKE_TASKS_CURRENT}"
+elif [[ "$1" == "set-property" && "$2" == "ci-runners.slice" ]]; then
+  printf '%s\\n' "\${3#TasksMax=}" > "\${FAKE_TASKS_MAX_STATE}"
+elif [[ "$1" == "daemon-reload" ]]; then
+  exit 0
+elif [[ "$1" == "enable" && "$2" == "ci-runner-capacity-reconcile.timer" ]]; then
+  exit 0
+elif [[ "$1" == "start" && "$2" == "ci-runner-capacity-reconcile.timer" ]]; then
+  exit 0
+else
+  printf 'unexpected systemctl call: %s\\n' "$*" >&2
+  exit 91
+fi
+`
+  );
+  chmodSync(systemctl, 0o755);
+
+  const installer = resolve(
+    repoRoot,
+    '.github/runner-host/install-capacity-contract.sh'
+  );
+  const result = spawnSync(
+    mode === 'stage' ? installer : '/bin/bash',
+    mode === 'stage'
+      ? ['--apply']
+      : [
+          '-c',
+          'source "$1"; apply_live_contract "$2"',
+          'runner-installer-test',
+          installer,
+          installRoot,
+        ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FAKE_AUTOSCALER_ENVIRONMENT: autoscalerEnvironment,
+        FAKE_EVENTS: events,
+        FAKE_TASKS_CURRENT: current,
+        FAKE_TASKS_MAX_STATE: state,
+        PATH: `${binDirectory}:${process.env.PATH ?? ''}`,
+        ...(mode === 'stage' ? { RUNNER_HOST_INSTALL_ROOT: installRoot } : {}),
+      },
+    }
+  );
+
+  return {
+    ...result,
+    events: readFileSync(events, 'utf8').trim().split('\n').filter(Boolean),
+  };
+};
+
+describe('Gem runner process-capacity contract', () => {
+  it('keeps ten runners while providing measured task headroom', () => {
+    expect(readHostFile('ci-runners.slice')).toContain('TasksMax=2048');
+    const service = readHostFile('ci-runner-autoscaler.service.snapshot');
+    expect(service).toContain('Environment=AUTOSCALER_MAX_RUNNERS=10');
+    expect(service).toContain('Environment=AUTOSCALER_RUNNER_CPUS=2');
+    expect(service).toContain('Environment=AUTOSCALER_RUNNER_MEMORY_MB=4096');
+  });
+
+  it('changes only the slice and preserves the live autoscaler service', () => {
+    const installer = readHostFile('install-capacity-contract.sh');
+    expect(installer).toContain('ci-runner-capacity-reconcile.timer');
+    expect(installer).not.toContain(
+      '/etc/systemd/system/ci-runner-autoscaler.service'
+    );
+    expect(installer).not.toMatch(
+      /systemctl (?:re)?start ci-runner-autoscaler\.service/u
+    );
+  });
+
+  it('stages files without reading or mutating live systemd state', () => {
+    const result = runInstaller({ mode: 'stage' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('live host unchanged');
+    expect(result.events.some(event => event.startsWith('install '))).toBe(
+      true
+    );
+    expect(result.events.some(event => event.startsWith('systemctl '))).toBe(
+      false
+    );
+  });
+
+  it.each([
+    {
+      name: 'wrong cap',
+      autoscalerEnvironment: 'AUTOSCALER_MAX_RUNNERS=11',
+      maximum: '1024',
+    },
+    {
+      name: 'duplicate cap',
+      autoscalerEnvironment:
+        'AUTOSCALER_MAX_RUNNERS=10 AUTOSCALER_MAX_RUNNERS=10',
+      maximum: '1024',
+    },
+    {
+      name: 'missing cap',
+      autoscalerEnvironment: 'AUTOSCALER_RUNNER_CPUS=2',
+      maximum: '1024',
+    },
+    {
+      name: 'invalid TasksMax',
+      autoscalerEnvironment: 'AUTOSCALER_MAX_RUNNERS=10',
+      maximum: 'infinity',
+    },
+    {
+      name: 'invalid TasksCurrent',
+      autoscalerEnvironment: 'AUTOSCALER_MAX_RUNNERS=10',
+      current: 'unknown',
+      maximum: '1024',
+    },
+    {
+      name: 'unsafe downward clamp',
+      autoscalerEnvironment: 'AUTOSCALER_MAX_RUNNERS=10',
+      current: '1700',
+      maximum: '4096',
+    },
+  ])('fails $name preflight before any host mutation', fixture => {
+    const result = runInstaller(fixture);
+
+    expect(result.status).not.toBe(0);
+    expect(result.events.some(event => event.startsWith('install '))).toBe(
+      false
+    );
+    expect(
+      result.events.some(event =>
+        /^systemctl (?:daemon-reload|enable|set-property)\b/u.test(event)
+      )
+    ).toBe(false);
+  });
+
+  it('preflights before installation and starts the enabled timer last', () => {
+    const result = runInstaller({});
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('runner_capacity_preflight=passed');
+    expect(result.events.slice(0, 4)).toEqual([
+      'systemctl show ci-runner-autoscaler.service --property Environment --value',
+      'systemctl show ci-runners.slice --property TasksMax --value',
+      'systemctl show ci-runners.slice --property TasksCurrent --value',
+      expect.stringMatching(/^install /u),
+    ]);
+    const reconciliation = result.events.findIndex(event =>
+      event.startsWith('systemctl set-property ci-runners.slice')
+    );
+    const timerEnable = result.events.indexOf(
+      'systemctl enable ci-runner-capacity-reconcile.timer'
+    );
+    const timerStart = result.events.indexOf(
+      'systemctl start ci-runner-capacity-reconcile.timer'
+    );
+    expect(reconciliation).toBeGreaterThan(3);
+    expect(timerEnable).toBeLessThan(reconciliation);
+    expect(timerStart).toBeGreaterThan(reconciliation);
+    expect(timerStart).toBe(result.events.length - 1);
+  });
+
+  it('starts the timer and preserves a saturated reconciliation failure', () => {
+    const result = runInstaller({ current: '1700', maximum: '2048' });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('runner_tasks_status=warning');
+    expect(result.events).toContain(
+      'systemctl enable ci-runner-capacity-reconcile.timer'
+    );
+    expect(result.events.at(-1)).toBe(
+      'systemctl start ci-runner-capacity-reconcile.timer'
+    );
+    expect(
+      result.events.some(event => event.startsWith('systemctl set-property'))
+    ).toBe(false);
+  });
+
+  it('automatically heals TasksMax drift and reruns the diagnostic', () => {
+    const result = runReconciler({ current: '958', maximum: '1024' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('runner_capacity_reconciliation=repaired');
+    expect(result.stdout).toContain('runner_tasks_status=ok');
+    expect(result.stdout).toContain('runner_tasks_ratio_pct=46');
+    expect(result.effectiveMaximum).toBe('2048');
+    expect(result.mutations).toBe('TasksMax=2048\n');
+  });
+
+  it('clamps an unsafe higher TasksMax to the reviewed ceiling', () => {
+    const result = runReconciler({ current: '958', maximum: '4096' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('runner_capacity_reconciliation=repaired');
+    expect(result.effectiveMaximum).toBe('2048');
+    expect(result.mutations).toBe('TasksMax=2048\n');
+  });
+
+  it.each([
+    { current: '1700', name: 'warning-level target usage' },
+    { current: '3000', name: 'usage above the target ceiling' },
+  ])('refuses to lower a higher limit with $name', ({ current }) => {
+    const result = runReconciler({ current, maximum: '4096' });
+
+    expect(result.status).toBe(5);
+    expect(result.stdout).toContain('runner_capacity_reconciliation=blocked');
+    expect(result.stdout).toContain('refusing to lower TasksMax');
+    expect(result.effectiveMaximum).toBe('4096');
+    expect(result.mutations).toBe('');
+  });
+
+  it('leaves an already-correct TasksMax unchanged', () => {
+    const result = runReconciler({ current: '958', maximum: '2048' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('runner_capacity_reconciliation=no-op');
+    expect(result.stdout).toContain('runner_tasks_status=ok');
+    expect(result.effectiveMaximum).toBe('2048');
+    expect(result.mutations).toBe('');
+  });
+
+  it('fails closed when the live runner cap is not exactly ten', () => {
+    const result = runReconciler({
+      current: '958',
+      maximum: '1024',
+      maxRunners: '11',
+    });
+
+    expect(result.status).toBe(3);
+    expect(result.stdout).toContain('runner_capacity_reconciliation=blocked');
+    expect(result.stdout).toContain(
+      'live AUTOSCALER_MAX_RUNNERS must be exactly 10; observed 11'
+    );
+    expect(result.effectiveMaximum).toBe('1024');
+    expect(result.mutations).toBe('');
+  });
+
+  it('alerts without mutation on genuine saturation at the reviewed ceiling', () => {
+    const result = runReconciler({ current: '1700', maximum: '2048' });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('runner_capacity_reconciliation=no-op');
+    expect(result.stdout).toContain('runner_tasks_status=warning');
+    expect(result.stdout).toContain('runner_tasks_ratio_pct=83');
+    expect(result.effectiveMaximum).toBe('2048');
+    expect(result.mutations).toBe('');
+  });
+
+  it('diagnoses saturation before the kernel rejects worker creation', () => {
+    const diagnostic = resolve(
+      repoRoot,
+      '.github/runner-host/diagnose-capacity.sh'
+    );
+    const saturated = spawnSync(diagnostic, [], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        RUNNER_TASKS_CURRENT: '958',
+        RUNNER_TASKS_MAX: '1024',
+      },
+    });
+    expect(saturated.status).toBe(1);
+    expect(saturated.stdout).toContain('runner_tasks_status=critical');
+    expect(saturated.stdout).toContain('runner_tasks_ratio_pct=93');
+    expect(saturated.stdout).toContain(
+      'runner_failure_class=dependency-or-environment-drift'
+    );
+
+    const repaired = spawnSync(diagnostic, [], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        RUNNER_TASKS_CURRENT: '958',
+        RUNNER_TASKS_MAX: '2048',
+      },
+    });
+    expect(repaired.status).toBe(0);
+    expect(repaired.stdout).toContain('runner_tasks_status=ok');
+    expect(repaired.stdout).toContain('runner_tasks_ratio_pct=46');
+  });
+
+  it('classifies Node EAGAIN as runner capacity, not a test assertion', () => {
+    expect(
+      diagnoseCiFailure(
+        'Caused by: Error: spawn /opt/hostedtoolcache/node/22.23.1/x64/bin/node EAGAIN'
+      )
+    ).toMatchObject({ failureClass: 'runner_process_exhaustion' });
+    expect(
+      diagnoseCiFailure('AssertionError: expected 1 to be 2')
+    ).toMatchObject({ failureClass: 'unknown' });
+  });
+
+  it('classifies proactive slice saturation diagnostics', () => {
+    expect(
+      diagnoseCiFailure(
+        'runner_tasks_status=critical\nrunner_tasks_current=958\nrunner_tasks_max=1024\nrunner_tasks_ratio_pct=93'
+      )
+    ).toMatchObject({ failureClass: 'runner_slice_task_saturation' });
+  });
+});

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -3,6 +3,7 @@ export type CiFailureClass =
   | 'golden_path_smoke_auth_contract'
   | 'neon_concurrency_key_collision'
   | 'test_fixture_import_timeout'
+  | 'runner_slice_task_saturation'
   | 'runner_process_exhaustion'
   | 'runner_host_pressure'
   | 'unknown';
@@ -63,6 +64,16 @@ const DIAGNOSES: ReadonlyArray<{
       'Hoist the mocked HUD page import outside the timed test bodies and avoid resetting modules when the assertions do not require a fresh module graph.',
   },
   {
+    failureClass: 'runner_slice_task_saturation',
+    matches: log =>
+      /runner_tasks_status=(?:warning|critical)/i.test(log) &&
+      /runner_tasks_(?:current|max|ratio_pct)=/i.test(log),
+    rootCause:
+      'The self-hosted runner pool is approaching or has reached the systemd ci-runners.slice task ceiling.',
+    remediation:
+      'Run .github/runner-host/diagnose-capacity.sh and restore the versioned ci-runners.slice TasksMax contract before retrying CI.',
+  },
+  {
     failureClass: 'runner_process_exhaustion',
     matches: log =>
       /\bEAGAIN\b|ERR_WORKER_INIT_FAILED|resource temporarily unavailable/i.test(
@@ -71,7 +82,7 @@ const DIAGNOSES: ReadonlyArray<{
     rootCause:
       'The runner could not create a process or worker because process resources were exhausted.',
     remediation:
-      'Reduce runner process pressure or retry on a healthy runner; do not modify the failing test based on this signature alone.',
+      'Run .github/runner-host/diagnose-capacity.sh to distinguish slice saturation from other host pressure; do not modify the failing test based on this signature alone.',
   },
   {
     failureClass: 'runner_host_pressure',

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -67,6 +67,25 @@ describe('diagnoseCiFailure', () => {
     ).toBe('runner_host_pressure');
   });
 
+  it('upgrades the proactive slice diagnostic to an exact capacity class', () => {
+    const diagnosis = diagnoseCiFailure(`
+      runner_tasks_status=critical
+      runner_tasks_current=958
+      runner_tasks_max=1024
+      runner_tasks_ratio_pct=93
+    `);
+
+    expect(diagnosis.failureClass).toBe('runner_slice_task_saturation');
+    expect(diagnosis.rootCause).toContain('ci-runners.slice');
+    expect(diagnosis.remediation).toContain('diagnose-capacity.sh');
+  });
+
+  it('does not infer slice saturation from an unrelated status line', () => {
+    expect(diagnoseCiFailure('runner_tasks_status=critical').failureClass).toBe(
+      'unknown'
+    );
+  });
+
   it('diagnoses a cancelled pending job whose Neon concurrency key lost its job prefix', () => {
     const diagnosis = diagnoseCiFailure(`
       E2E Smoke (PR Fast Feedback) was cancelled before runner assignment.


### PR DESCRIPTION
## Root cause

GitHub jobs `87010591966` and `87010591983` completed their assertions, then Node worker creation failed with `spawn ... node EAGAIN`. The Gem host still had CPU, memory, host PID, and load headroom, but `ci-runners.slice` was measured at 852/1,024 tasks and later 958/1,024.

Classification: dependency/environment drift. The obsolete slice-wide `TasksMax=1024` ceiling, not a PR assertion or flaky test, rejected new workers.

## Fix

- Version the Gem runner slice with `TasksMax=2048`, preserving the reviewed 16-CPU/50-GiB envelope.
- Keep the autoscaler capped at exactly 10 runners (2 CPU / 4 GiB each).
- Add a dry-run-by-default installer that refuses `--apply` unless the live service still reports `AUTOSCALER_MAX_RUNNERS=10`.
- Apply only the mutable slice property; never install or restart the autoscaler service or runner containers.
- Add a capacity diagnostic that warns at 80% and fails at 90% task utilization.
- Extend the existing Gem CI diagnosis pipeline with exact `runner_slice_task_saturation` detection while retaining generic `runner_process_exhaustion` for uncorroborated EAGAIN.

## Verification

Exact signed head `3b5765bfa67486ff393f8d3ac78bbc187725d3da`:

- Runner capacity contract: 21/21 passed under Node 22.23.1.
- Gem diagnosis: 8/8 passed, including exact saturation vs generic EAGAIN classification.
- Full web typecheck passed.
- Biome, bash syntax, ShellCheck, and diff check passed.
- Remote CI: unit shards 1-5, ci-fast, Build public routes, Layout Guard, Migration Guard, PR Ready, security scans, and review gates passed.
- GitHub verifies the SSH commit signature.

`systemd-analyze verify` is unavailable on the macOS coordinator and remains part of the guarded Ubuntu canary gate.

bug-to-test: satisfied by `runner-host-capacity.test.ts` and `ci-failure-diagnosis.test.ts`.

Exact-head QA/review/ship artifact: https://github.com/JovieInc/Jovie/pull/14407#issuecomment-4976791291

## Canary and cutover gate

No live host change is included in this PR. After required CI passes, an authorized Gem operator must, on the Ubuntu host:

1. Verify the service still has `AUTOSCALER_MAX_RUNNERS=10` and record current `TasksCurrent`, `TasksMax`, CPU/RAM/PSI, runner/container count, and immutable image ID.
2. Run `systemd-analyze verify` on the versioned slice.
3. Run the installer without `--apply` and confirm it is a dry run.
4. Run `sudo .github/runner-host/install-capacity-contract.sh --apply`.
5. Verify effective `TasksMax=2048`, autoscaler was not restarted, the same ten-runner cap remains, and active jobs were not interrupted.
6. Run one controlled unit cohort and confirm no EAGAIN, no critical task diagnostic, and no stale runner registrations.

Rollback: restore the previously recorded slice file/property only. Do not change max runners during this cutover.

Supersedes stale/conflicting #14363 after this replant is verified; do not merge both.

