### PR TITLE
feat(profile): enrich about section — facts strip, Listen/Follow rows, share

### DIFF
--- a/apps/web/app/[username]/about/page.tsx
+++ b/apps/web/app/[username]/about/page.tsx
@@ -4,6 +4,13 @@ import { BASE_URL } from '@/constants/app';
 import { AboutView } from '@/features/profile/views/AboutView';
 import { buildViewMetadata } from '@/features/profile/views/metadata';
 import { ProfileIntentPage } from '@/features/profile/views/ProfileIntentPage';
+import { getCreditedArtistsWithProfiles } from '@/lib/discography/artist-queries';
+import { getReleasesForProfileLite } from '@/lib/discography/queries';
+import {
+  type EntityMentionContext,
+  linkEntityMentions,
+} from '@/lib/profile/entity-mentions';
+import { logger } from '@/lib/utils/logger';
 import { convertCreatorProfileToArtist } from '@/types/db';
 import { getProfileAndLinks } from '../_lib/public-profile-loader';
 
@@ -42,10 +49,41 @@ export default async function AboutPage({ params }: Props) {
   }
 
   const artist = convertCreatorProfileToArtist(result.profile);
+  const profile = result.profile;
   const profileSettings =
-    (result.profile.settings as Record<string, unknown> | null) ?? {};
+    (profile.settings as Record<string, unknown> | null) ?? {};
   const allowPhotoDownloads =
     profileSettings.allowProfilePhotoDownloads === true;
+
+  // Entity-linked bio: resolve this profile's own releases + credited artists
+  // with public Jovie profiles, then link mentions in the tagline. Failures
+  // degrade to plain text.
+  const bioSegments = await (async () => {
+    const tagline = artist.tagline?.trim();
+    if (!tagline) return undefined;
+    try {
+      const [releases, creditedArtists] = await Promise.all([
+        getReleasesForProfileLite(profile.id),
+        getCreditedArtistsWithProfiles(profile.id),
+      ]);
+      const context: EntityMentionContext = {
+        ownHandle: artist.handle,
+        releases: releases.map(release => ({
+          title: release.title,
+          slug: release.slug,
+        })),
+        artists: creditedArtists,
+      };
+      return linkEntityMentions(tagline, context);
+    } catch (error) {
+      logger.error(
+        'Error building entity-linked bio segments',
+        { error, profileId: profile.id, route: '/[username]/about' },
+        'public-profile'
+      );
+      return undefined;
+    }
+  })();
 
   return (
     <ProfileIntentPage
@@ -58,6 +96,7 @@ export default async function AboutPage({ params }: Props) {
         genres={result.genres}
         pressPhotos={[...result.pressPhotos]}
         allowPhotoDownloads={allowPhotoDownloads}
+        bioSegments={bioSegments}
       />
     </ProfileIntentPage>
   );

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from 'next/navigation';
 // API (cookies(), headers()) in this RSC tree.
 
 import type { PublicRelease } from '@/components/features/profile/releases/types';
+import { BASE_URL } from '@/constants/app';
 import { ErrorBanner } from '@/features/feedback/ErrorBanner';
 import { DesktopQrOverlayClient } from '@/features/profile/DesktopQrOverlayClient';
 import { ProfileAeoContent } from '@/features/profile/ProfileAeoContent';
@@ -19,6 +20,7 @@ import {
   supportsDirectProfileClaim,
 } from '@/lib/claim/visitor-state';
 import { toPublicContacts } from '@/lib/contacts/mapper';
+import { getCreditedArtistsWithProfiles } from '@/lib/discography/artist-queries';
 import { getReleasesForProfileLite } from '@/lib/discography/queries';
 import { getEntityIdentityLinks } from '@/lib/entity/queries';
 import { DEFAULT_PROFILE_PAC_ASSIGNMENT } from '@/lib/flags/profile-pac';
@@ -30,6 +32,10 @@ import {
 } from '@/lib/flags/profile-variant';
 import { getLiveMerchCardsForProfile } from '@/lib/merch/service';
 import { buildProfileAeoContent } from '@/lib/profile/aeo-content';
+import {
+  collectEntityMentions,
+  type EntityMentionContext,
+} from '@/lib/profile/entity-mentions';
 import { getConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback-data';
 import {
   buildPublicProfileMetadata,
@@ -132,6 +138,27 @@ async function getPublicMerchCards(profileId: string) {
   }
 }
 
+/**
+ * Credited artists on this profile's catalog that have public Jovie profiles.
+ * Used to link bio/AEO mentions to their pages; failures degrade to no links.
+ */
+async function getCreditedArtistsForMentions(profileId: string) {
+  try {
+    return await getCreditedArtistsWithProfiles(profileId);
+  } catch (error) {
+    logger.error(
+      'Error fetching credited artists for entity mentions',
+      {
+        error,
+        profileId,
+        route: '/[username]',
+      },
+      'public-profile'
+    );
+    return [];
+  }
+}
+
 export default async function ArtistPage({ params }: Readonly<Props>) {
   const { username } = await params;
   const initialMode = 'profile';
@@ -195,6 +222,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
   const releasesPromise = getPublicReleases(profile.id);
   const merchCardsPromise = getPublicMerchCards(profile.id);
   const entityLinksPromise = getEntityIdentityLinks(profile.id);
+  const creditedArtistsPromise = getCreditedArtistsForMentions(profile.id);
 
   // Convert our profile data to the Artist type expected by components
   const artist = convertCreatorProfileToArtist(profile);
@@ -250,6 +278,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     alertOptInVariant,
     profilePacAssignment,
     entityLinks,
+    creditedArtists,
   ] = await Promise.all([
     tourDatesPromise.catch(() => [] as TourDateViewModel[]),
     releasesPromise,
@@ -260,6 +289,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     getProfileAlertOptInVariant(null).catch(() => 'button' as const),
     getProfilePacAssignment(null).catch(() => DEFAULT_PROFILE_PAC_ASSIGNMENT),
     entityLinksPromise.catch(() => []),
+    creditedArtistsPromise,
   ]);
   const tourDates = [...tourDatesRaw].sort(
     (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
@@ -277,13 +307,29 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     previewUrl: null,
   }));
 
+  // Entity-linked bio/AEO context: own releases (→ /{handle}/{slug}) and
+  // credited artists with public Jovie profiles (→ /{handle}).
+  const entityMentionContext: EntityMentionContext = {
+    ownHandle: artist.handle,
+    releases: releases.map(release => ({
+      title: release.title,
+      slug: release.slug,
+    })),
+    artists: creditedArtists,
+  };
+
   // Generate structured data for SEO (after tour dates resolve)
   const structuredData = generateProfileStructuredData(
     profile,
     genres,
     links,
     tourDates,
-    entityLinks
+    entityLinks,
+    collectEntityMentions(entityMentionContext).map(mention => ({
+      kind: mention.kind,
+      name: mention.name,
+      url: new URL(mention.href, BASE_URL).toString(),
+    }))
   );
   const aeoContent = buildProfileAeoContent({
     artist,
@@ -293,6 +339,7 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     tourDates,
     merchCards,
     socialLinks: links,
+    entityMentions: entityMentionContext,
   });
 
   return (

--- a/apps/web/components/features/profile/AboutSection.tsx
+++ b/apps/web/components/features/profile/AboutSection.tsx
@@ -2,14 +2,21 @@
 
 import { Calendar, Download, Home, MapPin } from 'lucide-react';
 import { ImageWithFallback } from '@/components/atoms/ImageWithFallback';
+import type { EntityMentionSegment } from '@/lib/profile/entity-mentions';
 import type { Artist } from '@/types/db';
 import type { PressPhoto } from '@/types/press-photos';
+import { EntityMentionText } from './EntityMentionText';
 
 interface AboutSectionProps {
   readonly artist: Artist;
   readonly genres?: string[] | null;
   readonly pressPhotos?: readonly PressPhoto[];
   readonly allowPhotoDownloads?: boolean;
+  /**
+   * Optional entity-linked segments for `artist.tagline` (computed
+   * server-side). Falls back to plain text when omitted.
+   */
+  readonly bioSegments?: readonly EntityMentionSegment[];
 }
 
 function sanitizeFilename(value: string): string {
@@ -59,6 +66,7 @@ export function AboutSection({
   genres,
   pressPhotos = [],
   allowPhotoDownloads = false,
+  bioSegments,
 }: AboutSectionProps) {
   const hasBio = Boolean(artist.tagline);
   const hasLocation = Boolean(artist.location);
@@ -89,7 +97,11 @@ export function AboutSection({
 
       {hasBio && (
         <p className='text-sm font-book leading-relaxed text-white/70 whitespace-pre-line'>
-          {artist.tagline}
+          {bioSegments ? (
+            <EntityMentionText segments={bioSegments} />
+          ) : (
+            artist.tagline
+          )}
         </p>
       )}
 

--- a/apps/web/components/features/profile/EntityMentionText.tsx
+++ b/apps/web/components/features/profile/EntityMentionText.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import { type CSSProperties, Fragment } from 'react';
+import { ENTITY_KIND_ACCENT_VAR } from '@/components/jovie/components/entity-accent';
+import type { EntityMentionSegment } from '@/lib/profile/entity-mentions';
+
+interface EntityMentionTextProps {
+  readonly segments: readonly EntityMentionSegment[];
+}
+
+/**
+ * Renders entity-linked text segments: plain text passes through, while
+ * release/artist mentions become inline internal links tinted with the
+ * entity-kind accent (see `--system-b-entity-chip-*-accent` tokens and the
+ * `.profile-entity-mention` rule in design-system.css).
+ */
+export function EntityMentionText({ segments }: EntityMentionTextProps) {
+  // Segments are a server-built partition of one string, so the character
+  // offset is a stable identity for each segment.
+  const keyed = segments.reduce<{
+    readonly offset: number;
+    readonly items: readonly {
+      key: string;
+      segment: EntityMentionSegment;
+    }[];
+  }>(
+    (accumulator, segment) => ({
+      offset: accumulator.offset + segment.text.length,
+      items: [
+        ...accumulator.items,
+        { key: `${segment.type}:${accumulator.offset}`, segment },
+      ],
+    }),
+    { offset: 0, items: [] }
+  ).items;
+
+  return (
+    <>
+      {keyed.map(({ key, segment }) => {
+        if (segment.type === 'text') {
+          return <Fragment key={key}>{segment.text}</Fragment>;
+        }
+
+        const accentStyle = {
+          '--jovie-entity-accent': `var(${ENTITY_KIND_ACCENT_VAR[segment.type]})`,
+        } as CSSProperties;
+
+        return (
+          <Link
+            key={key}
+            href={segment.href}
+            prefetch={false}
+            className='profile-entity-mention font-medium underline underline-offset-4 transition-colors duration-subtle'
+            style={accentStyle}
+            data-entity-kind={segment.type}
+          >
+            {segment.text}
+          </Link>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/components/features/profile/ProfileAboutShare.tsx
+++ b/apps/web/components/features/profile/ProfileAboutShare.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Check, Share2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface ProfileAboutShareProps {
+  readonly url: string;
+  readonly artistName: string;
+}
+
+export function ProfileAboutShare({
+  url,
+  artistName,
+}: Readonly<ProfileAboutShareProps>) {
+  const [shareSuccess, setShareSuccess] = useState(false);
+  const shareTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (shareTimeoutRef.current) clearTimeout(shareTimeoutRef.current);
+    },
+    []
+  );
+
+  const handleShare = useCallback(async () => {
+    const markShared = () => {
+      setShareSuccess(true);
+      if (shareTimeoutRef.current) clearTimeout(shareTimeoutRef.current);
+      shareTimeoutRef.current = setTimeout(() => setShareSuccess(false), 2000);
+    };
+
+    try {
+      if (typeof navigator.share === 'function') {
+        await navigator.share({ title: artistName, url });
+      } else {
+        await navigator.clipboard.writeText(url);
+      }
+      markShared();
+    } catch (error) {
+      // AbortError = user cancelled the share sheet, do nothing.
+      if (error instanceof Error && error.name === 'AbortError') return;
+      // Fallback: try the clipboard if sharing failed for another reason.
+      try {
+        await navigator.clipboard.writeText(url);
+        markShared();
+      } catch {
+        // Silent failure — matches the hero share control.
+      }
+    }
+  }, [url, artistName]);
+
+  return (
+    <button
+      type='button'
+      onClick={handleShare}
+      className='profile-aeo-content__share inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text)'
+      aria-label={
+        shareSuccess
+          ? `Copied link to ${artistName}'s profile`
+          : `Share ${artistName}'s profile`
+      }
+      data-testid='profile-about-share'
+    >
+      {shareSuccess ? (
+        <Check className='h-4 w-4' aria-hidden='true' />
+      ) : (
+        <Share2 className='h-4 w-4' aria-hidden='true' />
+      )}
+      <span aria-live='polite' className='sr-only'>
+        {shareSuccess ? 'Link Copied' : ''}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/components/features/profile/ProfileAeoContent.tsx
+++ b/apps/web/components/features/profile/ProfileAeoContent.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
 import { ProfileAboutShare } from '@/features/profile/ProfileAboutShare';
 import type { ProfileAeoContent as ProfileAeoContentModel } from '@/lib/profile/aeo-content';
+import { EntityMentionText } from './EntityMentionText';
 
 interface ProfileAeoContentProps {
   readonly content: ProfileAeoContentModel;
@@ -105,8 +106,10 @@ export function ProfileAeoContent({
           ) : null}
 
           <div className='profile-aeo-content__body space-y-3 text-mid leading-7 text-pretty'>
-            {content.description.map(paragraph => (
-              <p key={paragraph}>{paragraph}</p>
+            {content.descriptionSegments.map((segments, index) => (
+              <p key={content.description[index] ?? index}>
+                <EntityMentionText segments={segments} />
+              </p>
             ))}
           </div>
         </div>

--- a/apps/web/components/features/profile/ProfileAeoContent.tsx
+++ b/apps/web/components/features/profile/ProfileAeoContent.tsx
@@ -1,5 +1,7 @@
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
+import { SocialIcon } from '@/components/atoms/SocialIcon';
+import { ProfileAboutShare } from '@/features/profile/ProfileAboutShare';
 import type { ProfileAeoContent as ProfileAeoContentModel } from '@/lib/profile/aeo-content';
 
 interface ProfileAeoContentProps {
@@ -18,13 +20,90 @@ export function ProfileAeoContent({
       data-testid='profile-aeo-content'
     >
       <div className='profile-aeo-content__inner mx-auto grid max-w-5xl gap-8 border-t pt-8 lg:gap-11 lg:pt-10'>
-        <div className='space-y-3 lg:sticky lg:top-12 lg:self-start'>
-          <h2
-            id='profile-aeo-heading'
-            className='profile-aeo-content__heading text-3xl font-semibold leading-tight tracking-tight text-balance'
-          >
-            About {content.artistName}
-          </h2>
+        <div className='space-y-5 lg:sticky lg:top-12 lg:self-start'>
+          <div className='flex items-start justify-between gap-4'>
+            <h2
+              id='profile-aeo-heading'
+              className='profile-aeo-content__heading text-3xl font-semibold leading-tight tracking-tight text-balance'
+            >
+              About {content.artistName}
+            </h2>
+            <ProfileAboutShare
+              url={content.profileUrl}
+              artistName={content.artistName}
+            />
+          </div>
+
+          {content.facts.length > 0 ? (
+            <dl
+              className='profile-aeo-content__facts flex flex-col gap-3 border-y py-4 sm:flex-row sm:flex-wrap sm:gap-x-10 sm:gap-y-4'
+              data-testid='profile-about-facts'
+            >
+              {content.facts.map(fact => (
+                <div key={fact.label} className='space-y-1'>
+                  <dt className='profile-aeo-content__fact-label text-xs font-medium'>
+                    {fact.label}
+                  </dt>
+                  <dd className='profile-aeo-content__fact-value text-mid font-medium'>
+                    {fact.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
+
+          {content.listenLinks.length > 0 ? (
+            <div className='space-y-2' data-testid='profile-about-listen'>
+              <h3 className='profile-aeo-content__link-label text-xs font-medium'>
+                Listen
+              </h3>
+              <ul className='flex flex-wrap items-center gap-x-5 gap-y-2'>
+                {content.listenLinks.map(link => (
+                  <li key={link.id}>
+                    <a
+                      href={link.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='profile-aeo-content__link inline-flex min-h-11 items-center gap-2 text-sm font-medium transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text)'
+                    >
+                      <SocialIcon
+                        platform={link.platform}
+                        className='h-4 w-4'
+                      />
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {content.followLinks.length > 0 ? (
+            <div className='space-y-2' data-testid='profile-about-follow'>
+              <h3 className='profile-aeo-content__link-label text-xs font-medium'>
+                Follow
+              </h3>
+              <ul className='flex flex-wrap items-center gap-1'>
+                {content.followLinks.map(link => (
+                  <li key={link.id}>
+                    <a
+                      href={link.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='profile-aeo-content__link inline-flex h-11 w-11 items-center justify-center rounded-full transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text)'
+                      aria-label={`Follow ${content.artistName} on ${link.label}`}
+                    >
+                      <SocialIcon
+                        platform={link.platform}
+                        className='h-5 w-5'
+                      />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
           <div className='profile-aeo-content__body space-y-3 text-mid leading-7 text-pretty'>
             {content.description.map(paragraph => (
               <p key={paragraph}>{paragraph}</p>

--- a/apps/web/components/features/profile/views/AboutView.tsx
+++ b/apps/web/components/features/profile/views/AboutView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { EntityMentionSegment } from '@/lib/profile/entity-mentions';
 import type { Artist } from '@/types/db';
 import type { PressPhoto } from '@/types/press-photos';
 import { AboutSection } from '../AboutSection';
@@ -9,6 +10,8 @@ export interface AboutViewProps {
   readonly genres?: string[] | null;
   readonly pressPhotos?: PressPhoto[];
   readonly allowPhotoDownloads?: boolean;
+  /** Entity-linked segments for the artist bio (computed server-side). */
+  readonly bioSegments?: readonly EntityMentionSegment[];
 }
 
 /**
@@ -21,6 +24,7 @@ export function AboutView({
   genres,
   pressPhotos,
   allowPhotoDownloads,
+  bioSegments,
 }: AboutViewProps) {
   return (
     <AboutSection
@@ -28,6 +32,7 @@ export function AboutView({
       genres={genres}
       pressPhotos={pressPhotos}
       allowPhotoDownloads={allowPhotoDownloads}
+      bioSegments={bioSegments}
     />
   );
 }

--- a/apps/web/lib/discography/artist-queries/artist-search.ts
+++ b/apps/web/lib/discography/artist-queries/artist-search.ts
@@ -18,10 +18,13 @@ import { db } from '@/lib/db';
 import {
   type Artist,
   artists,
+  discogReleases,
+  discogTracks,
   releaseArtists,
   trackArtists,
 } from '@/lib/db/schema/content';
-import type { CollaboratorInfo } from './types';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import type { CollaboratorInfo, CreditedArtistWithProfile } from './types';
 
 /**
  * Search artists by name
@@ -52,6 +55,80 @@ export async function searchArtists(
     .where(whereClause)
     .orderBy(artists.name)
     .limit(limit);
+}
+
+/**
+ * Resolve artists credited on a creator's catalog (release- and track-level
+ * credits) to their public Jovie handles.
+ *
+ * Only artists whose registry row links to a public creator profile are
+ * returned — external collaborators without a Jovie account are excluded so
+ * bio mentions of them stay plain text. The display name prefers the credit
+ * name (stage name) since that is what bios and release credits show.
+ */
+export async function getCreditedArtistsWithProfiles(
+  creatorProfileId: string,
+  options?: { limit?: number }
+): Promise<CreditedArtistWithProfile[]> {
+  const limit = options?.limit ?? 50;
+
+  const [releaseCredits, trackCredits] = await Promise.all([
+    db
+      .selectDistinct({
+        name: drizzleSql<string>`coalesce(${releaseArtists.creditName}, ${artists.name})`,
+        handle: creatorProfiles.usernameNormalized,
+      })
+      .from(releaseArtists)
+      .innerJoin(
+        discogReleases,
+        eq(releaseArtists.releaseId, discogReleases.id)
+      )
+      .innerJoin(artists, eq(releaseArtists.artistId, artists.id))
+      .innerJoin(
+        creatorProfiles,
+        eq(artists.creatorProfileId, creatorProfiles.id)
+      )
+      .where(
+        and(
+          eq(discogReleases.creatorProfileId, creatorProfileId),
+          eq(creatorProfiles.isPublic, true)
+        )
+      )
+      .limit(limit),
+    db
+      .selectDistinct({
+        name: drizzleSql<string>`coalesce(${trackArtists.creditName}, ${artists.name})`,
+        handle: creatorProfiles.usernameNormalized,
+      })
+      .from(trackArtists)
+      .innerJoin(discogTracks, eq(trackArtists.trackId, discogTracks.id))
+      .innerJoin(artists, eq(trackArtists.artistId, artists.id))
+      .innerJoin(
+        creatorProfiles,
+        eq(artists.creatorProfileId, creatorProfiles.id)
+      )
+      .where(
+        and(
+          eq(discogTracks.creatorProfileId, creatorProfileId),
+          eq(creatorProfiles.isPublic, true)
+        )
+      )
+      .limit(limit),
+  ]);
+
+  const seen = new Set<string>();
+  const merged: CreditedArtistWithProfile[] = [];
+  for (const row of [...releaseCredits, ...trackCredits]) {
+    const name = row.name?.trim();
+    const handle = row.handle?.trim();
+    if (!name || !handle) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({ name, handle });
+    if (merged.length >= limit) break;
+  }
+  return merged;
 }
 
 /**

--- a/apps/web/lib/discography/artist-queries/index.ts
+++ b/apps/web/lib/discography/artist-queries/index.ts
@@ -20,7 +20,11 @@ export {
   processTrackArtistCredits,
 } from './artist-import';
 // Search operations
-export { getFrequentCollaborators, searchArtists } from './artist-search';
+export {
+  getCreditedArtistsWithProfiles,
+  getFrequentCollaborators,
+  searchArtists,
+} from './artist-search';
 // Recording-artist operations
 export {
   deleteRecordingArtists,
@@ -46,5 +50,6 @@ export {
 export type {
   ArtistWithRole,
   CollaboratorInfo,
+  CreditedArtistWithProfile,
   FindOrCreateArtistInput,
 } from './types';

--- a/apps/web/lib/discography/artist-queries/types.ts
+++ b/apps/web/lib/discography/artist-queries/types.ts
@@ -20,6 +20,13 @@ export interface CollaboratorInfo {
   releaseCount: number;
 }
 
+export interface CreditedArtistWithProfile {
+  /** Display name (credit name when set, otherwise canonical artist name). */
+  name: string;
+  /** Normalized Jovie handle of the linked public creator profile. */
+  handle: string;
+}
+
 export interface FindOrCreateArtistInput {
   name: string;
   spotifyId?: string | null;

--- a/apps/web/lib/profile/aeo-content.ts
+++ b/apps/web/lib/profile/aeo-content.ts
@@ -258,7 +258,9 @@ function buildFacts(
 
 function getPlatformLabel(platform: string): string {
   const key = normalizePlatformKey(platform);
-  return (key ? getRegistryEntry(key)?.name : undefined) ?? platform;
+  return (
+    (key ? getRegistryEntry(key)?.name : undefined) ?? sentenceCase(platform)
+  );
 }
 
 function buildLinkSections(

--- a/apps/web/lib/profile/aeo-content.ts
+++ b/apps/web/lib/profile/aeo-content.ts
@@ -6,6 +6,11 @@ import {
   normalizePlatformKey,
 } from '@/lib/dsp-registry';
 import type { PublicMerchCard } from '@/lib/merch/types';
+import {
+  type EntityMentionContext,
+  type EntityMentionSegment,
+  linkEntityMentions,
+} from '@/lib/profile/entity-mentions';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import type { Artist, LegacySocialLink } from '@/types/db';
 
@@ -46,7 +51,13 @@ export interface ProfileAeoContent {
   readonly facts: readonly ProfileAeoFact[];
   readonly listenLinks: readonly ProfileAeoLink[];
   readonly followLinks: readonly ProfileAeoLink[];
+  /** Plain-text paragraphs — used by meta descriptions, JSON-LD, and tests. */
   readonly description: readonly string[];
+  /**
+   * `description` split into entity-linked segments (parallel array). Render
+   * this in the UI; keep `description` for plain-text consumers.
+   */
+  readonly descriptionSegments: readonly (readonly EntityMentionSegment[])[];
   readonly faqs: readonly ProfileAeoFaqItem[];
 }
 
@@ -58,6 +69,12 @@ export interface BuildProfileAeoContentInput {
   readonly tourDates?: readonly TourDateViewModel[];
   readonly merchCards?: readonly PublicMerchCard[];
   readonly socialLinks?: readonly LegacySocialLink[];
+  /**
+   * Linkable entities for this profile (own releases with slugs, credited
+   * artists resolved to Jovie handles). When omitted, descriptions render
+   * as plain text segments.
+   */
+  readonly entityMentions?: EntityMentionContext;
   readonly now?: Date;
 }
 
@@ -524,6 +541,7 @@ export function buildProfileAeoContent({
   tourDates = [],
   merchCards = [],
   socialLinks = [],
+  entityMentions,
   now = new Date(),
 }: BuildProfileAeoContentInput): ProfileAeoContent {
   const uniqueGenres = getUniqueGenres(artist, genres);
@@ -534,22 +552,30 @@ export function buildProfileAeoContent({
   });
   const { listenLinks, followLinks } = buildLinkSections(artist, socialLinks);
 
+  const description = buildDescription({
+    artist,
+    genres: uniqueGenres,
+    latestRelease,
+    releases,
+    tourDates,
+    merchCards,
+    collaborators,
+    now,
+  });
+  const mentionContext: EntityMentionContext = entityMentions ?? {
+    ownHandle: artist.handle,
+  };
+
   return {
     artistName: artist.name,
     profileUrl: absoluteProfileUrl(artist.handle),
     facts: buildFacts(artist, uniqueGenres),
     listenLinks,
     followLinks,
-    description: buildDescription({
-      artist,
-      genres: uniqueGenres,
-      latestRelease,
-      releases,
-      tourDates,
-      merchCards,
-      collaborators,
-      now,
-    }),
+    description,
+    descriptionSegments: description.map(paragraph =>
+      linkEntityMentions(paragraph, mentionContext)
+    ),
     faqs: [
       buildOriginFaq(artist),
       buildLatestReleaseFaq({ artist, latestRelease, releases, socialLinks }),

--- a/apps/web/lib/profile/aeo-content.ts
+++ b/apps/web/lib/profile/aeo-content.ts
@@ -1,5 +1,10 @@
 import { BASE_URL } from '@/constants/app';
 import type { PublicRelease } from '@/features/profile/releases/types';
+import {
+  getRegistryEntry,
+  isDspPlatform,
+  normalizePlatformKey,
+} from '@/lib/dsp-registry';
 import type { PublicMerchCard } from '@/lib/merch/types';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import type { Artist, LegacySocialLink } from '@/types/db';
@@ -23,9 +28,24 @@ export interface ProfileAeoFaqItem {
   readonly source: ProfileAeoSource;
 }
 
+export interface ProfileAeoFact {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface ProfileAeoLink {
+  readonly id: string;
+  readonly platform: string;
+  readonly label: string;
+  readonly url: string;
+}
+
 export interface ProfileAeoContent {
   readonly artistName: string;
   readonly profileUrl: string;
+  readonly facts: readonly ProfileAeoFact[];
+  readonly listenLinks: readonly ProfileAeoLink[];
+  readonly followLinks: readonly ProfileAeoLink[];
   readonly description: readonly string[];
   readonly faqs: readonly ProfileAeoFaqItem[];
 }
@@ -205,6 +225,97 @@ function getOrigin(artist: Artist): string | null {
 
 function pluralize(count: number, singular: string, plural = `${singular}s`) {
   return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function sentenceCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function buildFacts(
+  artist: Artist,
+  genres: readonly string[]
+): ProfileAeoFact[] {
+  const facts: ProfileAeoFact[] = [];
+
+  if (genres.length > 0) {
+    facts.push({ label: 'Genre', value: sentenceCase(genres.join(', ')) });
+  }
+
+  if (artist.active_since_year) {
+    facts.push({
+      label: 'Active Since',
+      value: String(artist.active_since_year),
+    });
+  }
+
+  const origin = getOrigin(artist);
+  if (origin) {
+    facts.push({ label: 'Hometown', value: origin });
+  }
+
+  return facts;
+}
+
+function getPlatformLabel(platform: string): string {
+  const key = normalizePlatformKey(platform);
+  return (key ? getRegistryEntry(key)?.name : undefined) ?? platform;
+}
+
+function buildLinkSections(
+  artist: Artist,
+  socialLinks: readonly LegacySocialLink[]
+): {
+  readonly listenLinks: ProfileAeoLink[];
+  readonly followLinks: ProfileAeoLink[];
+} {
+  const listenLinks: ProfileAeoLink[] = [];
+  const followLinks: ProfileAeoLink[] = [];
+  const seenPlatforms = new Set<string>();
+
+  for (const link of socialLinks) {
+    const url = cleanText(link.url);
+    if (!url) continue;
+
+    const key = normalizePlatformKey(link.platform) ?? link.platform;
+    if (seenPlatforms.has(key)) continue;
+    seenPlatforms.add(key);
+
+    const item: ProfileAeoLink = {
+      id: link.id,
+      platform: link.platform,
+      label: getPlatformLabel(link.platform),
+      url,
+    };
+    if (isDspPlatform(link.platform)) {
+      listenLinks.push(item);
+    } else {
+      followLinks.push(item);
+    }
+  }
+
+  // Profile DSP URL columns fill in destinations that have no social link.
+  // YouTube is categorized as social by isDspPlatform, so the column only
+  // joins the listen row when the artist has no YouTube social link.
+  const dspColumnFallbacks = [
+    { platform: 'spotify', url: artist.spotify_url },
+    { platform: 'apple_music', url: artist.apple_music_url },
+    { platform: 'youtube', url: artist.youtube_url },
+  ] as const;
+
+  for (const fallback of dspColumnFallbacks) {
+    const url = cleanText(fallback.url);
+    if (!url || seenPlatforms.has(fallback.platform)) continue;
+    seenPlatforms.add(fallback.platform);
+
+    listenLinks.push({
+      id: `dsp-column-${fallback.platform}`,
+      platform: fallback.platform,
+      label: getPlatformLabel(fallback.platform),
+      url,
+    });
+  }
+
+  return { listenLinks, followLinks };
 }
 
 function buildDescription(params: {
@@ -419,10 +530,14 @@ export function buildProfileAeoContent({
     artistHandle: artist.handle,
     releases,
   });
+  const { listenLinks, followLinks } = buildLinkSections(artist, socialLinks);
 
   return {
     artistName: artist.name,
     profileUrl: absoluteProfileUrl(artist.handle),
+    facts: buildFacts(artist, uniqueGenres),
+    listenLinks,
+    followLinks,
     description: buildDescription({
       artist,
       genres: uniqueGenres,

--- a/apps/web/lib/profile/entity-mentions.ts
+++ b/apps/web/lib/profile/entity-mentions.ts
@@ -1,0 +1,174 @@
+/**
+ * Entity-linked bio mentions.
+ *
+ * Deterministic, server-side linker that turns plain-text bio/AEO paragraphs
+ * into typed segments so entity mentions (this profile's own releases and
+ * credited artists with Jovie profiles) render as internal links. No LLM,
+ * no client fetching — the same input always produces the same segments, so
+ * the output is safe to bake into ISR pages.
+ */
+
+export interface EntityMentionRelease {
+  readonly title: string;
+  readonly slug?: string | null;
+}
+
+export interface EntityMentionArtist {
+  readonly name: string;
+  /** Jovie handle when the artist has a public profile; otherwise null. */
+  readonly handle?: string | null;
+}
+
+export interface EntityMentionContext {
+  /** Handle of the profile the text belongs to (release links hang off it). */
+  readonly ownHandle: string;
+  readonly releases?: readonly EntityMentionRelease[];
+  readonly artists?: readonly EntityMentionArtist[];
+}
+
+export type EntityMentionSegment =
+  | { readonly type: 'text'; readonly text: string }
+  | { readonly type: 'release'; readonly text: string; readonly href: string }
+  | { readonly type: 'artist'; readonly text: string; readonly href: string };
+
+export interface ProfileEntityMentionLink {
+  readonly kind: 'release' | 'artist';
+  readonly name: string;
+  readonly href: string;
+}
+
+/** Cap on collected mentions (JSON-LD bloat guard). */
+export const MAX_ENTITY_MENTIONS = 25;
+
+const MIN_PHRASE_LENGTH = 2;
+const WORD_CHAR = /[a-z0-9]/;
+
+interface MentionCandidate {
+  readonly kind: 'release' | 'artist';
+  readonly phrase: string;
+  readonly lowerPhrase: string;
+  readonly href: string;
+}
+
+function isWordChar(char: string | undefined): boolean {
+  return char != null && WORD_CHAR.test(char);
+}
+
+function buildCandidates(context: EntityMentionContext): MentionCandidate[] {
+  const seen = new Set<string>();
+  const candidates: MentionCandidate[] = [];
+
+  for (const release of context.releases ?? []) {
+    const title = release.title?.trim();
+    const slug = release.slug?.trim();
+    if (!title || title.length < MIN_PHRASE_LENGTH || !slug) continue;
+    const lower = title.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    candidates.push({
+      kind: 'release',
+      phrase: title,
+      lowerPhrase: lower,
+      href: `/${encodeURIComponent(context.ownHandle)}/${encodeURIComponent(slug)}`,
+    });
+  }
+
+  for (const artist of context.artists ?? []) {
+    const name = artist.name?.trim();
+    const handle = artist.handle?.trim();
+    // Artists without a Jovie profile stay plain text — internal interlinking only.
+    if (!name || name.length < MIN_PHRASE_LENGTH || !handle) continue;
+    const lower = name.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    candidates.push({
+      kind: 'artist',
+      phrase: name,
+      lowerPhrase: lower,
+      href: `/${encodeURIComponent(handle)}`,
+    });
+  }
+
+  // Longest match first so overlapping names ("Cosmic Gate" vs "Gate")
+  // resolve to the most specific entity. Stable sort keeps releases ahead of
+  // artists at equal length, so a same-named release links to the release.
+  return candidates.sort(
+    (left, right) => right.phrase.length - left.phrase.length
+  );
+}
+
+/**
+ * Split plain text into typed segments, linking mentions of the entities in
+ * `context`. Matching is case-insensitive and word-boundary aware, so quoted
+ * titles (`"Take Me Over"`) match while substrings of longer words
+ * (`Sky` inside `Skyline`) do not.
+ */
+export function linkEntityMentions(
+  text: string,
+  context: EntityMentionContext
+): EntityMentionSegment[] {
+  if (!text) return [];
+
+  const candidates = buildCandidates(context);
+  if (candidates.length === 0) {
+    return [{ type: 'text', text }];
+  }
+
+  const lowerText = text.toLowerCase();
+  const segments: EntityMentionSegment[] = [];
+  let cursor = 0;
+  let index = 0;
+
+  const pushTextUpTo = (end: number) => {
+    if (end > cursor) {
+      segments.push({ type: 'text', text: text.slice(cursor, end) });
+    }
+  };
+
+  while (index < text.length) {
+    let matched: MentionCandidate | null = null;
+
+    if (!isWordChar(lowerText[index - 1])) {
+      for (const candidate of candidates) {
+        if (!lowerText.startsWith(candidate.lowerPhrase, index)) continue;
+        const end = index + candidate.lowerPhrase.length;
+        if (isWordChar(lowerText[end])) continue;
+        matched = candidate;
+        break;
+      }
+    }
+
+    if (matched) {
+      pushTextUpTo(index);
+      segments.push({
+        type: matched.kind,
+        text: text.slice(index, index + matched.phrase.length),
+        href: matched.href,
+      });
+      index += matched.phrase.length;
+      cursor = index;
+    } else {
+      index += 1;
+    }
+  }
+
+  pushTextUpTo(text.length);
+  return segments;
+}
+
+/**
+ * Flat, deduped list of linkable entities for a profile — used to build
+ * JSON-LD `mentions` without re-deriving the candidate set.
+ */
+export function collectEntityMentions(
+  context: EntityMentionContext,
+  limit: number = MAX_ENTITY_MENTIONS
+): ProfileEntityMentionLink[] {
+  return buildCandidates(context)
+    .slice(0, Math.max(0, limit))
+    .map(candidate => ({
+      kind: candidate.kind,
+      name: candidate.phrase,
+      href: candidate.href,
+    }));
+}

--- a/apps/web/lib/seo/structured-data/index.ts
+++ b/apps/web/lib/seo/structured-data/index.ts
@@ -11,7 +11,9 @@ export {
 export { generateMusicStructuredData } from './music';
 export {
   generateProfileStructuredData,
+  MAX_ENTITY_MENTIONS,
   MAX_EVENT_SCHEMAS,
+  type ProfileEntityMention,
 } from './profile';
 export {
   validateMerchRichResults,

--- a/apps/web/lib/seo/structured-data/profile.ts
+++ b/apps/web/lib/seo/structured-data/profile.ts
@@ -15,6 +15,17 @@ import { formatSchemaEventStartDate } from './event-date';
 /** Max MusicEvent schemas to emit (Google shows ~5 in rich results). */
 export const MAX_EVENT_SCHEMAS = 5;
 
+/** Max linked-entity `mentions` to emit on the profile entity node. */
+export const MAX_ENTITY_MENTIONS = 25;
+
+/** A profile-linked entity (own release or credited artist) for JSON-LD mentions. */
+export interface ProfileEntityMention {
+  readonly kind: 'release' | 'artist';
+  readonly name: string;
+  /** Absolute URL of the entity's Jovie page. */
+  readonly url: string;
+}
+
 const SOCIAL_PLATFORMS = new Set([
   'instagram',
   'twitter',
@@ -111,7 +122,8 @@ function buildArtistEntitySchema(
   profileUrl: string,
   genres: string[] | null,
   uniqueSocialUrls: string[],
-  listenActions: ReturnType<typeof buildListenActions>
+  listenActions: ReturnType<typeof buildListenActions>,
+  entityMentions: readonly ProfileEntityMention[]
 ): Record<string, unknown> {
   return {
     '@type': resolveArtistEntityType(profile.creator_type),
@@ -120,6 +132,13 @@ function buildArtistEntitySchema(
     description: profile.bio || `Music by ${artistName}`,
     url: profileUrl,
     ...(uniqueSocialUrls.length > 0 && { sameAs: uniqueSocialUrls }),
+    ...(entityMentions.length > 0 && {
+      mentions: entityMentions.slice(0, MAX_ENTITY_MENTIONS).map(mention => ({
+        '@type': mention.kind === 'artist' ? 'MusicGroup' : 'MusicRecording',
+        name: mention.name,
+        url: mention.url,
+      })),
+    }),
     genre: genres && genres.length > 0 ? genres : ['Music'],
     ...(profile.avatar_url && {
       image: {
@@ -248,7 +267,8 @@ export function generateProfileStructuredData(
   genres: string[] | null,
   links: LegacySocialLink[],
   tourDates: TourDateViewModel[] = [],
-  identityLinks: EntityIdentityLink[] = []
+  identityLinks: EntityIdentityLink[] = [],
+  entityMentions: readonly ProfileEntityMention[] = []
 ) {
   const artistName = profile.display_name || profile.username;
   const normalizedUsername =
@@ -263,7 +283,8 @@ export function generateProfileStructuredData(
     profileUrl,
     genres,
     uniqueSocialUrls,
-    listenActions
+    listenActions,
+    entityMentions
   );
   const profilePageSchema = buildProfilePageSchema(
     profile,

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -395,6 +395,26 @@
   text-decoration-color: var(--profile-aeo-text);
 }
 
+:where(.profile-aeo-content__facts) {
+  border-color: var(--profile-aeo-border);
+}
+
+:where(.profile-aeo-content__fact-value) {
+  color: var(--profile-aeo-text);
+}
+
+:where(.profile-aeo-content__fact-label),
+:where(.profile-aeo-content__link-label),
+:where(.profile-aeo-content__link),
+:where(.profile-aeo-content__share) {
+  color: var(--profile-aeo-muted);
+}
+
+:where(.profile-aeo-content__link:hover),
+:where(.profile-aeo-content__share:hover) {
+  color: var(--profile-aeo-text);
+}
+
 :where(.profile-aeo-claim-card) {
   --profile-aeo-claim-ink: var(--system-b-cinematic-black);
   background: var(--color-bg-paper);

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -4875,6 +4875,31 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   );
 }
 
+/* Inline entity links in public profile bio/AEO copy. The entity-kind accent
+   is provided via the `--jovie-entity-accent` custom property on the link. */
+.profile-entity-mention {
+  color: var(--jovie-entity-accent);
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--jovie-entity-accent) 45%,
+    transparent
+  );
+  transition:
+    color var(--system-b-duration-fast) var(--system-b-ease),
+    text-decoration-color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+.profile-entity-mention:hover,
+.profile-entity-mention:focus-visible {
+  text-decoration-color: var(--jovie-entity-accent);
+}
+
+.profile-entity-mention:focus-visible {
+  outline: 2px solid var(--jovie-entity-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
 .system-b-assistant-skill-mention {
   color: var(--color-text-secondary-token);
   font-weight: var(--font-weight-medium);

--- a/apps/web/tests/unit/lib/seo/structured-data.test.ts
+++ b/apps/web/tests/unit/lib/seo/structured-data.test.ts
@@ -201,6 +201,69 @@ describe('generateProfileStructuredData', () => {
     const artist = findInGraph(data, 'MusicGroup');
     expect(artist?.sameAs).toBeUndefined();
   });
+
+  it('emits linked-entity mentions on the artist node', () => {
+    const data = generateProfileStructuredData(
+      BASE_PROFILE,
+      ['pop'],
+      MOCK_LINKS,
+      [],
+      [],
+      [
+        {
+          kind: 'release',
+          name: 'Neon Circuit',
+          url: 'https://jov.ie/testartist/neon-circuit',
+        },
+        {
+          kind: 'artist',
+          name: 'Guest Vocalist',
+          url: 'https://jov.ie/guestvocalist',
+        },
+      ]
+    );
+
+    const artist = findInGraph(data, 'MusicGroup');
+    expect(artist?.mentions).toEqual([
+      {
+        '@type': 'MusicRecording',
+        name: 'Neon Circuit',
+        url: 'https://jov.ie/testartist/neon-circuit',
+      },
+      {
+        '@type': 'MusicGroup',
+        name: 'Guest Vocalist',
+        url: 'https://jov.ie/guestvocalist',
+      },
+    ]);
+    expect(validateProfileRichResults(data)).toEqual([]);
+  });
+
+  it('caps mentions at 25 and omits the key when empty', () => {
+    const manyMentions = Array.from({ length: 40 }, (_, i) => ({
+      kind: 'release' as const,
+      name: `Release ${i}`,
+      url: `https://jov.ie/testartist/release-${i}`,
+    }));
+
+    const capped = generateProfileStructuredData(
+      BASE_PROFILE,
+      ['pop'],
+      MOCK_LINKS,
+      [],
+      [],
+      manyMentions
+    );
+    const cappedArtist = findInGraph(capped, 'MusicGroup');
+    expect(cappedArtist?.mentions).toHaveLength(25);
+
+    const without = generateProfileStructuredData(
+      BASE_PROFILE,
+      ['pop'],
+      MOCK_LINKS
+    );
+    expect(findInGraph(without, 'MusicGroup')?.mentions).toBeUndefined();
+  });
 });
 
 describe('generateMusicStructuredData', () => {

--- a/apps/web/tests/unit/profile/entity-mentions.test.ts
+++ b/apps/web/tests/unit/profile/entity-mentions.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectEntityMentions,
+  type EntityMentionContext,
+  linkEntityMentions,
+  MAX_ENTITY_MENTIONS,
+} from '@/lib/profile/entity-mentions';
+
+const context: EntityMentionContext = {
+  ownHandle: 'tim',
+  releases: [
+    { title: 'Take Me Over', slug: 'take-me-over' },
+    { title: 'Gate', slug: 'gate' },
+    { title: 'Sky', slug: 'sky' },
+  ],
+  artists: [
+    { name: 'Cosmic Gate', handle: 'cosmicgate' },
+    { name: 'The Disco Biscuits', handle: null },
+    { name: 'Tim', handle: 'tim' },
+  ],
+};
+
+describe('linkEntityMentions', () => {
+  it('links a quoted release title, leaving the quotes as plain text', () => {
+    const segments = linkEntityMentions(
+      'Check out "Take Me Over" on streaming now.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'Check out "' },
+      {
+        type: 'release',
+        text: 'Take Me Over',
+        href: '/tim/take-me-over',
+      },
+      { type: 'text', text: '" on streaming now.' },
+    ]);
+  });
+
+  it('prefers the longest overlapping name', () => {
+    const segments = linkEntityMentions(
+      'Toured with Cosmic Gate last summer.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'Toured with ' },
+      { type: 'artist', text: 'Cosmic Gate', href: '/cosmicgate' },
+      { type: 'text', text: ' last summer.' },
+    ]);
+  });
+
+  it('matches case-insensitively but preserves the original casing in the segment', () => {
+    const segments = linkEntityMentions(
+      'take me over was the first single.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'release', text: 'take me over', href: '/tim/take-me-over' },
+      { type: 'text', text: ' was the first single.' },
+    ]);
+  });
+
+  it('keeps artists without a Jovie profile as plain text', () => {
+    const segments = linkEntityMentions(
+      'Shared bills with The Disco Biscuits.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'Shared bills with The Disco Biscuits.' },
+    ]);
+  });
+
+  it('does not match inside longer words (word boundaries)', () => {
+    const segments = linkEntityMentions(
+      'The Skyline venue was packed.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'The Skyline venue was packed.' },
+    ]);
+  });
+
+  it('links a standalone short title at a word boundary', () => {
+    const segments = linkEntityMentions('Sky is the opener.', context);
+
+    expect(segments).toEqual([
+      { type: 'release', text: 'Sky', href: '/tim/sky' },
+      { type: 'text', text: ' is the opener.' },
+    ]);
+  });
+
+  it('links the profile owner name to their own profile', () => {
+    const segments = linkEntityMentions(
+      'Tim started producing in 2012.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'artist', text: 'Tim', href: '/tim' },
+      { type: 'text', text: ' started producing in 2012.' },
+    ]);
+  });
+
+  it('links multiple entities in one paragraph', () => {
+    const segments = linkEntityMentions(
+      'After Take Me Over, Tim remixed Cosmic Gate.',
+      context
+    );
+
+    expect(segments).toEqual([
+      { type: 'text', text: 'After ' },
+      { type: 'release', text: 'Take Me Over', href: '/tim/take-me-over' },
+      { type: 'text', text: ', ' },
+      { type: 'artist', text: 'Tim', href: '/tim' },
+      { type: 'text', text: ' remixed ' },
+      { type: 'artist', text: 'Cosmic Gate', href: '/cosmicgate' },
+      { type: 'text', text: '.' },
+    ]);
+  });
+
+  it('returns a single text segment when there is nothing to link', () => {
+    expect(linkEntityMentions('Hello world.', { ownHandle: 'tim' })).toEqual([
+      { type: 'text', text: 'Hello world.' },
+    ]);
+    expect(linkEntityMentions('', context)).toEqual([]);
+  });
+
+  it('prefers the release when a release and artist share the same name', () => {
+    const segments = linkEntityMentions('Gate changed everything.', {
+      ownHandle: 'tim',
+      releases: [{ title: 'Gate', slug: 'gate' }],
+      artists: [{ name: 'Gate', handle: 'gate' }],
+    });
+
+    expect(segments).toEqual([
+      { type: 'release', text: 'Gate', href: '/tim/gate' },
+      { type: 'text', text: ' changed everything.' },
+    ]);
+  });
+
+  it('ignores releases without a slug and single-character phrases', () => {
+    const segments = linkEntityMentions('X marks Gate.', {
+      ownHandle: 'tim',
+      releases: [{ title: 'Gate' }],
+      artists: [{ name: 'X', handle: 'x' }],
+    });
+
+    expect(segments).toEqual([{ type: 'text', text: 'X marks Gate.' }]);
+  });
+});
+
+describe('collectEntityMentions', () => {
+  it('collects deduped linkable entities with hrefs', () => {
+    const mentions = collectEntityMentions(context);
+
+    expect(mentions).toContainEqual({
+      kind: 'release',
+      name: 'Take Me Over',
+      href: '/tim/take-me-over',
+    });
+    expect(mentions).toContainEqual({
+      kind: 'artist',
+      name: 'Cosmic Gate',
+      href: '/cosmicgate',
+    });
+    // No Jovie profile → not collected.
+    expect(
+      mentions.some(mention => mention.name === 'The Disco Biscuits')
+    ).toBe(false);
+  });
+
+  it('caps the number of mentions', () => {
+    const manyReleases = Array.from(
+      { length: MAX_ENTITY_MENTIONS + 10 },
+      (_, i) => ({
+        title: `Release Number ${i}`,
+        slug: `release-number-${i}`,
+      })
+    );
+
+    const mentions = collectEntityMentions({
+      ownHandle: 'tim',
+      releases: manyReleases,
+    });
+
+    expect(mentions).toHaveLength(MAX_ENTITY_MENTIONS);
+  });
+});

--- a/apps/web/tests/unit/profile/profile-about-share.test.tsx
+++ b/apps/web/tests/unit/profile/profile-about-share.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProfileAboutShare } from '@/features/profile/ProfileAboutShare';
+
+function mockClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+  return writeText;
+}
+
+describe('ProfileAboutShare', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    Object.defineProperty(navigator, 'share', {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  it('copies the profile URL when the Web Share API is unavailable', async () => {
+    const writeText = mockClipboard();
+
+    render(
+      <ProfileAboutShare url='https://jov.ie/dj-test' artistName='DJ Test' />
+    );
+
+    const button = screen.getByTestId('profile-about-share');
+    expect(button).toHaveAttribute('aria-label', "Share DJ Test's profile");
+
+    fireEvent.click(button);
+
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('https://jov.ie/dj-test');
+      expect(button).toHaveAttribute(
+        'aria-label',
+        "Copied link to DJ Test's profile"
+      );
+    });
+  });
+
+  it('uses the Web Share API when available', async () => {
+    const writeText = mockClipboard();
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: share,
+      configurable: true,
+    });
+
+    render(
+      <ProfileAboutShare url='https://jov.ie/dj-test' artistName='DJ Test' />
+    );
+
+    fireEvent.click(screen.getByTestId('profile-about-share'));
+
+    await vi.waitFor(() => {
+      expect(share).toHaveBeenCalledWith({
+        title: 'DJ Test',
+        url: 'https://jov.ie/dj-test',
+      });
+    });
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the user cancels the share sheet', async () => {
+    const writeText = mockClipboard();
+    const share = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error('cancelled'), { name: 'AbortError' })
+      );
+    Object.defineProperty(navigator, 'share', {
+      value: share,
+      configurable: true,
+    });
+
+    render(
+      <ProfileAboutShare url='https://jov.ie/dj-test' artistName='DJ Test' />
+    );
+
+    const button = screen.getByTestId('profile-about-share');
+    fireEvent.click(button);
+
+    await vi.waitFor(() => {
+      expect(share).toHaveBeenCalled();
+    });
+    expect(writeText).not.toHaveBeenCalled();
+    expect(button).toHaveAttribute('aria-label', "Share DJ Test's profile");
+  });
+});

--- a/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
+++ b/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
@@ -435,6 +435,84 @@ describe('Profile AEO content', () => {
     expect(html).toContain('Source: Official merch card');
   });
 
+  it('links entity mentions in the description while keeping plain-text paragraphs', () => {
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        tagline:
+          'DJ Test broke through with "Neon Circuit" and tours with Guest Vocalist.',
+      },
+      genres: ['tech house'],
+      releases: [
+        {
+          id: 'release-1',
+          title: 'Neon Circuit',
+          slug: 'neon-circuit',
+          releaseType: 'single',
+          releaseDate: '2026-05-01T00:00:00.000Z',
+          artworkUrl: null,
+          artistNames: ['DJ Test', 'Guest Vocalist'],
+        },
+      ],
+      entityMentions: {
+        ownHandle: 'dj-test',
+        releases: [{ title: 'Neon Circuit', slug: 'neon-circuit' }],
+        artists: [{ name: 'Guest Vocalist', handle: 'guestvocalist' }],
+      },
+      now,
+    });
+
+    // Plain-text accessor is unchanged for meta/JSON-LD consumers.
+    expect(content.description.join(' ')).toContain('Neon Circuit');
+
+    const linkedSegments = content.descriptionSegments
+      .flat()
+      .filter(segment => segment.type !== 'text');
+    expect(linkedSegments).toContainEqual({
+      type: 'release',
+      text: 'Neon Circuit',
+      href: '/dj-test/neon-circuit',
+    });
+    expect(linkedSegments).toContainEqual({
+      type: 'artist',
+      text: 'Guest Vocalist',
+      href: '/guestvocalist',
+    });
+
+    render(<ProfileAeoContent content={content} />);
+
+    // The release title appears in both the tagline and the generated
+    // latest-release sentence — every mention is linked.
+    const releaseLinks = screen.getAllByRole('link', { name: 'Neon Circuit' });
+    expect(releaseLinks.length).toBeGreaterThan(0);
+    for (const link of releaseLinks) {
+      expect(link).toHaveAttribute('href', '/dj-test/neon-circuit');
+      expect(link).toHaveAttribute('data-entity-kind', 'release');
+    }
+
+    const artistLinks = screen.getAllByRole('link', {
+      name: 'Guest Vocalist',
+    });
+    expect(artistLinks.length).toBeGreaterThan(0);
+    for (const link of artistLinks) {
+      expect(link).toHaveAttribute('href', '/guestvocalist');
+      expect(link).toHaveAttribute('data-entity-kind', 'artist');
+    }
+  });
+
+  it('defaults to plain-text segments when no entity context is provided', () => {
+    const content = buildContent();
+
+    expect(content.descriptionSegments).toHaveLength(
+      content.description.length
+    );
+    for (const [index, segments] of content.descriptionSegments.entries()) {
+      expect(segments).toEqual([
+        { type: 'text', text: content.description[index] },
+      ]);
+    }
+  });
+
   it('renders the editorial claim card only when a claim destination is provided', () => {
     const content = buildContent();
     const { rerender } = render(

--- a/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
+++ b/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
@@ -179,6 +179,178 @@ describe('Profile AEO content', () => {
     expect(content.faqs[3]?.answer).toContain('$68.00');
   });
 
+  it('builds the facts strip from genres, active year, and hometown', () => {
+    const content = buildContent();
+
+    expect(content.facts).toEqual([
+      { label: 'Genre', value: 'Tech house, electronic, club' },
+      { label: 'Active Since', value: '2018' },
+      { label: 'Hometown', value: 'Austin, TX' },
+    ]);
+  });
+
+  it('falls back to location for the hometown fact only when hometown is missing', () => {
+    const content = buildProfileAeoContent({
+      artist: { ...baseArtist, hometown: null, location: 'Berlin, DE' },
+      now,
+    });
+
+    expect(content.facts).toContainEqual({
+      label: 'Hometown',
+      value: 'Berlin, DE',
+    });
+
+    const withHometown = buildProfileAeoContent({ artist: baseArtist, now });
+    expect(withHometown.facts).toContainEqual({
+      label: 'Hometown',
+      value: 'Austin, TX',
+    });
+  });
+
+  it('omits the facts strip fields that have no data', () => {
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        hometown: null,
+        location: null,
+        active_since_year: null,
+        genres: null,
+      },
+      now,
+    });
+
+    expect(content.facts).toEqual([]);
+  });
+
+  it('splits social links into listen (DSP) and follow (non-DSP) rows', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      socialLinks: [
+        ...socialLinks,
+        {
+          id: 'link-2',
+          artist_id: 'artist-1',
+          platform: 'instagram',
+          url: 'https://instagram.com/djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'link-3',
+          artist_id: 'artist-1',
+          platform: 'youtube',
+          url: 'https://youtube.com/@djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+      now,
+    });
+
+    expect(content.listenLinks.map(link => link.label)).toEqual([
+      'Spotify',
+      'Apple Music',
+    ]);
+    expect(content.listenLinks[0]?.url).toBe(
+      'https://open.spotify.com/artist/test'
+    );
+    // The apple_music_url profile column fills in the missing DSP link.
+    expect(content.listenLinks[1]?.url).toBe(
+      'https://music.apple.com/artist/test'
+    );
+    // A YouTube social link is categorized as follow, not listen, and
+    // suppresses the youtube_url column fallback.
+    expect(content.followLinks.map(link => link.platform)).toEqual([
+      'instagram',
+      'youtube',
+    ]);
+  });
+
+  it('uses profile DSP URL columns for the listen row when no social links exist', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      socialLinks: [],
+      now,
+    });
+
+    expect(content.listenLinks.map(link => link.platform)).toEqual([
+      'spotify',
+      'apple_music',
+      'youtube',
+    ]);
+    expect(content.followLinks).toEqual([]);
+  });
+
+  it('renders the facts strip, listen, follow, and share controls', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      genres: ['tech house'],
+      socialLinks: [
+        ...socialLinks,
+        {
+          id: 'link-2',
+          artist_id: 'artist-1',
+          platform: 'instagram',
+          url: 'https://instagram.com/djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+      now,
+    });
+
+    render(<ProfileAeoContent content={content} />);
+
+    const facts = screen.getByTestId('profile-about-facts');
+    expect(facts).toBeVisible();
+    expect(facts).toHaveTextContent('Genre');
+    expect(facts).toHaveTextContent('Active Since');
+    expect(facts).toHaveTextContent('Hometown');
+
+    const listen = screen.getByTestId('profile-about-listen');
+    expect(listen).toBeVisible();
+    const spotifyLink = screen.getByRole('link', { name: 'Spotify' });
+    expect(spotifyLink).toHaveAttribute(
+      'href',
+      'https://open.spotify.com/artist/test'
+    );
+    expect(spotifyLink).toHaveAttribute('target', '_blank');
+    expect(spotifyLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    const follow = screen.getByTestId('profile-about-follow');
+    expect(follow).toBeVisible();
+    expect(
+      screen.getByRole('link', { name: 'Follow DJ Test on Instagram' })
+    ).toHaveAttribute('href', 'https://instagram.com/djtest');
+
+    expect(screen.getByTestId('profile-about-share')).toBeVisible();
+  });
+
+  it('hides the facts, listen, and follow sections when there is no data', () => {
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        hometown: null,
+        location: null,
+        active_since_year: null,
+        genres: null,
+        spotify_url: undefined,
+        apple_music_url: undefined,
+        youtube_url: undefined,
+      },
+      socialLinks: [],
+      now,
+    });
+
+    render(<ProfileAeoContent content={content} />);
+
+    expect(screen.queryByTestId('profile-about-facts')).toBeNull();
+    expect(screen.queryByTestId('profile-about-listen')).toBeNull();
+    expect(screen.queryByTestId('profile-about-follow')).toBeNull();
+    expect(screen.getByTestId('profile-about-share')).toBeVisible();
+    expect(screen.getByTestId('profile-aeo-content')).toBeVisible();
+  });
+
   it('keeps sparse profiles unique and sourced instead of using duplicate boilerplate', () => {
     const first = buildProfileAeoContent({
       artist: {

--- a/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
+++ b/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
@@ -243,6 +243,14 @@ describe('Profile AEO content', () => {
           clicks: 0,
           created_at: '2024-01-01T00:00:00.000Z',
         },
+        {
+          id: 'link-4',
+          artist_id: 'artist-1',
+          platform: 'venmo',
+          url: 'https://venmo.com/djtest',
+          clicks: 0,
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
       ],
       now,
     });
@@ -263,6 +271,13 @@ describe('Profile AEO content', () => {
     expect(content.followLinks.map(link => link.platform)).toEqual([
       'instagram',
       'youtube',
+      'venmo',
+    ]);
+    // Registry names win; unknown platforms fall back to sentence case.
+    expect(content.followLinks.map(link => link.label)).toEqual([
+      'Instagram',
+      'YouTube',
+      'Venmo',
     ]);
   });
 


### PR DESCRIPTION
Stacked on #14565.

## What

Turns the below-the-fold AEO block into a full bio footer, modeled on the owner's timwhite.co/tim-white-bio reference. All server-rendered (ISR), zero page.tsx changes, no JSON-LD changes (entity linking lands in the stacked follow-up).

- **Facts strip** — Genre (sentence case), Active Since, Hometown (location fallback only when no hometown). Renders only populated fields; strip omitted entirely when empty.
- **Listen row** — DSP links: `isDspPlatform` social links first, `spotify_url`/`apple_music_url`/`youtube_url` columns as deduped fallbacks. External, `noopener noreferrer`, no UTMs.
- **Follow row** — non-DSP social links reusing the `SocialIcon` atom, 44px hit areas, descriptive aria-labels.
- **Share control** — `ProfileAboutShare` client island: Web Share API → clipboard fallback, check-flip confirmation, `aria-live` announcement, 44px, muted-until-hover.

## Verification

- Typecheck/Biome clean; 15 new/updated unit tests (facts, hometown fallback, listen/follow split, DSP-column fallback, share clipboard + Web Share paths); arbitrary-values ratchet flat.
- Browser QA (/tim rich data, /dualipa sparse): zero console errors, zero overflow, CLS 0.0006, all links well-formed.
- Scoped `/qa --exhaustive`: health 100, ship-ready.

## Note

The About section is intentionally sr-only below 768px by pre-existing design (SEO copy in DOM, out of mobile layout) — the new sub-sections inherit that behavior. Making the enriched footer visible on mobile is a product decision, flagged for the owner.