### PR TITLE
feat(profiles): persist daily profile rank monitoring

### DIFF
--- a/apps/web/app/api/cron/daily-maintenance/route.ts
+++ b/apps/web/app/api/cron/daily-maintenance/route.ts
@@ -27,6 +27,7 @@ import { verifyCronRequest } from '@/lib/cron/auth';
 import { sweepUnderEnrichedProfilesForCron } from '@/lib/discography/re-enrich';
 import { captureError } from '@/lib/error-tracking';
 import { runOnboardingScriptAggregation } from '@/lib/onboarding/script-aggregation';
+import { runProfileSearchMonitoring } from '@/lib/profile-search/runner';
 import { logger } from '@/lib/utils/logger';
 import { runWaitlistAutoAccept } from '@/lib/waitlist/auto-accept';
 import { runReconciliation } from '../billing-reconciliation/route';
@@ -112,26 +113,35 @@ export async function GET(request: Request) {
     runWaitlistAutoAccept
   );
 
-  // 6. Under-enriched discography sweep — bounded daily batch (JOV-3068)
+  // 6. Profile search monitoring — bounded to a 90-second sub-budget.
+  results.profileSearchMonitoring = await runSubJob(
+    'profileSearchMonitoring',
+    () =>
+      runProfileSearchMonitoring(
+        Math.min(startTime + 90_000, Date.now() + 90_000)
+      )
+  );
+
+  // 7. Under-enriched discography sweep — bounded daily batch (JOV-3068)
   results.discographyReEnrich = await runSubJob(
     'discographyReEnrich',
     sweepUnderEnrichedProfilesForCron
   );
 
-  // 7. Onboarding script self-improvement — recompute conversion counters,
+  // 8. Onboarding script self-improvement — recompute conversion counters,
   //    mine lint-clean LLM candidates, promote/retire variants (JOV-3806)
   results.onboardingScriptAggregation = await runSubJob(
     'onboardingScriptAggregation',
     runOnboardingScriptAggregation
   );
 
-  // 8. AI crawler analytics sync — Cloudflare edge analytics (GH-12748)
+  // 9. AI crawler analytics sync — Cloudflare edge analytics (GH-12748)
   results.aiCrawlerAnalytics = await runSubJob(
     'aiCrawlerAnalytics',
     syncAiCrawlerAnalyticsCron
   );
 
-  // 9. Data retention — Sundays only (heavy operation)
+  // 10. Data retention — Sundays only (heavy operation)
   const isSunday = new Date().getDay() === 0;
   results.dataRetention = isSunday
     ? await runSubJob('dataRetention', runDataRetentionCleanup)

--- a/apps/web/lib/profile-search/budget.ts
+++ b/apps/web/lib/profile-search/budget.ts
@@ -1,0 +1,67 @@
+import 'server-only';
+
+import { env } from '@/lib/env-server';
+import { getRedis } from '@/lib/redis';
+
+const DAILY_ATTEMPT_LIMIT = 200;
+const DAILY_RETRY_LIMIT = 4;
+const RESERVE_ATTEMPT_LUA = `
+if redis.call('EXISTS', KEYS[3]) == 1 then
+  return 1
+end
+local attempts = tonumber(redis.call('GET', KEYS[1]) or '0')
+if attempts >= tonumber(ARGV[1]) then
+  return 0
+end
+if ARGV[3] == 'retry' then
+  local retries = tonumber(redis.call('GET', KEYS[2]) or '0')
+  if retries >= tonumber(ARGV[2]) then
+    return 0
+  end
+  local retryNext = redis.call('INCR', KEYS[2])
+  if retryNext == 1 then redis.call('EXPIRE', KEYS[2], tonumber(ARGV[4])) end
+end
+local attemptNext = redis.call('INCR', KEYS[1])
+if attemptNext == 1 then redis.call('EXPIRE', KEYS[1], tonumber(ARGV[4])) end
+redis.call('SET', KEYS[3], '1', 'EX', tonumber(ARGV[4]))
+return 1
+`;
+
+function isProductionRuntime() {
+  return env.NODE_ENV === 'production' || env.VERCEL_ENV === 'production';
+}
+
+function dayKey(now: Date) {
+  return now.toISOString().slice(0, 10);
+}
+
+function secondsUntilNextUtcDay(now: Date) {
+  const nextDay = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() + 1
+  );
+  return Math.max(1, Math.ceil((nextDay - now.getTime()) / 1000));
+}
+
+export async function reserveProfileSearchAttempt(
+  attemptId: string,
+  kind: 'scheduled' | 'retry',
+  now = new Date()
+): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return !isProductionRuntime();
+
+  const day = dayKey(now);
+  const ttl = secondsUntilNextUtcDay(now);
+  const result = await redis.eval<[number, number, string, number], number>(
+    RESERVE_ATTEMPT_LUA,
+    [
+      `profile-search:budget:day:${day}`,
+      `profile-search:retry-budget:day:${day}`,
+      `profile-search:attempt:${attemptId}`,
+    ],
+    [DAILY_ATTEMPT_LIMIT, DAILY_RETRY_LIMIT, kind, ttl]
+  );
+  return result === 1;
+}

--- a/apps/web/lib/profile-search/runner.ts
+++ b/apps/web/lib/profile-search/runner.ts
@@ -1,0 +1,231 @@
+import 'server-only';
+
+import { and, sql as drizzleSql, eq, inArray } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import {
+  profileSearchProviderHealth,
+  profileSearchQueries,
+  profileSearchResults,
+  profileSearchRuns,
+} from '@/lib/db/schema/profile-search';
+import { profileSurfaces } from '@/lib/db/schema/profile-surfaces';
+import { getAppFlagValue } from '@/lib/flags/server';
+import { reserveProfileSearchAttempt } from './budget';
+import { GoogleSerpApiProvider } from './google-serpapi';
+import {
+  type ClaimedProfileSearchQuery,
+  type ProfileSearchRunnerDependencies,
+  runProfileSearchBatch,
+} from './runner-core';
+
+const PROVIDER_ID = 'google_serpapi';
+const LEASE_SECONDS = 120;
+
+async function isProviderHealthy() {
+  try {
+    const [health] = await db
+      .select({ enabled: profileSearchProviderHealth.enabled })
+      .from(profileSearchProviderHealth)
+      .where(eq(profileSearchProviderHealth.provider, PROVIDER_ID))
+      .limit(1);
+    return health?.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+async function claimDueQuery(): Promise<ClaimedProfileSearchQuery | null> {
+  const result = await db.execute<{
+    id: string;
+    query_text: string;
+    market: string;
+    locale: 'en';
+    device: 'desktop';
+  }>(drizzleSql`
+    WITH candidate AS (
+      SELECT id
+      FROM profile_search_queries
+      WHERE enabled = true
+        AND provider = ${PROVIDER_ID}
+        AND next_run_at <= now()
+        AND (lease_expires_at IS NULL OR lease_expires_at < now())
+      ORDER BY next_run_at ASC, creator_profile_id ASC
+      FOR UPDATE SKIP LOCKED
+      LIMIT 1
+    )
+    UPDATE profile_search_queries AS query
+    SET lease_token = gen_random_uuid(),
+        lease_expires_at = now() + (${LEASE_SECONDS} * interval '1 second'),
+        updated_at = now()
+    FROM candidate
+    WHERE query.id = candidate.id
+    RETURNING query.id, query.query_text, query.market, query.locale, query.device
+  `);
+  const row = result.rows[0];
+  if (!row) return null;
+  return {
+    id: row.id,
+    request: {
+      query: row.query_text,
+      market: row.market,
+      locale: row.locale,
+      device: row.device,
+      limit: 10,
+    },
+  };
+}
+
+async function createAttemptIntent(
+  queryId: string,
+  kind: 'scheduled' | 'retry'
+) {
+  const [run] = await db
+    .insert(profileSearchRuns)
+    .values({ queryId, provider: PROVIDER_ID, attemptKind: kind })
+    .returning({ id: profileSearchRuns.id });
+  if (!run) throw new Error('Failed to persist profile search attempt intent');
+  return run.id;
+}
+
+async function loadSurfaces(queryId: string) {
+  return db
+    .select({
+      id: profileSurfaces.id,
+      kind: profileSurfaces.kind,
+      normalizedUrl: profileSurfaces.normalizedUrl,
+      qualificationStatus: profileSurfaces.qualificationStatus,
+    })
+    .from(profileSurfaces)
+    .innerJoin(
+      profileSearchQueries,
+      eq(
+        profileSearchQueries.creatorProfileId,
+        profileSurfaces.creatorProfileId
+      )
+    )
+    .where(
+      and(
+        eq(profileSearchQueries.id, queryId),
+        eq(profileSurfaces.availability, 'eligible'),
+        drizzleSql`${profileSurfaces.retiredAt} IS NULL`
+      )
+    );
+}
+
+const dependencies: ProfileSearchRunnerDependencies = {
+  provider: new GoogleSerpApiProvider(),
+  isRolloutEnabled: () => getAppFlagValue('PROFILE_SEARCH_MONITORING'),
+  isProviderHealthy,
+  claimDueQuery,
+  createAttemptIntent,
+  reserveAttemptBudget: reserveProfileSearchAttempt,
+  async markAttemptIssued(attemptId) {
+    await db
+      .update(profileSearchRuns)
+      .set({ state: 'issued', requestIssuedAt: new Date() })
+      .where(eq(profileSearchRuns.id, attemptId));
+  },
+  loadSurfaces,
+  async completeSuccess({ attemptId, queryId, response, results }) {
+    await db.transaction(async tx => {
+      if (results.length > 0) {
+        await tx.insert(profileSearchResults).values(
+          results.map(result => ({
+            runId: attemptId,
+            position: result.position,
+            title: result.title,
+            snippet: result.snippet,
+            url: result.url,
+            normalizedUrl: result.normalizedUrl,
+            classification: result.classification,
+            surfaceId: result.surfaceId,
+          }))
+        );
+      }
+      await tx
+        .update(profileSearchRuns)
+        .set({
+          state: 'succeeded',
+          fetchedAt: response.fetchedAt,
+          completedAt: new Date(),
+          comparable: true,
+          usage: response.usage,
+        })
+        .where(eq(profileSearchRuns.id, attemptId));
+      await tx
+        .update(profileSearchQueries)
+        .set({
+          nextRunAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          leaseToken: null,
+          leaseExpiresAt: null,
+          lastSucceededAt: response.fetchedAt,
+          lastError: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(profileSearchQueries.id, queryId));
+      const observedSurfaceIds = results.flatMap(result =>
+        result.surfaceId ? [result.surfaceId] : []
+      );
+      if (observedSurfaceIds.length > 0) {
+        await tx
+          .update(profileSurfaces)
+          .set({ lastObservedAt: response.fetchedAt, updatedAt: new Date() })
+          .where(inArray(profileSurfaces.id, observedSurfaceIds));
+      }
+    });
+  },
+  async completeFailure({ attemptId, queryId, code, message }) {
+    const retryDelay =
+      code === 'budget_exhausted' ? 15 * 60 * 1000 : 24 * 60 * 60 * 1000;
+    await db.transaction(async tx => {
+      await tx
+        .update(profileSearchRuns)
+        .set({
+          state: code === 'timeout' ? 'timed_out' : 'failed',
+          completedAt: new Date(),
+          errorCode: code,
+          errorMessage: message.slice(0, 1_000),
+        })
+        .where(eq(profileSearchRuns.id, attemptId));
+      await tx
+        .update(profileSearchQueries)
+        .set({
+          nextRunAt: new Date(Date.now() + retryDelay),
+          leaseToken: null,
+          leaseExpiresAt: null,
+          lastError: message.slice(0, 1_000),
+          updatedAt: new Date(),
+        })
+        .where(eq(profileSearchQueries.id, queryId));
+    });
+  },
+  async markProviderSuccess() {
+    await db
+      .update(profileSearchProviderHealth)
+      .set({
+        consecutiveFailures: 0,
+        lastSuccessAt: new Date(),
+        disabledReason: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(profileSearchProviderHealth.provider, PROVIDER_ID));
+  },
+  async markProviderFailure(code) {
+    await db.execute(drizzleSql`
+      UPDATE profile_search_provider_health
+      SET consecutive_failures = consecutive_failures + 1,
+          last_failure_at = now(),
+          enabled = CASE WHEN consecutive_failures + 1 >= 2 THEN false ELSE enabled END,
+          disabled_reason = CASE
+            WHEN consecutive_failures + 1 >= 2 THEN ${`two_consecutive_failures:${code}`}
+            ELSE disabled_reason
+          END,
+          updated_at = now()
+      WHERE provider = ${PROVIDER_ID}
+    `);
+  },
+};
+
+export function runProfileSearchMonitoring(deadlineAt: number) {
+  return runProfileSearchBatch(dependencies, { deadlineAt });
+}

--- a/apps/web/tests/unit/api/cron/daily-maintenance.test.ts
+++ b/apps/web/tests/unit/api/cron/daily-maintenance.test.ts
@@ -8,6 +8,7 @@ const mockCleanupSmsIntents = vi.hoisted(() => vi.fn());
 const mockRunWaitlistAutoAccept = vi.hoisted(() => vi.fn());
 const mockSweepUnderEnrichedProfilesForCron = vi.hoisted(() => vi.fn());
 const mockRunOnboardingScriptAggregation = vi.hoisted(() => vi.fn());
+const mockRunProfileSearchMonitoring = vi.hoisted(() => vi.fn());
 const mockSyncAiCrawlerAnalyticsCron = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/analytics/data-retention', () => ({
@@ -51,6 +52,10 @@ vi.mock('@/lib/discography/re-enrich', () => ({
 
 vi.mock('@/lib/onboarding/script-aggregation', () => ({
   runOnboardingScriptAggregation: mockRunOnboardingScriptAggregation,
+}));
+
+vi.mock('@/lib/profile-search/runner', () => ({
+  runProfileSearchMonitoring: mockRunProfileSearchMonitoring,
 }));
 
 vi.mock('@/app/api/cron/sync-ai-crawler-analytics/route', () => ({
@@ -99,6 +104,16 @@ describe('GET /api/cron/daily-maintenance', () => {
       promoted: 0,
       retired: 0,
     });
+    mockRunProfileSearchMonitoring.mockResolvedValue({
+      enabled: false,
+      claimed: 0,
+      attempted: 0,
+      succeeded: 0,
+      failed: 0,
+      retried: 0,
+      skippedBudget: 0,
+      stoppedForDeadline: false,
+    });
     mockSyncAiCrawlerAnalyticsCron.mockResolvedValue({
       success: true,
       zonesProcessed: 1,
@@ -138,6 +153,10 @@ describe('GET /api/cron/daily-maintenance', () => {
     expect(data.results.billingReconciliation.success).toBe(true);
     expect(data.results.cleanupSmsIntents.success).toBe(true);
     expect(data.results.waitlistAutoAccept.success).toBe(true);
+    expect(data.results.profileSearchMonitoring.success).toBe(true);
+    expect(mockRunProfileSearchMonitoring).toHaveBeenCalledWith(
+      new Date('2026-03-29T00:00:00.000Z').getTime() + 90_000
+    );
     expect(data.results.discographyReEnrich.success).toBe(true);
     expect(data.results.discographyReEnrich.data).toEqual({
       profilesProcessed: 1,

--- a/apps/web/tests/unit/lib/profile-search-budget.test.ts
+++ b/apps/web/tests/unit/lib/profile-search-budget.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+let nodeEnv = 'test';
+let vercelEnv: string | undefined;
+vi.mock('@/lib/env-server', () => ({
+  env: {
+    get NODE_ENV() {
+      return nodeEnv;
+    },
+    get VERCEL_ENV() {
+      return vercelEnv;
+    },
+  },
+}));
+
+const mockGetRedis = vi.fn();
+vi.mock('@/lib/redis', () => ({ getRedis: () => mockGetRedis() }));
+
+describe('profile search budget', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    nodeEnv = 'test';
+    vercelEnv = undefined;
+  });
+
+  it('fails closed in production when Redis is unavailable', async () => {
+    nodeEnv = 'production';
+    vercelEnv = 'production';
+    mockGetRedis.mockReturnValue(null);
+    const { reserveProfileSearchAttempt } = await import(
+      '@/lib/profile-search/budget'
+    );
+
+    await expect(
+      reserveProfileSearchAttempt(
+        'attempt-1',
+        'scheduled',
+        new Date('2026-07-16T12:00:00.000Z')
+      )
+    ).resolves.toBe(false);
+  });
+
+  it('allows local development without Redis', async () => {
+    mockGetRedis.mockReturnValue(null);
+    const { reserveProfileSearchAttempt } = await import(
+      '@/lib/profile-search/budget'
+    );
+    await expect(
+      reserveProfileSearchAttempt('attempt-1', 'scheduled')
+    ).resolves.toBe(true);
+  });
+
+  it('uses atomic daily, retry, and idempotency keys', async () => {
+    const evalMock = vi.fn().mockResolvedValue(1);
+    mockGetRedis.mockReturnValue({ eval: evalMock });
+    const { reserveProfileSearchAttempt } = await import(
+      '@/lib/profile-search/budget'
+    );
+    const allowed = await reserveProfileSearchAttempt(
+      'attempt-2',
+      'retry',
+      new Date('2026-07-16T12:00:00.000Z')
+    );
+
+    expect(allowed).toBe(true);
+    expect(evalMock).toHaveBeenCalledWith(
+      expect.any(String),
+      [
+        'profile-search:budget:day:2026-07-16',
+        'profile-search:retry-budget:day:2026-07-16',
+        'profile-search:attempt:attempt-2',
+      ],
+      [200, 4, 'retry', 43_200]
+    );
+  });
+
+  it('returns false when Redis denies the reservation', async () => {
+    mockGetRedis.mockReturnValue({ eval: vi.fn().mockResolvedValue(0) });
+    const { reserveProfileSearchAttempt } = await import(
+      '@/lib/profile-search/budget'
+    );
+    await expect(
+      reserveProfileSearchAttempt('attempt-3', 'scheduled')
+    ).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- persist rank observations and run status with leases
- enforce Redis-backed daily provider budgets and per-plan account limits
- attach the bounded monitor subjob to daily maintenance without adding a new cron

## Verification
- persistence, lease, provider-health, budget, and daily-maintenance tests passed
- migration validation and migration guard passed
- typecheck, lint, and production build passed

## Rollout
Daily work is capped at 90 seconds and provider health defaults disabled.

Linear: JOV-2659