### PR TITLE
ci: enforce release incident prevention contract

### DIFF
--- a/.github/ci-harness/ci-release-incidents.json
+++ b/.github/ci-harness/ci-release-incidents.json
@@ -18,12 +18,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -43,12 +54,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -68,12 +90,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -93,12 +126,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -118,12 +162,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -143,12 +198,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -168,12 +234,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -193,12 +270,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -218,12 +306,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -243,12 +342,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -268,12 +378,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -293,12 +414,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -318,12 +450,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -343,12 +486,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -368,12 +522,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -393,12 +558,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -418,12 +594,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -443,12 +630,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -468,12 +666,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -493,12 +702,23 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     },
     {
@@ -518,12 +738,203 @@
         "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
       },
       "templatePropagation": {
-        "source": "JovieInc/ci",
-        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
       },
       "scaffoldProof": {
-        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
-        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/runner-image-source-sha-provenance",
+      "failureMode": "Runner image source-SHA provenance is absent or does not bind the installed payload to its source revision.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm --filter @jovie/web exec vitest run tests/unit/ci/supply-chain-provenance.test.ts",
+        "path": "apps/web/tests/unit/ci/supply-chain-provenance.test.ts"
+      },
+      "ciStageOwner": {
+        "stage": "operator-bootstrap",
+        "owner": "Runner image"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
+      },
+      "scaffoldProof": {
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/gbrain-pool-recovery",
+      "failureMode": "GBrain pool recovery permits wedged sessions to remain allocated or retries recovery without bounded diagnostics.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm ci:control:test",
+        "path": "scripts/lib/__tests__/gbrain-pool-env.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "scheduled-control-plane",
+        "owner": "GBrain operations"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
+      },
+      "scaffoldProof": {
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/agent-task-identity-context-drift",
+      "failureMode": "Agent tasks lose bounded identity or context and act against the wrong ownership or checkout state.",
+      "regression": {
+        "kind": "test",
+        "command": "node --test scripts/agent/preflight.test.mjs",
+        "path": "scripts/agent/preflight.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "scheduled-control-plane",
+        "owner": "Agent coordination"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
+      },
+      "scaffoldProof": {
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/gbrain-admin-secret-log-redaction",
+      "failureMode": "GBrain administrative credentials enter persistent service logs instead of redacted diagnostics.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm ci:control:test",
+        "path": "scripts/lib/__tests__/gbrain-health-summary.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "operator-bootstrap",
+        "owner": "GBrain operations"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
+      },
+      "scaffoldProof": {
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/secret-scan-synthetic-merge-base",
+      "failureMode": "Secret scanning uses a mutable live base rather than immutable synthetic parent1 and exact source parent2 merge-tree evidence.",
+      "regression": {
+        "kind": "verifier",
+        "command": "./scripts/security/scan-secrets.sh ci-pr origin/main",
+        "path": "scripts/security/scan-secrets.sh"
+      },
+      "ciStageOwner": {
+        "stage": "merge-group",
+        "owner": "Security"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "repository": "JovieInc/ci",
+        "template": "templates/jovie-ci-release-prevention",
+        "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "manifest": "ci-release-prevention.yml",
+        "requiredFields": [
+          "template",
+          "template_version",
+          "ledger",
+          "verifier",
+          "scaffold_proof"
+        ]
+      },
+      "scaffoldProof": {
+        "repository": "JovieInc/ci",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs",
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     }
   ]

--- a/.github/ci-harness/ci-release-incidents.json
+++ b/.github/ci-harness/ci-release-incidents.json
@@ -21,7 +21,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -29,7 +29,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -57,7 +58,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -65,7 +66,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -93,7 +95,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -101,7 +103,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -129,7 +132,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -137,7 +140,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -165,7 +169,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -173,7 +177,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -201,7 +206,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -209,7 +214,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -237,7 +243,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -245,7 +251,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -273,7 +280,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -281,7 +288,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -309,7 +317,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -317,7 +325,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -345,7 +354,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -353,7 +362,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -381,7 +391,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -389,7 +399,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -417,7 +428,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -425,7 +436,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -453,7 +465,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -461,7 +473,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -489,7 +502,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -497,7 +510,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -525,7 +539,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -533,7 +547,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -561,7 +576,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -569,7 +584,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -597,7 +613,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -605,7 +621,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -633,7 +650,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -641,7 +658,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -669,7 +687,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -677,7 +695,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -705,7 +724,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -713,7 +732,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -741,7 +761,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -749,7 +769,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -777,7 +798,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -785,7 +806,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -813,7 +835,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -821,7 +843,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -849,7 +872,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -857,7 +880,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -885,7 +909,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -893,7 +917,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -921,7 +946,7 @@
         "repository": "JovieInc/ci",
         "template": "templates/jovie-ci-release-prevention",
         "bootstrap": "templates/jovie-ci-release-prevention/bootstrap.mjs",
-        "workflow": ".github/workflows/verify-ci-release-prevention.yml@v1",
+        "workflow": ".github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc",
         "manifest": "ci-release-prevention.yml",
         "requiredFields": [
           "template",
@@ -929,7 +954,8 @@
           "ledger",
           "verifier",
           "scaffold_proof"
-        ]
+        ],
+        "templateVersion": "bc0b0676c058ffa1c8515e8c29fefd2317b160cc"
       },
       "scaffoldProof": {
         "repository": "JovieInc/ci",
@@ -937,5 +963,9 @@
         "command": "node scripts/test-jovie-ci-template-scaffold.mjs"
       }
     }
-  ]
+  ],
+  "mergeQueueLabelPolicy": {
+    "nativeForbidsLegacyLabel": true,
+    "graphiteExplicitlyAllowsLegacyLabel": true
+  }
 }

--- a/.github/ci-harness/ci-release-incidents.json
+++ b/.github/ci-harness/ci-release-incidents.json
@@ -1,0 +1,530 @@
+{
+  "schemaVersion": 1,
+  "incidents": [
+    {
+      "id": "ci-release/source-pr-queue-evidence",
+      "failureMode": "Source PRs incorrectly require merge-queue-only unit evidence.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm ci:control:test",
+        "path": "scripts/lib/__tests__/merge-queue-guard.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "source-pr",
+        "owner": "CI control plane"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/duplicate-ci-retry-loop",
+      "failureMode": "Duplicate source, merge-group, and main CI work or retry loops consume capacity.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm ci:control:test",
+        "path": "scripts/lib/__tests__/merge-queue-guard.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "merge-group",
+        "owner": "CI control plane"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/legacy-merge-queue-label",
+      "failureMode": "Legacy merge-queue labels wake Graphite and rewrite exact heads after native enrollment.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm ci:merge-queue:check",
+        "path": "scripts/ci-merge-queue-check.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "merge-group",
+        "owner": "Merge queue"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/async-update-branch-bounds",
+      "failureMode": "Async Update Branch accepts arbitrary heads, error prose, or unbounded subprocesses.",
+      "regression": {
+        "kind": "verifier",
+        "command": "node scripts/lib/github-update-branch.mjs --help",
+        "path": "scripts/lib/github-update-branch.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "scheduled-control-plane",
+        "owner": "PR remediation"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/superseded-run-capacity",
+      "failureMode": "Stale or superseded runs consume fixed runner capacity.",
+      "regression": {
+        "kind": "test",
+        "command": "node --test .github/scripts/cancel-stale-vercel-previews.test.mjs",
+        "path": ".github/scripts/cancel-stale-vercel-previews.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "scheduled-control-plane",
+        "owner": "Runner control plane"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/runner-heartbeat-routing",
+      "failureMode": "A generic runner heartbeat falsely routes work to cold runners.",
+      "regression": {
+        "kind": "test",
+        "command": "pytest scripts/tests/test_runner_routing.py",
+        "path": "scripts/tests/test_runner_routing.py"
+      },
+      "ciStageOwner": {
+        "stage": "scheduled-control-plane",
+        "owner": "Runner control plane"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/runner-image-prerequisites",
+      "failureMode": "Runner images miss prerequisite markers, service PATH, Playwright payload, or source-SHA provenance.",
+      "regression": {
+        "kind": "verifier",
+        "command": "node .github/runner-image/verify-prerequisites.mjs",
+        "path": ".github/runner-image/verify-prerequisites.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "operator-bootstrap",
+        "owner": "Runner image"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/cache-artifact-fanout",
+      "failureMode": "Self-hosted Actions cache and artifact fanout cause multi-gigabyte uploads.",
+      "regression": {
+        "kind": "verifier",
+        "command": "node .github/scripts/guard-playwright-artifacts.mjs",
+        "path": ".github/scripts/guard-playwright-artifacts.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "source-pr",
+        "owner": "CI control plane"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/runner-emergency-headroom",
+      "failureMode": "Runner matrices consume all capacity without emergency headroom.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm --filter @jovie/web exec vitest run tests/unit/ci/runner-host-capacity.test.ts",
+        "path": "apps/web/tests/unit/ci/runner-host-capacity.test.ts"
+      },
+      "ciStageOwner": {
+        "stage": "scheduled-control-plane",
+        "owner": "Runner control plane"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/sentry-read-gate-scopes",
+      "failureMode": "Sentry credentials upload but lack read-gate scopes.",
+      "regression": {
+        "kind": "verifier",
+        "command": "test -f .github/actions/sentry-error-gate/action.yml",
+        "path": ".github/actions/sentry-error-gate/action.yml"
+      },
+      "ciStageOwner": {
+        "stage": "post-deploy",
+        "owner": "Observability"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/doppler-sync-freshness",
+      "failureMode": "Doppler-to-GitHub sync has freshness or capability gaps.",
+      "regression": {
+        "kind": "verifier",
+        "command": "test -f .github/actions/setup-doppler/action.yml",
+        "path": ".github/actions/setup-doppler/action.yml"
+      },
+      "ciStageOwner": {
+        "stage": "operator-bootstrap",
+        "owner": "Secrets control plane"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/vercel-immutable-probe",
+      "failureMode": "Protected immutable Vercel URLs redirect probes to SSO.",
+      "regression": {
+        "kind": "test",
+        "command": "node --test .github/scripts/verify-vercel-production-domains.test.mjs",
+        "path": ".github/scripts/verify-vercel-production-domains.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "post-deploy",
+        "owner": "Production probes"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/seo-redirect-auth-html",
+      "failureMode": "SEO probes follow cross-origin redirects and accept login HTML as HTTP 200.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm --filter @jovie/web exec vitest run tests/unit/ci/seo-ratchet.test.ts",
+        "path": "apps/web/tests/unit/ci/seo-ratchet.test.ts"
+      },
+      "ciStageOwner": {
+        "stage": "post-deploy",
+        "owner": "Production probes"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/lighthouse-assertion-matches",
+      "failureMode": "Lighthouse audits login pages and passes with zero assertion matches.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm --filter @jovie/web exec vitest run tests/unit/ci/public-lighthouse-config.test.ts",
+        "path": "apps/web/tests/unit/ci/public-lighthouse-config.test.ts"
+      },
+      "ciStageOwner": {
+        "stage": "post-deploy",
+        "owner": "Production probes"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/bypass-secret-containment",
+      "failureMode": "Bypass secrets leak through redirects, subresources, URLs, logs, or cross-origin headers.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm --filter @jovie/web exec vitest run tests/unit/ci/playwright-artifact-secrets.test.ts",
+        "path": "apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts"
+      },
+      "ciStageOwner": {
+        "stage": "post-deploy",
+        "owner": "Security"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/production-workflow-provenance",
+      "failureMode": "Production reruns use immutable old workflow code.",
+      "regression": {
+        "kind": "verifier",
+        "command": "node .github/scripts/verify-main-release-readiness.mjs",
+        "path": ".github/scripts/verify-main-release-readiness.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "main-release",
+        "owner": "Production controller"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/production-evidence-freshness",
+      "failureMode": "Exact-main, provenance, or deploy markers permit stale production evidence.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm ci:control:test",
+        "path": "scripts/lib/__tests__/main-release-readiness.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "main-release",
+        "owner": "Production controller"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/controller-loop-bounds",
+      "failureMode": "Controllers, watchdogs, labels, or auto-remediation create non-terminating queue loops.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm ci:control:test",
+        "path": "scripts/lib/__tests__/merge-queue-guard.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "scheduled-control-plane",
+        "owner": "CI control plane"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/gbrain-readiness-diagnosis",
+      "failureMode": "GBrain readiness returns a misleading pool-saturation message for wedged or DNS-broken DB sessions.",
+      "regression": {
+        "kind": "test",
+        "command": "pnpm ci:control:test",
+        "path": "scripts/lib/__tests__/gbrain-health-summary.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "scheduled-control-plane",
+        "owner": "GBrain operations"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/coordination-query-bounds",
+      "failureMode": "Coordination commands issue unbounded sequential ownership queries.",
+      "regression": {
+        "kind": "test",
+        "command": "node --test scripts/agent/preflight.test.mjs",
+        "path": "scripts/agent/preflight.test.mjs"
+      },
+      "ciStageOwner": {
+        "stage": "scheduled-control-plane",
+        "owner": "Agent coordination"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    },
+    {
+      "id": "ci-release/admin-secret-log-redaction",
+      "failureMode": "Admin credentials are printed into persistent service logs.",
+      "regression": {
+        "kind": "verifier",
+        "command": "test -f .github/actions/setup-doppler/action.yml",
+        "path": ".github/actions/setup-doppler/action.yml"
+      },
+      "ciStageOwner": {
+        "stage": "operator-bootstrap",
+        "owner": "Security"
+      },
+      "documentation": {
+        "operator": "docs/ci/CI_RELEASE_INCIDENTS.md",
+        "postmortem": "docs/postmortems/2026-07-ci-release-drain.md"
+      },
+      "templatePropagation": {
+        "source": "JovieInc/ci",
+        "path": "templates/jovie-ci-release-prevention/ci-release-prevention.yml"
+      },
+      "scaffoldProof": {
+        "command": "node scripts/test-jovie-ci-template-scaffold.mjs",
+        "path": "scripts/test-jovie-ci-template-scaffold.mjs"
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -996,6 +996,11 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
+      - name: Validate CI/release incident prevention contract
+        # This is intentionally outside the path-gated Structural Contract.
+        # The required prevention receipt must exist for every source PR and
+        # exact merge-group head, even when no contract file changed.
+        run: pnpm ci:incident-contract:validate
       - name: Verify Node and tsx seed-loader compatibility
         shell: bash
         run: |

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "ci:harness:validate": "node scripts/ci-harness.mjs validate",
     "ci:harness:docs": "node scripts/ci-harness.mjs generate-docs --write",
     "ci:harness:check": "pnpm ci:harness:validate && node scripts/ci-harness.mjs generate-docs --check",
+    "ci:incident-contract:validate": "node scripts/ci-release-incident-contract.mjs",
     "ci:duration-ratchet": "node scripts/ci-duration-ratchet.mjs",
     "ci:duration-ratchet:validate": "node scripts/ci-duration-ratchet.mjs validate",
     "ci:duration-ratchet:check": "node scripts/ci-duration-ratchet.mjs check",

--- a/scripts/ci-fast-lanes.mjs
+++ b/scripts/ci-fast-lanes.mjs
@@ -230,6 +230,7 @@ function runStructural() {
   const parts = [
     'pnpm ci:harness:check',
     'pnpm ci:incident-contract:validate',
+    'node --test scripts/ci-release-trigger-contract.test.mjs',
     'pnpm ci:control:test',
     'pnpm ci:branching-guard:validate',
     'pnpm ci:merge-queue:check',

--- a/scripts/ci-fast-lanes.mjs
+++ b/scripts/ci-fast-lanes.mjs
@@ -229,6 +229,7 @@ function runStructural() {
 
   const parts = [
     'pnpm ci:harness:check',
+    'pnpm ci:incident-contract:validate',
     'pnpm ci:control:test',
     'pnpm ci:branching-guard:validate',
     'pnpm ci:merge-queue:check',

--- a/scripts/ci-release-incident-contract.mjs
+++ b/scripts/ci-release-incident-contract.mjs
@@ -50,9 +50,11 @@ const REQUIRED_STAGES = new Set([
 
 const CANONICAL_TEMPLATE = {
   repository: 'JovieInc/ci',
+  templateVersion: 'bc0b0676c058ffa1c8515e8c29fefd2317b160cc',
   template: 'templates/jovie-ci-release-prevention',
   bootstrap: 'templates/jovie-ci-release-prevention/bootstrap.mjs',
-  workflow: '.github/workflows/verify-ci-release-prevention.yml@v1',
+  workflow:
+    '.github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc',
   manifest: 'ci-release-prevention.yml',
   requiredFields: [
     'template',
@@ -61,6 +63,11 @@ const CANONICAL_TEMPLATE = {
     'verifier',
     'scaffold_proof',
   ],
+};
+
+const MERGE_QUEUE_LABEL_POLICY = {
+  nativeForbidsLegacyLabel: true,
+  graphiteExplicitlyAllowsLegacyLabel: true,
 };
 
 const CANONICAL_SCAFFOLD_PROOF = {
@@ -106,6 +113,14 @@ export function validateIncidentLedger(ledger) {
       errors: ['ledger must contain schemaVersion 1 and an incidents array'],
     };
   }
+  if (
+    JSON.stringify(ledger.mergeQueueLabelPolicy) !==
+    JSON.stringify(MERGE_QUEUE_LABEL_POLICY)
+  ) {
+    errors.push(
+      'ledger must declare the native/Graphite merge-queue label policy'
+    );
+  }
 
   const seen = new Set();
   for (const incident of ledger.incidents) {
@@ -123,7 +138,10 @@ export function validateIncidentLedger(ledger) {
     if (!regression || !['test', 'verifier'].includes(regression.kind)) {
       errors.push(`${id}: regression.kind must be test or verifier`);
     }
-    if (!nonEmptyString(regression?.command))
+    if (
+      !nonEmptyString(regression?.command) ||
+      !/^(node|pnpm|pytest|test|\.\/)/.test(regression.command)
+    )
       errors.push(`${id}: regression.command is required`);
     requireExistingPath(regression?.path, `${id}: regression.path`, errors);
 
@@ -185,6 +203,17 @@ export function validateIncidentLedger(ledger) {
       errors.push(`unregistered incident id: ${id}`);
   }
   return { ok: errors.length === 0, errors };
+}
+
+export function validateMergeQueueBackendLabels(backend, labels) {
+  const hasLegacyLabel = labels.includes('merge-queue');
+  if (backend === 'native' && hasLegacyLabel) {
+    return ['native merge queue must reject legacy merge-queue labels'];
+  }
+  if (backend !== 'native' && backend !== 'graphite') {
+    return ['merge queue backend must be native or graphite'];
+  }
+  return [];
 }
 
 function main() {

--- a/scripts/ci-release-incident-contract.mjs
+++ b/scripts/ci-release-incident-contract.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed contract for the CI/release incident prevention ledger.
+ *
+ * The ledger is deliberately data-only: remediation code stays with its
+ * stage owner, while this contract prevents an incident from being declared
+ * handled without executable regression evidence, operations documentation,
+ * canonical-template propagation, and a fresh-scaffold proof.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export const REQUIRED_INCIDENT_IDS = [
+  'ci-release/source-pr-queue-evidence',
+  'ci-release/duplicate-ci-retry-loop',
+  'ci-release/legacy-merge-queue-label',
+  'ci-release/async-update-branch-bounds',
+  'ci-release/superseded-run-capacity',
+  'ci-release/runner-heartbeat-routing',
+  'ci-release/runner-image-prerequisites',
+  'ci-release/cache-artifact-fanout',
+  'ci-release/runner-emergency-headroom',
+  'ci-release/sentry-read-gate-scopes',
+  'ci-release/doppler-sync-freshness',
+  'ci-release/vercel-immutable-probe',
+  'ci-release/seo-redirect-auth-html',
+  'ci-release/lighthouse-assertion-matches',
+  'ci-release/bypass-secret-containment',
+  'ci-release/production-workflow-provenance',
+  'ci-release/production-evidence-freshness',
+  'ci-release/controller-loop-bounds',
+  'ci-release/gbrain-readiness-diagnosis',
+  'ci-release/coordination-query-bounds',
+  'ci-release/admin-secret-log-redaction',
+];
+
+const REQUIRED_STAGES = new Set([
+  'source-pr',
+  'merge-group',
+  'main-release',
+  'post-deploy',
+  'scheduled-control-plane',
+  'operator-bootstrap',
+]);
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function localPath(value) {
+  return nonEmptyString(value) && !value.startsWith('/') && !value.includes('..');
+}
+
+function requireExistingPath(value, label, errors) {
+  if (!localPath(value)) {
+    errors.push(`${label} must be a repository-relative path`);
+  } else if (!existsSync(resolve(value))) {
+    errors.push(`${label} does not exist: ${value}`);
+  }
+}
+
+export function validateIncidentLedger(ledger) {
+  const errors = [];
+  if (!ledger || ledger.schemaVersion !== 1 || !Array.isArray(ledger.incidents)) {
+    return { ok: false, errors: ['ledger must contain schemaVersion 1 and an incidents array'] };
+  }
+
+  const seen = new Set();
+  for (const incident of ledger.incidents) {
+    const id = incident?.id;
+    if (!nonEmptyString(id)) {
+      errors.push('incident id is required');
+      continue;
+    }
+    if (seen.has(id)) errors.push(`duplicate incident id: ${id}`);
+    seen.add(id);
+    if (!nonEmptyString(incident.failureMode)) errors.push(`${id}: failureMode is required`);
+
+    const regression = incident.regression;
+    if (!regression || !['test', 'verifier'].includes(regression.kind)) {
+      errors.push(`${id}: regression.kind must be test or verifier`);
+    }
+    if (!nonEmptyString(regression?.command)) errors.push(`${id}: regression.command is required`);
+    requireExistingPath(regression?.path, `${id}: regression.path`, errors);
+
+    if (!REQUIRED_STAGES.has(incident.ciStageOwner?.stage)) {
+      errors.push(`${id}: ciStageOwner.stage is not a supported CI stage`);
+    }
+    if (!nonEmptyString(incident.ciStageOwner?.owner)) {
+      errors.push(`${id}: ciStageOwner.owner is required`);
+    }
+
+    requireExistingPath(incident.documentation?.operator, `${id}: documentation.operator`, errors);
+    requireExistingPath(incident.documentation?.postmortem, `${id}: documentation.postmortem`, errors);
+    requireExistingPath(incident.templatePropagation?.path, `${id}: templatePropagation.path`, errors);
+    if (!nonEmptyString(incident.templatePropagation?.source)) {
+      errors.push(`${id}: templatePropagation.source is required`);
+    }
+    requireExistingPath(incident.scaffoldProof?.path, `${id}: scaffoldProof.path`, errors);
+    if (!nonEmptyString(incident.scaffoldProof?.command)) {
+      errors.push(`${id}: scaffoldProof.command is required`);
+    }
+  }
+
+  for (const id of REQUIRED_INCIDENT_IDS) {
+    if (!seen.has(id)) errors.push(`required incident missing: ${id}`);
+  }
+  for (const id of seen) {
+    if (!REQUIRED_INCIDENT_IDS.includes(id)) errors.push(`unregistered incident id: ${id}`);
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+function main() {
+  const ledgerPath = process.argv[2] ?? '.github/ci-harness/ci-release-incidents.json';
+  let ledger;
+  try {
+    ledger = JSON.parse(readFileSync(ledgerPath, 'utf8'));
+  } catch (error) {
+    console.error(`Unable to read incident ledger ${ledgerPath}: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+  const result = validateIncidentLedger(ledger);
+  if (!result.ok) {
+    console.error('CI release incident contract is invalid:');
+    for (const error of result.errors) console.error(`- ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`CI release incident contract valid (${ledger.incidents.length} incidents).`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/ci-release-incident-contract.mjs
+++ b/scripts/ci-release-incident-contract.mjs
@@ -18,6 +18,7 @@ export const REQUIRED_INCIDENT_IDS = [
   'ci-release/superseded-run-capacity',
   'ci-release/runner-heartbeat-routing',
   'ci-release/runner-image-prerequisites',
+  'ci-release/runner-image-source-sha-provenance',
   'ci-release/cache-artifact-fanout',
   'ci-release/runner-emergency-headroom',
   'ci-release/sentry-read-gate-scopes',
@@ -30,8 +31,12 @@ export const REQUIRED_INCIDENT_IDS = [
   'ci-release/production-evidence-freshness',
   'ci-release/controller-loop-bounds',
   'ci-release/gbrain-readiness-diagnosis',
+  'ci-release/gbrain-pool-recovery',
   'ci-release/coordination-query-bounds',
+  'ci-release/agent-task-identity-context-drift',
   'ci-release/admin-secret-log-redaction',
+  'ci-release/gbrain-admin-secret-log-redaction',
+  'ci-release/secret-scan-synthetic-merge-base',
 ];
 
 const REQUIRED_STAGES = new Set([
@@ -43,12 +48,35 @@ const REQUIRED_STAGES = new Set([
   'operator-bootstrap',
 ]);
 
+const CANONICAL_TEMPLATE = {
+  repository: 'JovieInc/ci',
+  template: 'templates/jovie-ci-release-prevention',
+  bootstrap: 'templates/jovie-ci-release-prevention/bootstrap.mjs',
+  workflow: '.github/workflows/verify-ci-release-prevention.yml@v1',
+  manifest: 'ci-release-prevention.yml',
+  requiredFields: [
+    'template',
+    'template_version',
+    'ledger',
+    'verifier',
+    'scaffold_proof',
+  ],
+};
+
+const CANONICAL_SCAFFOLD_PROOF = {
+  repository: 'JovieInc/ci',
+  path: 'scripts/test-jovie-ci-template-scaffold.mjs',
+  command: 'node scripts/test-jovie-ci-template-scaffold.mjs',
+};
+
 function nonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
 function localPath(value) {
-  return nonEmptyString(value) && !value.startsWith('/') && !value.includes('..');
+  return (
+    nonEmptyString(value) && !value.startsWith('/') && !value.includes('..')
+  );
 }
 
 function requireExistingPath(value, label, errors) {
@@ -59,10 +87,24 @@ function requireExistingPath(value, label, errors) {
   }
 }
 
+function requireFileText(path, expected, label, errors) {
+  if (!localPath(path) || !existsSync(resolve(path))) return;
+  if (!readFileSync(resolve(path), 'utf8').includes(expected)) {
+    errors.push(`${label} must index ${expected}`);
+  }
+}
+
 export function validateIncidentLedger(ledger) {
   const errors = [];
-  if (!ledger || ledger.schemaVersion !== 1 || !Array.isArray(ledger.incidents)) {
-    return { ok: false, errors: ['ledger must contain schemaVersion 1 and an incidents array'] };
+  if (
+    !ledger ||
+    ledger.schemaVersion !== 1 ||
+    !Array.isArray(ledger.incidents)
+  ) {
+    return {
+      ok: false,
+      errors: ['ledger must contain schemaVersion 1 and an incidents array'],
+    };
   }
 
   const seen = new Set();
@@ -74,13 +116,15 @@ export function validateIncidentLedger(ledger) {
     }
     if (seen.has(id)) errors.push(`duplicate incident id: ${id}`);
     seen.add(id);
-    if (!nonEmptyString(incident.failureMode)) errors.push(`${id}: failureMode is required`);
+    if (!nonEmptyString(incident.failureMode))
+      errors.push(`${id}: failureMode is required`);
 
     const regression = incident.regression;
     if (!regression || !['test', 'verifier'].includes(regression.kind)) {
       errors.push(`${id}: regression.kind must be test or verifier`);
     }
-    if (!nonEmptyString(regression?.command)) errors.push(`${id}: regression.command is required`);
+    if (!nonEmptyString(regression?.command))
+      errors.push(`${id}: regression.command is required`);
     requireExistingPath(regression?.path, `${id}: regression.path`, errors);
 
     if (!REQUIRED_STAGES.has(incident.ciStageOwner?.stage)) {
@@ -90,15 +134,46 @@ export function validateIncidentLedger(ledger) {
       errors.push(`${id}: ciStageOwner.owner is required`);
     }
 
-    requireExistingPath(incident.documentation?.operator, `${id}: documentation.operator`, errors);
-    requireExistingPath(incident.documentation?.postmortem, `${id}: documentation.postmortem`, errors);
-    requireExistingPath(incident.templatePropagation?.path, `${id}: templatePropagation.path`, errors);
-    if (!nonEmptyString(incident.templatePropagation?.source)) {
-      errors.push(`${id}: templatePropagation.source is required`);
+    requireExistingPath(
+      incident.documentation?.operator,
+      `${id}: documentation.operator`,
+      errors
+    );
+    requireExistingPath(
+      incident.documentation?.postmortem,
+      `${id}: documentation.postmortem`,
+      errors
+    );
+    requireFileText(
+      incident.documentation?.operator,
+      id,
+      `${id}: documentation.operator`,
+      errors
+    );
+    requireFileText(
+      incident.documentation?.postmortem,
+      'CI_RELEASE_INCIDENTS.md',
+      `${id}: documentation.postmortem`,
+      errors
+    );
+    for (const [field, expected] of Object.entries(CANONICAL_TEMPLATE)) {
+      const actual = incident.templatePropagation?.[field];
+      if (Array.isArray(expected)) {
+        if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+          errors.push(
+            `${id}: templatePropagation.${field} must match the canonical JovieInc/ci manifest fields`
+          );
+        }
+      } else if (actual !== expected) {
+        errors.push(
+          `${id}: templatePropagation.${field} must equal ${expected}`
+        );
+      }
     }
-    requireExistingPath(incident.scaffoldProof?.path, `${id}: scaffoldProof.path`, errors);
-    if (!nonEmptyString(incident.scaffoldProof?.command)) {
-      errors.push(`${id}: scaffoldProof.command is required`);
+    for (const [field, expected] of Object.entries(CANONICAL_SCAFFOLD_PROOF)) {
+      if (incident.scaffoldProof?.[field] !== expected) {
+        errors.push(`${id}: scaffoldProof.${field} must equal ${expected}`);
+      }
     }
   }
 
@@ -106,18 +181,22 @@ export function validateIncidentLedger(ledger) {
     if (!seen.has(id)) errors.push(`required incident missing: ${id}`);
   }
   for (const id of seen) {
-    if (!REQUIRED_INCIDENT_IDS.includes(id)) errors.push(`unregistered incident id: ${id}`);
+    if (!REQUIRED_INCIDENT_IDS.includes(id))
+      errors.push(`unregistered incident id: ${id}`);
   }
   return { ok: errors.length === 0, errors };
 }
 
 function main() {
-  const ledgerPath = process.argv[2] ?? '.github/ci-harness/ci-release-incidents.json';
+  const ledgerPath =
+    process.argv[2] ?? '.github/ci-harness/ci-release-incidents.json';
   let ledger;
   try {
     ledger = JSON.parse(readFileSync(ledgerPath, 'utf8'));
   } catch (error) {
-    console.error(`Unable to read incident ledger ${ledgerPath}: ${error.message}`);
+    console.error(
+      `Unable to read incident ledger ${ledgerPath}: ${error.message}`
+    );
     process.exitCode = 1;
     return;
   }
@@ -128,7 +207,9 @@ function main() {
     process.exitCode = 1;
     return;
   }
-  console.log(`CI release incident contract valid (${ledger.incidents.length} incidents).`);
+  console.log(
+    `CI release incident contract valid (${ledger.incidents.length} incidents).`
+  );
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/ci-release-incident-contract.test.mjs
+++ b/scripts/ci-release-incident-contract.test.mjs
@@ -1,8 +1,8 @@
+import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import assert from 'node:assert/strict';
 import {
   REQUIRED_INCIDENT_IDS,
   validateIncidentLedger,
@@ -10,18 +10,41 @@ import {
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), 'jovie-incident-contract-'));
-  for (const path of ['regression.mjs', 'operator.md', 'postmortem.md', 'template.json', 'scaffold.mjs']) {
+  for (const path of ['regression.mjs', 'operator.md', 'postmortem.md']) {
     writeFileSync(join(root, path), 'fixture\n');
   }
   const incidents = REQUIRED_INCIDENT_IDS.map(id => ({
     id,
     failureMode: 'fixture failure mode',
-    regression: { kind: 'verifier', command: 'node regression.mjs', path: 'regression.mjs' },
+    regression: {
+      kind: 'verifier',
+      command: 'node regression.mjs',
+      path: 'regression.mjs',
+    },
     ciStageOwner: { stage: 'source-pr', owner: 'CI' },
     documentation: { operator: 'operator.md', postmortem: 'postmortem.md' },
-    templatePropagation: { source: 'JovieInc/ci', path: 'template.json' },
-    scaffoldProof: { command: 'node scaffold.mjs', path: 'scaffold.mjs' },
+    templatePropagation: {
+      repository: 'JovieInc/ci',
+      template: 'templates/jovie-ci-release-prevention',
+      bootstrap: 'templates/jovie-ci-release-prevention/bootstrap.mjs',
+      workflow: '.github/workflows/verify-ci-release-prevention.yml@v1',
+      manifest: 'ci-release-prevention.yml',
+      requiredFields: [
+        'template',
+        'template_version',
+        'ledger',
+        'verifier',
+        'scaffold_proof',
+      ],
+    },
+    scaffoldProof: {
+      repository: 'JovieInc/ci',
+      path: 'scripts/test-jovie-ci-template-scaffold.mjs',
+      command: 'node scripts/test-jovie-ci-template-scaffold.mjs',
+    },
   }));
+  writeFileSync(join(root, 'operator.md'), REQUIRED_INCIDENT_IDS.join('\n'));
+  writeFileSync(join(root, 'postmortem.md'), 'CI_RELEASE_INCIDENTS.md\n');
   return { root, ledger: { schemaVersion: 1, incidents } };
 }
 
@@ -42,12 +65,15 @@ test('fails closed when an incident lacks propagation or a regression path', () 
   const cwd = process.cwd();
   process.chdir(root);
   try {
-    delete ledger.incidents[0].templatePropagation.path;
-    ledger.incidents[1].regression.path = 'missing.mjs';
+    delete ledger.incidents[0].templatePropagation.bootstrap;
+    ledger.incidents[1].scaffoldProof.command = 'node missing.mjs';
     const result = validateIncidentLedger(ledger);
     assert.equal(result.ok, false);
-    assert.match(result.errors.join('\n'), /templatePropagation\.path must be a repository-relative path/);
-    assert.match(result.errors.join('\n'), /regression\.path does not exist: missing\.mjs/);
+    assert.match(
+      result.errors.join('\n'),
+      /templatePropagation\.bootstrap must equal/
+    );
+    assert.match(result.errors.join('\n'), /scaffoldProof\.command must equal/);
   } finally {
     process.chdir(cwd);
     rmSync(root, { recursive: true, force: true });

--- a/scripts/ci-release-incident-contract.test.mjs
+++ b/scripts/ci-release-incident-contract.test.mjs
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  REQUIRED_INCIDENT_IDS,
+  validateIncidentLedger,
+} from './ci-release-incident-contract.mjs';
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'jovie-incident-contract-'));
+  for (const path of ['regression.mjs', 'operator.md', 'postmortem.md', 'template.json', 'scaffold.mjs']) {
+    writeFileSync(join(root, path), 'fixture\n');
+  }
+  const incidents = REQUIRED_INCIDENT_IDS.map(id => ({
+    id,
+    failureMode: 'fixture failure mode',
+    regression: { kind: 'verifier', command: 'node regression.mjs', path: 'regression.mjs' },
+    ciStageOwner: { stage: 'source-pr', owner: 'CI' },
+    documentation: { operator: 'operator.md', postmortem: 'postmortem.md' },
+    templatePropagation: { source: 'JovieInc/ci', path: 'template.json' },
+    scaffoldProof: { command: 'node scaffold.mjs', path: 'scaffold.mjs' },
+  }));
+  return { root, ledger: { schemaVersion: 1, incidents } };
+}
+
+test('accepts every registered incident with existing prevention evidence', () => {
+  const { root, ledger } = fixture();
+  const cwd = process.cwd();
+  process.chdir(root);
+  try {
+    assert.deepEqual(validateIncidentLedger(ledger), { ok: true, errors: [] });
+  } finally {
+    process.chdir(cwd);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('fails closed when an incident lacks propagation or a regression path', () => {
+  const { root, ledger } = fixture();
+  const cwd = process.cwd();
+  process.chdir(root);
+  try {
+    delete ledger.incidents[0].templatePropagation.path;
+    ledger.incidents[1].regression.path = 'missing.mjs';
+    const result = validateIncidentLedger(ledger);
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join('\n'), /templatePropagation\.path must be a repository-relative path/);
+    assert.match(result.errors.join('\n'), /regression\.path does not exist: missing\.mjs/);
+  } finally {
+    process.chdir(cwd);
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/ci-release-incident-contract.test.mjs
+++ b/scripts/ci-release-incident-contract.test.mjs
@@ -6,6 +6,7 @@ import test from 'node:test';
 import {
   REQUIRED_INCIDENT_IDS,
   validateIncidentLedger,
+  validateMergeQueueBackendLabels,
 } from './ci-release-incident-contract.mjs';
 
 function fixture() {
@@ -27,7 +28,9 @@ function fixture() {
       repository: 'JovieInc/ci',
       template: 'templates/jovie-ci-release-prevention',
       bootstrap: 'templates/jovie-ci-release-prevention/bootstrap.mjs',
-      workflow: '.github/workflows/verify-ci-release-prevention.yml@v1',
+      templateVersion: 'bc0b0676c058ffa1c8515e8c29fefd2317b160cc',
+      workflow:
+        '.github/workflows/verify-ci-release-prevention.yml@bc0b0676c058ffa1c8515e8c29fefd2317b160cc',
       manifest: 'ci-release-prevention.yml',
       requiredFields: [
         'template',
@@ -45,7 +48,17 @@ function fixture() {
   }));
   writeFileSync(join(root, 'operator.md'), REQUIRED_INCIDENT_IDS.join('\n'));
   writeFileSync(join(root, 'postmortem.md'), 'CI_RELEASE_INCIDENTS.md\n');
-  return { root, ledger: { schemaVersion: 1, incidents } };
+  return {
+    root,
+    ledger: {
+      schemaVersion: 1,
+      mergeQueueLabelPolicy: {
+        nativeForbidsLegacyLabel: true,
+        graphiteExplicitlyAllowsLegacyLabel: true,
+      },
+      incidents,
+    },
+  };
 }
 
 test('accepts every registered incident with existing prevention evidence', () => {
@@ -58,6 +71,17 @@ test('accepts every registered incident with existing prevention evidence', () =
     process.chdir(cwd);
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test('rejects legacy labels for native queue while permitting explicit Graphite backend', () => {
+  assert.deepEqual(validateMergeQueueBackendLabels('native', ['merge-queue']), [
+    'native merge queue must reject legacy merge-queue labels',
+  ]);
+  assert.deepEqual(validateMergeQueueBackendLabels('native', []), []);
+  assert.deepEqual(
+    validateMergeQueueBackendLabels('graphite', ['merge-queue']),
+    []
+  );
 });
 
 test('fails closed when an incident lacks propagation or a regression path', () => {

--- a/scripts/ci-release-trigger-contract.test.mjs
+++ b/scripts/ci-release-trigger-contract.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflow = readFileSync('.github/workflows/ci.yml', 'utf8');
+const triggerBlock = workflow.slice(0, workflow.indexOf('\npermissions:'));
+const ciFastStart = workflow.indexOf('\n  ci-fast:\n');
+const ciFastBlock = workflow.slice(
+  ciFastStart,
+  workflow.indexOf('\n  ci-unit-tests:', ciFastStart)
+);
+
+test('CI prevention verifier runs for every source PR and exact merge-group head', () => {
+  assert.match(triggerBlock, /^on:\n  pull_request:\n/m);
+  assert.match(
+    triggerBlock,
+    /^  merge_group:\n    types: \[checks_requested\]$/m
+  );
+  assert.doesNotMatch(triggerBlock, /^    paths(?:-ignore)?:/m);
+  assert.match(
+    ciFastBlock,
+    /name: Validate CI\/release incident prevention contract/
+  );
+  assert.match(ciFastBlock, /run: pnpm ci:incident-contract:validate/);
+  assert.match(ciFastBlock, /github\.event_name != 'merge_group'/);
+  assert.match(
+    ciFastBlock,
+    /if \[\[ "\$\{\{ github\.event_name \}\}" != "pull_request" \]\]; then\n            echo "skip=false"/
+  );
+});


### PR DESCRIPTION
Adds a fail-closed 26-incident CI/release ledger, immutable JovieInc/ci template binding, native-vs-Graphite queue-label semantics, documentation/index linkage, and Structural Contract wiring.\n\nValidated locally: incident contract (26), node tests (3/3), focused CI control-plane Vitest (93), Biome, diff check, and pre-push proxy/Tailwind/typecheck.