### PR TITLE
docs: add README status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A modern artist profile and link-in-bio platform built with Next.js, Clerk authentication, Neon PostgreSQL, and Drizzle ORM.
 
+[![CI](https://github.com/JovieInc/Jovie/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JovieInc/Jovie/actions/workflows/ci.yml?query=branch%3Amain)
+[![CodeQL](https://github.com/JovieInc/Jovie/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/JovieInc/Jovie/actions/workflows/codeql.yml?query=branch%3Amain)
+[![Security](https://github.com/JovieInc/Jovie/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/JovieInc/Jovie/actions/workflows/security.yml?query=branch%3Amain)
+
 ## Security & trust
 
 Jovie tracks OpenSSF security posture in-repository and is working toward an OpenSSF Best Practices badge.


### PR DESCRIPTION
## Summary
- Add README badges for the main CI workflow, CodeQL security analysis, and security scanning on `main`
- Place badges directly under the repository description for quick green/red visibility

## Testing
- Documentation-only change; verified diff is limited to `README.md` with 4 additions