### PR TITLE
fix(ci): unblock fixed runner routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      runner: ${{ steps.route.outputs.runner }}
+      # Actions suppresses job outputs that resemble configured masked values.
+      # Keep runner labels local to the trusted workflow and export only this enum.
+      runner_class: ${{ steps.route.outputs.runner_class }}
     steps:
       - name: Checkout trusted runner routing policy
         continue-on-error: true
@@ -383,20 +385,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          runner='ubuntu-latest'
+          runner_class='hosted'
+          runner_label='ubuntu-latest'
           if [ "$HEARTBEAT_HEALTH" = 'up' ]; then
-            runner='jovie-runner'
+            runner_class='fixed'
+            runner_label='jovie-runner'
           fi
 
-          case "$runner" in
-            jovie-runner|ubuntu-latest) ;;
+          case "$runner_class" in
+            fixed|hosted) ;;
             *)
-              echo "::warning::Invalid runner route '$runner'; using ubuntu-latest."
-              runner='ubuntu-latest'
+              echo "::warning::Invalid runner class '$runner_class'; using ubuntu-latest."
+              runner_class='hosted'
+              runner_label='ubuntu-latest'
               ;;
           esac
-          echo "runner=$runner" >> "$GITHUB_OUTPUT"
-          echo "::notice::Unit runner route: $runner — $HEARTBEAT_EVIDENCE"
+          echo "runner_class=$runner_class" >> "$GITHUB_OUTPUT"
+          echo "::notice::Unit runner route: $runner_label — $HEARTBEAT_EVIDENCE"
 
   # ── Centralized deterministic path-change detection ────────────────────
   # Source and combined heads compute their own exact diff. The former
@@ -2849,7 +2854,7 @@ jobs:
     # observation routes this run to hosted capacity before the matrix is
     # created. Two shards per candidate cap fixed-pool use at four, preserving
     # anti-slam headroom for Runner Heartbeat and emergency work.
-    runs-on: ${{ needs.ci-unit-runner-route.outputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ needs.ci-unit-runner-route.outputs.runner_class == 'fixed' && 'jovie-runner' || 'ubuntu-latest' }}
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- **[internal] Fixed-pool unit routing:** healthy runner heartbeats now select the fixed CI pool through a non-sensitive route token, preserving hosted fail-closed fallback without GitHub suppressing the runner decision.
 - **[internal] Governed Vercel agent skills:** Jovie now pins the reviewed AI SDK, React performance, and React composition skills; a Jovie-owned discovery workflow and CI/pre-commit guard reject OpenReview, broad or global installs, missing policy overlays, and malformed source pins.
 - **[internal] Repository artifact hygiene guardrails (JOV-4264):** CI and pre-commit checks reject recursive/generated paths, temporary files, root screenshots, unapproved binaries, oversized payloads, and repository-wide file/byte/binary budget overruns.
 - **[internal] Bounded artifact lifecycle helpers:** owned-output, atomic issue-output, run-retention, generated-artifact retention, performance-artifact retention, and local-runtime cleanup helpers now cover QA, AgentOS, Hermes, Design Lab, profile review, iOS performance, and screenshot producers with fail-closed symlink and race protections.

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1262,13 +1262,14 @@ describe('unit-test runner capacity', () => {
     expect(routeJob).toContain('runs-on: ubuntu-latest');
     expect(routeJob).toContain('ref: main');
     expect(routeJob).toContain('continue-on-error: true');
-    expect(routeJob).toContain("runner='ubuntu-latest'");
+    expect(routeJob).toContain("runner_class='hosted'");
     expect(routeJob).toContain('.github/scripts/query-runner-heartbeat.sh');
     expect(routeJob).toContain('[ "$HEARTBEAT_HEALTH" = \'up\' ]');
-    expect(routeJob).toContain('jovie-runner|ubuntu-latest');
+    expect(routeJob).toContain('fixed|hosted');
+    expect(routeJob).not.toContain('runner: ${{ steps.route.outputs.runner }}');
     expect(routeJob).not.toContain('secrets.');
     expect(unitJob).toContain(
-      "runs-on: ${{ needs.ci-unit-runner-route.outputs.runner || 'ubuntu-latest' }}"
+      "runs-on: ${{ needs.ci-unit-runner-route.outputs.runner_class == 'fixed' && 'jovie-runner' || 'ubuntu-latest' }}"
     );
     expect(unitJob).not.toContain('vars.CI_UNIT_RUNNER');
     expect(unitJob).toContain('max-parallel: 2');

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -118,12 +118,13 @@ describe('merge_group workflow contract', () => {
     expect(route).not.toContain('secrets.');
     expect(route).toContain('.github/scripts/query-runner-heartbeat.sh');
     expect(route).toContain('[ "$HEARTBEAT_HEALTH" = \'up\' ]');
-    expect(route).toContain("runner='ubuntu-latest'");
-    expect(route).toContain('jovie-runner|ubuntu-latest');
+    expect(route).toContain("runner_class='hosted'");
+    expect(route).toContain('fixed|hosted');
+    expect(route).not.toContain('runner: ${{ steps.route.outputs.runner }}');
     expect(units).toContain('ci-unit-runner-route');
     expect(units).toContain('ci-merge-group-admission');
     expect(units).toContain(
-      "runs-on: ${{ needs.ci-unit-runner-route.outputs.runner || 'ubuntu-latest' }}"
+      "runs-on: ${{ needs.ci-unit-runner-route.outputs.runner_class == 'fixed' && 'jovie-runner' || 'ubuntu-latest' }}"
     );
     expect(units).not.toContain('vars.CI_UNIT_RUNNER');
     expect(units).toContain('max-parallel: 2');

--- a/scripts/tests/test_runner_routing.py
+++ b/scripts/tests/test_runner_routing.py
@@ -274,13 +274,13 @@ def _run_route_select(
         capture_output=True,
         check=False,
     )
-    route = ""
+    runner_class = ""
     if output.exists():
-        route = output.read_text(encoding="utf-8").strip().split("=", 1)[1]
-    return result, route
+        runner_class = output.read_text(encoding="utf-8").strip().split("=", 1)[1]
+    return result, runner_class
 
 
-def test_route_selects_only_allowlisted_fixed_or_hosted_labels(tmp_path: Path) -> None:
+def test_route_emits_only_non_sensitive_fixed_or_hosted_class(tmp_path: Path) -> None:
     fixed_result, fixed = _run_route_select(tmp_path / "fixed", "up")
     hosted_dir = tmp_path / "hosted"
     hosted_dir.mkdir()
@@ -292,9 +292,9 @@ def test_route_selects_only_allowlisted_fixed_or_hosted_labels(tmp_path: Path) -
     assert fixed_result.returncode == 0, fixed_result.stderr
     assert hosted_result.returncode == 0, hosted_result.stderr
     assert missing_result.returncode == 0, missing_result.stderr
-    assert fixed == "jovie-runner"
-    assert hosted == "ubuntu-latest"
-    assert missing == "ubuntu-latest"
+    assert fixed == "fixed"
+    assert hosted == "hosted"
+    assert missing == "hosted"
 
 
 def test_prelanding_missing_trusted_helper_routes_hosted(tmp_path: Path) -> None:
@@ -329,7 +329,7 @@ def test_prelanding_missing_trusted_helper_routes_hosted(tmp_path: Path) -> None
     assert "trusted heartbeat helper unavailable" in outputs["evidence"]
     route_result, route = _run_route_select(tmp_path / "route", outputs["health"])
     assert route_result.returncode == 0, route_result.stderr
-    assert route == "ubuntu-latest"
+    assert route == "hosted"
 
 
 def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
@@ -355,17 +355,20 @@ def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
     assert "secrets." not in route
     assert "GH_TOKEN: ${{ github.token }}" in route
     assert "HEARTBEAT_API_TIMEOUT_SECONDS: '20'" in route
-    assert "jovie-runner|ubuntu-latest" in route
-    assert "runner='ubuntu-latest'" in route
+    assert "fixed|hosted" in route
+    assert "runner_class='hosted'" in route
+    assert "runner: ${{ steps.route.outputs.runner }}" not in route
     assert query.count('timeout "${HEARTBEAT_API_TIMEOUT_SECONDS}s" gh api') == 2
     assert 'head_repository.full_name == $repo' in query
     assert '.[0].run_id == $run_id' in query
     assert '.[0].head_sha == $head_sha' in query
     assert 'index("jovie-runner") != null' in query
-    assert "needs: [ci-path-changes, ci-unit-runner-route]" in units
     assert (
-        "runs-on: ${{ needs.ci-unit-runner-route.outputs.runner || "
-        "'ubuntu-latest' }}"
+        "[ci-path-changes, ci-unit-runner-route, ci-merge-group-admission]" in units
+    )
+    assert (
+        "runs-on: ${{ needs.ci-unit-runner-route.outputs.runner_class == "
+        "'fixed' && 'jovie-runner' || 'ubuntu-latest' }}"
     ) in units
     assert "vars.CI_UNIT_RUNNER" not in units
     assert "max-parallel: 2" in units


### PR DESCRIPTION
## Summary

- Export only `runner_class=fixed|hosted` from the trusted runner-route job, avoiding GitHub's secret-like job-output suppression of the literal runner label.
- Map that enum to literal `jovie-runner` or `ubuntu-latest` labels at the downstream unit job.
- Preserve the hosted fail-closed fallback and `max-parallel: 2` anti-slam cap.

Live evidence: direct-main run 29682034021 found a fresh healthy heartbeat and selected the fixed label, then GitHub logged `Skip output 'runner' since it may contain secret`; unit shards consequently ran on `ubuntu-latest`.

## Bug-to-Test

bug-to-test: satisfied

Regression coverage proves healthy, down, and missing heartbeat routes emit only the non-sensitive enum and locks the downstream label mapping.

## Test Coverage

All changed CI paths have structural contract coverage.

- Python runner-routing contracts: 9 passed
- Merge-group workflow contracts: 12 passed
- Deploy workflow contracts: 70 passed

## Pre-Landing Review

No issues found. The enum is exhaustive (`fixed|hosted`), missing output maps to hosted, and literal self-hosted selection remains gated by fresh heartbeat evidence.

## Design Review

No frontend files changed; design review and React performance guidance are not applicable.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN. The diff only repairs unit-runner selection and its deterministic contracts.

## Plan Completion

No plan file detected.

## Linear follow-ups

Linear follow-ups: none.

## Verification Results

- Node 22.23.1 / pnpm 9.15.4
- `actionlint` on `.github/workflows/ci.yml`
- `pnpm ci:harness:check`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write apps/web` (7,123 files, no fixes)
- `pnpm --filter @jovie/web run test:bug-to-test`
- Signed commit verified locally with ED25519 fingerprint `SHA256:9eE14ApL9SJiyLhLh7e1Cp2aVp6wtCffo3LA4iHPlp4`

## Test plan

- [x] Healthy heartbeat selects the fixed class without exporting a runner label.
- [x] Down, missing, or malformed routing evidence selects hosted capacity.
- [x] Downstream mapping retains `max-parallel: 2`.
