### PR TITLE
fix(design-system): map --linear paren utilities to semantic tokens (safe surfaces)

### DIFF
--- a/apps/web/components/features/admin/FunnelMetricsStrip.tsx
+++ b/apps/web/components/features/admin/FunnelMetricsStrip.tsx
@@ -112,7 +112,7 @@ export function FunnelMetricsStrip({
         <ContentSectionHeader
           title='Core KPIs'
           subtitle='Revenue, runway, and monetization health'
-          className='min-h-0 px-(--linear-app-header-padding-x) py-3'
+          className='min-h-0 px-app-header py-3'
         />
         <div className='grid gap-3 px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y) sm:grid-cols-2 xl:grid-cols-3'>
           <MetricCard
@@ -177,7 +177,7 @@ export function FunnelMetricsStrip({
         <ContentSectionHeader
           title='Instagram Activation'
           subtitle='First-week bio-link adoption and activation'
-          className='min-h-0 px-(--linear-app-header-padding-x) py-3'
+          className='min-h-0 px-app-header py-3'
         />
         <div className='grid gap-3 px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y) sm:grid-cols-2 xl:grid-cols-5'>
           <MetricCard
@@ -225,7 +225,7 @@ export function FunnelMetricsStrip({
         <ContentSectionHeader
           title='YC metrics'
           subtitle='Benchmark gaps and operating signals'
-          className='min-h-0 px-(--linear-app-header-padding-x) py-3'
+          className='min-h-0 px-app-header py-3'
         />
         <div className='grid gap-3 px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y) sm:grid-cols-2 xl:grid-cols-4'>
           <PlaceholderMetricCard

--- a/apps/web/components/features/admin/ScreenshotGallery.tsx
+++ b/apps/web/components/features/admin/ScreenshotGallery.tsx
@@ -179,7 +179,7 @@ export function ScreenshotGallery({ screenshots }: ScreenshotGalleryProps) {
         <button
           type='button'
           onClick={() => setSelectedIndex(globalIndex)}
-          className='block w-full cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)'
+          className='block w-full cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
           aria-label={`View ${screenshot.title}`}
         >
           <div className='relative aspect-video overflow-hidden bg-surface-1'>

--- a/apps/web/components/features/admin/admin-users-table/AdminUsersTableUnified.tsx
+++ b/apps/web/components/features/admin/admin-users-table/AdminUsersTableUnified.tsx
@@ -105,7 +105,7 @@ function AdminUserMobileCard({
             type='checkbox'
             checked={isSelected}
             onChange={() => onToggleSelect(user.id)}
-            className='mt-0.5 h-4 w-4 rounded border-(--linear-border-strong) bg-surface-0 text-(--linear-accent) focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+            className='mt-0.5 h-4 w-4 rounded border-(--linear-border-strong) bg-surface-0 text-(--linear-accent) focus-visible:ring-1 focus-visible:ring-ring'
             aria-label={`Select ${user.name ?? user.email ?? 'user'}`}
           />
           <div className='min-w-0'>

--- a/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
+++ b/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
@@ -117,7 +117,7 @@ function AgentRunDetailPopover({
         <button
           type='button'
           aria-label={`Inspect ${artifact.title}`}
-          className='rounded-md p-1 text-tertiary-token opacity-70 transition-colors hover:bg-surface-1 hover:text-primary-token hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+          className='rounded-md p-1 text-tertiary-token opacity-70 transition-colors hover:bg-surface-1 hover:text-primary-token hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
         >
           <Info className='size-3.5' aria-hidden='true' />
         </button>
@@ -217,7 +217,7 @@ function AgentOsBoardCard({
           onClick={() => onSelect(artifact)}
           aria-label={artifact.title}
           aria-pressed={isSelected}
-          className='min-w-0 flex-1 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus) focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface)'
+          className='min-w-0 flex-1 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface)'
         >
           <p className='line-clamp-2 text-app font-[560] leading-5 text-primary-token'>
             {artifact.title}
@@ -294,7 +294,7 @@ function AgentOsBoard({
                 aria-pressed={statusFilter === status}
                 aria-label={`Filter by ${RUN_STATUS_LABEL[status]} (${laneRows.length})`}
                 className={cn(
-                  'rounded px-1 text-2xs tabular-nums transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+                  'rounded px-1 text-2xs tabular-nums transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
                   statusFilter === status
                     ? 'bg-surface-0 font-[560] text-primary-token'
                     : 'text-tertiary-token hover:bg-surface-0 hover:text-secondary-token'
@@ -529,7 +529,7 @@ export function AgentOsRunsPanel({
             </div>
           </div>
         }
-        className='min-h-0 flex-col items-start px-(--linear-app-header-padding-x) py-3 sm:flex-row sm:items-center'
+        className='min-h-0 flex-col items-start px-app-header py-3 sm:flex-row sm:items-center'
         bodyClassName='w-full'
         subtitleClassName='whitespace-normal'
         actionsClassName='ml-0 w-full max-w-full flex-wrap justify-start sm:ml-auto sm:w-auto sm:justify-end'
@@ -571,7 +571,7 @@ export function AgentOsRunsPanel({
                   cn(
                     getRowClassName(artifact),
                     artifact.id === selectedArtifact?.id &&
-                      'bg-surface-0 ring-1 ring-inset ring-(--linear-border-focus)'
+                      'bg-surface-0 ring-1 ring-inset ring-ring'
                   )
                 }
                 getRowTestId={artifact => `agent-os-run-${artifact.id}`}

--- a/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
+++ b/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
@@ -58,7 +58,7 @@ function RowActionLink({ href, label }: RowActionLinkProps) {
       rel='noopener noreferrer'
       aria-label={`${label} (opens in a new tab)`}
       onClick={e => e.stopPropagation()}
-      className='inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs font-[520] text-tertiary-token transition-colors hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+      className='inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs font-[520] text-tertiary-token transition-colors hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
     >
       {label}
       <ExternalLink className='size-3' aria-hidden='true' />
@@ -137,7 +137,7 @@ export function WorkflowRunRow({
       <button
         type='button'
         onClick={() => onSelect(artifact)}
-        className='grid gap-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface)'
+        className='grid gap-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface)'
         aria-pressed={isSelected}
       >
         {mainContent}

--- a/apps/web/components/features/admin/creator-actions-menu/CreatorActionsMenu.tsx
+++ b/apps/web/components/features/admin/creator-actions-menu/CreatorActionsMenu.tsx
@@ -170,7 +170,7 @@ export function CreatorActionsMenu({
           <DropdownMenuTrigger asChild>
             <AppIconButton
               ariaLabel='Open creator actions'
-              className='h-8 w-8 rounded-full bg-transparent text-quaternary-token hover:bg-surface-1 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/25 [&_svg]:h-3.5 [&_svg]:w-3.5'
+              className='h-8 w-8 rounded-full bg-transparent text-quaternary-token hover:bg-surface-1 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-ring/25 [&_svg]:h-3.5 [&_svg]:w-3.5'
               disabled={isLoading}
             >
               <MoreVertical className='h-3.5 w-3.5' />

--- a/apps/web/components/features/admin/leads/LeadGtmInsights.tsx
+++ b/apps/web/components/features/admin/leads/LeadGtmInsights.tsx
@@ -67,7 +67,7 @@ export async function LeadGtmInsights() {
         <ContentSectionHeader
           title='GTM insights'
           subtitle='Attributed cohort performance and ramp recommendation'
-          className='px-(--linear-app-header-padding-x) py-3'
+          className='px-app-header py-3'
         />
         <div className='space-y-4 px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y)'>
           <div className='grid gap-3 sm:grid-cols-2 xl:grid-cols-5'>

--- a/apps/web/components/features/admin/outreach/DmQueuePanel.tsx
+++ b/apps/web/components/features/admin/outreach/DmQueuePanel.tsx
@@ -101,7 +101,7 @@ export function DmQueuePanel() {
             {total} queued
           </span>
         }
-        className='min-h-0 px-(--linear-app-header-padding-x) py-3'
+        className='min-h-0 px-app-header py-3'
         actionsClassName='shrink-0'
       />
       <div className='px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y)'>

--- a/apps/web/components/features/admin/outreach/OutreachKpis.tsx
+++ b/apps/web/components/features/admin/outreach/OutreachKpis.tsx
@@ -60,7 +60,7 @@ export function OutreachKpis({ counts, embedded = false }: OutreachKpisProps) {
             {counts.total} total
           </span>
         }
-        className='min-h-0 px-(--linear-app-header-padding-x) py-3'
+        className='min-h-0 px-app-header py-3'
         actionsClassName='shrink-0'
       />
       <div className='px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y)'>

--- a/apps/web/components/features/admin/outreach/OutreachOverviewPanel.tsx
+++ b/apps/web/components/features/admin/outreach/OutreachOverviewPanel.tsx
@@ -87,7 +87,7 @@ export function OutreachOverviewPanel({
           titleWidth='w-36'
           descriptionWidth='w-56'
           actionWidths={['w-16']}
-          className='min-h-0 px-(--linear-app-header-padding-x) py-3'
+          className='min-h-0 px-app-header py-3'
         />
         <div className='grid gap-3 px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y) sm:grid-cols-2 xl:grid-cols-4'>
           {['total', 'email', 'dm', 'review'].map(key => (

--- a/apps/web/components/features/admin/table/AdminTableHeader.tsx
+++ b/apps/web/components/features/admin/table/AdminTableHeader.tsx
@@ -51,7 +51,7 @@ export function AdminTableSubheader({
       className={cn(
         hasToolbar
           ? 'bg-surface-1'
-          : 'border-b border-(--linear-app-frame-seam) bg-surface-1 px-(--linear-app-header-padding-x) py-1',
+          : 'border-b border-(--linear-app-frame-seam) bg-surface-1 px-app-header py-1',
         className
       )}
     >

--- a/apps/web/components/features/admin/table/SortableHeaderButton.tsx
+++ b/apps/web/components/features/admin/table/SortableHeaderButton.tsx
@@ -24,7 +24,7 @@ export function SortableHeaderButton({
         'inline-flex w-full items-center gap-2 text-left text-app font-medium tracking-normal',
         'rounded-full px-1.5 py-1 transition-[background-color,color,box-shadow] duration-subtle',
         'text-secondary-token hover:bg-surface-1 hover:text-primary-token',
-        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
         'active:bg-surface-0',
         className
       )}

--- a/apps/web/components/features/admin/table/TableRowActions.tsx
+++ b/apps/web/components/features/admin/table/TableRowActions.tsx
@@ -24,7 +24,7 @@ export function TableRowActions({
   const isVerificationLoading = verificationStatus === 'loading';
   const isRefreshLoading = refreshIngestStatus === 'loading';
   const rowActionClassName =
-    'h-8 w-8 rounded-full bg-transparent text-quaternary-token hover:bg-surface-1 hover:text-secondary-token active:bg-surface-0 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/25 [&_svg]:h-3.5 [&_svg]:w-3.5';
+    'h-8 w-8 rounded-full bg-transparent text-quaternary-token hover:bg-surface-1 hover:text-secondary-token active:bg-surface-0 focus-visible:ring-1 focus-visible:ring-ring/25 [&_svg]:h-3.5 [&_svg]:w-3.5';
 
   return (
     <div className='flex items-center justify-end gap-1'>

--- a/apps/web/components/features/dashboard/AudienceRowActionsMenu.tsx
+++ b/apps/web/components/features/dashboard/AudienceRowActionsMenu.tsx
@@ -61,7 +61,7 @@ export function AudienceRowActionsMenu({
       <DropdownMenuTrigger asChild>
         <AppIconButton
           ariaLabel='Open audience row actions'
-          className='h-8 w-8 rounded-lg border border-transparent bg-transparent text-quaternary-token hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/25 [&_svg]:h-3.5 [&_svg]:w-3.5'
+          className='h-8 w-8 rounded-lg border border-transparent bg-transparent text-quaternary-token hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-ring/25 [&_svg]:h-3.5 [&_svg]:w-3.5'
         >
           <MoreHorizontal className='h-4 w-4' />
         </AppIconButton>

--- a/apps/web/components/features/dashboard/atoms/DspConnectionPill.tsx
+++ b/apps/web/components/features/dashboard/atoms/DspConnectionPill.tsx
@@ -27,7 +27,7 @@ const BASE_PILL_CLASSNAME =
   'inline-flex min-h-7 items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-caption tracking-tight transition-[background-color,border-color,color] duration-subtle';
 
 const INTERACTIVE_PILL_CLASSNAME =
-  'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20 disabled:opacity-50 disabled:cursor-not-allowed';
+  'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-ring/20 disabled:opacity-50 disabled:cursor-not-allowed';
 
 const CONNECTION_PILL_PROVIDERS = [
   'spotify',

--- a/apps/web/components/features/dashboard/atoms/LinkPill.tsx
+++ b/apps/web/components/features/dashboard/atoms/LinkPill.tsx
@@ -110,7 +110,7 @@ export function LinkPill({
     <AppIconButton
       ariaLabel={menuButtonAria}
       ref={setReferenceRef}
-      className='-mr-2 h-10 w-10 rounded-lg border-transparent bg-surface-0 text-quaternary-token hover:bg-surface-1 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/25 [&_svg]:h-5 [&_svg]:w-5'
+      className='-mr-2 h-10 w-10 rounded-lg border-transparent bg-surface-0 text-quaternary-token hover:bg-surface-1 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-ring/25 [&_svg]:h-5 [&_svg]:w-5'
       {...getReferenceProps()}
     >
       <Icon name='MoreHorizontal' className='h-5 w-5 opacity-90' />

--- a/apps/web/components/features/dashboard/insights/InsightActions.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightActions.tsx
@@ -18,7 +18,7 @@ export function InsightActions({ insightId }: InsightActionsProps) {
         size='sm'
         disabled={isPending}
         onClick={() => mutate({ insightId, status: 'dismissed' })}
-        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-tight text-tertiary-token transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-secondary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/20'
+        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-tight text-tertiary-token transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-secondary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-ring/20'
       >
         <X className='h-3 w-3' />
         Dismiss
@@ -28,7 +28,7 @@ export function InsightActions({ insightId }: InsightActionsProps) {
         size='sm'
         disabled={isPending}
         onClick={() => mutate({ insightId, status: 'acted_on' })}
-        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-tight text-secondary-token transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-primary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/20'
+        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-tight text-secondary-token transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-primary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-ring/20'
       >
         <Check className='h-3 w-3' />
         Done

--- a/apps/web/components/features/dashboard/molecules/DspMatchCard.tsx
+++ b/apps/web/components/features/dashboard/molecules/DspMatchCard.tsx
@@ -154,7 +154,7 @@ export function DspMatchCard({
           <button
             type='button'
             onClick={() => setIsExpanded(!isExpanded)}
-            className='flex h-7 w-full items-center justify-between rounded-lg border border-transparent px-2 text-xs text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+            className='flex h-7 w-full items-center justify-between rounded-lg border border-transparent px-2 text-xs text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-ring'
           >
             <span>Confidence breakdown</span>
             <Icon

--- a/apps/web/components/features/dashboard/molecules/ProfileCompletionCard.tsx
+++ b/apps/web/components/features/dashboard/molecules/ProfileCompletionCard.tsx
@@ -146,7 +146,7 @@ export const ProfileCompletionCard = memo(
               type='button'
               onClick={handleDismiss}
               aria-label='Dismiss Profile Completion Card'
-              className='shrink-0 rounded-lg border border-(--linear-app-frame-seam) p-1.5 text-tertiary-token transition-[background-color,border-color,color,box-shadow] duration-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+              className='shrink-0 rounded-lg border border-(--linear-app-frame-seam) p-1.5 text-tertiary-token transition-[background-color,border-color,color,box-shadow] duration-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-1 focus-visible:ring-ring'
             >
               <X className='h-4 w-4' aria-hidden='true' />
             </button>

--- a/apps/web/components/features/dashboard/organisms/ProfileEditorSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/ProfileEditorSection.tsx
@@ -61,7 +61,7 @@ function ProfileIdentityFieldRow({
         <button
           type='button'
           className={cn(
-            'w-full rounded-md border border-transparent px-3 py-2.5 text-center transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-1 focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20 active:bg-surface-2',
+            'w-full rounded-md border border-transparent px-3 py-2.5 text-center transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-1 focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-ring/20 active:bg-surface-2',
             tone === 'primary'
               ? 'min-h-13 text-base font-semibold tracking-tighter text-primary-token'
               : 'min-h-11 text-app font-caption tracking-tight text-secondary-token'

--- a/apps/web/components/features/dashboard/organisms/dashboard-activity-feed/DashboardActivityFeed.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-activity-feed/DashboardActivityFeed.tsx
@@ -103,7 +103,7 @@ const ActivityItem = memo(function ActivityItem({
         />
         <Link
           href={activity.href}
-          className='group relative flex items-start gap-2.5 rounded-md px-1.5 py-1.5 transition-[background-color] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+          className='group relative flex items-start gap-2.5 rounded-md px-1.5 py-1.5 transition-[background-color] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
         >
           {content}
         </Link>

--- a/apps/web/components/features/dashboard/organisms/dashboard-theme-toggle/DashboardThemeToggle.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-theme-toggle/DashboardThemeToggle.tsx
@@ -141,7 +141,7 @@ function ThemeToggleButton({
             disabled={isUpdating}
             onClick={onToggle}
             className={cn(
-              'h-8 w-8 rounded-full bg-surface-1 text-quaternary-token hover:bg-surface-2 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/25 [&_svg]:h-4 [&_svg]:w-4',
+              'h-8 w-8 rounded-full bg-surface-1 text-quaternary-token hover:bg-surface-2 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-ring/25 [&_svg]:h-4 [&_svg]:w-4',
               isUpdating && 'opacity-70'
             )}
           >
@@ -166,7 +166,7 @@ function ThemeToggleButton({
           disabled={isUpdating}
           onClick={onToggle}
           className={cn(
-            'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border border-subtle transition-colors duration-subtle ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus) disabled:cursor-not-allowed disabled:opacity-50',
+            'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border border-subtle transition-colors duration-subtle ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
             isDark ? 'bg-(--linear-border-focus)' : 'bg-surface-0',
             'p-0.5'
           )}

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceCard.tsx
@@ -34,7 +34,7 @@ export function DspPresenceCard({
         'cursor-pointer p-3.5 transition-[border-color,background-color,box-shadow] duration-subtle',
         'bg-[color-mix(in_oklab,var(--linear-bg-surface-0)_94%,transparent)] hover:border-default hover:bg-(--linear-bg-surface-0)',
         isSelected &&
-          'border-(--linear-border-focus) bg-(--linear-bg-surface-0) ring-1 ring-(--linear-border-focus)'
+          'border-(--linear-border-focus) bg-(--linear-bg-surface-0) ring-1 ring-ring'
       )}
       data-testid={`presence-card-${item.providerId}`}
     >

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx
@@ -77,7 +77,7 @@ const LinkCell = memo(function LinkCell({
       href={item.externalArtistUrl}
       target='_blank'
       rel='noopener noreferrer'
-      className='flex h-6 w-6 items-center justify-center rounded text-tertiary-token transition-colors duration-subtle ease-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+      className='flex h-6 w-6 items-center justify-center rounded text-tertiary-token transition-colors duration-subtle ease-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
       aria-label={`View on ${label}`}
       onClick={e => e.stopPropagation()}
     >
@@ -144,7 +144,7 @@ export const DspPresenceTable = memo(function DspPresenceTable({
           'bg-[color-mix(in_oklab,var(--linear-row-selected)_24%,var(--linear-bg-surface-0))]',
           'shadow-[inset_2px_0_0_0_var(--linear-border-focus),inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_14%,var(--linear-app-frame-seam))]',
           'hover:bg-[color-mix(in_oklab,var(--linear-row-selected)_28%,var(--linear-bg-surface-0))]',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
         ].join(' ');
       }
 
@@ -154,7 +154,7 @@ export const DspPresenceTable = memo(function DspPresenceTable({
         'hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_78%,transparent)]',
         'hover:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-app-frame-seam)_72%,transparent)]',
         '[&:hover_span]:text-primary-token',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
       ].join(' ');
     },
     [selectedMatchId]

--- a/apps/web/components/features/dashboard/organisms/jovie-work-feed/JovieWorkFeed.tsx
+++ b/apps/web/components/features/dashboard/organisms/jovie-work-feed/JovieWorkFeed.tsx
@@ -110,7 +110,7 @@ const JovieWorkItemRow = memo(function JovieWorkItemRow({
         />
         <Link
           href={item.href}
-          className='group relative flex items-start gap-2.5 rounded-md px-1.5 py-1.5 transition-[background-color] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+          className='group relative flex items-start gap-2.5 rounded-md px-1.5 py-1.5 transition-[background-color] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
         >
           {content}
         </Link>

--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
@@ -102,7 +102,7 @@ export function OnboardingHandleStep({
               'flex items-center gap-2 rounded-full border px-2 py-1.5 transition-[background-color,border-color,box-shadow] duration-subtle',
               'border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,var(--linear-bg-surface-0))]',
               'hover:border-default hover:bg-surface-0',
-              'focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-(--linear-border-focus)/16',
+              'focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-ring/16',
               hasError && 'border-destructive/60'
             )}
           >

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
@@ -158,7 +158,7 @@ const ArtworkCell = memo(function ArtworkCell({
             // Always renders white-on-black scrim in both themes — pair the
             // light/dark utilities so the play glyph stays legible on the
             // `bg-black/50` overlay (satisfies no-hardcoded-theme-colors).
-            'absolute inset-0 grid place-items-center rounded-sm bg-black/50 text-white dark:text-white transition-opacity duration-subtle ease-subtle focus-visible:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
+            'absolute inset-0 grid place-items-center rounded-sm bg-black/50 text-white dark:text-white transition-opacity duration-subtle ease-subtle focus-visible:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/55',
             isTrackPlaying
               ? 'opacity-100'
               : 'opacity-0 group-hover/row:opacity-100'

--- a/apps/web/components/features/dashboard/organisms/releases/cells/AvailabilityCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/AvailabilityCell.tsx
@@ -334,7 +334,7 @@ export const AvailabilityCell = memo(function AvailabilityCell({
                           }
                           onClick={createCopyHandler(providerKey, testId)}
                           className={cn(
-                            'rounded-full p-1.5 text-tertiary-token transition-[background-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+                            'rounded-full p-1.5 text-tertiary-token transition-[background-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-ring',
                             isCopied && 'text-emerald-600 dark:text-emerald-400'
                           )}
                         >

--- a/apps/web/components/features/dashboard/organisms/releases/cells/PopularityIcon.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/PopularityIcon.tsx
@@ -60,7 +60,7 @@ export const PopularityIcon = memo(function PopularityIcon({
       <TooltipTrigger asChild>
         <button
           type='button'
-          className='inline-flex items-end gap-[1.5px] rounded-sm opacity-80 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)'
+          className='inline-flex items-end gap-[1.5px] rounded-sm opacity-80 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
           aria-label={`Popularity ${displayPopularity} out of 100`}
         >
           {/* Bar 1 - shortest (4px) */}

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
@@ -45,7 +45,7 @@ export const ReleaseTaskCompactRow = React.memo(function ReleaseTaskCompactRow({
         type='button'
         onClick={() => onNavigate(task.id)}
         className={cn(
-          'flex-1 text-left text-2xs truncate transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none',
+          'flex-1 text-left text-2xs truncate transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none',
           isAi ? 'opacity-70' : 'hover:text-accent'
         )}
       >

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRowPrimitives.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRowPrimitives.tsx
@@ -46,7 +46,7 @@ export function ReleaseTaskCheckbox({
       disabled={isAutomated}
       onChange={() => onToggle(task.id, !isDone)}
       className={cn(
-        'flex-shrink-0 rounded accent-accent cursor-pointer disabled:cursor-default disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-bg-page) outline-none transition-[box-shadow] duration-subtle ease-subtle',
+        'flex-shrink-0 rounded accent-accent cursor-pointer disabled:cursor-default disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-bg-page) outline-none transition-[box-shadow] duration-subtle ease-subtle',
         className
       )}
       aria-label={`Mark "${task.title}" as ${isDone ? 'incomplete' : 'complete'}`}

--- a/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
@@ -345,7 +345,7 @@ function SortableTaskBoardCard({
         {...listeners}
         data-testid={`task-board-card-${task.id}`}
         onClick={() => onOpenTask(task)}
-        className='block w-full cursor-grab text-left active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+        className='block w-full cursor-grab text-left active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
       >
         <TaskBoardCard
           task={task}

--- a/apps/web/components/features/dashboard/tasks/TaskDescriptionHelper.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskDescriptionHelper.tsx
@@ -22,7 +22,7 @@ export function TaskDescriptionHelper({
         aria-label={`Open ${helper.title} description helper`}
         data-testid='task-description-helper'
         onClick={onBeginEditing}
-        className='absolute inset-0 rounded-2xl bg-[color-mix(in_oklab,var(--linear-app-content-surface)_82%,var(--linear-app-shell-border)_18%)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+        className='absolute inset-0 rounded-2xl bg-[color-mix(in_oklab,var(--linear-app-content-surface)_82%,var(--linear-app-shell-border)_18%)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
       />
       <div className='pointer-events-none relative z-10 max-w-[40rem] space-y-3 px-5 py-5 text-left'>
         <div className='space-y-1'>

--- a/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
@@ -233,7 +233,7 @@ export const TaskListRow = memo(function TaskListRow({
                 event.stopPropagation();
                 onOpenRelease(task);
               }}
-              className='inline-flex min-w-0 max-w-full items-center gap-1 text-secondary-token transition-colors duration-subtle ease-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) focus-visible:text-primary-token'
+              className='inline-flex min-w-0 max-w-full items-center gap-1 text-secondary-token transition-colors duration-subtle ease-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) focus-visible:text-primary-token'
               title={task.releaseTitle}
             >
               <Disc3 className='h-3 w-3 shrink-0 text-tertiary-token' />

--- a/apps/web/components/features/dashboard/tokens/card-tokens.ts
+++ b/apps/web/components/features/dashboard/tokens/card-tokens.ts
@@ -128,7 +128,7 @@ export const cardTokens = {
       hover:border-default
       focus-visible:outline-none
       focus-visible:ring-2
-      focus-visible:ring-(--linear-border-focus)
+      focus-visible:ring-ring
       focus-visible:ring-offset-2
     `,
 

--- a/apps/web/components/molecules/AppSearchField.tsx
+++ b/apps/web/components/molecules/AppSearchField.tsx
@@ -36,7 +36,7 @@ export function AppSearchField({
   return (
     <div
       className={cn(
-        'flex h-(--linear-app-control-height-sm) items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-2.5 text-primary-token transition-[border-color,box-shadow,background-color] duration-subtle hover:bg-surface-1 focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-(--linear-border-focus)/14',
+        'flex h-app-control-sm items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-2.5 text-primary-token transition-[border-color,box-shadow,background-color] duration-subtle hover:bg-surface-1 focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-ring/14',
         className
       )}
     >

--- a/apps/web/components/molecules/ContentSectionHeader.tsx
+++ b/apps/web/components/molecules/ContentSectionHeader.tsx
@@ -29,7 +29,7 @@ export function ContentSectionHeader({
   return (
     <div
       className={cn(
-        'flex min-w-0 shrink-0 items-center justify-between gap-2 px-(--linear-app-header-padding-x)',
+        'flex min-w-0 shrink-0 items-center justify-between gap-2 px-app-header',
         variant === 'default' && 'border-b border-subtle bg-transparent',
         density === 'compact'
           ? 'min-h-10 py-1.5'

--- a/apps/web/components/molecules/ContentSectionHeaderSkeleton.tsx
+++ b/apps/web/components/molecules/ContentSectionHeaderSkeleton.tsx
@@ -37,7 +37,7 @@ export function ContentSectionHeaderSkeleton({
   return (
     <div
       className={cn(
-        'flex min-h-(--linear-app-header-height) min-w-0 shrink-0 items-center justify-between gap-3 overflow-x-auto overflow-y-hidden border-b border-subtle bg-transparent px-(--linear-app-header-padding-x) py-1.5 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+        'flex min-h-(--linear-app-header-height) min-w-0 shrink-0 items-center justify-between gap-3 overflow-x-auto overflow-y-hidden border-b border-subtle bg-transparent px-app-header py-1.5 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
         className
       )}
       aria-hidden='true'

--- a/apps/web/components/molecules/MerchPricingPresetPicker.tsx
+++ b/apps/web/components/molecules/MerchPricingPresetPicker.tsx
@@ -35,7 +35,7 @@ export function MerchPricingPresetPicker({
           <label
             key={option.preset}
             className={cn(
-              'inline-flex h-7 cursor-pointer items-center rounded-md border px-2 text-3xs font-medium transition-[background-color,border-color,color] duration-subtle has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--linear-border-focus)/55',
+              'inline-flex h-7 cursor-pointer items-center rounded-md border px-2 text-3xs font-medium transition-[background-color,border-color,color] duration-subtle has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/55',
               active
                 ? 'border-default bg-surface-1 text-primary-token'
                 : 'border-subtle bg-surface-0 text-tertiary-token hover:border-default hover:text-secondary-token'

--- a/apps/web/components/molecules/TimeRangeSelector.tsx
+++ b/apps/web/components/molecules/TimeRangeSelector.tsx
@@ -80,7 +80,7 @@ export function TimeRangeSelector<T extends AnalyticsRange>({
           <button
             type='button'
             className={cn(
-              'inline-flex h-6 items-center gap-1 rounded-full border border-transparent px-1.5 py-0 text-2xs font-normal text-tertiary-token transition-colors duration-subtle hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/30',
+              'inline-flex h-6 items-center gap-1 rounded-full border border-transparent px-1.5 py-0 text-2xs font-normal text-tertiary-token transition-colors duration-subtle hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30',
               className
             )}
             aria-label={ariaLabel ?? 'Analytics Time Range'}
@@ -214,7 +214,7 @@ export function TimeRangeSelector<T extends AnalyticsRange>({
               title={
                 disabled ? 'Upgrade to Pro for extended analytics' : undefined
               }
-              className={`relative h-7 rounded-full border border-transparent px-2.5 text-xs font-caption tracking-tight shadow-none transition-[background-color,color,border-color,box-shadow] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-app-content-surface) ${stateClass}`}
+              className={`relative h-7 rounded-full border border-transparent px-2.5 text-xs font-caption tracking-tight shadow-none transition-[background-color,color,border-color,box-shadow] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-app-content-surface) ${stateClass}`}
             >
               {getTimeRangeLabel(range, 'short')}
             </button>

--- a/apps/web/components/molecules/drawer-header/DrawerHeaderActions.tsx
+++ b/apps/web/components/molecules/drawer-header/DrawerHeaderActions.tsx
@@ -14,7 +14,7 @@ import {
 import { cn } from '@/lib/utils';
 
 export const DRAWER_HEADER_ICON_BUTTON_CLASSNAME =
-  'h-7 w-7 rounded-full border border-transparent bg-transparent shadow-none hover:bg-surface-1 focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) active:bg-surface-1';
+  'h-7 w-7 rounded-full border border-transparent bg-transparent shadow-none hover:bg-surface-1 focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-ring active:bg-surface-1';
 
 export interface DrawerHeaderAction {
   readonly id: string;

--- a/apps/web/components/molecules/drawer/CollapsibleSectionHeading.tsx
+++ b/apps/web/components/molecules/drawer/CollapsibleSectionHeading.tsx
@@ -33,7 +33,7 @@ export function CollapsibleSectionHeading({
         DRAWER_SECTION_HEADING_CLASSNAME,
         'flex w-full items-center justify-between rounded-lg border border-transparent px-2.5 py-2 transition-[background-color,color,border-color] duration-subtle',
         'hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token',
-        'focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+        'focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
         className
       )}
     >

--- a/apps/web/components/molecules/drawer/DrawerActionRow.tsx
+++ b/apps/web/components/molecules/drawer/DrawerActionRow.tsx
@@ -25,7 +25,7 @@ export function DrawerActionRow({
       className={cn(
         'flex min-h-9 w-full items-center gap-2 rounded-full border border-transparent px-2.5 py-1.5 text-left text-xs text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-subtle',
         'hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-primary-token',
-        'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+        'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-ring',
         className
       )}
     >

--- a/apps/web/components/molecules/drawer/DrawerButton.tsx
+++ b/apps/web/components/molecules/drawer/DrawerButton.tsx
@@ -28,7 +28,7 @@ export interface DrawerButtonProps
 }
 
 export const DRAWER_BUTTON_CLASSNAME =
-  'border font-caption tracking-tight shadow-none transition-[background-color,border-color,color] duration-subtle focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20';
+  'border font-caption tracking-tight shadow-none transition-[background-color,border-color,color] duration-subtle focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-ring/20';
 
 export const DrawerButton = React.forwardRef<
   HTMLButtonElement,

--- a/apps/web/components/molecules/drawer/DrawerEditableTextField.tsx
+++ b/apps/web/components/molecules/drawer/DrawerEditableTextField.tsx
@@ -216,7 +216,7 @@ export const DrawerEditableTextField = React.memo(
               onClick={() => setIsEditing(true)}
               onDoubleClick={() => setIsEditing(true)}
               className={cn(
-                'flex w-full min-w-0 cursor-text items-center text-left transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+                'flex w-full min-w-0 cursor-text items-center text-left transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
                 density === 'inline'
                   ? // Align the text baseline with sibling static rows by
                     // removing horizontal inset. The hover chip sits over the
@@ -302,7 +302,7 @@ export const DrawerEditableTextField = React.memo(
                       target='_blank'
                       rel='noreferrer'
                       aria-label={action.ariaLabel}
-                      className='inline-flex h-6 w-6 items-center justify-center rounded-md text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+                      className='inline-flex h-6 w-6 items-center justify-center rounded-md text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
                       onClick={event => {
                         event.stopPropagation();
                         action.onClick?.();

--- a/apps/web/components/molecules/drawer/SidebarLinkRow.tsx
+++ b/apps/web/components/molecules/drawer/SidebarLinkRow.tsx
@@ -190,7 +190,7 @@ export function SidebarLinkRow({
                   'rounded-md border border-transparent p-1 text-tertiary-token',
                   'hover:border-subtle hover:bg-surface-0 hover:text-primary-token',
                   'transition-[background-color,border-color,color,box-shadow] duration-subtle focus-visible:outline-none',
-                  'focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+                  'focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-ring'
                 )}
                 aria-label={`Actions for ${label}`}
               >

--- a/apps/web/components/molecules/filters/FilterSearchInput.tsx
+++ b/apps/web/components/molecules/filters/FilterSearchInput.tsx
@@ -68,7 +68,7 @@ export function FilterSearchInput({
             'w-full rounded-lg border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_48%,transparent)] bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_34%,transparent)] py-1.5 pl-8 pr-6 text-xs',
             'text-primary-token placeholder:text-tertiary-token',
             'transition-[background-color,border-color,box-shadow] duration-subtle',
-            'focus-visible:border-(--linear-border-focus) focus-visible:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_44%,transparent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/14'
+            'focus-visible:border-(--linear-border-focus) focus-visible:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_44%,transparent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/14'
           )}
           aria-label={placeholder}
         />

--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -359,7 +359,7 @@ export function PersistentAudioBar({
           type='button'
           onClick={handleToggle}
           disabled={isLoading}
-          className='relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-0 text-secondary-token transition-[background-color,color,border-color] duration-subtle hover:border-default hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) disabled:opacity-50 before:absolute before:-inset-2 before:content-[""]'
+          className='relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-0 text-secondary-token transition-[background-color,color,border-color] duration-subtle hover:border-default hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50 before:absolute before:-inset-2 before:content-[""]'
           aria-label={playButtonLabel}
         >
           {playButtonIcon}
@@ -369,7 +369,7 @@ export function PersistentAudioBar({
         <button
           type='button'
           onClick={stop}
-          className='relative flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-quaternary-token transition-colors duration-subtle hover:text-secondary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) before:absolute before:-inset-2.5 before:content-[""]'
+          className='relative flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-quaternary-token transition-colors duration-subtle hover:text-secondary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring before:absolute before:-inset-2.5 before:content-[""]'
           aria-label='Dismiss Player'
         >
           <X className='h-3.5 w-3.5' />

--- a/apps/web/components/organisms/SharedCommandPalette.tsx
+++ b/apps/web/components/organisms/SharedCommandPalette.tsx
@@ -177,7 +177,7 @@ function CmdKPaletteRow({
         onCommit(index);
       }}
       className={cn(
-        'flex min-h-14 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left outline-none transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+        'flex min-h-14 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left outline-none transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
         isActive
           ? 'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_76%,white_14%)] text-primary-token shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_36%,transparent),0_10px_28px_-24px_rgba(0,0,0,0.9)]'
           : 'hover:bg-white/[0.045]'

--- a/apps/web/components/organisms/WorkspaceTabsSurface.tsx
+++ b/apps/web/components/organisms/WorkspaceTabsSurface.tsx
@@ -146,7 +146,7 @@ export function WorkspaceTabsSurface<
             title={title}
             subtitle={description}
             actions={actions}
-            className='min-h-0 px-(--linear-app-header-padding-x) py-3'
+            className='min-h-0 px-app-header py-3'
             actionsClassName='shrink-0'
           />
           {shouldShowTabControls ? (

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.tsx
@@ -98,7 +98,7 @@ function renderArtistLine(
       <button
         type='button'
         onClick={() => onArtistClick(fallback)}
-        className='rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+        className='rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
       >
         {fallback}
       </button>
@@ -122,7 +122,7 @@ function renderArtistLine(
         key={key}
         type='button'
         onClick={() => onArtistClick(part.value)}
-        className='rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+        className='rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
       >
         {part.value}
       </button>

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -332,7 +332,7 @@ function TrackListRow({
         onClick={handleTogglePlayback}
         disabled={!playableUrl && !isActiveTrack}
         className={cn(
-          'flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-caption tabular-nums transition-[background-color,color,border-color] duration-subtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+          'flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-caption tabular-nums transition-[background-color,color,border-color] duration-subtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
           isActiveTrack
             ? 'border border-(--linear-app-frame-seam) bg-surface-0 text-primary-token hover:bg-surface-1'
             : 'border border-transparent bg-transparent text-tertiary-token hover:bg-surface-0 hover:text-primary-token',
@@ -350,7 +350,7 @@ function TrackListRow({
         <button
           type='button'
           onClick={onSelect}
-          className='group/track-open flex min-w-0 flex-1 items-center gap-1.5 rounded-md text-left transition-[color,background-color] duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+          className='group/track-open flex min-w-0 flex-1 items-center gap-1.5 rounded-md text-left transition-[color,background-color] duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
           aria-label={`Open track details for ${track.title}`}
           data-testid={`release-track-open-${track.id}`}
         >

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -428,7 +428,7 @@ export function TrackSidebar({
                       onClick={handleTogglePlayback}
                       aria-label={isPlaying ? 'Pause preview' : 'Play preview'}
                       aria-pressed={isPlaying}
-                      className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token transition-[background-color,color,border-color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+                      className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token transition-[background-color,color,border-color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
                     >
                       {isPlaying ? (
                         <Pause className='h-4 w-4' />

--- a/apps/web/components/organisms/sidebar/controls.tsx
+++ b/apps/web/components/organisms/sidebar/controls.tsx
@@ -29,7 +29,7 @@ export const SidebarTrigger = React.forwardRef<
       variant='ghost'
       size='icon'
       className={cn(
-        'h-7 w-7 outline-none focus-visible:bg-sidebar-accent focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
+        'h-7 w-7 outline-none focus-visible:bg-sidebar-accent focus-visible:ring-1 focus-visible:ring-ring/35',
         className
       )}
       onClick={handleClick}
@@ -72,7 +72,7 @@ export const SidebarRail = React.forwardRef<
       title='Toggle Sidebar'
       className={cn(
         'absolute inset-y-0 z-20 max-sm:hidden w-4 -translate-x-1/2 transition-[transform] duration-fast ease-interactive after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 after:transition-colors after:duration-fast after:ease-interactive hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
-        'focus-visible:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
+        'focus-visible:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/35',
         'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
         'in-data-[side=left][data-state=closed]:cursor-e-resize in-data-[side=right][data-state=closed]:cursor-w-resize',
         'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar',

--- a/apps/web/components/organisms/sidebar/group.tsx
+++ b/apps/web/components/organisms/sidebar/group.tsx
@@ -34,7 +34,7 @@ export const SidebarGroupLabel = React.forwardRef<
       ref={ref}
       data-sidebar='group-label'
       className={cn(
-        'flex h-7 shrink-0 items-center rounded-full px-2.5 text-xs font-caption tracking-normal text-sidebar-muted/90 outline-none transition-[background-color,color,opacity,margin] duration-slow ease-interactive focus-visible:bg-sidebar-accent focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35 [&>svg]:size-3.5 [&>svg]:shrink-0',
+        'flex h-7 shrink-0 items-center rounded-full px-2.5 text-xs font-caption tracking-normal text-sidebar-muted/90 outline-none transition-[background-color,color,opacity,margin] duration-slow ease-interactive focus-visible:bg-sidebar-accent focus-visible:ring-1 focus-visible:ring-ring/35 [&>svg]:size-3.5 [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-7 group-data-[collapsible=icon]:opacity-0',
         className
       )}
@@ -55,7 +55,7 @@ export const SidebarGroupAction = React.forwardRef<
       ref={ref}
       data-sidebar='group-action'
       className={cn(
-        'absolute right-2 top-2 flex aspect-square w-4 items-center justify-center rounded-md p-0 text-sidebar-item-icon outline-none transition-[background-color,color] duration-normal ease-interactive hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:bg-sidebar-accent focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35 [&>svg]:h-4 [&>svg]:w-4 [&>svg]:shrink-0',
+        'absolute right-2 top-2 flex aspect-square w-4 items-center justify-center rounded-md p-0 text-sidebar-item-icon outline-none transition-[background-color,color] duration-normal ease-interactive hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:bg-sidebar-accent focus-visible:ring-1 focus-visible:ring-ring/35 [&>svg]:h-4 [&>svg]:w-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 after:lg:hidden',
         'group-data-[collapsible=icon]:hidden',

--- a/apps/web/components/organisms/sidebar/layout.tsx
+++ b/apps/web/components/organisms/sidebar/layout.tsx
@@ -32,7 +32,7 @@ export const SidebarInput = React.forwardRef<
       ref={ref}
       data-sidebar='input'
       className={cn(
-        'h-8 w-full bg-sidebar-input-background border border-sidebar-input-border shadow-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/24',
+        'h-8 w-full bg-sidebar-input-background border border-sidebar-input-border shadow-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-ring/24',
         className
       )}
       {...props}

--- a/apps/web/components/organisms/sidebar/menu.tsx
+++ b/apps/web/components/organisms/sidebar/menu.tsx
@@ -49,7 +49,7 @@ const sidebarMenuButtonVariants = cva(
     // Active state — filled background only, no border/inset ring
     'data-[active=true]:bg-[color-mix(in_oklab,var(--color-sidebar-accent-active)_88%,var(--linear-app-content-surface))] data-[active=true]:text-sidebar-item-foreground',
     // Focus state - subtle bg plus tokenized keyboard ring
-    'focus-visible:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
+    'focus-visible:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/35',
     // Disabled state
     'disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50',
     // Menu action spacing
@@ -196,7 +196,7 @@ export const SidebarMenuAction = React.forwardRef<
       className={cn(
         'relative flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-item-icon outline-none transition-[background-color,color] duration-normal ease-interactive',
         'hover:text-sidebar-foreground hover:bg-sidebar-accent',
-        'focus-visible:bg-sidebar-accent focus-visible:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
+        'focus-visible:bg-sidebar-accent focus-visible:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/35',
         '[&>svg]:size-3 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 after:lg:hidden',
@@ -314,7 +314,7 @@ export const SidebarMenuSubButton = React.forwardRef<
       className={cn(
         'flex min-h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-full px-2.5 text-app leading-[1.15] text-sidebar-item-foreground outline-none transition-[background-color,color,box-shadow] duration-normal ease-interactive [font-weight:var(--font-weight-nav)]',
         'hover:bg-sidebar-accent hover:text-sidebar-item-foreground',
-        'focus-visible:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
+        'focus-visible:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/35',
         'active:bg-sidebar-accent active:text-sidebar-item-foreground',
         'disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50',
         '[&>span:last-child]:truncate [&>svg]:size-3.5 [&>svg]:shrink-0 [&>svg]:text-sidebar-item-icon [&>svg]:transition-colors',

--- a/apps/web/components/organisms/table/molecules/DisplayMenuDropdown.tsx
+++ b/apps/web/components/organisms/table/molecules/DisplayMenuDropdown.tsx
@@ -33,7 +33,7 @@ function ToggleSwitch({
       role='switch'
       aria-checked={checked}
       onClick={onToggle}
-      className='flex w-full items-center justify-between gap-2 rounded px-1.5 py-1 transition-[background-color] duration-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+      className='flex w-full items-center justify-between gap-2 rounded px-1.5 py-1 transition-[background-color] duration-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
     >
       <span className='text-app text-secondary-token'>{label}</span>
       <span

--- a/apps/web/components/organisms/table/molecules/ResponsiveActionsCell.tsx
+++ b/apps/web/components/organisms/table/molecules/ResponsiveActionsCell.tsx
@@ -145,7 +145,7 @@ export function ResponsiveActionsCell({
           <DropdownMenuTrigger asChild>
             <button
               type='button'
-              className='inline-flex h-7 w-7 items-center justify-center rounded-full bg-surface-0 text-tertiary-token transition-[background-color,color,box-shadow] duration-subtle ease-out hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
+              className='inline-flex h-7 w-7 items-center justify-center rounded-full bg-surface-0 text-tertiary-token transition-[background-color,color,box-shadow] duration-subtle ease-out hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-ring/20'
               aria-label='More Actions'
             >
               <MoreVertical className='h-4 w-4' />

--- a/apps/web/components/organisms/table/molecules/TableHeaderCell.tsx
+++ b/apps/web/components/organisms/table/molecules/TableHeaderCell.tsx
@@ -71,7 +71,7 @@ export function TableHeaderCell<TData>({
                 tableHeaderClass,
                 'flex w-full items-center gap-2',
                 'rounded-full border border-transparent px-1.5 transition-[background-color,border-color,box-shadow] duration-subtle hover:border-subtle hover:bg-surface-1',
-                'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
+                'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-ring/20'
               )}
             >
               {flexRender(header.column.columnDef.header, header.getContext())}

--- a/apps/web/tests/unit/dashboard/display-menu-dropdown-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/display-menu-dropdown-system-b-style-guard.test.ts
@@ -27,9 +27,7 @@ describe('DisplayMenuDropdown System B style guard', () => {
     expect(source).toContain('hover:bg-surface-1');
     expect(source).toContain('focus-visible:bg-surface-1');
     expect(source).toContain('focus-visible:outline-none');
-    expect(source).toContain(
-      'focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
-    );
+    expect(source).toContain('focus-visible:ring-1 focus-visible:ring-ring');
     expect(source).toContain('h-4 w-7 shrink-0');
     expect(source).toContain('h-3 w-3 rounded-full');
     expect(source).toContain('translate-x-3');

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 2177
+  "count": 2096
 }

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -626,10 +626,7 @@ describe('LibrarySurface', () => {
     fireEvent.click(drawer.getByRole('button', { name: 'Providers' }));
     const providerLink = drawer.getByRole('link', { name: /Spotify/u });
 
-    expect(
-      overflowButton.className.includes('focus-visible:ring-ring') ||
-        overflowButton.className.includes('focus-visible:ring-ring')
-    ).toBe(true);
+    expect(overflowButton.className).toContain('focus-visible:ring-ring');
     for (const element of [previewButton, providerLink]) {
       expect(element.className).toContain(
         'focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55'

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -626,9 +626,10 @@ describe('LibrarySurface', () => {
     fireEvent.click(drawer.getByRole('button', { name: 'Providers' }));
     const providerLink = drawer.getByRole('link', { name: /Spotify/u });
 
-    expect(overflowButton.className).toContain(
-      'focus-visible:ring-(--linear-border-focus)'
-    );
+    expect(
+      overflowButton.className.includes('focus-visible:ring-ring') ||
+        overflowButton.className.includes('focus-visible:ring-ring')
+    ).toBe(true);
     for (const element of [previewButton, providerLink]) {
       expect(element.className).toContain(
         'focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55'


### PR DESCRIPTION
## Summary
Partial **lane 5** for #13988: convert Tailwind paren-form `(--linear-*)` utilities to exact same-var semantic utilities on safe dashboard/admin/molecules/organisms surfaces.

### Verified map (from `apps/web/tailwind.config.js` only)
| From | To | Why exact |
|------|-----|-----------|
| `ring-(--linear-border-focus)` (+ opacity/`focus-*` prefixes) | `ring-ring` | `ringColor.ring = var(--linear-border-focus)` |
| `px-(--linear-app-header-padding-x)` | `px-app-header` | `spacing.app-header = var(--linear-app-header-padding-x)` |
| `h-(--linear-app-control-height-sm)` | `h-app-control-sm` | `spacing.app-control-sm = var(--linear-app-control-height-sm)` |

**Not mapped** (would change rendered values): text/bg/border paren forms → `*-token` / `surface-*` / `border-subtle` / `border-focus` (those utilities point at `--color-*`, which diverges from `--linear-*` outside marketing bridges). Also left `border-(--linear-border-focus)` alone for that reason.

### Baseline
- **Before:** 2177
- **After:** 2096
- **Delta:** **−81**

### Scope notes
- Skipped files with pre-existing ESLint failures (Title Case / server-boundary) so the PR stays mapping-only.
- Style-guard tests updated for `ring-ring` (DisplayMenuDropdown + LibrarySurface companions).

## Cost Impact
N/A — className renames only; no runtime API/cron/infra changes.

## Bug-to-test
waived — ratchet baseline (`linear-namespace.baseline.json`) + style-guard unit tests are the regression guard.

## Test plan
- [x] `pnpm --filter web exec vitest run tests/unit/design-system/linear-namespace-ratchet.test.ts`
- [x] `pnpm --filter web exec vitest run tests/unit/design-system/arbitrary-values-ratchet.test.ts`
- [x] DisplayMenuDropdown + LibrarySurface style guards
- [x] `pre-push-gate.sh lint` (biome + typecheck + tailwind guard)

<!-- linear-issue-id: none — GH #13988 lane 5 partial -->