### PR TITLE
ci: add structured review bundles

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -54,6 +54,72 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Build bounded review bundle
+        id: review-bundle
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_TRIGGER: ${{ github.event.action }}
+        run: |
+          BUNDLE_PATH="$(mktemp "${RUNNER_TEMP}/jovie-review-bundle.XXXXXX")"
+          export BUNDLE_PATH
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+
+          base_sha = os.environ["BASE_SHA"]
+          head_sha = os.environ["HEAD_SHA"]
+          diff_range = f"{base_sha}...{head_sha}"
+          max_diff_bytes = 120_000
+          test_path = re.compile(r"(^|/)(test|tests|__tests__|fixtures|mocks)(/|$)|(^|/).*\.(test|spec)\.[^.]+$")
+
+          def git(*args):
+              return subprocess.check_output(["git", *args], text=True)
+
+          changed_files = git("diff", "--name-only", "--diff-filter=ACMRD", diff_range).splitlines()
+          non_test_loc = 0
+          for row in git("diff", "--numstat", "--diff-filter=ACMRD", diff_range).splitlines():
+              added, deleted, path = row.split("\t", 2)
+              if not test_path.search(path):
+                  non_test_loc += sum(int(value) for value in (added, deleted) if value.isdigit())
+
+          diff = subprocess.check_output([
+              "git", "--no-pager", "diff", "--no-ext-diff", "--no-color",
+              "--unified=40", "--binary", diff_range,
+          ])
+          truncated = len(diff) > max_diff_bytes
+          if truncated:
+              diff = diff[:max_diff_bytes] + b"\n\n[review bundle diff truncated at 120000 bytes]\n"
+
+          metadata = {
+              "bundle_version": 1,
+              "pr_number": os.environ["PR_NUMBER"],
+              "base_branch": os.environ["BASE_BRANCH"],
+              "base_sha": base_sha,
+              "head_sha": head_sha,
+              "merge_trigger": os.environ["MERGE_TRIGGER"],
+              "changed_files": changed_files,
+              "non_test_loc": non_test_loc,
+              "blame_pr": os.environ.get("PR_NUMBER") or "unavailable",
+              "blame_commit": head_sha or "unavailable",
+              "diff_context_lines": 40,
+              "diff_max_bytes": max_diff_bytes,
+              "diff_truncated": truncated,
+          }
+          with open(os.environ["BUNDLE_PATH"], "wb") as bundle:
+              bundle.write(b"# Jovie structured review bundle\n")
+              bundle.write(json.dumps(metadata, indent=2, sort_keys=True).encode())
+              bundle.write(b"\n\n## Normalized diff\n\n")
+              bundle.write(diff)
+          print(f"Review bundle: {os.environ['BUNDLE_PATH']}")
+          print(f"Changed files: {len(changed_files)}; non-test LOC: {non_test_loc}; diff truncated: {truncated}")
+          PY
+          echo "path=$BUNDLE_PATH" >> "$GITHUB_OUTPUT"
+
       - name: Set up Bun (for gbrain CLI/MCP)
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -107,7 +173,12 @@ jobs:
             knowledge of the WHOLE codebase and company — not just this diff. If
             gbrain is unavailable, say so in one line and review from the diff alone.
 
-            Then review the diff (use `gh pr diff ${{ github.event.pull_request.number }}`) for, in priority order:
+            Then review the exact normalized diff in the bounded bundle at
+            `${{ steps.review-bundle.outputs.path }}`. It includes deterministic
+            provenance metadata (PR/base/head/blame commit, changed files, and
+            non-test LOC) followed by the diff. Use `gh pr diff` only if you need
+            to investigate context not included in the bundle; do not substitute
+            a different diff for the bundled review input.
             1. Correctness bugs and regressions.
             2. Security / auth / data-loss risks.
             3. Violations of an established decision or convention — CITE the gbrain


### PR DESCRIPTION
## Summary
- Add an additive pre-review step to `claude-review.yml` that writes a deterministic, bounded diff bundle to the runner temp directory.
- Include PR/base/head provenance, changed files, non-test LOC, merge trigger, and blame PR/commit metadata.
- Keep the existing Claude review engine and CI behavior unchanged; the prompt now points the reviewer at the bundle as its normalized diff input.

## Verification
- `actionlint .github/workflows/claude-review.yml`
- `git diff --check`
- Extracted and executed the workflow bundle step locally; verified the temp file and metadata fields.

## Context
Backport of the structured review bundling gap identified in [`autoreview-vs-jovie-gap-analysis-2026-07-15.md`](/Users/timwhite/.gbrain/plans/autoreview-vs-jovie-gap-analysis-2026-07-15.md).
