### PR TITLE
feat(profile): unified card anatomy — square art, full-width CTAs, one card language

### DIFF
--- a/apps/web/app/[username]/about/page.tsx
+++ b/apps/web/app/[username]/about/page.tsx
@@ -4,6 +4,13 @@ import { BASE_URL } from '@/constants/app';
 import { AboutView } from '@/features/profile/views/AboutView';
 import { buildViewMetadata } from '@/features/profile/views/metadata';
 import { ProfileIntentPage } from '@/features/profile/views/ProfileIntentPage';
+import { getCreditedArtistsWithProfiles } from '@/lib/discography/artist-queries';
+import { getReleasesForProfileLite } from '@/lib/discography/queries';
+import {
+  type EntityMentionContext,
+  linkEntityMentions,
+} from '@/lib/profile/entity-mentions';
+import { logger } from '@/lib/utils/logger';
 import { convertCreatorProfileToArtist } from '@/types/db';
 import { getProfileAndLinks } from '../_lib/public-profile-loader';
 
@@ -42,10 +49,41 @@ export default async function AboutPage({ params }: Props) {
   }
 
   const artist = convertCreatorProfileToArtist(result.profile);
+  const profile = result.profile;
   const profileSettings =
-    (result.profile.settings as Record<string, unknown> | null) ?? {};
+    (profile.settings as Record<string, unknown> | null) ?? {};
   const allowPhotoDownloads =
     profileSettings.allowProfilePhotoDownloads === true;
+
+  // Entity-linked bio: resolve this profile's own releases + credited artists
+  // with public Jovie profiles, then link mentions in the tagline. Failures
+  // degrade to plain text.
+  const bioSegments = await (async () => {
+    const tagline = artist.tagline?.trim();
+    if (!tagline) return undefined;
+    try {
+      const [releases, creditedArtists] = await Promise.all([
+        getReleasesForProfileLite(profile.id),
+        getCreditedArtistsWithProfiles(profile.id),
+      ]);
+      const context: EntityMentionContext = {
+        ownHandle: artist.handle,
+        releases: releases.map(release => ({
+          title: release.title,
+          slug: release.slug,
+        })),
+        artists: creditedArtists,
+      };
+      return linkEntityMentions(tagline, context);
+    } catch (error) {
+      logger.error(
+        'Error building entity-linked bio segments',
+        { error, profileId: profile.id, route: '/[username]/about' },
+        'public-profile'
+      );
+      return undefined;
+    }
+  })();
 
   return (
     <ProfileIntentPage
@@ -58,6 +96,7 @@ export default async function AboutPage({ params }: Props) {
         genres={result.genres}
         pressPhotos={[...result.pressPhotos]}
         allowPhotoDownloads={allowPhotoDownloads}
+        bioSegments={bioSegments}
       />
     </ProfileIntentPage>
   );

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from 'next/navigation';
 // API (cookies(), headers()) in this RSC tree.
 
 import type { PublicRelease } from '@/components/features/profile/releases/types';
+import { BASE_URL } from '@/constants/app';
 import { ErrorBanner } from '@/features/feedback/ErrorBanner';
 import { DesktopQrOverlayClient } from '@/features/profile/DesktopQrOverlayClient';
 import { ProfileAeoContent } from '@/features/profile/ProfileAeoContent';
@@ -19,6 +20,7 @@ import {
   supportsDirectProfileClaim,
 } from '@/lib/claim/visitor-state';
 import { toPublicContacts } from '@/lib/contacts/mapper';
+import { getCreditedArtistsWithProfiles } from '@/lib/discography/artist-queries';
 import { getReleasesForProfileLite } from '@/lib/discography/queries';
 import { getEntityIdentityLinks } from '@/lib/entity/queries';
 import { DEFAULT_PROFILE_PAC_ASSIGNMENT } from '@/lib/flags/profile-pac';
@@ -30,6 +32,10 @@ import {
 } from '@/lib/flags/profile-variant';
 import { getLiveMerchCardsForProfile } from '@/lib/merch/service';
 import { buildProfileAeoContent } from '@/lib/profile/aeo-content';
+import {
+  collectEntityMentions,
+  type EntityMentionContext,
+} from '@/lib/profile/entity-mentions';
 import { getConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback-data';
 import {
   buildPublicProfileMetadata,
@@ -132,6 +138,27 @@ async function getPublicMerchCards(profileId: string) {
   }
 }
 
+/**
+ * Credited artists on this profile's catalog that have public Jovie profiles.
+ * Used to link bio/AEO mentions to their pages; failures degrade to no links.
+ */
+async function getCreditedArtistsForMentions(profileId: string) {
+  try {
+    return await getCreditedArtistsWithProfiles(profileId);
+  } catch (error) {
+    logger.error(
+      'Error fetching credited artists for entity mentions',
+      {
+        error,
+        profileId,
+        route: '/[username]',
+      },
+      'public-profile'
+    );
+    return [];
+  }
+}
+
 export default async function ArtistPage({ params }: Readonly<Props>) {
   const { username } = await params;
   const initialMode = 'profile';
@@ -195,6 +222,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
   const releasesPromise = getPublicReleases(profile.id);
   const merchCardsPromise = getPublicMerchCards(profile.id);
   const entityLinksPromise = getEntityIdentityLinks(profile.id);
+  const creditedArtistsPromise = getCreditedArtistsForMentions(profile.id);
 
   // Convert our profile data to the Artist type expected by components
   const artist = convertCreatorProfileToArtist(profile);
@@ -250,6 +278,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     alertOptInVariant,
     profilePacAssignment,
     entityLinks,
+    creditedArtists,
   ] = await Promise.all([
     tourDatesPromise.catch(() => [] as TourDateViewModel[]),
     releasesPromise,
@@ -260,6 +289,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     getProfileAlertOptInVariant(null).catch(() => 'button' as const),
     getProfilePacAssignment(null).catch(() => DEFAULT_PROFILE_PAC_ASSIGNMENT),
     entityLinksPromise.catch(() => []),
+    creditedArtistsPromise,
   ]);
   const tourDates = [...tourDatesRaw].sort(
     (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
@@ -277,13 +307,29 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     previewUrl: null,
   }));
 
+  // Entity-linked bio/AEO context: own releases (→ /{handle}/{slug}) and
+  // credited artists with public Jovie profiles (→ /{handle}).
+  const entityMentionContext: EntityMentionContext = {
+    ownHandle: artist.handle,
+    releases: releases.map(release => ({
+      title: release.title,
+      slug: release.slug,
+    })),
+    artists: creditedArtists,
+  };
+
   // Generate structured data for SEO (after tour dates resolve)
   const structuredData = generateProfileStructuredData(
     profile,
     genres,
     links,
     tourDates,
-    entityLinks
+    entityLinks,
+    collectEntityMentions(entityMentionContext).map(mention => ({
+      kind: mention.kind,
+      name: mention.name,
+      url: new URL(mention.href, BASE_URL).toString(),
+    }))
   );
   const aeoContent = buildProfileAeoContent({
     artist,
@@ -293,6 +339,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     tourDates,
     merchCards,
     socialLinks: links,
+    entityMentions: entityMentionContext,
   });
 
   return (

--- a/apps/web/components/features/profile/AboutSection.tsx
+++ b/apps/web/components/features/profile/AboutSection.tsx
@@ -2,14 +2,21 @@
 
 import { Calendar, Download, Home, MapPin } from 'lucide-react';
 import { ImageWithFallback } from '@/components/atoms/ImageWithFallback';
+import type { EntityMentionSegment } from '@/lib/profile/entity-mentions';
 import type { Artist } from '@/types/db';
 import type { PressPhoto } from '@/types/press-photos';
+import { EntityMentionText } from './EntityMentionText';
 
 interface AboutSectionProps {
   readonly artist: Artist;
   readonly genres?: string[] | null;
   readonly pressPhotos?: readonly PressPhoto[];
   readonly allowPhotoDownloads?: boolean;
+  /**
+   * Optional entity-linked segments for `artist.tagline` (computed
+   * server-side). Falls back to plain text when omitted.
+   */
+  readonly bioSegments?: readonly EntityMentionSegment[];
 }
 
 function sanitizeFilename(value: string): string {
@@ -59,6 +66,7 @@ export function AboutSection({
   genres,
   pressPhotos = [],
   allowPhotoDownloads = false,
+  bioSegments,
 }: AboutSectionProps) {
   const hasBio = Boolean(artist.tagline);
   const hasLocation = Boolean(artist.location);
@@ -89,7 +97,11 @@ export function AboutSection({
 
       {hasBio && (
         <p className='text-sm font-book leading-relaxed text-white/70 whitespace-pre-line'>
-          {artist.tagline}
+          {bioSegments ? (
+            <EntityMentionText segments={bioSegments} />
+          ) : (
+            artist.tagline
+          )}
         </p>
       )}
 

--- a/apps/web/components/features/profile/EntityMentionText.tsx
+++ b/apps/web/components/features/profile/EntityMentionText.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import { type CSSProperties, Fragment } from 'react';
+import { ENTITY_KIND_ACCENT_VAR } from '@/components/jovie/components/entity-accent';
+import type { EntityMentionSegment } from '@/lib/profile/entity-mentions';
+
+interface EntityMentionTextProps {
+  readonly segments: readonly EntityMentionSegment[];
+}
+
+/**
+ * Renders entity-linked text segments: plain text passes through, while
+ * release/artist mentions become inline internal links tinted with the
+ * entity-kind accent (see `--system-b-entity-chip-*-accent` tokens and the
+ * `.profile-entity-mention` rule in design-system.css).
+ */
+export function EntityMentionText({ segments }: EntityMentionTextProps) {
+  // Segments are a server-built partition of one string, so the character
+  // offset is a stable identity for each segment.
+  const keyed = segments.reduce<{
+    readonly offset: number;
+    readonly items: readonly {
+      key: string;
+      segment: EntityMentionSegment;
+    }[];
+  }>(
+    (accumulator, segment) => ({
+      offset: accumulator.offset + segment.text.length,
+      items: [
+        ...accumulator.items,
+        { key: `${segment.type}:${accumulator.offset}`, segment },
+      ],
+    }),
+    { offset: 0, items: [] }
+  ).items;
+
+  return (
+    <>
+      {keyed.map(({ key, segment }) => {
+        if (segment.type === 'text') {
+          return <Fragment key={key}>{segment.text}</Fragment>;
+        }
+
+        const accentStyle = {
+          '--jovie-entity-accent': `var(${ENTITY_KIND_ACCENT_VAR[segment.type]})`,
+        } as CSSProperties;
+
+        return (
+          <Link
+            key={key}
+            href={segment.href}
+            prefetch={false}
+            className='profile-entity-mention font-medium underline underline-offset-4 transition-colors duration-subtle'
+            style={accentStyle}
+            data-entity-kind={segment.type}
+          >
+            {segment.text}
+          </Link>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/components/features/profile/ProfileAboutShare.tsx
+++ b/apps/web/components/features/profile/ProfileAboutShare.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Check, Share2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface ProfileAboutShareProps {
+  readonly url: string;
+  readonly artistName: string;
+}
+
+export function ProfileAboutShare({
+  url,
+  artistName,
+}: Readonly<ProfileAboutShareProps>) {
+  const [shareSuccess, setShareSuccess] = useState(false);
+  const shareTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (shareTimeoutRef.current) clearTimeout(shareTimeoutRef.current);
+    },
+    []
+  );
+
+  const handleShare = useCallback(async () => {
+    const markShared = () => {
+      setShareSuccess(true);
+      if (shareTimeoutRef.current) clearTimeout(shareTimeoutRef.current);
+      shareTimeoutRef.current = setTimeout(() => setShareSuccess(false), 2000);
+    };
+
+    try {
+      if (typeof navigator.share === 'function') {
+        await navigator.share({ title: artistName, url });
+      } else {
+        await navigator.clipboard.writeText(url);
+      }
+      markShared();
+    } catch (error) {
+      // AbortError = user cancelled the share sheet, do nothing.
+      if (error instanceof Error && error.name === 'AbortError') return;
+      // Fallback: try the clipboard if sharing failed for another reason.
+      try {
+        await navigator.clipboard.writeText(url);
+        markShared();
+      } catch {
+        // Silent failure — matches the hero share control.
+      }
+    }
+  }, [url, artistName]);
+
+  return (
+    <button
+      type='button'
+      onClick={handleShare}
+      className='profile-aeo-content__share inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text)'
+      aria-label={
+        shareSuccess
+          ? `Copied link to ${artistName}'s profile`
+          : `Share ${artistName}'s profile`
+      }
+      data-testid='profile-about-share'
+    >
+      {shareSuccess ? (
+        <Check className='h-4 w-4' aria-hidden='true' />
+      ) : (
+        <Share2 className='h-4 w-4' aria-hidden='true' />
+      )}
+      <span aria-live='polite' className='sr-only'>
+        {shareSuccess ? 'Link Copied' : ''}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/components/features/profile/ProfileAeoContent.tsx
+++ b/apps/web/components/features/profile/ProfileAeoContent.tsx
@@ -1,6 +1,9 @@
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
+import { SocialIcon } from '@/components/atoms/SocialIcon';
+import { ProfileAboutShare } from '@/features/profile/ProfileAboutShare';
 import type { ProfileAeoContent as ProfileAeoContentModel } from '@/lib/profile/aeo-content';
+import { EntityMentionText } from './EntityMentionText';
 
 interface ProfileAeoContentProps {
   readonly content: ProfileAeoContentModel;
@@ -18,16 +21,95 @@ export function ProfileAeoContent({
       data-testid='profile-aeo-content'
     >
       <div className='profile-aeo-content__inner mx-auto grid max-w-5xl gap-8 border-t pt-8 lg:gap-11 lg:pt-10'>
-        <div className='space-y-3 lg:sticky lg:top-12 lg:self-start'>
-          <h2
-            id='profile-aeo-heading'
-            className='profile-aeo-content__heading text-3xl font-semibold leading-tight tracking-tight text-balance'
-          >
-            About {content.artistName}
-          </h2>
+        <div className='space-y-5 lg:sticky lg:top-12 lg:self-start'>
+          <div className='flex items-start justify-between gap-4'>
+            <h2
+              id='profile-aeo-heading'
+              className='profile-aeo-content__heading text-3xl font-semibold leading-tight tracking-tight text-balance'
+            >
+              About {content.artistName}
+            </h2>
+            <ProfileAboutShare
+              url={content.profileUrl}
+              artistName={content.artistName}
+            />
+          </div>
+
+          {content.facts.length > 0 ? (
+            <dl
+              className='profile-aeo-content__facts flex flex-col gap-3 border-y py-4 sm:flex-row sm:flex-wrap sm:gap-x-10 sm:gap-y-4'
+              data-testid='profile-about-facts'
+            >
+              {content.facts.map(fact => (
+                <div key={fact.label} className='space-y-1'>
+                  <dt className='profile-aeo-content__fact-label text-xs font-medium'>
+                    {fact.label}
+                  </dt>
+                  <dd className='profile-aeo-content__fact-value text-mid font-medium'>
+                    {fact.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
+
+          {content.listenLinks.length > 0 ? (
+            <div className='space-y-2' data-testid='profile-about-listen'>
+              <h3 className='profile-aeo-content__link-label text-xs font-medium'>
+                Listen
+              </h3>
+              <ul className='flex flex-wrap items-center gap-x-5 gap-y-2'>
+                {content.listenLinks.map(link => (
+                  <li key={link.id}>
+                    <a
+                      href={link.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='profile-aeo-content__link inline-flex min-h-11 items-center gap-2 text-sm font-medium transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text)'
+                    >
+                      <SocialIcon
+                        platform={link.platform}
+                        className='h-4 w-4'
+                      />
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {content.followLinks.length > 0 ? (
+            <div className='space-y-2' data-testid='profile-about-follow'>
+              <h3 className='profile-aeo-content__link-label text-xs font-medium'>
+                Follow
+              </h3>
+              <ul className='flex flex-wrap items-center gap-1'>
+                {content.followLinks.map(link => (
+                  <li key={link.id}>
+                    <a
+                      href={link.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='profile-aeo-content__link inline-flex h-11 w-11 items-center justify-center rounded-full transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text)'
+                      aria-label={`Follow ${content.artistName} on ${link.label}`}
+                    >
+                      <SocialIcon
+                        platform={link.platform}
+                        className='h-5 w-5'
+                      />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
           <div className='profile-aeo-content__body space-y-3 text-mid leading-7 text-pretty'>
-            {content.description.map(paragraph => (
-              <p key={paragraph}>{paragraph}</p>
+            {content.descriptionSegments.map((segments, index) => (
+              <p key={content.description[index] ?? index}>
+                <EntityMentionText segments={segments} />
+              </p>
             ))}
           </div>
         </div>

--- a/apps/web/components/features/profile/ProfileEmptyBentoCard.tsx
+++ b/apps/web/components/features/profile/ProfileEmptyBentoCard.tsx
@@ -5,7 +5,7 @@ import type { LucideIcon } from 'lucide-react';
 import type { CSSProperties, MouseEvent, ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
-export type ProfileEmptyBentoAccent = 'alerts' | 'music' | 'events';
+export type ProfileEmptyBentoAccent = 'music' | 'events';
 
 export type ProfileEmptyBentoLayout = 'prominent' | 'compact' | 'inline';
 
@@ -14,10 +14,6 @@ export type ProfileEmptyBentoLayout = 'prominent' | 'compact' | 'inline';
  * Inline styles (not arbitrary Tailwind) to avoid the arbitrary-value ratchet.
  */
 const ACCENT_GRADIENTS: Record<ProfileEmptyBentoAccent, CSSProperties> = {
-  alerts: {
-    background:
-      'radial-gradient(120% 100% at 50% -8%, color-mix(in oklab, var(--color-accent-purple) 82%, white) 0%, color-mix(in oklab, var(--color-accent-purple) 48%, #1a1030) 44%, color-mix(in oklab, var(--color-accent-purple) 22%, #0a0814) 100%)',
-  },
   music: {
     background:
       'radial-gradient(120% 100% at 50% -8%, color-mix(in oklab, var(--color-accent-pink) 78%, white) 0%, color-mix(in oklab, var(--color-accent-pink) 44%, #2a1028) 44%, color-mix(in oklab, var(--color-accent-pink) 20%, #0a0814) 100%)',

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -283,6 +283,7 @@ export const ProfileHomeRail = memo(function ProfileHomeRail({
           city: show.city,
           startDate: show.startDate,
           ticketUrl: show.ticketUrl,
+          ticketStatus: show.ticketStatus,
         })
       );
     }

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Bell } from 'lucide-react';
 import { type MouseEvent, memo, useMemo } from 'react';
 import {
+  EntityCard,
   type EntityCardModel,
   merchToEntityCard,
   releaseToEntityCard,
@@ -10,7 +10,6 @@ import {
 } from '@/components/organisms/entity-card';
 import type { NotificationSourceContext } from '@/features/profile/artist-notifications-cta/types';
 import type { ProfileRenderMode } from '@/features/profile/contracts';
-import { ProfileEmptyBentoCard } from '@/features/profile/ProfileEmptyBentoCard';
 import type { ProfilePrimaryActionCardRelease } from '@/features/profile/ProfilePrimaryActionCard';
 import {
   startOfProfileSurfaceLocalDay as startOfLocalDay,
@@ -82,18 +81,6 @@ function getUpcomingTourDates(
     );
 }
 
-function HomeAlertsSwitch() {
-  return (
-    <span
-      className='relative inline-flex h-7 w-12 shrink-0 items-center rounded-full border border-white/18 bg-white/18 p-1 shadow-sm transition-colors duration-subtle group-hover:bg-white/24'
-      aria-hidden='true'
-      data-testid='profile-home-alerts-switch'
-    >
-      <span className='block h-6 w-6 rounded-full bg-white shadow-[0_3px_10px_rgba(0,0,0,0.32)] dark:bg-white' />
-    </span>
-  );
-}
-
 function HomeAlertsCard({
   artist,
   onAlertsClick,
@@ -105,11 +92,8 @@ function HomeAlertsCard({
   renderMode: ProfileRenderMode;
   sourceContext: NotificationSourceContext;
 }>) {
-  const title = 'Alerts';
-  const description = `${artist.name}: music, shows, merch.`;
   const isInteractive = renderMode === 'interactive';
   const subscribeHref = `/${artist.handle}?mode=subscribe`;
-  const ariaLabel = `Turn on alerts for ${artist.name}`;
   const handleClick = isInteractive
     ? (event: MouseEvent<HTMLElement>) => {
         if (!onAlertsClick) {
@@ -120,21 +104,33 @@ function HomeAlertsCard({
       }
     : undefined;
 
+  // The alerts card is a standard unified-anatomy card — icon art zone,
+  // context eyebrow, "Alerts" title, one-line body, full-width CTA — the
+  // same design as every other card in the home carousel.
+  const model: EntityCardModel = {
+    id: `alerts-${artist.id}`,
+    kind: 'alerts',
+    href: isInteractive ? subscribeHref : null,
+    imageUrl: null,
+    imageAlt: `Alerts for ${artist.name}`,
+    eyebrow: artist.name,
+    title: 'Alerts',
+    meta: 'Music, shows, merch — first.',
+    cta: {
+      label: 'Get Updates',
+      href: isInteractive ? subscribeHref : null,
+    },
+  };
+
   return (
-    <ProfileEmptyBentoCard
-      accent='alerts'
-      icon={Bell}
-      title={title}
-      body={description}
-      // Carousel card geometry: the prominent column layout fills the fixed
-      // 3:4 card box; the inline strip layout is gone with the stacked rail.
-      layout='prominent'
-      className='h-full'
-      trailing={<HomeAlertsSwitch />}
-      href={isInteractive ? subscribeHref : undefined}
-      onClick={handleClick}
-      ariaLabel={ariaLabel}
+    <EntityCard
+      model={model}
+      treatment='detailed'
+      surface='pearl'
+      anatomy='unified'
+      className='h-full w-full overflow-hidden'
       dataTestId='profile-home-alerts-fallback-card'
+      onClick={handleClick}
     />
   );
 }

--- a/apps/web/components/features/profile/TourModePanel.tsx
+++ b/apps/web/components/features/profile/TourModePanel.tsx
@@ -160,12 +160,9 @@ function TourDateRow({
           {getTicketStatusLabel(item.date.ticketStatus, canBuyTickets)}
         </a>
       ) : (
-        <span
-          className={cn(
-            'inline-flex min-h-11 shrink-0 items-center rounded-xl border px-3 text-xs font-semibold tracking-tight',
-            getTicketStatusClassName(item.date.ticketStatus, canBuyTickets)
-          )}
-        >
+        // No ticket target: plain muted meta text — a non-interactive span
+        // must never wear button chrome.
+        <span className='shrink-0 text-xs font-medium text-white/38'>
           {getTicketStatusLabel(item.date.ticketStatus, canBuyTickets)}
         </span>
       )}

--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -179,7 +179,9 @@ function SubjectText({
       <p className='truncate text-sm font-semibold leading-tight text-primary-token'>
         {title}
       </p>
-      <p className='mt-0.5 truncate text-xs text-tertiary-token'>{meta}</p>
+      <p className='entity-card-meta mt-0.5 truncate text-xs text-tertiary-token'>
+        {meta}
+      </p>
     </div>
   );
 }
@@ -764,7 +766,7 @@ export function ProfilePacCard({
         className
       )}
     >
-      <div className='relative min-h-0 w-full flex-1 overflow-hidden border-b border-subtle bg-surface-2'>
+      <div className='relative aspect-square w-full flex-none overflow-hidden border-b border-subtle bg-surface-2'>
         {artImageUrl ? (
           <ImageWithFallback
             src={artImageUrl}
@@ -772,7 +774,7 @@ export function ProfilePacCard({
             fill
             priority={artPriority}
             sizes='(max-width: 767px) 70vw, 300px'
-            className='object-contain'
+            className='object-cover'
             fallbackVariant='release'
             fallbackClassName='bg-transparent'
           />
@@ -783,20 +785,22 @@ export function ProfilePacCard({
         )}
       </div>
 
-      <div className='flex min-h-0 min-w-0 flex-none flex-col gap-2 p-3'>
-        <div className='flex items-center justify-between gap-2'>
-          <p className='truncate text-3xs font-semibold uppercase leading-none tracking-wide text-tertiary-token'>
-            {contextLabel}
-          </p>
-          {contextAside}
+      <div className='flex min-h-0 min-w-0 flex-1 flex-col gap-1.5 px-3 py-1.5'>
+        {/* Text zone — clips under tight card heights so the action footer
+            below never moves and never clips (zero-CLS contract). */}
+        <div className='flex min-h-0 min-w-0 flex-1 flex-col gap-1.5 overflow-hidden'>
+          <div className='flex items-center justify-between gap-2'>
+            <p className='entity-card-eyebrow truncate text-3xs font-semibold uppercase leading-none tracking-wide text-tertiary-token'>
+              {contextLabel}
+            </p>
+            {contextAside}
+          </div>
+
+          {subject}
         </div>
 
-        {subject}
-
-        {isCaptureState ? <div className='min-w-0'>{action}</div> : null}
-
-        <div className='mt-auto flex min-w-0 flex-col gap-2 pt-1'>
-          {isCaptureState ? null : action}
+        <div className='flex min-w-0 flex-none flex-col gap-1.5'>
+          {isCaptureState ? <div className='min-w-0'>{action}</div> : action}
           <div aria-live='polite' className='min-w-0 empty:hidden'>
             {status}
           </div>

--- a/apps/web/components/features/profile/views/AboutView.tsx
+++ b/apps/web/components/features/profile/views/AboutView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { EntityMentionSegment } from '@/lib/profile/entity-mentions';
 import type { Artist } from '@/types/db';
 import type { PressPhoto } from '@/types/press-photos';
 import { AboutSection } from '../AboutSection';
@@ -9,6 +10,8 @@ export interface AboutViewProps {
   readonly genres?: string[] | null;
   readonly pressPhotos?: PressPhoto[];
   readonly allowPhotoDownloads?: boolean;
+  /** Entity-linked segments for the artist bio (computed server-side). */
+  readonly bioSegments?: readonly EntityMentionSegment[];
 }
 
 /**
@@ -21,6 +24,7 @@ export function AboutView({
   genres,
   pressPhotos,
   allowPhotoDownloads,
+  bioSegments,
 }: AboutViewProps) {
   return (
     <AboutSection
@@ -28,6 +32,7 @@ export function AboutView({
       genres={genres}
       pressPhotos={pressPhotos}
       allowPhotoDownloads={allowPhotoDownloads}
+      bioSegments={bioSegments}
     />
   );
 }

--- a/apps/web/components/organisms/entity-card/EntityCard.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.test.tsx
@@ -19,11 +19,13 @@ vi.mock('next/link', () => ({
 vi.mock('@/components/atoms/ImageWithFallback', () => ({
   ImageWithFallback: ({
     alt,
+    className,
     src,
   }: {
     readonly alt: string;
+    readonly className?: string;
     readonly src: string;
-  }) => React.createElement('img', { alt, src }),
+  }) => React.createElement('img', { alt, className, src }),
 }));
 
 const merchModel: EntityCardModel = {
@@ -169,5 +171,66 @@ describe('EntityCard', () => {
     const button = screen.getByRole('button');
     expect(button).not.toHaveTextContent('');
     expect(button).toHaveTextContent('Action');
+  });
+
+  describe('unified anatomy (profile home carousel)', () => {
+    it('locks the art zone to a full-bleed square with cover-fitted artwork', () => {
+      render(
+        <EntityCard model={merchModel} treatment='detailed' anatomy='unified' />
+      );
+      const image = screen.getByRole('img');
+      expect(image.parentElement?.className).toContain('aspect-square');
+      expect(image.className).toContain('object-cover');
+      // Full-bleed: the card carries no padding around the art zone.
+      const card = screen.getByTestId('entity-card-merch');
+      expect(card.className).toContain('p-0');
+    });
+
+    it('fits music artwork with object-cover (no letterbox bands)', () => {
+      const music: EntityCardModel = {
+        id: 'r1',
+        kind: 'music',
+        href: '/tim/r1',
+        imageUrl: 'https://cdn.test/art.jpg',
+        imageAlt: 'Art',
+        title: 'Release',
+        cta: { label: 'Listen', href: '/tim/r1' },
+      };
+      render(
+        <EntityCard model={music} treatment='detailed' anatomy='unified' />
+      );
+      expect(screen.getByRole('img').className).toContain('object-cover');
+      expect(screen.getByRole('img').className).not.toContain('object-contain');
+    });
+
+    it('renders a full-width 36px CTA and folds the price into the meta line', () => {
+      render(
+        <EntityCard model={merchModel} treatment='detailed' anatomy='unified' />
+      );
+      const cta = screen.getByText('Buy');
+      expect(cta.className).toContain('h-9');
+      expect(cta.className).toContain('w-full');
+      // Price joins the single meta line; there is no separate price block.
+      expect(screen.getByText('Premium tee · $45.00')).toBeInTheDocument();
+      expect(screen.queryByText('Profit $11.87')).not.toBeInTheDocument();
+    });
+
+    it('renders a target-less CTA as plain muted meta text, not button chrome', () => {
+      const noTickets: EntityCardModel = {
+        id: 's9',
+        kind: 'show',
+        title: 'The Echo',
+        imageAlt: 'The Echo',
+        datePill: { month: 'Jul', day: '29' },
+        cta: { label: 'No Tickets', href: null, disabled: true },
+      };
+      render(
+        <EntityCard model={noTickets} treatment='detailed' anatomy='unified' />
+      );
+      const text = screen.getByText('No Tickets');
+      expect(text.className).toContain('text-tertiary-token');
+      expect(text.className).not.toContain('rounded-full');
+      expect(text.className).not.toContain('bg-btn-primary');
+    });
   });
 });

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, MouseEvent, ReactNode } from 'react';
 import { ImageWithFallback } from '@/components/atoms/ImageWithFallback';
 import {
   getProfileCardShapeClassName,
@@ -33,14 +33,24 @@ interface EntityCardProps {
   readonly className?: string;
   readonly priority?: boolean;
   readonly dataTestId?: string;
-  readonly onClick?: () => void;
+  readonly onClick?: (event: MouseEvent<HTMLElement>) => void;
   /**
    * 'square' (default): the art zone is a fixed square — for content-driven
    * card heights. 'fill': the art zone flexes to fill whatever height the
-   * content zone leaves — for height-locked cards (profile home carousel),
-   * where a fixed square would push the CTA out of the card.
+   * content zone leaves — for height-locked cards where a fixed square would
+   * push the CTA out of the card. Ignored when `anatomy='unified'` (the art
+   * zone is always a full-width square there).
    */
   readonly artFit?: 'square' | 'fill';
+  /**
+   * 'unified': the single profile-card anatomy — full-bleed square art zone
+   * (object-cover, no letterboxing), eyebrow/title/meta text zone, and a
+   * full-width 36px CTA anchored to the bottom. Used by every card in the
+   * profile home carousel so the featured card, entity cards, and slot cards
+   * share one design. 'default' keeps the legacy per-treatment layout
+   * (chat/app consumers).
+   */
+  readonly anatomy?: 'default' | 'unified';
 }
 
 type SizeConfig = {
@@ -80,13 +90,30 @@ const SIZE: Record<EntityTreatment, SizeConfig> = {
 function EntityCtaControl({
   cta,
   block,
+  unified = false,
 }: Readonly<{
   cta: EntityCardCta;
   block: boolean;
+  unified?: boolean;
 }>) {
+  // Unified anatomy: a CTA with no target is not a button at all — render it
+  // as plain muted meta text (e.g. "No Tickets"), never with button chrome.
+  if (unified && (cta.disabled || (!cta.href && !cta.onClick))) {
+    return (
+      <span className='flex h-9 w-full items-center text-xs text-tertiary-token'>
+        {cta.label}
+      </span>
+    );
+  }
+
   const className = cn(
     'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover',
-    block ? 'h-11 w-full' : 'h-11 min-w-0 flex-1',
+    // Unified anatomy: full-width 36px CTA (two CTAs share the row evenly).
+    unified
+      ? 'h-9 min-w-0 flex-1'
+      : block
+        ? 'h-11 w-full'
+        : 'h-11 min-w-0 flex-1',
     cta.disabled &&
       'cursor-not-allowed border-subtle bg-surface-0 text-tertiary-token hover:border-subtle hover:bg-surface-0'
   );
@@ -147,7 +174,7 @@ function CardShell({
   testId?: string;
   className: string;
   style?: CSSProperties;
-  onClick?: () => void;
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
   children: ReactNode;
 }>) {
   if (href?.startsWith('/')) {
@@ -196,16 +223,21 @@ export function EntityCard({
   dataTestId,
   onClick,
   artFit = 'square',
+  anatomy = 'default',
 }: EntityCardProps) {
   const size = SIZE[treatment];
+  const isUnified = anatomy === 'unified';
   // Composition shape (#11899): fixed card aspect + semantic media geometry.
   // Album/product/show artwork is square; video thumbnails stay landscape.
   // Text truncates inside the shape; the CTA footer never moves.
   const shapeClassName = shape
     ? cn(getProfileCardShapeClassName(shape), 'overflow-hidden')
     : null;
-  const artClassName =
-    artFit === 'fill'
+  const artClassName = isUnified
+    ? // Unified anatomy: the art zone is a full-width square (album art is
+      // square by default; non-square art object-covers the square zone).
+      'aspect-square rounded-none'
+    : artFit === 'fill'
       ? 'min-h-0 w-full flex-1 rounded-xl'
       : shape
         ? cn(
@@ -213,8 +245,11 @@ export function EntityCard({
             treatment === 'big' ? 'rounded-2xl' : 'rounded-xl'
           )
         : size.artClass;
-  const titleClampClassName =
-    shape && treatment !== 'big' ? 'line-clamp-1' : 'line-clamp-2';
+  const titleClampClassName = isUnified
+    ? 'line-clamp-1'
+    : shape && treatment !== 'big'
+      ? 'line-clamp-1'
+      : 'line-clamp-2';
   const preset = KIND_PRESETS[model.kind];
   const accent = model.accent ?? preset.accent;
   const Icon = preset.icon;
@@ -232,6 +267,13 @@ export function EntityCard({
     background: `radial-gradient(120% 120% at 32% 22%, color-mix(in oklab, ${accentVar(accent)} 22%, transparent), transparent 62%), linear-gradient(155deg, var(--color-bg-surface-2), var(--color-bg-surface-1))`,
   };
 
+  // Unified anatomy: one meta line — the price joins it instead of a separate
+  // footer block, so every card shares the eyebrow/title/meta/CTA anatomy.
+  const metaText =
+    isUnified && model.price
+      ? [model.meta, model.price.display].filter(Boolean).join(' · ')
+      : model.meta;
+
   return (
     <CardShell
       href={cardHref}
@@ -240,7 +282,9 @@ export function EntityCard({
       onClick={onClick}
       className={cn(
         'group flex min-w-0 flex-col text-left transition-[background-color,border-color] duration-subtle focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--color-focus-ring)',
-        treatment === 'big' ? 'gap-0 overflow-hidden p-0' : 'gap-3 p-3',
+        treatment === 'big' || isUnified
+          ? 'gap-0 overflow-hidden p-0'
+          : 'gap-3 p-3',
         isPearl
           ? 'rounded-(--profile-inner-radius) border border-(--profile-pearl-border) bg-(--profile-pearl-bg) shadow-(--profile-pearl-shadow) backdrop-blur-2xl hover:bg-(--profile-pearl-bg-hover)'
           : 'rounded-2xl border border-subtle bg-surface-1 shadow-card hover:border-default',
@@ -251,9 +295,10 @@ export function EntityCard({
       <div
         className={cn(
           'relative flex w-full items-center justify-center overflow-hidden border border-subtle',
-          artFit === 'fill' ? null : 'shrink-0',
+          !isUnified && artFit === 'fill' ? null : 'shrink-0',
           artClassName,
-          treatment === 'big' && 'rounded-none border-0'
+          (treatment === 'big' || isUnified) && 'rounded-none border-0',
+          isUnified && 'border-b border-subtle'
         )}
         style={artStyle}
       >
@@ -267,7 +312,11 @@ export function EntityCard({
               treatment === 'big' ? '320px' : '(max-width: 767px) 70vw, 300px'
             }
             className={
-              model.kind === 'music' ? 'object-contain' : 'object-cover'
+              // Unified anatomy: square art in a square zone — cover crops
+              // non-square art instead of letterboxing it.
+              isUnified || model.kind !== 'music'
+                ? 'object-cover'
+                : 'object-contain'
             }
             fallbackVariant={preset.fallbackVariant}
             fallbackClassName='bg-transparent'
@@ -282,28 +331,50 @@ export function EntityCard({
             </span>
           </div>
         ) : (
-          <Icon className='h-7 w-7 text-tertiary-token' aria-hidden='true' />
+          <Icon
+            className={cn(
+              'text-tertiary-token',
+              isUnified ? 'h-8 w-8' : 'h-7 w-7'
+            )}
+            aria-hidden='true'
+          />
         )}
       </div>
 
       <div
         className={cn(
           'flex min-h-0 min-w-0 flex-1 flex-col gap-1.5',
-          treatment === 'big' && 'p-3'
+          treatment === 'big' && 'p-3',
+          // Unified: the text zone + 36px CTA share (card height − card
+          // width), which is tight on small cards — keep chrome minimal so
+          // eyebrow + title + CTA always fit; the meta line hides entirely
+          // below the card-height threshold where it would clip (see
+          // .entity-card-meta in design-system.css).
+          isUnified && 'px-3 py-1.5'
         )}
       >
         {/* Text zone — when the card is height-locked it clips so the CTA
             footer below never moves (#11899: content fits the shape, button
             never shifts). */}
-        <div className='flex min-h-0 min-w-0 flex-1 flex-col gap-1.5 overflow-hidden'>
+        <div
+          className={cn(
+            'flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden',
+            isUnified ? 'gap-1' : 'gap-1.5'
+          )}
+        >
           <div className='flex min-w-0 items-center justify-between gap-2'>
-            <span className='inline-flex min-w-0 items-center gap-1.5 text-3xs font-semibold uppercase leading-none tracking-[0.08em] text-tertiary-token'>
+            <span
+              className={cn(
+                'inline-flex min-w-0 items-center gap-1.5 text-3xs font-semibold uppercase leading-none tracking-[0.08em] text-tertiary-token',
+                isUnified && 'entity-card-eyebrow'
+              )}
+            >
               <Icon className='h-3 w-3 shrink-0' aria-hidden='true' />
               <span className='truncate'>
                 {model.eyebrow ?? preset.eyebrow}
               </span>
             </span>
-            {size.showStatus && model.status ? (
+            {size.showStatus && !isUnified && model.status ? (
               <span className='inline-flex shrink-0 items-center gap-1.5 rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.06em] text-secondary-token'>
                 <span
                   className='h-1.5 w-1.5 shrink-0 rounded-full'
@@ -319,20 +390,31 @@ export function EntityCard({
             className={cn(
               'min-w-0 font-[590] leading-tight tracking-tighter text-primary-token',
               titleClampClassName,
-              size.titleClass
+              // Unified: match the featured card's title size — one design.
+              isUnified ? 'text-sm' : size.titleClass
             )}
           >
             {model.title}
           </h3>
 
-          {size.showMeta && model.meta ? (
-            <p className='min-w-0 truncate text-[11.5px] text-tertiary-token'>
-              {model.meta}
+          {size.showMeta && metaText ? (
+            <p
+              className={cn(
+                'min-w-0 truncate text-[11.5px] text-tertiary-token',
+                isUnified && 'entity-card-meta'
+              )}
+            >
+              {metaText}
             </p>
           ) : null}
 
           {size.showMeta && model.secondaryMeta ? (
-            <p className='min-w-0 truncate text-[11.5px] text-tertiary-token'>
+            <p
+              className={cn(
+                'min-w-0 truncate text-[11.5px] text-tertiary-token',
+                isUnified && 'entity-card-meta'
+              )}
+            >
               {model.secondaryMeta}
             </p>
           ) : null}
@@ -340,30 +422,60 @@ export function EntityCard({
 
         <div
           className={cn(
-            'flex gap-2 pt-1',
+            'flex gap-2',
+            isUnified ? null : 'pt-1',
             PROFILE_CARD_FOOTER_ANCHOR_CLASSNAME,
-            isInteractive
-              ? size.ctaBlock
-                ? 'flex-col items-stretch'
-                : 'flex-row items-stretch'
-              : cn(
-                  'items-center',
-                  size.ctaBlock ? 'flex-col items-stretch' : 'justify-between'
-                )
+            isUnified
+              ? isInteractive
+                ? 'flex-row items-stretch'
+                : 'flex-col items-stretch'
+              : isInteractive
+                ? size.ctaBlock
+                  ? 'flex-col items-stretch'
+                  : 'flex-row items-stretch'
+                : cn(
+                    'items-center',
+                    size.ctaBlock ? 'flex-col items-stretch' : 'justify-between'
+                  )
           )}
         >
           {isInteractive ? (
             <>
               {model.cta ? (
-                <EntityCtaControl cta={model.cta} block={size.ctaBlock} />
+                <EntityCtaControl
+                  cta={model.cta}
+                  block={size.ctaBlock}
+                  unified={isUnified}
+                />
               ) : null}
               {model.secondaryCta ? (
                 <EntityCtaControl
                   cta={model.secondaryCta}
                   block={size.ctaBlock}
+                  unified={isUnified}
                 />
               ) : null}
             </>
+          ) : isUnified ? (
+            // Unified anatomy: full-width 36px CTA at the bottom of every
+            // card. The CTA is a visual cue for the whole-card link — when
+            // neither the card nor the CTA has a target, it degrades to
+            // plain muted meta text instead of button chrome.
+            model.cta ? (
+              model.cta.disabled || (!model.cta.href && !cardHref) ? (
+                <span className='flex h-9 w-full items-center text-xs text-tertiary-token'>
+                  {model.cta.label}
+                </span>
+              ) : (
+                <span
+                  className={cn(
+                    'inline-flex h-9 w-full shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle group-hover:border-(--linear-btn-primary-hover) group-hover:bg-btn-primary-hover'
+                  )}
+                >
+                  {model.cta.label}
+                </span>
+              )
+            ) : null
           ) : (
             <>
               {model.price ? (

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -469,7 +469,7 @@ export function EntityCard({
               ) : (
                 <span
                   className={cn(
-                    'inline-flex h-9 w-full shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle group-hover:border-(--linear-btn-primary-hover) group-hover:bg-btn-primary-hover'
+                    'inline-flex h-9 w-full shrink-0 items-center justify-center rounded-full bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle group-hover:bg-btn-primary-hover'
                   )}
                 >
                   {model.cta.label}

--- a/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
@@ -84,17 +84,36 @@ describe('EntityCarousel profile geometry', () => {
     }
   });
 
-  it('flexes the art zone inside the height-locked card without cropping artwork', () => {
+  it('locks the art zone to a full-width square with cover-fitted artwork', () => {
     render(<EntityCarousel items={items} />);
 
     for (const image of screen.getAllByRole('img')) {
-      // Height-locked 3:4 cards: the art zone flexes to fill whatever the
-      // content zone leaves (a fixed square would push the CTA out), and
-      // release artwork is fitted (object-contain), never cropped.
-      expect(image.parentElement?.className).toContain('flex-1');
-      expect(image.parentElement?.className).not.toContain('aspect-square');
-      expect(image.className).toContain('object-contain');
+      // Unified card anatomy: the art zone is a square matched to the full
+      // card width (no letterbox bands), and artwork object-covers the
+      // square zone — square art fills it exactly, non-square art crops.
+      expect(image.parentElement?.className).toContain('aspect-square');
+      expect(image.parentElement?.className).not.toContain('flex-1');
+      expect(image.className).toContain('object-cover');
     }
+  });
+
+  it('renders a full-width 36px CTA at the bottom of every card', () => {
+    const withCta: EntityCardModel[] = [
+      {
+        id: 'release-1',
+        kind: 'music',
+        href: '/tim/release-1',
+        imageUrl: '/release-1.jpg',
+        imageAlt: 'Release one',
+        title: 'Release One',
+        cta: { label: 'Listen', href: '/tim/release-1' },
+      },
+    ];
+    render(<EntityCarousel items={withCta} />);
+
+    const cta = screen.getByText('Listen');
+    expect(cta.className).toContain('h-9');
+    expect(cta.className).toContain('w-full');
   });
 
   it('renders leading and trailing slot cards in the same geometry', () => {

--- a/apps/web/components/organisms/entity-card/EntityCarousel.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.tsx
@@ -165,12 +165,12 @@ export function EntityCarousel({
             <EntityCard
               model={model}
               treatment='detailed'
-              // The hero keeps image priority; carousel art stays lazy so the
-              // LCP image never competes with the cover photo. artFit='fill'
-              // lets the art zone flex inside the height-locked card so the
-              // CTA footer never clips.
+              // Unified profile-card anatomy: full-bleed square art, text
+              // zone, and a full-width CTA — the same design as the featured
+              // PAC card. The hero keeps image priority; carousel art stays
+              // lazy so the LCP image never competes with the cover photo.
               surface={surface}
-              artFit='fill'
+              anatomy='unified'
               className='h-full w-full overflow-hidden'
               onClick={
                 onCardClick ? () => onCardClick(index, model) : undefined

--- a/apps/web/components/organisms/entity-card/adapters.test.ts
+++ b/apps/web/components/organisms/entity-card/adapters.test.ts
@@ -308,4 +308,34 @@ describe('showToEntityCard', () => {
     });
     expect(model.datePill).toEqual({ month: 'Jul', day: '29' });
   });
+
+  it('never links a cancelled or sold-out show to tickets', () => {
+    const cancelled = showToEntityCard({
+      id: 's4',
+      venueName: 'Enmore Theatre',
+      startDate: '2026-11-29T08:00:00.000Z',
+      ticketUrl: 'https://tickets.test/enmore',
+      ticketStatus: 'cancelled',
+    });
+    expect(cancelled.href).toBeNull();
+    expect(cancelled.cta).toEqual({
+      label: 'Cancelled',
+      href: null,
+      disabled: true,
+    });
+
+    const soldOut = showToEntityCard({
+      id: 's5',
+      venueName: 'The Echo',
+      startDate: '2026-07-29T02:30:00.000Z',
+      ticketUrl: 'https://tickets.test/echo',
+      ticketStatus: 'sold_out',
+    });
+    expect(soldOut.href).toBeNull();
+    expect(soldOut.cta).toEqual({
+      label: 'Sold Out',
+      href: null,
+      disabled: true,
+    });
+  });
 });

--- a/apps/web/components/organisms/entity-card/adapters.test.ts
+++ b/apps/web/components/organisms/entity-card/adapters.test.ts
@@ -284,13 +284,28 @@ describe('showToEntityCard', () => {
     });
   });
 
-  it('omits the CTA when there is no ticket url', () => {
+  it('renders a target-less No Tickets CTA when there is no ticket url', () => {
     const model = showToEntityCard({
       id: 's2',
       venueName: 'Club',
       startDate: null,
     });
-    expect(model.cta).toBeNull();
+    expect(model.cta).toEqual({
+      label: 'No Tickets',
+      href: null,
+      disabled: true,
+    });
     expect(model.datePill).toBeNull();
+  });
+
+  it('formats the date pill in UTC so it always matches the events list', () => {
+    // 02:30 UTC is still the previous day in US timezones — the card and the
+    // TourModePanel list (also UTC) must agree on "Jul 29".
+    const model = showToEntityCard({
+      id: 's3',
+      venueName: 'The Echo',
+      startDate: '2026-07-29T02:30:00.000Z',
+    });
+    expect(model.datePill).toEqual({ month: 'Jul', day: '29' });
   });
 });

--- a/apps/web/components/organisms/entity-card/adapters.ts
+++ b/apps/web/components/organisms/entity-card/adapters.ts
@@ -11,21 +11,6 @@ import type {
   EntityStatusTone,
 } from './types';
 
-const MONTHS = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-] as const;
-
 function toDate(value: Date | string | null | undefined): Date | null {
   if (!value) {
     return null;
@@ -232,8 +217,17 @@ export function chatTourDateContextToEntityCard(
   };
 }
 
-const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' });
-const dayFormatter = new Intl.DateTimeFormat('en-US', { day: 'numeric' });
+// Show dates render in UTC everywhere on the profile (card date pills AND the
+// events list) so the two never disagree — local-time formatting split them
+// for evening shows (e.g. "JUL 28" on the card vs "Jul 29" in the list).
+const monthFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  timeZone: 'UTC',
+});
+const dayFormatter = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  timeZone: 'UTC',
+});
 
 function getTourEyebrow(
   isNearYou: boolean,
@@ -370,7 +364,7 @@ export function aiCrawlerAnalyticsToEntityCard(
         ? { label: 'Active', tone: 'live' }
         : { label: 'Collecting', tone: 'neutral' },
     cta: analytics.isTeaser
-      ? { label: 'Upgrade to Pro', href: null, disabled: true }
+      ? { label: 'Upgrade To Pro', href: null, disabled: true }
       : {
           label: preset.ctaLabel,
           href: null,
@@ -401,11 +395,13 @@ export function showToEntityCard(show: ShowEntityInput): EntityCardModel {
     title,
     meta: location || null,
     datePill: date
-      ? { month: MONTHS[date.getMonth()], day: String(date.getDate()) }
+      ? { month: monthFormatter.format(date), day: dayFormatter.format(date) }
       : null,
     status: null,
     cta: show.ticketUrl
       ? { label: preset.ctaLabel, href: show.ticketUrl, external: true }
-      : null,
+      : // No ticket URL: keep the bottom slot honest — a target-less CTA the
+        // card renders as plain muted text, never as button chrome.
+        { label: 'No Tickets', href: null, disabled: true },
   };
 }

--- a/apps/web/components/organisms/entity-card/adapters.ts
+++ b/apps/web/components/organisms/entity-card/adapters.ts
@@ -1,6 +1,6 @@
 import { getMerchPriceDisplay } from '@/lib/merch/pricing';
 import type { PublicMerchCard } from '@/lib/merch/types';
-import type { TourDateViewModel } from '@/lib/tour-dates/types';
+import type { TicketStatus, TourDateViewModel } from '@/lib/tour-dates/types';
 import { formatLocationString } from '@/lib/utils/string-utils';
 import type { AiCrawlerAnalyticsResponse } from '@/types/ai-crawler-analytics';
 import { KIND_PRESETS } from './kind-presets';
@@ -133,6 +133,7 @@ export interface ShowEntityInput {
   readonly startDate?: Date | string | null;
   readonly ticketUrl?: string | null;
   readonly status?: EntityStatusTone | null;
+  readonly ticketStatus?: TicketStatus | null;
 }
 
 export interface ChatReleaseContextInput {
@@ -383,11 +384,14 @@ export function showToEntityCard(show: ShowEntityInput): EntityCardModel {
   const date = toDate(show.startDate);
   const title = show.title?.trim() || show.venueName?.trim() || 'Show';
   const location = [show.venueName, show.city].filter(Boolean).join(' · ');
+  const isCancelled = show.ticketStatus === 'cancelled';
+  const isSoldOut = show.ticketStatus === 'sold_out';
+  const canBuyTickets = Boolean(show.ticketUrl) && !isCancelled && !isSoldOut;
 
   return {
     id: show.id,
     kind: 'show',
-    href: show.ticketUrl ?? null,
+    href: canBuyTickets ? show.ticketUrl : null,
     imageUrl: null,
     imageAlt: title,
     accent: preset.accent,
@@ -398,10 +402,18 @@ export function showToEntityCard(show: ShowEntityInput): EntityCardModel {
       ? { month: monthFormatter.format(date), day: dayFormatter.format(date) }
       : null,
     status: null,
-    cta: show.ticketUrl
+    // A show that cannot sell tickets gets a target-less CTA — the card
+    // renders it as plain muted text, never a dead Tickets link.
+    cta: canBuyTickets
       ? { label: preset.ctaLabel, href: show.ticketUrl, external: true }
-      : // No ticket URL: keep the bottom slot honest — a target-less CTA the
-        // card renders as plain muted text, never as button chrome.
-        { label: 'No Tickets', href: null, disabled: true },
+      : {
+          label: isCancelled
+            ? 'Cancelled'
+            : isSoldOut
+              ? 'Sold Out'
+              : 'No Tickets',
+          href: null,
+          disabled: true,
+        },
   };
 }

--- a/apps/web/components/organisms/entity-card/kind-presets.ts
+++ b/apps/web/components/organisms/entity-card/kind-presets.ts
@@ -1,4 +1,5 @@
 import {
+  Bell,
   Bot,
   type LucideIcon,
   Music2,
@@ -53,6 +54,13 @@ export const KIND_PRESETS: Record<EntityKind, KindPreset> = {
     accent: 'blue',
     fallbackVariant: 'generic',
     ctaLabel: 'View Details',
+  },
+  alerts: {
+    eyebrow: 'Alerts',
+    icon: Bell,
+    accent: 'purple',
+    fallbackVariant: 'generic',
+    ctaLabel: 'Get Updates',
   },
 };
 

--- a/apps/web/components/organisms/entity-card/types.ts
+++ b/apps/web/components/organisms/entity-card/types.ts
@@ -1,7 +1,7 @@
 import type { MouseEvent } from 'react';
 
 /** The entity kinds a card can represent across profile + chat + dashboard. */
-export type EntityKind = 'merch' | 'music' | 'video' | 'show' | 'ai';
+export type EntityKind = 'merch' | 'music' | 'video' | 'show' | 'ai' | 'alerts';
 
 /** Carbon accent palette name (maps to `--color-accent-<name>`). */
 export type EntityAccent =

--- a/apps/web/lib/discography/artist-queries/artist-search.ts
+++ b/apps/web/lib/discography/artist-queries/artist-search.ts
@@ -18,10 +18,13 @@ import { db } from '@/lib/db';
 import {
   type Artist,
   artists,
+  discogReleases,
+  discogTracks,
   releaseArtists,
   trackArtists,
 } from '@/lib/db/schema/content';
-import type { CollaboratorInfo } from './types';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import type { CollaboratorInfo, CreditedArtistWithProfile } from './types';
 
 /**
  * Search artists by name
@@ -52,6 +55,80 @@ export async function searchArtists(
     .where(whereClause)
     .orderBy(artists.name)
     .limit(limit);
+}
+
+/**
+ * Resolve artists credited on a creator's catalog (release- and track-level
+ * credits) to their public Jovie handles.
+ *
+ * Only artists whose registry row links to a public creator profile are
+ * returned — external collaborators without a Jovie account are excluded so
+ * bio mentions of them stay plain text. The display name prefers the credit
+ * name (stage name) since that is what bios and release credits show.
+ */
+export async function getCreditedArtistsWithProfiles(
+  creatorProfileId: string,
+  options?: { limit?: number }
+): Promise<CreditedArtistWithProfile[]> {
+  const limit = options?.limit ?? 50;
+
+  const [releaseCredits, trackCredits] = await Promise.all([
+    db
+      .selectDistinct({
+        name: drizzleSql<string>`coalesce(${releaseArtists.creditName}, ${artists.name})`,
+        handle: creatorProfiles.usernameNormalized,
+      })
+      .from(releaseArtists)
+      .innerJoin(
+        discogReleases,
+        eq(releaseArtists.releaseId, discogReleases.id)
+      )
+      .innerJoin(artists, eq(releaseArtists.artistId, artists.id))
+      .innerJoin(
+        creatorProfiles,
+        eq(artists.creatorProfileId, creatorProfiles.id)
+      )
+      .where(
+        and(
+          eq(discogReleases.creatorProfileId, creatorProfileId),
+          eq(creatorProfiles.isPublic, true)
+        )
+      )
+      .limit(limit),
+    db
+      .selectDistinct({
+        name: drizzleSql<string>`coalesce(${trackArtists.creditName}, ${artists.name})`,
+        handle: creatorProfiles.usernameNormalized,
+      })
+      .from(trackArtists)
+      .innerJoin(discogTracks, eq(trackArtists.trackId, discogTracks.id))
+      .innerJoin(artists, eq(trackArtists.artistId, artists.id))
+      .innerJoin(
+        creatorProfiles,
+        eq(artists.creatorProfileId, creatorProfiles.id)
+      )
+      .where(
+        and(
+          eq(discogTracks.creatorProfileId, creatorProfileId),
+          eq(creatorProfiles.isPublic, true)
+        )
+      )
+      .limit(limit),
+  ]);
+
+  const seen = new Set<string>();
+  const merged: CreditedArtistWithProfile[] = [];
+  for (const row of [...releaseCredits, ...trackCredits]) {
+    const name = row.name?.trim();
+    const handle = row.handle?.trim();
+    if (!name || !handle) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({ name, handle });
+    if (merged.length >= limit) break;
+  }
+  return merged;
 }
 
 /**

--- a/apps/web/lib/discography/artist-queries/index.ts
+++ b/apps/web/lib/discography/artist-queries/index.ts
@@ -20,7 +20,11 @@ export {
   processTrackArtistCredits,
 } from './artist-import';
 // Search operations
-export { getFrequentCollaborators, searchArtists } from './artist-search';
+export {
+  getCreditedArtistsWithProfiles,
+  getFrequentCollaborators,
+  searchArtists,
+} from './artist-search';
 // Recording-artist operations
 export {
   deleteRecordingArtists,
@@ -46,5 +50,6 @@ export {
 export type {
   ArtistWithRole,
   CollaboratorInfo,
+  CreditedArtistWithProfile,
   FindOrCreateArtistInput,
 } from './types';

--- a/apps/web/lib/discography/artist-queries/types.ts
+++ b/apps/web/lib/discography/artist-queries/types.ts
@@ -20,6 +20,13 @@ export interface CollaboratorInfo {
   releaseCount: number;
 }
 
+export interface CreditedArtistWithProfile {
+  /** Display name (credit name when set, otherwise canonical artist name). */
+  name: string;
+  /** Normalized Jovie handle of the linked public creator profile. */
+  handle: string;
+}
+
 export interface FindOrCreateArtistInput {
   name: string;
   spotifyId?: string | null;

--- a/apps/web/lib/profile/aeo-content.ts
+++ b/apps/web/lib/profile/aeo-content.ts
@@ -1,6 +1,16 @@
 import { BASE_URL } from '@/constants/app';
 import type { PublicRelease } from '@/features/profile/releases/types';
+import {
+  getRegistryEntry,
+  isDspPlatform,
+  normalizePlatformKey,
+} from '@/lib/dsp-registry';
 import type { PublicMerchCard } from '@/lib/merch/types';
+import {
+  type EntityMentionContext,
+  type EntityMentionSegment,
+  linkEntityMentions,
+} from '@/lib/profile/entity-mentions';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import type { Artist, LegacySocialLink } from '@/types/db';
 
@@ -23,10 +33,31 @@ export interface ProfileAeoFaqItem {
   readonly source: ProfileAeoSource;
 }
 
+export interface ProfileAeoFact {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface ProfileAeoLink {
+  readonly id: string;
+  readonly platform: string;
+  readonly label: string;
+  readonly url: string;
+}
+
 export interface ProfileAeoContent {
   readonly artistName: string;
   readonly profileUrl: string;
+  readonly facts: readonly ProfileAeoFact[];
+  readonly listenLinks: readonly ProfileAeoLink[];
+  readonly followLinks: readonly ProfileAeoLink[];
+  /** Plain-text paragraphs — used by meta descriptions, JSON-LD, and tests. */
   readonly description: readonly string[];
+  /**
+   * `description` split into entity-linked segments (parallel array). Render
+   * this in the UI; keep `description` for plain-text consumers.
+   */
+  readonly descriptionSegments: readonly (readonly EntityMentionSegment[])[];
   readonly faqs: readonly ProfileAeoFaqItem[];
 }
 
@@ -38,6 +69,12 @@ export interface BuildProfileAeoContentInput {
   readonly tourDates?: readonly TourDateViewModel[];
   readonly merchCards?: readonly PublicMerchCard[];
   readonly socialLinks?: readonly LegacySocialLink[];
+  /**
+   * Linkable entities for this profile (own releases with slugs, credited
+   * artists resolved to Jovie handles). When omitted, descriptions render
+   * as plain text segments.
+   */
+  readonly entityMentions?: EntityMentionContext;
   readonly now?: Date;
 }
 
@@ -205,6 +242,99 @@ function getOrigin(artist: Artist): string | null {
 
 function pluralize(count: number, singular: string, plural = `${singular}s`) {
   return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function sentenceCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function buildFacts(
+  artist: Artist,
+  genres: readonly string[]
+): ProfileAeoFact[] {
+  const facts: ProfileAeoFact[] = [];
+
+  if (genres.length > 0) {
+    facts.push({ label: 'Genre', value: sentenceCase(genres.join(', ')) });
+  }
+
+  if (artist.active_since_year) {
+    facts.push({
+      label: 'Active Since',
+      value: String(artist.active_since_year),
+    });
+  }
+
+  const origin = getOrigin(artist);
+  if (origin) {
+    facts.push({ label: 'Hometown', value: origin });
+  }
+
+  return facts;
+}
+
+function getPlatformLabel(platform: string): string {
+  const key = normalizePlatformKey(platform);
+  return (
+    (key ? getRegistryEntry(key)?.name : undefined) ?? sentenceCase(platform)
+  );
+}
+
+function buildLinkSections(
+  artist: Artist,
+  socialLinks: readonly LegacySocialLink[]
+): {
+  readonly listenLinks: ProfileAeoLink[];
+  readonly followLinks: ProfileAeoLink[];
+} {
+  const listenLinks: ProfileAeoLink[] = [];
+  const followLinks: ProfileAeoLink[] = [];
+  const seenPlatforms = new Set<string>();
+
+  for (const link of socialLinks) {
+    const url = cleanText(link.url);
+    if (!url) continue;
+
+    const key = normalizePlatformKey(link.platform) ?? link.platform;
+    if (seenPlatforms.has(key)) continue;
+    seenPlatforms.add(key);
+
+    const item: ProfileAeoLink = {
+      id: link.id,
+      platform: link.platform,
+      label: getPlatformLabel(link.platform),
+      url,
+    };
+    if (isDspPlatform(link.platform)) {
+      listenLinks.push(item);
+    } else {
+      followLinks.push(item);
+    }
+  }
+
+  // Profile DSP URL columns fill in destinations that have no social link.
+  // YouTube is categorized as social by isDspPlatform, so the column only
+  // joins the listen row when the artist has no YouTube social link.
+  const dspColumnFallbacks = [
+    { platform: 'spotify', url: artist.spotify_url },
+    { platform: 'apple_music', url: artist.apple_music_url },
+    { platform: 'youtube', url: artist.youtube_url },
+  ] as const;
+
+  for (const fallback of dspColumnFallbacks) {
+    const url = cleanText(fallback.url);
+    if (!url || seenPlatforms.has(fallback.platform)) continue;
+    seenPlatforms.add(fallback.platform);
+
+    listenLinks.push({
+      id: `dsp-column-${fallback.platform}`,
+      platform: fallback.platform,
+      label: getPlatformLabel(fallback.platform),
+      url,
+    });
+  }
+
+  return { listenLinks, followLinks };
 }
 
 function buildDescription(params: {
@@ -411,6 +541,7 @@ export function buildProfileAeoContent({
   tourDates = [],
   merchCards = [],
   socialLinks = [],
+  entityMentions,
   now = new Date(),
 }: BuildProfileAeoContentInput): ProfileAeoContent {
   const uniqueGenres = getUniqueGenres(artist, genres);
@@ -419,20 +550,32 @@ export function buildProfileAeoContent({
     artistHandle: artist.handle,
     releases,
   });
+  const { listenLinks, followLinks } = buildLinkSections(artist, socialLinks);
+
+  const description = buildDescription({
+    artist,
+    genres: uniqueGenres,
+    latestRelease,
+    releases,
+    tourDates,
+    merchCards,
+    collaborators,
+    now,
+  });
+  const mentionContext: EntityMentionContext = entityMentions ?? {
+    ownHandle: artist.handle,
+  };
 
   return {
     artistName: artist.name,
     profileUrl: absoluteProfileUrl(artist.handle),
-    description: buildDescription({
-      artist,
-      genres: uniqueGenres,
-      latestRelease,
-      releases,
-      tourDates,
-      merchCards,
-      collaborators,
-      now,
-    }),
+    facts: buildFacts(artist, uniqueGenres),
+    listenLinks,
+    followLinks,
+    description,
+    descriptionSegments: description.map(paragraph =>
+      linkEntityMentions(paragraph, mentionContext)
+    ),
     faqs: [
       buildOriginFaq(artist),
       buildLatestReleaseFaq({ artist, latestRelease, releases, socialLinks }),

--- a/apps/web/lib/profile/entity-mentions.ts
+++ b/apps/web/lib/profile/entity-mentions.ts
@@ -1,0 +1,174 @@
+/**
+ * Entity-linked bio mentions.
+ *
+ * Deterministic, server-side linker that turns plain-text bio/AEO paragraphs
+ * into typed segments so entity mentions (this profile's own releases and
+ * credited artists with Jovie profiles) render as internal links. No LLM,
+ * no client fetching — the same input always produces the same segments, so
+ * the output is safe to bake into ISR pages.
+ */
+
+export interface EntityMentionRelease {
+  readonly title: string;
+  readonly slug?: string | null;
+}
+
+export interface EntityMentionArtist {
+  readonly name: string;
+  /** Jovie handle when the artist has a public profile; otherwise null. */
+  readonly handle?: string | null;
+}
+
+export interface EntityMentionContext {
+  /** Handle of the profile the text belongs to (release links hang off it). */
+  readonly ownHandle: string;
+  readonly releases?: readonly EntityMentionRelease[];
+  readonly artists?: readonly EntityMentionArtist[];
+}
+
+export type EntityMentionSegment =
+  | { readonly type: 'text'; readonly text: string }
+  | { readonly type: 'release'; readonly text: string; readonly href: string }
+  | { readonly type: 'artist'; readonly text: string; readonly href: string };
+
+export interface ProfileEntityMentionLink {
+  readonly kind: 'release' | 'artist';
+  readonly name: string;
+  readonly href: string;
+}
+
+/** Cap on collected mentions (JSON-LD bloat guard). */
+export const MAX_ENTITY_MENTIONS = 25;
+
+const MIN_PHRASE_LENGTH = 2;
+const WORD_CHAR = /[a-z0-9]/;
+
+interface MentionCandidate {
+  readonly kind: 'release' | 'artist';
+  readonly phrase: string;
+  readonly lowerPhrase: string;
+  readonly href: string;
+}
+
+function isWordChar(char: string | undefined): boolean {
+  return char != null && WORD_CHAR.test(char);
+}
+
+function buildCandidates(context: EntityMentionContext): MentionCandidate[] {
+  const seen = new Set<string>();
+  const candidates: MentionCandidate[] = [];
+
+  for (const release of context.releases ?? []) {
+    const title = release.title?.trim();
+    const slug = release.slug?.trim();
+    if (!title || title.length < MIN_PHRASE_LENGTH || !slug) continue;
+    const lower = title.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    candidates.push({
+      kind: 'release',
+      phrase: title,
+      lowerPhrase: lower,
+      href: `/${encodeURIComponent(context.ownHandle)}/${encodeURIComponent(slug)}`,
+    });
+  }
+
+  for (const artist of context.artists ?? []) {
+    const name = artist.name?.trim();
+    const handle = artist.handle?.trim();
+    // Artists without a Jovie profile stay plain text — internal interlinking only.
+    if (!name || name.length < MIN_PHRASE_LENGTH || !handle) continue;
+    const lower = name.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    candidates.push({
+      kind: 'artist',
+      phrase: name,
+      lowerPhrase: lower,
+      href: `/${encodeURIComponent(handle)}`,
+    });
+  }
+
+  // Longest match first so overlapping names ("Cosmic Gate" vs "Gate")
+  // resolve to the most specific entity. Stable sort keeps releases ahead of
+  // artists at equal length, so a same-named release links to the release.
+  return candidates.sort(
+    (left, right) => right.phrase.length - left.phrase.length
+  );
+}
+
+/**
+ * Split plain text into typed segments, linking mentions of the entities in
+ * `context`. Matching is case-insensitive and word-boundary aware, so quoted
+ * titles (`"Take Me Over"`) match while substrings of longer words
+ * (`Sky` inside `Skyline`) do not.
+ */
+export function linkEntityMentions(
+  text: string,
+  context: EntityMentionContext
+): EntityMentionSegment[] {
+  if (!text) return [];
+
+  const candidates = buildCandidates(context);
+  if (candidates.length === 0) {
+    return [{ type: 'text', text }];
+  }
+
+  const lowerText = text.toLowerCase();
+  const segments: EntityMentionSegment[] = [];
+  let cursor = 0;
+  let index = 0;
+
+  const pushTextUpTo = (end: number) => {
+    if (end > cursor) {
+      segments.push({ type: 'text', text: text.slice(cursor, end) });
+    }
+  };
+
+  while (index < text.length) {
+    let matched: MentionCandidate | null = null;
+
+    if (!isWordChar(lowerText[index - 1])) {
+      for (const candidate of candidates) {
+        if (!lowerText.startsWith(candidate.lowerPhrase, index)) continue;
+        const end = index + candidate.lowerPhrase.length;
+        if (isWordChar(lowerText[end])) continue;
+        matched = candidate;
+        break;
+      }
+    }
+
+    if (matched) {
+      pushTextUpTo(index);
+      segments.push({
+        type: matched.kind,
+        text: text.slice(index, index + matched.phrase.length),
+        href: matched.href,
+      });
+      index += matched.phrase.length;
+      cursor = index;
+    } else {
+      index += 1;
+    }
+  }
+
+  pushTextUpTo(text.length);
+  return segments;
+}
+
+/**
+ * Flat, deduped list of linkable entities for a profile — used to build
+ * JSON-LD `mentions` without re-deriving the candidate set.
+ */
+export function collectEntityMentions(
+  context: EntityMentionContext,
+  limit: number = MAX_ENTITY_MENTIONS
+): ProfileEntityMentionLink[] {
+  return buildCandidates(context)
+    .slice(0, Math.max(0, limit))
+    .map(candidate => ({
+      kind: candidate.kind,
+      name: candidate.phrase,
+      href: candidate.href,
+    }));
+}

--- a/apps/web/lib/seo/structured-data/index.ts
+++ b/apps/web/lib/seo/structured-data/index.ts
@@ -11,7 +11,9 @@ export {
 export { generateMusicStructuredData } from './music';
 export {
   generateProfileStructuredData,
+  MAX_ENTITY_MENTIONS,
   MAX_EVENT_SCHEMAS,
+  type ProfileEntityMention,
 } from './profile';
 export {
   validateMerchRichResults,

--- a/apps/web/lib/seo/structured-data/profile.ts
+++ b/apps/web/lib/seo/structured-data/profile.ts
@@ -15,6 +15,17 @@ import { formatSchemaEventStartDate } from './event-date';
 /** Max MusicEvent schemas to emit (Google shows ~5 in rich results). */
 export const MAX_EVENT_SCHEMAS = 5;
 
+/** Max linked-entity `mentions` to emit on the profile entity node. */
+export const MAX_ENTITY_MENTIONS = 25;
+
+/** A profile-linked entity (own release or credited artist) for JSON-LD mentions. */
+export interface ProfileEntityMention {
+  readonly kind: 'release' | 'artist';
+  readonly name: string;
+  /** Absolute URL of the entity's Jovie page. */
+  readonly url: string;
+}
+
 const SOCIAL_PLATFORMS = new Set([
   'instagram',
   'twitter',
@@ -111,7 +122,8 @@ function buildArtistEntitySchema(
   profileUrl: string,
   genres: string[] | null,
   uniqueSocialUrls: string[],
-  listenActions: ReturnType<typeof buildListenActions>
+  listenActions: ReturnType<typeof buildListenActions>,
+  entityMentions: readonly ProfileEntityMention[]
 ): Record<string, unknown> {
   return {
     '@type': resolveArtistEntityType(profile.creator_type),
@@ -120,6 +132,13 @@ function buildArtistEntitySchema(
     description: profile.bio || `Music by ${artistName}`,
     url: profileUrl,
     ...(uniqueSocialUrls.length > 0 && { sameAs: uniqueSocialUrls }),
+    ...(entityMentions.length > 0 && {
+      mentions: entityMentions.slice(0, MAX_ENTITY_MENTIONS).map(mention => ({
+        '@type': mention.kind === 'artist' ? 'MusicGroup' : 'MusicRecording',
+        name: mention.name,
+        url: mention.url,
+      })),
+    }),
     genre: genres && genres.length > 0 ? genres : ['Music'],
     ...(profile.avatar_url && {
       image: {
@@ -248,7 +267,8 @@ export function generateProfileStructuredData(
   genres: string[] | null,
   links: LegacySocialLink[],
   tourDates: TourDateViewModel[] = [],
-  identityLinks: EntityIdentityLink[] = []
+  identityLinks: EntityIdentityLink[] = [],
+  entityMentions: readonly ProfileEntityMention[] = []
 ) {
   const artistName = profile.display_name || profile.username;
   const normalizedUsername =
@@ -263,7 +283,8 @@ export function generateProfileStructuredData(
     profileUrl,
     genres,
     uniqueSocialUrls,
-    listenActions
+    listenActions,
+    entityMentions
   );
   const profilePageSchema = buildProfilePageSchema(
     profile,

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -313,9 +313,28 @@
   height: 100%;
   max-height: 104vw;
   align-self: center;
+  /* Size container so card content can respond to the card's own height. */
+  container-type: size;
   transition:
     transform var(--ds-motion-subtle-duration) var(--ds-motion-subtle-easing),
     opacity var(--ds-motion-subtle-duration) var(--ds-motion-subtle-easing);
+}
+
+/* Unified card anatomy: the art zone is a full-width square, so the text
+   zone + CTA share (card height − card width). Progressive disclosure keeps
+   every line whole instead of clipping mid-line: the meta line hides below
+   the height where it fits (~448px), and the eyebrow hides below the height
+   where it fits next to the title (~360px) — title and CTA always fit. */
+@container (max-height: 447px) {
+  :where(.profile-entity-card) .entity-card-meta {
+    display: none;
+  }
+}
+
+@container (max-height: 359px) {
+  :where(.profile-entity-card) .entity-card-eyebrow {
+    display: none;
+  }
 }
 
 /* Scroll-driven edge treatment (transform/opacity only; applied via

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -395,6 +395,26 @@
   text-decoration-color: var(--profile-aeo-text);
 }
 
+:where(.profile-aeo-content__facts) {
+  border-color: var(--profile-aeo-border);
+}
+
+:where(.profile-aeo-content__fact-value) {
+  color: var(--profile-aeo-text);
+}
+
+:where(.profile-aeo-content__fact-label),
+:where(.profile-aeo-content__link-label),
+:where(.profile-aeo-content__link),
+:where(.profile-aeo-content__share) {
+  color: var(--profile-aeo-muted);
+}
+
+:where(.profile-aeo-content__link:hover),
+:where(.profile-aeo-content__share:hover) {
+  color: var(--profile-aeo-text);
+}
+
 :where(.profile-aeo-claim-card) {
   --profile-aeo-claim-ink: var(--system-b-cinematic-black);
   background: var(--color-bg-paper);
@@ -4853,6 +4873,31 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
     var(--jovie-entity-accent) 82%,
     var(--color-text-primary-token) 18%
   );
+}
+
+/* Inline entity links in public profile bio/AEO copy. The entity-kind accent
+   is provided via the `--jovie-entity-accent` custom property on the link. */
+.profile-entity-mention {
+  color: var(--jovie-entity-accent);
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--jovie-entity-accent) 45%,
+    transparent
+  );
+  transition:
+    color var(--system-b-duration-fast) var(--system-b-ease),
+    text-decoration-color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+.profile-entity-mention:hover,
+.profile-entity-mention:focus-visible {
+  text-decoration-color: var(--jovie-entity-accent);
+}
+
+.profile-entity-mention:focus-visible {
+  outline: 2px solid var(--jovie-entity-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }
 
 .system-b-assistant-skill-mention {

--- a/apps/web/tests/unit/lib/seo/structured-data.test.ts
+++ b/apps/web/tests/unit/lib/seo/structured-data.test.ts
@@ -201,6 +201,69 @@ describe('generateProfileStructuredData', () => {
     const artist = findInGraph(data, 'MusicGroup');
     expect(artist?.sameAs).toBeUndefined();
   });
+
+  it('emits linked-entity mentions on the artist node', () => {
+    const data = generateProfileStructuredData(
+      BASE_PROFILE,
+      ['pop'],
+      MOCK_LINKS,
+      [],
+      [],
+      [
+        {
+          kind: 'release',
+          name: 'Neon Circuit',
+          url: 'https://jov.ie/testartist/neon-circuit',
+        },
+        {
+          kind: 'artist',
+          name: 'Guest Vocalist',
+          url: 'https://jov.ie/guestvocalist',
+        },
+      ]
+    );
+
+    const artist = findInGraph(data, 'MusicGroup');
+    expect(artist?.mentions).toEqual([
+      {
+        '@type': 'MusicRecording',
+        name: 'Neon Circuit',
+        url: 'https://jov.ie/testartist/neon-circuit',
+      },
+      {
+        '@type': 'MusicGroup',
+        name: 'Guest Vocalist',
+        url: 'https://jov.ie/guestvocalist',
+      },
+    ]);
+    expect(validateProfileRichResults(data)).toEqual([]);
+  });
+
+  it('caps mentions at 25 and omits the key when empty', () => {
+    const manyMentions = Array.from({ length: 40 }, (_, i) => ({
+      kind: 'release' as const,
+      name: `Release ${i}`,
+      url: `https://jov.ie/testartist/release-${i}`,
+    }));
+
+    const capped = generateProfileStructuredData(
+      BASE_PROFILE,
+      ['pop'],
+      MOCK_LINKS,
+      [],
+      [],
+      manyMentions
+    );
+    const cappedArtist = findInGraph(capped, 'MusicGroup');
+    expect(cappedArtist?.mentions).toHaveLength(25);
+
+    const without = generateProfileStructuredData(
+      BASE_PROFILE,
+      ['pop'],
+      MOCK_LINKS
+    );
+    expect(findInGraph(without, 'MusicGroup')?.mentions).toBeUndefined();
+  });
 });
 
 describe('generateMusicStructuredData', () => {

--- a/apps/web/tests/unit/profile/ProfileEmptyBentoCard.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileEmptyBentoCard.test.tsx
@@ -1,27 +1,29 @@
 import { render, screen } from '@testing-library/react';
-import { Bell, Music2 } from 'lucide-react';
+import { Music2, Ticket } from 'lucide-react';
 import { describe, expect, it } from 'vitest';
 import { ProfileEmptyBentoCard } from '@/features/profile/ProfileEmptyBentoCard';
 
 describe('ProfileEmptyBentoCard', () => {
-  it('renders a prominent alerts bento with full-color gradient background', () => {
+  it('renders a prominent events bento with full-color gradient background', () => {
     render(
       <ProfileEmptyBentoCard
-        accent='alerts'
-        icon={Bell}
-        title='Alerts'
-        body='Tim White: music, shows, merch.'
+        accent='events'
+        icon={Ticket}
+        title='No Events'
+        body='Get alerted when shows are announced.'
         layout='prominent'
-        dataTestId='profile-home-alerts-fallback-card'
-        trailing={<span data-testid='profile-home-alerts-switch'>switch</span>}
+        dataTestId='profile-events-empty-card'
+        trailing={<span data-testid='profile-events-empty-trailing'>slot</span>}
       />
     );
 
-    const card = screen.getByTestId('profile-home-alerts-fallback-card');
-    expect(card.style.background).toContain('var(--color-accent-purple)');
-    expect(screen.getByText('Alerts')).toBeVisible();
-    expect(screen.getByText('Tim White: music, shows, merch.')).toBeVisible();
-    expect(screen.getByTestId('profile-home-alerts-switch')).toBeVisible();
+    const card = screen.getByTestId('profile-events-empty-card');
+    expect(card.style.background).toContain('var(--color-accent-blue)');
+    expect(screen.getByText('No Events')).toBeVisible();
+    expect(
+      screen.getByText('Get alerted when shows are announced.')
+    ).toBeVisible();
+    expect(screen.getByTestId('profile-events-empty-trailing')).toBeVisible();
   });
 
   it('renders a compact music empty bento with CTA action', () => {

--- a/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
@@ -148,7 +148,7 @@ describe('ProfileHomeRail', () => {
     expect(screen.getAllByText('Never Say A Word')).toHaveLength(1);
   });
 
-  it('renders a prominent gradient alerts card when the home rail is empty', () => {
+  it('renders the alerts card as a standard unified-anatomy card (no gradient)', () => {
     render(
       <ProfileHomeRail
         artist={makeArtist()}
@@ -163,8 +163,14 @@ describe('ProfileHomeRail', () => {
     );
 
     const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
-    expect(alertsCard.style.background).toContain('var(--color-accent-purple)');
-    expect(alertsCard.className).toContain('min-h-44');
+    // Standard card: pearl surface, no accent gradient, unified anatomy
+    // (square icon art zone + full-width "Get Updates" CTA).
+    expect(alertsCard.style.background).toBe('');
+    expect(alertsCard.className).toContain('bg-(--profile-pearl-bg)');
+    expect(alertsCard).toHaveTextContent('Alerts');
+    const cta = screen.getByText('Get Updates');
+    expect(cta.className).toContain('h-9');
+    expect(cta.className).toContain('w-full');
   });
 
   it('keeps the carousel shell with PAC and alerts cards even when the catalog is empty', () => {
@@ -182,12 +188,12 @@ describe('ProfileHomeRail', () => {
     );
 
     const carousel = screen.getByTestId('profile-home-carousel');
-    expect(
-      screen.getByTestId('profile-home-alerts-fallback-card')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('profile-home-alerts-switch')
-    ).toBeInTheDocument();
+    const alertsCard = screen.getByTestId('profile-home-alerts-fallback-card');
+    expect(alertsCard).toBeInTheDocument();
+    // The alerts card shares the unified entity-card anatomy (full-bleed
+    // square art zone, full-width CTA).
+    expect(alertsCard.className).toContain('p-0');
+    expect(screen.getByText('Get Updates')).toBeInTheDocument();
     // No entity items → the carousel still hosts the slot cards.
     expect(carousel.querySelectorAll(':scope > li').length).toBeGreaterThan(0);
     expect(screen.queryByTestId('entity-card-music')).not.toBeInTheDocument();

--- a/apps/web/tests/unit/profile/entity-mentions.test.ts
+++ b/apps/web/tests/unit/profile/entity-mentions.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectEntityMentions,
+  type EntityMentionContext,
+  linkEntityMentions,
+  MAX_ENTITY_MENTIONS,
+} from '@/lib/profile/entity-mentions';
+
+const context: EntityMentionContext = {
+  ownHandle: 'tim',
+  releases: [
+    { title: 'Take Me Over', slug: 'take-me-over' },
+    { title: 'Gate', slug: 'gate' },
+    { title: 'Sky', slug: 'sky' },
+  ],
+  artists: [
+    { name: 'Cosmic Gate', handle: 'cosmicgate' },
+    { name: 'The Disco Biscuits', handle: null },
+    { name: 'Tim', handle: 'tim' },
+  ],
+};
+
+describe('linkEntityMentions', () => {
+  it('links a quoted release title, leaving the quotes as plain text', () => {
+    const segments = linkEntityMentions(
+      'Check out "Take Me Over" on streaming now.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'Check out "' },
+      {
+        type: 'release',
+        text: 'Take Me Over',
+        href: '/tim/take-me-over',
+      },
+      { type: 'text', text: '" on streaming now.' },
+    ]);
+  });
+
+  it('prefers the longest overlapping name', () => {
+    const segments = linkEntityMentions(
+      'Toured with Cosmic Gate last summer.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'Toured with ' },
+      { type: 'artist', text: 'Cosmic Gate', href: '/cosmicgate' },
+      { type: 'text', text: ' last summer.' },
+    ]);
+  });
+
+  it('matches case-insensitively but preserves the original casing in the segment', () => {
+    const segments = linkEntityMentions(
+      'take me over was the first single.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'release', text: 'take me over', href: '/tim/take-me-over' },
+      { type: 'text', text: ' was the first single.' },
+    ]);
+  });
+
+  it('keeps artists without a Jovie profile as plain text', () => {
+    const segments = linkEntityMentions(
+      'Shared bills with The Disco Biscuits.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'Shared bills with The Disco Biscuits.' },
+    ]);
+  });
+
+  it('does not match inside longer words (word boundaries)', () => {
+    const segments = linkEntityMentions(
+      'The Skyline venue was packed.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'The Skyline venue was packed.' },
+    ]);
+  });
+
+  it('links a standalone short title at a word boundary', () => {
+    const segments = linkEntityMentions('Sky is the opener.', context);
+
+    expect(segments).toEqual([
+      { type: 'release', text: 'Sky', href: '/tim/sky' },
+      { type: 'text', text: ' is the opener.' },
+    ]);
+  });
+
+  it('links the profile owner name to their own profile', () => {
+    const segments = linkEntityMentions(
+      'Tim started producing in 2012.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'artist', text: 'Tim', href: '/tim' },
+      { type: 'text', text: ' started producing in 2012.' },
+    ]);
+  });
+
+  it('links multiple entities in one paragraph', () => {
+    const segments = linkEntityMentions(
+      'After Take Me Over, Tim remixed Cosmic Gate.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'After ' },
+      { type: 'release', text: 'Take Me Over', href: '/tim/take-me-over' },
+      { type: 'text', text: ', ' },
+      { type: 'artist', text: 'Tim', href: '/tim' },
+      { type: 'text', text: ' remixed ' },
+      { type: 'artist', text: 'Cosmic Gate', href: '/cosmicgate' },
+      { type: 'text', text: '.' },
+    ]);
+  });
+
+  it('returns a single text segment when there is nothing to link', () => {
+    expect(linkEntityMentions('Hello world.', { ownHandle: 'tim' })).toEqual([
+      { type: 'text', text: 'Hello world.' },
+    ]);
+    expect(linkEntityMentions('', context)).toEqual([]);
+  });
+
+  it('prefers the release when a release and artist share the same name', () => {
+    const segments = linkEntityMentions('Gate changed everything.', {
+      ownHandle: 'tim',
+      releases: [{ title: 'Gate', slug: 'gate' }],
+      artists: [{ name: 'Gate', handle: 'gate' }],
+    });
+
+    expect(segments).toEqual([
+      { type: 'release', text: 'Gate', href: '/tim/gate' },
+      { type: 'text', text: ' changed everything.' },
+    ]);
+  });
+
+  it('ignores releases without a slug and single-character phrases', () => {
+    const segments = linkEntityMentions('X marks Gate.', {
+      ownHandle: 'tim',
+      releases: [{ title: 'Gate' }],
+      artists: [{ name: 'X', handle: 'x' }],
+    });
+
+    expect(segments).toEqual([{ type: 'text', text: 'X marks Gate.' }]);
+  });
+});
+
+describe('collectEntityMentions', () => {
+  it('collects deduped linkable entities with hrefs', () => {
+    const mentions = collectEntityMentions(context);
+
+    expect(mentions).toContainEqual({
+      kind: 'release',
+      name: 'Take Me Over',
+      href: '/tim/take-me-over',
+    });
+    expect(mentions).toContainEqual({
+      kind: 'artist',
+      name: 'Cosmic Gate',
+      href: '/cosmicgate',
+    });
+    // No Jovie profile → not collected.
+    expect(
+      mentions.some(mention => mention.name === 'The Disco Biscuits')
+    ).toBe(false);
+  });
+
+  it('caps the number of mentions', () => {
+    const manyReleases = Array.from(
+      { length: MAX_ENTITY_MENTIONS + 10 },
+      (_, i) => ({
+        title: `Release Number ${i}`,
+        slug: `release-number-${i}`,
+      })
+    );
+
+    const mentions = collectEntityMentions({
+      ownHandle: 'tim',
+      releases: manyReleases,
+    });
+
+    expect(mentions).toHaveLength(MAX_ENTITY_MENTIONS);
+  });
+});

--- a/apps/web/tests/unit/profile/profile-about-share.test.tsx
+++ b/apps/web/tests/unit/profile/profile-about-share.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProfileAboutShare } from '@/features/profile/ProfileAboutShare';
+
+function mockClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+  return writeText;
+}
+
+describe('ProfileAboutShare', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    Object.defineProperty(navigator, 'share', {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  it('copies the profile URL when the Web Share API is unavailable', async () => {
+    const writeText = mockClipboard();
+
+    render(
+      <ProfileAboutShare url='https://jov.ie/dj-test' artistName='DJ Test' />
+    );
+
+    const button = screen.getByTestId('profile-about-share');
+    expect(button).toHaveAttribute('aria-label', "Share DJ Test's profile");
+
+    fireEvent.click(button);
+
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('https://jov.ie/dj-test');
+      expect(button).toHaveAttribute(
+        'aria-label',
+        "Copied link to DJ Test's profile"
+      );
+    });
+  });
+
+  it('uses the Web Share API when available', async () => {
+    const writeText = mockClipboard();
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: share,
+      configurable: true,
+    });
+
+    render(
+      <ProfileAboutShare url='https://jov.ie/dj-test' artistName='DJ Test' />
+    );
+
+    fireEvent.click(screen.getByTestId('profile-about-share'));
+
+    await vi.waitFor(() => {
+      expect(share).toHaveBeenCalledWith({
+        title: 'DJ Test',
+        url: 'https://jov.ie/dj-test',
+      });
+    });
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the user cancels the share sheet', async () => {
+    const writeText = mockClipboard();
+    const share = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error('cancelled'), { name: 'AbortError' })
+      );
+    Object.defineProperty(navigator, 'share', {
+      value: share,
+      configurable: true,
+    });
+
+    render(
+      <ProfileAboutShare url='https://jov.ie/dj-test' artistName='DJ Test' />
+    );
+
+    const button = screen.getByTestId('profile-about-share');
+    fireEvent.click(button);
+
+    await vi.waitFor(() => {
+      expect(share).toHaveBeenCalled();
+    });
+    expect(writeText).not.toHaveBeenCalled();
+    expect(button).toHaveAttribute('aria-label', "Share DJ Test's profile");
+  });
+});

--- a/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
+++ b/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
@@ -179,6 +179,193 @@ describe('Profile AEO content', () => {
     expect(content.faqs[3]?.answer).toContain('$68.00');
   });
 
+  it('builds the facts strip from genres, active year, and hometown', () => {
+    const content = buildContent();
+
+    expect(content.facts).toEqual([
+      { label: 'Genre', value: 'Tech house, electronic, club' },
+      { label: 'Active Since', value: '2018' },
+      { label: 'Hometown', value: 'Austin, TX' },
+    ]);
+  });
+
+  it('falls back to location for the hometown fact only when hometown is missing', () => {
+    const content = buildProfileAeoContent({
+      artist: { ...baseArtist, hometown: null, location: 'Berlin, DE' },
+      now,
+    });
+
+    expect(content.facts).toContainEqual({
+      label: 'Hometown',
+      value: 'Berlin, DE',
+    });
+
+    const withHometown = buildProfileAeoContent({ artist: baseArtist, now });
+    expect(withHometown.facts).toContainEqual({
+      label: 'Hometown',
+      value: 'Austin, TX',
+    });
+  });
+
+  it('omits the facts strip fields that have no data', () => {
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        hometown: null,
+        location: null,
+        active_since_year: null,
+        genres: null,
+      },
+      now,
+    });
+
+    expect(content.facts).toEqual([]);
+  });
+
+  it('splits social links into listen (DSP) and follow (non-DSP) rows', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      socialLinks: [
+        ...socialLinks,
+        {
+          id: 'link-2',
+          artist_id: 'artist-1',
+          platform: 'instagram',
+          url: 'https://instagram.com/djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'link-3',
+          artist_id: 'artist-1',
+          platform: 'youtube',
+          url: 'https://youtube.com/@djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'link-4',
+          artist_id: 'artist-1',
+          platform: 'venmo',
+          url: 'https://venmo.com/djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+      now,
+    });
+
+    expect(content.listenLinks.map(link => link.label)).toEqual([
+      'Spotify',
+      'Apple Music',
+    ]);
+    expect(content.listenLinks[0]?.url).toBe(
+      'https://open.spotify.com/artist/test'
+    );
+    // The apple_music_url profile column fills in the missing DSP link.
+    expect(content.listenLinks[1]?.url).toBe(
+      'https://music.apple.com/artist/test'
+    );
+    // A YouTube social link is categorized as follow, not listen, and
+    // suppresses the youtube_url column fallback.
+    expect(content.followLinks.map(link => link.platform)).toEqual([
+      'instagram',
+      'youtube',
+      'venmo',
+    ]);
+    // Registry names win; unknown platforms fall back to sentence case.
+    expect(content.followLinks.map(link => link.label)).toEqual([
+      'Instagram',
+      'YouTube',
+      'Venmo',
+    ]);
+  });
+
+  it('uses profile DSP URL columns for the listen row when no social links exist', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      socialLinks: [],
+      now,
+    });
+
+    expect(content.listenLinks.map(link => link.platform)).toEqual([
+      'spotify',
+      'apple_music',
+      'youtube',
+    ]);
+    expect(content.followLinks).toEqual([]);
+  });
+
+  it('renders the facts strip, listen, follow, and share controls', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      genres: ['tech house'],
+      socialLinks: [
+        ...socialLinks,
+        {
+          id: 'link-2',
+          artist_id: 'artist-1',
+          platform: 'instagram',
+          url: 'https://instagram.com/djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+      now,
+    });
+
+    render(<ProfileAeoContent content={content} />);
+
+    const facts = screen.getByTestId('profile-about-facts');
+    expect(facts).toBeVisible();
+    expect(facts).toHaveTextContent('Genre');
+    expect(facts).toHaveTextContent('Active Since');
+    expect(facts).toHaveTextContent('Hometown');
+
+    const listen = screen.getByTestId('profile-about-listen');
+    expect(listen).toBeVisible();
+    const spotifyLink = screen.getByRole('link', { name: 'Spotify' });
+    expect(spotifyLink).toHaveAttribute(
+      'href',
+      'https://open.spotify.com/artist/test'
+    );
+    expect(spotifyLink).toHaveAttribute('target', '_blank');
+    expect(spotifyLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    const follow = screen.getByTestId('profile-about-follow');
+    expect(follow).toBeVisible();
+    expect(
+      screen.getByRole('link', { name: 'Follow DJ Test on Instagram' })
+    ).toHaveAttribute('href', 'https://instagram.com/djtest');
+
+    expect(screen.getByTestId('profile-about-share')).toBeVisible();
+  });
+
+  it('hides the facts, listen, and follow sections when there is no data', () => {
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        hometown: null,
+        location: null,
+        active_since_year: null,
+        genres: null,
+        spotify_url: undefined,
+        apple_music_url: undefined,
+        youtube_url: undefined,
+      },
+      socialLinks: [],
+      now,
+    });
+
+    render(<ProfileAeoContent content={content} />);
+
+    expect(screen.queryByTestId('profile-about-facts')).toBeNull();
+    expect(screen.queryByTestId('profile-about-listen')).toBeNull();
+    expect(screen.queryByTestId('profile-about-follow')).toBeNull();
+    expect(screen.getByTestId('profile-about-share')).toBeVisible();
+    expect(screen.getByTestId('profile-aeo-content')).toBeVisible();
+  });
+
   it('keeps sparse profiles unique and sourced instead of using duplicate boilerplate', () => {
     const first = buildProfileAeoContent({
       artist: {
@@ -246,6 +433,84 @@ describe('Profile AEO content', () => {
     expect(html).toContain('data-testid="profile-aeo-content"');
     expect(html).toContain('Where can I buy DJ Test merch?');
     expect(html).toContain('Source: Official merch card');
+  });
+
+  it('links entity mentions in the description while keeping plain-text paragraphs', () => {
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        tagline:
+          'DJ Test broke through with "Neon Circuit" and tours with Guest Vocalist.',
+      },
+      genres: ['tech house'],
+      releases: [
+        {
+          id: 'release-1',
+          title: 'Neon Circuit',
+          slug: 'neon-circuit',
+          releaseType: 'single',
+          releaseDate: '2026-05-01T00:00:00.000Z',
+          artworkUrl: null,
+          artistNames: ['DJ Test', 'Guest Vocalist'],
+        },
+      ],
+      entityMentions: {
+        ownHandle: 'dj-test',
+        releases: [{ title: 'Neon Circuit', slug: 'neon-circuit' }],
+        artists: [{ name: 'Guest Vocalist', handle: 'guestvocalist' }],
+      },
+      now,
+    });
+
+    // Plain-text accessor is unchanged for meta/JSON-LD consumers.
+    expect(content.description.join(' ')).toContain('Neon Circuit');
+
+    const linkedSegments = content.descriptionSegments
+      .flat()
+      .filter(segment => segment.type !== 'text');
+    expect(linkedSegments).toContainEqual({
+      type: 'release',
+      text: 'Neon Circuit',
+      href: '/dj-test/neon-circuit',
+    });
+    expect(linkedSegments).toContainEqual({
+      type: 'artist',
+      text: 'Guest Vocalist',
+      href: '/guestvocalist',
+    });
+
+    render(<ProfileAeoContent content={content} />);
+
+    // The release title appears in both the tagline and the generated
+    // latest-release sentence — every mention is linked.
+    const releaseLinks = screen.getAllByRole('link', { name: 'Neon Circuit' });
+    expect(releaseLinks.length).toBeGreaterThan(0);
+    for (const link of releaseLinks) {
+      expect(link).toHaveAttribute('href', '/dj-test/neon-circuit');
+      expect(link).toHaveAttribute('data-entity-kind', 'release');
+    }
+
+    const artistLinks = screen.getAllByRole('link', {
+      name: 'Guest Vocalist',
+    });
+    expect(artistLinks.length).toBeGreaterThan(0);
+    for (const link of artistLinks) {
+      expect(link).toHaveAttribute('href', '/guestvocalist');
+      expect(link).toHaveAttribute('data-entity-kind', 'artist');
+    }
+  });
+
+  it('defaults to plain-text segments when no entity context is provided', () => {
+    const content = buildContent();
+
+    expect(content.descriptionSegments).toHaveLength(
+      content.description.length
+    );
+    for (const [index, segments] of content.descriptionSegments.entries()) {
+      expect(segments).toEqual([
+        { type: 'text', text: content.description[index] },
+      ]);
+    }
   });
 
   it('renders the editorial claim card only when a claim destination is provided', () => {


### PR DESCRIPTION
Stacked on #14559.

## What

One card design across the entire profile home carousel, per product-owner teardown + /design-review (which found three competing card languages).

- **Unified anatomy** (`EntityCard` `anatomy='unified'`): full-bleed square art zone (aspect 1/1 at full card width, `object-cover` — no more letterbox bands), eyebrow/title/meta text zone, full-width 36px CTA anchored at bottom. Two half-width CTAs supported for future use.
- **PAC featured card conforms** to the same anatomy (player, seek, capture states, instrumentation untouched; zero-CLS box verified before/after interaction).
- **Alerts card rebuilt** as a standard unified card (Bell art zone, full-width "Get Updates") — off-brand purple gradient removed. Same testid, same flow.
- **Show-date bug fixed:** card date pills used viewer-local time while the events list used UTC ("JUL 28" vs "Jul 29") — both UTC now.
- **"No Tickets" affordance lie:** non-interactive span wearing button chrome → plain muted meta text; cancelled/sold-out shows never link to tickets (QA find).
- **Short-card progressive disclosure:** container queries hide meta (~<448px card height) then eyebrow (~<360px) instead of clipping mid-glyph; title + CTA always render whole.
- Dropped `--linear-*` border on the unified CTA (namespace ratchet is shrink-only; visually neutral).

## Verification

- Typecheck/Biome clean; 601+ unit tests incl. updated guards (`EntityCard`, `EntityCarousel.geometry`, `adapters`, `ProfileHomeRail`, bento tests); arbitrary-values ratchet flat.
- Scoped `/qa --exhaustive` on the profile surface: health ~74 → ~97, zero console errors at 5 viewports × 2 profiles, snap/overflow/tab-bar clearances verified (~20 screenshots).
- Pre-push gate: all suites pass (one env flake — pnpm's Node pinned to 22.22.1 — resolved by activating 22.23.1; unrelated to this diff).