### PR TITLE
fix(ci): ignore terminal Vercel rollouts

### DIFF
--- a/.github/scripts/promote-production-deployment.sh
+++ b/.github/scripts/promote-production-deployment.sh
@@ -153,7 +153,12 @@ fetch_rollout() {
 }
 
 rollout_is_active() {
-  jq -e '. != null and .activeStage != null' >/dev/null 2>&1 <<<"$1"
+  # Terminal records can retain activeStage; unknown states must stay fail-closed.
+  jq -e '
+    . != null and
+    .state != "COMPLETE" and
+    .state != "ABORTED"
+  ' >/dev/null 2>&1 <<<"$1"
 }
 
 rollout_target_id() {

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -608,7 +608,9 @@ if [ "$cmd" = "rolling-release" ] && [ "$2" = "fetch" ]; then
   fi
 
   rollout='null'
-  if [ "$FAKE_SCENARIO" = "foreign" ]; then
+  if [ "$FAKE_SCENARIO" = "foreign-complete" ]; then
+    rollout='{"state":"COMPLETE","currentCanaryPercentage":100,"activeStage":{"index":2,"isFinalStage":true,"targetPercentage":100},"canaryDeployment":{"id":"dpl_foreign"}}'
+  elif [ "$FAKE_SCENARIO" = "foreign" ]; then
     rollout='{"activeStage":{"targetPercentage":10},"canaryDeployment":{"id":"dpl_foreign"}}'
   elif [ "$FAKE_SCENARIO" = "rolling" ] &&
     grep -q '^promote ' "$VERCEL_CALL_LOG" &&
@@ -731,6 +733,18 @@ def test_promotion_controller_rejects_foreign_rollout_without_mutation(
     assert (tmp_path / "github-output").read_text().strip() == (
         "failure_subtype=production_promotion_foreign_rollout"
     )
+
+
+def test_promotion_controller_ignores_completed_foreign_rollout_record(
+    tmp_path: Path,
+) -> None:
+    result = _run_promotion_controller(tmp_path, "foreign-complete")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    calls = (tmp_path / "vercel-calls").read_text()
+    assert calls.count("promote dpl_target") == 1
+    assert "rolling-release complete" not in calls
+    assert "rolling-release abort" not in calls
 
 
 def test_promotion_controller_aborts_timed_out_owned_rollout_and_stops(


### PR DESCRIPTION
## Summary

- Treat Vercel rolling-release states COMPLETE and ABORTED as terminal even when stale records retain activeStage.
- Keep missing, malformed, and future states fail-closed.
- Add an exact foreign-COMPLETE regression fixture.

## Production evidence

Production run 29662430677 reached promotion, then safely refused the stale foreign rollout. A read-only Vercel rolling-release fetch showed state COMPLETE, currentCanaryPercentage 100, and the final activeStage at 100% for the old canary deployment.

Vercel CLI 54.14.5 types define the complete state vocabulary as ACTIVE, COMPLETE, and ABORTED.

## Verification

- Promotion controller tests: 11/11 passed
- Full scripts/tests/test_vercel_prebuilt_deploy.py: 28/28 passed
- bash -n: passed
- shellcheck: passed
- git diff --check: passed

## CI strategy

This change is limited to the production controller shell script and its deterministic Python fixture. Source-heavy application CI is intentionally not awaited before gating because it adds no signal for this patch; the gated merge queue retains the next-tier integration checks.