### PR TITLE
fix(chat): normalize AI SDK v6 streams at the lib/ai boundary (JOV-3694, JOV-3693)

### DIFF
--- a/apps/web/lib/ai/stream-normalization.ts
+++ b/apps/web/lib/ai/stream-normalization.ts
@@ -1,0 +1,112 @@
+/**
+ * WHATWG stream normalization for the `@/lib/ai` boundary.
+ *
+ * The AI SDK's `AsyncIterableStream<T>` contract is `ReadableStream<T> &
+ * AsyncIterable<T>`: server response paths call `pipeThrough`/`tee` (WHATWG
+ * half) while eval and mobile consumers use `for await` (iterable half).
+ * Wrappers applied at this boundary (e.g. the output leak guard's guarded
+ * streams in `lib/eval/leak-guard.ts`) must preserve BOTH halves. Handing a
+ * bare async generator to `toUIMessageStreamResponse()` crashes inside the
+ * SDK's `createUIMessageStreamResponse` with
+ * `TypeError: stream.pipeThrough is not a function` (JOV-3694 / JOV-3693).
+ */
+
+/**
+ * Normalizes any `AsyncIterable` into a genuine WHATWG `ReadableStream` that
+ * stays async-iterable, restoring the full `AsyncIterableStream` contract.
+ *
+ * - Streams that already satisfy the WHATWG surface pass through untouched —
+ *   no re-piping, no extra buffering.
+ * - Bare async iterables (e.g. generator-based guarded streams) are pumped
+ *   into a real `ReadableStream`; cancellation propagates to the source
+ *   iterator so upstream generators and model streams clean up.
+ */
+export function toWhatwgReadableStream<T>(
+  source: AsyncIterable<T>
+): ReadableStream<T> & AsyncIterable<T> {
+  const stream = isWhatwgReadableStream(source)
+    ? source
+    : pumpAsyncIterableIntoReadableStream(source);
+  return ensureAsyncIterable(stream);
+}
+
+/**
+ * Duck-typed WHATWG check instead of `instanceof ReadableStream`: streams can
+ * cross module realms (Turbopack), where constructor identity differs.
+ */
+function isWhatwgReadableStream<T>(
+  source: AsyncIterable<T>
+): source is ReadableStream<T> & AsyncIterable<T> {
+  const candidate = source as Partial<ReadableStream<T>>;
+  return (
+    typeof candidate.pipeThrough === 'function' &&
+    typeof candidate.getReader === 'function' &&
+    typeof candidate.tee === 'function'
+  );
+}
+
+function pumpAsyncIterableIntoReadableStream<T>(
+  source: AsyncIterable<T>
+): ReadableStream<T> {
+  const iterator = source[Symbol.asyncIterator]();
+  return new ReadableStream<T>({
+    async pull(controller) {
+      try {
+        const { done, value } = await iterator.next();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      await iterator.return?.(reason);
+    },
+  });
+}
+
+/**
+ * Node's `ReadableStream` is natively async-iterable; other runtimes' are
+ * not. Attach the same reader-based iterator the AI SDK's own
+ * `createAsyncIterableStream` uses when it is missing.
+ */
+function ensureAsyncIterable<T>(
+  stream: ReadableStream<T>
+): ReadableStream<T> & AsyncIterable<T> {
+  const candidate = stream as ReadableStream<T> & Partial<AsyncIterable<T>>;
+  if (typeof candidate[Symbol.asyncIterator] === 'function') {
+    return candidate as ReadableStream<T> & AsyncIterable<T>;
+  }
+
+  // Patch through a loose alias: the DOM lib types the built-in
+  // `[Symbol.asyncIterator]` as a richer `ReadableStreamAsyncIterator`, which
+  // only exists where the native method is already present.
+  const patchTarget = candidate as unknown as {
+    [Symbol.asyncIterator]?: (this: ReadableStream<T>) => AsyncIterator<T>;
+  };
+  patchTarget[Symbol.asyncIterator] = function asyncIterator(
+    this: ReadableStream<T>
+  ): AsyncIterator<T> {
+    const reader = this.getReader();
+    return {
+      async next(): Promise<IteratorResult<T>> {
+        const { done, value } = await reader.read();
+        if (done) {
+          reader.releaseLock();
+          return { done: true, value: undefined };
+        }
+        return { done: false, value };
+      },
+      async return(): Promise<IteratorResult<T>> {
+        await reader.cancel();
+        reader.releaseLock();
+        return { done: true, value: undefined };
+      },
+    };
+  };
+
+  return candidate as ReadableStream<T> & AsyncIterable<T>;
+}

--- a/apps/web/lib/eval/leak-guard.ts
+++ b/apps/web/lib/eval/leak-guard.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 import type { AsyncIterableStream } from 'ai';
 
+import { toWhatwgReadableStream } from '@/lib/ai/stream-normalization';
 import {
   detectSystemPromptLeak,
   PROMPT_DISCLOSURE_REFUSAL,
@@ -314,7 +315,10 @@ function createGuardedTextStream(
     }
   }
 
-  return generator() as unknown as AsyncIterableStream<string>;
+  // Normalize back to a genuine WHATWG ReadableStream: the AI SDK's
+  // `createUIMessageStreamResponse` calls `stream.pipeThrough(...)`, which a
+  // bare generator does not have (JOV-3694 / JOV-3693).
+  return toWhatwgReadableStream(generator());
 }
 
 type TextDeltaChunk = {
@@ -366,7 +370,9 @@ function createGuardedDeltaStream<T>(
     }
   }
 
-  return generator() as unknown as AsyncIterableStream<T>;
+  // See createGuardedTextStream: keep the AsyncIterableStream contract whole
+  // (ReadableStream + AsyncIterable) for `toUIMessageStreamResponse()`.
+  return toWhatwgReadableStream(generator());
 }
 
 type StreamTextOptions = {

--- a/apps/web/tests/unit/lib/ai/stream-normalization.test.ts
+++ b/apps/web/tests/unit/lib/ai/stream-normalization.test.ts
@@ -1,0 +1,168 @@
+import { type LanguageModel, streamText } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+
+import { toWhatwgReadableStream } from '@/lib/ai/stream-normalization';
+import {
+  createStaticTextLanguageModel,
+  PROMPT_LEAK_CANARY,
+} from '@/lib/chat/prompt-disclosure-guard';
+import { wrapStreamTextResult } from '@/lib/eval/leak-guard';
+
+vi.mock('@sentry/nextjs', () => ({
+  addBreadcrumb: vi.fn(),
+}));
+
+function streamResultFor(text: string) {
+  return streamText({
+    model: createStaticTextLanguageModel(text) as unknown as LanguageModel,
+    prompt: 'hi',
+  });
+}
+
+describe('toWhatwgReadableStream', () => {
+  it('passes a genuine WHATWG ReadableStream through untouched', () => {
+    const source = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue('a');
+        controller.close();
+      },
+    });
+
+    const normalized = toWhatwgReadableStream(source);
+
+    expect(normalized).toBe(source);
+    expect(typeof normalized.pipeThrough).toBe('function');
+  });
+
+  it('normalizes a bare AsyncIterable lacking pipeThrough into a genuine ReadableStream', async () => {
+    async function* source() {
+      yield 'alpha';
+      yield 'beta';
+    }
+    const bare = source();
+    expect(
+      typeof (bare as unknown as { pipeThrough?: unknown }).pipeThrough
+    ).toBe('undefined');
+
+    const normalized = toWhatwgReadableStream(bare);
+
+    expect(normalized).toBeInstanceOf(ReadableStream);
+    expect(typeof normalized.pipeThrough).toBe('function');
+    expect(typeof normalized.getReader).toBe('function');
+    expect(typeof normalized.tee).toBe('function');
+
+    const chunks: string[] = [];
+    for await (const chunk of normalized) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual(['alpha', 'beta']);
+  });
+
+  it('supports pipeThrough-based consumption of a normalized generator', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+    }
+
+    const normalized = toWhatwgReadableStream(source());
+    const doubled = normalized.pipeThrough(
+      new TransformStream<number, number>({
+        transform(chunk, controller) {
+          controller.enqueue(chunk * 2);
+        },
+      })
+    );
+
+    const reader = doubled.getReader();
+    const chunks: number[] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    expect(chunks).toEqual([2, 4]);
+  });
+
+  it('propagates cancellation to the source iterator', async () => {
+    let returned = false;
+    async function* source() {
+      try {
+        yield 'a';
+        yield 'b';
+      } finally {
+        returned = true;
+      }
+    }
+
+    const normalized = toWhatwgReadableStream(source());
+    const reader = normalized.getReader();
+    expect((await reader.read()).value).toBe('a');
+    await reader.cancel('consumer done');
+
+    expect(returned).toBe(true);
+  });
+});
+
+/**
+ * Regression coverage for JOV-3694 (authed chat 500) and JOV-3693 (anonymous
+ * onboarding 500): both routes call
+ * `turn.streamResult.toUIMessageStreamResponse()` on a `streamText` result
+ * wrapped by the output leak guard at the `@/lib/ai/sdk` boundary. The guard
+ * must keep the SDK's `AsyncIterableStream` contract (ReadableStream +
+ * AsyncIterable); a bare generator crashes the SDK's
+ * `createUIMessageStreamResponse` with `TypeError: stream.pipeThrough is not
+ * a function`.
+ */
+describe('wrapStreamTextResult stream contract (JOV-3694 / JOV-3693)', () => {
+  it('keeps toUIMessageStream() output a genuine WHATWG ReadableStream', () => {
+    const wrapped = wrapStreamTextResult(streamResultFor('Onward.'), {
+      source: 'streamText',
+    });
+
+    const uiStream = wrapped.toUIMessageStream();
+
+    expect(uiStream).toBeInstanceOf(ReadableStream);
+    expect(typeof uiStream.pipeThrough).toBe('function');
+  });
+
+  it('toUIMessageStreamResponse() streams SSE instead of throwing pipeThrough TypeError', async () => {
+    const wrapped = wrapStreamTextResult(
+      streamResultFor('Pitch it four weeks out.'),
+      { source: 'streamText' }
+    );
+
+    const response = wrapped.toUIMessageStreamResponse();
+
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    const body = await response.text();
+    expect(body).toContain('Pitch it four weeks out.');
+  });
+
+  it('still swaps leaked text deltas for the refusal', async () => {
+    const wrapped = wrapStreamTextResult(
+      streamResultFor(`leak: ${PROMPT_LEAK_CANARY}`),
+      { source: 'streamText' }
+    );
+
+    const response = wrapped.toUIMessageStreamResponse();
+    const body = await response.text();
+
+    expect(body).toContain("can't share my internal setup");
+    expect(body).not.toContain(PROMPT_LEAK_CANARY);
+  });
+
+  it('keeps textStream and fullStream genuinely stream-shaped and async-iterable', async () => {
+    const wrapped = wrapStreamTextResult(streamResultFor('hello world'), {
+      source: 'streamText',
+    });
+
+    expect(typeof wrapped.textStream.pipeThrough).toBe('function');
+    expect(typeof wrapped.fullStream.pipeThrough).toBe('function');
+
+    const deltas: string[] = [];
+    for await (const delta of wrapped.textStream) {
+      deltas.push(delta);
+    }
+    expect(deltas.join('')).toBe('hello world');
+  });
+});


### PR DESCRIPTION
## Workstream summary

AI SDK v6 stream normalization. `POST /api/chat` 500s with
`TypeError: stream.pipeThrough is not a function` (minified `a.pipeThrough` in
prod) — turn-fatal for a pro-tier user in prod (Sentry JOVIE-WEB-P2) and for
anonymous onboarding turns in dev/CI. The fix normalizes streams to genuine
WHATWG `ReadableStream`s at the `@/lib/ai` chokepoint so every response path
gets a standards-compliant stream.

## Linear issues (grouped: same root cause at the SDK boundary)

- [JOV-3694](https://linear.app/jovie/issue/JOV-3694) — authed chat turn 500,
  pro-tier user, prod (Turbopack build, Node 22), Sentry JOVIE-WEB-P2.
- [JOV-3693](https://linear.app/jovie/issue/JOV-3693) — anonymous onboarding
  turn 500 (`mode: 'onboarding'`), dev/CI.

Grouped because both stack traces die at the same SDK frame
(`createUIMessageStreamResponse`, ai dist `index.mjs:5029`
`stream.pipeThrough(new JsonToSseTransformStream())`) from the same type
violation, so one fix at the shared chokepoint covers both.

## Confirmed root cause

AI SDK v6's `AsyncIterableStream<T>` is `ReadableStream<T> & AsyncIterable<T>`.
`toUIMessageStreamResponse()` calls `this.toUIMessageStream()` and then
`stream.pipeThrough(...)` on the result — so the stream must keep the WHATWG
half of that contract.

Jovie's output leak guard broke it: `@/lib/ai/sdk`'s `streamText` wraps every
result with `wrapStreamTextResult` (`apps/web/lib/eval/leak-guard.ts`,
default-enabled), which overrides `toUIMessageStream` to return
`createGuardedDeltaStream(...)` — previously a **bare async generator** cast to
`AsyncIterableStream<T>` (async-iterable, but no `pipeThrough`/`getReader`/
`tee`). The SDK's prototype `toUIMessageStreamResponse` then received the
generator and threw inside `createUIMessageStreamResponse`. Runtime-independent
(prod + dev + CI) whenever the guard is on.

This also explains why no-op'ing `lib/chat/run.ts`'s
`wrapStreamResultWithLeakGuard` did not fix it (JOV-3693's exclusion): that is
a different wrapper — the sdk.ts-level `wrapStreamTextResult` stayed active.
The Turbopack web-streams realm-mismatch hypothesis was a red herring; the
mismatch was our own wrapper lying about the stream type.

## Scope

- **New:** `apps/web/lib/ai/stream-normalization.ts` —
  `toWhatwgReadableStream(source)`: genuine WHATWG streams (duck-typed via
  `pipeThrough`+`getReader`+`tee`, not `instanceof`, which fails cross-realm)
  pass through untouched; bare iterables are pumped into a real
  `ReadableStream` (pull/cancel; cancel propagates to the source iterator);
  `Symbol.asyncIterator` attached when missing (mirrors the SDK's own
  `createAsyncIterableStream`).
- **Changed:** `apps/web/lib/eval/leak-guard.ts` —
  `createGuardedTextStream`/`createGuardedDeltaStream` now return
  `toWhatwgReadableStream(generator())` instead of casting the generator.
  Guard scanning/fallback semantics unchanged.
- **Tests:** `apps/web/tests/unit/lib/ai/stream-normalization.test.ts`.
- No call-site changes: both `route.ts:2955` (authed) and
  `onboarding-handler.ts:532` (`tryHandleAnonymousOnboardingChat`) consume
  `turn.streamResult` from `executeChatTurn` → `@/lib/ai/sdk` `streamText`, so
  the chokepoint fix protects both, plus `fullStream`/`textStream` consumers
  (e.g. `lib/mobile/chat/turn-handler.ts`).
- No dependency pins/patches, no AI SDK downgrade, no pipeline rewrite.

## Validation

- New regression test wraps a **real** `ai.streamText` result (via
  `createStaticTextLanguageModel`) with the real `wrapStreamTextResult`:
  - **Pre-fix:** 4/8 tests fail, reproducing the exact prod error —
    `TypeError: stream.pipeThrough is not a function` at
    `createUIMessageStreamResponse` (`ai/src/ui-message-stream/create-ui-message-stream-response.ts:28`)
    ← `DefaultStreamTextResult.toUIMessageStreamResponse`.
  - **Post-fix:** 8/8 pass. Covers both stream shapes (genuine passthrough,
    bare-generator normalization), `pipeThrough` consumption, cancel
    propagation, and the guard contract (canary swapped for refusal;
    `textStream`/`fullStream` stay stream-shaped and async-iterable).
- `pnpm --filter web exec vitest run`:
  - `tests/unit/lib/ai/stream-normalization.test.ts` + `lib/eval/leak-guard.test.ts` — 16 passed.
  - `tests/unit/api/chat/` (route + onboarding-handler + 7 more) — 65 passed.
  - `lib/chat/` — 202 passed. `tests/unit/lib/ai/` + `lib/mobile/chat/` — 88 passed.
- `pnpm biome check --write <changed files>` — clean.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — clean, zero
  errors (run in an isolated worktree, so the untracked foreign WIP
  `LowCreditBanner.tsx` does not interfere).
- `pnpm --filter @jovie/web run test:bug-to-test` — "not applicable (not a bug
  fix PR)" by branch-name classification; regression evidence included anyway
  (failing-then-passing test above).

### Pre-push gate note (exact failures, not hidden)

`git push` runs `scripts/hooks/pre-push-gate.sh affected` (biome + affected
typecheck/lint + full web suite in 8 shards). Three push attempts failed at
`vitest run --shard 7/8` with `1 failed | 264 passed` files / `3 failed | 2503
passed` tests — but the failure is environmental, not branch-caused:

- The **identical 8-shard sequence** run standalone in the same worktree
  (`node scripts/run-affected-tests.mjs --base origin/main --max-workers 2`)
  passed all 8 shards, exit 0 (17,000+ tests).
- Shard 7/8 alone passed 3/3 standalone, including with hook git-env vars set.
- A faithful `git hook run pre-push` reproduction died mid-shard-5 with exit
  128 (process-level death under host contention, not a test failure).
- Hook-context shard durations inflate ~60% (212s vs 133s) — shared
  orchestration host with many concurrent agent worktrees.
- My changed files are not in shard 7; every affected-suite component passed
  repeatedly.

Flake filed as [JOV-4329](https://linear.app/jovie/issue/JOV-4329). The branch
was pushed with the gate's documented escape hatch
(`JOVIE_SKIP_PRE_PUSH_GATE=1`); CI on this PR is the verification of record.

## Risk level

Low. Three files (one new helper, two one-line returns in the guard, one test
file). The guard's scanning/redaction/fallback behavior is unchanged — only
the container type of its output streams changes (bare generator → genuine
`ReadableStream` that remains async-iterable). Genuine SDK streams pass
through untouched, so the guard-disabled path is byte-identical.

## Rollback

Revert this PR's single commit. No schema, config, env, or dependency changes;
no data migration. The pre-fix behavior returns immediately (chat turns 500
again only for leak-guard-wrapped results).

## GBrain

- **Read:** `engineering/backlog-triage-2026-07-20` (lists JOV-3694 + JOV-3693
  as the #1 actionable engineering item; fix at the lib/ai chokepoint).
- **Written:** `engineering/ai-sdk-v6-stream-normalization`
  (type: engineering-decision — symptom, confirmed root cause, normalization
  pattern, protected call sites, tests; covers JOV-3694 + JOV-3693).
