### PR TITLE
fix(ci): scope controller ruleset visibility

### DIFF
--- a/.github/workflows/merge-queue-autoenroll.yml
+++ b/.github/workflows/merge-queue-autoenroll.yml
@@ -107,6 +107,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           MERGE_QUEUE_BACKEND: ${{ vars.MERGE_QUEUE_BACKEND }}
+          MERGE_QUEUE_NATIVE_AUTHORIZATION: merge-queue-autoenroll
         run: |
           if [[ "$MERGE_QUEUE_BACKEND" != "native" ]]; then
             echo "::error::Merge Queue Auto-Enroll requires MERGE_QUEUE_BACKEND=native" >&2

--- a/scripts/lib/__tests__/merge-queue-backend.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-backend.test.mjs
@@ -254,6 +254,12 @@ describe('queue workflow mutation safety', () => {
     expect(rebasePreflight).toContain(
       'node scripts/merge-queue-backend.mjs preflight'
     );
+    expect(rebasePreflight).toContain(
+      'MERGE_QUEUE_NATIVE_AUTHORIZATION: merge-queue-autoenroll'
+    );
+    expect(rebasePreflight).toContain(
+      'GH_TOKEN: ${{ steps.app-token.outputs.token }}'
+    );
     expect(
       drain.indexOf('node scripts/merge-queue-backend.mjs preflight')
     ).toBeLessThan(
@@ -271,6 +277,7 @@ describe('native live preflight', () => {
       branchProtectionRef: VALID_BRANCH_PROTECTION_REF,
     });
     expect(result.ok).toBe(true);
+    expect(result.evidence.bypassActorsVisible).toBe(true);
     expect(result.evidence).not.toHaveProperty('classicPushAllowanceCount');
     expect(result.evidence).not.toHaveProperty('classicPushAllowanceActors');
   });
@@ -363,6 +370,32 @@ describe('native live preflight', () => {
     expect(result.errors).toContain('ruleset bypass_actors must be an array');
   });
 
+  it('allows unavailable bypass actors only for an explicit controller preflight', () => {
+    const result = validateNativePreflightEvidence({
+      ruleset: { ...structuredClone(VALID_RULESET), bypass_actors: undefined },
+      repository: VALID_REPOSITORY,
+      workflowYaml: VALID_WORKFLOW,
+      branchProtectionRef: VALID_BRANCH_PROTECTION_REF,
+      allowUnavailableBypassActors: true,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.evidence.bypassActorsVisible).toBe(false);
+  });
+
+  it.each([
+    null,
+    {},
+  ])('rejects a visible malformed bypass_actors value in controller mode', bypass_actors => {
+    const result = validateNativePreflightEvidence({
+      ruleset: { ...structuredClone(VALID_RULESET), bypass_actors },
+      repository: VALID_REPOSITORY,
+      workflowYaml: VALID_WORKFLOW,
+      branchProtectionRef: VALID_BRANCH_PROTECTION_REF,
+      allowUnavailableBypassActors: true,
+    });
+    expect(result.errors).toContain('ruleset bypass_actors must be an array');
+  });
+
   it.each([
     158384, 2934433,
   ])('rejects non-empty bypass_actors including actor %s', actor_id => {
@@ -373,10 +406,78 @@ describe('native live preflight', () => {
       },
       repository: VALID_REPOSITORY,
       workflowYaml: VALID_WORKFLOW,
+      branchProtectionRef: VALID_BRANCH_PROTECTION_REF,
+      allowUnavailableBypassActors: true,
     });
     expect(result.errors).toContain(
       'ruleset bypass_actors must be empty before native enrollment'
     );
+  });
+
+  it('keeps direct preflight strict while an explicit controller can proceed', async () => {
+    const ruleset = structuredClone(VALID_RULESET);
+    delete ruleset.bypass_actors;
+    await expect(
+      preflightMergeQueue({
+        backend: 'native',
+        repository: REPOSITORY,
+        runner: createNativeRunner({ ruleset }),
+      })
+    ).rejects.toMatchObject({ code: 'native_preflight_failed' });
+    await expect(
+      preflightMergeQueue({
+        backend: 'native',
+        repository: REPOSITORY,
+        runner: createNativeRunner({ ruleset }),
+        allowUnavailableBypassActors: true,
+      })
+    ).resolves.toMatchObject({
+      ready: true,
+      bypassActorsVisible: false,
+    });
+  });
+
+  it('derives controller visibility only from the exact CLI authorization', async () => {
+    const ruleset = structuredClone(VALID_RULESET);
+    delete ruleset.bypass_actors;
+    await expect(
+      runCli(['preflight'], {
+        env: {
+          MERGE_QUEUE_BACKEND: 'native',
+          GITHUB_REPOSITORY: REPOSITORY,
+          MERGE_QUEUE_NATIVE_AUTHORIZATION: 'test-fixture',
+        },
+        runner: createNativeRunner({ ruleset }),
+        write: vi.fn(),
+      })
+    ).rejects.toMatchObject({ code: 'native_preflight_failed' });
+
+    await expect(
+      runCli(['preflight'], {
+        env: {
+          MERGE_QUEUE_BACKEND: 'native',
+          GITHUB_REPOSITORY: REPOSITORY,
+          MERGE_QUEUE_NATIVE_AUTHORIZATION: 'merge-queue-autoenroll',
+        },
+        runner: createNativeRunner({ ruleset }),
+        write: vi.fn(),
+      })
+    ).resolves.toMatchObject({ ready: true, bypassActorsVisible: false });
+
+    await expect(
+      runCli(['enroll', '14359', HEAD], {
+        env: {
+          MERGE_QUEUE_BACKEND: 'native',
+          GITHUB_REPOSITORY: REPOSITORY,
+          MERGE_QUEUE_NATIVE_AUTHORIZATION: 'merge-queue-autoenroll',
+        },
+        runner: createNativeRunner({
+          ruleset,
+          states: [prState({ autoMergeRequest: AUTO_MERGE })],
+        }),
+        write: vi.fn(),
+      })
+    ).resolves.toMatchObject({ changed: false });
   });
 
   it('reports every unsafe activation condition instead of partially enabling native mode', () => {

--- a/scripts/merge-queue-backend.mjs
+++ b/scripts/merge-queue-backend.mjs
@@ -213,6 +213,7 @@ export function validateNativePreflightEvidence({
   branchProtectionRef,
   rulesetId = DEFAULT_RULESET_ID,
   baseBranch = DEFAULT_BASE_BRANCH,
+  allowUnavailableBypassActors = false,
 } = {}) {
   const errors = [];
   const mergeQueueRule = ruleset?.rules?.find(
@@ -229,6 +230,9 @@ export function validateNativePreflightEvidence({
   );
   const bypassActors = ruleset?.bypass_actors;
   const hasValidBypassActors = Array.isArray(bypassActors);
+  const bypassActorsVisible = bypassActors !== undefined;
+  const unavailableBypassActorsAllowed =
+    allowUnavailableBypassActors === true && !bypassActorsVisible;
   const hasBranchProtectionRef =
     typeof branchProtectionRef === 'object' &&
     branchProtectionRef !== null &&
@@ -275,7 +279,8 @@ export function validateNativePreflightEvidence({
     'source required checks must be loose; merge_group validates latest main':
       ruleset?.rules?.find(rule => rule?.type === 'required_status_checks')
         ?.parameters?.strict_required_status_checks_policy === false,
-    'ruleset bypass_actors must be an array': hasValidBypassActors,
+    'ruleset bypass_actors must be an array':
+      hasValidBypassActors || unavailableBypassActorsAllowed,
     'ruleset bypass_actors must be empty before native enrollment':
       !hasValidBypassActors || bypassActors.length === 0,
     [`repository default branch must be ${baseBranch}`]:
@@ -303,6 +308,7 @@ export function validateNativePreflightEvidence({
       requiredChecks,
       rulesetId: ruleset?.id ?? null,
       workflowHasMergeGroup,
+      bypassActorsVisible,
     },
   };
 }
@@ -312,6 +318,7 @@ export async function preflightMergeQueue({
   repository = DEFAULT_REPOSITORY,
   rulesetId = DEFAULT_RULESET_ID,
   baseBranch = DEFAULT_BASE_BRANCH,
+  allowUnavailableBypassActors = false,
   runner = createGhRunner(),
 } = {}) {
   const resolvedBackend = requireNativeBackend(backend);
@@ -357,6 +364,7 @@ export async function preflightMergeQueue({
     branchProtectionRef,
     rulesetId,
     baseBranch,
+    allowUnavailableBypassActors,
   });
   if (!validation.ok) {
     throw backendError(
@@ -535,6 +543,7 @@ export async function enrollPullRequest({
   repository = DEFAULT_REPOSITORY,
   rulesetId = DEFAULT_RULESET_ID,
   baseBranch = DEFAULT_BASE_BRANCH,
+  allowUnavailableBypassActors = false,
   number,
   expectedHeadOid,
   runner = createGhRunner(),
@@ -554,6 +563,7 @@ export async function enrollPullRequest({
     repository,
     rulesetId,
     baseBranch,
+    allowUnavailableBypassActors,
     runner,
   });
 
@@ -681,14 +691,17 @@ export async function runCli(
   const repository = env.REPO ?? env.GITHUB_REPOSITORY ?? DEFAULT_REPOSITORY;
   const rulesetId = env.MERGE_QUEUE_RULESET_ID ?? DEFAULT_RULESET_ID;
   const baseBranch = env.MERGE_QUEUE_BASE_BRANCH ?? DEFAULT_BASE_BRANCH;
+  const allowUnavailableBypassActors =
+    env.MERGE_QUEUE_NATIVE_AUTHORIZATION === 'merge-queue-autoenroll';
   const [command, ...args] = argv;
   const options = { backend, repository, rulesetId, baseBranch, runner };
+  const preflightOptions = { ...options, allowUnavailableBypassActors };
   const commands = {
-    preflight: () => preflightMergeQueue(options),
+    preflight: () => preflightMergeQueue(preflightOptions),
     'list-state': () => listPullRequestQueueStates(options),
     enroll: () =>
       enrollPullRequest({
-        ...options,
+        ...preflightOptions,
         number: args[0],
         expectedHeadOid: args[1],
       }),


### PR DESCRIPTION
## Summary

- Keep default and local native preflight strict: missing or malformed `bypass_actors` still fails.
- Permit an unavailable `bypass_actors` field only when `allowUnavailableBypassActors === true`; visible values must always be an empty array.
- Return `bypassActorsVisible` evidence so controller runs distinguish hidden from verified-empty state.
- Derive the exception only from exact `MERGE_QUEUE_NATIVE_AUTHORIZATION=merge-queue-autoenroll` and forward it through both direct CLI preflight and the internal enroll preflight.
- Give the rebase preflight step the same exact authorization and Jovie Bot token contract already used by enrollment.

## Safety contracts

- Strict missing: rejected.
- Explicit controller missing: accepted with `bypassActorsVisible=false`.
- Known empty: accepted with `bypassActorsVisible=true`.
- Known non-empty or malformed: rejected in every mode.
- Wrong authorization, including `test-fixture`: does not unlock unavailable visibility.
- Native backend checks and mutation authorization remain unchanged.

## Verification

- Five focused backend, queue, harness, and workflow test files: 267 passed.
- `pnpm ci:harness:check`: manifest valid and generated docs current.
- `actionlint -shellcheck= .github/workflows/merge-queue-autoenroll.yml`: passed.
- Biome passed for both edited JavaScript files.
- `git diff --check`: passed.
- Signed commit; exact-main-guarded, user-authorized `--no-verify` bootstrap push after all focused checks passed.

No live settings, queue state, labels, or workflow runs were mutated.