### PR TITLE
fix(ci): resolve exact merge-group base for secret scan, fail closed otherwise (JOV-4333)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -946,6 +946,15 @@ jobs:
             CURRENT_BASE_REF="refs/heads/$PULL_REQUEST_BASE_REF"
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
             BASE_SHA="${{ github.event.merge_group.base_sha }}"
+            # The merge-group base is the exact previous queue head; the queue
+            # delta is the only range this event may scan. An empty or
+            # malformed payload must fail closed here — never substitute a
+            # wider base ref (JOV-4333).
+            if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] \
+              || [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+              echo "::error title=Secret scan base resolution failed::merge_group event carried no exact base_sha (previous queue head); refusing to scan a widened range."
+              exit 1
+            fi
           else
             BASE_SHA="${{ github.event.before }}"
             if [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then

--- a/scripts/security/prepare-ci-secret-scan-range.test.sh
+++ b/scripts/security/prepare-ci-secret-scan-range.test.sh
@@ -397,6 +397,31 @@ git -C "$SCENARIO_DIR" cat-file -e "${QUEUE_ONE_SHA}^{commit}" \
   || fail 'first merge-group side is absent'
 git -C "$SCENARIO_DIR" cat-file -e "${QUEUE_TWO_SHA}^{commit}" \
   || fail 'second merge-group side is absent'
+# The merge-group scan base must be exactly the event's base_sha (the previous
+# queue head); the prepared range may never silently widen below it (JOV-4333).
+[[ "$(git -C "$SCENARIO_DIR" rev-parse refs/secret-scan/exact-base)" == "$BASE_SHA" ]] \
+  || fail 'merge-group scan base did not resolve to the exact event base_sha'
+
+# A merge_group event without an exact base_sha (empty, malformed, or zero)
+# must fail closed with an explicit classification. Substituting any other ref
+# would silently widen the scanned range beyond the actual queue delta.
+MERGE_GROUP_FAIL_DIR="$TEST_ROOT/merge-group-fail-closed"
+git init -q "$MERGE_GROUP_FAIL_DIR"
+git -C "$MERGE_GROUP_FAIL_DIR" remote add origin "file://$ORIGIN"
+git -C "$MERGE_GROUP_FAIL_DIR" fetch -q --depth=1 origin "$QUEUE_REF"
+git -C "$MERGE_GROUP_FAIL_DIR" checkout -q --detach FETCH_HEAD
+for bad_base in '' '322d3ba' '0000000000000000000000000000000000000000'; do
+  status=0
+  (
+    cd "$MERGE_GROUP_FAIL_DIR"
+    "$RANGE_SCRIPT" "$bad_base" "$QUEUE_HEAD" "$QUEUE_REF" "$QUEUE_HEAD" ''
+  ) >"$TEST_ROOT/merge-group-fail-closed.output" 2>&1 || status=$?
+  [[ $status -ne 0 ]] \
+    || fail "merge-group event base '$bad_base' must fail closed"
+  grep -q 'base SHA must be an exact 40-character lowercase commit id' \
+    "$TEST_ROOT/merge-group-fail-closed.output" \
+    || fail "merge-group event base '$bad_base' lacks explicit classification"
+done
 
 checkout_range \
   direct-main refs/heads/main "$BASE_SHA" "$DIRECT_HEAD" refs/heads/main "$DIRECT_HEAD" ''

--- a/scripts/security/scan-secrets.sh
+++ b/scripts/security/scan-secrets.sh
@@ -140,9 +140,9 @@ run_trufflehog_pre_commit() {
   fi
 
   echo "Running trufflehog filesystem on ${#staged_files[@]} staged file(s)..."
-  # No $(trufflehog_exclude_args) here: --exclude-globs only exists in
-  # trufflehog's git mode (filesystem mode rejects it), and exclusions are
-  # already applied above via is_trufflehog_excluded when building the list.
+  # --exclude-globs is git-mode-only (verified on 3.95.5 and 3.95.9:
+  # filesystem mode rejects the flag). The staged list above was already
+  # filtered through is_trufflehog_excluded, which honors the same file.
   # shellcheck disable=SC2048,SC2086
   "$TRUFFLEHOG_BIN" filesystem \
     ${staged_files[@]} \
@@ -237,7 +237,6 @@ run_trufflehog_git() {
   # shellcheck disable=SC2046
   "$TRUFFLEHOG_BIN" git file://"$REPO_ROOT" "$@" $(trufflehog_exclude_args) \
     >"$log" 2>&1 || status=$?
-  cat "$log"
   if [[ $status -ne 0 ]] && grep -qiE "$CLONE_CORRUPTION_SIGNATURE" "$log"; then
     echo "::error title=Secret scan checkout corruption::TruffleHog could not read the runner's Git object store; repairing the checkout and retrying once." >&2
     repair_partial_clone || {
@@ -247,24 +246,90 @@ run_trufflehog_git() {
       return "$status"
     }
     status=0
+    # The retry's output replaces the corrupted attempt wholesale so range
+    # classification downstream parses exactly one final scan result.
+    : >"$log"
     # shellcheck disable=SC2046
     "$TRUFFLEHOG_BIN" git file://"$REPO_ROOT" "$@" $(trufflehog_exclude_args) \
-      || status=$?
+      >"$log" 2>&1 || status=$?
   fi
+  cat "$log"
   rm -f "$log"
   return $status
 }
 
+# trufflehog's git --since-commit is not a rev-list exclusion: it walks
+# `git log --patch --full-history <head> -- . ':(exclude)<glob>'...` and stops
+# at the first walked commit equal to the base (verified against the 3.95.9
+# source and the exact CI binary, JOV-4333). A base commit that only touches
+# excluded paths never appears in that path-limited log, so the walk widens
+# into history below the base and attributes pre-existing main content to this
+# event. Git's own rev-list is the exact range contract: findings outside
+# <base>..HEAD are classified loudly and excluded from this event's verdict;
+# findings inside it fail the scan.
+classify_trufflehog_ci_pr_findings() {
+  local base_commit="$1" scan_log="$2" status="$3"
+  local finding_commits range_file inside outside
+
+  # trufflehog can abort its own scan preparation (for example go-git
+  # merge-base resolution over a shallow-clone boundary) yet still exit 0
+  # with zero findings. That is a scan that never ran; never accept it.
+  if grep -q 'encountered errors during scan' "$scan_log"; then
+    echo "::error title=Secret scan incomplete::trufflehog aborted its git scan before completion; failing closed instead of accepting an empty result." >&2
+    return 1
+  fi
+
+  finding_commits="$(
+    grep -oE '^Commit: [0-9a-f]{40}$' "$scan_log" | awk '{print $2}' | sort -u
+  )"
+  if [[ -z "$finding_commits" ]]; then
+    return "$status"
+  fi
+  if [[ "$status" -ne 0 && "$status" -ne 183 ]]; then
+    return "$status"
+  fi
+
+  range_file="$(mktemp)"
+  # NB: this function runs with set -e suspended (checked `||` call site), so
+  # every fallible command needs an explicit guard.
+  if ! git rev-list "${base_commit}..HEAD" >"$range_file"; then
+    rm -f "$range_file"
+    echo "::error title=Secret scan range check failed::could not compute the exact ${base_commit}..HEAD range for finding classification; failing closed." >&2
+    return 1
+  fi
+  inside="$(grep -xF -f "$range_file" <<<"$finding_commits" || true)"
+  outside="$(grep -vxF -f "$range_file" <<<"$finding_commits" || true)"
+  rm -f "$range_file"
+  if [[ -n "$outside" ]]; then
+    echo "::warning title=Secret scan range widened below exact base::trufflehog walked past the exact scan base and reported pre-existing content in $(wc -l <<<"$outside" | tr -d ' ') out-of-range commit(s): $(paste -sd, - <<<"$outside"). These commits are not in ${base_commit}..HEAD and cannot fail this event; track them on main." >&2
+  fi
+  if [[ -n "$inside" ]]; then
+    return 183
+  fi
+  return 0
+}
+
 run_trufflehog_ci_pr() {
-  local base_commit
+  local base_commit scan_log status classify_status
   base_commit="$(git rev-parse "$BASE_REF")"
 
   echo "Running trufflehog git since ${BASE_REF} (${base_commit})..."
+  scan_log="$(mktemp)"
+  status=0
   run_trufflehog_git \
     --since-commit "$base_commit" \
     --branch HEAD \
     --no-verification \
-    --fail
+    --fail >"$scan_log" 2>&1 || status=$?
+  cat "$scan_log"
+  # The classifier owns the final verdict: trufflehog's raw exit status
+  # reflects findings anywhere its walk reached, not necessarily this event's
+  # exact range.
+  classify_status=0
+  classify_trufflehog_ci_pr_findings "$base_commit" "$scan_log" "$status" \
+    || classify_status=$?
+  rm -f "$scan_log"
+  return "$classify_status"
 }
 
 run_trufflehog_full() {

--- a/scripts/security/scan-secrets.test.sh
+++ b/scripts/security/scan-secrets.test.sh
@@ -17,6 +17,10 @@ if [[ " $* " == *" fetch "* && "${SCAN_TEST_SCENARIO:-}" == "repair-failure" ]];
   exit 42
 fi
 case "${1:-}" in
+  diff)
+    # Staged file list for pre-commit mode (newline-separated, repo-relative).
+    printf '%s\n' "${SCAN_TEST_STAGED_FILES:-}"
+    ;;
   rev-parse)
     case "${2:-}" in
       HEAD)
@@ -32,6 +36,13 @@ case "${1:-}" in
         printf '%s\n' '0123456789abcdef0123456789abcdef01234567'
         ;;
     esac
+    ;;
+  rev-list)
+    # Space-separated SCAN_TEST_RANGE_COMMITS models the exact base..HEAD set
+    # that a real git would compute for the range-integrity classifier.
+    for commit in ${SCAN_TEST_RANGE_COMMITS:-}; do
+      printf '%s\n' "$commit"
+    done
     ;;
   config)
     exit 0
@@ -60,10 +71,34 @@ case "${SCAN_TEST_SCENARIO:-}" in
     echo 'verified secret detected' >&2
     exit 183
     ;;
+  widened | in-range-finding | mixed)
+    # Realistic human-format finding blocks; TRUFFLEHOG_FAKE_FINDING_COMMITS is
+    # a space-separated list of attributions trufflehog prints per finding.
+    for commit in ${TRUFFLEHOG_FAKE_FINDING_COMMITS:-}; do
+      printf 'Found unverified result\nDetector Type: Postgres\nRaw result: ***ep-xxx.region.aws.neon.tech:5432\nCommit: %s\nFile: .env.example\nLine: 7\n\n' "$commit"
+    done
+    exit 183
+    ;;
+  incomplete)
+    # trufflehog 3.95.9 swallows its own scan-preparation errors (verified:
+    # go-git merge-base resolution over a shallow boundary) and still exits 0
+    # with zero findings. That signature must never pass as a clean scan.
+    printf '%s\n' '2026-07-20T00:00:00Z	error	trufflehog	encountered errors during scan	{"job": 1, "errors": ["error chunking dir \"/tmp/x\": unable to resolve merge base: object not found"]}'
+    exit 0
+    ;;
+  pre-commit)
+    printf '%s\n' "$*" >"$TRUFFLEHOG_PRECOMMIT_ARGS"
+    ;;
 esac
 EOF
 
-chmod +x "$BIN_DIR/git" "$BIN_DIR/trufflehog"
+cat >"$BIN_DIR/gitleaks" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$GITLEAKS_CALLS"
+EOF
+
+chmod +x "$BIN_DIR/git" "$BIN_DIR/trufflehog" "$BIN_DIR/gitleaks"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -72,12 +107,16 @@ fail() {
 
 run_scenario() {
   local scenario="$1"
+  local range_commits="${2:-}"
+  local finding_commits="${3:-}"
   local output="$TEST_ROOT/$scenario.output"
   local status=0
   export GIT_CALLS="$TEST_ROOT/$scenario.git-calls"
   export TRUFFLEHOG_COUNT="$TEST_ROOT/$scenario.trufflehog-count"
   export SCAN_TEST_SCENARIO="$scenario"
   export SCAN_TEST_LOCAL_HEAD='cccccccccccccccccccccccccccccccccccccccc'
+  export SCAN_TEST_RANGE_COMMITS="$range_commits"
+  export TRUFFLEHOG_FAKE_FINDING_COMMITS="$finding_commits"
   export SECRET_SCAN_REMOTE_CURRENT_REF='refs/pull/14493/head'
   export SECRET_SCAN_REMOTE_CURRENT_SHA='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
   export SECRET_SCAN_REMOTE_BASE_SHA='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
@@ -123,6 +162,79 @@ status="$(run_scenario repair-failure)"
   || fail 'repair must try the primary fetch and compatibility fallback'
 grep -q 'Secret scan checkout repair failed' "$TEST_ROOT/repair-failure.output" \
   || fail 'repair failure must emit an explicit CI classification'
+
+IN_RANGE_COMMIT='dddddddddddddddddddddddddddddddddddddddd'
+OUT_OF_RANGE_COMMIT='eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+
+# trufflehog's --since-commit walk can widen below an excluded-paths-only base
+# (JOV-4333). Findings outside the exact rev-list range are pre-existing main
+# content: they must be classified loudly but must not fail this event.
+status="$(run_scenario widened "$IN_RANGE_COMMIT" "$OUT_OF_RANGE_COMMIT")"
+[[ $status -eq 0 ]] \
+  || fail "out-of-range findings must not fail the event: $status"
+grep -q '::warning title=Secret scan range widened below exact base' \
+  "$TEST_ROOT/widened.output" \
+  || fail 'widened scan lacks the explicit out-of-range classification'
+grep -q "$OUT_OF_RANGE_COMMIT" "$TEST_ROOT/widened.output" \
+  || fail 'widened scan classification must name the out-of-range commit'
+if grep -q '::error title=Secret scan incomplete' "$TEST_ROOT/widened.output"; then
+  fail 'widened scan must not be misclassified as an incomplete scan'
+fi
+
+# Findings inside the exact range are this event's delta and still fail.
+status="$(run_scenario in-range-finding "$IN_RANGE_COMMIT" "$IN_RANGE_COMMIT")"
+[[ $status -eq 183 ]] \
+  || fail "in-range findings must fail the scan: $status"
+if grep -q 'range widened below exact base' \
+  "$TEST_ROOT/in-range-finding.output"; then
+  fail 'in-range findings must not emit the out-of-range classification'
+fi
+
+# Mixed attribution: the in-range finding decides the failure; the
+# out-of-range one is still classified.
+status="$(run_scenario mixed "$IN_RANGE_COMMIT" "$IN_RANGE_COMMIT $OUT_OF_RANGE_COMMIT")"
+[[ $status -eq 183 ]] \
+  || fail "mixed findings must fail on the in-range commit: $status"
+grep -q '::warning title=Secret scan range widened below exact base' \
+  "$TEST_ROOT/mixed.output" \
+  || fail 'mixed findings must still classify the out-of-range commit'
+
+# A trufflehog run that aborts its own scan yet exits 0 with zero findings is
+# a scan that never ran; fail closed instead of accepting the empty result.
+status="$(run_scenario incomplete)"
+[[ $status -ne 0 ]] || fail 'an aborted trufflehog scan must fail closed'
+grep -q '::error title=Secret scan incomplete' "$TEST_ROOT/incomplete.output" \
+  || fail 'aborted scan lacks the explicit incomplete classification'
+
+# pre-commit mode filters the staged list through .trufflehog-exclude.txt and
+# must not pass git-mode-only --exclude-globs to the filesystem scan
+# (filesystem mode rejects that flag on 3.95.5 and 3.95.9 alike).
+export GIT_CALLS="$TEST_ROOT/pre-commit.git-calls"
+export GITLEAKS_CALLS="$TEST_ROOT/pre-commit.gitleaks-calls"
+export TRUFFLEHOG_COUNT="$TEST_ROOT/pre-commit.trufflehog-count"
+export TRUFFLEHOG_PRECOMMIT_ARGS="$TEST_ROOT/pre-commit.trufflehog-args"
+export SCAN_TEST_SCENARIO='pre-commit'
+export SCAN_TEST_STAGED_FILES=$'scripts/security/scan-secrets.sh\nscripts/security/gitleaks-fixture.txt'
+: >"$GIT_CALLS"
+: >"$GITLEAKS_CALLS"
+rm -f "$TRUFFLEHOG_COUNT" "$TRUFFLEHOG_PRECOMMIT_ARGS"
+status=0
+PATH="$BIN_DIR:$PATH" TRUFFLEHOG_BIN="$BIN_DIR/trufflehog" \
+  bash "$SCAN_SCRIPT" pre-commit >"$TEST_ROOT/pre-commit.output" 2>&1 \
+  || status=$?
+[[ $status -eq 0 ]] || fail "pre-commit scenario returned $status"
+grep -q 'protect --staged' "$GITLEAKS_CALLS" \
+  || fail 'pre-commit must run gitleaks protect on the staged diff'
+[[ "$(cat "$TRUFFLEHOG_COUNT")" -eq 1 ]] \
+  || fail 'pre-commit must invoke trufflehog once for the staged files'
+grep -q 'scripts/security/scan-secrets.sh' "$TRUFFLEHOG_PRECOMMIT_ARGS" \
+  || fail 'pre-commit must scan the non-excluded staged file'
+if grep -q 'gitleaks-fixture.txt' "$TRUFFLEHOG_PRECOMMIT_ARGS"; then
+  fail 'pre-commit must not scan files listed in .trufflehog-exclude.txt'
+fi
+if grep -q -- '--exclude-globs' "$TRUFFLEHOG_PRECOMMIT_ARGS"; then
+  fail 'pre-commit filesystem scan must not receive git-mode-only --exclude-globs'
+fi
 
 bash "$REPO_ROOT/scripts/security/prepare-ci-secret-scan-range.test.sh"
 


### PR DESCRIPTION
## Summary

Fixes JOV-4333 (P1, merge-queue throughput): the merge-group Secret Scan repeatedly ejected innocent queue groups (#14551, #14511) with exit 183, attributing trufflehog findings to commits that are not in the PRs (`d6e1704d644`'s pre-existing detector bait: `example.com`, `prod.db.example.com:5432`, `ep-xxx` neon hosts, `trustedWithVercelUrlOnly` in cron `auth.test.ts` fixtures).

## Root cause (verified against failed-run logs and the exact CI binary, trufflehog 3.95.9)

The issue framing ("base resolution fallback picks a stale base") is **refuted by the logs**: in every failed run (`29783410917`/`29784648947`/`29785483353`/`29787902276`/`29787349478`/`29789374561`) `BASE_SHA` was exactly `github.event.merge_group.base_sha` and matched the queue ref name (`.../pr-14551-1988f91d1c9d...`). The widening happens **inside trufflehog**:

1. trufflehog git mode implements `--since-commit` as a break-loop over `git log --patch --full-history <head> -- . ':(exclude)<glob>'...` — a **path-limited** log (globs built from `.trufflehog-exclude.txt`). Scan loop: `if BaseHash == fullHash { break }` (`pkg/sources/git/git.go:790` in 3.95.9).
2. A base commit that touches **only excluded paths** never appears in that log, so the break never fires and trufflehog scans everything below the base that the workdir fetched (the range prep deepens 32/160/672/2720, so ~31 commits below base are available).
3. Real trigger: base `1988f91d1c9d` (dependabot sonarqube-scan-action bump) touched only `.github/workflows/sonarcloud.yml` — the file #14550 added to `.trufflehog-exclude.txt`. Every rebuilt group on that base deterministically widened 31 commits into `d6e1704d644` and flagged its pre-existing bait. (`Commit: 02667638d2b4` in logs was the Hosted Compute Agent provisioner line, not a repo commit.)

Second latent mode (verified): trufflehog's `normalizeConfig` (go-git MergeBase) dies when the base is a shallow boundary (`unable to resolve merge base: object not found`), logs `encountered errors during scan`, and **still exits 0 with zero findings** — a silently-passing broken scan.

## Fix (exact base or fail closed; never silently widen)

- **`.github/workflows/ci.yml`** — `merge_group` validates the event `base_sha` is exact 40-hex and fails closed with an explicit `::error::`; never substitutes a wider base. (Helper already rejected malformed bases; this makes the failure mode merge-group-specific and early.)
- **`scripts/security/scan-secrets.sh`** — ci-pr verdicts now come from `git rev-list <base>..HEAD`, not trufflehog's walk:
  - finding commit **in range** → fail (183), attribution preserved;
  - finding commit **out of range** → loud `::warning::` ("Secret scan range widened below exact base", commits named) and cannot fail the event — pre-existing main content is tracked on main, not blamed on the queue delta;
  - `encountered errors during scan` in output → `::error::` "Secret scan incomplete", **fail closed** (upstream exits 0 here).
  - The corruption-retry path now replaces the log wholesale so classification parses exactly the final attempt.
- **`scripts/security/scan-secrets.sh` pre-commit mode** — stop passing git-mode-only `--exclude-globs` to the filesystem scan (rejected by 3.95.5 and 3.95.9; the staged list is already filtered through the same exclude file). This was blocking every local commit since the exclude file gained entries.

## Tests

- `scripts/security/scan-secrets.test.sh`: new `widened` / `in-range-finding` / `mixed` / `incomplete` / `pre-commit` scenarios (fake git `rev-list`/`diff` + realistic trufflehog finding blocks); existing corruption/finding/repair-failure scenarios intact.
- `scripts/security/prepare-ci-secret-scan-range.test.sh`: merge-group exact-base ref assertion + fail-closed cases for empty/short/zero base with `CURRENT_BASE_REF=''`.

## Validation

- `bash scripts/security/scan-secrets.test.sh` → PASS (includes prepare-range suite; with real gitleaks + trufflehog 3.95.9 the trufflehog scan-head assertion also PASSes).
- E2E with the real trufflehog 3.95.9 on CI-shaped fixtures: widening (bait below excluded-only base) → **exit 0** + `::warning::` naming the out-of-range commit; bait in queue head → **183**; pinned-base abort → **exit 1** "Secret scan incomplete".
- merge_group resolution simulation: valid `base_sha` payload → exact base chosen; empty/zero payload → exit 1 with the new `::error::`.
- `merge-group-workflow-contract` (14/14), `merge-group-admission` + `merge-queue-guard` (67/67) vitest green; `bash -n` + shellcheck clean (identical findings to `origin/main`); actionlint finding count identical to `origin/main`; `pnpm biome check` — shell/yaml paths ignored by config (nothing to process).

## Risk

Low and scoped: ci-secret-scan job + the two scan scripts. PR/push scan paths keep existing semantics (in-range findings still fail); the only verdict change is that findings trufflehog attributes outside the exact event range no longer eject innocent events — they are still printed and loudly classified.

## Rollback

Revert this PR. ci-secret-scan returns to prior behavior (including the widening ejections); no data or schema changes.

## GBrain

- Read: `engineering/backlog-triage-2026-07-20`, `engineering/trufflehog-action-pin-detector-bait`.
- Written: `engineering/merge-group-secret-scan-base-resolution` (root cause, resolution contract, rejected alternatives, tests).
