### PR TITLE
fix(ci): retry native queue enrollment proof

### DIFF
--- a/scripts/lib/__tests__/merge-queue-backend.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-backend.test.mjs
@@ -70,6 +70,7 @@ function createNativeRunner({
   branchProtectionRef = VALID_BRANCH_PROTECTION_REF,
   states = [],
   listPages = null,
+  mergeResult = ok(),
 } = {}) {
   const stateQueue = [...states];
   const restResponses = new Map([
@@ -113,7 +114,7 @@ function createNativeRunner({
       query.includes('disablePullRequestAutoMerge')
     )
       return ok({ data: {} });
-    if (args[0] === 'pr' && args[1] === 'merge') return ok();
+    if (args[0] === 'pr' && args[1] === 'merge') return mergeResult;
     throw new Error(`Unexpected gh command: ${args.join(' ')}`);
   });
 }
@@ -538,6 +539,70 @@ describe('native enrollment', () => {
         HEAD,
       ])
     );
+  });
+
+  it('polls through stale reads until the exact-head enrollment is authoritative', async () => {
+    const wait = vi.fn(async () => {});
+    const runner = createNativeRunner({
+      states: [
+        prState(),
+        prState(),
+        prState(),
+        prState({
+          isInMergeQueue: true,
+          mergeQueueEntry: QUEUE_ENTRY,
+        }),
+      ],
+    });
+
+    await expect(
+      enroll(runner, {
+        postconditionAttempts: 6,
+        postconditionDelayMs: 2_000,
+        wait,
+      })
+    ).resolves.toMatchObject({
+      changed: true,
+      postconditionAttempts: 3,
+      state: { headRefOid: HEAD, queued: true },
+    });
+    expect(wait).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenNthCalledWith(1, 2_000);
+    expect(wait).toHaveBeenNthCalledWith(2, 2_000);
+  });
+
+  it('fails closed with mutation stderr after bounded authoritative reads', async () => {
+    const wait = vi.fn(async () => {});
+    const runner = createNativeRunner({
+      states: [prState(), prState(), prState()],
+      mergeResult: {
+        code: 1,
+        stdout: '',
+        stderr: 'GraphQL: Pull request head SHA changed',
+      },
+    });
+
+    await expect(
+      enroll(runner, {
+        postconditionAttempts: 2,
+        postconditionDelayMs: 2_000,
+        wait,
+      })
+    ).rejects.toMatchObject({
+      code: 'enrollment_postcondition_failed',
+      message: expect.stringContaining(
+        'mutation error: enrolling PR #14359 with native failed with exit code 1: GraphQL: Pull request head SHA changed'
+      ),
+      details: {
+        mutationError: {
+          code: 'gh_command_failed',
+          details: { stderr: 'GraphQL: Pull request head SHA changed' },
+        },
+        postconditionAttempts: 2,
+        state: { headRefOid: HEAD, queued: false },
+      },
+    });
+    expect(wait).toHaveBeenCalledTimes(1);
   });
 
   it('refuses a changed head before invoking the enrollment mutation', async () => {

--- a/scripts/merge-queue-backend.mjs
+++ b/scripts/merge-queue-backend.mjs
@@ -10,6 +10,8 @@ export const MERGE_QUEUE_BACKENDS = Object.freeze(['graphite', 'native']);
 const DEFAULT_REPOSITORY = 'JovieInc/Jovie';
 const DEFAULT_RULESET_ID = '10512119';
 const DEFAULT_BASE_BRANCH = 'main';
+const DEFAULT_ENROLLMENT_POSTCONDITION_ATTEMPTS = 6;
+const DEFAULT_ENROLLMENT_POSTCONDITION_DELAY_MS = 2_000;
 const CI_WORKFLOW_PATH = '.github/workflows/ci.yml';
 const NATIVE_MUTATION_AUTHORIZATIONS = new Set([
   'merge-queue-autoenroll',
@@ -153,6 +155,32 @@ async function attemptGh(runner, args, description) {
     return error;
   }
 }
+
+function errorEvidence(error) {
+  const candidate =
+    typeof error === 'object' && error !== null ? error : undefined;
+  return {
+    code:
+      typeof candidate?.code === 'string' ? candidate.code : 'unknown_error',
+    message: error instanceof Error ? error.message : String(error),
+    details:
+      typeof candidate?.details === 'object' && candidate.details !== null
+        ? candidate.details
+        : {},
+  };
+}
+
+function errorSummary(error) {
+  const evidence = errorEvidence(error);
+  const stderr =
+    typeof evidence.details.stderr === 'string'
+      ? evidence.details.stderr.trim()
+      : '';
+  return stderr ? `${evidence.message}: ${stderr}` : evidence.message;
+}
+
+const sleep = milliseconds =>
+  new Promise(resolve => setTimeout(resolve, milliseconds));
 
 export function createGhRunner({ env = process.env, spawn = spawnSync } = {}) {
   return async args => {
@@ -538,6 +566,25 @@ function assertEnrollCandidate(state, expectedHeadOid) {
   }
 }
 
+async function pollEnrollmentPostcondition({
+  stateOptions,
+  expectedHeadOid,
+  attempts,
+  delayMs,
+  wait,
+}) {
+  let state;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    state = await readPullRequestQueueState(stateOptions);
+    if (enrollmentPostcondition(state, expectedHeadOid)) {
+      return { attempts: attempt, state };
+    }
+    assertEnrollCandidate(state, expectedHeadOid);
+    if (attempt < attempts) await wait(delayMs);
+  }
+  return { attempts, state };
+}
+
 export async function enrollPullRequest({
   backend,
   repository = DEFAULT_REPOSITORY,
@@ -547,6 +594,9 @@ export async function enrollPullRequest({
   number,
   expectedHeadOid,
   runner = createGhRunner(),
+  postconditionAttempts = DEFAULT_ENROLLMENT_POSTCONDITION_ATTEMPTS,
+  postconditionDelayMs = DEFAULT_ENROLLMENT_POSTCONDITION_DELAY_MS,
+  wait = sleep,
 } = {}) {
   const resolvedBackend = requireNativeBackend(backend);
   const parsedNumber = parsePullRequestNumber(number);
@@ -587,19 +637,36 @@ export async function enrollPullRequest({
     args,
     `enrolling PR #${parsedNumber} with ${resolvedBackend}`
   );
-  const after = await readPullRequestQueueState(stateOptions);
-  if (enrollmentPostcondition(after, expectedHead)) {
+  const observation = await pollEnrollmentPostcondition({
+    stateOptions,
+    expectedHeadOid: expectedHead,
+    attempts: postconditionAttempts,
+    delayMs: postconditionDelayMs,
+    wait,
+  });
+  if (enrollmentPostcondition(observation.state, expectedHead)) {
     return {
       backend: resolvedBackend,
       changed: true,
+      postconditionAttempts: observation.attempts,
       reconciledAfterCommandError: Boolean(mutationError),
-      state: after,
+      state: observation.state,
     };
   }
+  const mutationErrorDetails = mutationError
+    ? errorEvidence(mutationError)
+    : null;
+  const mutationFailure = mutationError
+    ? `; mutation error: ${errorSummary(mutationError)}`
+    : '';
   throw backendError(
     'enrollment_postcondition_failed',
-    `Could not prove PR #${parsedNumber} is enrolled at ${expectedHead}`,
-    { mutationError: mutationError?.message ?? null, state: after }
+    `Could not prove PR #${parsedNumber} is enrolled at ${expectedHead} after ${observation.attempts} authoritative reads${mutationFailure}`,
+    {
+      mutationError: mutationErrorDetails,
+      postconditionAttempts: observation.attempts,
+      state: observation.state,
+    }
   );
 }
 


### PR DESCRIPTION
## Summary
- poll GitHub's authoritative pull-request queue state for bounded eventual consistency after native enrollment
- keep exact-head, open, ready-for-review checks fail closed on every observation
- preserve command-error reconciliation and include the original gh error code/stderr when enrollment truly fails

## Root cause
Controller run https://github.com/JovieInc/Jovie/actions/runs/29656344730 successfully enrolled #14458, but its immediate GraphQL read was stale and falsely raised enrollment_postcondition_failed. A later authoritative read showed the exact head in AWAITING_CHECKS.

## Validation
- pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/merge-queue-backend.test.mjs (35 passed)
- pnpm ci:merge-queue:check
- pnpm turbo typecheck (10/10)
- pnpm biome check --write scripts/merge-queue-backend.mjs scripts/lib/__tests__/merge-queue-backend.test.mjs
- pnpm --filter @jovie/web run test:bug-to-test with this PR evidence

bug-to-test: satisfied
Regression test: scripts/lib/__tests__/merge-queue-backend.test.mjs

## Risk
CI control-plane change. Polling is bounded to six authoritative reads over at most ten seconds, uses the existing exact head SHA, and still errors unless native queue membership is proven.