### PR TITLE
fix(build): bound admin skill prompt tracing

### DIFF
--- a/apps/web/components/features/admin/system-map/AdminSystemMapSkillsTab.tsx
+++ b/apps/web/components/features/admin/system-map/AdminSystemMapSkillsTab.tsx
@@ -3,15 +3,27 @@ import path from 'node:path';
 import { SKILL_REGISTRY } from '@/lib/agents/registry';
 import { SkillDocCard } from './SkillDocCard';
 
+const promptReaders: Record<string, () => Promise<string>> = {
+  'apps/web/lib/services/retouching/styles/white-space.md': () =>
+    fs.readFile(
+      path.join(
+        process.cwd(),
+        'lib',
+        'services',
+        'retouching',
+        'styles',
+        'white-space.md'
+      ),
+      'utf-8'
+    ),
+};
+
 async function readPromptContent(
   promptPath: string | undefined
 ): Promise<string | null> {
   if (!promptPath) return null;
   try {
-    // promptPath is relative to the repo root; Next.js cwd is the app dir
-    const repoRoot = path.resolve(process.cwd(), '../..');
-    const fullPath = path.join(repoRoot, promptPath);
-    return await fs.readFile(fullPath, 'utf-8');
+    return (await promptReaders[promptPath]?.()) ?? null;
   } catch {
     return null;
   }

--- a/apps/web/lib/auth/dev-test-auth-identity.ts
+++ b/apps/web/lib/auth/dev-test-auth-identity.ts
@@ -1,4 +1,5 @@
-import { createHash } from 'node:crypto';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import type { DevTestAuthPersona } from '@/lib/auth/dev-test-auth-types';
 import { normalizeEmail } from '@/lib/utils/email';
 
@@ -10,10 +11,9 @@ export const DEFAULT_DEV_TEST_AUTH_EMAILS = {
 
 export function getDeterministicTestBetterAuthUserId(email: string): string {
   const normalizedEmail = normalizeEmail(email);
-  const bytes = createHash('sha256')
-    .update(`jovie:better-auth-test-user:${normalizedEmail}`)
-    .digest()
-    .subarray(0, 16);
+  const bytes = sha256(
+    new TextEncoder().encode(`jovie:better-auth-test-user:${normalizedEmail}`)
+  ).slice(0, 16);
 
   // RFC 9562 UUIDv8 reserves the payload for application-defined,
   // deterministic data. PostgreSQL accepts it as a native UUID while the
@@ -21,7 +21,7 @@ export function getDeterministicTestBetterAuthUserId(email: string): string {
   bytes[6] = (bytes[6] & 0x0f) | 0x80;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
 
-  const hex = bytes.toString('hex');
+  const hex = bytesToHex(bytes);
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 

--- a/apps/web/lib/auth/test-mode-constants.ts
+++ b/apps/web/lib/auth/test-mode-constants.ts
@@ -4,3 +4,8 @@ export const TEST_AUTH_BYPASS_MODE = 'bypass-auth';
 export const TEST_MODE_COOKIE = '__e2e_test_mode';
 export const TEST_USER_ID_COOKIE = '__e2e_test_user_id';
 export const TEST_PERSONA_COOKIE = '__e2e_test_persona';
+
+// Precomputed by getDeterministicDevTestAuthPersonaUserId('creator'). Keep the
+// browser-reachable test-mode module free of Node's crypto implementation.
+export const DEFAULT_TEST_CREATOR_USER_ID =
+  '02fbb6ae-fae2-89bb-a4b2-d18ec56ee2ff';

--- a/apps/web/lib/auth/test-mode.ts
+++ b/apps/web/lib/auth/test-mode.ts
@@ -1,6 +1,6 @@
 import { isIPv4 } from 'node:net';
-import { getDeterministicDevTestAuthPersonaUserId } from '@/lib/auth/dev-test-auth-identity';
 import {
+  DEFAULT_TEST_CREATOR_USER_ID,
   TEST_AUTH_BYPASS_MODE,
   TEST_MODE_COOKIE,
   TEST_MODE_HEADER,
@@ -9,6 +9,7 @@ import {
 } from '@/lib/auth/test-mode-constants';
 
 export {
+  DEFAULT_TEST_CREATOR_USER_ID,
   TEST_AUTH_BYPASS_MODE,
   TEST_MODE_COOKIE,
   TEST_MODE_HEADER,
@@ -170,6 +171,6 @@ export function resolveTestBypassUserId(
         process.env.TEST_CLERK_USER_ID ??
         null
     ) ??
-    getDeterministicDevTestAuthPersonaUserId('creator')
+    DEFAULT_TEST_CREATOR_USER_ID
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -210,6 +210,7 @@
     "@jovie/auth-routing": "workspace:*",
     "@jovie/ui": "workspace:*",
     "@neondatabase/serverless": "^1.1.0",
+    "@noble/hashes": "2.2.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.218.0",
     "@opentelemetry/sdk-node": "^0.218.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",

--- a/apps/web/tests/unit/lib/auth/test-mode.test.ts
+++ b/apps/web/tests/unit/lib/auth/test-mode.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getDeterministicDevTestAuthPersonaUserId } from '@/lib/auth/dev-test-auth-identity';
 import {
+  DEFAULT_TEST_CREATOR_USER_ID,
   isTestAuthBypassEnabled,
   resolveTestBypassUserId,
   TEST_AUTH_BYPASS_MODE,
@@ -138,7 +139,10 @@ describe('test-mode auth bypass', () => {
           return null;
         },
       })
-    ).toBe(getDeterministicDevTestAuthPersonaUserId('creator'));
+    ).toBe(DEFAULT_TEST_CREATOR_USER_ID);
+    expect(DEFAULT_TEST_CREATOR_USER_ID).toBe(
+      getDeterministicDevTestAuthPersonaUserId('creator')
+    );
   });
 
   it('allows bypass markers on private development hosts', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
       '@neondatabase/serverless':
         specifier: ^1.1.0
         version: 1.1.0
+      '@noble/hashes':
+        specifier: 2.2.0
+        version: 2.2.0
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.218.0
         version: 0.218.0(@opentelemetry/api@1.9.1)


### PR DESCRIPTION
## Summary
- replace the dynamic repository-root prompt read with a static allowlisted reader
- keep the admin skills UI behavior while preventing Turbopack from tracing the entire monorepo
- use a browser-safe SHA-256 implementation for deterministic dev-auth IDs so Storybook can import the auth graph
- unblock Vercel production builds and the required Storybook a11y gate

## Validation
- `pnpm --filter @jovie/web typecheck`
- `pnpm --filter @jovie/web lint`
- production-config build passed with the broad-file-trace warning removed (`doppler run -p jovie-web -c prd -- env SENTRY_AUTH_TOKEN= pnpm --filter @jovie/web build`)
- `pnpm --filter @jovie/web exec vitest run tests/unit/lib/auth/test-mode.test.ts` (17 passed)
- `pnpm --filter @jovie/web test:a11y` (600 passed)
- `git diff --check`