### PR TITLE
fix(ci): neutralize superseded release observers

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -129,6 +129,64 @@ jobs:
             exit 1
           fi
 
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            run_record="$(gh api \
+              "repos/$REPOSITORY/actions/runs/$TRIGGER_RUN_ID/attempts/$TRIGGER_RUN_ATTEMPT")"
+            workflow_record="$(gh api \
+              "repos/$REPOSITORY/actions/workflows/$TRIGGER_WORKFLOW_ID")"
+            jq -e \
+              --arg workflow_id "$TRIGGER_WORKFLOW_ID" '
+                type == "object" and
+                (.id | type == "number" and . >= 1 and floor == .) and
+                (.id | tostring) == $workflow_id and
+                .name == "Production Controller" and
+                .path == ".github/workflows/production-controller.yml"
+              ' >/dev/null <<<"$workflow_record" || {
+              echo "::error::Production Controller workflow identity was not proven."
+              exit 1
+            }
+            controller_generation_selector='
+              if (
+                type == "object" and
+                (.id | type == "number" and . >= 1 and floor == .) and
+                (.id | tostring) == $run_id and
+                (.run_attempt | type == "number" and . >= 1 and floor == .) and
+                (.run_attempt | tostring) == $run_attempt and
+                (.workflow_id | type == "number" and . >= 1 and floor == .) and
+                (.workflow_id | tostring) == $workflow_id and
+                .head_sha == $transport_sha and
+                .head_branch == "main" and
+                .head_repository.full_name == $repo and
+                .event == "workflow_run" and
+                .path == ".github/workflows/production-controller.yml" and
+                .status == "completed" and
+                .conclusion == "success" and
+                (.display_title | type == "string" and
+                  test("^Production Controller [0-9a-f]{40} from CI [1-9][0-9]* attempt [1-9][0-9]*$"))
+              ) then
+                .display_title
+                | capture("^Production Controller (?<generation>[0-9a-f]{40}) from CI [1-9][0-9]* attempt [1-9][0-9]*$")
+                | .generation
+              else
+                empty
+              end
+          '
+            if ! controller_generation="$(jq -er \
+              --arg repo "$REPOSITORY" \
+              --arg run_id "$TRIGGER_RUN_ID" \
+              --arg run_attempt "$TRIGGER_RUN_ATTEMPT" \
+              --arg workflow_id "$TRIGGER_WORKFLOW_ID" \
+              --arg transport_sha "$release_sha" \
+              "$controller_generation_selector" <<<"$run_record")"; then
+              echo "::error::Exact Production Controller attempt evidence did not match the workflow_run signal."
+              exit 1
+            fi
+            if [ "$controller_generation" != "$release_sha" ]; then
+              echo "::notice::Production Controller generation $controller_generation was superseded before desktop observer dispatch; transport head is $release_sha."
+              exit 0
+            fi
+          fi
+
           echo "environment=$environment" >> "$GITHUB_OUTPUT"
           current_main_sha="$(gh api "repos/$REPOSITORY/commits/main" --jq '.sha // empty')"
           [[ "$current_main_sha" =~ ^[0-9a-f]{40}$ ]] || {
@@ -282,42 +340,6 @@ jobs:
 
           production_proven=false
           if [ "$EVENT_NAME" = "workflow_run" ]; then
-            run_record="$(gh api \
-              "repos/$REPOSITORY/actions/runs/$TRIGGER_RUN_ID/attempts/$TRIGGER_RUN_ATTEMPT")"
-            jq -e \
-              --arg repo "$REPOSITORY" \
-              --arg run_id "$TRIGGER_RUN_ID" \
-              --arg run_attempt "$TRIGGER_RUN_ATTEMPT" \
-              --arg workflow_id "$TRIGGER_WORKFLOW_ID" \
-              --arg sha "$release_sha" '
-                type == "object" and
-                (.id | tostring) == $run_id and
-                (.run_attempt | tostring) == $run_attempt and
-                (.workflow_id | tostring) == $workflow_id and
-                .head_sha == $sha and
-                .head_branch == "main" and
-                .head_repository.full_name == $repo and
-                .event == "workflow_run" and
-                .path == ".github/workflows/production-controller.yml" and
-                .status == "completed" and
-                .conclusion == "success" and
-                (.display_title | test("^Production Controller " + $sha + " from CI [1-9][0-9]* attempt [1-9][0-9]*$"))
-              ' >/dev/null <<<"$run_record" || {
-              echo "::error::Exact Production Controller attempt evidence did not match the workflow_run signal."
-              exit 1
-            }
-            workflow_record="$(gh api \
-              "repos/$REPOSITORY/actions/workflows/$TRIGGER_WORKFLOW_ID")"
-            jq -e \
-              --arg workflow_id "$TRIGGER_WORKFLOW_ID" '
-                type == "object" and
-                (.id | tostring) == $workflow_id and
-                .name == "Production Controller" and
-                .path == ".github/workflows/production-controller.yml"
-              ' >/dev/null <<<"$workflow_record" || {
-              echo "::error::Production Controller workflow identity was not proven."
-              exit 1
-            }
             jobs_json="$(gh api --paginate --slurp \
               "repos/$REPOSITORY/actions/runs/$TRIGGER_RUN_ID/attempts/$TRIGGER_RUN_ATTEMPT/jobs?per_page=100")"
             jq -e '

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -97,16 +97,6 @@ jobs:
             exit 1
           fi
 
-          current_main_sha="$(gh api "repos/$REPOSITORY/commits/main" --jq '.sha // empty')"
-          [[ "$current_main_sha" =~ ^[0-9a-f]{40}$ ]] || {
-            echo "::error::Could not resolve exact current main for TestFlight authorization."
-            exit 1
-          }
-          if [ "$current_main_sha" != "$release_sha" ]; then
-            echo "::notice::TestFlight generation $release_sha was superseded by $current_main_sha."
-            exit 0
-          fi
-
           production_controller_workflow="$(gh api \
             "repos/$REPOSITORY/actions/workflows/production-controller.yml")"
           jq -e '
@@ -120,6 +110,61 @@ jobs:
           }
           production_controller_workflow_id="$(jq -r '.id | tostring' \
             <<<"$production_controller_workflow")"
+
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            run_record="$(gh api \
+              "repos/$REPOSITORY/actions/runs/$TRIGGER_RUN_ID/attempts/$TRIGGER_RUN_ATTEMPT")"
+            controller_generation_selector='
+              if (
+                type == "object" and
+                (.id | type == "number" and . >= 1 and floor == .) and
+                (.id | tostring) == $run_id and
+                (.run_attempt | type == "number" and . >= 1 and floor == .) and
+                (.run_attempt | tostring) == $run_attempt and
+                (.workflow_id | type == "number" and . >= 1 and floor == .) and
+                (.workflow_id | tostring) == $workflow_id and
+                .head_sha == $transport_sha and
+                .head_branch == "main" and
+                .head_repository.full_name == $repo and
+                .event == "workflow_run" and
+                .path == ".github/workflows/production-controller.yml" and
+                .status == "completed" and
+                .conclusion == "success" and
+                (.display_title | type == "string" and
+                  test("^Production Controller [0-9a-f]{40} from CI [1-9][0-9]* attempt [1-9][0-9]*$"))
+              ) then
+                .display_title
+                | capture("^Production Controller (?<generation>[0-9a-f]{40}) from CI [1-9][0-9]* attempt [1-9][0-9]*$")
+                | .generation
+              else
+                empty
+              end
+          '
+            if ! controller_generation="$(jq -er \
+              --arg repo "$REPOSITORY" \
+              --arg run_id "$TRIGGER_RUN_ID" \
+              --arg run_attempt "$TRIGGER_RUN_ATTEMPT" \
+              --arg workflow_id "$production_controller_workflow_id" \
+              --arg transport_sha "$release_sha" \
+              "$controller_generation_selector" <<<"$run_record")"; then
+              echo "::error::Exact Production Controller attempt evidence did not match the workflow_run signal."
+              exit 1
+            fi
+            if [ "$controller_generation" != "$release_sha" ]; then
+              echo "::notice::Production Controller generation $controller_generation was superseded before TestFlight observer dispatch; transport head is $release_sha."
+              exit 0
+            fi
+          fi
+
+          current_main_sha="$(gh api "repos/$REPOSITORY/commits/main" --jq '.sha // empty')"
+          [[ "$current_main_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::Could not resolve exact current main for TestFlight authorization."
+            exit 1
+          }
+          if [ "$current_main_sha" != "$release_sha" ]; then
+            echo "::notice::TestFlight generation $release_sha was superseded by $current_main_sha."
+            exit 0
+          fi
 
           prove_existing_production_marker() {
             local expected_sha="$1"
@@ -214,32 +259,6 @@ jobs:
 
           production_proven=false
           if [ "$EVENT_NAME" = "workflow_run" ]; then
-            run_record="$(gh api \
-              "repos/$REPOSITORY/actions/runs/$TRIGGER_RUN_ID/attempts/$TRIGGER_RUN_ATTEMPT")"
-            jq -e \
-              --arg repo "$REPOSITORY" \
-              --arg run_id "$TRIGGER_RUN_ID" \
-              --arg run_attempt "$TRIGGER_RUN_ATTEMPT" \
-              --arg sha "$release_sha" \
-              --arg workflow_id "$production_controller_workflow_id" '
-                type == "object" and
-                (.id | tostring) == $run_id and
-                (.run_attempt | tostring) == $run_attempt and
-                .head_sha == $sha and
-                .head_branch == "main" and
-                .head_repository.full_name == $repo and
-                .event == "workflow_run" and
-                (.workflow_id | tostring) == $workflow_id and
-                .path == ".github/workflows/production-controller.yml" and
-                .status == "completed" and
-                .conclusion == "success" and
-                (.display_title | type == "string" and
-                  test("^Production Controller " + $sha +
-                    " from CI [1-9][0-9]* attempt [1-9][0-9]*$"))
-              ' >/dev/null <<<"$run_record" || {
-              echo "::error::Exact Production Controller attempt evidence did not match the workflow_run signal."
-              exit 1
-            }
             jobs_json="$(gh api --paginate --slurp \
               "repos/$REPOSITORY/actions/runs/$TRIGGER_RUN_ID/attempts/$TRIGGER_RUN_ATTEMPT/jobs?per_page=100")"
             jq -e '

--- a/scripts/lib/__tests__/ci-harness.test.mjs
+++ b/scripts/lib/__tests__/ci-harness.test.mjs
@@ -307,6 +307,125 @@ describe('ci-harness manifest', () => {
     expect(action).not.toContain('secrets.');
   });
 
+  it('neutralizes only well-formed superseded production observer signals', () => {
+    const fixture = JSON.parse(
+      readFileSync(
+        resolve(
+          REPO_ROOT,
+          'scripts/lib/__tests__/fixtures/production-controller-observer-signals.json'
+        ),
+        'utf8'
+      )
+    );
+    const workflows = [
+      {
+        job: 'authorize-release',
+        path: '.github/workflows/ios-testflight.yml',
+        workflowIdentityMarker: 'production_controller_workflow="$(gh api',
+      },
+      {
+        job: 'authorize-release',
+        path: '.github/workflows/desktop-release.yml',
+        workflowIdentityMarker: 'workflow_record="$(gh api',
+      },
+    ];
+
+    for (const observer of workflows) {
+      const workflow = readFileSync(resolve(REPO_ROOT, observer.path), 'utf8');
+      const authorize = extractWorkflowJobBlock(workflow, observer.job);
+      const selectorStartMarker = "controller_generation_selector='\n";
+      const selectorStart = authorize.indexOf(selectorStartMarker);
+      const selectorEnd = authorize.indexOf("\n          '\n", selectorStart);
+
+      expect(selectorStart, observer.path).toBeGreaterThanOrEqual(0);
+      expect(selectorEnd, observer.path).toBeGreaterThan(selectorStart);
+      const selector = authorize.slice(
+        selectorStart + selectorStartMarker.length,
+        selectorEnd
+      );
+      const resolveGeneration = runRecord =>
+        spawnSync(
+          'jq',
+          [
+            '-er',
+            '--arg',
+            'repo',
+            fixture.repository,
+            '--arg',
+            'run_id',
+            fixture.signal.runId,
+            '--arg',
+            'run_attempt',
+            fixture.signal.runAttempt,
+            '--arg',
+            'workflow_id',
+            fixture.signal.workflowId,
+            '--arg',
+            'transport_sha',
+            fixture.signal.transportHeadSha,
+            selector,
+          ],
+          { encoding: 'utf8', input: JSON.stringify(runRecord) }
+        );
+
+      const matching = resolveGeneration(fixture.records.matching);
+      expect(matching.status, matching.stderr).toBe(0);
+      expect(matching.stdout.trim()).toBe(fixture.signal.transportHeadSha);
+
+      const superseded = resolveGeneration(fixture.records.superseded);
+      expect(superseded.status, superseded.stderr).toBe(0);
+      expect(superseded.stdout.trim()).toBe(
+        '23eb0f7c03af2efb4687787cf05fea0fb1506970'
+      );
+      expect(superseded.stdout.trim()).not.toBe(
+        fixture.signal.transportHeadSha
+      );
+
+      const malformed = resolveGeneration(fixture.records.malformedTitle);
+      expect(malformed.status, observer.path).not.toBe(0);
+      const wrongRunIdentity = resolveGeneration({
+        ...fixture.records.matching,
+        id: fixture.records.matching.id + 1,
+      });
+      expect(wrongRunIdentity.status, observer.path).not.toBe(0);
+
+      const workflowIdentity = authorize.indexOf(
+        observer.workflowIdentityMarker
+      );
+      const selectorIndex = authorize.indexOf(
+        'controller_generation_selector='
+      );
+      const neutralIndex = authorize.indexOf(
+        'if [ "$controller_generation" != "$release_sha" ]'
+      );
+      const jobsIndex = authorize.indexOf('jobs_json=', neutralIndex);
+      const currentMainIndex = authorize.indexOf('current_main_sha=');
+      const markerIndex = authorize.indexOf(
+        'if prove_existing_production_marker "$release_sha"',
+        neutralIndex
+      );
+      const authorizedIndex = authorize.indexOf(
+        'echo "authorized=true"',
+        neutralIndex
+      );
+
+      expect(workflowIdentity, observer.path).toBeGreaterThanOrEqual(0);
+      expect(workflowIdentity, observer.path).toBeLessThan(selectorIndex);
+      expect(selectorIndex, observer.path).toBeLessThan(neutralIndex);
+      expect(neutralIndex, observer.path).toBeLessThan(currentMainIndex);
+      expect(neutralIndex, observer.path).toBeLessThan(jobsIndex);
+      expect(neutralIndex, observer.path).toBeLessThan(markerIndex);
+      expect(neutralIndex, observer.path).toBeLessThan(authorizedIndex);
+      expect(authorize.slice(neutralIndex, jobsIndex)).toContain('exit 0');
+      expect(authorize.slice(neutralIndex)).toContain(
+        '.name == "Production Verified"'
+      );
+      expect(authorize.slice(neutralIndex)).toContain(
+        '[ "$verified_count" = "1" ]'
+      );
+    }
+  });
+
   it('keeps build and layout in one hosted merge-group workspace', () => {
     const workflow = readFileSync(
       resolve(REPO_ROOT, '.github/workflows/ci.yml'),

--- a/scripts/lib/__tests__/fixtures/production-controller-observer-signals.json
+++ b/scripts/lib/__tests__/fixtures/production-controller-observer-signals.json
@@ -1,0 +1,62 @@
+{
+  "source": "GitHub Actions Production Controller run 29683753890 observed 2026-07-19",
+  "repository": "JovieInc/Jovie",
+  "signal": {
+    "runId": "29683753890",
+    "runAttempt": "1",
+    "workflowId": "316053388",
+    "transportHeadSha": "d208da0cb385065c8dd8ca794067230e14d366d3"
+  },
+  "workflow": {
+    "id": 316053388,
+    "name": "Production Controller",
+    "path": ".github/workflows/production-controller.yml"
+  },
+  "records": {
+    "matching": {
+      "id": 29683753890,
+      "run_attempt": 1,
+      "workflow_id": 316053388,
+      "head_sha": "d208da0cb385065c8dd8ca794067230e14d366d3",
+      "head_branch": "main",
+      "head_repository": {
+        "full_name": "JovieInc/Jovie"
+      },
+      "event": "workflow_run",
+      "path": ".github/workflows/production-controller.yml",
+      "status": "completed",
+      "conclusion": "success",
+      "display_title": "Production Controller d208da0cb385065c8dd8ca794067230e14d366d3 from CI 29682922411 attempt 1"
+    },
+    "superseded": {
+      "id": 29683753890,
+      "run_attempt": 1,
+      "workflow_id": 316053388,
+      "head_sha": "d208da0cb385065c8dd8ca794067230e14d366d3",
+      "head_branch": "main",
+      "head_repository": {
+        "full_name": "JovieInc/Jovie"
+      },
+      "event": "workflow_run",
+      "path": ".github/workflows/production-controller.yml",
+      "status": "completed",
+      "conclusion": "success",
+      "display_title": "Production Controller 23eb0f7c03af2efb4687787cf05fea0fb1506970 from CI 29682922411 attempt 1"
+    },
+    "malformedTitle": {
+      "id": 29683753890,
+      "run_attempt": 1,
+      "workflow_id": 316053388,
+      "head_sha": "d208da0cb385065c8dd8ca794067230e14d366d3",
+      "head_branch": "main",
+      "head_repository": {
+        "full_name": "JovieInc/Jovie"
+      },
+      "event": "workflow_run",
+      "path": ".github/workflows/production-controller.yml",
+      "status": "completed",
+      "conclusion": "success",
+      "display_title": "Production Controller 23eb0f7c03af2efb4687787cf05fea0fb1506970 from CI 29682922411 attempt 1 trailing"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Strictly cross-prove Production Controller workflow and run identity before observer authorization.
- Parse the exact 40-character controller generation from the bounded display title and success-neutral superseded transport signals before any job, marker, or release work.
- Preserve exact successful Production Verified job plus marker proof for matching generations; malformed evidence remains fail-closed.

## Incident evidence

- Production Controller run 29683753890 transported d208da0c while its strict title identified generation 23eb0f7c.
- That superseded signal produced failing iOS and desktop observer runs 29683760802 and 29683760816.
- A shared fixture reproduces the signal for both observers and covers matching, superseded, malformed-title, and wrong-run-identity cases.

## Verification

- Exact PR-mode ci-fast: all lanes passed, including ios-fast and structural.
- CI controls: 177/177; deploy workflow: 70/70; desktop guard: 14/14.
- CI harness, iOS lint, Biome, and actionlint passed.