### PR TITLE
fix(security): resolve CSP connect-src blocks for qr/vercel paths (JOV-3526, JOV-2637)

### DIFF
--- a/apps/web/constants/platforms/cdn-domains.ts
+++ b/apps/web/constants/platforms/cdn-domains.ts
@@ -96,6 +96,9 @@ export const INFRASTRUCTURE_CONNECT_DOMAINS: readonly string[] = [
   // Vercel Blob client uploads + direct browser fetches
   '*.blob.vercel-storage.com',
   '*.public.blob.vercel-storage.com',
+  // QR Code API — browser fetches the QR PNG as a blob for the
+  // "Download QR Code" actions (ProfileSidebarHeader, dashboard PreviewPanel)
+  'api.qrserver.com',
 ];
 
 /**

--- a/apps/web/tests/unit/constants/platforms/cdn-domains-sync.test.ts
+++ b/apps/web/tests/unit/constants/platforms/cdn-domains-sync.test.ts
@@ -67,6 +67,11 @@ describe('CDN domain registry', () => {
       expect(domains).toContain('https://*.blob.vercel-storage.com');
       expect(domains).toContain('https://*.public.blob.vercel-storage.com');
     });
+
+    it('includes api.qrserver.com for QR code download actions', () => {
+      const domains = getCspConnectSrcDomains();
+      expect(domains).toContain('https://api.qrserver.com');
+    });
   });
 
   describe('getCspImgSrcDomains', () => {

--- a/apps/web/tests/unit/lib/content-security-policy.test.ts
+++ b/apps/web/tests/unit/lib/content-security-policy.test.ts
@@ -83,6 +83,16 @@ describe('buildContentSecurityPolicy', () => {
     expect(connectSrc).toContain('https://*.public.blob.vercel-storage.com');
   });
 
+  it('includes api.qrserver.com in connect-src for QR code downloads', () => {
+    const csp = buildContentSecurityPolicy({
+      nonce: 'test-nonce',
+      isDev: false,
+    });
+    const connectSrc = findDirective(csp, 'connect-src');
+
+    expect(connectSrc).toContain('https://api.qrserver.com');
+  });
+
   it('includes Sentry regional ingest wildcard in connect-src', () => {
     const csp = buildContentSecurityPolicy({
       nonce: 'test-nonce',


### PR DESCRIPTION
## Summary

Resolves two Sentry CSP `connect-src` violation reports that share one trust boundary (browser `connect` fetches blocked by Content-Security-Policy):

- **JOV-3526** — Blocked 'connect' from `api.qrserver.com`
- **JOV-2637** — Blocked 'connect' from `vercel.com`

Grouped per GBrain read of `engineering/backlog-triage-2026-07-20` (actionable queue item 4: "JOV-3526 + JOV-2637 — CSP connect blocks").

## Evidence per host

### `api.qrserver.com` (JOV-3526) → legit product feature hitting the block

Two live browser `fetch()` paths download the QR PNG as a blob (both connect-src governed):

- `apps/web/components/organisms/profile-sidebar/ProfileSidebarHeader.tsx:85-100` — "Download QR Code" overflow action: `fetch(getQrCodeUrl(profileUrl, 420))` → `downloadBlob`.
- `apps/web/lib/queries/useQrCodeDownloadMutation.ts:18` — `fetchWithTimeoutResponse(qrUrl)`, used by the dashboard `PreviewPanel.tsx:184-191` "QR" download button (size 512).

The QR *display* path (`QRCode.tsx`, `QRCodeCard.tsx`) uses `next/image` → `img-src`, already allowed via the `INFRASTRUCTURE_IMAGE_DOMAINS` "Utilities" entry — unchanged.

### `vercel.com` (JOV-2637) → already resolved on main

- `INFRASTRUCTURE_CONNECT_DOMAINS` already contains `'vercel.com'`, added by #10703 (2026-06-11, `fix(csp): allow vercel.com connect on chat surface`, JOV-3056 / Sentry JOVIE-WEB-M7) — landed after JOV-2637 was filed (2026-05-28); same violation family.
- Browser consumers: `@vercel/toolbar` runtime + chat-surface deployment status. `api.vercel.com` appears only in server-side code (`app/api/deploy/status/route.ts`) — not CSP-governed, so no wildcard was or is needed.

## Decision per host

- `api.qrserver.com`: **added** to `INFRASTRUCTURE_CONNECT_DOMAINS` in `apps/web/constants/platforms/cdn-domains.ts` (the canonical registry — per `.claude/rules/security.md`, CSP directives are never edited directly). Exact host only, no wildcard. Host was already trusted in `img-src`; removing the download features instead would be a product regression.
- `vercel.com`: **no change** — kept, already pinned by existing tests.

## Scope

- `apps/web/constants/platforms/cdn-domains.ts` — one registry entry + comment documenting the two consuming features.
- `apps/web/tests/unit/constants/platforms/cdn-domains-sync.test.ts` — pin `https://api.qrserver.com` in `getCspConnectSrcDomains`.
- `apps/web/tests/unit/lib/content-security-policy.test.ts` — pin `https://api.qrserver.com` in built connect-src.

Net delta to the enforcing policy: exactly one host added to `connect-src`. No wildcards, no other directives touched.

## Validation

- `vitest run tests/unit/lib/content-security-policy.test.ts tests/unit/constants/platforms/cdn-domains-sync.test.ts` → 32 passed, 1 pre-existing skip (retired Clerk FAPI), 0 failed.
- Full pre-push gate green on this commit: `pnpm run pre-push` (biome/typecheck/lint) + `automation-verify.sh affected` (typecheck --affected, lint --affected, affected vitest shards, ci:harness:check). Note: gate requires node ≥22.23.1 per `.nvmrc`; under node 22.22.1 the unrelated `tests/unit/ci/runner-setup-action.test.ts` env contract fails.
- `pnpm biome check --write` on changed files → clean.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` → clean.

## Risk

Low. One exact host added to `connect-src`; host already present in `img-src`. connect-src remains enumerative (no `*` / broad patterns). The two QR download features move from CSP-blocked to functional — that is the fix, not a behavior regression.

## Rollback

Revert this commit (single registry line + two test pins). The new tests fail first if the registry entry is dropped accidentally, so silent regression is pinned.

## GBrain

- Read: `engineering/backlog-triage-2026-07-20` (workstream assignment, item 4).
- Written: `engineering/csp-connect-src-qr-vercel` (type: engineering-decision) — per-host evidence, decision, justification, protected behavior.