### PR TITLE
fix(releases): guard releaseId at the query boundary (JOV-3308)

### DIFF
--- a/apps/web/components/jovie/chat-context-rail.ts
+++ b/apps/web/components/jovie/chat-context-rail.ts
@@ -1,4 +1,5 @@
 import type { ChatRailContextTarget } from '@/app/app/(shell)/chat/ChatEntityPanelContext';
+import { isChatContextTemplatePlaceholder } from '@/lib/chat/context-label';
 import { parseTokens } from '@/lib/chat/tokens';
 import { encodeToolEvents } from '@/lib/chat/tool-events';
 import type { MessagePart } from './types';
@@ -89,6 +90,13 @@ export function deriveChatRailContextTargets({
         return;
       }
 
+      // The system prompt documents token syntax with literal placeholders
+      // (`@release:<id>[<title>]`); when the model echoes one back, the parsed
+      // id is the placeholder itself, not a real entity id (JOV-3308).
+      if (isChatContextTemplatePlaceholder(token.id)) {
+        return;
+      }
+
       targets.push({
         kind: token.kind,
         id: token.id,
@@ -116,7 +124,7 @@ export function deriveChatRailContextTargets({
           firstStringValue(event.input, field.idKeys) ??
           firstStringValue(event.output, field.idKeys);
 
-        if (!id) {
+        if (!id || isChatContextTemplatePlaceholder(id)) {
           continue;
         }
 

--- a/apps/web/lib/discography/queries.ts
+++ b/apps/web/lib/discography/queries.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { and, sql as drizzleSql, eq, inArray, isNull, ne } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { isUniqueViolation as isUniqueViolationUtil } from '@/lib/db/errors';
@@ -21,6 +22,7 @@ import {
 } from '@/lib/db/schema/content';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { publicReleaseEligibilitySqlPredicate } from '@/lib/profile/public-release-eligibility';
+import { uuidSchema } from '@/lib/validation/schemas/base';
 import { resolveTrackProviderLinks } from './track-provider-links';
 
 /**
@@ -442,6 +444,18 @@ export async function getReleaseForProfileById(
   releaseId: string,
   options?: { includeDrafts?: boolean }
 ): Promise<ReleaseWithProviders | null> {
+  // Query-boundary guard (JOV-3308): releaseId can arrive from chat entity
+  // tokens / tool calls, where the model may pass the literal system-prompt
+  // placeholder `<id>`. Postgres would throw `invalid input syntax for type
+  // uuid` — treat a non-UUID as "no such release" (graceful empty state).
+  if (!uuidSchema.safeParse(releaseId).success) {
+    Sentry.captureMessage('getReleaseForProfileById: non-UUID releaseId', {
+      level: 'warning',
+      extra: { creatorProfileId, releaseId },
+    });
+    return null;
+  }
+
   const filters = [
     eq(discogReleases.creatorProfileId, creatorProfileId),
     eq(discogReleases.id, releaseId),

--- a/apps/web/tests/unit/chat/chat-context-rail.test.ts
+++ b/apps/web/tests/unit/chat/chat-context-rail.test.ts
@@ -70,4 +70,50 @@ describe('deriveChatRailContextTargets', () => {
       }),
     ]);
   });
+
+  it('ignores entity tokens whose id is a system-prompt placeholder (JOV-3308)', () => {
+    const targets = deriveChatRailContextTargets({
+      messages: [
+        {
+          id: 'msg-3',
+          parts: [
+            {
+              type: 'text',
+              // The model echoing the documented token syntax literally.
+              text: 'Here is @release:<id>[Midnight Drive] as requested',
+            },
+          ],
+        },
+      ],
+      profile: { id: 'profile-1', label: 'Tim White' },
+    });
+
+    expect(targets).toEqual([]);
+  });
+
+  it('ignores tool-event entity ids that are template placeholders (JOV-3308)', () => {
+    const targets = deriveChatRailContextTargets({
+      messages: [
+        {
+          id: 'msg-4',
+          parts: [
+            {
+              type: 'dynamic-tool',
+              toolName: 'generateAlbumArt',
+              toolCallId: 'tool-2',
+              state: 'output-available',
+              input: {
+                releaseId: '<id>',
+                releaseTitle: 'Midnight Drive',
+              },
+              output: { success: false },
+            },
+          ],
+        },
+      ],
+      profile: { id: 'profile-1', label: 'Tim White' },
+    });
+
+    expect(targets).toEqual([]);
+  });
 });

--- a/apps/web/tests/unit/discography/queries.get-release-for-profile-by-id.test.ts
+++ b/apps/web/tests/unit/discography/queries.get-release-for-profile-by-id.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  const selectMock = vi.fn();
+  const captureMessageMock = vi.fn();
+
+  return {
+    selectMock,
+    captureMessageMock,
+  };
+});
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: hoisted.selectMock,
+  },
+  doesTableExist: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: hoisted.captureMessageMock,
+}));
+
+import { getReleaseForProfileById } from '@/lib/discography/queries';
+
+const CREATOR_PROFILE_ID = '3fa85f64-5717-4562-b3fc-2c963f66afa6';
+const RELEASE_ID = '7c9e6679-7425-40de-944b-e07fc1f90ae7';
+
+/** Chain for the initial release lookup: select().from().where().limit(1) */
+function createReleaseChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+/** Chain for track summaries: select().from().innerJoin().where().groupBy() */
+function createTrackSummaryChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          groupBy: vi.fn().mockResolvedValue(rows),
+        }),
+      }),
+    }),
+  };
+}
+
+/** Chain for artist names: select().from().innerJoin().where().orderBy() */
+function createArtistNamesChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockResolvedValue(rows),
+        }),
+      }),
+    }),
+  };
+}
+
+/** Chain for provider links: select().from().where() (awaited directly) */
+function createProviderLinksChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  };
+}
+
+function mockHydrationChains() {
+  hoisted.selectMock
+    .mockReturnValueOnce(createTrackSummaryChain([]))
+    .mockReturnValueOnce(createArtistNamesChain([]))
+    .mockReturnValueOnce(createProviderLinksChain([]));
+}
+
+describe('getReleaseForProfileById', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    '<id>',
+    'not-a-uuid',
+    'rel_1',
+    '',
+  ])('returns null without querying when releaseId is not a UUID (%s)', async releaseId => {
+    const result = await getReleaseForProfileById(
+      CREATOR_PROFILE_ID,
+      releaseId
+    );
+
+    expect(result).toBeNull();
+    expect(hoisted.selectMock).not.toHaveBeenCalled();
+    expect(hoisted.captureMessageMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.captureMessageMock).toHaveBeenCalledWith(
+      'getReleaseForProfileById: non-UUID releaseId',
+      expect.objectContaining({
+        level: 'warning',
+        extra: expect.objectContaining({ releaseId }),
+      })
+    );
+  });
+
+  it('queries and returns the release for a valid UUID (unchanged behavior)', async () => {
+    const releaseRow = {
+      id: RELEASE_ID,
+      creatorProfileId: CREATOR_PROFILE_ID,
+      title: 'Midnight Drive',
+      slug: 'midnight-drive',
+    };
+    hoisted.selectMock.mockReturnValueOnce(createReleaseChain([releaseRow]));
+    mockHydrationChains();
+
+    const result = await getReleaseForProfileById(
+      CREATOR_PROFILE_ID,
+      RELEASE_ID
+    );
+
+    expect(result).toEqual({
+      ...releaseRow,
+      artistNames: [],
+      providerLinks: [],
+      trackSummary: undefined,
+    });
+    expect(hoisted.selectMock).toHaveBeenCalledTimes(4);
+    expect(hoisted.captureMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a valid UUID that matches no release', async () => {
+    hoisted.selectMock.mockReturnValueOnce(createReleaseChain([]));
+
+    const result = await getReleaseForProfileById(
+      CREATOR_PROFILE_ID,
+      RELEASE_ID
+    );
+
+    expect(result).toBeNull();
+    expect(hoisted.selectMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.captureMessageMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Workstream: query-boundary input validation. A literal template token `"<id>"` was reaching Postgres as `releaseId` in the chat release-context path, throwing `invalid input syntax for type uuid` on every hit.

- **Issue:** JOV-3308
- **Sentry:** JOVIE-WEB-MN (`POST /app/chat`)

## Confirmed root cause

1. The chat system prompt documents entity-token syntax with literal placeholders: `` `@release:<id>[<title>]` `` (`apps/web/lib/chat/system-prompt.ts:153`).
2. The model echoes the placeholder back in assistant text (or passes `releaseId: '<id>'` as tool input).
3. `deriveChatRailContextTargets` (`apps/web/components/jovie/chat-context-rail.ts`) accepted those ids with no placeholder filtering → rail target `id: '<id>'`.
4. `useReleaseEntityQuery` → `loadReleaseEntity` server action (a `POST` to the current route, i.e. `/app/chat` — matches the Sentry transaction).
5. `getReleaseForProfileById` fed the value straight into `eq(discogReleases.id, releaseId)` → PG 22P02. No UUID guard existed anywhere in the chain (callers `release-matrix-loader.ts:81`, `release-metadata.ts:32`).

## Scope

- `apps/web/lib/discography/queries.ts` — `getReleaseForProfileById` now validates `releaseId` with the established `uuidSchema` (`lib/validation/schemas/base.ts`) before building filters. Non-UUID → `Sentry.captureMessage` at `warning` level (sibling pattern: `spotify-import.ts`) + `null` (graceful empty state). **Valid-UUID behavior unchanged.**
- `apps/web/components/jovie/chat-context-rail.ts` — leak fix (outside the chat route): entity tokens and tool-event ids matching the existing `isChatContextTemplatePlaceholder` helper are dropped, so the rail never issues a query for `<id>`.
- Tests: new `tests/unit/discography/queries.get-release-for-profile-by-id.test.ts` (6 tests) + 2 new placeholder cases in `tests/unit/chat/chat-context-rail.test.ts`.

Deliberately **not** touched: `apps/web/app/api/chat/**` (owned by another workstream this wave). Optional follow-up: reword the system-prompt token docs to reduce model echoing — not required, the two layers here close the loop.

## Validation

- `vitest run tests/unit/discography/queries.get-release-for-profile-by-id.test.ts tests/unit/chat/chat-context-rail.test.ts` → 10/10 pass
- Wider net: `vitest run tests/unit/discography tests/unit/chat` → 109 files, 923/923 pass
- `pnpm biome check --write <changed files>` → clean
- `pnpm --filter @jovie/web run typecheck -- --pretty false` → clean (node 22.23.1)

## Risk

Low. The guard only adds an early-return for inputs that previously crashed the query; the rail filter only drops targets that could never resolve to a real entity. No schema, API, or valid-path behavior change.

## Rollback

Revert this PR (single commit). No migrations or config changes.

## GBrain

- Read: `engineering/backlog-triage-2026-07-20` (JOV-3308 is queue item 3; scope matches)
- Written: `engineering/release-id-uuid-guard` (symptom, root cause, guard pattern, leak-hunt result, tests)
