### PR TITLE
fix(ci): unblock production deploy — in-job staging build + self-hosted runner race fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1559,6 +1559,11 @@ jobs:
           export HOSTNAME=localhost
 
           OVERFLOW_PORT=$((3210 + ${{ strategy.job-index }}))
+          # Pin app/auth URLs to this shard's isolated port — the shared build
+          # artifact bakes localhost:3100, which no longer matches this lane.
+          export NEXT_PUBLIC_APP_URL="http://localhost:$OVERFLOW_PORT"
+          export BETTER_AUTH_URL="http://localhost:$OVERFLOW_PORT"
+          export NEXT_PUBLIC_BETTER_AUTH_URL="http://localhost:$OVERFLOW_PORT"
           PORT="$OVERFLOW_PORT" node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
 
@@ -3577,9 +3582,12 @@ jobs:
           export SPOTIFY_CLIENT_ID="${{ secrets.SPOTIFY_CLIENT_ID }}"
           export SPOTIFY_CLIENT_SECRET="${{ secrets.SPOTIFY_CLIENT_SECRET }}"
           export MUSICFETCH_API_TOKEN="${{ secrets.MUSICFETCH_API_TOKEN }}"
-          export UPSTASH_REDIS_REST_URL="${{ secrets.UPSTASH_REDIS_REST_URL }}"
-          export UPSTASH_REDIS_REST_TOKEN="${{ secrets.UPSTASH_REDIS_REST_TOKEN }}"
-
+          # Deliberately NO UPSTASH_REDIS_REST_URL/TOKEN here: the OTP rate
+          # limiter's IP key collapses to 127.0.0.1 in this lane, so one shared
+          # Upstash bucket (3 sends/60s) is raced by every external dev/agent
+          # run — OTP send returned 429 and the code step never rendered.
+          # Without Redis, secondary storage falls back to per-process memory
+          # and this lane's OTP sends stay deterministic.
           PORT=3250 node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
           trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
@@ -3603,7 +3611,6 @@ jobs:
           BASE_URL=http://localhost:3250 E2E_SKIP_WEB_SERVER=1 pnpm --filter @jovie/web run test:e2e:golden-path:ci
         env:
           # The runner also needs the database and deterministic E2E OTP flag.
-          # UPSTASH_* is optional; the spec degrades to the in-memory limiter.
           DATABASE_URL: ${{ env.DATABASE_URL }}
           E2E_TEST_MODE: '1'
           BETTER_AUTH_URL: http://localhost:3250
@@ -3615,8 +3622,8 @@ jobs:
           SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
           SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
           MUSICFETCH_API_TOKEN: ${{ secrets.MUSICFETCH_API_TOKEN }}
-          UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
-          UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+          # UPSTASH_* intentionally unset (see the note above server start):
+          # per-process in-memory limiting keeps OTP sends deterministic.
 
       - name: Upload Playwright Artifacts on Failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3584,12 +3584,13 @@ jobs:
           export SPOTIFY_CLIENT_ID="${{ secrets.SPOTIFY_CLIENT_ID }}"
           export SPOTIFY_CLIENT_SECRET="${{ secrets.SPOTIFY_CLIENT_SECRET }}"
           export MUSICFETCH_API_TOKEN="${{ secrets.MUSICFETCH_API_TOKEN }}"
-          # Deliberately NO UPSTASH_REDIS_REST_URL/TOKEN here: the OTP rate
-          # limiter's IP key collapses to 127.0.0.1 in this lane, so one shared
-          # Upstash bucket (3 sends/60s) is raced by every external dev/agent
-          # run — OTP send returned 429 and the code step never rendered.
-          # Without Redis, secondary storage falls back to per-process memory
-          # and this lane's OTP sends stay deterministic.
+          # UPSTASH_REDIS_* MUST stay set in this lane: the anonymous onboarding
+          # chat limiters are requireRedis and fail CLOSED (429) without Redis.
+          # The loopback-IP shared-bucket OTP race is handled app-side instead —
+          # deterministic +e2e test emails are exempt from the OTP send limit.
+          export UPSTASH_REDIS_REST_URL="${{ secrets.UPSTASH_REDIS_REST_URL }}"
+          export UPSTASH_REDIS_REST_TOKEN="${{ secrets.UPSTASH_REDIS_REST_TOKEN }}"
+
           PORT=3250 node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
           trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
@@ -3624,8 +3625,8 @@ jobs:
           SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
           SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
           MUSICFETCH_API_TOKEN: ${{ secrets.MUSICFETCH_API_TOKEN }}
-          # UPSTASH_* intentionally unset (see the note above server start):
-          # per-process in-memory limiting keeps OTP sends deterministic.
+          UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+          UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
       - name: Upload Playwright Artifacts on Failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3487,8 +3487,8 @@ jobs:
         uses: ./.github/actions/resolve-neon-database-url
         with:
           connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
-          candidate_json_key: db_url
-          fallback_json_key: db_url_pooled
+          candidate_json_key: db_url_pooled
+          fallback_json_key: db_url
 
       - name: Export DATABASE_URL (shared ephemeral branch)
         if: needs.neon-db.result == 'success'
@@ -3510,14 +3510,26 @@ jobs:
         id: resolve-golden-path-fallback-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          candidate_url: ${{ steps.neon-branch.outputs.db_url }}
-          fallback_candidate_url: ${{ steps.neon-branch.outputs.db_url_pooled }}
+          candidate_url: ${{ steps.neon-branch.outputs.db_url_pooled }}
+          fallback_candidate_url: ${{ steps.neon-branch.outputs.db_url }}
           credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
           credential_fallback_url: ${{ secrets.DATABASE_URL }}
 
       - name: Export DATABASE_URL (fallback ephemeral branch)
         if: needs.neon-db.result != 'success'
         run: echo "DATABASE_URL=${{ steps.resolve-golden-path-fallback-neon-db-url.outputs.database_url }}" >> "$GITHUB_ENV"
+
+      - name: Fail if Neon DB URL is missing (Golden Path)
+        run: |
+          if [[ -z "$DATABASE_URL" ]]; then
+            echo "No Neon ephemeral DATABASE_URL available. Refusing to run Golden Path against staging/production DBs."
+            exit 1
+          fi
+
+      - name: Verify Neon DB connectivity (fail-fast)
+        run: pnpm --filter=@jovie/web exec tsx tests/e2e/verify-neon-db-connectivity.ts
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
 
       - name: Run migrations (ephemeral Neon)
         run: pnpm --filter=@jovie/web run drizzle:migrate:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1159,7 +1159,7 @@ jobs:
     # Shared Next.js build for a11y + layout-guard — build once, test twice.
     # On PRs to main: always runs (non-fork) for build validation. Part of the merge gate.
     # Merge groups rebuild the synthetic combined head to catch integration failures.
-    # On main push: always runs for full coverage + JOV-4087 vercel deploy artifact.
+    # On main push: always runs for full coverage.
     # Fork PRs are excluded (no secrets) — skipped via fork-pr-gate.
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false) || github.event_name == 'workflow_dispatch') }}
     # Production deploy artifacts must not wait behind the saturated fixed PR
@@ -1271,124 +1271,6 @@ jobs:
           path: /tmp/nextjs-build.tar
           retention-days: 1
           if-no-files-found: error
-
-      # JOV-4087: produce .vercel/output once on main so deploy-staging can skip
-      # its own vercel build (~3–5 min). Keep turbo `.next` artifact untouched for
-      # downstream test jobs. Soft-fail so a Vercel CLI blip cannot red the merge gate.
-      - name: Pull Vercel env (preview) for deploy artifact
-        id: vercel_pull
-        if: ${{ steps.check_changes.outputs.run_full_ci == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        continue-on-error: true
-        timeout-minutes: 10
-        run: |
-          set -euo pipefail
-          scope_args=()
-          if [ -n "${VERCEL_ORG_ID:-}" ]; then
-            scope_args=(--scope "$VERCEL_ORG_ID")
-          fi
-          for i in {1..3}; do
-            if ./node_modules/.bin/vercel pull --yes --environment=preview --token "$VERCEL_TOKEN" "${scope_args[@]}"; then
-              break
-            fi
-            echo "Vercel pull attempt $i failed, retrying in 10s..."
-            sleep 10
-            if [ $i -eq 3 ]; then exit 1; fi
-          done
-          for env_file in .vercel/.env.preview.local .vercel/.env.local; do
-            if [ -f "$env_file" ]; then
-              grep -v '^TURBO_REMOTE_ONLY=' "$env_file" > "${env_file}.tmp" || true
-              mv "${env_file}.tmp" "$env_file"
-            fi
-          done
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
-      - name: Vercel build (deploy artifact)
-        id: vercel_build
-        if: ${{ steps.check_changes.outputs.run_full_ci == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.vercel_pull.outcome == 'success' }}
-        continue-on-error: true
-        timeout-minutes: 10
-        run: |
-          set -euo pipefail
-          scope_args=()
-          if [ -n "${VERCEL_ORG_ID:-}" ]; then
-            scope_args=(--scope "$VERCEL_ORG_ID")
-          fi
-          # `vercel build` replaces the standalone tree. Snapshot the traced
-          # runtime first, then restore it at the repo-relative paths recorded
-          # in the generated function configs.
-          test -d apps/web/.next/standalone/apps/web/.next/node_modules
-          tar -czf /tmp/vercel-runtime-node-modules.tar.gz \
-            -C apps/web/.next/standalone/apps/web/.next node_modules
-          # Do NOT inherit NEXT_PUBLIC_CLERK_MOCK from the turbo build step —
-          # deploy artifact must match staging preview compile flags.
-          for i in {1..3}; do
-            if env -u TURBO_REMOTE_ONLY -u NEXT_PUBLIC_CLERK_MOCK -u NEXT_PUBLIC_CLERK_PROXY_DISABLED \
-              ./node_modules/.bin/vercel build --token "$VERCEL_TOKEN" "${scope_args[@]}"; then
-              break
-            fi
-            echo "Vercel build attempt $i failed, retrying in 10s..."
-            sleep 10
-            if [ $i -eq 3 ]; then exit 1; fi
-          done
-          # Generated function configs reference chunks across the complete
-          # Next server tree, not only edge assets. Preserve that trace root so
-          # the prebuilt upload is closed over every generated server file.
-          test -d apps/web/.next/server/chunks
-          rm -rf apps/web/.next/node_modules
-          tar -xzf /tmp/vercel-runtime-node-modules.tar.gz -C apps/web/.next
-          find apps/web/.next/node_modules -maxdepth 1 -type d \
-            -name 'import-in-the-middle-*' -print -quit | grep -q .
-          # Vercel's function trace references the generated robots response at
-          # its public-file path even though the source route is app/robots.ts.
-          # Materialize it only inside the deploy artifact; the deploy helper
-          # removes generated public files before any source fallback.
-          test -f apps/web/.next/server/app/robots.txt.body
-          cp apps/web/.next/server/app/robots.txt.body apps/web/public/robots.txt
-          printf '%s\n' 'apps/web/public/robots.txt' \
-            > .vercel/jovie-generated-public-files
-          tar -czf /tmp/vercel-build-output.tar.gz -C . \
-            .vercel/output \
-            .vercel/jovie-generated-public-files \
-            apps/web/public/robots.txt \
-            apps/web/.next/BUILD_ID \
-            apps/web/.next/app-path-routes-manifest.json \
-            apps/web/.next/build-manifest.json \
-            apps/web/.next/package.json \
-            apps/web/.next/prerender-manifest.json \
-            apps/web/.next/required-server-files.json \
-            apps/web/.next/server \
-            apps/web/.next/node_modules
-          tar -tzf /tmp/vercel-build-output.tar.gz \
-            apps/web/.next/package.json >/dev/null
-          tar -tzf /tmp/vercel-build-output.tar.gz \
-            apps/web/.next/server/chunks >/dev/null
-          tar -tzf /tmp/vercel-build-output.tar.gz \
-            apps/web/.next/node_modules >/dev/null
-          tar -tzf /tmp/vercel-build-output.tar.gz \
-            apps/web/public/robots.txt >/dev/null
-          echo "vercel_artifact=true" >> "$GITHUB_OUTPUT"
-        env:
-          COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
-          COREPACK_ENABLE_STRICT: 0
-          VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
-      - name: Upload vercel build artifact
-        if: ${{ steps.vercel_build.outputs.vercel_artifact == 'true' }}
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: vercel-build-output-${{ github.run_id }}
-          path: /tmp/vercel-build-output.tar.gz
-          retention-days: 1
-          if-no-files-found: warn
 
   ci-layout-guard:
     name: Layout Guard
@@ -5282,7 +5164,7 @@ jobs:
           fi
 
   deploy-staging:
-    # deploy-gate already needs ci-build-public (JOV-4087 vercel artifact producer).
+    # deploy-gate already needs ci-build-public.
     needs: [deploy-gate]
     # Fast main path: merge on deterministic checks, deploy a production build to
     # a preview URL, verify it on staging, then promote only if it passes.
@@ -5373,39 +5255,9 @@ jobs:
         # merge commit message. The Slack drift notification in deploy-notify
         # fires when verify fails but deploy proceeds (bypass alert).
         continue-on-error: ${{ contains(github.event.head_commit.message, '[skip-schema-verify]') }}
-      # JOV-4087: reuse vercel build from ci-build-public when available.
-      - name: Download vercel build artifact
-        id: download_vercel_build
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: vercel-build-output-${{ github.run_id }}
-          path: /tmp
-
-      - name: Restore vercel build output from artifact
-        id: restore_vercel_build
-        if: steps.download_vercel_build.outcome == 'success'
-        continue-on-error: true
-        run: |
-          set -euo pipefail
-          if [ -f /tmp/vercel-build-output.tar.gz ]; then
-            mkdir -p .vercel
-            tar -xzf /tmp/vercel-build-output.tar.gz -C .
-            if [ -d .vercel/output ]; then
-              echo "restored=true" >> "$GITHUB_OUTPUT"
-              echo "Restored .vercel/output from ci-build-public artifact (JOV-4087)"
-            else
-              echo "restored=false" >> "$GITHUB_OUTPUT"
-              echo "::warning::vercel artifact missing .vercel/output after extract"
-            fi
-          else
-            echo "restored=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::vercel-build-output tar not found after download"
-          fi
-
       - name: Pull env (staging preview)
-        # Always pull project metadata/env; needed even when prebuilt output is restored
-        # (deploy CLI reads .vercel/project.json).
+        # Always pull project metadata/env; the deploy CLI reads
+        # .vercel/project.json even for prebuilt deploys.
         timeout-minutes: 10
         run: |
           scope_args=()
@@ -5431,10 +5283,9 @@ jobs:
       - name: Check signup readiness (staging deploy env)
         run: pnpm --filter=@jovie/web exec tsx scripts/check-signup-readiness.ts --target=stg --source=env
       - name: Build (preview target for staging verification)
-        # Skip when JOV-4087 artifact restored successfully.
-        if: steps.restore_vercel_build.outputs.restored != 'true'
         timeout-minutes: 10
         run: |
+          set -euo pipefail
           scope_args=()
           if [ -n "${VERCEL_ORG_ID:-}" ]; then
             scope_args=(--scope "$VERCEL_ORG_ID")
@@ -5447,6 +5298,12 @@ jobs:
             sleep 10
             if [ $i -eq 3 ]; then exit 1; fi
           done
+          # Vercel's function trace references the generated robots response at
+          # its public-file path even though the source route is app/robots.ts.
+          test -f apps/web/.next/server/app/robots.txt.body
+          cp apps/web/.next/server/app/robots.txt.body apps/web/public/robots.txt
+          printf '%s\n' 'apps/web/public/robots.txt' \
+            > .vercel/jovie-generated-public-files
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
           COREPACK_ENABLE_STRICT: 0
@@ -5456,11 +5313,7 @@ jobs:
       - name: Package build output for provenance attestation
         run: |
           set -euo pipefail
-          if [ -f /tmp/vercel-build-output.tar.gz ] && [ "${{ steps.restore_vercel_build.outputs.restored }}" = "true" ]; then
-            echo "Using downloaded vercel-build-output.tar.gz for attestation"
-          else
-            tar -czf /tmp/vercel-build-output.tar.gz -C . .vercel/output
-          fi
+          tar -czf /tmp/vercel-build-output.tar.gz -C . .vercel/output
       - name: Attest build provenance (SLSA Level 2)
         id: attest
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
@@ -5519,7 +5372,7 @@ jobs:
           # The closed staging artifact contains more than Vercel's 15k plain
           # upload limit. Give the archive path the full prebuilt budget.
           VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'false'
-          # The restored artifact is the thing canary verifies. A source
+          # The in-job prebuilt artifact is the thing canary verifies. A source
           # fallback would silently discard it and repeat the slow server build.
           VERCEL_ENABLE_SOURCE_FALLBACK: 'false'
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1097,14 +1097,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         id: resolve-drizzle-neon-db-url
         if: steps.check_changes.outputs.run_full_ci == 'true'
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url
           fallback_json_key: db_url_pooled
           credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
@@ -1250,15 +1250,22 @@ jobs:
       - name: Verify build output exists
         if: steps.check_changes.outputs.run_full_ci == 'true'
         run: |
-          if [ ! -d "apps/web/.next" ]; then
-            echo "::error::Build output directory apps/web/.next does not exist — build may have used remote cache without producing local output"
-            exit 1
-          fi
+          # Fail closed on a partial tree: remote-cache hits or tar truncation can
+          # leave apps/web/.next present without the files lanes actually run.
+          for required in \
+            apps/web/.next/BUILD_ID \
+            apps/web/.next/standalone/apps/web/server.js \
+            apps/web/.next/standalone/apps/web/.next/BUILD_ID; do
+            if [ ! -f "$required" ]; then
+              echo "::error::Build output missing $required — build may have used remote cache without producing local output"
+              exit 1
+            fi
+          done
           echo "Build output verified: $(du -sh apps/web/.next | cut -f1)"
 
       - name: Package build artifact
         if: steps.check_changes.outputs.run_full_ci == 'true'
-        run: tar -cf /tmp/nextjs-build.tar -C apps/web .next
+        run: tar -cf "${{ runner.temp }}/nextjs-build.tar" -C apps/web .next
 
       - name: Upload build artifact
         if: steps.check_changes.outputs.run_full_ci == 'true'
@@ -1270,7 +1277,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build.tar
+          path: ${{ runner.temp }}/nextjs-build.tar
           retention-days: 1
           if-no-files-found: error
 
@@ -1333,7 +1340,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
 
       - name: Require combined-head build artifact
         if: github.event_name == 'merge_group' && steps.download.outcome != 'success'
@@ -1343,7 +1350,7 @@ jobs:
 
       - name: Extract build artifact
         if: steps.download.outcome == 'success'
-        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+        run: tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
 
       - name: Run deterministic layout behavior guard
         if: steps.download.outcome == 'success'
@@ -1354,7 +1361,7 @@ jobs:
           LAYOUT_GUARD_MANIFEST=$(node ../../.github/scripts/layout-guard-manifest.mjs)
           mapfile -t LAYOUT_GUARD_SPECS <<< "$LAYOUT_GUARD_MANIFEST"
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "::error::Layout Guard standalone server entrypoint is missing."
             exit 1
           fi
@@ -1362,15 +1369,16 @@ jobs:
           mkdir -p tests/.auth
           echo '{"cookies":[],"origins":[]}' > tests/.auth/user.json
           export HOSTNAME=localhost
-          export NEXT_PUBLIC_APP_URL=http://localhost:3100
+          export NEXT_PUBLIC_APP_URL=http://localhost:3230
 
-          PORT=3100 node .next/standalone/apps/web/server.js &
+          PORT=3230 node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
           trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
 
           SERVER_READY=false
           for attempt in $(seq 1 30); do
-            if curl -sf http://localhost:3100 > /dev/null 2>&1; then
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
+            if curl -sf http://localhost:3230 > /dev/null 2>&1; then
               SERVER_READY=true
               break
             fi
@@ -1385,7 +1393,7 @@ jobs:
 
           pnpm exec playwright test "${LAYOUT_GUARD_SPECS[@]}" --config=playwright.config.noauth.ts --project=chromium --reporter=line
         env:
-          BASE_URL: http://localhost:3100
+          BASE_URL: http://localhost:3230
           SMOKE_ONLY: '1'
           CI: true
           HUD_KIOSK_TOKEN: layout-guard-ci
@@ -1429,7 +1437,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         # Use only the ephemeral branch credentials from the neon-db artifact.
@@ -1438,7 +1446,7 @@ jobs:
         id: resolve-mobile-overflow-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url_pooled
           fallback_json_key: db_url
 
@@ -1500,11 +1508,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
 
       - name: Extract build artifact
         if: steps.download-build.outcome == 'success'
-        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+        run: tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
 
       - name: Build app fallback
         if: steps.download-build.outcome != 'success'
@@ -1523,7 +1531,7 @@ jobs:
         run: |
           cd apps/web
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "Standalone server not found - mobile overflow guard cannot start."
             exit 1
           fi
@@ -1550,12 +1558,14 @@ jobs:
           export NEXT_PUBLIC_CLERK_PROXY_DISABLED=1
           export HOSTNAME=localhost
 
-          PORT=3100 node .next/standalone/apps/web/server.js &
+          OVERFLOW_PORT=$((3210 + ${{ strategy.job-index }}))
+          PORT="$OVERFLOW_PORT" node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
 
           SERVER_READY=false
           for attempt in $(seq 1 30); do
-            if curl -sf http://localhost:3100 > /dev/null 2>&1; then
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
+            if curl -sf "http://localhost:$OVERFLOW_PORT" > /dev/null 2>&1; then
               SERVER_READY=true
               break
             fi
@@ -1570,9 +1580,8 @@ jobs:
 
           # The lane uses the deterministic test-auth bypass, so use the
           # no-auth config and avoid its unrelated legacy Clerk setup project.
-          pnpm exec playwright test tests/e2e/mobile-overflow.spec.ts --config=playwright.config.noauth.ts --project=chromium --reporter=line
+          BASE_URL="http://localhost:$OVERFLOW_PORT" pnpm exec playwright test tests/e2e/mobile-overflow.spec.ts --config=playwright.config.noauth.ts --project=chromium --reporter=line
         env:
-          BASE_URL: http://localhost:3100
           DATABASE_URL: ${{ env.DATABASE_URL }}
           NODE_ENV: test
           # Match ci-e2e-smoke: standalone is production-built; VERCEL_ENV=development
@@ -1636,7 +1645,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         # Prefer ephemeral branch host from neon-db artifact. credential_source
@@ -1646,7 +1655,7 @@ jobs:
         id: resolve-lighthouse-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url_pooled
           fallback_json_key: db_url
           credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
@@ -1707,11 +1716,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
 
       - name: Extract build artifact
         if: steps.download-build.outcome == 'success'
-        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+        run: tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
 
       - name: Build app fallback for public Lighthouse
         if: steps.download-build.outcome != 'success'
@@ -1760,7 +1769,7 @@ jobs:
           export BETTER_AUTH_URL=http://localhost:3000
           export NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3000
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "Standalone server not found - public Lighthouse cannot start."
             exit 1
           fi
@@ -1771,6 +1780,7 @@ jobs:
           echo "Waiting for standalone server..."
           SERVER_READY=false
           for i in {1..30}; do
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
             if curl -s http://localhost:3000 > /dev/null; then
               echo "Server is ready!"
               SERVER_READY=true
@@ -1900,11 +1910,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
 
       - name: Extract build artifact
         if: steps.check_changes.outputs.run_full_ci == 'true' && steps.download-build.outcome == 'success'
-        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+        run: tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
 
       - name: Build app fallback for dashboard Lighthouse
         if: steps.check_changes.outputs.run_full_ci == 'true' && steps.download-build.outcome != 'success'
@@ -1930,7 +1940,7 @@ jobs:
           export NEXT_PUBLIC_CLERK_MOCK=1
           export NEXT_PUBLIC_CLERK_PROXY_DISABLED=1
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "Standalone server not found — dashboard Lighthouse cannot start."
             exit 1
           fi
@@ -1942,6 +1952,7 @@ jobs:
           echo "Waiting for standalone server..."
           SERVER_READY=false
           for i in {1..30}; do
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
             if curl -s http://localhost:3000 > /dev/null; then
               SERVER_READY=true
               break
@@ -2008,14 +2019,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         if: needs.ci-path-changes.outputs.run_neon == 'true'
         id: resolve-onboarding-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url_pooled
           fallback_json_key: db_url
 
@@ -2043,11 +2054,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
 
       - name: Extract build artifact
         if: steps.download-build.outcome == 'success'
-        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+        run: tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
 
       - name: Build app fallback for onboarding Lighthouse
         if: steps.download-build.outcome != 'success'
@@ -2072,7 +2083,7 @@ jobs:
           export NEXT_PUBLIC_CLERK_MOCK=1
           export NEXT_PUBLIC_CLERK_PROXY_DISABLED=1
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "Standalone server not found — onboarding Lighthouse cannot start."
             exit 1
           fi
@@ -2084,6 +2095,7 @@ jobs:
           echo "Waiting for standalone server..."
           SERVER_READY=false
           for i in {1..30}; do
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
             if curl -s http://localhost:3000 > /dev/null; then
               SERVER_READY=true
               break
@@ -2141,14 +2153,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         if: needs.ci-path-changes.outputs.run_neon == 'true'
         id: resolve-admin-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url_pooled
           fallback_json_key: db_url
 
@@ -2175,11 +2187,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
 
       - name: Extract build artifact
         if: steps.download-build.outcome == 'success'
-        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+        run: tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
 
       - name: Build app fallback for admin Lighthouse
         if: steps.download-build.outcome != 'success'
@@ -2204,7 +2216,7 @@ jobs:
           export NEXT_PUBLIC_CLERK_MOCK=1
           export NEXT_PUBLIC_CLERK_PROXY_DISABLED=1
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "Standalone server not found — admin Lighthouse cannot start."
             exit 1
           fi
@@ -2216,6 +2228,7 @@ jobs:
           echo "Waiting for standalone server..."
           SERVER_READY=false
           for i in {1..30}; do
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
             if curl -s http://localhost:3000 > /dev/null; then
               SERVER_READY=true
               break
@@ -2276,14 +2289,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         if: needs.ci-path-changes.outputs.run_neon == 'true'
         id: resolve-chat-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url_pooled
           fallback_json_key: db_url
 
@@ -2310,11 +2323,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
 
       - name: Extract build artifact
         if: steps.download-build.outcome == 'success'
-        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+        run: tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
 
       - name: Build app fallback for chat Lighthouse
         if: steps.download-build.outcome != 'success'
@@ -2339,7 +2352,7 @@ jobs:
           export NEXT_PUBLIC_CLERK_MOCK=1
           export NEXT_PUBLIC_CLERK_PROXY_DISABLED=1
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "Standalone server not found — chat Lighthouse cannot start."
             exit 1
           fi
@@ -2351,6 +2364,7 @@ jobs:
           echo "Waiting for standalone server..."
           SERVER_READY=false
           for i in {1..30}; do
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
             if curl -s http://localhost:3000 > /dev/null; then
               SERVER_READY=true
               break
@@ -2416,14 +2430,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         id: resolve-pr-neon-db-url
         if: steps.check_changes.outputs.run_full_ci == 'true'
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url
           fallback_json_key: db_url_pooled
 
@@ -2936,14 +2950,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         if: steps.check_changes.outputs.run_full_ci == 'true'
         id: resolve-a11y-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url_pooled
           fallback_json_key: db_url
           credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
@@ -2971,11 +2985,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
 
       - name: Extract build artifact
         if: steps.check_changes.outputs.run_full_ci == 'true'
-        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+        run: tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
 
       - name: Run migrations (ephemeral Neon)
         if: steps.check_changes.outputs.run_full_ci == 'true'
@@ -3008,21 +3022,22 @@ jobs:
           }
           trap cleanup EXIT
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "Standalone server not found - public axe audit cannot start."
             exit 1
           fi
 
           # Keep absolute URLs on loopback (GHA HOSTNAME is the runner machine name).
           export HOSTNAME=localhost
-          export NEXT_PUBLIC_APP_URL=http://localhost:3100
+          export NEXT_PUBLIC_APP_URL=http://localhost:3220
 
-          PORT=3100 node .next/standalone/apps/web/server.js &
+          PORT=3220 node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
 
           SERVER_READY=false
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:3100 > /dev/null 2>&1; then
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
+            if curl -sf http://localhost:3220 > /dev/null 2>&1; then
               SERVER_READY=true
               break
             fi
@@ -3036,7 +3051,7 @@ jobs:
 
           pnpm exec playwright test tests/e2e/axe-audit.spec.ts --config=playwright.config.ts --project=chromium --reporter=line
         env:
-          BASE_URL: http://localhost:3100
+          BASE_URL: http://localhost:3220
           SMOKE_ONLY: '1'
           CI: true
           DATABASE_URL: ${{ env.DATABASE_URL }}
@@ -3075,14 +3090,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
         continue-on-error: true
 
       - name: Resolve DATABASE_URL from Neon artifact
         id: resolve-a11y-authed-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url_pooled
           fallback_json_key: db_url
           credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
@@ -3109,14 +3124,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
         continue-on-error: true
 
       - name: Extract or rebuild
         if: env.DATABASE_URL != ''
         run: |
-          if [ -f /tmp/nextjs-build-download/nextjs-build.tar ]; then
-            tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+          if [ -f "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" ]; then
+            tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
           else
             pnpm turbo build --filter=@jovie/web
           fi
@@ -3148,7 +3163,7 @@ jobs:
           cleanup() { kill "$SERVER_PID" 2>/dev/null || true; }
           trap cleanup EXIT
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "::error::Standalone server not found for authenticated a11y."
             exit 1
           fi
@@ -3163,10 +3178,11 @@ jobs:
           export NEXT_PUBLIC_CLERK_PROXY_DISABLED=1
           export HOSTNAME=localhost
 
-          PORT=3100 node .next/standalone/apps/web/server.js &
+          PORT=3270 node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:3100 > /dev/null 2>&1; then break; fi
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
+            if curl -sf http://localhost:3270 > /dev/null 2>&1; then break; fi
             sleep 1
           done
 
@@ -3175,7 +3191,7 @@ jobs:
             tests/e2e/chat-axe.spec.ts \
             --config=playwright.config.ts --project=chromium
         env:
-          BASE_URL: http://localhost:3100
+          BASE_URL: http://localhost:3270
           CI: true
           DATABASE_URL: ${{ env.DATABASE_URL }}
           NODE_ENV: test
@@ -3241,14 +3257,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         if: steps.check_changes.outputs.run_full_ci == 'true' && needs.neon-db.result == 'success'
         id: resolve-e2e-smoke-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url
           fallback_json_key: db_url_pooled
 
@@ -3306,11 +3322,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
 
       - name: Extract build artifact
         if: steps.check_changes.outputs.run_full_ci == 'true'
-        run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+        run: tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
 
       - name: Materialize standalone assets (PR smoke)
         if: steps.check_changes.outputs.run_full_ci == 'true'
@@ -3324,7 +3340,7 @@ jobs:
         run: |
           cd apps/web
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "::error::Standalone server not found — ci-build-public artifact is required for PR smoke"
             exit 1
           fi
@@ -3368,17 +3384,18 @@ jobs:
           # absolute URL construction and can rewrite redirects to 0.0.0.0 / non-loopback
           # hosts, which breaks claim flows and test-auth trusted-host checks.
           export HOSTNAME=localhost
-          export NEXT_PUBLIC_APP_URL=http://localhost:3100
-          export BETTER_AUTH_URL=http://localhost:3100
-          export NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3100
+          export NEXT_PUBLIC_APP_URL=http://localhost:3240
+          export BETTER_AUTH_URL=http://localhost:3240
+          export NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3240
 
-          PORT=3100 node .next/standalone/apps/web/server.js &
+          PORT=3240 node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
           trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
 
           SERVER_READY=false
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:3100 > /dev/null 2>&1; then
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
+            if curl -sf http://localhost:3240 > /dev/null 2>&1; then
               SERVER_READY=true
               break
             fi
@@ -3391,11 +3408,11 @@ jobs:
           fi
 
           cd "$GITHUB_WORKSPACE"
-          CI=true BASE_URL=http://localhost:3100 pnpm --filter=@jovie/web exec playwright test --config=playwright.config.smoke.ts --project=chromium --reporter=line
+          CI=true BASE_URL=http://localhost:3240 pnpm --filter=@jovie/web exec playwright test --config=playwright.config.smoke.ts --project=chromium --reporter=line
         env:
           DATABASE_URL: ${{ env.DATABASE_URL }}
-          BETTER_AUTH_URL: http://localhost:3100
-          NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:3100
+          BETTER_AUTH_URL: http://localhost:3240
+          NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:3240
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           FLAGS_SECRET: ${{ secrets.FLAGS_SECRET }}
@@ -3455,14 +3472,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         if: needs.neon-db.result == 'success'
         id: resolve-golden-path-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url
           fallback_json_key: db_url_pooled
 
@@ -3512,8 +3529,8 @@ jobs:
         run: pnpm turbo build --filter=@jovie/web --force
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
-          NEXT_PUBLIC_APP_URL: http://localhost:3100
-          NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:3100
+          NEXT_PUBLIC_APP_URL: http://localhost:3250
+          NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:3250
           NEXT_IGNORE_ESLINT: '1'
           NEXT_IGNORE_TYPECHECK: '1'
           NEXT_PRIVATE_SKIP_SIZE_CHECK: 'true'
@@ -3527,7 +3544,7 @@ jobs:
         run: |
           cd apps/web
 
-          if [ ! -f .next/standalone/apps/web/server.js ]; then
+          if [ ! -f .next/standalone/apps/web/server.js ] || [ ! -f .next/standalone/apps/web/.next/BUILD_ID ]; then
             echo "::error::Standalone server not found — ci-build-public artifact is required for the golden path"
             exit 1
           fi
@@ -3547,11 +3564,11 @@ jobs:
           # The loopback-only server gate also requires this explicit flag before
           # it will bypass Turnstile for the first anonymous request.
           export PUBLIC_NOAUTH_SMOKE=1
-          export NEXT_PUBLIC_APP_URL=http://localhost:3100
-          export BETTER_AUTH_URL=http://localhost:3100
-          export NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3100
+          export NEXT_PUBLIC_APP_URL=http://localhost:3250
+          export BETTER_AUTH_URL=http://localhost:3250
+          export NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3250
           # GHA HOSTNAME is the runner machine name; pin loopback so BA redirects
-          # and form origin checks stay on localhost:3100.
+          # and form origin checks stay on localhost:3250.
           export HOSTNAME=localhost
           export NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}"
           export CLERK_SECRET_KEY="${{ secrets.CLERK_SECRET_KEY }}"
@@ -3563,13 +3580,14 @@ jobs:
           export UPSTASH_REDIS_REST_URL="${{ secrets.UPSTASH_REDIS_REST_URL }}"
           export UPSTASH_REDIS_REST_TOKEN="${{ secrets.UPSTASH_REDIS_REST_TOKEN }}"
 
-          PORT=3100 node .next/standalone/apps/web/server.js &
+          PORT=3250 node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
           trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
 
           SERVER_READY=false
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:3100 > /dev/null 2>&1; then
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
+            if curl -sf http://localhost:3250 > /dev/null 2>&1; then
               SERVER_READY=true
               break
             fi
@@ -3582,14 +3600,14 @@ jobs:
           fi
 
           cd "$GITHUB_WORKSPACE"
-          BASE_URL=http://localhost:3100 E2E_SKIP_WEB_SERVER=1 pnpm --filter @jovie/web run test:e2e:golden-path:ci
+          BASE_URL=http://localhost:3250 E2E_SKIP_WEB_SERVER=1 pnpm --filter @jovie/web run test:e2e:golden-path:ci
         env:
           # The runner also needs the database and deterministic E2E OTP flag.
           # UPSTASH_* is optional; the spec degrades to the in-memory limiter.
           DATABASE_URL: ${{ env.DATABASE_URL }}
           E2E_TEST_MODE: '1'
-          BETTER_AUTH_URL: http://localhost:3100
-          NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:3100
+          BETTER_AUTH_URL: http://localhost:3250
+          NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:3250
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
@@ -3786,14 +3804,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         id: resolve-e2e-migrate-neon-db-url
         if: steps.check_changes.outputs.run_full_ci == 'true'
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url
           fallback_json_key: db_url_pooled
           credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
@@ -3862,13 +3880,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         id: resolve-e2e-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url
           fallback_json_key: db_url_pooled
           credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
@@ -4997,13 +5015,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}
-          path: /tmp/neon-db-connection
+          path: ${{ runner.temp }}/neon-db-connection
 
       - name: Resolve DATABASE_URL from Neon artifact
         id: resolve-smoke-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
-          connection_file: /tmp/neon-db-connection/connection.json
+          connection_file: ${{ runner.temp }}/neon-db-connection/connection.json
           candidate_json_key: db_url_pooled
           fallback_json_key: db_url
           credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
@@ -5029,14 +5047,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextjs-build-${{ github.run_id }}
-          path: /tmp/nextjs-build-download
+          path: ${{ runner.temp }}/nextjs-build-download
         continue-on-error: true
 
       - name: Extract or rebuild for smoke tests
         run: |
-          if [ -f /tmp/nextjs-build-download/nextjs-build.tar ]; then
+          if [ -f "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" ]; then
             echo "Reusing build artifact (saves ~3-4 min)"
-            tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
+            tar -xf "$RUNNER_TEMP/nextjs-build-download/nextjs-build.tar" -C apps/web
           else
             echo "Build artifact not available, building from scratch"
             pnpm turbo build --filter=@jovie/web
@@ -5047,8 +5065,8 @@ jobs:
         env:
           DATABASE_URL: ${{ env.DATABASE_URL }}
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
-          NEXT_PUBLIC_APP_URL: http://localhost:3100
-          NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:3100
+          NEXT_PUBLIC_APP_URL: http://localhost:3260
+          NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:3260
           # Keep rebuild fallback equivalent to the shared ci-build artifact.
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: 1x00000000000000000000AA
           # NEXT_PUBLIC_* must be present at build time for standalone smoke runs.
@@ -5070,9 +5088,9 @@ jobs:
           export NODE_ENV=test
           export VERCEL_ENV=development
           export HOSTNAME=localhost
-          export NEXT_PUBLIC_APP_URL=http://localhost:3100
-          export BETTER_AUTH_URL=http://localhost:3100
-          export NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3100
+          export NEXT_PUBLIC_APP_URL=http://localhost:3260
+          export BETTER_AUTH_URL=http://localhost:3260
+          export NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3260
           export NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}"
           export NEXT_PUBLIC_TURNSTILE_SITE_KEY="1x00000000000000000000AA"
           export TURNSTILE_SECRET_KEY="1x0000000000000000000000000000000AA"
@@ -5090,14 +5108,15 @@ jobs:
           export FLAGS_SECRET="${{ secrets.FLAGS_SECRET }}"
           export URL_ENCRYPTION_KEY="smoke-preview-url-encryption-key"
           export AI_GATEWAY_API_KEY="smoke-preview-ai-gateway-key"
-          PORT=3100 node .next/standalone/apps/web/server.js &
+          PORT=3260 node .next/standalone/apps/web/server.js &
           SERVER_PID=$!
           trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
 
           # Wait for server readiness
           SERVER_READY=false
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:3100 > /dev/null 2>&1; then
+            kill -0 "$SERVER_PID" 2>/dev/null || { echo "Standalone server died"; exit 1; }
+            if curl -sf http://localhost:3260 > /dev/null 2>&1; then
               SERVER_READY=true
               break
             fi
@@ -5112,14 +5131,14 @@ jobs:
           # Run smoke tests with BASE_URL set (skips Playwright webServer config)
           cd "$GITHUB_WORKSPACE"
           set +e
-          CI=true BASE_URL=http://localhost:3100 pnpm --filter=@jovie/web exec playwright test --config=playwright.config.smoke.ts --reporter=line
+          CI=true BASE_URL=http://localhost:3260 pnpm --filter=@jovie/web exec playwright test --config=playwright.config.smoke.ts --reporter=line
           EXIT_CODE=$?
           set -e
           exit $EXIT_CODE
         env:
           DATABASE_URL: ${{ env.DATABASE_URL }}
-          BETTER_AUTH_URL: http://localhost:3100
-          NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:3100
+          BETTER_AUTH_URL: http://localhost:3260
+          NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:3260
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: 1x00000000000000000000AA
           TURNSTILE_SECRET_KEY: 1x0000000000000000000000000000000AA

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1181,6 +1181,8 @@ jobs:
           rm -f .git/info/sparse-checkout
           git config --local --unset-all extensions.partialClone 2>/dev/null || true
           git config --local --unset-all remote.origin.promisorRemote 2>/dev/null || true
+          git reset --hard HEAD 2>/dev/null || true
+          git clean -ffdx 2>/dev/null || true
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -1294,6 +1296,8 @@ jobs:
           rm -f .git/info/sparse-checkout
           git config --local --unset-all extensions.partialClone 2>/dev/null || true
           git config --local --unset-all remote.origin.promisorRemote 2>/dev/null || true
+          git reset --hard HEAD 2>/dev/null || true
+          git clean -ffdx 2>/dev/null || true
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -2761,10 +2765,50 @@ jobs:
     outputs:
       run_full_ci: ${{ steps.check_changes.outputs.run_full_ci }}
     steps:
+      # Fixed self-hosted runners reuse one workspace across PRs. Stale sparse-checkout
+      # / dirty trees leave .github/actions/* missing and fail composite action load
+      # ("Can't find action.yml under setup-node-pnpm") before any tests run.
+      - name: Reset workspace git state (self-hosted)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -d .git ]]; then exit 0; fi
+          git sparse-checkout disable 2>/dev/null || true
+          git config --local --unset-all core.sparseCheckout 2>/dev/null || true
+          git config --local --unset-all core.sparseCheckoutCone 2>/dev/null || true
+          rm -f .git/info/sparse-checkout
+          git config --local --unset-all extensions.partialClone 2>/dev/null || true
+          git config --local --unset-all remote.origin.promisorRemote 2>/dev/null || true
+          # Clear dirty tracked/untracked leftovers so checkout clean does not skip
+          # paths ("not uptodate; will not remove from working tree").
+          git reset --hard HEAD 2>/dev/null || true
+          git clean -ffdx 2>/dev/null || true
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # Full history for vitest --changed (names via commit graph)
           filter: blob:none # historical blobs lazy-fetch; saves ~30s × 5 shards/run
+          clean: true
+
+      - name: Materialize full tree (self-hosted)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git sparse-checkout disable 2>/dev/null || true
+          git reset --hard HEAD
+          git checkout-index -a -f
+
+      - name: Verify checkout sentinel
+        shell: bash
+        run: |
+          set -euo pipefail
+          sentinel=".github/actions/setup-node-pnpm/action.yml"
+          if [[ ! -f "$sentinel" ]]; then
+            echo "::error::Incomplete checkout — missing ${sentinel}"
+            exit 1
+          fi
 
       - name: Check for relevant changes
         id: check_changes
@@ -4055,7 +4099,46 @@ jobs:
     outputs:
       deployment_url: ${{ steps.pr_deploy.outputs.deployment_url }}
     steps:
+      # Same fixed-runner hygiene as unit tests / public build: clear sparse
+      # leftovers and dirty trees before composite setup-node-pnpm runs.
+      - name: Reset workspace git state (self-hosted)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -d .git ]]; then exit 0; fi
+          git sparse-checkout disable 2>/dev/null || true
+          git config --local --unset-all core.sparseCheckout 2>/dev/null || true
+          git config --local --unset-all core.sparseCheckoutCone 2>/dev/null || true
+          rm -f .git/info/sparse-checkout
+          git config --local --unset-all extensions.partialClone 2>/dev/null || true
+          git config --local --unset-all remote.origin.promisorRemote 2>/dev/null || true
+          git reset --hard HEAD 2>/dev/null || true
+          git clean -ffdx 2>/dev/null || true
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          clean: true
+
+      - name: Materialize full tree (self-hosted)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git sparse-checkout disable 2>/dev/null || true
+          git reset --hard HEAD
+          git checkout-index -a -f
+
+      - name: Verify checkout sentinel
+        shell: bash
+        run: |
+          set -euo pipefail
+          sentinel=".github/actions/setup-node-pnpm/action.yml"
+          if [[ ! -f "$sentinel" ]]; then
+            echo "::error::Incomplete checkout — missing ${sentinel}"
+            exit 1
+          fi
+
       - uses: ./.github/actions/setup-node-pnpm
       - name: Pull env (preview)
         timeout-minutes: 10
@@ -4590,6 +4673,8 @@ jobs:
           rm -f .git/info/sparse-checkout
           git config --local --unset-all extensions.partialClone 2>/dev/null || true
           git config --local --unset-all remote.origin.promisorRemote 2>/dev/null || true
+          git reset --hard HEAD 2>/dev/null || true
+          git clean -ffdx 2>/dev/null || true
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -877,7 +877,9 @@ jobs:
     # Run for push to main or any selected evidence lane that needs ephemeral DB credentials.
     if: ${{ needs.ci-path-changes.outputs.skip == 'false' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login && github.event.pull_request.user.login != 'dependabot[bot]' && (needs.ci-path-changes.outputs.run_neon == 'true' || needs.ci-path-changes.outputs.run_public_lighthouse == 'true' || needs.ci-path-changes.outputs.run_golden_path == 'true' || contains(github.event.pull_request.labels.*.name, 'launch-candidate') || (contains(github.event.pull_request.labels.*.name, 'testing') && needs.ci-path-changes.outputs.run_e2e == 'true')))) }}
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
+    # 5m was warm-store-only: the admission probe needs @neondatabase/serverless
+    # from the installed tree, and a cold pnpm install alone runs ~5m.
+    timeout-minutes: 10
     concurrency:
       group: neon-endpoint-pool-neon-db-${{ (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '0') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '4') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '8')) && '0' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '1') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '5') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '9')) && '1' || (endsWith(format('{0}', github.event.pull_request.number || github.run_number), '2') || endsWith(format('{0}', github.event.pull_request.number || github.run_number), '6')) && '2' || '3' }}
       cancel-in-progress: false

--- a/.github/workflows/merge-queue-autoenroll.yml
+++ b/.github/workflows/merge-queue-autoenroll.yml
@@ -50,6 +50,12 @@ jobs:
     # the heterogeneous self-hosted fast pool does not.
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Jovie Bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.JOVIE_BOT_APP_ID }}
+          private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
       - name: Checkout main policy code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -59,7 +65,7 @@ jobs:
         run: gh --version
       - name: Enroll clean PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           GH_RETRY_ATTEMPTS: 8
           GH_RETRY_MAX_DELAY: 60
@@ -79,6 +85,12 @@ jobs:
       github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Jovie Bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.JOVIE_BOT_APP_ID }}
+          private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
       - name: Checkout main policy code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -92,7 +104,7 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Preflight native queue cutover
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           MERGE_QUEUE_BACKEND: ${{ vars.MERGE_QUEUE_BACKEND }}
         run: |
@@ -103,7 +115,7 @@ jobs:
           node scripts/merge-queue-backend.mjs preflight
       - name: Rebase blocked agent PRs onto main (Phase 2)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           DRAIN_REMEDIATE_APPLY: '1'
           DRAIN_REMEDIATE_MAX_PER_RUN: '3'

--- a/apps/web/app/api/chat/onboarding-handler.ts
+++ b/apps/web/app/api/chat/onboarding-handler.ts
@@ -312,24 +312,34 @@ export async function tryHandleAnonymousOnboardingChat(
   }
 
   // --- Rate limits: IP + ASN + session ---
-  const rate = await checkAnonymousChatRateLimit({ ip, sessionId, asn });
-  if (!rate.success) {
-    return NextResponse.json(
-      {
-        error: 'Rate limit exceeded',
-        message: rate.reason,
-        errorCode: 'RATE_LIMITED',
-        requestId,
-      },
-      {
-        status: 429,
-        headers: {
-          ...corsHeaders,
-          ...createRateLimitHeaders(rate),
-          'x-request-id': requestId,
+  // E2E exemption (same triple-guard shape as the OTP rule in
+  // lib/auth/rate-limit-rules.ts): these limiters are requireRedis and FAIL
+  // CLOSED (success:false) when Redis is absent, and their IP key collapses to
+  // loopback in CI where one shared Upstash bucket is raced by external
+  // dev/agent runs — deterministic test traffic would 429 nondeterministically
+  // either way, so the guard skips the check entirely. Never on production.
+  const skipAnonymousChatRateLimit =
+    env.E2E_TEST_MODE === '1' && env.VERCEL_ENV !== 'production';
+  if (!skipAnonymousChatRateLimit) {
+    const rate = await checkAnonymousChatRateLimit({ ip, sessionId, asn });
+    if (!rate.success) {
+      return NextResponse.json(
+        {
+          error: 'Rate limit exceeded',
+          message: rate.reason,
+          errorCode: 'RATE_LIMITED',
+          requestId,
         },
-      }
-    );
+        {
+          status: 429,
+          headers: {
+            ...corsHeaders,
+            ...createRateLimitHeaders(rate),
+            'x-request-id': requestId,
+          },
+        }
+      );
+    }
   }
 
   // --- Validate and shape the UIMessage payload ---

--- a/apps/web/lib/auth/better-auth.ts
+++ b/apps/web/lib/auth/better-auth.ts
@@ -33,10 +33,16 @@ import { captureError } from '@/lib/error-tracking';
 import { logger } from '@/lib/utils/logger';
 import { generateAppleClientSecret } from './apple-client-secret';
 import { provisionAppUser } from './provision';
-import { AUTH_RATE_LIMIT_RULES } from './rate-limit-rules';
+import {
+  AUTH_RATE_LIMIT_RULES,
+  isDeterministicTestOtpEmail,
+} from './rate-limit-rules';
 import { secondaryStorage } from './secondary-storage';
 
-export { AUTH_RATE_LIMIT_RULES } from './rate-limit-rules';
+export {
+  AUTH_RATE_LIMIT_RULES,
+  isDeterministicTestOtpEmail,
+} from './rate-limit-rules';
 
 /**
  * Better Auth server instance (Clerk → Better Auth migration; see
@@ -48,23 +54,6 @@ export { AUTH_RATE_LIMIT_RULES } from './rate-limit-rules';
  */
 
 export const DETERMINISTIC_TEST_OTP = '424242';
-
-/**
- * Deterministic E2E OTP gate (triple-guarded, plan security row 11):
- * requires E2E_TEST_MODE=1, hard-blocked on production deploys, and only for
- * the repo's canonical test-email shapes (`…+e2e…@` / `…+clerk_test…@`,
- * optionally with a trailing `+suffix` segment as used by
- * tests/helpers/clerk-auth.ts).
- */
-const TEST_OTP_EMAIL_PATTERN = /\+(e2e|clerk_test)(\+[^@]*)?@/i;
-
-export function isDeterministicTestOtpEmail(email: string): boolean {
-  return (
-    env.E2E_TEST_MODE === '1' &&
-    env.VERCEL_ENV !== 'production' &&
-    TEST_OTP_EMAIL_PATTERN.test(email)
-  );
-}
 
 /**
  * Trusted origins: production + staging + local dev + native deep-link

--- a/apps/web/lib/auth/rate-limit-rules.ts
+++ b/apps/web/lib/auth/rate-limit-rules.ts
@@ -6,10 +6,62 @@
  * unrelated users behind one NAT exhaust authentication for each other.
  * Credential and mutation endpoints remain durably rate-limited below.
  */
+import { env } from '@/lib/env-server';
+
+/**
+ * Canonical deterministic E2E test-email shapes (`…+e2e…@` / `…+clerk_test…@`,
+ * optionally with a trailing `+suffix` segment as used by
+ * tests/helpers/clerk-auth.ts).
+ */
+const TEST_OTP_EMAIL_PATTERN = /\+(e2e|clerk_test)(\+[^@]*)?@/i;
+
+/**
+ * Deterministic E2E OTP gate (triple-guarded, plan security row 11):
+ * requires E2E_TEST_MODE=1, hard-blocked on production deploys, and only for
+ * the repo's canonical test-email shapes.
+ *
+ * Lives here (not better-auth.ts) because the OTP rate-limit rule below needs
+ * it and better-auth.ts imports this module — importing it there would cycle.
+ */
+export function isDeterministicTestOtpEmail(email: string): boolean {
+  return (
+    env.E2E_TEST_MODE === '1' &&
+    env.VERCEL_ENV !== 'production' &&
+    TEST_OTP_EMAIL_PATTERN.test(email)
+  );
+}
+
+/**
+ * Read the OTP recipient out of a `/email-otp/send-verification-otp` request.
+ * The request is cloned before parsing so Better Auth's own body read still
+ * works. Unparseable bodies stay rate-limited (fail-closed).
+ */
+async function readOtpRequestEmail(request: Request): Promise<string | null> {
+  try {
+    const body: unknown = await request.clone().json();
+    if (body && typeof body === 'object' && 'email' in body) {
+      const { email } = body as { email: unknown };
+      return typeof email === 'string' ? email : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export const AUTH_RATE_LIMIT_RULES = {
   '/get-session': false,
   '/sign-in/social': { window: 60, max: 10 },
-  '/email-otp/send-verification-otp': { window: 60, max: 3 },
+  // Function form (better-auth@1.6.23 resolves `(request, currentRule)`;
+  // returning `false` disables limiting for that request). CI sends many OTPs
+  // from one loopback IP against the shared Upstash bucket, which external
+  // dev/agent runs exhaust — deterministic E2E test emails therefore bypass
+  // this limit (triple-guarded above); everyone else keeps 3 sends/60s.
+  '/email-otp/send-verification-otp': async (request: Request) => {
+    const email = await readOtpRequestEmail(request);
+    if (email && isDeterministicTestOtpEmail(email)) return false;
+    return { window: 60, max: 3 };
+  },
   '/phone-number/send-otp': { window: 60, max: 3 },
   '/phone-number/verify': { window: 60, max: 5 },
   '/one-time-token/verify': { window: 60, max: 10 },

--- a/apps/web/lib/auth/rate-limit-rules.ts
+++ b/apps/web/lib/auth/rate-limit-rules.ts
@@ -20,7 +20,7 @@ const TEST_OTP_EMAIL_PATTERN = /\+(e2e|clerk_test)(\+[^@]*)?@/i;
  * requires E2E_TEST_MODE=1, hard-blocked on production deploys, and only for
  * the repo's canonical test-email shapes.
  *
- * Lives here (not better-auth.ts) because the OTP rate-limit rule below needs
+ * Lives here (not better-auth.ts) because the OTP rate-limit rules below need
  * it and better-auth.ts imports this module — importing it there would cycle.
  */
 export function isDeterministicTestOtpEmail(email: string): boolean {
@@ -32,7 +32,7 @@ export function isDeterministicTestOtpEmail(email: string): boolean {
 }
 
 /**
- * Read the OTP recipient out of a `/email-otp/send-verification-otp` request.
+ * Read the OTP recipient out of an email-OTP request body.
  * The request is cloned before parsing so Better Auth's own body read still
  * works. Unparseable bodies stay rate-limited (fail-closed).
  */
@@ -49,19 +49,36 @@ async function readOtpRequestEmail(request: Request): Promise<string | null> {
   }
 }
 
+/**
+ * Function form (better-auth@1.6.23 resolves `(request, currentRule)`;
+ * returning `false` disables limiting for that request).
+ *
+ * CI and local self-hosted runners collapse client IPs to 127.0.0.1, so the
+ * plugin defaults (3 req / 60s per path, shared Upstash secondary storage)
+ * are exhausted by concurrent golden-path / agent OTP traffic. Deterministic
+ * E2E test emails therefore bypass this limit (triple-guarded above);
+ * everyone else keeps the 3/60s window.
+ *
+ * Applied to both send + sign-in: Golden Path failed on
+ * `/sign-in/email-otp` 429 after only send was exempted (PR #14456 run
+ * 29629642549).
+ */
+async function deterministicTestOtpRule(
+  request: Request
+): Promise<false | { window: number; max: number }> {
+  const email = await readOtpRequestEmail(request);
+  if (email && isDeterministicTestOtpEmail(email)) return false;
+  return { window: 60, max: 3 };
+}
+
 export const AUTH_RATE_LIMIT_RULES = {
   '/get-session': false,
   '/sign-in/social': { window: 60, max: 10 },
-  // Function form (better-auth@1.6.23 resolves `(request, currentRule)`;
-  // returning `false` disables limiting for that request). CI sends many OTPs
-  // from one loopback IP against the shared Upstash bucket, which external
-  // dev/agent runs exhaust — deterministic E2E test emails therefore bypass
-  // this limit (triple-guarded above); everyone else keeps 3 sends/60s.
-  '/email-otp/send-verification-otp': async (request: Request) => {
-    const email = await readOtpRequestEmail(request);
-    if (email && isDeterministicTestOtpEmail(email)) return false;
-    return { window: 60, max: 3 };
-  },
+  '/email-otp/send-verification-otp': deterministicTestOtpRule,
+  // emailOTP plugin default is also 3/60s for sign-in; same shared-IP race as
+  // send. customRules win over plugin.rateLimit when the path key matches
+  // (better-auth rate-limiter resolveRateLimitConfig).
+  '/sign-in/email-otp': deterministicTestOtpRule,
   '/phone-number/send-otp': { window: 60, max: 3 },
   '/phone-number/verify': { window: 60, max: 5 },
   '/one-time-token/verify': { window: 60, max: 10 },

--- a/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
+++ b/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
@@ -677,4 +677,99 @@ describe('tryHandleAnonymousOnboardingChat', () => {
     expect(result?.headers.get('set-cookie')).toBeNull();
     expect(hoisted.encodeSessionCookieMock).not.toHaveBeenCalled();
   });
+
+  describe('anonymous chat rate-limit E2E guard', () => {
+    function mockRateLimitExceeded() {
+      hoisted.checkAnonymousChatRateLimitMock.mockResolvedValue({
+        success: false,
+        limit: 10,
+        remaining: 0,
+        reset: new Date(Date.now() + 60_000),
+        reason: 'Too many anonymous chat requests from this IP',
+      });
+    }
+
+    function mockChatTurnOk() {
+      hoisted.executeChatTurnMock.mockResolvedValue({
+        streamResult: {
+          toUIMessageStreamResponse: ({
+            headers,
+          }: {
+            headers: Record<string, string>;
+          }) => new Response('ok', { status: 200, headers }),
+        },
+        selectedModel: 'anthropic/claude-haiku-4-5-20251001',
+        systemPrompt: '',
+        toolNames: [],
+        modelMessages: [],
+      });
+    }
+
+    it('still 429s when the limiter trips and the E2E guard is off', async () => {
+      vi.resetModules();
+      stubRuntimeEnv();
+      vi.stubEnv('E2E_TEST_MODE', '');
+      mockRateLimitExceeded();
+      const { tryHandleAnonymousOnboardingChat } = await import(
+        '@/app/api/chat/onboarding-handler'
+      );
+      const req = makeRequest({
+        mode: 'onboarding',
+        messages: [userMessage('hi')],
+      });
+      const result = await tryHandleAnonymousOnboardingChat(req, 'req-rl-1');
+
+      expect(result?.status).toBe(429);
+      const body = await result?.json();
+      expect(body.errorCode).toBe('RATE_LIMITED');
+      expect(hoisted.checkAnonymousChatRateLimitMock).toHaveBeenCalledTimes(1);
+      expect(hoisted.executeChatTurnMock).not.toHaveBeenCalled();
+    });
+
+    it('skips the limiter entirely when the E2E guard is on', async () => {
+      vi.resetModules();
+      stubRuntimeEnv();
+      vi.stubEnv('E2E_TEST_MODE', '1');
+      // Would 429 if it were consulted — the guard must not call it at all.
+      mockRateLimitExceeded();
+      mockChatTurnOk();
+      const { tryHandleAnonymousOnboardingChat } = await import(
+        '@/app/api/chat/onboarding-handler'
+      );
+      const req = makeRequest({
+        mode: 'onboarding',
+        messages: [userMessage('hi')],
+      });
+      const result = await tryHandleAnonymousOnboardingChat(req, 'req-rl-2');
+
+      expect(result?.status).toBe(200);
+      expect(hoisted.checkAnonymousChatRateLimitMock).not.toHaveBeenCalled();
+      expect(hoisted.executeChatTurnMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps limiting on production deploys even with E2E_TEST_MODE=1', async () => {
+      vi.resetModules();
+      stubRuntimeEnv({ nodeEnv: 'production', vercelEnv: 'production' });
+      vi.stubEnv('E2E_TEST_MODE', '1');
+      hoisted.checkGateForUserMock.mockResolvedValue(true);
+      hoisted.isTurnstileConfiguredMock.mockReturnValue(true);
+      hoisted.verifyTurnstileTokenMock.mockResolvedValue({ success: true });
+      mockRateLimitExceeded();
+      const { tryHandleAnonymousOnboardingChat } = await import(
+        '@/app/api/chat/onboarding-handler'
+      );
+      const req = makeRequest({
+        mode: 'onboarding',
+        turnstileToken: 'tok',
+        messages: [userMessage('hi')],
+      });
+      const result = await tryHandleAnonymousOnboardingChat(req, 'req-rl-3');
+
+      expect(result?.status).toBe(429);
+      const body = await result?.json();
+      expect(body.errorCode).toBe('RATE_LIMITED');
+      expect(hoisted.checkAnonymousChatRateLimitMock).toHaveBeenCalledTimes(1);
+      expect(hoisted.executeChatTurnMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -336,7 +336,6 @@ describe('deploy workflow Vercel env resolution', () => {
   it('passes the exact GitHub SHA into every external Vercel build and source deploy', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const buildShaEnv = 'VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}';
-    const buildJob = getJobBlock(workflow, 'ci-build-public');
     const stagingJob = getJobBlock(workflow, 'deploy-staging');
     const deployStep = getStepBlock(
       stagingJob,
@@ -347,9 +346,6 @@ describe('deploy workflow Vercel env resolution', () => {
       'utf8'
     );
 
-    expect(getStepBlock(buildJob, 'Vercel build (deploy artifact)')).toContain(
-      buildShaEnv
-    );
     expect(
       getStepBlock(
         stagingJob,
@@ -454,8 +450,13 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(deployScript).toContain('VERCEL_FORCE_SOURCE_DEPLOY');
   });
 
-  it('uses the restored prebuilt and refuses source-cache substitution', () => {
+  it('builds the staging prebuilt in-job and refuses source-cache substitution', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
+    const stagingJob = getJobBlock(workflow, 'deploy-staging');
+    const buildStep = getStepBlock(
+      stagingJob,
+      'Build (preview target for staging verification)'
+    );
     const deployStep = getStepBlock(
       workflow,
       'Deploy (staging preview, prebuilt)'
@@ -463,21 +464,28 @@ describe('deploy workflow Vercel env resolution', () => {
 
     expect(deployStep).not.toContain('VERCEL_FORCE_SOURCE_DEPLOY');
     expect(deployStep).toContain("VERCEL_ENABLE_SOURCE_FALLBACK: 'false'");
+    expect(stagingJob).not.toContain('download_vercel_build');
+    expect(stagingJob).not.toContain('restore_vercel_build');
+    expect(buildStep).toContain('jovie-generated-public-files');
+    expect(buildStep).not.toContain('steps.restore_vercel_build');
   });
 
   it('packages generated public trace files and budgets remote fallback readiness', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
-    const buildJob = getJobBlock(workflow, 'ci-build-public');
     const stagingJob = getJobBlock(workflow, 'deploy-staging');
+    const buildStep = getStepBlock(
+      stagingJob,
+      'Build (preview target for staging verification)'
+    );
     const readinessStep = getStepBlock(
       stagingJob,
       'Wait for staging deployment readiness'
     );
 
-    expect(buildJob).toContain(
+    expect(buildStep).toContain(
       'cp apps/web/.next/server/app/robots.txt.body apps/web/public/robots.txt'
     );
-    expect(buildJob).toContain('.vercel/jovie-generated-public-files');
+    expect(buildStep).toContain('.vercel/jovie-generated-public-files');
     expect(readinessStep).toContain('--timeout 20m');
     expect(readinessStep).toContain('BUILDING|QUEUED|INITIALIZING)');
     expect(readinessStep).toContain('handing off to retrying canary');
@@ -1509,7 +1517,7 @@ describe('CI PR neon migrate workflow', () => {
 });
 
 describe('production promotion exact-artifact contract', () => {
-  it('deploys the restored staging prebuilt without a source fallback', () => {
+  it('deploys the in-job staging prebuilt without a source fallback', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const deployStep = getStepBlock(
       workflow,

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1006,6 +1006,58 @@ describe('CI E2E smoke workflow', () => {
   });
 });
 
+describe('CI Golden Path Neon workflow', () => {
+  it('prefers pooled endpoints and verifies connectivity before migrations', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const goldenPathJob = getJobBlock(workflow, 'ci-golden-path');
+    const sharedResolver = getStepBlock(
+      goldenPathJob,
+      'Resolve DATABASE_URL from Neon artifact'
+    );
+    const fallbackResolver = getStepBlock(
+      goldenPathJob,
+      'Resolve DATABASE_URL (fallback Neon ephemeral)'
+    );
+
+    expect(sharedResolver).toContain('candidate_json_key: db_url_pooled');
+    expect(sharedResolver).toContain('fallback_json_key: db_url');
+    expect(fallbackResolver).toContain(
+      'candidate_url: ${{ steps.neon-branch.outputs.db_url_pooled }}'
+    );
+    expect(fallbackResolver).toContain(
+      'fallback_candidate_url: ${{ steps.neon-branch.outputs.db_url }}'
+    );
+
+    const failClosedStep = getStepBlock(
+      goldenPathJob,
+      'Fail if Neon DB URL is missing (Golden Path)'
+    );
+    const verifyDbStep = getStepBlock(
+      goldenPathJob,
+      'Verify Neon DB connectivity (fail-fast)'
+    );
+    const failClosedIndex = goldenPathJob.indexOf(
+      '- name: Fail if Neon DB URL is missing (Golden Path)'
+    );
+    const verifyIndex = goldenPathJob.indexOf(
+      '- name: Verify Neon DB connectivity (fail-fast)'
+    );
+    const migrateIndex = goldenPathJob.indexOf(
+      '- name: Run migrations (ephemeral Neon)'
+    );
+
+    expect(failClosedStep).toContain(
+      'Refusing to run Golden Path against staging/production DBs'
+    );
+    expect(failClosedStep).toContain('if [[ -z "$DATABASE_URL" ]]; then');
+    expect(failClosedStep).toContain('exit 1');
+    expect(verifyDbStep).toContain('tests/e2e/verify-neon-db-connectivity.ts');
+    expect(failClosedIndex).toBeGreaterThanOrEqual(0);
+    expect(verifyIndex).toBeGreaterThan(failClosedIndex);
+    expect(migrateIndex).toBeGreaterThan(verifyIndex);
+  });
+});
+
 describe('CI public lighthouse workflow', () => {
   it('pins the standalone server and browser to one loopback origin', () => {
     const workflow = readFileSync(workflowPath, 'utf8');

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -925,7 +925,13 @@ describe('CI E2E smoke workflow', () => {
 
   it('pins Better Auth to the local standalone origin for smoke and golden-path jobs', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
-    const localOrigin = 'http://localhost:3100';
+    // Shared build artifact feeds multiple lanes on one self-hosted machine, so
+    // each lane serves on its own loopback port; the baked-in public build URL
+    // stays on the legacy default and is overridden by lane runtime exports.
+    const sharedOrigin = 'http://localhost:3100';
+    const e2eSmokeOrigin = 'http://localhost:3240';
+    const goldenPathOrigin = 'http://localhost:3250';
+    const extendedSmokeOrigin = 'http://localhost:3260';
     const sharedBuild = getStepBlock(
       getJobBlock(workflow, 'ci-build-public'),
       'Build app (public routes only — no secrets needed)'
@@ -934,50 +940,62 @@ describe('CI E2E smoke workflow', () => {
     const extendedSmokeJob = getJobBlock(workflow, 'ci-smoke-required');
 
     expect(sharedBuild).toContain(
-      `NEXT_PUBLIC_BETTER_AUTH_URL: ${localOrigin}`
+      `NEXT_PUBLIC_BETTER_AUTH_URL: ${sharedOrigin}`
     );
-    expect(sharedBuild).toContain(`NEXT_PUBLIC_APP_URL: ${localOrigin}`);
+    expect(sharedBuild).toContain(`NEXT_PUBLIC_APP_URL: ${sharedOrigin}`);
     expect(sharedBuild).toContain("NEXT_PUBLIC_E2E_MODE: '1'");
     const goldenBuild = getStepBlock(
       goldenPathJob,
       'Build real-Clerk golden-path artifact'
     );
     expect(goldenBuild).toContain(
-      `NEXT_PUBLIC_BETTER_AUTH_URL: ${localOrigin}`
+      `NEXT_PUBLIC_BETTER_AUTH_URL: ${goldenPathOrigin}`
     );
-    expect(goldenBuild).toContain(`NEXT_PUBLIC_APP_URL: ${localOrigin}`);
+    expect(goldenBuild).toContain(`NEXT_PUBLIC_APP_URL: ${goldenPathOrigin}`);
     const extendedBuild = getStepBlock(
       extendedSmokeJob,
       'Extract or rebuild for smoke tests'
     );
     expect(extendedBuild).toContain(
-      `NEXT_PUBLIC_BETTER_AUTH_URL: ${localOrigin}`
+      `NEXT_PUBLIC_BETTER_AUTH_URL: ${extendedSmokeOrigin}`
     );
-    expect(extendedBuild).toContain(`NEXT_PUBLIC_APP_URL: ${localOrigin}`);
+    expect(extendedBuild).toContain(
+      `NEXT_PUBLIC_APP_URL: ${extendedSmokeOrigin}`
+    );
     expect(extendedBuild).toContain("NEXT_PUBLIC_E2E_MODE: '1'");
 
     const standaloneSteps = [
-      getStepBlock(
-        getJobBlock(workflow, 'ci-e2e-smoke'),
-        'Run E2E Smoke (Chromium)'
-      ),
-      getStepBlock(goldenPathJob, 'Run Golden Path (Chromium, Better Auth)'),
-      getStepBlock(extendedSmokeJob, 'Run Required Smoke Tests'),
+      {
+        origin: e2eSmokeOrigin,
+        step: getStepBlock(
+          getJobBlock(workflow, 'ci-e2e-smoke'),
+          'Run E2E Smoke (Chromium)'
+        ),
+      },
+      {
+        origin: goldenPathOrigin,
+        step: getStepBlock(
+          goldenPathJob,
+          'Run Golden Path (Chromium, Better Auth)'
+        ),
+      },
+      {
+        origin: extendedSmokeOrigin,
+        step: getStepBlock(extendedSmokeJob, 'Run Required Smoke Tests'),
+      },
     ];
 
-    for (const step of standaloneSteps) {
-      expect(step).toContain(`export BETTER_AUTH_URL=${localOrigin}`);
-      expect(step).toContain(
-        `export NEXT_PUBLIC_BETTER_AUTH_URL=${localOrigin}`
-      );
+    for (const { origin, step } of standaloneSteps) {
+      expect(step).toContain(`export BETTER_AUTH_URL=${origin}`);
+      expect(step).toContain(`export NEXT_PUBLIC_BETTER_AUTH_URL=${origin}`);
       expect(step).toContain('export HOSTNAME=localhost');
-      expect(step).toContain(`export NEXT_PUBLIC_APP_URL=${localOrigin}`);
-      expect(step).toContain(`BETTER_AUTH_URL: ${localOrigin}`);
-      expect(step).toContain(`NEXT_PUBLIC_BETTER_AUTH_URL: ${localOrigin}`);
+      expect(step).toContain(`export NEXT_PUBLIC_APP_URL=${origin}`);
+      expect(step).toContain(`BETTER_AUTH_URL: ${origin}`);
+      expect(step).toContain(`NEXT_PUBLIC_BETTER_AUTH_URL: ${origin}`);
       expect(step).toContain('SESSION_SECRET: ${{ secrets.SESSION_SECRET }}');
     }
 
-    for (const step of [standaloneSteps[0], standaloneSteps[2]]) {
+    for (const { step } of [standaloneSteps[0], standaloneSteps[2]]) {
       expect(step).toContain(
         'export UPSTASH_REDIS_REST_URL="${{ secrets.UPSTASH_REDIS_REST_URL }}"'
       );
@@ -1074,7 +1092,7 @@ describe('CI public lighthouse workflow', () => {
       'name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
     );
     expect(resolveDbStep).toContain(
-      'connection_file: /tmp/neon-db-connection/connection.json'
+      'connection_file: ${{ runner.temp }}/neon-db-connection/connection.json'
     );
     // credential_source only fills missing username/password; ephemeral host
     // still comes from the neon-db artifact (see resolve-neon-database-url).
@@ -1180,7 +1198,7 @@ describe('CI mobile overflow workflow', () => {
       'name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
     );
     expect(resolveDbStep).toContain(
-      'connection_file: /tmp/neon-db-connection/connection.json'
+      'connection_file: ${{ runner.temp }}/neon-db-connection/connection.json'
     );
     expect(resolveDbStep).not.toContain('credential_source_url');
     expect(verifyDbStep).toContain('tests/e2e/verify-neon-db-connectivity.ts');
@@ -1445,7 +1463,7 @@ describe('CI public a11y workflow', () => {
       "if: steps.check_changes.outputs.run_full_ci == 'true'"
     );
     expect(resolveDbStep).toContain(
-      'connection_file: /tmp/neon-db-connection/connection.json'
+      'connection_file: ${{ runner.temp }}/neon-db-connection/connection.json'
     );
     expect(exportStep).toContain(
       "if: steps.check_changes.outputs.run_full_ci == 'true'"
@@ -1500,7 +1518,7 @@ describe('CI PR neon migrate workflow', () => {
       'name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
     );
     expect(resolveDbStep).toContain(
-      'connection_file: /tmp/neon-db-connection/connection.json'
+      'connection_file: ${{ runner.temp }}/neon-db-connection/connection.json'
     );
     expect(resolveDbStep).toContain('candidate_json_key: db_url');
     expect(resolveDbStep).not.toContain('credential_source_url');

--- a/apps/web/tests/unit/lib/auth/better-auth-provision-hook.test.ts
+++ b/apps/web/tests/unit/lib/auth/better-auth-provision-hook.test.ts
@@ -60,6 +60,7 @@ vi.mock('@/lib/auth/provision', () => ({
 }));
 vi.mock('@/lib/auth/rate-limit-rules', () => ({
   AUTH_RATE_LIMIT_RULES: {},
+  isDeterministicTestOtpEmail: () => false,
 }));
 vi.mock('@/lib/auth/secondary-storage', () => ({
   secondaryStorage: {},

--- a/apps/web/tests/unit/lib/auth/rate-limit-rules.test.ts
+++ b/apps/web/tests/unit/lib/auth/rate-limit-rules.test.ts
@@ -1,7 +1,32 @@
-import { describe, expect, it } from 'vitest';
-import { AUTH_RATE_LIMIT_RULES } from '@/lib/auth/rate-limit-rules';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AUTH_RATE_LIMIT_RULES,
+  isDeterministicTestOtpEmail,
+} from '@/lib/auth/rate-limit-rules';
+
+const OTP_SEND_PATH = '/email-otp/send-verification-otp' as const;
+
+function makeOtpSendRequest(body: unknown): Request {
+  return new Request(`http://localhost/api/auth${OTP_SEND_PATH}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+async function resolveOtpSendRule(request: Request) {
+  const rule = AUTH_RATE_LIMIT_RULES[OTP_SEND_PATH];
+  if (typeof rule !== 'function') {
+    throw new Error('expected the OTP send rule to be a function');
+  }
+  return rule(request);
+}
 
 describe('Better Auth rate-limit policy', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('keeps read-only session hydration out of the shared IP bucket', () => {
     expect(AUTH_RATE_LIMIT_RULES['/get-session']).toBe(false);
   });
@@ -11,13 +36,105 @@ describe('Better Auth rate-limit policy', () => {
       window: 60,
       max: 10,
     });
-    expect(AUTH_RATE_LIMIT_RULES['/email-otp/send-verification-otp']).toEqual({
-      window: 60,
-      max: 3,
-    });
     expect(AUTH_RATE_LIMIT_RULES['/one-time-token/verify']).toEqual({
       window: 60,
       max: 10,
     });
+  });
+});
+
+describe('isDeterministicTestOtpEmail', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('accepts the canonical +e2e and +clerk_test shapes under the E2E guard', () => {
+    vi.stubEnv('E2E_TEST_MODE', '1');
+    vi.stubEnv('VERCEL_ENV', 'preview');
+    expect(isDeterministicTestOtpEmail('artist+e2e@example.com')).toBe(true);
+    expect(isDeterministicTestOtpEmail('artist+clerk_test@example.com')).toBe(
+      true
+    );
+    expect(isDeterministicTestOtpEmail('artist+e2e+step2@example.com')).toBe(
+      true
+    );
+  });
+
+  it('rejects non-test email shapes even under the E2E guard', () => {
+    vi.stubEnv('E2E_TEST_MODE', '1');
+    vi.stubEnv('VERCEL_ENV', 'preview');
+    expect(isDeterministicTestOtpEmail('artist@example.com')).toBe(false);
+    expect(isDeterministicTestOtpEmail('e2e@example.com')).toBe(false);
+    expect(isDeterministicTestOtpEmail('artist+e2efoo@example.com')).toBe(
+      false
+    );
+  });
+
+  it('rejects test emails when E2E_TEST_MODE is not set', () => {
+    vi.stubEnv('E2E_TEST_MODE', '');
+    vi.stubEnv('VERCEL_ENV', 'preview');
+    expect(isDeterministicTestOtpEmail('artist+e2e@example.com')).toBe(false);
+  });
+
+  it('is hard-blocked on production deploys even with E2E_TEST_MODE=1', () => {
+    vi.stubEnv('E2E_TEST_MODE', '1');
+    vi.stubEnv('VERCEL_ENV', 'production');
+    expect(isDeterministicTestOtpEmail('artist+e2e@example.com')).toBe(false);
+  });
+});
+
+describe('OTP send rate-limit rule', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('disables limiting for deterministic E2E test emails under the guard', async () => {
+    vi.stubEnv('E2E_TEST_MODE', '1');
+    vi.stubEnv('VERCEL_ENV', 'development');
+    const request = makeOtpSendRequest({ email: 'artist+e2e@example.com' });
+    await expect(resolveOtpSendRule(request)).resolves.toBe(false);
+    // The rule must leave the body intact for Better Auth's own parser.
+    await expect(request.json()).resolves.toEqual({
+      email: 'artist+e2e@example.com',
+    });
+  });
+
+  it('keeps the 3-per-60s window for real emails even under the guard', async () => {
+    vi.stubEnv('E2E_TEST_MODE', '1');
+    vi.stubEnv('VERCEL_ENV', 'development');
+    await expect(
+      resolveOtpSendRule(makeOtpSendRequest({ email: 'fan@example.com' }))
+    ).resolves.toEqual({ window: 60, max: 3 });
+  });
+
+  it('limits deterministic test emails when E2E_TEST_MODE is off', async () => {
+    vi.stubEnv('E2E_TEST_MODE', '');
+    vi.stubEnv('VERCEL_ENV', 'development');
+    await expect(
+      resolveOtpSendRule(
+        makeOtpSendRequest({ email: 'artist+e2e@example.com' })
+      )
+    ).resolves.toEqual({ window: 60, max: 3 });
+  });
+
+  it('limits deterministic test emails on production even with E2E_TEST_MODE=1', async () => {
+    vi.stubEnv('E2E_TEST_MODE', '1');
+    vi.stubEnv('VERCEL_ENV', 'production');
+    await expect(
+      resolveOtpSendRule(
+        makeOtpSendRequest({ email: 'artist+e2e@example.com' })
+      )
+    ).resolves.toEqual({ window: 60, max: 3 });
+  });
+
+  it('fails closed (stays limited) when the request body is unparseable', async () => {
+    vi.stubEnv('E2E_TEST_MODE', '1');
+    vi.stubEnv('VERCEL_ENV', 'development');
+    await expect(
+      resolveOtpSendRule(makeOtpSendRequest('not-json{{'))
+    ).resolves.toEqual({ window: 60, max: 3 });
+    await expect(
+      resolveOtpSendRule(makeOtpSendRequest({ type: 'sign-in' }))
+    ).resolves.toEqual({ window: 60, max: 3 });
   });
 });

--- a/apps/web/tests/unit/lib/auth/rate-limit-rules.test.ts
+++ b/apps/web/tests/unit/lib/auth/rate-limit-rules.test.ts
@@ -5,19 +5,27 @@ import {
 } from '@/lib/auth/rate-limit-rules';
 
 const OTP_SEND_PATH = '/email-otp/send-verification-otp' as const;
+const OTP_SIGN_IN_PATH = '/sign-in/email-otp' as const;
+const OTP_PATHS = [OTP_SEND_PATH, OTP_SIGN_IN_PATH] as const;
 
-function makeOtpSendRequest(body: unknown): Request {
-  return new Request(`http://localhost/api/auth${OTP_SEND_PATH}`, {
+function makeOtpRequest(
+  path: (typeof OTP_PATHS)[number],
+  body: unknown
+): Request {
+  return new Request(`http://localhost/api/auth${path}`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: typeof body === 'string' ? body : JSON.stringify(body),
   });
 }
 
-async function resolveOtpSendRule(request: Request) {
-  const rule = AUTH_RATE_LIMIT_RULES[OTP_SEND_PATH];
+async function resolveOtpRule(
+  path: (typeof OTP_PATHS)[number],
+  request: Request
+) {
+  const rule = AUTH_RATE_LIMIT_RULES[path];
   if (typeof rule !== 'function') {
-    throw new Error('expected the OTP send rule to be a function');
+    throw new Error(`expected the ${path} rule to be a function`);
   }
   return rule(request);
 }
@@ -40,6 +48,12 @@ describe('Better Auth rate-limit policy', () => {
       window: 60,
       max: 10,
     });
+  });
+
+  it('uses a function rule for both email-OTP send and sign-in paths', () => {
+    for (const path of OTP_PATHS) {
+      expect(typeof AUTH_RATE_LIMIT_RULES[path]).toBe('function');
+    }
   });
 });
 
@@ -83,7 +97,7 @@ describe('isDeterministicTestOtpEmail', () => {
   });
 });
 
-describe('OTP send rate-limit rule', () => {
+describe.each(OTP_PATHS)('email-OTP rate-limit rule (%s)', path => {
   beforeEach(() => {
     vi.unstubAllEnvs();
   });
@@ -91,8 +105,8 @@ describe('OTP send rate-limit rule', () => {
   it('disables limiting for deterministic E2E test emails under the guard', async () => {
     vi.stubEnv('E2E_TEST_MODE', '1');
     vi.stubEnv('VERCEL_ENV', 'development');
-    const request = makeOtpSendRequest({ email: 'artist+e2e@example.com' });
-    await expect(resolveOtpSendRule(request)).resolves.toBe(false);
+    const request = makeOtpRequest(path, { email: 'artist+e2e@example.com' });
+    await expect(resolveOtpRule(path, request)).resolves.toBe(false);
     // The rule must leave the body intact for Better Auth's own parser.
     await expect(request.json()).resolves.toEqual({
       email: 'artist+e2e@example.com',
@@ -103,7 +117,7 @@ describe('OTP send rate-limit rule', () => {
     vi.stubEnv('E2E_TEST_MODE', '1');
     vi.stubEnv('VERCEL_ENV', 'development');
     await expect(
-      resolveOtpSendRule(makeOtpSendRequest({ email: 'fan@example.com' }))
+      resolveOtpRule(path, makeOtpRequest(path, { email: 'fan@example.com' }))
     ).resolves.toEqual({ window: 60, max: 3 });
   });
 
@@ -111,8 +125,9 @@ describe('OTP send rate-limit rule', () => {
     vi.stubEnv('E2E_TEST_MODE', '');
     vi.stubEnv('VERCEL_ENV', 'development');
     await expect(
-      resolveOtpSendRule(
-        makeOtpSendRequest({ email: 'artist+e2e@example.com' })
+      resolveOtpRule(
+        path,
+        makeOtpRequest(path, { email: 'artist+e2e@example.com' })
       )
     ).resolves.toEqual({ window: 60, max: 3 });
   });
@@ -121,8 +136,9 @@ describe('OTP send rate-limit rule', () => {
     vi.stubEnv('E2E_TEST_MODE', '1');
     vi.stubEnv('VERCEL_ENV', 'production');
     await expect(
-      resolveOtpSendRule(
-        makeOtpSendRequest({ email: 'artist+e2e@example.com' })
+      resolveOtpRule(
+        path,
+        makeOtpRequest(path, { email: 'artist+e2e@example.com' })
       )
     ).resolves.toEqual({ window: 60, max: 3 });
   });
@@ -131,10 +147,10 @@ describe('OTP send rate-limit rule', () => {
     vi.stubEnv('E2E_TEST_MODE', '1');
     vi.stubEnv('VERCEL_ENV', 'development');
     await expect(
-      resolveOtpSendRule(makeOtpSendRequest('not-json{{'))
+      resolveOtpRule(path, makeOtpRequest(path, 'not-json{{'))
     ).resolves.toEqual({ window: 60, max: 3 });
     await expect(
-      resolveOtpSendRule(makeOtpSendRequest({ type: 'sign-in' }))
+      resolveOtpRule(path, makeOtpRequest(path, { type: 'sign-in' }))
     ).resolves.toEqual({ window: 60, max: 3 });
   });
 });

--- a/scripts/lib/__tests__/merge-queue-backend.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-backend.test.mjs
@@ -9,6 +9,7 @@ import {
   runCli,
   validateNativePreflightEvidence,
 } from '../../merge-queue-backend.mjs';
+import { extractWorkflowJobBlock } from '../merge-queue-guard.mjs';
 
 const REPOSITORY = 'JovieInc/Jovie';
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..');
@@ -208,22 +209,43 @@ describe('queue workflow mutation safety', () => {
     );
   });
 
-  it('requires native configuration and ruleset preflight before autoenroll mutations', () => {
+  it('requires native configuration, app auth, and preflight before autoenroll mutations', () => {
     const workflow = readRepoFile(
       '.github/workflows/merge-queue-autoenroll.yml'
     );
+    const enrollJob = extractWorkflowJobBlock(workflow, 'enroll');
+    const rebaseJob = extractWorkflowJobBlock(workflow, 'rebase');
     const enroll = workflowStep(workflow, 'Enroll clean PRs');
     const rebasePreflight = workflowStep(
       workflow,
       'Preflight native queue cutover'
     );
+    const rebaseMutation = workflowStep(
+      workflow,
+      'Rebase blocked agent PRs onto main (Phase 2)'
+    );
     const drain = readRepoFile('scripts/drain-pr-queue.sh');
+    const tokenAction =
+      'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1';
 
     expect(workflow).toContain(
       'MERGE_QUEUE_BACKEND: ${{ vars.MERGE_QUEUE_BACKEND }}'
     );
     expect(workflow).not.toContain("MERGE_QUEUE_BACKEND || 'graphite'");
     expect(workflow).toContain('  rebase:\n    needs: enroll\n');
+    for (const job of [enrollJob, rebaseJob]) {
+      expect(job).toContain(tokenAction);
+      expect(job).toContain('id: app-token');
+      expect(job).toContain('app-id: ${{ vars.JOVIE_BOT_APP_ID }}');
+      expect(job).toContain(
+        'private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}'
+      );
+      expect(job).not.toContain('secrets.GITHUB_TOKEN');
+    }
+    for (const step of [enroll, rebasePreflight, rebaseMutation]) {
+      expect(step).toContain('GH_TOKEN: ${{ steps.app-token.outputs.token }}');
+      expect(step).not.toContain('secrets.GITHUB_TOKEN');
+    }
     expect(enroll).toContain('if [[ "$MERGE_QUEUE_BACKEND" != "native" ]]');
     expect(enroll).toContain('bash scripts/drain-pr-queue.sh');
     expect(rebasePreflight).toContain(

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -445,35 +445,57 @@ def test_staging_job_budget_contains_deploy_and_readiness_steps() -> None:
     )
 
 
-def test_reusable_vercel_artifact_contains_traced_runtime_dependencies() -> None:
+def _staging_build_step(workflow: str) -> str:
+    staging = workflow[
+        workflow.index("  deploy-staging:") : workflow.index(
+            "  canary-health-gate:"
+        )
+    ]
+    return staging[
+        staging.index(
+            "- name: Build (preview target for staging verification)"
+        ) : staging.index("- name: Package build output for provenance attestation")
+    ]
+
+
+def test_staging_build_runs_in_job_and_materializes_trace_closure() -> None:
     workflow = CI_WORKFLOW.read_text()
-    producer = workflow[
-        workflow.index("- name: Vercel build (deploy artifact)") : workflow.index(
-            "- name: Upload vercel build artifact"
+    staging = workflow[
+        workflow.index("  deploy-staging:") : workflow.index(
+            "  canary-health-gate:"
         )
     ]
 
-    assert "apps/web/.next/standalone/apps/web/.next/node_modules" in producer
-    snapshot_index = producer.index("vercel-runtime-node-modules.tar.gz")
-    build_index = producer.index("./node_modules/.bin/vercel build")
-    restore_index = producer.index(
-        "tar -xzf /tmp/vercel-runtime-node-modules.tar.gz"
+    # The staging artifact is built and deployed in the same job, so the
+    # JOV-4087 cross-job producer/upload/download/restore chain is gone and
+    # traced runtime dependencies never leave the workspace.
+    assert "download-artifact" not in staging
+    assert "restore_vercel_build" not in staging
+    assert "vercel-runtime-node-modules.tar.gz" not in staging
+
+    build_step = _staging_build_step(workflow)
+
+    # The in-job artifact is the thing canary verifies, so the build always
+    # runs (no step-level if:) and cannot be skipped by artifact state.
+    assert "if:" not in build_step.split("run: |", 1)[0]
+    assert "./node_modules/.bin/vercel build" in build_step
+
+    # Vercel's function trace references the generated robots response at its
+    # public-file path even though the source route is app/robots.ts, so the
+    # build materializes it and records it for the deploy script's cleanup.
+    assert "test -f apps/web/.next/server/app/robots.txt.body" in build_step
+    assert (
+        "cp apps/web/.next/server/app/robots.txt.body apps/web/public/robots.txt"
+        in build_step
     )
-    assert snapshot_index < build_index < restore_index
-    assert "apps/web/.next/node_modules" in producer
-    assert "import-in-the-middle-*" in producer
-    assert "apps/web/.next/server/chunks" in producer
-    assert "apps/web/.next/server \\" in producer
-    assert "apps/web/.next/server/edge \\" not in producer
-    for metadata_file in (
-        "BUILD_ID",
-        "app-path-routes-manifest.json",
-        "build-manifest.json",
-        "package.json",
-        "prerender-manifest.json",
-        "required-server-files.json",
-    ):
-        assert f"apps/web/.next/{metadata_file}" in producer
+    assert ".vercel/jovie-generated-public-files" in build_step
+
+    deploy_step = staging[
+        staging.index("- name: Deploy (staging preview, prebuilt)") :
+    ]
+    # Fail-closed: a source fallback would silently discard the in-job
+    # artifact and repeat the slow server build.
+    assert "VERCEL_ENABLE_SOURCE_FALLBACK: 'false'" in deploy_step
 
 
 def test_staging_clerk_secrets_are_exposed_to_vercel_builds() -> None:
@@ -484,18 +506,18 @@ def test_staging_clerk_secrets_are_exposed_to_vercel_builds() -> None:
     )
     expected_secret = "CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_STAGING }}"
 
-    producer = workflow[
-        workflow.index("- name: Vercel build (deploy artifact)") : workflow.index(
-            "- name: Upload vercel build artifact"
-        )
-    ]
     staging = workflow[
         workflow.index("  deploy-staging:") : workflow.index(
             "  canary-health-gate:"
         )
     ]
-    assert expected_publishable in producer
-    assert expected_secret in producer
+    build_step = _staging_build_step(workflow)
+
+    # The in-job staging build must sign Clerk tokens with staging keys.
+    assert expected_publishable in build_step
+    assert expected_secret in build_step
+    # The prebuilt deploy step also receives them so CLI-side env resolution
+    # cannot fall back to production keys.
     assert staging.count(expected_publishable) >= 2
     assert staging.count(expected_secret) >= 2
 


### PR DESCRIPTION
## Why

Production deploys and several self-hosted CI lanes were failing for independent reasons: staging reused an incomplete cross-job Vercel artifact, shared runner workspaces and `/tmp` paths leaked state across jobs, browser lanes raced on fixed ports, and Golden Path could select an unpooled Neon URL. This PR fixes those blockers as one rebased CI batch.

## Changes

### Production deploy

- Build the staging Vercel artifact inside `deploy-staging`, matching the healthy preview-lane pattern.
- Remove the dead cross-job staging artifact producer from `ci-build-public`.
- Keep deployment fail-closed with source fallback disabled and attest the fresh in-job artifact.

### Self-hosted workspace, artifact, and port isolation

- Hard-clean and fully materialize self-hosted workspaces before jobs use repository actions.
- Stage build and Neon artifacts under each job's `${{ runner.temp }}` directory and verify required build files before use.
- Give browser lanes unique ports, verify the spawned server remains alive, and pin mobile auth URLs to the lane port.
- Raise the Neon migration timeout for cold installs and restore lane-scoped Redis/rate-limit behavior for deterministic E2E traffic.

### Golden Path database safety

- Prefer `db_url_pooled` over `db_url`, retain the direct URL only as a compatibility fallback, and fail closed when neither exists.
- Verify database connectivity before running Golden Path migrations.
- Cover pooled precedence, missing-value guards, connectivity failure, and migration ordering in the deploy workflow contract.

### Native merge-queue controller authentication

- Generate a job-local Jovie Bot installation token in both `enroll` and `rebase` using the repository-pinned `actions/create-github-app-token` action.
- Use that token for drain, classic-protection preflight, and remediation API calls; no mutation/preflight step uses `secrets.GITHUB_TOKEN`.
- Keep controller checkouts pinned to `main` with `persist-credentials: false` and preserve the fail-closed native-backend preflight.

## Exact-head verification

- Base: `6c8e8f919b0d3481dd5648ea27b90172d551bb19`
- Head: `a49d6cab73297b9f41d993e4ab291984d7824b6c`
- Deploy workflow contract: 52/52 passed.
- CI harness, merge-group, queue backend, and queue guard contracts: 99/99 passed.
- `pnpm ci:harness:check`: passed; generated CI docs are current.
- `pnpm ci:merge-queue:check`: passed.
- `actionlint -shellcheck=` on `ci.yml` and `merge-queue-autoenroll.yml`: passed.
- Biome on both edited contract tests: passed with no changes.
- `git diff --check`: passed.
- New repair commits are signed and verified with the configured ED25519 signer.

## Bug-to-Test

- Golden Path pooled-URL selection and fail-closed migration behavior are enforced by `apps/web/tests/unit/ci/deploy-workflow.test.ts`.
- Both merge-queue jobs' app-token creation and all privileged consumers are enforced by `scripts/lib/__tests__/merge-queue-backend.test.mjs`.
