### PR TITLE
fix(ci): require a single native protection plane

### DIFF
--- a/scripts/lib/__tests__/merge-queue-backend.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-backend.test.mjs
@@ -263,77 +263,59 @@ describe('queue workflow mutation safety', () => {
 });
 
 describe('native live preflight', () => {
-  it.each([
-    ['no classic rule', VALID_BRANCH_PROTECTION_REF],
-    [
-      'an unrestricted classic rule',
-      {
-        name: 'main',
-        branchProtectionRule: {
-          pushAllowances: { totalCount: 0, nodes: [] },
-        },
-      },
-    ],
-  ])('accepts %s', (_label, branchProtectionRef) => {
+  it('accepts an exact ref with no classic branch-protection rule', () => {
     const result = validateNativePreflightEvidence({
       ruleset: VALID_RULESET,
       repository: VALID_REPOSITORY,
       workflowYaml: VALID_WORKFLOW,
-      branchProtectionRef,
+      branchProtectionRef: VALID_BRANCH_PROTECTION_REF,
     });
     expect(result.ok).toBe(true);
-    expect(result.evidence.classicPushAllowanceCount).toBe(0);
+    expect(result.evidence).not.toHaveProperty('classicPushAllowanceCount');
+    expect(result.evidence).not.toHaveProperty('classicPushAllowanceActors');
   });
 
   it.each([
-    ['App', { __typename: 'App', id: 'A_1', slug: 'graphite-app' }],
-    ['User', { __typename: 'User', id: 'U_1', login: 'octocat' }],
-    ['Team', { __typename: 'Team', id: 'T_1', slug: 'release-engineering' }],
-  ])('rejects a classic %s push allowance with actor identity', (_kind, actor) => {
+    ['an unrestricted classic rule', { id: 'BPR_unrestricted' }],
+    [
+      'a classic rule with legacy push allowances',
+      {
+        id: 'BPR_restricted',
+        pushAllowances: { totalCount: 0, nodes: [] },
+      },
+    ],
+  ])('rejects %s as a dual control plane', (_label, branchProtectionRule) => {
     const result = validateNativePreflightEvidence({
       ruleset: VALID_RULESET,
       repository: VALID_REPOSITORY,
       workflowYaml: VALID_WORKFLOW,
       branchProtectionRef: {
         name: 'main',
-        branchProtectionRule: {
-          pushAllowances: {
-            totalCount: 1,
-            nodes: [{ actor }],
-          },
-        },
+        branchProtectionRule,
       },
     });
     expect(result.ok).toBe(false);
     expect(result.errors).toContainEqual(
-      expect.stringContaining(
-        `${actor.__typename}:${actor.login ?? actor.slug}`
-      )
+      expect.stringContaining(`found rule ${branchProtectionRule.id}`)
+    );
+    expect(result.errors).toContainEqual(
+      expect.stringContaining('dual control planes')
     );
   });
 
   it.each([
     ['missing ref evidence', undefined],
+    ['null ref evidence', null],
+    ['malformed ref evidence', []],
+    ['missing ref name', { branchProtectionRule: null }],
+    ['wrong ref name', { name: 'develop', branchProtectionRule: null }],
     ['missing branchProtectionRule', { name: 'main' }],
-    ['missing pushAllowances', { name: 'main', branchProtectionRule: {} }],
+    ['classic rule without an id', { name: 'main', branchProtectionRule: {} }],
     [
-      'malformed totalCount',
-      {
-        name: 'main',
-        branchProtectionRule: {
-          pushAllowances: { totalCount: '0', nodes: [] },
-        },
-      },
+      'classic rule with a malformed id',
+      { name: 'main', branchProtectionRule: { id: 123 } },
     ],
-    [
-      'missing actor identity',
-      {
-        name: 'main',
-        branchProtectionRule: {
-          pushAllowances: { totalCount: 1, nodes: [{ actor: null }] },
-        },
-      },
-    ],
+    ['malformed classic rule', { name: 'main', branchProtectionRule: 'BPR' }],
   ])('fails closed on %s', (_label, branchProtectionRef) => {
     const result = validateNativePreflightEvidence({
       ruleset: VALID_RULESET,
@@ -347,17 +329,16 @@ describe('native live preflight', () => {
     );
   });
 
-  it('queries the exact protected ref and includes push-allowance actors', async () => {
+  it('queries only the exact ref and non-sensitive classic-rule identity', async () => {
     const runner = createNativeRunner();
     const result = await preflightMergeQueue({
       backend: 'native',
       repository: REPOSITORY,
       runner,
     });
-    expect(result).toMatchObject({
-      ready: true,
-      classicPushAllowanceCount: 0,
-    });
+    expect(result).toMatchObject({ ready: true });
+    expect(result).not.toHaveProperty('classicPushAllowanceCount');
+    expect(result).not.toHaveProperty('classicPushAllowanceActors');
     const protectionCall = runner.mock.calls.find(([args]) =>
       queryText(args).includes('MergeQueueBranchProtection')
     )?.[0];
@@ -365,8 +346,9 @@ describe('native live preflight', () => {
       expect.arrayContaining(['-f', 'refName=refs/heads/main'])
     );
     expect(queryText(protectionCall)).toContain(
-      'branchProtectionRule{pushAllowances(first:100){totalCount nodes{actor{__typename'
+      'ref(qualifiedName:$refName){name branchProtectionRule{id}}'
     );
+    expect(queryText(protectionCall)).not.toContain('pushAllowances');
   });
 
   it.each([

--- a/scripts/merge-queue-backend.mjs
+++ b/scripts/merge-queue-backend.mjs
@@ -29,7 +29,7 @@ const REQUIRED_NATIVE_STATE_FIELDS =
   );
 const PULL_REQUEST_STATE_QUERY = `query MergeQueuePullRequestState($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){${PULL_REQUEST_STATE_FIELDS}}}}`;
 const OPEN_PULL_REQUEST_STATES_QUERY = `query MergeQueueOpenPullRequestStates($owner:String!,$name:String!,$endCursor:String){repository(owner:$owner,name:$name){pullRequests(first:100,after:$endCursor,states:OPEN){nodes{${PULL_REQUEST_STATE_FIELDS}} pageInfo{hasNextPage endCursor}}}}`;
-const BRANCH_PROTECTION_QUERY = `query MergeQueueBranchProtection($owner:String!,$name:String!,$refName:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$refName){name branchProtectionRule{pushAllowances(first:100){totalCount nodes{actor{__typename ... on App{id name slug} ... on User{id login name} ... on Team{id name slug}}}}}}}}`;
+const BRANCH_PROTECTION_QUERY = `query MergeQueueBranchProtection($owner:String!,$name:String!,$refName:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$refName){name branchProtectionRule{id}}}}`;
 const DEQUEUE_PULL_REQUEST_MUTATION = `mutation DequeuePullRequest($id:ID!){dequeuePullRequest(input:{id:$id}){mergeQueueEntry{id}}}`;
 const DISABLE_AUTO_MERGE_MUTATION = `mutation DisablePullRequestAutoMerge($pullRequestId:ID!){disablePullRequestAutoMerge(input:{pullRequestId:$pullRequestId}){pullRequest{id}}}`;
 
@@ -242,50 +242,18 @@ export function validateNativePreflightEvidence({
   const hasBranchProtectionRuleShape =
     branchProtectionRule === null ||
     (typeof branchProtectionRule === 'object' &&
-      !Array.isArray(branchProtectionRule));
+      !Array.isArray(branchProtectionRule) &&
+      typeof branchProtectionRule.id === 'string' &&
+      branchProtectionRule.id.length > 0);
   const hasExactBranchProtectionEvidence =
     hasBranchProtectionRef &&
     branchProtectionRef.name === baseBranch &&
     hasBranchProtectionRuleField &&
     hasBranchProtectionRuleShape;
-  const pushAllowances =
-    branchProtectionRule === null
-      ? { totalCount: 0, nodes: [] }
-      : branchProtectionRule?.pushAllowances;
-  const allowanceCount = pushAllowances?.totalCount;
-  const allowanceNodes = pushAllowances?.nodes;
-  const allowanceActorIdentities = Array.isArray(allowanceNodes)
-    ? allowanceNodes.map(({ actor } = {}) => {
-        const type =
-          typeof actor?.__typename === 'string' ? actor.__typename : 'Unknown';
-        const identity =
-          actor?.login ??
-          actor?.slug ??
-          actor?.name ??
-          actor?.id ??
-          'unidentified';
-        return `${type}:${identity}`;
-      })
-    : [];
-  const hasValidPushAllowances =
-    hasExactBranchProtectionEvidence &&
-    typeof pushAllowances === 'object' &&
-    pushAllowances !== null &&
-    !Array.isArray(pushAllowances) &&
-    Number.isSafeInteger(allowanceCount) &&
-    allowanceCount >= 0 &&
-    Array.isArray(allowanceNodes) &&
-    allowanceNodes.length === Math.min(allowanceCount, 100) &&
-    allowanceNodes.every(({ actor } = {}) => {
-      const identity = actor?.login ?? actor?.slug ?? actor?.name ?? actor?.id;
-      return (
-        typeof actor?.__typename === 'string' &&
-        actor.__typename.length > 0 &&
-        typeof identity === 'string' &&
-        identity.length > 0
-      );
-    });
-  const classicRestrictionDetails = allowanceActorIdentities.join(', ');
+  const classicRuleId =
+    typeof branchProtectionRule?.id === 'string'
+      ? branchProtectionRule.id
+      : 'unknown';
   const validations = {
     [`ruleset id must be ${rulesetId}`]:
       String(ruleset?.id ?? '') === String(rulesetId),
@@ -320,10 +288,8 @@ export function validateNativePreflightEvidence({
       workflowHasMergeGroup,
     [`classic branch protection evidence must include exact refs/heads/${baseBranch} branchProtectionRule`]:
       hasExactBranchProtectionEvidence,
-    [`classic branch protection pushAllowances for refs/heads/${baseBranch} must include a non-negative integer totalCount and identified actor nodes`]:
-      !hasExactBranchProtectionEvidence || hasValidPushAllowances,
-    [`classic branch protection for refs/heads/${baseBranch} must not restrict pushes; found ${Number.isSafeInteger(allowanceCount) ? allowanceCount : 'unknown'} allowance(s): ${classicRestrictionDetails || 'unidentified'}`]:
-      !hasValidPushAllowances || allowanceCount === 0,
+    [`classic branch protection for refs/heads/${baseBranch} must be absent; found rule ${classicRuleId}, which creates dual control planes with native ruleset ${rulesetId}`]:
+      !hasBranchProtectionRuleField || branchProtectionRule === null,
   };
   for (const [message, condition] of Object.entries(validations)) {
     if (!condition) errors.push(message);
@@ -337,8 +303,6 @@ export function validateNativePreflightEvidence({
       requiredChecks,
       rulesetId: ruleset?.id ?? null,
       workflowHasMergeGroup,
-      classicPushAllowanceCount: hasValidPushAllowances ? allowanceCount : null,
-      classicPushAllowanceActors: allowanceActorIdentities,
     },
   };
 }
@@ -381,9 +345,9 @@ export async function preflightMergeQueue({
         name,
         refName: `refs/heads/${baseBranch}`,
       }),
-      'reading classic branch protection push allowances'
+      'checking for redundant classic branch protection'
     ),
-    'reading classic branch protection push allowances'
+    'checking for redundant classic branch protection'
   );
   const branchProtectionRef = branchProtectionPayload?.data?.repository?.ref;
   const validation = validateNativePreflightEvidence({


### PR DESCRIPTION
## Summary

- Query only the exact `refs/heads/main` ref name and `branchProtectionRule { id }`, avoiding admin-sensitive push-allowance fields that normal automation tokens cannot read.
- Require `branchProtectionRule === null`; any classic rule fails with its ID and a clear dual-control-plane error.
- Fail closed on missing, wrong-ref, or malformed GraphQL evidence.
- Remove classic push-allowance counts and actor identities from preflight evidence while preserving the existing native ruleset and autoenroll app-token contracts.

## Bug-to-test mapping

- No classic rule: exact-ref evidence passes.
- Any classic rule, including an unrestricted rule: preflight rejects the second control plane.
- Missing or malformed evidence: preflight fails closed.
- Query contract: exact `refs/heads/main`, minimal `branchProtectionRule{id}` selection, and no `pushAllowances` field.

## Verification

- `pnpm exec vitest run scripts/lib/__tests__/merge-queue-backend.test.mjs scripts/lib/__tests__/merge-queue-guard.test.mjs scripts/lib/__tests__/ci-harness.test.mjs scripts/lib/__tests__/merge-group-workflow-contract.test.mjs` — 101 passed.
- `pnpm ci:harness:check` — manifest valid and generated docs current.
- Biome passed for both edited files.
- `git diff --check` passed.
- Actionlint skipped because no workflow file changed.
- Signed commit; exact-main-guarded, user-authorized `--no-verify` bootstrap push after the focused checks passed.