### PR TITLE
fix(ci): preserve Vercel build provenance

### DIFF
--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -99,9 +99,12 @@ run_deploy() {
   fi
 
   if [ -n "${VERCEL_GIT_COMMIT_SHA:-}" ]; then
+    local build_sha="${VERCEL_GIT_COMMIT_SHA:0:7}"
     "${deploy_cmd[@]}" "${VERCEL_CMD[@]}" deploy "$@" \
       --build-env "VERCEL_GIT_COMMIT_SHA=${VERCEL_GIT_COMMIT_SHA}" \
       --env "VERCEL_GIT_COMMIT_SHA=${VERCEL_GIT_COMMIT_SHA}" \
+      --build-env "NEXT_PUBLIC_BUILD_SHA=${build_sha}" \
+      --env "NEXT_PUBLIC_BUILD_SHA=${build_sha}" \
       --token "$VERCEL_TOKEN" "${VERCEL_SCOPE_ARGS[@]}"
     return
   fi

--- a/apps/web/app/api/health/build-info/route.ts
+++ b/apps/web/app/api/health/build-info/route.ts
@@ -12,7 +12,7 @@ export function GET() {
   const version = env.NEXT_PUBLIC_APP_VERSION ?? '0.0.0';
   const environment = env.VERCEL_ENV;
   const isDevelopment = env.NODE_ENV !== 'production';
-  const buildSha = env.NEXT_PUBLIC_BUILD_SHA?.trim();
+  const buildSha = env.NEXT_PUBLIC_BUILD_SHA?.trim().slice(0, 7);
   const runtimeCommitSha = env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7);
 
   if (_cachedBuildId === undefined) {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -419,10 +419,11 @@ const nextConfig = {
   env: {
     // Build-time env vars — these get inlined into client bundles by Next.js
     NEXT_PUBLIC_APP_VERSION: APP_VERSION,
-    NEXT_PUBLIC_BUILD_SHA: (process.env.VERCEL_GIT_COMMIT_SHA || '').slice(
-      0,
-      7
-    ),
+    NEXT_PUBLIC_BUILD_SHA: (
+      process.env.NEXT_PUBLIC_BUILD_SHA ||
+      process.env.VERCEL_GIT_COMMIT_SHA ||
+      ''
+    ).slice(0, 7),
     NEXT_PUBLIC_CI: process.env.CI === 'true' ? 'true' : 'false',
   },
   // Keep @statsig/statsig-node-core external so Next.js does not webpack-bundle

--- a/apps/web/tests/unit/api/health/build-info.critical.test.ts
+++ b/apps/web/tests/unit/api/health/build-info.critical.test.ts
@@ -45,7 +45,7 @@ describe('@critical GET /api/health/build-info', () => {
 
   it('prefers build-time commit sha when available in production', async () => {
     vi.stubEnv('NODE_ENV', 'production');
-    vi.stubEnv('NEXT_PUBLIC_BUILD_SHA', 'abcdef1');
+    vi.stubEnv('NEXT_PUBLIC_BUILD_SHA', 'abcdef1234567890');
     vi.stubEnv('VERCEL_GIT_COMMIT_SHA', '1234567890abcdef');
 
     const { GET } = await import('@/app/api/health/build-info/route');

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -136,6 +136,8 @@ echo "https://jovie-source-fallback.vercel.app"
     assert "--prebuilt" not in calls[1]
     assert "--build-env VERCEL_GIT_COMMIT_SHA=0123456789abcdef" in calls[1]
     assert "--env VERCEL_GIT_COMMIT_SHA=0123456789abcdef" in calls[1]
+    assert "--build-env NEXT_PUBLIC_BUILD_SHA=0123456" in calls[1]
+    assert "--env NEXT_PUBLIC_BUILD_SHA=0123456" in calls[1]
 
 
 def test_failed_prebuilt_with_url_still_falls_back_to_source(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- inject a non-reserved seven-character build SHA into Vercel CLI source deployments
- prefer the explicit build SHA in Next.js config while retaining the Vercel fallback
- normalize build-info SHA output for deterministic canary comparison

## Why
Two healthy current-main staging deployments returned HTTP 200 from `/api/health/build-info` without `commitSha`, so the canary correctly blocked production promotion. Vercel deployment metadata had the SHA, but the reserved runtime variable was not exposed inside CLI source deployments.

## Validation
- `pnpm exec pytest scripts/tests/test_vercel_prebuilt_deploy.py` (13 passed)
- focused Vitest build-info/workflow suite (40 passed)
- `pnpm --filter=@jovie/web typecheck`
- `bash -n .github/scripts/vercel-prebuilt-deploy.sh`
- `git diff --check`