### PR TITLE
fix(design-system): indent chat tool activity with subordinate weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 ## [Unreleased]
 
 - **Entity mention hover cards now use the same rich entity card as the chat rail:** hovering an inline release, artist, track, or event mention opens the canonical compact EntityCard instead of a one-off popover layout.
+- **Chat tool activity is quieter and indented:** agent tool-call rows sit one rhythm step in from assistant prose with secondary color and book weight, so narrative stays primary and consecutive steps form a quiet run.
 - **Artist profiles now adapt to release, touring, and live-support moments:** one music-native link brings listening, tickets, support, fan capture, setup guidance, and product truth into a clearer responsive journey.
 - **[internal] Production Sentry gate secret binding:** the post-deploy error-rate gate now runs inside the protected production environment, so its API token is available without crossing a nested reusable-workflow boundary.
 - **[internal] Fixed-pool unit routing:** healthy runner heartbeats now select the fixed CI pool through a non-sensitive route token, preserving hosted fail-closed fallback without GitHub suppressing the runner decision.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -642,6 +642,23 @@ Destructive actions use `destructive` on any variant. Examples: primary destruct
 | Hover | `oklch(96.2% 0.003 260)` | `rgba(255,255,255,0.022)` |
 | Selected | `oklch(94.8% 0.006 260)` | `rgba(255,255,255,0.048)` |
 
+### Chat Agent Activity (Tool-Call Rows)
+
+Quiet tool-call / streaming activity in the chat transcript is a first-class System B pattern (GH #13897). It must stay visually subordinate to assistant prose — not a second card chrome family.
+
+| Property | Token / class | Notes |
+|----------|---------------|-------|
+| Indent | `--system-b-chat-activity-indent` (`space-4`) | One rhythm step in from prose left edge |
+| Size | `--system-b-chat-activity-size` (`text-xs`) | One step below chat body (`text-app`) |
+| Weight | `--system-b-chat-activity-weight` (`font-weight-book` / 450) | Lighter than prose |
+| Color | `--system-b-chat-activity-color` (secondary text) | Meta uses tertiary |
+| Surface | `.system-b-chat-activity-feed` + `.system-b-chat-activity-row` | No borders, no nested cards |
+| Motion | spin token + `prefers-reduced-motion` | Running icon only; duration tokens |
+
+**Do:** group consecutive tool steps into one indented activity run; reserve row min-height so body/next-step text does not shift layout.
+
+**Don't:** give activity rows `font-semibold`, primary text color, or full-width card chrome. Interactive empty-state CTAs stay on `.system-b-chat-action-card` (elevated). Artifact / confirm result cards use `.system-b-chat-tool-surface*`.
+
 ### Confirmations & Destructive Actions
 
 | Action shape | Replacement | When |

--- a/apps/web/components/jovie/components/ChatActionCard.tsx
+++ b/apps/web/components/jovie/components/ChatActionCard.tsx
@@ -3,6 +3,14 @@
 import { AlertCircle, ArrowRight, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
+/**
+ * Elevated empty-state / inbox CTA card.
+ *
+ * Quiet tool-call activity in the transcript uses the subordinate
+ * `.system-b-chat-activity-*` pattern (indented, book weight, secondary
+ * color) — not this surface. Keep action cards full-weight and unindented
+ * so CTAs stay scannable; agent status steps stay visually quieter (issue 13897).
+ */
 interface ChatActionCardProps {
   readonly title: string;
   readonly body: string;

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -227,16 +227,34 @@ function isVerboseToolModeEnabled(): boolean {
   }
 }
 
+function getActivityIconState(
+  event: PersistedToolEvent,
+  isLocked: boolean
+): 'running' | 'error' | 'success' | 'locked' | 'default' {
+  if (isLocked) return 'locked';
+  if (event.state === 'running') return 'running';
+  if (event.state === 'failed' || event.state === 'denied') return 'error';
+  if (event.state === 'succeeded') return 'success';
+  return 'default';
+}
+
+function getActivityTimelineEdge(
+  index: number,
+  count: number
+): 'first' | 'last' | 'middle' {
+  if (index === 0) return 'first';
+  if (index === count - 1) return 'last';
+  return 'middle';
+}
+
 function ToolActivityRow({
   event,
-  variant,
   multiple,
   index,
   count,
   feedback,
 }: Readonly<{
   event: PersistedToolEvent;
-  variant: ToolRendererVariant;
   multiple: boolean;
   index: number;
   count: number;
@@ -244,12 +262,12 @@ function ToolActivityRow({
 }>) {
   const body = getToolStatusBody(event);
   const nextStep = getToolStatusNextStep(event);
-  const isInline = variant === 'inline';
   const isError = event.state === 'failed' || event.state === 'denied';
   const isRunning = event.state === 'running';
   const isLocked = isLockedToolEvent(event);
   const Icon = isLocked ? Lock : TOOL_STATUS_ICONS[event.state];
   const showVerboseDetails = isVerboseToolModeEnabled();
+  const iconState = getActivityIconState(event, isLocked);
 
   return (
     <div
@@ -258,74 +276,45 @@ function ToolActivityRow({
       data-tool-state={event.state}
       data-tool-locked={isLocked ? 'true' : undefined}
       role={isError ? 'alert' : 'status'}
-      className={cn(
-        'relative flex w-full items-start gap-2.5 text-primary-token',
-        isInline ? 'py-1' : 'py-1.5'
-      )}
+      className='system-b-chat-activity-row'
     >
       {multiple ? (
         <span
           aria-hidden='true'
           data-testid='tool-activity-timeline-line'
-          className={cn(
-            'absolute left-2 w-px bg-[color-mix(in_oklab,var(--linear-app-shell-border)_70%,transparent)]',
-            index === 0 ? 'top-3.5' : 'top-0',
-            index === count - 1 ? 'bottom-[calc(100%_-_14px)]' : 'bottom-0'
-          )}
+          data-edge={getActivityTimelineEdge(index, count)}
+          className='system-b-chat-activity-timeline'
         />
       ) : null}
       <span
-        className={cn(
-          'relative z-10 mt-0.5 flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full bg-(--linear-app-content-surface)',
-          isRunning && 'text-secondary-token',
-          isError && 'text-red-500',
-          isLocked && 'text-secondary-token',
-          !isRunning && !isError && !isLocked && 'text-success'
-        )}
+        className='system-b-chat-activity-icon'
+        data-state={iconState}
+        data-spinning={isRunning ? 'true' : undefined}
       >
         <Icon
-          className={cn(
-            isInline ? 'h-3.5 w-3.5' : 'h-4 w-4',
-            isRunning && 'animate-spin motion-reduce:animate-none'
-          )}
+          className={cn(isRunning && 'animate-spin motion-reduce:animate-none')}
           strokeWidth={2.25}
+          aria-hidden='true'
         />
       </span>
-      <div className='min-w-0 flex-1'>
+      <div className='system-b-chat-activity-copy'>
         <div
           title={getToolStatusTitle(event)}
-          className={cn(
-            'truncate font-semibold tracking-tight',
-            isError && 'text-red-500',
-            isInline ? 'text-xs' : 'text-app'
-          )}
+          data-state={isError ? 'error' : undefined}
+          className='system-b-chat-activity-title'
         >
           {getToolStatusTitle(event)}
         </div>
         {body ? (
-          <div
-            className={cn(
-              'mt-0.5 text-secondary-token',
-              isInline ? 'line-clamp-2 text-2xs' : 'line-clamp-2 text-xs'
-            )}
-          >
-            {body}
-          </div>
+          <div className='system-b-chat-activity-body'>{body}</div>
         ) : null}
         {nextStep ? (
-          <div
-            className={cn(
-              'mt-0.5 text-tertiary-token',
-              isInline ? 'line-clamp-2 text-3xs' : 'line-clamp-2 text-2xs'
-            )}
-          >
-            {nextStep}
-          </div>
+          <div className='system-b-chat-activity-next'>{nextStep}</div>
         ) : null}
         {showVerboseDetails ? (
           <details
             data-testid='chat-tool-verbose'
-            className='mt-1.5 text-3xs leading-4 text-tertiary-token'
+            className='system-b-chat-activity-verbose'
           >
             <summary className='cursor-pointer select-none text-secondary-token'>
               Verbose tool details
@@ -369,17 +358,13 @@ function ToolActivityFeed({
     <div
       data-testid='tool-activity-feed'
       data-tool-count={events.length}
-      className={cn(
-        'w-full text-primary-token',
-        variant === 'inline' ? 'max-w-full' : 'max-w-105',
-        multiple ? 'space-y-0.5' : 'space-y-0'
-      )}
+      data-variant={variant}
+      className='system-b-chat-activity-feed'
     >
       {events.map((event, index) => (
         <ToolActivityRow
           key={event.toolCallId}
           event={event}
-          variant={variant}
           multiple={multiple}
           index={index}
           count={events.length}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -121,6 +121,21 @@
   --system-b-chat-message-content-max: 66ch;
   --system-b-chat-body-size: var(--text-app);
   --system-b-chat-body-line-height: 1.5;
+  /* Agent activity (tool-call status rows) — one step subordinate to prose */
+  --system-b-chat-activity-indent: var(--space-4);
+  --system-b-chat-activity-size: var(--text-xs);
+  --system-b-chat-activity-line-height: var(--space-4);
+  --system-b-chat-activity-weight: var(--font-weight-book);
+  --system-b-chat-activity-color: var(--color-text-secondary-token);
+  --system-b-chat-activity-meta-color: var(--color-text-tertiary-token);
+  --system-b-chat-activity-gap: var(--space-0-5);
+  --system-b-chat-activity-row-py: var(--space-1);
+  --system-b-chat-activity-icon-size: 0.875rem;
+  --system-b-chat-activity-timeline-color: color-mix(
+    in oklab,
+    var(--linear-app-shell-border) 70%,
+    transparent
+  );
   --system-b-chat-composer-max-width: 45rem;
   --system-b-chat-composer-thread-scroll-padding: 9rem;
   --system-b-chat-composer-scroll-fade-height: 7rem;
@@ -9298,6 +9313,157 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   color: var(--color-text-primary-token);
   font-size: var(--system-b-chat-body-size);
   line-height: var(--system-b-chat-body-line-height);
+}
+
+/*
+ * Agent activity feed (GH #13897)
+ * Quiet tool-call / status rows: indented one rhythm step from prose,
+ * secondary color, book weight, one size step below body. Consecutive
+ * steps form a single run with no card chrome. Interactive CTA cards
+ * stay on `.system-b-chat-action-card` (elevated, not this pattern).
+ */
+:where(.system-b-chat-activity-feed) {
+  width: 100%;
+  max-width: var(--system-b-chat-message-content-max);
+  padding-left: var(--system-b-chat-activity-indent);
+  color: var(--system-b-chat-activity-color);
+  font-size: var(--system-b-chat-activity-size);
+  font-weight: var(--system-b-chat-activity-weight);
+  line-height: var(--system-b-chat-activity-line-height);
+}
+
+:where(.system-b-chat-activity-feed[data-variant="inline"]) {
+  max-width: 100%;
+}
+
+:where(.system-b-chat-activity-feed > * + *) {
+  margin-top: var(--system-b-chat-activity-gap);
+}
+
+:where(.system-b-chat-activity-row) {
+  position: relative;
+  display: flex;
+  width: 100%;
+  align-items: flex-start;
+  gap: var(--space-2);
+  /* Reserve vertical space so body/next-step text does not shift layout */
+  min-height: calc(
+    var(--system-b-chat-activity-line-height) +
+    (var(--system-b-chat-activity-row-py) * 2)
+  );
+  padding-block: var(--system-b-chat-activity-row-py);
+  color: var(--system-b-chat-activity-color);
+}
+
+:where(.system-b-chat-activity-timeline) {
+  position: absolute;
+  left: calc(var(--system-b-chat-activity-icon-size) / 2);
+  width: var(--space-px);
+  transform: translateX(-50%);
+  background: var(--system-b-chat-activity-timeline-color);
+}
+
+:where(.system-b-chat-activity-timeline[data-edge="first"]) {
+  top: calc(
+    var(--system-b-chat-activity-row-py) +
+    (var(--system-b-chat-activity-icon-size) / 2)
+  );
+  bottom: 0;
+}
+
+:where(.system-b-chat-activity-timeline[data-edge="last"]) {
+  top: 0;
+  bottom: calc(
+    100% -
+    (
+      var(--system-b-chat-activity-row-py) +
+      (var(--system-b-chat-activity-icon-size) / 2)
+    )
+  );
+}
+
+:where(.system-b-chat-activity-timeline[data-edge="middle"]) {
+  top: 0;
+  bottom: 0;
+}
+
+:where(.system-b-chat-activity-icon) {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  width: var(--system-b-chat-activity-icon-size);
+  height: var(--system-b-chat-activity-icon-size);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  margin-top: var(--space-0-5);
+  border-radius: var(--radius-full);
+  background: var(--linear-app-content-surface);
+  color: var(--system-b-chat-activity-color);
+}
+
+:where(.system-b-chat-activity-icon[data-state="success"]) {
+  color: var(--color-success);
+}
+
+:where(.system-b-chat-activity-icon[data-state="error"]) {
+  color: var(--color-error);
+}
+
+:where(.system-b-chat-activity-icon svg) {
+  width: 100%;
+  height: 100%;
+}
+
+:where(.system-b-chat-activity-copy) {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+:where(.system-b-chat-activity-title) {
+  overflow: hidden;
+  color: var(--system-b-chat-activity-color);
+  font-size: var(--system-b-chat-activity-size);
+  font-weight: var(--system-b-chat-activity-weight);
+  line-height: var(--system-b-chat-activity-line-height);
+  letter-spacing: -0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(.system-b-chat-activity-title[data-state="error"]) {
+  color: var(--color-error);
+}
+
+:where(.system-b-chat-activity-body) {
+  display: -webkit-box;
+  margin-top: var(--space-0-5);
+  overflow: hidden;
+  color: var(--system-b-chat-activity-meta-color);
+  font-size: var(--text-2xs);
+  font-weight: var(--system-b-chat-activity-weight);
+  line-height: var(--space-4);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+:where(.system-b-chat-activity-next) {
+  display: -webkit-box;
+  margin-top: var(--space-0-5);
+  overflow: hidden;
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-3xs);
+  font-weight: var(--system-b-chat-activity-weight);
+  line-height: var(--space-4);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+:where(.system-b-chat-activity-verbose) {
+  margin-top: var(--space-1-5);
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-3xs);
+  line-height: var(--space-4);
 }
 
 :where(.system-b-chat-markdown) {

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -278,7 +278,7 @@ describe('ChatMessage', () => {
     expect(copyButton.querySelector('.system-b-chat-copy-icon')).toBeTruthy();
   });
 
-  it('renders one generic tool as an inline activity row without card chrome', () => {
+  it('renders one generic tool as an indented subordinate activity row without card chrome', () => {
     const messageProps = {
       id: 'assistant-tool-1',
       role: 'assistant' as const,
@@ -295,17 +295,20 @@ describe('ChatMessage', () => {
 
     fastRender(<ChatMessage {...messageProps} />);
 
+    const feed = screen.getByTestId('tool-activity-feed');
     const statusRow = screen.getByTestId('tool-status-row');
+    expect(feed).toHaveClass('system-b-chat-activity-feed');
+    expect(feed).toHaveAttribute('data-tool-count', '1');
+    expect(statusRow).toHaveClass('system-b-chat-activity-row');
     expect(statusRow.className).not.toContain('rounded-xl');
     expect(statusRow.className).not.toContain('border');
-    expect(screen.getByTestId('tool-activity-feed')).toHaveAttribute(
-      'data-tool-count',
-      '1'
-    );
+    expect(
+      statusRow.querySelector('.system-b-chat-activity-title')
+    ).toBeTruthy();
     expect(screen.queryByTestId('tool-activity-timeline-line')).toBeNull();
   });
 
-  it('connects multiple generic tools with timeline lines', () => {
+  it('connects multiple generic tools with timeline lines in one quiet activity run', () => {
     const messageProps = {
       id: 'assistant-tool-2',
       role: 'assistant' as const,
@@ -329,14 +332,15 @@ describe('ChatMessage', () => {
 
     fastRender(<ChatMessage {...messageProps} />);
 
-    expect(screen.getByTestId('tool-activity-feed')).toHaveAttribute(
-      'data-tool-count',
-      '2'
-    );
+    const feed = screen.getByTestId('tool-activity-feed');
+    expect(feed).toHaveClass('system-b-chat-activity-feed');
+    expect(feed).toHaveAttribute('data-tool-count', '2');
     expect(screen.getAllByTestId('tool-status-row')).toHaveLength(2);
-    expect(screen.getAllByTestId('tool-activity-timeline-line')).toHaveLength(
-      2
-    );
+    const timelineLines = screen.getAllByTestId('tool-activity-timeline-line');
+    expect(timelineLines).toHaveLength(2);
+    expect(timelineLines[0]).toHaveAttribute('data-edge', 'first');
+    expect(timelineLines[1]).toHaveAttribute('data-edge', 'last');
+    expect(timelineLines[0]).toHaveClass('system-b-chat-activity-timeline');
     expect(screen.getByText("Couldn't send your feedback")).toBeInTheDocument();
     expect(screen.getByText('Feedback failed.')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Introduce a first-class System B **agent activity** pattern for chat transcript tool-call rows: one rhythm step indent, secondary text, book weight (450), one size step below body prose.
- Wire `ToolActivityFeed` / `ToolActivityRow` to `.system-b-chat-activity-*` primitives so consecutive steps form a quiet run with no card chrome.
- Keep elevated empty-state CTAs on `.system-b-chat-action-card` (documented boundary); document the pattern in `DESIGN.md`.

Fixes #13897

## Changes
| Area | What |
|------|------|
| `design-system.css` | Activity tokens + feed/row/title/body/timeline/icon primitives |
| `tool-ui.tsx` | Activity rows use System B classes; timeline edge via `data-edge` |
| `ChatActionCard.tsx` | Doc boundary vs quiet activity (no hex in comments — style guard) |
| `ChatMessage.test.tsx` | Asserts subordinate activity classes + quiet multi-step run |
| `DESIGN.md` | Canon for chat agent activity |

## Acceptance
- [x] Tool activity indented one rhythm step from prose (`--system-b-chat-activity-indent: space-4`)
- [x] Secondary color, book weight, size one step below body (`text-xs` vs `text-app`)
- [x] Consecutive steps = quiet run; no nested card chrome
- [x] Row min-height reserves space; spinner respects `motion-reduce` / reduced-motion tokens

## Verification
- Focused chat unit tests (ChatMessage, tool-ui-errors, ChatActionCard, style-guard) — pass
- Biome + typecheck on touched surfaces — pass

## Risk
Low / taste surface (chat transcript visual hierarchy). No auth, billing, or schema.