### PR TITLE
fix(ci): stabilize production deploy bootstrap

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -29,8 +29,12 @@ runs:
       shell: bash
       run: node .github/runner-image/verify-prerequisites.mjs --component dependencies
 
-    # Per-job pnpm install dir (JOV-4175). Two prior failure modes on the
-    # self-hosted pool, both from a shared persistent dest:
+    # Pin the Node 24-based v5 installer because it installs the repo's exact
+    # packageManager version directly. v6.0.9 first bootstraps pnpm 11.7.0 and
+    # then runs `self-update 9.15.4`; that downgrade intermittently failed with
+    # ENOENT inside a fresh runner.temp dest (run 29657049045), before any test
+    # could start. The per-job install dir still prevents the two earlier
+    # self-hosted pool failure modes caused by a shared persistent dest:
     #   1. default ~/setup-pnpm carried a pnpm v11 layout that crashed pinned
     #      9.15.4 ("Worker pnpm exited with code 1", run 29070623310)
     #   2. version-scoped ~/setup-pnpm-v9 raced between CONCURRENT runner
@@ -40,7 +44,7 @@ runs:
     # re-download costs seconds. The package store stays shared and safe.
     - name: Setup pnpm
       if: steps.runner-prereqs.outputs.dependencies_warm != 'true'
-      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
         dest: ${{ runner.temp }}/setup-pnpm
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5611,6 +5611,37 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-node-pnpm
+      # Production runtime config comes from the isolated Doppler `prd`
+      # service token. Vercel remains the deployment control plane only.
+      - uses: ./.github/actions/setup-doppler
+        with:
+          doppler-token: ${{ secrets.DOPPLER_TOKEN_PRD }}
+      - name: Configure production deployment credentials
+        shell: bash
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for key in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+            if [ -z "${!key:-}" ]; then
+              missing+=("$key")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required production deployment credentials: ${missing[*]}"
+            exit 1
+          fi
+
+          # Write after setup-doppler so runtime config cannot override the
+          # repository-scoped deployment identity used by Vercel CLI steps.
+          {
+            printf 'VERCEL_TOKEN=%s\n' "$VERCEL_TOKEN"
+            printf 'VERCEL_ORG_ID=%s\n' "$VERCEL_ORG_ID"
+            printf 'VERCEL_PROJECT_ID=%s\n' "$VERCEL_PROJECT_ID"
+          } >> "$GITHUB_ENV"
       - name: Verify production domains are on canonical Vercel project
         id: domain-guard
         env:
@@ -5650,6 +5681,28 @@ jobs:
             fail_stage "Missing production deployment inputs: ${missing[*]}" missing_creds
           fi
 
+          required_runtime_env=(
+            NEXT_PUBLIC_BETTER_AUTH_URL
+            BETTER_AUTH_SECRET
+            DATABASE_URL
+            SESSION_SECRET
+            AI_GATEWAY_API_KEY
+            NEXT_PUBLIC_TURNSTILE_SITE_KEY
+            TURNSTILE_SECRET_KEY
+          )
+          missing_runtime_env=()
+          runtime_env_args=()
+          for key in "${required_runtime_env[@]}"; do
+            if [ -z "${!key:-}" ]; then
+              missing_runtime_env+=("$key")
+            else
+              runtime_env_args+=(--env "${key}=${!key}")
+            fi
+          done
+          if [ "${#missing_runtime_env[@]}" -gt 0 ]; then
+            fail_stage "Missing production runtime env: ${missing_runtime_env[*]}" production_artifact_failed
+          fi
+
           expected="${GITHUB_SHA:0:7}"
           scope_args=(--scope "$VERCEL_ORG_ID")
           rm -rf .vercel/output .vercel/.env.preview.local .vercel/.env.production.local .vercel/.env.local
@@ -5667,7 +5720,7 @@ jobs:
           done
 
           if ! pnpm --filter=@jovie/web exec tsx scripts/check-signup-readiness.ts \
-            --target=prd --source=vercel-file; then
+            --target=prd --source=env; then
             fail_stage "Production signup configuration is incomplete." production_artifact_failed
           fi
 
@@ -5687,6 +5740,7 @@ jobs:
             --prebuilt --archive=tgz --prod --skip-domain --format=json \
             --env "VERCEL_GIT_COMMIT_SHA=${GITHUB_SHA}" \
             --env "NEXT_PUBLIC_BUILD_SHA=${expected}" \
+            "${runtime_env_args[@]}" \
             --meta "githubCommitSha=${GITHUB_SHA}" \
             --token "$VERCEL_TOKEN" "${scope_args[@]}")"; then
             fail_stage "Production prebuilt deployment failed." production_artifact_failed

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -543,6 +543,61 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(buildStep).toContain('vercel build');
   });
 
+  it('loads production runtime config from Doppler without yielding Vercel deployment identity', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const promoteJob = getJobBlock(workflow, 'promote-production');
+    const configureStep = getStepBlock(
+      promoteJob,
+      'Configure production deployment credentials'
+    );
+    const stageStep = getStepBlock(
+      promoteJob,
+      'Build and stage production deployment'
+    );
+    const dopplerIndex = promoteJob.indexOf(
+      '- uses: ./.github/actions/setup-doppler'
+    );
+    const configureIndex = promoteJob.indexOf(
+      '- name: Configure production deployment credentials'
+    );
+    const domainGuardIndex = promoteJob.indexOf(
+      '- name: Verify production domains are on canonical Vercel project'
+    );
+    const runtimeKeys = [
+      'NEXT_PUBLIC_BETTER_AUTH_URL',
+      'BETTER_AUTH_SECRET',
+      'DATABASE_URL',
+      'SESSION_SECRET',
+      'AI_GATEWAY_API_KEY',
+      'NEXT_PUBLIC_TURNSTILE_SITE_KEY',
+      'TURNSTILE_SECRET_KEY',
+    ];
+
+    expect(dopplerIndex).toBeGreaterThanOrEqual(0);
+    expect(configureIndex).toBeGreaterThan(dopplerIndex);
+    expect(domainGuardIndex).toBeGreaterThan(configureIndex);
+    expect(promoteJob).toContain(
+      'doppler-token: ${{ secrets.DOPPLER_TOKEN_PRD }}'
+    );
+    expect(configureStep).toContain(
+      'Missing required production deployment credentials:'
+    );
+    for (const key of ['VERCEL_TOKEN', 'VERCEL_ORG_ID', 'VERCEL_PROJECT_ID']) {
+      expect(configureStep).toContain(`${key}: \${{ secrets.${key} }}`);
+      expect(configureStep).toContain(`printf '${key}=%s\\n'`);
+    }
+
+    expect(stageStep).toContain('--target=prd --source=env');
+    expect(stageStep).not.toContain('--target=prd --source=vercel-file');
+    expect(stageStep).toContain('required_runtime_env=(');
+    expect(stageStep).toContain('Missing production runtime env:');
+    expect(stageStep).toContain('runtime_env_args+=(--env "${key}=${!key}")');
+    expect(stageStep).toContain('"${runtime_env_args[@]}"');
+    for (const key of runtimeKeys) {
+      expect(stageStep).toContain(key);
+    }
+  });
+
   it('verifies production promotion through the canonical public alias', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const promoteJob = getJobBlock(workflow, 'promote-production');
@@ -1636,7 +1691,8 @@ describe('production promotion exact-artifact contract', () => {
     expect(deployIndex).toBeGreaterThan(buildIndex);
     expect(inspectIndex).toBeGreaterThan(deployIndex);
     expect(canaryIndex).toBeGreaterThan(inspectIndex);
-    expect(stageStep).toContain('--target=prd --source=vercel-file');
+    expect(stageStep).toContain('--target=prd --source=env');
+    expect(stageStep).not.toContain('--target=prd --source=vercel-file');
     expect(stageStep).toContain('VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA"');
     expect(stageStep).toContain('NEXT_PUBLIC_BUILD_SHA="$expected"');
     expect(stageStep).toContain('--meta "githubCommitSha=${GITHUB_SHA}"');

--- a/apps/web/tests/unit/ci/runner-setup-action.test.ts
+++ b/apps/web/tests/unit/ci/runner-setup-action.test.ts
@@ -29,6 +29,16 @@ describe('self-hosted runner setup action', () => {
     expect(action).toContain('pnpm install --frozen-lockfile');
   });
 
+  it('installs the pinned pnpm directly instead of downgrading a pnpm 11 bootstrap', () => {
+    expect(action).toContain(
+      'uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0'
+    );
+    expect(action).not.toContain(
+      'pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271'
+    );
+    expect(action).toContain('dest: ${{ runner.temp }}/setup-pnpm');
+  });
+
   it('restores an exact baked installed tree and falls back when no marker exists', () => {
     expect(action).toContain(
       'node .github/runner-image/verify-prerequisites.mjs --component dependencies'


### PR DESCRIPTION
## Description

Restores the authoritative `main` deploy and shared CI bootstrap paths without changing any credentials or external environment configuration.

- Loads production runtime config from the isolated Doppler `prd` service token before promotion.
- Reasserts GitHub-owned Vercel control-plane credentials after Doppler setup.
- Validates the seven signup-critical keys from `source=env` and forwards them safely to the production prebuilt deployment.
- Pins the Node 24-based pnpm action that installs the repo's exact pnpm version directly, avoiding the pnpm 11.7.0 -> 9.15.4 self-update ENOENT seen before tests could start.

Authoritative failures:
- CI run 29656124491, `Promote to Production` job 88111797205.
- CI run 29657049045, `Test Performance Budgets` job 88113197723.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Testing

- [x] Regression tests added or updated
- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/ci/runner-setup-action.test.ts tests/unit/ci/deploy-workflow.test.ts` (78 passed)
- [x] `python3 -m pytest scripts/tests/test_vercel_prebuilt_deploy.py` (23 passed)
- [x] `pnpm exec vitest run scripts/lib/__tests__/merge-group-workflow-contract.test.mjs` (8 passed)
- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] `pnpm --filter @jovie/web run test:bug-to-test`
- [x] `pnpm biome check --write apps/web`
- [x] `actionlint .github/workflows/ci.yml` (valid; pre-existing informational ShellCheck findings only)

bug-to-test: satisfied

## Deployment Notes

- No secret values, credentials, repository settings, or Vercel/Doppler configuration changed.
- Existing `DOPPLER_TOKEN_PRD` and Vercel GitHub secrets remain the only trust anchors.
- Rollback is one revert: production returns to Vercel-file readiness and pnpm/action-setup v6.0.9.

## Code Quality

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Performance considerations addressed

Design-canonical: not applicable.

## Checklist

- [x] PR title follows conventional commit format
- [x] Branch is up to date with `main` at `f539031014b58d3c9ab59912fd6eae6f924ebe44`
- [x] Regression evidence is included
