### PR TITLE
fix(e2e): follow canonical golden path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1843,6 +1843,13 @@ jobs:
 
           export NEXT_PUBLIC_CLERK_MOCK=1
           export NEXT_PUBLIC_CLERK_PROXY_DISABLED=1
+          # GHA sets HOSTNAME to the runner name. Next standalone otherwise uses
+          # its 0.0.0.0 bind address for absolute redirects, which turns a
+          # same-origin Lighthouse request into cross-origin CORS/HTTP noise.
+          export HOSTNAME=localhost
+          export NEXT_PUBLIC_APP_URL=http://localhost:3000
+          export BETTER_AUTH_URL=http://localhost:3000
+          export NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3000
 
           if [ ! -f .next/standalone/apps/web/server.js ]; then
             echo "Standalone server not found - public Lighthouse cannot start."
@@ -1883,7 +1890,7 @@ jobs:
           fi
         env:
           CI: true
-          BASE_URL: http://127.0.0.1:3000
+          BASE_URL: http://localhost:3000
           PUBLIC_LIGHTHOUSE_SHARD_INDEX: ${{ matrix.shard }}
           PUBLIC_LIGHTHOUSE_TOTAL_SHARDS: '2'
           PROFILE_MOBILE_PERF_BUDGETS: '1'
@@ -1893,6 +1900,16 @@ jobs:
           PUBLIC_NOAUTH_SMOKE: '1'
           URL_ENCRYPTION_KEY: lighthouse-public-ci-url-encryption-key
           AI_GATEWAY_API_KEY: lighthouse-public-ci
+
+      - name: Upload public Lighthouse mobile artifacts on failure
+        if: ${{ failure() && matrix.shard == 1 }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: public-lighthouse-mobile-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
+          retention-days: 3
 
   ci-lighthouse-dashboard-pr:
     name: Lighthouse (dashboard PR)
@@ -3566,6 +3583,12 @@ jobs:
           # Enables Better Auth's deterministic OTP only for the golden path's
           # canonical +e2e test address; production hard-blocks this switch.
           export E2E_TEST_MODE=1
+          # Makes the anonymous /start turn deterministic while preserving the
+          # real session cookie, persistence, signup, claim, and activation path.
+          export CHAT_LLM_FAILURE_INJECTION=1
+          # The loopback-only server gate also requires this explicit flag before
+          # it will bypass Turnstile for the first anonymous request.
+          export PUBLIC_NOAUTH_SMOKE=1
           export NEXT_PUBLIC_APP_URL=http://localhost:3100
           export BETTER_AUTH_URL=http://localhost:3100
           export NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3100

--- a/apps/web/app/(dynamic)/start/layout.test.tsx
+++ b/apps/web/app/(dynamic)/start/layout.test.tsx
@@ -79,6 +79,19 @@ describe('start route layout', () => {
     ]);
   });
 
+  it('keeps live auth enabled for the real-auth Golden Path on loopback', async () => {
+    vi.stubEnv('PUBLIC_NOAUTH_SMOKE', '1');
+    vi.stubEnv('E2E_TEST_MODE', '1');
+    vi.stubEnv('VERCEL_ENV', '');
+    const { default: StartLayout } = await import('./layout');
+
+    render(await StartLayout({ children: <div data-testid='child' /> }));
+
+    expect(mocks.providerProps).toEqual([
+      { forceBypassClerk: false, skipCoreProviders: true },
+    ]);
+  });
+
   it('bypasses Clerk for local Playwright E2E runs', async () => {
     vi.stubEnv('NEXT_PUBLIC_E2E_MODE', '1');
     vi.stubEnv('VERCEL_ENV', '');

--- a/apps/web/app/(dynamic)/start/layout.tsx
+++ b/apps/web/app/(dynamic)/start/layout.tsx
@@ -18,8 +18,11 @@ export default async function StartLayout({
 }>) {
   // Anonymous onboarding never needs a live Clerk bootstrap on loopback E2E/dev
   // hosts — loading FAPI JS from localhost causes CORS console errors and jank.
+  // The Golden Path uses the same loopback Turnstile bypass with a real Better
+  // Auth signup, so E2E_TEST_MODE must keep the live cookie-backed provider.
   const forceBypassClerk =
     !isSecureEnv() &&
+    env.E2E_TEST_MODE !== '1' &&
     (env.PUBLIC_NOAUTH_SMOKE === '1' ||
       process.env.NEXT_PUBLIC_E2E_MODE === '1');
   const initialFlags = await getAppFlagsSnapshot({

--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -4766,7 +4766,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 
 .system-b-mounted-home-workspace-callout
   .system-b-mounted-home-workspace-callout-label {
-  color: var(--color-text-tertiary-token);
+  color: var(--color-text-secondary-token);
 }
 
 .system-b-mounted-home-workspace-callout
@@ -4778,7 +4778,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 
 .system-b-mounted-home-workspace-callout
   .system-b-mounted-home-workspace-callout-body {
-  color: var(--color-text-tertiary-token);
+  color: var(--color-text-secondary-token);
   font-size: var(--text-sm);
 }
 

--- a/apps/web/app/api/onboarding/claim/route.ts
+++ b/apps/web/app/api/onboarding/claim/route.ts
@@ -2,7 +2,6 @@ import { and, desc, eq, inArray, isNull } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { getCachedAuth } from '@/lib/auth/cached';
 import { db } from '@/lib/db';
-import { users } from '@/lib/db/schema/auth';
 import { chatAuditLog, chatConversations } from '@/lib/db/schema/chat';
 import { captureError } from '@/lib/error-tracking';
 import { materializeClaimedOnboardingProfile } from '@/lib/onboarding/claim-profile';
@@ -28,12 +27,12 @@ function profilePayload(
 /**
  * POST /api/onboarding/claim (JOV-2132).
  *
- * Called by the inline Clerk SignUp completion handler to associate any
- * anonymous onboarding chat transcript(s) with the freshly created Clerk user.
+ * Called by the inline signup completion handler to associate any anonymous
+ * onboarding chat transcript(s) with the freshly created app user.
  *
  * Flow:
- *  1. Require Clerk auth (must be called from an authenticated context — the
- *     user just signed up; Clerk middleware has populated request auth).
+ *  1. Require auth (must be called from an authenticated context — the user
+ *     just signed up and Better Auth has provisioned the app user).
  *  2. Resolve the signed sessionId from the onboarding cookie.
  *  3. SELECT all chat_conversations rows where sessionId = ? AND userId IS NULL.
  *  4. If 1 row → UPDATE userId, record consent audit log entry.
@@ -48,8 +47,10 @@ function profilePayload(
  */
 export async function POST(req: Request) {
   try {
-    const { userId: clerkUserId } = await getCachedAuth();
-    if (!clerkUserId) {
+    // getCachedAuth().userId is the app `users.id` UUID. A valid Better Auth
+    // session without a linked app user intentionally resolves to null.
+    const { userId } = await getCachedAuth();
+    if (!userId) {
       return NextResponse.json(
         { error: 'Unauthorized', errorCode: 'UNAUTHORIZED' },
         { status: 401 }
@@ -61,20 +62,6 @@ export async function POST(req: Request) {
       // No anonymous session to claim — successful no-op so the client can
       // call this endpoint unconditionally after sign-up.
       return NextResponse.json({ claimed: 0 });
-    }
-
-    // Resolve the internal DB users.id from the Clerk user id.
-    const [userRow] = await db
-      .select({ id: users.id })
-      .from(users)
-      .where(eq(users.clerkId, clerkUserId))
-      .limit(1);
-
-    if (!userRow) {
-      // The Clerk user has authenticated but hasn't been mirrored into our
-      // users table yet (Clerk webhook race). Treat as a soft success — the
-      // client can retry once the webhook fires.
-      return NextResponse.json({ claimed: 0, retryAfterWebhook: true });
     }
 
     // Look up all unclaimed conversations tied to this sessionId.
@@ -116,7 +103,7 @@ export async function POST(req: Request) {
       //     is still the catch-all for the cross-user case
       const claimedPrimary = await db
         .update(chatConversations)
-        .set({ userId: userRow.id, updatedAt: new Date() })
+        .set({ userId, updatedAt: new Date() })
         .where(
           and(
             eq(chatConversations.id, primary.id),
@@ -140,7 +127,7 @@ export async function POST(req: Request) {
       }
 
       const profile = await materializeClaimedOnboardingProfile({
-        userId: userRow.id,
+        userId,
         conversationId: primary.id,
         ipAddress,
         userAgent,
@@ -150,13 +137,13 @@ export async function POST(req: Request) {
       // primary is already claimed, audit gap is a forensic loss but not a
       // user-visible failure.
       await db.insert(chatAuditLog).values({
-        userId: userRow.id,
+        userId,
         creatorProfileId: null,
         conversationId: primary.id,
         action: 'claim_anonymous_conversation',
         field: 'user_id',
         previousValue: null,
-        newValue: userRow.id,
+        newValue: userId,
         metadata: {
           sessionId,
           claimedConversationCount: candidates.length,
@@ -173,7 +160,7 @@ export async function POST(req: Request) {
         await db
           .update(chatConversations)
           .set({
-            userId: userRow.id,
+            userId,
             sessionId: null,
             title: '(superseded — claimed alongside another transcript)',
             updatedAt: new Date(),

--- a/apps/web/components/features/auth/GoogleOneTap.tsx
+++ b/apps/web/components/features/auth/GoogleOneTap.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { authClient } from '@/lib/auth/client';
+import { authClient, isGoogleOneTapConfigured } from '@/lib/auth/client';
 import type { AuthShellMode } from './AuthShell';
 
 /**
@@ -47,11 +47,11 @@ export function GoogleOneTap({ mode, suppress }: GoogleOneTapProps) {
   useEffect(() => {
     if (suppress) return;
     if (isNativeWebview()) return;
+    if (!isGoogleOneTapConfigured()) return;
 
-    // `authClient.oneTap` is only present when the `oneTapClient` plugin was
-    // mounted in `lib/auth/client.ts` (i.e. `NEXT_PUBLIC_GOOGLE_CLIENT_ID` is
-    // set). If absent, One Tap is silently disabled — the provider buttons
-    // remain the primary Google affordance.
+    // Better Auth's proxy client can expose a callable unknown property even
+    // when the plugin is absent. The explicit configuration gate above keeps
+    // mock/DB-less builds from calling a server route that was never mounted.
     const oneTap = authClient.oneTap;
     if (!oneTap) return;
 

--- a/apps/web/lib/auth/better-auth.ts
+++ b/apps/web/lib/auth/better-auth.ts
@@ -30,7 +30,9 @@ import {
 import { env } from '@/lib/env';
 import { publicEnv } from '@/lib/env-public';
 import { captureError } from '@/lib/error-tracking';
+import { logger } from '@/lib/utils/logger';
 import { generateAppleClientSecret } from './apple-client-secret';
+import { provisionAppUser } from './provision';
 import { AUTH_RATE_LIMIT_RULES } from './rate-limit-rules';
 import { secondaryStorage } from './secondary-storage';
 
@@ -263,6 +265,40 @@ export const auth = betterAuth({
     customRules: AUTH_RATE_LIMIT_RULES,
   },
   trustedOrigins: () => resolveTrustedOrigins(),
+  databaseHooks: {
+    user: {
+      create: {
+        after: async user => {
+          try {
+            await provisionAppUser({
+              betterAuthUserId: user.id,
+              email: user.email,
+              emailVerified: user.emailVerified,
+              name: user.name,
+            });
+          } catch (error) {
+            // provisionAppUser never throws by contract; this is
+            // belt-and-braces so the auth callback can never fail here.
+            // gate.ts lazy-create heals on the next request.
+            try {
+              logger.error('[auth] provision hook failed', error);
+              await captureError('Better Auth provision hook failed', error, {
+                betterAuthUserId: user.id,
+                operation: 'databaseHooks.user.create.after',
+              });
+            } catch (telemetryError) {
+              // Telemetry must never turn the fail-open repair path into an
+              // auth failure. The next request still heals through gate.ts.
+              console.error(
+                '[auth] provision hook telemetry failed',
+                telemetryError
+              );
+            }
+          }
+        },
+      },
+    },
+  },
   telemetry: { enabled: false },
   plugins: buildPlugins(),
 });

--- a/apps/web/lib/auth/client.ts
+++ b/apps/web/lib/auth/client.ts
@@ -27,6 +27,15 @@ import { createAuthClient } from 'better-auth/react';
 const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
 
 /**
+ * Better Auth clients are proxy-backed, so an unknown property can look
+ * callable even when its plugin was not mounted. Keep the compile-time env
+ * gate explicit instead of treating `authClient.oneTap` presence as proof.
+ */
+export function isGoogleOneTapConfigured(): boolean {
+  return Boolean(googleClientId);
+}
+
+/**
  * Plugins:
  * - `emailOTPClient` — email one-time-code sign-in (replaces the Clerk
  *   email-code strategy used by EmailCodeAuthForm).

--- a/apps/web/tests/e2e/golden-path.spec.ts
+++ b/apps/web/tests/e2e/golden-path.spec.ts
@@ -3,17 +3,25 @@ import { expect, type Page, test } from '@playwright/test';
 import { APP_ROUTES } from '@/constants/routes';
 import {
   ensureSignedInUser,
+  fillControlledInputUntilEnabled,
   getAdminCredentials,
   hasAdminCredentials,
 } from '../helpers/clerk-auth';
+import {
+  installRuntimeAutomationBypass,
+  resetAuthStatePreservingOnboardingSession,
+} from './utils/runtime-automation-bypass';
 
 /**
- * Golden Path E2E — Signup -> Onboarding -> Music Fetch -> Live Profile
+ * Golden Path E2E — Anonymous Chat -> Signup -> Claim -> Live Profile
  *
  * Tests the complete new-user journey end to end with REAL data:
- * - No mocks for music fetch
+ * - Real anonymous conversation persistence and Better Auth signup
+ * - Deterministic confirmed artist/handle tool-call fixtures
+ * - Real claim endpoint and public profile activation
  * - No pre-authenticated state
- * - Real Better Auth email-OTP signup (test environment)
+ *
+ * MusicFetch integration coverage remains in musicfetch-coverage.spec.ts.
  *
  * Jovie's pricing is a 14-day reverse trial with NO card required at signup
  * (see docs/PRICING-PHILOSOPHY.md), so the golden path's "first value" moment
@@ -114,11 +122,28 @@ async function ensureDbUser(betterAuthUserId: string) {
     WHERE spotify_id = ${KNOWN_TIM_WHITE_SPOTIFY_ID}
   `;
 
-  await sql`
-    UPDATE users
-    SET user_status = 'waitlist_approved', updated_at = NOW()
-    WHERE better_auth_user_id = ${betterAuthUserId}
-  `;
+  await expect
+    .poll(
+      async () => {
+        const [user] = await sql`
+          UPDATE users
+          SET user_status = 'waitlist_approved', updated_at = NOW()
+          WHERE better_auth_user_id = ${betterAuthUserId}
+          RETURNING id
+        `;
+        return user?.id ?? null;
+      },
+      {
+        message:
+          'Better Auth app-user provisioning hook did not create a linked users row',
+        timeout: 30_000,
+      }
+    )
+    .toBeTruthy();
+
+  // The sign-in response is still withheld at this point, so the browser has
+  // neither the new session cookie nor a chance to cache the pending state.
+  // Approving here removes the old cache-invalidation race entirely.
 }
 
 /**
@@ -244,39 +269,223 @@ async function createFreshUserOnce(page: import('@playwright/test').Page) {
   const continueButton = page.getByRole('button', {
     name: 'Continue with Email',
   });
-  await emailInput.fill(email);
-  // The standalone app can finish client hydration immediately after its
-  // server-rendered form becomes visible. Wait for React state to enable the
-  // submit control before clicking so the typed address is not lost.
-  await expect(continueButton).toBeEnabled({ timeout: 30_000 });
+  // Hydration can reset the server-rendered controlled input after the first
+  // fill. Refill until React retains the value and enables submission.
+  await fillControlledInputUntilEnabled(emailInput, continueButton, email);
   await continueButton.click();
   await expect(page.locator('[data-auth-email-code-step="code"]')).toBeVisible({
     timeout: 30_000,
   });
-  await page.getByLabel('Digit 1 of 6').pressSequentially('424242');
-  await page.waitForURL(/\/(start|onboarding)/, { timeout: 30_000 });
-  await page.waitForLoadState('domcontentloaded');
 
-  const sessionHandle = await page.waitForFunction(
-    async () => {
-      try {
-        const response = await fetch('/api/auth/get-session');
-        if (!response.ok) return false;
-        const session = (await response.json()) as {
-          user?: { id?: string };
-        };
-        return session.user?.id || false;
-      } catch {
-        return false;
+  // OTP verification hard-navigates to /start as soon as Better Auth returns.
+  // New app users begin in the pending waitlist state, so approve the linked
+  // app row while the sign-in response is withheld from the browser. This
+  // preserves the real session cookie and lets the first /start mount perform
+  // the one authoritative claim without racing the start-route auth gate.
+  const signInRoute = '**/api/auth/sign-in/email-otp';
+  let betterAuthUserId: string | null = null;
+  let settleAuthPreparation: (error: Error | null) => void = () => undefined;
+  const authPreparationResult = new Promise<Error | null>(resolve => {
+    settleAuthPreparation = resolve;
+  });
+  await page.route(signInRoute, async route => {
+    let response: Awaited<ReturnType<typeof route.fetch>> | null = null;
+    let body: string | null = null;
+    let preparationError: Error | null = null;
+
+    try {
+      response = await route.fetch();
+      body = await response.text();
+      if (response.status() !== 200) {
+        throw new Error(
+          `Better Auth email-OTP sign-in returned ${response.status()}`
+        );
       }
-    },
-    undefined,
-    { timeout: 30_000 }
-  );
-  const betterAuthUserId = await sessionHandle.jsonValue<string>();
 
-  await ensureDbUser(betterAuthUserId);
-  return { email, betterAuthUserId };
+      const payload = JSON.parse(body) as { user?: { id?: string } };
+      betterAuthUserId = payload.user?.id ?? null;
+      if (!betterAuthUserId) {
+        throw new Error('Better Auth email-OTP response omitted the user id');
+      }
+
+      await ensureDbUser(betterAuthUserId);
+    } catch (error) {
+      preparationError =
+        error instanceof Error ? error : new Error(String(error));
+    }
+
+    try {
+      if (response && body !== null) {
+        await route.fulfill({ response, body });
+      } else {
+        await route.abort();
+      }
+    } catch (error) {
+      preparationError ??=
+        error instanceof Error ? error : new Error(String(error));
+    }
+
+    settleAuthPreparation(preparationError);
+  });
+  try {
+    const automaticStartNavigationPromise = page.waitForURL(
+      url => url.pathname === '/start',
+      { waitUntil: 'domcontentloaded', timeout: 30_000 }
+    );
+    void automaticStartNavigationPromise.catch(() => undefined);
+    const claimResponsePromise = page.waitForResponse(
+      response =>
+        response.request().method() === 'POST' &&
+        new URL(response.url()).pathname === '/api/onboarding/claim',
+      { timeout: 30_000 }
+    );
+    void claimResponsePromise.catch(() => undefined);
+    await page.getByLabel('Digit 1 of 6').pressSequentially('424242');
+    let authPreparationTimeout: ReturnType<typeof setTimeout> | undefined;
+    const authPreparationError = await Promise.race([
+      authPreparationResult,
+      new Promise<Error>(resolve => {
+        authPreparationTimeout = setTimeout(
+          () =>
+            resolve(
+              new Error(
+                'Better Auth email-OTP request did not reach the preparation barrier'
+              )
+            ),
+          30_000
+        );
+      }),
+    ]);
+    if (authPreparationTimeout) clearTimeout(authPreparationTimeout);
+    if (authPreparationError) throw authPreparationError;
+    await automaticStartNavigationPromise;
+    const claimResponse = await claimResponsePromise;
+    expect(claimResponse.status()).toBe(200);
+    const claimPayload = (await claimResponse.json()) as {
+      claimed?: number;
+      conversationId?: string;
+    };
+
+    if (!betterAuthUserId) {
+      throw new Error('Better Auth sign-in did not expose a user id');
+    }
+
+    return { email, betterAuthUserId, claimPayload };
+  } finally {
+    await page.unroute(signInRoute);
+  }
+}
+
+async function seedAnonymousOnboardingJourney(page: Page, handle: string) {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) throw new Error('DATABASE_URL required for onboarding seed');
+
+  // Mark only this browser as local automation before React initializes so
+  // the anonymous turn bypasses Turnstile without enabling auth bypass.
+  await page.addInitScript(installRuntimeAutomationBypass);
+  await page.route('**/api/chat', async route => {
+    await route.continue({
+      headers: {
+        ...route.request().headers(),
+        'x-jovie-e2e-llm-failure': '1',
+      },
+    });
+  });
+  await page.goto('/start', { waitUntil: 'domcontentloaded' });
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => document.documentElement.dataset.e2eMode ?? null),
+      {
+        message: 'Golden path browser did not install its runtime marker',
+        timeout: 30_000,
+      }
+    )
+    .toBe('1');
+  const input = page.locator('[aria-label="Chat message input" i]');
+  await expect(input).toBeVisible({ timeout: 30_000 });
+  await input.fill('I am Tim White');
+  const sendButton = page.getByRole('button', { name: 'Send message' });
+  // Synchronize on the real user-facing composer without coupling the fixture
+  // to component attributes that the canonical chat does not expose.
+  await expect(sendButton).toBeEnabled({ timeout: 30_000 });
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      candidate =>
+        candidate.request().method() === 'POST' &&
+        new URL(candidate.url()).pathname === '/api/chat'
+    ),
+    sendButton.click(),
+  ]);
+  expect(response.status()).toBe(200);
+  const requestBody = response.request().postDataJSON() as {
+    messages?: Array<{ id?: string; role?: string }>;
+  };
+  const clientMessageId = requestBody.messages
+    ?.toReversed()
+    .find(message => message.role === 'user')?.id;
+  expect(
+    clientMessageId,
+    'Anonymous chat request did not include a user message id'
+  ).toBeTruthy();
+
+  const sql = neon(dbUrl);
+  const persistedMessages = await sql`
+    SELECT conversation_id
+    FROM chat_messages
+    WHERE client_message_id = ${clientMessageId}
+      AND role = 'user'
+    ORDER BY created_at DESC
+    LIMIT 2
+  `;
+  expect(
+    persistedMessages.length,
+    'Anonymous chat user message was not persisted exactly once'
+  ).toBe(1);
+  const conversationId = persistedMessages[0]?.conversation_id;
+  expect(
+    conversationId,
+    'Anonymous chat did not reserve a conversation'
+  ).toBeTruthy();
+
+  const toolCalls = [
+    {
+      schemaVersion: 2,
+      toolCallId: `golden-artist-${Date.now()}`,
+      toolName: 'confirmSpotifyArtist',
+      state: 'succeeded',
+      output: {
+        action: 'spotify_artist_confirmed',
+        spotifyArtistId: '4Uwpa6zW3zzCSQvooQNksm',
+        artist: {
+          id: '4Uwpa6zW3zzCSQvooQNksm',
+          name: 'Tim White',
+          url: 'https://open.spotify.com/artist/4Uwpa6zW3zzCSQvooQNksm',
+        },
+      },
+      uiHint: 'artifact',
+    },
+    {
+      schemaVersion: 2,
+      toolCallId: `golden-handle-${Date.now()}`,
+      toolName: 'checkHandle',
+      state: 'succeeded',
+      output: { action: 'check_handle', handle },
+      uiHint: 'artifact',
+    },
+  ];
+  const updated = await sql`
+    UPDATE chat_messages
+    SET tool_calls = ${JSON.stringify(toolCalls)}::jsonb
+    WHERE id = (
+      SELECT id FROM chat_messages
+      WHERE conversation_id = ${conversationId}
+      ORDER BY created_at DESC LIMIT 1
+    )
+    RETURNING id
+  `;
+  expect(updated.length, 'Anonymous chat message was not persisted').toBe(1);
+  return conversationId;
 }
 
 async function createFreshUser(page: import('@playwright/test').Page) {
@@ -297,7 +506,7 @@ async function createFreshUser(page: import('@playwright/test').Page) {
         throw error;
       }
 
-      await page.context().clearCookies();
+      await resetAuthStatePreservingOnboardingSession(page.context());
       await page
         .evaluate(() => {
           localStorage.clear();
@@ -317,7 +526,7 @@ async function createFreshUser(page: import('@playwright/test').Page) {
 /*  Test suite                                                          */
 /* ------------------------------------------------------------------ */
 
-test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Live Profile', () => {
+test.describe('Golden Path: Anonymous Chat -> Signup -> Claim -> Live Profile', () => {
   test.describe.configure({ mode: 'serial' });
 
   // Fresh browser — no inherited auth state
@@ -352,114 +561,56 @@ test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Live Profile'
       timeout: 30_000,
     });
 
-    // The collapsed homepage (#11988) is hero + minimal footer: no claim
-    // input, no signup links — the funnel routes through the hero command
-    // center into /start chat. Assert the hero rendered, then enter the
-    // classic signup path directly (this spec's scope is signup →
-    // onboarding → live profile, not the chat funnel).
+    // The collapsed homepage routes onboarding through /start chat.
     await expect(page.getByTestId('homepage-hero-command-center')).toBeVisible({
       timeout: 20_000,
     });
 
     // ──────────────────────────────────────────────────────────────────
-    // STEP 2: Initiate signup
+    // STEP 2: Start the canonical anonymous chat journey
     // ──────────────────────────────────────────────────────────────────
-    await page.goto('/signup', {
-      waitUntil: 'domcontentloaded',
-      timeout: 30_000,
-    });
-    await page.waitForURL(/\/(signup|onboarding)/, { timeout: 30_000 });
+    const randomSuffix = Math.random().toString(36).slice(2, 8);
+    const uniqueHandle = `t${Date.now().toString(36)}${randomSuffix}`;
+    const conversationId = await seedAnonymousOnboardingJourney(
+      page,
+      uniqueHandle
+    );
 
     // ──────────────────────────────────────────────────────────────────
     // STEP 3: Create account
     // ──────────────────────────────────────────────────────────────────
-    const { betterAuthUserId } = await createFreshUser(page);
-
-    // ──────────────────────────────────────────────────────────────────
-    // STEP 4: Onboarding — Handle step
-    // ──────────────────────────────────────────────────────────────────
-    // Generate a unique handle and pass it via search param.
-    // When the handle is pre-filled via ?handle=, the validation hook's
-    // fast path marks it as available immediately (skips API check),
-    // avoiding the TanStack Pacer debouncer state race condition.
-    const randomSuffix = Math.random().toString(36).slice(2, 8);
-    const uniqueHandle = `t${Date.now().toString(36)}${randomSuffix}`;
-
-    // Navigate to onboarding with pre-filled handle, submit handle step,
-    // and advance to DSP step. Retry the whole sequence since the Neon
-    // WebSocket pool can fail during SSR or server action execution.
-    await expect(async () => {
-      await page.goto(`/onboarding?handle=${uniqueHandle}`, {
-        waitUntil: 'domcontentloaded',
-        timeout: 60_000,
-      });
-      await expect(
-        page.locator('[data-testid="onboarding-form-wrapper"]')
-      ).toBeVisible({ timeout: 10_000 });
-
-      // Handle input should be pre-filled
-      const handleEl = page.getByLabel('Claim Your Handle');
-      const handleVisible = await handleEl
-        .isVisible({ timeout: 3_000 })
-        .catch(() => false);
-
-      if (handleVisible) {
-        // Still on handle step — submit it through the icon-only claim button.
-        await expect
-          .poll(async () => (await handleEl.inputValue()).trim(), {
-            timeout: 20_000,
-          })
-          .toBe(uniqueHandle);
-
-        const claimHandleButton = page.getByTestId('onboarding-handle-submit');
-        await expect(claimHandleButton).toBeEnabled({ timeout: 30_000 });
-        await claimHandleButton.click();
-      }
-
-      // Must reach DSP step (artist search)
-      await expect(
-        page.getByPlaceholder(/search by artist name or paste a spotify link/i)
-      ).toBeVisible({ timeout: 60_000 });
-    }).toPass({
-      timeout: 180_000,
-      intervals: [3_000, 5_000, 10_000, 15_000],
-    });
-
-    // ──────────────────────────────────────────────────────────────────
-    // STEP 5: Onboarding — Artist search (Music Fetch)
-    // ──────────────────────────────────────────────────────────────────
-    const artistInput = page.getByPlaceholder(
-      /search by artist name or paste a spotify link/i
-    );
-    await expect(artistInput).toBeVisible({ timeout: 5_000 });
-
+    const { betterAuthUserId, claimPayload } = await createFreshUser(page);
     const TEST_SPOTIFY_ID = '4Uwpa6zW3zzCSQvooQNksm';
     const testSpotifyUrl = `https://open.spotify.com/artist/${TEST_SPOTIFY_ID}`;
-    const capturedSpotifyUrl: string | null = testSpotifyUrl;
-    const capturedSpotifyId: string | null = TEST_SPOTIFY_ID;
 
-    await artistInput.fill(testSpotifyUrl);
-
-    // ──────────────────────────────────────────────────────────────────
-    // STEP 6: Current onboarding V2 — verify import and finish path
-    // ──────────────────────────────────────────────────────────────────
-
-    const importCompleteHeading = page.getByRole('heading', {
-      name: /^(Spotify connected|Your Link Is Live)$/i,
+    // Assert the real client auto-claim response captured during OTP completion.
+    // A duplicate request here would race the hook and mask which caller won.
+    expect(claimPayload).toMatchObject({
+      claimed: 1,
+      conversationId,
     });
-    await expect(importCompleteHeading).toBeVisible({ timeout: 180_000 });
+    const sql = neon(process.env.DATABASE_URL!);
+    await expect
+      .poll(async () => {
+        const rows = await sql`
+          SELECT cp.id FROM creator_profiles cp
+          INNER JOIN users u ON u.id = cp.user_id
+          WHERE u.better_auth_user_id = ${betterAuthUserId}
+            AND cp.username_normalized = ${uniqueHandle}
+        `;
+        return rows.length;
+      })
+      .toBe(1);
 
     // Ensure Spotify URL is saved on the profile via direct DB write.
     // The fire-and-forget connectSpotifyArtist uses the flaky WebSocket pool
     // and often fails silently in test envs. This guarantees the URL is persisted
     // so we can hard-assert DSP links render on the public profile.
     //
-    // Fallback uses a known real Spotify artist ID for "Tim White" in case
-    // the response interceptor didn't capture the URL (e.g. search cached).
-    const spotifyIdToSave = capturedSpotifyId || TEST_SPOTIFY_ID;
-    const spotifyUrlToSave = capturedSpotifyUrl || testSpotifyUrl;
+    const spotifyIdToSave = TEST_SPOTIFY_ID;
+    const spotifyUrlToSave = testSpotifyUrl;
     console.log(
-      `[golden-path] Setting spotify_url=${spotifyUrlToSave} spotify_id=${spotifyIdToSave} (captured=${capturedSpotifyUrl})`
+      `[golden-path] Activated conversation=${conversationId}; setting spotify_url=${spotifyUrlToSave}`
     );
     await ensureSpotifyUrlOnProfile(
       betterAuthUserId,

--- a/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
+++ b/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
@@ -127,8 +127,8 @@ const PROFILE_MOBILE_SCREENS = [
   },
   {
     id: 'notifications',
-    path: '/testartist/notifications',
-    rootSelector: '[data-testid="notifications-page"]',
+    path: '/testartist?mode=subscribe',
+    rootSelector: '[data-testid="profile-compact-surface"]',
     readySelectors: ['[data-testid="profile-mobile-notifications-step-email"]'],
   },
 ] as const satisfies readonly MobileProfileScreen[];
@@ -569,6 +569,7 @@ type ReleaseCardLayout = {
   readonly artwork: {
     readonly width: number;
     readonly height: number;
+    readonly contentWidth: number;
   } | null;
   readonly title: {
     readonly top: number;
@@ -619,7 +620,12 @@ async function collectMockHomeReleaseCardLayout(
 
     return {
       card: rect(card),
-      artwork: artwork ? rect(artwork) : null,
+      artwork: artwork
+        ? {
+            ...rect(artwork),
+            contentWidth: artwork.parentElement?.clientWidth ?? 0,
+          }
+        : null,
       title: title ? rect(title) : null,
       hero: hero ? rect(hero) : null,
       cover: cover
@@ -681,9 +687,12 @@ test.describe('Public Profile Mock Home Release Card Layout @smoke @critical', (
       }
 
       expect(
-        layout.artwork?.width ?? 0,
-        `${viewport.label} bento artwork should fill the card width`
-      ).toBeGreaterThanOrEqual(layout.card.width - 2);
+        Math.abs(
+          (layout.artwork?.width ?? 0) -
+            (layout.artwork?.contentWidth ?? Number.POSITIVE_INFINITY)
+        ),
+        `${viewport.label} bento artwork should fill its padded content box`
+      ).toBeLessThanOrEqual(2);
 
       if (layout.title) {
         expect(
@@ -823,7 +832,7 @@ test.describe('Public Profile Mobile Viewport Stability @smoke @critical', () =>
 
         const response = await smokeNavigate(
           flowPage,
-          '/testartist/notifications',
+          '/testartist?mode=subscribe',
           {
             timeout: 120_000,
           }
@@ -836,10 +845,10 @@ test.describe('Public Profile Mobile Viewport Stability @smoke @critical', () =>
           SMOKE_TIMEOUTS.NAVIGATION
         );
 
-        const rootSelector = '[data-testid="notifications-page"]';
-        const activeFlow = flowPage.locator(
-          '[role="dialog"][data-testid="profile-mobile-notifications-flow"]'
-        );
+        const rootSelector = '[data-testid="profile-compact-surface"]';
+        const activeFlow = flowPage
+          .locator('[data-testid="profile-mobile-notifications-flow"]:visible')
+          .first();
         const emailInput = activeFlow.getByTestId('mobile-email-input');
         await focusAndAssertNoShift(
           flowPage,
@@ -850,7 +859,7 @@ test.describe('Public Profile Mobile Viewport Stability @smoke @critical', () =>
         await emailInput.fill(`mobile-${viewport.id}@example.com`);
         await activeFlow
           .getByTestId('profile-mobile-notifications-step-email')
-          .getByRole('button', { name: /^continue$/i })
+          .getByRole('button', { name: /^submit$/i })
           .click();
 
         const firstOtpDigit = activeFlow.getByLabel('Digit 1 of 6');

--- a/apps/web/tests/e2e/profile-notifications-hosts.spec.ts
+++ b/apps/web/tests/e2e/profile-notifications-hosts.spec.ts
@@ -113,7 +113,7 @@ test.describe('Profile Notifications Hosts', () => {
       ).toBeVisible();
     });
 
-    test(`dedicated notifications page auto-opens overlay flow @ ${breakpoint.name}`, async ({
+    test(`legacy notifications page redirects to the canonical subscribe flow @ ${breakpoint.name}`, async ({
       page,
     }) => {
       await blockAnalytics(page);
@@ -128,9 +128,12 @@ test.describe('Profile Notifications Hosts', () => {
       });
       await waitForHydration(page);
 
-      await expect(page.getByTestId('notifications-page')).toBeVisible();
+      await expect(page).toHaveURL(/\/testartist\?mode=subscribe$/);
+      await expect(page.getByTestId('profile-compact-surface')).toBeVisible();
       await expect(
-        page.getByTestId('profile-mobile-notifications-flow')
+        page.locator(
+          '[data-testid="profile-mobile-notifications-flow"]:visible'
+        )
       ).toBeVisible();
       await expect(
         page.getByTestId('profile-mobile-notifications-step-email')

--- a/apps/web/tests/e2e/utils/runtime-automation-bypass.ts
+++ b/apps/web/tests/e2e/utils/runtime-automation-bypass.ts
@@ -1,0 +1,41 @@
+import type { BrowserContext } from '@playwright/test';
+
+export const ONBOARDING_SESSION_COOKIE_NAME = 'jovie_onboarding_session';
+
+/**
+ * Mark one browser document as local E2E automation as soon as its root exists.
+ *
+ * Playwright init scripts can run before the parser creates `documentElement`, so
+ * the bootstrap must defer the write instead of assuming an HTML root exists.
+ * Keep this function self-contained: Playwright serializes it into the browser.
+ */
+export function installRuntimeAutomationBypass(): void {
+  const initialRoot = document.documentElement;
+  if (initialRoot) {
+    initialRoot.dataset.e2eMode = '1';
+    return;
+  }
+
+  const observer = new MutationObserver(() => {
+    const root = document.documentElement;
+    if (!root) return;
+
+    root.dataset.e2eMode = '1';
+    observer.disconnect();
+  });
+  observer.observe(document, { childList: true });
+}
+
+/** Clear auth state between signup attempts without losing the anonymous journey. */
+export async function resetAuthStatePreservingOnboardingSession(
+  context: BrowserContext
+): Promise<void> {
+  const onboardingCookies = (await context.cookies()).filter(
+    cookie => cookie.name === ONBOARDING_SESSION_COOKIE_NAME
+  );
+
+  await context.clearCookies();
+  if (onboardingCookies.length > 0) {
+    await context.addCookies(onboardingCookies);
+  }
+}

--- a/apps/web/tests/helpers/auth.ts
+++ b/apps/web/tests/helpers/auth.ts
@@ -235,6 +235,26 @@ export async function setTestAuthBypassSession(
   }
 }
 
+/** Refill a controlled field until React hydration retains it and enables submit. */
+export async function fillControlledInputUntilEnabled(
+  input: Locator,
+  submit: Locator,
+  value: string,
+  timeout = 30_000
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        await input.fill(value);
+        return (
+          (await input.inputValue()) === value && (await submit.isEnabled())
+        );
+      },
+      { timeout, intervals: [100, 250, 500] }
+    )
+    .toBe(true);
+}
+
 export async function waitForAuthenticatedHealth(
   page: Page,
   options: { readonly timeout?: number } = {}

--- a/apps/web/tests/unit/api/onboarding/claim.test.ts
+++ b/apps/web/tests/unit/api/onboarding/claim.test.ts
@@ -49,13 +49,6 @@ vi.mock('@/lib/db', () => ({
   },
 }));
 
-vi.mock('@/lib/db/schema/auth', () => ({
-  users: {
-    id: 'users.id',
-    clerkId: 'users.clerk_id',
-  },
-}));
-
 vi.mock('@/lib/db/schema/chat', () => ({
   chatConversations: {
     id: 'chat_conversations.id',
@@ -109,13 +102,6 @@ function makeRequest(): Request {
     method: 'POST',
     headers: { 'user-agent': 'test-agent/1.0' },
   });
-}
-
-function setupDbSelectForUsers(userId: string | null) {
-  const limit = vi.fn().mockResolvedValue(userId ? [{ id: userId }] : []);
-  const where = vi.fn().mockReturnValue({ limit });
-  const from = vi.fn().mockReturnValue({ where });
-  mockDbSelect.mockReturnValueOnce({ from });
 }
 
 function setupDbSelectForCandidates(
@@ -173,7 +159,11 @@ function pickPrimaryAndOthers<T extends { createdAt: Date }>(
 describe('POST /api/onboarding/claim — race, idempotency, failure paths', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetCachedAuth.mockResolvedValue({ userId: 'clerk_user_123' });
+    mockGetCachedAuth.mockResolvedValue({
+      userId: '3a53ba3e-150c-4ab5-8e73-2d2499764e2c',
+      sessionId: 'ba_session_123',
+      orgId: null,
+    });
     mockGetCurrentOnboardingSessionId.mockResolvedValue('sess_abc123');
     mockExtractClientIP.mockReturnValue('10.0.0.1');
     mockMaterializeClaimedOnboardingProfile.mockResolvedValue({
@@ -184,12 +174,31 @@ describe('POST /api/onboarding/claim — race, idempotency, failure paths', () =
   });
 
   it('returns 401 when unauthenticated', async () => {
-    mockGetCachedAuth.mockResolvedValue({ userId: null });
+    mockGetCachedAuth.mockResolvedValue({
+      userId: null,
+      sessionId: null,
+      orgId: null,
+    });
     const res = await POST(makeRequest());
     expect(res.status).toBe(401);
     const json = await res.json();
     expect(json.errorCode).toBe('UNAUTHORIZED');
     expect(mockGetCurrentOnboardingSessionId).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when a Better Auth session has no provisioned app user', async () => {
+    mockGetCachedAuth.mockResolvedValue({
+      userId: null,
+      sessionId: 'ba_session_without_app_user',
+      orgId: null,
+    });
+
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ errorCode: 'UNAUTHORIZED' });
+    expect(mockGetCurrentOnboardingSessionId).not.toHaveBeenCalled();
+    expect(mockDbSelect).not.toHaveBeenCalled();
   });
 
   it('returns {claimed: 0} (no-op) when no onboarding session cookie', async () => {
@@ -200,15 +209,7 @@ describe('POST /api/onboarding/claim — race, idempotency, failure paths', () =
     expect(mockClearOnboardingSessionCookie).not.toHaveBeenCalled();
   });
 
-  it('returns retryAfterWebhook when Clerk user not yet mirrored in DB (webhook race)', async () => {
-    setupDbSelectForUsers(null); // no userRow
-    const res = await POST(makeRequest());
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ claimed: 0, retryAfterWebhook: true });
-  });
-
   it('clears cookie and returns {claimed:0} when no unclaimed conversations for session', async () => {
-    setupDbSelectForUsers('user_db_1');
     setupDbSelectForCandidates([]); // none
     const res = await POST(makeRequest());
     expect(res.status).toBe(200);
@@ -217,7 +218,7 @@ describe('POST /api/onboarding/claim — race, idempotency, failure paths', () =
   });
 
   it('claims the single (most recent) candidate, writes audit, clears cookie, returns claimed count', async () => {
-    setupDbSelectForUsers('user_db_1');
+    const appUserId = '3a53ba3e-150c-4ab5-8e73-2d2499764e2c';
     setupDbSelectForCandidates([
       { id: 'conv_1', createdAt: new Date('2026-05-01') },
     ]);
@@ -233,12 +234,20 @@ describe('POST /api/onboarding/claim — race, idempotency, failure paths', () =
     expect(mockClearOnboardingSessionCookie).toHaveBeenCalledTimes(1);
     expect(mockDbUpdate).toHaveBeenCalled();
     expect(mockDbInsert).toHaveBeenCalled();
+    expect(mockDbUpdate.mock.results[0]?.value.set).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: appUserId })
+    );
+    expect(mockDbInsert.mock.results[0]?.value.values).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: appUserId, newValue: appUserId })
+    );
+    expect(mockMaterializeClaimedOnboardingProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: appUserId })
+    );
     // ip/ua passed via extract
     expect(mockExtractClientIP).toHaveBeenCalled();
   });
 
   it('handles multiple candidates: claims primary (recency order), detaches siblings, writes audit with discarded list', async () => {
-    setupDbSelectForUsers('user_db_1');
     const c1 = { id: 'old_1', createdAt: new Date('2026-04-01') };
     const c2 = { id: 'newer', createdAt: new Date('2026-05-01') };
     setupDbSelectForCandidates([c2, c1]); // desc order: primary = newer
@@ -256,7 +265,6 @@ describe('POST /api/onboarding/claim — race, idempotency, failure paths', () =
   });
 
   it('idempotent on concurrent claim race: CAS returns 0 rows → soft success with alreadyClaimed, clears cookie', async () => {
-    setupDbSelectForUsers('user_db_1');
     setupDbSelectForCandidates([{ id: 'conv_1', createdAt: new Date() }]);
     setupUpdateForPrimary(0); // race lost
     const res = await POST(makeRequest());
@@ -271,7 +279,6 @@ describe('POST /api/onboarding/claim — race, idempotency, failure paths', () =
   });
 
   it('returns 409 SESSION_ALREADY_CLAIMED on unique constraint violation (session claimed by different user)', async () => {
-    setupDbSelectForUsers('user_db_1');
     setupDbSelectForCandidates([{ id: 'conv_1', createdAt: new Date() }]);
     setupUpdateForPrimary(1);
     setupInsertAudit(false); // throws unique
@@ -386,9 +393,12 @@ describe('claim route invariants (property tests for recency, idempotency, data 
         ),
         async msg => {
           vi.clearAllMocks();
-          mockGetCachedAuth.mockResolvedValue({ userId: 'clerk_user_123' });
+          mockGetCachedAuth.mockResolvedValue({
+            userId: '3a53ba3e-150c-4ab5-8e73-2d2499764e2c',
+            sessionId: 'ba_session_property',
+            orgId: null,
+          });
           mockGetCurrentOnboardingSessionId.mockResolvedValue('sess_409_prop');
-          setupDbSelectForUsers('user_1');
           setupDbSelectForCandidates([{ id: 'c1', createdAt: new Date() }]);
           setupUpdateForPrimary(1);
           const values = vi.fn().mockRejectedValue(new Error(msg));

--- a/apps/web/tests/unit/auth/AuthShell.test.tsx
+++ b/apps/web/tests/unit/auth/AuthShell.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   authState,
   providerEnabledState,
+  oneTapConfiguredState,
+  oneTapMock,
   searchParamsState,
   signInSocialMock,
   sendOtpMock,
@@ -17,6 +19,8 @@ const {
     google: true,
     apple: true,
   },
+  oneTapConfiguredState: { value: false },
+  oneTapMock: vi.fn(),
   searchParamsState: { value: '' },
   signInSocialMock: vi.fn(),
   sendOtpMock: vi.fn(),
@@ -38,8 +42,9 @@ vi.mock('@/lib/auth/client', () => ({
     emailOtp: {
       sendVerificationOtp: sendOtpMock,
     },
-    oneTap: undefined,
+    oneTap: oneTapMock,
   },
+  isGoogleOneTapConfigured: () => oneTapConfiguredState.value,
 }));
 
 vi.mock('next/navigation', () => ({
@@ -78,9 +83,11 @@ describe('AuthShell — Better Auth SSO + email-code contract', () => {
     authState.isSignedIn = false;
     providerEnabledState.google = true;
     providerEnabledState.apple = true;
+    oneTapConfiguredState.value = false;
     searchParamsState.value = '';
     signInSocialMock.mockResolvedValue(undefined);
     sendOtpMock.mockResolvedValue({ data: {} });
+    oneTapMock.mockResolvedValue(undefined);
   });
 
   it('is ready at first paint without a Clerk-loaded gate', () => {
@@ -88,6 +95,26 @@ describe('AuthShell — Better Auth SSO + email-code contract', () => {
     expect(
       container.querySelector('[data-auth-shell-ready="true"]')
     ).not.toBeNull();
+  });
+
+  it('does not call the proxy-backed One Tap route when the plugin is unconfigured', async () => {
+    render(<AuthShell mode='sign-up' />);
+
+    await waitFor(() => {
+      expect(oneTapMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('calls One Tap only when its client id configured the plugin', async () => {
+    oneTapConfiguredState.value = true;
+    render(<AuthShell mode='sign-up' />);
+
+    await waitFor(() => {
+      expect(oneTapMock).toHaveBeenCalledWith({
+        callbackURL: '/signup',
+        context: 'signup',
+      });
+    });
   });
 
   it('starts Google sign-in through Better Auth social with mode-aware callbacks', async () => {

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -765,13 +765,73 @@ describe('CI E2E smoke workflow', () => {
     expect(smokeManifest).toContain("'golden-path.spec.ts'");
     expect(smokeStep).toContain('export E2E_USE_TEST_AUTH_BYPASS=1');
     expect(smokeStep).not.toContain('export E2E_TEST_MODE=1');
+    expect(smokeStep).not.toContain('export PUBLIC_NOAUTH_SMOKE=1');
     expect(goldenPathStep).toContain('export E2E_TEST_MODE=1');
+    expect(goldenPathStep).toContain('export CHAT_LLM_FAILURE_INJECTION=1');
+    expect(goldenPathStep).toContain('export PUBLIC_NOAUTH_SMOKE=1');
     expect(goldenPathStep).not.toContain('E2E_USE_TEST_AUTH_BYPASS');
     expect(goldenPathSpec).toContain(
       "process.env.E2E_USE_TEST_AUTH_BYPASS === '1'"
     );
     expect(goldenPathSpec).toContain(
       'Golden path requires the dedicated real-auth lane'
+    );
+    expect(goldenPathSpec).toContain(
+      "const signInRoute = '**/api/auth/sign-in/email-otp'"
+    );
+    const routeFetchIndex = goldenPathSpec.indexOf(
+      'response = await route.fetch()'
+    );
+    const approveAppUserIndex = goldenPathSpec.indexOf(
+      'await ensureDbUser(betterAuthUserId)'
+    );
+    const signInFulfillIndex = goldenPathSpec.indexOf(
+      'await route.fulfill({ response, body })'
+    );
+    const navigationArmIndex = goldenPathSpec.indexOf(
+      'const automaticStartNavigationPromise = page.waitForURL('
+    );
+    const claimArmIndex = goldenPathSpec.indexOf(
+      'const claimResponsePromise = page.waitForResponse('
+    );
+    const otpSubmitIndex = goldenPathSpec.indexOf(
+      "pressSequentially('424242')"
+    );
+    const authPreparationIndex = goldenPathSpec.indexOf(
+      'const authPreparationError = await Promise.race(['
+    );
+    const unrouteIndex = goldenPathSpec.indexOf(
+      'await page.unroute(signInRoute)'
+    );
+    expect(routeFetchIndex).toBeGreaterThan(-1);
+    expect(approveAppUserIndex).toBeGreaterThan(routeFetchIndex);
+    expect(signInFulfillIndex).toBeGreaterThan(approveAppUserIndex);
+    expect(navigationArmIndex).toBeGreaterThan(-1);
+    expect(navigationArmIndex).toBeLessThan(otpSubmitIndex);
+    expect(claimArmIndex).toBeGreaterThan(navigationArmIndex);
+    expect(claimArmIndex).toBeLessThan(otpSubmitIndex);
+    expect(authPreparationIndex).toBeGreaterThan(otpSubmitIndex);
+    expect(unrouteIndex).toBeGreaterThan(authPreparationIndex);
+    expect(goldenPathSpec).toContain('authPreparationResult,');
+    expect(goldenPathSpec).toContain(
+      'without racing the start-route auth gate'
+    );
+    expect(goldenPathSpec).toContain(
+      'Better Auth email-OTP request did not reach the preparation barrier'
+    );
+    expect(goldenPathSpec).not.toContain('heldClaimResponsePromise');
+    expect(goldenPathSpec).not.toContain('await page.reload({');
+    expect(goldenPathSpec).not.toContain(
+      "const claimRoute = '**/api/onboarding/claim'"
+    );
+    expect(goldenPathSpec).not.toContain(
+      'body: JSON.stringify({ claimed: 0 })'
+    );
+    expect(goldenPathSpec).not.toContain(
+      'const sessionHandle = await page.waitForFunction('
+    );
+    expect(goldenPathSpec).toContain(
+      'resetAuthStatePreservingOnboardingSession(page.context())'
     );
   });
 
@@ -866,6 +926,25 @@ describe('CI E2E smoke workflow', () => {
 });
 
 describe('CI public lighthouse workflow', () => {
+  it('pins the standalone server and browser to one loopback origin', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const lighthouseJob = getJobBlock(workflow, 'ci-lighthouse-pr');
+    const runStep = getStepBlock(
+      lighthouseJob,
+      'Run Lighthouse CI (public launch thresholds)'
+    );
+    const localOrigin = 'http://localhost:3000';
+
+    expect(runStep).toContain('export HOSTNAME=localhost');
+    expect(runStep).toContain(`export NEXT_PUBLIC_APP_URL=${localOrigin}`);
+    expect(runStep).toContain(`export BETTER_AUTH_URL=${localOrigin}`);
+    expect(runStep).toContain(
+      `export NEXT_PUBLIC_BETTER_AUTH_URL=${localOrigin}`
+    );
+    expect(runStep).toContain(`BASE_URL: ${localOrigin}`);
+    expect(runStep).not.toContain('http://127.0.0.1:3000');
+  });
+
   it('uses seeded isolated Neon fixtures instead of the stable main DB', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const lighthouseJob = getJobBlock(workflow, 'ci-lighthouse-pr');
@@ -929,6 +1008,16 @@ describe('CI public lighthouse workflow', () => {
     expect(lighthouseJob).toContain(
       'tests/e2e/profile-mobile-viewport-stability.spec.ts'
     );
+
+    const failureArtifactStep = getStepBlock(
+      lighthouseJob,
+      'Upload public Lighthouse mobile artifacts on failure'
+    );
+    expect(failureArtifactStep).toContain(
+      'if: ${{ failure() && matrix.shard == 1 }}'
+    );
+    expect(failureArtifactStep).toContain('apps/web/playwright-report/');
+    expect(failureArtifactStep).toContain('apps/web/test-results/');
   });
 
   it('public launch Lighthouse config includes CI Chrome stability flags', () => {

--- a/apps/web/tests/unit/e2e/auth-helper.test.ts
+++ b/apps/web/tests/unit/e2e/auth-helper.test.ts
@@ -1,9 +1,35 @@
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  fillControlledInputUntilEnabled,
   resolveBypassFallbackUserId,
   setTestAuthBypassSession,
 } from '../../helpers/auth';
+
+describe('fillControlledInputUntilEnabled', () => {
+  it('refills when hydration resets the first controlled value', async () => {
+    let value = '';
+    let fills = 0;
+    const input = {
+      fill: vi.fn(async (next: string) => {
+        fills += 1;
+        value = fills === 1 ? '' : next;
+      }),
+      inputValue: () => Promise.resolve(value),
+    } as unknown as Locator;
+    const submit = {
+      isEnabled: () => Promise.resolve(Boolean(value)),
+    } as unknown as Locator;
+
+    await fillControlledInputUntilEnabled(
+      input,
+      submit,
+      'artist@test.jovie.com'
+    );
+
+    expect(input.fill).toHaveBeenCalledTimes(2);
+  });
+});
 
 describe('resolveBypassFallbackUserId', () => {
   it('returns the persisted UUID identity for a persona cookie fallback', () => {

--- a/apps/web/tests/unit/e2e/runtime-automation-bypass.test.ts
+++ b/apps/web/tests/unit/e2e/runtime-automation-bypass.test.ts
@@ -1,0 +1,76 @@
+import type { BrowserContext } from '@playwright/test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  installRuntimeAutomationBypass,
+  ONBOARDING_SESSION_COOKIE_NAME,
+  resetAuthStatePreservingOnboardingSession,
+} from '../../e2e/utils/runtime-automation-bypass';
+
+describe('installRuntimeAutomationBypass', () => {
+  afterEach(() => {
+    delete document.documentElement?.dataset.e2eMode;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('marks an existing document root without constructing an observer', () => {
+    const MutationObserverSpy = vi.fn();
+    vi.stubGlobal('MutationObserver', MutationObserverSpy);
+
+    installRuntimeAutomationBypass();
+
+    expect(document.documentElement.dataset.e2eMode).toBe('1');
+    expect(MutationObserverSpy).not.toHaveBeenCalled();
+  });
+
+  it('marks a document root inserted after init and disconnects its observer', async () => {
+    const originalRoot = document.documentElement;
+    originalRoot.remove();
+    expect(document.documentElement).toBeNull();
+
+    const disconnect = vi.spyOn(MutationObserver.prototype, 'disconnect');
+
+    try {
+      installRuntimeAutomationBypass();
+      expect(disconnect).not.toHaveBeenCalled();
+
+      document.append(originalRoot);
+
+      await vi.waitFor(() => {
+        expect(document.documentElement?.dataset.e2eMode).toBe('1');
+        expect(disconnect).toHaveBeenCalledOnce();
+      });
+    } finally {
+      if (!document.documentElement) document.append(originalRoot);
+    }
+  });
+
+  it('preserves only the signed onboarding cookie while clearing auth state', async () => {
+    const onboardingCookie = {
+      name: ONBOARDING_SESSION_COOKIE_NAME,
+      value: 'session.signature',
+      domain: 'localhost',
+      path: '/',
+    };
+    const clearCookies = vi.fn().mockResolvedValue(undefined);
+    const addCookies = vi.fn().mockResolvedValue(undefined);
+    const context = {
+      cookies: vi.fn().mockResolvedValue([
+        onboardingCookie,
+        {
+          name: 'better-auth.session_token',
+          value: 'auth',
+          domain: 'localhost',
+          path: '/',
+        },
+      ]),
+      clearCookies,
+      addCookies,
+    } as unknown as BrowserContext;
+
+    await resetAuthStatePreservingOnboardingSession(context);
+
+    expect(clearCookies).toHaveBeenCalledOnce();
+    expect(addCookies).toHaveBeenCalledWith([onboardingCookie]);
+  });
+});

--- a/apps/web/tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts
@@ -105,7 +105,8 @@ describe('mounted homepage workspace System B source contract', () => {
     expect(css).toContain('var(--system-b-app-frame-seam)');
     expect(css).toContain('var(--system-b-app-content-surface)');
     expect(css).toContain('var(--color-text-primary-token)');
-    expect(css).toContain('var(--color-text-tertiary-token)');
+    expect(css).toContain('var(--color-text-secondary-token)');
+    expect(css).not.toContain('var(--color-text-tertiary-token)');
     expect(css).toContain('var(--radius-3xl)');
     expect(css).toContain('var(--radius-xl)');
     expect(css).toContain('var(--text-5xl)');

--- a/apps/web/tests/unit/lib/auth/better-auth-provision-hook.test.ts
+++ b/apps/web/tests/unit/lib/auth/better-auth-provision-hook.test.ts
@@ -1,0 +1,169 @@
+import type { BetterAuthOptions } from 'better-auth';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  betterAuth: vi.fn((options: BetterAuthOptions) => ({ options })),
+  provisionAppUser: vi.fn().mockResolvedValue('app-user-id'),
+  captureError: vi.fn().mockResolvedValue(undefined),
+  loggerError: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+vi.mock('@better-auth/oauth-provider', () => ({
+  oauthProvider: vi.fn(() => ({ id: 'oauth-provider' })),
+}));
+vi.mock('better-auth', () => ({ betterAuth: mocks.betterAuth }));
+vi.mock('better-auth/adapters/drizzle', () => ({
+  drizzleAdapter: vi.fn(() => ({ id: 'drizzle-adapter' })),
+}));
+vi.mock('better-auth/next-js', () => ({
+  nextCookies: vi.fn(() => ({ id: 'next-cookies' })),
+}));
+vi.mock('better-auth/plugins', () => ({
+  bearer: vi.fn(() => ({ id: 'bearer' })),
+  emailOTP: vi.fn(() => ({ id: 'email-otp' })),
+  jwt: vi.fn(() => ({ id: 'jwt' })),
+  oneTap: vi.fn(() => ({ id: 'one-tap' })),
+  oneTimeToken: vi.fn(() => ({ id: 'one-time-token' })),
+}));
+vi.mock('@/lib/db', () => ({ db: {} }));
+vi.mock('@/lib/db/schema/better-auth', () => ({
+  baAccounts: {},
+  baJwks: {},
+  baOauthAccessTokens: {},
+  baOauthClients: {},
+  baOauthConsents: {},
+  baOauthRefreshTokens: {},
+  baSessions: {},
+  baUsers: {},
+  baVerifications: {},
+}));
+vi.mock('@/lib/env', () => ({
+  env: {
+    E2E_TEST_MODE: '0',
+    VERCEL_ENV: 'preview',
+    BETTER_AUTH_SECRET: 'unit-test-secret',
+  },
+}));
+vi.mock('@/lib/env-public', () => ({ publicEnv: {} }));
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mocks.captureError,
+}));
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { error: mocks.loggerError },
+}));
+vi.mock('@/lib/auth/apple-client-secret', () => ({
+  generateAppleClientSecret: vi.fn(() => 'apple-secret'),
+}));
+vi.mock('@/lib/auth/provision', () => ({
+  provisionAppUser: mocks.provisionAppUser,
+}));
+vi.mock('@/lib/auth/rate-limit-rules', () => ({
+  AUTH_RATE_LIMIT_RULES: {},
+}));
+vi.mock('@/lib/auth/secondary-storage', () => ({
+  secondaryStorage: {},
+}));
+
+await import('@/lib/auth/better-auth');
+
+function getUserCreatedHook() {
+  const options = mocks.betterAuth.mock.calls[0]?.[0];
+  const hook = options?.databaseHooks?.user?.create?.after;
+  expect(hook).toBeTypeOf('function');
+  return hook!;
+}
+
+describe('Better Auth app-user provisioning hook', () => {
+  beforeEach(() => {
+    mocks.provisionAppUser.mockReset().mockResolvedValue('app-user-id');
+    mocks.captureError.mockClear();
+    mocks.loggerError.mockClear();
+  });
+
+  it('provisions the canonical app user after Better Auth creates an identity', async () => {
+    await getUserCreatedHook()(
+      {
+        id: 'ba-user-123',
+        email: 'artist@example.com',
+        emailVerified: true,
+        name: 'Artist',
+        image: null,
+        createdAt: new Date('2026-07-15T00:00:00Z'),
+        updatedAt: new Date('2026-07-15T00:00:00Z'),
+      },
+      null
+    );
+
+    expect(mocks.provisionAppUser).toHaveBeenCalledExactlyOnceWith({
+      betterAuthUserId: 'ba-user-123',
+      email: 'artist@example.com',
+      emailVerified: true,
+      name: 'Artist',
+    });
+  });
+
+  it('keeps signup fail-open and records an unexpected hook rejection', async () => {
+    const error = new Error('provisioning rejected');
+    mocks.provisionAppUser.mockRejectedValueOnce(error);
+
+    await expect(
+      getUserCreatedHook()(
+        {
+          id: 'ba-user-456',
+          email: 'artist2@example.com',
+          emailVerified: false,
+          name: null,
+          image: null,
+          createdAt: new Date('2026-07-15T00:00:00Z'),
+          updatedAt: new Date('2026-07-15T00:00:00Z'),
+        },
+        null
+      )
+    ).resolves.toBeUndefined();
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      '[auth] provision hook failed',
+      error
+    );
+    expect(mocks.captureError).toHaveBeenCalledWith(
+      'Better Auth provision hook failed',
+      error,
+      {
+        betterAuthUserId: 'ba-user-456',
+        operation: 'databaseHooks.user.create.after',
+      }
+    );
+  });
+
+  it('keeps signup fail-open when failure telemetry also rejects', async () => {
+    const provisioningError = new Error('provisioning rejected');
+    const telemetryError = new Error('telemetry unavailable');
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    mocks.provisionAppUser.mockRejectedValueOnce(provisioningError);
+    mocks.captureError.mockRejectedValueOnce(telemetryError);
+
+    await expect(
+      getUserCreatedHook()(
+        {
+          id: 'ba-user-telemetry-failure',
+          email: 'artist3@example.com',
+          emailVerified: false,
+          name: null,
+          image: null,
+          createdAt: new Date('2026-07-15T00:00:00Z'),
+          updatedAt: new Date('2026-07-15T00:00:00Z'),
+        },
+        null
+      )
+    ).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[auth] provision hook telemetry failed',
+      telemetryError
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -3,7 +3,18 @@ export type CiFailureClass =
   | 'gate_dependency_cache_timeout'
   | 'bounded_source_scan_timeout'
   | 'visual_qa_prune_timestamp_race'
+  | 'golden_path_signup_hydration_reset'
+  | 'golden_path_competing_start_navigation'
+  | 'golden_path_waitlist_gate_before_claim'
+  | 'golden_path_auth_provider_bypassed'
+  | 'golden_path_app_user_provisioning_gap'
   | 'golden_path_smoke_auth_contract'
+  | 'golden_path_stale_runtime_marker'
+  | 'golden_path_stale_onboarding_surface'
+  | 'profile_release_card_content_box_mismatch'
+  | 'profile_mobile_legacy_notifications_route'
+  | 'vercel_build_exceeded_maximum_time'
+  | 'vercel_concurrent_build_queue'
   | 'layout_guard_contract_missing'
   | 'standalone_runtime_launcher_mismatch'
   | 'chat_composer_unsettled_entry_animation'
@@ -83,6 +94,71 @@ const DIAGNOSES: ReadonlyArray<{
       'The ownership preflight could not resolve the canonical GBrain ledger inside its bounded deadline because the requested slug drifted, the CLI exceeded a nested or overall timeout, or the database session was unhealthy.',
     remediation:
       'Read coordination/agent-job-ledger first, preserve the 10s fail-closed ceiling, and use the receipt requested/resolved slug, engine/CLI/MCP latency, timeout tier, lookup health, and DB lock/session signals to repair the lookup path before retrying.',
+  },
+  {
+    failureClass: 'golden_path_signup_hydration_reset',
+    matches: log =>
+      /Golden Path \(PR\)/i.test(log) &&
+      /golden-path\.spec\.ts/i.test(log) &&
+      /Continue with Email/i.test(log) &&
+      /(?:toBeEnabled|element is not enabled|disabled)/i.test(log),
+    rootCause:
+      'React hydration reset the server-rendered controlled email value after the Golden Path filled it, so the Continue with Email button remained disabled.',
+    remediation:
+      'Refill the controlled email input until React retains the exact value and enables submission; keep the behavioral helper covered by a first-fill-reset regression.',
+  },
+  {
+    failureClass: 'golden_path_competing_start_navigation',
+    matches: log =>
+      /(?:Golden Path \(PR\)|golden-path\.spec\.ts)/i.test(log) &&
+      /page\.goto: net::ERR_ABORTED/i.test(log) &&
+      /\/start/i.test(log),
+    rootCause:
+      'The Golden Path issued an explicit /start navigation while the OTP form was still completing its own hard navigation, so one request was deterministically aborted before the authenticated onboarding mount stabilized.',
+    remediation:
+      'Arm the OTP-driven /start navigation and real claim before submitting the code. If the fixture must approve the app user, withhold the sign-in response until that row is ready instead of issuing a competing goto or reload.',
+  },
+  {
+    failureClass: 'golden_path_waitlist_gate_before_claim',
+    matches: log =>
+      /Golden Path: Anonymous Chat -> Signup -> Claim -> Live Profile/i.test(
+        log
+      ) &&
+      /page\.waitForResponse: Timeout \d+ms exceeded/i.test(log) &&
+      /heldClaimResponsePromise/i.test(log),
+    rootCause:
+      'The Golden fixture waited for the first onboarding claim before approving the freshly provisioned app user. The start-route auth gate server-redirected /start to /waitlist first, so useOnboardingClaim unmounted and the awaited request could never occur.',
+    remediation:
+      'Do not rerun the unchanged head. Intercept the Better Auth email-OTP sign-in response, approve the linked app user while withholding that response, then release the response so client navigation reaches the first /start mount and performs the single authoritative claim.',
+  },
+  {
+    failureClass: 'golden_path_auth_provider_bypassed',
+    matches: log =>
+      /Golden Path \(PR\)/i.test(log) &&
+      /export E2E_TEST_MODE=1/i.test(log) &&
+      /export PUBLIC_NOAUTH_SMOKE=1/i.test(log) &&
+      /page\.waitForResponse: Timeout \d+ms exceeded/i.test(log) &&
+      /api\/onboarding\/claim/i.test(log),
+    rootCause:
+      'The loopback no-auth smoke flag forced the /start route to mount signed-out auth defaults during the real-auth Golden Path, so the cookie-backed session never reached useOnboardingClaim and no claim request was sent.',
+    remediation:
+      'Keep the live auth provider enabled when E2E_TEST_MODE arms the real-auth Golden Path while retaining the loopback-only Turnstile bypass; cover the combined flag state in the start-layout regression.',
+  },
+  {
+    failureClass: 'golden_path_app_user_provisioning_gap',
+    matches: log =>
+      /Better Auth app-user provisioning hook did not create a linked users row/i.test(
+        log
+      ) ||
+      (/Golden Path: Anonymous Chat -> Signup -> Claim -> Live Profile/i.test(
+        log
+      ) &&
+        /claimResponse\.status\(\)\)\.toBe\(200\)/i.test(log) &&
+        /Received:[^\n]*401/i.test(log)),
+    rootCause:
+      'The real-auth Golden Path created a valid Better Auth identity, but it did not resolve to a linked app users.id before the onboarding claim. A stale auth merge may have removed databaseHooks.user.create.after, or the claim route may still be reinterpreting the canonical app UUID as a legacy Clerk id.',
+    remediation:
+      'Do not rerun the unchanged head. Restore the idempotent provisionAppUser create hook, use getCachedAuth().userId directly as the app UUID in the claim route, and preserve both the missing-app-user 401 regression and hook-wiring test.',
   },
   {
     failureClass: 'golden_path_smoke_auth_contract',
@@ -190,6 +266,77 @@ const DIAGNOSES: ReadonlyArray<{
       'A downstream migration exhausted its Neon connectivity retries because the shared connection artifact carried credentials that no longer authenticated; run-id-only artifact selection permits this drift on reruns.',
     remediation:
       'Bind the Neon connection artifact producer and every consumer to both github.run_id and github.run_attempt, then fail closed when the exact-attempt artifact is absent instead of retrying stale credentials.',
+  },
+  {
+    failureClass: 'golden_path_stale_runtime_marker',
+    matches: log =>
+      /Golden Path \(PR\)/i.test(log) &&
+      /golden-path\.spec\.ts/i.test(log) &&
+      /Onboarding runtime policy did not finish initializing/i.test(log) &&
+      /data-interaction-ready/i.test(log),
+    rootCause:
+      'The Golden Path waited for removed onboarding-chat marker attributes even though the canonical chat and composer had rendered and were ready for behavioral interaction.',
+    remediation:
+      'Wait for the real chat input and enabled send control after installing the document-scoped automation marker; do not couple the fixture to nonexistent component attributes.',
+  },
+  {
+    failureClass: 'golden_path_stale_onboarding_surface',
+    matches: log =>
+      /Golden Path \(PR\)/i.test(log) &&
+      /golden-path\.spec\.ts/i.test(log) &&
+      /onboarding-form-wrapper/i.test(log) &&
+      /(?:\/start\?handle|waiting for locator|toBeVisible)/i.test(log),
+    rootCause:
+      'The Golden Path still asserted the removed classic onboarding form after the compatibility route redirected the browser to the canonical /start chat surface.',
+    remediation:
+      'Drive the canonical /start anonymous chat, persist deterministic artist and handle tool calls, then verify the real signup claim response instead of retrying the removed form.',
+  },
+  {
+    failureClass: 'profile_mobile_legacy_notifications_route',
+    matches: log =>
+      /profile-mobile-viewport-stability\.spec\.ts/i.test(log) &&
+      /alerts walkthrough focus never shifts the shell/i.test(log) &&
+      /email target should be visible/i.test(log) &&
+      /\[role=["']dialog["']\]\[data-testid=["']profile-mobile-notifications-flow["']\]/i.test(
+        log
+      ) &&
+      /element\(s\) not found/i.test(log),
+    rootCause:
+      'The mobile profile fixture opened the retired /testartist/notifications surface, followed its redirect to the canonical ?mode=subscribe route, then searched the inline flow through an obsolete role=dialog wrapper and silently allowed the missing notifications-page root to fall back.',
+    remediation:
+      'Do not rerun the unchanged head. Exercise /testartist?mode=subscribe directly, require profile-compact-surface as the layout root, and scope interactions to the visible profile-mobile-notifications-flow regardless of overlay or inline presentation. Keep the legacy redirect covered separately.',
+  },
+  {
+    failureClass: 'profile_release_card_content_box_mismatch',
+    matches: log =>
+      /profile-mobile-viewport-stability\.spec\.ts/i.test(log) &&
+      /bento artwork should fill the card width/i.test(log) &&
+      /Expected:\s*>=\s*\d+[\s\S]*Received:\s*\d+/i.test(log),
+    rootCause:
+      'The mobile profile fixture compared an image inside the detailed card padding and artwork border with the outer card width, so stable padded geometry failed deterministically.',
+    remediation:
+      'Compare the rendered image width with its artwork parent content box within the existing two-pixel rendering tolerance; retain the separate outer-card and document-overflow assertions instead of widening the threshold or rerunning.',
+  },
+  {
+    failureClass: 'vercel_build_exceeded_maximum_time',
+    matches: log =>
+      /BUILD_EXCEEDED_MAXIMUM_TIME/i.test(log) &&
+      /(?:Vercel|deployment|deploy)/i.test(log),
+    rootCause:
+      'A Vercel source deployment occupied a concurrent-build slot until it exceeded the platform build-time ceiling, starving accepted prebuilt PR deployments behind it.',
+    remediation:
+      'Do not rerun queued PR previews. Inspect the slot-holding deployment, cancel it only when ownership proves it obsolete, suppress irrelevant main deploys, and restore a runtime-closed prebuilt artifact so staging does not force another source build.',
+  },
+  {
+    failureClass: 'vercel_concurrent_build_queue',
+    matches: log =>
+      /(?:Current PR preview deployment state:\s*QUEUED|PR preview is QUEUED after readiness wait|isInConcurrentBuildsQueue[^\n]*(?:true|1))/i.test(
+        log
+      ),
+    rootCause:
+      'Vercel accepted the exact-head deployment, but project concurrent-build capacity was occupied and the deployment remained in the concurrent-build queue past the bounded readiness wait.',
+    remediation:
+      'Do not rerun the unchanged head or create a duplicate deployment. Inspect the accepted deployment and current slot holder, cancel only provably obsolete work, and retry through normal CI only after a new head or confirmed capacity recovery.',
   },
   {
     failureClass: 'neon_concurrency_key_collision',

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -88,6 +88,178 @@ describe('diagnoseCiFailure', () => {
     expect(diagnosis.remediation).toContain('timeout tier');
   });
 
+  it('diagnoses a Golden Path email value erased by hydration', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Golden Path (PR)
+      [chromium] tests/e2e/golden-path.spec.ts
+      Continue with Email
+      expect(locator).toBeEnabled() failed: element is not enabled
+    `);
+
+    expect(diagnosis.failureClass).toBe('golden_path_signup_hydration_reset');
+    expect(diagnosis.rootCause).toContain('hydration');
+    expect(diagnosis.remediation).toContain('Refill');
+  });
+
+  it('diagnoses the real-auth Golden Path mounted with signed-out defaults', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Golden Path (PR)
+      export E2E_TEST_MODE=1
+      export PUBLIC_NOAUTH_SMOKE=1
+      TimeoutError: page.waitForResponse: Timeout 30000ms exceeded
+      waiting for POST /api/onboarding/claim
+    `);
+
+    expect(diagnosis.failureClass).toBe('golden_path_auth_provider_bypassed');
+    expect(diagnosis.rootCause).toContain('signed-out auth defaults');
+    expect(diagnosis.remediation).toContain('live auth provider');
+  });
+
+  it('diagnoses the pending-user waitlist deadlock before the first claim', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Golden Path: Anonymous Chat -> Signup -> Claim -> Live Profile
+      TimeoutError: page.waitForResponse: Timeout 30000ms exceeded while waiting for event "response"
+      > 309 | const heldClaimResponsePromise = page.waitForResponse(
+      at createFreshUserOnce (tests/e2e/golden-path.spec.ts:309:43)
+    `);
+
+    expect(diagnosis.failureClass).toBe(
+      'golden_path_waitlist_gate_before_claim'
+    );
+    expect(diagnosis.rootCause).toContain('/waitlist');
+    expect(diagnosis.remediation).toContain('Do not rerun');
+    expect(diagnosis.remediation).toContain('withholding that response');
+  });
+
+  it('diagnoses a Golden Path app-user provisioning gap instead of rerunning', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Golden Path: Anonymous Chat -> Signup -> Claim -> Live Profile
+      Expected: 200
+      Received: 401
+      > 357 | expect(claimResponse.status()).toBe(200);
+      at createFreshUserOnce (tests/e2e/golden-path.spec.ts:357:34)
+    `);
+
+    expect(diagnosis.failureClass).toBe(
+      'golden_path_app_user_provisioning_gap'
+    );
+    expect(diagnosis.rootCause).toContain('linked app users.id');
+    expect(diagnosis.remediation).toContain('Do not rerun');
+    expect(diagnosis.remediation).toContain('provisionAppUser');
+  });
+
+  it('diagnoses the explicit provisioning barrier when the hook is removed', () => {
+    expect(
+      diagnoseCiFailure(
+        'Better Auth app-user provisioning hook did not create a linked users row'
+      ).failureClass
+    ).toBe('golden_path_app_user_provisioning_gap');
+  });
+
+  it('diagnoses competing OTP and fixture navigation to /start', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Golden Path (PR)
+      tests/e2e/golden-path.spec.ts
+      Error: page.goto: net::ERR_ABORTED at http://localhost:3100/start
+    `);
+
+    expect(diagnosis.failureClass).toBe(
+      'golden_path_competing_start_navigation'
+    );
+    expect(diagnosis.rootCause).toContain('OTP form');
+    expect(diagnosis.remediation).toContain('withhold the sign-in response');
+  });
+
+  it('diagnoses the removed classic onboarding fixture on canonical /start', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Golden Path (PR)
+      [chromium] tests/e2e/golden-path.spec.ts
+      page URL: http://localhost:3100/start?handle=tmrlisyuuem7u0e
+      expect(locator('[data-testid="onboarding-form-wrapper"]')).toBeVisible()
+      waiting for locator('[data-testid="onboarding-form-wrapper"]')
+    `);
+
+    expect(diagnosis.failureClass).toBe('golden_path_stale_onboarding_surface');
+    expect(diagnosis.rootCause).toContain('canonical /start');
+    expect(diagnosis.remediation).toContain('anonymous chat');
+  });
+
+  it('diagnoses a stale Golden Path runtime marker assertion', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Golden Path (PR)
+      [chromium] tests/e2e/golden-path.spec.ts:335:5
+      Onboarding runtime policy did not finish initializing
+      expect(locator).toHaveAttribute('data-interaction-ready', 'true')
+      Expected: "true"
+      Received: null
+    `);
+
+    expect(diagnosis.failureClass).toBe('golden_path_stale_runtime_marker');
+    expect(diagnosis.rootCause).toContain('marker attributes');
+    expect(diagnosis.remediation).toContain('real chat input');
+  });
+
+  it('diagnoses the padded profile artwork assertion against the wrong box', () => {
+    const diagnosis = diagnoseCiFailure(`
+      [chromium] tests/e2e/profile-mobile-viewport-stability.spec.ts:636:9
+      Error: iPhone SE 2/3 bento artwork should fill the card width
+      Expected: >= 222
+      Received: 196
+    `);
+
+    expect(diagnosis.failureClass).toBe(
+      'profile_release_card_content_box_mismatch'
+    );
+    expect(diagnosis.rootCause).toContain('outer card width');
+    expect(diagnosis.remediation).toContain('artwork parent content box');
+    expect(diagnosis.remediation).toContain('instead of widening');
+  });
+
+  it('diagnoses the stale notifications-page dialog fixture after its canonical redirect', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Lighthouse (public routes PR) (1)
+      [chromium] tests/e2e/profile-mobile-viewport-stability.spec.ts:820:9
+      Public Profile Mobile Viewport Stability @smoke @critical › iPhone SE 2/3 alerts walkthrough focus never shifts the shell
+      Error: iPhone SE 2/3 email target should be visible
+      Locator: locator('[role="dialog"][data-testid="profile-mobile-notifications-flow"]').getByTestId('mobile-email-input')
+      Error: element(s) not found
+    `);
+
+    expect(diagnosis.failureClass).toBe(
+      'profile_mobile_legacy_notifications_route'
+    );
+    expect(diagnosis.rootCause).toContain('followed its redirect');
+    expect(diagnosis.remediation).toContain('Do not rerun');
+    expect(diagnosis.remediation).toContain('profile-compact-surface');
+    expect(diagnosis.remediation).toContain(
+      'legacy redirect covered separately'
+    );
+  });
+
+  it('diagnoses an accepted PR preview stuck in Vercel concurrency', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Vercel accepted https://jovie-example.vercel.app
+      Current PR preview deployment state: QUEUED
+      ::error::PR preview is QUEUED after readiness wait (status 0)
+    `);
+
+    expect(diagnosis.failureClass).toBe('vercel_concurrent_build_queue');
+    expect(diagnosis.rootCause).toContain('concurrent-build capacity');
+    expect(diagnosis.remediation).toContain('Do not rerun the unchanged head');
+    expect(diagnosis.remediation).toContain('provably obsolete');
+  });
+
+  it('diagnoses a Vercel source build holding capacity until timeout', () => {
+    const diagnosis = diagnoseCiFailure(`
+      Vercel deployment dpl_example failed
+      errorCode=BUILD_EXCEEDED_MAXIMUM_TIME
+    `);
+
+    expect(diagnosis.failureClass).toBe('vercel_build_exceeded_maximum_time');
+    expect(diagnosis.rootCause).toContain('source deployment');
+    expect(diagnosis.remediation).toContain('runtime-closed prebuilt artifact');
+  });
+
   it('diagnoses deterministic Better Auth OTP rejection in the bypass smoke lane', () => {
     const diagnosis = diagnoseCiFailure(`
       E2E Smoke (PR Fast Feedback)


### PR DESCRIPTION
## Root cause

The authoritative Golden Path job exposed two independent deterministic fixture failures on current main:

1. **Broken test synchronization — hydration reset.** The standalone signup form could hydrate after the first email fill, erase the controlled value, and leave `Continue with Email` disabled. This is `golden_path_signup_hydration_reset`, not flaky CI.
2. **Broken fixture / route drift.** The spec retried the removed classic `/onboarding` form while the compatibility route correctly served the canonical `/start` onboarding chat. This is `golden_path_stale_onboarding_surface`, not a runner or dependency failure.

Primary review also found and blocked a first implementation: the DOM automation marker is client-only, while the first anonymous `/api/chat` request is server-gated by Turnstile. The final patch explicitly enables the existing `PUBLIC_NOAUTH_SMOKE` contract only in the dedicated loopback Golden server. The handler separately requires a loopback hostname and remains fail-closed in preview/production and for spoofed forwarded hosts.

## Smallest safe fix

- Refill the signup email until React retains the exact value and enables submit.
- Exercise the canonical `/start` anonymous chat, persistence, Better Auth signup, and real claim response.
- Defer the browser marker until `documentElement` exists.
- Enable deterministic chat fallback and the existing loopback-only no-auth smoke contract only in the dedicated Golden job.
- Teach Gem to diagnose both exact failure classes and route this repair to focused deterministic coverage.

No required check is bypassed. The live secret-backed Golden Path lane is authoritative and required before merge.

## Local verification

- Onboarding handler + workflow + auth + runtime regressions: 61/61 passed.
- Gem diagnosis + affected-selector regressions: 80/80 passed.
- Playwright discovery compiled and listed the canonical Golden test.
- Web typecheck passed on Node 22.23.1.
- Biome passed.
- CI harness manifest passed.
- Exact affected-test plan is `selected` and excludes the live Playwright spec locally.
- Actionlint introduced no new findings versus current main (same baseline output).
- Signed head: `56dd1febe4297abaf7e6769cdc96fee6fbf87cbb`.

bug-to-test: satisfied

