### PR TITLE
fix(design-system): map admin --linear paren utilities to tokens

### DIFF
--- a/apps/web/components/features/admin/ActivityTableUnified.tsx
+++ b/apps/web/components/features/admin/ActivityTableUnified.tsx
@@ -129,7 +129,7 @@ const ACTIVITY_SUBHEADER = (
 );
 
 const ACTIVITY_CONTAINER_CLASSNAME =
-  'h-full border-0 bg-(--linear-app-content-surface)';
+  'h-full border-0 bg-(--app-shell-content-surface)';
 
 export function ActivityTableUnified({
   items,

--- a/apps/web/components/features/admin/admin-creator-profiles/AdminCreatorsPageWrapper.tsx
+++ b/apps/web/components/features/admin/admin-creator-profiles/AdminCreatorsPageWrapper.tsx
@@ -52,7 +52,7 @@ export function AdminCreatorsPageWrapper(
         <IngestProfileDropdown onIngestPending={handleIngestPending} />
 
         <div
-          className='h-5 w-px bg-(--linear-app-frame-seam)'
+          className='h-5 w-px bg-(--app-shell-frame-seam)'
           aria-hidden='true'
         />
 

--- a/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
+++ b/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge } from '@jovie/ui';
+import { Badge, Button } from '@jovie/ui';
 import {
   Popover,
   PopoverContent,
@@ -114,13 +114,15 @@ function AgentRunDetailPopover({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <button
+        <Button
           type='button'
+          variant='ghost'
+          size='icon'
           aria-label={`Inspect ${artifact.title}`}
-          className='rounded-md p-1 text-tertiary-token opacity-70 transition-colors hover:bg-surface-1 hover:text-primary-token hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+          className='h-auto w-auto rounded-md p-1 text-tertiary-token opacity-70 transition-colors hover:bg-surface-1 hover:text-primary-token hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
         >
           <Info className='size-3.5' aria-hidden='true' />
-        </button>
+        </Button>
       </PopoverTrigger>
       <PopoverContent
         align='end'
@@ -212,12 +214,13 @@ function AgentOsBoardCard({
       )}
     >
       <div className='flex min-w-0 items-start justify-between gap-2'>
-        <button
+        <Button
           type='button'
+          variant='ghost'
           onClick={() => onSelect(artifact)}
           aria-label={artifact.title}
           aria-pressed={isSelected}
-          className='min-w-0 flex-1 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-(--app-shell-content-surface)'
+          className='min-w-0 h-auto flex-1 justify-start rounded-md text-left hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-(--app-shell-content-surface)'
         >
           <p className='line-clamp-2 text-app font-[560] leading-5 text-primary-token'>
             {artifact.title}
@@ -235,7 +238,7 @@ function AgentOsBoardCard({
               {formatGateProgressLabel(artifact)}
             </p>
           </div>
-        </button>
+        </Button>
         <div className='flex shrink-0 items-center gap-1'>
           <AgentRunDetailPopover artifact={artifact} />
         </div>
@@ -286,22 +289,24 @@ function AgentOsBoard({
               <p className='text-xs font-[560] text-primary-token'>
                 {RUN_STATUS_LABEL[status]}
               </p>
-              <button
+              <Button
                 type='button'
+                variant='ghost'
+                size='sm'
                 onClick={() =>
                   onStatusFilterChange(statusFilter === status ? null : status)
                 }
                 aria-pressed={statusFilter === status}
                 aria-label={`Filter by ${RUN_STATUS_LABEL[status]} (${laneRows.length})`}
                 className={cn(
-                  'rounded px-1 text-2xs tabular-nums transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                  'h-auto rounded px-1 text-2xs tabular-nums transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
                   statusFilter === status
                     ? 'bg-surface-0 font-[560] text-primary-token'
                     : 'text-tertiary-token hover:bg-surface-0 hover:text-secondary-token'
                 )}
               >
                 {laneRows.length}
-              </button>
+              </Button>
             </div>
             {laneRows.length > 0 ? (
               laneRows.map(artifact => (
@@ -434,8 +439,10 @@ function ViewModeButton({
   const isActive = mode === activeMode;
 
   return (
-    <button
+    <Button
       type='button'
+      variant='ghost'
+      size='sm'
       onClick={() => onSelect(mode)}
       aria-pressed={isActive}
       className={cn(
@@ -447,7 +454,7 @@ function ViewModeButton({
     >
       {icon}
       {label}
-    </button>
+    </Button>
   );
 }
 

--- a/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
+++ b/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge, Button } from '@jovie/ui';
+import { Badge } from '@jovie/ui';
 import {
   Popover,
   PopoverContent,
@@ -114,21 +114,19 @@ function AgentRunDetailPopover({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button
+        <button
           type='button'
-          variant='ghost'
-          size='icon'
           aria-label={`Inspect ${artifact.title}`}
-          className='h-auto w-auto rounded-md p-1 text-tertiary-token opacity-70 transition-colors hover:bg-surface-1 hover:text-primary-token hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+          className='rounded-md p-1 text-tertiary-token opacity-70 transition-colors hover:bg-surface-1 hover:text-primary-token hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
         >
           <Info className='size-3.5' aria-hidden='true' />
-        </Button>
+        </button>
       </PopoverTrigger>
       <PopoverContent
         align='end'
         side='top'
         sideOffset={6}
-        className='w-85 rounded-xl border border-(--linear-app-frame-seam) bg-surface-1 p-3 shadow-popover'
+        className='w-85 rounded-xl border border-(--app-shell-frame-seam) bg-surface-1 p-3 shadow-popover'
       >
         <div className='space-y-3'>
           <div className='min-w-0'>
@@ -214,13 +212,12 @@ function AgentOsBoardCard({
       )}
     >
       <div className='flex min-w-0 items-start justify-between gap-2'>
-        <Button
+        <button
           type='button'
-          variant='ghost'
           onClick={() => onSelect(artifact)}
           aria-label={artifact.title}
           aria-pressed={isSelected}
-          className='min-w-0 h-auto flex-1 justify-start rounded-md text-left hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface)'
+          className='min-w-0 flex-1 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-(--app-shell-content-surface)'
         >
           <p className='line-clamp-2 text-app font-[560] leading-5 text-primary-token'>
             {artifact.title}
@@ -238,7 +235,7 @@ function AgentOsBoardCard({
               {formatGateProgressLabel(artifact)}
             </p>
           </div>
-        </Button>
+        </button>
         <div className='flex shrink-0 items-center gap-1'>
           <AgentRunDetailPopover artifact={artifact} />
         </div>
@@ -289,24 +286,22 @@ function AgentOsBoard({
               <p className='text-xs font-[560] text-primary-token'>
                 {RUN_STATUS_LABEL[status]}
               </p>
-              <Button
+              <button
                 type='button'
-                variant='ghost'
-                size='sm'
                 onClick={() =>
                   onStatusFilterChange(statusFilter === status ? null : status)
                 }
                 aria-pressed={statusFilter === status}
                 aria-label={`Filter by ${RUN_STATUS_LABEL[status]} (${laneRows.length})`}
                 className={cn(
-                  'h-auto rounded px-1 text-2xs tabular-nums transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                  'rounded px-1 text-2xs tabular-nums transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
                   statusFilter === status
                     ? 'bg-surface-0 font-[560] text-primary-token'
                     : 'text-tertiary-token hover:bg-surface-0 hover:text-secondary-token'
                 )}
               >
                 {laneRows.length}
-              </Button>
+              </button>
             </div>
             {laneRows.length > 0 ? (
               laneRows.map(artifact => (
@@ -439,10 +434,8 @@ function ViewModeButton({
   const isActive = mode === activeMode;
 
   return (
-    <Button
+    <button
       type='button'
-      variant='ghost'
-      size='sm'
       onClick={() => onSelect(mode)}
       aria-pressed={isActive}
       className={cn(
@@ -454,7 +447,7 @@ function ViewModeButton({
     >
       {icon}
       {label}
-    </Button>
+    </button>
   );
 }
 
@@ -560,7 +553,7 @@ export function AgentOsRunsPanel({
               onStatusFilterChange={setStatusFilter}
             />
           ) : (
-            <div className='min-w-0 rounded-lg border border-subtle bg-(--linear-app-content-surface)'>
+            <div className='min-w-0 rounded-lg border border-subtle bg-(--app-shell-content-surface)'>
               <AdminDataTable
                 data={rows}
                 columns={columns}

--- a/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
+++ b/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Button } from '@jovie/ui';
+
 import { Clock3, ExternalLink } from 'lucide-react';
 import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
 import { cn } from '@/lib/utils';
@@ -134,14 +136,15 @@ export function WorkflowRunRow({
 
   return (
     <div className={containerClassName}>
-      <button
+      <Button
         type='button'
+        variant='ghost'
         onClick={() => onSelect(artifact)}
-        className='grid gap-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-(--app-shell-content-surface)'
+        className='grid h-auto w-full gap-2 rounded-none text-left hover:bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-(--app-shell-content-surface)'
         aria-pressed={isSelected}
       >
         {mainContent}
-      </button>
+      </Button>
       {hasActions ? (
         <div className='flex items-center gap-1 border-t border-subtle pt-2'>
           <RowActionLink href={artifact.pullRequestUrl} label='Open PR' />

--- a/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
+++ b/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { Button } from '@jovie/ui';
-
 import { Clock3, ExternalLink } from 'lucide-react';
 import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
 import { cn } from '@/lib/utils';
@@ -136,15 +134,14 @@ export function WorkflowRunRow({
 
   return (
     <div className={containerClassName}>
-      <Button
+      <button
         type='button'
-        variant='ghost'
         onClick={() => onSelect(artifact)}
-        className='grid h-auto w-full gap-2 rounded-none text-left hover:bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface)'
+        className='grid gap-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-(--app-shell-content-surface)'
         aria-pressed={isSelected}
       >
         {mainContent}
-      </Button>
+      </button>
       {hasActions ? (
         <div className='flex items-center gap-1 border-t border-subtle pt-2'>
           <RowActionLink href={artifact.pullRequestUrl} label='Open PR' />

--- a/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
+++ b/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
@@ -297,7 +297,7 @@ export function AdminFeedbackTable({
 
   return (
     <div className='flex h-full min-h-155 overflow-hidden'>
-      <div className='h-full w-full border-r border-subtle bg-(--linear-app-content-surface) lg:w-[58%]'>
+      <div className='h-full w-full border-r border-subtle bg-(--app-shell-content-surface) lg:w-[58%]'>
         <AdminTableHeader
           title='Feedback'
           subtitle='Triage product feedback and close the loop with clear status.'

--- a/apps/web/components/features/admin/table/AdminTableHeader.tsx
+++ b/apps/web/components/features/admin/table/AdminTableHeader.tsx
@@ -51,7 +51,7 @@ export function AdminTableSubheader({
       className={cn(
         hasToolbar
           ? 'bg-surface-1'
-          : 'border-b border-(--linear-app-frame-seam) bg-surface-1 px-app-header py-1',
+          : 'border-b border-(--app-shell-frame-seam) bg-surface-1 px-app-header py-1',
         className
       )}
     >

--- a/apps/web/components/features/admin/table/AdminTableShell.tsx
+++ b/apps/web/components/features/admin/table/AdminTableShell.tsx
@@ -127,7 +127,7 @@ export function AdminTableShell({
           <div
             ref={toolbarRef}
             className={cn(
-              'sticky top-0 z-30 border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface)/96 backdrop-blur-md supports-backdrop-filter:bg-(--linear-app-content-surface)/88',
+              'sticky top-0 z-30 border-b border-(--app-shell-frame-seam) bg-(--app-shell-content-surface)/96 backdrop-blur-md supports-backdrop-filter:bg-(--app-shell-content-surface)/88',
               headerElevated && 'dark:shadow-inset-highlight'
             )}
           >
@@ -139,9 +139,7 @@ export function AdminTableShell({
       </div>
 
       {footer ? (
-        <div className='border-t border-(--linear-app-frame-seam)'>
-          {footer}
-        </div>
+        <div className='border-t border-(--app-shell-frame-seam)'>{footer}</div>
       ) : null}
     </div>
   );

--- a/apps/web/components/features/admin/waitlist-table/AdminWaitlistTableWithViews.tsx
+++ b/apps/web/components/features/admin/waitlist-table/AdminWaitlistTableWithViews.tsx
@@ -382,7 +382,7 @@ export function AdminWaitlistTableWithViews(props: WaitlistTableProps) {
               getItemId={entry => entry.id}
               onItemMove={handleItemMove}
               cardHeight={200}
-              className='bg-(--linear-app-content-surface)'
+              className='bg-(--app-shell-content-surface)'
               emptyState={
                 <div className='text-center text-secondary-token'>
                   <p className='text-sm font-medium text-primary-token'>
@@ -409,7 +409,7 @@ function WaitlistIntegrityStatus({
   const hasIssues = integrity.totalIssues > 0;
 
   return (
-    <div className='flex min-h-9 items-center gap-2 border-t border-(--linear-app-frame-seam) px-4 py-2 text-2xs'>
+    <div className='flex min-h-9 items-center gap-2 border-t border-(--app-shell-frame-seam) px-4 py-2 text-2xs'>
       {hasIssues ? (
         <AlertTriangle className='h-3.5 w-3.5 shrink-0 text-amber-500' />
       ) : (

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -444,7 +444,7 @@ describe('surface elevation guardrails', () => {
       'lg:rounded-[var(--linear-app-shell-radius)]'
     );
     expect(rightDrawer).not.toContain('lg:border');
-    expect(adminTableShell).toContain('bg-(--linear-app-content-surface)/96');
+    expect(adminTableShell).toContain('bg-(--app-shell-content-surface)/96');
   });
 
   it('does not use semi-transparent bg-surface-1 in app shell (bg-surface-1/XX)', () => {

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1775
+  "count": 1761
 }


### PR DESCRIPTION
## Summary
Partial **lane 5** for #13988 scoped to admin features: convert exact same-var Tailwind paren-form `(--linear-*)` utilities to semantic shell aliases.

### Verified map
| From | To | Why exact |
|------|-----|-----------|
| `bg-(--linear-app-content-surface)` (+ opacity) | `bg-(--app-shell-content-surface)` | `design-system.css`: `--app-shell-content-surface: var(--linear-app-content-surface)` |
| `ring-offset-(--linear-app-content-surface)` | `ring-offset-(--app-shell-content-surface)` | same shell alias |
| `border-(--linear-app-frame-seam)` / `bg-(--linear-app-frame-seam)` | `(--app-shell-frame-seam)` | `design-system.css`: `--app-shell-frame-seam: var(--linear-app-frame-seam)` |

**Not mapped (no exact theme/shell alias, or value-diverging):** content padding paren forms, `text-(--linear-accent)`, `border-(--linear-border-focus)`, raw `var(--linear-*)` chart fills.

### Scope notes
- Skipped files with pre-existing ESLint Title Case / server-boundary failures so the PR stays mapping-only (same approach as #14538).
- Companion assertion update in `surface-elevation-guardrails.test.ts` for `AdminTableShell`.

### Baseline
- **Before:** 2096
- **After:** 2082
- **Delta:** **−14**

## Cost Impact
N/A — className renames only; no runtime API/cron/infra changes.

## Bug-to-test
waived — ratchet baseline (`linear-namespace.baseline.json`) + surface elevation guard are the regression guard.

## Test plan
- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/design-system/linear-namespace-ratchet.test.ts`
- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/app/surface-elevation-guardrails.test.ts`
- [x] Biome check on staged files
- [x] ESLint clean on committed admin files

<!-- linear-issue-id: none — GH #13988 lane 5 admin partial -->