### PR TITLE
fix(agent): accelerate gbrain ownership preflight

### DIFF
--- a/scripts/agent/PREFLIGHT.md
+++ b/scripts/agent/PREFLIGHT.md
@@ -24,8 +24,9 @@ The ownership gate is deterministic and hard-budgeted — a semantic query can
 never hang the run (the previously observed failure mode was a 90s hybrid
 query hang):
 
-1. **ledger** — `gbrain get agent-job-ledger` (canonical ownership surface,
-   one deterministic read, 3s cap)
+1. **ledger** — read `coordination/agent-job-ledger` through GBrain's declared
+   public engine exports in one process (7s cap); source/compiled installs
+   without those exports fall back to `gbrain get` (3s cap)
 2. **keyword** — `gbrain search "<terms>" --limit 5` (keyword index, 5s cap)
 3. **semantic** — `gbrain query "<terms>"` ONLY when keyword came back empty,
    capped to whatever remains of the budget
@@ -36,6 +37,14 @@ source (`ledger` / `keyword` / `semantic`) is recorded in
 `receipt.ownership.source`; a budget-exhausted lookup records
 `gbrain-timeout`. Unreachable/empty GBrain keeps the existing policy:
 soft by default, hard block with `AGENT_PREFLIGHT_REQUIRE_GBRAIN=1`.
+
+The ownership receipt also records requested/resolved slug, engine/CLI/MCP
+latency when available, timeout tier, and lookup health. Nullable DB lock and
+session signal fields only report signatures seen in command stderr; `null`
+means no signal was observed, not that a database health probe passed. This
+lets Gem classify
+`gbrain_ownership_preflight_latency_or_slug_drift` without scraping free-form
+logs or exposing database details.
 
 ## gstack: pinned version, out-of-band upgrades (JOV-4184)
 
@@ -126,5 +135,5 @@ Exit `0` = `verdict: go`. Exit `1` = `verdict: blocked`. Exit `2` = script error
 | `AGENT_PREFLIGHT_REQUIRE_GSTACK=1` | Missing gstack bin → hard block |
 | `AGENT_PREFLIGHT_TASK` | Same as `--task` |
 | `AGENT_PREFLIGHT_OWNERSHIP_BUDGET_MS` | Ownership hard ceiling (default 10000) |
-| `AGENT_PREFLIGHT_LEDGER_PAGE` | Ledger page slug (default `agent-job-ledger`) |
+| `AGENT_PREFLIGHT_LEDGER_PAGE` | Ledger page slug (default `coordination/agent-job-ledger`) |
 | `GSTACK_STATE_DIR` | Override `~/.gstack` for the cached update-check read |

--- a/scripts/agent/preflight-lib.mjs
+++ b/scripts/agent/preflight-lib.mjs
@@ -82,6 +82,7 @@ export function evaluateWorktree(input) {
  *   gbrainOutput: string | null,
  *   source?: 'ledger' | 'keyword' | 'semantic' | 'gbrain' | null,
  *   timedOut?: boolean,
+ *   diagnostics?: object,
  *   requireGbrain?: boolean,
  *   task?: string | null,
  *   ms?: number,
@@ -107,6 +108,7 @@ export function evaluateOwnership(input) {
         source: 'gbrain-missing',
         reachable: false,
         ms: input.ms ?? 0,
+        diagnostics: input.diagnostics ?? null,
       },
       blockers,
     };
@@ -130,6 +132,7 @@ export function evaluateOwnership(input) {
         source: timedOut ? 'gbrain-timeout' : 'gbrain-empty',
         reachable: false,
         ms: input.ms ?? 0,
+        diagnostics: input.diagnostics ?? null,
       },
       blockers,
     };
@@ -143,6 +146,7 @@ export function evaluateOwnership(input) {
       source: input.source || 'gbrain',
       reachable: true,
       ms: input.ms ?? 0,
+      diagnostics: input.diagnostics ?? null,
     },
     blockers,
   };

--- a/scripts/agent/preflight.mjs
+++ b/scripts/agent/preflight.mjs
@@ -4,9 +4,9 @@
  * Collects environment facts, evaluates via preflight-lib, prints one JSON receipt.
  */
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import {
   assembleReceipt,
@@ -58,8 +58,8 @@ function run(cmd, args, opts = {}) {
   };
 }
 
-function which(bin) {
-  const r = run('bash', ['-lc', `command -v ${bin}`], { timeout: 3000 });
+function which(bin, timeout = 3_000) {
+  const r = run('bash', ['-c', `command -v ${bin}`], { timeout });
   if (r.status !== 0) return null;
   return r.stdout.trim() || null;
 }
@@ -115,7 +115,71 @@ const OWNERSHIP_BUDGET_MS = Math.max(
   Number(process.env.AGENT_PREFLIGHT_OWNERSHIP_BUDGET_MS) || 10_000
 );
 const OWNERSHIP_LEDGER_PAGE =
-  process.env.AGENT_PREFLIGHT_LEDGER_PAGE || 'agent-job-ledger';
+  process.env.AGENT_PREFLIGHT_LEDGER_PAGE || 'coordination/agent-job-ledger';
+
+const PAGE_NOT_FOUND = /(?:page[_ -]?not[_ -]?found|no page[^\n]*slug)/i;
+
+// `gbrain get` pays CLI bootstrap, migration/config probes, and shutdown drain
+// on every invocation. GBrain's public package exports provide a bounded,
+// read-only one-process path that connects once and reads the canonical page.
+// This is intentionally discovered from the installed gbrain binary; when a
+// compiled/no-source install does not expose the public package, the existing
+// CLI path remains the fallback.
+const GBRAIN_ENGINE_READ_SOURCE = `
+import { loadConfig, toEngineConfig } from 'gbrain/config';
+import { createEngine } from 'gbrain/engine-factory';
+const started = Date.now();
+const config = loadConfig();
+if (!config) throw new Error('gbrain_config_missing');
+const engineConfig = toEngineConfig(config);
+const engine = await createEngine(engineConfig);
+const created = Date.now();
+try {
+  await engine.connect(engineConfig);
+  const connected = Date.now();
+  const page = await engine.getPage(process.argv[1]);
+  const read = Date.now();
+  process.stdout.write(JSON.stringify({
+    found: Boolean(page),
+    create_ms: created - started,
+    connect_ms: connected - created,
+    read_ms: read - connected,
+    total_ms: read - started,
+  }));
+} finally {
+  await engine.disconnect();
+}
+`;
+
+function findGbrainPackageRoot(gbrain) {
+  let current;
+  try {
+    current = dirname(realpathSync(gbrain));
+  } catch {
+    return null;
+  }
+  for (let i = 0; i < 5; i++) {
+    const manifest = join(current, 'package.json');
+    if (existsSync(manifest)) {
+      try {
+        const pkg = JSON.parse(readFileSync(manifest, 'utf8'));
+        if (
+          pkg.name === 'gbrain' &&
+          pkg.exports?.['./config'] &&
+          pkg.exports?.['./engine-factory']
+        ) {
+          return current;
+        }
+      } catch {
+        return null;
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
 
 function collectOwnership(task) {
   const start = nowMs();
@@ -133,44 +197,198 @@ function collectOwnership(task) {
 
   const deadline = start + OWNERSHIP_BUDGET_MS;
   const remaining = () => Math.max(0, deadline - nowMs());
-  const finish = (out, source, timedOut = false) =>
-    evaluateOwnership({
+  const attempts = [];
+  const finish = (out, source, failureReason = null) => {
+    const elapsed = nowMs() - start;
+    const timeoutAttempt = [...attempts]
+      .reverse()
+      .find(attempt => attempt.outcome === 'timeout');
+    const resolvedSlug = source === 'ledger' ? OWNERSHIP_LEDGER_PAGE : null;
+    const degradedAttempt = attempts.find(attempt =>
+      ['timeout', 'page_not_found', 'error'].includes(attempt.outcome)
+    );
+    const health = out
+      ? degradedAttempt
+        ? `degraded_${degradedAttempt.outcome}`
+        : 'healthy'
+      : failureReason === 'page_not_found'
+        ? 'page_not_found'
+        : failureReason === 'timeout'
+          ? 'timeout'
+          : 'empty';
+    const diagnostics = {
+      failure_class:
+        health === 'healthy'
+          ? null
+          : 'gbrain_ownership_preflight_latency_or_slug_drift',
+      requested_slug: OWNERSHIP_LEDGER_PAGE,
+      resolved_slug: resolvedSlug,
+      transport:
+        attempts.find(attempt => attempt.outcome === 'success')?.transport ??
+        'cli',
+      cli_ms:
+        attempts
+          .filter(attempt => attempt.transport === 'cli')
+          .reduce((sum, attempt) => sum + attempt.ms, 0) || null,
+      mcp_ms: null,
+      engine_ms:
+        attempts
+          .filter(attempt => attempt.transport === 'engine')
+          .reduce((sum, attempt) => sum + attempt.ms, 0) || null,
+      timeout_tier: timeoutAttempt?.timeout_tier ?? null,
+      lookup_health: health,
+      db_lock_signal_detected: attempts.some(
+        attempt => attempt.db_lock_signal_detected === true
+      )
+        ? true
+        : null,
+      session_signal_detected: attempts.some(
+        attempt => attempt.session_signal_detected === true
+      )
+        ? true
+        : null,
+      attempts,
+    };
+    return evaluateOwnership({
       gbrainOnPath: true,
       gbrainOutput: out,
       source,
-      timedOut,
+      timedOut: failureReason === 'timeout',
+      diagnostics,
       requireGbrain,
       task,
-      ms: nowMs() - start,
+      ms: elapsed,
     });
-
-  let timedOut = false;
-  const step = (args, cap) => {
-    const budget = Math.min(cap, remaining());
-    if (budget <= 0) return '';
-    const r = run(gbrain, args, { timeout: budget });
-    if (r.error) timedOut = true;
-    return (r.stdout || '').trim();
   };
 
-  // 1. FAST PATH — the agent-job-ledger page is the canonical ownership
+  const step = (name, args, cap) => {
+    const budget = Math.min(cap, remaining());
+    if (budget <= 0) {
+      attempts.push({
+        step: name,
+        ms: 0,
+        outcome: 'timeout',
+        timeout_tier: 'overall',
+        db_lock_signal_detected: null,
+        session_signal_detected: null,
+      });
+      return { output: '', outcome: 'timeout' };
+    }
+    const stepStart = nowMs();
+    const r = run(gbrain, args, { timeout: budget });
+    const combined = `${r.stdout || ''}\n${r.stderr || ''}`;
+    const output = (r.stdout || '').trim();
+    const timedOut = r.error?.code === 'ETIMEDOUT';
+    const pageNotFound = !timedOut && PAGE_NOT_FOUND.test(combined);
+    const outcome = timedOut
+      ? 'timeout'
+      : pageNotFound
+        ? 'page_not_found'
+        : output
+          ? 'success'
+          : 'empty';
+    attempts.push({
+      step: name,
+      transport: 'cli',
+      ms: nowMs() - stepStart,
+      outcome,
+      timeout_tier: timedOut
+        ? budget < cap
+          ? 'overall'
+          : `${name}_step`
+        : null,
+      db_lock_signal_detected:
+        /(?:database|db)[^\n]{0,40}lock|advisory lock/i.test(combined) || null,
+      session_signal_detected:
+        /(?:stale|blocked|waiting)[^\n]{0,40}session/i.test(combined) || null,
+    });
+    return { output: pageNotFound ? '' : output, outcome };
+  };
+
+  const packageRoot = findGbrainPackageRoot(gbrain);
+  const bunBudget = Math.min(1_000, remaining());
+  const bun = packageRoot && bunBudget > 0 ? which('bun', bunBudget) : null;
+  if (packageRoot && bun) {
+    const budget = Math.min(7_000, remaining());
+    const engineStart = nowMs();
+    const r = run(
+      bun,
+      ['-e', GBRAIN_ENGINE_READ_SOURCE, OWNERSHIP_LEDGER_PAGE],
+      { timeout: budget, cwd: packageRoot }
+    );
+    const ms = nowMs() - engineStart;
+    const timedOut = r.error?.code === 'ETIMEDOUT';
+    let result = null;
+    if (!timedOut && r.status === 0) {
+      try {
+        result = JSON.parse(r.stdout.trim());
+      } catch {
+        result = null;
+      }
+    }
+    const outcome = timedOut
+      ? 'timeout'
+      : result?.found === true
+        ? 'success'
+        : result?.found === false
+          ? 'page_not_found'
+          : 'error';
+    attempts.push({
+      step: 'ledger',
+      transport: 'engine',
+      ms,
+      outcome,
+      timeout_tier: timedOut
+        ? budget < 7_000
+          ? 'overall'
+          : 'ledger_step'
+        : null,
+      db_lock_signal_detected:
+        /(?:database|db)[^\n]{0,40}lock|advisory lock/i.test(r.stderr || '') ||
+        null,
+      session_signal_detected:
+        /(?:stale|blocked|waiting)[^\n]{0,40}session/i.test(r.stderr || '') ||
+        null,
+    });
+    if (outcome === 'success') {
+      return finish('canonical ledger available', 'ledger');
+    }
+    // A timed-out engine read has already consumed most/all of the gate. A
+    // cold CLI retry cannot fit its remaining budget and would only add load.
+    if (outcome === 'timeout') return finish('', null, 'timeout');
+  }
+
+  // 1. FAST PATH — the canonical ledger page is the ownership
   //    surface: one deterministic read, no ranking, no embedding.
-  const ledger = step(['get', OWNERSHIP_LEDGER_PAGE], 3_000);
-  if (ledger) return finish(ledger, 'ledger');
+  const priorLedgerAttempt = attempts.find(
+    attempt => attempt.step === 'ledger'
+  );
+  const ledger =
+    priorLedgerAttempt?.outcome === 'page_not_found'
+      ? { output: '', outcome: attempts[0]?.outcome ?? 'empty' }
+      : step('ledger', ['get', OWNERSHIP_LEDGER_PAGE], 3_000);
+  if (ledger.outcome === 'success') return finish(ledger.output, 'ledger');
 
   // 2. Keyword index — deterministic search over current claims/priorities.
   const queryText = task
     ? `agent ownership current claims priorities: ${task}`
     : 'agent org chart ownership coordination';
-  const keyword = step(['search', queryText, '--limit', '5'], 5_000);
-  if (keyword) return finish(keyword, 'keyword');
+  const keyword = step('keyword', ['search', queryText, '--limit', '5'], 5_000);
+  if (keyword.outcome === 'success') return finish(keyword.output, 'keyword');
 
   // 3. Semantic/hybrid query — ONLY when keyword came back empty, and only
   //    inside whatever budget is left (never past the 10s hard ceiling).
-  const semantic = step(['query', queryText], remaining());
-  if (semantic) return finish(semantic, 'semantic');
+  const semantic = step('semantic', ['query', queryText], OWNERSHIP_BUDGET_MS);
+  if (semantic.outcome === 'success') {
+    return finish(semantic.output, 'semantic');
+  }
 
-  return finish('', null, timedOut);
+  const failureReason = attempts.some(attempt => attempt.outcome === 'timeout')
+    ? 'timeout'
+    : ledger.outcome === 'page_not_found'
+      ? 'page_not_found'
+      : 'empty';
+  return finish('', null, failureReason);
 }
 
 function findGstackBin(repoRoot) {

--- a/scripts/agent/preflight.test.mjs
+++ b/scripts/agent/preflight.test.mjs
@@ -5,7 +5,9 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -402,13 +404,15 @@ function installFakeGbrain(dir, script) {
   return bin;
 }
 
-test('CLI: ownership fast path reads the agent-job-ledger page first', () => {
+test('CLI: ownership fast path reads the canonical ledger slug and short-circuits', () => {
   const dir = mkdtempSync(join(tmpdir(), 'pf-ledger-'));
   try {
     makeGitRepo(dir);
+    const calls = join(dir, 'calls.log');
     const bin = installFakeGbrain(
       dir,
-      `if [ "$1" = "get" ] && [ "$2" = "agent-job-ledger" ]; then
+      `echo "$*" >> "${calls}"
+if [ "$1" = "get" ] && [ "$2" = "coordination/agent-job-ledger" ]; then
   echo "ledger: eve owns triage"
   exit 0
 fi
@@ -421,6 +425,141 @@ exit 1`
     const receipt = JSON.parse(res.stdout.trim().split('\n').pop());
     assert.equal(receipt.ownership.source, 'ledger');
     assert.equal(receipt.ownership.reachable, true);
+    assert.equal(
+      readFileSync(calls, 'utf8').trim(),
+      'get coordination/agent-job-ledger'
+    );
+    assert.equal(
+      receipt.ownership.diagnostics.requested_slug,
+      'coordination/agent-job-ledger'
+    );
+    assert.equal(
+      receipt.ownership.diagnostics.resolved_slug,
+      'coordination/agent-job-ledger'
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI: page_not_found is distinct from timeout and falls back to keyword', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pf-page-missing-'));
+  try {
+    makeGitRepo(dir);
+    const bin = installFakeGbrain(
+      dir,
+      `if [ "$1" = "get" ]; then echo "page_not_found: $2" >&2; exit 1; fi
+if [ "$1" = "search" ]; then echo "keyword owner context"; exit 0; fi
+exit 1`
+    );
+    const res = runPreflight(dir, {
+      PATH: `${bin}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${dirname(process.execPath)}`,
+    });
+    const receipt = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.equal(receipt.ownership.source, 'keyword');
+    assert.equal(
+      receipt.ownership.diagnostics.failure_class,
+      'gbrain_ownership_preflight_latency_or_slug_drift'
+    );
+    assert.equal(
+      receipt.ownership.diagnostics.lookup_health,
+      'degraded_page_not_found'
+    );
+    assert.equal(receipt.ownership.diagnostics.db_lock_signal_detected, null);
+    assert.equal(receipt.ownership.diagnostics.session_signal_detected, null);
+    assert.equal(receipt.ownership.diagnostics.timeout_tier, null);
+    assert.equal(
+      receipt.ownership.diagnostics.attempts[0].outcome,
+      'page_not_found'
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI: diagnostics distinguish nested step timeout from overall deadline', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pf-timeout-tiers-'));
+  try {
+    makeGitRepo(dir);
+    const bin = installFakeGbrain(
+      dir,
+      `if [ "$1" = "get" ]; then sleep 30; fi
+if [ "$1" = "search" ]; then echo "fallback owner"; exit 0; fi
+exit 1`
+    );
+    const nested = runPreflight(dir, {
+      AGENT_PREFLIGHT_OWNERSHIP_BUDGET_MS: '4500',
+      PATH: `${bin}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${dirname(process.execPath)}`,
+    });
+    const nestedReceipt = JSON.parse(nested.stdout.trim().split('\n').pop());
+    assert.equal(nestedReceipt.ownership.source, 'keyword');
+    assert.equal(
+      nestedReceipt.ownership.diagnostics.attempts[0].timeout_tier,
+      'ledger_step'
+    );
+
+    const overallDir = join(dir, 'overall');
+    const overallBin = installFakeGbrain(
+      overallDir,
+      `if [ "$1" = "get" ]; then exit 0; fi
+if [ "$1" = "search" ]; then sleep 30; fi
+exit 1`
+    );
+    const overall = runPreflight(dir, {
+      AGENT_PREFLIGHT_OWNERSHIP_BUDGET_MS: '1500',
+      PATH: `${overallBin}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${dirname(process.execPath)}`,
+    });
+    const overallReceipt = JSON.parse(overall.stdout.trim().split('\n').pop());
+    assert.equal(overallReceipt.ownership.source, 'gbrain-timeout');
+    assert.equal(overallReceipt.ownership.diagnostics.timeout_tier, 'overall');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI: supported one-process gbrain engine read wins before cold CLI', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pf-engine-'));
+  try {
+    makeGitRepo(dir);
+    const packageRoot = join(dir, 'gbrain-package');
+    const packageSrc = join(packageRoot, 'src');
+    const bin = join(dir, 'fake-bin');
+    mkdirSync(packageSrc, { recursive: true });
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(
+      join(packageRoot, 'package.json'),
+      JSON.stringify({
+        name: 'gbrain',
+        exports: {
+          './config': './src/config.ts',
+          './engine-factory': './src/engine-factory.ts',
+        },
+      })
+    );
+    writeFileSync(
+      join(packageSrc, 'cli.ts'),
+      '#!/usr/bin/env bash\necho COLD_CLI_SHOULD_NOT_RUN >&2\nexit 1\n'
+    );
+    chmodSync(join(packageSrc, 'cli.ts'), 0o755);
+    symlinkSync(join(packageSrc, 'cli.ts'), join(bin, 'gbrain'));
+    const calls = join(dir, 'bun-calls.log');
+    writeFileSync(
+      join(bin, 'bun'),
+      `#!/usr/bin/env bash
+echo "$*" >> "${calls}"
+echo '{"found":true,"create_ms":1,"connect_ms":3,"read_ms":1,"total_ms":5}'
+`
+    );
+    chmodSync(join(bin, 'bun'), 0o755);
+
+    const res = runPreflight(dir, {
+      PATH: `${bin}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${dirname(process.execPath)}`,
+    });
+    const receipt = JSON.parse(res.stdout.trim().split('\n').pop());
+    assert.equal(receipt.ownership.source, 'ledger');
+    assert.equal(receipt.ownership.diagnostics.engine_ms > 0, true);
+    assert.equal(receipt.ownership.diagnostics.cli_ms, null);
+    assert.match(readFileSync(calls, 'utf8'), /coordination\/agent-job-ledger/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -5,6 +5,7 @@ export type CiFailureClass =
   | 'test_fixture_import_timeout'
   | 'runner_process_exhaustion'
   | 'runner_host_pressure'
+  | 'gbrain_ownership_preflight_latency_or_slug_drift'
   | 'unknown';
 
 export interface CiFailureDiagnosis {
@@ -19,6 +20,15 @@ const DIAGNOSES: ReadonlyArray<{
   readonly rootCause: string;
   readonly remediation: string;
 }> = [
+  {
+    failureClass: 'gbrain_ownership_preflight_latency_or_slug_drift',
+    matches: log =>
+      /gbrain_ownership_preflight_latency_or_slug_drift/i.test(log),
+    rootCause:
+      'The ownership preflight could not resolve the canonical GBrain ledger inside its bounded deadline because the requested slug drifted, the CLI exceeded a nested or overall timeout, or the database session was unhealthy.',
+    remediation:
+      'Read coordination/agent-job-ledger first, preserve the 10s fail-closed ceiling, and use the receipt requested/resolved slug, engine/CLI/MCP latency, timeout tier, lookup health, and DB lock/session signals to repair the lookup path before retrying.',
+  },
   {
     failureClass: 'golden_path_smoke_auth_contract',
     matches: log =>

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { diagnoseCiFailure } from '../../jobs/ci-failure-diagnosis';
 
 describe('diagnoseCiFailure', () => {
+  it('diagnoses ownership preflight slug or latency drift from its structured receipt', () => {
+    const diagnosis = diagnoseCiFailure(`
+      {"failure_class":"gbrain_ownership_preflight_latency_or_slug_drift","requested_slug":"agent-job-ledger","resolved_slug":null,"engine_ms":3004,"cli_ms":null,"mcp_ms":null,"timeout_tier":"ledger_step","lookup_health":"timeout","db_lock_signal_detected":true,"session_signal_detected":null}
+    `);
+
+    expect(diagnosis.failureClass).toBe(
+      'gbrain_ownership_preflight_latency_or_slug_drift'
+    );
+    expect(diagnosis.remediation).toContain('coordination/agent-job-ledger');
+    expect(diagnosis.remediation).toContain('engine/CLI/MCP latency');
+    expect(diagnosis.remediation).toContain('timeout tier');
+  });
+
   it('diagnoses deterministic Better Auth OTP rejection in the bypass smoke lane', () => {
     const diagnosis = diagnoseCiFailure(`
       E2E Smoke (PR Fast Feedback)


### PR DESCRIPTION
## Root cause

The ownership preflight requested the non-canonical `agent-job-ledger` slug. That miss triggered multiple cold GBrain CLI processes, while even a successful canonical CLI read took 18 seconds and could not fit the gate's 10-second ceiling. The collector also discarded exit/stderr distinctions, so `page_not_found` and nested/overall timeouts were indistinguishable.

## Fix

- read canonical `coordination/agent-job-ledger` first
- use GBrain's declared public config/engine exports in one bounded process (7 seconds nested under the existing 10-second overall deadline)
- short-circuit fallback after canonical success; retain bounded CLI fallback for installs without public package sources
- emit privacy-safe lookup diagnostics and a deterministic Gem failure class
- keep DB lock/session signals nullable; they are log signatures, not health probes

## Verification

- `node --test scripts/agent/preflight.test.mjs` — 29/29
- `pnpm exec vitest run --config scripts/vitest.config.mts scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts` — 9/9
- Biome targeted paths — clean
- `git diff --check` — clean
- live contract: canonical ledger resolved through engine in 2.043s ownership / 2.26s total, no CLI fallback
