### PR TITLE
fix(ci): detect nested migration paths

### DIFF
--- a/apps/web/scripts/check-migrations.sh
+++ b/apps/web/scripts/check-migrations.sh
@@ -61,7 +61,7 @@ fi
 log_info "Checking migrations against base: $BASE_BRANCH"
 
 # Get list of changed files in migrations directory
-CHANGED_FILES=$(git diff --name-status "$BASE_BRANCH"...HEAD -- "$MIGRATIONS_DIR" 2>/dev/null || echo "")
+CHANGED_FILES=$(git diff --name-status --relative "$BASE_BRANCH"...HEAD -- "$MIGRATIONS_DIR" 2>/dev/null || echo "")
 
 if [ -z "$CHANGED_FILES" ]; then
     log_success "No migration changes detected"

--- a/scripts/lib/__tests__/ci-harness.test.mjs
+++ b/scripts/lib/__tests__/ci-harness.test.mjs
@@ -1,6 +1,13 @@
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   buildCiHarnessArtifact,
@@ -34,6 +41,52 @@ const EXPECTED_MERGE_GATE_NAMES = [
 ];
 
 describe('ci-harness manifest', () => {
+  it('counts migration files relative to the apps/web working directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'jovie-migration-guard-'));
+    const webRoot = resolve(root, 'apps/web');
+    const migrations = resolve(webRoot, 'drizzle/migrations');
+    const runGit = (...args) =>
+      spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+
+    try {
+      mkdirSync(migrations, { recursive: true });
+      writeFileSync(resolve(migrations, '0080_existing.sql'), 'SELECT 1;\n');
+      expect(runGit('init', '-q').status).toBe(0);
+      expect(runGit('config', 'user.name', 'Migration Guard Test').status).toBe(
+        0
+      );
+      expect(
+        runGit('config', 'user.email', 'migration-guard@example.com').status
+      ).toBe(0);
+      expect(runGit('add', '.').status).toBe(0);
+      expect(runGit('commit', '-q', '--no-gpg-sign', '-m', 'base').status).toBe(
+        0
+      );
+      const base = runGit('rev-parse', 'HEAD').stdout.trim();
+
+      writeFileSync(resolve(migrations, '0081_new.sql'), 'SELECT 2;\n');
+      expect(runGit('add', '.').status).toBe(0);
+      expect(
+        runGit('commit', '-q', '--no-gpg-sign', '-m', 'migration').status
+      ).toBe(0);
+
+      const result = spawnSync(
+        'bash',
+        [resolve(REPO_ROOT, 'apps/web/scripts/check-migrations.sh'), base],
+        {
+          cwd: webRoot,
+          encoding: 'utf8',
+          env: { ...process.env, SKIP_MIGRATION_GUARD: '' },
+        }
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('A\tdrizzle/migrations/0081_new.sql');
+      expect(result.stdout).toContain('Added: 1 files');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('validates the checked-in manifest', () => {
     const validation = validateCiHarnessManifest(manifest);
     expect(validation.errors).toEqual([]);


### PR DESCRIPTION
## Summary
- make Migration Guard emit paths relative to its `apps/web` working directory
- add a behavioral regression that creates a nested Git repo fixture and proves a new migration is counted

## Root cause
CI runs `check-migrations.sh` after `cd apps/web`, but `git diff` emitted repo-root paths such as `apps/web/drizzle/migrations/0082_real_peter_parker.sql`. The parser only accepts `drizzle/migrations/**`, so it silently reported `Added: 0`.

## Exact evidence
- base: `23eb0f7c03af2efb4687787cf05fea0fb1506970`
- before, against original PR #14452 head/base: the guard listed `A apps/web/drizzle/migrations/0082_real_peter_parker.sql` but summarized `Added: 0`
- after, against the same untouched PR #14452 head/base: it listed `A drizzle/migrations/0082_real_peter_parker.sql` and summarized `Added: 1`, `Violations: 0`

## Verification (Node 22.23.1)
- `bash -n apps/web/scripts/check-migrations.sh`
- `pnpm ci:harness:check`
- `pnpm run ci:control:test` — 9 files, 175 tests passed
- focused migration regression — 32 tests passed
- Biome on the changed JS test
- pre-push typecheck and repo lint passed

## Pre-push disclosure
The selector treated this two-file guard fix as a full-web change and began unrelated Playwright/artifact plus full Vitest work. One 262-file chunk completed (1,910 passed, 39 skipped); the next chunk was making unrelated progress when it was stopped to avoid an unbounded serial suite. The push used the documented `JOVIE_SKIP_PRE_PUSH_GATE=1` escape after the exact behavioral red/green, shell syntax, harness, control, typecheck, lint, and Biome checks above were green.

No profile branch, migration artifact, workflow, ruleset, queue entry, or production setting was changed.