### PR TITLE
feat(chat): smooth streaming text cadence (JOV-3525)

### DIFF
--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -568,6 +568,10 @@ export function useJovieChat({
   } = useChat({
     id: activeConversationId ?? 'new-chat',
     transport,
+    // JOV-3525: batch streaming UI updates to ~20fps so raw token deltas don't
+    // re-render the timeline on every burst; pairs with server-side
+    // smoothStream word-level pacing in lib/chat/run.ts.
+    experimental_throttle: 50,
     onFinish: ({ message }) => {
       const metadata = extractChatTurnMetadata(message.metadata);
       const finishedConversationId =

--- a/apps/web/lib/chat/run.ts
+++ b/apps/web/lib/chat/run.ts
@@ -2,6 +2,7 @@ import {
   convertToModelMessages,
   type LanguageModel,
   type ModelMessage,
+  smoothStream,
   stepCountIs,
   type ToolSet,
   type UIMessage,
@@ -377,6 +378,10 @@ export async function executeChatTurn(
           return {};
         },
     abortSignal: signal,
+    // JOV-3525: pace raw model deltas into a steady word-level reveal so the
+    // client render cadence is smooth; pairs with useChat
+    // experimental_throttle in useJovieChat.
+    experimental_transform: smoothStream({ delayInMs: 15, chunking: 'word' }),
     experimental_telemetry: buildAiTelemetry({
       functionId: 'jovie-chat',
       identity: {

--- a/apps/web/tests/unit/chat/run.stream-smoothing.test.ts
+++ b/apps/web/tests/unit/chat/run.stream-smoothing.test.ts
@@ -1,0 +1,146 @@
+/**
+ * JOV-3525 — chat streaming cadence (server half).
+ *
+ * `executeChatTurn` must pace raw model deltas into a steady word-level reveal
+ * via the AI SDK v6 `experimental_transform: smoothStream(...)` streamText
+ * option, and that transform must still compose with the leak-guard /
+ * stream-normalization boundary (#14540) that turns the result into a WHATWG
+ * SSE response.
+ */
+
+import type { UIMessage } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+
+import { executeChatTurn } from '@/lib/chat/run';
+import type { ArtistContext } from '@/lib/chat/types';
+
+const smoothStreamMock = vi.hoisted(() => {
+  const sentinelTransform = vi.fn();
+  return {
+    sentinelTransform,
+    mock: vi.fn(() => sentinelTransform),
+  };
+});
+
+// Mirror run.parity.test.ts: capture streamText options instead of hitting the
+// gateway; smoothStream is mocked so the exact pacing config is pinned.
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return {
+    ...actual,
+    smoothStream: smoothStreamMock.mock,
+    streamText: vi.fn(opts => ({
+      __mocked: true,
+      __opts: opts,
+    })),
+  };
+});
+
+vi.mock('@ai-sdk/gateway', () => ({
+  createGateway: vi.fn(() =>
+    vi.fn((modelId: string) => ({ __model: modelId }))
+  ),
+  gateway: vi.fn(),
+}));
+
+const baseArtistContext: ArtistContext = {
+  displayName: 'Aurora',
+  username: 'aurora',
+  bio: null,
+  genres: ['indie'],
+  spotifyFollowers: 500,
+  spotifyPopularity: 22,
+  spotifyUrl: null,
+  appleMusicUrl: null,
+  profileViews: 100,
+  hasSocialLinks: true,
+  hasMusicLinks: true,
+  tippingStats: {
+    tipClicks: 0,
+    tipsSubmitted: 0,
+    totalReceivedCents: 0,
+    monthReceivedCents: 0,
+  },
+};
+
+const paidPlanLimits = {
+  booleans: { aiCanUseTools: true },
+  limits: { aiDailyMessageLimit: 500 },
+} as unknown as Parameters<typeof executeChatTurn>[0]['planLimits'];
+
+function userMessage(text: string, id = 'm1'): UIMessage {
+  return {
+    id,
+    role: 'user',
+    parts: [{ type: 'text', text }],
+  } as UIMessage;
+}
+
+describe('executeChatTurn — stream smoothing (JOV-3525)', () => {
+  const baseInput = {
+    artistContext: baseArtistContext,
+    releases: [],
+    resolvedProfileId: 'profile-1',
+    resolvedConversationId: 'conv-1',
+    userId: 'user-1',
+    userPlan: 'free',
+    insightsEnabled: false,
+    forceLightModel: false,
+    tools: {},
+    signal: new AbortController().signal,
+    requestId: 'req-1',
+  };
+
+  it('builds the transform with the issue-pinned pacing config', async () => {
+    await executeChatTurn({
+      ...baseInput,
+      uiMessages: [userMessage('hello')],
+      planLimits: paidPlanLimits,
+    });
+
+    expect(smoothStreamMock.mock).toHaveBeenCalledWith({
+      delayInMs: 15,
+      chunking: 'word',
+    });
+  });
+
+  it('passes the smoothStream transform to streamText as experimental_transform', async () => {
+    const turn = await executeChatTurn({
+      ...baseInput,
+      uiMessages: [userMessage('hello')],
+      planLimits: paidPlanLimits,
+    });
+
+    const opts = (
+      turn.streamResult as unknown as {
+        __opts: { experimental_transform?: unknown };
+      }
+    ).__opts;
+    expect(opts.experimental_transform).toBe(
+      smoothStreamMock.sentinelTransform
+    );
+  });
+
+  it('smoothed stream still produces a WHATWG SSE response through the #14540 normalization boundary', async () => {
+    const actual = await vi.importActual<typeof import('ai')>('ai');
+    const { createStaticTextLanguageModel } = await import(
+      '@/lib/chat/prompt-disclosure-guard'
+    );
+    const { wrapStreamTextResult } = await import('@/lib/eval/leak-guard');
+
+    const result = actual.streamText({
+      model: createStaticTextLanguageModel('Onward.') as never,
+      prompt: 'hi',
+      experimental_transform: actual.smoothStream({
+        delayInMs: 15,
+        chunking: 'word',
+      }),
+    });
+    const wrapped = wrapStreamTextResult(result, { source: 'streamText' });
+
+    const response = wrapped.toUIMessageStreamResponse();
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    const body = await response.text();
+    expect(body).toContain('Onward.');
+  });
+});

--- a/apps/web/tests/unit/chat/useJovieChat.stream-cadence.test.tsx
+++ b/apps/web/tests/unit/chat/useJovieChat.stream-cadence.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useJovieChat } from '@/components/jovie/hooks/useJovieChat';
+
+// JOV-3525 — chat streaming cadence (client half): the useChat hook must batch
+// streaming UI updates via the AI SDK v6 `experimental_throttle` option so raw
+// token deltas don't re-render the timeline on every burst. Pairs with the
+// server-side smoothStream transform (see run.stream-smoothing.test.ts).
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const useChatMock = vi.fn(() => ({
+  messages: [],
+  sendMessage: vi.fn(),
+  status: 'ready' as const,
+  setMessages: vi.fn(),
+  stop: vi.fn(),
+}));
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: (options: unknown) => useChatMock(options),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn(),
+  }),
+}));
+
+vi.mock('@tanstack/react-pacer', () => ({
+  useAsyncRateLimiter: (
+    fn: (args: { text: string }) => Promise<void>,
+    _options: { onReject?: () => void }
+  ) => ({
+    maybeExecute: (args: { text: string }) => fn(args),
+    getRemainingInWindow: () => 1,
+    state: { isExecuting: false },
+  }),
+}));
+
+vi.mock('@/lib/queries/useChatConversationQuery', () => ({
+  useChatConversationQuery: () => ({
+    data: undefined,
+    error: null,
+    isError: false,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/lib/queries/useChatMutations', () => ({
+  useAddMessagesMutation: () => ({ mutate: vi.fn() }),
+  useCreateConversationMutation: () => ({
+    mutateAsync: vi.fn().mockResolvedValue({ conversation: { id: 'conv_1' } }),
+  }),
+}));
+
+describe('useJovieChat — streaming cadence (JOV-3525)', () => {
+  it('configures useChat with a 50ms experimental_throttle (~20fps UI updates)', () => {
+    renderHook(() => useJovieChat({ profileId: 'profile_1' }));
+
+    expect(useChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({ experimental_throttle: 50 })
+    );
+  });
+});


### PR DESCRIPTION
## Description

Workstream: chat streaming cadence ([JOV-3525](https://linear.app/jovie/issue/JOV-3525/web-chat-smooth-streaming-text-cadence-experimental-throttle)). Assistant replies streamed in with a jerky, uneven cadence — raw model deltas rendered 1:1 with no client-side throttle and no server-side smoothing. This PR applies the two complementary, config-only AI SDK v6 levers the issue pins:

- **Client:** `experimental_throttle: 50` on the `useChat` config in `apps/web/components/jovie/hooks/useJovieChat.ts` — batches streaming UI updates to ~20fps.
- **Server:** `experimental_transform: smoothStream({ delayInMs: 15, chunking: 'word' })` on the `streamText` call in `apps/web/lib/chat/run.ts` — steady word-level reveal.

**Confirmed gap (base `74c52e06`, includes #14540):** repo-wide search found zero `experimental_throttle` and zero `smoothStream` matches. Option names/values verified against installed `ai@6.0.137` and `@ai-sdk/react@3.0.176` dist types per the ai-sdk skill (no API guessing).

**Placement note:** the issue sanctions the `@/lib/ai/sdk` chokepoint *or* `lib/chat/run.ts`. Verified `run.ts` is the only in-app `streamText` call site (the sdk.ts export is a transparent pass-through; its leak-guard `wrapStreamTextOptions` spreads options, so the transform passes through untouched). Placed at `run.ts` to keep blast radius scoped to chat and the diff config-only.

**Composition with #14540 (stream normalization):** `smoothStream` is an input-side `streamText` option; #14540's `toWhatwgReadableStream` is result-side inside the leak guard. No interaction surface — covered by a dedicated composition test (real transform → `wrapStreamTextResult().toUIMessageStreamResponse()` still yields a WHATWG SSE stream).

## Type of Change

- [x] Performance improvement (perceived — streaming cadence polish)

## Testing

- [x] Unit tests pass
- [x] New tests added (if applicable)
- [x] `bug-to-test: satisfied` — wiring regression tests added at the config layer (the smallest layer that would have caught the missing options)

New focused tests (4):
- `apps/web/tests/unit/chat/run.stream-smoothing.test.ts` — pins `smoothStream({ delayInMs: 15, chunking: 'word' })` args, asserts `experimental_transform` wiring identity, and proves the smoothed stream still composes with the #14540 normalization boundary into a WHATWG SSE response.
- `apps/web/tests/unit/chat/useJovieChat.stream-cadence.test.tsx` — asserts `useChat` receives `experimental_throttle: 50`.

Validation outputs (worktree on latest `origin/main`):

```
vitest run (new):        2 files, 4 tests — passed
vitest run (neighbors):  6 files, 50 tests — passed
                         (run.parity 20, stream-normalization 8, sdk.gateway 3,
                          useJovieChat stale-stream/rate-limit/draft-persistence 19)
biome check --write:     4 files, clean (1 formatting fix applied, tests re-run green)
typecheck @jovie/web:    exit 0
```

## Risk

Low. Config-only, additive options on existing AI SDK v6 APIs; no behavior change to non-chat surfaces (`run.ts` is chat's only streamText site). Perceived-latency budget per issue: ≤ ~100ms added (throttle 50ms + smoothStream 15ms pacing); no TTFT change beyond first-word pacing. JOV-3005 render-storm protections untouched (memoization and timeline reducer unchanged; throttle *reduces* render frequency). No layout-shift impact: same final text/layout, fewer intermediate renders.

## Rollback

Revert this single commit; both options are independent — either line can also be removed separately without affecting the other.

## GBrain

- **Read:** `engineering/backlog-triage-2026-07-20` (JOV-3525 queued in the actionable UI/UX cluster), `engineering/ai-sdk-v6-stream-normalization` (#14540 merged at `74c52e06` — the base of this branch).
- **Written:** `engineering/chat-streaming-cadence` (gap, options + values, placement rationale, composition analysis, test evidence).

## Icon Usage Standards ✅

Not applicable — no icon changes.

## Code Quality

- [x] Code follows project style guidelines (Biome clean)
- [x] Self-review completed
- [x] Code is properly commented (both options carry JOV-3525 rationale comments)
- [x] No console.log statements left in code
- [x] TypeScript types are properly defined (typecheck exit 0)
- [x] Performance considerations addressed (this PR *is* the perceived-perf change)

## Accessibility

No visual/structural changes; streaming text pacing only. No animation was added, so `prefers-reduced-motion` users see the same paced reveal (nothing to suppress). The issue's optional Streamdown fade animation (which would need reduced-motion handling) is explicitly out of scope.

## Database Changes

None.

## Breaking Changes

None.

## Deployment Notes

None — no env vars, flags, or third-party changes.

## Screenshots/Videos

Timing-config-only change; cadence is covered by unit assertions on the exact option values.

## Design Skill Evidence

`design-canonical: not applicable` — no visual surface, layout, color, motion-design, or icon change; streaming timing configuration only. Layout-shift audit: no state transition shifts layout (same final content; fewer intermediate renders).

## Related Issues

Closes JOV-3525
Related: JOV-3004 (parent epic), builds on JOV-3005 / JOV-3006 (Done), composes with JOV-3694/JOV-3693 (#14540)

## Checklist

- [x] PR title follows conventional commit format
- [x] Branch is up to date with target branch (based on latest `origin/main` `74c52e06`)
- [ ] All CI checks pass (pending on push)
- [x] Documentation updated (GBrain decision record)
