### PR TITLE
fix(ci): quarantine merge units on hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,17 +323,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: node .github/scripts/verify-main-release-readiness.mjs
 
-  # Select unit capacity per CI run. Repository-variable failover cannot rescue
-  # a job already queued on an offline label, and the installed App currently
-  # lacks Variables:read/write. This hosted, secretless observer therefore
-  # defaults every stale, malformed, or API-uncertain heartbeat to hosted
-  # capacity and uses the fixed pool only with fresh positive evidence.
+  # Manual diagnostics retain the secretless routing observer, but no automated
+  # CI event consumes its output while fixed unit capacity is quarantined.
   ci-unit-runner-route:
     name: Unit Runner Route
-    if: >-
-      github.event_name == 'merge_group' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
@@ -361,8 +355,8 @@ jobs:
           GH_REPO: ${{ github.repository }}
           HEARTBEAT_MAX_AGE_SECONDS: '900'
           HEARTBEAT_API_TIMEOUT_SECONDS: '5'
-          HEARTBEAT_EXPECTED_EVENT: ${{ (github.event_name == 'push' || github.event_name == 'merge_group') && github.event_name || '' }}
-          HEARTBEAT_EXPECTED_SHA: ${{ (github.event_name == 'push' || github.event_name == 'merge_group') && github.sha || '' }}
+          HEARTBEAT_EXPECTED_EVENT: ''
+          HEARTBEAT_EXPECTED_SHA: ''
           HEARTBEAT_POLL_ATTEMPTS: '10'
           HEARTBEAT_POLL_INTERVAL_SECONDS: '5'
         run: |
@@ -2852,8 +2846,7 @@ jobs:
 
   ci-unit-tests:
     name: Unit Tests (${{ matrix.shard }})
-    needs:
-      [ci-path-changes, ci-unit-runner-route, ci-merge-group-admission]
+    needs: [ci-path-changes, ci-merge-group-admission]
     # Runs five shards on every merge-group combined head and direct-main
     # fallback. The merge-group command remains --affected, but the matrix may
     # never turn into a skipped placeholder. Source PRs defer unit evidence to
@@ -2861,7 +2854,6 @@ jobs:
     if: >-
       always() &&
       needs.ci-path-changes.result == 'success' &&
-      needs.ci-unit-runner-route.result == 'success' &&
       (
         github.event_name != 'merge_group' ||
         needs.ci-merge-group-admission.result == 'success'
@@ -2871,16 +2863,15 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
         github.event_name == 'workflow_dispatch'
       )
-    # Fresh heartbeat evidence may use the five fixed runners. Every uncertain
-    # observation routes this run to hosted capacity before the matrix is
-    # created. Two shards per candidate cap fixed-pool use at four, preserving
-    # anti-slam headroom for Runner Heartbeat and emergency work.
-    runs-on: ${{ needs.ci-unit-runner-route.outputs.runner_class == 'fixed' && 'jovie-runner' || 'ubuntu-latest' }}
+    # Phase 0: quarantine generic fixed-runner routing until all five named
+    # services have immutable warm-canary receipts. Combined heads use explicit
+    # hosted capacity, so this change's own merge group gets the safe fast path.
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
       fail-fast: false
-      # Five logical shards, at most two concurrent per queue candidate.
-      max-parallel: 2
+      # Hosted capacity runs all five logical shards without consuming Gem.
+      max-parallel: 5
       matrix:
         shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
     outputs:

--- a/.github/workflows/runner-heartbeat.yml
+++ b/.github/workflows/runner-heartbeat.yml
@@ -2,13 +2,10 @@ name: Runner Heartbeat
 
 on:
   # GitHub cron delivery is best-effort and can be delayed well past its nominal
-  # interval. Probe every combined candidate and direct main generation so the
-  # hosted CI router can await current, exact evidence instead of inheriting a
-  # stale scheduled result.
+  # interval. Scheduled, direct-main, and manual probes retain monitoring while
+  # phase 0 prevents merge-group candidates from consuming the fixed pool.
   push:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
   schedule:
     - cron: '*/10 * * * *'
   workflow_dispatch:
@@ -19,8 +16,8 @@ permissions:
 concurrency:
   group: runner-heartbeat
   # A saturated/offline pool retains only the newest queued probe. The hosted
-  # observer and per-run CI route treat queued/in-progress, stale, malformed,
-  # or API-uncertain evidence as down and select hosted unit capacity.
+  # observer treats queued/in-progress, stale, malformed, or API-uncertain
+  # evidence as down. Unit capacity remains explicitly hosted in phase 0.
   cancel-in-progress: true
 
 jobs:

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1258,7 +1258,7 @@ describe('deploy workflow Vercel env resolution', () => {
 });
 
 describe('unit-test runner capacity', () => {
-  it('fills the pool without exceeding each ephemeral runner CPU quota', () => {
+  it('uses five-way hosted capacity while fixed runners are quarantined', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const routeJob = getJobBlock(workflow, 'ci-unit-runner-route');
     const unitJob = getJobBlock(workflow, 'ci-unit-tests');
@@ -1272,16 +1272,16 @@ describe('unit-test runner capacity', () => {
     expect(routeJob).toContain('fixed|hosted');
     expect(routeJob).not.toContain('runner: ${{ steps.route.outputs.runner }}');
     expect(routeJob).not.toContain('secrets.');
-    expect(unitJob).toContain(
-      "runs-on: ${{ needs.ci-unit-runner-route.outputs.runner_class == 'fixed' && 'jovie-runner' || 'ubuntu-latest' }}"
-    );
+    expect(unitJob).toContain('runs-on: ubuntu-latest');
+    expect(unitJob).not.toContain('runs-on: jovie-runner');
+    expect(unitJob).not.toContain('ci-unit-runner-route');
     expect(unitJob).not.toContain('vars.CI_UNIT_RUNNER');
-    expect(unitJob).toContain('max-parallel: 2');
+    expect(unitJob).toContain('max-parallel: 5');
     expect(unitJob).toContain(
-      'Five logical shards, at most two concurrent per queue candidate'
+      'Hosted capacity runs all five logical shards without consuming Gem'
     );
-    expect(unitJob).toContain('anti-slam headroom');
-    expect(unitJob).toContain('Runner Heartbeat');
+    expect(unitJob).toContain('all five named');
+    expect(unitJob).toContain('warm-canary receipts');
     expect(unitJob).toContain('run: echo "run_full_ci=true"');
     expect(unitJob).not.toContain(
       "github.event_name == 'merge_group' && needs.ci-path-changes.outputs.run_test == 'true'"

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -107,11 +107,13 @@ describe('merge_group workflow contract', () => {
     expect(CI_WORKFLOW).not.toContain('steps.graphite');
   });
 
-  it('selects unit capacity on hosted evidence and fails uncertainty to hosted', () => {
+  it('quarantines fixed unit capacity until all named warm receipts exist', () => {
     const route = getJobBlock(CI_WORKFLOW, 'ci-unit-runner-route');
     const units = getJobBlock(CI_WORKFLOW, 'ci-unit-tests');
 
     expect(route).toContain('runs-on: ubuntu-latest');
+    expect(route).toContain("if: github.event_name == 'workflow_dispatch'");
+    expect(route).not.toContain("github.event_name == 'merge_group'");
     expect(route).toContain('ref: main');
     expect(route).toContain('continue-on-error: true');
     expect(route).toContain('GH_TOKEN: ${{ github.token }}');
@@ -121,13 +123,13 @@ describe('merge_group workflow contract', () => {
     expect(route).toContain("runner_class='hosted'");
     expect(route).toContain('fixed|hosted');
     expect(route).not.toContain('runner: ${{ steps.route.outputs.runner }}');
-    expect(units).toContain('ci-unit-runner-route');
+    expect(units).not.toContain('ci-unit-runner-route');
     expect(units).toContain('ci-merge-group-admission');
-    expect(units).toContain(
-      "runs-on: ${{ needs.ci-unit-runner-route.outputs.runner_class == 'fixed' && 'jovie-runner' || 'ubuntu-latest' }}"
-    );
+    expect(units).toContain('runs-on: ubuntu-latest');
+    expect(units).not.toContain('runs-on: jovie-runner');
     expect(units).not.toContain('vars.CI_UNIT_RUNNER');
-    expect(units).toContain('max-parallel: 2');
+    expect(units).toContain('max-parallel: 5');
+    expect(units).toContain('all five named');
   });
 
   it('admits expensive queue lanes only while exact external gates are green', () => {
@@ -169,7 +171,7 @@ describe('merge_group workflow contract', () => {
     const ciFast = getJobBlock(CI_WORKFLOW, 'ci-fast');
     expect(ciFast).toContain("github.event_name != 'merge_group'");
     const units = getJobBlock(CI_WORKFLOW, 'ci-unit-tests');
-    expect(units).toContain("needs.ci-unit-runner-route.result == 'success'");
+    expect(units).not.toContain('ci-unit-runner-route');
     expect(units).toContain(
       "github.event_name == 'push' && github.ref == 'refs/heads/main'"
     );
@@ -263,7 +265,7 @@ describe('merge_group workflow contract', () => {
     expect(buildLayout).not.toContain('actions/upload-artifact');
     expect(buildLayout).not.toContain('actions/download-artifact');
     expect(unitTests).toContain("shard: ['1/5', '2/5', '3/5', '4/5', '5/5']");
-    expect(unitTests).toContain('max-parallel: 2');
+    expect(unitTests).toContain('max-parallel: 5');
     expect(getJobBlock(CI_WORKFLOW, 'ci-a11y')).not.toContain(
       "github.event_name == 'merge_group'"
     );
@@ -460,7 +462,6 @@ describe('merge_group workflow contract', () => {
     }
 
     const activeJobs = [
-      'ci-unit-runner-route',
       'ci-path-changes',
       'ci-merge-group-admission',
       'ci-risk-classifier',

--- a/scripts/tests/test_runner_routing.py
+++ b/scripts/tests/test_runner_routing.py
@@ -633,25 +633,22 @@ def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
     assert 'degrade pending "current exact heartbeat' in query
     assert "for ((attempt = 1; attempt <= POLL_ATTEMPTS; attempt++))" in awaiter
     assert 'if [[ "$probe_state" != "pending" ]]' in awaiter
-    assert (
-        "[ci-path-changes, ci-unit-runner-route, ci-merge-group-admission]" in units
-    )
-    assert (
-        "runs-on: ${{ needs.ci-unit-runner-route.outputs.runner_class == "
-        "'fixed' && 'jovie-runner' || 'ubuntu-latest' }}"
-    ) in units
+    assert "needs: [ci-path-changes, ci-merge-group-admission]" in units
+    assert "ci-unit-runner-route" not in units
+    assert "runs-on: ubuntu-latest" in units
+    assert "runs-on: jovie-runner" not in units
     assert "vars.CI_UNIT_RUNNER" not in units
-    assert "max-parallel: 2" in units
+    assert "max-parallel: 5" in units
+    assert "all five named" in units
 
 
-def test_event_driven_heartbeat_has_no_recursive_trigger_or_fixed_pool_fanout() -> None:
+def test_merge_group_allocates_no_fixed_runner_probe() -> None:
     heartbeat = (_WORKFLOWS / "runner-heartbeat.yml").read_text(encoding="utf-8")
     route = _job_block("ci.yml", "ci-unit-runner-route")
 
     assert "push:" in heartbeat
     assert "branches: [main]" in heartbeat
-    assert "merge_group:" in heartbeat
-    assert "types: [checks_requested]" in heartbeat
+    assert "merge_group:" not in heartbeat
     assert "schedule:" in heartbeat
     assert "workflow_dispatch:" in heartbeat
     assert "pull_request:" not in heartbeat
@@ -661,6 +658,8 @@ def test_event_driven_heartbeat_has_no_recursive_trigger_or_fixed_pool_fanout() 
     assert "group: runner-heartbeat" in heartbeat
     assert "cancel-in-progress: true" in heartbeat
     assert "matrix:" not in heartbeat
+    assert "if: github.event_name == 'workflow_dispatch'" in route
+    assert "github.event_name == 'merge_group'" not in route
     assert "actions: write" not in route
     assert "/dispatches" not in route
     assert "gh workflow run" not in route


### PR DESCRIPTION
## Summary

- Quarantine generic fixed-runner routing for merge-group unit shards.
- Run all five unit shards explicitly on ubuntu-latest with max-parallel 5.
- Remove merge_group heartbeat probing while retaining scheduled, direct-main, and manual monitoring.

## Safety boundary

- Source pull-request behavior is unchanged: unit shards still run only for merge-group, direct-main, or manual events.
- This candidate self-applies: its merge-group combined head allocates zero generic fixed jobs and runs five hosted unit shards in parallel.
- No runner labels, services, heartbeat state, caches, lockfiles, or live infrastructure were mutated.
- Existing setup-node-pnpm behavior remains intact: GitHub-hosted pnpm cache keyed by **/pnpm-lock.yaml; no node_modules cache or artifact was added.
- GitHub merge_group semantics: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group

## Verification

- Node 22: deploy workflow contract — 70 passed
- Node 22: merge-group contract — 12 passed
- Python routing + workflow hygiene — 47 passed
- CI control suite — 177 passed
- CI harness manifest/docs check — passed
- Merge-queue config check — passed
- actionlint — passed
- Biome — passed
- bug-to-test — not applicable (CI configuration-only change)
- Independent review — PASS, 0 P0/P1/P2 (two reviewers)

## Local pre-push runtime incident

The ordinary pre-push gate ran under unsupported Node v26.5.0 and failed 24 localStorage-dependent tests across seven unrelated files. Required Node 22 focused/control suites are fresh and green. The exact-prepared signed SHA was pushed once with the documented JOVIE_SKIP_PRE_PUSH_GATE=1 exception after root authorization; no force and no --no-verify.

## Release boundary

- Draft only.
- Labels intentionally empty.
- Do not enqueue or merge until review is complete.
