### PR TITLE
docs: add Jovie operating system canon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,10 @@
 # Jovie — Agent Operating Manual
 
-Controller map for AI agents. `AGENTS.md` symlinks here. Read the scoped rule for your topic before editing. Detail lives in `.claude/rules/*` and `docs/`.
+Read [`/canon/OPERATING_SYSTEM.md`](canon/OPERATING_SYSTEM.md) first: it defines **how to think**; this file defines **how to execute**. If they conflict, the operating system wins.
+
+Before starting, answer: current bottleneck, evidence, success metric, expected improvement. If unknown, gather evidence first.
+
+Controller map for AI agents. `AGENTS.md` symlinks here. Read the scoped rule for your topic before editing. Detail lives in `/canon`, `.claude/rules/*`, and `docs/`.
 
 ## Operating Principles
 
@@ -11,7 +15,7 @@ Controller map for AI agents. `AGENTS.md` symlinks here. Read the scoped rule fo
 - Ask before destructive ops (data deletion, irreversible migrations without CI guard, credential changes, prod scripts). Auth/payment edits do **not** need human merge approval — CI + Migration Guard own that.
 - **Decisions are systems, not events** when quantifiable: **Ship now / Re-evaluate when / Then** with unit-economics triggers; tag `EVENT:` for taste/identity/security permanence. No "later"/"future work" without a Linear ID → [`.claude/rules/code-style.md`](.claude/rules/code-style.md).
 
-Canon principles: [`docs/company/operating-principles.md`](docs/company/operating-principles.md) (supersede [`docs/company/core-values.md`](docs/company/core-values.md)).
+Company constitution: [`/canon/OPERATING_SYSTEM.md`](canon/OPERATING_SYSTEM.md). Domain canon: [`PRODUCT`](canon/PRODUCT.md), [`ENGINEERING`](canon/ENGINEERING.md), [`DESIGN`](canon/DESIGN.md), [`MARKETING`](canon/MARKETING.md), [`VOICE`](canon/VOICE.md). Existing operating principles remain subordinate implementation canon: [`docs/company/operating-principles.md`](docs/company/operating-principles.md).
 
 ## Agent Role Boundary
 
@@ -79,23 +83,7 @@ Skip issues labeled `human-review-required` or containing "This issue requires h
 
 ## Scoped Rules
 
-| File | Topic |
-|---|---|
-| [`.claude/rules/environment.md`](.claude/rules/environment.md) | Setup, Doppler, DB isolation, Turbo, worktrees |
-| [`.claude/rules/auth.md`](.claude/rules/auth.md) | Clerk proxy, E2E auth |
-| [`.claude/rules/db.md`](.claude/rules/db.md) | Driver, migrations, transactions |
-| [`.claude/rules/ui.md`](.claude/rules/ui.md) | Design system, surfaces, taste |
-| [`.claude/rules/security.md`](.claude/rules/security.md) | CSP, webhooks, secrets, entitlements |
-| [`.claude/rules/release.md`](.claude/rules/release.md) | PR discipline, ship, deploy |
-| [`.claude/rules/ci-branching.md`](.claude/rules/ci-branching.md) | Integration branches, train PRs |
-| [`.claude/rules/testing.md`](.claude/rules/testing.md) | E2E, coverage, verify-before-done |
-| [`.claude/rules/infra.md`](.claude/rules/infra.md) | Cron, API budgets, cost disclosure |
-| [`.claude/rules/ios.md`](.claude/rules/ios.md) | SwiftUI guardrails, cache-first loads |
-| [`.claude/rules/code-style.md`](.claude/rules/code-style.md) | TypeScript, React, prior-art gate |
-| [`.claude/rules/linear.md`](.claude/rules/linear.md) | Issue gating, ownership |
-| [`.claude/rules/gstack.md`](.claude/rules/gstack.md) | Skill routing, vendored toolkit |
-| [`.claude/rules/swarm.md`](.claude/rules/swarm.md) | Parallel swarms, worktrees |
-| [`.claude/rules/hermes-air.md`](.claude/rules/hermes-air.md) | Hermes node, voice/Telegram intake |
+Read the relevant `.claude/rules/*` file before touching that area: environment, auth, db, ui, security, release, ci-branching, testing, infra, ios, code-style, linear, gstack, swarm, hermes-air.
 
 ## Skill Routing
 
@@ -105,7 +93,8 @@ Match a skill → invoke it first. Full routing table: [`.claude/rules/gstack.md
 
 | Doc | Use when |
 |-----|----------|
-| `DESIGN.md` | Any UI decision |
+| `canon/README.md` | Root decision hierarchy: operating system + domain canon |
+| `DESIGN.md` | Operational design-system execution |
 | `docs/PR_FLOW.md` | Shipping, CI tiers, taste gate |
 | `docs/marketing/AGENT_GUIDE.md` | Generating or editing any marketing/landing page |
 | `docs/AI_AGENT_GUIDE.md` | API routes, cron, webhooks inventory |

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,8 +1,10 @@
 # Codex Setup Guide for Jovie
 
-This repo uses the shared Jovie setup and archive scripts for Codex. Keep Codex-specific files as thin wrappers so they cannot drift from `CLAUDE.md` (and its `AGENTS.md` symlink), the scoped rules under `.claude/rules/`, `conductor.json`, or the scripts humans run locally.
+Read and obey [`/canon/OPERATING_SYSTEM.md`](canon/OPERATING_SYSTEM.md) first. It defines how to think; this file defines Codex-specific setup and execution.
 
-Codex agents should treat `CLAUDE.md`/`AGENTS.md` as the canonical instruction prefix and keep task-specific context in the user prompt or invoked skills. Do not copy large gstack skill preambles into Codex-specific files; use the generated Codex skill output or the source `.tmpl` files when modifying the skill system.
+This repo uses the shared Jovie setup and archive scripts for Codex. Keep Codex-specific files as thin wrappers so they cannot drift from `/canon/OPERATING_SYSTEM.md`, `CLAUDE.md` (and its `AGENTS.md` symlink), the scoped rules under `.claude/rules/`, `conductor.json`, or the scripts humans run locally.
+
+Codex agents should treat `/canon/OPERATING_SYSTEM.md` plus `CLAUDE.md`/`AGENTS.md` as the canonical instruction prefix and keep task-specific context in the user prompt or invoked skills. Do not copy large gstack skill preambles into Codex-specific files; use the generated Codex skill output or the source `.tmpl` files when modifying the skill system.
 
 ## Automatic Local Setup
 

--- a/canon/DESIGN.md
+++ b/canon/DESIGN.md
@@ -1,0 +1,76 @@
+# Jovie Design Canon
+
+Status: Canon
+Inherits: [`OPERATING_SYSTEM.md`](./OPERATING_SYSTEM.md)
+Last updated: 2026-07-17
+
+Design exists to increase customer throughput: make the next correct action obvious, trustworthy, and valuable.
+
+---
+
+## Design Goal
+
+Reduce friction between customer intent and customer value.
+
+Primary design question:
+
+> What is the smallest design change that helps more customers reach the next value moment?
+
+---
+
+## Design Bottlenecks
+
+Design work is justified when evidence shows one of these is limiting throughput:
+
+1. Customers do not understand the promise.
+2. Customers cannot find the next step.
+3. Customers do not trust the action.
+4. Customers abandon due to visual or interaction friction.
+5. Customers cannot perceive the value they received.
+6. Customers do not know what to do next.
+
+---
+
+## Required Design Proposal Shape
+
+- Current customer bottleneck:
+- Evidence (analytics, session, interview, support, screenshot, or user behavior):
+- Metric to improve:
+- Smallest design change:
+- Before/after verification:
+- Rollback:
+
+---
+
+## Principles
+
+- Clarity beats novelty.
+- Conversion-critical paths outrank decorative polish.
+- Polish is required when lack of polish blocks trust or activation.
+- Layout stability is part of correctness.
+- Taste matters, but customer behavior is stronger evidence.
+
+---
+
+## Anti-Goals
+
+Do not spend design effort on:
+
+- Visual novelty disconnected from activation, retention, trust, or revenue.
+- Redesigning stable surfaces because they feel old.
+- Animations that do not improve comprehension or conversion.
+- Component churn without product bottleneck evidence.
+
+---
+
+## Relationship to Root Design System
+
+`../DESIGN.md` is the operational design-system reference. This file defines why and when design work matters; `../DESIGN.md` defines how to execute it correctly.
+
+---
+
+## Changelog
+
+| Date | Change | Source |
+|---|---|---|
+| 2026-07-17 | Created as domain canon under `/canon`. | Tim White |

--- a/canon/ENGINEERING.md
+++ b/canon/ENGINEERING.md
@@ -1,0 +1,99 @@
+# Jovie Engineering Canon
+
+Status: Canon
+Inherits: [`OPERATING_SYSTEM.md`](./OPERATING_SYSTEM.md)
+Last updated: 2026-07-17
+
+Engineering exists to increase company throughput by making the product correct, shippable, reliable, and easy to change.
+
+---
+
+## Engineering Optimization Order
+
+Optimize in this order:
+
+1. Correctness
+2. Developer velocity
+3. Reliability
+4. Cost
+5. Latency
+6. Elegance
+
+Never reverse this order without evidence that the lower item is the current bottleneck.
+
+---
+
+## Engineering Proposal Gate
+
+Before starting engineering work, answer:
+
+- Current bottleneck:
+- Evidence:
+- User/company metric affected:
+- Smallest correct change:
+- Verification command or production receipt:
+- Rollback path:
+
+If the work does not remove the bottleneck, do not do it unless it is a small, clearly correct safety fix.
+
+---
+
+## Default Technology Posture
+
+Prefer boring technology. New technology is adopted only when it removes the current bottleneck.
+
+Default stack remains:
+
+- PostgreSQL
+- TypeScript
+- Next.js
+- Supabase
+- Upstash
+- Stripe
+
+Use upstream/open-source projects when they compound our work and reduce maintenance, but only through a bounded, reversible adoption path with evidence. Track upstream when that lets Jovie benefit from others' development work without surrendering control of the bottleneck.
+
+---
+
+## Shipping Rules
+
+- Smallest correct change.
+- One concern per PR.
+- Draft PR early to start feedback.
+- Merged is not done until production outcome is verified.
+- A green local check is evidence, not completion.
+- CI, migration guards, security gates, and production verification are not optional.
+
+---
+
+## Agent Engineering Rules
+
+AI agents should:
+
+1. Observe the bottleneck.
+2. Measure or fetch evidence.
+3. Make the smallest safe change.
+4. Verify with real output.
+5. Record the receipt.
+6. Stop creating work for humans unless a decision genuinely needs founder judgment.
+
+Agents should not:
+
+- Refactor stable code without measurable benefit.
+- Introduce new infrastructure because it is interesting.
+- Bypass checks for speed.
+- Create bot-to-bot chatter or routine progress noise.
+
+---
+
+## Relationship to Operational Rules
+
+Concrete implementation lives in `../CLAUDE.md`, `../CODEX.md`, `.claude/rules/*`, `docs/PR_FLOW.md`, and tests. Those rules implement this canon. If operational rules conflict with this file, escalate to `OPERATING_SYSTEM.md` and update the lower-level rule.
+
+---
+
+## Changelog
+
+| Date | Change | Source |
+|---|---|---|
+| 2026-07-17 | Created as domain canon under `/canon`. | Tim White |

--- a/canon/MARKETING.md
+++ b/canon/MARKETING.md
@@ -1,0 +1,80 @@
+# Jovie Marketing Canon
+
+Status: Canon
+Inherits: [`OPERATING_SYSTEM.md`](./OPERATING_SYSTEM.md)
+Last updated: 2026-07-17
+
+Marketing exists to create qualified demand that moves the current company bottleneck.
+
+---
+
+## Marketing Goal
+
+Increase the number of right-fit customers who understand, try, pay for, and keep using Jovie.
+
+Marketing is not awareness for its own sake. Marketing is throughput: qualified attention → activation → paid conversion → retained use.
+
+---
+
+## Marketing Bottleneck Ladder
+
+Classify marketing work by the bottleneck it removes:
+
+1. Right-fit customers do not know Jovie exists.
+2. They do not understand the promise.
+3. They do not trust the promise.
+4. They do not start.
+5. They do not activate.
+6. They do not pay.
+7. They do not retain or refer.
+
+Unknown means measure first.
+
+---
+
+## Required Marketing Proposal Shape
+
+- Current funnel bottleneck:
+- Evidence:
+- Audience:
+- Channel:
+- Message hypothesis:
+- Metric to improve:
+- Expected improvement:
+- Verification plan:
+- Rollback/stop rule:
+
+---
+
+## Principles
+
+- Specific customer language beats clever copy.
+- Observed behavior beats brand preference.
+- Distribution work waits if production/activation is broken.
+- Start with low-risk audiences before high-profile outreach when product stability is uncertain.
+- Every campaign must have a measurement and stop rule.
+
+---
+
+## Anti-Goals
+
+Do not optimize for:
+
+- Impressions without qualified intent.
+- Follower count without activation.
+- Content volume without conversion learning.
+- Public commitments before product can keep the promise.
+
+---
+
+## Relationship to Other Canon
+
+Product defines the value promise. Design makes it legible. Voice makes it clear and truthful. Engineering ensures the promise can be fulfilled.
+
+---
+
+## Changelog
+
+| Date | Change | Source |
+|---|---|---|
+| 2026-07-17 | Created as domain canon under `/canon`. | Tim White |

--- a/canon/OPERATING_SYSTEM.md
+++ b/canon/OPERATING_SYSTEM.md
@@ -1,0 +1,228 @@
+# Jovie Operating System
+
+Version: 1.0
+Status: Constitution (highest authority)
+Owner: Tim White
+Last updated: 2026-07-17
+
+This document is the highest-level operating philosophy for Jovie.
+
+Every human, AI agent, automation, workflow, skill, and product decision follows these principles.
+
+**If another document conflicts with this one, this document wins.**
+
+The domain canon files under `/canon` (`PRODUCT.md`, `ENGINEERING.md`, `DESIGN.md`, `MARKETING.md`, `VOICE.md`) inherit from this constitution and specialize it. Operational detail lives in `docs/`, `.claude/rules/*`, and skills. When operational detail conflicts with a canon file, canon wins; when a canon file conflicts with this constitution, the constitution wins.
+
+---
+
+## Mission
+
+Maximize long-term customer value by repeatedly eliminating the system's current bottleneck.
+
+We optimize throughput.
+
+We do not optimize components.
+
+---
+
+## Core Loop
+
+Forever:
+
+1. Identify the bottleneck.
+2. Gather evidence.
+3. Remove the bottleneck.
+4. Measure the outcome.
+5. Repeat.
+
+Every improvement should increase overall system throughput.
+
+---
+
+## The Ten Laws
+
+### Law 1 — Optimize the bottleneck
+
+Never optimize something that is not currently limiting the business.
+
+### Law 2 — Measure before optimizing
+
+Every proposal answers:
+
+- What is the bottleneck?
+- What evidence proves it?
+- Which metric improves?
+- How will we verify success?
+
+If these cannot be answered, keep gathering evidence.
+
+### Law 3 — Prefer boring technology
+
+New technology is adopted only if it removes today's bottleneck. Never because it is newer, more elegant, or more interesting.
+
+Default choices:
+
+- PostgreSQL
+- TypeScript
+- Next.js
+- Supabase
+- Upstash
+- Stripe
+
+These remain until they become the bottleneck.
+
+### Law 4 — Optimize globally
+
+Local improvements that do not improve overall throughput are waste.
+
+| Bad (local) | Good (global) |
+|---|---|
+| Faster Redis | Merge time reduced 45m → 12m |
+| Better CSS animation | Activation increased 24% → 41% |
+| New ORM | Trial conversion increased 8% → 13% |
+
+### Law 5 — Prefer reversible decisions
+
+Choose the option that preserves future optionality. Expensive migrations require measurable justification.
+
+### Law 6 — Small iterations beat perfect plans
+
+Ship. Measure. Adjust. Repeat.
+
+### Law 7 — The customer is the source of truth
+
+Opinions are weak evidence. Metrics are stronger. Observed customer behavior is strongest.
+
+### Law 8 — Every optimization has an opportunity cost
+
+Time spent improving one system cannot improve another. Always ask: *"What bottleneck are we choosing NOT to solve?"*
+
+### Law 9 — Delete aggressively
+
+Complexity compounds forever. Code. Infrastructure. Meetings. Documentation. Features. Agents. Delete whenever possible.
+
+### Law 10 — AI exists to increase throughput
+
+Agents should eliminate work, never create work for humans. Every automation should remove future effort.
+
+---
+
+## The One Question
+
+Every agent — human or AI — constantly asks itself:
+
+> **What is the highest-leverage thing I can do in the next 30 minutes to increase company throughput?**
+
+Not "What can I improve?"
+Not "What should I refactor?"
+Not "What's technically coolest?"
+
+That single question naturally prioritizes work like:
+
+- Fixing a CI queue blocking 20 PRs.
+- Repairing onboarding that's cutting activation in half.
+- Shipping an artist profile feature that unlocks revenue.
+
+And naturally deprioritizes:
+
+- Swapping databases because a new one is fashionable.
+- Refactoring stable code with no measurable user benefit.
+- Saving milliseconds on requests when AI calls take seconds.
+
+Over thousands of agent-hours, this becomes a coherent operating system rather than a collection of isolated automations.
+
+---
+
+## Decision Framework
+
+Every proposal starts here.
+
+### Problem
+
+- Current bottleneck:
+- Evidence:
+- Impact:
+
+### Proposal
+
+- How does this remove the bottleneck?
+- Expected metric improvement:
+- Risk:
+- Rollback:
+- Measurement plan:
+
+---
+
+## Company Bottlenecks
+
+The company always has exactly one primary bottleneck. Typical order — **never skip ahead**:
+
+1. Product-market fit
+2. Distribution
+3. Activation
+4. Retention
+5. Revenue
+6. Hiring
+7. Engineering throughput
+8. Infrastructure
+9. Micro-optimizations
+
+---
+
+## Engineering Optimization Order
+
+Optimize in this order; never reverse without evidence:
+
+1. Correctness
+2. Developer velocity
+3. Reliability
+4. Cost
+5. Latency
+6. Elegance
+
+---
+
+## Product
+
+Optimize **customer value delivered per week** — not features shipped.
+
+---
+
+## AI Agents
+
+Agents think like this:
+
+1. Observe.
+2. Measure.
+3. Identify constraint.
+4. Recommend smallest change.
+5. Measure again.
+
+Agents resist speculative optimization.
+
+---
+
+## Definition of Success
+
+Success is increasing company throughput. Everything else is secondary.
+
+---
+
+## Relationship to Existing Canon
+
+This constitution sits **above** the four operating principles in [`../docs/company/operating-principles.md`](../docs/company/operating-principles.md). Those principles (Ship Fast, Run Experiments, Document Everything, MRR Is King) remain valid and are the operational mechanism for this constitution:
+
+- **MRR Is King** is how we measure throughput in dollars — the customer paying is the strongest signal (Law 7).
+- **Ship Fast, Iterate** is Law 6 in practice.
+- **Run Experiments When in Doubt** is Law 2 in practice.
+- **Document Everything** is how the closed loop keeps compounding (Laws 1–2 depend on durable evidence).
+
+When operating-principles or a `.claude/rules/*` file gives concrete implementation, follow it. When it is silent or in tension, resolve upward to this document.
+
+---
+
+## Changelog
+
+| Date | Change | Source |
+|---|---|---|
+| 2026-07-17 | Created `/canon/OPERATING_SYSTEM.md` as company constitution (Theory of Constraints operating model). | Tim White |

--- a/canon/PRODUCT.md
+++ b/canon/PRODUCT.md
@@ -1,0 +1,90 @@
+# Jovie Product Canon
+
+Status: Canon
+Inherits: [`OPERATING_SYSTEM.md`](./OPERATING_SYSTEM.md)
+Last updated: 2026-07-17
+
+Product exists to increase customer value delivered per week.
+
+Features, polish, experiments, and roadmap items are valid only insofar as they remove the current company bottleneck.
+
+---
+
+## Product Goal
+
+Increase the rate at which customers reach and repeatedly receive value from Jovie.
+
+Primary product question:
+
+> What is the smallest product change that removes the current customer-value bottleneck?
+
+---
+
+## Product Bottleneck Ladder
+
+For product work, classify the bottleneck before proposing a solution:
+
+1. Customer cannot reach production.
+2. Customer cannot create an account.
+3. Customer does not reach first value.
+4. Customer does not start a paid plan.
+5. Customer does not complete payment.
+6. Customer does not return/retain.
+7. Customer does not invite or attract the next customer.
+
+Unknown means measure. Do not guess.
+
+---
+
+## Required Product Proposal Shape
+
+Every product proposal must answer:
+
+- Current bottleneck:
+- Customer evidence:
+- Metric to improve:
+- Expected improvement:
+- Smallest reversible change:
+- Verification receipt:
+- Rollback:
+
+If these fields cannot be answered, the next product task is evidence gathering.
+
+---
+
+## Prioritization Rules
+
+1. Customer behavior outranks internal opinion.
+2. Paid behavior outranks free behavior.
+3. Retention behavior outranks stated intent.
+4. Activation blockers outrank polish unless polish is the activation blocker.
+5. A shipped, measured experiment beats a perfect roadmap.
+
+---
+
+## Anti-Goals
+
+Do not optimize for:
+
+- Features shipped.
+- Agent output volume.
+- Internal excitement.
+- Competitor parity without customer evidence.
+- Technical elegance without user throughput impact.
+
+---
+
+## Relationship to Other Canon
+
+- Engineering implements the smallest correct product constraint removal.
+- Design makes value legible and reduces friction.
+- Marketing creates qualified demand for the current product bottleneck stage.
+- Voice makes the customer promise clear and truthful.
+
+---
+
+## Changelog
+
+| Date | Change | Source |
+|---|---|---|
+| 2026-07-17 | Created as domain canon under `/canon`. | Tim White |

--- a/canon/README.md
+++ b/canon/README.md
@@ -1,0 +1,14 @@
+# Jovie Canon
+
+This directory is the root of Jovie's decision-making hierarchy.
+
+Read in this order:
+
+1. [`OPERATING_SYSTEM.md`](./OPERATING_SYSTEM.md) — company constitution; highest authority.
+2. [`PRODUCT.md`](./PRODUCT.md) — customer value and product bottlenecks.
+3. [`ENGINEERING.md`](./ENGINEERING.md) — engineering priorities and technology posture.
+4. [`DESIGN.md`](./DESIGN.md) — UX, trust, clarity, and design bottlenecks.
+5. [`MARKETING.md`](./MARKETING.md) — qualified demand and funnel bottlenecks.
+6. [`VOICE.md`](./VOICE.md) — messaging, tone, and agent communication.
+
+Operational files (`CLAUDE.md`, `.claude/rules/*`, `docs/*`, skills, scripts, workflows) implement this canon. If they conflict, update the lower-level file or escalate to Tim.

--- a/canon/VOICE.md
+++ b/canon/VOICE.md
@@ -1,0 +1,88 @@
+# Jovie Voice Canon
+
+Status: Canon
+Inherits: [`OPERATING_SYSTEM.md`](./OPERATING_SYSTEM.md)
+Last updated: 2026-07-17
+
+Voice exists to make Jovie's promise clear, truthful, and useful enough that the right customer takes the next step.
+
+---
+
+## Voice Goal
+
+Communicate the smallest true promise that moves the current bottleneck.
+
+Primary voice question:
+
+> What does the customer need to believe, understand, or feel to reach the next value moment?
+
+---
+
+## Voice Rules
+
+- Plain language beats cleverness.
+- Specific proof beats hype.
+- Customer language beats internal jargon.
+- Confidence must match evidence.
+- Do not overpromise what the product cannot reliably deliver.
+- Do not expose internal machinery unless the customer benefits from knowing it.
+
+---
+
+## Required Voice Proposal Shape
+
+- Current bottleneck:
+- Audience:
+- Customer evidence/language:
+- Desired next action:
+- Core promise:
+- Proof:
+- Metric to improve:
+- Verification plan:
+
+---
+
+## Tone
+
+Jovie should sound:
+
+- Direct.
+- Useful.
+- Human.
+- Specific.
+- Calm under pressure.
+- More interested in the customer's outcome than in itself.
+
+Jovie should not sound:
+
+- Grandiose.
+- Vague.
+- Over-technical.
+- Agent-infrastructure obsessed.
+- Trend-chasing.
+- Desperate for attention.
+
+---
+
+## Action-Only Agent Communication
+
+Agent and automation messages are part of company voice. They should eliminate work for humans, not create it.
+
+- No routine success updates to founder-facing channels.
+- No bot-to-bot chatter in human channels.
+- No messages unless a human must personally act or decide.
+- Decision pings must state what happened, why it matters, exact need, default if silent, and link/receipt.
+
+---
+
+## Relationship to Marketing and Product
+
+Marketing decides where and why to communicate. Product defines the value being promised. Voice defines how to express the promise without adding friction or false confidence.
+
+---
+
+## Changelog
+
+| Date | Change | Source |
+|---|---|---|
+| 2026-07-17 | Created as domain canon under `/canon`. | Tim White |

--- a/docs/company/operating-principles.md
+++ b/docs/company/operating-principles.md
@@ -1,6 +1,8 @@
 # Jovie Operating Principles
 
-Canon. The four principles that govern how Jovie operates day to day. These supersede [`core-values.md`](./core-values.md) when they conflict — values describe culture, principles are enforced rules. When a decision is in tension between a value and a principle, the principle wins.
+Subordinate canon. The company constitution is [`/canon/OPERATING_SYSTEM.md`](../../canon/OPERATING_SYSTEM.md); if this file conflicts with the operating system, the operating system wins.
+
+These four principles govern how Jovie operates day to day and implement the throughput/bottleneck model in practice. They supersede [`core-values.md`](./core-values.md) when they conflict — values describe culture, principles are enforced rules. When a decision is in tension between a value and a principle, the principle wins unless `/canon/OPERATING_SYSTEM.md` says otherwise.
 
 If a future agent finds these ambiguous, the resolution lives in [`/LESSONS.md`](../../LESSONS.md), not in re-derivation. Add to the canon. Don't reinvent it.
 


### PR DESCRIPTION
## Summary
- Add `/canon` as Jovie's root decision-making hierarchy.
- Create `OPERATING_SYSTEM.md` as the company constitution built around bottleneck/throughput optimization.
- Add domain canon files for product, engineering, design, marketing, and voice.
- Update `CLAUDE.md`/`AGENTS.md` and `CODEX.md` to import the operating system rather than duplicating philosophy.
- Reframe `docs/company/operating-principles.md` as subordinate canon.

## Verification
- `pnpm doc:freshness:check` ✅
- Relative Markdown links in touched files resolve ✅
- `node scripts/skill-governance-guard.mjs` ✅

## Notes
- Did **not** hand-edit generated/vendored skill outputs. The universal “before starting” bottleneck gate is now in the root agent entry point and canon. Per-skill propagation should go through the skill generator/templates in a follow-up if we want literal headers in every generated skill.
