### PR TITLE
fix(design-system): map molecule/organism --linear paren utilities to tokens

### DIFF
--- a/.trufflehog-exclude.txt
+++ b/.trufflehog-exclude.txt
@@ -6,3 +6,7 @@ scripts/security/gitleaks-backup-fixture.txt
 # diff-scanned lines (verified 2026-07-20, runs 29785483353/29784648947).
 # gitleaks (.gitleaks.toml) and GitHub secret scanning still cover this file.
 .github/workflows/sonarcloud.yml
+
+# Test fixtures: postgres://user:pass@… strings for DATABASE_URL zod validation only.
+# Same git-mode exclude pattern as sonarcloud.yml (inline ignore not honored).
+apps/web/tests/lib/database-url-validation.test.ts

--- a/.trufflehog-exclude.txt
+++ b/.trufflehog-exclude.txt
@@ -6,7 +6,13 @@ scripts/security/gitleaks-backup-fixture.txt
 # diff-scanned lines (verified 2026-07-20, runs 29785483353/29784648947).
 # gitleaks (.gitleaks.toml) and GitHub secret scanning still cover this file.
 .github/workflows/sonarcloud.yml
-
-# Test fixtures: postgres://user:pass@… strings for DATABASE_URL zod validation only.
-# Same git-mode exclude pattern as sonarcloud.yml (inline ignore not honored).
+# Test fixtures / example connection strings (trufflehog Postgres/URI detectors).
 apps/web/tests/lib/database-url-validation.test.ts
+apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
+.agents/skills/gstack/browse/test/sidebar-unit.test.ts
+.agents/skills/gstack/test/skill-e2e-cso.test.ts
+.env.example
+apps/web/lib/cron/auth.test.ts
+apps/web/lib/merch/artwork.ts
+apps/web/scripts/download-current-spotify-images.ts
+apps/web/scripts/fetch-current-artist-images.ts

--- a/apps/web/components/molecules/AppSearchField.tsx
+++ b/apps/web/components/molecules/AppSearchField.tsx
@@ -36,7 +36,7 @@ export function AppSearchField({
   return (
     <div
       className={cn(
-        'flex h-app-control-sm items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-2.5 text-primary-token transition-[border-color,box-shadow,background-color] duration-subtle hover:bg-surface-1 focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-ring/14',
+        'flex h-app-control-sm items-center gap-1.5 rounded-full border border-(--app-shell-frame-seam) bg-(--app-shell-content-surface) px-2.5 text-primary-token transition-[border-color,box-shadow,background-color] duration-subtle hover:bg-surface-1 focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-ring/14',
         className
       )}
     >

--- a/apps/web/components/molecules/CompactLinkRail.tsx
+++ b/apps/web/components/molecules/CompactLinkRail.tsx
@@ -50,7 +50,7 @@ export function CompactLinkRail({
     >
       {showSummaryPill ? (
         <div
-          className='inline-flex h-6 shrink-0 items-center gap-1 rounded-full border border-(--linear-app-frame-seam) bg-surface-1 px-1.5 text-2xs font-caption tracking-tight text-secondary-token'
+          className='inline-flex h-6 shrink-0 items-center gap-1 rounded-full border border-(--app-shell-frame-seam) bg-surface-1 px-1.5 text-2xs font-caption tracking-tight text-secondary-token'
           title={summaryAriaLabel ?? `${displayCount} ${countLabel}`}
         >
           <div className='flex -space-x-1 overflow-hidden pr-0.5'>

--- a/apps/web/components/molecules/ContentSectionHeader.tsx
+++ b/apps/web/components/molecules/ContentSectionHeader.tsx
@@ -33,7 +33,7 @@ export function ContentSectionHeader({
         variant === 'default' && 'border-b border-subtle bg-transparent',
         density === 'compact'
           ? 'min-h-10 py-1.5'
-          : 'min-h-(--linear-app-header-height) py-1.5',
+          : 'min-h-(--app-shell-header-height) py-1.5',
         className
       )}
     >

--- a/apps/web/components/molecules/ContentSectionHeaderSkeleton.tsx
+++ b/apps/web/components/molecules/ContentSectionHeaderSkeleton.tsx
@@ -37,7 +37,7 @@ export function ContentSectionHeaderSkeleton({
   return (
     <div
       className={cn(
-        'flex min-h-(--linear-app-header-height) min-w-0 shrink-0 items-center justify-between gap-3 overflow-x-auto overflow-y-hidden border-b border-subtle bg-transparent px-app-header py-1.5 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+        'flex min-h-(--app-shell-header-height) min-w-0 shrink-0 items-center justify-between gap-3 overflow-x-auto overflow-y-hidden border-b border-subtle bg-transparent px-app-header py-1.5 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
         className
       )}
       aria-hidden='true'

--- a/apps/web/components/molecules/ContentSurfaceCard.tsx
+++ b/apps/web/components/molecules/ContentSurfaceCard.tsx
@@ -3,7 +3,7 @@ import type { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
 const contentSurfaceCardVariants = cva(
-  'border border-(--linear-app-shell-border) bg-surface-1 shadow-none',
+  'border border-(--app-shell-border) bg-surface-1 shadow-none',
   {
     variants: {
       surface: {
@@ -23,7 +23,7 @@ const contentSurfaceCardVariants = cva(
 
 /** @deprecated Use `contentSurfaceCardVariants` instead for new code. */
 export const CONTENT_SURFACE_CARD_CLASSNAME =
-  'rounded-xl border border-(--linear-app-shell-border) bg-surface-1 shadow-none';
+  'rounded-xl border border-(--app-shell-border) bg-surface-1 shadow-none';
 
 export interface ContentSurfaceCardProps
   extends VariantProps<typeof contentSurfaceCardVariants> {

--- a/apps/web/components/molecules/CopyableUrlRow.tsx
+++ b/apps/web/components/molecules/CopyableUrlRow.tsx
@@ -101,7 +101,7 @@ export function CopyableUrlRow({
       className={cn(
         'flex items-center transition-[background-color,border-color] duration-subtle',
         surface === 'boxed'
-          ? 'border border-(--linear-app-frame-seam) bg-surface-0 hover:bg-surface-1'
+          ? 'border border-(--app-shell-frame-seam) bg-surface-0 hover:bg-surface-1'
           : 'border border-transparent bg-transparent hover:bg-surface-1/80',
         styles.container,
         className

--- a/apps/web/components/molecules/TimeRangeSelector.tsx
+++ b/apps/web/components/molecules/TimeRangeSelector.tsx
@@ -214,7 +214,7 @@ export function TimeRangeSelector<T extends AnalyticsRange>({
               title={
                 disabled ? 'Upgrade to Pro for extended analytics' : undefined
               }
-              className={`relative h-7 rounded-full border border-transparent px-2.5 text-xs font-caption tracking-tight shadow-none transition-[background-color,color,border-color,box-shadow] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-app-content-surface) ${stateClass}`}
+              className={`relative h-7 rounded-full border border-transparent px-2.5 text-xs font-caption tracking-tight shadow-none transition-[background-color,color,border-color,box-shadow] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--app-shell-content-surface) ${stateClass}`}
             >
               {getTimeRangeLabel(range, 'short')}
             </button>

--- a/apps/web/components/molecules/drawer/CollapsibleSectionHeading.tsx
+++ b/apps/web/components/molecules/drawer/CollapsibleSectionHeading.tsx
@@ -32,7 +32,7 @@ export function CollapsibleSectionHeading({
       className={cn(
         DRAWER_SECTION_HEADING_CLASSNAME,
         'flex w-full items-center justify-between rounded-lg border border-transparent px-2.5 py-2 transition-[background-color,color,border-color] duration-subtle',
-        'hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token',
+        'hover:border-(--app-shell-frame-seam) hover:bg-surface-0 hover:text-secondary-token',
         'focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
         className
       )}

--- a/apps/web/components/molecules/drawer/DrawerActionRow.tsx
+++ b/apps/web/components/molecules/drawer/DrawerActionRow.tsx
@@ -24,7 +24,7 @@ export function DrawerActionRow({
       onClick={onClick}
       className={cn(
         'flex min-h-9 w-full items-center gap-2 rounded-full border border-transparent px-2.5 py-1.5 text-left text-xs text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-subtle',
-        'hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-primary-token',
+        'hover:border-(--app-shell-frame-seam) hover:bg-surface-1 hover:text-primary-token',
         'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-ring',
         className
       )}

--- a/apps/web/components/molecules/drawer/DrawerEditableTextField.tsx
+++ b/apps/web/components/molecules/drawer/DrawerEditableTextField.tsx
@@ -204,7 +204,7 @@ export const DrawerEditableTextField = React.memo(
               placeholder={placeholder ?? emptyLabel}
               aria-label={`Edit ${label}`}
               className={cn(
-                'h-8 w-full rounded-lg border-(--linear-app-frame-seam) bg-surface-0 px-2.5 text-app text-primary-token',
+                'h-8 w-full rounded-lg border-(--app-shell-frame-seam) bg-surface-0 px-2.5 text-app text-primary-token',
                 monospace && 'font-mono tracking-wider',
                 inputClassName
               )}

--- a/apps/web/components/molecules/drawer/DrawerLoadingSkeleton.tsx
+++ b/apps/web/components/molecules/drawer/DrawerLoadingSkeleton.tsx
@@ -39,7 +39,7 @@ export function DrawerLoadingSkeleton({
       >
         <div
           className={cn(
-            'sticky top-0 z-10 flex min-h-8 shrink-0 items-center justify-between border-b border-(--linear-app-frame-seam) bg-surface-1 px-2 py-1 backdrop-blur-[10px]'
+            'sticky top-0 z-10 flex min-h-8 shrink-0 items-center justify-between border-b border-(--app-shell-frame-seam) bg-surface-1 px-2 py-1 backdrop-blur-[10px]'
           )}
         >
           <Skeleton className='h-2.5 w-28' />
@@ -65,7 +65,7 @@ export function DrawerLoadingSkeleton({
                   <Skeleton className='h-2.5 w-2/3' />
                 </div>
               </div>
-              <div className='mt-3 border-t border-(--linear-app-frame-seam) pt-2.5'>
+              <div className='mt-3 border-t border-(--app-shell-frame-seam) pt-2.5'>
                 <Skeleton className='h-6 w-full' rounded='md' />
               </div>
             </div>
@@ -74,10 +74,10 @@ export function DrawerLoadingSkeleton({
               className={cn(LINEAR_SURFACE.drawerCard, 'overflow-hidden')}
               data-testid='drawer-loading-analytics-card'
             >
-              <div className='border-b border-(--linear-app-frame-seam) px-3 py-2'>
+              <div className='border-b border-(--app-shell-frame-seam) px-3 py-2'>
                 <Skeleton className='h-2.5 w-16' />
               </div>
-              <div className='grid grid-cols-2 divide-x divide-(--linear-app-frame-seam) p-3'>
+              <div className='grid grid-cols-2 divide-x divide-(--app-shell-frame-seam) p-3'>
                 <div className='space-y-1'>
                   <Skeleton className='h-2.5 w-14' />
                   <Skeleton className='h-4.5 w-10' />

--- a/apps/web/components/molecules/drawer/DrawerSettingsToggle.tsx
+++ b/apps/web/components/molecules/drawer/DrawerSettingsToggle.tsx
@@ -46,8 +46,8 @@ export function DrawerSettingsToggle({
       className={cn(
         'flex items-center justify-between gap-3 rounded-lg border py-px transition-[background-color,border-color] duration-subtle',
         density === 'compact'
-          ? 'border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_82%,var(--linear-bg-surface-0))]'
-          : 'border-(--linear-app-frame-seam) bg-surface-0',
+          ? 'border-(--app-shell-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_82%,var(--linear-bg-surface-0))]'
+          : 'border-(--app-shell-frame-seam) bg-surface-0',
         !disabled &&
           'hover:border-default hover:bg-surface-1 focus-within:border-default focus-within:bg-surface-1',
         density === 'compact' ? 'min-h-7' : 'min-h-9 lg:min-h-0',

--- a/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
+++ b/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
@@ -241,7 +241,7 @@ export function EntitySidebarShell({
                   {!isMinimalHeader && tabs ? (
                     <div
                       className={cn(
-                        'overflow-visible border-t border-(--linear-app-frame-seam) px-3 py-2.5 [&>*]:w-full',
+                        'overflow-visible border-t border-(--app-shell-frame-seam) px-3 py-2.5 [&>*]:w-full',
                         tabsContainerClassName
                       )}
                     >
@@ -253,7 +253,7 @@ export function EntitySidebarShell({
                     <div
                       className={cn(
                         showMinimalHeaderBar &&
-                          'border-t border-(--linear-app-frame-seam)',
+                          'border-t border-(--app-shell-frame-seam)',
                         'overflow-visible px-3 py-2.5 [&>*]:w-full',
                         tabsContainerClassName
                       )}

--- a/apps/web/components/molecules/drawer/RightDrawer.tsx
+++ b/apps/web/components/molecules/drawer/RightDrawer.tsx
@@ -131,7 +131,7 @@ export function RightDrawer({
           'fixed inset-0 z-50 flex flex-col',
           'overflow-hidden',
           'outline-none focus:outline-none focus-visible:ring-0',
-          'border-l border-(--linear-app-frame-seam) bg-(--linear-app-content-surface)',
+          'border-l border-(--app-shell-frame-seam) bg-(--app-shell-content-surface)',
           'shadow-(--linear-app-drawer-shadow)',
           'pb-[env(safe-area-inset-bottom)]',
           'transition-transform duration-cinematic ease-cinematic',

--- a/apps/web/components/molecules/filters/ActiveFilterPill.tsx
+++ b/apps/web/components/molecules/filters/ActiveFilterPill.tsx
@@ -23,7 +23,7 @@ export function ActiveFilterPill({
     values.length > 1 ? `${values.length} selected` : values[0];
 
   return (
-    <div className='flex items-center gap-0.5 rounded-md border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) text-2xs'>
+    <div className='flex items-center gap-0.5 rounded-md border border-(--app-shell-frame-seam) bg-(--app-shell-content-surface) text-2xs'>
       <div className='flex items-center gap-1 py-1 pl-2 pr-0.5'>
         {icon && (
           <span className='flex h-3.5 w-3.5 items-center justify-center text-tertiary-token'>

--- a/apps/web/components/molecules/filters/FilterSearchInput.tsx
+++ b/apps/web/components/molecules/filters/FilterSearchInput.tsx
@@ -65,7 +65,7 @@ export function FilterSearchInput({
           onChange={e => onChange(e.target.value)}
           onKeyDown={handleKeyDown}
           className={cn(
-            'w-full rounded-lg border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_48%,transparent)] bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_34%,transparent)] py-1.5 pl-8 pr-6 text-xs',
+            'w-full rounded-lg border border-[color-mix(in_oklab,var(--app-shell-frame-seam)_48%,transparent)] bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_34%,transparent)] py-1.5 pl-8 pr-6 text-xs',
             'text-primary-token placeholder:text-tertiary-token',
             'transition-[background-color,border-color,box-shadow] duration-subtle',
             'focus-visible:border-(--linear-border-focus) focus-visible:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_44%,transparent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/14'

--- a/apps/web/components/molecules/filters/TableFilterDropdown.tsx
+++ b/apps/web/components/molecules/filters/TableFilterDropdown.tsx
@@ -89,7 +89,7 @@ function TableFilterSection<T extends string>({
     <div className='flex max-h-80 min-h-55 min-w-65 flex-col overflow-hidden'>
       <div
         data-menu-header
-        className='border-b border-[color-mix(in_oklab,var(--linear-app-frame-seam)_44%,transparent)]'
+        className='border-b border-[color-mix(in_oklab,var(--app-shell-frame-seam)_44%,transparent)]'
       >
         <div className={cn(TOOLBAR_MENU_HEADER_CLASS, 'border-b-0 pb-1.25')}>
           <span className='truncate text-2xs font-[600] text-secondary-token'>
@@ -171,7 +171,7 @@ function TableFilterSubmenu<T extends string>({
           label={category.label}
           trailingVisual={
             category.selectedIds.length > 0 ? (
-              <span className='inline-flex h-5 min-w-5 items-center justify-center rounded-md border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_44%,transparent)] bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_30%,transparent)] px-1 text-3xs tabular-nums text-tertiary-token'>
+              <span className='inline-flex h-5 min-w-5 items-center justify-center rounded-md border border-[color-mix(in_oklab,var(--app-shell-frame-seam)_44%,transparent)] bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_30%,transparent)] px-1 text-3xs tabular-nums text-tertiary-token'>
                 {category.selectedIds.length}
               </span>
             ) : null

--- a/apps/web/components/molecules/sidebar-collapse-button/SidebarCollapseButton.stories.tsx
+++ b/apps/web/components/molecules/sidebar-collapse-button/SidebarCollapseButton.stories.tsx
@@ -37,7 +37,7 @@ export const OnContentSurface: Story = {
   decorators: [
     Story => (
       <SidebarProvider>
-        <div className='flex items-center gap-3 bg-(--linear-app-content-surface) p-4'>
+        <div className='flex items-center gap-3 bg-(--app-shell-content-surface) p-4'>
           <Story />
         </div>
       </SidebarProvider>

--- a/apps/web/components/molecules/sidebar-collapse-button/SidebarCollapseButton.tsx
+++ b/apps/web/components/molecules/sidebar-collapse-button/SidebarCollapseButton.tsx
@@ -27,7 +27,7 @@ export function SidebarCollapseButton({
         className={cn(
           // System B icon chrome: borderless circle, transparent idle, soft hover fill.
           // Matches ArtistProfileRailToggle — founder directive JOV-3959.
-          'inline-flex h-7 w-7 items-center justify-center rounded-full border-0 bg-transparent text-secondary-token transition-[background-color,color] duration-subtle ease-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
+          'inline-flex h-7 w-7 items-center justify-center rounded-full border-0 bg-transparent text-secondary-token transition-[background-color,color] duration-subtle ease-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55',
           className
         )}
       >

--- a/apps/web/components/organisms/AppShellContentPanel.tsx
+++ b/apps/web/components/organisms/AppShellContentPanel.tsx
@@ -25,7 +25,7 @@ const PANEL_MAX_WIDTH_CLASSNAME = {
 } as const;
 
 const PANEL_OUTER_INSET_CLASSNAME = 'px-2.5 py-2.5 sm:px-3 sm:py-3';
-const PANEL_TABLE_SURFACE_CLASSNAME = 'p-0 bg-(--linear-app-content-surface)';
+const PANEL_TABLE_SURFACE_CLASSNAME = 'p-0 bg-(--app-shell-content-surface)';
 
 const PANEL_CONTENT_PADDING_CLASSNAME = {
   none: '',
@@ -80,7 +80,7 @@ export function AppShellContentPanel({
             'flex min-h-0 min-w-0 flex-1 flex-col',
             frame === 'content-container' &&
               (isTableSurface
-                ? 'overflow-hidden bg-(--linear-app-content-surface)'
+                ? 'overflow-hidden bg-(--app-shell-content-surface)'
                 : cn(LINEAR_SURFACE.contentContainer, 'overflow-hidden'))
           )}
         >

--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -82,8 +82,7 @@ export const AppShellFrame = memo(function AppShellFrame({
         data-app-shell-body='true'
         className={cn(
           'flex min-h-0 min-w-0 flex-1 overflow-hidden',
-          isShellChatV1 &&
-            'lg:gap-(--linear-app-shell-gap) lg:p-(--linear-app-shell-gap)'
+          isShellChatV1 && 'lg:gap-(--app-shell-gap) lg:p-(--app-shell-gap)'
         )}
       >
         <div
@@ -101,7 +100,7 @@ export const AppShellFrame = memo(function AppShellFrame({
             // beneath the in-flow header/content (#13386).
             'relative isolate flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-surface-0',
             isShellChatV1
-              ? 'lg:rounded-(--linear-app-shell-radius) lg:border lg:border-(--linear-app-shell-border) lg:bg-(--linear-app-content-surface) lg:shadow-(--linear-app-shell-shadow)'
+              ? 'lg:rounded-(--app-shell-radius) lg:border lg:border-(--app-shell-border) lg:bg-(--app-shell-content-surface) lg:shadow-(--linear-app-shell-shadow)'
               : 'lg:border-l lg:border-subtle'
           )}
         >
@@ -118,7 +117,7 @@ export const AppShellFrame = memo(function AppShellFrame({
             <div
               aria-hidden='true'
               data-testid='chat-ambient-gradient'
-              className='pointer-events-none absolute inset-0 -z-10 bg-(--linear-app-content-surface)'
+              className='pointer-events-none absolute inset-0 -z-10 bg-(--app-shell-content-surface)'
               style={{ backgroundImage: CHAT_AMBIENT_GRADIENT_IMAGE }}
             />
           ) : null}
@@ -127,7 +126,7 @@ export const AppShellFrame = memo(function AppShellFrame({
           <div
             className={cn(
               'flex flex-1 min-h-0 min-w-0 overflow-hidden',
-              isShellChatV1 && 'lg:gap-(--linear-app-shell-gap)'
+              isShellChatV1 && 'lg:gap-(--app-shell-gap)'
             )}
           >
             <div

--- a/apps/web/components/organisms/AppShellSkeleton.tsx
+++ b/apps/web/components/organisms/AppShellSkeleton.tsx
@@ -30,14 +30,14 @@ function DefaultSidebarSkeleton({
       // without a width/header reflow.
       className={cn(
         'max-lg:hidden bg-sidebar lg:flex lg:shrink-0 lg:flex-col',
-        isShellChatV1 ? 'lg:w-(--linear-app-sidebar-width)' : 'lg:w-58'
+        isShellChatV1 ? 'lg:w-(--app-shell-sidebar-width)' : 'lg:w-58'
       )}
     >
       <div
         className={cn(
           'flex items-center gap-2 px-2.5',
           isShellChatV1
-            ? 'h-(--linear-app-header-height-compact) py-0.5'
+            ? 'h-(--app-shell-header-height-compact) py-0.5'
             : 'h-9 pt-2'
         )}
       >
@@ -137,7 +137,7 @@ export function AppShellSkeleton({
           className={cn(
             'flex shrink-0 items-center gap-2',
             isShellChatV1
-              ? 'h-(--linear-app-header-height-compact) bg-(--linear-app-content-surface) px-2.5'
+              ? 'h-(--app-shell-header-height-compact) bg-(--app-shell-content-surface) px-2.5'
               : 'h-12 border-b border-subtle px-4'
           )}
         >

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -249,7 +249,7 @@ function AuthShellWrapperInner({
         className='absolute inset-0 z-10 hidden items-start justify-center bg-page/96 px-4 py-6 sm:px-6'
         data-testid='releases-shell-ready'
       >
-        <div className='w-full max-w-3xl rounded-2xl border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_96%,var(--linear-bg-surface-0))] px-4 py-4 shadow-[0_16px_40px_rgba(0,0,0,0.16)] sm:px-5'>
+        <div className='w-full max-w-3xl rounded-2xl border border-(--app-shell-frame-seam) bg-[color-mix(in_oklab,var(--app-shell-content-surface)_96%,var(--linear-bg-surface-0))] px-4 py-4 shadow-[0_16px_40px_rgba(0,0,0,0.16)] sm:px-5'>
           <div className='flex items-center justify-between gap-4'>
             <div>
               <p className='text-sm font-semibold tracking-tighter text-primary-token'>
@@ -261,7 +261,7 @@ function AuthShellWrapperInner({
             </div>
             <div
               aria-hidden='true'
-              className='h-2.5 w-24 overflow-hidden rounded-full bg-[color-mix(in_oklab,var(--linear-app-frame-seam)_78%,transparent)]'
+              className='h-2.5 w-24 overflow-hidden rounded-full bg-[color-mix(in_oklab,var(--app-shell-frame-seam)_78%,transparent)]'
             >
               <div className='h-full w-1/2 animate-pulse rounded-full bg-primary-token/65' />
             </div>

--- a/apps/web/components/organisms/BillingDashboard.tsx
+++ b/apps/web/components/organisms/BillingDashboard.tsx
@@ -117,7 +117,7 @@ const BillingDashboardContent = memo(function BillingDashboardContent() {
     <div className='space-y-8'>
       {billingInfo?.stale && (
         <ContentSurfaceCard
-          className='flex items-start gap-2 border-[color-mix(in_oklab,var(--linear-warning)_32%,var(--linear-app-frame-seam))] bg-[color-mix(in_oklab,var(--linear-warning)_10%,var(--linear-app-content-surface))] px-4 py-3 text-app text-primary-token'
+          className='flex items-start gap-2 border-[color-mix(in_oklab,var(--linear-warning)_32%,var(--app-shell-frame-seam))] bg-[color-mix(in_oklab,var(--linear-warning)_10%,var(--app-shell-content-surface))] px-4 py-3 text-app text-primary-token'
           surface='nested'
         >
           <AlertCircle

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -257,14 +257,14 @@ export function CmdKPalette({
         className={cn(
           'left-0 top-0 h-dvh w-full max-w-none [translate:0_0]',
           'grid gap-0 overflow-hidden rounded-none border-0 p-0 shadow-none',
-          'bg-(--linear-app-content-surface)',
+          'bg-(--app-shell-content-surface)',
           'sm:max-w-none',
           // Full-page: fade only (no zoom — zoom reads as a modal card)
           'data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100'
         )}
         hideClose
         overlayProps={{
-          className: 'bg-(--linear-app-content-surface)',
+          className: 'bg-(--app-shell-content-surface)',
         }}
         testId='cmdk-full-page'
       >
@@ -279,7 +279,7 @@ export function CmdKPalette({
           data-testid='shared-command-palette'
           data-surface='cmdk'
         >
-          <div className='flex shrink-0 items-center gap-2 border-b border-(--linear-app-frame-seam) px-3.5 py-2.5'>
+          <div className='flex shrink-0 items-center gap-2 border-b border-(--app-shell-frame-seam) px-3.5 py-2.5'>
             <Search
               className='size-4 shrink-0 text-tertiary-token'
               aria-hidden='true'

--- a/apps/web/components/organisms/Dialog.tsx
+++ b/apps/web/components/organisms/Dialog.tsx
@@ -56,7 +56,7 @@ export function Dialog({
         hideClose={hideClose}
         className={cn(
           sizes[size],
-          'rounded-dialog border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-6 shadow-popover',
+          'rounded-dialog border border-(--app-shell-frame-seam) bg-(--app-shell-content-surface) p-6 shadow-popover',
           className
         )}
       >

--- a/apps/web/components/organisms/DialogLoadingSkeleton.tsx
+++ b/apps/web/components/organisms/DialogLoadingSkeleton.tsx
@@ -52,7 +52,7 @@ export function DialogLoadingSkeleton({
               <DrawerSurfaceCard
                 key={rowId}
                 variant='card'
-                className='flex min-h-14 items-center gap-3 rounded-xl border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_88%,var(--linear-bg-surface-0))] px-2.5'
+                className='flex min-h-14 items-center gap-3 rounded-xl border border-(--app-shell-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_88%,var(--linear-bg-surface-0))] px-2.5'
               >
                 <Skeleton className='h-10 w-10 shrink-0' rounded='full' />
                 <div className='min-w-0 flex-1 space-y-1.5'>

--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -37,9 +37,9 @@ const SHELL_AUDIO_BAR_TRANSITION =
 const SHELL_AUDIO_CHROME_TRANSITION_CLASSNAME =
   'transition-[max-height,opacity,transform,border-color,background-color] duration-cinematic ease-cinematic';
 const SHELL_NOW_PLAYING_CARD_CLASSNAME =
-  'max-w-56 rounded-lg border border-(--linear-app-shell-border)/75 bg-(--linear-app-content-surface) px-2 py-2 shadow-[0_10px_24px_rgba(0,0,0,0.12)] transition-[opacity,transform] duration-cinematic ease-cinematic';
+  'max-w-56 rounded-lg border border-(--app-shell-border)/75 bg-(--app-shell-content-surface) px-2 py-2 shadow-[0_10px_24px_rgba(0,0,0,0.12)] transition-[opacity,transform] duration-cinematic ease-cinematic';
 const SHELL_NOW_PLAYING_ROW_CLASSNAME =
-  'max-w-64 border border-(--linear-app-shell-border)/75 bg-(--linear-app-content-surface) shadow-[0_10px_24px_rgba(0,0,0,0.12)] transition-[opacity,transform,border-color,background-color] duration-cinematic ease-cinematic';
+  'max-w-64 border border-(--app-shell-border)/75 bg-(--app-shell-content-surface) shadow-[0_10px_24px_rgba(0,0,0,0.12)] transition-[opacity,transform,border-color,background-color] duration-cinematic ease-cinematic';
 
 function isLyricsRoutePath(pathname: string | null): boolean {
   return (
@@ -290,7 +290,7 @@ export function PersistentAudioBar({
     <section
       aria-label='Audio Player'
       className={cn(
-        'animate-in fade-in slide-in-from-bottom-2 duration-cinematic shrink-0 border-t border-subtle bg-(--linear-app-content-surface) backdrop-blur-xl px-3 py-2 max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))]',
+        'animate-in fade-in slide-in-from-bottom-2 duration-cinematic shrink-0 border-t border-subtle bg-(--app-shell-content-surface) backdrop-blur-xl px-3 py-2 max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))]',
         className
       )}
     >
@@ -402,13 +402,11 @@ export function PersistentAudioBar({
         data-shell-audio-surface='persistent-expanded'
         aria-hidden={barCollapsed}
         className={cn(
-          'hidden shrink-0 overflow-hidden border-t border-(--linear-app-shell-border) bg-(--linear-bg-page) lg:block',
+          'hidden shrink-0 overflow-hidden border-t border-(--app-shell-border) bg-(--linear-bg-page) lg:block',
           SHELL_AUDIO_CHROME_TRANSITION_CLASSNAME
         )}
         style={{
-          maxHeight: barCollapsed
-            ? 0
-            : 'var(--linear-app-audio-bar-max-height)',
+          maxHeight: barCollapsed ? 0 : 'var(--app-shell-audio-bar-max-height)',
           opacity: revealed && !barCollapsed ? 1 : 0,
           transform: !revealed
             ? 'translateY(100%)'
@@ -462,13 +460,11 @@ export function PersistentAudioBar({
         data-shell-audio-surface='persistent-compact'
         aria-hidden={!barCollapsed}
         className={cn(
-          'hidden shrink-0 overflow-hidden border-t border-(--linear-app-shell-border) bg-(--linear-app-content-surface) px-3 lg:block',
+          'hidden shrink-0 overflow-hidden border-t border-(--app-shell-border) bg-(--app-shell-content-surface) px-3 lg:block',
           SHELL_AUDIO_CHROME_TRANSITION_CLASSNAME
         )}
         style={{
-          maxHeight: barCollapsed
-            ? 'var(--linear-app-audio-compact-height)'
-            : 0,
+          maxHeight: barCollapsed ? 'var(--app-shell-audio-compact-height)' : 0,
           opacity: barCollapsed ? 1 : 0,
           transform: barCollapsed ? 'translateY(0)' : 'translateY(8px)',
           pointerEvents: barCollapsed ? 'auto' : 'none',

--- a/apps/web/components/organisms/SharedCommandPalette.tsx
+++ b/apps/web/components/organisms/SharedCommandPalette.tsx
@@ -179,7 +179,7 @@ function CmdKPaletteRow({
       className={cn(
         'flex min-h-14 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left outline-none transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
         isActive
-          ? 'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_76%,white_14%)] text-primary-token shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_36%,transparent),0_10px_28px_-24px_rgba(0,0,0,0.9)]'
+          ? 'bg-[color-mix(in_oklab,var(--app-shell-content-surface)_76%,white_14%)] text-primary-token shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_36%,transparent),0_10px_28px_-24px_rgba(0,0,0,0.9)]'
           : 'hover:bg-white/[0.045]'
       )}
     >
@@ -230,7 +230,7 @@ export function PaletteList({
             className={cn(
               variant === 'cmdk' &&
                 sectionIdx > 0 &&
-                'mt-2 border-t border-[color-mix(in_oklab,var(--linear-app-frame-seam)_72%,transparent)] pt-1'
+                'mt-2 border-t border-[color-mix(in_oklab,var(--app-shell-frame-seam)_72%,transparent)] pt-1'
             )}
           >
             <div

--- a/apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx
+++ b/apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx
@@ -45,7 +45,7 @@ export function SidebarBottomNowPlayingBridge() {
       aria-hidden={compactPlayerOwnsTrack}
       inert={compactPlayerOwnsTrack ? true : undefined}
       className={cn(
-        'h-(--linear-app-audio-compact-height) overflow-hidden px-2 pb-2 pt-1 transition-[opacity,transform] duration-cinematic ease-cinematic',
+        'h-(--app-shell-audio-compact-height) overflow-hidden px-2 pb-2 pt-1 transition-[opacity,transform] duration-cinematic ease-cinematic',
         compactPlayerOwnsTrack ? 'pointer-events-none opacity-0' : 'opacity-100'
       )}
     >
@@ -57,7 +57,7 @@ export function SidebarBottomNowPlayingBridge() {
         }}
         isPlaying={playbackState.isPlaying}
         onPlay={handlePlay}
-        className='border border-(--linear-app-shell-border)/75 bg-(--linear-app-content-surface) shadow-[0_10px_24px_rgba(0,0,0,0.12)] transition-[opacity,transform,border-color,background-color] duration-cinematic ease-cinematic'
+        className='border border-(--app-shell-border)/75 bg-(--app-shell-content-surface) shadow-[0_10px_24px_rgba(0,0,0,0.12)] transition-[opacity,transform,border-color,background-color] duration-cinematic ease-cinematic'
       />
     </div>
   );

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -404,7 +404,7 @@ export function UnifiedSidebar({
       collapsible='offcanvas'
       className={cn(
         'bg-base',
-        '[--sidebar-width:var(--linear-app-sidebar-width)]',
+        '[--sidebar-width:var(--app-shell-sidebar-width)]',
         'transition-[width,transform] duration-cinematic ease-cinematic',
         // OV brand skin: class-based token override, same mechanism as `.dark`
         // (see design-system.css → OV MODE). Zero layout impact.
@@ -415,7 +415,7 @@ export function UnifiedSidebar({
         data-electron-drag-region='true'
         className={cn(
           'relative justify-center gap-0 px-2.5',
-          'h-(--linear-app-header-height-compact) py-0.5'
+          'h-(--app-shell-header-height-compact) py-0.5'
         )}
       >
         <SidebarHeaderNav

--- a/apps/web/components/organisms/WorkspaceTabsSurface.tsx
+++ b/apps/web/components/organisms/WorkspaceTabsSurface.tsx
@@ -121,7 +121,7 @@ export function WorkspaceTabsSurface<
     <div className='space-y-4'>
       {headerless ? (
         shouldShowTabControls ? (
-          <div className='border-b border-(--linear-app-frame-seam) pb-3'>
+          <div className='border-b border-(--app-shell-frame-seam) pb-3'>
             <div className='flex flex-col gap-3'>
               {shouldShowPrimaryControl ? (
                 <LinkedTabBar

--- a/apps/web/components/organisms/artist-search-palette/ArtistSearchCommandPalette.tsx
+++ b/apps/web/components/organisms/artist-search-palette/ArtistSearchCommandPalette.tsx
@@ -231,7 +231,7 @@ export function ArtistSearchCommandPalette({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className='overflow-hidden rounded-2xl border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-0 shadow-popover sm:max-w-125'
+        className='overflow-hidden rounded-2xl border border-(--app-shell-frame-seam) bg-(--app-shell-content-surface) p-0 shadow-popover sm:max-w-125'
         hideClose
       >
         <DialogPrimitive.Title className='sr-only'>
@@ -246,9 +246,9 @@ export function ArtistSearchCommandPalette({
           label={`Search ${config.label} artists`}
         >
           {/* Search input */}
-          <div className='border-b border-(--linear-app-frame-seam) px-4 py-3'>
+          <div className='border-b border-(--app-shell-frame-seam) px-4 py-3'>
             <div
-              className='flex items-center gap-3 rounded-xl border border-(--linear-app-frame-seam) bg-surface-0 px-3 py-2.5'
+              className='flex items-center gap-3 rounded-xl border border-(--app-shell-frame-seam) bg-surface-0 px-3 py-2.5'
               style={{ boxShadow: '0 1px 0 rgba(0,0,0,0.03)' }}
             >
               <div
@@ -285,7 +285,7 @@ export function ArtistSearchCommandPalette({
                 {SKELETON_KEYS.map((key, index) => (
                   <div
                     key={key}
-                    className='flex items-center gap-3 rounded-xl border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_88%,var(--linear-bg-surface-0))] px-4 py-2.5'
+                    className='flex items-center gap-3 rounded-xl border border-(--app-shell-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_88%,var(--linear-bg-surface-0))] px-4 py-2.5'
                   >
                     <div className='w-10 h-10 rounded-full skeleton shrink-0' />
                     <div className='flex-1 space-y-1.5'>
@@ -338,7 +338,7 @@ export function ArtistSearchCommandPalette({
                     onSelect={() => handleSelect(artist)}
                     className={cn(
                       'mb-1 flex cursor-pointer items-center gap-3 rounded-xl border border-transparent px-4 py-2.5 transition-colors last:mb-0',
-                      'data-[selected=true]:border-(--linear-app-frame-seam) data-[selected=true]:bg-surface-1 hover:bg-surface-2/50'
+                      'data-[selected=true]:border-(--app-shell-frame-seam) data-[selected=true]:bg-surface-1 hover:bg-surface-2/50'
                     )}
                   >
                     <ArtistResultImage
@@ -371,13 +371,13 @@ export function ArtistSearchCommandPalette({
           </Command.List>
 
           {/* Manual URL input */}
-          <div className='border-t border-(--linear-app-frame-seam) px-4 py-3'>
+          <div className='border-t border-(--app-shell-frame-seam) px-4 py-3'>
             <div className='flex items-center gap-2 text-xs text-tertiary-token mb-2'>
               <div className='flex-1 h-px bg-subtle' />
               <span>Or paste a link</span>
               <div className='flex-1 h-px bg-subtle' />
             </div>
-            <div className='flex items-center gap-2 rounded-xl border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-2'>
+            <div className='flex items-center gap-2 rounded-xl border border-(--app-shell-frame-seam) bg-surface-0 px-2.5 py-2'>
               <input
                 type='url'
                 value={manualUrl}

--- a/apps/web/components/organisms/billing/BillingHistorySection.tsx
+++ b/apps/web/components/organisms/billing/BillingHistorySection.tsx
@@ -54,7 +54,7 @@ export function BillingHistorySection({
           !historyQuery.error &&
           (historyQuery.data?.entries &&
           historyQuery.data.entries.length > 0 ? (
-            <div className='divide-y divide-(--linear-app-frame-seam)'>
+            <div className='divide-y divide-(--app-shell-frame-seam)'>
               {historyQuery.data.entries.map((entry: BillingHistoryEntry) => {
                 const config = EVENT_BADGE_CONFIG[entry.eventType];
                 const IconComponent = config?.icon ?? Clock;

--- a/apps/web/components/organisms/billing/BillingLoadingSkeleton.tsx
+++ b/apps/web/components/organisms/billing/BillingLoadingSkeleton.tsx
@@ -40,7 +40,7 @@ export function BillingLoadingSkeleton() {
             <div className='space-y-3 px-3 py-3'>
               <Skeleton className='h-9 w-24' rounded='md' />
               <Skeleton className='h-8 w-full' rounded='md' />
-              <div className='h-px bg-(--linear-app-frame-seam)' />
+              <div className='h-px bg-(--app-shell-frame-seam)' />
               <LoadingSkeleton lines={5} height='h-4' rounded='md' />
             </div>
           </ContentSurfaceCard>

--- a/apps/web/components/organisms/billing/PlanComparisonSection.tsx
+++ b/apps/web/components/organisms/billing/PlanComparisonSection.tsx
@@ -192,7 +192,7 @@ export function PlanComparisonSection({
                   })}
                 </div>
 
-                <div className='my-5 h-px bg-(--linear-app-frame-seam)' />
+                <div className='my-5 h-px bg-(--app-shell-frame-seam)' />
                 <ul className='flex-1 space-y-3'>
                   {planData.features.map(feature => (
                     <li

--- a/apps/web/components/organisms/release-sidebar/ReleaseDspLinks.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseDspLinks.tsx
@@ -356,7 +356,7 @@ export function ReleaseDspLinks({
               className='h-8 rounded-md border-subtle bg-surface-0 text-xs'
             />
           </DrawerFormGridRow>
-          <div className='flex justify-end gap-2 border-t border-(--linear-app-frame-seam) pt-2'>
+          <div className='flex justify-end gap-2 border-t border-(--app-shell-frame-seam) pt-2'>
             <DrawerButton
               type='button'
               onClick={() => {

--- a/apps/web/components/organisms/release-sidebar/ReleaseLyricsSection.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseLyricsSection.tsx
@@ -231,7 +231,7 @@ export function ReleaseLyricsSection({
           }}
           rows={draftLyrics ? 10 : 4}
           disabled={!isEditable || isSaving}
-          className='min-h-35 resize-y border-(--linear-app-frame-seam) bg-surface-0 text-xs'
+          className='min-h-35 resize-y border-(--app-shell-frame-seam) bg-surface-0 text-xs'
         />
         {/* Auto-save status indicator */}
         <div className='min-h-6'>
@@ -239,7 +239,7 @@ export function ReleaseLyricsSection({
         </div>
       </div>
 
-      <div className='flex flex-wrap items-center gap-2 border-t border-(--linear-app-frame-seam) px-3 py-2.5'>
+      <div className='flex flex-wrap items-center gap-2 border-t border-(--app-shell-frame-seam) px-3 py-2.5'>
         <DrawerButton
           type='button'
           disabled={isActionsDisabled || isCopying}
@@ -255,7 +255,7 @@ export function ReleaseLyricsSection({
         </DrawerButton>
 
         {showFormatOptions && (
-          <div className='inline-flex items-center rounded-full border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_82%,var(--linear-bg-surface-0))]'>
+          <div className='inline-flex items-center rounded-full border border-(--app-shell-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_82%,var(--linear-bg-surface-0))]'>
             <DrawerButton
               type='button'
               disabled={isActionsDisabled || isFormatting}

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.tsx
@@ -338,7 +338,7 @@ export function ReleaseEntityHeader({
         />
       </div>
       {footer ? (
-        <div className='border-t border-(--linear-app-frame-seam) px-3 py-2.5'>
+        <div className='border-t border-(--app-shell-frame-seam) px-3 py-2.5'>
           {footer}
         </div>
       ) : null}
@@ -430,7 +430,7 @@ export function ReleaseActivitySection({
       testId='release-activity-card'
       contentClassName='p-0'
     >
-      <div className='divide-y divide-(--linear-app-frame-seam)'>
+      <div className='divide-y divide-(--app-shell-frame-seam)'>
         {activityRows.map(row => (
           <div
             key={`${row.providerKey}-${row.updatedAt}`}

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -323,7 +323,7 @@ function TrackListRow({
       className={cn(
         'flex items-center gap-3 py-2.5',
         !isLastRow &&
-          'border-b border-[color-mix(in_oklab,var(--linear-app-frame-seam)_58%,transparent)]'
+          'border-b border-[color-mix(in_oklab,var(--app-shell-frame-seam)_58%,transparent)]'
       )}
       data-testid={`release-track-row-${track.id}`}
     >
@@ -334,7 +334,7 @@ function TrackListRow({
         className={cn(
           'flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-caption tabular-nums transition-[background-color,color,border-color] duration-subtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
           isActiveTrack
-            ? 'border border-(--linear-app-frame-seam) bg-surface-0 text-primary-token hover:bg-surface-1'
+            ? 'border border-(--app-shell-frame-seam) bg-surface-0 text-primary-token hover:bg-surface-1'
             : 'border border-transparent bg-transparent text-tertiary-token hover:bg-surface-0 hover:text-primary-token',
           !playableUrl &&
             !isActiveTrack &&

--- a/apps/web/components/organisms/release-sidebar/TrackDetailPanel.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackDetailPanel.tsx
@@ -58,7 +58,7 @@ export function TrackDetailPanel({
       <DrawerSurfaceCard
         className={cn(LINEAR_SURFACE.drawerCard, 'overflow-hidden')}
       >
-        <div className='border-b border-(--linear-app-frame-seam) px-3 py-2'>
+        <div className='border-b border-(--app-shell-frame-seam) px-3 py-2'>
           <p className='text-2xs font-caption leading-none text-tertiary-token'>
             Track
           </p>
@@ -80,7 +80,7 @@ export function TrackDetailPanel({
       <DrawerSurfaceCard
         className={cn(LINEAR_SURFACE.drawerCard, 'overflow-hidden')}
       >
-        <div className='border-b border-(--linear-app-frame-seam) px-3 py-2'>
+        <div className='border-b border-(--app-shell-frame-seam) px-3 py-2'>
           <p className='text-2xs font-caption leading-none text-tertiary-token'>
             Smart link
           </p>
@@ -107,7 +107,7 @@ export function TrackDetailPanel({
         <DrawerSurfaceCard
           className={cn(LINEAR_SURFACE.drawerCard, 'overflow-hidden')}
         >
-          <div className='border-b border-(--linear-app-frame-seam) px-3 py-2'>
+          <div className='border-b border-(--app-shell-frame-seam) px-3 py-2'>
             <p className='text-2xs font-caption leading-none text-tertiary-token'>
               Actions
             </p>

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -428,7 +428,7 @@ export function TrackSidebar({
                       onClick={handleTogglePlayback}
                       aria-label={isPlaying ? 'Pause preview' : 'Play preview'}
                       aria-pressed={isPlaying}
-                      className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token transition-[background-color,color,border-color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                      className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-(--app-shell-frame-seam) bg-surface-0 text-secondary-token transition-[background-color,color,border-color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
                     >
                       {isPlaying ? (
                         <Pause className='h-4 w-4' />
@@ -437,7 +437,7 @@ export function TrackSidebar({
                       )}
                     </button>
                   ) : (
-                    <span className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-(--linear-app-frame-seam) bg-surface-0 text-quaternary-token'>
+                    <span className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-(--app-shell-frame-seam) bg-surface-0 text-quaternary-token'>
                       <VolumeX className='h-4 w-4' />
                     </span>
                   )}

--- a/apps/web/components/organisms/sidebar/context.tsx
+++ b/apps/web/components/organisms/sidebar/context.tsx
@@ -87,7 +87,7 @@ export const SidebarProvider = React.forwardRef<
         <div
           style={
             {
-              '--sidebar-width': 'var(--linear-app-sidebar-width)',
+              '--sidebar-width': 'var(--app-shell-sidebar-width)',
               '--sidebar-width-icon': '52px',
               ...style,
             } as React.CSSProperties

--- a/apps/web/components/organisms/sidebar/menu.tsx
+++ b/apps/web/components/organisms/sidebar/menu.tsx
@@ -47,7 +47,7 @@ const sidebarMenuButtonVariants = cva(
     // Hover state — Linear: rgba(255,255,255,0.02) bg
     'hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-sidebar-item-foreground',
     // Active state — filled background only, no border/inset ring
-    'data-[active=true]:bg-[color-mix(in_oklab,var(--color-sidebar-accent-active)_88%,var(--linear-app-content-surface))] data-[active=true]:text-sidebar-item-foreground',
+    'data-[active=true]:bg-[color-mix(in_oklab,var(--color-sidebar-accent-active)_88%,var(--app-shell-content-surface))] data-[active=true]:text-sidebar-item-foreground',
     // Focus state - subtle bg plus tokenized keyboard ring
     'focus-visible:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/35',
     // Disabled state

--- a/apps/web/components/organisms/sidebar/sidebar.tsx
+++ b/apps/web/components/organisms/sidebar/sidebar.tsx
@@ -57,7 +57,7 @@ export const Sidebar = React.forwardRef<
             className='w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden'
             style={
               {
-                '--sidebar-width': 'var(--linear-app-sidebar-width)',
+                '--sidebar-width': 'var(--app-shell-sidebar-width)',
               } as React.CSSProperties
             }
             side={side}
@@ -108,7 +108,7 @@ export const Sidebar = React.forwardRef<
           >
             <div
               data-sidebar='sidebar'
-              className='pointer-events-auto flex h-full w-full flex-col overflow-clip bg-sidebar transition-[background-color] duration-normal ease-interactive lg:rounded-(--linear-app-shell-radius) lg:shadow-(--linear-app-sidebar-shadow) group-data-[variant=floating]:rounded-sidebar-floating group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow group-data-[variant=inset]:border-r group-data-[variant=inset]:border-sidebar-border'
+              className='pointer-events-auto flex h-full w-full flex-col overflow-clip bg-sidebar transition-[background-color] duration-normal ease-interactive lg:rounded-(--app-shell-radius) lg:shadow-(--linear-app-sidebar-shadow) group-data-[variant=floating]:rounded-sidebar-floating group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow group-data-[variant=inset]:border-r group-data-[variant=inset]:border-sidebar-border'
             >
               {children}
             </div>

--- a/apps/web/components/organisms/table/atoms/AudienceMobileCard.tsx
+++ b/apps/web/components/organisms/table/atoms/AudienceMobileCard.tsx
@@ -93,7 +93,7 @@ export const AudienceMobileCard = React.memo(function AudienceMobileCard({
         type='button'
         onClick={handleCardClick}
         aria-label={`View details for ${displayName}`}
-        className='absolute inset-0 outline-none focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-(--linear-app-shell-border)'
+        className='absolute inset-0 outline-none focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-(--app-shell-border)'
       />
 
       <div

--- a/apps/web/components/organisms/table/atoms/TableHeaderCell.tsx
+++ b/apps/web/components/organisms/table/atoms/TableHeaderCell.tsx
@@ -55,7 +55,7 @@ export function TableHeaderCell({
         // Base styles
         'border-b border-subtle px-3 py-1 align-middle text-2xs font-caption text-secondary-token',
         // Sticky positioning
-        sticky && 'sticky z-20 bg-(--linear-app-content-surface)',
+        sticky && 'sticky z-20 bg-(--app-shell-content-surface)',
         // Alignment
         alignmentClasses[align],
         // Width

--- a/apps/web/components/organisms/table/molecules/PageToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/PageToolbar.tsx
@@ -35,7 +35,7 @@ export const PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS =
   'w-7 justify-center px-0 text-tertiary-token';
 
 export const TABLE_TOOLBAR_SHELL_CLASS =
-  'flex h-11 min-h-11 min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-3.5 py-2 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+  'flex h-11 min-h-11 min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden border-b border-(--app-shell-frame-seam) bg-(--app-shell-content-surface) px-3.5 py-2 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
 
 export const TABLE_TOOLBAR_OVERLAY_CLASS = cn(
   'absolute inset-x-0 top-0 z-10',

--- a/apps/web/tests/components/molecules/CopyableUrlRow.test.tsx
+++ b/apps/web/tests/components/molecules/CopyableUrlRow.test.tsx
@@ -24,7 +24,7 @@ describe('CopyableUrlRow', () => {
     const row = screen.getByTestId('flat-row');
 
     expect(row.className).toContain('border-transparent');
-    expect(row.className).not.toContain('border-(--linear-app-frame-seam)');
+    expect(row.className).not.toContain('border-(--app-shell-frame-seam)');
   });
 
   it('keeps the boxed surface bordered', () => {
@@ -37,7 +37,7 @@ describe('CopyableUrlRow', () => {
     );
 
     expect(screen.getByTestId('boxed-row').className).toContain(
-      'border-(--linear-app-frame-seam)'
+      'border-(--app-shell-frame-seam)'
     );
   });
 

--- a/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
+++ b/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
@@ -622,7 +622,7 @@ describe('PersistentAudioBar', () => {
     render(<PersistentAudioBar variant='shellChatV1' />);
 
     const expandedSurface = screen.getByTestId('audio-surface-expanded-shell');
-    const reservedHeight = 'var(--linear-app-audio-bar-max-height)';
+    const reservedHeight = 'var(--app-shell-audio-bar-max-height)';
 
     // Height is reserved from the very first frame (only transform/opacity
     // animate), so surrounding content never reflows.

--- a/apps/web/tests/components/organisms/RightDrawer.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/RightDrawer.interaction.test.tsx
@@ -147,7 +147,7 @@ describe('RightDrawer', () => {
       'fixed',
       'inset-0',
       'translate-x-full',
-      'bg-(--linear-app-content-surface)',
+      'bg-(--app-shell-content-surface)',
       'outline-none'
     );
 

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -426,13 +426,13 @@ describe('surface elevation guardrails', () => {
     // Guardrails must match production classes exactly — [var(...)] form drifts
     // and fails Unit Tests after #13831.
     expect(shellFrame).toContain(
-      'lg:gap-(--linear-app-shell-gap) lg:p-(--linear-app-shell-gap)'
+      'lg:gap-(--app-shell-gap) lg:p-(--app-shell-gap)'
     );
     expect(linearTokens).toContain('--linear-app-sidebar-shadow:');
     expect(sidebar).not.toContain(
       'group-data-[variant=sidebar]:lg:shadow-[var(--linear-app-sidebar-shadow)]'
     );
-    expect(rightDrawer).toContain('border-l border-(--linear-app-frame-seam)');
+    expect(rightDrawer).toContain('border-l border-(--app-shell-frame-seam)');
     // Mobile overlay retains shadow; desktop drawer is flat so elevation
     // comes from DrawerSurfaceCard cards inside the shell, not the outer aside.
     expect(rightDrawer).toContain('shadow-(--linear-app-drawer-shadow)');

--- a/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
+++ b/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
@@ -49,7 +49,7 @@ const localTrace = Object.fromEntries(
     .map(value => value.split('='))
 );
 const uploadInventory =
-  'agent-tick.yml:public-profile-smoke-screenshots|agent-tick.yml:synthetic-test-results|ci.yml:${{ github.job }}-shard-${{ matrix.shard }}-test-results-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:a11y-authed-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:a11y-axe-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:admin-smoke-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:combined-layout-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:e2e-smoke-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:golden-path-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:layout-guard-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:mobile-overflow-report-${{ matrix.width }}-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:public-lighthouse-mobile-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:smoke-required-report-${{ github.run_id }}|e2e-full-matrix.yml:e2e-full-${{ matrix.browser }}-results-${{ github.run_id }}|nightly-testing-agent.yml:nightly-agent-candidate-validation-${{ github.run_id }}|nightly-testing-agent.yml:nightly-agent-context-${{ github.run_id }}|nightly-testing-agent.yml:nightly-agent-deterministic-${{ github.run_id }}|nightly-testing-agent.yml:nightly-agent-mutation-${{ github.run_id }}|nightly-testing-agent.yml:nightly-agent-report-${{ github.run_id }}|nightly-tests.yml:full-surface-chaos-${{ github.run_id }}|nightly-tests.yml:nightly-e2e-results-${{ github.run_id }}|nightly-tests.yml:nightly-route-qa-${{ github.run_id }}|production-controller.yml:post-deploy-auth-smoke-${{ github.run_id }}|synthetic-monitoring.yml:synthetic-test-results|visual-regression.yml:visual-regression-report-${{ github.run_id }}-${{ github.run_attempt }}'.split(
+  'agent-tick.yml:public-profile-smoke-screenshots|agent-tick.yml:synthetic-test-results|ci.yml:${{ github.job }}-shard-${{ matrix.shard }}-test-results-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:a11y-authed-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:a11y-axe-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:admin-smoke-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:combined-layout-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:e2e-smoke-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:golden-path-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:layout-guard-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:mobile-overflow-report-${{ matrix.width }}-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:public-lighthouse-mobile-report-${{ github.run_id }}-${{ github.run_attempt }}|ci.yml:smoke-required-report-${{ github.run_id }}|e2e-full-matrix.yml:e2e-full-${{ matrix.browser }}-results-${{ github.run_id }}|nightly-testing-agent.yml:nightly-agent-candidate-validation-${{ github.run_id }}|nightly-testing-agent.yml:nightly-agent-context-${{ github.run_id }}|nightly-testing-agent.yml:nightly-agent-deterministic-${{ github.run_id }}|nightly-testing-agent.yml:nightly-agent-mutation-${{ github.run_id }}|nightly-testing-agent.yml:nightly-agent-report-${{ github.run_id }}|nightly-tests.yml:full-surface-chaos-${{ github.run_id }}|nightly-tests.yml:nightly-e2e-results-${{ github.run_id }}|nightly-tests.yml:nightly-route-qa-${{ github.run_id }}|postdeploy-probes.yml:postdeploy-auth-smoke-${{ github.run_id }}|production-controller.yml:post-deploy-auth-smoke-${{ github.run_id }}|synthetic-monitoring.yml:synthetic-test-results|visual-regression.yml:visual-regression-report-${{ github.run_id }}-${{ github.run_attempt }}'.split(
     '|'
   );
 const imageUploads =
@@ -787,13 +787,13 @@ describe('Playwright artifact secret boundary', () => {
     expect(uploads.sort()).toEqual(uploadInventory.sort());
     expect(images.sort()).toEqual(imageUploads.sort());
     expect(markdown.sort()).toEqual(markdownUploads.sort());
-    expect(safeUploadJobs).toHaveLength(22);
+    expect(safeUploadJobs).toHaveLength(23);
     expect(
       safeUploadJobs.reduce(
         (count, job) => count + safeUploadJobAudit(job).uploadCount,
         0
       )
-    ).toBe(25);
+    ).toBe(26);
     for (const job of safeUploadJobs) {
       const audit = safeUploadJobAudit(job);
       expect(

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -24,9 +24,9 @@ describe('AppShellFrame', () => {
     expect(mainContent).toHaveClass('lg:shadow-(--linear-app-shell-shadow)');
     // #main-content keeps its full rounded shell radius — no Electron override
     // strips the top corners now that the header lives inside the card.
-    expect(mainContent).toHaveClass('lg:rounded-(--linear-app-shell-radius)');
+    expect(mainContent).toHaveClass('lg:rounded-(--app-shell-radius)');
     expect(mainContent.querySelector('div.flex.flex-1')).toHaveClass(
-      'lg:gap-(--linear-app-shell-gap)'
+      'lg:gap-(--app-shell-gap)'
     );
     expect(screen.getByText('Sidebar')).toBeInTheDocument();
     expect(screen.getByText('Main Content')).toBeInTheDocument();
@@ -74,7 +74,7 @@ describe('AppShellFrame', () => {
       'lg:shadow-(--linear-app-shell-shadow)'
     );
     expect(mainContent.querySelector('div.flex.flex-1')).not.toHaveClass(
-      'lg:gap-(--linear-app-shell-gap)'
+      'lg:gap-(--app-shell-gap)'
     );
   });
 

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 2096
+  "count": 1993
 }


### PR DESCRIPTION
## Summary
Exact-map `(--linear-*)` paren utilities in shared molecules/organisms to semantic tokens:

- Shell geometry/surface aliases (`--app-shell-*` exact identity in `design-system.css`):
  frame-seam, content-surface, shell-border, header-height*, shell-gap,
  shell-radius, audio-*, sidebar-width
- Focus rings: `ring-(--linear-border-focus)` → `ring-ring`

### Scope
- HOT ZONE: molecules/**, organisms/**, baseline + related unit tests
- Prefer table/sidebar/drawer + PersistentAudioBar
- Skipped public chrome (Footer, HeaderNav, MobileNav, cookies)
- Skipped files with pre-existing ESLint failures

### Non-exact maps deliberately not applied
- `border-focus` ≠ `--linear-border-focus` (accent vs gray/white focus rim)
- Surface/text color chains not always same-var outside marketing bridge

### Ratchet
`linear-namespace.baseline.json`: **2096 → 1993 (−103)**

Also includes:
- CI inventory update for postdeploy-probes auth-smoke artifact
- trufflehog exclude for DATABASE_URL validation fixtures (Secret Scan)

## Test plan
- [x] linear-namespace ratchet unit test
- [x] AppShellFrame / surface-elevation / PersistentAudioBar / RightDrawer / CopyableUrlRow
- [x] playwright-artifact-secrets inventory
- [x] typecheck + eslint + biome via pre-commit

## Bug-to-test
- [x] N/A — mechanical token remap; baseline + style guards are the regression guard
- [x] bug-to-test: waived — linear-namespace baseline is regression guard