### PR TITLE
fix(ci): stabilize pre-push gate shard 7/8 against node/env skew (JOV-4329)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,11 @@
 #!/usr/bin/env sh
 set -e  # Required: ensures pre-push-gate.sh failure actually blocks pushes
 
+# Hook-driven pushes coincide with peak contention on the orchestration host
+# (JOV-4329): a signal-killed vitest shard surfaces as exit 128 with no test
+# summary. Default to a single vitest worker in hook context to shrink peak
+# shard memory; standalone runs keep 2 and either way
+# AUTOMATION_VERIFY_MAX_WORKERS overrides.
+export AUTOMATION_VERIFY_MAX_WORKERS="${AUTOMATION_VERIFY_MAX_WORKERS:-1}"
+
 bash scripts/hooks/pre-push-gate.sh affected

--- a/scripts/automation-verify.sh
+++ b/scripts/automation-verify.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 
 SCOPE="${1:-affected}"
 
+# Self-select a repo-conforming Node when run standalone (JOV-4329); a no-op
+# when invoked through pre-push-gate.sh, which already resolved it.
+if ! RESOLVED_NODE_BIN="$(bash scripts/hooks/resolve-repo-node.sh)"; then
+  exit 1
+fi
+if [[ -n "$RESOLVED_NODE_BIN" ]]; then
+  echo "[automation-verify] using repo-pinned Node at $RESOLVED_NODE_BIN (ambient: $(node --version 2>/dev/null || echo none))"
+  export PATH="$RESOLVED_NODE_BIN:$PATH"
+fi
+
 case "$SCOPE" in
   affected)
     echo "[automation-verify] Running affected verify bundle"

--- a/scripts/hooks/pre-push-gate.sh
+++ b/scripts/hooks/pre-push-gate.sh
@@ -15,6 +15,17 @@ if [[ "${JOVIE_SKIP_PRE_PUSH_GATE:-}" == "1" ]]; then
   exit 0
 fi
 
+# Self-select a repo-conforming Node instead of inheriting the shell's
+# (JOV-4329): the ambient Node may violate engines and fail the
+# runner-prerequisite contract tests mid-gate.
+if ! RESOLVED_NODE_BIN="$(bash scripts/hooks/resolve-repo-node.sh)"; then
+  exit 1
+fi
+if [[ -n "$RESOLVED_NODE_BIN" ]]; then
+  echo "[pre-push-gate] using repo-pinned Node at $RESOLVED_NODE_BIN (ambient: $(node --version 2>/dev/null || echo none))"
+  export PATH="$RESOLVED_NODE_BIN:$PATH"
+fi
+
 MODE="${1:-lint}"
 
 run_lint() {

--- a/scripts/hooks/pre-push-gate.test.mjs
+++ b/scripts/hooks/pre-push-gate.test.mjs
@@ -46,8 +46,8 @@ test('.no-mistakes.yaml points lint/test/format at pre-push-gate.sh', () => {
   assert.match(config, /format: bash scripts\/hooks\/pre-push-gate\.sh format/);
 });
 
-test('.husky/pre-push delegates to pre-push-gate lint profile', () => {
+test('.husky/pre-push delegates to the pre-push-gate affected profile', () => {
   const hook = readFileSync(path.join(repoRoot, '.husky/pre-push'), 'utf8');
   assert.match(hook, /set -e/);
-  assert.match(hook, /pre-push-gate\.sh lint/);
+  assert.match(hook, /pre-push-gate\.sh affected/);
 });

--- a/scripts/hooks/resolve-repo-node.sh
+++ b/scripts/hooks/resolve-repo-node.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Resolve a repo-conforming Node for the pre-push gate (JOV-4329).
+#
+# The gate must not inherit whatever Node happens to be on the shell's PATH.
+# On the orchestration host the default is pnpm's Node 22.22.1, which violates
+# engines (`>=22.23.1 <23`) and fails the runner-prerequisite contract tests:
+# verify-prerequisites.mjs --write-marker rejects any Node older than .nvmrc,
+# so shard 7/8 reported exactly 3 failures under 22.22.1 and passed under the
+# .nvmrc-pinned 22.23.1.
+#
+# Behavior:
+#   - ambient `node` already satisfies .nvmrc (same major, >= pinned): exit 0,
+#     print nothing (caller keeps PATH as-is);
+#   - ambient `node` violates .nvmrc but the pinned install exists under nvm:
+#     print the bin directory to prepend to PATH, exit 0;
+#   - otherwise: print an actionable message to stderr, exit 1. Failing fast
+#     beats discovering the mismatch as 3 opaque test failures mid-gate.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PINNED="$(tr -d '[:space:]' < "$REPO_ROOT/.nvmrc")"
+PINNED="${PINNED#v}"
+
+satisfies() {
+  # $1 = candidate version (vX.Y.Z), $2 = pinned minimum (X.Y.Z).
+  # Conforming means same major and >= pinned (mirrors engines `>=PINNED <major+1`).
+  local candidate="${1#v}"
+  local c_major c_minor c_patch p_major p_minor p_patch
+  IFS='.' read -r c_major c_minor c_patch <<<"$candidate"
+  IFS='.' read -r p_major p_minor p_patch <<<"$2"
+  [[ "${c_major:-0}" == "${p_major:-0}" ]] || return 1
+  (( ${c_minor:-0} > ${p_minor:-0} )) && return 0
+  (( ${c_minor:-0} < ${p_minor:-0} )) && return 1
+  (( ${c_patch:-0} >= ${p_patch:-0} ))
+}
+
+CURRENT="$(node --version 2>/dev/null || true)"
+if [[ -n "$CURRENT" ]] && satisfies "$CURRENT" "$PINNED"; then
+  exit 0
+fi
+
+NVM_VERSIONS="${NVM_DIR:-${HOME:-}/.nvm}/versions/node"
+if [[ -x "$NVM_VERSIONS/v$PINNED/bin/node" ]]; then
+  echo "$NVM_VERSIONS/v$PINNED/bin"
+  exit 0
+fi
+
+echo "[resolve-repo-node] ambient Node ${CURRENT:-not found} does not satisfy .nvmrc ($PINNED) and no pinned install exists at $NVM_VERSIONS/v$PINNED" >&2
+echo "[resolve-repo-node] install it (nvm install $PINNED) or re-run with a conforming Node on PATH" >&2
+exit 1

--- a/scripts/lib/__tests__/pre-push-gate.test.mjs
+++ b/scripts/lib/__tests__/pre-push-gate.test.mjs
@@ -1,0 +1,164 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '../../..');
+const resolverPath = resolve(repoRoot, 'scripts/hooks/resolve-repo-node.sh');
+const pinnedVersion = readFileSync(resolve(repoRoot, '.nvmrc'), 'utf8').trim();
+const gate = readFileSync(
+  resolve(repoRoot, 'scripts/hooks/pre-push-gate.sh'),
+  'utf8'
+);
+const automationVerify = readFileSync(
+  resolve(repoRoot, 'scripts/automation-verify.sh'),
+  'utf8'
+);
+const huskyPrePush = readFileSync(resolve(repoRoot, '.husky/pre-push'), 'utf8');
+
+describe('resolve-repo-node.sh', () => {
+  const temporaryDirectories = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  function makeNodeStub(version) {
+    const directory = mkdtempSync(resolve(tmpdir(), 'jovie-node-stub-'));
+    temporaryDirectories.push(directory);
+    const nodePath = resolve(directory, 'node');
+    writeFileSync(nodePath, `#!/bin/sh\necho ${version}\n`);
+    chmodSync(nodePath, 0o755);
+    return directory;
+  }
+
+  function makeNvmRoot(withPinnedInstall) {
+    const directory = mkdtempSync(resolve(tmpdir(), 'jovie-nvm-root-'));
+    temporaryDirectories.push(directory);
+    if (withPinnedInstall) {
+      const binDirectory = resolve(
+        directory,
+        'versions/node',
+        `v${pinnedVersion}`,
+        'bin'
+      );
+      mkdirSync(binDirectory, { recursive: true });
+      const nodePath = resolve(binDirectory, 'node');
+      writeFileSync(nodePath, `#!/bin/sh\necho v${pinnedVersion}\n`);
+      chmodSync(nodePath, 0o755);
+    }
+    return directory;
+  }
+
+  function runResolver(nodeVersion, withPinnedInstall) {
+    const nodeBin = makeNodeStub(nodeVersion);
+    const nvmRoot = makeNvmRoot(withPinnedInstall);
+    const result = spawnSync('/bin/bash', [resolverPath], {
+      encoding: 'utf8',
+      env: {
+        PATH: `${nodeBin}:/usr/bin:/bin`,
+        NVM_DIR: nvmRoot,
+        HOME: nvmRoot,
+      },
+    });
+    return { nvmRoot, result };
+  }
+
+  it('keeps the ambient Node silently when it exactly satisfies .nvmrc', () => {
+    const { result } = runResolver(`v${pinnedVersion}`, false);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+  });
+
+  it('keeps a newer same-major ambient Node', () => {
+    const [major, minor] = pinnedVersion.split('.').map(Number);
+    const { result } = runResolver(`v${major}.${minor + 1}.0`, false);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('rejects an older same-major ambient Node in favor of the pinned install', () => {
+    const [major, minor, patch] = pinnedVersion.split('.').map(Number);
+    const older = `v${major}.${minor}.${Math.max(patch - 1, 0)}`;
+    const { nvmRoot, result } = runResolver(older, true);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(
+      `${nvmRoot}/versions/node/v${pinnedVersion}/bin`
+    );
+  });
+
+  it('rejects a newer-major ambient Node (engines ceiling) in favor of the pinned install', () => {
+    const [major] = pinnedVersion.split('.').map(Number);
+    const { nvmRoot, result } = runResolver(`v${major + 1}.0.0`, true);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(
+      `${nvmRoot}/versions/node/v${pinnedVersion}/bin`
+    );
+  });
+
+  it('fails fast with an actionable message when no conforming Node exists', () => {
+    const [major, minor, patch] = pinnedVersion.split('.').map(Number);
+    const older = `v${major}.${minor}.${Math.max(patch - 1, 0)}`;
+    const { result } = runResolver(older, false);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      `does not satisfy .nvmrc (${pinnedVersion})`
+    );
+    expect(result.stderr).toContain(older);
+    expect(result.stderr).toContain('nvm install');
+  });
+});
+
+describe('pre-push gate Node and fanout wiring (JOV-4329)', () => {
+  it('resolves a repo-conforming Node before the gate dispatches', () => {
+    expect(gate).toContain('bash scripts/hooks/resolve-repo-node.sh');
+    expect(gate).toContain('export PATH="$RESOLVED_NODE_BIN:$PATH"');
+    expect(gate.indexOf('resolve-repo-node.sh')).toBeLessThan(
+      gate.indexOf('case "$MODE" in')
+    );
+  });
+
+  it('resolves a repo-conforming Node for standalone automation-verify runs', () => {
+    expect(automationVerify).toContain(
+      'bash scripts/hooks/resolve-repo-node.sh'
+    );
+    expect(automationVerify.indexOf('resolve-repo-node.sh')).toBeLessThan(
+      automationVerify.indexOf('case "$SCOPE" in')
+    );
+  });
+
+  it('keeps the resolve step ahead of the affected-test runner', () => {
+    expect(automationVerify.indexOf('resolve-repo-node.sh')).toBeLessThan(
+      automationVerify.indexOf('node scripts/run-affected-tests.mjs')
+    );
+  });
+
+  it('defaults hook pushes to a single vitest worker without clobbering overrides', () => {
+    expect(huskyPrePush).toContain(
+      'export AUTOMATION_VERIFY_MAX_WORKERS="${AUTOMATION_VERIFY_MAX_WORKERS:-1}"'
+    );
+    expect(huskyPrePush).not.toMatch(/^AUTOMATION_VERIFY_MAX_WORKERS=1$/m);
+  });
+
+  it('keeps the documented max-workers knob in the verify bundle', () => {
+    expect(automationVerify).toContain(
+      '--max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}"'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Workstream: pre-push gate shard flake ([JOV-4329](https://linear.app/jovie/issue/JOV-4329)). The pre-push gate (`scripts/hooks/pre-push-gate.sh affected` → affected vitest shards) intermittently failed at **shard 7/8 with exactly 3 failing tests** in `apps/web/tests/unit/ci/runner-setup-action.test.ts`. Three independent agents hit it on 2026-07-20 and each spent 25–30 min re-proving "flake, not mine" before bypassing with the documented `JOVIE_SKIP_PRE_PUSH_GATE=1` + standalone-green proof.

## Root causes (with evidence)

**1. Node skew — deterministic, explains all three real push failures.** The gate inherited whatever Node the pushing shell had on `PATH`. On the orchestration host the default is pnpm's Node **22.22.1** (`~/Library/pnpm/node`), which violates `engines.node >=22.23.1 <23` and `.nvmrc` (22.23.1). `.npmrc` sets `engine-strict=false`, so pnpm only warns. The vitest workers spawn `verify-prerequisites.mjs --write-marker` via `process.execPath`; `buildExpectedManifest()` throws `Node 22.22.1 does not satisfy 22.23.1 <= Node < 23`, so exactly the three marker-writing tests fail (`accepts a complete exact marker…`, `falls back on required runtime or Playwright version drift`, `falls back when browser executables are missing`) while everything else passes. Reproduced both directions in a clean worktree off `origin/main`:

- node 22.22.1 → `Tests 3 failed | 22 passed (25)` — the 3 `--write-marker` tests
- node 22.23.1 (.nvmrc) → `Tests 25 passed (25)`

**2. Contention kill — intermittent, explains the exit-128 mid-run deaths.** Under git-hook context with host contention a shard process died by signal mid-run; `scripts/run-affected-tests.mjs` maps a signal-killed child (null exit code) to **exit 128**, so the push surfaced `exit 128` with no vitest summary. Shard durations inflate ~60% in-hook (212s vs 133s): push storms mean N agents × the gate on one host, and memory pressure kills workers.

## Chosen fix

- **`scripts/hooks/resolve-repo-node.sh` (new):** the gate self-selects a repo-conforming Node instead of inheriting the shell's. Ambient Node is kept when it satisfies `.nvmrc` (same major, ≥ pinned — mirrors `engines`); otherwise the pinned nvm install (`$NVM_DIR/versions/node/v<pinned>/bin`) is prepended to `PATH`; otherwise the gate **fails fast** with an actionable message instead of dying 25 min in with 3 opaque test failures.
- **`scripts/hooks/pre-push-gate.sh` + `scripts/automation-verify.sh`:** resolve + prepend before running anything (covers all gate modes and standalone `automation-verify.sh` runs).
- **`.husky/pre-push`:** defaults `AUTOMATION_VERIFY_MAX_WORKERS` to **1** in hook context (hook pushes coincide with peak contention; halving vitest fanout shrinks peak shard memory). Standalone runs keep 2; the documented knob still overrides. This is a probabilistic mitigation for cause 2, not a proven fix — host contention itself is infra.

## Rejected alternatives

- **Retries of failed shards** — papers over the signal; explicitly out of scope for this workstream.
- **Skip-with-explicit-reason on the 3 tests** — `runner-setup-action.test.ts` has no env-guard skip convention, and the assertions are the real contract; the environment was the bug, not the tests. No assertions weakened.
- **Rebalancing shards** — cosmetic; neither cause is related to shard assignment.

## Scope

6 files, +30/−2 on tracked plus 2 new: `scripts/hooks/resolve-repo-node.sh` (new), `scripts/hooks/pre-push-gate.sh`, `scripts/automation-verify.sh`, `.husky/pre-push`, `scripts/hooks/pre-push-gate.test.mjs` (revived a stale assertion — it expected the pre-follow-up `lint` profile while the hook has run `affected`; the file is not wired into any lane, failure was latent), `scripts/lib/__tests__/pre-push-gate.test.mjs` (new, 10 tests: resolver boundary matrix + wiring contracts). No selector surgery: a scripts-only diff plans `mode=none` in the gate, so the new tests ride the `ci:harness:test` lane (JOV-4325 precedent).

## Validation

- Repro both directions above (clean worktree `origin/main` @ 11456daa2e8).
- `bash scripts/hooks/pre-push-gate.sh affected` run fully, exit 0, from the worktree under **ambient node 22.22.1** (resolver engaged: printed `/Users/timwhite/.nvm/versions/node/v22.23.1/bin`, `node --version` → `v22.23.1` after prepend) and under **ambient node 22.23.1** (resolver no-op).
- Real `git push` through `.husky/pre-push` green under ambient 22.22.1 (this branch).
- `pnpm exec vitest --root scripts run lib/__tests__/pre-push-gate.test.mjs lib/__tests__/automation-verify.test.mjs` → **189/189** (10 new + 179 existing).
- `node --test scripts/hooks/pre-push-gate.test.mjs` → **5/5** (was 4/5 on main due to the stale assertion).
- Full 8-shard suite (`node scripts/run-affected-tests.mjs --base origin/main~1 --max-workers 2`, the exact command class that killed 3 pushes) under **ambient node 22.22.1** via the resolver-selected PATH: shards 1–6 green; shard 7/8 ran `tests/unit/ci/runner-setup-action.test.ts` **green (25/25)** — cause 1 is dead under the exact original conditions — but the shard then exited 1 on 2 vitest **pool worker-start timeouts** (`Failed to start forks worker … Timeout waiting for worker to respond`; zero test failures; shard duration 298s vs 76s for shard 1). That is cause 2 reproduced live in its worker-spawn manifestation: host contention on the shared orchestration machine. Standalone re-run of shards 7+8 minutes later: **green** (shard 7: 265 files / 2512 tests in 99s; shard 8: 264 files / 2283 tests in 175s), so the full suite passes under ambient 22.22.1 once the pinned Node is selected.
- `pnpm ci:harness:test` (full scripts lane): **43 files, 849/849**.
- `pnpm biome check --write` on changed files: clean. Full pre-commit ladder (secrets, hygiene, governance) green on the commit.

## Risk

Low and additive. Gate behavior changes only when the ambient Node violates `.nvmrc`: previously confusing mid-gate failure, now pinned Node or a fail-fast with instructions. One intentional behavior change: when the pinned Node is **not installed** and ambient violates, the gate fails fast instead of running — for `selected`-mode diffs that previously passed this is a new block; remedy is `nvm install` (one time) or the documented `JOVIE_SKIP_PRE_PUSH_GATE=1` escape hatch. Hook-context worker default 1 vs 2 slows full-suite pushes but is overridable via `AUTOMATION_VERIFY_MAX_WORKERS`.

## Rollback

Revert commit `58b21c900c4`; the gate returns to inheriting the ambient Node and 2 workers in all contexts.

## GBrain

- **Read:** `engineering/backlog-triage-2026-07-20`, `engineering/ci-harness-env-test-failures` (JOV-4325 sibling lane, merged PR #14527).
- **Written:** `engineering/pre-push-gate-shard-flake` — both mapped causes, chosen fix, rejected alternatives (retries/weakening), validation evidence.

bug-to-test: satisfied — `scripts/lib/__tests__/pre-push-gate.test.mjs` (10 tests) + revived `scripts/hooks/pre-push-gate.test.mjs`.

Linear: JOV-4329
