### PR TITLE
feat(profile): iOS-grade public profile overhaul — hero, unified carousel, jank fixes

### DIFF
--- a/apps/web/app/[username]/about/page.tsx
+++ b/apps/web/app/[username]/about/page.tsx
@@ -4,6 +4,13 @@ import { BASE_URL } from '@/constants/app';
 import { AboutView } from '@/features/profile/views/AboutView';
 import { buildViewMetadata } from '@/features/profile/views/metadata';
 import { ProfileIntentPage } from '@/features/profile/views/ProfileIntentPage';
+import { getCreditedArtistsWithProfiles } from '@/lib/discography/artist-queries';
+import { getReleasesForProfileLite } from '@/lib/discography/queries';
+import {
+  type EntityMentionContext,
+  linkEntityMentions,
+} from '@/lib/profile/entity-mentions';
+import { logger } from '@/lib/utils/logger';
 import { convertCreatorProfileToArtist } from '@/types/db';
 import { getProfileAndLinks } from '../_lib/public-profile-loader';
 
@@ -42,10 +49,41 @@ export default async function AboutPage({ params }: Props) {
   }
 
   const artist = convertCreatorProfileToArtist(result.profile);
+  const profile = result.profile;
   const profileSettings =
-    (result.profile.settings as Record<string, unknown> | null) ?? {};
+    (profile.settings as Record<string, unknown> | null) ?? {};
   const allowPhotoDownloads =
     profileSettings.allowProfilePhotoDownloads === true;
+
+  // Entity-linked bio: resolve this profile's own releases + credited artists
+  // with public Jovie profiles, then link mentions in the tagline. Failures
+  // degrade to plain text.
+  const bioSegments = await (async () => {
+    const tagline = artist.tagline?.trim();
+    if (!tagline) return undefined;
+    try {
+      const [releases, creditedArtists] = await Promise.all([
+        getReleasesForProfileLite(profile.id),
+        getCreditedArtistsWithProfiles(profile.id),
+      ]);
+      const context: EntityMentionContext = {
+        ownHandle: artist.handle,
+        releases: releases.map(release => ({
+          title: release.title,
+          slug: release.slug,
+        })),
+        artists: creditedArtists,
+      };
+      return linkEntityMentions(tagline, context);
+    } catch (error) {
+      logger.error(
+        'Error building entity-linked bio segments',
+        { error, profileId: profile.id, route: '/[username]/about' },
+        'public-profile'
+      );
+      return undefined;
+    }
+  })();
 
   return (
     <ProfileIntentPage
@@ -58,6 +96,7 @@ export default async function AboutPage({ params }: Props) {
         genres={result.genres}
         pressPhotos={[...result.pressPhotos]}
         allowPhotoDownloads={allowPhotoDownloads}
+        bioSegments={bioSegments}
       />
     </ProfileIntentPage>
   );

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from 'next/navigation';
 // API (cookies(), headers()) in this RSC tree.
 
 import type { PublicRelease } from '@/components/features/profile/releases/types';
+import { BASE_URL } from '@/constants/app';
 import { ErrorBanner } from '@/features/feedback/ErrorBanner';
 import { DesktopQrOverlayClient } from '@/features/profile/DesktopQrOverlayClient';
 import { ProfileAeoContent } from '@/features/profile/ProfileAeoContent';
@@ -19,6 +20,7 @@ import {
   supportsDirectProfileClaim,
 } from '@/lib/claim/visitor-state';
 import { toPublicContacts } from '@/lib/contacts/mapper';
+import { getCreditedArtistsWithProfiles } from '@/lib/discography/artist-queries';
 import { getReleasesForProfileLite } from '@/lib/discography/queries';
 import { getEntityIdentityLinks } from '@/lib/entity/queries';
 import { DEFAULT_PROFILE_PAC_ASSIGNMENT } from '@/lib/flags/profile-pac';
@@ -30,6 +32,10 @@ import {
 } from '@/lib/flags/profile-variant';
 import { getLiveMerchCardsForProfile } from '@/lib/merch/service';
 import { buildProfileAeoContent } from '@/lib/profile/aeo-content';
+import {
+  collectEntityMentions,
+  type EntityMentionContext,
+} from '@/lib/profile/entity-mentions';
 import { getConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback-data';
 import {
   buildPublicProfileMetadata,
@@ -132,6 +138,27 @@ async function getPublicMerchCards(profileId: string) {
   }
 }
 
+/**
+ * Credited artists on this profile's catalog that have public Jovie profiles.
+ * Used to link bio/AEO mentions to their pages; failures degrade to no links.
+ */
+async function getCreditedArtistsForMentions(profileId: string) {
+  try {
+    return await getCreditedArtistsWithProfiles(profileId);
+  } catch (error) {
+    logger.error(
+      'Error fetching credited artists for entity mentions',
+      {
+        error,
+        profileId,
+        route: '/[username]',
+      },
+      'public-profile'
+    );
+    return [];
+  }
+}
+
 export default async function ArtistPage({ params }: Readonly<Props>) {
   const { username } = await params;
   const initialMode = 'profile';
@@ -195,6 +222,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
   const releasesPromise = getPublicReleases(profile.id);
   const merchCardsPromise = getPublicMerchCards(profile.id);
   const entityLinksPromise = getEntityIdentityLinks(profile.id);
+  const creditedArtistsPromise = getCreditedArtistsForMentions(profile.id);
 
   // Convert our profile data to the Artist type expected by components
   const artist = convertCreatorProfileToArtist(profile);
@@ -250,6 +278,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     alertOptInVariant,
     profilePacAssignment,
     entityLinks,
+    creditedArtists,
   ] = await Promise.all([
     tourDatesPromise.catch(() => [] as TourDateViewModel[]),
     releasesPromise,
@@ -260,6 +289,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     getProfileAlertOptInVariant(null).catch(() => 'button' as const),
     getProfilePacAssignment(null).catch(() => DEFAULT_PROFILE_PAC_ASSIGNMENT),
     entityLinksPromise.catch(() => []),
+    creditedArtistsPromise,
   ]);
   const tourDates = [...tourDatesRaw].sort(
     (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
@@ -277,13 +307,29 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     previewUrl: null,
   }));
 
+  // Entity-linked bio/AEO context: own releases (→ /{handle}/{slug}) and
+  // credited artists with public Jovie profiles (→ /{handle}).
+  const entityMentionContext: EntityMentionContext = {
+    ownHandle: artist.handle,
+    releases: releases.map(release => ({
+      title: release.title,
+      slug: release.slug,
+    })),
+    artists: creditedArtists,
+  };
+
   // Generate structured data for SEO (after tour dates resolve)
   const structuredData = generateProfileStructuredData(
     profile,
     genres,
     links,
     tourDates,
-    entityLinks
+    entityLinks,
+    collectEntityMentions(entityMentionContext).map(mention => ({
+      kind: mention.kind,
+      name: mention.name,
+      url: new URL(mention.href, BASE_URL).toString(),
+    }))
   );
   const aeoContent = buildProfileAeoContent({
     artist,
@@ -293,6 +339,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     tourDates,
     merchCards,
     socialLinks: links,
+    entityMentions: entityMentionContext,
   });
 
   return (

--- a/apps/web/components/features/profile/AboutSection.tsx
+++ b/apps/web/components/features/profile/AboutSection.tsx
@@ -2,14 +2,21 @@
 
 import { Calendar, Download, Home, MapPin } from 'lucide-react';
 import { ImageWithFallback } from '@/components/atoms/ImageWithFallback';
+import type { EntityMentionSegment } from '@/lib/profile/entity-mentions';
 import type { Artist } from '@/types/db';
 import type { PressPhoto } from '@/types/press-photos';
+import { EntityMentionText } from './EntityMentionText';
 
 interface AboutSectionProps {
   readonly artist: Artist;
   readonly genres?: string[] | null;
   readonly pressPhotos?: readonly PressPhoto[];
   readonly allowPhotoDownloads?: boolean;
+  /**
+   * Optional entity-linked segments for `artist.tagline` (computed
+   * server-side). Falls back to plain text when omitted.
+   */
+  readonly bioSegments?: readonly EntityMentionSegment[];
 }
 
 function sanitizeFilename(value: string): string {
@@ -59,6 +66,7 @@ export function AboutSection({
   genres,
   pressPhotos = [],
   allowPhotoDownloads = false,
+  bioSegments,
 }: AboutSectionProps) {
   const hasBio = Boolean(artist.tagline);
   const hasLocation = Boolean(artist.location);
@@ -89,7 +97,11 @@ export function AboutSection({
 
       {hasBio && (
         <p className='text-sm font-book leading-relaxed text-white/70 whitespace-pre-line'>
-          {artist.tagline}
+          {bioSegments ? (
+            <EntityMentionText segments={bioSegments} />
+          ) : (
+            artist.tagline
+          )}
         </p>
       )}
 

--- a/apps/web/components/features/profile/EntityMentionText.tsx
+++ b/apps/web/components/features/profile/EntityMentionText.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import { type CSSProperties, Fragment } from 'react';
+import { ENTITY_KIND_ACCENT_VAR } from '@/components/jovie/components/entity-accent';
+import type { EntityMentionSegment } from '@/lib/profile/entity-mentions';
+
+interface EntityMentionTextProps {
+  readonly segments: readonly EntityMentionSegment[];
+}
+
+/**
+ * Renders entity-linked text segments: plain text passes through, while
+ * release/artist mentions become inline internal links tinted with the
+ * entity-kind accent (see `--system-b-entity-chip-*-accent` tokens and the
+ * `.profile-entity-mention` rule in design-system.css).
+ */
+export function EntityMentionText({ segments }: EntityMentionTextProps) {
+  // Segments are a server-built partition of one string, so the character
+  // offset is a stable identity for each segment.
+  const keyed = segments.reduce<{
+    readonly offset: number;
+    readonly items: readonly {
+      key: string;
+      segment: EntityMentionSegment;
+    }[];
+  }>(
+    (accumulator, segment) => ({
+      offset: accumulator.offset + segment.text.length,
+      items: [
+        ...accumulator.items,
+        { key: `${segment.type}:${accumulator.offset}`, segment },
+      ],
+    }),
+    { offset: 0, items: [] }
+  ).items;
+
+  return (
+    <>
+      {keyed.map(({ key, segment }) => {
+        if (segment.type === 'text') {
+          return <Fragment key={key}>{segment.text}</Fragment>;
+        }
+
+        const accentStyle = {
+          '--jovie-entity-accent': `var(${ENTITY_KIND_ACCENT_VAR[segment.type]})`,
+        } as CSSProperties;
+
+        return (
+          <Link
+            key={key}
+            href={segment.href}
+            prefetch={false}
+            className='profile-entity-mention font-medium underline underline-offset-4 transition-colors duration-subtle'
+            style={accentStyle}
+            data-entity-kind={segment.type}
+          >
+            {segment.text}
+          </Link>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/components/features/profile/ProfileAboutShare.tsx
+++ b/apps/web/components/features/profile/ProfileAboutShare.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Check, Share2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface ProfileAboutShareProps {
+  readonly url: string;
+  readonly artistName: string;
+}
+
+export function ProfileAboutShare({
+  url,
+  artistName,
+}: Readonly<ProfileAboutShareProps>) {
+  const [shareSuccess, setShareSuccess] = useState(false);
+  const shareTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (shareTimeoutRef.current) clearTimeout(shareTimeoutRef.current);
+    },
+    []
+  );
+
+  const handleShare = useCallback(async () => {
+    const markShared = () => {
+      setShareSuccess(true);
+      if (shareTimeoutRef.current) clearTimeout(shareTimeoutRef.current);
+      shareTimeoutRef.current = setTimeout(() => setShareSuccess(false), 2000);
+    };
+
+    try {
+      if (typeof navigator.share === 'function') {
+        await navigator.share({ title: artistName, url });
+      } else {
+        await navigator.clipboard.writeText(url);
+      }
+      markShared();
+    } catch (error) {
+      // AbortError = user cancelled the share sheet, do nothing.
+      if (error instanceof Error && error.name === 'AbortError') return;
+      // Fallback: try the clipboard if sharing failed for another reason.
+      try {
+        await navigator.clipboard.writeText(url);
+        markShared();
+      } catch {
+        // Silent failure — matches the hero share control.
+      }
+    }
+  }, [url, artistName]);
+
+  return (
+    <button
+      type='button'
+      onClick={handleShare}
+      className='profile-aeo-content__share inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text)'
+      aria-label={
+        shareSuccess
+          ? `Copied link to ${artistName}'s profile`
+          : `Share ${artistName}'s profile`
+      }
+      data-testid='profile-about-share'
+    >
+      {shareSuccess ? (
+        <Check className='h-4 w-4' aria-hidden='true' />
+      ) : (
+        <Share2 className='h-4 w-4' aria-hidden='true' />
+      )}
+      <span aria-live='polite' className='sr-only'>
+        {shareSuccess ? 'Link Copied' : ''}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/components/features/profile/ProfileAeoContent.tsx
+++ b/apps/web/components/features/profile/ProfileAeoContent.tsx
@@ -1,6 +1,9 @@
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
+import { SocialIcon } from '@/components/atoms/SocialIcon';
+import { ProfileAboutShare } from '@/features/profile/ProfileAboutShare';
 import type { ProfileAeoContent as ProfileAeoContentModel } from '@/lib/profile/aeo-content';
+import { EntityMentionText } from './EntityMentionText';
 
 interface ProfileAeoContentProps {
   readonly content: ProfileAeoContentModel;
@@ -18,16 +21,95 @@ export function ProfileAeoContent({
       data-testid='profile-aeo-content'
     >
       <div className='profile-aeo-content__inner mx-auto grid max-w-5xl gap-8 border-t pt-8 lg:gap-11 lg:pt-10'>
-        <div className='space-y-3 lg:sticky lg:top-12 lg:self-start'>
-          <h2
-            id='profile-aeo-heading'
-            className='profile-aeo-content__heading text-3xl font-semibold leading-tight tracking-tight text-balance'
-          >
-            About {content.artistName}
-          </h2>
+        <div className='space-y-5 lg:sticky lg:top-12 lg:self-start'>
+          <div className='flex items-start justify-between gap-4'>
+            <h2
+              id='profile-aeo-heading'
+              className='profile-aeo-content__heading text-3xl font-semibold leading-tight tracking-tight text-balance'
+            >
+              About {content.artistName}
+            </h2>
+            <ProfileAboutShare
+              url={content.profileUrl}
+              artistName={content.artistName}
+            />
+          </div>
+
+          {content.facts.length > 0 ? (
+            <dl
+              className='profile-aeo-content__facts flex flex-col gap-3 border-y py-4 sm:flex-row sm:flex-wrap sm:gap-x-10 sm:gap-y-4'
+              data-testid='profile-about-facts'
+            >
+              {content.facts.map(fact => (
+                <div key={fact.label} className='space-y-1'>
+                  <dt className='profile-aeo-content__fact-label text-xs font-medium'>
+                    {fact.label}
+                  </dt>
+                  <dd className='profile-aeo-content__fact-value text-mid font-medium'>
+                    {fact.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
+
+          {content.listenLinks.length > 0 ? (
+            <div className='space-y-2' data-testid='profile-about-listen'>
+              <h3 className='profile-aeo-content__link-label text-xs font-medium'>
+                Listen
+              </h3>
+              <ul className='flex flex-wrap items-center gap-x-5 gap-y-2'>
+                {content.listenLinks.map(link => (
+                  <li key={link.id}>
+                    <a
+                      href={link.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='profile-aeo-content__link inline-flex min-h-11 items-center gap-2 text-sm font-medium transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text)'
+                    >
+                      <SocialIcon
+                        platform={link.platform}
+                        className='h-4 w-4'
+                      />
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {content.followLinks.length > 0 ? (
+            <div className='space-y-2' data-testid='profile-about-follow'>
+              <h3 className='profile-aeo-content__link-label text-xs font-medium'>
+                Follow
+              </h3>
+              <ul className='flex flex-wrap items-center gap-1'>
+                {content.followLinks.map(link => (
+                  <li key={link.id}>
+                    <a
+                      href={link.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='profile-aeo-content__link inline-flex h-11 w-11 items-center justify-center rounded-full transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text)'
+                      aria-label={`Follow ${content.artistName} on ${link.label}`}
+                    >
+                      <SocialIcon
+                        platform={link.platform}
+                        className='h-5 w-5'
+                      />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
           <div className='profile-aeo-content__body space-y-3 text-mid leading-7 text-pretty'>
-            {content.description.map(paragraph => (
-              <p key={paragraph}>{paragraph}</p>
+            {content.descriptionSegments.map((segments, index) => (
+              <p key={content.description[index] ?? index}>
+                <EntityMentionText segments={segments} />
+              </p>
             ))}
           </div>
         </div>

--- a/apps/web/components/features/profile/ProfileEmptyBentoCard.tsx
+++ b/apps/web/components/features/profile/ProfileEmptyBentoCard.tsx
@@ -18,9 +18,10 @@ const ACCENT_GRADIENTS: Record<ProfileEmptyBentoAccent, CSSProperties> = {
     background:
       'radial-gradient(120% 100% at 50% -8%, color-mix(in oklab, var(--color-accent-pink) 78%, white) 0%, color-mix(in oklab, var(--color-accent-pink) 44%, #2a1028) 44%, color-mix(in oklab, var(--color-accent-pink) 20%, #0a0814) 100%)',
   },
+  // Events: standard surface-1 card treatment (no off-token accent gradient).
   events: {
     background:
-      'radial-gradient(120% 100% at 50% -8%, color-mix(in oklab, var(--color-accent-blue) 78%, white) 0%, color-mix(in oklab, var(--color-accent-blue) 44%, #102040) 44%, color-mix(in oklab, var(--color-accent-blue) 20%, #0a0814) 100%)',
+      'linear-gradient(155deg, var(--color-bg-surface-2), var(--color-bg-surface-1))',
   },
 };
 

--- a/apps/web/components/features/profile/ProfileEmptyBentoCard.tsx
+++ b/apps/web/components/features/profile/ProfileEmptyBentoCard.tsx
@@ -5,7 +5,7 @@ import type { LucideIcon } from 'lucide-react';
 import type { CSSProperties, MouseEvent, ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
-export type ProfileEmptyBentoAccent = 'alerts' | 'music' | 'events';
+export type ProfileEmptyBentoAccent = 'music' | 'events';
 
 export type ProfileEmptyBentoLayout = 'prominent' | 'compact' | 'inline';
 
@@ -14,10 +14,6 @@ export type ProfileEmptyBentoLayout = 'prominent' | 'compact' | 'inline';
  * Inline styles (not arbitrary Tailwind) to avoid the arbitrary-value ratchet.
  */
 const ACCENT_GRADIENTS: Record<ProfileEmptyBentoAccent, CSSProperties> = {
-  alerts: {
-    background:
-      'radial-gradient(120% 100% at 50% -8%, color-mix(in oklab, var(--color-accent-purple) 82%, white) 0%, color-mix(in oklab, var(--color-accent-purple) 48%, #1a1030) 44%, color-mix(in oklab, var(--color-accent-purple) 22%, #0a0814) 100%)',
-  },
   music: {
     background:
       'radial-gradient(120% 100% at 50% -8%, color-mix(in oklab, var(--color-accent-pink) 78%, white) 0%, color-mix(in oklab, var(--color-accent-pink) 44%, #2a1028) 44%, color-mix(in oklab, var(--color-accent-pink) 20%, #0a0814) 100%)',

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Bell } from 'lucide-react';
-import { type MouseEvent, useMemo } from 'react';
+import { type MouseEvent, memo, useMemo } from 'react';
 import {
   type EntityCardModel,
   merchToEntityCard,
@@ -93,13 +93,11 @@ function HomeAlertsCard({
   artist,
   onAlertsClick,
   renderMode,
-  prominent,
   sourceContext,
 }: Readonly<{
   artist: Artist;
   onAlertsClick?: (context: NotificationSourceContext) => void;
   renderMode: ProfileRenderMode;
-  prominent: boolean;
   sourceContext: NotificationSourceContext;
 }>) {
   const title = 'Alerts';
@@ -123,7 +121,10 @@ function HomeAlertsCard({
       icon={Bell}
       title={title}
       body={description}
-      layout={prominent ? 'prominent' : 'inline'}
+      // Carousel card geometry: the prominent column layout fills the fixed
+      // 3:4 card box; the inline strip layout is gone with the stacked rail.
+      layout='prominent'
+      className='h-full'
       trailing={<HomeAlertsSwitch />}
       href={isInteractive ? subscribeHref : undefined}
       onClick={handleClick}
@@ -163,7 +164,7 @@ export const __profileHomeRailTestUtils = {
   getS2OrderedItems,
 };
 
-export function ProfileHomeRail({
+export const ProfileHomeRail = memo(function ProfileHomeRail({
   artist,
   latestRelease,
   profileSettings,
@@ -211,41 +212,28 @@ export function ProfileHomeRail({
   );
   const nearbyTourDateId = nearbyDates[0]?.date?.id ?? null;
 
-  // One ordered card list — featured item first, then the rest. No stacked
-  // sections: a single carousel is the profile home surface.
+  // One ordered card list — back catalog, merch, and shows. The featured
+  // latest release is NOT an entity card here: it lives in the carousel's
+  // leading slot as the PAC card below, so it never renders twice.
   const carouselItems = useMemo<EntityCardModel[]>(() => {
     const featuredItems: EntityCardModel[] = [];
     const releaseItems: EntityCardModel[] = [];
     const merchItems: EntityCardModel[] = [];
     const showItems: EntityCardModel[] = [];
 
-    // Featured: the latest release when it's visible per profile settings.
+    // The PAC card hosts the visible latest release; only the slug is needed
+    // here to keep it out of the plain catalog list.
     const hasFeaturedRelease = Boolean(
       releaseVisibility?.show && latestRelease
     );
     const featuredReleaseSlug =
       hasFeaturedRelease && latestRelease ? latestRelease.slug : null;
-    const featuredReleaseId =
-      featuredReleaseSlug === null
-        ? null
-        : (releases.find(release => release.slug === featuredReleaseSlug)?.id ??
-          null);
 
-    if (hasFeaturedRelease && latestRelease) {
-      featuredItems.push(
-        releaseToEntityCard(
-          {
-            id: featuredReleaseId ?? undefined,
-            title: latestRelease.title,
-            slug: latestRelease.slug,
-            artworkUrl: latestRelease.artworkUrl,
-            releaseDate: latestRelease.releaseDate,
-            releaseType: latestRelease.releaseType,
-          },
-          { handle: artist.handle, now }
-        )
-      );
-    } else if (upcomingTourDates.length === 0 && featuredPlaylistFallback) {
+    if (
+      !hasFeaturedRelease &&
+      upcomingTourDates.length === 0 &&
+      featuredPlaylistFallback
+    ) {
       // Fallback feature when there's no release or upcoming show: the
       // artist's confirmed "This Is" playlist, as a music card.
       featuredItems.push({
@@ -319,8 +307,6 @@ export function ProfileHomeRail({
     upcomingTourDates,
   ]);
 
-  const isLowContentHome = carouselItems.length === 0;
-
   // Primary Action Card subject: the visible latest release (preferred) or
   // the newest catalog release. Preview URL comes from the lite releases
   // payload; when absent the PAC degrades to a link-out (no inline play).
@@ -356,7 +342,6 @@ export function ProfileHomeRail({
       artist={artist}
       onAlertsClick={onAlertsClick}
       renderMode={renderMode}
-      prominent={isLowContentHome}
       sourceContext={{
         artistId: artist.id,
         profileId: artist.id,
@@ -368,29 +353,34 @@ export function ProfileHomeRail({
     />
   );
 
+  // One screen, one primary focus: the carousel IS the home surface. The PAC
+  // card is the featured first card; the alerts card is the last card. Both
+  // render inside the same fixed card geometry — no stacked sections.
   return (
     <div
       ref={exposureRef}
-      className='min-w-0 space-y-2 md:mx-auto md:w-full md:max-w-80'
+      className='flex min-h-0 min-w-0 flex-1 flex-col md:mx-auto md:w-full md:max-w-80'
       data-testid='profile-home-rail'
     >
-      <ProfilePacCard
-        artist={artist}
-        release={pacRelease}
-        merchCard={merchCards[0] ?? null}
-        nextShow={pacNextShow}
-        hasTip={hasTip}
-        assignment={profilePacAssignment}
-        isSubscribed={isSubscribed}
-        renderMode={renderMode}
-      />
-      {alertsCard}
       <ReleaseCatalogCarousel
         items={carouselItems}
         artistHandle={artist.handle}
         artistId={artist.id}
         analyticsEnabled={renderMode !== 'preview'}
+        leading={
+          <ProfilePacCard
+            artist={artist}
+            release={pacRelease}
+            merchCard={merchCards[0] ?? null}
+            nextShow={pacNextShow}
+            hasTip={hasTip}
+            assignment={profilePacAssignment}
+            isSubscribed={isSubscribed}
+            renderMode={renderMode}
+          />
+        }
+        trailing={alertsCard}
       />
     </div>
   );
-}
+});

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -380,7 +380,6 @@ export const ProfileHomeRail = memo(function ProfileHomeRail({
             assignment={profilePacAssignment}
             isSubscribed={isSubscribed}
             renderMode={renderMode}
-            artPriority={pacArtPriority}
           />
         }
         trailing={alertsCard}

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -55,6 +55,11 @@ interface ProfileHomeRailProps {
   readonly merchCards?: readonly PublicMerchCard[];
   readonly releases?: readonly PublicRelease[];
   readonly hasTip?: boolean;
+  /**
+   * Set when the profile has no hero photo: the PAC card's artwork becomes
+   * the LCP image, so it must load with priority instead of lazy.
+   */
+  readonly pacArtPriority?: boolean;
 }
 
 function getUpcomingTourDates(
@@ -179,6 +184,7 @@ export const ProfileHomeRail = memo(function ProfileHomeRail({
   merchCards = [],
   releases = [],
   hasTip = false,
+  pacArtPriority = false,
 }: Readonly<ProfileHomeRailProps>) {
   // PAC instrumentation (spec §8): pac_exposure fires when the rail is ≥50%
   // visible, once per state per session, keyed to the visitor's variant.
@@ -377,6 +383,7 @@ export const ProfileHomeRail = memo(function ProfileHomeRail({
             assignment={profilePacAssignment}
             isSubscribed={isSubscribed}
             renderMode={renderMode}
+            artPriority={pacArtPriority}
           />
         }
         trailing={alertsCard}

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Bell } from 'lucide-react';
 import { type MouseEvent, memo, useMemo } from 'react';
 import {
+  EntityCard,
   type EntityCardModel,
   merchToEntityCard,
   releaseToEntityCard,
@@ -10,7 +10,6 @@ import {
 } from '@/components/organisms/entity-card';
 import type { NotificationSourceContext } from '@/features/profile/artist-notifications-cta/types';
 import type { ProfileRenderMode } from '@/features/profile/contracts';
-import { ProfileEmptyBentoCard } from '@/features/profile/ProfileEmptyBentoCard';
 import type { ProfilePrimaryActionCardRelease } from '@/features/profile/ProfilePrimaryActionCard';
 import {
   startOfProfileSurfaceLocalDay as startOfLocalDay,
@@ -82,18 +81,6 @@ function getUpcomingTourDates(
     );
 }
 
-function HomeAlertsSwitch() {
-  return (
-    <span
-      className='relative inline-flex h-7 w-12 shrink-0 items-center rounded-full border border-white/18 bg-white/18 p-1 shadow-sm transition-colors duration-subtle group-hover:bg-white/24'
-      aria-hidden='true'
-      data-testid='profile-home-alerts-switch'
-    >
-      <span className='block h-6 w-6 rounded-full bg-white shadow-[0_3px_10px_rgba(0,0,0,0.32)] dark:bg-white' />
-    </span>
-  );
-}
-
 function HomeAlertsCard({
   artist,
   onAlertsClick,
@@ -105,11 +92,8 @@ function HomeAlertsCard({
   renderMode: ProfileRenderMode;
   sourceContext: NotificationSourceContext;
 }>) {
-  const title = 'Alerts';
-  const description = `${artist.name}: music, shows, merch.`;
   const isInteractive = renderMode === 'interactive';
   const subscribeHref = `/${artist.handle}?mode=subscribe`;
-  const ariaLabel = `Turn on alerts for ${artist.name}`;
   const handleClick = isInteractive
     ? (event: MouseEvent<HTMLElement>) => {
         if (!onAlertsClick) {
@@ -120,21 +104,33 @@ function HomeAlertsCard({
       }
     : undefined;
 
+  // The alerts card is a standard unified-anatomy card — icon art zone,
+  // context eyebrow, "Alerts" title, one-line body, full-width CTA — the
+  // same design as every other card in the home carousel.
+  const model: EntityCardModel = {
+    id: `alerts-${artist.id}`,
+    kind: 'alerts',
+    href: isInteractive ? subscribeHref : null,
+    imageUrl: null,
+    imageAlt: `Alerts for ${artist.name}`,
+    eyebrow: artist.name,
+    title: 'Alerts',
+    meta: 'Music, shows, merch — first.',
+    cta: {
+      label: 'Get Updates',
+      href: isInteractive ? subscribeHref : null,
+    },
+  };
+
   return (
-    <ProfileEmptyBentoCard
-      accent='alerts'
-      icon={Bell}
-      title={title}
-      body={description}
-      // Carousel card geometry: the prominent column layout fills the fixed
-      // 3:4 card box; the inline strip layout is gone with the stacked rail.
-      layout='prominent'
-      className='h-full'
-      trailing={<HomeAlertsSwitch />}
-      href={isInteractive ? subscribeHref : undefined}
-      onClick={handleClick}
-      ariaLabel={ariaLabel}
+    <EntityCard
+      model={model}
+      treatment='detailed'
+      surface='pearl'
+      anatomy='unified'
+      className='h-full w-full overflow-hidden'
       dataTestId='profile-home-alerts-fallback-card'
+      onClick={handleClick}
     />
   );
 }
@@ -287,6 +283,7 @@ export const ProfileHomeRail = memo(function ProfileHomeRail({
           city: show.city,
           startDate: show.startDate,
           ticketUrl: show.ticketUrl,
+          ticketStatus: show.ticketStatus,
         })
       );
     }

--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -577,11 +577,6 @@ export function ProfilePrimaryTabPanel({
           tourDates={[...tourDates]}
           emptyStateSourceContext={eventsEmptySourceContext}
           renderMode={renderMode}
-          className={
-            tourDates.length === 0
-              ? 'flex flex-1 flex-col justify-center'
-              : undefined
-          }
         />
       </div>
     );

--- a/apps/web/components/features/profile/ReleaseCatalogCarousel.tsx
+++ b/apps/web/components/features/profile/ReleaseCatalogCarousel.tsx
@@ -86,11 +86,14 @@ export function ReleaseCatalogCarousel({
       dataTestId={dataTestId}
       leading={leading}
       trailing={trailing}
-      // Edge-to-edge: cancel the surface's --page-pad with a negative margin,
-      // then re-inset the track so the first card aligns with the padded
-      // content above while later cards scroll off the true surface edge.
+      // Edge-to-edge on mobile: cancel the surface's --page-pad with a
+      // negative margin, then re-inset the track so the first card aligns
+      // with the padded content above while later cards scroll off the true
+      // surface edge. On desktop the shell's rounded corner would clip the
+      // peek card mid-radius, so the track stays inside the padded gutter and
+      // its own straight clip edge crops the peek card instead.
       // min-h-0 + flex-1 lets the track own all remaining viewport height.
-      className='-mx-(--page-pad) min-h-0 flex-1 scroll-px-(--page-pad) px-(--page-pad)'
+      className='-mx-(--page-pad) min-h-0 flex-1 scroll-px-(--page-pad) px-(--page-pad) md:mx-0 md:scroll-px-0 md:px-0'
       onCardImpression={handleCardImpression}
       onCardClick={handleCardClick}
     />

--- a/apps/web/components/features/profile/ReleaseCatalogCarousel.tsx
+++ b/apps/web/components/features/profile/ReleaseCatalogCarousel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { type ReactNode, useCallback } from 'react';
 import { EntityCarousel } from '@/components/organisms/entity-card';
 import type { EntityCardModel } from '@/components/organisms/entity-card/types';
 import { track } from '@/lib/analytics';
@@ -11,6 +11,10 @@ interface ReleaseCatalogCarouselProps {
   readonly artistId: string;
   readonly analyticsEnabled?: boolean;
   readonly dataTestId?: string;
+  /** Featured first card (PAC) rendered in the same card geometry. */
+  readonly leading?: ReactNode;
+  /** Final card (alerts) rendered in the same card geometry. */
+  readonly trailing?: ReactNode;
 }
 
 function isCatalogReleaseCard(
@@ -29,6 +33,8 @@ export function ReleaseCatalogCarousel({
   artistId,
   analyticsEnabled = true,
   dataTestId = 'profile-home-carousel',
+  leading,
+  trailing,
 }: Readonly<ReleaseCatalogCarouselProps>) {
   const handleCardImpression = useCallback(
     (index: number, model: EntityCardModel) => {
@@ -78,10 +84,13 @@ export function ReleaseCatalogCarousel({
       items={items}
       surface='pearl'
       dataTestId={dataTestId}
+      leading={leading}
+      trailing={trailing}
       // Edge-to-edge: cancel the surface's --page-pad with a negative margin,
       // then re-inset the track so the first card aligns with the padded
       // content above while later cards scroll off the true surface edge.
-      className='-mx-(--page-pad) scroll-px-(--page-pad) px-(--page-pad)'
+      // min-h-0 + flex-1 lets the track own all remaining viewport height.
+      className='-mx-(--page-pad) min-h-0 flex-1 scroll-px-(--page-pad) px-(--page-pad)'
       onCardImpression={handleCardImpression}
       onCardClick={handleCardClick}
     />

--- a/apps/web/components/features/profile/TourModePanel.tsx
+++ b/apps/web/components/features/profile/TourModePanel.tsx
@@ -160,12 +160,9 @@ function TourDateRow({
           {getTicketStatusLabel(item.date.ticketStatus, canBuyTickets)}
         </a>
       ) : (
-        <span
-          className={cn(
-            'inline-flex min-h-11 shrink-0 items-center rounded-xl border px-3 text-xs font-semibold tracking-tight',
-            getTicketStatusClassName(item.date.ticketStatus, canBuyTickets)
-          )}
-        >
+        // No ticket target: plain muted meta text — a non-interactive span
+        // must never wear button chrome.
+        <span className='shrink-0 text-xs font-medium text-white/38'>
           {getTicketStatusLabel(item.date.ticketStatus, canBuyTickets)}
         </span>
       )}

--- a/apps/web/components/features/profile/TourModePanel.tsx
+++ b/apps/web/components/features/profile/TourModePanel.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils';
 import { formatLocationString } from '@/lib/utils/string-utils';
 import type { Artist } from '@/types/db';
 import { ArtistNotificationsCTA } from './artist-notifications-cta/ArtistNotificationsCTA';
+import { subscriptionPrimaryActionClassName } from './artist-notifications-cta/shared';
 import type { NotificationSourceContext } from './artist-notifications-cta/types';
 import { ProfileDrawerShell } from './ProfileDrawerShell';
 
@@ -189,7 +190,7 @@ function TourDatesContent({
         <Button
           type='button'
           variant='primary'
-          className='h-11 w-full rounded-full'
+          className='h-9 w-full rounded-full'
           disabled
         >
           Event Alerts
@@ -202,6 +203,8 @@ function TourDatesContent({
           source={emptyStateSourceContext.ctaLocation}
           sourceContext={emptyStateSourceContext}
           triggerLabel='Event Alerts'
+          // Unified 36px CTA scale — matches the Listen CTA on home cards.
+          triggerClassName={`${subscriptionPrimaryActionClassName} h-9! w-full justify-center gap-2 px-4 text-xs`}
           presentation='overlay'
         />
       );
@@ -244,7 +247,7 @@ function TourDatesContent({
     <div data-testid='tour-drawer-list'>
       {groups.map(group => (
         <section key={group.label} className='pb-4'>
-          <div className='px-4 pb-2 pt-3 text-2xs font-bold uppercase tracking-[0.16em] text-white/32'>
+          <div className='px-4 pb-2 pt-3 text-2xs font-semibold text-tertiary-token'>
             {group.label}
           </div>
           <div className='border-y border-white/[0.075]'>

--- a/apps/web/components/features/profile/artist-notifications-cta/ArtistNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ArtistNotificationsCTA.tsx
@@ -17,6 +17,7 @@ export function ArtistNotificationsCTA({
   source,
   sourceContext,
   triggerLabel,
+  triggerClassName,
 }: ArtistNotificationsCTAProps) {
   const resolvedPresentation =
     presentation ?? (autoOpen || forceExpanded ? 'inline' : 'overlay');
@@ -35,6 +36,7 @@ export function ArtistNotificationsCTA({
       source={source}
       sourceContext={sourceContext}
       triggerLabel={triggerLabel}
+      triggerClassName={triggerClassName}
     />
   );
 }

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -61,6 +61,8 @@ export interface ProfileInlineNotificationsCTAProps {
   readonly source?: NotificationSource;
   readonly sourceContext?: NotificationSourceContext;
   readonly triggerLabel?: string;
+  /** Optional trigger className override (e.g. the 36px empty-state CTA). */
+  readonly triggerClassName?: string;
   readonly experimentVariant?: ProfileAlertOptInVariant;
 }
 
@@ -173,6 +175,7 @@ export function ProfileInlineNotificationsCTA({
   source,
   sourceContext,
   triggerLabel: triggerLabelProp,
+  triggerClassName: triggerClassNameProp,
   experimentVariant,
 }: ProfileInlineNotificationsCTAProps) {
   const { contentPreferences, artistEmail, subscriptionDetails } =
@@ -834,7 +837,7 @@ export function ProfileInlineNotificationsCTA({
   const triggerLabel = isSubscribed
     ? 'Manage alerts'
     : (triggerLabelProp ?? 'Get alerts');
-  const triggerClassName = getTriggerClassName(variant);
+  const triggerClassName = triggerClassNameProp ?? getTriggerClassName(variant);
   const trigger =
     isInline || hideTrigger ? null : (
       <button

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -9,6 +9,10 @@ import { captureError } from '@/lib/error-tracking';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
 import { readArtistEmailReadyFromSettings } from '@/lib/notifications/artist-email';
 import { normalizeSubscriptionEmail } from '@/lib/notifications/validation';
+import {
+  getCaptureDismissalStatus,
+  invalidateCaptureDismissalStatus,
+} from '@/lib/profile/capture-dismissal-client';
 import { readProfileAccentTheme } from '@/lib/profile/profile-theme';
 import {
   useUpdateContentPreferencesMutation,
@@ -401,19 +405,11 @@ export function ProfileInlineNotificationsCTA({
     }
 
     let isActive = true;
-    fetch(`/api/profile/capture-dismissal?artist_id=${artist.id}`, {
-      cache: 'no-store',
-    })
-      .then(async response => {
-        if (!response.ok) return;
-        const data = (await response.json()) as {
-          readonly suppressed?: boolean;
-        };
-        if (isActive) {
-          setCaptureSuppressed(Boolean(data.suppressed));
-        }
-      })
-      .catch(() => {});
+    void getCaptureDismissalStatus(artist.id).then(data => {
+      if (isActive) {
+        setCaptureSuppressed(Boolean(data?.suppressed));
+      }
+    });
 
     return () => {
       isActive = false;
@@ -579,6 +575,7 @@ export function ProfileInlineNotificationsCTA({
         throw new Error('Capture dismissal failed');
       }
 
+      invalidateCaptureDismissalStatus(artist.id);
       handleClose();
     } catch (error) {
       void captureError('Profile capture dismissal failed', error, {

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
@@ -91,8 +91,11 @@ const FLOW_TRANSITION = {
   ease: [0.22, 1, 0.36, 1] as const,
 };
 
-const CAPTURE_CONSENT_COPY =
-  'By submitting, you agree to receive updates from this artist and Jovie. Reply STOP to opt out. Message and data rates may apply.';
+const CAPTURE_CONSENT_COPY: Record<'email' | 'sms', string> = {
+  email:
+    'By submitting, you agree to receive email updates from this artist and Jovie. Unsubscribe anytime.',
+  sms: 'By submitting, you agree to receive text updates from this artist and Jovie. Reply STOP to opt out. Message and data rates may apply.',
+};
 
 const PREFERENCE_META: Record<
   Extract<NotificationContentType, 'newMusic' | 'tourDates' | 'merch'>,
@@ -511,8 +514,8 @@ export function ProfileMobileNotificationsFlow({
                   {error}
                 </p>
               ) : null}
-              <p className='text-xs leading-4 text-white/42'>
-                {CAPTURE_CONSENT_COPY}
+              <p className='text-xs leading-4 text-tertiary-token'>
+                {CAPTURE_CONSENT_COPY[isSms ? 'sms' : 'email']}
               </p>
               <div className='flex items-center justify-between gap-3'>
                 <button
@@ -831,7 +834,9 @@ export function ProfileMobileNotificationsFlow({
 
   const contentBody = (
     <>
-      <div className='absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.055),transparent_42%)]' />
+      {presentation === 'inline' ? null : (
+        <div className='absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.055),transparent_42%)]' />
+      )}
 
       <div
         className={cn(
@@ -925,8 +930,10 @@ export function ProfileMobileNotificationsFlow({
         </div>
       </div>
     ) : (
+      // Inline: transparent so the sheet sits on the page's own surface with
+      // no rounded seam against a mismatched background token.
       <div
-        className='relative flex h-full min-h-full flex-1 flex-col rounded-(--profile-card-radius) bg-[color:var(--profile-stage-bg)] dark:text-white'
+        className='relative flex h-full min-h-full flex-1 flex-col dark:text-white'
         data-testid='profile-mobile-notifications-flow'
         data-shell-variant='inline-full-height'
         style={contentStyle}

--- a/apps/web/components/features/profile/artist-notifications-cta/types.ts
+++ b/apps/web/components/features/profile/artist-notifications-cta/types.ts
@@ -87,4 +87,10 @@ export interface ArtistNotificationsCTAProps {
   readonly source?: NotificationSource;
   readonly sourceContext?: NotificationSourceContext;
   readonly triggerLabel?: string;
+  /**
+   * Optional override for the trigger button's className. Used by surface
+   * empty states that need the trigger on the unified 36px CTA scale instead
+   * of the default 48px pill.
+   */
+  readonly triggerClassName?: string;
 }

--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -179,7 +179,9 @@ function SubjectText({
       <p className='truncate text-sm font-semibold leading-tight text-primary-token'>
         {title}
       </p>
-      <p className='mt-0.5 truncate text-xs text-tertiary-token'>{meta}</p>
+      <p className='entity-card-meta mt-0.5 truncate text-xs text-tertiary-token'>
+        {meta}
+      </p>
     </div>
   );
 }
@@ -764,7 +766,7 @@ export function ProfilePacCard({
         className
       )}
     >
-      <div className='relative min-h-0 w-full flex-1 overflow-hidden border-b border-subtle bg-surface-2'>
+      <div className='relative aspect-square w-full flex-none overflow-hidden border-b border-subtle bg-surface-2'>
         {artImageUrl ? (
           <ImageWithFallback
             src={artImageUrl}
@@ -772,7 +774,7 @@ export function ProfilePacCard({
             fill
             priority={artPriority}
             sizes='(max-width: 767px) 70vw, 300px'
-            className='object-contain'
+            className='object-cover'
             fallbackVariant='release'
             fallbackClassName='bg-transparent'
           />
@@ -783,20 +785,22 @@ export function ProfilePacCard({
         )}
       </div>
 
-      <div className='flex min-h-0 min-w-0 flex-none flex-col gap-2 p-3'>
-        <div className='flex items-center justify-between gap-2'>
-          <p className='truncate text-3xs font-semibold uppercase leading-none tracking-wide text-tertiary-token'>
-            {contextLabel}
-          </p>
-          {contextAside}
+      <div className='flex min-h-0 min-w-0 flex-1 flex-col gap-1.5 px-3 py-1.5'>
+        {/* Text zone — clips under tight card heights so the action footer
+            below never moves and never clips (zero-CLS contract). */}
+        <div className='flex min-h-0 min-w-0 flex-1 flex-col gap-1.5 overflow-hidden'>
+          <div className='flex items-center justify-between gap-2'>
+            <p className='entity-card-eyebrow truncate text-3xs font-semibold uppercase leading-none tracking-wide text-tertiary-token'>
+              {contextLabel}
+            </p>
+            {contextAside}
+          </div>
+
+          {subject}
         </div>
 
-        {subject}
-
-        {isCaptureState ? <div className='min-w-0'>{action}</div> : null}
-
-        <div className='mt-auto flex min-w-0 flex-col gap-2 pt-1'>
-          {isCaptureState ? null : action}
+        <div className='flex min-w-0 flex-none flex-col gap-1.5'>
+          {isCaptureState ? <div className='min-w-0'>{action}</div> : action}
           <div aria-live='polite' className='min-w-0 empty:hidden'>
             {status}
           </div>

--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -73,6 +73,11 @@ interface ProfilePacCardProps {
   readonly isSubscribed?: boolean;
   readonly renderMode?: ProfileRenderMode;
   readonly className?: string;
+  /**
+   * Priority-load the artwork image. Set by the surface when there is no
+   * hero photo — then this card's art is the page LCP and must not lazy-load.
+   */
+  readonly artPriority?: boolean;
 }
 
 interface CaptureCopy {
@@ -189,6 +194,7 @@ export function ProfilePacCard({
   isSubscribed = false,
   renderMode = 'interactive',
   className,
+  artPriority = false,
 }: Readonly<ProfilePacCardProps>) {
   const isInteractive = renderMode === 'interactive';
   const previewUrl = release?.previewUrl ?? null;
@@ -764,6 +770,7 @@ export function ProfilePacCard({
             src={artImageUrl}
             alt={artImageAlt}
             fill
+            priority={artPriority}
             sizes='(max-width: 767px) 70vw, 300px'
             className='object-contain'
             fallbackVariant='release'

--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -23,6 +23,10 @@ import type {
 import type { PublicMerchCard } from '@/lib/merch/types';
 import { subscribeToNotifications } from '@/lib/notifications/client';
 import { normalizeSubscriptionEmail } from '@/lib/notifications/validation';
+import {
+  getCaptureDismissalStatus,
+  invalidateCaptureDismissalStatus,
+} from '@/lib/profile/capture-dismissal-client';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import type { PacState as PacEventState } from '@/lib/tracking/pac-events-contract';
 import { cn } from '@/lib/utils';
@@ -258,19 +262,13 @@ export function ProfilePacCard({
   // the prompt eligible and the API re-validates on write.
   useEffect(() => {
     if (!isInteractive || isSubscribed) return;
-    const controller = new AbortController();
-    void fetch(
-      `/api/profile/capture-dismissal?artist_id=${encodeURIComponent(artist.id)}`,
-      { signal: controller.signal, credentials: 'same-origin' }
-    )
-      .then(res => (res.ok ? res.json() : null))
-      .then((data: { suppressed?: boolean } | null) => {
-        if (data?.suppressed) setCaptureSuppressed(true);
-      })
-      .catch(() => {
-        // Best-effort only.
-      });
-    return () => controller.abort();
+    let cancelled = false;
+    void getCaptureDismissalStatus(artist.id).then(data => {
+      if (!cancelled && data?.suppressed) setCaptureSuppressed(true);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [artist.id, isInteractive, isSubscribed]);
 
   // --- Playback: register with the single global audio engine (#12330).
@@ -462,9 +460,13 @@ export function ProfilePacCard({
       headers: { 'Content-Type': 'application/json' },
       credentials: 'same-origin',
       body: JSON.stringify({ artist_id: artist.id, source: 'profile_pac' }),
-    }).catch(() => {
-      // Best-effort — suppression is also held in memory for this session.
-    });
+    })
+      .then(res => {
+        if (res.ok) invalidateCaptureDismissalStatus(artist.id);
+      })
+      .catch(() => {
+        // Best-effort — suppression is also held in memory for this session.
+      });
   }, [artist.id, assignment.dismissAffordance, dispatch, emit]);
 
   const handleSecondaryClick = useCallback(

--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -772,7 +772,6 @@ export function ProfilePacCard({
             src={artImageUrl}
             alt={artImageAlt}
             fill
-            priority={artPriority}
             sizes='(max-width: 767px) 70vw, 300px'
             className='object-cover'
             fallbackVariant='release'
@@ -790,7 +789,7 @@ export function ProfilePacCard({
             below never moves and never clips (zero-CLS contract). */}
         <div className='flex min-h-0 min-w-0 flex-1 flex-col gap-1.5 overflow-hidden'>
           <div className='flex items-center justify-between gap-2'>
-            <p className='entity-card-eyebrow truncate text-3xs font-semibold uppercase leading-none tracking-wide text-tertiary-token'>
+            <p className='entity-card-eyebrow truncate text-3xs font-semibold leading-none text-tertiary-token'>
               {contextLabel}
             </p>
             {contextAside}

--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -39,20 +39,18 @@ import {
 } from './pac-machine';
 
 /**
- * Primary Action Card — the one card below the profile hero that resolves
- * per visitor state (spec #13060/#13061).
+ * Primary Action Card — the featured first card of the profile home carousel
+ * that resolves per visitor state (spec #13060/#13061).
  *
- * Anatomy (4 zones): context strip / subject / action / status.
+ * Card anatomy: art zone (release/state artwork, square) on top, content zone
+ * below (context label / subject / action / status). The prompt state swaps
+ * the content zone to the capture form INSIDE the same fixed card box.
  *
- * Zero-CLS contract: the server renders the S0 default inside a container
- * with a reserved fixed height. State transitions animate the container's
- * own height (420ms cinematic easing, 0ms under reduced motion via the
- * `--duration-cinematic` token) — content below the card never shifts
- * during hydration, and moves only through the deliberate height animation
- * on user-driven transitions.
+ * Zero-CLS contract: the card lives inside the carousel's reserved 3:4
+ * geometry (`.profile-entity-card`), so state transitions never move any
+ * element outside the card — no height animation, no ResizeObserver, content
+ * below the carousel never shifts.
  */
-
-const PAC_RESERVED_HEIGHT_PX = 112;
 
 export interface ProfilePacRelease {
   readonly title: string;
@@ -96,10 +94,6 @@ function getCaptureCopy(
     cta: 'Get Updates',
   };
 }
-
-const CARD_RADIUS_STYLE = {
-  borderRadius: 'var(--profile-action-radius)',
-} as const;
 
 function PrimaryPill({
   children,
@@ -164,44 +158,19 @@ function PrimaryPill({
   );
 }
 
-function SubjectZone({
-  imageUrl,
-  imageAlt,
+function SubjectText({
   title,
   meta,
 }: Readonly<{
-  imageUrl: string | null;
-  imageAlt: string;
   title: string;
   meta: string;
 }>) {
   return (
-    <div className='flex min-w-0 flex-1 items-center gap-3'>
-      <div
-        className='relative h-12 w-12 shrink-0 overflow-hidden rounded-xl bg-white/10'
-        aria-hidden={imageUrl ? undefined : true}
-      >
-        {imageUrl ? (
-          <ImageWithFallback
-            src={imageUrl}
-            alt={imageAlt}
-            fill
-            sizes='48px'
-            className='object-cover'
-            fallbackVariant='release'
-          />
-        ) : (
-          <div className='flex h-full w-full items-center justify-center text-white/50'>
-            <Play className='h-4 w-4 fill-current' />
-          </div>
-        )}
-      </div>
-      <div className='min-w-0 flex-1'>
-        <p className='truncate text-sm font-semibold leading-tight text-white dark:text-white'>
-          {title}
-        </p>
-        <p className='mt-0.5 truncate text-xs text-white/60'>{meta}</p>
-      </div>
+    <div className='min-w-0'>
+      <p className='truncate text-sm font-semibold leading-tight text-primary-token'>
+        {title}
+      </p>
+      <p className='mt-0.5 truncate text-xs text-tertiary-token'>{meta}</p>
     </div>
   );
 }
@@ -505,22 +474,6 @@ export function ProfilePacCard({
     [emit, state.kind]
   );
 
-  // --- Zero-CLS height reservation + 420ms self-height animation.
-  const innerRef = useRef<HTMLDivElement>(null);
-  const [heightPx, setHeightPx] = useState<number>(PAC_RESERVED_HEIGHT_PX);
-  useEffect(() => {
-    const node = innerRef.current;
-    if (!node || typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(entries => {
-      const measured = entries[0]?.contentRect.height;
-      if (typeof measured === 'number' && measured > 0) {
-        setHeightPx(Math.max(Math.round(measured), PAC_RESERVED_HEIGHT_PX));
-      }
-    });
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, []);
-
   // --- Zone content per state.
   const copy = getCaptureCopy(assignment.copyArm, artist.name);
   const listenHref = release?.slug
@@ -534,12 +487,7 @@ export function ProfilePacCard({
   let contextAside: ReactNode = null;
 
   const releaseSubject = (
-    <SubjectZone
-      imageUrl={release?.artworkUrl ?? artist.image_url ?? null}
-      imageAlt={release ? `${release.title} artwork` : artist.name}
-      title={release?.title ?? artist.name}
-      meta={artist.name}
-    />
+    <SubjectText title={release?.title ?? artist.name} meta={artist.name} />
   );
 
   switch (state.kind) {
@@ -581,7 +529,7 @@ export function ProfilePacCard({
               onSeek={seek}
               className='h-1.5 flex-1'
             />
-            <span className='shrink-0 text-xs tabular-nums text-white/50'>
+            <span className='shrink-0 text-xs tabular-nums text-tertiary-token'>
               {formatDuration(playbackState.currentTime * 1000)}
             </span>
           </div>
@@ -619,14 +567,7 @@ export function ProfilePacCard({
           )}
         </button>
       );
-      subject = (
-        <div className='min-w-0 flex-1'>
-          <p className='truncate text-sm font-semibold leading-tight text-white dark:text-white'>
-            {copy.title}
-          </p>
-          <p className='mt-0.5 truncate text-xs text-white/60'>{copy.body}</p>
-        </div>
-      );
+      subject = <SubjectText title={copy.title} meta={copy.body} />;
       action = (
         <form
           onSubmit={handleCaptureSubmit}
@@ -671,14 +612,10 @@ export function ProfilePacCard({
     case 'success': {
       contextLabel = 'Stay In The Loop';
       subject = (
-        <div className='min-w-0 flex-1'>
-          <p className='truncate text-sm font-semibold leading-tight text-white dark:text-white'>
-            {"You're in"}
-          </p>
-          <p className='mt-0.5 truncate text-xs text-white/60'>
-            Watch your inbox for {artist.name} updates.
-          </p>
-        </div>
+        <SubjectText
+          title={"You're in"}
+          meta={`Watch your inbox for ${artist.name} updates.`}
+        />
       );
       status = null;
       break;
@@ -687,9 +624,7 @@ export function ProfilePacCard({
     case 'merch': {
       contextLabel = 'Merch';
       subject = (
-        <SubjectZone
-          imageUrl={merchCard?.primaryImageUrl ?? null}
-          imageAlt={merchCard?.title ?? 'Merch'}
+        <SubjectText
           title={merchCard?.title ?? `${artist.name} merch`}
           meta={
             merchCard ? formatAmount(merchCard.retailPriceCents) : artist.name
@@ -710,14 +645,10 @@ export function ProfilePacCard({
     case 'tip': {
       contextLabel = 'Support';
       subject = (
-        <div className='min-w-0 flex-1'>
-          <p className='truncate text-sm font-semibold leading-tight text-white dark:text-white'>
-            Support {artist.name}
-          </p>
-          <p className='mt-0.5 truncate text-xs text-white/60'>
-            Tips go straight to the artist.
-          </p>
-        </div>
+        <SubjectText
+          title={`Support ${artist.name}`}
+          meta='Tips go straight to the artist.'
+        />
       );
       action = (
         <PrimaryPill
@@ -737,14 +668,10 @@ export function ProfilePacCard({
         .filter(Boolean)
         .join(' · ');
       subject = (
-        <div className='min-w-0 flex-1'>
-          <p className='truncate text-sm font-semibold leading-tight text-white dark:text-white'>
-            {nextShow?.title ?? `${artist.name} live`}
-          </p>
-          <p className='mt-0.5 truncate text-xs text-white/60'>
-            {showMeta || 'Upcoming show'}
-          </p>
-        </div>
+        <SubjectText
+          title={nextShow?.title ?? `${artist.name} live`}
+          meta={showMeta || 'Upcoming show'}
+        />
       );
       action =
         state.kind === 'tickets' && nextShow?.ticketUrl ? (
@@ -769,14 +696,10 @@ export function ProfilePacCard({
     case 'following': {
       contextLabel = 'Following';
       subject = (
-        <div className='min-w-0 flex-1'>
-          <p className='truncate text-sm font-semibold leading-tight text-white dark:text-white'>
-            You follow {artist.name}
-          </p>
-          <p className='mt-0.5 truncate text-xs text-white/60'>
-            {"You'll hear about new drops first."}
-          </p>
-        </div>
+        <SubjectText
+          title={`You follow ${artist.name}`}
+          meta="You'll hear about new drops first."
+        />
       );
       action = (
         <PrimaryPill
@@ -790,11 +713,31 @@ export function ProfilePacCard({
     }
   }
 
-  // Merge exposure + height refs on the outer section (callback refs).
+  const isCaptureState =
+    state.kind === 'prompt' ||
+    state.kind === 'submitting' ||
+    state.kind === 'error';
+
+  // Art zone: state-relevant artwork. The merch state shows the merch image;
+  // every other state shows the release artwork (artist image as fallback).
+  const artImageUrl =
+    state.kind === 'merch'
+      ? (merchCard?.primaryImageUrl ??
+        release?.artworkUrl ??
+        artist.image_url ??
+        null)
+      : (release?.artworkUrl ?? artist.image_url ?? null);
+  const artImageAlt =
+    state.kind === 'merch'
+      ? (merchCard?.title ?? 'Merch')
+      : release
+        ? `${release.title} artwork`
+        : artist.name;
+
+  // Exposure ref on the outer card (callback ref).
   const sectionRef = useCallback(
     (node: HTMLElement | null) => {
       exposureRef(node);
-      // height measurement lives on the inner content node, not the section.
     },
     [exposureRef]
   );
@@ -809,39 +752,45 @@ export function ProfilePacCard({
       data-degraded={state.degraded ? 'true' : undefined}
       data-dismiss-affordance={assignment.dismissAffordance}
       className={cn(
-        'w-full overflow-hidden border border-white/10 bg-white/5 backdrop-blur-2xl',
+        'flex h-full w-full min-w-0 flex-col overflow-hidden rounded-(--profile-inner-radius) border border-(--profile-pearl-border) bg-(--profile-pearl-bg) shadow-(--profile-pearl-shadow) backdrop-blur-2xl',
         className
       )}
-      style={{
-        ...CARD_RADIUS_STYLE,
-        height: heightPx,
-        transition: 'height var(--duration-cinematic) var(--ease-cinematic)',
-      }}
     >
-      <div
-        ref={innerRef}
-        className='flex flex-col justify-center gap-3 p-4'
-        style={{ minHeight: PAC_RESERVED_HEIGHT_PX }}
-      >
-        <div className='flex items-center justify-between gap-3'>
-          <p className='truncate text-xs font-medium text-white/50'>
+      <div className='relative min-h-0 w-full flex-1 overflow-hidden border-b border-subtle bg-surface-2'>
+        {artImageUrl ? (
+          <ImageWithFallback
+            src={artImageUrl}
+            alt={artImageAlt}
+            fill
+            sizes='(max-width: 767px) 70vw, 300px'
+            className='object-contain'
+            fallbackVariant='release'
+            fallbackClassName='bg-transparent'
+          />
+        ) : (
+          <div className='flex h-full w-full items-center justify-center text-tertiary-token'>
+            <Play className='h-7 w-7 fill-current' aria-hidden='true' />
+          </div>
+        )}
+      </div>
+
+      <div className='flex min-h-0 min-w-0 flex-none flex-col gap-2 p-3'>
+        <div className='flex items-center justify-between gap-2'>
+          <p className='truncate text-3xs font-semibold uppercase leading-none tracking-wide text-tertiary-token'>
             {contextLabel}
           </p>
           {contextAside}
         </div>
-        <div className='flex min-w-0 items-center justify-between gap-3'>
-          {subject}
-          {state.kind === 'prompt' ||
-          state.kind === 'submitting' ||
-          state.kind === 'error'
-            ? null
-            : action}
-        </div>
-        {(state.kind === 'prompt' ||
-          state.kind === 'submitting' ||
-          state.kind === 'error') && <div>{action}</div>}
-        <div aria-live='polite' className='min-w-0 empty:hidden'>
-          {status}
+
+        {subject}
+
+        {isCaptureState ? <div className='min-w-0'>{action}</div> : null}
+
+        <div className='mt-auto flex min-w-0 flex-col gap-2 pt-1'>
+          {isCaptureState ? null : action}
+          <div aria-live='polite' className='min-w-0 empty:hidden'>
+            {status}
+          </div>
         </div>
       </div>
     </section>

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -820,6 +820,7 @@ export function ProfileCompactSurface({
                 merchCards={merchCards}
                 releases={releases}
                 hasTip={hasTip}
+                pacArtPriority={!resolvedHeroImageUrl}
               />
             ) : (
               <ProfilePrimaryTabPanel

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -431,16 +431,13 @@ export function ProfileCompactSurface({
     'h-11! w-11! border-white/14 bg-black/24 text-white dark:text-white shadow-[0_10px_24px_rgba(0,0,0,0.22)] backdrop-blur-md hover:bg-black/36';
   const socialIconClassName =
     'inline-flex h-7 w-7 items-center justify-center text-white/68 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
-  // Composition rule (#11899, lib/profile/composition.ts): hero media has
-  // priority — it grows with the viewport (flex-1, #11083) but never shrinks
-  // below the 240px floor (min-h-60). On short viewports it locks to exactly
-  // the floor and the rail below scrolls; the image crops (object-cover),
-  // never squashes.
-  // Compact viewports (height ≤820, iPhone SE / short chrome): compress the
-  // hero to ≤190px so the bento release card stays above the fold
-  // (profile-mobile-viewport-stability). Taller phones keep flex growth.
+  // Composition rule: the home hero has one definite token-driven height
+  // (h-(--cover-height) = clamp(220px, 34svh, 400px)) on every viewport. It
+  // never shrink-wraps — the old short-viewport min-h-0/flex-none band
+  // collapse is gone. Media crops via object-cover, never squashes; the
+  // carousel below owns the remaining viewport height.
   const heroHeightClassName = isHomeMode
-    ? 'min-h-(--cover-height) flex-1 [@media(max-height:820px)]:flex-none [@media(max-height:820px)]:min-h-0 [@media(max-height:820px)]:max-h-[190px]'
+    ? 'h-(--cover-height) shrink-0'
     : 'h-[calc(3.5rem+max(env(safe-area-inset-top),0px))]';
   const homeContentColumnClassName = 'min-h-0 flex-1';
   const homeContentScrollClassName = 'min-h-0 flex-1';
@@ -592,8 +589,10 @@ export function ProfileCompactSurface({
                 )}
               </div>
 
-              <div className='profile-cover-home-gradient pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(2,3,4,0.1)_0%,rgba(2,3,4,0.18)_30%,rgba(3,4,6,0.48)_64%,rgba(5,6,8,0.94)_88%,var(--profile-stage-bg)_100%)]' />
-              <div className='profile-cover-home-fade pointer-events-none absolute inset-x-0 bottom-0 h-28 bg-[linear-gradient(180deg,transparent,var(--profile-stage-bg)_90%)]' />
+              <div
+                className='profile-cover-home-gradient pointer-events-none'
+                aria-hidden='true'
+              />
             </>
           ) : null}
 
@@ -787,7 +786,16 @@ export function ProfileCompactSurface({
               // shell edge, where profile-compact-surface already clips.
               isHomeMode && '-mx-(--page-pad) px-(--page-pad)',
               homeContentScrollClassName,
-              showBottomNav ? CONTENT_SAFE_AREA_BOTTOM_PADDING : 'pb-0',
+              // Home mode: the scroll region becomes a flex column so the
+              // carousel rail can flex into the full remaining height
+              // (percentage heights fail against flexed parents).
+              isHomeMode && 'flex flex-col',
+              // Exactly ONE tab-bar reservation: when the bar is visible it
+              // is in-flow below the scroll region and IS the reservation
+              // (no extra padding — that double-counted ~74px of dead space).
+              // When the bar is hidden (cold visitor) the padding reserves
+              // the same footprint so the bar appearing causes no shift.
+              showBottomNav ? 'pb-0' : CONTENT_SAFE_AREA_BOTTOM_PADDING,
               !isHomeMode &&
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70'
             )}

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -26,7 +26,6 @@ import type { PublicRelease } from '@/features/profile/releases/types';
 import { SubscriptionConfirmedBanner } from '@/features/profile/SubscriptionConfirmedBanner';
 import type { UserLocation } from '@/hooks/useUserLocation';
 import { track } from '@/lib/analytics';
-import { Mark } from '@/lib/brand/primitives';
 import { sortDSPsByGeoPopularity } from '@/lib/dsp';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
 import {
@@ -288,7 +287,6 @@ export function ProfileCompactSurface({
   dataTestId,
   hideBackButton = false,
   hideMoreMenu = false,
-  hideJovieBranding = false,
   headerSocialLinksOverride,
   renderInteractiveOverlays = true,
   renderSemanticHeading = true,
@@ -428,9 +426,11 @@ export function ProfileCompactSurface({
   const isMenuActive =
     drawerOpen && drawerView === 'menu' && activeVisiblePrimaryTab !== 'tour';
   const topChromeButtonClassName =
-    'h-11! w-11! border-white/14 bg-black/24 text-white dark:text-white shadow-[0_10px_24px_rgba(0,0,0,0.22)] backdrop-blur-md hover:bg-black/36';
+    'profile-top-chrome-icon text-white dark:text-white';
+  // 28px visual glyph box with a 44×44 hit area: box-content + p-2 grows the
+  // hit box to 44px while -m-2 cancels the layout footprint (no shift).
   const socialIconClassName =
-    'inline-flex h-7 w-7 items-center justify-center text-white/68 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
+    'box-content inline-flex h-7 w-7 items-center justify-center p-2 -m-2 text-white/68 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
   // Composition rule: the home hero has one definite token-driven height
   // (h-(--cover-height) = clamp(220px, 34svh, 400px)) on every viewport. It
   // never shrink-wraps — the old short-viewport min-h-0/flex-none band
@@ -616,7 +616,7 @@ export function ProfileCompactSurface({
                 <CircleIconButton
                   onClick={onBack}
                   size='lg'
-                  variant='pearl'
+                  variant='pearlQuiet'
                   className={topChromeButtonClassName}
                   ariaLabel='Back'
                 >
@@ -644,15 +644,14 @@ export function ProfileCompactSurface({
                 <CircleIconButton
                   onClick={onOpenMenu}
                   size='lg'
-                  variant='pearl'
+                  variant='pearlQuiet'
                   className={topChromeButtonClassName}
                   ariaLabel='Menu'
                 >
-                  {hideJovieBranding ? (
-                    <MoreHorizontal className='h-5 w-5' />
-                  ) : (
-                    <Mark size={18} className='h-5 w-5' />
-                  )}
+                  {/* The drawer is an overflow menu (Share / Pay / Contact), so
+                      the trigger wears the overflow ellipsis — never a brand
+                      mark or gear. */}
+                  <MoreHorizontal className='h-5 w-5' />
                 </CircleIconButton>
               )}
             </div>
@@ -664,7 +663,7 @@ export function ProfileCompactSurface({
               data-testid='profile-hero-identity-block'
             >
               <div
-                className='min-w-0 px-3 py-2.5 [overflow-wrap:anywhere] [@media(max-height:820px)]:px-2.5 [@media(max-height:820px)]:py-2'
+                className='min-w-0 py-2 [overflow-wrap:anywhere]'
                 data-testid='profile-hero-identity-content'
               >
                 <IdentityHeading
@@ -678,7 +677,7 @@ export function ProfileCompactSurface({
                     href={profileHref}
                     prefetch={false}
                     aria-label={`Go to ${artist.name}'s profile`}
-                    className='inline-flex max-w-full min-w-0 flex-wrap items-start gap-1 rounded-md text-3xl font-semibold leading-none tracking-normal text-(--profile-status-pill-fg) drop-shadow-[0_2px_14px_rgba(0,0,0,0.42)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent [@media(max-height:820px)]:text-2xl [@media(max-height:760px)]:text-2xl'
+                    className='inline-flex max-w-full min-w-0 flex-wrap items-start gap-1 rounded-md py-2.5 -my-2.5 text-3xl font-semibold leading-none tracking-normal text-(--profile-status-pill-fg) drop-shadow-[0_2px_14px_rgba(0,0,0,0.42)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent [@media(max-height:820px)]:text-2xl [@media(max-height:760px)]:text-2xl'
                   >
                     <span className='min-w-0 max-w-full [overflow-wrap:anywhere]'>
                       {artist.name}
@@ -695,7 +694,7 @@ export function ProfileCompactSurface({
                   </Link>
                 </IdentityHeading>
 
-                <div className='mt-1 flex min-w-0 items-center justify-between gap-2 [@media(max-height:820px)]:mt-0.5'>
+                <div className='mt-2 flex min-w-0 items-center justify-between gap-2 [@media(max-height:820px)]:mt-1'>
                   <p className='flex min-w-0 items-center gap-1.5 text-xs font-medium leading-4 tracking-normal text-white/74 [@media(max-height:820px)]:text-2xs'>
                     <span className='min-w-0 truncate'>{heroSubtitle}</span>
                     {locationLabel ? (

--- a/apps/web/components/features/profile/views/AboutView.tsx
+++ b/apps/web/components/features/profile/views/AboutView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { EntityMentionSegment } from '@/lib/profile/entity-mentions';
 import type { Artist } from '@/types/db';
 import type { PressPhoto } from '@/types/press-photos';
 import { AboutSection } from '../AboutSection';
@@ -9,6 +10,8 @@ export interface AboutViewProps {
   readonly genres?: string[] | null;
   readonly pressPhotos?: PressPhoto[];
   readonly allowPhotoDownloads?: boolean;
+  /** Entity-linked segments for the artist bio (computed server-side). */
+  readonly bioSegments?: readonly EntityMentionSegment[];
 }
 
 /**
@@ -21,6 +24,7 @@ export function AboutView({
   genres,
   pressPhotos,
   allowPhotoDownloads,
+  bioSegments,
 }: AboutViewProps) {
   return (
     <AboutSection
@@ -28,6 +32,7 @@ export function AboutView({
       genres={genres}
       pressPhotos={pressPhotos}
       allowPhotoDownloads={allowPhotoDownloads}
+      bioSegments={bioSegments}
     />
   );
 }

--- a/apps/web/components/organisms/entity-card/EntityCard.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.test.tsx
@@ -19,11 +19,13 @@ vi.mock('next/link', () => ({
 vi.mock('@/components/atoms/ImageWithFallback', () => ({
   ImageWithFallback: ({
     alt,
+    className,
     src,
   }: {
     readonly alt: string;
+    readonly className?: string;
     readonly src: string;
-  }) => React.createElement('img', { alt, src }),
+  }) => React.createElement('img', { alt, className, src }),
 }));
 
 const merchModel: EntityCardModel = {
@@ -169,5 +171,66 @@ describe('EntityCard', () => {
     const button = screen.getByRole('button');
     expect(button).not.toHaveTextContent('');
     expect(button).toHaveTextContent('Action');
+  });
+
+  describe('unified anatomy (profile home carousel)', () => {
+    it('locks the art zone to a full-bleed square with cover-fitted artwork', () => {
+      render(
+        <EntityCard model={merchModel} treatment='detailed' anatomy='unified' />
+      );
+      const image = screen.getByRole('img');
+      expect(image.parentElement?.className).toContain('aspect-square');
+      expect(image.className).toContain('object-cover');
+      // Full-bleed: the card carries no padding around the art zone.
+      const card = screen.getByTestId('entity-card-merch');
+      expect(card.className).toContain('p-0');
+    });
+
+    it('fits music artwork with object-cover (no letterbox bands)', () => {
+      const music: EntityCardModel = {
+        id: 'r1',
+        kind: 'music',
+        href: '/tim/r1',
+        imageUrl: 'https://cdn.test/art.jpg',
+        imageAlt: 'Art',
+        title: 'Release',
+        cta: { label: 'Listen', href: '/tim/r1' },
+      };
+      render(
+        <EntityCard model={music} treatment='detailed' anatomy='unified' />
+      );
+      expect(screen.getByRole('img').className).toContain('object-cover');
+      expect(screen.getByRole('img').className).not.toContain('object-contain');
+    });
+
+    it('renders a full-width 36px CTA and folds the price into the meta line', () => {
+      render(
+        <EntityCard model={merchModel} treatment='detailed' anatomy='unified' />
+      );
+      const cta = screen.getByText('Buy');
+      expect(cta.className).toContain('h-9');
+      expect(cta.className).toContain('w-full');
+      // Price joins the single meta line; there is no separate price block.
+      expect(screen.getByText('Premium tee · $45.00')).toBeInTheDocument();
+      expect(screen.queryByText('Profit $11.87')).not.toBeInTheDocument();
+    });
+
+    it('renders a target-less CTA as plain muted meta text, not button chrome', () => {
+      const noTickets: EntityCardModel = {
+        id: 's9',
+        kind: 'show',
+        title: 'The Echo',
+        imageAlt: 'The Echo',
+        datePill: { month: 'Jul', day: '29' },
+        cta: { label: 'No Tickets', href: null, disabled: true },
+      };
+      render(
+        <EntityCard model={noTickets} treatment='detailed' anatomy='unified' />
+      );
+      const text = screen.getByText('No Tickets');
+      expect(text.className).toContain('text-tertiary-token');
+      expect(text.className).not.toContain('rounded-full');
+      expect(text.className).not.toContain('bg-btn-primary');
+    });
   });
 });

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -34,6 +34,13 @@ interface EntityCardProps {
   readonly priority?: boolean;
   readonly dataTestId?: string;
   readonly onClick?: () => void;
+  /**
+   * 'square' (default): the art zone is a fixed square — for content-driven
+   * card heights. 'fill': the art zone flexes to fill whatever height the
+   * content zone leaves — for height-locked cards (profile home carousel),
+   * where a fixed square would push the CTA out of the card.
+   */
+  readonly artFit?: 'square' | 'fill';
 }
 
 type SizeConfig = {
@@ -188,6 +195,7 @@ export function EntityCard({
   priority = false,
   dataTestId,
   onClick,
+  artFit = 'square',
 }: EntityCardProps) {
   const size = SIZE[treatment];
   // Composition shape (#11899): fixed card aspect + semantic media geometry.
@@ -196,12 +204,15 @@ export function EntityCard({
   const shapeClassName = shape
     ? cn(getProfileCardShapeClassName(shape), 'overflow-hidden')
     : null;
-  const artClassName = shape
-    ? cn(
-        model.kind === 'video' ? 'aspect-video' : 'aspect-square',
-        treatment === 'big' ? 'rounded-2xl' : 'rounded-xl'
-      )
-    : size.artClass;
+  const artClassName =
+    artFit === 'fill'
+      ? 'min-h-0 w-full flex-1 rounded-xl'
+      : shape
+        ? cn(
+            model.kind === 'video' ? 'aspect-video' : 'aspect-square',
+            treatment === 'big' ? 'rounded-2xl' : 'rounded-xl'
+          )
+        : size.artClass;
   const titleClampClassName =
     shape && treatment !== 'big' ? 'line-clamp-1' : 'line-clamp-2';
   const preset = KIND_PRESETS[model.kind];
@@ -239,7 +250,8 @@ export function EntityCard({
     >
       <div
         className={cn(
-          'relative flex w-full shrink-0 items-center justify-center overflow-hidden border border-subtle',
+          'relative flex w-full items-center justify-center overflow-hidden border border-subtle',
+          artFit === 'fill' ? null : 'shrink-0',
           artClassName,
           treatment === 'big' && 'rounded-none border-0'
         )}
@@ -251,7 +263,9 @@ export function EntityCard({
             alt={model.imageAlt}
             fill
             priority={priority}
-            sizes={treatment === 'big' ? '320px' : '180px'}
+            sizes={
+              treatment === 'big' ? '320px' : '(max-width: 767px) 70vw, 300px'
+            }
             className={
               model.kind === 'music' ? 'object-contain' : 'object-cover'
             }
@@ -274,19 +288,14 @@ export function EntityCard({
 
       <div
         className={cn(
-          'flex min-w-0 flex-1 flex-col gap-1.5',
-          shape && 'min-h-0',
+          'flex min-h-0 min-w-0 flex-1 flex-col gap-1.5',
           treatment === 'big' && 'p-3'
         )}
       >
-        {/* Text zone — when shaped it clips so the CTA footer below never
-            moves (#11899: content fits the shape, button never shifts). */}
-        <div
-          className={cn(
-            'flex min-w-0 flex-col gap-1.5',
-            shape && 'min-h-0 flex-1 overflow-hidden'
-          )}
-        >
+        {/* Text zone — when the card is height-locked it clips so the CTA
+            footer below never moves (#11899: content fits the shape, button
+            never shifts). */}
+        <div className='flex min-h-0 min-w-0 flex-1 flex-col gap-1.5 overflow-hidden'>
           <div className='flex min-w-0 items-center justify-between gap-2'>
             <span className='inline-flex min-w-0 items-center gap-1.5 text-3xs font-semibold uppercase leading-none tracking-[0.08em] text-tertiary-token'>
               <Icon className='h-3 w-3 shrink-0' aria-hidden='true' />

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, MouseEvent, ReactNode } from 'react';
 import { ImageWithFallback } from '@/components/atoms/ImageWithFallback';
 import {
   getProfileCardShapeClassName,
@@ -33,14 +33,24 @@ interface EntityCardProps {
   readonly className?: string;
   readonly priority?: boolean;
   readonly dataTestId?: string;
-  readonly onClick?: () => void;
+  readonly onClick?: (event: MouseEvent<HTMLElement>) => void;
   /**
    * 'square' (default): the art zone is a fixed square — for content-driven
    * card heights. 'fill': the art zone flexes to fill whatever height the
-   * content zone leaves — for height-locked cards (profile home carousel),
-   * where a fixed square would push the CTA out of the card.
+   * content zone leaves — for height-locked cards where a fixed square would
+   * push the CTA out of the card. Ignored when `anatomy='unified'` (the art
+   * zone is always a full-width square there).
    */
   readonly artFit?: 'square' | 'fill';
+  /**
+   * 'unified': the single profile-card anatomy — full-bleed square art zone
+   * (object-cover, no letterboxing), eyebrow/title/meta text zone, and a
+   * full-width 36px CTA anchored to the bottom. Used by every card in the
+   * profile home carousel so the featured card, entity cards, and slot cards
+   * share one design. 'default' keeps the legacy per-treatment layout
+   * (chat/app consumers).
+   */
+  readonly anatomy?: 'default' | 'unified';
 }
 
 type SizeConfig = {
@@ -80,13 +90,30 @@ const SIZE: Record<EntityTreatment, SizeConfig> = {
 function EntityCtaControl({
   cta,
   block,
+  unified = false,
 }: Readonly<{
   cta: EntityCardCta;
   block: boolean;
+  unified?: boolean;
 }>) {
+  // Unified anatomy: a CTA with no target is not a button at all — render it
+  // as plain muted meta text (e.g. "No Tickets"), never with button chrome.
+  if (unified && (cta.disabled || (!cta.href && !cta.onClick))) {
+    return (
+      <span className='flex h-9 w-full items-center text-xs text-tertiary-token'>
+        {cta.label}
+      </span>
+    );
+  }
+
   const className = cn(
     'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover',
-    block ? 'h-11 w-full' : 'h-11 min-w-0 flex-1',
+    // Unified anatomy: full-width 36px CTA (two CTAs share the row evenly).
+    unified
+      ? 'h-9 min-w-0 flex-1'
+      : block
+        ? 'h-11 w-full'
+        : 'h-11 min-w-0 flex-1',
     cta.disabled &&
       'cursor-not-allowed border-subtle bg-surface-0 text-tertiary-token hover:border-subtle hover:bg-surface-0'
   );
@@ -147,7 +174,7 @@ function CardShell({
   testId?: string;
   className: string;
   style?: CSSProperties;
-  onClick?: () => void;
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
   children: ReactNode;
 }>) {
   if (href?.startsWith('/')) {
@@ -196,16 +223,21 @@ export function EntityCard({
   dataTestId,
   onClick,
   artFit = 'square',
+  anatomy = 'default',
 }: EntityCardProps) {
   const size = SIZE[treatment];
+  const isUnified = anatomy === 'unified';
   // Composition shape (#11899): fixed card aspect + semantic media geometry.
   // Album/product/show artwork is square; video thumbnails stay landscape.
   // Text truncates inside the shape; the CTA footer never moves.
   const shapeClassName = shape
     ? cn(getProfileCardShapeClassName(shape), 'overflow-hidden')
     : null;
-  const artClassName =
-    artFit === 'fill'
+  const artClassName = isUnified
+    ? // Unified anatomy: the art zone is a full-width square (album art is
+      // square by default; non-square art object-covers the square zone).
+      'aspect-square rounded-none'
+    : artFit === 'fill'
       ? 'min-h-0 w-full flex-1 rounded-xl'
       : shape
         ? cn(
@@ -213,8 +245,11 @@ export function EntityCard({
             treatment === 'big' ? 'rounded-2xl' : 'rounded-xl'
           )
         : size.artClass;
-  const titleClampClassName =
-    shape && treatment !== 'big' ? 'line-clamp-1' : 'line-clamp-2';
+  const titleClampClassName = isUnified
+    ? 'line-clamp-1'
+    : shape && treatment !== 'big'
+      ? 'line-clamp-1'
+      : 'line-clamp-2';
   const preset = KIND_PRESETS[model.kind];
   const accent = model.accent ?? preset.accent;
   const Icon = preset.icon;
@@ -232,6 +267,13 @@ export function EntityCard({
     background: `radial-gradient(120% 120% at 32% 22%, color-mix(in oklab, ${accentVar(accent)} 22%, transparent), transparent 62%), linear-gradient(155deg, var(--color-bg-surface-2), var(--color-bg-surface-1))`,
   };
 
+  // Unified anatomy: one meta line — the price joins it instead of a separate
+  // footer block, so every card shares the eyebrow/title/meta/CTA anatomy.
+  const metaText =
+    isUnified && model.price
+      ? [model.meta, model.price.display].filter(Boolean).join(' · ')
+      : model.meta;
+
   return (
     <CardShell
       href={cardHref}
@@ -240,7 +282,9 @@ export function EntityCard({
       onClick={onClick}
       className={cn(
         'group flex min-w-0 flex-col text-left transition-[background-color,border-color] duration-subtle focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--color-focus-ring)',
-        treatment === 'big' ? 'gap-0 overflow-hidden p-0' : 'gap-3 p-3',
+        treatment === 'big' || isUnified
+          ? 'gap-0 overflow-hidden p-0'
+          : 'gap-3 p-3',
         isPearl
           ? 'rounded-(--profile-inner-radius) border border-(--profile-pearl-border) bg-(--profile-pearl-bg) shadow-(--profile-pearl-shadow) backdrop-blur-2xl hover:bg-(--profile-pearl-bg-hover)'
           : 'rounded-2xl border border-subtle bg-surface-1 shadow-card hover:border-default',
@@ -251,9 +295,10 @@ export function EntityCard({
       <div
         className={cn(
           'relative flex w-full items-center justify-center overflow-hidden border border-subtle',
-          artFit === 'fill' ? null : 'shrink-0',
+          !isUnified && artFit === 'fill' ? null : 'shrink-0',
           artClassName,
-          treatment === 'big' && 'rounded-none border-0'
+          (treatment === 'big' || isUnified) && 'rounded-none border-0',
+          isUnified && 'border-b border-subtle'
         )}
         style={artStyle}
       >
@@ -267,7 +312,11 @@ export function EntityCard({
               treatment === 'big' ? '320px' : '(max-width: 767px) 70vw, 300px'
             }
             className={
-              model.kind === 'music' ? 'object-contain' : 'object-cover'
+              // Unified anatomy: square art in a square zone — cover crops
+              // non-square art instead of letterboxing it.
+              isUnified || model.kind !== 'music'
+                ? 'object-cover'
+                : 'object-contain'
             }
             fallbackVariant={preset.fallbackVariant}
             fallbackClassName='bg-transparent'
@@ -282,28 +331,50 @@ export function EntityCard({
             </span>
           </div>
         ) : (
-          <Icon className='h-7 w-7 text-tertiary-token' aria-hidden='true' />
+          <Icon
+            className={cn(
+              'text-tertiary-token',
+              isUnified ? 'h-8 w-8' : 'h-7 w-7'
+            )}
+            aria-hidden='true'
+          />
         )}
       </div>
 
       <div
         className={cn(
           'flex min-h-0 min-w-0 flex-1 flex-col gap-1.5',
-          treatment === 'big' && 'p-3'
+          treatment === 'big' && 'p-3',
+          // Unified: the text zone + 36px CTA share (card height − card
+          // width), which is tight on small cards — keep chrome minimal so
+          // eyebrow + title + CTA always fit; the meta line hides entirely
+          // below the card-height threshold where it would clip (see
+          // .entity-card-meta in design-system.css).
+          isUnified && 'px-3 py-1.5'
         )}
       >
         {/* Text zone — when the card is height-locked it clips so the CTA
             footer below never moves (#11899: content fits the shape, button
             never shifts). */}
-        <div className='flex min-h-0 min-w-0 flex-1 flex-col gap-1.5 overflow-hidden'>
+        <div
+          className={cn(
+            'flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden',
+            isUnified ? 'gap-1' : 'gap-1.5'
+          )}
+        >
           <div className='flex min-w-0 items-center justify-between gap-2'>
-            <span className='inline-flex min-w-0 items-center gap-1.5 text-3xs font-semibold uppercase leading-none tracking-[0.08em] text-tertiary-token'>
+            <span
+              className={cn(
+                'inline-flex min-w-0 items-center gap-1.5 text-3xs font-semibold uppercase leading-none tracking-[0.08em] text-tertiary-token',
+                isUnified && 'entity-card-eyebrow'
+              )}
+            >
               <Icon className='h-3 w-3 shrink-0' aria-hidden='true' />
               <span className='truncate'>
                 {model.eyebrow ?? preset.eyebrow}
               </span>
             </span>
-            {size.showStatus && model.status ? (
+            {size.showStatus && !isUnified && model.status ? (
               <span className='inline-flex shrink-0 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.06em] text-secondary-token'>
                 <span
                   className='h-1.5 w-1.5 shrink-0 rounded-full'
@@ -319,20 +390,31 @@ export function EntityCard({
             className={cn(
               'min-w-0 font-[590] leading-tight tracking-tighter text-primary-token',
               titleClampClassName,
-              size.titleClass
+              // Unified: match the featured card's title size — one design.
+              isUnified ? 'text-sm' : size.titleClass
             )}
           >
             {model.title}
           </h3>
 
-          {size.showMeta && model.meta ? (
-            <p className='min-w-0 truncate text-[11.5px] text-tertiary-token'>
-              {model.meta}
+          {size.showMeta && metaText ? (
+            <p
+              className={cn(
+                'min-w-0 truncate text-[11.5px] text-tertiary-token',
+                isUnified && 'entity-card-meta'
+              )}
+            >
+              {metaText}
             </p>
           ) : null}
 
           {size.showMeta && model.secondaryMeta ? (
-            <p className='min-w-0 truncate text-[11.5px] text-tertiary-token'>
+            <p
+              className={cn(
+                'min-w-0 truncate text-[11.5px] text-tertiary-token',
+                isUnified && 'entity-card-meta'
+              )}
+            >
               {model.secondaryMeta}
             </p>
           ) : null}
@@ -340,30 +422,60 @@ export function EntityCard({
 
         <div
           className={cn(
-            'flex gap-2 pt-1',
+            'flex gap-2',
+            isUnified ? null : 'pt-1',
             PROFILE_CARD_FOOTER_ANCHOR_CLASSNAME,
-            isInteractive
-              ? size.ctaBlock
-                ? 'flex-col items-stretch'
-                : 'flex-row items-stretch'
-              : cn(
-                  'items-center',
-                  size.ctaBlock ? 'flex-col items-stretch' : 'justify-between'
-                )
+            isUnified
+              ? isInteractive
+                ? 'flex-row items-stretch'
+                : 'flex-col items-stretch'
+              : isInteractive
+                ? size.ctaBlock
+                  ? 'flex-col items-stretch'
+                  : 'flex-row items-stretch'
+                : cn(
+                    'items-center',
+                    size.ctaBlock ? 'flex-col items-stretch' : 'justify-between'
+                  )
           )}
         >
           {isInteractive ? (
             <>
               {model.cta ? (
-                <EntityCtaControl cta={model.cta} block={size.ctaBlock} />
+                <EntityCtaControl
+                  cta={model.cta}
+                  block={size.ctaBlock}
+                  unified={isUnified}
+                />
               ) : null}
               {model.secondaryCta ? (
                 <EntityCtaControl
                   cta={model.secondaryCta}
                   block={size.ctaBlock}
+                  unified={isUnified}
                 />
               ) : null}
             </>
+          ) : isUnified ? (
+            // Unified anatomy: full-width 36px CTA at the bottom of every
+            // card. The CTA is a visual cue for the whole-card link — when
+            // neither the card nor the CTA has a target, it degrades to
+            // plain muted meta text instead of button chrome.
+            model.cta ? (
+              model.cta.disabled || (!model.cta.href && !cardHref) ? (
+                <span className='flex h-9 w-full items-center text-xs text-tertiary-token'>
+                  {model.cta.label}
+                </span>
+              ) : (
+                <span
+                  className={cn(
+                    'inline-flex h-9 w-full shrink-0 items-center justify-center rounded-full bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle group-hover:bg-btn-primary-hover'
+                  )}
+                >
+                  {model.cta.label}
+                </span>
+              )
+            ) : null
           ) : (
             <>
               {model.price ? (

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -365,7 +365,7 @@ export function EntityCard({
           <div className='flex min-w-0 items-center justify-between gap-2'>
             <span
               className={cn(
-                'inline-flex min-w-0 items-center gap-1.5 text-3xs font-semibold uppercase leading-none tracking-[0.08em] text-tertiary-token',
+                'inline-flex min-w-0 items-center gap-1.5 text-3xs font-semibold leading-none text-tertiary-token',
                 isUnified && 'entity-card-eyebrow'
               )}
             >
@@ -375,7 +375,7 @@ export function EntityCard({
               </span>
             </span>
             {size.showStatus && !isUnified && model.status ? (
-              <span className='inline-flex shrink-0 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.06em] text-secondary-token'>
+              <span className='inline-flex shrink-0 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-3xs font-medium text-secondary-token'>
                 <span
                   className='h-1.5 w-1.5 shrink-0 rounded-full'
                   style={{ background: statusDotVar(model.status.tone) }}

--- a/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
@@ -50,21 +50,30 @@ const items: EntityCardModel[] = [
 ];
 
 describe('EntityCarousel profile geometry', () => {
-  it('uses one horizontal-only scroll owner and equal card footprints', () => {
+  it('fills the track height and uses the shared aspect-ratio card geometry', () => {
     render(<EntityCarousel items={items} dataTestId='profile-home-carousel' />);
 
     const carousel = screen.getByTestId('profile-home-carousel');
     expect(carousel.className).toContain('overflow-x-auto');
     expect(carousel.className).toContain('overflow-y-hidden');
     expect(carousel.className).toContain('profile-horizontal-rail');
+    expect(carousel.className).toContain('h-full');
+    expect(carousel.className).toContain('items-stretch');
+    expect(carousel.className).toContain('snap-mandatory');
+    expect(carousel.className).toContain('overscroll-x-contain');
     expect(carousel.className).not.toContain('touch-action');
 
     const footprints = [...carousel.querySelectorAll(':scope > li')];
     expect(footprints).toHaveLength(2);
+    // One stable geometry for every card: the .profile-entity-card class owns
+    // aspect-ratio/height/cap in design-system.css — no fixed px footprints.
     expect(
       footprints.every(
         item =>
-          item.className.includes('w-56') && item.className.includes('h-96')
+          item.className.includes('profile-entity-card') &&
+          item.className.includes('snap-always') &&
+          !item.className.includes('w-56') &&
+          !item.className.includes('h-96')
       )
     ).toBe(true);
 
@@ -75,12 +84,58 @@ describe('EntityCarousel profile geometry', () => {
     }
   });
 
-  it('keeps release artwork square and fits it without cropping', () => {
+  it('flexes the art zone inside the height-locked card without cropping artwork', () => {
     render(<EntityCarousel items={items} />);
 
     for (const image of screen.getAllByRole('img')) {
-      expect(image.parentElement?.className).toContain('aspect-square');
+      // Height-locked 3:4 cards: the art zone flexes to fill whatever the
+      // content zone leaves (a fixed square would push the CTA out), and
+      // release artwork is fitted (object-contain), never cropped.
+      expect(image.parentElement?.className).toContain('flex-1');
+      expect(image.parentElement?.className).not.toContain('aspect-square');
       expect(image.className).toContain('object-contain');
     }
+  });
+
+  it('renders leading and trailing slot cards in the same geometry', () => {
+    render(
+      <EntityCarousel
+        items={items}
+        dataTestId='profile-home-carousel'
+        leading={<section data-testid='slot-leading' />}
+        trailing={<section data-testid='slot-trailing' />}
+      />
+    );
+
+    const carousel = screen.getByTestId('profile-home-carousel');
+    const footprints = [...carousel.querySelectorAll(':scope > li')];
+    expect(footprints).toHaveLength(4);
+
+    const leadingLi = carousel.querySelector('[data-carousel-slot="leading"]');
+    const trailingLi = carousel.querySelector(
+      '[data-carousel-slot="trailing"]'
+    );
+    expect(leadingLi?.className).toContain('profile-entity-card');
+    expect(trailingLi?.className).toContain('profile-entity-card');
+    // Leading slot is the first card, trailing slot the last.
+    expect(footprints[0]).toBe(leadingLi);
+    expect(footprints[footprints.length - 1]).toBe(trailingLi);
+    expect(leadingLi?.contains(screen.getByTestId('slot-leading'))).toBe(true);
+    expect(trailingLi?.contains(screen.getByTestId('slot-trailing'))).toBe(
+      true
+    );
+  });
+
+  it('renders slot-only carousels (no entity items) without an empty shell', () => {
+    render(
+      <EntityCarousel
+        items={[]}
+        dataTestId='profile-home-carousel'
+        leading={<section data-testid='slot-leading' />}
+      />
+    );
+
+    const carousel = screen.getByTestId('profile-home-carousel');
+    expect(carousel.querySelectorAll(':scope > li')).toHaveLength(1);
   });
 });

--- a/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
@@ -84,17 +84,36 @@ describe('EntityCarousel profile geometry', () => {
     }
   });
 
-  it('flexes the art zone inside the height-locked card without cropping artwork', () => {
+  it('locks the art zone to a full-width square with cover-fitted artwork', () => {
     render(<EntityCarousel items={items} />);
 
     for (const image of screen.getAllByRole('img')) {
-      // Height-locked 3:4 cards: the art zone flexes to fill whatever the
-      // content zone leaves (a fixed square would push the CTA out), and
-      // release artwork is fitted (object-contain), never cropped.
-      expect(image.parentElement?.className).toContain('flex-1');
-      expect(image.parentElement?.className).not.toContain('aspect-square');
-      expect(image.className).toContain('object-contain');
+      // Unified card anatomy: the art zone is a square matched to the full
+      // card width (no letterbox bands), and artwork object-covers the
+      // square zone — square art fills it exactly, non-square art crops.
+      expect(image.parentElement?.className).toContain('aspect-square');
+      expect(image.parentElement?.className).not.toContain('flex-1');
+      expect(image.className).toContain('object-cover');
     }
+  });
+
+  it('renders a full-width 36px CTA at the bottom of every card', () => {
+    const withCta: EntityCardModel[] = [
+      {
+        id: 'release-1',
+        kind: 'music',
+        href: '/tim/release-1',
+        imageUrl: '/release-1.jpg',
+        imageAlt: 'Release one',
+        title: 'Release One',
+        cta: { label: 'Listen', href: '/tim/release-1' },
+      },
+    ];
+    render(<EntityCarousel items={withCta} />);
+
+    const cta = screen.getByText('Listen');
+    expect(cta.className).toContain('h-9');
+    expect(cta.className).toContain('w-full');
   });
 
   it('renders leading and trailing slot cards in the same geometry', () => {

--- a/apps/web/components/organisms/entity-card/EntityCarousel.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.tsx
@@ -165,12 +165,12 @@ export function EntityCarousel({
             <EntityCard
               model={model}
               treatment='detailed'
-              // The hero keeps image priority; carousel art stays lazy so the
-              // LCP image never competes with the cover photo. artFit='fill'
-              // lets the art zone flex inside the height-locked card so the
-              // CTA footer never clips.
+              // Unified profile-card anatomy: full-bleed square art, text
+              // zone, and a full-width CTA — the same design as the featured
+              // PAC card. The hero keeps image priority; carousel art stays
+              // lazy so the LCP image never competes with the cover photo.
               surface={surface}
-              artFit='fill'
+              anatomy='unified'
               className='h-full w-full overflow-hidden'
               onClick={
                 onCardClick ? () => onCardClick(index, model) : undefined

--- a/apps/web/components/organisms/entity-card/EntityCarousel.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
+import { useReducedMotion } from '@/lib/hooks/useReducedMotion';
 import { cn } from '@/lib/utils';
 import { EntityCard } from './EntityCard';
 import type { EntityCardModel, EntitySurface } from './types';
@@ -10,26 +11,46 @@ interface EntityCarouselProps {
   readonly surface?: EntitySurface;
   readonly className?: string;
   readonly dataTestId?: string;
+  /**
+   * Custom cards rendered in the same fixed card geometry as entity items —
+   * `leading` becomes the featured first card (e.g. the PAC card), `trailing`
+   * the last card (e.g. the alerts card). Neither participates in entity
+   * impression/click analytics.
+   */
+  readonly leading?: ReactNode;
+  readonly trailing?: ReactNode;
   readonly onCardImpression?: (index: number, model: EntityCardModel) => void;
   readonly onCardClick?: (index: number, model: EntityCardModel) => void;
 }
+
+const CARD_ITEM_CLASSNAME =
+  'profile-entity-card flex shrink-0 snap-start snap-always';
 
 /**
  * One horizontal snap track with one stable card geometry. Ordering can make an
  * item prominent, but its dimensions must not change: mixed card sizes create a
  * false hierarchy, crop the trailing cards, and make the rail look vertically
  * scrollable inside the fixed profile shell.
+ *
+ * Geometry lives in `.profile-entity-card` (design-system.css): 3:4 aspect
+ * ratio, height locked to the track (h-full), width derived from height,
+ * capped so no card exceeds ~78vw. The track fills the remaining viewport
+ * height (h-full) so primary content never needs vertical scrolling.
  */
 export function EntityCarousel({
   items,
   surface = 'pearl',
   className,
   dataTestId,
+  leading,
+  trailing,
   onCardImpression,
   onCardClick,
 }: EntityCarouselProps) {
+  const trackRef = useRef<HTMLUListElement | null>(null);
   const itemRefs = useRef<Array<HTMLLIElement | null>>([]);
   const trackedImpressionKeys = useRef<Set<string>>(new Set());
+  const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
     if (!onCardImpression || items.length === 0) {
@@ -84,18 +105,53 @@ export function EntityCarousel({
     return () => observer.disconnect();
   }, [items, onCardImpression]);
 
-  if (items.length === 0) {
+  // Scroll-driven edge treatment: cards not fully inside the track dim and
+  // scale down slightly (transform/opacity only). Skipped entirely when the
+  // user prefers reduced motion — cards stay at full scale/opacity.
+  useEffect(() => {
+    if (prefersReducedMotion || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+    const track = trackRef.current;
+    if (!track) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          const node = entry.target as HTMLElement;
+          node.dataset.edge = entry.isIntersecting ? 'false' : 'true';
+        }
+      },
+      { root: track, threshold: 0.95 }
+    );
+
+    for (const node of Array.from(track.children)) {
+      observer.observe(node);
+    }
+
+    return () => observer.disconnect();
+  }, [prefersReducedMotion, items, leading, trailing]);
+
+  if (items.length === 0 && !leading && !trailing) {
     return null;
   }
 
   return (
     <ul
+      ref={trackRef}
       className={cn(
-        'profile-horizontal-rail flex snap-x snap-mandatory list-none gap-3 overflow-x-auto overflow-y-hidden overscroll-x-contain',
+        'profile-horizontal-rail flex h-full snap-x snap-mandatory list-none items-stretch gap-3 overflow-x-auto overflow-y-hidden overscroll-x-contain',
         className
       )}
       data-testid={dataTestId ?? 'entity-carousel'}
     >
+      {leading ? (
+        <li data-carousel-slot='leading' className={CARD_ITEM_CLASSNAME}>
+          {leading}
+        </li>
+      ) : null}
       {items.map((model, index) => {
         return (
           <li
@@ -104,18 +160,17 @@ export function EntityCarousel({
               itemRefs.current[index] = node;
             }}
             data-carousel-index={index}
-            // items-start keeps the deterministic shape in charge: a stretched
-            // cross-axis would override the card's fixed aspect ratio.
-            className='flex h-96 w-56 shrink-0 snap-start items-start'
+            className={CARD_ITEM_CLASSNAME}
           >
             <EntityCard
               model={model}
               treatment='detailed'
-              // Square art plus metadata and a 44px control cannot fit inside
-              // the old 4:5 shell. The rail owns one explicit 224x384 footprint
-              // so every card stays equal without clipping its useful content.
+              // The hero keeps image priority; carousel art stays lazy so the
+              // LCP image never competes with the cover photo. artFit='fill'
+              // lets the art zone flex inside the height-locked card so the
+              // CTA footer never clips.
               surface={surface}
-              priority={index === 0}
+              artFit='fill'
               className='h-full w-full overflow-hidden'
               onClick={
                 onCardClick ? () => onCardClick(index, model) : undefined
@@ -124,6 +179,11 @@ export function EntityCarousel({
           </li>
         );
       })}
+      {trailing ? (
+        <li data-carousel-slot='trailing' className={CARD_ITEM_CLASSNAME}>
+          {trailing}
+        </li>
+      ) : null}
     </ul>
   );
 }

--- a/apps/web/components/organisms/entity-card/adapters.test.ts
+++ b/apps/web/components/organisms/entity-card/adapters.test.ts
@@ -353,13 +353,58 @@ describe('showToEntityCard', () => {
     });
   });
 
-  it('omits the CTA when there is no ticket url', () => {
+  it('renders a target-less No Tickets CTA when there is no ticket url', () => {
     const model = showToEntityCard({
       id: 's2',
       venueName: 'Club',
       startDate: null,
     });
-    expect(model.cta).toBeNull();
+    expect(model.cta).toEqual({
+      label: 'No Tickets',
+      href: null,
+      disabled: true,
+    });
     expect(model.datePill).toBeNull();
+  });
+
+  it('formats the date pill in UTC so it always matches the events list', () => {
+    // 02:30 UTC is still the previous day in US timezones — the card and the
+    // TourModePanel list (also UTC) must agree on "Jul 29".
+    const model = showToEntityCard({
+      id: 's3',
+      venueName: 'The Echo',
+      startDate: '2026-07-29T02:30:00.000Z',
+    });
+    expect(model.datePill).toEqual({ month: 'Jul', day: '29' });
+  });
+
+  it('never links a cancelled or sold-out show to tickets', () => {
+    const cancelled = showToEntityCard({
+      id: 's4',
+      venueName: 'Enmore Theatre',
+      startDate: '2026-11-29T08:00:00.000Z',
+      ticketUrl: 'https://tickets.test/enmore',
+      ticketStatus: 'cancelled',
+    });
+    expect(cancelled.href).toBeNull();
+    expect(cancelled.cta).toEqual({
+      label: 'Cancelled',
+      href: null,
+      disabled: true,
+    });
+
+    const soldOut = showToEntityCard({
+      id: 's5',
+      venueName: 'The Echo',
+      startDate: '2026-07-29T02:30:00.000Z',
+      ticketUrl: 'https://tickets.test/echo',
+      ticketStatus: 'sold_out',
+    });
+    expect(soldOut.href).toBeNull();
+    expect(soldOut.cta).toEqual({
+      label: 'Sold Out',
+      href: null,
+      disabled: true,
+    });
   });
 });

--- a/apps/web/components/organisms/entity-card/adapters.ts
+++ b/apps/web/components/organisms/entity-card/adapters.ts
@@ -1,6 +1,6 @@
 import { getMerchPriceDisplay } from '@/lib/merch/pricing';
 import type { PublicMerchCard } from '@/lib/merch/types';
-import type { TourDateViewModel } from '@/lib/tour-dates/types';
+import type { TicketStatus, TourDateViewModel } from '@/lib/tour-dates/types';
 import { formatLocationString } from '@/lib/utils/string-utils';
 import type { AiCrawlerAnalyticsResponse } from '@/types/ai-crawler-analytics';
 import { KIND_PRESETS } from './kind-presets';
@@ -10,24 +10,6 @@ import type {
   EntityCardStatus,
   EntityStatusTone,
 } from './types';
-
-const MONTHS = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-] as const;
-
-const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' });
-const dayFormatter = new Intl.DateTimeFormat('en-US', { day: 'numeric' });
 
 function toDate(value: Date | string | null | undefined): Date | null {
   if (!value) {
@@ -151,6 +133,7 @@ export interface ShowEntityInput {
   readonly startDate?: Date | string | null;
   readonly ticketUrl?: string | null;
   readonly status?: EntityStatusTone | null;
+  readonly ticketStatus?: TicketStatus | null;
 }
 
 export interface ChatReleaseContextInput {
@@ -383,6 +366,18 @@ export function chatTourDateContextToEntityCard(
   };
 }
 
+// Show dates render in UTC everywhere on the profile (card date pills AND the
+// events list) so the two never disagree — local-time formatting split them
+// for evening shows (e.g. "JUL 28" on the card vs "Jul 29" in the list).
+const monthFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  timeZone: 'UTC',
+});
+const dayFormatter = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  timeZone: 'UTC',
+});
+
 function getTourEyebrow(
   isNearYou: boolean,
   distanceKm: number | null | undefined
@@ -537,11 +532,14 @@ export function showToEntityCard(show: ShowEntityInput): EntityCardModel {
   const date = toDate(show.startDate);
   const title = show.title?.trim() || show.venueName?.trim() || 'Show';
   const location = [show.venueName, show.city].filter(Boolean).join(' · ');
+  const isCancelled = show.ticketStatus === 'cancelled';
+  const isSoldOut = show.ticketStatus === 'sold_out';
+  const canBuyTickets = Boolean(show.ticketUrl) && !isCancelled && !isSoldOut;
 
   return {
     id: show.id,
     kind: 'show',
-    href: show.ticketUrl ?? null,
+    href: canBuyTickets ? show.ticketUrl : null,
     imageUrl: null,
     imageAlt: title,
     accent: preset.accent,
@@ -549,11 +547,21 @@ export function showToEntityCard(show: ShowEntityInput): EntityCardModel {
     title,
     meta: location || null,
     datePill: date
-      ? { month: MONTHS[date.getMonth()], day: String(date.getDate()) }
+      ? { month: monthFormatter.format(date), day: dayFormatter.format(date) }
       : null,
     status: null,
-    cta: show.ticketUrl
+    // A show that cannot sell tickets gets a target-less CTA — the card
+    // renders it as plain muted text, never a dead Tickets link.
+    cta: canBuyTickets
       ? { label: preset.ctaLabel, href: show.ticketUrl, external: true }
-      : null,
+      : {
+          label: isCancelled
+            ? 'Cancelled'
+            : isSoldOut
+              ? 'Sold Out'
+              : 'No Tickets',
+          href: null,
+          disabled: true,
+        },
   };
 }

--- a/apps/web/components/organisms/entity-card/kind-presets.ts
+++ b/apps/web/components/organisms/entity-card/kind-presets.ts
@@ -76,11 +76,11 @@ export function entityCardArtStyle(accent: EntityAccent): CSSProperties {
   };
 }
 
-/** Color for a status dot, sourced from design tokens. */
+/** Color for a status dot, sourced from semantic status tokens. */
 export function statusDotVar(tone: EntityStatusTone | undefined): string {
   switch (tone) {
     case 'live':
-      return 'var(--color-accent-green)';
+      return 'var(--color-success)';
     case 'scheduled':
       return 'var(--color-accent-orange)';
     case 'draft':

--- a/apps/web/components/organisms/entity-card/kind-presets.ts
+++ b/apps/web/components/organisms/entity-card/kind-presets.ts
@@ -1,4 +1,5 @@
 import {
+  Bell,
   Bot,
   type LucideIcon,
   Music2,
@@ -53,6 +54,13 @@ export const KIND_PRESETS: Record<EntityKind, KindPreset> = {
     accent: 'blue',
     fallbackVariant: 'generic',
     ctaLabel: 'View Details',
+  },
+  alerts: {
+    eyebrow: 'Alerts',
+    icon: Bell,
+    accent: 'purple',
+    fallbackVariant: 'generic',
+    ctaLabel: 'Get Updates',
   },
 };
 

--- a/apps/web/components/organisms/entity-card/types.ts
+++ b/apps/web/components/organisms/entity-card/types.ts
@@ -1,7 +1,7 @@
 import type { MouseEvent } from 'react';
 
 /** The entity kinds a card can represent across profile + chat + dashboard. */
-export type EntityKind = 'merch' | 'music' | 'video' | 'show' | 'ai';
+export type EntityKind = 'merch' | 'music' | 'video' | 'show' | 'ai' | 'alerts';
 
 /** Carbon accent palette name (maps to `--color-accent-<name>`). */
 export type EntityAccent =

--- a/apps/web/lib/discography/artist-queries/artist-search.ts
+++ b/apps/web/lib/discography/artist-queries/artist-search.ts
@@ -18,10 +18,13 @@ import { db } from '@/lib/db';
 import {
   type Artist,
   artists,
+  discogReleases,
+  discogTracks,
   releaseArtists,
   trackArtists,
 } from '@/lib/db/schema/content';
-import type { CollaboratorInfo } from './types';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import type { CollaboratorInfo, CreditedArtistWithProfile } from './types';
 
 /**
  * Search artists by name
@@ -52,6 +55,80 @@ export async function searchArtists(
     .where(whereClause)
     .orderBy(artists.name)
     .limit(limit);
+}
+
+/**
+ * Resolve artists credited on a creator's catalog (release- and track-level
+ * credits) to their public Jovie handles.
+ *
+ * Only artists whose registry row links to a public creator profile are
+ * returned — external collaborators without a Jovie account are excluded so
+ * bio mentions of them stay plain text. The display name prefers the credit
+ * name (stage name) since that is what bios and release credits show.
+ */
+export async function getCreditedArtistsWithProfiles(
+  creatorProfileId: string,
+  options?: { limit?: number }
+): Promise<CreditedArtistWithProfile[]> {
+  const limit = options?.limit ?? 50;
+
+  const [releaseCredits, trackCredits] = await Promise.all([
+    db
+      .selectDistinct({
+        name: drizzleSql<string>`coalesce(${releaseArtists.creditName}, ${artists.name})`,
+        handle: creatorProfiles.usernameNormalized,
+      })
+      .from(releaseArtists)
+      .innerJoin(
+        discogReleases,
+        eq(releaseArtists.releaseId, discogReleases.id)
+      )
+      .innerJoin(artists, eq(releaseArtists.artistId, artists.id))
+      .innerJoin(
+        creatorProfiles,
+        eq(artists.creatorProfileId, creatorProfiles.id)
+      )
+      .where(
+        and(
+          eq(discogReleases.creatorProfileId, creatorProfileId),
+          eq(creatorProfiles.isPublic, true)
+        )
+      )
+      .limit(limit),
+    db
+      .selectDistinct({
+        name: drizzleSql<string>`coalesce(${trackArtists.creditName}, ${artists.name})`,
+        handle: creatorProfiles.usernameNormalized,
+      })
+      .from(trackArtists)
+      .innerJoin(discogTracks, eq(trackArtists.trackId, discogTracks.id))
+      .innerJoin(artists, eq(trackArtists.artistId, artists.id))
+      .innerJoin(
+        creatorProfiles,
+        eq(artists.creatorProfileId, creatorProfiles.id)
+      )
+      .where(
+        and(
+          eq(discogTracks.creatorProfileId, creatorProfileId),
+          eq(creatorProfiles.isPublic, true)
+        )
+      )
+      .limit(limit),
+  ]);
+
+  const seen = new Set<string>();
+  const merged: CreditedArtistWithProfile[] = [];
+  for (const row of [...releaseCredits, ...trackCredits]) {
+    const name = row.name?.trim();
+    const handle = row.handle?.trim();
+    if (!name || !handle) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({ name, handle });
+    if (merged.length >= limit) break;
+  }
+  return merged;
 }
 
 /**

--- a/apps/web/lib/discography/artist-queries/index.ts
+++ b/apps/web/lib/discography/artist-queries/index.ts
@@ -20,7 +20,11 @@ export {
   processTrackArtistCredits,
 } from './artist-import';
 // Search operations
-export { getFrequentCollaborators, searchArtists } from './artist-search';
+export {
+  getCreditedArtistsWithProfiles,
+  getFrequentCollaborators,
+  searchArtists,
+} from './artist-search';
 // Recording-artist operations
 export {
   deleteRecordingArtists,
@@ -46,5 +50,6 @@ export {
 export type {
   ArtistWithRole,
   CollaboratorInfo,
+  CreditedArtistWithProfile,
   FindOrCreateArtistInput,
 } from './types';

--- a/apps/web/lib/discography/artist-queries/types.ts
+++ b/apps/web/lib/discography/artist-queries/types.ts
@@ -20,6 +20,13 @@ export interface CollaboratorInfo {
   releaseCount: number;
 }
 
+export interface CreditedArtistWithProfile {
+  /** Display name (credit name when set, otherwise canonical artist name). */
+  name: string;
+  /** Normalized Jovie handle of the linked public creator profile. */
+  handle: string;
+}
+
 export interface FindOrCreateArtistInput {
   name: string;
   spotifyId?: string | null;

--- a/apps/web/lib/profile/aeo-content.ts
+++ b/apps/web/lib/profile/aeo-content.ts
@@ -1,6 +1,16 @@
 import { BASE_URL } from '@/constants/app';
 import type { PublicRelease } from '@/features/profile/releases/types';
+import {
+  getRegistryEntry,
+  isDspPlatform,
+  normalizePlatformKey,
+} from '@/lib/dsp-registry';
 import type { PublicMerchCard } from '@/lib/merch/types';
+import {
+  type EntityMentionContext,
+  type EntityMentionSegment,
+  linkEntityMentions,
+} from '@/lib/profile/entity-mentions';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import type { Artist, LegacySocialLink } from '@/types/db';
 
@@ -23,10 +33,31 @@ export interface ProfileAeoFaqItem {
   readonly source: ProfileAeoSource;
 }
 
+export interface ProfileAeoFact {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface ProfileAeoLink {
+  readonly id: string;
+  readonly platform: string;
+  readonly label: string;
+  readonly url: string;
+}
+
 export interface ProfileAeoContent {
   readonly artistName: string;
   readonly profileUrl: string;
+  readonly facts: readonly ProfileAeoFact[];
+  readonly listenLinks: readonly ProfileAeoLink[];
+  readonly followLinks: readonly ProfileAeoLink[];
+  /** Plain-text paragraphs — used by meta descriptions, JSON-LD, and tests. */
   readonly description: readonly string[];
+  /**
+   * `description` split into entity-linked segments (parallel array). Render
+   * this in the UI; keep `description` for plain-text consumers.
+   */
+  readonly descriptionSegments: readonly (readonly EntityMentionSegment[])[];
   readonly faqs: readonly ProfileAeoFaqItem[];
 }
 
@@ -38,6 +69,12 @@ export interface BuildProfileAeoContentInput {
   readonly tourDates?: readonly TourDateViewModel[];
   readonly merchCards?: readonly PublicMerchCard[];
   readonly socialLinks?: readonly LegacySocialLink[];
+  /**
+   * Linkable entities for this profile (own releases with slugs, credited
+   * artists resolved to Jovie handles). When omitted, descriptions render
+   * as plain text segments.
+   */
+  readonly entityMentions?: EntityMentionContext;
   readonly now?: Date;
 }
 
@@ -205,6 +242,99 @@ function getOrigin(artist: Artist): string | null {
 
 function pluralize(count: number, singular: string, plural = `${singular}s`) {
   return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function sentenceCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function buildFacts(
+  artist: Artist,
+  genres: readonly string[]
+): ProfileAeoFact[] {
+  const facts: ProfileAeoFact[] = [];
+
+  if (genres.length > 0) {
+    facts.push({ label: 'Genre', value: sentenceCase(genres.join(', ')) });
+  }
+
+  if (artist.active_since_year) {
+    facts.push({
+      label: 'Active Since',
+      value: String(artist.active_since_year),
+    });
+  }
+
+  const origin = getOrigin(artist);
+  if (origin) {
+    facts.push({ label: 'Hometown', value: origin });
+  }
+
+  return facts;
+}
+
+function getPlatformLabel(platform: string): string {
+  const key = normalizePlatformKey(platform);
+  return (
+    (key ? getRegistryEntry(key)?.name : undefined) ?? sentenceCase(platform)
+  );
+}
+
+function buildLinkSections(
+  artist: Artist,
+  socialLinks: readonly LegacySocialLink[]
+): {
+  readonly listenLinks: ProfileAeoLink[];
+  readonly followLinks: ProfileAeoLink[];
+} {
+  const listenLinks: ProfileAeoLink[] = [];
+  const followLinks: ProfileAeoLink[] = [];
+  const seenPlatforms = new Set<string>();
+
+  for (const link of socialLinks) {
+    const url = cleanText(link.url);
+    if (!url) continue;
+
+    const key = normalizePlatformKey(link.platform) ?? link.platform;
+    if (seenPlatforms.has(key)) continue;
+    seenPlatforms.add(key);
+
+    const item: ProfileAeoLink = {
+      id: link.id,
+      platform: link.platform,
+      label: getPlatformLabel(link.platform),
+      url,
+    };
+    if (isDspPlatform(link.platform)) {
+      listenLinks.push(item);
+    } else {
+      followLinks.push(item);
+    }
+  }
+
+  // Profile DSP URL columns fill in destinations that have no social link.
+  // YouTube is categorized as social by isDspPlatform, so the column only
+  // joins the listen row when the artist has no YouTube social link.
+  const dspColumnFallbacks = [
+    { platform: 'spotify', url: artist.spotify_url },
+    { platform: 'apple_music', url: artist.apple_music_url },
+    { platform: 'youtube', url: artist.youtube_url },
+  ] as const;
+
+  for (const fallback of dspColumnFallbacks) {
+    const url = cleanText(fallback.url);
+    if (!url || seenPlatforms.has(fallback.platform)) continue;
+    seenPlatforms.add(fallback.platform);
+
+    listenLinks.push({
+      id: `dsp-column-${fallback.platform}`,
+      platform: fallback.platform,
+      label: getPlatformLabel(fallback.platform),
+      url,
+    });
+  }
+
+  return { listenLinks, followLinks };
 }
 
 function buildDescription(params: {
@@ -411,6 +541,7 @@ export function buildProfileAeoContent({
   tourDates = [],
   merchCards = [],
   socialLinks = [],
+  entityMentions,
   now = new Date(),
 }: BuildProfileAeoContentInput): ProfileAeoContent {
   const uniqueGenres = getUniqueGenres(artist, genres);
@@ -419,20 +550,32 @@ export function buildProfileAeoContent({
     artistHandle: artist.handle,
     releases,
   });
+  const { listenLinks, followLinks } = buildLinkSections(artist, socialLinks);
+
+  const description = buildDescription({
+    artist,
+    genres: uniqueGenres,
+    latestRelease,
+    releases,
+    tourDates,
+    merchCards,
+    collaborators,
+    now,
+  });
+  const mentionContext: EntityMentionContext = entityMentions ?? {
+    ownHandle: artist.handle,
+  };
 
   return {
     artistName: artist.name,
     profileUrl: absoluteProfileUrl(artist.handle),
-    description: buildDescription({
-      artist,
-      genres: uniqueGenres,
-      latestRelease,
-      releases,
-      tourDates,
-      merchCards,
-      collaborators,
-      now,
-    }),
+    facts: buildFacts(artist, uniqueGenres),
+    listenLinks,
+    followLinks,
+    description,
+    descriptionSegments: description.map(paragraph =>
+      linkEntityMentions(paragraph, mentionContext)
+    ),
     faqs: [
       buildOriginFaq(artist),
       buildLatestReleaseFaq({ artist, latestRelease, releases, socialLinks }),

--- a/apps/web/lib/profile/capture-dismissal-client.test.ts
+++ b/apps/web/lib/profile/capture-dismissal-client.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getCaptureDismissalStatus,
+  invalidateCaptureDismissalStatus,
+} from './capture-dismissal-client';
+
+// Regression: ISSUE-001 — PAC card and inline notifications CTA each fired
+// their own GET /api/profile/capture-dismissal on page load, doubling the
+// request (and the server-side session counter) per view.
+// Found by /qa on 2026-07-20
+// Report: .gstack/qa-reports/qa-report-localhost-3101-2026-07-20.md
+
+const ARTIST_ID = '8473a72f-51a0-4ce0-8739-4facfd89a7a5';
+
+function mockFetchOnce(payload: unknown, ok = true) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    json: () => Promise.resolve(payload),
+  } as unknown as Response);
+}
+
+describe('getCaptureDismissalStatus', () => {
+  beforeEach(() => {
+    invalidateCaptureDismissalStatus(ARTIST_ID);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('dedupes concurrent calls into one fetch per artist', async () => {
+    const fetchMock = mockFetchOnce({ suppressed: false });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const [a, b] = await Promise.all([
+      getCaptureDismissalStatus(ARTIST_ID),
+      getCaptureDismissalStatus(ARTIST_ID),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/profile/capture-dismissal?artist_id=${ARTIST_ID}`,
+      { credentials: 'same-origin' }
+    );
+    expect(a).toEqual({ suppressed: false });
+    expect(b).toBe(a);
+  });
+
+  it('serves repeat sequential calls from cache', async () => {
+    const fetchMock = mockFetchOnce({ suppressed: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getCaptureDismissalStatus(ARTIST_ID);
+    const again = await getCaptureDismissalStatus(ARTIST_ID);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(again).toEqual({ suppressed: true });
+  });
+
+  it('refetches after invalidation', async () => {
+    const fetchMock = mockFetchOnce({ suppressed: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getCaptureDismissalStatus(ARTIST_ID);
+    invalidateCaptureDismissalStatus(ARTIST_ID);
+    await getCaptureDismissalStatus(ARTIST_ID);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves null on non-OK responses without rejecting', async () => {
+    const fetchMock = mockFetchOnce(null, false);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(getCaptureDismissalStatus(ARTIST_ID)).resolves.toBeNull();
+  });
+
+  it('resolves null on network failure without rejecting', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+    await expect(getCaptureDismissalStatus(ARTIST_ID)).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/profile/capture-dismissal-client.ts
+++ b/apps/web/lib/profile/capture-dismissal-client.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared client for GET /api/profile/capture-dismissal.
+ *
+ * Multiple profile components (PAC card, inline notifications CTA) need the
+ * same suppression state on page load. Deduplicate into one in-flight +
+ * cached request per artist so the server sees a single status check per
+ * page view (the endpoint increments a session counter when suppressed, so
+ * duplicate fetches also double-counted sessions).
+ */
+
+export interface CaptureDismissalStatus {
+  readonly suppressed?: boolean;
+  readonly sessionCount?: number;
+  readonly nextEligibleAt?: string | null;
+}
+
+const statusCache = new Map<string, Promise<CaptureDismissalStatus | null>>();
+
+export function getCaptureDismissalStatus(
+  artistId: string
+): Promise<CaptureDismissalStatus | null> {
+  const cached = statusCache.get(artistId);
+  if (cached) return cached;
+
+  const request = fetch(
+    `/api/profile/capture-dismissal?artist_id=${encodeURIComponent(artistId)}`,
+    { credentials: 'same-origin' }
+  )
+    .then(res =>
+      res.ok ? (res.json() as Promise<CaptureDismissalStatus>) : null
+    )
+    .catch(() => null);
+
+  statusCache.set(artistId, request);
+  return request;
+}
+
+/** Drop the cached status (e.g. after a successful dismissal POST). */
+export function invalidateCaptureDismissalStatus(artistId: string): void {
+  statusCache.delete(artistId);
+}

--- a/apps/web/lib/profile/entity-mentions.ts
+++ b/apps/web/lib/profile/entity-mentions.ts
@@ -1,0 +1,174 @@
+/**
+ * Entity-linked bio mentions.
+ *
+ * Deterministic, server-side linker that turns plain-text bio/AEO paragraphs
+ * into typed segments so entity mentions (this profile's own releases and
+ * credited artists with Jovie profiles) render as internal links. No LLM,
+ * no client fetching — the same input always produces the same segments, so
+ * the output is safe to bake into ISR pages.
+ */
+
+export interface EntityMentionRelease {
+  readonly title: string;
+  readonly slug?: string | null;
+}
+
+export interface EntityMentionArtist {
+  readonly name: string;
+  /** Jovie handle when the artist has a public profile; otherwise null. */
+  readonly handle?: string | null;
+}
+
+export interface EntityMentionContext {
+  /** Handle of the profile the text belongs to (release links hang off it). */
+  readonly ownHandle: string;
+  readonly releases?: readonly EntityMentionRelease[];
+  readonly artists?: readonly EntityMentionArtist[];
+}
+
+export type EntityMentionSegment =
+  | { readonly type: 'text'; readonly text: string }
+  | { readonly type: 'release'; readonly text: string; readonly href: string }
+  | { readonly type: 'artist'; readonly text: string; readonly href: string };
+
+export interface ProfileEntityMentionLink {
+  readonly kind: 'release' | 'artist';
+  readonly name: string;
+  readonly href: string;
+}
+
+/** Cap on collected mentions (JSON-LD bloat guard). */
+export const MAX_ENTITY_MENTIONS = 25;
+
+const MIN_PHRASE_LENGTH = 2;
+const WORD_CHAR = /[a-z0-9]/;
+
+interface MentionCandidate {
+  readonly kind: 'release' | 'artist';
+  readonly phrase: string;
+  readonly lowerPhrase: string;
+  readonly href: string;
+}
+
+function isWordChar(char: string | undefined): boolean {
+  return char != null && WORD_CHAR.test(char);
+}
+
+function buildCandidates(context: EntityMentionContext): MentionCandidate[] {
+  const seen = new Set<string>();
+  const candidates: MentionCandidate[] = [];
+
+  for (const release of context.releases ?? []) {
+    const title = release.title?.trim();
+    const slug = release.slug?.trim();
+    if (!title || title.length < MIN_PHRASE_LENGTH || !slug) continue;
+    const lower = title.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    candidates.push({
+      kind: 'release',
+      phrase: title,
+      lowerPhrase: lower,
+      href: `/${encodeURIComponent(context.ownHandle)}/${encodeURIComponent(slug)}`,
+    });
+  }
+
+  for (const artist of context.artists ?? []) {
+    const name = artist.name?.trim();
+    const handle = artist.handle?.trim();
+    // Artists without a Jovie profile stay plain text — internal interlinking only.
+    if (!name || name.length < MIN_PHRASE_LENGTH || !handle) continue;
+    const lower = name.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    candidates.push({
+      kind: 'artist',
+      phrase: name,
+      lowerPhrase: lower,
+      href: `/${encodeURIComponent(handle)}`,
+    });
+  }
+
+  // Longest match first so overlapping names ("Cosmic Gate" vs "Gate")
+  // resolve to the most specific entity. Stable sort keeps releases ahead of
+  // artists at equal length, so a same-named release links to the release.
+  return candidates.sort(
+    (left, right) => right.phrase.length - left.phrase.length
+  );
+}
+
+/**
+ * Split plain text into typed segments, linking mentions of the entities in
+ * `context`. Matching is case-insensitive and word-boundary aware, so quoted
+ * titles (`"Take Me Over"`) match while substrings of longer words
+ * (`Sky` inside `Skyline`) do not.
+ */
+export function linkEntityMentions(
+  text: string,
+  context: EntityMentionContext
+): EntityMentionSegment[] {
+  if (!text) return [];
+
+  const candidates = buildCandidates(context);
+  if (candidates.length === 0) {
+    return [{ type: 'text', text }];
+  }
+
+  const lowerText = text.toLowerCase();
+  const segments: EntityMentionSegment[] = [];
+  let cursor = 0;
+  let index = 0;
+
+  const pushTextUpTo = (end: number) => {
+    if (end > cursor) {
+      segments.push({ type: 'text', text: text.slice(cursor, end) });
+    }
+  };
+
+  while (index < text.length) {
+    let matched: MentionCandidate | null = null;
+
+    if (!isWordChar(lowerText[index - 1])) {
+      for (const candidate of candidates) {
+        if (!lowerText.startsWith(candidate.lowerPhrase, index)) continue;
+        const end = index + candidate.lowerPhrase.length;
+        if (isWordChar(lowerText[end])) continue;
+        matched = candidate;
+        break;
+      }
+    }
+
+    if (matched) {
+      pushTextUpTo(index);
+      segments.push({
+        type: matched.kind,
+        text: text.slice(index, index + matched.phrase.length),
+        href: matched.href,
+      });
+      index += matched.phrase.length;
+      cursor = index;
+    } else {
+      index += 1;
+    }
+  }
+
+  pushTextUpTo(text.length);
+  return segments;
+}
+
+/**
+ * Flat, deduped list of linkable entities for a profile — used to build
+ * JSON-LD `mentions` without re-deriving the candidate set.
+ */
+export function collectEntityMentions(
+  context: EntityMentionContext,
+  limit: number = MAX_ENTITY_MENTIONS
+): ProfileEntityMentionLink[] {
+  return buildCandidates(context)
+    .slice(0, Math.max(0, limit))
+    .map(candidate => ({
+      kind: candidate.kind,
+      name: candidate.phrase,
+      href: candidate.href,
+    }));
+}

--- a/apps/web/lib/seo/structured-data/index.ts
+++ b/apps/web/lib/seo/structured-data/index.ts
@@ -11,7 +11,9 @@ export {
 export { generateMusicStructuredData } from './music';
 export {
   generateProfileStructuredData,
+  MAX_ENTITY_MENTIONS,
   MAX_EVENT_SCHEMAS,
+  type ProfileEntityMention,
 } from './profile';
 export {
   validateMerchRichResults,

--- a/apps/web/lib/seo/structured-data/profile.ts
+++ b/apps/web/lib/seo/structured-data/profile.ts
@@ -15,6 +15,17 @@ import { formatSchemaEventStartDate } from './event-date';
 /** Max MusicEvent schemas to emit (Google shows ~5 in rich results). */
 export const MAX_EVENT_SCHEMAS = 5;
 
+/** Max linked-entity `mentions` to emit on the profile entity node. */
+export const MAX_ENTITY_MENTIONS = 25;
+
+/** A profile-linked entity (own release or credited artist) for JSON-LD mentions. */
+export interface ProfileEntityMention {
+  readonly kind: 'release' | 'artist';
+  readonly name: string;
+  /** Absolute URL of the entity's Jovie page. */
+  readonly url: string;
+}
+
 const SOCIAL_PLATFORMS = new Set([
   'instagram',
   'twitter',
@@ -111,7 +122,8 @@ function buildArtistEntitySchema(
   profileUrl: string,
   genres: string[] | null,
   uniqueSocialUrls: string[],
-  listenActions: ReturnType<typeof buildListenActions>
+  listenActions: ReturnType<typeof buildListenActions>,
+  entityMentions: readonly ProfileEntityMention[]
 ): Record<string, unknown> {
   return {
     '@type': resolveArtistEntityType(profile.creator_type),
@@ -120,6 +132,13 @@ function buildArtistEntitySchema(
     description: profile.bio || `Music by ${artistName}`,
     url: profileUrl,
     ...(uniqueSocialUrls.length > 0 && { sameAs: uniqueSocialUrls }),
+    ...(entityMentions.length > 0 && {
+      mentions: entityMentions.slice(0, MAX_ENTITY_MENTIONS).map(mention => ({
+        '@type': mention.kind === 'artist' ? 'MusicGroup' : 'MusicRecording',
+        name: mention.name,
+        url: mention.url,
+      })),
+    }),
     genre: genres && genres.length > 0 ? genres : ['Music'],
     ...(profile.avatar_url && {
       image: {
@@ -248,7 +267,8 @@ export function generateProfileStructuredData(
   genres: string[] | null,
   links: LegacySocialLink[],
   tourDates: TourDateViewModel[] = [],
-  identityLinks: EntityIdentityLink[] = []
+  identityLinks: EntityIdentityLink[] = [],
+  entityMentions: readonly ProfileEntityMention[] = []
 ) {
   const artistName = profile.display_name || profile.username;
   const normalizedUsername =
@@ -263,7 +283,8 @@ export function generateProfileStructuredData(
     profileUrl,
     genres,
     uniqueSocialUrls,
-    listenActions
+    listenActions,
+    entityMentions
   );
   const profilePageSchema = buildProfilePageSchema(
     profile,

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -359,6 +359,43 @@
   opacity: 0.75;
 }
 
+/* Chromeless top-chrome icon buttons (back / overflow menu): glyph-only by
+   default, with a legibility drop-shadow so the glyph reads over hero media on
+   touch devices that never hover. The pearl circle reveals on hover /
+   focus-visible only. Unlayered on purpose so it beats the layered variant
+   utilities on the same element. */
+.profile-top-chrome-icon {
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  color: var(--profile-status-pill-fg);
+}
+
+.profile-top-chrome-icon > svg {
+  filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.72))
+    drop-shadow(0 0 2px rgba(0, 0, 0, 0.6));
+}
+
+@media (hover: hover) {
+  .profile-top-chrome-icon:hover {
+    border-color: var(--profile-pearl-border);
+    background: var(--profile-pearl-bg);
+    box-shadow: var(--profile-pearl-shadow);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+  }
+}
+
+.profile-top-chrome-icon:focus-visible {
+  border-color: var(--profile-pearl-border);
+  background: var(--profile-pearl-bg);
+  box-shadow: var(--profile-pearl-shadow);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+}
+
 :where(.profile-horizontal-rail) {
   -ms-overflow-style: none;
   scrollbar-width: none;

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -328,9 +328,28 @@
   height: 100%;
   max-height: 104vw;
   align-self: center;
+  /* Size container so card content can respond to the card's own height. */
+  container-type: size;
   transition:
     transform var(--ds-motion-subtle-duration) var(--ds-motion-subtle-easing),
     opacity var(--ds-motion-subtle-duration) var(--ds-motion-subtle-easing);
+}
+
+/* Unified card anatomy: the art zone is a full-width square, so the text
+   zone + CTA share (card height − card width). Progressive disclosure keeps
+   every line whole instead of clipping mid-line: the meta line hides below
+   the height where it fits (~448px), and the eyebrow hides below the height
+   where it fits next to the title (~360px) — title and CTA always fit. */
+@container (max-height: 447px) {
+  :where(.profile-entity-card) .entity-card-meta {
+    display: none;
+  }
+}
+
+@container (max-height: 359px) {
+  :where(.profile-entity-card) .entity-card-eyebrow {
+    display: none;
+  }
 }
 
 /* Scroll-driven edge treatment (transform/opacity only; applied via
@@ -389,6 +408,26 @@
 :where(.profile-aeo-content__source:hover) {
   color: var(--profile-aeo-text);
   text-decoration-color: var(--profile-aeo-text);
+}
+
+:where(.profile-aeo-content__facts) {
+  border-color: var(--profile-aeo-border);
+}
+
+:where(.profile-aeo-content__fact-value) {
+  color: var(--profile-aeo-text);
+}
+
+:where(.profile-aeo-content__fact-label),
+:where(.profile-aeo-content__link-label),
+:where(.profile-aeo-content__link),
+:where(.profile-aeo-content__share) {
+  color: var(--profile-aeo-muted);
+}
+
+:where(.profile-aeo-content__link:hover),
+:where(.profile-aeo-content__share:hover) {
+  color: var(--profile-aeo-text);
 }
 
 :where(.profile-aeo-claim-card) {
@@ -4849,6 +4888,31 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
     var(--jovie-entity-accent) 82%,
     var(--color-text-primary-token) 18%
   );
+}
+
+/* Inline entity links in public profile bio/AEO copy. The entity-kind accent
+   is provided via the `--jovie-entity-accent` custom property on the link. */
+.profile-entity-mention {
+  color: var(--jovie-entity-accent);
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--jovie-entity-accent) 45%,
+    transparent
+  );
+  transition:
+    color var(--system-b-duration-fast) var(--system-b-ease),
+    text-decoration-color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+.profile-entity-mention:hover,
+.profile-entity-mention:focus-visible {
+  text-decoration-color: var(--jovie-entity-accent);
+}
+
+.profile-entity-mention:focus-visible {
+  outline: 2px solid var(--jovie-entity-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }
 
 .system-b-assistant-skill-mention {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -498,7 +498,10 @@ html[data-profile-initial-mode]
 
 @media (min-width: 768px) {
   .public-profile-compact-shell {
-    --cover-height: 340px;
+    /* Proportional hero: on short desktop windows the shell shrinks below
+       740px and a fixed 340px hero would crush the carousel to a sliver.
+       Share the shell height instead (45%, floored at 200px). */
+    --cover-height: clamp(200px, 45%, 340px);
     height: min(740px, calc(100dvh - (var(--page-pad) * 2)));
   }
 }

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -52,7 +52,7 @@
   --section-gap: clamp(16px, 3vw, 28px);
   --card-pad: clamp(14px, 3vw, 24px);
   --avatar-size: clamp(88px, 22vw, 144px);
-  --cover-height: clamp(300px, min(94vw, 46svh), 430px);
+  --cover-height: clamp(220px, 34svh, 400px);
   --content-max: 720px;
   --profile-bottom-nav-height: calc(
     3.125rem +
@@ -178,7 +178,7 @@
   --section-gap: clamp(16px, 3vw, 28px);
   --card-pad: clamp(14px, 3vw, 24px);
   --avatar-size: clamp(88px, 22vw, 144px);
-  --cover-height: clamp(300px, min(94vw, 46svh), 430px);
+  --cover-height: clamp(220px, 34svh, 400px);
   --content-max: 720px;
 }
 
@@ -301,6 +301,45 @@
   );
 }
 
+/* Single hero legibility gradient, limited to the bottom ~55% of the cover so
+   the artist photo stays clearly visible in the upper zone. Replaces the old
+   stacked full-height scrims (profile-cover-home-gradient +
+   profile-cover-home-fade) that darkened the whole photo. */
+:where(.profile-cover-home-gradient) {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  height: 55%;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    rgba(3, 4, 6, 0.42) 52%,
+    rgba(5, 6, 8, 0.9) 86%,
+    var(--profile-stage-bg) 100%
+  );
+}
+
+/* Profile home carousel card geometry: one 3:4 shape that fills the remaining
+   viewport height. Width derives from height via aspect-ratio; the max-height
+   cap keeps width at or under ~78vw (width = 0.75 × height). Cards center
+   vertically when the track is taller than the capped card height. */
+:where(.profile-entity-card) {
+  aspect-ratio: 3 / 4;
+  height: 100%;
+  max-height: 104vw;
+  align-self: center;
+  transition:
+    transform var(--ds-motion-subtle-duration) var(--ds-motion-subtle-easing),
+    opacity var(--ds-motion-subtle-duration) var(--ds-motion-subtle-easing);
+}
+
+/* Scroll-driven edge treatment (transform/opacity only; applied via
+   IntersectionObserver and skipped entirely under reduced motion). */
+:where(.profile-entity-card[data-edge="true"]) {
+  transform: scale(0.96);
+  opacity: 0.75;
+}
+
 :where(.profile-horizontal-rail) {
   -ms-overflow-style: none;
   scrollbar-width: none;
@@ -414,16 +453,10 @@
   }
 }
 
-/* Compact mobile home hero: reserve room for the showcase release card below.
-   On short viewports (≤820px tall) cap the cover at 190px so the bento card
-   stays above the fold (profile-mobile-viewport-stability). Media crops via
-   object-cover; content below the hero scrolls. */
-[data-testid="profile-compact-surface"][data-mode="profile"] {
-  @media (max-height: 820px) {
-    --cover-height: 190px;
-  }
-}
-
+/* Compact mobile home hero: one definite token-driven height on every
+   viewport (--cover-height, clamp(220px, 34svh, 400px)). The hero never
+   shrink-wraps; media crops via object-cover and the carousel below owns the
+   remaining viewport height. */
 /* Query-mode profile URLs are served from the ISR home shell, then hydrate into
    the requested mode from window.location. Match the mode header on first paint
    so hydration does not move the compact profile frame. */
@@ -451,9 +484,6 @@ html[data-profile-initial-mode]
 html[data-profile-initial-mode]
   [data-testid="profile-compact-surface"][data-mode="profile"]
   .profile-cover-home-gradient,
-html[data-profile-initial-mode]
-  [data-testid="profile-compact-surface"][data-mode="profile"]
-  .profile-cover-home-fade,
 html[data-profile-initial-mode]
   [data-testid="profile-compact-surface"][data-mode="profile"]
   [data-testid="profile-hero-identity-block"] {

--- a/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
+++ b/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
@@ -558,7 +558,7 @@ const MOCK_HOME_RELEASE_CARD_VIEWPORTS = [
 ] as const satisfies readonly MobileProfileViewport[];
 
 type ReleaseCardLayout = {
-  readonly card: {
+  readonly pac: {
     readonly top: number;
     readonly bottom: number;
     readonly left: number;
@@ -566,16 +566,17 @@ type ReleaseCardLayout = {
     readonly width: number;
     readonly height: number;
   };
-  readonly artwork: {
+  readonly pacBox: {
     readonly width: number;
     readonly height: number;
-    readonly contentWidth: number;
+  };
+  readonly pacIsFirstCard: boolean;
+  readonly peerCard: {
+    readonly width: number;
+    readonly height: number;
   } | null;
-  readonly title: {
+  readonly tabBar: {
     readonly top: number;
-    readonly bottom: number;
-    readonly left: number;
-    readonly right: number;
   } | null;
   readonly hero: {
     readonly top: number;
@@ -590,20 +591,24 @@ async function collectMockHomeReleaseCardLayout(
   page: Page
 ): Promise<ReleaseCardLayout> {
   return page.evaluate(() => {
-    const card = document.querySelector<HTMLElement>(
-      '[data-testid="profile-home-carousel"] a'
+    const carousel = document.querySelector<HTMLElement>(
+      '[data-testid="profile-home-carousel"]'
     );
-    const artwork = card?.querySelector<HTMLImageElement>('img') ?? null;
-    const title = card?.querySelector<HTMLElement>('h3') ?? null;
+    const pac = document.querySelector<HTMLElement>(
+      '[data-testid="profile-pac"]'
+    );
     const hero = document.querySelector<HTMLElement>(
       '[data-testid="profile-hero-identity-block"]'
     );
     const cover = document.querySelector<HTMLElement>(
       '[data-testid="profile-cover"]'
     );
+    const tabBar = document.querySelector<HTMLElement>(
+      '[data-testid="profile-tab-bar"]'
+    );
 
-    if (!card) {
-      throw new Error('Mock-home release card layout target missing');
+    if (!carousel || !pac) {
+      throw new Error('Mock-home featured release (PAC) card target missing');
     }
 
     const rect = (element: Element) => {
@@ -618,15 +623,23 @@ async function collectMockHomeReleaseCardLayout(
       };
     };
 
+    const firstLi = carousel.querySelector(':scope > li');
+    // A peer card in the same track (entity card or alerts card) used to
+    // verify the PAC card shares the fixed 3:4 carousel geometry.
+    const peerLi = [...carousel.querySelectorAll(':scope > li')].find(
+      li => li !== firstLi
+    );
+
     return {
-      card: rect(card),
-      artwork: artwork
-        ? {
-            ...rect(artwork),
-            contentWidth: artwork.parentElement?.clientWidth ?? 0,
-          }
+      pac: rect(pac),
+      // offsetWidth/offsetHeight are transform-free (edge-dimmed peer cards
+      // are scaled to 0.96 via transform, which would skew getBoundingClientRect).
+      pacBox: { width: pac.offsetWidth, height: pac.offsetHeight },
+      pacIsFirstCard: Boolean(firstLi?.contains(pac)),
+      peerCard: peerLi
+        ? { width: peerLi.offsetWidth, height: peerLi.offsetHeight }
         : null,
-      title: title ? rect(title) : null,
+      tabBar: tabBar ? { top: tabBar.getBoundingClientRect().top } : null,
       hero: hero ? rect(hero) : null,
       cover: cover
         ? {
@@ -639,7 +652,7 @@ async function collectMockHomeReleaseCardLayout(
 
 test.describe('Public Profile Mock Home Release Card Layout @smoke @critical', () => {
   for (const viewport of MOCK_HOME_RELEASE_CARD_VIEWPORTS) {
-    test(`${viewport.label} renders a stable bento release card`, async ({
+    test(`${viewport.label} renders a stable featured release card`, async ({
       page,
     }, testInfo) => {
       await page.setViewportSize({
@@ -659,7 +672,7 @@ test.describe('Public Profile Mock Home Release Card Layout @smoke @critical', (
       // budget as navigation so a slow cold compile reads as slow, not failed.
       await waitForAnyVisible(
         page,
-        ['[data-testid="profile-home-carousel"] a'],
+        ['[data-testid="profile-pac"]'],
         SMOKE_TIMEOUTS.NAVIGATION
       );
       await settleLayout(page);
@@ -679,37 +692,90 @@ test.describe('Public Profile Mock Home Release Card Layout @smoke @critical', (
       ).toBeLessThanOrEqual(2);
 
       const layout = await collectMockHomeReleaseCardLayout(page);
+
+      // The featured release card (PAC) is the FIRST card of the single home
+      // carousel — the old stacked bento strip above the carousel is gone.
+      expect(
+        layout.pacIsFirstCard,
+        `${viewport.label} featured release card should be the first carousel card`
+      ).toBe(true);
+
+      // Same fixed 3:4 geometry as every other card in the track.
+      if (layout.peerCard) {
+        expect(
+          Math.abs(layout.pacBox.height - layout.peerCard.height),
+          `${viewport.label} featured card should match peer card height`
+        ).toBeLessThanOrEqual(2);
+        expect(
+          Math.abs(layout.pacBox.width - layout.peerCard.width),
+          `${viewport.label} featured card should match peer card width`
+        ).toBeLessThanOrEqual(2);
+      }
+      expect(
+        Math.abs(layout.pacBox.width / layout.pacBox.height - 0.75),
+        `${viewport.label} featured card should keep the 3:4 card aspect`
+      ).toBeLessThanOrEqual(0.02);
+
       if (layout.hero) {
         expect(
-          layout.card.top,
-          `${viewport.label} release card should sit below hero identity`
+          layout.pac.top,
+          `${viewport.label} featured card should sit below hero identity`
         ).toBeGreaterThanOrEqual(layout.hero.bottom + 4);
       }
 
-      expect(
-        Math.abs(
-          (layout.artwork?.width ?? 0) -
-            (layout.artwork?.contentWidth ?? Number.POSITIVE_INFINITY)
-        ),
-        `${viewport.label} bento artwork should fill its padded content box`
-      ).toBeLessThanOrEqual(2);
-
-      if (layout.title) {
+      // Fully visible above the bottom tab bar inside the profile shell — no
+      // clipping, no scrolling needed for the primary content. (The demo
+      // phone frame itself can extend past the browser viewport — that is
+      // the showcase page's own presentation, so containment is asserted
+      // against the shell and tab bar, not the window.)
+      const shell = await page.evaluate(() => {
+        const el = document.querySelector<HTMLElement>(
+          '[data-testid="profile-compact-surface"]'
+        );
+        if (!el) return null;
+        const box = el.getBoundingClientRect();
+        return { top: box.top, bottom: box.bottom };
+      });
+      if (shell) {
         expect(
-          layout.title.top,
-          `${viewport.label} release title should stay inside the card`
-        ).toBeGreaterThanOrEqual(layout.card.top + 6);
+          layout.pac.bottom,
+          `${viewport.label} featured card should stay inside the profile shell`
+        ).toBeLessThanOrEqual(shell.bottom + 1);
         expect(
-          layout.title.bottom,
-          `${viewport.label} release title should stay inside the card`
-        ).toBeLessThanOrEqual(layout.card.bottom - 6);
+          layout.pac.top,
+          `${viewport.label} featured card should stay inside the profile shell`
+        ).toBeGreaterThanOrEqual(shell.top - 1);
+      }
+      if (layout.tabBar) {
+        expect(
+          layout.pac.bottom,
+          `${viewport.label} featured card should clear the bottom tab bar`
+        ).toBeLessThanOrEqual(layout.tabBar.top + 1);
       }
 
+      // Stability: the card's bounding box must not move once rendered.
+      await settleLayout(page);
+      const settled = await collectMockHomeReleaseCardLayout(page);
+      expect(
+        Math.abs(settled.pac.top - layout.pac.top),
+        `${viewport.label} featured card should not shift vertically`
+      ).toBeLessThanOrEqual(1);
+      expect(
+        Math.abs(settled.pac.height - layout.pac.height),
+        `${viewport.label} featured card should not change height`
+      ).toBeLessThanOrEqual(1);
+
       if (viewport.height <= 820 && layout.cover) {
+        // Token-driven hero: clamp(220px, 34svh, 400px) — the old ≤190px
+        // shrink-wrap band is gone and the hero never collapses.
         expect(
           layout.cover.height,
-          `${viewport.label} home hero should compress on compact viewports`
-        ).toBeLessThanOrEqual(190);
+          `${viewport.label} home hero should keep its 220px floor on compact viewports`
+        ).toBeGreaterThanOrEqual(220);
+        expect(
+          layout.cover.height,
+          `${viewport.label} home hero should stay within the 400px token cap`
+        ).toBeLessThanOrEqual(400);
       }
     });
   }

--- a/apps/web/tests/unit/lib/seo/structured-data.test.ts
+++ b/apps/web/tests/unit/lib/seo/structured-data.test.ts
@@ -201,6 +201,69 @@ describe('generateProfileStructuredData', () => {
     const artist = findInGraph(data, 'MusicGroup');
     expect(artist?.sameAs).toBeUndefined();
   });
+
+  it('emits linked-entity mentions on the artist node', () => {
+    const data = generateProfileStructuredData(
+      BASE_PROFILE,
+      ['pop'],
+      MOCK_LINKS,
+      [],
+      [],
+      [
+        {
+          kind: 'release',
+          name: 'Neon Circuit',
+          url: 'https://jov.ie/testartist/neon-circuit',
+        },
+        {
+          kind: 'artist',
+          name: 'Guest Vocalist',
+          url: 'https://jov.ie/guestvocalist',
+        },
+      ]
+    );
+
+    const artist = findInGraph(data, 'MusicGroup');
+    expect(artist?.mentions).toEqual([
+      {
+        '@type': 'MusicRecording',
+        name: 'Neon Circuit',
+        url: 'https://jov.ie/testartist/neon-circuit',
+      },
+      {
+        '@type': 'MusicGroup',
+        name: 'Guest Vocalist',
+        url: 'https://jov.ie/guestvocalist',
+      },
+    ]);
+    expect(validateProfileRichResults(data)).toEqual([]);
+  });
+
+  it('caps mentions at 25 and omits the key when empty', () => {
+    const manyMentions = Array.from({ length: 40 }, (_, i) => ({
+      kind: 'release' as const,
+      name: `Release ${i}`,
+      url: `https://jov.ie/testartist/release-${i}`,
+    }));
+
+    const capped = generateProfileStructuredData(
+      BASE_PROFILE,
+      ['pop'],
+      MOCK_LINKS,
+      [],
+      [],
+      manyMentions
+    );
+    const cappedArtist = findInGraph(capped, 'MusicGroup');
+    expect(cappedArtist?.mentions).toHaveLength(25);
+
+    const without = generateProfileStructuredData(
+      BASE_PROFILE,
+      ['pop'],
+      MOCK_LINKS
+    );
+    expect(findInGraph(without, 'MusicGroup')?.mentions).toBeUndefined();
+  });
 });
 
 describe('generateMusicStructuredData', () => {

--- a/apps/web/tests/unit/profile/ProfileEmptyBentoCard.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileEmptyBentoCard.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { ProfileEmptyBentoCard } from '@/features/profile/ProfileEmptyBentoCard';
 
 describe('ProfileEmptyBentoCard', () => {
-  it('renders a prominent events bento with full-color gradient background', () => {
+  it('renders a prominent events bento with the standard surface-1 card treatment', () => {
     render(
       <ProfileEmptyBentoCard
         accent='events'
@@ -18,7 +18,7 @@ describe('ProfileEmptyBentoCard', () => {
     );
 
     const card = screen.getByTestId('profile-events-empty-card');
-    expect(card.style.background).toContain('var(--color-accent-blue)');
+    expect(card.style.background).toContain('var(--color-bg-surface-1)');
     expect(screen.getByText('No Events')).toBeVisible();
     expect(
       screen.getByText('Get alerted when shows are announced.')

--- a/apps/web/tests/unit/profile/ProfileEmptyBentoCard.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileEmptyBentoCard.test.tsx
@@ -1,27 +1,29 @@
 import { render, screen } from '@testing-library/react';
-import { Bell, Music2 } from 'lucide-react';
+import { Music2, Ticket } from 'lucide-react';
 import { describe, expect, it } from 'vitest';
 import { ProfileEmptyBentoCard } from '@/features/profile/ProfileEmptyBentoCard';
 
 describe('ProfileEmptyBentoCard', () => {
-  it('renders a prominent alerts bento with full-color gradient background', () => {
+  it('renders a prominent events bento with full-color gradient background', () => {
     render(
       <ProfileEmptyBentoCard
-        accent='alerts'
-        icon={Bell}
-        title='Alerts'
-        body='Tim White: music, shows, merch.'
+        accent='events'
+        icon={Ticket}
+        title='No Events'
+        body='Get alerted when shows are announced.'
         layout='prominent'
-        dataTestId='profile-home-alerts-fallback-card'
-        trailing={<span data-testid='profile-home-alerts-switch'>switch</span>}
+        dataTestId='profile-events-empty-card'
+        trailing={<span data-testid='profile-events-empty-trailing'>slot</span>}
       />
     );
 
-    const card = screen.getByTestId('profile-home-alerts-fallback-card');
-    expect(card.style.background).toContain('var(--color-accent-purple)');
-    expect(screen.getByText('Alerts')).toBeVisible();
-    expect(screen.getByText('Tim White: music, shows, merch.')).toBeVisible();
-    expect(screen.getByTestId('profile-home-alerts-switch')).toBeVisible();
+    const card = screen.getByTestId('profile-events-empty-card');
+    expect(card.style.background).toContain('var(--color-accent-blue)');
+    expect(screen.getByText('No Events')).toBeVisible();
+    expect(
+      screen.getByText('Get alerted when shows are announced.')
+    ).toBeVisible();
+    expect(screen.getByTestId('profile-events-empty-trailing')).toBeVisible();
   });
 
   it('renders a compact music empty bento with CTA action', () => {

--- a/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
@@ -118,7 +118,7 @@ describe('ProfileHomeRail', () => {
     ).toEqual(['merch-1', 'show-1']);
   });
 
-  it('renders alerts above content cards in the home rail DOM order (JOV-11084)', () => {
+  it('renders the PAC card first and the alerts card last inside the carousel', () => {
     render(
       <ProfileHomeRail
         artist={makeArtist()}
@@ -132,18 +132,23 @@ describe('ProfileHomeRail', () => {
       />
     );
 
-    const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
     const carousel = screen.getByTestId('profile-home-carousel');
+    const pacCard = screen.getByTestId('profile-pac');
+    const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
 
-    expect(alertsCard.compareDocumentPosition(carousel)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING
-    );
-    expect(
-      screen.getByRole('heading', { name: 'Never Say A Word' })
-    ).toBeInTheDocument();
+    // Both live inside the single carousel — no stacked sections.
+    expect(carousel.contains(pacCard)).toBe(true);
+    expect(carousel.contains(alertsCard)).toBe(true);
+
+    const footprints = [...carousel.querySelectorAll(':scope > li')];
+    expect(footprints[0]?.contains(pacCard)).toBe(true);
+    expect(footprints[footprints.length - 1]?.contains(alertsCard)).toBe(true);
+    // The featured release renders once, inside the PAC card (not as a
+    // duplicate plain catalog card).
+    expect(screen.getAllByText('Never Say A Word')).toHaveLength(1);
   });
 
-  it('renders a prominent gradient alerts bento when the home rail is empty', () => {
+  it('renders a prominent gradient alerts card when the home rail is empty', () => {
     render(
       <ProfileHomeRail
         artist={makeArtist()}
@@ -162,7 +167,7 @@ describe('ProfileHomeRail', () => {
     expect(alertsCard.className).toContain('min-h-44');
   });
 
-  it('pins the alerts bento above the carousel and renders no carousel when empty', () => {
+  it('keeps the carousel shell with PAC and alerts cards even when the catalog is empty', () => {
     render(
       <ProfileHomeRail
         artist={makeArtist()}
@@ -176,19 +181,19 @@ describe('ProfileHomeRail', () => {
       />
     );
 
+    const carousel = screen.getByTestId('profile-home-carousel');
     expect(
       screen.getByTestId('profile-home-alerts-fallback-card')
     ).toBeInTheDocument();
     expect(
       screen.getByTestId('profile-home-alerts-switch')
     ).toBeInTheDocument();
-    // No items → carousel renders nothing (no empty shell).
-    expect(
-      screen.queryByTestId('profile-home-carousel')
-    ).not.toBeInTheDocument();
+    // No entity items → the carousel still hosts the slot cards.
+    expect(carousel.querySelectorAll(':scope > li').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('entity-card-music')).not.toBeInTheDocument();
   });
 
-  it('renders the latest release as the featured carousel card', () => {
+  it('renders the latest release as the featured PAC card, not a catalog card', () => {
     render(
       <ProfileHomeRail
         artist={makeArtist()}
@@ -202,17 +207,22 @@ describe('ProfileHomeRail', () => {
       />
     );
 
-    const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
+    const pacCard = screen.getByTestId('profile-pac');
     const carousel = screen.getByTestId('profile-home-carousel');
+    const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
 
-    expect(alertsCard).toBeInTheDocument();
+    expect(pacCard).toBeInTheDocument();
+    expect(pacCard.dataset.state).toBe('idle');
     expect(carousel).toBeInTheDocument();
-    expect(alertsCard.compareDocumentPosition(carousel)).toBe(
+    expect(alertsCard).toBeInTheDocument();
+    // Featured release title lives in the PAC card only.
+    expect(screen.getAllByText('The Deep End')).toHaveLength(1);
+    expect(
+      screen.queryByRole('heading', { name: 'The Deep End' })
+    ).not.toBeInTheDocument();
+    expect(pacCard.compareDocumentPosition(alertsCard)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
-    expect(
-      screen.getByRole('heading', { name: 'The Deep End' })
-    ).toBeInTheDocument();
   });
 
   it('adds back-catalog releases without duplicating the featured release', () => {
@@ -242,9 +252,8 @@ describe('ProfileHomeRail', () => {
     );
 
     expect(screen.getByTestId('profile-home-carousel')).toBeInTheDocument();
-    expect(
-      screen.getAllByRole('heading', { name: 'The Deep End' })
-    ).toHaveLength(1);
+    // The featured release appears exactly once (inside the PAC card).
+    expect(screen.getAllByText('The Deep End')).toHaveLength(1);
     expect(
       screen.getByRole('heading', { name: 'Under Lights' })
     ).toBeInTheDocument();
@@ -268,8 +277,9 @@ describe('ProfileHomeRail', () => {
       screen.queryByTestId('profile-home-alerts-fallback-card')
     ).not.toBeInTheDocument();
     expect(screen.getByTestId('profile-home-carousel')).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { name: 'The Deep End' })
-    ).toBeInTheDocument();
+    // Subscribed visitor: the PAC card resolves to the S2 'following' state.
+    const pacCard = screen.getByTestId('profile-pac');
+    expect(pacCard.dataset.state).toBe('following');
+    expect(screen.getByText('You follow Tim White')).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
@@ -148,7 +148,7 @@ describe('ProfileHomeRail', () => {
     expect(screen.getAllByText('Never Say A Word')).toHaveLength(1);
   });
 
-  it('renders a prominent gradient alerts card when the home rail is empty', () => {
+  it('renders the alerts card as a standard unified-anatomy card (no gradient)', () => {
     render(
       <ProfileHomeRail
         artist={makeArtist()}
@@ -163,8 +163,14 @@ describe('ProfileHomeRail', () => {
     );
 
     const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
-    expect(alertsCard.style.background).toContain('var(--color-accent-purple)');
-    expect(alertsCard.className).toContain('min-h-44');
+    // Standard card: pearl surface, no accent gradient, unified anatomy
+    // (square icon art zone + full-width "Get Updates" CTA).
+    expect(alertsCard.style.background).toBe('');
+    expect(alertsCard.className).toContain('bg-(--profile-pearl-bg)');
+    expect(alertsCard).toHaveTextContent('Alerts');
+    const cta = screen.getByText('Get Updates');
+    expect(cta.className).toContain('h-9');
+    expect(cta.className).toContain('w-full');
   });
 
   it('keeps the carousel shell with PAC and alerts cards even when the catalog is empty', () => {
@@ -182,12 +188,12 @@ describe('ProfileHomeRail', () => {
     );
 
     const carousel = screen.getByTestId('profile-home-carousel');
-    expect(
-      screen.getByTestId('profile-home-alerts-fallback-card')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('profile-home-alerts-switch')
-    ).toBeInTheDocument();
+    const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
+    expect(alertsCard).toBeInTheDocument();
+    // The alerts card shares the unified entity-card anatomy (full-bleed
+    // square art zone, full-width CTA).
+    expect(alertsCard.className).toContain('p-0');
+    expect(screen.getByText('Get Updates')).toBeInTheDocument();
     // No entity items → the carousel still hosts the slot cards.
     expect(carousel.querySelectorAll(':scope > li').length).toBeGreaterThan(0);
     expect(screen.queryByTestId('entity-card-music')).not.toBeInTheDocument();

--- a/apps/web/tests/unit/profile/TourModePanel.test.tsx
+++ b/apps/web/tests/unit/profile/TourModePanel.test.tsx
@@ -145,7 +145,7 @@ describe('TourModePanel', () => {
     );
   });
 
-  it('renders the events empty state as a full-color gradient bento card', () => {
+  it('renders the events empty state with the standard surface-1 card treatment', () => {
     render(<TourModePanel artist={artist} tourDates={[]} />);
 
     expect(
@@ -156,7 +156,7 @@ describe('TourModePanel', () => {
     expect(heading.className).not.toMatch(/text-\(--color-text-tooltip\)/);
     const bentoCard = screen.getByTestId('profile-primary-tab-events-empty')
       .firstChild as HTMLElement;
-    expect(bentoCard.style.background).toContain('var(--color-accent-blue)');
+    expect(bentoCard.style.background).toContain('var(--color-bg-surface-1)');
   });
 
   it('renders the styled all-shows list when no geolocation is available', () => {

--- a/apps/web/tests/unit/profile/entity-mentions.test.ts
+++ b/apps/web/tests/unit/profile/entity-mentions.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectEntityMentions,
+  type EntityMentionContext,
+  linkEntityMentions,
+  MAX_ENTITY_MENTIONS,
+} from '@/lib/profile/entity-mentions';
+
+const context: EntityMentionContext = {
+  ownHandle: 'tim',
+  releases: [
+    { title: 'Take Me Over', slug: 'take-me-over' },
+    { title: 'Gate', slug: 'gate' },
+    { title: 'Sky', slug: 'sky' },
+  ],
+  artists: [
+    { name: 'Cosmic Gate', handle: 'cosmicgate' },
+    { name: 'The Disco Biscuits', handle: null },
+    { name: 'Tim', handle: 'tim' },
+  ],
+};
+
+describe('linkEntityMentions', () => {
+  it('links a quoted release title, leaving the quotes as plain text', () => {
+    const segments = linkEntityMentions(
+      'Check out "Take Me Over" on streaming now.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'Check out "' },
+      {
+        type: 'release',
+        text: 'Take Me Over',
+        href: '/tim/take-me-over',
+      },
+      { type: 'text', text: '" on streaming now.' },
+    ]);
+  });
+
+  it('prefers the longest overlapping name', () => {
+    const segments = linkEntityMentions(
+      'Toured with Cosmic Gate last summer.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'Toured with ' },
+      { type: 'artist', text: 'Cosmic Gate', href: '/cosmicgate' },
+      { type: 'text', text: ' last summer.' },
+    ]);
+  });
+
+  it('matches case-insensitively but preserves the original casing in the segment', () => {
+    const segments = linkEntityMentions(
+      'take me over was the first single.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'release', text: 'take me over', href: '/tim/take-me-over' },
+      { type: 'text', text: ' was the first single.' },
+    ]);
+  });
+
+  it('keeps artists without a Jovie profile as plain text', () => {
+    const segments = linkEntityMentions(
+      'Shared bills with The Disco Biscuits.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'Shared bills with The Disco Biscuits.' },
+    ]);
+  });
+
+  it('does not match inside longer words (word boundaries)', () => {
+    const segments = linkEntityMentions(
+      'The Skyline venue was packed.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'The Skyline venue was packed.' },
+    ]);
+  });
+
+  it('links a standalone short title at a word boundary', () => {
+    const segments = linkEntityMentions('Sky is the opener.', context);
+
+    expect(segments).toEqual([
+      { type: 'release', text: 'Sky', href: '/tim/sky' },
+      { type: 'text', text: ' is the opener.' },
+    ]);
+  });
+
+  it('links the profile owner name to their own profile', () => {
+    const segments = linkEntityMentions(
+      'Tim started producing in 2012.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'artist', text: 'Tim', href: '/tim' },
+      { type: 'text', text: ' started producing in 2012.' },
+    ]);
+  });
+
+  it('links multiple entities in one paragraph', () => {
+    const segments = linkEntityMentions(
+      'After Take Me Over, Tim remixed Cosmic Gate.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'After ' },
+      { type: 'release', text: 'Take Me Over', href: '/tim/take-me-over' },
+      { type: 'text', text: ', ' },
+      { type: 'artist', text: 'Tim', href: '/tim' },
+      { type: 'text', text: ' remixed ' },
+      { type: 'artist', text: 'Cosmic Gate', href: '/cosmicgate' },
+      { type: 'text', text: '.' },
+    ]);
+  });
+
+  it('returns a single text segment when there is nothing to link', () => {
+    expect(linkEntityMentions('Hello world.', { ownHandle: 'tim' })).toEqual([
+      { type: 'text', text: 'Hello world.' },
+    ]);
+    expect(linkEntityMentions('', context)).toEqual([]);
+  });
+
+  it('prefers the release when a release and artist share the same name', () => {
+    const segments = linkEntityMentions('Gate changed everything.', {
+      ownHandle: 'tim',
+      releases: [{ title: 'Gate', slug: 'gate' }],
+      artists: [{ name: 'Gate', handle: 'gate' }],
+    });
+
+    expect(segments).toEqual([
+      { type: 'release', text: 'Gate', href: '/tim/gate' },
+      { type: 'text', text: ' changed everything.' },
+    ]);
+  });
+
+  it('ignores releases without a slug and single-character phrases', () => {
+    const segments = linkEntityMentions('X marks Gate.', {
+      ownHandle: 'tim',
+      releases: [{ title: 'Gate' }],
+      artists: [{ name: 'X', handle: 'x' }],
+    });
+
+    expect(segments).toEqual([{ type: 'text', text: 'X marks Gate.' }]);
+  });
+});
+
+describe('collectEntityMentions', () => {
+  it('collects deduped linkable entities with hrefs', () => {
+    const mentions = collectEntityMentions(context);
+
+    expect(mentions).toContainEqual({
+      kind: 'release',
+      name: 'Take Me Over',
+      href: '/tim/take-me-over',
+    });
+    expect(mentions).toContainEqual({
+      kind: 'artist',
+      name: 'Cosmic Gate',
+      href: '/cosmicgate',
+    });
+    // No Jovie profile → not collected.
+    expect(
+      mentions.some(mention => mention.name === 'The Disco Biscuits')
+    ).toBe(false);
+  });
+
+  it('caps the number of mentions', () => {
+    const manyReleases = Array.from(
+      { length: MAX_ENTITY_MENTIONS + 10 },
+      (_, i) => ({
+        title: `Release Number ${i}`,
+        slug: `release-number-${i}`,
+      })
+    );
+
+    const mentions = collectEntityMentions({
+      ownHandle: 'tim',
+      releases: manyReleases,
+    });
+
+    expect(mentions).toHaveLength(MAX_ENTITY_MENTIONS);
+  });
+});

--- a/apps/web/tests/unit/profile/profile-about-share.test.tsx
+++ b/apps/web/tests/unit/profile/profile-about-share.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProfileAboutShare } from '@/features/profile/ProfileAboutShare';
+
+function mockClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+  return writeText;
+}
+
+describe('ProfileAboutShare', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    Object.defineProperty(navigator, 'share', {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  it('copies the profile URL when the Web Share API is unavailable', async () => {
+    const writeText = mockClipboard();
+
+    render(
+      <ProfileAboutShare url='https://jov.ie/dj-test' artistName='DJ Test' />
+    );
+
+    const button = screen.getByTestId('profile-about-share');
+    expect(button).toHaveAttribute('aria-label', "Share DJ Test's profile");
+
+    fireEvent.click(button);
+
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('https://jov.ie/dj-test');
+      expect(button).toHaveAttribute(
+        'aria-label',
+        "Copied link to DJ Test's profile"
+      );
+    });
+  });
+
+  it('uses the Web Share API when available', async () => {
+    const writeText = mockClipboard();
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: share,
+      configurable: true,
+    });
+
+    render(
+      <ProfileAboutShare url='https://jov.ie/dj-test' artistName='DJ Test' />
+    );
+
+    fireEvent.click(screen.getByTestId('profile-about-share'));
+
+    await vi.waitFor(() => {
+      expect(share).toHaveBeenCalledWith({
+        title: 'DJ Test',
+        url: 'https://jov.ie/dj-test',
+      });
+    });
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the user cancels the share sheet', async () => {
+    const writeText = mockClipboard();
+    const share = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error('cancelled'), { name: 'AbortError' })
+      );
+    Object.defineProperty(navigator, 'share', {
+      value: share,
+      configurable: true,
+    });
+
+    render(
+      <ProfileAboutShare url='https://jov.ie/dj-test' artistName='DJ Test' />
+    );
+
+    const button = screen.getByTestId('profile-about-share');
+    fireEvent.click(button);
+
+    await vi.waitFor(() => {
+      expect(share).toHaveBeenCalled();
+    });
+    expect(writeText).not.toHaveBeenCalled();
+    expect(button).toHaveAttribute('aria-label', "Share DJ Test's profile");
+  });
+});

--- a/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
+++ b/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
@@ -179,6 +179,193 @@ describe('Profile AEO content', () => {
     expect(content.faqs[3]?.answer).toContain('$68.00');
   });
 
+  it('builds the facts strip from genres, active year, and hometown', () => {
+    const content = buildContent();
+
+    expect(content.facts).toEqual([
+      { label: 'Genre', value: 'Tech house, electronic, club' },
+      { label: 'Active Since', value: '2018' },
+      { label: 'Hometown', value: 'Austin, TX' },
+    ]);
+  });
+
+  it('falls back to location for the hometown fact only when hometown is missing', () => {
+    const content = buildProfileAeoContent({
+      artist: { ...baseArtist, hometown: null, location: 'Berlin, DE' },
+      now,
+    });
+
+    expect(content.facts).toContainEqual({
+      label: 'Hometown',
+      value: 'Berlin, DE',
+    });
+
+    const withHometown = buildProfileAeoContent({ artist: baseArtist, now });
+    expect(withHometown.facts).toContainEqual({
+      label: 'Hometown',
+      value: 'Austin, TX',
+    });
+  });
+
+  it('omits the facts strip fields that have no data', () => {
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        hometown: null,
+        location: null,
+        active_since_year: null,
+        genres: null,
+      },
+      now,
+    });
+
+    expect(content.facts).toEqual([]);
+  });
+
+  it('splits social links into listen (DSP) and follow (non-DSP) rows', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      socialLinks: [
+        ...socialLinks,
+        {
+          id: 'link-2',
+          artist_id: 'artist-1',
+          platform: 'instagram',
+          url: 'https://instagram.com/djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'link-3',
+          artist_id: 'artist-1',
+          platform: 'youtube',
+          url: 'https://youtube.com/@djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'link-4',
+          artist_id: 'artist-1',
+          platform: 'venmo',
+          url: 'https://venmo.com/djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+      now,
+    });
+
+    expect(content.listenLinks.map(link => link.label)).toEqual([
+      'Spotify',
+      'Apple Music',
+    ]);
+    expect(content.listenLinks[0]?.url).toBe(
+      'https://open.spotify.com/artist/test'
+    );
+    // The apple_music_url profile column fills in the missing DSP link.
+    expect(content.listenLinks[1]?.url).toBe(
+      'https://music.apple.com/artist/test'
+    );
+    // A YouTube social link is categorized as follow, not listen, and
+    // suppresses the youtube_url column fallback.
+    expect(content.followLinks.map(link => link.platform)).toEqual([
+      'instagram',
+      'youtube',
+      'venmo',
+    ]);
+    // Registry names win; unknown platforms fall back to sentence case.
+    expect(content.followLinks.map(link => link.label)).toEqual([
+      'Instagram',
+      'YouTube',
+      'Venmo',
+    ]);
+  });
+
+  it('uses profile DSP URL columns for the listen row when no social links exist', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      socialLinks: [],
+      now,
+    });
+
+    expect(content.listenLinks.map(link => link.platform)).toEqual([
+      'spotify',
+      'apple_music',
+      'youtube',
+    ]);
+    expect(content.followLinks).toEqual([]);
+  });
+
+  it('renders the facts strip, listen, follow, and share controls', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      genres: ['tech house'],
+      socialLinks: [
+        ...socialLinks,
+        {
+          id: 'link-2',
+          artist_id: 'artist-1',
+          platform: 'instagram',
+          url: 'https://instagram.com/djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+      now,
+    });
+
+    render(<ProfileAeoContent content={content} />);
+
+    const facts = screen.getByTestId('profile-about-facts');
+    expect(facts).toBeVisible();
+    expect(facts).toHaveTextContent('Genre');
+    expect(facts).toHaveTextContent('Active Since');
+    expect(facts).toHaveTextContent('Hometown');
+
+    const listen = screen.getByTestId('profile-about-listen');
+    expect(listen).toBeVisible();
+    const spotifyLink = screen.getByRole('link', { name: 'Spotify' });
+    expect(spotifyLink).toHaveAttribute(
+      'href',
+      'https://open.spotify.com/artist/test'
+    );
+    expect(spotifyLink).toHaveAttribute('target', '_blank');
+    expect(spotifyLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    const follow = screen.getByTestId('profile-about-follow');
+    expect(follow).toBeVisible();
+    expect(
+      screen.getByRole('link', { name: 'Follow DJ Test on Instagram' })
+    ).toHaveAttribute('href', 'https://instagram.com/djtest');
+
+    expect(screen.getByTestId('profile-about-share')).toBeVisible();
+  });
+
+  it('hides the facts, listen, and follow sections when there is no data', () => {
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        hometown: null,
+        location: null,
+        active_since_year: null,
+        genres: null,
+        spotify_url: undefined,
+        apple_music_url: undefined,
+        youtube_url: undefined,
+      },
+      socialLinks: [],
+      now,
+    });
+
+    render(<ProfileAeoContent content={content} />);
+
+    expect(screen.queryByTestId('profile-about-facts')).toBeNull();
+    expect(screen.queryByTestId('profile-about-listen')).toBeNull();
+    expect(screen.queryByTestId('profile-about-follow')).toBeNull();
+    expect(screen.getByTestId('profile-about-share')).toBeVisible();
+    expect(screen.getByTestId('profile-aeo-content')).toBeVisible();
+  });
+
   it('keeps sparse profiles unique and sourced instead of using duplicate boilerplate', () => {
     const first = buildProfileAeoContent({
       artist: {
@@ -246,6 +433,84 @@ describe('Profile AEO content', () => {
     expect(html).toContain('data-testid="profile-aeo-content"');
     expect(html).toContain('Where can I buy DJ Test merch?');
     expect(html).toContain('Source: Official merch card');
+  });
+
+  it('links entity mentions in the description while keeping plain-text paragraphs', () => {
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        tagline:
+          'DJ Test broke through with "Neon Circuit" and tours with Guest Vocalist.',
+      },
+      genres: ['tech house'],
+      releases: [
+        {
+          id: 'release-1',
+          title: 'Neon Circuit',
+          slug: 'neon-circuit',
+          releaseType: 'single',
+          releaseDate: '2026-05-01T00:00:00.000Z',
+          artworkUrl: null,
+          artistNames: ['DJ Test', 'Guest Vocalist'],
+        },
+      ],
+      entityMentions: {
+        ownHandle: 'dj-test',
+        releases: [{ title: 'Neon Circuit', slug: 'neon-circuit' }],
+        artists: [{ name: 'Guest Vocalist', handle: 'guestvocalist' }],
+      },
+      now,
+    });
+
+    // Plain-text accessor is unchanged for meta/JSON-LD consumers.
+    expect(content.description.join(' ')).toContain('Neon Circuit');
+
+    const linkedSegments = content.descriptionSegments
+      .flat()
+      .filter(segment => segment.type !== 'text');
+    expect(linkedSegments).toContainEqual({
+      type: 'release',
+      text: 'Neon Circuit',
+      href: '/dj-test/neon-circuit',
+    });
+    expect(linkedSegments).toContainEqual({
+      type: 'artist',
+      text: 'Guest Vocalist',
+      href: '/guestvocalist',
+    });
+
+    render(<ProfileAeoContent content={content} />);
+
+    // The release title appears in both the tagline and the generated
+    // latest-release sentence — every mention is linked.
+    const releaseLinks = screen.getAllByRole('link', { name: 'Neon Circuit' });
+    expect(releaseLinks.length).toBeGreaterThan(0);
+    for (const link of releaseLinks) {
+      expect(link).toHaveAttribute('href', '/dj-test/neon-circuit');
+      expect(link).toHaveAttribute('data-entity-kind', 'release');
+    }
+
+    const artistLinks = screen.getAllByRole('link', {
+      name: 'Guest Vocalist',
+    });
+    expect(artistLinks.length).toBeGreaterThan(0);
+    for (const link of artistLinks) {
+      expect(link).toHaveAttribute('href', '/guestvocalist');
+      expect(link).toHaveAttribute('data-entity-kind', 'artist');
+    }
+  });
+
+  it('defaults to plain-text segments when no entity context is provided', () => {
+    const content = buildContent();
+
+    expect(content.descriptionSegments).toHaveLength(
+      content.description.length
+    );
+    for (const [index, segments] of content.descriptionSegments.entries()) {
+      expect(segments).toEqual([
+        { type: 'text', text: content.description[index] },
+      ]);
+    }
   });
 
   it('renders the editorial claim card only when a claim destination is provided', () => {

--- a/apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts
+++ b/apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts
@@ -13,34 +13,23 @@ const PROFILE_COMPACT_SURFACE = join(
 const DESIGN_SYSTEM = join(process.cwd(), 'styles', 'design-system.css');
 
 /**
- * Public profile home hero must flex-grow on tall viewports instead of capping
- * at a fixed --cover-height band (GitHub #11083). On short viewports
- * (height ≤820px, iPhone SE class) it must compress to ≤190px so the bento
- * release card stays above the fold (profile-mobile-viewport-stability).
- * Media crops via object-cover — never the old 180px squish band (#11899).
+ * Public profile home hero has ONE definite token-driven height on every
+ * viewport: h-(--cover-height) with --cover-height: clamp(220px, 34svh, 400px).
+ * The old short-viewport shrink-wrap (flex-none + min-h-0 + ≤190px cap) made
+ * the hero collapse to ~60px on viewports ≤820px tall, hiding the artist
+ * photo and name — it must never come back. The carousel below the hero owns
+ * the remaining viewport height.
  */
 describe('ProfileCompactSurface home hero layout', () => {
-  it('grows the home hero with flex-1 and a min-height floor', () => {
+  it('locks the home hero to the token-driven cover height (no flex/shrink-wrap)', () => {
     const contents = readFileSync(PROFILE_COMPACT_SURFACE, 'utf8');
 
-    expect(contents).toMatch(/min-h-\(--cover-height\)/);
-    expect(contents).toMatch(/\bflex-1\b/);
-    expect(contents).not.toMatch(/\bmax-h-108\b/);
-    expect(contents).not.toMatch(
-      /isHomeMode\s*\?\s*'h-\[var\(--cover-height\)\]'/
-    );
-    expect(contents).not.toMatch(/isHomeMode\s*\?\s*'h-\(--cover-height\)'/);
-  });
-
-  it('locks short viewports (≤820px tall) to a 190px hero cap for the bento fold', () => {
-    const contents = readFileSync(PROFILE_COMPACT_SURFACE, 'utf8');
-
-    expect(contents).toMatch(/\[@media\(max-height:820px\)\]:flex-none/);
-    expect(contents).toMatch(/\[@media\(max-height:820px\)\]:max-h-\[190px\]/);
-    // The pre-composition 180px squish band (#11899) must not come back.
-    expect(contents).not.toMatch(/\[@media\(max-height:760px\)\]:h-45\b/);
-    expect(contents).not.toMatch(/\[@media\(max-height:760px\)\]:max-h-45\b/);
-    expect(contents).not.toMatch(/\[@media\(max-height:820px\)\]:h-45\b/);
+    expect(contents).toMatch(/isHomeMode\s*\?\s*'h-\(--cover-height\) /);
+    // The short-viewport shrink-wrap band must not come back.
+    expect(contents).not.toMatch(/\[@media\(max-height:820px\)\]:flex-none/);
+    expect(contents).not.toMatch(/\[@media\(max-height:820px\)\]:min-h-0/);
+    expect(contents).not.toMatch(/\[@media\(max-height:820px\)\]:max-h-/);
+    expect(contents).not.toMatch(/min-h-\(--cover-height\)\s+flex-1/);
     expect(contents).toMatch(
       /homeContentColumnClassName\s*=\s*'min-h-0 flex-1'/
     );
@@ -49,24 +38,46 @@ describe('ProfileCompactSurface home hero layout', () => {
     );
   });
 
-  it('sets the short-viewport --cover-height token to 190px (not the old 240px band)', () => {
-    const contents = readFileSync(DESIGN_SYSTEM, 'utf8');
+  it('uses ONE legibility gradient limited to the bottom of the hero', () => {
+    const contents = readFileSync(PROFILE_COMPACT_SURFACE, 'utf8');
 
-    expect(contents).toMatch(
-      /max-height:\s*820px\)[\s\S]{0,120}--cover-height:\s*190px/
-    );
-    // Collapsed non-home mode uses calc(3.5rem…) with hero media hidden —
-    // fixed px short-viewport band is the only compact home hero assignment.
+    // The stacked full-height scrim pair is replaced by a single class-driven
+    // gradient; the fade layer is removed entirely.
+    expect(contents).toMatch(/profile-cover-home-gradient/);
+    expect(contents).not.toMatch(/profile-cover-home-fade/);
     expect(contents).not.toMatch(
-      /max-height:\s*820px\)[\s\S]{0,120}--cover-height:\s*240px/
+      /profile-cover-home-gradient[^/]*bg-\[linear-gradient/
+    );
+
+    const css = readFileSync(DESIGN_SYSTEM, 'utf8');
+    expect(css).toMatch(
+      /\.profile-cover-home-gradient\)\s*\{[\s\S]{0,200}height:\s*55%/
     );
   });
 
-  it('does not shrink the mid-height band hero via the removed 761-880 override', () => {
+  it('sets --cover-height to clamp(220px, 34svh, 400px) with no short-viewport override', () => {
     const contents = readFileSync(DESIGN_SYSTEM, 'utf8');
 
+    const assignments = contents.match(
+      /--cover-height:\s*clamp\(220px,\s*34svh,\s*400px\)/g
+    );
+    // :root and .profile-viewport both define the mobile value.
+    expect(assignments?.length).toBeGreaterThanOrEqual(2);
+    // No max-height media band may shrink the hero token anymore.
     expect(contents).not.toMatch(
-      /max-height:\s*880px\)\s*and\s*\(min-height:\s*761px\)/
+      /max-height:\s*820px\)[\s\S]{0,120}--cover-height/
+    );
+    // Desktop compact shell keeps its 340px override.
+    expect(contents).toMatch(
+      /\.public-profile-compact-shell\s*\{[\s\S]{0,120}--cover-height:\s*340px/
+    );
+  });
+
+  it('keeps the collapsed deep-link mode header behavior untouched', () => {
+    const contents = readFileSync(DESIGN_SYSTEM, 'utf8');
+
+    expect(contents).toMatch(
+      /html\[data-profile-initial-mode\][\s\S]{0,200}--cover-height:\s*calc\(3\.5rem/
     );
   });
 });

--- a/apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts
+++ b/apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts
@@ -67,10 +67,9 @@ describe('ProfileCompactSurface home hero layout', () => {
     expect(contents).not.toMatch(
       /max-height:\s*820px\)[\s\S]{0,120}--cover-height/
     );
-    // Desktop compact shell keeps a proportional hero override (short
-    // windows share shell height instead of crushing the carousel).
+    // Desktop compact shell keeps its 340px override.
     expect(contents).toMatch(
-      /\.public-profile-compact-shell\s*\{[\s\S]{0,400}--cover-height:\s*clamp\(200px,\s*45%,\s*340px\)/
+      /\.public-profile-compact-shell\s*\{[\s\S]{0,120}--cover-height:\s*340px/
     );
   });
 

--- a/apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts
+++ b/apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts
@@ -67,9 +67,10 @@ describe('ProfileCompactSurface home hero layout', () => {
     expect(contents).not.toMatch(
       /max-height:\s*820px\)[\s\S]{0,120}--cover-height/
     );
-    // Desktop compact shell keeps its 340px override.
+    // Desktop compact shell keeps a proportional hero override (short
+    // windows share shell height instead of crushing the carousel).
     expect(contents).toMatch(
-      /\.public-profile-compact-shell\s*\{[\s\S]{0,120}--cover-height:\s*340px/
+      /\.public-profile-compact-shell\s*\{[\s\S]{0,400}--cover-height:\s*clamp\(200px,\s*45%,\s*340px\)/
     );
   });
 

--- a/apps/web/tests/unit/profile/profile-compact-template.test.tsx
+++ b/apps/web/tests/unit/profile/profile-compact-template.test.tsx
@@ -723,9 +723,12 @@ describe('ProfileCompactTemplate', () => {
 
     expect(alertsCard).toHaveTextContent('Alerts');
     expect(carousel).toHaveTextContent('Listen');
-    expect(alertsCard.compareDocumentPosition(carousel)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING
-    );
+    // The alerts card is the LAST card of the single home carousel — no
+    // stacked sections outside the track.
+    expect(carousel.contains(alertsCard)).toBe(true);
+    expect(
+      screen.getByTestId('profile-pac').compareDocumentPosition(alertsCard)
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(
       screen.queryByTestId('profile-hero-status-pill')
     ).not.toBeInTheDocument();

--- a/apps/web/tests/unit/profile/profile-shell-token-contract.test.ts
+++ b/apps/web/tests/unit/profile/profile-shell-token-contract.test.ts
@@ -54,6 +54,12 @@ describe('profile shell token contract', () => {
       'utf8'
     );
     expect(compactSurfaceContents).toContain('--profile-content-bg');
-    expect(compactSurfaceContents).toContain('--profile-stage-bg');
+    // The hero legibility gradient lives in design-system.css
+    // (.profile-cover-home-gradient) and is the --profile-stage-bg consumer.
+    const designSystemContents = readFileSync(DESIGN_SYSTEM, 'utf8');
+    expect(designSystemContents).toContain('--profile-stage-bg');
+    expect(designSystemContents).toMatch(
+      /\.profile-cover-home-gradient[\s\S]{0,400}var\(--profile-stage-bg\)/
+    );
   });
 });

--- a/apps/web/tests/unit/profile/public-profile-contract-guard.test.ts
+++ b/apps/web/tests/unit/profile/public-profile-contract-guard.test.ts
@@ -41,6 +41,7 @@ const PROFILE_SHELL = join(
   'profile-shell',
   'ProfileShell.tsx'
 );
+const DESIGN_SYSTEM = join(ROOT, 'styles', 'design-system.css');
 
 const REPRESENTATIVE_PROFILE_ENTRYPOINTS = [
   join(ROOT, 'app', '[username]', 'page.tsx'),
@@ -109,8 +110,14 @@ describe('public profile contract guard', () => {
     expect(readFileSync(PROFILE_COMPACT_SURFACE, 'utf8')).toContain(
       '--profile-content-bg'
     );
+    // The hero legibility gradient is the --profile-stage-bg consumer: the
+    // surface renders the class hook, the token reference lives in the
+    // gradient rule in design-system.css.
     expect(readFileSync(PROFILE_COMPACT_SURFACE, 'utf8')).toContain(
-      '--profile-stage-bg'
+      'profile-cover-home-gradient'
+    );
+    expect(readFileSync(DESIGN_SYSTEM, 'utf8')).toMatch(
+      /\.profile-cover-home-gradient[\s\S]{0,400}var\(--profile-stage-bg\)/
     );
     expect(readFileSync(PROFILE_SHELL, 'utf8')).toContain(
       '--profile-shell-header-max-width'


### PR DESCRIPTION
## What

Public profile home (`/{username}`) rebuilt to feel native: hero always visible, one aspect-locked snap carousel as the entire home surface, latest-release PAC card merged in as the featured first card, zero console errors.

## Bugs fixed (all reproduced before/after)

- **Hero invisible on mobile (critical):** on viewports ≤820px tall the hero shrink-wrapped to 60px — no photo, no artist name. Root cause: `min-h-0 flex-none max-h-[190px]` band + 190px token cap. Now `--cover-height: clamp(220px, 34svh, 400px)` with a definite height on every viewport; single bottom-55% legibility gradient instead of two full-height scrims.
- **Smashed desktop windows:** fixed 340px hero crushed the carousel to a sliver; desktop hero is now proportional `clamp(200px, 45%, 340px)`.
- **Latest release duplicated** (standalone PAC strip + first carousel card) — PAC merged into the carousel as the featured card (full player, seek, capture states, instrumentation preserved).
- **Cards clipped behind tab bar / forced vertical scroll:** cards locked to 3:4, height = remaining viewport, width derived (≤78vw cap). No vertical scroll for primary content; no horizontal scroll outside the carousel.
- **~140px dead space on desktop** from double tab-bar reservation — now exactly one reservation in each visibility state.
- **Jank:** PAC `height` animation + ResizeObserver deleted (fixed card geometry); `ProfileHomeRail` memoized; single priority image (hero), PAC art eager only when no hero photo (LCP fix); honest carousel `sizes`.
- **Console errors 8 → 0:** `/api/profile/capture-dismissal` 500s (missing migration 0068 in dev DB, applied) + double-fetch fixed via shared cached client (`capture-dismissal-client.ts`).

## Verification

- Typecheck + Biome clean; **808/808 unit tests** (arbitrary-values ratchet went down).
- E2E: `profile-mobile-viewport-stability` **84/84**. (19 failures in `responsive-shell`/`public-profile-layout` reproduce identically against main — pre-existing, not this PR.)
- `/qa --exhaustive` health 91 → 100 (report: `.gstack/qa-reports/qa-report-localhost-3101-2026-07-20.md`).
- Browser-verified at 375×667 → 1440×900 on `/tim` and `/dualipa`.
- Pre-push gate passes standalone (exit 0); pushed via the documented `JOVIE_SKIP_PRE_PUSH_GATE=1` escape hatch because the gate dies with SIGPIPE (141) specifically when invoked by the git hook — infra issue, filed below.

## Follow-ups (stacked PRs on this branch)

Card unification → chrome/jank polish → desktop about enrichment → entity-linked bio.

## Ops notes

- Dev DB `__drizzle_migrations` is hash-drifted (8 migrations never applied though `db:migrate` reports current) — recommend dev DB reset/force-migrate.
- Pre-push gate SIGPIPE under git hook (passes standalone) — needs infra investigation.