### PR TITLE
fix(web): unblock staging/prod deploy Invalid URL on /_not-found

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -174,7 +174,7 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_STG }}
         run: >-
           doppler run --project jovie-web --config stg
-          --only-secrets=NEXT_PUBLIC_BETTER_AUTH_URL,BETTER_AUTH_SECRET,DATABASE_URL,SESSION_SECRET,AI_GATEWAY_API_KEY,NEXT_PUBLIC_TURNSTILE_SITE_KEY,TURNSTILE_SECRET_KEY
+          --only-secrets=NEXT_PUBLIC_BETTER_AUTH_URL,BETTER_AUTH_SECRET,DATABASE_URL,SESSION_SECRET,AI_GATEWAY_API_KEY,NEXT_PUBLIC_TURNSTILE_SITE_KEY,TURNSTILE_SECRET_KEY,NEXT_PUBLIC_APP_URL,NEXT_PUBLIC_PROFILE_URL,NEXT_PUBLIC_PROFILE_HOSTNAME
           --no-fallback -- env -u DOPPLER_TOKEN pnpm --filter=@jovie/web exec
           tsx scripts/check-signup-readiness.ts --target=stg --source=env
       - name: Build (preview target for staging verification)
@@ -203,7 +203,7 @@ jobs:
           }
           export -f staging_build
           doppler run --project jovie-web --config stg \
-            --only-secrets=VERCEL_AUTOMATION_BYPASS_SECRET,NEXT_PUBLIC_BETTER_AUTH_URL,BETTER_AUTH_SECRET,BETTER_AUTH_URL,DATABASE_URL,SESSION_SECRET,AI_GATEWAY_API_KEY,NEXT_PUBLIC_TURNSTILE_SITE_KEY,TURNSTILE_SECRET_KEY \
+            --only-secrets=VERCEL_AUTOMATION_BYPASS_SECRET,NEXT_PUBLIC_BETTER_AUTH_URL,BETTER_AUTH_SECRET,BETTER_AUTH_URL,DATABASE_URL,SESSION_SECRET,AI_GATEWAY_API_KEY,NEXT_PUBLIC_TURNSTILE_SITE_KEY,TURNSTILE_SECRET_KEY,NEXT_PUBLIC_APP_URL,NEXT_PUBLIC_PROFILE_URL,NEXT_PUBLIC_PROFILE_HOSTNAME \
             --no-fallback -- env -u DOPPLER_TOKEN bash -c staging_build
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_STG }}

--- a/apps/web/lib/env-public.ts
+++ b/apps/web/lib/env-public.ts
@@ -9,6 +9,33 @@ function getRuntimeHtmlDatasetValue(
 }
 
 /**
+ * Normalize a public URL env value into an absolute origin URL.
+ *
+ * Off-Vercel builds (e.g. `vercel build` in CI) may expose host-only values
+ * like `staging.jov.ie` — or miss NEXT_PUBLIC_* vars entirely — and a bare
+ * `new URL(raw)` then throws during page-data collection (e.g. /_not-found),
+ * aborting the whole build. This helper never throws: host-only values get an
+ * `https://` prefix and anything unparseable falls back.
+ */
+export function absolutePublicUrl(
+  raw: string | undefined,
+  fallback = 'https://jov.ie'
+): string {
+  const value = raw?.trim();
+  if (!value) {
+    return fallback;
+  }
+  const withProtocol = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value)
+    ? value
+    : `https://${value}`;
+  try {
+    return new URL(withProtocol).origin;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
  * Public environment variables with lazy access.
  *
  * Uses getters to read environment variables at access time rather than
@@ -45,10 +72,10 @@ export const publicEnv = {
   },
   get NEXT_PUBLIC_APP_URL() {
     // Single domain architecture: app routes are at jov.ie/app/*
-    return process.env.NEXT_PUBLIC_APP_URL || 'https://jov.ie';
+    return absolutePublicUrl(process.env.NEXT_PUBLIC_APP_URL);
   },
   get NEXT_PUBLIC_PROFILE_URL() {
-    return process.env.NEXT_PUBLIC_PROFILE_URL || 'https://jov.ie';
+    return absolutePublicUrl(process.env.NEXT_PUBLIC_PROFILE_URL);
   },
   get NEXT_PUBLIC_PROFILE_HOSTNAME() {
     return process.env.NEXT_PUBLIC_PROFILE_HOSTNAME || 'jov.ie';

--- a/apps/web/tests/unit/lib/env/absolute-public-url.test.ts
+++ b/apps/web/tests/unit/lib/env/absolute-public-url.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { absolutePublicUrl, publicEnv } from '@/lib/env-public';
+
+const ORIGINAL_ENV = {
+  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  NEXT_PUBLIC_PROFILE_URL: process.env.NEXT_PUBLIC_PROFILE_URL,
+};
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  vi.resetModules();
+});
+
+describe('absolutePublicUrl', () => {
+  it('falls back when the value is missing or empty', () => {
+    expect(absolutePublicUrl(undefined)).toBe('https://jov.ie');
+    expect(absolutePublicUrl('')).toBe('https://jov.ie');
+    expect(absolutePublicUrl('   ')).toBe('https://jov.ie');
+  });
+
+  it('upgrades host-only values to absolute https URLs', () => {
+    expect(absolutePublicUrl('staging.jov.ie')).toBe('https://staging.jov.ie');
+  });
+
+  it('keeps valid absolute URLs and strips trailing slashes', () => {
+    expect(absolutePublicUrl('https://jov.ie')).toBe('https://jov.ie');
+    expect(absolutePublicUrl('https://staging.jov.ie/')).toBe(
+      'https://staging.jov.ie'
+    );
+  });
+
+  it('preserves non-https protocols and ports for local development', () => {
+    expect(absolutePublicUrl('http://localhost:3000')).toBe(
+      'http://localhost:3000'
+    );
+  });
+
+  it('falls back for unparseable values instead of throwing', () => {
+    expect(absolutePublicUrl('not a url :::')).toBe('https://jov.ie');
+  });
+
+  it('honors a custom fallback', () => {
+    expect(absolutePublicUrl(undefined, 'https://staging.jov.ie')).toBe(
+      'https://staging.jov.ie'
+    );
+  });
+});
+
+describe('publicEnv URL getters', () => {
+  it('normalizes a host-only NEXT_PUBLIC_PROFILE_URL', () => {
+    process.env.NEXT_PUBLIC_PROFILE_URL = 'staging.jov.ie';
+    expect(publicEnv.NEXT_PUBLIC_PROFILE_URL).toBe('https://staging.jov.ie');
+    expect(() => new URL(publicEnv.NEXT_PUBLIC_PROFILE_URL)).not.toThrow();
+  });
+
+  it('normalizes a host-only NEXT_PUBLIC_APP_URL', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'staging.jov.ie';
+    expect(publicEnv.NEXT_PUBLIC_APP_URL).toBe('https://staging.jov.ie');
+  });
+
+  it('defaults to https://jov.ie when unset', () => {
+    delete process.env.NEXT_PUBLIC_PROFILE_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    expect(publicEnv.NEXT_PUBLIC_PROFILE_URL).toBe('https://jov.ie');
+    expect(publicEnv.NEXT_PUBLIC_APP_URL).toBe('https://jov.ie');
+  });
+});
+
+describe('BASE_URL (constants/domains)', () => {
+  it('yields a valid absolute URL for metadataBase even with host-only env', async () => {
+    process.env.NEXT_PUBLIC_PROFILE_URL = 'staging.jov.ie';
+    vi.resetModules();
+    const { BASE_URL } = await import('@/constants/domains');
+    expect(BASE_URL).toBe('https://staging.jov.ie');
+    // Regression: `new URL(BASE_URL)` at module scope in app/layout.tsx threw
+    // ERR_INVALID_URL during /_not-found page-data collection on off-Vercel
+    // staging builds, aborting the whole deploy.
+    expect(() => new URL(BASE_URL)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
**P0 production bottleneck.** Production Controller fails at deploy-staging with:
\`Failed to collect configuration for /_not-found\` → \`TypeError: Invalid URL\`.

Root layout evaluates \`metadataBase: new URL(BASE_URL)\`. Off-Vercel \`vercel build\` can see host-only/missing NEXT_PUBLIC URL env and throw during page-data collection, blocking all promotions. Public site stays on the previous deploy.

## Changes
- \`absolutePublicUrl()\` helper — never throws; host-only → https; invalid → fallback
- Wire APP/PROFILE public URL getters through it
- Inject NEXT_PUBLIC_APP_URL / PROFILE_URL / PROFILE_HOSTNAME into staging build Doppler set
- Unit tests (10) including BASE_URL metadataBase regression

## Test plan
- [x] vitest tests/unit/lib/env/absolute-public-url.test.ts (10/10)
- [ ] CI
- [ ] Production Controller deploy-staging green after merge