### PR TITLE
Fix noisy Storybook test warnings

### DIFF
--- a/apps/web/.storybook/next-themes-mock.tsx
+++ b/apps/web/.storybook/next-themes-mock.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+type ThemeAttribute = 'class' | `data-${string}`;
+type SystemTheme = 'dark' | 'light';
+
+interface ThemeProviderProps {
+  readonly children?: ReactNode;
+  readonly attribute?: ThemeAttribute | readonly ThemeAttribute[];
+  readonly defaultTheme?: string;
+  readonly enableColorScheme?: boolean;
+  readonly enableSystem?: boolean;
+  readonly forcedTheme?: string;
+  readonly storageKey?: string;
+  readonly themes?: readonly string[];
+  readonly value?: Readonly<Record<string, string>>;
+}
+
+interface ThemeContextValue {
+  readonly forcedTheme?: string;
+  readonly resolvedTheme?: string;
+  readonly setTheme: Dispatch<SetStateAction<string>>;
+  readonly systemTheme?: SystemTheme;
+  readonly theme?: string;
+  readonly themes: readonly string[];
+}
+
+const defaultThemeContext: ThemeContextValue = {
+  setTheme: () => undefined,
+  themes: [],
+};
+
+const DEFAULT_THEMES = ['light', 'dark'] as const;
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function getSystemTheme(): SystemTheme {
+  return globalThis.matchMedia?.('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
+function StorybookThemeProvider({
+  children,
+  attribute = 'data-theme',
+  defaultTheme,
+  enableColorScheme = true,
+  enableSystem = true,
+  forcedTheme,
+  storageKey = 'theme',
+  themes = DEFAULT_THEMES,
+  value,
+}: ThemeProviderProps) {
+  const fallbackTheme = defaultTheme ?? (enableSystem ? 'system' : 'light');
+  const [theme, setThemeState] = useState(() => {
+    try {
+      return globalThis.localStorage?.getItem(storageKey) ?? fallbackTheme;
+    } catch {
+      return fallbackTheme;
+    }
+  });
+  const [systemTheme, setSystemTheme] = useState<SystemTheme>(getSystemTheme);
+  const activeTheme = forcedTheme ?? theme;
+  const resolvedTheme =
+    activeTheme === 'system' ? systemTheme : activeTheme || undefined;
+
+  const setTheme: Dispatch<SetStateAction<string>> = useCallback(
+    nextTheme => {
+      setThemeState(currentTheme => {
+        const resolvedNextTheme =
+          typeof nextTheme === 'function' ? nextTheme(currentTheme) : nextTheme;
+        try {
+          globalThis.localStorage?.setItem(storageKey, resolvedNextTheme);
+        } catch {
+          // Storage is optional in isolated browser tests.
+        }
+        return resolvedNextTheme;
+      });
+    },
+    [storageKey]
+  );
+
+  useEffect(() => {
+    const updateStoredTheme = (event: StorageEvent) => {
+      if (event.key === storageKey) {
+        setThemeState(event.newValue ?? fallbackTheme);
+      }
+    };
+    globalThis.addEventListener?.('storage', updateStoredTheme);
+    return () => globalThis.removeEventListener?.('storage', updateStoredTheme);
+  }, [fallbackTheme, storageKey]);
+
+  useEffect(() => {
+    if (!enableSystem || !globalThis.matchMedia) return;
+
+    const media = globalThis.matchMedia('(prefers-color-scheme: dark)');
+    const updateSystemTheme = () => {
+      setSystemTheme(media.matches ? 'dark' : 'light');
+    };
+    media.addEventListener('change', updateSystemTheme);
+    return () => media.removeEventListener('change', updateSystemTheme);
+  }, [enableSystem]);
+
+  useEffect(() => {
+    if (!resolvedTheme) return;
+
+    const root = document.documentElement;
+    const attributes = Array.isArray(attribute) ? attribute : [attribute];
+    const themeValues = themes.map(item => value?.[item] ?? item);
+    const resolvedValue = value?.[resolvedTheme] ?? resolvedTheme;
+
+    for (const item of attributes) {
+      if (item === 'class') {
+        root.classList.remove(...themeValues);
+        root.classList.add(resolvedValue);
+      } else {
+        root.setAttribute(item, resolvedValue);
+      }
+    }
+    if (enableColorScheme && ['dark', 'light'].includes(resolvedTheme)) {
+      root.style.colorScheme = resolvedTheme;
+    }
+  }, [attribute, enableColorScheme, resolvedTheme, themes, value]);
+
+  const context = useMemo<ThemeContextValue>(
+    () => ({
+      forcedTheme,
+      resolvedTheme,
+      setTheme,
+      systemTheme: enableSystem ? systemTheme : undefined,
+      theme,
+      themes: enableSystem ? [...themes, 'system'] : themes,
+    }),
+    [
+      enableSystem,
+      forcedTheme,
+      resolvedTheme,
+      setTheme,
+      systemTheme,
+      theme,
+      themes,
+    ]
+  );
+
+  return (
+    <ThemeContext.Provider value={context}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function ThemeProvider(props: ThemeProviderProps) {
+  const parent = useContext(ThemeContext);
+  return parent ? props.children : <StorybookThemeProvider {...props} />;
+}
+
+export function useTheme(): ThemeContextValue {
+  return useContext(ThemeContext) ?? defaultThemeContext;
+}

--- a/apps/web/components/atoms/FrostedButton.tsx
+++ b/apps/web/components/atoms/FrostedButton.tsx
@@ -16,9 +16,9 @@ const toneToVariant: Record<
   NonNullable<FrostedButtonProps['tone']>,
   ButtonProps['variant']
 > = {
-  solid: 'frosted',
-  ghost: 'frosted-ghost',
-  outline: 'frosted-outline',
+  solid: 'secondary',
+  ghost: 'ghost',
+  outline: 'secondary',
 };
 
 export const FrostedButton = React.forwardRef<

--- a/apps/web/components/atoms/Popover.stories.tsx
+++ b/apps/web/components/atoms/Popover.stories.tsx
@@ -18,7 +18,7 @@ export const Default: Story = {
     <div className='flex justify-center'>
       <Popover>
         <PopoverTrigger asChild>
-          <Button variant='outline'>More info</Button>
+          <Button variant='secondary'>More info</Button>
         </PopoverTrigger>
         <PopoverContent sideOffset={8} align='center'>
           <p className='text-sm text-gray-700 dark:text-gray-200'>

--- a/apps/web/tests/unit/atoms/FrostedButton.test.tsx
+++ b/apps/web/tests/unit/atoms/FrostedButton.test.tsx
@@ -32,22 +32,22 @@ describe('FrostedButton', () => {
     expect(link).toHaveAttribute('href', '/page');
   });
 
-  it('applies solid tone by default (maps to frosted variant)', () => {
+  it('applies solid tone by default (maps to secondary variant)', () => {
     render(<FrostedButton>Solid</FrostedButton>);
     const button = screen.getByRole('button', { name: 'Solid' });
-    expect(button).toHaveAttribute('data-variant', 'frosted');
+    expect(button).toHaveAttribute('data-variant', 'secondary');
   });
 
-  it('applies ghost tone (maps to frosted-ghost variant)', () => {
+  it('applies ghost tone (maps to ghost variant)', () => {
     render(<FrostedButton tone='ghost'>Ghost</FrostedButton>);
     const button = screen.getByRole('button', { name: 'Ghost' });
-    expect(button).toHaveAttribute('data-variant', 'frosted-ghost');
+    expect(button).toHaveAttribute('data-variant', 'ghost');
   });
 
-  it('applies outline tone (maps to frosted-outline variant)', () => {
+  it('applies outline tone (maps to secondary variant)', () => {
     render(<FrostedButton tone='outline'>Outline</FrostedButton>);
     const button = screen.getByRole('button', { name: 'Outline' });
-    expect(button).toHaveAttribute('data-variant', 'frosted-outline');
+    expect(button).toHaveAttribute('data-variant', 'secondary');
   });
 
   it('adds target="_blank" and rel="noopener noreferrer" when external=true', () => {

--- a/apps/web/tests/unit/storybook/next-themes-mock.test.tsx
+++ b/apps/web/tests/unit/storybook/next-themes-mock.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ThemeProvider, useTheme } from '../../../.storybook/next-themes-mock';
+
+function ThemeControls() {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  return (
+    <button type='button' onClick={() => setTheme('light')}>
+      {resolvedTheme}
+    </button>
+  );
+}
+
+describe('Storybook next-themes mock', () => {
+  afterEach(() => {
+    document.documentElement.classList.remove('dark', 'light');
+    document.documentElement.style.colorScheme = '';
+    globalThis.localStorage.clear();
+  });
+
+  it('provides interactive theme state without injecting a script tag', async () => {
+    render(
+      <ThemeProvider attribute='class' defaultTheme='dark'>
+        <ThemeControls />
+      </ThemeProvider>
+    );
+
+    expect(document.querySelector('script')).toBeNull();
+    expect(screen.getByRole('button')).toHaveTextContent('dark');
+    await waitFor(() => {
+      expect(document.documentElement).toHaveClass('dark');
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button')).toHaveTextContent('light');
+    await waitFor(() => {
+      expect(document.documentElement).toHaveClass('light');
+      expect(document.documentElement).not.toHaveClass('dark');
+    });
+    expect(globalThis.localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('defaults to light when system themes are disabled', async () => {
+    render(
+      <ThemeProvider attribute='class' enableSystem={false}>
+        <ThemeControls />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('light');
+    await waitFor(() => {
+      expect(document.documentElement).toHaveClass('light');
+    });
+  });
+});

--- a/apps/web/vitest.config.storybook.mts
+++ b/apps/web/vitest.config.storybook.mts
@@ -33,6 +33,12 @@ export default defineConfig({
     target: 'esnext',
   },
   resolve: {
+    alias: {
+      // next-themes injects a server bootstrap <script>. Browser-mode story
+      // tests mount previews entirely on the client, where React warns for
+      // every script and never executes it.
+      'next-themes': path.join(dirname, '.storybook/next-themes-mock.tsx'),
+    },
     dedupe: [
       'react',
       'react-dom',
@@ -55,7 +61,6 @@ export default defineConfig({
       'react-dom/client',
       // Storybook / Next.js framework
       '@storybook/nextjs-vite',
-      'next-themes',
       'sonner',
       // UI libraries
       'clsx',


### PR DESCRIPTION
## Summary

- replace next-themes with a script-free, API-compatible provider only in Storybook browser tests
- move Popover and FrostedButton stories/components off deprecated Button variant aliases
- add regression coverage for theme state, storage, DOM application, and FrostedButton variant mapping

## Bug-to-Test

Satisfied. Regression evidence:
- apps/web/tests/unit/storybook/next-themes-mock.test.tsx
- apps/web/tests/unit/atoms/FrostedButton.test.tsx

## Verification

- Storybook browser suite: 120 passed, 1 skipped, 600 tests passed
- focused regression suite: 2 files, 12 tests passed
- web production typecheck: passed
- web production build: passed
- pre-commit secret scan, repository hygiene, ESLint, Biome, accessibility, and typecheck gates: passed
- pre-push affected/full test bundle and CI harness on Node 22.23.1: passed
- CodeRabbit uncommitted review: 3 valid minor findings fixed; 1 finding declined to preserve next-themes 0.4.6 resolvedTheme behavior
- independent adversarial review: blocker fixed before commit

## Risk

Low. The next-themes alias is scoped to vitest.config.storybook.mts and does not affect production builds or the Storybook development server. Canonical Button variants preserve the existing visual intent without deprecated aliases.

## Documentation

No documentation or version change required. This is an internal test-harness cleanup with no user-facing API or workflow change.