### PR TITLE
ci(nightly): repair deep-evidence receivers and consolidate storybook a11y lane (JOV-4326)

### DIFF
--- a/.github/ci-harness/manifest.json
+++ b/.github/ci-harness/manifest.json
@@ -204,14 +204,6 @@
       "remediation": "An explicitly requested authenticated axe run regressed. Fix the violation behind auth; the lane is informational evidence and never feeds PR Ready."
     },
     {
-      "id": "ci-storybook-a11y",
-      "name": "Storybook A11y",
-      "tier": "preview-evidence",
-      "mergeGate": false,
-      "nextLocalCommand": "pnpm --filter @jovie/web test:a11y",
-      "remediation": "An explicitly requested Storybook a11y run regressed. Fix the component-level violation in the story instead of disabling the rule."
-    },
-    {
       "id": "ci-e2e-smoke",
       "name": "E2E Smoke (manual)",
       "tier": "risk-triggered-smoke",

--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -368,8 +368,7 @@ jobs:
           done
 
   # --------------------------------------------------------------------------
-  # JOB: main-ci-health
-  # Formerly: main-ci-health-monitor.yml (every ~15 min)
+  # JOB: neon-cleanup
   # --------------------------------------------------------------------------
   neon-cleanup:
     name: Neon Branch Cleanup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4481,21 +4481,9 @@ jobs:
           done
 
           echo "All required combined-head checks passed."
-  ci-storybook-a11y:
-    name: Storybook A11y
-    needs: [ci-path-changes]
-    if: ${{ needs.ci-path-changes.result == 'success' && github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 1
-      - uses: ./.github/actions/setup-node-pnpm
-      - name: Setup Playwright (Chromium)
-        uses: ./.github/actions/setup-playwright
-      - name: Run Storybook accessibility tests
-        run: pnpm --filter @jovie/web test:a11y
+  # Storybook a11y evidence lives exclusively in the scheduled visual-a11y.yml
+  # storybook-a11y lane; the duplicate manual ci-storybook-a11y job was removed
+  # (JOV-4326) so the evidence has a single owner.
   ci-pr-ready:
     name: ${{ github.event_name == 'pull_request' && 'PR Ready' || 'PR Ready (source inactive)' }}
     # The source-branch aggregate is intentionally small and deterministic.

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -72,7 +72,10 @@ jobs:
       github.event.inputs.suite == 'all' ||
       github.event.inputs.suite == 'unit'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The unsharded suite was still making steady progress when the 30m cap
+    # cancelled it every night (Jul 15-20, JOV-4326). 60m fits the current
+    # suite with headroom; the nightly cadence tolerates the longer lane.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -198,6 +201,11 @@ jobs:
         env:
           DATABASE_URL: ${{ steps.neon-branch.outputs.db_url }}
           NODE_ENV: test
+          # Cap the dev-server V8 heap the same way playwright.config.smoke.ts
+          # does for CI: GitHub-hosted runners expose ~7 GiB RAM and the
+          # dev-fast default of 8 GiB starves the OS + Playwright, wedging the
+          # bypass server mid-sweep (ECONNREFUSED / socket hang up, JOV-4326).
+          NODE_OPTIONS: '--max-old-space-size=4096'
           PORT: '3100'
           BASE_URL: http://127.0.0.1:3100
           NEXT_PUBLIC_APP_URL: http://127.0.0.1:3100

--- a/apps/web/tests/e2e/admin-dashboard.spec.ts
+++ b/apps/web/tests/e2e/admin-dashboard.spec.ts
@@ -1,15 +1,12 @@
 import { expect, test } from '@playwright/test';
 import { APP_ROUTES } from '@/constants/routes';
-import {
-  ensureSignedInUser,
-  getAdminCredentials,
-  hasAdminCredentials,
-} from '../helpers/clerk-auth';
+import { hasAdminCredentials } from '../helpers/clerk-auth';
 import {
   ADMIN_FAST_HEALTH_SURFACES,
   ADMIN_RENDER_SURFACES,
   getAdminSurfaceById,
 } from './utils/admin-surface-manifest';
+import { signInAsAdmin } from './utils/admin-test-utils';
 import { smokeNavigateWithRetry } from './utils/smoke-test-utils';
 
 /**
@@ -40,7 +37,7 @@ test.describe('Admin Dashboard', () => {
   test.beforeEach(async ({ page }) => {
     test.skip(!hasAdminCredentials(), 'Admin credentials not configured');
 
-    await ensureSignedInUser(page, getAdminCredentials());
+    await signInAsAdmin(page);
   });
 
   // ── Main admin dashboard page ────────────────────────────────────────────

--- a/apps/web/tests/e2e/admin-gtm-health.spec.ts
+++ b/apps/web/tests/e2e/admin-gtm-health.spec.ts
@@ -1,6 +1,7 @@
-import { ClerkTestError, signInUser } from '../helpers/clerk-auth';
+import { ClerkTestError } from '../helpers/clerk-auth';
 import { expect, test } from './setup';
 import { getAdminSurfaceById } from './utils/admin-surface-manifest';
+import { hasAdminCredentials, signInAsAdmin } from './utils/admin-test-utils';
 import {
   assertNoCriticalErrors,
   SMOKE_TIMEOUTS,
@@ -25,7 +26,7 @@ async function expectAdminPage(
     page.url().includes('/sign-up')
   ) {
     try {
-      await signInUser(page);
+      await signInAsAdmin(page);
     } catch (error) {
       if (error instanceof ClerkTestError) {
         test.skip(
@@ -55,6 +56,14 @@ async function expectAdminPage(
 }
 
 test.describe('Admin GTM Health @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    // The shared storage state carries the lane's creator persona; admin
+    // surfaces redirect non-admins to /app, so establish the admin session
+    // before the first navigation (JOV-4326).
+    test.skip(!hasAdminCredentials(), 'Admin auth not available');
+    await signInAsAdmin(page);
+  });
+
   test('admin growth renders speed dial, funnel, and lead table without runtime errors', async ({
     page,
   }, testInfo) => {
@@ -85,10 +94,7 @@ test.describe('Admin GTM Health @smoke', () => {
     const { getContext, cleanup } = setupPageMonitoring(page);
 
     try {
-      await expectAdminPage(
-        page,
-        getAdminSurfaceById('growth-outreach-email').path
-      );
+      await expectAdminPage(page, getAdminSurfaceById('growth-outreach').path);
       // The page loads with the outreach accordion auto-opened via ?view=outreach
       await expect(page.getByTestId('admin-growth-page')).toBeVisible({
         timeout: SMOKE_TIMEOUTS.VISIBILITY,

--- a/apps/web/tests/e2e/admin-navigation.spec.ts
+++ b/apps/web/tests/e2e/admin-navigation.spec.ts
@@ -1,14 +1,13 @@
 import { expect, test } from '@playwright/test';
 import { APP_ROUTES } from '@/constants/routes';
-import { ensureSignedInUser } from '../helpers/clerk-auth';
 import {
   ADMIN_PRIMARY_NAV_SURFACES,
   getAdminSurfaceById,
 } from './utils/admin-surface-manifest';
 import {
   checkForClientError,
-  getAdminCredentials,
   hasAdminCredentials,
+  signInAsAdmin,
 } from './utils/admin-test-utils';
 import {
   SMOKE_TIMEOUTS,
@@ -63,7 +62,7 @@ test.describe('Admin Navigation Persistence @smoke', () => {
     'Admin nav persistence runs in the slower authenticated coverage lane'
   );
 
-  // signInUser needs 180s+ for Clerk + Turbopack compilation, plus test body navigation
+  // Admin bypass sign-in + dashboard landing needs 180s+ under dev-server compilation, plus test body navigation
   test.setTimeout(300_000);
 
   test.beforeEach(async ({ page }) => {
@@ -80,10 +79,8 @@ test.describe('Admin Navigation Persistence @smoke', () => {
       console.log(`[Page Error] ${error.message}`);
     });
 
-    const { username, password } = getAdminCredentials();
-
     try {
-      await ensureSignedInUser(page, { username, password });
+      await signInAsAdmin(page);
     } catch (error) {
       console.error('Failed to sign in admin user:', error);
       test.skip();
@@ -103,8 +100,8 @@ test.describe('Admin Navigation Persistence @smoke', () => {
 
     const adminNavSection = page.locator('[data-testid="admin-nav-section"]');
 
-    // signInUser in beforeEach already navigated to /app/dashboard
-    // and waited for transient React 19 errors to resolve
+    // signInAsAdmin in beforeEach already landed on /app/dashboard
+    // and waited for the app shell to be ready
     // We're already on the dashboard - no need to navigate again
 
     // Wait for page to fully stabilize with retry for admin nav visibility
@@ -335,8 +332,8 @@ test.describe('Admin Navigation Persistence @smoke', () => {
 
     const adminNavSection = page.locator('[data-testid="admin-nav-section"]');
 
-    // signInUser in beforeEach already navigated to /app/dashboard
-    // and waited for transient React 19 errors to resolve
+    // signInAsAdmin in beforeEach already landed on /app/dashboard
+    // and waited for the app shell to be ready
     await page
       .waitForLoadState('networkidle', { timeout: 5000 })
       .catch(() => {})
@@ -455,8 +452,8 @@ test.describe('Admin Navigation Persistence @smoke', () => {
 
     const adminNavSection = page.locator('[data-testid="admin-nav-section"]');
 
-    // signInUser in beforeEach already navigated to /app/dashboard
-    // and waited for transient React 19 errors to resolve
+    // signInAsAdmin in beforeEach already landed on /app/dashboard
+    // and waited for the app shell to be ready
     await page
       .waitForLoadState('networkidle', { timeout: 5000 })
       .catch(() => {})

--- a/apps/web/tests/e2e/utils/admin-surface-manifest.ts
+++ b/apps/web/tests/e2e/utils/admin-surface-manifest.ts
@@ -142,63 +142,15 @@ export const ADMIN_RENDER_SURFACES: readonly AdminSurfaceDescriptor[] = [
     includeInFastHealth: true,
   },
   {
-    id: 'growth-outreach-all',
-    name: 'Admin Growth Outreach All',
-    path: buildAdminGrowthHref(
-      'outreach',
-      new URLSearchParams({ queue: 'all' })
-    ),
-    rootTestId: 'admin-growth-view-outreach-all',
-    snapshotSlug: 'admin-growth-outreach-all',
-    primaryWorkspace: false,
-    utilityRoot: false,
-    includeInFastHealth: false,
-  },
-  {
-    id: 'growth-outreach-email',
-    name: 'Admin Growth Outreach Email',
-    path: buildAdminGrowthHref(
-      'outreach',
-      new URLSearchParams({ queue: 'email' })
-    ),
-    rootTestId: 'admin-growth-view-outreach-email',
-    snapshotSlug: 'admin-growth-outreach-email',
-    primaryWorkspace: false,
-    utilityRoot: false,
-    includeInFastHealth: true,
-  },
-  {
-    id: 'growth-outreach-dm',
-    name: 'Admin Growth Outreach DM',
-    path: buildAdminGrowthHref(
-      'outreach',
-      new URLSearchParams({ queue: 'dm' })
-    ),
-    rootTestId: 'admin-growth-view-outreach-dm',
-    snapshotSlug: 'admin-growth-outreach-dm',
-    primaryWorkspace: false,
-    utilityRoot: false,
-    includeInFastHealth: false,
-  },
-  {
-    id: 'growth-outreach-review',
-    name: 'Admin Growth Outreach Review',
-    path: buildAdminGrowthHref(
-      'outreach',
-      new URLSearchParams({ queue: 'review' })
-    ),
-    rootTestId: 'admin-growth-view-outreach-review',
-    snapshotSlug: 'admin-growth-outreach-review',
-    primaryWorkspace: false,
-    utilityRoot: false,
-    includeInFastHealth: false,
-  },
-  {
-    id: 'growth-campaigns',
-    name: 'Admin Growth Campaigns',
-    path: buildAdminGrowthHref('campaigns'),
-    rootTestId: 'admin-growth-view-campaigns',
-    snapshotSlug: 'admin-growth-campaigns',
+    // The growth page now consolidates outreach + campaigns into a single
+    // "Outreach & Campaigns" accordion (GtmCollapsibles) that auto-opens via
+    // ?view=outreach; the per-queue views and their dedicated testids no
+    // longer exist (JOV-4326). The page shell is the stable render contract.
+    id: 'growth-outreach',
+    name: 'Admin Growth Outreach',
+    path: buildAdminGrowthHref('outreach'),
+    rootTestId: 'admin-growth-page',
+    snapshotSlug: 'admin-growth-outreach',
     primaryWorkspace: false,
     utilityRoot: false,
     includeInFastHealth: true,

--- a/apps/web/tests/e2e/utils/admin-test-utils.ts
+++ b/apps/web/tests/e2e/utils/admin-test-utils.ts
@@ -9,9 +9,12 @@
 
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
+import { APP_ROUTES } from '@/constants/routes';
 import {
+  ensureSignedInUser,
   getAdminCredentials as getSharedAdminCredentials,
   hasAdminCredentials as hasSharedAdminCredentials,
+  setTestAuthBypassSession,
 } from '../../helpers/clerk-auth';
 
 // ============================================================================
@@ -36,6 +39,45 @@ export function hasAdminCredentials(): boolean {
  */
 export function getAdminCredentials(): AdminCredentials {
   return getSharedAdminCredentials();
+}
+
+/**
+ * Sign the page in as an ADMIN identity.
+ *
+ * Under Better Auth the dev bypass is the only auth path and
+ * `ensureSignedInUser` resolves the persona from `E2E_TEST_AUTH_PERSONA`
+ * (creator/creator-ready in the heavy lanes), so admin specs that rely on it
+ * land on the dashboard redirect instead of the admin workspace (JOV-4326).
+ * The bypass has a dedicated `admin` persona (`users.isAdmin = true`); the
+ * session route mints its cookie into the browser context. This mirrors the
+ * pattern already used by admin-visual-regression.spec.ts and
+ * nightly/full-surface-chaos.spec.ts.
+ *
+ * Like the legacy bypass sign-in, this lands on the app shell (`/app`) so
+ * specs can assume an authenticated dashboard is already loaded.
+ */
+export async function signInAsAdmin(page: Page): Promise<Page> {
+  if (process.env.E2E_USE_TEST_AUTH_BYPASS === '1') {
+    await setTestAuthBypassSession(page, 'admin');
+    await page.goto(APP_ROUTES.DASHBOARD, { waitUntil: 'domcontentloaded' });
+    // Mirror waitForShellReadyAfterAuth: the shell (or chat composer) must be
+    // visible before specs interact with the dashboard.
+    const main = page.locator('main').first();
+    const chatComposer = page
+      .locator('textarea, [contenteditable="true"], a[href="/app/chat"]')
+      .first();
+    await expect
+      .poll(
+        async () =>
+          (await main.isVisible().catch(() => false)) ||
+          (await chatComposer.isVisible().catch(() => false)),
+        { timeout: 30_000, intervals: [2_000, 5_000, 10_000] }
+      )
+      .toBe(true);
+    return page;
+  }
+
+  return ensureSignedInUser(page, getAdminCredentials());
 }
 
 // ============================================================================

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -299,7 +299,6 @@ describe('source PR path-output reachability contract', () => {
       'ci-e2e-migrate',
       'ci-e2e-tests',
       'ci-pr-vercel-preview',
-      'ci-storybook-a11y',
       'ci-smoke-required',
     ]) {
       expect(getJobBlock(workflow, jobKey), jobKey).toContain(
@@ -398,20 +397,20 @@ describe('CI test-performance path gate', () => {
 });
 
 describe('CI Storybook accessibility path gate', () => {
-  it('classifies relevant paths but runs only by manual dispatch', () => {
+  it('classifies relevant paths; the scheduled visual-a11y lane owns execution', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const pathJob = getJobBlock(workflow, 'ci-path-changes');
     const detectStep = getStepBlock(
       pathJob,
       'Detect path changes for all job types'
     );
-    const storybookJob = getJobBlock(workflow, 'ci-storybook-a11y');
 
     expect(pathJob).toContain(
       "run_storybook_a11y: ${{ steps.detect.outputs.run_storybook_a11y || 'false' }}"
     );
-    expect(storybookJob).toContain("github.event_name == 'workflow_dispatch'");
-    expect(storybookJob).not.toContain("github.event_name == 'pull_request'");
+    // The duplicate manual ci-storybook-a11y job was removed (JOV-4326); the
+    // scheduled visual-a11y.yml storybook-a11y lane is the single owner.
+    expect(workflow).not.toContain('ci-storybook-a11y:');
     expect(detectStep).not.toContain('DEEP_CI_LABEL');
 
     const pattern = detectStep.match(/STORYBOOK_A11Y_PATTERN='([^']+)'/)?.[1];

--- a/scripts/lib/__tests__/ci-harness.test.mjs
+++ b/scripts/lib/__tests__/ci-harness.test.mjs
@@ -112,7 +112,6 @@ describe('ci-harness manifest', () => {
       'Lighthouse (chat manual)',
       'A11y (axe)',
       'A11y (authenticated, informational)',
-      'Storybook A11y',
       'E2E Smoke (manual)',
       'Golden Path (manual)',
       'Extended Smoke (manual)',
@@ -220,7 +219,6 @@ describe('ci-harness manifest', () => {
       'ci-smoke-required',
       'ci-lighthouse-pr',
       'ci-a11y',
-      'ci-storybook-a11y',
       'ci-layout-guard',
       'ci-build-layout',
       'ci-ios',
@@ -252,7 +250,6 @@ describe('ci-harness manifest', () => {
       'ci-e2e-tests',
       'ci-test-performance',
       'ci-pr-vercel-preview',
-      'ci-storybook-a11y',
       'ci-summary',
       'ci-smoke-required',
     ];

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -430,7 +430,7 @@ describe('aggregate required checks', () => {
     }
   });
 
-  it('keeps Storybook A11y manual and outside source PR Ready', () => {
+  it('keeps Storybook A11y scheduled-only and outside source PR Ready', () => {
     const branchProtectionYaml = readFileSync(
       resolve(REPO_ROOT, MERGE_QUEUE_REPO_PATHS.branchProtection),
       'utf8'
@@ -444,19 +444,18 @@ describe('aggregate required checks', () => {
       'utf8'
     );
     const storybookBlock = extractWorkflowJobBlock(
-      ciWorkflowYaml,
-      'ci-storybook-a11y'
+      visualWorkflowYaml,
+      'storybook-a11y'
     );
     const prReadyBlock = extractWorkflowJobBlock(ciWorkflowYaml, 'ci-pr-ready');
 
     expect(
       parseRequiredStatusChecksFromYaml(branchProtectionYaml)
     ).not.toContain('Storybook A11y');
-    expect(storybookBlock).toContain(
-      "github.event_name == 'workflow_dispatch'"
-    );
-    expect(storybookBlock).toMatch(/pnpm --filter @jovie\/web test:a11y/);
-    expect(storybookBlock).not.toContain("github.event_name == 'pull_request'");
+    // The duplicate manual ci-storybook-a11y job was removed (JOV-4326); the
+    // scheduled visual-a11y.yml storybook-a11y lane is the single owner.
+    expect(ciWorkflowYaml).not.toContain('ci-storybook-a11y:');
+    expect(storybookBlock).toMatch(/pnpm --filter web test:a11y/);
     expect(prReadyBlock).not.toMatch(/ci-storybook-a11y|STORYBOOK_A11Y_RESULT/);
     expect(visualWorkflowYaml).not.toMatch(/^\s+pull_request:/m);
     expect(visualWorkflowYaml).not.toMatch(/^\s+push:/m);


### PR DESCRIPTION
## Workstream summary

Scheduled deep-evidence receivers are consistently red (Linear **JOV-4326**):
`nightly-tests.yml` (daily) failing/cancelled Jul 15–20 and `e2e-full-matrix.yml`
(weekly) failing every recent run. This PR diagnoses each failure class from the
run logs, fixes what is verifiably a CI/test-side defect, files the genuine
product bug separately, and lands the two small consolidations from the issue.

## Per-failure diagnosis (signatures quoted from failed runs)

### nightly-tests.yml

| Failure | Signature | Classification | Action |
| --- | --- | --- | --- |
| `Full Unit Test Suite` cancelled nightly at ~30m | Still passing test files at 10:11:35Z, cancelled 10:11:40Z (`timeout-minutes: 30`) | Infra/config: timeout too small for the unsharded suite | **Fixed**: timeout 30 → 60 |
| Jul 17 run wedged 19h49m then cancelled | Both jobs stuck 18h+ despite job timeouts; next scheduled run cancelled via concurrency group | Runner/platform anomaly | Documented (concurrency group already cleans up) |
| `Nightly E2E Suite` fails at "Run full surface chaos sweep" | `curl: (7) Failed to connect to 127.0.0.1 port 3100` mid persona-prep; `page.goto: Timeout 45000ms exceeded` on `/api/dev/test-auth/enter`; `apiRequestContext.post: socket hang up`; 500s on `/app` + `/api/auth/get-session` | Infra: bypass dev server wedges mid-sweep. In-repo precedent: `playwright.config.smoke.ts` caps CI dev heap at 4096MB ("~7 GiB RAM; an 8 GiB V8 heap starves the OS"); `dev-fast.mjs` defaults to 8192MB | **Fix applied** (verify on next scheduled run): `NODE_OPTIONS: --max-old-space-size=4096` on the bypass-server step |
| "Upload full surface chaos report" fails | `PLAYWRIGHT_ARTIFACT_SECRET_EXPOSURE: blocked 5 unsafe or unverifiable Playwright artifact file(s); categories=unknown-binary:5` | Guard working as designed — failed-test traces poison the producer stage | Documented; heals when the sweep passes. Guard not touched (security-sensitive) |

### e2e-full-matrix.yml

| Failure | Signature | Classification | Action |
| --- | --- | --- | --- |
| Jun 1–Jul 6 runs die in ~4 min | `jq: parse error: Invalid numeric literal at line 1, column 4` in `neon-create-branch-with-retry/create-branch.sh:45`; "Failed to create Neon branch after 2 attempts" | Infra: Neon branch creation (branch-cap pressure; recovered by Jul 13) | Documented; currently inactive |
| Admin cluster, 12–13 of 15 failures/browser (admin-dashboard, admin-gtm-health, admin-navigation) | "Admin creators page did not render the creators table shell"; "Admin dashboard content container missing"; webserver `Error fetching profile: [UnauthorizedSessionError]: Unauthorized` | **Stale tests** post-Better-Auth migration (#13488, Jul 9): `signInUser` ignores admin credentials and uses `E2E_TEST_AUTH_PERSONA=creator-ready`; `app/(shell)/admin/layout.tsx` correctly redirects non-admins to /app. First failing run (Jul 13) = first run after the migration | **Fixed**: new `signInAsAdmin(page)` in `tests/e2e/utils/admin-test-utils.ts` uses the bypass `admin` persona (`users.isAdmin=true`), the established pattern already used by admin-visual-regression + full-surface-chaos specs |
| admin-visual-regression, 5–6 failures | `admin-growth-view-outreach-all` etc. "element(s) not found" | **Stale manifest**: growth page consolidated outreach+campaigns into the `GtmCollapsibles` "Outreach & Campaigns" accordion; the per-queue views/testids no longer exist | **Fixed**: 5 stale entries in `admin-surface-manifest.ts` replaced by one consolidated `growth-outreach` surface (`admin-growth-page`) |
| anti-cloaking ×2 (both browsers) | `⨯ Error: No QueryClient set, use QueryClientProvider to set one` at `useLinkVerificationMutation` ← `InterstitialClient (app/out/[id]/InterstitialClient.tsx:35)` | **Product bug**: `/out/[id]` renders `InterstitialClient` without a `QueryProvider` (same class as JOVIE-WEB-A6/A7 fixed in admin layout) | **Filed JOV-4328** — not fixed here (product change) |
| artist-profiles ×1 (chromium only) | `expect(endScrollY).toBeGreaterThan(startScrollY)` — expected >1795, got 1785 | Flake (10px scroll drift after 180ms wait) | Documented; not changed |

## Consolidations

- **Storybook a11y dedup**: removed the manual-only `ci-storybook-a11y` job from
  `ci.yml`; the scheduled `visual-a11y.yml` `storybook-a11y` lane (daily 07:37 UTC,
  same `pnpm --filter web test:a11y`) is the single owner. Manifest entry removed;
  characterization locks updated in `ci-harness.test.mjs`, `deploy-workflow.test.ts`,
  `merge-queue-guard.test.mjs` (now assert single ownership). `pnpm ci:harness:docs`
  + `pnpm ci:harness:check` clean.
- **agent-tick.yml**: stale `# JOB: main-ci-health` banner above `neon-cleanup:`
  corrected (comment-only).

## Scope

Changed: `.github/workflows/{ci,nightly-tests,agent-tick}.yml`,
`.github/ci-harness/manifest.json`,
`apps/web/tests/e2e/{admin-dashboard,admin-gtm-health,admin-navigation}.spec.ts`,
`apps/web/tests/e2e/utils/{admin-surface-manifest,admin-test-utils}.ts`,
`apps/web/tests/unit/ci/deploy-workflow.test.ts`,
`scripts/lib/__tests__/{ci-harness,merge-queue-guard}.test.mjs`.
No product code changes. No secrets/env inventions.

## Validation

- YAML parse OK for all touched workflows + manifest.json; `actionlint` output
  identical to origin/main (pre-existing shellcheck notes only)
- `pnpm ci:harness:docs` (docs current) + `pnpm ci:harness:check` → "CI harness manifest is valid."
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/ci-harness.test.mjs lib/__tests__/merge-group-workflow-contract.test.mjs lib/__tests__/merge-queue-guard.test.mjs` → 104/104 pass
- `pnpm --filter web exec vitest run tests/unit/ci/deploy-workflow.test.ts` → 74/74 pass
- `pnpm --filter @jovie/web run typecheck -- --pretty false` → exit 0 (note: repo typecheck excludes `tests/e2e/**`; a targeted `tsc -p` over the 5 changed e2e files reports 0 errors in them)
- `pnpm biome check --write` on all changed files → clean
- E2E lanes themselves cannot be run locally (Neon/secrets); admin sign-in + heap-cap fixes verify on the next scheduled runs.

## Risk

Low: workflow timeouts/env comments, test-only sign-in and manifest updates,
comment-only banner. The heap cap mirrors an already-documented CI pattern.
`run_storybook_a11y` path detection in `ci.yml` intentionally retained (used by
path classification; no job consumed it even before).

## Rollback

Revert this PR. All changes are additive/config/test-side; no data or product
behavior depends on them.

## GBrain

- Read: `engineering/backlog-triage-2026-07-20` (JOV-4326 is queue item 5)
- Written: `engineering/deep-evidence-receivers-red-diagnosis` (type:engineering-decision) — full per-workflow signatures, classification, fixes, follow-ups

Refs JOV-4326. Product bug filed: JOV-4328.
