### PR TITLE
fix(design-system): map shell --linear paren utilities to tokens

### DIFF
--- a/apps/web/components/shell/ActivityHoverRow.tsx
+++ b/apps/web/components/shell/ActivityHoverRow.tsx
@@ -56,7 +56,7 @@ export function ActivityHoverRow({
       type='button'
       onClick={onClick}
       className={cn(
-        'group/act flex items-center gap-2.5 h-8 px-2 rounded-md text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle',
+        'group/act flex items-center gap-2.5 h-8 px-2 rounded-md text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle',
         danger
           ? 'text-rose-300/85 hover:bg-rose-500/10 hover:text-rose-200'
           : 'text-secondary-token hover:bg-surface-1/50 hover:text-primary-token',

--- a/apps/web/components/shell/ArtistProfileRailToggle.tsx
+++ b/apps/web/components/shell/ArtistProfileRailToggle.tsx
@@ -62,7 +62,7 @@ export function ArtistProfileRailToggle() {
           'text-xs font-semibold text-secondary-token',
           'transition-[background,color,opacity] duration-subtle ease-subtle',
           'hover:bg-surface-0 hover:text-primary-token',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
           isOpen && 'bg-surface-0 text-primary-token'
         )}
       >

--- a/apps/web/components/shell/ArtworkPlayOverlay.tsx
+++ b/apps/web/components/shell/ArtworkPlayOverlay.tsx
@@ -30,7 +30,7 @@ export const ArtworkPlayOverlay = React.memo(function ArtworkPlayOverlay({
       type='button'
       onClick={onPlay}
       className={cn(
-        'absolute inset-0 grid place-items-center bg-black/50 text-white dark:text-white transition-opacity duration-subtle ease-subtle hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none',
+        'absolute inset-0 grid place-items-center bg-black/50 text-white dark:text-white transition-opacity duration-subtle ease-subtle hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none',
         visible ? 'opacity-100' : 'opacity-0',
         className
       )}

--- a/apps/web/components/shell/ColumnLabel.tsx
+++ b/apps/web/components/shell/ColumnLabel.tsx
@@ -70,7 +70,7 @@ export function ColumnLabel<F extends string>({
       type='button'
       onClick={() => onSort(field)}
       className={cn(
-        'group/col h-6 px-1 -mx-1 rounded-md text-3xs uppercase tracking-[0.12em] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle',
+        'group/col h-6 px-1 -mx-1 rounded-md text-3xs uppercase tracking-[0.12em] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle',
         flex ? 'flex-1 min-w-0' : (width ?? ''),
         'shrink-0 inline-flex items-center gap-1',
         align === 'right' && 'flex-row-reverse',

--- a/apps/web/components/shell/ContextMenuOverlay.test.tsx
+++ b/apps/web/components/shell/ContextMenuOverlay.test.tsx
@@ -81,7 +81,7 @@ describe('ContextMenuOverlay', () => {
       items: [{ label: 'Play', onSelect: () => undefined }],
     };
     render(<ContextMenuOverlay state={state} onClose={onClose} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Close menu' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close Menu' }));
     expect(onClose).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/components/shell/ContextMenuOverlay.tsx
+++ b/apps/web/components/shell/ContextMenuOverlay.tsx
@@ -106,7 +106,7 @@ export function ContextMenuOverlay({
     <div className='fixed inset-0 z-[110]'>
       <button
         type='button'
-        aria-label='Close menu'
+        aria-label='Close Menu'
         tabIndex={-1}
         className='absolute inset-0 cursor-default'
         onClick={onClose}
@@ -147,7 +147,7 @@ export function ContextMenuOverlay({
                 onClose();
               }}
               className={cn(
-                'relative group/mi w-full flex items-center gap-2.5 h-7 px-2 rounded-md text-xs font-caption text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle',
+                'relative group/mi w-full flex items-center gap-2.5 h-7 px-2 rounded-md text-xs font-caption text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle',
                 item.disabled
                   ? 'opacity-50 cursor-not-allowed text-secondary-token'
                   : item.tone === 'danger'

--- a/apps/web/components/shell/CuesPanel.tsx
+++ b/apps/web/components/shell/CuesPanel.tsx
@@ -41,7 +41,7 @@ const CueRow = memo(function CueRow({
       type='button'
       onClick={() => onSeek?.(c.at)}
       disabled={disabled}
-      className='group/cue w-full flex items-center gap-2 h-8 px-2 rounded-md text-xs text-secondary-token hover:bg-surface-1/40 hover:text-primary-token disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle'
+      className='group/cue w-full flex items-center gap-2 h-8 px-2 rounded-md text-xs text-secondary-token hover:bg-surface-1/40 hover:text-primary-token disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle'
     >
       <span className='relative w-9 shrink-0'>
         <span

--- a/apps/web/components/shell/InlineEditRow.tsx
+++ b/apps/web/components/shell/InlineEditRow.tsx
@@ -134,7 +134,7 @@ export function InlineEditRow({
           aria-label={`Edit ${label}`}
           className={cn(
             valueClass,
-            'bg-transparent outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/24 rounded-sm'
+            'bg-transparent outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/24 rounded-sm'
           )}
         />
       </div>
@@ -178,7 +178,7 @@ export function InlineEditRow({
             enterEdit();
           }}
           aria-label={`Edit ${label}`}
-          className='shrink-0 inline-flex items-center justify-center h-5 w-5 rounded text-quaternary-token hover:text-primary-token hover:bg-surface-1/60 opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-opacity duration-subtle ease-subtle'
+          className='shrink-0 inline-flex items-center justify-center h-5 w-5 rounded text-quaternary-token hover:text-primary-token hover:bg-surface-1/60 opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-opacity duration-subtle ease-subtle'
         >
           <Pencil className='h-3 w-3' strokeWidth={2.25} />
         </button>

--- a/apps/web/components/shell/JovieOverlay.tsx
+++ b/apps/web/components/shell/JovieOverlay.tsx
@@ -71,7 +71,7 @@ export function JovieOverlay({
               <Mic className='h-3.5 w-3.5' strokeWidth={2.5} />
               <span
                 aria-hidden='true'
-                className='absolute inset-0 rounded-full ring-2 ring-(--linear-border-focus)/35 anim-calm-halo'
+                className='absolute inset-0 rounded-full ring-2 ring-ring/35 anim-calm-halo'
               />
             </span>
             <div className='flex-1 min-w-0'>

--- a/apps/web/components/shell/LyricRow.tsx
+++ b/apps/web/components/shell/LyricRow.tsx
@@ -76,7 +76,7 @@ export const LyricRow = React.memo(function LyricRow({
           data-focused={isFocused && !isActive ? '' : undefined}
           className={cn(
             'group/lyric block w-full text-center cursor-pointer select-none bg-transparent border-0 p-0',
-            'transition-[color,opacity,transform] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
+            'transition-[color,opacity,transform] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55',
             isActive
               ? 'text-primary-token text-3xl leading-[1.25] font-display opacity-100'
               : 'text-tertiary-token text-xl leading-[1.35] font-display opacity-60 hover:opacity-90 hover:text-secondary-token'
@@ -111,7 +111,7 @@ export const LyricRow = React.memo(function LyricRow({
         type='button'
         onClick={onStamp}
         className={cn(
-          'shrink-0 h-6 px-1.5 rounded text-3xs tabular-nums font-caption transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
+          'shrink-0 h-6 px-1.5 rounded text-3xs tabular-nums font-caption transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55',
           isActive
             ? 'bg-cyan-500/15 text-cyan-300 border border-cyan-500/30'
             : 'text-tertiary-token bg-surface-1 border border-(--linear-app-shell-border) hover:text-primary-token hover:border-cyan-500/40'

--- a/apps/web/components/shell/LyricsList.tsx
+++ b/apps/web/components/shell/LyricsList.tsx
@@ -53,7 +53,7 @@ const LyricListRow = memo(function LyricListRow({
       type='button'
       onClick={() => onSeek?.(line.at)}
       disabled={disabled}
-      className='group/lyric w-full flex items-start gap-2 px-2 py-1.5 rounded-md text-xs text-secondary-token hover:bg-surface-1/40 hover:text-primary-token disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle text-left'
+      className='group/lyric w-full flex items-start gap-2 px-2 py-1.5 rounded-md text-xs text-secondary-token hover:bg-surface-1/40 hover:text-primary-token disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle text-left'
     >
       <span className='shrink-0 w-9 pt-0.5 text-3xs tabular-nums text-quaternary-token group-hover/lyric:text-tertiary-token transition-colors duration-subtle ease-subtle'>
         {formatLyricsTime(line.at)}
@@ -100,7 +100,7 @@ export function LyricsList({
           <button
             type='button'
             onClick={onEdit}
-            className='text-3xs uppercase tracking-[0.06em] text-quaternary-token hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) rounded transition-colors duration-subtle ease-subtle'
+            className='text-3xs uppercase tracking-[0.06em] text-quaternary-token hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) rounded transition-colors duration-subtle ease-subtle'
           >
             {editLabel}
           </button>

--- a/apps/web/components/shell/MobilePlayerCard.tsx
+++ b/apps/web/components/shell/MobilePlayerCard.tsx
@@ -91,7 +91,7 @@ export const MobilePlayerCard = React.memo(function MobilePlayerCard({
         <button
           type='button'
           onClick={onPlay}
-          className='h-9 w-9 rounded-full grid place-items-center border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset shrink-0 transition-colors duration-subtle ease-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
+          className='h-9 w-9 rounded-full grid place-items-center border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset shrink-0 transition-colors duration-subtle ease-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
           aria-label={isPlaying ? 'Pause' : 'Play'}
         >
           {isPlaying ? (

--- a/apps/web/components/shell/ScrubGradient.tsx
+++ b/apps/web/components/shell/ScrubGradient.tsx
@@ -131,7 +131,7 @@ export function ScrubGradient({
       <span className={cn(TIME_LABEL, 'text-right')}>
         {formatTime(safeCurrent)}
       </span>
-      <div className='relative flex-1 min-w-15 h-8 rounded-sm focus-within:ring-1 focus-within:ring-(--linear-border-focus)'>
+      <div className='relative flex-1 min-w-15 h-8 rounded-sm focus-within:ring-1 focus-within:ring-ring'>
         <svg
           viewBox={`0 0 ${SCRUB_W} ${SCRUB_H}`}
           className='w-full h-full overflow-visible'

--- a/apps/web/components/shell/SidebarBottomNowPlaying.tsx
+++ b/apps/web/components/shell/SidebarBottomNowPlaying.tsx
@@ -78,7 +78,7 @@ export const SidebarBottomNowPlaying = React.memo(
           type='button'
           onClick={onPlay}
           aria-label={isPlaying ? 'Pause' : 'Play'}
-          className='shrink-0 h-7 w-7 rounded-full grid place-items-center text-primary-token hover:bg-surface-1/70 transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
+          className='shrink-0 h-7 w-7 rounded-full grid place-items-center text-primary-token hover:bg-surface-1/70 transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
         >
           {isPlaying ? (
             <Pause className='h-3 w-3' strokeWidth={2.5} fill='currentColor' />

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -69,7 +69,7 @@ export function getSidebarNavRowClassName({
   const nonCollapsedSize = tight ? 'h-6 px-2.5' : 'h-7 px-2.5';
 
   return cn(
-    'relative grid items-center rounded-full w-full transition-[background-color,box-shadow,color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+    'relative grid items-center rounded-full w-full transition-[background-color,box-shadow,color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
     'font-normal',
     'before:pointer-events-none before:absolute before:inset-y-1.5 before:left-6 before:w-px before:bg-[color-mix(in_oklab,var(--linear-app-frame-seam)_32%,transparent)]',
     'after:pointer-events-none after:absolute after:inset-y-1.5 after:left-10 after:w-px after:bg-[color-mix(in_oklab,var(--linear-app-frame-seam)_32%,transparent)]',

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -274,7 +274,7 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
             onClick={e => onThreadContextMenu(e, thread)}
             aria-label={`Chat Actions for ${thread.title}`}
             className={cn(
-              'absolute right-1 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-full text-quaternary-token transition-[background-color,color,opacity] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
+              'absolute right-1 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-full text-quaternary-token transition-[background-color,color,opacity] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55',
               'opacity-0 group-hover/thread:opacity-100 focus-visible:opacity-100'
             )}
           >

--- a/apps/web/components/shell/SuggestionCard.tsx
+++ b/apps/web/components/shell/SuggestionCard.tsx
@@ -77,7 +77,7 @@ export function SuggestionCard({
             <button
               type='button'
               onClick={onDismiss}
-              className='inline-flex items-center h-7 px-3 rounded-full text-2xs text-quaternary-token hover:text-primary-token hover:bg-surface-1/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle'
+              className='inline-flex items-center h-7 px-3 rounded-full text-2xs text-quaternary-token hover:text-primary-token hover:bg-surface-1/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) transition-colors duration-subtle ease-subtle'
             >
               {dismissLabel}
             </button>
@@ -86,7 +86,7 @@ export function SuggestionCard({
             type='button'
             onClick={onAct}
             disabled={!onAct}
-            className='inline-flex items-center gap-1.5 h-7 px-3.5 rounded-full text-xs font-medium bg-white dark:bg-surface-1 text-black dark:text-white hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) disabled:cursor-not-allowed disabled:opacity-60 shadow-[0_4px_14px_rgba(0,0,0,0.35),inset_0_1px_0_rgba(255,255,255,0.45)] transition-[filter,box-shadow,opacity] duration-subtle ease-out'
+            className='inline-flex items-center gap-1.5 h-7 px-3.5 rounded-full text-xs font-medium bg-white dark:bg-surface-1 text-black dark:text-white hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) disabled:cursor-not-allowed disabled:opacity-60 shadow-[0_4px_14px_rgba(0,0,0,0.35),inset_0_1px_0_rgba(255,255,255,0.45)] transition-[filter,box-shadow,opacity] duration-subtle ease-out'
           >
             {actionLabel}
             <ArrowRight className='h-3 w-3' strokeWidth={2.5} />

--- a/apps/web/components/shell/TabletPlayerCard.tsx
+++ b/apps/web/components/shell/TabletPlayerCard.tsx
@@ -106,7 +106,7 @@ export const TabletPlayerCard = React.memo(function TabletPlayerCard({
             <button
               type='button'
               onClick={onPrevious}
-              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
+              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
               aria-label='Previous'
             >
               <SkipBack
@@ -118,7 +118,7 @@ export const TabletPlayerCard = React.memo(function TabletPlayerCard({
             <button
               type='button'
               onClick={onPlay}
-              className='h-9 w-9 rounded-full grid place-items-center border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle ease-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
+              className='h-9 w-9 rounded-full grid place-items-center border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle ease-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
               aria-label={isPlaying ? 'Pause' : 'Play'}
             >
               {isPlaying ? (
@@ -138,7 +138,7 @@ export const TabletPlayerCard = React.memo(function TabletPlayerCard({
             <button
               type='button'
               onClick={onNext}
-              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
+              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
               aria-label='Next'
             >
               <SkipForward

--- a/apps/web/components/shell/ThreadView.test.tsx
+++ b/apps/web/components/shell/ThreadView.test.tsx
@@ -84,7 +84,7 @@ describe('ThreadView shell contract', () => {
       'utf8'
     );
 
-    expect(source).toContain('px-(--linear-app-header-padding-x)');
+    expect(source).toContain('px-app-header');
     expect(source).toContain('max-w-[44rem]');
     expect(source).toContain('env(safe-area-inset-bottom)');
     expect(source).toContain('shadow-popover');

--- a/apps/web/components/shell/ThreadView.tsx
+++ b/apps/web/components/shell/ThreadView.tsx
@@ -95,7 +95,7 @@ export function ThreadView({
         onScroll={checkAtBottom}
         className='absolute inset-0 overflow-y-auto'
       >
-        <div className='mx-auto w-full max-w-[44rem] px-(--linear-app-header-padding-x) pb-(--system-b-chat-composer-thread-scroll-padding) pt-5 sm:pt-6'>
+        <div className='mx-auto w-full max-w-[44rem] px-app-header pb-(--system-b-chat-composer-thread-scroll-padding) pt-5 sm:pt-6'>
           <header>
             <h1 className='text-2xl font-semibold leading-tight text-primary-token'>
               {thread.title}
@@ -120,14 +120,14 @@ export function ThreadView({
       />
       <div className='absolute inset-x-0 bottom-0'>
         {/* system-b-allow: safe-area inset requires calc(); no spacing token covers env() (JOV-3532) */}
-        <div className='relative mx-auto w-full max-w-[44rem] px-(--linear-app-header-padding-x) pb-[calc(1rem+env(safe-area-inset-bottom))]'>
+        <div className='relative mx-auto w-full max-w-[44rem] px-app-header pb-[calc(1rem+env(safe-area-inset-bottom))]'>
           {!atBottom && (
             <button
               type='button'
               onClick={scrollToBottom}
               aria-label='Scroll To Bottom'
               className={cn(
-                'absolute left-1/2 -top-10 z-10 grid h-8 w-8 -translate-x-1/2 place-items-center rounded-full border border-(--linear-app-shell-border) bg-(--linear-app-content-surface) text-secondary-token shadow-popover transition-colors duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55'
+                'absolute left-1/2 -top-10 z-10 grid h-8 w-8 -translate-x-1/2 place-items-center rounded-full border border-(--linear-app-shell-border) bg-(--linear-app-content-surface) text-secondary-token shadow-popover transition-colors duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55'
               )}
             >
               <ArrowDown className='h-3.5 w-3.5' strokeWidth={2.25} />

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1993
+  "count": 1967
 }


### PR DESCRIPTION
## Summary
Mechanical exact same-var maps under `apps/web/components/shell/**` only (mirrors #14538 safe maps):

- `ring-(--linear-border-focus)` → `ring-ring` (incl. opacity suffixes)
- `px-(--linear-app-header-padding-x)` → `px-app-header`

Also fixes Title Case `aria-label` on touched `ContextMenuOverlay` (`Close Menu`) so eslint pre-commit gate passes.

**linear-namespace ratchet:** `2096` → `2070` (**−26**)

No visual judgment changes; no dashboard/admin/molecules/marketing; no design-system.css infra.

## Verification
- `vitest` linear-namespace + arbitrary-values ratchets: pass
- Shell unit tests (ThreadView, Mobile/TabletPlayerCard, EntityPopover, AppShellRightRail): pass
- Pre-commit: gitleaks/trufflehog, biome, eslint, typecheck: pass
- Pre-push full suite blocked on **unrelated** main drift: `playwright-artifact-secrets` expects 25 upload inventory entries; current workflows include `postdeploy-probes.yml:postdeploy-auth-smoke-…`. Used documented `JOVIE_SKIP_PRE_PUSH_GATE=1` hatch after focused green evidence.

bug-to-test: waived — linear-namespace baseline is regression guard