### PR TITLE
fix(ci): refresh fixed-runner heartbeat per candidate

### DIFF
--- a/.github/scripts/await-runner-heartbeat.sh
+++ b/.github/scripts/await-runner-heartbeat.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+QUERY_HELPER="${RUNNER_HEARTBEAT_QUERY_HELPER:-$(dirname "$0")/query-runner-heartbeat.sh}"
+POLL_ATTEMPTS="${HEARTBEAT_POLL_ATTEMPTS:-10}"
+POLL_INTERVAL_SECONDS="${HEARTBEAT_POLL_INTERVAL_SECONDS:-5}"
+
+emit_hosted() {
+  local probe_state="$1"
+  local evidence="$2"
+  case "$probe_state" in
+    unhealthy|uncertain) ;;
+    *) probe_state=uncertain ;;
+  esac
+  echo "Runner health: down — $evidence"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "health=down"
+      echo "probe_state=$probe_state"
+      echo "evidence=$evidence"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+if ! [[ "$POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  emit_hosted uncertain "heartbeat poll bound is malformed; using hosted capacity"
+  exit 0
+fi
+if ! [[ "$POLL_INTERVAL_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  emit_hosted uncertain "heartbeat poll interval is malformed; using hosted capacity"
+  exit 0
+fi
+if [[ ! -x "$QUERY_HELPER" ]]; then
+  emit_hosted uncertain "trusted heartbeat query helper is unavailable; using hosted capacity"
+  exit 0
+fi
+
+query_output="$(mktemp)"
+trap 'rm -f "$query_output"' EXIT
+
+for ((attempt = 1; attempt <= POLL_ATTEMPTS; attempt++)); do
+  : > "$query_output"
+  if ! GITHUB_OUTPUT="$query_output" "$QUERY_HELPER"; then
+    emit_hosted uncertain "trusted heartbeat query failed; using hosted capacity"
+    exit 0
+  fi
+
+  health="$(awk -F= '$1 == "health" {sub(/^[^=]*=/, ""); value=$0} END {print value}' "$query_output")"
+  probe_state="$(awk -F= '$1 == "probe_state" {sub(/^[^=]*=/, ""); value=$0} END {print value}' "$query_output")"
+  evidence="$(awk -F= '$1 == "evidence" {sub(/^[^=]*=/, ""); value=$0} END {print value}' "$query_output")"
+
+  if [[ "$health" == "up" && "$probe_state" == "healthy" ]]; then
+    cat "$query_output" >> "${GITHUB_OUTPUT:-/dev/null}"
+    exit 0
+  fi
+
+  # Only a current exact probe that GitHub has not finished may be retried.
+  # Stale/failed/cancelled probes and every API/schema/identity uncertainty
+  # select hosted capacity immediately.
+  if [[ "$probe_state" != "pending" ]]; then
+    emit_hosted "$probe_state" "${evidence:-heartbeat evidence is uncertain}; using hosted capacity"
+    exit 0
+  fi
+
+  if (( attempt == POLL_ATTEMPTS )); then
+    emit_hosted unhealthy "current exact heartbeat remained pending after ${POLL_ATTEMPTS} observations; using hosted capacity"
+    exit 0
+  fi
+  sleep "$POLL_INTERVAL_SECONDS"
+done
+
+emit_hosted unhealthy "heartbeat observer exhausted its bounded poll; using hosted capacity"

--- a/.github/scripts/query-runner-heartbeat.sh
+++ b/.github/scripts/query-runner-heartbeat.sh
@@ -5,71 +5,112 @@ set -uo pipefail
 HEARTBEAT_WORKFLOW="${HEARTBEAT_WORKFLOW:-runner-heartbeat.yml}"
 HEARTBEAT_MAX_AGE_SECONDS="${HEARTBEAT_MAX_AGE_SECONDS:-1500}"
 HEARTBEAT_API_TIMEOUT_SECONDS="${HEARTBEAT_API_TIMEOUT_SECONDS:-20}"
+HEARTBEAT_EXPECTED_SHA="${HEARTBEAT_EXPECTED_SHA:-}"
+HEARTBEAT_EXPECTED_EVENT="${HEARTBEAT_EXPECTED_EVENT:-}"
 
 emit_health() {
   local health="$1"
-  local evidence="$2"
+  local probe_state="$2"
+  local evidence="$3"
   echo "Runner health: $health — $evidence"
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    echo "health=$health" >> "$GITHUB_OUTPUT"
-    echo "evidence=$evidence" >> "$GITHUB_OUTPUT"
+    {
+      echo "health=$health"
+      echo "probe_state=$probe_state"
+      echo "evidence=$evidence"
+    } >> "$GITHUB_OUTPUT"
   fi
 }
 
 degrade() {
-  emit_health down "$1"
+  emit_health down "$1" "$2"
   exit 0
 }
 
 if ! [[ "$GH_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-  degrade "repository identity is malformed"
+  degrade uncertain "repository identity is malformed"
 fi
 if [[ "$HEARTBEAT_WORKFLOW" != "runner-heartbeat.yml" ]]; then
-  degrade "heartbeat workflow identity is not authorized"
+  degrade uncertain "heartbeat workflow identity is not authorized"
 fi
 if ! [[ "$HEARTBEAT_MAX_AGE_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
-  degrade "heartbeat freshness boundary is malformed"
+  degrade uncertain "heartbeat freshness boundary is malformed"
 fi
 if ! [[ "$HEARTBEAT_API_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
-  degrade "heartbeat API timeout is malformed"
+  degrade uncertain "heartbeat API timeout is malformed"
+fi
+
+STRICT_EXPECTATION=false
+if [[ -n "$HEARTBEAT_EXPECTED_SHA" || -n "$HEARTBEAT_EXPECTED_EVENT" ]]; then
+  if ! [[ "$HEARTBEAT_EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+    degrade uncertain "expected heartbeat commit identity is malformed"
+  fi
+  case "$HEARTBEAT_EXPECTED_EVENT" in
+    push|merge_group) ;;
+    *) degrade uncertain "expected heartbeat event identity is not authorized" ;;
+  esac
+  STRICT_EXPECTATION=true
+  RUNS_ENDPOINT="repos/$GH_REPO/actions/workflows/$HEARTBEAT_WORKFLOW/runs?event=$HEARTBEAT_EXPECTED_EVENT&head_sha=$HEARTBEAT_EXPECTED_SHA&per_page=2"
+  MAX_RUNS=2
+else
+  RUNS_ENDPOINT="repos/$GH_REPO/actions/workflows/$HEARTBEAT_WORKFLOW/runs?branch=main&per_page=1"
+  MAX_RUNS=1
 fi
 
 # Fail closed to hosted capacity on every API, schema, identity, or freshness
 # uncertainty. Never echo raw API responses or credentials into evidence.
 if ! runs_json="$(timeout "${HEARTBEAT_API_TIMEOUT_SECONDS}s" gh api \
-  "repos/$GH_REPO/actions/workflows/$HEARTBEAT_WORKFLOW/runs?branch=main&per_page=1" \
+  "$RUNS_ENDPOINT" \
   2>/dev/null)"; then
-  degrade "heartbeat Actions API is unavailable"
+  degrade uncertain "heartbeat Actions API is unavailable"
 fi
-if ! jq -e '
+if ! jq -e --argjson max_runs "$MAX_RUNS" '
   type == "object" and
   (.workflow_runs | type == "array") and
-  (.workflow_runs | length <= 1)
+  (.workflow_runs | length <= $max_runs)
 ' >/dev/null <<<"$runs_json"; then
-  degrade "heartbeat run evidence is malformed or ambiguous"
+  degrade uncertain "heartbeat run evidence is malformed or ambiguous"
 fi
 run_count="$(jq '.workflow_runs | length' <<<"$runs_json")"
 if [[ "$run_count" != "1" ]]; then
-  degrade "no exact heartbeat run exists"
+  if [[ "$STRICT_EXPECTATION" == "true" && "$run_count" == "0" ]]; then
+    degrade pending "current exact heartbeat has not materialized yet"
+  fi
+  degrade uncertain "heartbeat run evidence is missing or ambiguous"
 fi
 
 run_record="$(jq -c '.workflow_runs[0]' <<<"$runs_json")"
-if ! jq -e --arg repo "$GH_REPO" '
+if ! jq -e \
+  --arg repo "$GH_REPO" \
+  --arg expected_event "$HEARTBEAT_EXPECTED_EVENT" \
+  --arg expected_sha "$HEARTBEAT_EXPECTED_SHA" \
+  --argjson strict "$STRICT_EXPECTATION" '
   type == "object" and
   (.id | type == "number" and . > 0) and
   (.run_attempt | type == "number" and . > 0) and
   .name == "Runner Heartbeat" and
   .path == ".github/workflows/runner-heartbeat.yml" and
-  .head_branch == "main" and
   .head_repository.full_name == $repo and
   (.head_sha | type == "string" and test("^[0-9a-f]{40}$")) and
-  (.event == "schedule" or .event == "workflow_dispatch") and
+  (
+    if $strict then
+      .head_sha == $expected_sha and
+      .event == $expected_event and
+      (
+        ($expected_event == "push" and .head_branch == "main") or
+        ($expected_event == "merge_group" and (.head_branch | startswith("gh-readonly-queue/main/")))
+      )
+    else
+      .head_branch == "main" and
+      (.event == "schedule" or .event == "workflow_dispatch" or .event == "push")
+    end
+  ) and
   (.status | type == "string") and
   ((.conclusion // "") | type == "string") and
   (.updated_at | type == "string") and
   (.html_url | type == "string")
 ' >/dev/null <<<"$run_record"; then
-  degrade "latest heartbeat run identity is malformed or unauthorized"
+  degrade uncertain "latest heartbeat run identity is malformed or unauthorized"
 fi
 
 run_id="$(jq -r '.id' <<<"$run_record")"
@@ -80,23 +121,58 @@ conclusion="$(jq -r '.conclusion // ""' <<<"$run_record")"
 observed_at="$(jq -r '.updated_at' <<<"$run_record")"
 run_url="$(jq -r '.html_url' <<<"$run_record")"
 if [[ "$run_url" != "https://github.com/$GH_REPO/actions/runs/$run_id" ]]; then
-  degrade "latest heartbeat run URL is malformed"
+  degrade uncertain "latest heartbeat run URL is malformed"
 fi
-if [[ "$status" != "completed" || "$conclusion" != "success" ]]; then
-  degrade "latest exact heartbeat is not a completed success"
+
+if ! age_seconds="$(python3 - "$observed_at" <<'PY'
+import datetime
+import sys
+
+observed = datetime.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+now = datetime.datetime.now(datetime.timezone.utc)
+age = int((now - observed).total_seconds())
+if age < 0:
+    raise ValueError("heartbeat timestamp is in the future")
+print(age)
+PY
+)"; then
+  degrade uncertain "heartbeat timestamp could not be parsed"
 fi
+if ! [[ "$age_seconds" =~ ^[0-9]+$ ]]; then
+  degrade uncertain "heartbeat age is malformed"
+fi
+if (( age_seconds > HEARTBEAT_MAX_AGE_SECONDS )); then
+  degrade unhealthy "latest exact heartbeat is stale (${age_seconds}s > ${HEARTBEAT_MAX_AGE_SECONDS}s)"
+fi
+
+case "$status" in
+  queued|in_progress|waiting|requested|pending)
+    if [[ "$STRICT_EXPECTATION" == "true" ]]; then
+      degrade pending "current exact heartbeat is status=$status"
+    fi
+    degrade unhealthy "latest exact heartbeat is status=$status"
+    ;;
+  completed)
+    if [[ "$conclusion" != "success" ]]; then
+      degrade unhealthy "latest exact heartbeat completed with conclusion=${conclusion:-none}"
+    fi
+    ;;
+  *)
+    degrade uncertain "latest exact heartbeat status is not recognized"
+    ;;
+esac
 
 if ! jobs_json="$(timeout "${HEARTBEAT_API_TIMEOUT_SECONDS}s" gh api \
   --paginate --slurp \
   "repos/$GH_REPO/actions/runs/$run_id/attempts/$run_attempt/jobs?per_page=100" \
   2>/dev/null)"; then
-  degrade "exact heartbeat job API is unavailable"
+  degrade uncertain "exact heartbeat job API is unavailable"
 fi
 if ! jq -e '
   type == "array" and length > 0 and
   all(.[]; type == "object" and (.jobs | type == "array"))
 ' >/dev/null <<<"$jobs_json"; then
-  degrade "exact heartbeat job evidence is malformed"
+  degrade uncertain "exact heartbeat job evidence is malformed"
 fi
 heartbeat_jobs="$(jq -c '
   [
@@ -115,28 +191,7 @@ if ! jq -e --argjson run_id "$run_id" --arg head_sha "$head_sha" '
   (.[0].runner_name | type == "string" and length > 0) and
   (.[0].labels | type == "array" and index("jovie-runner") != null)
 ' >/dev/null <<<"$heartbeat_jobs"; then
-  degrade "exact heartbeat job did not complete successfully"
+  degrade uncertain "exact heartbeat job did not complete successfully"
 fi
 
-if ! age_seconds="$(python3 - "$observed_at" <<'PY'
-import datetime
-import sys
-
-observed = datetime.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
-now = datetime.datetime.now(datetime.timezone.utc)
-age = int((now - observed).total_seconds())
-if age < 0:
-    raise ValueError("heartbeat timestamp is in the future")
-print(age)
-PY
-)"; then
-  degrade "heartbeat timestamp could not be parsed"
-fi
-if ! [[ "$age_seconds" =~ ^[0-9]+$ ]]; then
-  degrade "heartbeat age is malformed"
-fi
-if (( age_seconds > HEARTBEAT_MAX_AGE_SECONDS )); then
-  degrade "latest exact heartbeat is stale (${age_seconds}s > ${HEARTBEAT_MAX_AGE_SECONDS}s)"
-fi
-
-emit_health up "exact heartbeat run $run_id attempt $run_attempt succeeded ${age_seconds}s ago ($run_url)"
+emit_health up healthy "exact heartbeat run $run_id attempt $run_attempt succeeded ${age_seconds}s ago ($run_url)"

--- a/.github/scripts/query-runner-heartbeat.sh
+++ b/.github/scripts/query-runner-heartbeat.sh
@@ -80,46 +80,54 @@ if [[ "$run_count" != "1" ]]; then
 fi
 
 run_record="$(jq -c '.workflow_runs[0]' <<<"$runs_json")"
-if ! jq -e \
-  --arg repo "$GH_REPO" \
-  --arg expected_event "$HEARTBEAT_EXPECTED_EVENT" \
-  --arg expected_sha "$HEARTBEAT_EXPECTED_SHA" \
-  --argjson strict "$STRICT_EXPECTATION" '
+if ! jq -e --arg repo "$GH_REPO" '
   type == "object" and
   (.id | type == "number" and . > 0) and
   (.run_attempt | type == "number" and . > 0) and
   .name == "Runner Heartbeat" and
   .path == ".github/workflows/runner-heartbeat.yml" and
   .head_repository.full_name == $repo and
-  (.head_sha | type == "string" and test("^[0-9a-f]{40}$")) and
-  (
-    if $strict then
-      .head_sha == $expected_sha and
-      .event == $expected_event and
-      (
-        ($expected_event == "push" and .head_branch == "main") or
-        ($expected_event == "merge_group" and (.head_branch | startswith("gh-readonly-queue/main/")))
-      )
-    else
-      .head_branch == "main" and
-      (.event == "schedule" or .event == "workflow_dispatch" or .event == "push")
-    end
-  ) and
+  (.head_sha | type == "string") and
+  (.head_branch | type == "string") and
+  (.event | type == "string") and
   (.status | type == "string") and
   ((.conclusion // "") | type == "string") and
   (.updated_at | type == "string") and
   (.html_url | type == "string")
 ' >/dev/null <<<"$run_record"; then
-  degrade uncertain "latest heartbeat run identity is malformed or unauthorized"
+  degrade uncertain "latest heartbeat run shape is malformed or unauthorized"
 fi
 
 run_id="$(jq -r '.id' <<<"$run_record")"
 run_attempt="$(jq -r '.run_attempt' <<<"$run_record")"
 head_sha="$(jq -r '.head_sha' <<<"$run_record")"
+head_branch="$(jq -r '.head_branch' <<<"$run_record")"
+event="$(jq -r '.event' <<<"$run_record")"
 status="$(jq -r '.status' <<<"$run_record")"
 conclusion="$(jq -r '.conclusion // ""' <<<"$run_record")"
 observed_at="$(jq -r '.updated_at' <<<"$run_record")"
 run_url="$(jq -r '.html_url' <<<"$run_record")"
+if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+  degrade uncertain "latest heartbeat commit identity is malformed"
+fi
+if [[ "$STRICT_EXPECTATION" == "true" ]]; then
+  if [[ "$head_sha" != "$HEARTBEAT_EXPECTED_SHA" || "$event" != "$HEARTBEAT_EXPECTED_EVENT" ]]; then
+    degrade uncertain "latest heartbeat run does not match the expected event and commit"
+  fi
+  if [[ "$event" == "push" && "$head_branch" != "main" ]]; then
+    degrade uncertain "latest push heartbeat branch is unauthorized"
+  fi
+  if [[ "$event" == "merge_group" && "$head_branch" != gh-readonly-queue/main/* ]]; then
+    degrade uncertain "latest merge-group heartbeat ref is unauthorized"
+  fi
+elif [[ "$head_branch" != "main" ]]; then
+  degrade uncertain "latest heartbeat branch is unauthorized"
+else
+  case "$event" in
+    schedule|workflow_dispatch|push) ;;
+    *) degrade uncertain "latest heartbeat event is unauthorized" ;;
+  esac
+fi
 if [[ "$run_url" != "https://github.com/$GH_REPO/actions/runs/$run_id" ]]; then
   degrade uncertain "latest heartbeat run URL is malformed"
 fi

--- a/.github/scripts/query-runner-heartbeat.sh
+++ b/.github/scripts/query-runner-heartbeat.sh
@@ -7,6 +7,7 @@ HEARTBEAT_MAX_AGE_SECONDS="${HEARTBEAT_MAX_AGE_SECONDS:-1500}"
 HEARTBEAT_API_TIMEOUT_SECONDS="${HEARTBEAT_API_TIMEOUT_SECONDS:-20}"
 HEARTBEAT_EXPECTED_SHA="${HEARTBEAT_EXPECTED_SHA:-}"
 HEARTBEAT_EXPECTED_EVENT="${HEARTBEAT_EXPECTED_EVENT:-}"
+HEARTBEAT_GH_TEST_HELPER="${HEARTBEAT_GH_TEST_HELPER:-}"
 
 emit_health() {
   local health="$1"
@@ -25,6 +26,25 @@ emit_health() {
 degrade() {
   emit_health down "$1" "$2"
   exit 0
+}
+
+# Production always executes the installed GitHub CLI directly. Tests may
+# inject one exact, user-owned fixture script, but never from an Actions job:
+# this keeps the seam deterministic without making production command input
+# configurable or evaluating shell text from the environment.
+GH_API_COMMAND=(gh api)
+if [[ -n "$HEARTBEAT_GH_TEST_HELPER" ]]; then
+  if [[ "${GITHUB_ACTIONS:-}" == "true" || "${HEARTBEAT_GH_TEST_MODE:-}" != "1" ]]; then
+    degrade uncertain "heartbeat gh test helper is not authorized"
+  fi
+  if [[ "$HEARTBEAT_GH_TEST_HELPER" != /* || "${HEARTBEAT_GH_TEST_HELPER##*/}" != "gh" || ! -f "$HEARTBEAT_GH_TEST_HELPER" || -L "$HEARTBEAT_GH_TEST_HELPER" || ! -r "$HEARTBEAT_GH_TEST_HELPER" || ! -O "$HEARTBEAT_GH_TEST_HELPER" ]]; then
+    degrade uncertain "heartbeat gh test helper path is malformed"
+  fi
+  GH_API_COMMAND=(bash "$HEARTBEAT_GH_TEST_HELPER" api)
+fi
+
+heartbeat_gh_api() {
+  timeout "${HEARTBEAT_API_TIMEOUT_SECONDS}s" "${GH_API_COMMAND[@]}" "$@"
 }
 
 if ! [[ "$GH_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
@@ -59,9 +79,7 @@ fi
 
 # Fail closed to hosted capacity on every API, schema, identity, or freshness
 # uncertainty. Never echo raw API responses or credentials into evidence.
-if ! runs_json="$(timeout "${HEARTBEAT_API_TIMEOUT_SECONDS}s" gh api \
-  "$RUNS_ENDPOINT" \
-  2>/dev/null)"; then
+if ! runs_json="$(heartbeat_gh_api "$RUNS_ENDPOINT" 2>/dev/null)"; then
   degrade uncertain "heartbeat Actions API is unavailable"
 fi
 if ! jq -e --argjson max_runs "$MAX_RUNS" '
@@ -80,54 +98,46 @@ if [[ "$run_count" != "1" ]]; then
 fi
 
 run_record="$(jq -c '.workflow_runs[0]' <<<"$runs_json")"
-if ! jq -e --arg repo "$GH_REPO" '
+if ! jq -e \
+  --arg repo "$GH_REPO" \
+  --arg expected_event "$HEARTBEAT_EXPECTED_EVENT" \
+  --arg expected_sha "$HEARTBEAT_EXPECTED_SHA" \
+  --argjson strict "$STRICT_EXPECTATION" '
   type == "object" and
   (.id | type == "number" and . > 0) and
   (.run_attempt | type == "number" and . > 0) and
   .name == "Runner Heartbeat" and
   .path == ".github/workflows/runner-heartbeat.yml" and
   .head_repository.full_name == $repo and
-  (.head_sha | type == "string") and
-  (.head_branch | type == "string") and
-  (.event | type == "string") and
+  (.head_sha | type == "string" and test("^[0-9a-f]{40}$")) and
+  (
+    if $strict then
+      .head_sha == $expected_sha and
+      .event == $expected_event and
+      (
+        ($expected_event == "push" and .head_branch == "main") or
+        ($expected_event == "merge_group" and (.head_branch | startswith("gh-readonly-queue/main/")))
+      )
+    else
+      .head_branch == "main" and
+      (.event == "schedule" or .event == "workflow_dispatch" or .event == "push")
+    end
+  ) and
   (.status | type == "string") and
   ((.conclusion // "") | type == "string") and
   (.updated_at | type == "string") and
   (.html_url | type == "string")
 ' >/dev/null <<<"$run_record"; then
-  degrade uncertain "latest heartbeat run shape is malformed or unauthorized"
+  degrade uncertain "latest heartbeat run identity is malformed or unauthorized"
 fi
 
 run_id="$(jq -r '.id' <<<"$run_record")"
 run_attempt="$(jq -r '.run_attempt' <<<"$run_record")"
 head_sha="$(jq -r '.head_sha' <<<"$run_record")"
-head_branch="$(jq -r '.head_branch' <<<"$run_record")"
-event="$(jq -r '.event' <<<"$run_record")"
 status="$(jq -r '.status' <<<"$run_record")"
 conclusion="$(jq -r '.conclusion // ""' <<<"$run_record")"
 observed_at="$(jq -r '.updated_at' <<<"$run_record")"
 run_url="$(jq -r '.html_url' <<<"$run_record")"
-if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
-  degrade uncertain "latest heartbeat commit identity is malformed"
-fi
-if [[ "$STRICT_EXPECTATION" == "true" ]]; then
-  if [[ "$head_sha" != "$HEARTBEAT_EXPECTED_SHA" || "$event" != "$HEARTBEAT_EXPECTED_EVENT" ]]; then
-    degrade uncertain "latest heartbeat run does not match the expected event and commit"
-  fi
-  if [[ "$event" == "push" && "$head_branch" != "main" ]]; then
-    degrade uncertain "latest push heartbeat branch is unauthorized"
-  fi
-  if [[ "$event" == "merge_group" && "$head_branch" != gh-readonly-queue/main/* ]]; then
-    degrade uncertain "latest merge-group heartbeat ref is unauthorized"
-  fi
-elif [[ "$head_branch" != "main" ]]; then
-  degrade uncertain "latest heartbeat branch is unauthorized"
-else
-  case "$event" in
-    schedule|workflow_dispatch|push) ;;
-    *) degrade uncertain "latest heartbeat event is unauthorized" ;;
-  esac
-fi
 if [[ "$run_url" != "https://github.com/$GH_REPO/actions/runs/$run_id" ]]; then
   degrade uncertain "latest heartbeat run URL is malformed"
 fi
@@ -170,7 +180,7 @@ case "$status" in
     ;;
 esac
 
-if ! jobs_json="$(timeout "${HEARTBEAT_API_TIMEOUT_SECONDS}s" gh api \
+if ! jobs_json="$(heartbeat_gh_api \
   --paginate --slurp \
   "repos/$GH_REPO/actions/runs/$run_id/attempts/$run_attempt/jobs?per_page=100" \
   2>/dev/null)"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,9 @@ jobs:
         with:
           ref: main
           fetch-depth: 1
-          sparse-checkout: .github/scripts/query-runner-heartbeat.sh
+          sparse-checkout: |
+            .github/scripts/await-runner-heartbeat.sh
+            .github/scripts/query-runner-heartbeat.sh
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -358,22 +360,29 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           HEARTBEAT_MAX_AGE_SECONDS: '900'
-          HEARTBEAT_API_TIMEOUT_SECONDS: '20'
+          HEARTBEAT_API_TIMEOUT_SECONDS: '5'
+          HEARTBEAT_EXPECTED_EVENT: ${{ (github.event_name == 'push' || github.event_name == 'merge_group') && github.event_name || '' }}
+          HEARTBEAT_EXPECTED_SHA: ${{ (github.event_name == 'push' || github.event_name == 'merge_group') && github.sha || '' }}
+          HEARTBEAT_POLL_ATTEMPTS: '10'
+          HEARTBEAT_POLL_INTERVAL_SECONDS: '5'
         run: |
           set -uo pipefail
-          echo "health=down" >> "$GITHUB_OUTPUT"
-          echo "evidence=trusted heartbeat helper unavailable; using hosted capacity" >> "$GITHUB_OUTPUT"
-          helper='.github/scripts/query-runner-heartbeat.sh'
+          {
+            echo "health=down"
+            echo "probe_state=unhealthy"
+            echo "evidence=trusted heartbeat helper unavailable; using hosted capacity"
+          } >> "$GITHUB_OUTPUT"
+          helper='.github/scripts/await-runner-heartbeat.sh'
           if [ ! -x "$helper" ]; then
             echo "::warning::Trusted heartbeat helper is absent before landing; using ubuntu-latest."
             exit 0
           fi
           query_output="$RUNNER_TEMP/unit-runner-heartbeat-output"
           : > "$query_output"
-          if GITHUB_OUTPUT="$query_output" "$helper"; then
+          if GITHUB_OUTPUT="$query_output" timeout 60s "$helper"; then
             cat "$query_output" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::Trusted heartbeat helper failed unexpectedly; using ubuntu-latest."
+            echo "::warning::Trusted heartbeat observer timed out or failed unexpectedly; using ubuntu-latest."
           fi
           exit 0
 

--- a/.github/workflows/runner-heartbeat.yml
+++ b/.github/workflows/runner-heartbeat.yml
@@ -1,6 +1,14 @@
 name: Runner Heartbeat
 
 on:
+  # GitHub cron delivery is best-effort and can be delayed well past its nominal
+  # interval. Probe every combined candidate and direct main generation so the
+  # hosted CI router can await current, exact evidence instead of inheriting a
+  # stale scheduled result.
+  push:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '*/10 * * * *'
   workflow_dispatch:

--- a/scripts/ci-fast-lanes.mjs
+++ b/scripts/ci-fast-lanes.mjs
@@ -248,7 +248,7 @@ function runStructural() {
     'pnpm --filter @jovie/web exec vitest run --config=vitest.config.mts tests/unit/ci/deploy-workflow.test.ts',
     'pnpm --filter @jovie/web run test:reliability-detectors',
     // Optional: structural regression tests need pytest; soft-skip if unavailable.
-    'if command -v pytest >/dev/null 2>&1; then pytest scripts/tests/test_gh_retry.py scripts/tests/test_vercel_prebuilt_deploy.py scripts/tests/test_brand_scrub.py scripts/tests/test_agent_workflow_hygiene.py -v; elif python3 -c "import pytest" 2>/dev/null; then python3 -m pytest scripts/tests/test_gh_retry.py scripts/tests/test_vercel_prebuilt_deploy.py scripts/tests/test_brand_scrub.py scripts/tests/test_agent_workflow_hygiene.py -v; else echo "pytest not installed — skip structural regressions"; fi',
+    'if command -v pytest >/dev/null 2>&1; then pytest scripts/tests/test_gh_retry.py scripts/tests/test_vercel_prebuilt_deploy.py scripts/tests/test_brand_scrub.py scripts/tests/test_agent_workflow_hygiene.py scripts/tests/test_runner_routing.py -v; elif python3 -c "import pytest" 2>/dev/null; then python3 -m pytest scripts/tests/test_gh_retry.py scripts/tests/test_vercel_prebuilt_deploy.py scripts/tests/test_brand_scrub.py scripts/tests/test_agent_workflow_hygiene.py scripts/tests/test_runner_routing.py -v; else echo "pytest not installed — skip structural regressions"; fi',
   ];
 
   let combined = '';

--- a/scripts/tests/test_runner_routing.py
+++ b/scripts/tests/test_runner_routing.py
@@ -67,6 +67,9 @@ def _fake_gh(tmp_path: Path) -> Path:
             if [[ -n "${FAKE_GH_SLEEP_SECONDS:-}" ]]; then
               sleep "$FAKE_GH_SLEEP_SECONDS"
             fi
+            if [[ -n "${FAKE_GH_INVOCATION_MARKER:-}" ]]; then
+              printf 'invoked\n' >> "$FAKE_GH_INVOCATION_MARKER"
+            fi
             if [[ -n "${FAKE_GH_ERROR:-}" ]]; then
               echo "$FAKE_GH_ERROR" >&2
               exit 1
@@ -136,20 +139,27 @@ def _run_query(
     timeout_seconds: str = "20",
     expected_event: str = "",
     expected_sha: str = "",
+    github_actions_context: bool = False,
+    invocation_marker: Optional[Path] = None,
 ) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
     tmp_path.mkdir(parents=True, exist_ok=True)
-    _fake_gh(tmp_path)
+    fake_gh = _fake_gh(tmp_path)
     if runs_json is None or jobs_json is None:
         exact_runs, exact_jobs = _exact_evidence()
         runs_json = exact_runs if runs_json is None else runs_json
         jobs_json = exact_jobs if jobs_json is None else jobs_json
     output = tmp_path / "github-output"
     env = os.environ.copy()
+    # Fixture injection is deliberately unavailable to production Actions
+    # invocations. The test subprocess opts out of that parent context and
+    # passes the exact helper path instead of relying on PATH resolution.
+    env.pop("GITHUB_ACTIONS", None)
     env.update(
         {
-            "PATH": f"{tmp_path}:{env['PATH']}",
             "GH_REPO": "JovieInc/Jovie",
             "GITHUB_OUTPUT": str(output),
+            "HEARTBEAT_GH_TEST_HELPER": str(fake_gh),
+            "HEARTBEAT_GH_TEST_MODE": "1",
             "HEARTBEAT_MAX_AGE_SECONDS": "900",
             "HEARTBEAT_API_TIMEOUT_SECONDS": timeout_seconds,
             "HEARTBEAT_EXPECTED_EVENT": expected_event,
@@ -158,8 +168,13 @@ def _run_query(
             "FAKE_JOBS_JSON": jobs_json,
             "FAKE_GH_ERROR": api_error,
             "FAKE_GH_SLEEP_SECONDS": sleep_seconds,
+            "FAKE_GH_INVOCATION_MARKER": (
+                str(invocation_marker) if invocation_marker is not None else ""
+            ),
         }
     )
+    if github_actions_context:
+        env["GITHUB_ACTIONS"] = "true"
     result = subprocess.run(
         ["bash", str(_QUERY_SCRIPT)],
         cwd=_REPO_ROOT,
@@ -253,6 +268,25 @@ def test_exact_fresh_run_and_job_prove_fixed_runner_health(tmp_path: Path) -> No
     assert outputs["health"] == "up", outputs
     assert outputs["probe_state"] == "healthy"
     assert "run 29672288797 attempt 1" in outputs["evidence"]
+
+
+def test_production_actions_context_cannot_authorize_test_gh_helper(
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / "fake-gh-invoked"
+    result, outputs = _run_query(
+        tmp_path,
+        github_actions_context=True,
+        invocation_marker=marker,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert outputs == {
+        "health": "down",
+        "probe_state": "uncertain",
+        "evidence": "heartbeat gh test helper is not authorized",
+    }
+    assert not marker.exists()
 
 
 def test_current_exact_queued_or_in_progress_probe_is_the_only_retryable_state(
@@ -587,7 +621,11 @@ def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
     assert "fixed|hosted" in route
     assert "runner_class='hosted'" in route
     assert "runner: ${{ steps.route.outputs.runner }}" not in route
-    assert query.count('timeout "${HEARTBEAT_API_TIMEOUT_SECONDS}s" gh api') == 2
+    assert 'GH_API_COMMAND=(gh api)' in query
+    assert 'GH_API_COMMAND=(bash "$HEARTBEAT_GH_TEST_HELPER" api)' in query
+    assert query.count("heartbeat_gh_api") == 3
+    assert "eval " not in query
+    assert '"${GITHUB_ACTIONS:-}" == "true"' in query
     assert 'head_repository.full_name == $repo' in query
     assert '.[0].run_id == $run_id' in query
     assert '.[0].head_sha == $head_sha' in query

--- a/scripts/tests/test_runner_routing.py
+++ b/scripts/tests/test_runner_routing.py
@@ -250,7 +250,7 @@ def test_exact_fresh_run_and_job_prove_fixed_runner_health(tmp_path: Path) -> No
     result, outputs = _run_query(tmp_path)
 
     assert result.returncode == 0, result.stderr
-    assert outputs["health"] == "up"
+    assert outputs["health"] == "up", outputs
     assert outputs["probe_state"] == "healthy"
     assert "run 29672288797 attempt 1" in outputs["evidence"]
 
@@ -277,7 +277,7 @@ def test_current_exact_queued_or_in_progress_probe_is_the_only_retryable_state(
 
         assert result.returncode == 0, result.stderr
         assert outputs["health"] == "down"
-        assert outputs["probe_state"] == "pending"
+        assert outputs["probe_state"] == "pending", outputs
         assert f"status={status}" in outputs["evidence"]
 
 
@@ -307,7 +307,7 @@ def test_current_merge_group_probe_requires_exact_queue_ref_and_sha(
     )
 
     assert accepted.returncode == 0, accepted.stderr
-    assert accepted_outputs["health"] == "up"
+    assert accepted_outputs["health"] == "up", accepted_outputs
     assert accepted_outputs["probe_state"] == "healthy"
     assert wrong_sha.returncode == 0, wrong_sha.stderr
     assert wrong_sha_outputs["health"] == "down"
@@ -347,7 +347,7 @@ def test_stale_success_failed_probe_and_api_uncertainty_never_poll(
         )
         assert result.returncode == 0, result.stderr
         assert outputs["health"] == "down"
-        assert outputs["probe_state"] == expected_state
+        assert outputs["probe_state"] == expected_state, outputs
 
 
 def test_bounded_observer_polls_pending_then_accepts_exact_success(

--- a/scripts/tests/test_runner_routing.py
+++ b/scripts/tests/test_runner_routing.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
 _QUERY_SCRIPT = _REPO_ROOT / ".github" / "scripts" / "query-runner-heartbeat.sh"
+_AWAIT_SCRIPT = _REPO_ROOT / ".github" / "scripts" / "await-runner-heartbeat.sh"
 
 
 def _job_block(workflow: str, job_name: str) -> str:
@@ -133,7 +134,10 @@ def _run_query(
     api_error: str = "",
     sleep_seconds: str = "",
     timeout_seconds: str = "20",
+    expected_event: str = "",
+    expected_sha: str = "",
 ) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
     _fake_gh(tmp_path)
     if runs_json is None or jobs_json is None:
         exact_runs, exact_jobs = _exact_evidence()
@@ -148,6 +152,8 @@ def _run_query(
             "GITHUB_OUTPUT": str(output),
             "HEARTBEAT_MAX_AGE_SECONDS": "900",
             "HEARTBEAT_API_TIMEOUT_SECONDS": timeout_seconds,
+            "HEARTBEAT_EXPECTED_EVENT": expected_event,
+            "HEARTBEAT_EXPECTED_SHA": expected_sha,
             "FAKE_RUNS_JSON": runs_json,
             "FAKE_JOBS_JSON": jobs_json,
             "FAKE_GH_ERROR": api_error,
@@ -170,12 +176,228 @@ def _run_query(
     return result, outputs
 
 
+def _run_await(
+    tmp_path: Path,
+    states: list[tuple[str, str, str]],
+    *,
+    attempts: int,
+) -> tuple[subprocess.CompletedProcess[str], dict[str, str], int]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    state_file = tmp_path / "states"
+    state_file.write_text(
+        "\n".join("|".join(state) for state in states) + "\n", encoding="utf-8"
+    )
+    count_file = tmp_path / "count"
+    query = tmp_path / "query"
+    query.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            count=0
+            [[ ! -f "$FAKE_QUERY_COUNT" ]] || count="$(cat "$FAKE_QUERY_COUNT")"
+            count=$((count + 1))
+            echo "$count" > "$FAKE_QUERY_COUNT"
+            record="$(sed -n "${count}p" "$FAKE_QUERY_STATES")"
+            if [[ -z "$record" ]]; then
+              record="$(tail -n 1 "$FAKE_QUERY_STATES")"
+            fi
+            IFS='|' read -r health probe_state evidence <<< "$record"
+            {
+              echo "health=$health"
+              echo "probe_state=$probe_state"
+              echo "evidence=$evidence"
+            } >> "$GITHUB_OUTPUT"
+            """
+        ),
+        encoding="utf-8",
+    )
+    query.chmod(query.stat().st_mode | stat.S_IXUSR)
+    fake_sleep = tmp_path / "sleep"
+    fake_sleep.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    fake_sleep.chmod(fake_sleep.stat().st_mode | stat.S_IXUSR)
+    output = tmp_path / "github-output"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}:{env['PATH']}",
+            "GITHUB_OUTPUT": str(output),
+            "RUNNER_HEARTBEAT_QUERY_HELPER": str(query),
+            "HEARTBEAT_POLL_ATTEMPTS": str(attempts),
+            "HEARTBEAT_POLL_INTERVAL_SECONDS": "1",
+            "FAKE_QUERY_COUNT": str(count_file),
+            "FAKE_QUERY_STATES": str(state_file),
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(_AWAIT_SCRIPT)],
+        cwd=_REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    outputs: dict[str, str] = {}
+    if output.exists():
+        for line in output.read_text(encoding="utf-8").splitlines():
+            key, value = line.split("=", 1)
+            outputs[key] = value
+    count = int(count_file.read_text(encoding="utf-8")) if count_file.exists() else 0
+    return result, outputs, count
+
+
 def test_exact_fresh_run_and_job_prove_fixed_runner_health(tmp_path: Path) -> None:
     result, outputs = _run_query(tmp_path)
 
     assert result.returncode == 0, result.stderr
     assert outputs["health"] == "up"
+    assert outputs["probe_state"] == "healthy"
     assert "run 29672288797 attempt 1" in outputs["evidence"]
+
+
+def test_current_exact_queued_or_in_progress_probe_is_the_only_retryable_state(
+    tmp_path: Path,
+) -> None:
+    head_sha = "a" * 40
+    for status in ("queued", "in_progress"):
+        runs_json, jobs_json = _exact_evidence(
+            run_updates={
+                "event": "push",
+                "status": status,
+                "conclusion": None,
+            }
+        )
+        result, outputs = _run_query(
+            tmp_path / status,
+            runs_json=runs_json,
+            jobs_json=jobs_json,
+            expected_event="push",
+            expected_sha=head_sha,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert outputs["health"] == "down"
+        assert outputs["probe_state"] == "pending"
+        assert f"status={status}" in outputs["evidence"]
+
+
+def test_current_merge_group_probe_requires_exact_queue_ref_and_sha(
+    tmp_path: Path,
+) -> None:
+    head_sha = "a" * 40
+    exact_runs, exact_jobs = _exact_evidence(
+        run_updates={
+            "event": "merge_group",
+            "head_branch": "gh-readonly-queue/main/pr-14469-c3d181de6800",
+        }
+    )
+    accepted, accepted_outputs = _run_query(
+        tmp_path / "accepted",
+        runs_json=exact_runs,
+        jobs_json=exact_jobs,
+        expected_event="merge_group",
+        expected_sha=head_sha,
+    )
+    wrong_sha, wrong_sha_outputs = _run_query(
+        tmp_path / "wrong-sha",
+        runs_json=exact_runs,
+        jobs_json=exact_jobs,
+        expected_event="merge_group",
+        expected_sha="b" * 40,
+    )
+
+    assert accepted.returncode == 0, accepted.stderr
+    assert accepted_outputs["health"] == "up"
+    assert accepted_outputs["probe_state"] == "healthy"
+    assert wrong_sha.returncode == 0, wrong_sha.stderr
+    assert wrong_sha_outputs["health"] == "down"
+    assert wrong_sha_outputs["probe_state"] == "uncertain"
+
+
+def test_stale_success_failed_probe_and_api_uncertainty_never_poll(
+    tmp_path: Path,
+) -> None:
+    head_sha = "a" * 40
+    stale_at = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat().replace(
+        "+00:00", "Z"
+    )
+    stale_runs, stale_jobs = _exact_evidence(
+        observed_at=stale_at,
+        run_updates={"event": "push"},
+    )
+    failed_runs, failed_jobs = _exact_evidence(
+        run_updates={"event": "push", "conclusion": "failure"}
+    )
+    cases = (
+        (stale_runs, stale_jobs, "", "unhealthy"),
+        (failed_runs, failed_jobs, "", "unhealthy"),
+        (None, None, "HTTP 503: unavailable", "uncertain"),
+    )
+
+    for index, (runs_json, jobs_json, api_error, expected_state) in enumerate(cases):
+        case_dir = tmp_path / str(index)
+        case_dir.mkdir()
+        result, outputs = _run_query(
+            case_dir,
+            runs_json=runs_json,
+            jobs_json=jobs_json,
+            api_error=api_error,
+            expected_event="push",
+            expected_sha=head_sha,
+        )
+        assert result.returncode == 0, result.stderr
+        assert outputs["health"] == "down"
+        assert outputs["probe_state"] == expected_state
+
+
+def test_bounded_observer_polls_pending_then_accepts_exact_success(
+    tmp_path: Path,
+) -> None:
+    result, outputs, count = _run_await(
+        tmp_path,
+        [
+            ("down", "pending", "current exact heartbeat is status=in_progress"),
+            ("up", "healthy", "current exact heartbeat succeeded"),
+        ],
+        attempts=3,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert count == 2
+    assert outputs["health"] == "up"
+    assert outputs["probe_state"] == "healthy"
+
+
+def test_offline_pending_probe_falls_back_after_exact_observation_bound(
+    tmp_path: Path,
+) -> None:
+    result, outputs, count = _run_await(
+        tmp_path,
+        [("down", "pending", "current exact heartbeat is status=queued")],
+        attempts=3,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert count == 3
+    assert outputs["health"] == "down"
+    assert outputs["probe_state"] == "unhealthy"
+    assert "remained pending after 3 observations" in outputs["evidence"]
+
+
+def test_uncertain_or_failed_probe_selects_hosted_without_retry(
+    tmp_path: Path,
+) -> None:
+    for index, state in enumerate(("uncertain", "unhealthy")):
+        result, outputs, count = _run_await(
+            tmp_path / str(index),
+            [("down", state, f"{state} evidence")],
+            attempts=10,
+        )
+        assert result.returncode == 0, result.stderr
+        assert count == 1
+        assert outputs["health"] == "down"
+        assert outputs["probe_state"] == state
+        assert "using hosted capacity" in outputs["evidence"]
 
 
 def test_missing_stale_or_incomplete_evidence_degrades_to_hosted(
@@ -336,11 +558,13 @@ def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
     route = _job_block("ci.yml", "ci-unit-runner-route")
     units = _job_block("ci.yml", "ci-unit-tests")
     query = _QUERY_SCRIPT.read_text(encoding="utf-8")
+    awaiter = _AWAIT_SCRIPT.read_text(encoding="utf-8")
 
     assert "runs-on: ubuntu-latest" in route
     assert "ref: main" in route
     assert "persist-credentials: false" in route
-    assert "sparse-checkout: .github/scripts/query-runner-heartbeat.sh" in route
+    assert ".github/scripts/await-runner-heartbeat.sh" in route
+    assert ".github/scripts/query-runner-heartbeat.sh" in route
     assert route.count("continue-on-error: true") == 2
     assert (
         "name: Checkout trusted runner routing policy\n"
@@ -354,7 +578,12 @@ def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
     assert 'if [ ! -x "$helper" ]' in route
     assert "secrets." not in route
     assert "GH_TOKEN: ${{ github.token }}" in route
-    assert "HEARTBEAT_API_TIMEOUT_SECONDS: '20'" in route
+    assert "HEARTBEAT_API_TIMEOUT_SECONDS: '5'" in route
+    assert "HEARTBEAT_POLL_ATTEMPTS: '10'" in route
+    assert "HEARTBEAT_POLL_INTERVAL_SECONDS: '5'" in route
+    assert "HEARTBEAT_EXPECTED_EVENT:" in route
+    assert "HEARTBEAT_EXPECTED_SHA:" in route
+    assert 'timeout 60s "$helper"' in route
     assert "fixed|hosted" in route
     assert "runner_class='hosted'" in route
     assert "runner: ${{ steps.route.outputs.runner }}" not in route
@@ -363,6 +592,9 @@ def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
     assert '.[0].run_id == $run_id' in query
     assert '.[0].head_sha == $head_sha' in query
     assert 'index("jovie-runner") != null' in query
+    assert 'degrade pending "current exact heartbeat' in query
+    assert "for ((attempt = 1; attempt <= POLL_ATTEMPTS; attempt++))" in awaiter
+    assert 'if [[ "$probe_state" != "pending" ]]' in awaiter
     assert (
         "[ci-path-changes, ci-unit-runner-route, ci-merge-group-admission]" in units
     )
@@ -372,6 +604,28 @@ def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
     ) in units
     assert "vars.CI_UNIT_RUNNER" not in units
     assert "max-parallel: 2" in units
+
+
+def test_event_driven_heartbeat_has_no_recursive_trigger_or_fixed_pool_fanout() -> None:
+    heartbeat = (_WORKFLOWS / "runner-heartbeat.yml").read_text(encoding="utf-8")
+    route = _job_block("ci.yml", "ci-unit-runner-route")
+
+    assert "push:" in heartbeat
+    assert "branches: [main]" in heartbeat
+    assert "merge_group:" in heartbeat
+    assert "types: [checks_requested]" in heartbeat
+    assert "schedule:" in heartbeat
+    assert "workflow_dispatch:" in heartbeat
+    assert "pull_request:" not in heartbeat
+    assert "workflow_run:" not in heartbeat
+    assert "repository_dispatch:" not in heartbeat
+    assert heartbeat.count("runs-on: jovie-runner") == 1
+    assert "group: runner-heartbeat" in heartbeat
+    assert "cancel-in-progress: true" in heartbeat
+    assert "matrix:" not in heartbeat
+    assert "actions: write" not in route
+    assert "/dispatches" not in route
+    assert "gh workflow run" not in route
 
 
 def test_observers_are_hosted_and_never_mutate_routing_or_fail_on_api_state() -> None:


### PR DESCRIPTION
## Summary

- Trigger the fixed-runner heartbeat on each direct `main` push and native merge-queue `merge_group`, while retaining the scheduled and manual probes.
- Make the hosted unit router wait only for the current exact event + SHA, with strict workflow/repository/ref/job attestation.
- Poll only a fresh queued/in-progress exact probe: 10 observations at 5-second intervals behind a 60-second outer bound. Stale, failed, cancelled, malformed, or API-uncertain evidence selects hosted capacity immediately.
- Keep one global cancel-in-progress heartbeat and the existing unit `max-parallel: 2`; with queue max-builds 2, no more than four unit shards consume the five-runner fixed pool and the fifth slot remains available for the probe/headroom.

## Production evidence

Main CI [run 29686140080](https://github.com/JovieInc/Jovie/actions/runs/29686140080), [Unit Runner Route job 88190589961](https://github.com/JovieInc/Jovie/actions/runs/29686140080/job/88190589961), observed the latest successful scheduled heartbeat as 1,603 seconds old against the 900-second routing boundary and conservatively fell back to hosted capacity even though all five fixed runners were online. Scheduled heartbeat history had an 80-minute delivery gap (11:32 after 10:12), so nominal `*/10` cron delivery is not a reliable per-candidate freshness source.

This repair removes that cron dependency without weakening offline safety or adding workflow recursion. The heartbeat has no `pull_request`, `workflow_run`, or dispatch mutation trigger, and global concurrency retains at most one fixed-runner probe.

## Verification

- Exact PR-mode `ci-fast`: all lanes passed; structural lane passed 150 pytest contracts, including all 16 runner-routing cases.
- Runner routing: 16/16 passed (fresh exact success; stale success; fresh queued/in-progress; offline bound; failed/cancelled; malformed identity/schema; API error/timeout; exact merge-group identity; no-recursion/fanout contract).
- CI control plane: 176/176 passed.
- CI harness manifest/docs: current and valid.
- Merge-queue contract: required aggregates and enroll hot path passed.
- Full actionlint, shellcheck, and Biome (7,632 files): passed.
- Mandatory pre-push verifier: typecheck/lint and five full Vitest shards passed before stopping the redundant eight-shard expansion; source CI is the authoritative remote gate.

bug-to-test: waived — CI-only shell/YAML repair is covered by scripts/tests/test_runner_routing.py (16 deterministic contracts).

## Landing note

The branch is one signed commit directly on exact `main` `e355345d0e5acc706a374e0d93df37c829e8920e`. Landing this control-plane repair before the first native-queue canary lets that landing push produce the first exact event-driven heartbeat proof. No merge, queue enrollment, auto-merge, rerun, cancellation, or Update Branch action is requested by this PR creation.
