### PR TITLE
fix(out): wrap /out/[id] interstitial in QueryProvider (JOV-4328)

### DIFF
--- a/apps/web/app/out/layout.test.tsx
+++ b/apps/web/app/out/layout.test.tsx
@@ -1,0 +1,84 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetWrappedLink } = vi.hoisted(() => ({
+  mockGetWrappedLink: vi.fn(),
+}));
+
+vi.mock('@/lib/services/link-wrapping', () => ({
+  getWrappedLink: mockGetWrappedLink,
+}));
+
+// Presentational shells are passthroughs: this test targets the QueryClient
+// provider contract of the /out/[id] route tree, not visual structure.
+vi.mock('@/components/molecules/ContentSectionHeader', () => ({
+  ContentSectionHeader: () => null,
+}));
+
+vi.mock('@/components/molecules/ContentSurfaceCard', () => ({
+  ContentSurfaceCard: ({ children }: { readonly children: ReactNode }) =>
+    children,
+}));
+
+vi.mock('@/components/organisms/StandaloneProductPage', () => ({
+  StandaloneProductPage: ({ children }: { readonly children: ReactNode }) =>
+    children,
+}));
+
+import InterstitialPage from './[id]/page';
+import OutLayout from './layout';
+
+const SENSITIVE_WRAPPED_LINK = {
+  category: 'adult',
+  clickCount: 0,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  domain: 'example.com',
+  id: 'wrapped-link-id',
+  kind: 'sensitive',
+  originalUrl: 'https://example.com',
+  shortId: 'valid-link',
+  titleAlias: 'External Link',
+};
+
+function QueryClientProbe() {
+  // Throws "No QueryClient set, use QueryClientProvider to set one" when the
+  // layout subtree loses its QueryProvider (JOV-4328 / JOVIE-WEB-A6 / A7).
+  useQueryClient();
+  return <div data-testid='query-client-probe'>ok</div>;
+}
+
+describe('/out layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('provides a QueryClient to the /out subtree', () => {
+    render(
+      <OutLayout>
+        <QueryClientProbe />
+      </OutLayout>
+    );
+
+    expect(screen.getByTestId('query-client-probe')).toBeInTheDocument();
+  });
+
+  it('renders the /out/[id] interstitial without a missing-QueryClient crash', async () => {
+    mockGetWrappedLink.mockResolvedValue(SENSITIVE_WRAPPED_LINK);
+
+    render(
+      <OutLayout>
+        {
+          await InterstitialPage({
+            params: Promise.resolve({ id: 'valid-link' }),
+          })
+        }
+      </OutLayout>
+    );
+
+    expect(
+      screen.getByRole('button', { name: /continue to link/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/out/layout.tsx
+++ b/apps/web/app/out/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+import { QueryProvider } from '@/components/providers/QueryProvider';
+
+export default function OutLayout({ children }: { children: ReactNode }) {
+  // Wrap the /out subtree in QueryProvider so client components with
+  // TanStack Query hooks (e.g. InterstitialClient's
+  // useLinkVerificationMutation on /out/[id]) always have a QueryClient
+  // context available. Same bug class as JOVIE-WEB-A6 / JOVIE-WEB-A7
+  // (admin subtree): "No QueryClient set, use QueryClientProvider to set
+  // one". See JOV-4328.
+  return <QueryProvider>{children}</QueryProvider>;
+}


### PR DESCRIPTION
## Workstream summary
`/out/[id]` sensitive-link interstitial crashed at render — `InterstitialClient` runs a react-query mutation with no `QueryClientProvider` anywhere above the route. This PR adds the missing provider at the route-subtree level, following the repo's established pattern.

## Issue
Linear **JOV-4328** — `/out/[id]` interstitial crashes: `InterstitialClient` rendered without `QueryProvider`. Nightly-matrix diagnosis (`e2e-full-matrix.yml` run 29760784412, 2026-07-20, failing identically on chromium + firefox; `tests/e2e/anti-cloaking.spec.ts:243,269`):

```
⨯ Error: No QueryClient set, use QueryClientProvider to set one
    at useLinkVerificationMutation (lib/queries/useLinkVerificationMutation.ts:85:21)
    at InterstitialClient (app/out/[id]/InterstitialClient.tsx:35:32)
```

## Confirmed root cause
`apps/web/app/out/[id]/page.tsx` renders `InterstitialClient` (client component) which calls `useLinkVerificationMutation` → `useMutation`. No `app/out/layout.tsx` existed and no ancestor provides a `QueryClient` for this public route. Reproduced pre-fix in vitest: rendering the real page with no provider ancestor throws `No QueryClient set`, exactly like production. Same bug class as Sentry **JOVIE-WEB-A6 / JOVIE-WEB-A7** (admin subtree, fixed by wrapping `app/(shell)/admin/layout.tsx`).

## Scope
- `apps/web/app/out/layout.tsx` (new) — wraps the `/out` subtree in `QueryProvider`, mirroring the admin/hud/hud-tv/exp layout pattern. 12 lines, no refactors.
- `apps/web/app/out/layout.test.tsx` (new, colocated) — guards the contract:
  1. probe component calling `useQueryClient()` renders inside `OutLayout` (throws if the provider is ever removed);
  2. composes real `OutLayout` + real `/out/[id]` page + real `InterstitialClient` and asserts the "Continue to link" button renders without the crash.

## Validation
- Pre-fix red: `app/out/layout.test.tsx` failed (`./layout` unresolvable); scratch repro of the page alone threw `No QueryClient set` (scratch file removed after evidence capture).
- Post-fix: `app/out/layout.test.tsx` **2/2 pass**.
- Siblings: `tests/unit/app/out-link-page.test.ts` 3/3, `app/app/(shell)/admin/layout.test.tsx` 2/2 pass.
- `pnpm biome check --write apps/web/app/out/layout.tsx apps/web/app/out/layout.test.tsx` — clean (import-order auto-fix only).
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — clean.
- Pre-commit hooks (gitleaks, trufflehog, eslint, repo-hygiene, proxy-guard) — all pass.

## Risk
Low. Additive provider wrap on one small public route; `QueryProvider` is already used the same way on 4 other subtrees. Server components under `/out` are unaffected (passed as `children`). The `MissingLinkState` path gains a harmless provider it doesn't use.

## Rollback
Revert this commit; `/out/[id]` returns to the previous (crashing) behavior — no data or schema changes involved.

## GBrain
- Read: `engineering/backlog-triage-2026-07-20`, `engineering/deep-evidence-receivers-red-diagnosis`
- Written: `engineering/out-interstitial-query-provider` (symptom, root cause, provider pattern, tests, A6/A7 recurrence note)