### PR TITLE
fix(ui): use canonical EntityCard in entity hover popover (#13919)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- **Entity mention hover cards now use the same rich entity card as the chat rail:** hovering an inline release, artist, track, or event mention opens the canonical compact EntityCard instead of a one-off popover layout.
 - **Artist profiles now adapt to release, touring, and live-support moments:** one music-native link brings listening, tickets, support, fan capture, setup guidance, and product truth into a clearer responsive journey.
 - **[internal] Production Sentry gate secret binding:** the post-deploy error-rate gate now runs inside the protected production environment, so its API token is available without crossing a nested reusable-workflow boundary.
 - **[internal] Fixed-pool unit routing:** healthy runner heartbeats now select the fixed CI pool through a non-sensitive route token, preserving hosted fail-closed fallback without GitHub suppressing the runner decision.

--- a/apps/web/components/jovie/components/EntityChipPopover.test.tsx
+++ b/apps/web/components/jovie/components/EntityChipPopover.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { ComponentProps, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fastRender } from '@/tests/utils/fast-render';
 import { EntityChip } from './EntityChip';
@@ -19,10 +19,14 @@ vi.mock('@/app/app/(shell)/chat/ChatEntityPanelContext', () => ({
   useOptionalChatEntityPanel: () => mockEntityPanelState.entityPanel,
 }));
 
-vi.mock('next/image', () => ({
-  default: ({ src, alt, ...rest }: ComponentProps<'img'>) => (
-    <img src={src as string} alt={alt ?? ''} {...rest} />
-  ),
+vi.mock('@/components/atoms/ImageWithFallback', () => ({
+  ImageWithFallback: ({
+    alt,
+    src,
+  }: {
+    readonly alt: string;
+    readonly src?: string | null;
+  }) => (src ? <img src={src} alt={alt} /> : null),
 }));
 
 function renderPopover(children?: ReactNode) {
@@ -127,12 +131,17 @@ describe('EntityChipPopover', () => {
     expect(screen.queryByTestId('entity-chip-popover-content')).toBeNull();
   });
 
-  it('renders label inside the popover body when open', async () => {
+  it('renders the canonical compact EntityCard when open', async () => {
     const user = userEvent.setup();
     renderPopover();
     await user.click(screen.getByTestId('entity-chip-popover-trigger'));
     const content = await screen.findByTestId('entity-chip-popover-content');
     expect(content.textContent).toContain('Sober');
+
+    const card = screen.getByTestId('entity-chip-popover-card');
+    expect(card).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Sober' })).toBeInTheDocument();
+    expect(content.textContent).toContain('Release');
   });
 
   it('uses the chat overlay tier with an opaque bounded surface', async () => {
@@ -142,15 +151,7 @@ describe('EntityChipPopover', () => {
     const content = await screen.findByTestId('entity-chip-popover-content');
 
     expect(content).toHaveClass('system-b-entity-chip-popover-content');
-    expect(
-      content.querySelector('.system-b-entity-chip-popover-body')
-    ).toBeTruthy();
-    expect(
-      content.querySelector('.system-b-entity-chip-popover-placeholder')
-    ).toBeTruthy();
-    expect(
-      content.querySelector('.system-b-entity-chip-popover-title')
-    ).toHaveTextContent('Sober');
+    expect(screen.getByTestId('entity-chip-popover-card')).toBeTruthy();
   });
 
   it('renders the release panel action with System B casing and primitives', async () => {
@@ -165,7 +166,6 @@ describe('EntityChipPopover', () => {
     const action = await screen.findByRole('button', {
       name: /Open Release/i,
     });
-    expect(action).toHaveClass('system-b-entity-chip-popover-action');
     expect(action).toHaveTextContent('Open Release');
 
     await user.click(action);
@@ -177,5 +177,25 @@ describe('EntityChipPopover', () => {
       source: 'manual',
       focusKey: 'release:rel_1:Sober',
     });
+  });
+
+  it('degrades gracefully for unresolved entities without layout thrash', async () => {
+    const user = userEvent.setup();
+    fastRender(
+      <EntityChipPopover kind='track' id='trk_missing' label='Unknown Track'>
+        <EntityChip
+          data={{ kind: 'track', id: 'trk_missing', label: 'Unknown Track' }}
+          variant='transcript'
+        />
+      </EntityChipPopover>
+    );
+
+    await user.click(screen.getByTestId('entity-chip-popover-trigger'));
+    const card = await screen.findByTestId('entity-chip-popover-card');
+    expect(card.tagName).toBe('DIV');
+    expect(
+      screen.getByRole('heading', { name: 'Unknown Track' })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Open/i })).toBeNull();
   });
 });

--- a/apps/web/components/jovie/components/EntityChipPopover.tsx
+++ b/apps/web/components/jovie/components/EntityChipPopover.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { Popover, PopoverContent, PopoverTrigger } from '@jovie/ui';
-import { ArrowUpRight } from 'lucide-react';
-import Image from 'next/image';
 import {
   type CSSProperties,
   type KeyboardEvent,
@@ -16,10 +14,15 @@ import {
 } from 'react';
 import { useOptionalChatEntityPanel } from '@/app/app/(shell)/chat/ChatEntityPanelContext';
 import { useOptionalPreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
+import {
+  type ChatEntityMentionInput,
+  chatEntityMentionToEntityCard,
+  EntityCard,
+} from '@/components/organisms/entity-card';
 import type { EntityKind } from '@/lib/chat/tokens';
-import type { EntityRef, EntityRefMeta } from '@/lib/commands/entities';
+import type { EntityRef } from '@/lib/commands/entities';
 import { useAppFlag } from '@/lib/flags/client';
-import { getInitials } from '@/lib/utils/initials';
+import { cn } from '@/lib/utils';
 import { ENTITY_KIND_ACCENT_VAR } from './entity-accent';
 
 const HOVER_OPEN_DELAY_MS = 200;
@@ -52,8 +55,8 @@ interface EntityChipPopoverProps {
  * - Escape → close (Radix Popover handles by default)
  * - focus visible ring on the trigger
  *
- * Popover content is lazy-mounted (Radix only renders when open) so adding
- * one wrapper per transcript chip doesn't pay Popover state cost upfront.
+ * Popover content renders the canonical compact `EntityCard` (same component
+ * as the chat right rail) so every entity surface shares one anatomy.
  */
 export function EntityChipPopover({
   kind,
@@ -174,7 +177,7 @@ export function EntityChipPopover({
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className='system-b-entity-chip-popover-content'
+        className='system-b-entity-chip-popover-content border-0 bg-transparent p-0 shadow-none'
         side='top'
         sideOffset={6}
         align='start'
@@ -198,6 +201,7 @@ export function EntityChipPopover({
       >
         <EntityChipPopoverBody
           kind={kind}
+          id={id}
           label={label}
           entity={entity}
           canOpen={canOpenEntityPanel}
@@ -212,6 +216,7 @@ export function EntityChipPopover({
 
 interface EntityChipPopoverBodyProps {
   readonly kind: EntityKind;
+  readonly id: string;
   readonly label: string;
   readonly entity: EntityRef | undefined;
   readonly canOpen: boolean;
@@ -220,8 +225,63 @@ interface EntityChipPopoverBodyProps {
   readonly onOpenProfilePreview: () => void;
 }
 
+function toMentionInput(
+  kind: EntityKind,
+  id: string,
+  label: string,
+  entity: EntityRef | undefined
+): ChatEntityMentionInput {
+  const meta = entity?.meta;
+  const base: ChatEntityMentionInput = {
+    kind,
+    id,
+    label: entity?.label ?? label,
+    thumbnail: entity?.thumbnail ?? null,
+  };
+
+  if (!meta) {
+    return base;
+  }
+
+  if (meta.kind === 'release') {
+    return {
+      ...base,
+      subtitle: meta.subtitle,
+      releaseType: meta.releaseType,
+      totalTracks: meta.totalTracks,
+      totalDurationMs: meta.totalDurationMs,
+    };
+  }
+  if (meta.kind === 'artist') {
+    return {
+      ...base,
+      subtitle: meta.subtitle,
+      followers: meta.followers,
+      verified: meta.verified,
+      isYou: meta.isYou,
+    };
+  }
+  if (meta.kind === 'event') {
+    return {
+      ...base,
+      subtitle: meta.subtitle,
+      venue: meta.venue,
+      city: meta.city,
+      eventType: meta.eventType,
+      eventDate: meta.eventDate,
+    };
+  }
+  return {
+    ...base,
+    subtitle: meta.subtitle,
+    durationMs: meta.durationMs,
+    releaseTitle: meta.releaseTitle,
+  };
+}
+
 function EntityChipPopoverBody({
   kind,
+  id,
   label,
   entity,
   canOpen,
@@ -229,114 +289,46 @@ function EntityChipPopoverBody({
   canOpenProfilePreview,
   onOpenProfilePreview,
 }: EntityChipPopoverBodyProps) {
-  const eyebrow = entity ? eyebrowFor(entity) : KIND_PREFIX[kind];
-  const subtitle = entity?.meta?.subtitle;
-  const stats = entity?.meta ? compactStatsFor(entity.meta) : null;
-  const thumbnail = entity?.thumbnail;
+  const model = useMemo(() => {
+    const mention = toMentionInput(kind, id, label, entity);
+    const interactive = canOpen || canOpenProfilePreview;
+    const cta = canOpenProfilePreview
+      ? {
+          label: 'Open Live Profile Preview',
+          onClick: () => {
+            onOpenProfilePreview();
+          },
+        }
+      : canOpen
+        ? {
+            label: `Open ${KIND_PREFIX[kind]}`,
+            onClick: () => {
+              onOpenEntity();
+            },
+          }
+        : null;
+
+    return chatEntityMentionToEntityCard(mention, {
+      interactive,
+      cta,
+    });
+  }, [
+    kind,
+    id,
+    label,
+    entity,
+    canOpen,
+    canOpenProfilePreview,
+    onOpenEntity,
+    onOpenProfilePreview,
+  ]);
 
   return (
-    <div className='system-b-entity-chip-popover-body'>
-      <div className='system-b-entity-chip-popover-media'>
-        {thumbnail ? (
-          <Image
-            src={thumbnail}
-            alt=''
-            width={48}
-            height={48}
-            className='system-b-entity-chip-popover-thumbnail'
-            aria-hidden
-          />
-        ) : (
-          <div aria-hidden className='system-b-entity-chip-popover-placeholder'>
-            {getInitials(label) || '·'}
-          </div>
-        )}
-      </div>
-      <div className='system-b-entity-chip-popover-copy'>
-        <p className='system-b-entity-chip-popover-eyebrow'>{eyebrow}</p>
-        <p className='system-b-entity-chip-popover-title'>{label}</p>
-        {subtitle ? (
-          <p className='system-b-entity-chip-popover-subtitle'>{subtitle}</p>
-        ) : null}
-        {stats ? (
-          <p className='system-b-entity-chip-popover-stats'>{stats}</p>
-        ) : null}
-        {canOpenProfilePreview ? (
-          <button
-            type='button'
-            onClick={onOpenProfilePreview}
-            className='system-b-entity-chip-popover-action focus-ring'
-          >
-            Open live profile preview
-            <ArrowUpRight className='system-b-entity-chip-popover-action-icon' />
-          </button>
-        ) : null}
-        {canOpen ? (
-          <button
-            type='button'
-            onClick={onOpenEntity}
-            className='system-b-entity-chip-popover-action focus-ring'
-          >
-            Open {KIND_PREFIX[kind]}
-            <ArrowUpRight className='system-b-entity-chip-popover-action-icon' />
-          </button>
-        ) : null}
-      </div>
-    </div>
+    <EntityCard
+      model={model}
+      treatment='compact'
+      className={cn('w-full shadow-popover')}
+      dataTestId='entity-chip-popover-card'
+    />
   );
-}
-
-function eyebrowFor(entity: EntityRef): string {
-  const meta = entity.meta;
-  if (!meta) return KIND_PREFIX[entity.kind];
-  if (meta.kind === 'release') {
-    const type = meta.releaseType
-      ? meta.releaseType[0].toUpperCase() +
-        meta.releaseType.slice(1).toLowerCase()
-      : null;
-    return type ? `Release · ${type}` : 'Release';
-  }
-  if (meta.kind === 'artist') {
-    if (meta.isYou) return 'Artist · You';
-    if (meta.verified) return 'Artist · Verified';
-    return 'Artist';
-  }
-  if (meta.kind === 'event') {
-    return meta.eventType
-      ? `Event · ${meta.eventType[0].toUpperCase()}${meta.eventType.slice(1)}`
-      : 'Event';
-  }
-  return 'Track';
-}
-
-function compactStatsFor(meta: EntityRefMeta): string | null {
-  const parts: string[] = [];
-  if (meta.kind === 'release') {
-    if (typeof meta.totalTracks === 'number' && meta.totalTracks > 0) {
-      parts.push(
-        `${meta.totalTracks} ${meta.totalTracks === 1 ? 'track' : 'tracks'}`
-      );
-    }
-    if (typeof meta.totalDurationMs === 'number' && meta.totalDurationMs > 0) {
-      const totalSeconds = Math.round(meta.totalDurationMs / 1000);
-      const minutes = Math.floor(totalSeconds / 60);
-      const seconds = totalSeconds % 60;
-      parts.push(`${minutes}:${seconds.toString().padStart(2, '0')}`);
-    }
-  } else if (meta.kind === 'artist') {
-    if (typeof meta.followers === 'number' && meta.followers > 0) {
-      parts.push(`${compactNumber(meta.followers)} followers`);
-    }
-  } else if (meta.kind === 'event') {
-    if (meta.venue) parts.push(meta.venue);
-    if (meta.city) parts.push(meta.city);
-  }
-  return parts.length > 0 ? parts.join(' · ') : null;
-}
-
-function compactNumber(value: number): string {
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
-  if (value >= 10_000) return `${Math.round(value / 1000)}k`;
-  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
-  return value.toString();
 }

--- a/apps/web/components/organisms/entity-card/adapters.test.ts
+++ b/apps/web/components/organisms/entity-card/adapters.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { PublicMerchCard } from '@/lib/merch/types';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import {
+  chatEntityMentionToEntityCard,
   chatReleaseContextToEntityCard,
   chatTourDateContextToEntityCard,
   merchToEntityCard,
@@ -147,6 +148,74 @@ describe('chatReleaseContextToEntityCard', () => {
 
     expect(model.title).toBe('Lost In The Light');
     expect(model.meta).toBe('Loading Release');
+  });
+});
+
+describe('chatEntityMentionToEntityCard', () => {
+  it('maps a resolved release mention into a compact card model', () => {
+    const model = chatEntityMentionToEntityCard({
+      kind: 'release',
+      id: 'rel_1',
+      label: 'Sober',
+      thumbnail: 'https://cdn.test/sober.jpg',
+      releaseType: 'single',
+      totalTracks: 1,
+      totalDurationMs: 210_000,
+    });
+
+    expect(model.kind).toBe('music');
+    expect(model.title).toBe('Sober');
+    expect(model.imageUrl).toBe('https://cdn.test/sober.jpg');
+    expect(model.eyebrow).toBe('Release · Single');
+    expect(model.meta).toBe('1 track · 3:30');
+    expect(model.href).toBeUndefined();
+    expect(model.cta).toBeNull();
+  });
+
+  it('degrades to label-only for unresolved mentions', () => {
+    const model = chatEntityMentionToEntityCard({
+      kind: 'artist',
+      id: 'art_x',
+      label: 'Unknown Artist',
+    });
+
+    expect(model.kind).toBe('music');
+    expect(model.title).toBe('Unknown Artist');
+    expect(model.imageUrl).toBeNull();
+    expect(model.eyebrow).toBe('Artist');
+    expect(model.meta).toBeNull();
+  });
+
+  it('maps events to show cards with date pills when artwork is missing', () => {
+    const model = chatEntityMentionToEntityCard({
+      kind: 'event',
+      id: 'evt_1',
+      label: 'Brooklyn Steel',
+      eventType: 'tour',
+      eventDate: '2026-06-12T23:30:00.000Z',
+      venue: 'Brooklyn Steel',
+      city: 'Brooklyn, NY',
+    });
+
+    expect(model.kind).toBe('show');
+    expect(model.eyebrow).toBe('Event · Tour');
+    expect(model.datePill).toEqual({ month: 'Jun', day: '12' });
+    expect(model.meta).toBe('Brooklyn Steel · Brooklyn, NY');
+  });
+
+  it('attaches interactive CTAs for panel open actions', () => {
+    const onClick = vi.fn();
+    const model = chatEntityMentionToEntityCard(
+      { kind: 'release', id: 'rel_1', label: 'Sober' },
+      { interactive: true, cta: { label: 'Open Release', onClick } }
+    );
+
+    expect(model.interactive).toBe(true);
+    expect(model.cta?.label).toBe('Open Release');
+    model.cta?.onClick?.(
+      {} as unknown as import('react').MouseEvent<HTMLElement>
+    );
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/components/organisms/entity-card/adapters.ts
+++ b/apps/web/components/organisms/entity-card/adapters.ts
@@ -26,6 +26,9 @@ const MONTHS = [
   'Dec',
 ] as const;
 
+const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' });
+const dayFormatter = new Intl.DateTimeFormat('en-US', { day: 'numeric' });
+
 function toDate(value: Date | string | null | undefined): Date | null {
   if (!value) {
     return null;
@@ -189,6 +192,154 @@ export function chatReleaseContextToEntityCard(
   };
 }
 
+/**
+ * Inline chat entity mention (chip / hover popover) → compact EntityCard.
+ * Accepts the wire mention shape without importing chat command modules so the
+ * organism stays free of composer/registry coupling.
+ */
+export type ChatEntityMentionKind = 'release' | 'artist' | 'track' | 'event';
+
+export interface ChatEntityMentionInput {
+  readonly kind: ChatEntityMentionKind;
+  readonly id: string;
+  readonly label: string;
+  readonly thumbnail?: string | null;
+  readonly subtitle?: string | null;
+  readonly releaseType?: string | null;
+  readonly totalTracks?: number | null;
+  readonly totalDurationMs?: number | null;
+  readonly followers?: number | null;
+  readonly verified?: boolean;
+  readonly isYou?: boolean;
+  readonly venue?: string | null;
+  readonly city?: string | null;
+  readonly eventType?: string | null;
+  readonly eventDate?: string | null;
+  readonly durationMs?: number | null;
+  readonly releaseTitle?: string | null;
+}
+
+function cardKindForMention(
+  kind: ChatEntityMentionKind
+): EntityCardModel['kind'] {
+  return kind === 'event' ? 'show' : 'music';
+}
+
+function mentionEyebrow(input: ChatEntityMentionInput): string {
+  switch (input.kind) {
+    case 'release': {
+      const typeLabel = formatReleaseType(input.releaseType);
+      return typeLabel ? `Release · ${typeLabel}` : 'Release';
+    }
+    case 'artist': {
+      if (input.isYou) return 'Artist · You';
+      if (input.verified) return 'Artist · Verified';
+      return 'Artist';
+    }
+    case 'event': {
+      if (!input.eventType) return 'Event';
+      const type =
+        input.eventType.charAt(0).toUpperCase() + input.eventType.slice(1);
+      return `Event · ${type}`;
+    }
+    default:
+      return 'Track';
+  }
+}
+
+function mentionMeta(input: ChatEntityMentionInput): string | null {
+  if (input.subtitle?.trim()) {
+    return input.subtitle.trim();
+  }
+
+  const parts: string[] = [];
+  switch (input.kind) {
+    case 'release': {
+      if (typeof input.totalTracks === 'number' && input.totalTracks > 0) {
+        parts.push(
+          `${input.totalTracks} ${input.totalTracks === 1 ? 'track' : 'tracks'}`
+        );
+      }
+      if (
+        typeof input.totalDurationMs === 'number' &&
+        input.totalDurationMs > 0
+      ) {
+        const totalSeconds = Math.round(input.totalDurationMs / 1000);
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
+        parts.push(`${minutes}:${seconds.toString().padStart(2, '0')}`);
+      }
+      break;
+    }
+    case 'artist': {
+      if (typeof input.followers === 'number' && input.followers > 0) {
+        parts.push(`${compactFollowers(input.followers)} followers`);
+      }
+      break;
+    }
+    case 'track': {
+      if (input.releaseTitle?.trim()) {
+        parts.push(input.releaseTitle.trim());
+      }
+      if (typeof input.durationMs === 'number' && input.durationMs > 0) {
+        const totalSeconds = Math.round(input.durationMs / 1000);
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
+        parts.push(`${minutes}:${seconds.toString().padStart(2, '0')}`);
+      }
+      break;
+    }
+    case 'event': {
+      if (input.venue?.trim()) parts.push(input.venue.trim());
+      if (input.city?.trim()) parts.push(input.city.trim());
+      break;
+    }
+  }
+
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+function compactFollowers(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 10_000) return `${Math.round(value / 1000)}k`;
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  return value.toString();
+}
+
+/** Chat inline entity mention → compact EntityCard model (popover / rail). */
+export function chatEntityMentionToEntityCard(
+  input: ChatEntityMentionInput,
+  options?: Readonly<{
+    cta?: EntityCardModel['cta'];
+    interactive?: boolean;
+  }>
+): EntityCardModel {
+  const kind = cardKindForMention(input.kind);
+  const preset = KIND_PRESETS[kind];
+  const title = input.label.trim() || 'Untitled';
+  const date = input.kind === 'event' ? toDate(input.eventDate ?? null) : null;
+
+  return {
+    id: input.id,
+    kind,
+    imageUrl: input.thumbnail ?? null,
+    imageAlt: title,
+    accent: preset.accent,
+    eyebrow: mentionEyebrow(input),
+    title,
+    meta: mentionMeta(input),
+    datePill:
+      kind === 'show' && date && !input.thumbnail
+        ? {
+            month: monthFormatter.format(date),
+            day: dayFormatter.format(date),
+          }
+        : null,
+    interactive: options?.interactive === true,
+    cta: options?.cta ?? null,
+  };
+}
+
 export interface ChatTourDateContextInput {
   readonly id: string;
   readonly title?: string | null;
@@ -231,9 +382,6 @@ export function chatTourDateContextToEntityCard(
     meta: 'Tour Date Context',
   };
 }
-
-const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' });
-const dayFormatter = new Intl.DateTimeFormat('en-US', { day: 'numeric' });
 
 function getTourEyebrow(
   isNearYou: boolean,
@@ -370,7 +518,7 @@ export function aiCrawlerAnalyticsToEntityCard(
         ? { label: 'Active', tone: 'live' }
         : { label: 'Collecting', tone: 'neutral' },
     cta: analytics.isTeaser
-      ? { label: 'Upgrade to Pro', href: null, disabled: true }
+      ? { label: 'Upgrade To Pro', href: null, disabled: true }
       : {
           label: preset.ctaLabel,
           href: null,

--- a/apps/web/components/organisms/entity-card/index.ts
+++ b/apps/web/components/organisms/entity-card/index.ts
@@ -1,4 +1,6 @@
 export type {
+  ChatEntityMentionInput,
+  ChatEntityMentionKind,
   ChatReleaseContextInput,
   ChatTourDateContextInput,
   ReleaseEntityInput,
@@ -7,6 +9,7 @@ export type {
 } from './adapters';
 export {
   aiCrawlerAnalyticsToEntityCard,
+  chatEntityMentionToEntityCard,
   chatReleaseContextToEntityCard,
   chatTourDateContextToEntityCard,
   merchToEntityCard,

--- a/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
@@ -92,7 +92,7 @@ describe('entity rich chip System B style guard', () => {
     expect(mentionCss).not.toContain('border-radius: var(--radius-full)');
   });
 
-  it('keeps entity chip popover internals on named System B primitives', () => {
+  it('keeps entity chip popover on the canonical EntityCard + System B trigger', () => {
     const popoverSource = readFileSync(
       path.join(webRoot, 'components/jovie/components/EntityChipPopover.tsx'),
       'utf8'
@@ -101,20 +101,23 @@ describe('entity rich chip System B style guard', () => {
       path.join(webRoot, 'styles/design-system.css'),
       'utf8'
     );
-    const requiredClasses = [
-      'system-b-entity-chip-trigger',
-      'system-b-entity-chip-popover-body',
-      'system-b-entity-chip-popover-thumbnail',
-      'system-b-entity-chip-popover-placeholder',
-      'system-b-entity-chip-popover-title',
-      'system-b-entity-chip-popover-action',
-      'system-b-entity-chip-popover-action-icon',
-    ];
 
-    for (const className of requiredClasses) {
-      expect(popoverSource).toContain(className);
-      expect(designSystemSource).toContain(`.${className}`);
-    }
+    expect(popoverSource).toContain('system-b-entity-chip-trigger');
+    expect(popoverSource).toContain('system-b-entity-chip-popover-content');
+    expect(popoverSource).toContain(
+      "from '@/components/organisms/entity-card'"
+    );
+    expect(popoverSource).toContain('chatEntityMentionToEntityCard');
+    expect(popoverSource).toContain('<EntityCard');
+    expect(popoverSource).toContain("treatment='compact'");
+    expect(popoverSource).not.toContain('system-b-entity-chip-popover-body');
+    expect(popoverSource).not.toContain(
+      'system-b-entity-chip-popover-thumbnail'
+    );
+    expect(designSystemSource).toContain('.system-b-entity-chip-trigger');
+    expect(designSystemSource).toContain(
+      '.system-b-entity-chip-popover-content'
+    );
 
     expect(popoverSource).not.toMatch(
       /h-12 w-12|rounded-xl border border-subtle|mt-2 inline-flex|text-2xs font-caption/


### PR DESCRIPTION
## Summary
- Replace bespoke `EntityChipPopover` markup with the shared compact `EntityCard` used by the chat right rail.
- Add `chatEntityMentionToEntityCard` adapter for resolved and unresolved chat entity mentions.
- Preserve hover/click/keyboard a11y and Open Release / Open Live Profile Preview actions via interactive EntityCard CTAs.

## Why
#13919: entity mention hover should render the canonical rich entity card (same component as the right rail), not a one-off popover layout.

## Test plan
- [x] `vitest` EntityChipPopover + adapters + style-guard
- [x] `typecheck` @jovie/web
- [x] Biome + ESLint on touched files (pre-commit)

## Risk
Low — content swap inside an existing popover. Visual change: hover content now matches compact EntityCard anatomy (image + title/meta) instead of the previous 48px horizontal thumbnail layout.

## Cost Impact
None.

Fixes #13919
<!-- linear-issue-id:none -->