### PR TITLE
test(marketing): lock artist-profiles h1→h2→h3 heading order (JOV-2246)

### DIFF
--- a/apps/web/tests/unit/marketing/artist-profile/ArtistProfileHeadingOrder.test.tsx
+++ b/apps/web/tests/unit/marketing/artist-profile/ArtistProfileHeadingOrder.test.tsx
@@ -1,0 +1,70 @@
+import { render } from '@testing-library/react';
+import { run as axeRun } from 'axe-core';
+import { describe, expect, it, vi } from 'vitest';
+import { ArtistProfileHeroAdaptiveIntro } from '@/components/marketing/artist-profile/ArtistProfileHeroAdaptiveIntro';
+import { ArtistProfileOutcomesCarousel } from '@/components/marketing/artist-profile/ArtistProfileOutcomesCarousel';
+import { ARTIST_PROFILE_COPY } from '@/data/artistProfileCopy';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn().mockResolvedValue(undefined),
+  }),
+  usePathname: () => '/artist-profiles',
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+  redirect: vi.fn(),
+  notFound: vi.fn(),
+}));
+
+// The proof card is irrelevant to heading structure and its jsdom render is
+// disproportionately heavy, so it is stubbed out.
+vi.mock('@/features/profile/ProfilePrimaryActionCard', () => ({
+  ProfilePrimaryActionCard: () => <div data-testid='ppac-stub' />,
+}));
+
+function renderHeroThroughOutcomes() {
+  return render(
+    <>
+      <ArtistProfileHeroAdaptiveIntro
+        hero={ARTIST_PROFILE_COPY.hero}
+        adaptive={ARTIST_PROFILE_COPY.adaptive}
+      />
+      <ArtistProfileOutcomesCarousel outcomes={ARTIST_PROFILE_COPY.outcomes} />
+    </>
+  );
+}
+
+describe('artist-profiles heading order (JOV-2246)', () => {
+  it('renders an h2 between the hero h1 and the outcome card h3s', () => {
+    const { container } = renderHeroThroughOutcomes();
+
+    const headings = Array.from(
+      container.querySelectorAll('h1, h2, h3, h4, h5, h6')
+    );
+    const levels = headings.map(h => Number(h.tagName.slice(1)));
+
+    expect(levels[0]).toBe(1);
+    // WCAG 1.3.1 / axe heading-order: levels may never increase by more
+    // than one (no h1 → h3 skip between hero and outcomes carousel).
+    for (let index = 1; index < levels.length; index += 1) {
+      expect(levels[index]).toBeLessThanOrEqual(levels[index - 1] + 1);
+    }
+    expect(levels).toContain(2);
+    expect(levels).toContain(3);
+  });
+
+  it('passes the axe heading-order rule', async () => {
+    const { container } = renderHeroThroughOutcomes();
+
+    const results = await axeRun(container, {
+      runOnly: { type: 'rule', values: ['heading-order'] },
+    });
+
+    expect(results.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

JOV-2246 reported an h1→h3 heading skip on `/artist-profiles` (WCAG 1.3.1 / axe `heading-order`): hero `<h1>` jumping straight to the outcomes carousel card `<h3>`s with no `<h2>` in between.

Verification on current `main` shows the violation is already resolved in code: `ArtistProfileOutcomesCarousel` renders its section header via `ArtistProfileSectionHeader` (an `<h2>`), and `ArtistProfileHeroAdaptiveIntro` → `ArtistProfileModeSwitcher` also renders an `<h2>`. Rendered heading sequence for the hero → adaptive intro → outcomes carousel slice:

```
H1: The link your music deserves.
H2: One profile that adapts to every fan.
H2: Built around fan outcomes.
H3: Straight to listen
H3: Local dates first
H3: Support without friction
H3: Capture the fan
H3: Keep one link everywhere
```

axe-core `heading-order` on that slice reports **zero violations**. No UI change is needed — so this PR adds the missing regression coverage to lock the fix in:

- `apps/web/tests/unit/marketing/artist-profile/ArtistProfileHeadingOrder.test.tsx`
  - asserts heading levels never increase by more than one across the hero → outcomes slice (first heading is h1, h2 present before the card h3s)
  - runs the axe-core `heading-order` rule and asserts zero violations

No production code is touched.

## Test plan

- `pnpm exec vitest run tests/unit/marketing/artist-profile/` — 7 files, 24 tests, all pass (2 new)
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — clean
- `pnpm biome check --write` on the new file — clean
- axe-core `heading-order` rule against the rendered hero → adaptive intro → outcomes carousel slice — 0 violations
- Manual VoiceOver pass not performed (no macOS screen-reader environment in CI/dev container); heading sequence above is the machine-verifiable equivalent, and the e2e axe audit (`tests/e2e/axe-audit.spec.ts`, `marketing-artist-profiles` surface) covers the full page

Fixes JOV-2246