### PR TITLE
fix(design-system): map dashboard --linear paren utilities to tokens

### DIFF
--- a/apps/web/components/features/dashboard/AudienceRowActionsMenu.tsx
+++ b/apps/web/components/features/dashboard/AudienceRowActionsMenu.tsx
@@ -61,7 +61,7 @@ export function AudienceRowActionsMenu({
       <DropdownMenuTrigger asChild>
         <AppIconButton
           ariaLabel='Open audience row actions'
-          className='h-8 w-8 rounded-lg border border-transparent bg-transparent text-quaternary-token hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-ring/25 [&_svg]:h-3.5 [&_svg]:w-3.5'
+          className='h-8 w-8 rounded-lg border border-transparent bg-transparent text-quaternary-token hover:border-subtle hover:bg-surface-0 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-ring/25 [&_svg]:h-3.5 [&_svg]:w-3.5'
         >
           <MoreHorizontal className='h-4 w-4' />
         </AppIconButton>

--- a/apps/web/components/features/dashboard/atoms/AudienceIntentBadge.tsx
+++ b/apps/web/components/features/dashboard/atoms/AudienceIntentBadge.tsx
@@ -15,17 +15,17 @@ const INTENT_BADGES: Record<
   high: {
     label: 'High',
     className: 'border-default bg-surface-1 text-secondary-token',
-    dotClassName: 'bg-(--linear-text-secondary)',
+    dotClassName: 'bg-secondary-token',
   },
   medium: {
     label: 'Medium',
     className: 'border-subtle bg-surface-0 text-tertiary-token',
-    dotClassName: 'bg-(--linear-text-tertiary)',
+    dotClassName: 'bg-tertiary-token',
   },
   low: {
     label: 'Low',
     className: 'border-subtle bg-transparent text-tertiary-token',
-    dotClassName: 'bg-(--linear-text-tertiary)/70',
+    dotClassName: 'bg-tertiary-token/70',
   },
 };
 

--- a/apps/web/components/features/dashboard/atoms/CategorySection.tsx
+++ b/apps/web/components/features/dashboard/atoms/CategorySection.tsx
@@ -23,7 +23,7 @@ export function CategorySection({
       className={cn(
         variant === 'flat'
           ? 'py-2'
-          : 'rounded-lg border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-3',
+          : 'rounded-lg border border-subtle bg-(--linear-app-content-surface) p-3',
         className
       )}
     >

--- a/apps/web/components/features/dashboard/atoms/PlatformPill.parts.tsx
+++ b/apps/web/components/features/dashboard/atoms/PlatformPill.parts.tsx
@@ -41,7 +41,7 @@ export interface PillIconProps {
 export function PillIcon({ platformIcon, style }: Readonly<PillIconProps>) {
   return (
     <span
-      className='flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-(--linear-app-frame-seam) bg-surface-0 p-0.5 transition-colors'
+      className='flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-subtle bg-surface-0 p-0.5 transition-colors'
       style={style}
       aria-hidden='true'
     >
@@ -121,7 +121,7 @@ export function ExpandedContent({
       </div>
 
       {badgeText ? (
-        <span className='shrink-0 rounded-md border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs font-caption text-secondary-token'>
+        <span className='shrink-0 rounded-md border border-subtle bg-surface-0 px-1.5 py-0.5 text-3xs font-caption text-secondary-token'>
           {badgeText}
         </span>
       ) : null}

--- a/apps/web/components/features/dashboard/atoms/VerticalDivider.tsx
+++ b/apps/web/components/features/dashboard/atoms/VerticalDivider.tsx
@@ -7,7 +7,5 @@
  * Note: This is a purely decorative element and does not need ARIA attributes.
  */
 export function VerticalDivider() {
-  return (
-    <div className='h-5 w-px bg-(--linear-border-subtle)' aria-hidden='true' />
-  );
+  return <div className='h-5 w-px bg-subtle' aria-hidden='true' />;
 }

--- a/apps/web/components/features/dashboard/audience/table/molecules/AudienceTableHeader.tsx
+++ b/apps/web/components/features/dashboard/audience/table/molecules/AudienceTableHeader.tsx
@@ -174,7 +174,7 @@ export function AudienceTableHeader({
                     </div>
                     <span
                       className={cn(
-                        'inline-flex items-center rounded-md border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-0.5 text-2xs font-caption text-secondary-token tabular-nums transition-colors duration-subtle whitespace-nowrap',
+                        'inline-flex items-center rounded-md border border-subtle bg-surface-0 px-2 py-0.5 text-2xs font-caption text-secondary-token tabular-nums transition-colors duration-subtle whitespace-nowrap',
                         selectedCount > 0 &&
                           'pointer-events-none opacity-0 -translate-y-0.5'
                       )}

--- a/apps/web/components/features/dashboard/dashboard-analytics/AnalyticsFunnel.tsx
+++ b/apps/web/components/features/dashboard/dashboard-analytics/AnalyticsFunnel.tsx
@@ -81,10 +81,10 @@ export function AnalyticsFunnel({
               <ContentSurfaceCard
                 className={`
                   relative overflow-hidden rounded-xl
-                  bg-gradient-to-r from-(--linear-bg-surface-1) to-(--linear-bg-surface-2)
+                  bg-gradient-to-r from-surface-1 to-surface-2
                   px-6 py-5 text-center
                   ${isLast ? '' : 'hover:border-default'}
-                  ${isLast ? 'border-primary/20 ring-1 ring-primary/15 bg-gradient-to-r from-[color-mix(in_srgb,var(--linear-accent)_12%,var(--linear-bg-surface-1))] to-(--linear-bg-surface-1)' : ''}
+                  ${isLast ? 'border-primary/20 ring-1 ring-primary/15 bg-gradient-to-r from-[color-mix(in_srgb,var(--linear-accent)_12%,var(--linear-bg-surface-1))] to-surface-1' : ''}
                   transition-colors duration-subtle
                 `}
               >

--- a/apps/web/components/features/dashboard/dashboard-pay/DashboardPay.tsx
+++ b/apps/web/components/features/dashboard/dashboard-pay/DashboardPay.tsx
@@ -329,7 +329,7 @@ const TipLinkSection = memo(function TipLinkSection({
         <h3 className='text-app font-caption text-primary-token'>Pay Link</h3>
       </div>
 
-      <div className='flex items-center gap-2 rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-3 py-2.5'>
+      <div className='flex items-center gap-2 rounded-lg border border-subtle bg-surface-0 px-3 py-2.5'>
         <Copy className='max-sm:hidden h-3.5 w-3.5 shrink-0 text-tertiary-token' />
         <span className='min-w-0 flex-1 truncate text-app text-secondary-token'>
           {tipUrl}

--- a/apps/web/components/features/dashboard/insights/InsightActions.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightActions.tsx
@@ -18,7 +18,7 @@ export function InsightActions({ insightId }: InsightActionsProps) {
         size='sm'
         disabled={isPending}
         onClick={() => mutate({ insightId, status: 'dismissed' })}
-        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-tight text-tertiary-token transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-secondary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-ring/20'
+        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-tight text-tertiary-token transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-subtle hover:bg-surface-1 hover:text-secondary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-ring/20'
       >
         <X className='h-3 w-3' />
         Dismiss
@@ -28,7 +28,7 @@ export function InsightActions({ insightId }: InsightActionsProps) {
         size='sm'
         disabled={isPending}
         onClick={() => mutate({ insightId, status: 'acted_on' })}
-        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-tight text-secondary-token transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-primary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-ring/20'
+        className='h-7 gap-1 rounded-lg border border-transparent px-2.5 text-2xs font-caption tracking-tight text-secondary-token transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-ring/20'
       >
         <Check className='h-3 w-3' />
         Done

--- a/apps/web/components/features/dashboard/insights/InsightCard.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightCard.tsx
@@ -47,7 +47,7 @@ interface InsightCardProps {
 export function InsightCard({ insight }: InsightCardProps) {
   return (
     <article
-      className='border-b border-(--linear-app-frame-seam) px-1 py-3.5 transition-colors duration-subtle last:border-b-0 hover:bg-surface-0/60'
+      className='border-b border-subtle px-1 py-3.5 transition-colors duration-subtle last:border-b-0 hover:bg-surface-0/60'
       aria-label={`${PRIORITY_LABELS[insight.priority]} insight: ${insight.title}`}
     >
       <div className='flex items-start gap-3'>
@@ -63,7 +63,7 @@ export function InsightCard({ insight }: InsightCardProps) {
               size='sm'
               className={`rounded-md px-1.5 py-0.5 text-3xs ${
                 insight.priority === 'low'
-                  ? 'border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token'
+                  ? 'border-subtle bg-surface-0 text-secondary-token'
                   : ''
               }`}
               style={priorityBadgeStyle(insight.priority)}
@@ -82,7 +82,7 @@ export function InsightCard({ insight }: InsightCardProps) {
             </p>
           ) : null}
 
-          <div className='mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-(--linear-app-frame-seam) pt-3'>
+          <div className='mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-subtle pt-3'>
             <div className='flex items-center gap-2'>
               <span className='text-3xs font-caption text-secondary-token capitalize'>
                 {insight.category}

--- a/apps/web/components/features/dashboard/insights/InsightsBadge.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightsBadge.tsx
@@ -14,7 +14,7 @@ export function InsightsBadge() {
   if (count === 0) return null;
 
   return (
-    <span className='ml-auto inline-flex min-w-5 items-center justify-center rounded-md border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs font-caption leading-none text-secondary-token tabular-nums'>
+    <span className='ml-auto inline-flex min-w-5 items-center justify-center rounded-md border border-subtle bg-surface-0 px-1.5 py-0.5 text-3xs font-caption leading-none text-secondary-token tabular-nums'>
       {count > 99 ? '99+' : count}
     </span>
   );

--- a/apps/web/components/features/dashboard/insights/InsightsSummaryWidget.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightsSummaryWidget.tsx
@@ -40,13 +40,13 @@ export function InsightsSummaryWidget() {
           <span className='text-app font-caption text-primary-token'>
             AI Insights
           </span>
-          <span className='inline-flex min-w-5 items-center justify-center rounded-md border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs font-caption leading-none text-secondary-token tabular-nums'>
+          <span className='inline-flex min-w-5 items-center justify-center rounded-md border border-subtle bg-surface-0 px-1.5 py-0.5 text-3xs font-caption leading-none text-secondary-token tabular-nums'>
             {totalActive}
           </span>
         </div>
         <Link
           href={APP_ROUTES.INSIGHTS}
-          className='inline-flex items-center gap-1 rounded-lg border border-transparent px-1.5 py-1 text-2xs font-caption text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-primary-token'
+          className='inline-flex items-center gap-1 rounded-lg border border-transparent px-1.5 py-1 text-2xs font-caption text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
         >
           <span>View all</span>
           <ChevronRight className='h-3 w-3' aria-hidden='true' />
@@ -58,7 +58,7 @@ export function InsightsSummaryWidget() {
         {insights.map(insight => (
           <li
             key={insight.id}
-            className='flex items-start gap-2 rounded-lg border border-transparent px-2 py-1.5 transition-[background-color,border-color] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-0'
+            className='flex items-start gap-2 rounded-lg border border-transparent px-2 py-1.5 transition-[background-color,border-color] duration-subtle hover:border-subtle hover:bg-surface-0'
           >
             <InsightCategoryIcon category={insight.category} size='sm' />
             <p className='line-clamp-2 text-xs leading-snug text-secondary-token'>

--- a/apps/web/components/features/dashboard/layout/PreviewPanel.tsx
+++ b/apps/web/components/features/dashboard/layout/PreviewPanel.tsx
@@ -83,12 +83,12 @@ function PreviewPanelEmpty({
 
               <div className='mx-auto w-full max-w-80'>
                 <div className={cn(LINEAR_SURFACE.sidebarCard, 'p-2.5')}>
-                  <div className='rounded-3xl border border-(--linear-app-frame-seam) bg-surface-1 p-2'>
+                  <div className='rounded-3xl border border-subtle bg-surface-1 p-2'>
                     <div className='mb-2 flex items-center justify-between px-2.5 pt-1'>
                       <div className='h-2.5 w-16 rounded skeleton' />
                       <div className='h-5 w-20 rounded-lg skeleton' />
                     </div>
-                    <div className='relative aspect-[9/19.5] overflow-hidden rounded-3xl border border-(--linear-app-frame-seam) bg-surface-0'>
+                    <div className='relative aspect-[9/19.5] overflow-hidden rounded-3xl border border-subtle bg-surface-0'>
                       <div className='pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center pt-2.5'>
                         <div className='h-1.5 w-24 rounded-full bg-black/55' />
                       </div>
@@ -367,14 +367,14 @@ export function PreviewPanel() {
                   </p>
                 </div>
                 <div className='flex items-center gap-1.5'>
-                  <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-tight text-secondary-token'>
+                  <div className='rounded-lg border border-subtle bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-tight text-secondary-token'>
                     Mobile
                   </div>
-                  <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-tight text-secondary-token'>
+                  <div className='rounded-lg border border-subtle bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-tight text-secondary-token'>
                     {visibleLinkCount} live
                   </div>
                   {hiddenLinkCount > 0 && (
-                    <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-tight text-secondary-token'>
+                    <div className='rounded-lg border border-subtle bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-tight text-secondary-token'>
                       {hiddenLinkCount} draft{hiddenLinkCount === 1 ? '' : 's'}
                     </div>
                   )}
@@ -383,15 +383,15 @@ export function PreviewPanel() {
 
               <div className='mx-auto w-full max-w-80'>
                 <div className={cn(LINEAR_SURFACE.sidebarCard, 'p-2.5')}>
-                  <div className='rounded-3xl border border-(--linear-app-frame-seam) bg-surface-1 p-2'>
+                  <div className='rounded-3xl border border-subtle bg-surface-1 p-2'>
                     <div className='mb-2 flex items-center justify-between px-2.5 pt-1 text-3xs font-caption tracking-tight text-secondary-token'>
                       <span>Preview</span>
-                      <span className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-0.5 text-3xs tracking-tight'>
+                      <span className='rounded-lg border border-subtle bg-surface-0 px-2 py-0.5 text-3xs tracking-tight'>
                         {username ? `@${username}` : 'Profile'}
                       </span>
                     </div>
 
-                    <div className='relative aspect-[9/19.5] max-h-185 overflow-hidden rounded-3xl border border-(--linear-app-frame-seam) bg-surface-0'>
+                    <div className='relative aspect-[9/19.5] max-h-185 overflow-hidden rounded-3xl border border-subtle bg-surface-0'>
                       <div className='pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center pt-2.5'>
                         <div className='h-1.5 w-24 rounded-full bg-black/55' />
                       </div>
@@ -483,11 +483,11 @@ export function PreviewPanel() {
                   url={profileUrl}
                   size='md'
                   className='flex-1'
-                  inputClassName='h-8 rounded-lg border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1.5 text-2xs'
+                  inputClassName='h-8 rounded-lg border-subtle bg-surface-0 px-2.5 py-1.5 text-2xs'
                 />
                 <button
                   type='button'
-                  className='shrink-0 rounded-md border border-(--linear-app-frame-seam) bg-surface-0 p-1.5 text-tertiary-token transition-colors hover:border-default hover:bg-surface-1 hover:text-secondary-token'
+                  className='shrink-0 rounded-md border border-subtle bg-surface-0 p-1.5 text-tertiary-token transition-colors hover:border-default hover:bg-surface-1 hover:text-secondary-token'
                   onClick={() =>
                     globalThis.open(profileUrl, '_blank', 'noopener,noreferrer')
                   }
@@ -512,7 +512,7 @@ export function PreviewPanel() {
                 </p>
               </div>
 
-              <p className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-2 text-2xs leading-5 text-secondary-token'>
+              <p className='rounded-lg border border-subtle bg-surface-0 px-2.5 py-2 text-2xs leading-5 text-secondary-token'>
                 {visibleLinkCount} visible link
                 {visibleLinkCount === 1 ? '' : 's'} currently anchor the public
                 profile
@@ -521,7 +521,7 @@ export function PreviewPanel() {
                   : '.'}
               </p>
 
-              <div className='grid grid-cols-3 divide-x divide-(--linear-app-frame-seam)'>
+              <div className='grid grid-cols-3 divide-x divide-subtle'>
                 <div className='space-y-px pr-3'>
                   <p className='text-3xs font-medium leading-[14px] text-tertiary-token'>
                     Visible
@@ -552,7 +552,7 @@ export function PreviewPanel() {
                 {snapshotTags.map(tag => (
                   <span
                     key={tag}
-                    className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-tight text-secondary-token'
+                    className='rounded-lg border border-subtle bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-tight text-secondary-token'
                   >
                     {tag}
                   </span>

--- a/apps/web/components/features/dashboard/molecules/DspMatchCard.tsx
+++ b/apps/web/components/features/dashboard/molecules/DspMatchCard.tsx
@@ -98,7 +98,7 @@ export function DspMatchCard({
         <div className='flex items-center gap-3'>
           {/* Provider Icon or Artist Image */}
           {externalArtistImageUrl ? (
-            <div className='relative h-10 w-10 shrink-0 overflow-hidden rounded-lg border border-(--linear-app-frame-seam) bg-surface-0'>
+            <div className='relative h-10 w-10 shrink-0 overflow-hidden rounded-lg border border-subtle bg-surface-0'>
               <Image
                 src={externalArtistImageUrl}
                 alt={externalArtistName}
@@ -109,7 +109,7 @@ export function DspMatchCard({
               />
             </div>
           ) : (
-            <div className='flex h-10 w-10 items-center justify-center rounded-lg border border-(--linear-app-frame-seam) bg-surface-0'>
+            <div className='flex h-10 w-10 items-center justify-center rounded-lg border border-subtle bg-surface-0'>
               <DspProviderIcon provider={providerId} size='lg' />
             </div>
           )}
@@ -125,7 +125,7 @@ export function DspMatchCard({
                   href={externalArtistUrl}
                   target='_blank'
                   rel='noopener noreferrer'
-                  className='flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-transparent text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-primary-token'
+                  className='flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-transparent text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
                   title={`View on ${PROVIDER_LABELS[providerId]}`}
                 >
                   <Icon name='ExternalLink' className='h-3.5 w-3.5' />
@@ -150,11 +150,11 @@ export function DspMatchCard({
 
       {/* Expandable Confidence Breakdown */}
       {confidenceBreakdown && (
-        <div className='mt-3 border-t border-(--linear-app-frame-seam) pt-3'>
+        <div className='mt-3 border-t border-subtle pt-3'>
           <button
             type='button'
             onClick={() => setIsExpanded(!isExpanded)}
-            className='flex h-7 w-full items-center justify-between rounded-lg border border-transparent px-2 text-xs text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-ring'
+            className='flex h-7 w-full items-center justify-between rounded-lg border border-transparent px-2 text-xs text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-ring'
           >
             <span>Confidence breakdown</span>
             <Icon
@@ -176,14 +176,14 @@ export function DspMatchCard({
 
       {/* Actions */}
       {isActionable && (
-        <div className='mt-3 flex items-center justify-end gap-2 border-t border-(--linear-app-frame-seam) pt-3'>
+        <div className='mt-3 flex items-center justify-end gap-2 border-t border-subtle pt-3'>
           {onReject && (
             <Button
               variant='ghost'
               size='sm'
               onClick={() => onReject(matchId)}
               disabled={isLoading}
-              className='h-7 rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 text-2xs font-caption text-secondary-token hover:bg-surface-1 hover:text-primary-token'
+              className='h-7 rounded-lg border border-subtle bg-surface-0 px-2.5 text-2xs font-caption text-secondary-token hover:bg-surface-1 hover:text-primary-token'
             >
               {isRejecting ? 'Rejecting...' : 'Reject'}
             </Button>

--- a/apps/web/components/features/dashboard/molecules/MatchConfidenceBreakdown.tsx
+++ b/apps/web/components/features/dashboard/molecules/MatchConfidenceBreakdown.tsx
@@ -170,7 +170,7 @@ export function MatchConfidenceBreakdown({
       ))}
 
       {/* Total */}
-      <div className='border-t border-(--linear-app-frame-seam) pt-2'>
+      <div className='border-t border-subtle pt-2'>
         <div className='flex items-center justify-between text-app'>
           <span className='font-caption text-primary-token'>
             Total Confidence

--- a/apps/web/components/features/dashboard/molecules/ProfileCompletionCard.tsx
+++ b/apps/web/components/features/dashboard/molecules/ProfileCompletionCard.tsx
@@ -82,7 +82,7 @@ export const ProfileCompletionCard = memo(
       : 'Complete these essentials so fans can find you.';
 
     return (
-      <ContentSurfaceCard className='mb-2 border-(--linear-app-frame-seam) p-3.5 sm:mb-3 sm:p-4'>
+      <ContentSurfaceCard className='mb-2 border-subtle p-3.5 sm:mb-3 sm:p-4'>
         <div className='flex items-start justify-between gap-3'>
           <div className='min-w-0 flex-1 space-y-2'>
             <div className='flex items-center gap-1.5 text-2xs font-caption tracking-tight text-tertiary-token'>
@@ -121,7 +121,7 @@ export const ProfileCompletionCard = memo(
                 <li key={step.id}>
                   <Link
                     href={step.href}
-                    className='group flex items-center justify-between gap-3 rounded-md border border-transparent px-3 py-2 transition-[background-color,border-color] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-0'
+                    className='group flex items-center justify-between gap-3 rounded-md border border-transparent px-3 py-2 transition-[background-color,border-color] duration-subtle hover:border-subtle hover:bg-surface-0'
                   >
                     <div className='min-w-0'>
                       <p className='text-app font-caption text-primary-token'>
@@ -146,7 +146,7 @@ export const ProfileCompletionCard = memo(
               type='button'
               onClick={handleDismiss}
               aria-label='Dismiss Profile Completion Card'
-              className='shrink-0 rounded-lg border border-(--linear-app-frame-seam) p-1.5 text-tertiary-token transition-[background-color,border-color,color,box-shadow] duration-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-1 focus-visible:ring-ring'
+              className='shrink-0 rounded-lg border border-subtle p-1.5 text-tertiary-token transition-[background-color,border-color,color,box-shadow] duration-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-1 focus-visible:ring-ring'
             >
               <X className='h-4 w-4' aria-hidden='true' />
             </button>

--- a/apps/web/components/features/dashboard/molecules/ProfileLiveCelebration.tsx
+++ b/apps/web/components/features/dashboard/molecules/ProfileLiveCelebration.tsx
@@ -201,7 +201,7 @@ export function ProfileLiveCelebration({
           Your Profile Is Live
         </h2>
 
-        <div className='flex items-center gap-2 rounded-lg border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-4 py-2.5'>
+        <div className='flex items-center gap-2 rounded-lg border border-subtle bg-(--linear-app-content-surface) px-4 py-2.5'>
           <span className='text-app font-medium text-primary-token'>
             {profileUrl}
           </span>

--- a/apps/web/components/features/dashboard/molecules/ProfilePaySurface.tsx
+++ b/apps/web/components/features/dashboard/molecules/ProfilePaySurface.tsx
@@ -66,7 +66,7 @@ function QrPreviewPanel({
   return (
     <div
       className={cn(
-        'shrink-0 rounded-2xl border border-(--linear-app-frame-seam) bg-surface-0',
+        'shrink-0 rounded-2xl border border-subtle bg-surface-0',
         isDrawer
           ? 'flex h-39 w-39 items-center justify-center p-3'
           : 'flex h-37 w-37 items-center justify-center p-3'
@@ -83,7 +83,7 @@ function QrPreviewPanel({
         />
       ) : (
         <div className='space-y-2 text-center'>
-          <div className='mx-auto flex h-10 w-10 items-center justify-center rounded-xl border border-(--linear-app-frame-seam) bg-surface-1 text-tertiary-token'>
+          <div className='mx-auto flex h-10 w-10 items-center justify-center rounded-xl border border-subtle bg-surface-1 text-tertiary-token'>
             <Link2 className='h-4 w-4' aria-hidden='true' />
           </div>
           <p className='text-2xs leading-[14px] text-tertiary-token'>
@@ -103,7 +103,7 @@ function ProviderPill({
   if (provider === 'none') return null;
 
   return (
-    <span className='inline-flex items-center rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-0.5 text-2xs font-caption text-secondary-token'>
+    <span className='inline-flex items-center rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-2xs font-caption text-secondary-token'>
       {provider === 'stripe' ? 'Stripe' : 'Venmo'}
     </span>
   );
@@ -242,7 +242,7 @@ export function ProfilePaySurface({
     >
       <div className={cn('min-w-0', isDrawer ? 'space-y-4' : 'space-y-3')}>
         <div className='flex flex-wrap items-center gap-2'>
-          <span className='inline-flex items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-0.5 text-2xs font-caption text-secondary-token'>
+          <span className='inline-flex items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-2xs font-caption text-secondary-token'>
             <StatusIcon paymentState={summary.paymentState} />
             {getProfileMonetizationHeading(summary.paymentState)}
           </span>

--- a/apps/web/components/features/dashboard/molecules/ProfilePreview.tsx
+++ b/apps/web/components/features/dashboard/molecules/ProfilePreview.tsx
@@ -67,7 +67,7 @@ export function ProfilePreview({
   return (
     <div
       className={cn(
-        'h-full w-full overflow-hidden rounded-3xl border border-(--linear-app-frame-seam)',
+        'h-full w-full overflow-hidden rounded-3xl border border-subtle',
         className
       )}
     >

--- a/apps/web/components/features/dashboard/molecules/SetupTaskItem.tsx
+++ b/apps/web/components/features/dashboard/molecules/SetupTaskItem.tsx
@@ -24,7 +24,7 @@ export function SetupTaskItem({
         <div
           className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-app font-caption ${
             complete
-              ? 'border border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token'
+              ? 'border border-subtle bg-surface-0 text-secondary-token'
               : 'border border-accent/20 bg-accent/10 text-accent'
           }`}
           aria-hidden='true'

--- a/apps/web/components/features/dashboard/molecules/SocialBioNudge.tsx
+++ b/apps/web/components/features/dashboard/molecules/SocialBioNudge.tsx
@@ -56,7 +56,7 @@ function MilestoneRow({
           'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border',
           isComplete
             ? 'border-success/25 bg-success/10 text-success'
-            : 'border-(--linear-app-frame-seam) bg-surface-0 text-tertiary-token'
+            : 'border-subtle bg-surface-0 text-tertiary-token'
         )}
       >
         {isComplete ? (
@@ -212,10 +212,10 @@ export const SocialBioNudge = memo(function SocialBioNudge({
   );
 
   return (
-    <div className='rounded-xl border border-(--linear-app-frame-seam) bg-surface-1 p-4'>
+    <div className='rounded-xl border border-subtle bg-surface-1 p-4'>
       <div className='flex items-start gap-3'>
         <div
-          className='rounded-full border border-(--linear-app-frame-seam) bg-surface-0 p-2 text-secondary-token'
+          className='rounded-full border border-subtle bg-surface-0 p-2 text-secondary-token'
           aria-hidden='true'
         >
           <SocialIcon platform='instagram' className='h-4 w-4' />

--- a/apps/web/components/features/dashboard/molecules/phone-mockup-preview/PhoneMockupPreview.tsx
+++ b/apps/web/components/features/dashboard/molecules/phone-mockup-preview/PhoneMockupPreview.tsx
@@ -34,7 +34,7 @@ export function PhoneMockupPreview({
         className={cn(
           'relative w-full max-w-75 mx-auto',
           'aspect-9/19 rounded-3xl',
-          'bg-surface-1 border border-(--linear-app-frame-seam)',
+          'bg-surface-1 border border-subtle',
           'overflow-hidden'
         )}
       >
@@ -42,7 +42,7 @@ export function PhoneMockupPreview({
         <div
           className={cn(
             'relative w-full h-full rounded-3xl overflow-hidden',
-            'border border-(--linear-app-frame-seam) bg-surface-0',
+            'border border-subtle bg-surface-0',
             'transition-colors duration-cinematic'
           )}
         >
@@ -146,7 +146,7 @@ export function PhoneMockupPreview({
                     aria-hidden='true'
                     tabIndex={-1}
                     className={cn(
-                      'relative block rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 p-4 hover:bg-surface-1',
+                      'relative block rounded-lg border border-subtle bg-surface-0 p-4 hover:bg-surface-1',
                       'transition-colors duration-subtle',
                       'overflow-hidden',
                       activeLink === link.id && 'ring-2 ring-primary-500/20'
@@ -202,7 +202,7 @@ export function PhoneMockupPreview({
                 ))
               ) : (
                 <div className='h-full flex flex-col items-center justify-center text-center p-6'>
-                  <div className='mb-3 flex h-12 w-12 items-center justify-center rounded-lg border border-(--linear-app-frame-seam) bg-surface-0'>
+                  <div className='mb-3 flex h-12 w-12 items-center justify-center rounded-lg border border-subtle bg-surface-0'>
                     <Link2
                       className='w-6 h-6 text-tertiary-token'
                       aria-hidden='true'

--- a/apps/web/components/features/dashboard/organisms/DashboardPreview.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardPreview.tsx
@@ -65,12 +65,12 @@ export function DashboardPreview({
 
       {/* Mobile Frame Preview */}
       <div className='flex justify-center'>
-        <div className='relative w-70 rounded-3xl border border-(--linear-app-frame-seam) bg-surface-1 p-2'>
+        <div className='relative w-70 rounded-3xl border border-subtle bg-surface-1 p-2'>
           {/* Top notch */}
           <div className='absolute left-1/2 top-2 z-10 h-3 w-20 -translate-x-1/2 rounded-b-lg bg-surface-1'></div>
 
           <div
-            className='relative overflow-hidden rounded-3xl border border-(--linear-app-frame-seam) bg-surface-0'
+            className='relative overflow-hidden rounded-3xl border border-subtle bg-surface-0'
             style={{ height: '500px' }}
           >
             {/* Status Bar Mockup */}
@@ -101,7 +101,7 @@ export function DashboardPreview({
       {/* Profile URL and Actions */}
       <div className='pt-4 text-center space-y-3'>
         <div className='flex items-center justify-center gap-2'>
-          <code className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-1 text-2xs text-secondary-token'>
+          <code className='rounded-lg border border-subtle bg-surface-0 px-2 py-1 text-2xs text-secondary-token'>
             {BASE_URL}/{artist.handle || 'username'}
           </code>
           <CopyToClipboardButton

--- a/apps/web/components/features/dashboard/organisms/GetStartedChecklistCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/GetStartedChecklistCard.tsx
@@ -169,7 +169,7 @@ export function GetStartedChecklistCard({
 
   return (
     <ContentSurfaceCard className='overflow-hidden p-0'>
-      <div className='flex items-center justify-between gap-3 border-b border-(--linear-app-frame-seam) px-3 py-2'>
+      <div className='flex items-center justify-between gap-3 border-b border-subtle px-3 py-2'>
         <div className='flex items-center gap-1.5'>
           <h3 className='text-xs font-caption tracking-tight text-primary-token'>
             Get Started
@@ -192,7 +192,7 @@ export function GetStartedChecklistCard({
           <button
             type='button'
             onClick={handleDismiss}
-            className='rounded-full border border-transparent px-2 py-0.5 text-2xs text-tertiary-token transition-colors hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token'
+            className='rounded-full border border-transparent px-2 py-0.5 text-2xs text-tertiary-token transition-colors hover:border-subtle hover:bg-surface-0 hover:text-secondary-token'
           >
             Dismiss
           </button>
@@ -250,7 +250,7 @@ export function GetStartedChecklistCard({
             return (
               <li
                 key={item.id}
-                className='flex items-center gap-2 rounded-full border border-transparent px-2.5 py-1.5 hover:border-(--linear-app-frame-seam) hover:bg-surface-0'
+                className='flex items-center gap-2 rounded-full border border-transparent px-2.5 py-1.5 hover:border-subtle hover:bg-surface-0'
               >
                 {checkboxEl}
                 <Link
@@ -269,7 +269,7 @@ export function GetStartedChecklistCard({
               className={`flex items-center gap-2 rounded-full border border-transparent px-2.5 py-1.5 transition-colors ${
                 isDone
                   ? 'bg-surface-0 opacity-50'
-                  : 'hover:border-(--linear-app-frame-seam) hover:bg-surface-0'
+                  : 'hover:border-subtle hover:bg-surface-0'
               }`}
             >
               {checkboxEl}
@@ -281,7 +281,7 @@ export function GetStartedChecklistCard({
                     e.stopPropagation();
                     handleCopyUrl();
                   }}
-                  className='rounded-full border border-transparent px-2 py-0.5 text-3xs text-tertiary-token transition-colors hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-secondary-token'
+                  className='rounded-full border border-transparent px-2 py-0.5 text-3xs text-tertiary-token transition-colors hover:border-subtle hover:bg-surface-1 hover:text-secondary-token'
                 >
                   Copy
                 </button>

--- a/apps/web/components/features/dashboard/organisms/InlineChatArea.tsx
+++ b/apps/web/components/features/dashboard/organisms/InlineChatArea.tsx
@@ -82,7 +82,7 @@ const InlineChatMessage = memo(function InlineChatMessage({
           <div
             className={cn(
               'max-w-[85%] rounded-xl px-3 py-2',
-              'border border-(--linear-app-frame-seam) bg-surface-0 text-primary-token'
+              'border border-subtle bg-surface-0 text-primary-token'
             )}
           >
             <div className='whitespace-pre-wrap text-app leading-relaxed'>
@@ -275,7 +275,7 @@ export const InlineChatArea = forwardRef<
                 <div className='flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-surface-2'>
                   <BrandLogo size={14} tone='auto' />
                 </div>
-                <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-3 py-2'>
+                <div className='rounded-lg border border-subtle bg-surface-0 px-3 py-2'>
                   <Loader2 className='h-4 w-4 animate-spin text-secondary-token' />
                 </div>
               </div>

--- a/apps/web/components/features/dashboard/organisms/MobileProfileDrawer.tsx
+++ b/apps/web/components/features/dashboard/organisms/MobileProfileDrawer.tsx
@@ -16,9 +16,9 @@ export function MobileProfileDrawer({ onOpen }: MobileProfileDrawerProps) {
   return (
     <button
       type='button'
-      aria-label='Open profile panel'
+      aria-label='Open Profile Panel'
       onClick={onOpen}
-      className='flex h-8 w-8 items-center justify-center rounded-lg border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) lg:hidden'
+      className='flex h-8 w-8 items-center justify-center rounded-lg border border-subtle bg-(--linear-app-content-surface) lg:hidden'
     >
       <PanelRight className='size-4 text-secondary-token' />
     </button>

--- a/apps/web/components/features/dashboard/organisms/MusicImportHero.tsx
+++ b/apps/web/components/features/dashboard/organisms/MusicImportHero.tsx
@@ -76,7 +76,7 @@ export const MusicImportHero = memo(function MusicImportHero({
   // Failed state
   if (isFailed && !hasReleases) {
     return (
-      <div className='rounded-lg border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-4'>
+      <div className='rounded-lg border border-subtle bg-(--linear-app-content-surface) p-4'>
         <div className='flex items-center gap-2 text-secondary-token'>
           <AlertCircle className='h-4 w-4 shrink-0' />
           <p className='text-sm'>

--- a/apps/web/components/features/dashboard/organisms/OnboardingFormWrapper.tsx
+++ b/apps/web/components/features/dashboard/organisms/OnboardingFormWrapper.tsx
@@ -22,7 +22,7 @@ function OnboardingFormLoadingShell() {
       stableStageHeight='tall'
       stageVariant='flat'
       sidebar={
-        <nav aria-label='Onboarding steps loading'>
+        <nav aria-label='Onboarding Steps Loading'>
           <ul className='space-y-1.5'>
             {SIDEBAR_STEP_KEYS.map(key => (
               <li key={key}>
@@ -45,9 +45,9 @@ function OnboardingFormLoadingShell() {
             <div className='mt-2 h-5 w-72 skeleton rounded-md' />
           </div>
 
-          <div className='rounded-xl border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_96%,var(--linear-bg-surface-0))] p-4 sm:p-5'>
+          <div className='rounded-xl border border-subtle bg-[color-mix(in_oklab,var(--linear-app-content-surface)_96%,var(--linear-bg-surface-0))] p-4 sm:p-5'>
             <div className='w-full space-y-3'>
-              <div className='flex w-full items-center gap-3 rounded-full border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,var(--linear-bg-surface-0))] px-4 py-3'>
+              <div className='flex w-full items-center gap-3 rounded-full border border-subtle bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,var(--linear-bg-surface-0))] px-4 py-3'>
                 <div className='h-4 w-3 skeleton rounded' />
                 <div className='h-5 flex-1 skeleton rounded-md' />
               </div>

--- a/apps/web/components/features/dashboard/organisms/ProfileEditPreviewCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/ProfileEditPreviewCard.tsx
@@ -187,7 +187,7 @@ export function ProfileEditPreviewCard({
       </div>
 
       <div className='space-y-2 px-3 py-2'>
-        <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-2'>
+        <div className='rounded-lg border border-subtle bg-surface-0 px-2.5 py-2'>
           <div className='mb-0.5 text-app font-caption tracking-normal text-secondary-token'>
             Current
           </div>
@@ -210,7 +210,7 @@ export function ProfileEditPreviewCard({
         </div>
       </div>
 
-      <div className='flex items-center gap-1.5 border-t border-(--linear-app-frame-seam) px-3 py-2'>
+      <div className='flex items-center gap-1.5 border-t border-subtle px-3 py-2'>
         <DrawerButton
           type='button'
           tone='primary'

--- a/apps/web/components/features/dashboard/organisms/SettingsBillingSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsBillingSection.tsx
@@ -126,7 +126,7 @@ export function SettingsBillingSection() {
                 className={cn(
                   'rounded-md px-1.5 text-3xs',
                   badgeVariant === 'secondary' &&
-                    'border border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token',
+                    'border border-subtle bg-surface-0 text-secondary-token',
                   badgeVariant === 'warning' &&
                     'border border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300',
                   badgeVariant === 'success' &&
@@ -155,7 +155,7 @@ export function SettingsBillingSection() {
       </div>
 
       {isStale && billingData?.staleReason ? (
-        <div className='border-t border-(--linear-app-frame-seam) px-4 py-3.5 sm:px-5'>
+        <div className='border-t border-subtle px-4 py-3.5 sm:px-5'>
           <div className='flex items-start gap-2 text-amber-700 dark:text-amber-300'>
             <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0' aria-hidden />
             <p className='text-app leading-[18px]'>{billingData.staleReason}</p>
@@ -164,7 +164,7 @@ export function SettingsBillingSection() {
       ) : null}
 
       {portalMutation.error ? (
-        <div className='border-t border-(--linear-app-frame-seam) px-4 py-3.5 sm:px-5'>
+        <div className='border-t border-subtle px-4 py-3.5 sm:px-5'>
           <p className='text-app leading-[18px] text-destructive'>
             {portalMutation.error instanceof Error
               ? portalMutation.error.message

--- a/apps/web/components/features/dashboard/organisms/SettingsContactsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsContactsSection.tsx
@@ -66,7 +66,7 @@ export function SettingsContactsSection({
               Failed to load contacts.
             </p>
             <Button variant='ghost' size='sm' onClick={() => refetch()}>
-              Try again
+              Try Again
             </Button>
           </ContentSurfaceCard>
         </div>
@@ -208,7 +208,7 @@ function ContactsListInner({
             className='gap-1.5 text-secondary-token hover:text-primary-token'
           >
             <Plus className='h-4 w-4' aria-hidden />
-            Add contact
+            Add Contact
           </Button>
         }
       >
@@ -278,7 +278,7 @@ const ContactRow = memo(function ContactRow({
       type='button'
       onClick={onClick}
       aria-pressed={isSelected}
-      className={`flex w-full items-center gap-3 rounded-lg border px-3 py-3 text-left transition-[background-color,border-color,box-shadow] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) ${
+      className={`flex w-full items-center gap-3 rounded-lg border px-3 py-3 text-left transition-[background-color,border-color,box-shadow] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-base ${
         isSelected
           ? 'border-subtle bg-surface-0'
           : 'border-transparent hover:bg-surface-0'

--- a/apps/web/components/features/dashboard/organisms/SettingsPolished.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsPolished.tsx
@@ -109,7 +109,7 @@ const SettingsSidebar = memo(
     useRouteLinks = false,
   }: SettingsSidebarProps) => (
     <aside className='h-fit'>
-      <div className='max-h-[calc(100vh-4.5rem)] overflow-y-auto rounded-xl border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_97%,var(--linear-bg-surface-0))] p-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur-sm'>
+      <div className='max-h-[calc(100vh-4.5rem)] overflow-y-auto rounded-xl border border-subtle bg-[color-mix(in_oklab,var(--linear-app-content-surface)_97%,var(--linear-bg-surface-0))] p-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur-sm'>
         {groups.map(group => (
           <div key={group.id} className='mb-2 last:mb-0'>
             <p className='mb-1 px-2.5 text-2xs font-medium tracking-tight text-tertiary-token'>
@@ -175,7 +175,7 @@ function MobileProfilePanelTrigger() {
     <button
       type='button'
       onClick={open}
-      className='flex w-full items-center justify-between rounded-xl border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_96%,var(--linear-bg-surface-0))] px-3 py-3 text-left transition-colors hover:bg-surface-0 active:bg-surface-1 lg:hidden'
+      className='flex w-full items-center justify-between rounded-xl border border-subtle bg-[color-mix(in_oklab,var(--linear-app-content-surface)_96%,var(--linear-bg-surface-0))] px-3 py-3 text-left transition-colors hover:bg-surface-0 active:bg-surface-1 lg:hidden'
     >
       <div>
         <p className='text-sm font-caption text-primary-token'>

--- a/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
@@ -145,11 +145,11 @@ function UsageSummaryRow({ label, value, detail }: UsageSummaryRowProps) {
 function UsageLoadingState() {
   return (
     <UsagePanelShell>
-      <div className='border-b border-(--linear-app-frame-seam) px-4 py-4 sm:px-5'>
+      <div className='border-b border-subtle px-4 py-4 sm:px-5'>
         <div className='h-4 w-32 animate-pulse rounded bg-surface-2 motion-reduce:animate-none' />
         <div className='mt-2 h-3 w-64 max-w-full animate-pulse rounded bg-surface-2 motion-reduce:animate-none' />
       </div>
-      <div className='divide-y divide-(--linear-app-frame-seam)'>
+      <div className='divide-y divide-subtle'>
         {['daily', 'monthly'].map(key => (
           <div key={key} className='px-4 py-4 sm:px-5'>
             <div className='flex justify-between gap-4'>
@@ -234,7 +234,7 @@ export function SettingsUsageStatsSection() {
 
   return (
     <UsagePanelShell>
-      <div className='flex flex-wrap items-start justify-between gap-3 border-b border-(--linear-app-frame-seam) px-4 py-4 sm:px-5'>
+      <div className='flex flex-wrap items-start justify-between gap-3 border-b border-subtle px-4 py-4 sm:px-5'>
         <div className='min-w-0 space-y-1'>
           <div className='flex flex-wrap items-center gap-2'>
             <p className='text-app font-caption text-primary-token'>
@@ -266,7 +266,7 @@ export function SettingsUsageStatsSection() {
       </div>
 
       {isStale ? (
-        <div className='border-b border-(--linear-app-frame-seam) px-4 py-3.5 sm:px-5'>
+        <div className='border-b border-subtle px-4 py-3.5 sm:px-5'>
           <div className='flex items-start gap-2 text-warning'>
             <AlertCircle className='mt-0.5 h-4 w-4 shrink-0' aria-hidden />
             <p className='text-app leading-[18px]'>
@@ -277,7 +277,7 @@ export function SettingsUsageStatsSection() {
         </div>
       ) : null}
 
-      <div className='divide-y divide-(--linear-app-frame-seam)'>
+      <div className='divide-y divide-subtle'>
         <UsageMeterRow
           title='Daily Messages'
           description='Quota for the current 24-hour window.'
@@ -298,7 +298,7 @@ export function SettingsUsageStatsSection() {
         />
       </div>
 
-      <div className='mt-auto divide-y divide-(--linear-app-frame-seam) border-t border-(--linear-app-frame-seam)'>
+      <div className='mt-auto divide-y divide-subtle border-t border-subtle'>
         <UsageSummaryRow
           label='Plan'
           value={copy.planLabel}

--- a/apps/web/components/features/dashboard/organisms/SmartActionCards.tsx
+++ b/apps/web/components/features/dashboard/organisms/SmartActionCards.tsx
@@ -39,7 +39,7 @@ function ActionCard({
       className='group flex items-center justify-between gap-3 p-3.5 transition-[background-color,border-color] duration-subtle hover:bg-surface-0'
     >
       <div className='flex items-center gap-3 min-w-0'>
-        <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token'>
+        <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-subtle bg-surface-0 text-secondary-token'>
           {icon}
         </div>
         <div className='min-w-0'>

--- a/apps/web/components/features/dashboard/organisms/account-settings/ConnectedAccountsCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/account-settings/ConnectedAccountsCard.tsx
@@ -111,7 +111,7 @@ export function ConnectedAccountsCard({ user }: ConnectedAccountsCardProps) {
               className='flex items-start justify-between gap-3 px-4 py-3 sm:px-5'
             >
               <div className='flex min-w-0 items-center gap-3'>
-                <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-(--linear-app-frame-seam) bg-surface-0'>
+                <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-subtle bg-surface-0'>
                   <Link2 className='h-4 w-4 text-secondary-token' aria-hidden />
                 </div>
                 <div className='min-w-0'>

--- a/apps/web/components/features/dashboard/organisms/account-settings/EmailManagementCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/account-settings/EmailManagementCard.tsx
@@ -101,7 +101,7 @@ export function EmailManagementCard({ user }: EmailManagementCardProps) {
                     size='sm'
                     disabled={syncingEmailId === email.id}
                     onClick={() => handleMakePrimary(email)}
-                    className='h-7 rounded-lg border border-transparent px-2.5 text-2xs font-caption text-secondary-token hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-primary-token'
+                    className='h-7 rounded-lg border border-transparent px-2.5 text-2xs font-caption text-secondary-token hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
                   >
                     {syncingEmailId === email.id ? 'Updating…' : 'Make primary'}
                   </Button>
@@ -189,7 +189,7 @@ export function EmailManagementCard({ user }: EmailManagementCardProps) {
                   variant='ghost'
                   size='sm'
                   onClick={resetEmailForm}
-                  className='h-7 rounded-lg border border-transparent px-2.5 text-2xs font-caption text-secondary-token hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-primary-token'
+                  className='h-7 rounded-lg border border-transparent px-2.5 text-2xs font-caption text-secondary-token hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
                 >
                   Cancel
                 </Button>

--- a/apps/web/components/features/dashboard/organisms/artist-selection-form/ArtistSelectionForm.tsx
+++ b/apps/web/components/features/dashboard/organisms/artist-selection-form/ArtistSelectionForm.tsx
@@ -66,7 +66,7 @@ export function ArtistSelectionForm() {
             )}
 
             {/* Form Card */}
-            <div className='rounded-lg border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-6 transition-colors'>
+            <div className='rounded-lg border border-subtle bg-(--linear-app-content-surface) p-6 transition-colors'>
               <form onSubmit={handleSubmit} className='space-y-6'>
                 <div>
                   <Combobox
@@ -147,7 +147,7 @@ export function ArtistSelectionForm() {
                     variant='secondary'
                     className='w-full'
                   >
-                    Skip for Now
+                    Skip For Now
                   </Button>
                 </div>
               </form>

--- a/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberActivityFeed.tsx
+++ b/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberActivityFeed.tsx
@@ -37,7 +37,7 @@ export function AudienceMemberActivityFeed({
   return (
     <div className='relative'>
       <div
-        className='absolute top-2.5 bottom-2.5 left-3 w-px bg-(--linear-border-subtle)'
+        className='absolute top-2.5 bottom-2.5 left-3 w-px bg-subtle'
         aria-hidden='true'
       />
 

--- a/apps/web/components/features/dashboard/organisms/contact-mode/ContactMode.tsx
+++ b/apps/web/components/features/dashboard/organisms/contact-mode/ContactMode.tsx
@@ -58,7 +58,7 @@ const ContactListItem = memo(function ContactListItem({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <ContentSurfaceCard className='group flex items-center justify-between gap-4 px-4 py-3 transition-[background-color,border-color,box-shadow] duration-subtle ease-subtle hover:border-default hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'>
+        <ContentSurfaceCard className='group flex items-center justify-between gap-4 px-4 py-3 transition-[background-color,border-color,box-shadow] duration-subtle ease-subtle hover:border-default hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-base'>
           <div className='min-w-0 flex-1'>
             <div className='flex items-center gap-2'>
               <p className='text-app font-caption text-primary-token'>
@@ -82,7 +82,7 @@ const ContactListItem = memo(function ContactListItem({
                   size='sm'
                   variant='ghost'
                   asChild
-                  className='h-8 w-8 p-0 text-tertiary-token transition-[color,background-color] duration-subtle ease-subtle hover:bg-surface-2 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/50 focus-visible:ring-offset-1'
+                  className='h-8 w-8 p-0 text-tertiary-token transition-[color,background-color] duration-subtle ease-subtle hover:bg-surface-2 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:ring-offset-1'
                   title={`Email ${contact.email}`}
                 >
                   <a href={emailHref ?? '#'}>
@@ -96,7 +96,7 @@ const ContactListItem = memo(function ContactListItem({
                   size='sm'
                   variant='ghost'
                   asChild
-                  className='h-8 w-8 p-0 text-tertiary-token transition-[color,background-color] duration-subtle ease-subtle hover:bg-surface-2 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/50 focus-visible:ring-offset-1'
+                  className='h-8 w-8 p-0 text-tertiary-token transition-[color,background-color] duration-subtle ease-subtle hover:bg-surface-2 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:ring-offset-1'
                   title={`Call ${contact.phone}`}
                 >
                   <a href={phoneHref ?? '#'}>
@@ -169,7 +169,7 @@ export function ContactMode({
       <div className='flex h-full flex-col items-center justify-center gap-3 px-4 text-center'>
         <p className='text-secondary-token'>Unable to load contacts</p>
         <Button size='sm' variant='secondary' onClick={() => router.refresh()}>
-          Try again
+          Try Again
         </Button>
       </div>
     );
@@ -184,7 +184,7 @@ export function ContactMode({
           variant='secondary'
           onClick={() => router.push(APP_ROUTES.SETTINGS_CONTACTS)}
         >
-          Add contacts
+          Add Contacts
         </Button>
       </div>
     );
@@ -211,14 +211,14 @@ export function ContactMode({
         </div>
       </div>
 
-      <div className='border-t border-(--linear-app-frame-seam) p-4'>
+      <div className='border-t border-subtle p-4'>
         <Button
           size='sm'
           variant='ghost'
           onClick={() => router.push(APP_ROUTES.SETTINGS_CONTACTS)}
           className='w-full text-app text-secondary-token'
         >
-          Manage contacts
+          Manage Contacts
         </Button>
       </div>
     </ContentSurfaceCard>

--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx
@@ -304,13 +304,13 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
             <>
               <DrawerSection title='Role' className='space-y-2' surface='card'>
                 <Label className='text-app text-secondary-token'>
-                  Contact type
+                  Contact Type
                 </Label>
                 <Select value={contact.role} onValueChange={handleRoleChange}>
-                  <SelectTrigger className='h-8 rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 text-app'>
+                  <SelectTrigger className='h-8 rounded-lg border border-subtle bg-surface-0 px-2.5 text-app'>
                     <SelectValue>{roleLabel}</SelectValue>
                   </SelectTrigger>
-                  <SelectContent className='rounded-lg border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-1'>
+                  <SelectContent className='rounded-lg border-subtle bg-(--linear-app-content-surface) p-1'>
                     {CONTACT_ROLE_OPTIONS.map(option => (
                       <SelectItem
                         key={option.value}
@@ -372,18 +372,18 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
                 >
                   <div className='space-y-2'>
                     <Label className='text-app text-secondary-token'>
-                      Default action
+                      Default Action
                     </Label>
                     <Select
                       value={contact.preferredChannel || ''}
                       onValueChange={handlePreferredChannelChange}
                     >
-                      <SelectTrigger className='h-8 rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 text-app'>
+                      <SelectTrigger className='h-8 rounded-lg border border-subtle bg-surface-0 px-2.5 text-app'>
                         <SelectValue placeholder='Select preferred channel'>
                           {getPreferredChannelLabel(contact.preferredChannel)}
                         </SelectValue>
                       </SelectTrigger>
-                      <SelectContent className='rounded-lg border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-1'>
+                      <SelectContent className='rounded-lg border-subtle bg-(--linear-app-content-surface) p-1'>
                         <SelectItem value='email'>Email</SelectItem>
                         <SelectItem value='phone'>Phone</SelectItem>
                       </SelectContent>
@@ -425,10 +425,10 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
                         aria-pressed={isSelected}
                         title={territory}
                         className={cn(
-                          'inline-flex h-6 max-w-full shrink-0 items-center whitespace-nowrap rounded-md border px-2 text-2xs font-caption leading-none transition-[background-color,border-color,color] duration-subtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+                          'inline-flex h-6 max-w-full shrink-0 items-center whitespace-nowrap rounded-md border px-2 text-2xs font-caption leading-none transition-[background-color,border-color,color] duration-subtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
                           isSelected
                             ? 'border-(--linear-border-focus)/35 bg-surface-1 text-primary-token'
-                            : 'border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token hover:bg-surface-1 hover:text-primary-token'
+                            : 'border-subtle bg-surface-0 text-secondary-token hover:bg-surface-1 hover:text-primary-token'
                         )}
                       >
                         {territory}
@@ -448,7 +448,7 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
 
           {/* Saving indicator */}
           {contact.isSaving && (
-            <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-3 py-2 text-center text-app text-tertiary-token'>
+            <div className='rounded-lg border border-subtle bg-surface-0 px-3 py-2 text-center text-app text-tertiary-token'>
               Saving...
             </div>
           )}

--- a/apps/web/components/features/dashboard/organisms/dashboard-activity-feed/DashboardActivityFeed.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-activity-feed/DashboardActivityFeed.tsx
@@ -99,11 +99,11 @@ const ActivityItem = memo(function ActivityItem({
       <li className='relative'>
         <div
           aria-hidden='true'
-          className='absolute left-3 top-0 bottom-0 w-px bg-(--linear-border-subtle)'
+          className='absolute left-3 top-0 bottom-0 w-px bg-subtle'
         />
         <Link
           href={activity.href}
-          className='group relative flex items-start gap-2.5 rounded-md px-1.5 py-1.5 transition-[background-color] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+          className='group relative flex items-start gap-2.5 rounded-md px-1.5 py-1.5 transition-[background-color] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-base'
         >
           {content}
         </Link>
@@ -115,7 +115,7 @@ const ActivityItem = memo(function ActivityItem({
     <li className='relative'>
       <div
         aria-hidden='true'
-        className='absolute left-3 top-0 bottom-0 w-px bg-(--linear-border-subtle)'
+        className='absolute left-3 top-0 bottom-0 w-px bg-subtle'
       />
       <div className='group relative flex items-start gap-2.5 rounded-md px-1.5 py-1.5'>
         {content}

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell.tsx
@@ -53,7 +53,7 @@ export function AudienceTableLoadingShell() {
       <div className='flex-1 min-h-0 overflow-hidden bg-(--linear-app-content-surface)'>
         <div className='flex h-full min-h-0 flex-col'>
           <div className='flex-1 min-h-0 overflow-hidden sm:hidden'>
-            <div className='divide-y divide-(--linear-border-subtle)'>
+            <div className='divide-y divide-subtle'>
               {AUDIENCE_MOBILE_ROW_KEYS.map(key => (
                 <div key={key} className='flex items-center gap-3 px-4 py-3'>
                   <LoadingSkeleton

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
@@ -133,10 +133,7 @@ const MobileCardList = memo(function MobileCardList({
   return (
     <div className='md:hidden h-full overflow-auto'>
       {rows.map(member => (
-        <div
-          key={member.id}
-          className='border-b border-(--linear-app-frame-seam)'
-        >
+        <div key={member.id} className='border-b border-subtle'>
           <AudienceMobileCard
             member={member}
             mode={mode}

--- a/apps/web/components/features/dashboard/organisms/dsp-matches/ConfirmMatchDialog.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-matches/ConfirmMatchDialog.tsx
@@ -87,7 +87,7 @@ export function ConfirmMatchDialog({
   return (
     <Dialog open={open} onClose={onClose} size='md'>
       <DialogTitle className='flex items-center gap-3'>
-        <div className='flex h-8 w-8 items-center justify-center rounded-lg border border-(--linear-app-frame-seam) bg-surface-0'>
+        <div className='flex h-8 w-8 items-center justify-center rounded-lg border border-subtle bg-surface-0'>
           <Icon name='Link2' className='h-4 w-4 text-secondary-token' />
         </div>
         <span>Confirm artist match</span>
@@ -115,7 +115,7 @@ export function ConfirmMatchDialog({
                 unoptimized={isExternalDspImage(externalArtistImageUrl)}
               />
             ) : (
-              <div className='flex h-16 w-16 items-center justify-center rounded-lg border border-(--linear-app-frame-seam) bg-surface-0'>
+              <div className='flex h-16 w-16 items-center justify-center rounded-lg border border-subtle bg-surface-0'>
                 <DspProviderIcon provider={providerId} size='lg' />
               </div>
             )}
@@ -131,7 +131,7 @@ export function ConfirmMatchDialog({
                     href={externalArtistUrl}
                     target='_blank'
                     rel='noopener noreferrer'
-                    className='flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-transparent text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-primary-token'
+                    className='flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-transparent text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
                   >
                     <Icon name='ExternalLink' className='h-4 w-4' />
                   </a>
@@ -144,7 +144,7 @@ export function ConfirmMatchDialog({
 
               <div className='mt-2 flex flex-wrap items-center gap-2'>
                 <ConfidenceBadge score={confidenceScore} size='md' showLabel />
-                <span className='rounded-md border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs font-caption text-secondary-token'>
+                <span className='rounded-md border border-subtle bg-surface-0 px-1.5 py-0.5 text-3xs font-caption text-secondary-token'>
                   {matchingIsrcCount} matching ISRCs
                 </span>
               </div>

--- a/apps/web/components/features/dashboard/organisms/dsp-matches/DspMatchList.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-matches/DspMatchList.tsx
@@ -156,7 +156,7 @@ export function DspMatchList({ profileId, className }: DspMatchListProps) {
                 <span className='inline-flex items-center gap-1.5'>
                   <span>{filter.label}</span>
                   {count > 0 && (
-                    <span className='rounded-md border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs text-secondary-token tabular-nums'>
+                    <span className='rounded-md border border-subtle bg-surface-0 px-1.5 py-0.5 text-3xs text-secondary-token tabular-nums'>
                       {count}
                     </span>
                   )}

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceCard.tsx
@@ -32,9 +32,9 @@ export function DspPresenceCard({
     <ContentSurfaceCard
       className={cn(
         'cursor-pointer p-3.5 transition-[border-color,background-color,box-shadow] duration-subtle',
-        'bg-[color-mix(in_oklab,var(--linear-bg-surface-0)_94%,transparent)] hover:border-default hover:bg-(--linear-bg-surface-0)',
+        'bg-[color-mix(in_oklab,var(--linear-bg-surface-0)_94%,transparent)] hover:border-default hover:bg-surface-0',
         isSelected &&
-          'border-(--linear-border-focus) bg-(--linear-bg-surface-0) ring-1 ring-ring'
+          'border-(--linear-border-focus) bg-surface-0 ring-1 ring-ring'
       )}
       data-testid={`presence-card-${item.providerId}`}
     >
@@ -46,7 +46,7 @@ export function DspPresenceCard({
         <div className='flex items-start justify-between gap-2.5'>
           <div className='flex items-center gap-2.5'>
             {item.externalArtistImageUrl ? (
-              <div className='relative h-10 w-10 shrink-0 overflow-hidden rounded-full border border-subtle bg-(--linear-bg-surface-0)'>
+              <div className='relative h-10 w-10 shrink-0 overflow-hidden rounded-full border border-subtle bg-surface-0'>
                 <Image
                   src={item.externalArtistImageUrl}
                   alt={item.externalArtistName ?? label}
@@ -57,7 +57,7 @@ export function DspPresenceCard({
                 />
               </div>
             ) : (
-              <div className='flex h-10 w-10 items-center justify-center rounded-full border border-subtle bg-(--linear-bg-surface-0)'>
+              <div className='flex h-10 w-10 items-center justify-center rounded-full border border-subtle bg-surface-0'>
                 <DspProviderIcon provider={item.providerId} size='lg' />
               </div>
             )}

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx
@@ -77,7 +77,7 @@ const LinkCell = memo(function LinkCell({
       href={item.externalArtistUrl}
       target='_blank'
       rel='noopener noreferrer'
-      className='flex h-6 w-6 items-center justify-center rounded text-tertiary-token transition-colors duration-subtle ease-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+      className='flex h-6 w-6 items-center justify-center rounded text-tertiary-token transition-colors duration-subtle ease-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-base'
       aria-label={`View on ${label}`}
       onClick={e => e.stopPropagation()}
     >
@@ -144,7 +144,7 @@ export const DspPresenceTable = memo(function DspPresenceTable({
           'bg-[color-mix(in_oklab,var(--linear-row-selected)_24%,var(--linear-bg-surface-0))]',
           'shadow-[inset_2px_0_0_0_var(--linear-border-focus),inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_14%,var(--linear-app-frame-seam))]',
           'hover:bg-[color-mix(in_oklab,var(--linear-row-selected)_28%,var(--linear-bg-surface-0))]',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-base',
         ].join(' ');
       }
 
@@ -154,7 +154,7 @@ export const DspPresenceTable = memo(function DspPresenceTable({
         'hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_78%,transparent)]',
         'hover:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-app-frame-seam)_72%,transparent)]',
         '[&:hover_span]:text-primary-token',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-base',
       ].join(' ');
     },
     [selectedMatchId]

--- a/apps/web/components/features/dashboard/organisms/jovie-work-feed/JovieWorkFeed.tsx
+++ b/apps/web/components/features/dashboard/organisms/jovie-work-feed/JovieWorkFeed.tsx
@@ -106,11 +106,11 @@ const JovieWorkItemRow = memo(function JovieWorkItemRow({
       <li className='relative'>
         <div
           aria-hidden='true'
-          className='absolute left-3 top-0 bottom-0 w-px bg-(--linear-border-subtle)'
+          className='absolute left-3 top-0 bottom-0 w-px bg-subtle'
         />
         <Link
           href={item.href}
-          className='group relative flex items-start gap-2.5 rounded-md px-1.5 py-1.5 transition-[background-color] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+          className='group relative flex items-start gap-2.5 rounded-md px-1.5 py-1.5 transition-[background-color] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-base'
         >
           {content}
         </Link>
@@ -122,7 +122,7 @@ const JovieWorkItemRow = memo(function JovieWorkItemRow({
     <li className='relative'>
       <div
         aria-hidden='true'
-        className='absolute left-3 top-0 bottom-0 w-px bg-(--linear-border-subtle)'
+        className='absolute left-3 top-0 bottom-0 w-px bg-subtle'
       />
       <div className='group relative flex items-start gap-2.5 rounded-md px-1.5 py-1.5'>
         {content}

--- a/apps/web/components/features/dashboard/organisms/links/ChatStyleLinkList.tsx
+++ b/apps/web/components/features/dashboard/organisms/links/ChatStyleLinkList.tsx
@@ -147,7 +147,7 @@ export const ChatStyleLinkList = React.memo(function ChatStyleLinkList<
                       transform: `translateY(${virtualRow.start}px)`,
                     }}
                   >
-                    <div className='flex items-center gap-3 rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-4 py-3 opacity-60'>
+                    <div className='flex items-center gap-3 rounded-lg border border-subtle bg-surface-0 px-4 py-3 opacity-60'>
                       <div className='h-4 w-4' />
                       <div className='flex h-10 w-10 shrink-0 items-center justify-center rounded-lg skeleton' />
                       <div className='flex-1'>

--- a/apps/web/components/features/dashboard/organisms/links/IngestedSuggestions.tsx
+++ b/apps/web/components/features/dashboard/organisms/links/IngestedSuggestions.tsx
@@ -221,8 +221,8 @@ export const IngestedSuggestions = React.memo(function IngestedSuggestions({
   return (
     // biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-label needed for accessibility
     <div
-      className={`rounded-lg border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-3 py-2.5 ${className ?? ''}`}
-      aria-label='Ingested link suggestions'
+      className={`rounded-lg border border-subtle bg-(--linear-app-content-surface) px-3 py-2.5 ${className ?? ''}`}
+      aria-label='Ingested Link Suggestions'
     >
       <div className='flex flex-wrap items-center justify-center gap-2'>
         {suggestions.map(suggestion => {
@@ -256,7 +256,7 @@ export const IngestedSuggestions = React.memo(function IngestedSuggestions({
 
               <AppIconButton
                 ariaLabel={`Dismiss ${suggestion.platform.name} suggestion`}
-                className='absolute top-1/2 right-2 z-10 h-6 w-6 -translate-y-1/2 rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 text-quaternary-token hover:bg-surface-1 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/25 [&_svg]:h-3.5 [&_svg]:w-3.5'
+                className='absolute top-1/2 right-2 z-10 h-6 w-6 -translate-y-1/2 rounded-lg border border-subtle bg-surface-0 text-quaternary-token hover:bg-surface-1 hover:text-secondary-token focus-visible:ring-1 focus-visible:ring-ring/25 [&_svg]:h-3.5 [&_svg]:w-3.5'
                 onClick={event => handleDismiss(suggestion, event)}
               >
                 <X className='h-3.5 w-3.5' aria-hidden />

--- a/apps/web/components/features/dashboard/organisms/listen-now-form/ListenNowForm.tsx
+++ b/apps/web/components/features/dashboard/organisms/listen-now-form/ListenNowForm.tsx
@@ -191,7 +191,7 @@ export function ListenNowForm({ artist, onUpdate }: ListenNowFormProps) {
           Primary Streaming
         </h3>
 
-        <ContentSurfaceCard className='divide-y divide-(--linear-border-subtle) overflow-hidden bg-surface-1 p-0'>
+        <ContentSurfaceCard className='divide-y divide-subtle overflow-hidden bg-surface-1 p-0'>
           {/* Spotify row */}
           <div className='flex items-center gap-3 px-4 py-3'>
             <div
@@ -385,7 +385,7 @@ export function ListenNowForm({ artist, onUpdate }: ListenNowFormProps) {
           </ContentSurfaceCard>
         ) : (
           <div className='space-y-0'>
-            <ContentSurfaceCard className='divide-y divide-(--linear-border-subtle) overflow-hidden p-0'>
+            <ContentSurfaceCard className='divide-y divide-subtle overflow-hidden p-0'>
               {additionalLinks.map((link, index) => {
                 const meta = PLATFORM_METADATA_MAP[link.platform];
                 const dspInfo = connectedDspInfo[link.platform];

--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
@@ -100,7 +100,7 @@ export function OnboardingHandleStep({
           <div
             className={cn(
               'flex items-center gap-2 rounded-full border px-2 py-1.5 transition-[background-color,border-color,box-shadow] duration-subtle',
-              'border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,var(--linear-bg-surface-0))]',
+              'border-subtle bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,var(--linear-bg-surface-0))]',
               'hover:border-default hover:bg-surface-0',
               'focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-ring/16',
               hasError && 'border-destructive/60'

--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingNameStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingNameStep.tsx
@@ -55,10 +55,10 @@ export function OnboardingNameStep({
             value={fullName}
             onChange={e => onNameChange(e.target.value)}
             placeholder={namePlaceholder}
-            aria-label='Your full name'
+            aria-label='Your Full Name'
             maxLength={50}
             autoComplete='name'
-            className='w-full rounded-md border border-subtle bg-surface-1 px-3 py-2.5 text-primary-token placeholder:text-tertiary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-app-content-surface)'
+            className='w-full rounded-md border border-subtle bg-surface-1 px-3 py-2.5 text-primary-token placeholder:text-tertiary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-app-content-surface)'
           />
 
           <Button

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactHeader.tsx
@@ -72,7 +72,7 @@ export function ProfileContactHeader({
           }}
           displayClassName='text-app font-semibold leading-[15px] tracking-tight text-primary-token'
           emptyClassName='text-tertiary-token'
-          inputClassName='h-8 rounded-lg border-(--linear-app-frame-seam) bg-surface-0 px-2.5 text-sm font-semibold'
+          inputClassName='h-8 rounded-lg border-subtle bg-surface-0 px-2.5 text-sm font-semibold'
         />
 
         <div className='truncate text-2xs leading-[14px] tracking-[-0.005em] text-secondary-token'>

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
@@ -630,7 +630,7 @@ export function ProfileContactSidebar() {
             {[1, 2, 3, 4, 5].map(i => (
               <div
                 key={i}
-                className='flex items-center gap-3 rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-2'
+                className='flex items-center gap-3 rounded-lg border border-subtle bg-surface-0 px-2.5 py-2'
               >
                 <div className='h-8 w-8 shrink-0 rounded-lg skeleton' />
                 <div className='flex-1 h-4 rounded skeleton' />

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SidebarLinkInput.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SidebarLinkInput.tsx
@@ -178,8 +178,8 @@ export function SidebarLinkInput({
         autoCapitalize='none'
         autoCorrect='off'
         autoComplete='off'
-        className='h-9 rounded-lg border-(--linear-app-frame-seam) bg-surface-0 text-app'
-        aria-label='Add link'
+        className='h-9 rounded-lg border-subtle bg-surface-0 text-app'
+        aria-label='Add Link'
         autoFocus
       />
 
@@ -188,7 +188,7 @@ export function SidebarLinkInput({
           <div
             ref={refs.setFloating}
             style={floatingStyles}
-            className='z-100 max-h-60 overflow-y-auto overflow-x-hidden overscroll-contain rounded-lg border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) py-1 shadow-popover'
+            className='z-100 max-h-60 overflow-y-auto overflow-x-hidden overscroll-contain rounded-lg border border-subtle bg-(--linear-app-content-surface) py-1 shadow-popover'
             onMouseDown={e => e.preventDefault()}
             aria-hidden='true'
           >
@@ -209,7 +209,7 @@ export function SidebarLinkInput({
         <button
           type='button'
           onClick={handleAdd}
-          className='mt-2 flex w-full items-center gap-2 rounded-md border border-(--linear-app-frame-seam) bg-surface-0 px-3 py-2 text-app transition-colors hover:bg-surface-1'
+          className='mt-2 flex w-full items-center gap-2 rounded-md border border-subtle bg-surface-0 px-3 py-2 text-app transition-colors hover:bg-surface-1'
         >
           <SocialIcon
             platform={detectedLink.platform.icon}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/MobileReleaseList.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/MobileReleaseList.tsx
@@ -244,7 +244,7 @@ const MobileReleaseRow = memo(function MobileReleaseRow({
           lockReason={lockReason}
         />
       }
-      className='border-b border-(--linear-app-frame-seam) last:border-b-0'
+      className='border-b border-subtle last:border-b-0'
       contentClassName='bg-transparent'
     >
       <ShellListRowButton

--- a/apps/web/components/features/dashboard/organisms/releases/ReleaseEditDialog.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/ReleaseEditDialog.tsx
@@ -69,7 +69,7 @@ export function ReleaseEditDialog({
           className='h-4.5 w-4.5 text-secondary-token'
           aria-hidden='true'
         />
-        Edit release links
+        Edit Release Links
       </DialogTitle>
       <DialogDescription className='text-app text-secondary-token'>
         Swap in a preferred DSP link or revert back to our detected URL. All
@@ -81,11 +81,11 @@ export function ReleaseEditDialog({
             {/* Release info header */}
             <DrawerSurfaceCard
               variant='card'
-              className='rounded-lg border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-3.5'
+              className='rounded-lg border border-subtle bg-(--linear-app-content-surface) p-3.5'
             >
               <EntityHeaderCard
                 image={
-                  <div className='relative h-16 w-16 shrink-0 overflow-hidden rounded-lg border border-(--linear-app-frame-seam) bg-surface-0'>
+                  <div className='relative h-16 w-16 shrink-0 overflow-hidden rounded-lg border border-subtle bg-surface-0'>
                     <ImageWithFallback
                       src={release.artworkUrl}
                       alt={`${release.title} artwork`}
@@ -101,7 +101,7 @@ export function ReleaseEditDialog({
                 badge={
                   <Badge
                     variant='secondary'
-                    className='rounded-md border border-(--linear-app-frame-seam) bg-surface-1 px-2 py-0.5 text-2xs text-secondary-token'
+                    className='rounded-md border border-subtle bg-surface-1 px-2 py-0.5 text-2xs text-secondary-token'
                   >
                     {release.releaseDate
                       ? formatReleaseDateShort(release.releaseDate)
@@ -127,7 +127,7 @@ export function ReleaseEditDialog({
                   <DrawerSurfaceCard
                     key={`${release.id}-${provider.key}`}
                     variant='card'
-                    className='rounded-lg border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-2.5'
+                    className='rounded-lg border border-subtle bg-(--linear-app-content-surface) p-2.5'
                   >
                     <div className='flex items-center justify-between gap-2'>
                       <div className='flex items-center gap-2'>
@@ -191,7 +191,7 @@ export function ReleaseEditDialog({
           </div>
         ) : null}
       </DialogBody>
-      <DialogActions className='justify-end border-t border-(--linear-app-frame-seam) pt-4'>
+      <DialogActions className='justify-end border-t border-subtle pt-4'>
         <DrawerButton
           onClick={onClose}
           className='h-7 rounded-lg px-2.5 text-2xs'

--- a/apps/web/components/features/dashboard/organisms/releases/cells/AvailabilityCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/AvailabilityCell.tsx
@@ -208,7 +208,7 @@ export const AvailabilityCell = memo(function AvailabilityCell({
           aria-label='Show Provider Availability Details'
           aria-haspopup='listbox'
           aria-expanded={open}
-          className='inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_82%,var(--linear-bg-surface-0))] px-1.5 py-1 text-xs font-normal tracking-tight text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-subtle hover:border-default hover:bg-surface-1 hover:text-primary-token focus-visible:border-(--color-accent) focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)'
+          className='inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-subtle bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_82%,var(--linear-bg-surface-0))] px-1.5 py-1 text-xs font-normal tracking-tight text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-subtle hover:border-default hover:bg-surface-1 hover:text-primary-token focus-visible:border-(--color-accent) focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)'
         >
           <CompactLinkRail
             items={compactProviders.map(providerKey => ({
@@ -244,9 +244,9 @@ export const AvailabilityCell = memo(function AvailabilityCell({
 
       <PopoverContent
         align='end'
-        className='w-80 rounded-xl border border-(--linear-app-frame-seam) bg-surface-1 p-0 shadow-popover'
+        className='w-80 rounded-xl border border-subtle bg-surface-1 p-0 shadow-popover'
       >
-        <div className='border-b border-(--linear-app-frame-seam) px-3 py-2'>
+        <div className='border-b border-subtle px-3 py-2'>
           <p className='text-xs font-caption tracking-tight text-primary-token'>
             Platform Availability
           </p>
@@ -267,7 +267,7 @@ export const AvailabilityCell = memo(function AvailabilityCell({
             return (
               <div
                 key={providerKey}
-                className='flex min-h-9 items-center justify-between border-b border-(--linear-app-frame-seam) px-3 py-1.5 last:border-b-0'
+                className='flex min-h-9 items-center justify-between border-b border-subtle px-3 py-1.5 last:border-b-0'
               >
                 <div className='flex min-w-0 items-center gap-2.5'>
                   {/* Status dot with screen reader text */}
@@ -276,7 +276,7 @@ export const AvailabilityCell = memo(function AvailabilityCell({
                       className='flex h-2.5 w-2.5 items-center justify-center rounded-full bg-surface-1'
                       aria-hidden='true'
                     >
-                      <span className='h-1 w-1 rounded-full bg-(--linear-text-tertiary)' />
+                      <span className='h-1 w-1 rounded-full bg-tertiary-token' />
                     </span>
                   ) : (
                     <span
@@ -425,7 +425,7 @@ export const AvailabilityCell = memo(function AvailabilityCell({
         </div>
 
         {validationError && (
-          <div className='min-h-7 border-t border-(--linear-app-frame-seam) px-3 py-1.5'>
+          <div className='min-h-7 border-t border-subtle px-3 py-1.5'>
             <p className='text-2xs text-error'>{validationError}</p>
           </div>
         )}

--- a/apps/web/components/features/dashboard/organisms/releases/cells/PopularityCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/PopularityCell.tsx
@@ -34,7 +34,7 @@ export const PopularityCell = memo(function PopularityCell({
             className='gap-1.5 rounded-full px-1 py-0.5 text-tertiary-token'
             aria-label={`Spotify popularity ${displayPopularity} out of 100`}
           >
-            <div className='h-2 w-12 overflow-hidden rounded-full bg-(--linear-border-subtle)'>
+            <div className='h-2 w-12 overflow-hidden rounded-full bg-subtle'>
               <div
                 className='h-full rounded-full bg-brand-spotify transition-[background-color,width] duration-subtle ease-subtle'
                 style={{ width: `${clampedPopularity}%` }}

--- a/apps/web/components/features/dashboard/organisms/releases/cells/PopularityIcon.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/PopularityIcon.tsx
@@ -39,13 +39,13 @@ export const PopularityIcon = memo(function PopularityIcon({
 
   // Color mapping for each level
   const colors = {
-    low: 'bg-(--linear-text-tertiary)',
+    low: 'bg-tertiary-token',
     med: 'bg-amber-400 dark:bg-amber-300',
     high: 'bg-emerald-500 dark:bg-emerald-400',
   };
 
   const activeColor = colors[level];
-  const inactiveColor = 'bg-(--linear-border-subtle)';
+  const inactiveColor = 'bg-subtle';
 
   // Number of bars to fill based on level
   const barCounts: Record<'low' | 'med' | 'high', number> = {

--- a/apps/web/components/features/dashboard/organisms/releases/cells/SmartLinkCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/SmartLinkCell.tsx
@@ -34,7 +34,7 @@ export const SmartLinkCell = memo(function SmartLinkCell({
     return (
       <div
         className={cn(
-          'flex h-7 items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-2.5',
+          'flex h-7 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2.5',
           'text-2xs font-[430] tracking-tight text-tertiary-token select-none transition-[background-color,border-color,color] duration-subtle'
         )}
         title={

--- a/apps/web/components/features/dashboard/organisms/releases/components/AddProviderUrlPopover.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/components/AddProviderUrlPopover.tsx
@@ -91,7 +91,7 @@ export function AddProviderUrlPopover({
       </PopoverTrigger>
       <PopoverContent
         align='start'
-        className='w-70 rounded-xl border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-0 shadow-popover'
+        className='w-70 rounded-xl border border-subtle bg-(--linear-app-content-surface) p-0 shadow-popover'
         onOpenAutoFocus={e => {
           e.preventDefault();
           inputRef.current?.focus();

--- a/apps/web/components/features/dashboard/organisms/shopify/ShopifyStoreCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/shopify/ShopifyStoreCard.tsx
@@ -116,7 +116,7 @@ export const ShopifyStoreCard = memo(function ShopifyStoreCard() {
       <div className='px-4 py-2.5 sm:px-5 sm:py-3'>
         <div className='mb-2.5 flex items-center gap-2'>
           <div
-            className='flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-(--linear-app-frame-seam) bg-surface-0'
+            className='flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-subtle bg-surface-0'
             aria-hidden='true'
           >
             <ShoppingBag className='h-3.5 w-3.5 text-secondary-token' />
@@ -188,7 +188,7 @@ export const ShopifyStoreCard = memo(function ShopifyStoreCard() {
               disabled={saveState === 'saving'}
               variant='ghost'
               size='sm'
-              className='h-7 rounded-lg border border-transparent px-2.5 text-2xs font-caption text-secondary-token hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-primary-token'
+              className='h-7 rounded-lg border border-transparent px-2.5 text-2xs font-caption text-secondary-token hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
             >
               Disconnect
             </Button>
@@ -200,7 +200,7 @@ export const ShopifyStoreCard = memo(function ShopifyStoreCard() {
             href={shopPageUrl}
             target='_blank'
             rel='noopener noreferrer'
-            className='inline-flex items-center gap-1.5 rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1.5 text-xs font-caption text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token'
+            className='inline-flex items-center gap-1.5 rounded-lg border border-subtle bg-surface-0 px-2.5 py-1.5 text-xs font-caption text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token'
           >
             <ExternalLink className='h-3 w-3' />
             Preview shop link

--- a/apps/web/components/features/dashboard/organisms/socials-form/SocialLinkSuggestionRows.tsx
+++ b/apps/web/components/features/dashboard/organisms/socials-form/SocialLinkSuggestionRows.tsx
@@ -26,7 +26,7 @@ export function SocialLinkSuggestionRows({
       <p className='text-app font-caption text-secondary-token'>
         Detected profiles
       </p>
-      <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-0 divide-y divide-(--linear-border-subtle)'>
+      <div className='rounded-lg border border-subtle bg-surface-0 divide-y divide-subtle'>
         {suggestions.map(suggestion => {
           const isActioning = actioningId === suggestion.id;
 

--- a/apps/web/components/features/dashboard/organisms/socials-form/SocialsForm.tsx
+++ b/apps/web/components/features/dashboard/organisms/socials-form/SocialsForm.tsx
@@ -109,7 +109,7 @@ const SOCIAL_PLATFORM_GROUPS = [
     ),
   },
   {
-    label: 'All supported platforms',
+    label: 'All Supported Platforms',
     platforms: SOCIAL_LINK_PLATFORM_CANDIDATES.filter(
       platform =>
         !SUGGESTED_PLATFORM_SET.has(platform.id) &&
@@ -273,7 +273,7 @@ export function SocialsForm({ artist }: Readonly<SocialsFormProps>) {
 
   if (loading) {
     return (
-      <ContentSurfaceCard className='divide-y divide-(--linear-border-subtle) overflow-hidden p-0'>
+      <ContentSurfaceCard className='divide-y divide-subtle overflow-hidden p-0'>
         {SOCIALS_FORM_LOADING_KEYS.map(key => (
           <div key={key} className='flex items-center gap-3 px-4 py-3'>
             <div className='h-8 w-8 rounded-md skeleton shrink-0' />
@@ -316,7 +316,7 @@ export function SocialsForm({ artist }: Readonly<SocialsFormProps>) {
         </div>
       ) : (
         <form onSubmit={handleSubmit} className='space-y-0'>
-          <ContentSurfaceCard className='divide-y divide-(--linear-border-subtle) overflow-hidden p-0'>
+          <ContentSurfaceCard className='divide-y divide-subtle overflow-hidden p-0'>
             {socialLinks.map((link, index) => (
               <div
                 key={link.id || `new-${index}`}

--- a/apps/web/components/features/dashboard/organisms/table/TableToolbar.tsx
+++ b/apps/web/components/features/dashboard/organisms/table/TableToolbar.tsx
@@ -53,7 +53,7 @@ export function TableToolbar({
   return (
     <div
       className={cn(
-        'flex items-center justify-between gap-3 border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-3.5 py-2',
+        'flex items-center justify-between gap-3 border-b border-subtle bg-(--linear-app-content-surface) px-3.5 py-2',
         className
       )}
     >
@@ -65,7 +65,7 @@ export function TableToolbar({
             onCheckedChange={checked => {
               checked ? onSelectAll() : onDeselectAll();
             }}
-            aria-label='Select all rows'
+            aria-label='Select All Rows'
           />
         )}
 

--- a/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
@@ -496,7 +496,7 @@ export function TourDateSidebar({
                           'flex-1 rounded-full border px-3 py-2 text-xs font-caption transition-[background-color,border-color,color] duration-subtle',
                           formData.ticketStatus === status
                             ? 'border-accent/35 bg-accent/10 text-accent'
-                            : 'border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token hover:bg-surface-1 hover:text-primary-token'
+                            : 'border-subtle bg-surface-0 text-secondary-token hover:bg-surface-1 hover:text-primary-token'
                         )}
                       >
                         {status === 'available' && 'On Sale'}

--- a/apps/web/components/features/dashboard/release-tasks/MetadataAgentPanel.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/MetadataAgentPanel.tsx
@@ -328,7 +328,7 @@ export function MetadataAgentPanel({
   }
 
   return (
-    <section className='mb-6 rounded-xl border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-4'>
+    <section className='mb-6 rounded-xl border border-subtle bg-(--linear-app-content-surface) p-4'>
       <div className='flex flex-col gap-2 md:flex-row md:items-start md:justify-between'>
         <div>
           <p className='text-2xs font-medium text-tertiary-token'>
@@ -343,13 +343,13 @@ export function MetadataAgentPanel({
           </p>
         </div>
 
-        <div className='rounded-full border border-(--linear-app-frame-seam) px-3 py-1 text-xs font-medium text-secondary-token'>
+        <div className='rounded-full border border-subtle px-3 py-1 text-xs font-medium text-secondary-token'>
           {currentStatusLabel}
         </div>
       </div>
 
       <div className='mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4'>
-        <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-1 p-3'>
+        <div className='rounded-lg border border-subtle bg-surface-1 p-3'>
           <p className='text-2xs font-medium text-tertiary-token'>
             Source Of Truth
           </p>
@@ -360,7 +360,7 @@ export function MetadataAgentPanel({
           </p>
         </div>
 
-        <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-1 p-3'>
+        <div className='rounded-lg border border-subtle bg-surface-1 p-3'>
           <p className='text-2xs font-medium text-tertiary-token'>
             Destinations
           </p>
@@ -376,7 +376,7 @@ export function MetadataAgentPanel({
           </p>
         </div>
 
-        <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-1 p-3'>
+        <div className='rounded-lg border border-subtle bg-surface-1 p-3'>
           <p className='text-2xs font-medium text-tertiary-token'>Review</p>
           <p className='mt-2 text-sm text-primary-token'>{reviewLabel}</p>
           <p className='mt-1 text-xs text-secondary-token'>
@@ -384,7 +384,7 @@ export function MetadataAgentPanel({
           </p>
         </div>
 
-        <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-1 p-3'>
+        <div className='rounded-lg border border-subtle bg-surface-1 p-3'>
           <p className='text-2xs font-medium text-tertiary-token'>Tracking</p>
           <p className='mt-2 text-sm text-primary-token'>{trackingLabel}</p>
           <p className='mt-1 text-xs text-secondary-token'>
@@ -416,7 +416,7 @@ export function MetadataAgentPanel({
                 void handleApproveSend();
               }}
               disabled={actionState === 'loading' || isPending}
-              className='rounded-md border border-(--linear-app-frame-seam) px-3 py-2 text-sm font-medium text-primary-token disabled:cursor-not-allowed disabled:opacity-60'
+              className='rounded-md border border-subtle px-3 py-2 text-sm font-medium text-primary-token disabled:cursor-not-allowed disabled:opacity-60'
             >
               Approve And Send
             </button>
@@ -429,7 +429,7 @@ export function MetadataAgentPanel({
                 void handleDraftCorrection();
               }}
               disabled={actionState === 'loading' || isPending}
-              className='rounded-md border border-(--linear-app-frame-seam) px-3 py-2 text-sm font-medium text-primary-token disabled:cursor-not-allowed disabled:opacity-60'
+              className='rounded-md border border-subtle px-3 py-2 text-sm font-medium text-primary-token disabled:cursor-not-allowed disabled:opacity-60'
             >
               Draft Correction
             </button>
@@ -468,7 +468,7 @@ export function MetadataAgentPanel({
 
       {latestRequest && (
         <div className='mt-4 grid gap-4 lg:grid-cols-2'>
-          <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-1 p-3'>
+          <div className='rounded-lg border border-subtle bg-surface-1 p-3'>
             <p className='text-2xs font-medium text-tertiary-token'>Timeline</p>
             <div className='mt-2 space-y-2 text-sm text-primary-token'>
               <p>Prepared: {formatTimestamp(latestRequest.createdAt)}</p>
@@ -490,7 +490,7 @@ export function MetadataAgentPanel({
             ) : null}
           </div>
 
-          <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-1 p-3'>
+          <div className='rounded-lg border border-subtle bg-surface-1 p-3'>
             <p className='text-2xs font-medium text-tertiary-token'>
               Tracking State
             </p>
@@ -502,7 +502,7 @@ export function MetadataAgentPanel({
                       href={target.canonicalUrl}
                       target='_blank'
                       rel='noreferrer'
-                      className='underline decoration-(--linear-app-frame-seam) underline-offset-2'
+                      className='underline decoration-subtle underline-offset-2'
                     >
                       {formatStatusLabel(target.targetType)}
                     </a>

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
@@ -45,7 +45,7 @@ export const ReleaseTaskCompactRow = React.memo(function ReleaseTaskCompactRow({
         type='button'
         onClick={() => onNavigate(task.id)}
         className={cn(
-          'flex-1 text-left text-2xs truncate transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none',
+          'flex-1 text-left text-2xs truncate transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-base outline-none',
           isAi ? 'opacity-70' : 'hover:text-accent'
         )}
       >

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskEmptyState.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskEmptyState.tsx
@@ -17,7 +17,7 @@ export function ReleaseTaskEmptyState({
   isLoading,
 }: ReleaseTaskEmptyStateProps) {
   return (
-    <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-1'>
+    <div className='rounded-lg border border-subtle bg-surface-1'>
       <EmptyState
         icon={<ListChecks className='h-5 w-5' aria-hidden='true' />}
         heading='Your Release Playbook'

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskExplainerPopover.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskExplainerPopover.tsx
@@ -25,7 +25,7 @@ export function ReleaseTaskExplainerPopover({
         <button
           type='button'
           className='flex-shrink-0 rounded p-0.5 text-tertiary-token opacity-60 hover:opacity-100 hover:bg-surface-1 transition-opacity'
-          aria-label='Task info'
+          aria-label='Task Info'
         >
           <Info className='h-3.5 w-3.5' />
         </button>
@@ -34,7 +34,7 @@ export function ReleaseTaskExplainerPopover({
         align='end'
         side='top'
         sideOffset={4}
-        className='w-72 rounded-lg border border-(--linear-app-frame-seam) bg-surface-1 p-3 shadow-lg'
+        className='w-72 rounded-lg border border-subtle bg-surface-1 p-3 shadow-lg'
       >
         <p className='text-2xs leading-relaxed text-secondary-token'>
           {explainerText}

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPastReleaseState.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPastReleaseState.tsx
@@ -10,7 +10,7 @@ export function ReleaseTaskPastReleaseState({
   isLoading,
 }: ReleaseTaskPastReleaseStateProps) {
   return (
-    <div className='flex min-h-45 flex-col items-center justify-center rounded-lg border border-(--linear-app-frame-seam) bg-surface-1 px-4 py-10 text-center'>
+    <div className='flex min-h-45 flex-col items-center justify-center rounded-lg border border-subtle bg-surface-1 px-4 py-10 text-center'>
       <p className='text-sm font-medium text-secondary-token mb-1'>
         This release is already out
       </p>

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRowPrimitives.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRowPrimitives.tsx
@@ -46,7 +46,7 @@ export function ReleaseTaskCheckbox({
       disabled={isAutomated}
       onChange={() => onToggle(task.id, !isDone)}
       className={cn(
-        'flex-shrink-0 rounded accent-accent cursor-pointer disabled:cursor-default disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-bg-page) outline-none transition-[box-shadow] duration-subtle ease-subtle',
+        'flex-shrink-0 rounded accent-accent cursor-pointer disabled:cursor-default disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-1 focus-visible:ring-offset-base outline-none transition-[box-shadow] duration-subtle ease-subtle',
         className
       )}
       aria-label={`Mark "${task.title}" as ${isDone ? 'incomplete' : 'complete'}`}

--- a/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
@@ -345,7 +345,7 @@ function SortableTaskBoardCard({
         {...listeners}
         data-testid={`task-board-card-${task.id}`}
         onClick={() => onOpenTask(task)}
-        className='block w-full cursor-grab text-left active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+        className='block w-full cursor-grab text-left active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-base'
       >
         <TaskBoardCard
           task={task}

--- a/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
@@ -233,7 +233,7 @@ export const TaskListRow = memo(function TaskListRow({
                 event.stopPropagation();
                 onOpenRelease(task);
               }}
-              className='inline-flex min-w-0 max-w-full items-center gap-1 text-secondary-token transition-colors duration-subtle ease-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) focus-visible:text-primary-token'
+              className='inline-flex min-w-0 max-w-full items-center gap-1 text-secondary-token transition-colors duration-subtle ease-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-base focus-visible:text-primary-token'
               title={task.releaseTitle}
             >
               <Disc3 className='h-3 w-3 shrink-0 text-tertiary-token' />

--- a/apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx
@@ -32,7 +32,7 @@ function TasksUpgradeContent({
       className={cn(
         'mx-auto flex w-full flex-col items-center justify-center text-center',
         compact
-          ? 'rounded-2xl border border-(--linear-app-frame-seam) bg-surface-1 px-5 py-8'
+          ? 'rounded-2xl border border-subtle bg-surface-1 px-5 py-8'
           : 'max-w-xl rounded-3xl border border-subtle bg-surface-1 px-8 py-14'
       )}
       data-testid={testId}

--- a/apps/web/components/features/dashboard/tokens/card-tokens.ts
+++ b/apps/web/components/features/dashboard/tokens/card-tokens.ts
@@ -154,7 +154,7 @@ export const cardTokens = {
     // Elevated card — shared card surface inside the shell
     elevated: tw`
       bg-surface-1
-      border border-(--linear-app-frame-seam)
+      border border-subtle
       rounded-xl
       p-4 sm:p-6
       transition-[background-color,border-color] ${timing.slow} ${timing.easing}
@@ -163,7 +163,7 @@ export const cardTokens = {
     // Floating card — shared card surface with seam border
     floating: tw`
       bg-surface-1
-      border border-(--linear-app-frame-seam)
+      border border-subtle
       rounded-xl
       p-4 sm:p-6
       transition-[background-color,border-color] ${timing.slow} ${timing.easing}
@@ -173,7 +173,7 @@ export const cardTokens = {
     onboarding: tw`
       relative
       bg-surface-1
-      border border-(--linear-app-frame-seam)
+      border border-subtle
       rounded-2xl
       transition-[background-color,border-color] ${timing.slow} ${timing.easing}
     `,
@@ -181,7 +181,7 @@ export const cardTokens = {
     // Feature card — shared card surface with seam border
     feature: tw`
       bg-surface-1
-      border border-(--linear-app-frame-seam)
+      border border-subtle
       rounded-2xl
       p-6 sm:p-8
       transition-[background-color,border-color] ${timing.slow} ${timing.easing}

--- a/apps/web/components/features/dashboard/tokens/mobile-tokens.ts
+++ b/apps/web/components/features/dashboard/tokens/mobile-tokens.ts
@@ -6,7 +6,7 @@
  * spacing/typography can evolve consistently without inline class drift.
  */
 export const mobileReleaseTokens = {
-  list: 'overflow-hidden rounded-2xl border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface)',
+  list: 'overflow-hidden rounded-2xl border border-subtle bg-(--linear-app-content-surface)',
   row: {
     container:
       'flex w-full items-center gap-3 px-4 py-3 text-left transition-[background-color,border-color] active:bg-surface-0 focus-visible:outline-none focus-visible:bg-surface-0',
@@ -21,7 +21,7 @@ export const mobileReleaseTokens = {
     dot: 'text-3xs text-quaternary-token',
   },
   groupHeader:
-    'sticky top-0 z-10 flex items-center justify-between border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-4 py-2',
+    'sticky top-0 z-10 flex items-center justify-between border-b border-subtle bg-(--linear-app-content-surface) px-4 py-2',
   groupHeaderTitle: 'text-xs font-semibold text-primary-token',
   groupHeaderCount: 'text-2xs tabular-nums text-tertiary-token',
   footer: {

--- a/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx
+++ b/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx
@@ -436,7 +436,7 @@ describe('ShellReleasesView', () => {
       })
     );
     fireEvent.click(
-      screen.getAllByRole('button', { name: 'Edit release links' })[0]
+      screen.getAllByRole('button', { name: 'Edit Release Links' })[0]
     );
 
     expect(await screen.findByTestId('release-sidebar')).toHaveTextContent(

--- a/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx
+++ b/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx
@@ -436,7 +436,7 @@ describe('ShellReleasesView', () => {
       })
     );
     fireEvent.click(
-      screen.getAllByRole('button', { name: 'Edit Release Links' })[0]
+      screen.getAllByRole('button', { name: 'Edit release links' })[0]
     );
 
     expect(await screen.findByTestId('release-sidebar')).toHaveTextContent(

--- a/apps/web/tests/components/releases/ReleaseEditDialog.test.tsx
+++ b/apps/web/tests/components/releases/ReleaseEditDialog.test.tsx
@@ -149,7 +149,7 @@ describe('ReleaseEditDialog', () => {
       />
     );
 
-    expect(screen.getByText('Edit release links')).toBeInTheDocument();
+    expect(screen.getByText('Edit Release Links')).toBeInTheDocument();
     expect(screen.getByText('Skyline Dreams')).toBeInTheDocument();
     expect(screen.getByText('Manual')).toBeInTheDocument();
     expect(

--- a/apps/web/tests/components/releases/release-actions.test.tsx
+++ b/apps/web/tests/components/releases/release-actions.test.tsx
@@ -87,7 +87,7 @@ describe('buildReleaseActions', () => {
 
     expect(items[0]).toMatchObject({
       id: 'edit',
-      label: 'Edit Release Links',
+      label: 'Edit release links',
     });
     expect(items[1]).toEqual({ type: 'separator' });
     expect(separators).toHaveLength(1);

--- a/apps/web/tests/components/releases/release-actions.test.tsx
+++ b/apps/web/tests/components/releases/release-actions.test.tsx
@@ -87,7 +87,7 @@ describe('buildReleaseActions', () => {
 
     expect(items[0]).toMatchObject({
       id: 'edit',
-      label: 'Edit release links',
+      label: 'Edit Release Links',
     });
     expect(items[1]).toEqual({ type: 'separator' });
     expect(separators).toHaveLength(1);

--- a/apps/web/tests/unit/dashboard/ProfileContactSidebar.scroll.test.tsx
+++ b/apps/web/tests/unit/dashboard/ProfileContactSidebar.scroll.test.tsx
@@ -180,7 +180,7 @@ describe('ProfileContactSidebar scroll contract', () => {
     const scrollRegion = screen.getByTestId(
       'profile-contact-tabbed-card-scroll-region'
     );
-    const linkInput = screen.getByRole('textbox', { name: 'Add link' });
+    const linkInput = screen.getByRole('textbox', { name: 'Add Link' });
     expect(tabbedCard).toHaveClass('min-h-0', 'flex-1', 'overflow-hidden');
     const rerenderState = () => {
       view.rerender(<ProfileContactSidebar />);

--- a/apps/web/tests/unit/dashboard/chat-social-actions-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/chat-social-actions-system-b-style-guard.test.ts
@@ -57,8 +57,8 @@ describe('chat social add action System B source contract', () => {
       ).not.toMatch(pattern);
     }
 
-    expect(source).toContain('border-(--linear-app-frame-seam)');
+    expect(source).toContain('border-subtle');
     expect(source).toContain('bg-surface-0');
-    expect(source).toContain('divide-(--linear-border-subtle)');
+    expect(source).toContain('divide-subtle');
   });
 });

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1967
+  "count": 1775
 }

--- a/apps/web/tests/unit/links/IngestedSuggestions.render.test.tsx
+++ b/apps/web/tests/unit/links/IngestedSuggestions.render.test.tsx
@@ -33,7 +33,7 @@ describe('IngestedSuggestions - rendering', () => {
     );
 
     expect(
-      screen.getByLabelText('Ingested link suggestions')
+      screen.getByLabelText('Ingested Link Suggestions')
     ).toBeInTheDocument();
   });
 
@@ -79,7 +79,7 @@ describe('IngestedSuggestions - rendering', () => {
       />
     );
 
-    const container = screen.getByLabelText('Ingested link suggestions');
+    const container = screen.getByLabelText('Ingested Link Suggestions');
     expect(container).toHaveClass('custom-class');
   });
 


### PR DESCRIPTION
## Summary
Dashboard-only lane of the `--linear-*` paren-form → semantic token migration (follow-up to #14538 / #13988 lane 5).

Exact className string replacements for colors/surfaces/text/borders where semantic utilities are established:

| From | To | Occurrences |
|------|-----|-------------|
| `border-(--linear-app-frame-seam)` | `border-subtle` | ~143 |
| `divide-(--linear-app-frame-seam\|border-subtle)` | `divide-subtle` | 10 |
| `bg-(--linear-border-subtle)` | `bg-subtle` | 8 |
| `ring-(--linear-border-focus)` | `ring-ring` | 7 |
| `ring-offset-(--linear-bg-page)` | `ring-offset-base` | 11 |
| `bg/from/to-(--linear-bg-surface-*)` | `*-surface-*` | 7 |
| `bg-(--linear-text-*)` (status dots) | `bg-*-token` | 5 |
| `decoration-(--linear-app-frame-seam)` | `decoration-subtle` | 1 |

**Skipped (as scoped):**
- `ProfileAboutTab`, `UniversalLinkInputUrlMode`, `ChatStyleLinkItem` (heavy custom UI)
- `OnboardingHandleOnlyForm` (pre-existing `DSPs` Title Case lint)
- Shell chrome `bg-(--linear-app-content-surface)`, `row-hover`/`row-selected`, `border-(--linear-border-focus)`, btn-primary borders, accent, color-mix

Also fixed pre-existing Title Case labels on touched files so ESLint pre-commit stays green.

## Baseline delta
- **linear-namespace:** 2096 → **1904** (**−192**)
- 81 files, mechanical codemod + title-case hygiene on touched files

## Cost Impact
N/A — className renames only.

## Bug-to-test
waived — ratchet baseline (`linear-namespace.baseline.json`) + dashboard style-guard unit tests are the regression guard.

## Test plan
- [x] `vitest` dashboard unit suite (107 files / 512 tests)
- [x] `linear-namespace-ratchet` + `arbitrary-values-ratchet`
- [x] `chat-social-actions-system-b-style-guard` updated for `border-subtle` / `divide-subtle`
- [x] pre-commit: biome + eslint + typecheck green

<!-- linear-issue-id: none — GH #13988 lane 5 dashboard wave -->