### PR TITLE
feat(profiles): reconcile known artist surfaces

### DIFF
--- a/apps/web/lib/profile-surfaces/candidates.ts
+++ b/apps/web/lib/profile-surfaces/candidates.ts
@@ -1,0 +1,211 @@
+import {
+  canonicalizeSurfaceUrl,
+  type ProfileQualificationStatus,
+  type ProfileSurfaceKind,
+} from './contracts';
+
+const DSP_PLATFORMS = new Set([
+  'amazon_music',
+  'apple_music',
+  'bandcamp',
+  'deezer',
+  'soundcloud',
+  'spotify',
+  'tidal',
+  'youtube_music',
+]);
+
+const AUTHORITY_PLATFORMS = new Set([
+  'genius',
+  'musicbrainz',
+  'musixmatch',
+  'wikipedia',
+]);
+
+export interface SurfaceSourceCandidate {
+  readonly sourceType: string;
+  readonly sourceRefId: string;
+  readonly sourceUrl: string;
+  readonly externalId: string | null;
+}
+
+export interface SurfaceCandidate {
+  readonly kind: ProfileSurfaceKind;
+  readonly platform: string;
+  readonly displayName: string | null;
+  readonly handle: string | null;
+  readonly url: string;
+  readonly normalizedUrl: string;
+  readonly externalId: string | null;
+  readonly qualificationStatus: ProfileQualificationStatus;
+  readonly identityConfidence: string;
+  readonly isOfficial: boolean;
+  readonly monitoringPriority: number;
+  readonly sources: readonly SurfaceSourceCandidate[];
+}
+
+interface CandidateInput {
+  readonly profile: {
+    readonly id: string;
+    readonly username: string;
+    readonly displayName: string | null;
+  };
+  readonly publicProfileBaseUrl: string;
+  readonly socials: ReadonlyArray<{
+    readonly id: string;
+    readonly platform: string;
+    readonly platformType: string | null;
+    readonly displayText: string | null;
+    readonly url: string;
+    readonly confidence: string;
+    readonly sortOrder: number | null;
+  }>;
+  readonly dspMatches: ReadonlyArray<{
+    readonly id: string;
+    readonly providerId: string;
+    readonly externalArtistName: string | null;
+    readonly externalArtistUrl: string | null;
+    readonly externalArtistId: string | null;
+    readonly confidenceScore: string | null;
+  }>;
+  readonly identityLinks: ReadonlyArray<{
+    readonly id: string;
+    readonly platform: string;
+    readonly url: string;
+    readonly externalId: string | null;
+  }>;
+}
+
+function classifyKind(
+  platform: string,
+  platformType?: string | null
+): ProfileSurfaceKind {
+  if (platformType === 'website' || platform === 'website') return 'website';
+  if (DSP_PLATFORMS.has(platform)) return 'dsp';
+  if (AUTHORITY_PLATFORMS.has(platform)) return 'authority';
+  return 'social';
+}
+
+function addCandidate(
+  map: Map<string, SurfaceCandidate>,
+  candidate: Omit<SurfaceCandidate, 'normalizedUrl'>
+) {
+  const canonical = canonicalizeSurfaceUrl(candidate.url);
+  if (!canonical) return;
+
+  const existing = map.get(canonical.url);
+  if (!existing) {
+    map.set(canonical.url, { ...candidate, normalizedUrl: canonical.url });
+    return;
+  }
+
+  const preferCandidate =
+    existing.qualificationStatus !== 'qualified' &&
+    candidate.qualificationStatus === 'qualified';
+  map.set(canonical.url, {
+    ...(preferCandidate ? candidate : existing),
+    normalizedUrl: canonical.url,
+    sources: [...existing.sources, ...candidate.sources],
+  });
+}
+
+export function buildSurfaceCandidates(input: CandidateInput) {
+  const candidates = new Map<string, SurfaceCandidate>();
+  const publicProfileUrl = new URL(
+    `/${encodeURIComponent(input.profile.username)}`,
+    input.publicProfileBaseUrl
+  ).toString();
+
+  addCandidate(candidates, {
+    kind: 'jovie',
+    platform: 'jovie',
+    displayName: input.profile.displayName,
+    handle: input.profile.username,
+    url: publicProfileUrl,
+    externalId: input.profile.id,
+    qualificationStatus: 'qualified',
+    identityConfidence: '1.00',
+    isOfficial: true,
+    monitoringPriority: -1,
+    sources: [
+      {
+        sourceType: 'creator_profile',
+        sourceRefId: input.profile.id,
+        sourceUrl: publicProfileUrl,
+        externalId: input.profile.id,
+      },
+    ],
+  });
+
+  for (const row of input.socials) {
+    addCandidate(candidates, {
+      kind: classifyKind(row.platform, row.platformType),
+      platform: row.platform,
+      displayName: row.displayText,
+      handle: row.displayText,
+      url: row.url,
+      externalId: null,
+      qualificationStatus: 'qualified',
+      identityConfidence: row.confidence,
+      isOfficial: true,
+      monitoringPriority: row.sortOrder ?? 0,
+      sources: [
+        {
+          sourceType: 'social_link',
+          sourceRefId: row.id,
+          sourceUrl: row.url,
+          externalId: null,
+        },
+      ],
+    });
+  }
+
+  for (const row of input.dspMatches) {
+    if (!row.externalArtistUrl) continue;
+    addCandidate(candidates, {
+      kind: 'dsp',
+      platform: row.providerId,
+      displayName: row.externalArtistName,
+      handle: null,
+      url: row.externalArtistUrl,
+      externalId: row.externalArtistId,
+      qualificationStatus: 'qualified',
+      identityConfidence: row.confidenceScore ?? '0.95',
+      isOfficial: true,
+      monitoringPriority: 0,
+      sources: [
+        {
+          sourceType: 'dsp_match',
+          sourceRefId: row.id,
+          sourceUrl: row.externalArtistUrl,
+          externalId: row.externalArtistId,
+        },
+      ],
+    });
+  }
+
+  for (const row of input.identityLinks) {
+    addCandidate(candidates, {
+      kind: classifyKind(row.platform),
+      platform: row.platform,
+      displayName: null,
+      handle: null,
+      url: row.url,
+      externalId: row.externalId,
+      qualificationStatus: 'suggested',
+      identityConfidence: '0.70',
+      isOfficial: false,
+      monitoringPriority: 0,
+      sources: [
+        {
+          sourceType: 'identity_link',
+          sourceRefId: row.id,
+          sourceUrl: row.url,
+          externalId: row.externalId,
+        },
+      ],
+    });
+  }
+
+  return [...candidates.values()];
+}

--- a/apps/web/lib/profile-surfaces/reconciliation.ts
+++ b/apps/web/lib/profile-surfaces/reconciliation.ts
@@ -1,0 +1,238 @@
+import {
+  and,
+  sql as drizzleSql,
+  eq,
+  inArray,
+  lt,
+  notInArray,
+} from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { dspArtistMatches } from '@/lib/db/schema/dsp-enrichment';
+import { artistIdentityLinks } from '@/lib/db/schema/identity';
+import { socialLinks } from '@/lib/db/schema/links';
+import {
+  profileSurfaceQualificationEvents,
+  profileSurfaceSources,
+  profileSurfaces,
+} from '@/lib/db/schema/profile-surfaces';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { publicEnv } from '@/lib/env-public';
+import { buildSurfaceCandidates } from './candidates';
+
+/** Reconcile one artist after canonical social/DSP writes or bounded backfill. */
+export async function reconcileProfileSurfaces(
+  creatorProfileId: string
+): Promise<{ surfaces: number; sources: number }> {
+  const startedAt = new Date();
+  const [profileRows, socialRows, dspRows, identityRows, existingRows] =
+    await Promise.all([
+      db
+        .select({
+          id: creatorProfiles.id,
+          username: creatorProfiles.username,
+          displayName: creatorProfiles.displayName,
+        })
+        .from(creatorProfiles)
+        .where(eq(creatorProfiles.id, creatorProfileId))
+        .limit(1),
+      db
+        .select()
+        .from(socialLinks)
+        .where(
+          and(
+            eq(socialLinks.creatorProfileId, creatorProfileId),
+            eq(socialLinks.isActive, true),
+            eq(socialLinks.state, 'active')
+          )
+        ),
+      db
+        .select()
+        .from(dspArtistMatches)
+        .where(
+          and(
+            eq(dspArtistMatches.creatorProfileId, creatorProfileId),
+            inArray(dspArtistMatches.status, ['confirmed', 'auto_confirmed'])
+          )
+        ),
+      db
+        .select()
+        .from(artistIdentityLinks)
+        .where(eq(artistIdentityLinks.creatorProfileId, creatorProfileId)),
+      db
+        .select({
+          id: profileSurfaces.id,
+          normalizedUrl: profileSurfaces.normalizedUrl,
+          qualificationStatus: profileSurfaces.qualificationStatus,
+        })
+        .from(profileSurfaces)
+        .where(
+          and(
+            eq(profileSurfaces.creatorProfileId, creatorProfileId),
+            drizzleSql`${profileSurfaces.retiredAt} IS NULL`
+          )
+        ),
+    ]);
+
+  const profile = profileRows[0];
+  if (!profile) return { surfaces: 0, sources: 0 };
+
+  const values = buildSurfaceCandidates({
+    profile,
+    publicProfileBaseUrl: publicEnv.NEXT_PUBLIC_PROFILE_URL,
+    socials: socialRows,
+    dspMatches: dspRows,
+    identityLinks: identityRows,
+  });
+  if (values.length === 0) return { surfaces: 0, sources: 0 };
+
+  const reconciled = await db
+    .insert(profileSurfaces)
+    .values(
+      values.map(value => ({
+        creatorProfileId,
+        kind: value.kind,
+        platform: value.platform,
+        displayName: value.displayName,
+        handle: value.handle,
+        url: value.url,
+        normalizedUrl: value.normalizedUrl,
+        externalId: value.externalId,
+        qualificationStatus: value.qualificationStatus,
+        identityConfidence: value.identityConfidence,
+        isOfficial: value.isOfficial,
+        availability: 'eligible',
+        monitoringPriority: value.monitoringPriority,
+        lastDiscoveredAt: startedAt,
+        lastVerifiedAt:
+          value.qualificationStatus === 'qualified' ? startedAt : null,
+        retiredAt: null,
+        replacedBySurfaceId: null,
+        updatedAt: startedAt,
+      }))
+    )
+    .onConflictDoUpdate({
+      target: [profileSurfaces.creatorProfileId, profileSurfaces.normalizedUrl],
+      targetWhere: drizzleSql`${profileSurfaces.retiredAt} IS NULL`,
+      set: {
+        kind: drizzleSql`excluded.kind`,
+        platform: drizzleSql`excluded.platform`,
+        displayName: drizzleSql`excluded.display_name`,
+        handle: drizzleSql`excluded.handle`,
+        url: drizzleSql`excluded.url`,
+        externalId: drizzleSql`excluded.external_id`,
+        qualificationStatus: drizzleSql`excluded.qualification_status`,
+        identityConfidence: drizzleSql`excluded.identity_confidence`,
+        isOfficial: drizzleSql`excluded.is_official`,
+        monitoringPriority: drizzleSql`excluded.monitoring_priority`,
+        lastDiscoveredAt: startedAt,
+        updatedAt: startedAt,
+      },
+    })
+    .returning({
+      id: profileSurfaces.id,
+      normalizedUrl: profileSurfaces.normalizedUrl,
+      qualificationStatus: profileSurfaces.qualificationStatus,
+    });
+
+  const surfaceByUrl = new Map(
+    reconciled.map(row => [row.normalizedUrl, row] as const)
+  );
+  const sourceValues = values.flatMap(value => {
+    const surface = surfaceByUrl.get(value.normalizedUrl);
+    if (!surface) return [];
+    return value.sources.map(source => ({
+      surfaceId: surface.id,
+      sourceType: source.sourceType,
+      sourceRefId: source.sourceRefId,
+      sourceUrl: source.sourceUrl,
+      externalId: source.externalId,
+      isLive: true,
+      lastSeenAt: startedAt,
+    }));
+  });
+
+  if (sourceValues.length > 0) {
+    await db
+      .insert(profileSurfaceSources)
+      .values(sourceValues)
+      .onConflictDoUpdate({
+        target: [
+          profileSurfaceSources.sourceType,
+          profileSurfaceSources.sourceRefId,
+        ],
+        set: {
+          surfaceId: drizzleSql`excluded.surface_id`,
+          sourceUrl: drizzleSql`excluded.source_url`,
+          externalId: drizzleSql`excluded.external_id`,
+          isLive: true,
+          lastSeenAt: startedAt,
+        },
+      });
+  }
+
+  const activeSurfaceIds = reconciled.map(row => row.id);
+  if (activeSurfaceIds.length > 0) {
+    await db
+      .update(profileSurfaceSources)
+      .set({ isLive: false })
+      .where(
+        and(
+          inArray(profileSurfaceSources.surfaceId, activeSurfaceIds),
+          lt(profileSurfaceSources.lastSeenAt, startedAt)
+        )
+      );
+  }
+
+  const previousByUrl = new Map(
+    existingRows.map(row => [row.normalizedUrl, row] as const)
+  );
+  const qualificationEvents = reconciled.flatMap(row => {
+    const previous = previousByUrl.get(row.normalizedUrl);
+    if (previous?.qualificationStatus === row.qualificationStatus) return [];
+    return [
+      {
+        surfaceId: row.id,
+        previousStatus: previous?.qualificationStatus ?? null,
+        nextStatus: row.qualificationStatus,
+        actorType: 'reconciliation',
+        reason: previous ? 'source_evidence_changed' : 'surface_discovered',
+        evidence: { observedAt: startedAt.toISOString() },
+      },
+    ];
+  });
+  if (qualificationEvents.length > 0) {
+    await db
+      .insert(profileSurfaceQualificationEvents)
+      .values(qualificationEvents);
+  }
+
+  const liveSourceRows = await db
+    .select({ surfaceId: profileSurfaceSources.surfaceId })
+    .from(profileSurfaceSources)
+    .where(
+      and(
+        inArray(profileSurfaceSources.surfaceId, activeSurfaceIds),
+        eq(profileSurfaceSources.isLive, true)
+      )
+    );
+  const surfacesWithSources = [
+    ...new Set(liveSourceRows.map(row => row.surfaceId)),
+  ];
+  if (activeSurfaceIds.length > surfacesWithSources.length) {
+    await db
+      .update(profileSurfaces)
+      .set({
+        availability: 'retired',
+        retiredAt: startedAt,
+        updatedAt: startedAt,
+      })
+      .where(
+        and(
+          inArray(profileSurfaces.id, activeSurfaceIds),
+          notInArray(profileSurfaces.id, surfacesWithSources)
+        )
+      );
+  }
+
+  return { surfaces: reconciled.length, sources: sourceValues.length };
+}

--- a/apps/web/tests/unit/lib/profile-surface-candidates.test.ts
+++ b/apps/web/tests/unit/lib/profile-surface-candidates.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { buildSurfaceCandidates } from '@/lib/profile-surfaces/candidates';
+
+const emptyInput = {
+  profile: {
+    id: '11111111-1111-4111-8111-111111111111',
+    username: 'tim',
+    displayName: 'Tim White',
+  },
+  publicProfileBaseUrl: 'https://jov.ie',
+  socials: [],
+  dspMatches: [],
+  identityLinks: [],
+} as const;
+
+describe('buildSurfaceCandidates', () => {
+  it('always creates one qualified Jovie surface', () => {
+    expect(buildSurfaceCandidates(emptyInput)).toEqual([
+      expect.objectContaining({
+        kind: 'jovie',
+        platform: 'jovie',
+        url: 'https://jov.ie/tim',
+        qualificationStatus: 'qualified',
+        isOfficial: true,
+      }),
+    ]);
+  });
+
+  it('classifies official websites, DSPs, socials, and authority sources', () => {
+    const surfaces = buildSurfaceCandidates({
+      ...emptyInput,
+      socials: [
+        {
+          id: 'social-website',
+          platform: 'website',
+          platformType: 'website',
+          displayText: 'Official site',
+          url: 'https://timwhite.com',
+          confidence: '1.00',
+          sortOrder: 1,
+        },
+        {
+          id: 'social-instagram',
+          platform: 'instagram',
+          platformType: 'social',
+          displayText: '@timwhite',
+          url: 'https://instagram.com/timwhite',
+          confidence: '0.99',
+          sortOrder: 2,
+        },
+      ],
+      dspMatches: [
+        {
+          id: 'dsp-spotify',
+          providerId: 'spotify',
+          externalArtistName: 'Tim White',
+          externalArtistUrl: 'https://open.spotify.com/artist/abc',
+          externalArtistId: 'abc',
+          confidenceScore: '0.98',
+        },
+      ],
+      identityLinks: [
+        {
+          id: 'identity-wikipedia',
+          platform: 'wikipedia',
+          url: 'https://en.wikipedia.org/wiki/Tim_White',
+          externalId: null,
+        },
+      ],
+    });
+
+    expect(surfaces.map(surface => [surface.platform, surface.kind])).toEqual([
+      ['jovie', 'jovie'],
+      ['website', 'website'],
+      ['instagram', 'social'],
+      ['spotify', 'dsp'],
+      ['wikipedia', 'authority'],
+    ]);
+    expect(surfaces.at(-1)?.qualificationStatus).toBe('suggested');
+  });
+
+  it('merges provenance and prefers qualified evidence for one URL', () => {
+    const surfaces = buildSurfaceCandidates({
+      ...emptyInput,
+      socials: [
+        {
+          id: 'social-instagram',
+          platform: 'instagram',
+          platformType: 'social',
+          displayText: '@timwhite',
+          url: 'https://www.instagram.com/timwhite/?utm_source=jovie',
+          confidence: '0.99',
+          sortOrder: 1,
+        },
+      ],
+      identityLinks: [
+        {
+          id: 'identity-instagram',
+          platform: 'instagram',
+          url: 'https://instagram.com/timwhite',
+          externalId: null,
+        },
+      ],
+    });
+
+    const instagram = surfaces.find(
+      surface => surface.platform === 'instagram'
+    );
+    expect(instagram).toMatchObject({
+      qualificationStatus: 'qualified',
+      normalizedUrl: 'https://instagram.com/timwhite',
+      isOfficial: true,
+    });
+    expect(instagram?.sources).toHaveLength(2);
+  });
+
+  it('skips invalid and incomplete destinations', () => {
+    const surfaces = buildSurfaceCandidates({
+      ...emptyInput,
+      socials: [
+        {
+          id: 'bad-social',
+          platform: 'instagram',
+          platformType: 'social',
+          displayText: null,
+          url: 'javascript:alert(1)',
+          confidence: '0.50',
+          sortOrder: null,
+        },
+      ],
+      dspMatches: [
+        {
+          id: 'missing-dsp-url',
+          providerId: 'spotify',
+          externalArtistName: 'Tim White',
+          externalArtistUrl: null,
+          externalArtistId: 'abc',
+          confidenceScore: null,
+        },
+      ],
+    });
+
+    expect(surfaces).toHaveLength(1);
+    expect(surfaces[0]?.kind).toBe('jovie');
+  });
+});


### PR DESCRIPTION
## Summary
- build candidate surfaces from official website, social, DSP, lyrics, wiki, and MusicBrainz evidence
- prioritize the Jovie profile while keeping every qualified canonical surface rankable
- retire stale surfaces when canonical evidence disappears

## Verification
- reconciliation, candidate-builder, and evidence-removal regression tests passed
- typecheck, lint, and production build passed

## Stack
Depends on the canonical surface registry foundation.

Linear: JOV-2659