### PR TITLE
fix(ci): unblock native merge queue

### DIFF
--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -579,14 +579,33 @@ final class JovieUITests: XCTestCase {
     XCTAssertEqual(input.value as? String, draft)
 
     app.buttons["Open navigation drawer"].tap()
-    app.buttons["shell-drawer-surface-shell-tab-profile"].tap()
+    let contentPlaneMarker = app.buttons["Open navigation drawer"]
+    let profileSurface = app.buttons["shell-drawer-surface-shell-tab-profile"]
+    XCTAssertTrue(
+      waitForDrawerSurfaceToBeUncovered(
+        profileSurface,
+        contentPlaneMarker: contentPlaneMarker,
+        timeout: 3
+      ),
+      "Profile surface stayed covered by the opening content plane.\n\(app.debugDescription)"
+    )
+    profileSurface.tap()
     XCTAssertTrue(
       app.buttons["Copy URL"].waitForExistence(timeout: 10),
       "Shell navigation did not switch to Profile.\n\(app.debugDescription)"
     )
 
     app.buttons["Open navigation drawer"].tap()
-    app.buttons["shell-drawer-surface-shell-tab-chat"].tap()
+    let chatSurface = app.buttons["shell-drawer-surface-shell-tab-chat"]
+    XCTAssertTrue(
+      waitForDrawerSurfaceToBeUncovered(
+        chatSurface,
+        contentPlaneMarker: contentPlaneMarker,
+        timeout: 3
+      ),
+      "Chat surface stayed covered by the opening content plane.\n\(app.debugDescription)"
+    )
+    chatSurface.tap()
     let restoredInput = app.textFields["Ask Jovie"]
     XCTAssertTrue(
       waitForHittable(restoredInput, timeout: 10),
@@ -1153,6 +1172,34 @@ final class JovieUITests: XCTestCase {
     }
 
     return element.exists && element.isHittable
+  }
+
+  /// SwiftUI reports recessed drawer controls hittable before the animated
+  /// content plane has physically cleared them. Wait on the actual frames so
+  /// XCUITest cannot synthesize a tap into the covering plane.
+  private func waitForDrawerSurfaceToBeUncovered(
+    _ surface: XCUIElement,
+    contentPlaneMarker: XCUIElement,
+    timeout: TimeInterval
+  ) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+
+    while Date() < deadline {
+      if surface.exists,
+         surface.isHittable,
+         contentPlaneMarker.exists,
+         contentPlaneMarker.frame.minX >= surface.frame.maxX
+      {
+        return true
+      }
+
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+
+    return surface.exists
+      && surface.isHittable
+      && contentPlaneMarker.exists
+      && contentPlaneMarker.frame.minX >= surface.frame.maxX
   }
 
   /// Resolve a primary tab bar / Talk FAB control by accessibility identifier.

--- a/scripts/lib/__tests__/merge-group-member-policy.test.mjs
+++ b/scripts/lib/__tests__/merge-group-member-policy.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  assertCurrentPullRequest,
   evaluateForkMemberPolicy,
   evaluateSizeMemberPolicy,
   resolveMergeGroupMembers,
@@ -9,7 +10,6 @@ const BASE = '1'.repeat(40);
 const FIRST = '2'.repeat(40);
 const HEAD = '3'.repeat(40);
 const SOURCE_101 = 'a'.repeat(40);
-const SOURCE_102 = 'b'.repeat(40);
 
 function event(overrides = {}) {
   return {
@@ -30,20 +30,16 @@ function commit(sha, parent, number) {
   return {
     sha,
     parents: [{ sha: parent }],
-    commit: { message: `fix(ci): queue member ${number} (#${number})` },
-  };
-}
-
-function entry(number, position, syntheticHead, sourceHead, base = BASE) {
-  return {
-    position,
-    state: 'AWAITING_CHECKS',
-    baseCommit: { oid: base },
-    headCommit: { oid: syntheticHead },
-    pullRequest: {
-      number,
-      baseRefName: 'main',
-      headRefOid: sourceHead,
+    commit: {
+      message: `fix(ci): queue member ${number} (#${number})`,
+      committer: {
+        name: 'GitHub',
+        email: 'noreply@github.com',
+      },
+      verification: {
+        verified: true,
+        reason: 'valid',
+      },
     },
   };
 }
@@ -57,21 +53,6 @@ function comparison(commits) {
     base_commit: { sha: BASE },
     merge_base_commit: { sha: BASE },
     commits,
-  };
-}
-
-function queue(nodes) {
-  return {
-    configuration: {
-      maximumEntriesToMerge: 10,
-      mergeMethod: 'SQUASH',
-      mergingStrategy: 'ALLGREEN',
-    },
-    entries: {
-      totalCount: nodes.length,
-      pageInfo: { hasNextPage: false },
-      nodes,
-    },
   };
 }
 
@@ -106,71 +87,57 @@ function sizedPr(labels) {
 }
 
 describe('merge-group member discovery', () => {
-  it('cross-proves every member of a multi-entry group in queue order', () => {
+  it('resolves every member from the exact synthetic first-parent chain', () => {
     const members = resolveMergeGroupMembers({
       event: event(),
       comparison: comparison([
         commit(FIRST, BASE, 101),
         commit(HEAD, FIRST, 102),
       ]),
-      queue: queue([
-        entry(101, 4, FIRST, SOURCE_101),
-        entry(102, 5, HEAD, SOURCE_102, FIRST),
-        entry(103, 6, '4'.repeat(40), 'c'.repeat(40), HEAD),
-      ]),
     });
 
     expect(members).toEqual([
       {
         number: 101,
-        position: 4,
-        queueState: 'AWAITING_CHECKS',
         syntheticHeadSha: FIRST,
-        sourceHeadSha: SOURCE_101,
       },
       {
         number: 102,
-        position: 5,
-        queueState: 'AWAITING_CHECKS',
         syntheticHeadSha: HEAD,
-        sourceHeadSha: SOURCE_102,
       },
     ]);
   });
 
   it('fails closed on unknown, truncated, or malformed member evidence', () => {
     const commits = [commit(HEAD, BASE, 102)];
-    const validQueue = queue([entry(102, 1, HEAD, SOURCE_102)]);
-
     expect(() =>
       resolveMergeGroupMembers({
         event: event({ head_ref: 'refs/heads/main' }),
         comparison: comparison(commits),
-        queue: validQueue,
       })
     ).toThrow(/head_ref is not a main merge-queue ref/);
 
     expect(() =>
       resolveMergeGroupMembers({
         event: event(),
-        comparison: comparison(commits),
-        queue: queue([]),
+        comparison: {
+          ...comparison(commits),
+          total_commits: 2,
+        },
       })
-    ).toThrow(/absent from the live merge queue/);
+    ).toThrow(/exact base\.\.head range/);
 
     expect(() =>
       resolveMergeGroupMembers({
         event: event(),
-        comparison: comparison(commits),
-        queue: {
-          ...validQueue,
-          entries: {
-            ...validQueue.entries,
-            pageInfo: { hasNextPage: true },
+        comparison: comparison([
+          {
+            ...commits[0],
+            parents: [{ sha: '9'.repeat(40) }],
           },
-        },
+        ]),
       })
-    ).toThrow(/incomplete or malformed/);
+    ).toThrow(/not the expected first-parent link/);
 
     expect(() =>
       resolveMergeGroupMembers({
@@ -179,11 +146,11 @@ describe('merge-group member discovery', () => {
           {
             ...commits[0],
             commit: {
+              ...commits[0].commit,
               message: 'synthetic commit without an attributable trailer',
             },
           },
         ]),
-        queue: validQueue,
       })
     ).toThrow(/no final \(#PR\) trailer/);
 
@@ -192,30 +159,94 @@ describe('merge-group member discovery', () => {
         event: event(),
         comparison: comparison([
           commit(FIRST, BASE, 101),
-          commit(HEAD, FIRST, 102),
-        ]),
-        queue: queue([
-          entry(101, 4, FIRST, SOURCE_101),
-          entry(102, 6, HEAD, SOURCE_102),
+          commit(HEAD, FIRST, 101),
         ]),
       })
-    ).toThrow(/out of merge queue order/);
+    ).toThrow(/repeats PR #101/);
+  });
 
+  it('rejects commits without canonical GitHub generation evidence', () => {
+    const valid = commit(HEAD, BASE, 102);
+
+    for (const synthetic of [
+      {
+        ...valid,
+        commit: {
+          ...valid.commit,
+          verification: { verified: false, reason: 'valid' },
+        },
+      },
+      {
+        ...valid,
+        commit: {
+          ...valid.commit,
+          verification: { verified: true, reason: 'unknown_key' },
+        },
+      },
+      {
+        ...valid,
+        commit: {
+          ...valid.commit,
+          committer: {
+            name: 'Contributor',
+            email: 'noreply@github.com',
+          },
+        },
+      },
+      {
+        ...valid,
+        commit: {
+          ...valid.commit,
+          committer: {
+            name: 'GitHub',
+            email: 'contributor@example.com',
+          },
+        },
+      },
+    ]) {
+      expect(() =>
+        resolveMergeGroupMembers({
+          event: event(),
+          comparison: comparison([synthetic]),
+        })
+      ).toThrow(/not verified GitHub-generated evidence/);
+    }
+  });
+
+  it('caps unprivileged member discovery at the trusted ruleset bound', () => {
     expect(() =>
       resolveMergeGroupMembers({
         event: event(),
-        comparison: comparison([
-          commit(FIRST, BASE, 101),
-          commit(HEAD, FIRST, 102),
-        ]),
-        queue: queue([
-          entry(101, 4, FIRST, SOURCE_101),
-          // A later queue entry is based on the previous synthetic head, not
-          // the original merge-group base.
-          entry(102, 5, HEAD, SOURCE_102),
-        ]),
+        comparison: comparison(
+          Array.from({ length: 11 }, () => commit(HEAD, BASE, 102))
+        ),
       })
-    ).toThrow(/does not match the synthetic chain/);
+    ).toThrow(/exceeds trusted 10-member bound/);
+  });
+
+  it('requires current open main-bound PR metadata after discovery', () => {
+    const member = {
+      number: 101,
+      syntheticHeadSha: HEAD,
+    };
+    const current = {
+      number: 101,
+      state: 'open',
+      base: { ref: 'main' },
+      head: { sha: SOURCE_101, repo: { fork: false } },
+      labels: [],
+    };
+
+    expect(() => assertCurrentPullRequest(member, current)).not.toThrow();
+    expect(() =>
+      assertCurrentPullRequest(member, {
+        ...current,
+        head: { ...current.head, sha: 'not-a-sha' },
+      })
+    ).toThrow(/changed or is malformed after group discovery/);
+    expect(() =>
+      assertCurrentPullRequest(member, { ...current, state: 'closed' })
+    ).toThrow(/changed or is malformed after group discovery/);
   });
 });
 

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -31,6 +31,14 @@ const CLAUDE_REVIEW_WORKFLOW = readFileSync(
   resolve(REPO_ROOT, '.github/workflows/claude-review.yml'),
   'utf8'
 );
+const MEMBER_POLICY = readFileSync(
+  resolve(REPO_ROOT, 'scripts/lib/merge-group-member-policy.mjs'),
+  'utf8'
+);
+const BRANCH_RULESET = readFileSync(
+  resolve(REPO_ROOT, '.github/rulesets/branch-protection.yml'),
+  'utf8'
+);
 const EVENT = JSON.parse(
   readFileSync(
     resolve(import.meta.dirname, 'fixtures/merge-group-checks-requested.json'),
@@ -313,6 +321,8 @@ describe('merge_group workflow contract', () => {
     expect(forkGate).toContain("github.event_name == 'merge_group'");
     expect(forkGate).toContain('ref: ${{ github.event.merge_group.base_sha }}');
     expect(forkGate).toContain('persist-credentials: false');
+    expect(forkGate).toContain('contents: read');
+    expect(forkGate).toContain('pull-requests: read');
     expect(forkGate).toContain('GH_TOKEN: ${{ github.token }}');
     expect(forkGate).not.toContain('actions/create-github-app-token');
     expect(forkGate).not.toContain('secrets.');
@@ -334,6 +344,8 @@ describe('merge_group workflow contract', () => {
       'ref: ${{ github.event.merge_group.base_sha }}'
     );
     expect(sizeGuard).toContain('persist-credentials: false');
+    expect(SIZE_GUARD_WORKFLOW).toContain('contents: read');
+    expect(SIZE_GUARD_WORKFLOW).toContain('pull-requests: read');
     expect(sizeGuard).toContain('GH_TOKEN: ${{ github.token }}');
     expect(sizeGuard).not.toContain('actions/create-github-app-token');
     expect(sizeGuard).not.toContain('secrets.');
@@ -346,6 +358,15 @@ describe('merge_group workflow contract', () => {
     expect(getJobBlock(SIZE_GUARD_WORKFLOW, 'size')).toContain(
       "github.event_name == 'pull_request'"
     );
+    expect(MEMBER_POLICY).toContain('fetchComparison');
+    expect(MEMBER_POLICY).toContain('fetchPullRequest');
+    expect(MEMBER_POLICY).not.toContain("githubRequest('/graphql'");
+    expect(MEMBER_POLICY).not.toContain('mergeQueue(');
+    const maxMembers = BRANCH_RULESET.match(
+      /^\s*max_entries_to_merge:\s*(\d+)$/m
+    )?.[1];
+    expect(maxMembers).toBeTruthy();
+    expect(MEMBER_POLICY).toContain(`const MAX_GROUP_MEMBERS = ${maxMembers};`);
   });
 
   it('keeps source and combined-head lanes deterministic and free of privileged secrets', () => {

--- a/scripts/lib/merge-group-member-policy.mjs
+++ b/scripts/lib/merge-group-member-policy.mjs
@@ -4,7 +4,8 @@ import { evaluatePrSizePolicy } from './pr-size-guard-policy.mjs';
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const GENERATED_PR_TRAILER_PATTERN = /\(#(\d+)\)$/;
-const ACTIVE_GROUP_STATES = new Set(['AWAITING_CHECKS', 'LOCKED', 'MERGEABLE']);
+// Fail closed at the checked-in native queue's max_entries_to_merge ceiling.
+const MAX_GROUP_MEMBERS = 10;
 const SIZE_BYPASS_LABELS = new Set(['big-pr', 'codemod']);
 const COLLABORATOR_ASSOCIATIONS = new Set(['COLLABORATOR', 'MEMBER', 'OWNER']);
 const OPINIONATED_REVIEW_STATES = new Set([
@@ -51,6 +52,21 @@ function generatedPullRequestNumber(commit) {
   return requireInteger(Number(match[1]), 'synthetic pull request number');
 }
 
+function requireGitHubGeneratedCommit(commit) {
+  const committer = commit?.commit?.committer;
+  const verification = commit?.commit?.verification;
+  if (
+    committer?.name !== 'GitHub' ||
+    committer?.email !== 'noreply@github.com' ||
+    verification?.verified !== true ||
+    verification?.reason !== 'valid'
+  ) {
+    fail(
+      `synthetic commit ${commit?.sha ?? 'unknown'} is not verified GitHub-generated evidence`
+    );
+  }
+}
+
 export function validateMergeGroupEvent(event) {
   if (event?.action !== 'checks_requested')
     fail('unexpected merge_group action');
@@ -85,13 +101,13 @@ export function validateMergeGroupEvent(event) {
  * Resolve every PR represented by one exact merge_group head.
  *
  * GitHub's merge_group payload deliberately exposes only base/head refs and
- * SHAs. For an ALLGREEN/SQUASH queue, the exact base..head first-parent range
- * contains one GitHub-generated squash commit per member. We cross-prove each
- * generated commit's final (#PR) trailer against the live GraphQL merge queue
- * entry with the same generated head commit. Nothing is inferred from the
- * single-PR-looking gh-readonly-queue ref.
+ * SHAs. The exact base..head first-parent range contains one GitHub-generated
+ * commit per member, whose final (#PR) trailer identifies that member. Current
+ * PR metadata is fetched through the REST API after discovery; the unprivileged
+ * merge_group token cannot read the live mergeQueue GraphQL field, and this
+ * combined-head workflow must never receive a privileged App secret.
  */
-export function resolveMergeGroupMembers({ event, comparison, queue }) {
+export function resolveMergeGroupMembers({ event, comparison }) {
   const { baseSha, headSha } = validateMergeGroupEvent(event);
 
   if (
@@ -106,45 +122,11 @@ export function resolveMergeGroupMembers({ event, comparison, queue }) {
   ) {
     fail('compare API did not return the exact base..head range');
   }
-
-  const configuration = queue?.configuration;
-  if (
-    configuration?.mergeMethod !== 'SQUASH' ||
-    configuration?.mergingStrategy !== 'ALLGREEN'
-  ) {
-    fail('live merge queue is not ALLGREEN/SQUASH');
-  }
-
-  const connection = queue?.entries;
-  if (
-    !connection ||
-    connection.pageInfo?.hasNextPage !== false ||
-    !Array.isArray(connection.nodes) ||
-    connection.totalCount !== connection.nodes.length
-  ) {
-    fail('merge queue entry discovery is incomplete or malformed');
-  }
-  if (
-    !Number.isInteger(configuration.maximumEntriesToMerge) ||
-    comparison.commits.length > configuration.maximumEntriesToMerge
-  ) {
-    fail('merge group exceeds the live maximumEntriesToMerge policy');
-  }
-
-  const entriesByPullRequest = new Map();
-  for (const entry of connection.nodes) {
-    const number = requireInteger(
-      entry?.pullRequest?.number,
-      'merge queue pull request number'
-    );
-    if (entriesByPullRequest.has(number)) {
-      fail(`merge queue contains duplicate PR #${number}`);
-    }
-    entriesByPullRequest.set(number, entry);
+  if (comparison.commits.length > MAX_GROUP_MEMBERS) {
+    fail(`merge group exceeds trusted ${MAX_GROUP_MEMBERS}-member bound`);
   }
 
   let parentSha = baseSha;
-  let previousPosition = 0;
   const seenNumbers = new Set();
   const members = comparison.commits.map(commit => {
     const commitSha = requireSha(commit?.sha, 'synthetic commit sha');
@@ -158,51 +140,16 @@ export function resolveMergeGroupMembers({ event, comparison, queue }) {
         `synthetic commit ${commitSha} is not the expected first-parent link`
       );
     }
+    requireGitHubGeneratedCommit(commit);
 
     const number = generatedPullRequestNumber(commit);
     if (seenNumbers.has(number)) fail(`merge group repeats PR #${number}`);
     seenNumbers.add(number);
 
-    const entry = entriesByPullRequest.get(number);
-    if (!entry) fail(`PR #${number} is absent from the live merge queue`);
-    const position = requireInteger(
-      entry.position,
-      `PR #${number} queue position`
-    );
-    if (
-      position <= previousPosition ||
-      (previousPosition > 0 && position !== previousPosition + 1)
-    ) {
-      fail(`PR #${number} is out of merge queue order`);
-    }
-    if (!ACTIVE_GROUP_STATES.has(entry.state)) {
-      fail(
-        `PR #${number} has non-buildable queue state ${entry.state ?? 'missing'}`
-      );
-    }
-    if (
-      entry.baseCommit?.oid !== parentSha ||
-      entry.headCommit?.oid !== commitSha
-    ) {
-      fail(
-        `PR #${number} queue commit evidence does not match the synthetic chain`
-      );
-    }
-    if (
-      entry.pullRequest.baseRefName !== 'main' ||
-      !SHA_PATTERN.test(String(entry.pullRequest.headRefOid ?? ''))
-    ) {
-      fail(`PR #${number} has malformed live head metadata`);
-    }
-
     parentSha = commitSha;
-    previousPosition = position;
     return {
       number,
-      position,
-      queueState: entry.state,
       syntheticHeadSha: commitSha,
-      sourceHeadSha: entry.pullRequest.headRefOid,
     };
   });
 
@@ -226,10 +173,10 @@ export function assertCurrentPullRequest(member, pr) {
     pr?.number !== member.number ||
     pr?.state !== 'open' ||
     pr?.base?.ref !== 'main' ||
-    pr?.head?.sha !== member.sourceHeadSha ||
+    !SHA_PATTERN.test(String(pr?.head?.sha ?? '')) ||
     typeof pr?.head?.repo?.fork !== 'boolean'
   ) {
-    fail(`PR #${member.number} changed after merge queue discovery`);
+    fail(`PR #${member.number} changed or is malformed after group discovery`);
   }
   labelsFor(pr);
 }
@@ -417,50 +364,6 @@ async function githubPages(path, { token, maxPages = 30 } = {}) {
   fail(`GitHub API pagination exceeded ${maxPages} pages for ${path}`);
 }
 
-async function fetchQueue({ owner, name, branch, token }) {
-  const query = `
-    query QueueMembers($owner: String!, $name: String!, $branch: String!) {
-      repository(owner: $owner, name: $name) {
-        mergeQueue(branch: $branch) {
-          configuration {
-            maximumEntriesToMerge
-            mergeMethod
-            mergingStrategy
-          }
-          entries(first: 100) {
-            totalCount
-            pageInfo { hasNextPage }
-            nodes {
-              position
-              state
-              baseCommit { oid }
-              headCommit { oid }
-              pullRequest {
-                number
-                baseRefName
-                headRefOid
-              }
-            }
-          }
-        }
-      }
-    }
-  `;
-  const result = await githubRequest('/graphql', {
-    token,
-    method: 'POST',
-    body: { query, variables: { owner, name, branch } },
-  });
-  if (result.data?.errors?.length) {
-    fail(
-      `GitHub GraphQL error: ${result.data.errors[0]?.message ?? 'unknown error'}`
-    );
-  }
-  const queue = result.data?.data?.repository?.mergeQueue;
-  if (!queue) fail('GitHub GraphQL returned no merge queue');
-  return queue;
-}
-
 async function fetchPullRequest(repository, number, token) {
   const result = await githubRequest(`/repos/${repository}/pulls/${number}`, {
     token,
@@ -492,14 +395,10 @@ async function runPolicy() {
   if (!token || !eventPath) fail('GH_TOKEN and GITHUB_EVENT_PATH are required');
 
   const event = JSON.parse(await readFile(eventPath, 'utf8'));
-  const { baseSha, branch, headSha, name, owner, repository } =
-    validateMergeGroupEvent(event);
+  const { baseSha, headSha, repository } = validateMergeGroupEvent(event);
 
-  const [comparison, queue] = await Promise.all([
-    fetchComparison(repository, baseSha, headSha, token),
-    fetchQueue({ owner, name, branch, token }),
-  ]);
-  const members = resolveMergeGroupMembers({ event, comparison, queue });
+  const comparison = await fetchComparison(repository, baseSha, headSha, token);
+  const members = resolveMergeGroupMembers({ event, comparison });
   const pullRequests = await Promise.all(
     members.map(member => fetchPullRequest(repository, member.number, token))
   );


### PR DESCRIPTION
## Description

Repairs the two independent blockers exposed by the first native merge-queue and direct-main production proofs:

- **Merge-group policy:** replace the inaccessible live `mergeQueue` GraphQL lookup with an unprivileged REST evidence chain: authenticated `merge_group` payload, exact `base..head` first-parent comparison, valid GitHub-generated commit identity/signature, bounded membership, and freshly fetched current PR metadata before fork/size policy evaluation.
- **iOS fallback:** wait for both the Profile and Chat drawer surfaces to be geometrically unobscured before tapping them, preserving the real draft round-trip assertion without sleeps or timeout inflation.

The merge-group jobs remain secret-free and use only `contents: read` plus `pull-requests: read`. No production runtime, repository setting, merge-queue controller, deployment, database, or environment-variable behavior changes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Chore

## Testing

- [x] Unit tests pass
- [x] Targeted iOS UI regression passes
- [x] New regression tests added

### Bug-to-Test Rule

- [x] Regression tests added or updated
- [x] `bug-to-test: satisfied`

Evidence to finalize before push:

- `pnpm biome check --write <changed paths>`
- `pnpm exec vitest run --config scripts/vitest.config.mts scripts/lib/__tests__/merge-group-member-policy.test.mjs scripts/lib/__tests__/merge-group-workflow-contract.test.mjs`
- Exact failed merge-group replay for both `--policy=fork` and `--policy=size`
- `pnpm run ios:lint`
- Exact focused `JovieUITests.testChatComposerPreservesDraftAcrossShellNavigation` passed 3/3; trimming either required geometry gate reproduced the transition failure 2/2

## Risk and Rollback

- Merge-group member discovery still fails closed on malformed events, comparisons, generated-commit provenance, group size, or current PR metadata.
- Combined-head workflows receive no App credential or repository secret.
- The iOS change is test-harness synchronization only; the draft preservation and shell-navigation product assertions remain intact.
- Rollback is the single repair commit.

## Applicability

- Icon usage: not applicable
- Accessibility/browser testing: not applicable; no product UI changes
- Database changes: none
- Environment variables: none
- Design skill evidence: `design-canonical: not applicable`

## Post-merge Proof

Re-enroll one exact-head PR as a native queue canary only after this source PR is green, then verify both merge-group policy contexts and the deeper combined-head CI before normal draining resumes.

Related to #14469 and #14484.
