### PR TITLE
feat(review): add scope governor guardrails

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -115,6 +115,28 @@ jobs:
                things a single-PR reviewer can't know.
             4. Missing tests on non-trivial logic.
 
+            SCOPE GOVERNOR — classify every accepted finding before proposing a fix:
+            - `in-scope blocker`: a correctness, security, data-loss, or regression
+              issue directly in the PR's original files and intent that must be fixed.
+            - `follow-up`: valid but non-blocking work that can be deferred safely.
+            - `stop-and-escalate`: out-of-scope, ambiguous/high-risk work, or a decision
+              that needs a maintainer rather than an automatic patch.
+            Label every accepted finding with exactly one of those strings. Do not
+            silently turn a follow-up or stop-and-escalate finding into a patch.
+
+            SCOPE BUDGET: Treat the PR's initial changed-file count and non-test LOC as
+            its original scope. Never expand beyond 2x either budget without explicit
+            approval in the PR description or a maintainer comment containing the
+            exact token `scope-approved`. Without that token, classify the finding as
+            `stop-and-escalate` and do not propose edits outside the budget. Test-only
+            additions needed to verify an in-scope fix do not count as non-test LOC.
+
+            TWO-CYCLE PAUSE: Inspect the PR timeline for review-triggered fix cycles
+            (a review finding followed by a patch and another review). After two such
+            cycles without convergence, pause before another edit: reclassify every
+            remaining finding, mark unresolved/ambiguous items `stop-and-escalate`,
+            and ask for a maintainer decision. Never attempt a third automatic fix.
+
             BE HIGH-SIGNAL — this must not become noise:
             - Only comment on things that genuinely matter. No nitpicks, no style
               (biome/lint handle that), no praise, no summaries of what the PR does.
@@ -122,5 +144,9 @@ jobs:
               line saying so.
             - Defer taste/UX/product/copy judgments to human reviewers — do not opine on those.
 
-            Post ONE concise PR review. Each finding: file:line, the issue, why it
-            matters (cite gbrain if relevant), and a concrete fix.
+            Post ONE concise PR review. Start with a `Scope governor` line stating the
+            original files/non-test LOC budget, whether the 2x budget is exceeded, and
+            whether the two-cycle pause applies. Each accepted finding must include:
+            `Classification: in-scope blocker|follow-up|stop-and-escalate`, plus
+            file:line, the issue, why it matters (cite gbrain if relevant), and a
+            concrete fix only when its classification permits one.

--- a/scripts/lib/__tests__/scope-governor.test.mjs
+++ b/scripts/lib/__tests__/scope-governor.test.mjs
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyAcceptedFindings,
+  classifyFinding,
+  scopeDecision,
+  scopeExpansion,
+  shouldPauseForReclassification,
+} from '../scope-governor.mjs';
+
+describe('scope governor', () => {
+  const baseScope = {
+    originalFiles: 4,
+    originalNonTestLoc: 100,
+    currentFiles: 4,
+    currentNonTestLoc: 100,
+  };
+
+  it('labels accepted blockers and follow-ups', () => {
+    expect(classifyFinding({ accepted: true, blocker: true }, baseScope)).toBe(
+      'in-scope blocker'
+    );
+    expect(classifyFinding({ accepted: true }, baseScope)).toBe('follow-up');
+    expect(
+      classifyAcceptedFindings(
+        [{ accepted: true, blocker: true }, { accepted: true }],
+        baseScope
+      ).map(finding => finding.classification)
+    ).toEqual(['in-scope blocker', 'follow-up']);
+  });
+
+  it('escalates explicit out-of-scope findings', () => {
+    expect(
+      classifyFinding({ accepted: true, outOfScope: true }, baseScope)
+    ).toBe('stop-and-escalate');
+  });
+
+  it('requires explicit approval beyond 2x original files or non-test LOC', () => {
+    expect(
+      scopeExpansion({ ...baseScope, currentFiles: 9 }).requiresApproval
+    ).toBe(true);
+    expect(
+      classifyFinding(
+        { accepted: true, blocker: true },
+        { ...baseScope, currentFiles: 9 }
+      )
+    ).toBe('stop-and-escalate');
+    expect(
+      classifyFinding(
+        { accepted: true, blocker: true },
+        { ...baseScope, currentNonTestLoc: 201, approval: 'scope-approved' }
+      )
+    ).toBe('in-scope blocker');
+  });
+
+  it('pauses after two non-converged review-triggered fix cycles', () => {
+    expect(
+      shouldPauseForReclassification({
+        ...baseScope,
+        reviewTriggeredFixCycles: 2,
+        converged: false,
+      })
+    ).toBe(true);
+    expect(
+      scopeDecision({
+        ...baseScope,
+        reviewTriggeredFixCycles: 2,
+        converged: false,
+      }).action
+    ).toBe('pause-and-reclassify');
+    expect(
+      classifyFinding(
+        { accepted: true, blocker: true },
+        { ...baseScope, reviewTriggeredFixCycles: 2 }
+      )
+    ).toBe('stop-and-escalate');
+  });
+});

--- a/scripts/lib/scope-governor.mjs
+++ b/scripts/lib/scope-governor.mjs
@@ -1,0 +1,110 @@
+export const FINDING_CLASSES = Object.freeze([
+  'in-scope blocker',
+  'follow-up',
+  'stop-and-escalate',
+]);
+
+export const SCOPE_APPROVAL_TOKEN = 'scope-approved';
+
+function positiveNumber(value) {
+  return Number.isFinite(Number(value)) && Number(value) >= 0
+    ? Number(value)
+    : 0;
+}
+
+export function normalizeScope(scope = {}) {
+  return {
+    originalFiles: positiveNumber(scope.originalFiles),
+    originalNonTestLoc: positiveNumber(scope.originalNonTestLoc),
+    currentFiles: positiveNumber(scope.currentFiles),
+    currentNonTestLoc: positiveNumber(scope.currentNonTestLoc),
+    reviewTriggeredFixCycles: Math.max(
+      0,
+      Math.floor(positiveNumber(scope.reviewTriggeredFixCycles))
+    ),
+    converged: scope.converged === true,
+    approval:
+      scope.approval === true ||
+      String(scope.approval ?? '')
+        .toLowerCase()
+        .includes(SCOPE_APPROVAL_TOKEN),
+  };
+}
+
+export function scopeExpansion(scope = {}) {
+  const normalized = normalizeScope(scope);
+  const filesExpanded =
+    normalized.originalFiles > 0 &&
+    normalized.currentFiles > normalized.originalFiles * 2;
+  const nonTestLocExpanded =
+    normalized.originalNonTestLoc > 0 &&
+    normalized.currentNonTestLoc > normalized.originalNonTestLoc * 2;
+
+  return {
+    filesExpanded,
+    nonTestLocExpanded,
+    requiresApproval: filesExpanded || nonTestLocExpanded,
+    approved: normalized.approval,
+  };
+}
+
+export function shouldPauseForReclassification(scope = {}) {
+  const normalized = normalizeScope(scope);
+  return normalized.reviewTriggeredFixCycles >= 2 && !normalized.converged;
+}
+
+export function classifyFinding(finding = {}, scope = {}) {
+  const normalized = normalizeScope(scope);
+  const expansion = scopeExpansion(normalized);
+
+  if (finding.accepted === false) return null;
+  if (finding.stopAndEscalate === true || finding.outOfScope === true) {
+    return 'stop-and-escalate';
+  }
+  if (expansion.requiresApproval && !expansion.approved) {
+    return 'stop-and-escalate';
+  }
+  if (shouldPauseForReclassification(normalized)) {
+    return 'stop-and-escalate';
+  }
+  if (finding.blocker === true && finding.inScope !== false) {
+    return 'in-scope blocker';
+  }
+  return 'follow-up';
+}
+
+export function classifyAcceptedFindings(findings = [], scope = {}) {
+  return findings
+    .filter(finding => finding.accepted !== false)
+    .map(finding => ({
+      ...finding,
+      classification: classifyFinding(finding, scope),
+    }));
+}
+
+export function scopeDecision(scope = {}) {
+  const normalized = normalizeScope(scope);
+  const expansion = scopeExpansion(normalized);
+  const paused = shouldPauseForReclassification(normalized);
+
+  return {
+    ...expansion,
+    paused,
+    action: paused
+      ? 'pause-and-reclassify'
+      : expansion.requiresApproval && !expansion.approved
+        ? 'stop-and-escalate'
+        : 'continue',
+  };
+}
+
+if (import.meta.main) {
+  const input = process.argv[2];
+  if (!input) {
+    console.error('Usage: node scripts/lib/scope-governor.mjs <scope.json>');
+    process.exit(1);
+  }
+
+  const scope = JSON.parse(input);
+  console.log(JSON.stringify(scopeDecision(scope), null, 2));
+}


### PR DESCRIPTION
## Summary
- Add a review-scope classification protocol to the Claude review workflow: `in-scope blocker`, `follow-up`, or `stop-and-escalate`.
- Pause after two non-converging review-triggered fix cycles and reclassify remaining findings before another edit.
- Require explicit `scope-approved` approval before exceeding 2x the original changed-file or non-test LOC budget.
- Add a small tested scope-governor policy module for deterministic classification and budget decisions.

## Context
Backports the scope-governor gap identified in [`/Users/timwhite/.gbrain/plans/autoreview-vs-jovie-gap-analysis-2026-07-15.md`](/Users/timwhite/.gbrain/plans/autoreview-vs-jovie-gap-analysis-2026-07-15.md).

## Test plan
- `./node_modules/.bin/vitest --root scripts --config vitest.config.mts run lib/__tests__/scope-governor.test.mjs`
- `node --check scripts/lib/scope-governor.mjs`
- `actionlint .github/workflows/claude-review.yml` (when available)
- Pre-push checks passed: Biome, proxy/Tailwind guards, web typecheck, CI harness validation.
