### PR TITLE
fix(ci): cover Vercel rollout horizon

### DIFF
--- a/.github/scripts/promote-production-deployment.sh
+++ b/.github/scripts/promote-production-deployment.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 deploy_id="${PRODUCTION_DEPLOYMENT_ID:-}"
 vercel_cli="${VERCEL_CLI:-./node_modules/.bin/vercel}"
 poll_seconds="${PRODUCTION_PROMOTION_POLL_SECONDS:-5}"
-settle_attempts="${PRODUCTION_PROMOTION_SETTLE_ATTEMPTS:-36}"
+# Production holds at 10% for five minutes. The eight-minute default leaves
+# three minutes for Vercel's asynchronous rollout state to converge.
+settle_attempts="${PRODUCTION_PROMOTION_SETTLE_ATTEMPTS:-96}"
 cleanup_attempts="${PRODUCTION_PROMOTION_CLEANUP_ATTEMPTS:-12}"
 promote_timeout="${PRODUCTION_PROMOTION_CLI_TIMEOUT:-3m}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5841,7 +5841,7 @@ jobs:
 
       - name: Promote staged production deployment
         id: promote
-        timeout-minutes: 10
+        timeout-minutes: 15
         env:
           PRODUCTION_DEPLOYMENT_ID: ${{ steps.stage-production.outputs.production_deployment_id }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1744,10 +1744,43 @@ describe('production promotion exact-artifact contract', () => {
     expect(smokeJob).not.toContain('Wait for CDN propagation');
   });
 
-  it('keeps promotion ownership checks and cleanup hard-bounded', () => {
+  it('keeps promotion ownership and live rollout horizon hard-bounded', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
     const controller = readFileSync(productionPromotionControllerPath, 'utf8');
+    const promotionJob = getJobBlock(workflow, 'promote-production');
+    const promotionStep = getStepBlock(
+      promotionJob,
+      'Promote staged production deployment'
+    );
+    const defaultPollSeconds = Number(
+      controller.match(/PRODUCTION_PROMOTION_POLL_SECONDS:-([0-9]+)}/)?.[1]
+    );
+    const defaultSettleAttempts = Number(
+      controller.match(/PRODUCTION_PROMOTION_SETTLE_ATTEMPTS:-([0-9]+)}/)?.[1]
+    );
+    const defaultPromoteTimeoutMinutes = Number(
+      controller.match(/PRODUCTION_PROMOTION_CLI_TIMEOUT:-([0-9]+)m}/)?.[1]
+    );
+    const promotionStepTimeoutMinutes = Number(
+      promotionStep.match(/timeout-minutes:\s*([0-9]+)/)?.[1]
+    );
+    // Vercel durations are minutes; production holds 10% traffic for 5 minutes.
+    const liveAutomaticStageSeconds = 5 * 60;
+    const apiConvergenceBufferSeconds = 3 * 60;
+    const shellAndApiBufferSeconds = 60;
 
-    expect(controller).toContain('PRODUCTION_PROMOTION_SETTLE_ATTEMPTS:-36');
+    expect(defaultPollSeconds).toBe(5);
+    expect(defaultSettleAttempts).toBe(96);
+    expect(defaultPollSeconds * defaultSettleAttempts).toBeGreaterThanOrEqual(
+      liveAutomaticStageSeconds + apiConvergenceBufferSeconds
+    );
+    expect(defaultPromoteTimeoutMinutes).toBe(3);
+    expect(promotionStepTimeoutMinutes).toBe(15);
+    expect(promotionStepTimeoutMinutes * 60).toBeGreaterThanOrEqual(
+      defaultPromoteTimeoutMinutes * 60 +
+        defaultPollSeconds * defaultSettleAttempts +
+        shellAndApiBufferSeconds
+    );
     expect(controller).toContain('PRODUCTION_PROMOTION_CLEANUP_ATTEMPTS:-12');
     expect(controller).toContain('rolling-release fetch');
     expect(controller).toContain('rollout_target_id');


### PR DESCRIPTION
## Summary

- Extend the production rolling-release settle default from 36 to 96 polls.
- Increase only the promotion step timeout from 10 to 15 minutes.
- Add a static contract that keeps the controller and workflow budgets aligned.

## Evidence

Vercel documents rolling-release duration values in minutes: a stage with duration 5 holds traffic for five minutes. Production is configured for an automatic 10% stage lasting five minutes before 100%.

Official documentation: https://vercel.com/docs/rolling-releases/rolling-release-deployment

Authoritative main run 29663818107 was canceled before the Promote staged production deployment step began, so the known-short controller did not mutate production.

## Budget

- Live automatic stage: 5 minutes
- API convergence buffer: 3 minutes
- Default settle horizon: 96 polls × 5 seconds = 8 minutes
- CLI bound: 3 minutes
- Required shell/API buffer: at least 1 minute
- Promotion step cap: 15 minutes

The step therefore covers the 12-minute asserted minimum and leaves three additional minutes for bounded cleanup and API overhead. Terminal rollout state still exits early; environment overrides, ownership checks, and fail-closed cleanup remain unchanged.

## Verification

- scripts/tests/test_vercel_prebuilt_deploy.py: 28/28 passed
- deploy-workflow.test.ts: 53/53 passed
- Biome: passed
- bash -n: passed
- shellcheck: passed
- actionlint: exit 0
- git diff --check: passed
- Signed commit hook: gitleaks, TruffleHog, repo hygiene, proxy guard, ESLint, typecheck all passed

## CI strategy

This is a production-controller bootstrap. Source-heavy application CI is intentionally not awaited before gating because the previous main controller cannot safely complete the known five-minute rollout and unrelated source lanes add no signal to the bounded shell/workflow contract. The gated landing creates a fresh main run with the corrected production horizon.