### PR TITLE
ci(scripts): add typecheck coverage with shrink-only baseline (JOV-4327)

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,8 @@
     "prepare": "husky",
     "next:proxy-guard": "pnpm --filter=@jovie/web run next:proxy-guard",
     "typecheck:web:fast": "pnpm --filter @jovie/web run typecheck -- --pretty false",
+    "typecheck:scripts": "node scripts/typecheck-scripts.mjs",
+    "typecheck:scripts:update": "node scripts/typecheck-scripts.mjs --update-baseline",
     "pre-push": "bash scripts/hooks/biome-pre-push.sh && pnpm --filter=@jovie/web run pre-push",
     "pre-push:gate": "bash scripts/hooks/pre-push-gate.sh lint",
     "pre-push:gate:test": "bash scripts/hooks/pre-push-gate.sh test",

--- a/scripts/ci-fast-lanes.mjs
+++ b/scripts/ci-fast-lanes.mjs
@@ -46,6 +46,12 @@ const LANES = [
     run: runTypecheck,
   },
   {
+    id: 'scripts-typecheck',
+    name: 'Scripts Typecheck (shrink-only baseline)',
+    nextLocalCommand: 'pnpm run typecheck:scripts',
+    run: runScriptsTypecheck,
+  },
+  {
     id: 'guardrails',
     name: 'Guardrails (proxy)',
     nextLocalCommand: 'pnpm next:proxy-guard',
@@ -175,6 +181,13 @@ function runEslintServerBoundaries() {
 function runTypecheck() {
   // --force is mandatory (JOV-3499). Gate guard scans this file + ci.yml.
   return shell('pnpm turbo typecheck --affected --force');
+}
+
+function runScriptsTypecheck() {
+  // JOV-4327: scripts/ tree typecheck vs shrink-only baseline. Runs
+  // unconditionally (no path gating) — the baseline comparison is ~6s and the
+  // error graph also covers imported files outside scripts/.
+  return shell('pnpm run typecheck:scripts');
 }
 
 function runGuardrails() {

--- a/scripts/lib/__tests__/scripts-typecheck.test.mjs
+++ b/scripts/lib/__tests__/scripts-typecheck.test.mjs
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  BASELINE_SCHEMA_VERSION,
+  compareWithBaseline,
+  parseTscOutput,
+} from '../../typecheck-scripts.mjs';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..');
+
+/** Build the ErrorCounts Map shape used by the runner. */
+function counts(entries) {
+  return new Map(
+    Object.entries(entries).map(([file, byCode]) => [
+      file,
+      new Map(Object.entries(byCode)),
+    ])
+  );
+}
+
+describe('scripts-typecheck: parseTscOutput', () => {
+  it('counts errors per (file, code) and normalizes paths repo-relative', () => {
+    const output = [
+      `${REPO_ROOT}/scripts/a.mjs(3,10): error TS2305: Module '"node:fs"' has no exported member 'chdirSync'.`,
+      `${REPO_ROOT}/scripts/a.mjs(9,5): error TS2305: Module '"node:path"' has no exported member 'nope'.`,
+      `${REPO_ROOT}/scripts/b.mjs(1,1): error TS2339: Property 'x' does not exist.`,
+      "error TS2688: Cannot find type definition file for 'node'.",
+      '  The file is in the program because:',
+      '    Entry point of type library',
+    ].join('\n');
+    const { counts: parsed, globalErrors } = parseTscOutput(output);
+
+    expect(parsed.get('scripts/a.mjs')?.get('TS2305')).toBe(2);
+    expect(parsed.get('scripts/b.mjs')?.get('TS2339')).toBe(1);
+    expect(globalErrors).toHaveLength(1);
+    expect(globalErrors[0]).toContain('TS2688');
+  });
+
+  it('handles tsc output with no errors', () => {
+    const { counts: parsed, globalErrors } = parseTscOutput('');
+    expect(parsed.size).toBe(0);
+    expect(globalErrors).toHaveLength(0);
+  });
+});
+
+describe('scripts-typecheck: compareWithBaseline', () => {
+  it('passes when current errors exactly match the baseline', () => {
+    const current = counts({ 'scripts/a.mjs': { TS2305: 1, TS2339: 2 } });
+    const baseline = {
+      files: { 'scripts/a.mjs': { TS2305: 1, TS2339: 2 } },
+    };
+    const result = compareWithBaseline(current, baseline);
+    expect(result.ok).toBe(true);
+    expect(result.newErrors).toHaveLength(0);
+    expect(result.staleEntries).toHaveLength(0);
+  });
+
+  it('fails on an error in a file not present in the baseline (chdirSync class)', () => {
+    const current = counts({ 'scripts/new-monitor.mjs': { TS2305: 1 } });
+    const result = compareWithBaseline(current, { files: {} });
+    expect(result.ok).toBe(false);
+    expect(result.newErrors).toEqual([
+      {
+        file: 'scripts/new-monitor.mjs',
+        code: 'TS2305',
+        count: 1,
+        baseline: 0,
+      },
+    ]);
+  });
+
+  it('fails when a (file, code) count grows beyond the baseline', () => {
+    const current = counts({ 'scripts/a.mjs': { TS2305: 2 } });
+    const baseline = { files: { 'scripts/a.mjs': { TS2305: 1 } } };
+    const result = compareWithBaseline(current, baseline);
+    expect(result.ok).toBe(false);
+    expect(result.newErrors).toEqual([
+      { file: 'scripts/a.mjs', code: 'TS2305', count: 2, baseline: 1 },
+    ]);
+  });
+
+  it('fails when the baseline is stale (shrink-only: errors fixed but baseline not regenerated)', () => {
+    const current = counts({ 'scripts/a.mjs': { TS2305: 1 } });
+    const baseline = {
+      files: {
+        'scripts/a.mjs': { TS2305: 1 },
+        'scripts/fixed.mjs': { TS2339: 3 },
+      },
+    };
+    const result = compareWithBaseline(current, baseline);
+    expect(result.ok).toBe(false);
+    expect(result.staleEntries).toEqual([
+      { file: 'scripts/fixed.mjs', code: 'TS2339', count: 0, baseline: 3 },
+    ]);
+  });
+});
+
+describe('scripts-typecheck: lane contract', () => {
+  it('baseline file is valid, totals match, counts positive', () => {
+    const baseline = JSON.parse(
+      readFileSync(
+        resolve(REPO_ROOT, 'scripts/typecheck-baseline.json'),
+        'utf8'
+      )
+    );
+    expect(baseline.schemaVersion).toBe(BASELINE_SCHEMA_VERSION);
+    expect(baseline.files).toBeTypeOf('object');
+    let sum = 0;
+    for (const [file, byCode] of Object.entries(baseline.files)) {
+      // Keys are repo-root-relative. Besides scripts/ itself, files imported
+      // by scripts/ (e.g. apps/web/scripts/*, .github/scripts/*) are covered
+      // as part of the dependency graph.
+      expect(file.startsWith('/')).toBe(false);
+      expect(file.split('/')).not.toContain('..');
+      for (const [code, count] of Object.entries(byCode)) {
+        expect(code).toMatch(/^TS\d+$/);
+        expect(Number.isInteger(count) && count > 0).toBe(true);
+        sum += count;
+      }
+    }
+    expect(baseline.totalErrors).toBe(sum);
+  });
+
+  it('scripts/tsconfig.json enables checkJs over the .mjs + .ts tree', () => {
+    // tsconfig.json is JSONC (header comments); strip // lines before parse.
+    const raw = readFileSync(
+      resolve(REPO_ROOT, 'scripts/tsconfig.json'),
+      'utf8'
+    );
+    const stripped = raw
+      .split('\n')
+      .filter(line => !line.trim().startsWith('//'))
+      .join('\n');
+    const config = JSON.parse(stripped);
+    expect(config.compilerOptions.allowJs).toBe(true);
+    expect(config.compilerOptions.checkJs).toBe(true);
+    expect(config.compilerOptions.noEmit).toBe(true);
+    expect(config.include).toEqual(
+      expect.arrayContaining(['**/*.mjs', '**/*.ts'])
+    );
+  });
+
+  it('ci-fast lanes include the scripts-typecheck lane wired to the package script', () => {
+    const lanes = readFileSync(
+      resolve(REPO_ROOT, 'scripts/ci-fast-lanes.mjs'),
+      'utf8'
+    );
+    expect(lanes).toContain("id: 'scripts-typecheck'");
+    expect(lanes).toContain('pnpm run typecheck:scripts');
+
+    const pkg = JSON.parse(
+      readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8')
+    );
+    expect(pkg.scripts['typecheck:scripts']).toBe(
+      'node scripts/typecheck-scripts.mjs'
+    );
+    expect(pkg.scripts['typecheck:scripts:update']).toContain(
+      '--update-baseline'
+    );
+  });
+});

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,42 @@
+{
+  // Typecheck coverage for the scripts/ tree (JOV-4327).
+  //
+  // Why this exists: scripts/*.mjs run on plain Node and scripts/**/*.ts run via
+  // tsx in prod hermes monitors, but nothing type-checked them — a nonexistent
+  // `chdirSync` import from `node:fs` survived review and crash-looped two
+  // monitors (fixed in #14527). This config + scripts/typecheck-scripts.mjs close
+  // that gap. The lane is a shrink-only ratchet: pre-existing errors live in
+  // scripts/typecheck-baseline.json; any NEW error fails the lane.
+  //
+  // Compiler choices:
+  // - nodenext: matches plain-Node ESM resolution for the .mjs tree, so missing
+  //   extensions / bad named imports are caught the way Node would fail.
+  // - strict:false: strict on the legacy .mjs tree yields ~1900 implicit-any
+  //   noise errors that would swamp the baseline. The incident class (TS2305
+  //   bad named import, TS2307 missing module, TS2304 unknown name, TS2339
+  //   unknown property) is reported regardless of strict mode.
+  // - typeRoots: @types/node is already a pinned devDependency of @jovie/web,
+  //   installed at apps/web/node_modules/@types by every workspace install.
+  //   Pointing there avoids adding a root devDependency + lockfile churn. If
+  //   @jovie/web ever drops @types/node this fails loudly (TS2688) — re-point
+  //   typeRoots or promote @types/node to the root package.
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "checkJs": true,
+    "strict": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"],
+    "typeRoots": ["../apps/web/node_modules/@types"]
+  },
+  "include": ["**/*.mjs", "**/*.mts", "**/*.ts"],
+  "exclude": ["node_modules", "__pycache__", "**/node_modules"]
+}

--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -1,0 +1,204 @@
+{
+  "schemaVersion": 1,
+  "tool": "scripts/typecheck-scripts.mjs",
+  "generatedAt": "2026-07-20T21:19:18.004Z",
+  "totalErrors": 202,
+  "files": {
+    ".github/scripts/verify-main-release-readiness.mjs": {
+      "TS2339": 3
+    },
+    "apps/web/scripts/generate-brand-assets.ts": {
+      "TS1470": 2,
+      "TS2339": 3
+    },
+    "scripts/agent/preflight.mjs": {
+      "TS2339": 2
+    },
+    "scripts/agent/preflight.test.mjs": {
+      "TS2322": 1
+    },
+    "scripts/audit-test-coverage.ts": {
+      "TS1470": 1
+    },
+    "scripts/auth-redirect-uris.ts": {
+      "TS1470": 1
+    },
+    "scripts/browse-auth.ts": {
+      "TS1470": 1,
+      "TS2304": 2
+    },
+    "scripts/ci/neon-orphan-reaper.mjs": {
+      "TS2339": 2
+    },
+    "scripts/doc-freshness-lint.mjs": {
+      "TS2339": 10
+    },
+    "scripts/ds-offscale-report.mjs": {
+      "TS2362": 1
+    },
+    "scripts/generate-footer-cta-video.ts": {
+      "TS1470": 1
+    },
+    "scripts/generated-artifact-retention.mjs": {
+      "TS2339": 2
+    },
+    "scripts/generated-artifact-retention.test.mjs": {
+      "TS2339": 1,
+      "TS2362": 1
+    },
+    "scripts/github-transition-issue.mjs": {
+      "TS2305": 1,
+      "TS2353": 1
+    },
+    "scripts/hermes/jobs/agent-config-health.ts": {
+      "TS1470": 1
+    },
+    "scripts/hermes/jobs/agentcookie-sync.ts": {
+      "TS1470": 1,
+      "TS2305": 1
+    },
+    "scripts/hermes/jobs/ci-failure-monitor.ts": {
+      "TS1470": 2
+    },
+    "scripts/hermes/jobs/codex-issue-shipper.ts": {
+      "TS2339": 1,
+      "TS2345": 1
+    },
+    "scripts/hermes/jobs/daily-briefing.ts": {
+      "TS1470": 1
+    },
+    "scripts/hermes/jobs/gbrain-health-summary.ts": {
+      "TS1470": 1,
+      "TS2305": 1,
+      "TS2345": 4
+    },
+    "scripts/hermes/jobs/pipeline-scoreboard.ts": {
+      "TS2305": 1
+    },
+    "scripts/hermes/jobs/pr-stuck-monitor.ts": {
+      "TS1470": 1
+    },
+    "scripts/knowledge/distill.ts": {
+      "TS1470": 1
+    },
+    "scripts/knowledge/fetch.ts": {
+      "TS1470": 1,
+      "TS2304": 2,
+      "TS2307": 1,
+      "TS2584": 8
+    },
+    "scripts/lib/__tests__/agent-config-health.test.mjs": {
+      "TS2345": 1
+    },
+    "scripts/lib/__tests__/automation-verify.test.mjs": {
+      "TS2345": 1
+    },
+    "scripts/lib/__tests__/ci-harness.test.mjs": {
+      "TS2345": 1
+    },
+    "scripts/lib/__tests__/codex-issue-shipper.test.mjs": {
+      "TS2345": 3
+    },
+    "scripts/lib/__tests__/main-release-readiness.test.mjs": {
+      "TS2322": 5
+    },
+    "scripts/lib/__tests__/merge-queue-backend.test.mjs": {
+      "TS2345": 3,
+      "TS2353": 4,
+      "TS2561": 8
+    },
+    "scripts/lib/__tests__/merge-queue-guard.test.mjs": {
+      "TS2322": 18
+    },
+    "scripts/lib/__tests__/qa-swarm.test.mjs": {
+      "TS2345": 5
+    },
+    "scripts/lib/__tests__/ship-ledger.test.mjs": {
+      "TS2339": 4
+    },
+    "scripts/lib/__tests__/tracker-client.test.mjs": {
+      "TS2339": 2,
+      "TS2353": 3
+    },
+    "scripts/lib/ci-duration-ratchet.mjs": {
+      "TS2353": 1
+    },
+    "scripts/lib/github-update-branch.mjs": {
+      "TS2339": 1
+    },
+    "scripts/lib/merge-group-admission.mjs": {
+      "TS2339": 2,
+      "TS2353": 1
+    },
+    "scripts/lib/merge-group-member-policy.mjs": {
+      "TS2339": 3,
+      "TS2353": 5
+    },
+    "scripts/lib/merge-queue-guard.mjs": {
+      "TS2339": 2,
+      "TS2362": 1,
+      "TS2363": 1
+    },
+    "scripts/lib/pr-check-failures.mjs": {
+      "TS2339": 1
+    },
+    "scripts/lib/pr-comment-analysis.mjs": {
+      "TS2345": 1
+    },
+    "scripts/lib/tracker.mjs": {
+      "TS2362": 1,
+      "TS2363": 1
+    },
+    "scripts/linear-claim-issue.mjs": {
+      "TS2339": 3
+    },
+    "scripts/linear-query-todo.mjs": {
+      "TS2339": 3
+    },
+    "scripts/linear-transition-issue.mjs": {
+      "TS2339": 3
+    },
+    "scripts/merge-queue-backend.mjs": {
+      "TS2339": 13,
+      "TS2353": 3,
+      "TS2561": 1
+    },
+    "scripts/observability-issue-github.mjs": {
+      "TS2345": 1
+    },
+    "scripts/observability-issue-github.test.mjs": {
+      "TS2339": 4,
+      "TS2345": 1
+    },
+    "scripts/pr-comment-retro.mjs": {
+      "TS2339": 1
+    },
+    "scripts/pr-conflict-handler.mjs": {
+      "TS2339": 1
+    },
+    "scripts/qa-swarm/linear.mjs": {
+      "TS2339": 4
+    },
+    "scripts/qa-swarm/types.mjs": {
+      "TS2304": 1
+    },
+    "scripts/send-changelog-email.mjs": {
+      "TS2307": 2,
+      "TS2339": 2
+    },
+    "scripts/ship-swarm/next-batch.mjs": {
+      "TS2339": 3
+    },
+    "scripts/skill-governance-guard.mjs": {
+      "TS2339": 1
+    },
+    "scripts/turnstile-config.ts": {
+      "TS1470": 1,
+      "TS2540": 8
+    },
+    "scripts/voice-stack-bake-off/validate-test-script.ts": {
+      "TS1470": 1,
+      "TS2307": 1
+    }
+  }
+}

--- a/scripts/typecheck-scripts.mjs
+++ b/scripts/typecheck-scripts.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * Typecheck coverage for the scripts/ tree with a shrink-only error baseline
+ * (JOV-4327).
+ *
+ * Motivation: the .mjs scripts run on plain Node and the .ts scripts (hermes
+ * jobs) run via tsx in prod hermes monitors, but no CI lane type-checked them. A
+ * nonexistent `chdirSync` import from `node:fs` survived review and
+ * crash-looped two hermes monitors (ci-failure-monitor, pr-stuck-monitor) —
+ * fixed in #14527. This lane catches that class (TS2305 bad named import,
+ * TS2307 missing module, TS2304 unknown name, TS2339 unknown property, …)
+ * before it ships.
+ *
+ * Ratchet semantics (mirrors the repo's ratchet philosophy):
+ * - `tsc -p scripts/tsconfig.json` runs over the whole scripts/ tree.
+ * - Pre-existing errors are recorded in scripts/typecheck-baseline.json as
+ *   per-file, per-error-code counts (no line numbers, so unrelated edits in a
+ *   file do not churn the baseline).
+ * - FAIL when any (file, code) count EXCEEDS the baseline — i.e. any new
+ *   error, any newly-dirty file, or any error in a file not in the baseline.
+ * - FAIL when the baseline holds entries for errors that no longer exist —
+ *   fixing errors must shrink the baseline in the same PR:
+ *     pnpm run typecheck:scripts:update
+ *   Regrowing the baseline via that command is visible as JSON diff in review.
+ * - Config-level errors (no file prefix, e.g. TS2688 missing @types/node)
+ *   always fail — they mean the check itself is broken and must never pass.
+ *
+ * Usage:
+ *   node scripts/typecheck-scripts.mjs                  # check (CI + local)
+ *   node scripts/typecheck-scripts.mjs --update-baseline # regenerate baseline
+ *
+ * Env:
+ *   SCRIPTS_TYPECHECK_BASELINE_PATH  Override baseline path (tests).
+ *   SCRIPTS_TYPECHECK_TSCONFIG_PATH  Override tsconfig path (tests).
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+export const BASELINE_SCHEMA_VERSION = 1;
+export const DEFAULT_BASELINE_PATH = resolve(
+  REPO_ROOT,
+  'scripts/typecheck-baseline.json'
+);
+export const DEFAULT_TSCONFIG_PATH = resolve(
+  REPO_ROOT,
+  'scripts/tsconfig.json'
+);
+
+const ERROR_LINE_PATTERN = /^(.+?)\((\d+),(\d+)\): error (TS\d+): (.*)$/;
+const GLOBAL_ERROR_PATTERN = /^error (TS\d+): (.*)$/;
+
+/** @typedef {Map<string, Map<string, number>>} ErrorCounts file → code → count */
+
+/**
+ * Parse `tsc --pretty false` output into per-(file, code) counts plus global
+ * (file-less) errors. File paths are normalized to repo-root-relative.
+ * @param {string} output
+ * @returns {{ counts: ErrorCounts, globalErrors: string[], lines: Map<string, string[]> }}
+ */
+export function parseTscOutput(output) {
+  /** @type {ErrorCounts} */
+  const counts = new Map();
+  /** @type {string[]} */
+  const globalErrors = [];
+  /** @type {Map<string, string[]>} key `${file}::${code}` → raw error lines */
+  const lines = new Map();
+
+  for (const rawLine of (output || '').split('\n')) {
+    const line = rawLine.trim();
+    const fileMatch = ERROR_LINE_PATTERN.exec(line);
+    if (fileMatch) {
+      const [, file, , , code] = fileMatch;
+      const normalized = relative(REPO_ROOT, resolve(REPO_ROOT, file));
+      if (!counts.has(normalized)) counts.set(normalized, new Map());
+      const byCode = counts.get(normalized);
+      byCode.set(code, (byCode.get(code) ?? 0) + 1);
+      const key = `${normalized}::${code}`;
+      if (!lines.has(key)) lines.set(key, []);
+      lines.get(key).push(line);
+      continue;
+    }
+    if (GLOBAL_ERROR_PATTERN.test(line)) {
+      globalErrors.push(line);
+    }
+  }
+  return { counts, globalErrors, lines };
+}
+
+const countFor = (counts, file, code) => counts.get(file)?.get(code) ?? 0;
+
+/**
+ * Compare current error counts against a baseline.
+ * @param {ErrorCounts} current
+ * @param {{ files?: Record<string, Record<string, number>> }} baseline
+ * @returns {{ ok: boolean, newErrors: Array<{ file: string, code: string, count: number, baseline: number }>, staleEntries: Array<{ file: string, code: string, count: number, baseline: number }> }}
+ */
+export function compareWithBaseline(current, baseline) {
+  const baselineFiles = baseline?.files ?? {};
+  /** @type {Array<{ file: string, code: string, count: number, baseline: number }>} */
+  const newErrors = [];
+  /** @type {Array<{ file: string, code: string, count: number, baseline: number }>} */
+  const staleEntries = [];
+
+  for (const [file, byCode] of current) {
+    for (const [code, count] of byCode) {
+      const baselineCount = baselineFiles[file]?.[code] ?? 0;
+      if (count > baselineCount) {
+        newErrors.push({ file, code, count, baseline: baselineCount });
+      }
+    }
+  }
+  for (const [file, byCode] of Object.entries(baselineFiles)) {
+    for (const [code, baselineCount] of Object.entries(byCode)) {
+      const currentCount = countFor(current, file, code);
+      if (currentCount < baselineCount) {
+        staleEntries.push({
+          file,
+          code,
+          count: currentCount,
+          baseline: baselineCount,
+        });
+      }
+    }
+  }
+  return {
+    ok: newErrors.length === 0 && staleEntries.length === 0,
+    newErrors,
+    staleEntries,
+  };
+}
+
+/** @param {ErrorCounts} counts */
+function totalErrors(counts) {
+  let total = 0;
+  for (const byCode of counts.values()) {
+    for (const count of byCode.values()) total += count;
+  }
+  return total;
+}
+
+/** @param {ErrorCounts} counts */
+function toBaselineJson(counts) {
+  /** @type {Record<string, Record<string, number>>} */
+  const files = {};
+  for (const file of [...counts.keys()].sort()) {
+    const byCode = counts.get(file);
+    files[file] = {};
+    for (const code of [...byCode.keys()].sort()) {
+      files[file][code] = byCode.get(code);
+    }
+  }
+  return {
+    schemaVersion: BASELINE_SCHEMA_VERSION,
+    tool: 'scripts/typecheck-scripts.mjs',
+    generatedAt: new Date().toISOString(),
+    totalErrors: totalErrors(counts),
+    files,
+  };
+}
+
+function baselinePath() {
+  return process.env.SCRIPTS_TYPECHECK_BASELINE_PATH
+    ? resolve(process.env.SCRIPTS_TYPECHECK_BASELINE_PATH)
+    : DEFAULT_BASELINE_PATH;
+}
+
+function tsconfigPath() {
+  return process.env.SCRIPTS_TYPECHECK_TSCONFIG_PATH
+    ? resolve(process.env.SCRIPTS_TYPECHECK_TSCONFIG_PATH)
+    : DEFAULT_TSCONFIG_PATH;
+}
+
+/**
+ * Run tsc and return parsed output.
+ * Invokes node_modules/typescript/bin/tsc via the current node binary so no
+ * platform-specific .bin shim is needed; typescript is a pinned root devDep.
+ * @returns {{ status: number, output: string }}
+ */
+function runTsc() {
+  const tscEntrypoint = resolve(REPO_ROOT, 'node_modules/typescript/bin/tsc');
+  if (!existsSync(tscEntrypoint)) {
+    return {
+      status: 1,
+      output:
+        `[scripts-typecheck] Cannot find ${tscEntrypoint}.\n` +
+        'Remediation: run `pnpm install` at the repo root (typescript is a root devDependency).\n',
+    };
+  }
+  const result = spawnSync(
+    process.execPath,
+    [tscEntrypoint, '-p', tsconfigPath(), '--pretty', 'false'],
+    { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 }
+  );
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  if (result.error) {
+    return { status: 1, output: `${output}${result.error.message}\n` };
+  }
+  return { status: result.status ?? 1, output };
+}
+
+function loadBaseline() {
+  const path = baselinePath();
+  if (!existsSync(path)) {
+    console.error(`[scripts-typecheck] Baseline not found: ${path}`);
+    console.error(
+      'Remediation: generate it with `pnpm run typecheck:scripts:update`.'
+    );
+    process.exit(1);
+  }
+  const parsed = JSON.parse(readFileSync(path, 'utf8'));
+  if (parsed?.schemaVersion !== BASELINE_SCHEMA_VERSION) {
+    console.error(
+      `[scripts-typecheck] Baseline schemaVersion must be ${BASELINE_SCHEMA_VERSION}; got ${parsed?.schemaVersion}`
+    );
+    process.exit(1);
+  }
+  return parsed;
+}
+
+function main() {
+  const updateMode = process.argv.includes('--update-baseline');
+  const { output } = runTsc();
+  const { counts, globalErrors, lines } = parseTscOutput(output);
+
+  if (globalErrors.length > 0) {
+    console.error(
+      '[scripts-typecheck] FAIL — tsc reported config-level errors; the check itself is broken.'
+    );
+    for (const line of globalErrors) console.error(`  ${line}`);
+    process.exit(1);
+  }
+
+  if (updateMode) {
+    const baseline = toBaselineJson(counts);
+    writeFileSync(baselinePath(), `${JSON.stringify(baseline, null, 2)}\n`);
+    console.log(
+      `[scripts-typecheck] baseline updated → ${baselinePath()} ` +
+        `(${baseline.totalErrors} errors across ${Object.keys(baseline.files).length} files)`
+    );
+    process.exit(0);
+  }
+
+  const baseline = loadBaseline();
+  const { ok, newErrors, staleEntries } = compareWithBaseline(counts, baseline);
+
+  if (ok) {
+    console.log(
+      `[scripts-typecheck] PASS — ${totalErrors(counts)} pre-existing errors match the baseline ` +
+        `(${baseline.totalErrors} baselined); no new errors.`
+    );
+    process.exit(0);
+  }
+
+  if (newErrors.length > 0) {
+    console.error(
+      `[scripts-typecheck] FAIL — ${newErrors.length} (file, error-code) group(s) exceed the baseline.`
+    );
+    for (const { file, code, count, baseline: base } of newErrors) {
+      console.error(`  ${file}: ${code} ×${count} (baseline ×${base})`);
+      for (const line of lines.get(`${file}::${code}`) ?? []) {
+        console.error(`    ${line}`);
+      }
+    }
+    console.error(
+      'Fix the new errors. If one is genuinely pre-existing, regenerate the ' +
+        'baseline with `pnpm run typecheck:scripts:update` (visible in PR diff).'
+    );
+  }
+  if (staleEntries.length > 0) {
+    console.error(
+      `[scripts-typecheck] FAIL — baseline is stale: ${staleEntries.length} (file, error-code) group(s) no longer produce the baselined errors.`
+    );
+    for (const { file, code, count, baseline: base } of staleEntries) {
+      console.error(`  ${file}: ${code} ×${count} (baseline ×${base})`);
+    }
+    console.error(
+      'The baseline is shrink-only: regenerate it with `pnpm run typecheck:scripts:update` ' +
+        'in the same PR that removes the errors.'
+    );
+  }
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Workstream: **typecheck coverage for `scripts/`** — [JOV-4327](https://linear.app/jovie/issue/JOV-4327/test-add-typecheck-coverage-for-scripts-chdirsync-class-bugs-reach).

**Incident motivation:** a nonexistent `chdirSync` import from `node:fs` (`scripts/hermes/lib/ensure-jovie-repo-cwd.ts`) survived review and crash-looped two prod hermes monitors (`ci-failure-monitor`, `pr-stuck-monitor`) from the Jul 8 adoption rewrite until #14527. Root enabler: `scripts/` — plain `.mjs` on node + `.ts` via tsx — has **no typecheck lane**, so this class reaches prod. Main today still carries 4 live TS2305s of the same class (3 hermes jobs importing a nonexistent `notifyOps` from `lib/ops-notify`, 1 `normalizeIssueNumber` from `lib/tracker.mjs`) — now pinned by the baseline so they cannot multiply.

## Design

- **`scripts/tsconfig.json`** — `allowJs` + `checkJs` over the whole tree; `module`/`moduleResolution: nodenext` so module semantics match plain-node ESM (missing extensions / bad named imports fail the way Node would). `types: ["node"]` resolves via `typeRoots → apps/web/node_modules/@types` — `@types/node` is already a pinned `@jovie/web` devDep, so no root dep/lockfile churn; if that ever disappears the lane fails loudly (TS2688), never silently.
- **`strict: false`, deliberately.** Strict on the legacy `.mjs` tree produces ~1,972 errors, ~1,400 of them implicit-any noise (TS7006/7031/7005) that would swamp the signal. The incident class — TS2305 bad named import, TS2307 missing module, TS2304 unknown name, TS2339 unknown property — is reported regardless of strict mode. Per-directory strict can be ratcheted up once the baseline is small.
- **Baseline ratchet, not scoped-include.** Alternative considered: include only already-clean dirs — rejected because the incident file lived in `scripts/hermes/lib`, which is *not* clean today; scoped-include would leave the highest-risk files uncovered. Instead, `scripts/typecheck-scripts.mjs` runs `tsc`, aggregates errors to per-**(file, error-code) counts** (no line numbers — robust to unrelated edits), and compares against `scripts/typecheck-baseline.json` (202 pre-existing errors / 57 files):
  - any (file, code) count **exceeding** the baseline → **FAIL** (new error, newly-dirty file, or error in a file not in the baseline)
  - baseline entries for errors that **no longer exist** → **FAIL** — shrink-only: fixing errors requires regenerating the baseline (`pnpm run typecheck:scripts:update`) in the same PR; regrowth via that command is visible as JSON diff in review
  - config-level errors (no file prefix, e.g. TS2688) → always **FAIL** — a broken check must never pass
- **Wiring:** new `scripts-typecheck` lane in `scripts/ci-fast-lanes.mjs` (runs unconditionally, ~6s; no path gating since the error graph includes files imported by `scripts/`, e.g. `apps/web/scripts/generate-brand-assets.ts`), plus `typecheck:scripts` / `typecheck:scripts:update` package scripts.

## Scope

`package.json` (2 script entries), `scripts/ci-fast-lanes.mjs` (1 lane), `scripts/tsconfig.json`, `scripts/typecheck-scripts.mjs`, `scripts/typecheck-baseline.json`, `scripts/lib/__tests__/scripts-typecheck.test.mjs`. No `apps/web/**`, no workflow files.

## Validation

- **Incident-class proof:** scratch file reintroducing the exact #14527 bug fails the lane:
  ```
  [scripts-typecheck] FAIL — 1 (file, error-code) group(s) exceed the baseline.
    scripts/__scratch_chdirsync_proof.mjs: TS2305 ×1 (baseline ×0)
      scripts/__scratch_chdirsync_proof.mjs(2,10): error TS2305: Module '"node:fs"' has no exported member 'chdirSync'.
  EXIT=1
  ```
  Green again after scratch removal.
- **Lane green on main state:** `pnpm run typecheck:scripts` → `PASS — 202 pre-existing errors match the baseline (202 baselined); no new errors.`
- **`pnpm ci:harness:test`: 848/848 passed (43 files)** including 9 new tests (parser, comparator semantics: new-error/count-growth/stale-baseline, baseline/tsconfig/lane wiring contracts).
- **`pnpm ci:harness:check`** — manifest valid, generated docs current.
- **`pnpm biome check --write` on changed files** — clean.
- **`post-task-validate.sh`** — `{"continue": true}` (web typecheck, biome, boundaries, affected tests).

## Risk

Low. New ci-fast lane adds ~6s; fails closed on any new scripts type error. The baseline pins today's state, so the lane is green on main on arrival. Merge-conflict surface: `scripts/ci-fast-lanes.mjs` + `package.json` scripts block only.

## Rollback

Revert this PR (or drop the lane entry from `scripts/ci-fast-lanes.mjs`) — no runtime surface, no migrations, no dependency changes.

## Pre-push gate note (full disclosure)

Local push used the documented escape hatch (`JOVIE_SKIP_PRE_PUSH_GATE=1`, see `scripts/hooks/pre-push-gate.sh:6`) after three gate attempts demonstrated environment flake, not check failures: attempt 1 failed web vitest shard 7/8 while a heavy validator ran concurrently; attempt 2 failed shard 5/8; both shards pass standalone (2512/2512 and 1907/1907 tests). Attempt 3 ran the **entire gate green** — lint, affected typecheck/lint, all 8 web shards (8/8 "Test Files … passed"), `ci:harness:check` — then the local hook process died with SIGPIPE (141) before git could send refs. The gate's substance passes deterministically for this diff; CI merge gates re-run everything on this PR regardless.

## GBrain

- **Read:** `engineering/backlog-triage-2026-07-20`, `engineering/ci-harness-env-test-failures` (JOV-4325/#14527 post-mortem naming this issue as follow-up)
- **Written:** `engineering/scripts-typecheck-coverage` (design, ratchet choice + rationale, shrink instructions)
