### PR TITLE
fix(ci): tolerate bounded alias probe resets

### DIFF
--- a/.github/scripts/verify-production-alias.sh
+++ b/.github/scripts/verify-production-alias.sh
@@ -9,6 +9,7 @@ vercel_cli="${VERCEL_CLI:-./node_modules/.bin/vercel}"
 max_attempts="${PRODUCTION_ALIAS_MAX_ATTEMPTS:-15}"
 retry_seconds="${PRODUCTION_ALIAS_RETRY_SECONDS:-10}"
 required_rounds="${PRODUCTION_ALIAS_REQUIRED_ROUNDS:-3}"
+max_transient_failures="${PRODUCTION_ALIAS_MAX_TRANSIENT_FAILURES:-2}"
 
 write_failure() {
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
@@ -28,6 +29,7 @@ if [[ "$expected_deploy_id" != dpl_* ]] ||
   ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]] ||
   ! [[ "$retry_seconds" =~ ^[0-9]+$ ]] ||
   ! [[ "$required_rounds" =~ ^[1-9][0-9]*$ ]] ||
+  ! [[ "$max_transient_failures" =~ ^[0-9]+$ ]] ||
   [ "$required_rounds" -gt "$max_attempts" ]; then
   echo "Production alias verifier inputs are invalid." >&2
   write_failure
@@ -54,13 +56,22 @@ curl_args=(
 last_status=""
 last_sha=""
 last_current_id=""
-consecutive_rounds=0
+# Prove each target independently so one transport reset cannot erase another
+# target's exact evidence. Unknowns preserve proof only within the bounded
+# tolerance; observed mismatches reset it, and success still requires an
+# all-exact latest round.
+current_matches=0
+current_transient_failures=0
+routing_matches=(0 0 0)
+routing_transient_failures=(0 0 0)
 for attempt in $(seq 1 "$max_attempts"); do
   if [ "$attempt" -gt 1 ]; then
     sleep "$retry_seconds"
   fi
 
-  current_ok=false
+  round_exact=true
+  current_observation="transient"
+  observed_current_id=""
   current_json=""
   if current_json="$(vercel inspect "$canonical_domain" --format=json 2>/dev/null)" &&
     jq -e '
@@ -69,19 +80,42 @@ for attempt in $(seq 1 "$max_attempts"); do
       (.readyState | type == "string") and
       (.target | type == "string")
     ' >/dev/null 2>&1 <<<"$current_json"; then
-    last_current_id="$(jq -r '.id' <<<"$current_json")"
+    observed_current_id="$(jq -r '.id' <<<"$current_json")"
+    last_current_id="$observed_current_id"
     current_ready="$(jq -r '.readyState | ascii_upcase' <<<"$current_json")"
     current_target="$(jq -r '.target | ascii_downcase' <<<"$current_json")"
-    if [ "$last_current_id" = "$expected_deploy_id" ] &&
+    current_observation="mismatch"
+    if [ "$observed_current_id" = "$expected_deploy_id" ] &&
       [ "$current_ready" = "READY" ] &&
       [ "$current_target" = "production" ]; then
-      current_ok=true
+      current_observation="match"
     fi
   fi
 
-  echo "  attempt ${attempt}/${max_attempts} production-current: id=${last_current_id:-<unknown>} expected=${expected_deploy_id}"
+  case "$current_observation" in
+    match)
+      if [ "$current_matches" -lt "$required_rounds" ]; then
+        current_matches=$((current_matches + 1))
+      fi
+      current_transient_failures=0
+      ;;
+    mismatch)
+      current_matches=0
+      current_transient_failures=0
+      round_exact=false
+      ;;
+    transient)
+      current_transient_failures=$((current_transient_failures + 1))
+      if [ "$current_transient_failures" -gt "$max_transient_failures" ]; then
+        current_matches=0
+      fi
+      round_exact=false
+      ;;
+  esac
 
-  round_ok="$current_ok"
+  echo "  attempt ${attempt}/${max_attempts} production-current: id=${observed_current_id:-<unknown>} expected=${expected_deploy_id}, proof=${current_matches}/${required_rounds}, transient=${current_transient_failures}/${max_transient_failures}"
+
+  routing_index=0
   for routing in plain stable canary; do
     routing_query=""
     case "$routing" in
@@ -96,28 +130,61 @@ for attempt in $(seq 1 "$max_attempts"); do
       probe_url="${probe_url}&${routing_query}"
     fi
 
-    response="$(curl "${curl_args[@]}" -w "\n%{http_code}" "$probe_url" 2>/dev/null || printf '\n000')"
-    last_status="${response##*$'\n'}"
-    body="${response%$'\n'*}"
-    last_sha="$(printf '%s' "$body" | jq -r '.commitSha // ""' 2>/dev/null || echo "")"
-    environment="$(printf '%s' "$body" | jq -r '.environment // ""' 2>/dev/null || echo "")"
-
-    echo "  attempt ${attempt}/${max_attempts} production-alias/${routing}: HTTP ${last_status}, commitSha=${last_sha:-<empty>}, environment=${environment:-<empty>}"
-    if [ "$last_status" != "200" ] ||
-      [ "$last_sha" != "$expected_sha" ] ||
-      [ "$environment" != "production" ]; then
-      round_ok=false
+    route_observation="transient"
+    response=""
+    last_status="000"
+    last_sha=""
+    environment=""
+    if response="$(curl "${curl_args[@]}" -w "\n%{http_code}" "$probe_url" 2>/dev/null)"; then
+      last_status="${response##*$'\n'}"
+      body="${response%$'\n'*}"
+      last_sha="$(printf '%s' "$body" | jq -r '.commitSha // ""' 2>/dev/null || echo "")"
+      environment="$(printf '%s' "$body" | jq -r '.environment // ""' 2>/dev/null || echo "")"
+      route_observation="match"
+      if [ "$last_status" != "200" ] ||
+        [ "$last_sha" != "$expected_sha" ] ||
+        [ "$environment" != "production" ]; then
+        route_observation="mismatch"
+      fi
     fi
+
+    case "$route_observation" in
+      match)
+        if [ "${routing_matches[$routing_index]}" -lt "$required_rounds" ]; then
+          routing_matches[routing_index]=$((routing_matches[routing_index] + 1))
+        fi
+        routing_transient_failures[routing_index]=0
+        ;;
+      mismatch)
+        routing_matches[routing_index]=0
+        routing_transient_failures[routing_index]=0
+        round_exact=false
+        ;;
+      transient)
+        routing_transient_failures[routing_index]=$((routing_transient_failures[routing_index] + 1))
+        if [ "${routing_transient_failures[$routing_index]}" -gt "$max_transient_failures" ]; then
+          routing_matches[routing_index]=0
+        fi
+        round_exact=false
+        ;;
+    esac
+
+    echo "  attempt ${attempt}/${max_attempts} production-alias/${routing}: HTTP ${last_status}, commitSha=${last_sha:-<empty>}, environment=${environment:-<empty>}, proof=${routing_matches[$routing_index]}/${required_rounds}, transient=${routing_transient_failures[$routing_index]}/${max_transient_failures}"
+    routing_index=$((routing_index + 1))
   done
 
-  if [ "$round_ok" = "true" ]; then
-    consecutive_rounds=$((consecutive_rounds + 1))
-    if [ "$consecutive_rounds" -ge "$required_rounds" ]; then
-      echo "Canonical production is ${expected_deploy_id} and serves ${expected_sha} across ${required_rounds} consecutive routing rounds."
-      exit 0
+  proof_complete=true
+  if [ "$current_matches" -lt "$required_rounds" ]; then
+    proof_complete=false
+  fi
+  for routing_index in 0 1 2; do
+    if [ "${routing_matches[$routing_index]}" -lt "$required_rounds" ]; then
+      proof_complete=false
     fi
-  else
-    consecutive_rounds=0
+  done
+  if [ "$round_exact" = "true" ] && [ "$proof_complete" = "true" ]; then
+    echo "Canonical production is ${expected_deploy_id} and serves ${expected_sha}; Production Current and every routing path have ${required_rounds} independently confirmed exact observations, and the latest round is exact."
+    exit 0
   fi
 done
 

--- a/scripts/tests/test_vercel_prebuilt_deploy.py
+++ b/scripts/tests/test_vercel_prebuilt_deploy.py
@@ -873,17 +873,44 @@ def _write_fake_alias_tools(tmp_path: Path) -> tuple[Path, Path]:
     fake_bin.mkdir()
     fake_curl = fake_bin / "curl"
     fake_curl.write_text(
-        "#!/usr/bin/env bash\n"
-        "set -euo pipefail\n"
-        "printf '%s\\n' \"$*\" >> \"$CURL_CALL_LOG\"\n"
-        "printf '{\"commitSha\":\"%s\",\"environment\":\"production\"}\\n200\\n' \"$FAKE_BUILD_SHA\"\n"
+        r'''#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$CURL_CALL_LOG"
+call_index="$(wc -l < "$CURL_CALL_LOG" | tr -d ' ')"
+IFS=',' read -r -a observations <<< "${FAKE_CURL_SEQUENCE:-match}"
+observation="${observations[$((call_index - 1))]:-match}"
+build_sha="$FAKE_BUILD_SHA"
+build_environment="$FAKE_BUILD_ENVIRONMENT"
+
+case "$observation" in
+  match) ;;
+  stale-sha) build_sha="old1234" ;;
+  wrong-environment) build_environment="preview" ;;
+  transient) exit 28 ;;
+  *)
+    echo "Unknown fake curl observation: $observation" >&2
+    exit 2
+    ;;
+esac
+
+printf '{"commitSha":"%s","environment":"%s"}\n200\n' \
+  "$build_sha" "$build_environment"
+'''
     )
     fake_curl.chmod(0o755)
     return fake_vercel, fake_bin
 
 
 def _run_alias_verifier(
-    tmp_path: Path, *, current_id: str, build_sha: str
+    tmp_path: Path,
+    *,
+    current_id: str,
+    build_sha: str,
+    max_attempts: int = 1,
+    required_rounds: int = 1,
+    max_transient_failures: int = 0,
+    curl_sequence: str = "match",
+    build_environment: str = "production",
 ) -> subprocess.CompletedProcess[str]:
     fake_vercel, fake_bin = _write_fake_alias_tools(tmp_path)
     env = {
@@ -891,16 +918,19 @@ def _run_alias_verifier(
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
         "EXPECTED_COMMIT_SHA": "new5678full",
         "EXPECTED_PRODUCTION_DEPLOYMENT_ID": "dpl_target",
-        "PRODUCTION_ALIAS_MAX_ATTEMPTS": "1",
-        "PRODUCTION_ALIAS_REQUIRED_ROUNDS": "1",
+        "PRODUCTION_ALIAS_MAX_ATTEMPTS": str(max_attempts),
+        "PRODUCTION_ALIAS_REQUIRED_ROUNDS": str(required_rounds),
+        "PRODUCTION_ALIAS_MAX_TRANSIENT_FAILURES": str(max_transient_failures),
         "PRODUCTION_ALIAS_RETRY_SECONDS": "0",
         "VERCEL_CLI": str(fake_vercel),
         "VERCEL_TOKEN": "token",
         "VERCEL_ORG_ID": "team_test",
         "VERCEL_CALL_LOG": str(tmp_path / "vercel-calls"),
         "CURL_CALL_LOG": str(tmp_path / "curl-calls"),
+        "FAKE_CURL_SEQUENCE": curl_sequence,
         "FAKE_CURRENT_ID": current_id,
         "FAKE_BUILD_SHA": build_sha,
+        "FAKE_BUILD_ENVIRONMENT": build_environment,
         "GITHUB_OUTPUT": str(tmp_path / "github-output"),
     }
     return subprocess.run(
@@ -912,6 +942,12 @@ def _run_alias_verifier(
         timeout=10,
         check=False,
     )
+
+
+def _alias_observation_sequence(
+    *attempts: tuple[str, str, str],
+) -> str:
+    return ",".join(observation for attempt in attempts for observation in attempt)
 
 
 def test_alias_verifier_requires_exact_id_sha_and_all_rolling_routes(
@@ -927,6 +963,112 @@ def test_alias_verifier_requires_exact_id_sha_and_all_rolling_routes(
     assert "vcrrForceStable=true" in curl_calls
     assert "vcrrForceCanary=true" in curl_calls
     assert "x-vercel-protection-bypass" not in curl_calls
+
+
+def test_alias_verifier_replays_production_transients_with_independent_proof(
+    tmp_path: Path,
+) -> None:
+    # Exact route-observation pattern from production run 29686884512. The
+    # legacy global streak never exceeded one clean round, even though every
+    # response that arrived identified the exact Production deployment.
+    observations = _alias_observation_sequence(
+        ("match", "match", "match"),
+        ("transient", "match", "match"),
+        ("match", "match", "match"),
+        ("transient", "match", "match"),
+        ("transient", "match", "match"),
+        ("match", "match", "match"),
+        ("transient", "match", "match"),
+        ("transient", "match", "match"),
+        ("transient", "match", "transient"),
+        ("match", "match", "match"),
+        ("match", "match", "transient"),
+        ("match", "match", "match"),
+        ("match", "match", "transient"),
+        ("match", "match", "transient"),
+        ("match", "match", "match"),
+    )
+    result = _run_alias_verifier(
+        tmp_path,
+        current_id="dpl_target",
+        build_sha="new5678",
+        max_attempts=15,
+        required_rounds=3,
+        max_transient_failures=2,
+        curl_sequence=observations,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "attempt 6/15 production-alias/canary" in result.stdout
+    assert len((tmp_path / "curl-calls").read_text().splitlines()) == 18
+
+
+def test_alias_verifier_requires_every_latest_observation_to_be_exact(
+    tmp_path: Path,
+) -> None:
+    result = _run_alias_verifier(
+        tmp_path,
+        current_id="dpl_target",
+        build_sha="new5678",
+        max_attempts=3,
+        required_rounds=2,
+        max_transient_failures=2,
+        curl_sequence=_alias_observation_sequence(
+            ("match", "match", "match"),
+            ("match", "transient", "match"),
+            ("transient", "match", "match"),
+        ),
+    )
+
+    assert result.returncode == 1
+    assert "attempt 3/3 production-alias/plain: HTTP 000" in result.stdout
+
+
+def test_alias_verifier_resets_proof_on_observed_identity_mismatch(
+    tmp_path: Path,
+) -> None:
+    result = _run_alias_verifier(
+        tmp_path,
+        current_id="dpl_target",
+        build_sha="new5678",
+        max_attempts=5,
+        required_rounds=3,
+        max_transient_failures=2,
+        curl_sequence=_alias_observation_sequence(
+            ("match", "match", "match"),
+            ("match", "match", "match"),
+            ("wrong-environment", "match", "match"),
+            ("match", "match", "match"),
+            ("match", "match", "match"),
+        ),
+    )
+
+    assert result.returncode == 1
+    assert "environment=preview" in result.stdout
+
+
+def test_alias_verifier_resets_proof_after_bounded_transport_unknowns(
+    tmp_path: Path,
+) -> None:
+    result = _run_alias_verifier(
+        tmp_path,
+        current_id="dpl_target",
+        build_sha="new5678",
+        max_attempts=6,
+        required_rounds=3,
+        max_transient_failures=2,
+        curl_sequence=_alias_observation_sequence(
+            ("match", "match", "match"),
+            ("match", "match", "match"),
+            ("transient", "match", "match"),
+            ("transient", "match", "match"),
+            ("transient", "match", "match"),
+            ("match", "match", "match"),
+        ),
+    )
+
+    assert result.returncode == 1
+    assert "attempt 6/6 production-alias/plain: HTTP 200" in result.stdout
 
 
 def test_alias_verifier_rejects_stale_sha_even_on_expected_deployment(


### PR DESCRIPTION
## Scope

Repair only the canonical production alias verifier and its deterministic controller tests. This does not change workflow topology, merge-queue behavior, branch protection, deployment identity, rollback policy, or production mutation ordering.

## Exact failure evidence

- Main run [`29686884512`](https://github.com/JovieInc/Jovie/actions/runs/29686884512), promotion job [`88193453590`](https://github.com/JovieInc/Jovie/actions/runs/29686884512/job/88193453590), checked out exact SHA `e355345d0e5acc706a374e0d93df37c829e8920e`.
- Vercel Production Current matched exact deployment `dpl_5jUE7wJKLqbZD9hU23KzUR8VUzax` on all 15 attempts.
- Every route response that arrived was HTTP 200 with `commitSha=e355345` and `environment=production`.
- Fully exact rounds were 1, 3, 6, 10, 12, and 15. The old single global streak never exceeded one because independent transport resets occurred on plain at attempts 2, 4, 5, 7, 8, 9 and canary at attempts 9, 11, 13, 14.
- The deployment was exact; convergence accounting produced the false negative and skipped Sentry/post-deploy fanout.

## Fail-closed repair

- Track exact proof independently for Production Current and the plain, stable, and canary routes.
- Treat only command/transport failure as unknown. Preserve that target's proof for at most two consecutive unknowns.
- Reset a target immediately on every observed deployment ID, readiness, target, HTTP status, commit SHA, or environment mismatch.
- Complete only on an attempt where all four latest observations are exact.
- Log proof and transient counters per target for deterministic diagnosis.

The captured production sequence now completes on attempt 6, the first all-exact attempt where each target has accumulated three exact observations. No mismatch or unknown attempt can complete.

## Verification

- Regression fixture failed on the parent verifier after all 15 attempts, then passed with this change at attempt 6.
- `33 passed`: full `scripts/tests/test_vercel_prebuilt_deploy.py`
- `70 passed`: `apps/web/tests/unit/ci/deploy-workflow.test.ts`
- `176 passed`: `pnpm ci:control:test`
- `pnpm ci:harness:check`
- `pnpm ci:merge-queue:check`
- `bash -n .github/scripts/verify-production-alias.sh`
- `shellcheck .github/scripts/verify-production-alias.sh`
- `git diff --check`
- Signed pre-commit secret, hygiene, governance, and proxy guards passed.
- Fresh read-only public probes returned HTTP 200, `commitSha=e355345`, `environment=production` for plain, stable, and canary.

Pre-push note: the repository hook over-selected `mode=full related=0 mandatory=0` and began unrelated application tests, including unrelated localStorage failures. It was stopped and the documented `HUSKY=0` escape was used after the exact scoped proof above was green.

## Landing proof

Do not rerun the old failed job: it checks out `e355345d` and executes the old verifier. The first production release after this commit lands is the live proof. Require canonical verification to pass, then require Sentry/post-deploy fanout and final `Production Verified` for that exact new main SHA.
