### PR TITLE
fix(profile): music-cards row no longer clipped on public profile (JOV-3377)

### DIFF
--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -777,6 +777,15 @@ export function ProfileCompactSurface({
           <div
             className={cn(
               'profile-content-scroll-region overflow-y-auto overscroll-contain',
+              // Home mode: bleed the scroll region to the shell edge. With
+              // overflow-y-auto, overflow-x computes to auto (CSS Overflow 3),
+              // so this region clips at its own padding box — which sits
+              // --page-pad inside the shell because the parent column pads it.
+              // That hard-clips the catalog carousel's trailing card instead
+              // of letting it peek to the surface edge. Cancelling the parent
+              // padding here (and re-insetting with px) moves the clip to the
+              // shell edge, where profile-compact-surface already clips.
+              isHomeMode && '-mx-(--page-pad) px-(--page-pad)',
               homeContentScrollClassName,
               showBottomNav ? CONTENT_SAFE_AREA_BOTTOM_PADDING : 'pb-0',
               !isHomeMode &&

--- a/apps/web/tests/unit/profile/profile-compact-template.test.tsx
+++ b/apps/web/tests/unit/profile/profile-compact-template.test.tsx
@@ -445,6 +445,41 @@ describe('ProfileCompactTemplate', () => {
     ).not.toBeInTheDocument();
   });
 
+  // Regression: JOV-3377 — with overflow-y-auto, overflow-x computes to auto
+  // (CSS Overflow 3), so the home scroll region clips at its own padding box.
+  // Without the --page-pad bleed, that clip lands --page-pad inside the shell
+  // and hard-clips the catalog carousel's trailing card instead of letting it
+  // peek to the surface edge.
+  it('bleeds the home content scroll region to the shell edge so the catalog carousel is not clipped', async () => {
+    render(
+      <ProfileCompactTemplate
+        mode='profile'
+        artist={mockArtist}
+        socialLinks={[]}
+        contacts={[]}
+      />
+    );
+
+    const scrollRegion = screen.getByTestId('profile-content-scroll');
+    expect(scrollRegion.className).toContain('-mx-(--page-pad)');
+    expect(scrollRegion.className).toContain('px-(--page-pad)');
+    expect(scrollRegion.className).toContain('overflow-y-auto');
+  });
+
+  it('does not bleed the content scroll region outside home mode', async () => {
+    render(
+      <ProfileCompactTemplate
+        mode='listen'
+        artist={mockArtist}
+        socialLinks={[]}
+        contacts={[]}
+      />
+    );
+
+    const scrollRegion = screen.getByTestId('profile-content-scroll');
+    expect(scrollRegion.className).not.toContain('-mx-(--page-pad)');
+  });
+
   it('can hide the menu trigger for clean marketing screenshots', async () => {
     render(
       <ProfileCompactTemplate


### PR DESCRIPTION
## Summary

On the public artist profile (e.g. jov.ie/tim), the horizontal music-card row hard-clipped the trailing card at the content padding edge instead of letting it peek to the surface edge.

**Root cause:** the home content scroll region (`.profile-content-scroll-region`) sets `overflow-y-auto`. Per CSS Overflow Module Level 3, when one axis is non-visible, `overflow-x: visible` computes to `auto` — so this region clipped horizontal overflow at its own padding box. That box sits `--page-pad` inside the shell because the parent column applies `px-(--page-pad)`, which is exactly where the second card was cut off. It also made the region itself a horizontal scroll container with 2×`--page-pad` of scrollable overflow, which could swallow swipe gestures aimed at the carousel. This defeated the `ReleaseCatalogCarousel` edge-to-edge design (`-mx-(--page-pad)` bleed so cards scroll off the true surface edge), introduced with the JOV-3272 swipeable back-catalog work.

**Fix (smallest correct change):** in home mode only, bleed the scroll region to the shell edge with `-mx-(--page-pad) px-(--page-pad)`. The compensating padding keeps every child's alignment pixel-identical; the horizontal clip boundary moves from the padded content edge to the shell edge, where `profile-compact-surface` already clips via `overflow-hidden`. The carousel's own bleed now works as designed: first card aligned with the padded content above, trailing card peeking cleanly to the surface edge on mobile and desktop. Non-home tabs are untouched.

## Changes

- `apps/web/components/features/profile/templates/ProfileCompactSurface.tsx` — home-mode-only bleed on the content scroll region (+ explanatory comment).
- `apps/web/tests/unit/profile/profile-compact-template.test.tsx` — two regression tests: home mode bleeds the scroll region; non-home modes do not.

## Test plan / results

- `vitest run tests/unit/profile/profile-compact-template.test.tsx tests/unit/profile/ReleaseCatalogCarousel.test.tsx` — 41 passed (includes the 2 new regression tests).
- `vitest run components/organisms/entity-card/EntityCarousel.geometry.test.tsx tests/unit/profile/ProfileHomeRail.test.tsx tests/unit/profile/profile-compact-surface-hero-layout.test.ts tests/unit/profile/profile-compact-subscribe-regression.test.ts tests/unit/profile/public-profile-contract-guard.test.ts tests/unit/profile/profile-shell-token-contract.test.ts` — 23 passed (carousel geometry, swipe rail, viewport-lock and shell contracts all intact, i.e. no regression to JOV-3272 / JOV-1305 behavior).
- `pnpm --filter @jovie/web run typecheck` — clean.
- `pnpm biome check --write` on touched files — clean.
- Full pre-commit gate ladder (conflict markers, gitleaks + trufflehog secrets scan, repo hygiene, lint-staged) passed.

Not run: on-device visual verification at iPhone SE→Pro Max widths (no browser/device available in this environment). The fix restores the carousel's intended full-bleed geometry, which is width-independent (`--page-pad` clamp 16–32px compensated exactly on both axes).

Note: the repo's pinned trufflehog (3.95.5) rejects the `--exclude-globs` flag used by `scripts/security/scan-secrets.sh` in pre-commit (filesystem) mode — the secrets rung is broken on a fresh machine for any commit. I ran the hook with a wrapper that strips the unsupported flag so the real scan still executed (no findings). Filed as a separate infra concern, not fixed here to keep this diff minimal.

Fixes JOV-3377