### PR TITLE
feat(marketing): add artist profile product truth chapters

### DIFF
--- a/apps/web/components/marketing/artist-profile/ArtistProfileFinalCta.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileFinalCta.tsx
@@ -9,12 +9,14 @@ interface ArtistProfileFinalCtaProps {
   readonly finalCta: ArtistProfileLandingCopy['finalCta'];
   readonly ctaHref?: string;
   readonly roomy?: boolean;
+  readonly showSignature?: boolean;
 }
 
 export function ArtistProfileFinalCta({
   finalCta,
   ctaHref = APP_ROUTES.SIGNUP,
   roomy = false,
+  showSignature = false,
 }: Readonly<ArtistProfileFinalCtaProps>) {
   return (
     <ArtistProfileSectionShell
@@ -37,6 +39,11 @@ export function ArtistProfileFinalCta({
       <p className={cn(SHELL_LEAD_CLASS, 'mx-auto mt-5 max-w-[34rem] sm:mt-6')}>
         {finalCta.subhead}
       </p>
+      {showSignature ? (
+        <p className='mt-5 font-mono text-xs tracking-tight text-tertiary-token'>
+          {finalCta.signature}
+        </p>
+      ) : null}
       <div className='mt-8'>
         <ShellCtaButton
           href={ctaHref}

--- a/apps/web/components/marketing/artist-profile/ArtistProfileHowItWorks.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileHowItWorks.tsx
@@ -1,13 +1,6 @@
-'use client';
-
-import { Popover, PopoverContent, PopoverTrigger } from '@jovie/ui';
 import { CheckCircle2, QrCode, Search } from 'lucide-react';
-import { type ReactNode, useEffect, useState } from 'react';
 import { ProviderIcon } from '@/components/atoms/ProviderIcon';
-import { CopyableUrlRow } from '@/components/molecules/CopyableUrlRow';
-import { DrawerSurfaceCard } from '@/components/molecules/drawer';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
-import { useReducedMotion } from '@/lib/hooks/useReducedMotion';
 import { cn } from '@/lib/utils';
 import { ArtistProfileSectionHeader } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
@@ -21,294 +14,158 @@ function getProviderLabel(provider: string): string {
 interface ArtistProfileHowItWorksProps {
   readonly howItWorks: ArtistProfileLandingCopy['howItWorks'];
 }
+
 export function ArtistProfileHowItWorks({
   howItWorks,
 }: Readonly<ArtistProfileHowItWorksProps>) {
-  const reducedMotion = useReducedMotion();
-  const [progress, setProgress] = useState(howItWorks.sync.startProgress);
-
-  useEffect(() => {
-    if (reducedMotion) {
-      setProgress(howItWorks.sync.endProgress);
-      return;
-    }
-
-    const timer = globalThis.setTimeout(() => {
-      setProgress(howItWorks.sync.endProgress);
-    }, 220);
-
-    return () => {
-      globalThis.clearTimeout(timer);
-    };
-  }, [
-    howItWorks.sync.endProgress,
-    howItWorks.sync.startProgress,
-    reducedMotion,
-  ]);
-
   return (
-    <ArtistProfileSectionShell className='bg-white/[0.012]'>
+    <ArtistProfileSectionShell className='bg-surface-0'>
       <div className='mx-auto max-w-280'>
         <ArtistProfileSectionHeader
           align='left'
           headline={howItWorks.headline}
           body={howItWorks.body}
-          className='max-w-[40rem]'
-          headlineClassName='max-w-none'
-          bodyClassName='max-w-[30rem]'
+          className='max-w-3xl'
+          bodyClassName='max-w-xl'
         />
 
-        <div className='mt-10 grid gap-5 lg:grid-cols-3 lg:gap-5'>
-          <article className='flex flex-col gap-3'>
-            <StepNumber value={1} />
-            <div className='relative min-h-42 space-y-3 pt-1'>
-              <div
-                aria-hidden='true'
-                className='pointer-events-none absolute inset-x-8 top-4 h-14 rounded-full bg-white/8 blur-3xl'
-              />
-              <div className='flex h-11 items-center gap-3 rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-4'>
-                <Search
-                  className='h-4 w-4 text-tertiary-token'
-                  strokeWidth={1.85}
-                />
-                <span className='text-app font-medium text-primary-token'>
-                  {howItWorks.claim.searchValue}
-                </span>
-              </div>
-              <DrawerSurfaceCard
-                variant='card'
-                className='rounded-[0.95rem] p-2.5'
-              >
-                <div className='flex items-center gap-3'>
-                  <span className='flex h-10 w-10 items-center justify-center rounded-full bg-(--color-accent-green)/12'>
-                    <ProviderIcon provider='spotify' className='h-4.5 w-4.5' />
-                  </span>
-                  <div className='min-w-0 flex-1'>
-                    <p className='truncate text-app font-semibold text-primary-token'>
-                      {howItWorks.claim.resultName}
-                    </p>
-                    <p className='text-2xs text-secondary-token'>
-                      {howItWorks.claim.resultSubtitle}
-                    </p>
-                  </div>
-                  <span className='rounded-full bg-white dark:bg-surface-1 px-3 py-1.5 text-2xs font-semibold text-black dark:text-white'>
-                    {howItWorks.claim.ctaLabel}
-                  </span>
-                </div>
-              </DrawerSurfaceCard>
-              <div className='flex items-center justify-between rounded-[0.95rem] border border-(--linear-app-frame-seam) bg-surface-0 px-3.5 py-3'>
-                <p className='font-mono text-xs font-medium tracking-[-0.02em] text-secondary-token'>
-                  {howItWorks.claim.profilePath}
-                </p>
-                <CheckCircle2
-                  className='h-4 w-4 text-success'
-                  strokeWidth={2}
-                />
-              </div>
-            </div>
-            <div>
-              <p className='text-mid font-semibold tracking-[-0.03em] text-primary-token'>
-                {howItWorks.steps[0]?.title}
-              </p>
-              <p className='mt-1.5 text-app leading-[1.6] text-secondary-token'>
-                {howItWorks.steps[0]?.description}
-              </p>
-            </div>
-          </article>
-
-          <article className='flex flex-col gap-3'>
-            <StepNumber value={2} />
-            <DrawerSurfaceCard
-              variant='card'
-              className='rounded-[1.15rem] p-3.5'
+        <ol className='mt-10 grid gap-4 lg:grid-cols-3'>
+          {howItWorks.steps.map((step, index) => (
+            <li
+              key={step.id}
+              className='flex min-h-96 flex-col rounded-2xl border border-subtle bg-surface-1 p-5 sm:p-6'
             >
-              <div className='flex items-center justify-between gap-3'>
-                <div>
-                  <p className='text-app font-semibold text-primary-token'>
-                    Importing {howItWorks.sync.artistName}
-                  </p>
-                  <p className='mt-1 text-2xs text-secondary-token'>
-                    Matching providers and pulling the catalog into place.
-                  </p>
-                </div>
-                <p className='text-xs font-semibold text-primary-token'>
-                  {progress}%
-                </p>
-              </div>
-              <div className='mt-3 h-2 overflow-hidden rounded-full bg-(--color-accent-green)/10'>
-                <div
-                  className='h-full rounded-full bg-(--color-accent-green) transition-[width] duration-cinematic ease-out'
-                  style={{ width: `${progress}%` }}
-                />
-              </div>
-              <div className='mt-3 space-y-2'>
-                {howItWorks.sync.providers.map(provider => (
-                  <div
-                    key={provider.provider}
-                    className='flex items-center justify-between rounded-[0.95rem] border border-(--linear-app-frame-seam) bg-surface-0 px-3.5 py-3'
-                  >
-                    <div className='flex items-center gap-3'>
-                      <ProviderIcon
-                        provider={provider.provider}
-                        className='h-4.5 w-4.5'
-                      />
-                      <p className='text-app font-medium text-primary-token'>
-                        {getProviderLabel(provider.provider)}
-                      </p>
-                    </div>
-                    <span
-                      className={cn(
-                        'rounded-full px-2.5 py-1 text-3xs font-semibold',
-                        provider.status === 'Ingesting'
-                          ? 'border border-accent/18 bg-(--color-bg-surface-2) text-primary-token'
-                          : 'bg-white/6 text-secondary-token'
-                      )}
-                    >
-                      {provider.status}
-                    </span>
-                  </div>
-                ))}
-              </div>
-              <p className='mt-3 text-xs font-medium tracking-[-0.02em] text-secondary-token'>
-                {howItWorks.sync.otherProvidersLabel}
+              <p className='font-mono text-3xs text-tertiary-token'>
+                0{index + 1}
               </p>
-            </DrawerSurfaceCard>
-            <div>
-              <p className='text-mid font-semibold tracking-[-0.03em] text-primary-token'>
-                {howItWorks.steps[1]?.title}
-              </p>
-              <p className='mt-1.5 text-app leading-[1.6] text-secondary-token'>
-                {howItWorks.steps[1]?.description}
-              </p>
-            </div>
-          </article>
 
-          <article className='flex flex-col gap-3'>
-            <StepNumber value={3} />
-            <div className='relative min-h-42 space-y-3 pt-1'>
-              <div
-                aria-hidden='true'
-                className='pointer-events-none absolute inset-x-8 top-4 h-14 rounded-full bg-white/8 blur-3xl'
-              />
-              <CopyableUrlRow
-                url={howItWorks.share.url}
-                displayValue={howItWorks.share.displayValue}
-                className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0'
-                valueClassName='text-secondary-token'
-                surface='boxed'
-              />
-              <div className='mt-3 flex flex-wrap gap-2'>
-                <HoverPopover
-                  label={howItWorks.share.qrLabel}
-                  content={
-                    <div className='rounded-[0.9rem] bg-white dark:bg-surface-1 p-2.5 shadow-[0_14px_32px_rgba(0,0,0,0.16)]'>
-                      <div className='grid grid-cols-7 gap-1'>
-                        {QR_CELLS.map(cell => (
-                          <span
-                            key={cell.id}
-                            className='h-2.5 w-2.5 rounded-xs'
-                            style={{
-                              backgroundColor: cell.filled
-                                ? '#0b0b0b'
-                                : '#f3f2ee',
-                            }}
-                          />
-                        ))}
-                      </div>
-                    </div>
-                  }
-                />
-                <HoverPopover
-                  label={howItWorks.share.deepLinksLabel}
-                  content={
-                    <div className='space-y-1.5'>
-                      {howItWorks.share.deepLinks.map(link => (
-                        <p
-                          key={link}
-                          className='font-mono text-2xs tracking-[-0.01em] text-primary-token'
-                        >
-                          {link}
-                        </p>
-                      ))}
-                    </div>
-                  }
-                />
+              <div className='mt-8 flex-1'>
+                {step.id === 'claim' ? (
+                  <ClaimPreview howItWorks={howItWorks} />
+                ) : null}
+                {step.id === 'connect' ? (
+                  <ConnectPreview howItWorks={howItWorks} />
+                ) : null}
+                {step.id === 'share' ? (
+                  <SharePreview howItWorks={howItWorks} />
+                ) : null}
               </div>
-            </div>
-            <div>
-              <p className='text-mid font-semibold tracking-[-0.03em] text-primary-token'>
-                {howItWorks.steps[2]?.title}
+
+              <h3 className='mt-8 text-lg font-semibold tracking-tight text-primary-token'>
+                {step.title}
+              </h3>
+              <p className='mt-3 text-app leading-relaxed text-secondary-token'>
+                {step.description}
               </p>
-              <p className='mt-1.5 text-app leading-[1.6] text-secondary-token'>
-                {howItWorks.steps[2]?.description}
-              </p>
-            </div>
-          </article>
-        </div>
+            </li>
+          ))}
+        </ol>
       </div>
     </ArtistProfileSectionShell>
   );
 }
 
-function StepNumber({ value }: Readonly<{ value: number }>) {
+function ClaimPreview({
+  howItWorks,
+}: Readonly<{ howItWorks: ArtistProfileLandingCopy['howItWorks'] }>) {
   return (
-    <span className='text-[2.15rem] font-semibold leading-none tracking-[-0.08em] text-primary-token'>
-      {value}
-    </span>
+    <div className='space-y-3'>
+      <div className='flex min-h-11 items-center gap-3 rounded-lg border border-subtle bg-surface-0 px-3.5'>
+        <Search className='h-4 w-4 text-tertiary-token' aria-hidden='true' />
+        <span className='text-app font-medium text-primary-token'>
+          {howItWorks.claim.searchValue}
+        </span>
+      </div>
+      <div className='flex items-center gap-3 rounded-xl border border-subtle bg-surface-0 p-3'>
+        <span className='flex h-10 w-10 items-center justify-center rounded-full border border-subtle bg-surface-1'>
+          <ProviderIcon provider='spotify' className='h-4 w-4' />
+        </span>
+        <div className='min-w-0 flex-1'>
+          <p className='truncate text-app font-semibold text-primary-token'>
+            {howItWorks.claim.resultName}
+          </p>
+          <p className='mt-1 text-2xs text-secondary-token'>
+            {howItWorks.claim.resultSubtitle}
+          </p>
+        </div>
+        <span className='rounded-full bg-primary-token px-3 py-1.5 text-3xs font-semibold text-surface-1'>
+          {howItWorks.claim.ctaLabel}
+        </span>
+      </div>
+      <p className='flex items-center justify-between rounded-lg border border-subtle bg-surface-0 px-3.5 py-3 font-mono text-xs text-secondary-token'>
+        {howItWorks.claim.profilePath}
+        <CheckCircle2 className='h-4 w-4 text-success' aria-hidden='true' />
+      </p>
+    </div>
   );
 }
 
-function HoverPopover({
-  label,
-  content,
-}: Readonly<{
-  label: string;
-  content: ReactNode;
-}>) {
-  const [open, setOpen] = useState(false);
-
+function ConnectPreview({
+  howItWorks,
+}: Readonly<{ howItWorks: ArtistProfileLandingCopy['howItWorks'] }>) {
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type='button'
-          onMouseEnter={() => setOpen(true)}
-          onMouseLeave={() => setOpen(false)}
-          onFocus={() => setOpen(true)}
-          onBlur={() => setOpen(false)}
-          className='inline-flex items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-3 py-1.5 text-2xs font-medium text-secondary-token transition-colors hover:bg-surface-1'
-        >
-          {label === 'QR code' ? (
-            <QrCode className='h-3.5 w-3.5' strokeWidth={1.85} />
-          ) : null}
-          {label}
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        side='bottom'
-        align='start'
-        showArrow
-        className='w-auto rounded-xl border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-3 shadow-[0_22px_54px_rgba(0,0,0,0.24)]'
-      >
-        {content}
-      </PopoverContent>
-    </Popover>
+    <div className='rounded-xl border border-subtle bg-surface-0 p-3.5'>
+      <p className='text-app font-semibold text-primary-token'>
+        {howItWorks.sync.title}
+      </p>
+      <p className='mt-1 text-2xs text-secondary-token'>
+        {howItWorks.sync.detail}
+      </p>
+      <div className='mt-4 space-y-2'>
+        {howItWorks.sync.providers.map(provider => (
+          <div
+            key={provider.provider}
+            className='flex items-center justify-between rounded-lg border border-subtle bg-surface-1 px-3 py-2.5'
+          >
+            <span className='flex items-center gap-2.5 text-xs font-medium text-primary-token'>
+              <ProviderIcon provider={provider.provider} className='h-4 w-4' />
+              {getProviderLabel(provider.provider)}
+            </span>
+            <span
+              className={cn(
+                'text-3xs font-semibold',
+                provider.status === 'Matched'
+                  ? 'text-success'
+                  : 'text-secondary-token'
+              )}
+            >
+              {provider.status}
+            </span>
+          </div>
+        ))}
+      </div>
+      <p className='mt-3 text-2xs text-tertiary-token'>
+        {howItWorks.sync.otherProvidersLabel}
+      </p>
+    </div>
   );
 }
 
-const QR_PATTERN = [
-  '1110111',
-  '1010101',
-  '1110111',
-  '0001000',
-  '1111101',
-  '1010001',
-  '1110111',
-] as const;
-
-const QR_CELLS = QR_PATTERN.flatMap((row, rowIndex) =>
-  row.split('').map((cell, cellIndex) => ({
-    id: `r${rowIndex}c${cellIndex}`,
-    filled: cell === '1',
-  }))
-);
+function SharePreview({
+  howItWorks,
+}: Readonly<{ howItWorks: ArtistProfileLandingCopy['howItWorks'] }>) {
+  return (
+    <div className='rounded-xl border border-subtle bg-surface-0 p-4'>
+      <div className='flex items-center justify-between gap-3'>
+        <p className='font-mono text-xs text-primary-token'>
+          {howItWorks.share.displayValue}
+        </p>
+        <span className='flex h-10 w-10 items-center justify-center rounded-lg border border-subtle bg-surface-1 text-secondary-token'>
+          <QrCode className='h-4 w-4' aria-hidden='true' />
+        </span>
+      </div>
+      <div className='mt-5 border-t border-subtle pt-4'>
+        <p className='text-3xs font-semibold text-tertiary-token'>
+          {howItWorks.share.deepLinksLabel}
+        </p>
+        <div className='mt-3 space-y-2'>
+          {howItWorks.share.deepLinks.slice(0, 3).map(link => (
+            <p key={link} className='font-mono text-2xs text-secondary-token'>
+              {link}
+            </p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/marketing/artist-profile/ArtistProfileSocialProof.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileSocialProof.tsx
@@ -1,8 +1,6 @@
-import Link from 'next/link';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
 import type { ArtistProfileSocialProofData } from '@/data/socialProof';
-import { cn } from '@/lib/utils';
-import { SHELL_H2_CLASS, SHELL_LEAD_CLASS } from './ArtistProfileSectionHeader';
+import { ArtistProfileSectionHeader } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
 
 interface ArtistProfileSocialProofProps {
@@ -14,64 +12,32 @@ export function ArtistProfileSocialProof({
   socialProof,
   proofData,
 }: Readonly<ArtistProfileSocialProofProps>) {
+  if (!proofData.hasRealQuotes) {
+    return null;
+  }
+
   return (
     <ArtistProfileSectionShell>
-      <div className='max-w-[34rem]'>
-        <h2 aria-label={socialProof.headline} className={SHELL_H2_CLASS}>
-          <span className='block'>Built by an artist.</span>
-          <span className='block'>For artists.</span>
-        </h2>
-        <p className={cn(SHELL_LEAD_CLASS, 'mt-5 max-w-[30rem] sm:mt-6')}>
-          {socialProof.intro}
-        </p>
+      <ArtistProfileSectionHeader
+        align='left'
+        headline={socialProof.headline}
+        body={socialProof.intro}
+        className='max-w-3xl'
+      />
+
+      <div className='mt-10 grid gap-4 lg:grid-cols-3'>
+        {proofData.quotes.map(quote => (
+          <article key={quote.id} className='border-t border-subtle pt-5'>
+            <p className='text-sm leading-relaxed text-primary-token'>
+              {quote.quote}
+            </p>
+            <p className='mt-6 text-app font-semibold text-primary-token'>
+              {quote.name}
+            </p>
+            <p className='mt-1 text-xs text-tertiary-token'>{quote.role}</p>
+          </article>
+        ))}
       </div>
-
-      {proofData.hasRealQuotes ? (
-        <div className='mt-6 grid gap-4 lg:grid-cols-3'>
-          {proofData.quotes.map(quote => (
-            <article
-              key={quote.id}
-              className='rounded-[1.1rem] bg-white/[0.018] p-5'
-            >
-              <p className='text-sm leading-[1.7] text-primary-token'>
-                {quote.quote}
-              </p>
-              <p className='mt-5 text-app font-medium text-primary-token'>
-                {quote.name}
-              </p>
-              <p className='mt-1 text-xs text-tertiary-token'>{quote.role}</p>
-            </article>
-          ))}
-        </div>
-      ) : null}
-
-      {!proofData.hasRealQuotes && proofData.founderQuote ? (
-        <article className='mx-auto mt-6 max-w-280 overflow-hidden rounded-[1.9rem] border border-black/10 bg-white dark:bg-surface-1 px-6 py-6 text-black dark:text-white shadow-[0_22px_60px_rgba(0,0,0,0.16)] sm:px-8 sm:py-7 lg:px-10 lg:py-8'>
-          <blockquote className='max-w-3xl text-pretty text-[clamp(1.375rem,2.4vw,2rem)] font-semibold leading-[1.18] tracking-[-0.025em] text-black dark:text-white'>
-            “{proofData.founderQuote.quote}”
-          </blockquote>
-          <div className='mt-6 flex flex-col gap-1 text-left'>
-            <p className='text-sm font-medium tracking-[-0.02em] text-black dark:text-white'>
-              {proofData.founderQuote.name}
-            </p>
-            <p className='text-xs tracking-[-0.01em] text-secondary-token'>
-              {proofData.founderQuote.role}
-            </p>
-            <Link
-              href={proofData.founderQuote.profileHref}
-              className='mt-3 inline-flex w-fit font-mono text-xs tracking-[-0.02em] text-secondary-token transition-colors hover:text-primary-token'
-            >
-              {proofData.founderQuote.profileLabel}
-            </Link>
-          </div>
-        </article>
-      ) : null}
-
-      {!proofData.hasRealQuotes && !proofData.founderQuote ? (
-        <p className='mt-6 text-app leading-[1.65] text-tertiary-token'>
-          {proofData.founderFallback}
-        </p>
-      ) : null}
     </ArtistProfileSectionShell>
   );
 }

--- a/apps/web/components/marketing/artist-profile/ArtistProfileSpecWall.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileSpecWall.tsx
@@ -13,6 +13,7 @@ import {
 import Image from 'next/image';
 import type { CSSProperties } from 'react';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
+import type { ArtistProfileTruthTile } from '@/data/artistProfileFeatures';
 import type { MarketingFeatureTile } from '@/data/marketingFeatureTiles';
 import { getAccentCssVars } from '@/lib/ui/accent-palette';
 import { cn } from '@/lib/utils';
@@ -36,7 +37,8 @@ type AccentStyle = CSSProperties & {
 
 interface ArtistProfileSpecWallProps {
   readonly specWall: ArtistProfileLandingCopy['specWall'];
-  readonly tiles: readonly MarketingFeatureTile[];
+  readonly tiles?: readonly MarketingFeatureTile[];
+  readonly truthTiles?: readonly ArtistProfileTruthTile[];
 }
 
 function ScreenshotCrop({
@@ -344,10 +346,47 @@ function ArtistProfilePowerFeatureTile({
 export function ArtistProfileSpecWall({
   specWall,
   tiles,
+  truthTiles,
 }: Readonly<ArtistProfileSpecWallProps>) {
+  if (truthTiles) {
+    return (
+      <ArtistProfileSectionShell width='page'>
+        <div className='mx-auto max-w-public-content'>
+          <ArtistProfileSectionHeader
+            align='left'
+            headline={specWall.headline}
+            body={specWall.subhead}
+            className='max-w-3xl'
+            bodyClassName='max-w-xl'
+          />
+
+          <ol className='mt-10 grid border-t border-subtle sm:grid-cols-2 lg:grid-cols-5'>
+            {truthTiles.map((tile, index) => (
+              <li
+                key={tile.id}
+                data-testid='artist-profile-truth-tile'
+                className='min-h-44 border-b border-subtle p-5 sm:border-r sm:[&:nth-child(2n)]:border-r-0 lg:border-r lg:[&:nth-child(5n)]:border-r-0'
+              >
+                <p className='font-mono text-3xs text-tertiary-token'>
+                  {String(index + 1).padStart(2, '0')}
+                </p>
+                <h3 className='mt-8 text-sm font-semibold text-primary-token'>
+                  {tile.title}
+                </h3>
+                <p className='mt-3 text-app leading-relaxed text-secondary-token'>
+                  {tile.body}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </ArtistProfileSectionShell>
+    );
+  }
+
   return (
     <ArtistProfileSectionShell width='page' containerClassName='max-w-none'>
-      <div className='mx-auto max-w-(--linear-content-max)'>
+      <div className='mx-auto max-w-public-content'>
         <ArtistProfileSectionHeader
           align='left'
           headline={specWall.headline}
@@ -358,7 +397,7 @@ export function ArtistProfileSpecWall({
         />
 
         <div className='mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-12 xl:grid-rows-4 xl:gap-4'>
-          {tiles.map(tile => (
+          {(tiles ?? []).map(tile => (
             <ArtistProfilePowerFeatureTile key={tile.id} tile={tile} />
           ))}
         </div>

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 2185
+  "count": 2177
 }

--- a/apps/web/tests/unit/marketing/artist-profile/ArtistProfileSocialProof.test.tsx
+++ b/apps/web/tests/unit/marketing/artist-profile/ArtistProfileSocialProof.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ArtistProfileSocialProof } from '@/components/marketing/artist-profile/ArtistProfileSocialProof';
+import { ARTIST_PROFILE_COPY } from '@/data/artistProfileCopy';
+import type { ArtistProfileSocialProofData } from '@/data/socialProof';
+
+const realProof: ArtistProfileSocialProofData = {
+  proofWhisper: 'Artist proof',
+  logos: [],
+  profileCards: [],
+  quotes: [
+    {
+      id: 'real-artist',
+      name: 'A Real Artist',
+      role: 'Independent artist',
+      quote: 'This is a verified artist quote.',
+    },
+  ],
+  founderFallback: 'Built with artists.',
+  hasRealQuotes: true,
+};
+
+describe('ArtistProfileSocialProof', () => {
+  it('renders verified artist quotes when the proof gate is open', () => {
+    render(
+      <ArtistProfileSocialProof
+        socialProof={ARTIST_PROFILE_COPY.socialProof}
+        proofData={realProof}
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: ARTIST_PROFILE_COPY.socialProof.headline,
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByText('This is a verified artist quote.')).toBeVisible();
+    expect(screen.getByText('A Real Artist')).toBeVisible();
+    expect(screen.getByText('Independent artist')).toBeVisible();
+  });
+
+  it('renders nothing when the proof gate is closed', () => {
+    const { container } = render(
+      <ArtistProfileSocialProof
+        socialProof={ARTIST_PROFILE_COPY.socialProof}
+        proofData={{ ...realProof, quotes: [], hasRealQuotes: false }}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/tests/unit/marketing/artist-profile/ArtistProfileSpecWall.test.tsx
+++ b/apps/web/tests/unit/marketing/artist-profile/ArtistProfileSpecWall.test.tsx
@@ -1,15 +1,15 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { ArtistProfileSpecWall } from '@/components/marketing/artist-profile';
 import { ARTIST_PROFILE_COPY } from '@/data/artistProfileCopy';
-import { ARTIST_PROFILE_SPEC_TILES } from '@/data/artistProfileFeatures';
+import { ARTIST_PROFILE_TRUTH_TILES } from '@/data/artistProfileFeatures';
 
 describe('ArtistProfileSpecWall', () => {
-  it('renders the compact eight-tile spec wall without legacy slop copy', () => {
+  it('renders the compact ten-tile product truth wall without legacy slop copy', () => {
     render(
       <ArtistProfileSpecWall
         specWall={ARTIST_PROFILE_COPY.specWall}
-        tiles={ARTIST_PROFILE_SPEC_TILES}
+        truthTiles={ARTIST_PROFILE_TRUTH_TILES}
       />
     );
 
@@ -24,50 +24,22 @@ describe('ArtistProfileSpecWall', () => {
       )
     ).toBeInTheDocument();
 
+    expect(screen.getAllByTestId('artist-profile-truth-tile')).toHaveLength(10);
+
     const headings = screen.getAllByRole('heading', { level: 3 });
     const titles = headings.map(heading => heading.textContent);
 
-    expect(titles).toEqual([
-      'Audience Quality Filtering',
-      'Rich Analytics',
-      'Geo Insights',
-      'Always in Sync',
-      'Activate Creators',
-      'Press-Ready Assets',
-      'UTM Builder',
-      'Blazing Fast',
-    ]);
+    expect(titles).toEqual(ARTIST_PROFILE_TRUTH_TILES.map(tile => tile.title));
 
-    for (const title of titles) {
-      const card = screen
-        .getByRole('heading', { name: title ?? '' })
-        .closest('article');
-      expect(card).not.toBeNull();
-
-      if (!card) {
-        continue;
-      }
-
-      expect(within(card).getByRole('img')).toBeInTheDocument();
-    }
-
-    const audienceQualityCard = screen
-      .getByRole('heading', { name: 'Audience Quality Filtering' })
-      .closest('article');
-
-    expect(audienceQualityCard).not.toBeNull();
-
-    if (audienceQualityCard) {
-      expect(
-        within(audienceQualityCard).getByRole('img', {
-          name: 'Audience Quality Filtering Preview',
-        })
-      ).toBeInTheDocument();
-      expect(
-        within(audienceQualityCard).getByText('Actual Fans')
-      ).toBeInTheDocument();
-    }
-
+    expect(screen.queryByText('Details that matter.')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Built from 15 years of music marketing experience, obsessing over the details that make a profile convert.'
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Audience Quality Filtering')
+    ).not.toBeInTheDocument();
     expect(screen.queryByText('Power features')).not.toBeInTheDocument();
     expect(screen.queryByText('Opinionated design')).not.toBeInTheDocument();
     expect(screen.queryByText('Product philosophy')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- add the ten-tile product-truth wall and three-step “How it works” chapter
- add an evidence gate that renders social proof only when real approved quotes exist
- tighten the FAQ to four high-intent questions and add the final creator CTA

## Why

The page needs to prove what the product actually does without fabricated testimonials or an undifferentiated feature grid. This layer makes the tradeoffs explicit and keeps unsupported social proof out of production.

## Stack

1. Copy foundation
2. Adaptive profile proof
3. Outcomes and capture story
4. **Product-truth chapters** ← this PR
5. Route composition
6. Journey tests and changelog

Base: `codex/artist-profile-outcomes-capture`.

## Verification

- unit coverage for the zero-proof and approved-proof gates plus product-truth rendering
- semantic-token migration lowers and locks the deprecated namespace ratchet from 2,185 to 2,177

## PR chain

[#14473](https://github.com/JovieInc/Jovie/pull/14473) → [#14474](https://github.com/JovieInc/Jovie/pull/14474) → [#14475](https://github.com/JovieInc/Jovie/pull/14475) → [#14476](https://github.com/JovieInc/Jovie/pull/14476) → [#14477](https://github.com/JovieInc/Jovie/pull/14477) → [#14478](https://github.com/JovieInc/Jovie/pull/14478)
