### PR TITLE
fix(a11y): hide loading composer from assistive tech

### DIFF
--- a/apps/web/app/app/(shell)/chat/loading.tsx
+++ b/apps/web/app/app/(shell)/chat/loading.tsx
@@ -42,13 +42,12 @@ export default function ChatLoading() {
                   >
                     <LoadingSkeleton height='h-4' width='w-4' rounded='full' />
                   </button>
-                  <textarea
-                    disabled
-                    rows={1}
-                    aria-label='Chat Message Input'
-                    placeholder='What are you working on?'
-                    className='min-w-0 flex-1 resize-none bg-transparent py-1.5 text-sm leading-6 text-primary-token placeholder:text-tertiary-token focus:outline-none'
-                  />
+                  <div
+                    aria-hidden='true'
+                    className='min-w-0 flex-1 py-1.5 text-sm leading-6 text-tertiary-token'
+                  >
+                    What are you working on?
+                  </div>
                   <button
                     type='button'
                     disabled

--- a/apps/web/tests/unit/chat/ChatLoading.test.tsx
+++ b/apps/web/tests/unit/chat/ChatLoading.test.tsx
@@ -65,6 +65,19 @@ describe('ChatLoading (chat home)', () => {
       'true'
     );
   });
+
+  it('does not expose disabled controls as the loading composer', async () => {
+    const { default: ChatLoading } = await import(
+      '@/app/app/(shell)/chat/loading'
+    );
+    render(<ChatLoading />);
+
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.getByText('What are you working on?')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+  });
 });
 
 describe('ChatConversationLoading (chat/[id])', () => {


### PR DESCRIPTION
## Summary
- Replace the disabled loading-state textarea with an inert placeholder that preserves the composer geometry.
- Prevent assistive technology and axe from treating the loading fallback as a real textbox with unreadable disabled-state contrast.
- Add a focused regression asserting the loading surface exposes no textbox and keeps its placeholder aria-hidden.

This is the unique current-main repair extracted from #14034. The broader contrast and selector work is superseded by #14412; #14034 remains open pending remote authenticated-a11y proof on this PR.

## Root cause
The authenticated accessibility scan could observe the route loading fallback before hydration. That fallback rendered a disabled textarea whose near-black disabled foreground/background produced an approximately 1.02:1 contrast violation. It was presentation-only but exposed as an interactive textbox.

## Bug-to-Test
bug-to-test: satisfied

Regression test: `apps/web/tests/unit/chat/ChatLoading.test.tsx`

## Verification
- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/chat/ChatLoading.test.tsx` (9/9)
- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] `pnpm biome check 'apps/web/app/app/(shell)/chat/loading.tsx' apps/web/tests/unit/chat/ChatLoading.test.tsx`
- [x] `git diff --check`
- [ ] Remote authenticated accessibility job

## Scope
- Two files only, 19 insertions and 7 deletions.
- No CI concurrency, workflow artifact, selector, or #14412 contrast changes included.
- Linear follow-ups: none.
