### PR TITLE
ci(security): exclude cron/auth.test.ts from trufflehog (fixture DB URLs)

### DIFF
--- a/.trufflehog-exclude.txt
+++ b/.trufflehog-exclude.txt
@@ -6,3 +6,10 @@ scripts/security/gitleaks-backup-fixture.txt
 # diff-scanned lines (verified 2026-07-20, runs 29785483353/29784648947).
 # gitleaks (.gitleaks.toml) and GitHub secret scanning still cover this file.
 .github/workflows/sonarcloud.yml
+
+# cron/auth.test.ts: fake postgres://user:pass@example DB URLs in timing-safe
+# comparison fixtures (trustedWithVercelUrlOnly et al.) — URI/Postgres detector
+# bait, unverified non-credentials. Phantom-content scans via stale queue refs
+# hit this file (JOV-4333 root fix in flight; this is the parallel mitigation
+# matching .github/workflows/sonarcloud.yml). gitleaks still covers it.
+apps/web/lib/cron/auth.test.ts


### PR DESCRIPTION
## Problem
`apps/web/lib/cron/auth.test.ts` contains fake `postgres://user:pass@example.com` / `*.neon.tech:5432` fixture strings (timing-safe comparison tests, JOV-3038 era) — URI/Postgres detector bait, always unverified. They surface in Secret Scan when stale merge-group refs put the file into trufflehog's served object graph (root cause being fixed in JOV-4333), ejecting innocent PRs (e.g. #14552, source-PR job 88506915089).

## Change
One line in `.trufflehog-exclude.txt` (now emitted as `--exclude-globs` per #14550) + rationale comment. Same pattern as `sonarcloud.yml` (#14550) and `database-url-validation.test.ts` (#14560).

## Safety
gitleaks (`.gitleaks.toml`) and GitHub native secret scanning continue covering the file — only trufflehog is excluded. Fixture strings are definitionally non-credentials.

## Validation
- File content verified: only comment + path added
- Mechanism verified on #14550 (8→0 findings with exact CI binary/invocation)

## Risk / rollback
Low. Rollback = revert. The JOV-4333 root fix (exact base resolution + queue-ref hygiene) remains the durable solution; these exclusions are the parallel mitigations.