### PR TITLE
fix(reliability): fail-soft reads on migration-drifted relations (JOV-3353, JOV-3359)

### DIFF
--- a/apps/web/lib/library/approval-status.server.ts
+++ b/apps/web/lib/library/approval-status.server.ts
@@ -2,22 +2,62 @@ import 'server-only';
 
 import { and, eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
+import { getDeepErrorMessage, unwrapPgError } from '@/lib/db/errors';
 import { libraryAssetApprovalStatuses } from '@/lib/db/schema/library';
+import { captureWarning } from '@/lib/error-tracking';
 import type { LibraryApprovalStatus } from './approval-status';
 import { DEFAULT_LIBRARY_APPROVAL_STATUS } from './approval-status';
+
+/**
+ * True when Postgres reports the `library_asset_approval_statuses` relation
+ * is missing — migration 0058 shipped ahead of prod (migration-drift class,
+ * JOV-3359). Drizzle surfaces these as "Failed query: ..." with the
+ * underlying PG error (42P01 undefined_table) on `.cause`.
+ */
+export function isMissingLibraryApprovalStatusTableError(
+  error: unknown
+): boolean {
+  const message = getDeepErrorMessage(error).toLowerCase();
+  if (
+    !message.includes('does not exist') &&
+    unwrapPgError(error).code !== '42P01'
+  ) {
+    return false;
+  }
+
+  return message.includes('library_asset_approval_statuses');
+}
 
 export async function getLibraryApprovalStatusMapForProfile(
   creatorProfileId: string
 ): Promise<ReadonlyMap<string, LibraryApprovalStatus>> {
-  const rows = await db
-    .select({
-      assetId: libraryAssetApprovalStatuses.assetId,
-      approvalStatus: libraryAssetApprovalStatuses.approvalStatus,
-    })
-    .from(libraryAssetApprovalStatuses)
-    .where(eq(libraryAssetApprovalStatuses.creatorProfileId, creatorProfileId));
+  try {
+    const rows = await db
+      .select({
+        assetId: libraryAssetApprovalStatuses.assetId,
+        approvalStatus: libraryAssetApprovalStatuses.approvalStatus,
+      })
+      .from(libraryAssetApprovalStatuses)
+      .where(
+        eq(libraryAssetApprovalStatuses.creatorProfileId, creatorProfileId)
+      );
 
-  return new Map(rows.map(row => [row.assetId, row.approvalStatus] as const));
+    return new Map(rows.map(row => [row.assetId, row.approvalStatus] as const));
+  } catch (error) {
+    // Migration drift (JOV-3359): degrade to "no explicit statuses" so every
+    // asset renders at its documented default instead of 500-ing the Library
+    // page. Only the missing-relation class degrades; every other error
+    // still throws.
+    if (!isMissingLibraryApprovalStatusTableError(error)) {
+      throw error;
+    }
+    await captureWarning(
+      '[library] library_asset_approval_statuses relation missing (migration drift); treating all assets as default approval status',
+      error,
+      { creatorProfileId }
+    );
+    return new Map();
+  }
 }
 
 export async function upsertLibraryApprovalStatus(input: {

--- a/apps/web/lib/waitlist/settings.ts
+++ b/apps/web/lib/waitlist/settings.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 import { and, sql as drizzleSql, eq } from 'drizzle-orm';
 import { type DbOrTransaction, db } from '@/lib/db';
+import { getDeepErrorMessage, unwrapPgError } from '@/lib/db/errors';
 import { waitlistSettings } from '@/lib/db/schema/waitlist';
 import { captureWarning } from '@/lib/error-tracking';
 import { getRedis } from '@/lib/redis';
@@ -172,67 +173,16 @@ function getStartOfNextDayUTC(now: Date = new Date()): Date {
   return next;
 }
 
-async function ensureSettingsRow(
-  dbOrTx: DbOrTransaction = db
-): Promise<WaitlistGateSettings> {
-  // Hot path: cheap SELECT first (matches previous behavior and keeps
-  // existing test mocks working without requiring full insert chain mocks).
-  const [existing] = await dbOrTx
-    .select()
-    .from(waitlistSettings)
-    .where(eq(waitlistSettings.id, SETTINGS_ROW_ID))
-    .limit(1);
-
-  if (existing) {
-    return existing;
-  }
-
-  const now = new Date();
-
-  // Miss path: single atomic upsert (INSERT ... ON CONFLICT DO UPDATE) creates
-  // the row if absent. On concurrent first callers, the loser takes the
-  // conflict path and still receives the row via RETURNING — no reload race,
-  // no throw ever.
-  const [row] = await dbOrTx
-    .insert(waitlistSettings)
-    .values({
-      id: SETTINGS_ROW_ID,
-      gateEnabled: true,
-      autoAcceptEnabled: false,
-      autoAcceptAfterDays: 7,
-      autoAcceptDailyLimit: 0,
-      autoAcceptedToday: 0,
-      autoAcceptResetsAt: getStartOfNextDayUTC(now),
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: waitlistSettings.id,
-      set: {
-        // Self-assignment is a deliberate no-op: ensures RETURNING yields the
-        // existing row on the conflict path without mutating data or timestamps.
-        updatedAt: drizzleSql`${waitlistSettings.updatedAt}`,
-      },
-    })
-    .returning();
-
-  if (row) {
-    return row;
-  }
-
-  // Defensive fallback (extremely rare). Plain select again, else safe defaults.
-  // Guarantees ensureSettingsRow (and therefore gate + auto-accept paths) never
-  // throws on reload.
-  const [reloaded] = await dbOrTx
-    .select()
-    .from(waitlistSettings)
-    .where(eq(waitlistSettings.id, SETTINGS_ROW_ID))
-    .limit(1);
-
-  if (reloaded) {
-    return reloaded;
-  }
-
-  const fallback: WaitlistGateSettings = {
+/**
+ * Documented default gate state — matches the column defaults in
+ * `lib/db/schema/waitlist.ts` (gate on, auto-accept off). Used when the
+ * settings row cannot be materialized and when the `waitlist_settings`
+ * relation is missing in prod (migration drift, JOV-3353).
+ */
+function getDefaultWaitlistGateSettings(
+  now: Date = new Date()
+): WaitlistGateSettings {
+  return {
     gateEnabled: true,
     autoAcceptEnabled: false,
     autoAcceptAfterDays: 7,
@@ -240,7 +190,102 @@ async function ensureSettingsRow(
     autoAcceptedToday: 0,
     autoAcceptResetsAt: getStartOfNextDayUTC(now),
   };
-  return fallback;
+}
+
+/**
+ * True when Postgres reports the `waitlist_settings` relation is missing —
+ * the known migration-drift class where code ships ahead of the prod
+ * migration (JOV-3353). Drizzle surfaces these as "Failed query: ..." with
+ * the underlying PG error (42P01 undefined_table) on `.cause`.
+ */
+export function isMissingWaitlistSettingsTableError(error: unknown): boolean {
+  const message = getDeepErrorMessage(error).toLowerCase();
+  if (
+    !message.includes('does not exist') &&
+    unwrapPgError(error).code !== '42P01'
+  ) {
+    return false;
+  }
+
+  return message.includes('waitlist_settings');
+}
+
+async function ensureSettingsRow(
+  dbOrTx: DbOrTransaction = db
+): Promise<WaitlistGateSettings> {
+  try {
+    // Hot path: cheap SELECT first (matches previous behavior and keeps
+    // existing test mocks working without requiring full insert chain mocks).
+    const [existing] = await dbOrTx
+      .select()
+      .from(waitlistSettings)
+      .where(eq(waitlistSettings.id, SETTINGS_ROW_ID))
+      .limit(1);
+
+    if (existing) {
+      return existing;
+    }
+
+    const now = new Date();
+
+    // Miss path: single atomic upsert (INSERT ... ON CONFLICT DO UPDATE) creates
+    // the row if absent. On concurrent first callers, the loser takes the
+    // conflict path and still receives the row via RETURNING — no reload race,
+    // no throw ever.
+    const [row] = await dbOrTx
+      .insert(waitlistSettings)
+      .values({
+        id: SETTINGS_ROW_ID,
+        gateEnabled: true,
+        autoAcceptEnabled: false,
+        autoAcceptAfterDays: 7,
+        autoAcceptDailyLimit: 0,
+        autoAcceptedToday: 0,
+        autoAcceptResetsAt: getStartOfNextDayUTC(now),
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: waitlistSettings.id,
+        set: {
+          // Self-assignment is a deliberate no-op: ensures RETURNING yields the
+          // existing row on the conflict path without mutating data or timestamps.
+          updatedAt: drizzleSql`${waitlistSettings.updatedAt}`,
+        },
+      })
+      .returning();
+
+    if (row) {
+      return row;
+    }
+
+    // Defensive fallback (extremely rare). Plain select again, else safe defaults.
+    // Guarantees ensureSettingsRow (and therefore gate + auto-accept paths) never
+    // throws on reload.
+    const [reloaded] = await dbOrTx
+      .select()
+      .from(waitlistSettings)
+      .where(eq(waitlistSettings.id, SETTINGS_ROW_ID))
+      .limit(1);
+
+    if (reloaded) {
+      return reloaded;
+    }
+
+    return getDefaultWaitlistGateSettings(now);
+  } catch (error) {
+    // Migration drift (JOV-3353): degrade reads to the documented default
+    // gate state instead of 500-ing /start and /signin. Only the missing-
+    // relation class degrades; every other error still throws. Write paths
+    // (admin updates) surface the error from their own UPDATE statement.
+    if (!isMissingWaitlistSettingsTableError(error)) {
+      throw error;
+    }
+    await captureWarning(
+      '[waitlist] waitlist_settings relation missing (migration drift); using default gate settings',
+      error
+    );
+    return getDefaultWaitlistGateSettings();
+  }
 }
 
 export async function getWaitlistSettings(

--- a/apps/web/tests/unit/library/approval-status-server.test.ts
+++ b/apps/web/tests/unit/library/approval-status-server.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDbSelect, mockCaptureWarning } = vi.hoisted(() => ({
+  mockDbSelect: vi.fn(),
+  mockCaptureWarning: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mockDbSelect,
+  },
+}));
+
+vi.mock('@/lib/db/schema/library', () => ({
+  libraryAssetApprovalStatuses: {
+    assetId: 'asset_id',
+    approvalStatus: 'approval_status',
+    creatorProfileId: 'creator_profile_id',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col, val) => ({ eq: val })),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureWarning: mockCaptureWarning,
+}));
+
+/**
+ * Mirrors the prod migration-drift failure (JOV-3359): Drizzle wraps the PG
+ * 42P01 (undefined_table) error, so the outer message is "Failed query: ..."
+ * and the real error lives on `.cause`.
+ */
+function createMissingApprovalStatusTableError() {
+  return new Error(
+    'Failed query: select "asset_id", "approval_status" from "library_asset_approval_statuses" where "library_asset_approval_statuses"."creator_profile_id" = $1',
+    {
+      cause: {
+        code: '42P01',
+        message: 'relation "library_asset_approval_statuses" does not exist',
+      },
+    }
+  );
+}
+
+function setupDbSelectMock(
+  rows: Array<{ assetId: string; approvalStatus: string }>
+) {
+  mockDbSelect.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  });
+}
+
+function setupDbSelectError(error: unknown) {
+  mockDbSelect.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockRejectedValue(error),
+    }),
+  });
+}
+
+describe('getLibraryApprovalStatusMapForProfile', () => {
+  let getLibraryApprovalStatusMapForProfile: typeof import('@/lib/library/approval-status.server').getLibraryApprovalStatusMapForProfile;
+  let isMissingLibraryApprovalStatusTableError: typeof import('@/lib/library/approval-status.server').isMissingLibraryApprovalStatusTableError;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockDbSelect.mockClear();
+    mockCaptureWarning.mockClear();
+
+    const mod = await import('@/lib/library/approval-status.server');
+    getLibraryApprovalStatusMapForProfile =
+      mod.getLibraryApprovalStatusMapForProfile;
+    isMissingLibraryApprovalStatusTableError =
+      mod.isMissingLibraryApprovalStatusTableError;
+  });
+
+  it('returns explicit approval statuses keyed by asset id (happy path unchanged)', async () => {
+    setupDbSelectMock([
+      { assetId: 'release_1', approvalStatus: 'approved' },
+      { assetId: 'release_2', approvalStatus: 'needs_review' },
+    ]);
+
+    const result = await getLibraryApprovalStatusMapForProfile('profile-1');
+
+    expect(result.size).toBe(2);
+    expect(result.get('release_1')).toBe('approved');
+    expect(result.get('release_2')).toBe('needs_review');
+    expect(mockCaptureWarning).not.toHaveBeenCalled();
+  });
+
+  it('degrades to an empty map with one warning when the relation is missing in prod (JOV-3359)', async () => {
+    setupDbSelectError(createMissingApprovalStatusTableError());
+
+    const result = await getLibraryApprovalStatusMapForProfile('profile-1');
+
+    expect(result.size).toBe(0);
+    expect(mockCaptureWarning).toHaveBeenCalledTimes(1);
+    expect(mockCaptureWarning.mock.calls[0][0]).toContain(
+      'library_asset_approval_statuses'
+    );
+  });
+
+  it('still throws non-drift DB errors (no broad swallow)', async () => {
+    setupDbSelectError(new Error('connection terminated unexpectedly'));
+
+    await expect(
+      getLibraryApprovalStatusMapForProfile('profile-1')
+    ).rejects.toThrow('connection terminated unexpectedly');
+    expect(mockCaptureWarning).not.toHaveBeenCalled();
+  });
+
+  it('matches only the missing library_asset_approval_statuses relation', () => {
+    expect(
+      isMissingLibraryApprovalStatusTableError(
+        createMissingApprovalStatusTableError()
+      )
+    ).toBe(true);
+    expect(
+      isMissingLibraryApprovalStatusTableError(
+        new Error('relation "waitlist_settings" does not exist', {
+          cause: { code: '42P01' },
+        })
+      )
+    ).toBe(false);
+    expect(isMissingLibraryApprovalStatusTableError(new Error('boom'))).toBe(
+      false
+    );
+  });
+});

--- a/apps/web/tests/unit/waitlist/settings.test.ts
+++ b/apps/web/tests/unit/waitlist/settings.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { captureWarning } from '@/lib/error-tracking';
 
 const { mockDbSelect, mockDbInsert, mockDbUpdate } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(),
@@ -78,6 +79,33 @@ function setupDbSelectMock(row: ReturnType<typeof createMockSettings> | null) {
       }),
     }),
   });
+}
+
+function setupDbSelectError(error: unknown) {
+  mockDbSelect.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockRejectedValue(error),
+      }),
+    }),
+  });
+}
+
+/**
+ * Mirrors the prod migration-drift failure (JOV-3353): Drizzle wraps the PG
+ * 42P01 (undefined_table) error, so the outer message is "Failed query: ..."
+ * and the real error lives on `.cause`.
+ */
+function createMissingWaitlistSettingsError() {
+  return new Error(
+    'Failed query: select "id", "gate_enabled", "auto_accept_enabled", "auto_accept_after_days", "auto_accept_daily_limit", "auto_accepted_today", "auto_accept_resets_at", "created_at", "updated_at" from "waitlist_settings" where "waitlist_settings"."id" = $1 limit $2',
+    {
+      cause: {
+        code: '42P01',
+        message: 'relation "waitlist_settings" does not exist',
+      },
+    }
+  );
 }
 
 describe('isWaitlistGateEnabled', () => {
@@ -340,5 +368,75 @@ describe('updateWaitlistSettings invalidates cache', () => {
 
     // updateWaitlistSettings still works (admin tooling preserved)
     expect(mockDbUpdate).toHaveBeenCalled();
+  });
+});
+
+describe('migration-drift fail-soft (JOV-3353)', () => {
+  let isWaitlistGateEnabled: typeof import('@/lib/waitlist/settings').isWaitlistGateEnabled;
+  let getWaitlistSettings: typeof import('@/lib/waitlist/settings').getWaitlistSettings;
+  let isMissingWaitlistSettingsTableError: typeof import('@/lib/waitlist/settings').isMissingWaitlistSettingsTableError;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockDbSelect.mockClear();
+    mockDbInsert.mockClear();
+    mockDbUpdate.mockClear();
+    vi.mocked(captureWarning).mockClear();
+
+    const mod = await import('@/lib/waitlist/settings');
+    isWaitlistGateEnabled = mod.isWaitlistGateEnabled;
+    getWaitlistSettings = mod.getWaitlistSettings;
+    isMissingWaitlistSettingsTableError =
+      mod.isMissingWaitlistSettingsTableError;
+  });
+
+  it('matches only the missing waitlist_settings relation', () => {
+    expect(
+      isMissingWaitlistSettingsTableError(createMissingWaitlistSettingsError())
+    ).toBe(true);
+    expect(
+      isMissingWaitlistSettingsTableError(
+        new Error('relation "library_asset_approval_statuses" does not exist', {
+          cause: { code: '42P01' },
+        })
+      )
+    ).toBe(false);
+    expect(isMissingWaitlistSettingsTableError(new Error('boom'))).toBe(false);
+  });
+
+  it('isWaitlistGateEnabled degrades to the documented default gate state with one warning when the relation is missing', async () => {
+    setupDbSelectError(createMissingWaitlistSettingsError());
+
+    // Documented default gate state (schema default) is gateEnabled=true.
+    await expect(isWaitlistGateEnabled()).resolves.toBe(true);
+    expect(captureWarning).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(captureWarning).mock.calls[0][0]).toContain(
+      'waitlist_settings'
+    );
+  });
+
+  it('getWaitlistSettings returns documented defaults without issuing writes when the relation is missing', async () => {
+    setupDbSelectError(createMissingWaitlistSettingsError());
+
+    const settings = await getWaitlistSettings();
+
+    expect(settings.gateEnabled).toBe(true);
+    expect(settings.autoAcceptEnabled).toBe(false);
+    expect(settings.autoAcceptAfterDays).toBe(7);
+    expect(settings.autoAcceptDailyLimit).toBe(0);
+    expect(settings.autoAcceptResetsAt.getTime()).toBeGreaterThan(Date.now());
+    // No INSERT/UPDATE may be attempted against the drifted relation.
+    expect(mockDbInsert).not.toHaveBeenCalled();
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(captureWarning).toHaveBeenCalledTimes(1);
+  });
+
+  it('still throws non-drift DB errors (no broad swallow)', async () => {
+    setupDbSelectError(new Error('connection terminated unexpectedly'));
+
+    await expect(isWaitlistGateEnabled()).rejects.toThrow(
+      'connection terminated unexpectedly'
+    );
+    expect(captureWarning).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description

**Workstream:** fail-soft reads on prod-migration-drift (GBrain triage `engineering/backlog-triage-2026-07-20`, actionable queue item 2).

Prod Neon is missing two relations the drizzle schema expects, so read paths threw and 500'd:

- `waitlist_settings` (baseline 0000, prod drifted) → `ensureSettingsRow` threw on every call → `GET /start` (56 events / 55 users) and `GET /signin` (50 / 48) via `isWaitlistGateEnabled` in the auth gate (Redis fail-soft existed, but no try/catch around the DB fetch).
- `library_asset_approval_statuses` (migration `0058_fair_madame_masque.sql`) → `getLibraryApprovalStatusMapForProfile` threw on every Library page load (`app/app/(shell)/library/page.tsx:48`).

### Issues + grouping rationale

- **JOV-3353** (canonical; JOV-3354 is a canceled duplicate) — missing `waitlist_settings`.
- **JOV-3359** — missing `library_asset_approval_statuses`.

Grouped into one PR: same root cause (schema ahead of prod; migration-drift class), same fix pattern, and same rollback boundary (one revert restores both throw paths).

### Confirmed root cause

Drizzle surfaces the drift as `Failed query: ...` wrapping PG `42P01` (`undefined_table`) on `.cause` — error bodies match the Linear issue titles verbatim (the exact failing SELECTs).

### Fix (smallest correct, established pattern)

Uses the repo's existing narrow-guard fail-soft pattern — `lib/connectors/schema-errors.ts`, `lib/analytics/daily-profile-views.ts` — not an invented one:

1. Guard helper `isMissing<Relation>TableError(error)`: `getDeepErrorMessage` includes `does not exist` **or** `unwrapPgError(error).code === '42P01'` (helpers from `lib/db/errors.ts`), **and** the message references the specific relation. Narrow by construction — connection resets, logic bugs, and constraint errors still throw.
2. Catch site: `if (!guard(error)) throw error;` → one `captureWarning('[scope] … relation missing (migration drift); …', error, ctx)` → degrade to the documented default.

Scope of changes:

- `apps/web/lib/waitlist/settings.ts` — `ensureSettingsRow` degrades to the **documented default gate state** (identical to the schema column defaults in `lib/db/schema/waitlist.ts`: `gateEnabled: true`, auto-accept off, existing in-code fallback extracted to `getDefaultWaitlistGateSettings`). Protects `isWaitlistGateEnabled` (/start, /signin), `getWaitlistSettings`, `tryReserveAutoAcceptSlot`. The degraded row has `autoAcceptResetsAt` in the future, so no follow-up UPDATE is attempted against the missing relation; the admin write path still surfaces errors from its own UPDATE.
- `apps/web/lib/library/approval-status.server.ts` — `getLibraryApprovalStatusMapForProfile` degrades to an **empty `Map`** (every asset renders at `DEFAULT_LIBRARY_APPROVAL_STATUS`); merch and asset-share loads on the Library page are no longer collateral of the all-or-nothing page-level catch.

Happy-path behavior when the tables exist is unchanged (pure try/catch addition + extracted default factory).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Unit tests pass
- [x] New tests added (if applicable)

### Bug-to-Test Rule (required for bug fixes)

- [x] Regression test added or updated (`*.test.*` / `*.spec.*`)
- [x] `bug-to-test: satisfied` noted in this PR description

New regression tests simulate the exact prod failure shape (Drizzle-wrapped 42P01):

- `apps/web/tests/unit/waitlist/settings.test.ts` (+4): guard matches only `waitlist_settings`; `isWaitlistGateEnabled` resolves `true` (documented default) with exactly one warning; `getWaitlistSettings` returns defaults with **no INSERT/UPDATE attempted**; non-drift DB errors still throw with no warning. Existing happy-path tests unchanged and green.
- `apps/web/tests/unit/library/approval-status-server.test.ts` (new, 4): happy path returns the status map; missing relation resolves an empty Map with exactly one warning; non-drift errors still throw; guard matches only `library_asset_approval_statuses`.

### Validation outputs

```
$ pnpm --filter web exec vitest run tests/unit/waitlist tests/unit/library tests/unit/api/library-approval-status.test.ts
 Test Files  21 passed (21)
      Tests  124 passed (124)

$ pnpm biome check --write apps/web/lib/waitlist/settings.ts apps/web/lib/library/approval-status.server.ts apps/web/tests/unit/waitlist/settings.test.ts apps/web/tests/unit/library/approval-status-server.test.ts
Checked 4 files in 16ms. Fixed 2 files.  (formatting only; re-verified)

$ pnpm --filter @jovie/web run typecheck -- --pretty false
(exit 0, no errors)
```

## Risk

Low. Pure additive try/catch on read paths; degradation is scoped to the 42P01 / `does not exist` class naming the exact relation, so real errors (connection, logic, constraints) still throw and alert. When tables exist, behavior is byte-identical to today. Note: during active drift the degraded gate default is `gateEnabled: true` — the same default the code already uses when the settings row cannot be materialized, and the schema column default.

## Rollback

Revert this PR (single commit) to restore previous throw behavior; no migrations, no data changes, no cache state to clear (degraded values ride the existing 5s/30s gate cache TTLs).

## OPS follow-up (human/ops track, recorded in Linear)

Code fail-soft stops the 500s but the drift remains: ops must run a **prod migration journal audit** (compare `drizzle/migrations` journal vs prod `__drizzle_migrations`; re-apply baseline 0000 delta for `waitlist_settings` and migration 0058 for `library_asset_approval_statuses`). The Sentry warnings emitted by these fail-soft paths are the drift heartbeat until then.

## GBrain

- **Read:** `engineering/backlog-triage-2026-07-20` (workstream assignment, actionable queue item 2).
- **Written:** `engineering/prod-migration-drift-fail-soft-reads` (type: engineering-decision — symptom, root cause, pattern, protected paths, tests, ops follow-up).
