### PR TITLE
feat(profiles): orchestrate bounded rank monitoring

### DIFF
--- a/apps/web/lib/profile-search/classification.ts
+++ b/apps/web/lib/profile-search/classification.ts
@@ -1,0 +1,82 @@
+import { canonicalizeSurfaceUrl } from '@/lib/profile-surfaces/contracts';
+import type { ProfileSearchOrganicResult } from './provider';
+
+export type SearchResultClassification =
+  | 'owned'
+  | 'aligned'
+  | 'qualified'
+  | 'conflicting'
+  | 'unknown';
+
+export interface ClassifiableSurface {
+  readonly id: string;
+  readonly kind: string;
+  readonly normalizedUrl: string;
+  readonly qualificationStatus: string;
+}
+
+export interface ClassifiedSearchResult extends ProfileSearchOrganicResult {
+  readonly classification: SearchResultClassification;
+  readonly surfaceId: string | null;
+}
+
+function matchesSurface(
+  resultUrl: string,
+  surface: ClassifiableSurface
+): boolean {
+  if (resultUrl === surface.normalizedUrl) return true;
+  if (surface.kind !== 'website') return false;
+
+  const result = canonicalizeSurfaceUrl(resultUrl);
+  const expected = canonicalizeSurfaceUrl(surface.normalizedUrl);
+  return Boolean(result && expected && result.hostname === expected.hostname);
+}
+
+export function classifySearchResults(
+  results: readonly ProfileSearchOrganicResult[],
+  surfaces: readonly ClassifiableSurface[]
+): ClassifiedSearchResult[] {
+  return results.map(result => {
+    const surface = surfaces.find(candidate =>
+      matchesSurface(result.normalizedUrl, candidate)
+    );
+    if (!surface) {
+      return { ...result, classification: 'unknown', surfaceId: null };
+    }
+
+    let classification: SearchResultClassification;
+    if (surface.qualificationStatus === 'conflicting') {
+      classification = 'conflicting';
+    } else if (surface.qualificationStatus !== 'qualified') {
+      classification = 'unknown';
+    } else if (surface.kind === 'jovie') {
+      classification = 'owned';
+    } else if (surface.kind === 'website') {
+      classification = 'aligned';
+    } else {
+      classification = 'qualified';
+    }
+
+    return { ...result, classification, surfaceId: surface.id };
+  });
+}
+
+export function summarizeQualifiedShare(
+  results: readonly ClassifiedSearchResult[]
+) {
+  const counts = {
+    owned: 0,
+    aligned: 0,
+    qualified: 0,
+    conflicting: 0,
+    unknown: 0,
+  };
+  for (const result of results) counts[result.classification] += 1;
+  const qualifiedCount = counts.owned + counts.aligned + counts.qualified;
+  return {
+    ...counts,
+    qualifiedCount,
+    qualifiedShare:
+      results.length === 0 ? null : qualifiedCount / results.length,
+  };
+}

--- a/apps/web/lib/profile-search/runner-core.ts
+++ b/apps/web/lib/profile-search/runner-core.ts
@@ -1,0 +1,165 @@
+import {
+  type ClassifiableSurface,
+  type ClassifiedSearchResult,
+  classifySearchResults,
+} from './classification';
+import {
+  type ProfileSearchProvider,
+  ProfileSearchProviderError,
+  type ProfileSearchRequest,
+  type ProfileSearchResponse,
+} from './provider';
+
+const MAX_SCHEDULED_RUNS = 10;
+const MAX_RETRY_ATTEMPTS = 4;
+const STOP_CLAIMING_MARGIN_MS = 15_000;
+
+export interface ClaimedProfileSearchQuery {
+  readonly id: string;
+  readonly request: ProfileSearchRequest;
+}
+
+export interface ProfileSearchRunnerDependencies {
+  readonly provider: ProfileSearchProvider;
+  isRolloutEnabled(): Promise<boolean>;
+  isProviderHealthy(): Promise<boolean>;
+  claimDueQuery(): Promise<ClaimedProfileSearchQuery | null>;
+  createAttemptIntent(
+    queryId: string,
+    kind: 'scheduled' | 'retry'
+  ): Promise<string>;
+  reserveAttemptBudget(
+    attemptId: string,
+    kind: 'scheduled' | 'retry'
+  ): Promise<boolean>;
+  markAttemptIssued(attemptId: string): Promise<void>;
+  loadSurfaces(queryId: string): Promise<readonly ClassifiableSurface[]>;
+  completeSuccess(input: {
+    readonly attemptId: string;
+    readonly queryId: string;
+    readonly response: ProfileSearchResponse;
+    readonly results: readonly ClassifiedSearchResult[];
+  }): Promise<void>;
+  completeFailure(input: {
+    readonly attemptId: string;
+    readonly queryId: string;
+    readonly code: string;
+    readonly message: string;
+  }): Promise<void>;
+  markProviderSuccess(): Promise<void>;
+  markProviderFailure(code: string): Promise<void>;
+}
+
+export interface ProfileSearchRunnerStats {
+  readonly enabled: boolean;
+  readonly claimed: number;
+  readonly attempted: number;
+  readonly succeeded: number;
+  readonly failed: number;
+  readonly retried: number;
+  readonly skippedBudget: number;
+  readonly stoppedForDeadline: boolean;
+}
+
+function failureDetails(error: unknown) {
+  if (error instanceof ProfileSearchProviderError) {
+    return {
+      code: error.code,
+      message: error.message,
+      retryable: error.retryable,
+    };
+  }
+  return {
+    code: 'unexpected',
+    message: error instanceof Error ? error.message : 'Unknown provider error',
+    retryable: false,
+  };
+}
+
+export async function runProfileSearchBatch(
+  dependencies: ProfileSearchRunnerDependencies,
+  options: { readonly deadlineAt: number; readonly now?: () => number }
+): Promise<ProfileSearchRunnerStats> {
+  const now = options.now ?? Date.now;
+  const rolloutEnabled = await dependencies.isRolloutEnabled();
+  const providerHealthy =
+    rolloutEnabled && (await dependencies.isProviderHealthy());
+  const stats = {
+    enabled: rolloutEnabled && providerHealthy,
+    claimed: 0,
+    attempted: 0,
+    succeeded: 0,
+    failed: 0,
+    retried: 0,
+    skippedBudget: 0,
+    stoppedForDeadline: false,
+  };
+  if (!stats.enabled) return stats;
+
+  while (stats.claimed < MAX_SCHEDULED_RUNS) {
+    if (options.deadlineAt - now() < STOP_CLAIMING_MARGIN_MS) {
+      stats.stoppedForDeadline = true;
+      break;
+    }
+    const query = await dependencies.claimDueQuery();
+    if (!query) break;
+    stats.claimed += 1;
+
+    let kind: 'scheduled' | 'retry' = 'scheduled';
+    while (true) {
+      const attemptId = await dependencies.createAttemptIntent(query.id, kind);
+      const reserved = await dependencies.reserveAttemptBudget(attemptId, kind);
+      if (!reserved) {
+        stats.skippedBudget += 1;
+        await dependencies.completeFailure({
+          attemptId,
+          queryId: query.id,
+          code: 'budget_exhausted',
+          message: 'Profile search budget exhausted',
+        });
+        break;
+      }
+
+      await dependencies.markAttemptIssued(attemptId);
+      stats.attempted += 1;
+      try {
+        const response = await dependencies.provider.search(query.request);
+        const surfaces = await dependencies.loadSurfaces(query.id);
+        const results = classifySearchResults(
+          response.organicResults,
+          surfaces
+        );
+        await dependencies.completeSuccess({
+          attemptId,
+          queryId: query.id,
+          response,
+          results,
+        });
+        await dependencies.markProviderSuccess();
+        stats.succeeded += 1;
+        break;
+      } catch (error) {
+        const failure = failureDetails(error);
+        await dependencies.completeFailure({
+          attemptId,
+          queryId: query.id,
+          code: failure.code,
+          message: failure.message,
+        });
+        await dependencies.markProviderFailure(failure.code);
+        const canRetry =
+          failure.retryable &&
+          stats.retried < MAX_RETRY_ATTEMPTS &&
+          options.deadlineAt - now() >= STOP_CLAIMING_MARGIN_MS;
+        if (!canRetry) {
+          stats.failed += 1;
+          break;
+        }
+        stats.retried += 1;
+        kind = 'retry';
+      }
+    }
+  }
+
+  return stats;
+}

--- a/apps/web/tests/unit/lib/profile-search-classification.test.ts
+++ b/apps/web/tests/unit/lib/profile-search-classification.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifySearchResults,
+  summarizeQualifiedShare,
+} from '@/lib/profile-search/classification';
+
+const result = (position: number, normalizedUrl: string) => ({
+  position,
+  title: `Result ${position}`,
+  snippet: null,
+  url: normalizedUrl,
+  normalizedUrl,
+});
+
+describe('profile search classification', () => {
+  const surfaces = [
+    {
+      id: 'jovie',
+      kind: 'jovie',
+      normalizedUrl: 'https://jov.ie/tim',
+      qualificationStatus: 'qualified',
+    },
+    {
+      id: 'website',
+      kind: 'website',
+      normalizedUrl: 'https://timwhite.com',
+      qualificationStatus: 'qualified',
+    },
+    {
+      id: 'instagram',
+      kind: 'social',
+      normalizedUrl: 'https://instagram.com/timwhite',
+      qualificationStatus: 'qualified',
+    },
+    {
+      id: 'conflict',
+      kind: 'authority',
+      normalizedUrl: 'https://musicbrainz.org/artist/wrong',
+      qualificationStatus: 'conflicting',
+    },
+  ];
+
+  it('distinguishes owned, aligned, qualified, conflicting, and unknown', () => {
+    const classified = classifySearchResults(
+      [
+        result(1, 'https://jov.ie/tim'),
+        result(2, 'https://timwhite.com/music'),
+        result(3, 'https://instagram.com/timwhite'),
+        result(4, 'https://musicbrainz.org/artist/wrong'),
+        result(5, 'https://example.com/other'),
+      ],
+      surfaces
+    );
+
+    expect(classified.map(item => item.classification)).toEqual([
+      'owned',
+      'aligned',
+      'qualified',
+      'conflicting',
+      'unknown',
+    ]);
+    expect(summarizeQualifiedShare(classified)).toMatchObject({
+      owned: 1,
+      aligned: 1,
+      qualified: 1,
+      conflicting: 1,
+      unknown: 1,
+      qualifiedCount: 3,
+      qualifiedShare: 0.6,
+    });
+  });
+
+  it('never matches a shared platform by domain alone', () => {
+    const [classified] = classifySearchResults(
+      [result(1, 'https://instagram.com/someone-else')],
+      surfaces
+    );
+    expect(classified).toMatchObject({
+      classification: 'unknown',
+      surfaceId: null,
+    });
+  });
+
+  it('reports no share when the result set is empty', () => {
+    expect(summarizeQualifiedShare([]).qualifiedShare).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/lib/profile-search-runner-core.test.ts
+++ b/apps/web/tests/unit/lib/profile-search-runner-core.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ProfileSearchProviderError } from '@/lib/profile-search/provider';
+import {
+  type ClaimedProfileSearchQuery,
+  type ProfileSearchRunnerDependencies,
+  runProfileSearchBatch,
+} from '@/lib/profile-search/runner-core';
+
+const query: ClaimedProfileSearchQuery = {
+  id: 'query-1',
+  request: {
+    query: 'Tim White',
+    market: 'US',
+    locale: 'en',
+    device: 'desktop',
+    limit: 10,
+  },
+};
+
+function dependencies(
+  overrides: Partial<ProfileSearchRunnerDependencies> = {}
+): ProfileSearchRunnerDependencies {
+  let claimed = false;
+  return {
+    provider: {
+      id: 'test',
+      search: vi.fn().mockResolvedValue({
+        provider: 'test',
+        fetchedAt: new Date('2026-07-16T00:00:00.000Z'),
+        request: query.request,
+        organicResults: [
+          {
+            position: 1,
+            title: 'Tim White | Jovie',
+            snippet: null,
+            url: 'https://jov.ie/tim',
+            normalizedUrl: 'https://jov.ie/tim',
+          },
+        ],
+        usage: {},
+      }),
+    },
+    isRolloutEnabled: vi.fn().mockResolvedValue(true),
+    isProviderHealthy: vi.fn().mockResolvedValue(true),
+    claimDueQuery: vi.fn(async () => {
+      if (claimed) return null;
+      claimed = true;
+      return query;
+    }),
+    createAttemptIntent: vi.fn().mockResolvedValue('attempt-1'),
+    reserveAttemptBudget: vi.fn().mockResolvedValue(true),
+    markAttemptIssued: vi.fn().mockResolvedValue(undefined),
+    loadSurfaces: vi.fn().mockResolvedValue([
+      {
+        id: 'surface-1',
+        kind: 'jovie',
+        normalizedUrl: 'https://jov.ie/tim',
+        qualificationStatus: 'qualified',
+      },
+    ]),
+    completeSuccess: vi.fn().mockResolvedValue(undefined),
+    completeFailure: vi.fn().mockResolvedValue(undefined),
+    markProviderSuccess: vi.fn().mockResolvedValue(undefined),
+    markProviderFailure: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('runProfileSearchBatch', () => {
+  it('fails closed unless rollout and provider health are enabled', async () => {
+    const disabled = dependencies({
+      isRolloutEnabled: vi.fn().mockResolvedValue(false),
+    });
+    expect(
+      await runProfileSearchBatch(disabled, {
+        deadlineAt: 100_000,
+        now: () => 0,
+      })
+    ).toMatchObject({ enabled: false, claimed: 0 });
+    expect(disabled.isProviderHealthy).not.toHaveBeenCalled();
+
+    const unhealthy = dependencies({
+      isProviderHealthy: vi.fn().mockResolvedValue(false),
+    });
+    expect(
+      await runProfileSearchBatch(unhealthy, {
+        deadlineAt: 100_000,
+        now: () => 0,
+      })
+    ).toMatchObject({ enabled: false, claimed: 0 });
+  });
+
+  it('persists intent, reserves budget, marks issued, and stores classified results', async () => {
+    const deps = dependencies();
+    const stats = await runProfileSearchBatch(deps, {
+      deadlineAt: 100_000,
+      now: () => 0,
+    });
+
+    expect(stats).toMatchObject({
+      enabled: true,
+      claimed: 1,
+      attempted: 1,
+      succeeded: 1,
+      failed: 0,
+    });
+    expect(deps.completeSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        results: [expect.objectContaining({ classification: 'owned' })],
+      })
+    );
+  });
+
+  it('does not issue a request when the atomic budget is exhausted', async () => {
+    const deps = dependencies({
+      reserveAttemptBudget: vi.fn().mockResolvedValue(false),
+    });
+    const stats = await runProfileSearchBatch(deps, {
+      deadlineAt: 100_000,
+      now: () => 0,
+    });
+
+    expect(stats).toMatchObject({ attempted: 0, skippedBudget: 1 });
+    expect(deps.markAttemptIssued).not.toHaveBeenCalled();
+    expect(deps.completeFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'budget_exhausted' })
+    );
+  });
+
+  it('retries transient failures and records provider health', async () => {
+    const search = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new ProfileSearchProviderError('timeout', 'timeout', true)
+      )
+      .mockResolvedValueOnce({
+        provider: 'test',
+        fetchedAt: new Date(),
+        request: query.request,
+        organicResults: [],
+        usage: {},
+      });
+    const deps = dependencies({ provider: { id: 'test', search } });
+    const stats = await runProfileSearchBatch(deps, {
+      deadlineAt: 100_000,
+      now: () => 0,
+    });
+
+    expect(stats).toMatchObject({ attempted: 2, retried: 1, succeeded: 1 });
+    expect(deps.markProviderFailure).toHaveBeenCalledWith('timeout');
+    expect(deps.markProviderSuccess).toHaveBeenCalledOnce();
+  });
+
+  it('stops before claiming when less than fifteen seconds remain', async () => {
+    const deps = dependencies();
+    const stats = await runProfileSearchBatch(deps, {
+      deadlineAt: 14_999,
+      now: () => 0,
+    });
+    expect(stats).toMatchObject({ claimed: 0, stoppedForDeadline: true });
+    expect(deps.claimDueQuery).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- classify exact-name Google results against canonical artist surfaces
- calculate rank, movement, and Jovie visibility KPIs
- orchestrate bounded monitoring runs with retries and provider-health gating

## Verification
- classification, KPI, retry, and runner tests passed
- typecheck, lint, and production build passed

## Rollout
The runner fails closed while provider health or monitoring flags are disabled.

Linear: JOV-2659