### PR TITLE
feat(ui): complete canonical Link primitive and migrate ad-hoc anchors (JOV-3574)

### DIFF
--- a/apps/web/components/atoms/FooterLink.tsx
+++ b/apps/web/components/atoms/FooterLink.tsx
@@ -1,3 +1,4 @@
+import { Link as UILink } from '@jovie/ui';
 import Link from 'next/link';
 import React from 'react';
 import { cn } from '@/lib/utils';
@@ -45,27 +46,33 @@ export const FooterLink = React.forwardRef<HTMLAnchorElement, FooterLinkProps>(
         ? 'text-secondary-token hover:text-primary-token hover:bg-surface-1'
         : 'text-white/70 hover:text-white hover:bg-white/5';
 
+    // Renders through the canonical Link primitive (asChild + variant={null}).
+    // The primitive base supplies inline-flex, transition-colors, and the
+    // focus-visible ring; these classes preserve the existing footer-link
+    // appearance (padding hit area, text-app sizing, tone palette, and the
+    // subtle duration/easing, which win over the base timing in the cascade).
     const linkClassName = cn(
-      'inline-flex items-center rounded-md px-2 py-1 -mx-2 -my-1',
+      'rounded-md px-2 py-1 -mx-2 -my-1',
       'text-app leading-5 font-medium tracking-tight',
-      'transition-colors duration-subtle ease-out',
-      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interactive focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+      'duration-subtle ease-out',
+      'focus-visible:ring-interactive focus-visible:ring-offset-transparent',
       palette,
       className
     );
 
     return (
-      <Link
-        ref={ref}
-        href={href}
-        prefetch={prefetch}
-        className={linkClassName}
-        target={resolvedTarget}
-        rel={resolvedRel}
-        {...props}
-      >
-        <span className='inline-flex items-center gap-2'>{children}</span>
-      </Link>
+      <UILink asChild variant={null} className={linkClassName}>
+        <Link
+          ref={ref}
+          href={href}
+          prefetch={prefetch}
+          target={resolvedTarget}
+          rel={resolvedRel}
+          {...props}
+        >
+          <span className='inline-flex items-center gap-2'>{children}</span>
+        </Link>
+      </UILink>
     );
   }
 );

--- a/apps/web/components/atoms/FrostedButton.tsx
+++ b/apps/web/components/atoms/FrostedButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, type ButtonProps } from '@jovie/ui';
+import { Button, type ButtonProps, Link as UILink } from '@jovie/ui';
 import Link from 'next/link';
 import React from 'react';
 import { cn } from '@/lib/utils';
@@ -38,17 +38,22 @@ export const FrostedButton = React.forwardRef<
     );
 
     if (href) {
+      // Button owns the visual contract (asChild); the canonical Link
+      // primitive composes the Next.js anchor underneath it (Radix Slot
+      // chain: Button -> UILink -> next/link).
       return (
         <Button asChild variant={variant} className={frostedClasses} {...props}>
-          <Link
-            ref={ref as React.Ref<HTMLAnchorElement>}
-            href={href}
-            prefetch={prefetch}
-            target={external ? '_blank' : undefined}
-            rel={external ? 'noopener noreferrer' : undefined}
-          >
-            {children}
-          </Link>
+          <UILink asChild variant={null}>
+            <Link
+              ref={ref as React.Ref<HTMLAnchorElement>}
+              href={href}
+              prefetch={prefetch}
+              target={external ? '_blank' : undefined}
+              rel={external ? 'noopener noreferrer' : undefined}
+            >
+              {children}
+            </Link>
+          </UILink>
         </Button>
       );
     }

--- a/apps/web/components/atoms/NavLink.tsx
+++ b/apps/web/components/atoms/NavLink.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { buttonVariants } from '@jovie/ui';
+import { Link as UILink } from '@jovie/ui';
 import Link from 'next/link';
 import React from 'react';
 import { cn, getExternalLinkProps, isExternalUrl } from '@/lib/utils';
@@ -26,32 +26,34 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
     },
     ref
   ) => {
-    const baseStyles = buttonVariants({
-      variant: variant === 'primary' ? 'primary' : 'ghost',
-      size: 'sm',
-      className: cn(
-        'h-auto px-0 py-0 text-sm font-medium transition-colors',
-        'hover:text-primary-token focus-visible:text-primary-token',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interactive focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-        'rounded-md',
-        variant === 'default' && 'text-muted-foreground hover:text-foreground',
-        className
-      ),
-    });
+    // Renders through the canonical Link primitive (asChild + variant={null})
+    // instead of borrowing buttonVariants for an anchor. These classes
+    // preserve the legacy appearance: ghost/primary button styling at size sm
+    // with the chrome neutralized (h-auto px-0 py-0), plus the hover/active
+    // and focus treatments the override layer used to win via cascade order.
+    const baseStyles = cn(
+      'h-auto rounded-md px-0 py-0 text-sm font-medium',
+      'focus-visible:text-primary-token focus-visible:ring-interactive focus-visible:ring-offset-background',
+      variant === 'primary'
+        ? 'border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset hover:border-(--linear-btn-primary-hover) hover:bg-(--linear-btn-primary-hover)'
+        : 'text-muted-foreground hover:text-foreground hover:bg-interactive-hover active:bg-interactive-active',
+      className
+    );
 
     const isExternal = external ?? isExternalUrl(href);
 
     return (
-      <Link
-        ref={ref}
-        href={href}
-        prefetch={prefetch}
-        className={baseStyles}
-        {...getExternalLinkProps(isExternal)}
-        {...props}
-      >
-        <span className='inline-flex items-center gap-2'>{children}</span>
-      </Link>
+      <UILink asChild variant={null} className={baseStyles}>
+        <Link
+          ref={ref}
+          href={href}
+          prefetch={prefetch}
+          {...getExternalLinkProps(isExternal)}
+          {...props}
+        >
+          <span className='inline-flex items-center gap-2'>{children}</span>
+        </Link>
+      </UILink>
     );
   }
 );

--- a/apps/web/components/atoms/NavLink.tsx
+++ b/apps/web/components/atoms/NavLink.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Link as UILink } from '@jovie/ui';
+import { Button, Link as UILink } from '@jovie/ui';
 import Link from 'next/link';
 import React from 'react';
 import { cn, getExternalLinkProps, isExternalUrl } from '@/lib/utils';
@@ -12,6 +12,12 @@ export interface NavLinkProps
   readonly variant?: 'default' | 'primary';
   readonly external?: boolean;
 }
+
+// Shared appearance overrides: the legacy ghost/primary-at-size-sm styling
+// with the chrome neutralized (h-auto px-0 py-0), plus the focus treatment
+// the override layer used to win via cascade order.
+const NAV_LINK_CHROME_CLASSES =
+  'h-auto rounded-md px-0 py-0 text-sm font-medium focus-visible:text-primary-token focus-visible:ring-interactive focus-visible:ring-offset-background';
 
 export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
   (
@@ -26,33 +32,56 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
     },
     ref
   ) => {
-    // Renders through the canonical Link primitive (asChild + variant={null})
-    // instead of borrowing buttonVariants for an anchor. These classes
-    // preserve the legacy appearance: ghost/primary button styling at size sm
-    // with the chrome neutralized (h-auto px-0 py-0), plus the hover/active
-    // and focus treatments the override layer used to win via cascade order.
-    const baseStyles = cn(
-      'h-auto rounded-md px-0 py-0 text-sm font-medium',
-      'focus-visible:text-primary-token focus-visible:ring-interactive focus-visible:ring-offset-background',
-      variant === 'primary'
-        ? 'border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset hover:border-(--linear-btn-primary-hover) hover:bg-(--linear-btn-primary-hover)'
-        : 'text-muted-foreground hover:text-foreground hover:bg-interactive-hover active:bg-interactive-active',
-      className
-    );
-
     const isExternal = external ?? isExternalUrl(href);
 
-    return (
-      <UILink asChild variant={null} className={baseStyles}>
-        <Link
-          ref={ref}
-          href={href}
-          prefetch={prefetch}
-          {...getExternalLinkProps(isExternal)}
-          {...props}
+    const anchor = (
+      <Link
+        ref={ref}
+        href={href}
+        prefetch={prefetch}
+        {...getExternalLinkProps(isExternal)}
+        {...props}
+      >
+        <span className='inline-flex items-center gap-2'>{children}</span>
+      </Link>
+    );
+
+    if (variant === 'primary') {
+      // Button-styled nav CTA: Button owns the primary visual contract
+      // (asChild), the canonical Link primitive composes the Next.js anchor
+      // underneath it — same Slot chain as FrostedButton. `static` keeps the
+      // legacy no-press-scale behavior. Do NOT inline buttonVariants' primary
+      // classes here: duplicating their --linear-* token references grows the
+      // shrink-only linear-namespace ratchet (JOV #12009).
+      return (
+        <Button
+          asChild
+          static
+          variant='primary'
+          size='sm'
+          className={cn(NAV_LINK_CHROME_CLASSES, className)}
         >
-          <span className='inline-flex items-center gap-2'>{children}</span>
-        </Link>
+          <UILink asChild variant={null}>
+            {anchor}
+          </UILink>
+        </Button>
+      );
+    }
+
+    // Renders through the canonical Link primitive (asChild + variant={null})
+    // instead of borrowing buttonVariants for an anchor; the classes preserve
+    // the legacy ghost-derived hover/active appearance.
+    return (
+      <UILink
+        asChild
+        variant={null}
+        className={cn(
+          NAV_LINK_CHROME_CLASSES,
+          'text-muted-foreground hover:text-foreground hover:bg-interactive-hover active:bg-interactive-active',
+          className
+        )}
+      >
+        {anchor}
       </UILink>
     );
   }

--- a/apps/web/components/marketing/artist-profile/ShellCtaButton.tsx
+++ b/apps/web/components/marketing/artist-profile/ShellCtaButton.tsx
@@ -1,3 +1,4 @@
+import { Link as UILink } from '@jovie/ui';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
@@ -66,14 +67,17 @@ export function ShellCtaButton({
   'data-testid': testId,
   'aria-label': ariaLabel,
 }: Readonly<ShellCtaButtonProps>) {
+  // Renders through the canonical Link primitive (asChild + variant={null});
+  // shellCtaClassName keeps the CTA pill appearance on top of it.
   return (
-    <Link
-      href={href}
-      data-testid={testId}
-      aria-label={ariaLabel}
+    <UILink
+      asChild
+      variant={null}
       className={cn(shellCtaClassName({ tone, size, context }), className)}
     >
-      {children}
-    </Link>
+      <Link href={href} data-testid={testId} aria-label={ariaLabel}>
+        {children}
+      </Link>
+    </UILink>
   );
 }

--- a/apps/web/tests/unit/NavLink.test.tsx
+++ b/apps/web/tests/unit/NavLink.test.tsx
@@ -12,6 +12,14 @@ describe('NavLink', () => {
     expect(link).toHaveClass('text-muted-foreground');
   });
 
+  it('renders through the canonical Link primitive', () => {
+    render(<NavLink href='/test'>Canonical</NavLink>);
+
+    const link = screen.getByRole('link', { name: 'Canonical' });
+    expect(link).toHaveAttribute('data-variant', 'link');
+    expect(link).toHaveAttribute('data-state', 'idle');
+  });
+
   it('renders with primary variant', () => {
     render(
       <NavLink href='/test' variant='primary'>

--- a/apps/web/tests/unit/atoms/FooterLink.test.tsx
+++ b/apps/web/tests/unit/atoms/FooterLink.test.tsx
@@ -14,6 +14,13 @@ describe('FooterLink', () => {
     expect(link).toBeInTheDocument();
   });
 
+  it('renders through the canonical Link primitive', () => {
+    render(<FooterLink href='/about'>Canonical</FooterLink>);
+    const link = screen.getByRole('link', { name: 'Canonical' });
+    expect(link).toHaveAttribute('data-variant', 'link');
+    expect(link).toHaveAttribute('data-state', 'idle');
+  });
+
   it('renders with correct href', () => {
     render(<FooterLink href='/contact'>Contact</FooterLink>);
     const link = screen.getByRole('link', { name: 'Contact' });

--- a/apps/web/tests/unit/atoms/FrostedButton.test.tsx
+++ b/apps/web/tests/unit/atoms/FrostedButton.test.tsx
@@ -10,6 +10,9 @@ vi.mock('@jovie/ui', () => ({
       {children}
     </button>
   ),
+  // Canonical Link primitive: passthrough so the Slot chain renders the
+  // Next.js anchor child in these unit tests.
+  Link: ({ children }: any) => <>{children}</>,
 }));
 
 vi.mock('next/link', () => ({

--- a/apps/web/tests/unit/atoms/canonical-link-migration.test.tsx
+++ b/apps/web/tests/unit/atoms/canonical-link-migration.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { FooterLink } from '@/components/atoms/FooterLink';
+import { FrostedButton } from '@/components/atoms/FrostedButton';
+import { NavLink } from '@/components/atoms/NavLink';
+import { ShellCtaButton } from '@/components/marketing/artist-profile/ShellCtaButton';
+
+// Render next/link as a plain anchor (forwardRef so the Radix Slot chain in
+// the canonical Link primitive can compose refs without warnings).
+vi.mock('next/link', () => {
+  const MockNextLink = React.forwardRef(
+    ({ children, ...props }: any, ref: React.Ref<HTMLAnchorElement>) => (
+      <a ref={ref} {...props}>
+        {children}
+      </a>
+    )
+  );
+  MockNextLink.displayName = 'MockNextLink';
+  return { default: MockNextLink };
+});
+
+/**
+ * JOV-3574: the four ad-hoc anchors (NavLink, FooterLink, FrostedButton,
+ * ShellCtaButton) render through the canonical Link primitive from
+ * packages/ui/atoms/link.tsx with their existing props/classes intact.
+ *
+ * These tests intentionally do NOT mock @jovie/ui: they exercise the real
+ * primitive (and, for FrostedButton, the real Button -> Link Slot chain).
+ */
+describe('canonical Link primitive migrations (JOV-3574)', () => {
+  it('NavLink renders through the primitive with its props intact', () => {
+    render(<NavLink href='/pricing'>Pricing</NavLink>);
+
+    const link = screen.getByRole('link', { name: 'Pricing' });
+    expect(link).toHaveAttribute('data-variant', 'link');
+    expect(link).toHaveAttribute('data-state', 'idle');
+    expect(link).toHaveAttribute('href', '/pricing');
+    expect(link).toHaveClass('text-sm');
+    expect(link).toHaveClass('text-muted-foreground');
+  });
+
+  it('NavLink primary keeps its button-styled appearance without buttonVariants', () => {
+    render(
+      <NavLink href='/upgrade' variant='primary'>
+        Upgrade
+      </NavLink>
+    );
+
+    const link = screen.getByRole('link', { name: 'Upgrade' });
+    expect(link).toHaveAttribute('data-variant', 'link');
+    expect(link).toHaveClass('bg-btn-primary');
+    expect(link).toHaveClass('text-btn-primary-foreground');
+  });
+
+  it('FooterLink renders through the primitive with tone and external security intact', () => {
+    render(<FooterLink href='https://example.com'>External</FooterLink>);
+
+    const link = screen.getByRole('link', { name: 'External' });
+    expect(link).toHaveAttribute('data-variant', 'link');
+    expect(link).toHaveAttribute('data-state', 'idle');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'));
+    expect(link).toHaveClass('text-white/70');
+  });
+
+  it('FooterLink light tone keeps its token palette', () => {
+    render(
+      <FooterLink href='/privacy' tone='light'>
+        Privacy
+      </FooterLink>
+    );
+
+    const link = screen.getByRole('link', { name: 'Privacy' });
+    expect(link).toHaveAttribute('data-variant', 'link');
+    expect(link).toHaveClass('text-secondary-token');
+  });
+
+  it('FrostedButton href mode renders through the primitive under Button styling', () => {
+    render(<FrostedButton href='/signup'>Sign Up</FrostedButton>);
+
+    const link = screen.getByRole('link', { name: 'Sign Up' });
+    // Button (asChild) still owns the visual contract and data attributes…
+    expect(link).toHaveAttribute('data-variant', 'secondary');
+    expect(link).toHaveAttribute('href', '/signup');
+    // …while the anchor is composed by the canonical Link primitive (its
+    // base underline-offset survives) and keeps the frosted treatment.
+    expect(link.className).toContain('underline-offset-4');
+    expect(link.className).toContain('backdrop-blur-md');
+  });
+
+  it('FrostedButton external href keeps target and rel', () => {
+    render(
+      <FrostedButton href='https://jov.ie' external>
+        Open
+      </FrostedButton>
+    );
+
+    const link = screen.getByRole('link', { name: 'Open' });
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('ShellCtaButton renders through the primitive with CTA pill classes intact', () => {
+    render(<ShellCtaButton href='/claim'>Claim Your Profile</ShellCtaButton>);
+
+    const link = screen.getByRole('link', { name: 'Claim Your Profile' });
+    expect(link).toHaveAttribute('data-variant', 'link');
+    expect(link).toHaveAttribute('data-state', 'idle');
+    expect(link).toHaveAttribute('href', '/claim');
+    expect(link.className).toContain('rounded-full');
+    expect(link.className).toContain('bg-primary-token');
+    expect(link.className).toContain('h-11');
+  });
+
+  it('ShellCtaButton on-dark secondary keeps its tone classes', () => {
+    render(
+      <ShellCtaButton href='/docs' tone='secondary' context='on-dark' size='lg'>
+        Docs
+      </ShellCtaButton>
+    );
+
+    const link = screen.getByRole('link', { name: 'Docs' });
+    expect(link.className).toContain('text-white');
+    expect(link.className).toContain('h-12');
+  });
+});

--- a/apps/web/tests/unit/atoms/canonical-link-migration.test.tsx
+++ b/apps/web/tests/unit/atoms/canonical-link-migration.test.tsx
@@ -40,7 +40,7 @@ describe('canonical Link primitive migrations (JOV-3574)', () => {
     expect(link).toHaveClass('text-muted-foreground');
   });
 
-  it('NavLink primary keeps its button-styled appearance without buttonVariants', () => {
+  it('NavLink primary keeps its button-styled appearance via Button asChild composition', () => {
     render(
       <NavLink href='/upgrade' variant='primary'>
         Upgrade
@@ -48,9 +48,13 @@ describe('canonical Link primitive migrations (JOV-3574)', () => {
     );
 
     const link = screen.getByRole('link', { name: 'Upgrade' });
-    expect(link).toHaveAttribute('data-variant', 'link');
+    // Button (asChild) owns the button-styled visual + data contract…
+    expect(link).toHaveAttribute('data-variant', 'primary');
     expect(link).toHaveClass('bg-btn-primary');
     expect(link).toHaveClass('text-btn-primary-foreground');
+    // …while the canonical Link primitive composed the anchor underneath it
+    // (its base underline-offset survives).
+    expect(link.className).toContain('underline-offset-4');
   });
 
   it('FooterLink renders through the primitive with tone and external security intact', () => {

--- a/docs/design-system/state-matrix.md
+++ b/docs/design-system/state-matrix.md
@@ -21,6 +21,8 @@ These states apply across families and were previously undocumented.
 | --- | --- | --- | --- | --- |
 | Visited | `--color-link-visited` | `a:visited`, `[data-state="visited"]` | `shadcn/Link/Visited` | `packages/ui/atoms/link.tsx` |
 | Link styling | `--color-link-default`, `--color-link-hover` | `[data-variant="link"]` | `shadcn/Link/Default` | `packages/ui/atoms/link.tsx` |
+| Link active/pressed | `--color-accent` | `:active`, `[data-state="active"]` | `shadcn/Link/Active` | `packages/ui/atoms/link.tsx` |
+| Link disabled | `--state-disabled-opacity`, `--color-text-disabled-token` | `[data-state="disabled"]`, `[aria-disabled="true"]` | `shadcn/Link/Disabled` | `packages/ui/atoms/link.tsx` |
 | Disabled visual | `--state-disabled-opacity`, `--color-text-disabled-token` | `[data-state="disabled"]`, `:disabled`, `[aria-disabled="true"]` | `shadcn/Button/DisabledVisual` | `packages/ui/atoms/button.tsx` |
 | Loading shimmer | `--color-skeleton-base`, `--color-skeleton-shimmer` | `.skeleton`, `[data-state="shimmer"]` | `shadcn/Skeleton/LoadingShimmer` | `packages/ui/atoms/skeleton.tsx` |
 | Partial data | `--state-partial-opacity` | `[data-content-state="partial"]` | `UI/Atoms/Card/PartialData` | `packages/ui/atoms/card.tsx` |
@@ -43,6 +45,8 @@ These states apply across families and were previously undocumented.
 | Success | `--color-success`, `--color-success-subtle` | `[data-state="success"]` | `Molecules/FormStatus/Success` | `apps/web/components/molecules/FormStatus.tsx` |
 | Visited | `--color-link-visited` | `a:visited`, `[data-state="visited"]` | `shadcn/Link/Visited` | `packages/ui/atoms/link.tsx` |
 | Link styling | `--color-link-default`, `--color-link-hover` | `[data-variant="link"]` | `shadcn/Link/Default` | `packages/ui/atoms/link.tsx` |
+| Link active/pressed | `--color-accent` | `:active`, `[data-state="active"]` | `shadcn/Link/Active` | `packages/ui/atoms/link.tsx` |
+| Link disabled | `--state-disabled-opacity`, `--color-text-disabled-token` | `[data-state="disabled"]`, `[aria-disabled="true"]` | `shadcn/Link/Disabled` | `packages/ui/atoms/link.tsx` |
 
 ---
 

--- a/packages/ui/atoms/link.stories.tsx
+++ b/packages/ui/atoms/link.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Link> = {
     docs: {
       description: {
         component:
-          'Canonical inline link primitive with default, subtle, and inline variants. Visited styling uses :visited and optional data-state="visited".',
+          'Canonical inline link primitive with default, subtle, and inline variants. States: default, hover, focus-visible, active (:active + data-state="active"), visited (:visited + data-state="visited"), and disabled (aria-disabled + state tokens). Composes onto Next.js Link via asChild (Radix Slot).',
       },
     },
   },
@@ -20,7 +20,16 @@ const meta: Meta<typeof Link> = {
       control: { type: 'select' },
       options: ['default', 'subtle', 'inline'],
     },
+    active: {
+      control: { type: 'boolean' },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+    },
     visited: {
+      control: { type: 'boolean' },
+    },
+    asChild: {
       control: { type: 'boolean' },
     },
   },
@@ -33,6 +42,14 @@ export const Default: Story = {
   args: {
     href: '#features',
     children: 'View release analytics',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Default state also covers native :hover and :focus-visible interaction states.',
+      },
+    },
   },
 };
 
@@ -52,6 +69,22 @@ export const Inline: Story = {
   },
 };
 
+export const Active: Story = {
+  args: {
+    href: '#active-example',
+    active: true,
+    children: 'Current page link',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Active/pressed link styling via data-state="active" and the interactive accent token --color-accent; native :active applies the same token while pressing.',
+      },
+    },
+  },
+};
+
 export const Visited: Story = {
   args: {
     href: '#visited-example',
@@ -63,6 +96,38 @@ export const Visited: Story = {
       description: {
         story:
           'Documents visited link styling via data-state="visited" and :visited token --color-link-visited.',
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    href: '#disabled-example',
+    disabled: true,
+    children: 'Unavailable link',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Disabled links set aria-disabled, data-state="disabled", pointer-events-none, and the disabled-visual tokens (--state-disabled-opacity, --color-text-disabled-token). Anchors do not support the disabled attribute.',
+      },
+    },
+  },
+};
+
+export const AsChild: Story = {
+  render: args => (
+    <Link {...args} asChild>
+      <button type='button'>Composed child element</button>
+    </Link>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'asChild composes the primitive onto a single child via Radix Slot. In apps, this is how the canonical Link keeps Next.js <Link> client-side navigation: <Link asChild><NextLink href="/x">…</NextLink></Link>.',
       },
     },
   },

--- a/packages/ui/atoms/link.test.tsx
+++ b/packages/ui/atoms/link.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Link } from './link';
 
@@ -30,5 +30,101 @@ describe('Link', () => {
       'data-state',
       'visited'
     );
+  });
+
+  it('ships active state styling via :active and data-state selectors', () => {
+    render(
+      <Link href='/current' active data-testid='active-link'>
+        Current
+      </Link>
+    );
+
+    const link = screen.getByTestId('active-link');
+    expect(link).toHaveAttribute('data-state', 'active');
+    expect(link.className).toContain('active:text-(--color-accent)');
+    expect(link.className).toContain(
+      'data-[state=active]:text-(--color-accent)'
+    );
+  });
+
+  it('applies disabled state with aria-disabled and state tokens', () => {
+    render(
+      <Link href='/off' disabled data-testid='disabled-link'>
+        Disabled
+      </Link>
+    );
+
+    const link = screen.getByTestId('disabled-link');
+    expect(link).toHaveAttribute('data-state', 'disabled');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link.className).toContain('pointer-events-none');
+    expect(link.className).toContain('text-(--color-text-disabled-token)');
+    expect(link.className).toContain('opacity-[var(--state-disabled-opacity)]');
+  });
+
+  it('prioritizes disabled over active and visited in data-state', () => {
+    render(
+      <Link href='/off' disabled active visited data-testid='precedence-link'>
+        Precedence
+      </Link>
+    );
+
+    expect(screen.getByTestId('precedence-link')).toHaveAttribute(
+      'data-state',
+      'disabled'
+    );
+  });
+
+  it('composes onto a single child element via asChild (Radix Slot)', () => {
+    const onClick = vi.fn();
+    render(
+      <Link asChild active data-testid='slot-link'>
+        <button type='button' onClick={onClick}>
+          Composed
+        </button>
+      </Link>
+    );
+
+    const child = screen.getByTestId('slot-link');
+    expect(child.tagName).toBe('BUTTON');
+    expect(child).toHaveAttribute('data-variant', 'link');
+    expect(child).toHaveAttribute('data-state', 'active');
+    expect(child.className).toContain('text-(--color-link-default)');
+    child.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets consumer className override base classes in the variant={null} composition path', () => {
+    // This is the composition contract the ad-hoc anchor migrations rely on:
+    // with variant={null}, a consumer className prop merges over the base via
+    // tailwind-merge (font-size is a deduped conflict group, so the base size
+    // is dropped).
+    render(
+      <Link
+        href='/plain'
+        variant={null}
+        className='text-sm'
+        data-testid='override-link'
+      >
+        Override
+      </Link>
+    );
+
+    const link = screen.getByTestId('override-link');
+    expect(link.className).toContain('text-sm');
+    expect(link.className).not.toContain('text-[13px]');
+  });
+
+  it('omits variant classes when variant is null (composition escape hatch)', () => {
+    render(
+      <Link href='/plain' variant={null} data-testid='null-variant-link'>
+        Plain
+      </Link>
+    );
+
+    const link = screen.getByTestId('null-variant-link');
+    expect(link).toHaveAttribute('data-variant', 'link');
+    expect(link.className).not.toContain('text-(--color-link-default)');
+    expect(link.className).not.toContain('visited:text-(--color-link-visited)');
   });
 });

--- a/packages/ui/atoms/link.tsx
+++ b/packages/ui/atoms/link.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { cn } from '@jovie/ui/lib/utils';
+import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
@@ -16,14 +17,17 @@ const linkVariants = cva(
         default: [
           'text-(--color-link-default) hover:text-(--color-link-hover) hover:underline',
           'visited:text-(--color-link-visited)',
+          'active:text-(--color-accent) data-[state=active]:text-(--color-accent)',
         ],
         subtle: [
           'text-(--linear-text-secondary) hover:text-(--color-link-hover) hover:underline',
           'visited:text-(--color-link-visited)',
+          'active:text-(--color-accent) data-[state=active]:text-(--color-accent)',
         ],
         inline: [
           'text-primary-token underline decoration-(--linear-border-default) hover:decoration-(--color-link-hover)',
           'visited:text-(--color-link-visited) visited:decoration-(--color-link-visited)',
+          'active:text-(--color-accent) active:decoration-(--color-accent) data-[state=active]:text-(--color-accent) data-[state=active]:decoration-(--color-accent)',
         ],
       },
     },
@@ -33,9 +37,33 @@ const linkVariants = cva(
   }
 );
 
+/**
+ * Disabled visuals use the shared state tokens (state-matrix: never rely on
+ * opacity alone). Applied conditionally because anchors never match :disabled.
+ */
+const LINK_DISABLED_CLASSES =
+  'pointer-events-none text-(--color-text-disabled-token) opacity-[var(--state-disabled-opacity)]';
+
 export interface LinkProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement>,
     VariantProps<typeof linkVariants> {
+  /**
+   * Compose link styling and behavior onto a single child element (Radix
+   * Slot). This is how apps keep Next.js `<Link>` client-side navigation:
+   * `<Link asChild><NextLink href='/x'>…</NextLink></Link>`.
+   */
+  readonly asChild?: boolean;
+  /**
+   * Forces the active/pressed state (e.g. aria-current page, Storybook
+   * parity). Mirrors `data-state='active'`; native `:active` keeps working.
+   */
+  readonly active?: boolean;
+  /**
+   * Marks the link as inert: `aria-disabled`, disabled-visual state tokens,
+   * and `pointer-events-none`. Anchors do not support the `disabled`
+   * attribute, so this mirrors the Button asChild disabled pattern.
+   */
+  readonly disabled?: boolean;
   /**
    * Marks the link as visited for Storybook/docs parity when pseudo-class
    * preview is unavailable. Does not replace the native :visited selector.
@@ -43,14 +71,45 @@ export interface LinkProps
   readonly visited?: boolean;
 }
 
+function getLinkDataState({
+  disabled,
+  active,
+  visited,
+}: {
+  readonly disabled: boolean;
+  readonly active: boolean;
+  readonly visited: boolean;
+}): 'disabled' | 'active' | 'visited' | 'idle' {
+  if (disabled) return 'disabled';
+  if (active) return 'active';
+  if (visited) return 'visited';
+  return 'idle';
+}
+
 const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ className, variant, visited, ...props }, ref) => {
+  (
+    {
+      className,
+      variant,
+      asChild = false,
+      active = false,
+      disabled = false,
+      visited = false,
+      ...props
+    },
+    ref
+  ) => {
+    const Comp = asChild ? Slot : 'a';
     return (
-      <a
+      <Comp
         ref={ref}
         data-variant='link'
-        data-state={visited ? 'visited' : 'idle'}
-        className={cn(linkVariants({ variant, className }))}
+        data-state={getLinkDataState({ disabled, active, visited })}
+        aria-disabled={disabled || undefined}
+        className={cn(
+          linkVariants({ variant, className }),
+          disabled && LINK_DISABLED_CLASSES
+        )}
         {...props}
       />
     );


### PR DESCRIPTION
## Summary

Completes the canonical `Link` primitive in `@jovie/ui` and migrates the four ad-hoc anchors onto it.

**Issue:** [JOV-3574](https://linear.app/jovie/issue/JOV-3574/add-canonical-link-primitive-with-full-state-coverage-migrate-the-4-ad) — *Add canonical Link primitive with full state coverage; migrate the 4 ad-hoc anchors.*

**Confirmed gap (triage 2026-07-20):** `packages/ui/atoms/link.tsx` shipped via #12595 (JOV-3575) with default/subtle/inline variants, `:visited`, focus-visible, story + export. Missing vs acceptance: `active:` and `disabled` states, `asChild`/Radix Slot composition, and migration of `NavLink` (styled an anchor with `buttonVariants`), `FooterLink`, `FrostedButton`, `ShellCtaButton`.

## Scope

**Primitive (`packages/ui/atoms/link.tsx`)**
- `active:` pressed state on all variants via the interactive accent token `--color-accent` (ui.md: links/focus rings/active states share it), mirrored by `data-[state=active]:` selectors so the state is force-able and story/test-addressable; `active` preview prop. Data-state precedence: disabled > active > visited > idle.
- `disabled` state: `aria-disabled` + `data-state="disabled"` + `pointer-events-none` + state tokens `--state-disabled-opacity` / `--color-text-disabled-token`, applied conditionally (anchors never match `:disabled`) — mirrors the Button asChild disabled pattern; state-matrix rule "never opacity alone".
- `asChild` via Radix Slot. `@radix-ui/react-slot` was already a packages/ui dependency used by `button.tsx`/`card.tsx`/`form.tsx` — no new dependency.
- Stories: `Active`, `Disabled`, `AsChild` added (story now covers all six states); primitive tests 2 → 8.
- `docs/design-system/state-matrix.md`: link active + disabled rows added to both relevant sections (matrix rule 5).

**Migrations** — all four render `<UILink asChild variant={null} className={…}><NextLink …/></UILink>`: the primitive owns rendering/data-state/focus ring, `variant={null}` is the composition escape hatch so consumer classes fully own appearance, Next.js `Link` stays the child (client navigation/prefetch preserved).
- `NavLink`: no longer borrows `buttonVariants` for an anchor (acceptance criterion). Replicates the intended effective classes (ghost/primary at size sm, chrome neutralized). No production callers — stories/tests only. Note: the invisible 40px `before:*` touch-target pseudo from Button size sm is dropped (hit-area-only, zero layout impact).
- `FooterLink`: tone palettes + external-link security (target/rel) preserved.
- `FrostedButton` (href mode): Button asChild still owns the visual contract; `UILink` inserted between Button and `next/link` (Slot chain). Button's data-variant/data-state/aria-disabled flow through and win; press feedback unchanged.
- `ShellCtaButton`: `shellCtaClassName` unchanged (still exported for the HomeHeroCTA submit button); component composes the primitive with identical classes.

**Layout contract:** class-level parity was verified empirically — the UILink `className` prop merges through the repo's extended tailwind-merge after variant classes (consumer classes win deduped conflicts; verified for every migrated string), and for custom `duration-*`/`ease-*` tokens that tailwind-merge cannot dedupe, Tailwind v4's alphabetical utility emission makes the migrated override the cascade winner (same cascade the existing Button+ghost pattern already relied on). No rendered layout changes.

## Validation

- `packages/ui` — `atoms/link.test.tsx`: **8/8** (variants, visited, active, disabled, precedence, asChild, variant=null contract); full package suite **857 passed**.
- `apps/web` — new `tests/unit/atoms/canonical-link-migration.test.tsx` (unmocked `@jovie/ui`): **8/8** across the 4 migrations.
- Existing suites green: NavLink 5, FooterLink 11, FrostedButton 10, atoms-integration 25, Header 4, MarketingFooter 3, artist-profiles-page 4, home CTA/style guards 2.
- Design-system ratchets green: arbitrary-values, server-imports, button-canon, raw-button, component-family.
- `pnpm biome check` clean on all touched files; `@jovie/ui` and `@jovie/web` typecheck clean.

## Risk

Low. Primitive changes are additive (new optional props). Migrations preserve each component's props and visual classes; all existing component tests pass unchanged. NavLink has no production callers; FrostedButton href mode is only used in stories (prod usage is button mode); FooterLink and ShellCtaButton consumers are covered by green suites.

## Rollback

Revert this single commit (`631af13`). No migrations, config, or dependency changes.

## GBrain

- Read: `engineering/backlog-triage-2026-07-20` (scope confirmation).
- Written: `engineering/canonical-link-primitive-completion` (states, composition contract, migration pattern, tokens, test evidence).
