### PR TITLE
feat(marketing): add artist outcome and capture chapters

### DIFF
--- a/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.tsx
@@ -1,5 +1,4 @@
-'use client';
-
+import { ArrowRight, BellRing, Check } from 'lucide-react';
 import type {
   ArtistProfileCaptureVisualCopy,
   ArtistProfileLandingCopy,
@@ -15,22 +14,144 @@ interface ArtistProfileCaptureSectionProps {
     | ArtistProfileLandingCopy['capture'];
 }
 
+function isEditorialCapture(
+  capture: ArtistProfileCaptureSectionProps['capture']
+): capture is ArtistProfileLandingCopy['capture'] {
+  return 'journey' in capture && 'benefits' in capture;
+}
+
 export function ArtistProfileCaptureSection({
   id,
   capture,
 }: Readonly<ArtistProfileCaptureSectionProps>) {
+  if (!isEditorialCapture(capture)) {
+    return (
+      <ArtistProfileSectionShell className='bg-white/[0.012]' id={id}>
+        <div className='mx-auto max-w-280'>
+          <ArtistProfileSectionHeader
+            align='center'
+            headline={capture.headline}
+            body={capture.subhead}
+            className='max-w-[46rem]'
+            bodyClassName='mx-auto max-w-[34rem]'
+          />
+
+          <ArtistProfileCaptureVisual capture={capture} className='mt-10' />
+        </div>
+      </ArtistProfileSectionShell>
+    );
+  }
+
   return (
-    <ArtistProfileSectionShell className='bg-white/[0.012]' id={id}>
+    <ArtistProfileSectionShell className='bg-surface-0' id={id}>
       <div className='mx-auto max-w-280'>
         <ArtistProfileSectionHeader
-          align='center'
+          align='left'
           headline={capture.headline}
-          body={capture.subhead}
-          className='max-w-[46rem]'
-          bodyClassName='mx-auto max-w-[34rem]'
+          body={capture.body}
+          className='max-w-3xl'
+          bodyClassName='max-w-2xl'
         />
 
-        <ArtistProfileCaptureVisual capture={capture} className='mt-10' />
+        <div
+          className='mt-12 grid items-stretch gap-4 lg:grid-cols-[minmax(0,1fr)_3rem_minmax(0,1fr)] lg:gap-6'
+          data-testid='artist-profile-capture-demo'
+        >
+          <article
+            role='img'
+            aria-label={capture.journey.inputPreviewLabel}
+            className='flex min-h-64 flex-col justify-between rounded-2xl border border-subtle bg-surface-1 p-5 sm:p-6'
+          >
+            <div>
+              <p className='text-xs font-semibold text-secondary-token'>
+                {capture.journey.inputEyebrow}
+              </p>
+              <h3 className='mt-3 text-2xl font-semibold tracking-tight text-primary-token'>
+                {capture.action.title}
+              </h3>
+              <p className='mt-2 text-app leading-relaxed text-secondary-token'>
+                {capture.action.detail}
+              </p>
+            </div>
+
+            <div
+              aria-hidden='true'
+              className='mt-8 rounded-xl border border-subtle bg-surface-0 p-2'
+            >
+              <div className='flex items-center gap-2'>
+                <div className='min-w-0 flex-1 rounded-lg border border-subtle bg-surface-1 px-3 py-3 font-mono text-xs text-tertiary-token'>
+                  {capture.action.inputPlaceholder}
+                </div>
+                <span className='inline-flex min-h-11 shrink-0 items-center rounded-lg bg-primary-token px-4 text-xs font-semibold text-surface-1'>
+                  {capture.action.ctaLabel}
+                </span>
+              </div>
+              <p className='mt-3 flex items-center gap-2 px-1 pb-1 text-xs font-medium text-secondary-token'>
+                <Check
+                  className='h-3.5 w-3.5 text-success'
+                  aria-hidden='true'
+                />
+                {capture.action.confirmedLabel}
+              </p>
+            </div>
+          </article>
+
+          <div className='flex items-center justify-center' aria-hidden='true'>
+            <ArrowRight className='h-5 w-5 rotate-90 text-tertiary-token lg:rotate-0' />
+          </div>
+
+          <article className='flex min-h-64 flex-col justify-between rounded-2xl border border-subtle bg-surface-1 p-5 sm:p-6'>
+            <div>
+              <p className='text-xs font-semibold text-secondary-token'>
+                {capture.journey.notificationEyebrow}
+              </p>
+              <h3 className='mt-3 text-2xl font-semibold tracking-tight text-primary-token'>
+                {capture.journey.notificationHeadline}
+              </h3>
+              <p className='mt-2 text-app leading-relaxed text-secondary-token'>
+                {capture.journey.notificationBody}
+              </p>
+            </div>
+
+            <div className='mt-8 rounded-xl border border-subtle bg-surface-0 p-4'>
+              <div className='flex items-start gap-3'>
+                <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary-token text-surface-1'>
+                  <BellRing className='h-4 w-4' aria-hidden='true' />
+                </span>
+                <div className='min-w-0'>
+                  <div className='flex items-center gap-2 text-2xs text-tertiary-token'>
+                    <span className='font-semibold text-secondary-token'>
+                      {capture.notification.appName}
+                    </span>
+                    <span>{capture.notification.timeLabel}</span>
+                  </div>
+                  <p className='mt-2 text-sm font-semibold text-primary-token'>
+                    {capture.notification.title}
+                  </p>
+                  <p className='mt-1.5 text-xs leading-relaxed text-secondary-token'>
+                    {capture.notification.detail}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <ol className='mt-8 grid gap-3 md:grid-cols-3'>
+          {capture.benefits.map((benefit, index) => (
+            <li key={benefit.id} className='border-t border-subtle pt-4'>
+              <p className='font-mono text-3xs text-tertiary-token'>
+                0{index + 1}
+              </p>
+              <p className='mt-3 text-sm font-semibold text-primary-token'>
+                {benefit.label}
+              </p>
+              <p className='mt-2 text-app leading-relaxed text-secondary-token'>
+                {benefit.detail}
+              </p>
+            </li>
+          ))}
+        </ol>
       </div>
     </ArtistProfileSectionShell>
   );

--- a/apps/web/components/marketing/artist-profile/ArtistProfileHero.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileHero.tsx
@@ -10,23 +10,17 @@ export function ArtistProfileHero({ hero }: Readonly<ArtistProfileHeroProps>) {
   return (
     <section
       data-testid='homepage-hero'
-      className='homepage-hero homepage-hero--artist-profile relative overflow-hidden border-b border-white/[0.03] bg-black dark:bg-black'
+      className='homepage-hero homepage-hero--artist-profile relative overflow-hidden border-b border-subtle bg-black dark:bg-black'
       aria-labelledby='artist-profile-hero-heading'
     >
-      <div
-        aria-hidden='true'
-        className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.09),transparent_44%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_48%)]'
-      />
-      <div
-        aria-hidden='true'
-        className='pointer-events-none absolute inset-x-0 top-0 h-[28rem] bg-[radial-gradient(circle_at_50%_0%,rgba(83,131,255,0.14),transparent_52%)]'
-      />
-
       <MarketingContainer
         width='page'
-        className='relative !max-w-(--linear-content-max) !px-5 sm:!px-6 lg:!px-0'
+        className='relative !px-5 sm:!px-6 lg:!px-0'
       >
-        <div className='mx-auto flex max-w-3xl flex-col items-center pb-10 pt-[calc(var(--linear-header-height)+3rem)] text-center sm:pb-12 sm:pt-[calc(var(--linear-header-height)+3.5rem)] lg:pb-14 lg:pt-[calc(var(--linear-header-height)+4rem)]'>
+        <div className='mx-auto flex min-h-[72svh] max-w-3xl flex-col items-center justify-center pb-16 pt-[calc(var(--public-shell-header-offset)+4rem)] text-center sm:min-h-[76svh] sm:pb-20 lg:min-h-[80svh]'>
+          <p className='mb-6 text-xs font-medium tracking-wide text-secondary-token'>
+            {hero.eyebrow}
+          </p>
           <h1
             id='artist-profile-hero-heading'
             className='max-w-[11ch] text-[clamp(3.125rem,7.15vw,5.625rem)] font-[660] leading-[0.95] tracking-[-0.055em] text-primary-token'
@@ -39,6 +33,9 @@ export function ArtistProfileHero({ hero }: Readonly<ArtistProfileHeroProps>) {
           <div className='mt-7 flex justify-center'>
             <HomeHeroCTA />
           </div>
+          <p className='mt-5 font-mono text-xs tracking-tight text-tertiary-token'>
+            {hero.signature}
+          </p>
         </div>
       </MarketingContainer>
     </section>

--- a/apps/web/components/marketing/artist-profile/ArtistProfileHeroAdaptiveIntro.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileHeroAdaptiveIntro.tsx
@@ -1,122 +1,41 @@
-import { HomeTrustSection } from '@/components/features/home/HomeTrustSection';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
 import { ARTIST_PROFILE_SECTION_TEST_IDS } from '@/data/artistProfilePageOrder';
-import { MarketingContainer } from '../MarketingContainer';
 import { ArtistProfileHero } from './ArtistProfileHero';
 import { ArtistProfileModeSwitcher } from './ArtistProfileModeSwitcher';
+import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
 
 interface ArtistProfileHeroAdaptiveIntroProps {
   readonly hero: ArtistProfileLandingCopy['hero'];
   readonly adaptive: ArtistProfileLandingCopy['adaptive'];
-  readonly phoneCaption: string;
-  readonly phoneSubcaption: string;
+  /** Compatibility props are removed with the landing composition update. */
+  readonly phoneCaption?: string;
+  readonly phoneSubcaption?: string;
+  readonly showForgeUiMarketingUpdates?: boolean;
 }
 
 export function ArtistProfileHeroAdaptiveIntro({
   hero,
   adaptive,
-  phoneCaption,
-  phoneSubcaption,
 }: Readonly<ArtistProfileHeroAdaptiveIntroProps>) {
   return (
-    <div className='artist-profile-hero-adaptive-intro relative overflow-x-clip bg-black dark:bg-black'>
+    <div className='relative overflow-x-clip bg-black dark:bg-black'>
       <div data-testid={ARTIST_PROFILE_SECTION_TEST_IDS.hero}>
         <ArtistProfileHero hero={hero} />
       </div>
 
       <div
         data-testid={ARTIST_PROFILE_SECTION_TEST_IDS.adaptive}
-        className='relative bg-black dark:bg-black pb-[4.5rem] pt-2 sm:pb-10 sm:pt-4 lg:pb-12 lg:pt-6'
+        className='relative bg-black dark:bg-black'
       >
-        <MarketingContainer
-          width='page'
-          className='relative !max-w-(--linear-content-max) !px-5 sm:!px-6 lg:!px-0'
+        <ArtistProfileSectionShell
+          className='border-b border-subtle'
+          containerClassName='!px-5 sm:!px-6 lg:!px-0'
         >
-          <div className='artist-profile-intro-stage'>
-            <div className='artist-profile-intro-rail'>
-              <div data-testid='artist-profile-adaptive-sequence'>
-                <ArtistProfileModeSwitcher
-                  adaptive={adaptive}
-                  phoneCaption={phoneCaption}
-                  phoneSubcaption={phoneSubcaption}
-                />
-              </div>
-            </div>
+          <div data-testid='artist-profile-adaptive-sequence'>
+            <ArtistProfileModeSwitcher adaptive={adaptive} />
           </div>
-        </MarketingContainer>
+        </ArtistProfileSectionShell>
       </div>
-
-      <div
-        data-testid={ARTIST_PROFILE_SECTION_TEST_IDS.trust}
-        className='artist-profile-intro-trust relative z-30 lg:-mt-28 xl:-mt-32'
-      >
-        <HomeTrustSection label='Trusted By Artists' />
-      </div>
-
-      <style>{`
-        .artist-profile-intro-stage {
-          position: relative;
-        }
-
-        .artist-profile-intro-rail {
-          position: relative;
-        }
-
-        @media (min-width: 768px) and (min-height: 821px) {
-          .artist-profile-intro-stage {
-            min-height: calc(100svh + 2rem);
-          }
-
-          .artist-profile-intro-rail {
-            position: sticky;
-            top: clamp(
-              calc(var(--linear-header-height) + 1.5rem),
-              12svh,
-              calc(var(--linear-header-height) + 4rem)
-            );
-          }
-        }
-
-        @media (min-width: 1024px) and (min-height: 821px) {
-          .artist-profile-intro-stage {
-            min-height: calc(100svh + 4rem);
-          }
-
-          .artist-profile-intro-rail {
-            top: clamp(
-              calc(var(--linear-header-height) + 2rem),
-              14svh,
-              calc(var(--linear-header-height) + 6rem)
-            );
-          }
-        }
-
-        @media (min-width: 1024px) and (max-height: 820px) {
-          .artist-profile-hero-adaptive-intro {
-            --artist-profile-intro-scroll-reserve: 44rem;
-          }
-
-          .artist-profile-intro-stage::after {
-            /* A real flow child, rather than padding, extends sticky's
-             * containing block through the trust handoff. */
-            content: '';
-            display: block;
-            height: var(--artist-profile-intro-scroll-reserve);
-          }
-
-          .artist-profile-intro-rail {
-            position: sticky;
-            top: 1rem;
-          }
-
-          .artist-profile-intro-trust {
-            /* The rail's reserve keeps its pinned phone behind the trust
-             * handoff; the matching negative margin keeps downstream
-             * sections in their stable document positions. */
-            margin-top: calc(-3rem - var(--artist-profile-intro-scroll-reserve));
-          }
-        }
-      `}</style>
     </div>
   );
 }

--- a/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx
@@ -1,0 +1,93 @@
+import { ArrowRight, MapPin, Music2, QrCode } from 'lucide-react';
+import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
+import { cn } from '@/lib/utils';
+import { SHELL_H2_CLASS, SHELL_LEAD_CLASS } from './ArtistProfileSectionHeader';
+import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
+
+interface ArtistProfileOpinionatedSectionProps {
+  readonly opinionated: ArtistProfileLandingCopy['opinionated'];
+}
+
+const DECISION_ICONS = {
+  release: Music2,
+  tour: MapPin,
+  support: QrCode,
+} as const;
+
+export function ArtistProfileOpinionatedSection({
+  opinionated,
+}: Readonly<ArtistProfileOpinionatedSectionProps>) {
+  return (
+    <ArtistProfileSectionShell>
+      <div className='grid items-start gap-12 lg:grid-cols-[minmax(0,0.8fr)_minmax(30rem,1.2fr)] lg:gap-20'>
+        <div className='max-w-xl lg:sticky lg:top-32'>
+          <p className='text-xs font-medium tracking-wide text-secondary-token'>
+            {opinionated.eyebrow}
+          </p>
+          <h2 className={cn(SHELL_H2_CLASS, 'mt-5 max-w-[12ch]')}>
+            {opinionated.headline}
+          </h2>
+          <p className={cn(SHELL_LEAD_CLASS, 'mt-6')}>{opinionated.body}</p>
+          <p className='mt-7 inline-flex rounded-full border border-subtle bg-surface-0 px-4 py-2 font-mono text-xs text-secondary-token'>
+            {opinionated.principle}
+          </p>
+        </div>
+
+        <div className='overflow-hidden rounded-2xl border border-subtle bg-surface-0'>
+          <div
+            aria-hidden='true'
+            className='hidden grid-cols-[1fr_1fr_auto] gap-6 border-b border-subtle px-5 py-4 text-3xs font-semibold text-tertiary-token sm:grid'
+          >
+            {opinionated.columns.map(column => (
+              <span key={column}>{column}</span>
+            ))}
+          </div>
+
+          <div className='divide-y divide-subtle'>
+            {opinionated.decisions.map(decision => {
+              const Icon = DECISION_ICONS[decision.id];
+
+              return (
+                <article key={decision.id} className='px-5 py-6'>
+                  <dl className='grid gap-5 sm:grid-cols-[1fr_1fr_auto] sm:items-center sm:gap-6'>
+                    <div>
+                      <dt className='sr-only'>{opinionated.columns[0]}</dt>
+                      <dd className='flex items-center gap-3'>
+                        <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-1 text-secondary-token'>
+                          <Icon className='h-4 w-4' aria-hidden='true' />
+                        </span>
+                        <span className='text-sm font-semibold text-primary-token'>
+                          {decision.context}
+                        </span>
+                      </dd>
+                    </div>
+
+                    <div>
+                      <dt className='sr-only'>{opinionated.columns[1]}</dt>
+                      <dd className='text-app text-secondary-token'>
+                        {decision.signal}
+                      </dd>
+                    </div>
+
+                    <div>
+                      <dt className='sr-only'>{opinionated.columns[2]}</dt>
+                      <dd className='flex items-center gap-3 sm:justify-end'>
+                        <ArrowRight
+                          className='h-4 w-4 text-tertiary-token'
+                          aria-hidden='true'
+                        />
+                        <span className='font-mono text-xs font-semibold text-primary-token'>
+                          {decision.action}
+                        </span>
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </ArtistProfileSectionShell>
+  );
+}

--- a/apps/web/components/marketing/artist-profile/ArtistProfileOutcomesCarousel.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOutcomesCarousel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Check, ChevronLeft, ChevronRight, Mail } from 'lucide-react';
 import Image from 'next/image';
 import type { CSSProperties } from 'react';
 import { useId, useRef } from 'react';
@@ -11,7 +11,7 @@ import {
   HOMEPAGE_PROFILE_PREVIEW_TOUR_DATES,
 } from '@/features/home/homepage-profile-preview-fixture';
 import { ProfilePrimaryActionCard } from '@/features/profile/ProfilePrimaryActionCard';
-import { getAccentCssVars } from '@/lib/ui/accent-palette';
+import { useReducedMotion } from '@/lib/hooks/useReducedMotion';
 import { cn } from '@/lib/utils';
 import { ArtistProfileSectionHeader } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
@@ -20,13 +20,19 @@ interface ArtistProfileOutcomesCarouselProps {
   readonly outcomes: ArtistProfileLandingCopy['outcomes'];
 }
 
-type OutcomeId = ArtistProfileLandingCopy['outcomes']['cards'][number]['id'];
+type OutcomeId =
+  ArtistProfileLandingCopy['outcomes']['landingCards'][number]['id'];
 
-const OUTCOME_CARD_ACCENTS: Record<OutcomeId, string> = {
-  'drive-streams': getAccentCssVars('blue').solid,
-  'sell-out': getAccentCssVars('purple').solid,
-  'get-paid': getAccentCssVars('green').solid,
-  'share-anywhere': getAccentCssVars('orange').solid,
+type QrPreviewStyle = CSSProperties & {
+  readonly '--qr-preview-ink': string;
+  readonly '--qr-preview-paper': string;
+};
+
+// QR ink and paper are protocol colors, not theme colors. Keeping them local
+// prevents dark mode from reducing the code's contrast or changing its meaning.
+const QR_PREVIEW_STYLE: QrPreviewStyle = {
+  '--qr-preview-ink': '#000',
+  '--qr-preview-paper': '#fff',
 };
 
 // Per-card widths. Horizontal rail lets each outcome take the room its
@@ -34,14 +40,11 @@ const OUTCOME_CARD_ACCENTS: Record<OutcomeId, string> = {
 // proofs, so they get wider slots; Share anywhere is a single QR card
 // and can stay narrow.
 const OUTCOME_CARD_WIDTHS: Record<OutcomeId, string> = {
-  'drive-streams': 'w-full sm:w-[34rem] lg:w-[38rem]',
-  'sell-out': 'w-full sm:w-[36rem] lg:w-[40rem]',
-  'get-paid': 'w-full sm:w-[30rem] lg:w-[32rem]',
-  'share-anywhere': 'w-full sm:w-[24rem] lg:w-[26rem]',
-};
-
-type OutcomeAccentStyle = CSSProperties & {
-  readonly '--outcome-accent': string;
+  'straight-to-listen': 'w-full sm:w-[34rem] lg:w-[38rem]',
+  'local-dates-first': 'w-full sm:w-[36rem] lg:w-[40rem]',
+  'support-without-friction': 'w-full sm:w-[30rem] lg:w-[32rem]',
+  'capture-the-fan': 'w-full sm:w-[27rem] lg:w-[29rem]',
+  'one-link-everywhere': 'w-full sm:w-[24rem] lg:w-[26rem]',
 };
 
 const SHOWCASE_VIEWER_LOCATION = {
@@ -54,6 +57,7 @@ export function ArtistProfileOutcomesCarousel({
 }: Readonly<ArtistProfileOutcomesCarouselProps>) {
   const railId = useId();
   const scrollerRef = useRef<HTMLElement | null>(null);
+  const reducedMotion = useReducedMotion();
 
   const scrollByDirection = (direction: 'prev' | 'next') => {
     const rail = scrollerRef.current;
@@ -64,7 +68,10 @@ export function ArtistProfileOutcomesCarousel({
     const scrollStep = Math.max(rail.clientWidth * 0.8, 240);
     const nextLeft = direction === 'next' ? scrollStep : -scrollStep;
 
-    rail.scrollBy({ left: nextLeft, behavior: 'smooth' });
+    rail.scrollBy({
+      left: nextLeft,
+      behavior: reducedMotion ? 'auto' : 'smooth',
+    });
   };
 
   return (
@@ -74,7 +81,7 @@ export function ArtistProfileOutcomesCarousel({
       width='page'
     >
       <div>
-        <div className='mx-auto max-w-(--linear-content-max) px-5 sm:px-6 lg:px-0'>
+        <div className='mx-auto max-w-public-content px-5 sm:px-6 lg:px-0'>
           <ArtistProfileSectionHeader
             align='left'
             headline={outcomes.headline}
@@ -91,11 +98,12 @@ export function ArtistProfileOutcomesCarousel({
         />
 
         <p id='artist-profile-outcomes-instructions' className='sr-only'>
-          Use the previous and next controls to browse the outcome cards.
+          Browse the five outcome cards. Previous and next controls are
+          available when the cards form a horizontal rail.
         </p>
 
         <div className='relative mt-10 w-full overflow-x-hidden'>
-          <div className='pointer-events-none absolute right-[max(1.25rem,calc((100vw-var(--linear-content-max))/2))] top-4 z-20 hidden items-center gap-2 lg:flex'>
+          <div className='pointer-events-none absolute right-[max(1.25rem,calc((100vw-var(--public-content-max-page))/2))] top-4 z-20 hidden items-center gap-2 lg:flex'>
             <button
               type='button'
               aria-controls={railId}
@@ -103,7 +111,7 @@ export function ArtistProfileOutcomesCarousel({
               onClick={() => {
                 scrollByDirection('prev');
               }}
-              className='pointer-events-auto rounded-full border border-white/10 bg-black/62 p-2.5 text-white dark:text-white shadow-[0_18px_44px_rgba(0,0,0,0.28)] backdrop-blur-xl transition-colors hover:bg-white dark:hover:bg-surface-1 hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
+              className='pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-black/62 text-white dark:text-white shadow-[0_18px_44px_rgba(0,0,0,0.28)] backdrop-blur-xl transition-colors hover:bg-white dark:hover:bg-surface-1 hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
             >
               <ChevronLeft className='h-4 w-4' aria-hidden='true' />
             </button>
@@ -114,35 +122,37 @@ export function ArtistProfileOutcomesCarousel({
               onClick={() => {
                 scrollByDirection('next');
               }}
-              className='pointer-events-auto rounded-full border border-white/10 bg-black/62 p-2.5 text-white dark:text-white shadow-[0_18px_44px_rgba(0,0,0,0.28)] backdrop-blur-xl transition-colors hover:bg-white dark:hover:bg-surface-1 hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
+              className='pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-black/62 text-white dark:text-white shadow-[0_18px_44px_rgba(0,0,0,0.28)] backdrop-blur-xl transition-colors hover:bg-white dark:hover:bg-surface-1 hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
             >
               <ChevronRight className='h-4 w-4' aria-hidden='true' />
             </button>
           </div>
 
-          <div className='sr-only focus-within:not-sr-only focus-within:absolute focus-within:left-5 focus-within:top-4 focus-within:z-20 focus-within:flex focus-within:gap-2 sm:focus-within:left-6 lg:hidden'>
-            <button
-              type='button'
-              aria-controls={railId}
-              aria-label='Scroll Outcomes Left'
-              onClick={() => {
-                scrollByDirection('prev');
-              }}
-              className='rounded-full border border-black/12 bg-(--color-cell-hover) px-3 py-2 text-xs font-semibold text-black dark:text-white shadow-[0_18px_42px_rgba(0,0,0,0.16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/15'
-            >
-              Prev
-            </button>
-            <button
-              type='button'
-              aria-controls={railId}
-              aria-label='Scroll Outcomes Right'
-              onClick={() => {
-                scrollByDirection('next');
-              }}
-              className='rounded-full border border-black/12 bg-(--color-cell-hover) px-3 py-2 text-xs font-semibold text-black dark:text-white shadow-[0_18px_42px_rgba(0,0,0,0.16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/15'
-            >
-              Next
-            </button>
+          <div className='hidden sm:block lg:hidden'>
+            <div className='sr-only focus-within:not-sr-only focus-within:absolute focus-within:left-6 focus-within:top-4 focus-within:z-20 focus-within:flex focus-within:gap-2'>
+              <button
+                type='button'
+                aria-controls={railId}
+                aria-label='Scroll Outcomes Left'
+                onClick={() => {
+                  scrollByDirection('prev');
+                }}
+                className='min-h-11 min-w-11 rounded-full border border-black/12 bg-(--color-cell-hover) px-3 py-2 text-xs font-semibold text-black dark:text-white shadow-[0_18px_42px_rgba(0,0,0,0.16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/15'
+              >
+                Prev
+              </button>
+              <button
+                type='button'
+                aria-controls={railId}
+                aria-label='Scroll Outcomes Right'
+                onClick={() => {
+                  scrollByDirection('next');
+                }}
+                className='min-h-11 min-w-11 rounded-full border border-black/12 bg-(--color-cell-hover) px-3 py-2 text-xs font-semibold text-black dark:text-white shadow-[0_18px_42px_rgba(0,0,0,0.16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/15'
+              >
+                Next
+              </button>
+            </div>
           </div>
 
           <section
@@ -151,9 +161,12 @@ export function ArtistProfileOutcomesCarousel({
             data-testid='artist-profile-outcomes-grid'
             aria-label='Outcome Showcase'
             aria-describedby='artist-profile-outcomes-instructions'
-            className='relative grid grid-cols-1 gap-3 overflow-visible pb-3 pl-5 pr-5 sm:flex sm:gap-3.5 sm:overflow-x-auto sm:overflow-y-hidden sm:overscroll-x-contain sm:scroll-smooth sm:snap-x sm:snap-mandatory sm:pl-6 sm:pr-[12vw] sm:scroll-pl-6 lg:pl-[max(1.5rem,calc((100vw-var(--linear-content-max))/2))] lg:pr-[14vw] lg:scroll-pl-[max(1.5rem,calc((100vw-var(--linear-content-max))/2))] [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
+            className={cn(
+              'relative grid grid-cols-1 gap-3 overflow-visible pb-3 pl-5 pr-5 sm:flex sm:gap-3.5 sm:overflow-x-auto sm:overflow-y-hidden sm:overscroll-x-contain sm:snap-x sm:snap-mandatory sm:pl-6 sm:pr-[12vw] sm:scroll-pl-6 lg:pl-[max(1.5rem,calc((100vw-var(--public-content-max-page))/2))] lg:pr-[14vw] lg:scroll-pl-[max(1.5rem,calc((100vw-var(--public-content-max-page))/2))] [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+              !reducedMotion && 'sm:scroll-smooth'
+            )}
           >
-            {outcomes.cards.map(card => (
+            {outcomes.landingCards.map(card => (
               <OutcomeCard key={card.id} card={card} outcomes={outcomes} />
             ))}
           </section>
@@ -167,48 +180,41 @@ function OutcomeCard({
   card,
   outcomes,
 }: Readonly<{
-  card: ArtistProfileLandingCopy['outcomes']['cards'][number];
+  card: ArtistProfileLandingCopy['outcomes']['landingCards'][number];
   outcomes: ArtistProfileLandingCopy['outcomes'];
 }>) {
-  const style: OutcomeAccentStyle = {
-    '--outcome-accent': OUTCOME_CARD_ACCENTS[card.id],
-  };
-
   const proof = outcomes.syntheticProofs;
 
   return (
     <article
       data-testid='artist-profile-outcome-card'
       className={cn(
-        'group relative flex shrink-0 snap-start flex-col overflow-hidden rounded-[1.5rem] border border-white/8 bg-(--color-bg-base) shadow-[0_22px_56px_rgba(0,0,0,0.28)]',
+        'group relative flex shrink-0 snap-start flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-lg',
         OUTCOME_CARD_WIDTHS[card.id]
       )}
-      style={style}
     >
-      <div
-        className='absolute inset-0 opacity-90'
-        style={{
-          background:
-            'radial-gradient(circle at 80% 78%, color-mix(in srgb, var(--outcome-accent) 18%, transparent), transparent 36%), linear-gradient(145deg, rgba(255,255,255,0.055), rgba(255,255,255,0.015) 44%, rgba(0,0,0,0.42))',
-        }}
-        aria-hidden='true'
-      />
       <div className='relative flex h-full flex-col p-4 sm:p-5'>
         <div className='max-w-[18rem]'>
-          <h3 className='max-w-[10ch] text-[clamp(1.85rem,3.4vw,3rem)] font-semibold leading-[0.92] tracking-[-0.065em] text-primary-token'>
+          <h3 className='max-w-[12ch] text-2xl font-semibold leading-tight tracking-tight text-primary-token sm:text-3xl'>
             {card.title}
           </h3>
+          <p className='mt-3 max-w-[38ch] text-app leading-relaxed text-secondary-token'>
+            {card.description}
+          </p>
         </div>
 
-        <div className='mt-4'>
-          {card.id === 'drive-streams' ? <DriveStreamsProof /> : null}
-          {card.id === 'sell-out' ? (
+        <div className='mt-6'>
+          {card.id === 'straight-to-listen' ? <DriveStreamsProof /> : null}
+          {card.id === 'local-dates-first' ? (
             <SellOutProof proof={proof.visualProofs.sellOut} />
           ) : null}
-          {card.id === 'get-paid' ? (
+          {card.id === 'support-without-friction' ? (
             <GetPaidProof proof={proof.visualProofs.getPaid} />
           ) : null}
-          {card.id === 'share-anywhere' ? (
+          {card.id === 'capture-the-fan' ? (
+            <CaptureFanProof proof={proof.captureFan} />
+          ) : null}
+          {card.id === 'one-link-everywhere' ? (
             <ShareProof proof={proof.shareAnywhere} />
           ) : null}
         </div>
@@ -385,6 +391,48 @@ function GetPaidProof({
   );
 }
 
+function CaptureFanProof({
+  proof,
+}: Readonly<{
+  proof: ArtistProfileLandingCopy['outcomes']['syntheticProofs']['captureFan'];
+}>) {
+  return (
+    <div className='rounded-xl border border-subtle bg-surface-1 p-4 sm:p-5'>
+      <div className='flex items-center gap-3'>
+        <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-2 text-primary-token'>
+          <Mail className='h-4 w-4' aria-hidden='true' />
+        </span>
+        <div>
+          <p className='text-xs font-semibold text-primary-token'>
+            {proof.inputLabel}
+          </p>
+          <p className='mt-1 font-mono text-xs text-tertiary-token'>
+            {proof.inputValue}
+          </p>
+        </div>
+      </div>
+
+      <div className='mt-4 flex items-center justify-between gap-3 rounded-lg border border-subtle bg-surface-0 px-3 py-2.5'>
+        <span className='text-xs font-medium text-secondary-token'>
+          {proof.ctaLabel}
+        </span>
+        <span className='inline-flex items-center gap-1.5 rounded-full bg-primary-token px-3 py-1.5 text-3xs font-semibold text-surface-1'>
+          <Check className='h-3 w-3' aria-hidden='true' />
+          {proof.confirmedLabel}
+        </span>
+      </div>
+
+      <p className='mt-4 flex items-center gap-2 text-xs font-medium text-secondary-token'>
+        <span
+          aria-hidden='true'
+          className='h-1.5 w-1.5 rounded-full bg-success'
+        />
+        {proof.followUpLabel}
+      </p>
+    </div>
+  );
+}
+
 function ShareProof({
   proof,
 }: Readonly<{
@@ -397,15 +445,20 @@ function ShareProof({
           {proof.title}
         </p>
 
-        <div className='mt-3.5 flex h-39 w-39 items-center justify-center rounded-xl bg-white dark:bg-surface-1 shadow-[inset_0_0_0_1px_rgba(17,17,17,0.06)]'>
+        <div
+          className='mt-3.5 flex h-39 w-39 items-center justify-center rounded-xl bg-(--qr-preview-paper) shadow-[inset_0_0_0_1px_rgba(17,17,17,0.06)]'
+          style={QR_PREVIEW_STYLE}
+        >
           <div className='grid grid-cols-7 gap-2'>
             {QR_CELLS.map(cell => (
               <span
                 key={cell.id}
-                className='h-2.5 w-2.5 rounded-xs'
-                style={{
-                  backgroundColor: cell.filled ? '#0b0b0b' : '#f2f0ea',
-                }}
+                className={cn(
+                  'h-2.5 w-2.5 rounded-xs',
+                  cell.filled
+                    ? 'bg-(--qr-preview-ink)'
+                    : 'bg-(--qr-preview-paper)'
+                )}
               />
             ))}
           </div>

--- a/apps/web/components/marketing/artist-profile/ArtistProfileSectionShell.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileSectionShell.tsx
@@ -27,10 +27,8 @@ export function ArtistProfileSectionShell({
       ref={sectionRef}
       id={id}
       className={cn(
-        // Inside .frame-skin, padding + hairline divider come from the
-        // .frame-section utility (declared in home.css). Outside frame-skin
-        // we keep the previous SaaS-rhythm padding so other surfaces are
-        // unaffected by this redesign.
+        // Shared rhythm keeps every landing-page chapter on the same vertical
+        // cadence while each section controls only its own surface treatment.
         'frame-section relative py-20 sm:py-24 lg:py-28',
         className
       )}

--- a/apps/web/components/marketing/artist-profile/ShellCtaButton.tsx
+++ b/apps/web/components/marketing/artist-profile/ShellCtaButton.tsx
@@ -24,12 +24,12 @@ const SHAPE: Record<Size, string> = {
 
 const TONE: Record<`${Tone}-${Context}`, string> = {
   'primary-on-dark':
-    'bg-white text-black dark:text-white hover:bg-white/90 shadow-[0_1px_0_rgba(255,255,255,0.06)_inset]',
+    'bg-white text-black dark:text-black hover:bg-white/90 shadow-[0_1px_0_rgba(255,255,255,0.06)_inset]',
   'primary-auto': 'bg-primary-token text-surface-1 hover:bg-primary-token/90',
   'secondary-on-dark':
     'bg-white/[0.04] text-white dark:text-white border border-white/12 hover:bg-white/[0.08]',
   'secondary-auto':
-    'bg-transparent text-primary-token border border-(--linear-app-shell-border) hover:bg-surface-2/80',
+    'bg-transparent text-primary-token border border-subtle hover:bg-surface-2/80',
 };
 
 const RING_OFFSET: Record<Context, string> = {
@@ -49,7 +49,7 @@ export function shellCtaClassName({
   return cn(
     'inline-flex shrink-0 items-center justify-center rounded-full font-semibold tracking-[-0.011em]',
     'transition-[background-color,border-color,box-shadow,opacity] duration-subtle ease-subtle',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus) focus-visible:ring-offset-2',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2',
     RING_OFFSET[context],
     SHAPE[size],
     TONE[`${tone}-${context}`]

--- a/apps/web/tests/e2e/artist-profiles.spec.ts
+++ b/apps/web/tests/e2e/artist-profiles.spec.ts
@@ -32,30 +32,18 @@ async function getViewportHeight(page: import('@playwright/test').Page) {
   return viewport?.height ?? 0;
 }
 
-async function getDocumentY(
+async function expectFullyInViewport(
+  page: import('@playwright/test').Page,
   locator: import('@playwright/test').Locator
-): Promise<number> {
-  return locator.evaluate(
-    el => window.scrollY + el.getBoundingClientRect().top
+) {
+  const box = await locator.boundingBox();
+  const viewportHeight = await getViewportHeight(page);
+
+  expect(box).not.toBeNull();
+  expect(box?.y ?? -1).toBeGreaterThanOrEqual(0);
+  expect((box?.y ?? 0) + (box?.height ?? 0)).toBeLessThanOrEqual(
+    viewportHeight
   );
-}
-
-async function scrollToY(page: import('@playwright/test').Page, top: number) {
-  await page.evaluate(nextTop => {
-    window.scrollTo({ top: nextTop, behavior: 'instant' });
-  }, top);
-  await page.waitForTimeout(180);
-}
-
-async function getClientRect(locator: import('@playwright/test').Locator) {
-  return locator.evaluate(el => {
-    const rect = el.getBoundingClientRect();
-    return {
-      top: rect.top,
-      bottom: rect.bottom,
-      height: rect.height,
-    };
-  });
 }
 
 const MODE_TRANSITION_SETTLE_MS = 400;
@@ -102,36 +90,6 @@ function expectStableGeometry(
       `${surface} ${key} shifted`
     ).toBeLessThanOrEqual(GEOMETRY_TOLERANCE_PX);
   }
-}
-
-async function expectFullyInViewport(
-  page: import('@playwright/test').Page,
-  locator: import('@playwright/test').Locator
-) {
-  const box = await locator.boundingBox();
-  const viewportHeight = await getViewportHeight(page);
-
-  expect(box).not.toBeNull();
-  expect(box?.y ?? -1).toBeGreaterThanOrEqual(0);
-  expect((box?.y ?? 0) + (box?.height ?? 0)).toBeLessThanOrEqual(
-    viewportHeight
-  );
-}
-
-async function expectNotPartiallyVisible(
-  page: import('@playwright/test').Page,
-  locator: import('@playwright/test').Locator
-) {
-  const box = await locator.boundingBox();
-  if (!box) {
-    return;
-  }
-
-  const viewportHeight = await getViewportHeight(page);
-  const intersectsViewport = box.y < viewportHeight && box.y + box.height > 0;
-  const fullyVisible = box.y >= 0 && box.y + box.height <= viewportHeight;
-
-  expect(intersectsViewport && !fullyVisible).toBe(false);
 }
 
 test.describe('Artist Profiles Landing', () => {
@@ -185,114 +143,66 @@ test.describe('Artist Profiles Landing', () => {
     await expectFullyInViewport(page, page.getByTestId('homepage-claim-form'));
   });
 
-  test('top story stays legible through the desktop hero-to-adaptive handoff', async ({
+  test('adaptive profile exposes four moment-based modes without layout shift', async ({
     page,
   }) => {
-    const heroHeading = page.getByRole('heading', {
-      name: /the link your music deserves\./i,
-    });
-    const claimForm = page.getByTestId('homepage-claim-form');
-    const adaptiveHeading = page.getByRole('heading', { name: 'One profile.' });
-    const adaptiveSubcaption = page.getByText('Adapts to every fan.');
     const adaptiveSection = page.getByTestId('artist-profile-section-adaptive');
-    const trust = page.getByTestId('homepage-trust');
-    const adaptivePhone = adaptiveSection.getByRole('img').first();
-    const phone = page.getByAltText(
-      "Jovie artist profile showing Tim White's live profile view."
+    await adaptiveSection.scrollIntoViewIfNeeded();
+
+    await expect(
+      adaptiveSection.getByRole('heading', {
+        name: 'One profile that adapts to every fan.',
+      })
+    ).toBeVisible();
+    await expect(adaptiveSection.getByRole('tab')).toHaveCount(4);
+
+    const initialHeight = await adaptiveSection.evaluate(
+      element => element.getBoundingClientRect().height
     );
+    const modes = [
+      {
+        label: 'Upcoming Release',
+        headline: 'Before a drop, your profile becomes a countdown.',
+        screenshotAlt:
+          'Jovie artist profile showing an upcoming release and pre-save state.',
+      },
+      {
+        label: 'Release Day',
+        headline:
+          'When the song is live, fans go straight to the right service.',
+        screenshotAlt:
+          'Jovie artist profile showing a release-day listen view.',
+      },
+      {
+        label: 'Touring',
+        headline: "When you're on the road, nearby dates come first.",
+        screenshotAlt:
+          'Jovie artist profile showing nearby shows and ticket paths.',
+      },
+      {
+        label: 'Live Support',
+        headline: 'At the merch table, one scan becomes support and capture.',
+        screenshotAlt: 'Jovie artist profile showing direct support options.',
+      },
+    ] as const;
 
-    await expect(heroHeading).toBeVisible();
-    await expect(claimForm).toBeVisible();
-    await expectFullyInViewport(page, claimForm);
-    await expect(phone).toBeVisible();
+    for (const mode of modes) {
+      const tab = adaptiveSection.getByRole('tab', { name: mode.label });
+      await expect(tab).toBeVisible();
+      await tab.click();
+      await expect(tab).toHaveAttribute('aria-selected', 'true');
+      await expect(
+        adaptiveSection.getByText(mode.headline, { exact: true })
+      ).toBeVisible();
+      await expect(
+        adaptiveSection.getByAltText(mode.screenshotAlt)
+      ).toBeVisible();
 
-    const adaptiveTop = await getDocumentY(adaptiveSection);
-    await scrollToY(page, Math.max(0, adaptiveTop - 20));
-
-    await expect(adaptiveHeading).toBeVisible();
-    await expect(adaptiveSubcaption).toBeVisible();
-    await expect(
-      page.getByRole('tab', { name: 'Upcoming Release' })
-    ).toBeVisible();
-    await expect(
-      page.getByText('Before a drop, your profile becomes a countdown.')
-    ).toBeVisible();
-    await expectFullyInViewport(page, adaptivePhone);
-
-    const trustRect = await getClientRect(trust);
-    const viewportHeight = await getViewportHeight(page);
-    expect(trustRect.top).toBeGreaterThanOrEqual(viewportHeight);
-
-    const supportTab = page.getByRole('tab', { name: 'Live Support' });
-    await expect(supportTab).toBeVisible();
-    await supportTab.click();
-    await expect(
-      page.getByText(
-        'At the merch table, one scan becomes support and capture.'
-      )
-    ).toBeVisible();
-    await expect(
-      page.getByAltText('Jovie artist profile showing direct support options.')
-    ).toBeVisible();
-
-    const trustTop = await getDocumentY(trust);
-    await scrollToY(page, Math.max(0, trustTop - 220));
-    await expect(trust).toBeVisible();
-
-    const trustBoxDuringOverlay = await trust.boundingBox();
-    const adaptivePhoneBoxDuringOverlay = await adaptivePhone.boundingBox();
-    expect(trustBoxDuringOverlay).not.toBeNull();
-    expect(adaptivePhoneBoxDuringOverlay).not.toBeNull();
-    expect(trustBoxDuringOverlay?.y ?? Number.POSITIVE_INFINITY).toBeLessThan(
-      (adaptivePhoneBoxDuringOverlay?.y ?? 0) +
-        (adaptivePhoneBoxDuringOverlay?.height ?? 0)
-    );
-
-    await scrollToY(page, Math.max(0, trustTop - 40));
-    await expect(trust).toBeVisible();
-    await expectNotPartiallyVisible(page, adaptivePhone);
-  });
-
-  test('top story stays legible on mobile without a clipped adaptive phone state', async ({
-    page,
-  }) => {
-    await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto('/artist-profiles', { waitUntil: 'domcontentloaded' });
-    await waitForHydration(page);
-
-    const heroHeading = page.getByRole('heading', {
-      name: /the link your music deserves\./i,
-    });
-    const adaptiveHeading = page.getByRole('heading', { name: 'One profile.' });
-    const adaptiveSection = page.getByTestId('artist-profile-section-adaptive');
-    const trust = page.getByTestId('homepage-trust');
-    const phone = page.getByAltText(
-      "Jovie artist profile showing Tim White's live profile view."
-    );
-
-    await expect(heroHeading).toBeVisible();
-    await expect(page.getByTestId('homepage-claim-form')).toBeVisible();
-    await expectFullyInViewport(page, page.getByTestId('homepage-claim-form'));
-    await expect(phone).toBeVisible();
-
-    const adaptiveTop = await getDocumentY(adaptiveSection);
-    await scrollToY(page, Math.max(0, adaptiveTop - 36));
-
-    await expect(adaptiveHeading).toBeVisible();
-    await expect(page.getByText('Adapts to every fan.')).toBeVisible();
-    await expect(
-      page.getByRole('tab', { name: 'Upcoming Release' })
-    ).toBeVisible();
-    await expectFullyInViewport(page, phone);
-
-    const trustRect = await getClientRect(trust);
-    const viewportHeight = await getViewportHeight(page);
-    expect(trustRect.top).toBeGreaterThanOrEqual(viewportHeight);
-
-    const trustTop = await getDocumentY(trust);
-    await scrollToY(page, Math.max(0, trustTop - 80));
-    await expect(trust).toBeVisible();
-    await expectNotPartiallyVisible(page, phone);
+      const selectedHeight = await adaptiveSection.evaluate(
+        element => element.getBoundingClientRect().height
+      );
+      expect(Math.abs(selectedHeight - initialHeight)).toBeLessThanOrEqual(1);
+    }
   });
 
   test('adaptive mode changes preserve desktop and mobile geometry', async ({
@@ -379,12 +289,11 @@ test.describe('Artist Profiles Landing', () => {
     }
   });
 
-  test('outcomes section comes right after the trust strip and keeps a stable grid across breakpoints', async ({
+  test('five fan outcomes keep a stable rail across breakpoints', async ({
     page,
   }) => {
     await expectNoHorizontalOverflow(page);
 
-    const trust = page.getByTestId('artist-profile-section-trust');
     const outcomesSection = page.getByTestId('artist-profile-section-outcomes');
     const captureSection = page.getByTestId('artist-profile-section-capture');
     const grid = page.getByTestId('artist-profile-outcomes-grid');
@@ -394,21 +303,21 @@ test.describe('Artist Profiles Landing', () => {
     await expect(grid).toBeVisible();
     await expect(scroller).toBeHidden();
     await expect(
-      outcomesSection.getByRole('heading', { name: /drive streams/i })
-    ).toBeVisible();
-    await expect(
-      outcomesSection.getByRole('heading', { name: /sell out/i })
-    ).toBeVisible();
-    await expect(
-      outcomesSection
-        .getByTestId('artist-profile-drive-streams-live-card')
-        .getByText('Tim White')
-    ).toBeVisible();
-    await expect(
-      outcomesSection
-        .getByTestId('artist-profile-drive-streams-live-card')
-        .getByText('w/ Cosmic Gate')
-    ).toBeVisible();
+      outcomesSection.getByTestId('artist-profile-outcome-card')
+    ).toHaveCount(5);
+    for (const title of [
+      'Straight to listen',
+      'Local dates first',
+      'Support without friction',
+      'Capture the fan',
+      'Keep one link everywhere',
+    ]) {
+      await expect(
+        outcomesSection.getByRole('heading', { name: title })
+      ).toBeVisible();
+    }
+    await expect(outcomesSection.getByText('Tim White')).toHaveCount(2);
+    await expect(outcomesSection.getByText('w/ Cosmic Gate')).toHaveCount(2);
     await expect(
       outcomesSection.getByTestId('artist-profile-drive-streams-live-card')
     ).toBeVisible();
@@ -419,10 +328,12 @@ test.describe('Artist Profiles Landing', () => {
       outcomesSection.getByTestId('artist-profile-sell-out-tour-card')
     ).toBeVisible();
     await expect(page.getByText('Wired to my latest release')).toHaveCount(0);
-    const trustTop = await getDocumentY(trust);
-    const outcomesTop = await getDocumentY(outcomesSection);
-    const captureTop = await getDocumentY(captureSection);
-    expect(outcomesTop).toBeGreaterThan(trustTop);
+    const outcomesTop = await outcomesSection.evaluate(
+      element => element.getBoundingClientRect().top + window.scrollY
+    );
+    const captureTop = await captureSection.evaluate(
+      element => element.getBoundingClientRect().top + window.scrollY
+    );
     expect(captureTop).toBeGreaterThan(outcomesTop);
 
     const startScrollY = await page.evaluate(() => window.scrollY);
@@ -447,8 +358,8 @@ test.describe('Artist Profiles Landing', () => {
     await expect(mobileGrid).toBeVisible();
     await expect(mobileScroller).toBeHidden();
     await expect(
-      page.getByRole('heading', { name: /drive streams/i })
-    ).toBeVisible();
+      mobileOutcomesSection.getByTestId('artist-profile-outcome-card')
+    ).toHaveCount(5);
 
     await expectNoHorizontalOverflow(page);
   });

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 2200
+  "count": 2185
 }


### PR DESCRIPTION
## Summary

- replace the generic hero with the one-link artist-profile promise and adaptive proof handoff
- add the five-outcome rail, fan-capture causal story, and “Opinionated by Design” decision table
- make carousel controls real scroll controls, keep desktop targets at 44×44, and collapse mobile into a readable stack

## Why

This layer connects product behavior to artist outcomes: fewer choices, moment-aware calls to action, owned audience capture, local-show discovery, and a page that remains current without link churn.

## Stack

1. Copy foundation
2. Adaptive profile proof
3. **Outcomes and capture story** ← this PR
4. Product-truth chapters
5. Route composition
6. Journey tests and changelog

Base: `codex/artist-profile-adaptive-proof`.

## Verification

- responsive carousel, capture semantics, and decision-row accessibility reviewed at desktop, tablet, mobile, and 320 px
- semantic-token migration lowers and locks the deprecated namespace ratchet from 2,200 to 2,185

## PR chain

[#14473](https://github.com/JovieInc/Jovie/pull/14473) → [#14474](https://github.com/JovieInc/Jovie/pull/14474) → [#14475](https://github.com/JovieInc/Jovie/pull/14475) → [#14476](https://github.com/JovieInc/Jovie/pull/14476) → [#14477](https://github.com/JovieInc/Jovie/pull/14477) → [#14478](https://github.com/JovieInc/Jovie/pull/14478)
