### PR TITLE
fix(ci): use exact-head GitHub rebases for remediation

### DIFF
--- a/scripts/drain-pr-remediate.mjs
+++ b/scripts/drain-pr-remediate.mjs
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
-/** Phase 2 of /drain: rebase stale BLOCKED agent PRs onto latest main. */
-import { execFile, execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+/** Phase 2 of /drain: rebase stale BLOCKED agent PRs onto their latest base. */
+import { execFile } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import { tryGitHubRebase } from './lib/github-update-branch.mjs';
 import { listBlockedAgentPrs } from './lib/pr-check-failures.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -82,83 +81,15 @@ function parseArgs(argv) {
   return options;
 }
 
-function hoursSince(isoTimestamp) {
+function hoursSince(isoTimestamp, nowMs = Date.now()) {
   if (!isoTimestamp) return Number.POSITIVE_INFINITY;
-  const deltaMs = Date.now() - Date.parse(isoTimestamp);
+  const deltaMs = nowMs - Date.parse(isoTimestamp);
   if (!Number.isFinite(deltaMs)) return Number.POSITIVE_INFINITY;
   return deltaMs / (1000 * 60 * 60);
 }
 
-function runGit(args, cwd) {
-  return execFileSync('git', args, {
-    cwd,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-}
-
-function runGh(args, cwd = process.cwd()) {
-  return execFileSync('gh', args, {
-    cwd,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-}
-
-async function ghJson(args) {
-  const { stdout } = await execFileAsync('gh', args, {
-    encoding: 'utf8',
-    maxBuffer: 20 * 1024 * 1024,
-  });
-  return JSON.parse(stdout);
-}
-
-function tryMechanicalRebase({ repo, pr, baseRef, dryRun }) {
-  if (dryRun) {
-    return {
-      ok: true,
-      dryRun: true,
-      reason: 'dry-run: would rebase onto origin/' + baseRef,
-    };
-  }
-
-  const workdir = mkdtempSync(
-    join(tmpdir(), `jovie-drain-rebase-${pr.number}-`)
-  );
-  try {
-    runGh(['repo', 'clone', repo, '.', '--', '--no-tags'], workdir);
-    runGit(
-      ['fetch', 'origin', baseRef, pr.headRefName, '--depth', '80'],
-      workdir
-    );
-    runGit(
-      ['checkout', '-B', pr.headRefName, `origin/${pr.headRefName}`],
-      workdir
-    );
-    try {
-      runGit(['rebase', `origin/${baseRef}`], workdir);
-    } catch (_error) {
-      runGit(['rebase', '--abort'], workdir);
-      return {
-        ok: false,
-        conflict: true,
-        reason: 'rebase conflict — needs human resolution',
-      };
-    }
-
-    runGit(
-      ['push', '--force-with-lease', 'origin', `HEAD:${pr.headRefName}`],
-      workdir
-    );
-    return {
-      ok: true,
-      dryRun: false,
-      reason:
-        'rebased onto origin/' + baseRef + ' and pushed --force-with-lease',
-    };
-  } finally {
-    rmSync(workdir, { recursive: true, force: true });
-  }
+function hasPrLabel(pr, labelName) {
+  return (pr.labels ?? []).some(label => (label.name ?? label) === labelName);
 }
 
 async function labelPr(repo, prNumber, labelName) {
@@ -167,6 +98,25 @@ async function labelPr(repo, prNumber, labelName) {
     ['pr', 'edit', String(prNumber), '-R', repo, '--add-label', labelName],
     { encoding: 'utf8' }
   );
+}
+
+async function removeLabelPr(repo, prNumber, labelName) {
+  try {
+    await execFileAsync(
+      'gh',
+      [
+        'api',
+        '-X',
+        'DELETE',
+        `repos/${repo}/issues/${prNumber}/labels/${encodeURIComponent(labelName)}`,
+      ],
+      { encoding: 'utf8' }
+    );
+  } catch (error) {
+    const detail = `${error?.stderr ?? ''} ${error?.message ?? ''}`;
+    if (/HTTP 404|Not Found/i.test(detail)) return;
+    throw error;
+  }
 }
 
 async function commentPr(repo, prNumber, body) {
@@ -189,21 +139,16 @@ async function commentPr(repo, prNumber, body) {
   );
 }
 
-async function fetchBaseRefName(repo, prNumber) {
-  const pr = await ghJson([
-    'pr',
-    'view',
-    String(prNumber),
-    '-R',
-    repo,
-    '--json',
-    'baseRefName',
-  ]);
-  return pr.baseRefName ?? 'main';
-}
+export async function remediateBlockedPrs(options, dependencies = {}) {
+  const listBlockedAgentPrsImpl =
+    dependencies.listBlockedAgentPrsImpl ?? listBlockedAgentPrs;
+  const rebaseImpl = dependencies.rebaseImpl ?? tryGitHubRebase;
+  const labelPrImpl = dependencies.labelPrImpl ?? labelPr;
+  const removeLabelPrImpl = dependencies.removeLabelPrImpl ?? removeLabelPr;
+  const commentPrImpl = dependencies.commentPrImpl ?? commentPr;
+  const nowMs = dependencies.nowMs ?? Date.now();
 
-export async function remediateBlockedPrs(options) {
-  const blocked = await listBlockedAgentPrs(options.repo, {
+  const blocked = await listBlockedAgentPrsImpl(options.repo, {
     limit: options.limit,
   });
 
@@ -223,13 +168,9 @@ export async function remediateBlockedPrs(options) {
       break;
     }
 
-    const baseRef =
-      options.baseRef === 'main'
-        ? await fetchBaseRefName(options.repo, pr.number)
-        : options.baseRef;
-
-    const hours = hoursSince(pr.updatedAt);
-    if (hours < options.cooldownHours) {
+    const hours = hoursSince(pr.updatedAt, nowMs);
+    const hasConflictLabel = hasPrLabel(pr, 'needs-conflict-resolution');
+    if (hours < options.cooldownHours && !hasConflictLabel) {
       const item = {
         number: pr.number,
         headRefName: pr.headRefName,
@@ -248,28 +189,36 @@ export async function remediateBlockedPrs(options) {
       `  #${pr.number} [${pr.headRefName}] rebase candidate — ${pr.failures.join(', ')}`
     );
 
-    const rebase = tryMechanicalRebase({
+    const rebase = await rebaseImpl({
       repo: options.repo,
       pr,
-      baseRef,
+      expectedBaseRefName: options.baseRef === 'main' ? null : options.baseRef,
       dryRun: options.dryRun,
     });
+    const baseRef = rebase.baseRefName ?? options.baseRef;
 
     const item = {
       number: pr.number,
       headRefName: pr.headRefName,
-      action: rebase.ok ? 'rebased' : 'rebase_failed',
+      action: rebase.ok
+        ? rebase.updated
+          ? 'rebased'
+          : 'rebase_noop'
+        : 'rebase_failed',
       reason: rebase.reason,
       failures: pr.failures,
       conflict: Boolean(rebase.conflict),
       dryRun: Boolean(rebase.dryRun),
+      category: rebase.category ?? null,
+      expectedHeadOid: rebase.expectedHeadOid ?? null,
+      observedHeadOid: rebase.observedHeadOid ?? null,
     };
     results.push(item);
 
     if (!rebase.ok) {
       if (!options.dryRun && rebase.conflict) {
-        await labelPr(options.repo, pr.number, 'needs-conflict-resolution');
-        await commentPr(
+        await labelPrImpl(options.repo, pr.number, 'needs-conflict-resolution');
+        await commentPrImpl(
           options.repo,
           pr.number,
           '## Drain auto-rebase blocked\n\nAutomatic rebase onto latest `main` hit merge conflicts. Resolve conflicts locally, push, then re-enroll with the `merge-queue` label.'
@@ -279,14 +228,26 @@ export async function remediateBlockedPrs(options) {
       continue;
     }
 
+    if (!rebase.updated) {
+      console.log(`    - ${rebase.reason}`);
+      continue;
+    }
+
     applied += 1;
 
     if (!options.dryRun) {
-      await labelPr(options.repo, pr.number, 'merge-queue');
-      await commentPr(
+      if (hasConflictLabel) {
+        await removeLabelPrImpl(
+          options.repo,
+          pr.number,
+          'needs-conflict-resolution'
+        );
+      }
+      await labelPrImpl(options.repo, pr.number, 'merge-queue');
+      await commentPrImpl(
         options.repo,
         pr.number,
-        `## Drain auto-rebase\n\nRebased onto latest \`${baseRef}\` to re-trigger CI after a possible main-side fix.\n\nFailing checks before rebase: ${pr.failures.join(', ')}`
+        `## Drain auto-rebase\n\nGitHub Update Branch rebased the exact PR head onto latest \`${baseRef}\` to re-trigger CI after a possible main-side fix.\n\nHead: \`${rebase.expectedHeadOid}\` → \`${rebase.observedHeadOid}\`\n\nFailing checks before rebase: ${pr.failures.join(', ')}`
       );
       console.log(`    ✓ ${rebase.reason}; +merge-queue`);
     } else {

--- a/scripts/drain-pr-remediate.mjs
+++ b/scripts/drain-pr-remediate.mjs
@@ -154,6 +154,7 @@ export async function remediateBlockedPrs(options, dependencies = {}) {
 
   const results = [];
   let applied = 0;
+  let mutationBudgetUsed = 0;
 
   console.log('=== REMEDIATE (BLOCKED agent PRs → rebase onto main) ===');
   console.log(
@@ -161,9 +162,9 @@ export async function remediateBlockedPrs(options, dependencies = {}) {
   );
 
   for (const pr of blocked) {
-    if (applied >= options.maxPerRun) {
+    if (mutationBudgetUsed >= options.maxPerRun) {
       console.log(
-        `  cap reached (${options.maxPerRun}/run); remaining candidates skipped`
+        `  mutation cap reached (${mutationBudgetUsed}/${options.maxPerRun}); remaining candidates skipped`
       );
       break;
     }
@@ -196,6 +197,10 @@ export async function remediateBlockedPrs(options, dependencies = {}) {
       dryRun: options.dryRun,
     });
     const baseRef = rebase.baseRefName ?? options.baseRef;
+    const consumedBudget = options.dryRun
+      ? Boolean(rebase.updated)
+      : Boolean(rebase.mutationAttempted);
+    if (consumedBudget) mutationBudgetUsed += 1;
 
     const item = {
       number: pr.number,
@@ -212,6 +217,9 @@ export async function remediateBlockedPrs(options, dependencies = {}) {
       category: rebase.category ?? null,
       expectedHeadOid: rebase.expectedHeadOid ?? null,
       observedHeadOid: rebase.observedHeadOid ?? null,
+      mutationAttempted: Boolean(rebase.mutationAttempted),
+      mutationApplied: Boolean(rebase.mutationApplied),
+      consumedBudget,
     };
     results.push(item);
 
@@ -267,9 +275,15 @@ export async function remediateBlockedPrs(options, dependencies = {}) {
   }
 
   console.log(
-    `=== remediate done (applied=${applied}, dryRun=${options.dryRun}) ===`
+    `=== remediate done (applied=${applied}, mutationBudgetUsed=${mutationBudgetUsed}, dryRun=${options.dryRun}) ===`
   );
-  return { blocked: blocked.length, applied, results, dryRun: options.dryRun };
+  return {
+    blocked: blocked.length,
+    applied,
+    mutationBudgetUsed,
+    results,
+    dryRun: options.dryRun,
+  };
 }
 
 async function main() {

--- a/scripts/drain-pr-remediate.mjs
+++ b/scripts/drain-pr-remediate.mjs
@@ -229,6 +229,13 @@ export async function remediateBlockedPrs(options, dependencies = {}) {
     }
 
     if (!rebase.updated) {
+      if (!options.dryRun && hasConflictLabel) {
+        await removeLabelPrImpl(
+          options.repo,
+          pr.number,
+          'needs-conflict-resolution'
+        );
+      }
       console.log(`    - ${rebase.reason}`);
       continue;
     }

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -767,6 +767,7 @@ function ghSequence({
   before = snapshot(),
   mutation = mutationSnapshot(),
   after = snapshot({ headRefOid: UPDATED_HEAD }),
+  afterSequence = null,
   mutationError = null,
 } = {}) {
   const calls = [];
@@ -775,7 +776,9 @@ function ghSequence({
     calls.push(args);
     if (args[0] === 'pr' && args[1] === 'view') {
       snapshotCalls += 1;
-      return snapshotCalls === 1 ? before : after;
+      if (snapshotCalls === 1) return before;
+      const snapshots = afterSequence ?? [after];
+      return snapshots[Math.min(snapshotCalls - 2, snapshots.length - 1)];
     }
     if (args[0] === 'api' && args[1] === 'graphql') {
       if (mutationError) throw mutationError;
@@ -818,6 +821,56 @@ describe('exact-head GitHub Update Branch rebase', () => {
     expect(gh.calls.flat().join(' ')).not.toMatch(
       /repo clone|force-with-lease|git push/
     );
+  });
+
+  it('polls through a stale post-mutation read until the exact updated head is visible', async () => {
+    const sleepImpl = vi.fn(async () => {});
+    const gh = ghSequence({
+      afterSequence: [snapshot(), snapshot({ headRefOid: UPDATED_HEAD })],
+    });
+
+    const result = await tryGitHubRebase({
+      repo: 'JovieInc/Jovie',
+      pr: blockedPr(),
+      expectedBaseRefName: null,
+      dryRun: false,
+      ghJsonImpl: gh.ghJsonImpl,
+      sleepImpl,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      updated: true,
+      expectedHeadOid: ORIGINAL_HEAD,
+      observedHeadOid: UPDATED_HEAD,
+    });
+    expect(sleepImpl).toHaveBeenCalledOnce();
+    expect(sleepImpl).toHaveBeenCalledWith(250);
+  });
+
+  it('fails closed when the updated head never becomes visible', async () => {
+    const sleepImpl = vi.fn(async () => {});
+    const gh = ghSequence({ afterSequence: [snapshot()] });
+
+    const result = await tryGitHubRebase({
+      repo: 'JovieInc/Jovie',
+      pr: blockedPr(),
+      expectedBaseRefName: null,
+      dryRun: false,
+      ghJsonImpl: gh.ghJsonImpl,
+      sleepImpl,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      conflict: false,
+      category: 'verification_failure',
+      expectedHeadOid: ORIGINAL_HEAD,
+      observedHeadOid: ORIGINAL_HEAD,
+    });
+    expect(sleepImpl.mock.calls.map(([delayMs]) => delayMs)).toEqual([
+      250, 500, 1000, 2000,
+    ]);
   });
 
   it('treats a concurrent head update as stale, never as a conflict', async () => {
@@ -958,6 +1011,39 @@ describe('remediation mutations', () => {
     });
 
     expect(summary.applied).toBe(0);
+    expect(labelPrImpl).not.toHaveBeenCalled();
+    expect(commentPrImpl).not.toHaveBeenCalled();
+  });
+
+  it('clears a stale conflict label on a verified no-op without queue churn', async () => {
+    const labelPrImpl = vi.fn();
+    const removeLabelPrImpl = vi.fn();
+    const commentPrImpl = vi.fn();
+
+    const summary = await remediateBlockedPrs(options, {
+      listBlockedAgentPrsImpl: async () => [
+        blockedPr({ labels: [{ name: 'needs-conflict-resolution' }] }),
+      ],
+      rebaseImpl: async () => ({
+        ok: true,
+        updated: false,
+        conflict: false,
+        category: 'no_change',
+        reason: 'GitHub reports the pull request branch is already current',
+      }),
+      labelPrImpl,
+      removeLabelPrImpl,
+      commentPrImpl,
+      nowMs: Date.parse('2026-07-18T00:00:00Z'),
+    });
+
+    expect(summary.applied).toBe(0);
+    expect(removeLabelPrImpl).toHaveBeenCalledOnce();
+    expect(removeLabelPrImpl).toHaveBeenCalledWith(
+      'JovieInc/Jovie',
+      123,
+      'needs-conflict-resolution'
+    );
     expect(labelPrImpl).not.toHaveBeenCalled();
     expect(commentPrImpl).not.toHaveBeenCalled();
   });

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -1,6 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { remediateBlockedPrs } from '../../drain-pr-remediate.mjs';
+import {
+  classifyGitHubRebaseFailure,
+  tryGitHubRebase,
+} from '../github-update-branch.mjs';
 import {
   bisectBatchFailure,
   ciWorkflowHasMergeGroupTrigger,
@@ -717,5 +722,311 @@ describe('merge queue telemetry parser', () => {
     ]);
 
     expect(metrics.readyToMergedSeconds).toBeNull();
+  });
+});
+
+const ORIGINAL_HEAD = 'a'.repeat(40);
+const UPDATED_HEAD = 'b'.repeat(40);
+const RACING_HEAD = 'c'.repeat(40);
+
+function snapshot(overrides = {}) {
+  return {
+    id: 'PR_kwDO_example',
+    state: 'OPEN',
+    isDraft: false,
+    baseRefName: 'main',
+    headRefName: 'tim/jov-123-example',
+    headRefOid: ORIGINAL_HEAD,
+    mergeable: 'MERGEABLE',
+    ...overrides,
+  };
+}
+
+function mutationSnapshot() {
+  return {
+    data: {
+      updatePullRequestBranch: {
+        pullRequest: snapshot({ headRefOid: UPDATED_HEAD }),
+      },
+    },
+  };
+}
+
+function blockedPr(overrides = {}) {
+  return {
+    number: 123,
+    headRefName: 'tim/jov-123-example',
+    updatedAt: '2026-07-01T00:00:00Z',
+    labels: [],
+    failures: ['CI / PR Ready'],
+    ...overrides,
+  };
+}
+
+function ghSequence({
+  before = snapshot(),
+  mutation = mutationSnapshot(),
+  after = snapshot({ headRefOid: UPDATED_HEAD }),
+  mutationError = null,
+} = {}) {
+  const calls = [];
+  let snapshotCalls = 0;
+  const ghJsonImpl = vi.fn(async args => {
+    calls.push(args);
+    if (args[0] === 'pr' && args[1] === 'view') {
+      snapshotCalls += 1;
+      return snapshotCalls === 1 ? before : after;
+    }
+    if (args[0] === 'api' && args[1] === 'graphql') {
+      if (mutationError) throw mutationError;
+      return mutation;
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  });
+  return { calls, ghJsonImpl };
+}
+
+function ghError(message) {
+  return Object.assign(new Error(message), { stderr: message });
+}
+
+describe('exact-head GitHub Update Branch rebase', () => {
+  it('passes the observed head to updatePullRequestBranch with REBASE and verifies the new head', async () => {
+    const gh = ghSequence();
+
+    const result = await tryGitHubRebase({
+      repo: 'JovieInc/Jovie',
+      pr: blockedPr(),
+      expectedBaseRefName: null,
+      dryRun: false,
+      ghJsonImpl: gh.ghJsonImpl,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      updated: true,
+      conflict: false,
+      expectedHeadOid: ORIGINAL_HEAD,
+      observedHeadOid: UPDATED_HEAD,
+      baseRefName: 'main',
+    });
+    const mutationArgs = gh.calls.find(
+      args => args[0] === 'api' && args[1] === 'graphql'
+    );
+    expect(mutationArgs.join('\n')).toContain('updateMethod: REBASE');
+    expect(mutationArgs).toContain(`expectedHeadOid=${ORIGINAL_HEAD}`);
+    expect(gh.calls.flat().join(' ')).not.toMatch(
+      /repo clone|force-with-lease|git push/
+    );
+  });
+
+  it('treats a concurrent head update as stale, never as a conflict', async () => {
+    const gh = ghSequence({
+      mutationError: ghError('GraphQL: head branch was modified'),
+      after: snapshot({ headRefOid: UPDATED_HEAD }),
+    });
+
+    const result = await tryGitHubRebase({
+      repo: 'JovieInc/Jovie',
+      pr: blockedPr(),
+      expectedBaseRefName: null,
+      dryRun: false,
+      ghJsonImpl: gh.ghJsonImpl,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      conflict: false,
+      category: 'stale_head',
+      expectedHeadOid: ORIGINAL_HEAD,
+      observedHeadOid: UPDATED_HEAD,
+    });
+  });
+
+  it('refuses enrollment when the post-update head differs from the mutation result', async () => {
+    const gh = ghSequence({
+      after: snapshot({ headRefOid: RACING_HEAD }),
+    });
+
+    const result = await tryGitHubRebase({
+      repo: 'JovieInc/Jovie',
+      pr: blockedPr(),
+      expectedBaseRefName: null,
+      dryRun: false,
+      ghJsonImpl: gh.ghJsonImpl,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      conflict: false,
+      category: 'verification_failure',
+      expectedHeadOid: ORIGINAL_HEAD,
+      observedHeadOid: RACING_HEAD,
+    });
+  });
+
+  it('only classifies a conflict when GitHub confirms CONFLICTING after failure', () => {
+    const error = ghError('GraphQL: pull request is not mergeable');
+
+    expect(
+      classifyGitHubRebaseFailure({
+        error,
+        before: snapshot(),
+        after: snapshot({ mergeable: 'CONFLICTING' }),
+      })
+    ).toMatchObject({ conflict: true, category: 'conflict' });
+    expect(
+      classifyGitHubRebaseFailure({
+        error: ghError('HTTP 503 service unavailable'),
+        before: snapshot(),
+        after: snapshot({ mergeable: 'MERGEABLE' }),
+      })
+    ).toMatchObject({ conflict: false, category: 'transient' });
+    expect(
+      classifyGitHubRebaseFailure({
+        error: ghError('HTTP 403 Resource not accessible by integration'),
+        before: snapshot(),
+        after: snapshot({ mergeable: 'UNKNOWN' }),
+      })
+    ).toMatchObject({ conflict: false, category: 'auth' });
+    expect(
+      classifyGitHubRebaseFailure({
+        error: ghError('GraphQL: PR branch already up-to-date'),
+        before: snapshot(),
+        after: snapshot(),
+      })
+    ).toMatchObject({
+      ok: true,
+      updated: false,
+      conflict: false,
+      category: 'no_change',
+    });
+  });
+});
+
+describe('remediation mutations', () => {
+  const options = {
+    repo: 'JovieInc/Jovie',
+    baseRef: 'main',
+    dryRun: false,
+    maxPerRun: 3,
+    cooldownHours: 0,
+    limit: 10,
+  };
+
+  it('bypasses the cooldown for a stale conflict label', async () => {
+    const rebaseImpl = vi.fn(async () => ({
+      ok: true,
+      updated: true,
+      dryRun: true,
+      reason: 'would rebase exact head',
+    }));
+
+    const summary = await remediateBlockedPrs(
+      { ...options, dryRun: true, cooldownHours: 4 },
+      {
+        listBlockedAgentPrsImpl: async () => [
+          blockedPr({
+            updatedAt: '2026-07-18T17:59:00Z',
+            labels: [{ name: 'needs-conflict-resolution' }],
+          }),
+        ],
+        rebaseImpl,
+        nowMs: Date.parse('2026-07-18T18:00:00Z'),
+      }
+    );
+
+    expect(rebaseImpl).toHaveBeenCalledOnce();
+    expect(summary.applied).toBe(1);
+  });
+
+  it('does not add conflict or queue labels for transient rebase failures', async () => {
+    const labelPrImpl = vi.fn();
+    const commentPrImpl = vi.fn();
+
+    const summary = await remediateBlockedPrs(options, {
+      listBlockedAgentPrsImpl: async () => [blockedPr()],
+      rebaseImpl: async () => ({
+        ok: false,
+        conflict: false,
+        category: 'transient',
+        reason: 'GitHub rebase transient: HTTP 503',
+      }),
+      labelPrImpl,
+      commentPrImpl,
+      nowMs: Date.parse('2026-07-18T00:00:00Z'),
+    });
+
+    expect(summary.applied).toBe(0);
+    expect(labelPrImpl).not.toHaveBeenCalled();
+    expect(commentPrImpl).not.toHaveBeenCalled();
+  });
+
+  it('adds needs-conflict-resolution only for confirmed conflicts', async () => {
+    const labelPrImpl = vi.fn();
+    const commentPrImpl = vi.fn();
+
+    await remediateBlockedPrs(options, {
+      listBlockedAgentPrsImpl: async () => [blockedPr()],
+      rebaseImpl: async () => ({
+        ok: false,
+        conflict: true,
+        category: 'conflict',
+        reason: 'GitHub confirmed conflicts',
+      }),
+      labelPrImpl,
+      commentPrImpl,
+      nowMs: Date.parse('2026-07-18T00:00:00Z'),
+    });
+
+    expect(labelPrImpl).toHaveBeenCalledOnce();
+    expect(labelPrImpl).toHaveBeenCalledWith(
+      'JovieInc/Jovie',
+      123,
+      'needs-conflict-resolution'
+    );
+    expect(commentPrImpl).toHaveBeenCalledOnce();
+  });
+
+  it('clears a stale conflict label before enrolling the rebased head', async () => {
+    const labelPrImpl = vi.fn();
+    const removeLabelPrImpl = vi.fn();
+    const commentPrImpl = vi.fn();
+
+    const summary = await remediateBlockedPrs(options, {
+      listBlockedAgentPrsImpl: async () => [
+        blockedPr({ labels: [{ name: 'needs-conflict-resolution' }] }),
+      ],
+      rebaseImpl: async () => ({
+        ok: true,
+        updated: true,
+        conflict: false,
+        category: 'updated',
+        baseRefName: 'main',
+        expectedHeadOid: ORIGINAL_HEAD,
+        observedHeadOid: UPDATED_HEAD,
+        reason: 'GitHub rebased the exact head',
+      }),
+      labelPrImpl,
+      removeLabelPrImpl,
+      commentPrImpl,
+      nowMs: Date.parse('2026-07-18T00:00:00Z'),
+    });
+
+    expect(summary.applied).toBe(1);
+    expect(removeLabelPrImpl).toHaveBeenCalledWith(
+      'JovieInc/Jovie',
+      123,
+      'needs-conflict-resolution'
+    );
+    expect(labelPrImpl).toHaveBeenCalledWith(
+      'JovieInc/Jovie',
+      123,
+      'merge-queue'
+    );
+    expect(removeLabelPrImpl.mock.invocationCallOrder[0]).toBeLessThan(
+      labelPrImpl.mock.invocationCallOrder[0]
+    );
+    expect(commentPrImpl).toHaveBeenCalledOnce();
   });
 });

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -808,6 +808,8 @@ describe('exact-head GitHub Update Branch rebase', () => {
     expect(result).toMatchObject({
       ok: true,
       updated: true,
+      mutationAttempted: true,
+      mutationApplied: true,
       conflict: false,
       expectedHeadOid: ORIGINAL_HEAD,
       observedHeadOid: UPDATED_HEAD,
@@ -863,6 +865,8 @@ describe('exact-head GitHub Update Branch rebase', () => {
 
     expect(result).toMatchObject({
       ok: false,
+      mutationAttempted: true,
+      mutationApplied: true,
       conflict: false,
       category: 'verification_failure',
       expectedHeadOid: ORIGINAL_HEAD,
@@ -889,6 +893,8 @@ describe('exact-head GitHub Update Branch rebase', () => {
 
     expect(result).toMatchObject({
       ok: false,
+      mutationAttempted: true,
+      mutationApplied: false,
       conflict: false,
       category: 'stale_head',
       expectedHeadOid: ORIGINAL_HEAD,
@@ -1001,6 +1007,8 @@ describe('remediation mutations', () => {
       listBlockedAgentPrsImpl: async () => [blockedPr()],
       rebaseImpl: async () => ({
         ok: false,
+        mutationAttempted: true,
+        mutationApplied: false,
         conflict: false,
         category: 'transient',
         reason: 'GitHub rebase transient: HTTP 503',
@@ -1011,6 +1019,45 @@ describe('remediation mutations', () => {
     });
 
     expect(summary.applied).toBe(0);
+    expect(summary.mutationBudgetUsed).toBe(1);
+    expect(labelPrImpl).not.toHaveBeenCalled();
+    expect(commentPrImpl).not.toHaveBeenCalled();
+  });
+
+  it('stops after one attempted but unverified mutation', async () => {
+    const rebaseImpl = vi.fn(async () => ({
+      ok: false,
+      mutationAttempted: true,
+      mutationApplied: true,
+      conflict: false,
+      category: 'verification_failure',
+      reason: 'updated head did not converge before timeout',
+    }));
+    const labelPrImpl = vi.fn();
+    const commentPrImpl = vi.fn();
+
+    const summary = await remediateBlockedPrs(
+      { ...options, maxPerRun: 1 },
+      {
+        listBlockedAgentPrsImpl: async () => [
+          blockedPr(),
+          blockedPr({ number: 124, headRefName: 'codex/next-candidate' }),
+        ],
+        rebaseImpl,
+        labelPrImpl,
+        commentPrImpl,
+        nowMs: Date.parse('2026-07-18T00:00:00Z'),
+      }
+    );
+
+    expect(rebaseImpl).toHaveBeenCalledOnce();
+    expect(summary).toMatchObject({ applied: 0, mutationBudgetUsed: 1 });
+    expect(summary.results).toHaveLength(1);
+    expect(summary.results[0]).toMatchObject({
+      mutationAttempted: true,
+      mutationApplied: true,
+      consumedBudget: true,
+    });
     expect(labelPrImpl).not.toHaveBeenCalled();
     expect(commentPrImpl).not.toHaveBeenCalled();
   });
@@ -1027,6 +1074,8 @@ describe('remediation mutations', () => {
       rebaseImpl: async () => ({
         ok: true,
         updated: false,
+        mutationAttempted: true,
+        mutationApplied: false,
         conflict: false,
         category: 'no_change',
         reason: 'GitHub reports the pull request branch is already current',
@@ -1086,6 +1135,8 @@ describe('remediation mutations', () => {
       rebaseImpl: async () => ({
         ok: true,
         updated: true,
+        mutationAttempted: true,
+        mutationApplied: true,
         conflict: false,
         category: 'updated',
         baseRefName: 'main',

--- a/scripts/lib/github-update-branch.mjs
+++ b/scripts/lib/github-update-branch.mjs
@@ -3,6 +3,8 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
+const POST_UPDATE_VERIFY_DELAYS_MS = [0, 250, 500, 1000, 2000];
+
 const UPDATE_PULL_REQUEST_BRANCH_MUTATION = `
   mutation UpdatePullRequestBranch(
     $pullRequestId: ID!
@@ -134,12 +136,52 @@ async function tryFetchPrSnapshot(repo, prNumber, ghJsonImpl) {
   }
 }
 
+function sleep(delayMs) {
+  return new Promise(resolve => setTimeout(resolve, delayMs));
+}
+
+async function pollForUpdatedHead({
+  repo,
+  prNumber,
+  before,
+  mutated,
+  ghJsonImpl,
+  sleepImpl,
+}) {
+  let lastSnapshot = null;
+
+  for (const delayMs of POST_UPDATE_VERIFY_DELAYS_MS) {
+    if (delayMs > 0) await sleepImpl(delayMs);
+
+    const snapshot = await tryFetchPrSnapshot(repo, prNumber, ghJsonImpl);
+    if (!snapshot) continue;
+    lastSnapshot = snapshot;
+
+    if (
+      snapshot.id !== before.id ||
+      snapshot.baseRefName !== before.baseRefName ||
+      snapshot.headRefName !== before.headRefName
+    ) {
+      return { snapshot, identityChanged: true };
+    }
+    if (snapshot.headRefOid === mutated.headRefOid) {
+      return { snapshot, converged: true };
+    }
+    if (snapshot.headRefOid !== before.headRefOid) {
+      return { snapshot, headChanged: true };
+    }
+  }
+
+  return { snapshot: lastSnapshot, timedOut: true };
+}
+
 export async function tryGitHubRebase({
   repo,
   pr,
   expectedBaseRefName,
   dryRun,
   ghJsonImpl = ghJson,
+  sleepImpl = sleep,
 }) {
   if (dryRun) {
     return {
@@ -230,8 +272,12 @@ export async function tryGitHubRebase({
   }
 
   const mutated = mutation?.data?.updatePullRequestBranch?.pullRequest;
-  const after = await tryFetchPrSnapshot(repo, pr.number, ghJsonImpl);
-  if (!mutated?.headRefOid || !after?.headRefOid) {
+  if (
+    !mutated?.headRefOid ||
+    mutated.id !== before.id ||
+    mutated.baseRefName !== before.baseRefName ||
+    mutated.headRefName !== before.headRefName
+  ) {
     return {
       ok: false,
       conflict: false,
@@ -239,18 +285,20 @@ export async function tryGitHubRebase({
       baseRefName: before.baseRefName,
       expectedHeadOid: before.headRefOid,
       reason:
-        'GitHub rebase returned without a verifiable post-update head; refusing enrollment mutation',
+        'GitHub rebase returned without a verifiable PR identity, base, or head; refusing enrollment mutation',
     };
   }
-  if (
-    mutated.id !== before.id ||
-    after.id !== before.id ||
-    mutated.baseRefName !== before.baseRefName ||
-    after.baseRefName !== before.baseRefName ||
-    mutated.headRefName !== before.headRefName ||
-    after.headRefName !== before.headRefName ||
-    mutated.headRefOid !== after.headRefOid
-  ) {
+
+  const verification = await pollForUpdatedHead({
+    repo,
+    prNumber: pr.number,
+    before,
+    mutated,
+    ghJsonImpl,
+    sleepImpl,
+  });
+  const after = verification.snapshot;
+  if (verification.identityChanged || verification.headChanged) {
     return {
       ok: false,
       conflict: false,
@@ -260,6 +308,17 @@ export async function tryGitHubRebase({
       observedHeadOid: after.headRefOid,
       reason:
         'PR identity, base, or head changed after GitHub rebase; refusing enrollment mutation',
+    };
+  }
+  if (!verification.converged || !after?.headRefOid) {
+    return {
+      ok: false,
+      conflict: false,
+      category: 'verification_failure',
+      baseRefName: before.baseRefName,
+      expectedHeadOid: before.headRefOid,
+      observedHeadOid: after?.headRefOid ?? null,
+      reason: `GitHub rebase head was not visible after ${POST_UPDATE_VERIFY_DELAYS_MS.length} bounded verification reads; refusing enrollment mutation`,
     };
   }
   if (after.headRefOid === before.headRefOid) {

--- a/scripts/lib/github-update-branch.mjs
+++ b/scripts/lib/github-update-branch.mjs
@@ -4,6 +4,7 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 
 const POST_UPDATE_VERIFY_DELAYS_MS = [0, 250, 500, 1000, 2000];
+const NO_MUTATION = { mutationAttempted: false, mutationApplied: false };
 
 const UPDATE_PULL_REQUEST_BRANCH_MUTATION = `
   mutation UpdatePullRequestBranch(
@@ -185,6 +186,7 @@ export async function tryGitHubRebase({
 }) {
   if (dryRun) {
     return {
+      ...NO_MUTATION,
       ok: true,
       updated: true,
       dryRun: true,
@@ -199,6 +201,7 @@ export async function tryGitHubRebase({
     before = await fetchPrSnapshot(repo, pr.number, ghJsonImpl);
   } catch (error) {
     return {
+      ...NO_MUTATION,
       ok: false,
       conflict: false,
       category: 'snapshot_failure',
@@ -212,6 +215,7 @@ export async function tryGitHubRebase({
     before.headRefName !== pr.headRefName
   ) {
     return {
+      ...NO_MUTATION,
       ok: false,
       conflict: false,
       category: 'stale_pr',
@@ -221,6 +225,7 @@ export async function tryGitHubRebase({
   }
   if (expectedBaseRefName && before.baseRefName !== expectedBaseRefName) {
     return {
+      ...NO_MUTATION,
       ok: false,
       conflict: false,
       category: 'stale_base',
@@ -230,6 +235,7 @@ export async function tryGitHubRebase({
   }
   if (!before.id || !before.headRefOid) {
     return {
+      ...NO_MUTATION,
       ok: false,
       conflict: false,
       category: 'snapshot_failure',
@@ -239,6 +245,7 @@ export async function tryGitHubRebase({
   }
   if (before.mergeable === 'CONFLICTING') {
     return {
+      ...NO_MUTATION,
       ok: false,
       conflict: true,
       category: 'conflict',
@@ -265,6 +272,8 @@ export async function tryGitHubRebase({
     const after = await tryFetchPrSnapshot(repo, pr.number, ghJsonImpl);
     return {
       ...classifyGitHubRebaseFailure({ error, before, after }),
+      mutationAttempted: true,
+      mutationApplied: false,
       baseRefName: before.baseRefName,
       expectedHeadOid: before.headRefOid,
       observedHeadOid: after?.headRefOid ?? null,
@@ -272,6 +281,12 @@ export async function tryGitHubRebase({
   }
 
   const mutated = mutation?.data?.updatePullRequestBranch?.pullRequest;
+  const mutationState = {
+    mutationAttempted: true,
+    mutationApplied: Boolean(
+      mutated?.headRefOid && mutated.headRefOid !== before.headRefOid
+    ),
+  };
   if (
     !mutated?.headRefOid ||
     mutated.id !== before.id ||
@@ -279,6 +294,7 @@ export async function tryGitHubRebase({
     mutated.headRefName !== before.headRefName
   ) {
     return {
+      ...mutationState,
       ok: false,
       conflict: false,
       category: 'verification_failure',
@@ -300,6 +316,7 @@ export async function tryGitHubRebase({
   const after = verification.snapshot;
   if (verification.identityChanged || verification.headChanged) {
     return {
+      ...mutationState,
       ok: false,
       conflict: false,
       category: 'verification_failure',
@@ -312,6 +329,7 @@ export async function tryGitHubRebase({
   }
   if (!verification.converged || !after?.headRefOid) {
     return {
+      ...mutationState,
       ok: false,
       conflict: false,
       category: 'verification_failure',
@@ -324,6 +342,7 @@ export async function tryGitHubRebase({
   if (after.headRefOid === before.headRefOid) {
     if (after.mergeable === 'CONFLICTING') {
       return {
+        ...mutationState,
         ok: false,
         conflict: true,
         category: 'conflict',
@@ -334,6 +353,7 @@ export async function tryGitHubRebase({
       };
     }
     return {
+      ...mutationState,
       ok: true,
       updated: false,
       conflict: false,
@@ -346,6 +366,7 @@ export async function tryGitHubRebase({
   }
 
   return {
+    ...mutationState,
     ok: true,
     updated: true,
     conflict: false,

--- a/scripts/lib/github-update-branch.mjs
+++ b/scripts/lib/github-update-branch.mjs
@@ -1,0 +1,299 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const UPDATE_PULL_REQUEST_BRANCH_MUTATION = `
+  mutation UpdatePullRequestBranch(
+    $pullRequestId: ID!
+    $expectedHeadOid: GitObjectID!
+  ) {
+    updatePullRequestBranch(
+      input: {
+        pullRequestId: $pullRequestId
+        expectedHeadOid: $expectedHeadOid
+        updateMethod: REBASE
+      }
+    ) {
+      pullRequest {
+        id
+        baseRefName
+        headRefName
+        headRefOid
+      }
+    }
+  }
+`;
+
+async function ghJson(args) {
+  const { stdout } = await execFileAsync('gh', args, {
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  return JSON.parse(stdout);
+}
+
+function errorText(error) {
+  const raw = [error?.stderr, error?.stdout, error?.message]
+    .filter(Boolean)
+    .join(' ')
+    .replace(/gh[pousr]_[A-Za-z0-9_]+/g, '[REDACTED]')
+    .replace(/Bearer\s+\S+/gi, 'Bearer [REDACTED]')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return (raw || 'unknown GitHub API error').slice(0, 300);
+}
+
+function failureCategory(error) {
+  const text = errorText(error);
+  if (
+    /timed? out|timeout|HTTP 50[234]|rate limit|temporar|ECONNRESET|EAI_AGAIN|connection reset|server error/i.test(
+      text
+    )
+  ) {
+    return 'transient';
+  }
+  if (
+    /authentication|unauthorized|forbidden|resource not accessible|requires authentication|HTTP 40[13]/i.test(
+      text
+    )
+  ) {
+    return 'auth';
+  }
+  return 'api_failure';
+}
+
+export function classifyGitHubRebaseFailure({ error, before, after }) {
+  const detail = errorText(error);
+
+  // expectedHeadOid makes a concurrent head update fail safely. Never call
+  // that a conflict: another actor already produced a newer authoritative head.
+  if (
+    before?.headRefOid &&
+    after?.headRefOid &&
+    before.headRefOid !== after.headRefOid
+  ) {
+    return {
+      ok: false,
+      conflict: false,
+      category: 'stale_head',
+      reason: `head changed during GitHub rebase (${before.headRefOid.slice(0, 12)} -> ${after.headRefOid.slice(0, 12)}); leaving the newer head untouched`,
+    };
+  }
+
+  // GitHub's post-failure mergeability snapshot is the only conflict proof.
+  // CLI exit status and error prose also cover auth, rate limits, and outages.
+  if (after?.mergeable === 'CONFLICTING') {
+    return {
+      ok: false,
+      conflict: true,
+      category: 'conflict',
+      reason: `GitHub rebase confirmed merge conflicts: ${detail}`,
+    };
+  }
+
+  if (
+    before?.headRefOid === after?.headRefOid &&
+    /already up.to.date|already current|not behind/i.test(detail)
+  ) {
+    return {
+      ok: true,
+      updated: false,
+      conflict: false,
+      category: 'no_change',
+      reason: 'GitHub reports the pull request branch is already current',
+    };
+  }
+
+  const category = failureCategory(error);
+  return {
+    ok: false,
+    conflict: false,
+    category,
+    reason: `GitHub rebase ${category.replace('_', ' ')}: ${detail}`,
+  };
+}
+
+async function fetchPrSnapshot(repo, prNumber, ghJsonImpl) {
+  return ghJsonImpl([
+    'pr',
+    'view',
+    String(prNumber),
+    '-R',
+    repo,
+    '--json',
+    'id,state,isDraft,baseRefName,headRefName,headRefOid,mergeable',
+  ]);
+}
+
+async function tryFetchPrSnapshot(repo, prNumber, ghJsonImpl) {
+  try {
+    return await fetchPrSnapshot(repo, prNumber, ghJsonImpl);
+  } catch {
+    return null;
+  }
+}
+
+export async function tryGitHubRebase({
+  repo,
+  pr,
+  expectedBaseRefName,
+  dryRun,
+  ghJsonImpl = ghJson,
+}) {
+  if (dryRun) {
+    return {
+      ok: true,
+      updated: true,
+      dryRun: true,
+      baseRefName: expectedBaseRefName,
+      reason:
+        'dry-run: would request an exact-head GitHub Update Branch rebase',
+    };
+  }
+
+  let before;
+  try {
+    before = await fetchPrSnapshot(repo, pr.number, ghJsonImpl);
+  } catch (error) {
+    return {
+      ok: false,
+      conflict: false,
+      category: 'snapshot_failure',
+      reason: `could not read exact PR head before GitHub rebase: ${errorText(error)}`,
+    };
+  }
+
+  if (
+    before.state !== 'OPEN' ||
+    before.isDraft ||
+    before.headRefName !== pr.headRefName
+  ) {
+    return {
+      ok: false,
+      conflict: false,
+      category: 'stale_pr',
+      baseRefName: before.baseRefName,
+      reason: 'PR state or head ref changed before GitHub rebase',
+    };
+  }
+  if (expectedBaseRefName && before.baseRefName !== expectedBaseRefName) {
+    return {
+      ok: false,
+      conflict: false,
+      category: 'stale_base',
+      baseRefName: before.baseRefName,
+      reason: `PR base changed before GitHub rebase (${expectedBaseRefName} -> ${before.baseRefName})`,
+    };
+  }
+  if (!before.id || !before.headRefOid) {
+    return {
+      ok: false,
+      conflict: false,
+      category: 'snapshot_failure',
+      baseRefName: before.baseRefName,
+      reason: 'GitHub PR snapshot omitted id or headRefOid; refusing mutation',
+    };
+  }
+  if (before.mergeable === 'CONFLICTING') {
+    return {
+      ok: false,
+      conflict: true,
+      category: 'conflict',
+      baseRefName: before.baseRefName,
+      expectedHeadOid: before.headRefOid,
+      observedHeadOid: before.headRefOid,
+      reason: 'GitHub confirmed merge conflicts before rebase',
+    };
+  }
+
+  let mutation;
+  try {
+    mutation = await ghJsonImpl([
+      'api',
+      'graphql',
+      '-f',
+      `query=${UPDATE_PULL_REQUEST_BRANCH_MUTATION}`,
+      '-f',
+      `pullRequestId=${before.id}`,
+      '-f',
+      `expectedHeadOid=${before.headRefOid}`,
+    ]);
+  } catch (error) {
+    const after = await tryFetchPrSnapshot(repo, pr.number, ghJsonImpl);
+    return {
+      ...classifyGitHubRebaseFailure({ error, before, after }),
+      baseRefName: before.baseRefName,
+      expectedHeadOid: before.headRefOid,
+      observedHeadOid: after?.headRefOid ?? null,
+    };
+  }
+
+  const mutated = mutation?.data?.updatePullRequestBranch?.pullRequest;
+  const after = await tryFetchPrSnapshot(repo, pr.number, ghJsonImpl);
+  if (!mutated?.headRefOid || !after?.headRefOid) {
+    return {
+      ok: false,
+      conflict: false,
+      category: 'verification_failure',
+      baseRefName: before.baseRefName,
+      expectedHeadOid: before.headRefOid,
+      reason:
+        'GitHub rebase returned without a verifiable post-update head; refusing enrollment mutation',
+    };
+  }
+  if (
+    mutated.id !== before.id ||
+    after.id !== before.id ||
+    mutated.baseRefName !== before.baseRefName ||
+    after.baseRefName !== before.baseRefName ||
+    mutated.headRefName !== before.headRefName ||
+    after.headRefName !== before.headRefName ||
+    mutated.headRefOid !== after.headRefOid
+  ) {
+    return {
+      ok: false,
+      conflict: false,
+      category: 'verification_failure',
+      baseRefName: before.baseRefName,
+      expectedHeadOid: before.headRefOid,
+      observedHeadOid: after.headRefOid,
+      reason:
+        'PR identity, base, or head changed after GitHub rebase; refusing enrollment mutation',
+    };
+  }
+  if (after.headRefOid === before.headRefOid) {
+    if (after.mergeable === 'CONFLICTING') {
+      return {
+        ok: false,
+        conflict: true,
+        category: 'conflict',
+        baseRefName: before.baseRefName,
+        expectedHeadOid: before.headRefOid,
+        observedHeadOid: after.headRefOid,
+        reason: 'GitHub rebase left the head unchanged and confirmed conflicts',
+      };
+    }
+    return {
+      ok: true,
+      updated: false,
+      conflict: false,
+      category: 'no_change',
+      baseRefName: before.baseRefName,
+      expectedHeadOid: before.headRefOid,
+      observedHeadOid: after.headRefOid,
+      reason: 'GitHub reports the pull request branch is already current',
+    };
+  }
+
+  return {
+    ok: true,
+    updated: true,
+    conflict: false,
+    category: 'updated',
+    baseRefName: before.baseRefName,
+    expectedHeadOid: before.headRefOid,
+    observedHeadOid: after.headRefOid,
+    reason: `GitHub rebased ${before.headRefOid.slice(0, 12)} -> ${after.headRefOid.slice(0, 12)} onto ${before.baseRefName}`,
+  };
+}

--- a/scripts/lib/pr-check-failures.mjs
+++ b/scripts/lib/pr-check-failures.mjs
@@ -345,6 +345,7 @@ export async function listBlockedAgentPrs(repo, { limit = 200 } = {}) {
       title: pr.title,
       headRefName: pr.headRefName,
       updatedAt: pr.updatedAt,
+      labels: pr.labels,
       failures,
     });
   }

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -1205,12 +1205,20 @@ JSON
         assert "CI / PR Ready (missing)" in result.stdout
         assert "[dry-run] would +merge-queue on #889" not in result.stdout
 
-    def test_drain_remediate_script_exists(self) -> None:
+    def test_drain_remediate_uses_exact_head_github_rebase(self) -> None:
         remediate = _REPO_ROOT / "scripts" / "drain-pr-remediate.mjs"
+        update_branch = _REPO_ROOT / "scripts" / "lib" / "github-update-branch.mjs"
         assert remediate.is_file()
-        content = remediate.read_text(encoding="utf-8")
+        assert update_branch.is_file()
+        content = remediate.read_text(encoding="utf-8") + update_branch.read_text(
+            encoding="utf-8"
+        )
         assert "listBlockedAgentPrs" in content
-        assert "force-with-lease" in content
+        assert "updatePullRequestBranch" in content
+        assert "expectedHeadOid" in content
+        assert "updateMethod: REBASE" in content
+        assert "force-with-lease" not in content
+        assert "repo', 'clone" not in content
 
     def test_gtmq_drafts_bypass_ordinary_label_mutations_but_fail_closed_without_sources(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

- replace local clone/rebase/force-push remediation with GitHub Update Branch using GraphQL `updatePullRequestBranch`, `expectedHeadOid`, and `REBASE`
- fail closed on head races and API/auth/transient failures; apply `needs-conflict-resolution` only when GitHub reports `CONFLICTING`
- clear stale false-conflict labels before native merge-queue enrollment and cover the control path with focused regressions

## Root cause

The old catch-all local rebase path converted any local git failure, including missing committer identity, into a merge conflict. That falsely labeled clean PRs and introduced a four-hour remediation cooldown loop.

## Verification

- `pnpm ci:control:test` (127 passed)
- `python3 -m pytest scripts/tests/test_gh_retry.py -q` (59 passed)
- `pnpm ci:harness:check`
- `pnpm ci:merge-queue:check`
- `pnpm test:bug-to-test` (not applicable)
- live `--dry-run` completed without mutation

## Risk

CI control-plane change. Exact-head pre/post verification prevents enrollment after a concurrent head change; non-conflict errors leave labels untouched for a later retry.