### PR TITLE
fix(ci): fail closed on missing layout guard specs

### DIFF
--- a/.github/scripts/layout-guard-manifest.mjs
+++ b/.github/scripts/layout-guard-manifest.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+
+export const REQUIRED_LAYOUT_GUARD_SPECS = ['tests/e2e/hud-scroll.spec.ts'];
+
+export const OPTIONAL_LAYOUT_GUARD_SPECS = [
+  'tests/e2e/marketing-document-scroll.spec.ts',
+];
+
+export function selectLayoutGuardSpecs(fileExists = existsSync) {
+  for (const spec of REQUIRED_LAYOUT_GUARD_SPECS) {
+    if (!fileExists(spec)) {
+      throw new Error(`Layout Guard contract missing required spec: ${spec}`);
+    }
+  }
+
+  return [
+    ...REQUIRED_LAYOUT_GUARD_SPECS,
+    ...OPTIONAL_LAYOUT_GUARD_SPECS.filter(spec => fileExists(spec)),
+  ];
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  try {
+    process.stdout.write(`${selectLayoutGuardSpecs().join('\n')}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`::error::${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/layout-guard-manifest.test.mjs
+++ b/.github/scripts/layout-guard-manifest.test.mjs
@@ -1,0 +1,83 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  OPTIONAL_LAYOUT_GUARD_SPECS,
+  REQUIRED_LAYOUT_GUARD_SPECS,
+  selectLayoutGuardSpecs,
+} from './layout-guard-manifest.mjs';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..');
+const manifestScript = resolve(
+  repoRoot,
+  '.github/scripts/layout-guard-manifest.mjs'
+);
+const workflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/ci.yml'),
+  'utf8'
+);
+
+describe('Layout Guard workflow contract', () => {
+  it('requires every stable spec and includes an optional spec only when present', () => {
+    const required = new Set(REQUIRED_LAYOUT_GUARD_SPECS);
+    const withRequiredOnly = selectLayoutGuardSpecs(spec => required.has(spec));
+    const withOptional = selectLayoutGuardSpecs(() => true);
+
+    expect(withRequiredOnly).toEqual(REQUIRED_LAYOUT_GUARD_SPECS);
+    expect(withOptional).toEqual([
+      ...REQUIRED_LAYOUT_GUARD_SPECS,
+      ...OPTIONAL_LAYOUT_GUARD_SPECS,
+    ]);
+  });
+
+  it('fails closed when a required spec is missing', () => {
+    expect(() => selectLayoutGuardSpecs(() => false)).toThrow(
+      'Layout Guard contract missing required spec: tests/e2e/hud-scroll.spec.ts'
+    );
+
+    const emptyWebRoot = mkdtempSync(
+      resolve(tmpdir(), 'layout-guard-missing-')
+    );
+    try {
+      const result = spawnSync(process.execPath, [manifestScript], {
+        cwd: emptyWebRoot,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        '::error::Layout Guard contract missing required spec: tests/e2e/hud-scroll.spec.ts'
+      );
+      expect(result.stdout).toBe('');
+    } finally {
+      rmSync(emptyWebRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps current required specs materialized and executes the selected manifest', () => {
+    for (const spec of REQUIRED_LAYOUT_GUARD_SPECS) {
+      expect(() =>
+        readFileSync(resolve(repoRoot, 'apps/web', spec))
+      ).not.toThrow();
+    }
+
+    expect(workflow).toContain(
+      'node ../../.github/scripts/layout-guard-manifest.mjs'
+    );
+    expect(workflow).toContain(
+      'pnpm exec playwright test "${LAYOUT_GUARD_SPECS[@]}"'
+    );
+    expect(workflow).toContain(
+      'PORT=3100 node .next/standalone/apps/web/server.js'
+    );
+    expect(workflow).toContain(
+      '::error::Layout Guard standalone server failed to start within 30s.'
+    );
+    expect(workflow).toContain('--config=playwright.config.noauth.ts');
+    expect(workflow).not.toContain('pnpm --filter=@jovie/web exec next start');
+    expect(workflow).not.toContain('layout-overlap-guard.spec.ts');
+    expect(workflow).not.toContain('not found — skipping');
+  });
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1449,31 +1449,51 @@ jobs:
         if: steps.download.outcome == 'success'
         run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
 
-      - name: Run layout overlap/touching guard
+      - name: Run deterministic layout behavior guard
         if: steps.download.outcome == 'success'
         run: |
+          set -euo pipefail
           cd apps/web
 
-          if [ ! -f tests/e2e/layout-overlap-guard.spec.ts ]; then
-            echo "⚠ layout-overlap-guard.spec.ts not found — skipping"
-            exit 0
+          LAYOUT_GUARD_MANIFEST=$(node ../../.github/scripts/layout-guard-manifest.mjs)
+          mapfile -t LAYOUT_GUARD_SPECS <<< "$LAYOUT_GUARD_MANIFEST"
+
+          if [ ! -f .next/standalone/apps/web/server.js ]; then
+            echo "::error::Layout Guard standalone server entrypoint is missing."
+            exit 1
           fi
+
           mkdir -p tests/.auth
           echo '{"cookies":[],"origins":[]}' > tests/.auth/user.json
-          PORT=3100 pnpm --filter=@jovie/web exec next start &
+          export HOSTNAME=localhost
+          export NEXT_PUBLIC_APP_URL=http://localhost:3100
+
+          PORT=3100 node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3100 > /dev/null 2>&1; then break; fi
+          trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+
+          SERVER_READY=false
+          for attempt in $(seq 1 30); do
+            if curl -sf http://localhost:3100 > /dev/null 2>&1; then
+              SERVER_READY=true
+              break
+            fi
+            echo "Waiting for Layout Guard standalone server ($attempt/30)..."
             sleep 1
           done
-          pnpm exec playwright test tests/e2e/layout-overlap-guard.spec.ts --project=chromium --reporter=line
-          EXIT_CODE=$?
-          kill $SERVER_PID 2>/dev/null || true
-          exit $EXIT_CODE
+
+          if [ "$SERVER_READY" = "false" ]; then
+            echo "::error::Layout Guard standalone server failed to start within 30s."
+            exit 1
+          fi
+
+          pnpm exec playwright test "${LAYOUT_GUARD_SPECS[@]}" --config=playwright.config.noauth.ts --project=chromium --reporter=line
         env:
           BASE_URL: http://localhost:3100
           SMOKE_ONLY: '1'
           CI: true
+          HUD_KIOSK_TOKEN: layout-guard-ci
+          HUD_AGENT_RUNS_FIXTURES: '1'
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
 
       - name: Upload Playwright Report on Failure
@@ -4355,7 +4375,7 @@ jobs:
             echo "| Unit Tests | $UNIT_RESULT | \`pnpm --filter=@jovie/web run test:fast\` |"
             echo "| Build (public routes) | $BUILD_RESULT | \`pnpm run build:web\` |"
             echo "| A11y (axe) | $A11Y_RESULT | \`pnpm exec playwright test tests/e2e/axe-audit.spec.ts --project=chromium\` |"
-            echo "| Layout Guard | $LAYOUT_GUARD_RESULT | \`pnpm exec playwright test tests/e2e/layout-overlap-guard.spec.ts --project=chromium\` |"
+            echo "| Layout Guard | $LAYOUT_GUARD_RESULT | \`pnpm exec playwright test tests/e2e/hud-scroll.spec.ts --config=playwright.config.noauth.ts --project=chromium\` |"
             echo "| Risk classifier | $RISK_RESULT | \`pnpm ci:harness:check\` |"
             echo "| Preview Deploy | $PREVIEW_RESULT | \`pnpm run build:web\` |"
             echo
@@ -4409,7 +4429,7 @@ jobs:
           # Layout Guard must succeed when it runs (skipped when the shared build artifact is absent).
           if [[ "$LAYOUT_GUARD_RESULT" != "success" && "$LAYOUT_GUARD_RESULT" != "skipped" ]]; then
             echo "❌ Layout Guard did not pass (result: $LAYOUT_GUARD_RESULT)"
-            echo "Likely fix: run pnpm exec playwright test tests/e2e/layout-overlap-guard.spec.ts locally and fix overlapping/touching elements."
+            echo "Likely fix: run pnpm exec playwright test tests/e2e/hud-scroll.spec.ts --config=playwright.config.noauth.ts locally and repair the failing deterministic layout behavior."
             exit 1
           fi
 

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -4,6 +4,8 @@ export type CiFailureClass =
   | 'bounded_source_scan_timeout'
   | 'visual_qa_prune_timestamp_race'
   | 'golden_path_smoke_auth_contract'
+  | 'layout_guard_contract_missing'
+  | 'standalone_runtime_launcher_mismatch'
   | 'neon_endpoint_capacity_admission'
   | 'neon_probe_workspace_dependency_resolution'
   | 'neon_concurrency_key_collision'
@@ -93,6 +95,29 @@ const DIAGNOSES: ReadonlyArray<{
       'The real-auth golden-path spec ran inside the bypass smoke lane, where E2E_TEST_MODE and the dedicated journey credentials are intentionally absent, so the Better Auth test code was rejected.',
     remediation:
       'Keep golden-path self-skipped whenever the smoke auth bypass is enabled and run the journey only in the dedicated Golden Path job, which supplies E2E_TEST_MODE and real-auth credentials.',
+  },
+  {
+    failureClass: 'layout_guard_contract_missing',
+    matches: log =>
+      /::error::Layout Guard contract missing required spec: tests\/e2e\/[\w./-]+\.spec\.ts/i.test(
+        log
+      ) || /layout-overlap-guard\.spec\.ts not found [—-] skipping/i.test(log),
+    rootCause:
+      'The Layout Guard workflow referenced a deleted or absent Playwright contract and treated the missing test as a successful check.',
+    remediation:
+      'Restore the required deterministic Layout Guard manifest or update the workflow and its contract test together; never turn a missing required spec into success.',
+  },
+  {
+    failureClass: 'standalone_runtime_launcher_mismatch',
+    matches: log =>
+      /"next start" does not work with "output: standalone"/i.test(log) &&
+      /Failed to load external module require-in-the-middle-[a-z0-9]+/i.test(
+        log
+      ),
+    rootCause:
+      'A CI lane launched `next start` against an `output: standalone` artifact, so requests used the regular .next/server runtime instead of the traced standalone runtime and could not resolve its hash-shim packages.',
+    remediation:
+      'Launch .next/standalone/apps/web/server.js directly, fail closed when that entrypoint is absent or never becomes ready, and preserve the synced standalone runtime instead of reinstalling dependencies or blindly retrying.',
   },
   {
     failureClass: 'neon_endpoint_capacity_admission',

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -113,6 +113,50 @@ describe('diagnoseCiFailure', () => {
     ).toBe('unknown');
   });
 
+  it('diagnoses the fail-closed Layout Guard manifest signature', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Layout Guard
+      ::error::Layout Guard contract missing required spec: tests/e2e/hud-scroll.spec.ts
+    `);
+
+    expect(diagnosis.failureClass).toBe('layout_guard_contract_missing');
+    expect(diagnosis.rootCause).toContain('missing test');
+    expect(diagnosis.remediation).toContain('never turn');
+  });
+
+  it('recognizes the legacy missing-spec false green without matching generic missing files', () => {
+    expect(
+      diagnoseCiFailure('layout-overlap-guard.spec.ts not found — skipping')
+        .failureClass
+    ).toBe('layout_guard_contract_missing');
+    expect(
+      diagnoseCiFailure('unrelated.spec.ts not found — skipping').failureClass
+    ).toBe('unknown');
+  });
+
+  it('diagnoses a standalone artifact launched through next start', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Layout Guard
+      \"next start\" does not work with \"output: standalone\" configuration.
+      Error: Failed to load external module require-in-the-middle-a99415fa67232f7f
+    `);
+
+    expect(diagnosis.failureClass).toBe('standalone_runtime_launcher_mismatch');
+    expect(diagnosis.rootCause).toContain('next start');
+    expect(diagnosis.remediation).toContain(
+      '.next/standalone/apps/web/server.js'
+    );
+    expect(diagnosis.remediation).toContain('fail closed');
+  });
+
+  it('does not infer a launcher mismatch from an unrelated missing module', () => {
+    expect(
+      diagnoseCiFailure(
+        'Error: Failed to load external module require-in-the-middle-deadbeef'
+      ).failureClass
+    ).toBe('unknown');
+  });
+
   it('classifies the analytics scanner timeout separately from runner pressure', () => {
     const log = `
       FAIL tests/unit/analytics-metrics-layer-guard.test.ts > canonical metrics layer guard

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -181,6 +181,15 @@ const RUNNER_PREREQUISITE_VISUAL_QA_REPAIR_MANIFEST = [
   'apps/web/lib/agent-os/visual-qa/diff-artifacts.ts',
   'apps/web/tests/unit/agent-os/visual-qa/diff-artifacts.test.ts',
 ];
+const LAYOUT_GUARD_CONTRACT_MANIFEST = [
+  '.github/scripts/layout-guard-manifest.mjs',
+  '.github/scripts/layout-guard-manifest.test.mjs',
+  '.github/workflows/ci.yml',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+];
 
 describe('automation-verify affected scope', () => {
   it('keeps runner I/O admission on focused controller regressions', () => {
@@ -722,6 +731,29 @@ describe('automation-verify affected scope', () => {
         ? ['scripts/lib/__tests__/automation-verify.test.mjs']
         : []),
     ]);
+  });
+
+  it('keeps the Layout Guard contract repair on its focused cross-runtime regressions', () => {
+    const plan = buildAffectedTestPlan(LAYOUT_GUARD_CONTRACT_MANIFEST);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.rootVitestTests).toEqual([
+      '.github/scripts/layout-guard-manifest.test.mjs',
+    ]);
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+      'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+    ]);
+  });
+
+  it.each(
+    LAYOUT_GUARD_CONTRACT_MANIFEST
+  )('fails closed when the Layout Guard contract repair is missing %s', missingInput => {
+    expect(
+      buildAffectedTestPlan(
+        LAYOUT_GUARD_CONTRACT_MANIFEST.filter(file => file !== missingInput)
+      ).mode
+    ).toBe('full');
   });
 
   it.each(

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -238,6 +238,22 @@ const RUNNER_PREREQUISITE_VISUAL_QA_REPAIR_MANIFEST = new Set([
   ...RUNNER_PREREQUISITE_CONTRACT_MANIFEST,
   ...VISUAL_QA_DIFF_ARTIFACTS_MANIFEST,
 ]);
+const LAYOUT_GUARD_CONTRACT_MANIFEST = new Set([
+  '.github/scripts/layout-guard-manifest.mjs',
+  '.github/scripts/layout-guard-manifest.test.mjs',
+  '.github/workflows/ci.yml',
+  'scripts/hermes/jobs/ci-failure-diagnosis.ts',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+  'scripts/run-affected-tests.mjs',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+]);
+const LAYOUT_GUARD_CONTRACT_ROOT_TESTS = [
+  '.github/scripts/layout-guard-manifest.test.mjs',
+];
+const LAYOUT_GUARD_CONTRACT_SCRIPT_TESTS = [
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+  'scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts',
+];
 
 function isInvestorNoteIngestionInput(file) {
   return (
@@ -359,6 +375,12 @@ export function buildAffectedTestPlan(changedFiles) {
   const isExactRunnerPrerequisiteRepair =
     isExactRunnerPrerequisiteContract ||
     isExactRunnerPrerequisiteVisualQaRepair;
+  const layoutGuardContractInputCount = files.filter(file =>
+    LAYOUT_GUARD_CONTRACT_MANIFEST.has(file)
+  ).length;
+  const isExactLayoutGuardContract =
+    layoutGuardContractInputCount === LAYOUT_GUARD_CONTRACT_MANIFEST.size &&
+    files.length === LAYOUT_GUARD_CONTRACT_MANIFEST.size;
   const relatedFiles = files.filter(
     file =>
       TESTABLE_FILE.test(file) &&
@@ -455,9 +477,12 @@ export function buildAffectedTestPlan(changedFiles) {
   }
 
   const selectedTests = unique([...directTests, ...mandatoryTests]);
-  const rootVitestTests = isExactVercelCongestionControl
-    ? VERCEL_CONGESTION_CONTROL_ROOT_VITEST_TESTS
-    : [];
+  const rootVitestTests = unique([
+    ...(isExactVercelCongestionControl
+      ? VERCEL_CONGESTION_CONTROL_ROOT_VITEST_TESTS
+      : []),
+    ...(isExactLayoutGuardContract ? LAYOUT_GUARD_CONTRACT_ROOT_TESTS : []),
+  ]);
   const pythonTests = unique([
     ...(isExactVercelCongestionControl
       ? VERCEL_CONGESTION_CONTROL_PYTHON_TESTS
@@ -491,6 +516,7 @@ export function buildAffectedTestPlan(changedFiles) {
     ...(isExactRunnerPrerequisiteRepair
       ? RUNNER_PREREQUISITE_CONTROL_TESTS
       : []),
+    ...(isExactLayoutGuardContract ? LAYOUT_GUARD_CONTRACT_SCRIPT_TESTS : []),
   ]);
   const isCoveredSource = file => {
     if (/\.(?:test|spec)\.[cm]?[jt]sx?$/.test(file)) return true;
@@ -568,14 +594,16 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactVisualQaSelectorRepair &&
     !isExactGtmqSourceGateReaper &&
     !isExactRunnerIoPressure &&
-    !isExactRunnerPrerequisiteRepair;
+    !isExactRunnerPrerequisiteRepair &&
+    !isExactLayoutGuardContract;
   const hasIncompletePerformanceProfilerRepair =
     performanceProfilerRepairInputCount > 0 &&
     !isExactPerformanceProfilerRepair &&
     !isExactGoldenPathSmokeContractRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactRunnerIoPressure &&
-    !isExactRunnerPrerequisiteRepair;
+    !isExactRunnerPrerequisiteRepair &&
+    !isExactLayoutGuardContract;
   const hasIncompleteGtmqSourceGateReaper =
     gtmqSourceGateReaperInputCount > 0 &&
     !isExactGtmqSourceGateReaper &&
@@ -585,7 +613,8 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactVisualQaSelectorRepair &&
     !isExactPerformanceProfilerRepairWithSelector &&
     !isExactRunnerIoPressure &&
-    !isExactRunnerPrerequisiteRepair;
+    !isExactRunnerPrerequisiteRepair &&
+    !isExactLayoutGuardContract;
   const hasIncompleteRunnerIoPressure =
     runnerIoPressureInputCount > 0 &&
     !isExactRunnerIoPressure &&
@@ -595,7 +624,8 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactVisualQaSelectorRepair &&
     !isExactGtmqSourceGateReaper &&
     !isExactPerformanceProfilerRepair &&
-    !isExactRunnerPrerequisiteRepair;
+    !isExactRunnerPrerequisiteRepair &&
+    !isExactLayoutGuardContract;
   const hasIncompleteRunnerPrerequisiteContract =
     runnerPrerequisiteContractInputCount > 0 &&
     !isExactRunnerPrerequisiteRepair &&
@@ -605,6 +635,19 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactPrerequisiteTrain &&
     !isExactGoldenPathSmokeContractRepair &&
     !isExactPersistedAuthFixtureRepair &&
+    !isExactLayoutGuardContract &&
+    !isExactPerformanceProfilerRepair &&
+    !isExactRunnerIoPressure;
+  const hasIncompleteLayoutGuardContract =
+    layoutGuardContractInputCount > 0 &&
+    !isExactLayoutGuardContract &&
+    !isExactPrerequisiteTrain &&
+    !isExactAffectedTestSelector &&
+    !isExactGoldenPathSmokeContractRepair &&
+    !isExactPersistedAuthFixtureRepair &&
+    !isExactGtmqSourceGateReaper &&
+    !isExactVisualQaSelectorRepair &&
+    !isExactRunnerPrerequisiteRepair &&
     !isExactPerformanceProfilerRepair &&
     !isExactRunnerIoPressure;
   const hasUncoveredSource =
@@ -619,7 +662,8 @@ export function buildAffectedTestPlan(changedFiles) {
     hasIncompletePerformanceProfilerRepair ||
     hasIncompleteGtmqSourceGateReaper ||
     hasIncompleteRunnerIoPressure ||
-    hasIncompleteRunnerPrerequisiteContract;
+    hasIncompleteRunnerPrerequisiteContract ||
+    hasIncompleteLayoutGuardContract;
   const hasSelectedTests =
     selectedTests.length > 0 ||
     rootVitestTests.length > 0 ||
@@ -640,7 +684,8 @@ export function buildAffectedTestPlan(changedFiles) {
             isExactVisualQaSelectorRepair ||
             isExactGtmqSourceGateReaper ||
             isExactRunnerIoPressure ||
-            isExactRunnerPrerequisiteRepair)
+            isExactRunnerPrerequisiteRepair ||
+            isExactLayoutGuardContract)
         ? 'selected'
         : relatedFiles.length === 0
           ? 'none'


### PR DESCRIPTION
## Root cause

PR #13878's `Layout Guard` check passed after the workflow printed `layout-overlap-guard.spec.ts not found — skipping` and exited 0. That spec was deliberately deleted with the broad flaky pairwise overlap heuristic, but the workflow retained the obsolete filename and converted missing coverage into success.

Classification: broken test/workflow contract plus missing automation.

## Fix

- Replace the obsolete reference with an explicit required/optional deterministic spec manifest.
- Require `hud-scroll.spec.ts`; fail closed with an exact error if it is absent.
- Include `marketing-document-scroll.spec.ts` only when that separately owned file is present.
- Pin the lane to the no-auth Playwright config and a job-local HUD kiosk token.
- Add Gem diagnosis `layout_guard_contract_missing`, covering both the new fail-closed signature and the legacy false-green log.
- Keep the exact repair on focused affected-test coverage.

## Verification

- `node scripts/run-affected-tests.mjs --base origin/main --max-workers 2` — 87/87 Gem+selector and 3/3 manifest tests passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm biome check --write <changed JS/TS files>` — passed.
- `SHELLCHECK_OPTS=... actionlint .github/workflows/ci.yml` using repository exclusions — passed.
- Exact no-auth Playwright collection — 5 intended tests in `hud-scroll.spec.ts`; no auth-setup dependency.
- `pnpm --filter @jovie/web run test:bug-to-test` — satisfied.

## Bug-to-Test

- [x] Regression added: required-only, optional-present, and CLI missing-required nonzero behavior; workflow execution contract; Gem positive/negative signatures; affected selector completeness.

No broad overlap heuristic is restored. No required checks are bypassed.