### PR TITLE
ci(security): exclude sonarcloud.yml from trufflehog via git-mode-honored globs

### DIFF
--- a/.trufflehog-exclude.txt
+++ b/.trufflehog-exclude.txt
@@ -1,2 +1,8 @@
 scripts/security/gitleaks-fixture.txt
 scripts/security/gitleaks-backup-fixture.txt
+# sonarcloud.yml: SONAR_TOKEN secret-REFERENCES + 40-hex action pins are
+# SonarCloud-detector bait (8+ unverified hits per bump, all non-credentials).
+# trufflehog git-mode does not honor inline trufflehog:ignore markers on
+# diff-scanned lines (verified 2026-07-20, runs 29785483353/29784648947).
+# gitleaks (.gitleaks.toml) and GitHub secret scanning still cover this file.
+.github/workflows/sonarcloud.yml

--- a/scripts/security/scan-secrets.sh
+++ b/scripts/security/scan-secrets.sh
@@ -70,8 +70,18 @@ ensure_trufflehog() {
 }
 
 trufflehog_exclude_args() {
+  # --exclude-globs, not --exclude-paths: trufflehog git mode does not honor
+  # --exclude-paths entries (verified 2026-07-20 with 3.95.9 — findings in
+  # excluded files still fired), while comma-separated globs suppress in
+  # both git and filesystem modes. Entries in EXCLUDE_PATHS are plain
+  # repo-relative paths, which are valid globs as-is; comment lines and
+  # blanks are dropped when building the list.
   if [[ -f "$EXCLUDE_PATHS" ]]; then
-    printf '%s' "--exclude-paths=$EXCLUDE_PATHS"
+    local globs
+    globs="$(grep -vE '^\s*(#|$)' "$EXCLUDE_PATHS" | paste -sd, -)"
+    if [[ -n "$globs" ]]; then
+      printf '%s' "--exclude-globs=$globs"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Problem
Every sonarqube-scan-action pin bump fails the merge-group Secret Scan: trufflehog's SonarCloud detector pattern-matches 'sonarqube'+40-hex action pins and the standard `${{ secrets.SONAR_TOKEN }}` references — 8 unverified findings, 0 verified (runs 29783410917, 29784648947, 29785483353 on PR #14508).

## Root cause of the failed mitigations (verified with the exact CI binary 3.95.9 + invocation)
- Inline `trufflehog:ignore` markers on the pin/env lines: **not honored in git mode** (only filesystem semantics).
- `--exclude-paths` entries in `.trufflehog-exclude.txt`: **also not honored in git mode** — findings in excluded files still fired.
- `--exclude-globs`: **works in both modes** (same range: 8 → 0 findings).

## Changes
- `.trufflehog-exclude.txt`: add `.github/workflows/sonarcloud.yml` with rationale comment (gitleaks via .gitleaks.toml + GitHub secret scanning continue covering the file; only trufflehog is excluded).
- `scripts/security/scan-secrets.sh`: `trufflehog_exclude_args` now builds `--exclude-globs` from the file (plain paths are valid globs; comments/blanks dropped), replacing `--exclude-paths`.

## Validation
- Exact CI binary (3.95.9) git mode, 20-commit range incl. the 14508 branch: 0 unverified (was 8), 0 verified; fixtures still excluded; bash syntax check on the script.

## Risk / rollback
Low — sonarcloud.yml keeps gitleaks + GitHub-native secret scanning. Rollback = revert. Follow-up: if more SonarCloud-detector-bait files appear, the same list extends.