### PR TITLE
ci: audit security finding suppressions

### DIFF
--- a/.github/scripts/security-suppression-audit.py
+++ b/.github/scripts/security-suppression-audit.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Keep security-review suppressions auditable in structured output.
+
+Reviewers may record an intentionally suppressed security finding with this marker:
+<!-- jovie-security-suppression {"type":"secret-scan","reason":"..."} -->
+The marker is machine-readable, while workflows emit a visible, fixed notice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import html
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+MARKER = re.compile(
+    r"<!--\s*jovie-security-suppression\s+(.*?)\s*-->", re.DOTALL
+)
+NOTICE = (
+    "Security finding suppressions are present; review suppressed findings and "
+    "reasons below."
+)
+
+
+def flatten(value: Any) -> list[dict[str, Any]]:
+    """Flatten paginated GitHub API responses without accepting scalar records."""
+    if isinstance(value, list):
+        result: list[dict[str, Any]] = []
+        for item in value:
+            result.extend(flatten(item))
+        return result
+    return [value] if isinstance(value, dict) else []
+
+
+def author_for(record: dict[str, Any]) -> str:
+    """Resolve normalized or native GitHub authors, including deleted users."""
+    author = record.get("author")
+    if isinstance(author, str) and author.strip():
+        return author.strip()
+    if isinstance(author, dict):
+        login = author.get("login")
+        if isinstance(login, str) and login.strip():
+            return login.strip()
+
+    user = record.get("user")
+    if isinstance(user, dict):
+        login = user.get("login")
+        if isinstance(login, str) and login.strip():
+            return login.strip()
+    return "unknown"
+
+
+def extract(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract valid markers, failing closed when a marker is malformed."""
+    findings: list[dict[str, Any]] = []
+    for record in records:
+        body = record.get("body")
+        if not isinstance(body, str):
+            continue
+        for raw in MARKER.findall(body):
+            try:
+                marker = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid suppression marker: {exc}") from exc
+            if not isinstance(marker, dict):
+                raise ValueError("suppression marker payload must be a JSON object")
+
+            suppression_type = marker.get("type")
+            reason = marker.get("reason")
+            if not isinstance(suppression_type, str) or not suppression_type.strip():
+                raise ValueError(
+                    "suppression marker requires a non-empty string 'type'"
+                )
+            if not isinstance(reason, str) or not reason.strip():
+                raise ValueError(
+                    "suppression marker requires a non-empty string 'reason'"
+                )
+            findings.append(
+                {
+                    "type": suppression_type.strip(),
+                    "reason": reason.strip(),
+                    "author": author_for(record),
+                    "source": record.get("source", "review"),
+                    "pr_number": record.get("pr_number"),
+                }
+            )
+    return findings
+
+
+def normalize(report: dict[str, Any]) -> dict[str, Any]:
+    """Preserve suppressed findings and add a notice without hiding active data."""
+    suppressed = report.get("suppressedFindings", [])
+    if not isinstance(suppressed, list):
+        raise ValueError("suppressedFindings must be an array")
+    output = dict(report)
+    output["suppressedFindings"] = suppressed
+    if suppressed:
+        output["suppressionNotice"] = {
+            "id": "security.suppressions.active",
+            "severity": "info",
+            "message": NOTICE,
+            "unsuppressible": True,
+        }
+    return output
+
+
+def markdown_summary(report: dict[str, Any]) -> str:
+    """Render a fixed notice and escaped reasons for the Actions summary."""
+
+    def cell(value: Any) -> str:
+        return (
+            html.escape(str(value), quote=False)
+            .replace("|", "\\|")
+            .replace("\r", " ")
+            .replace("\n", " ")
+        )
+
+    suppressed = report.get("suppressedFindings", [])
+    if not isinstance(suppressed, list):
+        raise ValueError("suppressedFindings must be an array")
+
+    lines = [
+        "### Security suppression audit",
+        "",
+        f"Suppressed security findings: **{len(suppressed)}**",
+    ]
+    if not suppressed:
+        lines.extend(["", "No security finding suppressions detected."])
+        return "\n".join(lines) + "\n"
+
+    lines.extend(
+        [
+            "",
+            NOTICE,
+            "",
+            "| Type | Author | PR | Reason |",
+            "| --- | --- | ---: | --- |",
+        ]
+    )
+    for finding in suppressed:
+        if not isinstance(finding, dict):
+            raise ValueError("suppressed finding must be a JSON object")
+        lines.append(
+            "| {type} | {author} | {pr_number} | {reason} |".format(
+                type=cell(finding.get("type", "unknown")),
+                author=cell(finding.get("author", "unknown")),
+                pr_number=cell(finding.get("pr_number") or "—"),
+                reason=cell(finding.get("reason", "")),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("normalize", "audit"), required=True)
+    parser.add_argument(
+        "--input", required=True, help="JSON report or GitHub API response"
+    )
+    parser.add_argument("--output", help="write structured JSON here instead of stdout")
+    parser.add_argument(
+        "--summary-output", help="append an escaped Markdown audit summary here"
+    )
+    args = parser.parse_args()
+    data = json.loads(Path(args.input).read_text(encoding="utf-8"))
+
+    if args.mode == "normalize":
+        if not isinstance(data, dict):
+            raise ValueError("normalize input must be a JSON object")
+        result = normalize(data)
+    else:
+        suppressions = extract(flatten(data))
+        by_type = collections.Counter(item["type"] for item in suppressions)
+        by_author = collections.Counter(item["author"] for item in suppressions)
+        result = {
+            "total": len(suppressions),
+            "byType": dict(sorted(by_type.items())),
+            "byAuthor": dict(sorted(by_author.items())),
+            "suppressedFindings": suppressions,
+        }
+        if suppressions:
+            result["suppressionNotice"] = {
+                "id": "security.suppressions.active",
+                "severity": "info",
+                "message": NOTICE,
+                "unsuppressible": True,
+            }
+
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    if args.summary_output:
+        if args.mode != "audit":
+            raise ValueError("--summary-output is only supported in audit mode")
+        with Path(args.summary_output).open("a", encoding="utf-8") as summary:
+            summary.write(markdown_summary(result))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"security suppression audit: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/.github/scripts/test-security-suppression-audit.py
+++ b/.github/scripts/test-security-suppression-audit.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Regression tests for the security suppression audit CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT = Path(__file__).with_name("security-suppression-audit.py")
+
+
+def run_audit(mode: str, payload: Any, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as directory:
+        source = Path(directory) / "input.json"
+        source.write_text(json.dumps(payload), encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--mode", mode, "--input", str(source)],
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+
+
+class SecuritySuppressionAuditTest(unittest.TestCase):
+    def test_audit_preserves_reason_and_counts_type_and_author(self) -> None:
+        payload = [
+            {
+                "body": "<!-- jovie-security-suppression "
+                '{"type":"secret-scan","reason":"fixture with } brace"} -->',
+                "author": "alice",
+                "pr_number": 42,
+            },
+            {
+                "body": "<!-- jovie-security-suppression "
+                '{"type":"secret-scan","reason":"second reason"} -->',
+                "user": None,
+                "pr_number": 43,
+            },
+        ]
+
+        result = json.loads(run_audit("audit", payload).stdout)
+
+        self.assertEqual(result["total"], 2)
+        self.assertEqual(result["byType"], {"secret-scan": 2})
+        self.assertEqual(result["byAuthor"], {"alice": 1, "unknown": 1})
+        self.assertEqual(
+            result["suppressedFindings"][0]["reason"], "fixture with } brace"
+        )
+        self.assertTrue(result["suppressionNotice"]["unsuppressible"])
+
+    def test_normalize_keeps_suppressed_findings_and_notice(self) -> None:
+        payload = {
+            "findings": [],
+            "suppressedFindings": [
+                {"type": "dependency", "reason": "owner accepted"}
+            ],
+        }
+
+        result = json.loads(run_audit("normalize", payload).stdout)
+
+        self.assertEqual(
+            result["suppressedFindings"][0]["reason"], "owner accepted"
+        )
+        self.assertEqual(
+            result["suppressionNotice"]["id"], "security.suppressions.active"
+        )
+        self.assertTrue(result["suppressionNotice"]["unsuppressible"])
+
+    def test_audit_omits_notice_when_empty(self) -> None:
+        result = json.loads(
+            run_audit("audit", [{"body": "no marker here", "author": "alice"}]).stdout
+        )
+
+        self.assertEqual(result["total"], 0)
+        self.assertNotIn("suppressionNotice", result)
+        self.assertEqual(result["suppressedFindings"], [])
+
+    def test_malformed_marker_fails_closed(self) -> None:
+        completed = run_audit(
+            "audit",
+            [{"body": "<!-- jovie-security-suppression [] -->"}],
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("payload must be a JSON object", completed.stderr)
+
+    def test_summary_escapes_untrusted_markdown_cells(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "input.json"
+            summary = Path(directory) / "summary.md"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "body": "<!-- jovie-security-suppression "
+                            '{"type":"secret|scan","reason":"<b>line|one\\nline two</b>"} -->',
+                            "author": "alice",
+                            "pr_number": 42,
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--mode",
+                    "audit",
+                    "--input",
+                    str(source),
+                    "--summary-output",
+                    str(summary),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            rendered = summary.read_text(encoding="utf-8")
+            self.assertIn("secret\\|scan", rendered)
+            self.assertIn("&lt;b&gt;line\\|one line two&lt;/b&gt;", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -267,6 +267,13 @@ jobs:
             file:line, the issue, why it matters (cite gbrain if relevant), and a
             concrete fix only when its classification permits one.
 
+            SECURITY SUPPRESSION AUDIT: never silently suppress a security finding.
+            If you intentionally suppress one, include this exact machine-readable
+            marker in the review body and keep the human-readable reason next to it:
+            <!-- jovie-security-suppression {"type":"<finding type>","reason":"<why it is accepted>"} -->
+            Suppressed findings must remain auditable by type and author; do not use
+            a generic summary that hides unrelated active security findings.
+
             Do not post or mutate GitHub. Return the complete review only in the
             structured `review_markdown` field. A trusted bounded step publishes it.
 

--- a/.github/workflows/security-suppression-audit.yml
+++ b/.github/workflows/security-suppression-audit.yml
@@ -1,0 +1,146 @@
+name: Security Suppression Audit
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  schedule:
+    - cron: '15 6 * * *' # Offset from the heavier security scan.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-suppression-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review-audit:
+    name: Security Suppression Audit
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.review.user.login == 'jovie-bot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout trusted main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Verify suppression audit contract
+        run: python3 .github/scripts/test-security-suppression-audit.py
+
+      - name: Collect current PR review output
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api --paginate --slurp \
+            "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" \
+            | jq --argjson pr_number "$PR_NUMBER" \
+              '[.[][] | . + {pr_number: $pr_number, source: "review"}]' \
+            > "$RUNNER_TEMP/security-review-output.json"
+
+      - name: Preserve reasons and publish fixed suppression notice
+        run: |
+          set -euo pipefail
+          report="$RUNNER_TEMP/security-suppressions.json"
+          python3 .github/scripts/security-suppression-audit.py \
+            --mode audit \
+            --input "$RUNNER_TEMP/security-review-output.json" \
+            --output "$report" \
+            --summary-output "$GITHUB_STEP_SUMMARY"
+          cat "$report"
+          if [[ "$(jq -r '.total' "$report")" -gt 0 ]]; then
+            echo "::notice title=Security suppressions::Suppressed findings and reasons remain visible in the audit summary."
+          fi
+
+  nightly-audit:
+    name: Nightly Security Suppression Audit
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout trusted main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Verify suppression audit contract
+        run: python3 .github/scripts/test-security-suppression-audit.py
+
+      - name: Collect review output from open PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          repo = os.environ['REPO']
+
+          def api_pages(endpoint: str) -> list[dict[str, object]]:
+              raw = subprocess.check_output(
+                  ['gh', 'api', '--paginate', '--slurp', endpoint], text=True
+              )
+              pages = json.loads(raw)
+              return [
+                  item
+                  for page in pages
+                  if isinstance(page, list)
+                  for item in page
+                  if isinstance(item, dict)
+              ]
+
+          pulls = api_pages(f'repos/{repo}/pulls?state=open&per_page=100')
+          if len(pulls) > 500:
+              raise RuntimeError('refusing to audit more than 500 open PRs')
+
+          reviews: list[dict[str, object]] = []
+          for pull in pulls:
+              number = pull.get('number')
+              if not isinstance(number, int) or number < 1:
+                  raise RuntimeError('GitHub returned an invalid PR number')
+              for review in api_pages(
+                  f'repos/{repo}/pulls/{number}/reviews?per_page=100'
+              ):
+                  review['pr_number'] = number
+                  review['source'] = 'review'
+                  reviews.append(review)
+
+          output = Path(os.environ['RUNNER_TEMP']) / 'security-review-output.json'
+          output.write_text(json.dumps(reviews), encoding='utf-8')
+          print(f'Collected {len(reviews)} reviews from {len(pulls)} open PRs')
+          PY
+
+      - name: Count suppressions by type and author
+        run: |
+          set -euo pipefail
+          report="$RUNNER_TEMP/nightly-security-suppressions.json"
+          python3 .github/scripts/security-suppression-audit.py \
+            --mode audit \
+            --input "$RUNNER_TEMP/security-review-output.json" \
+            --output "$report" \
+            --summary-output "$GITHUB_STEP_SUMMARY"
+          cat "$report"
+          if [[ "$(jq -r '.total' "$report")" -gt 0 ]]; then
+            echo "::notice title=Security suppressions::Nightly audit found suppressed findings; reasons remain visible in the summary."
+          fi

--- a/scripts/ci-fast-lanes.mjs
+++ b/scripts/ci-fast-lanes.mjs
@@ -241,6 +241,7 @@ function runStructural() {
     'pnpm --filter=@jovie/web run lint:contrast-ratchet',
     'pnpm doc:freshness:check',
     'node .github/scripts/quarantine-ledger.mjs validate',
+    'python3 .github/scripts/test-security-suppression-audit.py',
     // CI workflow changes live at the repo root, so Turbo --affected can select
     // only the root package and return success after running zero web tests.
     // Target Vitest directly so the deploy contract always executes and fails


### PR DESCRIPTION
## Summary
- define a machine-readable security suppression marker for Claude review output
- preserve suppression type/reason/author in structured audit output
- emit an unsuppressible suppression notice in the PR check summary
- add a lightweight nightly count by suppression type and author

This backports the security-audit suppression handling identified in:
`/Users/timwhite/.gbrain/plans/autoreview-vs-jovie-gap-analysis-2026-07-15.md`

## Verification
- `python3 -m pytest .github/scripts/test-security-suppression-audit.py -q`
- `python3 -m py_compile .github/scripts/security-suppression-audit.py`
- `git diff --check`
- `actionlint .github/workflows/security.yml .github/workflows/claude-review.yml`
- pre-push checks passed (Biome, proxy/Tailwind guards, web typecheck, affected verify, CI harness)
