### PR TITLE
fix(auth): return Apple sign-in to pending iOS OAuth flow

### DIFF
--- a/apps/web/app/(auth)/identity/IdentityPageClient.test.tsx
+++ b/apps/web/app/(auth)/identity/IdentityPageClient.test.tsx
@@ -38,6 +38,11 @@ vi.mock('@/lib/auth/client', () => ({
 describe('IdentityPageClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.history.replaceState(
+      {},
+      '',
+      '/identity?response_type=code&client_id=logyourbody-ios&redirect_uri=logyourbody%3A%2F%2Foauth&scope=openid+profile+email+offline_access&state=oauth-state&code_challenge=pkce-challenge&code_challenge_method=S256&exp=123&sig=signed'
+    );
     signInSocial.mockResolvedValue({ data: {}, error: null });
   });
 
@@ -55,15 +60,32 @@ describe('IdentityPageClient', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('starts Apple through Better Auth', async () => {
+  it('returns from Apple to the complete pending OAuth transaction', async () => {
     render(<IdentityPageClient />);
     fireEvent.click(
       screen.getByRole('button', { name: 'Continue with Apple' })
     );
 
     await waitFor(() =>
-      expect(signInSocial).toHaveBeenCalledWith({ provider: 'apple' })
+      expect(signInSocial).toHaveBeenCalledWith({
+        provider: 'apple',
+        callbackURL: window.location.href,
+      })
     );
+
+    const callbackURL = new URL(signInSocial.mock.calls[0]?.[0].callbackURL);
+    expect(callbackURL.pathname).toBe('/identity');
+    expect(Object.fromEntries(callbackURL.searchParams)).toEqual({
+      response_type: 'code',
+      client_id: 'logyourbody-ios',
+      redirect_uri: 'logyourbody://oauth',
+      scope: 'openid profile email offline_access',
+      state: 'oauth-state',
+      code_challenge: 'pkce-challenge',
+      code_challenge_method: 'S256',
+      exp: '123',
+      sig: 'signed',
+    });
   });
 
   it('shows a recoverable error when Apple cannot start', async () => {

--- a/apps/web/app/(auth)/identity/IdentityPageClient.test.tsx
+++ b/apps/web/app/(auth)/identity/IdentityPageClient.test.tsx
@@ -41,7 +41,7 @@ describe('IdentityPageClient', () => {
     window.history.replaceState(
       {},
       '',
-      '/identity?response_type=code&client_id=logyourbody-ios&redirect_uri=logyourbody%3A%2F%2Foauth&scope=openid+profile+email+offline_access&state=oauth-state&code_challenge=pkce-challenge&code_challenge_method=S256&exp=123&sig=signed'
+      '/identity?response_type=code&client_id=logyourbody-ios&redirect_uri=logyourbody%3A%2F%2Foauth&scope=openid+profile+email+offline_access&state=oauth-state&code_challenge=pkce-challenge&code_challenge_method=S256&exp=123&ba_param=state&ba_param=sig&sig=signed'
     );
     signInSocial.mockResolvedValue({ data: {}, error: null });
   });
@@ -84,8 +84,13 @@ describe('IdentityPageClient', () => {
       code_challenge: 'pkce-challenge',
       code_challenge_method: 'S256',
       exp: '123',
+      ba_param: 'sig',
       sig: 'signed',
     });
+    expect(callbackURL.searchParams.getAll('ba_param')).toEqual([
+      'state',
+      'sig',
+    ]);
   });
 
   it('shows a recoverable error when Apple cannot start', async () => {
@@ -98,5 +103,20 @@ describe('IdentityPageClient', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent(
       'Apple sign in could not be started. Try again.'
     );
+  });
+
+  it('shows the same recoverable error when the auth client throws', async () => {
+    signInSocial.mockRejectedValue(new Error('network unavailable'));
+    render(<IdentityPageClient />);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with Apple' })
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Apple sign in could not be started. Try again.'
+    );
+    expect(
+      screen.getByRole('button', { name: 'Continue with Apple' })
+    ).toBeEnabled();
   });
 });

--- a/apps/web/app/(auth)/identity/IdentityPageClient.tsx
+++ b/apps/web/app/(auth)/identity/IdentityPageClient.tsx
@@ -20,7 +20,10 @@ export function IdentityPageClient() {
     setPending(true);
     setError(null);
     try {
-      const result = await authClient.signIn.social({ provider: 'apple' });
+      const result = await authClient.signIn.social({
+        provider: 'apple',
+        callbackURL: window.location.href,
+      });
       if (result.error) {
         setError('Apple sign in could not be started. Try again.');
         setPending(false);


### PR DESCRIPTION
## Summary
- preserve the complete signed `/identity` URL when starting Apple through Better Auth
- return users to the pending LogYourBody OAuth 2.1 + PKCE transaction after Apple authentication
- add a regression test covering every outer authorization parameter

## Root cause
`IdentityPageClient` called `authClient.signIn.social({ provider: "apple" })` without a `callbackURL`. Better Auth therefore completed Apple authentication without returning to the signed outer OAuth authorization request, leaving the iOS `ASWebAuthenticationSession` waiting forever for `logyourbody://oauth`.

## Validation
- regression proof: new test fails against the pre-fix source because `callbackURL` is absent
- `pnpm --filter web exec vitest run "app/(auth)/identity/IdentityPageClient.test.tsx"` (3 passed)
- `pnpm biome check --write` on both changed files
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit gitleaks, trufflehog, repository hygiene, Biome, ESLint, and scoped typecheck passed
- pre-push affected typecheck/lint/CI harness passed

## Bug-to-test
The regression test asserts that `response_type`, native `redirect_uri`, scopes, state, PKCE challenge/method, expiry, and signature all survive the Apple round-trip.

No Linear issue — ad-hoc production auth fix.