### PR TITLE
fix(chat): use strict chatToolSchema in 6 latent route violations

### DIFF
--- a/apps/web/app/api/chat/album-art/apply/route.ts
+++ b/apps/web/app/api/chat/album-art/apply/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { chatToolSchema } from '@/lib/chat/strict-schema';
 import { captureError } from '@/lib/error-tracking';
 import { applyGeneratedAlbumArt } from '@/lib/services/album-art/apply';
 import { logger } from '@/lib/utils/logger';
@@ -8,7 +9,7 @@ import { parseAlbumArtRequestBody, requireAlbumArtUser } from '../shared';
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 
-const applyGeneratedAlbumArtSchema = z.object({
+const applyGeneratedAlbumArtSchema = chatToolSchema({
   profileId: z.string().uuid(),
   releaseId: z.string().uuid(),
   generationId: z.string().uuid(),

--- a/apps/web/app/api/chat/album-art/create-release-and-apply/route.ts
+++ b/apps/web/app/api/chat/album-art/create-release-and-apply/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { chatToolSchema } from '@/lib/chat/strict-schema';
 import { captureError } from '@/lib/error-tracking';
 import { createReleaseAndApplyGeneratedAlbumArt } from '@/lib/services/album-art/apply';
 import { logger } from '@/lib/utils/logger';
@@ -16,7 +17,7 @@ function isValidIsoDate(value: string): boolean {
   );
 }
 
-const createReleaseAndApplySchema = z.object({
+const createReleaseAndApplySchema = chatToolSchema({
   profileId: z.string().uuid(),
   title: z.string().min(1).max(200),
   releaseType: z

--- a/apps/web/app/api/chat/audio/route.ts
+++ b/apps/web/app/api/chat/audio/route.ts
@@ -10,12 +10,13 @@ import { z } from 'zod';
 import { requireAuth } from '@/lib/auth/require-auth';
 import { getSessionContext } from '@/lib/auth/session';
 import { routeChatAudioUpload } from '@/lib/chat/route-audio-upload';
+import { chatToolSchema } from '@/lib/chat/strict-schema';
 import { captureError } from '@/lib/error-tracking';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
 
 export const runtime = 'nodejs';
 
-const chatAudioSchema = z.object({
+const chatAudioSchema = chatToolSchema({
   blobUrl: z.string().url(),
   blobPathname: z.string().min(1),
   fileName: z.string().min(1),

--- a/apps/web/app/api/chat/confirm-link/route.ts
+++ b/apps/web/app/api/chat/confirm-link/route.ts
@@ -3,7 +3,7 @@ import { and, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getCachedAuth } from '@/lib/auth/cached';
-
+import { chatToolSchema } from '@/lib/chat/strict-schema';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema/auth';
 import { chatAuditLog } from '@/lib/db/schema/chat';
@@ -17,7 +17,7 @@ import { detectPlatform } from '@/lib/utils/platform-detection/detector';
 import { validateSocialLinkUrl } from '@/lib/utils/url-validation';
 import { httpUrlSchema } from '@/lib/validation/schemas/base';
 
-const confirmLinkSchema = z.object({
+const confirmLinkSchema = chatToolSchema({
   profileId: z.string().uuid(),
   platform: z.string().min(1),
   url: httpUrlSchema,

--- a/apps/web/app/api/chat/confirm-remove-link/route.ts
+++ b/apps/web/app/api/chat/confirm-remove-link/route.ts
@@ -3,7 +3,7 @@ import { and, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getCachedAuth } from '@/lib/auth/cached';
-
+import { chatToolSchema } from '@/lib/chat/strict-schema';
 import { db } from '@/lib/db';
 import { chatAuditLog } from '@/lib/db/schema/chat';
 import { socialLinks } from '@/lib/db/schema/links';
@@ -13,7 +13,7 @@ import { NO_CACHE_HEADERS } from '@/lib/http/headers';
 import { getClientIP } from '@/lib/rate-limit';
 import { logger } from '@/lib/utils/logger';
 
-const confirmRemoveLinkSchema = z.object({
+const confirmRemoveLinkSchema = chatToolSchema({
   profileId: z.string().uuid(),
   linkId: z.string().uuid(),
 });

--- a/apps/web/app/api/chat/feedback/route.ts
+++ b/apps/web/app/api/chat/feedback/route.ts
@@ -18,6 +18,7 @@ import { eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getCachedAuth } from '@/lib/auth/cached';
+import { chatToolSchema } from '@/lib/chat/strict-schema';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema/auth';
 import { chatTurns } from '@/lib/db/schema/chat';
@@ -28,7 +29,7 @@ import { parseJsonBody } from '@/lib/http/parse-json';
 import { createRateLimitHeaders, generalLimiter } from '@/lib/rate-limit';
 import { logger } from '@/lib/utils/logger';
 
-const payloadSchema = z.object({
+const payloadSchema = chatToolSchema({
   messageId: z.string().trim().min(1).max(128),
   /** 'up' | 'down' to vote, null to undo the current vote. */
   vote: z.enum(['up', 'down']).nullable(),


### PR DESCRIPTION
## Summary
6 chat API routes used bare `z.object()` — flagged error-level by `@jovie/chat-tool-schema-strict` (unknown keys must be rejected) but latent on main: the rule only surfaces when the files are staged (pre-commit lint-staged), which is how they slipped. Discovered when a merge commit's pre-commit failed on `confirm-link/route.ts` on a clean main checkout.

Fix: `chatToolSchema()` (= `z.object().strict()`) in confirm-link, confirm-remove-link, feedback, audio, album-art/apply, album-art/create-release-and-apply. Validation behavior otherwise unchanged.

## Root cause class
Routes bypassing the repo's strict-schema helper. Adjacent-bug sweep: full `app/api/chat/**` eslint run — 0 violations remain after this PR.

## Validation
- eslint on all 6 files + full app/api/chat/** sweep: 0 violations
- biome check: clean; typecheck @jovie/web: exit 0
- z-import retention verified per file (still used for field schemas)

## Risk / rollback
Low — same validation plus strict unknown-key rejection (mirrors the other 20+ chat routes already using chatToolSchema). Rollback = revert.

## GBrain
Read: engineering/backlog-triage-2026-07-20. Will update engineering/deep-evidence-receivers-red-diagnosis (JOV-4328 sibling class) after merge.